### PR TITLE
Add "Video and audio files" default filter to Open Video dialog

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -7,6 +7,7 @@ v5.1.0-beta11 (TBD)
 * Fix ASSA "Set position" and "Image color picker" showing a blank video background when the "HH:MM:SS:FF" time code format was enabled - thx bichitoxxx
 * Restore the WebVTT "X-TIMESTAMP-MAP" setting (Options -> Settings -> Subtitle Formats) to optionally ignore the header offset that shifts all time codes on load - thx anakinsleftleg
 * Fix Ctrl+End / Ctrl+Home on the subtitle grid not scrolling the last/first line fully into view - thx KaDeeKe
+* Open video file dialog: add a "Video and audio files" filter as the default so audio files (e.g. mp3) can be picked without switching the filter
 * Update Portuguese (Brazil) translation - thx rosilucia-hub
 
 -----------------------------------------------------------------------------------------------------

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -667,6 +667,7 @@
     "videoFile": "Video file",
     "videoFileGeneratedX": "Video file generated: \"{0}\"",
     "videoFiles": "Video files",
+    "videoAndAudioFiles": "Video and audio files",
     "videoInformation": "Video info",
     "videoOffset": "Video offset",
     "videoOneFrameBack": "Video, one frame back",

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -667,6 +667,7 @@ public class LanguageGeneral
     public string VideoFile { get; set; }
     public string VideoFileGeneratedX { get; set; }
     public string VideoFiles { get; set; }
+    public string VideoAndAudioFiles { get; set; }
     public string VideoInformation { get; set; }
     public string VideoOffset { get; set; }
     public string VideoOneFrameBack { get; set; }
@@ -1418,6 +1419,7 @@ public class LanguageGeneral
         VideoFile = "Video file";
         VideoFileGeneratedX = "Video file generated: \"{0}\"";
         VideoFiles = "Video files";
+        VideoAndAudioFiles = "Video and audio files";
         VideoInformation = "Video info";
         VideoOffset = "Video offset";
         VideoOneFrameBack = "Video, one frame back";

--- a/src/ui/Logic/Media/FileHelper.cs
+++ b/src/ui/Logic/Media/FileHelper.cs
@@ -565,6 +565,12 @@ namespace Nikse.SubtitleEdit.Logic.Media
         {
             var fileTypes = new List<FilePickerFileType>
             {
+                // Combined filter first so it's the default selection - lets the user pick an audio
+                // file (e.g. an mp3 for transcription review) without first switching the filter.
+                new FilePickerFileType(Se.Language.General.VideoAndAudioFiles)
+                {
+                    Patterns = GetVideoExtensions().Concat(GetAudioExtensions()).ToList()
+                },
                 new FilePickerFileType(Se.Language.General.VideoFiles)
                 {
                     Patterns = GetVideoExtensions()


### PR DESCRIPTION
## Motivation
From a user running a distributed team reviewing Whisper-generated SRTs against **audio** (low-res mp3) files: opening an mp3 via **Video → Open Video…** required expanding the picker and switching the file-type filter away from the video-only default before the mp3 was even selectable.

## Change
Add a combined **"Video and audio files"** filter as the first (default) entry in the Open Video picker (`FileHelper.MakeOpenVideoFilter`). The picker defaults to the first filter, so both video and audio files are now selectable immediately — no filter switching. The existing **Video files**, **Audio files**, and **All files** entries remain below it.

This is the shared filter used by the main Open Video flow and the other `PickOpenVideoFile` callers, so it applies everywhere at once.

Considered but deliberately skipped a "default filter" *setting* — the combined default already serves both video-only and audio-only users with zero clicks, so a toggle would just add UI to undo a good default.

## Testing
- `dotnet build src/ui/UI.csproj -c Debug`: 0 warnings / 0 errors.
- Verified in-app: Open Video defaults to "Video and audio files" showing both types; an mp3 is selectable without switching filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)