### PR TITLE
TTS window: OK applies subtitle changes to main window, Cancel discards

### DIFF
--- a/docs/features/text-to-speech.md
+++ b/docs/features/text-to-speech.md
@@ -16,6 +16,7 @@ Generate speech audio from subtitle text using various TTS engines.
 4. Optionally enable **Review audio clips** to review each generated clip
 5. Optionally enable **Generate video file** to create a video with the audio
 6. Click **Generate** to start
+7. Close the window with **OK** to apply the session's subtitle changes (lines merged before generation, text edits made in the review window) to the subtitle in the main window — or **Cancel** to discard them
 
 ## Supported Engines
 
@@ -89,7 +90,7 @@ Each subtitle line is shown as a row with the following columns:
 |--------|-------------|
 | **Include** | Checkbox to include or exclude the line from the final output |
 | **#** | Subtitle line number |
-| **Text** | The subtitle text (editable — double-click to modify before regenerating) |
+| **Text** | The subtitle text (editable — double-click to modify before regenerating). Text edits are applied to the subtitle in the main window when the Text to speech window is closed with **OK** |
 | **Voice** | The voice used for that line |
 | **Speed** | The speed factor applied to fit the audio into the subtitle's duration |
 | **CPS** | Characters per second for the subtitle line |

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -6685,103 +6685,125 @@ public partial class MainViewModel :
                 _videoFileName ?? string.Empty, AudioVisualizer?.WavePeaks, Path.GetTempPath());
         });
 
-        await OfferToApplyTtsReviewTextChanges(result.ReviewTextChanges);
+        // OK is the consent to apply the session's subtitle changes; Cancel/Escape/title-bar
+        // close discards them.
+        if (result.OkPressed)
+        {
+            ApplyTtsChanges(result.MergedSubtitle, result.ReviewTextChanges);
+        }
     }
 
     /// <summary>
-    /// After the TTS window closes: if the user edited line texts in its review step, offer to
-    /// apply those edits to the subtitle so the text stays in sync with the generated audio and
-    /// doesn't have to be redone by hand (#12093). Lines are matched by the time codes they had
-    /// when the review opened - the TTS pipeline may renumber (empty-line removal keeps times) so
-    /// numbers/indices can't be used. A line merged before generation spans several original
-    /// lines, so its segment matches no single line's start+end; those edits can't be split back
-    /// and are reported rather than applied. Edits that match no line at all (e.g. an imported
-    /// session for a different subtitle) are ignored silently.
+    /// After the TTS window closes with OK: apply the subtitle changes made there, so the text
+    /// stays in sync with the generated audio and doesn't have to be redone by hand (#12093).
+    /// Two kinds exist: lines merged by the merge-continuation-lines step (each merged line
+    /// replaces the run of lines it spans) and text edits from the review step. Both are matched
+    /// by the time codes the lines had when the step ran - the TTS pipeline may renumber
+    /// (empty-line removal keeps times) so numbers/indices can't be used. Changes that match no
+    /// line (e.g. an imported session for a different subtitle) are ignored silently.
     /// </summary>
