### PR TITLE
STT: hide Purfview Faster-Whisper-XXL engine on Linux ARM64

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -187,8 +187,11 @@ public partial class SpeechToTextViewModel : ObservableObject
             Engines.Add(new WhisperEnginePurfviewFasterWhisperXxl());
             Engines.Add(new WhisperEngineConstMe());
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
+                 RuntimeInformation.ProcessArchitecture == Architecture.X64)
         {
+            // Purfview only ships Windows and Linux x86_64 builds - there is no Linux ARM64
+            // binary, so don't offer the engine on Linux ARM (it could only fail to run).
             Engines.Add(new WhisperEnginePurfviewFasterWhisperXxl());
         }
 


### PR DESCRIPTION
## Problem

Purfview's [whisper-standalone-win](https://github.com/Purfview/whisper-standalone-win/releases/tag/Faster-Whisper-XXL) only publishes **Windows** and **Linux x86_64** builds — there is no aarch64/ARM64 binary. But `SpeechToTextViewModel` added the "Purfview Faster Whisper XXL" engine for *all* Linux regardless of architecture, so on Linux ARM64 users saw an option that could only fail: selecting it downloaded a ~1.6 GB x64 archive whose executable throws `PlatformNotSupportedException`.

This is the same LinuxArm scenario that surfaced the download-hang bug fixed in #12127. That PR made the failure graceful; this one removes the dead option entirely.

## Fix

Gate the engine to Linux **X64**, mirroring how the `WhisperEngineCTranslate2` engine directly below is already restricted:

```csharp
else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
         RuntimeInformation.ProcessArchitecture == Architecture.X64)
{
    Engines.Add(new WhisperEnginePurfviewFasterWhisperXxl());
}
```

Windows behavior is unchanged. Linux x64 behavior is unchanged. Linux ARM64 no longer lists the engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)