### PR TITLE
TTS bug hunt batches 2-4: cancellation/lifecycle, review playback/export, engine hardening

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/AllTalk.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/AllTalk.cs
@@ -163,7 +163,17 @@ public class AllTalk : ITtsEngine
 
         var languageCode = language != null ? language.Code : "en";
         Se.WriteToolsLog($"AllTalk: voice={allTalkVoice.Voice}, language={languageCode}, textLen={text.Length}");
-        var allTalkFileNameOutputFileName = await _ttsDownloadService.AllTalkVoiceSpeak(text, allTalkVoice, languageCode);
+        var allTalkFileNameOutputFileName = await _ttsDownloadService.AllTalkVoiceSpeak(text, allTalkVoice, languageCode, cancellationToken);
+
+        // The server reports its output as a local path. It can be empty (unexpected response
+        // JSON) or unreachable from here (server on another machine / different working dir) -
+        // File.Move then threw unhandled instead of failing the segment like other engines.
+        if (string.IsNullOrWhiteSpace(allTalkFileNameOutputFileName) || !File.Exists(allTalkFileNameOutputFileName))
+        {
+            var error = $"AllTalk did not produce a readable output file (reported path: \"{allTalkFileNameOutputFileName}\") - is the server running on this machine?";
+            Se.WriteToolsLog("AllTalk: " + error, true);
+            return new TtsResult { Text = text, FileName = string.Empty, Error = true, ErrorMessage = error };
+        }
 
         var outputFileName = Path.Combine(GetSetAllTalkFolder(), Guid.NewGuid() + ".wav");
         File.Move(allTalkFileNameOutputFileName, outputFileName);

--- a/src/ui/Features/Video/TextToSpeech/Engines/ElevenLabs.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ElevenLabs.cs
@@ -233,7 +233,7 @@ public class ElevenLabs : ITtsEngine
             }
         }
 
-        if (model == "eleven_turbo_v2)")
+        if (model == "eleven_turbo_v2")
         {
             languages = new List<TtsLanguage>
             {
@@ -241,7 +241,7 @@ public class ElevenLabs : ITtsEngine
             };
         }
 
