### PR TITLE
TTS: harden voice-list refresh, engine-switch state, and engine nits (bug hunt batch 4)

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/AllTalk.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/AllTalk.cs
@@ -163,7 +163,17 @@ public class AllTalk : ITtsEngine
 
         var languageCode = language != null ? language.Code : "en";
         Se.WriteToolsLog($"AllTalk: voice={allTalkVoice.Voice}, language={languageCode}, textLen={text.Length}");
-        var allTalkFileNameOutputFileName = await _ttsDownloadService.AllTalkVoiceSpeak(text, allTalkVoice, languageCode);
+        var allTalkFileNameOutputFileName = await _ttsDownloadService.AllTalkVoiceSpeak(text, allTalkVoice, languageCode, cancellationToken);
+
+        // The server reports its output as a local path. It can be empty (unexpected response
+        // JSON) or unreachable from here (server on another machine / different working dir) -
+        // File.Move then threw unhandled instead of failing the segment like other engines.
+        if (string.IsNullOrWhiteSpace(allTalkFileNameOutputFileName) || !File.Exists(allTalkFileNameOutputFileName))
+        {
+            var error = $"AllTalk did not produce a readable output file (reported path: \"{allTalkFileNameOutputFileName}\") - is the server running on this machine?";
+            Se.WriteToolsLog("AllTalk: " + error, true);
+            return new TtsResult { Text = text, FileName = string.Empty, Error = true, ErrorMessage = error };
+        }
 
         var outputFileName = Path.Combine(GetSetAllTalkFolder(), Guid.NewGuid() + ".wav");
         File.Move(allTalkFileNameOutputFileName, outputFileName);

--- a/src/ui/Features/Video/TextToSpeech/Engines/ElevenLabs.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ElevenLabs.cs
@@ -233,7 +233,7 @@ public class ElevenLabs : ITtsEngine
             }
         }
 
-        if (model == "eleven_turbo_v2)")
+        if (model == "eleven_turbo_v2")
         {
             languages = new List<TtsLanguage>
             {
@@ -241,7 +241,7 @@ public class ElevenLabs : ITtsEngine
             };
         }
 
