### PR TITLE
Adjust all times: shortcut steps follow the time code display mode

### DIFF
--- a/docs/features/adjust-all-times.md
+++ b/docs/features/adjust-all-times.md
@@ -17,6 +17,8 @@ The window remembers its position and stays open across New/Open, so adjustments
 
 ## Keyboard shortcuts
 
-- Shift/Ctrl/Alt + Left or Right arrow — Show earlier/later by 1 frame / 10 frames / 1 second
+- Shift/Ctrl/Alt + Left or Right arrow — Show earlier/later
+  - Time codes shown as milliseconds: 10 ms / 100 ms / 500 ms
+  - Time codes shown as frames: 1 frame / 10 frames / 1 second
 
 > **Note:** "Selected lines and forward" applies the shift to the currently selected lines and every line after them.

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2197,7 +2197,8 @@
     "pointSyncViaOther": "Point sync via other subtitle",
     "adjustmentX": "Adjustment: {0}",
     "totalAdjustmentX": "Total adjustment: {0}",
-    "adjustAllShortcuts": "Keyboard shortcuts:\r\n\r\n• Shift + Left/Right: Move 1 frame\r\n• Ctrl + Left/Right: Move 10 frames\r\n• Alt + Left/Right: Move 1 second",
+    "adjustAllShortcuts": "Keyboard shortcuts:\r\n\r\n• Shift + Left/Right: Move 10 ms\r\n• Ctrl + Left/Right: Move 100 ms\r\n• Alt + Left/Right: Move 500 ms",
+    "adjustAllShortcutsFrames": "Keyboard shortcuts:\r\n\r\n• Shift + Left/Right: Move 1 frame\r\n• Ctrl + Left/Right: Move 10 frames\r\n• Alt + Left/Right: Move 1 second",
     "offsetInSeconds": "Offset in seconds",
     "speedFactor": "Speed factor",
     "showEarlierLaterDotDotDot": "Show earlier/later..."

--- a/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesViewModel.cs
+++ b/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesViewModel.cs
@@ -131,7 +131,7 @@ public partial class AdjustAllTimesViewModel : ObservableObject
         await MessageBox.Show(
             Window,
             Se.Language.General.Information,
-            Se.Language.Sync.AdjustAllShortcuts,
+            GetShortcutsText(),
             MessageBoxButtons.OK,
             MessageBoxIcon.Information);
     }
@@ -191,32 +191,32 @@ public partial class AdjustAllTimesViewModel : ObservableObject
         else if ((e.Key == Key.Right || e.Key == Key.FnRightArrow) && e.KeyModifiers == KeyModifiers.Shift)
         {
             e.Handled = true;
-            ShowLaterTimeSpan(GetFrameDuration(1));
+            ShowLaterTimeSpan(GetSmallStep());
         }
         else if ((e.Key == Key.Right || e.Key == Key.FnRightArrow) && e.KeyModifiers == KeyModifiers.Control)
         {
             e.Handled = true;
-            ShowLaterTimeSpan(GetFrameDuration(10));
+            ShowLaterTimeSpan(GetMediumStep());
         }
         else if ((e.Key == Key.Right || e.Key == Key.FnRightArrow) && e.KeyModifiers == KeyModifiers.Alt)
         {
             e.Handled = true;
-            ShowLaterTimeSpan(TimeSpan.FromSeconds(1));
+            ShowLaterTimeSpan(GetLargeStep());
         }
         else if ((e.Key == Key.Left || e.Key == Key.FnLeftArrow) && e.KeyModifiers == KeyModifiers.Shift)
         {
             e.Handled = true;
-            ShowEarlierTimeSpan(GetFrameDuration(1));
+            ShowEarlierTimeSpan(GetSmallStep());
         }
         else if ((e.Key == Key.Left || e.Key == Key.FnLeftArrow) && e.KeyModifiers == KeyModifiers.Control)
         {
             e.Handled = true;
-            ShowEarlierTimeSpan(GetFrameDuration(10));
+            ShowEarlierTimeSpan(GetMediumStep());
         }
         else if ((e.Key == Key.Left || e.Key == Key.FnLeftArrow) && e.KeyModifiers == KeyModifiers.Alt)
         {
             e.Handled = true;
-            ShowEarlierTimeSpan(TimeSpan.FromSeconds(1));
+            ShowEarlierTimeSpan(GetLargeStep());
         }
         else if (UiUtil.IsHelp(e))
         {
@@ -224,6 +224,16 @@ public partial class AdjustAllTimesViewModel : ObservableObject
             UiUtil.ShowHelp("features/adjust-all-times");
         }
     }
