### PR TITLE
STT: use model's real folder name for distil Whisper models (#12133)

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCTranslate2.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCTranslate2.cs
@@ -90,8 +90,13 @@ public class WhisperEngineCTranslate2 : ISpeechToTextEngine
 
     public string GetModelForCmdLine(string modelName)
     {
-        var modelFileName = Path.Combine(GetAndCreateWhisperModelFolder(null), "faster-whisper-" + modelName);
-        return modelFileName;
+        // Resolve via the model's real folder name so distil models (published as
+        // "faster-distil-whisper-...") get the correct --model path, not "faster-whisper-<name>" (#12133).
+        var model = Models.FirstOrDefault(m => m.Name == modelName);
+        var folderName = model != null
+            ? WhisperEnginePurfviewFasterWhisperXxl.GetModelFolderName(model)
+            : "faster-whisper-" + modelName;
+        return Path.Combine(GetAndCreateWhisperModelFolder(null), folderName);
     }
 
     public bool SupportsCustomModels => true;

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEnginePurfviewFasterWhisperXxl.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEnginePurfviewFasterWhisperXxl.cs
@@ -52,6 +52,21 @@ public class WhisperEnginePurfviewFasterWhisperXxl : ISpeechToTextEngine
         return folder;
     }
 
+    /// <summary>
+    /// The on-disk "_models" sub-folder name for a model. Most models follow the
+    /// "faster-whisper-&lt;name&gt;" convention, but the distil models are published as
+    /// "faster-distil-whisper-&lt;name&gt;" (the words are in a different order), so use the
+    /// model's explicit Folder when it has one. Building the name from Name alone produced
+    /// e.g. "faster-whisper-distil-large-v3.5", which faster-whisper-xxl.exe cannot find, so
+    /// it silently re-downloaded the model into its own correctly-named folder (#12133).
+    /// </summary>
+    internal static string GetModelFolderName(WhisperModel model)
+    {
+        return !string.IsNullOrEmpty(model.Folder)
+            ? model.Folder
+            : "faster-whisper-" + model.Name;
+    }
+
     public string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel)
     {
         var baseFolder = GetAndCreateWhisperFolder();
@@ -64,7 +79,7 @@ public class WhisperEnginePurfviewFasterWhisperXxl : ISpeechToTextEngine
 
         if (whisperModel != null)
         {
-            folder = Path.Combine(folder, "faster-whisper-" + whisperModel.Name);
+            folder = Path.Combine(folder, GetModelFolderName(whisperModel));
             if (!Directory.Exists(folder))
             {
                 Directory.CreateDirectory(folder);
@@ -83,20 +98,10 @@ public class WhisperEnginePurfviewFasterWhisperXxl : ISpeechToTextEngine
     public bool IsModelInstalled(WhisperModel model)
     {
         var baseFolder = GetAndCreateWhisperFolder();
-        var folder = Path.Combine(baseFolder, "_models");
-        folder = Path.Combine(folder, "faster-whisper-" + model.Name);
+        var folder = Path.Combine(baseFolder, "_models", GetModelFolderName(model));
         if (!Directory.Exists(folder))
         {
-            // Also check with the model's own Folder name (custom models)
-            if (!string.IsNullOrEmpty(model.Folder))
-            {
-                folder = Path.Combine(baseFolder, "_models", model.Folder);
-            }
-
-            if (!Directory.Exists(folder))
-            {
-                return false;
-            }
+            return false;
         }
 
         var binFileName = Path.Combine(folder, "model.bin");
@@ -118,6 +123,9 @@ public class WhisperEnginePurfviewFasterWhisperXxl : ISpeechToTextEngine
             }
         }
 
+        // Require the finished file, not an in-progress download: the downloader writes a
+        // "model.bin.$$$" partial and only renames it to "model.bin" on success, so a partial
+        // never matches above. The size floor is a second guard against a truncated file.
         var fileInfo = new FileInfo(binFileName);
         return fileInfo.Length > 10_000_000;
     }


### PR DESCRIPTION
Fixes #12133

## Problem

The Purfview Faster-Whisper-XXL / CTranslate2 model folder was built as `"faster-whisper-" + model.Name`. That's correct for most models, but the **distil** models are published under a different word order — `faster-distil-whisper-<name>`. So SE downloaded e.g. `distil-large-v3.5` into:

```
_models\faster-whisper-distil-large-v3.5\      ← SE (wrong)
```

`faster-whisper-xxl.exe` looks for `faster-distil-whisper-large-v3.5`, doesn't find it, and **silently re-downloads** the model into its own correctly-named folder — wasting bandwidth and confusing users (SE's UI reports the model as installed while the exe fetches it again). Reported for all `distil-*` models, not just v3.5.

## Root cause

Each `WhisperModel` already carries the correct folder name in its `Folder` property (`faster-distil-whisper-large-v3.5`) — the engine just wasn't using it, reconstructing the path from `Name` with a hard-coded prefix instead.

## Fix

Add `WhisperEnginePurfviewFasterWhisperXxl.GetModelFolderName()` which prefers `model.Folder` (falling back to the legacy `faster-whisper-<name>` form), and use it in the three places that built model paths by hand:

- `GetAndCreateWhisperModelFolder` (download destination; CTranslate2 delegates here)
- `IsModelInstalled`
- `WhisperEngineCTranslate2.GetModelForCmdLine` (the `--model` path passed to the exe)

Also kept `IsModelInstalled` requiring the finished `model.bin` so an in-progress `model.bin.$$$` partial is never mistaken for an installed model.

## Verification

Reproduced and confirmed on disk with a real download:

- **Before:** SE created `_models\faster-whisper-distil-large-v3.5\` (transposed, wrong)
- **After:** SE uses `_models\faster-distil-whisper-large-v3.5\`, matching what the exe expects — no more re-download

Build: `dotnet build src/ui/UI.csproj` — succeeded, 0 errors.

### Note on existing installs
Users who already downloaded a distil model on an older build have an orphaned `faster-whisper-distil-*` folder. After this fix SE looks in the correct folder and downloads once more into the right place (harmless; the old folder can be deleted). No automatic migration/rename is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)