### PR TITLE
Add CrispEmbed as an OCR engine with multiple backends

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -248,6 +248,7 @@ public static class DependencyInjectionExtensions
         collection.AddHttpClient<ILibMpvDownloadService, LibMpvDownloadService>();
         collection.AddHttpClient<ILibVlcDownloadService, LibVlcDownloadService>();
         collection.AddHttpClient<IPaddleOcrDownloadService, PaddleOcrDownloadService>();
+        collection.AddHttpClient<ICrispEmbedDownloadService, CrispEmbedDownloadService>();
         collection.AddHttpClient<ISpellCheckDictionaryDownloadService, SpellCheckDictionaryDownloadService>();
         collection.AddHttpClient<ITesseractDownloadService, TesseractDownloadService>();
         collection.AddHttpClient<IWhisperDownloadService, WhisperDownloadService>();
@@ -353,6 +354,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<DownloadLibVlcViewModel>();
         collection.AddTransient<DownloadLlamaCppViewModel>();
         collection.AddTransient<DownloadPaddleOcrViewModel>();
+        collection.AddTransient<DownloadCrispEmbedViewModel>();
         collection.AddTransient<DownloadTesseractModelViewModel>();
         collection.AddTransient<DownloadTesseractViewModel>();
         collection.AddTransient<DownloadTtsViewModel>();

--- a/src/ui/Features/Ocr/Download/DownloadCrispEmbedViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadCrispEmbedViewModel.cs
@@ -1,0 +1,333 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Ocr.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Compression;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Timers;
+using Timer = System.Timers.Timer;
+
+namespace Nikse.SubtitleEdit.Features.Ocr.Download;
+
+/// <summary>
+/// Downloads either the CrispEmbed engine binaries (release archive, variant-aware, with an
+/// .installed.sha256 sidecar for update tracking) or a single GGUF model (streamed to disk).
+/// </summary>
+public partial class DownloadCrispEmbedViewModel : ObservableObject
+{
+    [ObservableProperty] private string _titleText;
+    [ObservableProperty] private double _progressValue;
+    [ObservableProperty] private string _progressText;
+    [ObservableProperty] private string _error;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; internal set; }
+
+    private readonly ICrispEmbedDownloadService _downloadService;
+    private readonly IZipUnpacker _zipUnpacker;
+    private System.Threading.Tasks.Task? _downloadTask;
+    private readonly Timer _timer;
+    private bool _done;
+    private readonly CancellationTokenSource _cancellationTokenSource;
+    private readonly MemoryStream _downloadStream;
+
+    private bool _isModelDownload;
+    private string _engineVariant = string.Empty;
+    private CrispEmbedModel? _model;
+    private string _modelTempFileName = string.Empty;
+    private string _modelFileName = string.Empty;
+
+    public DownloadCrispEmbedViewModel(ICrispEmbedDownloadService downloadService, IZipUnpacker zipUnpacker)
+    {
+        _downloadService = downloadService;
+        _zipUnpacker = zipUnpacker;
+
+        _cancellationTokenSource = new CancellationTokenSource();
+        _downloadStream = new MemoryStream();
+
+        TitleText = string.Format(Se.Language.General.DownloadingX, CrispEmbedEngine.StaticName);
+        ProgressText = Se.Language.General.StartingDotDotDot;
+        Error = string.Empty;
+
+        _timer = new Timer(500);
+        _timer.Elapsed += OnTimerOnElapsed;
+    }
+
+    private readonly Lock _lockObj = new();
+
+    /// <summary>
+    /// Engine download. <paramref name="variant"/>: on Windows "cpu", "vulkan", or "cuda"
+    /// (defaults to vulkan); on Linux x86_64 "cuda" or empty for the CPU build; ignored on
+    /// macOS / Linux ARM64.
+    /// </summary>
+    public void InitializeEngine(string variant)
+    {
+        _isModelDownload = false;
+        _engineVariant = variant;
+        var displayName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || variant == "cuda"
+            ? $"{CrispEmbedEngine.StaticName} {_engineVariant}".TrimEnd()
+            : CrispEmbedEngine.StaticName;
+        TitleText = string.Format(Se.Language.General.DownloadingX, displayName);
+        StartDownload();
+    }
+
+    public void InitializeModel(CrispEmbedBackend backend, CrispEmbedModel model)
+    {
+        _isModelDownload = true;
+        _model = model;
+        _modelFileName = backend.GetModelPath(model);
+        _modelTempFileName = _modelFileName + ".$tmp$";
+        TitleText = string.Format(Se.Language.General.DownloadingX, model.Name);
+        StartDownload();
+    }
+
+    private void OnTimerOnElapsed(object? sender, ElapsedEventArgs args)
+    {
+        lock (_lockObj)
+        {
+            if (_done)
+            {
+                return;
+            }
+
+            if (_downloadTask is { IsCompletedSuccessfully: true })
+            {
+                _timer.Stop();
+                _done = true;
+
+                try
+                {
+                    if (_isModelDownload)
+                    {
+                        FinishModelDownload();
+                    }
+                    else
+                    {
+                        FinishEngineDownload();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // e.g. a truncated archive that still had Length > 0 - without this the
+                    // Timer would swallow the exception and leave the dialog stuck open.
+                    ProgressText = _isModelDownload ? "Download failed" : "Unpacking failed";
+                    Error = ex.Message;
+                    Se.LogError(ex, "CrispEmbed download post-processing failed");
+                }
+
+                return;
+            }
+
+            if (_downloadTask is { IsFaulted: true })
+            {
+                _timer.Stop();
+                _done = true;
+                DeleteTempModelFile();
+                var ex = _downloadTask.Exception?.InnerException ?? _downloadTask.Exception;
+                if (ex is OperationCanceledException)
+                {
+                    ProgressText = "Download canceled";
+                    Close();
+                }
+                else
+                {
+                    ProgressText = "Download failed";
+                    Error = ex?.Message ?? "Unknown error";
+                }
+            }
+        }
+    }
+
+    private void FinishEngineDownload()
+    {
+        if (_downloadStream.Length == 0)
+        {
+            ProgressText = "Download failed";
+            Error = "No data received";
+            return;
+        }
+
+        var folder = CrispEmbedEngine.GetAndCreateFolder();
+        DownloadHashManager.WriteSidecar(folder, DownloadHashManager.ResolveCrispEmbedKey(_engineVariant), _downloadStream);
+        RemoveStaleBinaries(folder);
+
+        TitleText = string.Format(Se.Language.General.UnpackingX, CrispEmbedEngine.StaticName);
+        // The CrispEmbed release archives have no wrapping top-level folder (binaries sit at
+        // the archive root), so there is no skip-folder level to strip - unlike CrispASR.
+        _downloadStream.Position = 0;
+        _zipUnpacker.UnpackZipStream(_downloadStream, folder, string.Empty, false, new List<string>(), null);
+        _downloadStream.Dispose();
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            foreach (var name in CrispEmbedEngine.BinaryBaseNames)
+            {
+                var path = Path.Combine(folder, name);
+                if (File.Exists(path))
+                {
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                    {
+                        MacHelper.MakeExecutable(path);
+                    }
+                    else
+                    {
+                        LinuxHelper.MakeExecutable(path);
+                    }
+                }
+            }
+        }
+
+        OkPressed = true;
+        Close();
+    }
+
+    private void FinishModelDownload()
+    {
+        if (!File.Exists(_modelTempFileName) || new FileInfo(_modelTempFileName).Length == 0)
+        {
+            ProgressText = "Download failed";
+            Error = "No data received";
+            return;
+        }
+
+        if (File.Exists(_modelFileName))
+        {
+            File.Delete(_modelFileName);
+        }
+
+        File.Move(_modelTempFileName, _modelFileName);
+        OkPressed = true;
+        Close();
+    }
+
+    /// <summary>
+    /// Removes leftover binaries from a previous CrispEmbed install before extracting the new
+    /// archive, so switching variants (e.g. Vulkan → CPU) cannot leave orphan ggml DLLs that
+    /// the new executable would load by mistake. Only top-level executables and shared
+    /// libraries are removed; the models/ subfolder and the sidecar are left in place.
+    /// </summary>
+    private static void RemoveStaleBinaries(string folder)
+    {
+        if (!Directory.Exists(folder))
+        {
+            return;
+        }
+
+        try
+        {
+            foreach (var file in Directory.GetFiles(folder, "*", SearchOption.TopDirectoryOnly))
+            {
+                var ext = Path.GetExtension(file).ToLowerInvariant();
+                var name = Path.GetFileName(file);
+                var isBinary = ext is ".exe" or ".dll" or ".so" or ".dylib"
+                    || (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                        && Array.IndexOf(CrispEmbedEngine.BinaryBaseNames, name) >= 0);
+                if (!isBinary)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    File.Delete(file);
+                }
+                catch
+                {
+                    // best-effort — a locked file will be overwritten by the unpack step
+                }
+            }
+        }
+        catch
+        {
+            // ignore — cleanup is best-effort
+        }
+    }
+
+    private void StartDownload()
+    {
+        var downloadProgress = new Progress<float>(number =>
+        {
+            var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+            var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+            ProgressValue = percentage;
+            ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+        });
+
+        if (_isModelDownload && _model != null)
+        {
+            _downloadTask = _downloadService.DownloadModel(_model.Url, _modelTempFileName, downloadProgress, _cancellationTokenSource.Token);
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            _downloadTask = _engineVariant switch
+            {
+                "cuda" => _downloadService.DownloadEngineWindowsCuda(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
+                "cpu" => _downloadService.DownloadEngineWindowsCpu(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
+                _ => _downloadService.DownloadEngineWindowsVulkan(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
+            };
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                 && _engineVariant == "cuda"
+                 && RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
+        {
+            _downloadTask = _downloadService.DownloadEngineLinuxCuda(_downloadStream, downloadProgress, _cancellationTokenSource.Token);
+        }
+        else
+        {
+            _downloadTask = _downloadService.DownloadEngine(_downloadStream, downloadProgress, _cancellationTokenSource.Token);
+        }
+
+        _timer.Start();
+    }
+
+    private void Close()
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            Window?.Close();
+        });
+    }
+
+    [RelayCommand]
+    private void CommandCancel()
+    {
+        _cancellationTokenSource?.Cancel();
+        _done = true;
+        _timer.Stop();
+        DeleteTempModelFile();
+        Close();
+    }
+
+    private void DeleteTempModelFile()
+    {
+        try
+        {
+            if (!string.IsNullOrEmpty(_modelTempFileName) && File.Exists(_modelTempFileName))
+            {
+                File.Delete(_modelTempFileName);
+            }
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            CommandCancel();
+        }
+    }
+}

