### PR TITLE
Fix ElevenLabs pauses: disable text normalization, map break tags per model

### DIFF
--- a/docs/features/text-to-speech.md
+++ b/docs/features/text-to-speech.md
@@ -78,6 +78,20 @@ OmniVoice TTS runs the omnivoice-tts CLI on CPU. It supports a large set of lang
 
 MistralSpeech is configured with an API key and model selection. The selected model is remembered in settings.
 
+## ElevenLabs Pauses and Pacing
+
+You can control pausing and pacing in ElevenLabs output directly from the subtitle text.
+
+- **Break tags** — Insert `<break time="1.5s" />` for an explicit pause (up to about 3 seconds). Keep them sparse: too many break tags in one line can make ElevenLabs speed up or add audio artifacts.
+- **Punctuation** — Ellipses (`...`) add a hesitant pause, and dashes (`---`) add a short break. These are less precise than break tags but useful for a natural feel.
+
+Subtitle Edit sends your text to ElevenLabs with **text normalization turned off**, so these pause cues are preserved instead of being collapsed or rewritten.
+
+Behavior depends on the selected model:
+
+- **Standard models** (`eleven_turbo_v2_5`, `eleven_multilingual_v2`, …) honor SSML `<break>` tags and punctuation pauses.
+- **Eleven v3** does not support SSML `<break>` tags. Subtitle Edit automatically converts each `<break time="Xs" />` into the nearest v3 audio pause tag — `[short pause]` (under 0.75 s), `[pause]` (up to 1.5 s), or `[long pause]` (longer) — so the same subtitle text keeps working when you switch to v3.
+
 ## Review Audio Clips
 
 When **Review audio clips** is enabled, a dedicated review window opens after generation. This window lets you inspect, play, and regenerate audio for every subtitle line before the result is used. A 120px waveform of the original video audio is shown above the grid as a reference. Per-session review state (clips, history, includes, edits) is persisted to `SubtitleEditTts.json` so you can return to the same review later.

--- a/src/ui/Logic/Download/TtsDownloadService.cs
+++ b/src/ui/Logic/Download/TtsDownloadService.cs
@@ -12,6 +12,7 @@ using System.Net.Http.Headers;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -306,7 +307,12 @@ public class TtsDownloadService : ITtsDownloadService
         var similarityBoost = Se.Settings.Video.TextToSpeech.ElevenLabsSimilarity.ToString(CultureInfo.InvariantCulture);
         var speed = Se.Settings.Video.TextToSpeech.ElevenLabsSpeed.ToString(CultureInfo.InvariantCulture);
         var styleExaggeration = Se.Settings.Video.TextToSpeech.ElevenLabsStyleeExaggeration.ToString(CultureInfo.InvariantCulture);
-        var data = "{ \"text\": \"" + Json.EncodeJsonText(text) + $"\", \"model_id\": \"{model}\"{language}, \"voice_settings\": {{ \"stability\": {stability}, \"similarity_boost\": {similarityBoost}, \"speed\": {speed}, \"style\": {styleExaggeration} }} }}";
+
+        // Disable ElevenLabs text normalization so the user's pause cues survive: SSML
+        // <break time="1.5s"/> tags and punctuation pauses (",,," "..." "---") are otherwise
+        // collapsed/rewritten by the "auto" normalizer on multilingual models. All standard
+        // (non-v3) models honor break tags; v3 is handled on the text-to-dialogue path (#12093).
+        var data = "{ \"text\": \"" + Json.EncodeJsonText(text) + $"\", \"model_id\": \"{model}\"{language}, \"voice_settings\": {{ \"stability\": {stability}, \"similarity_boost\": {similarityBoost}, \"speed\": {speed}, \"style\": {styleExaggeration} }}, \"apply_text_normalization\": \"off\" }}";
 
         return await SendElevenLabsSpeakRequestAsync(url, data, apiKey, acceptAudioMpeg: true, stream, "ElevenLabs TTS", cancellationToken);
     }
