### PR TITLE
Fix TTS review/import follow-ups from #12093 feedback

### DIFF
--- a/src/ui/Features/Assa/AssaResolutionResampler/AssaResolutionResamplerViewModel.cs
+++ b/src/ui/Features/Assa/AssaResolutionResampler/AssaResolutionResamplerViewModel.cs
@@ -89,7 +89,7 @@ public partial class AssaResolutionResamplerViewModel : ObservableObject
             return;
         }
 
-        var files = await Window.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        var files = await NativePickers.OpenFilePickerAsync(Window, new FilePickerOpenOptions
         {
             Title = Se.Language.General.OpenVideoFile,
             AllowMultiple = false,
@@ -120,7 +120,7 @@ public partial class AssaResolutionResamplerViewModel : ObservableObject
             return;
         }
 
-        var files = await Window.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        var files = await NativePickers.OpenFilePickerAsync(Window, new FilePickerOpenOptions
         {
             Title = Se.Language.General.OpenVideoFile,
             AllowMultiple = false,

--- a/src/ui/Features/Options/Settings/WaveformThemes/WaveformThemesViewModel.cs
+++ b/src/ui/Features/Options/Settings/WaveformThemes/WaveformThemesViewModel.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Shared.PromptTextBox;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -176,7 +177,7 @@ public partial class WaveformThemesViewModel : ObservableObject
             return;
         }
 
-        var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        var files = await NativePickers.OpenFilePickerAsync(topLevel, new FilePickerOpenOptions
         {
             Title = Se.Language.Options.Settings.WaveformLoadThemeDotDotDot,
             AllowMultiple = false,
@@ -238,7 +239,7 @@ public partial class WaveformThemesViewModel : ObservableObject
 
         var suggestedName = (SelectedTheme?.Name ?? "custom").Replace(' ', '_');
 
-        var file = await topLevel.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+        var file = await NativePickers.SaveFilePickerAsync(topLevel, new FilePickerSaveOptions
         {
             Title = Se.Language.Options.Settings.WaveformExportThemeDotDotDot,
             SuggestedFileName = suggestedName,

--- a/src/ui/Features/Video/ShotChanges/ShotChangesViewModel.cs
+++ b/src/ui/Features/Video/ShotChanges/ShotChangesViewModel.cs
@@ -539,7 +539,7 @@ public partial class ShotChangesViewModel : ObservableObject
             Patterns = new List<string> { "*.*" },
         });
 
-        var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        var files = await NativePickers.OpenFilePickerAsync(topLevel, new FilePickerOpenOptions
         {
             Title = Se.Language.Video.ShotChanges.OpenShotChangesFile,
             AllowMultiple = false,

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
@@ -254,7 +254,7 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject
             string? sourcePath;
             if (engine.CustomModelIsFolder)
             {
-                var folders = await Window.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+                var folders = await NativePickers.OpenFolderPickerAsync(Window, new FolderPickerOpenOptions
                 {
                     Title = Se.Language.Video.AudioToText.SelectModel,
                     AllowMultiple = false,
@@ -263,7 +263,7 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject
             }
             else
             {
-                var files = await Window.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+                var files = await NativePickers.OpenFilePickerAsync(Window, new FilePickerOpenOptions
                 {
                     Title = Se.Language.Video.AudioToText.SelectModel,
                     AllowMultiple = false,

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -500,6 +500,14 @@ public partial class ReviewSpeechViewModel : ObservableObject
             }
         }
 
+        // The audio files go into a "wav" subfolder so they don't flood the folder the user
+        // picked (usually the subtitle's own folder) with hundreds of clips - only the JSON
+        // lives at the top level (#12093). Import resolves the relative "wav/0001.wav" names
+        // against the JSON's folder, and legacy exports with the clips next to the JSON still
+        // import fine.
+        var audioFolder = Path.Combine(folder, "wav");
+        Directory.CreateDirectory(audioFolder);
+
         // Copy files. Files still referenced by rows or their history entries must not be
         // overwritten: re-exporting to the folder a session was imported from used to replace an
         // original take (e.g. 0002.wav) that a history entry still pointed at - "pick from
@@ -532,7 +540,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
         {
             index++;
             var sourceFileName = line.StepResult.CurrentFileName;
-            var targetFileName = Path.Combine(folder, index.ToString().PadLeft(4, '0') + Path.GetExtension((string?)sourceFileName));
+            var targetFileName = Path.Combine(audioFolder, index.ToString().PadLeft(4, '0') + Path.GetExtension((string?)sourceFileName));
 
             // A row can point at a deleted/moved file (e.g. an imported session whose folder was
             // cleaned). File.Copy used to throw unhandled mid-export, leaving some files copied
@@ -559,7 +567,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 string candidate;
                 do
                 {
-                    candidate = Path.Combine(folder, $"{index.ToString().PadLeft(4, '0')}_{suffix}{Path.GetExtension((string?)sourceFileName)}");
+                    candidate = Path.Combine(audioFolder, $"{index.ToString().PadLeft(4, '0')}_{suffix}{Path.GetExtension((string?)sourceFileName)}");
                     suffix++;
                 }
                 while (referencedFiles.Contains(Path.GetFullPath(candidate)) || File.Exists(candidate));
@@ -591,9 +599,10 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
             exportFormat.Items.Add(new TtsImportExportItem
             {
-                // File name only, not the absolute path: the export folder is meant to be moved
-                // or shared, and Import resolves the name against the JSON's own directory.
-                AudioFileName = string.IsNullOrEmpty(targetFileName) ? string.Empty : Path.GetFileName(targetFileName),
+                // Relative path ("wav/0001.wav"), not absolute: the export folder is meant to be
+                // moved or shared, and Import resolves the path against the JSON's own directory.
+                // Forward slash so the same JSON opens on Windows, macOS and Linux.
+                AudioFileName = string.IsNullOrEmpty(targetFileName) ? string.Empty : "wav/" + Path.GetFileName(targetFileName),
                 StartMs = (long)Math.Round((double)line.StepResult.Paragraph.StartTime.TotalMilliseconds, MidpointRounding.AwayFromZero),
                 EndMs = (long)Math.Round((double)line.StepResult.Paragraph.EndTime.TotalMilliseconds, MidpointRounding.AwayFromZero),
                 VoiceName = line.StepResult.Voice?.Name ?? string.Empty,
@@ -1207,6 +1216,31 @@ public partial class ReviewSpeechViewModel : ObservableObject
             // review (space to listen, R to redo), as requested in #12093.
             e.Handled = true;
             RegenerateSelectedLine();
+        }
+    }
+
+    /// <summary>
+    /// Tunnel-stage KeyUp twin of <see cref="OnPreviewKeyDown"/>. Avalonia's Button raises
+    /// OnClick from OnKeyUp on Space whenever the button is focused - it does not check that
+    /// the button also saw the KeyDown - so a handled KeyDown alone still let a focused button
+    /// (OK!) click on Space release, both playing the line and publishing the session (#12093).
+    /// </summary>
+    internal void OnPreviewKeyUp(KeyEventArgs e)
+    {
+        var isTextBoxFocused = Window?.FocusManager?.GetFocusedElement() is TextBox;
+
+        if (MatchesPlayPauseShortcut(e))
+        {
+            if (e.KeyModifiers == KeyModifiers.None && isTextBoxFocused)
+            {
+                return;
+            }
+
+            e.Handled = true;
+        }
+        else if (e.Key == Key.R && e.KeyModifiers == KeyModifiers.None && !isTextBoxFocused)
+        {
+            e.Handled = true;
         }
     }
 

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
@@ -79,12 +79,18 @@ public class ReviewSpeechWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
+        // Focus the grid, not a button, so the window receives key events (OnKeyDown needs a
+        // focused element) without arming any button: a focused button fires OnClick on bare
+        // Space/Enter, and OK used to be focused here - so the first Space a user pressed
+        // published the whole session instead of playing the selected line (#12093).
+        Activated += delegate { vm.LineGrid.Focus(); };
 
-        // Tunnel-stage handler: sees Space/R before the focused button does. Without this, the
-        // initially focused OK button swallowed bare Space as a button click - publishing the
-        // whole session when the user just wanted to play a line (#12093).
+        // Tunnel-stage handlers: see Space/R before the focused control does. KeyDown alone is
+        // not enough - Avalonia's Button fires OnClick from OnKeyUp on Space (unconditionally
+        // when focused, no IsPressed check), so a focused button still clicked on Space release
+        // even with the KeyDown handled (#12093).
         AddHandler(KeyDownEvent, (_, e) => vm.OnPreviewKeyDown(e), Avalonia.Interactivity.RoutingStrategies.Tunnel);
+        AddHandler(KeyUpEvent, (_, e) => vm.OnPreviewKeyUp(e), Avalonia.Interactivity.RoutingStrategies.Tunnel);
         Loaded += delegate
         {
             vm.Loaded();

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1680,7 +1680,10 @@ public partial class TextToSpeechViewModel : ObservableObject
                 Languages.ToArray(),
                 SelectedLanguage,
                 videoFileNameForReview,
-                Path.GetDirectoryName(fileName)!,
+                // Scratch folder for regenerate intermediates - NOT the imported JSON's folder:
+                // using that folder filled the user's own export folder with GUID-named temp
+                // wavs on every regenerate (#12093). Same location the fresh Generate flow uses.
+                Path.GetTempPath(),
                 peaksForReview);
             // Forward the imported cast so a subsequent Export round-trips the mappings instead
             // of writing ActorVoiceMappings = [] back to SubtitleEditTts.json.
@@ -1697,6 +1700,18 @@ public partial class TextToSpeechViewModel : ObservableObject
         // no merged wav, no dialog, nothing (#12093).
         if (result.OkPressed)
         {
+            // Enter the same visible "generating" state as a fresh Generate run - progress bar,
+            // status text and a working Cancel button. Without this the merge ran with the
+            // window looking completely idle, giving no sign anything was happening (#12093).
+            ProgressValue = 0;
+            ProgressText = string.Empty;
+            ProgressPercentText = string.Empty;
+            ProgressEtaText = string.Empty;
+            IsGenerating = true;
+            IsNotGenerating = false;
+            ProgressOpacity = 1.0;
+            DoneOrCancelText = Se.Language.General.Cancel;
+
             try
             {
                 await MergeAndAddToVideo(result.StepResults);

--- a/src/ui/Logic/Media/FileHelper.cs
+++ b/src/ui/Logic/Media/FileHelper.cs
@@ -69,7 +69,7 @@ namespace Nikse.SubtitleEdit.Logic.Media
             }
 
             // Start async operation to open the dialog.
-            var files = await topLevel.StorageProvider.OpenFilePickerAsync(options);
+            var files = await NativePickers.OpenFilePickerAsync(topLevel, options);
 
             if (files.Count >= 1)
             {
@@ -101,7 +101,7 @@ namespace Nikse.SubtitleEdit.Logic.Media
             }
 
             // Start async operation to open the dialog.
-            var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            var files = await NativePickers.OpenFilePickerAsync(topLevel, new FilePickerOpenOptions
             {
                 Title = title,
                 AllowMultiple = true,
@@ -141,7 +141,7 @@ namespace Nikse.SubtitleEdit.Logic.Media
                 }
             }
 
-            var files = await topLevel.StorageProvider.OpenFilePickerAsync(options);
+            var files = await NativePickers.OpenFilePickerAsync(topLevel, options);
 
             if (files.Count >= 1)
             {
@@ -181,7 +181,7 @@ namespace Nikse.SubtitleEdit.Logic.Media
                 }
             }
 
-            var files = await topLevel.StorageProvider.OpenFilePickerAsync(options);
+            var files = await NativePickers.OpenFilePickerAsync(topLevel, options);
 
             return files.Select(p => p.Path.LocalPath).ToArray();
         }
@@ -265,7 +265,7 @@ namespace Nikse.SubtitleEdit.Logic.Media
                 FileTypeChoices = MakeSaveFilePickerFileTypes(currentFormat),
                 DefaultExtension = currentFormat.Extension.TrimStart('.')
             };
-            var file = await topLevel.StorageProvider.SaveFilePickerAsync(options);
+            var file = await NativePickers.SaveFilePickerAsync(topLevel, options);
 
             if (file != null)
             {
@@ -403,7 +403,7 @@ namespace Nikse.SubtitleEdit.Logic.Media
                 }
             }
 
-            var file = await topLevel.StorageProvider.SaveFilePickerAsync(options);
+            var file = await NativePickers.SaveFilePickerAsync(topLevel, options);
 
             if (file != null)
             {
@@ -454,7 +454,7 @@ namespace Nikse.SubtitleEdit.Logic.Media
                 }
             }
 
-            var file = await topLevel.StorageProvider.SaveFilePickerAsync(options);
+            var file = await NativePickers.SaveFilePickerAsync(topLevel, options);
 
             if (file != null)
             {
@@ -531,7 +531,7 @@ namespace Nikse.SubtitleEdit.Logic.Media
         {
             var topLevel = TopLevel.GetTopLevel(sender)!;
 
-            var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            var files = await NativePickers.OpenFilePickerAsync(topLevel, new FilePickerOpenOptions
             {
                 Title = title,
                 AllowMultiple = false,
@@ -550,7 +550,7 @@ namespace Nikse.SubtitleEdit.Logic.Media
         {
             var topLevel = TopLevel.GetTopLevel(sender)!;
 
-            var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            var files = await NativePickers.OpenFilePickerAsync(topLevel, new FilePickerOpenOptions
             {
                 Title = title,
                 AllowMultiple = true,
@@ -596,7 +596,7 @@ namespace Nikse.SubtitleEdit.Logic.Media
         {
             var topLevel = TopLevel.GetTopLevel(sender)!;
 
-            var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            var files = await NativePickers.OpenFilePickerAsync(topLevel, new FilePickerOpenOptions
             {
                 Title = title,
                 AllowMultiple = false,

--- a/src/ui/Logic/Media/IFolderHelper.cs
+++ b/src/ui/Logic/Media/IFolderHelper.cs
@@ -22,7 +22,7 @@ public class FolderHelper : IFolderHelper
 
         if (storageProvider.CanPickFolder)
         {
-            var folders = await storageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+            var folders = await NativePickers.OpenFolderPickerAsync(window, new FolderPickerOpenOptions
             {
                 Title = title,
                 AllowMultiple = false

--- a/src/ui/Logic/Media/NativePickers.cs
+++ b/src/ui/Logic/Media/NativePickers.cs
@@ -1,0 +1,68 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Platform.Storage;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Logic.Media;
+
+/// <summary>
+/// Wrappers around the StorageProvider pickers that suspend Topmost on all app windows while
+/// the native dialog is open.
+///
+/// Dialogs shown via WindowService.ShowDialogAsync are Topmost while active (so they stay above
+/// the undocked video/audio windows, #11971). On Windows a native file/folder picker is a plain
+/// non-topmost window owned by the window that opened it - and a non-topmost window can never
+/// sit above a topmost one. So a picker opened from such a dialog (e.g. the text-to-speech
+/// window's Import) appeared *behind* its own topmost owner: the user saw the picker and the
+/// owner vanish behind the main window, reachable only via the taskbar (#12093). Dropping
+/// Topmost for the picker's lifetime avoids that; the previous values are restored afterwards
+/// (and the owner's re-activation re-asserts the correct state via KeepTopmostWhileOwnerActive).
+/// </summary>
+public static class NativePickers
+{
+    public static Task<IReadOnlyList<IStorageFile>> OpenFilePickerAsync(TopLevel topLevel, FilePickerOpenOptions options)
+    {
+        return RunWithTopmostSuspendedAsync(() => topLevel.StorageProvider.OpenFilePickerAsync(options));
+    }
+
+    public static Task<IStorageFile?> SaveFilePickerAsync(TopLevel topLevel, FilePickerSaveOptions options)
+    {
+        return RunWithTopmostSuspendedAsync(() => topLevel.StorageProvider.SaveFilePickerAsync(options));
+    }
+
+    public static Task<IReadOnlyList<IStorageFolder>> OpenFolderPickerAsync(TopLevel topLevel, FolderPickerOpenOptions options)
+    {
+        return RunWithTopmostSuspendedAsync(() => topLevel.StorageProvider.OpenFolderPickerAsync(options));
+    }
+
+    private static async Task<T> RunWithTopmostSuspendedAsync<T>(Func<Task<T>> showNativeDialog)
+    {
+        var suspended = new List<Window>();
+        if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            foreach (var window in desktop.Windows)
+            {
+                if (window.Topmost)
+                {
+                    window.Topmost = false;
+                    suspended.Add(window);
+                }
+            }
+        }
+
+        try
+        {
+            return await showNativeDialog();
+        }
+        finally
+        {
+            foreach (var window in suspended)
+            {
+                window.Topmost = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes the four remaining problems from the beta7 retest feedback in #12093:

**Space still clicking OK in the review window.** Root cause found in Avalonia 12's `Button`: `OnKeyUp` raises `OnClick()` on Space whenever the button is focused - it does **not** check `IsPressed`/that the button saw the KeyDown. So the beta7 tunnel-stage KeyDown handler started playback, but the Space *release* still reached the focused OK button and published the session ("300ms of sound and clicks OK at the same time"). Space/R are now swallowed at tunnel-stage KeyUp too, and the window focuses the line grid instead of the OK button on activation - so no button is armed, and arrow keys navigate the rows as a bonus.

**TTS window + Explorer dropping behind the main window on Windows (Import, merge output folder).** Since the #11971 fix, dialogs are `Topmost` while active. On Windows a native file/folder picker is a plain non-topmost window owned by the window that opened it - and a non-topmost window can never sit above a topmost one, so the picker opened *behind* its own topmost owner, reachable only via the taskbar. This is Windows-specific z-order behavior, which is why it never reproduced on macOS. All `StorageProvider` pickers now run through a new `NativePickers` wrapper that suspends `Topmost` on the app's windows while the native dialog is open and restores it afterwards.

**Import → OK merged silently.** The merge/save pipeline after importing a session now shows the same progress bar/status text/Cancel button as a fresh Generate run; previously the window looked completely idle while ffmpeg merged segments.

**Export folder clutter.** Export now puts the clips in a `wav` subfolder (`SubtitleEditTts.json` stays at the top level and references `wav/0001.wav`; moved/shared folders still re-import, legacy exports with clips next to the JSON still work). Imported sessions also stopped using the export folder as scratch space - regenerate intermediates (the GUID-named wavs from the screenshot) now go to the temp folder like the fresh Generate flow.

Build clean, all 527 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)