### PR TITLE
Flatpak: fetch mujs from the official release tarball, not Codeberg git

### DIFF
--- a/installer/flatpak/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/dk.nikse.subtitleedit.yaml
@@ -131,10 +131,11 @@ modules:
       - /include
       - /lib/pkgconfig
     sources:
-      - type: git
-        url: https://codeberg.org/ccxvii/mujs.git
-        tag: 1.3.8
-        commit: 307f18c4216420f2f56e22d8e7040baa39a6304a
+      # Official release tarball from the upstream site - the Codeberg git repo
+      # returns intermittent 504s and the GitHub mirror is stale (stops at 1.3.7).
+      - type: archive
+        url: https://mujs.com/downloads/mujs-1.3.8.tar.gz
+        sha256: 506d34882f2620a2fdeb6db63dbb7a8ffd98f417689d8f3c84f2feac275e39a9
       - type: file
         url: https://www.unicode.org/Public/16.0.0/ucd/UnicodeData.txt
         sha256: ff58e5823bd095166564a006e47d111130813dcf8bf234ef79fa51a870edb48f

--- a/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
@@ -131,10 +131,11 @@ modules:
       - /include
       - /lib/pkgconfig
     sources:
-      - type: git
-        url: https://codeberg.org/ccxvii/mujs.git
-        tag: 1.3.8
-        commit: 307f18c4216420f2f56e22d8e7040baa39a6304a
+      # Official release tarball from the upstream site - the Codeberg git repo
+      # returns intermittent 504s and the GitHub mirror is stale (stops at 1.3.7).
+      - type: archive
+        url: https://mujs.com/downloads/mujs-1.3.8.tar.gz
+        sha256: 506d34882f2620a2fdeb6db63dbb7a8ffd98f417689d8f3c84f2feac275e39a9
       - type: file
         url: https://www.unicode.org/Public/16.0.0/ucd/UnicodeData.txt
         sha256: ff58e5823bd095166564a006e47d111130813dcf8bf234ef79fa51a870edb48f


### PR DESCRIPTION
The three flatpak jobs in the v5.1.0-beta14 release run failed **three attempts in a row** with:

```
fatal: unable to access 'https://codeberg.org/ccxvii/mujs.git/': The requested URL returned error: 504
```

Codeberg is having an outage; the GitHub mirror of mujs is stale (latest tag 1.3.7, the pinned 1.3.8 isn't there). Upstream also distributes release tarballs on its official site, so switch both manifests (`installer/flatpak/` + `installer/flatpak/flathub/`) from the git source to:

```yaml
- type: archive
  url: https://mujs.com/downloads/mujs-1.3.8.tar.gz
  sha256: 506d34882f2620a2fdeb6db63dbb7a8ffd98f417689d8f3c84f2feac275e39a9
```

Same 1.3.8 release, sha256-pinned, immune to Codeberg availability. Tarball downloaded and verified (contents match `mujs-1.3.8/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)