### PR TITLE
Google Lens Sharp: restore word order for multi-line subtitles (#12149)

### DIFF
--- a/src/ui/Logic/Ocr/GoogleLens/LensCore.cs
+++ b/src/ui/Logic/Ocr/GoogleLens/LensCore.cs
@@ -212,7 +212,71 @@ public class LensCore
             }
         }
 
+        segments = OrderSegmentsIntoReadingLines(segments);
+
         return new LensResult(detectedLanguage, segments);
+    }
+
+    /// <summary>
+    /// Google Lens returns the text chunks of a multi-line subtitle interleaved between the visual
+    /// rows (e.g. top-word, bottom-word, top-word, ...), which scrambles the sentence. Use each
+    /// chunk's bounding box to restore reading order: group chunks into rows by their vertical
+    /// center, order the rows top-to-bottom and the chunks within a row left-to-right, then merge
+    /// each row into a single line. No-op when boxes are missing (all default), so this can only
+    /// improve ordering, never worsen it. (#12149)
+    /// </summary>
+    internal static List<Segment> OrderSegmentsIntoReadingLines(List<Segment> segments)
+    {
+        if (segments.Count < 2)
+        {
+            return segments;
+        }
+
+        // When geometry is missing every chunk carries the same default centre box; there is nothing
+        // to sort by, so leave the segments (and their line breaks) exactly as they came.
+        var first = segments[0].BoundingBox;
+        var allSameBox = segments.All(s =>
+            s.BoundingBox.CenterPerX == first.CenterPerX &&
+            s.BoundingBox.CenterPerY == first.CenterPerY);
+        if (allSameBox)
+        {
+            return segments;
+        }
+
+        // Sorting by vertical center makes rows appear top-to-bottom; a new row is only started when
+        // a chunk's center is farther than half a line height from the current row's reference.
+        var byTop = segments.OrderBy(s => s.BoundingBox.CenterPerY).ToList();
+        var rows = new List<List<Segment>>();
+        foreach (var seg in byTop)
+        {
+            var placed = false;
+            foreach (var row in rows)
+            {
+                var reference = row[0];
+                var threshold = Math.Min(seg.BoundingBox.PerHeight, reference.BoundingBox.PerHeight) * 0.5;
+                if (Math.Abs(seg.BoundingBox.CenterPerY - reference.BoundingBox.CenterPerY) <= threshold)
+                {
+                    row.Add(seg);
+                    placed = true;
+                    break;
+                }
+            }
+
+            if (!placed)
+            {
+                rows.Add(new List<Segment> { seg });
+            }
+        }
+
+        var result = new List<Segment>(rows.Count);
+        foreach (var row in rows)
+        {
+            var inReadingOrder = row.OrderBy(s => s.BoundingBox.CenterPerX).ToList();
+            var text = string.Join(" ", inReadingOrder.Select(s => s.Text));
+            result.Add(new Segment(text, inReadingOrder[0].BoundingBox));
+        }
+
+        return result;
     }
 
     protected async Task<LensProtoResponse> SendProtoRequest(byte[] serializedRequest, string twoLetterLanguageCode)

