### PR TITLE
Add right-to-left option to ASSA karaoke advanced effects (#12271)

### DIFF
--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/AssaApplyAdvancedEffectViewModel.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/AssaApplyAdvancedEffectViewModel.cs
@@ -7,6 +7,7 @@ using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
 using Nikse.SubtitleEdit.Controls.VideoPlayer;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Assa.AssaApplyAdvancedEffect.Effects;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Sync.VisualSync;
 using Nikse.SubtitleEdit.Logic;
@@ -97,6 +98,23 @@ public partial class AssaApplyAdvancedEffectViewModel : ObservableObject
         _firstSelectedIndex = _selectedSubtitleLines.Count > 0
             ? Paragraphs.IndexOf(Paragraphs.First(p => p.Subtitle.Id == _selectedSubtitleLines[0].Id))
             : 0;
+
+        // Default the karaoke effects to right-to-left when the subtitle text is a right-to-left
+        // language (Hebrew, Arabic, ...) so the highlight progresses in reading order. (#12271)
+        if (paragraphs.Any(p => LanguageAutoDetect.ContainsRightToLeftLetter(p.Text)))
+        {
+            foreach (var effect in OverrideTags)
+            {
+                if (effect is AdvancedEffectKaraoke karaoke)
+                {
+                    karaoke.RightToLeft = true;
+                }
+                else if (effect is AdvancedEffectFancyKaraoke fancyKaraoke)
+                {
+                    fancyKaraoke.RightToLeft = true;
+                }
+            }
+        }
 
         if (audioVisualizer == null || audioVisualizer.WavePeaks == null || audioVisualizer.WavePeaks.Peaks.Count == 0)
         {

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/AssaApplyAdvancedEffectWindow.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/AssaApplyAdvancedEffectWindow.cs
@@ -75,11 +75,22 @@ public class AssaApplyAdvancedEffectWindow : Window
                     settingsStack.Children.Add(speedRow);
                     panel.Children.Add(settingsStack);
                 }
+                else if (item is AdvancedEffectKaraoke karaokeItem)
+                {
+                    var rightToLeftRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8, Margin = new Thickness(0, 6, 0, 0) };
+                    rightToLeftRow.Children.Add(new TextBlock { Text = Se.Language.Assa.AdvancedEffectKaraokeRightToLeft, VerticalAlignment = VerticalAlignment.Center, FontSize = 12 });
+                    rightToLeftRow.Children.Add(UiUtil.MakeCheckBox(karaokeItem, nameof(AdvancedEffectKaraoke.RightToLeft)));
+                    panel.Children.Add(rightToLeftRow);
+                }
                 else if (item is AdvancedEffectFancyKaraoke fancyKaraokeItem)
                 {
                     var autoDetectActiveWordRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8, Margin = new Thickness(0, 6, 0, 0) };
                     autoDetectActiveWordRow.Children.Add(new TextBlock { Text = Se.Language.Assa.AdvancedEffectFancyKaraokeAutoDetectActiveWord, VerticalAlignment = VerticalAlignment.Center, FontSize = 12 });
                     autoDetectActiveWordRow.Children.Add(UiUtil.MakeCheckBox(fancyKaraokeItem, nameof(AdvancedEffectFancyKaraoke.AutoDetectActiveWord)));
+
+                    var rightToLeftRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8, Margin = new Thickness(0, 4, 0, 0) };
+                    rightToLeftRow.Children.Add(new TextBlock { Text = Se.Language.Assa.AdvancedEffectKaraokeRightToLeft, VerticalAlignment = VerticalAlignment.Center, FontSize = 12 });
+                    rightToLeftRow.Children.Add(UiUtil.MakeCheckBox(fancyKaraokeItem, nameof(AdvancedEffectFancyKaraoke.RightToLeft)));
 
                     var activeGlowRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8, Margin = new Thickness(0, 4, 0, 0) };
                     activeGlowRow.Children.Add(new TextBlock { Text = Se.Language.Assa.AdvancedEffectFancyKaraokeGlow, VerticalAlignment = VerticalAlignment.Center, FontSize = 12 });
@@ -100,6 +111,7 @@ public class AssaApplyAdvancedEffectWindow : Window
 
                     var settingsStack = new StackPanel { Spacing = 2 };
                     settingsStack.Children.Add(autoDetectActiveWordRow);
+                    settingsStack.Children.Add(rightToLeftRow);
                     settingsStack.Children.Add(activeGlowRow);
                     settingsStack.Children.Add(activeColorRow);
                     settingsStack.Children.Add(inactiveColorRow);

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFancyKaraoke.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFancyKaraoke.cs
@@ -35,6 +35,13 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
     public bool AutoDetectActiveWord { get; set; } = false;
 
     /// <summary>
+    /// When true (and auto-sequencing by words), advance the active word from the end of the line
+    /// towards the start so the highlight progresses visually right-to-left. Auto-enabled for
+    /// right-to-left languages (Hebrew, Arabic, ...) where the default order runs backwards. (#12271)
+    /// </summary>
+    public bool RightToLeft { get; set; }
+
+    /// <summary>
     /// Glow color used for the active word's 3c (ASS BGR).
     /// </summary>
     public Color GlowColor { get; set; } = Color.FromRgb(0xFF, 0xDD, 0x00); // &H00DDFF& in ASS BGR
@@ -203,6 +210,10 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
                 sb.Append(posTags);
             }
 
