### PR TITLE
Add an AI assistant button to the subtitle text box (#12285)

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -379,6 +379,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<FindViewModel>();
         collection.AddTransient<FixCommonErrorsProfileViewModel>();
         collection.AddTransient<Features.Tools.AiReview.AiReviewViewModel>();
+        collection.AddTransient<Features.Main.AiAssistant.AiAssistantViewModel>();
         collection.AddTransient<Features.Tools.AiReview.AiReviewPromptViewModel>();
         collection.AddTransient<FixCommonErrorsViewModel>();
         collection.AddTransient<FixNamesViewModel>();

--- a/src/ui/Features/Main/AiAssistant/AiAssistantViewModel.cs
+++ b/src/ui/Features/Main/AiAssistant/AiAssistantViewModel.cs
@@ -1,0 +1,247 @@
+using Avalonia.Controls;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Tools.AiReview;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.LlamaCpp;
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Main.AiAssistant;
+
+/// <summary>
+/// The subtitle text box AI assistant: quick actions and a free question for the
+/// current line, with the neighbouring lines given as context. Reuses the same
+/// engines, models and settings as Tools -> AI review (Ollama, llama.cpp, or an
+/// OpenAI compatible server); nothing is applied automatically, the user reviews
+/// the suggestion and presses Apply.
+/// </summary>
+public partial class AiAssistantViewModel : ObservableObject
+{
+    [ObservableProperty] private string _currentText;
+    [ObservableProperty] private string _contextText;
+    [ObservableProperty] private string _questionText;
+    [ObservableProperty] private string _resultText;
+    [ObservableProperty] private string _statusText;
+    [ObservableProperty] private bool _isBusy;
+    [ObservableProperty] private string _selectedEngine;
+
+    public Window? Window { get; set; }
+    public bool ApplyPressed { get; private set; }
+    public string ResultToApply { get; private set; } = string.Empty;
+
+    private string _language;
+    private double _maxCharsPerSecond;
+    private int _maxSingleLineLength;
+    private CancellationTokenSource? _cancellationTokenSource;
+
+    public AiAssistantViewModel()
+    {
+        _currentText = string.Empty;
+        _contextText = string.Empty;
+        _questionText = string.Empty;
+        _resultText = string.Empty;
+        _statusText = string.Empty;
+        _language = "the same language as the text";
+        _maxCharsPerSecond = 20;
+        _maxSingleLineLength = 42;
+        _selectedEngine = string.IsNullOrEmpty(Se.Settings.Tools.AiReview.Engine)
+            ? SeAiReview.EngineLlamaCpp
+            : Se.Settings.Tools.AiReview.Engine;
+    }
+
+    public void Initialize(string currentText, string contextText, string? languageName,
+        double maxCharsPerSecond, int maxSingleLineLength)
+    {
+        CurrentText = currentText ?? string.Empty;
+        ContextText = contextText ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(languageName))
+        {
+            _language = languageName!;
+        }
+
+        if (maxCharsPerSecond > 0)
+        {
+            _maxCharsPerSecond = maxCharsPerSecond;
+        }
+
+        if (maxSingleLineLength > 0)
+        {
+            _maxSingleLineLength = maxSingleLineLength;
+        }
+    }
+
+    [RelayCommand]
+    private Task FixErrors() => RunAsync(
+        "Fix only spelling, grammar and punctuation errors in the current subtitle line, in " + _language + ". " +
+        "Do not rephrase, do not change meaning, tone or style. Keep names, slang and intentional dialect. " +
+        "Keep formatting tags and line breaks. Return only the corrected line, nothing else.");
+
+    [RelayCommand]
+    private Task FitReadingSpeed() => RunAsync(
+        "Rephrase the current subtitle line in " + _language + " so it is shorter and easier to read, " +
+        "keeping the exact meaning. Aim for at most " + _maxSingleLineLength.ToString(CultureInfo.InvariantCulture) +
+        " characters per line and a comfortable reading speed of about " +
+        _maxCharsPerSecond.ToString(CultureInfo.InvariantCulture) + " characters per second. " +
+        "Keep formatting tags. Return only the rephrased line, nothing else.");
+
+    [RelayCommand]
+    private Task MakeFormal() => RunAsync(
+        "Rewrite the current subtitle line in " + _language + " in a more formal register, keeping the meaning. " +
+        "Keep formatting tags and line breaks. Return only the rewritten line, nothing else.");
+
+    [RelayCommand]
+    private Task MakeInformal() => RunAsync(
+        "Rewrite the current subtitle line in " + _language + " in a more casual, colloquial register, keeping the meaning. " +
+        "Keep formatting tags and line breaks. Return only the rewritten line, nothing else.");
+
+    [RelayCommand]
+    private Task Ask()
+    {
+        if (string.IsNullOrWhiteSpace(QuestionText))
+        {
+            return Task.CompletedTask;
+        }
+
+        return RunAsync(
+            "You are helping a subtitler with the current subtitle line, in " + _language + ". " +
+            "Use the surrounding lines only as context. Answer the request. " +
+            "If the request asks to change the line, return only the new line text with no explanation; " +
+            "otherwise answer briefly.\n\nRequest: " + QuestionText.Trim());
+    }
+
+    private async Task RunAsync(string instruction)
+    {
+        if (IsBusy || Window == null)
+        {
+            return;
+        }
+
+        var systemPrompt =
+            "You are a professional subtitle assistant. You are given the current subtitle line and, for context " +
+            "only, the lines before and after it. Follow the instruction. Never invent content that is not implied " +
+            "by the line. When returning a changed line, return only the line text.";
+
+        var userContent =
+            "Context (previous and next lines, do not change these):\n" + ContextText +
+            "\n\nCurrent line:\n" + CurrentText +
+            "\n\nInstruction:\n" + instruction;
+
+        var review = Se.Settings.Tools.AiReview;
+        string url;
+        var model = string.Empty;
+        string? apiKey = null;
+
+        try
+        {
+            IsBusy = true;
+            StatusText = SelectedEngine + "...";
+            ResultText = string.Empty;
+
+            if (SelectedEngine == SeAiReview.EngineOpenAiCompatible)
+            {
+                url = (review.OpenAiCompatibleUrl ?? string.Empty).Trim();
+                model = (review.OpenAiCompatibleModel ?? string.Empty).Trim();
+                apiKey = string.IsNullOrWhiteSpace(review.OpenAiCompatibleApiKey)
+                    ? null
+                    : review.OpenAiCompatibleApiKey.Trim();
+            }
+            else if (SelectedEngine == SeAiReview.EngineOllama)
+            {
+                url = review.OllamaUrl;
+                model = (review.OllamaModel ?? string.Empty).Trim();
+            }
+            else
+            {
+                var reviewModel = LlamaCppServerManager.GetAllReviewModels()
+                    .FirstOrDefault(m => m.FileName == review.LlamaCppModelFileName);
+                if (reviewModel == null)
+                {
+                    await MessageBox.Show(Window, Se.Language.Tools.AiReview.Title,
+                        Se.Language.Tools.AiReview.SetupHint, MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    return;
+                }
+
+                await LlamaCppServerManager.EnsureServerRunningAsync(reviewModel, CancellationToken.None);
+                url = LlamaCppServerManager.ApiUrl;
+            }
+
+            _cancellationTokenSource = new CancellationTokenSource();
+            using var client = new AiReviewClient();
+            var reply = await client.ChatAsync(url, model, systemPrompt, userContent,
+                _cancellationTokenSource.Token, apiKey);
+            ResultText = CleanReply(reply);
+        }
+        catch (Exception e)
+        {
+            ResultText = string.Empty;
+            await MessageBox.Show(Window, Se.Language.General.Error, e.Message,
+                MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+        finally
+        {
+            IsBusy = false;
+            StatusText = string.Empty;
+        }
+    }
+
+    private static string CleanReply(string reply)
+    {
+        if (string.IsNullOrWhiteSpace(reply))
+        {
+            return string.Empty;
+        }
+
+        var text = reply.Trim();
+
+        // Some models wrap the answer in a code fence; strip it.
+        if (text.StartsWith("```", StringComparison.Ordinal))
+        {
+            var firstBreak = text.IndexOf('\n');
+            if (firstBreak > 0)
+            {
+                text = text[(firstBreak + 1)..];
+            }
+
+            if (text.EndsWith("```", StringComparison.Ordinal))
+            {
+                text = text[..^3];
+            }
+
+            text = text.Trim();
+        }
+
+        // Or in surrounding quotes.
+        if (text.Length >= 2 && text[0] == '"' && text[^1] == '"')
+        {
+            text = text[1..^1].Trim();
+        }
+
+        return text;
+    }
+
+    [RelayCommand]
+    private void Apply()
+    {
+        if (string.IsNullOrWhiteSpace(ResultText))
+        {
+            return;
+        }
+
+        ResultToApply = ResultText.Trim();
+        ApplyPressed = true;
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        _cancellationTokenSource?.Cancel();
+        Window?.Close();
+    }
+}

--- a/src/ui/Features/Main/AiAssistant/AiAssistantViewModel.cs
+++ b/src/ui/Features/Main/AiAssistant/AiAssistantViewModel.cs
@@ -174,7 +174,7 @@ public partial class AiAssistantViewModel : ObservableObject
             _cancellationTokenSource = new CancellationTokenSource();
             using var client = new AiReviewClient();
             var reply = await client.ChatAsync(url, model, systemPrompt, userContent,
-                _cancellationTokenSource.Token, apiKey);
+                _cancellationTokenSource.Token, apiKey, preferJsonObject: false);
             ResultText = CleanReply(reply);
         }
         catch (Exception e)
@@ -198,6 +198,17 @@ public partial class AiAssistantViewModel : ObservableObject
         }
 
         var text = reply.Trim();
