### PR TITLE
Fix text box orientation in right to left translation mode

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1250,6 +1250,9 @@ public static partial class InitListViewAndEditBox
         // Right panel for text editing (show/duration is to the left)
         var textEditGrid = new Grid
         {
+            // RightToLeftHelper mirrors this grid by name so the current/original
+            // text boxes keep matching the mirrored subtitle grid columns.
+            Name = "SubtitleTextEditGrid",
             ColumnDefinitions = new ColumnDefinitions("*,*,Auto"),
             RowDefinitions = new RowDefinitions("Auto,*,Auto"),
         };

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -118,6 +118,7 @@ public static partial class InitListViewAndEditBox
         var notNullConverter = new NotNullConverter();
         var nullToOpacityConverter = new NullToOpacityConverter();
         var syntaxHighlightingConverter = new TextWithSubtitleSyntaxHighlightingConverter();
+        var textToFlowDirectionConverter = new TextToFlowDirectionConverter();
         vm.SubtitleDataGridSyntaxHighlighting = syntaxHighlightingConverter;
         // How the Text/Original cells fit their text to the window (feature #11590). Read once here;
         // the grid is rebuilt when settings are applied, so a changed mode takes effect then.
@@ -305,6 +306,7 @@ public static partial class InitListViewAndEditBox
                 {
                     VerticalAlignment = VerticalAlignment.Center,
                     [!TextBlock.InlinesProperty] = new Binding(nameof(SubtitleLineViewModel.Text)) { Converter = syntaxHighlightingConverter, Mode = BindingMode.OneWay },
+                    [!TextBlock.FlowDirectionProperty] = new Binding(nameof(SubtitleLineViewModel.Text)) { Converter = textToFlowDirectionConverter, Mode = BindingMode.OneWay },
                 };
                 SubtitleGridTextDisplayModeDisplay.ApplyTo(textBlock, gridTextDisplayMode);
 
@@ -336,6 +338,7 @@ public static partial class InitListViewAndEditBox
                 {
                     VerticalAlignment = VerticalAlignment.Center,
                     [!TextBlock.InlinesProperty] = new Binding(nameof(SubtitleLineViewModel.OriginalText)) { Converter = syntaxHighlightingConverter, Mode = BindingMode.OneWay },
+                    [!TextBlock.FlowDirectionProperty] = new Binding(nameof(SubtitleLineViewModel.OriginalText)) { Converter = textToFlowDirectionConverter, Mode = BindingMode.OneWay },
                 };
                 SubtitleGridTextDisplayModeDisplay.ApplyTo(textBlock, gridTextDisplayMode);
 
@@ -1736,6 +1739,7 @@ public static partial class InitListViewAndEditBox
             textBox.AddHandler(InputElement.PointerPressedEvent, (_, e) => vm.StoreTextEditorPointerArgs(e), RoutingStrategies.Tunnel);
 
             SetupMacContextMenuForTextBox(textBox, vm);
+            MainHelpers.RightToLeftHelper.FollowContentDirection(textBox);
 
             vm.EditTextBox = new TextBoxWrapper(textBox);
             return textBox;
@@ -1846,6 +1850,7 @@ public static partial class InitListViewAndEditBox
             }
 
             SetupMacContextMenuForTextBox(textBox, vm);
+            MainHelpers.RightToLeftHelper.FollowContentDirection(textBox);
 
             vm.EditTextBoxOriginal = new TextBoxWrapper(textBox);
             return textBox;

--- a/src/ui/Features/Main/Layout/TextEditorBindingHelper.cs
+++ b/src/ui/Features/Main/Layout/TextEditorBindingHelper.cs
@@ -5,6 +5,7 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using AvaloniaEdit;
 using Nikse.SubtitleEdit.Features.Shared.TextBoxUtils;
+using Nikse.SubtitleEdit.Logic.Config;
 
 namespace Nikse.SubtitleEdit.Features.Main.Layout;
 
