### PR TITLE
Fix arrow key after shift+arrow jumping back to the anchor

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -20647,9 +20647,19 @@ public partial class MainViewModel :
         BatchGridSelection(detach, () =>
         {
             SubtitleGrid.SelectedItems.Clear();
+
+            // Add the moving end of the selection first: the DataGrid only moves its current cell for
+            // the first item added into an empty selection. Filling the range in ascending order left
+            // the current cell on the anchor when extending downwards, so a plain arrow key afterwards
+            // jumped back to anchor+1 instead of continuing from the moving end. The shift+click path
+            // above adds the clicked row first for the same reason.
+            SubtitleGrid.SelectedItems.Add(Subtitles[_shiftSelectCurrentIndex]);
             for (var i = startIdx; i <= endIdx; i++)
             {
-                SubtitleGrid.SelectedItems.Add(Subtitles[i]);
+                if (i != _shiftSelectCurrentIndex)
+                {
+                    SubtitleGrid.SelectedItems.Add(Subtitles[i]);
+                }
             }
         });
 


### PR DESCRIPTION
Extending the subtitle grid selection with Shift+Down / Shift+PageDown / Shift+End left the DataGrid's **current cell** on the anchor row, so the next plain arrow key continued from the anchor instead of from the moving end of the selection.

Repro:
1. Click line 3.
2. Shift+Down three times → lines 3-6 selected (correct).
3. Press Down → the selection collapses to **line 4**, not line 7.

## Cause

`DataGridSelectedItemsCollection.Add` only updates currency for the **first** item added into an empty selection (`if (_selectedSlotsTable.RangeCount == 0) OwningGrid.SelectedItem = dataItem;`); every later `Add` goes through `SetRowSelection`, which never touches `CurrentSlot`. `HandleShiftArrowSelection` clears the selection and then fills the range in ascending order, so when extending *downwards* the first row added is the anchor - and the current cell stays there. Extending upwards happened to work, because then the moving end *is* the lowest index.

## Fix

Add the moving end of the selection first, then the rest of the range. This is exactly what the shift+**click** path already does (`SubtitleGrid.SelectedItems.Add(Subtitles[rowIndex]);` before its loop) so that the clicked row becomes current.

Note: a downward mouse drag-select has the same root cause (`DragSelectSubtitleGridToIndex` also fills ascending, and its incremental moves never update currency at all). Fixing that properly needs the current cell updated on every drag move, not just at the first one, so it is left out of this PR rather than half-fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)