### PR TITLE
Two more minor perf wins: ASSA resampler + selected-lines lookup

### DIFF
--- a/src/libse/Common/AssaResampler.cs
+++ b/src/libse/Common/AssaResampler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -7,6 +8,16 @@ namespace Nikse.SubtitleEdit.Core.Common
 {
     public static class AssaResampler
     {
+        // FixDrawing runs once per dialogue line during resampling, but its tag/endTag pairs
+        // come from a small fixed vocabulary (\iclip(, \clip(, the \p drawing markers) - cache
+        // the compiled regex per pattern instead of rebuilding it for every line.
+        private static readonly ConcurrentDictionary<string, Regex> RegexCache = new ConcurrentDictionary<string, Regex>();
+
+        private static Regex GetCachedRegex(string pattern)
+        {
+            return RegexCache.GetOrAdd(pattern, p => new Regex(p));
+        }
+
         public static int Resample(decimal source, decimal target, int v)
         {
             var factor = target / source;
@@ -71,8 +82,8 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         private static string FixDrawing(decimal sourceWidth, decimal targetWidth, decimal sourceHeight, decimal targetHeight, string input, string tag, string endTag, StringBuilder errors)
         {
-            var regexStart = new Regex(tag);
-            var regexEnd = new Regex(endTag);
+            var regexStart = GetCachedRegex(tag);
+            var regexEnd = GetCachedRegex(endTag);
             var s = input;
             var match = regexStart.Match(s);
             var sb = new StringBuilder();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8067,7 +8067,7 @@ public partial class MainViewModel :
         }
 
         // Work on the selected lines in grid order.
-        var selectedItems = SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>().ToList();
+        var selectedItems = new HashSet<SubtitleLineViewModel>(SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>());
         var ordered = Subtitles.Where(s => selectedItems.Contains(s)).ToList();
         if (ordered.Count == 0)
         {
@@ -8119,7 +8119,7 @@ public partial class MainViewModel :
             return;
         }
 
-        var selectedItems = SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>().ToList();
+        var selectedItems = new HashSet<SubtitleLineViewModel>(SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>());
         var ordered = Subtitles.Where(s => selectedItems.Contains(s)).ToList();
         if (ordered.Count == 0)
         {


### PR DESCRIPTION
Two more small, low-risk optimizations found in the ongoing perf sweep this session, no behavior changes:

- **`AssaResampler.FixDrawing`**: cache the compiled `Regex` for the tag/endTag pair instead of rebuilding it on every call. The method runs once per dialogue line during ASSA resolution resampling, but the tag pairs come from a small fixed vocabulary (`\iclip(`, `\clip(`, the `\p` drawing markers), so every line rebuilt the same regexes from scratch.
- **`MainViewModel.RemoveTextForHearingImpairedSelectedLines` / `SaveSelectedLinesAs`**: `Subtitles.Where(s => selectedItems.Contains(s))` where `selectedItems` was a `List<T>` - O(total lines × selected lines) for a large selection (e.g. Ctrl+A) on a large file. The identical pattern was already fixed elsewhere in this file with a `HashSet` (see `:10974`, `:14192`) - these two call sites were missed in that earlier pass, now brought in line.

Full test suite passes: 485 libse tests + 527 UI tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)