--- a/src/ui/Features/Ocr/Download/DownloadCrispEmbedWindow.cs
+++ b/src/ui/Features/Ocr/Download/DownloadCrispEmbedWindow.cs
@@ -1,0 +1,66 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+
+namespace Nikse.SubtitleEdit.Features.Ocr.Download;
+
+public class DownloadCrispEmbedWindow : Window
+{
+    public DownloadCrispEmbedWindow(DownloadCrispEmbedViewModel vm)
+    {
+        vm.Window = this;
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = "Downloading CrispEmbed";
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        WindowStartupLocation = WindowStartupLocation.CenterOwner;
+
+        DataContext = vm;
+
+        var titleText = new TextBlock
+        {
+            FontSize = 20,
+            FontWeight = FontWeight.Bold,
+        }.WithBindText(vm, nameof(vm.TitleText));
+
+        var progressBar = UiUtil.MakeProgressBar();
+        progressBar.MinWidth = 400;
+        progressBar.Bind(ProgressBar.ValueProperty, new Binding(nameof(vm.ProgressValue)));
+
+        var statusText = new TextBlock();
+        statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.ProgressText)));
+
+        var errorText = new TextBlock
+        {
+            Foreground = Brushes.Red,
+            TextWrapping = TextWrapping.Wrap,
+            MaxWidth = 400,
+        };
+        errorText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.Error)));
+
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CommandCancelCommand);
+        var buttonBar = UiUtil.MakeButtonBar(buttonCancel);
+
+        Content = new StackPanel
+        {
+            Spacing = 8,
+            Margin = UiUtil.MakeWindowMargin(),
+            Children =
+            {
+                titleText,
+                progressBar,
+                statusText,
+                errorText,
+                buttonBar,
+            }
+        };
+
+        Loaded += delegate
+        {
+            buttonCancel.Focus(); // hack to make OnKeyDown work
+        };
+        KeyDown += (_, e) => vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Ocr/Engines/CrispEmbedBackend.cs
+++ b/src/ui/Features/Ocr/Engines/CrispEmbedBackend.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace Nikse.SubtitleEdit.Features.Ocr.Engines;
+
+/// <summary>
+/// One OCR backend (model family) for the CrispEmbed engine, e.g. GLM-OCR. All backends run
+/// through the same crispembed-server executable; only the GGUF model differs.
+/// </summary>
+public class CrispEmbedBackend
+{
+    public string Name { get; set; } = string.Empty;
+    public List<CrispEmbedModel> Models { get; set; } = new();
+
+    public string GetModelPath(CrispEmbedModel model)
+    {
+        return Path.Combine(CrispEmbedEngine.GetAndCreateModelFolder(), model.Name);
+    }
+
+    public bool IsModelInstalled(CrispEmbedModel model)
+    {
+        var modelFile = GetModelPath(model);
+        if (!File.Exists(modelFile))
+        {
+            return false;
+        }
+
+        return new FileInfo(modelFile).Length > 10_000_000;
+    }
+
+    public override string ToString()
+    {
+        return Name;
+    }
+}

--- a/src/ui/Features/Ocr/Engines/CrispEmbedEngine.cs
+++ b/src/ui/Features/Ocr/Engines/CrispEmbedEngine.cs
@@ -166,6 +166,25 @@ public static class CrispEmbedEngine
                     },
                 },
             },
+            new()
+            {
+                Name = "Qwen3-VL-2B",
+                Models = new List<CrispEmbedModel>
+                {
+                    new()
+                    {
+                        Name = "qwen3-vl-2b-q4_k.gguf",
+                        Size = "1.59 GB",
+                        Url = "https://huggingface.co/cstr/qwen3-vl-2b-crispembed-gguf/resolve/main/qwen3-vl-2b-q4_k.gguf",
+                    },
+                    new()
+                    {
+                        Name = "qwen3-vl-2b-q8_0.gguf",
+                        Size = "2.29 GB",
+                        Url = "https://huggingface.co/cstr/qwen3-vl-2b-crispembed-gguf/resolve/main/qwen3-vl-2b-q8_0.gguf",
+                    },
+                },
+            },
         };
     }
 }

--- a/src/ui/Features/Ocr/Engines/CrispEmbedEngine.cs
+++ b/src/ui/Features/Ocr/Engines/CrispEmbedEngine.cs
@@ -147,25 +147,9 @@ public static class CrispEmbedEngine
                     },
                 },
             },
