### PR TITLE
Add OpenRouter and Alibaba Qwen3-ASR online speech-to-text engines (#12154)

### DIFF
--- a/src/libse/AudioToText/WhisperChoice.cs
+++ b/src/libse/AudioToText/WhisperChoice.cs
@@ -32,5 +32,7 @@
         public const string CrispAsrSenseVoice = "Crisp ASR SenseVoice";
         public const string CrispAsrArk = "Crisp ASR ARK";
         public const string OpenAiCompatible = "OpenAI Compatible";
+        public const string OpenRouter = "OpenRouter";
+        public const string DashScopeQwen3 = "Alibaba Qwen3-ASR";
     }
 }

--- a/src/libse/Settings/ToolsSettings.cs
+++ b/src/libse/Settings/ToolsSettings.cs
@@ -92,6 +92,20 @@ namespace Nikse.SubtitleEdit.Core.Settings
         public bool OpenAiCompatibleSttStream { get; set; }
         public string OpenAiCompatibleSttAudioFormat { get; set; }
 
+        public string OpenRouterSttApiKey { get; set; }
+        public string OpenRouterSttModel { get; set; }
+        public string OpenRouterSttLanguage { get; set; }
+        public decimal OpenRouterSttTemperature { get; set; }
+        public string OpenRouterSttPrompt { get; set; }
+        public int OpenRouterSttTimeoutSeconds { get; set; }
+
+        public string DashScopeSttApiKey { get; set; }
+        public string DashScopeSttModel { get; set; }
+        public string DashScopeSttLanguage { get; set; }
+        public string DashScopeSttRegion { get; set; }
+        public bool DashScopeSttEnableWords { get; set; }
+        public int DashScopeSttTimeoutSeconds { get; set; }
+
         public string OpenRouterUrl { get; set; }
         public string OpenRouterPrompt { get; set; }
         public string OpenRouterApiKey { get; set; }
@@ -523,6 +537,20 @@ namespace Nikse.SubtitleEdit.Core.Settings
             OpenAiCompatibleSttPrompt = string.Empty;
             OpenAiCompatibleSttStream = false;
             OpenAiCompatibleSttAudioFormat = "mp3";
+
+            OpenRouterSttApiKey = string.Empty;
+            OpenRouterSttModel = "openai/whisper-1";
+            OpenRouterSttLanguage = string.Empty;
+            OpenRouterSttTemperature = 0;
+            OpenRouterSttPrompt = string.Empty;
+            OpenRouterSttTimeoutSeconds = 300;
+
+            DashScopeSttApiKey = string.Empty;
+            DashScopeSttModel = "qwen3-asr-flash-filetrans";
+            DashScopeSttLanguage = string.Empty;
+            DashScopeSttRegion = "international";
+            DashScopeSttEnableWords = false;
+            DashScopeSttTimeoutSeconds = 3600;
 
             VoskPostProcessing = true;
             WhisperChoice = Configuration.IsRunningOnWindows ? AudioToText.WhisperChoice.PurfviewFasterWhisperXxl : AudioToText.WhisperChoice.OpenAi;

--- a/src/ui/Assets/SpeechToText/AlibabaQwen3Asr.txt
+++ b/src/ui/Assets/SpeechToText/AlibabaQwen3Asr.txt
@@ -1,0 +1,23 @@
+Alibaba Cloud Qwen3-ASR (DashScope)
+
+Qwen3-ASR is Alibaba's multilingual speech recognition model, accessed through
+Alibaba Cloud Model Studio (DashScope).
+
+Setup:
+1. Create an API key in Alibaba Cloud Model Studio.
+2. Paste it into the API Key field.
+3. Pick your Region:
+     international - dashscope-intl.aliyuncs.com
+     china        - dashscope.aliyuncs.com
+   The API key must match the selected region.
+
+How it works:
+- The audio is uploaded to DashScope temporary storage (kept ~48 hours) and
+  transcribed asynchronously with the qwen3-asr-flash-filetrans model.
+- Sentence-level timestamps are always returned. Enable "Word-level timestamps"
+  for finer timing.
+- Files up to about 12 hours are supported.
+
+Notes:
+- A Language Hint (e.g. en, zh, ja) can be set; leave empty to auto-detect.
+- Costs are billed by Alibaba Cloud per the selected model.

--- a/src/ui/Assets/SpeechToText/OpenRouter.txt
+++ b/src/ui/Assets/SpeechToText/OpenRouter.txt
@@ -1,0 +1,20 @@
+OpenRouter speech-to-text
+
+OpenRouter routes audio transcription to Whisper, GPT-4o-transcribe, Groq and
+other providers behind a single API key.
+
+Setup:
+1. Create an API key at https://openrouter.ai/keys
+2. Paste it into the API Key field.
+3. Choose a transcription model, for example:
+     openai/whisper-1
+     openai/whisper-large-v3
+     openai/gpt-4o-transcribe
+     qwen/qwen3-asr-flash
+
+The audio is uploaded to OpenRouter and transcribed. Segment timestamps are
+requested automatically; long audio is split into chunks first.
+
+Notes:
+- A Language Hint (e.g. en, de, es) can improve accuracy; leave empty to auto-detect.
+- Costs are billed by OpenRouter per the selected model.

