### PR TITLE
Add CrispASR MOSS-Transcribe speech-to-text engine

### DIFF
--- a/src/libse/AudioToText/WhisperChoice.cs
+++ b/src/libse/AudioToText/WhisperChoice.cs
@@ -31,6 +31,7 @@
         public const string CrispAsrMega = "Crisp ASR Mega";
         public const string CrispAsrSenseVoice = "Crisp ASR SenseVoice";
         public const string CrispAsrArk = "Crisp ASR ARK";
+        public const string CrispAsrMossTranscribe = "Crisp ASR MOSS-Transcribe";
         public const string OpenAiCompatible = "OpenAI Compatible";
         public const string OpenRouter = "OpenRouter";
         public const string DashScopeQwen3 = "Alibaba Qwen3-ASR";

--- a/src/ui/Assets/SpeechToText/CrispASRMOSS-Transcribe.txt
+++ b/src/ui/Assets/SpeechToText/CrispASRMOSS-Transcribe.txt
@@ -1,0 +1,7 @@
+
+🦉 MOSS-Transcribe-preview-2B  (OpenMOSS-Team)
+
+Type: Qwen3-Omni audio encoder (32L, windowed attn) + GatedMLP adapter + Qwen3-1.7B LM decoder
+Focus: 🎯 Chinese and English
+Note: dedicated ASR sibling of moss-audio; lowercase, lightly punctuated output
+

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
@@ -34,6 +34,7 @@ public class CrispAsrEngine : CrispAsrEngineBase
             new CrispAsrKyutai(),
             new CrispAsrSenseVoice(),
             new CrispAsrArk(),
+            new CrispAsrMossTranscribe(),
         };
 
         SelectedBackend = _backends[0];

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrMossTranscribe.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrMossTranscribe.cs
@@ -1,0 +1,149 @@
+using Nikse.SubtitleEdit.Core.AudioToText;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+public class CrispAsrMossTranscribe : CrispAsrEngineBase
+{
+    public static string StaticName => "Crisp ASR MOSS-Transcribe";
+    public override string Name => StaticName;
+    public override string Choice => WhisperChoice.CrispAsrMossTranscribe;
+    public override string BackendName => "moss-transcribe";
+    public override string DefaultLanguage => "auto";
+    public override bool IncludeLanguage => true;
+    public override string Url => "https://github.com/CrispStrobe/CrispASR";
+
+    // OpenMOSS-Team/MOSS-Transcribe-preview-2B (Qwen3-Omni audio encoder + Qwen3-1.7B LM)
+    // is a dedicated ASR model officially covering Chinese and English only.
+    public override List<WhisperLanguage> Languages =>
+        new()
+        {
+            new WhisperLanguage("auto", "Auto detect"),
+            new WhisperLanguage("zh", "chinese"),
+            new WhisperLanguage("en", "english"),
+        };
+
+    public override List<WhisperModel> Models =>
+       new()
+       {
+            new WhisperModel
+            {
+                Name = "moss-transcribe-preview-2b-q4_k.gguf",
+                Size = "2.82 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/MOSS-Transcribe-preview-2B-GGUF/resolve/main/moss-transcribe-preview-2b-q4_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "moss-transcribe-preview-2b-q8_0.gguf",
+                Size = "3.52 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/MOSS-Transcribe-preview-2B-GGUF/resolve/main/moss-transcribe-preview-2b-q8_0.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "moss-transcribe-preview-2b-f16.gguf",
+                Size = "4.84 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/MOSS-Transcribe-preview-2B-GGUF/resolve/main/moss-transcribe-preview-2b-f16.gguf",
+                ],
+            },
+       };
+
+    public override string Extension => string.Empty;
+    public override string UnpackSkipFolder => string.Empty;
+
+    public override bool IsEngineInstalled()
+    {
+        var executableFile = GetExecutable();
+        return File.Exists(executableFile);
+    }
+
+    public override string ToString()
+    {
+        return CrispAsrEngine.GetBackendDisplayName(this);
+    }
+
+    public override string GetAndCreateWhisperFolder()
+    {
+        var folder = Se.CrispAsrFolder;
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public override string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel)
+    {
+        var folder = GetAndCreateWhisperFolder();
+        var modelsFolder = Path.Combine(folder, "models");
+        if (!Directory.Exists(modelsFolder))
+        {
+            Directory.CreateDirectory(modelsFolder);
+        }
+
+        return modelsFolder;
+    }
+
+    public override string GetExecutable()
+    {
+        string fullPath = Path.Combine(GetAndCreateWhisperFolder(), GetExecutableFileName());
+        return fullPath;
+    }
+
+    public override bool IsModelInstalled(WhisperModel model)
+    {
+        var modelFile = GetModelForCmdLine(model.Name);
+        if (!File.Exists(modelFile))
+        {
+            return false;
+        }
+
+        return new FileInfo(modelFile).Length > 10_000_000;
+    }
+
+    public override string GetModelForCmdLine(string modelName)
+    {
+        var modelFileName = Path.Combine(GetAndCreateWhisperModelFolder(null), modelName);
+        return modelFileName;
+    }
+
+    public override string GetWhisperModelDownloadFileName(WhisperModel whisperModel, string url)
+    {
+        var folder = GetAndCreateWhisperModelFolder(whisperModel);
+        var fileNameOnly = Path.GetFileName(url);
+        var fileName = Path.Combine(folder, fileNameOnly);
+        return fileName;
+    }
+
+    internal static string GetExecutableFileName()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return "crispasr.exe";
+        }
+
+        return "crispasr";
+    }
+
+    public override bool CanBeDownloaded()
+    {
+        return true;
+    }
+
+    public override string CommandLineParameter
+    {
+        get => Se.Settings.Tools.AudioToText.CommandLineParameterCrispAsrMossTranscribe;
+        set => Se.Settings.Tools.AudioToText.CommandLineParameterCrispAsrMossTranscribe = value;
+    }
+}

