### PR TITLE
Make OCR word un-compositing fully optional (#12243)

### DIFF
--- a/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
@@ -363,10 +363,16 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
                     }
                 }
 
-                var autoSplitGuesses = UnknownWordGuesser.CreateGuessesFromLetters(result, _threeLetterIsoLanguageName);
-                if (autoSplitGuesses.Any())
+                // Heuristic (affix/particle/phonetic) splitting of merged words is un-compositing too, so
+                // it must obey the same "word split list" toggle - otherwise turning that off still left this
+                // path splitting words unconditionally, which over-corrects more than it fixes (#12243).
+                if (SpellCheckConfig.UseWordSplitList())
                 {
-                    guesses.AddRange(autoSplitGuesses);
+                    var autoSplitGuesses = UnknownWordGuesser.CreateGuessesFromLetters(result, _threeLetterIsoLanguageName);
+                    if (autoSplitGuesses.Any())
+                    {
+                        guesses.AddRange(autoSplitGuesses);
+                    }
                 }
 
                 foreach (var g in guesses)

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -619,6 +619,7 @@ public class SettingsPage : UserControl
             }),
             MakeCheckboxSetting(Se.Language.Options.Settings.SpellCheckEnglishTreatInApostropheAsIng, nameof(_vm.SpellCheckEnglishTreatInApostropheAsIng)),
             MakeCheckboxSetting(Se.Language.Options.Settings.OcrUseWordSplitList, nameof(_vm.OcrUseWordSplitList)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.OcrGuessUnknownWords, nameof(_vm.OcrGuessUnknownWords)),
             MakeCheckboxSetting(Se.Language.Options.Settings.SpeechToTextSelectedLinesPromptFirstTimeOnly, nameof(_vm.SpeechToTextSelectedLinesPromptFistTimeOnly)),
             MakeCheckboxSetting(Se.Language.Options.Settings.MultipleReplaceShowDotDotDotButtons, nameof(_vm.MultipleReplaceShowDotDotDotButtons)),
             MakeCheckboxSetting(Se.Language.Options.Settings.GridFocusTextboxAfterInsertNew, nameof(_vm.GridFocusTextboxAfterInsertNew)),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -167,6 +167,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<string> _splitOddNumberOfLinesActions;
     [ObservableProperty] private string _selectedSplitOddNumberOfLinesAction;
     [ObservableProperty] private bool _ocrUseWordSplitList;
+    [ObservableProperty] private bool _ocrGuessUnknownWords;
     [ObservableProperty] private bool _speechToTextSelectedLinesPromptFistTimeOnly;
     [ObservableProperty] private bool _multipleReplaceShowDotDotDotButtons;
     [ObservableProperty] private bool _gridFocusTextboxAfterInsertNew;
@@ -753,6 +754,7 @@ public partial class SettingsViewModel : ObservableObject
         SelectedSplitOddNumberOfLinesAction = MapFromSplitOddActionToLanguageCode(Se.Settings.Tools.SplitOddLinesAction);
         SelectedSpellCheckEngine = MapFromSpellCheckEngine(Se.Settings.SpellCheck.SpellCheckProvider);
         OcrUseWordSplitList = Se.Settings.Ocr.UseWordSplitList;
+        OcrGuessUnknownWords = Se.Settings.Ocr.DoTryToGuessUnknownWords;
         SpeechToTextSelectedLinesPromptFistTimeOnly = Se.Settings.Tools.SpeechToTextSelectedLinesPromptFirstTimeOnly;
         MultipleReplaceShowDotDotDotButtons = Se.Settings.Tools.MultipleReplaceShowDotDotDotButtons;
         GridFocusTextboxAfterInsertNew = Se.Settings.Tools.GridFocusTextboxAfterInsertNew;
@@ -1482,6 +1484,7 @@ public partial class SettingsViewModel : ObservableObject
         Se.Settings.Tools.SplitOddLinesAction = MapFromSplitOddActionTranslationToCode(SelectedSplitOddNumberOfLinesAction);
         Se.Settings.SpellCheck.SpellCheckProvider = MapFromUISpellCheckEngineToCode(SelectedSpellCheckEngine);
         Se.Settings.Ocr.UseWordSplitList = OcrUseWordSplitList;