-            new()
-            {
-                Name = "PaddleOCR-VL",
-                Models = new List<CrispEmbedModel>
-                {
-                    new()
-                    {
-                        Name = "paddleocr-vl-0.9b-q4_k.gguf",
-                        Size = "1.3 GB",
-                        Url = "https://huggingface.co/cstr/paddleocr-vl-0.9b-GGUF/resolve/main/paddleocr-vl-0.9b-q4_k.gguf",
-                    },
-                    new()
-                    {
-                        Name = "paddleocr-vl-0.9b-q8_0.gguf",
-                        Size = "1.48 GB",
-                        Url = "https://huggingface.co/cstr/paddleocr-vl-0.9b-GGUF/resolve/main/paddleocr-vl-0.9b-q8_0.gguf",
-                    },
-                },
-            },
+            // PaddleOCR-VL (109 languages) omitted for now: in CrispEmbed v0.14.0 both the
+            // q4_k and q8_0 quants truncate or hallucinate on subtitle-style single-line
+            // images via both the server and CLI single-model paths - verified 2026-07-11.
             new()
             {
                 Name = "Qwen3-VL-2B",

--- a/src/ui/Features/Ocr/Engines/CrispEmbedEngine.cs
+++ b/src/ui/Features/Ocr/Engines/CrispEmbedEngine.cs
@@ -1,0 +1,171 @@
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Nikse.SubtitleEdit.Features.Ocr.Engines;
+
+/// <summary>
+/// Shared install/paths/backends for the CrispEmbed OCR engine
+/// (https://github.com/CrispStrobe/CrispEmbed) - a local ggml-based OCR engine with
+/// multiple model backends, same family as CrispASR. The engine binaries live in
+/// &lt;OcrFolder&gt;/CrispEmbed and the GGUF models in a "models" subfolder; OCR runs
+/// through crispembed-server so the model is only loaded once per OCR session.
+/// </summary>
+public static class CrispEmbedEngine
+{
+    public const string StaticName = "CrispEmbed";
+    public const string Url = "https://github.com/CrispStrobe/CrispEmbed";
+
+    public static bool CanBeDownloaded()
+    {
+        if (OperatingSystem.IsWindows() || OperatingSystem.IsLinux())
+        {
+            return true;
+        }
+
+        // Only an arm64 build is published for macOS.
+        return OperatingSystem.IsMacOS() && RuntimeInformation.ProcessArchitecture == Architecture.Arm64;
+    }
+
+    /// <summary>
+    /// Like CrispASR, the Windows variants differ wildly in size (CPU ~5 MB, Vulkan ~24 MB,
+    /// CUDA ~691 MB) and the variant is picked at download time, so show a range.
+    /// </summary>
+    public static string DownloadSizeText
+    {
+        get
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return "~5 MB – 691 MB";
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return "~8 MB";
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return "~6 MB";
+            }
+
+            return string.Empty;
+        }
+    }
+
+    public static string GetAndCreateFolder()
+    {
+        var folder = Se.CrispEmbedFolder;
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public static string GetAndCreateModelFolder()
+    {
+        var folder = Path.Combine(GetAndCreateFolder(), "models");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    /// <summary>
+    /// Base names (no .exe suffix) of the executables shipped in a CrispEmbed release archive.
+    /// Shared by the post-download chmod loop and the stale-binary cleanup so the lists cannot
+    /// drift apart.
+    /// </summary>
+    public static readonly string[] BinaryBaseNames = { "crispembed-server", "crispembed", "crispembed-quantize" };
+
+    public static string GetServerExecutableFileName()
+    {
+        return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "crispembed-server.exe" : "crispembed-server";
+    }
+
+    public static string GetServerExecutable()
+    {
+        return Path.Combine(GetAndCreateFolder(), GetServerExecutableFileName());
+    }
+
+    public static bool IsEngineInstalled()
+    {
+        return File.Exists(GetServerExecutable());
+    }
+
+    /// <summary>
+    /// The OCR backends offered in Subtitle Edit - the three CrispEmbed models best suited
+    /// for subtitle OCR. Model URLs/sizes match cstr's HuggingFace repos as referenced by
+    /// the CrispEmbed v0.14.0 model registry.
+    /// </summary>
+    public static List<CrispEmbedBackend> GetBackends()
+    {
+        return new List<CrispEmbedBackend>
+        {
+            new()
+            {
+                Name = "GLM-OCR",
+                Models = new List<CrispEmbedModel>
+                {
+                    new()
+                    {
+                        Name = "glm-ocr-q4_k.gguf",
+                        Size = "889 MB",
+                        Url = "https://huggingface.co/cstr/glm-ocr-crispembed-GGUF/resolve/main/glm-ocr-q4_k.gguf",
+                    },
+                    new()
+                    {
+                        Name = "glm-ocr-q8_0.gguf",
+                        Size = "1.18 GB",
+                        Url = "https://huggingface.co/cstr/glm-ocr-crispembed-GGUF/resolve/main/glm-ocr-q8_0.gguf",
+                    },
+                },
+            },
+            new()
+            {
+                Name = "GOT-OCR2",
+                Models = new List<CrispEmbedModel>
+                {
+                    new()
+                    {
+                        Name = "got-ocr2-q4_k.gguf",
+                        Size = "445 MB",
+                        Url = "https://huggingface.co/cstr/got-ocr2-crispembed-GGUF/resolve/main/got-ocr2-q4_k.gguf",
+                    },
+                    new()
+                    {
+                        Name = "got-ocr2-q8_0.gguf",
+                        Size = "600 MB",
+                        Url = "https://huggingface.co/cstr/got-ocr2-crispembed-GGUF/resolve/main/got-ocr2-q8_0.gguf",
+                    },
+                },
+            },
+            new()
+            {
+                Name = "PaddleOCR-VL",
+                Models = new List<CrispEmbedModel>
+                {
+                    new()
+                    {
+                        Name = "paddleocr-vl-0.9b-q4_k.gguf",
+                        Size = "1.3 GB",
+                        Url = "https://huggingface.co/cstr/paddleocr-vl-0.9b-GGUF/resolve/main/paddleocr-vl-0.9b-q4_k.gguf",
+                    },
+                    new()
+                    {
+                        Name = "paddleocr-vl-0.9b-q8_0.gguf",
+                        Size = "1.48 GB",
+                        Url = "https://huggingface.co/cstr/paddleocr-vl-0.9b-GGUF/resolve/main/paddleocr-vl-0.9b-q8_0.gguf",
+                    },
+                },
+            },
+        };
+    }
+}

--- a/src/ui/Features/Ocr/Engines/CrispEmbedModel.cs
+++ b/src/ui/Features/Ocr/Engines/CrispEmbedModel.cs
@@ -1,0 +1,16 @@
+namespace Nikse.SubtitleEdit.Features.Ocr.Engines;
+
+/// <summary>
+/// A downloadable GGUF model (one quantization) for a CrispEmbed OCR backend.
+/// </summary>
+public class CrispEmbedModel
+{
+    public string Name { get; set; } = string.Empty;
+    public string Size { get; set; } = string.Empty;
+    public string Url { get; set; } = string.Empty;
+
+    public override string ToString()
+    {
+        return Name;
+    }
+}

--- a/src/ui/Features/Ocr/Engines/CrispEmbedModelDisplay.cs
+++ b/src/ui/Features/Ocr/Engines/CrispEmbedModelDisplay.cs
@@ -1,0 +1,16 @@
+namespace Nikse.SubtitleEdit.Features.Ocr.Engines;
+
+/// <summary>
+/// Combo-box row for a CrispEmbed model: keeps the backend alongside the model so the
+/// item template can show the install-status dot.
+/// </summary>
+public class CrispEmbedModelDisplay
+{
+    public required CrispEmbedBackend Backend { get; init; }
+    public required CrispEmbedModel Model { get; init; }
+
+    public override string ToString()
+    {
+        return Model.Name;
+    }
+}

--- a/src/ui/Features/Ocr/Engines/CrispEmbedOcr.cs
+++ b/src/ui/Features/Ocr/Engines/CrispEmbedOcr.cs
@@ -1,0 +1,249 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using SkiaSharp;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Ocr.Engines;
+
+/// <summary>
+/// Runs OCR through a local crispembed-server instance so the GGUF model is loaded once per
+/// OCR session instead of once per subtitle image. The server only accepts image file paths,
+/// so each bitmap is written to a temp PNG (flattened onto an opaque background - subtitle
+/// bitmaps are typically white text on transparency) and posted to /ocr/model.
+/// </summary>
+public class CrispEmbedOcr : IDisposable
+{
+    private readonly HttpClient _httpClient;
+    private Process? _serverProcess;
+    private int _port;
+
+    public string Error { get; set; }
+
+    public CrispEmbedOcr(int timeoutMinutes = 5)
+    {
+        Error = string.Empty;
+        _httpClient = new HttpClient();
+        _httpClient.Timeout = TimeSpan.FromMinutes(Math.Max(1, timeoutMinutes));
+    }
+
+    public async Task<bool> StartServerAsync(string serverExecutable, string modelFileName, CancellationToken cancellationToken)
+    {
+        if (!File.Exists(serverExecutable))
+        {
+            Error = $"CrispEmbed server not found: {serverExecutable}";
+            return false;
+        }
+
+        if (!File.Exists(modelFileName))
+        {
+            Error = $"CrispEmbed model not found: {modelFileName}";
+            return false;
+        }
+
+        _port = GetFreePort();
+        var arguments = $"--ocr \"{modelFileName}\" --host 127.0.0.1 --port {_port}";
+        Se.WriteToolsLog($"{serverExecutable} {arguments}");
+
+        try
+        {
+            _serverProcess = new Process
+            {
+                StartInfo = new ProcessStartInfo(serverExecutable, arguments)
+                {
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    CreateNoWindow = true,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    WorkingDirectory = Path.GetDirectoryName(serverExecutable),
+                },
+            };
+
+            _serverProcess.OutputDataReceived += (_, e) => LogServerOutput(e.Data);
+            _serverProcess.ErrorDataReceived += (_, e) => LogServerOutput(e.Data);
+            _serverProcess.Start();
+            _serverProcess.BeginOutputReadLine();
+            _serverProcess.BeginErrorReadLine();
+        }
+        catch (Exception ex)
+        {
+            // e.g. Win32Exception when the binary is missing the executable bit, quarantined,
+            // or the wrong architecture - surface it instead of dying as an unobserved task.
+            Error = ex.Message;
+            SeLogger.Error(ex, "Failed to start CrispEmbed server");
+            return false;
+        }
+
+        // Model load happens before the server starts listening, so poll /health until it
+        // answers. Large models can take a while to load from a cold disk cache.
+        var healthUrl = $"http://127.0.0.1:{_port}/health";
+        var timeout = DateTime.UtcNow.AddMinutes(5);
+        while (DateTime.UtcNow < timeout)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (_serverProcess.HasExited)
+            {
+                Error = $"CrispEmbed server exited with code {_serverProcess.ExitCode}";
+                SeLogger.Error("CrispEmbed server exited during startup: " + Error);
+                return false;
+            }
+
+            try
+            {
+                using var response = await _httpClient.GetAsync(healthUrl, cancellationToken);
+                if (response.IsSuccessStatusCode)
+                {
+                    return true;
+                }
+            }
+            catch (HttpRequestException)
+            {
+                // not listening yet
+            }
+            catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                // request timeout while the model loads - keep polling
+            }
+
+            await Task.Delay(250, cancellationToken);
+        }
+
+        Error = "CrispEmbed server did not start in time";
+        return false;
+    }
+
+    public async Task<string> Ocr(SKBitmap bitmap, CancellationToken cancellationToken)
+    {
+        var tempFileName = Path.Combine(Path.GetTempPath(), $"se-crispembed-{Guid.NewGuid()}.png");
+        try
+        {
+            using (var flattened = FlattenImage(bitmap))
+            {
+                await File.WriteAllBytesAsync(tempFileName, flattened.ToPngArray(), cancellationToken);
+            }
+
+            // The server reads the image from disk, so only the path goes over the wire. The
+            // server's request parser does not un-escape JSON strings, so send forward slashes
+            // (fine with Windows file APIs) to keep the serialized path escape-free.
+            var input = JsonSerializer.Serialize(new { image = tempFileName.Replace('\\', '/') });
+            var content = new StringContent(input, Encoding.UTF8);
+            content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+            var result = await _httpClient.PostAsync($"http://127.0.0.1:{_port}/ocr/model", content, cancellationToken);
+            var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
+            var json = Encoding.UTF8.GetString(bytes).Trim();
+            if (!result.IsSuccessStatusCode)
+            {
+                Error = json;
+                SeLogger.Error("Error calling CrispEmbed for OCR: Status code=" + result.StatusCode + Environment.NewLine + json);
+                return string.Empty;
+            }
+
+            // The recognized text is returned under the legacy "latex" key for all engines
+            // (math and document alike); accept "text" too in case upstream renames it.
+            using var document = JsonDocument.Parse(json);
+            var resultText = document.RootElement.TryGetProperty("latex", out var latexElement)
+                ? latexElement.GetString() ?? string.Empty
+                : document.RootElement.TryGetProperty("text", out var textElement)
+                    ? textElement.GetString() ?? string.Empty
+                    : string.Empty;
+
+            return resultText.Replace("\r\n", "\n").Replace("\n", Environment.NewLine).Trim();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException ex)
+        {
+            Error = "Request timed out";
+            SeLogger.Error(ex, "CrispEmbed OCR request timed out");
+            return string.Empty;
+        }
+        catch (Exception ex)
+        {
+            SeLogger.Error(ex, "Error calling CrispEmbed for OCR");
+            return string.Empty;
+        }
+        finally
+        {
+            try
+            {
+                File.Delete(tempFileName);
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+    }
+
+    /// <summary>
+    /// Draws the bitmap onto an opaque black background with a small margin. Subtitle bitmaps
+    /// are usually white/coloured glyphs on full transparency, which would otherwise be
+    /// flattened to an arbitrary background by the server's image loader.
+    /// </summary>
+    private static SKBitmap FlattenImage(SKBitmap source)
+    {
+        var margin = Math.Max(8, (int)(Math.Max(source.Width, source.Height) * 0.05));
+        var info = new SKImageInfo(source.Width + margin * 2, source.Height + margin * 2, SKColorType.Rgba8888, SKAlphaType.Opaque);
+        var flattened = new SKBitmap(info);
+        using var canvas = new SKCanvas(flattened);
+        canvas.Clear(SKColors.Black);
+        using (var image = SKImage.FromBitmap(source))
+        {
+            var destRect = new SKRect(margin, margin, margin + source.Width, margin + source.Height);
+            var sampling = new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.None);
+            canvas.DrawImage(image, destRect, sampling, null);
+        }
+
+        canvas.Flush();
+        return flattened;
+    }
+
+    private static void LogServerOutput(string? line)
+    {
+        if (!string.IsNullOrWhiteSpace(line))
+        {
+            Se.WriteToolsLog("crispembed-server: " + line);
+        }
+    }
+
+    private static int GetFreePort()
+    {
+        using var listener = new TcpListener(System.Net.IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (_serverProcess is { HasExited: false })
+            {
+                _serverProcess.Kill(entireProcessTree: true);
+            }
+
+            _serverProcess?.Dispose();
+        }
+        catch
+        {
+            // ignore
+        }
+
+        _httpClient.Dispose();
+    }
+}

