### PR TITLE
Add customizable <<  seek  >> panel to the waveform toolbar

### DIFF
--- a/src/ui/Features/Main/Layout/InitWaveform.cs
+++ b/src/ui/Features/Main/Layout/InitWaveform.cs
@@ -658,6 +658,61 @@ public class InitWaveform
         Attached.SetIcon(toggleButtonCenter, IconNames.AlignHorizontalCenter);
         toggleButtonCenter.IsCheckedChanged += (s, e) => vm.WaveformCenterCheckedChanged();
 
+        var settingVideoSeek = GetToolbarSettingFor(SeWaveformToolbarItemType.VideoSeek);
+        var buttonSeekBack = new NonSpaceButton
+        {
+            FontSize = settingVideoSeek.FontSize,
+            VerticalAlignment = VerticalAlignment.Center,
+            Command = vm.WaveformVideoSeekBackCommand,
+            FontWeight = FontWeight.Bold,
+            [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.SeekBackHint, shortcuts),
+        };
+        Attached.SetIcon(buttonSeekBack, IconNames.ChevronDoubleLeft);
+        AutomationProperties.SetName(buttonSeekBack, string.Format(languageHints.SeekBackHint, string.Empty).TrimEnd());
+
+        var comboBoxSeekSeconds = new ComboBox
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            HorizontalContentAlignment = HorizontalAlignment.Center,
+            FontSize = 12,
+            MaxHeight = 22,
+            MinHeight = 22,
+            // The Fluent ComboBox theme forces MinWidth ~64; clear it so the box shrinks to the
+            // widest item ("0.25") instead of leaving a wide gap before the drop-down arrow.
+            MinWidth = 0,
+            Padding = new Thickness(4, 2, 0, 2),
+            Background = Brushes.Transparent,
+            BorderThickness = new Thickness(0),
+            [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.SeekAmountHint, shortcuts),
+            [AutomationProperties.NameProperty] = string.Format(languageHints.SeekAmountHint, string.Empty).TrimEnd(),
+        };
+        comboBoxSeekSeconds.Bind(ItemsControl.ItemsSourceProperty, new Binding(nameof(vm.VideoSeekAmounts)));
+        comboBoxSeekSeconds.Bind(SelectingItemsControl.SelectedItemProperty, new Binding(nameof(vm.SelectedVideoSeekAmount)) { Mode = BindingMode.TwoWay });
+
+        var buttonSeekForward = new NonSpaceButton
+        {
+            FontSize = settingVideoSeek.FontSize,
+            VerticalAlignment = VerticalAlignment.Center,
+            Command = vm.WaveformVideoSeekForwardCommand,
+            FontWeight = FontWeight.Bold,
+            [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.SeekForwardHint, shortcuts),
+        };
+        Attached.SetIcon(buttonSeekForward, IconNames.ChevronDoubleRight);
+        AutomationProperties.SetName(buttonSeekForward, string.Format(languageHints.SeekForwardHint, string.Empty).TrimEnd());
+
+        var panelVideoSeek = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(settingVideoSeek.LeftMargin, 0, settingVideoSeek.RightMargin, 0),
+            Children =
+            {
+                buttonSeekBack,
+                comboBoxSeekSeconds,
+                buttonSeekForward,
+            },
+        };
+
         var settingMore = GetToolbarSettingFor(SeWaveformToolbarItemType.More);
         var buttonMore = new NonSpaceButton
         {
@@ -721,6 +776,7 @@ public class InitWaveform
             panelSpeed,
             toggleButtonAutoSelectOnPlay,
             toggleButtonCenter,
+            panelVideoSeek,
             buttonMore
         );
         foreach (var sortedButton in sortableButtons)
@@ -765,6 +821,7 @@ public class InitWaveform
         StackPanel panelSpeed,
         ToggleButton toggleButtonAutoSelectOnPlay,
         ToggleButton toggleButtonCenter,
