### PR TITLE
Video OCR: test current frame, editable results, double-click seek

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2170,7 +2170,11 @@
       "unableToReadVideoTitle": "Unable to read video",
       "unableToReadVideoMessage": "Could not read video info from: {0}",
       "abortOcrTitle": "Abort OCR?",
-      "abortOcrMessage": "Do you want to abort the running OCR?"
+      "abortOcrMessage": "Do you want to abort the running OCR?",
+      "testOcr": "Test current frame",
+      "testOcrRunning": "Testing OCR on current frame...",
+      "testOcrResultX": "Test result: {0}",
+      "testOcrNoTextFound": "Test: no text found in the scan area"
     },
     "goToVideoPosition": "Go to video position",
     "generateBlankVideoDotDotDot": "Generate blank video...",

--- a/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
@@ -428,6 +428,126 @@ public partial class VideoOcrViewModel : ObservableObject
         CropSelector?.SetSelectionVideoRect(0, 0, VideoWidth, VideoHeight);
     }
 
+    /// <summary>
+    /// OCRs only the frame at the current preview position so the user can validate the scan
+    /// area, engine, and settings without scanning the whole video. The result is shown in the
+    /// status text.
+    /// </summary>
+    [RelayCommand]
+    private async Task TestOcr()
+    {
+        if (IsRunning || string.IsNullOrEmpty(_videoFileName) || VideoWidth <= 0 || VideoHeight <= 0)
+        {
+            return;
+        }
+
+        var engineOk = await EnsureEngineIsAvailable();
+        if (!engineOk)
+        {
+            return;
+        }
+
+        ClampSelection();
+
+        _cancellationTokenSource = new CancellationTokenSource();
+        var cancellationToken = _cancellationTokenSource.Token;
+
+        IsRunning = true;
+        ProgressText = Se.Language.Video.VideoOcr.TestOcrRunning;
+
+        var frameFileName = Path.Combine(Path.GetTempPath(), "se_video_ocr_test_" + Guid.NewGuid() + ".jpg");
+        try
+        {
+            await ExtractSingleFrame(frameFileName, PreviewPositionSeconds, cancellationToken);
+            if (!File.Exists(frameFileName) || new FileInfo(frameFileName).Length == 0)
+            {
+                throw new Exception("Could not extract the current frame - see log for the ffmpeg command line.");
+            }
+
+            var group = new VideoOcrFrameGroup { RepresentativeFileName = frameFileName };
+            await OcrGroups(new List<VideoOcrFrameGroup> { group }, () => { }, _ => { }, cancellationToken);
+
+            ProgressText = string.IsNullOrWhiteSpace(group.Text)
+                ? Se.Language.Video.VideoOcr.TestOcrNoTextFound
+                : string.Format(Se.Language.Video.VideoOcr.TestOcrResultX, group.Text.ReplaceLineEndings(" | "));
+        }
+        catch (OperationCanceledException)
+        {
+            ProgressText = string.Empty;
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, "Video OCR: test on current frame failed");
+            ProgressText = string.Empty;
+
+            await MessageBox.Show(
+                Window!,
+                Se.Language.General.Error,
+                exception.Message,
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+        }
+        finally
+        {
+            IsRunning = false;
+
+            try
+            {
+                File.Delete(frameFileName);
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+    }
+
+    private async Task ExtractSingleFrame(string outputFileName, double positionSeconds, CancellationToken cancellationToken)
+    {
+        var scale = string.Empty;
+        var maxImageWidth = Se.Settings.Video.VideoOcr.MaxImageWidth;
+        if (maxImageWidth > 0 && SelectionWidth > maxImageWidth)
+        {
+            scale = $",scale={maxImageWidth}:-2";
+        }
+
+        // -ss before -i: seek in the demuxer, so a test frame late in a long video is still fast.
+        var arguments = $"-nostdin -y -ss {positionSeconds.ToString("0.###", CultureInfo.InvariantCulture)} " +
+                        $"-i \"{_videoFileName}\" " +
+                        $"-vf \"crop={SelectionWidth}:{SelectionHeight}:{SelectionX}:{SelectionY}{scale}\" " +
+                        $"-frames:v 1 -q:v 2 \"{outputFileName}\"";
+
+        Se.WriteToolsLog("Video OCR: extracting test frame - ffmpeg " + arguments);
+        var process = FfmpegGenerator.GetProcess(arguments, (_, _) => { });
+
+#pragma warning disable CA1416 // Validate platform compatibility
+        process.Start();
+#pragma warning restore CA1416
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        try
+        {
+            await process.WaitForExitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(true);
+                }
+            }
+            catch
+            {
+                // ignore
+            }
+
+            throw;
+        }
+    }
+
     [RelayCommand]
     private async Task StartOcr()
     {
@@ -692,6 +812,15 @@ public partial class VideoOcrViewModel : ObservableObject
             ProgressText = string.Format(Se.Language.Video.VideoOcr.RunningOcrXY, 0, ocrGroups.Count);
         });
 
