### PR TITLE
Fix alignment toggle shortcut, OCR an2 tags, and OCR italic hotkey

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -10048,7 +10048,7 @@ public partial class MainViewModel :
             return;
         }
 
-        SetAlignmentToSelected("an1");
+        SetAlignmentToSelected("an1", allowToggle: true);
         _updateAudioVisualizer = true;
     }
 
@@ -10061,7 +10061,7 @@ public partial class MainViewModel :
             return;
         }
 
-        SetAlignmentToSelected("an2");
+        SetAlignmentToSelected("an2", allowToggle: true);
         _updateAudioVisualizer = true;
     }
 
@@ -10075,7 +10075,7 @@ public partial class MainViewModel :
             return;
         }
 
-        SetAlignmentToSelected("an3");
+        SetAlignmentToSelected("an3", allowToggle: true);
         _updateAudioVisualizer = true;
     }
 
@@ -10089,7 +10089,7 @@ public partial class MainViewModel :
             return;
         }
 
-        SetAlignmentToSelected("an4");
+        SetAlignmentToSelected("an4", allowToggle: true);
         _updateAudioVisualizer = true;
     }
 
@@ -10103,7 +10103,7 @@ public partial class MainViewModel :
             return;
         }
 
-        SetAlignmentToSelected("an5");
+        SetAlignmentToSelected("an5", allowToggle: true);
         _updateAudioVisualizer = true;
     }
 
@@ -10117,7 +10117,7 @@ public partial class MainViewModel :
             return;
         }
 
-        SetAlignmentToSelected("an6");
+        SetAlignmentToSelected("an6", allowToggle: true);
         _updateAudioVisualizer = true;
     }
 
@@ -10131,7 +10131,7 @@ public partial class MainViewModel :
             return;
         }
 
-        SetAlignmentToSelected("an7");
+        SetAlignmentToSelected("an7", allowToggle: true);
         _updateAudioVisualizer = true;
     }
 
@@ -10145,7 +10145,7 @@ public partial class MainViewModel :
             return;
         }
 
-        SetAlignmentToSelected("an8");
+        SetAlignmentToSelected("an8", allowToggle: true);
         _updateAudioVisualizer = true;
     }
 
@@ -10159,7 +10159,7 @@ public partial class MainViewModel :
             return;
         }
 
-        SetAlignmentToSelected("an9");
+        SetAlignmentToSelected("an9", allowToggle: true);
         _updateAudioVisualizer = true;
     }
 