--- a/src/ui/Logic/Config/SeAudioToText.cs
+++ b/src/ui/Logic/Config/SeAudioToText.cs
@@ -60,6 +60,7 @@ public class SeAudioToText
     public string CommandLineParameterCrispAsrMega { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrSenseVoice { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrArk { get; set; } = "--max-len 50 --split-on-punct";
+    public string CommandLineParameterCrispAsrMossTranscribe { get; set; } = "--max-len 50 --split-on-punct";
     public string CrispAsrForcedAligner { get; set; } = "built-in";
 
     public string WhisperExtraSettingsHistory { get; set; } = string.Empty;

--- a/src/ui/UI.csproj
+++ b/src/ui/UI.csproj
@@ -189,6 +189,12 @@
 		<AvaloniaResource Include="Assets\SpeechToText\CrispASRSenseVoice.txt">
 		  <CopyToOutputDirectory></CopyToOutputDirectory>
 		</AvaloniaResource>
+		<AvaloniaResource Include="Assets\SpeechToText\CrispASRARK.txt">
+		  <CopyToOutputDirectory></CopyToOutputDirectory>
+		</AvaloniaResource>
+		<AvaloniaResource Include="Assets\SpeechToText\CrispASRMOSS-Transcribe.txt">
+		  <CopyToOutputDirectory></CopyToOutputDirectory>
+		</AvaloniaResource>
 		<AvaloniaResource Include="Assets\Themes.zip" />
 		<AvaloniaResource Include="Assets\SpeechToText\PurfviewFasterWhisper.txt">
 			<CopyToOutputDirectory></CopyToOutputDirectory>


### PR DESCRIPTION
## Summary
- Adds `Crisp ASR MOSS-Transcribe` as a new speech-to-text backend, wired up the same way as the existing Crisp ASR backends (Ark, SenseVoice, GLM, etc.)
- Model: [`OpenMOSS-Team/MOSS-Transcribe-preview-2B`](https://huggingface.co/cstr/MOSS-Transcribe-preview-2B-GGUF) — Qwen3-Omni audio encoder + Qwen3-1.7B LM, dedicated ASR (not the more general `moss-audio` sibling), officially covering Chinese and English (`--backend moss-transcribe`)
- Exposes the q4_k / q8_0 / f16 GGUF quantizations, matching the pattern used for other Crisp ASR backends
- Fixes a pre-existing latent bug: `Assets/SpeechToText/CrispASRARK.txt` existed on disk but was never registered as an `AvaloniaResource` in `UI.csproj`, so opening the ARK backend's help panel would throw at runtime. Registered it alongside the new MOSS-Transcribe asset.

## Test plan
- [x] `dotnet build` succeeds
- [x] Launched the app and confirmed it starts cleanly with the new engine wired in
- [ ] Could not click through Video > Audio to text > Whisper CPP > Crisp ASR backend dropdown in this environment (no macOS Accessibility permission for UI scripting) — please confirm the new backend and its help text show correctly before merging