### PR TITLE
AI assistant: engine settings in window, UI polish, strip think blocks

### DIFF
--- a/src/ui/Features/Main/AiAssistant/AiAssistantViewModel.cs
+++ b/src/ui/Features/Main/AiAssistant/AiAssistantViewModel.cs
@@ -1,14 +1,16 @@
 using Avalonia.Controls;
+using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Tools.AiReview;
+using Nikse.SubtitleEdit.Features.Translate;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using System;
+using System.Collections.ObjectModel;
 using System.Globalization;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,10 +18,10 @@ namespace Nikse.SubtitleEdit.Features.Main.AiAssistant;
 
 /// <summary>
 /// The subtitle text box AI assistant: quick actions and a free question for the
-/// current line, with the neighbouring lines given as context. Reuses the same
-/// engines, models and settings as Tools -> AI review (Ollama, llama.cpp, or an
-/// OpenAI compatible server); nothing is applied automatically, the user reviews
-/// the suggestion and presses Apply.
+/// current line, with the neighbouring lines given as context. Shares the engine,
+/// model and connection settings with Tools -> AI review (Ollama, llama.cpp, or an
+/// OpenAI compatible server), and lets the user change them directly in the window;
+/// nothing is applied automatically, the user reviews the suggestion and presses Apply.
 /// </summary>
 public partial class AiAssistantViewModel : ObservableObject
 {
@@ -29,30 +31,60 @@ public partial class AiAssistantViewModel : ObservableObject
     [ObservableProperty] private string _resultText;
     [ObservableProperty] private string _statusText;
     [ObservableProperty] private bool _isBusy;
+    [ObservableProperty] private bool _isNotBusy = true;
+    [ObservableProperty] private bool _hasResult;
+    [ObservableProperty] private string _languageDisplay;
+    [ObservableProperty] private bool _hasLanguage;
+    [ObservableProperty] private ObservableCollection<string> _engines;
     [ObservableProperty] private string _selectedEngine;
+    [ObservableProperty] private bool _isOllamaVisible;
+    [ObservableProperty] private bool _isLlamaCppVisible;
+    [ObservableProperty] private bool _isOpenAiCompatibleVisible;
+    [ObservableProperty] private string _ollamaModel;
+    [ObservableProperty] private string _openAiCompatibleUrl;
+    [ObservableProperty] private string _openAiCompatibleModel;
+    [ObservableProperty] private string _openAiCompatibleApiKey;
+    [ObservableProperty] private ObservableCollection<LlamaCppModelDisplay> _llamaCppModels;
+    [ObservableProperty] private LlamaCppModelDisplay? _selectedLlamaCppModel;
 
     public Window? Window { get; set; }
     public bool ApplyPressed { get; private set; }
     public string ResultToApply { get; private set; } = string.Empty;
 
+    private readonly IWindowService _windowService;
     private string _language;
     private double _maxCharsPerSecond;
     private int _maxSingleLineLength;
     private CancellationTokenSource? _cancellationTokenSource;
 
-    public AiAssistantViewModel()
+    public AiAssistantViewModel(IWindowService windowService)
     {
+        _windowService = windowService;
+
         _currentText = string.Empty;
         _contextText = string.Empty;
         _questionText = string.Empty;
         _resultText = string.Empty;
         _statusText = string.Empty;
+        _languageDisplay = string.Empty;
         _language = "the same language as the text";
         _maxCharsPerSecond = 20;
         _maxSingleLineLength = 42;
-        _selectedEngine = string.IsNullOrEmpty(Se.Settings.Tools.AiReview.Engine)
-            ? SeAiReview.EngineLlamaCpp
-            : Se.Settings.Tools.AiReview.Engine;
+
+        var review = Se.Settings.Tools.AiReview;
+        Engines = new ObservableCollection<string> { SeAiReview.EngineLlamaCpp, SeAiReview.EngineOllama, SeAiReview.EngineOpenAiCompatible };
+        SelectedEngine = Engines.Contains(review.Engine) ? review.Engine : SeAiReview.EngineLlamaCpp;
+        OllamaModel = review.OllamaModel;
+        OpenAiCompatibleUrl = review.OpenAiCompatibleUrl;
+        OpenAiCompatibleModel = review.OpenAiCompatibleModel;
+        OpenAiCompatibleApiKey = review.OpenAiCompatibleApiKey;
+        LlamaCppModels = new ObservableCollection<LlamaCppModelDisplay>();
+        SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(
+            LlamaCppModels,
+            LlamaCppServerManager.GetAllReviewModels(),
+            review.LlamaCppModelFileName);
+
+        UpdateEngineVisibility();
     }
 
     public void Initialize(string currentText, string contextText, string? languageName,
@@ -63,6 +95,7 @@ public partial class AiAssistantViewModel : ObservableObject
         if (!string.IsNullOrWhiteSpace(languageName))
         {
             _language = languageName!;
+            LanguageDisplay = languageName!;
         }
 
         if (maxCharsPerSecond > 0)
@@ -73,6 +106,73 @@ public partial class AiAssistantViewModel : ObservableObject
         if (maxSingleLineLength > 0)
         {
             _maxSingleLineLength = maxSingleLineLength;
+        }
+    }
+
+    partial void OnSelectedEngineChanged(string value)
+    {
+        UpdateEngineVisibility();
+    }
+
+    partial void OnIsBusyChanged(bool value)
+    {
+        IsNotBusy = !value;
+    }
+
+    partial void OnResultTextChanged(string value)
+    {
+        HasResult = !string.IsNullOrWhiteSpace(value);
+    }
+
+    partial void OnLanguageDisplayChanged(string value)
+    {
+        HasLanguage = !string.IsNullOrEmpty(value);
+    }
+
+    private void UpdateEngineVisibility()
+    {
+        IsOllamaVisible = SelectedEngine == SeAiReview.EngineOllama;
+        IsOpenAiCompatibleVisible = SelectedEngine == SeAiReview.EngineOpenAiCompatible;
+        IsLlamaCppVisible = !IsOllamaVisible && !IsOpenAiCompatibleVisible;
+    }
+
+    private void SaveSettings()
+    {
+        var settings = Se.Settings.Tools.AiReview;
+        settings.Engine = SelectedEngine;
+        settings.OllamaModel = OllamaModel.Trim();
+        settings.LlamaCppModelFileName = SelectedLlamaCppModel?.Model.FileName ?? string.Empty;
+        settings.OpenAiCompatibleUrl = OpenAiCompatibleUrl.Trim();
+        settings.OpenAiCompatibleModel = OpenAiCompatibleModel.Trim();
+        settings.OpenAiCompatibleApiKey = OpenAiCompatibleApiKey.Trim();
+        Se.SaveSettings();
+    }
+
+    private void RefreshLlamaCppModels()
+    {
+        var selectedFileName = SelectedLlamaCppModel?.Model.FileName;
+        SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(
+            LlamaCppModels,
+            LlamaCppServerManager.GetAllReviewModels(),
+            selectedFileName);
+    }
+
+    [RelayCommand]
+    private async Task PickOllamaModel()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var result = await _windowService.ShowDialogAsync<Ocr.PickOllamaModelWindow, Ocr.PickOllamaModelViewModel>(Window, vm =>
+        {
+            vm.Initialize(Se.Language.General.PickOllamaModel, OllamaModel, Se.Settings.Tools.AiReview.OllamaUrl);
+        });
+
+        if (result is { OkPressed: true, SelectedModel: not null })
+        {
+            OllamaModel = result.SelectedModel;
         }
     }
 
