### PR TITLE
Fix ASSA/SSA styles editor not switching to "Styles in file"

### DIFF
--- a/src/ui/Features/Assa/AssaStylesViewModel.cs
+++ b/src/ui/Features/Assa/AssaStylesViewModel.cs
@@ -1151,6 +1151,28 @@ public partial class AssaStylesViewModel : ObservableObject
 
     internal void FileStylesChanged(object? sender, SelectionChangedEventArgs e)
     {
+        SwitchToFileStyle();
+    }
+
+    internal void StorageStylesChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        SwitchToStorageStyle();
+    }
+
+    // Also switch context when a grid merely gains focus (e.g. clicking the row that is already
+    // selected), otherwise SelectionChanged never fires and the title/editor stays on the other grid.
+    internal void FileStylesGotFocus(object? sender, FocusChangedEventArgs e)
+    {
+        SwitchToFileStyle();
+    }
+
+    internal void StorageStylesGotFocus(object? sender, FocusChangedEventArgs e)
+    {
+        SwitchToStorageStyle();
+    }
+
+    private void SwitchToFileStyle()
+    {
         var selectedStyle = SelectedFileStyle;
         CurrentStyle = selectedStyle;
         CurrentTitle = Se.Language.Assa.StylesInFile;
@@ -1159,7 +1181,7 @@ public partial class AssaStylesViewModel : ObservableObject
         IsTakeUsagesFromVisible = FileStyleGrid.SelectedItems.Count == 1;
     }
 
-    internal void StorageStylesChanged(object? sender, SelectionChangedEventArgs e)
+    private void SwitchToStorageStyle()
     {
         var selectedStyle = SelectedStorageStyle;
         CurrentStyle = selectedStyle;

--- a/src/ui/Features/Assa/AssaStylesWindow.cs
+++ b/src/ui/Features/Assa/AssaStylesWindow.cs
@@ -157,6 +157,7 @@ public class AssaStylesWindow : Window
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedFileStyle)) { Source = vm });
         dataGrid.SelectionChanged += vm.FileStylesChanged;
+        dataGrid.GotFocus += vm.FileStylesGotFocus;
         dataGrid.KeyDown += vm.FileStylesKeyDown;
         dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
         {
@@ -327,6 +328,7 @@ public class AssaStylesWindow : Window
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedStorageStyle)) { Source = vm });
         dataGrid.SelectionChanged += vm.StorageStylesChanged;
+        dataGrid.GotFocus += vm.StorageStylesGotFocus;
         vm.StorageStyleGrid = dataGrid;
 
         var flyout = new MenuFlyout();

--- a/src/ui/Features/Ssa/SsaStylesViewModel.cs
+++ b/src/ui/Features/Ssa/SsaStylesViewModel.cs
@@ -847,6 +847,28 @@ public partial class SsaStylesViewModel : ObservableObject
 
     internal void FileStylesChanged(object? sender, SelectionChangedEventArgs e)
     {
+        SwitchToFileStyle();
+    }
+
+    internal void StorageStylesChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        SwitchToStorageStyle();
+    }
+
+    // Also switch context when a grid merely gains focus (e.g. clicking the row that is already
+    // selected), otherwise SelectionChanged never fires and the title/editor stays on the other grid.
+    internal void FileStylesGotFocus(object? sender, FocusChangedEventArgs e)
+    {
+        SwitchToFileStyle();
+    }
+
+    internal void StorageStylesGotFocus(object? sender, FocusChangedEventArgs e)
+    {
+        SwitchToStorageStyle();
+    }
+
+    private void SwitchToFileStyle()
+    {
         var selectedStyle = SelectedFileStyle;
         CurrentStyle = selectedStyle;
         CurrentTitle = Se.Language.Assa.StylesInFile;
@@ -855,7 +877,7 @@ public partial class SsaStylesViewModel : ObservableObject
         IsTakeUsagesFromVisible = FileStyleGrid.SelectedItems.Count == 1;
     }
 
-    internal void StorageStylesChanged(object? sender, SelectionChangedEventArgs e)
+    private void SwitchToStorageStyle()
     {
         var selectedStyle = SelectedStorageStyle;
         CurrentStyle = selectedStyle;

--- a/src/ui/Features/Ssa/SsaStylesWindow.cs
+++ b/src/ui/Features/Ssa/SsaStylesWindow.cs
@@ -158,6 +158,7 @@ public class SsaStylesWindow : Window
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedFileStyle)) { Source = vm });
         dataGrid.SelectionChanged += vm.FileStylesChanged;
+        dataGrid.GotFocus += vm.FileStylesGotFocus;
         dataGrid.KeyDown += vm.FileStylesKeyDown;
         dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
         {
@@ -301,6 +302,7 @@ public class SsaStylesWindow : Window
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedStorageStyle)) { Source = vm });
         dataGrid.SelectionChanged += vm.StorageStylesChanged;
+        dataGrid.GotFocus += vm.StorageStylesGotFocus;
         vm.StorageStyleGrid = dataGrid;
 
         var flyout = new MenuFlyout();


### PR DESCRIPTION
## Problem

In the ASSA (and SSA) styles dialog, the editor's title label wouldn't switch to **"Styles in file"** when clicking a row in the file-styles grid — it stayed on **"Styles saved"**.

## Cause

The editor title/context (`CurrentTitle`, `CurrentStyle`, etc.) was only updated on each grid's **`SelectionChanged`** event. The file-styles grid keeps its own selected row (row 0 is selected on open). So after clicking the storage grid (title → "Styles saved") and then clicking the *already-selected* row in the file-styles grid, `SelectionChanged` never fired and the title stayed on "Styles saved". Only clicking a *different* file row happened to work.

## Fix

Also switch context on the grid's **`GotFocus`** event, so clicking anywhere into a grid — even re-clicking the row that's already selected — updates the editor. The shared logic is extracted into `SwitchToFileStyle()` / `SwitchToStorageStyle()`.

Applied to both the ASSA and SSA styles dialogs.

## Files

- `src/ui/Features/Assa/AssaStylesViewModel.cs` / `AssaStylesWindow.cs`
- `src/ui/Features/Ssa/SsaStylesViewModel.cs` / `SsaStylesWindow.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)