### PR TITLE
Fix re-browsing the other subtitle in point sync via other

### DIFF
--- a/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherViewModel.cs
+++ b/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherViewModel.cs
@@ -113,10 +113,17 @@ public partial class PointSyncViaOtherViewModel : ObservableObject
         }
 
         FileNameOther = fileName;
+        Othersubtitles.Clear();
         foreach (var p in subtitle.Paragraphs)
         {
             Othersubtitles.Add(new SubtitleLineViewModel(p, subtitle.OriginalFormat));
         }
+
+        SelectedOtherSubtitle = Othersubtitles.FirstOrDefault();
+
+        // Sync points reference lines in the replaced file, so they are no longer valid.
+        SyncPoints.Clear();
+        IsOkEnabled = false;
     }
 
     [RelayCommand]


### PR DESCRIPTION
Fixes #12398

In "Point sync via other subtitle", picking a different file with the "..." browse button after the first pick appeared to do nothing: the new file's lines were appended to `Othersubtitles` instead of replacing them, so the list still showed the first file at the top (while the filename label updated).

Changes in `BrowseOther()`:
- Clear `Othersubtitles` before loading the newly picked file.
- Select the first line of the new file (mirrors the left-hand list in `Initialize`).
- Clear existing `SyncPoints` and reset `IsOkEnabled`, since sync points reference lines/indexes from the replaced file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)