### PR TITLE
Waveform: stop the cursor immediately on every pause path

### DIFF
--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -275,8 +275,9 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             Attached.SetIcon(_buttonPlay, "fa-solid fa-play");
             _buttonPlay.Click += (_, _) =>
             {
+                var wasPlaying = _videoPlayerInstance.IsPlaying;
                 _videoPlayerInstance.PlayOrPause();
-                PlayPauseRequested?.Invoke();
+                PlayPauseRequested?.Invoke(wasPlaying);
             };
             _buttonPlay.Bind(Button.CommandProperty, new Binding
             {
@@ -589,8 +590,9 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
 
             if (ClickToTogglePlay)
             {
+                var wasPlaying = _videoPlayerInstance.IsPlaying;
                 _videoPlayerInstance.PlayOrPause();
-                PlayPauseRequested?.Invoke();
+                PlayPauseRequested?.Invoke(wasPlaying);
                 e.Handled = true;
             }
 
@@ -677,7 +679,14 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             e.Handled = true;
         }
 
-        public event Action? PlayPauseRequested;
+        /// <summary>
+        /// Raised when the user toggles playback via this control (toolbar button, click on the
+        /// video surface or <see cref="TogglePlayPause"/>). The argument is true when playback was
+        /// running, i.e. the request pauses. Captured before the toggle because the player's
+        /// IsPlaying lags the pause command (~100 ms for mpv), so owners can react on the request
+        /// itself — e.g. freeze the interpolated waveform cursor (issue #12233).
+        /// </summary>
+        public event Action<bool>? PlayPauseRequested;
         public event Action? StopRequested;
         public event Action? FullscreenRequested;
         public event Action? FullscreenCollapseRequested;
@@ -803,7 +812,9 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
 
         internal void TogglePlayPause()
         {
+            var wasPlaying = _videoPlayerInstance.IsPlaying;
             _videoPlayerInstance.PlayOrPause();
+            PlayPauseRequested?.Invoke(wasPlaying);
         }
 
         internal AudioTrackInfo? ToggleAudioTrack()

--- a/src/ui/Features/Main/Layout/InitVideoPlayer.cs
+++ b/src/ui/Features/Main/Layout/InitVideoPlayer.cs
@@ -79,6 +79,17 @@ public static class InitVideoPlayer
         control.VideoFileNamePointerPressed += vm.VideoPlayerControlPointerPressed;
         control.SurfacePointerPressed += (_, _) => vm.VideoPlayerAreaPointerPressed();
         control.UserSeeked += vm.OnVideoPlayerUserSeeked;
+        // Freeze the interpolated waveform cursor the instant a pause is requested from the
+        // player itself (toolbar button / click on the video); without this the cursor keeps
+        // gliding until mpv's IsPlaying flips ~100 ms later (issue #12233).
+        control.PlayPauseRequested += willPause =>
+        {
+            if (willPause)
+            {
+                vm.RequestPausePlayheadFreeze();
+            }
+        };
+        control.StopRequested += vm.OnVideoPlayerStopRequested;
 
         Grid.SetRow(control, 0);
         mainGrid.Children.Add(control);

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -356,6 +356,7 @@ public partial class MainViewModel :
     private bool _pauseRequested; // a pause command fired; freeze the cursor now, before mpv's IsPlaying flips
     private long _playheadPauseSettleTs; // when we last paused; briefly hold the estimate so it doesn't snap back
     private const double PlayheadPauseSettleMs = 300; // mpv's reported position lags ~100-200 ms after a pause
+    private const double PlayheadPausedEaseFactor = 0.25; // per-tick fraction for closing small paused-state gaps (~0.1 s converges in ~10 ticks / ~160 ms)
     private CancellationTokenSource _videoOpenTokenSource;
     private readonly HashSet<string> _waveformsBeingGenerated = new(StringComparer.OrdinalIgnoreCase);
     private readonly Lock _waveformsBeingGeneratedLock = new();
@@ -20437,11 +20438,21 @@ public partial class MainViewModel :
 
             // mpv has arrived (or we gave up waiting): resume normal tracking from the real position.
             _playheadSeekTarget = null;
-            _playheadEstimateSeconds = rawPosition;
             _playheadValid = true;
             _playheadLastRealSeconds = rawPosition;
             _playheadLastTimestamp = nowTimestamp;
-            return rawPosition;
+
+            if (vp.IsPlaying)
+            {
+                _playheadEstimateSeconds = rawPosition;
+                return rawPosition;
+            }
+
+            // Paused arrival (stop button / click-to-pause seeks): keep showing the pinned value
+            // and let the paused-branch easing below close the small arrival residual (up to the
+            // 0.15 s tolerance) over a few ticks — snapping here showed as a tiny cursor jump
+            // right after stopping.
+            return _playheadEstimateSeconds;
         }
 
         if (vp.IsPlaying && !_pauseRequested && _playheadValid && _playheadLastRealSeconds >= 0)
