### PR TITLE
Three minor perf wins: spell check + find/replace

### DIFF
--- a/src/libuilogic/SpellCheck/SpellChecker.cs
+++ b/src/libuilogic/SpellCheck/SpellChecker.cs
@@ -32,7 +32,7 @@ public class SpellChecker : ISpellChecker, IDoSpell
 
     private WordList? _hunspellWeCantSpell;
     protected SpellCheckWordLists? WordLists;
-    protected readonly List<string> SkipAllList = new();
+    protected readonly HashSet<string> SkipAllList = new();
     protected readonly Dictionary<string, string> ChangeAllDictionary = new();
     private string _twoLetterLanguageCode = string.Empty;
 
@@ -408,7 +408,12 @@ public class SpellChecker : ISpellChecker, IDoSpell
 
     protected static bool IsEmailUrlOrHashTag(string word)
     {
-        return EmailRegex.IsMatch(word) || UrlRegex.IsMatch(word) || HashtagRegex.IsMatch(word);
+        // Each regex structurally requires its anchor character ('@', '.', '#'), so an ordinary
+        // word without one can never match - skip the (relatively expensive) regex for it. This
+        // runs once per word during spell check, and most words are none of these three.
+        return (word.Contains('@') && EmailRegex.IsMatch(word)) ||
+               (word.Contains('.') && UrlRegex.IsMatch(word)) ||
+               (word.StartsWith('#') && HashtagRegex.IsMatch(word));
     }
 
     protected static bool IsNumber(string word)

--- a/src/ui/Logic/FindService.cs
+++ b/src/ui/Logic/FindService.cs
@@ -20,6 +20,22 @@ public partial class FindService : IFindService
     private readonly List<string> _searchHistory = new List<string>();
     private const int MaxSearchHistoryItems = 10;
 
+    // ReplaceAll/Count/FindAll call into regex mode once per line; caching the last-built Regex
+    // avoids recompiling the same pattern for every line in the subtitle.
+    private string? _cachedRegexPattern;
+    private Regex? _cachedRegex;
+
+    private Regex GetCachedRegex(string pattern)
+    {
+        if (_cachedRegex == null || _cachedRegexPattern != pattern)
+        {
+            _cachedRegex = new Regex(pattern);
+            _cachedRegexPattern = pattern;
+        }
+
+        return _cachedRegex;
+    }
+
     public IReadOnlyList<string> SearchHistory => _searchHistory.AsReadOnly();
 
     public FindService()
@@ -352,7 +368,7 @@ public partial class FindService : IFindService
         searchText = RegexUtils.FixNewLine(searchText); // \r\n / \r in the pattern -> \n to match the text (#11956)
         try
         {
-            var regex = new Regex(searchText);
+            var regex = GetCachedRegex(searchText);
 
             if (startIndex > 0 && maxReplacements == 1)
             {


### PR DESCRIPTION
Three small, low-risk optimizations, no behavior changes:

- **Spell check `SkipAllList`**: `List<string>` -> `HashSet<string>`. Every use site was already `Add`/`Remove`/`Contains`/`Clear` (pure set operations), and `Contains` runs once per word during a spell-check pass - O(n) per word against a list that only grows as the user clicks "Skip all".
- **`IsEmailUrlOrHashTag`**: guard each regex with a cheap character check (`Contains('@')`, `Contains('.')`, `StartsWith('#')`) before running it. Each regex is structurally anchored on that character, so an ordinary word without it can never match - this just skips the regex engine for the overwhelming majority of words. Runs once per word.
- **`FindService.ReplaceWithRegex`**: cache the last-compiled `Regex` instead of rebuilding it for every line. "Replace All" in regex mode was recompiling the same pattern once per line in the subtitle - the pattern is loop-invariant across the whole file.

Full test suite (527 UI tests + libuilogic tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)