@@ -15042,116 +15042,8 @@ public partial class MainViewModel :
 
     private bool ToggleTextBoxTag(ITextBoxWrapper tb, string tag)
     {
-        if (tb == null || tb.Text == null)
-        {
-            return false;
-        }
-
         var isAssa = SelectedSubtitleFormat is AdvancedSubStationAlpha;
-        var selectionStart = Math.Min(tb.SelectionStart, tb.SelectionEnd);
-        var selectionEnd = Math.Max(tb.SelectionStart, tb.SelectionEnd);
-        var selectionLength = selectionEnd - selectionStart;
-
-        // No text selected - toggle the whole line (or just the current dialog line).
-        if (selectionLength == 0)
-        {
-            var text = tb.Text;
-            var lines = text.SplitToLines();
-
-            // Find the line where the caret is currently located (do not count wrapped lines).
-            var numberOfNewLines = 0;
-            for (var i = 0; i < selectionStart && i < text.Length; i++)
-            {
-                if (text[i] == '\n')
-                {
-                    numberOfNewLines++;
-                }
-            }
-
-            var selectedLineIdx = Math.Min(numberOfNewLines, lines.Count - 1);
-            var selectedLine = lines[selectedLineIdx];
-
-            // When the caret is on a dialog line ("- ..."), only toggle that line so the
-            // other speaker's line keeps its formatting.
-            var isDialog = selectedLine.StartsWith('-') ||
-                           selectedLine.StartsWith("<" + tag + ">-", StringComparison.OrdinalIgnoreCase);
-
-            var textLen = text.Length;
-            if (isDialog)
-            {
-                lines[selectedLineIdx] = HtmlUtil.ToggleTag(selectedLine, tag, false, isAssa);
-                text = string.Join(Environment.NewLine, lines);
-            }
-            else
-            {
-                text = HtmlUtil.ToggleTag(text, tag, false, isAssa);
-            }
-
-            tb.Text = text;
-
-            // Keep the caret next to where it was, shifting by the length of the opening
-            // tag inserted before it: "<i>" (3) for HTML, "{\i1}" (5) for ASSA.
-            var openTagLength = isAssa ? tag.Length + 4 : tag.Length + 2;
-            var newCaret = textLen > text.Length
-                ? Math.Max(selectionStart - openTagLength, 0)
-                : selectionStart + openTagLength;
-            Dispatcher.UIThread.Post(() =>
-            {
-                tb.Focus();
-                tb.SelectionStart = newCaret;
-                tb.SelectionEnd = newCaret;
-            });
-        }
-        else
-        {
-            // Move leading/trailing white-space (spaces and new-lines) outside the tag so
-            // " 'word'" becomes " <i>'word'</i>" instead of "<i> 'word'</i>".
-            var pre = string.Empty;
-            var post = string.Empty;
-            var selectedText = tb.Text.Substring(selectionStart, selectionLength);
-            while (selectedText.EndsWith(' ') || selectedText.EndsWith(Environment.NewLine, StringComparison.Ordinal) ||
-                   selectedText.StartsWith(' ') || selectedText.StartsWith(Environment.NewLine, StringComparison.Ordinal))
-            {
-                if (selectedText.EndsWith(' '))
-                {
-                    post = " " + post;
-                    selectedText = selectedText.Remove(selectedText.Length - 1);
-                }
-
-                if (selectedText.EndsWith(Environment.NewLine, StringComparison.Ordinal))
-                {
-                    post = Environment.NewLine + post;
-                    selectedText = selectedText.Remove(selectedText.Length - Environment.NewLine.Length);
-                }
-
-                if (selectedText.StartsWith(' '))
-                {
-                    pre += " ";
-                    selectedText = selectedText.Remove(0, 1);
-                }
-
-                if (selectedText.StartsWith(Environment.NewLine, StringComparison.Ordinal))
-                {
-                    pre += Environment.NewLine;
-                    selectedText = selectedText.Remove(0, Environment.NewLine.Length);
-                }
-            }
-
-            selectedText = pre + HtmlUtil.ToggleTag(selectedText, tag, false, isAssa) + post;
-
-            tb.Text = tb.Text
-                .Remove(selectionStart, selectionLength)
-                .Insert(selectionStart, selectedText);
-
-            Dispatcher.UIThread.Post(() =>
-            {
-                tb.Focus();
-                tb.SelectionStart = selectionStart;
-                tb.SelectionEnd = selectionStart + selectedText.Length;
-            });
-        }
-
-        return true;
+        return TextBoxTagToggler.ToggleTag(tb, tag, isAssa);
     }
 
 
@@ -19008,7 +18900,7 @@ public partial class MainViewModel :
         }
     }
 
-    private void SetAlignmentToSelected(string alignment)
+    private void SetAlignmentToSelected(string alignment, bool allowToggle = false)
     {
         var selectedItems = _selectedSubtitles?.ToList() ?? [];
         if (selectedItems.Count == 0)
@@ -19016,44 +18908,15 @@ public partial class MainViewModel :
             return;
         }
 
