### PR TITLE
TTS: fix 20 confirmed findings from the second-pass bug hunt

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceMappingViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceMappingViewModel.cs
@@ -353,9 +353,12 @@ public partial class ActorVoiceMappingViewModel : ObservableObject
         try
         {
             row.IsPlaying = true;
+            // Pass the row's model - with null, model-dependent engines either tested the wrong
+            // (globally saved) model or failed outright. Language/region stay null; engines fall
+            // back to their own saved defaults for those.
             var result = await TtsInstructionSwap.RunAsync(row.SelectedEngine, row.Instruction, () =>
                 row.SelectedEngine.Speak(Utilities.UnbreakLine(_voiceTestText), _waveFolder, row.SelectedVoice,
-                    null, null, null, _cancellationTokenSource.Token));
+                    null, null, row.SelectedModel, _cancellationTokenSource.Token));
 
             if (!_cancellationTokenSource.IsCancellationRequested && File.Exists(result.FileName))
             {

--- a/src/ui/Features/Video/TextToSpeech/Engines/AzureSpeech.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/AzureSpeech.cs
@@ -140,10 +140,26 @@ public class AzureSpeech : ITtsEngine
             throw new ArgumentException("Voice is not an AzureVoice");
         }
 
+        // Callers pass null region/model when this engine is not the globally selected one
+        // (per-actor cast rows, cast-dialog voice test) - fall back to the saved settings
+        // instead of dereferencing null into the request URL, which produced a nonsense host
+        // (https://.tts.speech...) and aborted the whole generation run.
+        if (string.IsNullOrWhiteSpace(region))
+        {
+            region = Se.Settings.Video.TextToSpeech.AzureRegion;
+        }
+
+        if (string.IsNullOrWhiteSpace(region))
+        {
+            var error = "Azure region is not set - enter it in the Azure engine settings.";
+            Se.WriteToolsLog("AzureSpeech: " + error, true);
+            return new TtsResult { Text = text, FileName = string.Empty, Error = true, ErrorMessage = error };
+        }
+
         Se.WriteToolsLog($"AzureSpeech: voice={azureVoice.ShortName}, locale={azureVoice.Locale}, region={region}, model={model}, textLen={text.Length}");
 
         var ms = new MemoryStream();
-        var ok = await _ttsDownloadService.DownloadAzureVoiceSpeak(text, azureVoice, model!, Se.Settings.Video.TextToSpeech.AzureApiKey, "en", region!, ms, null, cancellationToken);
+        var ok = await _ttsDownloadService.DownloadAzureVoiceSpeak(text, azureVoice, model ?? string.Empty, Se.Settings.Video.TextToSpeech.AzureApiKey, "en", region, ms, null, cancellationToken);
         if (!ok)
         {
             Se.WriteToolsLog($"AzureSpeech: request failed (voice={azureVoice.ShortName}, region={region})");

--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
@@ -311,7 +311,18 @@ public class CosyVoice3CrispAsr : ITtsEngine
                     var sidecarDest = Path.ChangeExtension(dest, ".txt");
                     if (!File.Exists(sidecarDest))
                     {
-                        try { File.Copy(sidecar, sidecarDest); } catch { }
+                        // The qwen3-tts.cpp voice pack's .txt sidecars are Wikimedia attribution
+                        // blurbs, not spoken transcriptions - used as ref-text they produce
+                        // runaway, off-voice output, and being non-empty they also defeat the
+                        // missing-transcription prompt. Same filter Qwen3 (CrispASR) applies.
+                        try
+                        {
+                            if (!Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(File.ReadAllText(sidecar)))
+                            {
+                                File.Copy(sidecar, sidecarDest);
+                            }
+                        }
+                        catch { }
                     }
                 }
             }

--- a/src/ui/Features/Video/TextToSpeech/Engines/EdgeTts.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/EdgeTts.cs
@@ -124,8 +124,8 @@ public class EdgeTts : ITtsEngine
 
         var folder = GetSetEdgeTtsFolder();
         var fileName = Path.Combine(folder, Guid.NewGuid() + ".mp3");
-        var escapedText = text.Replace("\"", "\\\"");
-        var escapedVoice = edgeVoice.Name.Replace("\"", "\\\"");
+        var escapedText = EscapeQuotedArgValue(text);
+        var escapedVoice = EscapeQuotedArgValue(edgeVoice.Name);
         var args =
             $"--voice \"{escapedVoice}\" --text \"{escapedText}\" --write-media \"{fileName}\"";
 
@@ -188,6 +188,42 @@ public class EdgeTts : ITtsEngine
         }
 
         return new TtsResult { Text = text, FileName = string.Empty, Error = true };
+    }
+
+    /// <summary>
+    /// Escapes a value for use inside a quoted command-line argument ("{value}") per the
+    /// MSVCRT/.NET parsing rules: quotes are backslash-escaped, and any run of backslashes
+    /// immediately preceding a quote (or the end of the value, where our closing quote follows)
+    /// is doubled. Escaping only quotes used to let a line *ending* in a backslash produce \",
+    /// turning the closing quote into a literal and swallowing the following --write-media
+    /// argument - failing the segment through all retries.
+    /// </summary>
+    internal static string EscapeQuotedArgValue(string value)
+    {
+        var sb = new StringBuilder(value.Length + 8);
+        var backslashes = 0;
+        foreach (var ch in value)
+        {
+            if (ch == '\\')
+            {
+                backslashes++;
+                continue;
+            }
+
+            if (ch == '"')
+            {
+                sb.Append('\\', backslashes * 2 + 1).Append('"');
+            }
+            else
+            {
+                sb.Append('\\', backslashes).Append(ch);
+            }
+
+            backslashes = 0;
+        }
+
+        sb.Append('\\', backslashes * 2);
+        return sb.ToString();
     }
 
     // Strip the --text "..." value from the logged command so subtitle content

