### PR TITLE
Add generic OpenAI-compatible engine to auto-translate

### DIFF
--- a/src/libse/AutoTranslate/OpenAiCompatibleTranslate.cs
+++ b/src/libse/AutoTranslate/OpenAiCompatibleTranslate.cs
@@ -1,0 +1,110 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Settings;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Core.Translate;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Core.AutoTranslate
+{
+    /// <summary>
+    /// Generic engine for any service exposing an OpenAI-compatible "chat/completions"
+    /// endpoint (vLLM, Xiaomi MIMO, Together, etc.) - URL, API key, and model are all
+    /// user-configured, so providers SE has no dedicated engine for still work (#12324).
+    /// </summary>
+    public class OpenAiCompatibleTranslate : IAutoTranslator, IDisposable
+    {
+        private HttpClient _httpClient;
+
+        public static string StaticName { get; set; } = "OpenAI Compatible API";
+        public override string ToString() => StaticName;
+        public string Name => StaticName;
+        public string Url => "https://platform.openai.com/docs/api-reference/chat";
+        public string Error { get; set; }
+        public int MaxCharacters => 1500;
+
+        public void Initialize()
+        {
+            _httpClient?.Dispose();
+            _httpClient = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
+            _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
+            _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
+            _httpClient.BaseAddress = new Uri(Configuration.Settings.Tools.OpenAiCompatibleTranslateUrl.TrimEnd('/'));
+            _httpClient.Timeout = TimeSpan.FromMinutes(15);
+
+            if (!string.IsNullOrEmpty(Configuration.Settings.Tools.OpenAiCompatibleTranslateApiKey))
+            {
+                _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", "Bearer " + Configuration.Settings.Tools.OpenAiCompatibleTranslateApiKey);
+            }
+        }
+
+        public List<TranslationPair> GetSupportedSourceLanguages()
+        {
+            return ChatGptTranslate.ListLanguages();
+        }
+
+        public List<TranslationPair> GetSupportedTargetLanguages()
+        {
+            return ChatGptTranslate.ListLanguages();
+        }
+
+        public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+        {
+            // Model stays optional: single-model servers (e.g. llama.cpp, vLLM with one
+            // model loaded) ignore it, while hosted providers require it.
+            var model = Configuration.Settings.Tools.OpenAiCompatibleTranslateModel;
+            var modelJson = string.Empty;
+            if (!string.IsNullOrEmpty(model))
+            {
+                modelJson = "\"model\": \"" + Json.EncodeJsonText(model) + "\",";
+            }
+
+            if (string.IsNullOrWhiteSpace(Configuration.Settings.Tools.OpenAiCompatibleTranslatePrompt))
+            {
+                Configuration.Settings.Tools.OpenAiCompatibleTranslatePrompt = new ToolsSettings().OpenAiCompatibleTranslatePrompt;
+            }
+            var prompt = string.Format(Configuration.Settings.Tools.OpenAiCompatibleTranslatePrompt, sourceLanguageCode, targetLanguageCode);
+            var input = "{" + modelJson + "\"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
+            var content = new StringContent(input, Encoding.UTF8);
+            content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+            var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
+            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var json = Encoding.UTF8.GetString(bytes).Trim();
+            if (!result.IsSuccessStatusCode)
+            {
+                Error = json;
+                SeLogger.Error("Error calling " + StaticName + ": Status code=" + result.StatusCode + Environment.NewLine + json);
+            }
+
+            result.EnsureSuccessStatusCode();
+
+            var parser = new SeJsonParser();
+            var resultText = parser.GetFirstObject(json, "content");
+            if (resultText == null)
+            {
+                return string.Empty;
+            }
+
+            var outputText = Json.DecodeJsonText(resultText).Trim();
+            if (outputText.StartsWith('"') && outputText.EndsWith('"') && !text.StartsWith('"'))
+            {
+                outputText = outputText.Trim('"').Trim();
+            }
+
+            outputText = ChatGptTranslate.FixNewLines(outputText);
+            outputText = ChatGptTranslate.RemovePreamble(text, outputText);
+            outputText = ChatGptTranslate.DecodeUnicodeEscapes(outputText);
+            return outputText.Trim();
+        }
+
+        public void Dispose()
+        {
+            _httpClient?.Dispose();
+        }
+    }
+}

