### PR TITLE
Fix undo change detection reading the subtitles from a timer thread

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14717,6 +14717,15 @@ public partial class MainViewModel :
 
     public UndoRedoItem MakeUndoRedoObject(string description)
     {
+        // The undo change-detection timer calls this from a thread pool thread. Snapshotting
+        // Subtitles from there can throw mid-enumeration, or - worse - capture the collection half
+        // way through a UI-thread edit (say after one of two selected lines has been removed),
+        // putting a state that never existed on the undo stack.
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            return Dispatcher.UIThread.Invoke(() => MakeUndoRedoObject(description));
+        }
+
         return new UndoRedoItem(
             description,
             Subtitles.Select(p => new SubtitleLineViewModel(p)).ToArray(),
@@ -18427,6 +18436,15 @@ public partial class MainViewModel :
 
     public int GetFastHash()
     {
+        // The undo change-detection timer calls this from a thread pool thread, and the loop below
+        // walks Subtitles - an ObservableCollection the UI thread mutates (insert / delete / merge /
+        // replace all). A tick overlapping an edit threw "Collection was modified" or an index
+        // out-of-range exception; the timer swallows those, so that undo entry was silently lost.
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            return Dispatcher.UIThread.Invoke(GetFastHash);
+        }
+
         // Runs every 250 ms (undo change detection) plus every 400 ms (title/auto-save),
         // so it must not allocate: the old version concatenated fileName+encoding and
         // called Trim() on Header/Footer - the editor normalises subtitles to ASSA, so


### PR DESCRIPTION
The undo change-detection timer fires on a **thread pool thread** every 250 ms and called `client.GetFastHash()` and `client.MakeUndoRedoObject(...)` straight from there (`UndoRedoManager.CheckForChanges`). Both walk `Subtitles` - an `ObservableCollection<SubtitleLineViewModel>` that the UI thread mutates on insert / delete / merge / replace-all - and nothing pinned those reads to the UI thread. The comments in `CheckForChanges` are about lock ordering only, and `IsTyping()` (500 ms since the last *key*) does not cover mouse- or menu-driven edits.

Consequences when a tick overlapped an edit:

- `Subtitles[i]` threw `ArgumentOutOfRangeException`, or the LINQ enumeration threw "Collection was modified". Both are swallowed by the `catch` in `CheckForChanges`, so **that undo state was silently lost**.
- Or the snapshot was captured mid-mutation (e.g. after one of two selected lines had been removed), so Ctrl+Z restored **a state that never existed**.

## Fix

Marshal the two client methods onto the UI thread with `Dispatcher.UIThread.Invoke` when called from off-thread.

Doing it in the client rather than in `UndoRedoManager` keeps the manager free of UI concerns - and, importantly, keeps its unit tests meaningful: they call `CheckForChanges(null)` directly and would otherwise have to be rewritten around a dispatcher seam (there is no `InternalsVisibleTo`, and posting to a dispatcher that no one pumps would make them silently no-op). It also covers the manager's other callers, `CanUndo` and `Undo`, which already run on the UI thread and so pay nothing (`CheckAccess()` is true → direct call).

No deadlock: `Timer.Dispose()` is the non-blocking overload, and the UI thread never waits on the timer thread, so the blocking `Invoke` always completes.

Existing tests pass (665).

🤖 Generated with [Claude Code](https://claude.com/claude-code)