### PR TITLE
Fix online STT engine UI layout and OpenRouter segmentation (#12154)

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -1,6 +1,13 @@
 
 Subtitle Edit Changelog
 
+v5.1.0-beta10 (4th of July 2026)
+
+* Fix online speech-to-text (OpenRouter / Alibaba Qwen3-ASR) settings layout - the engine's settings rows no longer overlap/jumble together
+* OpenRouter speech-to-text: split the transcript into multiple timed sentences instead of one long line, and run post-processing using the engine's language hint
+
+-----------------------------------------------------------------------------------------------------
+
 v5.1.0-beta9 (4th of July 2026)
 
 * Add OpenRouter and Alibaba Qwen3-ASR online speech-to-text engines to Audio to text - OpenRouter reaches Whisper/GPT-4o-transcribe/Groq/Chirp with one key; Alibaba Qwen3-ASR (DashScope) uploads the audio and transcribes asynchronously with sentence timestamps

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -1288,16 +1288,83 @@ public partial class SpeechToTextViewModel : ObservableObject
 
             if (!string.IsNullOrEmpty(response.Text))
             {
-                // No segment timings — span the whole slice. Falling back to a
-                // historical 5 s window only when we genuinely don't know the
-                // end (callers without a populated _videoInfo).
+                // No segment timings (e.g. OpenRouter's Whisper returns only
+                // `text`): split into sentences and spread the slice's duration
+                // across them by length, so the result isn't one giant cue
+                // (issue #12154). Falling back to a historical 5 s window only
+                // when we genuinely don't know the end.
                 var startMs = offsetSeconds * 1000.0;
                 var endMs = chunkEndSeconds > offsetSeconds
                     ? chunkEndSeconds * 1000.0
                     : startMs + 5000.0;
-                subtitle.Paragraphs.Add(new Paragraph(response.Text.Trim(), startMs, endMs));
+                AddTextAsTimedSentences(subtitle, response.Text.Trim(), startMs, endMs);
             }
         }
+    }
+
+    /// <summary>
+    /// Split a block of transcript text into sentence-sized paragraphs and
+    /// distribute the [<paramref name="startMs"/>, <paramref name="endMs"/>]
+    /// window across them proportionally to each sentence's length. Used for
+    /// providers that return only recognized text with no per-segment timings.
+    /// Language-agnostic: breaks on Latin and CJK sentence punctuation.
+    /// </summary>
+    internal static void AddTextAsTimedSentences(Subtitle subtitle, string text, double startMs, double endMs)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return;
+        }
+
+        var sentences = SplitIntoSentences(text);
+        var totalChars = sentences.Sum(s => s.Length);
+        if (sentences.Count <= 1 || totalChars == 0 || endMs <= startMs)
+        {
+            var end = endMs > startMs ? endMs : startMs + 2000.0;
+            subtitle.Paragraphs.Add(new Paragraph(text.Trim(), startMs, end));
+            return;
+        }
+
+        var span = endMs - startMs;
+        var cursor = startMs;
+        for (var i = 0; i < sentences.Count; i++)
+        {
+            var duration = span * ((double)sentences[i].Length / totalChars);
+            var pEnd = i == sentences.Count - 1 ? endMs : cursor + duration;
+            subtitle.Paragraphs.Add(new Paragraph(sentences[i].Trim(), cursor, pEnd));
+            cursor = pEnd;
+        }
+    }
+
+    /// <summary>
+    /// Break text into sentences, keeping trailing sentence punctuation. Handles
+    /// Latin (. ! ?) and CJK (。！？…) terminators; returns the whole string as a
+    /// single element when it has no sentence punctuation.
+    /// </summary>
+    internal static List<string> SplitIntoSentences(string text)
+    {
+        var result = new List<string>();
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return result;
+        }
+
+        var matches = Regex.Matches(text.Trim(), @"[^.!?。！？…]*[.!?。！？…]+[""'”’)\]]*\s*|[^.!?。！？…]+$");
+        foreach (Match m in matches)
+        {
+            var sentence = m.Value.Trim();
+            if (sentence.Length > 0)
+            {
+                result.Add(sentence);
+            }
+        }
+
+        if (result.Count == 0)
+        {
+            result.Add(text.Trim());
+        }
+
+        return result;
     }
 
     /// <summary>
