### PR TITLE
Fix nine bugs found in bug hunt

### DIFF
--- a/src/ui/Features/Options/Shortcuts/ShortcutTreeNode.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutTreeNode.cs
@@ -22,6 +22,18 @@ public partial class ShortcutTreeNode : ObservableObject
 
     public ShortCut? ShortCut { get; set; }
 
+    // The grid's shortcut column renders KeyParts/IsAssigned/IsUnassigned, so they
+    // must follow every DisplayShortcut update (e.g. from the edit panel), not just
+    // the values computed in the constructor.
+    partial void OnDisplayShortcutChanged(string value)
+    {
+        KeyParts = string.IsNullOrEmpty(value)
+            ? new List<string>()
+            : new List<string>(value.Split(" + ", StringSplitOptions.None));
+        IsAssigned = KeyParts.Count > 0;
+        IsUnassigned = !IsAssigned;
+    }
+
     public ShortcutTreeNode(string activeIn, string title, string displayShortCut, ShortCut shortcut)
     {
         ActiveIn = activeIn;

--- a/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
@@ -46,6 +46,10 @@ public partial class ShortcutsViewModel : ObservableObject
     private IFileHelper _fileHelper;
     private readonly IWindowService _windowService;
     private List<ShortCut> _allShortcuts;
+    // Snapshot of the persisted shortcuts taken when the dialog opens, so Cancel can
+    // undo commands that write straight into Se.Settings.Shortcuts (Import,
+    // Import from SE 4, Reset all).
+    private List<SeShortCut> _shortcutsSnapshot = new();
     private List<IRelayCommand> _configurableCommands;
     private Color _color1;
     private Color _color2;
@@ -204,6 +208,9 @@ public partial class ShortcutsViewModel : ObservableObject
     public void LoadShortCuts(MainViewModel vm)
     {
         MainViewModel = vm;
+        _shortcutsSnapshot = Se.Settings.Shortcuts
+            .Select(s => new SeShortCut(s.ActionName, new List<string>(s.Keys)) { ControlName = s.ControlName })
+            .ToList();
         _allShortcuts = ShortcutsMain.GetAllShortcuts(vm);
         BuildGroupTiles();
         UpdateVisibleShortcuts(string.Empty);
@@ -506,7 +513,7 @@ public partial class ShortcutsViewModel : ObservableObject
             sb.AppendLine();
             foreach (var duplicate in duplicates)
             {
-                sb.AppendLine($"� {duplicate}");
+                sb.AppendLine($"- {duplicate}");
             }
             sb.AppendLine();
             sb.Append("Save anyway?");
@@ -932,7 +939,7 @@ public partial class ShortcutsViewModel : ObservableObject
                 continue;
             }
 
-            var keysCombination = string.Join("+", shortcut.Keys.OrderBy(k => k));
+            var keysCombination = string.Join("+", shortcut.Keys.Select(ShortcutManager.NormalizeKeyToken).OrderBy(k => k));
             if (string.IsNullOrWhiteSpace(keysCombination))
             {
                 continue;
@@ -1021,12 +1028,27 @@ public partial class ShortcutsViewModel : ObservableObject
 
         if (result.OkPressed && !string.IsNullOrEmpty(result.PressedKey))
         {
+            EnsureShortcutKeyInList(result.PressedKeyOnly);
             SelectedShortcut = result.PressedKeyOnly;
             CtrlIsSelected = result.IsControlPressed;
             AltIsSelected = result.IsAltPressed;
             ShiftIsSelected = result.IsShiftPressed;
             WinIsSelected = result.IsWinPressed;
             UpdateShortcutDo();
+        }
+    }
+
+    /// <summary>
+    /// The key ComboBox's SelectedItem binding is two-way, so assigning a token that is
+    /// not in the items collection (e.g. captured numpad tokens like "NumPadReturn")
+    /// makes Avalonia clear the selection and write null back - silently dropping the
+    /// key. Add missing tokens to the list before selecting them.
+    /// </summary>
+    private void EnsureShortcutKeyInList(string? key)
+    {
+        if (!string.IsNullOrEmpty(key) && !Shortcuts.Contains(key))
+        {
+            Shortcuts.Add(key);
         }
     }
 
@@ -1073,9 +1095,10 @@ public partial class ShortcutsViewModel : ObservableObject
     [RelayCommand]
     private void ResetShortcut()
     {
-        var shortcut = SelectedShortcut;
+        // No SelectedShortcut check: modifier-only bindings (e.g. a lone "Ctrl")
+        // leave the key dropdown empty but still need to be clearable.
         var node = SelectedNode;
-        if (string.IsNullOrEmpty(shortcut) || node?.ShortCut is null)
+        if (node?.ShortCut is null)
         {
             return;
         }
@@ -1192,6 +1215,7 @@ public partial class ShortcutsViewModel : ObservableObject
                     continue;
                 }
 
+                EnsureShortcutKeyInList(key);
                 SelectedShortcut = key;
                 return;
             }
