### PR TITLE
OCR: force Python-side UTF-8 in seconv PaddleOCR, UTF-8 stderr in UI OCR engines

### DIFF
--- a/src/seconv/Core/PaddleOcrEngine.cs
+++ b/src/seconv/Core/PaddleOcrEngine.cs
@@ -80,6 +80,15 @@ internal sealed class PaddleOcrEngine : IOcrEngine
                 UseShellExecute = false,
                 CreateNoWindow = true,
             };
+
+            // StandardOutputEncoding only fixes the decoding side. paddleocr is a Python CLI, and
+            // on Windows Python encodes a *redirected* stdout with the ANSI codepage (until UTF-8
+            // becomes the default in Python 3.15, PEP 686) - so the producer side must be forced
+            // to UTF-8 too, or non-ASCII text still arrives as mojibake. Same env vars the UI's
+            // Paddle engine sets.
+            psi.EnvironmentVariables["PYTHONIOENCODING"] = "utf-8";
+            psi.EnvironmentVariables["PYTHONUTF8"] = "1";
+
             using var proc = Process.Start(psi)
                 ?? throw new InvalidOperationException("Failed to start paddleocr process.");
             // Drain stderr concurrently — paddleocr is chatty on stderr, and reading stdout

--- a/src/ui/Features/Ocr/Engines/GoogleLensOcr.cs
+++ b/src/ui/Features/Ocr/Engines/GoogleLensOcr.cs
@@ -79,6 +79,9 @@ public class GoogleLensOcr
                     RedirectStandardError = true,
                     CreateNoWindow = true,
                     StandardOutputEncoding = Encoding.UTF8,
+                    // Without this, .NET decodes stderr with the OEM codepage on Windows, so any
+                    // non-ASCII text in error output turns into mojibake in logs/error messages.
+                    StandardErrorEncoding = Encoding.UTF8,
                 }
             })
             {

--- a/src/ui/Features/Ocr/Engines/PaddleOcr.cs
+++ b/src/ui/Features/Ocr/Engines/PaddleOcr.cs
@@ -311,6 +311,9 @@ public partial class PaddleOcr
         };
 
         process.StartInfo.StandardOutputEncoding = Encoding.UTF8;
+        // Without this, .NET decodes stderr with the OEM codepage on Windows, so any non-ASCII
+        // text in Paddle's (chatty) stderr turns into mojibake in logs/error messages.
+        process.StartInfo.StandardErrorEncoding = Encoding.UTF8;
         process.StartInfo.RedirectStandardOutput = true;
         process.StartInfo.EnvironmentVariables["PYTHONIOENCODING"] = "utf-8";
         process.StartInfo.EnvironmentVariables["PYTHONUTF8"] = "1";


### PR DESCRIPTION
Follow-up to #12094.

## seconv PaddleOCR: the producer-side half of the fix

#12094 set `StandardOutputEncoding`/`StandardErrorEncoding`, which fixes the .NET **decoding** side — complete for Tesseract (a native binary that always writes UTF-8 bytes). But `paddleocr` is a Python CLI, and on Windows Python encodes a *redirected* stdout with the ANSI codepage (cp1252 on US Windows) until UTF-8 becomes the default in Python 3.15 (PEP 686). So after #12094, Paddle output could still arrive as mojibake — cp1252-encoded bytes decoded as UTF-8 (e.g. `é` → `�`).

This sets `PYTHONIOENCODING=utf-8` and `PYTHONUTF8=1` on the paddleocr child process, forcing the producer side to UTF-8 as well — the same env vars SE5's own UI Paddle engine (`src/ui/Features/Ocr/Engines/PaddleOcr.cs`) has always set.

## UI: cosmetic stderr gaps

A sweep of all `RedirectStandardOutput` sites in `src/ui` found the text-bearing paths already correct (UI Tesseract reads its `.hocr` output file as UTF-8; UI Paddle and Google Lens set stdout encoding + the Python env vars; all Whisper/STT sites set both encodings). The only gaps were cosmetic: **UI PaddleOcr** and **GoogleLensOcr** redirect stderr without `StandardErrorEncoding`, so non-ASCII text in their chatty stderr was OEM-decoded into mojibake in logs and error messages on Windows. Both now set it.

## Testing

- seconv and UI build clean; all 525 UI tests pass.
- The Windows-specific decoding behavior can't be exercised on this dev machine (macOS consoles are UTF-8); the change mirrors the env-var setup the UI Paddle engine has shipped with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)