### PR TITLE
Fix "Mersclar" typo in Portuguese (Brazil) translation

### DIFF
--- a/src/ui/Assets/Languages/Portuguese (Brazil).json
+++ b/src/ui/Assets/Languages/Portuguese (Brazil).json
@@ -907,7 +907,7 @@
       "FixCommonErrors": "Corrigir _erros comuns...",
       "CheckAndFixNetflixErrors": "Verificar e corrigir erros da Netfli_x...",
       "MakeEmptyTranslationFromCurrentSubtitle": "Criar nova tradução _vazia a partir da legenda atual",
-      "MergeLinesWithSameText": "_Mersclar linhas com o mesmo texto...",
+      "MergeLinesWithSameText": "_Mesclar linhas com o mesmo texto...",
       "MergeLinesWithSameTimeCodes": "Unir linhas com os mesmos códigos de tempo...",
       "SplitBreakLongLines": "Dividir",
       "EvenlyDistributeLines": "Distribuir linhas uniformemente (por CPS)",


### PR DESCRIPTION
Reported in #12180.

The first Tools > merge menu item in `Portuguese (Brazil).json` read *"Mersclar linhas com o mesmo texto..."* (extra `r`). Corrected to *"Mesclar"* to match the other merge entries below it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)