### PR TITLE
Add thematic categories with icons to the shortcuts window

### DIFF
--- a/src/ui/Features/Options/Shortcuts/ShortcutGroup.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutGroup.cs
@@ -1,0 +1,100 @@
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Options.Shortcuts;
+
+/// <summary>
+/// Thematic grouping of shortcuts, used only for browsing/filtering in the shortcuts
+/// window. Unlike <see cref="ShortcutCategory"/> it has no effect on dispatch - the
+/// category still decides which focused control a shortcut is active in.
+/// </summary>
+public enum ShortcutGroup
+{
+    General,
+    File,
+    Video,
+    Waveform,
+    SubtitleGrid,
+    TextBox,
+    SubtitleGridAndTextBox,
+    Sync,
+    Translate,
+    Search,
+    Tools,
+    Ai,
+}
+
+public static class ShortcutGroupUi
+{
+    public static ShortcutGroup FromCategory(ShortcutCategory category)
+    {
+        return category switch
+        {
+            ShortcutCategory.Waveform => ShortcutGroup.Waveform,
+            ShortcutCategory.SubtitleGrid => ShortcutGroup.SubtitleGrid,
+            ShortcutCategory.TextBox => ShortcutGroup.TextBox,
+            ShortcutCategory.SubtitleGridAndTextBox => ShortcutGroup.SubtitleGridAndTextBox,
+            _ => ShortcutGroup.General,
+        };
+    }
+
+    public static string GetName(ShortcutGroup group)
+    {
+        var language = Se.Language.Options.Shortcuts;
+        return group switch
+        {
+            ShortcutGroup.File => language.CategoryFile,
+            ShortcutGroup.Video => language.CategoryVideo,
+            ShortcutGroup.Waveform => language.CategoryWaveform,
+            ShortcutGroup.SubtitleGrid => language.CategorySubtitleGrid,
+            ShortcutGroup.TextBox => language.CategoryTextBox,
+            ShortcutGroup.SubtitleGridAndTextBox => language.CategorySubtitleGridAndTextBox,
+            ShortcutGroup.Sync => language.CategorySync,
+            ShortcutGroup.Translate => language.CategoryTranslate,
+            ShortcutGroup.Search => language.CategorySearch,
+            ShortcutGroup.Tools => language.CategoryTools,
+            ShortcutGroup.Ai => language.CategoryAi,
+            _ => language.CategoryGeneral,
+        };
+    }
+
+    public static string GetIconName(ShortcutGroup group)
+    {
+        return group switch
+        {
+            ShortcutGroup.File => IconNames.FileOutline,
+            ShortcutGroup.Video => IconNames.MovieOpenOutline,
+            ShortcutGroup.Waveform => IconNames.Waveform,
+            ShortcutGroup.SubtitleGrid => IconNames.ViewList,
+            ShortcutGroup.TextBox => IconNames.FormTextBox,
+            ShortcutGroup.SubtitleGridAndTextBox => IconNames.ViewSplitVertical,
+            ShortcutGroup.Sync => IconNames.Sync,
+            ShortcutGroup.Translate => IconNames.Translate,
+            ShortcutGroup.Search => IconNames.Find,
+            ShortcutGroup.Tools => IconNames.Tools,
+            ShortcutGroup.Ai => IconNames.Creation,
+            _ => IconNames.Settings,
+        };
+    }
+
+    // Mid-saturation tones picked to stay readable on both the dark and light theme.
+    public static IBrush GetBrush(ShortcutGroup group)
+    {
+        return group switch
+        {
+            ShortcutGroup.File => new SolidColorBrush(Color.Parse("#5fa8e0")),
+            ShortcutGroup.Video => new SolidColorBrush(Color.Parse("#a78bfa")),
+            ShortcutGroup.Waveform => new SolidColorBrush(Color.Parse("#f0b429")),
+            ShortcutGroup.SubtitleGrid => new SolidColorBrush(Color.Parse("#4ec98a")),
+            ShortcutGroup.TextBox => new SolidColorBrush(Color.Parse("#4fc3e8")),
+            ShortcutGroup.SubtitleGridAndTextBox => new SolidColorBrush(Color.Parse("#7fa8f0")),
+            ShortcutGroup.Sync => new SolidColorBrush(Color.Parse("#58c9b4")),
+            ShortcutGroup.Translate => new SolidColorBrush(Color.Parse("#6bb84e")),
+            ShortcutGroup.Search => new SolidColorBrush(Color.Parse("#d9a03f")),
+            ShortcutGroup.Tools => new SolidColorBrush(Color.Parse("#f0885a")),
+            ShortcutGroup.Ai => new SolidColorBrush(Color.Parse("#e668c4")),
+            _ => new SolidColorBrush(Color.Parse("#8494a4")),
+        };
+    }
+}

--- a/src/ui/Features/Options/Shortcuts/ShortcutGroup.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutGroup.cs
@@ -78,6 +78,13 @@ public static class ShortcutGroupUi
         };
     }
 
+    // Soft tint of the group color, used as background behind the colored icon.
+    public static IBrush GetSoftBrush(ShortcutGroup group)
+    {
+        var color = ((SolidColorBrush)GetBrush(group)).Color;
+        return new SolidColorBrush(color, 0.16);
+    }
+
     // Mid-saturation tones picked to stay readable on both the dark and light theme.
     public static IBrush GetBrush(ShortcutGroup group)
     {

--- a/src/ui/Features/Options/Shortcuts/ShortcutGroup.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutGroup.cs
@@ -82,7 +82,7 @@ public static class ShortcutGroupUi
     public static IBrush GetSoftBrush(ShortcutGroup group)
     {
         var color = ((SolidColorBrush)GetBrush(group)).Color;
-        return new SolidColorBrush(color, 0.16);
+        return new SolidColorBrush(color, 0.28);
     }
 
     // Mid-saturation tones picked to stay readable on both the dark and light theme.

--- a/src/ui/Features/Options/Shortcuts/ShortcutGroupTile.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutGroupTile.cs
@@ -29,7 +29,8 @@ public class ShortcutGroupTile
         Group = null;
         Name = Se.Language.General.All;
         IconName = IconNames.ViewGrid;
-        Brush = new SolidColorBrush(Color.Parse("#8494a4"));
+        // System accent so "All" cannot be mistaken for the gray "General" group.
+        Brush = UiUtil.GetAccentBrush();
         Count = count;
     }
 }

--- a/src/ui/Features/Options/Shortcuts/ShortcutGroupTile.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutGroupTile.cs
@@ -1,0 +1,35 @@
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Options.Shortcuts;
+
+/// <summary>
+/// One clickable tile in the group filter strip. Group == null means "all groups".
+/// </summary>
+public class ShortcutGroupTile
+{
+    public ShortcutGroup? Group { get; }
+    public string Name { get; }
+    public string IconName { get; }
+    public IBrush Brush { get; }
+    public int Count { get; }
+
+    public ShortcutGroupTile(ShortcutGroup group, int count)
+    {
+        Group = group;
+        Name = ShortcutGroupUi.GetName(group);
+        IconName = ShortcutGroupUi.GetIconName(group);
+        Brush = ShortcutGroupUi.GetBrush(group);
+        Count = count;
+    }
+
+    public ShortcutGroupTile(int count) // "All" tile
+    {
+        Group = null;
+        Name = Se.Language.General.All;
+        IconName = IconNames.ViewGrid;
+        Brush = new SolidColorBrush(Color.Parse("#8494a4"));
+        Count = count;
+    }
+}

--- a/src/ui/Features/Options/Shortcuts/ShortcutTreeNode.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutTreeNode.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Nikse.SubtitleEdit.Logic;
 
@@ -6,17 +6,23 @@ namespace Nikse.SubtitleEdit.Features.Options.Shortcuts;
 
 public partial class ShortcutTreeNode : ObservableObject
 {
-    [ObservableProperty] private string _category;
+    [ObservableProperty] private string _activeIn;
+    [ObservableProperty] private string _groupName;
+    [ObservableProperty] private string _groupIconName;
+    [ObservableProperty] private IBrush _groupBrush;
     [ObservableProperty] private string _title;
     [ObservableProperty] private string _displayShortcut;
 
     public ShortCut? ShortCut { get; set; }
 
-    public ShortcutTreeNode(string category, string title, string displayShortCut, ShortCut shortcut)
+    public ShortcutTreeNode(string activeIn, string title, string displayShortCut, ShortCut shortcut)
     {
-        Category = category;
+        ActiveIn = activeIn;
         Title = title;
         ShortCut = shortcut;
         DisplayShortcut = displayShortCut;
+        GroupName = ShortcutGroupUi.GetName(shortcut.Group);
+        GroupIconName = ShortcutGroupUi.GetIconName(shortcut.Group);
+        GroupBrush = ShortcutGroupUi.GetBrush(shortcut.Group);
     }
 }

--- a/src/ui/Features/Options/Shortcuts/ShortcutTreeNode.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutTreeNode.cs
@@ -1,6 +1,8 @@
 using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Nikse.SubtitleEdit.Logic;
+using System;
+using System.Collections.Generic;
 
 namespace Nikse.SubtitleEdit.Features.Options.Shortcuts;
 
@@ -10,8 +12,13 @@ public partial class ShortcutTreeNode : ObservableObject
     [ObservableProperty] private string _groupName;
     [ObservableProperty] private string _groupIconName;
     [ObservableProperty] private IBrush _groupBrush;
+    [ObservableProperty] private IBrush _groupSoftBrush;
     [ObservableProperty] private string _title;
     [ObservableProperty] private string _displayShortcut;
+    [ObservableProperty] private List<string> _keyParts;
+    [ObservableProperty] private bool _isAssigned;
+    [ObservableProperty] private bool _isUnassigned;
+    [ObservableProperty] private double _activeInOpacity;
 
     public ShortCut? ShortCut { get; set; }
 
@@ -21,8 +28,16 @@ public partial class ShortcutTreeNode : ObservableObject
         Title = title;
         ShortCut = shortcut;
         DisplayShortcut = displayShortCut;
+        KeyParts = string.IsNullOrEmpty(displayShortCut)
+            ? new List<string>()
+            : new List<string>(displayShortCut.Split(" + ", StringSplitOptions.None));
+        IsAssigned = KeyParts.Count > 0;
+        IsUnassigned = !IsAssigned;
         GroupName = ShortcutGroupUi.GetName(shortcut.Group);
         GroupIconName = ShortcutGroupUi.GetIconName(shortcut.Group);
         GroupBrush = ShortcutGroupUi.GetBrush(shortcut.Group);
+        GroupSoftBrush = ShortcutGroupUi.GetSoftBrush(shortcut.Group);
+        // "Everywhere" pills are dimmed so context-scoped shortcuts stand out while scrolling.
+        ActiveInOpacity = shortcut.Category == ShortcutCategory.General ? 0.55 : 1.0;
     }
 }

