### PR TITLE
Add live spell check items to the subtitle grid context menu

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -307,6 +307,9 @@ public static partial class InitListViewAndEditBox
                 var textBlock = new TextBlock
                 {
                     VerticalAlignment = VerticalAlignment.Center,
+
+                    // Lets the subtitle grid context menu find the word under the pointer (live spell check)
+                    Tag = SubtitleGridColumnKeys.Text,
                     [!TextBlock.InlinesProperty] = new Binding(nameof(SubtitleLineViewModel.Text)) { Converter = syntaxHighlightingConverter, Mode = BindingMode.OneWay },
                     [!TextBlock.FlowDirectionProperty] = new Binding(nameof(SubtitleLineViewModel.Text)) { Converter = textToFlowDirectionConverter, Mode = BindingMode.OneWay },
                 };
@@ -339,6 +342,9 @@ public static partial class InitListViewAndEditBox
                 var textBlock = new TextBlock
                 {
                     VerticalAlignment = VerticalAlignment.Center,
+
+                    // Lets the subtitle grid context menu find the word under the pointer (live spell check)
+                    Tag = SubtitleGridColumnKeys.OriginalText,
                     [!TextBlock.InlinesProperty] = new Binding(nameof(SubtitleLineViewModel.OriginalText)) { Converter = syntaxHighlightingConverter, Mode = BindingMode.OneWay },
                     [!TextBlock.FlowDirectionProperty] = new Binding(nameof(SubtitleLineViewModel.OriginalText)) { Converter = textToFlowDirectionConverter, Mode = BindingMode.OneWay },
                 };

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -328,6 +328,7 @@ public partial class MainViewModel :
     private bool _loading;
     private bool _opening;
     private PointerEventArgs? _lastTextEditorPointerArgs;
+    private PointerEventArgs? _lastSubtitleGridPointerArgs;
     private HashSet<int>? _visibleLayers;
     private readonly List<SubtitleLineViewModel> _waveformSubtitleBuffer = new();
     private DispatcherTimer _positionTimer = new();
@@ -19148,6 +19149,284 @@ public partial class MainViewModel :
                 });
             }
         }
