### PR TITLE
Add "Set start and go to next" shortcut (SE4 parity, #12165)

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -512,6 +512,7 @@
     "setOutCueToClosestShotChangeLeftGreenZone": "Set out-cue to closest shot change (snap to left green zone)",
     "setOutCueToClosestShotChangeRightGreenZone": "Set out-cue to closest shot change (snap to right green zone)",
     "setStart": "Set start",
+    "setStartAndGoToNext": "Set start and go to next",
     "setStartAndKeepDuration": "Set start and keep duration",
     "setStartAndOffsetTheRest": "Set start and offset the rest",
     "setUpLikeSubtitleEdit4": "Set up like Subtitle Edit 4 (theme, shortcuts, replace rules)",

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12614,6 +12614,52 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private void WaveformSetStartAndGoToNext()
+    {
+        // SE4 parity: stamp the current video position as the selected line's start time and
+        // immediately advance to the next line, for rapid lyric/LRC synchronisation (#12165).
+        // Mirrors WaveformSetStart (start only, ASSA multi-select aware) plus the go-to-next
+        // from WaveformSetEndAndGoToNext.
+        var s = SelectedSubtitle;
+        var vp = GetVideoPlayerControl();
+        if (s == null || vp == null || LockTimeCodes)
+        {
+            return;
+        }
+
+        var idx = Subtitles.IndexOf(s);
+        if (idx < 0)
+        {
+            return;
+        }
+
+        var videoPositionSeconds = vp.Position;
+        var gap = Se.Settings.General.MinimumBetweenLines.GetMilliseconds() / 1000.0;
+        if (videoPositionSeconds >= s.EndTime.TotalSeconds - gap)
+        {
+            return;
+        }
+
+        var isAssa = SelectedSubtitleFormat is AdvancedSubStationAlpha;
+        if (isAssa)
+        {
+            var selectedItems = SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>().ToList();
+            foreach (var item in selectedItems)
+            {
+                item.SetStartTimeOnly(TimeSpan.FromSeconds(videoPositionSeconds));
+            }
+        }
+        else
+        {
+            s.SetStartTimeOnly(TimeSpan.FromSeconds(videoPositionSeconds));
+        }
+
+        SelectAndScrollToRow(idx + 1);
+
+        _updateAudioVisualizer = true;
+    }
+
+    [RelayCommand]
     private void WaveformSetStartAndKeepDuration()
     {
         var s = SelectedSubtitle;

--- a/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
+++ b/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
@@ -232,6 +232,7 @@ public static class Se4ShortcutsImporter
         ["MainAdjustSetStartAndOffsetTheRest2"] = nameof(MainViewModel.WaveformSetStartAndOffsetTheRestCommand),
         ["MainAdjustSetStartAndEndOfPrevious"] = nameof(MainViewModel.WaveformSetStartAndSetEndOfPreviousMinusGapCommand),
         ["MainAdjustSetEndAndOffsetTheRest"] = nameof(MainViewModel.WaveformSetEndAndOffsetTheRestCommand),
+        ["MainAdjustSetStartAndGotoNext"] = nameof(MainViewModel.WaveformSetStartAndGoToNextCommand),
         ["MainAdjustSetEndAndGotoNext"] = nameof(MainViewModel.WaveformSetEndAndGoToNextCommand),
         ["MainAdjustSetEndNextStartAndGoToNext"] = nameof(MainViewModel.WaveformSetEndAndStartOfNextAfterGapAndGoToNextCommand),
         ["MainAdjustStartDownEndUpAndGoToNext"] = nameof(MainViewModel.SetSubtitleStartAtVideoPositionSetEndAtKeyUpAndGoToNextCommand),

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -512,6 +512,7 @@ public class LanguageGeneral
     public string SetOutCueToClosestShotChangeLeftGreenZone { get; set; }
     public string SetOutCueToClosestShotChangeRightGreenZone { get; set; }
     public string SetStart { get; set; }
+    public string SetStartAndGoToNext { get; set; }
     public string SetStartAndKeepDuration { get; set; }
     public string SetStartAndOffsetTheRest { get; set; }
     public string SetUpLikeSubtitleEdit4 { get; set; }
@@ -1264,6 +1265,7 @@ public class LanguageGeneral
         SetOutCueToClosestShotChangeLeftGreenZone = "Set out-cue to closest shot change (snap to left green zone)";
         SetOutCueToClosestShotChangeRightGreenZone = "Set out-cue to closest shot change (snap to right green zone)";
         SetStart = "Set start";
+        SetStartAndGoToNext = "Set start and go to next";
         SetStartAndKeepDuration = "Set start and keep duration";
         SetStartAndOffsetTheRest = "Set start and offset the rest";
         SetUpLikeSubtitleEdit4 = "Set up like Subtitle Edit 4 (theme, shortcuts, replace rules)";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -259,6 +259,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.WaveformSetStartAndOffsetTheRestCommand),  Se.Language.General.SetStartAndOffsetTheRest },
         { nameof(MainViewModel.WaveformSetEndAndOffsetTheRestCommand),  Se.Language.General.SetEndAndOffsetTheRest },
         { nameof(MainViewModel.WaveformSetStartCommand),  Se.Language.General.SetStart },
