### PR TITLE
Video OCR: install-status dots on engine/model pickers

### DIFF
--- a/src/ui/Features/Ocr/Download/PaddleOcrInstallHelper.cs
+++ b/src/ui/Features/Ocr/Download/PaddleOcrInstallHelper.cs
@@ -17,6 +17,26 @@ namespace Nikse.SubtitleEdit.Features.Ocr.Download;
 public static class PaddleOcrInstallHelper
 {
     /// <summary>
+    /// True when the standalone Paddle OCR engine binary and the OCR models are already on disk,
+    /// so no download is needed. Used to show an install-status dot next to the engine in a picker.
+    /// The Python engine is installed via pip (outside our control), so it is not covered here.
+    /// </summary>
+    public static bool IsStandaloneInstalled()
+    {
+        if (Configuration.IsRunningOnWindows && !File.Exists(Path.Combine(Se.PaddleOcrFolder, "paddleocr.exe")))
+        {
+            return false;
+        }
+
+        if (Configuration.IsRunningOnLinux && !File.Exists(Path.Combine(Se.PaddleOcrFolder, "paddleocr.bin")))
+        {
+            return false;
+        }
+
+        return Directory.Exists(Se.PaddleOcrModelsFolder);
+    }
+
+    /// <summary>
     /// Makes sure the Paddle OCR engine (standalone only) and models are installed,
     /// prompting the user to download what is missing. Returns false if the user cancelled.
     /// </summary>

--- a/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
@@ -257,6 +257,7 @@ public partial class VideoOcrViewModel : ObservableObject
         {
             var selectName = string.IsNullOrEmpty(downloaded) ? model?.FileName : downloaded;
             SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.OcrModels, selectName);
+            (Window as VideoOcrWindow)?.RefreshDownloadDots();
         }
     }
 
@@ -330,6 +331,7 @@ public partial class VideoOcrViewModel : ObservableObject
         }
 
         SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.OcrModels, model.FileName);
