### PR TITLE
Remove redundant "Repeat previous/next line" shortcuts (#12141)

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -1,6 +1,14 @@
 
 Subtitle Edit Changelog
 
+v5.1.0-beta9 (TBD)
+
+* Google Lens Sharp: fix scrambled word order on multi-line subtitles - the text chunks Google returns interleaved between the two lines are now re-ordered top-to-bottom/left-to-right using their bounding boxes - thx fraternl
+* OCR: fix the Dictionary combo box becoming empty after downloading/re-downloading a spell check dictionary
+* Remove redundant "Repeat previous line"/"Repeat next line" shortcuts - use "Play previous (and loop)"/"Play next (and loop)" instead (they also handle multiple selections and no selection) - thx abc16361
+
+-----------------------------------------------------------------------------------------------------
+
 v5.1.0-beta8 (3rd of July 2026)
 
 * Fix "Fix common OCR errors" doing nothing when no Hunspell dictionary is installed for the language - the OCR replace list (e.g. spa_OCRFixReplaceList.xml) is now applied on its own again - thx perkesfurmah-collab

--- a/src/ui/Assets/Languages/Dutch.json
+++ b/src/ui/Assets/Languages/Dutch.json
@@ -2692,8 +2692,6 @@
       "SurroundWith": "",
       "SurroundWithXY": "",
       "RepeatLine": "",
-      "RepeatPreviousLine": "",
-      "RepeatNextLine": "",
       "MoveVideoPositionMilliseconds": "",
       "ImportShortcutsTitle": "",
       "ExportShortcutsTitle": "",

--- a/src/ui/Assets/Languages/German.json
+++ b/src/ui/Assets/Languages/German.json
@@ -2693,8 +2693,6 @@
       "SurroundWith": "Umgeben mit...",
       "SurroundWithX": "Mit \u201E{0}\u201C umgeben",
       "RepeatLine": "Zeile wiederholen",
-      "RepeatPreviousLine": "Vorherige Zeile wiederholen",
-      "RepeatNextLine": "N\u00E4chste Zeile wiederholen",
       "MoveVideoPositionMilliseconds": "Verschiebe die Videoposition in Millisekunden",
       "ImportShortcutsTitle": "Tastenkombinationen importieren",
       "ExportShortcutsTitle": "Tastenkombinationen exportieren",

--- a/src/ui/Assets/Languages/Italian.json
+++ b/src/ui/Assets/Languages/Italian.json
@@ -2811,8 +2811,6 @@
       "SurroundWith": "Surround con...",
       "SurroundWithXY": "Surround con {0}/{1}",
       "RepeatLine": "Ripeti riga",
-      "RepeatPreviousLine": "Ripeti riga precedente",
-      "RepeatNextLine": "Ripeti riga successiva",
       "MoveVideoPositionMilliseconds": "Sposta posizione video in millisecondi",
       "ImportShortcutsTitle": "Importa definizione tasti rapidi",
       "ExportShortcutsTitle": "Esporta definizione tasti rapidi",

--- a/src/ui/Assets/Languages/Norwegian.json
+++ b/src/ui/Assets/Languages/Norwegian.json
@@ -2688,8 +2688,6 @@
       "SurroundWith": "Omgi med...",
       "SurroundWithXY": "Omgi med {0}/{1}",
       "RepeatLine": "Gjenta linje",
-      "RepeatPreviousLine": "Gjenta forrige linje",
-      "RepeatNextLine": "Gjenta neste linje",
       "MoveVideoPositionMilliseconds": "Flytt videoposisjon i millisekunder",
       "ImportShortcutsTitle": "Importer hurtigtaster",
       "ExportShortcutsTitle": "Eksporter hurtigtaster",

--- a/src/ui/Assets/Languages/Portuguese (Brazil).json
+++ b/src/ui/Assets/Languages/Portuguese (Brazil).json
@@ -2738,8 +2738,6 @@
       "SurroundWith": "Cercar com...",
       "SurroundWithXY": "Cercar com {0}/{1}",
       "RepeatLine": "Repetir linha",
-      "RepeatPreviousLine": "Repetir linha anterior",
-      "RepeatNextLine": "Repetir próxima linha",
       "MoveVideoPositionMilliseconds": "Mover a posição do vídeo em milissegundos",
       "ImportShortcutsTitle": "Importar atalhos",
       "ExportShortcutsTitle": "Exportar atalhos",

--- a/src/ui/Assets/Languages/Spanish.json
+++ b/src/ui/Assets/Languages/Spanish.json
@@ -2692,8 +2692,6 @@
       "SurroundWith": "Rodear con...",
       "SurroundWithXY": "Rodear con {0}/{1}",
       "RepeatLine": "Repetir línea",
-      "RepeatPreviousLine": "Repetir línea anterior",
-      "RepeatNextLine": "Repetir línea siguiente",
       "MoveVideoPositionMilliseconds": "Mover vídeo en milisegundos",
       "ImportShortcutsTitle": "Importar atajos",
       "ExportShortcutsTitle": "Exportar atajos",

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1010,7 +1010,7 @@ public partial class MainViewModel :
         // Select synchronously rather than via SelectAndScrollToSubtitle (which posts the selection
         // to the dispatcher): the grid's SelectionChanged handler calls ResetPlaySelection, so a
         // deferred selection would null _playSelectionItem *after* we set it and break stop/loop.
-        // Mirror RepeatNextLine — change selection first, then assign _playSelectionItem.
+        // Change selection first, then assign _playSelectionItem.
         SubtitleGrid.SelectedItem = next;
         SubtitleGrid.ScrollIntoView(next, null);
         vp.Position = next.StartTime.TotalSeconds;
@@ -11099,55 +11099,6 @@ public partial class MainViewModel :
         _shortcutManager.ClearKeys();
     }
 
