### PR TITLE
Fix ElevenLabs v3 request body, test-voice error detail, language sort

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/ElevenLabs.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ElevenLabs.cs
@@ -226,10 +226,11 @@ public class ElevenLabs : ITtsEngine
 
             if (model == "eleven_turbo_v2_5")
             {
+                // Fall through to the sorted return below - an early return here put these
+                // three at the bottom of the language combo instead of in alphabetical order.
                 languages.Add(new TtsLanguage("Hungarian", "hu"));
                 languages.Add(new TtsLanguage("Norwegian", "no"));
                 languages.Add(new TtsLanguage("Vietnamese", "vi"));
-                return Task.FromResult(languages.ToArray());
             }
         }
 

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1433,12 +1433,18 @@ public partial class TextToSpeechViewModel : ObservableObject
             var result = await engine.Speak(text, _waveFolder, voice, SelectedLanguage, SelectedRegion, SelectedModel, testVoiceToken);
             if (!testVoiceToken.IsCancellationRequested)
             {
-                if (!File.Exists(result.FileName))
+                if (result.Error || string.IsNullOrEmpty(result.FileName) || !File.Exists(result.FileName))
                 {
+                    // Engines that fail via TtsResult (e.g. the ElevenLabs 429/401 text) carry the
+                    // actual reason in ErrorMessage - showing only the empty output path made the
+                    // dialog useless for exactly the failures users report (#12093).
+                    var detail = string.IsNullOrEmpty(result.ErrorMessage)
+                        ? $"Output audio file was not generated: {result.FileName}"
+                        : result.ErrorMessage;
                     await MessageBox.Show(
                         Window,
                         "Test voice error",
-                        $"Output audio file was not generated: {result.FileName}",
+                        detail,
                         MessageBoxButtons.OK,
                         MessageBoxIcon.Error);
 

--- a/src/ui/Logic/Download/TtsDownloadService.cs
+++ b/src/ui/Logic/Download/TtsDownloadService.cs
@@ -427,18 +427,24 @@ public class TtsDownloadService : ITtsDownloadService
         var text = ConvertBreakTagsToV3AudioTags(Utilities.UnbreakLine(inputText));
 
         var stability = Se.Settings.Video.TextToSpeech.ElevenLabsStability.ToString(CultureInfo.InvariantCulture);
-        var speed = Se.Settings.Video.TextToSpeech.ElevenLabsSpeed.ToString(CultureInfo.InvariantCulture);
-    
+
+        // Per the text-to-dialogue schema each "inputs" item accepts ONLY text + voice_id;
+        // language_code is a top-level field and stability goes in the top-level "settings"
+        // object. They used to be placed inside inputs[0], where the API silently ignored
+        // them - every v3 generation ran with default stability and no language enforcement.
+        // The endpoint has no speed parameter at all, so the speed setting is not sent.
+        // Normalization is turned off for the same reason as the v2 path: the "auto"
+        // normalizer can rewrite the user's punctuation pause cues ("..." etc.) (#12093).
         var languageFragment = string.IsNullOrEmpty(languageCode)
             ? string.Empty
-            : "\"language_code\": \"" + languageCode + "\", ";
+            : ", \"language_code\": \"" + languageCode + "\"";
         var data = "{ \"inputs\": [{ " +
                    "\"text\": \"" + Json.EncodeJsonText(text) + "\", " +
-                   "\"voice_id\": \"" + voice.VoiceId + "\", " +
+                   "\"voice_id\": \"" + voice.VoiceId + "\"" +
+                   " }]" +
                    languageFragment +
-                   "\"stability\": " + stability + ", " +
-                   "\"speed\": " + speed +
-                   " }] }";
+                   ", \"settings\": { \"stability\": " + stability + " }" +
+                   ", \"apply_text_normalization\": \"off\" }";
 
         return await SendElevenLabsSpeakRequestAsync(url, data, apiKey, acceptAudioMpeg: false, stream, "ElevenLabs TTS v3", cancellationToken);
     }


### PR DESCRIPTION
Three bugs found while reviewing the TTS/ElevenLabs area (follow-up to #12093 / #12397):

## 1. Eleven v3: settings were sent in the wrong place and silently ignored

`DownloadElevenLabsVoiceSpeak3` put `language_code`, `stability` and `speed` **inside** the `inputs[]` items, but per the [text-to-dialogue schema](https://elevenlabs.io/docs/api-reference/text-to-dialogue/convert) each input accepts only `text` + `voice_id` — the extra fields were silently dropped, so every v3 generation ran with default stability and no language enforcement.

- `language_code` → now a top-level field
- `stability` → now in the top-level `settings` object (the only field it accepts)
- `speed` → removed; the endpoint has no speed parameter
- `apply_text_normalization: "off"` → now sent on the v3 path too, matching the v2 path, so punctuation pause cues (`...`) aren't rewritten by the "auto" normalizer

## 2. Test voice discarded the engine's error message

When an engine failed via `TtsResult` (e.g. ElevenLabs 429 rate limit / 401 invalid key), the test-voice dialog showed "Output audio file was not generated:" with an empty path — the `ErrorMessage` the engine returned was never shown. The bulk-generate and review-regenerate paths already surface it; test voice now does too.

## 3. Language combo unsorted for `eleven_turbo_v2_5` (the default model)

`ElevenLabs.GetLanguages` returned early for turbo v2.5, skipping the `OrderBy` — Hungarian/Norwegian/Vietnamese appeared at the bottom of the list after Ukrainian instead of alphabetically.

## Test plan

- [x] `dotnet build src/ui/UI.csproj` — 0 warnings, 0 errors
- [ ] Manual: v3 generation with a non-default stability + a language selected; verify the request succeeds and the audio reflects stability
- [ ] Manual: test voice with an invalid ElevenLabs API key; verify the dialog shows the HTTP 401 detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)