--- a/src/libse/Settings/ToolsSettings.cs
+++ b/src/libse/Settings/ToolsSettings.cs
@@ -54,6 +54,10 @@ namespace Nikse.SubtitleEdit.Core.Settings
         public string ChatGptPrompt { get; set; }
         public string ChatGptApiKey { get; set; }
         public string ChatGptModel { get; set; }
+        public string OpenAiCompatibleTranslateUrl { get; set; }
+        public string OpenAiCompatibleTranslatePrompt { get; set; }
+        public string OpenAiCompatibleTranslateApiKey { get; set; }
+        public string OpenAiCompatibleTranslateModel { get; set; }
         public string GroqUrl { get; set; }
         public string GroqPrompt { get; set; }
         public string GroqApiKey { get; set; }
@@ -384,6 +388,10 @@ namespace Nikse.SubtitleEdit.Core.Settings
             ChatGptUrl = "https://api.openai.com/v1/chat/completions";
             ChatGptPrompt = "Translate from {0} to {1}, keep punctuation as input, keep line breaks exactly the same, do not censor the translation, give only the output without comments:";
             ChatGptModel = ChatGptTranslate.DefaultModel;
+            OpenAiCompatibleTranslateUrl = "http://localhost:8000/v1/chat/completions";
+            OpenAiCompatibleTranslatePrompt = "Translate from {0} to {1}, keep punctuation as input, keep line breaks exactly the same, do not censor the translation, give only the output without comments:";
+            OpenAiCompatibleTranslateApiKey = string.Empty;
+            OpenAiCompatibleTranslateModel = string.Empty;
             GroqUrl = "https://api.groq.com/openai/v1/chat/completions";
             GroqPrompt = "Translate from {0} to {1}, keep punctuation as input, keep line breaks exactly the same, do not censor the translation, give only the output without comments:";
             GroqModel = GroqTranslate.Models[0];

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -144,6 +144,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             new LibreTranslate(),
             new MyMemoryApi(),
             new ChatGptTranslate(),
+            new OpenAiCompatibleTranslate(),
             new LmStudioTranslate(),
             new OllamaTranslate(),
             new LlamaCppTranslate(),
@@ -200,6 +201,11 @@ public partial class AutoTranslateViewModel : ObservableObject
         Configuration.Settings.Tools.ChatGptApiKey = Se.Settings.AutoTranslate.ChatGptApiKey;
         Configuration.Settings.Tools.ChatGptModel = Se.Settings.AutoTranslate.ChatGptModel;
         Configuration.Settings.Tools.ChatGptPrompt = Se.Settings.AutoTranslate.ChatGptPrompt;
+
+        Configuration.Settings.Tools.OpenAiCompatibleTranslateUrl = Se.Settings.AutoTranslate.OpenAiCompatibleUrl;
+        Configuration.Settings.Tools.OpenAiCompatibleTranslateApiKey = Se.Settings.AutoTranslate.OpenAiCompatibleApiKey;
+        Configuration.Settings.Tools.OpenAiCompatibleTranslateModel = Se.Settings.AutoTranslate.OpenAiCompatibleModel;
+        Configuration.Settings.Tools.OpenAiCompatibleTranslatePrompt = Se.Settings.AutoTranslate.OpenAiCompatiblePrompt;
 
         Configuration.Settings.Tools.LmStudioApiUrl = Se.Settings.AutoTranslate.LmStudioApiUrl;
         Configuration.Settings.Tools.LmStudioModel = Se.Settings.AutoTranslate.LmStudioModel;
@@ -328,6 +334,13 @@ public partial class AutoTranslateViewModel : ObservableObject
             Configuration.Settings.Tools.ChatGptModel = apiModel.Trim();
         }
 