--- a/src/ui/Features/Video/SpeechToText/DashScope/DashScopeSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/DashScope/DashScopeSttService.cs
@@ -1,0 +1,429 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.OpenAiCompatible;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.DashScope;
+
+/// <summary>
+/// Speech-to-text via Alibaba Cloud Model Studio (DashScope) Qwen3-ASR, using the
+/// asynchronous file-transcription path so real sentence (and optional word)
+/// timestamps come back — the sync multimodal endpoint returns text only.
+///
+/// The async Filetrans job only accepts publicly resolvable URLs, so a local
+/// file is first uploaded to DashScope's own temporary storage (an <c>oss://</c>
+/// URL valid ~48h). The flow: getPolicy → OSS multipart upload → submit async
+/// task → poll tasks/{id} → download the transcription_url JSON → map its
+/// millisecond sentence timings into <see cref="OpenAiCompatibleSegment"/>s.
+/// </summary>
+public class DashScopeSttService : ISttTranscriber
+{
+    public const string InternationalBaseUrl = "https://dashscope-intl.aliyuncs.com";
+    public const string ChinaBaseUrl = "https://dashscope.aliyuncs.com";
+    private const string UploadsPath = "/api/v1/uploads";
+    private const string TranscriptionPath = "/api/v1/services/audio/asr/transcription";
+    private const string TasksPath = "/api/v1/tasks/";
+
+    private readonly HttpClient _httpClient;
+    private readonly DashScopeSttSettings _settings;
+
+    public DashScopeSttService(DashScopeSttSettings settings)
+        : this(OpenAiSttService.SharedHttpClient, settings)
+    {
+    }
+
+    public DashScopeSttService(HttpClient httpClient, DashScopeSttSettings settings)
+    {
+        _httpClient = httpClient;
+        _settings = settings;
+    }
+
+    /// <summary>Region base URL for the given region setting ("china" → Beijing, else international).</summary>
+    public static string GetBaseUrl(string? region)
+    {
+        return string.Equals(region, "china", StringComparison.OrdinalIgnoreCase)
+            ? ChinaBaseUrl
+            : InternationalBaseUrl;
+    }
+
+    private string BaseUrl => GetBaseUrl(_settings.Region);
+
+    public async Task<OpenAiCompatibleSttResponse> TranscribeAsync(
+        string audioFilePath,
+        string? language,
+        IProgress<string>? progress,
+        IProgress<OpenAiCompatibleSegment>? segmentProgress,
+        CancellationToken cancellationToken)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        if (_settings.TimeoutSeconds > 0)
+        {
+            timeoutCts.CancelAfter(TimeSpan.FromSeconds(_settings.TimeoutSeconds));
+        }
+        var ct = timeoutCts.Token;
+
+        var bytes = await File.ReadAllBytesAsync(audioFilePath, ct);
+        var fileName = Path.GetFileName(audioFilePath);
+
+        progress?.Report("Uploading audio to DashScope temporary storage...");
+        _settings.Logger?.Invoke("DashScope: uploading audio to temporary storage");
+        var ossUrl = await UploadFileAsync(bytes, fileName, ct);
+
+        progress?.Report("Submitting transcription task...");
+        _settings.Logger?.Invoke($"DashScope: submitting async task for {ossUrl}");
+        var taskId = await SubmitTaskAsync(ossUrl, language, ct);
+
+        progress?.Report("Waiting for transcription to complete...");
+        var transcriptionUrl = await PollTaskAsync(taskId, ct);
+
+        _settings.Logger?.Invoke($"DashScope: fetching result from {transcriptionUrl}");
+        using var resultResponse = await _httpClient.GetAsync(transcriptionUrl, HttpCompletionOption.ResponseHeadersRead, ct);
+        resultResponse.EnsureSuccessStatusCode();
+        var resultJson = await resultResponse.Content.ReadAsStringAsync(ct);
+
+        return ParseTranscriptionResult(resultJson);
+    }
+
+    /// <summary>
+    /// Upload the audio to DashScope temporary storage and return its
+    /// <c>oss://</c> URL. Two steps: fetch an upload policy, then POST the file
+    /// to the returned OSS host with the signed form fields (file field last).
+    /// </summary>
+    private async Task<string> UploadFileAsync(byte[] audioBytes, string fileName, CancellationToken ct)
+    {
+        var model = string.IsNullOrWhiteSpace(_settings.Model) ? "qwen3-asr-flash-filetrans" : _settings.Model;
+        var policyUrl = $"{BaseUrl}{UploadsPath}?action=getPolicy&model={Uri.EscapeDataString(model)}";
+        using var policyRequest = new HttpRequestMessage(HttpMethod.Get, policyUrl);
+        policyRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _settings.ApiKey);
+
+        using var policyResponse = await _httpClient.SendAsync(policyRequest, HttpCompletionOption.ResponseHeadersRead, ct);
+        if (!policyResponse.IsSuccessStatusCode)
+        {
+            var err = await policyResponse.Content.ReadAsStringAsync(ct);
+            throw new HttpRequestException($"DashScope upload-policy request failed ({(int)policyResponse.StatusCode}). Response: {err}");
+        }
+
+        var policyJson = await policyResponse.Content.ReadAsStringAsync(ct);
+        var policy = JsonSerializer.Deserialize<DashScopeUploadPolicyResponse>(policyJson,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true })?.Data
+            ?? throw new InvalidOperationException("DashScope upload-policy response could not be parsed.");
+
+        var key = $"{policy.UploadDir}/{fileName}";
+
+        using var form = new MultipartFormDataContent
+        {
+            { new StringContent(policy.OssAccessKeyId), "OSSAccessKeyId" },
+            { new StringContent(policy.Policy), "policy" },
+            { new StringContent(policy.Signature), "Signature" },
+            { new StringContent(key), "key" },
+            { new StringContent(policy.XOssObjectAcl), "x-oss-object-acl" },
+            { new StringContent(policy.XOssForbidOverwrite), "x-oss-forbid-overwrite" },
+            { new StringContent("200"), "success_action_status" },
+        };
+        var fileContent = new ByteArrayContent(audioBytes);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        form.Add(fileContent, "file", fileName); // file field must be last
+
+        using var uploadResponse = await _httpClient.PostAsync(policy.UploadHost, form, ct);
+        if (!uploadResponse.IsSuccessStatusCode)
+        {
+            var err = await uploadResponse.Content.ReadAsStringAsync(ct);
+            throw new HttpRequestException($"DashScope OSS upload failed ({(int)uploadResponse.StatusCode}). Response: {err}");
+        }
+
+        return "oss://" + key;
+    }
+
+    private async Task<string> SubmitTaskAsync(string ossUrl, string? language, CancellationToken ct)
+    {
+        var body = BuildSubmitBody(_settings, ossUrl, language);
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        using var request = new HttpRequestMessage(HttpMethod.Post, BaseUrl + TranscriptionPath)
+        {
+            Content = content,
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _settings.ApiKey);
+        request.Headers.TryAddWithoutValidation("X-DashScope-Async", "enable");
+        request.Headers.TryAddWithoutValidation("X-DashScope-OssResourceResolve", "enable");
+
+        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+        var json = await response.Content.ReadAsStringAsync(ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            _settings.Logger?.Invoke($"DashScope async submit failed ({(int)response.StatusCode}): {json}");
+            throw new HttpRequestException($"DashScope async submit failed ({(int)response.StatusCode}). Response: {json}");
+        }
+
+        var taskId = JsonSerializer.Deserialize<DashScopeTaskResponse>(json,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true })?.Output?.TaskId;
+        if (string.IsNullOrEmpty(taskId))
+        {
+            throw new InvalidOperationException($"DashScope async submit returned no task_id. Response: {json}");
+        }
+
+        return taskId;
+    }
+
+    private async Task<string> PollTaskAsync(string taskId, CancellationToken ct)
+    {
+        var url = BaseUrl + TasksPath + Uri.EscapeDataString(taskId);
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _settings.ApiKey);
+
+            using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+            var json = await response.Content.ReadAsStringAsync(ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException($"DashScope task poll failed ({(int)response.StatusCode}). Response: {json}");
+            }
+
+            var output = JsonSerializer.Deserialize<DashScopeTaskResponse>(json, options)?.Output;
+            var status = output?.TaskStatus ?? "UNKNOWN";
+            switch (status.ToUpperInvariant())
+            {
+                case "SUCCEEDED":
+                    var transcriptionUrl = output?.Result?.TranscriptionUrl
+                        ?? (output?.Results != null && output.Results.Count > 0 ? output.Results[0].TranscriptionUrl : null);
+                    if (string.IsNullOrEmpty(transcriptionUrl))
+                    {
+                        throw new InvalidOperationException($"DashScope task succeeded but returned no transcription_url. Response: {json}");
+                    }
+                    return transcriptionUrl;
+
+                case "FAILED":
+                case "UNKNOWN":
+                    throw new InvalidOperationException($"DashScope transcription task {status}. Response: {json}");
+
+                default: // QUEUED, PENDING, PROCESSING
+                    await Task.Delay(TimeSpan.FromSeconds(3), ct);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Serialize the async submit body. <c>enable_words</c> adds word-level
+    /// timings; a fixed language is sent only when the user set one.
+    /// </summary>
+    internal static string BuildSubmitBody(DashScopeSttSettings settings, string fileUrl, string? language)
+    {
+        var languageToUse = language ?? settings.Language;
+
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("model", string.IsNullOrWhiteSpace(settings.Model) ? "qwen3-asr-flash-filetrans" : settings.Model);
+
+            writer.WritePropertyName("input");
+            writer.WriteStartObject();
+            writer.WriteString("file_url", fileUrl);
+            writer.WriteEndObject();
+
+            writer.WritePropertyName("parameters");
+            writer.WriteStartObject();
+            writer.WriteBoolean("enable_itn", false);
+            writer.WriteBoolean("enable_words", settings.EnableWords);
+            if (!string.IsNullOrWhiteSpace(languageToUse) && languageToUse != "auto")
+            {
+                writer.WriteString("language", languageToUse);
+            }
+            writer.WriteEndObject();
+
+            writer.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    /// <summary>
+    /// Map a DashScope transcription-result JSON into the shared response shape.
+    /// Each sentence (millisecond begin/end) becomes one timed segment.
+    /// </summary>
+    internal static OpenAiCompatibleSttResponse ParseTranscriptionResult(string json)
+    {
+        var segments = new List<OpenAiCompatibleSegment>();
+        var fullText = new StringBuilder();
+
+        try
+        {
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            var result = JsonSerializer.Deserialize<DashScopeTranscriptionResult>(json, options);
+            var transcripts = result?.Transcripts;
+            if (transcripts != null)
+            {
+                var id = 0;
+                foreach (var transcript in transcripts)
+                {
+                    if (transcript.Sentences == null)
+                    {
+                        continue;
+                    }
+
+                    foreach (var sentence in transcript.Sentences)
+                    {
+                        var text = (sentence.Text ?? string.Empty).Trim();
+                        if (text.Length == 0)
+                        {
+                            continue;
+                        }
+
+                        segments.Add(new OpenAiCompatibleSegment
+                        {
+                            Id = id++,
+                            Start = sentence.BeginTime / 1000.0,
+                            End = sentence.EndTime / 1000.0,
+                            Text = text,
+                        });
+
+                        if (fullText.Length > 0)
+                        {
+                            fullText.Append(' ');
+                        }
+                        fullText.Append(text);
+                    }
+                }
+            }
+        }
+        catch (JsonException)
+        {
+            // Leave segments empty; caller falls back to chunk-spanning text.
+        }
+
+        return new OpenAiCompatibleSttResponse
+        {
+            Text = fullText.ToString().Trim(),
+            Segments = segments,
+            Duration = segments.Count > 0 ? segments[^1].End : 0,
+        };
+    }
+
+    public static DashScopeSttSettings GetSettingsFromConfiguration()
+    {
+        var tools = Configuration.Settings.Tools;
+        return new DashScopeSttSettings
+        {
+            ApiKey = tools.DashScopeSttApiKey,
+            Model = tools.DashScopeSttModel,
+            Language = tools.DashScopeSttLanguage,
+            Region = tools.DashScopeSttRegion,
+            EnableWords = tools.DashScopeSttEnableWords,
+            TimeoutSeconds = tools.DashScopeSttTimeoutSeconds,
+            Logger = Se.WriteToolsLog,
+        };
+    }
+}
+
+public class DashScopeSttSettings
+{
+    public string ApiKey { get; set; } = string.Empty;
+    public string Model { get; set; } = "qwen3-asr-flash-filetrans";
+    public string Language { get; set; } = string.Empty;
+    public string Region { get; set; } = "international";
+    public bool EnableWords { get; set; }
+    public int TimeoutSeconds { get; set; } = 3600;
+    public Action<string>? Logger { get; set; }
+}
+
+// --- Upload policy (getPolicy) ---
+internal class DashScopeUploadPolicyResponse
+{
+    [JsonPropertyName("data")]
+    public DashScopeUploadPolicy? Data { get; set; }
+}
+
+internal class DashScopeUploadPolicy
+{
+    [JsonPropertyName("policy")]
+    public string Policy { get; set; } = string.Empty;
+
+    [JsonPropertyName("signature")]
+    public string Signature { get; set; } = string.Empty;
+
+    [JsonPropertyName("upload_dir")]
+    public string UploadDir { get; set; } = string.Empty;
+
+    [JsonPropertyName("upload_host")]
+    public string UploadHost { get; set; } = string.Empty;
+
+    [JsonPropertyName("oss_access_key_id")]
+    public string OssAccessKeyId { get; set; } = string.Empty;
+
+    [JsonPropertyName("x_oss_object_acl")]
+    public string XOssObjectAcl { get; set; } = string.Empty;
+
+    [JsonPropertyName("x_oss_forbid_overwrite")]
+    public string XOssForbidOverwrite { get; set; } = string.Empty;
+}
+
+// --- Async submit / poll ---
+internal class DashScopeTaskResponse
+{
+    [JsonPropertyName("output")]
+    public DashScopeTaskOutput? Output { get; set; }
+}
+
+internal class DashScopeTaskOutput
+{
+    [JsonPropertyName("task_id")]
+    public string? TaskId { get; set; }
+
+    [JsonPropertyName("task_status")]
+    public string? TaskStatus { get; set; }
+
+    [JsonPropertyName("result")]
+    public DashScopeTaskResult? Result { get; set; }
+
+    [JsonPropertyName("results")]
+    public List<DashScopeTaskResult>? Results { get; set; }
+}
+
+internal class DashScopeTaskResult
+{
+    [JsonPropertyName("transcription_url")]
+    public string? TranscriptionUrl { get; set; }
+}
+
+// --- transcription_url result JSON ---
+internal class DashScopeTranscriptionResult
+{
+    [JsonPropertyName("transcripts")]
+    public List<DashScopeTranscript>? Transcripts { get; set; }
+}
+
+internal class DashScopeTranscript
+{
+    [JsonPropertyName("text")]
+    public string? Text { get; set; }
+
+    [JsonPropertyName("sentences")]
+    public List<DashScopeSentence>? Sentences { get; set; }
+}
+
+internal class DashScopeSentence
+{
+    [JsonPropertyName("begin_time")]
+    public double BeginTime { get; set; }
+
+    [JsonPropertyName("end_time")]
+    public double EndTime { get; set; }
+
+    [JsonPropertyName("text")]
+    public string? Text { get; set; }
+}

--- a/src/ui/Features/Video/SpeechToText/Engines/DashScopeQwen3SttEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/DashScopeQwen3SttEngine.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Platform;
+using Nikse.SubtitleEdit.Core.AudioToText;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.DashScope;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+/// <summary>
+/// Online speech-to-text via Alibaba Cloud Model Studio (DashScope) Qwen3-ASR.
+/// Uses the asynchronous file-transcription path (upload → submit → poll →
+/// fetch) so real sentence timestamps are returned. See
+/// <see cref="DashScopeSttService"/> for the request flow.
+/// </summary>
+public class DashScopeQwen3SttEngine : IOnlineSttEngine
+{
+    public static string StaticName => "Alibaba Qwen3-ASR";
+    public string Name => StaticName;
+    public string Choice => WhisperChoice.DashScopeQwen3;
+    public string Url => "https://www.alibabacloud.com/help/en/model-studio/qwen-speech-recognition";
+
+    public override string ToString() => Name;
+
+    public List<WhisperLanguage> Languages => WhisperLanguage.Languages.OrderBy(p => p.Name).ToList();
+    public List<WhisperModel> Models => new();
+
+    public string Extension => string.Empty;
+    public string UnpackSkipFolder => string.Empty;
+
+    public bool IsEngineInstalled() => true;
+    public bool CanBeDownloaded() => false;
+
+    public ISttTranscriber? CreateTranscriber(out string? configErrorMessage)
+    {
+        var settings = DashScopeSttService.GetSettingsFromConfiguration();
+        if (string.IsNullOrWhiteSpace(settings.ApiKey))
+        {
+            configErrorMessage = Se.Language.General.OnlineSttApiKeyMissing;
+            return null;
+        }
+
+        configErrorMessage = null;
+        return new DashScopeSttService(settings);
+    }
+
+    public string ProbeUrl => DashScopeSttService.GetBaseUrl(Se.Settings.Tools.DashScopeSttRegion);
+
+    // The async Filetrans job accepts the whole file (up to 12 h) via a single
+    // upload, so never split it into chunks — set the threshold beyond any file.
+    public long UploadThresholdBytes => long.MaxValue;
+    public long ChunkSizeBytes => long.MaxValue;
+
+    public string GetAndCreateWhisperFolder() => WhisperHelper.GetWhisperFolder(WhisperChoice.DashScopeQwen3);
+    public string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel) => new WhisperModel().ModelFolder;
+    public string GetExecutable() => string.Empty;
+    public bool IsModelInstalled(WhisperModel model) => true;
+    public string GetModelForCmdLine(string modelName) => modelName;
+    public string GetWhisperModelDownloadFileName(WhisperModel whisperModel, string url) => string.Empty;
+
+    public async Task<string> GetHelpText()
+    {
+        var uri = new Uri("avares://SubtitleEdit/Assets/SpeechToText/AlibabaQwen3Asr.txt");
+        try
+        {
+            await using var stream = AssetLoader.Open(uri);
+            using var reader = new StreamReader(stream);
+            return await reader.ReadToEndAsync();
+        }
+        catch
+        {
+            return "Alibaba Cloud (DashScope) Qwen3-ASR speech-to-text.\n\n" +
+                   "Create an API key in Alibaba Cloud Model Studio, pick your region, and set the key.\n" +
+                   "The audio is uploaded to DashScope temporary storage and transcribed asynchronously " +
+                   "with sentence timestamps.";
+        }
+    }
+
+    public string CommandLineParameter
+    {
+        get => string.Empty;
+        set { }
+    }
+}

