### PR TITLE
Fix truncated "Number" and "Show" columns in auto-translate grid

### DIFF
--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -380,14 +380,14 @@ public class AutoTranslateWindow : Window
                 {
                     Header = Se.Language.General.NumberSymbol,
                     Binding = new Binding(nameof(TranslateRow.Number)),
-                    Width = new DataGridLength(50),
+                    Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
                 },
                 new DataGridTextColumn
                 {
                     Header = Se.Language.General.Show,
                     Binding = new Binding(nameof(TranslateRow.Show)),
-                    Width = new DataGridLength(100),
+                    Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
                 },
                 new DataGridTextColumn


### PR DESCRIPTION
## Summary
- The "Number" (#) and "Show" columns in the auto-translate window's DataGrid used fixed widths (50 / 100), which truncated their content for larger subtitle numbers and longer timecodes
- Changed both columns to auto width so the full cell content is always visible

## Test plan
- [x] Open a subtitle file with many lines (1000+) and launch Auto-translate
- [x] Verify the "#" column shows full subtitle numbers without truncation
- [x] Verify the "Show" column displays the full timecode without clipping

## Before

<img width="867" height="553" alt="image" src="https://github.com/user-attachments/assets/32d3a5a2-7686-4d1c-b55c-1221d9ef5013" />


## After 

<img width="884" height="548" alt="image" src="https://github.com/user-attachments/assets/e8a2c656-aae7-49be-8900-9a4cdf0c00a1" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)