+
+        AddSubtitleGridSpellCheckMenuItems(sender as MenuFlyout);
+    }
+
+    private const int MaxSpellCheckMenuWords = 10;
+
+    /// <summary>
+    /// Adds the live spell check items for the right-clicked line to the subtitle grid context menu.
+    /// A single misspelled word is shown flat (like in the subtitle text box), several words each get
+    /// their own submenu.
+    /// </summary>
+    private void AddSubtitleGridSpellCheckMenuItems(MenuFlyout? flyout)
+    {
+        if (flyout == null)
+        {
+            return;
+        }
+
+        // Clear previous spell check menu items (identified by their Tag)
+        var itemsToRemove = flyout.Items.Where(item => item is MenuItem mi && mi.Tag?.ToString() == "SpellCheck" ||
+                                                       item is Separator sep && sep.Tag?.ToString() == "SpellCheck")
+            .ToList();
+        foreach (var item in itemsToRemove)
+        {
+            flyout.Items.Remove(item);
+        }
+
+        var pointerArgs = _lastSubtitleGridPointerArgs;
+        _lastSubtitleGridPointerArgs = null;
+
+        if (IsSubtitleGridFlyoutHeaderVisible ||
+            (!Se.Settings.Appearance.SubtitleGridLiveSpellCheck && !Se.Settings.Appearance.SubtitleTextBoxLiveSpellCheck))
+        {
+            return;
+        }
+
+        // Insert spell check items at the beginning of the menu
+        var insertIndex = 0;
+
+        var cell = pointerArgs == null ? null : GetSubtitleGridSpellCheckCell(pointerArgs);
+        if (cell != null)
+        {
+            var (line, isOriginal) = cell.Value;
+            var text = isOriginal ? line.OriginalText : line.Text;
+            var words = GetMisspelledWords(text);
+
+            if (words.Count == 1)
+            {
+                var word = words[0];
+
+                // Add first 5 suggestions
+                foreach (var suggestion in _spellCheckManager.GetSuggestions(word).Take(5))
+                {
+                    flyout.Items.Insert(insertIndex++, MakeSuggestionMenuItem(line, isOriginal, word, suggestion));
+                }
+
+                if (insertIndex > 0)
+                {
+                    // Add separator
+                    flyout.Items.Insert(insertIndex++, new Separator { Tag = "SpellCheck" });
+                }
+
+                flyout.Items.Insert(insertIndex++, MakeAddToUserDictionaryMenuItem(word));
+                flyout.Items.Insert(insertIndex++, MakeIgnoreAllMenuItem(word));
+            }
+            else if (words.Count > 1)
+            {
+                foreach (var word in words.Take(MaxSpellCheckMenuWords))
+                {
+                    flyout.Items.Insert(insertIndex++, MakeMisspelledWordMenuItem(line, isOriginal, word));
+                }
+
+                // Add separator
+                flyout.Items.Insert(insertIndex++, new Separator { Tag = "SpellCheck" });
+            }
+        }
+
+        var changeDictionary = new MenuItem
+        {
+            Header = Se.Language.SpellCheck.PickSpellCheckDictionaryDotDotDot,
+            Tag = "SpellCheck"
+        };
+        changeDictionary.Click += (_, _) => { CommandPickLiveSpellCheckDictionary(); };
+        flyout.Items.Insert(insertIndex++, changeDictionary);
+
+        // Add separator after spell check items
+        flyout.Items.Insert(insertIndex, new Separator { Tag = "SpellCheck" });
+    }
+
+    /// <summary>
+    /// A misspelled word with its suggestions, "add to user dictionary" and "ignore all" in a submenu.
+    /// The suggestions are only looked up when the submenu is opened - asking hunspell for suggestions for
+    /// every misspelled word in the line would make the context menu slow to open.
+    /// </summary>
+    private MenuItem MakeMisspelledWordMenuItem(SubtitleLineViewModel line, bool isOriginal, string word)
+    {
+        var wordItem = new MenuItem
+        {
+            Header = word,
+            Tag = "SpellCheck"
+        };
+        wordItem.Items.Add(MakeAddToUserDictionaryMenuItem(word));
+        wordItem.Items.Add(MakeIgnoreAllMenuItem(word));
+
+        var suggestionsAdded = false;
+        wordItem.SubmenuOpened += (_, _) =>
+        {
+            if (suggestionsAdded)
+            {
+                return;
+            }
+
+            suggestionsAdded = true;
+
+            var index = 0;
+            foreach (var suggestion in _spellCheckManager.GetSuggestions(word).Take(5))
+            {
+                wordItem.Items.Insert(index++, MakeSuggestionMenuItem(line, isOriginal, word, suggestion));
+            }
+
+            if (index > 0)
+            {
+                wordItem.Items.Insert(index, new Separator());
+            }
+        };
+
+        return wordItem;
+    }
+
+    private MenuItem MakeSuggestionMenuItem(SubtitleLineViewModel line, bool isOriginal, string word, string suggestion)
+    {
+        var suggestionItem = new MenuItem
+        {
+            Header = suggestion,
+            FontWeight = FontWeight.Bold,
+            Tag = "SpellCheck"
+        };
+        suggestionItem.Click += (_, _) => { ReplaceSubtitleGridWord(line, isOriginal, word, suggestion); };
+        return suggestionItem;
+    }
+
+    private MenuItem MakeAddToUserDictionaryMenuItem(string word)
+    {
+        var addToDictItem = new MenuItem
+        {
+            Header = string.Format(Se.Language.SpellCheck.AddXToUserDictionary, word),
+            Tag = "SpellCheck"
+        };
+        addToDictItem.Click += (_, _) =>
+        {
+            _spellCheckManager.AdToUserDictionary(word);
+            RefreshLiveSpellCheck();
+        };
+        return addToDictItem;
+    }
+
+    private MenuItem MakeIgnoreAllMenuItem(string word)
+    {
+        var ignoreAllItem = new MenuItem
+        {
+            Header = string.Format(Se.Language.SpellCheck.IgnoreAllX, word),
+            Tag = "SpellCheck"
+        };
+        ignoreAllItem.Click += (_, _) =>
+        {
+            _spellCheckManager.AddIgnoreWord(word);
+            RefreshLiveSpellCheck();
+        };
+        return ignoreAllItem;
+    }
+
+    /// <summary>
+    /// The misspelled words of a line, in reading order and without duplicates - the same word twice in a
+    /// line would give two menu items with the same header.
+    /// </summary>
+    private List<string> GetMisspelledWords(string? text)
+    {
+        if (string.IsNullOrEmpty(text) || !Se.Settings.Appearance.SubtitleGridLiveSpellCheck)
+        {
+            return new List<string>();
+        }
+
+        return SpellCheckWordLists.Split(text)
+            .Where(w => w.Length >= 2 && !_spellCheckManager.IsWordCorrect(w, text))
+            .Select(w => w.Text)
+            .Distinct()
+            .ToList();
+    }
+
+    /// <summary>
+    /// The subtitle line and text column the pointer is over. Falls back to the text column of the
+    /// right-clicked row when the pointer is not over one of the two text columns.
+    /// </summary>
+    private (SubtitleLineViewModel Line, bool IsOriginal)? GetSubtitleGridSpellCheckCell(PointerEventArgs pointerArgs)
+    {
+        if (SubtitleGrid == null)
+        {
+            return null;
+        }
+
+        var position = pointerArgs.GetPosition(SubtitleGrid);
+        var textBlock = FindSubtitleGridTextBlock(position);
+        if (textBlock?.DataContext is SubtitleLineViewModel cellLine)
+        {
+            return (cellLine, textBlock.Tag as string == InitListViewAndEditBox.SubtitleGridColumnKeys.OriginalText);
+        }
+
+        var line = Subtitles.GetOrNull(GetDataGridRowIndexFromPoint(position));
+        return line == null ? null : (line, false);
+    }
+
+    private TextBlock? FindSubtitleGridTextBlock(Avalonia.Point pointerPosition)
+    {
+        if (SubtitleGrid.InputHitTest(pointerPosition) is not Avalonia.Visual hit)
+        {
+            return null;
+        }
+
+        if (hit is TextBlock hitTextBlock && IsSubtitleGridTextBlock(hitTextBlock))
+        {
+            return hitTextBlock;
+        }
+
+        // The pointer can be over the cell padding instead of the text block itself
+        var cell = hit.FindAncestorOfType<DataGridCell>();
+        return cell?.GetVisualDescendants().OfType<TextBlock>().FirstOrDefault(IsSubtitleGridTextBlock);
+    }
+
+    private static bool IsSubtitleGridTextBlock(TextBlock textBlock)
+    {
+        return textBlock.Tag as string == InitListViewAndEditBox.SubtitleGridColumnKeys.Text ||
+               textBlock.Tag as string == InitListViewAndEditBox.SubtitleGridColumnKeys.OriginalText;
+    }
+
+    /// <summary>
+    /// Replaces every occurrence of <paramref name="word"/> in the line with <paramref name="suggestion"/>.
+    /// The menu offers each misspelled word once, so a word occurring twice in the line is corrected in both
+    /// places - fixing only one of them would leave the other one underlined with no obvious way to fix it.
+    /// </summary>
+    private void ReplaceSubtitleGridWord(SubtitleLineViewModel line, bool isOriginal, string word, string suggestion)
+    {
+        // Split the current text: the line may have been edited since the menu was opened
+        var text = isOriginal ? line.OriginalText : line.Text;
+        if (string.IsNullOrEmpty(text))
+        {
+            return;
+        }
+
+        var occurrences = SpellCheckWordLists.Split(text).Where(w => w.Text == word).ToList();
+        if (occurrences.Count == 0)
+        {
+            return;
+        }
+
+        // Replace from the back, so the indexes of the remaining occurrences stay valid
+        var newText = text;
+        for (var i = occurrences.Count - 1; i >= 0; i--)
+        {
+            var occurrence = occurrences[i];
+            newText = newText.Remove(occurrence.Index, occurrence.Length).Insert(occurrence.Index, suggestion);
+        }
+
+        if (isOriginal)
+        {
+            line.OriginalText = newText;
+            if (ReferenceEquals(SelectedSubtitle, line) && EditTextBoxOriginal.Text != newText)
+            {
+                EditTextBoxOriginal.Text = newText;
+            }
+
+            return;
+        }
+
+        line.Text = newText;
+        if (ReferenceEquals(SelectedSubtitle, line) && EditTextBox.Text != newText)
+        {
+            EditTextBox.Text = newText;
+        }
     }
 
     private bool IsTextInputFocused()
