### PR TITLE
Add PaddleOCR-VL 1.6 to the llama.cpp OCR model list

### DIFF
--- a/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
+++ b/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
@@ -132,6 +132,11 @@ public static class LlamaCppServerManager
             "https://huggingface.co/ggml-org/LightOnOCR-1B-1025-GGUF/resolve/main/LightOnOCR-1B-1025-Q8_0.gguf",
             MmprojFileName: "mmproj-LightOnOCR-1B-1025-Q8_0.gguf",
             MmprojUrl: "https://huggingface.co/ggml-org/LightOnOCR-1B-1025-GGUF/resolve/main/mmproj-LightOnOCR-1B-1025-Q8_0.gguf"),
+        // PaddlePaddle's official llama.cpp package - 109 languages (NaViT + ERNIE-4.5).
+        new LlamaCppModel("PaddleOCR-VL 1.6", "PaddleOCR-VL-1.6-GGUF.gguf", "1.8 GB",
+            "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6-GGUF/resolve/main/PaddleOCR-VL-1.6-GGUF.gguf",
+            MmprojFileName: "PaddleOCR-VL-1.6-GGUF-mmproj.gguf",
+            MmprojUrl: "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6-GGUF/resolve/main/PaddleOCR-VL-1.6-GGUF-mmproj.gguf"),
     };
 
     /// <summary>


### PR DESCRIPTION
Adds PaddlePaddle's official llama.cpp package of [PaddleOCR-VL 1.6](https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6-GGUF) (NaViT + ERNIE-4.5, 109 languages; model + mmproj, 1.8 GB total) as a third entry in the llama.cpp OCR model list, alongside GLM-OCR and LightOnOCR. One list entry — the existing download/server/OCR plumbing handles the rest.

This restores the 109-language PaddleOCR-VL option that was evaluated and dropped from the CrispEmbed backend list in #12366 (broken there in CrispEmbed v0.14.0's integration — this verification confirms the model family itself is fine when run through llama.cpp).

## Verification (headless, pinned llama.cpp b9833, Apple M4)

Driven through SE's actual `LlamaCppServerManager.EnsureServerRunningAsync` + `LlamaCppOcr` code path:

- Real Blu-ray sup (alien4.sup, 6 lines sampled across the movie): 6/6 exact, 0.3–4.3 s/line
- Synthetic subtitle image ("Hello world, this is a test.", white on black): exact — notably the same image CrispEmbed's Paddle path truncated
- Multi-line Danish/Spanish/French with accents and italics: line break and text exact, one diacritic slip (`Àh` for `Åh`)

Full UI test suite passes (608 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)