### PR TITLE
Fix common errors: clearer step 2 selection UX (#12377)

### DIFF
--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -32,7 +32,6 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
     [ObservableProperty] private ObservableCollection<FixDisplayItem> _fixes;
     [ObservableProperty] private ObservableCollection<FixDisplayItem> _visibleFixes;
     [ObservableProperty] private ObservableCollection<FixFilterChip> _fixChips;
-    [ObservableProperty] private string _fixesSummaryText;
     [ObservableProperty] private string _fixesSelectAllText;
     [ObservableProperty] private string _applySelectedFixesText;
     [ObservableProperty] private FixDisplayItem? _selectedFix;
@@ -85,7 +84,6 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         Fixes = new ObservableCollection<FixDisplayItem>();
         VisibleFixes = new ObservableCollection<FixDisplayItem>();
         FixChips = new ObservableCollection<FixFilterChip>();
-        FixesSummaryText = string.Empty;
         FixesSelectAllText = Se.Language.General.SelectAll;
         ApplySelectedFixesText = Se.Language.Tools.FixCommonErrors.ApplySelectedFixes;
         Paragraphs = new ObservableCollection<SubtitleLineViewModel>();
@@ -402,11 +400,9 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
 
     private void UpdateFixesSummary()
     {
-        // Count within the active category view so the summary matches the chip and the
-        // now category-scoped Select all (#12377); with "All" active VisibleFixes equals
-        // Fixes, so this is the full set.
+        // Count within the active category view so the toggle and chip figures match what
+        // Select all now acts on (#12377); with "All" active VisibleFixes equals Fixes.
         var selected = VisibleFixes.Count(f => f.IsSelected);
-        FixesSummaryText = string.Format(Se.Language.Tools.FixCommonErrors.XFixesYSelected, VisibleFixes.Count, selected);
 
         // Flip the toggle caption so the button says what its next click will do for the
         // current category: "Select none" once everything in view is ticked, else "Select all".

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -33,6 +33,8 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
     [ObservableProperty] private ObservableCollection<FixDisplayItem> _visibleFixes;
     [ObservableProperty] private ObservableCollection<FixFilterChip> _fixChips;
     [ObservableProperty] private string _fixesSummaryText;
+    [ObservableProperty] private string _fixesSelectAllText;
+    [ObservableProperty] private string _applySelectedFixesText;
     [ObservableProperty] private FixDisplayItem? _selectedFix;
     [ObservableProperty] private ObservableCollection<SubtitleLineViewModel> _paragraphs;
     [ObservableProperty] private SubtitleLineViewModel? _selectedParagraph;
@@ -84,6 +86,8 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         VisibleFixes = new ObservableCollection<FixDisplayItem>();
         FixChips = new ObservableCollection<FixFilterChip>();
         FixesSummaryText = string.Empty;
+        FixesSelectAllText = Se.Language.General.SelectAll;
+        ApplySelectedFixesText = Se.Language.Tools.FixCommonErrors.ApplySelectedFixes;
         Paragraphs = new ObservableCollection<SubtitleLineViewModel>();
         _language = Se.Language.Tools.FixCommonErrors;
         Step1IsVisible = true;
@@ -274,26 +278,18 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         }
     }
 
-    // Select all / invert operate on the fixes passing the active category chip, not the full
-    // list - with a category chip active they must not touch fixes hidden by the filter. With
-    // the "All" chip active VisibleFixes equals Fixes, so nothing changes there (#12377).
+    // Select all / none toggle. Operates on the fixes passing the active category chip, not the
+    // full list - with a category chip active it must not touch fixes hidden by the filter, and
+    // with the "All" chip active VisibleFixes equals Fixes, so it covers everything there. When
+    // anything in the view is still unticked it selects all of it, otherwise it clears the view,
+    // so one button both selects and deselects the current category (#12377).
     [RelayCommand]
     public void FixesSelectAll()
     {
+        var selectAll = VisibleFixes.Any(f => !f.IsSelected);
         foreach (var fix in VisibleFixes)
         {
-            fix.IsSelected = true;
-        }
-
-        UpdateFixesSummary();
-    }
-
-    [RelayCommand]
-    public void FixesInverseSelected()
-    {
-        foreach (var fix in VisibleFixes)
-        {
-            fix.IsSelected = !fix.IsSelected;
+            fix.IsSelected = selectAll;
         }
 
         UpdateFixesSummary();
@@ -407,10 +403,35 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
     private void UpdateFixesSummary()
     {
         // Count within the active category view so the summary matches the chip and the
-        // now category-scoped Select all / Invert (#12377); with "All" active VisibleFixes
-        // equals Fixes, so this is the full set.
+        // now category-scoped Select all (#12377); with "All" active VisibleFixes equals
+        // Fixes, so this is the full set.
         var selected = VisibleFixes.Count(f => f.IsSelected);
         FixesSummaryText = string.Format(Se.Language.Tools.FixCommonErrors.XFixesYSelected, VisibleFixes.Count, selected);
+
+        // Flip the toggle caption so the button says what its next click will do for the
+        // current category: "Select none" once everything in view is ticked, else "Select all".
+        var allVisibleSelected = VisibleFixes.Count > 0 && selected == VisibleFixes.Count;
+        FixesSelectAllText = allVisibleSelected ? Se.Language.General.SelectNone : Se.Language.General.SelectAll;
+
+        // The Apply button acts on every ticked fix across all categories, not just the visible
+        // ones, so show that global count in its caption to remove the "does it apply the whole
+        // list or only this tab" ambiguity raised on #12377.
+        var totalSelected = Fixes.Count(f => f.IsSelected);
+        ApplySelectedFixesText = $"{Se.Language.Tools.FixCommonErrors.ApplySelectedFixes} ({totalSelected})";
+
+        UpdateChipSelectedCounts();
+    }
+
+    // Keep each category chip's "selected / total" figure current so every tab shows how many
+    // of its own fixes are ticked, not just how many exist (#12377).
+    private void UpdateChipSelectedCounts()
+    {
+        foreach (var chip in FixChips)
+        {
+            chip.SelectedCount = chip.Action == null
+                ? Fixes.Count(f => f.IsSelected)
+                : Fixes.Count(f => f.ActionDisplay == chip.Action && f.IsSelected);
+        }
     }
 
     [RelayCommand]

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -446,8 +446,10 @@ public class FixCommonErrorsWindow : Window
             Spacing = 0,
         };
         leftButtons.Children.Add(summaryText);