--- a/src/ui/Features/Video/TextToSpeech/Engines/ElevenLabs.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ElevenLabs.cs
@@ -281,9 +281,17 @@ public class ElevenLabs : ITtsEngine
             throw new ArgumentException("Voice is not an ElevenLabVoice");
         }
 
+        // Callers pass null when this engine is not the globally selected one (per-actor cast
+        // rows, cast-dialog voice test) - fall back to the saved/default model instead of
+        // throwing, which aborted the whole generation run at the first ElevenLabs row.
         if (string.IsNullOrEmpty(model))
         {
-            throw new ArgumentException("ElevenLabs model is empty");
+            model = Se.Settings.Video.TextToSpeech.ElevenLabsModel;
+        }
+
+        if (string.IsNullOrEmpty(model))
+        {
+            model = "eleven_multilingual_v2";
         }
 
         Se.WriteToolsLog($"ElevenLabs: voice={elevenLabVoice.Voice}, voiceId={elevenLabVoice.VoiceId}, model={model}, textLen={text.Length}");

--- a/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
@@ -257,7 +257,18 @@ public class F5TtsCrispAsr : ITtsEngine
                     var sidecarDest = Path.ChangeExtension(dest, ".txt");
                     if (!File.Exists(sidecarDest))
                     {
-                        try { File.Copy(sidecar, sidecarDest); } catch { }
+                        // The qwen3-tts.cpp voice pack's .txt sidecars are Wikimedia attribution
+                        // blurbs, not spoken transcriptions - used as ref-text they produce
+                        // runaway, off-voice output, and being non-empty they also defeat the
+                        // missing-transcription prompt. Same filter Qwen3 (CrispASR) applies.
+                        try
+                        {
+                            if (!Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(File.ReadAllText(sidecar)))
+                            {
+                                File.Copy(sidecar, sidecarDest);
+                            }
+                        }
+                        catch { }
                     }
                 }
             }

