### PR TITLE
Fix UI freeze when switching to layout 12 with a video loaded

### DIFF
--- a/src/ui/Features/Main/Layout/InitLayout.cs
+++ b/src/ui/Features/Main/Layout/InitLayout.cs
@@ -942,13 +942,20 @@ public static partial class InitLayout
 
     private static int MakeLayout12(MainView mainPage, MainViewModel vm)
     {
+        // Detach the live video player from the old layout BEFORE cleaning it up. Otherwise
+        // CleanupOldContent walks into it and sets Content = null / clears its inner grid, which
+        // tears down the native mpv/VLC render host on the UI thread while the file is still open -
+        // freezing the UI. Layouts 1-11 avoid this by recreating the player via MakeLayoutVideoPlayer
+        // (which CloseFile()s the old one first); layout 12 reuses the live control, so it must be
+        // pulled out of the tree first.
+        vm.VideoPlayerControl?.RemoveControlFromParent();
+
         CleanupOldContent(vm.ContentGrid);
         vm.ContentGrid.Children.Add(InitListViewAndEditBox.MakeLayoutListViewAndEditBox(mainPage, vm));
 
-        // hide video player
+        // keep the video player alive but hidden so switching back to a video layout is instant
         if (vm.VideoPlayerControl != null)
         {
-            vm.VideoPlayerControl.RemoveControlFromParent();
             vm.ContentGrid.Children.Add(vm.VideoPlayerControl);
             vm.VideoPlayerControl.IsVisible = false;
         }


### PR DESCRIPTION
## Problem

Switching to **layout 12** (the last layout, no video) while a video is loaded froze the UI.

## Root cause

`MakeLayout12` in `src/ui/Features/Main/Layout/InitLayout.cs` reuses the *live* `vm.VideoPlayerControl` — the intent is to keep the same player alive and just hide it. But it called `CleanupOldContent(vm.ContentGrid)` **while that live control was still embedded in the old layout tree.**

`CleanupControl` recurses into every control. `VideoPlayerControl` is a `UserControl` that builds its entire UI into `Content = mainGrid` (`VideoPlayerControl.cs:536`), with the native **mpv/VLC render host** inside it. So cleanup hit the `ContentControl` branch and ran `contentControl.Content = null` (plus `panel.Children.Clear()` on the inner grid) — tearing down a running native video player synchronously on the UI thread while the file was still open. That native teardown blocks on the render loop → frozen UI.

Layouts 1–11 never hit this because they rebuild the player through `MakeLayoutVideoPlayer`, which calls `CloseFile()` on the old player *before* the old tree is cleaned up. Layout 12 is the only path that reuses the live control, and it let cleanup gut it first.

## Fix

Detach the video player from the old tree (`RemoveControlFromParent`) **before** `CleanupOldContent` runs, so cleanup can no longer reach into it. The control (with its native host and open file) stays intact, then gets re-added to `ContentGrid` and hidden — the method's original intent, minus the freeze.

## Testing

- Builds clean.
- Launched the app and switched to layout 12 with a video loaded — no freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)