### PR TITLE
Video OCR: add llama.cpp engine + tidy scan-area hint

### DIFF
--- a/src/ui/Features/Video/VideoOcr/VideoOcrEngineItem.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrEngineItem.cs
@@ -28,11 +28,12 @@ public class VideoOcrEngineItem
 
         if (OperatingSystem.IsWindows() || OperatingSystem.IsLinux())
         {
-            list.Add(new("Paddle OCR", OcrEngineType.PaddleOcrStandalone, "Local OCR engine (downloaded automatically) - fast and accurate"));
+            list.Add(new("Paddle OCR Standalone", OcrEngineType.PaddleOcrStandalone, "Local OCR engine (downloaded automatically) - fast and accurate"));
         }
 
         list.Add(new("Paddle OCR Python", OcrEngineType.PaddleOcrPython, "Local OCR engine via Python (requires \"pip install paddleocr\")"));
         list.Add(new("Ollama vision", OcrEngineType.Ollama, "Local vision model via Ollama - e.g. glm-ocr"));
+        list.Add(new("llama.cpp", OcrEngineType.LlamaCpp, "Local vision model via llama.cpp (downloaded automatically)"));
         list.Add(new("GLM API", OcrEngineType.Glm, "GLM vision model via Z.ai / bigmodel.cn API (requires API key)"));
 
         return list;

--- a/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
@@ -9,8 +9,10 @@ using Nikse.SubtitleEdit.Features.Ocr;
 using Nikse.SubtitleEdit.Features.Ocr.Download;
 using Nikse.SubtitleEdit.Features.Ocr.Engines;
 using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Translate;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using Nikse.SubtitleEdit.Logic.Media;
 using SkiaSharp;
 using System;
@@ -33,6 +35,7 @@ public partial class VideoOcrViewModel : ObservableObject
     [ObservableProperty] private bool _isPaddleEngine;
     [ObservableProperty] private bool _isOllamaEngine;
     [ObservableProperty] private bool _isGlmEngine;
+    [ObservableProperty] private bool _isLlamaCppEngine;
     [ObservableProperty] private ObservableCollection<OcrLanguage2> _paddleLanguages;
     [ObservableProperty] private OcrLanguage2? _selectedPaddleLanguage;
     [ObservableProperty] private string _ollamaUrl;
@@ -42,6 +45,10 @@ public partial class VideoOcrViewModel : ObservableObject
     [ObservableProperty] private string _glmModel;
     [ObservableProperty] private string _glmApiKey;
     [ObservableProperty] private string _glmLanguage;
+    [ObservableProperty] private ObservableCollection<LlamaCppModelDisplay> _llamaCppModels;
+    [ObservableProperty] private LlamaCppModelDisplay? _selectedLlamaCppModel;
+    [ObservableProperty] private string _llamaCppLanguage;
+    [ObservableProperty] private string _llamaCppServerButtonText;
     [ObservableProperty] private int _framesPerSecond;
     [ObservableProperty] private int _brightnessMinimum;
     [ObservableProperty] private int _textSimilarityPercent;
@@ -99,6 +106,9 @@ public partial class VideoOcrViewModel : ObservableObject
         GlmModel = string.Empty;
         GlmApiKey = string.Empty;
         GlmLanguage = string.Empty;
+        LlamaCppModels = new ObservableCollection<LlamaCppModelDisplay>();
+        LlamaCppLanguage = string.Empty;
+        LlamaCppServerButtonText = "Start server";
         ProgressText = string.Empty;
         PreviewPositionText = string.Empty;
         ScanAreaText = string.Empty;
@@ -191,6 +201,153 @@ public partial class VideoOcrViewModel : ObservableObject
         IsPaddleEngine = value.EngineType is OcrEngineType.PaddleOcrStandalone or OcrEngineType.PaddleOcrPython;
         IsOllamaEngine = value.EngineType == OcrEngineType.Ollama;
         IsGlmEngine = value.EngineType == OcrEngineType.Glm;
