### PR TITLE
Multiple replace: import rules directly from an SE 4 Settings.xml

### DIFF
--- a/docs/features/edit.md
+++ b/docs/features/edit.md
@@ -84,7 +84,7 @@ Right-click a category node to open its context menu:
 - **New rule** — add a rule to this category
 - **Move up / Move down** — reorder categories
 - **Delete** — remove the category and all its rules
-- **Import** — load rules from a `.template` file (JSON or legacy SE4 XML) or a `.csv` file
+- **Import** — load rules from a `.template` file (JSON or legacy SE4 XML), a `.csv` file, or a Subtitle Edit 4 `Settings.xml` (its multiple replace groups are imported directly)
 - **Export** — save selected categories to a `.template` (JSON) or `.csv` file
 
 ### Managing rules
@@ -117,7 +117,7 @@ The expand/collapse buttons (`+` / `−`) above the tree expand or collapse all 
 
 ### Import / Export
 
-Rule sets are stored as JSON `.template` files and can be shared across installations. The export dialog lets you choose which categories to include. SE4-format XML files can also be imported.
+Rule sets are stored as JSON `.template` files and can be shared across installations. The export dialog lets you choose which categories to include. SE4-format XML files can also be imported — both rule files exported from Subtitle Edit 4 and a full Subtitle Edit 4 `Settings.xml` (found in `%AppData%\Subtitle Edit`, or next to `SubtitleEdit.exe` for portable installs), whose multiple replace groups are then imported.
 
 Rules can also be exported to and imported from **CSV** (choose the `.csv` type in the export/import dialog), which is convenient for editing rules in a spreadsheet or sharing them as a simple table.
 

--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
@@ -518,13 +518,13 @@ public partial class MultipleReplaceViewModel : ObservableObject
             return;
         }
 
-        var fileName = await _fileHelper.PickOpenFile(Window, Se.Language.Options.Settings.OpenRuleFile, "Replace rules", ".template", "CSV (comma separated)", ".csv");
+        var fileName = await _fileHelper.PickOpenFile(Window, Se.Language.Options.Settings.OpenRuleFile, "Replace rules", ".template;.xml", "CSV (comma separated)", ".csv");
         if (string.IsNullOrEmpty(fileName))
         {
             return;
         }
 
-        // import from json, SE4 xml or csv
+        // import from json, SE4 xml (exported rules or a full Settings.xml) or csv
         List<RuleTreeNode>? imported = null;
         try
         {
@@ -539,6 +539,10 @@ public partial class MultipleReplaceViewModel : ObservableObject
             else if (content.Contains("<MultipleSearchAndReplaceList>"))
             {
                 temp = Se4XmlImporter.ImportFromXml(content);
+            }
+            else if (content.Contains("<MultipleSearchAndReplaceGroups>"))
+            {
+                temp = Se4SettingsXmlReplaceImporter.ImportFromXmlAsImportExport(content);
             }
             else
             {

--- a/src/ui/Features/Edit/MultipleReplace/Se4SettingsXmlReplaceImporter.cs
+++ b/src/ui/Features/Edit/MultipleReplace/Se4SettingsXmlReplaceImporter.cs
@@ -1,3 +1,4 @@
+using Nikse.SubtitleEdit.Features.Options.Settings;
 using Nikse.SubtitleEdit.Logic.Config;
 using System.Collections.Generic;
 using System.Linq;
@@ -82,6 +83,33 @@ public static class Se4SettingsXmlReplaceImporter
         }
 
         return result;
+    }
+
+    // Same data in the shape the Multiple Replace import dialog works with, so the user can
+    // point the right-click Import directly at an SE 4 Settings.xml (issue #12225).
+    internal static CategoryImportExportItem? ImportFromXmlAsImportExport(string xml)
+    {
+        var categories = ImportFromXml(xml);
+        if (categories.Count == 0)
+        {
+            return null;
+        }
+
+        return new CategoryImportExportItem
+        {
+            Categories = categories.Select(c => new CategoryImportExportItem.RuleImportExportCategory
+            {
+                Name = c.Name,
+                Rules = c.Rules.Select(r => new CategoryImportExportItem.RuleImportExportItem
+                {
+                    Find = r.Find,
+                    ReplaceWith = r.ReplaceWith,
+                    Description = r.Description,
+                    IsActive = r.Active,
+                    Type = r.Type.ToString(),
+                }).ToList(),
+            }).ToList(),
+        };
     }
 
     private static string? LocalValue(XElement parent, params string[] names)

