### PR TITLE
Show live segments for the CTranslate2 whisper engine (looked frozen)

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -3707,6 +3707,16 @@ public partial class SpeechToTextViewModel : ObservableObject
         if (engine is WhisperEngineCTranslate2)
         {
             parameters = parameters.Replace("--model", "--model_directory");
+
+            // whisper-ctranslate2 prints no segment lines unless --verbose is on; its only
+            // other progress output is a carriage-return tqdm bar, which never completes a
+            // line, so the newline-based console stays empty and a long CPU decode looks
+            // completely frozen (reported on macOS with large-v3). Default verbose on so
+            // segments stream live, unless the user set their own preference.
+            if (!parameters.Contains("--verbose", StringComparison.Ordinal))
+            {
+                parameters = "--verbose True " + parameters;
+            }
         }
 
         Se.WriteToolsLog($"{w} {parameters}");


### PR DESCRIPTION
## CTranslate2 engine: console stays empty for the whole run, looks frozen

### Problem
Running the Whisper CTranslate2 engine, the console log shows the "Calling speech-to-text" line and then nothing at all until the run finishes. whisper-ctranslate2 prints no segment lines unless --verbose is on; its only other progress output is a carriage-return tqdm bar, which never completes a line, so the newline-based console log never gets anything to show.

On macOS this is especially misleading: CTranslate2 has no Apple GPU backend, so a large-v3 decode runs sequentially on the CPU and takes a long time, all of it in total silence. It looks frozen or stuck in a loop while it is actually transcribing (that is how it was reported).

### Fix
Default `--verbose True` into the CTranslate2 parameter set, unless the user already set their own `--verbose` preference in the advanced parameters. Segments then stream into the console as they are decoded, matching the behavior of the other engines.

### Verified
On macOS against the shipped whisper-ctranslate2 0.5.7 bundle and the Systran large-v3 model, with the exact command line Subtitle Edit builds:
- without the flag: console output ends after the model loads, nothing more for the entire decode
- with the flag: `[MM:SS.mmm --> MM:SS.mmm] text` lines appear live per segment (Arabic text included)

### Files
- `src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs`
