### PR TITLE
TTS: fix eleven bugs from a systematic bug hunt (batch 1)

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/EncodingSettings/EncodingSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/EncodingSettings/EncodingSettingsViewModel.cs
@@ -37,6 +37,8 @@ public partial class EncodingSettingsViewModel : ObservableObject
         {
             SelectedEncoding = Encodings.FirstOrDefault(e => e.Name.Equals("Default", StringComparison.OrdinalIgnoreCase));
         }
+
+        IsStereo = Se.Settings.Video.TextToSpeech.CustomAudioStereo;
     }
 
     [RelayCommand]
@@ -46,7 +48,10 @@ public partial class EncodingSettingsViewModel : ObservableObject
         if (encoding != null)
         {
             Se.Settings.Video.TextToSpeech.CustomAudioEncoding = encoding.Code;
-            Se.Settings.Video.TextToSpeech.CustomAudioStereo = encoding.IsStereoEnabled;
+            // The user's checkbox, not the codec's IsStereoEnabled *capability* flag - saving the
+            // capability made the checkbox have no effect (always stereo for AAC/MP3, never for
+            // Default). Gated on the capability so a codec without the option can't force -ac 2.
+            Se.Settings.Video.TextToSpeech.CustomAudioStereo = IsStereo && encoding.IsStereoEnabled;
         }
 
         OkPressed = true;

--- a/src/ui/Features/Video/TextToSpeech/Engines/AzureSpeech.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/AzureSpeech.cs
@@ -118,8 +118,10 @@ public class AzureSpeech : ITtsEngine
 
     public async Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken)
     {
+        // Was DownloadElevenLabsVoiceList - which overwrote the Azure voice cache with an
+        // ElevenLabs-shaped JSON that Map() cannot parse, permanently emptying the voice combo.
         var ms = new MemoryStream();
-        await _ttsDownloadService.DownloadElevenLabsVoiceList(ms, null, cancellationToken);
+        await _ttsDownloadService.DownloadAzureVoiceList(ms, null, cancellationToken);
         await File.WriteAllBytesAsync(Path.Combine(GetSetAzureFolder(), JsonFileName), ms.ToArray(), cancellationToken);
         return await GetVoices(language);
     }

--- a/src/ui/Features/Video/TextToSpeech/Engines/Piper.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Piper.cs
@@ -179,7 +179,9 @@ public class Piper : ITtsEngine
     {
         var ms = new MemoryStream();
         await  _ttsDownloadService.DownloadPiperVoiceList(ms, null, cancellationToken);
-        await File.WriteAllBytesAsync(Path.Combine(GetSetPiperFolder(), "voices.json"), ms.ToArray(), cancellationToken);
+        // Must match the file GetVoices reads ("PiperVoices.json") - the refresh used to save to
+        // "voices.json", which nothing reads, so newly published upstream voices never appeared.
+        await File.WriteAllBytesAsync(Path.Combine(GetSetPiperFolder(), "PiperVoices.json"), ms.ToArray(), cancellationToken);
         return await GetVoices(language);
     }
 

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -1480,9 +1480,20 @@ public partial class ReviewSpeechViewModel : ObservableObject
         // Intermediate WAVs from TrimAndAdjustSpeed land in _waveFolder and would
         // otherwise pile up across regenerate cycles. Best-effort — _waveFolder is
         // usually a session-scoped temp dir but a stray locked file shouldn't tank