+        (Window as VideoOcrWindow)?.RefreshDownloadDots();
 
         try
         {

--- a/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
@@ -4,14 +4,21 @@ using Avalonia.Data;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Ocr.Download;
+using Nikse.SubtitleEdit.Features.Ocr.Engines;
+using Nikse.SubtitleEdit.Features.Translate;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using Nikse.SubtitleEdit.Logic.ValueConverters;
 
 namespace Nikse.SubtitleEdit.Features.Video.VideoOcr;
 
 public class VideoOcrWindow : Window
 {
+    private ComboBox? _comboEngine;
+    private ComboBox? _comboLlamaCppModel;
+
     public VideoOcrWindow(VideoOcrViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
@@ -171,9 +178,11 @@ public class VideoOcrWindow : Window
         return UiUtil.MakeBorderForControl(grid);
     }
 
-    private static Border MakeSettingsView(VideoOcrViewModel vm)
+    private Border MakeSettingsView(VideoOcrViewModel vm)
     {
         var comboEngine = UiUtil.MakeComboBox(vm.Engines, vm, nameof(vm.SelectedEngine)).WithWidth(220);
+        comboEngine.ItemTemplate = BuildEngineItemTemplate();
+        _comboEngine = comboEngine;
 
         var comboPaddleLanguage = UiUtil.MakeComboBox(vm.PaddleLanguages, vm, nameof(vm.SelectedPaddleLanguage)).WithWidth(220);
 
@@ -219,9 +228,13 @@ public class VideoOcrWindow : Window
         panel.Children.Add(glmPanel);
 
         // llama.cpp settings
+        var comboLlamaCppModel = UiUtil.MakeComboBox(vm.LlamaCppModels, vm, nameof(vm.SelectedLlamaCppModel)).WithWidth(330);
+        comboLlamaCppModel.ItemTemplate = BuildLlamaCppModelItemTemplate();
+        _comboLlamaCppModel = comboLlamaCppModel;
+
         var llamaCppPanel = new StackPanel { Orientation = Orientation.Vertical, Spacing = 4 };
         llamaCppPanel.Children.Add(UiUtil.MakeLabel(Se.Language.Video.VideoOcr.Model));
-        llamaCppPanel.Children.Add(UiUtil.MakeComboBox(vm.LlamaCppModels, vm, nameof(vm.SelectedLlamaCppModel)).WithWidth(330));
+        llamaCppPanel.Children.Add(comboLlamaCppModel);
         var llamaCppButtons = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 5 };
         llamaCppButtons.Children.Add(UiUtil.MakeButton(vm.DownloadLlamaCppCommand, IconNames.Download, Se.Language.General.Download));
         llamaCppButtons.Children.Add(MakeLlamaCppServerButton(vm));
@@ -267,6 +280,54 @@ public class VideoOcrWindow : Window
         var button = UiUtil.MakeButton(string.Empty, vm.ToggleLlamaCppServerCommand);
         button.Bind(Button.ContentProperty, new Binding(nameof(vm.LlamaCppServerButtonText)));
         return button;
+    }
+
+    // Install-status dot for the engine combo: green = ready to use, amber = a newer build is
+    // available, grey = downloadable but not on disk. Engines with nothing for us to download
+    // (Paddle OCR Python via pip, Ollama server, the cloud GLM API) get no dot.
+    private static DownloadDotStatus GetEngineDotStatus(VideoOcrEngineItem engine)
+    {
+        switch (engine.EngineType)
+        {
+            case OcrEngineType.PaddleOcrStandalone:
+                return PaddleOcrInstallHelper.IsStandaloneInstalled()
+                    ? DownloadDotStatus.UpToDate
+                    : DownloadDotStatus.NotInstalled;
+            case OcrEngineType.LlamaCpp:
+                return StatusDots.From(LlamaCppServerManager.IsEngineInstalled(), LlamaCppServerManager.GetEngineUpdateStatus());
+            default:
+                return DownloadDotStatus.None;
+        }
+    }
+
+    private static Avalonia.Controls.Templates.FuncDataTemplate<VideoOcrEngineItem> BuildEngineItemTemplate()
+    {
+        return StatusDots.ComboItemTemplate<VideoOcrEngineItem>(
+            engine => engine.Name,
+            _ => null,
+            GetEngineDotStatus);
+    }
+
+    private static Avalonia.Controls.Templates.FuncDataTemplate<LlamaCppModelDisplay> BuildLlamaCppModelItemTemplate()
+    {
+        return StatusDots.ComboItemTemplate<LlamaCppModelDisplay>(
+            model => model.Model.DisplayName,
+            model => model.Model.Size,
+            model => model.IsInstalled ? DownloadDotStatus.UpToDate : DownloadDotStatus.NotInstalled);
+    }
+
+    // Rebuilds the combo item templates so the install-status dots are re-evaluated - the dots are
+    // one-off snapshots, so a fresh template is the refresh. Called after a download or server start.
+    public void RefreshDownloadDots()
+    {
+        if (_comboEngine != null)
+        {
+            _comboEngine.ItemTemplate = BuildEngineItemTemplate();
+        }
+        if (_comboLlamaCppModel != null)
+        {
+            _comboLlamaCppModel.ItemTemplate = BuildLlamaCppModelItemTemplate();
+        }
     }
 
     private static TextBlock MakeHeader(string text, bool isFirst = false)


### PR DESCRIPTION
## Summary
Makes the burn-in / video OCR engine selection feel like the rest of the app's local-model pickers (text-to-speech, auto-translate) by adding the shared **install-status dot** to both comboboxes.

### Engine combobox
Each engine now shows a status dot via the shared `StatusDots` helper:
- 🟢 **green** — ready to use (installed)
- 🟠 **amber** — installed, newer build available
- ⚪ **grey** — downloadable but not on disk yet
- *no dot* — nothing for us to download (Paddle OCR Python via pip, Ollama server, the GLM cloud API)

`PaddleOcrInstallHelper.IsStandaloneInstalled()` is added so the **Paddle OCR Standalone** engine can report its dot synchronously; llama.cpp reports via `LlamaCppServerManager` install/update state.

### llama.cpp model combobox
Model rows now show the same install dot plus the download size (e.g. `● GLM-OCR 0.9B (Q8_0) (1.4 GB)`), matching how models render elsewhere.

### Accessibility
Every dotted row also carries the install state as a **tooltip and accessible name** (from `StatusDots`), so status is conveyed in text, not colour alone.

### Keeping dots fresh
The dots are one-off snapshots, so `VideoOcrWindow.RefreshDownloadDots()` rebuilds the item templates after a model/engine download or a server start.

## Auto-download
Downloading stays on the existing, app-consistent path: llama.cpp / Paddle Standalone auto-prompt to download when you start OCR (`EnsureEngineIsAvailable`), plus the explicit **Download** button and **Start/Stop server** button for llama.cpp. The new dots now make it obvious *before* running which engines/models still need a download.

## Testing
- `dotnet build -c Debug` succeeds (0 warnings, 0 errors).
- UI-only (combobox item templates); not driven headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)