### PR TITLE
Update CrispEmbed to v0.15.0

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -6,6 +6,7 @@ Subtitle Edit Changelog
 v5.1.0-rc2 (TBD)
 
 * Fix common errors: make Apply/Action/Before/After columns sortable in the fix list - thx subcor
+* OCR: update CrispEmbed to v0.15.0 - fixes garbled math-OCR output, faster detection/decoding
 * Update Japanese translation - thx hisui3393
 
 

--- a/src/ui/Logic/Download/CrispEmbedDownloadService.cs
+++ b/src/ui/Logic/Download/CrispEmbedDownloadService.cs
@@ -21,13 +21,13 @@ public class CrispEmbedDownloadService : ICrispEmbedDownloadService
 {
     private readonly HttpClient _httpClient;
 
-    private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.14.0/crispembed-windows-x86_64-cuda.zip";
-    private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.14.0/crispembed-windows-x86_64-vulkan.zip";
-    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.14.0/crispembed-windows-x86_64.zip";
-    private const string MacUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.14.0/crispembed-macos-arm64.tar.gz";
-    private const string LinuxUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.14.0/crispembed-linux-x86_64.tar.gz";
-    private const string LinuxCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.14.0/crispembed-linux-x86_64-cuda.tar.gz";
-    private const string LinuxArmUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.14.0/crispembed-linux-arm64.tar.gz";
+    private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.15.0/crispembed-windows-x86_64-cuda.zip";
+    private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.15.0/crispembed-windows-x86_64-vulkan.zip";
+    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.15.0/crispembed-windows-x86_64.zip";
+    private const string MacUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.15.0/crispembed-macos-arm64.tar.gz";
+    private const string LinuxUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.15.0/crispembed-linux-x86_64.tar.gz";
+    private const string LinuxCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.15.0/crispembed-linux-x86_64-cuda.tar.gz";
+    private const string LinuxArmUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.15.0/crispembed-linux-arm64.tar.gz";
 
     public CrispEmbedDownloadService(HttpClient httpClient)
     {

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -471,31 +471,38 @@ public static class DownloadHashManager
             // otherwise users will be prompted to "update" to the same version they just got.
             [CrispEmbed.WindowsCuda] = new[]
             {
-                "faf376578103b37d7b1d5a385072ff8c66f35cbb7f20a801a6ab0d4e85802cda", // v0.14.0 (current download URL)
+                "98423ef22da5b60420ca74f3b3ef41d152d1181659b06b6f873c369eea8dcdf7", // v0.15.0 (current download URL)
+                "faf376578103b37d7b1d5a385072ff8c66f35cbb7f20a801a6ab0d4e85802cda", // v0.14.0
             },
             [CrispEmbed.WindowsVulkan] = new[]
             {
-                "d1722ae897a0909de877e6d1defeb5cf56041ced923cb058770fc76f9dcc8a37", // v0.14.0 (current download URL)
+                "bae16ce2d475a48d9fb4573a5ed156b2c9ecff6c1565c509461ce5d70f11c6d9", // v0.15.0 (current download URL)
+                "d1722ae897a0909de877e6d1defeb5cf56041ced923cb058770fc76f9dcc8a37", // v0.14.0
             },
             [CrispEmbed.WindowsCpu] = new[]
             {
-                "49ba9a172f918c82648d69a4758841a45e29bb8e2700ffa64e4c94f325d0fec3", // v0.14.0 (current download URL)
+                "90cbe585e202d55c917ce4d14a5b92ca0db459f927ea396203822d94aa149e60", // v0.15.0 (current download URL)
+                "49ba9a172f918c82648d69a4758841a45e29bb8e2700ffa64e4c94f325d0fec3", // v0.14.0
             },
             [CrispEmbed.MacOs] = new[]
             {
-                "2a47142eea71f0120fbf86eda21a0d972618e01c2bf5d67e54204d8e5644411e", // v0.14.0 (current download URL)
+                "369605d468c0433eb3bd6c356d2220eaa49467f7a5970423e6373771cadece9c", // v0.15.0 (current download URL)
+                "2a47142eea71f0120fbf86eda21a0d972618e01c2bf5d67e54204d8e5644411e", // v0.14.0
             },
             [CrispEmbed.Linux] = new[]
             {
-                "e255a59c615fcdf869794c7fabc2f7a4da7babddce5a7ef4771e4fc4a51ff65c", // v0.14.0 (current download URL)
+                "8863cb689d892a7aaa7555306a019b99c863c3669571205db49032c4f8b34450", // v0.15.0 (current download URL)
+                "e255a59c615fcdf869794c7fabc2f7a4da7babddce5a7ef4771e4fc4a51ff65c", // v0.14.0
             },
             [CrispEmbed.LinuxCuda] = new[]
             {
-                "48e2c0e8536c7db717155adb418330e29bb5f7b1c8eda8686fe7513ae6ea58d9", // v0.14.0 (current download URL)
+                "5ce79deb4845c2b04757ee398b5f7ac0ff65bd5435a70da1f18491f3ff8c7c30", // v0.15.0 (current download URL)
+                "48e2c0e8536c7db717155adb418330e29bb5f7b1c8eda8686fe7513ae6ea58d9", // v0.14.0
             },
             [CrispEmbed.LinuxArm] = new[]
             {
-                "3d08ea2cb15da4f1d71dfc3ae030f855d7a5d32a662952b6ea43ff17d3b37788", // v0.14.0 (current download URL)
+                "3a5056e831ddd5af26cc9d623a2c2de7d51d2297bcac67045feb1dac117dece8", // v0.15.0 (current download URL)
+                "3d08ea2cb15da4f1d71dfc3ae030f855d7a5d32a662952b6ea43ff17d3b37788", // v0.14.0
             },
 
             // SHA-256 of crispasr.exe / crispasr extracted from each archive above.


### PR DESCRIPTION
## Summary
- Bump CrispEmbed download URLs from v0.14.0 to [v0.15.0](https://github.com/CrispStrobe/CrispEmbed/releases/tag/v0.15.0) for all seven platform archives
- Add v0.15.0 SHA-256 hashes at index 0 in DownloadHashManager (computed locally from the downloaded release assets - the release publishes no checksum file); v0.14.0 hashes retained so existing installs still validate
- Upstream highlights: fixed garbled math-OCR (TexTeller) output, big detection/decoder performance sweep, new OMR engines

## Test plan
- [x] Build succeeds
- [x] CrispEmbed engine tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)