@@ -157,6 +158,14 @@ public class TextEditorBindingHelper
         UpdateViewModelFromEditor();
         var routedEvent = _isOriginal ? OriginalTextChangedEvent : TextChangedEvent;
         _vm.SubtitleTextChanged(sender, new TextChangedEventArgs(routedEvent));
+
+        if (Se.Settings.Appearance.RightToLeft)
+        {
+            // Follow the content: an original subtitle in a left to right language
+            // stays readable next to a right to left working language and vice versa.
+            _textEditor.TextArea.FlowDirection = MainHelpers.RightToLeftHelper
+                .GetContentDirection(_textEditor.Text, FlowDirection.RightToLeft);
+        }
     }
 
     private void OnTextEditorTapped(object? sender, RoutedEventArgs e)

--- a/src/ui/Features/Main/Layout/TextEditorBindingHelper.cs
+++ b/src/ui/Features/Main/Layout/TextEditorBindingHelper.cs
@@ -159,13 +159,13 @@ public class TextEditorBindingHelper
         var routedEvent = _isOriginal ? OriginalTextChangedEvent : TextChangedEvent;
         _vm.SubtitleTextChanged(sender, new TextChangedEventArgs(routedEvent));
 
-        // Follow the content: an original subtitle in a left to right language
-        // stays readable next to a right to left working language and vice versa.
-        var requestedDirection = Se.Settings.Appearance.RightToLeft
-            ? FlowDirection.RightToLeft
-            : FlowDirection.LeftToRight;
-        _textEditor.TextArea.FlowDirection = MainHelpers.RightToLeftHelper
-            .GetContentDirection(_textEditor.Text, requestedDirection);
+        if (Se.Settings.Appearance.RightToLeft)
+        {
+            // Follow the content: an original subtitle in a left to right language
+            // stays readable next to a right to left working language and vice versa.
+            _textEditor.TextArea.FlowDirection = MainHelpers.RightToLeftHelper
+                .GetContentDirection(_textEditor.Text, FlowDirection.RightToLeft);
+        }
     }
 
     private void OnTextEditorTapped(object? sender, RoutedEventArgs e)

--- a/src/ui/Features/Main/Layout/TextEditorBindingHelper.cs
+++ b/src/ui/Features/Main/Layout/TextEditorBindingHelper.cs
@@ -159,13 +159,13 @@ public class TextEditorBindingHelper
         var routedEvent = _isOriginal ? OriginalTextChangedEvent : TextChangedEvent;
         _vm.SubtitleTextChanged(sender, new TextChangedEventArgs(routedEvent));
 
-        if (Se.Settings.Appearance.RightToLeft)
-        {
-            // Follow the content: an original subtitle in a left to right language
-            // stays readable next to a right to left working language and vice versa.
-            _textEditor.TextArea.FlowDirection = MainHelpers.RightToLeftHelper
-                .GetContentDirection(_textEditor.Text, FlowDirection.RightToLeft);
-        }
+        // Follow the content: an original subtitle in a left to right language
+        // stays readable next to a right to left working language and vice versa.
+        var requestedDirection = Se.Settings.Appearance.RightToLeft
+            ? FlowDirection.RightToLeft
+            : FlowDirection.LeftToRight;
+        _textEditor.TextArea.FlowDirection = MainHelpers.RightToLeftHelper
+            .GetContentDirection(_textEditor.Text, requestedDirection);
     }
 
     private void OnTextEditorTapped(object? sender, RoutedEventArgs e)

--- a/src/ui/Features/Main/MainHelpers/RightToLeftHelper.cs
+++ b/src/ui/Features/Main/MainHelpers/RightToLeftHelper.cs
@@ -5,6 +5,7 @@ using Avalonia.Media;
 using Avalonia.VisualTree;
 using AvaloniaEdit.Editing;
 using Nikse.SubtitleEdit.Controls;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic.Config;
 
 namespace Nikse.SubtitleEdit.Features.Main.MainHelpers;
@@ -25,6 +26,25 @@ internal static class RightToLeftHelper
     /// width binding travels with its definition object) and every child is
     /// remapped to the mirrored column index. Idempotent via the grid's Tag.
     /// </summary>
