### PR TITLE
Histogram-based colour isolation for VobSub OCR (#12293)

### DIFF
--- a/docs/features/seconv.md
+++ b/docs/features/seconv.md
@@ -8,6 +8,7 @@ seconv movie.srt subrip --encoding:source --FixCommonErrors
 seconv movie.mkv subrip --track-number:3
 seconv movie.sup subrip --ocr-engine:tesseract --ocr-language:eng
 seconv movie.sub subrip --ocr-engine:binaryocr --ocr-db:Latin.db   # VobSub (.idx auto-detected)
+seconv movie.sub subrip --ocr-engine:tesseract --no-vobsub-isolate-colors  # OCR raw palette (isolation is on by default)
 seconv movie.sup subrip --time-codes-only
 ```
 

--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -169,6 +169,7 @@ If two tracks share a language, the track number is added: `movie.#3.eng.srt`.
 | `--ollama-url:<url>` | Default `http://localhost:11434/api/chat` |
 | `--ollama-model:<model>` | Default `llama3.2-vision` |
 | `--time-codes-only` | Image sources (`.sup`, VobSub `.sub`/`.idx`, MKV PGS/VobSub, MP4 VobSub, TS DVB-sub) → text format with time codes only and empty text. **Skips OCR entirely** — no OCR engine required. Ignored for text inputs and image output targets. |
+| `--no-vobsub-isolate-colors` | Disable VobSub OCR colour isolation, which is **on by default**. Isolation rebuilds each subpicture as a crisp black-on-white bitmap via histogram-based colour analysis — the most frequent opaque colour (the glyph fill) becomes black and the gray outline / anti-alias colours collapse into the white background, which helps on discs whose outlines otherwise melt adjacent characters together (`Yuri` → `Yurl`). Pass this flag to OCR the raw palette instead. Ignored for non-VobSub sources and with `--time-codes-only`. |
 
 > **OCR database files are not bundled with `seconv`.** The `nocr` and `binaryocr` engines need a `.nocr` or `.db` file passed via `--ocr-db`. Sources:
 >

--- a/src/libse/Common/VobSubColorIsolation.cs
+++ b/src/libse/Common/VobSubColorIsolation.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using SkiaSharp;
+
+namespace Nikse.SubtitleEdit.Core.Common
+{
+    /// <summary>
+    /// Histogram-based colour isolation for VobSub OCR bitmaps (issue #12293).
+    ///
+    /// A VobSub subpicture is a strict 4-colour indexed image: one palette entry for the
+    /// transparent background, one for the main glyph fill, and one or two for the
+    /// anti-aliased outline / emphasis. When such a bitmap is composited for OCR the outline
+    /// colours bleed into the fill and the recogniser melts adjacent glyphs together
+    /// ("Yuri" → "Yurl"). Because DVD authoring tools assign the palette indices
+    /// unpredictably from disc to disc, there is no fixed colour to strip in an unattended
+    /// batch run.
+    ///
+    /// This pass rebuilds a crisp black-on-white bitmap purely from pixel frequency:
+    /// transparent pixels are the background, the most common opaque colour is the main text
+    /// body (kept as black), and every other opaque colour (the outline / anti-alias tiers)
+    /// collapses into the white background. The result is a clean binary mask that OCR
+    /// engines recognise far more reliably. Used by both the seconv CLI
+    /// (<c>--no-vobsub-isolate-colors</c> to disable) and the Batch Convert UI.
+    /// </summary>
+    public static class VobSubColorIsolation
+    {
+        /// <summary>
+        /// Returns a new opaque black-on-white bitmap in which only the dominant opaque colour
+        /// (the glyph fill) is kept as foreground. The caller owns the returned bitmap. When the
+        /// source has no opaque pixels (a blank / clear frame) a solid white bitmap is returned
+        /// so downstream OCR simply sees nothing.
+        /// </summary>
+        /// <param name="source">Rendered VobSub bitmap; a transparent background is expected.</param>
+        /// <param name="alphaThreshold">Pixels with alpha below this are treated as background.</param>
+        public static SKBitmap Isolate(SKBitmap source, byte alphaThreshold = 128)
+        {
+            var width = source.Width;
+            var height = source.Height;
+            var result = new SKBitmap(new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Opaque));
+
+            // Tally every opaque colour. Key on RGB only (alpha already gates the background)
+            // so anti-aliasing tiers that share a hue but differ in coverage still merge.
+            var counts = new Dictionary<uint, int>();
+            for (var y = 0; y < height; y++)
+            {
+                for (var x = 0; x < width; x++)
+                {
+                    var c = source.GetPixel(x, y);
+                    if (c.Alpha < alphaThreshold)
+                    {
+                        continue;
+                    }
+                    var key = (uint)((c.Red << 16) | (c.Green << 8) | c.Blue);
+                    counts[key] = counts.TryGetValue(key, out var n) ? n + 1 : 1;
+                }
+            }
+
+            using var canvas = new SKCanvas(result);
+            canvas.Clear(SKColors.White);
+
+            if (counts.Count == 0)
+            {
+                // No text pixels — hand back a blank white canvas.
+                return result;
+            }
+
+            // Most frequent opaque colour = the glyph fill (the "second tier" once the
+            // transparent background is excluded). Ties resolve to the lowest colour key so the
+            // output is deterministic regardless of dictionary iteration order.
+            var foreground = 0u;
+            var best = -1;
+            foreach (var kv in counts)
+            {
+                if (kv.Value > best || (kv.Value == best && kv.Key < foreground))
+                {
+                    best = kv.Value;
+                    foreground = kv.Key;
+                }
+            }
+
+            using var paint = new SKPaint { Color = SKColors.Black };
+            for (var y = 0; y < height; y++)
+            {
+                for (var x = 0; x < width; x++)
+                {
+                    var c = source.GetPixel(x, y);
+                    if (c.Alpha >= alphaThreshold &&
+                        (uint)((c.Red << 16) | (c.Green << 8) | c.Blue) == foreground)
+                    {
+                        canvas.DrawPoint(x, y, paint);
+                    }
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -112,6 +112,10 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         [Description("For image-based sources (.sup, VobSub .sub/.idx, MKV PGS/VobSub, MP4 VobSub, TS DVB-sub): output time codes only with empty text; skips OCR (no OCR engine required)")]
         public bool TimeCodesOnly { get; init; }
 
+        [CommandOption("--no-vobsub-isolate-colors|--novobsubisolatecolors")]
+        [Description("Disable VobSub OCR colour isolation (on by default). Isolation binarises each subpicture to black-on-white by keeping the most frequent opaque colour (glyph fill) and dropping the outline/anti-alias colours; pass this to OCR the raw palette instead")]
+        public bool NoVobSubIsolateColors { get; init; }
+
         [CommandOption("--ollama-url")]
         [Description("Ollama API endpoint (default: http://localhost:11434/api/chat)")]
         public string? OllamaUrl { get; init; }
@@ -491,6 +495,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 OcrDb = settings.OcrDb,
                 DictionaryFolder = settings.DictionaryFolder,
                 TimeCodesOnly = settings.TimeCodesOnly,
+                VobSubIsolateColors = !settings.NoVobSubIsolateColors,
                 OllamaUrl = settings.OllamaUrl,
                 OllamaModel = settings.OllamaModel,
                 TeletextOnly = settings.TeletextOnly,

--- a/src/seconv/Core/ImageOcrLoader.cs
+++ b/src/seconv/Core/ImageOcrLoader.cs
@@ -181,8 +181,9 @@ internal static class ImageOcrLoader
             }
 
             using var ocr = OcrEngineFactory.Create(options);
-            AnsiConsole.MarkupLine($"[dim]Running {ocr.Name} OCR on {what}...[/]");
-            return BitmapItemsToSubtitle(items, ocr);
+            var isolationNote = options.VobSubIsolateColors ? string.Empty : " (colour isolation off)";
+            AnsiConsole.MarkupLine($"[dim]Running {ocr.Name} OCR on {what}{isolationNote}...[/]");
+            return BitmapItemsToSubtitle(items, ocr, options.VobSubIsolateColors);
         }
         finally
         {
@@ -196,14 +197,31 @@ internal static class ImageOcrLoader
     /// <summary>
     /// Turns pre-decoded bitmap events into a Subtitle. <paramref name="ocr"/> null =
     /// time-codes-only (empty text kept); non-null = recognise each bitmap and drop blanks.
+    /// When <paramref name="isolateColors"/> is set, each bitmap is binarised via
+    /// <see cref="VobSubColorIsolation"/> before recognition (VobSub sources only, and never
+    /// in time-codes-only mode since no recognition happens there).
     /// </summary>
     private static Subtitle BitmapItemsToSubtitle(
-        IReadOnlyList<BitmapSubtitleLoader.BitmapSubtitleItem> items, IOcrEngine? ocr)
+        IReadOnlyList<BitmapSubtitleLoader.BitmapSubtitleItem> items, IOcrEngine? ocr, bool isolateColors = false)
     {
         var subtitle = new Subtitle();
         foreach (var item in items)
         {
-            var text = ocr is null ? string.Empty : ocr.Recognize(item.Bitmap);
+            string text;
+            if (ocr is null)
+            {
+                text = string.Empty;
+            }
+            else if (isolateColors)
+            {
+                using var isolated = VobSubColorIsolation.Isolate(item.Bitmap);
+                text = ocr.Recognize(isolated);
+            }
+            else
+            {
+                text = ocr.Recognize(item.Bitmap);
+            }
+
             if (ocr is null || !string.IsNullOrWhiteSpace(text))
             {
                 subtitle.Paragraphs.Add(new LibSeParagraph(

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -868,6 +868,17 @@ internal record class ConversionOptions
     /// </summary>
     public bool TimeCodesOnly { get; init; }
 
+    /// <summary>
+    /// VobSub OCR only: before recognition, rebuild each subpicture as a crisp black-on-white
+    /// bitmap using histogram-based colour isolation — the most frequent opaque colour (the
+    /// glyph fill) becomes black and the outline / anti-alias tiers collapse into the white
+    /// background. Improves recognition on discs whose gray outlines otherwise melt adjacent
+    /// characters together. On by default; disable with <c>--no-vobsub-isolate-colors</c> to
+    /// OCR the raw palette. See <see cref="VobSubColorIsolation"/>. Ignored for non-VobSub
+    /// sources and in <see cref="TimeCodesOnly"/> mode.
+    /// </summary>
+    public bool VobSubIsolateColors { get; init; } = true;
+
     /// <summary>Ollama API endpoint (default <c>http://localhost:11434/api/chat</c>).</summary>
     public string? OllamaUrl { get; init; }
 

--- a/src/seconv/Helpers/HelpDisplay.cs
+++ b/src/seconv/Helpers/HelpDisplay.cs
@@ -43,6 +43,7 @@ internal static class HelpDisplay
         ShowParameter("--ocr-language:<lang>", "Language for OCR (e.g. eng, deu, spa)");
         ShowParameter("--ocr-db:<path>", ".nocr (--ocr-engine=nocr) or .db (--ocr-engine=binaryocr)");
         ShowParameter("--time-codes-only", "Image sources (.sup/VobSub/PGS/DVB) -> text with time codes only; skips OCR");
+        ShowParameter("--no-vobsub-isolate-colors", "Disable VobSub OCR colour isolation (on by default; isolation binarises to black-on-white, dropping outline colours)");
         ShowParameter("--ollama-url:<url>", "Ollama API endpoint (default: http://localhost:11434/api/chat)");
         ShowParameter("--ollama-model:<model>", "Ollama vision model (default: llama3.2-vision)");
         ShowParameter("--multiple-replace:<path.xml>", "SE MultipleSearchAndReplaceGroups XML applied per paragraph");

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleVobSub.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleVobSub.cs
@@ -16,6 +16,13 @@ public class OcrSubtitleVobSub : IOcrSubtitle
     public SKColor Emphasis1 { get; set; } = SKColors.White;
     public SKColor Emphasis2 { get; set; } = SKColors.Black;
 
+    /// <summary>
+    /// When true, each decoded subpicture is rebuilt as a crisp black-on-white bitmap via
+    /// histogram-based colour isolation before it is handed to the OCR engine. See
+    /// <see cref="VobSubColorIsolation"/>.
+    /// </summary>
+    public bool IsolateColors { get; set; }
+
     private readonly List<VobSubMergedPack> _vobSubMergedPack;
     private List<SKColor>? _palette;
 
@@ -33,12 +40,18 @@ public class OcrSubtitleVobSub : IOcrSubtitle
             _vobSubMergedPack[index].Palette = _palette;
         }
 
-        if (UseCustomColors)
+        var bitmap = UseCustomColors
+            ? _vobSubMergedPack[index].SubPicture.GetBitmap(_palette, Background, Pattern, Emphasis1, Emphasis2, true, true)
+            : _vobSubMergedPack[index].GetBitmap();
+
+        if (IsolateColors)
         {
-            return _vobSubMergedPack[index].SubPicture.GetBitmap(_palette, Background, Pattern, Emphasis1, Emphasis2, true, true);
+            var isolated = VobSubColorIsolation.Isolate(bitmap);
+            bitmap.Dispose();
+            return isolated;
         }
 
-        return _vobSubMergedPack[index].GetBitmap();
+        return bitmap;
     }
 
     public TimeSpan GetStartTime(int index)

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
@@ -29,6 +29,7 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
 
     [ObservableProperty] private ObservableCollection<string> _ocrEngines;
     [ObservableProperty] private string? _selectedOcrEngine;
+    [ObservableProperty] private bool _vobSubIsolateColors;
 
     [ObservableProperty] private ObservableCollection<string> _languagePostFixes;
     [ObservableProperty] private string? _selectedLanguagePostFix;
@@ -170,6 +171,7 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
             ?? TargetEncodings.FirstOrDefault(p => p == TextEncoding.Utf8WithBom)
             ?? TargetEncodings.First();
         SelectedOcrEngine = OcrEngines.FirstOrDefault(p => p == Se.Settings.Tools.BatchConvert.OcrEngine) ?? OcrEngines.First();
+        VobSubIsolateColors = Se.Settings.Tools.BatchConvert.VobSubIsolateColors;
     }
 
     private void SaveSettings()
@@ -180,6 +182,7 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         Se.Settings.Tools.BatchConvert.TargetEncoding = SelectedTargetEncoding ?? TextEncoding.Utf8WithBom;
         Se.Settings.Tools.BatchConvert.LanguagePostFix = SelectedLanguagePostFix ?? Se.Language.General.TwoLetterLanguageCode;
         Se.Settings.Tools.BatchConvert.OcrEngine = SelectedOcrEngine ?? "nOcr";
+        Se.Settings.Tools.BatchConvert.VobSubIsolateColors = VobSubIsolateColors;
 
         var ocrEngine = SelectedOcrEngine;
         if (ocrEngine == "Tesseract")

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
@@ -106,6 +106,15 @@ public class BatchConvertSettingsWindow : Window
         };
         comboBoxOcrEngine.SelectionChanged += (s, e) => vm.OnOcrEngineChanged();
 
+        var checkBoxVobSubIsolateColors = new CheckBox
+        {
+            Content = Se.Language.Ocr.VobSubIsolateColors,
+            IsChecked = vm.VobSubIsolateColors,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.VobSubIsolateColors)) { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged },
+        };
+        ToolTip.SetTip(checkBoxVobSubIsolateColors, Se.Language.Ocr.VobSubIsolateColorsHint);
+
         var labelLanguagePostFix = UiUtil.MakeLabel(Se.Language.General.LanguagePostFix);
         var comboBoxLanguagePostFix = UiUtil.MakeComboBox(vm.LanguagePostFixes, vm, nameof(vm.SelectedLanguagePostFix));
         var panelLanguagePostFix = new StackPanel
@@ -123,6 +132,7 @@ public class BatchConvertSettingsWindow : Window
         {
             RowDefinitions =
             {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
@@ -149,8 +159,9 @@ public class BatchConvertSettingsWindow : Window
         grid.Add(checkBoxUseOutputFolder, 3, 0);
         grid.Add(panelOutputFolder, 4, 0);
         grid.Add(panelOcrEngine, 5, 0);
-        grid.Add(panelLanguagePostFix, 6, 0);
-        grid.Add(panelButtons, 7, 0);
+        grid.Add(checkBoxVobSubIsolateColors, 6, 0);
+        grid.Add(panelLanguagePostFix, 7, 0);
+        grid.Add(panelButtons, 8, 0);
 
 
         Content = grid;

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -126,7 +126,10 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             var vobSubMergedPackList = vobSubParser.MergeVobSubPacks();
             var palette = vobSubParser.IdxPalette;
             vobSubParser.VobSubPacks.Clear();
-            imageSubtitle = new OcrSubtitleVobSub(vobSubMergedPackList, palette);
+            imageSubtitle = new OcrSubtitleVobSub(vobSubMergedPackList, palette)
+            {
+                IsolateColors = Se.Settings.Tools.BatchConvert.VobSubIsolateColors,
+            };
             //TODO: multi track
         }
         else if ((item.FileName.EndsWith(".mkv", StringComparison.OrdinalIgnoreCase) || item.FileName.EndsWith(".mks", StringComparison.OrdinalIgnoreCase)) &&
@@ -149,7 +152,10 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                             if (trackId == track.TrackNumber.ToString(CultureInfo.InvariantCulture))
                             {
                                 var vobSubs = LoadVobSubFromMatroska(track, matroska, out var idx);
-                                imageSubtitle = new OcrSubtitleVobSub(vobSubs);
+                                imageSubtitle = new OcrSubtitleVobSub(vobSubs)
+                                {
+                                    IsolateColors = Se.Settings.Tools.BatchConvert.VobSubIsolateColors,
+                                };
                                 var fileName = Path.GetFileName(item.FileName);
                                 item.OutputFileName = fileName.Substring(0, fileName.LastIndexOf('.')).TrimEnd('.') + ".mkv";
                                 break;

--- a/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
+++ b/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
@@ -97,6 +97,8 @@ public class LanguageOcr
     public string VobSubColorEmphasis1 { get; set; }
     public string VobSubColorEmphasis2 { get; set; }
     public string VobSubColorsInvert { get; set; }
+    public string VobSubIsolateColors { get; set; }
+    public string VobSubIsolateColorsHint { get; set; }
     public string LlamaCppOcrSettingsTitle { get; set; }
     public string LlamaCppOcrPromptHint { get; set; }
     public string LlamaCppOcrPromptEmpty { get; set; }
@@ -205,6 +207,8 @@ public class LanguageOcr
         VobSubColorEmphasis1 = "Emphasis 1";
         VobSubColorEmphasis2 = "Emphasis 2";
         VobSubColorsInvert = "Invert background / emphasis 1";
+        VobSubIsolateColors = "Isolate VobSub colors for OCR";
+        VobSubIsolateColorsHint = "Rebuild each VobSub image as crisp black-on-white before OCR by keeping the most frequent color (text) and dropping the outline/anti-alias colors. Improves recognition on discs where gray outlines merge characters together.";
 
         LlamaCppOcrSettingsTitle = "llama.cpp OCR settings";
         LlamaCppOcrPromptHint = "Use {language} to insert the selected OCR language.";

--- a/src/ui/Logic/Config/SeBatchConvert.cs
+++ b/src/ui/Logic/Config/SeBatchConvert.cs
@@ -18,6 +18,15 @@ public class SeBatchConvert
     public string NOcrBinaryOcrFallbackDatabase { get; set; }
     public string BinaryOcrNOcrFallbackDatabase { get; set; }
 
+    /// <summary>
+    /// VobSub OCR only: before recognition, rebuild each subpicture as a crisp black-on-white
+    /// bitmap via histogram-based colour isolation (most frequent opaque colour = glyph fill →
+    /// black, outline / anti-alias colours → white background). On by default; improves
+    /// recognition on discs whose gray outlines otherwise melt adjacent characters together.
+    /// See <see cref="Core.Common.VobSubColorIsolation"/>.
+    /// </summary>
+    public bool VobSubIsolateColors { get; set; }
+
     public bool FormattingRemoveAll { get; set; }
     public bool FormattingRemoveItalic { get; set; }
     public bool FormattingRemoveUnderline { get; set; }
@@ -109,6 +118,7 @@ public class SeBatchConvert
         BinaryOcrDatabase = "Latin";
         NOcrBinaryOcrFallbackDatabase = string.Empty;
         BinaryOcrNOcrFallbackDatabase = string.Empty;
+        VobSubIsolateColors = true;
         OffsetTimeCodesForward = true;
         AdjustVia = "Seconds";
         AdjustDurationSeconds = 0.1;

--- a/tests/seconv/Core/VobSubColorIsolationTest.cs
+++ b/tests/seconv/Core/VobSubColorIsolationTest.cs
@@ -1,0 +1,110 @@
+using Nikse.SubtitleEdit.Core.Common;
+using SkiaSharp;
+using Xunit;
+
+namespace SeConvTests.Core;
+
+/// <summary>
+/// Histogram-based colour isolation for VobSub OCR bitmaps (issue #12293): the dominant
+/// opaque colour (glyph fill) must survive as black, every other opaque colour (outline /
+/// anti-alias tiers) must collapse to the white background, and the result is always an
+/// opaque black-on-white bitmap.
+/// </summary>
+public class VobSubColorIsolationTest
+{
+    private static SKBitmap MakeBitmap(int width, int height, Func<int, int, SKColor> pixel)
+    {
+        var bmp = new SKBitmap(new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Unpremul));
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                bmp.SetPixel(x, y, pixel(x, y));
+            }
+        }
+        return bmp;
+    }
+
+    [Fact]
+    public void Isolate_KeepsDominantFillAsBlack_DropsOutlineToWhite()
+    {
+        // A 10x10 frame: transparent background, a solid fill block (dominant opaque colour)
+        // and a couple of "outline" pixels in a different opaque colour. The fill must become
+        // black; the outline and the transparent background must become white.
+        var fill = new SKColor(200, 30, 30);      // most frequent opaque colour
+        var outline = new SKColor(40, 40, 40);    // less frequent opaque colour
+        using var source = MakeBitmap(10, 10, (x, y) =>
+        {
+            if (x is >= 2 and <= 6 && y is >= 2 and <= 6)
+            {
+                return fill; // 25 pixels
+            }
+            if (y == 1 && x is >= 2 and <= 3)
+            {
+                return outline; // 2 pixels
+            }
+            return SKColors.Transparent;
+        });
+
+        using var result = VobSubColorIsolation.Isolate(source);
+
+        Assert.Equal(SKAlphaType.Opaque, result.AlphaType);
+        Assert.Equal(SKColors.Black, result.GetPixel(4, 4));   // inside the fill block
+        Assert.Equal(SKColors.White, result.GetPixel(2, 1));   // an outline pixel
+        Assert.Equal(SKColors.White, result.GetPixel(0, 0));   // transparent background
+        Assert.Equal(255, result.GetPixel(4, 4).Alpha);        // fully opaque output
+    }
+
+    [Fact]
+    public void Isolate_AllTransparent_ReturnsSolidWhite()
+    {
+        using var source = MakeBitmap(6, 4, (_, _) => SKColors.Transparent);
+
+        using var result = VobSubColorIsolation.Isolate(source);
+
+        Assert.Equal(SKAlphaType.Opaque, result.AlphaType);
+        for (var y = 0; y < result.Height; y++)
+        {
+            for (var x = 0; x < result.Width; x++)
+            {
+                Assert.Equal(SKColors.White, result.GetPixel(x, y));
+            }
+        }
+    }
+
+    [Fact]
+    public void Isolate_SingleOpaqueColor_BecomesBlackOnWhite()
+    {
+        // Only one opaque colour present (no outline) — it is the fill, so it becomes black.
+        var text = new SKColor(255, 255, 255);
+        using var source = MakeBitmap(5, 5, (x, y) => (x == 2 && y is >= 1 and <= 3) ? text : SKColors.Transparent);
+
+        using var result = VobSubColorIsolation.Isolate(source);
+
+        Assert.Equal(SKColors.Black, result.GetPixel(2, 2));
+        Assert.Equal(SKColors.White, result.GetPixel(0, 0));
+    }
+
+    [Fact]
+    public void Isolate_SemiTransparentBelowThreshold_TreatedAsBackground()
+    {
+        // A pixel whose alpha is below the threshold must be ignored (background), even if it
+        // would otherwise be the most frequent colour.
+        var faint = new SKColor(200, 30, 30, 64);  // alpha 64 < default threshold 128
+        var solid = new SKColor(10, 220, 10, 255);
+        using var source = MakeBitmap(8, 8, (x, y) =>
+        {
+            if (y < 6)
+            {
+                return faint; // many faint pixels, but below threshold
+            }
+            return (x < 2) ? solid : SKColors.Transparent; // few solid pixels
+        });
+
+        using var result = VobSubColorIsolation.Isolate(source);
+
+        // Faint region → background (white); the only above-threshold colour is the fill (black).
+        Assert.Equal(SKColors.White, result.GetPixel(4, 0));
+        Assert.Equal(SKColors.Black, result.GetPixel(0, 7));
+    }
+}


### PR DESCRIPTION
Implements the feature requested in #12293: automatic colour isolation for VobSub/DVD OCR, so gray outlines and anti-aliasing no longer melt adjacent characters together (`Yuri` → `Yurl`) during unattended/batch OCR.

## Problem

A VobSub subpicture is a strict 4-colour indexed image (transparent background, glyph fill, and 1–2 outline/anti-alias colours). When composited for OCR, the outline colours bleed into the fill and the recogniser merges glyphs. DVD authoring tools assign the palette indices unpredictably from disc to disc, so there's no fixed colour to strip in a headless run.

## Approach

A preprocessing pass rebuilds each subpicture as a crisp **black-on-white** bitmap purely from pixel frequency:
- transparent pixels → background
- the **most frequent opaque colour** (the glyph fill) → black
- every other opaque colour (outline / anti-alias tiers) → white background

This matches the histogram tiering proposed in the issue, producing a clean binary mask that OCR engines recognise far more reliably.

## Changes

- **`libse`**: new shared `VobSubColorIsolation` helper (so both the CLI and UI use one implementation).
- **seconv CLI**: on by default; disable with `--no-vobsub-isolate-colors`. Docs + help updated.
- **Batch Convert UI**: on by default via a new `SeBatchConvert.VobSubIsolateColors` setting and a checkbox in the Batch Convert settings dialog. Applied through `OcrSubtitleVobSub`, so **all** OCR engines (Tesseract, nOCR, BinaryOCR, Ollama, PaddleOCR) benefit.
- The interactive OCR window and other `OcrSubtitleVobSub` users are unaffected (`IsolateColors` defaults to `false` there).

## Tests

- 4 new unit tests for the isolation logic (dominant-fill isolation, all-transparent, single-colour, sub-threshold alpha).
- Full seconv suite green (177 passing); `libse` + UI build clean.

## Notes

- **Default-on** in both the CLI and UI, per discussion — the flag/checkbox turns it **off**.
- Heuristic assumption: the glyph *fill* covers more pixels than the outline stroke (true for typical DVD subtitles). On a disc with very thin text inside a very thick border the dominant colour could be the outline — that's why it's toggleable.
- Only English `LanguageOcr` strings were added; other language files fall back to English.

Closes #12293

🤖 Generated with [Claude Code](https://claude.com/claude-code)