### PR TITLE
Fix ElevenLabs SSML break tags by sending enable_ssml_parsing

### DIFF
--- a/src/ui/Logic/Download/TtsDownloadService.cs
+++ b/src/ui/Logic/Download/TtsDownloadService.cs
@@ -313,11 +313,21 @@ public class TtsDownloadService : ITtsDownloadService
         // placed in the request body, so toggling it had no effect on the generated audio.
         var useSpeakerBoost = Se.Settings.Video.TextToSpeech.ElevenLabsSpeakerBoost > 0 ? "true" : "false";
 
+        // ElevenLabs only parses SSML when enable_ssml_parsing is true - it defaults to false,
+        // so <break time="1.5s"/> tags were sent but ignored/spoken as plain text even with
+        // normalization off. The flag is only documented on the websocket endpoints but the
+        // HTTP endpoint accepts it as a body field too. Set it only when the text actually
+        // contains a break tag, so ordinary subtitle text with stray '<' or formatting tags
+        // is never run through the SSML parser (#12093).
+        var ssmlParsing = text.Contains("<break", StringComparison.OrdinalIgnoreCase)
+            ? ", \"enable_ssml_parsing\": true"
+            : string.Empty;
+
         // Disable ElevenLabs text normalization so the user's pause cues survive: SSML
         // <break time="1.5s"/> tags and punctuation pauses (",,," "..." "---") are otherwise
         // collapsed/rewritten by the "auto" normalizer on multilingual models. All standard
         // (non-v3) models honor break tags; v3 is handled on the text-to-dialogue path (#12093).
-        var data = "{ \"text\": \"" + Json.EncodeJsonText(text) + $"\", \"model_id\": \"{model}\"{language}, \"voice_settings\": {{ \"stability\": {stability}, \"similarity_boost\": {similarityBoost}, \"speed\": {speed}, \"style\": {styleExaggeration}, \"use_speaker_boost\": {useSpeakerBoost} }}, \"apply_text_normalization\": \"off\" }}";
+        var data = "{ \"text\": \"" + Json.EncodeJsonText(text) + $"\", \"model_id\": \"{model}\"{language}, \"voice_settings\": {{ \"stability\": {stability}, \"similarity_boost\": {similarityBoost}, \"speed\": {speed}, \"style\": {styleExaggeration}, \"use_speaker_boost\": {useSpeakerBoost} }}, \"apply_text_normalization\": \"off\"{ssmlParsing} }}";
 
         return await SendElevenLabsSpeakRequestAsync(url, data, apiKey, acceptAudioMpeg: true, stream, "ElevenLabs TTS", cancellationToken);
     }


### PR DESCRIPTION
## Summary

Follow-up to the ElevenLabs pause fixes for #12093 — cvrle77 reported ([comment](https://github.com/SubtitleEdit/subtitleedit/issues/12093#issuecomment-4951485590)) that pauses still don't work on v2 models even with `apply_text_normalization: "off"` (in beta14/15).

Root cause: the ElevenLabs API only parses SSML when `enable_ssml_parsing` is `true`, and it **defaults to `false`** — so `<break time="1.5s" />` tags were sent but ignored/spoken as plain text. The flag is only documented on the websocket endpoints, but the HTTP `/v1/text-to-speech/{voice_id}` endpoint accepts it as a body field (production clients such as the moltis Rust client and LiveKit rely on it). For the same reason, break tags never worked in SE4 either — its request body had no SSML flag.

## Change

- `TtsDownloadService.DownloadElevenLabsVoiceSpeak` (non-v3 path) now appends `"enable_ssml_parsing": true` to the request body **only when the text contains `<break`** (case-insensitive), so ordinary subtitle text with stray `<` or formatting tags is never run through the SSML parser and behavior is unchanged for everyone else.
- The v3 path needs no change: v3 doesn't support SSML break tags, and `ConvertBreakTagsToV3AudioTags` already maps them to `[pause]` audio tags.

## Notes for users (per ElevenLabs docs)

- Only the self-closing form `<break time="1.5s" />` works (max 3 s); `<break ...></break>` is silently ignored by ElevenLabs.
- Punctuation runs (`,,,` `___` `---`) are not documented pause cues for v2 models; ellipses/dashes are v3-only guidance.
- Too many break tags in one generation can cause speed-ups/artifacts (documented ElevenLabs limitation).

## Test plan

- [x] `dotnet build src/ui/UI.csproj` — 0 warnings, 0 errors
- [ ] Manual: generate a line containing `<break time="1.5s" />` on `eleven_multilingual_v2` and verify the pause is audible

🤖 Generated with [Claude Code](https://claude.com/claude-code)