### PR TITLE
Fix common errors: scope the fixes summary count to the active category (#12377)

### DIFF
--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -387,6 +387,9 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         }
 
         RebuildVisibleFixes();
+        // Refresh the "N fixes, M selected" line so it reflects the newly active category,
+        // matching what Select all and Invert now act on (#12377, follow-up to #12408).
+        UpdateFixesSummary();
     }
 
     private void RebuildVisibleFixes()
@@ -403,8 +406,11 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
 
     private void UpdateFixesSummary()
     {
-        var selected = Fixes.Count(f => f.IsSelected);
-        FixesSummaryText = string.Format(Se.Language.Tools.FixCommonErrors.XFixesYSelected, Fixes.Count, selected);
+        // Count within the active category view so the summary matches the chip and the
+        // now category-scoped Select all / Invert (#12377); with "All" active VisibleFixes
+        // equals Fixes, so this is the full set.
+        var selected = VisibleFixes.Count(f => f.IsSelected);
+        FixesSummaryText = string.Format(Se.Language.Tools.FixCommonErrors.XFixesYSelected, VisibleFixes.Count, selected);
     }
 
     [RelayCommand]


### PR DESCRIPTION
Follow-up to #12408.

#12408 scoped "Select all" and "Invert selection" on the fixes step of Fix common errors to the active category chip. This finishes the same report (#12377): the "N fixes, M selected" summary was still counting the whole `Fixes` list, so with a category chip active the count did not match the chip or the now category-scoped Select all / Invert.

### Change
- `UpdateFixesSummary` now counts `VisibleFixes` (the chip-filtered list) instead of the full `Fixes` collection.
- `SetFixFilter` refreshes the summary when the active chip changes, so the count follows the selected category.

With the "All" chip active `VisibleFixes` equals `Fixes`, so the summary is unchanged there.

This matches the mockup in the original report: selecting a category shows that category's total (for example "694 fixes, 694 selected") rather than the whole list.