@@ -20538,7 +20549,20 @@ public partial class MainViewModel :
 
             if (!holdForPause)
             {
-                _playheadEstimateSeconds = rawPosition;
+                // Reconcile with mpv's settled position. Small gaps (the ~100 ms mpv keeps playing
+                // after a pause request, or a stop-pin's arrival tolerance) are eased over a few
+                // ticks instead of snapped — the snap showed as a tiny cursor jump shortly after
+                // pausing/stopping. Real discontinuities (seeks beyond the resync threshold) and
+                // sub-visible gaps still snap.
+                var gap = rawPosition - _playheadEstimateSeconds;
+                if (!_playheadValid || Math.Abs(gap) < 0.002 || Math.Abs(gap) >= PlayheadResyncThresholdSeconds)
+                {
+                    _playheadEstimateSeconds = rawPosition;
+                }
+                else
+                {
+                    _playheadEstimateSeconds += gap * PlayheadPausedEaseFactor;
+                }
             }
 
             _playheadValid = true;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1144,10 +1144,30 @@ public partial class MainViewModel :
 
     // Freeze the waveform cursor at its current spot the instant a pause is requested, instead of
     // letting it keep gliding for the ~100 ms until mpv's IsPlaying actually flips (#12033 follow-up).
-    private void RequestPausePlayheadFreeze()
+    // Internal so the video player control's own pause paths (toolbar button, click on the video
+    // surface) can trigger it too, via the PlayPauseRequested wiring in InitVideoPlayer (#12233).
+    internal void RequestPausePlayheadFreeze()
     {
         _pauseRequested = true;
         _playheadPauseSettleTs = Stopwatch.GetTimestamp();
+    }
+
+    // The player's Stop button pauses and seeks to 0; freeze the cursor immediately and pin it to
+    // the start so it jumps there at once instead of lingering until mpv reports the new position.
+    internal void OnVideoPlayerStopRequested()
+    {
+        RequestPausePlayheadFreeze();
+        PinPlayheadTo(0);
+    }
+
+    // Pause playback for actions that stay paused (dialogs, click-to-pause actions), freezing the
+    // interpolated waveform cursor at the same instant so it doesn't glide on after the pause
+    // (issue #12233). Play-again-immediately paths (PlayNext etc.) must NOT use this: they pin the
+    // playhead to the new position instead, and a lingering freeze would hold the cursor after Play.
+    private void PauseVideoAndFreezePlayhead(VideoPlayerControl vp)
+    {
+        RequestPausePlayheadFreeze();
+        vp.VideoPlayer.Pause();
     }
 
     [RelayCommand]
@@ -11684,13 +11704,23 @@ public partial class MainViewModel :
             return;
         }
 
-        control.VideoPlayer.Pause();
+        PauseVideoAndFreezePlayhead(control);
         var position = control.Position;
         var volume = control.Volume;
         var parent = (Control)control.Parent!;
 
         _fullScreenVideoPlayerControl = InitVideoPlayer.MakeVideoPlayer();
         _fullScreenVideoPlayerControl.IsFullScreen = true;
+        // The fullscreen player is created bare (not via MakeLayoutVideoPlayer), so wire the
+        // pause/stop cursor-freeze here as well (issue #12233).
+        _fullScreenVideoPlayerControl.PlayPauseRequested += willPause =>
+        {
+            if (willPause)
+            {
+                RequestPausePlayheadFreeze();
+            }
+        };
+        _fullScreenVideoPlayerControl.StopRequested += OnVideoPlayerStopRequested;
         var toggleKeys = Se.Settings.Shortcuts
             .FirstOrDefault(s => s.ActionName == nameof(VideoFullScreenCommand))?.Keys;
         var showMediaInfoKeys = Se.Settings.Shortcuts
@@ -14021,7 +14051,12 @@ public partial class MainViewModel :
         where TWindow : Window
         where TViewModel : class
     {
-        GetVideoPlayerControl()?.VideoPlayer.Pause();
+        var videoPlayerControl = GetVideoPlayerControl();
+        if (videoPlayerControl != null)
+        {
+            PauseVideoAndFreezePlayhead(videoPlayerControl);
+        }
+
         var result = await _windowService.ShowDialogAsync<TWindow, TViewModel>(owner ?? Window!, configureViewModel, configureWindow);
         _shortcutManager.ClearKeys();
         return result;
@@ -20654,8 +20689,9 @@ public partial class MainViewModel :
                         var p = _playSelectionItem.GetNextSubtitle(mediaPlayerSeconds);
                         if (p == null)
                         {
-                            vp.VideoPlayer.Pause();
+                            PauseVideoAndFreezePlayhead(vp);
                             vp.Position = _playSelectionItem.EndSeconds;
+                            PinPlayheadTo(_playSelectionItem.EndSeconds);
                             ResetPlaySelection();
                         }
                         else
@@ -21328,7 +21364,7 @@ public partial class MainViewModel :
 
             if (Se.Settings.General.SubtitleDoubleClickAction == SubtitleDoubleClickActionType.GoToSubtitleAndPauseAndFocusTextBox.ToString())
             {
-                vp.VideoPlayer.Pause();
+                PauseVideoAndFreezePlayhead(vp);
                 vp.Position = seconds;
                 AudioVisualizerCenterOnPositionIfNeeded(selectedItem, seconds);
                 FocusEditTextBox();
@@ -21345,7 +21381,7 @@ public partial class MainViewModel :
             }
 
             // SubtitleDoubleClickActionType.GoToSubtitleAndPause
-            vp.VideoPlayer.Pause();
+            PauseVideoAndFreezePlayhead(vp);
             vp.Position = seconds;
             AudioVisualizerCenterOnPositionIfNeeded(selectedItem, seconds);
         }