@@ -122,6 +222,8 @@ public partial class AiAssistantViewModel : ObservableObject
             return;
         }
 
+        SaveSettings();
+
         var systemPrompt =
             "You are a professional subtitle assistant. You are given the current subtitle line and, for context " +
             "only, the lines before and after it. Follow the instruction. Never invent content that is not implied " +
@@ -132,7 +234,6 @@ public partial class AiAssistantViewModel : ObservableObject
             "\n\nCurrent line:\n" + CurrentText +
             "\n\nInstruction:\n" + instruction;
 
-        var review = Se.Settings.Tools.AiReview;
         string url;
         var model = string.Empty;
         string? apiKey = null;
@@ -145,29 +246,36 @@ public partial class AiAssistantViewModel : ObservableObject
 
             if (SelectedEngine == SeAiReview.EngineOpenAiCompatible)
             {
-                url = (review.OpenAiCompatibleUrl ?? string.Empty).Trim();
-                model = (review.OpenAiCompatibleModel ?? string.Empty).Trim();
-                apiKey = string.IsNullOrWhiteSpace(review.OpenAiCompatibleApiKey)
+                url = OpenAiCompatibleUrl.Trim();
+                model = OpenAiCompatibleModel.Trim();
+                apiKey = string.IsNullOrWhiteSpace(OpenAiCompatibleApiKey)
                     ? null
-                    : review.OpenAiCompatibleApiKey.Trim();
+                    : OpenAiCompatibleApiKey.Trim();
             }
             else if (SelectedEngine == SeAiReview.EngineOllama)
             {
-                url = review.OllamaUrl;
-                model = (review.OllamaModel ?? string.Empty).Trim();
+                url = Se.Settings.Tools.AiReview.OllamaUrl;
+                model = OllamaModel.Trim();
             }
             else
             {
-                var reviewModel = LlamaCppServerManager.GetAllReviewModels()
-                    .FirstOrDefault(m => m.FileName == review.LlamaCppModelFileName);
-                if (reviewModel == null)
+                var display = SelectedLlamaCppModel;
+                if (display == null ||
+                    !await LlamaCppDownloadHelper.EnsureReadyAsync(Window, _windowService, display.Model.FileName,
+                        LlamaCppServerManager.GetAllReviewModels(), persistAsTranslateModel: false))
                 {
-                    await MessageBox.Show(Window, Se.Language.Tools.AiReview.Title,
-                        Se.Language.Tools.AiReview.SetupHint, MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    RefreshLlamaCppModels();
                     return;
                 }
 
-                await LlamaCppServerManager.EnsureServerRunningAsync(reviewModel, CancellationToken.None);
+                RefreshLlamaCppModels(); // pick up the fresh install state (green dot)
+                display = SelectedLlamaCppModel;
+                if (display == null)
+                {
+                    return;
+                }
+
+                await LlamaCppServerManager.EnsureServerRunningAsync(display.Model, CancellationToken.None);
                 url = LlamaCppServerManager.ApiUrl;
             }
 
@@ -176,6 +284,10 @@ public partial class AiAssistantViewModel : ObservableObject
             var reply = await client.ChatAsync(url, model, systemPrompt, userContent,
                 _cancellationTokenSource.Token, apiKey, preferJsonObject: false);
             ResultText = CleanReply(reply);
+        }
+        catch (OperationCanceledException)
+        {
+            // the user closed the window or cancelled the request
         }
         catch (Exception e)
         {
@@ -198,6 +310,21 @@ public partial class AiAssistantViewModel : ObservableObject
         }
 
         var text = reply.Trim();
