### PR TITLE
STT: skip 404 on optional vocab file when downloading Whisper models (#12133)

### DIFF
--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
@@ -110,24 +110,7 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject
             if (_downloadTask is { IsCompletedSuccessfully: true })
             {
                 CompleteDownload();
-
-                _downloadIndex++;
-                if (_downloadIndex < _downloadUrls.Count)
-                {
-                    var url = _downloadUrls[_downloadIndex];
-                    _downloadFileName = GetDownloadFileName(_downloadModel!, url);
-                    _downloadTask = _whisperDownloadService.DownloadFile(_downloadUrls[_downloadIndex], _downloadFileName, MakeDownloadProgress(), _cancellationTokenSource.Token);
-                    ProgressFileName = string.Format(Se.Language.General.FileNameX, Path.GetFileName(_downloadUrls[_downloadIndex]));
-                    ProgressValue = 0;
-                    _timer.Start();
-
-                    return;
-                }
-
-                _downloadTask = null;
-
-                OkPressed = true;
-                Close();
+                StartNextOrFinish();
 
                 return;
             }
@@ -139,18 +122,78 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject
                 {
                     ProgressText = "Download canceled";
                     Cancel();
+
+                    return;
                 }
-                else
+
+                // A 404 (FileNotFoundException) on an optional file isn't fatal: each model
+                // ships only one of vocabulary.txt / vocabulary.json, but the URL list asks for
+                // both, so one always 404s. Skip it and continue, like faster-whisper-xxl.exe
+                // does - only model.bin is required. (#12133 follow-up)
+                if (ex is FileNotFoundException && IsOptionalFile(_downloadUrls[_downloadIndex]))
                 {
-                    ProgressText = "Download failed";
-                    Error = ex?.Message ?? "Unknown error";
+                    DeletePartialDownload();
+                    StartNextOrFinish();
+
+                    return;
                 }
+
+                ProgressText = "Download failed";
+                Error = ex?.Message ?? "Unknown error";
 
                 return;
             }
 
             _timer.Start();
         }
+    }
+
+    // Files a model may or may not ship. A model provides exactly one vocabulary variant,
+    // but the URL list requests both, so a 404 on one of these is expected, not an error.
+    private static readonly string[] OptionalFileNames = { "vocabulary.txt", "vocabulary.json" };
+
+    private static bool IsOptionalFile(string url)
+    {
+        var fileName = Path.GetFileName(url);
+        return OptionalFileNames.Any(f => f.Equals(fileName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private void StartNextOrFinish()
+    {
+        _downloadIndex++;
+        if (_downloadIndex < _downloadUrls.Count)
+        {
+            var url = _downloadUrls[_downloadIndex];
+            _downloadFileName = GetDownloadFileName(_downloadModel!, url);
+            _downloadTask = _whisperDownloadService.DownloadFile(url, _downloadFileName, MakeDownloadProgress(), _cancellationTokenSource.Token);
+            ProgressFileName = string.Format(Se.Language.General.FileNameX, Path.GetFileName(url));
+            ProgressValue = 0;
+            _timer.Start();
+
+            return;
+        }
+
+        _downloadTask = null;
+
+        OkPressed = true;
+        Close();
+    }
+
+    private void DeletePartialDownload()
+    {
+        if (!string.IsNullOrEmpty(_downloadFileName) && File.Exists(_downloadFileName))
+        {
+            try
+            {
+                File.Delete(_downloadFileName);
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+
+        _downloadFileName = string.Empty;
     }
 
     private void CompleteDownload()


### PR DESCRIPTION
Final fix for #12133 (follow-up to #12139).

## Problem

Downloading a faster-whisper model (e.g. `distil-large-v3.5`) failed with **"Download failed"** on `vocabulary.txt`.

Each model ships **exactly one** vocabulary variant:
- `Systran/faster-whisper-tiny` → `vocabulary.txt`
- `large-v3`, `Systran/faster-distil-whisper-large-v3`, `Purfview/faster-distil-whisper-large-v3.5`, … → `vocabulary.json`

…but SE's hard-coded URL list requests **both**. The one the repo lacks returns HTTP 404, which `DownloadHelper` converts to a `FileNotFoundException` that is deliberately excluded from the retry filter — so it propagates and faults the entire model download.

`faster-whisper-xxl.exe` doesn't have this problem: it only fetches the files that exist.

## Fix

Treat a 404 on an **optional** file (`vocabulary.txt` / `vocabulary.json`) as non-fatal — skip it and continue to the next file, just like the exe does. Only `model.bin` is required. The 0-byte partial the 404 leaves behind is deleted.

Refactored the "advance to next URL" logic out of the success path into a shared `StartNextOrFinish()` so both the success and skip paths reuse it (no duplicated state-machine code).

## Verification

- Reproduced: `distil-large-v3.5` download failed on `vocabulary.txt` (confirmed HF returns 404 for it, 307/exists for `vocabulary.json`).
- With the fix: the download skips `vocabulary.txt` and completes into `_models\faster-distil-whisper-large-v3.5` (the correct folder from #12139). Confirmed working in the running app.
- Build: `dotnet build src/ui/UI.csproj` — succeeded, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)