+
+        // A model may still answer with a JSON object (some ignore the plain-text
+        // request); take the first string value out of it.
+        if (text.StartsWith("{", StringComparison.Ordinal))
+        {
+            var fromJson = TryExtractJsonString(text);
+            if (!string.IsNullOrWhiteSpace(fromJson))
+            {
+                text = fromJson.Trim();
+            }
+        }
 
         // Some models wrap the answer in a code fence; strip it.
         if (text.StartsWith("```", StringComparison.Ordinal))
@@ -223,6 +234,36 @@ public partial class AiAssistantViewModel : ObservableObject
         }
 
         return text;
+    }
+
+    private static string? TryExtractJsonString(string text)
+    {
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(text);
+            if (doc.RootElement.ValueKind != System.Text.Json.JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            foreach (var property in doc.RootElement.EnumerateObject())
+            {
+                if (property.Value.ValueKind == System.Text.Json.JsonValueKind.String)
+                {
+                    var value = property.Value.GetString();
+                    if (!string.IsNullOrWhiteSpace(value))
+                    {
+                        return value;
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // Not valid JSON; leave the text as it is.
+        }
+
+        return null;
     }
 
     [RelayCommand]

--- a/src/ui/Features/Main/AiAssistant/AiAssistantWindow.cs
+++ b/src/ui/Features/Main/AiAssistant/AiAssistantWindow.cs
@@ -1,0 +1,119 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Main.AiAssistant;
+
+public class AiAssistantWindow : Window
+{
+    public AiAssistantWindow(AiAssistantViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        var l = Se.Language.Tools.AiAssistant;
+        Title = l.Title;
+        Width = 720;
+        Height = 620;
+        MinWidth = 520;
+        MinHeight = 460;
+        CanResize = true;
+        vm.Window = this;
+        DataContext = vm;
+
+        var grid = new Grid
+        {
+            Margin = new Thickness(15),
+            RowDefinitions = new RowDefinitions("Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,*,Auto,Auto"),
+            ColumnDefinitions = new ColumnDefinitions("*"),
+        };
+
+        var currentLabel = UiUtil.MakeTextBlock(l.CurrentLine);
+        var currentBox = MakeReadonlyMultiline(vm, nameof(vm.CurrentText), 60);
+
+        var contextLabel = UiUtil.MakeTextBlock(l.ContextLines);
+        var contextBox = MakeReadonlyMultiline(vm, nameof(vm.ContextText), 70);
+
+        var actionPanel = new WrapPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Margin = new Thickness(0, 8, 0, 0),
+        };
+        actionPanel.Children.Add(MakeActionButton(l.FixErrors, vm.FixErrorsCommand));
+        actionPanel.Children.Add(MakeActionButton(l.FitReadingSpeed, vm.FitReadingSpeedCommand));
+        actionPanel.Children.Add(MakeActionButton(l.MakeFormal, vm.MakeFormalCommand));
+        actionPanel.Children.Add(MakeActionButton(l.MakeInformal, vm.MakeInformalCommand));
+
+        var questionBox = UiUtil.MakeTextBox(420, vm, nameof(vm.QuestionText));
+        questionBox.Watermark = l.AskPlaceholder;
+        var askButton = UiUtil.MakeButton(l.Ask, vm.AskCommand).Compact();
+        var questionPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 6,
+            Margin = new Thickness(0, 8, 0, 0),
+            Children = { questionBox, askButton },
+        };
+
+        var resultLabel = UiUtil.MakeTextBlock(l.Result);
+        resultLabel.Margin = new Thickness(0, 8, 0, 0);
+        var resultBox = new TextBox
+        {
+            AcceptsReturn = true,
+            TextWrapping = Avalonia.Media.TextWrapping.Wrap,
+            MinHeight = 120,
+            VerticalAlignment = VerticalAlignment.Stretch,
+        };
+        resultBox.Bind(TextBox.TextProperty, new Binding(nameof(vm.ResultText)) { Mode = BindingMode.TwoWay });
+
+        var statusText = UiUtil.MakeTextBlock(string.Empty);
+        statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.StatusText)));
+        statusText.Margin = new Thickness(0, 6, 0, 0);
+
+        var applyButton = UiUtil.MakeButton(l.Apply, vm.ApplyCommand);
+        var closeButton = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var buttonPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Spacing = 8,
+            Margin = new Thickness(0, 12, 0, 0),
+            Children = { applyButton, closeButton },
+        };
+
+        grid.Add(currentLabel, 0, 0);
+        grid.Add(currentBox, 1, 0);
+        grid.Add(contextLabel, 2, 0);
+        grid.Add(contextBox, 3, 0);
+        grid.Add(actionPanel, 4, 0);
+        grid.Add(questionPanel, 5, 0);
+        grid.Add(resultLabel, 6, 0);
+        grid.Add(resultBox, 8, 0);
+        grid.Add(statusText, 9, 0);
+        grid.Add(buttonPanel, 10, 0);
+
+        Content = grid;
+    }
+
+    private static TextBox MakeReadonlyMultiline(AiAssistantViewModel vm, string path, double minHeight)
+    {
+        var box = new TextBox
+        {
+            IsReadOnly = true,
+            AcceptsReturn = true,
+            TextWrapping = Avalonia.Media.TextWrapping.Wrap,
+            MinHeight = minHeight,
+            Margin = new Thickness(0, 2, 0, 0),
+        };
+        box.Bind(TextBox.TextProperty, new Binding(path));
+        return box;
+    }
+
+    private static Button MakeActionButton(string text, CommunityToolkit.Mvvm.Input.IRelayCommand command)
+    {
+        var button = UiUtil.MakeButton(text, command).Compact();
+        button.Margin = new Thickness(0, 0, 6, 6);
+        return button;
+    }
+}

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1610,6 +1610,16 @@ public static partial class InitListViewAndEditBox
             buttonPanel.Children.Add(removeFormattingButton);
         }
 
