### PR TITLE
Fix broken French and Swedish spell-check dictionary URLs (#12267)

### DIFF
--- a/src/ui/Assets/HunspellDictionaries.json
+++ b/src/ui/Assets/HunspellDictionaries.json
@@ -244,8 +244,8 @@
     "EnglishName": "French",
     "NativeName": "Français",
     "Files": [
-      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/fr_FR/fr.aff",
-      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/fr_FR/fr.dic"
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/fr_FR/dictionaries/fr.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/fr_FR/dictionaries/fr.dic"
     ],
     "Description": "French spell checker (LibreOffice)"
   },
@@ -677,8 +677,8 @@
     "EnglishName": "Swedish",
     "NativeName": "Svenska",
     "Files": [
-      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sv_SE/sv_SE.aff",
-      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sv_SE/sv_SE.dic"
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sv_SE/dictionaries/sv_SE.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sv_SE/dictionaries/sv_SE.dic"
     ],
     "Description": "Swedish spell checker (LibreOffice)"
   },
@@ -686,8 +686,8 @@
     "EnglishName": "Swedish (Finland)",
     "NativeName": "Svenska (Finland)",
     "Files": [
-      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sv_SE/sv_FI.aff",
-      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sv_SE/sv_FI.dic"
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sv_SE/dictionaries/sv_FI.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sv_SE/dictionaries/sv_FI.dic"
     ],
     "Description": "Swedish (Finland) spell checker (LibreOffice)"
   },


### PR DESCRIPTION
## Problem

Fixes #12267. The French spell-check dictionary (and both Swedish variants) could not be downloaded — the download silently failed with "Download failed". The OCR dictionary for French worked because it uses a different source.

## Cause

The download list (`src/ui/Assets/HunspellDictionaries.json`) points at the LibreOffice dictionaries repo. LibreOffice reorganized the `fr_FR` and `sv_SE` folders, moving the `.aff`/`.dic` files into a `dictionaries/` subfolder. The old URLs now return **404**.

## Verification

I checked **all 89 dictionaries / 164 file URLs** in the list via parallel HTTP requests (following redirects). Exactly 3 dictionaries were broken, all for the same reason:

| Dictionary | Old path (404) | Fixed path |
|---|---|---|
| French | `fr_FR/fr.{aff,dic}` | `fr_FR/dictionaries/fr.{aff,dic}` |
| Swedish | `sv_SE/sv_SE.{aff,dic}` | `sv_SE/dictionaries/sv_SE.{aff,dic}` |
| Swedish (Finland) | `sv_SE/sv_FI.{aff,dic}` | `sv_SE/dictionaries/sv_FI.{aff,dic}` |

The other 86 dictionaries (161 URLs) all resolve fine — only `fr_FR` and `sv_SE` were reorganized upstream.

## Fix

Updated the 6 affected URLs to the new `dictionaries/` subfolder. After the change, all 164 URLs resolve (200/206) and the JSON remains valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)