### PR TITLE
seconv: warn about unknown --settings keys, allow bare --apply-min-gap

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -5,6 +5,8 @@ Subtitle Edit Changelog
 
 v5.1.0-rc2 (TBD)
 
+* seconv: warn about unknown keys in the --settings JSON instead of silently ignoring them - thx shanecoopt
+* seconv: --apply-min-gap can now be used without a value, taking the gap from minimumMillisecondsBetweenLines - thx shanecoopt
 * Fix common errors: make Apply/Action/Before/After columns sortable in the fix list - thx subcor
 * OCR: update CrispEmbed to v0.15.0 - fixes garbled math-OCR output, faster detection/decoding
 * Update Japanese translation - thx hisui3393

--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -396,6 +396,8 @@ Available template tokens: `{title}`, `{number}`, `{start}`, `{end}`, `{duration
 
 The `exportImages` section styles text → image rendering (see [Image output styling](#image-output-styling) for the semantics); the equivalent CLI flags override it. The `general` section mirrors `Configuration.Settings.General`; any key left out keeps the libse default. The profile-shaping values (`minimumMillisecondsBetweenLines`, `maxNumberOfLines`, `mergeLinesShorterThan`, `subtitleMaximumCharactersPerSeconds`, `subtitleOptimalCharactersPerSeconds`, `subtitleMaximumWordsPerMinute`, `dialogStyle`, `continuationStyle`) feed Fix common errors and the split/merge operations, so set them to reproduce an SE4 profile. `dialogStyle` and `continuationStyle` take the enum names (case-insensitive): `dialogStyle` ∈ `DashBothLinesWithSpace`, `DashBothLinesWithoutSpace`, `DashSecondLineWithSpace`, `DashSecondLineWithoutSpace`; `continuationStyle` ∈ `None`, `NoneTrailingDots`, `NoneTrailingEllipsis`, `OnlyTrailingDots`, `LeadingTrailingDots`, `LeadingTrailingEllipsis`, `LeadingTrailingDash`, … (see the Fix common errors continuation styles).
 
+Keys that seconv does not recognize are ignored, so a settings file written for a newer version still applies everything this one understands — but they are listed in a warning, so a typo (or a key your seconv is too old to know) does not silently give you default output.
+
 ```bash
 seconv *.srt subrip --settings:my.json --profile:broadcast --remove-text-for-hi
 ```
@@ -415,7 +417,7 @@ Operations run after the structural transforms (offset, fps, renumber, adjust-du
 | Option | Description |
 |---|---|
 | `--apply-duration-limits` | Apply duration limits |
-| `--apply-min-gap:<ms>` | Enforce minimum gap of N ms between paragraphs |
+| `--apply-min-gap[:<ms>]` | Enforce a minimum gap between paragraphs. Without a value, uses `minimumMillisecondsBetweenLines` from `--settings` (libse default: 24 ms) |
 | `--balance-lines` | Balance line lengths |
 | `--beautify-time-codes` | Beautify time codes |
 | `--bridge-gaps:<ms>` | Bridge gaps shorter than N ms (extends previous end time) |

--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -1,7 +1,9 @@
+using Nikse.SubtitleEdit.Core.Common;
 using Spectre.Console;
 using Spectre.Console.Cli;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using SeConv.Core;
 
 namespace SeConv.Commands;
@@ -277,9 +279,11 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         [Description("Apply duration limits")]
         public bool ApplyDurationLimits { get; init; }
 
-        [CommandOption("--apply-min-gap|--ApplyMinGap")]
-        [Description("Enforce a minimum gap of N ms between paragraphs")]
-        public int? ApplyMinGap { get; init; }
+        // Optional value: bare --apply-min-gap uses minimumMillisecondsBetweenLines from
+        // --settings (or the libse default), matching what the UI does (issue #12437).
+        [CommandOption("--apply-min-gap|--ApplyMinGap [MS]")]
+        [Description("Enforce a minimum gap between paragraphs; omit the value to use minimumMillisecondsBetweenLines")]
+        public FlagValue<string>? ApplyMinGap { get; init; }
 
         [CommandOption("--bridge-gaps|--BridgeGaps")]
         [Description("Bridge gaps shorter than N ms by extending the previous end time")]
@@ -455,6 +459,17 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                     var seConvSettings = SeConvSettings.Load(settings.SettingsPath);
                     seConvSettings.ApplyToLibSe(settings.Profile);
                     seConvSettings.ApplyExportImages(imageStyle, settings.Profile);
+
+                    // Unknown keys are ignored by the JSON reader, which used to mean a typo - or a
+                    // key from a newer seconv - silently produced default output (issue #12437).
+                    var unknownKeys = seConvSettings.GetUnknownKeys().ToList();
+                    if (unknownKeys.Count > 0 && !silent)
+                    {
+                        AnsiConsole.MarkupLineInterpolated(
+                            $"[yellow]Warning: ignoring unknown key(s) in --settings file: {string.Join(", ", unknownKeys)}[/]");
+                        AnsiConsole.MarkupLine(
+                            "[yellow]Check for typos, or update seconv if the key was added in a newer version.[/]");
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -468,12 +483,19 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 return 1;
             }
 
-            // Image styling flags override the settings JSON. Unlike the JSON (which
-            // tolerates typos), a bad flag value fails fast so the user notices.
+            // Image styling flags override the settings JSON. Unlike the JSON (which only warns
+            // about unknown keys), a bad flag value fails fast so the user notices.
             var imageStyleError = ApplyImageStyleFlags(settings, imageStyle);
             if (imageStyleError != null)
             {
                 AnsiConsole.MarkupLineInterpolated($"[red]Error: {imageStyleError}[/]");
+                return 1;
+            }
+
+            // Must run after the --settings JSON is applied: a bare --apply-min-gap takes its
+            // value from libse's (possibly overridden) MinimumMillisecondsBetweenLines.
+            if (!TryResolveApplyMinGap(settings, silent, out var applyMinGapMs))
+            {
                 return 1;
             }
 
@@ -605,7 +627,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 AdjustDurationMs = settings.AdjustDuration,
                 ChangeSpeedPercent = settings.ChangeSpeed,
                 BridgeGapsMaxMs = settings.BridgeGaps,
-                ApplyMinGapMs = settings.ApplyMinGap,
+                ApplyMinGapMs = applyMinGapMs,
                 Resolution = resolution,
                 ImageStyle = imageStyle,
                 AssaStyleFile = settings.AssaStyleFile,
@@ -786,6 +808,50 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
             errors = result.Errors,
         };
         Console.WriteLine(System.Text.Json.JsonSerializer.Serialize(payload, JsonOptions));
+    }
+
+    /// <summary>
+    /// Resolves --apply-min-gap into the gap to enforce, in ms (null = the operation is off).
+    /// A bare --apply-min-gap uses libse's MinimumMillisecondsBetweenLines, so it follows the
+    /// --settings JSON. Returns false when the value is unusable, after printing the error.
+    /// </summary>
+    private static bool TryResolveApplyMinGap(Settings settings, bool silent, out int? gapMs)
+    {
+        gapMs = null;
+        if (settings.ApplyMinGap?.IsSet != true)
+        {
+            return true;
+        }
+
+        // FlagValue only carries the raw text, so "no value given" stays distinguishable from ":0".
+        var raw = settings.ApplyMinGap.Value;
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            gapMs = Configuration.Settings.General.MinimumMillisecondsBetweenLines;
+            return true;
+        }
+
+        if (!int.TryParse(raw.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var ms))
+        {
+            AnsiConsole.MarkupLineInterpolated(
+                $"[red]Error: --apply-min-gap expects a value in milliseconds, got '{raw}'.[/]");
+            return false;
+        }
+
+        if (ms <= 0)
+        {
+            // Enforcing a gap of zero is a no-op. Saying so beats silently doing nothing.
+            if (!silent)
+            {
+                AnsiConsole.MarkupLineInterpolated(
+                    $"[yellow]Warning: --apply-min-gap:{ms} enforces no gap and does nothing. Omit the value to use minimumMillisecondsBetweenLines.[/]");
+            }
+
+            return true;
+        }
+
+        gapMs = ms;
+        return true;
     }
 
     /// <summary>

--- a/src/seconv/Core/SeConvSettings.cs
+++ b/src/seconv/Core/SeConvSettings.cs
@@ -27,6 +27,9 @@ internal sealed class SeConvSettings
     [JsonPropertyName("profiles")]
     public Dictionary<string, SeConvSettings>? Profiles { get; set; }
 
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? UnknownMembers { get; set; }
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -45,6 +48,63 @@ internal sealed class SeConvSettings
         var json = File.ReadAllText(path);
         return JsonSerializer.Deserialize<SeConvSettings>(json, JsonOptions)
             ?? throw new InvalidDataException($"Settings file is empty or null: {path}");
+    }
+
+    /// <summary>
+    /// Keys in the JSON that match no known section or property - typos, or keys from a newer
+    /// seconv than the one running (issue #12437). System.Text.Json drops these silently, so a
+    /// settings file that does nothing looks exactly like one that works. Callers report these
+    /// as a warning rather than an error, so a file written for a newer seconv still applies
+    /// everything else it understands.
+    /// </summary>
+    public IEnumerable<string> GetUnknownKeys() => CollectUnknownKeys(string.Empty);
+
+    private IEnumerable<string> CollectUnknownKeys(string prefix)
+    {
+        foreach (var key in Prefixed(UnknownMembers, prefix))
+        {
+            yield return key;
+        }
+
+        foreach (var key in Prefixed(General?.UnknownMembers, prefix + "general."))
+        {
+            yield return key;
+        }
+
+        foreach (var key in Prefixed(Tools?.UnknownMembers, prefix + "tools."))
+        {
+            yield return key;
+        }
+
+        foreach (var key in Prefixed(RemoveTextForHearingImpaired?.UnknownMembers, prefix + "removeTextForHearingImpaired."))
+        {
+            yield return key;
+        }
+
+        foreach (var key in Prefixed(ExportImages?.UnknownMembers, prefix + "exportImages."))
+        {
+            yield return key;
+        }
+
+        if (Profiles is null)
+        {
+            yield break;
+        }
+
+        foreach (var (name, profile) in Profiles)
+        {
+            foreach (var key in profile.CollectUnknownKeys($"{prefix}profiles.{name}."))
+            {
+                yield return key;
+            }
+        }
+    }
+
+    private static IEnumerable<string> Prefixed(Dictionary<string, JsonElement>? unknown, string prefix)
+    {
+        return unknown is null
+            ? Enumerable.Empty<string>()
+            : unknown.Keys.Select(key => prefix + key);
     }
 
     /// <summary>
@@ -179,12 +239,18 @@ internal sealed class SeConvSettings
         // ContinuationStyle: ContinuationStyle, e.g. "NoneTrailingDots".
         public string? DialogStyle { get; set; }
         public string? ContinuationStyle { get; set; }
+
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement>? UnknownMembers { get; set; }
     }
 
     internal sealed class ToolsSection
     {
         public int? MergeShortLinesMaxGap { get; set; }
         public bool? MergeShortLinesOnlyContinuous { get; set; }
+
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement>? UnknownMembers { get; set; }
     }
 
     /// <summary>
@@ -216,6 +282,9 @@ internal sealed class SeConvSettings
         public string? ContentAlignment { get; set; }
         public int? BottomTopMargin { get; set; }
         public int? LeftRightMargin { get; set; }
+
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement>? UnknownMembers { get; set; }
 
         public void ApplyTo(ImageExportStyle style)
         {
@@ -281,5 +350,8 @@ internal sealed class SeConvSettings
         public bool? RemoveIfAllUppercase { get; set; }
         public string? RemoveIfContainsText { get; set; }
         public bool? RemoveIfOnlyMusicSymbols { get; set; }
+
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement>? UnknownMembers { get; set; }
     }
 }

--- a/src/seconv/Helpers/HelpDisplay.cs
+++ b/src/seconv/Helpers/HelpDisplay.cs
@@ -65,7 +65,7 @@ internal static class HelpDisplay
         AnsiConsole.WriteLine();
         
         ShowParameter("--apply-duration-limits", "Apply duration limits");
-        ShowParameter("--apply-min-gap:<ms>", "Enforce minimum gap of N ms between paragraphs");
+        ShowParameter("--apply-min-gap[:<ms>]", "Enforce minimum gap between paragraphs (default: minimumMillisecondsBetweenLines)");
         ShowParameter("--balance-lines", "Balance line lengths");
         ShowParameter("--bridge-gaps:<ms>", "Bridge gaps shorter than N ms (extends previous end time)");
         ShowParameter("--beautify-time-codes", "Beautify time codes");

--- a/tests/seconv/Core/SeConvSettingsTest.cs
+++ b/tests/seconv/Core/SeConvSettingsTest.cs
@@ -286,4 +286,51 @@ public class SeConvSettingsTest : IDisposable
 
         Assert.Equal(25.0, s.General!.CurrentFrameRate);
     }
+
+    // Unknown keys stay ignored (a file written for a newer seconv must still apply what this
+    // one understands), but they have to be reportable - silently dropping them made a typo
+    // look identical to a working settings file (issue #12437).
+    [Fact]
+    public void GetUnknownKeys_ReportsTyposAndUnknownSections()
+    {
+        var path = WriteSettings("""
+            {
+              "general": {
+                "minimumMsBetweenLines": 96,
+                "subtitleLineMaximumLength": 50
+              },
+              "bogusSection": { "x": 1 },
+              "profiles": {
+                "netflix": { "general": { "alsoWrong": 1 } }
+              }
+            }
+            """);
+
+        var s = SeConvSettings.Load(path);
+        var unknown = s.GetUnknownKeys().ToList();
+
+        Assert.Contains("general.minimumMsBetweenLines", unknown);
+        Assert.Contains("bogusSection", unknown);
+        Assert.Contains("profiles.netflix.general.alsoWrong", unknown);
+        Assert.Equal(3, unknown.Count);
+
+        // the known key alongside the typo is still applied
+        Assert.Equal(50, s.General!.SubtitleLineMaximumLength);
+    }
+
+    [Fact]
+    public void GetUnknownKeys_EmptyForAValidFile()
+    {
+        var path = WriteSettings("""
+            {
+              "general": { "minimumMillisecondsBetweenLines": 12 },
+              "tools": { "mergeShortLinesMaxGap": 250 }
+            }
+            """);
+
+        var s = SeConvSettings.Load(path);
+
+        Assert.Empty(s.GetUnknownKeys());
+        Assert.Equal(12, s.General!.MinimumMillisecondsBetweenLines);
+    }
 }


### PR DESCRIPTION
Fixes #12437.

### What happened

The reporter set `minimumMillisecondsBetweenLines` in a `--settings` JSON and always got 24 ms — the libse default — no matter what value they used.

That key is only understood since **v5.1.0-beta1** (`afb0254fe`, #11874); in **v5.0.0** `GeneralSection` had just five fields. `System.Text.Json` drops unmapped members silently, so on 5.0.0 the key was discarded without a word and `BridgeGaps` fell back to the default. Their `settings.json` is correct — it just isn't understood by the binary they're running. The current `main` handles it fine (verified: `0` → 1 ms, `12` → 12 ms, `96` → 96 ms; no `--settings` → 24 ms, exactly what they saw).

So there's no timing bug to fix — but there was **no way for them to find that out**, and that is worth fixing.

### 1. Unknown `--settings` keys are now reported

Unknown keys are still *ignored* (a settings file written for a newer seconv should keep working with an older one), but they're collected via `JsonExtensionData` and listed:

```
Warning: ignoring unknown key(s) in --settings file: bogusSection, general.minimumMsBetweenLines
Check for typos, or update seconv if the key was added in a newer version.
```

Nested profiles are covered too (`profiles.netflix.general.alsoWrong`). Suppressed under `--quiet` / `--json`.

### 2. `--apply-min-gap` takes an optional value

It reads like a flag, but it required the gap in ms — so the reporter's `--apply-min-gap:0` hit the `minMs <= 0` guard and did nothing at all, silently. Now:

| form | behavior |
|---|---|
| `--apply-min-gap` | uses `minimumMillisecondsBetweenLines` (follows `--settings`, like the UI) |
| `--apply-min-gap:250` | enforces 250 ms |
| `--apply-min-gap:0` | warns that it enforces no gap and does nothing |
| `--apply-min-gap:abc` | error |

### Verification

Exercised the built CLI end-to-end for each row above (bare flag with `minimumMillisecondsBetweenLines: 96` → gap 96 ms; with no `--settings` → 24 ms; explicit `:250` → 250 ms; no flag → untouched), plus the unknown-key warning. Full seconv suite passes: 219 tests, including two new ones for `GetUnknownKeys`.

Docs and `--help` updated; changelog entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)