### PR TITLE
Fix subtitle-format round-trip bugs (TTML, MicroDVD, JSON, SSA)

### DIFF
--- a/src/libse/SubtitleFormats/DfxpBasic.cs
+++ b/src/libse/SubtitleFormats/DfxpBasic.cs
@@ -121,6 +121,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         }
                         else if (line.Substring(i).StartsWith("<b>", StringComparison.OrdinalIgnoreCase))
                         {
+                            // Push like the <i> branch does, so the matching </b> restores this
+                            // parent instead of an outer one - otherwise an enclosing <i> (or <font>)
+                            // was lost for everything after a nested tag (e.g. <i>a<b>b</b>c</i>).
+                            styles.Push(currentStyle);
                             currentStyle = xml.CreateNode(XmlNodeType.Element, "span", null);
                             paragraph.AppendChild(currentStyle);
                             XmlAttribute attr = xml.CreateAttribute("tts:fontWeight", "http://www.w3.org/ns/10/ttml#style");
@@ -130,6 +134,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         }
                         else if (line.Substring(i).StartsWith("<font ", StringComparison.OrdinalIgnoreCase))
                         {
+                            // Push unconditionally so the matching </font> always restores the
+                            // right parent (the close-tag branch pops for every </font>); without
+                            // this an enclosing <i>/<b> was lost after a nested <font>.
+                            styles.Push(currentStyle);
                             int endIndex = line.Substring(i + 1).IndexOf('>');
                             if (endIndex > 0)
                             {

--- a/src/libse/SubtitleFormats/Json.cs
+++ b/src/libse/SubtitleFormats/Json.cs
@@ -85,7 +85,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             text = string.Join(Environment.NewLine, text.SplitToLines());
             var keepNext = false;
-            var hexLetters = "01234567890abcdef";
+            var hexLetters = "0123456789abcdefABCDEF"; // JSON \uXXXX escapes allow upper- or lower-case hex
             var i = 0;
             while (i < text.Length)
             {

--- a/src/libse/SubtitleFormats/MicroDvd.cs
+++ b/src/libse/SubtitleFormats/MicroDvd.cs
@@ -453,7 +453,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                                     {
                                         s = s.Remove(0, 7);
                                         singlePost = "</i></u>" + singlePost;
-                                        pre.Append("<><i>");
+                                        pre.Append("<u><i>");
                                     }
                                     else if (s.StartsWith("{Y:b,u}", StringComparison.Ordinal) || s.StartsWith("{Y:u,b}", StringComparison.Ordinal))
                                     {

--- a/src/libse/SubtitleFormats/SubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/SubStationAlpha.cs
@@ -657,12 +657,33 @@ Format: Marked, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 
         private static TimeCode GetTimeCodeFromString(string time)
         {
-            // h:mm:ss.cc
+            // h:mm:ss.cc - the fractional field is centiseconds in standard SSA, but be lenient
+            // about the digit count instead of assuming exactly 2 (a fixed *10 turned e.g.
+            // ".234" into +2.34 s and ".5" into +0.05 s, and threw on a missing fraction).
             var timeCode = time.Split(':', '.');
+            var lastPart = timeCode.Length > 3 ? timeCode[3].Trim() : string.Empty;
+            int ms;
+            if (lastPart.Length == 0)
+            {
+                ms = 0;
+            }
+            else if (lastPart.Length == 1)
+            {
+                ms = int.Parse(lastPart) * 100;
+            }
+            else if (lastPart.Length == 2)
+            {
+                ms = int.Parse(lastPart) * 10;
+            }
+            else
+            {
+                ms = int.Parse(lastPart.Substring(0, 3)); // 3+ digits: treat as milliseconds
+            }
+
             return new TimeCode(int.Parse(timeCode[0]),
                                 int.Parse(timeCode[1]),
                                 int.Parse(timeCode[2]),
-                                int.Parse(timeCode[3]) * 10);
+                                ms);
         }
 
         public override void RemoveNativeFormatting(Subtitle subtitle, SubtitleFormat newFormat)


### PR DESCRIPTION
Four independent format parsing/writing defects found in a code audit.

### 1. TTML/DFXP — enclosing style lost after a nested tag (`DfxpBasic.cs`)
In `ToText`, the `<i>` branch pushed the current style node onto the stack, but `<b>` and `<font>` did not — while the close-tag branch pops for `</i>`, `</b>` **and** `</font>`. So the stack was unbalanced and a close restored the wrong parent: `<i>a<b>b</b>c</i>` was written with italic lost on `c` (everything after the nested tag). Now every open pushes, matching every close, so styling resumes correctly after a nested tag closes. Inherited by all `TimedText10`-based formats.

*(Note: the overlap region itself — text inside the nested tag — still can't carry both styles because this writer emits flat sibling spans; that's a separate, pre-existing limitation. This fix restores the far more common "text after the nested tag" case.)*

### 2. MicroDVD — malformed `<>` tag (`MicroDvd.cs`)
The `{y:u,i}` (underline+italic) code appended `"<><i>"` instead of `"<u><i>"`, so `{y:u,i}Hello` loaded as `<><i>Hello</i></u>` — a bogus empty tag plus an unbalanced `</u>`. Fixed to `"<u><i>"`.

### 3. JSON — uppercase `\uXXXX` not decoded (`Json.cs`)
The escape decoder's hex set was lowercase-only, so a valid uppercase escape (`cafÉ` → "cafÉ") loaded as literal `cafu00C9`. Added `A`–`F`.

### 4. Classic SSA — fractional seconds assumed 2 digits (`SubStationAlpha.cs`)
`GetTimeCodeFromString` did `int.Parse(frac) * 10`, assuming centiseconds: `0:00:01.234` → +2.34 s, `0:00:01.5` → +0.05 s, and it threw on a missing fraction. Now handles 0/1/2/3+ fractional digits, matching the ASS reader.

Builds clean.
🤖 Generated with [Claude Code](https://claude.com/claude-code)