### PR TITLE
Fix Beautify Time Codes waveform preview refresh

### DIFF
--- a/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
@@ -222,23 +222,32 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
         ChangeDetail = BuildChangeDetail(o, b);
         ChangeNotes = BuildChangeNotes(o, b);
 
-        // Highlight: AllSelectedParagraphs drives the paint-with-selected-background path.
-        if (AudioVisualizerOriginal != null)
-        {
-            AudioVisualizerOriginal.AllSelectedParagraphs = new List<SubtitleLineViewModel> { o };
-        }
-        if (AudioVisualizerBeautified != null)
-        {
-            AudioVisualizerBeautified.AllSelectedParagraphs = new List<SubtitleLineViewModel> { b };
-        }
-
         // Center both visualizers on the *midpoint* of the (beautified) paragraph
         var midSeconds = (b.StartTime.TotalSeconds + b.EndTime.TotalSeconds) / 2.0;
         CenterVisualizerOn(AudioVisualizerOriginal, midSeconds);
         CenterVisualizerOn(AudioVisualizerBeautified, midSeconds);
 
-        AudioVisualizerOriginal?.InvalidateVisual();
-        AudioVisualizerBeautified?.InvalidateVisual();
+        if (AudioVisualizerOriginal != null)
+        {
+            AudioVisualizerOriginal.SetPosition(
+                AudioVisualizerOriginal.StartPositionSeconds,
+                _originalSubtitles,
+                AudioVisualizerOriginal.CurrentVideoPositionSeconds,
+                idx,
+                new List<SubtitleLineViewModel>());
+            AudioVisualizerOriginal.InvalidateVisual();
+        }
+
+        if (AudioVisualizerBeautified != null)
+        {
+            AudioVisualizerBeautified.SetPosition(
+                AudioVisualizerBeautified.StartPositionSeconds,
+                _beautifiedSubtitles,
+                AudioVisualizerBeautified.CurrentVideoPositionSeconds,
+                idx,
+                new List<SubtitleLineViewModel>());
+            AudioVisualizerBeautified.InvalidateVisual();
+        }
     }
 
     private string BuildChangeDetail(SubtitleLineViewModel original, SubtitleLineViewModel beautified)


### PR DESCRIPTION
## Problem

In the Beautify Time Codes window, subtitle blocks could be missing from the waveform preview when navigating between changes that were outside the visualizer's previously cached display range.

## Cause & Fix

`AudioVisualizer.SetPosition()` reloads `_displayableParagraphs` for the visualizer's current waveform range, including its +/- 15 second margin. However, `UpdateChangeView()` only changed `StartPositionSeconds` via `CenterVisualizerOn()` when moving between Beautify Time Codes changes.

As a result, the waveform was centered on the new change, but the cached displayable subtitle blocks still belonged to the previous range.

This fix replaces the previous direct `AllSelectedParagraphs` assignment with `SetPosition(..., idx, ...)`, because `SetPosition()` refreshes the visible paragraph cache and selected paragraph state together.

## Screenshots

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/326d1c77-6e9e-4e7f-b235-e31506059378"> | <video src="https://github.com/user-attachments/assets/46e2558d-160f-4c25-a691-4af06563cf06"> |
| Distant changes could show an empty preview until playback moved nearby. | Navigating between changes now refreshes preview blocks immediately. |


## Testing

Tested on Windows 11 x64 (local Release build).

Verified both full-subtitle beautify and selected-lines beautify.