--- a/src/ui/Features/Ocr/Engines/OcrEngineItem.cs
+++ b/src/ui/Features/Ocr/Engines/OcrEngineItem.cs
@@ -42,6 +42,12 @@ public class OcrEngineItem
         list.Add(new("Paddle OCR Python", OcrEngineType.PaddleOcrPython, "Paddle OCR Python", "", ""));
         list.Add(new("Ollama", OcrEngineType.Ollama, "Ollama e.g. via llama-vision", "", "http://localhost:11434/api/chat"));
         list.Add(new("llama.cpp", OcrEngineType.LlamaCpp, "llama.cpp", "", "http://127.0.0.1:8080/v1/chat/completions"));
+
+        if (CrispEmbedEngine.CanBeDownloaded())
+        {
+            list.Add(new(CrispEmbedEngine.StaticName, OcrEngineType.CrispEmbed, "CrispEmbed is a local OCR engine with multiple model backends (free/open source)", "", ""));
+        }
+
         list.Add(new("Google Vision", OcrEngineType.GoogleVision, "Google Vision is a cloud-based OCR engine by Google", "", ""));
 
         //list.Add(new("Azure Vision", OcrEngineType.AzureVision, "Azure Vision is a cloud-based OCR engine by Microsoft", "", ""));

--- a/src/ui/Features/Ocr/Engines/OcrEngineType.cs
+++ b/src/ui/Features/Ocr/Engines/OcrEngineType.cs
@@ -16,4 +16,5 @@ public enum OcrEngineType
     Mistral,
     BinaryImageCompare,
     Glm,
+    CrispEmbed,
 }

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -38,6 +38,7 @@ using Nikse.SubtitleEdit.Features.Translate;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Dictionaries;
+using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.Logic.Ocr;
@@ -87,6 +88,10 @@ public partial class OcrViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<LlamaCppModelDisplay> _llamaCppOcrModels;
     [ObservableProperty] private LlamaCppModelDisplay? _selectedLlamaCppOcrModel;
     [ObservableProperty] private string _llamaCppOcrServerButtonText;
+    [ObservableProperty] private ObservableCollection<CrispEmbedBackend> _crispEmbedBackends;
+    [ObservableProperty] private CrispEmbedBackend? _selectedCrispEmbedBackend;
+    [ObservableProperty] private ObservableCollection<CrispEmbedModelDisplay> _crispEmbedModels;
+    [ObservableProperty] private CrispEmbedModelDisplay? _selectedCrispEmbedModel;
     [ObservableProperty] private string _progressText;
     [ObservableProperty] private double _progressValue;
     [ObservableProperty] private string _selectionStatus;
@@ -97,6 +102,7 @@ public partial class OcrViewModel : ObservableObject
     [ObservableProperty] private bool _isNOcrVisible;
     [ObservableProperty] private bool _isOllamaVisible;
     [ObservableProperty] private bool _isLlamaCppVisible;
+    [ObservableProperty] private bool _isCrispEmbedVisible;
     [ObservableProperty] private bool _isTesseractVisible;
     [ObservableProperty] private bool _isBinaryImageCompareVisible;
     [ObservableProperty] private bool _isPaddleOcrVisible;
@@ -147,6 +153,12 @@ public partial class OcrViewModel : ObservableObject
 
     public Window? Window { get; set; }
     public DataGrid SubtitleGrid { get; set; }
+
+    // Rebuild the combo row visuals after a download finishes so the install-status dots
+    // reflect the current on-disk state instead of the snapshot taken when first realised.
+    public Action? RefreshEngineCombo { get; set; }
+    public Action? RefreshCrispEmbedModelCombo { get; set; }
+
     public MatroskaTrackInfo? SelectedMatroskaTrack { get; set; }
     public bool OkPressed { get; private set; }
 
@@ -220,6 +232,8 @@ public partial class OcrViewModel : ObservableObject
         LlamaCppUrl = string.Empty;
         LlamaCppOcrModels = new ObservableCollection<LlamaCppModelDisplay>();
         LlamaCppOcrServerButtonText = "Start server";
+        CrispEmbedBackends = new ObservableCollection<CrispEmbedBackend>(CrispEmbedEngine.GetBackends());
+        CrispEmbedModels = new ObservableCollection<CrispEmbedModelDisplay>();
         TesseractDictionaryItems = new ObservableCollection<TesseractDictionary>();
         TesseractEngineModes = new ObservableCollection<TesseractEngineModeItem>(TesseractEngineModeItem.List());
         SelectedTesseractEngineMode = TesseractEngineModes.FirstOrDefault(p => p.Oem == Se.Settings.Ocr.TesseractEngineMode)
@@ -276,6 +290,7 @@ public partial class OcrViewModel : ObservableObject
             OllamaModel = ocr.OllamaModel;
             OllamaUrl = ocr.OllamaUrl;
             LlamaCppUrl = ocr.LlamaCppUrl;
+            SelectedCrispEmbedBackend = CrispEmbedBackends.FirstOrDefault(p => p.Name == ocr.CrispEmbedBackend) ?? CrispEmbedBackends.FirstOrDefault();
             SelectedOllamaLanguage = ocr.OllamaLanguage;
             GoogleVisionApiKey = ocr.GoogleVisionApiKey;
             MistralApiKey = ocr.MistralApiKey;
@@ -320,6 +335,8 @@ public partial class OcrViewModel : ObservableObject
         {
             ocr.LlamaCppOcrModel = LlamaCppServerManager.GetModelPath(SelectedLlamaCppOcrModel.Model.FileName);
         }