--- a/src/ui/Features/Video/SpeechToText/Engines/IOnlineSttEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/IOnlineSttEngine.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.OpenAiCompatible;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+/// <summary>
+/// A speech-to-text transport that uploads audio to a cloud transcription
+/// service and returns segments/words in the shared
+/// <see cref="OpenAiCompatibleSttResponse"/> shape. Implemented per provider:
+/// OpenAI-compatible multipart (<see cref="OpenAiSttService"/>), OpenRouter's
+/// base64-JSON body, and DashScope's multimodal-generation request. Sharing the
+/// response shape lets the view model drive them all through one chunk/ingest
+/// pipeline.
+/// </summary>
+public interface ISttTranscriber
+{
+    Task<OpenAiCompatibleSttResponse> TranscribeAsync(
+        string audioFilePath,
+        string? language,
+        IProgress<string>? progress,
+        IProgress<OpenAiCompatibleSegment>? segmentProgress,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Marker for cloud STT engines that transcribe by calling an online API rather
+/// than running a local executable. The SpeechToText view model routes every
+/// engine implementing this through the shared upload/chunk/ingest pipeline
+/// (see ProcessOnlineSttTranscription), so provider-specific differences are
+/// confined to the returned <see cref="ISttTranscriber"/>.
+/// </summary>
+public interface IOnlineSttEngine : ISpeechToTextEngine
+{
+    /// <summary>
+    /// Build a transcriber from the current settings. Returns null and sets
+    /// <paramref name="configErrorMessage"/> to a user-facing message when the
+    /// engine is not configured (e.g. missing API key or endpoint).
+    /// </summary>
+    ISttTranscriber? CreateTranscriber(out string? configErrorMessage);
+
+    /// <summary>
+    /// URL whose host is pre-flight probed for reachability before uploading.
+    /// </summary>
+    string ProbeUrl { get; }
+
+    /// <summary>
+    /// Upload size (bytes) above which the audio is split into chunks to stay
+    /// under the provider's per-request cap.
+    /// </summary>
+    long UploadThresholdBytes { get; }
+
+    /// <summary>
+    /// Target size (bytes) for each chunk when splitting.
+    /// </summary>
+    long ChunkSizeBytes { get; }
+}

--- a/src/ui/Features/Video/SpeechToText/Engines/OpenRouterSttEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/OpenRouterSttEngine.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Platform;
+using Nikse.SubtitleEdit.Core.AudioToText;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.OpenRouter;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+/// <summary>
+/// Online speech-to-text via OpenRouter's audio transcription API. OpenRouter
+/// routes to Whisper / GPT-4o-transcribe / Groq / Chirp behind one endpoint and
+/// one API key, and returns the same verbose_json segment/word shape we already
+/// parse. See <see cref="OpenRouterSttService"/> for the request encoding.
+/// </summary>
+public class OpenRouterSttEngine : IOnlineSttEngine
+{
+    public static string StaticName => "OpenRouter";
+    public string Name => StaticName;
+    public string Choice => WhisperChoice.OpenRouter;
+    public string Url => "https://openrouter.ai/docs/guides/overview/multimodal/stt";
+
+    // OpenRouter proxies Whisper-class models (25 MB caps) but the audio is
+    // base64-inflated into a JSON body, so chunk more conservatively.
+    private const long UploadThreshold = 18L * 1024 * 1024;
+    private const long ChunkSize = 16L * 1024 * 1024;
+
+    public override string ToString() => Name;
+
+    public List<WhisperLanguage> Languages => WhisperLanguage.Languages.OrderBy(p => p.Name).ToList();
+    public List<WhisperModel> Models => new();
+
+    public string Extension => string.Empty;
+    public string UnpackSkipFolder => string.Empty;
+
+    public bool IsEngineInstalled() => true;
+    public bool CanBeDownloaded() => false;
+
+    public ISttTranscriber? CreateTranscriber(out string? configErrorMessage)
+    {
+        var settings = OpenRouterSttService.GetSettingsFromConfiguration();
+        if (string.IsNullOrWhiteSpace(settings.ApiKey))
+        {
+            configErrorMessage = Se.Language.General.OnlineSttApiKeyMissing;
+            return null;
+        }
+
+        configErrorMessage = null;
+        return new OpenRouterSttService(settings);
+    }
+
+    public string ProbeUrl => "https://openrouter.ai";
+    public long UploadThresholdBytes => UploadThreshold;
+    public long ChunkSizeBytes => ChunkSize;
+
+    public string GetAndCreateWhisperFolder() => WhisperHelper.GetWhisperFolder(WhisperChoice.OpenRouter);
+    public string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel) => new WhisperModel().ModelFolder;
+    public string GetExecutable() => string.Empty;
+    public bool IsModelInstalled(WhisperModel model) => true;
+    public string GetModelForCmdLine(string modelName) => modelName;
+    public string GetWhisperModelDownloadFileName(WhisperModel whisperModel, string url) => string.Empty;
+
+    public async Task<string> GetHelpText()
+    {
+        var uri = new Uri("avares://SubtitleEdit/Assets/SpeechToText/OpenRouter.txt");
+        try
+        {
+            await using var stream = AssetLoader.Open(uri);
+            using var reader = new StreamReader(stream);
+            return await reader.ReadToEndAsync();
+        }
+        catch
+        {
+            return "OpenRouter speech-to-text service.\n\n" +
+                   "Create an API key at https://openrouter.ai/keys, then set it in the OpenRouter fields.\n" +
+                   "Pick a transcription model such as openai/whisper-1 or openai/whisper-large-v3.";
+        }
+    }
+
+    public string CommandLineParameter
+    {
+        get => Se.Settings.Tools.OpenRouterSttPrompt;
+        set => Se.Settings.Tools.OpenRouterSttPrompt = value;
+    }
+}

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineFactory.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineFactory.cs
@@ -57,6 +57,16 @@ public static class WhisperEngineFactory
             return new OpenAiCompatibleSttEngine();
         }
 
