### PR TITLE
Fix spell check window opening blank

### DIFF
--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -436,7 +436,21 @@ public partial class SpellCheckViewModel : ObservableObject
 
         // Posted to run after the window exists (Window is assigned in the window ctor),
         // so the "continue from current line?" prompt and the close hook have an owner.
-        Dispatcher.UIThread.Post(() => _ = StartSpellCheckAsync(selectedSubtitleIndex), DispatcherPriority.Background);
+        Dispatcher.UIThread.Post(
+            async void () =>
+            {
+                try
+                {
+                    await StartSpellCheckAsync(selectedSubtitleIndex);
+                }
+                catch (Exception exception)
+                {
+                    // Without this the task was discarded and any failure in here was lost,
+                    // leaving the window up with no word, no text and no suggestions.
+                    Se.LogError(exception, "Spell check could not be started");
+                }
+            },
+            DispatcherPriority.Background);
     }
 
     /// <summary>
@@ -447,6 +461,14 @@ public partial class SpellCheckViewModel : ObservableObject
     /// </summary>
     private async Task StartSpellCheckAsync(int? selectedSubtitleIndex)
     {
+        // The view model is initialized before the window service shows the dialog, and the
+        // Background pass it yields for (YieldForPendingFlyoutDismissAsync) runs this posted
+        // callback before window.ShowDialog(). The window therefore exists but is not on screen
+        // yet, and a message box owned by a window that is not visible throws - which used to
+        // leave the spell check window blank whenever the prompt below was needed, i.e. for
+        // every line except the first one.
+        await WaitForWindowShownAsync();
+
         // Make sure a summary of changes is reported even when the user closes early (Esc / X),
         // not only when the run completes or "Done" is pressed.
         if (Window != null)
@@ -482,6 +504,37 @@ public partial class SpellCheckViewModel : ObservableObject
             : null;
 
         DoSpellCheck();
+    }
+
+    /// <summary>
+    /// Completes once the window is on screen, so message boxes owned by it can be shown.
+    /// </summary>
+    private Task WaitForWindowShownAsync()
+    {
+        var window = Window;
+        if (window == null || window.IsVisible)
+        {
+            return Task.CompletedTask;
+        }
+
+        var taskCompletionSource = new TaskCompletionSource();
+
+        void OnOpened(object? sender, EventArgs e)
+        {
+            window.Opened -= OnOpened;
+            taskCompletionSource.TrySetResult();
+        }
+
+        window.Opened += OnOpened;
+
+        // The window may have been shown between the check above and the subscription
+        if (window.IsVisible)
+        {
+            window.Opened -= OnOpened;
+            taskCompletionSource.TrySetResult();
+        }
+
+        return taskCompletionSource.Task;
     }
 
     private void CaptureTotals()