-    private async Task OfferToApplyTtsReviewTextChanges(List<ReviewTextChange> changes)
+    private void ApplyTtsChanges(Subtitle? mergedSubtitle, List<ReviewTextChange> changes)
     {
-        if (changes.Count == 0 || Window == null)
-        {
-            return;
-        }
-
         const double toleranceMs = 0.5;
-        var matches = new List<(SubtitleLineViewModel Line, string NewText)>();
+
+        // Merges first: a merged line then carries its merged time codes, so a review edit to a
+        // merged sentence applies through the same 1:1 matching below.
         var mergedCount = 0;
-        foreach (var change in changes)
+        foreach (var paragraph in mergedSubtitle?.Paragraphs ?? new List<Paragraph>())
         {
-            // Exact 1:1 match - same start and end as a current line.
-            var line = Subtitles.FirstOrDefault(s =>
-                Math.Abs(s.StartTime.TotalMilliseconds - change.StartMs) < toleranceMs &&
-                Math.Abs(s.EndTime.TotalMilliseconds - change.EndMs) < toleranceMs);
-            if (line != null)
+            var firstIndex = -1;
+            for (var i = 0; i < Subtitles.Count; i++)
             {
-                if (line.Text != change.NewText)
+                if (Math.Abs(Subtitles[i].StartTime.TotalMilliseconds - paragraph.StartTime.TotalMilliseconds) < toleranceMs)
                 {
-                    matches.Add((line, change.NewText));
+                    firstIndex = i;
+                    break;
+                }
+            }
+
+            if (firstIndex < 0 ||
+                Math.Abs(Subtitles[firstIndex].EndTime.TotalMilliseconds - paragraph.EndTime.TotalMilliseconds) < toleranceMs)
+            {
+                continue; // no match, or 1:1 - this paragraph wasn't merged
+            }
+
+            // The merged paragraph keeps the first line's start and the last line's end, so the
+            // consecutive run it replaced ends at the line matching its end time.
+            var lastIndex = -1;
+            for (var i = firstIndex + 1; i < Subtitles.Count; i++)
+            {
+                if (Math.Abs(Subtitles[i].EndTime.TotalMilliseconds - paragraph.EndTime.TotalMilliseconds) < toleranceMs)
+                {
+                    lastIndex = i;
+                    break;
                 }
 
+                if (Subtitles[i].EndTime.TotalMilliseconds > paragraph.EndTime.TotalMilliseconds)
+                {
+                    break;
+                }
+            }
+
+            if (lastIndex < 0)
+            {
                 continue;
             }
 
-            // No 1:1 line, but the segment starts on a real line and ends past it: this line was
-            // merged with following line(s) before generation. The edited text covers the whole
-            // merged sentence and can't be safely split back, so flag it instead of applying.
-            var mergedInto = Subtitles.FirstOrDefault(s =>
-                Math.Abs(s.StartTime.TotalMilliseconds - change.StartMs) < toleranceMs &&
-                s.EndTime.TotalMilliseconds < change.EndMs - toleranceMs);
-            if (mergedInto != null)
+            var mergedLine = Subtitles[firstIndex];
+            mergedLine.Text = paragraph.Text;
+            mergedLine.EndTime = TimeSpan.FromMilliseconds(paragraph.EndTime.TotalMilliseconds);
+            for (var i = lastIndex; i > firstIndex; i--)
             {
-                mergedCount++;
+                if (ReferenceEquals(Subtitles[i], SelectedSubtitle))
+                {
+                    SelectedSubtitle = mergedLine;
+                }
+
+                Subtitles.RemoveAt(i);
+            }
+
+            mergedCount++;
+        }
+
+        var updatedCount = 0;
+        foreach (var change in changes)
+        {
+            var line = Subtitles.FirstOrDefault(s =>
+                Math.Abs(s.StartTime.TotalMilliseconds - change.StartMs) < toleranceMs &&
+                Math.Abs(s.EndTime.TotalMilliseconds - change.EndMs) < toleranceMs);
+            if (line != null && line.Text != change.NewText)
+            {
+                line.Text = change.NewText;
+                updatedCount++;
             }
         }
 
-        if (matches.Count == 0 && mergedCount == 0)
+        if (mergedCount == 0 && updatedCount == 0)
         {
             return;
         }
 
-        var lang = Se.Language.Video.TextToSpeech;
-
-        // Only merged edits and nothing directly applicable: just tell the user why they weren't
-        // applied - there's nothing to confirm.
-        if (matches.Count == 0)
-        {
-            await MessageBox.Show(
-                Window,
-                lang.UpdateSubtitleTitle,
-                FormatCount(mergedCount, lang.ReviewMergedLinesNotUpdatedSingular, lang.ReviewMergedLinesNotUpdatedPlural),
-                MessageBoxButtons.OK,
-                MessageBoxIcon.Information);
-            return;
-        }
-
-        var message = FormatCount(matches.Count, lang.UpdateSubtitleFromReviewSingular, lang.UpdateSubtitleFromReviewPlural);
         if (mergedCount > 0)
         {
-            message += Environment.NewLine + Environment.NewLine +
-                       FormatCount(mergedCount, lang.ReviewMergedLinesNotUpdatedSingular, lang.ReviewMergedLinesNotUpdatedPlural);
-        }
-
-        var answer = await MessageBox.Show(
-            Window,
-            lang.UpdateSubtitleTitle,
-            message,
-            MessageBoxButtons.YesNo,
-            MessageBoxIcon.Question);
-
-        if (answer != MessageBoxResult.Yes)
-        {
-            return;
-        }
-
-        foreach (var (line, newText) in matches)
-        {
-            line.Text = newText;
+            Renumber();
         }
 
         _updateAudioVisualizer = true;
-        ShowStatus(FormatCount(matches.Count, lang.SubtitleUpdatedFromReviewSingular, lang.SubtitleUpdatedFromReviewPlural));
+        RefreshSubtitlePreview();
+
+        var lang = Se.Language.Video.TextToSpeech;
+        var parts = new List<string>();
+        if (updatedCount > 0)
+        {
+            parts.Add(FormatCount(updatedCount, lang.SubtitleUpdatedFromReviewSingular, lang.SubtitleUpdatedFromReviewPlural));
+        }
+
+        if (mergedCount > 0)
+        {
+            parts.Add(FormatCount(mergedCount, lang.SubtitleMergedLinesAppliedSingular, lang.SubtitleMergedLinesAppliedPlural));
+        }
+
+        ShowStatus(string.Join(" - ", parts));
     }
 
     // Picks the singular or plural resource string for a count, formatting the plural with {0}.

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewTextChange.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewTextChange.cs
@@ -3,9 +3,9 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.ReviewSpeech;
 /// <summary>
 /// A text edit made in the review window, keyed by the time codes the line had when the review
 /// opened (waveform drags may change the paragraph's times afterwards). The main window uses the
