### PR TITLE
Spell check: don't flag a lone ending quote as an unknown word (#12143)

### DIFF
--- a/src/libuilogic/SpellCheck/SpellCheckWordLists.cs
+++ b/src/libuilogic/SpellCheck/SpellCheckWordLists.cs
@@ -22,6 +22,7 @@ public class SpellCheckWordLists
     };
 
     private static readonly char[] PeriodAndDash = { '.', '-' };
+    private static readonly char[] ApostropheChars = { '\'', '‘', '’' };
     private static readonly char[] SplitChars2 = { ' ', '.', ',', '?', '!', ':', ';', '"', '“', '”', '(', ')', '[', ']', '{', '}', '|', '<', '>', '/', '+', '\r', '\n', '¿', '¡', '…', '—', '–', '♪', '♫', '„', '«', '»', '‹', '›', '؛', '،', '؟' };
 
     private readonly NameList _nameList;
@@ -539,7 +540,7 @@ public class SpellCheckWordLists
             {
                 if (sb.Length > 0)
                 {
-                    list.Add(new SpellCheckWord { Text = sb.ToString(), Index = i - sb.Length });
+                    AddWord(list, sb.ToString(), i - sb.Length);
                 }
 
                 sb.Clear();
@@ -551,10 +552,24 @@ public class SpellCheckWordLists
         }
         if (sb.Length > 0)
         {
-            list.Add(new SpellCheckWord { Text = sb.ToString(), Index = s.Length - sb.Length });
+            AddWord(list, sb.ToString(), s.Length - sb.Length);
         }
 
         return list;
+    }
+
+    // A token consisting solely of apostrophes/quote marks (e.g. the trailing ' in "...universum.'")
+    // is punctuation, not a word. The apostrophe is intentionally not a split char so contractions
+    // ('n, don't) and quote-wrapped words ('Met de waarheid') stay intact, but a lone quote must not
+    // be spell-checked - it has no word characters and would just be flagged as unknown. (#12143)
+    private static void AddWord(List<SpellCheckWord> list, string text, int index)
+    {
+        if (text.Trim(ApostropheChars).Length == 0)
+        {
+            return;
+        }
+
+        list.Add(new SpellCheckWord { Text = text, Index = index });
     }
 
     public List<string> GetAllNames()

--- a/tests/UI/Features/SpellCheck/SplitLoneQuoteTests.cs
+++ b/tests/UI/Features/SpellCheck/SplitLoneQuoteTests.cs
@@ -1,0 +1,56 @@
+using Nikse.SubtitleEdit.Features.SpellCheck;
+using System.Linq;
+
+namespace UITests.Features.SpellCheck;
+
+// #12143: a subtitle wrapped in single quotes (e.g. 'Met de waarheid\nverover ik het universum.')
+// made the tokenizer emit the trailing quote as its own word ("'"), which spell check then flagged
+// as unknown. Split must not emit tokens that consist solely of apostrophe/quote characters, while
+// keeping quote-wrapped words and contractions intact.
+public class SplitLoneQuoteTests
+{
+    [Fact]
+    public void Split_ShouldNotEmitTrailingLoneQuote()
+    {
+        var words = SpellCheckWordLists.Split("verover ik het universum.'");
+
+        Assert.DoesNotContain(words, w => w.Text == "'");
+        Assert.Equal(new[] { "verover", "ik", "het", "universum" }, words.Select(w => w.Text));
+    }
+
+    [Fact]
+    public void Split_ShouldKeepQuoteWrappedWord()
+    {
+        // The leading quote stays attached to the word so the checker's Trim('\'') retry can validate it.
+        var words = SpellCheckWordLists.Split("'Met de waarheid");
+
+        Assert.Equal(new[] { "'Met", "de", "waarheid" }, words.Select(w => w.Text));
+    }
+
+    [Fact]
+    public void Split_ShouldKeepContraction()
+    {
+        var words = SpellCheckWordLists.Split("'n beetje don't");
+
+        Assert.Equal(new[] { "'n", "beetje", "don't" }, words.Select(w => w.Text));
+    }
+
+    [Fact]
+    public void Split_ShouldDropStandaloneQuoteToken()
+    {
+        // A lone quote surrounded by spaces (or typographic single quotes) carries no word content.
+        var words = SpellCheckWordLists.Split("hallo ' ’ wereld");
+
+        Assert.Equal(new[] { "hallo", "wereld" }, words.Select(w => w.Text));
+    }
+
+    [Fact]
+    public void Split_ShouldPreserveIndexOfKeptWords()
+    {
+        var words = SpellCheckWordLists.Split("universum.'");
+
+        var word = Assert.Single(words);
+        Assert.Equal("universum", word.Text);
+        Assert.Equal(0, word.Index);
+    }
+}


### PR DESCRIPTION
Fixes #12143.

## Problem

A subtitle wrapped in single quotes, e.g.:

```
'Met de waarheid
verover ik het universum.'
```

made the Spell check stop on **"Word not found" = `'`** (just the trailing closing quote), offering nonsense suggestions.

## Root cause

`SpellCheckWordLists.Split()` intentionally does **not** treat the straight quote `'` as a split character, so contractions (`'n`, `don't`) and quote-wrapped words (`'Met`) stay intact (fix #11975). But for `…universum.'`, the `.` splits off `universum` and the trailing `'` accumulates alone, so `Split` emits a standalone `'` token.

`IsWordCorrect`'s "retry without wrapping quotes" step is guarded by `trimmed.Length > 0`, and `"'".Trim('\'')` is empty — so the lone quote falls through and is reported as misspelled. The same defect exists in both correctness paths (the Spell check dialog in `SpellCheckManager` and the live red-underline in `SpellChecker`), since both tokenize via `Split`.

## Fix

`Split` no longer emits a token that consists solely of apostrophe/quote characters (`'`, `‘`, `’`) — such a token has no word content and can never be a dictionary word. Fixing it at the tokenizer covers the dialog, live underline, and syntax highlighting in one place, and doesn't shift the `Index`/`Length` of the real words (quote-wrapped words like `'Met` and contractions are unchanged).

## Tests

Added `SplitLoneQuoteTests` (5 cases): trailing lone quote dropped, quote-wrapped word kept, contractions kept, standalone/typographic quote tokens dropped, and kept-word offsets preserved. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)