+        StackPanel panelVideoSeek,
         Button buttonMore)
     {
         var toolbarButtonForSort = new List<SortedControl>();
@@ -824,6 +881,9 @@ public class InitWaveform
                     break;
                 case SeWaveformToolbarItemType.Center:
                     toolbarButtonForSort.Add(new SortedControl { Sort = item.SortOrder, Control = toggleButtonCenter });
+                    break;
+                case SeWaveformToolbarItemType.VideoSeek:
+                    toolbarButtonForSort.Add(new SortedControl { Sort = item.SortOrder, Control = panelVideoSeek });
                     break;
                 case SeWaveformToolbarItemType.More:
                     toolbarButtonForSort.Add(new SortedControl { Sort = item.SortOrder, Control = buttonMore });

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -259,6 +259,8 @@ public partial class MainViewModel :
     [ObservableProperty] private bool _isTextBoxSplitAtCursorAndVideoPositionVisible;
     [ObservableProperty] private ObservableCollection<string> _speeds;
     [ObservableProperty] private string _selectedSpeed;
+    [ObservableProperty] private ObservableCollection<string> _videoSeekAmounts;
+    [ObservableProperty] private string _selectedVideoSeekAmount;
     [ObservableProperty] private bool _showWaveformDisplayModeSeparator;
     [ObservableProperty] private bool _showWaveformOnlyWaveform;
     [ObservableProperty] private bool _showWaveformOnlySpectrogram;
@@ -609,6 +611,11 @@ public partial class MainViewModel :
             "3.0x"
         });
         SelectedSpeed = "1.0x";
+
+        VideoSeekAmounts = new ObservableCollection<string>();
+        SelectedVideoSeekAmount = string.Empty;
+        RefreshVideoSeekAmounts();
+
         VideoOffsetText = string.Empty;
         SetVideoOffsetText = Se.Language.Main.Menu.SetVideoOffset;
         WaveformGeneratingText = string.Empty;
@@ -8426,6 +8433,10 @@ public partial class MainViewModel :
         LockTimeCodes = Se.Settings.General.LockTimeCodes;
         IsWaveformToolbarVisible = Se.Settings.Waveform.ShowToolbar;
 
