### PR TITLE
AI assistant: show stripped model reasoning behind an info button

### DIFF
--- a/src/ui/Features/Main/AiAssistant/AiAssistantViewModel.cs
+++ b/src/ui/Features/Main/AiAssistant/AiAssistantViewModel.cs
@@ -33,6 +33,8 @@ public partial class AiAssistantViewModel : ObservableObject
     [ObservableProperty] private bool _isBusy;
     [ObservableProperty] private bool _isNotBusy = true;
     [ObservableProperty] private bool _hasResult;
+    [ObservableProperty] private string _thinkText = string.Empty;
+    [ObservableProperty] private bool _hasThink;
     [ObservableProperty] private string _languageDisplay;
     [ObservableProperty] private bool _hasLanguage;
     [ObservableProperty] private ObservableCollection<string> _engines;
@@ -127,6 +129,11 @@ public partial class AiAssistantViewModel : ObservableObject
     partial void OnLanguageDisplayChanged(string value)
     {
         HasLanguage = !string.IsNullOrEmpty(value);
+    }
+
+    partial void OnThinkTextChanged(string value)
+    {
+        HasThink = !string.IsNullOrWhiteSpace(value);
     }
 
     private void UpdateEngineVisibility()
@@ -243,6 +250,7 @@ public partial class AiAssistantViewModel : ObservableObject
             IsBusy = true;
             StatusText = SelectedEngine + "...";
             ResultText = string.Empty;
+            ThinkText = string.Empty;
 
             if (SelectedEngine == SeAiReview.EngineOpenAiCompatible)
             {
@@ -283,7 +291,8 @@ public partial class AiAssistantViewModel : ObservableObject
             using var client = new AiReviewClient();
             var reply = await client.ChatAsync(url, model, systemPrompt, userContent,
                 _cancellationTokenSource.Token, apiKey, preferJsonObject: false);
-            ResultText = CleanReply(reply);
+            ResultText = CleanReply(reply, out var thinkText);
+            ThinkText = thinkText;
         }
         catch (OperationCanceledException)
         {
@@ -302,8 +311,9 @@ public partial class AiAssistantViewModel : ObservableObject
         }
     }
 
-    private static string CleanReply(string reply)
+    private static string CleanReply(string reply, out string thinkText)
     {
+        thinkText = string.Empty;
         if (string.IsNullOrWhiteSpace(reply))
         {
             return string.Empty;
@@ -313,16 +323,19 @@ public partial class AiAssistantViewModel : ObservableObject
 
         // Reasoning models (DeepSeek R1, Qwen3, ...) may emit their chain of thought in a
         // <think>...</think> block before the answer - some chat templates even swallow the
-        // opening tag, so key off the closing tag and keep only what follows it.
+        // opening tag, so key off the closing tag and keep only what follows it. The
+        // reasoning is kept so the UI can offer it behind an info button.
         var endThink = text.LastIndexOf("</think>", StringComparison.OrdinalIgnoreCase);
         if (endThink >= 0)
         {
+            thinkText = StripThinkTags(text[..endThink]);
             text = text[(endThink + "</think>".Length)..].Trim();
         }
         else if (text.StartsWith("<think>", StringComparison.OrdinalIgnoreCase))
         {
             // Unterminated reasoning block - the answer never arrived (e.g. cut off by the
             // token limit), so there is nothing usable to show.
+            thinkText = StripThinkTags(text);
             return string.Empty;
         }
 
@@ -361,6 +374,14 @@ public partial class AiAssistantViewModel : ObservableObject
         }
 
         return text;
+    }
+
+    private static string StripThinkTags(string text)
+    {
+        return text
+            .Replace("<think>", string.Empty, StringComparison.OrdinalIgnoreCase)
+            .Replace("</think>", string.Empty, StringComparison.OrdinalIgnoreCase)
+            .Trim();
     }
 
     private static string? TryExtractJsonString(string text)

--- a/src/ui/Features/Main/AiAssistant/AiAssistantWindow.cs
+++ b/src/ui/Features/Main/AiAssistant/AiAssistantWindow.cs
@@ -6,6 +6,7 @@ using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.Styling;
 using Nikse.SubtitleEdit.Features.Translate;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -184,9 +185,7 @@ public class AiAssistantWindow : Window
             AcceptsReturn = true,
             TextWrapping = TextWrapping.Wrap,
             BorderThickness = new Thickness(0),
-            // The Fluent flyout presenter caps its width at 456 (FlyoutThemeMaxWidth);
-            // stay under that including padding or the text gets clipped on the right.
-            Width = 420,
+            Width = 620,
             MaxHeight = 340,
         }.WithAccessibleName(l.ShowReasoning);
         thinkBox.Bind(TextBox.TextProperty, new Binding(nameof(vm.ThinkText)));