+    /// <summary>
+    /// In right to left mode a text control follows its content: text with right
+    /// to left letters (Arabic, Hebrew, and so on) stays right to left, text in a
+    /// left to right script (for example a Turkish or English original subtitle)
+    /// aligns left to right. Empty controls keep the requested direction so typing
+    /// in a right to left language starts on the correct side.
+    /// </summary>
+    internal static FlowDirection GetContentDirection(string? text, FlowDirection requested)
+    {
+        if (requested != FlowDirection.RightToLeft || string.IsNullOrWhiteSpace(text))
+        {
+            return requested;
+        }
+
+        return LanguageAutoDetect.ContainsRightToLeftLetter(text)
+            ? FlowDirection.RightToLeft
+            : FlowDirection.LeftToRight;
+    }
+
     private static void MirrorTextEditGrid(Grid grid, FlowDirection flowDirection)
     {
         var wantMirrored = flowDirection == FlowDirection.RightToLeft;
@@ -83,11 +103,11 @@ internal static class RightToLeftHelper
         }
         else if (visual is TextBox textBox)
         {
-            textBox.FlowDirection = flowDirection;
+            textBox.FlowDirection = GetContentDirection(textBox.Text, flowDirection);
         }
         else if (visual is TextArea textArea)
         {
-            textArea.FlowDirection = flowDirection;
+            textArea.FlowDirection = GetContentDirection(textArea.Document?.Text, flowDirection);
         }
 
         foreach (var child in visual.GetVisualChildren())

--- a/src/ui/Features/Main/MainHelpers/RightToLeftHelper.cs
+++ b/src/ui/Features/Main/MainHelpers/RightToLeftHelper.cs
@@ -19,14 +19,6 @@ internal static class RightToLeftHelper
     }
 
     /// <summary>
-    /// Mirrors the main text edit grid so the current and original text boxes keep
-    /// matching the mirrored subtitle grid columns (issue #12249). Setting
-    /// FlowDirection on a grid does not rearrange its children, so the columns are
-    /// swapped for real: the column definitions are reversed (the original column's
-    /// width binding travels with its definition object) and every child is
-    /// remapped to the mirrored column index. Idempotent via the grid's Tag.
-    /// </summary>
-    /// <summary>
     /// In right to left mode a text control follows its content: text with right
     /// to left letters (Arabic, Hebrew, and so on) stays right to left, text in a
     /// left to right script (for example a Turkish or English original subtitle)
@@ -63,6 +55,14 @@ internal static class RightToLeftHelper
         };
     }
 
