### PR TITLE
TTS: fix cancellation and lifecycle bugs (bug hunt batch 2)

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/ProcessExtensions.cs
+++ b/src/ui/Features/Video/TextToSpeech/ProcessExtensions.cs
@@ -19,15 +19,26 @@ public static class ProcessExtensions
     public static async Task StartAndWaitAsync(this Process process, CancellationToken cancellationToken)
     {
         process.StartProcess();
-        await process.WaitForExitAsync(cancellationToken);
+        try
+        {
+            await process.WaitForExitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // WaitForExitAsync only stops *waiting* on cancellation - the child keeps running.
+            // Cancel means stop the work, so kill it; otherwise a cancelled merge/generation
+            // leaves ffmpeg burning CPU (and holding its input files open) to completion.
+            KillNoError(process);
+            throw;
+        }
     }
 
     /// <summary>
     /// Starts the process and waits for it to exit, but no longer than <paramref name="timeout"/>.
     /// On overrun the process is killed and a <see cref="TimeoutException"/> naming the command is
     /// thrown, so a wedged child process (e.g. an ffmpeg waiting on a prompt) surfaces as an error
-    /// instead of freezing the pipeline forever (#12093). User cancellation still surfaces as
-    /// <see cref="OperationCanceledException"/>.
+    /// instead of freezing the pipeline forever (#12093). User cancellation kills the process too
+    /// and still surfaces as <see cref="OperationCanceledException"/>.
     /// </summary>
     public static async Task StartAndWaitAsync(this Process process, CancellationToken cancellationToken, TimeSpan timeout)
     {
@@ -39,19 +50,28 @@ public static class ProcessExtensions
         {
             await process.WaitForExitAsync(timeoutCts.Token);
         }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
-            try
+            KillNoError(process);
+            if (cancellationToken.IsCancellationRequested)
             {
-                process.Kill(entireProcessTree: true);
-            }
-            catch
-            {
-                // best-effort - the process may have exited in the meantime
+                throw; // user cancel - propagate as cancellation, not as a timeout
             }
 
             throw new TimeoutException(
                 $"\"{process.StartInfo.FileName} {process.StartInfo.Arguments}\" did not finish within {timeout.TotalSeconds:0} seconds and was killed.");
+        }
+    }
+
+    private static void KillNoError(Process process)
+    {
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch
+        {
+            // best-effort - the process may have exited in the meantime
         }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -592,10 +592,10 @@ public partial class ReviewSpeechViewModel : ObservableObject
         var old = _cancellationTokenSource;
         _cancellationTokenSource = next;
         _cancellationToken = next.Token;
-        if (!ReferenceEquals(old, next))
-        {
-            try { old.Dispose(); } catch (ObjectDisposedException) { }
-        }
+        // The old CTS is deliberately not disposed: it may still be held by a non-modal
+        // GeneratingAudioWindow whose Cancel button calls Cancel() on it - disposing here made
+        // that throw ObjectDisposedException. A CTS without timers has no unmanaged state that
+        // needs deterministic disposal; window close disposes the final instance.
     }
 
     [RelayCommand]
@@ -653,6 +653,15 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
         IsRegenerateEnabled = false;
 
