### PR TITLE
Add PGS position monitor to the binary/image-based edit window

### DIFF
--- a/src/ui/Assets/Languages/Danish.json
+++ b/src/ui/Assets/Languages/Danish.json
@@ -1838,7 +1838,19 @@
       "bottomAlignLines": "Justér til bund",
       "appendSubtitleDotDotDot": "Tilføj undertekst...",
       "shiftTimeCodes": "Forskyd tidskoder med",
-      "sortByStartTime": "Sortér efter starttid"
+      "sortByStartTime": "Sortér efter starttid",
+      "videoPreview": "Video",
+      "positionMap": "Positionskort",
+      "letterbox": "Letterbox",
+      "letterboxOff": "Fra (ingen letterbox)",
+      "letterboxCustom": "Brugerdefineret bjælkehøjde",
+      "barHeightPx": "Bjælkehøjde (px)",
+      "titleSafePercent": "Titelsikkert område (%)",
+      "positionSummary": "{0}×{1} - {2} undertekster - bjælkehøjde: {3} px",
+      "xInActivePicture": "{0} i billedet",
+      "xInTopBar": "{0} i øverste bjælke",
+      "xInBottomBar": "{0} i nederste bjælke",
+      "noImageSubtitlesLoaded": "Ingen billedbaserede undertekster indlæst"
     },
     "removeTextForHearingImpaired": {
       "title": "Fjern tekst for hørehæmmede",

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1869,7 +1869,19 @@
       "bottomAlignLines": "Bottom align",
       "appendSubtitleDotDotDot": "Append subtitle...",
       "shiftTimeCodes": "Shift time codes by",
-      "sortByStartTime": "Sort by start time"
+      "sortByStartTime": "Sort by start time",
+      "videoPreview": "Video",
+      "positionMap": "Position map",
+      "letterbox": "Letterbox",
+      "letterboxOff": "Off (no letterbox)",
+      "letterboxCustom": "Custom bar height",
+      "barHeightPx": "Bar height (px)",
+      "titleSafePercent": "Title-safe (%)",
+      "positionSummary": "{0}×{1} - {2} subtitles - bar height: {3} px",
+      "xInActivePicture": "{0} in picture",
+      "xInTopBar": "{0} in top bar",
+      "xInBottomBar": "{0} in bottom bar",
+      "noImageSubtitlesLoaded": "No image subtitles loaded"
     },
     "removeTextForHearingImpaired": {
       "title": "Remove text for hearing impaired",

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -228,6 +228,7 @@ public partial class BinaryEditViewModel : ObservableObject
     }
 
     private bool _updatingPositionMonitor;
+    private int _currentLetterboxBarHeight;
 
     partial void OnIsPositionMonitorActiveChanged(bool value)
     {
@@ -284,6 +285,31 @@ public partial class BinaryEditViewModel : ObservableObject
     }
 
     /// <summary>
+    /// Cycles to the next subtitle in the given zone, starting after the current
+    /// selection - lets the summary chips act as "go to next offender" buttons.
+    /// </summary>
+    public void SelectNextInZone(PositionMonitorZone zone)
+    {
+        if (Subtitles.Count == 0)
+        {
+            return;
+        }
+
+        var startIndex = SelectedSubtitle != null ? Subtitles.IndexOf(SelectedSubtitle) : -1;
+        for (var offset = 1; offset <= Subtitles.Count; offset++)
+        {
+            var index = (startIndex + offset) % Subtitles.Count;
+            var item = Subtitles[index];
+            var h = item.Bitmap?.PixelSize.Height ?? 0;
+            if (PositionMonitorLogic.Classify(item.Y, h, ScreenHeight, _currentLetterboxBarHeight) == zone)
+            {
+                SelectAndScrollToRow(index);
+                return;
+            }
+        }
+    }
+
+    /// <summary>
     /// Recomputes the letterbox bar height and per-zone counts, updates the summary
     /// header, and repaints the position map (discussion #12318).
     /// </summary>
@@ -313,6 +339,8 @@ public partial class BinaryEditViewModel : ObservableObject
                 LetterboxBarHeight = barHeight; // display the computed value in the (read-only) up/down
             }
 
+            _currentLetterboxBarHeight = barHeight;
+
             var active = 0;
             var top = 0;
             var bottom = 0;
@@ -323,12 +351,15 @@ public partial class BinaryEditViewModel : ObservableObject
                 {
                     case PositionMonitorZone.TopBar:
                         top++;
+                        item.ZoneBrush = PositionMonitorControl.ZoneRedBrush;
                         break;
                     case PositionMonitorZone.BottomBar:
                         bottom++;
+                        item.ZoneBrush = PositionMonitorControl.ZoneAmberBrush;
                         break;
                     default:
                         active++;
+                        item.ZoneBrush = PositionMonitorControl.ZoneGreenBrush;
                         break;
                 }
             }
@@ -2585,6 +2616,12 @@ public partial class BinaryEditViewModel : ObservableObject
 
     private void OnSubtitleItemPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
+        // Display-only zone indicator - must not mark the subtitle as modified.
+        if (e.PropertyName == nameof(BinarySubtitleItem.ZoneBrush))
+        {
+            return;
+        }
+
         _isDirty = true;
 
         // Keep the position map in sync when a subtitle is moved or its image changes.

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -51,6 +51,19 @@ public partial class BinaryEditViewModel : ObservableObject
     [ObservableProperty] private bool _isInsertBeforeVisible;
     [ObservableProperty] private bool _isInsertAfterVisible;
     [ObservableProperty] private bool _isToggleForcedVisible;
+    [ObservableProperty] private bool _isPositionMonitorActive;
+    [ObservableProperty] private ObservableCollection<LetterboxRatioItem> _letterboxRatios;
+    [ObservableProperty] private LetterboxRatioItem _selectedLetterboxRatio;
+    [ObservableProperty] private int _letterboxBarHeight;
+    [ObservableProperty] private bool _isLetterboxBarHeightEditable;
+    [ObservableProperty] private bool _showTitleSafeArea;
+    [ObservableProperty] private double _titleSafePercent;
+    [ObservableProperty] private string _positionMonitorSummary;
+    [ObservableProperty] private string _activePictureCountText;
+    [ObservableProperty] private string _topBarCountText;
+    [ObservableProperty] private string _bottomBarCountText;
+    [ObservableProperty] private bool _hasTopBarSubtitles;
+    [ObservableProperty] private bool _hasBottomBarSubtitles;
 
     public IOcrSubtitle? OcrSubtitle { get; set; }
 
@@ -60,6 +73,7 @@ public partial class BinaryEditViewModel : ObservableObject
     public VideoPlayerControl? VideoPlayerControl { get; set; }
     public Image? SubtitleOverlayImage { get; set; }
     public Border? VideoContentBorder { get; set; }
+    public PositionMonitorControl? PositionMonitor { get; set; }
     public bool OkPressed { get; private set; }
     public ObservableCollection<BinarySubtitleItem> Subtitles { get; set; }
 
@@ -91,6 +105,30 @@ public partial class BinaryEditViewModel : ObservableObject
         StatusText = string.Empty;
         CurrentPosition = string.Empty;
         CurrentSize = string.Empty;
