### PR TITLE
Make tool-dialog buttons consistent and fix Remove text for HI undo

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5509,9 +5509,14 @@ public partial class MainViewModel :
 
         void ApplyToGrid(Subtitle applied)
         {
-            ReplaceSubtitles(applied.Paragraphs.Select(p => new SubtitleLineViewModel(p, SelectedSubtitleFormat)));
-            SelectAndScrollToRow(0);
-            _updateAudioVisualizer = true;
+            // Stop change detection during the rewrite so the background undo snapshotter can't
+            // race the Subtitles Clear/AddRange (matches every other bulk grid operation).
+            RunWithoutChangeDetection(() =>
+            {
+                ReplaceSubtitles(applied.Paragraphs.Select(p => new SubtitleLineViewModel(p, SelectedSubtitleFormat)));
+                SelectAndScrollToRow(0);
+                _updateAudioVisualizer = true;
+            });
         }
 
         // Menu mode uses Apply + Done: the change is applied live via the ApplyToGrid callback,
@@ -8064,16 +8069,21 @@ public partial class MainViewModel :
 
         // The HI removal can drop lines that become empty, so the result is not 1:1 with the
         // selection - replace the selected block with the fixed lines (inserted where it started).
-        var selectedIds = ordered.Select(s => s.Id).ToHashSet();
-        var firstIndex = Subtitles.IndexOf(ordered[0]);
-        var kept = Subtitles.Where(s => !selectedIds.Contains(s.Id)).ToList();
-        var insertPos = Math.Min(firstIndex, kept.Count);
-        kept.InsertRange(insertPos, result.FixedSubtitle.Paragraphs.Select(p => new SubtitleLineViewModel(p, SelectedSubtitleFormat)));
+        // Stop change detection during the rewrite so the background undo snapshotter can't race
+        // the Subtitles Clear/AddRange, which left the operation without a clean undo entry.
+        RunWithoutChangeDetection(() =>
+        {
+            var selectedIds = ordered.Select(s => s.Id).ToHashSet();
+            var firstIndex = Subtitles.IndexOf(ordered[0]);
+            var kept = Subtitles.Where(s => !selectedIds.Contains(s.Id)).ToList();
+            var insertPos = Math.Min(firstIndex, kept.Count);
+            kept.InsertRange(insertPos, result.FixedSubtitle.Paragraphs.Select(p => new SubtitleLineViewModel(p, SelectedSubtitleFormat)));
 
-        ReplaceSubtitles(kept);
-        Renumber();
-        SelectAndScrollToRow(insertPos);
-        _updateAudioVisualizer = true;
+            ReplaceSubtitles(kept);
+            Renumber();
+            SelectAndScrollToRow(insertPos);
+            _updateAudioVisualizer = true;
+        });
     }
 
     [RelayCommand]

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5514,13 +5514,10 @@ public partial class MainViewModel :
             _updateAudioVisualizer = true;
         }
 
-        var result = await ShowDialogAsync<RemoveTextForHearingImpairedWindow, RemoveTextForHearingImpairedViewModel>(
+        // Menu mode uses Apply + Done: the change is applied live via the ApplyToGrid callback,
+        // so there is nothing to commit when the dialog closes.
+        await ShowDialogAsync<RemoveTextForHearingImpairedWindow, RemoveTextForHearingImpairedViewModel>(
             vm => { vm.Initialize(GetUpdateSubtitle(), ApplyToGrid); });
-
-        if (result.OkPressed)
-        {
-            ApplyToGrid(result.FixedSubtitle);
-        }
     }
 
     [RelayCommand]
@@ -7476,7 +7473,8 @@ public partial class MainViewModel :
             .ToList();
 
         // The dialog applies the change itself (idempotently, from a snapshot taken when it
-        // opened), so we must not re-apply here - doing so compounded the factor (Apply + OK).
+        // opened) via Apply, so we must not re-apply here. Done just signals via OkPressed
+        // that timings may have changed so the audio visualizer can refresh.
         var result = await ShowDialogAsync<ChangeSpeedWindow, ChangeSpeedViewModel>(vm => { vm.Initialize(Subtitles, selectedIndices); });
         if (result.OkPressed)
         {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8050,40 +8050,41 @@ public partial class MainViewModel :
             return;
         }
 