--- a/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
@@ -285,7 +285,18 @@ public class VoxCPM2CrispAsr : ITtsEngine
                     var sidecarDest = Path.ChangeExtension(dest, ".txt");
                     if (!File.Exists(sidecarDest))
                     {
-                        try { File.Copy(sidecar, sidecarDest); } catch { }
+                        // The qwen3-tts.cpp voice pack's .txt sidecars are Wikimedia attribution
+                        // blurbs, not spoken transcriptions - used as ref-text they produce
+                        // runaway, off-voice output, and being non-empty they also defeat the
+                        // missing-transcription prompt. Same filter Qwen3 (CrispASR) applies.
+                        try
+                        {
+                            if (!Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(File.ReadAllText(sidecar)))
+                            {
+                                File.Copy(sidecar, sidecarDest);
+                            }
+                        }
+                        catch { }
                     }
                 }
             }

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -196,6 +196,15 @@ public partial class ReviewSpeechViewModel : ObservableObject
             {
                 await Dispatcher.UIThread.InvokeAsync(async () =>
                 {
+                    // Re-check on the UI thread: Stop/Space pressed between this tick's threadpool
+                    // checks and this lambda running used to be ignored - the advance started a
+                    // fresh mpv for the next row while the UI had already reset to idle, leaving
+                    // audio playing with nothing able to stop it.
+                    if (_skipAutoContinue || _cancellationTokenSource.IsCancellationRequested || !ReferenceEquals(_playingRow, line))
+                    {
+                        return;
+                    }
+
                     line.IsPlaying = false;
                     var index = Lines.IndexOf(line);
                     if (index >= 0 && index < Lines.Count - 1)
@@ -313,7 +322,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
         {
             var row = new ReviewRow
             {
-                Include = true,
+                Include = p.Include,
                 Number = p.Paragraph.Number,
                 Text = p.Text,
                 Voice = p.Voice == null ? string.Empty : p.Voice.ToString(),
@@ -509,7 +518,14 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 targetFileName = string.Empty;
             }
 
-            if (!string.IsNullOrEmpty(targetFileName) && File.Exists(targetFileName))
+            // Re-exporting to the folder the session was imported from makes source and target
+            // the SAME file (import resolves names against the JSON folder). The overwrite path
+            // then deleted the target - destroying the source - and the copy threw with the
+            // audio gone and no JSON written. An identical path needs no copy at all.
+            var sourceIsTarget = !string.IsNullOrEmpty(targetFileName) &&
+                                 string.Equals(Path.GetFullPath(sourceFileName), Path.GetFullPath(targetFileName), StringComparison.OrdinalIgnoreCase);
+
+            if (!sourceIsTarget && !string.IsNullOrEmpty(targetFileName) && File.Exists(targetFileName))
             {
                 try
                 {
@@ -527,7 +543,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 }
             }
 
-            if (!string.IsNullOrEmpty(targetFileName))
+            if (!sourceIsTarget && !string.IsNullOrEmpty(targetFileName))
             {
                 File.Copy(sourceFileName, targetFileName, true);
             }
@@ -716,158 +732,169 @@ public partial class ReviewSpeechViewModel : ObservableObject
             return;
         }
 
-        var isEngineInstalled = await engine.IsInstalled(SelectedRegion);
-        if (!isEngineInstalled)
-        {
-            return;
-        }
-
-        if (!await TtsVoiceInstaller.EnsureVoiceInstalled(engine, voice, Window, _windowService))
-        {
-            return;
-        }
-
+        // Gate the whole grid BEFORE the engine probes below: IsInstalled / EnsureVoiceInstalled
+        // can take seconds (process spawn, HTTP), and with the gate applied only after them a
+        // second regenerate or a play started in that window swapped the shared cancellation
+        // source under this run. The per-row play/regenerate buttons, Ctrl+R and the Space
+        // shortcut all honor IsPlayingEnabled; OK/Export/Escape honor IsRegenerateEnabled.
+        // The outer try/finally guarantees the gate is lifted on every exit, including the
+        // engine-probe early returns.
         IsRegenerateEnabled = false;
-
-        // Gate the whole grid: the regenerate popup is non-modal, and starting a play or a
-        // second regenerate mid-run swapped the shared cancellation source under the first one.
-        // The per-row play/regenerate buttons, Ctrl+R and the Space shortcut all honor
-        // IsPlayingEnabled, so this closes every entry point at once.
         foreach (var l in Lines)
         {
             l.IsPlayingEnabled = false;
         }
 
-        var oldStyle = SelectedStyle;
-        if (engine is Murf && !string.IsNullOrEmpty(SelectedStyle))
-        {
-            Se.Settings.Video.TextToSpeech.MurfStyle = SelectedStyle;
-        }
-
-        var generatingAudioVm = _windowService.ShowWindow<GeneratingAudioWindow, GeneratingAudioViewModel>(Window!);
-        ReplaceCts(generatingAudioVm.CancellationTokenSource);
-
-        // Snapshot the panel state this regenerate runs with: the progress popup is non-modal,
-        // so clicking another row mid-run rewrites SelectedModel/Instruction (via the row-click
-        // panel sync) - reading them after the awaits recorded settings that never produced the
-        // audio into the row snapshot and its history entry.
-        var model = SelectedModel;
-        var instruction = Instruction;
-        var language = SelectedLanguage;
-        var region = SelectedRegion;
-
-        // The row's live StepResult must only change once the whole regenerate pipeline has
-        // succeeded - it used to be mutated right after Speak, so a cancel or a failed
-        // trim/post-process left the row half-updated (raw un-stretched clip with the old
-        // speed/voice display) and OK/Export published that state.
-        var originalFileName = line.StepResult.CurrentFileName;
-        var originalVoice = line.StepResult.Voice;
-
         try
         {
-            var speakResult = await TtsInstructionSwap.RunAsync(engine, instruction, () =>
-                engine.Speak(Utilities.UnbreakLine(line.Text), _waveFolder, voice, language, region, model, _cancellationToken));
-
-            if (speakResult.Error || string.IsNullOrEmpty(speakResult.FileName) || !File.Exists(speakResult.FileName))
+            var isEngineInstalled = await engine.IsInstalled(SelectedRegion);
+            if (!isEngineInstalled)
             {
-                if (Window != null)
-                {
-                    var detail = string.IsNullOrEmpty(speakResult.ErrorMessage)
-                        ? "The engine produced no audio - see error-log.txt in the Subtitle Edit data folder."
-                        : speakResult.ErrorMessage;
-                    await MessageBox.Show(
-                        Window,
-                        Se.Language.General.Error,
-                        "Regenerating audio failed: " + detail,
-                        MessageBoxButtons.OK,
-                        MessageBoxIcon.Error);
-                }
-
                 return;
             }
 
-            line.StepResult.CurrentFileName = speakResult.FileName;
-            line.StepResult.Voice = voice;
-
-            var adjustSpeedStepResult = await TrimAndAdjustSpeed(line);
-            var postProcessedFileName = await TtsPostProcessor.ApplyPostProcessing(adjustSpeedStepResult.CurrentFileName, _waveFolder, _cancellationToken);
-
-            if (_cancellationToken.IsCancellationRequested)
+            if (!await TtsVoiceInstaller.EnsureVoiceInstalled(engine, voice, Window, _windowService))
             {
+                return;
+            }
+
+            // Capture the *saved* style, not SelectedStyle: capturing the new value made the
+            // finally-block restore a no-op, so a one-line style override silently became the
+            // permanent global Murf style.
+            var oldStyle = Se.Settings.Video.TextToSpeech.MurfStyle;
+            if (engine is Murf && !string.IsNullOrEmpty(SelectedStyle))
+            {
+                Se.Settings.Video.TextToSpeech.MurfStyle = SelectedStyle;
+            }
+
+            var generatingAudioVm = _windowService.ShowWindow<GeneratingAudioWindow, GeneratingAudioViewModel>(Window!);
+            ReplaceCts(generatingAudioVm.CancellationTokenSource);
+
+            // Snapshot the panel state this regenerate runs with: the progress popup is non-modal,
+            // so clicking another row mid-run rewrites SelectedModel/Instruction (via the row-click
+            // panel sync) - reading them after the awaits recorded settings that never produced the
+            // audio into the row snapshot and its history entry.
+            var model = SelectedModel;
+            var instruction = Instruction;
+            var language = SelectedLanguage;
+            var region = SelectedRegion;
+
+            // The row's live StepResult must only change once the whole regenerate pipeline has
+            // succeeded - it used to be mutated right after Speak, so a cancel or a failed
+            // trim/post-process left the row half-updated (raw un-stretched clip with the old
+            // speed/voice display) and OK/Export published that state.
+            var originalFileName = line.StepResult.CurrentFileName;
+            var originalVoice = line.StepResult.Voice;
+
+            try
+            {
+                var speakResult = await TtsInstructionSwap.RunAsync(engine, instruction, () =>
+                    engine.Speak(Utilities.UnbreakLine(line.Text), _waveFolder, voice, language, region, model, _cancellationToken));
+
+                if (speakResult.Error || string.IsNullOrEmpty(speakResult.FileName) || !File.Exists(speakResult.FileName))
+                {
+                    if (Window != null)
+                    {
+                        var detail = string.IsNullOrEmpty(speakResult.ErrorMessage)
+                            ? "The engine produced no audio - see error-log.txt in the Subtitle Edit data folder."
+                            : speakResult.ErrorMessage;
+                        await MessageBox.Show(
+                            Window,
+                            Se.Language.General.Error,
+                            "Regenerating audio failed: " + detail,
+                            MessageBoxButtons.OK,
+                            MessageBoxIcon.Error);
+                    }
+
+                    return;
+                }
+
+                line.StepResult.CurrentFileName = speakResult.FileName;
+                line.StepResult.Voice = voice;
+
+                var adjustSpeedStepResult = await TrimAndAdjustSpeed(line);
+                var postProcessedFileName = await TtsPostProcessor.ApplyPostProcessing(adjustSpeedStepResult.CurrentFileName, _waveFolder, _cancellationToken);
+
+                if (_cancellationToken.IsCancellationRequested)
+                {
+                    line.StepResult.CurrentFileName = originalFileName;
+                    line.StepResult.Voice = originalVoice;
+                    return;
+                }
+
+                adjustSpeedStepResult.CurrentFileName = postProcessedFileName;
+                // Record which engine/model/instruction this regenerate used so the row's "click to
+                // sync left panel" feature can restore them later.
+                adjustSpeedStepResult.EngineName = engine.Name;
+                adjustSpeedStepResult.Model = model ?? string.Empty;
+                adjustSpeedStepResult.Instruction = instruction ?? string.Empty;
+                line.Speed = Math.Round(adjustSpeedStepResult.SpeedFactor, 2).ToString(CultureInfo.CurrentCulture);
+                line.Cps = Math.Round(adjustSpeedStepResult.Paragraph.GetCharactersPerSecond(), 2).ToString(CultureInfo.CurrentCulture);
+                line.StepResult = adjustSpeedStepResult;
+                line.Voice = voice.ToString();
+
+                line.AddHistory(voice, line.StepResult.CurrentFileName, engine.Name, model ?? string.Empty, instruction ?? string.Empty);
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancel in the GeneratingAudio popup: Speak and the ffmpeg steps surface it as a
+                // throw (it used to escape as an unhandled exception). Undo the partial row update.
                 line.StepResult.CurrentFileName = originalFileName;
                 line.StepResult.Voice = originalVoice;
                 return;
             }
-
-            adjustSpeedStepResult.CurrentFileName = postProcessedFileName;
-            // Record which engine/model/instruction this regenerate used so the row's "click to
-            // sync left panel" feature can restore them later.
-            adjustSpeedStepResult.EngineName = engine.Name;
-            adjustSpeedStepResult.Model = model ?? string.Empty;
-            adjustSpeedStepResult.Instruction = instruction ?? string.Empty;
-            line.Speed = Math.Round(adjustSpeedStepResult.SpeedFactor, 2).ToString(CultureInfo.CurrentCulture);
-            line.Cps = Math.Round(adjustSpeedStepResult.Paragraph.GetCharactersPerSecond(), 2).ToString(CultureInfo.CurrentCulture);
-            line.StepResult = adjustSpeedStepResult;
-            line.Voice = voice.ToString();
-
-            line.AddHistory(voice, line.StepResult.CurrentFileName, engine.Name, model ?? string.Empty, instruction ?? string.Empty);
-        }
-        catch (OperationCanceledException)
-        {
-            // Cancel in the GeneratingAudio popup: Speak and the ffmpeg steps surface it as a
-            // throw (it used to escape as an unhandled exception). Undo the partial row update.
-            line.StepResult.CurrentFileName = originalFileName;
-            line.StepResult.Voice = originalVoice;
-            return;
-        }
-        catch (HttpRequestException ex)
-        {
-            line.StepResult.CurrentFileName = originalFileName;
-            line.StepResult.Voice = originalVoice;
-            SeLogger.Error(ex, "TTS server error during regeneration.");
-            if (Window != null)
+            catch (HttpRequestException ex)
             {
-                await MessageBox.Show(
-                    Window,
-                    Se.Language.General.Error,
-                    "TTS server error: " + ex.Message,
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Error);
+                line.StepResult.CurrentFileName = originalFileName;
+                line.StepResult.Voice = originalVoice;
+                SeLogger.Error(ex, "TTS server error during regeneration.");
+                if (Window != null)
+                {
+                    await MessageBox.Show(
+                        Window,
+                        Se.Language.General.Error,
+                        "TTS server error: " + ex.Message,
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
+                }
+                return;
             }
-            return;
-        }
-        catch (Exception ex)
-        {
-            line.StepResult.CurrentFileName = originalFileName;
-            line.StepResult.Voice = originalVoice;
-            SeLogger.Error(ex, "Regenerating audio failed.");
-            if (Window != null)
+            catch (Exception ex)
             {
-                await MessageBox.Show(
-                    Window,
-                    Se.Language.General.Error,
-                    "Regenerating audio failed: " + ex.Message,
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Error);
+                line.StepResult.CurrentFileName = originalFileName;
+                line.StepResult.Voice = originalVoice;
+                SeLogger.Error(ex, "Regenerating audio failed.");
+                if (Window != null)
+                {
+                    await MessageBox.Show(
+                        Window,
+                        Se.Language.General.Error,
+                        "Regenerating audio failed: " + ex.Message,
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
+                }
+                return;
             }
-            return;
+            finally
+            {
+                generatingAudioVm.Close();
+                if (engine is Murf && oldStyle != null)
+                {
+                    Se.Settings.Video.TextToSpeech.MurfStyle = oldStyle;
+                }
+            }
+
+            _skipAutoContinue = true;
+            await PlayAudio(line.StepResult.CurrentFileName);
         }
         finally
         {
-            generatingAudioVm.Close();
             IsRegenerateEnabled = true;
             foreach (var l in Lines)
             {
                 l.IsPlayingEnabled = true;
             }
-            if (engine is Murf && oldStyle != null)
-            {
-                Se.Settings.Video.TextToSpeech.MurfStyle = oldStyle;
-            }
         }
-
-        _skipAutoContinue = true;
-        await PlayAudio(line.StepResult.CurrentFileName);
     }
 
     [RelayCommand]
@@ -965,13 +992,17 @@ public partial class ReviewSpeechViewModel : ObservableObject
         var vadMaxSilence = Se.Settings.Video.TextToSpeech.VadMaxSilenceSeconds;
         var doHighQualityStretch = Se.Settings.Video.TextToSpeech.HighQualityTimeStretchEnabled;
 
-        // Step 1: Trim silence from start and end
+        // Step 1: Trim silence from start and end. A failed trim (misconfigured/failing ffmpeg)
+        // must fall back to the untrimmed audio - adopting the missing output blindly made
+        // FfmpegMediaInfo.Parse below return a null Duration and the factor math NRE'd.
         var outputFileNameTrim = Path.Combine(_waveFolder, Guid.NewGuid() + ".wav");
         _tempAudioFiles.Add(outputFileNameTrim);
         var trimProcess = FfmpegGenerator.TrimSilenceStartAndEnd(item.CurrentFileName, outputFileNameTrim);
         await trimProcess.StartAndWaitAsync(_cancellationToken);
 
-        var currentFile = outputFileNameTrim;
+        var currentFile = File.Exists(outputFileNameTrim) && new FileInfo(outputFileNameTrim).Length > 0
+            ? outputFileNameTrim
+            : item.CurrentFileName;
 
         // Step 2: VAD-based internal silence compression
         if (doVad)
@@ -999,7 +1030,9 @@ public partial class ReviewSpeechViewModel : ObservableObject
         }
 
         var mediaInfo = FfmpegMediaInfo.Parse(currentFile);
-        if (mediaInfo.Duration.TotalMilliseconds <= p.DurationTotalMilliseconds + addDuration)
+        // Duration is null when ffmpeg could not read the file - keep the audio unstretched
+        // (same policy as the main pipeline) instead of NRE'ing into the generic error dialog.
+        if (mediaInfo.Duration == null || mediaInfo.Duration.TotalMilliseconds <= p.DurationTotalMilliseconds + addDuration)
         {
             return new TtsStepResult
             {
@@ -1078,6 +1111,14 @@ public partial class ReviewSpeechViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            // Closing mid-regenerate would publish/roll back a half-updated row and delete temp
+            // files under the running pipeline - the window buttons are disabled for the same
+            // reason; cancel the regenerate from its own popup instead.
+            if (!IsRegenerateEnabled)
+            {
+                return;
+            }
+
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))
@@ -1214,7 +1255,21 @@ public partial class ReviewSpeechViewModel : ObservableObject
             return;
         }
 
-        var voices = await engine.GetVoices(SelectedLanguage?.Code ?? string.Empty);
+        // Guarded like the main window's engine switch: a throwing GetVoices was swallowed by
+        // PostSafe and Voices.First() on an empty list (e.g. Qwen3 voice-clone model with no
+        // imported reference WAVs) threw - either way the panel was left half-switched with the
+        // previous engine's voices, and Regenerate handed the wrong engine's Voice to Speak.
+        Voice[] voices;
+        try
+        {
+            voices = await engine.GetVoices(SelectedLanguage?.Code ?? string.Empty);
+        }
+        catch (Exception ex)
+        {
+            SeLogger.Error(ex, $"ReviewSpeech: loading voices for {engine.Name} failed");
+            voices = [];
+        }
+
         Voices.Clear();
         foreach (var vo in voices)
         {
@@ -1228,9 +1283,9 @@ public partial class ReviewSpeechViewModel : ObservableObject
                                                   p.Name.Contains("English", StringComparison.OrdinalIgnoreCase));
         }
 
-        SelectedVoice = lastVoice ?? Voices.First();
+        SelectedVoice = lastVoice ?? Voices.FirstOrDefault();
 
-        if (engine.HasLanguageParameter)
+        if (engine.HasLanguageParameter && SelectedVoice != null)
         {
             var languages = await engine.GetLanguages(SelectedVoice, null); // SelectedModel);
             Languages.Clear();

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
@@ -37,9 +37,11 @@ public class ReviewSpeechWindow : Window
         var dataGrid = MakeDataGrid(vm);
         var waveform = MakeWaveform(vm);
 
-        var buttonExport = UiUtil.MakeButton(Se.Language.General.ExportDotDotDot, vm.ExportCommand);
-        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
-        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        // Disabled while a regenerate runs: its progress popup is non-modal, and publishing
+        // (OK/Export) or closing mid-run would commit the row's half-updated step result.
+        var buttonExport = UiUtil.MakeButton(Se.Language.General.ExportDotDotDot, vm.ExportCommand).WithBindEnabled(nameof(vm.IsRegenerateEnabled));
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand).WithBindEnabled(nameof(vm.IsRegenerateEnabled));
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand).WithBindEnabled(nameof(vm.IsRegenerateEnabled));
         var panelButtons = UiUtil.MakeButtonBar(buttonExport, buttonOk, buttonCancel);
 
         var grid = new Grid

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeechHistory/ReviewSpeechHistoryViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeechHistory/ReviewSpeechHistoryViewModel.cs
@@ -1,12 +1,17 @@
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ReviewSpeech;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 using System;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
@@ -44,25 +49,23 @@ public partial class ReviewSpeechHistoryViewModel : ObservableObject
     {
         _timer.Stop();
 
-        if (_cancellationTokenSource.IsCancellationRequested || _mpvContext == null)
+        // Same shape as the review window's watchdog: read mpv state under the lock (the
+        // null check used to happen outside it, racing the dispose in OnWindowClosing) and
+        // decide first, act after - the row properties are UI-bound and must be set on the
+        // dispatcher, not on this threadpool thread.
+        var stop = false;
+        lock (_playLock)
         {
-            lock (_playLock)
+            if (_cancellationTokenSource.IsCancellationRequested || _mpvContext == null || _mpvContext.IsPaused)
             {
-                StopPlay();
-                return;
+                stop = true;
             }
         }
-        else if (_mpvContext != null)
+
+        if (stop)
         {
-            lock (_playLock)
-            {
-                var paused = _mpvContext.IsPaused;
-                if (paused)
-                {
-                    StopPlay();
-                    return;
-                }
-            }
+            Dispatcher.UIThread.Post(StopPlay);
+            return;
         }
 
         _timer.Start();
@@ -70,9 +73,13 @@ public partial class ReviewSpeechHistoryViewModel : ObservableObject
 
     private void StopPlay()
     {
-        _mpvContext?.Stop();
-        _mpvContext?.Dispose();
-        _mpvContext = null;
+        lock (_playLock)
+        {
+            _mpvContext?.Stop();
+            _mpvContext?.Dispose();
+            _mpvContext = null;
+        }
+
         foreach (ReviewHistoryRow row in HistoryItems)
         {
             row.IsPlaying = false;
@@ -124,6 +131,25 @@ public partial class ReviewSpeechHistoryViewModel : ObservableObject
     {
         if (item == null)
         {
+            return;
+        }
+
+        // A history entry can point at a missing file (exported without audio, cleaned temp
+        // folder). mpv's failed loadfile is fire-and-forget, so playing it wedged the dialog in
+        // "playing" with every row disabled for its lifetime.
+        if (string.IsNullOrEmpty(item.FileName) || !File.Exists(item.FileName))
+        {
+            SeLogger.Error($"ReviewSpeechHistory: cannot play missing audio file \"{item.FileName}\"");
+            if (Window != null)
+            {
+                await MessageBox.Show(
+                    Window,
+                    Se.Language.General.Error,
+                    "The audio file for this history entry does not exist:" + Environment.NewLine + item.FileName,
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+
             return;
         }
 

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1600,6 +1600,7 @@ public partial class TextToSpeechViewModel : ObservableObject
                 EngineName = item.EngineName ?? string.Empty,
                 Model = item.Model ?? string.Empty,
                 Instruction = item.Instruction ?? string.Empty,
+                Include = item.Include,
             });
         }
 
@@ -1669,14 +1670,23 @@ public partial class TextToSpeechViewModel : ObservableObject
             return string.Empty;
         }
 
-        if (Path.IsPathRooted(audioFileName))
+        // A Windows drive path ("C:\...") is not rooted on Unix, so Path.IsPathRooted alone let
+        // legacy Windows exports opened on macOS/Linux fall through to a garbage
+        // jsonFolder + "C:\..." combine - skipping the sibling retry that would find the file.
+        var isWindowsAbsolute = audioFileName.Length >= 3 && char.IsLetter(audioFileName[0])
+            && audioFileName[1] == ':' && (audioFileName[2] == '\\' || audioFileName[2] == '/');
+
+        if (Path.IsPathRooted(audioFileName) || isWindowsAbsolute)
         {
             if (File.Exists(audioFileName))
             {
                 return audioFileName;
             }
 
-            var siblingFileName = Path.Combine(jsonFolder, Path.GetFileName(audioFileName));
+            // Path.GetFileName does not treat '\' as a separator on Unix - split on both.
+            var separatorIndex = Math.Max(audioFileName.LastIndexOf('\\'), audioFileName.LastIndexOf('/'));
+            var name = separatorIndex >= 0 ? audioFileName.Substring(separatorIndex + 1) : audioFileName;
+            var siblingFileName = Path.Combine(jsonFolder, name);
             return File.Exists(siblingFileName) ? siblingFileName : audioFileName;
         }
 
@@ -2537,6 +2547,14 @@ public partial class TextToSpeechViewModel : ObservableObject
         ProgressText = Se.Language.Video.TextToSpeech.AddingAudioToVideoFileDotDotDot;
         var outputFileName = Path.Combine(outputFolder, Path.GetFileNameWithoutExtension(audioFileName) + videoExt);
 
+        // Never let the output collide with the source video: picking the video's own folder as
+        // the output folder can make the paths identical, and ffmpeg runs with -y - depending on
+        // the build that either aborts or *truncates the user's source video* before reading it.
+        if (string.Equals(Path.GetFullPath(outputFileName), Path.GetFullPath(_videoFileName), StringComparison.OrdinalIgnoreCase))
+        {
+            outputFileName = Path.Combine(outputFolder, Path.GetFileNameWithoutExtension(audioFileName) + "_tts" + videoExt);
+        }
+
         var useCustomAudioEncoding = !string.IsNullOrEmpty(Se.Settings.Video.TextToSpeech.CustomAudioEncoding);
         var audioEncoding = Se.Settings.Video.TextToSpeech.CustomAudioEncoding;
         if (string.IsNullOrWhiteSpace(audioEncoding) || !useCustomAudioEncoding)
@@ -2996,21 +3014,27 @@ public partial class TextToSpeechViewModel : ObservableObject
         // many TTS engines otherwise insert weird pauses on \r\n.
         var text = Utilities.UnbreakLine(rawText);
 
+        // Fallbacks must carry the panel's instruction, not "": TtsInstructionSwap swaps the
+        // engine's saved instruction to whatever is passed here for the duration of the Speak
+        // call, so an empty fallback silently wiped the user's typed voice-design instruction
+        // for every line without an actor mapping - i.e. for every line of a normal subtitle.
+        var globalInstruction = Instruction ?? string.Empty;
+
         if (string.IsNullOrEmpty(actor) || !ctx.ByActor.TryGetValue(actor, out var mapping))
         {
-            return new ResolvedVoice(defaultEngine, defaultVoice, null, text, string.Empty);
+            return new ResolvedVoice(defaultEngine, defaultVoice, null, text, globalInstruction);
         }
 
         if (!ctx.EnginesByName.TryGetValue(mapping.EngineName, out var mappedEngine)
             || !ctx.VoicesByEngine.TryGetValue(mapping.EngineName, out var voices))
         {
-            return new ResolvedVoice(defaultEngine, defaultVoice, null, text, string.Empty);
+            return new ResolvedVoice(defaultEngine, defaultVoice, null, text, globalInstruction);
         }
 
         var mappedVoice = voices.FirstOrDefault(v => string.Equals(v.Name, mapping.VoiceName, StringComparison.OrdinalIgnoreCase));
         if (mappedVoice == null)
         {
-            return new ResolvedVoice(defaultEngine, defaultVoice, null, text, string.Empty);
+            return new ResolvedVoice(defaultEngine, defaultVoice, null, text, globalInstruction);
         }
 
         // Per-row model overrides the global one; empty string means "use the global model".
@@ -3460,6 +3484,9 @@ public partial class TextToSpeechViewModel : ObservableObject
                 Voices.Add(vo);
             }
             VoiceCount = Voices.Count;
+            // The label binds VoiceCountInfo; only VoiceCount was ever written, so the voice
+            // count next to the combo stayed permanently blank.
+            VoiceCountInfo = Voices.Count.ToString(System.Globalization.CultureInfo.InvariantCulture);
 
             var lastVoice = Voices.FirstOrDefault(v => v.Name == Se.Settings.Video.TextToSpeech.Voice);
             if (lastVoice == null)
@@ -3469,10 +3496,10 @@ public partial class TextToSpeechViewModel : ObservableObject
             }
             SelectedVoice = lastVoice ?? Voices.FirstOrDefault();
 
