### PR TITLE
Serve self-supplied .gguf models with the right chat template

### DIFF
--- a/docs/features/auto-translate.md
+++ b/docs/features/auto-translate.md
@@ -28,7 +28,7 @@ Automatically translate subtitles using various translation engines and AI servi
 - **ChatGPT** — OpenAI AI translation (requires API key)
 - **LM Studio (local LLM)** — Local LLM translation
 - **Ollama (local LLM)** — Local LLM-based translation
-- **llama.cpp (local LLM)** — Server-managed local LLM translation; Subtitle Edit downloads llama.cpp and a curated TranslateGemma model and runs a local `llama-server` for you
+- **llama.cpp (local LLM)** — Server-managed local LLM translation; Subtitle Edit downloads llama.cpp and a curated model (TranslateGemma, Qwen or Aya Expanse) and runs a local `llama-server` for you. See [Using your own model](#llamacpp-using-your-own-model) to run a model we don't ship, such as TranslateGemma 27B
 - **OpenAI Compatible API** — Generic engine for any service exposing an OpenAI-compatible `chat/completions` endpoint (vLLM, KoboldCpp, a llama.cpp server on another machine, cloud providers, ...); configure URL, model, prompt, and an optional API key
 - **Anthropic Claude** — AI translation (requires API key)
 - **Groq** — AI translation (requires API key)
@@ -44,6 +44,27 @@ Automatically translate subtitles using various translation engines and AI servi
 - **winstxnhdw-nllb-api** — NLLB (No Language Left Behind) API
 - **Baidu Translate** — Baidu translation (requires App ID and secret)
 - **CrispASR MADLAD** — Local MADLAD-based translation with downloadable models (shown with size and install status); also available in Batch Convert
+
+## llama.cpp: using your own model
+
+The models offered in the download list are deliberately kept small enough to run on an ordinary
+machine (around 8 GB or less). You are not limited to them — larger models such as TranslateGemma
+27B work fine if your hardware can handle them.
+
+Two ways to use one:
+
+1. **Drop a `.gguf` into the models folder.** Copy the file into Subtitle Edit's `llama.cpp/models`
+   folder and it appears in the model list marked *(custom)*. Subtitle Edit recognizes the model
+   family from the file name and starts `llama-server` with the right chat template, so a
+   self-downloaded TranslateGemma or Qwen quant behaves like the curated ones.
+2. **Run your own server.** Tick **Use remote server** and point Subtitle Edit at any
+   `llama-server` you started yourself (the default is `http://localhost:8080/v1/chat/completions`).
+   Subtitle Edit then does no model management at all.
+
+Be aware of what a bigger model costs. TranslateGemma 27B at Q4_K_M is roughly a 16 GB download and
+needs about 20 GB of VRAM to run fully on the GPU — a 24 GB card in practice. Google's own figures
+put the 12B ahead of the Gemma 3 27B baseline, so the 12B in the download list is already a strong
+choice and the jump to 27B buys less than the size difference suggests.
 
 ## Engine Configuration
 

--- a/src/libse/AutoTranslate/LlamaCppTranslate.cs
+++ b/src/libse/AutoTranslate/LlamaCppTranslate.cs
@@ -45,20 +45,16 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
 
         public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
         {
-            var model = string.Empty;
-            var modelJson = string.Empty;
-            if (!string.IsNullOrEmpty(model))
-            {
-                modelJson = "\"model\": \"" + model + "\",";
-                Configuration.Settings.Tools.LmStudioModel = model;
-            }
-
             if (string.IsNullOrWhiteSpace(Configuration.Settings.Tools.LlamaCppPrompt))
             {
                 Configuration.Settings.Tools.LlamaCppPrompt = new ToolsSettings().LlamaCppPrompt;
             }
             var prompt = string.Format(Configuration.Settings.Tools.LlamaCppPrompt, sourceLanguageCode, targetLanguageCode);
-            var input = "{ " + modelJson + " \"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
+
+            // No "model" field: llama-server serves the single model it was started with, and for a
+            // remote server the user's own llama-server does the same. Sending one would only risk a
+            // mismatch with whatever that server has loaded.
+            var input = "{ \"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);

--- a/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
+++ b/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
@@ -232,11 +232,45 @@ public static class LlamaCppServerManager
     }
 
     /// <summary>
+    /// Picks the llama-server chat-template flags for a <c>.gguf</c> we do not curate (a file the user
+    /// downloaded themselves, e.g. a TranslateGemma quant or size we do not offer). A curated entry with
+    /// the same file name wins; otherwise the family is guessed from the file name, because getting this
+    /// wrong is not cosmetic: every Gemma we ship needs <c>gemma</c> + <c>--no-jinja</c> (TranslateGemma's
+    /// embedded Jinja template is non-standard) and every Qwen needs <c>chatml</c> + <c>--no-jinja</c> (to
+    /// bypass the embedded template's thinking mode, which otherwise emits &lt;think&gt; blocks instead of a
+    /// translation). Families with a usable embedded template (Aya, Llama, EuroLLM, Phi) fall through to
+    /// the default of no override.
+    /// </summary>
+    public static (string? ChatTemplate, bool NoJinja) InferChatTemplate(string fileName)
+    {
+        var curated = TranslateModels.Concat(ReviewModels).Concat(OcrModels)
+            .FirstOrDefault(m => m.FileName.Equals(fileName, StringComparison.OrdinalIgnoreCase));
+        if (curated != null)
+        {
+            return (curated.ChatTemplate, curated.NoJinja);
+        }
+
+        // Matches "translategemma-27b-it.Q4_K_M.gguf", "google_gemma-3-27b-it-Q4_K_M.gguf", etc.
+        if (fileName.Contains("gemma", StringComparison.OrdinalIgnoreCase))
+        {
+            return ("gemma", true);
+        }
+
+        if (fileName.Contains("qwen", StringComparison.OrdinalIgnoreCase))
+        {
+            return ("chatml", true);
+        }
+
+        return (null, false);
+    }
+
+    /// <summary>
     /// Returns the curated <see cref="TranslateModels"/> plus any other <c>*.gguf</c> the user has
     /// dropped into the llama.cpp models folder. Custom entries are emitted with an empty <c>Url</c>
-    /// (no download needed - already on disk), the file name as <c>DisplayName</c>, and a
-    /// human-readable file size. <c>mmproj-*.gguf</c> sidecars are skipped because they're not
-    /// standalone translation models.
+    /// (no download needed - already on disk), the file name as <c>DisplayName</c>, a
+    /// human-readable file size, and chat-template flags from <see cref="InferChatTemplate"/> so a
+    /// self-supplied TranslateGemma/Qwen quant is served with the same flags as the curated ones.
+    /// <c>mmproj-*.gguf</c> sidecars are skipped because they're not standalone translation models.
     /// </summary>
     public static IReadOnlyList<LlamaCppModel> GetAllTranslateModels()
     {
@@ -284,7 +318,9 @@ public static class LlamaCppServerManager
                 }
 
                 var size = FormatFileSize(new FileInfo(path).Length);
-                custom.Add(new LlamaCppModel(name, name, size, Url: string.Empty));
+                var (chatTemplate, noJinja) = InferChatTemplate(name);
+                custom.Add(new LlamaCppModel(name, name, size, Url: string.Empty,
+                    ChatTemplate: chatTemplate, NoJinja: noJinja));
             }
         }
         catch