+
+    // The shortcut steps follow the time code display mode: frames when the time codes are
+    // shown as frames, plain milliseconds otherwise.
+    private static TimeSpan GetSmallStep() => Se.Settings.General.UseFrameMode ? GetFrameDuration(1) : TimeSpan.FromMilliseconds(10);
+    private static TimeSpan GetMediumStep() => Se.Settings.General.UseFrameMode ? GetFrameDuration(10) : TimeSpan.FromMilliseconds(100);
+    private static TimeSpan GetLargeStep() => Se.Settings.General.UseFrameMode ? TimeSpan.FromSeconds(1) : TimeSpan.FromMilliseconds(500);
+
+    internal static string GetShortcutsText() => Se.Settings.General.UseFrameMode
+        ? Se.Language.Sync.AdjustAllShortcutsFrames
+        : Se.Language.Sync.AdjustAllShortcuts;
 
     private static TimeSpan GetFrameDuration(int frames)
     {

--- a/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesWindow.cs
+++ b/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesWindow.cs
@@ -71,7 +71,7 @@ public class AdjustAllTimesWindow : Window
             },
         };
 
-        var buttonHelp = UiUtil.MakeButton(vm.ShowHelpCommand, IconNames.Help, Se.Language.Sync.AdjustAllShortcuts);
+        var buttonHelp = UiUtil.MakeButton(vm.ShowHelpCommand, IconNames.Help, AdjustAllTimesViewModel.GetShortcutsText());
         var buttonOk = UiUtil.MakeButtonDone(vm.OkCommand);
         var panelButtons = UiUtil.MakeButtonBar(buttonHelp, buttonOk);
 

--- a/src/ui/Logic/Config/Language/Sync/LanguageSync.cs
+++ b/src/ui/Logic/Config/Language/Sync/LanguageSync.cs
@@ -32,6 +32,7 @@ public class LanguageSync
     public string AdjustmentX { get; set; }
     public string TotalAdjustmentX { get; set; }
     public string AdjustAllShortcuts { get; set; }
+    public string AdjustAllShortcutsFrames { get; set; }
     public string OffsetInSeconds { get; set; }
     public string SpeedFactor { get; set; }
     public string ShowEarlierLaterDotDotDot { get; set; }
@@ -65,7 +66,8 @@ public class LanguageSync
         PointSyncViaOther = "Point sync via other subtitle";
         AdjustmentX = "Adjustment: {0}";
         TotalAdjustmentX = "Total adjustment: {0}";
-        AdjustAllShortcuts = "Keyboard shortcuts:\r\n\r\n• Shift + Left/Right: Move 1 frame\r\n• Ctrl + Left/Right: Move 10 frames\r\n• Alt + Left/Right: Move 1 second";
+        AdjustAllShortcuts = "Keyboard shortcuts:\r\n\r\n• Shift + Left/Right: Move 10 ms\r\n• Ctrl + Left/Right: Move 100 ms\r\n• Alt + Left/Right: Move 500 ms";
+        AdjustAllShortcutsFrames = "Keyboard shortcuts:\r\n\r\n• Shift + Left/Right: Move 1 frame\r\n• Ctrl + Left/Right: Move 10 frames\r\n• Alt + Left/Right: Move 1 second";
         OffsetInSeconds = "Offset in seconds";
         SpeedFactor = "Speed factor";
         ShowEarlierLaterDotDotDot = "Show earlier/later...";


### PR DESCRIPTION
Follow-up to #12067: the Shift/Ctrl/Alt+arrow shortcuts in "Adjust all times" stepped by frames unconditionally. They now follow the time code display mode (`Se.Settings.General.UseFrameMode`):

- **Milliseconds mode:** 10 ms / 100 ms / 500 ms (the classic steps)
- **Frame mode:** 1 frame / 10 frames / 1 second

The help text is now two language strings picked at display time (both the ? button hint and the help dialog), English.json updated accordingly, and `docs/features/adjust-all-times.md` describes both modes.

All 524 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)