+        // Alignment shortcuts toggle: pressing the same alignment again removes it (#12393)
+        var removeOnly = allowToggle && selectedItems.All(p =>
+            string.IsNullOrEmpty(p.Text) || AlignmentTagHelper.HasAlignment(p.Text, alignment));
+
         foreach (var item in selectedItems)
         {
-            item.Text = item.Text
-                .Replace("{\\an1}", string.Empty)
-                .Replace("{\\an2}", string.Empty)
-                .Replace("{\\an3}", string.Empty)
-                .Replace("{\\an4}", string.Empty)
-                .Replace("{\\an5}", string.Empty)
-                .Replace("{\\an6}", string.Empty)
-                .Replace("{\\an7}", string.Empty)
-                .Replace("{\\an8}", string.Empty)
-                .Replace("{\\an9}", string.Empty)
-                .Replace("\\an1", string.Empty)
-                .Replace("\\an2", string.Empty)
-                .Replace("\\an3", string.Empty)
-                .Replace("\\an4", string.Empty)
-                .Replace("\\an5", string.Empty)
-                .Replace("\\an6", string.Empty)
-                .Replace("\\an7", string.Empty)
-                .Replace("\\an8", string.Empty)
-                .Replace("\\an9", string.Empty);
-
-            if (alignment == "an2" && Se.Settings.General.WriteAn2Tag == false)
-            {
-                continue;
-            }
-
-            if (!string.IsNullOrEmpty(item.Text))
-            {
-                if (item.Text.StartsWith("{\\"))
-                {
-                    item.Text = item.Text.Insert(2, alignment + "\\");
-                }
-                else
-                {
-                    item.Text = $"{{\\{alignment}}}{item.Text}";
-                }
-            }
+            item.Text = removeOnly
+                ? AlignmentTagHelper.RemoveAlignmentTags(item.Text)
+                : AlignmentTagHelper.SetAlignment(item.Text, alignment, Se.Settings.General.WriteAn2Tag);
         }
     }
 

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -32,6 +32,7 @@ using Nikse.SubtitleEdit.Features.Shared.BinaryEdit;
 using Nikse.SubtitleEdit.Features.Shared.GoToLineNumber;
 using Nikse.SubtitleEdit.Features.Shared.PickFontName;
 using Nikse.SubtitleEdit.Features.Shared.ShowImage;
+using Nikse.SubtitleEdit.Features.Shared.TextBoxUtils;
 using Nikse.SubtitleEdit.Features.SpellCheck;
 using Nikse.SubtitleEdit.Features.SpellCheck.GetDictionaries;
 using Nikse.SubtitleEdit.Features.Translate;
@@ -4298,6 +4299,15 @@ public partial class OcrViewModel : ObservableObject
         }
     }
 
+    internal void TextBoxKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.I && e.KeyModifiers == KeyModifiers.Control && sender is TextBox textBox)
+        {
+            e.Handled = true;
+            TextBoxTagToggler.ToggleTag(new TextBoxWrapper(textBox), "i", isAssa: false);
+        }
+    }
+
     internal void SubtitleGridDoubleTapped()
     {
         CommandInspectLine();
@@ -5026,7 +5036,7 @@ public partial class OcrViewModel : ObservableObject
                     if (lineImages.Count > 1 || lineImages2.Count > 1)
                     {
                         // Multiple lines detected - apply alignment to each line
-                        var perLine = new List<string>();
+                        var lineAlignments = new List<string>();
                         var multiLineCenterX = position.X + bitmap.Width / 2.0;
                         var multiLineRelativeX = multiLineCenterX / screenSize.Width;
 
@@ -5038,13 +5048,10 @@ public partial class OcrViewModel : ObservableObject
                             var lineRelativeY = lineY / screenSize.Height;
 
                             // Get alignment for this specific line position
-                            var lineAlignment = GetAssaPositionFromScreen(multiLineRelativeX, lineRelativeY);
-
-                            // Add alignment tag to the line text
-                            perLine.Add($"{{\\{lineAlignment}}}{lines[i].Trim()}");
+                            lineAlignments.Add(GetAssaPositionFromScreen(multiLineRelativeX, lineRelativeY));
                         }
 
-                        return (string.Join("\n", perLine), true);
+                        return ApplyLineAlignmentTags(lines, lineAlignments, textToUse, Se.Settings.General.WriteAn2Tag);
                     }
                 }
             }
@@ -5059,7 +5066,7 @@ public partial class OcrViewModel : ObservableObject
 
             // Map to ASSA alignment positions (An1-An9)
             var assaPosition = GetAssaPositionFromScreen(relativeX, relativeY);
-            return ($"{{\\{assaPosition}}}{textToUse}", true);
+            return ApplyAlignmentTag(textToUse, assaPosition, Se.Settings.General.WriteAn2Tag);
         }
         catch
         {
@@ -5067,7 +5074,34 @@ public partial class OcrViewModel : ObservableObject
         }
     }
 