@@ -1237,5 +1261,12 @@ public partial class ShortcutsViewModel : ObservableObject
     internal void OnClosing(object? sender, WindowClosingEventArgs e)
     {
         UiUtil.SaveWindowPosition(Window);
+
+        if (!OkPressed)
+        {
+            // Import/Import-from-SE4/Reset-all mutate Se.Settings.Shortcuts directly;
+            // closing without OK must roll those back.
+            Se.Settings.Shortcuts = _shortcutsSnapshot;
+        }
     }
 }

--- a/src/ui/Logic/AutoBackupService.cs
+++ b/src/ui/Logic/AutoBackupService.cs
@@ -1,3 +1,4 @@
+using Avalonia.Threading;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Main;
@@ -8,6 +9,7 @@ using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Logic;
 
@@ -43,14 +45,20 @@ public class AutoBackupService : IAutoBackupService
         _timerAutoBackup = new System.Timers.Timer(TimeSpan.FromMinutes(minutes));
         _timerAutoBackup.Elapsed += (_, _) =>
         {
-            if (!_mainViewModel.HasChanges())
+            // Timer.Elapsed fires on a ThreadPool thread, but HasChanges/GetUpdateSubtitle
+            // mutate the shared subtitle and enumerate the UI-bound collection - take the
+            // snapshot on the UI thread, then write the file off-thread from a copy.
+            Dispatcher.UIThread.Post(() =>
             {
-                return;
-            }
+                if (_mainViewModel is not { } vm || !vm.HasChanges())
+                {
+                    return;
+                }
 
-            var saveFormat = _mainViewModel.SelectedSubtitleFormat;
-            var subtitle = _mainViewModel.GetUpdateSubtitle();
-            SaveAutoBackup(subtitle, saveFormat);
+                var saveFormat = vm.SelectedSubtitleFormat;
+                var subtitle = new Subtitle(vm.GetUpdateSubtitle(), false);
+                Task.Run(() => SaveAutoBackup(subtitle, saveFormat));
+            });
         };
         _timerAutoBackup.Start();
     }

--- a/src/ui/Logic/Download/DownloadHelper.cs
+++ b/src/ui/Logic/Download/DownloadHelper.cs
@@ -73,6 +73,15 @@ public static class DownloadHelper
                 {
                     request.Headers.Range = new System.Net.Http.Headers.RangeHeaderValue(currentPosition, null);
                 }
+                else if (currentPosition > startPosition && destination.CanSeek)
+                {
+                    // No Range header will be sent, so the server returns the file from
+                    // byte 0 - rewind the partial bytes from the failed attempt, otherwise
+                    // the full body would be appended after them and corrupt the download.
+                    destination.Seek(startPosition, SeekOrigin.Begin);
+                    destination.SetLength(startPosition);
+                    currentPosition = startPosition;
+                }
 
                 using var response = await httpClient.SendAsync(
                     request,

--- a/src/ui/Logic/Media/WaveFileExtractor.cs
+++ b/src/ui/Logic/Media/WaveFileExtractor.cs
@@ -65,7 +65,10 @@ public static class WaveFileExtractor
                 {
                     exeFilePath = "/usr/local/bin/ffmpeg";
                 }
-                exeFilePath = "ffmpeg";
+                else
+                {
+                    exeFilePath = "ffmpeg";
+                }
             }
             parameters = string.Format(fFmpegWaveTranscodeSettings, inputVideoFile, outWaveFile, audioParameter);
         }

--- a/src/ui/Logic/ShortcutManager.cs
+++ b/src/ui/Logic/ShortcutManager.cs
@@ -348,19 +348,29 @@ public class ShortcutManager : IShortcutManager
         return null;
     }
 