-            if (SelectedVoice != null)
-            {
-                ApplyInstructionForEngine(engine);
-            }
+            // Unconditional (handles a null voice fine): gating this on a loaded voice left the
+            // previous engine's instruction box and voice-combo lock in place when the new
+            // engine's voice list failed to load or was empty.
+            ApplyInstructionForEngine(engine);
 
             if (HasLanguageParameter && SelectedVoice != null)
             {
@@ -3488,6 +3515,13 @@ public partial class TextToSpeechViewModel : ObservableObject
                 SelectedLanguage = engine is OmniVoiceTtsCpp
                     ? Languages.FirstOrDefault(l => l.Code == "en") ?? Languages.FirstOrDefault()
                     : Languages.FirstOrDefault();
+            }
+            else if (SelectedVoice == null)
+            {
+                // No voices for the new engine - don't keep listing the previous engine's
+                // languages next to it.
+                Languages.Clear();
+                SelectedLanguage = null;
             }
 
             if (HasRegion)
@@ -3667,6 +3701,15 @@ public partial class TextToSpeechViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            // Escape during a run cancels the run (like the Cancel button) instead of closing
+            // the window over a live pipeline - closing also fires StopAllCrispAsrServers,
+            // killing the engine server an in-flight Speak is talking to.
+            if (IsGenerating)
+            {
+                _cancellationTokenSource?.Cancel();
+                return;
+            }
+
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))
@@ -3678,6 +3721,11 @@ public partial class TextToSpeechViewModel : ObservableObject
 
     internal void OnClosing(WindowClosingEventArgs e)
     {
+        // Title-bar close during a run: cancel the pipeline so it unwinds instead of running
+        // headless against a closed window (progress writes, folder picker, message boxes) while
+        // StopAllCrispAsrServers below kills the engine server it is talking to.
+        try { _cancellationTokenSource?.Cancel(); } catch (ObjectDisposedException) { }
+
         // An enabled System.Timers.Timer is rooted: without stopping it here, every open/close
         // of this window leaked a view model whose Elapsed handler kept firing every 100 ms for
         // the rest of the session (ReviewSpeechViewModel already does this on close).

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -45,9 +45,15 @@ public class TextToSpeechWindow : Window
             VerticalAlignment = VerticalAlignment.Bottom,
         };
 
