### PR TITLE
Fix Beautify Time Codes preview after inserting new subtitle lines

### DIFF
--- a/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
@@ -96,13 +96,9 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
             return;
         }
 
-        // Build a Subtitle and run the full libse beautifier — it reads the profile
-        // directly from Configuration.Settings.BeautifyTimeCodes.
-        var subtitle = new Subtitle();
-        foreach (var p in _allSubtitles.Select(p => p.Paragraph!).OrderBy(p => p.StartTime.TotalMilliseconds))
-        {
-            subtitle.Paragraphs.Add(new Paragraph(p));
-        }
+        // Build a Subtitle from the current row values and run the full libse
+        // beautifier — it reads the profile directly from Configuration.Settings.BeautifyTimeCodes.
+        var subtitle = BuildSubtitleFromRows();
 
         var beautifier = new Core.Forms.TimeCodesBeautifier(subtitle, _frameRate, new List<double>(), _shotChanges);
         beautifier.Beautify();
@@ -595,11 +591,7 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
         _timerUpdatePreview.Stop();
 
         // Apply final beautification to commit the result back to _allSubtitles
-        var subtitle = new Subtitle();
-        foreach (var p in _allSubtitles.Select(p => p.Paragraph!).OrderBy(p => p.StartTime.TotalMilliseconds))
-        {
-            subtitle.Paragraphs.Add(new Paragraph(p));
-        }
+        var subtitle = BuildSubtitleFromRows();
 
         var beautifier = new Core.Forms.TimeCodesBeautifier(subtitle, _frameRate, new List<double>(), _shotChanges);
         beautifier.Beautify();
@@ -626,6 +618,17 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
     public List<SubtitleLineViewModel> GetBeautifiedSubtitles()
     {
         return new List<SubtitleLineViewModel>(_allSubtitles);
+    }
+
+    private Subtitle BuildSubtitleFromRows()
+    {
+        var subtitle = new Subtitle();
+        foreach (var p in _allSubtitles.Select(p => p.ToParagraph()).OrderBy(p => p.StartTime.TotalMilliseconds))
+        {
+            subtitle.Paragraphs.Add(p);
+        }
+
+        return subtitle;
     }
 
     internal void OnKeyDown(KeyEventArgs e)


### PR DESCRIPTION
## Problem

After opening a subtitle and inserting a new subtitle line, **Beautify Time Codes** could open with an empty beautified preview and 0 detected changes.

## Cause & Fix

Beautify Time Codes built its working `Subtitle` from each row's backing `Paragraph` via `Paragraph!`.

That works for rows loaded from a subtitle file, but newly inserted rows may only have the current `SubtitleLineViewModel` values populated. In that case, relying on `Paragraph!` can prevent the beautifier preview from being built correctly.

The fix builds the working `Subtitle` with `ToParagraph()` instead. This is the appropriate conversion path because it creates a `Paragraph` from the row's current start time, end time, text, and related subtitle fields.

The shared helper is used by both preview generation and final apply so both paths use the same input source.

## Screenshots

| Before | After |
|---|---|
| Beautify Time Codes shows no preview changes after inserting a new subtitle line | Beautify Time Codes previews changes normally after inserting a new subtitle line |
| <video src="https://github.com/user-attachments/assets/9f908e77-c3cd-44a6-a820-afe82030ebda"> | <video src="https://github.com/user-attachments/assets/5fa8c5f6-f695-42c6-a2d7-6a4e2c392ec6"> |


## Testing

Tested on Windows 11 x64 (local Release build).

Verified both full-subtitle beautify and selected-lines beautify.