### PR TITLE
Fix TTS import OK doing nothing + review window keyboard flow (#12093)

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -952,6 +952,10 @@ public partial class ReviewSpeechViewModel : ObservableObject
         _skipAutoContinue = false;
         _startPlayTicks = DateTime.UtcNow.Ticks;
 
+        // Playing a row selects it, so the keyboard (Space to replay, R to regenerate) always
+        // targets the line just heard - previously selection stayed on the old row (#12093).
+        SelectedLine = line;
+
         line.IsPlaying = true;
         _playingRow = line;
         foreach (var l in Lines)
@@ -1172,29 +1176,51 @@ public partial class ReviewSpeechViewModel : ObservableObject
         else if (e.Key == Key.R && e.KeyModifiers == KeyModifiers.Control)
         {
             e.Handled = true;
-            var line = SelectedLine;
-            if (line == null || line.IsPlaying || !line.IsPlayingEnabled)
-            {
-                return;
-            }
-
-            if (RegenerateAudioCommand.CanExecute(line))
-            {
-                RegenerateAudioCommand.Execute(line);
-            }
+            RegenerateSelectedLine();
         }
-        else if (MatchesPlayPauseShortcut(e))
+    }
+
+    /// <summary>
+    /// Tunnel-stage keys (see the window's AddHandler): play/pause and regenerate must fire
+    /// before the focused control gets the key, otherwise a focused button treats bare Space
+    /// as a click - the initially focused OK button then published the session (#12093).
+    /// </summary>
+    internal void OnPreviewKeyDown(KeyEventArgs e)
+    {
+        // A modifier-less key must still type into a focused text box; with modifiers held the
+        // shortcut works everywhere.
+        var isTextBoxFocused = Window?.FocusManager?.GetFocusedElement() is TextBox;
+
+        if (MatchesPlayPauseShortcut(e))
         {
-            // A modifier-less binding (the default bare Space) must still type into a focused text
-            // box; with modifiers held the shortcut works everywhere. Buttons are unaffected either
-            // way - they handle Space themselves before this window-level handler runs.
-            if (e.KeyModifiers == KeyModifiers.None && Window?.FocusManager?.GetFocusedElement() is TextBox)
+            if (e.KeyModifiers == KeyModifiers.None && isTextBoxFocused)
             {
                 return;
             }
 
             e.Handled = true;
             TogglePlayPauseSelectedRow();
+        }
+        else if (e.Key == Key.R && e.KeyModifiers == KeyModifiers.None && !isTextBoxFocused)
+        {
+            // Bare R = regenerate the selected line: pairs with Space for fast keyboard-only
+            // review (space to listen, R to redo), as requested in #12093.
+            e.Handled = true;
+            RegenerateSelectedLine();
+        }
+    }
+
+    private void RegenerateSelectedLine()
+    {
+        var line = SelectedLine;
+        if (line == null || line.IsPlaying || !line.IsPlayingEnabled)
+        {
+            return;
+        }
+
+        if (RegenerateAudioCommand.CanExecute(line))
+        {
+            RegenerateAudioCommand.Execute(line);
         }
     }
 

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
@@ -80,6 +80,11 @@ public class ReviewSpeechWindow : Window
         Content = grid;
 
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
+
+        // Tunnel-stage handler: sees Space/R before the focused button does. Without this, the
+        // initially focused OK button swallowed bare Space as a button click - publishing the
+        // whole session when the user just wanted to play a line (#12093).
+        AddHandler(KeyDownEvent, (_, e) => vm.OnPreviewKeyDown(e), Avalonia.Interactivity.RoutingStrategies.Tunnel);
         Loaded += delegate
         {
             vm.Loaded();

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1687,6 +1687,35 @@ public partial class TextToSpeechViewModel : ObservableObject
                 _ = GenerateWavePeaksIfNeededAsync(videoFileNameForReview, vm);
             }
         });
+
+        // OK means "publish": run the same merge/add-to-video tail as the generate pipeline.
+        // This result used to be discarded, so OK after an import behaved exactly like Cancel -
+        // no merged wav, no dialog, nothing (#12093).
+        if (result.OkPressed)
+        {
+            try
+            {
+                await MergeAndAddToVideo(result.StepResults);
+            }
+            catch (OperationCanceledException)
+            {
+                ResetGeneratingUiState();
+            }
+            catch (Exception ex)
+            {
+                SeLogger.Error(ex, "Text-to-speech: merging imported audio segments failed");
+                Se.WriteToolsLog("Text-to-speech: merging imported audio segments failed: " + ex, true);
+                ResetGeneratingUiState();
+
+                await MessageBox.Show(
+                    Window,
+                    Se.Language.General.Error,
+                    "Merging the audio segments failed: " + ex.Message + Environment.NewLine + Environment.NewLine +
+                    "See error-log.txt in the Subtitle Edit data folder for details.",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+        }
     }
 
     /// <summary>
@@ -1987,9 +2016,10 @@ public partial class TextToSpeechViewModel : ObservableObject
     {
         try
         {
-            var engine = SelectedEngine;
-            var voice = SelectedVoice;
-            if (engine == null || voice == null || cancellationToken.IsCancellationRequested)
+            // No engine/voice needed here - each step result carries its own audio file. An
+            // engine/voice null-guard used to silently abort the merge for imported sessions
+            // whose selected engine had no loadable voice list ("OK does nothing", #12093).
+            if (cancellationToken.IsCancellationRequested)
             {
                 return null;
             }
@@ -2001,7 +2031,7 @@ public partial class TextToSpeechViewModel : ObservableObject
                 forceStereo = true;
             }
 
-            var silenceFileName = await GenerateSilenceWaveFile(cancellationToken);
+            var silenceFileName = await GenerateSilenceWaveFile(previousStepResult, cancellationToken);
 
             var inputFileName = silenceFileName;
             ProgressValue = 0;
@@ -2083,7 +2113,7 @@ public partial class TextToSpeechViewModel : ObservableObject
         }
     }
 
