### PR TITLE
Shortcuts window: normal weight for the shortcut name column (#12351)

### DIFF
--- a/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
@@ -263,7 +263,8 @@ public class ShortcutsWindow : Window
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
                     Binding = new Binding(nameof(ShortcutTreeNode.Title)),
                     IsReadOnly = true,
-                    FontWeight = FontWeight.SemiBold,
+                    // Normal weight: semi-bold on every row made the whole list read as bold (#12351).
+                    FontWeight = FontWeight.Normal,
                     Width = new DataGridLength(1, DataGridLengthUnitType.Star),
                 },
                 new DataGridTemplateColumn


### PR DESCRIPTION
On #12351 @GrampaWildWilly noted that in the Shortcuts window every shortcut name is bold, which makes the whole list read as heavy.

The Name column was set to semi-bold on every row. This sets it to normal weight so the list is calmer and easier to read. No other change.

The sortable-columns, sort reset, and column-reordering points from the same comment are left for your call, since they are Shortcuts window design decisions.
