### PR TITLE
Fix three live spell check bugs

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -329,6 +329,12 @@ public partial class MainViewModel :
     private bool _opening;
     private PointerEventArgs? _lastTextEditorPointerArgs;
     private PointerEventArgs? _lastSubtitleGridPointerArgs;
+
+    // The dictionary currently loaded into _spellCheckManager for live spell check, null when none
+    // could be loaded. The manager keeps the previously loaded dictionary in that case, so asking it
+    // to check a word would give an answer from the wrong language - or, with nothing ever loaded,
+    // report every word as misspelled.
+    private string? _liveSpellCheckDictionaryFileName;
     private HashSet<int>? _visibleLayers;
     private readonly List<SubtitleLineViewModel> _waveformSubtitleBuffer = new();
     private DispatcherTimer _positionTimer = new();
@@ -15717,7 +15723,15 @@ public partial class MainViewModel :
         // A dictionary the user picked explicitly (live spell check context menu or the spell
         // check window) wins over auto detection - otherwise the next call here would silently
         // revert to the auto detected language. It is cleared in ResetSubtitle.
-        ApplyLiveSpellCheck(_currentSpellCheckDictionary ?? AutoDetectSpellCheckDictionary());
+        //
+        // Entries without a dictionary file are not usable here: the spell check window lists the
+        // MS Word languages that way (name only), and picking one would otherwise leave live spell
+        // check pinned to an entry that can never load, disabling it for the rest of the session.
+        var pickedDictionary = string.IsNullOrEmpty(_currentSpellCheckDictionary?.DictionaryFileName)
+            ? null
+            : _currentSpellCheckDictionary;
+
+        ApplyLiveSpellCheck(pickedDictionary ?? AutoDetectSpellCheckDictionary());
     }
 
     private SpellCheckDictionaryDisplay? AutoDetectSpellCheckDictionary()
