### PR TITLE
Apply right to left mode after every layout build

### DIFF
--- a/src/ui/Features/Main/MainView.cs
+++ b/src/ui/Features/Main/MainView.cs
@@ -100,6 +100,16 @@ public class MainView : ViewBase
             Dispatcher.UIThread.Post(() =>
             {
                 InitLayout.MakeLayout(this, _vm, Se.Settings.General.LayoutNumber);
+
+                // The window level right to left pass runs when the window opens,
+                // which is before this deferred layout build, so the freshly built
+                // grid and text boxes would stay left to right until the mode is
+                // toggled. Re-apply after building.
+                if (Se.Settings.Appearance.RightToLeft && TopLevel.GetTopLevel(this) is Window rtlWindow)
+                {
+                    MainHelpers.RightToLeftHelper.SetRightToLeftForDataGridAndText(rtlWindow);
+                }
+
                 _vm.ContentGrid.InvalidateMeasure();
                 _vm.ContentGrid.InvalidateArrange();
                 Dispatcher.UIThread.Post(() => _vm.SubtitleGrid.Focus());

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -888,6 +888,12 @@ public partial class MainViewModel :
         var idx = SubtitleGrid.SelectedIndex;
         var savedAudioTrack = _audioTrack;
         Se.Settings.General.LayoutNumber = InitLayout.MakeLayout(MainView!, this, layoutNumber);
+        if (Se.Settings.Appearance.RightToLeft && Window != null)
+        {
+            // The rebuilt layout starts left to right; re-apply the mode.
+            RightToLeftHelper.SetRightToLeftForDataGridAndText(Window);
+        }
+
         SelectAndScrollToRow(Math.Max(0, idx));
         Dispatcher.UIThread.Post(() => SubtitleGrid.Focus());
         RefreshSubtitlePreview();
@@ -5765,6 +5771,12 @@ public partial class MainViewModel :
             });
 
             InitLayout.MakeLayout12KeepVideo(MainView!, this);
+            if (Se.Settings.Appearance.RightToLeft && Window != null)
+            {
+                // The rebuilt layout starts left to right; re-apply the mode.
+                RightToLeftHelper.SetRightToLeftForDataGridAndText(Window);
+            }
+
             RefreshSubtitlePreview();
         });
     }


### PR DESCRIPTION
Follow up to #12256 (the commit was pushed shortly after the merge, so it needs its own PR). Completes the right to left work from issue #12249.

### Problem

The window level right to left pass runs when the window opens, but the main layout is built later (posted to the dispatcher after the view attaches). Starting the app with right to left mode already enabled therefore walked a tree that did not yet contain the subtitle grid or the text boxes: the layout came up left to right, and only looked correct in sessions where the mode was toggled by hand afterwards. Switching layouts (View menu) had the same effect, since the rebuilt controls start left to right.

### Fix

Re-apply the right to left pass after every layout build: the deferred startup build, a layout switch, and the undocked video layout rebuild. All three call the existing helper, which is idempotent (the edit grid mirror tracks its state through its Tag, text directions are recomputed from content), so repeated application is safe. Left to right mode is unaffected; the calls are guarded by the setting.

### Testing

Verified on macOS (Apple Silicon): with right to left mode persisted from the previous session, the app now starts mirrored with no toggle needed, opening an original on top keeps the arrangement, and layout switching in right to left mode keeps the mirror. The four language arrangement screenshots on #12256 were taken with this commit included.
