### PR TITLE
Perf: remove steady-state allocations in GetFastHash and CalcFactory lookup

### DIFF
--- a/src/libse/Common/TextLengthCalculator/CalcFactory.cs
+++ b/src/libse/Common/TextLengthCalculator/CalcFactory.cs
@@ -20,20 +20,48 @@ namespace Nikse.SubtitleEdit.Core.Common.TextLengthCalculator
             new CalcIgnoreArabicDiacriticsNoSpace(),
         };
 
+        // Memo of the last strategy resolution. A single immutable pair swapped by reference
+        // keeps the lookup thread-safe without locking; the strategy is a settings value that
+        // practically never changes at runtime, so this hits on every call but the first.
+        private sealed class ResolvedCalculator
+        {
+            public readonly string Strategy;
+            public readonly ICalcLength Calculator;
+
+            public ResolvedCalculator(string strategy, ICalcLength calculator)
+            {
+                Strategy = strategy;
+                Calculator = calculator;
+            }
+        }
+
+        private static volatile ResolvedCalculator _lastResolved;
+
         public static ICalcLength MakeCalculator(string strategy)
         {
-            // Called per line on grid repaints (characters-per-second) - avoid the
-            // LINQ closure and the fallback allocation; the list entries are shared anyway.
+            // Called for every CountCharacters (grid CPS/length columns on repaint, waveform
+            // footer, per-keystroke text info), so resolving the strategy must be cheap: the
+            // memo avoids re-comparing reflection type names on every call.
+            var last = _lastResolved;
+            if (last != null && last.Strategy == strategy)
+            {
+                return last.Calculator;
+            }
+
+            // Avoid the LINQ closure and the fallback allocation; the list entries are shared anyway.
             var calculators = Calculators;
+            var result = calculators[0]; // CalcAll
             for (var i = 0; i < calculators.Count; i++)
             {
                 if (calculators[i].GetType().Name == strategy)
                 {
-                    return calculators[i];
+                    result = calculators[i];
+                    break;
                 }
             }
 
-            return calculators[0]; // CalcAll
+            _lastResolved = new ResolvedCalculator(strategy, result);
+            return result;
         }
     }
 }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -18289,14 +18289,20 @@ public partial class MainViewModel :
 
     public int GetFastHash()
     {
-        var pre = _subtitleFileName + SelectedEncoding.DisplayName;
-
+        // Runs every 250 ms (undo change detection) plus every 400 ms (title/auto-save),
+        // so it must not allocate: the old version concatenated fileName+encoding and
+        // called Trim() on Header/Footer - the editor normalises subtitles to ASSA, so
+        // Header is a multi-KB styles block ending in a newline and Trim() copied all of
+        // it on every call. Hash the parts separately and trim as spans instead
+        // (string.GetHashCode(span) equals the string's own GetHashCode, and hashes are
+        // only ever compared within this process).
         unchecked
         {
             var hash = 17;
-            hash = hash * 23 + (pre?.GetHashCode() ?? 0);
-            hash = hash * 23 + (_subtitle.Header?.Trim().GetHashCode() ?? 0);
-            hash = hash * 23 + (_subtitle.Footer?.Trim().GetHashCode() ?? 0);
+            hash = hash * 23 + (_subtitleFileName?.GetHashCode() ?? 0);
+            hash = hash * 23 + (SelectedEncoding.DisplayName?.GetHashCode() ?? 0);
+            hash = hash * 23 + (_subtitle.Header is { } header ? string.GetHashCode(header.AsSpan().Trim()) : 0);
+            hash = hash * 23 + (_subtitle.Footer is { } footer ? string.GetHashCode(footer.AsSpan().Trim()) : 0);
 
             var count = Subtitles.Count;
             for (var i = 0; i < count; i++)
@@ -18325,14 +18331,15 @@ public partial class MainViewModel :
     public int GetFastHashOriginal()
     {
         _subtitleOriginal ??= new Subtitle();
-        var pre = _subtitleFileNameOriginal + SelectedEncoding.DisplayName;
 
+        // Allocation-free for the same reason as GetFastHash above.
         unchecked
         {
             var hash = 17;
-            hash = hash * 23 + (pre?.GetHashCode() ?? 0);
-            hash = hash * 23 + (_subtitleOriginal.Header?.Trim().GetHashCode() ?? 0);
-            hash = hash * 23 + (_subtitleOriginal.Footer?.Trim().GetHashCode() ?? 0);
+            hash = hash * 23 + (_subtitleFileNameOriginal?.GetHashCode() ?? 0);
+            hash = hash * 23 + (SelectedEncoding.DisplayName?.GetHashCode() ?? 0);
+            hash = hash * 23 + (_subtitleOriginal.Header is { } header ? string.GetHashCode(header.AsSpan().Trim()) : 0);
+            hash = hash * 23 + (_subtitleOriginal.Footer is { } footer ? string.GetHashCode(footer.AsSpan().Trim()) : 0);
 
             var count = Subtitles.Count;
             for (var i = 0; i < count; i++)


### PR DESCRIPTION
Two micro-optimizations on paths that run constantly, follow-up to #12400.

## 1. `GetFastHash` / `GetFastHashOriginal`: no more per-call header copy

These run every 250 ms (undo change detection via `UndoRedoManager.CheckForChanges`) plus every 400 ms (title dirty-star / auto-save; twice with the original column visible) — roughly 6–7 full passes per second, forever, even when the app is idle. Each call allocated:

- `_subtitleFileName + SelectedEncoding.DisplayName` — a throwaway concat string
- `Header?.Trim()` / `Footer?.Trim()` — and since the SE5 editor normalises subtitles to ASSA internally, `Header` is a multi-KB `[V4+ Styles]` block that ends in a newline, so `Trim()` **copied the entire header on every call**.

Now the components are hashed separately and Header/Footer are trimmed as spans: `string.GetHashCode(header.AsSpan().Trim())` — zero allocation. `string.GetHashCode(ReadOnlySpan<char>)` returns the same value as the string's own `GetHashCode()`, and these hashes are only ever compared against other hashes computed in the same process (undo baseline, dirty-star, auto-save settle), so semantics are unchanged.

## 2. `CalcFactory.MakeCalculator`: memoize the strategy resolution

`MakeCalculator` sits on the path of **every** `CountCharacters` call — grid CPS/line-length columns on repaint, the waveform paragraph footer, per-keystroke text info, Netflix checks — and resolved the strategy by comparing `GetType().Name` against up to 11 entries on each call. The strategy is a settings value that practically never changes at runtime.

Added a one-entry memo: an immutable `(strategy, calculator)` pair swapped by reference (volatile read, no locking), so a hit costs a reference read plus one string compare. First call and strategy changes still fall through to the existing scan.

## Test plan

- [x] `dotnet build` libse (no-incremental) + UI — 0 warnings, 0 errors
- [x] LibSETests: 485/485 pass
- [x] Hash semantics: values still compared only against same-process hashes computed by the same function (undo baseline, dirty-star, auto-save)

🤖 Generated with [Claude Code](https://claude.com/claude-code)