### PR TITLE
MLX Whisper (macOS): detect pipx/venv/conda installs + clearer 'not found' message

### DIFF
--- a/docs/features/speech-to-text.md
+++ b/docs/features/speech-to-text.md
@@ -14,6 +14,7 @@ Subtitle Edit can automatically transcribe audio to text using Whisper-based and
 | Whisper CPP | Windows, Linux, macOS | Local CPU engine. On Windows the cuBLAS (NVIDIA CUDA) and Vulkan GPU backends can also be selected from the Whisper CPP backend dropdown. |
 | Purfview Faster Whisper XXL | Windows, Linux | Fast local engine, often used with NVIDIA CUDA |
 | Whisper CTranslate2 | Windows, Linux (x64), macOS (Apple Silicon) | CPU / NVIDIA CUDA depending on installation; CUDA requires [CUDA 12.x](https://developer.nvidia.com/cuda-12-0-0-download-archive) |
+| MLX Whisper | macOS (Apple Silicon) | Runs Whisper on the Apple GPU / Neural Engine via Apple's MLX. Not downloaded by Subtitle Edit — install the `mlx-whisper` Python package yourself (see notes below) |
 | Whisper Const-me | Windows | DirectX-based engine |
 | Whisper OpenAI | All | Python-based OpenAI Whisper workflow |
 | OpenAI Compatible Server | All | Connect to any OpenAI-compatible speech-to-text endpoint |
@@ -27,6 +28,7 @@ Engines and models are downloaded automatically on first use.
 - **Whisper CPP** is shown as a single entry; the CPU / cuBLAS / Vulkan backends are selected from a secondary dropdown when Whisper CPP is selected.
 - **Qwen3 ASR CPP** includes 0.6B and 1.7B model options, plus a forced-aligner model used for timing workflows.
 - **Crisp ASR** is exposed as one engine that wraps multiple backends (Parakeet, Canary, Cohere, Fire Red, GLM, Granite, Qwen3, Mega, Omni, Kyutai). Pick the backend from the Crisp ASR backend dropdown.
+- **MLX Whisper** (Apple Silicon Macs) is not bundled or auto-downloaded — it drives Apple's `mlx-whisper` Python package. Install it once with `pip3 install mlx-whisper` (or `pipx install mlx-whisper`); models download from Hugging Face on first use. Subtitle Edit detects the install by finding a Python that can `import mlx_whisper` — it probes Homebrew, python.org, pyenv and system interpreters, and (for pipx / virtual-env / conda installs, which isolate the package) reads the `mlx_whisper` command found on your PATH or at `~/.local/bin/mlx_whisper` to locate the matching interpreter. If it reports "not found" after a pipx/venv install, make sure `which mlx_whisper` resolves.
 - A **Forced aligner** option is shown for Crisp ASR backends and exposes the built-in aligner, Canary CTC, Qwen3, and the wav2vec2 zoo (12 language-specific CTC aligners that run on top of any Crisp ASR backend).
 - Several newer engines support automatic language selection.
 - Each engine can have separate advanced command-line parameters.

--- a/docs/third-party-components.md
+++ b/docs/third-party-components.md
@@ -233,6 +233,15 @@ Used for AI-based speech recognition.
 *   **Files:** Download or build the binary and ensure it is named `whisper-cli`.
 *   **Models:** Models (`.bin` files) go into a `Models` subfolder: `[Data Folder]/SpeechToText/Cpp/Models`.
 
+### MLX Whisper (Speech-to-Text, Apple Silicon)
+Runs Apple's `mlx-whisper` Python package on the GPU / Neural Engine. **Subtitle Edit does not download this engine** — you install the Python package yourself, and there is no file in the Data Folder.
+
+*   **Requirements:** An Apple Silicon Mac (M1 or newer) and Python 3.
+*   **Install:** `pip3 install mlx-whisper` — or, for an isolated install, `pipx install mlx-whisper`.
+*   **Models:** MLX-format Whisper weights (`tiny` … `large-v3-turbo`) are downloaded from Hugging Face (the `mlx-community` org) into the Hugging Face cache on first use.
+*   **How detection works:** Subtitle Edit does not look for a binary; it looks for a Python interpreter that can `import mlx_whisper`. It probes Homebrew (`/opt/homebrew/bin`, `/usr/local/bin`), python.org framework builds, pyenv, and the system Python. Because **pipx, virtual environments, and conda install the package into an isolated environment** that those shared interpreters cannot import, Subtitle Edit also reads the shebang of the installed `mlx_whisper` command — found on your `PATH` or at `~/.local/bin/mlx_whisper` (where pipx places it) — to locate the exact matching interpreter.
+*   **If it reports "not found" after installing:** confirm the command resolves with `which mlx_whisper`. If it does not, add its directory to your `PATH`, or symlink the command into `~/.local/bin`. (Symlinking or copying only the *model files* does nothing — detection is by the Python package, not a binary.)
+
 ### SE5 Speech-to-Text, OCR, and TTS Engines
 
 Some newer local engines are platform-specific or model-specific. Use the in-app downloaders where available, and check [Speech to Text](features/speech-to-text.md), [Text to Speech](features/text-to-speech.md), and [OCR](features/ocr.md) for current engine notes.

--- a/src/ui/Features/Video/SpeechToText/Engines/MlxWhisperMac.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/MlxWhisperMac.cs
@@ -30,6 +30,9 @@ public class MlxWhisperMac : ISpeechToTextEngine
 
     private const string TranscribeScriptName = "mlx_whisper_transcribe.py";
 
+    // The console-script shim pip/pipx installs for the package (mlx_whisper --help).
+    private const string CliShimName = "mlx_whisper";
+
     // Friendly model name -> MLX-format Hugging Face repo (mlx-community).
     private static readonly Dictionary<string, string> ModelRepos = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -136,8 +139,10 @@ public class MlxWhisperMac : ISpeechToTextEngine
     }
 
     /// <summary>