--- a/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
@@ -24,6 +24,8 @@ namespace Nikse.SubtitleEdit.Features.Options.Shortcuts;
 public partial class ShortcutsViewModel : ObservableObject
 {
     public ObservableCollection<ShortcutTreeNode> FlatNodes { get; } = new();
+    public ObservableCollection<ShortcutGroupTile> GroupTiles { get; } = new();
+    [ObservableProperty] private ShortcutGroupTile? _selectedGroupTile;
     [ObservableProperty] private ObservableCollection<string> _shortcuts;
     [ObservableProperty] private string? _selectedShortcut;
     [ObservableProperty] private ObservableCollection<string> _filters;
@@ -106,6 +108,11 @@ public partial class ShortcutsViewModel : ObservableObject
         _actorSlots[7] = Se.Settings.Actor8;
         _actorSlots[8] = Se.Settings.Actor9;
         _actorSlots[9] = Se.Settings.Actor10;
+    }
+
+    partial void OnSelectedGroupTileChanged(ShortcutGroupTile? value)
+    {
+        UpdateVisibleShortcuts(SearchText);
     }
 
     partial void OnCtrlIsSelectedChanged(bool value)
@@ -198,6 +205,7 @@ public partial class ShortcutsViewModel : ObservableObject
     {
         MainViewModel = vm;
         _allShortcuts = ShortcutsMain.GetAllShortcuts(vm);
+        BuildGroupTiles();
         UpdateVisibleShortcuts(string.Empty);
 
         _configurableCommands.Add(vm.SetColor1Command);
@@ -231,26 +239,48 @@ public partial class ShortcutsViewModel : ObservableObject
         _configurableCommands.Add(vm.SetActor10Command);
     }
 
+    private void BuildGroupTiles()
+    {
+        GroupTiles.Clear();
+        GroupTiles.Add(new ShortcutGroupTile(_allShortcuts.Count));
+        foreach (var group in Enum.GetValues<ShortcutGroup>())
+        {
+            var count = _allShortcuts.Count(p => p.Group == group);
+            if (count > 0)
+            {
+                GroupTiles.Add(new ShortcutGroupTile(group, count));
+            }
+        }
+
+        SelectedGroupTile = GroupTiles[0];
+    }
+
     internal void UpdateVisibleShortcuts(string searchText)
     {
         FlatNodes.Clear();
-        AddShortcuts(ShortcutCategory.General, Se.Language.Options.Shortcuts.CategoryGeneral, searchText);
-        AddShortcuts(ShortcutCategory.SubtitleGridAndTextBox,
-            Se.Language.Options.Shortcuts.CategorySubtitleGridAndTextBox, searchText);
-        AddShortcuts(ShortcutCategory.SubtitleGrid, Se.Language.Options.Shortcuts.CategorySubtitleGrid, searchText);
-        AddShortcuts(ShortcutCategory.Waveform, Se.Language.Options.Shortcuts.CategoryWaveform, searchText);
-        AddShortcuts(ShortcutCategory.TextBox, Se.Language.Options.Shortcuts.CategoryTextBox, searchText);
-    }
-
-    private void AddShortcuts(ShortcutCategory category, string categoryName, string searchText)
-    {
-        var shortcuts = _allShortcuts.Where(p => p.Category == category && Search(searchText, p)).ToList();
+        var group = SelectedGroupTile?.Group;
+        var shortcuts = _allShortcuts
+            .Where(p => (group == null || p.Group == group) && Search(searchText, p))
+            .OrderBy(p => (int)p.Group);
 
         foreach (var x in shortcuts)
         {
-            var leaf = new ShortcutTreeNode(categoryName, MakeDisplayName(x, false), MakeDisplayShortCut(x), x);
+            var leaf = new ShortcutTreeNode(GetActiveInName(x.Category), MakeDisplayName(x, false), MakeDisplayShortCut(x), x);
             FlatNodes.Add(leaf);
         }
+    }
+
+    private static string GetActiveInName(ShortcutCategory category)
+    {
+        var language = Se.Language.Options.Shortcuts;
+        return category switch
+        {
+            ShortcutCategory.SubtitleGridAndTextBox => language.CategorySubtitleGridAndTextBox,
+            ShortcutCategory.SubtitleGrid => language.CategorySubtitleGrid,
+            ShortcutCategory.Waveform => language.CategoryWaveform,
+            ShortcutCategory.TextBox => language.CategoryTextBox,
+            _ => language.ActiveInEverywhere,
+        };
     }
 
     private static string MakeDisplayName(ShortCut x, bool includeShortCutKeys = true)

--- a/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
@@ -48,11 +48,12 @@ public class ShortcutsWindow : Window
         // reading a generic "edit"/"combo box"/"check box" (issue #11745).
         AutomationProperties.SetName(_searchBox, language.SearchShortcuts);
 
+        var accentColor = UiUtil.GetAccentBrush() is ISolidColorBrush accentSolid ? accentSolid.Color : Colors.DodgerBlue;
         var labelBadgeCount = new Border
         {
-            Background = UiUtil.GetBorderBrush(),     // badge background
+            Background = new SolidColorBrush(accentColor, 0.18), // badge background
             CornerRadius = new CornerRadius(10),      // makes it pill-like
-            Padding = new Thickness(6, 3, 6, 2),      // spacing around text
+            Padding = new Thickness(8, 3, 8, 2),      // spacing around text
             Margin = new Thickness(0, 0, 12, 0),
             VerticalAlignment = VerticalAlignment.Center,
             HorizontalAlignment = HorizontalAlignment.Left,
@@ -60,8 +61,9 @@ public class ShortcutsWindow : Window
             {
                 [!TextBlock.TextProperty] = new Binding(nameof(vm.FlatNodes) + ".Count") { Source = vm, Mode = BindingMode.OneWay, Converter = new NumberToStringWithThousandSeparator() },
                 FontSize = 10,
+                FontWeight = FontWeight.SemiBold,
                 VerticalAlignment = VerticalAlignment.Center,
-                Foreground = Brushes.WhiteSmoke,
+                Foreground = new SolidColorBrush(accentColor),
                 HorizontalAlignment = HorizontalAlignment.Center
             }
         };
@@ -103,11 +105,22 @@ public class ShortcutsWindow : Window
             {
                 var icon = new ContentControl
                 {
-                    FontSize = 18,
+                    FontSize = 17,
+                    Foreground = Brushes.White,
                     HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
                 };
                 icon.Bind(Attached.IconProperty, new Binding(nameof(ShortcutGroupTile.IconName)));
-                icon.Bind(TemplatedControl.ForegroundProperty, new Binding(nameof(ShortcutGroupTile.Brush)));
+
+                var glyph = new Border
+                {
+                    Width = 32,
+                    Height = 32,
+                    CornerRadius = new CornerRadius(9),
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    Child = icon,
+                };
+                glyph.Bind(Border.BackgroundProperty, new Binding(nameof(ShortcutGroupTile.Brush)));
 
                 var name = new TextBlock
                 {
@@ -128,9 +141,9 @@ public class ShortcutsWindow : Window
                 return new StackPanel
                 {
                     Width = 92,
-                    Spacing = 2,
-                    Margin = new Thickness(0, 4, 0, 4),
-                    Children = { icon, name, count },
+                    Spacing = 3,
+                    Margin = new Thickness(0, 5, 0, 4),
+                    Children = { glyph, name, count },
                 };
             }),
         };
@@ -151,12 +164,35 @@ public class ShortcutsWindow : Window
             ItemsSource = vm.FlatNodes,
             Columns =
             {
-                new DataGridTextColumn
+                new DataGridTemplateColumn
                 {
                     Header = language.ActiveIn,
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    Binding = new Binding(nameof(ShortcutTreeNode.ActiveIn)),
+                    CanUserSort = false,
                     IsReadOnly = true,
+                    CellTemplate = new FuncDataTemplate<ShortcutTreeNode>((_, _) =>
+                    {
+                        var text = new TextBlock
+                        {
+                            FontSize = 11,
+                            VerticalAlignment = VerticalAlignment.Center,
+                        };
+                        text.Bind(TextBlock.TextProperty, new Binding(nameof(ShortcutTreeNode.ActiveIn)));
+
+                        var pill = new Border
+                        {
+                            BorderBrush = UiUtil.GetBorderBrush(),
+                            BorderThickness = new Thickness(1),
+                            CornerRadius = new CornerRadius(99),
+                            Padding = new Thickness(8, 1, 8, 2),
+                            Margin = new Thickness(4, 0, 4, 0),
+                            HorizontalAlignment = HorizontalAlignment.Left,
+                            VerticalAlignment = VerticalAlignment.Center,
+                            Child = text,
+                        };
+                        pill.Bind(Visual.OpacityProperty, new Binding(nameof(ShortcutTreeNode.ActiveInOpacity)));
+                        return pill;
+                    }),
                 },
                 new DataGridTemplateColumn
                 {
@@ -169,15 +205,26 @@ public class ShortcutsWindow : Window
                     {
                         var icon = new ContentControl
                         {
-                            FontSize = 16,
+                            FontSize = 14,
                             HorizontalAlignment = HorizontalAlignment.Center,
                             VerticalAlignment = VerticalAlignment.Center,
-                            Margin = new Thickness(4, 0, 4, 0),
                         };
                         icon.Bind(Attached.IconProperty, new Binding(nameof(ShortcutTreeNode.GroupIconName)));
                         icon.Bind(TemplatedControl.ForegroundProperty, new Binding(nameof(ShortcutTreeNode.GroupBrush)));
-                        icon.Bind(ToolTip.TipProperty, new Binding(nameof(ShortcutTreeNode.GroupName)));
-                        return icon;
+
+                        var square = new Border
+                        {
+                            Width = 22,
+                            Height = 22,
+                            CornerRadius = new CornerRadius(6),
+                            Margin = new Thickness(4, 2, 4, 2),
+                            HorizontalAlignment = HorizontalAlignment.Center,
+                            VerticalAlignment = VerticalAlignment.Center,
+                            Child = icon,
+                        };
+                        square.Bind(Border.BackgroundProperty, new Binding(nameof(ShortcutTreeNode.GroupSoftBrush)));
+                        square.Bind(ToolTip.TipProperty, new Binding(nameof(ShortcutTreeNode.GroupName)));
+                        return square;
                     }),
                 },
                 new DataGridTextColumn
@@ -195,13 +242,66 @@ public class ShortcutsWindow : Window
                     IsReadOnly = true,
                     Width = new DataGridLength(1, DataGridLengthUnitType.Star),
                 },