--- a/src/seconv/Core/AutoTranslateRunner.cs
+++ b/src/seconv/Core/AutoTranslateRunner.cs
@@ -229,14 +229,12 @@ internal sealed class AutoTranslateRunner
 
     private static LlamaCppModel ResolveLlamaCppModel(string? requestedModel)
     {
-        var curated = LlamaCppServerManager.TranslateModels;
-
         if (!string.IsNullOrWhiteSpace(requestedModel))
         {
             var name = requestedModel.Trim();
 
-            // Full path to a .gguf: use it directly, but inherit chat-template flags from the
-            // curated entry when the file name matches one (TranslateGemma/Qwen need them).
+            // Full path to a .gguf: use it directly, but infer the chat-template flags from the file
+            // name (TranslateGemma/Qwen need them, whether or not we curate that exact quant).
             if (Path.IsPathRooted(name) || name.Contains(Path.DirectorySeparatorChar) || name.Contains(Path.AltDirectorySeparatorChar))
             {
                 if (!File.Exists(name))
@@ -245,9 +243,9 @@ internal sealed class AutoTranslateRunner
                 }
 
                 var fileName = Path.GetFileName(name);
-                var template = curated.FirstOrDefault(m => m.FileName.Equals(fileName, StringComparison.OrdinalIgnoreCase));
+                var (chatTemplate, noJinja) = LlamaCppServerManager.InferChatTemplate(fileName);
                 return new LlamaCppModel(fileName, Path.GetFullPath(name), string.Empty, Url: string.Empty,
-                    ChatTemplate: template?.ChatTemplate, NoJinja: template?.NoJinja ?? false);
+                    ChatTemplate: chatTemplate, NoJinja: noJinja);
             }
 
             // Name: match curated + custom models in the models folder (with or without .gguf).

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -1052,7 +1052,7 @@ public partial class OcrViewModel : ObservableObject
     private async Task PickOllamaModel()
     {
         var result = await _windowService.ShowDialogAsync<PickOllamaModelWindow, PickOllamaModelViewModel>(Window!,
-            vm => { vm.Initialize(Se.Language.General.PickOllamaModel, OllamaModel, OllamaUrl); });
+            vm => { vm.Initialize(Se.Language.General.PickOllamaModel, OllamaModel, OllamaUrl, visionOnly: true); });
 
         _isCtrlDown = false;
 