--- a/tests/UI/Features/SpellCheck/SpellCheckStartLineTests.cs
+++ b/tests/UI/Features/SpellCheck/SpellCheckStartLineTests.cs
@@ -1,0 +1,108 @@
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+
+namespace UITests.Features.SpellCheck;
+
+// Scanning from the line the user selected (after answering "continue from current line?") must find
+// a misspelling on that very line, not only on the lines below it.
+public class SpellCheckStartLineTests : IDisposable
+{
+    private readonly string _originalDictionariesFolder;
+    private readonly Func<string> _originalSpellCheckDictionariesFolder;
+    private readonly string _tempDictionariesFolder;
+
+    public SpellCheckStartLineTests()
+    {
+        _originalDictionariesFolder = Se.DictionariesFolder;
+        _originalSpellCheckDictionariesFolder = SpellCheckConfig.DictionariesFolder;
+        _tempDictionariesFolder = Path.Combine(Path.GetTempPath(), "SeStartLineRepro_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDictionariesFolder);
+
+        var repoRoot = FindRepoRoot();
+        File.Copy(Path.Combine(repoRoot, "Dictionaries", "en_US.dic"), Path.Combine(_tempDictionariesFolder, "en_US.dic"));
+        File.Copy(Path.Combine(repoRoot, "Dictionaries", "en_US.aff"), Path.Combine(_tempDictionariesFolder, "en_US.aff"));
+
+        Se.DictionariesFolder = _tempDictionariesFolder;
+        SpellCheckConfig.DictionariesFolder = () => _tempDictionariesFolder;
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "Dictionaries")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir!.FullName;
+    }
+
+    private SpellCheckManager MakeManager()
+    {
+        var manager = new SpellCheckManager();
+        manager.Initialize(Path.Combine(_tempDictionariesFolder, "en_US.dic"), "en");
+        return manager;
+    }
+
+    private static ObservableCollection<SubtitleLineViewModel> MakeSubtitles()
+    {
+        return new ObservableCollection<SubtitleLineViewModel>
+        {
+            new() { Text = "This line is perfectly fine." },   // line 0: no errors
+            new() { Text = "Ths line has a typo." },           // line 1: "Ths" is misspelled
+            new() { Text = "This line is fine too." },         // line 2: no errors
+        };
+    }
+
+    [Fact]
+    public void FromTop_FindsTheTypo()
+    {
+        var results = MakeManager().CheckSpelling(MakeSubtitles(), null, null);
+
+        Assert.Single(results);
+        Assert.Equal("Ths", results[0].Word.Text);
+    }
+
+    [Fact]
+    public void FromLineBeforeTheTypo_FindsTheTypo()
+    {
+        // User selected line 0 (before the error) and answered "continue from current line"
+        var startFrom = new SpellCheckResult { LineIndex = 0, WordIndex = -1 };
+
+        var results = MakeManager().CheckSpelling(MakeSubtitles(), startFrom, null);
+
+        Assert.Single(results);
+        Assert.Equal("Ths", results[0].Word.Text);
+    }
+
+    [Fact]
+    public void FromTheLineWithTheTypo_FindsTheTypo()
+    {
+        // User selected line 1 - the line that HAS the typo - and answered "continue from current line".
+        // This is what StartSpellCheckAsync builds: new SpellCheckResult { LineIndex = startLine, WordIndex = -1 }
+        var startFrom = new SpellCheckResult { LineIndex = 1, WordIndex = -1 };
+
+        var results = MakeManager().CheckSpelling(MakeSubtitles(), startFrom, null);
+
+        Assert.Single(results);
+        Assert.Equal("Ths", results[0].Word.Text);
+    }
+
+    public void Dispose()
+    {
+        Se.DictionariesFolder = _originalDictionariesFolder;
+        SpellCheckConfig.DictionariesFolder = _originalSpellCheckDictionariesFolder;
+        try
+        {
+            Directory.Delete(_tempDictionariesFolder, true);
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+}


### PR DESCRIPTION
Starting the spell check with **any line but the first one** selected opened the window with no word, no text and no suggestions, and left it that way.

## Cause

`SpellCheckViewModel.Initialize` posts `StartSpellCheckAsync` at `DispatcherPriority.Background`. `WindowService.ShowDialogAsync` then does `await YieldForPendingFlyoutDismissAsync()` - which awaits a **Background** priority dispatcher pass - *before* calling `window.ShowDialog(owner)`. Same priority, queued earlier, so the posted callback runs in that pass: the window exists (`Window` is assigned in its constructor, which is what the old comment relied on) but is **not on screen yet**.

`StartSpellCheckAsync` then shows the "continue from current line?" message box owned by that not-yet-visible window, which throws. The exception was lost because the task was discarded (`_ = StartSpellCheckAsync(...)`), so `DoSpellCheck()` never ran and the window just sat there blank.

The prompt only appears when the selected line index is > 0, which is why selecting the first line worked and every other line did not.

## Fix

- Wait for the window's `Opened` event before starting the scan, so the prompt has a visible owner.
- Log a failure in that posted task instead of discarding it, so a future failure in here is not invisible.

## Tests

`CheckSpelling` itself was verified innocent first - new `SpellCheckStartLineTests` covers scanning from the top, from a line before the misspelling, and from the line that *has* the misspelling (the case that made this look like an off-by-one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)