### PR TITLE
Add multi window support on macOS with Window menu and Dock integration

### DIFF
--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -69,6 +69,11 @@ public static class InitMenu
                     Command = vm.CommandFileNewKeepVideoCommand,
                     [!MenuItem.IsVisibleProperty] = new Binding(nameof(vm.IsVideoLoaded)),
                 },
+                new MenuItem
+                {
+                    Header = l.NewWindow,
+                    Command = vm.CommandFileNewWindowCommand,
+                },
                 new Separator(),
                 new MenuItem
                 {

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -78,6 +78,15 @@ public static class InitNativeMacMenu
     // Conditional/Toggle helpers register into it (UI thread only, build is synchronous).
     private static MenuState? _building;
 
+    // Windows-menu ownership: when MacWindowsMenuInterop manages to register our
+    // "Window" submenu as NSApplication.windowsMenu, AppKit populates it (and mirrors
+    // it into the Dock icon's menu), and we must never mutate it again, since changing
+    // the NativeMenu would rebuild the NSMenu and wipe AppKit's entries. Until the
+    // first registration attempt resolves, the menu stays empty; on failure the manual
+    // list below takes over.
+    private static bool _appKitOwnsWindowsMenu;
+    private static bool _windowsMenuInteropFailed;
+
     // ── App menu ─────────────────────────────────────────────────────────────
     // Called from Program.cs. Sets the "Subtitle Edit" app dropdown contents.
     // Avalonia also auto-appends the standard macOS items (Hide, Quit, etc.).
@@ -120,7 +129,24 @@ public static class InitNativeMacMenu
             window.Activated += (_, _) =>
             {
                 _active = state;
-                UpdateWindowMenus();
+
+                // Runs after Avalonia has installed this window's NSMenuBar. Success
+                // means AppKit owns the Window menu contents (and feeds the Dock's
+                // window list) from here on.
+                Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                {
+                    if (MacWindowsMenuInterop.TryRegisterWindowsMenu(
+                            Clean(Se.Language.Main.Menu.WindowTitle),
+                            _states.Select(menuState => menuState.Window).OfType<Window>()))
+                    {
+                        _appKitOwnsWindowsMenu = true;
+                    }
+                    else if (!_appKitOwnsWindowsMenu)
+                    {
+                        _windowsMenuInteropFailed = true;
+                        UpdateWindowMenus();
+                    }
+                }, Avalonia.Threading.DispatcherPriority.Background);
             };
             window.Closed += (_, _) =>
             {
@@ -429,6 +455,13 @@ public static class InitNativeMacMenu
     // refreshes titles, which change when a file is opened or saved).
     private static void UpdateWindowMenus()
     {
+        if (_appKitOwnsWindowsMenu || !_windowsMenuInteropFailed)
+        {
+            // AppKit populates the menu (and the Dock list) itself, or the first
+            // registration attempt has not resolved yet; either way, hands off.
+            return;
+        }
+
         foreach (var menuState in _states)
         {
             if (menuState.WindowListItem?.Menu is not NativeMenu menu)

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -36,27 +36,46 @@ namespace Nikse.SubtitleEdit.Features.Main.Layout;
 /// </summary>
 public static class InitNativeMacMenu
 {
-    private static readonly List<(Func<MainViewModel, IRelayCommand> GetCmd, NativeMenuItem Item)> _gestureItems = [];
-    // IsVisible maps directly to NSMenuItem.setHidden: via Avalonia's SetIsVisible vtable slot.
-    // IsEnabled has no equivalent vtable slot — it only reaches the native layer through the
-    // SetAction predicate, which macOS never calls for container items (submenu, no action).
-    // All items here were IsVisible bindings in InitMenu.cs, so IsVisible is the correct mapping.
-    private static readonly List<(NativeMenuItem Item, Func<MainViewModel, bool> IsVisible, string[] Props)> _visibilities = [];
-    private static readonly List<(NativeMenuItem Item, Func<MainViewModel, bool> IsChecked, string[] Props)> _toggles = [];
-    private static readonly List<(NativeMenuItem Item, Func<MainViewModel, string> GetHeader, string[] Props)> _dynamicHeaders = [];
-    private static PropertyChangedEventHandler? _handler;
+    /// <summary>
+    /// All state for one window's menu bar. With File &gt; New window there are several
+    /// editor windows at once, each with its own NSMenuBar (macOS shows the focused
+    /// window's menu) bound to its own MainViewModel, so nothing here can be app-global.
+    /// </summary>
+    private sealed class MenuState
+    {
+        public readonly List<(Func<MainViewModel, IRelayCommand> GetCmd, NativeMenuItem Item)> GestureItems = [];
+        // IsVisible maps directly to NSMenuItem.setHidden: via Avalonia's SetIsVisible vtable slot.
+        // IsEnabled has no equivalent vtable slot; it only reaches the native layer through the
+        // SetAction predicate, which macOS never calls for container items (submenu, no action).
+        // All items here were IsVisible bindings in InitMenu.cs, so IsVisible is the correct mapping.
+        public readonly List<(NativeMenuItem Item, Func<MainViewModel, bool> IsVisible, string[] Props)> Visibilities = [];
+        public readonly List<(NativeMenuItem Item, Func<MainViewModel, bool> IsChecked, string[] Props)> Toggles = [];
+        public readonly List<(NativeMenuItem Item, Func<MainViewModel, string> GetHeader, string[] Props)> DynamicHeaders = [];
+        public PropertyChangedEventHandler? Handler;
 
-    private static NativeMenuItem? _reopenItem;
-    private static NativeMenuItem? _pluginsItem;
-    private static NativeMenuItem? _audioTracksItem;
+        public NativeMenuItem? ReopenItem;
+        public NativeMenuItem? PluginsItem;
+        public NativeMenuItem? AudioTracksItem;
 
-    // The real VM instance — set by Sync(), used by all lazy click handlers.
-    // MainViewModel is AddTransient in DI, so GetService() returns a new instance;
-    // we must hold a reference to the specific instance that owns the main window.
-    private static MainViewModel? _vm;
+        // The real VM instance, set by Sync(), used by all lazy click handlers.
+        // MainViewModel is AddTransient in DI, so GetService() returns a new instance;
+        // we must hold a reference to the specific instance that owns this window.
+        public MainViewModel? Vm;
 
-    private static Window? _window;
-    private static NativeMenu? _root;
+        public Window? Window;
+        public NativeMenu? Root;
+    }
+
+    // One state per open editor window, in creation order.
+    private static readonly List<MenuState> _states = [];
+
+    // The state whose window was most recently activated; the app menu (About,
+    // Preferences: global, not per window) routes its commands here.
+    private static MenuState? _active;
+
+    // The state whose structure MakeStructure is currently building; the Item/
+    // Conditional/Toggle helpers register into it (UI thread only, build is synchronous).
+    private static MenuState? _building;
 
     // ── App menu ─────────────────────────────────────────────────────────────
     // Called from Program.cs. Sets the "Subtitle Edit" app dropdown contents.
@@ -90,12 +109,36 @@ public static class InitNativeMacMenu
 
     public static void MakeStructure(NativeMenu root, Window window)
     {
-        _root = root;
-        _window = window;
-        _gestureItems.Clear();
-        _visibilities.Clear();
-        _toggles.Clear();
-        _dynamicHeaders.Clear();
+        var state = _states.FirstOrDefault(s => ReferenceEquals(s.Window, window));
+        if (state == null)
+        {
+            state = new MenuState { Window = window };
+            _states.Add(state);
+            _active ??= state;
+
+            window.Activated += (_, _) => _active = state;
+            window.Closed += (_, _) =>
+            {
+                if (state.Vm != null && state.Handler != null)
+                {
+                    state.Vm.PropertyChanged -= state.Handler;
+                }
+
+                _states.Remove(state);
+                if (ReferenceEquals(_active, state))
+                {
+                    _active = _states.LastOrDefault();
+                }
+            };
+        }
+
+        state.Root = root;
+        state.GestureItems.Clear();
+        state.Visibilities.Clear();
+        state.Toggles.Clear();
+        state.DynamicHeaders.Clear();
+
+        _building = state;
 
         var l = Se.Language.Main.Menu;
 
@@ -116,8 +159,8 @@ public static class InitNativeMacMenu
         fileItems.Items.Add(Conditional(Clean(l.CloseTranslation), v => v.FileCloseTranslationCommand,
             v => v.ShowColumnOriginalText, nameof(MainViewModel.ShowColumnOriginalText)));
 
-        _reopenItem = new NativeMenuItem(Clean(l.Reopen)) { Menu = new NativeMenu() };
-        fileItems.Items.Add(_reopenItem);
+        state.ReopenItem = new NativeMenuItem(Clean(l.Reopen)) { Menu = new NativeMenu() };
+        fileItems.Items.Add(state.ReopenItem);
         fileItems.Items.Add(Item(Clean(l.RestoreAutoBackup), v => v.ShowRestoreAutoBackupCommand));
         fileItems.Items.Add(new NativeMenuItemSeparator());
         fileItems.Items.Add(Item(Clean(l.Save), v => v.CommandFileSaveCommand));
@@ -125,9 +168,9 @@ public static class InitNativeMacMenu
         fileItems.Items.Add(new NativeMenuItemSeparator());
 
         var filePropsItem = new NativeMenuItem(string.Empty);
-        filePropsItem.Click += (_, _) => GetVm()?.FilePropertiesShowCommand.Execute(null);
-        _dynamicHeaders.Add((filePropsItem, v => Clean(v.FilePropertiesText), [nameof(MainViewModel.FilePropertiesText)]));
-        _visibilities.Add((filePropsItem, v => v.IsFilePropertiesVisible, [nameof(MainViewModel.IsFilePropertiesVisible)]));
+        filePropsItem.Click += (_, _) => state.Vm?.FilePropertiesShowCommand.Execute(null);
+        state.DynamicHeaders.Add((filePropsItem, v => Clean(v.FilePropertiesText), [nameof(MainViewModel.FilePropertiesText)]));
+        state.Visibilities.Add((filePropsItem, v => v.IsFilePropertiesVisible, [nameof(MainViewModel.IsFilePropertiesVisible)]));
         fileItems.Items.Add(filePropsItem);
 
         fileItems.Items.Add(Item(Clean(l.OpenContainingFolder), v => v.OpenContainingFolderCommand));
@@ -229,7 +272,7 @@ public static class InitNativeMacMenu
         toolItems.Items.Add(Item(Clean(l.SplitSubtitle), v => v.ShowToolsSplitCommand));
 
         // ── Plugins ───────────────────────────────────────────────────────────
-        _pluginsItem = new NativeMenuItem(Clean(Se.Language.Plugins.Title)) { Menu = new NativeMenu() };
+        state.PluginsItem = new NativeMenuItem(Clean(Se.Language.Plugins.Title)) { Menu = new NativeMenu() };
 
         // ── Spell Check ───────────────────────────────────────────────────────
         var spellItems = new NativeMenu();
@@ -246,9 +289,9 @@ public static class InitNativeMacMenu
         videoItems.Items.Add(Item(Clean(l.OpenVideoFromUrl), v => v.ShowVideoOpenFromUrlCommand));
         videoItems.Items.Add(Item(Clean(l.CloseVideoFile), v => v.CommandVideoCloseCommand));
 
-        _audioTracksItem = new NativeMenuItem(Clean(l.AudioTracks)) { Menu = new NativeMenu() };
-        _visibilities.Add((_audioTracksItem, v => v.IsAudioTracksVisible, [nameof(MainViewModel.IsAudioTracksVisible)]));
-        videoItems.Items.Add(_audioTracksItem);
+        state.AudioTracksItem = new NativeMenuItem(Clean(l.AudioTracks)) { Menu = new NativeMenu() };
+        state.Visibilities.Add((state.AudioTracksItem, v => v.IsAudioTracksVisible, [nameof(MainViewModel.IsAudioTracksVisible)]));
+        videoItems.Items.Add(state.AudioTracksItem);
 
         videoItems.Items.Add(new NativeMenuItemSeparator());
         videoItems.Items.Add(Item(Clean(l.SpeechToText), v => v.ShowSpeechToTextWhisperCommand));
@@ -287,8 +330,8 @@ public static class InitNativeMacMenu
         // so the alphabetical sort below places this item with the other "S" entries instead of
         // floating it to the top while the dynamic-header binding waits for Sync(vm) to run.
         var setOffsetItem = new NativeMenuItem(Clean(l.SetVideoOffset));
-        setOffsetItem.Click += (_, _) => GetVm()?.ShowVideoSetOffsetCommand.Execute(null);
-        _dynamicHeaders.Add((setOffsetItem, v => Clean(v.SetVideoOffsetText), [nameof(MainViewModel.SetVideoOffsetText)]));
+        setOffsetItem.Click += (_, _) => state.Vm?.ShowVideoSetOffsetCommand.Execute(null);
+        state.DynamicHeaders.Add((setOffsetItem, v => Clean(v.SetVideoOffsetText), [nameof(MainViewModel.SetVideoOffsetText)]));
         videoMoreList.Add(setOffsetItem);
 
         videoMoreList.Add(Toggle(Clean(l.SmpteTiming), v => v.ToggleSmpteTimingCommand,
@@ -298,7 +341,7 @@ public static class InitNativeMacMenu
         foreach (var item in videoMoreList.OrderBy(i => i.Header?.TrimStart('_', ' ')))
             videoMoreItems.Items.Add(item);
         var videoMoreMenu = new NativeMenuItem(Clean(Se.Language.General.More)) { Menu = videoMoreItems };
-        _visibilities.Add((videoMoreMenu, v => v.IsVideoLoaded, [nameof(MainViewModel.IsVideoLoaded)]));
+        state.Visibilities.Add((videoMoreMenu, v => v.IsVideoLoaded, [nameof(MainViewModel.IsVideoLoaded)]));
         videoItems.Items.Add(videoMoreMenu);
 
         // ── Synchronization ───────────────────────────────────────────────────
@@ -346,13 +389,13 @@ public static class InitNativeMacMenu
         assaItems.Items.Add(new NativeMenuItemSeparator());
         assaItems.Items.Add(Item(Clean(l.FilterLayersForDisplayDotDotDot), v => v.ShowPickLayerFilterCommand));
         var assaMenu = new NativeMenuItem(Clean(l.AssaTools)) { Menu = assaItems };
-        _visibilities.Add((assaMenu, v => v.IsFormatAssa, [nameof(MainViewModel.IsFormatAssa)]));
+        state.Visibilities.Add((assaMenu, v => v.IsFormatAssa, [nameof(MainViewModel.IsFormatAssa)]));
 
         // ── Assemble ──────────────────────────────────────────────────────────
         root.Items.Add(new NativeMenuItem(Clean(l.File)) { Menu = fileItems });
         root.Items.Add(new NativeMenuItem(Clean(l.Edit)) { Menu = editItems });
         root.Items.Add(new NativeMenuItem(Clean(l.Tools)) { Menu = toolItems });
-        root.Items.Add(_pluginsItem);
+        root.Items.Add(state.PluginsItem);
         root.Items.Add(new NativeMenuItem(Clean(l.SpellCheckTitle)) { Menu = spellItems });
         root.Items.Add(new NativeMenuItem(Clean(l.Video)) { Menu = videoItems });
         root.Items.Add(new NativeMenuItem(Clean(l.Synchronization)) { Menu = syncItems });
@@ -360,18 +403,21 @@ public static class InitNativeMacMenu
         root.Items.Add(new NativeMenuItem(Clean(l.Options)) { Menu = optionsItems });
         root.Items.Add(new NativeMenuItem(Clean(l.HelpTitle)) { Menu = helpItems });
         root.Items.Add(assaMenu);
+
+        _building = null;
     }
 
     // Called from LoadLanguage to rebuild all menu strings after a language switch.
     public static void Rebuild(MainViewModel vm)
     {
-        if (_root == null || _window == null)
+        var state = StateFor(vm);
+        if (state?.Root == null || state.Window == null)
         {
             return;
         }
-        _root.Items.Clear();
-        MakeStructure(_root, _window);
-        NativeMenu.SetMenu(_window, _root);
+        state.Root.Items.Clear();
+        MakeStructure(state.Root, state.Window);
+        NativeMenu.SetMenu(state.Window, state.Root);
         if (Application.Current != null)
         {
             SetupAppMenu(Application.Current);
@@ -385,58 +431,68 @@ public static class InitNativeMacMenu
 
     public static void Sync(MainViewModel vm)
     {
-        if (_handler != null && _vm != null)
+        // Bind this VM to its own window's menu: the state already holding the VM (re-sync),
+        // else the state for the VM's window, else the newest still-unbound one.
+        var state = _states.FirstOrDefault(s => ReferenceEquals(s.Vm, vm))
+                    ?? _states.FirstOrDefault(s => ReferenceEquals(s.Window, vm.Window))
+                    ?? _states.LastOrDefault(s => s.Vm == null);
+        if (state == null)
         {
-            _vm.PropertyChanged -= _handler;
+            return;
         }
 
-        _vm = vm;
+        if (state.Handler != null && state.Vm != null)
+        {
+            state.Vm.PropertyChanged -= state.Handler;
+        }
 
-        vm.NativeMenuReopen = _reopenItem;
-        vm.NativeMenuPlugins = _pluginsItem;
-        vm.NativeMenuAudioTracks = _audioTracksItem;
+        state.Vm = vm;
+
+        vm.NativeMenuReopen = state.ReopenItem;
+        vm.NativeMenuPlugins = state.PluginsItem;
+        vm.NativeMenuAudioTracks = state.AudioTracksItem;
 
         var shortcuts = ShortcutsMain.GetUsedShortcuts(vm);
-        foreach (var (getCmd, item) in _gestureItems)
+        foreach (var (getCmd, item) in state.GestureItems)
             item.Gesture = FindGesture(getCmd(vm), shortcuts);
 
-        foreach (var (item, isVisible, _) in _visibilities)
+        foreach (var (item, isVisible, _) in state.Visibilities)
             item.IsVisible = isVisible(vm);
 
-        foreach (var (item, isChecked, _) in _toggles)
+        foreach (var (item, isChecked, _) in state.Toggles)
             item.IsChecked = isChecked(vm);
 
-        foreach (var (item, getHeader, _) in _dynamicHeaders)
+        foreach (var (item, getHeader, _) in state.DynamicHeaders)
             item.Header = getHeader(vm);
 
-        if (_pluginsItem != null)
+        if (state.PluginsItem != null)
         {
-            _pluginsItem.IsEnabled = Se.Settings.Appearance.ShowPluginsMenu;
+            state.PluginsItem.IsEnabled = Se.Settings.Appearance.ShowPluginsMenu;
         }
 
-        _handler = (s, e) =>
+        state.Handler = (s, e) =>
         {
             if (s is not MainViewModel v2 || e.PropertyName is null)
             {
                 return;
             }
-            foreach (var (item, isVisible, props) in _visibilities)
+            foreach (var (item, isVisible, props) in state.Visibilities)
                 if (props.Contains(e.PropertyName))
                 {
                     item.IsVisible = isVisible(v2);
                 }
-            foreach (var (item, isChecked, props) in _toggles)
+            foreach (var (item, isChecked, props) in state.Toggles)
                 if (props.Contains(e.PropertyName))
                 {
                     item.IsChecked = isChecked(v2);
                 }
-            foreach (var (item, getHeader, props) in _dynamicHeaders)
+            foreach (var (item, getHeader, props) in state.DynamicHeaders)
                 if (props.Contains(e.PropertyName))
                 {
                     item.Header = getHeader(v2);
                 }
         };
-        vm.PropertyChanged += _handler;
+        vm.PropertyChanged += state.Handler;
 
         UpdateRecentFiles(vm);
         UpdatePluginsMenu(vm);
@@ -559,23 +615,37 @@ public static class InitNativeMacMenu
 
     public static void UpdateShortcuts(MainViewModel vm)
     {
+        var state = StateFor(vm);
+        if (state == null)
+        {
+            return;
+        }
+
         var shortcuts = ShortcutsMain.GetUsedShortcuts(vm);
-        foreach (var (getCmd, item) in _gestureItems)
+        foreach (var (getCmd, item) in state.GestureItems)
             item.Gesture = FindGesture(getCmd(vm), shortcuts);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
-    private static MainViewModel? GetVm() => _vm;
+    private static MenuState? StateFor(MainViewModel vm) =>
+        _states.FirstOrDefault(s => ReferenceEquals(s.Vm, vm))
+        ?? _states.FirstOrDefault(s => ReferenceEquals(s.Window, vm.Window));
+
+    // The VM the app menu (About, Preferences: app-global, not per window) targets:
+    // the most recently activated window's, falling back to any bound one.
+    private static MainViewModel? GetVm() =>
+        _active?.Vm ?? _states.Select(s => s.Vm).FirstOrDefault(v => v != null);
 
     private static NativeMenuItem Item(string? header, Func<MainViewModel, IRelayCommand> getCmd)
     {
+        var state = _building!;
         var item = new NativeMenuItem(header ?? string.Empty);
-        item.Click += (_, _) => { var v = GetVm(); if (v != null)
+        item.Click += (_, _) => { var v = state.Vm; if (v != null)
         {
             getCmd(v).Execute(null);
         } };
-        _gestureItems.Add((getCmd, item));
+        state.GestureItems.Add((getCmd, item));
         return item;
     }
 
@@ -583,21 +653,22 @@ public static class InitNativeMacMenu
         Func<MainViewModel, bool> isVisible, params string[] propertyNames)
     {
         var item = Item(header, getCmd);
-        _visibilities.Add((item, isVisible, propertyNames));
+        _building!.Visibilities.Add((item, isVisible, propertyNames));
         return item;
     }
 
     private static NativeMenuItem Toggle(string? header, Func<MainViewModel, IRelayCommand> getCmd,
         Func<MainViewModel, bool> isChecked, params string[] propertyNames)
     {
+        var state = _building!;
         var item = new NativeMenuItem(header ?? string.Empty);
         item.ToggleType = MenuItemToggleType.CheckBox;
-        item.Click += (_, _) => { var v = GetVm(); if (v != null)
+        item.Click += (_, _) => { var v = state.Vm; if (v != null)
         {
             getCmd(v).Execute(null);
         } };
-        _toggles.Add((item, isChecked, propertyNames));
-        _gestureItems.Add((getCmd, item));
+        state.Toggles.Add((item, isChecked, propertyNames));
+        state.GestureItems.Add((getCmd, item));
         return item;
     }
 

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -104,6 +104,7 @@ public static class InitNativeMacMenu
         fileItems.Items.Add(Item(Clean(l.New), v => v.CommandFileNewCommand));
         fileItems.Items.Add(Conditional(Clean(l.NewKeepVideo), v => v.CommandFileNewKeepVideoCommand,
             v => v.IsVideoLoaded, nameof(MainViewModel.IsVideoLoaded)));
+        fileItems.Items.Add(Item(Clean(l.NewWindow), v => v.CommandFileNewWindowCommand));
         fileItems.Items.Add(new NativeMenuItemSeparator());
         fileItems.Items.Add(Item(Clean(l.Open), v => v.CommandFileOpenCommand));
         fileItems.Items.Add(Conditional(Clean(l.OpenKeepVideo), v => v.CommandFileOpenKeepVideoCommand,

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -56,6 +56,7 @@ public static class InitNativeMacMenu
         public NativeMenuItem? ReopenItem;
         public NativeMenuItem? PluginsItem;
         public NativeMenuItem? AudioTracksItem;
+        public NativeMenuItem? WindowListItem;
 
         // The real VM instance, set by Sync(), used by all lazy click handlers.
         // MainViewModel is AddTransient in DI, so GetService() returns a new instance;
@@ -116,7 +117,11 @@ public static class InitNativeMacMenu
             _states.Add(state);
             _active ??= state;
 
-            window.Activated += (_, _) => _active = state;
+            window.Activated += (_, _) =>
+            {
+                _active = state;
+                UpdateWindowMenus();
+            };
             window.Closed += (_, _) =>
             {
                 if (state.Vm != null && state.Handler != null)
@@ -129,6 +134,8 @@ public static class InitNativeMacMenu
                 {
                     _active = _states.LastOrDefault();
                 }
+
+                UpdateWindowMenus();
             };
         }
 
@@ -401,10 +408,54 @@ public static class InitNativeMacMenu
         root.Items.Add(new NativeMenuItem(Clean(l.Synchronization)) { Menu = syncItems });
         root.Items.Add(new NativeMenuItem(Clean(l.Translate)) { Menu = translateItems });
         root.Items.Add(new NativeMenuItem(Clean(l.Options)) { Menu = optionsItems });
+
+        // Window list: one entry per open editor window, checkmark on the active one.
+        // Avalonia cannot register an AppKit windows menu (which is what would also feed
+        // the Dock icon's window list), so this menu is the discoverable way to switch
+        // between the windows File > New window opens.
+        state.WindowListItem = new NativeMenuItem(Clean(l.WindowTitle)) { Menu = new NativeMenu() };
+        root.Items.Add(state.WindowListItem);
+
         root.Items.Add(new NativeMenuItem(Clean(l.HelpTitle)) { Menu = helpItems });
         root.Items.Add(assaMenu);
 
         _building = null;
+
+        UpdateWindowMenus();
+    }
+
+    // Rebuilds every window's "Window" menu so all menu bars list all open editor
+    // windows. Called when a window opens, closes, or is activated (activation also
+    // refreshes titles, which change when a file is opened or saved).
+    private static void UpdateWindowMenus()
+    {
+        foreach (var menuState in _states)
+        {
+            if (menuState.WindowListItem?.Menu is not NativeMenu menu)
+            {
+                continue;
+            }
+
+            menu.Items.Clear();
+            foreach (var other in _states)
+            {
+                var window = other.Window;
+                if (window == null)
+                {
+                    continue;
+                }
+
+                var title = string.IsNullOrWhiteSpace(window.Title) ? "Subtitle Edit" : window.Title;
+                var item = new NativeMenuItem(title)
+                {
+                    ToggleType = MenuItemToggleType.CheckBox,
+                    IsChecked = ReferenceEquals(other, _active),
+                };
+                var captured = window;
+                item.Click += (_, _) => captured.Activate();
+                menu.Items.Add(item);
+            }
+        }
     }
 
     // Called from LoadLanguage to rebuild all menu strings after a language switch.

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -146,6 +146,8 @@ public static class InitNativeMacMenu
                         _windowsMenuInteropFailed = true;
                         UpdateWindowMenus();
                     }
+
+                    InstallDockMenu();
                 }, Avalonia.Threading.DispatcherPriority.Background);
             };
             window.Closed += (_, _) =>
@@ -766,6 +768,28 @@ public static class InitNativeMacMenu
             }
         }
         return null;
+    }
+
+    private static bool _dockMenuInstalled;
+
+    /// <summary>
+    /// Adds a "New window" command to the Dock icon's context menu (like Finder's
+    /// "New Finder Window") via Avalonia's NativeDock attached property. AppKit
+    /// shows it above the standard Dock items (the window list, Options, Quit).
+    /// </summary>
+    private static void InstallDockMenu()
+    {
+        if (_dockMenuInstalled || Avalonia.Application.Current is not { } app)
+        {
+            return;
+        }
+
+        var newWindowItem = new NativeMenuItem(Clean(Se.Language.Main.Menu.NewWindow));
+        newWindowItem.Click += (_, _) => MainWindowFactory.OpenNewWindow();
+        var dockMenu = new NativeMenu();
+        dockMenu.Add(newWindowItem);
+        NativeDock.SetMenu(app, dockMenu);
+        _dockMenuInstalled = true;
     }
 
     private static string Clean(string? s) => s?.Replace("_", string.Empty) ?? string.Empty;

--- a/src/ui/Features/Main/Layout/MacWindowsMenuInterop.cs
+++ b/src/ui/Features/Main/Layout/MacWindowsMenuInterop.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Avalonia.Controls;
+
+namespace Nikse.SubtitleEdit.Features.Main.Layout;
+
+/// <summary>
+/// Registers the menu bar's "Window" submenu with AppKit as the application's windows
+/// menu (NSApplication.windowsMenu). Avalonia's NativeMenu API has no notion of a
+/// windows menu, and without one the Dock icon's context menu never lists the app's
+/// open windows. Once registered, AppKit itself keeps the submenu populated with
+/// every open window and mirrors that list into the Dock menu, which is the standard
+/// macOS behavior users expect from multi-window apps.
+///
+/// Uses the Objective-C runtime directly (objc_msgSend). Every entry point is
+/// defensive: any failure reports false and the caller keeps the manually populated
+/// window list from InitNativeMacMenu as the fallback, so the worst case is the
+/// pre-existing behavior.
+/// </summary>
+internal static class MacWindowsMenuInterop
+{
+    private const string LibObjC = "/usr/lib/libobjc.A.dylib";
+
+    [DllImport(LibObjC)]
+    private static extern IntPtr objc_getClass(string name);
+
+    [DllImport(LibObjC)]
+    private static extern IntPtr sel_registerName(string name);
+
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern IntPtr SendPtr(IntPtr receiver, IntPtr sel);
+
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern IntPtr SendPtrPtr(IntPtr receiver, IntPtr sel, IntPtr arg);
+
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern IntPtr SendPtrLong(IntPtr receiver, IntPtr sel, long arg);
+
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern long SendLong(IntPtr receiver, IntPtr sel);
+
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern IntPtr SendPtrUtf8(IntPtr receiver, IntPtr sel, string arg);
+
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern void SendVoidPtrPtrBool(IntPtr receiver, IntPtr sel, IntPtr arg1, IntPtr arg2, sbyte arg3);
+
+    private static readonly IntPtr SelSharedApplication = sel_registerName("sharedApplication");
+    private static readonly IntPtr SelMainMenu = sel_registerName("mainMenu");
+    private static readonly IntPtr SelNumberOfItems = sel_registerName("numberOfItems");
+    private static readonly IntPtr SelItemAtIndex = sel_registerName("itemAtIndex:");
+    private static readonly IntPtr SelTitle = sel_registerName("title");
+    private static readonly IntPtr SelUtf8String = sel_registerName("UTF8String");
+    private static readonly IntPtr SelSubmenu = sel_registerName("submenu");
+    private static readonly IntPtr SelSetWindowsMenu = sel_registerName("setWindowsMenu:");
+    private static readonly IntPtr SelWindowsMenu = sel_registerName("windowsMenu");
+    private static readonly IntPtr SelStringWithUtf8 = sel_registerName("stringWithUTF8String:");
+    private static readonly IntPtr SelAddWindowsItem = sel_registerName("addWindowsItem:title:filename:");
+
+    // The windows menus (one NSMenu per editor window's menu bar) already handed to
+    // AppKit, so re-activation of the same window skips the objc round trip.
+    private static readonly HashSet<IntPtr> _registeredMenus = [];
+
+    /// <summary>
+    /// Finds the top-level menu named <paramref name="windowMenuTitle"/> in the current
+    /// NSMenuBar, registers it as NSApplication.windowsMenu, and asks AppKit to list the
+    /// given already-open windows in it. Returns true when AppKit now owns the windows
+    /// menu (the caller should then leave its contents to AppKit).
+    /// </summary>
+    public static bool TryRegisterWindowsMenu(string windowMenuTitle, IEnumerable<Window> openWindows)
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return false;
+        }
+
+        try
+        {
+            var nsAppClass = objc_getClass("NSApplication");
+            if (nsAppClass == IntPtr.Zero)
+            {
+                return false;
+            }
+
+            var nsApp = SendPtr(nsAppClass, SelSharedApplication);
+            if (nsApp == IntPtr.Zero)
+            {
+                return false;
+            }
+
+            var mainMenu = SendPtr(nsApp, SelMainMenu);
+            if (mainMenu == IntPtr.Zero)
+            {
+                return false;
+            }
+
+            // Locate our "Window" item in the currently installed menu bar (each editor
+            // window has its own NSMenuBar, so this runs again per activation).
+            var submenu = IntPtr.Zero;
+            var count = SendLong(mainMenu, SelNumberOfItems);
+            for (long i = 0; i < count; i++)
+            {
+                var item = SendPtrLong(mainMenu, SelItemAtIndex, i);
+                if (item == IntPtr.Zero)
+                {
+                    continue;
+                }
+
+                var titlePtr = SendPtr(item, SelTitle);
+                var utf8 = titlePtr == IntPtr.Zero ? IntPtr.Zero : SendPtr(titlePtr, SelUtf8String);
+                var title = utf8 == IntPtr.Zero ? null : Marshal.PtrToStringUTF8(utf8);
+                if (string.Equals(title, windowMenuTitle, StringComparison.Ordinal))
+                {
+                    submenu = SendPtr(item, SelSubmenu);
+                    break;
+                }
+            }
+
+            if (submenu == IntPtr.Zero)
+            {
+                return false;
+            }
+
+            if (SendPtr(nsApp, SelWindowsMenu) != submenu)
+            {
+                SendPtrPtr(nsApp, SelSetWindowsMenu, submenu);
+                if (SendPtr(nsApp, SelWindowsMenu) != submenu)
+                {
+                    return false;
+                }
+            }
+
+            // AppKit adds windows that appear after registration by itself; windows that
+            // were already open need introducing once per menu.
+            if (_registeredMenus.Add(submenu))
+            {
+                var nsStringClass = objc_getClass("NSString");
+                foreach (var window in openWindows)
+                {
+                    var handle = window.TryGetPlatformHandle();
+                    if (handle == null || handle.Handle == IntPtr.Zero)
+                    {
+                        continue;
+                    }
+
+                    var title = string.IsNullOrWhiteSpace(window.Title) ? "Subtitle Edit" : window.Title;
+                    var nsTitle = SendPtrUtf8(nsStringClass, SelStringWithUtf8, title);
+                    if (nsTitle == IntPtr.Zero)
+                    {
+                        continue;
+                    }
+
+                    SendVoidPtrPtrBool(nsApp, SelAddWindowsItem, handle.Handle, nsTitle, 0);
+                }
+            }
+
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/ui/Features/Main/Layout/MainWindowFactory.cs
+++ b/src/ui/Features/Main/Layout/MainWindowFactory.cs
@@ -1,0 +1,90 @@
+using Avalonia.Controls;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+
+namespace Nikse.SubtitleEdit.Features.Main.Layout;
+
+/// <summary>
+/// Creates main editor windows. The primary window is created here at startup (via
+/// Program.SetupMainWindow) and File &gt; New window creates additional independent ones,
+/// all inside this same process so they stack under a single Dock/taskbar icon and show
+/// up in its window list. Every window hosts its own MainView + MainViewModel (both
+/// registered transient), so each has its own subtitle, video and undo history; on macOS
+/// each also gets its own NSMenuBar bound to its own view model (see InitNativeMacMenu).
+/// </summary>
+public static class MainWindowFactory
+{
+    public const string AppName = "Subtitle Edit";
+
+    // Open main editor windows. The process force-exits when the last one closes: under
+    // ShutdownMode.OnLastWindowClose a single stray helper window (e.g. a leaked
+    // non-taskbar "please wait" progress window) is enough to keep the app alive as an
+    // invisible background process holding file/folder handles (#12172). The window's own
+    // OnClosing has already saved settings and cleaned up by the time Closed fires, and
+    // Closed never fires on a cancelled (unsaved-changes) close, so exiting is safe.
+    private static int _openMainWindows;
+
+    public static Window Create(bool isPrimary)
+    {
+        var window = new Window
+        {
+            Title = AppName,
+            Name = "MainWindow",
+            Icon = UiUtil.GetSeIcon(),
+            MinWidth = 800,
+            MinHeight = 500,
+        };
+
+        // Build runs from the MainView constructor, so the host window is handed over via
+        // a static; each view model must own its actual window, not desktop.MainWindow.
+        MainView.NextHostWindow = window;
+        var mainView = new MainView();
+
+        // Always host MainView inside a LayoutTransformControl, even at scale 1.0.
+        // SetCurrentTheme() runs before this window exists, so the saved UI scale is
+        // applied here at creation. Pre-wrapping also means later scale changes only
+        // update the transform instead of swapping window.Content, which would
+        // reparent the video player's native HWND and freeze the UI.
+        window.Content = new LayoutTransformControl { Child = mainView };
+        UiTheme.ApplyScaleToWindow(window);
+
+        // Restore the saved position only for the primary window; extra windows opening
+        // exactly on top of it would hide that a new window appeared at all.
+        if (isPrimary && Se.Settings.General.RememberPositionAndSize)
+        {
+            UiUtil.RestoreWindowPosition(window);
+        }
+
+        // Full macOS menu bar (File, Edit, Tools, ...) per window: the NSMenuBar follows
+        // the focused window, so every editor window carries a menu bound to its own view
+        // model. NativeMenu.SetMenu(Application, ...) only controls the App menu dropdown;
+        // NativeMenu.SetMenu(Window, ...) calls avnWindow.SetMainMenu and builds the full
+        // NSMenuBar with separate top-level menus.
+        if (OperatingSystem.IsMacOS())
+        {
+            var menuBarRoot = new NativeMenu();
+            InitNativeMacMenu.MakeStructure(menuBarRoot, window);
+            NativeMenu.SetMenu(window, menuBarRoot);
+        }
+
+        _openMainWindows++;
+        window.Closed += (_, _) =>
+        {
+            _openMainWindows--;
+            if (_openMainWindows <= 0)
+            {
+                Environment.Exit(0);
+            }
+        };
+
+        return window;
+    }
+
+    /// <summary>File &gt; New window: opens another independent editor window.</summary>
+    public static void OpenNewWindow()
+    {
+        var window = Create(isPrimary: false);
+        window.Show();
+    }
+}

--- a/src/ui/Features/Main/MainView.cs
+++ b/src/ui/Features/Main/MainView.cs
@@ -22,6 +22,15 @@ public class MainView : ViewBase
 {
     private MainViewModel? _vm;
 
+    /// <summary>
+    /// The window that will host the next MainView. Set by MainWindowFactory right before
+    /// constructing the view (Build runs from the constructor, so it can't be passed in).
+    /// With File &gt; New window there can be several editor windows, and each view model
+    /// must own its actual host window, not desktop.MainWindow (always the first window),
+    /// for dialog owners and the Closing/Deactivated/Loaded hooks to target correctly.
+    /// </summary>
+    internal static Window? NextHostWindow;
+
     protected override object Build()
     {
         _vm = Locator.Services.GetRequiredService<MainViewModel>();
@@ -33,14 +42,17 @@ public class MainView : ViewBase
         _vm.MainView = this;
         DataContext = _vm;
 
-        if (Application.Current?.ApplicationLifetime is ClassicDesktopStyleApplicationLifetime desktop)
+        var hostWindow = NextHostWindow;
+        NextHostWindow = null;
+        if (hostWindow == null &&
+            Application.Current?.ApplicationLifetime is ClassicDesktopStyleApplicationLifetime desktop)
         {
-            _vm.Window = desktop.MainWindow;
-            if (_vm.Window == null)
-            {
-                throw new InvalidOperationException("Main window is not set in the application lifetime.");
-            }
+            hostWindow = desktop.MainWindow;
+        }
 
+        if (hostWindow != null)
+        {
+            _vm.Window = hostWindow;
             _vm.Window.Closing += _vm.OnClosing;
             _vm.Window.Deactivated += _vm.OnWindowDeactivated;
             _vm.Window.Loaded += (_, _) =>

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1697,31 +1697,14 @@ public partial class MainViewModel :
     [RelayCommand]
     private void CommandFileNewWindow()
     {
-        // Opens an independent extra instance (window) of Subtitle Edit. On macOS the Dock and
-        // Finder only ever activate the already-running instance, so unlike Windows/Linux there
-        // is no built-in way to get a second window; "open -n" is the supported way to launch
-        // one. On Windows/Linux, starting the executable again does the same thing.
+        // Opens another independent editor window inside this same process, so all windows
+        // stack under a single Dock/taskbar icon and appear in its window list (a second
+        // process would get its own Dock icon on macOS). Each window hosts its own
+        // MainView/MainViewModel (both transient), with its own subtitle, video and undo
+        // history; on macOS it also gets its own menu bar bound to its own view model.
         try
         {
-            var processPath = Environment.ProcessPath;
-            if (string.IsNullOrEmpty(processPath))
-            {
-                return;
-            }
-
-            if (OperatingSystem.IsMacOS())
-            {
-                // Resolve the .app bundle root (".../Subtitle Edit.app/Contents/MacOS/<exe>") so
-                // the new instance launches with its own proper Dock icon and activation.
-                var bundlePath = Path.GetFullPath(Path.Combine(processPath, "..", "..", ".."));
-                if (bundlePath.EndsWith(".app", StringComparison.OrdinalIgnoreCase) && Directory.Exists(bundlePath))
-                {
-                    Process.Start("open", new[] { "-n", bundlePath });
-                    return;
-                }
-            }
-
-            Process.Start(new ProcessStartInfo(processPath) { UseShellExecute = false });
+            Layout.MainWindowFactory.OpenNewWindow();
         }
         catch (Exception ex)
         {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1695,6 +1695,41 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private void CommandFileNewWindow()
+    {
+        // Opens an independent extra instance (window) of Subtitle Edit. On macOS the Dock and
+        // Finder only ever activate the already-running instance, so unlike Windows/Linux there
+        // is no built-in way to get a second window; "open -n" is the supported way to launch
+        // one. On Windows/Linux, starting the executable again does the same thing.
+        try
+        {
+            var processPath = Environment.ProcessPath;
+            if (string.IsNullOrEmpty(processPath))
+            {
+                return;
+            }
+
+            if (OperatingSystem.IsMacOS())
+            {
+                // Resolve the .app bundle root (".../Subtitle Edit.app/Contents/MacOS/<exe>") so
+                // the new instance launches with its own proper Dock icon and activation.
+                var bundlePath = Path.GetFullPath(Path.Combine(processPath, "..", "..", ".."));
+                if (bundlePath.EndsWith(".app", StringComparison.OrdinalIgnoreCase) && Directory.Exists(bundlePath))
+                {
+                    Process.Start("open", new[] { "-n", bundlePath });
+                    return;
+                }
+            }
+
+            Process.Start(new ProcessStartInfo(processPath) { UseShellExecute = false });
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "Open new window failed");
+        }
+    }
+
+    [RelayCommand]
     private async Task CommandFileNew()
     {
         var doContinue = await HasChangesContinue();

--- a/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
@@ -8,6 +8,7 @@ public class LanguageMainMenu
     public string New { get; set; }
     public string NewKeepVideo { get; set; }
     public string NewWindow { get; set; }
+    public string WindowTitle { get; set; }
     public string Open { get; set; }
     public string OpenKeepVideo { get; set; }
     public string OpenOriginal { get; set; }
@@ -146,6 +147,7 @@ public class LanguageMainMenu
         New = "_New";
         NewKeepVideo = "New (keep _video)";
         NewWindow = "New _window";
+        WindowTitle = "Window";
         Open = "_Open...";
         OpenKeepVideo = "Open (_keep video)...";
         OpenOriginal = "Open ori_ginal...";

--- a/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
 
 namespace Nikse.SubtitleEdit.Logic.Config.Language;
 
@@ -7,6 +7,7 @@ public class LanguageMainMenu
     public string File { get; set; }
     public string New { get; set; }
     public string NewKeepVideo { get; set; }
+    public string NewWindow { get; set; }
     public string Open { get; set; }
     public string OpenKeepVideo { get; set; }
     public string OpenOriginal { get; set; }
@@ -144,6 +145,7 @@ public class LanguageMainMenu
         File = "_File";
         New = "_New";
         NewKeepVideo = "New (keep _video)";
+        NewWindow = "New _window";
         Open = "_Open...";
         OpenKeepVideo = "Open (_keep video)...";
         OpenOriginal = "Open ori_ginal...";

--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -180,36 +180,25 @@ namespace Nikse.SubtitleEdit
                 if (HasBatchConvertUiArg(args))
                 {
                     SetupBatchConvertOnlyWindow(lifetime);
+
+                    // Force-terminate the process once the window closes. Under
+                    // ShutdownMode.OnLastWindowClose a single stray window is enough to keep the
+                    // app alive as an invisible background process - e.g. a leaked non-taskbar
+                    // "please wait" progress window or an undocked video/audio window. Such a
+                    // lingering process holds file/current-directory handles and locks the folder
+                    // it was working in, which the user then can't delete or move (#12172).
+                    // Editor windows get the same guarantee (counted across all windows, so
+                    // File > New window works) inside MainWindowFactory.
+                    if (lifetime.MainWindow != null)
+                    {
+                        lifetime.MainWindow.Closed += (_, _) => Environment.Exit(0);
+                    }
                 }
                 else
                 {
+                    // Window creation (content, scale, macOS menu bar, close-to-exit hook) lives
+                    // in MainWindowFactory, shared with File > New window's extra editor windows.
                     SetupMainWindow(lifetime);
-
-                    // Set the full macOS menu bar (File, Edit, Tools, …) on the Window.
-                    // NativeMenu.SetMenu(Application, …) only controls the App menu dropdown;
-                    // NativeMenu.SetMenu(Window, …) calls avnWindow.SetMainMenu and builds
-                    // the full NSMenuBar with separate top-level menus.
-                    if (OperatingSystem.IsMacOS() && lifetime.MainWindow != null)
-                    {
-                        var menuBarRoot = new NativeMenu();
-                        Nikse.SubtitleEdit.Features.Main.Layout.InitNativeMacMenu.MakeStructure(menuBarRoot, lifetime.MainWindow);
-                        NativeMenu.SetMenu(lifetime.MainWindow, menuBarRoot);
-                    }
-                }
-
-                // Force-terminate the process once the primary window closes. Under
-                // ShutdownMode.OnLastWindowClose a single stray window is enough to keep the app
-                // alive as an invisible background process - e.g. a leaked non-taskbar "please
-                // wait" progress window or an undocked video/audio window. Such a lingering process
-                // holds file/current-directory handles and locks the folder it was working in,
-                // which the user then can't delete or move (#12172). The main window's own
-                // OnClosing has already saved settings and run CleanUp() by the time Closed fires,
-                // and Closed never fires on a cancelled (unsaved-changes) close, so exiting here is
-                // safe and guarantees shutdown regardless of any window, native thread, or child
-                // handle still lingering.
-                if (lifetime.MainWindow != null)
-                {
-                    lifetime.MainWindow.Closed += (_, _) => Environment.Exit(0);
                 }
 
 #if DEBUG
@@ -378,30 +367,7 @@ namespace Nikse.SubtitleEdit
 
         private static void SetupMainWindow(ClassicDesktopStyleApplicationLifetime lifetime)
         {
-            lifetime.MainWindow = new Window
-            {
-                Title = AppName,
-                Name = "MainWindow",
-                Icon = UiUtil.GetSeIcon(),
-                MinWidth = 800,
-                MinHeight = 500,
-            };
-
-            var mainView = new MainView();
-
-            // Always host MainView inside a LayoutTransformControl, even at scale 1.0.
-            // SetCurrentTheme() runs before this window exists, so the saved UI scale is
-            // applied here at creation. Pre-wrapping also means later scale changes only
-            // update the transform instead of swapping window.Content, which would
-            // reparent the video player's native HWND and freeze the UI.
-            lifetime.MainWindow.Content = new LayoutTransformControl { Child = mainView };
-            UiTheme.ApplyScaleToWindow(lifetime.MainWindow);
-
-            // Restore window position before showing
-            if (Se.Settings.General.RememberPositionAndSize)
-            {
-                UiUtil.RestoreWindowPosition(lifetime.MainWindow);
-            }
+            lifetime.MainWindow = Nikse.SubtitleEdit.Features.Main.Layout.MainWindowFactory.Create(isPrimary: true);
 
             lifetime.Startup += (_, e) => ParseStartupArgs(e.Args);
         }


### PR DESCRIPTION
## Problem

On Windows you can open several Subtitle Edit windows; on macOS only one window per app was possible, and launching the app again just focused the existing instance. Mac users working on two subtitles at once had no good option.

## What changed

- **File > New window** opens an additional, fully independent editor window in the same process: own MainViewModel/MainView (both are transient in DI), own subtitle, own video player. Windows stack under a single Dock icon like native Mac apps, instead of spawning extra app instances with their own icons.
- **Per window menu bar**: each window gets its own native NSMenuBar wired to its own view model, so the menu always operates on the focused window. The existing menu state sync (gestures, visibilities, toggles, dynamic submenus) became per window state, keyed by the active window.
- **Window menu**: a standard macOS Window menu is added to the menu bar and registered with AppKit (`setWindowsMenu:`), so AppKit itself maintains the open window list with checkmarks, and mirrors it into the Dock icon's context menu, exactly like Finder or Safari.
- **Dock "New window" command**: the Dock icon's context menu also offers New window, via Avalonia's `NativeDock.Menu` attached property (whose native side implements `applicationDockMenu:`); AppKit shows it above the standard Dock entries.
- Closing the last window still exits the process (ShutdownMode.OnLastWindowClose plus the existing safety net), and the batch convert window path keeps its explicit exit.

## Testing

On macOS 15 (Apple Silicon):

- File > New window and Dock > New window both open an extra window; all windows share one Dock icon.
- The Window menu and the Dock menu list every open window and focus the chosen one; the active window carries the checkmark.
- Menus (including shortcuts, dynamic submenus, and toggles) follow the focused window.
- Closing windows one by one exits the app with the last one; no stray background process remains.
- Speech to text, video playback, and file open/save behave independently per window.

Screenshots of the Window menu and the Dock menu follow in a comment.