--- a/src/ui/Logic/Ocr/GoogleLens/Proto/LensProtoResponse.cs
+++ b/src/ui/Logic/Ocr/GoogleLens/Proto/LensProtoResponse.cs
@@ -125,10 +125,19 @@ public class LensProtoResponse
                                         while (!wReader.IsAtEnd)
                                         {
                                             var wTag = wReader.ReadTag();
-                                            if (WireFormat.GetTagFieldNumber(wTag) == 1)
+                                            var wField = WireFormat.GetTagFieldNumber(wTag);
+                                            if (wField == 1)
                                             {
                                                 var wordBytes = wReader.ReadBytes().ToByteArray();
                                                 line.Words.Add(ParseWord(wordBytes));
+                                            }
+                                            else if (wField == 2)
+                                            {
+                                                // Line-level geometry (bounding box). Google returns the text
+                                                // chunks of a multi-line subtitle interleaved between rows, so we
+                                                // need each chunk's position to restore reading order. (#12149)
+                                                var geometryBytes = wReader.ReadBytes().ToByteArray();
+                                                line.Geometry = ParseGeometry(geometryBytes);
                                             }
                                             else
                                             {
@@ -179,170 +188,38 @@ public class LensProtoResponse
         return null;
     }
 
-    private static Paragraph ParseParagraph(byte[] data)
-    {
-        var paragraph = new Paragraph();
-        
-        Console.WriteLine($"DEBUG ParseParagraph: data length = {data.Length}");
-        Console.WriteLine($"DEBUG ParseParagraph: first 50 bytes = {BitConverter.ToString(data.Take(Math.Min(50, data.Length)).ToArray())}");
-        
-        using var stream = new MemoryStream(data);
-        using var reader = new CodedInputStream(stream);
-
-        try
-        {
-            while (!reader.IsAtEnd)
-            {
-                var tag = reader.ReadTag();
-                var fieldNumber = WireFormat.GetTagFieldNumber(tag);
-                Console.WriteLine($"DEBUG ParseParagraph: field {fieldNumber}");
-
-                switch (fieldNumber)
-                {
-                    case 1:
-                        paragraph.ContentLanguage = reader.ReadString();
-                        Console.WriteLine($"DEBUG ParseParagraph: ContentLanguage = '{paragraph.ContentLanguage}'");
-                        break;
-                        
-                    case 2:
-                        var lineData = reader.ReadBytes();
-                        Console.WriteLine($"DEBUG ParseParagraph: Reading line, data length = {lineData.Length}");
-                        paragraph.Lines.Add(ParseLine(lineData.ToByteArray()));
-                        break;
-                        
-                    case 3:
-                        var geometryData = reader.ReadBytes();
-                        Console.WriteLine($"DEBUG ParseParagraph: Reading geometry, data length = {geometryData.Length}");
-                        paragraph.Geometry = ParseGeometry(geometryData.ToByteArray());
-                        break;
-                        
-                    default:
-                        reader.SkipLastField();
-                        Console.WriteLine($"DEBUG ParseParagraph: Skipped field {fieldNumber}");
-                        break;
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"DEBUG ParseParagraph ERROR: {ex.Message}");
-            Console.WriteLine($"DEBUG ParseParagraph: Stream position {stream.Position}/{stream.Length}");
-            throw;
-        }
-
-        Console.WriteLine($"DEBUG ParseParagraph: Returning paragraph with {paragraph.Lines.Count} lines");
-        return paragraph;
-    }
-
-    private static Line ParseLine(byte[] data)
-    {
-        var line = new Line();
-        
-        Console.WriteLine($"DEBUG ParseLine: data length = {data.Length}");
-        
-        using var stream = new MemoryStream(data);
-        using var reader = new CodedInputStream(stream);
-
-        try
-        {
-            while (!reader.IsAtEnd)
-            {
-                var tag = reader.ReadTag();
-                var fieldNumber = WireFormat.GetTagFieldNumber(tag);
-                Console.WriteLine($"DEBUG ParseLine: field {fieldNumber}");
-
-                switch (fieldNumber)
-                {
-                    case 1:
-                        var wordData = reader.ReadBytes();
-                        Console.WriteLine($"DEBUG ParseLine: Reading word, data length = {wordData.Length}");
-                        line.Words.Add(ParseWord(wordData.ToByteArray()));
-                        break;
-                        
-                    case 2:
-                        var geometryData = reader.ReadBytes();
-                        Console.WriteLine($"DEBUG ParseLine: Reading geometry, data length = {geometryData.Length}");
-                        line.Geometry = ParseGeometry(geometryData.ToByteArray());
-                        break;
-                        
-                    default:
-                        reader.SkipLastField();
-                        Console.WriteLine($"DEBUG ParseLine: Skipped field {fieldNumber}");
-                        break;
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"DEBUG ParseLine ERROR: {ex.Message}");
-            Console.WriteLine($"DEBUG ParseLine: Stream position {stream.Position}/{stream.Length}");
-            throw;
-        }
-
-        Console.WriteLine($"DEBUG ParseLine: Returning line with {line.Words.Count} words");
-        return line;
-    }
-
     private static Word ParseWord(byte[] data)
     {
         var word = new Word();
-        
-        Console.WriteLine($"DEBUG ParseWord: data length = {data.Length}");
-        Console.WriteLine($"DEBUG ParseWord: first bytes = {BitConverter.ToString(data.Take(Math.Min(20, data.Length)).ToArray())}");
-        
+
         using var stream = new MemoryStream(data);
         using var reader = new CodedInputStream(stream);
 
-        try
+        while (!reader.IsAtEnd)
         {
-            while (!reader.IsAtEnd)
-            {
-                var tag = reader.ReadTag();
-                var fieldNumber = WireFormat.GetTagFieldNumber(tag);
-                Console.WriteLine($"DEBUG ParseWord: field {fieldNumber}");
+            var tag = reader.ReadTag();
+            var fieldNumber = WireFormat.GetTagFieldNumber(tag);
 
-                switch (fieldNumber)
-                {
-                    case 1:
-                        // Field 1 is metadata, skip it
-                        reader.SkipLastField();
-                        Console.WriteLine($"DEBUG ParseWord: skipped field 1");
-                        break;
-                        
-                    case 2:
-                        // Field 2 is PlainText
-                        word.PlainText = reader.ReadString();
-                        Console.WriteLine($"DEBUG ParseWord: field 2 PlainText = '{word.PlainText}'");
-                        break;
-                        
-                    case 3:
-                        // Field 3 is TextSeparator
-                        word.TextSeparator = reader.ReadString();
-                        word.HasTextSeparator = true;
-                        Console.WriteLine($"DEBUG ParseWord: field 3 TextSeparator = '{word.TextSeparator}'");
-                        break;
-                        
-                    case 4:
-                        // Field 4 is Geometry, skip it
-                        reader.SkipLastField();
-                        Console.WriteLine($"DEBUG ParseWord: skipped field 4");
-                        break;
-                        
-                    default:
-                        reader.SkipLastField();
-                        Console.WriteLine($"DEBUG ParseWord: skipped field {fieldNumber}");
-                        break;
-                }
+            switch (fieldNumber)
+            {
+                case 2:
+                    // Field 2 is PlainText
+                    word.PlainText = reader.ReadString();
+                    break;
+
+                case 3:
+                    // Field 3 is TextSeparator
+                    word.TextSeparator = reader.ReadString();
+                    word.HasTextSeparator = true;
+                    break;
+
+                default:
+                    // Field 1 (metadata) and field 4 (geometry) are not needed here.
+                    reader.SkipLastField();
+                    break;
             }
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"DEBUG ParseWord ERROR: {ex.Message}");
-            Console.WriteLine($"DEBUG ParseWord ERROR: Current position in stream: {stream.Position}/{stream.Length}");
-            throw;
-        }
 
-        Console.WriteLine($"DEBUG ParseWord: returning word with PlainText='{word.PlainText}'");
         return word;
     }
 

--- a/tests/UI/Logic/Ocr/GoogleLens/LensReadingOrderTests.cs
+++ b/tests/UI/Logic/Ocr/GoogleLens/LensReadingOrderTests.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using System.Linq;
+using Nikse.SubtitleEdit.Logic.Ocr.GoogleLens;
+
+namespace UITests.Logic.Ocr.GoogleLens;
+
+// #12149: Google Lens returns the text chunks of a multi-line subtitle interleaved between the two
+// visual rows, scrambling the sentence (e.g. "maar hebben toen ze die Koran ze hem geëxecuteerd.
+// Vonden,"). LensCore.OrderSegmentsIntoReadingLines uses each chunk's bounding box to restore
+// reading order. The boxes below are the real values captured from the Lens response for the
+// reporter's sample image (image1024.png, 849x148).
+public class LensReadingOrderTests
+{
+    private static Segment Seg(string text, double cx, double cy, double w, double h)
+        => new(text, new BoundingBox(new[] { cx, cy, w, h }, new[] { 849, 148 }));
+
+    [Fact]
+    public void OrderSegments_InterleavedTwoLineSubtitle_RestoresReadingOrder()
+    {
+        // Exactly the order and geometry Google returned: top/bottom/top/bottom/top/bottom.
+        var scrambled = new List<Segment>
+        {
+            Seg("maar", 0.0789, 0.1960, 0.1578, 0.3784),
+            Seg("hebben", 0.1372, 0.7972, 0.2297, 0.3919),
+            Seg("toen ze die", 0.3498, 0.1960, 0.3463, 0.3784),
+            Seg("ze hem", 0.3899, 0.7938, 0.2285, 0.3851),
+            Seg("Koran vonden,", 0.7715, 0.1960, 0.4499, 0.3784),
+            Seg("geëxecuteerd.", 0.7479, 0.7938, 0.4405, 0.3851),
+        };
+
+        var ordered = LensCore.OrderSegmentsIntoReadingLines(scrambled);
+
+        Assert.Equal(2, ordered.Count);
+        Assert.Equal("maar toen ze die Koran vonden,", ordered[0].Text);
+        Assert.Equal("hebben ze hem geëxecuteerd.", ordered[1].Text);
+    }
+
+    [Fact]
+    public void OrderSegments_AlreadyInOrder_IsUnchanged()
+    {
+        var segments = new List<Segment>
+        {
+            Seg("Line one here", 0.5, 0.25, 0.6, 0.3),
+            Seg("Line two here", 0.5, 0.75, 0.6, 0.3),
+        };
+
+        var ordered = LensCore.OrderSegmentsIntoReadingLines(segments);
+
+        Assert.Equal(new[] { "Line one here", "Line two here" }, ordered.Select(s => s.Text));
+    }
+
+    [Fact]
+    public void OrderSegments_SingleSegment_IsReturnedAsIs()
+    {
+        var segments = new List<Segment> { Seg("Just one line", 0.5, 0.5, 0.8, 0.3) };
+
+        var ordered = LensCore.OrderSegmentsIntoReadingLines(segments);
+
+        Assert.Single(ordered);
+        Assert.Equal("Just one line", ordered[0].Text);
+    }
+
+    [Fact]
+    public void OrderSegments_DefaultBoxes_KeepsSegmentsAndOrderUnchanged()
+    {
+        // When geometry is missing every chunk gets the same default centre box (0.5, 0.5); with
+        // nothing to sort by, the segments (and their line breaks) must be left exactly as-is - not
+        // shuffled and not merged into a single line.
+        var segments = new List<Segment>
+        {
+            Seg("alpha", 0.5, 0.5, 1, 1),
+            Seg("beta", 0.5, 0.5, 1, 1),
+            Seg("gamma", 0.5, 0.5, 1, 1),
+        };
+
+        var ordered = LensCore.OrderSegmentsIntoReadingLines(segments);
+
+        Assert.Equal(new[] { "alpha", "beta", "gamma" }, ordered.Select(s => s.Text));
+    }
+}


### PR DESCRIPTION
Fixes #12149.

## Problem
Google Lens scrambled the word order of multi-line subtitles, e.g.

> maar toen ze die Koran vonden,
> hebben ze hem geëxecuteerd.

came out reordered ("maar hebben toen ze die Koran ze hem geëxecuteerd. Vonden,").

## Root cause (confirmed with a live capture)
Running the real Sharp path against the reporter's sample image shows Google Lens returns the text chunks **interleaved between the two visual rows**:

```
[0] "maar"           cy=0.196 (top)
[1] "hebben"         cy=0.797 (bottom)
[2] "toen ze die"    cy=0.196 (top)
[3] "ze hem"         cy=0.794 (bottom)
[4] "Koran vonden,"  cy=0.196 (top)
[5] "geëxecuteerd."  cy=0.794 (bottom)
```

SE's Sharp parser was **discarding the per-line bounding box** (the active parse path skipped it), so every segment got the default centre box and SE emitted Google's scrambled order verbatim.

## Fix
- `LensProtoResponse`: parse the per-line geometry that was being skipped. Also removed ~150 lines of dead debug code (`ParseParagraph`/`ParseLine` were never called; `ParseWord` logged to the console on every field of every word).
- `LensCore.OrderSegmentsIntoReadingLines`: group chunks into rows by vertical centre, order rows top-to-bottom and chunks left-to-right, and merge each row into one line. Safe no-op when geometry is missing or there is a single segment, so it can only improve ordering.

## Verification
- Verified **live end-to-end** against the sample image — Sharp now returns the two lines in correct reading order (accents intact).
- Added deterministic regression tests (`LensReadingOrderTests`) built from the real captured bounding boxes — no network needed. All OCR tests pass; build is clean.

## Note
"Google Lens **Standalone**" wraps the external `chrome-lens.exe` and only exposes stdout text (no boxes), so it cannot be reordered from SE — that needs an upstream fix in the Python tool and is **not** addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