+        ocr.CrispEmbedBackend = SelectedCrispEmbedBackend?.Name ?? ocr.CrispEmbedBackend;
+        ocr.CrispEmbedModel = SelectedCrispEmbedModel?.Model.Name ?? ocr.CrispEmbedModel;
         ocr.GoogleVisionApiKey = GoogleVisionApiKey;
         ocr.MistralApiKey = MistralApiKey;
         ocr.GoogleVisionLanguage = SelectedGoogleVisionLanguage?.Code ?? "en";
@@ -1052,6 +1069,181 @@ public partial class OcrViewModel : ObservableObject
         }
 
         Se.Settings.Ocr.LlamaCppOcrModel = LlamaCppServerManager.GetModelPath(value.Model.FileName);
+    }
+
+    partial void OnSelectedCrispEmbedBackendChanged(CrispEmbedBackend? value)
+    {
+        CrispEmbedModels.Clear();
+        if (value == null)
+        {
+            SelectedCrispEmbedModel = null;
+            return;
+        }
+
+        Se.Settings.Ocr.CrispEmbedBackend = value.Name;
+
+        foreach (var model in value.Models)
+        {
+            CrispEmbedModels.Add(new CrispEmbedModelDisplay { Backend = value, Model = model });
+        }
+
+        SelectedCrispEmbedModel = CrispEmbedModels.FirstOrDefault(p => p.Model.Name == Se.Settings.Ocr.CrispEmbedModel)
+                                  ?? CrispEmbedModels.FirstOrDefault(p => value.IsModelInstalled(p.Model))
+                                  ?? CrispEmbedModels.FirstOrDefault();
+    }
+
+    partial void OnSelectedCrispEmbedModelChanged(CrispEmbedModelDisplay? value)
+    {
+        if (value == null)
+        {
+            return;
+        }
+
+        Se.Settings.Ocr.CrispEmbedModel = value.Model.Name;
+    }
+
+    [RelayCommand]
+    private async Task DownloadCrispEmbed()
+    {
+        if (Window == null || SelectedCrispEmbedBackend is not { } backend || SelectedCrispEmbedModel is not { } model)
+        {
+            return;
+        }
+
+        if (backend.IsModelInstalled(model.Model))
+        {
+            var answer = await MessageBox.Show(
+                Window,
+                Se.Language.General.Download,
+                string.Format(Se.Language.Translate.XIsAlreadyDownloadedReDownload, model.Model.Name),
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Question);
+
+            if (answer != MessageBoxResult.Yes)
+            {
+                return;
+            }
+        }
+
+        await EnsureCrispEmbedReady(forceModelDownload: true);
+    }
+
+    /// <summary>
+    /// Makes sure the CrispEmbed engine binaries and the selected model are on disk, offering
+    /// downloads for anything missing - the OCR-side analog of the CrispASR engine/model
+    /// download flow in the speech-to-text window.
+    /// </summary>
+    private async Task<bool> EnsureCrispEmbedReady(bool forceModelDownload = false)
+    {
+        if (Window == null || SelectedCrispEmbedBackend is not { } backend || SelectedCrispEmbedModel is not { } model)
+        {
+            return false;
+        }
+
+        if (!CrispEmbedEngine.IsEngineInstalled())
+        {
+            string variant;
+            if (Configuration.IsRunningOnWindows)
+            {
+                var answer = await MessageBox.Show(
+                    Window,
+                    "Download CrispEmbed?",
+                    $"{Environment.NewLine}\"CrispEmbed\" requires downloading the CrispEmbed engine.{Environment.NewLine}{Environment.NewLine}Download and use CrispEmbed?",
+                    MessageBoxButtons.Cancel,
+                    MessageBoxIcon.Question,
+                    "CPU",
+                    "Vulkan",
+                    "CUDA");
+
+                if (answer == MessageBoxResult.Cancel)
+                {
+                    return false;
+                }
+
+                variant = answer switch
+                {
+                    MessageBoxResult.Custom1 => "cpu",
+                    MessageBoxResult.Custom3 => "cuda",
+                    _ => "vulkan",
+                };
+            }
+            else if (Configuration.IsRunningOnLinux && RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
+            {
+                var answer = await MessageBox.Show(
+                    Window,
+                    "Download CrispEmbed?",
+                    $"{Environment.NewLine}\"CrispEmbed\" requires downloading the CrispEmbed engine.{Environment.NewLine}{Environment.NewLine}Download and use CrispEmbed?",
+                    MessageBoxButtons.Cancel,
+                    MessageBoxIcon.Question,
+                    "CPU",
+                    "GPU CUDA");
+
+                if (answer == MessageBoxResult.Cancel)
+                {
+                    return false;
+                }
+
+                variant = answer == MessageBoxResult.Custom2 ? "cuda" : string.Empty;
+            }
+            else
+            {
+                var answer = await MessageBox.Show(
+                    Window,
+                    "Download CrispEmbed?",
+                    $"{Environment.NewLine}\"CrispEmbed\" requires downloading the CrispEmbed engine ({CrispEmbedEngine.DownloadSizeText}).{Environment.NewLine}{Environment.NewLine}Download and use CrispEmbed?",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (answer != MessageBoxResult.Yes)
+                {
+                    return false;
+                }
+
+                variant = string.Empty;
+            }
+
+            var engineResult = await _windowService.ShowDialogAsync<DownloadCrispEmbedWindow, DownloadCrispEmbedViewModel>(Window,
+                vm => vm.InitializeEngine(variant));
+
+            _isCtrlDown = false;
+            RefreshEngineCombo?.Invoke();
+
+            if (!engineResult.OkPressed)
+            {
+                return false;
+            }
+        }
+
+        if (forceModelDownload || !backend.IsModelInstalled(model.Model))
+        {
+            if (!forceModelDownload)
+            {
+                var answer = await MessageBox.Show(
+                    Window,
+                    "Download model?",
+                    $"{Environment.NewLine}Download the model \"{model.Model.Name}\" ({model.Model.Size})?",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (answer != MessageBoxResult.Yes)
+                {
+                    return false;
+                }
+            }
+
+            var modelResult = await _windowService.ShowDialogAsync<DownloadCrispEmbedWindow, DownloadCrispEmbedViewModel>(Window,
+                vm => vm.InitializeModel(backend, model.Model));
+
+            _isCtrlDown = false;
+            RefreshCrispEmbedModelCombo?.Invoke();
+
+            if (!modelResult.OkPressed)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     [RelayCommand]
@@ -2198,6 +2390,17 @@ public partial class OcrViewModel : ObservableObject
         else if (ocrEngine.EngineType == OcrEngineType.LlamaCpp)
         {
             RunLlamaCppOcr(selectedIndices, _cancellationTokenSource.Token);
+        }
+        else if (ocrEngine.EngineType == OcrEngineType.CrispEmbed)
+        {
+            var ready = await EnsureCrispEmbedReady();
+            if (!ready)
+            {
+                PauseOcr();
+                return;
+            }
+
+            RunCrispEmbedOcr(selectedIndices, _cancellationTokenSource.Token);
         }
         else if (ocrEngine.EngineType == OcrEngineType.Mistral)
         {
@@ -3798,6 +4001,74 @@ public partial class OcrViewModel : ObservableObject
         });
     }
 
+    private void RunCrispEmbedOcr(List<int> selectedIndices, CancellationToken cancellationToken)
+    {
+        if (SelectedCrispEmbedBackend is not { } backend || SelectedCrispEmbedModel is not { } model)
+        {
+            PauseOcr();
+            return;
+        }
+
+        var engine = new CrispEmbedOcr(Se.Settings.Ocr.CrispEmbedOcrTimeoutMinutes);
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                ProgressText = "Loading CrispEmbed model...";
+                var started = await engine.StartServerAsync(
+                    CrispEmbedEngine.GetServerExecutable(),
+                    backend.GetModelPath(model.Model),
+                    cancellationToken);
+
+                if (!started)
+                {
+                    var error = engine.Error;
+                    SeLogger.Error("CrispEmbed server failed to start: " + error);
+                    await Dispatcher.UIThread.InvokeAsync(async () =>
+                    {
+                        await MessageBox.Show(
+                            Window!,
+                            "CrispEmbed error",
+                            $"The CrispEmbed server could not be started:{Environment.NewLine}{Environment.NewLine}{error}",
+                            MessageBoxButtons.OK,
+                            MessageBoxIcon.Error);
+                    });
+                    return;
+                }
+
+                for (var processedIndex = 0; processedIndex < selectedIndices.Count; processedIndex++)
+                {
+                    var i = selectedIndices[processedIndex];
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    UpdateOcrProgress(processedIndex + 1, selectedIndices.Count);
+
+                    var item = OcrSubtitleItems[i];
+                    var bitmap = item.GetSkBitmap();
+
+                    SelectAndScrollToRow(i);
+
+                    var text = await engine.Ocr(bitmap, cancellationToken);
+                    item.Text = text;
+
+                    OcrFixLineAndSetText(i, item);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            finally
+            {
+                engine.Dispose();
+                PauseOcr();
+            }
+        });
+    }
+
     private void RunMistralOcr(List<int> selectedIndices, CancellationToken cancellationToken)
     {
         var mistralOcr = new MistralOcr(MistralApiKey);
@@ -4304,6 +4575,7 @@ public partial class OcrViewModel : ObservableObject
         IsInspectLineVisible = et == OcrEngineType.nOcr || et == OcrEngineType.BinaryImageCompare;
         IsOllamaVisible = et == OcrEngineType.Ollama;
         IsLlamaCppVisible = et == OcrEngineType.LlamaCpp;
+        IsCrispEmbedVisible = et == OcrEngineType.CrispEmbed;
         IsTesseractVisible = et == OcrEngineType.Tesseract;
         IsPaddleOcrVisible = et == OcrEngineType.PaddleOcrStandalone || et == OcrEngineType.PaddleOcrPython;
         IsGoogleVisionVisible = et == OcrEngineType.GoogleVision;
@@ -4367,6 +4639,70 @@ public partial class OcrViewModel : ObservableObject
             SelectedLlamaCppOcrModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppOcrModels, LlamaCppServerManager.OcrModels, savedModelName);
             UpdateLlamaCppOcrServerButtonText();
         }
+
+        if (IsCrispEmbedVisible)
+        {
+            if (SelectedCrispEmbedBackend == null)
+            {
+                SelectedCrispEmbedBackend = CrispEmbedBackends.FirstOrDefault(p => p.Name == Se.Settings.Ocr.CrispEmbedBackend)
+                                            ?? CrispEmbedBackends.FirstOrDefault();
+            }
+
+            if (!_crispEmbedUpdatePromptShown)
+            {
+                Dispatcher.UIThread.Post(async () => await CheckCrispEmbedForUpdateAsync());
+            }
+        }
+    }
+
+    private bool _crispEmbedUpdatePromptShown;
+
+    /// <summary>
+    /// When the CrispEmbed engine is selected and the installed build is a known-but-older
+    /// release (per the .installed.sha256 sidecar), offer to download the current one - same
+    /// flow as the CrispASR update prompt in the speech-to-text window.
+    /// </summary>
+    private async Task CheckCrispEmbedForUpdateAsync()
+    {
+        if (_crispEmbedUpdatePromptShown || Window == null || !CrispEmbedEngine.IsEngineInstalled())
+        {
+            return;
+        }
+
+        var sidecar = DownloadHashManager.TryReadSidecar(CrispEmbedEngine.GetAndCreateFolder());
+        if (sidecar == null)
+        {
+            return;
+        }
+
+        var (key, hash) = sidecar.Value;
+        if (DownloadHashManager.GetStatus(key, hash) != DownloadHashManager.UpdateStatus.UpdateAvailable)
+        {
+            return;
+        }
+
+        _crispEmbedUpdatePromptShown = true;
+
+        var answer = await MessageBox.Show(
+            Window,
+            "Update CrispEmbed?",
+            $"A newer version of CrispEmbed is available.{Environment.NewLine}{Environment.NewLine}Download it now?",
+            MessageBoxButtons.YesNoCancel,
+            MessageBoxIcon.Question);
+
+        if (answer != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        var variant = DownloadHashManager.GetCrispEmbedVariant(key)
+                      ?? (Configuration.IsRunningOnWindows ? "vulkan" : string.Empty);
+
+        await _windowService.ShowDialogAsync<DownloadCrispEmbedWindow, DownloadCrispEmbedViewModel>(Window,
+            vm => vm.InitializeEngine(variant));
+
+        _isCtrlDown = false;
+        RefreshEngineCombo?.Invoke();
     }
 
     private bool _forceClose = false;

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -8,9 +8,11 @@ using Avalonia.Data.Converters;
 using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Styling;
+using Nikse.SubtitleEdit.Features.Ocr.Engines;
 using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.Logic.ValueConverters;
 using Optris.Icons.Avalonia;
 using System;
@@ -210,6 +212,16 @@ public class OcrWindow : Window
             .WithMarginRight(10)
             .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter());
         comboBoxEngines.SelectionChanged += vm.EngineSelectionChanged;
