### PR TITLE
Fix black video preview in burn-in / visual sync windows (#12205)

### DIFF
--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -24,6 +24,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     private IntPtr _mpv = IntPtr.Zero;
     private IntPtr _renderContext = IntPtr.Zero;
     private volatile bool _disposed;
+    private volatile bool _coreInitialized;
     private string _fileName = string.Empty;
     private double? _audioEndBound;
 
@@ -352,7 +353,13 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
             return -1;
         }
 
-        return _mpvInitialize(_mpv);
+        var err = _mpvInitialize(_mpv);
+        if (err >= 0)
+        {
+            _coreInitialized = true;
+        }
+
+        return err;
     }
 
     private static byte[] GetUtf8Bytes(string s)
@@ -465,6 +472,10 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         {
             Se.LogError(new InvalidOperationException(GetErrorString(err)), "LibMpvDynamicPlayer InitializeWithOpenGL mpv_initialize");
         }
+        else
+        {
+            _coreInitialized = true;
+        }
 
         // Create OpenGL init params
         var initParams = new MpvOpenGlInitParams
@@ -553,6 +564,10 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         if (err < 0)
         {
             Se.LogError(new InvalidOperationException(GetErrorString(err)), "LibMpvDynamicPlayer InitializeWithMetal mpv_initialize");
+        }
+        else
+        {
+            _coreInitialized = true;
         }
 
         // Build mpv_metal_init_params: device (required) + layer (optional).
@@ -752,6 +767,24 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
     public string FileName => _fileName;
 
+    /// <summary>
+    /// The mpv core is initialized lazily by the rendering surface - e.g. the OpenGL
+    /// control calls InitializeWithOpenGL on its first render pass. Windows that open a
+    /// video right away (the burn-in and visual sync previews load the file from their
+    /// Loaded event) can therefore issue "loadfile" before mpv_initialize has run; the
+    /// command then fails with MPV_ERROR_UNINITIALIZED and is never retried, leaving the
+    /// preview black until some other action reloads the file (issue #12205). Wait
+    /// (bounded) for the core to come up before sending commands.
+    /// </summary>
+    private async Task WaitForCoreInitializedAsync(int timeoutMs = 5000)
+    {
+        var end = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (!_coreInitialized && !_disposed && DateTime.UtcNow < end)
+        {
+            await Task.Delay(25);
+        }
+    }
+
     public async Task LoadFile(string path)
     {
         EnsureNotDisposed();
@@ -767,6 +800,8 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         // Reset any end-of-playback bound from a previous file (see audio-only handling below).
         SetOptionString("end", "none");
         _audioEndBound = null;
+
+        await WaitForCoreInitializedAsync();
 
         var err = await Task.Run(() => DoMpvCommand("loadfile", path));
         if (_disposed)
@@ -879,6 +914,8 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     public async Task LoadAudio(string path)
     {
         EnsureNotDisposed();
+
+        await WaitForCoreInitializedAsync();
 
         var err = await Task.Run(() => DoMpvCommand("loadfile", path));
         if (_disposed)
@@ -1484,6 +1521,8 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         {
             throw new InvalidOperationException(GetErrorString(err));
         }
+
+        _coreInitialized = true;
 
         // Build render context params for software rendering
         var apiTypeBytes = Encoding.UTF8.GetBytes(MPV_RENDER_API_TYPE_SW + "\0");


### PR DESCRIPTION
## Problem

The video preview in the **burn-in** and **visual sync** windows stayed black until the window was resized/maximized (#12205). The main window's player was unaffected.

## Root cause

Those windows open the video right from their `Loaded` event, but the mpv core is initialized **lazily by the rendering surface** — e.g. the OpenGL control calls `InitializeWithOpenGL` (→ `mpv_initialize`) on its *first render pass*, which hasn't happened yet at that point. The `loadfile` command therefore failed with `MPV_ERROR_UNINITIALIZED` (-3) and was never retried; all follow-up calls failed the same way (`pause`, `SetAudioTrack`: "core not initialized" in error-log.txt). Traced by logging the `loadfile` result:

```
main window:  LoadFile[OpenGL]: loadfile err=0     ← surface already initialized
burn-in:      LoadFile[]:       loadfile err=-3    ← core not initialized, never retried
```

The main window only works because its player idles until the user opens a file, long after the surface initialized.

## Fix

In `LibMpvDynamicPlayer`:

- Track core initialization with a `_coreInitialized` flag, set after `mpv_initialize` succeeds in all four init paths (OpenGL, Metal, software rendering, native wid `Initialize()`).
- `LoadFile` / `LoadAudio` now await `WaitForCoreInitializedAsync()` (25 ms polls, 5 s cap) before issuing `loadfile`. The wait is async on the UI thread, so the first render pass — which performs the initialization — is not blocked; the load fires right after init completes.

If the surface never initializes (e.g. mpv missing), the bounded wait falls through and the command fails/logs exactly as before.

## Testing

- macOS (mpv-opengl): burn-in preview and visual sync now show video immediately on open; main window playback unaffected.

Fixes #12205

🤖 Generated with [Claude Code](https://claude.com/claude-code)