### PR TITLE
Fix Ctrl+End/Ctrl+Home not fully scrolling the subtitle grid (#12173)

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -1,11 +1,12 @@
 
 Subtitle Edit Changelog
 
-v5.1.0-beta11 (4th of July 2026)
+v5.1.0-beta11 (TBD)
 
 * Fix settings not saving when the UI language had a duplicate/empty translation (e.g. Portuguese Brazil) - the Options dialog no longer aborts on a repeated translated string, and a failed save now logs and shows an error instead of silently doing nothing - thx rosilucia-hub
 * Fix ASSA "Set position" and "Image color picker" showing a blank video background when the "HH:MM:SS:FF" time code format was enabled - thx bichitoxxx
 * Restore the WebVTT "X-TIMESTAMP-MAP" setting (Options -> Settings -> Subtitle Formats) to optionally ignore the header offset that shifts all time codes on load - thx anakinsleftleg
+* Fix Ctrl+End / Ctrl+Home on the subtitle grid not scrolling the last/first line fully into view - thx KaDeeKe
 * Update Portuguese (Brazil) translation - thx rosilucia-hub
 
 -----------------------------------------------------------------------------------------------------

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -19459,13 +19459,21 @@ public partial class MainViewModel :
                     HandleShiftArrowSelection(Subtitles.Count); // clamps to Count - 1
                     return;
                 }
-                else if (keyEventArgs.Key == Key.Home && keyEventArgs.KeyModifiers == KeyModifiers.None && Subtitles.Count > 0)
+                // Handle Ctrl+Home/End the same as plain Home/End: Ctrl is the habitual
+                // "go to top/bottom" chord, and routing it through SelectAndScrollToRow reuses the
+                // reliable scroll (EnsureRowFullyVisibleInSubtitleGrid) instead of falling through to
+                // Avalonia's default DataGrid navigation, which leaves the last row partially visible (#12173).
+                else if (keyEventArgs.Key == Key.Home &&
+                         (keyEventArgs.KeyModifiers == KeyModifiers.None || keyEventArgs.KeyModifiers == KeyModifiers.Control) &&
+                         Subtitles.Count > 0)
                 {
                     keyEventArgs.Handled = true;
                     SelectAndScrollToRow(0);
                     return;
                 }
-                else if (keyEventArgs.Key == Key.End && keyEventArgs.KeyModifiers == KeyModifiers.None && Subtitles.Count > 0)
+                else if (keyEventArgs.Key == Key.End &&
+                         (keyEventArgs.KeyModifiers == KeyModifiers.None || keyEventArgs.KeyModifiers == KeyModifiers.Control) &&
+                         Subtitles.Count > 0)
                 {
                     keyEventArgs.Handled = true;
                     SelectAndScrollToRow(Subtitles.Count - 1);


### PR DESCRIPTION
Fixes #12173

## Problem
Ctrl+End on the subtitle grid often leaves the last line only partially visible (clipped, or a row or two below the fold), so a manual scroll is needed before e.g. right-click → Insert after.

## Root cause
Plain `Home`/`End` are already remapped to `SelectAndScrollToRow(...)`, which uses the reliable `EnsureRowFullyVisibleInSubtitleGrid` scroll (built for #11723 to work around Avalonia's `DataGrid.ScrollIntoView` under-scrolling with variable-height rows). But **Ctrl+Home/Ctrl+End were not handled** and fell through to Avalonia's default DataGrid navigation, which uses the raw `ScrollIntoView` and leaves the target partially visible.

## Fix
Route Ctrl+Home/Ctrl+End through the same `SelectAndScrollToRow` helper as plain Home/End (Ctrl is the habitual "jump to top/bottom" chord), so the first/last line is fully scrolled into view.

## Testing
- `dotnet build src/ui/UI.csproj -c Debug`: 0 warnings / 0 errors.
- Verified in-app: Ctrl+End selects and fully shows the last line (multi-line rows included); Ctrl+Home fully shows the first line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)