+    /// <summary>
+    /// Mirrors the main text edit grid so the current and original text boxes keep
+    /// matching the mirrored subtitle grid columns (issue #12249). Setting
+    /// FlowDirection on a grid does not rearrange its children, so the columns are
+    /// swapped for real: the column definitions are reversed (the original column's
+    /// width binding travels with its definition object) and every child is
+    /// remapped to the mirrored column index. Idempotent via the grid's Tag.
+    /// </summary>
     private static void MirrorTextEditGrid(Grid grid, FlowDirection flowDirection)
     {
         var wantMirrored = flowDirection == FlowDirection.RightToLeft;

--- a/src/ui/Features/Main/MainHelpers/RightToLeftHelper.cs
+++ b/src/ui/Features/Main/MainHelpers/RightToLeftHelper.cs
@@ -42,6 +42,13 @@ internal static class RightToLeftHelper
         {
             dataGrid.FlowDirection = flowDirection;
         }
+        else if (visual is Grid grid && grid.Name == "SubtitleTextEditGrid")
+        {
+            // Mirror the edit area with the subtitle grid: the grid's Original
+            // column moves to the other side under right to left, and the
+            // original text box below must follow it (issue #12249).
+            grid.FlowDirection = flowDirection;
+        }
         else if (visual is TextBox textBox)
         {
             textBox.FlowDirection = flowDirection;

--- a/src/ui/Features/Main/MainHelpers/RightToLeftHelper.cs
+++ b/src/ui/Features/Main/MainHelpers/RightToLeftHelper.cs
@@ -35,7 +35,7 @@ internal static class RightToLeftHelper
     /// </summary>
     internal static FlowDirection GetContentDirection(string? text, FlowDirection requested)
     {
-        if (requested != FlowDirection.RightToLeft || string.IsNullOrWhiteSpace(text))
+        if (string.IsNullOrWhiteSpace(text))
         {
             return requested;
         }
@@ -56,9 +56,12 @@ internal static class RightToLeftHelper
     {
         textBox.PropertyChanged += (_, e) =>
         {
-            if (e.Property == TextBox.TextProperty && Se.Settings.Appearance.RightToLeft)
+            if (e.Property == TextBox.TextProperty)
             {
-                textBox.FlowDirection = GetContentDirection(textBox.Text, FlowDirection.RightToLeft);
+                var requested = Se.Settings.Appearance.RightToLeft
+                    ? FlowDirection.RightToLeft
+                    : FlowDirection.LeftToRight;
+                textBox.FlowDirection = GetContentDirection(textBox.Text, requested);
             }
         };
     }

--- a/src/ui/Features/Main/MainHelpers/RightToLeftHelper.cs
+++ b/src/ui/Features/Main/MainHelpers/RightToLeftHelper.cs
@@ -35,7 +35,7 @@ internal static class RightToLeftHelper
     /// </summary>
     internal static FlowDirection GetContentDirection(string? text, FlowDirection requested)
     {
-        if (string.IsNullOrWhiteSpace(text))
+        if (requested != FlowDirection.RightToLeft || string.IsNullOrWhiteSpace(text))
         {
             return requested;
         }
@@ -56,12 +56,9 @@ internal static class RightToLeftHelper
     {
         textBox.PropertyChanged += (_, e) =>
         {
-            if (e.Property == TextBox.TextProperty)
+            if (e.Property == TextBox.TextProperty && Se.Settings.Appearance.RightToLeft)
             {
-                var requested = Se.Settings.Appearance.RightToLeft
-                    ? FlowDirection.RightToLeft
-                    : FlowDirection.LeftToRight;
-                textBox.FlowDirection = GetContentDirection(textBox.Text, requested);
+                textBox.FlowDirection = GetContentDirection(textBox.Text, FlowDirection.RightToLeft);
             }
         };
     }

--- a/src/ui/Features/Main/MainHelpers/RightToLeftHelper.cs
+++ b/src/ui/Features/Main/MainHelpers/RightToLeftHelper.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia;
+﻿using System.Linq;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
 using Avalonia.VisualTree;
@@ -14,6 +15,40 @@ internal static class RightToLeftHelper
     {
         var flowDirection = Se.Settings.Appearance.RightToLeft ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
         SetFlowDirectionRecursive(window, flowDirection);
+    }
+
+    /// <summary>
+    /// Mirrors the main text edit grid so the current and original text boxes keep
+    /// matching the mirrored subtitle grid columns (issue #12249). Setting
+    /// FlowDirection on a grid does not rearrange its children, so the columns are
+    /// swapped for real: the column definitions are reversed (the original column's
+    /// width binding travels with its definition object) and every child is
+    /// remapped to the mirrored column index. Idempotent via the grid's Tag.
+    /// </summary>
+    private static void MirrorTextEditGrid(Grid grid, FlowDirection flowDirection)
+    {
+        var wantMirrored = flowDirection == FlowDirection.RightToLeft;
+        var isMirrored = Equals(grid.Tag, "mirrored");
+        if (wantMirrored == isMirrored)
+        {
+            return;
+        }
+
+        grid.Tag = wantMirrored ? "mirrored" : null;
+
+        var definitions = grid.ColumnDefinitions.ToList();
+        grid.ColumnDefinitions.Clear();
+        definitions.Reverse();
+        foreach (var definition in definitions)
+        {
+            grid.ColumnDefinitions.Add(definition);
+        }
+
+        var last = definitions.Count - 1;
+        foreach (var child in grid.Children)
+        {
+            Grid.SetColumn(child, last - Grid.GetColumn(child));
+        }
     }
 
     private static void SetFlowDirectionRecursive(Visual visual, FlowDirection flowDirection)
@@ -44,10 +79,7 @@ internal static class RightToLeftHelper
         }
         else if (visual is Grid grid && grid.Name == "SubtitleTextEditGrid")
         {
-            // Mirror the edit area with the subtitle grid: the grid's Original
-            // column moves to the other side under right to left, and the
-            // original text box below must follow it (issue #12249).
-            grid.FlowDirection = flowDirection;
+            MirrorTextEditGrid(grid, flowDirection);
         }
         else if (visual is TextBox textBox)
         {

--- a/src/ui/Features/Main/MainHelpers/RightToLeftHelper.cs
+++ b/src/ui/Features/Main/MainHelpers/RightToLeftHelper.cs
@@ -45,6 +45,24 @@ internal static class RightToLeftHelper
             : FlowDirection.LeftToRight;
     }
 
+    /// <summary>
+    /// Keeps a text box's flow direction following its content while right to left
+    /// mode is enabled: right to left content stays right to left, left to right
+    /// content (for example a Turkish original next to an Arabic working language)
+    /// aligns left to right. Attach once when the text box is created; text set
+    /// while right to left mode is off is left alone.
+    /// </summary>
+    internal static void FollowContentDirection(TextBox textBox)
+    {
+        textBox.PropertyChanged += (_, e) =>
+        {
+            if (e.Property == TextBox.TextProperty && Se.Settings.Appearance.RightToLeft)
+            {
+                textBox.FlowDirection = GetContentDirection(textBox.Text, FlowDirection.RightToLeft);
+            }
+        };
+    }
+
     private static void MirrorTextEditGrid(Grid grid, FlowDirection flowDirection)
     {
         var wantMirrored = flowDirection == FlowDirection.RightToLeft;

--- a/src/ui/Features/Main/MainHelpers/RightToLeftHelper.cs
+++ b/src/ui/Features/Main/MainHelpers/RightToLeftHelper.cs
@@ -89,6 +89,29 @@ internal static class RightToLeftHelper
         }
     }
 
+    /// <summary>
+    /// Re-runs the subtitle grid's cell bindings after the right to left mode
+    /// changed: the per line flow direction converter reads the setting, and
+    /// bindings do not re-evaluate on their own when a setting changes. Rebinding
+    /// the items source re-creates the rows; selection and scroll position are
+    /// restored.
+    /// </summary>
+    internal static void RefreshDataGridBindings(DataGrid? grid, System.Collections.IEnumerable? itemsSource, object? selected)
+    {
+        if (grid == null)
+        {
+            return;
+        }
+
+        grid.ItemsSource = null;
+        grid.ItemsSource = itemsSource;
+        if (selected != null)
+        {
+            grid.SelectedItem = selected;
+            grid.ScrollIntoView(selected, null);
+        }
+    }
+
     private static void SetFlowDirectionRecursive(Visual visual, FlowDirection flowDirection)
     {
         if (visual is ComboBox)

--- a/src/ui/Features/Main/MainHelpers/RightToLeftHelper.cs
+++ b/src/ui/Features/Main/MainHelpers/RightToLeftHelper.cs
@@ -19,15 +19,16 @@ internal static class RightToLeftHelper
     }
 
     /// <summary>
-    /// In right to left mode a text control follows its content: text with right
-    /// to left letters (Arabic, Hebrew, and so on) stays right to left, text in a
-    /// left to right script (for example a Turkish or English original subtitle)
-    /// aligns left to right. Empty controls keep the requested direction so typing
-    /// in a right to left language starts on the correct side.
+    /// A text control follows its content in either mode: text with right to left
+    /// letters (Arabic, Hebrew, and so on) flows right to left, text in a left to
+    /// right script (for example a Turkish or English original subtitle) flows
+    /// left to right. The layout itself still follows only the mode toggle; this
+    /// governs text direction inside a control. Empty controls keep the requested
+    /// direction so typing starts on the side matching the active mode.
     /// </summary>
     internal static FlowDirection GetContentDirection(string? text, FlowDirection requested)
     {
-        if (requested != FlowDirection.RightToLeft || string.IsNullOrWhiteSpace(text))
+        if (string.IsNullOrWhiteSpace(text))
         {
             return requested;
         }
@@ -48,9 +49,12 @@ internal static class RightToLeftHelper
     {
         textBox.PropertyChanged += (_, e) =>
         {
-            if (e.Property == TextBox.TextProperty && Se.Settings.Appearance.RightToLeft)
+            if (e.Property == TextBox.TextProperty)
             {
-                textBox.FlowDirection = GetContentDirection(textBox.Text, FlowDirection.RightToLeft);
+                var requested = Se.Settings.Appearance.RightToLeft
+                    ? FlowDirection.RightToLeft
+                    : FlowDirection.LeftToRight;
+                textBox.FlowDirection = GetContentDirection(textBox.Text, requested);
             }
         };
     }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -11065,6 +11065,7 @@ public partial class MainViewModel :
                 Se.Settings.Appearance.RightToLeft = !Se.Settings.Appearance.RightToLeft;
                 IsRightToLeftEnabled = Se.Settings.Appearance.RightToLeft;
                 RightToLeftHelper.SetRightToLeftForDataGridAndText(Window);
+                RightToLeftHelper.RefreshDataGridBindings(SubtitleGrid, Subtitles, SelectedSubtitle);
                 return;
             }
 

--- a/src/ui/Logic/ValueConverters/TextToFlowDirectionConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextToFlowDirectionConverter.cs
@@ -8,17 +8,18 @@ using System.Globalization;
 namespace Nikse.SubtitleEdit.Logic.ValueConverters;
 
 /// <summary>
-/// In right to left mode, gives a text presenter a left to right flow direction
-/// when its content is in a left to right script (for example a Turkish original
-/// subtitle next to an Arabic working language). In every other case the binding
-/// is left unset so the control keeps its inherited direction.
+/// Gives a text presenter the flow direction of its content in either mode: cells
+/// with right to left letters flow right to left (also as the original next to a
+/// left to right working language), cells in a left to right script flow left to
+/// right (also as the original next to a right to left working language). Empty
+/// cells follow the active mode.
 /// </summary>
 public class TextToFlowDirectionConverter : IValueConverter
 {
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         var rightToLeftMode = Se.Settings.Appearance.RightToLeft;
-        if (rightToLeftMode && value is string text && !string.IsNullOrWhiteSpace(text))
+        if (value is string text && !string.IsNullOrWhiteSpace(text))
         {
             return LanguageAutoDetect.ContainsRightToLeftLetter(text)
                 ? FlowDirection.RightToLeft

--- a/src/ui/Logic/ValueConverters/TextToFlowDirectionConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextToFlowDirectionConverter.cs
@@ -9,21 +9,21 @@ using System.Globalization;
 namespace Nikse.SubtitleEdit.Logic.ValueConverters;
 
 /// <summary>
-/// Gives a text presenter the flow direction of its content: text with right to
-/// left letters flows right to left even in left to right mode, and text in a
-/// left to right script (for example a Turkish original next to an Arabic
-/// working language) flows left to right even in right to left mode. Empty
-/// cells leave the binding unset so the control keeps its inherited direction.
+/// In right to left mode, gives a text presenter a left to right flow direction
+/// when its content is in a left to right script (for example a Turkish original
+/// subtitle next to an Arabic working language). In every other case the binding
+/// is left unset so the control keeps its inherited direction.
 /// </summary>
 public class TextToFlowDirectionConverter : IValueConverter
 {
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (value is string text && !string.IsNullOrWhiteSpace(text))
+        if (Se.Settings.Appearance.RightToLeft &&
+            value is string text &&
+            !string.IsNullOrWhiteSpace(text) &&
+            !LanguageAutoDetect.ContainsRightToLeftLetter(text))
         {
-            return LanguageAutoDetect.ContainsRightToLeftLetter(text)
-                ? FlowDirection.RightToLeft
-                : FlowDirection.LeftToRight;
+            return FlowDirection.LeftToRight;
         }
 
         return AvaloniaProperty.UnsetValue;

--- a/src/ui/Logic/ValueConverters/TextToFlowDirectionConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextToFlowDirectionConverter.cs
@@ -1,4 +1,3 @@
-using Avalonia;
 using Avalonia.Data.Converters;
 using Avalonia.Media;
 using Nikse.SubtitleEdit.Core.Common;
@@ -18,15 +17,19 @@ public class TextToFlowDirectionConverter : IValueConverter
 {
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (Se.Settings.Appearance.RightToLeft &&
-            value is string text &&
-            !string.IsNullOrWhiteSpace(text) &&
-            !LanguageAutoDetect.ContainsRightToLeftLetter(text))
+        var rightToLeftMode = Se.Settings.Appearance.RightToLeft;
+        if (rightToLeftMode && value is string text && !string.IsNullOrWhiteSpace(text))
         {
-            return FlowDirection.LeftToRight;
+            return LanguageAutoDetect.ContainsRightToLeftLetter(text)
+                ? FlowDirection.RightToLeft
+                : FlowDirection.LeftToRight;
         }
 
-        return AvaloniaProperty.UnsetValue;
+        // Always produce an explicit direction: a binding that yields UnsetValue
+        // does not fall back to the inherited direction but to the property
+        // default (left to right), which left right to left cells misaligned in
+        // right to left mode.
+        return rightToLeftMode ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/src/ui/Logic/ValueConverters/TextToFlowDirectionConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextToFlowDirectionConverter.cs
@@ -9,21 +9,21 @@ using System.Globalization;
 namespace Nikse.SubtitleEdit.Logic.ValueConverters;
 
 /// <summary>
-/// In right to left mode, gives a text presenter a left to right flow direction
-/// when its content is in a left to right script (for example a Turkish original
-/// subtitle next to an Arabic working language). In every other case the binding
-/// is left unset so the control keeps its inherited direction.
+/// Gives a text presenter the flow direction of its content: text with right to
+/// left letters flows right to left even in left to right mode, and text in a
+/// left to right script (for example a Turkish original next to an Arabic
+/// working language) flows left to right even in right to left mode. Empty
+/// cells leave the binding unset so the control keeps its inherited direction.
 /// </summary>
 public class TextToFlowDirectionConverter : IValueConverter
 {
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (Se.Settings.Appearance.RightToLeft &&
-            value is string text &&
-            !string.IsNullOrWhiteSpace(text) &&
-            !LanguageAutoDetect.ContainsRightToLeftLetter(text))
+        if (value is string text && !string.IsNullOrWhiteSpace(text))
         {
-            return FlowDirection.LeftToRight;
+            return LanguageAutoDetect.ContainsRightToLeftLetter(text)
+                ? FlowDirection.RightToLeft
+                : FlowDirection.LeftToRight;
         }
 
         return AvaloniaProperty.UnsetValue;

--- a/src/ui/Logic/ValueConverters/TextToFlowDirectionConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextToFlowDirectionConverter.cs
@@ -1,0 +1,36 @@
+using Avalonia;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Globalization;
+
+namespace Nikse.SubtitleEdit.Logic.ValueConverters;
+
+/// <summary>
+/// In right to left mode, gives a text presenter a left to right flow direction
+/// when its content is in a left to right script (for example a Turkish original
+/// subtitle next to an Arabic working language). In every other case the binding
+/// is left unset so the control keeps its inherited direction.
+/// </summary>
+public class TextToFlowDirectionConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (Se.Settings.Appearance.RightToLeft &&
+            value is string text &&
+            !string.IsNullOrWhiteSpace(text) &&
+            !LanguageAutoDetect.ContainsRightToLeftLetter(text))
+        {
+            return FlowDirection.LeftToRight;
+        }
+
+        return AvaloniaProperty.UnsetValue;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
Fixes #12249.

### Problem

With right to left mode enabled in translation mode, the subtitle grid and the text boxes below it no longer correspond. The right to left helper sets FlowDirection on the DataGrid, which mirrors the whole list, so the Original column renders on the left. The text edit area below is a plain grid (current text in the first column, original text in the second) that the helper never touched, so the two text boxes kept their left to right positions: Original column on the left, original text box on the right. Subtitle Edit 4 mirrored both together.

### Fix

Two parts, developed and verified iteratively on macOS with a Turkish and Arabic subtitle pair:

1. **Box positions follow the mirrored grid.** Setting FlowDirection on a plain grid turned out not to rearrange its children (only the DataGrid honors it for column order), so the text edit grid now carries a name and the right to left helper mirrors its columns for real: the column definitions are reversed (the original column's width binding travels with its definition object, so the collapse when no original is loaded keeps working) and every child is remapped to the mirrored column index. Idempotent through the grid's Tag, so repeated passes from the window open and toggle paths cannot double swap.

2. **Text direction follows the content; the layout follows the mode.** Right to left mode used to force every text control right to left (pushing a Turkish original under an Arabic working language to the wrong side of its box), and left to right mode forced everything left to right (pushing an Arabic original under a Turkish working language to the wrong side). The two edit text boxes (both the plain and the color tags variants) and the Text and Original text grid columns now detect their content through LanguageAutoDetect.ContainsRightToLeftLetter in either mode, so each language reads from its own side whatever the mode is; empty controls follow the active mode so typing starts on the expected side. The layout itself (column order, box positions) still changes only with the mode toggle, exactly like Subtitle Edit 4. Subtitle Edit 4 resolved box direction per file and only in right to left mode (FixRightToLeftDependingOnLanguage); resolving per line and in both modes came out of testing all four language arrangements. The boxes re-evaluate on every text change, the grid cells bind through a converter (producing explicit directions, since a binding that yields UnsetValue falls back to the property default rather than the inherited direction), and toggling the mode rebinds the grid so the cells update immediately.

3. **The mode is applied after every layout build.** The window level right to left pass runs when the window opens, but the main layout is built later (posted to the dispatcher after the view attaches), so starting the app with right to left mode already enabled walked a tree that did not contain the subtitle grid or the text boxes yet: the layout came up left to right and only looked correct after toggling the mode by hand. Switching layouts had the same effect, since the rebuilt controls start left to right. The pass is now re-applied after the deferred startup layout build, after a layout switch, and after the undocked video layout rebuild; it is idempotent (the grid mirror tracks its state, directions are recomputed from content), so repeated application is safe. Toggling the mode also rebinds the subtitle grid's items source so the per line converter picks up the new mode immediately.

### Scope

- Applies on toggle and on window open (both call sites share the helper).
- The right to left UI language path (whole window flow direction) is unchanged.
- Other windows are unaffected by the mirroring; the helper matches the edit grid by name. Text boxes elsewhere pick up content aware direction only through the existing recursive pass, which already touched them.
- In left to right mode the layout never changes; only text direction inside cells and boxes follows the content.

### Testing

Verified on macOS (Apple Silicon) with a Turkish and an Arabic subtitle in all four arrangements (each language as the working and as the original subtitle, in each mode), including starting the app with right to left mode already enabled from the previous session:

- Right to left mode: the original text box sits under the Original column exactly as in Subtitle Edit 4, the Turkish side reads from the left, the Arabic side from the right, in the grid and in the boxes.
- Left to right mode: layout unchanged; a right to left original next to a left to right working language reads from the right in its column and box, and files with only left to right content look exactly as before.
- Toggling back and forth restores each arrangement with no double swap; other windows are unchanged.

Screenshots for both cases are in the comments.