-                new DataGridTextColumn
+                new DataGridTemplateColumn
                 {
                     Header = Se.Language.General.Shortcut,
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    Binding = new Binding(nameof(ShortcutTreeNode.DisplayShortcut)),
+                    CanUserSort = false,
                     IsReadOnly = true,
                     Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
+                    CellTemplate = new FuncDataTemplate<ShortcutTreeNode>((_, _) =>
+                    {
+                        // Keycap-style chips, one per key, right-aligned like the column header side.
+                        var keys = new ItemsControl
+                        {
+                            HorizontalAlignment = HorizontalAlignment.Right,
+                            VerticalAlignment = VerticalAlignment.Center,
+                            ItemsPanel = new FuncTemplate<Panel?>(() => new StackPanel
+                            {
+                                Orientation = Orientation.Horizontal,
+                                Spacing = 3,
+                            }),
+                            ItemTemplate = new FuncDataTemplate<string>((_, _) =>
+                            {
+                                var keyText = new TextBlock
+                                {
+                                    FontSize = 11,
+                                    FontWeight = FontWeight.SemiBold,
+                                    HorizontalAlignment = HorizontalAlignment.Center,
+                                };
+                                keyText.Bind(TextBlock.TextProperty, new Binding("."));
+                                return new Border
+                                {
+                                    Background = new SolidColorBrush(Colors.Gray, 0.12),
+                                    BorderBrush = new SolidColorBrush(Colors.Gray, 0.45),
+                                    BorderThickness = new Thickness(1, 1, 1, 2),
+                                    CornerRadius = new CornerRadius(4),
+                                    Padding = new Thickness(6, 1, 6, 2),
+                                    MinWidth = 24,
+                                    Child = keyText,
+                                };
+                            }),
+                        };
+                        keys.Bind(ItemsControl.ItemsSourceProperty, new Binding(nameof(ShortcutTreeNode.KeyParts)));
+                        keys.Bind(Visual.IsVisibleProperty, new Binding(nameof(ShortcutTreeNode.IsAssigned)));
+
+                        var notSet = new TextBlock
+                        {
+                            Text = Se.Language.Options.Shortcuts.Unassigned,
+                            FontSize = 11,
+                            FontStyle = FontStyle.Italic,
+                            Opacity = 0.45,
+                            HorizontalAlignment = HorizontalAlignment.Right,
+                            VerticalAlignment = VerticalAlignment.Center,
+                        };
+                        notSet.Bind(Visual.IsVisibleProperty, new Binding(nameof(ShortcutTreeNode.IsUnassigned)));
+
+                        return new Panel
+                        {
+                            Margin = new Thickness(4, 2, 8, 2),
+                            Children = { keys, notSet },
+                        };
+                    }),
                 },
             },
         };
@@ -241,7 +341,22 @@ public class ShortcutsWindow : Window
         var buttonResetAllShortcuts = UiUtil.MakeButton(Se.Language.General.Reset, vm.ResetAllShortcutsCommand);
         var buttonImportSe4 = UiUtil.MakeButton(language.ImportFromSe4, vm.ImportFromSe4Command);
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CommandCancelCommand);
-        var buttonPanel = UiUtil.MakeButtonBar(buttonOk, buttonResetAllShortcuts, buttonImportSe4, buttonCancel);
+
+        // Utility actions on the left, dialog actions on the right.
+        var buttonBarLeft = UiUtil.MakeControlBarLeft(buttonImportSe4, buttonResetAllShortcuts);
+        buttonBarLeft.Margin = new Thickness(10, 20, 10, 10);
+        buttonBarLeft.VerticalAlignment = VerticalAlignment.Bottom;
+        var buttonBarRight = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+        var buttonPanel = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+        };
+        buttonPanel.Add(buttonBarLeft, 0, 0);
+        buttonPanel.Add(buttonBarRight, 0, 1);
 
         var grid = new Grid
         {
@@ -267,6 +382,8 @@ public class ShortcutsWindow : Window
         {
             Orientation = Orientation.Horizontal,
             Margin = new Thickness(10),
+            HorizontalAlignment = HorizontalAlignment.Right,
+            VerticalAlignment = VerticalAlignment.Center,
         };
 
         // Get platform-specific labels
@@ -334,7 +451,28 @@ public class ShortcutsWindow : Window
         editPanel.Children.Add(buttonReset);
         buttonReset.Bind(IsEnabledProperty, new Binding(nameof(vm.IsControlsEnabled)) { Source = vm });
 
-        var editGridBorder = UiUtil.MakeBorderForControl(editPanel);
+        // Name of the shortcut being edited on the left, key controls on the right.
+        var labelEditing = new TextBlock
+        {
+            FontWeight = FontWeight.SemiBold,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(10, 0, 10, 0),
+            TextTrimming = TextTrimming.CharacterEllipsis,
+        };
+        labelEditing.Bind(TextBlock.TextProperty, new Binding(nameof(vm.SelectedNode) + "." + nameof(ShortcutTreeNode.Title)) { Source = vm });
+
+        var editSplitGrid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+        };
+        editSplitGrid.Add(labelEditing, 0, 0);
+        editSplitGrid.Add(editPanel, 0, 1);
+
+        var editGridBorder = UiUtil.MakeBorderForControl(editSplitGrid);
         grid.Add(editGridBorder, 3);
         grid.Add(buttonPanel, 4);
 

--- a/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
@@ -1,6 +1,8 @@
 using Avalonia;
 using Avalonia.Automation;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Layout;
@@ -10,6 +12,7 @@ using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.ValueConverters;
 using System;
+using Attached = Optris.Icons.Avalonia.Attached;
 
 namespace Nikse.SubtitleEdit.Features.Options.Shortcuts;
 
@@ -23,10 +26,10 @@ public class ShortcutsWindow : Window
         var language = Se.Language.Options.Shortcuts;
         UiUtil.InitializeWindow(this, GetType().Name);
         Title = language.Title;
-        Width = 760;
-        Height = 650;
-        MinWidth = 740;
-        MinHeight = 500;
+        Width = 900;
+        Height = 720;
+        MinWidth = 860;
+        MinHeight = 550;
         CanResize = true;
 
         _vm = vm;
@@ -90,6 +93,50 @@ public class ShortcutsWindow : Window
         topGrid.Add(labelFilter, 0, 2);
         topGrid.Add(comboBoxFilter, 0, 3);
 
+        // Group filter tiles - one per thematic group, plus "All".
+        var groupTiles = new ListBox
+        {
+            ItemsSource = vm.GroupTiles,
+            Margin = new Thickness(10, 0, 10, 0),
+            ItemsPanel = new FuncTemplate<Panel?>(() => new WrapPanel { Orientation = Orientation.Horizontal }),
+            ItemTemplate = new FuncDataTemplate<ShortcutGroupTile>((_, _) =>
+            {
+                var icon = new ContentControl
+                {
+                    FontSize = 18,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                };
+                icon.Bind(Attached.IconProperty, new Binding(nameof(ShortcutGroupTile.IconName)));
+                icon.Bind(TemplatedControl.ForegroundProperty, new Binding(nameof(ShortcutGroupTile.Brush)));
+
+                var name = new TextBlock
+                {
+                    FontSize = 11,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    TextAlignment = TextAlignment.Center,
+                };
+                name.Bind(TextBlock.TextProperty, new Binding(nameof(ShortcutGroupTile.Name)));
+
+                var count = new TextBlock
+                {
+                    FontSize = 10,
+                    Opacity = 0.6,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                };
+                count.Bind(TextBlock.TextProperty, new Binding(nameof(ShortcutGroupTile.Count)));
+
+                return new StackPanel
+                {
+                    Width = 92,
+                    Spacing = 2,
+                    Margin = new Thickness(0, 4, 0, 4),
+                    Children = { icon, name, count },
+                };
+            }),
+        };
+        groupTiles.Bind(SelectingItemsControl.SelectedItemProperty, new Binding(nameof(vm.SelectedGroupTile)) { Source = vm, Mode = BindingMode.TwoWay });
+        AutomationProperties.SetName(groupTiles, Se.Language.General.Category);
+
         var dataGrid = new DataGrid
         {
             AutoGenerateColumns = false,
@@ -106,9 +153,38 @@ public class ShortcutsWindow : Window
             {
                 new DataGridTextColumn
                 {
+                    Header = language.ActiveIn,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(ShortcutTreeNode.ActiveIn)),
+                    IsReadOnly = true,
+                },
+                new DataGridTemplateColumn
+                {
+                    Header = string.Empty,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    CanUserSort = false,
+                    CanUserResize = false,
+                    IsReadOnly = true,
+                    CellTemplate = new FuncDataTemplate<ShortcutTreeNode>((_, _) =>
+                    {
+                        var icon = new ContentControl
+                        {
+                            FontSize = 16,
+                            HorizontalAlignment = HorizontalAlignment.Center,
+                            VerticalAlignment = VerticalAlignment.Center,
+                            Margin = new Thickness(4, 0, 4, 0),
+                        };
+                        icon.Bind(Attached.IconProperty, new Binding(nameof(ShortcutTreeNode.GroupIconName)));
+                        icon.Bind(TemplatedControl.ForegroundProperty, new Binding(nameof(ShortcutTreeNode.GroupBrush)));
+                        icon.Bind(ToolTip.TipProperty, new Binding(nameof(ShortcutTreeNode.GroupName)));
+                        return icon;
+                    }),
+                },
+                new DataGridTextColumn
+                {
                     Header = Se.Language.General.Category,
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    Binding = new Binding(nameof(ShortcutTreeNode.Category)),
+                    Binding = new Binding(nameof(ShortcutTreeNode.GroupName)),
                     IsReadOnly = true,
                 },
                 new DataGridTextColumn
@@ -172,6 +248,7 @@ public class ShortcutsWindow : Window
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
@@ -183,7 +260,8 @@ public class ShortcutsWindow : Window
             Margin = new Thickness(UiUtil.WindowMarginWidth),
         };
         grid.Add(topGrid, 0);
-        grid.Add(borderDataGrid, 1);
+        grid.Add(groupTiles, 1);
+        grid.Add(borderDataGrid, 2);
 
         var editPanel = new StackPanel
         {
@@ -257,8 +335,8 @@ public class ShortcutsWindow : Window
         buttonReset.Bind(IsEnabledProperty, new Binding(nameof(vm.IsControlsEnabled)) { Source = vm });
 
         var editGridBorder = UiUtil.MakeBorderForControl(editPanel);
-        grid.Add(editGridBorder, 2);
-        grid.Add(buttonPanel, 3);
+        grid.Add(editGridBorder, 3);
+        grid.Add(buttonPanel, 4);
 
         Content = grid;
 

--- a/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
@@ -205,7 +205,7 @@ public class ShortcutsWindow : Window
                     {
                         var icon = new ContentControl
                         {
-                            FontSize = 14,
+                            FontSize = 16,
                             HorizontalAlignment = HorizontalAlignment.Center,
                             VerticalAlignment = VerticalAlignment.Center,
                         };
@@ -214,8 +214,8 @@ public class ShortcutsWindow : Window
 
                         var square = new Border
                         {
-                            Width = 22,
-                            Height = 22,
+                            Width = 24,
+                            Height = 24,
                             CornerRadius = new CornerRadius(6),
                             Margin = new Thickness(4, 2, 4, 2),
                             HorizontalAlignment = HorizontalAlignment.Center,
@@ -227,12 +227,26 @@ public class ShortcutsWindow : Window
                         return square;
                     }),
                 },