+
+        var lang = Se.Language.Tools.ImageBasedEdit;
+        _letterboxRatios = new ObservableCollection<LetterboxRatioItem>
+        {
+            new(lang.LetterboxOff, null, false, "off"),
+            new("1.66:1", 1.66, false, "1.66"),
+            new("1.85:1", 1.85, false, "1.85"),
+            new("2.00:1", 2.00, false, "2.00"),
+            new("2.20:1", 2.20, false, "2.20"),
+            new("2.35:1", 2.35, false, "2.35"),
+            new("2.39:1", 2.39, false, "2.39"),
+            new("2.40:1", 2.40, false, "2.40"),
+            new(lang.LetterboxCustom, null, true, "custom"),
+        };
+        _selectedLetterboxRatio = _letterboxRatios.FirstOrDefault(p => p.SettingsKey == Se.Settings.Tools.BinEditPositionMonitorRatio) ?? _letterboxRatios[0];
+        _letterboxBarHeight = Se.Settings.Tools.BinEditPositionMonitorBarHeight;
+        _isLetterboxBarHeightEditable = _selectedLetterboxRatio.IsCustom;
+        _showTitleSafeArea = Se.Settings.Tools.BinEditPositionMonitorTitleSafeOn;
+        _titleSafePercent = Se.Settings.Tools.BinEditPositionMonitorTitleSafePercent;
+        _isPositionMonitorActive = Se.Settings.Tools.BinEditPositionMonitorActive;
+        _positionMonitorSummary = string.Empty;
+        _activePictureCountText = string.Empty;
+        _topBarCountText = string.Empty;
+        _bottomBarCountText = string.Empty;
     }
 
     public void Initialize(string fileName, IOcrSubtitle? subtitle)
@@ -112,6 +150,8 @@ public partial class BinaryEditViewModel : ObservableObject
             }
             Renumber();
         }
+
+        RefreshPositionMonitor();
     }
 
     public void Initialize(IList<OcrSubtitleItem> ocrSubtitleItems, string sourceFileName = "")
@@ -136,6 +176,7 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         Renumber();
+        RefreshPositionMonitor();
     }
 
     public void RegisterVideoShortcuts()
@@ -156,6 +197,13 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         UpdateOverlayPosition();
+
+        var monitor = PositionMonitor;
+        if (monitor != null)
+        {
+            monitor.SelectedItem = value;
+            monitor.InvalidateVisual();
+        }
     }
 
     private bool IsVideoPlaying()
@@ -177,6 +225,139 @@ public partial class BinaryEditViewModel : ObservableObject
     partial void OnSelectCurrentSubtitleWhilePlayingChanged(bool value)
     {
         Se.Settings.Tools.BinEditSelectCurrentSubtitleWhilePlaying = value;
+    }
+
+    private bool _updatingPositionMonitor;
+
+    partial void OnIsPositionMonitorActiveChanged(bool value)
+    {
+        Se.Settings.Tools.BinEditPositionMonitorActive = value;
+        RefreshPositionMonitor();
+    }
+
+    partial void OnSelectedLetterboxRatioChanged(LetterboxRatioItem value)
+    {
+        if (value == null)
+        {
+            return;
+        }
+
+        IsLetterboxBarHeightEditable = value.IsCustom;
+        Se.Settings.Tools.BinEditPositionMonitorRatio = value.SettingsKey;
+        RefreshPositionMonitor();
+    }
+
+    partial void OnLetterboxBarHeightChanged(int value)
+    {
+        if (_updatingPositionMonitor)
+        {
+            return;
+        }
+
+        if (SelectedLetterboxRatio is { IsCustom: true })
+        {
+            Se.Settings.Tools.BinEditPositionMonitorBarHeight = value;
+        }
+
+        RefreshPositionMonitor();
+    }
+
+    partial void OnShowTitleSafeAreaChanged(bool value)
+    {
+        Se.Settings.Tools.BinEditPositionMonitorTitleSafeOn = value;
+        RefreshPositionMonitor();
+    }
+
+    partial void OnTitleSafePercentChanged(double value)
+    {
+        Se.Settings.Tools.BinEditPositionMonitorTitleSafePercent = value;
+        RefreshPositionMonitor();
+    }
+
+    public void SelectSubtitleFromPositionMonitor(BinarySubtitleItem item)
+    {
+        var index = Subtitles.IndexOf(item);
+        if (index >= 0)
+        {
+            SelectAndScrollToRow(index);
+        }
+    }
+
+    /// <summary>
+    /// Recomputes the letterbox bar height and per-zone counts, updates the summary
+    /// header, and repaints the position map (discussion #12318).
+    /// </summary>
+    public void RefreshPositionMonitor()
+    {
+        if (_updatingPositionMonitor)
+        {
+            return;
+        }
+
+        _updatingPositionMonitor = true;
+        try
+        {
+            var ratio = SelectedLetterboxRatio;
+            int barHeight;
+            if (ratio == null || (!ratio.IsCustom && ratio.Ratio == null))
+            {
+                barHeight = 0; // letterbox off
+            }
+            else if (ratio.IsCustom)
+            {
+                barHeight = Math.Max(0, LetterboxBarHeight);
+            }
+            else
+            {
+                barHeight = PositionMonitorLogic.CalculateBarHeight(ScreenWidth, ScreenHeight, ratio.Ratio!.Value);
+                LetterboxBarHeight = barHeight; // display the computed value in the (read-only) up/down
+            }
+
+            var active = 0;
+            var top = 0;
+            var bottom = 0;
+            foreach (var item in Subtitles)
+            {
+                var h = item.Bitmap?.PixelSize.Height ?? 0;
+                switch (PositionMonitorLogic.Classify(item.Y, h, ScreenHeight, barHeight))
+                {
+                    case PositionMonitorZone.TopBar:
+                        top++;
+                        break;
+                    case PositionMonitorZone.BottomBar:
+                        bottom++;
+                        break;
+                    default:
+                        active++;
+                        break;
+                }
+            }
+
+            var lang = Se.Language.Tools.ImageBasedEdit;
+            PositionMonitorSummary = string.Format(lang.PositionSummary, ScreenWidth, ScreenHeight, Subtitles.Count, barHeight);
+            ActivePictureCountText = string.Format(lang.XInActivePicture, active);
+            TopBarCountText = string.Format(lang.XInTopBar, top);
+            BottomBarCountText = string.Format(lang.XInBottomBar, bottom);
+            HasTopBarSubtitles = top > 0;
+            HasBottomBarSubtitles = bottom > 0;
+
+            var monitor = PositionMonitor;
+            if (monitor != null)
+            {
+                monitor.Items = Subtitles;
+                monitor.SelectedItem = SelectedSubtitle;
+                monitor.ScreenWidth = ScreenWidth;
+                monitor.ScreenHeight = ScreenHeight;
+                monitor.BarHeight = barHeight;
+                monitor.ShowTitleSafe = ShowTitleSafeArea;
+                monitor.TitleSafePercent = TitleSafePercent;
+                monitor.InvalidateVisual();
+            }
+        }
+        finally
+        {
+            _updatingPositionMonitor = false;
+        }
     }
 
     internal void SubtitleGridSelectionChanged(object? sender, SelectionChangedEventArgs e)
@@ -226,6 +407,7 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         UpdateOverlayPosition();
+        RefreshPositionMonitor();
     }
 
     partial void OnScreenHeightChanged(int value)
@@ -241,6 +423,7 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         UpdateOverlayPosition();
+        RefreshPositionMonitor();
     }
 
     public void UpdateOverlayPosition()
@@ -538,6 +721,8 @@ public partial class BinaryEditViewModel : ObservableObject
             RefreshStatusText();
             Window.Title = string.Format(Se.Language.Tools.ImageBasedEdit.EditImagedBaseSubtitleX, fileName);
         }