+        // Gate the whole grid: the regenerate popup is non-modal, and starting a play or a
+        // second regenerate mid-run swapped the shared cancellation source under the first one.
+        // The per-row play/regenerate buttons, Ctrl+R and the Space shortcut all honor
+        // IsPlayingEnabled, so this closes every entry point at once.
+        foreach (var l in Lines)
+        {
+            l.IsPlayingEnabled = false;
+        }
+
         var oldStyle = SelectedStyle;
         if (engine is Murf && !string.IsNullOrEmpty(SelectedStyle))
         {
@@ -662,11 +671,35 @@ public partial class ReviewSpeechViewModel : ObservableObject
         var generatingAudioVm = _windowService.ShowWindow<GeneratingAudioWindow, GeneratingAudioViewModel>(Window!);
         ReplaceCts(generatingAudioVm.CancellationTokenSource);
 
-        TtsResult speakResult;
+        // The row's live StepResult must only change once the whole regenerate pipeline has
+        // succeeded - it used to be mutated right after Speak, so a cancel or a failed
+        // trim/post-process left the row half-updated (raw un-stretched clip with the old
+        // speed/voice display) and OK/Export published that state.
+        var originalFileName = line.StepResult.CurrentFileName;
+        var originalVoice = line.StepResult.Voice;
+
         try
         {
-            speakResult = await TtsInstructionSwap.RunAsync(engine, Instruction, () =>
+            var speakResult = await TtsInstructionSwap.RunAsync(engine, Instruction, () =>
                 engine.Speak(Utilities.UnbreakLine(line.Text), _waveFolder, voice, SelectedLanguage, SelectedRegion, SelectedModel, _cancellationToken));
+
+            if (speakResult.Error || string.IsNullOrEmpty(speakResult.FileName) || !File.Exists(speakResult.FileName))
+            {
+                if (Window != null)
+                {
+                    var detail = string.IsNullOrEmpty(speakResult.ErrorMessage)
+                        ? "The engine produced no audio - see error-log.txt in the Subtitle Edit data folder."
+                        : speakResult.ErrorMessage;
+                    await MessageBox.Show(
+                        Window,
+                        Se.Language.General.Error,
+                        "Regenerating audio failed: " + detail,
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
+                }
+
+                return;
+            }
 
             line.StepResult.CurrentFileName = speakResult.FileName;
             line.StepResult.Voice = voice;
@@ -676,6 +709,8 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
             if (_cancellationToken.IsCancellationRequested)
             {
+                line.StepResult.CurrentFileName = originalFileName;
+                line.StepResult.Voice = originalVoice;
                 return;
             }
 
@@ -692,8 +727,18 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
             line.AddHistory(voice, line.StepResult.CurrentFileName, engine.Name, SelectedModel ?? string.Empty, Instruction ?? string.Empty);
         }
+        catch (OperationCanceledException)
+        {
+            // Cancel in the GeneratingAudio popup: Speak and the ffmpeg steps surface it as a
+            // throw (it used to escape as an unhandled exception). Undo the partial row update.
+            line.StepResult.CurrentFileName = originalFileName;
+            line.StepResult.Voice = originalVoice;
+            return;
+        }
         catch (HttpRequestException ex)
         {
+            line.StepResult.CurrentFileName = originalFileName;
+            line.StepResult.Voice = originalVoice;
             SeLogger.Error(ex, "TTS server error during regeneration.");
             if (Window != null)
             {
@@ -706,10 +751,30 @@ public partial class ReviewSpeechViewModel : ObservableObject
             }
             return;
         }
+        catch (Exception ex)
+        {
+            line.StepResult.CurrentFileName = originalFileName;
+            line.StepResult.Voice = originalVoice;
+            SeLogger.Error(ex, "Regenerating audio failed.");
+            if (Window != null)
+            {
+                await MessageBox.Show(
+                    Window,
+                    Se.Language.General.Error,
+                    "Regenerating audio failed: " + ex.Message,
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+            return;
+        }
         finally
         {
             generatingAudioVm.Close();
             IsRegenerateEnabled = true;
+            foreach (var l in Lines)
+            {
+                l.IsPlayingEnabled = true;
+            }
             if (engine is Murf && oldStyle != null)
             {
                 Se.Settings.Video.TextToSpeech.MurfStyle = oldStyle;

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeechHistory/ReviewSpeechHistoryViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeechHistory/ReviewSpeechHistoryViewModel.cs
@@ -127,6 +127,16 @@ public partial class ReviewSpeechHistoryViewModel : ObservableObject
             return;
         }
 
+        // A CancellationTokenSource is one-shot: after StopItem cancels it, the timer's
+        // IsCancellationRequested check killed every later play within 200 ms - one Stop
+        // permanently broke playback in this dialog. Renew it per play. (The old instance is
+        // intentionally not disposed here; the timer thread may still be reading it.)
+        if (_cancellationTokenSource.IsCancellationRequested)
+        {
+            _cancellationTokenSource = new CancellationTokenSource();
+            _cancellationToken = _cancellationTokenSource.Token;
+        }
+
         item.IsPlaying = true;
         await PlayAudio(item.FileName);
     }

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1349,8 +1349,10 @@ public partial class TextToSpeechViewModel : ObservableObject
     {
         var engine = SelectedEngine;
         var voice = SelectedVoice;
-        if (engine == null || voice == null || Window == null)
+        if (engine == null || voice == null || Window == null || IsGenerating)
         {
+            // IsGenerating guard: the button's IsVoiceTestEnabled binding is timer-driven (mpv
+            // idle) and stays true during a generate run, so this can be clicked mid-pipeline.
             return;
         }
 
@@ -1382,12 +1384,15 @@ public partial class TextToSpeechViewModel : ObservableObject
         text = Utilities.UnbreakLine(text);
 
         var generatingAudioVm = _windowService.ShowWindow<GeneratingAudioWindow, GeneratingAudioViewModel>(Window!);
-        _cancellationTokenSource = generatingAudioVm.CancellationTokenSource;
-        _cancellationToken = _cancellationTokenSource.Token;
+        // A local token only: assigning the popup's CTS into the shared _cancellationTokenSource/
+        // _cancellationToken fields hijacked a running generate pipeline (the pipeline re-reads
+        // the fields per stage) - the popup's Cancel then aborted the whole run, and the main
+        // Cancel button cancelled the popup instead of the generation.
+        var testVoiceToken = generatingAudioVm.CancellationTokenSource.Token;
         try
         {
-            var result = await engine.Speak(text, _waveFolder, voice, SelectedLanguage, SelectedRegion, SelectedModel, _cancellationToken);
-            if (!_cancellationToken.IsCancellationRequested)
+            var result = await engine.Speak(text, _waveFolder, voice, SelectedLanguage, SelectedRegion, SelectedModel, testVoiceToken);
+            if (!testVoiceToken.IsCancellationRequested)
             {
                 if (!File.Exists(result.FileName))
                 {
@@ -3572,6 +3577,13 @@ public partial class TextToSpeechViewModel : ObservableObject
 
     internal void OnClosing(WindowClosingEventArgs e)
     {
+        // An enabled System.Timers.Timer is rooted: without stopping it here, every open/close
+        // of this window leaked a view model whose Elapsed handler kept firing every 100 ms for
+        // the rest of the session (ReviewSpeechViewModel already does this on close).
+        _timer.Stop();
+        _timer.Elapsed -= OnTimerOnElapsed;
+        _timer.Dispose();
+
         lock (_playLock)
         {
             _mpvContext?.Dispose();


### PR DESCRIPTION
Second batch from the TTS bug hunt — the cancellation/lifecycle cluster. **Stacked on #12099** (base is that branch; merge #12099 first, then this retargets to main automatically).

## Fixes

- **Cancel now actually stops the work**: `StartAndWaitAsync` only stopped *waiting* on cancellation — the child ffmpeg kept running to completion (holding input files that the merge loop was deleting under it), and the timeout overload explicitly excluded user-cancel from `Kill`. Both overloads now kill the process tree on cancellation.
- **Test voice no longer hijacks a running generation**: it assigned the popup's `CancellationTokenSource` into the shared pipeline fields, so the popup's Cancel aborted the whole run and the main Cancel cancelled the popup instead. Now a local token + no-op while generating.
- **TTS window timer leak**: the 100 ms UI timer was never stopped/disposed on close — every open/close leaked a view model ticking for the rest of the session (the review window already cleaned up, confirming the omission).
- **Review history dialog**: playback permanently broke after the first Stop (one-shot CTS cancelled, never renewed; the 200 ms watchdog then killed every later play). Renewed per play.
- **Regenerate (review window)**, four related fixes:
  - cancel threw an unhandled `OperationCanceledException` (only `HttpRequestException` was caught); OCE is quiet now, other failures show a dialog;
  - the row's live `StepResult` was mutated right after `Speak`, so cancel/failed post-steps left a half-updated row that OK/Export published — rolled back on every failure path;
  - engine failures were never checked (row got an empty file name) — now surfaced with the engine's error message (pairs with the ElevenLabs `ErrorMessage` plumbing from #12098);
  - the non-modal progress popup left the grid interactive (`IsRegenerateEnabled` was bound to nothing), so a play/second regenerate mid-run swapped the shared CTS under the first one — all rows are now disabled during regenerate, and `ReplaceCts` no longer disposes a source a popup may still hold (`Cancel()` on a disposed CTS threw).

## Testing

- UI builds clean; all 525 UI tests pass; app smoke-launches.
- Remaining hunt findings queued for batch 3: review-window playback state machine (auto-continue follows selection, mpv lock race, missing-file wedge), voice-list refresh hardening (ElevenLabs/Murf/Mistral), export path portability, engine-switch consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)