### PR TITLE
Online STT: log failures, DashScope region hint, timeout handling, smaller OpenRouter chunks

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -733,6 +733,7 @@
     "openAiCompatibleSttPrompt": "Prompt",
     "dashScopeSttRegion": "Region",
     "dashScopeSttEnableWords": "Word-level timestamps",
+    "dashScopeSttRegionKeyHint": "Note: Alibaba Cloud Model Studio API keys are region-specific - make sure the selected region matches the region where the API key was created (China vs. International).",
     "onlineSttApiKeyMissing": "An API key is required. Please enter your API key and try again.",
     "openAiCompatibleSttAutoTranscribeOnAudioSelection": "Auto-transcribe new waveform selection via speech-to-text",
     "openAiCompatibleSttStream": "Stream response",

--- a/src/ui/Features/Video/SpeechToText/DashScope/DashScopeSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/DashScope/DashScopeSttService.cs
@@ -72,26 +72,35 @@ public class DashScopeSttService : ISttTranscriber
         }
         var ct = timeoutCts.Token;
 
-        var bytes = await File.ReadAllBytesAsync(audioFilePath, ct);
-        var fileName = Path.GetFileName(audioFilePath);
+        try
+        {
+            var bytes = await File.ReadAllBytesAsync(audioFilePath, ct);
+            var fileName = Path.GetFileName(audioFilePath);
 
-        progress?.Report("Uploading audio to DashScope temporary storage...");
-        _settings.Logger?.Invoke("DashScope: uploading audio to temporary storage");
-        var ossUrl = await UploadFileAsync(bytes, fileName, ct);
+            progress?.Report("Uploading audio to DashScope temporary storage...");
+            _settings.Logger?.Invoke($"DashScope: uploading audio to temporary storage ({BaseUrl})");
+            var ossUrl = await UploadFileAsync(bytes, fileName, ct);
 
-        progress?.Report("Submitting transcription task...");
-        _settings.Logger?.Invoke($"DashScope: submitting async task for {ossUrl}");
-        var taskId = await SubmitTaskAsync(ossUrl, language, ct);
+            progress?.Report("Submitting transcription task...");
+            _settings.Logger?.Invoke($"DashScope: submitting async task for {ossUrl}");
+            var taskId = await SubmitTaskAsync(ossUrl, language, ct);
 
-        progress?.Report("Waiting for transcription to complete...");
-        var transcriptionUrl = await PollTaskAsync(taskId, ct);
+            progress?.Report("Waiting for transcription to complete...");
+            var transcriptionUrl = await PollTaskAsync(taskId, ct);
 
-        _settings.Logger?.Invoke($"DashScope: fetching result from {transcriptionUrl}");
-        using var resultResponse = await _httpClient.GetAsync(transcriptionUrl, HttpCompletionOption.ResponseHeadersRead, ct);
-        resultResponse.EnsureSuccessStatusCode();
-        var resultJson = await resultResponse.Content.ReadAsStringAsync(ct);
+            _settings.Logger?.Invoke($"DashScope: fetching result from {transcriptionUrl}");
+            using var resultResponse = await _httpClient.GetAsync(transcriptionUrl, HttpCompletionOption.ResponseHeadersRead, ct);
+            resultResponse.EnsureSuccessStatusCode();
+            var resultJson = await resultResponse.Content.ReadAsStringAsync(ct);
 
-        return ParseTranscriptionResult(resultJson);
+            return ParseTranscriptionResult(resultJson);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Our own timeout fired, not a user cancel — surface it as an error
+            // so the caller doesn't mistake it for cancellation.
+            throw new TimeoutException($"DashScope transcription timed out after {_settings.TimeoutSeconds} seconds.");
+        }
     }
 
     /// <summary>
@@ -110,13 +119,18 @@ public class DashScopeSttService : ISttTranscriber
         if (!policyResponse.IsSuccessStatusCode)
         {
             var err = await policyResponse.Content.ReadAsStringAsync(ct);
+            _settings.Logger?.Invoke($"DashScope upload-policy request failed: GET {policyUrl} => {(int)policyResponse.StatusCode}: {err}");
             throw new HttpRequestException($"DashScope upload-policy request failed ({(int)policyResponse.StatusCode}). Response: {err}");
         }
 
         var policyJson = await policyResponse.Content.ReadAsStringAsync(ct);
         var policy = JsonSerializer.Deserialize<DashScopeUploadPolicyResponse>(policyJson,
-            new JsonSerializerOptions { PropertyNameCaseInsensitive = true })?.Data
-            ?? throw new InvalidOperationException("DashScope upload-policy response could not be parsed.");
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true })?.Data;
+        if (policy == null)
+        {
+            _settings.Logger?.Invoke($"DashScope upload-policy response could not be parsed: {policyJson}");
+            throw new InvalidOperationException($"DashScope upload-policy response could not be parsed. Response: {policyJson}");
+        }
 
         var key = $"{policy.UploadDir}/{fileName}";
 