+            // The active word for this step. In right-to-left mode advance from the last word
+            // towards the first so the highlight moves right-to-left visually.
+            var activeWordIndex = RightToLeft ? wordCount - 1 - w : w;
+
             string? currentColor = null;
             int localWordCounter = 0;
 
@@ -248,7 +259,7 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
 
                 // Non-whitespace token = a word/punctuation group
                 // Only the current word is active
-                var colorTag = localWordCounter == w ? activeTags : inactiveTags;
+                var colorTag = localWordCounter == activeWordIndex ? activeTags : inactiveTags;
                 if (colorTag != currentColor)
                 {
                     sb.Append(colorTag);

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectKaraoke.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectKaraoke.cs
@@ -22,6 +22,13 @@ public class AdvancedEffectKaraoke : IAdvancedEffectDisplay
     private const string HighlightColor = @"{\1c&HFFFFFF&}";
     private const string DimColor = @"{\1c&H808080&}";
 
+    /// <summary>
+    /// When true, reveal the characters from the end of the text towards the start so the
+    /// highlight progresses visually right-to-left. Auto-enabled for right-to-left languages
+    /// (Hebrew, Arabic, ...) where the default left-to-right reveal runs backwards. (#12271)
+    /// </summary>
+    public bool RightToLeft { get; set; }
+
     public override string ToString() => Name;
 
     public List<SubtitleLineViewModel> ApplyEffect(string header, List<SubtitleLineViewModel> subtitles, int width, int height, WavePeakData2? wavePeaks)
@@ -53,17 +60,21 @@ public class AdvancedEffectKaraoke : IAdvancedEffectDisplay
                     : subtitle.StartTime.Add(TimeSpan.FromMilliseconds((i + 1) * msPerChar));
                 line.StartTime = start;
                 line.EndTime = end;
-                line.Text = BuildKaraokeText(chars, i);
+                line.Text = BuildKaraokeText(chars, i, RightToLeft);
                 result.Add(line);
             }
         }
         return result;
     }
 
-    private static string BuildKaraokeText(char[] chars, int highlightUpTo)
+    private static string BuildKaraokeText(char[] chars, int step, bool rightToLeft)
     {
         var sb = new StringBuilder(chars.Length * 12);
         string? currentColor = null;
+
+        // step is 0-based, so step+1 characters are revealed. Left-to-right reveals the first
+        // step+1 characters; right-to-left reveals the last step+1 characters instead.
+        var revealFromEnd = chars.Length - 1 - step;
 
         for (var j = 0; j < chars.Length; j++)
         {
@@ -74,7 +85,8 @@ public class AdvancedEffectKaraoke : IAdvancedEffectDisplay
                 continue;
             }
 
-            var color = j <= highlightUpTo ? HighlightColor : DimColor;
+            var highlight = rightToLeft ? j >= revealFromEnd : j <= step;
+            var color = highlight ? HighlightColor : DimColor;
             if (color != currentColor)
             {
                 sb.Append(color);

--- a/src/ui/Logic/Config/Language/Assa/LanguageAssa.cs
+++ b/src/ui/Logic/Config/Language/Assa/LanguageAssa.cs
@@ -188,6 +188,7 @@ public class LanguageAssa
     public string AdvancedEffectHeartsDescription { get; set; }
     public string AdvancedEffectWordSpacing { get; set; }
     public string AdvancedEffectWordSpacingDescription { get; set; }
+    public string AdvancedEffectKaraokeRightToLeft { get; set; }
     public string AdvancedEffectFancyKaraokeAutoDetectActiveWord { get; set; }
     public string AdvancedEffectFancyKaraokeGlow { get; set; }
     public string AdvancedEffectFancyKaraokeActiveColor { get; set; }
@@ -401,6 +402,7 @@ public class LanguageAssa
         AdvancedEffectHeartsDescription = "Bezier-drawn hearts in three shapes rain gently from the top of the screen, tumbling and fading throughout each subtitle";
         AdvancedEffectWordSpacing = "Word spacing";
         AdvancedEffectWordSpacingDescription = "Increases spacing between words using the \\fsp tag for better readability";
+        AdvancedEffectKaraokeRightToLeft = "Right-to-left";
         AdvancedEffectFancyKaraokeAutoDetectActiveWord = "Auto-detect active word";
         AdvancedEffectFancyKaraokeGlow = "Active word glow";
         AdvancedEffectFancyKaraokeActiveColor = "Active color";


### PR DESCRIPTION
## Problem

Fixes #12271. The two karaoke ASSA advanced effects — character-based **Karaoke** and word-based **Karaoke - active word pop** — assign the highlight timing in logical text order. For right-to-left languages (Hebrew, Arabic) the highlight therefore progresses visually left-to-right, which is backwards for the reading direction. Existing RTL features only fix text layout, not the timing sequence.

## Change

Add a **Right-to-left** checkbox to both karaoke effects. When enabled, the highlight progression is reversed so the last character/word is highlighted first — matching right-to-left reading order.

- `AdvancedEffectKaraoke`: reveals the last `step+1` characters instead of the first.
- `AdvancedEffectFancyKaraoke` (auto word sequencing): advances the active word from the last word towards the first.

The checkbox is **auto-enabled** when the subtitle text is detected as a right-to-left language via `LanguageAutoDetect.ContainsRightToLeftLetter`, so RTL subtitles get the correct behavior by default while the user can still toggle it.

## Notes

Builds clean. The visual result depends on the user's RTL layout setup, so it's best confirmed by opening the effect on a Hebrew/Arabic subtitle in the running app — the checkbox is the requested control to get the progression direction right either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)