### PR TITLE
AI review: OpenAI-compatible endpoint engine + change log entry

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,7 @@ Subtitle Edit Changelog
 
 v5.1.0-beta5 (TBD)
 
+* Add AI review (Tools > AI review) - proofread subtitles with a local LLM via llama.cpp or Ollama, with a before/after grid and editable prompt
 * Add copy/paste support to the time code boxes (a bare number is milliseconds) - thx RobertoHN
 * Speech to text: add smaller model quants for FunASR nano/MLT-nano and Parakeet Japanese, and fix dead MADLAD download links
 * OCR: select the just-downloaded spell-check dictionary on any UI language

--- a/src/ui/Features/Tools/AiReview/AiReviewClient.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewClient.cs
@@ -25,15 +25,15 @@ public class AiReviewClient : IDisposable
         _httpClient.Timeout = TimeSpan.FromMinutes(15);
     }
 
-    public async Task<string> ChatAsync(string url, string model, string systemPrompt, string userContent, CancellationToken cancellationToken)
+    public async Task<string> ChatAsync(string url, string model, string systemPrompt, string userContent, CancellationToken cancellationToken, string? apiKey = null)
     {
         Error = string.Empty;
 
         // First try with enforced JSON output; some servers reject response_format, so retry without.
-        var response = await PostAsync(url, BuildRequestJson(model, systemPrompt, userContent, jsonMode: true), cancellationToken);
+        var response = await PostAsync(url, BuildRequestJson(model, systemPrompt, userContent, jsonMode: true), apiKey, cancellationToken);
         if (!response.ok && !cancellationToken.IsCancellationRequested)
         {
-            response = await PostAsync(url, BuildRequestJson(model, systemPrompt, userContent, jsonMode: false), cancellationToken);
+            response = await PostAsync(url, BuildRequestJson(model, systemPrompt, userContent, jsonMode: false), apiKey, cancellationToken);
         }
 
         if (!response.ok)
@@ -83,13 +83,19 @@ public class AiReviewClient : IDisposable
         return Encoding.UTF8.GetString(stream.ToArray());
     }
 
