### PR TITLE
Fix common OCR errors changing Dutch "Al" to "AI"

### DIFF
--- a/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
@@ -430,9 +430,12 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
             return true;
         }
 
-        if (s.Contains(' '))
+        // Split on line breaks too - the whole-line check gets multi-line text, and splitting
+        // only on space made "kamers\r\nwaar" one unknown "word", so every two-line subtitle
+        // counted as misspelled and the spell-check-gated OCR regexes ran on correct lines.
+        if (s.Contains(' ') || s.Contains('\n'))
         {
-            var parts = s.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            var parts = s.Split(new[] { ' ', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
             foreach (var part in parts)
             {
                 if (!_spellCheckManager.IsWordCorrect(part.Trim('¡', '¿', ',', '.', '!', '?', ':', ';', '(', ')', '[', ']', '{', '}', '+', '-', '£', '\\', '"', '”', '„', '“', '«', '»', '#', '&', '%', '\r', '\n', '؟')))

--- a/src/libuilogic/Ocr/FixEngine/SpellCheckRegex.cs
+++ b/src/libuilogic/Ocr/FixEngine/SpellCheckRegex.cs
@@ -32,6 +32,14 @@ public class SpellCheckRegex
     {
         return FindRegEx.Replace(input, match =>
         {
+            // A token that is already a correctly spelled word is not an OCR error - leave it
+            // alone even when the "fixed" form is also a dictionary word. E.g. Dutch "Al die
+            // regels" must not become "AI die regels" just because "AI" is a word too.
+            if (isWordSpelledCorrectly(match.Value.TrimStart('[').TrimEnd(']')))
+            {
+                return match.Value;
+            }
+
             // Convert "$1" or "I$1" into the actual word to check (e.g., "ITEM")
             string wordToCheck = match.Result(SpellCheckWord);
 

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixSpellCheckRegexTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixSpellCheckRegexTests.cs
@@ -1,0 +1,116 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+// The spell-check-gated OCR regexes (RegularExpressionsIfSpelledCorrectly) only verified that the
+// FIXED form was a dictionary word, never that the original already was one. With the Dutch list's
+// rule "\b([A-Z]+)l\b" → "$1I", the correct word "Al" was rewritten to "AI" ("Al die regels..." →
+// "AI die regels...") because "AI" is also in the dictionary. A word that is already spelled
+// correctly must never be "fixed".
+public class OcrFixSpellCheckRegexTests : IDisposable
+{
+    private readonly Func<string> _originalSpellCheckDictionariesFolder;
+    private readonly string _tempDictionariesFolder;
+
+    public OcrFixSpellCheckRegexTests()
+    {
+        _originalSpellCheckDictionariesFolder = SpellCheckConfig.DictionariesFolder;
+
+        _tempDictionariesFolder = Path.Combine(
+            Path.GetTempPath(),
+            "SeOcrFixSpellCheckRegexTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDictionariesFolder);
+        SpellCheckConfig.DictionariesFolder = () => _tempDictionariesFolder;
+
+        // Same trailing-l rule as shipped in nld/eng/dan _OCRFixReplaceList.xml.
+        File.WriteAllText(
+            Path.Combine(_tempDictionariesFolder, "nld_OCRFixReplaceList.xml"),
+            "<ReplaceList><RegularExpressionsIfSpelledCorrectly>" +
+            "<RegEx find=\"\\b([A-Z]+)l\\b\" spellCheck=\"$1I\" replaceWith=\"$1I\" />" +
+            "</RegularExpressionsIfSpelledCorrectly></ReplaceList>");
+    }
+
+    [Fact]
+    public void FixOcrErrors_DoesNotChangeCorrectWordToOtherDictionaryWord()
+    {
+        var engine = CreateEngine();
+
+        // "Zzyzx" makes the line fail the whole-line spell check, so the regex rules run.
+        var text = "Al die regels en kamers" + Environment.NewLine + "waar we niet mogen komen, Zzyzx.";
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(text, result.GetText());
+    }
+
+    [Fact]
+    public void FixOcrErrors_MultiLineTextWithOnlyCorrectWords_IsLeftAlone()
+    {
+        var engine = CreateEngine();
+
+        // No misspelled words at all - the whole-line gate must treat the line break as a
+        // word separator and skip the regex rules entirely.
+        var text = "Al die regels en kamers" + Environment.NewLine + "waar we niet mogen komen.";
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(text, result.GetText());
+    }
+
+    [Fact]
+    public void FixOcrErrors_StillFixesTrailingLowercaseLInRealOcrError()
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, "FBl agent", doTryToGuessUnknownWords: false);
+
+        Assert.Equal("FBI agent", result.GetText());
+    }
+
+    private static IOcrFixEngine CreateEngine()
+    {
+        IOcrFixEngine engine = new OcrFixEngine(new FakeDutchSpellChecker());
+        engine.Initialize(new Subtitle(), "nld", new SpellCheckDictionaryDisplay());
+        return engine;
+    }
+
+    private sealed class FakeDutchSpellChecker : ISpellChecker
+    {
+        private static readonly HashSet<string> Words = new(StringComparer.Ordinal)
+        {
+            "al", "die", "regels", "en", "kamers", "waar", "we", "niet", "mogen", "komen",
+            "AI", "FBI", "agent",
+        };
+
+        public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => true;
+
+        public bool IsWordCorrect(string word)
+        {
+            if (string.IsNullOrWhiteSpace(word))
+            {
+                return true;
+            }
+
+            // Like Hunspell, accept the initial-capitalized form of a lowercase dictionary word.
+            return Words.Contains(word) || Words.Contains(word.ToLowerInvariant());
+        }
+
+        public List<string> GetSuggestions(string word) => new();
+    }
+
+    public void Dispose()
+    {
+        SpellCheckConfig.DictionariesFolder = _originalSpellCheckDictionariesFolder;
+        try
+        {
+            Directory.Delete(_tempDictionariesFolder, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
+    }
+}


### PR DESCRIPTION
### Problem

With Dutch selected, "Fix common OCR errors" changed the correct line

> Al die regels en kamers / waar we niet mogen komen.

to "**AI** die regels en kamers...".

### Root cause

Two issues combined:

1. `SpellCheckRegex.Apply` (the `RegularExpressionsIfSpelledCorrectly` rules) only checked that the **fixed** form is a dictionary word, never that the original already was one. The nld list ships `\b([A-Z]+)l\b` → `$1I` (meant for FBl→FBI); since "AI" is in the Dutch dictionary, the valid word "Al" got rewritten. The same rule ships in the eng/dan lists, where e.g. "Al Pacino" could be mangled the same way.
2. These rules are gated on the line failing spell check, but `OcrFixEngine.IsSpelledCorrect` split only on spaces — "kamers\r\nwaar" counted as one unknown word, so every two-line subtitle was treated as misspelled and the rules ran on fully-correct lines.

### Fix

- `SpellCheckRegex.Apply`: skip a match whose original token is already spelled correctly — a valid word is not an OCR error, even when the "fixed" form is also a word.
- `OcrFixEngine.IsSpelledCorrect`: treat line breaks as word separators in the whole-line check.

### Tests

New `OcrFixSpellCheckRegexTests` (3 tests): the exact reported line stays intact, a fully-correct two-line paragraph skips the rules entirely, and a genuine "FBl agent" → "FBI agent" fix still works. Both tests fail without the corresponding fix. Full suite: 611 UI + 485 libse tests pass.

### Note (not addressed here)

nld/deu/nor `_OCRFixReplaceList.xml` each contain **two** `<RegularExpressionsIfSpelledCorrectly>` sections, and the loaders use `SelectSingleNode`, so the second section never loads (in nld that is the whole Dutch-specific block: IJ digraph, genitive, missing-space rules). Deliberately left as-is — some dormant rules look unsafe to activate without review (e.g. `\bij([a-z]+)` → `IJ$1` would capitalize mid-sentence "ijsberg").

🤖 Generated with [Claude Code](https://claude.com/claude-code)