-/// times to find the matching subtitle line and offer to apply the edit (#12093) - numbers and
-/// indices can't be used because the TTS pipeline may have renumbered (empty-line removal) or
-/// merged sentences.
+/// times to find the matching subtitle line and applies the edit when the TTS window is closed
+/// with OK (#12093) - numbers and indices can't be used because the TTS pipeline may have
+/// renumbered (empty-line removal) or merged sentences.
 /// </summary>
 public class ReviewTextChange
 {

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -93,7 +93,6 @@ public partial class TextToSpeechViewModel : ObservableObject
     [ObservableProperty] private string _progressText;
     [ObservableProperty] private double _progressValue;
     [ObservableProperty] private double _progressOpacity;
-    [ObservableProperty] private string _doneOrCancelText;
     [ObservableProperty] private bool _hasKeyFile;
     [ObservableProperty] private string _keyFile;
     [ObservableProperty] private bool _hasInstruction;
@@ -129,9 +128,14 @@ public partial class TextToSpeechViewModel : ObservableObject
     public ObservableCollection<string> OmniVoiceAccents { get; }
 
     // Text edits from OK'ed review sessions in this window, keyed by the lines' original time
-    // codes. The main window reads this after the dialog closes and offers to apply the edits
-    // to the subtitle (#12093). A later session's edit to the same line replaces the earlier one.
+    // codes. The main window applies these to the subtitle when this window is closed with OK
+    // (#12093). A later session's edit to the same line replaces the earlier one.
     public List<ReviewTextChange> ReviewTextChanges { get; } = new();
+
+    // Set when the user accepted the merge-continuation-lines step: the subtitle actually sent
+    // to the TTS engine. The main window applies the merges on OK so the subtitle stays in sync
+    // with the generated audio; Cancel discards them.
+    public Subtitle? MergedSubtitle { get; private set; }
 
     private Subtitle _subtitle = new();
     private readonly IFileHelper _fileHelper;
@@ -164,8 +168,6 @@ public partial class TextToSpeechViewModel : ObservableObject
         Region = string.Empty;
         VoiceCountInfo = string.Empty;
         ProgressText = string.Empty;
-        ProgressText = string.Empty;
-        DoneOrCancelText = string.Empty;
         IsVoiceTestEnabled = true;
         IsVoiceComboEnabled = true;
         IsGenerating = false;
@@ -970,6 +972,7 @@ public partial class TextToSpeechViewModel : ObservableObject
             merged.Paragraphs.Add(line.ToParagraph(_subtitle.OriginalFormat));
         }
         _subtitle = merged;
+        MergedSubtitle = merged;
     }
 
     /// <summary>
