### PR TITLE
Strip "Release" subfolder when unpacking whisper.cpp engines (#12220)

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCpp.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCpp.cs
@@ -29,7 +29,12 @@ public class WhisperEngineCpp : ISpeechToTextEngine
     }
 
     public string Extension => ".bin";
-    public string UnpackSkipFolder => string.Empty;
+
+    // The Windows whisper.cpp release (whisper-blas-bin-x64.zip) nests all binaries under a
+    // "Release/" folder, so whisper-cli.exe would otherwise land in Cpp/Release/ (see #12220).
+    // The Mac/Linux archives are flat; skipping "Release" is a no-op there because the unpacker
+    // only strips the prefix from entries that actually start with it.
+    public string UnpackSkipFolder => "Release";
 
     public bool IsEngineInstalled()
     {

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCppVulkan.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCppVulkan.cs
@@ -29,7 +29,11 @@ public class WhisperEngineCppVulkan : ISpeechToTextEngine
     }
 
     public string Extension => ".bin";
-    public string UnpackSkipFolder => string.Empty;
+
+    // Consistent with the other whisper.cpp engines: strip a leading "Release/" folder if the
+    // archive nests binaries in one (see #12220). No-op for the flat Vulkan archive because the
+    // unpacker only strips the prefix from entries that actually start with it.
+    public string UnpackSkipFolder => "Release";
 
     public bool IsEngineInstalled()
     {


### PR DESCRIPTION
## Problem

Reported in #12220: after downloading Whisper (CPU/Cpp) on Windows, `whisper-cli.exe` ended up in a `Release` sub-folder inside `Cpp` (`Cpp/Release/whisper-cli.exe`) instead of directly in `Cpp/`, so Subtitle Edit could not start the engine. A user confirmed that manually moving the files out of `Release/` fixed it.

## Root cause

The Windows whisper.cpp CPU build (`whisper-blas-bin-x64.zip` from `ggml-org/whisper.cpp` v1.9.1) nests every binary under a `Release/` folder. `WhisperEngineCpp.UnpackSkipFolder` was `string.Empty`, so the unpacker never stripped that prefix.

I inspected all the whisper.cpp archives to see which land in a sub-folder:

| Engine | Archive | Nested `Release/`? | Old `UnpackSkipFolder` |
|---|---|---|---|
| **Cpp (Win BLAS)** | whisper-blas-bin-x64.zip | **yes** | `""` ❌ |
| Cpp (Mac) | whisper-mac.zip | no (flat) | `""` |
| Cpp (Linux) | whisper-vulkan-linux64.zip | no (flat) | `""` |
| CuBlas (Win) | whisper-cublas…zip | yes | `"Release"` ✓ |
| CuBlas (Linux) | whisper-cuda-linux64.zip | no (flat) | `"Release"` ✓ |
| Vulkan (Win) | whisper-vulkan-x64.zip | no (flat) | `""` |

Only the Cpp Windows archive was mis-handled; cuBLAS already got it right.

## Fix

Set `UnpackSkipFolder => "Release"` on `WhisperEngineCpp` and `WhisperEngineCppVulkan` (cuBLAS already did this).

This is safe cross-platform: `ZipUnpacker` only strips the prefix from entries that actually start with it, so it is a **no-op** for the flat Mac/Linux and Vulkan archives — exactly how cuBLAS's unconditional `"Release"` already works on Linux.

## Notes

- Existing installs that already extracted into `Cpp/Release/` won't self-heal; a fresh download after this change fixes them (aligns with the #12363 "re-download when engine file is missing" improvement).
- Build passes with 0 warnings; the `WhisperCppEngineTests` delegation test compares against the backend rather than a hardcoded value, so it's unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)