+        // Frozen while generating: the pipeline reads SelectedLanguage/Region/Model live per
+        // segment, so changing engine/model/language mid-run made the remaining segments use
+        // the new values (or silently ended the run when the engine switch left SelectedVoice
+        // transiently null).
         var engineLayout = MakeEngineControls(vm);
+        engineLayout.Bind(InputElement.IsEnabledProperty, new Binding(nameof(vm.IsNotGenerating)));
 
         var settingsLayout = MakeSettingsControls(vm);
+        settingsLayout.Bind(InputElement.IsEnabledProperty, new Binding(nameof(vm.IsNotGenerating)));
 
         // Wrap the progress bar layout in WidthIgnoringPanel so its measured width never feeds
         // back up into the outer grid's column sizing. See the panel's class comment for why.

--- a/src/ui/Features/Video/TextToSpeech/TtsPostProcessor.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsPostProcessor.cs
@@ -74,6 +74,16 @@ public static class TtsPostProcessor
         {
             return currentFile;
         }
+        catch (Exception ex)
+        {
+            // Must not escape: AdoptStageOutput deletes the superseded input on each successful
+            // stage, so callers that fall back to their *original* file on an exception would
+            // point at a file a completed earlier stage already deleted. Returning the last
+            // adopted file keeps the audio chain intact.
+            SeLogger.Error(ex, "TTS post-processing failed - keeping the last successfully processed file");
+            Se.WriteToolsLog($"TTS post-processing failed ({ex.Message}) - keeping \"{currentFile}\"", true);
+            return currentFile;
+        }
     }
 
     /// <summary>

