### PR TITLE
Re-add qwen3-asr-1.7b-q4_k after upstream re-bake (CrispASR #240)

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrQwen3.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrQwen3.cs
@@ -52,13 +52,24 @@ public class CrispAsrQwen3 : CrispAsrEngineBase
             new WhisperLanguage("ro", "romanian"),
        };
 
-    // qwen3-asr-1.7b-q4_k.gguf is intentionally NOT listed: on CrispASR v0.8.9 it
-    // produces empty transcripts (sub-8-bit encoder drift; the checksum-verified file
-    // loads and "transcribes" but emits no text). Re-add if upstream ships an
-    // imatrix-repaired q4_k like the 0.6b repo got.
+    // qwen3-asr-1.7b-q4_k.gguf: the pre-2026-07-10 upload produced empty transcripts
+    // on CrispASR v0.8.9 (sub-8-bit audio-encoder drift, CrispASR issue #240). Upstream
+    // re-baked it with a Q8_0 audio-tower floor and replaced the file in place
+    // (now 1.49 GB, sha256 ec197cef...; the broken one was 1f1d26ee...). Verified OK
+    // against the pinned v0.8.9 binary. Users who downloaded the old file must delete
+    // it from CrispASR/models and re-download - same filename, so SE can't tell them apart.
     public override List<WhisperModel> Models =>
        new()
        {
+            new WhisperModel
+            {
+                Name = "qwen3-asr-1.7b-q4_k.gguf",
+                Size = "1.49 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/qwen3-asr-1.7b-GGUF/resolve/main/qwen3-asr-1.7b-q4_k.gguf",
+                ],
+            },
             new WhisperModel
             {
                 Name = "qwen3-asr-1.7b-q8_0.gguf",


### PR DESCRIPTION
Re-lists `qwen3-asr-1.7b-q4_k.gguf` in the CrispASR Qwen3 speech-to-text model list.

### Background
The q4_k was delisted because the original upload silently produced **empty transcripts** on CrispASR v0.8.9 (sub-8-bit audio-encoder drift — [CrispASR #240](https://github.com/CrispStrobe/CrispASR/issues/240)). Upstream root-caused it (encoder cos drift compounding to cos_min=0.75 → decode flips to "language none"), added a **Q8_0 floor for all `audio.*` tensors** to `crispasr-quantize`, and replaced the Q4_K/Q4_0/Q5_K files on `cstr/qwen3-asr-1.7b-GGUF` in place (2026-07-10).

### Verification (per our model-list rule)
Ran headlessly against the **pinned v0.8.9 release binary** (`c02d9200`, `crispasr-macos.tar.gz`), Apple M4/Metal:
- Fresh download: 1,490,915,200 bytes, sha256 `ec197cef…` (broken upload was `1f1d26ee…`)
- `say` + `ffmpeg` 16 kHz mono test clip, exact `--backend qwen3 -l en` invocation
- Result: correct non-empty transcript, `detected 'en' (p=1.000)` — the broken quant reported `'none' (p=1.000)` with empty output

### Caveat (noted in the code comment)
The fixed file has the **same filename** as the broken one, and SE only checks file existence — anyone who downloaded the pre-fix q4_k must delete it from `CrispASR/models` and re-download. SE can't distinguish them without hashing; the next CrispASR release will at least warn on empty transcripts (also from #240).

At 1.49 GB this becomes the smallest 1.7b option (vs 2.51 GB q8_0), listed first to match the 0.6b ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)