### PR TITLE
Fix empty language list in TTS Review window

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -1388,18 +1388,6 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
         SelectedVoice = lastVoice ?? Voices.FirstOrDefault();
 
-        if (engine.HasLanguageParameter && SelectedVoice != null)
-        {
-            var languages = await engine.GetLanguages(SelectedVoice, null); // SelectedModel);
-            Languages.Clear();
-            foreach (var language in languages)
-            {
-                Languages.Add(language);
-            }
-
-            SelectedLanguage = Languages.FirstOrDefault();
-        }
-
         if (engine.HasRegion)
         {
             var regions = await engine.GetRegions();
@@ -1459,6 +1447,26 @@ public partial class ReviewSpeechViewModel : ObservableObject
             {
                 SelectedModel = Models.FirstOrDefault();
             }
+        }
+
+        // Languages last: the list depends on the model for some engines (ElevenLabs returns an
+        // empty list for a null/unknown model), so the model - including the per-engine saved-model
+        // overrides above - must be resolved first. This used to run before the model was loaded,
+        // with null passed instead, leaving the language combo empty (#12093).
+        if (engine.HasLanguageParameter && SelectedVoice != null)
+        {
+            var languages = await engine.GetLanguages(SelectedVoice, SelectedModel);
+            Languages.Clear();
+            foreach (var language in languages)
+            {
+                Languages.Add(language);
+            }
+
+            // Same preference order as SelectedModelChanged: the saved language, then English,
+            // then whatever comes first.
+            SelectedLanguage = Languages.FirstOrDefault(p => p.Name == Se.Settings.Video.TextToSpeech.ElevenLabsLanguage)
+                               ?? Languages.FirstOrDefault(p => p.Code == "en")
+                               ?? Languages.FirstOrDefault();
         }
     }
 


### PR DESCRIPTION
Fixes item 2 of https://github.com/SubtitleEdit/subtitleedit/issues/12093#issuecomment-4882103442 — the language dropdown in the TTS Review window was empty.

## Cause
`ReviewSpeechViewModel.SelectedEngineChangedAsync` fetched languages with a `null` model (the `SelectedModel` argument was commented out), and `ElevenLabs.GetLanguages` returns an empty list for an unknown/null model. The languages were also loaded *before* the models, so even passing `SelectedModel` would have used a stale value. The main TTS window has the same load order but recovers because its model ComboBox's `SelectionChanged` handler refetches languages — the review dialog's combos aren't wired yet when `Initialize`/the first row-sync triggers the refresh, so the empty list stuck.

## Fix
- Load languages at the end of the engine-switch refresh, after models and the per-engine saved-model overrides, passing the resolved model.
- Select the language with the same preference order as `SelectedModelChanged`: saved ElevenLabs language → English → first entry (previously the first alphabetical entry always won).

Builds with 0 warnings/0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)