### PR TITLE
Fix RTL/translation scroll bar overlapping subtitle text (#12351)

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -529,6 +529,27 @@ public static partial class InitListViewAndEditBox
             Source = vm,
         });
 
+        // A narrow empty trailing column that reserves space for the DataGrid's overlay
+        // vertical scrollbar, so the bar covers this gutter instead of the outermost text
+        // column (issue #12351). This is the same "give the scrollbar its own space"
+        // approach used for the shortcut key column in the Shortcuts window; a trailing
+        // column is used here (rather than a fixed cell margin) because right to left mode
+        // moves the scrollbar to the other side and mirrors the grid, so the gutter follows
+        // it automatically in both directions without leaving a gap between the Text and
+        // Original columns in translation mode. Kept out of AutoFitColumns so it stays this
+        // fixed width, and excluded from width persistence as a non-stretchy layout helper.
+        vm.SubtitleGrid.Columns.Add(new DataGridTemplateColumn
+        {
+            Tag = SubtitleGridColumnKeys.ScrollbarGutter,
+            Header = string.Empty,
+            Width = new DataGridLength(20, DataGridLengthUnitType.Pixel),
+            MinWidth = 0,
+            CanUserResize = false,
+            CanUserReorder = false,
+            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            CellTemplate = new FuncDataTemplate<SubtitleLineViewModel>((value, nameScope) => new Border()),
+        });
+
         RestoreSubtitleGridColumnWidths(vm.SubtitleGrid);
 
         vm.SubtitleGrid.DataContext = vm.Subtitles;
@@ -1677,6 +1698,7 @@ public static partial class InitListViewAndEditBox
         public const string Wpm = "Wpm";
         public const string PixelWidth = "PixelWidth";
         public const string Layer = "Layer";
+        public const string ScrollbarGutter = "ScrollbarGutter";
     }
 
     // The stretchy text columns keep filling the window, so their width is never stored.
@@ -1716,7 +1738,10 @@ public static partial class InitListViewAndEditBox
         var widths = Se.Settings.General.SubtitleGridColumnWidths ??= new();
         foreach (var column in grid.Columns)
         {
-            if (column.Tag is string key && !IsStretchyColumn(key) && column.ActualWidth > 0)
+            if (column.Tag is string key
+                && !IsStretchyColumn(key)
+                && key != SubtitleGridColumnKeys.ScrollbarGutter
+                && column.ActualWidth > 0)
             {
                 widths[key] = column.ActualWidth;
             }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14671,7 +14671,9 @@ public partial class MainViewModel :
 
     public void AutoFitColumns()
     {
-        var columns = SubtitleGrid.Columns.Where(p => p.IsVisible).ToList();
+        var columns = SubtitleGrid.Columns
+            .Where(p => p.IsVisible && (p.Tag as string) != InitListViewAndEditBox.SubtitleGridColumnKeys.ScrollbarGutter)
+            .ToList();
 
         var showHideWidth = MeasureShowHideColumnWidth();
 


### PR DESCRIPTION
Fixes #12351.

### Problem

The subtitle grid's vertical scroll bar covered the outermost text column:

- In right to left mode the bar moves to the left, so in translation mode it hid the left aligned original (left to right) text, which is what @SiaL8er reported.
- In left to right mode the same thing happens on the other side: the bar hid the right aligned right to left translation text.

So it is really the same issue in both directions: the text that is aligned to the side the scroll bar sits on gets clipped.

### Fix

The scroll bar is Avalonia's DataGrid overlay scroll bar, so it draws over the trailing edge of the cells rather than taking its own space. This reserves a narrow empty trailing column, so the overlay bar covers that gutter instead of any text. Because right to left mode mirrors the grid, the gutter follows the scroll bar to the correct side automatically in both directions, and unlike a fixed cell margin it leaves no gap between the Text and Original columns in translation mode. The gutter is kept out of `AutoFitColumns` and out of column width persistence.

This is the same idea as the space you reserved for the shortcut key column in the Shortcuts window (commit c29a2cf).

### Testing

Tested on macOS in both directions with a Turkish original and an Arabic translation open (translation mode):

- Right to left mode: the original text on the left is no longer clipped by the scroll bar.
- Left to right mode: the Arabic translation on the right is no longer clipped either.
- Normal single column editing is unchanged apart from the thin trailing gutter.

### Screenshots

RTL

<img width="1022" height="908" alt="image" src="https://github.com/user-attachments/assets/79c6f75c-de1b-4a03-8cc6-5707d6520cbc" />


LTR

<img width="1020" height="909" alt="image" src="https://github.com/user-attachments/assets/96a2347b-1e9c-456f-98c2-031aa8a246bf" />

