### PR TITLE
Bump version to v5.1.0-beta6 and update change log

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -1,6 +1,26 @@
 
 Subtitle Edit Changelog
 
+v5.1.0-beta6 (3rd of July 2026)
+
+* Add SE4's "Column" list view shortcuts (delete text, delete text and shift up, insert text, paste, text up/down) - thx SiaL8er
+* Text to speech: fix stuck/silent generation - failures now show an error, cancel stops the running ffmpeg, and rate-limited ElevenLabs requests retry with backoff - thx cvrle77
+* Text to speech: fix export/import round-trip (import file filter, portable relative paths, missing-file handling) - thx cvrle77
+* Text to speech: large bug-fix pass across the engines and the review window (60+ fixes - voice-list refreshes no longer wipe cached voices, Azure/Piper voice refresh, Murf audio corruption, per-actor cast fixes, review playback/regenerate state fixes, the voice instruction is now applied when generating, Qwen3 model choice is persisted, and more)
+* Text to speech: play/stop the review window's selected line with the play/pause shortcut (Space) - thx cvrle77
+* Text to speech: the review window's Regenerate now offers the engine/model download prompts
+* Accessibility: fix Alt not activating the menu bar (e.g. with NVDA), and name splitters, waveform and Settings controls - thx Shaima-Almarzooqi
+* Make tool-dialog buttons consistent and fix "Remove text for HI" undo - thx mjuhasz
+* Fix seconv OCR (Tesseract/PaddleOCR) garbling non-ASCII output on Windows - thx Gorkycreator
+* Update Bulgarian translation - thx jekovcar
+* Update Czech translation - thx Matěj
+* Update Japanese translation - thx hisui3393
+* Update Korean translation - thx 12si27
+* Update Russian translation - thx jekovcar
+* Update Turkish translation - thx bilimiyorum
+
+-----------------------------------------------------------------------------------------------------
+
 v5.1.0-beta5 (2nd of July 2026)
 
 * Add AI review (Tools > AI review) - proofread subtitles with a local LLM via llama.cpp or Ollama, with a before/after grid and editable prompt

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.1.0-beta5",
+  "version": "v5.1.0-beta6",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -17,7 +17,7 @@ public class Se
 {
     internal const int CurrentMacOsFontMigrationVersion = 1;
 
-    public static string Version { get; set; } = "v5.1.0-beta5";
+    public static string Version { get; set; } = "v5.1.0-beta6";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Version bump (`Se.cs` + `English.json`) and the beta6 changelog section.

Entries were enumerated from the PR merge commits between the `v5.1.0-beta5` tag and HEAD (`git log v5.1.0-beta5..HEAD --first-parent`) — every merged PR and direct commit is either listed or deliberately folded:

- The ~10 TTS PRs (#12095–#12106 minus externals) are aggregated into six themed bullets credited to the #12093/#12088/#12087 reporters, rather than 60+ individual lines.
- #12108 (build-warning cleanup) and the language-tag fixup are omitted as internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)