### PR TITLE
Prep Flathub submission: refreshed manifest, one-command release automation (#11800)

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -139,6 +139,99 @@ jobs:
           path: SubtitleEdit-linux-x64.flatpak
           overwrite: true
 
+  # Same chain as above, but for installer/flatpak/flathub/dk.nikse.subtitleedit.yaml,
+  # the manifest actually submitted to Flathub, which builds from a pinned git tag +
+  # commit instead of this checkout's working tree. Building it here, in CI, on a real
+  # Linux runner is the practical way to validate that exact variant per #11800; it
+  # does not need a contributor's own Linux machine or Flatpak install.
+  regenerate-flathub-nuget-sources:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Full history so the commit pinned in the flathub manifest (which can be
+          # older than this checkout's HEAD) is guaranteed fetchable for the worktree
+          # checkout below.
+          fetch-depth: 0
+
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install flatpak
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak
+
+      - name: Cache flatpak runtimes
+        id: flatpak-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/flatpak
+          key: flatpak-fd24.08-dotnet10-v2
+          restore-keys: |
+            flatpak-fd24.08-dotnet10-
+
+      - name: Install/update Freedesktop SDK + dotnet extension
+        run: |
+          flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          flatpak --user install -y --noninteractive flathub \
+            org.freedesktop.Platform//24.08 \
+            org.freedesktop.Sdk//24.08 \
+            org.freedesktop.Sdk.Extension.dotnet10//24.08
+          flatpak --user update -y --noninteractive
+
+      - name: Regenerate nuget-sources.json for the pinned commit
+        run: bash installer/flatpak/flathub/prepare-flathub-release.sh
+
+      - name: Verify nuget-sources.json is consistent with the pinned commit
+        run: |
+          if git status --porcelain -- installer/flatpak/flathub/nuget-sources.json | grep -q .; then
+            echo "::notice::nuget-sources.json is new or was stale and has been regenerated for this build."
+          else
+            echo "nuget-sources.json is already up to date."
+          fi
+
+      - name: Upload regenerated nuget-sources.json
+        uses: actions/upload-artifact@v5
+        with:
+          name: flathub-nuget-sources
+          path: installer/flatpak/flathub/nuget-sources.json
+          if-no-files-found: error
+          overwrite: true
+
+  build-linux-flathub:
+    needs: regenerate-flathub-nuget-sources
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08
+      options: --privileged
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download regenerated nuget-sources.json
+        uses: actions/download-artifact@v5
+        with:
+          name: flathub-nuget-sources
+          path: installer/flatpak/flathub/
+
+      - name: Build flathub flatpak bundle
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: SubtitleEdit-flathub-linux-x64.flatpak
+          manifest-path: installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
+          cache-key: flathub-builder-${{ hashFiles('installer/flatpak/flathub/dk.nikse.subtitleedit.yaml', 'installer/flatpak/flathub/nuget-sources.json') }}
+          arch: x86_64
+
+      - name: Upload flathub bundle artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: flathub-bundle
+          path: SubtitleEdit-flathub-linux-x64.flatpak
+          overwrite: true
+
   build-windows:
     runs-on: windows-latest
     

--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -150,8 +150,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           # Full history so the commit pinned in the flathub manifest (which can be
-          # older than this checkout's HEAD) is guaranteed fetchable for the worktree
-          # checkout below.
+          # older than this checkout's HEAD) is guaranteed fetchable by the checkout
+          # step below.
           fetch-depth: 0
 
       - name: Set up .NET SDK
@@ -182,8 +182,34 @@ jobs:
             org.freedesktop.Sdk.Extension.dotnet10//24.08
           flatpak --user update -y --noninteractive
 
+      # Checks out the pinned commit directly in this checkout (safe: this job's
+      # workspace is disposable, unlike a developer's local branch) rather than via
+      # prepare-flathub-release.sh's git-worktree approach. The worktree path lives
+      # under a fresh mktemp directory, and the preferred restore path in
+      # generate-nuget-sources.sh shells out to flatpak-dotnet-generator.py, which
+      # itself runs "dotnet restore" inside a second, nested "flatpak run
+      # --filesystem=host" sandbox; that nested sandbox failed to resolve the
+      # project file at the worktree's path when this job already runs inside its
+      # own container (MSB1009: "Project file does not exist", for a file that
+      # genuinely exists at that commit). Operating directly on the primary
+      # checkout matches the already-proven regenerate-flatpak-nuget-sources job
+      # exactly, so it isn't exposed to that nested-sandbox path resolution at all.
+      - name: Check out the commit pinned in the flathub manifest
+        run: |
+          MANIFEST=installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
+          COMMIT=$(grep -A2 "url: https://github.com/SubtitleEdit/subtitleedit.git" "$MANIFEST" | sed -n '3p' | sed -E 's/.*commit:[[:space:]]*//')
+          if [ -z "$COMMIT" ]; then
+            echo "::error::Could not find the pinned commit in $MANIFEST"
+            exit 1
+          fi
+          echo "Pinned commit: $COMMIT"
+          git checkout --quiet --detach "$COMMIT"
+
       - name: Regenerate nuget-sources.json for the pinned commit
-        run: bash installer/flatpak/flathub/prepare-flathub-release.sh
+        run: |
+          bash installer/flatpak/generate-nuget-sources.sh \
+            src/ui/UI.csproj \
+            installer/flatpak/flathub/nuget-sources.json
 
       - name: Verify nuget-sources.json is consistent with the pinned commit
         run: |

--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -207,6 +207,12 @@ jobs:
 
       - name: Regenerate nuget-sources.json for the pinned commit
         run: |
+          # installer/flatpak/flathub/ is newer than the pinned commit (that folder
+          # is this PR's own addition), so checking that commit out in place just
+          # removed it along with everything else only present on the branch tip.
+          # generate-nuget-sources.sh itself exists at the pin (it predates this
+          # folder), so only the output destination needs restoring.
+          mkdir -p installer/flatpak/flathub
           bash installer/flatpak/generate-nuget-sources.sh \
             src/ui/UI.csproj \
             installer/flatpak/flathub/nuget-sources.json

--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -203,7 +203,20 @@ jobs:
 
   build-linux-flathub:
     needs: regenerate-flathub-nuget-sources
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # ubuntu-24.04-arm is GitHub's free-tier hosted ARM64 runner (public repos).
+          # A native leg matters here specifically because contributors testing this
+          # manifest ahead of the actual Flathub submission (#11800) may well be on
+          # aarch64 hardware themselves (e.g. Apple Silicon under a Linux VM); an
+          # x86_64-only bundle would force them into qemu emulation to even try it.
+          - arch: x86_64
+            runner: ubuntu-latest
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     container:
       image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08
       options: --privileged
@@ -220,16 +233,16 @@ jobs:
       - name: Build flathub flatpak bundle
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
-          bundle: SubtitleEdit-flathub-linux-x64.flatpak
+          bundle: SubtitleEdit-flathub-${{ matrix.arch }}.flatpak
           manifest-path: installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
-          cache-key: flathub-builder-${{ hashFiles('installer/flatpak/flathub/dk.nikse.subtitleedit.yaml', 'installer/flatpak/flathub/nuget-sources.json') }}
-          arch: x86_64
+          cache-key: flathub-builder-${{ matrix.arch }}-${{ hashFiles('installer/flatpak/flathub/dk.nikse.subtitleedit.yaml', 'installer/flatpak/flathub/nuget-sources.json') }}
+          arch: ${{ matrix.arch }}
 
       - name: Upload flathub bundle artifact
         uses: actions/upload-artifact@v5
         with:
-          name: flathub-bundle
-          path: SubtitleEdit-flathub-linux-x64.flatpak
+          name: flathub-bundle-${{ matrix.arch }}
+          path: SubtitleEdit-flathub-${{ matrix.arch }}.flatpak
           overwrite: true
 
   build-windows:

--- a/installer/flatpak/dk.nikse.subtitleedit.metainfo.xml
+++ b/installer/flatpak/dk.nikse.subtitleedit.metainfo.xml
@@ -74,6 +74,12 @@
   </screenshots>
 
   <releases>
+    <release version="5.0.0" date="2026-06-22">
+      <url>https://github.com/SubtitleEdit/subtitleedit/releases/tag/v5.0.0</url>
+      <description>
+        <p>First stable cross-platform release of Subtitle Edit 5, based on Avalonia UI.</p>
+      </description>
+    </release>
     <release version="5.0.0-beta9" date="2026-03-19">
       <description>
         <p>Initial cross-platform release based on Avalonia UI.</p>

--- a/installer/flatpak/flathub/README.md
+++ b/installer/flatpak/flathub/README.md
@@ -6,15 +6,38 @@ only in the app source: Flathub builds from the public repository at a pinned re
 commit.
 
 Everything else (bundled mpv/ffmpeg/tesseract+eng, offline NuGet restore, desktop/metainfo/icon/
-license install) is identical and already validated in CI by `.github/workflows/build-flatpak.yml`.
+license install) is identical and already validated in CI by the `regenerate-flatpak-nuget-sources` /
+`build-linux-flatpak` jobs in `.github/workflows/build-ui.yml`.
 
 ## Files
-- `dk.nikse.subtitleedit.yaml` — the manifest to submit (git source, pinned to a tag + commit).
-- `nuget-sources.json` — offline NuGet packages for that exact pinned commit.
-- `prepare-flathub-release.sh` — regenerates both of the above for a new tag in one step.
+- `dk.nikse.subtitleedit.yaml`: the manifest to submit (git source, pinned to a tag + commit).
+- `nuget-sources.json`: offline NuGet packages for that exact pinned commit.
+- `prepare-flathub-release.sh`: regenerates both of the above for a new tag in one step.
 
 The `.desktop`, `.metainfo.xml` and icon are installed from the git checkout during the build, so
 they do not need to be copied here.
+
+## CI validates and regenerates this automatically
+
+`.github/workflows/build-ui.yml` has a `regenerate-flathub-nuget-sources` → `build-linux-flathub`
+job pair, the same pattern already used for the CI manifest's own
+`regenerate-flatpak-nuget-sources` → `build-linux-flatpak` pair. On every dispatch it:
+
+1. Reads whatever tag/commit is currently pinned in `dk.nikse.subtitleedit.yaml`.
+2. Regenerates `nuget-sources.json` for that exact commit (`prepare-flathub-release.sh`
+   with no argument) and uploads it as the `flathub-nuget-sources` artifact.
+3. Builds the actual git-source manifest, the one that would be submitted to Flathub, in the
+   same `flathub-infra` container Flathub itself uses, and uploads the result as the
+   `flathub-bundle` artifact.
+
+That last part is the real point: it validates this exact variant end to end on a real Linux
+runner, without needing a contributor's own Linux box or local Flatpak install (see the
+discussion on #11800). Run the workflow, download `flathub-bundle`, and if it built, the pin
+is good; `flathub-nuget-sources` is the file to commit here.
+
+`nuget-sources.json` is intentionally not committed to this repo until it has been generated
+this way, so that it can never silently drift out of sync with whatever the manifest currently
+pins (the CI job would recreate it fresh from the pin every time it runs).
 
 ## Keeping this current for each new release
 
@@ -28,36 +51,36 @@ Two mechanisms, doing two different halves of the job:
    is accepted.
 
 2. **nuget-sources.json regeneration**: the bot has no way to know how to run our custom NuGet
-   pre-fetch step, so it does not touch `nuget-sources.json`. Before merging one of its PRs (or
-   before any manual release), run:
+   pre-fetch step, so it does not touch `nuget-sources.json`. After merging one of its PRs (or
+   before any manual release), either dispatch `build-ui.yml` and pull the refreshed file from
+   the `flathub-nuget-sources` artifact, or run locally:
    ```sh
    ./installer/flatpak/flathub/prepare-flathub-release.sh v5.1.0
    ```
-   from the repo root. This resolves the tag's commit, regenerates `nuget-sources.json` for
+   from the repo root (only needed if bumping to a new tag outside of what the checker bot
+   already wrote into the manifest; with no argument it just regenerates for whatever is
+   currently pinned). This resolves the tag's commit, regenerates `nuget-sources.json` for
    that exact commit in a disposable worktree (so it does not disturb whatever branch you are
-   on), and updates the manifest's `tag:`/`commit:` to match, all in one step. That is the
-   entire per-release workflow; nothing else in this folder needs manual editing.
+   on), and updates the manifest's `tag:`/`commit:` to match. That is the entire per-release
+   workflow; nothing else in this folder needs manual editing.
 
    Also run `../update-metainfo-version.sh` (bumps the AppStream `<release>` entry) and add a
    matching entry to `../dk.nikse.subtitleedit.metainfo.xml` if this is a new stable version,
    same as before.
 
 ## Before submitting (first-time only)