+
+        RefreshPositionMonitor();
 
         var videoFileName = TryGetVideoFileName(fileName);
         if (ShouldAutoOpenMatchingVideo(Se.Settings.Video.AutoOpen, videoFileName) && VideoPlayerControl != null)
@@ -2395,11 +2580,18 @@ public partial class BinaryEditViewModel : ObservableObject
             foreach (BinarySubtitleItem item in e.NewItems)
                 item.PropertyChanged += OnSubtitleItemPropertyChanged;
         _isDirty = true;
+        RefreshPositionMonitor();
     }
 
     private void OnSubtitleItemPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         _isDirty = true;
+
+        // Keep the position map in sync when a subtitle is moved or its image changes.
+        if (e.PropertyName is nameof(BinarySubtitleItem.X) or nameof(BinarySubtitleItem.Y) or nameof(BinarySubtitleItem.Bitmap))
+        {
+            RefreshPositionMonitor();
+        }
     }
 
     internal void OnVideoPositionChanged(double positionSeconds)

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -641,6 +641,26 @@ public class BinaryEditWindow : Window
         dataGridBorder.Margin = new Thickness(0, 0, 0, 5);
 
         // Columns: Forced, Number, Show, Duration, Text, Image
+        // Position-monitor zone dot (green = active picture, amber = bottom bar,
+        // red = top bar) so problem lines are visible directly in the grid.
+        dataGrid.Columns.Add(new DataGridTemplateColumn
+        {
+            Header = string.Empty,
+            Width = new DataGridLength(30),
+            MinWidth = 26,
+            IsReadOnly = true,
+            CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+            CellTemplate = new Avalonia.Controls.Templates.FuncDataTemplate<BinarySubtitleItem>((_, _) =>
+                new Ellipse
+                {
+                    Width = 9,
+                    Height = 9,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    [!Shape.FillProperty] = new Binding(nameof(BinarySubtitleItem.ZoneBrush)),
+                }),
+        });
+
         dataGrid.Columns.Add(new DataGridTemplateColumn
         {
             Header = Se.Language.General.Forced,
@@ -1006,38 +1026,43 @@ public class BinaryEditWindow : Window
             RowDefinitions =
             {
                 new RowDefinition(GridLength.Auto), // summary
+                new RowDefinition(GridLength.Auto), // zone chips
                 new RowDefinition(GridLength.Auto), // letterbox / title-safe controls
                 new RowDefinition(GridLength.Star), // position map canvas
             },
             Margin = new Thickness(8, 0, 8, 8),
         };
 
-        // Summary header: "1920×1080 - 623 subtitles - bar height: 138 px" + zone chips
+        // Summary header: "1920×1080 - 623 subtitles - bar height: 138 px"
         var summaryText = new TextBlock
         {
             VerticalAlignment = VerticalAlignment.Center,
             FontWeight = FontWeight.Bold,
+            Margin = new Thickness(0, 2, 0, 4),
             [!TextBlock.TextProperty] = new Binding(nameof(vm.PositionMonitorSummary)) { Source = vm },
         };
+        grid.Add(summaryText, 0);
 
-        var summaryPanel = new WrapPanel
+        // Zone chips on their own single line; clicking a chip jumps to the next
+        // subtitle in that zone.
+        var chipsPanel = new StackPanel
         {
             Orientation = Orientation.Horizontal,
-            Margin = new Thickness(0, 2, 0, 6),
+            Margin = new Thickness(0, 0, 0, 6),
         };
-        summaryPanel.Children.Add(summaryText);
-        summaryPanel.Children.Add(MakeZoneChip(vm, Color.FromRgb(0x22, 0xC5, 0x5E), nameof(vm.ActivePictureCountText), null));
-        summaryPanel.Children.Add(MakeZoneChip(vm, Color.FromRgb(0xF5, 0x9E, 0x0B), nameof(vm.BottomBarCountText), nameof(vm.HasBottomBarSubtitles)));
-        summaryPanel.Children.Add(MakeZoneChip(vm, Color.FromRgb(0xEF, 0x44, 0x44), nameof(vm.TopBarCountText), nameof(vm.HasTopBarSubtitles)));
-        grid.Add(summaryPanel, 0);
+        chipsPanel.Children.Add(MakeZoneChip(vm, Color.FromRgb(0x22, 0xC5, 0x5E), nameof(vm.ActivePictureCountText), null, PositionMonitorZone.ActivePicture, isFirst: true));
+        chipsPanel.Children.Add(MakeZoneChip(vm, Color.FromRgb(0xF5, 0x9E, 0x0B), nameof(vm.BottomBarCountText), nameof(vm.HasBottomBarSubtitles), PositionMonitorZone.BottomBar));
+        chipsPanel.Children.Add(MakeZoneChip(vm, Color.FromRgb(0xEF, 0x44, 0x44), nameof(vm.TopBarCountText), nameof(vm.HasTopBarSubtitles), PositionMonitorZone.TopBar));
+        grid.Add(chipsPanel, 1);
 
-        // Controls row: letterbox aspect ratio, bar height, title-safe margin
+        // Controls row: letterbox aspect ratio + bar height, and the title-safe
+        // margin. Grouped so label + control never wrap apart.
         var ratioCombo = UiUtil.MakeComboBox(vm.LetterboxRatios, vm, nameof(vm.SelectedLetterboxRatio));
         ratioCombo.MinWidth = 170;
 
         var barHeightUpDown = new NumericUpDown
         {
-            Width = 120,
+            Width = 130,
             Minimum = 0,
             Maximum = 2000,
             Increment = 1,
@@ -1058,40 +1083,55 @@ public class BinaryEditWindow : Window
 
         var titleSafeUpDown = new NumericUpDown
         {
-            Width = 110,
+            Width = 130,
             Minimum = 0,
             Maximum = 20,
             Increment = 0.5m,
             FormatString = "F1",
             VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(6, 0, 0, 0),
             DataContext = vm,
             [!NumericUpDown.ValueProperty] = new Binding(nameof(vm.TitleSafePercent)) { Mode = BindingMode.TwoWay },
             [!InputElement.IsEnabledProperty] = new Binding(nameof(vm.ShowTitleSafeArea)),
         };
 
+        var letterboxGroup = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Margin = new Thickness(0, 0, 18, 4),
+            Children =
+            {
+                new TextBlock
+                {
+                    Text = lang.Letterbox,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Margin = new Thickness(0, 0, 6, 0),
+                },
+                ratioCombo,
+                new TextBlock
+                {
+                    Text = lang.BarHeightPx,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Margin = new Thickness(12, 0, 6, 0),
+                },
+                barHeightUpDown,
+            },
+        };
+
+        var titleSafeGroup = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Margin = new Thickness(0, 0, 0, 4),
+            Children = { titleSafeCheckBox, titleSafeUpDown },
+        };
+
         var controlsPanel = new WrapPanel
         {
             Orientation = Orientation.Horizontal,
-            Margin = new Thickness(0, 0, 0, 6),
+            Margin = new Thickness(0, 0, 0, 4),
+            Children = { letterboxGroup, titleSafeGroup },
         };