+        if (staticName == OpenRouterSttEngine.StaticName)
+        {
+            return new OpenRouterSttEngine();
+        }
+
+        if (staticName == DashScopeQwen3SttEngine.StaticName)
+        {
+            return new DashScopeQwen3SttEngine();
+        }
+
         throw new NotImplementedException();
     }
 }

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineOpenAiCompatible.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineOpenAiCompatible.cs
@@ -6,16 +6,34 @@ using System.Threading.Tasks;
 using Avalonia.Platform;
 using Nikse.SubtitleEdit.Core.AudioToText;
 using Nikse.SubtitleEdit.Core.Settings;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.OpenAiCompatible;
 using Nikse.SubtitleEdit.Logic.Config;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 
-public class OpenAiCompatibleSttEngine : ISpeechToTextEngine
+public class OpenAiCompatibleSttEngine : IOnlineSttEngine
 {
     public static string StaticName => "OpenAI Compatible Server";
     public string Name => StaticName;
     public string Choice => WhisperChoice.OpenAiCompatible;
     public string Url => "https://platform.openai.com/docs/guides/speech-to-text";
+
+    public ISttTranscriber? CreateTranscriber(out string? configErrorMessage)
+    {
+        var settings = OpenAiSttService.GetSettingsFromConfiguration();
+        if (string.IsNullOrWhiteSpace(settings.EndpointUrl))
+        {
+            configErrorMessage = Se.Language.General.OpenAiCompatibleSttUrlMissing;
+            return null;
+        }
+
+        configErrorMessage = null;
+        return new OpenAiSttService(settings);
+    }
+
+    public string ProbeUrl => Se.Settings.Tools.OpenAiCompatibleSttUrl;
+    public long UploadThresholdBytes => OpenAiSttChunker.DefaultThresholdBytes;
+    public long ChunkSizeBytes => OpenAiSttChunker.DefaultChunkSizeBytes;
 
     public override string ToString()
     {

--- a/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
@@ -11,11 +11,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Settings;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Logic.Config;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.OpenAiCompatible;
 
-public class OpenAiSttService
+public class OpenAiSttService : ISttTranscriber
 {
     private static HttpClient? _sharedHttpClient;
     private static readonly Lock SharedHttpClientLock = new();

--- a/src/ui/Features/Video/SpeechToText/OpenRouter/OpenRouterSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/OpenRouter/OpenRouterSttService.cs
@@ -1,0 +1,216 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.OpenAiCompatible;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.OpenRouter;
+
+/// <summary>
+/// Speech-to-text via OpenRouter's audio transcription API. Unlike OpenAI's
+/// multipart <c>/v1/audio/transcriptions</c>, OpenRouter takes a JSON body with
+/// the audio base64-encoded under <c>input_audio</c>. It proxies Whisper /
+/// GPT-4o-transcribe / Groq / Chirp, so with <c>response_format=verbose_json</c>
+/// and <c>timestamp_granularities[]</c> it returns the same segment/word shape
+/// we already parse into <see cref="OpenAiCompatibleSttResponse"/>. When a model
+/// or provider ignores those hints and returns only <c>text</c>, the caller's
+/// chunk pipeline still spans each chunk's duration so timing survives.
+/// </summary>
+public class OpenRouterSttService : ISttTranscriber
+{
+    public const string DefaultEndpointUrl = "https://openrouter.ai/api/v1/audio/transcriptions";
+
+    private readonly HttpClient _httpClient;
+    private readonly OpenRouterSttSettings _settings;
+
+    public OpenRouterSttService(OpenRouterSttSettings settings)
+        : this(OpenAiSttService.SharedHttpClient, settings)
+    {
+    }
+
+    public OpenRouterSttService(HttpClient httpClient, OpenRouterSttSettings settings)
+    {
+        _httpClient = httpClient;
+        _settings = settings;
+    }
+
+    public Task<OpenAiCompatibleSttResponse> TranscribeAsync(
+        string audioFilePath,
+        string? language,
+        IProgress<string>? progress,
+        IProgress<OpenAiCompatibleSegment>? segmentProgress,
+        CancellationToken cancellationToken)
+    {
+        var bytes = File.ReadAllBytes(audioFilePath);
+        var format = OpenAiSttService.GetFileExtensionForFormat(Path.GetExtension(audioFilePath).TrimStart('.'));
+        return TranscribeAsync(bytes, format, language, cancellationToken);
+    }
+
+    /// <summary>
+    /// Build the OpenRouter request body and POST it. Exposed for unit tests so
+    /// the JSON shape can be asserted without a network call via
+    /// <see cref="BuildRequestBody"/>.
+    /// </summary>
+    public async Task<OpenAiCompatibleSttResponse> TranscribeAsync(
+        byte[] audioBytes,
+        string format,
+        string? language,
+        CancellationToken cancellationToken)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        if (_settings.TimeoutSeconds > 0)
+        {
+            timeoutCts.CancelAfter(TimeSpan.FromSeconds(_settings.TimeoutSeconds));
+        }
+        cancellationToken = timeoutCts.Token;
+
+        var body = BuildRequestBody(_settings, audioBytes, format, language);
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        using var request = new HttpRequestMessage(HttpMethod.Post, _settings.EndpointUrl)
+        {
+            Content = content,
+        };
+
+        if (!string.IsNullOrEmpty(_settings.ApiKey))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _settings.ApiKey);
+        }
+
+        // OpenRouter uses these to attribute traffic; harmless if the server ignores them.
+        request.Headers.TryAddWithoutValidation("HTTP-Referer", "https://www.nikse.dk/subtitleedit");
+        request.Headers.TryAddWithoutValidation("X-Title", "Subtitle Edit");
+
+        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
+            var statusCode = (int)response.StatusCode;
+            _settings.Logger?.Invoke(
+                $"OpenRouter STT failed: POST {_settings.EndpointUrl}{Environment.NewLine}" +
+                $"Status: {statusCode} {response.StatusCode}{Environment.NewLine}" +
+                $"RequestParams: model={_settings.Model}, language={language ?? _settings.Language}, format={format}, bytes={audioBytes.Length}{Environment.NewLine}" +
+                $"ResponseBody: {errorContent}");
+            throw new HttpRequestException(
+                $"OpenRouter STT request failed with status {statusCode} ({response.StatusCode}). Response: {errorContent}");
+        }
+
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        return ParseResponse(json);
+    }
+
+    /// <summary>
+    /// Serialize the OpenRouter transcription request body. The audio is
+    /// base64-encoded (raw, not a data URI) under <c>input_audio</c>, and
+    /// <c>verbose_json</c> + <c>timestamp_granularities[]</c> ask for segment and
+    /// word timings when the underlying model supports them.
+    /// </summary>
+    internal static string BuildRequestBody(OpenRouterSttSettings settings, byte[] audioBytes, string format, string? language)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("model", settings.Model);
+
+            writer.WritePropertyName("input_audio");
+            writer.WriteStartObject();
+            writer.WriteString("data", Convert.ToBase64String(audioBytes));
+            writer.WriteString("format", string.IsNullOrWhiteSpace(format) ? "mp3" : format);
+            writer.WriteEndObject();
+
+            writer.WriteString("response_format", "verbose_json");
+
+            writer.WritePropertyName("timestamp_granularities");
+            writer.WriteStartArray();
+            writer.WriteStringValue("segment");
+            writer.WriteStringValue("word");
+            writer.WriteEndArray();
+
+            var languageToUse = language ?? settings.Language;
+            if (!string.IsNullOrWhiteSpace(languageToUse))
+            {
+                writer.WriteString("language", languageToUse);
+            }
+
+            if (settings.Temperature > 0)
+            {
+                writer.WriteNumber("temperature", settings.Temperature);
+            }
+
+            if (!string.IsNullOrWhiteSpace(settings.Prompt))
+            {
+                writer.WriteString("prompt", settings.Prompt);
+            }
+
+            writer.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    /// <summary>
+    /// Parse an OpenRouter transcription response into the shared shape. Reuses
+    /// the OpenAI verbose_json model; if only word timings come back, they are
+    /// grouped into segments, and a bare <c>text</c> response falls through to
+    /// the caller's chunk-spanning path.
+    /// </summary>
+    internal static OpenAiCompatibleSttResponse ParseResponse(string json)
+    {
+        try
+        {
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            var result = JsonSerializer.Deserialize<OpenAiCompatibleSttResponse>(json, options);
+            if (result != null)
+            {
+                if ((result.Segments == null || result.Segments.Count == 0) &&
+                    result.Words != null && result.Words.Count > 0)
+                {
+                    result.Segments = OpenAiSttService.BuildSegmentsFromWords(result.Words);
+                }
+
+                return result;
+            }
+        }
+        catch (JsonException)
+        {
+            // Fall through to plain-text handling.
+        }
+
+        return new OpenAiCompatibleSttResponse { Text = json.Trim() };
+    }
+
+    public static OpenRouterSttSettings GetSettingsFromConfiguration()
+    {
+        var tools = Configuration.Settings.Tools;
+        return new OpenRouterSttSettings
+        {
+            EndpointUrl = DefaultEndpointUrl,
+            ApiKey = tools.OpenRouterSttApiKey,
+            Model = tools.OpenRouterSttModel,
+            Language = tools.OpenRouterSttLanguage,
+            Temperature = (double)tools.OpenRouterSttTemperature,
+            Prompt = tools.OpenRouterSttPrompt,
+            TimeoutSeconds = tools.OpenRouterSttTimeoutSeconds,
+            Logger = Se.WriteToolsLog,
+        };
+    }
+}
+
+public class OpenRouterSttSettings
+{
+    public string EndpointUrl { get; set; } = OpenRouterSttService.DefaultEndpointUrl;
+    public string ApiKey { get; set; } = string.Empty;
+    public string Model { get; set; } = "openai/whisper-1";
+    public string Language { get; set; } = string.Empty;
+    public double Temperature { get; set; }
+    public string Prompt { get; set; } = string.Empty;
+    public int TimeoutSeconds { get; set; } = 300;
+    public Action<string>? Logger { get; set; }
+}

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -105,6 +105,23 @@ public partial class SpeechToTextViewModel : ObservableObject
     [ObservableProperty] private string _openAiCompatibleSttAudioFormat = "mp3";
     public ObservableCollection<string> OpenAiCompatibleSttAudioFormats { get; } = new(new[] { "mp3", "m4a", "webm", "wav" });
 
