### PR TITLE
Bump version to v5.1.0-beta11 and add changelog

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -1,6 +1,15 @@
 
 Subtitle Edit Changelog
 
+v5.1.0-beta11 (4th of July 2026)
+
+* Fix settings not saving when the UI language had a duplicate/empty translation (e.g. Portuguese Brazil) - the Options dialog no longer aborts on a repeated translated string, and a failed save now logs and shows an error instead of silently doing nothing - thx rosilucia-hub
+* Fix ASSA "Set position" and "Image color picker" showing a blank video background when the "HH:MM:SS:FF" time code format was enabled - thx bichitoxxx
+* Restore the WebVTT "X-TIMESTAMP-MAP" setting (Options -> Settings -> Subtitle Formats) to optionally ignore the header offset that shifts all time codes on load - thx anakinsleftleg
+* Update Portuguese (Brazil) translation - thx rosilucia-hub
+
+-----------------------------------------------------------------------------------------------------
+
 v5.1.0-beta10 (4th of July 2026)
 
 * Fix online speech-to-text (OpenRouter / Alibaba Qwen3-ASR) settings layout - the engine's settings rows no longer overlap/jumble together

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -17,7 +17,7 @@ public class Se
 {
     internal const int CurrentMacOsFontMigrationVersion = 1;
 
-    public static string Version { get; set; } = "v5.1.0-beta10";
+    public static string Version { get; set; } = "v5.1.0-beta11";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Bumps `Se.Version` to `v5.1.0-beta11` and adds the beta11 changelog entry.

Covers this batch of fixes:
- Settings not saving with a duplicate/empty UI translation, e.g. Portuguese Brazil (#12180)
- ASSA Set position / Image color picker blank preview with `HH:MM:SS:FF` time code (#12182)
- Restored WebVTT `X-TIMESTAMP-MAP` opt-out setting (#12181)
- Portuguese (Brazil) translation corrections

🤖 Generated with [Claude Code](https://claude.com/claude-code)