### PR TITLE
seconv: image output styling via CLI flags and settings JSON

### DIFF
--- a/docs/features/seconv.md
+++ b/docs/features/seconv.md
@@ -10,6 +10,7 @@ seconv movie.sup subrip --ocr-engine:tesseract --ocr-language:eng
 seconv movie.sub subrip --ocr-engine:binaryocr --ocr-db:Latin.db   # VobSub (.idx auto-detected)
 seconv movie.sub subrip --ocr-engine:tesseract --no-vobsub-isolate-colors  # OCR raw palette (isolation is on by default)
 seconv movie.sup subrip --time-codes-only
+seconv movie.srt bluraysup --resolution:3840x2160 --background-color:"#B4000000"  # styled text → image
 ```
 
 For full usage, options, OCR setup, operations pipeline, examples, and exit codes, see the canonical reference:

--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -55,6 +55,7 @@ seconv movie.sup subrip --ocr-engine:ollama --ollama-model:llama3.2-vision
 
 seconv subs.srt bluraysup --resolution:1920x1080                   # render text → Blu-Ray sup
 seconv subs.srt bdnxml --resolution:1920x1080                      # render text → BDN-XML
+seconv subs.srt bluraysup --background-color:"#B4000000"           # ... with a black background box
 
 seconv subs.srt customtext --custom-format:my-template.xml         # custom template
 seconv *.srt subrip --multiple-replace:rules.xml                   # search-and-replace pass
@@ -120,6 +121,40 @@ seconv lint *.srt --json             # CI-friendly: exit 1 on any issue
 | `--plaintext-merge` | Plain text (`txt`) | Merge all subtitles into one space-separated block (no blank lines). Takes precedence over the two options below |
 | `--plaintext-unbreak` | Plain text (`txt`) | Unbreak each subtitle, joining its lines into one |
 | `--plaintext-no-blank-line` | Plain text (`txt`) | Do not put a blank line between subtitles (default keeps it) |
+
+### Image output styling
+
+When rendering a text subtitle to an image-based target (Blu-Ray `sup`, VobSub, BDN-XML, DOST, FCP, D-Cinema, images-with-time-code, WebVTT thumbnails), these options control how the text is drawn. `<i>`, `<b>`, and `<font color=...>` tags in the subtitle text are honored. The same values can be set in a `--settings` JSON file's `exportImages` section (see [Settings JSON](#settings-json)); CLI flags win over the JSON.
+
+| Option | Description |
+|---|---|
+| `--font-name:<name>` | Font family (default: `Arial`) |
+| `--font-size:<pt>` | Font size in points (default: `50`) |
+| `--font-color:<color>` | Text colour (default: `white`) |
+| `--font-bold` | Render text bold |
+| `--outline-color:<color>` | Outline colour (default: `black`) |
+| `--outline-width:<px>` | Outline width (default: `2.5`; `0` disables) |
+| `--shadow-color:<color>` | Shadow colour (default: `black`) |
+| `--shadow-width:<px>` | Shadow width (default: `0` = off) |
+| `--background-color:<color>` | Background box colour, e.g. `black` or `#B4000000` (semi-transparent black). Implies `--box-type:one-box` unless `--box-type` is given |
+| `--background-corner-radius:<px>` | Corner radius of the background box (default: `0`) |
+| `--box-type:<type>` | `none` (default) \| `one-box` \| `box-per-line` |
+| `--box-padding:<px>` | Box padding: one value for all sides, or `left,right,top,bottom` (default: `5,5,3,3`) |
+| `--line-spacing:<percent>` | Extra gap between lines as percent of line height (default: `0`) |
+| `--alignment:<pos>` | Screen position: `bottom-center` (default), `top-left`, `middle-right`, ... |
+| `--content-alignment:<align>` | Multi-line text justification: `left` \| `center` (default) \| `right` |
+| `--bottom-top-margin:<px>` | Vertical screen-edge margin (default: 5% of height) |
+| `--left-right-margin:<px>` | Horizontal screen-edge margin (default: 5% of width) |
+
+Colours accept hex (`#AARRGGBB`, `#RRGGBB`, with or without `#`) or a colour name (`white`, `black`, `yellow`, ...).
+
+```bash
+# SRT → UHD Blu-Ray sup with a semi-transparent black background box (SE4-style)
+seconv movie.srt bluraysup --resolution:3840x2160 --background-color:"#B4000000"
+
+# Custom font, bold, box per line
+seconv movie.srt bluraysup --font-name:Verdana --font-size:60 --font-bold --box-type:box-per-line
+```
 
 ### Containers / tracks
 
@@ -209,7 +244,7 @@ seconv movie.sub subrip --time-codes-only
 |---|---|
 | `--multiple-replace:<path.xml>` | SE *MultipleSearchAndReplaceGroups* XML, applied per paragraph after operations. Supports `Normal` (case-insensitive), `CaseSensitive`, and `RegularExpression` rules |
 | `--custom-format:<path.xml>` | SE *CustomFormatItem* XML (use with `--format customtext`) |
-| `--settings:<path.json>` | JSON file overlaying `Configuration.Settings` (general / tools / removeTextForHearingImpaired). Optional `profiles` map for named overlays |
+| `--settings:<path.json>` | JSON file overlaying `Configuration.Settings` (general / tools / removeTextForHearingImpaired) plus image-output styling (exportImages). Optional `profiles` map for named overlays |
 | `--profile:<name>` | Selects a named overlay from the settings file's `profiles` map. Requires `--settings` |
 
 #### Multiple-replace XML
@@ -287,16 +322,41 @@ Available template tokens: `{title}`, `{number}`, `{start}`, `{end}`, `{duration
     "removeTextBeforeColon": true,
     "removeInterjections": false
   },
+  "exportImages": {
+    "fontName": "Arial",
+    "fontSize": 50,
+    "fontColor": "#FFFFFF",
+    "isBold": false,
+    "outlineColor": "black",
+    "outlineWidth": 2.5,
+    "shadowColor": "black",
+    "shadowWidth": 0,
+    "backgroundColor": "#B4000000",
+    "backgroundCornerRadius": 0,
+    "boxType": "one-box",
+    "boxPaddingLeft": 5,
+    "boxPaddingRight": 5,
+    "boxPaddingTop": 3,
+    "boxPaddingBottom": 3,
+    "lineSpacingPercent": 0,
+    "alignment": "bottom-center",
+    "contentAlignment": "center",
+    "bottomTopMargin": 54,
+    "leftRightMargin": 96
+  },
   "profiles": {
     "broadcast": {
       "general": { "subtitleMaximumDisplayMilliseconds": 6000 },
       "removeTextForHearingImpaired": { "removeInterjections": true }
+    },
+    "uhd": {
+      "exportImages": { "fontSize": 100 }
     }
   }
 }
 ```
 