-    private static string GetAssaPositionFromScreen(double relativeX, double relativeY)
+    // "an2" is the default bottom-center alignment, so no tag is needed for it (#12393)
+    internal static (string Text, bool AlignmentAdded) ApplyAlignmentTag(string text, string assaPosition, bool writeAn2Tag)
+    {
+        if (assaPosition == "an2" && !writeAn2Tag)
+        {
+            return (text, false);
+        }
+
+        return ($"{{\\{assaPosition}}}{text}", true);
+    }
+
+    internal static (string Text, bool AlignmentAdded) ApplyLineAlignmentTags(List<string> lines, List<string> lineAlignments, string originalText, bool writeAn2Tag)
+    {
+        if (!writeAn2Tag && lineAlignments.All(p => p == "an2"))
+        {
+            return (originalText, false);
+        }
+
+        var perLine = new List<string>();
+        for (var i = 0; i < lines.Count; i++)
+        {
+            perLine.Add($"{{\\{lineAlignments[i]}}}{lines[i].Trim()}");
+        }
+
+        return (string.Join("\n", perLine), true);
+    }
+
+    internal static string GetAssaPositionFromScreen(double relativeX, double relativeY)
     {
         // Map screen coordinates to 3x3 grid for ASSA positions
         // relativeX: 0.0 = left, 1.0 = right

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -681,6 +681,7 @@ public class OcrWindow : Window
         flyout.Items.Add(menuItemSetFont);
         textBoxText.ContextFlyout = flyout;
         textBoxText.PointerReleased += vm.TextBoxPointerReleased;
+        textBoxText.KeyDown += vm.TextBoxKeyDown;
 
         textBoxText.TextChanged += vm.TextBoxTextChanged;
         var panelText = new StackPanel

--- a/src/ui/Features/Shared/TextBoxUtils/TextBoxTagToggler.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/TextBoxTagToggler.cs
@@ -1,0 +1,125 @@
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Core.Common;
+using System;
+
+namespace Nikse.SubtitleEdit.Features.Shared.TextBoxUtils;
+
+/// <summary>
+/// Toggles a formatting tag like &lt;i&gt; (or "{\i1}" for ASSA) in a text box, on the
+/// selected text or on the whole/current line when nothing is selected.
+/// </summary>
+public static class TextBoxTagToggler
+{
+    public static bool ToggleTag(ITextBoxWrapper? tb, string tag, bool isAssa)
+    {
+        if (tb == null || tb.Text == null)
+        {
+            return false;
+        }
+
+        var selectionStart = Math.Min(tb.SelectionStart, tb.SelectionEnd);
+        var selectionEnd = Math.Max(tb.SelectionStart, tb.SelectionEnd);
+        var selectionLength = selectionEnd - selectionStart;
+
+        // No text selected - toggle the whole line (or just the current dialog line).
+        if (selectionLength == 0)
+        {
+            var text = tb.Text;
+            var lines = text.SplitToLines();
+
+            // Find the line where the caret is currently located (do not count wrapped lines).
+            var numberOfNewLines = 0;
+            for (var i = 0; i < selectionStart && i < text.Length; i++)
+            {
+                if (text[i] == '\n')
+                {
+                    numberOfNewLines++;
+                }
+            }
+
+            var selectedLineIdx = Math.Min(numberOfNewLines, lines.Count - 1);
+            var selectedLine = lines[selectedLineIdx];
+
+            // When the caret is on a dialog line ("- ..."), only toggle that line so the
+            // other speaker's line keeps its formatting.
+            var isDialog = selectedLine.StartsWith('-') ||
+                           selectedLine.StartsWith("<" + tag + ">-", StringComparison.OrdinalIgnoreCase);
+
+            var textLen = text.Length;
+            if (isDialog)
+            {
+                lines[selectedLineIdx] = HtmlUtil.ToggleTag(selectedLine, tag, false, isAssa);
+                text = string.Join(Environment.NewLine, lines);
+            }
+            else
+            {
+                text = HtmlUtil.ToggleTag(text, tag, false, isAssa);
+            }
+
+            tb.Text = text;
+
+            // Keep the caret next to where it was, shifting by the length of the opening
+            // tag inserted before it: "<i>" (3) for HTML, "{\i1}" (5) for ASSA.
+            var openTagLength = isAssa ? tag.Length + 4 : tag.Length + 2;
+            var newCaret = textLen > text.Length
+                ? Math.Max(selectionStart - openTagLength, 0)
+                : selectionStart + openTagLength;
+            Dispatcher.UIThread.Post(() =>
+            {
+                tb.Focus();
+                tb.SelectionStart = newCaret;
+                tb.SelectionEnd = newCaret;
+            });
+        }
+        else
+        {
+            // Move leading/trailing white-space (spaces and new-lines) outside the tag so
+            // " 'word'" becomes " <i>'word'</i>" instead of "<i> 'word'</i>".
+            var pre = string.Empty;
+            var post = string.Empty;
+            var selectedText = tb.Text.Substring(selectionStart, selectionLength);
+            while (selectedText.EndsWith(' ') || selectedText.EndsWith(Environment.NewLine, StringComparison.Ordinal) ||
+                   selectedText.StartsWith(' ') || selectedText.StartsWith(Environment.NewLine, StringComparison.Ordinal))
+            {
+                if (selectedText.EndsWith(' '))
+                {
+                    post = " " + post;
+                    selectedText = selectedText.Remove(selectedText.Length - 1);
+                }
+
+                if (selectedText.EndsWith(Environment.NewLine, StringComparison.Ordinal))
+                {
+                    post = Environment.NewLine + post;
+                    selectedText = selectedText.Remove(selectedText.Length - Environment.NewLine.Length);
+                }
+
+                if (selectedText.StartsWith(' '))
+                {
+                    pre += " ";
+                    selectedText = selectedText.Remove(0, 1);
+                }
+
+                if (selectedText.StartsWith(Environment.NewLine, StringComparison.Ordinal))
+                {
+                    pre += Environment.NewLine;
+                    selectedText = selectedText.Remove(0, Environment.NewLine.Length);
+                }
+            }
+
+            selectedText = pre + HtmlUtil.ToggleTag(selectedText, tag, false, isAssa) + post;
+
+            tb.Text = tb.Text
+                .Remove(selectionStart, selectionLength)
+                .Insert(selectionStart, selectedText);
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                tb.Focus();
+                tb.SelectionStart = selectionStart;
+                tb.SelectionEnd = selectionStart + selectedText.Length;
+            });
+        }
+
+        return true;
+    }
+}

