### PR TITLE
Crisp ASR Cohere: add Arabic and Japanese models

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrCohere.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrCohere.cs
@@ -96,6 +96,73 @@ public class CrispAsrCohere : CrispAsrEngineBase
                 ],
             },
 
+            // Arabic/English specialist (cohere-transcribe-arabic-07-2026), tuned for Arabic dialects
+            // and Arabic/English code switching - clearly ahead of the general model on Arabic.
+            new WhisperModel
+            {
+                Name = "cohere-transcribe-arabic-q4_k.gguf",
+                Size = "1.51 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/cohere-transcribe-arabic-07-2026-GGUF/resolve/main/cohere-transcribe-arabic-q4_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "cohere-transcribe-arabic-q8_0.gguf",
+                Size = "2.42 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/cohere-transcribe-arabic-07-2026-GGUF/resolve/main/cohere-transcribe-arabic-q8_0.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "cohere-transcribe-arabic-f16.gguf",
+                Size = "4.14 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/cohere-transcribe-arabic-07-2026-GGUF/resolve/main/cohere-transcribe-arabic-f16.gguf",
+                ],
+            },
+
+            // Japanese fine-tune (efwkjn/cohere-asr-ja), general + anime domains.
+            new WhisperModel
+            {
+                Name = "cohere-asr-ja-q4_k.gguf",
+                Size = "1.51 GB",
+                Urls =
+                [
+                    "https://huggingface.co/CKHO/cohere-asr-ja-GGUF/resolve/main/cohere-asr-ja-q4_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "cohere-asr-ja-q6_k.gguf",
+                Size = "1.98 GB",
+                Urls =
+                [
+                    "https://huggingface.co/CKHO/cohere-asr-ja-GGUF/resolve/main/cohere-asr-ja-q6_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "cohere-asr-ja-q8_0.gguf",
+                Size = "2.42 GB",
+                Urls =
+                [
+                    "https://huggingface.co/CKHO/cohere-asr-ja-GGUF/resolve/main/cohere-asr-ja-q8_0.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "cohere-asr-ja-f16.gguf",
+                Size = "4.14 GB",
+                Urls =
+                [
+                    "https://huggingface.co/CKHO/cohere-asr-ja-GGUF/resolve/main/cohere-asr-ja-f16.gguf",
+                ],
+            },
        };
 
     public override string Extension => string.Empty;


### PR DESCRIPTION
Adds two more model families to the existing Crisp ASR **Cohere** backend. No new engine, no new dependency, no Python — just extra entries next to the current `cohere-transcribe-03-2026` quants.

### Arabic — `cstr/cohere-transcribe-arabic-07-2026-GGUF`
The Arabic/English specialist, tuned for Arabic dialects and Arabic/English code switching. On Cohere's Open Universal Arabic ASR leaderboard it is a clear step ahead of the general model (~25.9 vs ~30.7 WER). Uploaded by `cstr`, the same author whose general Cohere GGUFs we already ship.

| Model | Size |
|---|---|
| `cohere-transcribe-arabic-q4_k.gguf` | 1.51 GB |
| `cohere-transcribe-arabic-q8_0.gguf` | 2.42 GB |
| `cohere-transcribe-arabic-f16.gguf` | 4.14 GB |

### Japanese — `CKHO/cohere-asr-ja-GGUF`
GGUF quant of [`efwkjn/cohere-asr-ja`](https://huggingface.co/efwkjn/cohere-asr-ja), a Japanese fine-tune of the same `cohere-transcribe-03-2026` base (general + anime domains). The author's own eval has it well ahead of the stock Cohere model on Japanese CER — 12.9 vs 22.0 on TEDx, 17.5 vs 29.8 on jsut-book. Converted with CrispASR's own `convert-cohere-asr-to-gguf.py` and tagged for the `cohere` backend.

| Model | Size |
|---|---|
| `cohere-asr-ja-q4_k.gguf` | 1.51 GB |
| `cohere-asr-ja-q6_k.gguf` | 1.98 GB |
| `cohere-asr-ja-q8_0.gguf` | 2.42 GB |
| `cohere-asr-ja-f16.gguf` | 4.14 GB |

Note the Japanese quants are hosted by a third party rather than by `cstr` — happy to drop them or swap in `TransWithAI/cohere-transcribe-ja-v0.1-GGUF` (older v0.1 checkpoint, measurably worse per the author's table) if we would rather stay on `cstr`-hosted repos only.

Suggested by @muaz978 in #12290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)