-                new DataGridTextColumn
+                new DataGridTemplateColumn
                 {
                     Header = Se.Language.General.Category,
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    Binding = new Binding(nameof(ShortcutTreeNode.GroupName)),
+                    CanUserSort = false,
                     IsReadOnly = true,
+                    CellTemplate = new FuncDataTemplate<ShortcutTreeNode>((_, _) =>
+                    {
+                        // Category name in the group color so the grouping reads at a glance.
+                        var text = new TextBlock
+                        {
+                            FontSize = 12,
+                            FontWeight = FontWeight.Medium,
+                            VerticalAlignment = VerticalAlignment.Center,
+                            Margin = new Thickness(2, 0, 6, 0),
+                        };
+                        text.Bind(TextBlock.TextProperty, new Binding(nameof(ShortcutTreeNode.GroupName)));
+                        text.Bind(TextBlock.ForegroundProperty, new Binding(nameof(ShortcutTreeNode.GroupBrush)));
+                        return text;
+                    }),
                 },
                 new DataGridTextColumn
                 {
@@ -240,6 +254,7 @@ public class ShortcutsWindow : Window
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
                     Binding = new Binding(nameof(ShortcutTreeNode.Title)),
                     IsReadOnly = true,
+                    FontWeight = FontWeight.SemiBold,
                     Width = new DataGridLength(1, DataGridLengthUnitType.Star),
                 },
                 new DataGridTemplateColumn

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -14,6 +14,15 @@ public class LanguageSettingsShortcuts
     public string CategorySubtitleGrid { get; set; }
     public string CategoryWaveform { get; set; }
     public string CategoryTextBox { get; set; }
+    public string CategoryFile { get; set; }
+    public string CategoryVideo { get; set; }
+    public string CategorySync { get; set; }
+    public string CategoryTranslate { get; set; }
+    public string CategorySearch { get; set; }
+    public string CategoryTools { get; set; }
+    public string CategoryAi { get; set; }
+    public string ActiveIn { get; set; }
+    public string ActiveInEverywhere { get; set; }
 
     public string GeneralSetupLikeSe4 { get; set; }
 
@@ -324,6 +333,15 @@ public class LanguageSettingsShortcuts
         CategorySubtitleGrid = "Subtitle list view";
         CategoryWaveform = "Waveform";
         CategoryTextBox = "Text box";
+        CategoryFile = "File";
+        CategoryVideo = "Video";
+        CategorySync = "Synchronization";
+        CategoryTranslate = "Translate";
+        CategorySearch = "Search";
+        CategoryTools = "Tools";
+        CategoryAi = "AI";
+        ActiveIn = "Active in";
+        ActiveInEverywhere = "Everywhere";
 
         GeneralSetupLikeSe4 = "Set up like Subtitle Edit 4 (theme, shortcuts, replace rules)";
         GeneralMergeSelectedLines = "Merge selected lines";

--- a/src/ui/Logic/IconNames.cs
+++ b/src/ui/Logic/IconNames.cs
@@ -30,6 +30,7 @@ internal class IconNames
     public const string Cogs = "mdi-cogs";
     public const string ContentSave = "mdi-content-save";
     public const string Copy = "mdi-content-copy";
+    public const string Creation = "mdi-creation";
     public const string CheckCircle = "mdi-check-circle";
     public const string Download = "mdi-download";
     public const string CloudDownload = "mdi-cloud-download-outline";
@@ -45,12 +46,14 @@ internal class IconNames
     public const string EyeSettings = "mdi-eye-settings";
     public const string FileCog = "mdi-file-cog";
     public const string FileMultiple = "mdi-file-multiple";
+    public const string FileOutline = "mdi-file-outline";
     public const string Filter = "mdi-filter";
     public const string Find = "mdi-magnify";
     public const string FindReplace = "mdi-find-replace";
     public const string Folder = "mdi-folder";
     public const string FolderOpen = "mdi-folder-open";
     public const string FormatClear = "mdi-format-clear";
+    public const string FormTextBox = "mdi-form-textbox";
     public const string Fullscreen = "mdi-fullscreen";
     public const string FullscreenExit = "mdi-fullscreen-exit";
     public const string Help = "mdi-help";
@@ -66,6 +69,7 @@ internal class IconNames
     public const string MagnifyPlus = "mdi-magnify-plus";
     public const string MenuDown = "mdi-menu-down";
     public const string Minus = "mdi-minus";
+    public const string MovieOpenOutline = "mdi-movie-open-outline";
     public const string Netflix = "mdi-netflix";
     public const string Network = "mdi-network";
     public const string New = "mdi-invoice-text-plus";
@@ -101,10 +105,15 @@ internal class IconNames
     public const string Spellcheck = "mdi-spellcheck";
     public const string StopCircle = "mdi-stop-circle";
     public const string SwapVertical = "mdi-swap-vertical";
+    public const string Sync = "mdi-sync";
     public const string TimerMinus = "mdi-timer-minus-outline";
     public const string TimerSettings = "mdi-timer-cog-outline";
     public const string Tools = "mdi-tools";
+    public const string Translate = "mdi-translate";
     public const string Trash = "mdi-trash-can-outline";
+    public const string ViewGrid = "mdi-view-grid";
+    public const string ViewList = "mdi-view-list";
+    public const string ViewSplitVertical = "mdi-view-split-vertical";
     public const string Waveform = "mdi-waveform";
     public const string Web = "mdi-web";
 }

--- a/src/ui/Logic/Shortcut.cs
+++ b/src/ui/Logic/Shortcut.cs
@@ -11,6 +11,7 @@ public class ShortCut
 {
     public List<string> Keys { get; set; }
     public ShortcutCategory Category { get; set; }
+    public ShortcutGroup Group { get; set; }
     public string? Control { get; set; }
     public string Name { get; set; }
     public IRelayCommand Action { get; set; }
@@ -23,6 +24,7 @@ public class ShortCut
         Name = name;
         Keys = keys;
         Category = category;
+        Group = ShortcutGroupUi.FromCategory(category);
         Control = category.ToString();
         Action = action;
         HashCode = CalculateHash(keys, Control);
@@ -49,6 +51,7 @@ public class ShortCut
         Keys = keys.Keys;
         Action = shortcut.RelayCommand;
         Category = shortcut.Category;
+        Group = shortcut.Group;
         Name = shortcut.Name;
         Control = shortcut.Category.ToString();
         HashCode = CalculateHash(Keys, Control);
@@ -60,6 +63,7 @@ public class ShortCut
         Keys = new List<string>();
         Action = shortcut.RelayCommand;
         Category = shortcut.Category;
+        Group = shortcut.Group;
         Name = shortcut.Name;
         Control = string.Empty;
         HashCode = CalculateHash(Keys, Control);

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -54,6 +54,12 @@ public static class ShortcutsMain
         list.Add(new AvailableShortcut(command, name, category));
     }
 
+    private static void AddShortcut<T>(IList<AvailableShortcut> list, T command, string name, ShortcutCategory category, ShortcutGroup group)
+    where T : IRelayCommand
+    {
+        list.Add(new AvailableShortcut(command, name, category) { Group = group });
+    }
+
     public static readonly Dictionary<string, string> CommandTranslationLookup = BuildCommandTranslations();
 
     // Rebuilds CommandTranslationLookup in place so callers keep their reference to