+        Se.Settings.Ocr.DoTryToGuessUnknownWords = OcrGuessUnknownWords;
         Se.Settings.Tools.SpeechToTextSelectedLinesPromptFirstTimeOnly = SpeechToTextSelectedLinesPromptFistTimeOnly;
         Se.Settings.Tools.MultipleReplaceShowDotDotDotButtons = MultipleReplaceShowDotDotDotButtons;
         Se.Settings.Tools.GridFocusTextboxAfterInsertNew = GridFocusTextboxAfterInsertNew;

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonOcrErrors.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonOcrErrors.cs
@@ -46,10 +46,14 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 
             var fixAction = Language.FixText;
             var fixCount = 0;
+            // Honor the user's "try to guess unknown words" preference instead of forcing it on, so the
+            // aggressive unknown-word guessing/splitting can be turned off for this tool - matching the OCR
+            // window and SE 4 behavior (#12243).
+            var doTryToGuessUnknownWords = Se.Settings.Ocr.DoTryToGuessUnknownWords;
             for (var i = 0; i < subtitle.Paragraphs.Count; i++)
             {
                 var p = subtitle.Paragraphs[i];
-                var result = OcrFixEngine.FixOcrErrors(i, p.Text, true);
+                var result = OcrFixEngine.FixOcrErrors(i, p.Text, doTryToGuessUnknownWords);
                 var text = result.GetText();
                 if (text != p.Text)
                 {

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -299,6 +299,7 @@ public class LanguageSettings
     public string SplitOddLineActionWeightBottom { get; set; }
     public string SplitOddLinesAction { get; set; }
     public string OcrUseWordSplitList { get; set; }
+    public string OcrGuessUnknownWords { get; set; }
     public string SpeechToTextSelectedLinesPromptFirstTimeOnly { get; set; }
     public string MultipleReplaceShowDotDotDotButtons { get; set; }
     public string GridFocusTextboxAfterInsertNew { get; set; }
@@ -626,6 +627,7 @@ public class LanguageSettings
         SplitOddLineActionWeightBottom = "Weight bottom";
         SplitOddLinesAction = "Split odd lines action";
         OcrUseWordSplitList = "OCR: use word split list";
+        OcrGuessUnknownWords = "OCR: try to guess unknown words";
         SpeechToTextSelectedLinesPromptFirstTimeOnly = "Speech to text: selected lines, prompt for language/engine first time only";
         MultipleReplaceShowDotDotDotButtons = "Multiple replace: show context menu buttons";
         GridFocusTextboxAfterInsertNew = "Grid: focus text box after insert new subtitle";


### PR DESCRIPTION
Fixes #12243.

### Problem
In the "Fix common OCR errors" engine, merged words (e.g. `wehad` → `we had`) were split by **two** independent paths, but only one was gated by a setting:

| Path | Gated? |
|------|--------|
| Curated word-split list (`{iso}_WordSplitList.txt`) | ✅ "OCR: use word split list" |
| Heuristic `UnknownWordGuesser` (affix/particle/phonetic splitting) | ❌ ran unconditionally |

So even after disabling the word-split list, the aggressive heuristic splitter kept splitting words — "making more errors than it fixes," as the reporter put it, with no way to turn it off. This differs from SE 4, where the tool didn't force this behavior.

### Changes
1. **Gate the heuristic splitter** behind the existing `UseWordSplitList()` check, so the "OCR: use word split list" checkbox now disables *all* merged-word splitting. (`seconv` keeps `UseWordSplitList => true`, so CLI behavior is unchanged.)
2. **Stop hard-coding guess-unknown-words on** in the Fix-common-OCR-errors tool — it now honors `DoTryToGuessUnknownWords` (matching the OCR window and SE 4).
3. **Expose that preference** as a new "OCR: try to guess unknown words" checkbox in the Tools section of Settings, alongside "OCR: use word split list" (SE 4 had it there too).

Defaults are unchanged (both settings default on), so existing behavior is preserved for users who want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)