### PR TITLE
Update change log

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -5,8 +5,11 @@ Subtitle Edit Changelog
 
 v5.1.0-rc3 (TBD)
 
+* Spell check: fix the spell check window opening blank - no word, no text and no suggestions - unless the first line was selected
 * Live spell check: add spell check items to the subtitle grid context menu - suggestions, add to user dictionary and ignore all
 * Live spell check: picking a dictionary now also updates the subtitle grid, and no longer hides the spell check items in the text box context menu
+* Live spell check: fix cancelling "Pick spell check dictionary" switching the dictionary anyway, and the list always opening on English instead of the dictionary last used
+* Live spell check: fix "Ignore all" being forgotten again as soon as the settings window was closed
 * Live spell check: fix the English dictionary being used for other languages - thx muaz978
 * Scroll bar: shift+click on the trough jumps to that position - thx muaz978
 * Shortcuts: normal weight for the shortcut name column - thx muaz978


### PR DESCRIPTION
Adds the spell check fixes merged since the last change log update (#12457, #12458) to the `v5.1.0-rc3` section:

* Spell check: fix the spell check window opening blank - no word, no text and no suggestions - unless the first line was selected
* Live spell check: fix cancelling "Pick spell check dictionary" switching the dictionary anyway, and the list always opening on English instead of the dictionary last used
* Live spell check: fix "Ignore all" being forgotten again as soon as the settings window was closed

All three shipped in rc2 (verified by ancestor-checking the commits that introduced them against the tag), so they are real user-facing fixes. The two bugs fixed in #12458 that were introduced by #12454/#12455 in this same unreleased cycle are deliberately not listed - no released version ever had them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)