+        // Frame mode may have just been toggled - refresh the waveform seek combo (frames vs
+        // seconds) before SetLayout below rebuilds the toolbar and re-binds the combo.
+        RefreshVideoSeekAmounts();
+
         if (AudioVisualizer != null)
         {
             AudioVisualizer.DrawGridLines = Se.Settings.Waveform.DrawGridLines;
@@ -13261,6 +13272,85 @@ public partial class MainViewModel :
     private void VideoOneSecondForward()
     {
         MoveVideoPositionMs(1000);
+    }
+
+    // Waveform toolbar "seek video" buttons (<< / >>): step the video by the amount picked in
+    // the adjacent combo box (seconds or frames). User-selectable and remembered across sessions.
+    [RelayCommand]
+    private void WaveformVideoSeekBack()
+    {
+        MoveVideoPositionMs(-GetVideoSeekMs());
+    }
+
+    [RelayCommand]
+    private void WaveformVideoSeekForward()
+    {
+        MoveVideoPositionMs(GetVideoSeekMs());
+    }
+
+    // Rebuilds the "seek video" combo options for the current time/frame mode. In frame mode the
+    // amounts are whole frames ("1f", "10f", ...); otherwise decimal seconds. The last pick per
+    // mode is remembered in settings; fall back to a sensible default if it's not in the list.
+    // Called from the constructor and from ApplySettings so toggling frame mode refreshes the list.
+    private void RefreshVideoSeekAmounts()
+    {
+        // In frame mode the list mixes a few frame steps ("1f"..) with second steps ("1s"..);
+        // "f" = frames, "s" = seconds. Time mode lists plain decimal seconds.
+        var useFrameMode = Se.Settings.General.UseFrameMode;
+        var amounts = useFrameMode
+            ? new[] { "1f", "5f", "10f", "1s", "5s", "10s" }
+            : new[] { "0.1s", "0.25s", "0.5s", "1s", "2s", "3s", "5s", "10s" };
+        var saved = Se.Settings.Waveform.VideoSeekAmount;
+        var preferred = !string.IsNullOrEmpty(saved) && amounts.Contains(saved)
+            ? saved
+            : (useFrameMode ? "5f" : "2s");
+
+        // Skip a no-op rebuild so switching an unrelated setting doesn't reset the user's pick.
+        if (VideoSeekAmounts.SequenceEqual(amounts) && SelectedVideoSeekAmount == preferred)
+        {
+            return;
+        }
+
+        VideoSeekAmounts = new ObservableCollection<string>(amounts);
+        SelectedVideoSeekAmount = preferred;
+    }
+
+    private int GetVideoSeekMs()
+    {
+        var amount = SelectedVideoSeekAmount;
+        if (string.IsNullOrEmpty(amount))
+        {
+            return 2000;
+        }
+
+        // A trailing "f" means the amount is in frames - convert via the current frame rate.
+        if (amount.EndsWith("f", StringComparison.OrdinalIgnoreCase))
+        {
+            if (int.TryParse(amount.TrimEnd('f', 'F'), NumberStyles.Integer, CultureInfo.InvariantCulture, out var frames) && frames > 0)
+            {
+                return SubtitleFormat.FramesToMilliseconds(frames);
+            }
+
+            return 2000;
+        }
+
+        // "s" suffix (or no suffix) means seconds.
+        if (double.TryParse(amount.TrimEnd('s', 'S'), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var seconds) && seconds > 0)
+        {
+            return (int)Math.Round(seconds * 1000, MidpointRounding.AwayFromZero);
+        }
+
+        return 2000;
+    }
+
+    partial void OnSelectedVideoSeekAmountChanged(string value)
+    {
+        // Remember the raw pick so the combo restores it next session (when the mode's list still
+        // contains it). ComboBox clears the selection to null briefly while rebinding - ignore that.
+        if (!string.IsNullOrEmpty(value))
+        {
+            Se.Settings.Waveform.VideoSeekAmount = value;
+        }
     }
 
     [RelayCommand]

--- a/src/ui/Features/Options/Settings/WaveformToolbarItems/ToolbarItemDisplay.cs
+++ b/src/ui/Features/Options/Settings/WaveformToolbarItems/ToolbarItemDisplay.cs
@@ -43,6 +43,7 @@ public partial class ToolbarItemDisplay : ObservableObject
             SeWaveformToolbarItemType.PlaybackSpeed => Se.Language.General.PlaybackSpeed,
             SeWaveformToolbarItemType.AutoSelectOnPlay => Format(w.SelectCurrentLineWhilePlayingHint),
             SeWaveformToolbarItemType.Center => Format(w.CenterWaveformHint),
+            SeWaveformToolbarItemType.VideoSeek => w.SeekVideo,
             SeWaveformToolbarItemType.More => Se.Language.General.More,
             _ => type.ToString(),
         };

--- a/src/ui/Logic/Config/Language/Main/LanguageMainWaveform.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMainWaveform.cs
@@ -18,6 +18,10 @@ public class LanguageMainWaveform
     public string ResetZoomAndSpeed { get; set; }
     public string RemoveBlankLines { get; set; }
     public string PlaySelectedRepeatHint { get; set; }
+    public string SeekBackHint { get; set; }
+    public string SeekForwardHint { get; set; }
+    public string SeekAmountHint { get; set; }
+    public string SeekVideo { get; set; }
 
     public LanguageMainWaveform()
     {
@@ -37,5 +41,9 @@ public class LanguageMainWaveform
         ResetZoomAndSpeed = "Reset zoom & playback speed {0}";
         RemoveBlankLines = "Remove blank lines {0}";
         PlaySelectedRepeatHint = "Play selected subtitle(s) in repeat mode {0}";
+        SeekBackHint = "Seek video backward {0}";
+        SeekForwardHint = "Seek video forward {0}";
+        SeekAmountHint = "Seek amount {0}";
+        SeekVideo = "Seek video (<< >>)";
     }
 }

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -426,6 +426,10 @@ public class Se
             Settings.Waveform = new();
         }
 
