### PR TITLE
seconv: allow a zero minimum gap when bridging gaps

### DIFF
--- a/src/seconv/Core/LibSEIntegration.cs
+++ b/src/seconv/Core/LibSEIntegration.cs
@@ -692,11 +692,12 @@ internal static class LibSEIntegration
             return;
         }
 
-        var minGap = Math.Max(1, Configuration.Settings.General.MinimumMillisecondsBetweenLines);
+        // Zero is a valid minimum gap - it makes the previous line end exactly where the next one starts.
+        var minGap = Math.Max(0, Configuration.Settings.General.MinimumMillisecondsBetweenLines);
         if (minGap > maxMs)
         {
             // BridgeGaps requires minGap <= maxMs. Clamp to keep the call valid.
-            minGap = Math.Max(1, maxMs - 1);
+            minGap = Math.Max(0, maxMs - 1);
         }
 
         DurationsBridgeGaps.BridgeGaps(subtitle, minGap, divideEven: false, maxMs, fixedIndexes: null, dic: null, useFrames: false);

--- a/tests/seconv/Core/LibSEIntegrationTest.cs
+++ b/tests/seconv/Core/LibSEIntegrationTest.cs
@@ -50,4 +50,56 @@ public class LibSEIntegrationTest
         LibSEIntegration.DeleteLast(sub, 0);
         Assert.Equal(3, sub.Paragraphs.Count);
     }
+
+    [Theory]
+    [InlineData(0)] // regression for #12437: zero must stay zero, not be floored to 1 ms
+    [InlineData(12)]
+    [InlineData(24)]
+    [InlineData(96)]
+    public void BridgeGaps_LeavesGapFromMinimumMillisecondsBetweenLines(int minGap)
+    {
+        var saved = Configuration.Settings.General.MinimumMillisecondsBetweenLines;
+        try
+        {
+            Configuration.Settings.General.MinimumMillisecondsBetweenLines = minGap;
+
+            var sub = new Subtitle();
+            sub.Paragraphs.Add(new Paragraph("line 1", 1000, 2000));
+            sub.Paragraphs.Add(new Paragraph("line 2", 2500, 3500)); // 500 ms gap
+            sub.Renumber();
+
+            LibSEIntegration.BridgeGaps(sub, 1000);
+
+            var gap = sub.Paragraphs[1].StartTime.TotalMilliseconds - sub.Paragraphs[0].EndTime.TotalMilliseconds;
+            Assert.Equal(minGap, gap);
+        }
+        finally
+        {
+            Configuration.Settings.General.MinimumMillisecondsBetweenLines = saved;
+        }
+    }
+
+    [Fact]
+    public void BridgeGaps_ZeroMinGap_LeavesAlreadyTouchingLinesAlone()
+    {
+        var saved = Configuration.Settings.General.MinimumMillisecondsBetweenLines;
+        try
+        {
+            Configuration.Settings.General.MinimumMillisecondsBetweenLines = 0;
+
+            var sub = new Subtitle();
+            sub.Paragraphs.Add(new Paragraph("line 1", 1000, 2000));
+            sub.Paragraphs.Add(new Paragraph("line 2", 2000, 3000)); // no gap
+            sub.Renumber();
+
+            LibSEIntegration.BridgeGaps(sub, 1000);
+
+            Assert.Equal(2000, sub.Paragraphs[0].EndTime.TotalMilliseconds);
+            Assert.Equal(2000, sub.Paragraphs[1].StartTime.TotalMilliseconds);
+        }
+        finally
+        {
+            Configuration.Settings.General.MinimumMillisecondsBetweenLines = saved;
+        }
+    }
 }


### PR DESCRIPTION
Follow-up to #12437 (and #12443): setting `minimumMillisecondsBetweenLines` to `0` still produced a 1 ms gap.

The value was read correctly — seconv then floored it in its bridge-gaps wrapper:

```csharp
var minGap = Math.Max(1, Configuration.Settings.General.MinimumMillisecondsBetweenLines);
```

So `0` became `1` before it ever reached `DurationsBridgeGaps.BridgeGaps`, which computes `end = nextStart - minGap` and handles `0` fine — its only precondition is `minGap <= maxMs`. The desktop code path (`DurationsBridgeGaps2`) passes the configured value through unchanged, and `GeneralSettings` even ships a built-in profile with `MinimumMillisecondsBetweenLines = 0`, so zero is an intended, supported value. The floor was a stray defensive clamp added when the function was written.

`--apply-min-gap` needs no change: "enforce a minimum gap of 0" genuinely is a no-op, and it already warns about that as of #12443.

## Tests

Added to `tests/seconv/Core/LibSEIntegrationTest.cs`:

- a `[Theory]` asserting the resulting gap equals the configured `minimumMillisecondsBetweenLines` for 0 / 12 / 24 / 96 — the `0` case fails on `main` with `Expected: 0, Actual: 1`
- a case pinning idempotence: with a min gap of 0, already-touching lines are left alone rather than pulled into an overlap

## Not changed

`FixOverlappingDisplayTimes` has its own hardcoded `± 1` and ignores `MinimumMillisecondsBetweenLines`; collapsing it to a true zero gap is controlled by `FixCommonErrorsFixOverlapAllowEqualEndStart` (default `false`, and ASS/SSA is exempt). That looks deliberate, so it's left as-is — noting it here because it's the other way to end up with a 1 ms gap.

Fixes #12437

🤖 Generated with [Claude Code](https://claude.com/claude-code)