@@ -1616,7 +1683,17 @@ public partial class SpeechToTextViewModel : ObservableObject
 
     private Subtitle PostProcess(Subtitle transcript)
     {
-        if (SelectedLanguage is not WhisperLanguage language)
+        var languageCode = SelectedLanguage?.Code;
+        if (string.IsNullOrWhiteSpace(languageCode))
+        {
+            // Online engines null out SelectedLanguage; fall back to their configured
+            // language hint so post-processing (merge/split/casing) still runs (issue
+            // #12154). With no hint we can't pick language-specific rules safely, so
+            // leave the transcript as-is.
+            languageCode = GetOnlineEngineLanguageHint();
+        }
+
+        if (string.IsNullOrWhiteSpace(languageCode))
         {
             return transcript;
         }
@@ -1626,7 +1703,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             ProgressText = "Post-processing...";
         }
 
-        var postProcessor = new SpeechToTextPostProcessor(DoTranslateToEnglish ? "en" : language.Code)
+        var postProcessor = new SpeechToTextPostProcessor(DoTranslateToEnglish ? "en" : languageCode)
         {
             ParagraphMaxChars = Configuration.Settings.General.SubtitleLineMaximumLength * 2,
         };
@@ -1658,6 +1735,22 @@ public partial class SpeechToTextViewModel : ObservableObject
             );
 
         return transcript;
+    }
+
+    /// <summary>
+    /// The language hint configured for the selected online STT engine, or null
+    /// for local engines. Online engines don't use the shared language dropdown
+    /// (it's nulled out), so post-processing reads the per-engine setting instead.
+    /// </summary>
+    private string? GetOnlineEngineLanguageHint()
+    {
+        return GetEffectiveSelectedEngine() switch
+        {
+            OpenRouterSttEngine => Se.Settings.Tools.OpenRouterSttLanguage,
+            DashScopeQwen3SttEngine => Se.Settings.Tools.DashScopeSttLanguage,
+            OpenAiCompatibleSttEngine => Se.Settings.Tools.OpenAiCompatibleSttLanguage,
+            _ => null,
+        };
     }
 
     private WavePeakData2? MakeWavePeaks()

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -435,8 +435,11 @@ public class SpeechToTextWindow : Window
         grid.Add(panelConsoleLogHeader, row, 2);
         row++;
 
