### PR TITLE
Scroll bar: shift+click on the trough jumps to position (#12051 follow-up)

### DIFF
--- a/src/ui/Logic/DataGridScrollBarBehavior.cs
+++ b/src/ui/Logic/DataGridScrollBarBehavior.cs
@@ -1,13 +1,18 @@
-using Avalonia;
+using System;
+using System.Linq;
+using System.Reflection;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
 
 namespace Nikse.SubtitleEdit.Logic;
 
 /// <summary>
-/// Gives a <see cref="DataGrid"/>'s vertical scroll bar a working page size so that
-/// clicking the scroll bar trough (the channel above or below the thumb) scrolls a full
-/// page, as it does everywhere else and on other platforms (issue #12051).
+/// Gives a <see cref="DataGrid"/>'s vertical scroll bar Windows-standard trough behavior:
+/// a plain trough click scrolls a full page, and shift + trough click jumps the thumb
+/// straight to the click position (issue #12051 and its follow-up).
 ///
 /// Avalonia's DataGrid sets its vertical scroll bar's Maximum and ViewportSize but never
 /// its LargeChange, so it keeps RangeBase's default of 1. A trough click raises a large
@@ -17,10 +22,17 @@ namespace Nikse.SubtitleEdit.Logic;
 /// pages correctly while the subtitle grid and the Shortcuts grid do not. This keeps the
 /// vertical LargeChange in step with the viewport so a page always matches the visible
 /// height.
+///
+/// The DataGrid hooks the scroll bar's Scroll event (not ValueChanged) to refresh its
+/// rows, so a programmatic jump also invokes the grid's internal ProcessVerticalScroll.
 /// </summary>
 internal static class DataGridScrollBarBehavior
 {
     private const string VerticalScrollBarPartName = "PART_VerticalScrollbar";
+
+    private static readonly MethodInfo? ProcessVerticalScrollMethod = typeof(DataGrid).GetMethod(
+        "ProcessVerticalScroll",
+        BindingFlags.NonPublic | BindingFlags.Instance);
 
     public static void EnableTroughPageScroll(DataGrid grid)
     {
@@ -44,7 +56,48 @@ internal static class DataGridScrollBarBehavior
                     SyncLargeChange(verticalScrollBar);
                 }
             };
+
+            // Shift + trough click jumps to the click position, matching the Windows scroll
+            // bar. Tunnel so this runs before the trough repeat button starts paging.
+            verticalScrollBar.AddHandler(
+                InputElement.PointerPressedEvent,
+                (_, args) => JumpToClickPosition(grid, verticalScrollBar, args),
+                RoutingStrategies.Tunnel);
         };
+    }
+
+    private static void JumpToClickPosition(DataGrid grid, ScrollBar verticalScrollBar, PointerPressedEventArgs e)
+    {
+        if ((e.KeyModifiers & KeyModifiers.Shift) == 0 ||
+            !e.GetCurrentPoint(verticalScrollBar).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+
+        var track = verticalScrollBar.GetVisualDescendants().OfType<Track>().FirstOrDefault();
+        if (track == null || track.Bounds.Height <= 0)
+        {
+            return;
+        }
+
+        var range = verticalScrollBar.Maximum - verticalScrollBar.Minimum;
+        if (double.IsNaN(range) || range <= 0)
+        {
+            return;
+        }
+
+        // Center the thumb on the cursor: subtract half the thumb length and scale by the
+        // travel the thumb actually has (track height minus thumb length).
+        var thumbLength = track.Thumb?.Bounds.Height ?? 0;
+        var travel = Math.Max(1, track.Bounds.Height - thumbLength);
+        var offset = e.GetPosition(track).Y - (thumbLength / 2.0);
+        var fraction = Math.Clamp(offset / travel, 0.0, 1.0);
+
+        var newValue = verticalScrollBar.Minimum + (fraction * range);
+        verticalScrollBar.Value = Math.Clamp(newValue, verticalScrollBar.Minimum, verticalScrollBar.Maximum);
+
+        ProcessVerticalScrollMethod?.Invoke(grid, new object[] { ScrollEventType.EndScroll });
+        e.Handled = true;
     }
 
     private static void SyncLargeChange(ScrollBar verticalScrollBar)

--- a/src/ui/Logic/DataGridScrollBarBehavior.cs
+++ b/src/ui/Logic/DataGridScrollBarBehavior.cs
@@ -86,11 +86,30 @@ internal static class DataGridScrollBarBehavior
             return;
         }
 
+        // Only a trough click should jump. Ignore clicks that land outside the track (the line
+        // step arrows) or on the thumb itself (which begins a normal drag); without this guard a
+        // Shift+click on an arrow or the thumb would fling the view to min or max. (#12438 review)
+        var posY = e.GetPosition(track).Y;
+        if (posY < 0 || posY > track.Bounds.Height)
+        {
+            return;
+        }
+
+        var thumb = track.Thumb;
+        if (thumb != null)
+        {
+            var thumbTop = thumb.Bounds.Y;
+            if (posY >= thumbTop && posY <= thumbTop + thumb.Bounds.Height)
+            {
+                return;
+            }
+        }
+
         // Center the thumb on the cursor: subtract half the thumb length and scale by the
         // travel the thumb actually has (track height minus thumb length).
-        var thumbLength = track.Thumb?.Bounds.Height ?? 0;
+        var thumbLength = thumb?.Bounds.Height ?? 0;
         var travel = Math.Max(1, track.Bounds.Height - thumbLength);
-        var offset = e.GetPosition(track).Y - (thumbLength / 2.0);
+        var offset = posY - (thumbLength / 2.0);
         var fraction = Math.Clamp(offset / travel, 0.0, 1.0);
 
         var newValue = verticalScrollBar.Minimum + (fraction * range);


### PR DESCRIPTION
Follow-up to the trough paging fix (#12396) for the scroll bar behavior in #12051.

On Windows a plain click in the scroll bar trough pages, and shift + click jumps the thumb straight to the click position. This adds the shift + click jump to the DataGrid vertical scroll bar, so it now covers both Windows behaviors. It applies to the subtitle grid and the Shortcuts grid, since both share the same helper.

Details:
- Shift + left click in the trough sets the thumb to the click position, centering the thumb on the cursor and clamping to range. Without shift, the existing page behavior is unchanged.
- The DataGrid refreshes its rows off the scroll bar Scroll event rather than ValueChanged, so after setting the value the grid's internal ProcessVerticalScroll is invoked, the same path already used elsewhere for centering a row.

Requested by @GrampaWildWilly on #12051 as the remaining piece for full Windows scroll bar behavior.