+
+        // Reasoning models (DeepSeek R1, Qwen3, ...) may emit their chain of thought in a
+        // <think>...</think> block before the answer - some chat templates even swallow the
+        // opening tag, so key off the closing tag and keep only what follows it.
+        var endThink = text.LastIndexOf("</think>", StringComparison.OrdinalIgnoreCase);
+        if (endThink >= 0)
+        {
+            text = text[(endThink + "</think>".Length)..].Trim();
+        }
+        else if (text.StartsWith("<think>", StringComparison.OrdinalIgnoreCase))
+        {
+            // Unterminated reasoning block - the answer never arrived (e.g. cut off by the
+            // token limit), so there is nothing usable to show.
+            return string.Empty;
+        }
 
         // A model may still answer with a JSON object (some ignore the plain-text
         // request); take the first string value out of it.
@@ -274,6 +401,7 @@ public partial class AiAssistantViewModel : ObservableObject
             return;
         }
 
+        SaveSettings();
         ResultToApply = ResultText.Trim();
         ApplyPressed = true;
         Window?.Close();
@@ -284,5 +412,22 @@ public partial class AiAssistantViewModel : ObservableObject
     {
         _cancellationTokenSource?.Cancel();
         Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            _cancellationTokenSource?.Cancel();
+            Window?.Close();
+        }
+    }
+
+    internal void OnClosing()
+    {
+        SaveSettings();
+        _cancellationTokenSource?.Cancel();
+        UiUtil.SaveWindowPosition(Window);
     }
 }