+    [ObservableProperty] private bool _isOpenRouterSttVisible;
+    [ObservableProperty] private string? _openRouterSttApiKey;
+    [ObservableProperty] private string? _openRouterSttModel;
+    [ObservableProperty] private string? _openRouterSttLanguage;
+    [ObservableProperty] private decimal _openRouterSttTemperature;
+    [ObservableProperty] private string? _openRouterSttPrompt;
+    [ObservableProperty] private int _openRouterSttTimeoutSeconds;
+
+    [ObservableProperty] private bool _isDashScopeSttVisible;
+    [ObservableProperty] private string? _dashScopeSttApiKey;
+    [ObservableProperty] private string? _dashScopeSttModel;
+    [ObservableProperty] private string? _dashScopeSttLanguage;
+    [ObservableProperty] private string _dashScopeSttRegion = "international";
+    [ObservableProperty] private bool _dashScopeSttEnableWords;
+    [ObservableProperty] private int _dashScopeSttTimeoutSeconds;
+    public ObservableCollection<string> DashScopeSttRegions { get; } = new(new[] { "international", "china" });
+
     public Window? Window { get; set; }
 
     public bool OkPressed { get; private set; }
@@ -215,6 +232,10 @@ public partial class SpeechToTextViewModel : ObservableObject
         // Add OpenAI Compatible STT engine (available on all platforms)
         Engines.Add(new OpenAiCompatibleSttEngine());
 
+        // Online STT services reachable on all platforms
+        Engines.Add(new OpenRouterSttEngine());
+        Engines.Add(new DashScopeQwen3SttEngine());
+
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
             RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
             RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
@@ -286,6 +307,21 @@ public partial class SpeechToTextViewModel : ObservableObject
         var savedFormat = Se.Settings.Tools.OpenAiCompatibleSttAudioFormat;
         OpenAiCompatibleSttAudioFormat = OpenAiCompatibleSttAudioFormats.Contains(savedFormat) ? savedFormat : "mp3";
 
+        OpenRouterSttApiKey = Se.Settings.Tools.OpenRouterSttApiKey;
+        OpenRouterSttModel = Se.Settings.Tools.OpenRouterSttModel;
+        OpenRouterSttLanguage = Se.Settings.Tools.OpenRouterSttLanguage;
+        OpenRouterSttTemperature = Se.Settings.Tools.OpenRouterSttTemperature;
+        OpenRouterSttPrompt = Se.Settings.Tools.OpenRouterSttPrompt;
+        OpenRouterSttTimeoutSeconds = Se.Settings.Tools.OpenRouterSttTimeoutSeconds;
+
+        DashScopeSttApiKey = Se.Settings.Tools.DashScopeSttApiKey;
+        DashScopeSttModel = Se.Settings.Tools.DashScopeSttModel;
+        DashScopeSttLanguage = Se.Settings.Tools.DashScopeSttLanguage;
+        var savedRegion = Se.Settings.Tools.DashScopeSttRegion;
+        DashScopeSttRegion = DashScopeSttRegions.Contains(savedRegion) ? savedRegion : "international";
+        DashScopeSttEnableWords = Se.Settings.Tools.DashScopeSttEnableWords;
+        DashScopeSttTimeoutSeconds = Se.Settings.Tools.DashScopeSttTimeoutSeconds;
+
         var savedChoice = Se.Settings.Tools.AudioToText.WhisperChoice;
         var whisperCppEngine = Engines.OfType<WhisperCppEngine>().FirstOrDefault();
         var crispAsrEngine = Engines.OfType<CrispAsrEngine>().FirstOrDefault();
@@ -333,6 +369,20 @@ public partial class SpeechToTextViewModel : ObservableObject
         Se.Settings.Tools.OpenAiCompatibleSttStream = OpenAiCompatibleSttStream;
         Se.Settings.Tools.OpenAiCompatibleSttAudioFormat = OpenAiCompatibleSttAudioFormat ?? "mp3";
 
+        Se.Settings.Tools.OpenRouterSttApiKey = OpenRouterSttApiKey ?? string.Empty;
+        Se.Settings.Tools.OpenRouterSttModel = OpenRouterSttModel ?? string.Empty;
+        Se.Settings.Tools.OpenRouterSttLanguage = OpenRouterSttLanguage ?? string.Empty;
+        Se.Settings.Tools.OpenRouterSttTemperature = OpenRouterSttTemperature;
+        Se.Settings.Tools.OpenRouterSttPrompt = OpenRouterSttPrompt ?? string.Empty;
+        Se.Settings.Tools.OpenRouterSttTimeoutSeconds = OpenRouterSttTimeoutSeconds;
+
+        Se.Settings.Tools.DashScopeSttApiKey = DashScopeSttApiKey ?? string.Empty;
+        Se.Settings.Tools.DashScopeSttModel = DashScopeSttModel ?? string.Empty;
+        Se.Settings.Tools.DashScopeSttLanguage = DashScopeSttLanguage ?? string.Empty;
+        Se.Settings.Tools.DashScopeSttRegion = DashScopeSttRegion ?? "international";
+        Se.Settings.Tools.DashScopeSttEnableWords = DashScopeSttEnableWords;
+        Se.Settings.Tools.DashScopeSttTimeoutSeconds = DashScopeSttTimeoutSeconds;
+
         Se.SaveSettings();
     }
 
@@ -377,7 +427,7 @@ public partial class SpeechToTextViewModel : ObservableObject
 
     private static bool IsTranslateAvailable(ISpeechToTextEngine engine)
     {
-        return engine is not ChatLlmCppEngine and not Qwen3AsrCppEngine and not ICrispAsrEngine and not OpenAiCompatibleSttEngine;
+        return engine is not ChatLlmCppEngine and not Qwen3AsrCppEngine and not ICrispAsrEngine and not IOnlineSttEngine;
     }
 
     private void UpdateBackendSelectionUi()
@@ -1013,22 +1063,21 @@ public partial class SpeechToTextViewModel : ObservableObject
         }
     }
 