+    /// <summary>
+    /// Maps modifier-key aliases ("Ctrl"/"LeftCtrl"/"Control", ...) onto one canonical
+    /// token, matching how runtime lookup unifies them. Used by duplicate detection so
+    /// e.g. "Control+S" (SE 4 import) and "Ctrl+S" (UI checkboxes) count as the same.
+    /// </summary>
+    public static string NormalizeKeyToken(string key)
+    {
+        return key switch
+        {
+            "LeftCtrl" or "RightCtrl" or "Ctrl" => "Control",
+            "LeftShift" or "RightShift" => "Shift",
+            "LeftAlt" or "RightAlt" => "Alt",
+            "LWin" or "RWin" => "Win",
+            _ => key
+        };
+    }
+
     public static string CalculateNormalizedHash(List<string> inputKeys, string? control)
     {
         var keys = new List<string>(inputKeys.Count);
         foreach (var key in inputKeys)
         {
-            keys.Add(key switch
-            {
-                "LeftCtrl" or "RightCtrl" or "Ctrl" => "Control",
-                "LeftShift" or "RightShift" => "Shift",
-                "LeftAlt" or "RightAlt" => "Alt",
-                "LWin" or "RWin" => "Win",
-                _ => key
-            });
+            keys.Add(NormalizeKeyToken(key));
         }
 
         return ShortCut.CalculateHash(keys, control);

--- a/src/ui/Logic/ValueConverters/DoubleToDisplayShortConverter.cs
+++ b/src/ui/Logic/ValueConverters/DoubleToDisplayShortConverter.cs
@@ -14,6 +14,13 @@ public class DoubleToDisplayShortConverter : IValueConverter
     {
         if (value is double ms)
         {
+            if (ms == double.MaxValue || double.IsNaN(ms))
+            {
+                // Sentinel for "no value" (e.g. the gap after the last line) - show nothing
+                // instead of a clamped "0,000".
+                return string.Empty;
+            }
+
             if (Se.Settings.General.UseFrameMode)
             {
                 return new TimeCode(ms).ToShortStringHHMMSSFF();


### PR DESCRIPTION
Fixes nine verified bugs found in a code audit:

1. **Download retry corruption** (`DownloadHelper.cs`): after a mid-transfer error on a server without range support, the retry re-downloaded from byte 0 but wrote at the partial offset, corrupting the file (or looping until all retries failed). The stream is now rewound and truncated before a non-range retry.
2. **Stale key chips in shortcuts grid** (`ShortcutTreeNode.cs`): `KeyParts`/`IsAssigned`/`IsUnassigned` were computed once in the constructor, so editing or resetting a shortcut never updated the row. They now follow every `DisplayShortcut` change.
3. **ffmpeg path clobber** (`WaveFileExtractor.cs`): an unconditional `exeFilePath = "ffmpeg"` overwrote the macOS settings/`/usr/local/bin` fallbacks, breaking waveform extraction for GUI-launched apps on Homebrew/Intel Macs.
4. **Cancel didn't cancel** (`ShortcutsViewModel.cs`): Import, Import-from-SE4 and Reset-all wrote straight into `Se.Settings.Shortcuts`; closing without OK now restores a snapshot taken when the dialog opened.
5. **Auto-backup thread race** (`AutoBackupService.cs`): the timer called `GetUpdateSubtitle()` from a ThreadPool thread, racing UI-thread edits/saves. The snapshot is now taken on the UI thread and written off-thread from a deep copy.
6. **Numpad keys silently dropped** (`ShortcutsViewModel.cs`): captured tokens like `NumPadReturn` were not in the key ComboBox items, so the two-way binding nulled them out. Missing tokens are now added to the list before selection.
7. **Duplicate check missed `Control`/`Ctrl` aliases** (`ShortcutManager.cs`, `ShortcutsViewModel.cs`): duplicate detection compared raw tokens while runtime matching normalizes them - runtime-colliding shortcuts passed the check and one action never fired. Both now share `NormalizeKeyToken`.
8. **Reset no-op for modifier-only bindings** (`ShortcutsViewModel.cs`): the guard required a main key, so a lone "Ctrl" binding could not be cleared.
9. **Gap column showed "0,000" on the last line** (`DoubleToDisplayShortConverter.cs`): the `double.MaxValue` "no next line" sentinel was clamped to zero; it now renders empty like the sibling converters.

Also fixes a corrupted `�` bullet in the duplicate-shortcuts warning dialog.

Build clean, all 608 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)