### PR TITLE
Keep app open when "Save as" is cancelled on close

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17045,7 +17045,7 @@ public partial class MainViewModel :
             try
             {
                 if (!await PromptSaveChanges(Se.Language.General.SaveChangesMessage,
-                        async () => { await SaveSubtitle(); return true; }))
+                        () => SaveSubtitle()))
                 {
                     // Stay cancelled - window won't close
                     return;
@@ -21709,7 +21709,7 @@ public partial class MainViewModel :
         e.Cancel = true;
 
         if (!await PromptSaveChanges(Se.Language.General.SaveChangesMessage,
-                async () => { await SaveSubtitle(); return true; }))
+                () => SaveSubtitle()))
         {
             return;
         }


### PR DESCRIPTION
## Problem

Reported by a user: closing a project with unsaved changes, choosing **Yes** to save, then **cancelling** the "Save as" dialog closed the app anyway — losing the work. The expected behaviour is to cancel the close (stay open).

## Root cause

`MainViewModel.OnClosing` passed this to `PromptSaveChanges`:

```csharp
async () => { await SaveSubtitle(); return true; }
```

It awaited the save but **discarded `SaveSubtitle()`'s return value and always returned `true`**. `SaveSubtitle()` → `SaveSubtitleAs()` correctly returns `false` when the file picker is cancelled, but that `false` never reached `PromptSaveChanges`, so the close proceeded as if the save had succeeded.

## Fix

Propagate the real result: `() => SaveSubtitle()`. Now a cancelled "Save as" returns `false` → `PromptSaveChanges` returns `false` → `OnClosing` returns with `e.Cancel` still set, so the window stays open.

Fixed the identical lambda in the dead `OnWindowClosing` handler too (never subscribed, but fixed for consistency so it can't become a future trap). The other three `PromptSaveChanges` call sites already passed `SaveCurrentSubtitle`, which returns `false` on cancel, so they were already correct.

## Testing

Verified manually in a local Debug build:
- Unsaved changes → close → Yes → cancel "Save as" → **app stays open** ✅
- Yes → save successfully → app closes ✅
- No → closes without saving ✅
- Cancel at the first prompt → stays open ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)