+        IsLlamaCppEngine = value.EngineType == OcrEngineType.LlamaCpp;
+
+        if (IsLlamaCppEngine && LlamaCppModels.Count == 0)
+        {
+            var savedModelName = Path.GetFileName(Se.Settings.Video.VideoOcr.LlamaCppModel);
+            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.OcrModels, savedModelName);
+        }
+    }
+
+    partial void OnSelectedLlamaCppModelChanged(LlamaCppModelDisplay? value)
+    {
+        if (value == null)
+        {
+            return;
+        }
+
+        Se.Settings.Video.VideoOcr.LlamaCppModel = LlamaCppServerManager.GetModelPath(value.Model.FileName);
+    }
+
+    private void UpdateLlamaCppServerButtonText()
+    {
+        LlamaCppServerButtonText = LlamaCppServerManager.IsServerRunning ? "Stop server" : "Start server";
+    }
+
+    [RelayCommand]
+    private async Task DownloadLlamaCpp()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var model = SelectedLlamaCppModel?.Model;
+        var forceModelDownload = false;
+        if (model != null && LlamaCppServerManager.IsModelInstalled(model))
+        {
+            var answer = await MessageBox.Show(
+                Window,
+                Se.Language.General.Download,
+                string.Format(Se.Language.Translate.XIsAlreadyDownloadedReDownload, model.DisplayName),
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Question);
+
+            if (answer != MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            forceModelDownload = true;
+        }
+
+        var downloaded = await LlamaCppDownloadHelper.DownloadAsync(Window, _windowService, model, forceModelDownload: forceModelDownload);
+        if (downloaded != null)
+        {
+            var selectName = string.IsNullOrEmpty(downloaded) ? model?.FileName : downloaded;
+            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.OcrModels, selectName);
+        }
+    }
+
+    [RelayCommand]
+    private async Task ToggleLlamaCppServer()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        if (LlamaCppServerManager.IsServerRunning)
+        {
+            LlamaCppServerManager.StopServer();
+            UpdateLlamaCppServerButtonText();
+            return;
+        }
+
+        await EnsureLlamaCppReady();
+        UpdateLlamaCppServerButtonText();
+    }
+
+    private async Task<bool> EnsureLlamaCppReady()
+    {
+        if (Window == null)
+        {
+            return false;
+        }
+
+        var model = SelectedLlamaCppModel?.Model;
+        if (model == null)
+        {
+            return false;
+        }
+
+        var engineInstalled = LlamaCppServerManager.IsEngineInstalled();
+        var modelInstalled = LlamaCppServerManager.IsModelInstalled(model);
+        if (!engineInstalled || !modelInstalled)
+        {
+            string message;
+            if (!engineInstalled && !modelInstalled)
+            {
+                message = "llama.cpp requires the llama-server engine and the selected OCR model to be downloaded. Download now?";
+            }
+            else if (!engineInstalled)
+            {
+                message = "llama.cpp requires the llama-server engine to be downloaded. Download now?";
+            }
+            else
+            {
+                message = "llama.cpp requires the selected OCR model to be downloaded. Download now?";
+            }
+
+            var answer = await MessageBox.Show(
+                Window,
+                Se.Language.General.Download,
+                message,
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Question);
+
+            if (answer != MessageBoxResult.Yes)
+            {
+                return false;
+            }
+
+            await LlamaCppDownloadHelper.DownloadAsync(Window, _windowService, model);
+            if (!LlamaCppServerManager.IsEngineInstalled() || !LlamaCppServerManager.IsModelInstalled(model))
+            {
+                return false;
+            }
+        }
+
+        SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.OcrModels, model.FileName);
+
+        try
+        {
+            await LlamaCppServerManager.EnsureServerRunningAsync(model, _cancellationTokenSource.Token);
+        }
+        catch (Exception ex)
+        {
+            await MessageBox.Show(
+                Window,
+                Se.Language.General.Error,
+                ex.Message,
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return false;
+        }
+
+        UpdateLlamaCppServerButtonText();
+        return true;
     }
 
     private void LoadPreview()
@@ -581,6 +738,18 @@ public partial class VideoOcrViewModel : ObservableObject
                     glmOcr.Ocr(group.RepresentativeFileName, GlmUrl, GlmModel, GlmLanguage, cancellationToken),
                 () => glmOcr.Error, ReportOcrProgress, AddPreviewLine, cancellationToken);
         }
