### PR TITLE
Fix malformed ASSA tags when splitting a line with 2+ active tags

### DIFF
--- a/src/ui/Logic/ISplitManager.cs
+++ b/src/ui/Logic/ISplitManager.cs
@@ -438,7 +438,12 @@ public class SplitManager : ISplitManager
             return text2;
         }
 
-        return "{" + string.Join("", tagsToAdd.Select(t => t.TrimStart('{'))) + text2;
+        // Each entry in tagsToAdd is already a complete "{...}" block, so concatenate them as-is.
+        // The previous version stripped each block's leading "{" but kept its trailing "}", then
+        // prepended a single "{" - which produced malformed markup for two or more tags, e.g.
+        // "{\i1}\c&HFF0000&}Hello": the "{\i1}" parsed but "\c&HFF0000&}" showed as literal text
+        // and the color was lost.
+        return string.Concat(tagsToAdd) + text2;
     }
 
     private static string? GetLastAssaTag(string text, string prefix)


### PR DESCRIPTION
### Bug
When a subtitle line is split, `PropagateAssaTags` (in `ISplitManager.cs`) carries the styling that is still active at the split point onto the second half. Each collected tag is a complete `{...}` block, but the final assembly did:

```csharp
return "{" + string.Join("", tagsToAdd.Select(t => t.TrimStart('{'))) + text2;
```

That strips only each block's leading `{` while keeping its trailing `}`, then prepends a single `{`. With **two or more** active tags the result is malformed:

- Input first half: `{\i1}{\c&HFF0000&}Hello` (italic + red active)
- `tagsToAdd = ["{\i1}", "{\c&HFF0000&}"]`
- Prepended to the second half: `{\i1}\c&HFF0000&}…`

ASSA parses `{\i1}`, then `\c&HFF0000&}` becomes **literal on-screen text** and the red color is lost. Same for bold+font, color+font, etc. A single active tag was unaffected.

### Fix
Each entry is already a valid `{...}` block, so just concatenate them:

```csharp
return string.Concat(tagsToAdd) + text2;
```

→ `{\i1}{\c&HFF0000&}…` (well-formed, styling preserved). Single-tag behavior is identical to before.

Builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)