### PR TITLE
Add shortcut to toggle subtitle grid formatting mode

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9395,6 +9395,42 @@ public partial class MainViewModel :
         AutoFitColumns();
     }
 
+    // Cycle the grid's Text/Original text formatting mode (issue #12321): "show formatting"
+    // (tags hidden, styling rendered) -> "show tags" -> "no formatting". Handy for heavy ASS
+    // karaoke tags where the full tag text makes the grid hard to read. The grid cell
+    // converter reads the setting live, so re-notifying Text/OriginalText re-renders the rows.
+    [RelayCommand]
+    private void ToggleSubtitleGridFormatting()
+    {
+        int newMode;
+        string newModeName;
+        if (Se.Settings.Appearance.SubtitleGridFormattingType == (int)SubtitleGridFormattingTypes.ShowFormatting)
+        {
+            newMode = (int)SubtitleGridFormattingTypes.ShowTags;
+            newModeName = Se.Language.Options.Settings.SubtitleGridFormattingShowTags;
+        }
+        else if (Se.Settings.Appearance.SubtitleGridFormattingType == (int)SubtitleGridFormattingTypes.ShowTags)
+        {
+            newMode = (int)SubtitleGridFormattingTypes.NoFormatting;
+            newModeName = Se.Language.Options.Settings.SubtitleGridFormattingNone;
+        }
+        else
+        {
+            newMode = (int)SubtitleGridFormattingTypes.ShowFormatting;
+            newModeName = Se.Language.Options.Settings.SubtitleGridFormattingShowFormatting;
+        }
+
+        Se.Settings.Appearance.SubtitleGridFormattingType = newMode;
+        Se.SaveSettings();
+
+        foreach (var row in Subtitles)
+        {
+            row.RefreshAfterSettingsChanged();
+        }
+
+        ShowStatus(string.Format(Se.Language.Main.SubtitleGridFormattingX, newModeName));
+    }
+
     [RelayCommand]
     private void DuplicateSelectedLines()
     {

--- a/src/ui/Logic/Config/Language/Main/LanguageMain.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMain.cs
@@ -67,6 +67,7 @@ public class LanguageMain
     public string SingleLineLength { get; set; }
     public string SpeedIsNowX { get; set; }
     public string SpellCheckResult { get; set; }
+    public string SubtitleGridFormattingX { get; set; }
     public string SubtitleImportedFromMatroskaFile { get; set; }
     public string TextDown { get; set; }
     public string TextOnly { get; set; }
@@ -184,6 +185,7 @@ public class LanguageMain
         SingleLineLength = "Line length: ";
         SpeedIsNowX = "Speed is now \"{0}\"";
         SpellCheckResult = "Spell check completed. \n\n• Changed words: {0}\n• Skipped words: {1}";
+        SubtitleGridFormattingX = "Grid formatting: {0}";
         SubtitleImportedFromMatroskaFile = "Subtitle imported from Matroska file";
         TextDown = "Text down";
         TextOnly = "Text only";

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -134,6 +134,7 @@ public class LanguageSettingsShortcuts
     public string ToggleBookmark { get; set; }
     public string GoToNextBookmark { get; set; }
     public string ToggleWaveformToolbar { get; set; }
+    public string ToggleSubtitleGridFormatting { get; set; }
     public string WaveformSetStartAndSetEndOfPreviousMinusGap { get; set; }
     public string WaveformSetEndAndStartOfNextAfterGap { get; set; }
     public string WaveformSetEndAndStartOfNextAfterGapAndGoToNext { get; set; }
@@ -446,6 +447,7 @@ public class LanguageSettingsShortcuts
         ToggleBookmark = "Toggle bookmark (selected lines, no text)";
         GoToNextBookmark = "Go to next bookmark";
         ToggleWaveformToolbar = "Toggle waveform toolbar";
+        ToggleSubtitleGridFormatting = "Toggle grid formatting (show formatting/show tags/no formatting)";
         WaveformSetStartAndSetEndOfPreviousMinusGap = "Set start and set end of previous minus gap";
         WaveformSetEndAndStartOfNextAfterGap = "Set end and start of next plus gap";
         WaveformSetEndAndStartOfNextAfterGapAndGoToNext = "Set end and start of next plus gap and go to next";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -98,6 +98,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.OpenDataFolderCommand), Se.Language.Options.Shortcuts.OpenSeDataFolder },
         { nameof(MainViewModel.SetupLikeSe4Command), Se.Language.Options.Shortcuts.GeneralSetupLikeSe4 },
         { nameof(MainViewModel.ToggleIsWaveformToolbarVisibleCommand), Se.Language.Options.Shortcuts.ToggleWaveformToolbar },
+        { nameof(MainViewModel.ToggleSubtitleGridFormattingCommand), Se.Language.Options.Shortcuts.ToggleSubtitleGridFormatting },
 
         // File
         { nameof(MainViewModel.CommandFileOpenCommand), Se.Language.Options.Shortcuts.FileOpen },
@@ -478,6 +479,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.GoToPreviousBookmarkCommand, nameof(vm.GoToPreviousBookmarkCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.OpenDataFolderCommand, nameof(vm.OpenDataFolderCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ToggleIsWaveformToolbarVisibleCommand, nameof(vm.ToggleIsWaveformToolbarVisibleCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.ToggleSubtitleGridFormattingCommand, nameof(vm.ToggleSubtitleGridFormattingCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SetupLikeSe4Command, nameof(vm.SetupLikeSe4Command), ShortcutCategory.General);
 
         // File


### PR DESCRIPTION
Fixes #12321

Adds a new assignable shortcut, **"Toggle grid formatting (show formatting/show tags/no formatting)"** (General category), that cycles the subtitle grid's Text/Original text rendering mode:

- **Show formatting** – tags hidden, bold/italic/color rendered (clean text view)
- **Show tags** – full tag text with syntax highlighting
- **No formatting** – plain text incl. tags

This makes it a one-keypress operation to hide heavy ASS karaoke tags like `{\alpha&HFF&\t(0,200,\alpha&H00&)...}` in the grid, instead of going through Settings → Appearance.

Details:
- The chosen mode is persisted to settings (same setting as the existing Appearance combo box).
- Grid rows re-render in place via `RefreshAfterSettingsChanged()` — no layout rebuild.
- The new mode is announced in the status bar ("Grid formatting: Show tags").
- Ships unbound; users assign a key in Options → Shortcuts.

Tested: `dotnet build src/ui` clean, all 605 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)