### PR TITLE
TTS: ElevenLabs 429 retry/backoff, real error reasons, and review-window play shortcut (#12093)

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/ElevenLabs.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ElevenLabs.cs
@@ -289,13 +289,13 @@ public class ElevenLabs : ITtsEngine
         Se.WriteToolsLog($"ElevenLabs: voice={elevenLabVoice.Voice}, voiceId={elevenLabVoice.VoiceId}, model={model}, textLen={text.Length}");
 
         var ms = new MemoryStream();
-        var ok = await _ttsDownloadService.DownloadElevenLabsVoiceSpeak(text, elevenLabVoice, model, Se.Settings.Video.TextToSpeech.ElevenLabsApiKey, "en", ms, null, cancellationToken);
+        var (ok, error) = await _ttsDownloadService.DownloadElevenLabsVoiceSpeak(text, elevenLabVoice, model, Se.Settings.Video.TextToSpeech.ElevenLabsApiKey, language?.Code ?? "en", ms, null, cancellationToken);
         if (!ok)
         {
             // Forced: a failed API call must land in the tools log even when the setting is off,
             // so a bug report shows which segments failed and why (#12093).
-            Se.WriteToolsLog($"ElevenLabs: request failed (voice={elevenLabVoice.Voice}, textLen={text.Length}) - see error-log.txt for the HTTP status/response", true);
-            return new TtsResult { Text = text, FileName = string.Empty, Error = true };
+            Se.WriteToolsLog($"ElevenLabs: request failed (voice={elevenLabVoice.Voice}, textLen={text.Length}): {error}", true);
+            return new TtsResult { Text = text, FileName = string.Empty, Error = true, ErrorMessage = error };
         }
 
         var fileName = Path.Combine(GetSetElevenLabsFolder(), Guid.NewGuid() + ".mp3");

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -946,6 +946,87 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 RegenerateAudioCommand.Execute(line);
             }
         }