+        comboBoxEngines.ItemTemplate = MakeOcrEngineItemTemplate();
+        vm.RefreshEngineCombo = () => comboBoxEngines.ItemTemplate = MakeOcrEngineItemTemplate();
+
+        var comboBoxCrispEmbedModels = UiUtil.MakeComboBox(vm.CrispEmbedModels, vm, nameof(vm.SelectedCrispEmbedModel),
+                nameof(vm.IsCrispEmbedVisible))
+            .WithMinWidth(220)
+            .WithMarginRight(5)
+            .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter());
+        comboBoxCrispEmbedModels.ItemTemplate = MakeCrispEmbedModelItemTemplate();
+        vm.RefreshCrispEmbedModelCombo = () => comboBoxCrispEmbedModels.ItemTemplate = MakeCrispEmbedModelItemTemplate();
 
         var panel = new StackPanel
         {
@@ -322,6 +334,19 @@ public class OcrWindow : Window
                 UiUtil.MakeButton(vm.ShowLlamaCppOcrSettingsCommand, IconNames.Settings, Se.Language.General.Settings)
                     .WithMarginRight(10)
                     .BindIsVisible(vm, nameof(vm.IsLlamaCppVisible))
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+
+                // CrispEmbed settings
+                UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.Backend, vm => vm.IsCrispEmbedVisible),
+                UiUtil.MakeComboBox(vm.CrispEmbedBackends, vm, nameof(vm.SelectedCrispEmbedBackend),
+                        nameof(vm.IsCrispEmbedVisible))
+                    .WithMarginRight(10)
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.Model, vm => vm.IsCrispEmbedVisible),
+                comboBoxCrispEmbedModels,
+                UiUtil.MakeButton(vm.DownloadCrispEmbedCommand, IconNames.Download, Se.Language.General.Download)
+                    .WithMarginRight(10)
+                    .BindIsVisible(vm, nameof(vm.IsCrispEmbedVisible))
                     .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
 
                 // Google vision settings
@@ -1034,5 +1059,46 @@ public class OcrWindow : Window
         var button = UiUtil.MakeButton(string.Empty, vm.ToggleLlamaCppOcrServerCommand);
         button.Bind(Button.ContentProperty, new Binding(nameof(vm.LlamaCppOcrServerButtonText)));
         return button;
+    }
+
+    // Engine combo item template: CrispEmbed is the only OCR engine with a locally tracked
+    // install, so it gets the install-status dot (green = ready, amber = update available,
+    // grey = not downloaded yet) plus its download size; all other engines show no dot.
+    private static FuncDataTemplate<OcrEngineItem> MakeOcrEngineItemTemplate()
+    {
+        return StatusDots.ComboItemTemplate<OcrEngineItem>(
+            engine => engine.Name,
+            engine => engine.EngineType == OcrEngineType.CrispEmbed && !CrispEmbedEngine.IsEngineInstalled()
+                ? CrispEmbedEngine.DownloadSizeText
+                : null,
+            GetOcrEngineDotStatus);
+    }
+
+    private static DownloadDotStatus GetOcrEngineDotStatus(OcrEngineItem engine)
+    {
+        if (engine.EngineType != OcrEngineType.CrispEmbed)
+        {
+            return DownloadDotStatus.None;
+        }
+
+        if (!CrispEmbedEngine.IsEngineInstalled())
+        {
+            return DownloadDotStatus.NotInstalled;
+        }
+
+        // Installed: read the cheap .installed.sha256 sidecar so an outdated build shows amber.
+        return StatusDots.From(true, DownloadHashManager.GetSidecarStatus(CrispEmbedEngine.GetAndCreateFolder()));
+    }
+
+    // Model combo item template: a dot (green = downloaded, grey = not downloaded yet) plus the
+    // model's download size - same treatment as the speech-to-text model combo.
+    private static FuncDataTemplate<CrispEmbedModelDisplay> MakeCrispEmbedModelItemTemplate()
+    {
+        return StatusDots.ComboItemTemplate<CrispEmbedModelDisplay>(
+            model => model.Model.Name,
+            model => string.IsNullOrEmpty(model.Model.Size) ? null : model.Model.Size,
+            model => model.Backend.IsModelInstalled(model.Model)
+                ? DownloadDotStatus.UpToDate
+                : DownloadDotStatus.NotInstalled);
     }
 }

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -129,6 +129,7 @@ public class Se
     public static string PaddleOcrFolder => Path.Combine(OcrFolder, "PaddleOCR3-1");
     public static string PaddleOcrModelsFolder => Path.Combine(PaddleOcrFolder, "models");
     public static string GoogleLensOcrFolder => Path.Combine(OcrFolder, "Google-Lens");
+    public static string CrispEmbedFolder => Path.Combine(OcrFolder, "CrispEmbed");
     public static string VlcFolder => Path.Combine(DataFolder, "VLC");
     public static string SevenZipFolder => Path.Combine(DataFolder, "7Zip");
     private static readonly Lazy<string> _tesseractFolder = new(ResolveTesseractFolder);