-    private async Task<(bool ok, string body)> PostAsync(string url, string json, CancellationToken cancellationToken)
+    private async Task<(bool ok, string body)> PostAsync(string url, string json, string? apiKey, CancellationToken cancellationToken)
     {
         var content = new StringContent(json, Encoding.UTF8);
         content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
         try
         {
-            var result = await _httpClient.PostAsync(url, content, cancellationToken).ConfigureAwait(false);
+            using var request = new HttpRequestMessage(HttpMethod.Post, url) { Content = content };
+            if (!string.IsNullOrWhiteSpace(apiKey))
+            {
+                request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", apiKey.Trim());
+            }
+
+            var result = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
             var body = await result.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
             return (result.IsSuccessStatusCode, body);
         }

--- a/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
@@ -26,7 +26,11 @@ public partial class AiReviewViewModel : ObservableObject
     [ObservableProperty] private string _selectedEngine;
     [ObservableProperty] private bool _isOllamaVisible;
     [ObservableProperty] private bool _isLlamaCppVisible;
+    [ObservableProperty] private bool _isOpenAiCompatibleVisible;
     [ObservableProperty] private string _ollamaModel;
+    [ObservableProperty] private string _openAiCompatibleUrl;
+    [ObservableProperty] private string _openAiCompatibleModel;
+    [ObservableProperty] private string _openAiCompatibleApiKey;
     [ObservableProperty] private ObservableCollection<LlamaCppModelDisplay> _llamaCppModels;
     [ObservableProperty] private LlamaCppModelDisplay? _selectedLlamaCppModel;
     [ObservableProperty] private string _languageDisplay;
@@ -60,11 +64,14 @@ public partial class AiReviewViewModel : ObservableObject
     {
         _windowService = windowService;
 
-        Engines = new ObservableCollection<string> { SeAiReview.EngineLlamaCpp, SeAiReview.EngineOllama };
-        SelectedEngine = Se.Settings.Tools.AiReview.Engine == SeAiReview.EngineOllama
-            ? SeAiReview.EngineOllama
+        Engines = new ObservableCollection<string> { SeAiReview.EngineLlamaCpp, SeAiReview.EngineOllama, SeAiReview.EngineOpenAiCompatible };
+        SelectedEngine = Engines.Contains(Se.Settings.Tools.AiReview.Engine)
+            ? Se.Settings.Tools.AiReview.Engine
             : SeAiReview.EngineLlamaCpp;
         OllamaModel = Se.Settings.Tools.AiReview.OllamaModel;
+        OpenAiCompatibleUrl = Se.Settings.Tools.AiReview.OpenAiCompatibleUrl;
+        OpenAiCompatibleModel = Se.Settings.Tools.AiReview.OpenAiCompatibleModel;
+        OpenAiCompatibleApiKey = Se.Settings.Tools.AiReview.OpenAiCompatibleApiKey;
         LlamaCppModels = new ObservableCollection<LlamaCppModelDisplay>();
         SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(
             LlamaCppModels,
@@ -138,7 +145,8 @@ public partial class AiReviewViewModel : ObservableObject
     private void UpdateEngineVisibility()
     {
         IsOllamaVisible = SelectedEngine == SeAiReview.EngineOllama;
-        IsLlamaCppVisible = !IsOllamaVisible;
+        IsOpenAiCompatibleVisible = SelectedEngine == SeAiReview.EngineOpenAiCompatible;
+        IsLlamaCppVisible = !IsOllamaVisible && !IsOpenAiCompatibleVisible;
     }
 
     partial void OnSelectedSuggestionChanged(ReviewSuggestionItem? value)
@@ -172,6 +180,9 @@ public partial class AiReviewViewModel : ObservableObject
         settings.Engine = SelectedEngine;
         settings.OllamaModel = OllamaModel;
         settings.LlamaCppModelFileName = SelectedLlamaCppModel?.Model.FileName ?? string.Empty;
+        settings.OpenAiCompatibleUrl = OpenAiCompatibleUrl.Trim();
+        settings.OpenAiCompatibleModel = OpenAiCompatibleModel.Trim();
+        settings.OpenAiCompatibleApiKey = OpenAiCompatibleApiKey.Trim();
         Se.SaveSettings();
     }
 
@@ -188,6 +199,7 @@ public partial class AiReviewViewModel : ObservableObject
 
         string url;
         var model = string.Empty;
+        string? apiKey = null;
         if (SelectedEngine == SeAiReview.EngineLlamaCpp)
         {
             var display = SelectedLlamaCppModel;
@@ -222,6 +234,13 @@ public partial class AiReviewViewModel : ObservableObject
             }
 
             url = LlamaCppServerManager.ApiUrl;
+        }
+        else if (SelectedEngine == SeAiReview.EngineOpenAiCompatible)
+        {
+            url = OpenAiCompatibleUrl.Trim();
+            model = OpenAiCompatibleModel.Trim();
+            apiKey = string.IsNullOrWhiteSpace(OpenAiCompatibleApiKey) ? null : OpenAiCompatibleApiKey.Trim();
+            IsReviewing = true;
         }
         else
         {
@@ -273,12 +292,12 @@ public partial class AiReviewViewModel : ObservableObject
                 List<AiReviewChange>? changes = null;
                 try
                 {
-                    var reply = await client.ChatAsync(url, model, systemPrompt, userContent, ct);
+                    var reply = await client.ChatAsync(url, model, systemPrompt, userContent, ct, apiKey);
                     changes = AiReviewProtocol.ParseChanges(reply, editableNumbers);
                     if (changes.Count == 0 && AiReviewProtocol.ExtractJsonObject(reply) == null)
                     {
                         // invalid reply - one retry for this chunk
-                        reply = await client.ChatAsync(url, model, systemPrompt, userContent, ct);
+                        reply = await client.ChatAsync(url, model, systemPrompt, userContent, ct, apiKey);
                         changes = AiReviewProtocol.ParseChanges(reply, editableNumbers);
                     }
 

--- a/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
@@ -47,6 +47,24 @@ public class AiReviewWindow : Window
         };
         panelOllama.Bind(IsVisibleProperty, new Binding(nameof(vm.IsOllamaVisible)));
 
+        var textBoxOpenAiUrl = UiUtil.MakeTextBox(250, vm, nameof(vm.OpenAiCompatibleUrl))
+            .WithAccessibleName(Se.Language.General.Url);
+        var textBoxOpenAiModel = UiUtil.MakeTextBox(150, vm, nameof(vm.OpenAiCompatibleModel))
+            .WithAccessibleName(Se.Language.General.Model);
+        textBoxOpenAiModel.Watermark = Se.Language.General.Model;
+        var textBoxOpenAiApiKey = UiUtil.MakeTextBox(130, vm, nameof(vm.OpenAiCompatibleApiKey))
+            .WithAccessibleName(Se.Language.General.ApiKey);
+        textBoxOpenAiApiKey.Watermark = Se.Language.General.ApiKey;
+        textBoxOpenAiApiKey.PasswordChar = '\u25cf';
+        var panelOpenAiCompatible = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 5,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children = { textBoxOpenAiUrl, textBoxOpenAiModel, textBoxOpenAiApiKey },
+        };
+        panelOpenAiCompatible.Bind(IsVisibleProperty, new Binding(nameof(vm.IsOpenAiCompatibleVisible)));
+
         var comboLlamaCppModel = UiUtil.MakeComboBox(vm.LlamaCppModels, vm, nameof(vm.SelectedLlamaCppModel))
             .WithAccessibleName(Se.Language.General.Model);
         comboLlamaCppModel.Bind(IsVisibleProperty, new Binding(nameof(vm.IsLlamaCppVisible)));
@@ -104,7 +122,7 @@ public class AiReviewWindow : Window
 
         var toolbar = new Grid
         {
-            ColumnDefinitions = new ColumnDefinitions("Auto,Auto,Auto,Auto,Auto,*,Auto"),
+            ColumnDefinitions = new ColumnDefinitions("Auto,Auto,Auto,Auto,Auto,Auto,*,Auto"),
             ColumnSpacing = 8,
         };
         var labelEngine = UiUtil.MakeTextBlock(Se.Language.General.Engine).WithMarginRight(2);
@@ -113,8 +131,9 @@ public class AiReviewWindow : Window
         toolbar.Add(comboEngine, 0, 1);
         toolbar.Add(panelOllama, 0, 2);
         toolbar.Add(comboLlamaCppModel, 0, 3);
-        toolbar.Add(languageChip, 0, 4);
-        toolbar.Add(buttonEditPrompt, 0, 6);
+        toolbar.Add(panelOpenAiCompatible, 0, 4);
+        toolbar.Add(languageChip, 0, 5);
+        toolbar.Add(buttonEditPrompt, 0, 7);
 
         // ---------- filter chips ----------
         var chipsItems = new ItemsControl

--- a/src/ui/Logic/Config/SeAiReview.cs
+++ b/src/ui/Logic/Config/SeAiReview.cs
@@ -6,11 +6,15 @@ public class SeAiReview
     public string OllamaUrl { get; set; }
     public string OllamaModel { get; set; }
     public string LlamaCppModelFileName { get; set; }
+    public string OpenAiCompatibleUrl { get; set; }
+    public string OpenAiCompatibleModel { get; set; }
+    public string OpenAiCompatibleApiKey { get; set; }
     public string Prompt { get; set; }
     public int MaxLinesPerBatch { get; set; }
 
     public const string EngineOllama = "Ollama";
     public const string EngineLlamaCpp = "llama.cpp";
+    public const string EngineOpenAiCompatible = "OpenAI-compatible";
 
     public static string DefaultPrompt =>
         "You are a subtitle proofreader. Fix typos, spelling, grammar and punctuation in {language}." +
@@ -23,6 +27,9 @@ public class SeAiReview
         OllamaUrl = "http://localhost:11434/v1/chat/completions";
         OllamaModel = string.Empty;
         LlamaCppModelFileName = string.Empty;
+        OpenAiCompatibleUrl = "http://localhost:1234/v1/chat/completions";
+        OpenAiCompatibleModel = string.Empty;
+        OpenAiCompatibleApiKey = string.Empty;
         Prompt = DefaultPrompt;
         MaxLinesPerBatch = 15;
     }


### PR DESCRIPTION
Follow-up to #12077 — these two commits were pushed to the feature branch just after it was merged, so they missed main:

- **Generic OpenAI-compatible engine**: URL + model + optional API key (Bearer token, masked input). One engine covers LM Studio, KoboldCpp, vLLM, remote llama.cpp, and the OpenAI-compatible cloud APIs (OpenAI, Groq, OpenRouter, DeepSeek, Mistral, Gemini). Defaults to LM Studio's local URL.
- **Change log entry** for AI review in the beta5 section.

All 524 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)