-        if (model == "eleven_multilingual_v1)")
+        if (model == "eleven_multilingual_v1")
         {
             languages = new List<TtsLanguage>
             {

--- a/src/ui/Features/Video/TextToSpeech/Engines/GoogleSpeech.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/GoogleSpeech.cs
@@ -23,7 +23,11 @@ public class GoogleSpeech : ITtsEngine
 
     public Task<bool> IsInstalled(string? region)
     {
-        var ok = !string.IsNullOrEmpty(Se.Settings.Video.TextToSpeech.GoogleApiKey);
+        // This engine authenticates exclusively via the key *file* (HasKeyFile=true; Speak and
+        // RefreshVoices only use GoogleKeyFile) - checking GoogleApiKey reported a configured
+        // engine as "not installed" and a leftover API key with no key file as "installed".
+        var keyFile = Se.Settings.Video.TextToSpeech.GoogleKeyFile;
+        var ok = !string.IsNullOrEmpty(keyFile) && File.Exists(keyFile);
         return Task.FromResult(ok);
     }
 

--- a/src/ui/Features/Video/TextToSpeech/ProcessExtensions.cs
+++ b/src/ui/Features/Video/TextToSpeech/ProcessExtensions.cs
@@ -19,15 +19,26 @@ public static class ProcessExtensions
     public static async Task StartAndWaitAsync(this Process process, CancellationToken cancellationToken)
     {
         process.StartProcess();
-        await process.WaitForExitAsync(cancellationToken);
+        try
+        {
+            await process.WaitForExitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // WaitForExitAsync only stops *waiting* on cancellation - the child keeps running.
+            // Cancel means stop the work, so kill it; otherwise a cancelled merge/generation
+            // leaves ffmpeg burning CPU (and holding its input files open) to completion.
+            KillNoError(process);
+            throw;
+        }
     }
 
     /// <summary>
     /// Starts the process and waits for it to exit, but no longer than <paramref name="timeout"/>.
     /// On overrun the process is killed and a <see cref="TimeoutException"/> naming the command is
     /// thrown, so a wedged child process (e.g. an ffmpeg waiting on a prompt) surfaces as an error
-    /// instead of freezing the pipeline forever (#12093). User cancellation still surfaces as
-    /// <see cref="OperationCanceledException"/>.
+    /// instead of freezing the pipeline forever (#12093). User cancellation kills the process too
+    /// and still surfaces as <see cref="OperationCanceledException"/>.
     /// </summary>
     public static async Task StartAndWaitAsync(this Process process, CancellationToken cancellationToken, TimeSpan timeout)
     {
@@ -39,19 +50,28 @@ public static class ProcessExtensions
         {
             await process.WaitForExitAsync(timeoutCts.Token);
         }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
-            try
+            KillNoError(process);
+            if (cancellationToken.IsCancellationRequested)
             {
-                process.Kill(entireProcessTree: true);
-            }
-            catch
-            {
-                // best-effort - the process may have exited in the meantime
+                throw; // user cancel - propagate as cancellation, not as a timeout
             }
 
             throw new TimeoutException(
                 $"\"{process.StartInfo.FileName} {process.StartInfo.Arguments}\" did not finish within {timeout.TotalSeconds:0} seconds and was killed.");
+        }
+    }
+
+    private static void KillNoError(Process process)
+    {
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch
+        {
+            // best-effort - the process may have exited in the meantime
         }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -592,10 +592,10 @@ public partial class ReviewSpeechViewModel : ObservableObject
         var old = _cancellationTokenSource;
         _cancellationTokenSource = next;
         _cancellationToken = next.Token;
-        if (!ReferenceEquals(old, next))
-        {
-            try { old.Dispose(); } catch (ObjectDisposedException) { }
-        }
+        // The old CTS is deliberately not disposed: it may still be held by a non-modal
+        // GeneratingAudioWindow whose Cancel button calls Cancel() on it - disposing here made
+        // that throw ObjectDisposedException. A CTS without timers has no unmanaged state that
+        // needs deterministic disposal; window close disposes the final instance.
     }
 
     [RelayCommand]
@@ -653,6 +653,15 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
         IsRegenerateEnabled = false;
 
+        // Gate the whole grid: the regenerate popup is non-modal, and starting a play or a
+        // second regenerate mid-run swapped the shared cancellation source under the first one.
+        // The per-row play/regenerate buttons, Ctrl+R and the Space shortcut all honor
+        // IsPlayingEnabled, so this closes every entry point at once.
+        foreach (var l in Lines)
+        {
+            l.IsPlayingEnabled = false;
+        }
+
         var oldStyle = SelectedStyle;
         if (engine is Murf && !string.IsNullOrEmpty(SelectedStyle))
         {
@@ -662,11 +671,35 @@ public partial class ReviewSpeechViewModel : ObservableObject
         var generatingAudioVm = _windowService.ShowWindow<GeneratingAudioWindow, GeneratingAudioViewModel>(Window!);
         ReplaceCts(generatingAudioVm.CancellationTokenSource);
 
-        TtsResult speakResult;
+        // The row's live StepResult must only change once the whole regenerate pipeline has
+        // succeeded - it used to be mutated right after Speak, so a cancel or a failed
+        // trim/post-process left the row half-updated (raw un-stretched clip with the old
+        // speed/voice display) and OK/Export published that state.
+        var originalFileName = line.StepResult.CurrentFileName;
+        var originalVoice = line.StepResult.Voice;
+
         try
         {
-            speakResult = await TtsInstructionSwap.RunAsync(engine, Instruction, () =>
+            var speakResult = await TtsInstructionSwap.RunAsync(engine, Instruction, () =>
                 engine.Speak(Utilities.UnbreakLine(line.Text), _waveFolder, voice, SelectedLanguage, SelectedRegion, SelectedModel, _cancellationToken));
+
+            if (speakResult.Error || string.IsNullOrEmpty(speakResult.FileName) || !File.Exists(speakResult.FileName))
+            {
+                if (Window != null)
+                {
+                    var detail = string.IsNullOrEmpty(speakResult.ErrorMessage)
+                        ? "The engine produced no audio - see error-log.txt in the Subtitle Edit data folder."
+                        : speakResult.ErrorMessage;
+                    await MessageBox.Show(
+                        Window,
+                        Se.Language.General.Error,
+                        "Regenerating audio failed: " + detail,
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
+                }
+
+                return;
+            }
 
             line.StepResult.CurrentFileName = speakResult.FileName;
             line.StepResult.Voice = voice;
@@ -676,6 +709,8 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
             if (_cancellationToken.IsCancellationRequested)
             {
+                line.StepResult.CurrentFileName = originalFileName;
+                line.StepResult.Voice = originalVoice;
                 return;
             }
 
@@ -692,8 +727,18 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
             line.AddHistory(voice, line.StepResult.CurrentFileName, engine.Name, SelectedModel ?? string.Empty, Instruction ?? string.Empty);
         }
+        catch (OperationCanceledException)
+        {
+            // Cancel in the GeneratingAudio popup: Speak and the ffmpeg steps surface it as a
+            // throw (it used to escape as an unhandled exception). Undo the partial row update.
+            line.StepResult.CurrentFileName = originalFileName;
+            line.StepResult.Voice = originalVoice;
+            return;
+        }
         catch (HttpRequestException ex)
         {
+            line.StepResult.CurrentFileName = originalFileName;
+            line.StepResult.Voice = originalVoice;
             SeLogger.Error(ex, "TTS server error during regeneration.");
             if (Window != null)
             {
@@ -706,10 +751,30 @@ public partial class ReviewSpeechViewModel : ObservableObject
             }
             return;
         }
+        catch (Exception ex)
+        {
+            line.StepResult.CurrentFileName = originalFileName;
+            line.StepResult.Voice = originalVoice;
+            SeLogger.Error(ex, "Regenerating audio failed.");
+            if (Window != null)
+            {
+                await MessageBox.Show(
+                    Window,
+                    Se.Language.General.Error,
+                    "Regenerating audio failed: " + ex.Message,
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+            return;
+        }
         finally
         {
             generatingAudioVm.Close();
             IsRegenerateEnabled = true;
+            foreach (var l in Lines)
+            {
+                l.IsPlayingEnabled = true;
+            }
             if (engine is Murf && oldStyle != null)
             {
                 Se.Settings.Video.TextToSpeech.MurfStyle = oldStyle;

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -121,6 +121,10 @@ public partial class ReviewSpeechViewModel : ObservableObject
     private long _startPlayTicks;
     private readonly List<string> _tempAudioFiles = new();
 
+    // The row whose audio is currently playing. Auto-continue must advance from this row, not
+    // from SelectedLine - grid selection is two-way and can move during playback.
+    private ReviewRow? _playingRow;
+
     public ReviewSpeechViewModel(IFolderHelper folderHelper, IWindowService windowService)
     {
         _folderHelper = folderHelper;
@@ -160,22 +164,33 @@ public partial class ReviewSpeechViewModel : ObservableObject
         {
             _timer.Stop();
 
-            if (_cancellationTokenSource.IsCancellationRequested || _mpvContext == null)
+            // Read mpv state under the play lock: Stop()/OnClosing dispose _mpvContext under the
+            // same lock on the UI thread, and this tick runs on a threadpool thread - the old
+            // unguarded IsPaused read raced the dispose (NRE / native use-after-free window).
+            var stopped = false;
+            var paused = false;
+            lock (_playLock)
             {
-                IsPlayVisible = true;
-                IsStopVisible = false;
-                foreach (var l in Lines)
+                if (_cancellationTokenSource.IsCancellationRequested || _mpvContext == null)
                 {
-                    l.IsPlaying = false;
-                    l.IsPlayingEnabled = true;
+                    stopped = true;
                 }
+                else
+                {
+                    paused = _mpvContext.IsPaused;
+                }
+            }
 
+            if (stopped)
+            {
+                await Dispatcher.UIThread.InvokeAsync(ResetPlaybackUiState);
                 return;
             }
 
-            var paused = _mpvContext.IsPaused;
-
-            var line = SelectedLine;
+            // The row that is actually playing - not SelectedLine: two-way grid selection meant
+            // clicking another row during playback made auto-continue advance from the *clicked*
+            // row, stranding the playing row's stop icon and skipping the clicked one.
+            var line = _playingRow;
             var timeSinceStart = TimeSpan.FromTicks(DateTime.UtcNow.Ticks - _startPlayTicks);
             if (paused && AutoContinue && !_skipAutoContinue && line != null && timeSinceStart.TotalMilliseconds > 500)
             {
@@ -183,10 +198,11 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 {
                     line.IsPlaying = false;
                     var index = Lines.IndexOf(line);
-                    if (index < Lines.Count - 1)
+                    if (index >= 0 && index < Lines.Count - 1)
                     {
                         var nextLine = Lines[index + 1];
                         nextLine.IsPlaying = true;
+                        _playingRow = nextLine;
                         SelectedLine = nextLine;
                         LineGrid.ScrollIntoView(nextLine, null);
                         await PlayAudio(nextLine.StepResult.CurrentFileName);
@@ -194,43 +210,74 @@ public partial class ReviewSpeechViewModel : ObservableObject
                     else
                     {
                         _skipAutoContinue = true; // no more lines to play
-
-                        IsPlayVisible = true;
-                        IsStopVisible = false;
-                        foreach (var l in Lines)
-                        {
-                            l.IsPlaying = false;
-                            l.IsPlayingEnabled = true;
-                        }
+                        ResetPlaybackUiState();
                     }
                 });
 
                 return;
             }
 
-            IsPlayVisible = paused;
-            IsStopVisible = !paused;
-
             if (paused)
             {
-                foreach (var l in Lines)
-                {
-                    l.IsPlaying = false;
-                    l.IsPlayingEnabled = true;
-                }
+                await Dispatcher.UIThread.InvokeAsync(ResetPlaybackUiState);
                 return;
             }
+
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                IsPlayVisible = false;
+                IsStopVisible = true;
+            });
 
             _timer.Start();
         }
         catch (Exception ex)
         {
             SeLogger.Error(ex, "Error in ReviewSpeech playback timer.");
+            // A throw used to kill the timer for good, leaving every row disabled (PlayRow
+            // disables them and only this timer re-enables) - reset instead of wedging.
+            Dispatcher.UIThread.Post(ResetPlaybackUiState);
+        }
+    }
+
+    /// <summary>
+    /// Returns the playback UI to idle: play button showing, no row marked as playing, all
+    /// rows clickable again. Must run on the UI thread.
+    /// </summary>
+    private void ResetPlaybackUiState()
+    {
+        IsPlayVisible = true;
+        IsStopVisible = false;
+        _playingRow = null;
+        foreach (var l in Lines)
+        {
+            l.IsPlaying = false;
+            l.IsPlayingEnabled = true;
         }
     }
 
     private async Task PlayAudio(string fileName)
     {
+        // A row can point at a deleted/moved file (e.g. an imported session whose folder was
+        // cleaned). mpv's failed loadfile is only logged, so playback used to sit in "playing"
+        // forever with every row disabled and no error. Reset and tell the user instead.
+        if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
+        {
+            SeLogger.Error($"ReviewSpeech: cannot play missing audio file \"{fileName}\"");
+            ResetPlaybackUiState();
+            if (Window != null)
+            {
+                await MessageBox.Show(
+                    Window,
+                    Se.Language.General.Error,
+                    "The audio file for this line does not exist:" + Environment.NewLine + fileName,
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+
+            return;
+        }
+
         lock (_playLock)
         {
             _mpvContext?.Stop();
@@ -440,6 +487,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
         // Copy files
         var index = 0;
+        var missingAudioCount = 0;
         var exportFormat = new TtsImportExport
         {
             VideoFileName = _videoFileName,
@@ -451,7 +499,17 @@ public partial class ReviewSpeechViewModel : ObservableObject
             var sourceFileName = line.StepResult.CurrentFileName;
             var targetFileName = Path.Combine(folder, index.ToString().PadLeft(4, '0') + Path.GetExtension((string?)sourceFileName));
 
-            if (File.Exists(targetFileName))
+            // A row can point at a deleted/moved file (e.g. an imported session whose folder was
+            // cleaned). File.Copy used to throw unhandled mid-export, leaving some files copied
+            // and no JSON written. Export the row without audio instead and report the count.
+            if (string.IsNullOrEmpty(sourceFileName) || !File.Exists(sourceFileName))
+            {
+                missingAudioCount++;
+                SeLogger.Error($"ReviewSpeech export: audio file missing for line {index}: \"{sourceFileName}\"");
+                targetFileName = string.Empty;
+            }
+
+            if (!string.IsNullOrEmpty(targetFileName) && File.Exists(targetFileName))
             {
                 try
                 {
@@ -469,11 +527,16 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 }
             }
 
-            File.Copy(sourceFileName, targetFileName, true);
+            if (!string.IsNullOrEmpty(targetFileName))
+            {
+                File.Copy(sourceFileName, targetFileName, true);
+            }
 
             exportFormat.Items.Add(new TtsImportExportItem
             {
-                AudioFileName = targetFileName,
+                // File name only, not the absolute path: the export folder is meant to be moved
+                // or shared, and Import resolves the name against the JSON's own directory.
+                AudioFileName = string.IsNullOrEmpty(targetFileName) ? string.Empty : Path.GetFileName(targetFileName),
                 StartMs = (long)Math.Round((double)line.StepResult.Paragraph.StartTime.TotalMilliseconds, MidpointRounding.AwayFromZero),
                 EndMs = (long)Math.Round((double)line.StepResult.Paragraph.EndTime.TotalMilliseconds, MidpointRounding.AwayFromZero),
                 VoiceName = line.StepResult.Voice?.Name ?? string.Empty,
@@ -494,6 +557,16 @@ public partial class ReviewSpeechViewModel : ObservableObject
         // Export json
         var json = JsonSerializer.Serialize(exportFormat, new JsonSerializerOptions { WriteIndented = true });
         await File.WriteAllTextAsync(jsonFileName, json);
+
+        if (missingAudioCount > 0)
+        {
+            await MessageBox.Show(
+                Window,
+                Se.Language.General.Warning,
+                $"{missingAudioCount} line(s) had no audio file and were exported without audio - see error-log.txt in the Subtitle Edit data folder.",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Warning);
+        }
 
         await _folderHelper.OpenFolder(Window!, folder);
     }
@@ -535,6 +608,9 @@ public partial class ReviewSpeechViewModel : ObservableObject
         line.StepResult.EngineName = picked.EngineName ?? string.Empty;
         line.StepResult.Model = picked.Model ?? string.Empty;
         line.StepResult.Instruction = picked.Instruction ?? string.Empty;
+        // Restore the real speed factor too, not just the display string - otherwise Export
+        // writes the previous SpeedFactor next to this entry's audio file.
+        line.StepResult.SpeedFactor = picked.Speed;
         line.Speed = Math.Round(picked.Speed, 2).ToString(CultureInfo.CurrentCulture);
 
         // Mirror the click-to-sync behaviour so the left panel immediately reflects the picked
@@ -671,6 +747,15 @@ public partial class ReviewSpeechViewModel : ObservableObject
         var generatingAudioVm = _windowService.ShowWindow<GeneratingAudioWindow, GeneratingAudioViewModel>(Window!);
         ReplaceCts(generatingAudioVm.CancellationTokenSource);
 
+        // Snapshot the panel state this regenerate runs with: the progress popup is non-modal,
+        // so clicking another row mid-run rewrites SelectedModel/Instruction (via the row-click
+        // panel sync) - reading them after the awaits recorded settings that never produced the
+        // audio into the row snapshot and its history entry.
+        var model = SelectedModel;
+        var instruction = Instruction;
+        var language = SelectedLanguage;
+        var region = SelectedRegion;
+
         // The row's live StepResult must only change once the whole regenerate pipeline has
         // succeeded - it used to be mutated right after Speak, so a cancel or a failed
         // trim/post-process left the row half-updated (raw un-stretched clip with the old
@@ -680,8 +765,8 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
         try
         {
-            var speakResult = await TtsInstructionSwap.RunAsync(engine, Instruction, () =>
-                engine.Speak(Utilities.UnbreakLine(line.Text), _waveFolder, voice, SelectedLanguage, SelectedRegion, SelectedModel, _cancellationToken));
+            var speakResult = await TtsInstructionSwap.RunAsync(engine, instruction, () =>
+                engine.Speak(Utilities.UnbreakLine(line.Text), _waveFolder, voice, language, region, model, _cancellationToken));
 
             if (speakResult.Error || string.IsNullOrEmpty(speakResult.FileName) || !File.Exists(speakResult.FileName))
             {
@@ -718,14 +803,14 @@ public partial class ReviewSpeechViewModel : ObservableObject
             // Record which engine/model/instruction this regenerate used so the row's "click to
             // sync left panel" feature can restore them later.
             adjustSpeedStepResult.EngineName = engine.Name;
-            adjustSpeedStepResult.Model = SelectedModel ?? string.Empty;
-            adjustSpeedStepResult.Instruction = Instruction ?? string.Empty;
+            adjustSpeedStepResult.Model = model ?? string.Empty;
+            adjustSpeedStepResult.Instruction = instruction ?? string.Empty;
             line.Speed = Math.Round(adjustSpeedStepResult.SpeedFactor, 2).ToString(CultureInfo.CurrentCulture);
             line.Cps = Math.Round(adjustSpeedStepResult.Paragraph.GetCharactersPerSecond(), 2).ToString(CultureInfo.CurrentCulture);
             line.StepResult = adjustSpeedStepResult;
             line.Voice = voice.ToString();
 
-            line.AddHistory(voice, line.StepResult.CurrentFileName, engine.Name, SelectedModel ?? string.Empty, Instruction ?? string.Empty);
+            line.AddHistory(voice, line.StepResult.CurrentFileName, engine.Name, model ?? string.Empty, instruction ?? string.Empty);
         }
         catch (OperationCanceledException)
         {
@@ -798,6 +883,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
         _startPlayTicks = DateTime.UtcNow.Ticks;
 
         line.IsPlaying = true;
+        _playingRow = line;
         foreach (var l in Lines)
         {
             l.IsPlayingEnabled = false;
@@ -819,6 +905,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
         ReplaceCts(new CancellationTokenSource());
         _skipAutoContinue = false;
         _startPlayTicks = DateTime.UtcNow.Ticks;
+        _playingRow = line;
         await PlayAudio(line.StepResult.CurrentFileName);
     }
 
@@ -834,6 +921,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
             _mpvContext = null;
         }
 
+        _playingRow = null;
         IsPlayVisible = true;
         IsStopVisible = false;
     }

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeechHistory/ReviewSpeechHistoryViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeechHistory/ReviewSpeechHistoryViewModel.cs
@@ -127,6 +127,16 @@ public partial class ReviewSpeechHistoryViewModel : ObservableObject
             return;
         }
 
+        // A CancellationTokenSource is one-shot: after StopItem cancels it, the timer's
+        // IsCancellationRequested check killed every later play within 200 ms - one Stop
+        // permanently broke playback in this dialog. Renew it per play. (The old instance is
+        // intentionally not disposed here; the timer thread may still be reading it.)
+        if (_cancellationTokenSource.IsCancellationRequested)
+        {
+            _cancellationTokenSource = new CancellationTokenSource();
+            _cancellationToken = _cancellationTokenSource.Token;
+        }
+
         item.IsPlaying = true;
         await PlayAudio(item.FileName);
     }

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1349,8 +1349,10 @@ public partial class TextToSpeechViewModel : ObservableObject
     {
         var engine = SelectedEngine;
         var voice = SelectedVoice;
-        if (engine == null || voice == null || Window == null)
+        if (engine == null || voice == null || Window == null || IsGenerating)
         {
+            // IsGenerating guard: the button's IsVoiceTestEnabled binding is timer-driven (mpv
+            // idle) and stays true during a generate run, so this can be clicked mid-pipeline.
             return;
         }
 
@@ -1382,12 +1384,15 @@ public partial class TextToSpeechViewModel : ObservableObject
         text = Utilities.UnbreakLine(text);
 
         var generatingAudioVm = _windowService.ShowWindow<GeneratingAudioWindow, GeneratingAudioViewModel>(Window!);
-        _cancellationTokenSource = generatingAudioVm.CancellationTokenSource;
-        _cancellationToken = _cancellationTokenSource.Token;
+        // A local token only: assigning the popup's CTS into the shared _cancellationTokenSource/
+        // _cancellationToken fields hijacked a running generate pipeline (the pipeline re-reads
+        // the fields per stage) - the popup's Cancel then aborted the whole run, and the main
+        // Cancel button cancelled the popup instead of the generation.
+        var testVoiceToken = generatingAudioVm.CancellationTokenSource.Token;
         try
         {
-            var result = await engine.Speak(text, _waveFolder, voice, SelectedLanguage, SelectedRegion, SelectedModel, _cancellationToken);
-            if (!_cancellationToken.IsCancellationRequested)
+            var result = await engine.Speak(text, _waveFolder, voice, SelectedLanguage, SelectedRegion, SelectedModel, testVoiceToken);
+            if (!testVoiceToken.IsCancellationRequested)
             {
                 if (!File.Exists(result.FileName))
                 {
@@ -3572,6 +3577,13 @@ public partial class TextToSpeechViewModel : ObservableObject
 
     internal void OnClosing(WindowClosingEventArgs e)
     {
+        // An enabled System.Timers.Timer is rooted: without stopping it here, every open/close
+        // of this window leaked a view model whose Elapsed handler kept firing every 100 ms for
+        // the rest of the session (ReviewSpeechViewModel already does this on close).
+        _timer.Stop();
+        _timer.Elapsed -= OnTimerOnElapsed;
+        _timer.Dispose();
+
         lock (_playLock)
         {
             _mpvContext?.Dispose();

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1549,6 +1549,7 @@ public partial class TextToSpeechViewModel : ObservableObject
         }
 
         var stepResults = new List<TtsStepResult>();
+        var jsonFolder = Path.GetDirectoryName(fileName) ?? string.Empty;
         for (var index = 0; index < importExport.Items.Count; index++)
         {
             var item = importExport.Items[index];
@@ -1563,7 +1564,7 @@ public partial class TextToSpeechViewModel : ObservableObject
             stepResults.Add(new TtsStepResult
             {
                 Text = item.Text,
-                CurrentFileName = item.AudioFileName,
+                CurrentFileName = ResolveImportedAudioFileName(item.AudioFileName, jsonFolder),
                 Paragraph = paragraph,
                 SpeedFactor = item.SpeedFactor <= 0 ? 1.0f : item.SpeedFactor,
                 Voice = voice,
@@ -1584,6 +1585,20 @@ public partial class TextToSpeechViewModel : ObservableObject
         if (string.IsNullOrEmpty(_videoFileName) && !string.IsNullOrEmpty(videoFileNameForReview))
         {
             _videoFileName = videoFileNameForReview;
+        }
+
+        // The review window needs an engine and voice to offer regeneration. Voices can be empty
+        // when the selected engine's voice load failed (missing API key, network) - Voices.First()
+        // then threw and Import died with only a logged exception.
+        if (Engines.Count == 0 || Voices.Count == 0)
+        {
+            await MessageBox.Show(
+                Window,
+                Se.Language.General.Error,
+                "No voices are loaded for the selected engine - check the engine settings (e.g. API key) and try again.",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return;
         }
 
         // Try to populate _wavePeakData synchronously from the on-disk cache (fast, no ffmpeg).
@@ -1613,6 +1628,33 @@ public partial class TextToSpeechViewModel : ObservableObject
                 _ = GenerateWavePeaksIfNeededAsync(videoFileNameForReview, vm);
             }
         });
+    }
+
+    /// <summary>
+    /// Resolves an imported item's audio file. New exports store just the file name (resolved
+    /// against the JSON's own folder, so the export folder can be moved or shared); older exports
+    /// stored absolute paths - honored when they still exist, otherwise the same name is tried
+    /// next to the JSON.
+    /// </summary>
+    private static string ResolveImportedAudioFileName(string? audioFileName, string jsonFolder)
+    {
+        if (string.IsNullOrEmpty(audioFileName))
+        {
+            return string.Empty;
+        }
+
+        if (Path.IsPathRooted(audioFileName))
+        {
+            if (File.Exists(audioFileName))
+            {
+                return audioFileName;
+            }
+
+            var siblingFileName = Path.Combine(jsonFolder, Path.GetFileName(audioFileName));
+            return File.Exists(siblingFileName) ? siblingFileName : audioFileName;
+        }
+
+        return Path.Combine(jsonFolder, audioFileName);
     }
 
     private static WavePeakData2? TryLoadWavePeaksFromDisk(string videoFileName)

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1459,7 +1459,30 @@ public partial class TextToSpeechViewModel : ObservableObject
 
     private async Task RefreshVoices(ITtsEngine engine)
     {
-        var voices = await engine.RefreshVoices(string.Empty, CancellationToken.None);
+        Voice[] voices;
+        try
+        {
+            voices = await engine.RefreshVoices(string.Empty, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            // The voice-list downloads throw on HTTP failure (so an error body cannot overwrite
+            // the cached list). Keep the current voices and tell the user instead of crashing
+            // whichever command triggered the refresh.
+            SeLogger.Error(ex, $"Refreshing voices for {engine.Name} failed - keeping the cached voice list");
+            if (Window != null)
+            {
+                await MessageBox.Show(
+                    Window,
+                    Se.Language.General.Error,
+                    $"Refreshing voices failed: {ex.Message}",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+
+            return;
+        }
+
         Voices.Clear();
         foreach (var voice in voices)
         {
@@ -3076,8 +3099,22 @@ public partial class TextToSpeechViewModel : ObservableObject
                     var mediaInfo = FfmpegMediaInfo.Parse(currentFile);
                     if (mediaInfo.Duration == null)
                     {
+                        // The trim/VAD output is missing or unreadable (ffmpeg problem). Keep the
+                        // engine's original audio at original speed - same policy as the other
+                        // failure paths - instead of silently dropping the line from the output.
                         skippedNoDurationCount++;
-                        Se.WriteToolsLog($"TTS FixSpeed: segment {index + 1} dropped - could not read duration of \"{currentFile}\" (trim output missing or unreadable; ffmpeg problem?)", true);
+                        Se.WriteToolsLog($"TTS FixSpeed: segment {index + 1} - could not read duration of \"{currentFile}\" (trim output missing or unreadable; ffmpeg problem?) - keeping original audio", true);
+                        resultList.Add(new TtsStepResult
+                        {
+                            Paragraph = p,
+                            Text = item.Text,
+                            CurrentFileName = item.CurrentFileName,
+                            SpeedFactor = 1.0f,
+                            Voice = item.Voice,
+                            EngineName = item.EngineName,
+                            Model = item.Model,
+                            Instruction = item.Instruction,
+                        });
                         continue;
                     }
 
@@ -3387,7 +3424,33 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             IsEngineSettingsVisible = false;
             IsModelDownloadVisible = false;
-            var voices = await engine.GetVoices(SelectedLanguage?.Code ?? string.Empty);
+
+            // Engine capability flags first, and never skipped: when the voice load below fails
+            // or returns nothing (missing API key, no network), the user must still get the new
+            // engine's own fields (API key, region, model, ...) to fix the cause. The old flow
+            // returned early on an empty voice list, leaving every panel flag - and the voice
+            // list itself - describing the *previous* engine, so Generate could then hand the
+            // wrong engine's Voice object to Speak.
+            HasLanguageParameter = engine.HasLanguageParameter;
+            HasApiKey = engine.HasApiKey;
+            HasRegion = engine.HasRegion;
+            HasModel = engine.HasModel;
+            HasKeyFile = engine.HasKeyFile;
+            IsEdgeTtsEngine = engine is EdgeTts;
+
+            Voice[] voices;
+            try
+            {
+                voices = await engine.GetVoices(SelectedLanguage?.Code ?? string.Empty);
+            }
+            catch (Exception ex)
+            {
+                // PostSafe used to swallow this, skipping the whole engine switch. Show an empty
+                // voice list for the new engine instead of the previous engine's voices.
+                SeLogger.Error(ex, $"Loading voices for {engine.Name} failed");
+                voices = [];
+            }
+
             Voices.Clear();
             foreach (var vo in voices)
             {
@@ -3402,20 +3465,13 @@ public partial class TextToSpeechViewModel : ObservableObject
                                                        p.Name.Contains("English", StringComparison.OrdinalIgnoreCase));
             }
             SelectedVoice = lastVoice ?? Voices.FirstOrDefault();
-            if (SelectedVoice == null)
+
+            if (SelectedVoice != null)
             {
-                return;
+                ApplyInstructionForEngine(engine);
             }
 
-            HasLanguageParameter = engine.HasLanguageParameter;
-            HasApiKey = engine.HasApiKey;
-            HasRegion = engine.HasRegion;
-            HasModel = engine.HasModel;
-            HasKeyFile = engine.HasKeyFile;
-            IsEdgeTtsEngine = engine is EdgeTts;
-            ApplyInstructionForEngine(engine);
-
-            if (HasLanguageParameter)
+            if (HasLanguageParameter && SelectedVoice != null)
             {
                 var languages = await engine.GetLanguages(SelectedVoice, SelectedModel);
                 Languages.Clear();

--- a/src/ui/Features/Video/TextToSpeech/TtsPostProcessor.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsPostProcessor.cs
@@ -32,10 +32,7 @@ public static class TtsPostProcessor
                 var proProcess = FfmpegGenerator.ApplyProAudioChain(currentFile, proChainOutput);
                 await proProcess.StartAndWaitAsync(cancellationToken);
 
-                if (File.Exists(proChainOutput))
-                {
-                    currentFile = proChainOutput;
-                }
+                currentFile = AdoptStageOutput(currentFile, proChainOutput, "pro audio chain");
             }
 
             if (cancellationToken.IsCancellationRequested)
@@ -54,10 +51,7 @@ public static class TtsPostProcessor
                 await concatProcess.StartAndWaitAsync(cancellationToken);
 
                 SafeDelete(silenceFile);
-                if (File.Exists(paddedOutput))
-                {
-                    currentFile = paddedOutput;
-                }
+                currentFile = AdoptStageOutput(currentFile, paddedOutput, "silence padding");
             }
 
             if (cancellationToken.IsCancellationRequested)
@@ -71,10 +65,7 @@ public static class TtsPostProcessor
                 var srProcess = FfmpegGenerator.ChangeSampleRate(currentFile, resampledOutput, outputSampleRate);
                 await srProcess.StartAndWaitAsync(cancellationToken);
 
-                if (File.Exists(resampledOutput))
-                {
-                    currentFile = resampledOutput;
-                }
+                currentFile = AdoptStageOutput(currentFile, resampledOutput, "sample rate conversion");
             }
 
             return currentFile;
@@ -83,6 +74,26 @@ public static class TtsPostProcessor
         {
             return currentFile;
         }
+    }
+
+    /// <summary>
+    /// Adopts a stage's ffmpeg output when it was actually produced (exists and is non-empty -
+    /// a bare Exists check used to adopt zero-byte files from mid-run ffmpeg failures), deleting
+    /// the superseded input so a long run doesn't pile up one stale intermediate per stage per
+    /// line. A failed stage keeps the input and is force-logged - it used to be silently skipped,
+    /// leaving the user's enabled option quietly unapplied with no trace.
+    /// </summary>
+    private static string AdoptStageOutput(string inputFile, string outputFile, string stageName)
+    {
+        if (File.Exists(outputFile) && new FileInfo(outputFile).Length > 0)
+        {
+            SafeDelete(inputFile);
+            return outputFile;
+        }
+
+        Se.WriteToolsLog($"TTS post-processing: {stageName} produced no output for \"{inputFile}\" - stage skipped (ffmpeg failure?)", true);
+        SafeDelete(outputFile);
+        return inputFile;
     }
 
     private static void SafeDelete(string fileName)

--- a/src/ui/Logic/Download/TtsDownloadService.cs
+++ b/src/ui/Logic/Download/TtsDownloadService.cs
@@ -25,7 +25,7 @@ public interface ITtsDownloadService
     Task DownloadPiperVoice(string modelUrl, MemoryStream downloadStream, Progress<float> downloadProgress, CancellationToken token);
     Task DownloadPiperVoiceList(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
     Task DownloadAllTalkVoiceList(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
-    Task<string> AllTalkVoiceSpeak(string text, AllTalkVoice voice, string language);
+    Task<string> AllTalkVoiceSpeak(string text, AllTalkVoice voice, string language, CancellationToken cancellationToken);
     Task<bool> AllTalkIsInstalled();
     Task DownloadElevenLabsVoiceList(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
     Task DownloadAzureVoiceList(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
@@ -132,11 +132,13 @@ public class TtsDownloadService : ITtsDownloadService
         await DownloadHelper.DownloadFileAsync(_httpClient, url, stream, progress, cancellationToken);
     }
 
-    public async Task<string> AllTalkVoiceSpeak(string inputText, AllTalkVoice voice, string language)
+    public async Task<string> AllTalkVoiceSpeak(string inputText, AllTalkVoice voice, string language, CancellationToken cancellationToken)
     {
         using var multipartContent = new MultipartFormDataContent();
         var text = Utilities.UnbreakLine(inputText);
-        multipartContent.Add(new StringContent(Json.EncodeJsonText(text)), "text_input");
+        // Plain multipart form field - no JSON escaping: Json.EncodeJsonText turned quotes and
+        // backslashes into \" and \\ that AllTalk then spoke/mangled.
+        multipartContent.Add(new StringContent(text), "text_input");
         multipartContent.Add(new StringContent("standard"), "text_filtering");
         multipartContent.Add(new StringContent(voice.Voice), "character_voice_gen");
         multipartContent.Add(new StringContent("false"), "narrator_enabled");
@@ -151,14 +153,16 @@ public class TtsDownloadService : ITtsDownloadService
         HttpResponseMessage result;
         try
         {
-            result = await _httpClient.PostAsync(Se.Settings.Video.TextToSpeech.AllTalkUrl.TrimEnd('/') + "/api/tts-generate", multipartContent);
+            // Honor the caller's token - a bulk-generate Cancel used to leave the AllTalk
+            // request running to completion.
+            result = await _httpClient.PostAsync(Se.Settings.Video.TextToSpeech.AllTalkUrl.TrimEnd('/') + "/api/tts-generate", multipartContent, cancellationToken);
         }
         catch (HttpRequestException ex)
         {
             SeLogger.Error(ex, "AllTalk TTS server connection failed.");
             throw new HttpRequestException("AllTalk TTS server is not reachable. Please check that the server is running.", ex);
         }
-        catch (TaskCanceledException ex) when (!ex.CancellationToken.IsCancellationRequested)
+        catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
         {
             SeLogger.Error(ex, "AllTalk TTS server request timed out.");
             throw new HttpRequestException("AllTalk TTS server request timed out. Please check that the server is running.", ex);
@@ -168,12 +172,12 @@ public class TtsDownloadService : ITtsDownloadService
         {
             if (!result.IsSuccessStatusCode)
             {
-                var errorBody = await result.Content.ReadAsStringAsync();
+                var errorBody = await result.Content.ReadAsStringAsync(cancellationToken);
                 SeLogger.Error($"AllTalk TTS failed calling API at {_httpClient.BaseAddress}: Status code={result.StatusCode}" + Environment.NewLine + errorBody);
                 throw new HttpRequestException($"AllTalk TTS server returned error {(int)result.StatusCode} ({result.StatusCode}).");
             }
 
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
             var resultJson = Encoding.UTF8.GetString(bytes);
 
             var jsonParser = new SeJsonParser();
@@ -213,12 +217,19 @@ public class TtsDownloadService : ITtsDownloadService
         }
 
         var result = await _httpClient.SendAsync(requestMessage, cancellationToken);
-        await result.Content.CopyToAsync(ms, cancellationToken);
 
+        // Throw on failure instead of copying the error body into the stream: the caller writes
+        // the stream over its cached voice-list JSON, and since the bundled fallback only kicks
+        // in when the file is *missing*, one failed refresh (expired key, network error) used to
+        // permanently empty the voice list.
         if (!result.IsSuccessStatusCode)
         {
-            SeLogger.Error($"ElevenLabs TTS failed calling API address {url} : Status code={result.StatusCode}");
+            var error = (await result.Content.ReadAsStringAsync(cancellationToken)).Trim();
+            SeLogger.Error($"ElevenLabs TTS failed calling API address {url} : Status code={result.StatusCode} {TruncateForLog(error)}");
+            throw new HttpRequestException($"ElevenLabs voice list request failed: HTTP {(int)result.StatusCode} {result.StatusCode}");
         }
+
+        await result.Content.CopyToAsync(ms, cancellationToken);
     }
 
     public async Task DownloadMurfVoiceList(MemoryStream ms, IProgress<float>? progress, CancellationToken cancellationToken)
@@ -227,17 +238,20 @@ public class TtsDownloadService : ITtsDownloadService
 
         using var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
         requestMessage.Headers.TryAddWithoutValidation("Content-Type", "application/json");
-        requestMessage.Headers.TryAddWithoutValidation("Accept", "audio/mpeg");
+        requestMessage.Headers.TryAddWithoutValidation("Accept", "application/json");
         requestMessage.Headers.TryAddWithoutValidation("api-key", Se.Settings.Video.TextToSpeech.MurfApiKey);
 
         var result = await _httpClient.SendAsync(requestMessage, cancellationToken);
-        await result.Content.CopyToAsync(ms, cancellationToken);
 
+        // See DownloadElevenLabsVoiceList: an error body must not reach the cached voice list.
         if (!result.IsSuccessStatusCode)
         {
-            var error = Encoding.UTF8.GetString(ms.ToArray()).Trim();
-            SeLogger.Error($"Murf TTS failed calling API address {url} : Status code={result.StatusCode} {error}");
+            var error = (await result.Content.ReadAsStringAsync(cancellationToken)).Trim();
+            SeLogger.Error($"Murf TTS failed calling API address {url} : Status code={result.StatusCode} {TruncateForLog(error)}");
+            throw new HttpRequestException($"Murf voice list request failed: HTTP {(int)result.StatusCode} {result.StatusCode}");
         }
+
+        await result.Content.CopyToAsync(ms, cancellationToken);
     }
 
     public async Task DownloadAzureVoiceList(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
@@ -422,7 +436,11 @@ public class TtsDownloadService : ITtsDownloadService
 
         var text = Utilities.UnbreakLine(inputText);
 
-        var data = $"<speak version='1.0' xml:lang='en-US'><voice xml:lang='en-US' xml:gender='{voice.Gender}' name='{voice.ShortName}'>{System.Net.WebUtility.HtmlEncode(text)}</voice></speak>";
+        // Use the voice's own locale in the SSML instead of hardcoded en-US - the voice name
+        // usually wins, but a mismatched xml:lang can affect pronunciation of locale-ambiguous
+        // text (numbers, dates) for non-English voices.
+        var locale = string.IsNullOrWhiteSpace(voice.Locale) ? "en-US" : voice.Locale;
+        var data = $"<speak version='1.0' xml:lang='{locale}'><voice xml:lang='{locale}' xml:gender='{voice.Gender}' name='{voice.ShortName}'>{System.Net.WebUtility.HtmlEncode(text)}</voice></speak>";
         using var requestMessage = new HttpRequestMessage(HttpMethod.Post, url);
         requestMessage.Content = new StringContent(data, Encoding.UTF8);
 
@@ -663,10 +681,13 @@ public class TtsDownloadService : ITtsDownloadService
 
         var result = await _httpClient.SendAsync(requestMessage, cancellationToken);
 
+        // Throw instead of returning with an empty stream: the caller writes the stream over its
+        // cached voice-list JSON, so a silently failed refresh permanently emptied the voice list
+        // (the bundled fallback only restores when the file is missing).
         if (!result.IsSuccessStatusCode)
         {
             SeLogger.Error($"Mistral TTS failed calling API address {url} : Status code={result.StatusCode}");
-            return;
+            throw new HttpRequestException($"Mistral voice list request failed: HTTP {(int)result.StatusCode} {result.StatusCode}");
         }
 
         await result.Content.CopyToAsync(ms, cancellationToken);


### PR DESCRIPTION
Consolidated landing of the remaining bug-hunt stack. GitHub closed the stacked PRs #12100/#12101/#12102 when the batch-1 base branch was deleted on merge, and closed PRs cannot be retargeted or reopened - this PR carries their three commits unchanged (one commit per batch, full details in each commit message and in the original PR descriptions):

- **Batch 2** (#12100): cancellation kills child processes, Test Voice token isolation, TTS window timer disposal, history-dialog CTS renewal, regenerate catch/rollback/gating.
- **Batch 3** (#12101): review-window playback state machine (playing-row tracking, mpv lock race, wedge-proofing), history SpeedFactor restore, regenerate snapshotting, portable export/import round-trip.
- **Batch 4** (#12102): voice-list refresh hardening (ElevenLabs/Murf/Mistral), engine-switch consistency, FixSpeed keep-original, TtsPostProcessor logging/cleanup, Google/AllTalk/Azure/ElevenLabs engine nits.

UI builds clean; all 525 UI tests pass; app smoke-launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)