### PR TITLE
Mask auto-translate API keys with the shared eye-toggle control

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAutoTranslate.cs
+++ b/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAutoTranslate.cs
@@ -53,7 +53,7 @@ public static class ViewAutoTranslate
         var textBoxUrl = UiUtil.MakeTextBox(300, vm, nameof(vm.AutoTranslateUrl), nameof(vm.AutoTranslateUrlIsVisible));
 
         var labelApiKey = UiUtil.MakeLabel(Se.Language.General.ApiKey).WithBindVisible(vm, nameof(vm.AutoTranslateApiKeyIsVisible));
-        var textBoxApiKey = UiUtil.MakeTextBox(300, vm, nameof(vm.AutoTranslateApiKey), nameof(vm.AutoTranslateApiKeyIsVisible));
+        var textBoxApiKey = UiUtil.MakeApiKeyTextBox(300, vm, nameof(vm.AutoTranslateApiKey), nameof(vm.AutoTranslateApiKeyIsVisible));
 
 
         var grid = new Grid

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -307,7 +307,9 @@ public class AutoTranslateWindow : Window
         settingsPanel.Children.Add(UiUtil.MakeTextBox(150, vm, nameof(vm.ApiSecretText), nameof(vm.ApiSecretIsVisible)).WithMarginRight(15).WithAccessibleName(Se.Language.General.ApiSecret));
 
         settingsPanel.Children.Add(UiUtil.MakeTextBlock(Se.Language.General.ApiKey, vm, null, nameof(vm.ApiKeyIsVisible)).WithMarginRight(5));
-        settingsPanel.Children.Add(UiUtil.MakeTextBox(150, vm, nameof(vm.ApiKeyText), nameof(vm.ApiKeyIsVisible)).WithMarginRight(15).WithAccessibleName(Se.Language.General.ApiKey));
+        var panelApiKey = UiUtil.MakeApiKeyTextBox(150, vm, nameof(vm.ApiKeyText), nameof(vm.ApiKeyIsVisible));
+        panelApiKey.Margin = new Thickness(0, 0, 15, 0);
+        settingsPanel.Children.Add(panelApiKey);
 
         settingsPanel.Children.Add(UiUtil.MakeTextBlock(Se.Language.General.Formality, vm, null, nameof(vm.FormalityIsVisible)).WithMarginRight(5));
         settingsPanel.Children.Add(UiUtil.MakeComboBox(vm.Formalities, vm, nameof(vm.SelectedFormality), nameof(vm.FormalityIsVisible)).WithWidth(220).WithMarginRight(15).WithAccessibleName(Se.Language.General.Formality));

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -220,29 +220,6 @@ public class TextToSpeechWindow : Window
         }
     }
 
-    // The API key is a secret: mask it by default so it never shows in screenshots/screen
-    // shares, with an eye button that toggles visibility while editing (#12093).
-    private static StackPanel MakeApiKeyTextBox(TextToSpeechViewModel vm)
-    {
-        var textBox = UiUtil.MakeTextBox(325, vm, nameof(vm.ApiKey));
-        textBox.PasswordChar = '●';
-
-        var buttonReveal = UiUtil.MakeButton(null, IconNames.Eye);
-        AutomationProperties.SetName(buttonReveal, Se.Language.General.ApiKey);
-        buttonReveal.Click += (_, _) =>
-        {
-            textBox.RevealPassword = !textBox.RevealPassword;
-            Attached.SetIcon(buttonReveal, textBox.RevealPassword ? IconNames.EyeOff : IconNames.Eye);
-        };
-
-        return new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            Spacing = 5,
-            Children = { textBox, buttonReveal },
-        };
-    }
-
     // Checkbox (or checkbox row) with a muted one-line explanation below, indented to align
     // with the checkbox text.
     private static StackPanel WithCheckBoxHint(Control checkBoxOrPanel, string hint)
@@ -437,7 +414,7 @@ public class TextToSpeechWindow : Window
                     Content = Se.Language.General.ApiKey,
                     MinWidth = labelMinWidth,
                 },
-                MakeApiKeyTextBox(vm),
+                UiUtil.MakeApiKeyTextBox(325, vm, nameof(vm.ApiKey)),
             },
             [!StackPanel.IsVisibleProperty] = new Binding(nameof(vm.HasApiKey)) { Mode = BindingMode.OneWay },
         };

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -677,6 +677,42 @@ public static class UiUtil
         return textBox;
     }
 
+    /// <summary>
+    /// Text box for API keys and similar secrets: masked by default so the value never shows
+    /// in screenshots or screen shares, with an eye button to reveal it while editing.
+    /// </summary>
+    public static StackPanel MakeApiKeyTextBox(double width, object viewModel, string propertyTextPath,
+        string? propertyIsVisiblePath = null)
+    {
+        var textBox = MakeTextBox(width, viewModel, propertyTextPath);
+        textBox.PasswordChar = '●';
+        AutomationProperties.SetName(textBox, Se.Language.General.ApiKey);
+
+        var buttonReveal = MakeButton(null, IconNames.Eye);
+        AutomationProperties.SetName(buttonReveal, Se.Language.General.ApiKey);
+        buttonReveal.Click += (_, _) =>
+        {
+            textBox.RevealPassword = !textBox.RevealPassword;
+            Attached.SetIcon(buttonReveal, textBox.RevealPassword ? IconNames.EyeOff : IconNames.Eye);
+        };
+
+        var panel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 5,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children = { textBox, buttonReveal },
+        };
+
+        if (propertyIsVisiblePath != null)
+        {
+            panel.DataContext = viewModel;
+            panel.Bind(StackPanel.IsVisibleProperty, new Binding(propertyIsVisiblePath));
+        }
+
+        return panel;
+    }
+
     public static TextBlock MakeTextBlock(string text)
     {
         return new TextBlock

--- a/tests/UI/Logic/Accessibility/EditBoxAccessibilityNameTests.cs
+++ b/tests/UI/Logic/Accessibility/EditBoxAccessibilityNameTests.cs
@@ -25,6 +25,19 @@ public class TestApp : Application
 
         // Windows built in code use Attached.SetIcon; without the providers Program.cs
         // registers at startup, constructing such a window throws KeyNotFoundException.
+        RegisterIconProvidersOnce();
+    }
+
+    private static bool _iconProvidersRegistered;
+
+    private static void RegisterIconProvidersOnce()
+    {
+        if (_iconProvidersRegistered)
+        {
+            return;
+        }
+
+        _iconProvidersRegistered = true;
         Optris.Icons.Avalonia.IconProvider.Current
             .Register<Optris.Icons.Avalonia.FontAwesome.FontAwesomeIconProvider>()
             .Register<Optris.Icons.Avalonia.MaterialDesign.MaterialDesignIconProvider>();


### PR DESCRIPTION
Follow-up to #12114 (merged before these two commits landed on the branch):

- Moves the masked-with-eye-button API key text box from the TTS window into a shared `UiUtil.MakeApiKeyTextBox` helper, and uses it in the **auto-translate window** and **batch convert's auto-translate view** — API keys there are now hidden by default with an eye button to reveal.
- Cherry-picks the test-host hang fix (icon providers registered once per process) so the suite runs on this branch; identical to the commit in #12115 and merges cleanly in either order.

Full test suite: 527/527 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)