@@ -1075,7 +1078,6 @@ public partial class TextToSpeechViewModel : ObservableObject
         IsGenerating = true;
         IsNotGenerating = false;
         ProgressOpacity = 1.0;
-        DoneOrCancelText = Se.Language.General.Cancel;
         SaveSettings();
 
         Se.WriteToolsLog(
@@ -1174,7 +1176,6 @@ public partial class TextToSpeechViewModel : ObservableObject
         _generateStopwatch.Stop();
         ProgressPercentText = string.Empty;
         ProgressEtaText = string.Empty;
-        DoneOrCancelText = Se.Language.General.Done;
         IsGenerating = false;
         IsNotGenerating = true;
         ProgressOpacity = 0;
@@ -1720,7 +1721,6 @@ public partial class TextToSpeechViewModel : ObservableObject
             IsGenerating = true;
             IsNotGenerating = false;
             ProgressOpacity = 1.0;
-            DoneOrCancelText = Se.Language.General.Cancel;
 
             try
             {
@@ -1869,9 +1869,17 @@ public partial class TextToSpeechViewModel : ObservableObject
         }
     }
 
+    // OK closes the window accepting the session's subtitle changes: the main window then
+    // applies merged lines and review text edits (MergedSubtitle/ReviewTextChanges) to the
+    // open subtitle. Cancel (or Escape / title-bar close) discards them.
     [RelayCommand]
     private void Ok()
     {
+        SaveSettings();
+        _cancellationTokenSource.Cancel();
+        IsGenerating = false;
+        IsNotGenerating = true;
+        ProgressOpacity = 0;
         OkPressed = true;
         Close();
     }
@@ -1879,20 +1887,18 @@ public partial class TextToSpeechViewModel : ObservableObject
     [RelayCommand]
     private void Cancel()
     {
-        _cancellationTokenSource.Cancel();
-        IsGenerating = false;
-        IsNotGenerating = true;
-        ProgressOpacity = 0;
-    }
+        // During a run: stop the pipeline but keep the window open (same as Escape), so the
+        // user can adjust settings and generate again.
+        if (IsGenerating)
+        {
+            _cancellationTokenSource.Cancel();
+            IsGenerating = false;
+            IsNotGenerating = true;
+            ProgressOpacity = 0;
+            return;
+        }
 
-    [RelayCommand]
-    private void Done()
-    {
-        SaveSettings();
-        _cancellationTokenSource.Cancel();
-        IsGenerating = false;
-        IsNotGenerating = true;
-        ProgressOpacity = 0;
+        // Idle: close without applying anything to the main window (OkPressed stays false).
         Close();
     }
 

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -85,8 +85,10 @@ public class TextToSpeechWindow : Window
         // back up into the outer grid's column sizing. See the panel's class comment for why.
         var progressBarLayout = new WidthIgnoringPanel { Children = { MakeProgressBarControls(vm) } };
 
-        var buttonDone = UiUtil.MakeButtonDone(vm.DoneCommand).WithBindIsVisible(nameof(vm.IsNotGenerating));
-        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand).WithBindIsVisible(nameof(vm.IsGenerating));
+        // OK accepts the session (the main window applies merged lines and review text edits);
+        // Cancel stops a running generation, or - when idle - closes discarding those changes.
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand).WithBindIsVisible(nameof(vm.IsNotGenerating));
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
         var buttonCast = UiUtil.MakeButton(string.Empty, vm.ShowCastCommand)
             .WithIconLeftBindText(IconNames.PoliceBadge, nameof(vm.CastButtonText))
             .WithBindIsVisible(nameof(vm.HasCast))
@@ -105,8 +107,8 @@ public class TextToSpeechWindow : Window
         var buttonPanel = UiUtil.MakeButtonBar(
             buttonCast,
             UiUtil.MakeButton(Se.Language.General.ImportDotDotDot, vm.ImportCommand).WithBindIsEnabled(nameof(vm.IsNotGenerating)),
+            buttonOk,
             buttonCancel,
-            buttonDone,
             buttonGenerate
         ).WithMarginTop(0);
 
@@ -146,7 +148,7 @@ public class TextToSpeechWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonDone.Focus(); }; // hack to make OnKeyDown work
+        Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
     }
 
     // Install-status dot for the engine combo: green = ready, amber = a newer build is available,

