### PR TITLE
Don't split valid compounds in Fix OCR for compounding languages (#12200)

### DIFF
--- a/src/libuilogic/Ocr/FixEngine/UnknownWordGuesser.cs
+++ b/src/libuilogic/Ocr/FixEngine/UnknownWordGuesser.cs
@@ -24,6 +24,30 @@ public static class UnknownWordGuesser
         { "deu", new[] { "der", "die", "das", "und", "zu", "in" } }
     };
 
+    // Languages that form closed compounds by concatenating words, so a long unknown word is
+    // normally a legitimate compound of two valid words (e.g. Dutch "modderwarboel" = "modder" +
+    // "warboel", "zwaardengooier" = "zwaarden" + "gooier") rather than a lost-space OCR error.
+    // The phonetic consonant-seam splitting in GenerateSmartSplits must not run for these, or it
+    // "fixes" correct compounds by breaking them into two words (#12200). The curated affix and
+    // particle splits above stay enabled - they isolate a fragment that is not itself a word, so
+    // the spell-checked guess only wins on a genuine merge.
+    private static readonly HashSet<string> CompoundingLanguages = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "nld", "dut",        // Dutch
+        "deu", "ger",        // German
+        "afr",               // Afrikaans
+        "dan",               // Danish
+        "nor", "nob", "nno", // Norwegian
+        "swe",               // Swedish
+        "isl", "ice",        // Icelandic
+        "fin",               // Finnish
+        "fao",               // Faroese
+        "fry",               // Frisian
+        "ltz",               // Luxembourgish
+        "hun",               // Hungarian
+        "est",               // Estonian
+    };
+
     public static IEnumerable<string> CreateGuessesFromLetters(string word, string threeLetterIsoLanguageName)
     {
         if (string.IsNullOrWhiteSpace(word) || word.Length < 4) // Lowered to 4 to catch "ofit"
@@ -81,8 +105,8 @@ public static class UnknownWordGuesser
             }
         }
 
-        // 3. Smart Phonetic Splits
-        if (word.Length > 7)
+        // 3. Smart Phonetic Splits (skipped for closed-compounding languages - see #12200)
+        if (word.Length > 7 && !CompoundingLanguages.Contains(lang))
         {
             foreach (var split in GenerateSmartSplits(word, vowels))
             {

--- a/tests/UI/Features/Ocr/FixEngine/UnknownWordGuesserTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/UnknownWordGuesserTests.cs
@@ -44,12 +44,33 @@ public class UnknownWordGuesserTests
         Assert.DoesNotContain("vaudeville -veteraan", guesses);
     }
 
-    // Ordinary (non-hyphenated) words are still split, so the fix does not disable the feature.
+    // The phonetic split still works for non-compounding languages, so the feature is not disabled.
     [Fact]
     public void CreateGuessesFromLetters_PlainWord_StillSplitsBetweenConsonants()
     {
-        var guesses = UnknownWordGuesser.CreateGuessesFromLetters("werkplek", "nld").ToList();
+        var guesses = UnknownWordGuesser.CreateGuessesFromLetters("helpdesk", "eng").ToList();
 
-        Assert.Contains("werk plek", guesses);
+        Assert.Contains("help desk", guesses);
+    }
+
+    // Regression test for https://github.com/SubtitleEdit/subtitleedit/issues/12200
+    // "Fix common OCR errors" split legitimate Dutch closed compounds into two words (e.g.
+    // "modderwarboel" -> "modder warboel"), because the smart-split heuristic treated any long
+    // word whose halves are both valid as a lost-space OCR error. Closed compounding is normal in
+    // Dutch (and German, Afrikaans, the Scandinavian languages, Finnish, ...), so the phonetic
+    // consonant-seam split must not run for those languages at all.
+    [Theory]
+    [InlineData("modderwarboel", "nld")]
+    [InlineData("haklessen", "nld")]
+    [InlineData("drakendodersvrouw", "nld")]
+    [InlineData("drakendodersweduwe", "nld")]
+    [InlineData("zwaardengooier", "nld")]
+    [InlineData("werkplek", "nld")]
+    [InlineData("Schifffahrt", "deu")]
+    public void CreateGuessesFromLetters_CompoundingLanguage_ProducesNoConsonantSeamSplit(string word, string lang)
+    {
+        var guesses = UnknownWordGuesser.CreateGuessesFromLetters(word, lang).ToList();
+
+        Assert.DoesNotContain(guesses, g => g.Contains(' '));
     }
 }


### PR DESCRIPTION
Fixes #12200

## Problem

"Fix common OCR errors" was corrupting legitimate Dutch text by splitting valid closed compounds into two words:

- `modderwarboel` → `modder warboel`
- `zwaardengooier` → `zwaarden gooier`
- `haklessen` → `hak lessen`
- `drakendodersvrouw`, `drakendodersweduwe`, … likewise

## Root cause

`FixCommonOcrErrors.Fix` calls `OcrFixEngine.FixOcrErrors(i, text, doTryToGuessUnknownWords: true)`. For each unknown word, `OcrFixEngine.CheckAndFixWord` applies the first "guess" whose parts all spell-check OK. One guess source is `UnknownWordGuesser.CreateGuessesFromLetters`, whose step 3 `GenerateSmartSplits` inserts a space at **every consonant seam** for words longer than 7 chars.

For a **closed-compounding language** (Dutch, German, Afrikaans, the Scandinavian languages, Finnish, …), a long unknown word is normally a legitimate compound of two valid words — not a lost-space OCR error. Because compounds are productive/infinite, the finite dictionary can't contain them all, so they fall through to the guess path and get shredded. The check that accepts a split (`IsSpelledCorrect`) only requires **both halves to be valid words**, which is exactly what a real compound is.

Dutch (`nld`) was the most exposed of all: it's in none of the guesser's `LanguageAffixes`, `CommonParticles`, or `restrictedLanguages` maps, so it only hit the phonetic split — and the results were returned **unfiltered**. (This is the closed-compound sibling of the hyphenated-word over-splitting fixed in #12156.)

## Fix

Skip `GenerateSmartSplits` for closed-compounding languages (`nld/dut`, `deu/ger`, `afr`, `dan`, `nor/nob/nno`, `swe`, `isl/ice`, `fin`, `fao`, `fry`, `ltz`, `hun`, `est`).

The curated affix/particle splits (steps 1–2) stay enabled: they isolate a fragment that is *not* itself a word (e.g. an affix like `ung`), so the spell-checked guess only wins on a genuine merge. The curated `Dictionaries/*_WordSplitList.txt` files (used via a separate engine path) are untouched — no `nld_WordSplitList.txt` ships, so the Dutch guess path is now fully quiet.

## Why not just add the words to the Dutch word list?

That would be whack-a-mole: Dutch (and German, etc.) compounding is productive, so the set of valid compounds is effectively infinite and can't be enumerated. The words in the report are a tiny sample. Suppressing the heuristic for the whole language class fixes every current and future compound, not just the reported ones.

## Testing

- New regression tests in `UnknownWordGuesserTests` assert the reported Dutch words (plus a German `Schifffahrt`) produce no consonant-seam split.
- The existing "plain word still splits" test was repurposed from Dutch `werkplek` (itself a valid compound = werk + plek, i.e. it encoded the bug) to English `helpdesk` → `help desk`, proving the feature still works where splitting is appropriate.
- All 82 OCR-engine tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)