### PR TITLE
Apply TTS review text edits back to the subtitle

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -145,6 +145,7 @@ using Nikse.SubtitleEdit.Features.Video.ShotChanges;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.OpenAiCompatible;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ReviewSpeech;
 using Nikse.SubtitleEdit.Features.Video.TransparentSubtitles;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -6667,7 +6668,7 @@ public partial class MainViewModel :
             return;
         }
 
-        await ShowDialogAsync<TextToSpeechWindow, TextToSpeechViewModel>(vm =>
+        var result = await ShowDialogAsync<TextToSpeechWindow, TextToSpeechViewModel>(vm =>
         {
             // Pass SelectedSubtitleFormat explicitly so the TTS window's cast detection uses the
             // user's *current* selection (the editor normalises subtitles to ASSA internally, so
@@ -6675,7 +6676,109 @@ public partial class MainViewModel :
             vm.Initialize(GetUpdateSubtitle(), SelectedSubtitleFormat,
                 _videoFileName ?? string.Empty, AudioVisualizer?.WavePeaks, Path.GetTempPath());
         });
+
+        await OfferToApplyTtsReviewTextChanges(result.ReviewTextChanges);
     }
+
+    /// <summary>
+    /// After the TTS window closes: if the user edited line texts in its review step, offer to
+    /// apply those edits to the subtitle so the text stays in sync with the generated audio and
+    /// doesn't have to be redone by hand (#12093). Lines are matched by the time codes they had
+    /// when the review opened - the TTS pipeline may renumber (empty-line removal keeps times) so
+    /// numbers/indices can't be used. A line merged before generation spans several original
+    /// lines, so its segment matches no single line's start+end; those edits can't be split back
+    /// and are reported rather than applied. Edits that match no line at all (e.g. an imported
+    /// session for a different subtitle) are ignored silently.
+    /// </summary>
+    private async Task OfferToApplyTtsReviewTextChanges(List<ReviewTextChange> changes)
+    {
+        if (changes.Count == 0 || Window == null)
+        {
+            return;
+        }
+
+        const double toleranceMs = 0.5;
+        var matches = new List<(SubtitleLineViewModel Line, string NewText)>();
+        var mergedCount = 0;
+        foreach (var change in changes)
+        {
+            // Exact 1:1 match - same start and end as a current line.
+            var line = Subtitles.FirstOrDefault(s =>
+                Math.Abs(s.StartTime.TotalMilliseconds - change.StartMs) < toleranceMs &&
+                Math.Abs(s.EndTime.TotalMilliseconds - change.EndMs) < toleranceMs);
+            if (line != null)
+            {
+                if (line.Text != change.NewText)
+                {
+                    matches.Add((line, change.NewText));
+                }
+
+                continue;
+            }
+
+            // No 1:1 line, but the segment starts on a real line and ends past it: this line was
+            // merged with following line(s) before generation. The edited text covers the whole
+            // merged sentence and can't be safely split back, so flag it instead of applying.
+            var mergedInto = Subtitles.FirstOrDefault(s =>
+                Math.Abs(s.StartTime.TotalMilliseconds - change.StartMs) < toleranceMs &&
+                s.EndTime.TotalMilliseconds < change.EndMs - toleranceMs);
+            if (mergedInto != null)
+            {
+                mergedCount++;
+            }
+        }
+
+        if (matches.Count == 0 && mergedCount == 0)
+        {
+            return;
+        }
+
+        var lang = Se.Language.Video.TextToSpeech;
+
+        // Only merged edits and nothing directly applicable: just tell the user why they weren't
+        // applied - there's nothing to confirm.
+        if (matches.Count == 0)
+        {
+            await MessageBox.Show(
+                Window,
+                lang.UpdateSubtitleTitle,
+                FormatCount(mergedCount, lang.ReviewMergedLinesNotUpdatedSingular, lang.ReviewMergedLinesNotUpdatedPlural),
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Information);
+            return;
+        }
+
+        var message = FormatCount(matches.Count, lang.UpdateSubtitleFromReviewSingular, lang.UpdateSubtitleFromReviewPlural);
+        if (mergedCount > 0)
+        {
+            message += Environment.NewLine + Environment.NewLine +
+                       FormatCount(mergedCount, lang.ReviewMergedLinesNotUpdatedSingular, lang.ReviewMergedLinesNotUpdatedPlural);
+        }
+
+        var answer = await MessageBox.Show(
+            Window,
+            lang.UpdateSubtitleTitle,
+            message,
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Question);
+
+        if (answer != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        foreach (var (line, newText) in matches)
+        {
+            line.Text = newText;
+        }
+
+        _updateAudioVisualizer = true;
+        ShowStatus(FormatCount(matches.Count, lang.SubtitleUpdatedFromReviewSingular, lang.SubtitleUpdatedFromReviewPlural));
+    }
+
+    // Picks the singular or plural resource string for a count, formatting the plural with {0}.
+    private static string FormatCount(int count, string singular, string plural)
+        => count == 1 ? singular : string.Format(plural, count);
 
     [RelayCommand]
     private async Task ShowVideoTransparentSubtitles()

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewRow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewRow.cs
@@ -25,6 +25,13 @@ public partial class ReviewRow : ObservableObject
     // on the row itself so lookup is direct (no Lines.IndexOf, which would break under sorting).
     public SubtitleLineViewModel? WaveformParagraph { get; set; }
 
+    // Snapshots taken when the window opens, used on OK to detect text edits and map them back
+    // to the main subtitle (see ReviewTextChange). The times must be captured up front because
+    // waveform drags mutate StepResult.Paragraph while the window is open.
+    public string OriginalText { get; set; } = string.Empty;
+    public double OriginalStartMs { get; set; }
+    public double OriginalEndMs { get; set; }
+
     public ReviewRow()
     {
         Include = true;

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -109,6 +109,10 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
     public bool OkPressed { get; private set; }
 
+    // Text edits made in this window, published on OK so the caller can offer to apply them to
+    // the main subtitle (#12093). Keyed by the rows' original time codes - see ReviewTextChange.
+    public List<ReviewTextChange> TextChanges { get; private set; } = new();
+
     private readonly IFolderHelper _folderHelper;
     private readonly IWindowService _windowService;
 
@@ -335,6 +339,9 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 Speed = Math.Round(p.SpeedFactor, 2).ToString(CultureInfo.CurrentCulture),
                 Cps = Math.Round(p.Paragraph.GetCharactersPerSecond(), 2).ToString(CultureInfo.CurrentCulture),
                 StepResult = p,
+                OriginalText = p.Text,
+                OriginalStartMs = p.Paragraph.StartTime.TotalMilliseconds,
+                OriginalEndMs = p.Paragraph.EndTime.TotalMilliseconds,
             };
             row.StartHistory();
             Lines.Add(row);
@@ -1020,6 +1027,13 @@ public partial class ReviewSpeechViewModel : ObservableObject
         }
 
         StepResults = Lines.Where(p => p.Include).Select(p => p.StepResult).ToArray();