-    [RelayCommand]
-    private void RepeatPreviousLine()
-    {
-        var selectedItems = SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>().OrderBy(p => p.StartTime).ToList();
-        var vp = GetVideoPlayerControl();
-        if (Window == null || selectedItems.Count == 0 || vp == null)
-        {
-            return;
-        }
-
-        vp.VideoPlayer.Pause();
-        var currentIndex = Subtitles.IndexOf(selectedItems.First());
-        if (currentIndex <= 0)
-        {
-            return;
-        }
-
-        var p = Subtitles[currentIndex - 1];
-        SubtitleGrid.SelectedItem = p;
-        vp.Position = p.StartTime.TotalSeconds;
-        PinPlayheadTo(p.StartTime.TotalSeconds);
-        _playSelectionItem = new PlaySelectionItem(new List<SubtitleLineViewModel> { p }, p.EndTime, true);
-        vp.VideoPlayer.Play();
-    }
-
-    [RelayCommand]
-    private void RepeatNextLine()
-    {
-        var selectedItems = SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>().OrderBy(p => p.StartTime).ToList();
-        var vp = GetVideoPlayerControl();
-        if (Window == null || selectedItems.Count == 0 || vp == null)
-        {
-            return;
-        }
-
-        vp.VideoPlayer.Pause();
-        var currentIndex = Subtitles.IndexOf(selectedItems.First());
-        if (currentIndex >= Subtitles.Count - 1)
-        {
-            return;
-        }
-
-        var p = Subtitles[currentIndex + 1];
-        SubtitleGrid.SelectedItem = p;
-        vp.Position = p.StartTime.TotalSeconds;
-        PinPlayheadTo(p.StartTime.TotalSeconds);
-        _playSelectionItem = new PlaySelectionItem(new List<SubtitleLineViewModel> { p }, p.EndTime, true);
-        vp.VideoPlayer.Play();
-    }
 
     [RelayCommand]
     private void GoToNextLine()

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -249,8 +249,6 @@ public class LanguageSettingsShortcuts
     public string SurroundWith { get; set; }
     public string SurroundWithXY { get; set; }
     public string RepeatLine { get; set; }
-    public string RepeatPreviousLine { get; set; }
-    public string RepeatNextLine { get; set; }
     public string MoveVideoPositionMilliseconds { get; set; }
     public string ImportShortcutsTitle { get; set; }
     public string ExportShortcutsTitle { get; set; }
@@ -562,8 +560,6 @@ public class LanguageSettingsShortcuts
         SurroundWith = "Surround with...";
         SurroundWithXY = "Surround with {0}/{1}";
         RepeatLine = "Repeat line";