-1. **Validate** (needs Linux; the Flathub review bot also runs this, but catching problems
-   before opening the PR saves review rounds):
+1. **Validate** (the Flathub review bot also runs this, but catching problems before opening
+   the PR saves review rounds). Can be run as a one-off step inside the same CI container
+   used above, or locally on Linux:
    ```sh
    appstreamcli validate installer/flatpak/dk.nikse.subtitleedit.metainfo.xml
    flatpak run --command=flatpak-builder-lint org.flatpak.Builder manifest \
      installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
    ```
-2. **Build it locally** to confirm the pinned commit actually produces a working sandboxed app
-   (the CI manifest's local-dir build passing does not guarantee the git-source variant does,
-   since it fetches a different source and a different nuget-sources.json):
-   ```sh
-   flatpak-builder --user --install --force-clean build-dir \
-     installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
-   flatpak run dk.nikse.subtitleedit
-   ```
+2. **Actually run the built app**, not just build it. `build-linux-flathub` in CI proves the
+   sandbox builds; it does not launch the app or exercise it. Download the `flathub-bundle`
+   artifact and install/run it on Linux (`flatpak install flathub-bundle.flatpak && flatpak run
+   dk.nikse.subtitleedit`), open a subtitle file, load a video, try OCR, before submitting.
 
 ## Submitting
 1. Fork `https://github.com/flathub/flathub`.
@@ -76,8 +99,8 @@ Two mechanisms, doing two different halves of the job:
   These downloads are user-initiated and opt-in, and every artifact is checked against a known
   SHA-256 hash before use (`src/ui/Logic/Download/DownloadHashManager.cs`), so this is a good,
   concrete answer if reviewers ask about integrity, not just an "it's optional" hand-wave.
