### PR TITLE
Fix "Unable to check for updates" after changelog format change

### DIFF
--- a/src/ui/Features/Help/CheckForUpdates/CheckForUpdatesViewModel.cs
+++ b/src/ui/Features/Help/CheckForUpdates/CheckForUpdatesViewModel.cs
@@ -93,21 +93,17 @@ public partial class CheckForUpdatesViewModel : ObservableObject
     private static string ParseLatestChangeLog(string changeLogContent)
     {
         const string releaseSeparator = "-----------------------------------------------------------------------------------------------------";
-        var separatorIndex = changeLogContent.IndexOf(releaseSeparator, StringComparison.Ordinal);
-        if (separatorIndex > 0)
+        foreach (var block in changeLogContent.Split(releaseSeparator))
         {
-            var changeLog = changeLogContent[..separatorIndex].Trim();
-            if (!UnreleasedChangeLogRegex.IsMatch(changeLog))
+            var changeLog = block.Trim();
+            if (changeLog.Length == 0 ||
+                string.IsNullOrEmpty(ParseLatestVersion(changeLog)) || // file title or other block without a version header
+                UnreleasedChangeLogRegex.IsMatch(changeLog)) // unreleased draft entry
             {
-                return changeLog;
+                continue;
             }
 
-            // get next change log which is current released version
-            var releaseChangeLogIndex = changeLogContent.IndexOf(releaseSeparator, separatorIndex + releaseSeparator.Length, StringComparison.Ordinal);
-            if (releaseChangeLogIndex > 0)
-            {
-                return changeLogContent[(separatorIndex + releaseSeparator.Length) ..releaseChangeLogIndex].Trim();
-            }
+            return changeLog;
         }
 
         return changeLogContent.Trim();


### PR DESCRIPTION
Fixes #12412

The update check downloads `change-log.txt` fine — the failure is in parsing. `ParseLatestChangeLog` assumed the newest release block was everything before the **first** separator line. That held until July 12, when the draft `v5.1.0-rc1 (TBD)` section added a separator directly after the "Subtitle Edit Changelog" title. The parser then returned just the title (visible in the issue screenshot), `ParseLatestVersion` found no `vX.Y.Z (` line, and the check reported "Unable to check for updates" — on all platforms, not just macOS.

Change: split the changelog on the separator and return the first block that actually contains a version header and is not an unreleased draft (`TBD` / `xth Month` date). This works with both the current and the pre-July-12 file layout.

Verified against the live `change-log.txt` (resolves `v5.1.0-beta15`), the old layout without a leading separator, and a draft-topped layout with an `xth` date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)