### PR TITLE
CI: install Inno Setup 6.7.3 directly instead of via Chocolatey

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -393,8 +393,13 @@ jobs:
           Copy-Item "libmpv-temp/libmpv-2.dll" "./src/ui/bin/Release/net10.0/publish/"
           Get-ChildItem -Path "./src/ui/bin/Release/net10.0/publish" -Filter "*.pdb" -Recurse -File | Remove-Item -Force
 
-      - name: Install Inno Setup
-        run: choco install innosetup -y --no-progress
+      - name: Install Inno Setup 6.7.3
+        # Pin an exact version: the .iss script requires 6.7.3+, but Chocolatey still ships 6.7.1.
+        run: |
+          $url = "https://github.com/jrsoftware/issrc/releases/download/is-6_7_3/innosetup-6.7.3.exe"
+          Invoke-WebRequest -Uri $url -OutFile "$env:RUNNER_TEMP\innosetup.exe"
+          Start-Process -FilePath "$env:RUNNER_TEMP\innosetup.exe" `
+            -ArgumentList "/VERYSILENT","/SUPPRESSMSGBOXES","/NORESTART","/SP-" -Wait
 
       - name: Build Inno Setup installer
         run: |


### PR DESCRIPTION
## Problem

The Windows release build fails at the **Build Inno Setup installer** step:

```
Error on line 3 in ...Subtitle_Edit_Installer.iss: Update your Inno Setup version (6.7.3 or newer)
Compile aborted.
```

The installer script (`installer/WindowsInno/Subtitle_Edit_Installer.iss`) was bumped to require **Inno Setup 6.7.3+**, but the workflow installs it with `choco install innosetup`, and Chocolatey still ships **6.7.1**. So every Windows build aborts.

This is a `main`/CI infrastructure issue — unrelated to any application code change.

## Fix

Replace the Chocolatey install with a pinned direct download of the exact **6.7.3** release from jrsoftware's GitHub releases, installed silently:

```yaml
- name: Install Inno Setup 6.7.3
  run: |
    $url = "https://github.com/jrsoftware/issrc/releases/download/is-6_7_3/innosetup-6.7.3.exe"
    Invoke-WebRequest -Uri $url -OutFile "$env:RUNNER_TEMP\innosetup.exe"
    Start-Process -FilePath "$env:RUNNER_TEMP\innosetup.exe" `
      -ArgumentList "/VERYSILENT","/SUPPRESSMSGBOXES","/NORESTART","/SP-" -Wait
```

It installs to the same `C:\Program Files (x86)\Inno Setup 6\ISCC.exe` path the next step already uses, so nothing else changes. Pinning the exact version also makes the installer build reproducible instead of tracking whatever Chocolatey's latest happens to be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)