--- a/src/ui/Logic/Config/SeOcr.cs
+++ b/src/ui/Logic/Config/SeOcr.cs
@@ -23,6 +23,9 @@ public class SeOcr
     public string LlamaCppOcrModel { get; set; }
     public string LlamaCppOcrPrompt { get; set; }
     public int LlamaCppOcrTimeoutMinutes { get; set; }
+    public string CrispEmbedBackend { get; set; }
+    public string CrispEmbedModel { get; set; }
+    public int CrispEmbedOcrTimeoutMinutes { get; set; }
     public string GoogleVisionApiKey { get; set; }
     public string GoogleVisionLanguage { get; set; }
     public string MistralApiKey { get; set; }
@@ -83,6 +86,10 @@ public class SeOcr
         LlamaCppOcrModel = string.Empty;
         LlamaCppOcrPrompt = "Extract all text exactly as written. The language is {language}. Preserve line breaks.";
         LlamaCppOcrTimeoutMinutes = 5;
+
+        CrispEmbedBackend = "GLM-OCR";
+        CrispEmbedModel = "glm-ocr-q8_0.gguf"; // the CrispEmbed registry's default GLM-OCR quant
+        CrispEmbedOcrTimeoutMinutes = 5;
 
         GoogleVisionApiKey = string.Empty;
         GoogleVisionLanguage = "en";

