### PR TITLE
Rename "FCP/png" export to "Final Cut Pro + image"

### DIFF
--- a/src/libuilogic/Export/ExportHandlerFcp.cs
+++ b/src/libuilogic/Export/ExportHandlerFcp.cs
@@ -10,7 +10,7 @@ public class ExportHandlerFcp : IExportHandler
     public ExportImageType ExportImageType => ExportImageType.Fcp;
     public string Extension => "";
     public bool UseFileName => false;
-    public string Title => string.Format("Export to {0}", "FCP/image");
+    public string Title => string.Format("Export to {0}", "Final Cut Pro + image");
     public double FrameRate { get; set; } = 25.0;
 
     private string _folderName = string.Empty;

--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -251,7 +251,7 @@ public static class InitMenu
                         },
                         new MenuItem
                         {
-                            Header = "FCP/png",
+                            Header = "Final Cut Pro + image",
                             Command = vm.ExportFcpPngCommand,
                         },
                         new MenuItem

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -239,7 +239,7 @@ public static class InitNativeMacMenu
         exportItems.Items.Add(Item(lExport.TitleExportDCinemaSmpte2014Png, v => v.ExportDCinemaSmpte2014PngCommand));
         exportItems.Items.Add(Item(Ebu.NameOfFormat, v => v.ExportEbuStlCommand));
         exportItems.Items.Add(Item("DOST/png", v => v.ExportDostPngCommand));
-        exportItems.Items.Add(Item("FCP/png", v => v.ExportFcpPngCommand));
+        exportItems.Items.Add(Item("Final Cut Pro + image", v => v.ExportFcpPngCommand));
         exportItems.Items.Add(Item(Se.Language.General.ImagesWithTimeCode, v => v.ExportImagesWithTimeCodeCommand));
         exportItems.Items.Add(Item(Pac.NameOfFormat, v => v.ExportPacCommand));
         exportItems.Items.Add(Item(new PacUnicode().Name, v => v.ExportPacUnicodeCommand));

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -206,7 +206,7 @@ public class BinaryEditWindow : Window
                         },
                         new MenuItem
                         {
-                            Header = "FCP/png",
+                            Header = "Final Cut Pro + image",
                             Command = vm.ExportFcpPngCommand,
                         },
                         new MenuItem

--- a/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
+++ b/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
@@ -19,7 +19,7 @@ public static class InitNativeMacMenuBinaryEdit
         Add(exportMenu, Se.Language.General.BluRaySup, vm.ExportBluRaySupCommand);
         Add(exportMenu, Se.Language.General.BdnXml, vm.ExportBdnXmlCommand);
         Add(exportMenu, "DOST/png", vm.ExportDostPngCommand);
-        Add(exportMenu, "FCP/png", vm.ExportFcpPngCommand);
+        Add(exportMenu, "Final Cut Pro + image", vm.ExportFcpPngCommand);
         Add(exportMenu, Se.Language.General.ImagesWithHtmlIndex, vm.ExportHtmlIndexCommand);
         Add(exportMenu, Se.Language.General.ImagesWithTimeCode, vm.ExportImagesWithTimeCodeCommand);
         Add(exportMenu, Se.Language.File.Export.TitleExportVobSub, vm.ExportVobSubCommand);


### PR DESCRIPTION
Addresses discussion #12362 — a user upgrading from SE 4 could not find "Final Cut Pro + image" in SE 5.

### Analysis

The export was never missing: SE 5 has it as File → Export → **"FCP/png"** (`ExportHandlerFcp`, producing the same xmeml XML + png files as SE 4's `ExportPngXml` in FCP mode). It was just labeled differently than SE 4's "Final Cut Pro + image...", so users looking for the SE 4 name concluded it was gone.

### Changes

Renames the label to "Final Cut Pro + image" in:
- main window menu (`InitMenu.cs`) and native macOS menu (`InitNativeMacMenu.cs`)
- binary edit window menu (`BinaryEditWindow.cs`) and its native macOS menu (`InitNativeMacMenuBinaryEdit.cs`)
- the export window title (`ExportHandlerFcp.Title`, was "Export to FCP/image")

No functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)