-        var result = await ShowDialogAsync<RemoveTextForHearingImpairedWindow, RemoveTextForHearingImpairedViewModel>(vm =>
+        // Apply + Done, like the whole-file menu path: each Apply replaces the current block in the
+        // grid. Track the block by id so repeated passes replace what the previous pass produced -
+        // the removal can drop emptied lines, so the block is not 1:1 with the selection, and the
+        // first pass also collapses a possibly non-contiguous selection into one contiguous block.
+        var blockIds = ordered.Select(s => s.Id).ToHashSet();
+
+        void ApplyToGrid(Subtitle applied)
         {
-            var sub = new Subtitle();
-            foreach (var line in ordered)
+            // Stop change detection during the rewrite so the background undo snapshotter can't race
+            // the Subtitles Clear/AddRange (matches every other bulk grid operation).
+            RunWithoutChangeDetection(() =>
             {
-                sub.Paragraphs.Add(line.ToParagraph(SelectedSubtitleFormat));
-            }
+                var anchor = Subtitles.FirstOrDefault(s => blockIds.Contains(s.Id));
+                var firstIndex = anchor != null ? Subtitles.IndexOf(anchor) : Subtitles.Count;
+                var kept = Subtitles.Where(s => !blockIds.Contains(s.Id)).ToList();
+                var insertPos = Math.Min(firstIndex, kept.Count);
+                var newLines = applied.Paragraphs.Select(p => new SubtitleLineViewModel(p, SelectedSubtitleFormat)).ToList();
+                kept.InsertRange(insertPos, newLines);
 
-            vm.Initialize(sub);
-        });
-
-        if (!result.OkPressed)
-        {
-            _shortcutManager.ClearKeys();
-            return;
+                ReplaceSubtitles(kept);
+                Renumber();
+                SelectAndScrollToRow(insertPos);
+                blockIds = newLines.Select(s => s.Id).ToHashSet();
+                _updateAudioVisualizer = true;
+            });
         }
 
-        // The HI removal can drop lines that become empty, so the result is not 1:1 with the
-        // selection - replace the selected block with the fixed lines (inserted where it started).
-        // Stop change detection during the rewrite so the background undo snapshotter can't race
-        // the Subtitles Clear/AddRange, which left the operation without a clean undo entry.
-        RunWithoutChangeDetection(() =>
+        var sub = new Subtitle();
+        foreach (var line in ordered)
         {
-            var selectedIds = ordered.Select(s => s.Id).ToHashSet();
-            var firstIndex = Subtitles.IndexOf(ordered[0]);
-            var kept = Subtitles.Where(s => !selectedIds.Contains(s.Id)).ToList();
-            var insertPos = Math.Min(firstIndex, kept.Count);
-            kept.InsertRange(insertPos, result.FixedSubtitle.Paragraphs.Select(p => new SubtitleLineViewModel(p, SelectedSubtitleFormat)));
+            sub.Paragraphs.Add(line.ToParagraph(SelectedSubtitleFormat));
+        }
 
-            ReplaceSubtitles(kept);
-            Renumber();
-            SelectAndScrollToRow(insertPos);
-            _updateAudioVisualizer = true;
-        });
+        await ShowDialogAsync<RemoveTextForHearingImpairedWindow, RemoveTextForHearingImpairedViewModel>(
+            vm => { vm.Initialize(sub, ApplyToGrid); });
     }
 
     [RelayCommand]

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1742,8 +1742,8 @@ public partial class BinaryEditViewModel : ObservableObject
             RefreshGrid();
         }
 
-        // The dialog applies via this callback (on both Apply and Change/OK), so there is
-        // nothing to re-apply here - re-applying compounded the factor.
+        // The dialog applies via this callback (Apply), so there is nothing to re-apply here
+        // when it closes with Done - re-applying compounded the factor.
         await _windowService.ShowDialogAsync<ChangeSpeedWindow, ChangeSpeedViewModel>(Window, vm => { vm.Initialize(selectedIndices.Count > 0, ApplySpeed); });
     }
 