+        // Add toolbar items introduced after an older settings file was written (e.g. VideoSeek),
+        // so the waveform toolbar's per-type lookup never misses and new items are customizable.
+        Settings.Waveform.EnsureAllToolbarItems();
+
         if (Settings.BeautifyTimeCodes == null)
         {
             Settings.BeautifyTimeCodes = new();

--- a/src/ui/Logic/Config/SeWaveform.cs
+++ b/src/ui/Logic/Config/SeWaveform.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia.Media;
 using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Nikse.SubtitleEdit.Logic.Config;
 
@@ -37,6 +38,11 @@ public class SeWaveform
     // Step size per wheel notch when MouseWheelSetsVideoPosition is on.
     // 0 = one frame (uses General.CurrentFrameRate); otherwise the step in milliseconds.
     public int MouseWheelVideoPositionStepMs { get; set; }
+
+    // Last value picked in the waveform toolbar's "seek video" combo box (the << / >> buttons),
+    // stored as the raw option string. A trailing "f" means frames, "s" (or no suffix) means
+    // seconds. Remembered across sessions. See SeWaveformToolbarItemType.VideoSeek.
+    public string VideoSeekAmount { get; set; }
     public double ShotChangesSensitivity { get; set; }
     public string ShotChangesImportTimeCodeFormat { get; set; }
     public bool SnapToShotChanges { get; set; }
@@ -139,6 +145,7 @@ public class SeWaveform
         WaveformShowCps = true;
 
         MouseWheelVideoPositionStepMs = 500;
+        VideoSeekAmount = "2s";
 
         ToolbarItems =
         [
@@ -151,6 +158,7 @@ public class SeWaveform
             new SeWaveformToolbarItem { Type = SeWaveformToolbarItemType.SetStart, IsVisible = true, SortOrder = 70 },
             new SeWaveformToolbarItem { Type = SeWaveformToolbarItemType.SetEnd, IsVisible = true, SortOrder = 80 },
             new SeWaveformToolbarItem { Type = SeWaveformToolbarItemType.SetStartAndOffsetTheRest, IsVisible = true, SortOrder = 90 },
+            new SeWaveformToolbarItem { Type = SeWaveformToolbarItemType.VideoSeek, IsVisible = false, SortOrder = 95 },
             new SeWaveformToolbarItem { Type = SeWaveformToolbarItemType.VerticalZoom, IsVisible = true, SortOrder = 100 },
             new SeWaveformToolbarItem { Type = SeWaveformToolbarItemType.HorizontalZoom, IsVisible = true, SortOrder = 110 },
             new SeWaveformToolbarItem { Type = SeWaveformToolbarItemType.VideoPositionSlider, IsVisible = true, SortOrder = 120 },
@@ -159,5 +167,34 @@ public class SeWaveform
             new SeWaveformToolbarItem { Type = SeWaveformToolbarItemType.Center, IsVisible = true, SortOrder = 150 },
             new SeWaveformToolbarItem { Type = SeWaveformToolbarItemType.More, IsVisible = true, SortOrder = 160 },
         ];
+    }
+
+    /// <summary>
+    /// Appends any toolbar item types missing from a loaded (older) settings file so newly added
+    /// items (e.g. VideoSeek) appear for existing users and InitWaveform's per-type lookup can't
+    /// throw. New items go just before "More" so it stays the last item, matching the defaults.
+    /// </summary>
+    public void EnsureAllToolbarItems()
+    {
+        if (ToolbarItems == null)
+        {
+            ToolbarItems = new List<SeWaveformToolbarItem>();
+        }
+
+        var moreItem = ToolbarItems.Find(p => p.Type == SeWaveformToolbarItemType.More);
+        var appendSortOrder = moreItem?.SortOrder - 5 ??
+                              (ToolbarItems.Count > 0 ? ToolbarItems.Max(p => p.SortOrder) + 10 : 10);
+
+        foreach (SeWaveformToolbarItemType type in System.Enum.GetValues(typeof(SeWaveformToolbarItemType)))
+        {
+            if (ToolbarItems.Exists(p => p.Type == type))
+            {
+                continue;
+            }
+
+            // Missing items were introduced after this settings file was written; add them hidden
+            // so an upgrade never silently rearranges a toolbar the user has already tuned.
+            ToolbarItems.Add(new SeWaveformToolbarItem { Type = type, IsVisible = false, SortOrder = appendSortOrder });
+        }
     }
 }