+        await OcrGroups(ocrGroups, ReportOcrProgress, AddPreviewLine, cancellationToken);
+    }
+
+    /// <summary>
+    /// Runs the selected OCR engine over the given frame groups, storing each result in
+    /// <see cref="VideoOcrFrameGroup.Text"/>. Shared by the full scan and the single-frame test.
+    /// </summary>
+    private async Task OcrGroups(List<VideoOcrFrameGroup> ocrGroups, Action reportProgress, Action<VideoOcrFrameGroup> addPreviewLine, CancellationToken cancellationToken)
+    {
         var engineType = SelectedEngine.EngineType;
         if (engineType is OcrEngineType.PaddleOcrStandalone or OcrEngineType.PaddleOcrPython)
         {
@@ -708,8 +837,8 @@ public partial class VideoOcrViewModel : ObservableObject
                 if (group != null)
                 {
                     group.Text = VideoOcrLineBuilder.CleanOcrResult(p.Text);
-                    ReportOcrProgress();
-                    AddPreviewLine(group);
+                    reportProgress();
+                    addPreviewLine(group);
                 }
             });
 
@@ -731,14 +860,14 @@ public partial class VideoOcrViewModel : ObservableObject
             var ollamaOcr = new OllamaOcr(Se.Settings.Ocr.OllamaOcrTimeoutMinutes);
             await RunLlmOcr(ocrGroups, group => OcrWithBitmap(group, bitmap =>
                     ollamaOcr.Ocr(bitmap, OllamaUrl, OllamaModel, OllamaLanguage, cancellationToken)),
-                () => ollamaOcr.Error, ReportOcrProgress, AddPreviewLine, cancellationToken);
+                () => ollamaOcr.Error, reportProgress, addPreviewLine, cancellationToken);
         }
         else if (engineType == OcrEngineType.Glm)
         {
             var glmOcr = new GlmOcr(GlmApiKey);
             await RunLlmOcr(ocrGroups, group =>
                     glmOcr.Ocr(group.RepresentativeFileName, GlmUrl, GlmModel, GlmLanguage, cancellationToken),
-                () => glmOcr.Error, ReportOcrProgress, AddPreviewLine, cancellationToken);
+                () => glmOcr.Error, reportProgress, addPreviewLine, cancellationToken);
         }
         else if (engineType == OcrEngineType.LlamaCpp)
         {
@@ -750,7 +879,7 @@ public partial class VideoOcrViewModel : ObservableObject
             var prompt = Se.Settings.Ocr.LlamaCppOcrPrompt;
             await RunLlmOcr(ocrGroups, group => OcrWithBitmap(group, bitmap =>
                     llamaCppOcr.Ocr(bitmap, url, modelName, LlamaCppLanguage, prompt, cancellationToken)),
-                () => llamaCppOcr.Error, ReportOcrProgress, AddPreviewLine, cancellationToken);
+                () => llamaCppOcr.Error, reportProgress, addPreviewLine, cancellationToken);
         }
     }
 
@@ -913,6 +1042,34 @@ public partial class VideoOcrViewModel : ObservableObject
         SaveSettings();
         OkPressed = true;
         Window?.Close();
+    }
+
+    /// <summary>Removes the given result lines and renumbers the rest (Delete key in the grid).</summary>
+    internal void DeleteLines(List<VideoOcrLineItem> items)
+    {
+        if (IsRunning || items.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var item in items)
+        {
+            Lines.Remove(item);
+        }
+
+        var number = 1;
+        foreach (var line in Lines)
+        {
+            line.Number = number++;
+        }
+
+        IsOkEnabled = Lines.Count > 0;
+    }
+
+    /// <summary>Moves the preview to the given line's start time (double-click in the grid).</summary>
+    internal void SeekPreview(VideoOcrLineItem item)
+    {
+        PreviewPositionSeconds = Math.Clamp(item.StartTime.TotalSeconds, 0, DurationSeconds);
     }
 
     [RelayCommand]

--- a/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
@@ -11,6 +11,7 @@ using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using Nikse.SubtitleEdit.Logic.ValueConverters;
+using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Video.VideoOcr;
 
@@ -157,6 +158,9 @@ public class VideoOcrWindow : Window
                 UiUtil.MakeButton(Se.Language.Video.VideoOcr.BottomThird, vm.SetScanAreaBottomThirdCommand),
                 UiUtil.MakeButton(Se.Language.Video.VideoOcr.BottomHalf, vm.SetScanAreaBottomHalfCommand),
                 UiUtil.MakeButton(Se.Language.Video.VideoOcr.FullFrame, vm.SetScanAreaFullFrameCommand),
