### PR TITLE
Fix message box appearing behind undocked audio visualizer (#12268)

### DIFF
--- a/src/ui/Features/Shared/MessageBox.cs
+++ b/src/ui/Features/Shared/MessageBox.cs
@@ -242,6 +242,12 @@ public class MessageBox : Window
         string? custom3 = null)
     {
         var msgBox = new MessageBox(title, message, buttons, icon, custom1, custom2, custom3);
+
+        // Keep the message box above undocked tool windows (audio visualizer / video player),
+        // which float on top of the main window via KeepTopmostWhileOwnerActive. Without this the
+        // message box opens behind them in undocked mode. (#12268)
+        WindowService.KeepTopmostWhileOwnerActive(msgBox, owner);
+
         return await msgBox.ShowDialog<MessageBoxResult>(owner);
     }
 


### PR DESCRIPTION
## Problem

Fixes #12268. When the audio visualizer is undocked, message boxes appear *behind* it instead of on top.

## Cause

The undocked audio visualizer (and video player) float on top of the main window via `WindowService.KeepTopmostWhileOwnerActive`, which sets `Topmost` while the owner or the tool window is active. Regular dialogs go through `WindowService.ShowDialogAsync`, which applies the same helper to the dialog so it stays above the floating tool windows (the #11971 fix).

But `MessageBox.Show` bypasses `WindowService` — it constructs the window and calls `ShowDialog(owner)` directly — so message boxes had no such protection and opened behind the undocked audio visualizer.

## Fix

Apply the same `KeepTopmostWhileOwnerActive(msgBox, owner)` call in `MessageBox.Show` before `ShowDialog`, matching how the Settings/Shortcuts dialogs are handled. Since every message box in the app funnels through this single static method, this is a systematic fix covering all message boxes at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)