### PR TITLE
Refresh waveform context menu after UI language changes

### DIFF
--- a/src/ui/Features/Main/Layout/InitWaveform.cs
+++ b/src/ui/Features/Main/Layout/InitWaveform.cs
@@ -99,10 +99,6 @@ public class InitWaveform
                 WaveformHeightPercentage = settings.SpectrogramCombinedWaveformHeight,
             };
 
-            // The waveform is a focusable custom control with no text content, so without an
-            // accessible name screen readers announce it as a bare generic Avalonia control (#12087).
-            AutomationProperties.SetName(vm.AudioVisualizer, Se.Language.General.Waveform);
-
             vm.AudioVisualizer.OnNewSelectionInsert += vm.AudioVisualizerOnNewSelectionInsert;
             vm.AudioVisualizer.OnVideoPositionChanged += vm.AudioVisualizerOnVideoPositionChanged;
             vm.AudioVisualizer.OnToggleSelection += vm.AudioVisualizerOnToggleSelection;
@@ -115,10 +111,23 @@ public class InitWaveform
             vm.AudioVisualizer.OnSetStartAndOffsetTheRest += vm.AudioVisualizerSetStartAndOffsetTheRest;
             vm.AudioVisualizer.OnGenerateWaveformRequested += vm.AudioVisualizerOnGenerateWaveformRequested;
 
-            // Create a Flyout for the DataGrid
-            var flyout = new MenuFlyout();
             vm.AudioVisualizer.FlyoutMenuOpening += vm.AudioVisualizerFlyoutMenuOpening;
+        }
+        else
+        {
+            vm.AudioVisualizer.RemoveControlFromParent();
+        }
 
+        // The waveform is a focusable custom control with no text content, so without an
+        // accessible name screen readers announce it as a bare generic Avalonia control (#12087).
+        AutomationProperties.SetName(vm.AudioVisualizer, Se.Language.General.Waveform);
+
+        MakeWaveformContextMenu();
+
+        void MakeWaveformContextMenu()
+        {
+            // Rebuild the menu whenever the layout is rebuilt so a language change refreshes its text.
+            var flyout = new MenuFlyout();
             var insertSelectionMenuItem = new MenuItem
             {
                 Header = Se.Language.General.InsertNewSelection,
@@ -309,10 +318,6 @@ public class InitWaveform
             flyout.Items.Add(showWaveformAndSpectrogramMenuItem);
 
             vm.AudioVisualizer.MenuFlyout = flyout;
-        }
-        else
-        {
-            vm.AudioVisualizer.RemoveControlFromParent();
         }
 
         Grid.SetRow(vm.AudioVisualizer, 0);


### PR DESCRIPTION
## Problem

After changing the UI language via **Options > Choose UI Language...**, most controls were updated immediately, but the waveform context menu continued to use the previous language.

The updated menu text only appeared after closing and restarting Subtitle Edit.

## Cause & Fix

The `AudioVisualizer` control is reused when the main layout is rebuilt. However, its context menu was created inside the `vm.AudioVisualizer == null` block, so the menu labels were only initialized when the control was first created.

The fix rebuilds the waveform context menu whenever the layout is rebuilt. The existing `AudioVisualizer` instance and its event subscriptions are preserved; only the context menu and accessible name are refreshed using the current UI language.

## Screenshots

| Before | After |
|---|---|
| The context menu remains in the previous language | The context menu updates immediately after changing the UI language |
| <video src="https://github.com/user-attachments/assets/0bec4c25-5c95-4e16-9e79-f51d88a693dd"> | <video src="https://github.com/user-attachments/assets/cf449ba0-7776-433f-a60a-ba825114354c"> |

## Testing

Tested on Windows 11 x64 (local Release build).