### PR TITLE
TTS: fix import dialog hiding SE's own SubtitleEditTts.json export (#12093)

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1449,7 +1449,10 @@ public partial class TextToSpeechViewModel : ObservableObject
         _cancellationTokenSource = new CancellationTokenSource();
         _cancellationToken = _cancellationTokenSource.Token;
 
-        var fileName = await _fileHelper.PickOpenFile(Window, "Open SubtitleEditTts.json file", "TTS json files", "SubtitleEditTts.json");
+        // The pattern must start with '*' as-is: passing "SubtitleEditTts.json" would get a "*."
+        // prefix from PickOpenFile, and that pattern cannot match the exported file itself (Export
+        // writes exactly "SubtitleEditTts.json"), hiding it in SE's own open dialog (#12093).
+        var fileName = await _fileHelper.PickOpenFile(Window, "Open SubtitleEditTts.json file", "TTS json files", "*SubtitleEditTts.json");
         if (string.IsNullOrEmpty(fileName))
         {
             return;


### PR DESCRIPTION
Part of #12093 (the confirmed export/import mismatch).

TTS Export writes a file named exactly `SubtitleEditTts.json`, but the Import dialog passed `"SubtitleEditTts.json"` as the extension to `PickOpenFile`, which prepends `*.` — producing the filter pattern `*.SubtitleEditTts.json`. That pattern requires something *before* the name, so the file SE itself exports was invisible in SE's own open dialog. The reporter's rename workaround (`Kajsije.SubtitleEditTts.json`) matches the broken pattern exactly, confirming the diagnosis.

Fix: pass `*SubtitleEditTts.json`, which `PickOpenFile` uses verbatim and which matches both the exported name and any prefixed variant. A scan of all other `PickOpenFile` callers found no other filter with this shape.

UI builds clean; all 525 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)