### PR TITLE
Add Japanese anime/galgame model to Crisp ASR Qwen3

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrQwen3.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrQwen3.cs
@@ -90,6 +90,24 @@ public class CrispAsrQwen3 : CrispAsrEngineBase
             },
             new WhisperModel
             {
+                Name = "qwen3-asr-1.7b-ja-anime-q4_k.gguf",
+                Size = "1.49 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/qwen3-asr-1.7b-ja-anime-GGUF/resolve/main/qwen3-asr-1.7b-ja-anime-q4_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "qwen3-asr-1.7b-ja-anime-q8_0.gguf",
+                Size = "2.51 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/qwen3-asr-1.7b-ja-anime-GGUF/resolve/main/qwen3-asr-1.7b-ja-anime-q8_0.gguf",
+                ],
+            },
+            new WhisperModel
+            {
                 Name = "qwen3-asr-0.6b-q4_k.gguf",
                 Size = "631 MB",
                 Urls =


### PR DESCRIPTION
Adds `qwen3-asr-1.7b-ja-anime` (q4_k + q8_0) to the Crisp ASR Qwen3 model list.

It is a Japanese anime/galgame fine-tune of the Qwen3-ASR-1.7B we already ship — same architecture, same `qwen3` backend — so this is a model-list addition only, no new engine or download service. It keeps the base model's 30+ languages, with markedly better accuracy on anime/game speech. CrispASR registered it as an auto-download entry in v0.8.7.

| Model | Size |
| --- | --- |
| `qwen3-asr-1.7b-ja-anime-q4_k.gguf` | 1.49 GB |
| `qwen3-asr-1.7b-ja-anime-q8_0.gguf` | 2.51 GB |

## Verification

Both quants were run against the pinned CrispASR **v0.8.10** binary (`--backend qwen3 --language ja`) on a synthesized Japanese clip, rather than only checked for existence — a bad model-list entry costs the user a multi-GB download to discover, and a q4_k on the sibling repo shipped silently broken once before (CrispASR #240).

Reference: こんにちは。今日はとてもいい天気ですね。明日の朝、駅で会いましょう。

- **q4_k** → こんにちは、今日はとてもいい天気ですね。明日の朝、駅で会いましょう (5.2× realtime, Metal)
- **q8_0** → こんにちは。今日は、とても良い天気ですね。明日の朝、駅で会いましょう (3.6× realtime, Metal)

Both are correct; only punctuation and the いい/良い orthography vary. Build is clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)