### PR TITLE
Fix seconv OCR (Tesseract/PaddleOCR) mis-decoding UTF-8 output as OEM codepage

### DIFF
--- a/src/seconv/Core/PaddleOcrEngine.cs
+++ b/src/seconv/Core/PaddleOcrEngine.cs
@@ -75,6 +75,8 @@ internal sealed class PaddleOcrEngine : IOcrEngine
                 ArgumentList = { "ocr", "-i", pngPath, "--lang", Language, "--use_angle_cls", "false" },
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
+                StandardOutputEncoding = System.Text.Encoding.UTF8,
+                StandardErrorEncoding = System.Text.Encoding.UTF8,
                 UseShellExecute = false,
                 CreateNoWindow = true,
             };

--- a/src/seconv/Core/TesseractOcrEngine.cs
+++ b/src/seconv/Core/TesseractOcrEngine.cs
@@ -82,6 +82,8 @@ internal sealed class TesseractOcrEngine : IOcrEngine
                 ArgumentList = { pngPath, "stdout", "-l", Language, "--psm", "6" },
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
+                StandardOutputEncoding = System.Text.Encoding.UTF8,
+                StandardErrorEncoding = System.Text.Encoding.UTF8,
                 UseShellExecute = false,
                 CreateNoWindow = true,
             };


### PR DESCRIPTION
I encountered an issue with the SeConv OCR processor that wrote lines to the output `.srt` file with bad encoding.

example line: `“C” of “S” equals “C” of “T.”` became `ΓÇ£CΓÇ¥ of ΓÇ£SΓÇ¥ equals ΓÇ£CΓÇ¥ of ΓÇ£T.ΓÇ¥`

This proposed fix was both triaged and applied by Claude AI, then manually tested by me on the same VobSub file that previously produced incorrect output. I only tested on Windows with Tesseract, but the PaddleOCR change seemed reasonable, so I left it in for consideration.

# AI Report

Bug: TesseractOcrEngine.cs and PaddleOcrEngine.cs capture the Tesseract/PaddleOCR subprocess's stdout/stderr via RedirectStandardOutput/RedirectStandardError without setting StandardOutputEncoding/StandardErrorEncoding on ProcessStartInfo. .NET then decodes the captured bytes using the process's OEM/console codepage (cp437 on US Windows) instead of UTF-8, corrupting any non-ASCII OCR output — curly quotes, em-dashes, and accented letters come out as garbage (e.g. " → ΓÇ£, é → ├⌐).