--- a/tests/UI/Features/Edit/Se4SettingsXmlReplaceImporterTests.cs
+++ b/tests/UI/Features/Edit/Se4SettingsXmlReplaceImporterTests.cs
@@ -93,4 +93,38 @@ public class Se4SettingsXmlReplaceImporterTests
     {
         Assert.Empty(Se4SettingsXmlReplaceImporter.ImportFromXml(xml));
     }
+
+    [Fact]
+    public void ImportFromXmlAsImportExport_ConvertsToImportDialogShape()
+    {
+        var item = Se4SettingsXmlReplaceImporter.ImportFromXmlAsImportExport(Se4SettingsXml);
+
+        Assert.NotNull(item);
+        var category = Assert.Single(item!.Categories!);
+        Assert.Equal("Fix OCR errors", category.Name);
+        Assert.NotNull(category.Rules);
+        Assert.Equal(2, category.Rules!.Count);
+        Assert.Equal("teh", category.Rules[0].Find);
+        Assert.Equal("CaseInsensitive", category.Rules[0].Type);
+        Assert.True(category.Rules[0].IsActive);
+        Assert.Equal("RegularExpression", category.Rules[1].Type);
+        Assert.False(category.Rules[1].IsActive);
+
+        // The dialog turns the item into tree nodes via Enum.Parse on the type
+        // string - make sure the whole conversion round-trips.
+        var nodes = item.RuleTreeNodeList();
+        Assert.NotNull(nodes);
+        var node = Assert.Single(nodes!);
+        Assert.Equal("Fix OCR errors", node.CategoryName);
+        Assert.NotNull(node.SubNodes);
+        Assert.Equal(2, node.SubNodes!.Count);
+        Assert.Equal(MultipleReplaceType.CaseInsensitive, node.SubNodes[0].Type);
+        Assert.Equal(MultipleReplaceType.RegularExpression, node.SubNodes[1].Type);
+    }
+
+    [Fact]
+    public void ImportFromXmlAsImportExport_ReturnsNullWhenNoGroups()
+    {
+        Assert.Null(Se4SettingsXmlReplaceImporter.ImportFromXmlAsImportExport("<Settings></Settings>"));
+    }
 }


### PR DESCRIPTION
Follow-up to #12225.

The right-click **Import** in Multiple Replace only offered `.template`/`.csv` in the file picker and only parsed the stand-alone SE 4 export shape (`<MultipleSearchAndReplaceList>`), so users migrating from SE 4 could not point it at their old `Settings.xml` — the `Ctrl+4` "Set up like Subtitle Edit 4" flow was the only path that read it.

### Changes

- The import file picker now also accepts `.xml`.
- Content containing `<MultipleSearchAndReplaceGroups>` (the `Settings.xml` shape) is routed through `Se4SettingsXmlReplaceImporter` — the same parser `Ctrl+4` uses — via a new conversion to the import dialog's `CategoryImportExportItem` shape. Exported SE 4 rule files (`<MultipleSearchAndReplaceList>`) keep going through `Se4XmlImporter` as before.
- Docs updated (`docs/features/edit.md`), including the default SE 4 `Settings.xml` locations.
- Unit tests for the new conversion, including the `Enum.Parse` round-trip the dialog performs when building tree nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)