### PR TITLE
Update CrispASR Qwen3 and parakeet-ja model lists

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
@@ -78,7 +78,7 @@ public class CrispAsrParakeet : CrispAsrEngineBase
             new WhisperModel
             {
                 Name = "parakeet-tdt-0.6b-ja-q4_k.gguf",
-                Size = "470 MB",
+                Size = "476 MB",
                 Urls =
                 [
                     "https://huggingface.co/cstr/parakeet-tdt-0.6b-ja-GGUF/resolve/main/parakeet-tdt-0.6b-ja-q4_k.gguf",
@@ -86,8 +86,19 @@ public class CrispAsrParakeet : CrispAsrEngineBase
             },
             new WhisperModel
             {
+                // Upstream's recommended default for ja since CrispASR v0.8.8:
+                // TDT output byte-identical to F16 at roughly half the size.
+                Name = "parakeet-tdt-0.6b-ja-q8_0.gguf",
+                Size = "744 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/parakeet-tdt-0.6b-ja-GGUF/resolve/main/parakeet-tdt-0.6b-ja-q8_0.gguf",
+                ],
+            },
+            new WhisperModel
+            {
                 Name = "parakeet-tdt-0.6b-ja.gguf",
-                Size = "1.24 GB",
+                Size = "1.25 GB",
                 Urls =
                 [
                     "https://huggingface.co/cstr/parakeet-tdt-0.6b-ja-GGUF/resolve/main/parakeet-tdt-0.6b-ja.gguf",

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrQwen3.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrQwen3.cs
@@ -52,18 +52,13 @@ public class CrispAsrQwen3 : CrispAsrEngineBase
             new WhisperLanguage("ro", "romanian"),
        };
 
+    // qwen3-asr-1.7b-q4_k.gguf is intentionally NOT listed: on CrispASR v0.8.9 it
+    // produces empty transcripts (sub-8-bit encoder drift; the checksum-verified file
+    // loads and "transcribes" but emits no text). Re-add if upstream ships an
+    // imatrix-repaired q4_k like the 0.6b repo got.
     public override List<WhisperModel> Models =>
        new()
        {
-            new WhisperModel
-            {
-                Name = "qwen3-asr-1.7b-q4_k.gguf",
-                Size = "1.33 GB",
-                Urls =
-                [
-                    "https://huggingface.co/cstr/qwen3-asr-1.7b-GGUF/resolve/main/qwen3-asr-1.7b-q4_k.gguf",
-                ],
-            },
             new WhisperModel
             {
                 Name = "qwen3-asr-1.7b-q8_0.gguf",
@@ -80,6 +75,33 @@ public class CrispAsrQwen3 : CrispAsrEngineBase
                 Urls =
                 [
                     "https://huggingface.co/cstr/qwen3-asr-1.7b-GGUF/resolve/main/qwen3-asr-1.7b-f16.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "qwen3-asr-0.6b-q4_k.gguf",
+                Size = "631 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/qwen3-asr-0.6b-GGUF/resolve/main/qwen3-asr-0.6b-q4_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "qwen3-asr-0.6b-q8_0.gguf",
+                Size = "1.01 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/qwen3-asr-0.6b-GGUF/resolve/main/qwen3-asr-0.6b-q8_0.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "qwen3-asr-0.6b-f16.gguf",
+                Size = "1.88 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/qwen3-asr-0.6b-GGUF/resolve/main/qwen3-asr-0.6b-f16.gguf",
                 ],
             },
        };


### PR DESCRIPTION
Model-list refresh after auditing the CrispASR engines against the pinned v0.8.9 runtime, the [CrispASR releases](https://github.com/CrispStrobe/CrispASR/releases), and [huggingface.co/cstr](https://huggingface.co/cstr).

### Qwen3 engine
- **Removes `qwen3-asr-1.7b-q4_k.gguf` (was the default)** — on the pinned v0.8.9 runtime it silently produces empty transcripts. Verified empirically on macOS/Metal: the SHA-256-checked file loads and logs `transcribed 5.4s audio`, but emits no text (`detected 'none'`); the same class of sub-8-bit encoder-drift failure is described in the upstream 0.6b model card. `qwen3-asr-1.7b-q8_0.gguf` transcribes correctly with SE's exact invocation and becomes the first/default entry. Users who had q4_k selected fall back to the first list entry automatically.
- **Adds the new `qwen3-asr-0.6b` models** (q4_k 631 MB / q8_0 1.01 GB / f16 1.88 GB) — smaller and faster, same 30-language coverage, verified working against the v0.8.9 binary.

### Parakeet engine
- **Adds `parakeet-tdt-0.6b-ja-q8_0.gguf` (744 MB)** — upstream made it the recommended Japanese default in v0.8.8 (TDT output byte-identical to F16 at half the size).
- Refreshes the ja file sizes from the v0.8.8 GGUF re-export (all files now include the CTC head).

### Audit notes (no change needed)
- The v0.8.9 runtime pin is the latest release; all ~79 model URLs SE references still exist upstream.
- The omni engine's `--backend omniasr` + `omniasr-llm` model pairing was tested both ways — the runtime routes by GGUF metadata, identical output.
- The newest upstream repos (canary-qwen-2.5b, omnivoice, cohere-transcribe-arabic, kyutai-stt-2.6b-en) have no backend in the shipped v0.8.9 binary — revisit at the next runtime bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)