+        if (engineType == typeof(OpenAiCompatibleTranslate))
+        {
+            Configuration.Settings.Tools.OpenAiCompatibleTranslateUrl = apiUrl.Trim();
+            Configuration.Settings.Tools.OpenAiCompatibleTranslateApiKey = apiKey.Trim();
+            Configuration.Settings.Tools.OpenAiCompatibleTranslateModel = apiModel.Trim();
+        }
+
         if (engineType == typeof(LmStudioTranslate))
         {
             Configuration.Settings.Tools.LmStudioApiUrl = apiUrl.Trim();
@@ -452,6 +465,11 @@ public partial class AutoTranslateViewModel : ObservableObject
         Se.Settings.AutoTranslate.ChatGptApiKey = Configuration.Settings.Tools.ChatGptApiKey;
         Se.Settings.AutoTranslate.ChatGptModel = Configuration.Settings.Tools.ChatGptModel;
         Se.Settings.AutoTranslate.ChatGptPrompt = Configuration.Settings.Tools.ChatGptPrompt;
+
+        Se.Settings.AutoTranslate.OpenAiCompatibleUrl = Configuration.Settings.Tools.OpenAiCompatibleTranslateUrl;
+        Se.Settings.AutoTranslate.OpenAiCompatibleApiKey = Configuration.Settings.Tools.OpenAiCompatibleTranslateApiKey;
+        Se.Settings.AutoTranslate.OpenAiCompatibleModel = Configuration.Settings.Tools.OpenAiCompatibleTranslateModel;
+        Se.Settings.AutoTranslate.OpenAiCompatiblePrompt = Configuration.Settings.Tools.OpenAiCompatibleTranslatePrompt;
 
         Se.Settings.AutoTranslate.LmStudioApiUrl = Configuration.Settings.Tools.LmStudioApiUrl;
         Se.Settings.AutoTranslate.LmStudioModel = Configuration.Settings.Tools.LmStudioModel;
@@ -1685,6 +1703,31 @@ public partial class AutoTranslateViewModel : ObservableObject
 
             ApiKeyText = Configuration.Settings.Tools.ChatGptApiKey;
             ApiKeyIsVisible = true;
+            return;
+        }
+
+        if (engineType == typeof(OpenAiCompatibleTranslate))
+        {
+            if (string.IsNullOrEmpty(Configuration.Settings.Tools.OpenAiCompatibleTranslateUrl))
+            {
+                Configuration.Settings.Tools.OpenAiCompatibleTranslateUrl = "http://localhost:8000/v1/chat/completions";
+            }
+
+            FillUrls(new List<string>
+            {
+                Configuration.Settings.Tools.OpenAiCompatibleTranslateUrl.TrimEnd('/'),
+                "http://localhost:8000/v1/chat/completions",
+                "http://localhost:1234/v1/chat/completions",
+            }.Distinct().ToList());
+
+            ApiKeyText = Configuration.Settings.Tools.OpenAiCompatibleTranslateApiKey;
+            ApiKeyIsVisible = true;
+
+            // No model list to offer - the server decides which models exist, so the
+            // model stays a free-text field (and may be left empty for one-model servers).
+            ModelIsVisible = true;
+            ModelText = Configuration.Settings.Tools.OpenAiCompatibleTranslateModel;
+
             return;
         }
 

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -1180,6 +1180,7 @@ public partial class AutoTranslateViewModel : ObservableObject
 
         if (ApiKeyIsVisible && string.IsNullOrWhiteSpace(ApiKeyText) && engineType != typeof(LibreTranslate))
         {
+            IsProgressEnabled = false;
             await MessageBox.Show(
                 Window,
                 Se.Language.General.Error,
@@ -1189,12 +1190,30 @@ public partial class AutoTranslateViewModel : ObservableObject
             return false;
         }
 
-        if (ApiUrlIsVisible && string.IsNullOrWhiteSpace(ApiUrlText))
+        // Papago repurposes the URL field as its client ID, so only the empty check applies there.
+        if (ApiUrlIsVisible && engineType == typeof(PapagoTranslate) && string.IsNullOrWhiteSpace(ApiUrlText))
         {
+            IsProgressEnabled = false;
             await MessageBox.Show(
                 Window,
                 Se.Language.General.Error,
                 string.Format(Se.Language.General.XRequiresAnApiKey, translator.Name),
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return false;
+        }
+
+        // An empty or non-http(s) URL would otherwise reach the engine's Initialize() and
+        // throw an uncaught UriFormatException from "new Uri(...)".
+        if (ApiUrlIsVisible && engineType != typeof(PapagoTranslate) &&
+            (!Uri.TryCreate((ApiUrlText ?? string.Empty).Trim(), UriKind.Absolute, out var apiUri) ||
+             (apiUri.Scheme != Uri.UriSchemeHttp && apiUri.Scheme != Uri.UriSchemeHttps)))
+        {
+            IsProgressEnabled = false;
+            await MessageBox.Show(
+                Window,
+                Se.Language.General.Error,
+                string.Format(Se.Language.General.XRequiresAValidUrl, translator.Name),
                 MessageBoxButtons.OK,
                 MessageBoxIcon.Error);
             return false;
@@ -1232,7 +1251,25 @@ public partial class AutoTranslateViewModel : ObservableObject
         ProgressValue = 0;
         ProgressText = "0 %";
 
-        translator.Initialize();
+        try
+        {
+            translator.Initialize();
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, "Failed to initialize translation engine " + translator.Name);
+            _translationInProgress = false;
+            IsTranslateEnabled = true;
+            IsProgressEnabled = false;
+            StatusText = Se.Language.Translate.ReadyToTranslate;
+            await MessageBox.Show(
+                Window,
+                Se.Language.General.Error,
+                string.Format(Se.Language.General.ErrorX, exception.Message),
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return false;
+        }
 
         var sourceLanguage = translator.GetSupportedSourceLanguages()
             .FirstOrDefault(p => p.Name.Equals(SelectedSourceLanguage?.ToString() ?? string.Empty, StringComparison.InvariantCultureIgnoreCase));

--- a/src/ui/Features/Translate/TranslateSettingsViewModel.cs
+++ b/src/ui/Features/Translate/TranslateSettingsViewModel.cs
@@ -51,6 +51,7 @@ public partial class TranslateSettingsViewModel : ObservableObject
 
         var engineType = AutoTranslator.GetType();
         if (engineType == typeof(ChatGptTranslate) ||
+            engineType == typeof(OpenAiCompatibleTranslate) ||
             engineType == typeof(OllamaTranslate) ||
             engineType == typeof(LmStudioTranslate) ||
             engineType == typeof(AnthropicTranslate) ||
@@ -109,6 +110,11 @@ public partial class TranslateSettingsViewModel : ObservableObject
             {
                 Se.Settings.AutoTranslate.ChatGptPrompt = PromptText;
                 Configuration.Settings.Tools.ChatGptPrompt = PromptText;
+            }
+            else if (engineType == typeof(OpenAiCompatibleTranslate))
+            {
+                Se.Settings.AutoTranslate.OpenAiCompatiblePrompt = PromptText;
+                Configuration.Settings.Tools.OpenAiCompatibleTranslatePrompt = PromptText;
             }
             else if (engineType == typeof(OllamaTranslate))
             {
@@ -199,6 +205,14 @@ public partial class TranslateSettingsViewModel : ObservableObject
             if (string.IsNullOrWhiteSpace(PromptText))
             {
                 PromptText = new SeAutoTranslate().ChatGptPrompt;
+            }
+        }
+        else if (engineType == typeof(OpenAiCompatibleTranslate))
+        {
+            PromptText = Se.Settings.AutoTranslate.OpenAiCompatiblePrompt;
+            if (string.IsNullOrWhiteSpace(PromptText))
+            {
+                PromptText = new SeAutoTranslate().OpenAiCompatiblePrompt;
             }
         }
         else if (engineType == typeof(OllamaTranslate))

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -701,6 +701,7 @@ public class LanguageGeneral
     public string XOfYLinesUpdatedAndZNeighborsAdjusted { get; set; }
     public string NoBookmarksFound { get; set; }
     public string XRequiresAnApiKey { get; set; }
+    public string XRequiresAValidUrl { get; set; }
     public string XSeconds { get; set; }
     public string XSubtitles { get; set; }
     public string Yes { get; set; }
@@ -1455,6 +1456,7 @@ public class LanguageGeneral
         XOfYLinesUpdatedAndZNeighborsAdjusted = "{0}: {1} of {2} line(s) updated, {3} neighbor(s) adjusted";
         NoBookmarksFound = "No more bookmarks found";
         XRequiresAnApiKey = "{0} requires an API key";
+        XRequiresAValidUrl = "{0} requires a valid URL (e.g. \"http://...\" or \"https://...\")";
         XSeconds = "{0:0.0##} seconds";
         XSubtitles = "{0:#,###,##0} subtitles";
         Yes = "Yes";

--- a/src/ui/Logic/Config/SeAutoTranslate.cs
+++ b/src/ui/Logic/Config/SeAutoTranslate.cs
@@ -12,6 +12,10 @@ public class SeAutoTranslate
     public string ChatGptPrompt { get; set; }
     public string ChatGptApiKey { get; set; }
     public string ChatGptModel { get; set; }
+    public string OpenAiCompatibleUrl { get; set; }
+    public string OpenAiCompatiblePrompt { get; set; }
+    public string OpenAiCompatibleApiKey { get; set; }
+    public string OpenAiCompatibleModel { get; set; }
     public string OllamaPrompt { get; set; }
     public string OllamaModel { get; set; }
     public string OllamaModels { get; set; }
@@ -129,6 +133,10 @@ public class SeAutoTranslate
         ChatGptModel = ChatGptTranslate.DefaultModel;
         ChatGptPrompt = "Translate from {0} to {1}, keep punctuation as input, do not censor the translation, give only the output without comments:";
         ChatGptUrl = "https://api.openai.com/v1/chat/completions";
+        OpenAiCompatibleApiKey = string.Empty;
+        OpenAiCompatibleModel = string.Empty;
+        OpenAiCompatiblePrompt = "Translate from {0} to {1}, keep punctuation as input, keep line breaks exactly the same, do not censor the translation, give only the output without comments:";
+        OpenAiCompatibleUrl = "http://localhost:8000/v1/chat/completions";
         CopyPasteLineSeparator = "(...)";
         CopyPasteMaxBlockSize = 5000;
         DeepLApiKey = string.Empty;


### PR DESCRIPTION
Fixes #12324.

Adds an **"OpenAI Compatible API"** engine to the auto-translate window, so any service exposing an OpenAI-style `chat/completions` endpoint can be used without SE needing a dedicated engine — e.g. Xiaomi MIMO, vLLM, LiteLLM/gateways, or any self-hosted server. This mirrors the "OpenAI Compatible Server" option already available in the speech-to-text window.

### What the user configures
- **URL** — full endpoint URL (defaults to `http://localhost:8000/v1/chat/completions`)
- **API key** — optional; sent as `Authorization: Bearer …` when set
- **Model** — free text, optional: single-model servers (llama.cpp, vLLM with one model) ignore it; hosted providers require it, and their error body is surfaced in the existing translation error dialog
- **Prompt** — editable via the engine settings dialog like the other LLM engines

### Implementation
- New `OpenAiCompatibleTranslate` in libse, modeled on `ChatGptTranslate`/`LmStudioTranslate` and reusing the shared ChatGPT helpers (`ListLanguages`, `RemovePreamble`, `FixNewLines`, `DecodeUnicodeEscapes`)
- New settings in `ToolsSettings` + `SeAutoTranslate` (persisted like the other engines)
- Wired into `AutoTranslateViewModel` (engine list, load/save, engine panel) and `TranslateSettingsViewModel` (prompt edit + validation)

### Testing
- Verified end-to-end against a live OpenAI-compatible server (Ollama's `/v1/chat/completions`): en→da translation returns correct multi-line output, and the empty-model case surfaces the server's "model is required" error via `Error` as expected
- `dotnet build src/ui` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)