### PR TITLE
Stream Python speech to text output live instead of after the process exits

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -3620,6 +3620,7 @@ public partial class SpeechToTextViewModel : ObservableObject
 
             mlxProcess.StartInfo.EnvironmentVariables["PYTHONIOENCODING"] = "utf-8";
             mlxProcess.StartInfo.EnvironmentVariables["PYTHONUTF8"] = "1";
+            mlxProcess.StartInfo.EnvironmentVariables["PYTHONUNBUFFERED"] = "1";
 
             if (dataReceivedHandler != null)
             {
@@ -3766,6 +3767,13 @@ public partial class SpeechToTextViewModel : ObservableObject
         {
             process.StartInfo.EnvironmentVariables["PYTHONIOENCODING"] = "utf-8";
             process.StartInfo.EnvironmentVariables["PYTHONUTF8"] = "1";
+
+            // Without a terminal attached, Python block-buffers stdout (~8 KB), so a
+            // Python-based engine's progress output (e.g. whisper-ctranslate2's --verbose
+            // segment lines) sits in the buffer until the process exits and the console
+            // log stays empty for the whole run, which reads as frozen. Unbuffered mode
+            // makes every line arrive as soon as it is printed.
+            process.StartInfo.EnvironmentVariables["PYTHONUNBUFFERED"] = "1";
         }
 
         if (dataReceivedHandler != null)


### PR DESCRIPTION
## Problem

Python based speech to text engines (Whisper CTranslate2, MLX Whisper) showed a completely empty console while transcribing; all output appeared at once when the process finished. A 45 minute file decodes for many minutes with a blank console, which reads as frozen, and several users assumed the engine was looping without transcribing.

## Cause and fix

Without a terminal attached, Python block buffers stdout (about 8 KB), so newline terminated progress lines sit in the buffer until the process exits. Running the same command in a terminal is line buffered, which is why the problem never reproduces there.

Verified against the shipped whisper-ctranslate2 bundle with output piped the same way Subtitle Edit reads it: without `PYTHONUNBUFFERED` the first line arrives only when the process ends; with it, lines arrive the moment they are printed.

The fix sets `PYTHONUNBUFFERED=1` wherever `PYTHONIOENCODING` is already set (the generic engine path and the MLX helper path), so all Python based engines stream their progress live.