--- a/src/ui/Features/Main/AiAssistant/AiAssistantWindow.cs
+++ b/src/ui/Features/Main/AiAssistant/AiAssistantWindow.cs
@@ -1,7 +1,12 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Input;
 using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Translate;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -14,106 +19,301 @@ public class AiAssistantWindow : Window
         UiUtil.InitializeWindow(this, GetType().Name);
         var l = Se.Language.Tools.AiAssistant;
         Title = l.Title;
-        Width = 720;
-        Height = 620;
-        MinWidth = 520;
-        MinHeight = 460;
+        Width = 760;
+        Height = 680;
+        MinWidth = 560;
+        MinHeight = 500;
         CanResize = true;
         vm.Window = this;
         DataContext = vm;
 
-        var grid = new Grid
+        // ---------- toolbar: engine + model settings (same engines as Tools -> AI review) ----------
+        var comboEngine = UiUtil.MakeComboBox(vm.Engines, vm, nameof(vm.SelectedEngine))
+            .WithAccessibleName(Se.Language.General.Engine);
+
+        var textBoxOllamaModel = UiUtil.MakeTextBox(190, vm, nameof(vm.OllamaModel))
+            .WithAccessibleName(Se.Language.General.Model);
+        var buttonPickOllamaModel = UiUtil.MakeButton("...", vm.PickOllamaModelCommand)
+            .Compact()
+            .WithAccessibleName(Se.Language.General.PickOllamaModel);
+        var panelOllama = new StackPanel
         {
-            Margin = new Thickness(15),
-            RowDefinitions = new RowDefinitions("Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,*,Auto,Auto"),
-            ColumnDefinitions = new ColumnDefinitions("*"),
+            Orientation = Orientation.Horizontal,
+            Spacing = 5,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children = { textBoxOllamaModel, buttonPickOllamaModel },
         };
+        panelOllama.Bind(IsVisibleProperty, new Binding(nameof(vm.IsOllamaVisible)));
 
-        var currentLabel = UiUtil.MakeTextBlock(l.CurrentLine);
-        var currentBox = MakeReadonlyMultiline(vm, nameof(vm.CurrentText), 60);
+        var textBoxOpenAiUrl = UiUtil.MakeTextBox(220, vm, nameof(vm.OpenAiCompatibleUrl))
+            .WithAccessibleName(Se.Language.General.Url);
+        var textBoxOpenAiModel = UiUtil.MakeTextBox(130, vm, nameof(vm.OpenAiCompatibleModel))
+            .WithAccessibleName(Se.Language.General.Model);
+        textBoxOpenAiModel.PlaceholderText = Se.Language.General.Model;
+        var textBoxOpenAiApiKey = UiUtil.MakeTextBox(120, vm, nameof(vm.OpenAiCompatibleApiKey))
+            .WithAccessibleName(Se.Language.General.ApiKey);
+        textBoxOpenAiApiKey.PlaceholderText = Se.Language.General.ApiKey;
+        textBoxOpenAiApiKey.PasswordChar = '●';
+        var panelOpenAiCompatible = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 5,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children = { textBoxOpenAiUrl, textBoxOpenAiModel, textBoxOpenAiApiKey },
+        };
+        panelOpenAiCompatible.Bind(IsVisibleProperty, new Binding(nameof(vm.IsOpenAiCompatibleVisible)));
 
