### PR TITLE
OCR: fix Dictionary combo going empty after downloading a dictionary

### DIFF
--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -4463,7 +4463,11 @@ public partial class OcrViewModel : ObservableObject
 
     public void DictionaryChanged()
     {
-        IsDictionaryLoaded = Dictionaries.IndexOf(SelectedDictionary ?? Dictionaries.First()) > 0;
+        // Must stay safe when Dictionaries is empty: this runs from the combo's SelectionChanged, which
+        // fires mid-repopulate when LoadDictionaries clears the list (SelectedDictionary is null then).
+        // Calling Dictionaries.First() there threw and aborted LoadDictionaries before it re-added any
+        // items, leaving the Dictionary combo permanently empty after a download.
+        IsDictionaryLoaded = SelectedDictionary != null && Dictionaries.IndexOf(SelectedDictionary) > 0;
     }
 
     internal void OnLoaded()

--- a/tests/UI/Features/Ocr/OcrDictionaryComboTests.cs
+++ b/tests/UI/Features/Ocr/OcrDictionaryComboTests.cs
@@ -1,0 +1,59 @@
+using Avalonia.Headless.XUnit;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Features.Ocr;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+
+namespace UITests.Features.Ocr;
+
+// Downloading/re-downloading a spell-check dictionary in the OCR window left the Dictionary combo
+// empty. DictionaryChanged() runs from the combo's SelectionChanged, which fires while
+// LoadDictionaries() has momentarily cleared the list; the old code called Dictionaries.First() on the
+// empty collection, threw, and aborted LoadDictionaries before it could re-add any items.
+public class OcrDictionaryComboTests
+{
+    private static OcrViewModel ResolveViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<OcrViewModel>();
+    }
+
+    [AvaloniaFact]
+    public void DictionaryChanged_EmptyList_DoesNotThrow()
+    {
+        var vm = ResolveViewModel();
+
+        // Reproduce the mid-repopulate state: list cleared, nothing selected.
+        vm.Dictionaries.Clear();
+        vm.SelectedDictionary = null;
+
+        var ex = Record.Exception(() => vm.DictionaryChanged());
+
+        Assert.Null(ex);
+        Assert.False(vm.IsDictionaryLoaded);
+    }
+
+    [AvaloniaFact]
+    public void DictionaryChanged_NoneSelected_IsNotLoaded_RealDictionarySelected_IsLoaded()
+    {
+        var vm = ResolveViewModel();
+
+        vm.Dictionaries.Clear();
+        var none = new SpellCheckDictionaryDisplay { Name = "[None]", DictionaryFileName = string.Empty };
+        var real = new SpellCheckDictionaryDisplay { Name = "Dutch [nl_NL]", DictionaryFileName = @"C:\dic\nl_NL.dic" };
+        vm.Dictionaries.Add(none);
+        vm.Dictionaries.Add(real);
+
+        // First item ([None]) selected => not loaded.
+        vm.SelectedDictionary = none;
+        vm.DictionaryChanged();
+        Assert.False(vm.IsDictionaryLoaded);
+
+        // A real dictionary (index > 0) selected => loaded.
+        vm.SelectedDictionary = real;
+        vm.DictionaryChanged();
+        Assert.True(vm.IsDictionaryLoaded);
+    }
+}


### PR DESCRIPTION
## Problem
Downloading or re-downloading a spell-check dictionary in the OCR window left the **Dictionary** combo box empty — no items to choose from, and the newly downloaded dictionary was not added or selected.

## Root cause
`OcrViewModel.DictionaryChanged()` runs from the combo's `SelectionChanged` event. When `LoadDictionaries()` calls `Dictionaries.Clear()` to repopulate, the selected item is removed and `SelectionChanged` fires while the list is momentarily empty and `SelectedDictionary` is null. The old code:

```csharp
IsDictionaryLoaded = Dictionaries.IndexOf(SelectedDictionary ?? Dictionaries.First()) > 0;
```

called `Dictionaries.First()` on the empty collection, which throws. That exception unwound out of `Clear()` **before** `LoadDictionaries` re-added `[None]` and the installed dictionaries, so the combo was left permanently empty. The throw was swallowed by the async command, so no crash was shown — just an empty combo.

## Fix
Make it null/empty-safe with the same semantics (loaded only when a real dictionary, not `[None]`, is selected):

```csharp
IsDictionaryLoaded = SelectedDictionary != null && Dictionaries.IndexOf(SelectedDictionary) > 0;
```

`LoadDictionaries()` now completes, re-adds `[None]` + the installed dictionaries, and `PickDictionary` selects the just-downloaded one.

## Verification
- Added `OcrDictionaryComboTests` (via the real DI container); confirmed they **fail without the fix** (the empty-list case throws) and pass with it.
- Verified manually in the running app: after downloading/re-downloading a dictionary the combo stays populated and auto-selects the downloaded dictionary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