-        controlsPanel.Children.Add(new TextBlock
-        {
-            Text = lang.Letterbox,
-            VerticalAlignment = VerticalAlignment.Center,
-            Margin = new Thickness(0, 0, 6, 0),
-        });
-        controlsPanel.Children.Add(ratioCombo);
-        controlsPanel.Children.Add(new TextBlock
-        {
-            Text = lang.BarHeightPx,
-            VerticalAlignment = VerticalAlignment.Center,
-            Margin = new Thickness(12, 0, 6, 0),
-        });
-        controlsPanel.Children.Add(barHeightUpDown);
-        controlsPanel.Children.Add(new Border { Width = 18 }); // spacer
-        controlsPanel.Children.Add(titleSafeCheckBox);
-        controlsPanel.Children.Add(titleSafeUpDown);
-        grid.Add(controlsPanel, 1);
+        grid.Add(controlsPanel, 2);
 
         // The position map canvas
         var monitor = new PositionMonitorControl();
@@ -1106,12 +1146,12 @@ public class BinaryEditWindow : Window
             CornerRadius = new CornerRadius(4),
             ClipToBounds = true,
         };
-        grid.Add(monitorBorder, 2);
+        grid.Add(monitorBorder, 3);
 
         return grid;
     }
 
-    private static Border MakeZoneChip(BinaryEditViewModel vm, Color color, string textPropertyName, string? highlightPropertyName)
+    private static Border MakeZoneChip(BinaryEditViewModel vm, Color color, string textPropertyName, string? highlightPropertyName, PositionMonitorZone zone, bool isFirst = false)
     {
         var bullet = new Ellipse
         {
@@ -1132,15 +1172,19 @@ public class BinaryEditWindow : Window
         {
             CornerRadius = new CornerRadius(10),
             Padding = new Thickness(9, 2, 9, 2),
-            Margin = new Thickness(10, 0, 0, 0),
+            Margin = new Thickness(isFirst ? 0 : 10, 0, 0, 0),
             VerticalAlignment = VerticalAlignment.Center,
             Background = new SolidColorBrush(color, 0.12),
+            Cursor = new Cursor(StandardCursorType.Hand),
             Child = new StackPanel
             {
                 Orientation = Orientation.Horizontal,
                 Children = { bullet, text },
             },
         };
+
+        // Chip doubles as a "go to next subtitle in this zone" button.
+        chip.PointerPressed += (_, _) => vm.SelectNextInZone(zone);
 
         if (highlightPropertyName != null)
         {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Shapes;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Layout;
@@ -76,10 +77,33 @@ public class BinaryEditWindow : Window
         };
         contentGrid.Add(splitter, 0, 1);
 
-        // Right section - video player
+        // Right section - video player / position map, switched by a segmented toggle.
+        // Both panels stay in the visual tree (IsVisible-switched) so the mpv video
+        // surface is never detached.
+        var videoPanel = MakeVideoPlayer(vm);
+        videoPanel.Bind(Visual.IsVisibleProperty, new Binding("!" + nameof(vm.IsPositionMonitorActive)) { Source = vm });
+
+        var monitorPanel = MakePositionMonitorPanel(vm);
+        monitorPanel.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsPositionMonitorActive)) { Source = vm });
+
+        var panelHost = new Panel();
+        panelHost.Children.Add(videoPanel);
+        panelHost.Children.Add(monitorPanel);
+
+        var rightGrid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition(GridLength.Auto),
+                new RowDefinition(GridLength.Star),
+            },
+        };
+        rightGrid.Add(MakeRightPanelViewToggle(vm), 0);
+        rightGrid.Add(panelHost, 1);
+
         var rightContent = new Border
         {
-            Child = MakeVideoPlayer(vm),
+            Child = rightGrid,
             BorderBrush = UiUtil.GetBorderBrush(),
             BorderThickness = new Thickness(1),
             Margin = new Thickness(5),
@@ -934,5 +958,203 @@ public class BinaryEditWindow : Window
         };
 
         return videoGrid;