-        var contextLabel = UiUtil.MakeTextBlock(l.ContextLines);
-        var contextBox = MakeReadonlyMultiline(vm, nameof(vm.ContextText), 70);
+        var comboLlamaCppModel = UiUtil.MakeComboBox(vm.LlamaCppModels, vm, nameof(vm.SelectedLlamaCppModel))
+            .WithAccessibleName(Se.Language.General.Model);
+        comboLlamaCppModel.Bind(IsVisibleProperty, new Binding(nameof(vm.IsLlamaCppVisible)));
+        comboLlamaCppModel.ItemTemplate = new FuncDataTemplate<LlamaCppModelDisplay>((item, _) =>
+        {
+            var panel = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing = 7,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            if (item != null)
+            {
+                panel.Children.Add(new Avalonia.Controls.Shapes.Ellipse
+                {
+                    Width = 8,
+                    Height = 8,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Fill = item.IsInstalled
+                        ? new SolidColorBrush(Color.FromRgb(0x5c, 0xb8, 0x5c))
+                        : new SolidColorBrush(Color.FromArgb(0x50, 0x80, 0x88, 0x90)),
+                });
+                panel.Children.Add(new TextBlock
+                {
+                    Text = item.DisplayText,
+                    VerticalAlignment = VerticalAlignment.Center,
+                });
+            }
 
+            return panel;
+        });
+
+        var languageChip = new Border
+        {
+            Background = new SolidColorBrush(Color.FromArgb(0x24, 0x4c, 0x9c, 0xe8)),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x59, 0x4c, 0x9c, 0xe8)),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(10),
+            Padding = new Thickness(10, 3),
+            VerticalAlignment = VerticalAlignment.Center,
+            Child = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing = 6,
+                Children =
+                {
+                    new Optris.Icons.Avalonia.Icon { Value = "mdi-web", FontSize = 14, VerticalAlignment = VerticalAlignment.Center },
+                    MakeBoundTextBlock(nameof(vm.LanguageDisplay)),
+                },
+            },
+        };
+        languageChip.Bind(IsVisibleProperty, new Binding(nameof(vm.HasLanguage)));
+
+        var toolbar = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("Auto,Auto,Auto,Auto,Auto,*,Auto"),
+            ColumnSpacing = 8,
+        };
+        var labelEngine = UiUtil.MakeTextBlock(Se.Language.General.Engine).WithMarginRight(2);
+        labelEngine.VerticalAlignment = VerticalAlignment.Center;
+        toolbar.Add(labelEngine, 0, 0);
+        toolbar.Add(comboEngine, 0, 1);
+        toolbar.Add(panelOllama, 0, 2);
+        toolbar.Add(comboLlamaCppModel, 0, 3);
+        toolbar.Add(panelOpenAiCompatible, 0, 4);
+        toolbar.Add(languageChip, 0, 6);
+
+        // ---------- current line + context ----------
+        var currentLabel = MakeSectionLabel("mdi-text", l.CurrentLine);
+        var currentBox = MakeReadonlyMultiline(nameof(vm.CurrentText), 52, l.CurrentLine);
+
+        var contextLabel = MakeSectionLabel("mdi-message-text-outline", l.ContextLines);
+        var contextBox = MakeReadonlyMultiline(nameof(vm.ContextText), 62, l.ContextLines);
+        contextBox.Opacity = 0.75;
+
+        // ---------- quick actions ----------
         var actionPanel = new WrapPanel
         {
             Orientation = Orientation.Horizontal,
-            Margin = new Thickness(0, 8, 0, 0),
         };
-        actionPanel.Children.Add(MakeActionButton(l.FixErrors, vm.FixErrorsCommand));
-        actionPanel.Children.Add(MakeActionButton(l.FitReadingSpeed, vm.FitReadingSpeedCommand));
-        actionPanel.Children.Add(MakeActionButton(l.MakeFormal, vm.MakeFormalCommand));
-        actionPanel.Children.Add(MakeActionButton(l.MakeInformal, vm.MakeInformalCommand));
+        actionPanel.Children.Add(MakeActionButton(vm, l.FixErrors, vm.FixErrorsCommand, "mdi-spellcheck"));
+        actionPanel.Children.Add(MakeActionButton(vm, l.FitReadingSpeed, vm.FitReadingSpeedCommand, "mdi-play-speed"));
+        actionPanel.Children.Add(MakeActionButton(vm, l.MakeFormal, vm.MakeFormalCommand, "mdi-account-tie"));
+        actionPanel.Children.Add(MakeActionButton(vm, l.MakeInformal, vm.MakeInformalCommand, "mdi-emoticon-happy-outline"));
 
-        var questionBox = UiUtil.MakeTextBox(420, vm, nameof(vm.QuestionText));
-        questionBox.Watermark = l.AskPlaceholder;
-        var askButton = UiUtil.MakeButton(l.Ask, vm.AskCommand).Compact();
-        var questionPanel = new StackPanel
+        var questionBox = new TextBox
         {
-            Orientation = Orientation.Horizontal,
-            Spacing = 6,
-            Margin = new Thickness(0, 8, 0, 0),
-            Children = { questionBox, askButton },
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Center,
+            PlaceholderText = l.AskPlaceholder,
+            [!TextBox.TextProperty] = new Binding(nameof(vm.QuestionText)) { Mode = BindingMode.TwoWay },
+        }.WithAccessibleName(l.Ask);
+        questionBox.KeyDown += (_, e) =>
+        {
+            if (e.Key == Key.Enter)
+            {
+                e.Handled = true;
+                if (vm.AskCommand.CanExecute(null))
+                {
+                    vm.AskCommand.Execute(null);
+                }
+            }
         };