+        if (Se.Settings.Appearance.TextBoxShowButtonAiAssistant)
+        {
+            var aiAssistantButton = UiUtil.MakeButton(vm.ShowAiAssistantCommand, IconNames.Robot);
+            if (Se.Settings.Appearance.ShowHints)
+            {
+                ToolTip.SetTip(aiAssistantButton, Se.Language.Tools.AiAssistant.Hint);
+            }
+            buttonPanel.Children.Add(aiAssistantButton);
+        }
+
         textEditGrid.Add(buttonPanel, 1, 2);
 
         Grid.SetColumn(textEditGrid, 1);

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5358,6 +5358,76 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private async Task ShowAiAssistant()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var current = SelectedSubtitle;
+        if (current == null)
+        {
+            return;
+        }
+
+        var index = SelectedSubtitleIndex ?? Subtitles.IndexOf(current);
+
+        // Give the model the neighbouring lines as read-only context so it can
+        // resolve pronouns, speaker, and tone without changing them.
+        var context = new StringBuilder();
+        var from = Math.Max(0, index - 3);
+        var to = Math.Min(Subtitles.Count - 1, index + 3);
+        for (var i = from; i <= to; i++)
+        {
+            if (i == index)
+            {
+                continue;
+            }
+
+            var text = Subtitles[i].Text;
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                context.AppendLine(text.Replace(Environment.NewLine, " ").Replace("\n", " "));
+            }
+        }
+
+        var languageName = TwoLetterCodeToLanguageName(
+            LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(GetUpdateSubtitle()));
+
+        var result = await ShowDialogAsync<AiAssistant.AiAssistantWindow, AiAssistant.AiAssistantViewModel>(vm =>
+            vm.Initialize(
+                current.Text,
+                context.ToString().TrimEnd(),
+                languageName,
+                Se.Settings.General.SubtitleMaximumCharactersPerSeconds,
+                Se.Settings.General.SubtitleLineMaximumLength));
+
+        if (result.ApplyPressed && !string.IsNullOrEmpty(result.ResultToApply))
+        {
+            current.Text = result.ResultToApply;
+            SelectAndScrollToRow(index);
+        }
+    }
+
+    private static string? TwoLetterCodeToLanguageName(string? twoLetterCode)
+    {
+        if (string.IsNullOrEmpty(twoLetterCode))
+        {
+            return null;
+        }
+
+        try
+        {
+            return CultureInfo.GetCultureInfo(twoLetterCode).EnglishName;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    [RelayCommand]
     private async Task ShowToolsFixCommonErrors()
     {
         if (Window == null)

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -692,6 +692,7 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.TextBoxButtonShowItalic, nameof(_vm.TextBoxButtonShowItalic)),
             MakeCheckboxSetting(Se.Language.Options.Settings.TextBoxButtonShowColor, nameof(_vm.TextBoxButtonShowColor)),
             MakeCheckboxSetting(Se.Language.Options.Settings.TextBoxButtonShowRemoveFormatting, nameof(_vm.TextBoxButtonShowRemoveFormatting)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.TextBoxButtonShowAiAssistant, nameof(_vm.TextBoxButtonShowAiAssistant)),
 
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowUpDownStartTime, nameof(_vm.ShowUpDownStartTime)),
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowUpDownEndTime, nameof(_vm.ShowUpDownEndTime)),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -210,6 +210,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _textBoxButtonShowItalic;
     [ObservableProperty] private bool _textBoxButtonShowColor;
     [ObservableProperty] private bool _textBoxButtonShowRemoveFormatting;
