### PR TITLE
Fix OCR line-splitter: constant-true loop guard and dead threshold param

### DIFF
--- a/src/libuilogic/Ocr/NikseBitmapImageSplitter2.cs
+++ b/src/libuilogic/Ocr/NikseBitmapImageSplitter2.cs
@@ -568,7 +568,7 @@ public class NikseBitmapImageSplitter2
                     keysInSequence++;
                 }
 
-                if (keysInSequence > 2 && lastTransparentY - startY > minLineHeight)
+                if (keysInSequence >= minTransparentLines && lastTransparentY - startY > minLineHeight)
                 {
                     var part = bmp.CopyRectangle(new NikseRectangle(0, startY, bmp.Width, lastTransparentY - startY - 1));
                     if (!part.IsImageOnlyTransparent() && part.GetNonTransparentHeight() + keysInSequence * 0.4 >= minLineHeight)
@@ -835,7 +835,7 @@ public class NikseBitmapImageSplitter2
             }
         }
 
-        for (var myX = x; x < x + right && myX < bmp.Width; myX++)
+        for (var myX = x; myX < x + right && myX < bmp.Width; myX++)
         {
             var a = bmp.GetAlpha(myX, y - up);
             if (a > 150)


### PR DESCRIPTION
Two defects in the OCR image line-splitter (`NikseBitmapImageSplitter2.cs`), which separates stacked/touching subtitle text lines before recognition.

### 1. Constant-true loop guard disables the clearance check
`CanGoUpAndRight`'s horizontal-clearance loop was:
```csharp
for (var myX = x; x < x + right && myX < bmp.Width; myX++)
```
`x` is a fixed parameter, so `x < x + right` is `0 < 12` — always true. The loop therefore scanned all the way to `bmp.Width` instead of the intended `right` (12px) window, almost always hit an ink pixel somewhere to the right, and returned `false`. The "go up-and-right" back-jump that separates two vertically touching lines then never fired. Fixed to `myX < x + right`.

### 2. `minTransparentLines` parameter was dead
`SplitToLinesByMinTransparentHorizontalLines(..., int minTransparentLines)` never used the parameter — the run length was hardcoded as `keysInSequence > 2`. The caller computes a 3-blank-line and a 4-blank-line split and only trusts the result when they **agree**:
```csharp
var split3 = SplitToLinesByMinTransparentHorizontalLines(bmp, minLineHeight, 3);
var split4 = SplitToLinesByMinTransparentHorizontalLines(bmp, minLineHeight, 4);
var split = split3.Count == split4.Count ? split4 : split3;
```
Since the parameter was ignored, both calls returned identical lists, so the agreement check was always true and the intended stability heuristic never happened. Now uses `keysInSequence >= minTransparentLines` (the `=3` call is unchanged; the `=4` call now actually requires 4).

Builds clean.
🤖 Generated with [Claude Code](https://claude.com/claude-code)