+        var askButton = UiUtil.MakeButton(l.Ask, vm.AskCommand)
+            .WithIconLeft("mdi-send")
+            .WithBindEnabled(nameof(vm.IsNotBusy));
+        var questionRow = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("*,Auto"),
+            ColumnSpacing = 6,
+        };
+        questionRow.Add(questionBox, 0, 0);
+        questionRow.Add(askButton, 0, 1);
 
-        var resultLabel = UiUtil.MakeTextBlock(l.Result);
-        resultLabel.Margin = new Thickness(0, 8, 0, 0);
+        // ---------- result ----------
+        var resultLabel = MakeSectionLabel("mdi-robot-outline", l.Result);
         var resultBox = new TextBox
         {
             AcceptsReturn = true,
-            TextWrapping = Avalonia.Media.TextWrapping.Wrap,
-            MinHeight = 120,
+            TextWrapping = TextWrapping.Wrap,
+            MinHeight = 100,
+            BorderThickness = new Thickness(0),
             VerticalAlignment = VerticalAlignment.Stretch,
-        };
-        resultBox.Bind(TextBox.TextProperty, new Binding(nameof(vm.ResultText)) { Mode = BindingMode.TwoWay });
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            [!TextBox.TextProperty] = new Binding(nameof(vm.ResultText)) { Mode = BindingMode.TwoWay },
+        }.WithAccessibleName(l.Result);
+        var resultBorder = UiUtil.MakeBorderForControlNoPadding(resultBox);
 
