### PR TITLE
TTS: fix 17 findings from the third-pass bug hunt (incl. two regressions from the previous round)

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceMappingViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceMappingViewModel.cs
@@ -360,10 +360,28 @@ public partial class ActorVoiceMappingViewModel : ObservableObject
                 row.SelectedEngine.Speak(Utilities.UnbreakLine(_voiceTestText), _waveFolder, row.SelectedVoice,
                     null, null, row.SelectedModel, _cancellationTokenSource.Token));
 
-            if (!_cancellationTokenSource.IsCancellationRequested && File.Exists(result.FileName))
+            if (_cancellationTokenSource.IsCancellationRequested)
             {
-                await PlayAudio(result.FileName);
+                return;
             }
+
+            // Engine-reported failures (Error result with empty file name) used to close the
+            // spinner and do nothing - e.g. Azure's "region is not set" or an ElevenLabs 429
+            // just looked like a dead button. Surface the engine's reason.
+            if (result.Error || !File.Exists(result.FileName))
+            {
+                if (Window != null)
+                {
+                    var detail = string.IsNullOrEmpty(result.ErrorMessage)
+                        ? "The engine produced no audio - see error-log.txt in the Subtitle Edit data folder."
+                        : result.ErrorMessage;
+                    await MessageBox.Show(Window, Se.Language.General.Error, "Test voice failed: " + detail, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+
+                return;
+            }
+
+            await PlayAudio(result.FileName);
         }
         catch (OperationCanceledException)
         {

--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
@@ -414,7 +414,16 @@ public class CosyVoice3CrispAsr : ITtsEngine
         try
         {
             var sidecar = Path.ChangeExtension(wavPath, ".txt");
-            return File.Exists(sidecar) ? File.ReadAllText(sidecar).Trim() : string.Empty;
+            if (!File.Exists(sidecar))
+            {
+                return string.Empty;
+            }
+
+            // Sidecars written by pre-filter seeding can be Wikimedia attribution blurbs, not
+            // transcriptions - treat them as "no transcript" (same read-time filter Qwen3
+            // CrispASR applies) so they neither poison ref-text nor suppress the prompt.
+            var text = File.ReadAllText(sidecar).Trim();
+            return Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(text) ? string.Empty : text;
         }
         catch
         {
@@ -449,22 +458,27 @@ public class CosyVoice3CrispAsr : ITtsEngine
 
         // Either Preset OR FilePath must be set. Preset wins if both are populated (defensive
         // — shouldn't happen with the constructors but guards against future drift).
+        // Error results, not throws: a throw from Speak escapes the generate loop's per-segment
+        // handling and aborts the entire run - reachable from cast rows and the review window,
+        // where the main window's transcript prompt never had a chance to fire.
         var voiceArg = !string.IsNullOrEmpty(cosyVoice.Preset) ? cosyVoice.Preset : cosyVoice.FilePath;
         if (string.IsNullOrEmpty(voiceArg))
         {
-            throw new InvalidOperationException(
-                "CosyVoice3 (CrispASR) requires a preset or an imported reference WAV. "
+            var error = "CosyVoice3 (CrispASR) requires a preset or an imported reference WAV. "
                 + "Pick one of the baked presets (zero_shot / fleurs-*) or import a 16 kHz mono "
-                + "reference WAV with an adjacent .txt transcription sidecar.");
+                + "reference WAV with an adjacent .txt transcription sidecar.";
+            Se.WriteToolsLog("CosyVoice3 (CrispASR): " + error, true);
+            return new TtsResult { Text = text, FileName = string.Empty, Error = true, ErrorMessage = error };
         }
 
         var isClone = string.IsNullOrEmpty(cosyVoice.Preset);
         if (isClone && string.IsNullOrEmpty(cosyVoice.RefText))
         {
-            throw new InvalidOperationException(
-                $"CosyVoice3 (CrispASR) zero-shot cloning requires a transcription. "
+            var error = "CosyVoice3 (CrispASR) zero-shot cloning requires a transcription. "
                 + $"Add a .txt sidecar next to '{Path.GetFileName(cosyVoice.FilePath)}' with the "
-                + "spoken text of the reference WAV.");
+                + "spoken text of the reference WAV.";
+            Se.WriteToolsLog("CosyVoice3 (CrispASR): " + error, true);
+            return new TtsResult { Text = text, FileName = string.Empty, Error = true, ErrorMessage = error };
         }
 
         var modelKey = ResolveModelKey(model);

--- a/src/ui/Features/Video/TextToSpeech/Engines/ElevenLabs.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ElevenLabs.cs
@@ -297,7 +297,7 @@ public class ElevenLabs : ITtsEngine
         Se.WriteToolsLog($"ElevenLabs: voice={elevenLabVoice.Voice}, voiceId={elevenLabVoice.VoiceId}, model={model}, textLen={text.Length}");
 
         var ms = new MemoryStream();
-        var (ok, error) = await _ttsDownloadService.DownloadElevenLabsVoiceSpeak(text, elevenLabVoice, model, Se.Settings.Video.TextToSpeech.ElevenLabsApiKey, language?.Code ?? "en", ms, null, cancellationToken);
+        var (ok, error) = await _ttsDownloadService.DownloadElevenLabsVoiceSpeak(text, elevenLabVoice, model, Se.Settings.Video.TextToSpeech.ElevenLabsApiKey, language?.Code ?? string.Empty, ms, null, cancellationToken);
         if (!ok)
         {
             // Forced: a failed API call must land in the tools log even when the setting is off,

--- a/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
@@ -468,7 +468,16 @@ public class F5TtsCrispAsr : ITtsEngine
         try
         {
             var sidecar = Path.ChangeExtension(wavPath, ".txt");
-            return File.Exists(sidecar) ? File.ReadAllText(sidecar).Trim() : string.Empty;
+            if (!File.Exists(sidecar))
+            {
+                return string.Empty;
+            }
+
+            // Sidecars written by pre-filter seeding can be Wikimedia attribution blurbs, not
+            // transcriptions - treat them as "no transcript" (same read-time filter Qwen3
+            // CrispASR applies) so they neither poison ref-text nor suppress the prompt.
+            var text = File.ReadAllText(sidecar).Trim();
+            return Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(text) ? string.Empty : text;
         }
         catch
         {

--- a/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
@@ -509,7 +509,16 @@ public class VoxCPM2CrispAsr : ITtsEngine
         try
         {
             var sidecar = Path.ChangeExtension(wavPath, ".txt");
-            return File.Exists(sidecar) ? File.ReadAllText(sidecar).Trim() : string.Empty;
+            if (!File.Exists(sidecar))
+            {
+                return string.Empty;
+            }
+
+            // Sidecars written by pre-filter seeding can be Wikimedia attribution blurbs, not
+            // transcriptions - treat them as "no transcript" (same read-time filter Qwen3
+            // CrispASR applies) so they neither poison ref-text nor suppress the prompt.
+            var text = File.ReadAllText(sidecar).Trim();
+            return Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(text) ? string.Empty : text;
         }
         catch
         {

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -50,7 +50,9 @@ public partial class ReviewSpeechViewModel : ObservableObject
     [ObservableProperty] private string? _selectedStyle;
     [ObservableProperty] private ObservableCollection<ReviewRow> _lines;
     [ObservableProperty] private ReviewRow? _selectedLine;
-    [ObservableProperty] private bool _isRegenerateEnabled;
+    // True whenever no regenerate is in flight. Must start true: OK/Export/Cancel and Escape
+    // are gated on it, and the default false left them dead until the first regenerate ran.
+    [ObservableProperty] private bool _isRegenerateEnabled = true;
     [ObservableProperty] private bool _isElevenLabsControlsVisible;
     [ObservableProperty] private bool _autoContinue;
     [ObservableProperty] private bool _isPlayVisible;
@@ -199,9 +201,13 @@ public partial class ReviewSpeechViewModel : ObservableObject
                     // Re-check on the UI thread: Stop/Space pressed between this tick's threadpool
                     // checks and this lambda running used to be ignored - the advance started a
                     // fresh mpv for the next row while the UI had already reset to idle, leaving
-                    // audio playing with nothing able to stop it.
+                    // audio playing with nothing able to stop it. The timer is already stopped and
+                    // this lambda is the last thing to run, so it must also reset the playback UI:
+                    // a bare return left the finished row's stop icon showing and every row
+                    // disabled, with no way to recover in the window.
                     if (_skipAutoContinue || _cancellationTokenSource.IsCancellationRequested || !ReferenceEquals(_playingRow, line))
                     {
+                        ResetPlaybackUiState();
                         return;
                     }
 
@@ -311,7 +317,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
         ITtsEngine[] engines,
         ITtsEngine engine,
         Voice[] voices,
-        Voice voice,
+        Voice? voice,
         TtsLanguage[] languages,
         TtsLanguage? language,
         string videoFileName,
@@ -494,7 +500,27 @@ public partial class ReviewSpeechViewModel : ObservableObject
             }
         }
 
-        // Copy files
+        // Copy files. Files still referenced by rows or their history entries must not be
+        // overwritten: re-exporting to the folder a session was imported from used to replace an
+        // original take (e.g. 0002.wav) that a history entry still pointed at - "pick from
+        // history" then played and published the wrong audio with no warning.
+        var referencedFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var l in Lines)
+        {
+            if (!string.IsNullOrEmpty(l.StepResult.CurrentFileName))
+            {
+                referencedFiles.Add(Path.GetFullPath(l.StepResult.CurrentFileName));
+            }
+
+            foreach (var h in l.HistoryItems)
+            {
+                if (!string.IsNullOrEmpty(h.FileName))
+                {
+                    referencedFiles.Add(Path.GetFullPath(h.FileName));
+                }
+            }
+        }
+
         var index = 0;
         var missingAudioCount = 0;
         var exportFormat = new TtsImportExport
@@ -524,6 +550,21 @@ public partial class ReviewSpeechViewModel : ObservableObject
             // audio gone and no JSON written. An identical path needs no copy at all.
             var sourceIsTarget = !string.IsNullOrEmpty(targetFileName) &&
                                  string.Equals(Path.GetFullPath(sourceFileName), Path.GetFullPath(targetFileName), StringComparison.OrdinalIgnoreCase);
+
+            // Divert to a suffixed name when the default target is a *different* file that a row
+            // or history entry still references.
+            if (!sourceIsTarget && !string.IsNullOrEmpty(targetFileName) && referencedFiles.Contains(Path.GetFullPath(targetFileName)))
+            {
+                var suffix = 1;
+                string candidate;
+                do
+                {
+                    candidate = Path.Combine(folder, $"{index.ToString().PadLeft(4, '0')}_{suffix}{Path.GetExtension((string?)sourceFileName)}");
+                    suffix++;
+                }
+                while (referencedFiles.Contains(Path.GetFullPath(candidate)) || File.Exists(candidate));
+                targetFileName = candidate;
+            }
 
             if (!sourceIsTarget && !string.IsNullOrEmpty(targetFileName) && File.Exists(targetFileName))
             {
@@ -1663,12 +1704,21 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
     internal void OnClosing(WindowClosingEventArgs e)
     {
+        // Title-bar X / Alt+F4 bypass the Escape guard, so a regenerate can still be in flight
+        // here. Cancel it, but leave its popup-owned CTS undisposed (the popup's Cancel button
+        // still holds it) and skip the temp-file sweep below - the unwinding pipeline may still
+        // be writing those files.
+        var regenerateInFlight = !IsRegenerateEnabled;
+
         _skipAutoContinue = true;
         _timer.Stop();
         _timer.Elapsed -= OnTimerOnElapsed;
         _timer.Dispose();
         try { _cancellationTokenSource.Cancel(); } catch (ObjectDisposedException) { }
-        try { _cancellationTokenSource.Dispose(); } catch (ObjectDisposedException) { }
+        if (!regenerateInFlight)
+        {
+            try { _cancellationTokenSource.Dispose(); } catch (ObjectDisposedException) { }
+        }
         lock (_playLock)
         {
             _mpvContext?.Dispose();
@@ -1695,19 +1745,22 @@ public partial class ReviewSpeechViewModel : ObservableObject
         var publishedFiles = OkPressed
             ? new HashSet<string>(StepResults.Select(r => r.CurrentFileName), StringComparer.OrdinalIgnoreCase)
             : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var f in _tempAudioFiles)
+        if (!regenerateInFlight)
         {
-            if (publishedFiles.Contains(f))
+            foreach (var f in _tempAudioFiles)
             {
-                continue;
-            }
+                if (publishedFiles.Contains(f))
+                {
+                    continue;
+                }
 
-            try { if (File.Exists(f))
-            {
-                File.Delete(f);
-            } } catch { /* ignore */ }
+                try { if (File.Exists(f))
+                {
+                    File.Delete(f);
+                } } catch { /* ignore */ }
+            }
+            _tempAudioFiles.Clear();
         }
-        _tempAudioFiles.Clear();
 
         UiUtil.SaveWindowPosition(Window);
     }

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
@@ -1,5 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Input;
@@ -110,23 +111,26 @@ public class ReviewSpeechWindow : Window
             VerticalAlignment = VerticalAlignment.Stretch,
             Columns =
             {
-                //new DataGridTemplateColumn
-                //{
-                //    Header = Se.Language.General.Enabled,
-                //    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                //    CellTemplate = new FuncDataTemplate<ReviewRow>((item, _) =>
-                //        new Border
-                //        {
-                //            Background = Brushes.Transparent, // Prevents highlighting
-                //            Padding = new Thickness(4),
-                //            Child = new CheckBox
-                //            {
-                //                [!ToggleButton.IsCheckedProperty] = new Binding(nameof(ReviewRow.Include)),
-                //                HorizontalAlignment = HorizontalAlignment.Center
-                //            }
-                //        }),
-                //    Width = new DataGridLength(1, DataGridLengthUnitType.Auto)
-                //},
+                // Re-enabled: OK publishes only rows with Include ticked and Export/Import
+                // round-trip the flag, so without this column an imported session's excluded
+                // rows were invisible and could never be re-included.
+                new DataGridTemplateColumn
+                {
+                    Header = Se.Language.General.Enabled,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    CellTemplate = new FuncDataTemplate<ReviewRow>((item, _) =>
+                        new Border
+                        {
+                            Background = Brushes.Transparent, // Prevents highlighting
+                            Padding = new Thickness(4),
+                            Child = new CheckBox
+                            {
+                                [!ToggleButton.IsCheckedProperty] = new Binding(nameof(ReviewRow.Include)),
+                                HorizontalAlignment = HorizontalAlignment.Center
+                            }
+                        }),
+                    Width = new DataGridLength(1, DataGridLengthUnitType.Auto)
+                },
                 new DataGridTemplateColumn
                 {
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeechHistory/ReviewSpeechHistoryViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeechHistory/ReviewSpeechHistoryViewModel.cs
@@ -105,11 +105,6 @@ public partial class ReviewSpeechHistoryViewModel : ObservableObject
 
         await _mpvContext.LoadAudio(fileName);
 
-        foreach (var row in HistoryItems)
-        {
-            row.IsPlayingEnabled = false;
-        }
-
         _timer.Start();
     }
 

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -657,7 +657,15 @@ public partial class TextToSpeechViewModel : ObservableObject
         try
         {
             var sidecar = Path.ChangeExtension(wavPath, ".txt");
-            return File.Exists(sidecar) ? File.ReadAllText(sidecar).Trim() : null;
+            if (!File.Exists(sidecar))
+            {
+                return null;
+            }
+
+            // An attribution-blurb sidecar (pre-filter seeding) is not a transcript - report it
+            // as missing so the transcript prompt still fires instead of being suppressed.
+            var text = File.ReadAllText(sidecar).Trim();
+            return Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(text) ? null : text;
         }
         catch
         {
@@ -1001,7 +1009,20 @@ public partial class TextToSpeechViewModel : ObservableObject
         }
 
         var voice = SelectedVoice;
-        if (voice != null && !await TtsVoiceInstaller.EnsureVoiceInstalled(engine, voice, Window, _windowService))
+        if (voice == null)
+        {
+            // A failed engine switch (network blip, missing API key) legitimately leaves the
+            // voice list empty now - without this, Generate ended instantly with no message.
+            await MessageBox.Show(
+                Window!,
+                Se.Language.General.Error,
+                "No voices are loaded for the selected engine - check the engine settings (e.g. API key) and re-select the engine to reload its voices.",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return;
+        }
+
+        if (!await TtsVoiceInstaller.EnsureVoiceInstalled(engine, voice, Window, _windowService))
         {
             return;
         }
@@ -1489,6 +1510,8 @@ public partial class TextToSpeechViewModel : ObservableObject
             Voices.Add(voice);
         }
         SelectedVoice = Voices.FirstOrDefault(v => v.Name == Se.Settings.Video.TextToSpeech.Voice) ?? Voices.FirstOrDefault();
+        VoiceCount = Voices.Count;
+        VoiceCountInfo = Voices.Count.ToString(System.Globalization.CultureInfo.InvariantCulture);
     }
 
     [RelayCommand]
@@ -1614,15 +1637,16 @@ public partial class TextToSpeechViewModel : ObservableObject
             _videoFileName = videoFileNameForReview;
         }
 
-        // The review window needs an engine and voice to offer regeneration. Voices can be empty
-        // when the selected engine's voice load failed (missing API key, network) - Voices.First()
-        // then threw and Import died with only a logged exception.
-        if (Engines.Count == 0 || Voices.Count == 0)
+        // The review window needs at least one engine to offer regeneration; an empty global
+        // voice list is fine (each imported line resolved its own engine's voices above, and
+        // the review window guards regenerate on a missing voice) - blocking on it rejected
+        // perfectly reviewable sessions whenever the *selected* engine's voice load failed.
+        if (Engines.Count == 0)
         {
             await MessageBox.Show(
                 Window,
                 Se.Language.General.Error,
-                "No voices are loaded for the selected engine - check the engine settings (e.g. API key) and try again.",
+                "No usable TTS engines are available - check the engine settings and try again.",
                 MessageBoxButtons.OK,
                 MessageBoxIcon.Error);
             return;
@@ -1640,7 +1664,7 @@ public partial class TextToSpeechViewModel : ObservableObject
                 Engines.ToArray(),
                 SelectedEngine ?? Engines.First(),
                 Voices.ToArray(),
-                SelectedVoice ?? Voices.First(),
+                SelectedVoice ?? Voices.FirstOrDefault(),
                 Languages.ToArray(),
                 SelectedLanguage,
                 videoFileNameForReview,
@@ -1670,13 +1694,14 @@ public partial class TextToSpeechViewModel : ObservableObject
             return string.Empty;
         }
 
-        // A Windows drive path ("C:\...") is not rooted on Unix, so Path.IsPathRooted alone let
-        // legacy Windows exports opened on macOS/Linux fall through to a garbage
-        // jsonFolder + "C:\..." combine - skipping the sibling retry that would find the file.
-        var isWindowsAbsolute = audioFileName.Length >= 3 && char.IsLetter(audioFileName[0])
-            && audioFileName[1] == ':' && (audioFileName[2] == '\\' || audioFileName[2] == '/');
+        // A Windows path is not recognized as rooted on Unix ("C:\...", "\\server\share\...",
+        // "\folder\..."), so Path.IsPathRooted alone let legacy Windows exports opened on
+        // macOS/Linux fall through to a garbage jsonFolder + "C:\..." combine - skipping the
+        // sibling retry that would find the file. New-format exports store bare file names
+        // (never containing a backslash), so any backslash marks a legacy Windows path.
+        var isLegacyWindowsPath = audioFileName.Contains('\\');
 
-        if (Path.IsPathRooted(audioFileName) || isWindowsAbsolute)
+        if (Path.IsPathRooted(audioFileName) || isLegacyWindowsPath)
         {
             if (File.Exists(audioFileName))
             {
@@ -3039,7 +3064,13 @@ public partial class TextToSpeechViewModel : ObservableObject
 
         // Per-row model overrides the global one; empty string means "use the global model".
         var modelOverride = string.IsNullOrWhiteSpace(mapping.Model) ? null : mapping.Model;
-        return new ResolvedVoice(mappedEngine, mappedVoice, modelOverride, text, mapping.Instruction ?? string.Empty);
+        // A mapped row with no instruction of its own, on the globally selected engine, follows
+        // the panel instruction - otherwise mapping an actor to the same engine/voice made that
+        // actor's lines drop the voice design every unmapped line gets.
+        var instruction = string.IsNullOrWhiteSpace(mapping.Instruction) && ReferenceEquals(mappedEngine, defaultEngine)
+            ? globalInstruction
+            : mapping.Instruction ?? string.Empty;
+        return new ResolvedVoice(mappedEngine, mappedVoice, modelOverride, text, instruction);
     }
 
     private async Task<TtsStepResult[]?> FixSpeed(TtsStepResult[] previousStepResult, CancellationToken cancellationToken)
@@ -3449,6 +3480,13 @@ public partial class TextToSpeechViewModel : ObservableObject
 
         Dispatcher.UIThread.PostSafe(async () =>
         {
+            // Captured before any SelectedModel assignment below: OnSelectedModelChanged
+            // persists the Qwen3 (CrispASR) model on every change, so the generic
+            // "SelectedModel = Models.FirstOrDefault()" default overwrote the saved model
+            // with "1.7B VoiceDesign" right before the engine block tried to restore it -
+            // the user's model choice never survived a window open or engine re-switch.
+            var savedQwen3CrispAsrModel = Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrModel;
+
             IsEngineSettingsVisible = false;
             IsModelDownloadVisible = false;
 
@@ -3588,7 +3626,7 @@ public partial class TextToSpeechViewModel : ObservableObject
             }
             else if (SelectedEngine is Qwen3TtsCrispAsr)
             {
-                SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrModel);
+                SelectedModel = Models.FirstOrDefault(p => p == savedQwen3CrispAsrModel);
                 if (string.IsNullOrEmpty(SelectedModel))
                 {
                     SelectedModel = Models.FirstOrDefault();

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -48,12 +48,13 @@ public class TextToSpeechWindow : Window
         // Frozen while generating: the pipeline reads SelectedLanguage/Region/Model live per
         // segment, so changing engine/model/language mid-run made the remaining segments use
         // the new values (or silently ended the run when the engine switch left SelectedVoice
-        // transiently null).
+        // transiently null). Only the engine panel - the settings panel's review/video
+        // checkboxes are read once after generation, and toggling them mid-run is useful
+        // (e.g. remembering to enable review during a long run).
         var engineLayout = MakeEngineControls(vm);
         engineLayout.Bind(InputElement.IsEnabledProperty, new Binding(nameof(vm.IsNotGenerating)));
 
         var settingsLayout = MakeSettingsControls(vm);
-        settingsLayout.Bind(InputElement.IsEnabledProperty, new Binding(nameof(vm.IsNotGenerating)));
 
         // Wrap the progress bar layout in WidthIgnoringPanel so its measured width never feeds
         // back up into the outer grid's column sizing. See the panel's class comment for why.

--- a/src/ui/Features/Video/TextToSpeech/TtsInstructionSwap.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsInstructionSwap.cs
@@ -46,13 +46,17 @@ public static class TtsInstructionSwap
         var s = Se.Settings.Video.TextToSpeech;
         switch (engine)
         {
+            // The captured previous value is coalesced to "": null doubles as Restore's
+            // "engine has no instruction field" sentinel, so a null saved setting (settings
+            // JSON with null, a binding writing null) would skip the restore and permanently
+            // commit the temporary per-line instruction to global settings.
             case Qwen3TtsCpp:
             case Qwen3TtsCrispAsr:
-                var prevQwen = s.Qwen3TtsCppInstruction;
+                var prevQwen = s.Qwen3TtsCppInstruction ?? string.Empty;
                 s.Qwen3TtsCppInstruction = instruction ?? string.Empty;
                 return prevQwen;
             case OmniVoiceTtsCpp:
-                var prevOmni = s.OmniVoiceTtsCppInstruction;
+                var prevOmni = s.OmniVoiceTtsCppInstruction ?? string.Empty;
                 s.OmniVoiceTtsCppInstruction = instruction ?? string.Empty;
                 return prevOmni;
             default:

--- a/src/ui/Logic/Download/TtsDownloadService.cs
+++ b/src/ui/Logic/Download/TtsDownloadService.cs
@@ -293,8 +293,11 @@ public class TtsDownloadService : ITtsDownloadService
         var url = "https://api.elevenlabs.io/v1/text-to-speech/" + voice.VoiceId;
         var text = Utilities.UnbreakLine(inputText);
 
+        // Only send language_code when the user actually picked a language: cross-engine cast
+        // rows pass none, and forcing "en" made ElevenLabs apply English normalization and
+        // pronunciation hints to non-English lines.
         var language = string.Empty;
-        if (model is "eleven_turbo_v2_5")
+        if (model is "eleven_turbo_v2_5" && !string.IsNullOrEmpty(languageCode))
         {
             language = $", \"language_code\": \"{languageCode}\"";
         }
@@ -410,10 +413,13 @@ public class TtsDownloadService : ITtsDownloadService
         var stability = Se.Settings.Video.TextToSpeech.ElevenLabsStability.ToString(CultureInfo.InvariantCulture);
         var speed = Se.Settings.Video.TextToSpeech.ElevenLabsSpeed.ToString(CultureInfo.InvariantCulture);
     
+        var languageFragment = string.IsNullOrEmpty(languageCode)
+            ? string.Empty
+            : "\"language_code\": \"" + languageCode + "\", ";
         var data = "{ \"inputs\": [{ " +
                    "\"text\": \"" + Json.EncodeJsonText(text) + "\", " +
                    "\"voice_id\": \"" + voice.VoiceId + "\", " +
-                   "\"language_code\": \"" + languageCode + "\", " +
+                   languageFragment +
                    "\"stability\": " + stability + ", " +
                    "\"speed\": " + speed +
                    " }] }";


### PR DESCRIPTION
Third-pass hunt over the TTS area, focused on regression-checking the 20 fixes from #12104. It earned its keep: **two genuine regressions from that round were caught and fixed**, along with follow-on gaps in three of its fixes and several pre-existing bugs.

## Regressions from #12104 (mine, caught by this pass)

- **`IsRegenerateEnabled` was never initialized** — the new OK/Export/Cancel bindings left the review window's bottom buttons dead (and Escape swallowed) until the first regenerate ran. OK/Export were unusable in the normal flow. *This alone justifies the re-run.*
- The auto-advance re-check could return with the watchdog already stopped, wedging the grid (stop icon stranded, all rows disabled).
- The settings panel was over-frozen during generation — only the engine panel's values are read live per segment; the review/video checkboxes are read once post-run and toggling them mid-run is useful.

## Follow-ons to previous fixes

- The blurb filter only ran at seed time; folders seeded by older builds kept poisoned sidecars. F5/CosyVoice3/VoxCPM2 and the transcript-prompt gate now filter at **read time** too (mirroring Qwen3 CrispASR).
- CosyVoice3's no-transcript throw aborted whole runs from cast rows/review — now per-segment error results.
- Cast "Test" swallowed engine error results (incl. the new Azure no-region message) — now shown.
- ElevenLabs no longer forces `language_code: en` when no language is selected (field omitted).
- The legacy-Windows import resolver now also handles UNC and drive-relative paths (any backslash marks a legacy path; new exports store bare names).
- The Include round-trip needed its UI back: **the review grid's commented-out "Enabled" checkbox column is re-enabled** (OK/Export honor the flag; without the column, imported excluded rows were invisible and immutable). *Flagging for veto if it was hidden deliberately.* Import is also no longer blocked when just the selected engine's voice list is empty.
- Title-bar X mid-regenerate bypassed the Escape guard (disposed the popup's CTS, swept temp files under the pipeline) — both now skipped while a regenerate runs.
- Generate/Test with an empty voice list ended silently — now a clear error with the remedy.

## Pre-existing bugs found this pass

- **Qwen3 (CrispASR) model choice never survived a window open/engine switch** — the generic model default fired the persistence handler, clobbering the saved model right before restoration. Saved value captured first.
- Stale voice-count label after model/refresh/Murf-language voice reloads.
- Cast rows with a blank instruction on the global engine dropped the panel's voice design (mapped actor sounded nothing like unmapped lines).
- Re-export to the import folder could overwrite audio a history entry still referenced — diverted to suffixed names.
- History dialog: rows disabled only after the async load (double-play dispose race); `TtsInstructionSwap` null-restore could permanently commit a temporary instruction.

## Deferred (product decisions)

Hidden stale VoiceDesign instruction carried into Qwen3 CustomVoice as "style" with no visible control; Qwen3 cast-mapping voice list keyed off the global model.

## Testing

UI builds clean; all 525 UI tests pass; app smoke-launches. The reviewers also explicitly verified clean: the EdgeTts escaping algorithm (checked against .NET's parser rules), the regenerate try/finally control flow, the Azure/ElevenLabs fallbacks, the Murf guard, the Include construction-site trace, the post-processor catch-all, and the add-to-video uniquify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)