+    [ObservableProperty] private bool _textBoxButtonShowAiAssistant;
 
     [ObservableProperty] private bool _colorDurationTooShort;
     [ObservableProperty] private bool _colorDurationTooLong;
@@ -812,6 +813,7 @@ public partial class SettingsViewModel : ObservableObject
         TextBoxButtonShowItalic = appearance.TextBoxShowButtonItalic;
         TextBoxButtonShowColor = appearance.TextBoxShowButtonColor;
         TextBoxButtonShowRemoveFormatting = appearance.TextBoxShowButtonRemoveFormatting;
+        TextBoxButtonShowAiAssistant = appearance.TextBoxShowButtonAiAssistant;
         ShowButtonHints = appearance.ShowHints;
         GridCompactMode = appearance.GridCompactMode;
         GridAlternatingRows = appearance.GridAlternatingRows;
@@ -1547,6 +1549,7 @@ public partial class SettingsViewModel : ObservableObject
         appearance.TextBoxShowButtonItalic = TextBoxButtonShowItalic;
         appearance.TextBoxShowButtonColor = TextBoxButtonShowColor;
         appearance.TextBoxShowButtonRemoveFormatting = TextBoxButtonShowRemoveFormatting;
+        appearance.TextBoxShowButtonAiAssistant = TextBoxButtonShowAiAssistant;
         appearance.ShowHints = ShowButtonHints;
         appearance.DarkModeBackgroundColor = DarkModeBackgroundColor.FromColorToHex();
         appearance.DarkModeForegroundColor = DarkModeForegroundColor.FromColorToHex();

