### PR TITLE
Offer to open subtitle-less .mkv as a video file

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14558,8 +14558,13 @@ public partial class MainViewModel :
 
             if (FileUtil.IsMatroskaFileFast(fileName) && FileUtil.IsMatroskaFile(fileName))
             {
-                await ImportSubtitleFromMatroskaFile(fileName, videoFileName);
-                return;
+                if (await ImportSubtitleFromMatroskaFile(fileName, videoFileName))
+                {
+                    return;
+                }
+
+                // No subtitle tracks in the container - fall through to the "open as video file"
+                // prompt below (a subtitle-less .mkv is still a video), matching the .mp4 path (#12171).
             }
 
             if (ext == ".sup" && FileUtil.IsBluRaySup(fileName))
@@ -15491,32 +15496,20 @@ public partial class MainViewModel :
         }
     }
 
-    private async Task ImportSubtitleFromMatroskaFile(string fileName, string? videoFileName)
+    /// <summary>
+    /// Extracts a subtitle track from a Matroska (.mkv) file. Returns false when the container has
+    /// no subtitle tracks so the caller can fall through to the "open as video file" prompt - the
+    /// same path .mp4 files take. It used to dead-end here on a "does not seem to contain any
+    /// subtitles" error, so a subtitle-less .mkv could never be opened as a video (#12171).
+    /// </summary>
+    private async Task<bool> ImportSubtitleFromMatroskaFile(string fileName, string? videoFileName)
     {
         var matroska = new MatroskaFile(fileName);
         var subtitleList = matroska.GetTracks(true);
         if (subtitleList.Count == 0)
         {
             matroska.Dispose();
-            Dispatcher.UIThread.Post(async void () =>
-            {
-                try
-                {
-                    var answer = await MessageBox.Show(
-                        Window!,
-                        "No subtitle found",
-                        "The Matroska file does not seem to contain any subtitles.",
-                        MessageBoxButtons.OK,
-                        MessageBoxIcon.Error);
-                }
-                catch (Exception e)
-                {
-                    Se.LogError(e);
-                }
-            });
-
-            matroska.Dispose();
-            return;
+            return false;
         }
 
         if (subtitleList.Count > 1)
@@ -15615,6 +15608,10 @@ public partial class MainViewModel :
                 matroska.Dispose();
             }
         }
+
+        // A track was found and handled (the track dialog / extract runs on the UI thread via the
+        // Dispatcher posts above); tell the caller not to fall through to the video-open prompt.
+        return true;
     }
 
     private async Task<bool> LoadMatroskaSubtitle(


### PR DESCRIPTION
Fixes item 2 of #12171 — a `.mkv` with no subtitle tracks showed *"The Matroska file does not seem to contain any subtitles."* and dead-ended, even though the file is a valid video. An `.mp4` without subtitles already falls through to the *"open as video file?"* prompt, so the two behaved inconsistently.

## Cause
`.mkv` files are intercepted early and routed to `ImportSubtitleFromMatroskaFile`, which showed the error and returned — never reaching the generic video-open prompt that `.mp4` files hit after `ImportSubtitleFromMp4` returns false.

## Fix
`ImportSubtitleFromMatroskaFile` now returns `bool`: `false` when the container has no subtitle tracks (dropping the error dialog), so the caller falls through to the existing `ErrorLoadVideoFilePrompt` ("…Do you want to open it as a video file?") — the same path `.mp4` takes. `true` when a track was found and handled.

## Notes
- `.mkv` is in `Utilities.VideoFileExtensions` and real Matroska files clear the prompt's 1 MB size gate, so subtitle-less `.mkv` files now get the confirmation dialog just like `.mp4`.
- Item 1 of the issue (Speech-to-text video feedback/window-banner confusion) is a separate, larger UX concern and is not addressed here.

Builds with 0 warnings/0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)