--- a/src/ui/Logic/AlignmentTagHelper.cs
+++ b/src/ui/Logic/AlignmentTagHelper.cs
@@ -1,0 +1,66 @@
+using System;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Helpers for the ASSA style alignment tags "{\an1}".."{\an9}" used in subtitle text.
+/// </summary>
+public static class AlignmentTagHelper
+{
+    /// <summary>
+    /// True if the text contains the given alignment, either as "{\anX}" or inline as "\anX".
+    /// </summary>
+    public static bool HasAlignment(string text, string alignment)
+    {
+        return text.Contains("\\" + alignment, StringComparison.Ordinal);
+    }
+
+    public static string RemoveAlignmentTags(string text)
+    {
+        return text
+            .Replace("{\\an1}", string.Empty)
+            .Replace("{\\an2}", string.Empty)
+            .Replace("{\\an3}", string.Empty)
+            .Replace("{\\an4}", string.Empty)
+            .Replace("{\\an5}", string.Empty)
+            .Replace("{\\an6}", string.Empty)
+            .Replace("{\\an7}", string.Empty)
+            .Replace("{\\an8}", string.Empty)
+            .Replace("{\\an9}", string.Empty)
+            .Replace("\\an1", string.Empty)
+            .Replace("\\an2", string.Empty)
+            .Replace("\\an3", string.Empty)
+            .Replace("\\an4", string.Empty)
+            .Replace("\\an5", string.Empty)
+            .Replace("\\an6", string.Empty)
+            .Replace("\\an7", string.Empty)
+            .Replace("\\an8", string.Empty)
+            .Replace("\\an9", string.Empty);
+    }
+
+    /// <summary>
+    /// Removes any existing alignment tags and applies the given alignment.
+    /// "an2" (default bottom-center) is only written when writeAn2Tag is true.
+    /// </summary>
+    public static string SetAlignment(string text, string alignment, bool writeAn2Tag)
+    {
+        var result = RemoveAlignmentTags(text);
+
+        if (string.IsNullOrEmpty(result))
+        {
+            return result;
+        }
+
+        if (alignment == "an2" && !writeAn2Tag)
+        {
+            return result;
+        }
+
+        if (result.StartsWith("{\\", StringComparison.Ordinal))
+        {
+            return result.Insert(2, alignment + "\\");
+        }
+
+        return $"{{\\{alignment}}}{result}";
+    }
+}

