### PR TITLE
Fix the remaining build warnings

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -16321,6 +16321,14 @@ public partial class MainViewModel :
     // 14-byte invalid file produced when these formats went through the text save path (#11910).
     private async Task<bool> SaveBinarySubtitle(IBinaryPersistableSubtitle binaryFormat, bool isAutoSave)
     {
+        // This is the save-to-existing-file path; without a file name there is nothing to write
+        // to (callers route to Save As first). The local also proves non-null to the compiler.
+        var fileName = _subtitleFileName;
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return false;
+        }
+
         try
         {
             // EBU STL needs a UI helper to resolve its header; reuse the same one as File > Export.
@@ -16330,17 +16338,17 @@ public partial class MainViewModel :
             }
 
             using var ms = new MemoryStream();
-            if (!binaryFormat.Save(_subtitleFileName, ms, GetUpdateSubtitle(true), batchMode: true))
+            if (!binaryFormat.Save(fileName, ms, GetUpdateSubtitle(true), batchMode: true))
             {
                 if (!isAutoSave)
                 {
-                    ShowStatus(string.Format(Se.Language.General.CouldNotSaveFileXErrorY, _subtitleFileName, string.Empty));
+                    ShowStatus(string.Format(Se.Language.General.CouldNotSaveFileXErrorY, fileName, string.Empty));
                 }
 
                 return false;
             }
 
-            await File.WriteAllBytesAsync(_subtitleFileName, ms.ToArray());
+            await File.WriteAllBytesAsync(fileName, ms.ToArray());
         }
         catch (Exception ex)
         {

--- a/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
@@ -51,10 +51,10 @@ public class AiReviewWindow : Window
             .WithAccessibleName(Se.Language.General.Url);
         var textBoxOpenAiModel = UiUtil.MakeTextBox(150, vm, nameof(vm.OpenAiCompatibleModel))
             .WithAccessibleName(Se.Language.General.Model);
-        textBoxOpenAiModel.Watermark = Se.Language.General.Model;
+        textBoxOpenAiModel.PlaceholderText = Se.Language.General.Model;
         var textBoxOpenAiApiKey = UiUtil.MakeTextBox(130, vm, nameof(vm.OpenAiCompatibleApiKey))
             .WithAccessibleName(Se.Language.General.ApiKey);
-        textBoxOpenAiApiKey.Watermark = Se.Language.General.ApiKey;
+        textBoxOpenAiApiKey.PlaceholderText = Se.Language.General.ApiKey;
         textBoxOpenAiApiKey.PasswordChar = '\u25cf';
         var panelOpenAiCompatible = new StackPanel
         {


### PR DESCRIPTION
Three warnings, zero remaining after this:

- **`CS8604`** in `MainViewModel.SaveBinarySubtitle`: possibly-null `_subtitleFileName` passed to `File.WriteAllBytesAsync`. Guarded up front — this is the save-to-existing-file path, so a missing file name returns false (callers route to Save As), and the non-null local satisfies the compiler for the whole method.
- **`CS0618`** ×2 in `AiReviewWindow`: `TextBox.Watermark` is obsolete → `PlaceholderText`.

Full solution builds warning-free; all 525 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)