### PR TITLE
Fix download dialogs getting stuck when the download itself fails

### DIFF
--- a/src/ui/Features/Ocr/Download/DownloadGoogleLensOcrViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadGoogleLensOcrViewModel.cs
@@ -60,7 +60,10 @@ public partial class DownloadGoogleLensOcrViewModel : ObservableObject
                 return;
             }
 
-            if (_downloadTask is { IsCompleted: true })
+            // IsCompletedSuccessfully, not the broader IsCompleted (also true for
+            // Faulted/Canceled), so a failed download falls through to the IsFaulted
+            // branch below instead of proceeding as if it had succeeded.
+            if (_downloadTask is { IsCompletedSuccessfully: true })
             {
                 _timer.Stop();
                 _done = true;

--- a/src/ui/Features/Ocr/Download/DownloadPaddleOcrViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadPaddleOcrViewModel.cs
@@ -82,7 +82,10 @@ public partial class DownloadPaddleOcrViewModel : ObservableObject
                 return;
             }
 
-            if (_downloadTask is { IsCompleted: true })
+            // IsCompletedSuccessfully, not the broader IsCompleted (also true for
+            // Faulted/Canceled), so a failed download falls through to the IsFaulted
+            // branch below instead of proceeding as if it had succeeded.
+            if (_downloadTask is { IsCompletedSuccessfully: true })
             {
                 _timer.Stop();
 

--- a/src/ui/Features/Ocr/Download/DownloadTesseractViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadTesseractViewModel.cs
@@ -64,7 +64,10 @@ public partial class DownloadTesseractViewModel : ObservableObject
                 return;
             }
 
-            if (_downloadTask is { IsCompleted: true })
+            // IsCompletedSuccessfully, not the broader IsCompleted (also true for
+            // Faulted/Canceled), so a failed download falls through to the IsFaulted
+            // branch below instead of proceeding as if it had succeeded.
+            if (_downloadTask is { IsCompletedSuccessfully: true })
             {
                 _timer.Stop();
                 _done = true;

--- a/src/ui/Features/Shared/DownloadFfmpegViewModel.cs
+++ b/src/ui/Features/Shared/DownloadFfmpegViewModel.cs
@@ -66,7 +66,10 @@ public partial class DownloadFfmpegViewModel : ObservableObject
                 return;
             }
 
-            if (_downloadTask is { IsCompleted: true })
+            // IsCompletedSuccessfully, not the broader IsCompleted (also true for
+            // Faulted/Canceled), so a failed download falls through to the IsFaulted
+            // branch below instead of proceeding as if it had succeeded.
+            if (_downloadTask is { IsCompletedSuccessfully: true })
             {
                 _timer.Stop();
                 _done = true;

--- a/src/ui/Features/Shared/DownloadLibMpvViewModel.cs
+++ b/src/ui/Features/Shared/DownloadLibMpvViewModel.cs
@@ -64,7 +64,10 @@ public partial class DownloadLibMpvViewModel : ObservableObject
                 return;
             }
 
-            if (_downloadTask is { IsCompleted: true })
+            // IsCompletedSuccessfully, not the broader IsCompleted (also true for
+            // Faulted/Canceled), so a failed download falls through to the IsFaulted
+            // branch below instead of proceeding as if it had succeeded.
+            if (_downloadTask is { IsCompletedSuccessfully: true })
             {
                 _timer.Stop();
                 _done = true;

--- a/src/ui/Features/Shared/DownloadLibVlcViewModel.cs
+++ b/src/ui/Features/Shared/DownloadLibVlcViewModel.cs
@@ -63,7 +63,10 @@ public partial class DownloadLibVlcViewModel : ObservableObject
                 return;
             }
 
-            if (_downloadTask is { IsCompleted: true })
+            // IsCompletedSuccessfully, not the broader IsCompleted (also true for
+            // Faulted/Canceled), so a failed download falls through to the IsFaulted
+            // branch below instead of proceeding as if it had succeeded.
+            if (_downloadTask is { IsCompletedSuccessfully: true })
             {
                 _timer.Stop();
                 _done = true;

--- a/src/ui/Features/Shared/DownloadYtDlpViewModel.cs
+++ b/src/ui/Features/Shared/DownloadYtDlpViewModel.cs
@@ -56,7 +56,10 @@ public partial class DownloadYtDlpViewModel : ObservableObject
                 return;
             }
 