-The `general` section mirrors `Configuration.Settings.General`; any key left out keeps the libse default. The profile-shaping values (`minimumMillisecondsBetweenLines`, `maxNumberOfLines`, `mergeLinesShorterThan`, `subtitleMaximumCharactersPerSeconds`, `subtitleOptimalCharactersPerSeconds`, `subtitleMaximumWordsPerMinute`, `dialogStyle`, `continuationStyle`) feed Fix common errors and the split/merge operations, so set them to reproduce an SE4 profile. `dialogStyle` and `continuationStyle` take the enum names (case-insensitive): `dialogStyle` ∈ `DashBothLinesWithSpace`, `DashBothLinesWithoutSpace`, `DashSecondLineWithSpace`, `DashSecondLineWithoutSpace`; `continuationStyle` ∈ `None`, `NoneTrailingDots`, `NoneTrailingEllipsis`, `OnlyTrailingDots`, `LeadingTrailingDots`, `LeadingTrailingEllipsis`, `LeadingTrailingDash`, … (see the Fix common errors continuation styles).
+The `exportImages` section styles text → image rendering (see [Image output styling](#image-output-styling) for the semantics); the equivalent CLI flags override it. The `general` section mirrors `Configuration.Settings.General`; any key left out keeps the libse default. The profile-shaping values (`minimumMillisecondsBetweenLines`, `maxNumberOfLines`, `mergeLinesShorterThan`, `subtitleMaximumCharactersPerSeconds`, `subtitleOptimalCharactersPerSeconds`, `subtitleMaximumWordsPerMinute`, `dialogStyle`, `continuationStyle`) feed Fix common errors and the split/merge operations, so set them to reproduce an SE4 profile. `dialogStyle` and `continuationStyle` take the enum names (case-insensitive): `dialogStyle` ∈ `DashBothLinesWithSpace`, `DashBothLinesWithoutSpace`, `DashSecondLineWithSpace`, `DashSecondLineWithoutSpace`; `continuationStyle` ∈ `None`, `NoneTrailingDots`, `NoneTrailingEllipsis`, `OnlyTrailingDots`, `LeadingTrailingDots`, `LeadingTrailingEllipsis`, `LeadingTrailingDash`, … (see the Fix common errors continuation styles).
 
 ```bash
 seconv *.srt subrip --settings:my.json --profile:broadcast --remove-text-for-hi
@@ -427,6 +487,16 @@ seconv subs.sup subrip \
 ```bash
 seconv subs.srt bluraysup --resolution:1920x1080 --overwrite
 seconv subs.srt bdnxml --overwrite
+```
+
+### Styled Blu-Ray sup (SE4 `/convert` parity)
+```bash
+# SE4: SubtitleEdit.exe /convert movie.srt blu-raysup /Resolution:3840x2160 (+ styling from Settings.xml)
+seconv movie.srt bluraysup \
+  --resolution:3840x2160 \
+  --font-name:Arial --font-size:100 \
+  --background-color:"#B4000000" \
+  --overwrite
 ```
 
 ### EBU STL with reused header

--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -164,6 +164,76 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         [Description("Target frame rate")]
         public double? TargetFps { get; init; }
 
+        // Image output styling (Blu-Ray sup, VobSub, BDN-XML, ...). Flags override the
+        // settings JSON's exportImages section, which overrides the built-in defaults.
+        [CommandOption("--font-name|--fontname")]
+        [Description("Image output: font family name (default: Arial)")]
+        public string? FontName { get; init; }
+
+        [CommandOption("--font-size|--fontsize")]
+        [Description("Image output: font size in points (default: 50)")]
+        public float? FontSize { get; init; }
+
+        [CommandOption("--font-color|--fontcolor")]
+        [Description("Image output: text colour as hex (#AARRGGBB/#RRGGBB) or name (default: white)")]
+        public string? FontColor { get; init; }
+
+        [CommandOption("--font-bold|--fontbold")]
+        [Description("Image output: render text bold")]
+        public bool FontBold { get; init; }
+
+        [CommandOption("--outline-color|--outlinecolor")]
+        [Description("Image output: outline colour (default: black)")]
+        public string? OutlineColor { get; init; }
+
+        [CommandOption("--outline-width|--outlinewidth")]
+        [Description("Image output: outline width in pixels (default: 2.5; 0 disables)")]
+        public double? OutlineWidth { get; init; }
+
+        [CommandOption("--shadow-color|--shadowcolor")]
+        [Description("Image output: shadow colour (default: black)")]
+        public string? ShadowColor { get; init; }
+
+        [CommandOption("--shadow-width|--shadowwidth")]
+        [Description("Image output: shadow width in pixels (default: 0 = off)")]
+        public double? ShadowWidth { get; init; }
+
+        [CommandOption("--background-color|--backgroundcolor")]
+        [Description("Image output: background box colour, e.g. black or #B4000000 (semi-transparent black). Implies --box-type:one-box unless --box-type is given")]
+        public string? BackgroundColor { get; init; }
+
+        [CommandOption("--background-corner-radius|--backgroundcornerradius")]
+        [Description("Image output: corner radius of the background box (default: 0)")]
+        public double? BackgroundCornerRadius { get; init; }
+
+        [CommandOption("--box-type|--boxtype")]
+        [Description("Image output: background box style: none | one-box | box-per-line")]
+        public string? BoxType { get; init; }
+
+        [CommandOption("--box-padding|--boxpadding")]
+        [Description("Image output: box padding in pixels; one value for all sides or left,right,top,bottom (default: 5,5,3,3)")]
+        public string? BoxPadding { get; init; }
+
+        [CommandOption("--line-spacing|--linespacing")]
+        [Description("Image output: extra gap between lines as percent of line height (default: 0)")]
+        public int? LineSpacing { get; init; }
+
+        [CommandOption("--alignment")]
+        [Description("Image output: screen position, e.g. bottom-center (default), top-left, middle-right")]
+        public string? Alignment { get; init; }
+
+        [CommandOption("--content-alignment|--contentalignment")]
+        [Description("Image output: multi-line text justification: left | center (default) | right")]
+        public string? ContentAlignment { get; init; }
+
+        [CommandOption("--bottom-top-margin|--bottomtopmargin")]
+        [Description("Image output: vertical screen-edge margin in pixels (default: 5% of height)")]
+        public int? BottomTopMargin { get; init; }
+
+        [CommandOption("--left-right-margin|--leftrightmargin")]
+        [Description("Image output: horizontal screen-edge margin in pixels (default: 5% of width)")]
+        public int? LeftRightMargin { get; init; }
+
         [CommandOption("--teletext-only|--teletextonly")]
         [Description("Teletext only")]
         public bool TeletextOnly { get; init; }
@@ -332,11 +402,14 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
 
             // Load --settings:path.json overrides into libse Configuration before any conversion.
             // --profile <name> selects a named overlay from the same file.
+            var imageStyle = new ImageExportStyle();
             if (!string.IsNullOrWhiteSpace(settings.SettingsPath))
             {
                 try
                 {
-                    SeConvSettings.Load(settings.SettingsPath).ApplyToLibSe(settings.Profile);
+                    var seConvSettings = SeConvSettings.Load(settings.SettingsPath);
+                    seConvSettings.ApplyToLibSe(settings.Profile);
+                    seConvSettings.ApplyExportImages(imageStyle, settings.Profile);
                 }
                 catch (Exception ex)
                 {
@@ -347,6 +420,15 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
             else if (!string.IsNullOrWhiteSpace(settings.Profile))
             {
                 AnsiConsole.MarkupLine("[red]Error: --profile requires --settings:<path.json>[/]");
+                return 1;
+            }
+
+            // Image styling flags override the settings JSON. Unlike the JSON (which
+            // tolerates typos), a bad flag value fails fast so the user notices.
+            var imageStyleError = ApplyImageStyleFlags(settings, imageStyle);
+            if (imageStyleError != null)
+            {
+                AnsiConsole.MarkupLineInterpolated($"[red]Error: {imageStyleError}[/]");
                 return 1;
             }
 
@@ -480,6 +562,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 BridgeGapsMaxMs = settings.BridgeGaps,
                 ApplyMinGapMs = settings.ApplyMinGap,
                 Resolution = resolution,
+                ImageStyle = imageStyle,
                 AssaStyleFile = settings.AssaStyleFile,
                 PacCodePage = pacCodePage,
                 EbuHeaderFile = settings.EbuHeaderFile,
@@ -645,6 +728,161 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
             errors = result.Errors,
         };
         Console.WriteLine(System.Text.Json.JsonSerializer.Serialize(payload, JsonOptions));
+    }
+
+    /// <summary>
+    /// Applies the image-styling CLI flags on top of <paramref name="style"/>.
+    /// Returns an error message on an unparsable value, null on success.
+    /// </summary>
+    private static string? ApplyImageStyleFlags(Settings settings, ImageExportStyle style)
+    {
+        if (!string.IsNullOrWhiteSpace(settings.FontName))
+        {
+            style.FontName = settings.FontName;
+        }
+
+        if (settings.FontSize.HasValue)
+        {
+            if (settings.FontSize.Value <= 0)
+            {
+                return $"--font-size must be greater than 0 (got {settings.FontSize.Value}).";
+            }
+            style.FontSize = settings.FontSize.Value;
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.FontColor))
+        {
+            if (!ImageExportStyle.TryParseColor(settings.FontColor, out var fontColor))
+            {
+                return $"Unknown colour '{settings.FontColor}' for --font-color. Use hex (#AARRGGBB/#RRGGBB) or a colour name like white.";
+            }
+            style.FontColor = fontColor;
+        }
+
+        if (settings.FontBold)
+        {
+            style.IsBold = true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.OutlineColor))
+        {
+            if (!ImageExportStyle.TryParseColor(settings.OutlineColor, out var outlineColor))
+            {
+                return $"Unknown colour '{settings.OutlineColor}' for --outline-color.";
+            }
+            style.OutlineColor = outlineColor;
+        }
+
+        if (settings.OutlineWidth.HasValue)
+        {
+            style.OutlineWidth = settings.OutlineWidth.Value;
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.ShadowColor))
+        {
+            if (!ImageExportStyle.TryParseColor(settings.ShadowColor, out var shadowColor))
+            {
+                return $"Unknown colour '{settings.ShadowColor}' for --shadow-color.";
+            }
+            style.ShadowColor = shadowColor;
+        }
+
+        if (settings.ShadowWidth.HasValue)
+        {
+            style.ShadowWidth = settings.ShadowWidth.Value;
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.BackgroundColor))
+        {
+            if (!ImageExportStyle.TryParseColor(settings.BackgroundColor, out var backgroundColor))
+            {
+                return $"Unknown colour '{settings.BackgroundColor}' for --background-color.";
+            }
+            style.BackgroundColor = backgroundColor;
+        }
+
+        if (settings.BackgroundCornerRadius.HasValue)
+        {
+            style.BackgroundCornerRadius = settings.BackgroundCornerRadius.Value;
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.BoxType))
+        {
+            if (!ImageExportStyle.TryParseBoxType(settings.BoxType, out var boxType))
+            {
+                return $"Unknown box type '{settings.BoxType}' for --box-type. Use: none, one-box, or box-per-line.";
+            }
+            style.BoxType = boxType;
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.BoxPadding))
+        {
+            var parts = settings.BoxPadding.Split(',', StringSplitOptions.TrimEntries);
+            var values = new List<int>();
+            foreach (var part in parts)
+            {
+                if (!int.TryParse(part, out var n) || n < 0)
+                {
+                    values.Clear();
+                    break;
+                }
+                values.Add(n);
+            }
+
+            if (values.Count == 1)
+            {
+                style.BoxPaddingLeft = values[0];
+                style.BoxPaddingRight = values[0];
+                style.BoxPaddingTop = values[0];
+                style.BoxPaddingBottom = values[0];
+            }
+            else if (values.Count == 4)
+            {
+                style.BoxPaddingLeft = values[0];
+                style.BoxPaddingRight = values[1];
+                style.BoxPaddingTop = values[2];
+                style.BoxPaddingBottom = values[3];
+            }
+            else
+            {
+                return $"Invalid --box-padding '{settings.BoxPadding}'. Use one value for all sides (e.g. 5) or four: left,right,top,bottom (e.g. 5,5,3,3).";
+            }
+        }
+
+        if (settings.LineSpacing.HasValue)
+        {
+            style.LineSpacingPercent = settings.LineSpacing.Value;
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.Alignment))
+        {
+            if (!ImageExportStyle.TryParseAlignment(settings.Alignment, out var alignment))
+            {
+                return $"Unknown alignment '{settings.Alignment}' for --alignment. Use e.g. bottom-center, top-left, middle-right.";
+            }
+            style.Alignment = alignment;
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.ContentAlignment))
+        {
+            if (!ImageExportStyle.TryParseContentAlignment(settings.ContentAlignment, out var contentAlignment))
+            {
+                return $"Unknown content alignment '{settings.ContentAlignment}' for --content-alignment. Use: left, center, or right.";
+            }
+            style.ContentAlignment = contentAlignment;
+        }
+
+        if (settings.BottomTopMargin.HasValue)
+        {
+            style.BottomTopMargin = settings.BottomTopMargin.Value;
+        }
+
+        if (settings.LeftRightMargin.HasValue)
+        {
+            style.LeftRightMargin = settings.LeftRightMargin.Value;
+        }
+
+        return null;
     }
 
     private static List<int> ParseTrackNumbers(string? csv)

--- a/src/seconv/Core/ImageExportStyle.cs
+++ b/src/seconv/Core/ImageExportStyle.cs
@@ -1,0 +1,109 @@
+using System.Reflection;
+using Nikse.SubtitleEdit.UiLogic.Export;
+using SkiaSharp;
+
+namespace SeConv.Core;
+
+/// <summary>
+/// Resolved styling for text → image rendering (Blu-Ray sup, VobSub, BDN-XML, ...).
+/// Values are resolved in this order: defaults below, then the <c>exportImages</c>
+/// section of a <c>--settings</c> JSON file (base section first, then the selected
+/// profile's overlay), then individual CLI flags (<c>--font-name</c>, ...).
+/// Defaults match seconv's original hardcoded rendering (Arial 50, white text,
+/// black outline, no box).
+/// </summary>
+internal sealed class ImageExportStyle
+{
+    public string FontName { get; set; } = "Arial";
+    public float FontSize { get; set; } = 50;
+    public SKColor FontColor { get; set; } = SKColors.White;
+    public bool IsBold { get; set; }
+    public SKColor OutlineColor { get; set; } = SKColors.Black;
+    public double OutlineWidth { get; set; } = 2.5;
+    public SKColor ShadowColor { get; set; } = SKColors.Black;
+    public double ShadowWidth { get; set; }
+    public SKColor BackgroundColor { get; set; } = SKColors.Transparent;
+    public double BackgroundCornerRadius { get; set; }
+
+    /// <summary>
+    /// Null = auto: a visible <see cref="BackgroundColor"/> turns on <see cref="ExportBoxType.OneBox"/>,
+    /// otherwise no box. Setting a background colour without a box type would silently
+    /// render nothing, so the auto rule keeps "--background-color black" working alone.
+    /// </summary>
+    public ExportBoxType? BoxType { get; set; }
+
+    public int BoxPaddingLeft { get; set; } = 5;
+    public int BoxPaddingRight { get; set; } = 5;
+    public int BoxPaddingTop { get; set; } = 3;
+    public int BoxPaddingBottom { get; set; } = 3;
+
+    /// <summary>Extra gap between lines as percent of line height. 0 = single spacing (matches the GUI export default).</summary>
+    public int LineSpacingPercent { get; set; }
+
+    public ExportAlignment Alignment { get; set; } = ExportAlignment.BottomCenter;
+    public ExportContentAlignment ContentAlignment { get; set; } = ExportContentAlignment.Center;
+
+    /// <summary>Vertical screen-edge margin in pixels. Null = 5% of screen height.</summary>
+    public int? BottomTopMargin { get; set; }
+
+    /// <summary>Horizontal screen-edge margin in pixels. Null = 5% of screen width.</summary>
+    public int? LeftRightMargin { get; set; }
+
+    public ExportBoxType EffectiveBoxType =>
+        BoxType ?? (BackgroundColor.Alpha > 0 ? ExportBoxType.OneBox : ExportBoxType.None);
+
+    /// <summary>
+    /// Parses a colour from hex (<c>#AARRGGBB</c>, <c>#RRGGBB</c>, <c>#RGB</c>, with or
+    /// without <c>#</c>) or a named SkiaSharp colour (<c>white</c>, <c>black</c>, ...).
+    /// </summary>
+    public static bool TryParseColor(string value, out SKColor color)
+    {
+        color = SKColors.Transparent;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var v = value.Trim();
+        if (SKColor.TryParse(v, out color))
+        {
+            return true;
+        }
+
+        var field = typeof(SKColors)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .FirstOrDefault(f => f.FieldType == typeof(SKColor) &&
+                                 f.Name.Equals(v, StringComparison.OrdinalIgnoreCase));
+        if (field != null)
+        {
+            color = (SKColor)field.GetValue(null)!;
+            return true;
+        }
+
+        return false;
+    }
+
+    public static bool TryParseBoxType(string value, out ExportBoxType boxType)
+    {
+        boxType = ExportBoxType.None;
+        return Enum.TryParse(Normalize(value), ignoreCase: true, out boxType) && Enum.IsDefined(boxType);
+    }
+
+    public static bool TryParseAlignment(string value, out ExportAlignment alignment)
+    {
+        alignment = ExportAlignment.BottomCenter;
+        return Enum.TryParse(Normalize(value), ignoreCase: true, out alignment) && Enum.IsDefined(alignment);
+    }
+
+    public static bool TryParseContentAlignment(string value, out ExportContentAlignment alignment)
+    {
+        alignment = ExportContentAlignment.Center;
+        return Enum.TryParse(Normalize(value), ignoreCase: true, out alignment) && Enum.IsDefined(alignment);
+    }
+
+    // Accept "box-per-line" / "box_per_line" / "BoxPerLine" alike.
+    private static string Normalize(string value)
+    {
+        return value.Trim().Replace("-", string.Empty).Replace("_", string.Empty);
+    }
+}

--- a/src/seconv/Core/ImageOutputWriter.cs
+++ b/src/seconv/Core/ImageOutputWriter.cs
@@ -1,6 +1,5 @@
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.UiLogic.Export;
-using SkiaSharp;
 
 namespace SeConv.Core;
 
@@ -121,6 +120,7 @@ internal static class ImageOutputWriter
         var screenWidth = item.ScreenWidth ?? defaultWidth;
         var screenHeight = item.ScreenHeight ?? defaultHeight;
 
+        var style = options.ImageStyle;
         return new ImageParameter
         {
             Index = index,
@@ -128,26 +128,26 @@ internal static class ImageOutputWriter
             Bitmap = item.Bitmap,
             StartTime = item.StartTime.TimeSpan,
             EndTime = item.EndTime.TimeSpan,
-            Alignment = ExportAlignment.BottomCenter,
-            ContentAlignment = ExportContentAlignment.Center,
+            Alignment = style.Alignment,
+            ContentAlignment = style.ContentAlignment,
             // Font/colour fields are still required by the ImageParameter contract even
             // though no rendering happens — handlers read them for metadata in some
-            // formats (e.g. FCP XML). Mirror BuildParameter's defaults.
-            FontName = "Arial",
-            FontSize = 50,
-            FontColor = SKColors.White,
-            IsBold = false,
-            OutlineColor = SKColors.Black,
-            OutlineWidth = 2.5,
-            ShadowColor = SKColors.Black,
-            ShadowWidth = 0,
-            BackgroundColor = SKColors.Transparent,
-            BackgroundCornerRadius = 0,
-            LineSpacingPercent = 100,
+            // formats (e.g. FCP XML). Mirror BuildParameter's resolved style.
+            FontName = style.FontName,
+            FontSize = style.FontSize,
+            FontColor = style.FontColor,
+            IsBold = style.IsBold,
+            OutlineColor = style.OutlineColor,
+            OutlineWidth = style.OutlineWidth,
+            ShadowColor = style.ShadowColor,
+            ShadowWidth = style.ShadowWidth,
+            BackgroundColor = style.BackgroundColor,
+            BackgroundCornerRadius = style.BackgroundCornerRadius,
+            LineSpacingPercent = style.LineSpacingPercent,
             ScreenWidth = screenWidth,
             ScreenHeight = screenHeight,
-            BottomTopMargin = (int)(screenHeight * 0.05),
-            LeftRightMargin = (int)(screenWidth * 0.05),
+            BottomTopMargin = style.BottomTopMargin ?? (int)(screenHeight * 0.05),
+            LeftRightMargin = style.LeftRightMargin ?? (int)(screenWidth * 0.05),
             PaddingLeftRight = 0,
             PaddingTopBottom = 0,
             FramesPerSecond = options.TargetFps ?? options.Fps ?? 25.0,
@@ -160,29 +160,35 @@ internal static class ImageOutputWriter
 
     private static ImageParameter BuildParameter(Paragraph p, int index, int screenWidth, int screenHeight, ConversionOptions options)
     {
+        var style = options.ImageStyle;
         return new ImageParameter
         {
             Index = index,
             Text = p.Text ?? string.Empty,
             StartTime = p.StartTime.TimeSpan,
             EndTime = p.EndTime.TimeSpan,
-            Alignment = ExportAlignment.BottomCenter,
-            ContentAlignment = ExportContentAlignment.Center,
-            FontName = "Arial",
-            FontSize = 50,
-            FontColor = SKColors.White,
-            IsBold = false,
-            OutlineColor = SKColors.Black,
-            OutlineWidth = 2.5,
-            ShadowColor = SKColors.Black,
-            ShadowWidth = 0,
-            BackgroundColor = SKColors.Transparent,
-            BackgroundCornerRadius = 0,
-            LineSpacingPercent = 100,
+            Alignment = style.Alignment,
+            ContentAlignment = style.ContentAlignment,
+            FontName = style.FontName,
+            FontSize = style.FontSize,
+            FontColor = style.FontColor,
+            IsBold = style.IsBold,
+            OutlineColor = style.OutlineColor,
+            OutlineWidth = style.OutlineWidth,
+            ShadowColor = style.ShadowColor,
+            ShadowWidth = style.ShadowWidth,
+            BackgroundColor = style.BackgroundColor,
+            BackgroundCornerRadius = style.BackgroundCornerRadius,
+            BoxType = style.EffectiveBoxType,
+            BoxPaddingLeft = style.BoxPaddingLeft,
+            BoxPaddingRight = style.BoxPaddingRight,
+            BoxPaddingTop = style.BoxPaddingTop,
+            BoxPaddingBottom = style.BoxPaddingBottom,
+            LineSpacingPercent = style.LineSpacingPercent,
             ScreenWidth = screenWidth,
             ScreenHeight = screenHeight,
-            BottomTopMargin = (int)(screenHeight * 0.05),
-            LeftRightMargin = (int)(screenWidth * 0.05),
+            BottomTopMargin = style.BottomTopMargin ?? (int)(screenHeight * 0.05),
+            LeftRightMargin = style.LeftRightMargin ?? (int)(screenWidth * 0.05),
             PaddingLeftRight = 0,
             PaddingTopBottom = 0,
             FramesPerSecond = options.TargetFps ?? options.Fps ?? 25.0,

--- a/src/seconv/Core/LibSEIntegration.cs
+++ b/src/seconv/Core/LibSEIntegration.cs
@@ -778,7 +778,19 @@ internal static class LibSEIntegration
 
         if (!isAssaTarget)
         {
-            AnsiConsole.MarkupLine("[yellow]Warning: --resolution and --assa-style-file only apply to ASSA/SSA targets; ignored.[/]");
+            // --resolution is also meaningful for image-based targets (canvas size,
+            // see ImageOutputWriter) — there only the ASSA style file is ignored.
+            if (ImageOutputWriter.TryCreateHandler(normalizedFormat) != null)
+            {
+                if (!string.IsNullOrEmpty(assaStyleFile))
+                {
+                    AnsiConsole.MarkupLine("[yellow]Warning: --assa-style-file only applies to ASSA/SSA targets; ignored.[/]");
+                }
+            }
+            else
+            {
+                AnsiConsole.MarkupLine("[yellow]Warning: --resolution and --assa-style-file only apply to ASSA/SSA targets; ignored.[/]");
+            }
             return;
         }
 

--- a/src/seconv/Core/SeConvSettings.cs
+++ b/src/seconv/Core/SeConvSettings.cs
@@ -21,6 +21,9 @@ internal sealed class SeConvSettings
     [JsonPropertyName("removeTextForHearingImpaired")]
     public RemoveHiSection? RemoveTextForHearingImpaired { get; set; }
 
+    [JsonPropertyName("exportImages")]
+    public ExportImagesSection? ExportImages { get; set; }
+
     [JsonPropertyName("profiles")]
     public Dictionary<string, SeConvSettings>? Profiles { get; set; }
 
@@ -61,6 +64,25 @@ internal sealed class SeConvSettings
                 throw new InvalidOperationException($"Profile '{profileName}' not found in settings. Available: {available}");
             }
             profile.ApplyBaseSections();
+        }
+    }
+
+    /// <summary>
+    /// Overlays the <c>exportImages</c> section (base first, then the named profile's, if any)
+    /// onto <paramref name="style"/>. Unlike the other sections this does not go through
+    /// libse's Configuration — image rendering is driven by <see cref="ImageExportStyle"/>
+    /// on <c>ConversionOptions</c>. Call after <see cref="ApplyToLibSe"/>, which validates
+    /// the profile name.
+    /// </summary>
+    public void ApplyExportImages(ImageExportStyle style, string? profileName = null)
+    {
+        ExportImages?.ApplyTo(style);
+
+        if (!string.IsNullOrWhiteSpace(profileName) &&
+            Profiles is not null &&
+            Profiles.TryGetValue(profileName, out var profile))
+        {
+            profile.ExportImages?.ApplyTo(style);
         }
     }
 
@@ -163,6 +185,81 @@ internal sealed class SeConvSettings
     {
         public int? MergeShortLinesMaxGap { get; set; }
         public bool? MergeShortLinesOnlyContinuous { get; set; }
+    }
+
+    /// <summary>
+    /// Styling for text → image output (Blu-Ray sup, VobSub, BDN-XML, ...). Colours are
+    /// hex strings (<c>#AARRGGBB</c> / <c>#RRGGBB</c>) or SkiaSharp colour names; enums are
+    /// carried as strings (<c>boxType</c>: none | one-box | box-per-line; <c>alignment</c>:
+    /// e.g. bottom-center; <c>contentAlignment</c>: left | center | right). Following the
+    /// convention above, unparsable values are ignored rather than aborting the load.
+    /// </summary>
+    internal sealed class ExportImagesSection
+    {
+        public string? FontName { get; set; }
+        public float? FontSize { get; set; }
+        public string? FontColor { get; set; }
+        public bool? IsBold { get; set; }
+        public string? OutlineColor { get; set; }
+        public double? OutlineWidth { get; set; }
+        public string? ShadowColor { get; set; }
+        public double? ShadowWidth { get; set; }
+        public string? BackgroundColor { get; set; }
+        public double? BackgroundCornerRadius { get; set; }
+        public string? BoxType { get; set; }
+        public int? BoxPaddingLeft { get; set; }
+        public int? BoxPaddingRight { get; set; }
+        public int? BoxPaddingTop { get; set; }
+        public int? BoxPaddingBottom { get; set; }
+        public int? LineSpacingPercent { get; set; }
+        public string? Alignment { get; set; }
+        public string? ContentAlignment { get; set; }
+        public int? BottomTopMargin { get; set; }
+        public int? LeftRightMargin { get; set; }
+
+        public void ApplyTo(ImageExportStyle style)
+        {
+            if (!string.IsNullOrWhiteSpace(FontName))
+                style.FontName = FontName;
+            if (FontSize.HasValue)
+                style.FontSize = FontSize.Value;
+            if (!string.IsNullOrWhiteSpace(FontColor) && ImageExportStyle.TryParseColor(FontColor, out var fontColor))
+                style.FontColor = fontColor;
+            if (IsBold.HasValue)
+                style.IsBold = IsBold.Value;
+            if (!string.IsNullOrWhiteSpace(OutlineColor) && ImageExportStyle.TryParseColor(OutlineColor, out var outlineColor))
+                style.OutlineColor = outlineColor;
+            if (OutlineWidth.HasValue)
+                style.OutlineWidth = OutlineWidth.Value;
+            if (!string.IsNullOrWhiteSpace(ShadowColor) && ImageExportStyle.TryParseColor(ShadowColor, out var shadowColor))
+                style.ShadowColor = shadowColor;
+            if (ShadowWidth.HasValue)
+                style.ShadowWidth = ShadowWidth.Value;
+            if (!string.IsNullOrWhiteSpace(BackgroundColor) && ImageExportStyle.TryParseColor(BackgroundColor, out var backgroundColor))
+                style.BackgroundColor = backgroundColor;
+            if (BackgroundCornerRadius.HasValue)
+                style.BackgroundCornerRadius = BackgroundCornerRadius.Value;
+            if (!string.IsNullOrWhiteSpace(BoxType) && ImageExportStyle.TryParseBoxType(BoxType, out var boxType))
+                style.BoxType = boxType;
+            if (BoxPaddingLeft.HasValue)
+                style.BoxPaddingLeft = BoxPaddingLeft.Value;
+            if (BoxPaddingRight.HasValue)
+                style.BoxPaddingRight = BoxPaddingRight.Value;
+            if (BoxPaddingTop.HasValue)
+                style.BoxPaddingTop = BoxPaddingTop.Value;
+            if (BoxPaddingBottom.HasValue)
+                style.BoxPaddingBottom = BoxPaddingBottom.Value;
+            if (LineSpacingPercent.HasValue)
+                style.LineSpacingPercent = LineSpacingPercent.Value;
+            if (!string.IsNullOrWhiteSpace(Alignment) && ImageExportStyle.TryParseAlignment(Alignment, out var alignment))
+                style.Alignment = alignment;
+            if (!string.IsNullOrWhiteSpace(ContentAlignment) && ImageExportStyle.TryParseContentAlignment(ContentAlignment, out var contentAlignment))
+                style.ContentAlignment = contentAlignment;
+            if (BottomTopMargin.HasValue)
+                style.BottomTopMargin = BottomTopMargin.Value;
+            if (LeftRightMargin.HasValue)
+                style.LeftRightMargin = LeftRightMargin.Value;
+        }
     }
 
     internal sealed class RemoveHiSection

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -839,6 +839,12 @@ internal record class ConversionOptions
     /// <summary>Enforce a minimum gap of this many ms between consecutive paragraphs. Null disables.</summary>
     public int? ApplyMinGapMs { get; init; }
     public (int Width, int Height)? Resolution { get; init; }
+
+    /// <summary>
+    /// Styling for text → image output (font, outline, shadow, background box, ...).
+    /// Resolved from defaults + the settings JSON's <c>exportImages</c> section + CLI flags.
+    /// </summary>
+    public ImageExportStyle ImageStyle { get; init; } = new();
     public string? AssaStyleFile { get; init; }
     public int? PacCodePage { get; init; }
     public string? EbuHeaderFile { get; init; }

--- a/tests/seconv/Core/ImageExportStyleTest.cs
+++ b/tests/seconv/Core/ImageExportStyleTest.cs
@@ -1,0 +1,93 @@
+using Nikse.SubtitleEdit.UiLogic.Export;
+using SeConv.Core;
+using Xunit;
+
+namespace SeConvTests.Core;
+
+public class ImageExportStyleTest
+{
+    [Theory]
+    [InlineData("#FFFFFF", 255, 255, 255, 255)]
+    [InlineData("FFFFFF", 255, 255, 255, 255)]
+    [InlineData("#B4000000", 0, 0, 0, 180)]
+    [InlineData("white", 255, 255, 255, 255)]
+    [InlineData("Black", 0, 0, 0, 255)]
+    [InlineData("YELLOW", 255, 255, 0, 255)]
+    public void TryParseColor_ValidInputs(string input, byte r, byte g, byte b, byte a)
+    {
+        Assert.True(ImageExportStyle.TryParseColor(input, out var color));
+        Assert.Equal(r, color.Red);
+        Assert.Equal(g, color.Green);
+        Assert.Equal(b, color.Blue);
+        Assert.Equal(a, color.Alpha);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("notacolor")]
+    [InlineData("#GGGGGG")]
+    public void TryParseColor_InvalidInputs(string input)
+    {
+        Assert.False(ImageExportStyle.TryParseColor(input, out _));
+    }
+
+    [Theory]
+    [InlineData("none", ExportBoxType.None)]
+    [InlineData("one-box", ExportBoxType.OneBox)]
+    [InlineData("OneBox", ExportBoxType.OneBox)]
+    [InlineData("box-per-line", ExportBoxType.BoxPerLine)]
+    [InlineData("box_per_line", ExportBoxType.BoxPerLine)]
+    public void TryParseBoxType_ValidInputs(string input, ExportBoxType expected)
+    {
+        Assert.True(ImageExportStyle.TryParseBoxType(input, out var boxType));
+        Assert.Equal(expected, boxType);
+    }
+
+    [Theory]
+    [InlineData("nope")]
+    [InlineData("7")]
+    public void TryParseBoxType_InvalidInputs(string input)
+    {
+        Assert.False(ImageExportStyle.TryParseBoxType(input, out _));
+    }
+
+    [Theory]
+    [InlineData("bottom-center", ExportAlignment.BottomCenter)]
+    [InlineData("TopLeft", ExportAlignment.TopLeft)]
+    [InlineData("middle-right", ExportAlignment.MiddleRight)]
+    public void TryParseAlignment_ValidInputs(string input, ExportAlignment expected)
+    {
+        Assert.True(ImageExportStyle.TryParseAlignment(input, out var alignment));
+        Assert.Equal(expected, alignment);
+    }
+
+    [Fact]
+    public void EffectiveBoxType_DefaultsToNone()
+    {
+        var style = new ImageExportStyle();
+        Assert.Equal(ExportBoxType.None, style.EffectiveBoxType);
+    }
+
+    [Fact]
+    public void EffectiveBoxType_VisibleBackgroundImpliesOneBox()
+    {
+        var style = new ImageExportStyle();
+        Assert.True(ImageExportStyle.TryParseColor("#B4000000", out var bg));
+        style.BackgroundColor = bg;
+        Assert.Equal(ExportBoxType.OneBox, style.EffectiveBoxType);
+    }
+
+    [Fact]
+    public void EffectiveBoxType_ExplicitBoxTypeWinsOverBackground()
+    {
+        var style = new ImageExportStyle();
+        Assert.True(ImageExportStyle.TryParseColor("black", out var bg));
+        style.BackgroundColor = bg;
+        style.BoxType = ExportBoxType.BoxPerLine;
+        Assert.Equal(ExportBoxType.BoxPerLine, style.EffectiveBoxType);
+
+        style.BoxType = ExportBoxType.None;
+        Assert.Equal(ExportBoxType.None, style.EffectiveBoxType);
+    }
+}

--- a/tests/seconv/Core/ImageOutputTest.cs
+++ b/tests/seconv/Core/ImageOutputTest.cs
@@ -30,7 +30,7 @@ public class ImageOutputTest : IDisposable
 
         """;
 
-    private async Task<ConversionResult> ConvertTo(string format, string outFolderName)
+    private async Task<ConversionResult> ConvertTo(string format, string outFolderName, ImageExportStyle? style = null)
     {
         var input = Path.Combine(_tempRoot, "in.srt");
         await File.WriteAllTextAsync(input, SrtContent);
@@ -45,6 +45,7 @@ public class ImageOutputTest : IDisposable
             OutputFolder = outFolder,
             Overwrite = true,
             Resolution = (1920, 1080),
+            ImageStyle = style ?? new ImageExportStyle(),
         });
     }
 
@@ -123,6 +124,45 @@ public class ImageOutputTest : IDisposable
         Assert.True(result.Success, string.Join("; ", result.Errors));
         var pngs = Directory.GetFiles(Path.Combine(_tempRoot, "tc"), "*.png", SearchOption.AllDirectories);
         Assert.NotEmpty(pngs);
+    }
+
+    [Fact]
+    public async Task ConvertAsync_BdnXmlWithBackgroundBox_RendersOpaqueBox()
+    {
+        // A visible background colour implies a one-box background (Fredrik's v4
+        // "black background" workflow). With the default transparent background the
+        // trimmed bitmap's corner is transparent; with a box it must be the box colour.
+        Assert.True(ImageExportStyle.TryParseColor("#FF000000", out var black));
+        var style = new ImageExportStyle { BackgroundColor = black };
+
+        var result = await ConvertTo("bdnxml", "bdnbox", style);
+        Assert.True(result.Success, string.Join("; ", result.Errors));
+
+        var pngs = Directory.GetFiles(Path.Combine(_tempRoot, "bdnbox"), "*.png", SearchOption.AllDirectories);
+        Assert.Equal(2, pngs.Length);
+
+        using var bitmap = SkiaSharp.SKBitmap.Decode(pngs[0]);
+        var corner = bitmap.GetPixel(0, 0);
+        Assert.Equal(255, corner.Alpha);
+        Assert.Equal(0, corner.Red);
+        Assert.Equal(0, corner.Green);
+        Assert.Equal(0, corner.Blue);
+    }
+
+    [Fact]
+    public async Task ConvertAsync_BdnXmlDefaultStyle_HasTransparentCorner()
+    {
+        var result = await ConvertTo("bdnxml", "bdnplain");
+        Assert.True(result.Success, string.Join("; ", result.Errors));
+
+        var pngs = Directory.GetFiles(Path.Combine(_tempRoot, "bdnplain"), "*.png", SearchOption.AllDirectories);
+        Assert.Equal(2, pngs.Length);
+
+        // Bottom-left corner: the bottom edge of the trimmed bitmap comes from the
+        // comma's descender (mid-string), so the leftmost column is transparent there.
+        // The top-left corner is unsafe to probe — the 'H' outline may touch it.
+        using var bitmap = SkiaSharp.SKBitmap.Decode(pngs[0]);
+        Assert.Equal(0, bitmap.GetPixel(0, bitmap.Height - 1).Alpha);
     }
 
     [Fact]

--- a/tests/seconv/Core/SeConvSettingsTest.cs
+++ b/tests/seconv/Core/SeConvSettingsTest.cs
@@ -199,6 +199,78 @@ public class SeConvSettingsTest : IDisposable
     }
 
     [Fact]
+    public void ApplyExportImages_OverridesOnlySetKeys()
+    {
+        var path = WriteSettings("""
+            {
+              "exportImages": {
+                "fontName": "Verdana",
+                "fontSize": 42,
+                "backgroundColor": "#B4000000",
+                "boxType": "box-per-line",
+                "isBold": true
+              }
+            }
+            """);
+
+        var style = new SeConv.Core.ImageExportStyle();
+        SeConvSettings.Load(path).ApplyExportImages(style);
+
+        Assert.Equal("Verdana", style.FontName);
+        Assert.Equal(42, style.FontSize);
+        Assert.Equal(180, style.BackgroundColor.Alpha);
+        Assert.Equal(0, style.BackgroundColor.Red);
+        Assert.Equal(Nikse.SubtitleEdit.UiLogic.Export.ExportBoxType.BoxPerLine, style.BoxType);
+        Assert.True(style.IsBold);
+        // Untouched keys keep their defaults
+        Assert.Equal(SkiaSharp.SKColors.White, style.FontColor);
+        Assert.Equal(2.5, style.OutlineWidth);
+        Assert.Null(style.BottomTopMargin);
+    }
+
+    [Fact]
+    public void ApplyExportImages_ProfileOverlaysOnTopOfBase()
+    {
+        var path = WriteSettings("""
+            {
+              "exportImages": { "fontSize": 40, "fontName": "Verdana" },
+              "profiles": {
+                "uhd": { "exportImages": { "fontSize": 80 } }
+              }
+            }
+            """);
+
+        var style = new SeConv.Core.ImageExportStyle();
+        SeConvSettings.Load(path).ApplyExportImages(style, "uhd");
+
+        Assert.Equal(80, style.FontSize);       // profile overrode
+        Assert.Equal("Verdana", style.FontName); // base preserved
+    }
+
+    [Fact]
+    public void ApplyExportImages_BadValuesAreIgnored()
+    {
+        var path = WriteSettings("""
+            {
+              "exportImages": {
+                "fontColor": "notacolor",
+                "boxType": "roundish",
+                "alignment": "somewhere",
+                "fontSize": 30
+              }
+            }
+            """);
+
+        var style = new SeConv.Core.ImageExportStyle();
+        SeConvSettings.Load(path).ApplyExportImages(style);
+
+        Assert.Equal(SkiaSharp.SKColors.White, style.FontColor);
+        Assert.Null(style.BoxType);
+        Assert.Equal(Nikse.SubtitleEdit.UiLogic.Export.ExportAlignment.BottomCenter, style.Alignment);
+        Assert.Equal(30, style.FontSize);
+    }
+
+    [Fact]
     public void Load_AllowsCommentsAndTrailingCommas()
     {
         var path = WriteSettings("""


### PR DESCRIPTION
## Problem

Reported by email: in SE4, `SubtitleEdit.exe /convert "movie.srt" blu-raysup /Resolution:3840x2160` rendered SUP images with the export styling saved in `Settings.xml` (font, black background box, outline, ...). The SE5 equivalent, `seconv movie.srt SUP --resolution:3840x2160`, hardcoded Arial 50 pt white-on-transparent — so the black background (and any other styling) was silently lost when migrating scripts.

## Changes

- **New `ImageExportStyle`** for all text → image targets (Blu-Ray sup, VobSub, BDN-XML, DOST, FCP, D-Cinema, images-with-time-code, WebVTT thumbnails), resolved as: built-in defaults ← `--settings` JSON `exportImages` section (base, then the selected profile's overlay) ← CLI flags.
- **New CLI flags**: `--font-name`, `--font-size`, `--font-color`, `--font-bold`, `--outline-color`, `--outline-width`, `--shadow-color`, `--shadow-width`, `--background-color`, `--background-corner-radius`, `--box-type` (none | one-box | box-per-line), `--box-padding`, `--line-spacing`, `--alignment`, `--content-alignment`, `--bottom-top-margin`, `--left-right-margin`. Colours accept hex (`#AARRGGBB`/`#RRGGBB`) or names; bad flag values fail fast, bad JSON values are ignored per the existing settings-file convention.
- **`--background-color` implies `--box-type:one-box`** when no box type is given, so the common "black background" case works with a single flag instead of silently rendering nothing.
- **Fix double line spacing**: `LineSpacingPercent` was hardcoded to 100 (the GUI export default is 0), so seconv rendered multi-line subtitles double-spaced. Now defaults to 0.
- **Fix bogus warning**: image targets no longer print `--resolution ... only apply to ASSA/SSA targets; ignored` — the resolution sets the image canvas and is honored (only `--assa-style-file` is warned about there).
- Docs: new "Image output styling" section + `exportImages` JSON example in `docs/reference/command-line.md`, example in `docs/features/seconv.md`.
- Tests: colour/enum parsing, JSON section + profile overlay, and a render test asserting the background box actually reaches the output PNG (205 seconv tests pass).

The original report's workflow now works:

```bat
seconv "%%~na.1.swe.srt" SUP --resolution:3840x2160 --background-color:"#B4000000"
```

Verified end-to-end: SRT → 3840x2160 SUP → BDN-XML round-trip shows white text on a black box with `<i>` tags honored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)