### PR TITLE
Fix oversized ODS for empty subtitles in image-based export

### DIFF
--- a/src/libuilogic/Export/ImageRenderer.cs
+++ b/src/libuilogic/Export/ImageRenderer.cs
@@ -90,6 +90,18 @@ public static class ImageRenderer
 
         // Split segments into lines
         var lines = SplitIntoSegments(segments);
+
+        // Empty/whitespace-only subtitles draw nothing, so TrimTransparentPixels would
+        // fall back to the full oversized temp canvas below - larger than the video
+        // plane, which makes e.g. BDSup2Sub reject the exported file. Return a tiny
+        // transparent bitmap instead.
+        if (lines.All(line => line.All(segment => string.IsNullOrWhiteSpace(segment.Text))))
+        {
+            var emptyBitmap = new SKBitmap(2, 2);
+            emptyBitmap.Erase(SKColors.Transparent);
+            return emptyBitmap;
+        }
+
         var fontMetrics = regularFont.Metrics;
 
         // Calculate line spacing


### PR DESCRIPTION
Fixes #12299.

### What was wrong

The source subtitle in the issue contains 13 empty events. For empty/whitespace-only text, `ImageRenderer.GenerateBitmap` draws nothing onto its oversized scratch canvas (`max(4000, screenWidth) x max(2000, screenHeight)`), and `TrimTransparentPixels` explicitly falls back to returning the *full untrimmed bitmap* when every pixel is transparent. After padding, that produced a 4004x2004 ODS object — larger than the video plane at any export resolution (even 3840x2160, since the scratch canvas is at least 4000 wide) — so BDSup2Sub rejects the file with `Subpicture too large: 4004x2004`. Centering the oversized bitmap also made the x-offset negative, wrapping to 64174 in the unsigned PCS/WDS position fields.

4.0.16 emitted a small ~150x50 transparent bitmap for empty text, which is why its exports load fine.

(Not related to #12074 — that PR only changed PTS/DTS fields; this degenerate-render path has existed since the 5.x renderer was introduced.)

### The fix

In `ImageRenderer.GenerateBitmap`, detect empty/whitespace-only subtitles after line splitting and return a 2x2 transparent bitmap, mirroring 4.0.16 behavior and keeping event timing intact.

### Verification

Exported the reporter's source SRT to Blu-ray SUP via seconv and ran a segment validator applying BDSup2Sub's checks (ODS dimensions vs. PCS video size, composition positions in bounds):

- All 44 events exported; the 13 empty subtitles now produce 2x2 ODS objects (previously 4004x2004)
- 0 oversize errors, 0 out-of-bounds positions (previous wrapped x=64174 is now 639)
- Non-empty subtitles render unchanged (e.g. 566x152, 887x40)

🤖 Generated with [Claude Code](https://claude.com/claude-code)