@@ -20073,6 +20352,9 @@ public partial class MainViewModel :
             var props = e.GetCurrentPoint(control).Properties;
             _subtitleGridIsLeftClick = props.IsLeftButtonPressed;
             _subtitleGridIsRightClick = props.IsRightButtonPressed;
+
+            // Used by the context menu to find the word under the pointer (live spell check)
+            _lastSubtitleGridPointerArgs = e;
             _subtitleGridIsControlPressed = e.KeyModifiers.HasFlag(KeyModifiers.Control);
             // On macOS, Cmd (Meta) is the multi-select modifier; Ctrl triggers the context menu instead
             var isMultiSelectModifier = _subtitleGridIsControlPressed


### PR DESCRIPTION
Right-clicking a line in the subtitle grid now offers the same spell check items as the subtitle text box: suggestions, "Add to user dictionary", "Ignore all" and "Pick spell check dictionary...". Follow-up to #12454, which fixed changing the live spell check dictionary.

## Menu layout

A single misspelled word is shown flat, like in the text box:

```
the
tea
ten
─────────────────────────────
Add "teh" to user dictionary
Ignore all "teh"
Pick spell check dictionary...
─────────────────────────────
(rest of the menu)
```

Several misspelled words each get their own submenu, so the menu does not grow out of hand (at most 10 words - a line checked against the wrong dictionary can have every word underlined, and the dictionary picker sits right below the list):

```
teh    ▸  the / tea / ten / Add "teh" to user dictionary / Ignore all "teh"
wrold  ▸  world / wold / Add "wrold" to user dictionary / Ignore all "wrold"
Pick spell check dictionary...
─────────────────────────────
(rest of the menu)
```

## Notes

- The items act on the line under the pointer, in the text column as well as the original text column. The pointer is only used to tell the two columns apart; right-clicking anywhere else on the row falls back to the text column.
- Suggestions are looked up when a submenu is opened. Hunspell's `Suggest` is not cheap, and asking it for every misspelled word in the line up front would make the context menu slow to open. "Add to user dictionary" and "Ignore all" are built eagerly - they are free.
- A word occurring twice in a line is listed once and corrected in both places. Listing it twice gives two identical-looking menu entries, and correcting only one would leave the other underlined with no obvious way to reach it.
- Applying a suggestion updates the row and syncs the edit text box when the line is the selected one, so the two views cannot drift apart.
- The subtitle text box context menu is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)