@@ -138,6 +152,7 @@ public class DashScopeSttService : ISttTranscriber
         if (!uploadResponse.IsSuccessStatusCode)
         {
             var err = await uploadResponse.Content.ReadAsStringAsync(ct);
+            _settings.Logger?.Invoke($"DashScope OSS upload failed: POST {policy.UploadHost} => {(int)uploadResponse.StatusCode}: {err}");
             throw new HttpRequestException($"DashScope OSS upload failed ({(int)uploadResponse.StatusCode}). Response: {err}");
         }
 

--- a/src/ui/Features/Video/SpeechToText/Engines/OpenRouterSttEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/OpenRouterSttEngine.cs
@@ -23,10 +23,12 @@ public class OpenRouterSttEngine : IOnlineSttEngine
     public string Choice => WhisperChoice.OpenRouter;
     public string Url => "https://openrouter.ai/docs/guides/overview/multimodal/stt";
 
-    // OpenRouter proxies Whisper-class models (25 MB caps) but the audio is
-    // base64-inflated into a JSON body, so chunk more conservatively.
-    private const long UploadThreshold = 18L * 1024 * 1024;
-    private const long ChunkSize = 16L * 1024 * 1024;
+    // OpenRouter's upstream provider timeout is 60 seconds, so audio duration
+    // matters more than the Whisper 25 MB cap: a provider must finish
+    // transcribing the whole chunk within that window. Online engines upload
+    // 32 kbps mp3 (~240 KB/min), so ~2.5 MB keeps chunks near 10 minutes.
+    private const long UploadThreshold = 3L * 1024 * 1024;
+    private const long ChunkSize = 2560L * 1024;
 
     public override string ToString() => Name;
 

--- a/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
@@ -94,8 +94,27 @@ public class OpenAiSttService : ISttTranscriber
         {
             timeoutCts.CancelAfter(TimeSpan.FromSeconds(_settings.TimeoutSeconds));
         }
-        cancellationToken = timeoutCts.Token;
 
