### PR TITLE
Fix Google TTS language code and ElevenLabs speaker boost

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/GoogleSpeech.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/GoogleSpeech.cs
@@ -78,7 +78,12 @@ public class GoogleSpeech : ITtsEngine
             {
                 continue;
             }
-            var languageCode = name.Substring(0, 5);
+            // Voice names are BCP-47 tagged, e.g. "en-US-Wavenet-A" or "cmn-CN-Chirp3-HD-Achernar".
+            // The language code is the first two hyphen-separated segments. A fixed 5-char cut
+            // breaks 3-letter primary subtags (cmn/yue/fil), yielding e.g. "cmn-C", which Google's
+            // SynthesizeSpeech rejects - so every Mandarin/Cantonese/Filipino voice failed.
+            var nameParts = name.Split('-');
+            var languageCode = nameParts.Length >= 2 ? nameParts[0] + "-" + nameParts[1] : name;
             var ssmlGender = parser.GetFirstObject(item, "ssmlGender");
             var naturalSampleRateHertz = parser.GetFirstObject(item, "naturalSampleRateHertz");
 

--- a/src/ui/Logic/Download/TtsDownloadService.cs
+++ b/src/ui/Logic/Download/TtsDownloadService.cs
@@ -308,11 +308,16 @@ public class TtsDownloadService : ITtsDownloadService
         var speed = Se.Settings.Video.TextToSpeech.ElevenLabsSpeed.ToString(CultureInfo.InvariantCulture);
         var styleExaggeration = Se.Settings.Video.TextToSpeech.ElevenLabsStyleeExaggeration.ToString(CultureInfo.InvariantCulture);
 
+        // ElevenLabs use_speaker_boost is a boolean; the UI exposes it as a 0-100 slider, so any
+        // non-zero value enables it. Previously this setting was collected and saved but never
+        // placed in the request body, so toggling it had no effect on the generated audio.
+        var useSpeakerBoost = Se.Settings.Video.TextToSpeech.ElevenLabsSpeakerBoost > 0 ? "true" : "false";
+
         // Disable ElevenLabs text normalization so the user's pause cues survive: SSML
         // <break time="1.5s"/> tags and punctuation pauses (",,," "..." "---") are otherwise
         // collapsed/rewritten by the "auto" normalizer on multilingual models. All standard
         // (non-v3) models honor break tags; v3 is handled on the text-to-dialogue path (#12093).
-        var data = "{ \"text\": \"" + Json.EncodeJsonText(text) + $"\", \"model_id\": \"{model}\"{language}, \"voice_settings\": {{ \"stability\": {stability}, \"similarity_boost\": {similarityBoost}, \"speed\": {speed}, \"style\": {styleExaggeration} }}, \"apply_text_normalization\": \"off\" }}";
+        var data = "{ \"text\": \"" + Json.EncodeJsonText(text) + $"\", \"model_id\": \"{model}\"{language}, \"voice_settings\": {{ \"stability\": {stability}, \"similarity_boost\": {similarityBoost}, \"speed\": {speed}, \"style\": {styleExaggeration}, \"use_speaker_boost\": {useSpeakerBoost} }}, \"apply_text_normalization\": \"off\" }}";
 
         return await SendElevenLabsSpeakRequestAsync(url, data, apiKey, acceptAudioMpeg: true, stream, "ElevenLabs TTS", cancellationToken);
     }


### PR DESCRIPTION
Two independent Text-to-Speech bugs found during a code audit.

### 1. Google TTS — language code truncated for 3-letter-subtag voices (HIGH)
`GoogleSpeech.cs` derived the voice language code with `name.Substring(0, 5)`, assuming an `xx-YY` prefix. BCP-47 primary subtags aren't fixed-width: the bundled `GoogleVoices.json` has 44 `cmn-CN` voices plus `cmn-TW`, `yue-HK`, `fil-PH`, and `"cmn-CN-Chirp3-HD-Achernar".Substring(0,5)` → `"cmn-C"`. That malformed code is passed as `VoiceSelectionParams.LanguageCode`, and Google's `SynthesizeSpeech` rejects it — so **every Mandarin/Cantonese/Filipino Google voice fails to generate audio**.

Fix: take the first two hyphen-separated segments (`cmn-CN`, `en-US`, …).

### 2. ElevenLabs — "Speaker Boost" never sent (MEDIUM)
The Speaker Boost value has a UI slider, a help button, and is persisted to `Se.Settings.Video.TextToSpeech.ElevenLabsSpeakerBoost`, but it was never written into any request body — so toggling it did nothing. Now sent as `use_speaker_boost` on the standard ElevenLabs endpoint (the slider is a 0–100 value; any non-zero enables it, matching the boolean the API expects).

Note: only the standard `text-to-speech` endpoint is touched; the v3 `text-to-dialogue` body is left as-is.

### Verification
- Builds clean.
- Google: verified the malformed codes against the 50+ affected voices in `GoogleVoices.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)