+    }
+
+    private static Control MakeRightPanelViewToggle(BinaryEditViewModel vm)
+    {
+        var buttonVideo = new ToggleButton
+        {
+            Content = Se.Language.Tools.ImageBasedEdit.VideoPreview,
+            Padding = new Thickness(14, 4),
+            CornerRadius = new CornerRadius(4, 0, 0, 4),
+        };
+        var buttonMap = new ToggleButton
+        {
+            Content = Se.Language.Tools.ImageBasedEdit.PositionMap,
+            Padding = new Thickness(14, 4),
+            CornerRadius = new CornerRadius(0, 4, 4, 0),
+        };
+
+        // Explicit sync instead of IsChecked bindings: a click always toggles the
+        // button locally, so clicking the already-active side would untick it with
+        // no view-model change to re-assert the state.
+        void Sync()
+        {
+            buttonVideo.IsChecked = !vm.IsPositionMonitorActive;
+            buttonMap.IsChecked = vm.IsPositionMonitorActive;
+        }
+
+        buttonVideo.Click += (_, _) => { vm.IsPositionMonitorActive = false; Sync(); };
+        buttonMap.Click += (_, _) => { vm.IsPositionMonitorActive = true; Sync(); };
+        Sync();
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            Margin = new Thickness(0, 6, 0, 4),
+            Children = { buttonVideo, buttonMap },
+        };
+    }
+
+    private static Grid MakePositionMonitorPanel(BinaryEditViewModel vm)
+    {
+        var lang = Se.Language.Tools.ImageBasedEdit;
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition(GridLength.Auto), // summary
+                new RowDefinition(GridLength.Auto), // letterbox / title-safe controls
+                new RowDefinition(GridLength.Star), // position map canvas
+            },
+            Margin = new Thickness(8, 0, 8, 8),
+        };
+
+        // Summary header: "1920×1080 - 623 subtitles - bar height: 138 px" + zone chips
+        var summaryText = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.Bold,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.PositionMonitorSummary)) { Source = vm },
+        };
+
+        var summaryPanel = new WrapPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Margin = new Thickness(0, 2, 0, 6),
+        };
+        summaryPanel.Children.Add(summaryText);
+        summaryPanel.Children.Add(MakeZoneChip(vm, Color.FromRgb(0x22, 0xC5, 0x5E), nameof(vm.ActivePictureCountText), null));
+        summaryPanel.Children.Add(MakeZoneChip(vm, Color.FromRgb(0xF5, 0x9E, 0x0B), nameof(vm.BottomBarCountText), nameof(vm.HasBottomBarSubtitles)));
+        summaryPanel.Children.Add(MakeZoneChip(vm, Color.FromRgb(0xEF, 0x44, 0x44), nameof(vm.TopBarCountText), nameof(vm.HasTopBarSubtitles)));
+        grid.Add(summaryPanel, 0);
+
+        // Controls row: letterbox aspect ratio, bar height, title-safe margin
+        var ratioCombo = UiUtil.MakeComboBox(vm.LetterboxRatios, vm, nameof(vm.SelectedLetterboxRatio));
+        ratioCombo.MinWidth = 170;
+
+        var barHeightUpDown = new NumericUpDown
+        {
+            Width = 120,
+            Minimum = 0,
+            Maximum = 2000,
+            Increment = 1,
+            FormatString = "F0",
+            VerticalAlignment = VerticalAlignment.Center,
+            DataContext = vm,
+            [!NumericUpDown.ValueProperty] = new Binding(nameof(vm.LetterboxBarHeight)) { Mode = BindingMode.TwoWay },
+            [!InputElement.IsEnabledProperty] = new Binding(nameof(vm.IsLetterboxBarHeightEditable)),
+        };
+
+        var titleSafeCheckBox = new CheckBox
+        {
+            Content = lang.TitleSafePercent,
+            VerticalAlignment = VerticalAlignment.Center,
+            DataContext = vm,
+            [!ToggleButton.IsCheckedProperty] = new Binding(nameof(vm.ShowTitleSafeArea)) { Mode = BindingMode.TwoWay },
+        };
+
+        var titleSafeUpDown = new NumericUpDown
+        {
+            Width = 110,
+            Minimum = 0,
+            Maximum = 20,
+            Increment = 0.5m,
+            FormatString = "F1",
+            VerticalAlignment = VerticalAlignment.Center,
+            DataContext = vm,
+            [!NumericUpDown.ValueProperty] = new Binding(nameof(vm.TitleSafePercent)) { Mode = BindingMode.TwoWay },
+            [!InputElement.IsEnabledProperty] = new Binding(nameof(vm.ShowTitleSafeArea)),
+        };
+
+        var controlsPanel = new WrapPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Margin = new Thickness(0, 0, 0, 6),
+        };
+        controlsPanel.Children.Add(new TextBlock
+        {
+            Text = lang.Letterbox,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 0, 6, 0),
+        });
+        controlsPanel.Children.Add(ratioCombo);
+        controlsPanel.Children.Add(new TextBlock
+        {
+            Text = lang.BarHeightPx,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(12, 0, 6, 0),
+        });
+        controlsPanel.Children.Add(barHeightUpDown);
+        controlsPanel.Children.Add(new Border { Width = 18 }); // spacer
+        controlsPanel.Children.Add(titleSafeCheckBox);
+        controlsPanel.Children.Add(titleSafeUpDown);
+        grid.Add(controlsPanel, 1);
+
+        // The position map canvas
+        var monitor = new PositionMonitorControl();
+        monitor.ItemClicked += (_, item) => vm.SelectSubtitleFromPositionMonitor(item);
+        vm.PositionMonitor = monitor;
+
+        var monitorBorder = new Border
+        {
+            Child = monitor,
+            BorderBrush = UiUtil.GetBorderBrush(),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(4),
+            ClipToBounds = true,
+        };
+        grid.Add(monitorBorder, 2);
+
+        return grid;
+    }
+
+    private static Border MakeZoneChip(BinaryEditViewModel vm, Color color, string textPropertyName, string? highlightPropertyName)
+    {
+        var bullet = new Ellipse
+        {
+            Width = 9,
+            Height = 9,
+            Fill = new SolidColorBrush(color),
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 1, 5, 0),
+        };
+
+        var text = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            [!TextBlock.TextProperty] = new Binding(textPropertyName) { Source = vm },
+        };
+
+        var chip = new Border
+        {
+            CornerRadius = new CornerRadius(10),
+            Padding = new Thickness(9, 2, 9, 2),
+            Margin = new Thickness(10, 0, 0, 0),
+            VerticalAlignment = VerticalAlignment.Center,
+            Background = new SolidColorBrush(color, 0.12),
+            Child = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Children = { bullet, text },
+            },
+        };
+
+        if (highlightPropertyName != null)
+        {
+            // Outline the chip when any subtitle falls in this letterbox bar - the
+            // at-a-glance warning from discussion #12318.
+            chip.Bind(Border.BorderBrushProperty, new Binding(highlightPropertyName)
+            {
+                Source = vm,
+                Converter = new Avalonia.Data.Converters.FuncValueConverter<bool, IBrush?>(on =>
+                    on ? new SolidColorBrush(color, 0.85) : Brushes.Transparent),
+            });
+            chip.BorderThickness = new Thickness(1.5);
+        }
+
+        return chip;
     }
 }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -643,12 +643,14 @@ public class BinaryEditWindow : Window
         // Columns: Forced, Number, Show, Duration, Text, Image
         // Position-monitor zone dot (green = active picture, amber = bottom bar,
         // red = top bar) so problem lines are visible directly in the grid.