--- a/tests/UI/Features/Ocr/OcrCaptureAlignmentTests.cs
+++ b/tests/UI/Features/Ocr/OcrCaptureAlignmentTests.cs
@@ -1,0 +1,83 @@
+using Nikse.SubtitleEdit.Features.Ocr;
+
+namespace UITests.Features.Ocr;
+
+// OCR "capture alignment" should only add an alignment tag when the text is NOT at the
+// default bottom-center position (an2) - previously every OCR'ed line got a tag, even
+// bottom-center ones (issue #12393).
+public class OcrCaptureAlignmentTests
+{
+    [Fact]
+    public void ApplyAlignmentTag_TopCenter_AddsAn8()
+    {
+        var result = OcrViewModel.ApplyAlignmentTag("Hello", "an8", writeAn2Tag: false);
+
+        Assert.True(result.AlignmentAdded);
+        Assert.Equal("{\\an8}Hello", result.Text);
+    }
+
+    [Fact]
+    public void ApplyAlignmentTag_BottomCenter_NoTagAdded()
+    {
+        var result = OcrViewModel.ApplyAlignmentTag("Hello", "an2", writeAn2Tag: false);
+
+        Assert.False(result.AlignmentAdded);
+        Assert.Equal("Hello", result.Text);
+    }
+
+    [Fact]
+    public void ApplyAlignmentTag_BottomCenterWithWriteAn2Tag_AddsAn2()
+    {
+        var result = OcrViewModel.ApplyAlignmentTag("Hello", "an2", writeAn2Tag: true);
+
+        Assert.True(result.AlignmentAdded);
+        Assert.Equal("{\\an2}Hello", result.Text);
+    }
+
+    [Fact]
+    public void ApplyLineAlignmentTags_AllBottomCenter_NoTagsAdded()
+    {
+        var lines = new List<string> { "One", "Two" };
+        var alignments = new List<string> { "an2", "an2" };
+
+        var result = OcrViewModel.ApplyLineAlignmentTags(lines, alignments, "One\nTwo", writeAn2Tag: false);
+
+        Assert.False(result.AlignmentAdded);
+        Assert.Equal("One\nTwo", result.Text);
+    }
+
+    [Fact]
+    public void ApplyLineAlignmentTags_MixedAlignments_TagsAllLines()
+    {
+        var lines = new List<string> { "One", "Two" };
+        var alignments = new List<string> { "an8", "an2" };
+
+        var result = OcrViewModel.ApplyLineAlignmentTags(lines, alignments, "One\nTwo", writeAn2Tag: false);
+
+        Assert.True(result.AlignmentAdded);
+        Assert.Equal("{\\an8}One\n{\\an2}Two", result.Text);
+    }
+
+    [Fact]
+    public void ApplyLineAlignmentTags_AllBottomCenterWithWriteAn2Tag_TagsAllLines()
+    {
+        var lines = new List<string> { "One", "Two" };
+        var alignments = new List<string> { "an2", "an2" };
+
+        var result = OcrViewModel.ApplyLineAlignmentTags(lines, alignments, "One\nTwo", writeAn2Tag: true);
+
+        Assert.True(result.AlignmentAdded);
+        Assert.Equal("{\\an2}One\n{\\an2}Two", result.Text);
+    }
+
+    [Theory]
+    [InlineData(0.5, 0.1, "an8")] // top-center of screen
+    [InlineData(0.5, 0.9, "an2")] // bottom-center of screen
+    [InlineData(0.5, 0.5, "an5")] // middle-center of screen
+    [InlineData(0.1, 0.9, "an1")] // bottom-left of screen
+    [InlineData(0.9, 0.1, "an9")] // top-right of screen
+    public void GetAssaPositionFromScreen_MapsScreenPositionToAlignment(double relativeX, double relativeY, string expected)
+    {
+        Assert.Equal(expected, OcrViewModel.GetAssaPositionFromScreen(relativeX, relativeY));
+    }
+}

