### PR TITLE
Fix speech to text add periods for non Latin punctuation

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessor.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessor.cs
@@ -193,6 +193,17 @@ namespace Nikse.SubtitleEdit.Core.AudioToText
                    !es.Contains("--one_word", StringComparison.OrdinalIgnoreCase);
         }
 
+        // Characters that already terminate a line, so no period should be appended.
+        // Includes Latin punctuation plus Arabic (\u061F ? \u060C , \u061B ;), Urdu
+        // full stop (\u06D4), ellipsis, CJK terminators, and closing quotes/brackets.
+        private static readonly char[] LineTerminationChars =
+            ".!?,:;)]}\"'\u061F\u060C\u061B\u06D4\u2026\u3002\uFF01\uFF1F\uFF0C\uFF1A\u3001\u00BB\u201D".ToCharArray();
+
+        private static bool EndsWithLineTerminationChar(string text)
+        {
+            return text.Length > 0 && LineTerminationChars.Contains(text[text.Length - 1]);
+        }
+
         public Subtitle AddPeriods(Subtitle inputSubtitle, string language)
         {
             if (IsNonStandardLineTerminationLanguage(language))
@@ -209,14 +220,7 @@ namespace Nikse.SubtitleEdit.Core.AudioToText
                 var paragraph = subtitle.Paragraphs[index];
                 var next = subtitle.Paragraphs[index + 1];
                 if (next.StartTime.TotalMilliseconds - paragraph.EndTime.TotalMilliseconds > SetPeriodIfDistanceToNextIsMoreThan &&
-                    !paragraph.Text.EndsWith('.') &&
-                    !paragraph.Text.EndsWith('!') &&
-                    !paragraph.Text.EndsWith('?') &&
-                    !paragraph.Text.EndsWith(',') &&
-                    !paragraph.Text.EndsWith(':') &&
-                    !paragraph.Text.EndsWith(')') &&
-                    !paragraph.Text.EndsWith(']') &&
-                    !paragraph.Text.EndsWith('}'))
+                    !EndsWithLineTerminationChar(paragraph.Text))
                 {
                     var gap = next.StartTime.TotalMilliseconds - paragraph.EndTime.TotalMilliseconds;
                     if (gap > SetPeriodIfDistanceToNextIsMoreThanAlways)
@@ -239,14 +243,7 @@ namespace Nikse.SubtitleEdit.Core.AudioToText
 
             var last = subtitle.GetParagraphOrDefault(subtitle.Paragraphs.Count - 1);
             if (last != null &&
-                !last.Text.EndsWith('.') &&
-                !last.Text.EndsWith('!') &&
-                !last.Text.EndsWith('?') &&
-                !last.Text.EndsWith(',') &&
-                !last.Text.EndsWith(':') &&
-                !last.Text.EndsWith(')') &&
-                !last.Text.EndsWith(']') &&
-                !last.Text.EndsWith('}'))
+                !EndsWithLineTerminationChar(last.Text))
             {
                 subtitle.Paragraphs[subtitle.Paragraphs.Count - 1].Text += ".";
             }


### PR DESCRIPTION
## Problem

The "add periods" step of speech to text post processing produced lines ending in "؟." and "،." in Arabic transcriptions: a Latin period appended right after an Arabic question mark or comma.

The step appends a period to a line followed by a speech gap unless the line already ends with punctuation, but the ending check only recognized Latin characters (period, exclamation mark, question mark, comma, colon, closing brackets). The Arabic question mark, Arabic comma, and similar non Latin terminators were treated as unterminated text. The same applies to Urdu, ellipsis, and fullwidth CJK punctuation.

This also explains why the doubling looked random: only lines followed by a long enough pause were affected, so back to back lines stayed clean while lines before a scene change got the extra period.

## Fix

Both ending checks (the paragraph loop and the final paragraph) now use one shared list of line terminating characters that additionally includes the Arabic question mark (U+061F), Arabic comma (U+060C), Arabic semicolon (U+061B), the Urdu full stop (U+06D4), the ellipsis, fullwidth CJK terminators, and closing quotes.

Verified on a 45 minute Arabic transcription where dozens of lines previously came out as "...؟." with post processing enabled; with the fix the same lines end in "؟" alone, and Latin language behavior is unchanged.
