### PR TITLE
v5.1.0-rc2

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -13,6 +13,7 @@ v5.1.0-rc2 (TBD)
 * Fix common errors: make Apply/Action/Before/After columns sortable in the fix list - thx subcor
 * seconv: warn about unknown keys in the --settings JSON instead of silently ignoring them - thx shanecoopt
 * seconv: --apply-min-gap can now be used without a value, taking the gap from minimumMillisecondsBetweenLines - thx shanecoopt
+* seconv: fix minimumMillisecondsBetweenLines of 0 giving a 1 ms gap when bridging gaps - thx shanecoopt
 * Check for updates: no longer offers an older version as an update
 * OCR: update CrispEmbed to v0.15.0 - fixes garbled math-OCR output, faster detection/decoding
 * Save the language file with LF line endings on every OS, so re-saving it no longer produces a whole-file diff

--- a/change-log.txt
+++ b/change-log.txt
@@ -3,7 +3,7 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
-v5.1.0-rc2 (TBD)
+v5.1.0-rc2 (14th of July 2026)
 
 * Auto-translate: update llama.cpp to b9993
 * Auto-translate: fix chat template for self-supplied .gguf models in the llama.cpp engine - thx saneryiyiersansi

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -17,7 +17,7 @@ public class Se
 {
     internal const int CurrentMacOsFontMigrationVersion = 1;
 
-    public static string Version { get; set; } = "v5.1.0-rc1";
+    public static string Version { get; set; } = "v5.1.0-rc2";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Sets the v5.1.0-rc2 release date and bumps `Se.Version`, same shape as the rc1 release commit (69a996b0d).

- `change-log.txt`: `v5.1.0-rc2 (TBD)` -> `v5.1.0-rc2 (14th of July 2026)`
- `src/ui/Logic/Config/Se.cs`: `v5.1.0-rc1` -> `v5.1.0-rc2`

Also carries the changelog entry for #12451, which missed that merge:

```
* seconv: fix minimumMillisecondsBetweenLines of 0 giving a 1 ms gap when bridging gaps - thx shanecoopt
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)