### PR TITLE
Prepare v5.1.0-beta14: changelog + version bump

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -1,6 +1,31 @@
 
 Subtitle Edit Changelog
 
+v5.1.0-beta14 (10th of July 2026)
+
+* Add PGS position monitor to the image-based subtitle editor - a "Position map" view drawing every subtitle on the video canvas with configurable letterbox bars, zone color coding (active picture / bottom bar / top bar), title-safe margin, clickable zone chips, and a zone dot column in the grid - a BDSup2Sub++ style QC tool - thx Victory61
+* Auto-translate: add generic OpenAI-compatible engine (custom URL/model/API key)
+* AI assistant: engine settings in the window, strip think blocks, and show the model's reasoning behind an info button
+* Add AI assistant to the subtitle text box context menu
+* Add shortcut to toggle subtitle grid formatting mode
+* Text to speech: ElevenLabs pause cues work again - text normalization is now off so <break time="1.5s"/> and punctuation pauses are preserved, and on Eleven v3 break tags are auto-converted to [pause] audio tags - thx cvrle77
+* Text to speech: fix Google voices with 3-letter language codes (Mandarin/Cantonese/Filipino) failing to generate audio
+* Text to speech: the ElevenLabs "Speaker Boost" setting is now actually sent to the API
+* Fix waveform border drag not registering on trackpads (macOS) - thx okpukhalska-dot
+* Fix malformed ASSA tags when splitting a line with two or more active tags (e.g. bold + color)
+* Fix TTML/DFXP export losing an enclosing style after a nested tag (e.g. bold inside italic)
+* Fix subtitle format edge cases: MicroDVD "{y:u,i}" tag, uppercase \uXXXX in JSON, and 1/3-digit fractional seconds in classic SSA time codes
+* OCR: better separation of vertically touching text lines (two line-splitter fixes)
+* Fix ASSA/SSA properties video resolution and dark-theme picker color - thx kit132
+* Re-apply the layout direction live when the interface language changes - thx muaz978
+* Update CrispASR Qwen3 and parakeet-ja model lists
+* Add Turkish UI translation - thx bilimiyorum
+* Update Italian translation - thx bovirus
+* Update Korean translation - thx 12si27
+* Update Danish translation
+
+-----------------------------------------------------------------------------------------------------
+
 v5.1.0-beta13 (9th of July 2026)
 
 * Add an AI assistant button to the subtitle text box - quick actions (fix spelling/grammar, rephrase to fit reading speed, change tone) plus a free question box for the current line - thx muaz978

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -17,7 +17,7 @@ public class Se
 {
     internal const int CurrentMacOsFontMigrationVersion = 1;
 
-    public static string Version { get; set; } = "v5.1.0-beta13";
+    public static string Version { get; set; } = "v5.1.0-beta14";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Changelog entry for v5.1.0-beta14 and version bump in `Se.cs` (`v5.1.0-beta13` → `v5.1.0-beta14`).

Entries enumerated by ancestor-checking all first-parent commits in `v5.1.0-beta13..HEAD` (23 commits / 20 PR merges — not from timestamps). Covers: PGS position monitor (#12341, discussion #12318), OpenAI-compatible auto-translate (#12325), AI assistant improvements (#12313/#12315/#12330), grid formatting shortcut (#12322), ElevenLabs pause/Speaker Boost + Google TTS language-code fixes (#12331/#12332), waveform trackpad drag (#12335, #12177), ASSA split tags (#12333), format round-trip fixes (#12336), OCR line-splitter (#12337), ASSA/SSA properties (#12328, #12327), RTL live layout (#12306), CrispASR models (#12326), and translation updates (#12339/#12319/#12323/#12329).

Skipped as internal: "Update nuget", "Update default buttons", "Update English translation".

🤖 Generated with [Claude Code](https://claude.com/claude-code)