### PR TITLE
OCR: don't split Dutch hyphenated words into a space (#12156)

### DIFF
--- a/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
@@ -332,6 +332,14 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
                 isWordCorrect = true;
             }
 
+            // A hyphenated compound whose parts are each correct (e.g. "vaudeville-veteraan",
+            // "Bailey-gebied") is correct as a whole - so don't hand it to the unknown-word "guess"
+            // path, which would otherwise split it and leave a stray space next to the hyphen. (#12156)
+            if (!isWordCorrect && IsHyphenatedWordOfCorrectParts(result, lineText))
+            {
+                isWordCorrect = true;
+            }
+
             if (!string.IsNullOrEmpty(result) && !isWordCorrect && doTryToGuessUnknownWords)
             {
                 var guesses = new List<string>();
@@ -377,6 +385,36 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
 
         word.FixedWord = result;
         word.IsSpellCheckedOk = isWordCorrect;
+    }
+
+    // True when the word is a hyphenated compound (at least two parts) and every part is a
+    // correct word, a name, or a skipped word. Used to keep valid hyphenated words out of the
+    // unknown-word guess/split path. (#12156)
+    private bool IsHyphenatedWordOfCorrectParts(string word, string lineText)
+    {
+        if (word.IndexOf('-') <= 0)
+        {
+            return false;
+        }
+
+        var parts = word.Split('-', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length < 2)
+        {
+            return false;
+        }
+
+        foreach (var part in parts)
+        {
+            if (!_wordSkipList.Contains(part) &&
+                !_spellCheckManager.IsWordCorrect(part) &&
+                !_spellCheckWordLists.HasName(part) &&
+                !_spellCheckWordLists.HasNameExtended(part, lineText))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private bool IsSpelledCorrect(string s)

--- a/src/libuilogic/Ocr/FixEngine/UnknownWordGuesser.cs
+++ b/src/libuilogic/Ocr/FixEngine/UnknownWordGuesser.cs
@@ -104,6 +104,14 @@ public static class UnknownWordGuesser
         var guesses = new List<string>();
         for (int i = 3; i < word.Length - 3; i++)
         {
+            // Only ever split between two letters. Otherwise a hyphen (or apostrophe) reads as a
+            // "consonant" and we split right next to it, e.g. "vaudeville-veteraan" -> "vaudeville-
+            // veteraan" - a spurious space after the hyphen. (issue #12156)
+            if (!char.IsLetter(word[i]) || !char.IsLetter(word[i - 1]))
+            {
+                continue;
+            }
+
             bool isVowel = vowels.Contains(char.ToLower(word[i]));
             bool prevIsVowel = vowels.Contains(char.ToLower(word[i - 1]));
 

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixEngineHyphenGuessTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixEngineHyphenGuessTests.cs
@@ -1,0 +1,77 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+// Regression test for https://github.com/SubtitleEdit/subtitleedit/issues/12156
+// "Fix common OCR errors" turned Dutch hyphenated words into a split with a stray space next to
+// the hyphen, e.g. "vaudeville-veteraan" -> "vaudeville- veteraan". A hyphenated compound whose
+// parts are each correctly spelled must be left untouched and kept out of the guess/split path.
+public class OcrFixEngineHyphenGuessTests : IDisposable
+{
+    private readonly Func<string> _originalSpellCheckDictionariesFolder;
+    private readonly string _tempDictionariesFolder;
+
+    public OcrFixEngineHyphenGuessTests()
+    {
+        _originalSpellCheckDictionariesFolder = SpellCheckConfig.DictionariesFolder;
+
+        // Empty temp folder so no nld_OCRFixReplaceList.xml / names interfere - the fake spell
+        // checker is the only source of truth about which words are correct.
+        _tempDictionariesFolder = Path.Combine(Path.GetTempPath(), "SeOcrFixHyphenTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDictionariesFolder);
+        SpellCheckConfig.DictionariesFolder = () => _tempDictionariesFolder;
+    }
+
+    [Theory]
+    [InlineData("een vaudeville-veteraan", "vaudeville", "veteraan")]
+    [InlineData("het Bailey-gebied", "Bailey", "gebied")]
+    public void FixOcrErrors_HyphenatedWordOfCorrectParts_IsLeftUnchangedAndNotGuessed(string line, string partA, string partB)
+    {
+        var engine = new OcrFixEngine(new FakeSpellChecker("een", "het", partA, partB));
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(line, 0, 3000));
+        ((IOcrFixEngine)engine).Initialize(subtitle, "nld", new SpellCheckDictionaryDisplay { DictionaryFileName = string.Empty });
+
+        var result = engine.FixOcrErrors(0, line, doTryToGuessUnknownWords: true);
+
+        Assert.Equal(line, result.GetText());
+        Assert.DoesNotContain(result.Words, w => w.GuessUsed);
+
+        // The gate must also mark the compound as correctly spelled (not a flagged unknown word),
+        // so it is not underlined / offered for "fixing" in the OCR window.
+        var hyphenWord = result.Words.Single(w => w.Word.Contains('-'));
+        Assert.True(hyphenWord.IsSpellCheckedOk);
+    }
+
+    public void Dispose()
+    {
+        SpellCheckConfig.DictionariesFolder = _originalSpellCheckDictionariesFolder;
+        try
+        {
+            Directory.Delete(_tempDictionariesFolder, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private sealed class FakeSpellChecker : ISpellChecker
+    {
+        private readonly HashSet<string> _correct;
+
+        public FakeSpellChecker(params string[] correctWords)
+            => _correct = new HashSet<string>(correctWords, StringComparer.Ordinal);
+
+        public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => true;
+        public bool IsWordCorrect(string word) => _correct.Contains(word);
+        public List<string> GetSuggestions(string word) => new();
+    }
+}

--- a/tests/UI/Features/Ocr/FixEngine/UnknownWordGuesserTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/UnknownWordGuesserTests.cs
@@ -1,0 +1,55 @@
+using System.Linq;
+using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+public class UnknownWordGuesserTests
+{
+    // Regression test for https://github.com/SubtitleEdit/subtitleedit/issues/12156
+    // "Fix common OCR errors" inserted a space right after the hyphen in Dutch hyphenated
+    // words (e.g. "vaudeville-veteraan" -> "vaudeville- veteraan"), because the smart-split
+    // heuristic treated '-' as a splittable consonant. A split must never land next to a
+    // non-letter.
+    [Theory]
+    [InlineData("vaudeville-veteraan")]
+    [InlineData("Bailey-gebied")]
+    [InlineData("zwart-wit-foto")]
+    [InlineData("moeder-overste")]
+    public void CreateGuessesFromLetters_NeverSplitsNextToHyphen(string word)
+    {
+        var guesses = UnknownWordGuesser.CreateGuessesFromLetters(word, "nld").ToList();
+
+        foreach (var guess in guesses)
+        {
+            var spaceIndex = guess.IndexOf(' ');
+            while (spaceIndex >= 0)
+            {
+                Assert.True(spaceIndex > 0 && guess[spaceIndex - 1] != '-',
+                    $"'{word}' produced guess '{guess}' with a space right after a hyphen");
+                Assert.True(spaceIndex < guess.Length - 1 && guess[spaceIndex + 1] != '-',
+                    $"'{word}' produced guess '{guess}' with a space right before a hyphen");
+                spaceIndex = guess.IndexOf(' ', spaceIndex + 1);
+            }
+        }
+    }
+
+    // A hyphenated word must not be turned into a split whose only difference from the input
+    // is a space adjacent to the hyphen (the exact symptom reported in #12156).
+    [Fact]
+    public void CreateGuessesFromLetters_HyphenatedWord_DoesNotOnlyAddSpaceAtHyphen()
+    {
+        var guesses = UnknownWordGuesser.CreateGuessesFromLetters("vaudeville-veteraan", "nld").ToList();
+
+        Assert.DoesNotContain("vaudeville- veteraan", guesses);
+        Assert.DoesNotContain("vaudeville -veteraan", guesses);
+    }
+
+    // Ordinary (non-hyphenated) words are still split, so the fix does not disable the feature.
+    [Fact]
+    public void CreateGuessesFromLetters_PlainWord_StillSplitsBetweenConsonants()
+    {
+        var guesses = UnknownWordGuesser.CreateGuessesFromLetters("werkplek", "nld").ToList();
+
+        Assert.Contains("werk plek", guesses);
+    }
+}


### PR DESCRIPTION
Fixes #12156

## Problem
"Fix common OCR errors" inserted a stray space next to the hyphen in Dutch hyphenated words:

| before | after |
|---|---|
| `vaudeville-veteraan` | `vaudeville- veteraan` |
| `Bailey-gebied` | `Bailey- gebied` |

As the reporter noted, this is not a rule in `nld_OCRFixReplaceList.xml` — it comes from code.

## Root cause
`FixCommonOcrErrors` always runs with the unknown-word "guess" path on (`FixOcrErrors(i, p.Text, true)`). `SplitLine` keeps `-` inside a word token, and the single-arg `IsWordCorrect` checks the whole hyphenated token against Hunspell with no hyphen-splitting, so `vaudeville-veteraan` is "unknown" and guessing proceeds. `UnknownWordGuesser.GenerateSmartSplits` then treated the hyphen as a splittable consonant and inserted a space at the `-`/letter boundary; the resulting `A- B` was accepted because both halves spell-check.

## Fix
- **`UnknownWordGuesser.GenerateSmartSplits`** — only ever split between two letters, so a hyphen/apostrophe can never be a split boundary.
- **`OcrFixEngine.CheckAndFixWord`** — treat a hyphenated compound whose parts are each correct (word/name/skip-word) as correct, keeping it out of the guess/split path and marking it `IsSpellCheckedOk` (so valid compounds are no longer flagged as unknown words in the OCR window).

## Tests
- `UnknownWordGuesserTests` — the guesser never splits adjacent to a hyphen; ordinary words still split.
- `OcrFixEngineHyphenGuessTests` — full-engine drive with a fake spell checker; the compound is unchanged, not guessed, and marked spell-checked-OK.

Full FixEngine suite: 34/34 pass. Verified end-to-end against a real OpenTaal Dutch Hunspell dictionary — the two bogus splits go to zero. Confirmed the engine test has teeth (fails if the gate is removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
