### PR TITLE
Update change log

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,16 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.1.0-rc3 (TBD)
+
+* Live spell check: add spell check items to the subtitle grid context menu - suggestions, add to user dictionary and ignore all
+* Live spell check: picking a dictionary now also updates the subtitle grid, and no longer hides the spell check items in the text box context menu
+* Live spell check: fix the English dictionary being used for other languages - thx muaz978
+* Scroll bar: shift+click on the trough jumps to that position - thx muaz978
+* Shortcuts: normal weight for the shortcut name column - thx muaz978
+
+-----------------------------------------------------------------------------------------------------
+
 v5.1.0-rc2 (14th of July 2026)
 
 * Auto-translate: update llama.cpp to b9993


### PR DESCRIPTION
Adds a `v5.1.0-rc3 (TBD)` section with everything merged after the `v5.1.0-rc2` tag (enumerated from the PR merge commits between the tag and main):

* Live spell check: add spell check items to the subtitle grid context menu - suggestions, add to user dictionary and ignore all (#12455)
* Live spell check: picking a dictionary now also updates the subtitle grid, and no longer hides the spell check items in the text box context menu (#12454)
* Live spell check: fix the English dictionary being used for other languages - thx muaz978 (#12289)
* Scroll bar: shift+click on the trough jumps to that position - thx muaz978 (#12438)
* Shortcuts: normal weight for the shortcut name column - thx muaz978 (#12439)

`Se.Version` is left at `v5.1.0-rc2` and the heading at `(TBD)` - both are stamped when the release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)