--- a/tests/UI/Features/Shared/TextBoxTagTogglerTests.cs
+++ b/tests/UI/Features/Shared/TextBoxTagTogglerTests.cs
@@ -1,0 +1,78 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Features.Shared.TextBoxUtils;
+
+namespace UITests.Features.Shared;
+
+// Ctrl+I in the OCR window's text box (and the main window's edit box) toggles italic on
+// the selected part of the text, or on the whole line when nothing is selected (issue #12393).
+public class TextBoxTagTogglerTests
+{
+    private static TextBox MakeTextBox(string text, int selectionStart, int selectionEnd)
+    {
+        return new TextBox
+        {
+            Text = text,
+            SelectionStart = selectionStart,
+            SelectionEnd = selectionEnd,
+        };
+    }
+
+    [AvaloniaFact]
+    public void ToggleTag_SelectedWord_WrapsSelectionInItalic()
+    {
+        var textBox = MakeTextBox("Hello world", 6, 11);
+
+        TextBoxTagToggler.ToggleTag(new TextBoxWrapper(textBox), "i", isAssa: false);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("Hello <i>world</i>", textBox.Text);
+        Assert.Equal(6, textBox.SelectionStart);
+        Assert.Equal("<i>world</i>".Length + 6, textBox.SelectionEnd);
+    }
+
+    [AvaloniaFact]
+    public void ToggleTag_SelectedItalicWord_RemovesItalic()
+    {
+        var textBox = MakeTextBox("Hello <i>world</i>", 6, 18);
+
+        TextBoxTagToggler.ToggleTag(new TextBoxWrapper(textBox), "i", isAssa: false);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("Hello world", textBox.Text);
+    }
+
+    [AvaloniaFact]
+    public void ToggleTag_NoSelection_TogglesWholeText()
+    {
+        var textBox = MakeTextBox("Hello world", 0, 0);
+
+        TextBoxTagToggler.ToggleTag(new TextBoxWrapper(textBox), "i", isAssa: false);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("<i>Hello world</i>", textBox.Text);
+    }
+
+    [AvaloniaFact]
+    public void ToggleTag_SelectionWithSurroundingSpaces_KeepsSpacesOutsideTag()
+    {
+        var textBox = MakeTextBox("Hello world", 5, 11); // " world" selected
+
+        TextBoxTagToggler.ToggleTag(new TextBoxWrapper(textBox), "i", isAssa: false);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("Hello <i>world</i>", textBox.Text);
+    }
+
+    [AvaloniaFact]
+    public void ToggleTag_Assa_UsesAssaTags()
+    {
+        var textBox = MakeTextBox("Hello world", 6, 11);
+
+        TextBoxTagToggler.ToggleTag(new TextBoxWrapper(textBox), "i", isAssa: true);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("Hello {\\i1}world{\\i0}", textBox.Text);
+    }
+}