+
+        // All rows, not just included ones - excluding a row only skips its audio in the merge,
+        // while a text edit was still made deliberately and should reach the main subtitle.
+        TextChanges = Lines
+            .Where(row => row.Text != row.OriginalText)
+            .Select(row => new ReviewTextChange(row.OriginalStartMs, row.OriginalEndMs, row.Text))
+            .ToList();
 
         Se.SaveSettings();
         OkPressed = true;

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewTextChange.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewTextChange.cs
@@ -1,0 +1,22 @@
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.ReviewSpeech;
+
+/// <summary>
+/// A text edit made in the review window, keyed by the time codes the line had when the review
+/// opened (waveform drags may change the paragraph's times afterwards). The main window uses the
+/// times to find the matching subtitle line and offer to apply the edit (#12093) - numbers and
+/// indices can't be used because the TTS pipeline may have renumbered (empty-line removal) or
+/// merged sentences.
+/// </summary>
+public class ReviewTextChange
+{
+    public double StartMs { get; }
+    public double EndMs { get; }
+    public string NewText { get; }
+
+    public ReviewTextChange(double startMs, double endMs, string newText)
+    {
+        StartMs = startMs;
+        EndMs = endMs;
+        NewText = newText;
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -128,6 +128,11 @@ public partial class TextToSpeechViewModel : ObservableObject
     public ObservableCollection<string> OmniVoicePitches { get; }
     public ObservableCollection<string> OmniVoiceAccents { get; }
 
+    // Text edits from OK'ed review sessions in this window, keyed by the lines' original time
+    // codes. The main window reads this after the dialog closes and offers to apply the edits
+    // to the subtitle (#12093). A later session's edit to the same line replaces the earlier one.
+    public List<ReviewTextChange> ReviewTextChanges { get; } = new();
+
     private Subtitle _subtitle = new();
     private readonly IFileHelper _fileHelper;
     private readonly IFolderHelper _folderHelper;
@@ -1700,6 +1705,11 @@ public partial class TextToSpeechViewModel : ObservableObject
         // no merged wav, no dialog, nothing (#12093).
         if (result.OkPressed)
         {
+            // Text edits from an imported session can also apply to the open subtitle - the
+            // time-code matching in the main window simply won't find a line when the imported
+            // session belongs to a different subtitle.
+            CollectReviewTextChanges(result.TextChanges);
+
             // Enter the same visible "generating" state as a fresh Generate run - progress bar,
             // status text and a working Cancel button. Without this the merge ran with the
             // window looking completely idle, giving no sign anything was happening (#12093).
@@ -2883,10 +2893,23 @@ public partial class TextToSpeechViewModel : ObservableObject
 
         if (result.OkPressed)
         {
+            CollectReviewTextChanges(result.TextChanges);
             return result.StepResults;
         }
 
         return null;
+    }
+
+    // Merge one review session's text edits into ReviewTextChanges, letting the newest edit to
+    // a line (same original time codes) win over one from an earlier session in this window.
+    private void CollectReviewTextChanges(List<ReviewTextChange> changes)
+    {
+        foreach (var change in changes)
+        {
+            ReviewTextChanges.RemoveAll(c => Math.Abs(c.StartMs - change.StartMs) < 0.5 &&
+                                             Math.Abs(c.EndMs - change.EndMs) < 0.5);
+            ReviewTextChanges.Add(change);
+        }
     }
 
     // The compact cloud-engine descriptions ("pay/fast/good") read like debug output - expand

--- a/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
@@ -102,6 +102,15 @@ public class LanguageTextToSpeech
     public string MergeContinuationLinesPromptTitle { get; set; }
     public string MergeContinuationLinesPromptMessage { get; set; }
 
+    // Applying review text edits back to the main subtitle
+    public string UpdateSubtitleTitle { get; set; }
+    public string UpdateSubtitleFromReviewSingular { get; set; }
+    public string UpdateSubtitleFromReviewPlural { get; set; }
+    public string ReviewMergedLinesNotUpdatedSingular { get; set; }
+    public string ReviewMergedLinesNotUpdatedPlural { get; set; }
+    public string SubtitleUpdatedFromReviewSingular { get; set; }
+    public string SubtitleUpdatedFromReviewPlural { get; set; }
+
     public LanguageTextToSpeech()
     {
         Title = "Text to speech";
@@ -202,5 +211,15 @@ public class LanguageTextToSpeech
         MergeContinuationLinesPromptMessage = "Some lines appear to be a single sentence split across multiple subtitles." + Environment.NewLine + Environment.NewLine +
                                               "Merging them before generation lets the TTS engine speak each thought as one breath group, which usually sounds more natural." + Environment.NewLine + Environment.NewLine +
                                               "Review and apply merges now?";
+
+        UpdateSubtitleTitle = "Update subtitle?";
+        UpdateSubtitleFromReviewSingular = "You edited the text of one line while reviewing the generated speech." + Environment.NewLine + Environment.NewLine +
+                                           "Update the subtitle with this change so its text stays in sync with the audio?";
+        UpdateSubtitleFromReviewPlural = "You edited the text of {0} lines while reviewing the generated speech." + Environment.NewLine + Environment.NewLine +
+                                         "Update the subtitle with these changes so its text stays in sync with the audio?";
+        ReviewMergedLinesNotUpdatedSingular = "One edited line was merged before generation and could not be updated automatically.";
+        ReviewMergedLinesNotUpdatedPlural = "{0} edited lines were merged before generation and could not be updated automatically.";
+        SubtitleUpdatedFromReviewSingular = "Updated one line from the speech review";
+        SubtitleUpdatedFromReviewPlural = "Updated {0} lines from the speech review";
     }
 }


### PR DESCRIPTION
Implements item 3 of https://github.com/SubtitleEdit/subtitleedit/issues/12093#issuecomment-4882103442 — text edits made in the TTS *Review audio segments* window were used for the generated audio but discarded on close, so the main subtitle stayed out of sync and every edit had to be redone by hand.

## Behaviour
When the Text-to-speech window closes, if any line texts were edited during review, the user is asked whether to update the subtitle so its text matches the generated audio:

> You edited the text of 3 lines while reviewing the generated speech.
>
> Update the subtitle with these changes so its text stays in sync with the audio?

On **Yes**, the matching lines are updated and a status message is shown. On **No**, nothing changes.

## Matching
Edits are keyed by the **time codes** the line had when the review opened (waveform drags can change the segment times afterwards) and matched 1:1 against the current subtitle. Numbers/indices can't be used because the TTS pipeline may renumber the subtitle (empty-line removal keeps times but shifts numbers).

## Merged lines
A line **merged** before generation (the *Merge continuation lines* step) spans several original lines, so its segment matches no single line's start+end. The merged text can't be safely split back across the originals, so those edits are **reported in the prompt** rather than applied:

> 2 edited lines were merged before generation and could not be updated automatically.

Edits that match no line at all (e.g. an imported session belonging to a different subtitle) are ignored silently.

## Notes
- Applies to both the fresh *Generate* review and the *Import* review path.
- All user-facing strings live in `LanguageTextToSpeech`.

Builds with 0 warnings/0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)