### PR TITLE
Fix find-history flyout opening as an empty sliver

### DIFF
--- a/src/ui/Features/Edit/Find/FindWindow.cs
+++ b/src/ui/Features/Edit/Find/FindWindow.cs
@@ -41,7 +41,11 @@ public class FindWindow : Window
         buttonHistory.Margin = new Thickness(3, 0, 0, 3);
         buttonHistory.Flyout = historyFlyout;
         ToolTip.SetTip(buttonHistory, Se.Language.General.ShowHistory);
-        historyFlyout.Opening += (_, _) =>
+
+        // The items must exist BEFORE the flyout opens: items added from the Opening
+        // event come too late for the popup's initial measure, so the menu displayed
+        // as an empty sliver on Windows. Build eagerly and rebuild on history changes.
+        void RebuildHistoryMenu()
         {
             historyFlyout.Items.Clear();
             foreach (var text in vm.SearchHistory)
@@ -54,11 +58,12 @@ public class FindWindow : Window
                     CommandParameter = text,
                 });
             }
-        };
 
-        void UpdateHistoryEnabled() => buttonHistory.IsEnabled = vm.SearchHistory.Count > 0;
-        vm.SearchHistory.CollectionChanged += (_, _) => UpdateHistoryEnabled();
-        UpdateHistoryEnabled();
+            buttonHistory.IsVisible = vm.SearchHistory.Count > 0;
+        }
+
+        vm.SearchHistory.CollectionChanged += (_, _) => RebuildHistoryMenu();
+        RebuildHistoryMenu();
 
         var panelFind = new Grid
         {

--- a/tests/UI/Features/Edit/Find/FindWindowHistoryTests.cs
+++ b/tests/UI/Features/Edit/Find/FindWindowHistoryTests.cs
@@ -1,0 +1,88 @@
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.LogicalTree;
+using Nikse.SubtitleEdit.Features.Edit.Find;
+
+namespace UITests.Features.Edit.Find;
+
+/// <summary>
+/// The find-history flyout must have its menu items built before the flyout opens:
+/// items added from the Opening event come too late for the popup's initial measure,
+/// which made the menu display as an empty sliver on Windows (PR #12409 follow-up).
+/// </summary>
+public class FindWindowHistoryTests
+{
+    private static (FindWindow window, Button historyButton) BuildShownWindow()
+    {
+        var vm = new FindViewModel();
+        vm.SearchHistory.Add("foo");
+        vm.SearchHistory.Add("bar");
+
+        var window = new FindWindow(vm);
+        window.Show();
+
+        var historyButton = window.GetLogicalDescendants().OfType<Button>().First(b => b.Flyout != null);
+        return (window, historyButton);
+    }
+
+    [AvaloniaFact]
+    public void HistoryButton_IsVisible_WhenHistoryExists()
+    {
+        var (_, historyButton) = BuildShownWindow();
+
+        Assert.True(historyButton.IsVisible);
+    }
+
+    [AvaloniaFact]
+    public void HistoryButton_IsHidden_WhenHistoryIsEmpty()
+    {
+        var vm = new FindViewModel();
+        var window = new FindWindow(vm);
+        window.Show();
+
+        var historyButton = window.GetLogicalDescendants().OfType<Button>().First(b => b.Flyout != null);
+
+        Assert.False(historyButton.IsVisible);
+
+        // First search lands in history -> button appears.
+        vm.SearchHistory.Add("foo");
+        Assert.True(historyButton.IsVisible);
+    }
+
+    [AvaloniaFact]
+    public void HistoryFlyout_HasItemsBeforeOpening_AndFollowsHistoryChanges()
+    {
+        var (_, historyButton) = BuildShownWindow();
+
+        var flyout = Assert.IsType<MenuFlyout>(historyButton.Flyout);
+        Assert.Equal(2, flyout.Items.Count);
+
+        // Simulate InitializeFindData refreshing the history after window construction.
+        var vm = (FindViewModel)historyButton.DataContext!;
+        vm.SearchHistory.Add("baz");
+
+        Assert.Equal(3, flyout.Items.Count);
+    }
+
+    [AvaloniaFact]
+    public void HistoryButton_MouseClick_OpensFlyoutWithItems()
+    {
+        var (window, historyButton) = BuildShownWindow();
+        window.UpdateLayout();
+        AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        var center = historyButton.TranslatePoint(
+            new Point(historyButton.Bounds.Width / 2, historyButton.Bounds.Height / 2), window)!.Value;
+        window.MouseDown(center, MouseButton.Left);
+        window.MouseUp(center, MouseButton.Left);
+
+        var flyout = Assert.IsType<MenuFlyout>(historyButton.Flyout);
+        Assert.True(flyout.IsOpen, "history flyout should open on click");
+        Assert.Equal(2, flyout.Items.Count);
+    }
+}


### PR DESCRIPTION
## Summary
Follow-up to #12409: clicking the find-history icon button appeared to do nothing.

- Root cause: the flyout''s menu items were only added inside `MenuFlyout.Opening`, which is too late for the popup''s initial measure on Windows - the menu opened as an empty ~2px sliver.
- Fix: build the menu items eagerly and rebuild them whenever `SearchHistory` changes, so the flyout always has content before it opens.
- The button is now hidden entirely while there is no history (it appears after the first search).

## Test plan
- [x] New headless tests: button visible/hidden by history state, items exist before opening and follow history changes, mouse click opens the flyout with items
- [x] Verified manually on Windows - the history dropdown now shows recent searches

🤖 Generated with [Claude Code](https://claude.com/claude-code)