### PR TITLE
Automate winget submission for stable UI releases

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -894,6 +894,56 @@ jobs:
             ./release-assets/SubtitleEdit-Linux-ARM64.tar.gz
             ./release-assets/SubtitleEdit-linux-x64.flatpak
 
+  # Opens a version-bump PR against microsoft/winget-pkgs for the Nikse.SubtitleEdit
+  # package (issue #12292). Uses komac (via the winget-releaser action), which
+  # downloads the Inno installer and re-derives ProductCode/architecture from the
+  # binary itself — important because the v5 installer's AppID differs from the
+  # SubtitleEdit_is1 ProductCode in the pre-5.x manifests.
+  # Requirements (both already exist / must stay in place):
+  #   - WINGET_TOKEN secret: a *classic* PAT with public_repo scope (fine-grained
+  #     tokens are not supported by the action).
+  #   - A fork of microsoft/winget-pkgs under the token owner's account
+  #     (github.com/niksedk/winget-pkgs — matching fork-user below).
+  publish-winget:
+    if: ${{ inputs.create_release && !inputs.is_prerelease }}
+    needs: create-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check preconditions
+        id: check
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          TAG: ${{ needs.create-release.outputs.release_tag }}
+        run: |
+          if [ -z "$WINGET_TOKEN" ]; then
+            echo "::warning::WINGET_TOKEN secret is not set - skipping winget submission."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Only plain stable tags (v5.1.0) go to winget. Suffixed tags
+          # (v5.1.0-beta12) and auto-generated pre-release-* tags are skipped
+          # even if the run was accidentally not marked as a pre-release.
+          case "$TAG" in
+            v[0-9]*-*)
+              echo "::warning::Tag '$TAG' looks like a pre-release - skipping winget submission."
+              echo "run=false" >> "$GITHUB_OUTPUT" ;;
+            v[0-9]*)
+              echo "run=true" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "::warning::Tag '$TAG' is not a version tag - skipping winget submission."
+              echo "run=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Create winget-pkgs PR
+        if: steps.check.outputs.run == 'true'
+        uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
+        with:
+          identifier: Nikse.SubtitleEdit
+          installers-regex: 'SubtitleEdit-Windows-x64-Setup\.exe$'
+          release-tag: ${{ needs.create-release.outputs.release_tag }}
+          fork-user: niksedk
+          token: ${{ secrets.WINGET_TOKEN }}
+
   call-seconv:
     needs: [create-release]
     uses: ./.github/workflows/build-seconv.yml


### PR DESCRIPTION
Closes #12292 (the automation part — the 5.0.0 bump itself still needs one manual/first run, see below).

## What
Adds a `publish-winget` job to the UI release workflow that automatically opens a version-bump PR against [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) for `Nikse.SubtitleEdit` whenever a **stable** release is published.

## How
- Runs after `create-release`, only when `create_release` is true and `is_prerelease` is false.
- Extra tag guard: suffixed tags (`v5.1.0-beta12`) and auto-generated `pre-release-*` tags are skipped even if the run was accidentally not marked as a pre-release; the job also skips gracefully (with a warning) if the `WINGET_TOKEN` secret is missing.
- Uses [winget-releaser](https://github.com/vedantmgoyal9/winget-releaser) (pinned to the v2 commit), which drives [komac](https://github.com/russellbanks/Komac) — the same tool used for the existing 4.0.x manifests. Komac downloads the installer and re-derives ProductCode/architecture from the binary itself. That matters here: the v5 Inno installer has a new `AppID` (`{B5E6D1E0-…}_is1`), while the pre-5.x manifests say `SubtitleEdit_is1` and list x86+x64 — a plain manifest copy would carry the stale values forward.
- The winget `PackageVersion` is the release tag without the `v` prefix (e.g. `5.1.0`), and only `SubtitleEdit-Windows-x64-Setup.exe` is matched as the installer.

## Setup required (one-time, before the next stable release)
1. Create a **classic** PAT with `public_repo` scope on the `niksedk` account (fine-grained tokens are not supported by the action).
2. Add it as a repo secret named `WINGET_TOKEN`.
3. The fork it pushes to is https://github.com/niksedk/winget-pkgs, which already exists (`fork-user: niksedk`).

## Note on 5.0.0
This only fires on future release runs. For the already-published 5.0.0 (or once 5.1.0 goes stable, which supersedes it), a one-off submission can be done locally with:

```
komac update Nikse.SubtitleEdit --version 5.0.0 \
  --urls https://github.com/SubtitleEdit/subtitleedit/releases/download/v5.0.0/SubtitleEdit-Windows-x64-Setup.exe \
  --submit
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)