@@ -408,7 +414,12 @@ public class TtsDownloadService : ITtsDownloadService
         CancellationToken cancellationToken)
     {
         var url = "https://api.elevenlabs.io/v1/text-to-dialogue";
-        var text = Utilities.UnbreakLine(inputText);
+
+        // Eleven v3 does not support SSML <break> tags - it uses expressive audio tags instead.
+        // Translate any <break time="Xs"/> the user wrote into the nearest [short pause]/[pause]/
+        // [long pause] so their pacing still applies on v3. Punctuation pauses ("..." etc.) pass
+        // through unchanged and are honored by v3 directly (#12093).
+        var text = ConvertBreakTagsToV3AudioTags(Utilities.UnbreakLine(inputText));
 
         var stability = Se.Settings.Video.TextToSpeech.ElevenLabsStability.ToString(CultureInfo.InvariantCulture);
         var speed = Se.Settings.Video.TextToSpeech.ElevenLabsSpeed.ToString(CultureInfo.InvariantCulture);
@@ -425,6 +436,40 @@ public class TtsDownloadService : ITtsDownloadService
                    " }] }";
 
         return await SendElevenLabsSpeakRequestAsync(url, data, apiKey, acceptAudioMpeg: false, stream, "ElevenLabs TTS v3", cancellationToken);
+    }
+
+    // Matches SSML break tags like <break time="1.5s"/>, <break time="500ms" />, <break time='2s'>.
+    private static readonly Regex BreakTagRegex = new(
+        "<break\\s+time\\s*=\\s*[\"']?(?<value>\\d+(?:\\.\\d+)?)\\s*(?<unit>ms|s)[\"']?\\s*/?>",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Eleven v3 ignores SSML <break> tags, so translate each one into the closest v3 audio
+    /// pause tag ([short pause] &lt; 0.75 s, [pause] &lt;= 1.5 s, [long pause] otherwise). Text
+    /// without break tags is returned unchanged. (#12093)
+    /// </summary>
+    internal static string ConvertBreakTagsToV3AudioTags(string text)
+    {
+        if (string.IsNullOrEmpty(text) || text.IndexOf("<break", StringComparison.OrdinalIgnoreCase) < 0)
+        {
+            return text;
+        }
+
+        return BreakTagRegex.Replace(text, match =>
+        {
+            var seconds = double.Parse(match.Groups["value"].Value, CultureInfo.InvariantCulture);
+            if (string.Equals(match.Groups["unit"].Value, "ms", StringComparison.OrdinalIgnoreCase))
+            {
+                seconds /= 1000.0;
+            }
+
+            if (seconds < 0.75)
+            {
+                return "[short pause]";
+            }
+
+            return seconds <= 1.5 ? "[pause]" : "[long pause]";
+        });
     }
 
     public async Task<bool> DownloadAzureVoiceSpeak(


### PR DESCRIPTION
Fixes the ElevenLabs pause regression reported in #12093 (point 1): SSML `<break time="1.5s"/>` tags and punctuation pauses (`,,,`, `...`, `---`) worked in v4 but were ignored in v5.

### Root cause
Subtitle Edit already sends the subtitle text to ElevenLabs **unchanged** — `UnbreakLine` + `EncodeJsonText` preserve the markers and break tags. The regression is on the request/model side:

- The standard endpoint omitted `apply_text_normalization`, so ElevenLabs' default `auto` normalizer collapses/rewrites repeated punctuation and can drop break tags on multilingual models.
- v5 surfaces **Eleven v3**, which routes to the separate `text-to-dialogue` endpoint. Per ElevenLabs docs, **v3 does not support SSML `<break>` tags** — it uses expressive audio tags (`[pause]`) instead.

### Changes (`TtsDownloadService.cs`)
- **Standard endpoint** (`eleven_turbo_v2_5`, `eleven_multilingual_v2`, …): send `"apply_text_normalization": "off"`. All non-v3 models then honor `<break>` tags and punctuation pauses.
- **Eleven v3** (`text-to-dialogue`): translate each `<break time="Xs"/>` into the nearest v3 audio tag — `[short pause]` (< 0.75 s), `[pause]` (≤ 1.5 s), `[long pause]` (otherwise). Punctuation pauses pass through and are honored by v3 directly.
- Added `ConvertBreakTagsToV3AudioTags` (handles `s`/`ms`, quoted/unquoted, self-closing/`/`-less, case-insensitive).

### Verification
- Builds clean.
- Conversion logic checked across cases: `1.5s → [pause]`, `500ms → [short pause]`, `2s → [long pause]`, `3s → [long pause]`, `0.3s → [short pause]`, text without tags unchanged.

Refs: [ElevenLabs — break tags & model support](https://elevenlabs.io/docs/overview/capabilities/text-to-speech/best-practices), [text normalization](https://elevenlabs.io/docs/overview/models)

🤖 Generated with [Claude Code](https://claude.com/claude-code)