-        RepeatPreviousLine = "Repeat previous line";
-        RepeatNextLine = "Repeat next line";
         MoveVideoPositionMilliseconds = "Move video position in milliseconds";
         ImportShortcutsTitle = "Import shortcuts";
         ExportShortcutsTitle = "Export shortcuts";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -389,8 +389,6 @@ public static class ShortcutsMain
         { nameof(MainViewModel.SurroundWith1Command), string.Format(Se.Language.Options.Shortcuts.SurroundWithXY,  Se.Settings.Surround1Left, Se.Settings.Surround1Right) },
         { nameof(MainViewModel.SurroundWith2Command), string.Format(Se.Language.Options.Shortcuts.SurroundWithXY,  Se.Settings.Surround2Left, Se.Settings.Surround2Right) },
         { nameof(MainViewModel.SurroundWith3Command), string.Format(Se.Language.Options.Shortcuts.SurroundWithXY,  Se.Settings.Surround3Left, Se.Settings.Surround3Right) },
-        { nameof(MainViewModel.RepeatPreviousLineCommand), Se.Language.Options.Shortcuts.RepeatPreviousLine },
-        { nameof(MainViewModel.RepeatNextLineCommand), Se.Language.Options.Shortcuts.RepeatNextLine },
         { nameof(MainViewModel.InsertLineBeforeCommand), Se.Language.General.InsertBefore },
         { nameof(MainViewModel.InsertLineAfterCommand), Se.Language.General.InsertAfter },
         { nameof(MainViewModel.WaveformInsertNewSelectionCommand), Se.Language.Options.Shortcuts.WaveformInsertNewSelection },
@@ -762,8 +760,6 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.SurroundWith1Command, nameof(vm.SurroundWith1Command), ShortcutCategory.SubtitleGridAndTextBox);
         AddShortcut(shortcuts, vm.SurroundWith2Command, nameof(vm.SurroundWith2Command), ShortcutCategory.SubtitleGridAndTextBox);
         AddShortcut(shortcuts, vm.SurroundWith3Command, nameof(vm.SurroundWith3Command), ShortcutCategory.SubtitleGridAndTextBox);
-        AddShortcut(shortcuts, vm.RepeatPreviousLineCommand, nameof(vm.RepeatPreviousLineCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.RepeatNextLineCommand, nameof(vm.RepeatNextLineCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.InsertLineBeforeCommand, nameof(vm.InsertLineBeforeCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.InsertLineAfterCommand, nameof(vm.InsertLineAfterCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.WaveformInsertNewSelectionCommand, nameof(vm.WaveformInsertNewSelectionCommand), ShortcutCategory.Waveform);


### PR DESCRIPTION
Addresses #12141.

## Background
The reporter noticed that **"Repeat previous line"** / **"Repeat next line"** appear to duplicate **"Play previous (and loop)"** / **"Play next (and loop)"**, and preferred the Play versions because they work better with multiple selections.

Analysis confirmed it: for a single selected line the two pairs are functionally identical (pause, select the neighbour line, seek to its start, loop it). The only differences make the **Play** versions a strict superset:

- **No selection** — `Play*` falls back to the current video position; `Repeat*` does nothing.
- **Multi-selection ("next")** — `PlayNextAndLoop` anchors on the *last* selected line (plays past the whole block); `RepeatNextLine` anchors on the *first*. (For "previous" they were already identical.)
- `Play*` additionally has non-loop (`…AndStop`) siblings.

Neither `Repeat*` command shipped with a default key binding, so removal creates/resolves no default-key conflicts.

## Change
- Remove `RepeatPreviousLineCommand` / `RepeatNextLineCommand` from `MainViewModel`.
- Remove their `ShortcutsMain` registrations + translation-lookup entries.
- Remove the `RepeatPreviousLine` / `RepeatNextLine` language strings (English defaults + the six translations that carried them: es, pt-BR, nl, it, no, de).
- Change-log: new beta9 entry, plus the two other recent fixes that weren't recorded yet (Google Lens Sharp word order, OCR Dictionary combo).

## Verification
- Full-repo grep for `RepeatPreviousLine`/`RepeatNextLine` → no matches.
- All six edited translation JSONs re-validated as parseable.
- UI builds clean (0 warnings); the 40 shortcut tests pass.

Only caveat: a user who had manually bound one of these two commands would lose that binding (noted in the change-log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