--- a/src/ui/Features/Tools/AiReview/AiReviewClient.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewClient.cs
@@ -25,13 +25,17 @@ public class AiReviewClient : IDisposable
         _httpClient.Timeout = TimeSpan.FromMinutes(15);
     }
 
-    public async Task<string> ChatAsync(string url, string model, string systemPrompt, string userContent, CancellationToken cancellationToken, string? apiKey = null)
+    public async Task<string> ChatAsync(string url, string model, string systemPrompt, string userContent, CancellationToken cancellationToken, string? apiKey = null, bool preferJsonObject = true)
     {
         Error = string.Empty;
 
-        // First try with enforced JSON output; some servers reject response_format, so retry without.
-        var response = await PostAsync(url, BuildRequestJson(model, systemPrompt, userContent, jsonMode: true), apiKey, cancellationToken);
-        if (!response.ok && !cancellationToken.IsCancellationRequested)
+        // AI review wants a JSON object back; the text box assistant wants the plain
+        // reply, so it passes preferJsonObject: false to avoid a JSON-wrapped answer.
+        // Some servers reject response_format, so a JSON request also retries plain.
+        var response = await PostAsync(url,
+            BuildRequestJson(model, systemPrompt, userContent, jsonMode: preferJsonObject),
+            apiKey, cancellationToken);
+        if (!response.ok && preferJsonObject && !cancellationToken.IsCancellationRequested)
         {
             response = await PostAsync(url, BuildRequestJson(model, systemPrompt, userContent, jsonMode: false), apiKey, cancellationToken);
         }

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -316,6 +316,7 @@ public class LanguageSettings
     public string TextBoxButtonShowItalic { get; set; }
     public string TextBoxButtonShowColor { get; set; }
     public string TextBoxButtonShowRemoveFormatting { get; set; }
+    public string TextBoxButtonShowAiAssistant { get; set; }
     public string WaveformSingleClickAction { get; set; }
     public string WaveformDoubleClickAction { get; set; }
     public string AllSettings { get; set; }
@@ -644,6 +645,7 @@ public class LanguageSettings
         TextBoxButtonShowItalic = "Text box: show italic button";
         TextBoxButtonShowColor = "Text box: show color button";
         TextBoxButtonShowRemoveFormatting = "Text box: show remove formatting button";
+        TextBoxButtonShowAiAssistant = "Text box: show AI assistant button";
         WaveformSingleClickAction = "Waveform single-click action";
         WaveformDoubleClickAction = "Waveform double-click action (after single-click action)";
         AllSettings = "All settings";

--- a/src/ui/Logic/Config/Language/Tools/LanguageAiAssistant.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageAiAssistant.cs
@@ -1,0 +1,33 @@
+namespace Nikse.SubtitleEdit.Logic.Config.Language.Tools;
+
+public class LanguageAiAssistant
+{
+    public string Title { get; set; }
+    public string CurrentLine { get; set; }
+    public string ContextLines { get; set; }
+    public string FixErrors { get; set; }
+    public string FitReadingSpeed { get; set; }
+    public string MakeFormal { get; set; }
+    public string MakeInformal { get; set; }
+    public string AskPlaceholder { get; set; }
+    public string Ask { get; set; }
+    public string Result { get; set; }
+    public string Apply { get; set; }
+    public string Hint { get; set; }
+
+    public LanguageAiAssistant()
+    {
+        Title = "AI assistant";
+        CurrentLine = "Current line";
+        ContextLines = "Context (lines before and after)";
+        FixErrors = "Fix errors";
+        FitReadingSpeed = "Fit reading speed";
+        MakeFormal = "More formal";
+        MakeInformal = "More casual";
+        AskPlaceholder = "Ask about this line, or ask for a change...";
+        Ask = "Ask";
+        Result = "Suggestion";
+        Apply = "Apply to line";
+        Hint = "AI assistant for this line";
+    }
+}

--- a/src/ui/Logic/Config/Language/Tools/LanguageAiReview.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageAiReview.cs
@@ -26,6 +26,7 @@ public class LanguageAiReview
     public string LinesXToY { get; set; }
     public string LargeChangeWarning { get; set; }
     public string EngineError { get; set; }
+    public string SetupHint { get; set; }
 
     public LanguageAiReview()
     {
@@ -53,5 +54,6 @@ public class LanguageAiReview
         LinesXToY = "Lines {0}-{1}";
         LargeChangeWarning = "Large change - looks like a rewrite, review carefully";
         EngineError = "The AI engine could not be reached: {0}";
+        SetupHint = "Please choose an engine and model in Tools -> AI review first.";
     }
 }