--- a/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedViewModel.cs
+++ b/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedViewModel.cs
@@ -51,10 +51,11 @@ public partial class ChangeSpeedViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void Ok()
+    private void Done()
     {
+        // Changes are already applied via Apply; Done just closes. OkPressed signals the
+        // caller that timings may have changed so it can refresh (e.g. the audio visualizer).
         OkPressed = true;
-        Apply(); // apply once; idempotent (recomputed from the original snapshot)
         Window?.Close();
     }
 
@@ -103,12 +104,6 @@ public partial class ChangeSpeedViewModel : ObservableObject
                 TimeSpan.FromMilliseconds(_originalTimes[i].Start * factor),
                 TimeSpan.FromMilliseconds(_originalTimes[i].End * factor));
         }
-    }
-
-    [RelayCommand]
-    private void Cancel()
-    {
-        Window?.Close();
     }
 
     internal void Initialize(ObservableCollection<SubtitleLineViewModel> subtitles, IList<int> selectedIndices)

--- a/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedWindow.cs
+++ b/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedWindow.cs
@@ -83,10 +83,9 @@ public class ChangeSpeedWindow : Window
             },
         };
 
-        var buttonOk = UiUtil.MakeButton(Se.Language.General.Change, vm.OkCommand);
         var buttonApply = UiUtil.MakeButton(Se.Language.General.Apply, vm.ApplyCommand);
-        var buttonDone = UiUtil.MakeButtonDone(vm.CancelCommand);
-        var buttonPanel = UiUtil.MakeButtonBar(buttonOk, buttonApply, buttonDone);
+        var buttonDone = UiUtil.MakeButtonDone(vm.DoneCommand);
+        var buttonPanel = UiUtil.MakeButtonBar(buttonApply, buttonDone);
 
         var grid = new Grid
         {
@@ -117,7 +116,7 @@ public class ChangeSpeedWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
+        Activated += delegate { buttonDone.Focus(); }; // hack to make OnKeyDown work
         Loaded += (_, _) => UiUtil.RestoreWindowPosition(this);
         Closing += (_, _) => UiUtil.SaveWindowPosition(this);
         KeyDown += (_, e) => vm.OnKeyDown(e);

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModel.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModel.cs
@@ -70,17 +70,16 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
     [ObservableProperty] private string _fixText;
     [ObservableProperty] private bool _fixTextEnabled;
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(IsOkVisible))]
+    [NotifyPropertyChangedFor(nameof(IsSettingsMode))]
     private bool _isApplyVisible;
     [ObservableProperty] private string _linesFoundText;
 
     public Window? Window { get; set; }
 
-    public bool OkPressed { get; private set; }
-    public Subtitle FixedSubtitle { get; private set; }
-
-    // Menu mode (apply callback) shows Apply + Done; selected-lines mode (no callback) shows Ok + Cancel.
-    public bool IsOkVisible => !IsApplyVisible;
+    // Callers with a live target (menu, selected lines) pass an apply callback and get Apply + Done.
+    // Settings-only callers (BatchConvert) pass no callback and use the dialog as a settings editor,
+    // so they get Ok (save) + Cancel (discard).
+    public bool IsSettingsMode => !IsApplyVisible;
 
     private Subtitle _subtitle;
     private RemoveTextForHI? _removeTextForHiLib;
@@ -101,7 +100,6 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
         LinesFoundText = string.Format(Se.Language.Tools.RemoveTextForHearingImpaired.LinesFoundX, 0);
         _timer = new Timer(500);
         _timer.Elapsed += TimerElapsed;
-        FixedSubtitle = new Subtitle();
         _subtitle = new Subtitle();
     }
 
@@ -206,9 +204,8 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
     [RelayCommand]
     private void Ok()
     {
+        // Settings-only mode (no live target, e.g. BatchConvert): persist the options and close.
         SaveSettings();
-        OkPressed = true;
-        FixedSubtitle = BuildFixedSubtitle();
         Window?.Close();
     }
 