--- a/src/ui/Logic/Config/SeWaveformToolbarItemType.cs
+++ b/src/ui/Logic/Config/SeWaveformToolbarItemType.cs
@@ -17,5 +17,6 @@ public enum SeWaveformToolbarItemType
     PlaybackSpeed,
     AutoSelectOnPlay,
     Center,
+    VideoSeek,
     More
 }

--- a/src/ui/Logic/IconNames.cs
+++ b/src/ui/Logic/IconNames.cs
@@ -23,6 +23,8 @@ internal class IconNames
     public const string CheckBold = "mdi-check-bold";
     public const string ChevronLeft = "mdi-chevron-left";
     public const string ChevronRight = "mdi-chevron-right";
+    public const string ChevronDoubleLeft = "mdi-chevron-double-left";
+    public const string ChevronDoubleRight = "mdi-chevron-double-right";
     public const string Close = "mdi-close";
     public const string ClosedCaption = "mdi-closed-caption";
     public const string Cogs = "mdi-cogs";


### PR DESCRIPTION
Fixes #12176 — SE4 had buttons below the waveform to jump the video a few seconds; they were missing in SE5 ("where are the buttons to move the video only a few seconds?").

## What
A new customizable waveform-toolbar item **Seek video (`<< >>`)**: a `<<` button, a **Seek amount** combo box, and a `>>` button that step the video position by the selected amount.

- **Time mode** — the combo lists seconds: `0.1s, 0.25s, 0.5s, 1s, 2s, 3s, 5s, 10s`.
- **Frame mode** (`General.UseFrameMode`) — a mix of frame and second steps: `1f, 5f, 10f, 1s, 5s, 10s`. `f` = frames (converted via the current frame rate), `s` = seconds. Toggling frame mode in Settings refreshes the list live (no restart).
- The pick is **remembered across sessions** (`SeWaveform.VideoSeekAmount`).
- Seeking reuses the existing `MoveVideoPositionMs` helper, so clamping/accumulation matches the existing 100ms/500ms/1s step shortcuts.

## Customization
Like every other toolbar item, it can be shown/hidden, reordered, and have its margins/font size tuned in the waveform toolbar-items dialog (Options → Settings → Waveform). It shows there as "Seek video (`<< >>`)".

**Hidden by default** so an upgrade never silently rearranges a toolbar the user has already tuned — enable it via the toolbar-items dialog. `EnsureAllToolbarItems()` on settings load adds items introduced after an older settings file was written, so the per-type toolbar lookup can't miss.

## Notes
- The seconds combo uses `MinWidth = 0` + centered content so it sizes tightly to its value instead of leaving a wide gap.
- New strings live in `LanguageMainWaveform`; `ChevronDoubleLeft/Right` added to `IconNames`.

Open question for maintainer: should this be **visible by default** to more directly answer the "where did they go?" issue, or kept opt-in as here?

Builds with 0 warnings/0 errors; manually tested in both time and frame mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)