### PR TITLE
Bump version to v5.1.0-beta7 and update change log

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -1,6 +1,19 @@
 
 Subtitle Edit Changelog
 
+v5.1.0-beta7 (3rd of July 2026)
+
+* Add subtitle grid text fit setting: clip / wrap / ellipsis (Settings -> Appearance) - thx muaz978
+* Text to speech: pimp up the window UI - context line (line count, video file name), section headers, engine description, voice count badge, checkbox hints, progress percent/ETA, and a primary accent Generate button
+* Text to speech: fix Import not doing anything on OK - it now merges/saves/adds to video just like Generate - thx cvrle77
+* Text to speech: review window - Space no longer triggers OK, R regenerates the selected line, and playing a line selects it - thx cvrle77
+* Text to speech: mask the API key by default with a reveal button (also applied to Auto-translate's API key) - thx cvrle77
+* Fix a codebase-wide sweep of 46 confirmed bugs (crashes, wrong behavior, and dead error-handling branches across import/export, translation, spell check, ASSA/SSA styles, fix common errors, and more)
+* Update Russian translation - thx jekovcar
+* Update Turkish translation - thx bilimiyorum
+
+-----------------------------------------------------------------------------------------------------
+
 v5.1.0-beta6 (3rd of July 2026)
 
 * Add SE4's "Column" list view shortcuts (delete text, delete text and shift up, insert text, paste, text up/down) - thx SiaL8er

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.1.0-beta6",
+  "version": "v5.1.0-beta7",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -17,7 +17,7 @@ public class Se
 {
     internal const int CurrentMacOsFontMigrationVersion = 1;
 
-    public static string Version { get; set; } = "v5.1.0-beta6";
+    public static string Version { get; set; } = "v5.1.0-beta7";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Entries enumerated from the PR merge commits between the v5.1.0-beta6 tag and HEAD (`git log v5.1.0-beta6..HEAD --first-parent`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)