### PR TITLE
Waveform: mouse-wheel to set video position (#12134)

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -667,7 +667,57 @@ public class AudioVisualizer : Control
         {
             scrollDelta = InvertMouseWheel ? -e.Delta.X : e.Delta.X;
         }
-        
+
+        // SE 4 parity: seek the video position (step forward/back) instead of scrolling the view.
+        // Ctrl/Meta still keep their scroll + set-position-at-cursor behavior below.
+        if (Se.Settings.Waveform.MouseWheelSetsVideoPosition && !_isCtrlDown && !_isMetaDown)
+        {
+            // One "notch" per event; magnitude scales with the delta for fast wheels/trackpads.
+            var notches = scrollDelta > 0 ? Math.Ceiling(scrollDelta) : Math.Floor(scrollDelta);
+            var stepMs = Se.Settings.Waveform.MouseWheelVideoPositionStepMs;
+
+            double newVideoPosition;
+            var fps = Se.Settings.General.CurrentFrameRate;
+            if (stepMs <= 0 && fps >= 1)
+            {
+                // Frame step: quantize to the frame grid and move whole frames.
+                var currentFrame = Math.Round(CurrentVideoPositionSeconds * fps);
+                newVideoPosition = (currentFrame + notches) / fps;
+            }
+            else
+            {
+                // Millisecond step (also the fallback when a frame step has no frame rate).
+                var stepSeconds = stepMs > 0 ? stepMs / 1000.0 : 0.5;
+                newVideoPosition = CurrentVideoPositionSeconds + notches * stepSeconds;
+            }
+
+            if (newVideoPosition < 0)
+            {
+                newVideoPosition = 0;
+            }
+
+            if (WavePeaks != null && newVideoPosition > WavePeaks.LengthInSeconds)
+            {
+                newVideoPosition = WavePeaks.LengthInSeconds;
+            }
+
+            // Follow the play-head: scroll the view only when it would leave the visible range.
+            var visibleSeconds = EndPositionSeconds - StartPositionSeconds;
+            if (visibleSeconds > 0 && (newVideoPosition < StartPositionSeconds || newVideoPosition > EndPositionSeconds))
+            {
+                var followStart = newVideoPosition - visibleSeconds / 2;
+                StartPositionSeconds = followStart < 0 ? 0 : followStart;
+                OnHorizontalScroll?.Invoke(this, new PositionEventArgs { PositionInSeconds = StartPositionSeconds });
+            }
+
+            // Update locally so rapid wheeling builds on the new position before the player reports back.
+            CurrentVideoPositionSeconds = newVideoPosition;
+            OnVideoPositionChanged?.Invoke(this, new PositionEventArgs { PositionInSeconds = newVideoPosition });
+
+            InvalidateVisual();
+            return;
+        }
+
         var newStart = StartPositionSeconds + scrollDelta / 2;
         if (newStart < 0)
         {

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -517,6 +517,9 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformFocusOnMouseOver, nameof(_vm.WaveformFocusOnMouseOver)),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformFocusTextboxAfterInsertNew, nameof(_vm.WaveformFocusTextboxAfterInsertNew)),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformInvertMouseWheel, nameof(_vm.WaveformInvertMouseWheel)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.WaveformMouseWheelSetsVideoPosition, nameof(_vm.WaveformMouseWheelSetsVideoPosition)),
+            new SettingsItem(Se.Language.Options.Settings.WaveformMouseWheelVideoPositionStep,
+                () => UiUtil.MakeComboBox(_vm.WaveformMouseWheelVideoPositionSteps, _vm, nameof(_vm.SelectedWaveformMouseWheelVideoPositionStep))),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformDrawGridLines, nameof(_vm.WaveformDrawGridLines)),
             new SettingsItem(Se.Language.Options.Settings.WaveformTextFontSize, () => UiUtil.MakeNumericUpDownInt(
                 10 ,

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -271,6 +271,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private Color _waveformParagraphRightColor;
     [ObservableProperty] private Color _waveformFancyHighColor;
     [ObservableProperty] private bool _waveformInvertMouseWheel;
+    [ObservableProperty] private bool _waveformMouseWheelSetsVideoPosition;
     [ObservableProperty] private bool _waveformSnapToShotChanges;
     [ObservableProperty] private bool _waveformSnapToFrames;
     [ObservableProperty] private bool _waveformShotChangesAutoGenerate;
@@ -283,6 +284,36 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<string> _waveformDoubleClickActionTypes;
     [ObservableProperty] private string _selectedWaveformDoubleClickActionType;
 
+    [ObservableProperty] private ObservableCollection<string> _waveformMouseWheelVideoPositionSteps;
+    [ObservableProperty] private string _selectedWaveformMouseWheelVideoPositionStep;
+
+    // Selectable wheel step sizes (ms). 0 = one frame.
+    private static readonly int[] MouseWheelStepValuesMs = { 0, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000 };
+
+    private static string FormatMouseWheelStep(int ms)
+    {
+        if (ms <= 0)
+        {
+            return Se.Language.Options.Settings.WaveformMouseWheelStepOneFrame;
+        }
+
+        return ms >= 1000
+            ? Se.Language.Options.Settings.WaveformMouseWheelStepOneSecond
+            : string.Format(CultureInfo.InvariantCulture, Se.Language.Options.Settings.WaveformMouseWheelStepMilliseconds, ms);
+    }
+
+    private static int ParseMouseWheelStep(string display)
+    {
+        foreach (var ms in MouseWheelStepValuesMs)
+        {
+            if (FormatMouseWheelStep(ms) == display)
+            {
+                return ms;
+            }
+        }
+
+        return 500;
+    }
     [ObservableProperty] private ObservableCollection<string> _waveformExtractAudioFormats;
     [ObservableProperty] private string _selectedWaveformExtractAudioFormat;
     [ObservableProperty] private ObservableCollection<string> _waveformExtractAudioSampleRates;
@@ -466,6 +497,13 @@ public partial class SettingsViewModel : ObservableObject
         SelectedWaveformExtractAudioSampleRate = WaveformExtractAudioSampleRates[0];
         WaveformExtractAudioBitRates = new ObservableCollection<string> { "96k", "128k", "192k", "256k", "320k" };
         SelectedWaveformExtractAudioBitRate = "192k";
+
+        WaveformMouseWheelVideoPositionSteps = new ObservableCollection<string>();
+        foreach (var ms in MouseWheelStepValuesMs)
+        {
+            WaveformMouseWheelVideoPositionSteps.Add(FormatMouseWheelStep(ms));
+        }
+        SelectedWaveformMouseWheelVideoPositionStep = FormatMouseWheelStep(500);
 
         var subtitleFormats = SubtitleFormat.AllSubtitleFormats;
         var defaultSubtitleFormats = new List<string>();
@@ -860,6 +898,11 @@ public partial class SettingsViewModel : ObservableObject
         WaveformParagraphRightColor = Se.Settings.Waveform.WaveformParagraphRightColor.FromHexToColor();
         WaveformFancyHighColor = Se.Settings.Waveform.WaveformFancyHighColor.FromHexToColor();
         WaveformInvertMouseWheel = Se.Settings.Waveform.InvertMouseWheel;
+        WaveformMouseWheelSetsVideoPosition = Se.Settings.Waveform.MouseWheelSetsVideoPosition;
+        var mouseWheelStepDisplay = FormatMouseWheelStep(Se.Settings.Waveform.MouseWheelVideoPositionStepMs);
+        SelectedWaveformMouseWheelVideoPositionStep = WaveformMouseWheelVideoPositionSteps.Contains(mouseWheelStepDisplay)
+            ? mouseWheelStepDisplay
+            : FormatMouseWheelStep(500);
         WaveformSnapToShotChanges = Se.Settings.Waveform.SnapToShotChanges;
         WaveformSnapToFrames = Se.Settings.Waveform.SnapToFrames;
         WaveformShotChangesAutoGenerate = Se.Settings.Waveform.ShotChangesAutoGenerate;
@@ -1555,6 +1598,8 @@ public partial class SettingsViewModel : ObservableObject
         Se.Settings.Waveform.WaveformParagraphRightColor = WaveformParagraphRightColor.FromColorToHex();
         Se.Settings.Waveform.WaveformFancyHighColor = WaveformFancyHighColor.FromColorToHex();
         Se.Settings.Waveform.InvertMouseWheel = WaveformInvertMouseWheel;
+        Se.Settings.Waveform.MouseWheelSetsVideoPosition = WaveformMouseWheelSetsVideoPosition;
+        Se.Settings.Waveform.MouseWheelVideoPositionStepMs = ParseMouseWheelStep(SelectedWaveformMouseWheelVideoPositionStep);
         Se.Settings.Waveform.SnapToShotChanges = WaveformSnapToShotChanges;
         Se.Settings.Waveform.SnapToFrames = WaveformSnapToFrames;
         Se.Settings.Waveform.ShotChangesAutoGenerate = WaveformShotChangesAutoGenerate;

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -151,6 +151,11 @@ public class LanguageSettings
     public string ShowWaveformToolbarPlaybackSpeed { get; set; }
     public string WaveformFocusTextboxAfterInsertNew { get; set; }
     public string WaveformInvertMouseWheel { get; set; }
+    public string WaveformMouseWheelSetsVideoPosition { get; set; }
+    public string WaveformMouseWheelVideoPositionStep { get; set; }
+    public string WaveformMouseWheelStepOneFrame { get; set; }
+    public string WaveformMouseWheelStepOneSecond { get; set; }
+    public string WaveformMouseWheelStepMilliseconds { get; set; }
     public string WaveformSnapToShotChanges { get; set; }
     public string WaveformSnapToFrames { get; set; }
     public string WaveformShotChangesAutoGenerate { get; set; }
@@ -474,6 +479,11 @@ public class LanguageSettings
         ShowWaveformToolbarPlaybackSpeed = "Toolbar: show playback speed";
         WaveformFocusTextboxAfterInsertNew = "Focus text box after insert";
         WaveformInvertMouseWheel = "Invert mouse-wheel";
+        WaveformMouseWheelSetsVideoPosition = "Mouse-wheel sets video position";
+        WaveformMouseWheelVideoPositionStep = "Mouse-wheel video position step";
+        WaveformMouseWheelStepOneFrame = "1 frame";
+        WaveformMouseWheelStepOneSecond = "1 second";
+        WaveformMouseWheelStepMilliseconds = "{0} ms";
         WaveformSnapToShotChanges = "Snap to shot changes (hold Shift to override)";
         WaveformSnapToFrames = "Snap to frames";
         WaveformShotChangesAutoGenerate = "Shot changes auto-generate";

--- a/src/ui/Logic/Config/SeWaveform.cs
+++ b/src/ui/Logic/Config/SeWaveform.cs
@@ -28,6 +28,15 @@ public class SeWaveform
     public string ParagraphBackground { get; set; }
     public string ParagraphSelectedBackground { get; set; }
     public bool InvertMouseWheel { get; set; }
+
+    // SE 4 parity: when true, the mouse wheel over the waveform seeks the video position
+    // forward/backward (in steps) instead of scrolling the view. The view follows the
+    // play-head so it stays visible. Defaults to false (SE 5 scroll behavior). Issue #12134.
+    public bool MouseWheelSetsVideoPosition { get; set; }
+
+    // Step size per wheel notch when MouseWheelSetsVideoPosition is on.
+    // 0 = one frame (uses General.CurrentFrameRate); otherwise the step in milliseconds.
+    public int MouseWheelVideoPositionStepMs { get; set; }
     public double ShotChangesSensitivity { get; set; }
     public string ShotChangesImportTimeCodeFormat { get; set; }
     public bool SnapToShotChanges { get; set; }
@@ -128,6 +137,8 @@ public class SeWaveform
 
         WaveformShowNumberAndDuration = true;
         WaveformShowCps = true;
+
+        MouseWheelVideoPositionStepMs = 500;
 
         ToolbarItems =
         [


### PR DESCRIPTION
Resolves #12134 — restores SE 4-style waveform navigation where the mouse wheel moves through the audio (moves the play-head), rather than only panning the SE 5 view.

## What

- **New Waveform setting: "Mouse-wheel sets video position"** (default **off**). When on, rolling the wheel over the waveform/spectrogram seeks the video position forward/backward instead of scrolling the view. The view follows the play-head so it stays visible.
- **New "Mouse-wheel video position step" dropdown**: `1 frame` (quantized to the frame grid via the current frame rate) or `100 ms` … `1 second`. Default **500 ms**. Fast wheel/trackpad deltas scale the step proportionally (more than one step per event).

Modifiers are unchanged and backward-compatible:
- **Ctrl/Meta + wheel** → existing scroll + set-position-at-cursor behavior
- **Alt + wheel** → horizontal zoom, **Shift + wheel** → vertical zoom
- With the setting **off**, a plain wheel scrolls the view exactly as before.

## Settings

- `Waveform.MouseWheelSetsVideoPosition` (bool, default false)
- `Waveform.MouseWheelVideoPositionStepMs` (int, default 500; `0` = one frame)

## Files

- `AudioVisualizer.cs` — seek-by-step branch in `OnPointerWheelChanged`, clamped to `[0, LengthInSeconds]`, updates the play-head locally so rapid wheeling stays responsive
- `SeWaveform.cs` — the two settings + defaults
- `SettingsViewModel.cs` / `SettingsPage.cs` — checkbox + step dropdown, load/save
- `LanguageSettings.cs` — localizable labels (including a `{0} ms` format string for the step entries)

Follows the existing `InvertMouseWheel` settings pattern throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)