@@ -21444,7 +21480,7 @@ public partial class MainViewModel :
 
             if (Se.Settings.General.SubtitleSingleClickAction == SubtitleSingleClickActionType.GoToSubtitleAndPause.ToString())
             {
-                vp.VideoPlayer.Pause();
+                PauseVideoAndFreezePlayhead(vp);
                 vp.Position = seconds;
                 AudioVisualizerCenterOnPositionIfNeeded(selectedItem, seconds);
                 return;
@@ -21467,7 +21503,7 @@ public partial class MainViewModel :
 
             if (Se.Settings.General.SubtitleSingleClickAction == SubtitleSingleClickActionType.GoToSubtitleAndPauseAndFocusTextBox.ToString())
             {
-                vp.VideoPlayer.Pause();
+                PauseVideoAndFreezePlayhead(vp);
                 vp.Position = seconds;
                 AudioVisualizerCenterOnPositionIfNeeded(selectedItem, seconds);
                 FocusEditTextBox();
@@ -22304,7 +22340,7 @@ public partial class MainViewModel :
             switch (action)
             {
                 case WaveformSingleClickActionType.SetVideoPositionAndPauseAndSelectSubtitle:
-                    vp.VideoPlayer.Pause();
+                    PauseVideoAndFreezePlayhead(vp);
                     vp.Position = seconds;
                     if (e.Paragraph != null)
                     {
@@ -22317,7 +22353,7 @@ public partial class MainViewModel :
 
                     break;
                 case WaveformSingleClickActionType.SetVideopositionAndPauseAndSelectSubtitleAndCenter:
-                    vp.VideoPlayer.Pause();
+                    PauseVideoAndFreezePlayhead(vp);
                     vp.Position = seconds;
                     if (e.Paragraph != null)
                     {
@@ -22331,11 +22367,11 @@ public partial class MainViewModel :
 
                     break;
                 case WaveformSingleClickActionType.SetVideoPositionAndPause:
-                    vp.VideoPlayer.Pause();
+                    PauseVideoAndFreezePlayhead(vp);
                     vp.Position = seconds;
                     break;
                 case WaveformSingleClickActionType.SetVideopositionAndPauseAndCenter:
-                    vp.VideoPlayer.Pause();
+                    PauseVideoAndFreezePlayhead(vp);
                     vp.Position = seconds;
                     if (e.Paragraph != null)
                     {
@@ -22384,7 +22420,7 @@ public partial class MainViewModel :
 
                     break;
                 case WaveformDoubleClickActionType.Pause:
-                    vp.VideoPlayer.Pause();
+                    PauseVideoAndFreezePlayhead(vp);
                     break;
                 case WaveformDoubleClickActionType.Play:
                     vp.VideoPlayer.Play();


### PR DESCRIPTION
Fixes #12233

The #12033 follow-up froze the interpolated waveform cursor the instant a pause is requested, but only for the ViewModel command paths (spacebar / Pause shortcut). Pausing via the video player's own toolbar button or a click on the video surface bypassed it: those paths call `PlayOrPause()` directly inside `VideoPlayerControl`, and the `PlayPauseRequested` event had no subscribers. The cursor then kept gliding until mpv's polled `IsPlaying` flipped ~100 ms later, and any estimate-vs-mpv drift showed up as a late slide after the settle window — "cursor keeps moving after pausing".

### Changes

- `PlayPauseRequested` now carries intent (`wasPlaying`, captured **before** the toggle since mpv's `IsPlaying` lags the pause command) and is raised from the toolbar button, video-surface click and `TogglePlayPause`.
- `InitVideoPlayer.MakeLayoutVideoPlayer` wires it (docked + undocked players) to `RequestPausePlayheadFreeze`; the fullscreen player is wired at its creation site.
- The Stop button now freezes and pins the cursor to 0 immediately instead of lingering until mpv reports the new position.
- All pause-and-stay call sites in `MainViewModel` (dialog opening, subtitle single/double-click pause actions, waveform click pause actions, play-selection end) route through a `PauseVideoAndFreezePlayhead` helper. Transient pause-then-play paths (`PlayNext` etc.) keep pinning instead — a lingering freeze would hold the cursor for up to 300 ms after `Play()`.
- Small reconciles after pause/stop (the ~100 ms mpv keeps playing after a pause request, or the stop-pin's 0.15 s arrival tolerance) are eased over ~160 ms instead of snapped, removing the tiny cursor jump that remained after the settle window. Real seeks beyond the 0.5 s resync threshold still snap; the playing branch is unchanged.

Verified manually on macOS: pausing via the player toolbar button, clicking the video surface, and the stop button now stop the cursor on the click, with no residual glide or late jump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)