### PR TITLE
Export image-based: keep the profile's Resolution (fix #12244)

### DIFF
--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
@@ -677,15 +677,17 @@ public partial class ExportImageBasedViewModel : ObservableObject
             _ = Task.Run(() =>
             {
                 var mediaInfo = FfmpegMediaInfo2.Parse(videoFileName);
-                if (mediaInfo?.Dimension is { Width: > 0, Height: > 0 })
+                if (mediaInfo?.Dimension is { Width: > 0, Height: > 0 } dimension)
                 {
-                    var resolutionItem = new ResolutionItem(string.Empty, mediaInfo.Dimension.Width,
-                        mediaInfo.Dimension.Height);
-
                     Dispatcher.UIThread.Post(() =>
                     {
-                        Resolutions.Insert(1, resolutionItem);
-                        SelectedResolution = resolutionItem;
+                        // Make the source video's resolution available in the combo, but do NOT
+                        // override a resolution the active profile already set - otherwise a loaded
+                        // video silently replaces the profile's resolution and, on close, overwrites
+                        // it (#12244). Only fall back to the video size when the profile left no
+                        // valid resolution selected.
+                        var item = EnsureResolutionItem(dimension.Width, dimension.Height);
+                        SelectedResolution ??= item;
                         _dirty = true;
                     });
                 }
@@ -897,12 +899,40 @@ public partial class ExportImageBasedViewModel : ObservableObject
         }
     }
 
+    /// <summary>
+    /// Returns the resolution item matching <paramref name="width"/> x <paramref name="height"/>,
+    /// inserting a custom item (just below the "pick from video" entry) when that exact size is not
+    /// already in the list. Matching on BOTH dimensions - not width alone - and materialising
+    /// non-preset sizes is what lets a profile's custom resolution (e.g. 1920x960) round-trip on
+    /// reopen instead of snapping to a same-width preset or the 1920x1080 default (#12244). Returns
+    /// null for non-positive sizes.
+    /// </summary>
+    private ResolutionItem? EnsureResolutionItem(int width, int height)
+    {
+        if (width <= 0 || height <= 0)
+        {
+            return null;
+        }
+
+        var existing = Resolutions.FirstOrDefault(r => r.Width == width && r.Height == height);
+        if (existing != null)
+        {
+            return existing;
+        }
+
+        var item = new ResolutionItem(string.Empty, width, height);
+        // Index 0 is the "Pick resolution from video..." entry; keep custom sizes right below it.
+        Resolutions.Insert(1, item);
+        return item;
+    }
+
     private void LoadProfile(object? v)
     {
         if (v is SeExportImagesProfile profile)
         {
             SelectedFontSize = (int)profile.FontSize;
-            SelectedResolution = Resolutions.FirstOrDefault(r => r.Width == profile.ScreenWidth);
+            SelectedResolution = EnsureResolutionItem(profile.ScreenWidth, profile.ScreenHeight)
+                                 ?? Resolutions.FirstOrDefault(r => r.Width == 1920);
             SelectedTopBottomMargin = profile.BottomTopMargin;
             SelectedLeftRightMargin = profile.LeftRightMargin;
             SelectedOutlineWidth = profile.OutlineWidth;


### PR DESCRIPTION
Fixes [#12244](https://github.com/SubtitleEdit/subtitleedit/issues/12244) — profiles in the "Export to … (Blu-ray sup)" dialog lost (or silently overwrote) their **Resolution** on reopen, while font size restored fine.

### Root cause — two compounding defects

1. **`LoadProfile` matched resolution by Width only, against presets only.** The save path writes both `ScreenWidth` and `ScreenHeight`, but the load matched `Resolutions.FirstOrDefault(r => r.Width == profile.ScreenWidth)`. A profile's custom resolution (UHD 3840×1920) has no preset with that height, so it snapped to the same-width preset (3840×2160) or, with no width match, to the 1920×1080 default. Font size round-trips by exact value — hence only the resolution seemed to "reset".

2. **`Initialize` force-selected the loaded video's resolution _after_ the profile was applied.** `ExportBluRaySup` passes the main window's video in, and `Initialize` asynchronously set `SelectedResolution` to the video's size, overriding the profile. Because `SaveProfile` runs on close, the video's size was then written back into the selected profile — corrupting it. This is what made the reporter's UHD profile display the HD source video's 1920×960.

### Fix

- Add `EnsureResolutionItem(width, height)` — matches on **both** dimensions and materialises a custom `ResolutionItem` (just below the "pick from video" entry) when the exact size isn't a preset, so any resolution round-trips.
- `LoadProfile` uses it, so custom resolutions restore exactly.
- `Initialize` now only makes the video's resolution _available_ in the combo and falls back to it **only when the profile left no valid resolution selected** (`SelectedResolution ??= item` instead of overwrite). A profile with a resolution always wins; the video can still be picked manually.

### Verification

Standalone harness reproducing the reported setup (HD 1920×960 + UHD 3840×1920 profiles, presets-only list, a loaded HD video) — 8/8 checks pass:
- UHD reopens as 3840×1920 (not the 3840×2160 preset);
- a loaded 1920×960 video does **not** override the UHD profile;
- the profile is still 3840×1920 after save-on-close (no corruption);
- a custom 1920×960 doesn't get shadowed by the 1920×1080 preset;
- in-session profile switching round-trips;
- standard presets and the video-as-fallback (when a profile has no resolution) still work.

Built the UI project clean. Not driven through the live GUI, but the affected logic is covered by the harness above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)