### PR TITLE
Fix scroll bar trough click not paging in DataGrids (#12051)

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -97,6 +97,8 @@ public static partial class InitListViewAndEditBox
             FontSize = Se.Settings.Appearance.SubtitleGridFontSize,
         };
 
+        DataGridScrollBarBehavior.EnableTroughPageScroll(vm.SubtitleGrid);
+
         // hack to make drag and drop work on the DataGrid - also on empty rows
         var dropHost = new Border
         {

--- a/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
@@ -334,6 +334,7 @@ public class ShortcutsWindow : Window
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedNode)) { Source = vm });
         dataGrid.SelectionChanged += vm.ShortcutsDataGrid_SelectionChanged;
         dataGrid.DoubleTapped += vm.ShortcutsDataGridDoubleTapped;
+        DataGridScrollBarBehavior.EnableTroughPageScroll(dataGrid);
         var borderDataGrid = UiUtil.MakeBorderForControlNoPadding(dataGrid).WithMarginBottom(5);
 
         var flyout = new MenuFlyout();

--- a/src/ui/Logic/DataGridScrollBarBehavior.cs
+++ b/src/ui/Logic/DataGridScrollBarBehavior.cs
@@ -1,0 +1,58 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Gives a <see cref="DataGrid"/>'s vertical scroll bar a working page size so that
+/// clicking the scroll bar trough (the channel above or below the thumb) scrolls a full
+/// page, as it does everywhere else and on other platforms (issue #12051).
+///
+/// Avalonia's DataGrid sets its vertical scroll bar's Maximum and ViewportSize but never
+/// its LargeChange, so it keeps RangeBase's default of 1. A trough click raises a large
+/// increment that moves the value by a single pixel, which looks like a one line scroll.
+/// The horizontal scroll bar is given a LargeChange equal to its viewport, and a plain
+/// ScrollViewer binds LargeChange to its viewport too, which is why the Options window
+/// pages correctly while the subtitle grid and the Shortcuts grid do not. This keeps the
+/// vertical LargeChange in step with the viewport so a page always matches the visible
+/// height.
+/// </summary>
+internal static class DataGridScrollBarBehavior
+{
+    private const string VerticalScrollBarPartName = "PART_VerticalScrollbar";
+
+    public static void EnableTroughPageScroll(DataGrid grid)
+    {
+        grid.TemplateApplied += (_, e) =>
+        {
+            var verticalScrollBar = e.NameScope.Find<ScrollBar>(VerticalScrollBarPartName);
+            if (verticalScrollBar == null)
+            {
+                return;
+            }
+
+            SyncLargeChange(verticalScrollBar);
+
+            // The DataGrid updates ViewportSize (and Maximum) as the grid is resized or its
+            // rows change, so follow it and keep a page equal to the visible height.
+            verticalScrollBar.PropertyChanged += (_, args) =>
+            {
+                if (args.Property == ScrollBar.ViewportSizeProperty ||
+                    args.Property == ScrollBar.MaximumProperty)
+                {
+                    SyncLargeChange(verticalScrollBar);
+                }
+            };
+        };
+    }
+
+    private static void SyncLargeChange(ScrollBar verticalScrollBar)
+    {
+        var viewport = verticalScrollBar.ViewportSize;
+        if (!double.IsNaN(viewport) && viewport > 0 && verticalScrollBar.LargeChange != viewport)
+        {
+            verticalScrollBar.LargeChange = viewport;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #12051.

### Problem

Clicking the vertical scroll bar trough (the channel above or below the thumb) in the subtitle grid and in the Shortcuts dialog scrolled a single line instead of a page, so the arrow keys were the only way to move a page at a time. The Options window, which uses a plain ScrollViewer, paged correctly.

### Cause

Avalonia's DataGrid sets its vertical scroll bar's Maximum and ViewportSize but never its LargeChange, so it stays at RangeBase's default of 1: a trough click raises a large increment that moves the value by a single pixel. The DataGrid already gives its horizontal scroll bar a LargeChange equal to the viewport, and a plain ScrollViewer binds LargeChange to its viewport, which is why those page correctly while these two did not.

### Fix

A small reusable helper (`DataGridScrollBarBehavior`) keeps a DataGrid's vertical LargeChange in step with its ViewportSize, applied to the subtitle grid and the Shortcuts grid, so a trough click pages the way it does elsewhere and on Windows generally.

### Testing

Confirmed on Windows by @GrampaWildWilly (the reporter) on a portable test build: a trough click now pages in the Shortcuts dialog. Also verified on macOS.

### Scope

This is focused on the trough click paging, which was the main problem reported. Two related items are intentionally left out:
- The Shift+click jump-to-position behavior mentioned in the report is a small separate follow-up.
- The scroll bar overlapping content in the Shortcuts window (also raised in #12351) is a distinct issue from paging (the overlay bar covering content rather than the page amount), so it is not addressed here.