--- a/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
@@ -102,14 +102,11 @@ public class LanguageTextToSpeech
     public string MergeContinuationLinesPromptTitle { get; set; }
     public string MergeContinuationLinesPromptMessage { get; set; }
 
-    // Applying review text edits back to the main subtitle
-    public string UpdateSubtitleTitle { get; set; }
-    public string UpdateSubtitleFromReviewSingular { get; set; }
-    public string UpdateSubtitleFromReviewPlural { get; set; }
-    public string ReviewMergedLinesNotUpdatedSingular { get; set; }
-    public string ReviewMergedLinesNotUpdatedPlural { get; set; }
+    // Applying the TTS window's changes (review text edits, merged lines) back to the subtitle
     public string SubtitleUpdatedFromReviewSingular { get; set; }
     public string SubtitleUpdatedFromReviewPlural { get; set; }
+    public string SubtitleMergedLinesAppliedSingular { get; set; }
+    public string SubtitleMergedLinesAppliedPlural { get; set; }
 
     public LanguageTextToSpeech()
     {
@@ -212,14 +209,9 @@ public class LanguageTextToSpeech
                                               "Merging them before generation lets the TTS engine speak each thought as one breath group, which usually sounds more natural." + Environment.NewLine + Environment.NewLine +
                                               "Review and apply merges now?";
 
-        UpdateSubtitleTitle = "Update subtitle?";
-        UpdateSubtitleFromReviewSingular = "You edited the text of one line while reviewing the generated speech." + Environment.NewLine + Environment.NewLine +
-                                           "Update the subtitle with this change so its text stays in sync with the audio?";
-        UpdateSubtitleFromReviewPlural = "You edited the text of {0} lines while reviewing the generated speech." + Environment.NewLine + Environment.NewLine +
-                                         "Update the subtitle with these changes so its text stays in sync with the audio?";
-        ReviewMergedLinesNotUpdatedSingular = "One edited line was merged before generation and could not be updated automatically.";
-        ReviewMergedLinesNotUpdatedPlural = "{0} edited lines were merged before generation and could not be updated automatically.";
         SubtitleUpdatedFromReviewSingular = "Updated one line from the speech review";
         SubtitleUpdatedFromReviewPlural = "Updated {0} lines from the speech review";
+        SubtitleMergedLinesAppliedSingular = "Applied one line merge from text to speech";
+        SubtitleMergedLinesAppliedPlural = "Applied {0} line merges from text to speech";
     }
 }


### PR DESCRIPTION
Implements the third item of [cvrle77's report in #12093](https://github.com/SubtitleEdit/subtitleedit/issues/12093#issuecomment-4882103442): changes made in the TTS review should be applied to the main subtitle.

### Before

- The window closed with a single **Done** button that neither distinguished accept from discard nor propagated the session's subtitle changes.
- Review text edits triggered a separate Yes/No prompt after the window closed - regardless of how it was closed.
- Lines merged by the merge-continuation-lines step could not be applied at all; their review edits were only reported as "could not be updated".

### After

- **Done** is replaced by **OK** and **Cancel**. OK closes the window accepting the session's subtitle changes; Cancel stops a running generation, or - when idle - closes discarding the changes (exactly what Escape already did, so keyboard and buttons now match).
- On OK the main window applies the changes directly instead of prompting, with a status-bar summary:
  1. **Merged lines first** - each merged paragraph replaces the run of lines it spans, matched by the time codes (start of the first line, end of the last), then lines are renumbered. If a removed row was selected, selection moves to the merged line.
  2. **Review text edits second** - matched 1:1 by time codes as before. Because merges apply first, an edit made to a merged sentence in review now applies too, through the merged line's new time codes.
- Title-bar close (X) and Escape count as Cancel.

Also removes the vestigial `DoneOrCancelText` view-model property (set in four places, bound nowhere) and the now-unused Yes/No prompt language strings; stale keys in existing translation JSONs are ignored by the deserializer. Docs updated.

Note: if the user accepts the merge step but then cancels generation, OK still applies the merges - the merge was explicitly confirmed in its own dialog, so it is treated as an intended subtitle change even without finished audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)