--- a/src/ui/Logic/Config/Language/Tools/LanguageTools.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageTools.cs
@@ -3,6 +3,7 @@
 public class LanguageTools
 {
     public LanguageAiReview AiReview { get; set; } = new();
+    public LanguageAiAssistant AiAssistant { get; set; } = new();
     public LanguageFixCommonErrors FixCommonErrors { get; set; } = new();
     public LanguageAdjustDisplayDurations AdjustDurations { get; set; } = new();
     public LanguageApplyDurationLimits ApplyDurationLimits { get; set; } = new();

--- a/src/ui/Logic/Config/SeAppearance.cs
+++ b/src/ui/Logic/Config/SeAppearance.cs
@@ -81,6 +81,7 @@ public class SeAppearance
     public bool TextBoxShowButtonItalic { get; set; }
     public bool TextBoxShowButtonColor { get; set; }
     public bool TextBoxShowButtonRemoveFormatting { get; set; }
+    public bool TextBoxShowButtonAiAssistant { get; set; }
 
     public SeAppearance()
     {
@@ -145,5 +146,6 @@ public class SeAppearance
         TextBoxShowButtonItalic = true;
         TextBoxShowButtonColor = false;
         TextBoxShowButtonRemoveFormatting = false;
+        TextBoxShowButtonAiAssistant = true;
     }
 }

