### PR TITLE
Fix missing thin outlines in BDN XML / Blu-ray SUP export

### DIFF
--- a/src/libuilogic/Export/ImageRenderer.cs
+++ b/src/libuilogic/Export/ImageRenderer.cs
@@ -88,6 +88,16 @@ public static class ImageRenderer
         using var italicFont = new SKFont(ip.IsBold ? boldItalicTypeface : italicTypeface, fontSize);
         using var boldItalicFont = new SKFont(boldItalicTypeface, fontSize);
 
+        // Hinting snaps glyph edges to the pixel grid, which breaks the registration
+        // between the fill and the outline stroked from the raw glyph path - thin
+        // outlines then vanish on horizontal edges (issue #12206). Export renders at
+        // video resolution, so hinting is not needed.
+        foreach (var font in new[] { regularFont, boldFont, italicFont, boldItalicFont })
+        {
+            font.Hinting = SKFontHinting.None;
+            font.Subpixel = true;
+        }
+
         // Split segments into lines
         var lines = SplitIntoSegments(segments);
 
@@ -320,25 +330,35 @@ public static class ImageRenderer
                 var segment = segmentsToRender[i];
                 var currentFont = GetFont(segment, regularFont, boldFont, italicFont, boldItalicFont);
 
+                // Outlines are stroked on the raw glyph path with doubled width: the fill
+                // drawn on top covers the inner half, so the visible outline matches the
+                // requested width. Stroking through the glyph rasterizer instead loses thin
+                // horizontal outline edges entirely (issue #12206).
+                using var textPath = outlineWidth > 0
+                    ? GetShapedTextPath(segment.Text, currentX, textStartY + currentY, currentFont)
+                    : null;
+
                 // Draw shadow first (if shadow width > 0)
                 if (shadowWidth > 0)
                 {
                     var shadowOffsetX = currentX + (float)shadowWidth;
                     var shadowOffsetY = textStartY + currentY + (float)shadowWidth;
 
-                    if (outlineWidth > 0)
+                    if (textPath != null)
                     {
                         using var shadowOutlinePaint = new SKPaint
                         {
                             Color = shadowColor,
                             IsAntialias = true,
                             Style = SKPaintStyle.Stroke,
-                            StrokeWidth = (float)outlineWidth,
+                            StrokeWidth = (float)outlineWidth * 2,
                             StrokeJoin = SKStrokeJoin.Round,
                             StrokeCap = SKStrokeCap.Round,
                         };
 
-                        DrawShapedText(canvas, segment.Text, shadowOffsetX, shadowOffsetY, currentFont, shadowOutlinePaint);
+                        using var shadowPath = new SKPath(textPath);
+                        shadowPath.Offset((float)shadowWidth, (float)shadowWidth);
+                        canvas.DrawPath(shadowPath, shadowOutlinePaint);
                     }
 
                     using var shadowTextPaint = new SKPaint
@@ -352,19 +372,19 @@ public static class ImageRenderer
                 }
 
                 // Draw outline second (if outline width > 0)
-                if (outlineWidth > 0)
+                if (textPath != null)
                 {
                     using var outlinePaint = new SKPaint
                     {
                         Color = outlineColor,
                         IsAntialias = true,
                         Style = SKPaintStyle.Stroke,
-                        StrokeWidth = (float)outlineWidth,
+                        StrokeWidth = (float)outlineWidth * 2,
                         StrokeJoin = SKStrokeJoin.Round,
                         StrokeCap = SKStrokeCap.Round,
                     };
 
-                    DrawShapedText(canvas, segment.Text, currentX, textStartY + currentY, currentFont, outlinePaint);
+                    canvas.DrawPath(textPath, outlinePaint);
                 }
 
                 // Draw the main text on top
@@ -411,6 +431,29 @@ public static class ImageRenderer
     {
         using var shaper = new SKShaper(font.Typeface);
         canvas.DrawShapedText(shaper, text, x, y, SKTextAlign.Left, font, paint);
+    }
+
+    // Builds the combined glyph outline path for shaped text, positioned like
+    // DrawShapedText draws it. Glyphs without an outline (whitespace, color emoji)
+    // are skipped - they get no stroke, but the fill still renders them.
+    private static SKPath GetShapedTextPath(string text, float x, float y, SKFont font)
+    {
+        using var shaper = new SKShaper(font.Typeface);
+        var result = shaper.Shape(text, x, y, font);
+
+        var path = new SKPath();
+        for (var i = 0; i < result.Codepoints.Length; i++)
+        {
+            using var glyphPath = font.GetGlyphPath((ushort)result.Codepoints[i]);
+            if (glyphPath == null || glyphPath.IsEmpty)
+            {
+                continue;
+            }
+
+            path.AddPath(glyphPath, result.Points[i].X, result.Points[i].Y);
+        }
+
+        return path;
     }
 
     private static SKFont GetFont(TextSegment segment, SKFont regular, SKFont bold, SKFont italic, SKFont boldItalic)


### PR DESCRIPTION
Fixes #12206

At small outline widths (1–2) the outline vanished on horizontal glyph edges (top of T, E, H, …) in image-based exports, varying with font and font size — e.g. Franklin Gothic/Arial at size 44 lost top outlines while other sizes lost horizontal or vertical ones. v4.0.16 rendered the same settings correctly.

## Root cause

Two compounding problems in `ImageRenderer.RenderTextToCanvas`:

1. **The outline stroke was centered on the glyph edge**, so only `outlineWidth / 2` extended outside the glyph — and the fill drawn on top covered the inner half. At width 1, only half a pixel of outline could ever be visible.
2. **Stroking through the glyph rasterizer applies font hinting**, which snaps horizontal edges to the pixel grid. The surviving half-pixel rim landed in the same pixel row as the fill's antialiased edge, and the opaque fill blended over it — leaving ~50% alpha light-gray pixels (`rgba(169,169,169,130)`) instead of a black outline. Whether anything survives depends on where the cap-height edge lands on the pixel grid, which explains the font/size dependence reported in the issue.

## Fix

- Build the shaped text outline as an `SKPath` (via `SKShaper` glyph positions, preserving HarfBuzz shaping) and stroke the path directly, bypassing the hinted glyph rasterizer.
- Stroke with **2× the requested width** — the fill covers the inner half, so the visible outline matches the requested width (same semantics as ASSA/libass and v4's GDI+ path rendering).
- Disable hinting on export fonts so the fill edges stay registered with the raw path geometry (export renders at video resolution; hinting is not needed).

The same treatment is applied to the shadow outline pass. Glyphs without outline paths (e.g. color emoji) simply get no stroke; fills are unchanged.

## Verification

Headless harness calling `ImageRenderer.GenerateBitmap` with white text / black outline width 1, "THE HEIGHT", Arial/Tahoma/Helvetica at sizes 44/45/53. Per-column check for outline pixels above the topmost fill pixel:

| | Columns missing top outline |
|---|---|
| Before | ~98–100% in every font/size combination |
| After | 0 in every combination |

Visual inspection at 4× zoom confirms a clean, uniform 1px outline on all edges, and a styled sample (bold/italic/font color + shadow + outline) renders correctly. `LibUiLogicTests` (6) and `SeConvTests` (217) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)