-    /// The python3 interpreters to probe for mlx-whisper, in priority order: Homebrew, python.org
-    /// framework builds (newest first), pyenv, the system Python, and finally PATH resolution.
+    /// The python3 interpreters to probe for mlx-whisper, in priority order: the interpreter behind
+    /// an installed <c>mlx_whisper</c> CLI shim (covers pipx / venv / conda), then Homebrew,
+    /// python.org framework builds (newest first), pyenv, the system Python, and finally PATH
+    /// resolution.
     /// </summary>
     private static IEnumerable<string> GetPythonCandidates()
     {
@@ -150,6 +155,16 @@ public class MlxWhisperMac : ISpeechToTextEngine
             {
                 candidates.Add(path);
             }
+        }
+
+        // Highest priority: the exact interpreter behind an installed mlx_whisper CLI shim. pipx,
+        // a hand-made venv, and conda all install the package into an isolated environment that
+        // none of the shared interpreters below can import, so probing them alone reports "not
+        // found" even though the user did install it (#12209). The shim's shebang names the one
+        // interpreter that can import the package.
+        foreach (var interpreter in GetShebangInterpreters())
+        {
+            Add(interpreter);
         }
 
         Add("/opt/homebrew/bin/python3");
@@ -174,6 +189,117 @@ public class MlxWhisperMac : ISpeechToTextEngine
         Add("python3"); // resolved via PATH
 
         return candidates.Where(p => p == "python3" || File.Exists(p));
