### PR TITLE
Add AI assistant to text box context menu

### DIFF
--- a/src/ui/Assets/Languages/Danish.json
+++ b/src/ui/Assets/Languages/Danish.json
@@ -1886,6 +1886,20 @@
       "largeChangeWarning": "Stor ændring - ligner en omskrivning, gennemgå omhyggeligt",
       "engineError": "AI-motoren kunne ikke nås: {0}"
     },
+    "aiAssistant": {
+      "title": "AI-assistent",
+      "currentLine": "Aktuel linje",
+      "contextLines": "Kontekst (linjer før og efter)",
+      "fixErrors": "Ret fejl",
+      "fitReadingSpeed": "Tilpas læsehastighed",
+      "makeFormal": "Mere formel",
+      "makeInformal": "Mere uformel",
+      "askPlaceholder": "Spørg om denne linje, eller bed om en ændring...",
+      "ask": "Spørg",
+      "result": "Forslag",
+      "apply": "Anvend på linje",
+      "hint": "AI-assistent for denne linje"
+    },
     "pickSubtitleFormatImageBasedNoPreview": "Billedbaseret undertekstformat.\nBitmaps genereres under konverteringen - ingen tekstforhåndsvisning."
   },
   "spellCheck": {

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1462,6 +1462,20 @@ public static partial class InitListViewAndEditBox
             flyoutTextBox.Items.Add(unicodeMenuItem);
         }
 
+        flyoutTextBox.Items.Add(new Separator());
+
+        var menuItemTextBoxAiAssistant = new MenuItem
+        {
+            Header = Se.Language.Tools.AiAssistant.Title,
+            Command = vm.ShowAiAssistantCommand,
+            Icon = new Icon
+            {
+                Value = IconNames.Robot,
+                VerticalAlignment = VerticalAlignment.Center,
+            },
+        };
+        flyoutTextBox.Items.Add(menuItemTextBoxAiAssistant);
+
 
         // translation mode (original text)
         var textLabelOriginal = new TextBlock


### PR DESCRIPTION
Adds an **AI assistant** item to the subtitle text box context menu in the main view.

### Changes
- `InitListViewAndEditBox.cs`: new context-menu item after the Unicode-symbols block, with the Robot icon (matching the edit-box toolbar button). Wired to the existing `ShowAiAssistantCommand` — no new command/logic; it reuses the full AI-assistant feature (current line ±3 context lines → dialog → apply back).
- `Danish.json`: added the missing `tools.aiAssistant` section (label **"AI-assistent"**). It was absent entirely, so the menu *and* the existing AI assistant dialog were showing English in the Danish UI.

### Notes
- The menu item is shown unconditionally, unlike the toolbar button which is gated on the `TextBoxShowButtonAiAssistant` setting. Easy to gate on the same setting if preferred.
- Builds clean; both language JSON files validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)