-            if (_downloadTask is { IsCompleted: true })
+            // IsCompletedSuccessfully, not the broader IsCompleted (also true for
+            // Faulted/Canceled), so a failed download falls through to the IsFaulted
+            // branch below instead of proceeding as if it had succeeded.
+            if (_downloadTask is { IsCompletedSuccessfully: true })
             {
                 _timer.Stop();
                 _done = true;

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -108,7 +108,12 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
         lock (_lockObj)
         {
             _timer.Stop();
-            if (_downloadTask is { IsCompleted: true } && Engine != null)
+            // IsCompletedSuccessfully (not the broader IsCompleted, which is also true for
+            // Faulted/Canceled tasks) so a download that threw - e.g. Faster-Whisper-XXL's
+            // PlatformNotSupportedException on Linux ARM64 or macOS - falls through to the
+            // IsFaulted branch below instead of unpacking a file that was never downloaded,
+            // which left the dialog stuck on "Unpacking..." indefinitely.
+            if (_downloadTask is { IsCompletedSuccessfully: true } && Engine != null)
             {
                 if (Engine.Name == WhisperEnginePurfviewFasterWhisperXxl.StaticName)
                 {

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
@@ -104,7 +104,10 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject
         {
             _timer.Stop();
 
-            if (_downloadTask is { IsCompleted: true })
+            // IsCompletedSuccessfully, not the broader IsCompleted (also true for
+            // Faulted/Canceled), so a failed download falls through to the IsFaulted
+            // branch below instead of proceeding as if it had succeeded.
+            if (_downloadTask is { IsCompletedSuccessfully: true })
             {
                 CompleteDownload();
 


### PR DESCRIPTION
Found while testing the Flathub build from #11800 on Linux ARM64: opening Speech to text, picking Purfview Faster Whisper XXL, got stuck on "Unpacking 7-zip archive..." forever.

## Root cause

That engine's download method already correctly throws `PlatformNotSupportedException` for Linux ARM64 (and for macOS), since Purfview's upstream project only ships Windows and Linux x64 builds. Nothing showed that error though.

The download-progress timer callback decides "the download finished, proceed to unpack" using:
```csharp
if (_downloadTask is { IsCompleted: true })
```
`Task.IsCompleted` is true for **Faulted** and **Canceled** tasks too, not just ones that ran to completion. So a task that threw took this exact same branch as a successful download and tried to unpack a file that was never actually downloaded, which is what got stuck. The `IsFaulted` check right below it was unreachable for this case, since `IsCompleted` had already matched first.

## Fix

Checked for the same pattern across every download-progress dialog in the app. Nine of them had it: Faster Whisper XXL, Whisper models, Tesseract, Google Lens OCR, PaddleOCR, ffmpeg, libVLC, libmpv, yt-dlp. All switched from `IsCompleted` to `IsCompletedSuccessfully`, which is only true for tasks that actually ran to completion, so a faulted or canceled download now falls through to the existing `IsFaulted` handling and shows the real error instead of hanging.

Three other download dialogs (TTS, Tesseract model, dictionaries) already used `IsCompletedSuccessfully` correctly, this brings the rest in line with that existing, correct convention.

Not Flatpak-specific and not ARM64-specific: this would hang on any download failure on any platform (network failure, unsupported platform/architecture, whatever), across all nine dialogs.

## Files
- `src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs`
- `src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs`
- `src/ui/Features/Ocr/Download/DownloadTesseractViewModel.cs`
- `src/ui/Features/Ocr/Download/DownloadGoogleLensOcrViewModel.cs`
- `src/ui/Features/Ocr/Download/DownloadPaddleOcrViewModel.cs`
- `src/ui/Features/Shared/DownloadFfmpegViewModel.cs`
- `src/ui/Features/Shared/DownloadLibVlcViewModel.cs`
- `src/ui/Features/Shared/DownloadLibMpvViewModel.cs`
- `src/ui/Features/Shared/DownloadYtDlpViewModel.cs`
