### PR TITLE
TTS review: fix playback state machine and export round-trip (bug hunt batch 3)

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -121,6 +121,10 @@ public partial class ReviewSpeechViewModel : ObservableObject
     private long _startPlayTicks;
     private readonly List<string> _tempAudioFiles = new();
 
+    // The row whose audio is currently playing. Auto-continue must advance from this row, not
+    // from SelectedLine - grid selection is two-way and can move during playback.
+    private ReviewRow? _playingRow;
+
     public ReviewSpeechViewModel(IFolderHelper folderHelper, IWindowService windowService)
     {
         _folderHelper = folderHelper;
@@ -160,22 +164,33 @@ public partial class ReviewSpeechViewModel : ObservableObject
         {
             _timer.Stop();
 
-            if (_cancellationTokenSource.IsCancellationRequested || _mpvContext == null)
+            // Read mpv state under the play lock: Stop()/OnClosing dispose _mpvContext under the
+            // same lock on the UI thread, and this tick runs on a threadpool thread - the old
+            // unguarded IsPaused read raced the dispose (NRE / native use-after-free window).
+            var stopped = false;
+            var paused = false;
+            lock (_playLock)
             {
-                IsPlayVisible = true;
-                IsStopVisible = false;
-                foreach (var l in Lines)
+                if (_cancellationTokenSource.IsCancellationRequested || _mpvContext == null)
                 {
-                    l.IsPlaying = false;
-                    l.IsPlayingEnabled = true;
+                    stopped = true;
                 }
+                else
+                {
+                    paused = _mpvContext.IsPaused;
+                }
+            }
 
+            if (stopped)
+            {
+                await Dispatcher.UIThread.InvokeAsync(ResetPlaybackUiState);
                 return;
             }
 
-            var paused = _mpvContext.IsPaused;
-
-            var line = SelectedLine;
+            // The row that is actually playing - not SelectedLine: two-way grid selection meant
+            // clicking another row during playback made auto-continue advance from the *clicked*
+            // row, stranding the playing row's stop icon and skipping the clicked one.
+            var line = _playingRow;
             var timeSinceStart = TimeSpan.FromTicks(DateTime.UtcNow.Ticks - _startPlayTicks);
             if (paused && AutoContinue && !_skipAutoContinue && line != null && timeSinceStart.TotalMilliseconds > 500)
             {
@@ -183,10 +198,11 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 {
                     line.IsPlaying = false;
                     var index = Lines.IndexOf(line);
-                    if (index < Lines.Count - 1)
+                    if (index >= 0 && index < Lines.Count - 1)
                     {
                         var nextLine = Lines[index + 1];
                         nextLine.IsPlaying = true;
+                        _playingRow = nextLine;
                         SelectedLine = nextLine;
                         LineGrid.ScrollIntoView(nextLine, null);
                         await PlayAudio(nextLine.StepResult.CurrentFileName);
@@ -194,43 +210,74 @@ public partial class ReviewSpeechViewModel : ObservableObject
                     else
                     {
                         _skipAutoContinue = true; // no more lines to play
-
-                        IsPlayVisible = true;
-                        IsStopVisible = false;
-                        foreach (var l in Lines)
-                        {
-                            l.IsPlaying = false;
-                            l.IsPlayingEnabled = true;
-                        }
+                        ResetPlaybackUiState();
                     }
                 });
 
                 return;
             }
 
-            IsPlayVisible = paused;
-            IsStopVisible = !paused;
-
             if (paused)
             {
-                foreach (var l in Lines)
-                {
-                    l.IsPlaying = false;
-                    l.IsPlayingEnabled = true;
-                }
+                await Dispatcher.UIThread.InvokeAsync(ResetPlaybackUiState);
                 return;
             }
+
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                IsPlayVisible = false;
+                IsStopVisible = true;
+            });
 
             _timer.Start();
         }
         catch (Exception ex)
         {
             SeLogger.Error(ex, "Error in ReviewSpeech playback timer.");
+            // A throw used to kill the timer for good, leaving every row disabled (PlayRow
+            // disables them and only this timer re-enables) - reset instead of wedging.
+            Dispatcher.UIThread.Post(ResetPlaybackUiState);
+        }
+    }
+
+    /// <summary>
+    /// Returns the playback UI to idle: play button showing, no row marked as playing, all
+    /// rows clickable again. Must run on the UI thread.
+    /// </summary>
+    private void ResetPlaybackUiState()
+    {
+        IsPlayVisible = true;
+        IsStopVisible = false;
+        _playingRow = null;
+        foreach (var l in Lines)
+        {
+            l.IsPlaying = false;
+            l.IsPlayingEnabled = true;
         }
     }
 
     private async Task PlayAudio(string fileName)
     {
+        // A row can point at a deleted/moved file (e.g. an imported session whose folder was
+        // cleaned). mpv's failed loadfile is only logged, so playback used to sit in "playing"
+        // forever with every row disabled and no error. Reset and tell the user instead.
+        if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
+        {
+            SeLogger.Error($"ReviewSpeech: cannot play missing audio file \"{fileName}\"");
+            ResetPlaybackUiState();
+            if (Window != null)
+            {
+                await MessageBox.Show(
+                    Window,
+                    Se.Language.General.Error,
+                    "The audio file for this line does not exist:" + Environment.NewLine + fileName,
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+
+            return;
+        }
+
         lock (_playLock)
         {
             _mpvContext?.Stop();
@@ -440,6 +487,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
         // Copy files
         var index = 0;
+        var missingAudioCount = 0;
         var exportFormat = new TtsImportExport
         {
             VideoFileName = _videoFileName,
@@ -451,7 +499,17 @@ public partial class ReviewSpeechViewModel : ObservableObject
             var sourceFileName = line.StepResult.CurrentFileName;
             var targetFileName = Path.Combine(folder, index.ToString().PadLeft(4, '0') + Path.GetExtension((string?)sourceFileName));
 
-            if (File.Exists(targetFileName))
+            // A row can point at a deleted/moved file (e.g. an imported session whose folder was
+            // cleaned). File.Copy used to throw unhandled mid-export, leaving some files copied
+            // and no JSON written. Export the row without audio instead and report the count.
+            if (string.IsNullOrEmpty(sourceFileName) || !File.Exists(sourceFileName))
+            {
+                missingAudioCount++;
+                SeLogger.Error($"ReviewSpeech export: audio file missing for line {index}: \"{sourceFileName}\"");
+                targetFileName = string.Empty;
+            }
+
+            if (!string.IsNullOrEmpty(targetFileName) && File.Exists(targetFileName))
             {
                 try
                 {
@@ -469,11 +527,16 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 }
             }
 
-            File.Copy(sourceFileName, targetFileName, true);
+            if (!string.IsNullOrEmpty(targetFileName))
+            {
+                File.Copy(sourceFileName, targetFileName, true);
+            }
 
             exportFormat.Items.Add(new TtsImportExportItem
             {
-                AudioFileName = targetFileName,
+                // File name only, not the absolute path: the export folder is meant to be moved
+                // or shared, and Import resolves the name against the JSON's own directory.
+                AudioFileName = string.IsNullOrEmpty(targetFileName) ? string.Empty : Path.GetFileName(targetFileName),
                 StartMs = (long)Math.Round((double)line.StepResult.Paragraph.StartTime.TotalMilliseconds, MidpointRounding.AwayFromZero),
                 EndMs = (long)Math.Round((double)line.StepResult.Paragraph.EndTime.TotalMilliseconds, MidpointRounding.AwayFromZero),
                 VoiceName = line.StepResult.Voice?.Name ?? string.Empty,
@@ -494,6 +557,16 @@ public partial class ReviewSpeechViewModel : ObservableObject
         // Export json
         var json = JsonSerializer.Serialize(exportFormat, new JsonSerializerOptions { WriteIndented = true });
         await File.WriteAllTextAsync(jsonFileName, json);
+
+        if (missingAudioCount > 0)
+        {
+            await MessageBox.Show(
+                Window,
+                Se.Language.General.Warning,
+                $"{missingAudioCount} line(s) had no audio file and were exported without audio - see error-log.txt in the Subtitle Edit data folder.",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Warning);
+        }
 
         await _folderHelper.OpenFolder(Window!, folder);
     }
@@ -535,6 +608,9 @@ public partial class ReviewSpeechViewModel : ObservableObject
         line.StepResult.EngineName = picked.EngineName ?? string.Empty;
         line.StepResult.Model = picked.Model ?? string.Empty;
         line.StepResult.Instruction = picked.Instruction ?? string.Empty;
+        // Restore the real speed factor too, not just the display string - otherwise Export
+        // writes the previous SpeedFactor next to this entry's audio file.
+        line.StepResult.SpeedFactor = picked.Speed;
         line.Speed = Math.Round(picked.Speed, 2).ToString(CultureInfo.CurrentCulture);
 
         // Mirror the click-to-sync behaviour so the left panel immediately reflects the picked
@@ -671,6 +747,15 @@ public partial class ReviewSpeechViewModel : ObservableObject
         var generatingAudioVm = _windowService.ShowWindow<GeneratingAudioWindow, GeneratingAudioViewModel>(Window!);
         ReplaceCts(generatingAudioVm.CancellationTokenSource);
 
+        // Snapshot the panel state this regenerate runs with: the progress popup is non-modal,
+        // so clicking another row mid-run rewrites SelectedModel/Instruction (via the row-click
+        // panel sync) - reading them after the awaits recorded settings that never produced the
+        // audio into the row snapshot and its history entry.
+        var model = SelectedModel;
+        var instruction = Instruction;
+        var language = SelectedLanguage;
+        var region = SelectedRegion;
+
         // The row's live StepResult must only change once the whole regenerate pipeline has
         // succeeded - it used to be mutated right after Speak, so a cancel or a failed
         // trim/post-process left the row half-updated (raw un-stretched clip with the old
@@ -680,8 +765,8 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
         try
         {
-            var speakResult = await TtsInstructionSwap.RunAsync(engine, Instruction, () =>
-                engine.Speak(Utilities.UnbreakLine(line.Text), _waveFolder, voice, SelectedLanguage, SelectedRegion, SelectedModel, _cancellationToken));
+            var speakResult = await TtsInstructionSwap.RunAsync(engine, instruction, () =>
+                engine.Speak(Utilities.UnbreakLine(line.Text), _waveFolder, voice, language, region, model, _cancellationToken));
 
             if (speakResult.Error || string.IsNullOrEmpty(speakResult.FileName) || !File.Exists(speakResult.FileName))
             {
@@ -718,14 +803,14 @@ public partial class ReviewSpeechViewModel : ObservableObject
             // Record which engine/model/instruction this regenerate used so the row's "click to
             // sync left panel" feature can restore them later.
             adjustSpeedStepResult.EngineName = engine.Name;
-            adjustSpeedStepResult.Model = SelectedModel ?? string.Empty;
-            adjustSpeedStepResult.Instruction = Instruction ?? string.Empty;
+            adjustSpeedStepResult.Model = model ?? string.Empty;
+            adjustSpeedStepResult.Instruction = instruction ?? string.Empty;
             line.Speed = Math.Round(adjustSpeedStepResult.SpeedFactor, 2).ToString(CultureInfo.CurrentCulture);
             line.Cps = Math.Round(adjustSpeedStepResult.Paragraph.GetCharactersPerSecond(), 2).ToString(CultureInfo.CurrentCulture);
             line.StepResult = adjustSpeedStepResult;
             line.Voice = voice.ToString();
 
-            line.AddHistory(voice, line.StepResult.CurrentFileName, engine.Name, SelectedModel ?? string.Empty, Instruction ?? string.Empty);
+            line.AddHistory(voice, line.StepResult.CurrentFileName, engine.Name, model ?? string.Empty, instruction ?? string.Empty);
         }
         catch (OperationCanceledException)
         {
@@ -798,6 +883,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
         _startPlayTicks = DateTime.UtcNow.Ticks;
 
         line.IsPlaying = true;
+        _playingRow = line;
         foreach (var l in Lines)
         {
             l.IsPlayingEnabled = false;
@@ -819,6 +905,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
         ReplaceCts(new CancellationTokenSource());
         _skipAutoContinue = false;
         _startPlayTicks = DateTime.UtcNow.Ticks;
+        _playingRow = line;
         await PlayAudio(line.StepResult.CurrentFileName);
     }
 
@@ -834,6 +921,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
             _mpvContext = null;
         }
 
+        _playingRow = null;
         IsPlayVisible = true;
         IsStopVisible = false;
     }

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1549,6 +1549,7 @@ public partial class TextToSpeechViewModel : ObservableObject
         }
 
         var stepResults = new List<TtsStepResult>();
+        var jsonFolder = Path.GetDirectoryName(fileName) ?? string.Empty;
         for (var index = 0; index < importExport.Items.Count; index++)
         {
             var item = importExport.Items[index];
@@ -1563,7 +1564,7 @@ public partial class TextToSpeechViewModel : ObservableObject
             stepResults.Add(new TtsStepResult
             {
                 Text = item.Text,
-                CurrentFileName = item.AudioFileName,
+                CurrentFileName = ResolveImportedAudioFileName(item.AudioFileName, jsonFolder),
                 Paragraph = paragraph,
                 SpeedFactor = item.SpeedFactor <= 0 ? 1.0f : item.SpeedFactor,
                 Voice = voice,
@@ -1584,6 +1585,20 @@ public partial class TextToSpeechViewModel : ObservableObject
         if (string.IsNullOrEmpty(_videoFileName) && !string.IsNullOrEmpty(videoFileNameForReview))
         {
             _videoFileName = videoFileNameForReview;
+        }
+
+        // The review window needs an engine and voice to offer regeneration. Voices can be empty
+        // when the selected engine's voice load failed (missing API key, network) - Voices.First()
+        // then threw and Import died with only a logged exception.
+        if (Engines.Count == 0 || Voices.Count == 0)
+        {
+            await MessageBox.Show(
+                Window,
+                Se.Language.General.Error,
+                "No voices are loaded for the selected engine - check the engine settings (e.g. API key) and try again.",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return;
         }
 
         // Try to populate _wavePeakData synchronously from the on-disk cache (fast, no ffmpeg).
@@ -1613,6 +1628,33 @@ public partial class TextToSpeechViewModel : ObservableObject
                 _ = GenerateWavePeaksIfNeededAsync(videoFileNameForReview, vm);
             }
         });
+    }
+
+    /// <summary>
+    /// Resolves an imported item's audio file. New exports store just the file name (resolved
+    /// against the JSON's own folder, so the export folder can be moved or shared); older exports
+    /// stored absolute paths - honored when they still exist, otherwise the same name is tried
+    /// next to the JSON.
+    /// </summary>
+    private static string ResolveImportedAudioFileName(string? audioFileName, string jsonFolder)
+    {
+        if (string.IsNullOrEmpty(audioFileName))
+        {
+            return string.Empty;
+        }
+
+        if (Path.IsPathRooted(audioFileName))
+        {
+            if (File.Exists(audioFileName))
+            {
+                return audioFileName;
+            }
+
+            var siblingFileName = Path.Combine(jsonFolder, Path.GetFileName(audioFileName));
+            return File.Exists(siblingFileName) ? siblingFileName : audioFileName;
+        }
+
+        return Path.Combine(jsonFolder, audioFileName);
     }
 
     private static WavePeakData2? TryLoadWavePeaksFromDisk(string videoFileName)


### PR DESCRIPTION
Third batch from the TTS bug hunt — the review-window playback state machine and the export/import round-trip. **Stacked on #12100** (which stacks on #12099); merge in order and GitHub retargets each.

## Playback state machine

- **Auto-continue followed the selection, not the playing row**: grid selection is two-way, so clicking another row during playback stranded the playing row's stop icon and resumed from the clicked row's successor. The playing row is now tracked explicitly (`_playingRow`), and selection follows playback on auto-continue — which is also the "playing line isn't the selected line" complaint from #12093.
- **mpv race**: the 200 ms watchdog read `_mpvContext.IsPaused` outside `_playLock` while Stop/close dispose the player under that lock — NRE / native use-after-free window. State reads now happen under the lock, and all UI property updates from the timer thread are marshaled to the dispatcher.
- **No more wedges**: a throw inside a tick used to kill the timer permanently (all rows stayed disabled); playing a row whose audio file is missing sat in "playing" forever (mpv's failed loadfile is fire-and-forget). Both now reset the playback UI, the latter with an error naming the missing file.

## Regenerate/history correctness

- Picking a history entry now restores `StepResult.SpeedFactor`, not just the display string — Export no longer writes the previous speed next to the restored audio.
- The regenerate pipeline snapshots `SelectedModel`/`Instruction`/language/region up front — clicking another row mid-run (non-modal popup) used to rewrite them via the panel sync, recording settings that never produced the audio.

## Export/import round-trip

- Export no longer crashes unhandled mid-way when a row's audio file is missing (files copied, no JSON written) — such rows are exported without audio and the count is reported.
- **Exports are now portable**: the JSON stores audio file *names* instead of absolute paths, and Import resolves them against the JSON's own folder. Old exports with absolute paths still work (honored when they exist, then retried next to the JSON) — moving or sharing an export folder finally round-trips.
- Import shows a clear error instead of dying on `Voices.First()` when the selected engine's voice list failed to load.

## Testing

- UI builds clean; all 525 UI tests pass; app smoke-launches.
- Remaining hunt findings for a final batch: voice-list refresh hardening (ElevenLabs/Murf/Mistral), engine-switch consistency in the main TTS window, FixSpeed dropping trim-failed segments, TtsPostProcessor silent no-op + intermediate leaks, and the smaller engine nits (Google IsInstalled credential, AllTalk escaping/cancellation, Azure SSML locale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)