### PR TITLE
Offer re-download when speech-to-text engine exe has gone missing

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -2203,18 +2203,51 @@ public partial class SpeechToTextViewModel : ObservableObject
             if (!startOk)
             {
                 IsTranscribeEnabled = true;
-                Dispatcher.UIThread.Invoke(async () =>
-                {
-                    if (string.IsNullOrEmpty(_error))
-                    {
-                        await MessageBox.Show(Window!, "Unknown error", "Unable to start Whisper!");
-                    }
-                    else
-                    {
-                        await MessageBox.Show(Window!, "Error", "Unable to start Whisper: " + _error);
-                    }
-                });
+                ProgressOpacity = 0;
+                Dispatcher.UIThread.Invoke(async () => { await ShowUnableToStartEngineErrorAsync(); });
             }
+        }
+    }
+
+    /// <summary>
+    /// Shown when the speech-to-text engine process could not be started. If the engine's
+    /// executable has disappeared after the install check that ran when transcribe was
+    /// clicked - typically quarantined by antivirus software (#12220) - offer to
+    /// re-download the engine instead of only echoing the raw exception message.
+    /// </summary>
+    private async Task ShowUnableToStartEngineErrorAsync()
+    {
+        var error = _error;
+        _error = string.Empty;
+
+        var engine = GetEffectiveSelectedEngine();
+        if (engine.CanBeDownloaded() && !engine.IsEngineInstalled())
+        {
+            var answer = await MessageBox.Show(
+                Window!,
+                $"Unable to start {engine.Name}",
+                $"The {engine.Name} program file was not found:{Environment.NewLine}" +
+                $"{engine.GetExecutable()}{Environment.NewLine}{Environment.NewLine}" +
+                $"It may have been deleted or quarantined by antivirus software - if so, please restore it or add an exclusion for the folder.{Environment.NewLine}{Environment.NewLine}" +
+                $"Do you want to re-download \"{engine.Name}\"?",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Question);
+
+            if (answer == MessageBoxResult.Yes)
+            {
+                await ReDownloadWhisperEngine();
+            }
+
+            return;
+        }
+
+        if (string.IsNullOrEmpty(error))
+        {
+            await MessageBox.Show(Window!, "Unknown error", $"Unable to start {engine.Name}!");
+        }
+        else
+        {
+            await MessageBox.Show(Window!, "Error", $"Unable to start {engine.Name}: {error}");
         }
     }
 
@@ -3258,15 +3291,9 @@ public partial class SpeechToTextViewModel : ObservableObject
         var startGenerateAudioFileOk = GenerateAudioFile(_videoFileName, _audioTrackNumber);
         if (!startGenerateAudioFileOk)
         {
-            if (string.IsNullOrEmpty(_error))
-            {
-                await MessageBox.Show(Window!, "Unknown error", "Unable to start Whisper!");
-            }
-            else
-            {
-                await MessageBox.Show(Window!, "Error", "Unable to start Whisper: " + _error);
-            }
-            _error = string.Empty;
+            IsTranscribeEnabled = true;
+            ProgressOpacity = 0;
+            await ShowUnableToStartEngineErrorAsync();
         }
     }
 
@@ -3383,6 +3410,7 @@ public partial class SpeechToTextViewModel : ObservableObject
         catch (Exception e)
         {
             _error = e.Message;
+            SeLogger.Error(e, $"Unable to start speech-to-text engine \"{engine.Name}\"");
             return false;
         }
         _sw = Stopwatch.StartNew();


### PR DESCRIPTION
Fixes the dead-end error from #12220: *"Unable to start Whisper: An error occurred trying to start process '...\SpeechToText\Cpp\whisper-cli.exe' ... The system cannot find the file specified."*

### Analysis

The engine install check (`IsEngineInstalled()`) runs when the user clicks Transcribe, but the engine process only starts **after** audio extraction finishes — minutes later for long files. If the executable disappears in that window (typically quarantined by antivirus, which likes freshly downloaded unsigned binaries — see pigers' comment on the issue), `Process.Start` throws and the user just got the raw .NET exception text with no way forward.

### Changes

- Both "unable to start" paths now share one handler that re-checks the engine install state after a start failure. When the executable is gone (and the engine is downloadable), the dialog names the missing file, mentions the likely antivirus cause and suggests an exclusion, and offers to re-download the engine (Yes routes into the existing `ReDownloadWhisperEngine()` flow, including the CrispASR/Qwen3 variant pickers).
- The generic fallback message now names the actual engine instead of always saying "Whisper".
- The transcribe button is re-enabled and the progress bar hidden on start failure in the non-timer path (previously the button stayed disabled).
- The start exception is logged via `SeLogger` so error.log has the details.

Online engines (`CanBeDownloaded() == false`) keep the generic message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)