@@ -236,7 +233,8 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
     [RelayCommand]
     private void Done()
     {
-        // Menu mode: changes are already applied live via Apply, so Done just closes.
+        // Edit modes (menu, selected lines): changes are already applied live via Apply, so Done
+        // just closes.
         Window?.Close();
     }
 

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModel.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModel.cs
@@ -69,13 +69,18 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
     [ObservableProperty] private RemoveItem? _selectedFix;
     [ObservableProperty] private string _fixText;
     [ObservableProperty] private bool _fixTextEnabled;
-    [ObservableProperty] private bool _isApplyVisible;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsOkVisible))]
+    private bool _isApplyVisible;
     [ObservableProperty] private string _linesFoundText;
 
     public Window? Window { get; set; }
 
     public bool OkPressed { get; private set; }
     public Subtitle FixedSubtitle { get; private set; }
+
+    // Menu mode (apply callback) shows Apply + Done; selected-lines mode (no callback) shows Ok + Cancel.
+    public bool IsOkVisible => !IsApplyVisible;
 
     private Subtitle _subtitle;
     private RemoveTextForHI? _removeTextForHiLib;
@@ -225,6 +230,13 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
     [RelayCommand]
     private void Cancel()
     {
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Done()
+    {
+        // Menu mode: changes are already applied live via Apply, so Done just closes.
         Window?.Close();
     }
 

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
@@ -34,13 +34,21 @@ public class RemoveTextForHearingImpairedWindow : Window
         var settingsView = MakeSettingsView(vm);
         var fixesView = MakeFixesView(vm);
 
-        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        // Selected-lines mode (no apply callback) commits once with Ok/Cancel; menu mode applies
+        // live and repeatedly with Apply, then Done just closes.
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand)
+            .WithBindIsVisible(nameof(vm.IsOkVisible));
         var buttonApply = UiUtil.MakeButton(Se.Language.General.Apply, vm.ApplyCommand)
             .WithBindIsVisible(nameof(vm.IsApplyVisible));
+        var buttonDone = UiUtil.MakeButtonDone(vm.DoneCommand)
+            .WithBindIsVisible(nameof(vm.IsApplyVisible));
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand)
+            .WithBindIsVisible(nameof(vm.IsOkVisible));
         var panelButtons = UiUtil.MakeButtonBar(
             buttonOk,
             buttonApply,
-            UiUtil.MakeButtonCancel(vm.CancelCommand)
+            buttonDone,
+            buttonCancel
         );
 
         var grid = new Grid
@@ -68,7 +76,7 @@ public class RemoveTextForHearingImpairedWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
+        Activated += delegate { (vm.IsApplyVisible ? buttonDone : buttonOk).Focus(); }; // hack to make OnKeyDown work
     }
 
     private StackPanel MakeSettingsView(RemoveTextForHearingImpairedViewModel vm)

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
@@ -34,16 +34,16 @@ public class RemoveTextForHearingImpairedWindow : Window
         var settingsView = MakeSettingsView(vm);
         var fixesView = MakeFixesView(vm);
 
-        // Selected-lines mode (no apply callback) commits once with Ok/Cancel; menu mode applies
-        // live and repeatedly with Apply, then Done just closes.
+        // Settings-only callers (BatchConvert) have no live target and commit once with Ok/Cancel;
+        // edit callers (menu, selected lines) apply live and repeatedly with Apply, then Done closes.
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand)
-            .WithBindIsVisible(nameof(vm.IsOkVisible));
+            .WithBindIsVisible(nameof(vm.IsSettingsMode));
         var buttonApply = UiUtil.MakeButton(Se.Language.General.Apply, vm.ApplyCommand)
             .WithBindIsVisible(nameof(vm.IsApplyVisible));
         var buttonDone = UiUtil.MakeButtonDone(vm.DoneCommand)
             .WithBindIsVisible(nameof(vm.IsApplyVisible));
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand)
-            .WithBindIsVisible(nameof(vm.IsOkVisible));
+            .WithBindIsVisible(nameof(vm.IsSettingsMode));
         var panelButtons = UiUtil.MakeButtonBar(
             buttonOk,
             buttonApply,

--- a/tests/UI/Features/Sync/ChangeSpeed/ChangeSpeedViewModelTests.cs
+++ b/tests/UI/Features/Sync/ChangeSpeed/ChangeSpeedViewModelTests.cs
@@ -18,18 +18,17 @@ public class ChangeSpeedViewModelTests
         };
 
     [Fact]