+        else if (MatchesPlayPauseShortcut(e))
+        {
+            // A modifier-less binding (the default bare Space) must still type into a focused text
+            // box; with modifiers held the shortcut works everywhere. Buttons are unaffected either
+            // way - they handle Space themselves before this window-level handler runs.
+            if (e.KeyModifiers == KeyModifiers.None && Window?.FocusManager?.GetFocusedElement() is TextBox)
+            {
+                return;
+            }
+
+            e.Handled = true;
+            TogglePlayPauseSelectedRow();
+        }
+    }
+
+    /// <summary>
+    /// True when the pressed keys match the user's main-window play/pause bindings
+    /// (TogglePlayPause / TogglePlayPause2; defaults Space and Ctrl/Cmd+Space), so the review
+    /// window plays with the same keys as the rest of the app (#12093).
+    /// </summary>
+    private static bool MatchesPlayPauseShortcut(KeyEventArgs e)
+    {
+        var cmdOrWin = OperatingSystem.IsMacOS() ? "Win" : "Ctrl";
+        var toggleKeys = Se.Settings.Shortcuts.FirstOrDefault(s => s.ActionName == nameof(MainViewModel.TogglePlayPauseCommand))?.Keys
+                         ?? [nameof(Key.Space)];
+        var toggle2Keys = Se.Settings.Shortcuts.FirstOrDefault(s => s.ActionName == nameof(MainViewModel.TogglePlayPause2Command))?.Keys
+                          ?? [cmdOrWin, nameof(Key.Space)];
+        return MatchesKeys(e, toggleKeys) || MatchesKeys(e, toggle2Keys);
+    }
+
+    // Matches a stored shortcut key list (modifier tokens + one main key) against a key event.
+    // Multi-key non-modifier chords are not supported here - the full ShortcutManager handles
+    // those in the main window; a dialog only needs the simple form.
+    private static bool MatchesKeys(KeyEventArgs e, List<string> keys)
+    {
+        var modifiers = KeyModifiers.None;
+        Key? mainKey = null;
+        foreach (var token in keys)
+        {
+            if (token is "Ctrl" or "Control" or "LeftCtrl" or "RightCtrl")
+            {
+                modifiers |= KeyModifiers.Control;
+            }
+            else if (token is "Alt" or "LeftAlt" or "RightAlt")
+            {
+                modifiers |= KeyModifiers.Alt;
+            }
+            else if (token is "Shift" or "LeftShift" or "RightShift")
+            {
+                modifiers |= KeyModifiers.Shift;
+            }
+            else if (token is "Win" or "Meta" or "LWin" or "RWin" or "Cmd" or "Command")
+            {
+                modifiers |= KeyModifiers.Meta;
+            }
+            else if (Enum.TryParse<Key>(token, out var key) && mainKey == null)
+            {
+                mainKey = key;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        return mainKey != null && mainKey == e.Key && e.KeyModifiers == modifiers;
+    }
+
+    private void TogglePlayPauseSelectedRow()
+    {
+        if (IsStopVisible || Lines.Any(l => l.IsPlaying))
+        {
+            Stop();
+            return;
+        }
+
+        var line = SelectedLine;
+        if (line is { IsPlayingEnabled: true } && PlayRowCommand.CanExecute(line))
+        {
+            PlayRowCommand.Execute(line);
+        }
     }
 
     internal void SelectedEngineChanged(object? sender, SelectionChangedEventArgs e)

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -2618,6 +2618,10 @@ public partial class TextToSpeechViewModel : ObservableObject
             // empty, every paragraph falls back to the globally selected engine/voice.
             var castContext = await BuildCastContextAsync();
 
+            // Distinct failure reasons reported by the engines, so the dialogs below can say *why*
+            // segments failed (e.g. the ElevenLabs 429 text) instead of a bare count (#12093).
+            var errorMessages = new List<string>();
+
             for (var index = 0; index < _subtitle.Paragraphs.Count; index++)
             {
                 ProgressText = $"Generating speech: segment {index + 1} of {_subtitle.Paragraphs.Count}";
@@ -2644,6 +2648,10 @@ public partial class TextToSpeechViewModel : ObservableObject
                     resolution.Instruction,
                     () => resolution.Engine.Speak(resolution.Text, _waveFolder, resolution.Voice,
                         language, region, model, cancellationToken));
+                if (speakResult.Error && !string.IsNullOrEmpty(speakResult.ErrorMessage) && !errorMessages.Contains(speakResult.ErrorMessage))
+                {
+                    errorMessages.Add(speakResult.ErrorMessage);
+                }
                 resultList.Add(new TtsStepResult
                 {
                     Text = resolution.Text,
@@ -2669,10 +2677,15 @@ public partial class TextToSpeechViewModel : ObservableObject
             ProgressValue = 100;
 
             var failedCount = resultList.Count(r => string.IsNullOrEmpty(r.CurrentFileName));
+            // First engine-reported failure reason, e.g. the ElevenLabs 429 text. The generic
+            // rate/pitch hint only applies when no engine said anything more specific.
+            var firstError = errorMessages.Count > 0
+                ? errorMessages[0]
+                : "Check the engine settings (rate/pitch/volume must be a signed integer, e.g. \"+10\") and try again.";
             if (failedCount == resultList.Count && resultList.Count > 0)
             {
-                var msg = $"Text-to-speech failed for all {failedCount} segments. " +
-                          "Check the engine settings (rate/pitch/volume must be a signed integer, e.g. \"+10\") and try again.";
+                var msg = $"Text-to-speech failed for all {failedCount} segments." +
+                          Environment.NewLine + Environment.NewLine + firstError;
                 SeLogger.Error(msg);
                 await Dispatcher.UIThread.InvokeAsync(async () =>
                 {
@@ -2698,10 +2711,13 @@ public partial class TextToSpeechViewModel : ObservableObject
                         return true;
                     }
 
+                    var detail = errorMessages.Count > 0
+                        ? Environment.NewLine + Environment.NewLine + errorMessages[0]
+                        : string.Empty;
                     var answer = await MessageBox.Show(
                         Window,
                         Se.Language.General.Warning,
-                        $"{failedCount} of {resultList.Count} segments failed to generate (see error-log.txt in the Subtitle Edit data folder)." +
+                        $"{failedCount} of {resultList.Count} segments failed to generate (see error-log.txt in the Subtitle Edit data folder).{detail}" +
                         Environment.NewLine + Environment.NewLine +
                         "Continue with the remaining segments? The failed lines will be missing from the audio.",
                         MessageBoxButtons.YesNo,

--- a/src/ui/Features/Video/TextToSpeech/TtsResult.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsResult.cs
@@ -6,6 +6,10 @@ public record TtsResult
     public string Text { get; init; }
     public bool Error { get; init; }
 
+    // Human-readable reason when Error is true (e.g. the HTTP status + response body of a failed
+    // API call), so the UI can tell the user *why* segments failed instead of a bare count (#12093).
+    public string ErrorMessage { get; init; } = string.Empty;
+
     public TtsResult()
     {
         FileName = string.Empty;

--- a/src/ui/Logic/Download/TtsDownloadService.cs
+++ b/src/ui/Logic/Download/TtsDownloadService.cs
@@ -31,7 +31,7 @@ public interface ITtsDownloadService
     Task DownloadAzureVoiceList(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
     Task DownloadMurfVoiceList(MemoryStream stream, IProgress<float>? progress, CancellationToken cancellationToken);
 
-    Task<bool> DownloadElevenLabsVoiceSpeak(
+    Task<(bool Ok, string Error)> DownloadElevenLabsVoiceSpeak(
         string inputText,
         ElevenLabVoice voice,
         string model,
@@ -244,7 +244,7 @@ public class TtsDownloadService : ITtsDownloadService
         await DownloadHelper.DownloadFileAsync(_httpClient, url, stream, progress, cancellationToken);
     }
 
-    public async Task<bool> DownloadElevenLabsVoiceSpeak(
+    public async Task<(bool Ok, string Error)> DownloadElevenLabsVoiceSpeak(
         string inputText,
         ElevenLabVoice voice,
         string model,
@@ -273,26 +273,97 @@ public class TtsDownloadService : ITtsDownloadService
         var speed = Se.Settings.Video.TextToSpeech.ElevenLabsSpeed.ToString(CultureInfo.InvariantCulture);
         var styleExaggeration = Se.Settings.Video.TextToSpeech.ElevenLabsStyleeExaggeration.ToString(CultureInfo.InvariantCulture);
         var data = "{ \"text\": \"" + Json.EncodeJsonText(text) + $"\", \"model_id\": \"{model}\"{language}, \"voice_settings\": {{ \"stability\": {stability}, \"similarity_boost\": {similarityBoost}, \"speed\": {speed}, \"style\": {styleExaggeration} }} }}";
-        using var requestMessage = new HttpRequestMessage(HttpMethod.Post, url);
-        requestMessage.Content = new StringContent(data, Encoding.UTF8);
-        requestMessage.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-        requestMessage.Headers.TryAddWithoutValidation("Content-Type", "application/json");
-        requestMessage.Headers.TryAddWithoutValidation("Accept", "audio/mpeg");
-        requestMessage.Headers.TryAddWithoutValidation("xi-api-key", apiKey.Trim());
 
-        var result = await _httpClient.SendAsync(requestMessage, cancellationToken);
-        await result.Content.CopyToAsync(stream, cancellationToken);
-        if (!result.IsSuccessStatusCode)
-        {
-            var error = Encoding.UTF8.GetString(stream.ToArray()).Trim();
-            SeLogger.Error($"ElevenLabs TTS failed calling API as base address {_httpClient.BaseAddress} : Status code={result.StatusCode} {error}" + Environment.NewLine + "Data=" + data);
-            return false;
-        }
-
-        return true;
+        return await SendElevenLabsSpeakRequestAsync(url, data, apiKey, acceptAudioMpeg: true, stream, "ElevenLabs TTS", cancellationToken);
     }
 
-    private async Task<bool> DownloadElevenLabsVoiceSpeak3(
+    /// <summary>
+    /// Posts an ElevenLabs speak request and copies the audio response into <paramref name="stream"/>.
+    /// ElevenLabs enforces per-plan concurrency/request limits, and bulk generation fires one request
+    /// per subtitle line - so HTTP 429 (and transient 5xx) responses are retried with a backoff that
+    /// honors the Retry-After header instead of failing the segment outright (#12093). Returns a
+    /// human-readable error for the UI when all attempts fail.
+    /// </summary>
+    private async Task<(bool Ok, string Error)> SendElevenLabsSpeakRequestAsync(
+        string url,
+        string jsonData,
+        string apiKey,
+        bool acceptAudioMpeg,
+        MemoryStream stream,
+        string logContext,
+        CancellationToken cancellationToken)
+    {
+        const int maxAttempts = 4;
+        for (var attempt = 1; ; attempt++)
+        {
+            // A new request message per attempt - HttpRequestMessage cannot be re-sent.
+            using var requestMessage = new HttpRequestMessage(HttpMethod.Post, url);
+            requestMessage.Content = new StringContent(jsonData, Encoding.UTF8);
+            requestMessage.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+            requestMessage.Headers.TryAddWithoutValidation("Content-Type", "application/json");
+            if (acceptAudioMpeg)
+            {
+                requestMessage.Headers.TryAddWithoutValidation("Accept", "audio/mpeg");
+            }
+            requestMessage.Headers.TryAddWithoutValidation("xi-api-key", apiKey.Trim());
+
+            using var result = await _httpClient.SendAsync(requestMessage, cancellationToken);
+            if (result.IsSuccessStatusCode)
+            {
+                stream.SetLength(0);
+                await result.Content.CopyToAsync(stream, cancellationToken);
+                return (true, string.Empty);
+            }
+
+            var errorBody = TruncateForLog((await result.Content.ReadAsStringAsync(cancellationToken)).Trim());
+            var retryable = result.StatusCode == System.Net.HttpStatusCode.TooManyRequests || (int)result.StatusCode >= 500;
+            if (retryable && attempt < maxAttempts)
+            {
+                var delay = GetRetryDelay(result, attempt);
+                SeLogger.Error($"{logContext}: HTTP {(int)result.StatusCode} {result.StatusCode} - retrying in {delay.TotalSeconds:0.#}s (attempt {attempt} of {maxAttempts}): {errorBody}");
+                await Task.Delay(delay, cancellationToken);
+                continue;
+            }
+
+            var error = result.StatusCode == System.Net.HttpStatusCode.TooManyRequests
+                ? $"ElevenLabs rate limit (HTTP 429) still hit after {maxAttempts} attempts with backoff - the plan's concurrency/request limit is likely exceeded. {errorBody}"
+                : $"HTTP {(int)result.StatusCode} {result.StatusCode}: {errorBody}";
+            SeLogger.Error($"{logContext} failed calling {url}: {error}" + Environment.NewLine + "Data=" + jsonData);
+            return (false, error);
+        }
+    }
+
+    private static TimeSpan GetRetryDelay(HttpResponseMessage response, int attempt)
+    {
+        // Prefer the server's Retry-After (delta or absolute date); fall back to exponential
+        // backoff (2 s, 4 s, 8 s). Capped so a bogus header cannot stall generation for minutes.
+        var maxDelay = TimeSpan.FromSeconds(30);
+
+        var retryAfter = response.Headers.RetryAfter;
+        if (retryAfter?.Delta is { } delta && delta > TimeSpan.Zero)
+        {
+            return delta <= maxDelay ? delta : maxDelay;
+        }
+
+        if (retryAfter?.Date is { } date)
+        {
+            var untilDate = date - DateTimeOffset.UtcNow;
+            if (untilDate > TimeSpan.Zero)
+            {
+                return untilDate <= maxDelay ? untilDate : maxDelay;
+            }
+        }
+
+        return TimeSpan.FromSeconds(Math.Pow(2, attempt));
+    }
+
+    private static string TruncateForLog(string text)
+    {
+        const int maxLength = 300;
+        return text.Length <= maxLength ? text : text.Substring(0, maxLength) + "...";
+    }
+
+    private async Task<(bool Ok, string Error)> DownloadElevenLabsVoiceSpeak3(
         string inputText, 
         ElevenLabVoice voice, 
         string model, 
@@ -313,26 +384,10 @@ public class TtsDownloadService : ITtsDownloadService
                    "\"voice_id\": \"" + voice.VoiceId + "\", " +
                    "\"language_code\": \"" + languageCode + "\", " +
                    "\"stability\": " + stability + ", " +
-                   "\"speed\": " + speed + 
+                   "\"speed\": " + speed +
                    " }] }";
 
-        using var requestMessage = new HttpRequestMessage(HttpMethod.Post, url);
-        requestMessage.Content = new StringContent(data, Encoding.UTF8);
-        requestMessage.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-        requestMessage.Headers.TryAddWithoutValidation("Content-Type", "application/json");
-        requestMessage.Headers.TryAddWithoutValidation("xi-api-key", apiKey.Trim());
-
-        var result = await _httpClient.SendAsync(requestMessage, cancellationToken);
-        await result.Content.CopyToAsync(stream, cancellationToken);
-    
-        if (!result.IsSuccessStatusCode)
-        {
-            var error = Encoding.UTF8.GetString(stream.ToArray()).Trim();
-            SeLogger.Error($"ElevenLabs TTS v3 failed calling API as base address {_httpClient.BaseAddress} : Status code={result.StatusCode} {error}" + Environment.NewLine + "Data=" + data);
-            return false;
-        }
-
-        return true;
+        return await SendElevenLabsSpeakRequestAsync(url, data, apiKey, acceptAudioMpeg: false, stream, "ElevenLabs TTS v3", cancellationToken);
     }
 
     public async Task<bool> DownloadAzureVoiceSpeak(


### PR DESCRIPTION
Two more items from #12093, in two commits.

## ElevenLabs 429 retry/backoff + error messages

ElevenLabs enforces per-plan concurrency/request limits, and bulk generation fires one request per line — so large runs regularly hit HTTP 429, and each hit silently became a failed segment.

- **Retry with backoff**: 429 and transient 5xx responses are retried up to 4 attempts, honoring `Retry-After` (capped at 30 s) and falling back to exponential backoff (2/4/8 s). Both the v1/v2 endpoint and the `eleven_v3` dialogue endpoint share the new request helper.
- **Cleaner failure path**: the error body is read separately and truncated for logging; the audio stream is only written on success (previously an error response body was copied into the audio stream).
- **Real reasons in the UI**: `TtsResult` gains `ErrorMessage`, the ElevenLabs engine fills it, and the generation dialogs now show the first engine-reported reason (e.g. the 429 text naming the plan limit). The old "check rate/pitch/volume" hint — misleading for API engines — is only the fallback when no engine said anything specific.
- **Bonus fix**: ElevenLabs ignored the selected language — `Speak` passed a hardcoded `"en"` language code; it now passes the selected language (only applied to `eleven_turbo_v2_5` / `eleven_v3` requests).

## Review window: play/pause from the keyboard

The reporter asked for spacebar play/stop in the review window. Space (and Ctrl/Cmd+Space) now toggles play/stop of the **selected** row — honoring the user's configured main-window `TogglePlayPause` / `TogglePlayPause2` bindings instead of hardcoding keys. A modifier-less binding (the default bare Space) is ignored while a text box has focus, so editing a line still types spaces; buttons keep handling Space themselves before the window-level handler runs.

## Testing

- UI builds clean; all 525 UI tests pass.
- The retry path needs a real rate-limited ElevenLabs account to exercise end-to-end; the request/response handling changes are covered by the shared helper being used for every ElevenLabs speak call (including voice test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)