### PR TITLE
Check for updates: do not offer an older version as an update

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -9,6 +9,7 @@ v5.1.0-rc2 (TBD)
 * OCR: update CrispEmbed to v0.15.0 - fixes garbled math-OCR output, faster detection/decoding
 * Update Japanese translation - thx hisui3393
 
+-----------------------------------------------------------------------------------------------------
 
 v5.1.0-rc1 (13th of July 2026)
 

--- a/src/ui/Features/Help/CheckForUpdates/CheckForUpdatesViewModel.cs
+++ b/src/ui/Features/Help/CheckForUpdates/CheckForUpdatesViewModel.cs
@@ -68,19 +68,32 @@ public partial class CheckForUpdatesViewModel : ObservableObject
                 return;
             }
 
-            if (string.Equals(latestVersion, Se.Version, StringComparison.OrdinalIgnoreCase))
-            {
-                StatusText = Se.Language.Help.CheckForUpdatesUpToDate;
-            }
-            else
+            if (IsNewerThanCurrent(latestVersion))
             {
                 StatusText = string.Format(Se.Language.Help.CheckForUpdatesNewVersionAvailable, latestVersion);
                 IsDownloadLinkVisible = true;
+            }
+            else
+            {
+                StatusText = Se.Language.Help.CheckForUpdatesUpToDate;
             }
         }
         catch
         {
             StatusText = Se.Language.Help.CheckForUpdatesUnableToCheck;
+        }
+    }
+
+    internal static bool IsNewerThanCurrent(string latestVersion)
+    {
+        try
+        {
+            return new SemanticVersion(latestVersion).IsGreaterThan(new SemanticVersion(Se.Version));
+        }
+        catch (ArgumentException)
+        {
+            // unparsable version - only offer the download when it differs from what we run
+            return !string.Equals(latestVersion, Se.Version, StringComparison.OrdinalIgnoreCase);
         }
     }
 

--- a/tests/UI/Logic/SemanticVersionTests.cs
+++ b/tests/UI/Logic/SemanticVersionTests.cs
@@ -1,0 +1,30 @@
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+// "Check for updates" must never offer an older build as an update - an rc1 install
+// was being told that beta15 was a new version available.
+public class SemanticVersionTests
+{
+    [Theory]
+    [InlineData("v5.1.0-beta15", "v5.1.0-rc1")] // beta < rc, even with a higher number
+    [InlineData("v5.1.0-alpha2", "v5.1.0-beta1")]
+    [InlineData("v5.1.0-beta2", "v5.1.0-beta10")] // numeric, not alphabetic, ordering
+    [InlineData("v5.1.0-rc1", "v5.1.0")] // any pre-release < final
+    [InlineData("v5.0.9", "v5.1.0-beta1")]
+    [InlineData("v4.0.16", "v5.0.0")]
+    public void IsLessThan(string lower, string higher)
+    {
+        Assert.True(new SemanticVersion(lower).IsLessThan(new SemanticVersion(higher)));
+        Assert.True(new SemanticVersion(higher).IsGreaterThan(new SemanticVersion(lower)));
+    }
+
+    [Theory]
+    [InlineData("v5.1.0-rc1", "5.1.0-rc1")] // the "v" prefix is optional
+    [InlineData("v5.1.0", "v5.1.0")]
+    public void IsEqualTo(string a, string b)
+    {
+        Assert.True(new SemanticVersion(a).IsEqualTo(new SemanticVersion(b)));
+        Assert.False(new SemanticVersion(a).IsGreaterThan(new SemanticVersion(b)));
+    }
+}


### PR DESCRIPTION
A `v5.1.0-rc1` install was told that `v5.1.0-beta15` was a new version available. Two bugs combined to cause this.

### 1. Missing separator in `change-log.txt`

Release blocks are delimited by a `----` line, but the one between the `v5.1.0-rc2 (TBD)` draft and `v5.1.0-rc1` was missing, so both releases formed a single block. `ParseLatestChangeLog` skips blocks containing `TBD` (unreleased drafts) — because rc1 was glued to the rc2 draft, rc1 was skipped along with it and the next block down, beta15, became "the latest release".

### 2. The update check never actually compared versions

`CheckForUpdatesViewModel` used `string.Equals(latestVersion, Se.Version)` and treated *any* difference as an upgrade, so an older build was happily advertised as new. It now uses the existing `SemanticVersion` class and only offers the download when the changelog version is strictly greater than the running one, falling back to the old string comparison if either version fails to parse.

This also makes the check resilient to the same class of changelog mistake in future: if a released block is ever swallowed by a draft again, the worst outcome is a benign "you have the latest version" instead of a phantom downgrade.

### Verification

- Replayed the real parser against the fixed changelog: it now resolves `v5.1.0-rc1` and shows rc1's notes (previously beta15's). That equals `Se.Version`, so the dialog reports up-to-date.
- Added `tests/UI/Logic/SemanticVersionTests.cs` pinning the ordering that matters here (`beta15 < rc1`, `beta2 < beta10`, any pre-release `<` final) — 8 tests pass, UI project builds clean.

Note: the changelog fix helps existing rc1 users as soon as it lands on `main`, since the app fetches the raw file from there — no new build required. The `IsNewerThanCurrent` fix ships with the next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)