+        try
+        {
+            return await TranscribeCoreAsync(audioStream, fileName, language, progress, segmentProgress, timeoutCts.Token);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Our own timeout fired, not a user cancel — surface it as an error
+            // so the caller doesn't mistake it for cancellation.
+            throw new TimeoutException($"STT request timed out after {_settings.TimeoutSeconds} seconds.");
+        }
+    }
+
+    private async Task<OpenAiCompatibleSttResponse> TranscribeCoreAsync(
+        Stream audioStream,
+        string fileName,
+        string? language,
+        IProgress<string>? progress,
+        IProgress<OpenAiCompatibleSegment>? segmentProgress,
+        CancellationToken cancellationToken)
+    {
         using var content = new MultipartFormDataContent();
 
         // Content-Type, upload filename extension, and bytes must all agree —

--- a/src/ui/Features/Video/SpeechToText/OpenRouter/OpenRouterSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/OpenRouter/OpenRouterSttService.cs
@@ -16,12 +16,13 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.OpenRouter;
 /// <summary>
 /// Speech-to-text via OpenRouter's audio transcription API. Unlike OpenAI's
 /// multipart <c>/v1/audio/transcriptions</c>, OpenRouter takes a JSON body with
-/// the audio base64-encoded under <c>input_audio</c>. It proxies Whisper /
-/// GPT-4o-transcribe / Groq / Chirp, so with <c>response_format=verbose_json</c>
-/// and <c>timestamp_granularities[]</c> it returns the same segment/word shape
-/// we already parse into <see cref="OpenAiCompatibleSttResponse"/>. When a model
-/// or provider ignores those hints and returns only <c>text</c>, the caller's
-/// chunk pipeline still spans each chunk's duration so timing survives.
+/// the audio base64-encoded under <c>input_audio</c>. The documented response is
+/// <c>text</c> + usage only — <c>response_format=verbose_json</c> and
+/// <c>timestamp_granularities[]</c> are sent opportunistically in case the
+/// routed provider honors them and returns the segment/word shape we already
+/// parse into <see cref="OpenAiCompatibleSttResponse"/>. When only <c>text</c>
+/// comes back, the caller's chunk pipeline spans each chunk's duration and
+/// splits into sentences so timing survives.
 /// </summary>
 public class OpenRouterSttService : ISttTranscriber
 {
@@ -69,8 +70,26 @@ public class OpenRouterSttService : ISttTranscriber
         {
             timeoutCts.CancelAfter(TimeSpan.FromSeconds(_settings.TimeoutSeconds));
         }
-        cancellationToken = timeoutCts.Token;
+        var ct = timeoutCts.Token;
 
+        try
+        {
+            return await TranscribeCoreAsync(audioBytes, format, language, ct);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Our own timeout fired, not a user cancel — surface it as an error
+            // so the caller doesn't mistake it for cancellation.
+            throw new TimeoutException($"OpenRouter transcription timed out after {_settings.TimeoutSeconds} seconds.");
+        }
+    }
+
+    private async Task<OpenAiCompatibleSttResponse> TranscribeCoreAsync(
+        byte[] audioBytes,
+        string format,
+        string? language,
+        CancellationToken cancellationToken)
+    {
         var body = BuildRequestBody(_settings, audioBytes, format, language);
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
         using var request = new HttpRequestMessage(HttpMethod.Post, _settings.EndpointUrl)

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -1214,10 +1214,21 @@ public partial class SpeechToTextViewModel : ObservableObject
         }
         catch (HttpRequestException ex)
         {
+            // Log the full exception before simplifying the dialog text — the
+            // response body (e.g. DashScope's error code) is the only clue to
+            // what actually failed, and the dialog may hide it.
+            Se.WriteToolsLog($"Online STT transcription failed ({engine.Name}): {ex}");
+
             var message = ex.Message;
             if (message.Contains("401") || message.Contains("Unauthorized"))
             {
                 message = Se.Language.General.UnauthorizedApiKey;
+                if (engine is DashScopeQwen3SttEngine)
+                {
+                    // DashScope keys are region-scoped: a China (Beijing) key is
+                    // rejected by the international endpoint and vice versa.
+                    message += Environment.NewLine + Environment.NewLine + Se.Language.General.DashScopeSttRegionKeyHint;
+                }
             }
             else if (message.Contains("timeout") || message.Contains("timed out"))
             {
@@ -1230,8 +1241,42 @@ public partial class SpeechToTextViewModel : ObservableObject
                 IsTranscribeEnabled = true;
             });
         }