--- a/src/ui/Features/Ocr/PickOllamaModelViewModel.cs
+++ b/src/ui/Features/Ocr/PickOllamaModelViewModel.cs
@@ -21,6 +21,7 @@ public partial class PickOllamaModelViewModel : ObservableObject
     [ObservableProperty] private string? _selectedModel;
     [ObservableProperty] private string _title;
     [ObservableProperty] private bool _showAllModels;
+    [ObservableProperty] private bool _showAllModelsVisible;
     private string? _oldModel;
 
     // Full list returned by /api/tags plus a per-model flag for vision capability.
@@ -58,11 +59,19 @@ public partial class PickOllamaModelViewModel : ObservableObject
         Title = string.Empty;
     }
 
-    public void Initialize(string title, string? selectedModel, string url)
+    /// <summary>
+    /// Populates the picker from the Ollama server's model list. <paramref name="visionOnly"/> is for the
+    /// OCR callers, which can only use vision-capable models; text callers (auto-translate, AI review, AI
+    /// assistant) pass false and see every installed model - filtering those to vision models would hide
+    /// exactly the ones they want.
+    /// </summary>
+    public void Initialize(string title, string? selectedModel, string url, bool visionOnly = false)
     {
         Title = title;
         Models.Clear();
         _oldModel = selectedModel;
+        ShowAllModelsVisible = visionOnly;
+        ShowAllModels = !visionOnly;
         _ = Task.Run(async () =>
         {
             var fetched = await GetModelsWithCapabilitiesAsync(url);

--- a/src/ui/Features/Ocr/PickOllamaModelWindow.cs
+++ b/src/ui/Features/Ocr/PickOllamaModelWindow.cs
@@ -53,7 +53,10 @@ public class PickOllamaModelWindow : Window
             Height = double.NaN,
         };
 
+        // Only the OCR callers filter to vision-capable models, so only they get the "show all" escape
+        // hatch; for the text callers the list is unfiltered already and the checkbox would be a no-op.
         var checkBoxShowAll = UiUtil.MakeCheckBox(Se.Language.Ocr.ShowAllOllamaModels, vm, nameof(vm.ShowAllModels));
+        checkBoxShowAll.Bind(IsVisibleProperty, new Binding(nameof(vm.ShowAllModelsVisible)));
 
         grid.Add(listBox, 0);
         grid.Add(checkBoxShowAll, 1);

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
@@ -403,7 +403,7 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
     private async Task PickOllamaModel()
     {
         var result = await _windowService.ShowDialogAsync<PickOllamaModelWindow, PickOllamaModelViewModel>(Window!,
-            vm => { vm.Initialize(Se.Language.General.PickOllamaModel, SelectedOllamaModel, Se.Settings.Ocr.OllamaUrl); });
+            vm => { vm.Initialize(Se.Language.General.PickOllamaModel, SelectedOllamaModel, Se.Settings.Ocr.OllamaUrl, visionOnly: true); });
 
         if (result is { OkPressed: true, SelectedModel: not null })
         {

--- a/tests/seconv/Core/AutoTranslateRunnerTest.cs
+++ b/tests/seconv/Core/AutoTranslateRunnerTest.cs
@@ -135,6 +135,9 @@ public class AutoTranslateRunnerTest : IDisposable
 
         Assert.NotNull(runner.LlamaCppModel);
         Assert.Equal("my-own-model.gguf", runner.LlamaCppModel!.FileName);
+        // Unknown family: leave the embedded template alone.
+        Assert.Null(runner.LlamaCppModel.ChatTemplate);
+        Assert.False(runner.LlamaCppModel.NoJinja);
     }
 
     [Fact]
@@ -153,6 +156,55 @@ public class AutoTranslateRunnerTest : IDisposable
         Assert.Equal(path, runner.LlamaCppModel!.FileName);
         Assert.Equal("chatml", runner.LlamaCppModel.ChatTemplate);
         Assert.True(runner.LlamaCppModel.NoJinja);
+    }
+
+    // A TranslateGemma size/quant we do not curate (issue #12440 asked for the 27B). Whether it is
+    // dropped into the models folder or passed as a full path, it still needs gemma + --no-jinja:
+    // TranslateGemma's embedded Jinja template is non-standard, so serving it unflagged is broken.
+    [Fact]
+    public void Create_LlamaCppLocal_UncuratedTranslateGemmaByName_GetsGemmaTemplate()
+    {
+        PlantFakeInstall("translategemma-27b-it.Q4_K_M.gguf");
+
+        var runner = AutoTranslateRunner.Create(MakeOptions(model: "translategemma-27b-it.Q4_K_M"));
+
+        Assert.NotNull(runner.LlamaCppModel);
+        Assert.Equal("translategemma-27b-it.Q4_K_M.gguf", runner.LlamaCppModel!.FileName);
+        Assert.Equal("gemma", runner.LlamaCppModel.ChatTemplate);
+        Assert.True(runner.LlamaCppModel.NoJinja);
+    }
+
+    [Fact]
+    public void Create_LlamaCppLocal_UncuratedTranslateGemmaByFullPath_GetsGemmaTemplate()
+    {
+        PlantFakeInstall();
+        var path = Path.Combine(_fakeLlamaFolder, "models", "translategemma-27b-it.Q5_K_M.gguf");
+        using (var fs = File.Create(path))
+        {
+            fs.SetLength(11_000_000);
+        }
+
+        var runner = AutoTranslateRunner.Create(MakeOptions(model: path));
+
+        Assert.NotNull(runner.LlamaCppModel);
+        Assert.Equal("gemma", runner.LlamaCppModel!.ChatTemplate);
+        Assert.True(runner.LlamaCppModel.NoJinja);
+    }
+
+    [Theory]
+    [InlineData("translategemma-4b_Q5_K_M.gguf", "gemma", true)]   // curated: exact match
+    [InlineData("translategemma-27b-it.Q4_K_M.gguf", "gemma", true)] // uncurated: inferred
+    [InlineData("google_gemma-3-27b-it-Q4_K_M.gguf", "gemma", true)]
+    [InlineData("Qwen_Qwen3.5-32B-Q4_K_M.gguf", "chatml", true)]
+    [InlineData("aya-expanse-8b-Q4_K_M.gguf", null, false)]        // curated: embedded template
+    [InlineData("Meta-Llama-3.1-70B-Instruct-Q4_K_M.gguf", null, false)]
+    [InlineData("some-unknown-model.gguf", null, false)]
+    public void InferChatTemplate_PicksFlagsByFamily(string fileName, string? expectedTemplate, bool expectedNoJinja)
+    {
+        var (chatTemplate, noJinja) = LlamaCppServerManager.InferChatTemplate(fileName);
+
+        Assert.Equal(expectedTemplate, chatTemplate);
+        Assert.Equal(expectedNoJinja, noJinja);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #12440.

## The ask, and the answer

[#12440](https://github.com/SubtitleEdit/subtitleedit/issues/12440) asked for TranslateGemma **27B** in the llama.cpp engine. I don't think we should curate it, but chasing it down turned up a real bug that hits anyone trying to use a model we *don't* ship.

**Why not curate the 27B:** the curated lists deliberately stay at or under ~8 GB. TranslateGemma 27B is **16.6 GB** at Q4_K_M and needs ~20 GB of VRAM to run fully on the GPU (we pass `-ngl 99`), so realistically a 24 GB card. And Google's own figures put the **12B ahead of the Gemma 3 27B baseline** — the 12B we already ship is strong, and the jump to 27B buys less than the size difference suggests. Putting it in the download list would look supported and behave like a trap for most users.

For reference, the actual GGUF sizes:

| Quant | 4B | 12B | 27B |
|---|---|---|---|
| Q4_K_M | 2.5 GB | 7.3 GB | **16.6 GB** |
| Q5_K_M | 2.8 GB | 8.5 GB | 19.3 GB |
| Q8_0 | 4.1 GB | 12.5 GB | 28.7 GB |

## The bug

A `.gguf` dropped into the llama.cpp models folder was served with **no** `--chat-template` / `--no-jinja` flags. Those flags aren't cosmetic — every curated TranslateGemma sets them precisely because its embedded Jinja template is non-standard, and every Qwen sets them so the model emits a translation rather than `<think>` blocks. So a self-downloaded TranslateGemma 27B (or any quant we don't curate) showed up in the dropdown and quietly ran broken. That's exactly the path a user reaching for the 27B takes.

## Changes

- **`LlamaCppServerManager.InferChatTemplate`** — a curated entry with the same file name wins; otherwise the family is inferred from the file name (`gemma` → `gemma` + `--no-jinja`, `qwen` → `chatml` + `--no-jinja`, everything else keeps its embedded template).
- Used by **both** callers: the models-folder scan (the GUI path, which dropped the flags entirely) and seconv's `--translate-model` full-path branch, which only inherited them on an *exact* curated file-name match — so a 27B missed out there too.
- **`LlamaCppTranslate`**: removed the dead `model` block. It could never execute, and its body wrote to `LmStudioModel` — a copy/paste slip. No `"model"` field is sent; llama-server serves whatever it was started with.
- **Ollama model picker**: only the OCR callers need vision-capable models. The translate / AI review / AI assistant callers reused the picker as-is and so defaulted to hiding every non-vision model — i.e. exactly the ones they can use. The filter and its "show all" checkbox are now behind a `visionOnly` flag.
- **Docs**: a new *"llama.cpp: using your own model"* section covering the two supported routes to a model we don't ship (drop a `.gguf` in the models folder, or point at your own `llama-server` via "use remote server"), with the 27B's real cost stated plainly.

## Verification

Build is clean; the full suite passes (1361 tests).

The new tests were checked against the *old* code to confirm they catch the bug: with the fix reverted, `Create_LlamaCppLocal_UncuratedTranslateGemmaByName_GetsGemmaTemplate` fails (gets `null` instead of `gemma`); with it restored, it passes. Coverage added for the uncurated-TranslateGemma case both by name and by full path, plus a theory table over the family inference (curated exact match, uncurated Gemma/Qwen, embedded-template families like Aya/Llama, and unknown names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)