### PR TITLE
Do not mirror the video and waveform in right to left mode

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -421,6 +421,12 @@ public class AudioVisualizer : Control
 
     public AudioVisualizer()
     {
+        // A right to left UI language sets the whole window to RightToLeft, which
+        // mirrors every visual, including this waveform (the peaks and the region
+        // labels would render flipped). Pin the control to left to right so the
+        // waveform is never mirrored regardless of the UI language.
+        FlowDirection = Avalonia.Media.FlowDirection.LeftToRight;
+
         AllSelectedParagraphs = new List<SubtitleLineViewModel>();
         Focusable = true;
         IsHitTestVisible = true;

--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -221,6 +221,12 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
 
         public VideoPlayerControl(IVideoPlayer videoPlayerInstance)
         {
+            // A right to left UI language sets the whole window to RightToLeft, which
+            // mirrors every visual, including this video surface (the picture and any
+            // overlay would render flipped). Pin the player to left to right so the
+            // video is never mirrored regardless of the UI language.
+            FlowDirection = Avalonia.Media.FlowDirection.LeftToRight;
+
             _videoPlayerInstance = videoPlayerInstance;
             _videoFileName = string.Empty;
             _lastActivityTime = DateTime.UtcNow;


### PR DESCRIPTION
### Problem

With a right to left interface language (Arabic, Hebrew, Persian, and so on) the whole window FlowDirection is set to RightToLeft. That is correct for text and layout, but it also horizontally mirrors the graphics surfaces: the video picture rendered flipped (the image and any burned in preview text appeared mirrored, watermark reversed) and the waveform peaks and region labels rendered reversed.

### Fix

The video player control and the audio visualizer are pinned to FlowDirection LeftToRight in their constructors, so those two surfaces always render normally regardless of the interface language, while the rest of the window still mirrors for right to left languages. Text drawn inside them (the waveform region labels) is shaped correctly and no longer flipped.

### Testing

Verified on macOS with the Arabic interface language: the video picture and the waveform render normally (not mirrored), the rest of the UI still mirrors right to left. Left to right languages are unaffected.