@@ -195,7 +194,18 @@ public class AiAssistantWindow : Window
             .WithAccessibleName(l.ShowReasoning);
         buttonThink.FontSize = 13;
         buttonThink.Padding = new Thickness(4, 2);
-        buttonThink.Flyout = new Flyout { Content = thinkBox };
+        // The Fluent flyout presenter caps its width at 456 (FlyoutThemeMaxWidth), which
+        // would clip the text box - raise the cap while keeping the default presenter look.
+        Application.Current!.TryFindResource(typeof(FlyoutPresenter), out var presenterDefaultTheme);
+        buttonThink.Flyout = new Flyout
+        {
+            Content = thinkBox,
+            FlyoutPresenterTheme = new ControlTheme(typeof(FlyoutPresenter))
+            {
+                BasedOn = presenterDefaultTheme as ControlTheme,
+                Setters = { new Setter(MaxWidthProperty, 680d) },
+            },
+        };
         buttonThink.Bind(IsVisibleProperty, new Binding(nameof(vm.HasThink)));
         UiUtil.AttachHoverTooltip(buttonThink, l.ShowReasoning);
 

--- a/src/ui/Features/Main/AiAssistant/AiAssistantWindow.cs
+++ b/src/ui/Features/Main/AiAssistant/AiAssistantWindow.cs
@@ -184,7 +184,9 @@ public class AiAssistantWindow : Window
             AcceptsReturn = true,
             TextWrapping = TextWrapping.Wrap,
             BorderThickness = new Thickness(0),
-            Width = 520,
+            // The Fluent flyout presenter caps its width at 456 (FlyoutThemeMaxWidth);
+            // stay under that including padding or the text gets clipped on the right.
+            Width = 420,
             MaxHeight = 340,
         }.WithAccessibleName(l.ShowReasoning);
         thinkBox.Bind(TextBox.TextProperty, new Binding(nameof(vm.ThinkText)));

--- a/src/ui/Features/Main/AiAssistant/AiAssistantWindow.cs
+++ b/src/ui/Features/Main/AiAssistant/AiAssistantWindow.cs
@@ -178,7 +178,27 @@ public class AiAssistantWindow : Window
         questionRow.Add(askButton, 0, 1);
 
         // ---------- result ----------
+        var thinkBox = new TextBox
+        {
+            IsReadOnly = true,
+            AcceptsReturn = true,
+            TextWrapping = TextWrapping.Wrap,
+            BorderThickness = new Thickness(0),
+            Width = 520,
+            MaxHeight = 340,
+        }.WithAccessibleName(l.ShowReasoning);
+        thinkBox.Bind(TextBox.TextProperty, new Binding(nameof(vm.ThinkText)));
+        var buttonThink = UiUtil.MakeButton(null, "mdi-information-outline")
+            .Compact()
+            .WithAccessibleName(l.ShowReasoning);
+        buttonThink.FontSize = 13;
+        buttonThink.Padding = new Thickness(4, 2);
+        buttonThink.Flyout = new Flyout { Content = thinkBox };
+        buttonThink.Bind(IsVisibleProperty, new Binding(nameof(vm.HasThink)));
+        UiUtil.AttachHoverTooltip(buttonThink, l.ShowReasoning);
+
         var resultLabel = MakeSectionLabel("mdi-robot-outline", l.Result);
+        resultLabel.Children.Add(buttonThink);
         var resultBox = new TextBox
         {
             AcceptsReturn = true,

--- a/src/ui/Logic/Config/Language/Tools/LanguageAiAssistant.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageAiAssistant.cs
@@ -14,6 +14,7 @@ public class LanguageAiAssistant
     public string Result { get; set; }
     public string Apply { get; set; }
     public string Hint { get; set; }
+    public string ShowReasoning { get; set; }
 
     public LanguageAiAssistant()
     {
@@ -29,5 +30,6 @@ public class LanguageAiAssistant
         Result = "Suggestion";
         Apply = "Apply to line";
         Hint = "AI assistant for this line";
+        ShowReasoning = "Show the model's reasoning";
     }
 }


### PR DESCRIPTION
Follow-up to #12313: the `<think>` chain-of-thought that is stripped from reasoning-model replies is now kept and viewable. A small info icon appears next to the Suggestion label only when the reply contained a reasoning block; clicking it opens a flyout with the reasoning text (read-only, wrapped, scrollable). Also shown when the reasoning block was unterminated (answer cut off), so the user can see what the model was doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)