-    public void ApplyThenOk_DoesNotCompoundTheFactor()
+    public void ApplyThenDone_DoesNotCompoundTheFactor()
     {
-        // Regression (#bug-hunt): "Apply" then "Change"(OK) used to apply the factor twice
-        // (125% -> x0.8 -> x0.8 = x0.64). The dialog now recomputes from the original snapshot,
-        // so the result is the same as applying once.
+        // The dialog is Apply + Done: Apply commits once (125% -> x0.8) and Done just closes
+        // without re-applying, so the factor is never applied twice.
         var subtitles = OneLine();
         var vm = new ChangeSpeedViewModel();
         vm.Initialize(subtitles, new List<int>());
         vm.SpeedPercent = 125.0;
 
         vm.ApplyCommand.Execute(null);
-        vm.OkCommand.Execute(null);
+        vm.DoneCommand.Execute(null);
 
         Assert.Equal(800, subtitles[0].StartTime.TotalMilliseconds, 3);
         Assert.Equal(2400, subtitles[0].EndTime.TotalMilliseconds, 3);
@@ -53,17 +52,19 @@ public class ChangeSpeedViewModelTests
     }
 
     [Fact]
-    public void Ok_WithoutApply_AppliesOnce()
+    public void Done_WithoutApply_LeavesTimesUnchanged()
     {
+        // Done only closes; the change is committed by Apply, so closing without Apply is a no-op.
         var subtitles = OneLine();
         var vm = new ChangeSpeedViewModel();
         vm.Initialize(subtitles, new List<int>());
         vm.SpeedPercent = 125.0;
 
-        vm.OkCommand.Execute(null);
+        vm.DoneCommand.Execute(null);
 
-        Assert.Equal(800, subtitles[0].StartTime.TotalMilliseconds, 3);
-        Assert.Equal(2400, subtitles[0].EndTime.TotalMilliseconds, 3);
+        Assert.Equal(1000, subtitles[0].StartTime.TotalMilliseconds, 3);
+        Assert.Equal(3000, subtitles[0].EndTime.TotalMilliseconds, 3);
+        Assert.True(vm.OkPressed);
     }
 
     [Fact]
@@ -74,7 +75,7 @@ public class ChangeSpeedViewModelTests
         vm.Initialize(subtitles, new List<int>());
         vm.SpeedPercent = 0.0;
 
-        vm.OkCommand.Execute(null);
+        vm.ApplyCommand.Execute(null);
 
         // Times unchanged (no Infinity/overflow).
         Assert.Equal(1000, subtitles[0].StartTime.TotalMilliseconds, 3);

--- a/tests/UI/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModelTests.cs
+++ b/tests/UI/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModelTests.cs
@@ -16,11 +16,12 @@ public class RemoveTextForHearingImpairedViewModelTests
     }
 
     [AvaloniaFact]
-    public void Apply_IsHidden_WhenNoCallbackProvided()
+    public void SettingsMode_ShowsOkCancel_WhenNoCallbackProvided()
     {
         var vm = Resolve();
         vm.Initialize(new Subtitle());
         Assert.False(vm.IsApplyVisible);
+        Assert.True(vm.IsSettingsMode);
     }
 
     [AvaloniaFact]
@@ -42,7 +43,6 @@ public class RemoveTextForHearingImpairedViewModelTests
         vm.ApplyCommand.Execute(null);
 
         Assert.NotNull(applied);
-        Assert.False(vm.OkPressed); // Apply must not close / set OkPressed
         Assert.Single(applied!.Paragraphs); // the emptied line was dropped
         Assert.Equal("Hello there", applied.Paragraphs[0].Text);
     }