--- a/tests/UI/Logic/AlignmentTagHelperTests.cs
+++ b/tests/UI/Logic/AlignmentTagHelperTests.cs
@@ -1,0 +1,65 @@
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+// Alignment shortcuts should toggle: pressing e.g. "an8" when the line already has {\an8}
+// removes the tag again, and "an2" (default bottom-center) is only written when the
+// WriteAn2Tag setting is enabled (issue #12393).
+public class AlignmentTagHelperTests
+{
+    [Theory]
+    [InlineData("{\\an8}Hello", "an8", true)]
+    [InlineData("{\\an8\\i1}Hello", "an8", true)]
+    [InlineData("Hello", "an8", false)]
+    [InlineData("{\\an7}Hello", "an8", false)]
+    public void HasAlignment(string text, string alignment, bool expected)
+    {
+        Assert.Equal(expected, AlignmentTagHelper.HasAlignment(text, alignment));
+    }
+
+    [Theory]
+    [InlineData("{\\an8}Hello", "Hello")]
+    [InlineData("{\\an8\\i1}Hello", "{\\i1}Hello")]
+    [InlineData("Hello", "Hello")]
+    [InlineData("{\\an1}One\n{\\an9}Two", "One\nTwo")]
+    public void RemoveAlignmentTags(string text, string expected)
+    {
+        Assert.Equal(expected, AlignmentTagHelper.RemoveAlignmentTags(text));
+    }
+
+    [Fact]
+    public void SetAlignment_PlainText_AddsTag()
+    {
+        Assert.Equal("{\\an8}Hello", AlignmentTagHelper.SetAlignment("Hello", "an8", writeAn2Tag: false));
+    }
+
+    [Fact]
+    public void SetAlignment_ReplacesExistingAlignment()
+    {
+        Assert.Equal("{\\an8}Hello", AlignmentTagHelper.SetAlignment("{\\an7}Hello", "an8", writeAn2Tag: false));
+    }
+
+    [Fact]
+    public void SetAlignment_ExistingOverrideBlock_InsertsIntoBlock()
+    {
+        Assert.Equal("{\\an8\\i1}Hello", AlignmentTagHelper.SetAlignment("{\\i1}Hello", "an8", writeAn2Tag: false));
+    }
+
+    [Fact]
+    public void SetAlignment_An2WithoutWriteAn2Tag_OnlyRemoves()
+    {
+        Assert.Equal("Hello", AlignmentTagHelper.SetAlignment("{\\an8}Hello", "an2", writeAn2Tag: false));
+    }
+
+    [Fact]
+    public void SetAlignment_An2WithWriteAn2Tag_AddsTag()
+    {
+        Assert.Equal("{\\an2}Hello", AlignmentTagHelper.SetAlignment("Hello", "an2", writeAn2Tag: true));
+    }
+
+    [Fact]
+    public void SetAlignment_EmptyText_StaysEmpty()
+    {
+        Assert.Equal(string.Empty, AlignmentTagHelper.SetAlignment(string.Empty, "an8", writeAn2Tag: false));
+    }
+}


### PR DESCRIPTION
Fixes #12393 — all three reported problems:

### 1. Alignment shortcut is now toggleable
Pressing an alignment shortcut (e.g. F2 bound to top alignment/an8) when **all selected lines already have that alignment** now removes the tag instead of re-applying it, so an accidental alignment can be undone with the same key. The alignment picker dialog is unchanged (an explicit pick always applies). The tag set/remove logic is extracted into `AlignmentTagHelper`.

### 2. OCR no longer adds an alignment tag to every line
With "keep alignment" enabled, OCR previously prefixed every line with a tag — including `{\an2}`, the default bottom-center position. Now a computed position of `an2` adds no tag (both the single-text and the per-line multi-alignment paths), matching the old app and the main grid's existing `WriteAn2Tag` setting; users who want explicit `{\an2}` tags can still enable that setting. Mixed-alignment images keep tags on all lines so the alignment-group splitting on OK still works.

### 3. Ctrl+I works in the OCR text box
The OCR window's text box had no italic shortcut. Ctrl+I now toggles `<i>` on the selected part of the text (or the whole text when nothing is selected), same behavior as the main window's edit box. The selection-aware toggle was extracted from `MainViewModel.ToggleTextBoxTag` into the shared `TextBoxTagToggler`, which both windows now use.

### Tests
30 new tests (`AlignmentTagHelperTests`, `OcrCaptureAlignmentTests`, `TextBoxTagTogglerTests`) covering toggle on/off, an2 skipping and the WriteAn2Tag override, per-line mixed alignments, screen-position→anX mapping, and selection-based italic toggling incl. whitespace handling and ASSA tags. Full UI suite passes: 641/641.

🤖 Generated with [Claude Code](https://claude.com/claude-code)