+        catch (TimeoutException ex)
+        {
+            // Raised by the online STT services when their own timeout fires
+            // (distinct from a user cancel, which arrives as
+            // OperationCanceledException above).
+            Se.WriteToolsLog($"Online STT transcription timed out ({engine.Name}): {ex.Message}");
+
+            await Dispatcher.UIThread.InvokeAsync(async () =>
+            {
+                await MessageBox.Show(Window!, Se.Language.General.RequestTimeout, Se.Language.General.TranscriptionError);
+                IsTranscribeEnabled = true;
+            });
+
+            if (subtitle.Paragraphs.Count > 0)
+            {
+                LogToConsole($"Timed out - returning {subtitle.Paragraphs.Count} partial segment(s)");
+                var postProcessedSubtitle = PostProcess(subtitle);
+
+                if (_audioClips != null && ResultAudioClips.Count > 0)
+                {
+                    // See note above: match the original clip via _videoFileName,
+                    // not the transcoded temp file passed as audioFileName.
+                    var outputAudioClip = ResultAudioClips.FirstOrDefault(p => p.AudioFileName == _videoFileName);
+                    if (outputAudioClip != null)
+                    {
+                        outputAudioClip.Transcription = new Subtitle(postProcessedSubtitle);
+                    }
+                }
+
+                await Dispatcher.UIThread.InvokeAsync(async () => await MakeResult(postProcessedSubtitle));
+            }
+        }
         catch (Exception ex)
         {
+            Se.WriteToolsLog($"Online STT transcription failed ({engine.Name}): {ex}");
+
             await Dispatcher.UIThread.InvokeAsync(async () =>
             {
                 await MessageBox.Show(Window!, $"{Se.Language.General.TranscriptionFailed}: {ex.Message}", "Error");

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -733,6 +733,7 @@ public class LanguageGeneral
     public string OpenAiCompatibleSttPrompt { get; set; }
     public string DashScopeSttRegion { get; set; }
     public string DashScopeSttEnableWords { get; set; }
+    public string DashScopeSttRegionKeyHint { get; set; }
     public string OnlineSttApiKeyMissing { get; set; }
     public string OpenAiCompatibleSttAutoTranscribeOnAudioSelection { get; set; }
     public string OpenAiCompatibleSttStream { get; set; }
@@ -1486,6 +1487,7 @@ public class LanguageGeneral
         OpenAiCompatibleSttPrompt = "Prompt";
         DashScopeSttRegion = "Region";
         DashScopeSttEnableWords = "Word-level timestamps";
+        DashScopeSttRegionKeyHint = "Note: Alibaba Cloud Model Studio API keys are region-specific - make sure the selected region matches the region where the API key was created (China vs. International).";
         OnlineSttApiKeyMissing = "An API key is required. Please enter your API key and try again.";
         OpenAiCompatibleSttAutoTranscribeOnAudioSelection = "Auto-transcribe new waveform selection via speech-to-text";
         OpenAiCompatibleSttStream = "Stream response";

--- a/tests/UI/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttServiceTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttServiceTests.cs
@@ -310,8 +310,10 @@ public class OpenAiSttServiceTests
     [Fact]
     public async Task TranscribeAsync_HonorsPerCallTimeout_FromSettings()
     {
-        // settings.TimeoutSeconds drives a CancelAfter on a linked CTS;
-        // a handler that never completes should be cancelled by it.
+        // settings.TimeoutSeconds drives a CancelAfter on a linked CTS; a
+        // handler that never completes is cancelled by it, and the service
+        // reports that as TimeoutException — distinct from a caller cancel,
+        // which surfaces as OperationCanceledException.
         var requestStarted = new TaskCompletionSource();
         using var handler = new StubHandler(async (req, ct) =>
         {
@@ -328,7 +330,7 @@ public class OpenAiSttServiceTests
         var wav = MakeTinyWav();
         try
         {
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            await Assert.ThrowsAsync<TimeoutException>(
                 () => service.TranscribeAsync(wav, cancellationToken: TestContext.Current.CancellationToken));
             Assert.True(requestStarted.Task.IsCompletedSuccessfully);
         }


### PR DESCRIPTION
Follow-ups to the OpenRouter + Alibaba (DashScope) speech-to-text engines, addressing the open reports in #12154 and #12219.

## Failures are now logged (#12154)

The user's tools log stopped at "DashScope: uploading audio to temporary storage" with an empty error log — because the upload-policy and OSS-upload failure paths threw without logging, and the view model's catch blocks showed a dialog (rewriting any 401 into a generic message) without logging either. Now:

- `DashScopeSttService` logs the upload-policy, OSS-upload, and policy-parse failures (status + response body) to the tools log before throwing.
- The view model writes the full exception to the tools log in every catch block before simplifying the dialog text.

## DashScope 401 → region hint (#12154)

Alibaba Cloud Model Studio API keys are region-scoped: a China (Beijing) key is rejected with `InvalidApiKey` by `dashscope-intl.aliyuncs.com` and vice versa. Since the default region is International, this is the most likely cause of #12154. On a DashScope 401, the error dialog now adds a hint to check that the selected region matches where the key was created.

## Timeouts are no longer reported as user cancellation

The per-call `TimeoutSeconds` fired a linked CTS, so a timeout surfaced as `OperationCanceledException` and was treated as "cancelled by user" — partial results, no error, no log. The OpenAI-compatible, OpenRouter, and DashScope services now translate their own timeout into `TimeoutException` (caller cancellation still propagates as `OperationCanceledException`), and the view model reports it as an error while still returning any partial segments.

## OpenRouter chunks shrunk from ~70 minutes to ~10 minutes of audio (#12219)

Audio for online engines is uploaded as 32 kbps mp3 (~240 KB/min). The old 18 MB threshold / 16 MB chunks therefore held over an hour of audio per request, while [OpenRouter's STT docs](https://openrouter.ai/docs/guides/overview/multimodal/stt) state the upstream provider timeout is 60 seconds — long files always failed. Chunks are now ~2.5 MB (≈10 minutes), small enough for the provider to finish within the timeout.

Also corrects the `OpenRouterSttService` class comment: the documented response is text + usage only; `verbose_json`/`timestamp_granularities` are opportunistic hints, and the sentence-split fallback carries the timing.

## Testing

- Updated `TranscribeAsync_HonorsPerCallTimeout_FromSettings` to assert the new `TimeoutException`.
- Full UI test suite passes (572/572).

Fixes #12219, helps diagnose #12154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)