### PR TITLE
Add "Configure toolbar items..." to the waveform More menu

### DIFF
--- a/src/ui/Features/Main/Layout/InitWaveform.cs
+++ b/src/ui/Features/Main/Layout/InitWaveform.cs
@@ -730,6 +730,14 @@ public class InitWaveform
             Command = vm.ResetWaveformZoomAndSpeedCommand,
         };
         flyoutMore.Items.Add(menuItemResetZoom);
+        var menuItemConfigureToolbar = new MenuItem
+        {
+            Header = languageHints.ConfigureToolbarItems,
+            Command = vm.ConfigureWaveformToolbarItemsCommand,
+        };
+        flyoutMore.Items.Add(menuItemConfigureToolbar);
+
+        // Keep "Hide toolbar" last - it's the destructive/exit action of this menu.
         var menuItemHideControls = new MenuItem
         {
             Header = string.Format(languageHints.HideWaveformToolbar, string.Empty),

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -67,6 +67,7 @@ using Nikse.SubtitleEdit.Features.Ocr;
 using Nikse.SubtitleEdit.Features.Options.Language;
 using Nikse.SubtitleEdit.Features.Options.Plugins;
 using Nikse.SubtitleEdit.Features.Options.Settings;
+using Nikse.SubtitleEdit.Features.Options.Settings.WaveformToolbarItems;
 using Nikse.SubtitleEdit.Features.Options.Shortcuts;
 using Nikse.SubtitleEdit.Features.Options.WordLists;
 using Nikse.SubtitleEdit.Features.Shared;
@@ -12868,6 +12869,36 @@ public partial class MainViewModel :
     {
         IsWaveformToolbarVisible = false;
         Se.Settings.Waveform.ShowToolbar = false;
+    }
+
+    [RelayCommand]
+    private async Task ConfigureWaveformToolbarItems()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        // Edit a copy so Cancel leaves the saved layout untouched; the dialog is the same one
+        // reached from Options -> Settings -> Waveform.
+        var current = Se.Settings.Waveform.ToolbarItems
+            .Select(i => new SeWaveformToolbarItem(i))
+            .ToList();
+
+        var result = await _windowService.ShowDialogAsync<WaveformToolbarItemsWindow, WaveformToolbarItemsViewModel>(
+            Window, vm => vm.Initialize(current));
+
+        if (!result.OkPressed)
+        {
+            return;
+        }
+
+        Se.Settings.Waveform.ToolbarItems = result.ResultToolbarItems;
+        Se.SaveSettings();
+
+        // Rebuild the layout so the waveform toolbar reflects the new item set/order (the toolbar
+        // is built once in InitWaveform.MakeWaveform, with no incremental update path).
+        SetLayout(Se.Settings.General.LayoutNumber);
     }
 
 

--- a/src/ui/Logic/Config/Language/Main/LanguageMainWaveform.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMainWaveform.cs
@@ -22,6 +22,7 @@ public class LanguageMainWaveform
     public string SeekForwardHint { get; set; }
     public string SeekAmountHint { get; set; }
     public string SeekVideo { get; set; }
+    public string ConfigureToolbarItems { get; set; }
 
     public LanguageMainWaveform()
     {
@@ -45,5 +46,6 @@ public class LanguageMainWaveform
         SeekForwardHint = "Seek video forward {0}";
         SeekAmountHint = "Seek amount {0}";
         SeekVideo = "Seek video (<< >>)";
+        ConfigureToolbarItems = "Configure toolbar items...";
     }
 }


### PR DESCRIPTION
Adds a **Configure toolbar items...** entry to the waveform toolbar's **More** (⋮) flyout.

Until now the waveform toolbar's item set (show/hide, order, margins, font size) could only be customized from Options → Settings → Waveform. This makes it reachable directly from the toolbar itself.

- Opens the same `WaveformToolbarItemsWindow` dialog used in Settings, editing a **copy** of the current items so Cancel leaves the layout untouched.
- On **OK** it saves the new list and rebuilds the layout via `SetLayout(...)` so the toolbar reflects the change immediately (the toolbar is built once in `InitWaveform.MakeWaveform`, with no incremental update path).
- Placed above **Hide toolbar**, which stays last in the menu.

Follow-up to #12183 (the seek panel) — this makes enabling that and other hidden items discoverable without opening Settings.

Builds with 0 warnings/0 errors; tested from the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)