-        var statusText = UiUtil.MakeTextBlock(string.Empty);
-        statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.StatusText)));
-        statusText.Margin = new Thickness(0, 6, 0, 0);
-
-        var applyButton = UiUtil.MakeButton(l.Apply, vm.ApplyCommand);
-        var closeButton = UiUtil.MakeButtonCancel(vm.CancelCommand);
-        var buttonPanel = new StackPanel
+        // ---------- status ----------
+        var statusIcon = new Optris.Icons.Avalonia.Icon
         {
-            Orientation = Orientation.Horizontal,
-            HorizontalAlignment = HorizontalAlignment.Right,
-            Spacing = 8,
-            Margin = new Thickness(0, 12, 0, 0),
-            Children = { applyButton, closeButton },
+            Value = "mdi-robot-outline",
+            FontSize = 15,
+            Opacity = 0.8,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        var statusText = MakeBoundTextBlock(nameof(vm.StatusText));
+        statusText.Opacity = 0.8;
+        var busyBar = new ProgressBar
+        {
+            IsIndeterminate = true,
+            Height = 6,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        var statusRow = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("Auto,Auto,*"),
+            ColumnSpacing = 10,
+            MinHeight = 20,
+        };
+        statusRow.Add(statusIcon, 0, 0);
+        statusRow.Add(statusText, 0, 1);
+        statusRow.Add(busyBar, 0, 2);
+        statusRow.Bind(IsVisibleProperty, new Binding(nameof(vm.IsBusy)));
+
+        // ---------- bottom bar ----------
+        var applyButton = UiUtil.MakeButton(l.Apply, vm.ApplyCommand)
+            .WithIconLeft("fa-solid fa-check")
+            .WithBindEnabled(nameof(vm.HasResult));
+        var closeButton = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var bottomBar = UiUtil.MakeButtonBar(applyButton, closeButton);
+
+        // ---------- layout ----------
+        var grid = new Grid
+        {
+            Margin = UiUtil.MakeWindowMargin(),
+            RowDefinitions = new RowDefinitions("Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,*,Auto,Auto"),
+            ColumnDefinitions = new ColumnDefinitions("*"),
+            RowSpacing = 6,
         };
 
-        grid.Add(currentLabel, 0, 0);
-        grid.Add(currentBox, 1, 0);
-        grid.Add(contextLabel, 2, 0);
-        grid.Add(contextBox, 3, 0);
-        grid.Add(actionPanel, 4, 0);
-        grid.Add(questionPanel, 5, 0);
-        grid.Add(resultLabel, 6, 0);
-        grid.Add(resultBox, 8, 0);
-        grid.Add(statusText, 9, 0);
-        grid.Add(buttonPanel, 10, 0);
+        grid.Add(toolbar, 0, 0);
+        grid.Add(currentLabel, 1, 0);
+        grid.Add(currentBox, 2, 0);
+        grid.Add(contextLabel, 3, 0);
+        grid.Add(contextBox, 4, 0);
+        grid.Add(actionPanel, 5, 0);
+        grid.Add(questionRow, 6, 0);
+        grid.Add(resultLabel, 7, 0);
+        grid.Add(resultBorder, 8, 0);
+        grid.Add(statusRow, 9, 0);
+        grid.Add(bottomBar, 10, 0);
 
         Content = grid;
+
+        Loaded += delegate
+        {
+            questionBox.Focus();
+            UiUtil.RestoreWindowPosition(this);
+        };
+        Closing += delegate { vm.OnClosing(); };
+        KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 
-    private static TextBox MakeReadonlyMultiline(AiAssistantViewModel vm, string path, double minHeight)
+    private static StackPanel MakeSectionLabel(string iconName, string text)
+    {
+        var label = UiUtil.MakeTextBlock(text);
+        label.Opacity = 0.8;
+        label.VerticalAlignment = VerticalAlignment.Center;
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 6,
+            Margin = new Thickness(0, 6, 0, 0),
+            Children =
+            {
+                new Optris.Icons.Avalonia.Icon
+                {
+                    Value = iconName,
+                    FontSize = 14,
+                    Opacity = 0.7,
+                    VerticalAlignment = VerticalAlignment.Center,
+                },
+                label,
+            },
+        };
+    }
+
+    private static Border MakeReadonlyMultiline(string path, double minHeight, string accessibleName)
     {
         var box = new TextBox
         {
             IsReadOnly = true,
             AcceptsReturn = true,
-            TextWrapping = Avalonia.Media.TextWrapping.Wrap,
+            TextWrapping = TextWrapping.Wrap,
             MinHeight = minHeight,
-            Margin = new Thickness(0, 2, 0, 0),
-        };
+            BorderThickness = new Thickness(0),
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        }.WithAccessibleName(accessibleName);
         box.Bind(TextBox.TextProperty, new Binding(path));
-        return box;
+        return UiUtil.MakeBorderForControlNoPadding(box);
     }
 
-    private static Button MakeActionButton(string text, CommunityToolkit.Mvvm.Input.IRelayCommand command)
+    private static Button MakeActionButton(AiAssistantViewModel vm, string text,
+        CommunityToolkit.Mvvm.Input.IRelayCommand command, string iconName)
     {
-        var button = UiUtil.MakeButton(text, command).Compact();
+        var button = UiUtil.MakeButton(text, command)
+            .WithIconLeft(iconName)
+            .WithBindEnabled(nameof(vm.IsNotBusy))
+            .Compact();
         button.Margin = new Thickness(0, 0, 6, 6);
         return button;
+    }
+
+    private static TextBlock MakeBoundTextBlock(string textPropertyPath)
+    {
+        var textBlock = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        textBlock.Bind(TextBlock.TextProperty, new Binding(textPropertyPath));
+        return textBlock;
     }
 }


### PR DESCRIPTION
Improves the subtitle text box AI assistant:

- **Engine settings in the window**: the same engine toolbar as Tools -> AI review (llama.cpp with install-status model list, Ollama with model picker, OpenAI-compatible URL/model/API key), sharing the AI review settings. The "Please choose an engine and model in Tools -> AI review first" dead end is gone - a missing llama.cpp engine/model now triggers the normal download prompt.
- **UI polish modeled on AI review**: detected-language chip, section labels with icons, bordered text areas, icon buttons for the quick actions, full-width ask box with Enter-to-ask, indeterminate busy row, Apply disabled until there is a suggestion, actions disabled while busy, Esc closes, window position saved/restored.
- **Reasoning models**: `<think>...</think>` chain-of-thought blocks are stripped from replies (keyed off the closing tag, so it also works when the chat template swallows the opening tag), so Apply only inserts the actual answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)