-        grid.Add(consoleLogAndBatchView, row, 2, 20);
-        grid.Add(consoleLogOnlyView, row, 2, 20);
+        // Row span must reach the row just above the progress/buttons row so the
+        // console log fills the full height of the settings column. It covers every
+        // settings row including the OpenAI/OpenRouter/DashScope online-STT rows.
+        grid.Add(consoleLogAndBatchView, row, 2, 32);
+        grid.Add(consoleLogOnlyView, row, 2, 32);
         row++;
 
         grid.Add(labelEngine, row, 0);

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -372,11 +372,25 @@ public class SpeechToTextWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 14: OpenAI STT - Extra Headers
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 15: OpenAI STT - Audio Format
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 16: OpenAI STT - Stream
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 17: Translate to English
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 18: Post processing
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 19: Advanced settings label + button
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 20: textBoxAdvancedSettings (parameters)
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 21: panelProgress + OK/Cancel (same row)
+                // OpenRouter STT rows (6) — only visible when OpenRouter is selected, else collapse to 0.
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 17: OpenRouter - API Key
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 18: OpenRouter - Model
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 19: OpenRouter - Language
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 20: OpenRouter - Timeout
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 21: OpenRouter - Temperature
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 22: OpenRouter - Prompt
+                // Alibaba Qwen3-ASR (DashScope) STT rows (6).
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 23: DashScope - API Key
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 24: DashScope - Model
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 25: DashScope - Region
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 26: DashScope - Language
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 27: DashScope - Word timestamps
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 28: DashScope - Timeout
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 29: Translate to English
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 30: Post processing
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 31: Advanced settings label + button
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 32: textBoxAdvancedSettings (parameters)
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 33: panelProgress + OK/Cancel (same row)
             },
             ColumnDefinitions =
             {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -17,7 +17,7 @@ public class Se
 {
     internal const int CurrentMacOsFontMigrationVersion = 1;
 
-    public static string Version { get; set; } = "v5.1.0-beta8";
+    public static string Version { get; set; } = "v5.1.0-beta10";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();

--- a/tests/UI/Features/Video/SpeechToText/OnlineSttSentenceSplitTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/OnlineSttSentenceSplitTests.cs
@@ -1,0 +1,63 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText;
+
+namespace UITests.Features.Video.SpeechToText;
+
+public class OnlineSttSentenceSplitTests
+{
+    [Fact]
+    public void SplitIntoSentences_LatinPunctuation_SplitsAndKeepsTerminators()
+    {
+        var sentences = SpeechToTextViewModel.SplitIntoSentences("Hello there. How are you? I am fine!");
+
+        Assert.Equal(3, sentences.Count);
+        Assert.Equal("Hello there.", sentences[0]);
+        Assert.Equal("How are you?", sentences[1]);
+        Assert.Equal("I am fine!", sentences[2]);
+    }
+
+    [Fact]
+    public void SplitIntoSentences_CjkPunctuation_Splits()
+    {
+        var sentences = SpeechToTextViewModel.SplitIntoSentences("你好。今天天气怎么样？");
+
+        Assert.Equal(2, sentences.Count);
+        Assert.Equal("你好。", sentences[0]);
+        Assert.Equal("今天天气怎么样？", sentences[1]);
+    }
+
+    [Fact]
+    public void SplitIntoSentences_NoPunctuation_ReturnsWhole()
+    {
+        var sentences = SpeechToTextViewModel.SplitIntoSentences("just some words without any punctuation");
+
+        Assert.Single(sentences);
+        Assert.Equal("just some words without any punctuation", sentences[0]);
+    }
+
+    [Fact]
+    public void AddTextAsTimedSentences_DistributesSpanAcrossSentences()
+    {
+        var subtitle = new Subtitle();
+        SpeechToTextViewModel.AddTextAsTimedSentences(subtitle, "One. Two. Three.", 0, 3000);
+
+        Assert.Equal(3, subtitle.Paragraphs.Count);
+        // First cue starts at the window start, last cue ends exactly at the window end.
+        Assert.Equal(0, subtitle.Paragraphs[0].StartTime.TotalMilliseconds, 1);
+        Assert.Equal(3000, subtitle.Paragraphs[^1].EndTime.TotalMilliseconds, 1);
+        // Cues are contiguous and non-overlapping.
+        Assert.True(subtitle.Paragraphs[1].StartTime.TotalMilliseconds >= subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.True(subtitle.Paragraphs[2].StartTime.TotalMilliseconds >= subtitle.Paragraphs[1].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void AddTextAsTimedSentences_SingleSentence_OneCueSpanningWindow()
+    {
+        var subtitle = new Subtitle();
+        SpeechToTextViewModel.AddTextAsTimedSentences(subtitle, "A single sentence.", 1000, 5000);
+
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Equal(1000, subtitle.Paragraphs[0].StartTime.TotalMilliseconds, 1);
+        Assert.Equal(5000, subtitle.Paragraphs[0].EndTime.TotalMilliseconds, 1);
+    }
+}


### PR DESCRIPTION
Follow-up fixes after testing the OpenRouter / Alibaba Qwen3-ASR engines (feedback in [this comment](https://github.com/SubtitleEdit/subtitleedit/issues/12154#issuecomment-4881971345)).

### 1. Settings rows jumbled together (the critical blocker)
The Audio-to-Text settings grid uses a **fixed** `RowDefinitions` list that was sized for the OpenAI-compatible engine's 10 rows only. The new OpenRouter (6) and DashScope (6) rows were appended past the last defined row via the running `row++` counter, so Avalonia clamped the overflow onto shared rows — everything below overlapped. Added the 12 missing `RowDefinition`s.

### 2. OpenRouter output couldn't be split into sentences
Two causes:
- `PostProcess()` returned immediately for every online engine, because online engines null out the shared `SelectedLanguage` (they have their own language field) and the method bailed on `SelectedLanguage is not WhisperLanguage`. It now falls back to the engine's configured **language hint**, so merge/split/casing runs when a hint is set.
- OpenRouter's Whisper returns only `text` (no `segments`), which `IngestTranscriptionResponse` turned into a single giant cue. It now **splits the text into sentences** (Latin `. ! ?` and CJK `。！？…`) and distributes the slice's duration across them by length, so you get multiple timed cues.

### 3. Alibaba Qwen3-ASR (`qwen3-asr-flash-filetrans`)
This was unblocked-by rather than fixed: the reporter couldn't test it because of #1. The `-filetrans` model is intentional — it's the async file-transcription model that returns real sentence timestamps (the sync `qwen3-asr-flash` returns text only). No code change; testable once #1 lands. (Still not exercised against the live API here — no key on hand.)

### Tests
New unit tests for the sentence splitter; all 85 SpeechToText tests pass. UI builds clean in Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)