### PR TITLE
Fix common OCR errors: apply replace list without a Hunspell dictionary (#12126)

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,7 @@ Subtitle Edit Changelog
 
 v5.1.0-beta8 (3rd of July 2026)
 
+* Fix "Fix common OCR errors" doing nothing when no Hunspell dictionary is installed for the language - the OCR replace list (e.g. spa_OCRFixReplaceList.xml) is now applied on its own again - thx perkesfurmah-collab
 * Fix UI freeze when switching to layout 12 (no video pane) with a video loaded
 * Text to speech: review window - Space no longer clicks OK on key release either (Avalonia raises a focused button's click on Space key-up, independent of the tunnel-stage fix in beta7) - thx cvrle77
 * Text to speech: fix the Import/Export/merge-output file dialogs and the TTS window dropping behind the main window on Windows - thx cvrle77

--- a/src/seconv/Core/FixCommonErrorsRunner.cs
+++ b/src/seconv/Core/FixCommonErrorsRunner.cs
@@ -130,7 +130,8 @@ internal static class FixCommonErrorsRunner
     /// <summary>
     /// Applies the OCR-fix engine (OCR replace lists + Hunspell spell-check guessing) to every line,
     /// the headless equivalent of the GUI's "Fix common OCR errors". No-op when no dictionary folder
-    /// is configured or no Hunspell dictionary matches the detected language. (#11744)
+    /// is configured. When no Hunspell dictionary matches the language the OCR replace list is still
+    /// applied (the spell-check-driven guessing is skipped). (#11744, #12126)
     /// </summary>
     private static void RunOcrFix(Subtitle subtitle, string twoLetterLanguage)
     {
@@ -147,12 +148,14 @@ internal static class FixCommonErrorsRunner
         }
 
         var spellChecker = new SpellChecker();
+
+        // Fall back to an empty dictionary display when no Hunspell dictionary is installed for the
+        // language: the OCR replace list is still applied, the spell-check-driven "guess" path is just a
+        // no-op. Only en_US.dic ships with SE, so gating on a matching .dic made this silently do nothing
+        // for other languages on a fresh config - a regression from SE 4 (issue #12126).
         var dictionary = spellChecker.GetDictionaryLanguages(folder)
-            .FirstOrDefault(d => d.GetThreeLetterCode() == threeLetter);
-        if (dictionary == null)
-        {
-            return;
-        }
+            .FirstOrDefault(d => d.GetThreeLetterCode() == threeLetter)
+            ?? new SpellCheckDictionaryDisplay();
 
         IOcrFixEngine engine = new OcrFixEngine(spellChecker);
         engine.Initialize(subtitle, threeLetter, dictionary);

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonOcrErrors.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonOcrErrors.cs
@@ -33,11 +33,14 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 
             var spellCheckManager = new SpellCheckManager();
             var spellCheckers = spellCheckManager.GetDictionaryLanguages(Se.DictionariesFolder);
-            var spellChecker = spellCheckers.FirstOrDefault(x => x.GetThreeLetterCode() == threeLetterCode);
-            if (spellChecker == null)
-            {
-                return;
-            }
+
+            // Fall back to an empty dictionary display when no Hunspell dictionary is installed for the
+            // language. The OCR replace list (e.g. spa_OCRFixReplaceList.xml) is applied regardless of
+            // spell-checking; without a dictionary the spell-check-driven "guess" path is simply a no-op.
+            // Requiring a matching .dic here made the feature silently do nothing on a fresh config, since
+            // only en_US.dic ships with SE - a regression from SE 4 (issue #12126).
+            var spellChecker = spellCheckers.FirstOrDefault(x => x.GetThreeLetterCode() == threeLetterCode)
+                               ?? new SpellCheckDictionaryDisplay();
 
             OcrFixEngine.Initialize(subtitle, threeLetterCode, spellChecker);
 

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixNoDictionaryReplaceListTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixNoDictionaryReplaceListTests.cs
@@ -1,0 +1,100 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
+using Nikse.SubtitleEdit.Core.Interfaces;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+// #12126: "Fix common OCR errors" applied no corrections on a fresh config because it required a
+// matching Hunspell dictionary (.dic) - and only en_US.dic ships with SE. The OCR replace list is
+// spell-check independent, so its replacements must still be applied when no dictionary is installed
+// (this worked in SE 4). Drives the real FixCommonOcrErrors.Fix path with only the bundled-style
+// spa_OCRFixReplaceList.xml present and no Spanish dictionary - the exact reporter scenario.
+public class OcrFixNoDictionaryReplaceListTests : IDisposable
+{
+    private readonly string _originalSeDictionariesFolder;
+    private readonly Func<string> _originalSpellCheckDictionariesFolder;
+    private readonly IOcrFixEngine? _originalOcrFixEngine;
+    private readonly string _tempDictionariesFolder;
+
+    public OcrFixNoDictionaryReplaceListTests()
+    {
+        _originalSeDictionariesFolder = Se.DictionariesFolder;
+        _originalSpellCheckDictionariesFolder = SpellCheckConfig.DictionariesFolder;
+        _originalOcrFixEngine = FixCommonOcrErrors.OcrFixEngine;
+
+        _tempDictionariesFolder = Path.Combine(
+            Path.GetTempPath(),
+            "SeOcrFixNoDicTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDictionariesFolder);
+        Se.DictionariesFolder = _tempDictionariesFolder;
+        SpellCheckConfig.DictionariesFolder = () => _tempDictionariesFolder;
+
+        // Spanish OCR replace list with the reporter's whole-word accent fixes. No spa .dic/.aff -
+        // so there is no Hunspell dictionary for the language.
+        File.WriteAllText(
+            Path.Combine(_tempDictionariesFolder, "spa_OCRFixReplaceList.xml"),
+            "<ReplaceList><WholeWords>" +
+            "<Word from=\"aca\" to=\"acá\" />" +
+            "<Word from=\"dia\" to=\"día\" />" +
+            "</WholeWords></ReplaceList>");
+    }
+
+    [Fact]
+    public void Fix_WithoutHunspellDictionary_StillAppliesOcrReplaceList()
+    {
+        FixCommonOcrErrors.OcrFixEngine = new OcrFixEngine(new SpellChecker());
+
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hola, aca estoy. Un dia volvere.", 0, 3000));
+
+        var callbacks = new FakeFixCallbacks("es");
+        new FixCommonOcrErrors().Fix(subtitle, callbacks);
+
+        Assert.Equal("Hola, acá estoy. Un día volvere.", subtitle.Paragraphs[0].Text);
+        Assert.Equal(1, callbacks.FixCount);
+    }
+
+    public void Dispose()
+    {
+        Se.DictionariesFolder = _originalSeDictionariesFolder;
+        SpellCheckConfig.DictionariesFolder = _originalSpellCheckDictionariesFolder;
+        FixCommonOcrErrors.OcrFixEngine = _originalOcrFixEngine;
+        try
+        {
+            Directory.Delete(_tempDictionariesFolder, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private sealed class FakeFixCallbacks : IFixCallbacks
+    {
+        public FakeFixCallbacks(string language) => Language = language;
+
+        public int FixCount { get; private set; }
+
+        public bool AllowFix(Paragraph p, string action) => true;
+        public void AddFixToListView(Paragraph p, string action, string before, string after) => FixCount++;
+        public void AddFixToListView(Paragraph p, string action, string before, string after, bool isChecked) => FixCount++;
+        public void LogStatus(string sender, string message) { }
+        public void LogStatus(string sender, string message, bool isImportant) { }
+        public void UpdateFixStatus(int fixes, string message) { }
+        public bool IsName(string candidate) => false;
+        public HashSet<string> GetAbbreviations() => new();
+        public void AddToTotalErrors(int count) { }
+        public void AddToDeleteIndices(int index) { }
+        public SubtitleFormat Format => new SubRip();
+        public Encoding Encoding => Encoding.UTF8;
+        public string Language { get; }
+    }
+}


### PR DESCRIPTION
Fixes #12126.

## Problem
"Fix common OCR errors" applied **zero** corrections on a fresh config for any non-English language, even though the OCR replace list (e.g. `spa_OCRFixReplaceList.xml`) was present and valid. This is a regression from SE 4, where the replace list was applied independently of whether a Hunspell spell-check dictionary was installed.

## Root cause
Both the GUI (`FixCommonOcrErrors.Fix`) and CLI (`FixCommonErrorsRunner.RunOcrFix`) required a matching Hunspell `.dic` file and returned early if none was found:

```csharp
var spellChecker = spellCheckers.FirstOrDefault(x => x.GetThreeLetterCode() == threeLetterCode);
if (spellChecker == null)
{
    return; // no Spanish .dic → nothing happens
}
```

`GetDictionaryLanguages` only enumerates `*.dic` files, and **only `en_US.dic` ships with SE**. So after deleting config, a Spanish file matched no dictionary and the replace list was never touched — despite `aca`→`acá`, `dia`→`día` etc. being pure whole-word substitutions that need no spell checker.

## Fix
Fall back to an empty `SpellCheckDictionaryDisplay` when no matching `.dic` is found. The replace list still loads and its substitutions are applied; the only dictionary-dependent branch — the "guess unknown words" path — naturally degrades to a no-op without a dictionary, so no spurious changes occur. This restores SE 4 behavior.

## Verification
- New regression test `OcrFixNoDictionaryReplaceListTests` drives the real `FixCommonOcrErrors.Fix` with the reporter's Spanish scenario and no dictionary installed.
- Confirmed it fails against the pre-fix code (`"Hola, aca estoy. Un dia volvere."` unchanged) and passes after (`"Hola, acá estoy. Un día volvere."`).
- Full OCR + SpellCheck suites pass (72/72); `seconv` builds clean.

Note: words missing from the bundled list (e.g. `Adios`, `Algun`, `volvere`) still require a real Spanish Hunspell dictionary — as expected — but listed words now work as they did in SE 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
