### PR TITLE
seconv: fix garbled PGS/DVB-sub OCR by binarizing before Tesseract (#12291)

### DIFF
--- a/src/libse/Common/VobSubColorIsolation.cs
+++ b/src/libse/Common/VobSubColorIsolation.cs
@@ -93,5 +93,52 @@ namespace Nikse.SubtitleEdit.Core.Common
 
             return result;
         }
+
+        /// <summary>
+        /// Brightness-keyed binarization for PGS / DVB-sub OCR bitmaps (issue #12291) — the
+        /// same preparation the GUI OCR uses (<c>NikseBitmap.MakeBlackAndWhiteForOcr</c>):
+        /// bright, sufficiently opaque pixels (the glyph fill, incl. coloured fills like
+        /// yellow) become black, everything else — the dark outline, the darker half of the
+        /// antialias ramp, and the transparent background — becomes white. Unlike
+        /// <see cref="Isolate"/>, this does not assume an indexed palette, so it is robust
+        /// for antialiased PGS where no single exact RGB dominates. Without it, compositing
+        /// white-fill/black-outline glyphs onto an opaque white OCR canvas leaves hollow
+        /// outline rings that Tesseract reads as punctuation soup on some entries.
+        /// </summary>
+        /// <param name="source">Rendered PGS/DVB bitmap; a transparent background is expected.</param>
+        /// <param name="brightnessThreshold">Min brightness (max of R/G/B) for a pixel to count as text.</param>
+        /// <param name="alphaThreshold">Pixels with alpha below this are treated as background.</param>
+        public static SKBitmap BinarizeForOcr(SKBitmap source, int brightnessThreshold = 90, byte alphaThreshold = 100)
+        {
+            var width = source.Width;
+            var height = source.Height;
+            var result = new SKBitmap(new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Opaque));
+
+            using var canvas = new SKCanvas(result);
+            canvas.Clear(SKColors.White);
+
+            using var paint = new SKPaint { Color = SKColors.Black };
+            for (var y = 0; y < height; y++)
+            {
+                for (var x = 0; x < width; x++)
+                {
+                    var c = source.GetPixel(x, y);
+                    if (c.Alpha < alphaThreshold)
+                    {
+                        continue;
+                    }
+
+                    var brightness = c.Red > c.Green
+                        ? (c.Red > c.Blue ? c.Red : c.Blue)
+                        : (c.Green > c.Blue ? c.Green : c.Blue);
+                    if (brightness >= brightnessThreshold)
+                    {
+                        canvas.DrawPoint(x, y, paint);
+                    }
+                }
+            }
+
+            return result;
+        }
     }
 }

--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -116,6 +116,10 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         [Description("Disable VobSub OCR colour isolation (on by default). Isolation binarises each subpicture to black-on-white by keeping the most frequent opaque colour (glyph fill) and dropping the outline/anti-alias colours; pass this to OCR the raw palette instead")]
         public bool NoVobSubIsolateColors { get; init; }
 
+        [CommandOption("--no-pgs-isolate-colors|--nopgsisolatecolors")]
+        [Description("Disable PGS/DVB-sub OCR colour isolation (on by default)")]
+        public bool NoPgsIsolateColors { get; init; }
+
         [CommandOption("--ollama-url")]
         [Description("Ollama API endpoint (default: http://localhost:11434/api/chat)")]
         public string? OllamaUrl { get; init; }
@@ -579,6 +583,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 DictionaryFolder = settings.DictionaryFolder,
                 TimeCodesOnly = settings.TimeCodesOnly,
                 VobSubIsolateColors = !settings.NoVobSubIsolateColors,
+                PgsIsolateColors = !settings.NoPgsIsolateColors,
                 OllamaUrl = settings.OllamaUrl,
                 OllamaModel = settings.OllamaModel,
                 TeletextOnly = settings.TeletextOnly,

--- a/src/seconv/Core/ImageOcrLoader.cs
+++ b/src/seconv/Core/ImageOcrLoader.cs
@@ -37,8 +37,9 @@ internal static class ImageOcrLoader
         }
 
         using var ocr = OcrEngineFactory.Create(options);
