### PR TITLE
Speech to text: add MOSS-Transcribe-Diarize engine (CrispASR)

### DIFF
--- a/src/libse/AudioToText/WhisperChoice.cs
+++ b/src/libse/AudioToText/WhisperChoice.cs
@@ -29,6 +29,7 @@
         public const string CrispAsrKyutai = "Crisp ASR Kyutai";
         public const string CrispAsrMadlad = "Crisp ASR MADLAD";
         public const string CrispAsrMega = "Crisp ASR Mega";
+        public const string CrispAsrMossDiarize = "Crisp ASR MOSS Diarize";
         public const string CrispAsrSenseVoice = "Crisp ASR SenseVoice";
         public const string CrispAsrArk = "Crisp ASR ARK";
         public const string OpenAiCompatible = "OpenAI Compatible";

--- a/src/ui/Assets/SpeechToText/CrispASRMOSSDiarize.txt
+++ b/src/ui/Assets/SpeechToText/CrispASRMOSSDiarize.txt
@@ -1,0 +1,5 @@
+🎙️ MOSS-Transcribe-Diarize
+
+Type: Whisper encoder + Qwen3-0.6B LM decoder (0.9B total) — joint ASR + speaker diarization
+Focus: 🎯 English and Chinese — timestamped, speaker-labelled transcripts in a single pass
+Extras: each line is prefixed with its speaker, e.g. "(Speaker 1) Hello there."

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
@@ -30,6 +30,7 @@ public class CrispAsrEngine : CrispAsrEngineBase
             new CrispAsrGranite(),
             new CrispAsrQwen3(),
             new CrispAsrMega(),
+            new CrispAsrMossDiarize(),
             new CrispAsrOmni(),
             new CrispAsrKyutai(),
             new CrispAsrSenseVoice(),

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrMossDiarize.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrMossDiarize.cs
@@ -1,0 +1,141 @@
+using Nikse.SubtitleEdit.Core.AudioToText;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+public class CrispAsrMossDiarize : CrispAsrEngineBase
+{
+    public static string StaticName => "Crisp ASR MOSS Diarize";
+    public override string Name => StaticName;
+    public override string Choice => WhisperChoice.CrispAsrMossDiarize;
+    public override string BackendName => "moss-diarize";
+    public override string DefaultLanguage => "en";
+    public override bool IncludeLanguage => false;
+    public override bool HasNativeTimestamps => true;
+    public override string Url => "https://github.com/CrispStrobe/CrispASR";
+
+    public override List<WhisperLanguage> Languages =>
+       new()
+       {
+            new WhisperLanguage("en", "english"),
+            new WhisperLanguage("zh", "chinese"),
+       };
+
+    // q4_k is intentionally absent: it produces ~1.7x compressed timestamps (verified against
+    // the jfk.wav ground truth in the model card with CrispASR v0.8.10) - same sub-8-bit
+    // encoder drift that broke qwen3-asr q4_k. q8_0 and f16 both match the ground truth.
+    public override List<WhisperModel> Models =>
+       new()
+       {
+            new WhisperModel
+            {
+                Name = "moss-transcribe-diarize-0.9b-q8_0.gguf",
+                Size = "1.41 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/MOSS-Transcribe-Diarize-GGUF/resolve/main/moss-transcribe-diarize-0.9b-q8_0.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "moss-transcribe-diarize-0.9b-f16.gguf",
+                Size = "1.82 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/MOSS-Transcribe-Diarize-GGUF/resolve/main/moss-transcribe-diarize-0.9b-f16.gguf",
+                ],
+            },
+       };
+
+    public override string Extension => string.Empty;
+    public override string UnpackSkipFolder => string.Empty;
+
+    public override bool IsEngineInstalled()
+    {
+        var executableFile = GetExecutable();
+        return File.Exists(executableFile);
+    }
+
+    public override string ToString()
+    {
+        return CrispAsrEngine.GetBackendDisplayName(this);
+    }
+
+    public override string GetAndCreateWhisperFolder()
+    {
+        var folder = Se.CrispAsrFolder;
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public override string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel)
+    {
+        var folder = GetAndCreateWhisperFolder();
+        var modelsFolder = Path.Combine(folder, "models");
+        if (!Directory.Exists(modelsFolder))
+        {
+            Directory.CreateDirectory(modelsFolder);
+        }
+
+        return modelsFolder;
+    }
+
+    public override string GetExecutable()
+    {
+        string fullPath = Path.Combine(GetAndCreateWhisperFolder(), GetExecutableFileName());
+        return fullPath;
+    }
+
+    public override bool IsModelInstalled(WhisperModel model)
+    {
+        var modelFile = GetModelForCmdLine(model.Name);
+        if (!File.Exists(modelFile))
+        {
+            return false;
+        }
+
+        return new FileInfo(modelFile).Length > 10_000_000;
+    }
+
+    public override string GetModelForCmdLine(string modelName)
+    {
+        var modelFileName = Path.Combine(GetAndCreateWhisperModelFolder(null), modelName);
+        return modelFileName;
+    }
+
+    public override string GetWhisperModelDownloadFileName(WhisperModel whisperModel, string url)
+    {
+        var folder = GetAndCreateWhisperModelFolder(whisperModel);
+        var fileNameOnly = Path.GetFileName(url);
+        var fileName = Path.Combine(folder, fileNameOnly);
+        return fileName;
+    }
+
+    internal static string GetExecutableFileName()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return "crispasr.exe";
+        }
+
+        return "crispasr";
+    }
+
+    public override bool CanBeDownloaded()
+    {
+        return true;
+    }
+
+    public override string CommandLineParameter
+    {
+        get => Se.Settings.Tools.AudioToText.CommandLineParameterCrispAsrMossDiarize;
+        set => Se.Settings.Tools.AudioToText.CommandLineParameterCrispAsrMossDiarize = value;
+    }
+}

