### PR TITLE
Point sync via other: restore Apply and Find text buttons (#12262)

### DIFF
--- a/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherViewModel.cs
+++ b/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherViewModel.cs
@@ -7,6 +7,7 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Shared.FindText;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
@@ -40,6 +41,7 @@ public partial class PointSyncViaOtherViewModel : ObservableObject
     private readonly IWindowService _windowService;
 
     private string _videoFileName;
+    private List<SubtitleLineViewModel> _originalSubtitles;
 
     public PointSyncViaOtherViewModel(IFileHelper fileHelper, IWindowService windowService)
     {
@@ -53,12 +55,14 @@ public partial class PointSyncViaOtherViewModel : ObservableObject
         FileNameOther = string.Empty;
         _videoFileName = string.Empty;
         SyncedSubtitles = new List<SubtitleLineViewModel>();
+        _originalSubtitles = new List<SubtitleLineViewModel>();
     }
 
     public void Initialize(List<SubtitleLineViewModel> subtitles, string videoFileName, string fileName)
     {
         Subtitles.Clear();
         Subtitles.AddRange(subtitles);
+        _originalSubtitles = subtitles.Select(s => new SubtitleLineViewModel(s)).ToList();
         FileName = fileName;
         _videoFileName = videoFileName;
 
@@ -153,9 +157,64 @@ public partial class PointSyncViaOtherViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private void Apply()
+    {
+        if (SyncPoints.Count == 0)
+        {
+            return;
+        }
+
+        // Re-preview from the original timings so repeated Apply clicks don't stack.
+        var synced = PointSyncer.PointSync(_originalSubtitles, SyncPoints.ToList());
+        for (var i = 0; i < Subtitles.Count && i < synced.Count; i++)
+        {
+            Subtitles[i].StartTime = synced[i].StartTime;
+            Subtitles[i].EndTime = synced[i].EndTime;
+        }
+    }
+
+    [RelayCommand]
+    private async Task FindTextLeft()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var result = await _windowService.ShowDialogAsync<FindTextWindow, FindTextViewModel>(Window, vm =>
+        {
+            vm.Initialize(Subtitles.ToList(), string.Format(Se.Language.General.FindTextX, FileName));
+        });
+
+        if (result.OkPressed && result.SelectedSubtitle != null)
+        {
+            SelectedSubtitle = result.SelectedSubtitle;
+        }
+    }
+
+    [RelayCommand]
+    private async Task FindTextOther()
+    {
+        if (Window == null || Othersubtitles.Count == 0)
+        {
+            return;
+        }
+
+        var result = await _windowService.ShowDialogAsync<FindTextWindow, FindTextViewModel>(Window, vm =>
+        {
+            vm.Initialize(Othersubtitles.ToList(), string.Format(Se.Language.General.FindTextX, FileNameOther));
+        });
+
+        if (result.OkPressed && result.SelectedSubtitle != null)
+        {
+            SelectedOtherSubtitle = result.SelectedSubtitle;
+        }
+    }
+
+    [RelayCommand]
     private void Ok()
     {
-        SyncedSubtitles = PointSyncer.PointSync(Subtitles.ToList(), SyncPoints.ToList());
+        SyncedSubtitles = PointSyncer.PointSync(_originalSubtitles, SyncPoints.ToList());
         OkPressed = true;
         Close();
     }

--- a/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherWindow.cs
+++ b/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherWindow.cs
@@ -28,9 +28,10 @@ public class PointSyncViaOtherWindow : Window
         var controlView = MakeControlView(vm);
         var subtitleOtherView = MakeSubtitleOtherView(vm);
 
+        var buttonApply = UiUtil.MakeButton(Se.Language.General.Apply, vm.ApplyCommand).WithBindIsEnabled(nameof(vm.IsOkEnabled));
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand).WithBindIsEnabled(nameof(vm.IsOkEnabled));
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
-        var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+        var panelButtons = UiUtil.MakeButtonBar(buttonApply, buttonOk, buttonCancel);
 
         var grid = new Grid
         {
@@ -141,6 +142,19 @@ public class PointSyncViaOtherWindow : Window
         };
 
         var labelFileName = UiUtil.MakeLabel(string.Empty).WithBindText(vm, nameof(vm.FileName));
+        labelFileName.VerticalAlignment = VerticalAlignment.Center;
+        var buttonFindText = UiUtil.MakeButton(Se.Language.Sync.FindText, vm.FindTextLeftCommand);
+        buttonFindText.HorizontalAlignment = HorizontalAlignment.Right;
+        var panelHeader = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+        };
+        panelHeader.Add(labelFileName, 0, 0);
+        panelHeader.Add(buttonFindText, 0, 1);
 
         var fullTimeConverter = new TimeSpanToDisplayFullConverter();
         var shortTimeConverter = new TimeSpanToDisplayShortConverter();
@@ -184,7 +198,7 @@ public class PointSyncViaOtherWindow : Window
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle)));
 
-        grid.Add(labelFileName, 0);
+        grid.Add(panelHeader, 0);
         grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGrid), 1);
 
         return grid;
@@ -209,11 +223,25 @@ public class PointSyncViaOtherWindow : Window
 
         var buttonBrowseOther = UiUtil.MakeButtonBrowse(vm.BrowseOtherCommand);
         var labelOtherFileName = UiUtil.MakeLabel(string.Empty).WithBindText(vm, nameof(vm.FileNameOther));
+        labelOtherFileName.VerticalAlignment = VerticalAlignment.Center;
         var panelOtherBrowse = new StackPanel
         {
             Orientation = Orientation.Horizontal,
+            VerticalAlignment = VerticalAlignment.Center,
             Children = { buttonBrowseOther, labelOtherFileName },
         };
+        var buttonFindTextOther = UiUtil.MakeButton(Se.Language.Sync.FindText, vm.FindTextOtherCommand);
+        buttonFindTextOther.HorizontalAlignment = HorizontalAlignment.Right;
+        var panelOtherHeader = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+        };
+        panelOtherHeader.Add(panelOtherBrowse, 0, 0);
+        panelOtherHeader.Add(buttonFindTextOther, 0, 1);
 
         var fullTimeConverter = new TimeSpanToDisplayFullConverter();
         var shortTimeConverter = new TimeSpanToDisplayShortConverter();
@@ -257,7 +285,7 @@ public class PointSyncViaOtherWindow : Window
         };
         dataGridSubtitle.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedOtherSubtitle)));
 
-        grid.Add(panelOtherBrowse, 0);
+        grid.Add(panelOtherHeader, 0);
         grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGridSubtitle), 1);
 
         return grid;


### PR DESCRIPTION
Fixes #12262

The Avalonia **"Point sync via another subtitle…"** dialog was missing three controls that exist in SE 4:

- **Apply** button
- Two **"Find text…"** buttons (one per subtitle grid)

### Changes
- **Apply**: re-previews the synced timings in the left grid without closing the dialog. It recomputes from the *original* timings each time, so repeated Apply clicks don't stack. Enabled once at least one sync point exists.
- **OK**: now also syncs from the original snapshot instead of the live grid, so pressing OK after using Apply no longer double-applies the sync.
- **Find text**: added under each subtitle grid. Opens the shared `FindTextWindow` and selects the matching line — reusing the same pattern already used by Visual Sync (`FindTextLeft`/`FindTextRight`).

### Testing
- `dotnet build src/ui/UI.csproj` — succeeds, 0 warnings
- `dotnet test tests/UI/UITests.csproj --filter FullyQualifiedName~PointSync` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)