### PR TITLE
Fix live spell check using the English dictionary for other languages

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -6003,6 +6003,10 @@ public partial class MainViewModel :
             SetSubtitles(_subtitle);
             SelectAndScrollToRow(0);
             ShowStatus(string.Format(Se.Language.Main.TranscriptionCompletedWithXLines, _subtitle.Paragraphs.Count));
+
+            // The subtitle content (and so its language) just changed without a
+            // file open, so re-evaluate the live spell check dictionary.
+            SetupLiveSpellCheck();
         }
         else if (result.OkPressed && result.IsBatchMode && result.BatchItems.Count == 1)
         {
@@ -6088,6 +6092,10 @@ public partial class MainViewModel :
             SetSubtitles(_subtitle);
             SelectAndScrollToRow(0);
             ShowStatus(string.Format(Se.Language.Video.VideoOcr.LinesFoundX, _subtitle.Paragraphs.Count));
+
+            // The subtitle content (and so its language) just changed without a
+            // file open, so re-evaluate the live spell check dictionary.
+            SetupLiveSpellCheck();
         }
     }
 
@@ -15464,8 +15472,17 @@ public partial class MainViewModel :
     private void SetupLiveSpellCheck()
     {
         var dictionaryFound = false;
-        var twoLetterLanguageCode = LanguageAutoDetect.AutoDetectGoogleLanguage(GetUpdateSubtitle());
-        var threeLetterLanguageCode = Iso639Dash2LanguageCode.GetThreeLetterCodeFromTwoLetterCode(twoLetterLanguageCode);
+
+        // Use the detection variant that returns null for an empty or undetectable
+        // subtitle. The regular variant falls back to English, which armed the
+        // spell checker with the English dictionary on an empty subtitle at
+        // startup; content arriving later without a file open (for example a
+        // transcription in a language with no dictionary installed) was then
+        // checked against English, underlining every word.
+        var twoLetterLanguageCode = LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(GetUpdateSubtitle());
+        var threeLetterLanguageCode = string.IsNullOrEmpty(twoLetterLanguageCode)
+            ? null
+            : Iso639Dash2LanguageCode.GetThreeLetterCodeFromTwoLetterCode(twoLetterLanguageCode);
         if (!string.IsNullOrEmpty(threeLetterLanguageCode))
         {
             var spellCheckLanguages = _spellCheckManager.GetDictionaryLanguages(Se.DictionariesFolder);


### PR DESCRIPTION
### Problem

With live spell check enabled and only the English dictionary installed, an Arabic speech to text transcription came back with every single word underlined in red, in the subtitle grid and in the text box.

### Cause

Live spell check picks its dictionary by auto detecting the subtitle's language, but the detection helper used here falls back to English when the subtitle is empty or undetectable. The setup runs at startup before any file is loaded, so the spell checker was armed with the English dictionary against an empty subtitle. Content that arrives without a file open, such as a speech to text transcription or a video OCR result, never re-evaluated that choice, so Arabic text was spell checked against the English dictionary.

### Fix

Two small changes in MainViewModel:

1. `SetupLiveSpellCheck` now uses `AutoDetectGoogleLanguageOrNull`, which returns null instead of the English fallback. An empty or undetectable subtitle disables live spell check instead of arming it with the wrong dictionary. Opening a file re-evaluates as before.
2. The speech to text and video OCR result paths call `SetupLiveSpellCheck()` after inserting their content, the same way opening a file does.

A side effect worth noting: a fresh English transcription now gets live spell check enabled correctly, which previously only happened by accident of the English fallback.

### Testing

Verified on macOS (Apple Silicon), all three directions:

- Arabic transcription (MLX Whisper): no false underlines anywhere.
- Opening an English subtitle file: live spell check works as before, real typos underlined.
- English transcription: live spell check now activates on the result.
