### PR TITLE
Docs: add AI review section to What's New in SE5

### DIFF
--- a/docs/features/whats-new-in-se5.md
+++ b/docs/features/whats-new-in-se5.md
@@ -79,6 +79,16 @@ Subtitle Edit 5 adds local, downloadable auto-translate engines that run entirel
 
 See [Auto-translate](auto-translate.md) for the full engine list and workflow.
 
+## AI Review
+
+- New **Tools → AI review** — an AI proofreading pass that catches typos, spelling, grammar, punctuation, and casing errors without rephrasing or changing meaning, tone, or style.
+- **Runs locally by default** — uses a server-managed llama.cpp engine with a downloadable model picker, so no cloud service or API key is required. Ollama and any OpenAI-compatible endpoint are also supported.
+- **Review before you apply** — suggestions are listed as before/after pairs with a per-line reason, grouped by category (Spelling, Grammar, Punctuation, Casing, Other) with filter chips. Tick the ones you want and apply only those.
+- **Safe by design** — formatting tags (`<i>`, `{\an8}`, etc.) and line breaks are preserved; suggestions that touch tags are dropped, and large rewrites are flagged for a closer look and left unselected.
+- **Editable prompt** — the instructions sent to the model can be customized (with the subtitle language auto-detected and substituted in).
+
+See [AI Review](ai-review.md) for details.
+
 ## Batch conversion
 
 - **OCR while converting** — Batch Convert can turn image-based subtitles into text-based formats in bulk, using nOCR, Binary OCR, Tesseract, Ollama, or PaddleOCR. Language and pixels-are-space settings can be auto-detected for nOCR/Binary OCR, so converting many files with similar fonts needs far less manual setup.


### PR DESCRIPTION
Adds an **AI Review** section to `docs/features/whats-new-in-se5.md`, placed after Auto-translate since both are AI-related.

Covers the new **Tools → AI review** feature:
- AI proofreading pass (typos, spelling, grammar, punctuation, casing) that doesn't rephrase or change meaning/tone/style
- Local-first: server-managed llama.cpp with a downloadable model picker (no cloud/API key needed); Ollama and OpenAI-compatible endpoints also supported
- Review-before-apply: before/after suggestions with per-line reasons, category filter chips, selective apply
- Safety: preserves formatting tags and line breaks, drops tag-altering edits, flags large rewrites
- Editable prompt with auto-detected language substitution

Links to the existing `ai-review.md` reference doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)