-        // window close.
+        // window close. A regenerated row's *final* audio file is tracked here too,
+        // and on OK it was just published via StepResults for the merge step —
+        // deleting it would silently break that line in the final audio — so keep
+        // anything a published result still references.
+        var publishedFiles = OkPressed
+            ? new HashSet<string>(StepResults.Select(r => r.CurrentFileName), StringComparer.OrdinalIgnoreCase)
+            : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var f in _tempAudioFiles)
         {
+            if (publishedFiles.Contains(f))
+            {
+                continue;
+            }
+
             try { if (File.Exists(f))
             {
                 File.Delete(f);

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -350,6 +350,9 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             Se.Settings.Video.TextToSpeech.ElevenLabsApiKey = ApiKey;
             Se.Settings.Video.TextToSpeech.ElevenLabsModel = SelectedModel ?? string.Empty;
+            // Read back by name on model change (this file + ReviewSpeechViewModel) but was never
+            // written anywhere, so the language choice silently reset to English every time.
+            Se.Settings.Video.TextToSpeech.ElevenLabsLanguage = SelectedLanguage?.Name ?? string.Empty;
         }
         else if (SelectedEngine is MistralSpeech)
         {
@@ -2480,6 +2483,28 @@ public partial class TextToSpeechViewModel : ObservableObject
         await addAudioProcess.StartAndWaitAsync(cancellationToken);
 
         ProgressText = string.Empty;
+
+        // ffmpeg failures (bad custom encoding string, codec/container mismatch, ...) used to go
+        // unnoticed here, and the caller then showed "Video file generated" for a file that does
+        // not exist. Verify the output and report instead.
+        if (!File.Exists(outputFileName) || new FileInfo(outputFileName).Length == 0)
+        {
+            SeLogger.Error($"TextToSpeech: adding audio to video failed - no output produced (encoding=\"{audioEncoding}\", ducking={Se.Settings.Video.TextToSpeech.AudioDuckingEnabled})");
+            Se.WriteToolsLog($"TTS add-to-video failed: ffmpeg produced no output for \"{outputFileName}\" (encoding=\"{audioEncoding}\", ducking={Se.Settings.Video.TextToSpeech.AudioDuckingEnabled})", true);
+            if (Window != null)
+            {
+                await MessageBox.Show(
+                    Window,
+                    Se.Language.General.Error,
+                    "Adding the audio track to the video failed - the audio file was still saved." + Environment.NewLine + Environment.NewLine +
+                    "See error-log.txt in the Subtitle Edit data folder for details.",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+
+            return null;
+        }
+
         return outputFileName;
     }
 
@@ -2503,32 +2528,66 @@ public partial class TextToSpeechViewModel : ObservableObject
 
             var silenceFileName = await GenerateSilenceWaveFile(cancellationToken);
 
-            var outputFileName = string.Empty;
             var inputFileName = silenceFileName;
             ProgressValue = 0;
             for (var index = 0; index < previousStepResult.Length; index++)
             {
-                ProgressText = $"Merging audio: segment {index + 1} of {_subtitle.Paragraphs.Count}";
+                ProgressText = $"Merging audio: segment {index + 1} of {previousStepResult.Length}";
 
                 var item = previousStepResult[index];
-                outputFileName = Path.Combine(_waveFolder, $"silence{index}.wav");
+
+                // Upstream steps can drop a segment's audio (failed generation kept by the user,
+                // deleted files in an imported session). Leave silence for it instead of feeding
+                // ffmpeg a nonexistent input.
+                if (string.IsNullOrEmpty(item.CurrentFileName) || !File.Exists(item.CurrentFileName))
+                {
+                    Se.WriteToolsLog($"TTS merge: segment {index + 1} has no audio file - leaving silence", true);
+                    continue;
+                }
+
+                var outputFileName = Path.Combine(_waveFolder, $"silence{index}.wav");
                 if (File.Exists(outputFileName))
                 {
                     outputFileName = Path.Combine(_waveFolder, $"silence_{Guid.NewGuid()}.wav");
                 }
 
                 var mergeProcess = FfmpegGenerator.MergeAudioTracks(inputFileName, item.CurrentFileName, outputFileName, (float)item.Paragraph.StartTime.TotalSeconds, forceStereo);
-                var fileNameToDelete = inputFileName;
-                inputFileName = outputFileName;
                 await mergeProcess.StartAndWaitAsync(cancellationToken);
 
-                ProgressValue = (double)(index + 1) / previousStepResult.Length * 100.0;
+                // A failed merge used to go unnoticed: the loop advanced to the (missing) output
+                // and deleted the last good intermediate, so every later merge failed too and the
+                // wreck only surfaced far downstream. Stop with an error instead.
+                if (!File.Exists(outputFileName) || new FileInfo(outputFileName).Length == 0)
+                {
+                    SeLogger.Error($"TextToSpeech: merging segment {index + 1} produced no output (input=\"{item.CurrentFileName}\")");
+                    Se.WriteToolsLog($"TTS merge: segment {index + 1} failed - ffmpeg produced no output for \"{item.CurrentFileName}\"", true);
+                    await Dispatcher.UIThread.InvokeAsync(async () =>
+                    {
+                        if (Window != null)
+                        {
+                            await MessageBox.Show(
+                                Window,
+                                Se.Language.General.Error,
+                                $"Merging audio failed at segment {index + 1}." + Environment.NewLine + Environment.NewLine +
+                                "See error-log.txt in the Subtitle Edit data folder for details.",
+                                MessageBoxButtons.OK,
+                                MessageBoxIcon.Error);
+                        }
+                    });
+                    return null;
+                }
 
-                DeleteFileNoError(fileNameToDelete);
+                DeleteFileNoError(inputFileName);
+                inputFileName = outputFileName;
+
+                ProgressValue = (double)(index + 1) / previousStepResult.Length * 100.0;
             }
             ProgressValue = 100;
 
-            return outputFileName;
+            // The chain head is the fully merged track (or the bare silence track if every
+            // segment was skipped - still a valid, if empty, result the user gets told about
+            // via the forced tools-log entries above).
+            return inputFileName;
         }
         catch (OperationCanceledException)
         {

--- a/src/ui/Logic/Download/TtsDownloadService.cs
+++ b/src/ui/Logic/Download/TtsDownloadService.cs
@@ -184,17 +184,19 @@ public class TtsDownloadService : ITtsDownloadService
 
     public async Task<bool> AllTalkIsInstalled()
     {
-        var timeout = Task.Delay(2000); // 2 seconds timeout
-        var request = _httpClient.GetAsync(Se.Settings.Video.TextToSpeech.AllTalkUrl);
-
-        await Task.WhenAny(timeout, request); // wait for either timeout or the request
-
-        if (timeout.IsCompleted) // if the timeout ended first, then handle it
+        // The old Task.WhenAny check reported "installed" whenever the request completed before
+        // the 2 s timeout - including completing by *faulting*, so a connection refused (server
+        // not running, ~instant) counted as installed and generation failed later instead.
+        try
         {
-            return false;
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            var response = await _httpClient.GetAsync(Se.Settings.Video.TextToSpeech.AllTalkUrl, cts.Token);
+            return response.IsSuccessStatusCode;
         }
-
-        return true;
+        catch
+        {
+            return false; // connection refused, timeout, bad URL - the server is not reachable
+        }
     }
 
     public async Task DownloadElevenLabsVoiceList(Stream ms, IProgress<float>? progress, CancellationToken cancellationToken)
@@ -240,8 +242,23 @@ public class TtsDownloadService : ITtsDownloadService
 
     public async Task DownloadAzureVoiceList(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
     {
-        var url = "https://api.elevenlabs.io/v1/voices";
-        await DownloadHelper.DownloadFileAsync(_httpClient, url, stream, progress, cancellationToken);
+        // Azure's official voice-list endpoint (the previous URL pointed at the ElevenLabs API,
+        // whose response Azure's parser cannot read). Requires the user's region + subscription
+        // key; the response is a JSON array with DisplayName/ShortName/Gender/Locale fields -
+        // the exact shape AzureSpeech.Map parses. Throws on failure so a refresh cannot
+        // overwrite the cached voice list with an error body.
+        var region = Se.Settings.Video.TextToSpeech.AzureRegion;
+        if (string.IsNullOrWhiteSpace(region))
+        {
+            throw new InvalidOperationException("Azure region is not set - enter it in the TTS engine settings before refreshing voices.");
+        }
+
+        var url = $"https://{region.Trim()}.tts.speech.microsoft.com/cognitiveservices/voices/list";
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
+        requestMessage.Headers.TryAddWithoutValidation("Ocp-Apim-Subscription-Key", Se.Settings.Video.TextToSpeech.AzureApiKey.Trim());
+        var result = await _httpClient.SendAsync(requestMessage, cancellationToken);
+        result.EnsureSuccessStatusCode();
+        await result.Content.CopyToAsync(stream, cancellationToken);
     }
 
     public async Task<(bool Ok, string Error)> DownloadElevenLabsVoiceSpeak(
@@ -484,6 +501,11 @@ public class TtsDownloadService : ITtsDownloadService
             SeLogger.Error($"Murf TTS failed calling API as base address {fileUrl} : Status code={audioResult.StatusCode}");
             return false;
         }
+
+        // The stream still holds the generate-call's JSON response (parsed above for the audio
+        // URL) - without resetting, the MP3 would be appended after it and every Murf segment
+        // file would start with JSON garbage.
+        ms.SetLength(0);
         await audioResult.Content.CopyToAsync(ms, cancellationToken);
 
         return true;

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -520,12 +520,16 @@ public class FfmpegGenerator
 
     public static Process TrimSilenceStartAndEnd(string inputFileName, string outputFileName, DataReceivedEventHandler? dataReceivedHandler = null)
     {
+        // silenceremove keeps up to start_silence (100 ms) of the detected silence as padding.
+        // No unconditional atrim cuts here: a fixed atrim=start=0.1 ahead of the detection used
+        // to chop 100 ms off both ends whether or not it was silence, clipping the first/last
+        // phoneme for engines that start speaking immediately (e.g. Piper).
         var processMakeVideo = new Process
         {
             StartInfo =
             {
                 FileName = GetFfmpegLocation(),
-                Arguments = $"-nostdin -y -i \"{inputFileName}\" -af \"areverse,atrim=start=0.1,silenceremove=start_periods=1:start_silence=0.1:start_threshold=0.01,areverse,atrim=start=0.1,silenceremove=start_periods=1:start_silence=0.1:start_threshold=0.01\" \"{outputFileName}\"",
+                Arguments = $"-nostdin -y -i \"{inputFileName}\" -af \"areverse,silenceremove=start_periods=1:start_silence=0.1:start_threshold=0.01,areverse,silenceremove=start_periods=1:start_silence=0.1:start_threshold=0.01\" \"{outputFileName}\"",
                 UseShellExecute = false,
                 CreateNoWindow = true
             }
@@ -604,7 +608,10 @@ public class FfmpegGenerator
 
     public static Process AddAudioTrack(string inputFileName, string audioFileName, string outputFileName, string audioEncoding, bool? stereo, DataReceivedEventHandler? dataReceivedHandler = null)
     {
-        var audioEncodingString = !string.IsNullOrEmpty(audioEncoding) ? "-c:a " + audioEncoding + " " : "-c:a copy ";
+        // Empty encoding = let ffmpeg pick the container's default encoder (same as the ducking
+        // variant below). It used to mean "-c:a copy", which muxed the merged TTS track - a PCM
+        // wav - straight into .mp4, failing on ffmpeg builds older than 6.1.
+        var audioEncodingString = !string.IsNullOrEmpty(audioEncoding) ? "-c:a " + audioEncoding + " " : string.Empty;
         var stereoString = stereo == true ? "-ac 2 " : string.Empty;
 
         var processMakeVideo = new Process
@@ -628,6 +635,14 @@ public class FfmpegGenerator
     /// </summary>
     public static Process AddAudioTrackWithDucking(string inputFileName, string audioFileName, string outputFileName, string audioEncoding, bool? stereo, int originalVolumePercent, DataReceivedEventHandler? dataReceivedHandler = null)
     {
+        // "copy" cannot work here: the audio stream is fed from the amix filtergraph, and ffmpeg
+        // hard-errors on stream-copy from a complex filter. Fall back to the container's default
+        // encoder so "Copy" + ducking produces a video instead of always failing.
+        if (string.Equals(audioEncoding, "copy", StringComparison.OrdinalIgnoreCase))
+        {
+            audioEncoding = string.Empty;
+        }
+
         var audioEncodingString = !string.IsNullOrEmpty(audioEncoding) ? "-c:a " + audioEncoding + " " : string.Empty;
         var stereoString = stereo == true ? "-ac 2 " : string.Empty;
         var volumeFactor = Math.Clamp(originalVolumePercent / 100.0, 0.0, 1.0).ToString("0.00", CultureInfo.InvariantCulture);


### PR DESCRIPTION
First batch from a systematic multi-agent bug hunt over the text-to-speech area (~30 findings total; this PR takes the output-corruption group plus the small broken-feature fixes). Every fix was verified against the code by hand before changing anything.

## Output corruption

| Bug | Fix |
|---|---|
| **Review window deleted published audio**: `OnClosing` deleted all tracked intermediate WAVs — including a regenerated row's *final* audio just published via OK, silently breaking that line in the merge | Files still referenced by published step results are kept |
| **Murf segments started with JSON garbage**: the MP3 was appended to the MemoryStream still holding the generate-response JSON | Stream reset before the audio download |
| **Merge chain self-destructed on one failure**: an unchecked ffmpeg failure advanced the chain to a missing file and deleted the last good intermediate | Per-merge output verified (error dialog + forced tools log); missing-audio segments skipped as silence; progress denominator fixed |
| **"Video file generated" shown on ffmpeg failure** | Add-to-video output verified; audio-file-saved error shown instead |
| **Trim step ate 100 ms of speech from both ends** of every segment (unconditional `atrim=start=0.1` *before* silence detection) — clipped first/last phonemes on engines that start speaking immediately (Piper) | Removed the unconditional cuts; `silenceremove`'s 100 ms pad handling stays. *Worth an ear test on a Piper + ElevenLabs run.* |

## Broken features (small fixes)

- **Azure voice refresh downloaded the ElevenLabs voice list** over the Azure cache — unparseable, permanently emptying the voice combo (the bundled fallback only restores when the file is *missing*). The underlying `DownloadAzureVoiceList` also pointed at the ElevenLabs endpoint. Now calls Azure's `cognitiveservices/voices/list` with the user's region + key (the response array is exactly the shape `Map()` parses), throwing on failure so an error body can never overwrite the cache.
- **Piper voice refresh was a no-op** — saved `voices.json`, engine reads `PiperVoices.json`.
- **Encoding-settings stereo checkbox had zero effect** — saved the codec's capability flag, never loaded back.
- **"Default" encoding meant `-c:a copy`** in `AddAudioTrack`, muxing PCM WAV into .mp4 (fails before ffmpeg 6.1) — now the container's default encoder, matching the ducking variant; and **"Copy" + ducking** (impossible: stream-copy from a filtergraph) falls back to re-encoding instead of always failing.
- **ElevenLabs language never persisted** — read on every model change, written nowhere.
- **AllTalk "installed" on connection refused** — `Task.WhenAny` completes on a *faulted* request too; now a real request with timeout + status check.

## Testing

- UI builds clean; all 525 UI tests pass; app smoke-launches.
- The remaining hunt findings (cancellation/process-kill cluster, review-window state machine races, voice-list refresh hardening for ElevenLabs/Murf/Mistral, export path portability) are queued for follow-up batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)