+        else if (engineType == OcrEngineType.LlamaCpp)
+        {
+            var llamaCppOcr = new LlamaCppOcr(Se.Settings.Ocr.LlamaCppOcrTimeoutMinutes);
+            var url = LlamaCppServerManager.ApiUrl;
+            var modelName = SelectedLlamaCppModel?.Model.FileName is { } fileName
+                ? Path.GetFileNameWithoutExtension(fileName)
+                : "glmocr";
+            var prompt = Se.Settings.Ocr.LlamaCppOcrPrompt;
+            await RunLlmOcr(ocrGroups, group => OcrWithBitmap(group, bitmap =>
+                    llamaCppOcr.Ocr(bitmap, url, modelName, LlamaCppLanguage, prompt, cancellationToken)),
+                () => llamaCppOcr.Error, ReportOcrProgress, AddPreviewLine, cancellationToken);
+        }
     }
 
     private static async Task<string> OcrWithBitmap(VideoOcrFrameGroup group, Func<SKBitmap, Task<string>> ocr)
@@ -643,6 +812,11 @@ public partial class VideoOcrViewModel : ObservableObject
             return await PaddleOcrInstallHelper.EnsureInstalled(Window!, _windowService, engineType);
         }
 
+        if (engineType == OcrEngineType.LlamaCpp)
+        {
+            return await EnsureLlamaCppReady();
+        }
+
         return true;
     }
 
@@ -673,6 +847,7 @@ public partial class VideoOcrViewModel : ObservableObject
         GlmModel = settings.GlmModel;
         GlmApiKey = settings.GlmApiKey;
         GlmLanguage = settings.GlmLanguage;
+        LlamaCppLanguage = string.IsNullOrEmpty(settings.LlamaCppLanguage) ? "English" : settings.LlamaCppLanguage;
         FramesPerSecond = Math.Clamp(settings.FramesPerSecond, 1, 30);
         BrightnessMinimum = Math.Clamp(settings.BrightnessMinimum, 0, 255);
         TextSimilarityPercent = Math.Clamp(settings.TextSimilarityPercent, 0, 100);
@@ -693,6 +868,11 @@ public partial class VideoOcrViewModel : ObservableObject
         settings.GlmModel = GlmModel;
         settings.GlmApiKey = GlmApiKey;
         settings.GlmLanguage = GlmLanguage;
+        if (SelectedLlamaCppModel != null)
+        {
+            settings.LlamaCppModel = LlamaCppServerManager.GetModelPath(SelectedLlamaCppModel.Model.FileName);
+        }
+        settings.LlamaCppLanguage = LlamaCppLanguage;
         settings.FramesPerSecond = FramesPerSecond;
         settings.BrightnessMinimum = BrightnessMinimum;
         settings.TextSimilarityPercent = TextSimilarityPercent;

--- a/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
@@ -100,6 +100,7 @@ public class VideoOcrWindow : Window
             Background = Brushes.Black,
             Children = { image, cropSelector },
         };
+        ToolTip.SetTip(imageArea, Se.Language.Video.VideoOcr.ScanAreaInfo);
 
         var slider = new Slider
         {
@@ -150,13 +151,6 @@ public class VideoOcrWindow : Window
                 UiUtil.MakeButton(Se.Language.Video.VideoOcr.BottomHalf, vm.SetScanAreaBottomHalfCommand),
                 UiUtil.MakeButton(Se.Language.Video.VideoOcr.FullFrame, vm.SetScanAreaFullFrameCommand),
                 scanAreaText,
-                new TextBlock
-                {
-                    Text = Se.Language.Video.VideoOcr.ScanAreaInfo,
-                    VerticalAlignment = VerticalAlignment.Center,
-                    Opacity = 0.7,
-                    Margin = new Thickness(10, 0, 0, 0),
-                },
             },
         };
 
@@ -224,6 +218,19 @@ public class VideoOcrWindow : Window
         glmPanel.Bind(StackPanel.IsVisibleProperty, new Binding(nameof(vm.IsGlmEngine)) { Source = vm });
         panel.Children.Add(glmPanel);
 