+    }
+
+    /// <summary>
+    /// Interpreters discovered by reading the shebang of an installed <c>mlx_whisper</c> CLI shim.
+    /// A pip/pipx/venv/conda console script starts with <c>#!/abs/path/to/that/env/bin/python</c>,
+    /// which points at the exact interpreter that can <c>import mlx_whisper</c> - the one case the
+    /// fixed interpreter list cannot cover, because an isolated environment's package is not
+    /// importable from Homebrew/system Python (#12209).
+    /// </summary>
+    private static IEnumerable<string> GetShebangInterpreters()
+    {
+        var result = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var shim in GetCliShimCandidates())
+        {
+            try
+            {
+                if (!File.Exists(shim))
+                {
+                    continue;
+                }
+
+                // Read only the first line - a console script is tiny, but a same-named non-script
+                // file on one of these paths shouldn't be slurped whole.
+                using var reader = new StreamReader(shim);
+                var firstLine = reader.ReadLine();
+                if (firstLine == null || !firstLine.StartsWith("#!", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                // "#!/path/to/python" or "#!/path/to/python -E ...": take the interpreter token.
+                // The "#!/usr/bin/env python3" form names no specific environment, so its first
+                // token ("/usr/bin/env") is filtered out by the python-name check below - the bare
+                // "python3" PATH candidate already covers that case.
+                var interpreterPath = firstLine.Substring(2).Trim().Split(' ', '\t')[0];
+                if (Path.IsPathRooted(interpreterPath) &&
+                    Path.GetFileName(interpreterPath).StartsWith("python", StringComparison.OrdinalIgnoreCase) &&
+                    File.Exists(interpreterPath) &&
+                    seen.Add(interpreterPath))
+                {
+                    result.Add(interpreterPath);
+                }
+            }
+            catch
+            {
+                // Unreadable / permission-denied shim - skip and try the next candidate.
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Locations an installed <c>mlx_whisper</c> console-script shim commonly lives: pipx and
+    /// "pip install --user" write it to <c>~/.local/bin</c>; a Homebrew-managed Python writes it
+    /// into its own bin. The PATH is also scanned so a shim on the user's PATH is found when
+    /// Subtitle Edit is launched from a shell.
+    /// </summary>
+    private static IEnumerable<string> GetCliShimCandidates()
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrEmpty(home))
+        {
+            var localBin = Path.Combine(home, ".local", "bin", CliShimName);
+            if (seen.Add(localBin))
+            {
+                yield return localBin;
+            }
+        }
+
+        foreach (var dir in new[] { "/opt/homebrew/bin", "/usr/local/bin" })
+        {
+            var shim = Path.Combine(dir, CliShimName);
+            if (seen.Add(shim))
+            {
+                yield return shim;
+            }
+        }
+
+        var pathEnv = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(pathEnv))
+        {
+            yield break;
+        }
+
+        foreach (var dir in pathEnv.Split(Path.PathSeparator))
+        {
+            if (string.IsNullOrEmpty(dir))
+            {
+                continue;
+            }
+
+            string shim;
+            try
+            {
+                shim = Path.Combine(dir, CliShimName);
+            }
+            catch
+            {
+                continue; // malformed PATH entry (illegal characters)
+            }
+
+            if (seen.Add(shim))
+            {
+                yield return shim;
+            }
+        }
     }
 
     public override string ToString()

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -2783,11 +2783,22 @@ public partial class SpeechToTextViewModel : ObservableObject
             {
                 if (engine is MlxWhisperMac)
                 {
-                    // pip-managed engine - Subtitle Edit cannot download it.
+                    // pip-managed engine - Subtitle Edit cannot download it. The message explains
+                    // the detection model (SE looks for a Python that can import mlx_whisper, not a
+                    // binary) and the pipx/venv/conda caveat, since a user who installed it that way
+                    // otherwise hits "not found" with no idea why (#12209).
                     await MessageBox.Show(
                         Window!,
                         $"{engine.Name} not found",
-                        "mlx-whisper not found - install it with: pip3 install mlx-whisper");
+                        "Subtitle Edit could not find a Python that can import the \"mlx_whisper\" package." + Environment.NewLine +
+                        Environment.NewLine +
+                        "If it is not installed yet, install it with:" + Environment.NewLine +
+                        "    pip3 install mlx-whisper" + Environment.NewLine +
+                        Environment.NewLine +
+                        "If you installed it with pipx, a virtual environment, or conda, Subtitle Edit finds it " +
+                        "automatically only when the \"mlx_whisper\" command is on your PATH or at " +
+                        "~/.local/bin/mlx_whisper (where pipx puts it). Check with:" + Environment.NewLine +
+                        "    which mlx_whisper");
                     return;
                 }
 
@@ -4244,7 +4255,9 @@ public partial class SpeechToTextViewModel : ObservableObject
         if (engine is MlxWhisperMac && !isInstalled)
         {
             // pip-managed engine - Subtitle Edit cannot download it, so show install help instead.
-            EngineDownloadHint = "mlx-whisper not found - install it with: pip3 install mlx-whisper";
+            // Kept to one line here; the blocking dialog on transcribe explains the pipx/venv
+            // detection caveat in full (#12209).
+            EngineDownloadHint = "mlx-whisper not found - install with \"pip3 install mlx-whisper\", or ensure the \"mlx_whisper\" command is on your PATH";
             IsEngineDownloadButtonVisible = false;
             return;
         }


### PR DESCRIPTION
Fixes [#12209](https://github.com/SubtitleEdit/subtitleedit/issues/12209).

### Root cause

The MLX Whisper engine never looks for an `mlx_whisper` *binary* — it decides "installed?" by finding a `python3` that can `import mlx_whisper`, probing a fixed interpreter list (Homebrew, python.org framework, pyenv, system, PATH). The reporter installed via **pipx**, which puts the package in an isolated venv that none of those interpreters can import and exposes only the `mlx_whisper` console-script shim in `~/.local/bin`. Hence "not found" — and the reporter's workarounds couldn't help: symlinking the binary is irrelevant (SE doesn't look for it), and launching from a full-PATH shell doesn't help either, because even the PATH `python3` (Homebrew's) can't import the pipx-isolated package.

### Fix (option 1 from the issue analysis)

Add the one missing candidate that covers pipx, virtual-envs and conda together: read the **shebang** of an installed `mlx_whisper` shim — a console script starts with `#!/abs/path/to/that/env/bin/python`, i.e. the exact interpreter that can import the package. Shims are looked for at `~/.local/bin`, the Homebrew bins, and anywhere on `PATH`; the discovered interpreter is probed first. The `#!/usr/bin/env python3` form is ignored (it names no specific environment; the bare-PATH candidate already covers that).

### Also

- **Clearer "not found" message.** The dialog now explains that SE looks for a Python that can `import mlx_whisper` (not a binary), states the pipx/venv/conda caveat, and points at a concrete `which mlx_whisper` check — instead of telling a user who already installed it to `pip3 install` it again. The inline engine hint is shortened to match.
- **Docs.** MLX Whisper was undocumented; added it to `speech-to-text.md` (engine table + notes) and `third-party-components.md` (macOS install + how detection works).

### Verification

Built the UI project (clean). Exercised `GetShebangInterpreters()` in a standalone harness against a constructed pipx-style shim plus edge cases: it picked the rooted-`python` shebang, rejected the `#!/usr/bin/env python3` form, and skipped a non-script file without error. On the test Mac it also resolved a **real** installed `mlx_whisper` (`/Library/Frameworks/Python.framework/Versions/3.14/bin/mlx_whisper` → its `python3.14`) purely from the PATH shim.

Not independently verified on a live pipx install (no Apple-Silicon pipx environment on hand) — the pipx path is covered by the synthetic shim test, which mirrors pipx's shebang layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)