### PR TITLE
Write the language file with LF on every OS

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1699,6 +1699,11 @@ public partial class MainViewModel :
             WriteIndented = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+
+            // English.json is the base every translation is generated from, so it must not depend on
+            // who saved it: WriteIndented defaults to Environment.NewLine, which gives CRLF on Windows
+            // and LF elsewhere, turning a re-save into a whole-file diff with no real change in it.
+            NewLine = "\n",
         });
 
         var currentDirectory = Directory.GetCurrentDirectory();


### PR DESCRIPTION
"Save language file" (Ctrl/Cmd+Alt+Shift+L) writes `English.json` with different line endings depending on which OS you saved it from, so the next person to re-save it produces a whole-file diff that contains no actual change.

## Cause

`MainViewModel.SaveLanguageFile` serializes with `WriteIndented = true` but never sets `NewLine`. Per the .NET docs for `JsonSerializerOptions.NewLine`:

> Gets or sets the new line string to use when `Indented` is `true`. **The default is the value of `Environment.NewLine`.**

So the same code emits CRLF on Windows and LF on macOS/Linux.

```
as Windows writes it today : {\r\n  "title": "Subtitle Edit",\r\n  "general": {\r\n    "ok": "OK"\r\n  }\r\n}
with NewLine = "\n" (fix)  : {\n  "title": "Subtitle Edit",\n  "general": {\n    "ok": "OK"\n  }\n}
```

## Which line ending is correct here?

This isn't an Avalonia question — there's no UI framework in the path, just `System.Text.Json` and `File.WriteAllTextAsync`. The answer comes from what the file *is*: `English.json` is committed to the repo and is the base every translation is generated from, so it has to come out byte-identical no matter who saved it. That means **LF, pinned explicitly in code**. (`"\n"` and `"\r\n"` are the only values `System.Text.Json` accepts; anything else throws.)

## Change

One option, one file: `NewLine = "\n"` in `SaveLanguageFile`. No language files are touched.

## Known follow-ups (deliberately not in this PR)

- **`Italian.json` is currently committed with CRLF** while the other 27 language files are LF. This PR fixes what Subtitle Edit *writes*, but does not renormalize what is already in the repo.
- **The repo has no `.gitattributes`.** Adding `*.json text eol=lf` would stop a contributor's editor putting CRLF back on the next hand-edit — but it has to land *together with* renormalizing `Italian.json`. Adding it alone makes git report `Italian.json` as permanently modified for every contributor on every machine (verified). So both belong in one separate, language-file-touching PR.
- **UTF-8 BOM.** The language files disagree: 7 have one, 21 don't (`Encoding.UTF8` in the save path always emits one, so `English.json` has it). Not OS-dependent, so not this bug — noting it as the same family of problem.

## Verification

Clean build; full suite passes (1383 tests). The `NewLine` mechanism was checked against a Windows-simulating `NewLine = "\r\n"` to confirm the serializer honors the option, and the default-is-`Environment.NewLine` claim was confirmed against the .NET 10 ref pack docs rather than from memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)