-        leftButtons.Children.Add(UiUtil.MakeButton(Se.Language.General.SelectAll, _vm.FixesSelectAllCommand));
-        leftButtons.Children.Add(UiUtil.MakeButton(Se.Language.General.InvertSelection, _vm.FixesInverseSelectedCommand));
+        var buttonSelectAll = UiUtil.MakeButton(Se.Language.General.SelectAll, _vm.FixesSelectAllCommand);
+        // Caption toggles between "Select all" and "Select none" as the current category fills up.
+        buttonSelectAll.Bind(Button.ContentProperty, new Binding(nameof(_vm.FixesSelectAllText)) { Source = _vm });
+        leftButtons.Children.Add(buttonSelectAll);
 
         var rightButtons = new StackPanel
         {
@@ -457,7 +459,10 @@ public class FixCommonErrorsWindow : Window
             Spacing = 0,
         };
         rightButtons.Children.Add(UiUtil.MakeButton(Se.Language.Tools.FixCommonErrors.RefreshFixes, _vm.DoRefreshFixesCommand).WithIconLeft("fa-solid fa-rotate"));
-        _buttonApplySelectedFixes = UiUtil.MakeButton(Se.Language.Tools.FixCommonErrors.ApplySelectedFixes, _vm.DoApplyFixesCommand).WithIconLeft("fa-solid fa-check");
+        // Caption carries the live count of fixes the button will apply, e.g. "Apply selected fixes (706)".
+        _buttonApplySelectedFixes = UiUtil.MakeButton(Se.Language.Tools.FixCommonErrors.ApplySelectedFixes, _vm.DoApplyFixesCommand)
+            .WithIconLeftBindText("fa-solid fa-check", nameof(_vm.ApplySelectedFixesText));
+        AutomationProperties.SetName(_buttonApplySelectedFixes, Se.Language.Tools.FixCommonErrors.ApplySelectedFixes);
         rightButtons.Children.Add(_buttonApplySelectedFixes);
 
         var buttonBarFixes = new Grid

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -430,14 +430,6 @@ public class FixCommonErrorsWindow : Window
                 }
             });
 
-        var summaryText = new TextBlock
-        {
-            VerticalAlignment = VerticalAlignment.Center,
-            Opacity = 0.8,
-            Margin = new Thickness(4, 0, 10, 0),
-        };
-        summaryText.Bind(TextBlock.TextProperty, new Binding(nameof(_vm.FixesSummaryText)) { Source = _vm });
-
         var leftButtons = new StackPanel
         {
             Orientation = Orientation.Horizontal,
@@ -445,7 +437,6 @@ public class FixCommonErrorsWindow : Window
             VerticalAlignment = VerticalAlignment.Center,
             Spacing = 0,
         };
-        leftButtons.Children.Add(summaryText);
         var buttonSelectAll = UiUtil.MakeButton(Se.Language.General.SelectAll, _vm.FixesSelectAllCommand);
         // Caption toggles between "Select all" and "Select none" as the current category fills up.
         buttonSelectAll.Bind(Button.ContentProperty, new Binding(nameof(_vm.FixesSelectAllText)) { Source = _vm });

--- a/src/ui/Features/Tools/FixCommonErrors/FixFilterChip.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixFilterChip.cs
@@ -6,14 +6,21 @@ public partial class FixFilterChip : ObservableObject
 {
     [ObservableProperty] private bool _isActive;
     [ObservableProperty] private int _count;
+    [ObservableProperty] private int _selectedCount;
 
     /// <summary>Action display name this chip filters on - null means "all".</summary>
     public string? Action { get; init; }
     public string Label { get; init; } = string.Empty;
 
-    public string Display => Count > 0 ? $"{Label} ({Count})" : Label;
+    // Show "selected / total" so each tab reflects how many of its fixes are ticked (#12377).
+    public string Display => Count > 0 ? $"{Label} ({SelectedCount}/{Count})" : Label;
 
     partial void OnCountChanged(int value)
+    {
+        OnPropertyChanged(nameof(Display));
+    }
+
+    partial void OnSelectedCountChanged(int value)
     {
         OnPropertyChanged(nameof(Display));
     }


### PR DESCRIPTION
Follow-up to @subcor's feedback on #12377 after the summary-count fix landed. He tested the Linux build with the fix and suggested four refinements to the step 2 selection controls:

- The **Apply selected fixes** button now shows the live count of fixes it will apply, e.g. `Apply selected fixes (706)`. Because it applies every ticked fix across all categories, not just the active tab, showing that global number removes the ambiguity he raised.
- **Select all** is now a **select all / none** toggle, scoped to the active category. The caption reads `Select none` once everything in view is ticked.
- Category tabs now show **selected / total**, e.g. `Fix short gap (12/694)`, so each tab reflects how many of its own fixes are ticked.
- **Invert selection** is removed, since the toggle now covers both select and deselect.

The toggle and the removal of Invert touch the buttons added in #12408, so happy to adjust or drop either part if you would rather keep those as they were. Screenshots below.
