### PR TITLE
Restore WebVTT X-TIMESTAMP-MAP opt-out setting (#12181)

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2458,6 +2458,7 @@
       "defaultSaveAsFormat": "Default \"Save as\" format",
       "favoriteSubtitleFormats": "Favorite subtitle formats",
       "favoriteLanguages": "Favorite languages",
+      "webVttUseXTimestampMap": "WebVTT: use X-TIMESTAMP-MAP (offset time codes on load)",
       "showStopButton": "Show stop button",
       "showFullscreenButton": "Show full-screen button",
       "fullscreenHideControls": "Hide video controls in full-screen",

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -353,6 +353,7 @@ public class SettingsPage : UserControl
 
             new SettingsItem(Se.Language.Options.Settings.FavoriteSubtitleFormats, () => MakeFavoritesGrid(_vm)),
             new SettingsItem(Se.Language.Options.Settings.FavoriteLanguages, () => MakeLanguageFavoritesGrid(_vm)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.WebVttUseXTimestampMap, nameof(_vm.WebVttUseXTimestampMap)),
         ]));
 
         sections.Add(new SettingsSection(Se.Language.Options.Settings.SyntaxColoring,

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -133,6 +133,8 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<string> _favoriteSubtitleFormats;
     [ObservableProperty] private string? _selectedFavoriteSubtitleFormat;
 
+    [ObservableProperty] private bool _webVttUseXTimestampMap;
+
     [ObservableProperty] private ObservableCollection<PickLanguageDisplay> _favoriteLanguages;
     [ObservableProperty] private PickLanguageDisplay? _selectedFavoriteLanguage;
 
@@ -716,6 +718,8 @@ public partial class SettingsViewModel : ObservableObject
         {
             SelectedSaveSubtitleFormat = SaveSubtitleFormats.FirstOrDefault() ?? string.Empty;
         }
+
+        WebVttUseXTimestampMap = Se.Settings.Formats.WebVttUseXTimestampMap;
 
         if (!string.IsNullOrEmpty(general.FavoriteSubtitleFormats))
         {
@@ -1459,6 +1463,8 @@ public partial class SettingsViewModel : ObservableObject
 
         general.DefaultSubtitleFormat = SelectedDefaultSubtitleFormat;
         general.DefaultSaveAsFormat = SelectedSaveSubtitleFormat;
+
+        Se.Settings.Formats.WebVttUseXTimestampMap = WebVttUseXTimestampMap;
 
         var sbFavorites = new StringBuilder();
         foreach (var format in FavoriteSubtitleFormats)

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -198,6 +198,7 @@ public class LanguageSettings
     public string DefaultSaveAsFormat { get; set; }
     public string FavoriteSubtitleFormats { get; set; }
     public string FavoriteLanguages { get; set; }
+    public string WebVttUseXTimestampMap { get; set; }
 
     public string ShowStopButton { get; set; }
     public string ShowFullscreenButton { get; set; }
@@ -535,6 +536,7 @@ public class LanguageSettings
         DefaultFormat = "Default format";
         DefaultSaveAsFormat = "Default \"Save as\" format";
         FavoriteSubtitleFormats = "Favorite subtitle formats";
+        WebVttUseXTimestampMap = "WebVTT: use X-TIMESTAMP-MAP (offset time codes on load)";
         FavoriteLanguages = "Favorite languages";
         FilesAndLogs = "Files and logs";
         ShowErrorLogFile = "Show error log file";

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -591,6 +591,8 @@ public class Se
 
         var dc = Settings.File.DCinemaSmpte;
         var ss = Configuration.Settings.SubtitleSettings;
+        ss.WebVttUseXTimestampMap = Settings.Formats.WebVttUseXTimestampMap;
+        ss.WebVttUseMultipleXTimestampMap = Settings.Formats.WebVttUseMultipleXTimestampMap;
         ss.DCinemaAutoGenerateSubtitleId = dc.DCinemaAutoGenerateSubtitleId;
         ss.DCinemaFontSize = dc.DCinemaFontSize;
         ss.DCinemaBottomMargin = dc.DCinemaBottomMargin;

--- a/src/ui/Logic/Config/SeFormats.cs
+++ b/src/ui/Logic/Config/SeFormats.cs
@@ -13,13 +13,18 @@ public class SeFormats
     public decimal TmpegEncXmlOffsetY { get; set; }
     public bool TmpegEncXmlFontBold { get; set; }
 
+    // WebVTT "X-TIMESTAMP-MAP" header offsets every cue on load (e.g. MPEGTS:900000 = +10s).
+    // On by default to match the spec; can be turned off for files where the offset is unwanted.
+    public bool WebVttUseXTimestampMap { get; set; }
+    public bool WebVttUseMultipleXTimestampMap { get; set; }
+
 
     public SeFormats()
     {
         RosettaLanguage = "en";
         RosettaLanguageAutoDetect = true;
         RosettaFontSize = "100%";
-        RosettaLineHeight = "125%";        
+        RosettaLineHeight = "125%";
 
         TmpegEncXmlFontName = "Tahoma";
         TmpegEncXmlFontHeight = 0.067m;
@@ -27,5 +32,7 @@ public class SeFormats
         TmpegEncXmlOffsetX = 0.001m;
         TmpegEncXmlOffsetY = 0.001m;
 
+        WebVttUseXTimestampMap = true;
+        WebVttUseMultipleXTimestampMap = true;
     }
 }


### PR DESCRIPTION
Fixes #12181

## Problem
A WebVTT header such as `X-TIMESTAMP-MAP=LOCAL:00:00:00.000,MPEGTS:900000` offsets every cue by `900000 / 90000 = 10s` on load. SE4 had a hidden (XML-only) `WebVttUseXTimestampMap` setting to ignore it; SE5 (JSON settings) never exposed or persisted it, so users are stuck with the offset always applied.

## Root cause
The setting still exists in **libse** (`SubtitleSettings.WebVttUseXTimestampMap`, default `true`) and the shared WebVTT parser (`WebVTT.GetXTimeStampSeconds`) reads it. But SE5's `Se.UpdateLibSeSettings()` never assigned it, so it always kept libse's default of `true`, and there was no field or UI to change it.

## Changes
- **Persist** `WebVttUseXTimestampMap` and `WebVttUseMultipleXTimestampMap` in `SeFormats` (`Settings.json`), defaulting to `true` so behavior is unchanged unless the user opts out.
- **Bridge** both to `Configuration.Settings.SubtitleSettings` in `Se.UpdateLibSeSettings()`, which runs on load and after every save — so the parser picks up the value.
- **UI**: a checkbox *"WebVTT: use X-TIMESTAMP-MAP (offset time codes on load)"* in **Options → Settings → Subtitle Formats** (the most natural place), with load/save wiring and a new language string (`LanguageSettings` + `English.json`).

Only the primary `WebVttUseXTimestampMap` is exposed in the UI (the one requested); the `WebVttUseMultipleXTimestampMap` companion is persisted/bridged and defaults on.

## Testing
- `dotnet build src/ui/UI.csproj -c Debug`: 0 warnings / 0 errors.
- In-app: the checkbox appears in Subtitle Formats (checked by default); unchecking it and reopening a WebVTT with an `X-TIMESTAMP-MAP` header loads time codes without the 10s shift; choice persists across restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)