-        dataGrid.Columns.Add(new DataGridTemplateColumn
+        // Only shown while the right panel is in "Position map" mode.
+        var zoneColumn = new DataGridTemplateColumn
         {
             Header = string.Empty,
             Width = new DataGridLength(30),
             MinWidth = 26,
             IsReadOnly = true,
+            IsVisible = vm.IsPositionMonitorActive,
             CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
             CellTemplate = new Avalonia.Controls.Templates.FuncDataTemplate<BinarySubtitleItem>((_, _) =>
                 new Ellipse
@@ -659,7 +661,15 @@ public class BinaryEditWindow : Window
                     VerticalAlignment = VerticalAlignment.Center,
                     [!Shape.FillProperty] = new Binding(nameof(BinarySubtitleItem.ZoneBrush)),
                 }),
-        });
+        };
+        dataGrid.Columns.Add(zoneColumn);
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(vm.IsPositionMonitorActive))
+            {
+                zoneColumn.IsVisible = vm.IsPositionMonitorActive;
+            }
+        };
 
         dataGrid.Columns.Add(new DataGridTemplateColumn
         {

--- a/src/ui/Features/Shared/BinaryEdit/BinarySubtitleItem.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinarySubtitleItem.cs
@@ -19,6 +19,10 @@ public partial class BinarySubtitleItem : ObservableObject
     [ObservableProperty] private Bitmap? _bitmap;
     [ObservableProperty] private bool _isForced;
 
+    // Position-monitor zone indicator shown in the grid (green/amber/red dot).
+    // Display-only; excluded from dirty tracking.
+    [ObservableProperty] private Avalonia.Media.IBrush? _zoneBrush;
+
     private bool _isUpdating;
 
     public BinarySubtitleItem(OcrSubtitleItem item, int ocrSubtitleIndex)

--- a/src/ui/Features/Shared/BinaryEdit/PositionMonitorControl.cs
+++ b/src/ui/Features/Shared/BinaryEdit/PositionMonitorControl.cs
@@ -35,6 +35,11 @@ public class PositionMonitorControl : Control
     private static readonly Color ZoneAmber = Color.FromRgb(0xF5, 0x9E, 0x0B);
     private static readonly Color ZoneRed = Color.FromRgb(0xEF, 0x44, 0x44);
 
+    // Shared with the grid's zone-dot column and the summary chips.
+    public static readonly IBrush ZoneGreenBrush = new SolidColorBrush(ZoneGreen);
+    public static readonly IBrush ZoneAmberBrush = new SolidColorBrush(ZoneAmber);
+    public static readonly IBrush ZoneRedBrush = new SolidColorBrush(ZoneRed);
+
     private static readonly IBrush FrameBrush = new SolidColorBrush(Color.FromRgb(0x0D, 0x0D, 0x0D));
     private static readonly IBrush BarBrush = new SolidColorBrush(Color.FromArgb(0x14, 0xFF, 0xFF, 0xFF));
     private static readonly Pen FrameBorderPen = new(new SolidColorBrush(Color.FromArgb(0x50, 0xFF, 0xFF, 0xFF)), 1);
@@ -49,16 +54,17 @@ public class PositionMonitorControl : Control
     private static readonly Pen SelectedPen = new(Brushes.White, 2);
 
     // Cached per-zone brushes/pens - Render runs over every subtitle in the file,
-    // so avoid per-item allocations.
-    private static readonly IBrush GreenFill = new SolidColorBrush(ZoneGreen, 0.26);
-    private static readonly IBrush AmberFill = new SolidColorBrush(ZoneAmber, 0.26);
-    private static readonly IBrush RedFill = new SolidColorBrush(ZoneRed, 0.26);
-    private static readonly Pen GreenPen = new(new SolidColorBrush(ZoneGreen, 0.9), 1);
-    private static readonly Pen AmberPen = new(new SolidColorBrush(ZoneAmber, 0.9), 1);
-    private static readonly Pen RedPen = new(new SolidColorBrush(ZoneRed, 0.9), 1);
-    private static readonly Pen GreenSelectedPen = new(new SolidColorBrush(ZoneGreen), 1);
-    private static readonly Pen AmberSelectedPen = new(new SolidColorBrush(ZoneAmber), 1);
-    private static readonly Pen RedSelectedPen = new(new SolidColorBrush(ZoneRed), 1);
+    // so avoid per-item allocations. Green (the norm) is deliberately dim so the
+    // amber/red problem subtitles stand out at a glance.
+    private static readonly IBrush GreenFill = new SolidColorBrush(ZoneGreen, 0.13);
+    private static readonly IBrush AmberFill = new SolidColorBrush(ZoneAmber, 0.45);
+    private static readonly IBrush RedFill = new SolidColorBrush(ZoneRed, 0.45);
+    private static readonly Pen GreenPen = new(new SolidColorBrush(ZoneGreen, 0.45), 1);
+    private static readonly Pen AmberPen = new(new SolidColorBrush(ZoneAmber), 1.5);
+    private static readonly Pen RedPen = new(new SolidColorBrush(ZoneRed), 1.5);
+    private static readonly Pen GreenSelectedPen = new(ZoneGreenBrush, 1);
+    private static readonly Pen AmberSelectedPen = new(ZoneAmberBrush, 1);
+    private static readonly Pen RedSelectedPen = new(ZoneRedBrush, 1);
 
     public PositionMonitorControl()
     {
@@ -117,11 +123,29 @@ public class PositionMonitorControl : Control
             return;
         }
 
-        foreach (var item in items)
+        // Three passes so problem zones are never buried under the (many) green
+        // rectangles: green first, then bottom-bar amber, then top-bar red.
+        for (var pass = 0; pass < 3; pass++)
         {
-            if (!ReferenceEquals(item, SelectedItem))
+            var wantedZone = pass switch
             {
-                DrawItem(context, frame, scale, item, false);
+                0 => PositionMonitorZone.ActivePicture,
+                1 => PositionMonitorZone.BottomBar,
+                _ => PositionMonitorZone.TopBar,
+            };
+
+            foreach (var item in items)
+            {
+                if (ReferenceEquals(item, SelectedItem))
+                {
+                    continue;
+                }
+
+                var zone = PositionMonitorLogic.Classify(item.Y, GetBitmapHeight(item), ScreenHeight, BarHeight);
+                if (zone == wantedZone)
+                {
+                    DrawItem(context, frame, scale, item, false);
+                }
             }
         }
 

--- a/src/ui/Features/Shared/BinaryEdit/PositionMonitorControl.cs
+++ b/src/ui/Features/Shared/BinaryEdit/PositionMonitorControl.cs
@@ -1,0 +1,285 @@
+using Avalonia;
+using Avalonia.Collections;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.ObjectModel;
+using System.Globalization;
+
+namespace Nikse.SubtitleEdit.Features.Shared.BinaryEdit;
+
+/// <summary>
+/// Full-frame position map for image-based subtitles (discussion #12318): draws the
+/// video canvas with letterbox bars and every subtitle's real rectangle, color coded
+/// by zone (green = active picture, amber = bottom bar, red = top bar). The selected
+/// subtitle renders its actual decoded bitmap. Clicking a rectangle selects that line.
+/// </summary>
+public class PositionMonitorControl : Control
+{
+    public ObservableCollection<BinarySubtitleItem>? Items { get; set; }
+    public BinarySubtitleItem? SelectedItem { get; set; }
+    public int ScreenWidth { get; set; } = 1920;
+    public int ScreenHeight { get; set; } = 1080;
+    public int BarHeight { get; set; }
+    public bool ShowTitleSafe { get; set; }
+    public double TitleSafePercent { get; set; } = 5;
+
+    public event EventHandler<BinarySubtitleItem>? ItemClicked;
+
+    private const double FramePadding = 12;
+
+    private static readonly Color ZoneGreen = Color.FromRgb(0x22, 0xC5, 0x5E);
+    private static readonly Color ZoneAmber = Color.FromRgb(0xF5, 0x9E, 0x0B);
+    private static readonly Color ZoneRed = Color.FromRgb(0xEF, 0x44, 0x44);
+
+    private static readonly IBrush FrameBrush = new SolidColorBrush(Color.FromRgb(0x0D, 0x0D, 0x0D));
+    private static readonly IBrush BarBrush = new SolidColorBrush(Color.FromArgb(0x14, 0xFF, 0xFF, 0xFF));
+    private static readonly Pen FrameBorderPen = new(new SolidColorBrush(Color.FromArgb(0x50, 0xFF, 0xFF, 0xFF)), 1);
+    private static readonly Pen BarSeparatorPen = new(new SolidColorBrush(Color.FromArgb(0x60, 0xFF, 0xFF, 0xFF)), 1)
+    {
+        DashStyle = new DashStyle(new AvaloniaList<double> { 4, 4 }, 0),
+    };
+    private static readonly Pen TitleSafePen = new(new SolidColorBrush(Color.FromArgb(0x48, 0xFF, 0xFF, 0xFF)), 1)
+    {
+        DashStyle = new DashStyle(new AvaloniaList<double> { 2, 4 }, 0),
+    };
+    private static readonly Pen SelectedPen = new(Brushes.White, 2);
+
+    // Cached per-zone brushes/pens - Render runs over every subtitle in the file,
+    // so avoid per-item allocations.
+    private static readonly IBrush GreenFill = new SolidColorBrush(ZoneGreen, 0.26);
+    private static readonly IBrush AmberFill = new SolidColorBrush(ZoneAmber, 0.26);
+    private static readonly IBrush RedFill = new SolidColorBrush(ZoneRed, 0.26);
+    private static readonly Pen GreenPen = new(new SolidColorBrush(ZoneGreen, 0.9), 1);
+    private static readonly Pen AmberPen = new(new SolidColorBrush(ZoneAmber, 0.9), 1);
+    private static readonly Pen RedPen = new(new SolidColorBrush(ZoneRed, 0.9), 1);
+    private static readonly Pen GreenSelectedPen = new(new SolidColorBrush(ZoneGreen), 1);
+    private static readonly Pen AmberSelectedPen = new(new SolidColorBrush(ZoneAmber), 1);
+    private static readonly Pen RedSelectedPen = new(new SolidColorBrush(ZoneRed), 1);
+
+    public PositionMonitorControl()
+    {
+        ClipToBounds = true;
+        Cursor = new Cursor(StandardCursorType.Arrow);
+        PointerPressed += OnPointerPressedHandler;
+        PointerMoved += OnPointerMovedHandler;
+    }
+
+    public override void Render(DrawingContext context)
+    {
+        base.Render(context);
+
+        var bounds = Bounds;
+        if (bounds.Width <= 0 || bounds.Height <= 0 || ScreenWidth <= 0 || ScreenHeight <= 0)
+        {
+            return;
+        }
+
+        var frame = GetFrameRect();
+        var scale = frame.Width / ScreenWidth;
+
+        // Video frame
+        context.DrawRectangle(FrameBrush, null, frame);
+
+        // Letterbox bars
+        if (BarHeight > 0)
+        {
+            var barPixels = BarHeight * scale;
+            if (barPixels > 0.5 && barPixels * 2 < frame.Height)
+            {
+                var topBar = new Rect(frame.X, frame.Y, frame.Width, barPixels);
+                var bottomBar = new Rect(frame.X, frame.Bottom - barPixels, frame.Width, barPixels);
+                context.DrawRectangle(BarBrush, null, topBar);
+                context.DrawRectangle(BarBrush, null, bottomBar);
+                context.DrawLine(BarSeparatorPen, new Point(frame.X, topBar.Bottom), new Point(frame.Right, topBar.Bottom));
+                context.DrawLine(BarSeparatorPen, new Point(frame.X, bottomBar.Top), new Point(frame.Right, bottomBar.Top));
+            }
+        }
+
+        // Title-safe margin
+        if (ShowTitleSafe && TitleSafePercent > 0 && TitleSafePercent < 25)
+        {
+            var marginX = frame.Width * TitleSafePercent / 100.0;
+            var marginY = frame.Height * TitleSafePercent / 100.0;
+            var safeRect = new Rect(frame.X + marginX, frame.Y + marginY, frame.Width - 2 * marginX, frame.Height - 2 * marginY);
+            context.DrawRectangle(null, TitleSafePen, safeRect);
+        }
+
+        // Subtitle rectangles (selected drawn last, on top, with its real bitmap)
+        var items = Items;
+        if (items == null || items.Count == 0)
+        {
+            DrawCenteredHint(context, frame, Se.Language.Tools.ImageBasedEdit.NoImageSubtitlesLoaded);
+            context.DrawRectangle(null, FrameBorderPen, frame);
+            return;
+        }
+
+        foreach (var item in items)
+        {
+            if (!ReferenceEquals(item, SelectedItem))
+            {
+                DrawItem(context, frame, scale, item, false);
+            }
+        }
+
+        if (SelectedItem != null)
+        {
+            DrawItem(context, frame, scale, SelectedItem, true);
+        }
+
+        context.DrawRectangle(null, FrameBorderPen, frame);
+    }
+
+    private void DrawItem(DrawingContext context, Rect frame, double scale, BinarySubtitleItem item, bool isSelected)
+    {
+        var rect = GetItemRect(item, frame, scale);
+        if (rect == null)
+        {
+            return;
+        }
+
+        var zone = PositionMonitorLogic.Classify(item.Y, GetBitmapHeight(item), ScreenHeight, BarHeight);
+        var (fill, border, selectedBorder) = zone switch
+        {
+            PositionMonitorZone.TopBar => (RedFill, RedPen, RedSelectedPen),
+            PositionMonitorZone.BottomBar => (AmberFill, AmberPen, AmberSelectedPen),
+            _ => (GreenFill, GreenPen, GreenSelectedPen),
+        };
+
+        if (isSelected && item.Bitmap != null)
+        {
+            var src = new Rect(0, 0, item.Bitmap.PixelSize.Width, item.Bitmap.PixelSize.Height);
+            context.DrawImage(item.Bitmap, src, rect.Value);
+            context.DrawRectangle(null, SelectedPen, rect.Value.Inflate(1));
+            context.DrawRectangle(null, selectedBorder, rect.Value.Inflate(2.5));
+        }
+        else
+        {
+            context.DrawRectangle(fill, border, rect.Value);
+        }
+    }
+
+    private static void DrawCenteredHint(DrawingContext context, Rect frame, string text)
+    {
+        var ft = new FormattedText(
+            text,
+            CultureInfo.CurrentUICulture,
+            FlowDirection.LeftToRight,
+            Typeface.Default,
+            13,
+            new SolidColorBrush(Color.FromArgb(0x90, 0xFF, 0xFF, 0xFF)));
+        context.DrawText(ft, new Point(
+            frame.X + (frame.Width - ft.Width) / 2.0,
+            frame.Y + (frame.Height - ft.Height) / 2.0));
+    }
+
+    private Rect GetFrameRect()
+    {
+        var availableWidth = Math.Max(0, Bounds.Width - 2 * FramePadding);
+        var availableHeight = Math.Max(0, Bounds.Height - 2 * FramePadding);
+        if (availableWidth <= 0 || availableHeight <= 0)
+        {
+            return new Rect(FramePadding, FramePadding, 0, 0);
+        }
+
+        var scale = Math.Min(availableWidth / ScreenWidth, availableHeight / ScreenHeight);
+        var width = ScreenWidth * scale;
+        var height = ScreenHeight * scale;
+        return new Rect(
+            (Bounds.Width - width) / 2.0,
+            (Bounds.Height - height) / 2.0,
+            width,
+            height);
+    }
+
+    private Rect? GetItemRect(BinarySubtitleItem item, Rect frame, double scale)
+    {
+        var w = GetBitmapWidth(item);
+        var h = GetBitmapHeight(item);
+        if (w <= 0 || h <= 0)
+        {
+            return null;
+        }
+
+        return new Rect(
+            frame.X + item.X * scale,
+            frame.Y + item.Y * scale,
+            Math.Max(1.5, w * scale),
+            Math.Max(1.5, h * scale));
+    }
+
+    private static int GetBitmapWidth(BinarySubtitleItem item)
+    {
+        return item.Bitmap?.PixelSize.Width ?? 0;
+    }
+
+    private static int GetBitmapHeight(BinarySubtitleItem item)
+    {
+        return item.Bitmap?.PixelSize.Height ?? 0;
+    }
+
+    private BinarySubtitleItem? HitTest(Point point)
+    {
+        var items = Items;
+        if (items == null || items.Count == 0 || ScreenWidth <= 0 || ScreenHeight <= 0)
+        {
+            return null;
+        }
+
+        var frame = GetFrameRect();
+        if (frame.Width <= 0)
+        {
+            return null;
+        }
+
+        var scale = frame.Width / ScreenWidth;
+
+        // Prefer the smallest rectangle containing the point so overlapping
+        // subtitles remain individually selectable.
+        BinarySubtitleItem? best = null;
+        var bestArea = double.MaxValue;
+        foreach (var item in items)
+        {
+            var rect = GetItemRect(item, frame, scale);
+            if (rect == null || !rect.Value.Inflate(1).Contains(point))
+            {
+                continue;
+            }
+
+            var area = rect.Value.Width * rect.Value.Height;
+            if (area < bestArea)
+            {
+                bestArea = area;
+                best = item;
+            }
+        }
+
+        return best;
+    }
+
+    private void OnPointerPressedHandler(object? sender, PointerPressedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+
+        var hit = HitTest(e.GetPosition(this));
+        if (hit != null)
+        {
+            ItemClicked?.Invoke(this, hit);
+            e.Handled = true;
+        }
+    }
+
+    private void OnPointerMovedHandler(object? sender, PointerEventArgs e)
+    {
+        var hit = HitTest(e.GetPosition(this));
+        Cursor = hit != null
+            ? new Cursor(StandardCursorType.Hand)
+            : new Cursor(StandardCursorType.Arrow);
+    }
+}

--- a/src/ui/Features/Shared/BinaryEdit/PositionMonitorLogic.cs
+++ b/src/ui/Features/Shared/BinaryEdit/PositionMonitorLogic.cs
@@ -1,0 +1,86 @@
+using System;
+
+namespace Nikse.SubtitleEdit.Features.Shared.BinaryEdit;
+
+public enum PositionMonitorZone
+{
+    ActivePicture,
+    TopBar,
+    BottomBar,
+}
+
+/// <summary>
+/// Letterbox / zone math for the position monitor (discussion #12318):
+/// classifies where an image subtitle sits on the video canvas so QC can spot
+/// forced titles in the top letterbox bar and dialogue intruding into the bars.
+/// </summary>
+public static class PositionMonitorLogic
+{
+    /// <summary>
+    /// Computes the letterbox bar height in pixels for content with the given aspect
+    /// ratio inside a screenWidth x screenHeight frame. Returns 0 when the content
+    /// fills the frame (or on invalid input).
+    /// </summary>
+    public static int CalculateBarHeight(int screenWidth, int screenHeight, double contentAspectRatio)
+    {
+        if (screenWidth <= 0 || screenHeight <= 0 || contentAspectRatio <= 0)
+        {
+            return 0;
+        }
+
+        var contentHeight = screenWidth / contentAspectRatio;
+        var bar = (screenHeight - contentHeight) / 2.0;
+        return bar > 0 ? (int)Math.Round(bar) : 0;
+    }
+
+    /// <summary>
+    /// Classifies a subtitle rectangle: anything touching the top bar is TopBar (the
+    /// red flag - forced/narrative titles), anything touching the bottom bar is
+    /// BottomBar, everything else is inside the active picture.
+    /// </summary>
+    public static PositionMonitorZone Classify(int y, int height, int screenHeight, int barHeight)
+    {
+        if (barHeight <= 0 || screenHeight <= 0)
+        {
+            return PositionMonitorZone.ActivePicture;
+        }
+
+        if (y < barHeight)
+        {
+            return PositionMonitorZone.TopBar;
+        }
+
+        if (y + height > screenHeight - barHeight)
+        {
+            return PositionMonitorZone.BottomBar;
+        }
+
+        return PositionMonitorZone.ActivePicture;
+    }
+}
+
+/// <summary>
+/// Item for the letterbox aspect-ratio dropdown. Ratio is null for "Off" and "Custom".
+/// </summary>
+public class LetterboxRatioItem
+{
+    public string Name { get; }
+    public double? Ratio { get; }
+    public bool IsCustom { get; }
+
+    /// <summary>Invariant key persisted in settings ("off", "custom", or the ratio like "2.39").</summary>
+    public string SettingsKey { get; }
+
+    public LetterboxRatioItem(string name, double? ratio, bool isCustom, string settingsKey)
+    {
+        Name = name;
+        Ratio = ratio;
+        IsCustom = isCustom;
+        SettingsKey = settingsKey;
+    }
+
+    public override string ToString()
+    {
+        return Name;
+    }
+}

--- a/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
@@ -33,6 +33,18 @@ public class LanguageImageBasedEdit
     public string AppendSubtitleDotDotDot { get; set; }
     public string ShiftTimeCodes { get; set; }
     public string SortByStartTime { get; set; }
+    public string VideoPreview { get; set; }
+    public string PositionMap { get; set; }
+    public string Letterbox { get; set; }
+    public string LetterboxOff { get; set; }
+    public string LetterboxCustom { get; set; }
+    public string BarHeightPx { get; set; }
+    public string TitleSafePercent { get; set; }
+    public string PositionSummary { get; set; }
+    public string XInActivePicture { get; set; }
+    public string XInTopBar { get; set; }
+    public string XInBottomBar { get; set; }
+    public string NoImageSubtitlesLoaded { get; set; }
 
     public LanguageImageBasedEdit()
     {
@@ -67,5 +79,17 @@ public class LanguageImageBasedEdit
         AppendSubtitleDotDotDot = "Append subtitle...";
         ShiftTimeCodes = "Shift time codes by";
         SortByStartTime = "Sort by start time";
+        VideoPreview = "Video";
+        PositionMap = "Position map";
+        Letterbox = "Letterbox";
+        LetterboxOff = "Off (no letterbox)";
+        LetterboxCustom = "Custom bar height";
+        BarHeightPx = "Bar height (px)";
+        TitleSafePercent = "Title-safe (%)";
+        PositionSummary = "{0}×{1} - {2} subtitles - bar height: {3} px";
+        XInActivePicture = "{0} in picture";
+        XInTopBar = "{0} in top bar";
+        XInBottomBar = "{0} in bottom bar";
+        NoImageSubtitlesLoaded = "No image subtitles loaded";
     }
 }

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -81,6 +81,11 @@ public class SeTools
     public decimal BinEditOutlineWidth { get; set; }
     public decimal BinEditShadowWidth { get; set; }
     public bool BinEditSelectCurrentSubtitleWhilePlaying { get; set; }
+    public bool BinEditPositionMonitorActive { get; set; }
+    public string BinEditPositionMonitorRatio { get; set; }
+    public int BinEditPositionMonitorBarHeight { get; set; }
+    public bool BinEditPositionMonitorTitleSafeOn { get; set; }
+    public double BinEditPositionMonitorTitleSafePercent { get; set; }
 
     public string ImportTextSplitting { get; set; }
     public string ImportTextSplittingLineMode { get; set; }
@@ -197,6 +202,11 @@ public class SeTools
         BinEditBackgroundColor = Colors.Transparent.FromColorToHex();
         BinEditOutlineWidth = 2;
         BinEditShadowWidth = 1;
+        BinEditPositionMonitorActive = false;
+        BinEditPositionMonitorRatio = "off";
+        BinEditPositionMonitorBarHeight = 0;
+        BinEditPositionMonitorTitleSafeOn = true;
+        BinEditPositionMonitorTitleSafePercent = 5;
 
         ImportTextSplitting = "auto";
         ImportTextSplittingLineMode = "OneLineIsOneSubtitle";


### PR DESCRIPTION
Implements the **position monitor** from discussion #12318 — a BDSup2Sub++-style QC view for image-based subtitles (.sup/.sub/BDN), built into the binary edit window.

### What it does
- The right panel gets a segmented **`Video | Position map`** toggle (both panels stay in the visual tree so the mpv surface is never detached).
- **`PositionMonitorControl`** renders the full video canvas with every subtitle's real rectangle, color coded by zone: green = active picture, amber = bottom letterbox bar, red = top bar (forced titles). Anything touching a bar is flagged. The selected line shows its actual decoded bitmap; clicking a rectangle selects the line in the grid.
- **Configurable letterbox**: aspect-ratio presets (1.66:1 → 2.40:1) auto-compute the bar height (1920×1080 @ 2.39:1 → 138 px, matching the discussion's mock), or a custom bar height in px; optional title-safe % margin (dashed).
- **Summary header**: resolution · count · bar height, plus per-zone count chips. Chips get a colored outline as a warning when any subtitle sits in a bar, and **clicking a chip jumps to the next subtitle in that zone** (cycling).
- **Zone dot column** in the subtitle grid (only visible in Position map mode) so offending lines are visible directly in the list; display-only, excluded from dirty tracking.
- Live updates when subs are moved (X/Y or dragged in video view), screen size changes, or lines are added/removed. Green rects are drawn dim; amber/red drawn stronger and on top, so problems pop.
- Settings persisted (`SeTools.BinEditPositionMonitor*`); localized in English and Danish.

### UI feedback incorporated
- Zone chips on a single dedicated line
- Label+control groups that can't wrap apart (the title-safe field previously orphan-wrapped and clipped)
- Problem-visibility pass (dim green / strong amber+red / grid dots / clickable chips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)