### PR DESCRIPTION
## Summary

Tool/sync dialogs closed in inconsistent ways — some applied once and closed (`OK`), some applied repeatedly then closed (`Apply…` + `Done`), and a couple mixed the two in confusing ways. This PR settles on a single button paradigm, fixes the dialogs that violated it, and fixes a related undo bug uncovered along the way.

## Guiding principle: two archetypes

Every tool dialog should be one of two shapes. A dialog has **either** an `OK` **or** an `Apply` + `Done` — never both — and **`Done` never means Cancel**.

- **Archetype A — configure-then-commit (one-shot):** `[OK] [Cancel]` (a descriptive verb like *Merge*/*Join* may stand in for *OK*). `OK` computes the result, applies it once, and closes; `Cancel` discards. The subtitle isn't touched until `OK`.
  _Reference: Convert actors, Merge two subtitles._
- **Archetype B — interactive/repeatable:** `[Apply…] [Done]`. `Apply` performs the operation live and can be pressed repeatedly; **`Done` just closes and never re-applies** (everything is already applied via `Apply`).
  _Reference: Adjust all times (Show earlier/later), Fix Common Errors._

## Outliers fixed

**Change Speed** — was `Change` + `Apply` + `Done`, where the primary was mislabeled *Change* and *Done* was literally the *Cancel* command. Now a clean Archetype B: `Apply` + `Done`. `Apply` scales from the original-times snapshot (idempotent/repeatable); `Done` closes without re-applying. This also fixes the reused Change Speed in the "Edit image-based subtitle" (BinaryEdit) dialog.

**Remove text for Hearing Impaired** — previously had both `Apply` **and** `OK` where `OK` also applied (two commit paths → double-apply risk), and its two entry points behaved differently. Now:
- Both **edit** entry points — the Tools menu (whole file) and the selected-lines context action — use `Apply` + `Done`. The selected-lines path was rewritten to apply live via a re-entrant callback (it tracks the edited block by id so repeated `Apply` passes replace what the previous pass produced, and a non-contiguous selection collapses into one contiguous block on the first pass).
- The **settings-only** caller (Batch convert, which opens the dialog on an empty subtitle just to edit the persisted removal options) keeps `OK` (save) + `Cancel` (discard). This is the only remaining conditional and is now named `IsSettingsMode` — i.e. `OK`/`Cancel` means "editing settings", not "one of two edit paths".

## Bug fixed: Remove text for HI wasn't undoable

While unifying the above, I found that **selected-lines → Remove text for HI → OK could not be undone** (Ctrl+Z did nothing).

Root cause: the undo system is a 250 ms background snapshotter with no per-operation recording — bulk operations mutate the grid and rely on the timer capturing clean before/after states. Every other bulk grid operation wraps its mutation in `RunWithoutChangeDetection(...)` (which pauses the snapshotter during the rewrite). The two Remove text for HI handlers did **not**, so `ReplaceSubtitles`' `Clear()`/`AddRange()` ran with detection active and raced the threadpool snapshotter — the resulting "collection modified" enumeration is swallowed, leaving no clean undo entry.

Fix: wrap both Remove text for HI grid rewrites in `RunWithoutChangeDetection`, matching every peer operation. The edit is now captured as a discrete, undoable step.

## Verification

- Full solution builds clean; Change Speed and Remove text for HI unit tests updated and passing.
- Manually confirmed in-app: Change Speed applies without compounding; Remove text for HI applies live and is repeatable; `Ctrl+Z` now reverts it; Batch convert's "Remove text for HI settings" still shows `OK`/`Cancel`.
- Separately spot-checked the BinaryEdit adjust/resize dialogs (Color/Alpha/Brightness/Resize) — they already render previews into a separate bitmap and only mutate on `OK`, so their `Cancel` correctly reverts; no change needed.

## Commits

1. Make tool dialog buttons consistent (Apply+Done vs OK+Cancel)
2. Make Remove text for HI undoable (wrap grid rewrite in RunWithoutChangeDetection)
3. Unify Remove text for HI edit paths on Apply + Done