-    private async Task<string> GenerateSilenceWaveFile(CancellationToken cancellationToken)
+    private async Task<string> GenerateSilenceWaveFile(TtsStepResult[] stepResults, CancellationToken cancellationToken)
     {
         ProgressText = Se.Language.Video.TextToSpeech.PreparingMergeDotDotDot;
         ProgressValue = 0;
@@ -2103,6 +2133,15 @@ public partial class TextToSpeechViewModel : ObservableObject
         else if (_subtitle.Paragraphs.Count > 0)
         {
             durationInSeconds = (float)_subtitle.Paragraphs.Max(p => p.EndTime.TotalSeconds);
+        }
+
+        // An imported session can outlast the subtitle currently open in the main window (or
+        // there may be no video at all) - the silence base track must cover every segment being
+        // merged, or the tail would be dropped.
+        if (stepResults.Length > 0)
+        {
+            var maxEndSeconds = (float)stepResults.Max(r => r.Paragraph.EndTime.TotalSeconds);
+            durationInSeconds = Math.Max(durationInSeconds, maxEndSeconds);
         }
 
         var silenceProcess = FfmpegGenerator.GenerateEmptyAudio(silenceFileName, durationInSeconds);

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -1,4 +1,5 @@
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
@@ -219,6 +220,29 @@ public class TextToSpeechWindow : Window
         }
     }
 
+    // The API key is a secret: mask it by default so it never shows in screenshots/screen
+    // shares, with an eye button that toggles visibility while editing (#12093).
+    private static StackPanel MakeApiKeyTextBox(TextToSpeechViewModel vm)
+    {
+        var textBox = UiUtil.MakeTextBox(325, vm, nameof(vm.ApiKey));
+        textBox.PasswordChar = '●';
+
+        var buttonReveal = UiUtil.MakeButton(null, IconNames.Eye);
+        AutomationProperties.SetName(buttonReveal, Se.Language.General.ApiKey);
+        buttonReveal.Click += (_, _) =>
+        {
+            textBox.RevealPassword = !textBox.RevealPassword;
+            Attached.SetIcon(buttonReveal, textBox.RevealPassword ? IconNames.EyeOff : IconNames.Eye);
+        };
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 5,
+            Children = { textBox, buttonReveal },
+        };
+    }
+
     // Checkbox (or checkbox row) with a muted one-line explanation below, indented to align
     // with the checkbox text.
     private static StackPanel WithCheckBoxHint(Control checkBoxOrPanel, string hint)
@@ -413,7 +437,7 @@ public class TextToSpeechWindow : Window
                     Content = Se.Language.General.ApiKey,
                     MinWidth = labelMinWidth,
                 },
-                UiUtil.MakeTextBox(325, vm, nameof(vm.ApiKey)),
+                MakeApiKeyTextBox(vm),
             },
             [!StackPanel.IsVisibleProperty] = new Binding(nameof(vm.HasApiKey)) { Mode = BindingMode.OneWay },
         };

--- a/src/ui/Logic/IconNames.cs
+++ b/src/ui/Logic/IconNames.cs
@@ -38,6 +38,8 @@ internal class IconNames
     public const string Duplicate = "mdi-content-duplicate";
     public const string Electron = "mdi-electron-framework";
     public const string Export = "mdi-export";
+    public const string Eye = "mdi-eye";
+    public const string EyeOff = "mdi-eye-off";
     public const string EyeSettings = "mdi-eye-settings";
     public const string FileCog = "mdi-file-cog";
     public const string FileMultiple = "mdi-file-multiple";


### PR DESCRIPTION
Follow-ups from the [latest feedback](https://github.com/SubtitleEdit/subtitleedit/issues/12093#issuecomment-4876291972) on #12093.

### The main issue: OK after Import did nothing

`Import()` opened the review window and **discarded its result** — so clicking OK behaved exactly like Cancel: no merged wav, no save dialog, nothing. OK now runs the same merge / save-wav / add-to-video tail as the generate pipeline. Two follow-on bugs in that tail are also fixed:

- The silence base track is now sized to cover the imported segments too — an imported session can outlast the subtitle currently open in the main window, which would have cut off the tail of the merged wav.
- A vestigial engine/voice null-guard in `MergeAudioParagraphs` could still silently abort the merge for imported sessions whose selected engine had no loadable voice list (same "OK does nothing" symptom). The merge doesn't need an engine/voice at all — each step result carries its own audio file.

### Review window keyboard flow

- **Space no longer clicks OK.** Space/R are handled at tunnel stage, before the focused control sees the key — previously the initially focused OK button swallowed bare Space as a click and published the whole session. Space now always means play/pause (and still types normally in text boxes).
- **Bare R regenerates the selected line** — pairs with Space for fast keyboard-only review ("thumb on Space, finger on R"). Ctrl+R still works.
- **Playing a row selects it**, so Space (replay) and R (regenerate) always target the line just heard instead of a previously selected row.

### API key

Masked with `●` by default (no more editing screenshots), with an eye button to toggle visibility. Icon names verified against the bundled Material Design set.

### Not addressed here

- The Windows-only "file dialogs / windows drop to the taskbar" behavior needs a Windows repro — likely an Avalonia window-activation issue.
- The cut-off button row at 200% scaling is already fixed on main (#12112, stale saved window size applied to a non-resizable window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)