+        { nameof(MainViewModel.WaveformSetStartAndGoToNextCommand),  Se.Language.General.SetStartAndGoToNext },
         { nameof(MainViewModel.WaveformSetStartAndKeepDurationCommand),  Se.Language.General.SetStartAndKeepDuration },
         { nameof(MainViewModel.WaveformSetEndCommand),  Se.Language.General.SetEnd },
         { nameof(MainViewModel.WaveformSetEndAndGoToNextCommand),  Se.Language.General.SetEndAndGoToNext },
@@ -636,6 +637,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.WaveformSetStartAndOffsetTheRestCommand, nameof(vm.WaveformSetStartAndOffsetTheRestCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.WaveformSetEndAndOffsetTheRestCommand, nameof(vm.WaveformSetEndAndOffsetTheRestCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.WaveformSetStartCommand, nameof(vm.WaveformSetStartCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.WaveformSetStartAndGoToNextCommand, nameof(vm.WaveformSetStartAndGoToNextCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.WaveformSetStartAndKeepDurationCommand, nameof(vm.WaveformSetStartAndKeepDurationCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.WaveformSetEndCommand, nameof(vm.WaveformSetEndCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.WaveformSetEndAndGoToNextCommand, nameof(vm.WaveformSetEndAndGoToNextCommand), ShortcutCategory.General);


### PR DESCRIPTION
Fixes #12165

## Analysis: the shortcut is genuinely missing

SE4 has a **"Set start and go to next"** adjust command (config key `MainAdjustSetStartAndGotoNext`) — it stamps the current video position as the selected line's start time and immediately advances selection to the next line. It was a core part of the rapid lyric/LRC syncing workflow.

SE5 has the two siblings — `WaveformSetStartCommand` ("Set start", F11) and `WaveformSetEndAndGoToNextCommand` ("Set end and go to next", F10) — but **not** "Set start *and go to next*". Confirmed absent from `ShortcutsMain` and the SE4 importer map. So the report is correct.

## Fix

- **New command** `WaveformSetStartAndGoToNext` in `MainViewModel`. It mirrors `WaveformSetStart` (start-only timestamp, ASSA multi-select aware, guards against setting start past end to avoid negative duration via `SetStartTimeOnly` which keeps the end fixed) and then advances with `SelectAndScrollToRow(idx + 1)` like `WaveformSetEndAndGoToNext`.
- **Registered** in `ShortcutsMain` (command→label lookup + `AddShortcut`) so it shows up in the shortcut configuration UI under General.
- **SE4 import mapping** `MainAdjustSetStartAndGotoNext` → `WaveformSetStartAndGoToNextCommand`, so users importing their SE4 shortcut config get it wired automatically.
- **UI string** `SetStartAndGoToNext = "Set start and go to next"` added to `LanguageGeneral.cs` and `English.json`.

**Left unbound by default** (like many sibling commands) so it can't collide with an existing default; the user assigns their preferred key in Options → Shortcuts.

## Testing

- Builds clean (0 warnings / 0 errors).
- `Se4ShortcutsImporterMapTests.EveryMappedSe4ShortcutTargetsARegisteredCommand` passes — the new SE4 mapping targets a registered command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)