--- a/src/ui/Logic/Config/SeAudioToText.cs
+++ b/src/ui/Logic/Config/SeAudioToText.cs
@@ -58,6 +58,7 @@ public class SeAudioToText
     public string CommandLineParameterCrispAsrOmni { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrKyutai { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrMega { get; set; } = "--max-len 50 --split-on-punct";
+    public string CommandLineParameterCrispAsrMossDiarize { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrSenseVoice { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrArk { get; set; } = "--max-len 50 --split-on-punct";
     public string CrispAsrForcedAligner { get; set; } = "built-in";

--- a/src/ui/UI.csproj
+++ b/src/ui/UI.csproj
@@ -188,7 +188,13 @@
 		<AvaloniaResource Include="Assets\SpeechToText\CrispASRMega.txt">
 		  <CopyToOutputDirectory></CopyToOutputDirectory>
 		</AvaloniaResource>
+		<AvaloniaResource Include="Assets\SpeechToText\CrispASRMOSSDiarize.txt">
+		  <CopyToOutputDirectory></CopyToOutputDirectory>
+		</AvaloniaResource>
 		<AvaloniaResource Include="Assets\SpeechToText\CrispASRSenseVoice.txt">
+		  <CopyToOutputDirectory></CopyToOutputDirectory>
+		</AvaloniaResource>
+		<AvaloniaResource Include="Assets\SpeechToText\CrispASRARK.txt">
 		  <CopyToOutputDirectory></CopyToOutputDirectory>
 		</AvaloniaResource>
 		<AvaloniaResource Include="Assets\Themes.zip" />


### PR DESCRIPTION
Part of #12413 (the diarize half; hotwords can be passed via the extra command-line parameters box, see notes below).

**Depends on #12417** (CrispASR v0.8.10 — the `moss-diarize` backend does not exist in v0.8.9); this branch is based on it and includes its commit until it merges.

Adds **MOSS Diarize** as a new Crisp ASR backend: [MOSS-Transcribe-Diarize](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize), a 0.9B model doing joint transcription + speaker diarization + native timestamps in a single pass. Each subtitle line is prefixed with its speaker, e.g. `(Speaker 1) Hello there.` English + Chinese.

**Verified headlessly against the pinned v0.8.10 macOS binary** with the exact invocation SE constructs (`--backend moss-diarize -m <model> -f <wav> --output-srt --max-len 50 --split-on-punct`):
- `q8_0` and `f16` both reproduce the model card's jfk.wav ground truth (timestamps within ~0.3 s) and correctly separate/label speakers on a synthetic two-voice dialog.
- `q4_k` is **intentionally excluded**: it transcribes correctly but emits ~1.7× compressed timestamps (jfk.wav ends at 6.1 s instead of 10.5 s) — the same sub-8-bit encoder drift that broke qwen3-asr q4_k. A code comment documents this.

Notes:
- `--hotwords` is accepted by the backend (usable via the extra command-line parameters box), but a raw `[S02]` speaker tag can leak into the text when it's used — upstream quirk, so no dedicated hotwords UI in this PR.
- Drive-by fix: `CrispASRARK.txt` was never registered as an AvaloniaResource in `UI.csproj`, so the ARK engine's help text would fail to load; added it alongside the new engine's asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)