+                UiUtil.MakeButton(Se.Language.Video.VideoOcr.TestOcr, vm.TestOcrCommand)
+                    .WithBindEnabled(nameof(vm.IsRunning), new InverseBooleanConverter())
+                    .WithMarginLeft(10),
                 scanAreaText,
             },
         };
@@ -366,7 +370,7 @@ public class VideoOcrWindow : Window
             CanUserResizeColumns = true,
             HorizontalAlignment = HorizontalAlignment.Stretch,
             VerticalAlignment = VerticalAlignment.Stretch,
-            IsReadOnly = true,
+            IsReadOnly = false, // the text column is editable so OCR mistakes can be fixed in place
             DataContext = vm,
             ItemsSource = vm.Lines,
             Columns =
@@ -404,10 +408,29 @@ public class VideoOcrWindow : Window
                     Header = Se.Language.General.Text,
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
                     Binding = new Binding(nameof(VideoOcrLineItem.Text)),
-                    IsReadOnly = true,
+                    IsReadOnly = false,
                     Width = new DataGridLength(1, DataGridLengthUnitType.Star),
                 },
             },
+        };
+
+        // Double-click a line to see the frame it came from in the preview.
+        dataGrid.DoubleTapped += (s, e) =>
+        {
+            if (dataGrid.SelectedItem is VideoOcrLineItem item)
+            {
+                vm.SeekPreview(item);
+            }
+        };
+
+        // Delete removes the selected lines (unless a cell edit is in progress).
+        dataGrid.KeyDown += (s, e) =>
+        {
+            if (e.Key == Avalonia.Input.Key.Delete && e.Source is not TextBox)
+            {
+                vm.DeleteLines(dataGrid.SelectedItems.OfType<VideoOcrLineItem>().ToList());
+                e.Handled = true;
+            }
         };
 
         return UiUtil.MakeBorderForControl(dataGrid);

--- a/src/ui/Logic/Config/Language/Video/LanguageVideoOcr.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageVideoOcr.cs
@@ -33,6 +33,10 @@ public class LanguageVideoOcr
     public string UnableToReadVideoMessage { get; set; }
     public string AbortOcrTitle { get; set; }
     public string AbortOcrMessage { get; set; }
+    public string TestOcr { get; set; }
+    public string TestOcrRunning { get; set; }
+    public string TestOcrResultX { get; set; }
+    public string TestOcrNoTextFound { get; set; }
 
     public LanguageVideoOcr()
     {
@@ -67,5 +71,9 @@ public class LanguageVideoOcr
         UnableToReadVideoMessage = "Could not read video info from: {0}";
         AbortOcrTitle = "Abort OCR?";
         AbortOcrMessage = "Do you want to abort the running OCR?";
+        TestOcr = "Test current frame";
+        TestOcrRunning = "Testing OCR on current frame...";
+        TestOcrResultX = "Test result: {0}";
+        TestOcrNoTextFound = "Test: no text found in the scan area";
     }
 }


### PR DESCRIPTION
## Summary
Three quality-of-life improvements for the burn-in / video OCR window:

### 1. "Test current frame" button
New button in the scan-area row that OCRs **only the frame at the current preview position** with the selected engine and shows the result in the status text (`Test result: ...` / `Test: no text found in the scan area`). This lets you validate the scan area, engine choice, and brightness minimum in seconds instead of discovering a bad setting after scanning the whole video.

- The engine dispatch is factored out of `RunOcr` into a shared `OcrGroups()` so the test and the full scan run the exact same engine paths (Paddle standalone/Python, Ollama, llama.cpp, GLM).
- The test frame is extracted with a fast demuxer seek (`-ss` before `-i`), so testing late in a long video is still instant.
- Engine availability (download prompts, llama.cpp server start) goes through the same `EnsureEngineIsAvailable` as a full scan.

### 2. Editable results + Delete
The text column in the result grid is now editable, so OCR mistakes can be fixed in place before pressing OK. The <kbd>Delete</kbd> key removes the selected lines (with renumbering); the keypress is ignored while a cell edit is in progress.

### 3. Double-click a line → seek preview
Double-clicking a result line moves the video preview to that line's start time, so you can eyeball exactly what the OCR saw.

New language strings (`testOcr`, `testOcrRunning`, `testOcrResultX`, `testOcrNoTextFound`) added to `LanguageVideoOcr` and `English.json`.

## Testing
- `dotnet build -c Debug` succeeds (0 warnings, 0 errors).
- UI flow not driven headlessly; worth a quick manual smoke test (test button with each engine, cell edit, Delete key, double-click seek).

🤖 Generated with [Claude Code](https://claude.com/claude-code)