@@ -15750,12 +15764,22 @@ public partial class MainViewModel :
     /// </summary>
     private void ApplyLiveSpellCheck(SpellCheckDictionaryDisplay? dictionary)
     {
-        var dictionaryLoaded = false;
-        if (dictionary != null)
+        if (dictionary == null)
         {
-            var twoLetterLanguageCode = Iso639Dash2LanguageCode.GetTwoLetterCodeFromThreeLetterCode(dictionary.GetThreeLetterCode());
-            dictionaryLoaded = _spellCheckManager.Initialize(dictionary.DictionaryFileName, twoLetterLanguageCode);
+            _liveSpellCheckDictionaryFileName = null;
         }
+        else if (dictionary.DictionaryFileName != _liveSpellCheckDictionaryFileName)
+        {
+            // Only load when the dictionary actually changes: Initialize() clears the ignore list, so
+            // re-loading the dictionary already in use would throw away every "Ignore all" of this
+            // session (it is memory-only, unlike added words). It also re-reads the .dic/.aff from disk.
+            var twoLetterLanguageCode = Iso639Dash2LanguageCode.GetTwoLetterCodeFromThreeLetterCode(dictionary.GetThreeLetterCode());
+            _liveSpellCheckDictionaryFileName = _spellCheckManager.Initialize(dictionary.DictionaryFileName, twoLetterLanguageCode)
+                ? dictionary.DictionaryFileName
+                : null;
+        }
+
+        var dictionaryLoaded = _liveSpellCheckDictionaryFileName != null;
 
         if (EditTextBox is TextEditorWrapper wrapper)
         {
@@ -19326,7 +19350,11 @@ public partial class MainViewModel :
     /// </summary>
     private List<string> GetMisspelledWords(string? text)
     {
-        if (string.IsNullOrEmpty(text) || !Se.Settings.Appearance.SubtitleGridLiveSpellCheck)
+        // Without a loaded dictionary the manager reports every word as misspelled, so the menu would
+        // list the whole line while the grid - correctly - underlines nothing.
+        if (string.IsNullOrEmpty(text) ||
+            !Se.Settings.Appearance.SubtitleGridLiveSpellCheck ||
+            _liveSpellCheckDictionaryFileName == null)
         {
             return new List<string>();
         }
@@ -22400,8 +22428,10 @@ public partial class MainViewModel :
         Dispatcher.UIThread.Post(async () =>
         {
             var result = await ShowDialogAsync<PickSpellCheckDictionaryWindow, PickSpellCheckDictionaryViewModel>();
-            if (result?.SelectedDictionary == null)
+            if (result is not { OkPressed: true, SelectedDictionary: not null })
             {
+                // The dialog always has a dictionary selected, so without the OkPressed check
+                // closing it with Escape/Cancel switched the dictionary anyway.
                 return;
             }
 

--- a/src/ui/Features/Shared/PickSpellCheckDictionary/PickSpellCheckDictionaryViewModel.cs
+++ b/src/ui/Features/Shared/PickSpellCheckDictionary/PickSpellCheckDictionaryViewModel.cs
@@ -81,7 +81,13 @@ public partial class PickSpellCheckDictionaryViewModel : ObservableObject
                 SelectedDictionary = Dictionaries.FirstOrDefault(l => l.DictionaryFileName == Se.Settings.SpellCheck.LastLanguageDictionaryFile);
             }
 
-            SelectedDictionary = Dictionaries.FirstOrDefault(l => l.Name.Contains("English", StringComparison.OrdinalIgnoreCase));
+            // The remembered dictionary was selected above and then overwritten right away, so the
+            // list always opened on English
+            if (SelectedDictionary == null)
+            {
+                SelectedDictionary = Dictionaries.FirstOrDefault(l => l.Name.Contains("English", StringComparison.OrdinalIgnoreCase));
+            }
+
             if (SelectedDictionary == null)
             {
                 SelectedDictionary = Dictionaries[0];


### PR DESCRIPTION
Three bugs found while auditing the live spell check code merged in #12454 and #12455.

## 1. Cancelling "Pick spell check dictionary..." still switched the dictionary

`PickLiveSpellCheckDictionary` used the dialog result without checking `OkPressed`, and the dialog always has a dictionary selected (`LoadDictionaries` force-selects one), so the `SelectedDictionary == null` guard never fired. Pressing Escape or Cancel loaded the highlighted dictionary anyway, showed "Live spell check language X loaded", **and** pinned `_currentSpellCheckDictionary` - which makes `SetupLiveSpellCheck` skip auto-detection for the rest of the session.

Made worse by a dead assignment next to it: `PickSpellCheckDictionaryViewModel.LoadDictionaries` selected `LastLanguageDictionaryFile` and then overwrote it unconditionally on the next line, so the list always opened on **English**. Dismissing the dialog on a Danish subtitle therefore forced live spell check to English. Both are fixed (the equivalent code in `SpellCheckViewModel` has the `if (SelectedDictionary == null)` guard this one was missing).

## 2. The subtitle grid context menu listed every word as misspelled when no dictionary was loaded

`GetMisspelledWords` gated on the *setting* only, never on whether a dictionary had actually loaded. With an un-initialized manager, `SpellChecker.IsWordCorrect` falls through to a null hunspell and returns **false for every word**.

- Fresh install, no dictionaries: the grid correctly underlines nothing, but right-clicking a line topped the menu with a submenu per word, each offering "Add X to user dictionary" - which is a silent no-op, since `AdToUserDictionary` needs the word lists that `Initialize` creates.
- Open an English subtitle, then a Danish one with no Danish dictionary installed: the manager still holds **en_US**, so Danish words were checked against English and offered English suggestions.

Live spell check now tracks which dictionary is loaded, and the menu only offers words when there is one.

## 3. "Ignore all" was silently forgotten

`SpellChecker.Initialize` starts with `SkipAllList.Clear()`, and `ApplyLiveSpellCheck` re-initialized the manager on **every** `SetupLiveSpellCheck()` - including the one that runs when the settings window is closed. So: right-click a name → "Ignore all" → underline goes away → open Options, press OK → underlined again, with no indication why. (Added words survive because they are persisted to XML; ignores are session-only.)

The dictionary is now only loaded when it actually changes, which also stops re-reading the `.dic`/`.aff` from disk on the UI thread on every call.

## Also

Dictionaries without a dictionary file are ignored as a live spell check pick. The spell check window lists MS Word languages by name only (`DictionaryFileName` is empty), and since #12454 the window's choice feeds live spell check - so running a spell check with the MS Word provider pinned an entry that can never load, leaving live spell check dead for the session.

Existing tests pass (662).

🤖 Generated with [Claude Code](https://claude.com/claude-code)