### PR TITLE
Fix Turkish.json: remove trailing comma that broke JSON parsing

### DIFF
--- a/src/ui/Assets/Languages/Turkish.json
+++ b/src/ui/Assets/Languages/Turkish.json
@@ -1377,7 +1377,7 @@
 	  "linesXToY": "Satır {0}-{1}",
 	  "largeChangeWarning": "Büyük değişiklik - yeniden yazılmış gibi görünüyor, dikkatlice inceleyin",
 	  "engineError": "Yapay zekâ motoruna ulaşılamadı: {0}",
-	  "setupHint": "Lütfen önce Araçlar -> Yapay zekâ incelemesi menüsünden bir motor ve model seçin.",
+	  "setupHint": "Lütfen önce Araçlar -> Yapay zekâ incelemesi menüsünden bir motor ve model seçin."
     },
     "aiAssistant": {
       "title": "Yapay zekâ asistanı",


### PR DESCRIPTION
`LanguageFile_IsValidJson(Turkish.json)` fails on main — a trailing comma after the `aiReview.setupHint` entry slipped in with 03e2398f9 (#12356). One-character fix; all 27 language JSON tests pass again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)