--- a/src/ui/Features/Video/TextToSpeech/TtsStepResult.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsStepResult.cs
@@ -19,6 +19,10 @@ public class TtsStepResult
     public string Model { get; set; }
     public string Instruction { get; set; }
 
+    // Whether the review window's Include checkbox is/was ticked for this line. Defaults to
+    // true; carried through import so an exported session's unchecked rows stay unchecked.
+    public bool Include { get; set; }
+
     public TtsStepResult()
     {
         Paragraph = new Paragraph();
@@ -28,5 +32,6 @@ public class TtsStepResult
         EngineName = string.Empty;
         Model = string.Empty;
         Instruction = string.Empty;
+        Include = true;
     }
 }

--- a/src/ui/Logic/Download/TtsDownloadService.cs
+++ b/src/ui/Logic/Download/TtsDownloadService.cs
@@ -513,6 +513,16 @@ public class TtsDownloadService : ITtsDownloadService
 
         var parser = new SeJsonParser();
         var fileUrl = parser.GetFirstObject(Encoding.UTF8.GetString(ms.ToArray()), "audioFile");
+
+        // A 200 response without an audioFile URL (schema change, quota message) would make
+        // GetAsync throw on a null/empty URI and abort the whole generation run instead of
+        // failing this one segment.
+        if (string.IsNullOrWhiteSpace(fileUrl) || !Uri.TryCreate(fileUrl, UriKind.Absolute, out _))
+        {
+            SeLogger.Error($"Murf TTS returned no usable audioFile URL (\"{fileUrl}\") - response: {TruncateForLog(Encoding.UTF8.GetString(ms.ToArray()).Trim())}");
+            return false;
+        }
+
         var audioResult = await _httpClient.GetAsync(fileUrl, cancellationToken);
         if (!audioResult.IsSuccessStatusCode)
         {


### PR DESCRIPTION
Second-pass hunt over the post-fix TTS code: four parallel reviewers targeting both regressions from the recent fix series and previously missed bugs. **Good news first: none of the recent fixes regressed** — the reviewers explicitly verified the retry/backoff helper, kill-on-cancel at every call site, the post-processor deletions vs. history references, the throwing voice-list downloads at every caller, and the playing-row state machine. Everything below is either pre-existing or a gap the first pass missed. All 20 findings were verified against the code before fixing.

## Feature breakage

- **The voice-design instruction was silently ignored for every generated line** — `ResolveVoiceForParagraph`'s fallbacks returned `""` and `TtsInstructionSwap` swapped the engine's saved instruction to that for each call. Test Voice worked; Generate didn't. The most user-visible find of the hunt.
- Murf style save/restore in review regenerate was a no-op (captured the new value) — a one-line override permanently became the global setting.
- Cast dialog "Test" passed a null model (ElevenLabs/Azure rows always failed); cross-engine cast rows aborted the *whole run* on Azure (null region → nonsense URL) or ElevenLabs (throw on null model) — both engines now fall back to saved settings.
- F5-TTS/CosyVoice3/VoxCPM2 voice seeding copied Wikimedia attribution blurbs as cloning transcripts (runaway, off-voice output) — now filtered with Qwen3 (CrispASR)'s existing blurb detector.
- The voice-count label bound a property nothing wrote; Import dropped the exported Include flags.

## Data loss / crashes

- **Re-exporting to the folder a session was imported from destroyed the audio** (source == target: delete-then-copy) — identical paths now skip the copy.
- Add-to-video could target the source video itself (with `-y`, some ffmpeg builds truncate the input) — output name uniquified.
- Legacy Windows exports opened on macOS/Linux resolved to garbage paths (`Path.IsPathRooted("C:\\...")` is false on Unix) — the sibling-retry now handles them.
- Murf 200-without-audioFile aborted the run; review regenerate NRE'd on unreadable trim output; `TtsPostProcessor` exceptions stranded callers on a deleted file; EdgeTts argument quoting broke on trailing backslashes (proper MSVCRT-style escaping now).

## Races and mid-run interaction

- Review regenerate's grid gate started only after two awaited engine probes — a play/second regenerate in that window swapped the shared CTS under the run; the gate now applies first with a try/finally on every exit, and **OK/Export/Cancel/Escape are disabled during a regenerate** (they could publish a half-updated row).
- Stop at a clip boundary was ignored by the queued auto-advance (fresh mpv kept playing with the UI reset to idle) — the advance re-checks on the UI thread.
- Closing the TTS window mid-generation left the pipeline running headless and killed the engine server under it — Escape now cancels the run; close cancels the pipeline.
- The engine/settings panel stayed editable during generation while the pipeline reads model/language live per segment — frozen while generating.
- The review window's engine switch and the history dialog each still had bugs fixed elsewhere in earlier batches (unguarded `GetVoices`/`First()`, missing-file wedge, threadpool UI mutation) — now aligned.

## Deferred (noted, not fixed)

- Qwen3 (CrispASR) cast mappings resolve against the globally saved model's voice list — real, but needs per-row-model voice loading in the cast context (design change).
- `AllTalk.IsInstalled` caches `true` for the process lifetime (errors surface at Speak time — acceptable).

## Testing

UI builds clean; all 525 UI tests pass; app smoke-launches on macOS. The audio-path fixes (instruction fallback, blurb filter, cross-engine fallbacks) deserve a real Windows TTS run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)