--- a/src/ui/Logic/IconNames.cs
+++ b/src/ui/Logic/IconNames.cs
@@ -73,6 +73,7 @@ internal class IconNames
     public const string Next = "mdi-chevron-right";
     public const string Ocr = "mdi-ocr";
     public const string Palette = "mdi-palette";
+    public const string Robot = "mdi-robot";
     public const string PanRight = "mdi-pan-right";
     public const string Pause = "mdi-pause";
     public const string PauseCircle = "mdi-pause-circle";


### PR DESCRIPTION
Implements the text box AI assistant from #12285, following your suggestion to make it an optional text box button (like auto-break / unbreak / italic) with a robot icon that reuses the same engines and models as Tools -> AI review.

### What it does

A robot icon button next to the subtitle text box opens an assistant for the current line:

- Quick actions: Fix errors (spelling, grammar, punctuation); Fit reading speed (rephrase shorter to the line length and CPS limits); More formal; More casual.
- A free question box for anything else about the line.
- The lines before and after the current one are sent as read-only context, so the model can resolve pronouns, speaker and tone without changing them.
- Nothing is applied automatically: the suggestion appears in an editable box and is written to the line only when the user presses Apply, through the normal edit and undo path.

### How it connects

It reuses `AiReviewClient` and the `Tools -> AI review` settings (Ollama, llama.cpp, or an OpenAI compatible server), so there is no new configuration and no new dependency. The AI review client gained one optional argument so the assistant can request a plain text answer instead of a JSON object; AI review's behavior is unchanged.

The button is on by default and can be hidden in Options -> Settings (Text box: show AI assistant button).

### Notes

New UI strings live in a small `LanguageAiAssistant` section; the English defaults are in the class so untranslated languages fall back cleanly. Tested end to end on macOS against a local OpenAI compatible server, including Arabic lines with surrounding context. Screenshots below.
