### PR TITLE
Auto-translate: fix ChatGPT "This is not a chat model" error

### DIFF
--- a/src/libse/AutoTranslate/ChatGptTranslate.cs
+++ b/src/libse/AutoTranslate/ChatGptTranslate.cs
@@ -25,16 +25,24 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
         public string Url => "https://chat.openai.com/";
         public string Error { get; set; }
         public int MaxCharacters => 1500;
+        /// <summary>
+        /// Default when no model is configured. A mini model: cheap, broadly available on every
+        /// account tier, and served by the chat/completions endpoint this engine calls.
+        /// </summary>
+        public static string DefaultModel => "gpt-5.4-mini";
+
+        // Only models served by /v1/chat/completions belong here. The "-pro" models are
+        // responses-endpoint only and fail with "This is not a chat model" (#12078), and
+        // gpt-oss-120b is an open-weights model not hosted on api.openai.com at all.
         public static string[] Models => new[]
         {
-            "gpt-5.5-pro", "gpt-5.5",
-            "gpt-5.4-pro", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano",
+            "gpt-5.5",
+            "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano",
             "gpt-5.3-chat",
-            "gpt-5.2-pro", "gpt-5.2",
+            "gpt-5.2",
             "gpt-5.1",
-            "gpt-5-pro", "gpt-5", "gpt-5-mini", "gpt-5-nano",
+            "gpt-5", "gpt-5-mini", "gpt-5-nano",
             "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano",
-            "gpt-oss-120b",
         };
 
         public static string RemovePreamble(string original, string input)
@@ -93,7 +101,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             var model = Configuration.Settings.Tools.ChatGptModel;
             if (string.IsNullOrEmpty(model))
             {
-                model = Models[0];
+                model = DefaultModel;
                 Configuration.Settings.Tools.ChatGptModel = model;
             }
 

--- a/src/libse/Settings/ToolsSettings.cs
+++ b/src/libse/Settings/ToolsSettings.cs
@@ -369,7 +369,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
             AutoTranslateMistralPrompt = "Translate from {0} to {1}, keep punctuation as input, keep line breaks exactly the same, do not censor the translation, give only the output without comments:";
             ChatGptUrl = "https://api.openai.com/v1/chat/completions";
             ChatGptPrompt = "Translate from {0} to {1}, keep punctuation as input, keep line breaks exactly the same, do not censor the translation, give only the output without comments:";
-            ChatGptModel = ChatGptTranslate.Models[0];
+            ChatGptModel = ChatGptTranslate.DefaultModel;
             GroqUrl = "https://api.groq.com/openai/v1/chat/completions";
             GroqPrompt = "Translate from {0} to {1}, keep punctuation as input, keep line breaks exactly the same, do not censor the translation, give only the output without comments:";
             GroqModel = GroqTranslate.Models[0];

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -1665,7 +1665,20 @@ public partial class AutoTranslateViewModel : ObservableObject
 
             if (string.IsNullOrWhiteSpace(Configuration.Settings.Tools.ChatGptModel))
             {
-                Configuration.Settings.Tools.ChatGptModel = ChatGptTranslate.Models[0];
+                Configuration.Settings.Tools.ChatGptModel = ChatGptTranslate.DefaultModel;
+            }
+
+            // Migrate away from models older builds defaulted to that the chat/completions
+            // endpoint does not serve ("-pro" models, gpt-oss-120b) - they fail with
+            // "This is not a chat model" (#12078). Only on the official endpoint, so custom
+            // servers keep whatever model name the user configured.
+            var chatGptModel = Configuration.Settings.Tools.ChatGptModel;
+            var isOfficialChatGptUrl = Configuration.Settings.Tools.ChatGptUrl.Contains("api.openai.com", StringComparison.OrdinalIgnoreCase);
+            if (isOfficialChatGptUrl &&
+                (chatGptModel.EndsWith("-pro", StringComparison.OrdinalIgnoreCase) ||
+                 chatGptModel.StartsWith("gpt-oss", StringComparison.OrdinalIgnoreCase)))
+            {
+                Configuration.Settings.Tools.ChatGptModel = ChatGptTranslate.DefaultModel;
             }
 
             ModelText = Configuration.Settings.Tools.ChatGptModel;

--- a/src/ui/Logic/Config/SeAutoTranslate.cs
+++ b/src/ui/Logic/Config/SeAutoTranslate.cs
@@ -126,7 +126,7 @@ public class SeAutoTranslate
         BaiduApiKey = string.Empty;
         BaiduUrl = "https://fanyi-api.baidu.com";
         ChatGptApiKey = string.Empty;
-        ChatGptModel = ChatGptTranslate.Models[0];
+        ChatGptModel = ChatGptTranslate.DefaultModel;
         ChatGptPrompt = "Translate from {0} to {1}, keep punctuation as input, do not censor the translation, give only the output without comments:";
         ChatGptUrl = "https://api.openai.com/v1/chat/completions";
         CopyPasteLineSeparator = "(...)";


### PR DESCRIPTION
Fixes #12078.

The ChatGPT engine defaulted to `gpt-5.5-pro` (`Models[0]`), but the "-pro" models are served by the **responses** endpoint only — calling `/v1/chat/completions` with them fails with *"This is not a chat model"* regardless of the API key. So every user on default settings hit the reported error. `gpt-oss-120b` was also in the list but is an open-weights model not hosted on api.openai.com at all.

Full review of the model list against what `/v1/chat/completions` serves:

- **Removed:** gpt-5.5-pro, gpt-5.4-pro, gpt-5.2-pro, gpt-5-pro (responses-only), gpt-oss-120b (not on OpenAI's API — it belongs in the Groq/OpenRouter/local lists)
- **Kept:** gpt-5.5, gpt-5.4(+mini/nano), gpt-5.3-chat, gpt-5.2, gpt-5.1, gpt-5(+mini/nano), gpt-4.1(+mini/nano)

Changes:
- New `ChatGptTranslate.DefaultModel = "gpt-5.4-mini"` — cheap, chat-capable, available on every account tier (the modern analog of the gpt-4o-mini the reporter used in SE4) — used for all `Models[0]` fallbacks (libse + UI settings defaults)
- **Migration**: a previously saved "-pro"/gpt-oss model is replaced with the default when the URL is the official api.openai.com endpoint; custom server URLs keep their configured model name untouched

All 1009 tests pass.

Note: the model text box still doesn't expose the model list as a picker (the loaded `_apiModels` list is currently unused for all API engines) — that discoverability fix is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)