-        AnsiConsole.MarkupLine($"[dim]Running {ocr.Name} OCR on {pcsList.Count} Blu-Ray sup image(s)...[/]");
-        return PcsListToSubtitle(pcsList, ocr);
+        var isolationNote = options.PgsIsolateColors ? string.Empty : " (colour isolation off)";
+        AnsiConsole.MarkupLine($"[dim]Running {ocr.Name} OCR on {pcsList.Count} Blu-Ray sup image(s){isolationNote}...[/]");
+        return PcsListToSubtitle(pcsList, ocr, options.PgsIsolateColors);
     }
 
     /// <summary>
@@ -60,8 +61,9 @@ internal static class ImageOcrLoader
         }
 
         using var ocr = OcrEngineFactory.Create(options);
-        AnsiConsole.MarkupLine($"[dim]Running {ocr.Name} OCR on {pcsList.Count} MKV PGS image(s) (track #{track.TrackNumber})...[/]");
-        return PcsListToSubtitle(pcsList, ocr);
+        var isolationNote = options.PgsIsolateColors ? string.Empty : " (colour isolation off)";
+        AnsiConsole.MarkupLine($"[dim]Running {ocr.Name} OCR on {pcsList.Count} MKV PGS image(s) (track #{track.TrackNumber}){isolationNote}...[/]");
+        return PcsListToSubtitle(pcsList, ocr, options.PgsIsolateColors);
     }
 
     /// <summary>
