### PR TITLE
Fix common errors: select all/invert respect the active category chip

### DIFF
--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -274,10 +274,13 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         }
     }
 
+    // Select all / invert operate on the fixes passing the active category chip, not the full
+    // list - with a category chip active they must not touch fixes hidden by the filter. With
+    // the "All" chip active VisibleFixes equals Fixes, so nothing changes there (#12377).
     [RelayCommand]
     public void FixesSelectAll()
     {
-        foreach (var fix in Fixes)
+        foreach (var fix in VisibleFixes)
         {
             fix.IsSelected = true;
         }
@@ -288,7 +291,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
     [RelayCommand]
     public void FixesInverseSelected()
     {
-        foreach (var fix in Fixes)
+        foreach (var fix in VisibleFixes)
         {
             fix.IsSelected = !fix.IsSelected;
         }


### PR DESCRIPTION
## Summary

Fixes #12377.

On the fixes step of Fix common errors, "Select all" and "Invert selection" iterated the full `Fixes` collection, so with a category chip active they also silently toggled every fix hidden by the filter. They now operate on `VisibleFixes` — the chip-filtered list the user is actually looking at.

With the "All" chip active `VisibleFixes` equals `Fixes`, so the default behavior is unchanged.

## Testing

- `dotnet build src/ui/UI.csproj` — clean, 0 warnings/errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)