### PR TITLE
Fix CS0618 warnings: use BitmapEncoderOptions overload for Bitmap.Save

### DIFF
--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
@@ -612,7 +612,7 @@ public partial class ExportImageBasedViewModel : ObservableObject
             return;
         }
 
-        BitmapPreview.Save(fileName, 100);
+        BitmapPreview.Save(fileName, PngBitmapEncoderOptions.Default);
 
         Dispatcher.UIThread.Post(async void () =>
         {

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -1032,7 +1032,7 @@ public partial class OcrViewModel : ObservableObject
         }
 
         var bitmap = item.GetBitmap();
-        bitmap.Save(fileName, 100);
+        bitmap.Save(fileName, PngBitmapEncoderOptions.Default);
     }
 
     [RelayCommand]

--- a/src/ui/Features/Shared/ShowImage/ShowImageViewModel.cs
+++ b/src/ui/Features/Shared/ShowImage/ShowImageViewModel.cs
@@ -71,7 +71,7 @@ public partial class ShowImageViewModel : ObservableObject
             return;
         }
 
-        PreviewImage.Save(fileName, 100);
+        PreviewImage.Save(fileName, PngBitmapEncoderOptions.Default);
     }
 
 

--- a/src/ui/Logic/ClipboardHelper.cs
+++ b/src/ui/Logic/ClipboardHelper.cs
@@ -182,7 +182,7 @@ public static class ClipboardHelper
 
                 // Save bitmap to memory stream and read pixel data
                 using var memoryStream = new MemoryStream();
-                bitmap.Save(memoryStream);
+                bitmap.Save(memoryStream, PngBitmapEncoderOptions.Default);
                 memoryStream.Position = 0;
 
                 // Use SkiaSharp to decode the image and get pixel data
@@ -304,7 +304,7 @@ public static class ClipboardHelper
         {
             // Save to temporary file
             var tempPath = Path.Combine(Path.GetTempPath(), $"clipboard_{Guid.NewGuid()}.png");
-            bitmap.Save(tempPath);
+            bitmap.Save(tempPath, PngBitmapEncoderOptions.Default);
 
             // Try xclip first
             var psi = new ProcessStartInfo
@@ -359,7 +359,7 @@ public static class ClipboardHelper
         {
             // Save to temporary file
             var tempPath = Path.Combine(Path.GetTempPath(), $"clipboard_{Guid.NewGuid()}.png");
-            bitmap.Save(tempPath);
+            bitmap.Save(tempPath, PngBitmapEncoderOptions.Default);
 
             // Use osascript to copy image to clipboard
             var psi = new ProcessStartInfo

--- a/src/ui/Logic/SkBitmapExtensions.cs
+++ b/src/ui/Logic/SkBitmapExtensions.cs
@@ -259,7 +259,7 @@ internal static class SkBitmapExtensions
         }
 
         using var ms = new MemoryStream();
-        avaloniaBitmap.Save(ms);
+        avaloniaBitmap.Save(ms, PngBitmapEncoderOptions.Default);
         using var data = SKData.CreateCopy(ms.GetBuffer(), (nuint)ms.Length);
         using var image = SKImage.FromEncodedData(data);
         if (image == null)


### PR DESCRIPTION
## Problem

The build emitted `CS0618` obsolete-API warnings at seven `Bitmap.Save` call sites. Avalonia 12.1 deprecated the quality-based overloads:

```csharp
Bitmap.Save(string fileName, int? quality = null)   // obsolete
Bitmap.Save(Stream stream,   int? quality = null)   // obsolete
```

in favor of the options-based overloads that take a `BitmapEncoderOptions` (`PngBitmapEncoderOptions` / `JpegBitmapEncoderOptions`).

## Fix

All seven call sites save **PNG**, so they now pass `PngBitmapEncoderOptions.Default`:

- `Logic/ClipboardHelper.cs` — 3 sites (memory stream + Linux/macOS `.png` temp files)
- `Features/Files/ExportImageBased/ExportImageBasedViewModel.cs`
- `Logic/SkBitmapExtensions.cs` — stream re-decoded by Skia
- `Features/Shared/ShowImage/ShowImageViewModel.cs`
- `Features/Ocr/OcrViewModel.cs`

Behavior is unchanged: the format is selected by the options type (PNG, independent of file extension — same as the old default), and `PngBitmapEncoderOptions` defaults to `CompressionLevel.Optimal`. The `100` "quality" passed at three sites was meaningless for PNG and is dropped. No new `using` directives were needed.

Build is clean — 0 errors and 0 remaining `Bitmap.Save` CS0618 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)