@@ -107,7 +109,21 @@ internal static class ImageOcrLoader
                     try
                     {
                         // ocr == null → time-codes-only: keep the entry with empty text.
-                        var text = ocr is null ? string.Empty : ocr.Recognize(bitmap);
+                        string text;
+                        if (ocr is null)
+                        {
+                            text = string.Empty;
+                        }
+                        else if (options.PgsIsolateColors)
+                        {
+                            // Same antialiased binarisation as the PGS path (issue #12291).
+                            using var isolated = VobSubColorIsolation.BinarizeForOcr(bitmap);
+                            text = ocr.Recognize(isolated);
+                        }
+                        else
+                        {
+                            text = ocr.Recognize(bitmap);
+                        }
                         if (ocr is null || !string.IsNullOrWhiteSpace(text))
                         {
                             subtitle.Paragraphs.Add(new LibSeParagraph(text, (double)dvb.StartMilliseconds, (double)dvb.EndMilliseconds));
@@ -238,7 +254,7 @@ internal static class ImageOcrLoader
     /// kept with empty text so the output carries timing but no recognised characters.
     /// Entries whose bitmap is null (e.g. clear-screen commands) are skipped in both modes.
     /// </summary>
-    private static Subtitle PcsListToSubtitle(List<BluRaySupParser.PcsData> pcsList, IOcrEngine? ocr)
+    private static Subtitle PcsListToSubtitle(List<BluRaySupParser.PcsData> pcsList, IOcrEngine? ocr, bool isolateColors = false)
     {
         var subtitle = new Subtitle();
 
@@ -251,7 +267,22 @@ internal static class ImageOcrLoader
             }
             try
             {
-                var text = ocr is null ? string.Empty : ocr.Recognize(bitmap);
+                string text;
+                if (ocr is null)
+                {
+                    text = string.Empty;
+                }
+                else if (isolateColors)
+                {
+                    // PGS glyphs are white fill + black outline on transparency; binarise so
+                    // the fill survives the opaque white OCR canvas (issue #12291).
+                    using var isolated = VobSubColorIsolation.BinarizeForOcr(bitmap);
+                    text = ocr.Recognize(isolated);
+                }
+                else
+                {
+                    text = ocr.Recognize(bitmap);
+                }
                 if (ocr is null || !string.IsNullOrWhiteSpace(text))
                 {
                     subtitle.Paragraphs.Add(new LibSeParagraph(text, pcs.StartTime / 90.0, pcs.EndTime / 90.0));

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -885,6 +885,17 @@ internal record class ConversionOptions
     /// </summary>
     public bool VobSubIsolateColors { get; init; } = true;
 
+    /// <summary>
+    /// PGS / DVB-sub OCR only: before recognition, rebuild each bitmap as crisp black-on-white
+    /// via <see cref="VobSubColorIsolation.BinarizeForOcr"/>. PGS glyphs are typically
+    /// white fill with a black outline on transparency; composited onto the opaque white OCR
+    /// canvas the fill vanishes and Tesseract receives hollow outline rings, which garbles
+    /// some entries deterministically (issue #12291). On by default; disable with
+    /// <c>--no-pgs-isolate-colors</c> to OCR the raw bitmap. Ignored in
+    /// <see cref="TimeCodesOnly"/> mode.
+    /// </summary>
+    public bool PgsIsolateColors { get; init; } = true;
+
     /// <summary>Ollama API endpoint (default <c>http://localhost:11434/api/chat</c>).</summary>
     public string? OllamaUrl { get; init; }
 

--- a/src/seconv/Helpers/HelpDisplay.cs
+++ b/src/seconv/Helpers/HelpDisplay.cs
@@ -44,6 +44,7 @@ internal static class HelpDisplay
         ShowParameter("--ocr-db:<path>", ".nocr (--ocr-engine=nocr) or .db (--ocr-engine=binaryocr)");
         ShowParameter("--time-codes-only", "Image sources (.sup/VobSub/PGS/DVB) -> text with time codes only; skips OCR");
         ShowParameter("--no-vobsub-isolate-colors", "Disable VobSub OCR colour isolation (on by default; isolation binarises to black-on-white, dropping outline colours)");
+        ShowParameter("--no-pgs-isolate-colors", "Disable PGS/DVB-sub OCR colour isolation (on by default; isolation binarises to black-on-white so the white glyph fill survives the OCR canvas)");
         ShowParameter("--ollama-url:<url>", "Ollama API endpoint (default: http://localhost:11434/api/chat)");
         ShowParameter("--ollama-model:<model>", "Ollama vision model (default: llama3.2-vision)");
         ShowParameter("--multiple-replace:<path.xml>", "SE MultipleSearchAndReplaceGroups XML applied per paragraph");


### PR DESCRIPTION
Fixes the PGS half of #12291 (seconv OCR punctuation soup on entries the GUI reads cleanly).

### Root cause
`TesseractOcrEngine.Preprocess` composites the subtitle RGBA onto an **opaque white canvas**. PGS glyphs are white fill + black outline on transparency — composited onto white, the fill vanishes and Tesseract receives hollow outline rings. Most entries survive; some tip deterministically into garbage (12 of 155 in the reporter's track). The VobSub path got colour isolation in #12293; the **PGS and DVB-sub paths did not**.

### Fix
- New `VobSubColorIsolation.BinarizeForOcr` — the **same brightness-keyed binarization the GUI OCR uses** (`NikseBitmap.MakeBlackAndWhiteForOcr`: `max(R,G,B) ≥ 90` and `alpha ≥ 100` → black, else white; handles coloured fills like yellow).
- Applied in the Blu-ray `.sup`, MKV PGS, and TS DVB-sub OCR paths. On by default; `--no-pgs-isolate-colors` to disable (mirrors `--no-vobsub-isolate-colors`). Help text updated.

### Why not reuse the VobSub histogram isolation
Tried first — it made things **worse** on antialiased PGS (the dominant-exact-RGB assumption doesn't hold; on the sample it picked the wrong tier and garbled nearly every entry). The GUI's brightness threshold is the proven preparation, so seconv now matches it exactly.

### Verification (reporter's `serbian-30min.sup`, Tesseract 5.5.1, `srp_latn`)
| entry | before | after |
|---|---|---|
| 00:21:28 | `(=yoly{e:-\(-y` | `– Ne pričate...` |
| 00:29:55 | `MAe[-Toh:- 1 ı WAV/(e{-Tfox:Pink:1 A}` | `Video sam... video sam sve.` |

Full-file diff shows **only improvements**: the two catastrophic entries fixed plus five casing errors (`ZnačČI`→`Znači`, `pOnos`→`ponos`, …) fixed as a side effect of the crisper input; zero regressions across the remaining entries. Builds clean (seconv + UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)