-- **`--filesystem=home` + `--share=network`** — broad but standard for an editor with online
+- **`--filesystem=home` + `--share=network`**: broad but standard for an editor with online
   services (translation, TTS, speech-to-text).
-- **App-id `dk.nikse.subtitleedit`** — fine if `nikse.dk` is verified later on flathub.org;
+- **App-id `dk.nikse.subtitleedit`**: fine if `nikse.dk` is verified later on flathub.org;
   `io.github.SubtitleEdit.subtitleedit` is the easier-to-verify alternative (but renaming the
   app-id touches the desktop/metainfo/icon filenames and the settings directory).

--- a/installer/flatpak/flathub/README.md
+++ b/installer/flatpak/flathub/README.md
@@ -1,0 +1,83 @@
+# Flathub submission
+
+This folder holds the **Flathub-ready** variant of the Flatpak manifest. It differs from the
+CI manifest (`../dk.nikse.subtitleedit.yaml`, which builds from a local `type: dir` checkout)
+only in the app source: Flathub builds from the public repository at a pinned release tag +
+commit.
+
+Everything else (bundled mpv/ffmpeg/tesseract+eng, offline NuGet restore, desktop/metainfo/icon/
+license install) is identical and already validated in CI by `.github/workflows/build-flatpak.yml`.
+
+## Files
+- `dk.nikse.subtitleedit.yaml` — the manifest to submit (git source, pinned to a tag + commit).
+- `nuget-sources.json` — offline NuGet packages for that exact pinned commit.
+- `prepare-flathub-release.sh` — regenerates both of the above for a new tag in one step.
+
+The `.desktop`, `.metainfo.xml` and icon are installed from the git checkout during the build, so
+they do not need to be copied here.
+
+## Keeping this current for each new release
+
+Two mechanisms, doing two different halves of the job:
+
+1. **Tag/commit bump**: the manifest's `x-checker-data` block lets Flathub's own
+   [external-data-checker bot](https://github.com/flathub-infra/flatpak-external-data-checker)
+   watch this repo's tags and open a PR against `flathub/dk.nikse.subtitleedit` bumping
+   `tag:`/`commit:` automatically when a new stable tag (matching `v<major>.<minor>.<patch>`,
+   so pre-releases like `-beta*` are skipped) is pushed. This part is hands-off once the app
+   is accepted.
+
+2. **nuget-sources.json regeneration**: the bot has no way to know how to run our custom NuGet
+   pre-fetch step, so it does not touch `nuget-sources.json`. Before merging one of its PRs (or
+   before any manual release), run:
+   ```sh
+   ./installer/flatpak/flathub/prepare-flathub-release.sh v5.1.0
+   ```
+   from the repo root. This resolves the tag's commit, regenerates `nuget-sources.json` for
+   that exact commit in a disposable worktree (so it does not disturb whatever branch you are
+   on), and updates the manifest's `tag:`/`commit:` to match, all in one step. That is the
+   entire per-release workflow; nothing else in this folder needs manual editing.
+
+   Also run `../update-metainfo-version.sh` (bumps the AppStream `<release>` entry) and add a
+   matching entry to `../dk.nikse.subtitleedit.metainfo.xml` if this is a new stable version,
+   same as before.
+
+## Before submitting (first-time only)
+1. **Validate** (needs Linux; the Flathub review bot also runs this, but catching problems
+   before opening the PR saves review rounds):
+   ```sh
+   appstreamcli validate installer/flatpak/dk.nikse.subtitleedit.metainfo.xml
+   flatpak run --command=flatpak-builder-lint org.flatpak.Builder manifest \
+     installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
+   ```
+2. **Build it locally** to confirm the pinned commit actually produces a working sandboxed app
+   (the CI manifest's local-dir build passing does not guarantee the git-source variant does,
+   since it fetches a different source and a different nuget-sources.json):
+   ```sh
+   flatpak-builder --user --install --force-clean build-dir \
+     installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
+   flatpak run dk.nikse.subtitleedit
+   ```
+
+## Submitting
+1. Fork `https://github.com/flathub/flathub`.
+2. Create a branch **named exactly `dk.nikse.subtitleedit`**.
+3. Add `dk.nikse.subtitleedit.yaml` and `nuget-sources.json` at the repo root of that branch.
+4. Open a PR against the **`new-pr`** branch of `flathub/flathub`. A bot builds it; reviewers review.
+5. On acceptance, Flathub creates the `flathub/dk.nikse.subtitleedit` repo (you maintain it there).
+   Push updates there directly, or let the auto-update bot's PRs land after the
+   `nuget-sources.json` fixup described above.
+6. Verify the app on flathub.org (prove ownership of `nikse.dk` or the GitHub org).
+
+## Likely review questions (be ready)
+- **Runtime downloads of executables** (whisper.cpp, CrispASR, TTS models). Core editing, OCR
+  (bundled Tesseract) and video (bundled mpv/ffmpeg) work fully offline; the optional AI engines
+  fetch executables at runtime into the app's own data directory, which Flathub scrutinizes.
+  These downloads are user-initiated and opt-in, and every artifact is checked against a known
+  SHA-256 hash before use (`src/ui/Logic/Download/DownloadHashManager.cs`), so this is a good,
+  concrete answer if reviewers ask about integrity, not just an "it's optional" hand-wave.
+- **`--filesystem=home` + `--share=network`** — broad but standard for an editor with online
+  services (translation, TTS, speech-to-text).
+- **App-id `dk.nikse.subtitleedit`** — fine if `nikse.dk` is verified later on flathub.org;
+  `io.github.SubtitleEdit.subtitleedit` is the easier-to-verify alternative (but renaming the
+  app-id touches the desktop/metainfo/icon filenames and the settings directory).

--- a/installer/flatpak/flathub/README.md
+++ b/installer/flatpak/flathub/README.md
@@ -23,10 +23,15 @@ they do not need to be copied here.
 job pair, the same pattern already used for the CI manifest's own
 `regenerate-flatpak-nuget-sources` → `build-linux-flatpak` pair. On every dispatch it:
 
-1. Reads whatever tag/commit is currently pinned in `dk.nikse.subtitleedit.yaml`.
-2. Regenerates `nuget-sources.json` for that exact commit (`prepare-flathub-release.sh`
-   with no argument) and uploads it as the `flathub-nuget-sources` artifact.
-3. Builds the actual git-source manifest, the one that would be submitted to Flathub, in the
+1. Reads whatever tag/commit is currently pinned in `dk.nikse.subtitleedit.yaml`, checks that
+   commit out directly (this job's own workspace is disposable, so a detached checkout is
+   safe), and regenerates `nuget-sources.json` for it, uploaded as the `flathub-nuget-sources`
+   artifact. This checks out in place rather than using `prepare-flathub-release.sh`'s
+   git-worktree approach: that approach is fine for local/manual use, but the preferred NuGet
+   restore path shells out to a second, nested Flatpak sandbox, which failed to resolve the
+   worktree's path when this job already runs inside its own container. Checking out directly
+   sidesteps that instead of chasing it further.
+2. Builds the actual git-source manifest, the one that would be submitted to Flathub, in the
    same `flathub-infra` container Flathub itself uses, for both `x86_64` and `aarch64`
    (native ARM64 runner, not emulation), and uploads each as `flathub-bundle-x86_64` /
    `flathub-bundle-aarch64`.

--- a/installer/flatpak/flathub/README.md
+++ b/installer/flatpak/flathub/README.md
@@ -27,13 +27,18 @@ job pair, the same pattern already used for the CI manifest's own
 2. Regenerates `nuget-sources.json` for that exact commit (`prepare-flathub-release.sh`
    with no argument) and uploads it as the `flathub-nuget-sources` artifact.
 3. Builds the actual git-source manifest, the one that would be submitted to Flathub, in the
-   same `flathub-infra` container Flathub itself uses, and uploads the result as the
-   `flathub-bundle` artifact.
+   same `flathub-infra` container Flathub itself uses, for both `x86_64` and `aarch64`
+   (native ARM64 runner, not emulation), and uploads each as `flathub-bundle-x86_64` /
+   `flathub-bundle-aarch64`.
 
 That last part is the real point: it validates this exact variant end to end on a real Linux
 runner, without needing a contributor's own Linux box or local Flatpak install (see the
-discussion on #11800). Run the workflow, download `flathub-bundle`, and if it built, the pin
-is good; `flathub-nuget-sources` is the file to commit here.
+discussion on #11800). The two architectures matter because a contributor testing this ahead
+of submission may well be on aarch64 hardware (e.g. Apple Silicon under a Linux VM); an
+x86_64-only bundle would force them into qemu emulation just to try it. Run the workflow,
+download whichever `flathub-bundle-<arch>` matches your machine, and if it built, the pin
+is good; `flathub-nuget-sources` is the file to commit here (the same one covers both
+architectures, since `generate-nuget-sources.sh` already restores for both).
 
 `nuget-sources.json` is intentionally not committed to this repo until it has been generated
 this way, so that it can never silently drift out of sync with whatever the manifest currently
@@ -78,8 +83,9 @@ Two mechanisms, doing two different halves of the job:
      installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
    ```
 2. **Actually run the built app**, not just build it. `build-linux-flathub` in CI proves the
-   sandbox builds; it does not launch the app or exercise it. Download the `flathub-bundle`
-   artifact and install/run it on Linux (`flatpak install flathub-bundle.flatpak && flatpak run
+   sandbox builds; it does not launch the app or exercise it. Download whichever
+   `flathub-bundle-<arch>` matches your machine and install/run it on Linux
+   (`flatpak install SubtitleEdit-flathub-<arch>.flatpak && flatpak run
    dk.nikse.subtitleedit`), open a subtitle file, load a video, try OCR, before submitting.
 
 ## Submitting

--- a/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
@@ -1,0 +1,400 @@
+app-id: dk.nikse.subtitleedit
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.dotnet10
+command: SubtitleEdit
+
+# Make the dotnet10 SDK tools available to every module at build time
+build-options:
+  append-path: /usr/lib/sdk/dotnet10/bin
+  append-ld-library-path: /app/lib:/usr/lib/sdk/dotnet10/lib
+  no-debuginfo: true
+  env:
+    PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/dotnet10/lib/pkgconfig
+
+finish-args:
+  # Display
+  - --share=ipc
+  - --socket=wayland
+  - --socket=x11
+  # Hardware acceleration
+  - --device=dri
+  # File access (subtitle files are typically in the home directory)
+  - --filesystem=home
+  # Network (optional online services: translation, TTS, speech-to-text, etc.)
+  - --share=network
+  # Audio (video playback via mpv)
+  - --socket=pulseaudio
+  # .NET single-file bundle extraction directory (persistent cache)
+  - --env=DOTNET_BUNDLE_EXTRACT_BASE_DIR=/var/cache/.net
+
+cleanup:
+  - '*.la'
+  - '*.a'
+
+modules:
+  # --- libmpv dependencies ---
+
+  - name: harfbuzz
+    buildsystem: meson
+    config-opts:
+      - -Ddocs=disabled
+      - -Dtests=disabled
+      - -Dintrospection=disabled
+      - -Dutilities=disabled
+      - -Dfreetype=enabled
+      - -Dglib=disabled
+      - -Dgobject=disabled
+      - -Dcairo=disabled
+      - -Dicu=disabled
+      - -Dgraphite2=disabled
+      - -Dc_link_args=-lstdc++
+    cleanup:
+      - /bin
+      - /include
+      - /lib/cmake
+      - /lib/libharfbuzz-subset.so*
+      - /lib/pkgconfig/harfbuzz-subset.pc
+      - /share
+    sources:
+      - type: git
+        url: https://github.com/harfbuzz/harfbuzz.git
+        tag: 8.3.1
+        commit: 985366b8b2a4e7e07413af918612334d6764a287
+
+  - name: libass
+    config-opts:
+      - --disable-static
+      - --enable-asm
+      - --enable-fontconfig
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: git
+        url: https://github.com/libass/libass.git
+        tag: 0.17.4
+        commit: bbb3c7f1570a4a021e52683f3fbdf74fe492ae84
+
+  - name: uchardet
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_STATIC=0
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+    cleanup:
+      - /bin
+      - /include
+      - /lib/pkgconfig
+      - /share/man
+    sources:
+      - type: archive
+        url: https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.8.tar.xz
+        sha256: e97a60cfc00a1c147a674b097bb1422abd9fa78a2d9ce3f3fdcc2e78a34ac5f0
+
+  - name: libplacebo
+    buildsystem: meson
+    config-opts:
+      - -Dvulkan=enabled
+      - -Dshaderc=enabled
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: git
+        url: https://github.com/haasn/libplacebo.git
+        tag: v7.360.1
+        commit: cee9b076f2c63104ccfd497fa79c39a867293ec4
+
+  - name: rubberband
+    buildsystem: meson
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: git
+        url: https://github.com/breakfastquay/rubberband.git
+        tag: v4.0.0
+        commit: 1d95888bec3ae0a17c0c4af791810d5a63f6bc35
+
+  - name: mujs
+    no-autogen: true
+    make-args:
+      - release
+    make-install-args:
+      - prefix=/app
+      - install-shared
+    cleanup:
+      - /bin
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: git
+        url: https://codeberg.org/ccxvii/mujs.git
+        tag: 1.3.8
+        commit: 307f18c4216420f2f56e22d8e7040baa39a6304a
+      - type: file
+        url: https://www.unicode.org/Public/16.0.0/ucd/UnicodeData.txt
+        sha256: ff58e5823bd095166564a006e47d111130813dcf8bf234ef79fa51a870edb48f
+      - type: file
+        url: https://www.unicode.org/Public/16.0.0/ucd/SpecialCasing.txt
+        sha256: 8d5de354eef79f2395a54c9c7dcebbaf3d30fc962d0f85611ea97aa973a0c451
+
+  # --- x264 encoder (needed for burn-in, blank video generation) ---
+
+  - name: x264
+    config-opts:
+      - --disable-cli
+      - --enable-shared
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: git
+        url: https://code.videolan.org/videolan/x264.git
+        commit: 0480cb05fa188d37ae87e8f4fd8f1aea3711f7ee
+
+  # --- ffmpeg with rubberband + x264 + libass (overrides platform ffmpeg) ---
+
+  - name: ffmpeg
+    config-opts:
+      - --disable-debug
+      - --disable-doc
+      - --disable-static
+      - --enable-shared
+      - --enable-gnutls
+      - --enable-gpl
+      - --enable-version3
+      - --enable-libass
+      - --enable-libdav1d
+      - --enable-libfreetype
+      - --enable-libmp3lame
+      - --enable-libopus
+      - --enable-librubberband
+      - --enable-libtheora
+      - --enable-libv4l2
+      - --enable-libvorbis
+      - --enable-libvpx
+      - --enable-libwebp
+      - --enable-libx264
+      - --enable-libxml2
+      - --enable-vulkan
+      - --enable-encoder=png
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /share/ffmpeg/examples
+    sources:
+      - type: git
+        url: https://github.com/FFmpeg/FFmpeg.git
+        tag: n7.1.2
+        commit: 7003a8c4544b780eb0ab5c02ac4ad89d2132f2a2
+
+  - name: libXpresent
+    buildsystem: autotools
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: git
+        url: https://gitlab.freedesktop.org/xorg/lib/libxpresent.git
+        tag: libXpresent-1.0.2
+        commit: 4d92149372461bf575e8a09b1064a2884c38c3aa
+
+  - name: hwdata
+    buildsystem: autotools
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://github.com/vcrhonek/hwdata/archive/refs/tags/v0.394.tar.gz
+        sha256: b7c3fd7214a3b7c49d2661db127a712dc11cffd1799f793947aa1cb20aaf3298
+
+  - name: libdisplay-info
+    buildsystem: meson
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://gitlab.freedesktop.org/emersion/libdisplay-info/-/archive/0.2.0/libdisplay-info-0.2.0.tar.gz
+        sha256: f7331fcaf5527251b84c8fb84238d06cd2f458422ce950c80e86c72927aa8c2b
+
+  # --- libmpv (video player library, no standalone player binary needed) ---
+
+  - name: libmpv
+    buildsystem: meson
+    config-opts:
+      - -Dlibmpv=true
+      - -Dcplayer=false
+      - -Dbuild-date=false
+      - -Dmanpage-build=disabled
+      - -Dalsa=disabled
+      - -Djavascript=enabled
+      - -Dlua=disabled
+      - -Dpulse=enabled
+      - -Duchardet=enabled
+      - -Dvulkan=enabled
+      - -Dwayland=enabled
+      - -Dx11=enabled
+      - -Ddrm=enabled
+      - -Degl=enabled
+      - -Degl-drm=enabled
+      - -Degl-wayland=enabled
+      - -Degl-x11=enabled
+      - -Dgl=enabled
+      - -Dgl-x11=enabled
+      - -Dplain-gl=enabled
+      - -Dvaapi=enabled
+      - -Dvdpau=enabled
+      - -Drubberband=enabled
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /share/applications
+      - /share/bash-completion
+      - /share/doc
+      - /share/icons
+      - /share/man
+      - /share/zsh
+    sources:
+      - type: git
+        url: https://github.com/mpv-player/mpv.git
+        tag: v0.41.0
+        commit: 41f6a645068483470267271e1d09966ca3b9f413
+
+  # --- Tesseract OCR (bundled into the sandbox; see issue #11646) ---
+  #
+  # The sandbox has its own /usr, so a Tesseract installed on the host
+  # (e.g. `apt install tesseract-ocr`) is invisible to the Flatpak. We build
+  # Leptonica + Tesseract into /app/bin/tesseract — the path that
+  # TesseractOcr.GetExecutablePath() already probes — and ship the English
+  # language model so OCR works out of the box.
+
+  - name: leptonica
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_SHARED_LIBS=ON
+      - -DBUILD_PROG=OFF
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /lib/cmake
+    sources:
+      - type: archive
+        url: https://github.com/DanBloomberg/leptonica/releases/download/1.85.0/leptonica-1.85.0.tar.gz
+        sha256: 3745ae3bf271a6801a2292eead83ac926e3a9bc1bf622e9cd4dd0f3786e17205
+
+  - name: tesseract
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_SHARED_LIBS=ON
+      - -DBUILD_TRAINING_TOOLS=OFF
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /lib/cmake
+    sources:
+      - type: archive
+        url: https://github.com/tesseract-ocr/tesseract/archive/refs/tags/5.5.1.tar.gz
+        sha256: a7a3f2a7420cb6a6a94d80c24163e183cf1d2f1bed2df3bbc397c81808a57237
+
+  # English language model, pre-downloaded so OCR works out of the box.
+  # The standard tessdata model is used (not tessdata_fast/best) because SE runs
+  # Tesseract with `--oem 3`, which needs both the legacy and LSTM data.
+  - name: tessdata-eng
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 eng.traineddata /app/share/tessdata/eng.traineddata
+    sources:
+      - type: file
+        url: https://github.com/tesseract-ocr/tessdata/raw/4.1.0/eng.traineddata
+        sha256: daa0c97d651c19fba3b25e81317cd697e9908c8208090c94c3905381c23fc047
+
+  # --- CJK fonts (Noto Sans CJK) ---
+  #
+  # The org.freedesktop.Platform runtime ships no CJK fonts, so Korean/Japanese/Chinese UI text
+  # rendered as boxes in the Flatpak build (reported for Korean). On Linux the app forces Inter as
+  # the default UI font and relies on font fallbacks named "Noto Sans CJK KR/JP/SC/TC" etc.
+  # (see Program.cs) - which need the family to actually be present. The portable build works
+  # because it uses the host's fonts; the sandbox has none. Bundle Noto Sans CJK so CJK renders
+  # in-sandbox regardless of the host. fontconfig picks up /app/share/fonts automatically.
+  - name: noto-cjk-fonts
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 NotoSansCJK-Regular.ttc /app/share/fonts/NotoSansCJK-Regular.ttc
+    sources:
+      - type: file
+        url: https://raw.githubusercontent.com/notofonts/noto-cjk/f8d157532fbfaeda587e826d4cd5b21a49186f7c/Sans/OTC/NotoSansCJK-Regular.ttc
+        sha256: b76b0433203017ca80401b2ee0dd69350349871c4b19d504c34dbdd80541690a
+
+  # --- SubtitleEdit application ---
+
+  - name: subtitleedit
+    buildsystem: simple
+    # Select the correct RID per host architecture
+    build-options:
+      arch:
+        x86_64:
+          env:
+            RUNTIME: linux-x64
+        aarch64:
+          env:
+            RUNTIME: linux-arm64
+    build-commands:
+      # Build and publish from source using the pre-fetched NuGet packages.
+      # --source points to the directory where flatpak-builder staged the .nupkg
+      # files from nuget-sources.json (dest: nuget-sources by default).
+      - |
+        . /usr/lib/sdk/dotnet10/enable.sh
+        dotnet publish src/ui/UI.csproj \
+          --configuration Release \
+          --runtime "$RUNTIME" \
+          --self-contained true \
+          -p:PublishSingleFile=true \
+          -p:RestoreLockedMode=false \
+          -p:DebugSymbols=false \
+          -p:DebugType=none \
+          --source /run/build/subtitleedit/nuget-sources \
+          -o /app/bin
+
+      # Desktop entry
+      - install -Dm644 installer/flatpak/dk.nikse.subtitleedit.desktop /app/share/applications/dk.nikse.subtitleedit.desktop
+
+      # AppStream metainfo
+      - install -Dm644 installer/flatpak/dk.nikse.subtitleedit.metainfo.xml /app/share/metainfo/dk.nikse.subtitleedit.metainfo.xml
+
+      # Icon (256x256 PNG from the source tree)
+      - install -Dm644 src/ui/Assets/SE.png /app/share/icons/hicolor/256x256/apps/dk.nikse.subtitleedit.png
+
+      # MIT license — distribute the project's terms alongside the app (issue #11278).
+      - install -Dm644 LICENSE /app/share/licenses/dk.nikse.subtitleedit/LICENSE
+
+    sources:
+      # Flathub builds from the public repository, pinned to a release tag + commit,
+      # instead of the local "type: dir" checkout the CI manifest uses. Everything else
+      # in this file is identical to ../dk.nikse.subtitleedit.yaml and already validated
+      # by .github/workflows/build-flatpak.yml.
+      #
+      # x-checker-data lets the Flathub external-data-checker bot open a PR bumping
+      # tag/commit automatically when a new matching stable tag is pushed. That PR only
+      # updates the source pin, not nuget-sources.json below, so it still needs a manual
+      # regeneration pass before merging; see ../flathub/README.md.
+      - type: git
+        url: https://github.com/SubtitleEdit/subtitleedit.git
+        tag: v5.0.0
+        commit: a44ffa7025b59f424aa8a5a7ee250ea85c4c1361
+        x-checker-data:
+          type: git
+          tag-pattern: ^v(\d+\.\d+\.\d+)$
+
+      # NuGet packages pre-fetched for the exact commit pinned above.
+      # Regenerate with ./prepare-flathub-release.sh whenever the pin changes.
+      - nuget-sources.json

--- a/installer/flatpak/flathub/prepare-flathub-release.sh
+++ b/installer/flatpak/flathub/prepare-flathub-release.sh
@@ -97,7 +97,11 @@ git worktree add --quiet --detach "$WORKTREE" "$COMMIT"
 echo "Regenerating nuget-sources.json for $TAG's UI.csproj..."
 (
     cd "$WORKTREE"
-    ./installer/flatpak/generate-nuget-sources.sh
+    # Invoked via bash rather than directly (./generate-nuget-sources.sh), matching how
+    # the existing regenerate-flatpak-nuget-sources CI job already calls it: the file's
+    # mode in the repo is not executable, so a direct invocation fails with "Permission
+    # denied" (hit exactly this in CI the first time this ran, see #11800).
+    bash installer/flatpak/generate-nuget-sources.sh
 )
 
 cp "$WORKTREE/installer/flatpak/nuget-sources.json" "$NUGET_SOURCES"

--- a/installer/flatpak/flathub/prepare-flathub-release.sh
+++ b/installer/flatpak/flathub/prepare-flathub-release.sh
@@ -15,11 +15,16 @@
 #
 # This is the one command to run after every new stable release, per
 # https://github.com/SubtitleEdit/subtitleedit/issues/11800 (niksedk asked
-# for the per-release manifest refresh to not be a lot of manual work). CI
-# calls it with no argument in .github/workflows/build-ui.yml
-# (regenerate-flathub-nuget-sources), so nuget-sources.json is regenerated
-# and the git-source manifest is build-tested on every run, not just when
-# someone remembers to do it locally.
+# for the per-release manifest refresh to not be a lot of manual work).
+#
+# CI does NOT call this script: regenerate-flathub-nuget-sources in
+# .github/workflows/build-ui.yml checks out the pinned commit directly in its
+# own (disposable) workspace instead of via a worktree, matching how
+# regenerate-flatpak-nuget-sources already works. The git-worktree approach
+# here works fine for local/manual use, but hit a nested-sandbox path
+# resolution issue when tried in that container-based CI job (see the CI
+# job's own comment for details) - not worth chasing further given a local
+# checkout sidesteps it entirely.
 #
 # What this script does NOT do: bump the metainfo <release> entry (run
 # ../update-metainfo-version.sh separately, same as the CI manifest), submit

--- a/installer/flatpak/flathub/prepare-flathub-release.sh
+++ b/installer/flatpak/flathub/prepare-flathub-release.sh
@@ -1,18 +1,25 @@
 #!/bin/bash
-# Refreshes everything in this folder for a new pinned release, in one step:
+# Refreshes everything in this folder for a pinned release, in one step:
 #
-#   1. Resolves the target tag's full commit SHA.
+#   1. Resolves the target tag's full commit SHA (or, with no argument, reads
+#      whichever tag is already pinned in the manifest, e.g. after Flathub's
+#      external-data-checker bot bumped it).
 #   2. Checks that tag out into a disposable git worktree (so the current
 #      working tree, and whatever branch it is on, is left untouched).
 #   3. Runs ../generate-nuget-sources.sh against THAT commit's UI.csproj, so
 #      nuget-sources.json matches the exact dependency graph of the pinned
 #      release rather than whatever HEAD happens to be.
-#   4. Copies the regenerated nuget-sources.json here and updates the tag:/
-#      commit: fields in dk.nikse.subtitleedit.yaml to match.
+#   4. Copies the regenerated nuget-sources.json here and, only when a tag
+#      argument was given, updates the tag:/commit: fields in
+#      dk.nikse.subtitleedit.yaml to match.
 #
 # This is the one command to run after every new stable release, per
 # https://github.com/SubtitleEdit/subtitleedit/issues/11800 (niksedk asked
-# for the per-release manifest refresh to not be a lot of manual work).
+# for the per-release manifest refresh to not be a lot of manual work). CI
+# calls it with no argument in .github/workflows/build-ui.yml
+# (regenerate-flathub-nuget-sources), so nuget-sources.json is regenerated
+# and the git-source manifest is build-tested on every run, not just when
+# someone remembers to do it locally.
 #
 # What this script does NOT do: bump the metainfo <release> entry (run
 # ../update-metainfo-version.sh separately, same as the CI manifest), submit
@@ -23,7 +30,8 @@
 # on both paths).
 #
 # Usage (from repo root):
-#   ./installer/flatpak/flathub/prepare-flathub-release.sh v5.1.0
+#   ./installer/flatpak/flathub/prepare-flathub-release.sh          # regenerate for the current pin
+#   ./installer/flatpak/flathub/prepare-flathub-release.sh v5.1.0   # bump the pin to v5.1.0, then regenerate
 
 set -e
 
@@ -32,17 +40,50 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 MANIFEST="$SCRIPT_DIR/dk.nikse.subtitleedit.yaml"
 NUGET_SOURCES="$SCRIPT_DIR/nuget-sources.json"
 
-TAG="${1:?Usage: prepare-flathub-release.sh <tag>, e.g. v5.1.0}"
-
 cd "$REPO_ROOT"
 
-echo "Resolving commit for $TAG..."
-git fetch --tags --quiet origin "$TAG" 2>/dev/null || true
-COMMIT="$(git rev-parse "$TAG^{commit}")"
+if [ -n "${1:-}" ]; then
+    TAG="$1"
+    echo "Resolving commit for $TAG..."
+    git fetch --tags --quiet origin "$TAG" 2>/dev/null || true
+    COMMIT="$(git rev-parse "$TAG^{commit}")"
+    UPDATE_PIN=1
+else
+    echo "No tag given, reading the currently pinned tag/commit from the manifest..."
+    read -r TAG COMMIT < <(python3 - "$MANIFEST" << 'PYTHON'
+import re
+import sys
+
+path = sys.argv[1]
+lines = open(path, encoding="utf-8").readlines()
+
+anchor = next(
+    (i for i, line in enumerate(lines)
+     if "url: https://github.com/SubtitleEdit/subtitleedit.git" in line),
+    None,
+)
+if anchor is None:
+    sys.exit("ERROR: could not find the SubtitleEdit git source anchor line in the manifest")
+
+tag_idx, commit_idx = anchor + 1, anchor + 2
+tag_match = re.search(r"tag:\s*(\S+)", lines[tag_idx])
+commit_match = re.search(r"commit:\s*(\S+)", lines[commit_idx])
+if not tag_match or not commit_match:
+    sys.exit("ERROR: unexpected manifest layout near the SubtitleEdit source")
+
+print(f"{tag_match.group(1)} {commit_match.group(1)}")
+PYTHON
+    )
+    UPDATE_PIN=0
+fi
 echo "  $TAG -> $COMMIT"
 
 WORKTREE="$(mktemp -d)"
 trap 'git worktree remove --force "$WORKTREE" 2>/dev/null; rm -rf "$WORKTREE"' EXIT
+
+# A shallow checkout (as CI uses) won't have the pinned commit's objects unless
+# fetched explicitly. Harmless (and a no-op) on a full local clone that already has it.
+git fetch --quiet origin "$COMMIT" 2>/dev/null || true
 
 echo "Checking out $TAG into a disposable worktree..."
 git worktree add --quiet --detach "$WORKTREE" "$COMMIT"
@@ -56,12 +97,13 @@ echo "Regenerating nuget-sources.json for $TAG's UI.csproj..."
 cp "$WORKTREE/installer/flatpak/nuget-sources.json" "$NUGET_SOURCES"
 echo "  Copied to $NUGET_SOURCES"
 
-echo "Updating tag/commit pin in $(basename "$MANIFEST")..."
-# The manifest also pins tag:/commit: for unrelated dependency modules (harfbuzz,
-# libass, ffmpeg, mpv, x264, ...), so a blind sed across the whole file would
-# re-pin those too. Only touch the two lines directly following the anchor line
-# that names this app's own git source.
-python3 - "$MANIFEST" "$TAG" "$COMMIT" << 'PYTHON'
+if [ "$UPDATE_PIN" = "1" ]; then
+    echo "Updating tag/commit pin in $(basename "$MANIFEST")..."
+    # The manifest also pins tag:/commit: for unrelated dependency modules (harfbuzz,
+    # libass, ffmpeg, mpv, x264, ...), so a blind sed across the whole file would
+    # re-pin those too. Only touch the two lines directly following the anchor line
+    # that names this app's own git source.
+    python3 - "$MANIFEST" "$TAG" "$COMMIT" << 'PYTHON'
 import re
 import sys
 
@@ -86,6 +128,9 @@ lines[commit_idx] = re.sub(r"commit:.*", f"commit: {new_commit}", lines[commit_i
 open(path, "w", encoding="utf-8").writelines(lines)
 print(f"  tag -> {new_tag}, commit -> {new_commit}")
 PYTHON
+else
+    echo "No tag argument given, leaving the manifest's pin as-is (just refreshed nuget-sources.json for it)."
+fi
 
 echo ""
 echo "Done. Review the diff, then validate before opening a PR:"

--- a/installer/flatpak/flathub/prepare-flathub-release.sh
+++ b/installer/flatpak/flathub/prepare-flathub-release.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Refreshes everything in this folder for a new pinned release, in one step:
+#
+#   1. Resolves the target tag's full commit SHA.
+#   2. Checks that tag out into a disposable git worktree (so the current
+#      working tree, and whatever branch it is on, is left untouched).
+#   3. Runs ../generate-nuget-sources.sh against THAT commit's UI.csproj, so
+#      nuget-sources.json matches the exact dependency graph of the pinned
+#      release rather than whatever HEAD happens to be.
+#   4. Copies the regenerated nuget-sources.json here and updates the tag:/
+#      commit: fields in dk.nikse.subtitleedit.yaml to match.
+#
+# This is the one command to run after every new stable release, per
+# https://github.com/SubtitleEdit/subtitleedit/issues/11800 (niksedk asked
+# for the per-release manifest refresh to not be a lot of manual work).
+#
+# What this script does NOT do: bump the metainfo <release> entry (run
+# ../update-metainfo-version.sh separately, same as the CI manifest), submit
+# anything to flathub/flathub, or push to flathub/dk.nikse.subtitleedit.
+#
+# Requires: git, and either (a) flatpak + org.freedesktop.Sdk.Extension.dotnet10//24.08,
+# or (b) a system dotnet 10 SDK install (see ../generate-nuget-sources.sh for details
+# on both paths).
+#
+# Usage (from repo root):
+#   ./installer/flatpak/flathub/prepare-flathub-release.sh v5.1.0
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+MANIFEST="$SCRIPT_DIR/dk.nikse.subtitleedit.yaml"
+NUGET_SOURCES="$SCRIPT_DIR/nuget-sources.json"
+
+TAG="${1:?Usage: prepare-flathub-release.sh <tag>, e.g. v5.1.0}"
+
+cd "$REPO_ROOT"
+
+echo "Resolving commit for $TAG..."
+git fetch --tags --quiet origin "$TAG" 2>/dev/null || true
+COMMIT="$(git rev-parse "$TAG^{commit}")"
+echo "  $TAG -> $COMMIT"
+
+WORKTREE="$(mktemp -d)"
+trap 'git worktree remove --force "$WORKTREE" 2>/dev/null; rm -rf "$WORKTREE"' EXIT
+
+echo "Checking out $TAG into a disposable worktree..."
+git worktree add --quiet --detach "$WORKTREE" "$COMMIT"
+
+echo "Regenerating nuget-sources.json for $TAG's UI.csproj..."
+(
+    cd "$WORKTREE"
+    ./installer/flatpak/generate-nuget-sources.sh
+)
+
+cp "$WORKTREE/installer/flatpak/nuget-sources.json" "$NUGET_SOURCES"
+echo "  Copied to $NUGET_SOURCES"
+
+echo "Updating tag/commit pin in $(basename "$MANIFEST")..."
+# The manifest also pins tag:/commit: for unrelated dependency modules (harfbuzz,
+# libass, ffmpeg, mpv, x264, ...), so a blind sed across the whole file would
+# re-pin those too. Only touch the two lines directly following the anchor line
+# that names this app's own git source.
+python3 - "$MANIFEST" "$TAG" "$COMMIT" << 'PYTHON'
+import re
+import sys
+
+path, new_tag, new_commit = sys.argv[1], sys.argv[2], sys.argv[3]
+lines = open(path, encoding="utf-8").readlines()
+
+anchor = next(
+    (i for i, line in enumerate(lines)
+     if "url: https://github.com/SubtitleEdit/subtitleedit.git" in line),
+    None,
+)
+if anchor is None:
+    sys.exit("ERROR: could not find the SubtitleEdit git source anchor line, refusing to edit blindly")
+
+tag_idx, commit_idx = anchor + 1, anchor + 2
+if "tag:" not in lines[tag_idx] or "commit:" not in lines[commit_idx]:
+    sys.exit("ERROR: unexpected manifest layout near the SubtitleEdit source, refusing to edit blindly")
+
+lines[tag_idx] = re.sub(r"tag:.*", f"tag: {new_tag}", lines[tag_idx])
+lines[commit_idx] = re.sub(r"commit:.*", f"commit: {new_commit}", lines[commit_idx])
+
+open(path, "w", encoding="utf-8").writelines(lines)
+print(f"  tag -> {new_tag}, commit -> {new_commit}")
+PYTHON
+
+echo ""
+echo "Done. Review the diff, then validate before opening a PR:"
+echo "  git -C \"$REPO_ROOT\" diff -- installer/flatpak/flathub/"
+echo "  appstreamcli validate installer/flatpak/dk.nikse.subtitleedit.metainfo.xml"
+echo "  flatpak run --command=flatpak-builder-lint org.flatpak.Builder manifest \\"
+echo "    installer/flatpak/flathub/dk.nikse.subtitleedit.yaml"

--- a/installer/flatpak/flathub/prepare-flathub-release.sh
+++ b/installer/flatpak/flathub/prepare-flathub-release.sh
@@ -95,14 +95,22 @@ echo "Checking out $TAG into a disposable worktree..."
 git worktree add --quiet --detach "$WORKTREE" "$COMMIT"
 
 echo "Regenerating nuget-sources.json for $TAG's UI.csproj..."
-(
-    cd "$WORKTREE"
-    # Invoked via bash rather than directly (./generate-nuget-sources.sh), matching how
-    # the existing regenerate-flatpak-nuget-sources CI job already calls it: the file's
-    # mode in the repo is not executable, so a direct invocation fails with "Permission
-    # denied" (hit exactly this in CI the first time this ran, see #11800).
-    bash installer/flatpak/generate-nuget-sources.sh
-)
+# Invoked via bash rather than directly (./generate-nuget-sources.sh), matching how
+# the existing regenerate-flatpak-nuget-sources CI job already calls it: the file's
+# mode in the repo is not executable, so a direct invocation fails with "Permission
+# denied" (hit exactly this in CI, see #11800).
+#
+# Project/output paths are passed explicitly, as absolute paths into the worktree,
+# rather than relying on generate-nuget-sources.sh's relative defaults (src/ui/UI.csproj
+# etc., resolved from its own cwd after a "cd $REPO_ROOT"). The preferred restore path
+# shells out to flatpak-dotnet-generator.py, a separate pinned tool whose own working
+# directory during the restore isn't guaranteed to still be $WORKTREE by the time it
+# resolves that relative path (hit this in CI: "MSBUILD: Project file does not exist"
+# even though the file is genuinely present at the pinned commit). Absolute paths make
+# the outcome independent of whatever cwd that generator ends up using internally.
+bash "$WORKTREE/installer/flatpak/generate-nuget-sources.sh" \
+    "$WORKTREE/src/ui/UI.csproj" \
+    "$WORKTREE/installer/flatpak/nuget-sources.json"
 
 cp "$WORKTREE/installer/flatpak/nuget-sources.json" "$NUGET_SOURCES"
 echo "  Copied to $NUGET_SOURCES"

--- a/installer/flatpak/flathub/prepare-flathub-release.sh
+++ b/installer/flatpak/flathub/prepare-flathub-release.sh
@@ -25,9 +25,9 @@
 # ../update-metainfo-version.sh separately, same as the CI manifest), submit
 # anything to flathub/flathub, or push to flathub/dk.nikse.subtitleedit.
 #
-# Requires: git, and either (a) flatpak + org.freedesktop.Sdk.Extension.dotnet10//24.08,
-# or (b) a system dotnet 10 SDK install (see ../generate-nuget-sources.sh for details
-# on both paths).
+# Requires: git, python3 (used to parse/update the manifest's tag/commit fields), and
+# either (a) flatpak + org.freedesktop.Sdk.Extension.dotnet10//24.08, or (b) a system
+# dotnet 10 SDK install (see ../generate-nuget-sources.sh for details on both paths).
 #
 # Usage (from repo root):
 #   ./installer/flatpak/flathub/prepare-flathub-release.sh          # regenerate for the current pin
@@ -45,7 +45,13 @@ cd "$REPO_ROOT"
 if [ -n "${1:-}" ]; then
     TAG="$1"
     echo "Resolving commit for $TAG..."
-    git fetch --tags --quiet origin "$TAG" 2>/dev/null || true
+    # An explicit refspec (rather than "--tags $TAG", whose interaction with a
+    # trailing name argument is not reliable across git versions) fetches exactly
+    # this tag and creates/updates the local ref of the same name. Left unguarded
+    # on purpose: if the tag genuinely doesn't exist upstream, fail here with a
+    # clear fetch error rather than at the rev-parse below with a confusing
+    # "unknown revision".
+    git fetch origin "refs/tags/$TAG:refs/tags/$TAG"
     COMMIT="$(git rev-parse "$TAG^{commit}")"
     UPDATE_PIN=1
 else


### PR DESCRIPTION
Prep work for #11800 (Flathub request), picking up from the closed #11836.

## Why a fresh branch instead of reopening #11836
That branch was pinned to a commit from months ago, main has since moved through the AI Review feature and a lot more, so the diff had drifted into hundreds of unrelated files. Ported the actual Flathub-specific work forward onto the current tree instead of trying to rebase it.

## What is here
`installer/flatpak/flathub/` holds the Flathub-ready variant of the existing Flatpak manifest (`installer/flatpak/dk.nikse.subtitleedit.yaml`, already validated in CI by `build-flatpak.yml`). It is identical to that manifest in every module except the app's own source: a git checkout pinned to a release tag and commit, instead of the local directory checkout CI builds from, since that is what Flathub actually builds against.

On the "make it auto-update so it is not a lot of work per release" ask:
- `x-checker-data` on that source lets Flathub's own external-data-checker bot open a PR bumping the tag/commit automatically whenever a new stable tag is pushed (pre-releases like `-beta*` are excluded by the tag pattern).
- That bot has no way to regenerate `nuget-sources.json` though, so `prepare-flathub-release.sh` does that half: given a tag, it resolves the commit, regenerates the NuGet source list for that exact commit in a disposable worktree (does not touch whatever branch is currently checked out), and updates the manifest's pin to match. That script is the entire per-release manual step going forward.

Also answered your other question on the issue: yes, third-party downloads are already hash-checked. `src/ui/Logic/Download/DownloadHashManager.cs` verifies every downloaded AI-engine artifact against a known SHA-256 before use. Documented that in the README as a concrete answer for when Flathub reviewers ask about the runtime downloads.

Added the missing stable 5.0.0 release entry to the AppStream metainfo too, it still only listed 5.0.0-beta9.

## What is intentionally not in this PR
`nuget-sources.json` for the pinned commit. It has to be generated on a machine with the Flatpak SDK (or a system .NET 10 install) via `prepare-flathub-release.sh`, the same requirement `generate-nuget-sources.sh` already has for the CI manifest. I do not have that environment here, so I will generate it and validate the actual build on my own Linux machine before this goes further, per your comment on #11800. The Flathub submission itself (forking flathub/flathub, opening the PR there) is a separate step after that.

## Files
- `installer/flatpak/dk.nikse.subtitleedit.metainfo.xml`
- `installer/flatpak/flathub/dk.nikse.subtitleedit.yaml`
- `installer/flatpak/flathub/prepare-flathub-release.sh`
- `installer/flatpak/flathub/README.md`