@@ -471,9 +477,9 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.DoAlignmentAn9Command, nameof(vm.DoAlignmentAn9Command), ShortcutCategory.SubtitleGrid);
         AddShortcut(shortcuts, vm.AddOrEditBookmarkCommand, nameof(vm.AddOrEditBookmarkCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ToggleBookmarkSelectedLinesNoTextCommand, nameof(vm.ToggleBookmarkSelectedLinesNoTextCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.CopyTextFromOriginalToTranslationCommand, nameof(vm.CopyTextFromOriginalToTranslationCommand), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.SwitchOriginalAndTranslationTextSelectedLinesCommand, nameof(vm.SwitchOriginalAndTranslationTextSelectedLinesCommand), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.MergeOriginalIntoTranslationSelectedLinesCommand, nameof(vm.MergeOriginalIntoTranslationSelectedLinesCommand), ShortcutCategory.SubtitleGrid);
+        AddShortcut(shortcuts, vm.CopyTextFromOriginalToTranslationCommand, nameof(vm.CopyTextFromOriginalToTranslationCommand), ShortcutCategory.SubtitleGrid, ShortcutGroup.Translate);
+        AddShortcut(shortcuts, vm.SwitchOriginalAndTranslationTextSelectedLinesCommand, nameof(vm.SwitchOriginalAndTranslationTextSelectedLinesCommand), ShortcutCategory.SubtitleGrid, ShortcutGroup.Translate);
+        AddShortcut(shortcuts, vm.MergeOriginalIntoTranslationSelectedLinesCommand, nameof(vm.MergeOriginalIntoTranslationSelectedLinesCommand), ShortcutCategory.SubtitleGrid, ShortcutGroup.Translate);
         AddShortcut(shortcuts, vm.ListBookmarksCommand, nameof(vm.ListBookmarksCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToNextBookmarkCommand, nameof(vm.GoToNextBookmarkCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToPreviousBookmarkCommand, nameof(vm.GoToPreviousBookmarkCommand), ShortcutCategory.General);
@@ -483,61 +489,61 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.SetupLikeSe4Command, nameof(vm.SetupLikeSe4Command), ShortcutCategory.General);
 
         // File
-        AddShortcut(shortcuts, vm.CommandFileOpenCommand, nameof(vm.CommandFileOpenCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.CommandExitCommand, nameof(vm.CommandExitCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.CommandFileNewCommand, nameof(vm.CommandFileNewCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.CommandFileNewKeepVideoCommand, nameof(vm.CommandFileNewKeepVideoCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.CommandFileSaveCommand, nameof(vm.CommandFileSaveCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.CommandFileSaveAsCommand, nameof(vm.CommandFileSaveAsCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowStatisticsCommand, nameof(vm.ShowStatisticsCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowCompareCommand, nameof(vm.ShowCompareCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowRestoreAutoBackupCommand, nameof(vm.ShowRestoreAutoBackupCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.OpenContainingFolderCommand, nameof(vm.OpenContainingFolderCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.CopySubtitlePathToClipboardCommand, nameof(vm.CopySubtitlePathToClipboardCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.CopySubtitleOriginalPathToClipboardCommand, nameof(vm.CopySubtitleOriginalPathToClipboardCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ImportTimeCodesCommand, nameof(vm.ImportTimeCodesCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowImportSubtitleWithManuallyChosenEncodingCommand, nameof(vm.ShowImportSubtitleWithManuallyChosenEncodingCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.CommandFileOpenKeepVideoCommand, nameof(vm.CommandFileOpenKeepVideoCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.FileOpenOriginalCommand, nameof(vm.FileOpenOriginalCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.FileCloseOriginalCommand, nameof(vm.FileCloseOriginalCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ToggleTranslationModeCommand, nameof(vm.ToggleTranslationModeCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.FileCloseTranslationCommand, nameof(vm.FileCloseTranslationCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ExportBluRaySupCommand, nameof(vm.ExportBluRaySupCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowExportCustomTextFormatCommand, nameof(vm.ShowExportCustomTextFormatCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowExportPlainTextCommand, nameof(vm.ShowExportPlainTextCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.CommandFileOpenCommand, nameof(vm.CommandFileOpenCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.CommandExitCommand, nameof(vm.CommandExitCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.CommandFileNewCommand, nameof(vm.CommandFileNewCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.CommandFileNewKeepVideoCommand, nameof(vm.CommandFileNewKeepVideoCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.CommandFileSaveCommand, nameof(vm.CommandFileSaveCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.CommandFileSaveAsCommand, nameof(vm.CommandFileSaveAsCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.ShowStatisticsCommand, nameof(vm.ShowStatisticsCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.ShowCompareCommand, nameof(vm.ShowCompareCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.ShowRestoreAutoBackupCommand, nameof(vm.ShowRestoreAutoBackupCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.OpenContainingFolderCommand, nameof(vm.OpenContainingFolderCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.CopySubtitlePathToClipboardCommand, nameof(vm.CopySubtitlePathToClipboardCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.CopySubtitleOriginalPathToClipboardCommand, nameof(vm.CopySubtitleOriginalPathToClipboardCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.ImportTimeCodesCommand, nameof(vm.ImportTimeCodesCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.ShowImportSubtitleWithManuallyChosenEncodingCommand, nameof(vm.ShowImportSubtitleWithManuallyChosenEncodingCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.CommandFileOpenKeepVideoCommand, nameof(vm.CommandFileOpenKeepVideoCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.FileOpenOriginalCommand, nameof(vm.FileOpenOriginalCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.FileCloseOriginalCommand, nameof(vm.FileCloseOriginalCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.ToggleTranslationModeCommand, nameof(vm.ToggleTranslationModeCommand), ShortcutCategory.General, ShortcutGroup.Translate);
+        AddShortcut(shortcuts, vm.FileCloseTranslationCommand, nameof(vm.FileCloseTranslationCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.ExportBluRaySupCommand, nameof(vm.ExportBluRaySupCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.ShowExportCustomTextFormatCommand, nameof(vm.ShowExportCustomTextFormatCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.ShowExportPlainTextCommand, nameof(vm.ShowExportPlainTextCommand), ShortcutCategory.General, ShortcutGroup.File);
         AddShortcut(shortcuts, vm.CopyMsRelativeToCurrentSubtitleLineToClipboardCommand, nameof(vm.CopyMsRelativeToCurrentSubtitleLineToClipboardCommand), ShortcutCategory.General);
 
         AddShortcut(shortcuts, vm.UndoCommand, nameof(vm.UndoCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.RedoCommand, nameof(vm.RedoCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ShowHistoryCommand, nameof(vm.ShowHistoryCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowFindCommand, nameof(vm.ShowFindCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.FindNextCommand, nameof(vm.FindNextCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.FindPreviousCommand, nameof(vm.FindPreviousCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowReplaceCommand, nameof(vm.ShowReplaceCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowMultipleReplaceCommand, nameof(vm.ShowMultipleReplaceCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowGoToLineCommand, nameof(vm.ShowGoToLineCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.ShowFindCommand, nameof(vm.ShowFindCommand), ShortcutCategory.General, ShortcutGroup.Search);
+        AddShortcut(shortcuts, vm.FindNextCommand, nameof(vm.FindNextCommand), ShortcutCategory.General, ShortcutGroup.Search);
+        AddShortcut(shortcuts, vm.FindPreviousCommand, nameof(vm.FindPreviousCommand), ShortcutCategory.General, ShortcutGroup.Search);
+        AddShortcut(shortcuts, vm.ShowReplaceCommand, nameof(vm.ShowReplaceCommand), ShortcutCategory.General, ShortcutGroup.Search);
+        AddShortcut(shortcuts, vm.ShowMultipleReplaceCommand, nameof(vm.ShowMultipleReplaceCommand), ShortcutCategory.General, ShortcutGroup.Search);
+        AddShortcut(shortcuts, vm.ShowGoToLineCommand, nameof(vm.ShowGoToLineCommand), ShortcutCategory.General, ShortcutGroup.Search);
         AddShortcut(shortcuts, vm.RightToLeftToggleCommand, nameof(vm.RightToLeftToggleCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ReverseRightToLeftStartEndCommand, nameof(vm.ReverseRightToLeftStartEndCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ShowModifySelectionCommand, nameof(vm.ShowModifySelectionCommand), ShortcutCategory.General);
 
-        AddShortcut(shortcuts, vm.ShowGoToVideoPositionCommand, nameof(vm.ShowGoToVideoPositionCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.ShowGoToVideoPositionCommand, nameof(vm.ShowGoToVideoPositionCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.ToggleLinesItalicOrSelectedTextCommand, nameof(vm.ToggleLinesItalicOrSelectedTextCommand), ShortcutCategory.SubtitleGridAndTextBox);
         AddShortcut(shortcuts, vm.ToggleLinesBoldOrSelectedTextCommand, nameof(vm.ToggleLinesBoldOrSelectedTextCommand), ShortcutCategory.SubtitleGridAndTextBox);
 
-        AddShortcut(shortcuts, vm.PlayCommand, nameof(vm.PlayCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.PlayNextCommand, nameof(vm.PlayNextCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.PlayNextAndStopCommand, nameof(vm.PlayNextAndStopCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.PlayNextAndLoopCommand, nameof(vm.PlayNextAndLoopCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.PlayPreviousCommand, nameof(vm.PlayPreviousCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.PlayPreviousAndStopCommand, nameof(vm.PlayPreviousAndStopCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.PlayPreviousAndLoopCommand, nameof(vm.PlayPreviousAndLoopCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.PauseCommand, nameof(vm.PauseCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.TogglePlayPauseCommand, nameof(vm.TogglePlayPauseCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.TogglePlayPause2Command, nameof(vm.TogglePlayPause2Command), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.PlayCommand, nameof(vm.PlayCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.PlayNextCommand, nameof(vm.PlayNextCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.PlayNextAndStopCommand, nameof(vm.PlayNextAndStopCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.PlayNextAndLoopCommand, nameof(vm.PlayNextAndLoopCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.PlayPreviousCommand, nameof(vm.PlayPreviousCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.PlayPreviousAndStopCommand, nameof(vm.PlayPreviousAndStopCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.PlayPreviousAndLoopCommand, nameof(vm.PlayPreviousAndLoopCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.PauseCommand, nameof(vm.PauseCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.TogglePlayPauseCommand, nameof(vm.TogglePlayPauseCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.TogglePlayPause2Command, nameof(vm.TogglePlayPause2Command), ShortcutCategory.General, ShortcutGroup.Video);
 
         AddShortcut(shortcuts, vm.CommandShowLayoutCommand, nameof(vm.CommandShowLayoutCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowAutoTranslateCommand, nameof(vm.ShowAutoTranslateCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowTranslateViaCopyPasteCommand, nameof(vm.ShowTranslateViaCopyPasteCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.ShowAutoTranslateCommand, nameof(vm.ShowAutoTranslateCommand), ShortcutCategory.General, ShortcutGroup.Translate);
+        AddShortcut(shortcuts, vm.ShowTranslateViaCopyPasteCommand, nameof(vm.ShowTranslateViaCopyPasteCommand), ShortcutCategory.General, ShortcutGroup.Translate);
         AddShortcut(shortcuts, vm.CommandShowSettingsCommand, nameof(vm.CommandShowSettingsCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.CommandShowSettingsShortcutsCommand, nameof(vm.CommandShowSettingsShortcutsCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ShowWordListsCommand, nameof(vm.ShowWordListsCommand), ShortcutCategory.General);
@@ -549,8 +555,8 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.GoToNextLineAndSetVideoPositionCommand, nameof(vm.GoToNextLineAndSetVideoPositionCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToPreviousLineFromVideoPositionCommand, nameof(vm.GoToPreviousLineFromVideoPositionCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToNextLineFromVideoPositionCommand, nameof(vm.GoToNextLineFromVideoPositionCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoGoToPreviousTimeCodeCommand, nameof(vm.VideoGoToPreviousTimeCodeCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoGoToNextTimeCodeCommand, nameof(vm.VideoGoToNextTimeCodeCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.VideoGoToPreviousTimeCodeCommand, nameof(vm.VideoGoToPreviousTimeCodeCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoGoToNextTimeCodeCommand, nameof(vm.VideoGoToNextTimeCodeCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.SaveLanguageFileCommand, nameof(vm.SaveLanguageFileCommand), ShortcutCategory.General);
 
         AddShortcut(shortcuts, vm.UnbreakCommand, nameof(vm.UnbreakCommand), ShortcutCategory.General);
@@ -570,73 +576,73 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.TextBoxItalicCommand, nameof(vm.TextBoxItalicCommand), ShortcutCategory.TextBox);
 
         // Tools
-        AddShortcut(shortcuts, vm.ShowBridgeGapsCommand, nameof(vm.ShowBridgeGapsCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowToolsAdjustDurationsCommand, nameof(vm.ShowToolsAdjustDurationsCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowApplyDurationLimitsCommand, nameof(vm.ShowApplyDurationLimitsCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowToolsBatchConvertCommand, nameof(vm.ShowToolsBatchConvertCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowApplyMinGapCommand, nameof(vm.ShowApplyMinGapCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowToolsChangeCasingCommand, nameof(vm.ShowToolsChangeCasingCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowToolsChangeFormattingCommand, nameof(vm.ShowToolsChangeFormattingCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowToolsFixCommonErrorsCommand, nameof(vm.ShowToolsFixCommonErrorsCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowToolsAiReviewCommand, nameof(vm.ShowToolsAiReviewCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ToolsMakeEmptyTranslationFromCurrentSubtitleCommand, nameof(vm.ToolsMakeEmptyTranslationFromCurrentSubtitleCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowToolsMergeLinesWithSameTextCommand, nameof(vm.ShowToolsMergeLinesWithSameTextCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowToolsMergeLinesWithSameTimeCodesCommand, nameof(vm.ShowToolsMergeLinesWithSameTimeCodesCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowToolsSplitBreakLongLinesCommand, nameof(vm.ShowToolsSplitBreakLongLinesCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowToolsMergeShortLinesCommand, nameof(vm.ShowToolsMergeShortLinesCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowToolsMergeContinuationLinesCommand, nameof(vm.ShowToolsMergeContinuationLinesCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.SnapAllTimesToFramesCommand, nameof(vm.SnapAllTimesToFramesCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowToolsRemoveTextForHearingImpairedCommand, nameof(vm.ShowToolsRemoveTextForHearingImpairedCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowToolsJoinCommand, nameof(vm.ShowToolsJoinCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowToolsSplitCommand, nameof(vm.ShowToolsSplitCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.ShowBridgeGapsCommand, nameof(vm.ShowBridgeGapsCommand), ShortcutCategory.General, ShortcutGroup.Tools);
+        AddShortcut(shortcuts, vm.ShowToolsAdjustDurationsCommand, nameof(vm.ShowToolsAdjustDurationsCommand), ShortcutCategory.General, ShortcutGroup.Tools);
+        AddShortcut(shortcuts, vm.ShowApplyDurationLimitsCommand, nameof(vm.ShowApplyDurationLimitsCommand), ShortcutCategory.General, ShortcutGroup.Tools);
+        AddShortcut(shortcuts, vm.ShowToolsBatchConvertCommand, nameof(vm.ShowToolsBatchConvertCommand), ShortcutCategory.General, ShortcutGroup.Tools);
+        AddShortcut(shortcuts, vm.ShowApplyMinGapCommand, nameof(vm.ShowApplyMinGapCommand), ShortcutCategory.General, ShortcutGroup.Tools);
+        AddShortcut(shortcuts, vm.ShowToolsChangeCasingCommand, nameof(vm.ShowToolsChangeCasingCommand), ShortcutCategory.General, ShortcutGroup.Tools);
+        AddShortcut(shortcuts, vm.ShowToolsChangeFormattingCommand, nameof(vm.ShowToolsChangeFormattingCommand), ShortcutCategory.General, ShortcutGroup.Tools);
+        AddShortcut(shortcuts, vm.ShowToolsFixCommonErrorsCommand, nameof(vm.ShowToolsFixCommonErrorsCommand), ShortcutCategory.General, ShortcutGroup.Tools);
+        AddShortcut(shortcuts, vm.ShowToolsAiReviewCommand, nameof(vm.ShowToolsAiReviewCommand), ShortcutCategory.General, ShortcutGroup.Ai);
+        AddShortcut(shortcuts, vm.ToolsMakeEmptyTranslationFromCurrentSubtitleCommand, nameof(vm.ToolsMakeEmptyTranslationFromCurrentSubtitleCommand), ShortcutCategory.General, ShortcutGroup.Translate);
+        AddShortcut(shortcuts, vm.ShowToolsMergeLinesWithSameTextCommand, nameof(vm.ShowToolsMergeLinesWithSameTextCommand), ShortcutCategory.General, ShortcutGroup.Tools);
+        AddShortcut(shortcuts, vm.ShowToolsMergeLinesWithSameTimeCodesCommand, nameof(vm.ShowToolsMergeLinesWithSameTimeCodesCommand), ShortcutCategory.General, ShortcutGroup.Tools);
+        AddShortcut(shortcuts, vm.ShowToolsSplitBreakLongLinesCommand, nameof(vm.ShowToolsSplitBreakLongLinesCommand), ShortcutCategory.General, ShortcutGroup.Tools);
+        AddShortcut(shortcuts, vm.ShowToolsMergeShortLinesCommand, nameof(vm.ShowToolsMergeShortLinesCommand), ShortcutCategory.General, ShortcutGroup.Tools);
+        AddShortcut(shortcuts, vm.ShowToolsMergeContinuationLinesCommand, nameof(vm.ShowToolsMergeContinuationLinesCommand), ShortcutCategory.General, ShortcutGroup.Tools);
+        AddShortcut(shortcuts, vm.SnapAllTimesToFramesCommand, nameof(vm.SnapAllTimesToFramesCommand), ShortcutCategory.General, ShortcutGroup.Sync);
+        AddShortcut(shortcuts, vm.ShowToolsRemoveTextForHearingImpairedCommand, nameof(vm.ShowToolsRemoveTextForHearingImpairedCommand), ShortcutCategory.General, ShortcutGroup.Tools);
+        AddShortcut(shortcuts, vm.ShowToolsJoinCommand, nameof(vm.ShowToolsJoinCommand), ShortcutCategory.General, ShortcutGroup.Tools);
+        AddShortcut(shortcuts, vm.ShowToolsSplitCommand, nameof(vm.ShowToolsSplitCommand), ShortcutCategory.General, ShortcutGroup.Tools);
 
         // Spell check
-        AddShortcut(shortcuts, vm.ShowSpellCheckCommand, nameof(vm.ShowSpellCheckCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowSpellCheckDictionariesCommand, nameof(vm.ShowSpellCheckDictionariesCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.CommandPickLiveSpellCheckDictionaryCommand, nameof(vm.CommandPickLiveSpellCheckDictionaryCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.ShowSpellCheckCommand, nameof(vm.ShowSpellCheckCommand), ShortcutCategory.General, ShortcutGroup.Tools);
+        AddShortcut(shortcuts, vm.ShowSpellCheckDictionariesCommand, nameof(vm.ShowSpellCheckDictionariesCommand), ShortcutCategory.General, ShortcutGroup.Tools);
+        AddShortcut(shortcuts, vm.CommandPickLiveSpellCheckDictionaryCommand, nameof(vm.CommandPickLiveSpellCheckDictionaryCommand), ShortcutCategory.General, ShortcutGroup.Tools);
 
         // Video
-        AddShortcut(shortcuts, vm.CommandVideoOpenCommand, nameof(vm.CommandVideoOpenCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowVideoOpenFromUrlCommand, nameof(vm.ShowVideoOpenFromUrlCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.CommandVideoCloseCommand, nameof(vm.CommandVideoCloseCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowSpeechToTextWhisperCommand, nameof(vm.ShowSpeechToTextWhisperCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowVideoTextToSpeechCommand, nameof(vm.ShowVideoTextToSpeechCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowVideoOcrCommand, nameof(vm.ShowVideoOcrCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowVideoBurnInCommand, nameof(vm.ShowVideoBurnInCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowVideoTransparentSubtitlesCommand, nameof(vm.ShowVideoTransparentSubtitlesCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowShotChangesSubtitlesCommand, nameof(vm.ShowShotChangesSubtitlesCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowShotChangesListCommand, nameof(vm.ShowShotChangesListCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoUndockControlsCommand, nameof(vm.VideoUndockControlsCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoRedockControlsCommand, nameof(vm.VideoRedockControlsCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoGenerateBlankCommand, nameof(vm.VideoGenerateBlankCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoReEncodeCommand, nameof(vm.VideoReEncodeCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoCutCommand, nameof(vm.VideoCutCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.CutVideoSelectedLinesCommand, nameof(vm.CutVideoSelectedLinesCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoFullScreenCommand, nameof(vm.VideoFullScreenCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.CommandVideoOpenCommand, nameof(vm.CommandVideoOpenCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.ShowVideoOpenFromUrlCommand, nameof(vm.ShowVideoOpenFromUrlCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.CommandVideoCloseCommand, nameof(vm.CommandVideoCloseCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.ShowSpeechToTextWhisperCommand, nameof(vm.ShowSpeechToTextWhisperCommand), ShortcutCategory.General, ShortcutGroup.Ai);
+        AddShortcut(shortcuts, vm.ShowVideoTextToSpeechCommand, nameof(vm.ShowVideoTextToSpeechCommand), ShortcutCategory.General, ShortcutGroup.Ai);
+        AddShortcut(shortcuts, vm.ShowVideoOcrCommand, nameof(vm.ShowVideoOcrCommand), ShortcutCategory.General, ShortcutGroup.Ai);
+        AddShortcut(shortcuts, vm.ShowVideoBurnInCommand, nameof(vm.ShowVideoBurnInCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.ShowVideoTransparentSubtitlesCommand, nameof(vm.ShowVideoTransparentSubtitlesCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.ShowShotChangesSubtitlesCommand, nameof(vm.ShowShotChangesSubtitlesCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.ShowShotChangesListCommand, nameof(vm.ShowShotChangesListCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoUndockControlsCommand, nameof(vm.VideoUndockControlsCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoRedockControlsCommand, nameof(vm.VideoRedockControlsCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoGenerateBlankCommand, nameof(vm.VideoGenerateBlankCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoReEncodeCommand, nameof(vm.VideoReEncodeCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoCutCommand, nameof(vm.VideoCutCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.CutVideoSelectedLinesCommand, nameof(vm.CutVideoSelectedLinesCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoFullScreenCommand, nameof(vm.VideoFullScreenCommand), ShortcutCategory.General, ShortcutGroup.Video);
 
-        AddShortcut(shortcuts, vm.ShowSyncAdjustAllTimesCommand, nameof(vm.ShowSyncAdjustAllTimesCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowVisualSyncCommand, nameof(vm.ShowVisualSyncCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowSyncChangeFrameRateCommand, nameof(vm.ShowSyncChangeFrameRateCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowSyncChangeSpeedCommand, nameof(vm.ShowSyncChangeSpeedCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowPointSyncCommand, nameof(vm.ShowPointSyncCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowPointSyncViaOtherCommand, nameof(vm.ShowPointSyncViaOtherCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.ShowSyncAdjustAllTimesCommand, nameof(vm.ShowSyncAdjustAllTimesCommand), ShortcutCategory.General, ShortcutGroup.Sync);
+        AddShortcut(shortcuts, vm.ShowVisualSyncCommand, nameof(vm.ShowVisualSyncCommand), ShortcutCategory.General, ShortcutGroup.Sync);
+        AddShortcut(shortcuts, vm.ShowSyncChangeFrameRateCommand, nameof(vm.ShowSyncChangeFrameRateCommand), ShortcutCategory.General, ShortcutGroup.Sync);
+        AddShortcut(shortcuts, vm.ShowSyncChangeSpeedCommand, nameof(vm.ShowSyncChangeSpeedCommand), ShortcutCategory.General, ShortcutGroup.Sync);
+        AddShortcut(shortcuts, vm.ShowPointSyncCommand, nameof(vm.ShowPointSyncCommand), ShortcutCategory.General, ShortcutGroup.Sync);
+        AddShortcut(shortcuts, vm.ShowPointSyncViaOtherCommand, nameof(vm.ShowPointSyncViaOtherCommand), ShortcutCategory.General, ShortcutGroup.Sync);
 
-        AddShortcut(shortcuts, vm.VideoOneFrameBackCommand, nameof(vm.VideoOneFrameBackCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoOneFrameForwardCommand, nameof(vm.VideoOneFrameForwardCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.Video100MsBackCommand, nameof(vm.Video100MsBackCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.Video100MsForwardCommand, nameof(vm.Video100MsForwardCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.Video500MsBackCommand, nameof(vm.Video500MsBackCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.Video500MsForwardCommand, nameof(vm.Video500MsForwardCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoOneSecondBackCommand, nameof(vm.VideoOneSecondBackCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoOneSecondForwardCommand, nameof(vm.VideoOneSecondForwardCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoMoveCustom1BackCommand, nameof(vm.VideoMoveCustom1BackCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoMoveCustom1ForwardCommand, nameof(vm.VideoMoveCustom1ForwardCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoMoveCustom2BackCommand, nameof(vm.VideoMoveCustom2BackCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoMoveCustom2ForwardCommand, nameof(vm.VideoMoveCustom2ForwardCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoMoveCustom3BackCommand, nameof(vm.VideoMoveCustom3BackCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoMoveCustom3ForwardCommand, nameof(vm.VideoMoveCustom3ForwardCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoMoveCustom4BackCommand, nameof(vm.VideoMoveCustom4BackCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoMoveCustom4ForwardCommand, nameof(vm.VideoMoveCustom4ForwardCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.VideoOneFrameBackCommand, nameof(vm.VideoOneFrameBackCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoOneFrameForwardCommand, nameof(vm.VideoOneFrameForwardCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.Video100MsBackCommand, nameof(vm.Video100MsBackCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.Video100MsForwardCommand, nameof(vm.Video100MsForwardCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.Video500MsBackCommand, nameof(vm.Video500MsBackCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.Video500MsForwardCommand, nameof(vm.Video500MsForwardCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoOneSecondBackCommand, nameof(vm.VideoOneSecondBackCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoOneSecondForwardCommand, nameof(vm.VideoOneSecondForwardCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoMoveCustom1BackCommand, nameof(vm.VideoMoveCustom1BackCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoMoveCustom1ForwardCommand, nameof(vm.VideoMoveCustom1ForwardCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoMoveCustom2BackCommand, nameof(vm.VideoMoveCustom2BackCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoMoveCustom2ForwardCommand, nameof(vm.VideoMoveCustom2ForwardCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoMoveCustom3BackCommand, nameof(vm.VideoMoveCustom3BackCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoMoveCustom3ForwardCommand, nameof(vm.VideoMoveCustom3ForwardCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoMoveCustom4BackCommand, nameof(vm.VideoMoveCustom4BackCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoMoveCustom4ForwardCommand, nameof(vm.VideoMoveCustom4ForwardCommand), ShortcutCategory.General, ShortcutGroup.Video);
 
         AddShortcut(shortcuts, vm.WaveformSetStartAndOffsetTheRestCommand, nameof(vm.WaveformSetStartAndOffsetTheRestCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.WaveformSetEndAndOffsetTheRestCommand, nameof(vm.WaveformSetEndAndOffsetTheRestCommand), ShortcutCategory.Waveform);
@@ -659,8 +665,8 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.ShowWaveformSeekSilenceCommand, nameof(vm.ShowWaveformSeekSilenceCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.SeekSilenceBackCommand, nameof(vm.SeekSilenceBackCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.SeekSilenceForwardCommand, nameof(vm.SeekSilenceForwardCommand), ShortcutCategory.Waveform);
-        AddShortcut(shortcuts, vm.GoToPreviousShotChangeCommand, nameof(vm.GoToPreviousShotChangeCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.GoToNextShotChangeCommand, nameof(vm.GoToNextShotChangeCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.GoToPreviousShotChangeCommand, nameof(vm.GoToPreviousShotChangeCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.GoToNextShotChangeCommand, nameof(vm.GoToNextShotChangeCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.ExtendSelectedLinesToNextShotChangeOrNextSubtitleCommand, nameof(vm.ExtendSelectedLinesToNextShotChangeOrNextSubtitleCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ExtendSelectedLinesToPreviousShotChangeCommand, nameof(vm.ExtendSelectedLinesToPreviousShotChangeCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SnapSelectedLinesToNearestShotChangeCommand, nameof(vm.SnapSelectedLinesToNearestShotChangeCommand), ShortcutCategory.General);
@@ -670,8 +676,8 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.SetInCueToClosestShotChangeRightGreenZoneCommand, nameof(vm.SetInCueToClosestShotChangeRightGreenZoneCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SetOutCueToClosestShotChangeLeftGreenZoneCommand, nameof(vm.SetOutCueToClosestShotChangeLeftGreenZoneCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SetOutCueToClosestShotChangeRightGreenZoneCommand, nameof(vm.SetOutCueToClosestShotChangeRightGreenZoneCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.MoveAllShotChangeOneFrameBackCommand, nameof(vm.MoveAllShotChangeOneFrameBackCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.MoveAllShotChangeOneFrameForwardCommand, nameof(vm.MoveAllShotChangeOneFrameForwardCommand), ShortcutCategory.General);   
+        AddShortcut(shortcuts, vm.MoveAllShotChangeOneFrameBackCommand, nameof(vm.MoveAllShotChangeOneFrameBackCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.MoveAllShotChangeOneFrameForwardCommand, nameof(vm.MoveAllShotChangeOneFrameForwardCommand), ShortcutCategory.General, ShortcutGroup.Video);
 
         AddShortcut(shortcuts, vm.ResetWaveformZoomAndSpeedCommand, nameof(vm.ResetWaveformZoomAndSpeedCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ExtendSelectedToPreviousCommand, nameof(vm.ExtendSelectedToPreviousCommand), ShortcutCategory.General);
@@ -721,28 +727,28 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.ColumnPasteFromClipboardCommand, nameof(vm.ColumnPasteFromClipboardCommand), ShortcutCategory.SubtitleGrid);
         AddShortcut(shortcuts, vm.ColumnTextUpCommand, nameof(vm.ColumnTextUpCommand), ShortcutCategory.SubtitleGrid);
         AddShortcut(shortcuts, vm.ColumnTextDownCommand, nameof(vm.ColumnTextDownCommand), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.ImportPlainTextCommand, nameof(vm.ImportPlainTextCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ExportEbuStlCommand, nameof(vm.ExportEbuStlCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ExportPacCommand, nameof(vm.ExportPacCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.FixRightToLeftViaUnicodeControlCharactersCommand, nameof(vm.FixRightToLeftViaUnicodeControlCharactersCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.RemoveUnicodeControlCharactersCommand, nameof(vm.RemoveUnicodeControlCharactersCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowToolsRenumberCommand, nameof(vm.ShowToolsRenumberCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.ImportPlainTextCommand, nameof(vm.ImportPlainTextCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.ExportEbuStlCommand, nameof(vm.ExportEbuStlCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.ExportPacCommand, nameof(vm.ExportPacCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.FixRightToLeftViaUnicodeControlCharactersCommand, nameof(vm.FixRightToLeftViaUnicodeControlCharactersCommand), ShortcutCategory.General, ShortcutGroup.Tools);
+        AddShortcut(shortcuts, vm.RemoveUnicodeControlCharactersCommand, nameof(vm.RemoveUnicodeControlCharactersCommand), ShortcutCategory.General, ShortcutGroup.Tools);
+        AddShortcut(shortcuts, vm.ShowToolsRenumberCommand, nameof(vm.ShowToolsRenumberCommand), ShortcutCategory.General, ShortcutGroup.Tools);
         AddShortcut(shortcuts, vm.EvenlyDistributeSelectedLinesCommand, nameof(vm.EvenlyDistributeSelectedLinesCommand), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.AutoTranslateSelectedLinesCommand, nameof(vm.AutoTranslateSelectedLinesCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.AutoTranslateSelectedLinesCommand, nameof(vm.AutoTranslateSelectedLinesCommand), ShortcutCategory.General, ShortcutGroup.Translate);
         AddShortcut(shortcuts, vm.ShowAssaChangeResolutionCommand, nameof(vm.ShowAssaChangeResolutionCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ShowChooseProfileCommand, nameof(vm.ShowChooseProfileCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.TogglePlaybackSpeedCommand, nameof(vm.TogglePlaybackSpeedCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.PlaybackSlowerCommand, nameof(vm.PlaybackSlowerCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.PlaybackFasterCommand, nameof(vm.PlaybackFasterCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoSetPositionCurrentSubtitleStartCommand, nameof(vm.VideoSetPositionCurrentSubtitleStartCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoSetPositionCurrentSubtitleEndCommand, nameof(vm.VideoSetPositionCurrentSubtitleEndCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ToggleAudioTracksCommand, nameof(vm.ToggleAudioTracksCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.TogglePlaybackSpeedCommand, nameof(vm.TogglePlaybackSpeedCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.PlaybackSlowerCommand, nameof(vm.PlaybackSlowerCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.PlaybackFasterCommand, nameof(vm.PlaybackFasterCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoSetPositionCurrentSubtitleStartCommand, nameof(vm.VideoSetPositionCurrentSubtitleStartCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoSetPositionCurrentSubtitleEndCommand, nameof(vm.VideoSetPositionCurrentSubtitleEndCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.ToggleAudioTracksCommand, nameof(vm.ToggleAudioTracksCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.ListErrorsCommand, nameof(vm.ListErrorsCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToPreviousErrorCommand, nameof(vm.GoToPreviousErrorCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToNextErrorCommand, nameof(vm.GoToNextErrorCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ShowAddToNameListCommand, nameof(vm.ShowAddToNameListCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowFindDoubleWordsCommand, nameof(vm.ShowFindDoubleWordsCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowFindDoubleLinesCommand, nameof(vm.ShowFindDoubleLinesCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.ShowFindDoubleWordsCommand, nameof(vm.ShowFindDoubleWordsCommand), ShortcutCategory.General, ShortcutGroup.Search);
+        AddShortcut(shortcuts, vm.ShowFindDoubleLinesCommand, nameof(vm.ShowFindDoubleLinesCommand), ShortcutCategory.General, ShortcutGroup.Search);
         AddShortcut(shortcuts, vm.SetColor1Command, nameof(vm.SetColor1Command), ShortcutCategory.SubtitleGridAndTextBox);
         AddShortcut(shortcuts, vm.SetColor2Command, nameof(vm.SetColor2Command), ShortcutCategory.SubtitleGridAndTextBox);
         AddShortcut(shortcuts, vm.SetColor3Command, nameof(vm.SetColor3Command), ShortcutCategory.SubtitleGridAndTextBox);
@@ -773,31 +779,31 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.WaveformInsertAtPositionNoFocusTextBoxCommand, nameof(vm.WaveformInsertAtPositionNoFocusTextBoxCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.WaveformPasteFromClipboardCommand, nameof(vm.WaveformPasteFromClipboardCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.FocusSelectedLineCommand, nameof(vm.FocusSelectedLineCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.PlayFromStartOfVideoCommand, nameof(vm.PlayFromStartOfVideoCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoPlayFromJustBeforeTextCommand, nameof(vm.VideoPlayFromJustBeforeTextCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.RemoveBlankLinesCommand, nameof(vm.RemoveBlankLinesCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.PlayFromStartOfVideoCommand, nameof(vm.PlayFromStartOfVideoCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoPlayFromJustBeforeTextCommand, nameof(vm.VideoPlayFromJustBeforeTextCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.RemoveBlankLinesCommand, nameof(vm.RemoveBlankLinesCommand), ShortcutCategory.General, ShortcutGroup.Tools);
         AddShortcut(shortcuts, vm.InsertSubtitleAtVideoPositionSetEndAtKeyUpCommand, nameof(vm.InsertSubtitleAtVideoPositionSetEndAtKeyUpCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SetSubtitleStartAtVideoPositionSetEndAtKeyUpAndGoToNextCommand, nameof(vm.SetSubtitleStartAtVideoPositionSetEndAtKeyUpAndGoToNextCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.SpeechToTextSelectedLinesCommand, nameof(vm.SpeechToTextSelectedLinesCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.SpeechToTextSelectedLinesPromptForLangaugeAlwaysCommand, nameof(vm.SpeechToTextSelectedLinesPromptForLangaugeAlwaysCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.SpeechToTextSelectedLinesPromptForLangaugeFirstTimeCommand, nameof(vm.SpeechToTextSelectedLinesPromptForLangaugeFirstTimeCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.PlaySelectedLinesWithoutLoopCommand, nameof(vm.PlaySelectedLinesWithoutLoopCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.PlaySelectedLinesWithLoopCommand, nameof(vm.PlaySelectedLinesWithLoopCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.PlaySelectedLinesAndFocusWaveformCommand, nameof(vm.PlaySelectedLinesAndFocusWaveformCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.PlaySelectedLinesWithLoopAndFocusWaveformCommand, nameof(vm.PlaySelectedLinesWithLoopAndFocusWaveformCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.SpeechToTextSelectedLinesCommand, nameof(vm.SpeechToTextSelectedLinesCommand), ShortcutCategory.General, ShortcutGroup.Ai);
+        AddShortcut(shortcuts, vm.SpeechToTextSelectedLinesPromptForLangaugeAlwaysCommand, nameof(vm.SpeechToTextSelectedLinesPromptForLangaugeAlwaysCommand), ShortcutCategory.General, ShortcutGroup.Ai);
+        AddShortcut(shortcuts, vm.SpeechToTextSelectedLinesPromptForLangaugeFirstTimeCommand, nameof(vm.SpeechToTextSelectedLinesPromptForLangaugeFirstTimeCommand), ShortcutCategory.General, ShortcutGroup.Ai);
+        AddShortcut(shortcuts, vm.PlaySelectedLinesWithoutLoopCommand, nameof(vm.PlaySelectedLinesWithoutLoopCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.PlaySelectedLinesWithLoopCommand, nameof(vm.PlaySelectedLinesWithLoopCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.PlaySelectedLinesAndFocusWaveformCommand, nameof(vm.PlaySelectedLinesAndFocusWaveformCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.PlaySelectedLinesWithLoopAndFocusWaveformCommand, nameof(vm.PlaySelectedLinesWithLoopAndFocusWaveformCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.ToggleCasingCommand, nameof(vm.ToggleCasingCommand), ShortcutCategory.SubtitleGridAndTextBox);
         AddShortcut(shortcuts, vm.SelectionToLowerCommand, nameof(vm.SelectionToLowerCommand), ShortcutCategory.TextBox);
         AddShortcut(shortcuts, vm.SelectionToUpperCommand, nameof(vm.SelectionToUpperCommand), ShortcutCategory.TextBox);
-        AddShortcut(shortcuts, vm.GoogleItCommand, nameof(vm.GoogleItCommand), ShortcutCategory.TextBox);
-        AddShortcut(shortcuts, vm.ImportImageSubtitleForEditCommand, nameof(vm.ImportImageSubtitleForEditCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowMediaInformationCommand, nameof(vm.ShowMediaInformationCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowSubtitleFormatPickerCommand, nameof(vm.ShowSubtitleFormatPickerCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.GoogleItCommand, nameof(vm.GoogleItCommand), ShortcutCategory.TextBox, ShortcutGroup.Search);
+        AddShortcut(shortcuts, vm.ImportImageSubtitleForEditCommand, nameof(vm.ImportImageSubtitleForEditCommand), ShortcutCategory.General, ShortcutGroup.File);
+        AddShortcut(shortcuts, vm.ShowMediaInformationCommand, nameof(vm.ShowMediaInformationCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.ShowSubtitleFormatPickerCommand, nameof(vm.ShowSubtitleFormatPickerCommand), ShortcutCategory.General, ShortcutGroup.File);
         AddShortcut(shortcuts, vm.TrimWhitespaceSelectedLinesCommand, nameof(vm.TrimWhitespaceSelectedLinesCommand), ShortcutCategory.SubtitleGrid);
         AddShortcut(shortcuts, vm.FocusTextBoxCommand, nameof(vm.FocusTextBoxCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SortByNumberCommand, nameof(vm.SortByNumberCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SortByStartTimeCommand, nameof(vm.SortByStartTimeCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SortByEndTimeCommand, nameof(vm.SortByEndTimeCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.VideoToggleBrightnessCommand, nameof(vm.VideoToggleBrightnessCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.VideoToggleBrightnessCommand, nameof(vm.VideoToggleBrightnessCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.ShowPickLayerFilterCommand, nameof(vm.ShowPickLayerFilterCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ShowPickLayerCommand, nameof(vm.ShowPickLayerCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.CopyTextToClipboardCommand, nameof(vm.CopyTextToClipboardCommand), ShortcutCategory.General);
@@ -816,12 +822,12 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.FillSelectedLinesWithClipboardCommand, nameof(vm.FillSelectedLinesWithClipboardCommand), ShortcutCategory.SubtitleGrid);
         AddShortcut(shortcuts, vm.WaveformToggleWaveformSpectrogramHeightCommand, nameof(vm.WaveformToggleWaveformSpectrogramHeightCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SpectrogramToggleStyleCommand, nameof(vm.SpectrogramToggleStyleCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ShowBeautifyTimeCodesCommand, nameof(vm.ShowBeautifyTimeCodesCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.ShowBeautifyTimeCodesCommand, nameof(vm.ShowBeautifyTimeCodesCommand), ShortcutCategory.General, ShortcutGroup.Tools);
         AddShortcut(shortcuts, vm.ZoomLayoutInCommand, nameof(vm.ZoomLayoutInCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ZoomLayoutOutCommand, nameof(vm.ZoomLayoutOutCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.OpenSecondarySubtitleCommand, nameof(vm.OpenSecondarySubtitleCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ToggleCurrentSubtitleWhilePlayingCommand, nameof(vm.ToggleCurrentSubtitleWhilePlayingCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.ToggleSmpteTimingCommand, nameof(vm.ToggleSmpteTimingCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.OpenSecondarySubtitleCommand, nameof(vm.OpenSecondarySubtitleCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.ToggleCurrentSubtitleWhilePlayingCommand, nameof(vm.ToggleCurrentSubtitleWhilePlayingCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.ToggleSmpteTimingCommand, nameof(vm.ToggleSmpteTimingCommand), ShortcutCategory.General, ShortcutGroup.Video);
 
         return shortcuts;
     }
@@ -933,19 +939,22 @@ public static class ShortcutsMain
     {
         public string Name { get; set; }
         public ShortcutCategory Category { get; set; }
+        public ShortcutGroup Group { get; set; }
 
         public AvailableShortcut(IRelayCommand relayCommand, string shortcutName)
         {
             Name = shortcutName;
             RelayCommand = relayCommand;
             Category = ShortcutCategory.General;
+            Group = ShortcutGroupUi.FromCategory(ShortcutCategory.General);
         }
-        
+
         public AvailableShortcut(IRelayCommand relayCommand, string shortcutName, ShortcutCategory category)
         {
             Name = shortcutName;
             RelayCommand = relayCommand;
             Category = category;
+            Group = ShortcutGroupUi.FromCategory(category);
         }
 
         public IRelayCommand RelayCommand { get; set; }


### PR DESCRIPTION
Addresses #12316.

Design prototype that this implements: category tile filter + icon column + "Active in" context column.

### What changed

- **New thematic grouping** (`ShortcutGroup`): General, File, Video, Waveform, Subtitle list view, Text box, Grid + text box, Synchronization, Translate, Search, Tools, AI. It is display-only — the existing `ShortcutCategory` still drives dispatch/hashing and is untouched.
- **"Active in" column** — the old Category column, renamed. Shows the focus context where the shortcut fires ("Everywhere" for the old General).
- **Icon column** — each row gets a small colored group icon (mdi font icons, tinted per group) with the group name as tooltip, so long lists stay scannable while scrolling (the effect the emoji-prefix experiment in the issue was reaching for, without touching shortcut names or translations).
- **Group tile strip** — a wrap of tiles under the search box (icon + name + count, plus an "All" tile) that filters the grid per group.
- **145 shortcuts re-tagged** out of the General bucket (previously 321 of ~420 rows said "General"): 64 Video, 26 File, 24 Tools, 9 Search, 8 Translate, 7 Sync, 7 AI. Tags are a single extra argument on `AddShortcut`, so adjusting a shortcut's group later is a one-word change.
- New language strings (`CategoryFile`, `CategoryVideo`, …, `ActiveIn`, `ActiveInEverywhere`); other languages fall back to the English defaults until translated.
- Window default size bumped 760×650 → 900×720 for the two extra columns.

### Notes for review

- Group colors are fixed mid-saturation tones chosen to read on both dark and light themes (`ShortcutGroupUi.GetBrush`).
- Icon names were verified to exist in the bundled MaterialDesign icon font.
- Builds clean; needs a manual UI pass (Options → Shortcuts) since I did not launch the GUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)