-        if (model == "eleven_multilingual_v1)")
+        if (model == "eleven_multilingual_v1")
         {
             languages = new List<TtsLanguage>
             {

--- a/src/ui/Features/Video/TextToSpeech/Engines/GoogleSpeech.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/GoogleSpeech.cs
@@ -23,7 +23,11 @@ public class GoogleSpeech : ITtsEngine
 
     public Task<bool> IsInstalled(string? region)
     {
-        var ok = !string.IsNullOrEmpty(Se.Settings.Video.TextToSpeech.GoogleApiKey);
+        // This engine authenticates exclusively via the key *file* (HasKeyFile=true; Speak and
+        // RefreshVoices only use GoogleKeyFile) - checking GoogleApiKey reported a configured
+        // engine as "not installed" and a leftover API key with no key file as "installed".
+        var keyFile = Se.Settings.Video.TextToSpeech.GoogleKeyFile;
+        var ok = !string.IsNullOrEmpty(keyFile) && File.Exists(keyFile);
         return Task.FromResult(ok);
     }
 

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1459,7 +1459,30 @@ public partial class TextToSpeechViewModel : ObservableObject
 
     private async Task RefreshVoices(ITtsEngine engine)
     {
-        var voices = await engine.RefreshVoices(string.Empty, CancellationToken.None);
+        Voice[] voices;
+        try
+        {
+            voices = await engine.RefreshVoices(string.Empty, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            // The voice-list downloads throw on HTTP failure (so an error body cannot overwrite
+            // the cached list). Keep the current voices and tell the user instead of crashing
+            // whichever command triggered the refresh.
+            SeLogger.Error(ex, $"Refreshing voices for {engine.Name} failed - keeping the cached voice list");
+            if (Window != null)
+            {
+                await MessageBox.Show(
+                    Window,
+                    Se.Language.General.Error,
+                    $"Refreshing voices failed: {ex.Message}",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+
+            return;
+        }
+
         Voices.Clear();
         foreach (var voice in voices)
         {
@@ -3076,8 +3099,22 @@ public partial class TextToSpeechViewModel : ObservableObject
                     var mediaInfo = FfmpegMediaInfo.Parse(currentFile);
                     if (mediaInfo.Duration == null)
                     {
+                        // The trim/VAD output is missing or unreadable (ffmpeg problem). Keep the
+                        // engine's original audio at original speed - same policy as the other
+                        // failure paths - instead of silently dropping the line from the output.
                         skippedNoDurationCount++;
-                        Se.WriteToolsLog($"TTS FixSpeed: segment {index + 1} dropped - could not read duration of \"{currentFile}\" (trim output missing or unreadable; ffmpeg problem?)", true);
+                        Se.WriteToolsLog($"TTS FixSpeed: segment {index + 1} - could not read duration of \"{currentFile}\" (trim output missing or unreadable; ffmpeg problem?) - keeping original audio", true);
+                        resultList.Add(new TtsStepResult
+                        {
+                            Paragraph = p,
+                            Text = item.Text,
+                            CurrentFileName = item.CurrentFileName,
+                            SpeedFactor = 1.0f,
+                            Voice = item.Voice,
+                            EngineName = item.EngineName,
+                            Model = item.Model,
+                            Instruction = item.Instruction,
+                        });
                         continue;
                     }
 
@@ -3387,7 +3424,33 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             IsEngineSettingsVisible = false;
             IsModelDownloadVisible = false;
-            var voices = await engine.GetVoices(SelectedLanguage?.Code ?? string.Empty);
+
+            // Engine capability flags first, and never skipped: when the voice load below fails
+            // or returns nothing (missing API key, no network), the user must still get the new
+            // engine's own fields (API key, region, model, ...) to fix the cause. The old flow
+            // returned early on an empty voice list, leaving every panel flag - and the voice
+            // list itself - describing the *previous* engine, so Generate could then hand the
+            // wrong engine's Voice object to Speak.
+            HasLanguageParameter = engine.HasLanguageParameter;
+            HasApiKey = engine.HasApiKey;
+            HasRegion = engine.HasRegion;
+            HasModel = engine.HasModel;
+            HasKeyFile = engine.HasKeyFile;
+            IsEdgeTtsEngine = engine is EdgeTts;
+
+            Voice[] voices;
+            try
+            {
+                voices = await engine.GetVoices(SelectedLanguage?.Code ?? string.Empty);
+            }
+            catch (Exception ex)
+            {
+                // PostSafe used to swallow this, skipping the whole engine switch. Show an empty
+                // voice list for the new engine instead of the previous engine's voices.
+                SeLogger.Error(ex, $"Loading voices for {engine.Name} failed");
+                voices = [];
+            }
+
             Voices.Clear();
             foreach (var vo in voices)
             {
@@ -3402,20 +3465,13 @@ public partial class TextToSpeechViewModel : ObservableObject
                                                        p.Name.Contains("English", StringComparison.OrdinalIgnoreCase));
             }
             SelectedVoice = lastVoice ?? Voices.FirstOrDefault();
-            if (SelectedVoice == null)
+
+            if (SelectedVoice != null)
             {
-                return;
+                ApplyInstructionForEngine(engine);
             }
 
-            HasLanguageParameter = engine.HasLanguageParameter;
-            HasApiKey = engine.HasApiKey;
-            HasRegion = engine.HasRegion;
-            HasModel = engine.HasModel;
-            HasKeyFile = engine.HasKeyFile;
-            IsEdgeTtsEngine = engine is EdgeTts;
-            ApplyInstructionForEngine(engine);
-
-            if (HasLanguageParameter)
+            if (HasLanguageParameter && SelectedVoice != null)
             {
                 var languages = await engine.GetLanguages(SelectedVoice, SelectedModel);
                 Languages.Clear();

--- a/src/ui/Features/Video/TextToSpeech/TtsPostProcessor.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsPostProcessor.cs
@@ -32,10 +32,7 @@ public static class TtsPostProcessor
                 var proProcess = FfmpegGenerator.ApplyProAudioChain(currentFile, proChainOutput);
                 await proProcess.StartAndWaitAsync(cancellationToken);
 
-                if (File.Exists(proChainOutput))
-                {
-                    currentFile = proChainOutput;
-                }
+                currentFile = AdoptStageOutput(currentFile, proChainOutput, "pro audio chain");
             }
 
             if (cancellationToken.IsCancellationRequested)
@@ -54,10 +51,7 @@ public static class TtsPostProcessor
                 await concatProcess.StartAndWaitAsync(cancellationToken);
 
                 SafeDelete(silenceFile);
-                if (File.Exists(paddedOutput))
-                {
-                    currentFile = paddedOutput;
-                }
+                currentFile = AdoptStageOutput(currentFile, paddedOutput, "silence padding");
             }
 
             if (cancellationToken.IsCancellationRequested)
@@ -71,10 +65,7 @@ public static class TtsPostProcessor
                 var srProcess = FfmpegGenerator.ChangeSampleRate(currentFile, resampledOutput, outputSampleRate);
                 await srProcess.StartAndWaitAsync(cancellationToken);
 
-                if (File.Exists(resampledOutput))
-                {
-                    currentFile = resampledOutput;
-                }
+                currentFile = AdoptStageOutput(currentFile, resampledOutput, "sample rate conversion");
             }
 
             return currentFile;
@@ -83,6 +74,26 @@ public static class TtsPostProcessor
         {
             return currentFile;
         }
+    }
+
+    /// <summary>
+    /// Adopts a stage's ffmpeg output when it was actually produced (exists and is non-empty -
+    /// a bare Exists check used to adopt zero-byte files from mid-run ffmpeg failures), deleting
+    /// the superseded input so a long run doesn't pile up one stale intermediate per stage per
+    /// line. A failed stage keeps the input and is force-logged - it used to be silently skipped,
+    /// leaving the user's enabled option quietly unapplied with no trace.
+    /// </summary>
+    private static string AdoptStageOutput(string inputFile, string outputFile, string stageName)
+    {
+        if (File.Exists(outputFile) && new FileInfo(outputFile).Length > 0)
+        {
+            SafeDelete(inputFile);
+            return outputFile;
+        }
+
+        Se.WriteToolsLog($"TTS post-processing: {stageName} produced no output for \"{inputFile}\" - stage skipped (ffmpeg failure?)", true);
+        SafeDelete(outputFile);
+        return inputFile;
     }
 
     private static void SafeDelete(string fileName)

--- a/src/ui/Logic/Download/TtsDownloadService.cs
+++ b/src/ui/Logic/Download/TtsDownloadService.cs
@@ -25,7 +25,7 @@ public interface ITtsDownloadService
     Task DownloadPiperVoice(string modelUrl, MemoryStream downloadStream, Progress<float> downloadProgress, CancellationToken token);
     Task DownloadPiperVoiceList(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
     Task DownloadAllTalkVoiceList(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
-    Task<string> AllTalkVoiceSpeak(string text, AllTalkVoice voice, string language);
+    Task<string> AllTalkVoiceSpeak(string text, AllTalkVoice voice, string language, CancellationToken cancellationToken);
     Task<bool> AllTalkIsInstalled();
     Task DownloadElevenLabsVoiceList(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
     Task DownloadAzureVoiceList(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
@@ -132,11 +132,13 @@ public class TtsDownloadService : ITtsDownloadService
         await DownloadHelper.DownloadFileAsync(_httpClient, url, stream, progress, cancellationToken);
     }
 
-    public async Task<string> AllTalkVoiceSpeak(string inputText, AllTalkVoice voice, string language)
+    public async Task<string> AllTalkVoiceSpeak(string inputText, AllTalkVoice voice, string language, CancellationToken cancellationToken)
     {
         using var multipartContent = new MultipartFormDataContent();
         var text = Utilities.UnbreakLine(inputText);
-        multipartContent.Add(new StringContent(Json.EncodeJsonText(text)), "text_input");
+        // Plain multipart form field - no JSON escaping: Json.EncodeJsonText turned quotes and
+        // backslashes into \" and \\ that AllTalk then spoke/mangled.
+        multipartContent.Add(new StringContent(text), "text_input");
         multipartContent.Add(new StringContent("standard"), "text_filtering");
         multipartContent.Add(new StringContent(voice.Voice), "character_voice_gen");
         multipartContent.Add(new StringContent("false"), "narrator_enabled");
@@ -151,14 +153,16 @@ public class TtsDownloadService : ITtsDownloadService
         HttpResponseMessage result;
         try
         {
-            result = await _httpClient.PostAsync(Se.Settings.Video.TextToSpeech.AllTalkUrl.TrimEnd('/') + "/api/tts-generate", multipartContent);
+            // Honor the caller's token - a bulk-generate Cancel used to leave the AllTalk
+            // request running to completion.
+            result = await _httpClient.PostAsync(Se.Settings.Video.TextToSpeech.AllTalkUrl.TrimEnd('/') + "/api/tts-generate", multipartContent, cancellationToken);
         }
         catch (HttpRequestException ex)
         {
             SeLogger.Error(ex, "AllTalk TTS server connection failed.");
             throw new HttpRequestException("AllTalk TTS server is not reachable. Please check that the server is running.", ex);
         }
-        catch (TaskCanceledException ex) when (!ex.CancellationToken.IsCancellationRequested)
+        catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
         {
             SeLogger.Error(ex, "AllTalk TTS server request timed out.");
             throw new HttpRequestException("AllTalk TTS server request timed out. Please check that the server is running.", ex);
@@ -168,12 +172,12 @@ public class TtsDownloadService : ITtsDownloadService
         {
             if (!result.IsSuccessStatusCode)
             {
-                var errorBody = await result.Content.ReadAsStringAsync();
+                var errorBody = await result.Content.ReadAsStringAsync(cancellationToken);
                 SeLogger.Error($"AllTalk TTS failed calling API at {_httpClient.BaseAddress}: Status code={result.StatusCode}" + Environment.NewLine + errorBody);
                 throw new HttpRequestException($"AllTalk TTS server returned error {(int)result.StatusCode} ({result.StatusCode}).");
             }
 
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
             var resultJson = Encoding.UTF8.GetString(bytes);
 
             var jsonParser = new SeJsonParser();
@@ -213,12 +217,19 @@ public class TtsDownloadService : ITtsDownloadService
         }
 
         var result = await _httpClient.SendAsync(requestMessage, cancellationToken);
-        await result.Content.CopyToAsync(ms, cancellationToken);
 
+        // Throw on failure instead of copying the error body into the stream: the caller writes
+        // the stream over its cached voice-list JSON, and since the bundled fallback only kicks
+        // in when the file is *missing*, one failed refresh (expired key, network error) used to
+        // permanently empty the voice list.
         if (!result.IsSuccessStatusCode)
         {
-            SeLogger.Error($"ElevenLabs TTS failed calling API address {url} : Status code={result.StatusCode}");
+            var error = (await result.Content.ReadAsStringAsync(cancellationToken)).Trim();
+            SeLogger.Error($"ElevenLabs TTS failed calling API address {url} : Status code={result.StatusCode} {TruncateForLog(error)}");
+            throw new HttpRequestException($"ElevenLabs voice list request failed: HTTP {(int)result.StatusCode} {result.StatusCode}");
         }
+
+        await result.Content.CopyToAsync(ms, cancellationToken);
     }
 
     public async Task DownloadMurfVoiceList(MemoryStream ms, IProgress<float>? progress, CancellationToken cancellationToken)
@@ -227,17 +238,20 @@ public class TtsDownloadService : ITtsDownloadService
 
         using var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
         requestMessage.Headers.TryAddWithoutValidation("Content-Type", "application/json");
-        requestMessage.Headers.TryAddWithoutValidation("Accept", "audio/mpeg");
+        requestMessage.Headers.TryAddWithoutValidation("Accept", "application/json");
         requestMessage.Headers.TryAddWithoutValidation("api-key", Se.Settings.Video.TextToSpeech.MurfApiKey);
 
         var result = await _httpClient.SendAsync(requestMessage, cancellationToken);
-        await result.Content.CopyToAsync(ms, cancellationToken);
 
+        // See DownloadElevenLabsVoiceList: an error body must not reach the cached voice list.
         if (!result.IsSuccessStatusCode)
         {
-            var error = Encoding.UTF8.GetString(ms.ToArray()).Trim();
-            SeLogger.Error($"Murf TTS failed calling API address {url} : Status code={result.StatusCode} {error}");
+            var error = (await result.Content.ReadAsStringAsync(cancellationToken)).Trim();
+            SeLogger.Error($"Murf TTS failed calling API address {url} : Status code={result.StatusCode} {TruncateForLog(error)}");
+            throw new HttpRequestException($"Murf voice list request failed: HTTP {(int)result.StatusCode} {result.StatusCode}");
         }
+
+        await result.Content.CopyToAsync(ms, cancellationToken);
     }
 
     public async Task DownloadAzureVoiceList(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
@@ -422,7 +436,11 @@ public class TtsDownloadService : ITtsDownloadService
 
         var text = Utilities.UnbreakLine(inputText);
 
-        var data = $"<speak version='1.0' xml:lang='en-US'><voice xml:lang='en-US' xml:gender='{voice.Gender}' name='{voice.ShortName}'>{System.Net.WebUtility.HtmlEncode(text)}</voice></speak>";
+        // Use the voice's own locale in the SSML instead of hardcoded en-US - the voice name
+        // usually wins, but a mismatched xml:lang can affect pronunciation of locale-ambiguous
+        // text (numbers, dates) for non-English voices.
+        var locale = string.IsNullOrWhiteSpace(voice.Locale) ? "en-US" : voice.Locale;
+        var data = $"<speak version='1.0' xml:lang='{locale}'><voice xml:lang='{locale}' xml:gender='{voice.Gender}' name='{voice.ShortName}'>{System.Net.WebUtility.HtmlEncode(text)}</voice></speak>";
         using var requestMessage = new HttpRequestMessage(HttpMethod.Post, url);
         requestMessage.Content = new StringContent(data, Encoding.UTF8);
 
@@ -663,10 +681,13 @@ public class TtsDownloadService : ITtsDownloadService
 
         var result = await _httpClient.SendAsync(requestMessage, cancellationToken);
 
+        // Throw instead of returning with an empty stream: the caller writes the stream over its
+        // cached voice-list JSON, so a silently failed refresh permanently emptied the voice list
+        // (the bundled fallback only restores when the file is missing).
         if (!result.IsSuccessStatusCode)
         {
             SeLogger.Error($"Mistral TTS failed calling API address {url} : Status code={result.StatusCode}");
-            return;
+            throw new HttpRequestException($"Mistral voice list request failed: HTTP {(int)result.StatusCode} {result.StatusCode}");
         }
 
         await result.Content.CopyToAsync(ms, cancellationToken);


### PR DESCRIPTION
Final batch from the TTS bug hunt. **Stacked on #12101** (→ #12100 → #12099); merge in order.

## Voice-list refresh hardening (ElevenLabs / Murf / Mistral)

The list downloads copied HTTP error bodies (or nothing) into the stream and only logged; the engines wrote that over their cached voice JSON, and since the bundled fallback only restores a *missing* file, **one failed refresh permanently emptied the voice list**. The downloads now throw on non-success, and the view model's refresh wrapper catches, keeps the cached list, and shows the error. (Murf's list request also sent `Accept: audio/mpeg` to a JSON API.) Together with the Azure fix in batch 1, all voice-list refreshes are now failure-safe.

## Engine-switch consistency (main window)

A failed or empty voice load used to leave the window describing the *previous* engine (swallowed exception / early return): stale voice list, hidden API-key field — the user couldn't even enter the key to fix the cause — and Generate could hand the wrong engine's `Voice` object to `Speak`. Capability flags and the engine-specific settings blocks now always run; a failed load shows an empty voice list for the new engine.

## Pipeline consistency

- **FixSpeed** kept-original policy now covers the unreadable-trim-output path too (was: silently dropped the line from the final audio).
- **TtsPostProcessor**: failed stages are force-logged instead of silently disabling the user's enabled option, zero-byte outputs are no longer adopted, and superseded intermediates are deleted (a 1000-line run with all options used to leave ~3000 stale wavs).

## Engine nits

- **Google**: `IsInstalled` checked the API key, but the engine authenticates exclusively via the key *file* — configured engines reported "not installed" and vice versa.
- **AllTalk**: JSON escaping removed from a plain multipart field (quotes/backslashes were spoken), the speak request honors the cancellation token, and a missing/unreachable server output path fails the segment with a message instead of an unhandled `File.Move` throw.
- **Azure**: SSML now uses the voice's own locale instead of hardcoded `en-US`.
- **ElevenLabs**: fixed the `"eleven_turbo_v2)"` / `"eleven_multilingual_v1)"` stray-parenthesis comparisons (unreachable branches).

## Testing

- UI builds clean; all 525 UI tests pass; app smoke-launches.
- This completes the actionable findings from the hunt. Not addressed (judgment calls / lower value): the Cancel-flips-UI-before-pipeline-stops ordering race, background-thread property sets in older sibling VMs, and the OmniVoice `--ref-text` parameter question (needs a manual check against the CLI's expected form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)