### PR TITLE
Fix waveform border drag not registering on trackpad (#12177)

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -942,6 +942,12 @@ public class AudioVisualizer : Control
             return;
         }
 
+        // Refresh the hit-test from the actual press point. The cached hover state is set only on
+        // pointer-move, but on a trackpad a press often does not follow a same-pixel hover (tap-to-
+        // click, finger settling, throttled moves), so the cache can be stale and a border press
+        // would start a new selection instead of resizing the subtitle (#12177).
+        UpdateCursor(point);
+
         var p = _cachedHitParagraph;
         if (p == null)
         {


### PR DESCRIPTION
### Bug (part of #12177)
Dragging a subtitle's start/end border on the waveform "does not register properly" on a MacBook trackpad.

`AudioVisualizer.OnPointerPressed` decided resize-vs-new-selection from cached hover fields — `_cachedHitParagraph`, `_cachedIsNearLeftEdge`, `_cachedIsNearRightEdge` — which are written **only** in `UpdateCursor`, and `UpdateCursor` is called **only** from `OnPointerMoved`. On a trackpad the press coordinate frequently differs from the last hover coordinate (tap-to-click, finger settling, throttled move events, first click after focus), so the press used stale state:
- last hover over empty waveform → `_cachedHitParagraph == null` → press on a border starts a **new selection** instead of resizing;
- last hover not near an edge → the near-edge booleans are false → press exactly on the edge still won't resize.

A mouse rarely triggers it because hover and press land on the same pixel.

### Fix
Call `UpdateCursor(point)` at the start of `OnPointerPressed` so the hit-test and near-edge flags reflect the actual press point before they're used.

Builds clean.
🤖 Generated with [Claude Code](https://claude.com/claude-code)