-    private async Task ProcessOpenAiCompatibleTranscription(string audioFileName, string? language = null, CancellationToken cancellationToken = default)
+    private async Task ProcessOnlineSttTranscription(IOnlineSttEngine engine, string audioFileName, string? language = null, CancellationToken cancellationToken = default)
     {
-        // The OpenAI Compatible engine reads its config from
-        // Configuration.Settings.Tools via GetSettingsFromConfiguration(), so
-        // the user's in-window edits (URL, key, model, prompt, ...) must be
+        // Online STT engines read their config from Configuration.Settings.Tools,
+        // so the user's in-window edits (URL, key, model, prompt, ...) must be
         // persisted before we read them. The transcribe action is the commit
-        // moment for this engine — there is no separate OK button.
+        // moment for these engines — there is no separate OK button.
         SaveSettings();
-        var openAiSettings = OpenAiSttService.GetSettingsFromConfiguration();
 
-        if (string.IsNullOrWhiteSpace(openAiSettings.EndpointUrl))
+        var transcriber = engine.CreateTranscriber(out var configError);
+        if (transcriber == null)
         {
             await Dispatcher.UIThread.InvokeAsync(async () =>
             {
                 await MessageBox.Show(Window!,
-                    Se.Language.General.OpenAiCompatibleSttUrlMissing,
+                    configError ?? Se.Language.General.OpenAiCompatibleSttUrlMissing,
                     Se.Language.General.ConfigurationRequired);
                 IsTranscribeEnabled = true;
             });
@@ -1038,13 +1087,13 @@ public partial class SpeechToTextViewModel : ObservableObject
         ProgressText = Se.Language.Video.AudioToText.Transcribing;
         ProgressValue = 5;
 
-        var probeError = await ProbeOpenAiUrlAsync(openAiSettings.EndpointUrl, cancellationToken);
+        var probeError = await ProbeOpenAiUrlAsync(engine.ProbeUrl, cancellationToken);
         if (probeError != null)
         {
-            LogToConsole($"OpenAI Compatible STT endpoint probe failed: {probeError}. Retrying...");
+            LogToConsole($"Online STT endpoint probe failed: {probeError}. Retrying...");
             // Brief delay so transient DNS/socket hiccups have a chance to recover before retrying.
             await Task.Delay(300, cancellationToken);
-            probeError = await ProbeOpenAiUrlAsync(openAiSettings.EndpointUrl, cancellationToken);
+            probeError = await ProbeOpenAiUrlAsync(engine.ProbeUrl, cancellationToken);
         }
 
         if (probeError != null)
@@ -1066,7 +1115,7 @@ public partial class SpeechToTextViewModel : ObservableObject
 
         try
         {
-            var service = new OpenAiSttService(openAiSettings);
+            var service = transcriber;
 
             var segmentProgress = new Progress<OpenAiCompatibleSegment>(seg =>
             {
@@ -1092,10 +1141,10 @@ public partial class SpeechToTextViewModel : ObservableObject
             });
 
             var audioSizeBytes = new FileInfo(audioFileName).Length;
-            if (audioSizeBytes > OpenAiSttChunker.DefaultThresholdBytes && _videoInfo.TotalSeconds > 0)
+            if (audioSizeBytes > engine.UploadThresholdBytes && _videoInfo.TotalSeconds > 0)
             {
-                LogToConsole($"Audio file is {audioSizeBytes / (1024 * 1024)} MB — splitting into chunks to stay under the OpenAI 25 MB cap");
-                await TranscribeInChunksAsync(service, audioFileName, language, subtitle, segmentProgress, cancellationToken);
+                LogToConsole($"Audio file is {audioSizeBytes / (1024 * 1024)} MB — splitting into chunks to stay under the upload cap");
+                await TranscribeInChunksAsync(service, engine, audioFileName, language, subtitle, segmentProgress, cancellationToken);
             }
             else
             {
@@ -1259,7 +1308,8 @@ public partial class SpeechToTextViewModel : ObservableObject
     /// catch-blocks like the single-file path.
     /// </summary>
     private async Task TranscribeInChunksAsync(
-        OpenAiSttService service,
+        ISttTranscriber service,
+        IOnlineSttEngine engine,
         string audioFileName,
         string? language,
         Subtitle subtitle,
@@ -1268,7 +1318,7 @@ public partial class SpeechToTextViewModel : ObservableObject
     {
         var totalSeconds = _videoInfo.TotalSeconds;
         var fileSize = new FileInfo(audioFileName).Length;
-        var chunkCount = OpenAiSttChunker.ComputeChunkCount(fileSize);
+        var chunkCount = OpenAiSttChunker.ComputeChunkCount(fileSize, engine.ChunkSizeBytes);
 
         var ffmpegPath = Se.Settings.General.FfmpegPath;
         if (!File.Exists(ffmpegPath))
@@ -2572,7 +2622,7 @@ public partial class SpeechToTextViewModel : ObservableObject
 
         var engine = GetEffectiveSelectedEngine();
 
-        if (engine is not OpenAiCompatibleSttEngine)
+        if (engine is not IOnlineSttEngine)
         {
             if (SelectedModel is not SpeechToTextModelDisplay model)
             {
@@ -3062,7 +3112,7 @@ public partial class SpeechToTextViewModel : ObservableObject
     {
         if (!IsTranscribeEnabled)
         {
-            if (GetEffectiveSelectedEngine() is OpenAiCompatibleSttEngine)
+            if (GetEffectiveSelectedEngine() is IOnlineSttEngine)
             {
                 _openAiCts?.Cancel();
                 return;
@@ -3083,13 +3133,13 @@ public partial class SpeechToTextViewModel : ObservableObject
             return false;
         }
 
-        if (engine is OpenAiCompatibleSttEngine)
+        if (engine is IOnlineSttEngine onlineEngine)
         {
             var languageCode = SelectedLanguage?.Code;
             _timerWhisper.Stop();
             ShowProgressBar();
             _openAiCts = new CancellationTokenSource();
-            _ = ProcessOpenAiCompatibleTranscription(waveFileName, languageCode, _openAiCts.Token);
+            _ = ProcessOnlineSttTranscription(onlineEngine, waveFileName, languageCode, _openAiCts.Token);
             return true;
         }
 
@@ -3624,11 +3674,11 @@ public partial class SpeechToTextViewModel : ObservableObject
         }
 
         // Local whisper engines read the file directly and want 16 kHz PCM, so
-        // a pre-extracted 16 kHz WAV can be handed to them as-is. The OpenAI-
-        // compatible engine uploads the file instead, and a 16 kHz WAV easily
-        // exceeds the 25 MB cap on long audio — skip the short-circuit and
-        // transcode through ffmpeg into the chosen compressed format.
-        var isOpenAiEngine = GetEffectiveSelectedEngine() is OpenAiCompatibleSttEngine;
+        // a pre-extracted 16 kHz WAV can be handed to them as-is. Online engines
+        // upload the file instead, and a 16 kHz WAV easily exceeds the upload
+        // cap on long audio — skip the short-circuit and transcode through
+        // ffmpeg into the chosen compressed format.
+        var isOpenAiEngine = GetEffectiveSelectedEngine() is IOnlineSttEngine;
         if (!isOpenAiEngine && videoFileName.EndsWith(".wav", StringComparison.OrdinalIgnoreCase))
         {
             try
@@ -3649,14 +3699,14 @@ public partial class SpeechToTextViewModel : ObservableObject
 
         _ffmpegLog = new StringBuilder();
 
-        // OpenAI's STT endpoint caps uploads at 25 MB and a 2-hour WAV blows
-        // past that. When the OpenAI-compatible engine is selected, transcode
-        // to the user's chosen compressed format (mp3 by default) so the
-        // upload stays under the limit; other engines (whisper.cpp, faster-
-        // whisper, ...) keep getting WAV because they read the file locally
-        // and expect PCM.
+        // Online STT endpoints cap uploads (OpenAI 25 MB, DashScope 10 MB) and a
+        // 2-hour WAV blows past that. When an online engine is selected,
+        // transcode to a compressed format so the upload stays under the limit;
+        // the OpenAI-compatible engine honors the user's chosen format, the
+        // others default to mp3. Local engines (whisper.cpp, faster-whisper, ...)
+        // keep getting WAV because they read the file locally and expect PCM.
         var sttAudioFormat = isOpenAiEngine
-            ? OpenAiCompatibleSttAudioFormat
+            ? (GetEffectiveSelectedEngine() is OpenAiCompatibleSttEngine ? OpenAiCompatibleSttAudioFormat : "mp3")
             : "wav";
         var extension = OpenAiSttService.GetFileExtensionForFormat(sttAudioFormat);
         // Place the extracted audio in a dedicated per-run subfolder. Engines like
@@ -4005,20 +4055,24 @@ public partial class SpeechToTextViewModel : ObservableObject
 
         var isPurfview = engine.Name == WhisperEnginePurfviewFasterWhisperXxl.StaticName;
 
-        IsModelSelectionVisible = !(engine is OpenAiCompatibleSttEngine);
+        var isOnlineSttEngine = engine is IOnlineSttEngine;
+
+        IsModelSelectionVisible = !isOnlineSttEngine;
         if (!IsModelSelectionVisible)
         {
             SelectedModel = null;
         }
 
-        IsLanguageSelectionVisible = !(engine is OpenAiCompatibleSttEngine);
+        IsLanguageSelectionVisible = !isOnlineSttEngine;
         if (!IsLanguageSelectionVisible)
         {
             SelectedLanguage = null;
         }
 
         IsOpenAiCompatibleSttVisible = engine is OpenAiCompatibleSttEngine;
-        IsAdvancedSettingsVisible = !IsOpenAiCompatibleSttVisible;
+        IsOpenRouterSttVisible = engine is OpenRouterSttEngine;
+        IsDashScopeSttVisible = engine is DashScopeQwen3SttEngine;
+        IsAdvancedSettingsVisible = !isOnlineSttEngine;
 
         IsTranslateVisible = IsTranslateAvailable(engine);
 

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -7,6 +7,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
+using System.Linq;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -203,6 +204,8 @@ public class SpeechToTextWindow : Window
         };
 
         var openAiRows = MakeOpenAiCompatibleSttRows(vm);
+        var openRouterRows = MakeOpenRouterSttRows(vm);
+        var dashScopeRows = MakeDashScopeSttRows(vm);
 
         var labelAdvancedSettings = UiUtil.MakeTextBlock(Se.Language.General.AdvancedSettings).WithMarginTop(15)
             .BindIsVisible(vm, nameof(vm.IsAdvancedSettingsVisible));
@@ -443,10 +446,11 @@ public class SpeechToTextWindow : Window
         grid.Add(panelForcedAlignerControls, row, 1);
         row++;
 
-        foreach (var (label, control) in openAiRows)
+        foreach (var (label, control) in openAiRows.Concat(openRouterRows).Concat(dashScopeRows))
         {
-            // Link each OpenAI-compatible input to its visible label so a screen reader announces the
-            // label as the control's name instead of a bare "edit"/"combo box" (#11745).
+            // Link each online-STT input to its visible label so a screen reader announces the
+            // label as the control's name instead of a bare "edit"/"combo box" (#11745). Only the
+            // selected engine's rows are visible; the rest collapse to zero-height grid rows.
             AutomationProperties.SetLabeledBy(control, label);
             grid.Add(label, row, 0);
             grid.Add(control, row, 1);
@@ -721,6 +725,122 @@ public class SpeechToTextWindow : Window
             (MakeLabel(Se.Language.General.OpenAiCompatibleSttExtraHeaders), textExtraHeaders),
             (MakeLabel(Se.Language.General.OpenAiCompatibleSttAudioFormat), comboAudioFormat),
             (MakeLabel(Se.Language.General.OpenAiCompatibleSttStream), checkStream),
+        };
+    }
+
+    private static (Control Label, Control Control)[] MakeOpenRouterSttRows(SpeechToTextViewModel vm)
+    {
+        Control MakeLabel(string text) => UiUtil.MakeTextBlock(text).WithMarginTop(10)
+            .BindIsVisible(vm, nameof(vm.IsOpenRouterSttVisible));
+
+        TextBox MakeText(string property, double width, bool isPassword = false)
+        {
+            var tb = new TextBox
+            {
+                DataContext = vm,
+                Width = width,
+                HorizontalAlignment = HorizontalAlignment.Left,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 10, 0, 0),
+                [!TextBox.TextProperty] = new Binding(property) { Mode = BindingMode.TwoWay }
+            };
+            if (isPassword)
+            {
+                tb.PasswordChar = '*';
+            }
+            return tb.BindIsVisible(vm, nameof(vm.IsOpenRouterSttVisible));
+        }
+
+        var numericTimeout = new NumericUpDown
+        {
+            DataContext = vm,
+            Width = 120,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 10, 0, 0),
+            Minimum = 10,
+            Maximum = 3600,
+            FormatString = "F0",
+            [!NumericUpDown.ValueProperty] = new Binding(nameof(vm.OpenRouterSttTimeoutSeconds)) { Mode = BindingMode.TwoWay }
+        }.BindIsVisible(vm, nameof(vm.IsOpenRouterSttVisible));
+
+        var numericTemperature = new NumericUpDown
+        {
+            DataContext = vm,
+            Width = 120,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 10, 0, 0),
+            Minimum = 0,
+            Maximum = 1,
+            Increment = 0.1m,
+            FormatString = "F2",
+            [!NumericUpDown.ValueProperty] = new Binding(nameof(vm.OpenRouterSttTemperature)) { Mode = BindingMode.TwoWay }
+        }.BindIsVisible(vm, nameof(vm.IsOpenRouterSttVisible));
+
+        return new (Control, Control)[]
+        {
+            (MakeLabel(Se.Language.General.OpenAiCompatibleSttApiKey), MakeText(nameof(vm.OpenRouterSttApiKey), 400, isPassword: true)),
+            (MakeLabel(Se.Language.General.OpenAiCompatibleSttModel), MakeText(nameof(vm.OpenRouterSttModel), 250)),
+            (MakeLabel(Se.Language.General.OpenAiCompatibleSttLanguage), MakeText(nameof(vm.OpenRouterSttLanguage), 150)),
+            (MakeLabel(Se.Language.General.OpenAiCompatibleSttTimeout), numericTimeout),
+            (MakeLabel(Se.Language.General.OpenAiCompatibleSttTemperature), numericTemperature),
+            (MakeLabel(Se.Language.General.OpenAiCompatibleSttPrompt), MakeText(nameof(vm.OpenRouterSttPrompt), 400)),
+        };
+    }
+
+    private static (Control Label, Control Control)[] MakeDashScopeSttRows(SpeechToTextViewModel vm)
+    {
+        Control MakeLabel(string text) => UiUtil.MakeTextBlock(text).WithMarginTop(10)
+            .BindIsVisible(vm, nameof(vm.IsDashScopeSttVisible));
+
+        TextBox MakeText(string property, double width, bool isPassword = false)
+        {
+            var tb = new TextBox
+            {
+                DataContext = vm,
+                Width = width,
+                HorizontalAlignment = HorizontalAlignment.Left,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 10, 0, 0),
+                [!TextBox.TextProperty] = new Binding(property) { Mode = BindingMode.TwoWay }
+            };
+            if (isPassword)
+            {
+                tb.PasswordChar = '*';
+            }
+            return tb.BindIsVisible(vm, nameof(vm.IsDashScopeSttVisible));
+        }
+
+        var comboRegion = UiUtil.MakeComboBox(vm.DashScopeSttRegions, vm, nameof(vm.DashScopeSttRegion))
+            .WithMinWidth(150)
+            .WithMarginTop(10)
+            .BindIsVisible(vm, nameof(vm.IsDashScopeSttVisible));
+
+        var checkEnableWords = UiUtil.MakeCheckBox(vm, nameof(vm.DashScopeSttEnableWords))
+            .BindIsVisible(vm, nameof(vm.IsDashScopeSttVisible));
+
+        var numericTimeout = new NumericUpDown
+        {
+            DataContext = vm,
+            Width = 120,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 10, 0, 0),
+            Minimum = 30,
+            Maximum = 21600,
+            FormatString = "F0",
+            [!NumericUpDown.ValueProperty] = new Binding(nameof(vm.DashScopeSttTimeoutSeconds)) { Mode = BindingMode.TwoWay }
+        }.BindIsVisible(vm, nameof(vm.IsDashScopeSttVisible));
+
+        return new (Control, Control)[]
+        {
+            (MakeLabel(Se.Language.General.OpenAiCompatibleSttApiKey), MakeText(nameof(vm.DashScopeSttApiKey), 400, isPassword: true)),
+            (MakeLabel(Se.Language.General.OpenAiCompatibleSttModel), MakeText(nameof(vm.DashScopeSttModel), 250)),
+            (MakeLabel(Se.Language.General.DashScopeSttRegion), comboRegion),
+            (MakeLabel(Se.Language.General.OpenAiCompatibleSttLanguage), MakeText(nameof(vm.DashScopeSttLanguage), 150)),
+            (MakeLabel(Se.Language.General.DashScopeSttEnableWords), checkEnableWords),
+            (MakeLabel(Se.Language.General.OpenAiCompatibleSttTimeout), numericTimeout),
         };
     }
 

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -729,6 +729,9 @@ public class LanguageGeneral
     public string OpenAiCompatibleSttLanguage { get; set; }
     public string OpenAiCompatibleSttTemperature { get; set; }
     public string OpenAiCompatibleSttPrompt { get; set; }
+    public string DashScopeSttRegion { get; set; }
+    public string DashScopeSttEnableWords { get; set; }
+    public string OnlineSttApiKeyMissing { get; set; }
     public string OpenAiCompatibleSttAutoTranscribeOnAudioSelection { get; set; }
     public string OpenAiCompatibleSttStream { get; set; }
     public string OpenAiCompatibleSttStreamHint { get; set; }
@@ -1477,6 +1480,9 @@ public class LanguageGeneral
         OpenAiCompatibleSttLanguage = "Language Hint";
         OpenAiCompatibleSttTemperature = "Temperature";
         OpenAiCompatibleSttPrompt = "Prompt";
+        DashScopeSttRegion = "Region";
+        DashScopeSttEnableWords = "Word-level timestamps";
+        OnlineSttApiKeyMissing = "An API key is required. Please enter your API key and try again.";
         OpenAiCompatibleSttAutoTranscribeOnAudioSelection = "Auto-transcribe new waveform selection via speech-to-text";
         OpenAiCompatibleSttStream = "Stream response";
         OpenAiCompatibleSttStreamHint = "Send 'stream=true' to receive live text deltas (SSE). Disable for servers that reject the 'stream' parameter (e.g. Groq).";

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -532,6 +532,20 @@ public class Se
         Configuration.Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection = Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection;
         Configuration.Settings.Tools.OpenAiCompatibleSttStream = Settings.Tools.OpenAiCompatibleSttStream;
 
+        Configuration.Settings.Tools.OpenRouterSttApiKey = Settings.Tools.OpenRouterSttApiKey;
+        Configuration.Settings.Tools.OpenRouterSttModel = Settings.Tools.OpenRouterSttModel;
+        Configuration.Settings.Tools.OpenRouterSttLanguage = Settings.Tools.OpenRouterSttLanguage;
+        Configuration.Settings.Tools.OpenRouterSttTemperature = Settings.Tools.OpenRouterSttTemperature;
+        Configuration.Settings.Tools.OpenRouterSttPrompt = Settings.Tools.OpenRouterSttPrompt;
+        Configuration.Settings.Tools.OpenRouterSttTimeoutSeconds = Settings.Tools.OpenRouterSttTimeoutSeconds;
+
+        Configuration.Settings.Tools.DashScopeSttApiKey = Settings.Tools.DashScopeSttApiKey;
+        Configuration.Settings.Tools.DashScopeSttModel = Settings.Tools.DashScopeSttModel;
+        Configuration.Settings.Tools.DashScopeSttLanguage = Settings.Tools.DashScopeSttLanguage;
+        Configuration.Settings.Tools.DashScopeSttRegion = Settings.Tools.DashScopeSttRegion;
+        Configuration.Settings.Tools.DashScopeSttEnableWords = Settings.Tools.DashScopeSttEnableWords;
+        Configuration.Settings.Tools.DashScopeSttTimeoutSeconds = Settings.Tools.DashScopeSttTimeoutSeconds;
+
         Configuration.Settings.Tools.AutoTranslateLastName = Settings.AutoTranslate.AutoTranslateLastName;
 
         // BeautifyTimeCodes profile: skip apply on a fresh install so libse's built-in

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -124,6 +124,20 @@ public class SeTools
     public bool OpenAiCompatibleSttStream { get; set; }
     public string OpenAiCompatibleSttAudioFormat { get; set; } = "mp3";
 
+    public string OpenRouterSttApiKey { get; set; } = string.Empty;
+    public string OpenRouterSttModel { get; set; } = "openai/whisper-1";
+    public string OpenRouterSttLanguage { get; set; } = string.Empty;
+    public decimal OpenRouterSttTemperature { get; set; }
+    public string OpenRouterSttPrompt { get; set; } = string.Empty;
+    public int OpenRouterSttTimeoutSeconds { get; set; } = 300;
+
+    public string DashScopeSttApiKey { get; set; } = string.Empty;
+    public string DashScopeSttModel { get; set; } = "qwen3-asr-flash-filetrans";
+    public string DashScopeSttLanguage { get; set; } = string.Empty;
+    public string DashScopeSttRegion { get; set; } = "international";
+    public bool DashScopeSttEnableWords { get; set; }
+    public int DashScopeSttTimeoutSeconds { get; set; } = 3600;
+
     public List<string> FindHistory { get; set; } = new List<string>();
     public bool AllowSingleLetterShortcutsInTextbox { get; set; }
     public bool SpellCheckEnglishTreatInApostropheAsIng { get; set; } = true;

--- a/src/ui/UI.csproj
+++ b/src/ui/UI.csproj
@@ -215,6 +215,8 @@
 		<AvaloniaResource Include="Assets\SpeechToText\WhisperOpenAI.txt">
 			<CopyToOutputDirectory></CopyToOutputDirectory>
 		</AvaloniaResource>
+		<AvaloniaResource Include="Assets\SpeechToText\OpenRouter.txt" />
+		<AvaloniaResource Include="Assets\SpeechToText\AlibabaQwen3Asr.txt" />
 		<Content Include="SE.ico" />
 		<None Remove="Assets\Ocr.zip" />
 		<AvaloniaResource Include="Assets\Ocr.zip" />

--- a/tests/UI/Features/Video/SpeechToText/DashScope/DashScopeSttServiceTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/DashScope/DashScopeSttServiceTests.cs
@@ -1,0 +1,96 @@
+using System.Text.Json;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.DashScope;
+
+namespace UITests.Features.Video.SpeechToText.DashScope;
+
+public class DashScopeSttServiceTests
+{
+    private static DashScopeSttSettings MakeSettings()
+        => new()
+        {
+            ApiKey = "test-key",
+            Model = "qwen3-asr-flash-filetrans",
+            Language = "en",
+            Region = "international",
+            EnableWords = false,
+            TimeoutSeconds = 3600,
+        };
+
+    [Theory]
+    [InlineData("international", "https://dashscope-intl.aliyuncs.com")]
+    [InlineData("china", "https://dashscope.aliyuncs.com")]
+    [InlineData("", "https://dashscope-intl.aliyuncs.com")]
+    [InlineData(null, "https://dashscope-intl.aliyuncs.com")]
+    public void GetBaseUrl_PicksRegion(string? region, string expected)
+    {
+        Assert.Equal(expected, DashScopeSttService.GetBaseUrl(region));
+    }
+
+    [Fact]
+    public void BuildSubmitBody_SetsModelFileUrlAndParameters()
+    {
+        var settings = MakeSettings();
+        settings.EnableWords = true;
+        var body = DashScopeSttService.BuildSubmitBody(settings, "oss://bucket/dir/audio.mp3", "ja");
+
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+
+        Assert.Equal("qwen3-asr-flash-filetrans", root.GetProperty("model").GetString());
+        Assert.Equal("oss://bucket/dir/audio.mp3", root.GetProperty("input").GetProperty("file_url").GetString());
+
+        var parameters = root.GetProperty("parameters");
+        Assert.True(parameters.GetProperty("enable_words").GetBoolean());
+        Assert.False(parameters.GetProperty("enable_itn").GetBoolean());
+        Assert.Equal("ja", parameters.GetProperty("language").GetString());
+    }
+
+    [Fact]
+    public void BuildSubmitBody_OmitsLanguageWhenAutoOrEmpty()
+    {
+        var settings = MakeSettings();
+        settings.Language = string.Empty;
+        var body = DashScopeSttService.BuildSubmitBody(settings, "oss://x/y.mp3", null);
+
+        using var doc = JsonDocument.Parse(body);
+        Assert.False(doc.RootElement.GetProperty("parameters").TryGetProperty("language", out _));
+    }
+
+    [Fact]
+    public void ParseTranscriptionResult_MapsSentencesToSecondsSegments()
+    {
+        const string json = """
+            {
+              "transcripts": [
+                {
+                  "text": "Hello there. How are you?",
+                  "sentences": [
+                    { "begin_time": 760, "end_time": 3240, "text": "Hello there." },
+                    { "begin_time": 3500, "end_time": 5000, "text": "How are you?" }
+                  ]
+                }
+              ]
+            }
+            """;
+
+        var result = DashScopeSttService.ParseTranscriptionResult(json);
+
+        Assert.NotNull(result.Segments);
+        Assert.Equal(2, result.Segments!.Count);
+        // Milliseconds converted to seconds.
+        Assert.Equal(0.76, result.Segments[0].Start, 3);
+        Assert.Equal(3.24, result.Segments[0].End, 3);
+        Assert.Equal("Hello there.", result.Segments[0].Text);
+        Assert.Equal(5.0, result.Segments[1].End, 3);
+        Assert.Contains("How are you?", result.Text);
+    }
+
+    [Fact]
+    public void ParseTranscriptionResult_EmptyOrMalformed_ReturnsEmpty()
+    {
+        var result = DashScopeSttService.ParseTranscriptionResult("not json");
+        Assert.NotNull(result.Segments);
+        Assert.Empty(result.Segments!);
+        Assert.Equal(string.Empty, result.Text);
+    }
+}

--- a/tests/UI/Features/Video/SpeechToText/OpenRouter/OpenRouterSttServiceTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/OpenRouter/OpenRouterSttServiceTests.cs
@@ -1,0 +1,103 @@
+using System.Text;
+using System.Text.Json;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.OpenRouter;
+
+namespace UITests.Features.Video.SpeechToText.OpenRouter;
+
+public class OpenRouterSttServiceTests
+{
+    private static OpenRouterSttSettings MakeSettings(string model = "openai/whisper-1")
+        => new()
+        {
+            ApiKey = "test-key",
+            Model = model,
+            Language = "en",
+            Temperature = 0,
+            Prompt = string.Empty,
+            TimeoutSeconds = 30,
+        };
+
+    [Fact]
+    public void BuildRequestBody_EncodesAudioAndAsksForTimestamps()
+    {
+        var audio = Encoding.UTF8.GetBytes("hello-bytes");
+        var body = OpenRouterSttService.BuildRequestBody(MakeSettings(), audio, "mp3", "de");
+
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+
+        Assert.Equal("openai/whisper-1", root.GetProperty("model").GetString());
+        Assert.Equal(System.Convert.ToBase64String(audio), root.GetProperty("input_audio").GetProperty("data").GetString());
+        Assert.Equal("mp3", root.GetProperty("input_audio").GetProperty("format").GetString());
+        Assert.Equal("verbose_json", root.GetProperty("response_format").GetString());
+
+        var granularities = root.GetProperty("timestamp_granularities");
+        Assert.Equal(2, granularities.GetArrayLength());
+        Assert.Equal("segment", granularities[0].GetString());
+        Assert.Equal("word", granularities[1].GetString());
+
+        // Explicit language argument wins over the settings default.
+        Assert.Equal("de", root.GetProperty("language").GetString());
+    }
+
+    [Fact]
+    public void BuildRequestBody_OmitsEmptyLanguageAndZeroTemperature()
+    {
+        var settings = MakeSettings();
+        settings.Language = string.Empty;
+        var body = OpenRouterSttService.BuildRequestBody(settings, new byte[] { 1, 2, 3 }, "wav", null);
+
+        using var doc = JsonDocument.Parse(body);
+        Assert.False(doc.RootElement.TryGetProperty("language", out _));
+        Assert.False(doc.RootElement.TryGetProperty("temperature", out _));
+    }
+
+    [Fact]
+    public void ParseResponse_VerboseJson_ParsesSegments()
+    {
+        const string json = """
+            {
+              "text": "hello world",
+              "segments": [
+                { "id": 0, "start": 0.0, "end": 1.0, "text": "hello" },
+                { "id": 1, "start": 1.0, "end": 2.0, "text": " world" }
+              ]
+            }
+            """;
+
+        var result = OpenRouterSttService.ParseResponse(json);
+
+        Assert.Equal("hello world", result.Text);
+        Assert.NotNull(result.Segments);
+        Assert.Equal(2, result.Segments!.Count);
+        Assert.Equal("hello", result.Segments[0].Text);
+        Assert.Equal(1.0, result.Segments[1].Start);
+    }
+
+    [Fact]
+    public void ParseResponse_WordsOnly_GroupsIntoSegments()
+    {
+        const string json = """
+            {
+              "text": "one two",
+              "words": [
+                { "word": "one", "start": 0.0, "end": 0.4 },
+                { "word": "two", "start": 0.5, "end": 0.9 }
+              ]
+            }
+            """;
+
+        var result = OpenRouterSttService.ParseResponse(json);
+
+        Assert.NotNull(result.Segments);
+        Assert.True(result.Segments!.Count >= 1);
+        Assert.Contains("one", result.Segments[0].Text);
+    }
+
+    [Fact]
+    public void ParseResponse_PlainText_FallsBackToText()
+    {
+        var result = OpenRouterSttService.ParseResponse("just some text");
+        Assert.Equal("just some text", result.Text);
+    }
+}


### PR DESCRIPTION
Adds two dedicated online Speech-to-Text engines to the Audio-to-Text window, alongside the existing **OpenAI Compatible Server** (requested in #12154).

## OpenRouter
- POSTs base64 audio (JSON body) to `openrouter.ai/api/v1/audio/transcriptions`, requesting `verbose_json` + `timestamp_granularities`, and parses the same segment/word shape already used by the OpenAI-compatible engine.
- One API key reaches Whisper / GPT-4o-transcribe / Groq / Chirp (and `qwen/qwen3-asr-flash`).
- Large audio is chunked to stay under the upload cap; word-only responses are grouped into segments; plain-text responses fall back to per-chunk spans.

## Alibaba Qwen3-ASR (DashScope)
- Uses the **async Filetrans path for real timestamps** (the sync endpoint returns text only): uploads the local file to DashScope temporary storage (`oss://`, ~48 h) → submits the async job → polls → downloads the result JSON, mapping millisecond **sentence** timings into timed cues. Word-level timings optional via a checkbox.
- Region-selectable (international / China); handles files up to ~12 h in one job (no upload-size chunking needed).

## Shared plumbing
- New `ISttTranscriber` + `IOnlineSttEngine` marker interface; the ViewModel routes all three cloud engines through one `ProcessOnlineSttTranscription` pipeline (probe / chunk / ingest), so provider differences are confined to each service's request/response builder.
- Settings added to `SeTools`, libse `ToolsSettings`, and the `Se.cs` sync block; per-engine settings panels in the window; help-text assets for both.

## Tests
- 13 new unit tests (request-body shape + response mapping for both services).
- All 80 SpeechToText tests pass — the shared-plumbing refactor does not regress the existing OpenAI-compatible engine.

## Caveats
- Not exercised against the live APIs (no keys on hand): built to current published docs. Specifically unverified end-to-end: that OpenRouter honors `timestamp_granularities` inside its JSON body, and the exact DashScope OSS upload form-field names. If OpenRouter ignores the timestamp hints, the per-chunk-span fallback still yields timed cues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)