+        // llama.cpp settings
+        var llamaCppPanel = new StackPanel { Orientation = Orientation.Vertical, Spacing = 4 };
+        llamaCppPanel.Children.Add(UiUtil.MakeLabel(Se.Language.Video.VideoOcr.Model));
+        llamaCppPanel.Children.Add(UiUtil.MakeComboBox(vm.LlamaCppModels, vm, nameof(vm.SelectedLlamaCppModel)).WithWidth(330));
+        var llamaCppButtons = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 5 };
+        llamaCppButtons.Children.Add(UiUtil.MakeButton(vm.DownloadLlamaCppCommand, IconNames.Download, Se.Language.General.Download));
+        llamaCppButtons.Children.Add(MakeLlamaCppServerButton(vm));
+        llamaCppPanel.Children.Add(llamaCppButtons);
+        llamaCppPanel.Children.Add(UiUtil.MakeLabel(Se.Language.Video.VideoOcr.Language));
+        llamaCppPanel.Children.Add(UiUtil.MakeTextBox(330, vm, nameof(vm.LlamaCppLanguage)));
+        llamaCppPanel.Bind(StackPanel.IsVisibleProperty, new Binding(nameof(vm.IsLlamaCppEngine)) { Source = vm });
+        panel.Children.Add(llamaCppPanel);
+
         // Scan settings
         panel.Children.Add(MakeHeader(Se.Language.Video.VideoOcr.Scan));
         panel.Children.Add(MakeSettingRow(
@@ -253,6 +260,13 @@ public class VideoOcrWindow : Window
         };
 
         return UiUtil.MakeBorderForControl(scrollViewer);
+    }
+
+    private static Button MakeLlamaCppServerButton(VideoOcrViewModel vm)
+    {
+        var button = UiUtil.MakeButton(string.Empty, vm.ToggleLlamaCppServerCommand);
+        button.Bind(Button.ContentProperty, new Binding(nameof(vm.LlamaCppServerButtonText)));
+        return button;
     }
 
     private static TextBlock MakeHeader(string text, bool isFirst = false)

--- a/src/ui/Logic/Config/SeVideoOcr.cs
+++ b/src/ui/Logic/Config/SeVideoOcr.cs
@@ -13,6 +13,8 @@ public class SeVideoOcr
     public string GlmModel { get; set; }
     public string GlmApiKey { get; set; }
     public string GlmLanguage { get; set; }
+    public string LlamaCppModel { get; set; }
+    public string LlamaCppLanguage { get; set; }
     public int FramesPerSecond { get; set; }
     public int ImageSimilarityPercent { get; set; }
     public int TextSimilarityPercent { get; set; }
@@ -39,6 +41,8 @@ public class SeVideoOcr
         GlmModel = GlmOcr.DefaultModel;
         GlmApiKey = string.Empty;
         GlmLanguage = "English";
+        LlamaCppModel = string.Empty;
+        LlamaCppLanguage = "English";
         FramesPerSecond = 5;
         ImageSimilarityPercent = 92;
         TextSimilarityPercent = 80;


### PR DESCRIPTION
## Summary
Two changes to the burned-in / video OCR window (`VideoOcrWindow`):

### 1. Add a **llama.cpp** OCR engine
Adds a `llama.cpp` engine to the engine dropdown, wired to the **same curated OCR models** as the normal OCR window (`LlamaCppServerManager.OcrModels` — GLM-OCR, LightOnOCR), the same downloader (`LlamaCppDownloadHelper`), and the same local `llama-server` lifecycle. The settings panel exposes:
- model combobox (with download-status text)
- **Download** button
- **Start/Stop server** button
- language field

The selected model and language are persisted to `SeVideoOcr` settings. On scan start, `EnsureEngineIsAvailable` downloads the engine/model if needed and starts the local server; frames are then OCR'd against `LlamaCppServerManager.ApiUrl`.

Also renames the standalone Paddle entry from "Paddle OCR" to **"Paddle OCR Standalone"** to match the naming in the normal OCR window.

### 2. Tidy the scan-area hint
The "Drag on the video frame to select where the subtitles are" text was an inline `TextBlock` jammed into the horizontal scan-area row next to the label, three buttons, and the live coordinate text — so it crowded/overlapped. It's now a **tooltip on the video frame** itself (where the drag happens). The `ScanAreaInfo` language string is unchanged, so translations still apply.

## Testing
- `dotnet build -c Debug` succeeds (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)