### PR TITLE
Flatpak: pass VERSION=1.3.8 to mujs make (tarball has no git metadata)

### DIFF
--- a/installer/flatpak/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/dk.nikse.subtitleedit.yaml
@@ -121,11 +121,17 @@ modules:
 
   - name: mujs
     no-autogen: true
+    # VERSION must be passed explicitly: the Makefile derives it from git describe
+    # (no .git in a tarball) or the directory name (flatpak-builder extracts into
+    # /run/build/mujs), so mujs.pc otherwise gets an invalid version and mpv's
+    # meson rejects the dependency.
     make-args:
       - release
+      - VERSION=1.3.8
     make-install-args:
       - prefix=/app
       - install-shared
+      - VERSION=1.3.8
     cleanup:
       - /bin
       - /include

--- a/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
@@ -121,11 +121,17 @@ modules:
 
   - name: mujs
     no-autogen: true
+    # VERSION must be passed explicitly: the Makefile derives it from git describe
+    # (no .git in a tarball) or the directory name (flatpak-builder extracts into
+    # /run/build/mujs), so mujs.pc otherwise gets an invalid version and mpv's
+    # meson rejects the dependency.
     make-args:
       - release
+      - VERSION=1.3.8
     make-install-args:
       - prefix=/app
       - install-shared
+      - VERSION=1.3.8
     cleanup:
       - /bin
       - /include


### PR DESCRIPTION
Follow-up to #12345. The flatpak jobs now fail with:

```
Dependency mujs found: NO. Found mujs but need: '>= 1.0.0'
ERROR: Dependency lookup for mujs with method 'pkgconfig' failed: Invalid version, need 'mujs' ['>= 1.0.0'] found 'mujs'.
```

mujs's Makefile:
```make
ifneq ($(wildcard .git),)
  VERSION = $(shell git describe --tags --always)      # tarball: no .git
else
  VERSION = $(patsubst mujs-%,%,$(notdir $(CURDIR)))   # flatpak-builder extracts into /run/build/mujs
endif
```
Neither branch works under flatpak-builder with an archive source — `mujs.pc` ends up with `Version: mujs`, which meson rejects. Pass `VERSION=1.3.8` explicitly in `make-args` and `make-install-args` in both manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)