### PR TITLE
Fix blank ASSA Set position preview with HH:MM:SS:FF time code (#12182)

### DIFF
--- a/src/ui/Features/Assa/AssaImageColorPicker/AssaImageColorPickerViewModel.cs
+++ b/src/ui/Features/Assa/AssaImageColorPicker/AssaImageColorPickerViewModel.cs
@@ -13,6 +13,7 @@ using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
 using SkiaSharp;
+using System.Globalization;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Assa.AssaImageColorPicker;
@@ -121,7 +122,9 @@ public partial class AssaImageColorPickerViewModel : ObservableObject
             return;
         }
 
-        var fileName = FfmpegGenerator.GetScreenShot(videoFileName, new TimeCode(line.StartTime.TotalMilliseconds).ToDisplayString());
+        // Pass exact seconds (not ToDisplayString, which honors the HH:MM:SS:FF time-code format
+        // setting and would feed ffmpeg an unparseable "-ss 00:01:23:15", blanking the preview - #12182).
+        var fileName = FfmpegGenerator.GetScreenShot(videoFileName, (line.StartTime.TotalMilliseconds / 1000.0).ToString("0.###", CultureInfo.InvariantCulture));
         if (System.IO.File.Exists(fileName))
         {
             try

--- a/src/ui/Features/Assa/AssaSetPosition/AssaSetPositionViewModel.cs
+++ b/src/ui/Features/Assa/AssaSetPosition/AssaSetPositionViewModel.cs
@@ -212,7 +212,9 @@ public partial class AssaSetPositionViewModel : ObservableObject
             return;
         }
 
-        var fileName = FfmpegGenerator.GetScreenShot(videoFileName, new TimeCode(line.StartTime.TotalMilliseconds).ToDisplayString());
+        // Pass exact seconds (not ToDisplayString, which honors the HH:MM:SS:FF time-code format
+        // setting and would feed ffmpeg an unparseable "-ss 00:01:23:15", blanking the preview - #12182).
+        var fileName = FfmpegGenerator.GetScreenShot(videoFileName, (line.StartTime.TotalMilliseconds / 1000.0).ToString("0.###", CultureInfo.InvariantCulture));
         if (System.IO.File.Exists(fileName))
         {
             try

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -313,7 +313,7 @@ public class FfmpegGenerator
 
     public static string GetScreenShot(string inputFileName, string timeCode, string colorMatrix = "")
     {
-        timeCode = timeCode.Replace(',', '.');
+        timeCode = NormalizeFfmpegTimeCode(timeCode);
         var outputFileName = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.png");
         var vfMatrix = string.Empty;
         if (!string.IsNullOrEmpty(colorMatrix))
@@ -368,6 +368,35 @@ public class FfmpegGenerator
     private static bool HasFrame(string fileName)
     {
         return File.Exists(fileName) && new FileInfo(fileName).Length > 0;
+    }
+
+    // ffmpeg's -ss accepts "[HH:]MM:SS[.ms]" or plain seconds. A caller may pass a UI-formatted
+    // time code, and when the "HH:MM:SS:FF" time-code format is enabled that becomes a four-field
+    // "00:01:23:15" which ffmpeg cannot parse - it extracts no frame and the preview goes blank
+    // (#12182). Normalize the decimal comma and convert a trailing frame field to fractional
+    // seconds so the ffmpeg boundary is safe regardless of the caller's display setting.
+    private static string NormalizeFfmpegTimeCode(string timeCode)
+    {
+        timeCode = timeCode.Replace(',', '.');
+
+        var parts = timeCode.Split(':');
+        if (parts.Length == 4 &&
+            int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var hh) &&
+            int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var mm) &&
+            int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var ss) &&
+            int.TryParse(parts[3], NumberStyles.Integer, CultureInfo.InvariantCulture, out var ff))
+        {
+            var frameRate = Configuration.Settings.General.CurrentFrameRate;
+            if (frameRate < 1)
+            {
+                frameRate = 25;
+            }
+
+            var totalSeconds = (hh * 3600) + (mm * 60) + ss + (ff / frameRate);
+            return totalSeconds.ToString("0.###", CultureInfo.InvariantCulture);
+        }
+
+        return timeCode;
     }
 
     internal static string? GetScreenShotWithSubtitle(Subtitle previewSubtitle, int width, int height)


### PR DESCRIPTION
Fixes #12182

## Problem
In the ASSA **Set position** tool the video frame doesn't display (blank/checkered background), so you can't see where you're placing the text. It works right after a fresh install but breaks once settings are customized, and a reset fixes it — the reporter couldn't find which setting.

## Root cause
The preview grabs the background frame with ffmpeg:

```csharp
FfmpegGenerator.GetScreenShot(videoFileName,
    new TimeCode(line.StartTime.TotalMilliseconds).ToDisplayString());
```

`ToDisplayString()` is **not** a fixed format — it honors the `UseTimeFormatHHMMSSFF` setting (Options → time code = `HH:MM:SS:FF`):

- Default → `00:01:23.150` → ffmpeg `-ss` seeks fine → frame shown ✅
- Frames format enabled → `00:01:23:15` (four colon-separated fields). `GetScreenShot` only stripped commas, so ffmpeg gets an unparseable `-ss 00:01:23:15`, extracts no frame, and the code falls back to a checkered background ❌

The frames/SMPTE time-code format is commonly enabled by Aegisub/ASSA users, which is why customizing settings triggered it. It is **not** the UI language. The same code path affects the ASSA **Image color picker**. The main video window still plays because it uses mpv/libmpv, not ffmpeg screenshots.

## Changes
- `AssaSetPositionViewModel` and `AssaImageColorPickerViewModel` now pass exact seconds (invariant culture) to `GetScreenShot`, independent of the time-code display format.
- Harden `FfmpegGenerator.GetScreenShot` with `NormalizeFfmpegTimeCode`: normalize the decimal comma and convert a stray trailing frame field to fractional seconds (using `CurrentFrameRate`), so the ffmpeg boundary is safe regardless of the caller's display setting.

## Testing
- `dotnet build src/ui/UI.csproj -c Debug`: 0 warnings / 0 errors.
- Verified in-app: with the `HH:MM:SS:FF` time-code format enabled, Set position now shows the correct video frame instead of a blank background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)