--- a/src/ui/Logic/Download/CrispEmbedDownloadService.cs
+++ b/src/ui/Logic/Download/CrispEmbedDownloadService.cs
@@ -1,0 +1,86 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Logic.Download;
+
+public interface ICrispEmbedDownloadService
+{
+    Task DownloadEngine(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
+    Task DownloadEngineWindowsCuda(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
+    Task DownloadEngineWindowsVulkan(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
+    Task DownloadEngineWindowsCpu(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
+    Task DownloadEngineLinuxCuda(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
+    Task DownloadModel(string url, string destinationFileName, IProgress<float>? progress, CancellationToken cancellationToken);
+}
+
+public class CrispEmbedDownloadService : ICrispEmbedDownloadService
+{
+    private readonly HttpClient _httpClient;
+
+    private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.14.0/crispembed-windows-x86_64-cuda.zip";
+    private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.14.0/crispembed-windows-x86_64-vulkan.zip";
+    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.14.0/crispembed-windows-x86_64.zip";
+    private const string MacUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.14.0/crispembed-macos-arm64.tar.gz";
+    private const string LinuxUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.14.0/crispembed-linux-x86_64.tar.gz";
+    private const string LinuxCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.14.0/crispembed-linux-x86_64-cuda.tar.gz";
+    private const string LinuxArmUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.14.0/crispembed-linux-arm64.tar.gz";
+
+    public CrispEmbedDownloadService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task DownloadEngine(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        await DownloadHelper.DownloadFileAsync(_httpClient, GetUrl(), stream, progress, cancellationToken);
+    }
+
+    public async Task DownloadEngineWindowsCuda(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        await DownloadHelper.DownloadFileAsync(_httpClient, WindowsCudaUrl, stream, progress, cancellationToken);
+    }
+
+    public async Task DownloadEngineWindowsVulkan(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        await DownloadHelper.DownloadFileAsync(_httpClient, WindowsVulkanUrl, stream, progress, cancellationToken);
+    }
+
+    public async Task DownloadEngineWindowsCpu(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        await DownloadHelper.DownloadFileAsync(_httpClient, WindowsCpuUrl, stream, progress, cancellationToken);
+    }
+
+    public async Task DownloadEngineLinuxCuda(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        await DownloadHelper.DownloadFileAsync(_httpClient, LinuxCudaUrl, stream, progress, cancellationToken);
+    }
+
+    public async Task DownloadModel(string url, string destinationFileName, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        await DownloadHelper.DownloadFileAsync(_httpClient, url, destinationFileName, progress, cancellationToken);
+    }
+
+    private static string GetUrl()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return WindowsVulkanUrl;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? LinuxArmUrl : LinuxUrl;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return MacUrl;
+        }
+
+        throw new PlatformNotSupportedException();
+    }
+}

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -52,6 +52,21 @@ public static class DownloadHashManager
         public const string LinuxArmExecutable = "CrispAsr.Linux.Arm.Executable";
     }
 
+    public static class CrispEmbed
+    {
+        // Hashes of the release archive (.zip / .tar.gz) — recognised from the .installed.sha256
+        // sidecar written at install time. Index 0 must match the release CrispEmbedDownloadService.cs
+        // is pinned to. Like OmniVoice there is no executable-hash fallback: CrispEmbed has only
+        // ever shipped via SE with a sidecar.
+        public const string WindowsCuda = "CrispEmbed.Windows.Cuda";
+        public const string WindowsVulkan = "CrispEmbed.Windows.Vulkan";
+        public const string WindowsCpu = "CrispEmbed.Windows.Cpu";
+        public const string MacOs = "CrispEmbed.MacOs";
+        public const string Linux = "CrispEmbed.Linux";
+        public const string LinuxCuda = "CrispEmbed.Linux.Cuda";
+        public const string LinuxArm = "CrispEmbed.Linux.Arm";
+    }
+
     public static class LlamaCpp
     {
         // Hashes of the release archive (.zip / .tar.gz) — used when a sidecar hash exists alongside the install.
@@ -441,6 +456,38 @@ public static class DownloadHashManager
                 "8a8edb05d25ba793bcba90c528332ae17ef9324d689aa3ffd7c9dda48262bdbb", // v0.6.11
                 "f8b6e6f080dc5bd227b39417a48d525de3962c85519fa40debc1aec4e0251bfa", // v0.6.10
                 "b3dacccb8d16afb88a7c426edbeefaa6c8bee0f6bc5a5e6493fb4616c2ec32d1", // v0.6.9 (first SE-tracked Linux ARM64 build)
+            },
+
+            // CrispEmbed — https://github.com/CrispStrobe/CrispEmbed/releases
+            // Index 0 must match whatever version CrispEmbedDownloadService.cs is pinned to,
+            // otherwise users will be prompted to "update" to the same version they just got.
+            [CrispEmbed.WindowsCuda] = new[]
+            {
+                "faf376578103b37d7b1d5a385072ff8c66f35cbb7f20a801a6ab0d4e85802cda", // v0.14.0 (current download URL)
+            },
+            [CrispEmbed.WindowsVulkan] = new[]
+            {
+                "d1722ae897a0909de877e6d1defeb5cf56041ced923cb058770fc76f9dcc8a37", // v0.14.0 (current download URL)
+            },
+            [CrispEmbed.WindowsCpu] = new[]
+            {
+                "49ba9a172f918c82648d69a4758841a45e29bb8e2700ffa64e4c94f325d0fec3", // v0.14.0 (current download URL)
+            },
+            [CrispEmbed.MacOs] = new[]
+            {
+                "2a47142eea71f0120fbf86eda21a0d972618e01c2bf5d67e54204d8e5644411e", // v0.14.0 (current download URL)
+            },
+            [CrispEmbed.Linux] = new[]
+            {
+                "e255a59c615fcdf869794c7fabc2f7a4da7babddce5a7ef4771e4fc4a51ff65c", // v0.14.0 (current download URL)
+            },
+            [CrispEmbed.LinuxCuda] = new[]
+            {
+                "48e2c0e8536c7db717155adb418330e29bb5f7b1c8eda8686fe7513ae6ea58d9", // v0.14.0 (current download URL)
+            },
+            [CrispEmbed.LinuxArm] = new[]
+            {
+                "3d08ea2cb15da4f1d71dfc3ae030f855d7a5d32a662952b6ea43ff17d3b37788", // v0.14.0 (current download URL)
             },
 
             // SHA-256 of crispasr.exe / crispasr extracted from each archive above.
@@ -1129,25 +1176,66 @@ public static class DownloadHashManager
     /// </summary>
     public static UpdateStatus GetSidecarStatus(string installFolder)
     {
+        var sidecar = TryReadSidecar(installFolder);
+        return sidecar == null
+            ? UpdateStatus.Unknown
+            : GetStatus(sidecar.Value.Key, sidecar.Value.Hash);
+    }
+
+    /// <summary>
+    /// Reads the <c>.installed.sha256</c> sidecar in <paramref name="installFolder"/> and returns
+    /// the recorded hash key and archive hash, or null when the sidecar is missing or malformed.
+    /// Use this when the caller needs the key itself (e.g. to derive the install variant);
+    /// <see cref="GetSidecarStatus"/> is the shortcut when only the update status is needed.
+    /// </summary>
+    public static (string Key, string Hash)? TryReadSidecar(string installFolder)
+    {
         try
         {
             var sidecar = Path.Combine(installFolder, ".installed.sha256");
             if (!File.Exists(sidecar))
             {
-                return UpdateStatus.Unknown;
+                return null;
             }
 
             var lines = File.ReadAllLines(sidecar);
             if (lines.Length < 2)
             {
-                return UpdateStatus.Unknown;
+                return null;
             }
 
-            return GetStatus(lines[0].Trim(), lines[1].Trim());
+            return (lines[0].Trim(), lines[1].Trim());
         }
         catch
         {
-            return UpdateStatus.Unknown;
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Writes the <c>.installed.sha256</c> sidecar for a freshly downloaded release archive:
+    /// first line the hash key, second line the archive's SHA-256. Rewinds and hashes
+    /// <paramref name="archiveStream"/>. Best-effort - failures are swallowed since the sidecar
+    /// only powers update detection.
+    /// </summary>
+    public static void WriteSidecar(string installFolder, string? key, Stream archiveStream)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(key) || archiveStream.Length == 0)
+            {
+                return;
+            }
+
+            archiveStream.Position = 0;
+            var hash = ComputeSha256(archiveStream);
+
+            var sidecar = Path.Combine(installFolder, ".installed.sha256");
+            File.WriteAllText(sidecar, key + Environment.NewLine + hash);
+        }
+        catch
+        {
+            // ignore — hash side-car is best-effort
         }
     }
 
@@ -1258,6 +1346,67 @@ public static class DownloadHashManager
             CrispAsr.LinuxCuda or CrispAsr.LinuxCudaExecutable => "cuda",
             CrispAsr.Linux or CrispAsr.LinuxExecutable => string.Empty,
             CrispAsr.LinuxArm or CrispAsr.LinuxArmExecutable => string.Empty,
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Resolves the CrispEmbed hash key for the current OS and variant.
+    /// On Windows the variant selects between cuda, vulkan, and cpu.
+    /// On Linux x86_64 the variant selects between cuda and the default CPU build.
+    /// On Linux ARM64 and macOS the variant is ignored (only one build each).
+    /// Returns null if the platform / variant combination is unknown.
+    /// </summary>
+    public static string? ResolveCrispEmbedKey(string? variant)
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+            {
+                return CrispEmbed.LinuxArm;
+            }
+            if (variant == "cuda")
+            {
+                return CrispEmbed.LinuxCuda;
+            }
+            return CrispEmbed.Linux;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return CrispEmbed.MacOs;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return variant switch
+            {
+                "cuda" => CrispEmbed.WindowsCuda,
+                "cpu" => CrispEmbed.WindowsCpu,
+                "vulkan" => CrispEmbed.WindowsVulkan,
+                _ => null,
+            };
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Reverse of <see cref="ResolveCrispEmbedKey"/> — returns the variant string matching the
+    /// given hash key. For Windows: "cuda" / "vulkan" / "cpu". For Linux x86_64: "cuda" for the
+    /// CUDA build, empty string for the default CPU build. Returns null otherwise.
+    /// </summary>
+    public static string? GetCrispEmbedVariant(string key)
+    {
+        return key switch
+        {
+            CrispEmbed.WindowsCuda => "cuda",
+            CrispEmbed.WindowsVulkan => "vulkan",
+            CrispEmbed.WindowsCpu => "cpu",
+            CrispEmbed.LinuxCuda => "cuda",
+            CrispEmbed.Linux => string.Empty,
+            CrispEmbed.LinuxArm => string.Empty,
+            CrispEmbed.MacOs => string.Empty,
             _ => null,
         };
     }

--- a/tests/UI/Features/Ocr/Engines/CrispEmbedEngineTests.cs
+++ b/tests/UI/Features/Ocr/Engines/CrispEmbedEngineTests.cs
@@ -1,0 +1,48 @@
+using Nikse.SubtitleEdit.Features.Ocr;
+using Nikse.SubtitleEdit.Features.Ocr.Engines;
+
+namespace UITests.Features.Ocr.Engines;
+
+public class CrispEmbedEngineTests
+{
+    [Fact]
+    public void GetBackends_HasExpectedBackends()
+    {
+        var backends = CrispEmbedEngine.GetBackends();
+
+        Assert.Equal(new[] { "GLM-OCR", "GOT-OCR2", "PaddleOCR-VL" }, backends.Select(p => p.Name));
+    }
+
+    [Fact]
+    public void GetBackends_ModelsAreWellFormed()
+    {
+        foreach (var backend in CrispEmbedEngine.GetBackends())
+        {
+            Assert.NotEmpty(backend.Models);
+
+            foreach (var model in backend.Models)
+            {
+                Assert.EndsWith(".gguf", model.Name);
+                Assert.False(string.IsNullOrWhiteSpace(model.Size));
+
+                // The model is downloaded to <models>/<Name>, so the URL must end in the
+                // same file name or the install check would never see the download.
+                Assert.StartsWith("https://huggingface.co/", model.Url);
+                Assert.EndsWith("/" + model.Name, model.Url);
+            }
+
+            // No duplicate model file names within a backend - they share one models folder.
+            Assert.Equal(backend.Models.Count, backend.Models.Select(p => p.Name).Distinct().Count());
+        }
+    }
+
+    [Fact]
+    public void OcrEngines_CrispEmbedListedOnSupportedPlatforms()
+    {
+        var engines = OcrEngineItem.GetOcrEngines();
+
+        Assert.Equal(
+            CrispEmbedEngine.CanBeDownloaded(),
+            engines.Any(p => p.EngineType == OcrEngineType.CrispEmbed));
+    }
+}

--- a/tests/UI/Features/Ocr/Engines/CrispEmbedEngineTests.cs
+++ b/tests/UI/Features/Ocr/Engines/CrispEmbedEngineTests.cs
@@ -10,7 +10,7 @@ public class CrispEmbedEngineTests
     {
         var backends = CrispEmbedEngine.GetBackends();
 
-        Assert.Equal(new[] { "GLM-OCR", "GOT-OCR2", "PaddleOCR-VL" }, backends.Select(p => p.Name));
+        Assert.Equal(new[] { "GLM-OCR", "GOT-OCR2", "PaddleOCR-VL", "Qwen3-VL-2B" }, backends.Select(p => p.Name));
     }
 
     [Fact]

--- a/tests/UI/Features/Ocr/Engines/CrispEmbedEngineTests.cs
+++ b/tests/UI/Features/Ocr/Engines/CrispEmbedEngineTests.cs
@@ -10,7 +10,7 @@ public class CrispEmbedEngineTests
     {
         var backends = CrispEmbedEngine.GetBackends();
 
-        Assert.Equal(new[] { "GLM-OCR", "GOT-OCR2", "PaddleOCR-VL", "Qwen3-VL-2B" }, backends.Select(p => p.Name));
+        Assert.Equal(new[] { "GLM-OCR", "GOT-OCR2", "Qwen3-VL-2B" }, backends.Select(p => p.Name));
     }
 
     [Fact]


### PR DESCRIPTION
Adds [CrispEmbed](https://github.com/CrispStrobe/CrispEmbed) (local ggml-based OCR, same family as CrispASR) as a new OCR engine, following the CrispASR speech-to-text integration pattern.

## Backends

Three model backends, each with q4_k / q8_0 GGUF quants:

| Backend | Quants | Use case |
|---|---|---|
| GLM-OCR (default) | 889 MB / 1.18 GB | Best document-OCR quality, 8 languages |
| GOT-OCR2 | 445 MB / 600 MB | Smallest/fastest |
| Qwen3-VL-2B | 1.59 GB / 2.29 GB | General VLM OCR |

PaddleOCR-VL was evaluated but omitted: in CrispEmbed v0.14.0 both quants truncate/hallucinate on subtitle-style single-line images (via both server and CLI paths).

## UI (mirrors the CrispASR UX in the speech-to-text window)

- Engine combo gets install-status dots (green = ready, amber = update available, grey = not installed) driven by the `.installed.sha256` sidecar + `DownloadHashManager`; other OCR engines show no dot.
- Backend combo + model combo (with per-model dots and download sizes) appear when CrispEmbed is selected, plus a download/re-download button.
- Starting OCR prompts to download the engine (Windows: CPU/Vulkan/CUDA; Linux: CPU/CUDA; macOS arm64) and the selected model if missing.
- Selecting the engine offers an update when the installed build is a known-but-older release.

## Runtime

OCR runs through `crispembed-server --ocr <model> --port <free port>`, started once per OCR run so the model loads once; each subtitle bitmap is flattened to an opaque PNG and posted to `/ocr/model`. The server process is killed on completion/cancel.

## Infrastructure

- `CrispEmbedDownloadService` pinned to v0.14.0 release archives with SHA-256s registered in `DownloadHashManager` (from GitHub's asset digests, macOS one verified locally).
- Shared `.installed.sha256` read/write helpers extracted into `DownloadHashManager` (`TryReadSidecar`/`WriteSidecar`); `GetSidecarStatus` now uses them.

## Verification

All six shipped quants verified headlessly against the pinned v0.14.0 macOS binary with an ffmpeg-generated subtitle-style test image ("Hello world, this is a test.", white on black): every quant returned the exact text, confidence 0.93–0.999, 0.5–2.1 s/line on an M4. The live test also caught two contract details now handled in code: the response key is `latex` (legacy name, even for text models) and the server does not JSON-unescape request paths (paths are sent with forward slashes).

Unit tests: backend/model list well-formedness + platform gating (`CrispEmbedEngineTests`); full UI suite passes (608 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)