### PR TITLE
TTS: pick merged wav name via save dialog instead of silent auto-name

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1927,16 +1927,19 @@ public partial class TextToSpeechViewModel : ObservableObject
             return;
         }
 
-        var result = await _folderHelper.PickFolderAsync(Window!, Se.Language.General.SelectedAFolderToSaveTo);
-        if (string.IsNullOrEmpty(result))
+        // Save dialog with the subtitle's name as the default, instead of a folder picker plus
+        // a silently chosen name. The old exists-check fallback chain (video name -> subtitle
+        // name -> GUID) gave repeated exports to the same folder a different name every run,
+        // ending in a bare GUID (#12093). The native dialog owns the overwrite confirmation.
+        var audioFileName = await _fileHelper.PickSaveFile(Window!, ".wav", GetSuggestedMergedAudioFileName(), Se.Language.General.SaveFileAsTitle);
+        if (string.IsNullOrEmpty(audioFileName))
         {
             ResetGeneratingUiState();
             return;
         }
-        var outputFolder = result;
-        var audioFileName = Path.Combine(outputFolder, GetBestFileName(outputFolder, ".wav"));
+        var outputFolder = Path.GetDirectoryName(audioFileName)!;
 
-        File.Move(mergedAudioFileName, audioFileName);
+        File.Move(mergedAudioFileName, audioFileName, true);
         Se.WriteToolsLog($"TTS merge done: wrote \"{audioFileName}\"");
 
         await HandleAddToVideo(audioFileName, outputFolder, _cancellationToken);
@@ -2168,28 +2171,27 @@ public partial class TextToSpeechViewModel : ObservableObject
         return silenceFileName;
     }
 
-    private string GetBestFileName(string folder, string extension)
+    /// <summary>
+    /// Default name offered in the merged-wav save dialog: the subtitle's own name (what the
+    /// user asked for in #12093), the video's name when the subtitle is unsaved, and a generic
+    /// name as the last resort. Returns a full path when the source's folder is known, so the
+    /// dialog also starts in that folder.
+    /// </summary>
+    private string GetSuggestedMergedAudioFileName()
     {
-        var returnFileName = string.Empty;
-        if (!string.IsNullOrEmpty(_videoFileName))
+        // A new, never-saved subtitle has the literal FileName "Untitled" (no path/extension).
+        var subtitleFileName = _subtitle.FileName;
+        var sourceFileName = !string.IsNullOrEmpty(subtitleFileName) && subtitleFileName != "Untitled"
+            ? subtitleFileName
+            : _videoFileName;
+        if (string.IsNullOrEmpty(sourceFileName))
         {
-            returnFileName = Path.GetFileNameWithoutExtension(_videoFileName) + extension;
-        }
-        if (!string.IsNullOrEmpty(returnFileName) && !File.Exists(Path.Combine(folder, returnFileName)))
-        {
-            return returnFileName;
-        }
-
-        if (!string.IsNullOrEmpty(_subtitle.FileName))
-        {
-            returnFileName = Path.GetFileNameWithoutExtension(_subtitle.FileName) + extension;
-        }
-        if (!string.IsNullOrEmpty(returnFileName) && !File.Exists(Path.Combine(folder, returnFileName)))
-        {
-            return returnFileName;
+            return "SubtitleEditTts.wav";
         }
 
-        return Guid.NewGuid() + extension;
+        var folder = Path.GetDirectoryName(sourceFileName);
+        var name = Path.GetFileNameWithoutExtension(sourceFileName) + ".wav";
+        return string.IsNullOrEmpty(folder) ? name : Path.Combine(folder, name);
     }
 
     private async Task<TtsStepResult[]?> GenerateSpeech(CancellationToken cancellationToken)


### PR DESCRIPTION
Follow-up to the latest #12093 feedback ("1st iteration is named Pekmez od kajsija.wav, second Pekmez od kajsija.en.wav, and third is 06f0133b-….wav").

The merge step asked only for a **folder** and picked the output name itself via an exists-check fallback chain (video name → subtitle name → GUID), so every repeat export into the same folder silently degraded one step, ending in a bare GUID.

Now a native **save-file dialog** opens instead, suggesting the subtitle's own name (video name when the subtitle is unsaved, generic name as last resort) and starting in that file's folder. The default is stable across runs, the user can type any other name — exactly what was asked for — and the OS dialog handles overwrite confirmation, so the fallback chain is gone. The dialog goes through `FileHelper.PickSaveFile`, so it also inherits the `NativePickers` topmost fix from #12122.

All 527 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)