### PR TITLE
Spell check: start at the current line instead of asking

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -372,6 +372,7 @@ public partial class MainViewModel :
     private static SolidColorBrush _transparentBrush = new SolidColorBrush(Colors.Transparent);
     private static SolidColorBrush _errorBrush = new SolidColorBrush(_errorColor);
     private SpellCheckDictionaryDisplay? _currentSpellCheckDictionary;
+    private bool _spellCheckSessionInProgress;
     private FfmpegMediaInfo2? _mediaInfo;
     string _dropDownFormatsSearchText = string.Empty;
     private System.Timers.Timer _dropDownFormatsSearchTimer = new System.Timers.Timer(1000);
@@ -1806,6 +1807,7 @@ public partial class MainViewModel :
         Se.Settings.General.CurrentVideoOffsetInMs = 0;
         UpdateVideoOffsetStatus();
         _currentSpellCheckDictionary = null;
+        _spellCheckSessionInProgress = false;
 
         if (format != null)
         {
@@ -5893,7 +5895,12 @@ public partial class MainViewModel :
         }
 
         var dictionaryFileName = _currentSpellCheckDictionary?.DictionaryFileName ?? null;
-        var result = await ShowDialogAsync<SpellCheckWindow, SpellCheckViewModel>(vm => { vm.Initialize(Subtitles, SelectedSubtitleIndex, this, dictionaryFileName); });
+        var result = await ShowDialogAsync<SpellCheckWindow, SpellCheckViewModel>(
+            vm => { vm.Initialize(Subtitles, SelectedSubtitleIndex, this, dictionaryFileName, _spellCheckSessionInProgress); });
+
+        // Only an unfinished spell check leaves something to continue from, and only then is the
+        // "continue spell check from current line?" prompt asked on the next run.
+        _spellCheckSessionInProgress = !result.ScanCompleted;
 
         if (result.OkPressed)
         {

--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -67,6 +67,11 @@ public partial class SpellCheckViewModel : ObservableObject
     public int TotalAddedWords { get; set; }
 
     public bool OkPressed { get; private set; }
+
+    /// <summary>
+    /// True when the scan reached the end of the subtitle, so there is no unfinished session left.
+    /// </summary>
+    public bool ScanCompleted { get; private set; }
     public StackPanel PanelWholeText { get; internal set; }
     public TextBox TextBoxWordNotFound { get; internal set; }
 
@@ -93,6 +98,10 @@ public partial class SpellCheckViewModel : ObservableObject
     private int _scanStartLineIndex;
     private int? _stopBeforeLineIndex;
     private bool _hasWrapped;
+
+    // True when a spell check of this subtitle was left unfinished, which is the only case where
+    // "continue spell check from current line?" has something to continue from.
+    private bool _sessionInProgress;
 
     public SpellCheckViewModel(ISpellCheckManager spellCheckManager, IWindowService windowService, IFileHelper fileHelper, IBluRayHelper bluRayHelper, IOcrImageSourceHolder ocrImageSourceHolder)
     {
@@ -418,9 +427,10 @@ public partial class SpellCheckViewModel : ObservableObject
         previous?.Dispose();
     }
 
-    public void Initialize(ObservableCollection<SubtitleLineViewModel> paragraphs, int? selectedSubtitleIndex, IFocusSubtitleLine focusSubtitleLine, string? dictionaryFileName)
+    public void Initialize(ObservableCollection<SubtitleLineViewModel> paragraphs, int? selectedSubtitleIndex, IFocusSubtitleLine focusSubtitleLine, string? dictionaryFileName, bool sessionInProgress = false)
     {
         _focusSubtitleLine = focusSubtitleLine;
+        _sessionInProgress = sessionInProgress;
         Paragraphs.Clear();
         Paragraphs.AddRange(paragraphs);
         SetLanguage(dictionaryFileName);
@@ -477,24 +487,36 @@ public partial class SpellCheckViewModel : ObservableObject
         }
 
         var startLine = 0;
-        if (Window != null && selectedSubtitleIndex is int idx && idx > 0 && idx < Paragraphs.Count)
+        if (selectedSubtitleIndex is int idx && idx > 0 && idx < Paragraphs.Count)
         {
-            var answer = await MessageBox.Show(
-                Window,
-                Se.Language.SpellCheck.SpellCheck,
-                Se.Language.SpellCheck.ContinueFromCurrentLine,
-                MessageBoxButtons.YesNoCancel,
-                MessageBoxIcon.Question);
-
-            if (answer == MessageBoxResult.Cancel || answer == MessageBoxResult.None)
+            if (!_sessionInProgress)
             {
-                Dispatcher.UIThread.Invoke(() => Window?.Close());
-                return;
-            }
-
-            if (answer == MessageBoxResult.Yes)
-            {
+                // Nothing to continue from, so start where the user is standing instead of asking.
+                // The scan offers to wrap back to the top when it reaches the end, so the lines above
+                // are still covered.
                 startLine = idx;
+            }
+            else if (Window != null)
+            {
+                // A spell check of this subtitle was left unfinished, so "continue from current line"
+                // is a real choice: resume where the user is now, or start over from the top.
+                var answer = await MessageBox.Show(
+                    Window,
+                    Se.Language.SpellCheck.SpellCheck,
+                    Se.Language.SpellCheck.ContinueFromCurrentLine,
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (answer == MessageBoxResult.Cancel || answer == MessageBoxResult.None)
+                {
+                    Dispatcher.UIThread.Invoke(() => Window?.Close());
+                    return;
+                }
+
+                if (answer == MessageBoxResult.Yes)
+                {
+                    startLine = idx;
+                }
             }
         }
 
@@ -988,12 +1010,16 @@ public partial class SpellCheckViewModel : ObservableObject
                 }
                 else
                 {
+                    // Declining to wrap back ends the run: the user chose to leave the lines above
+                    // the start unchecked, so nothing is left hanging for a later "continue".
+                    ScanCompleted = true;
                     Ok();
                 }
             }, DispatcherPriority.Background);
         }
         else
         {
+            ScanCompleted = true;
             Ok();
         }
     }


### PR DESCRIPTION
Opening the spell check with any line but the first one selected always asked **"Continue spell check from current line?"** - including on the very first run, where there is nothing to continue *from*.

Now the scan just starts at the current line, from its first word. The prompt is only asked when a spell check of this subtitle was left unfinished, which is the only case where "continue from current line" is a real choice (resume where you are now, or start over from the top).

Reaching the end of the subtitle still offers to wrap back to the top, so the lines above the starting point are not skipped - the user simply gets that question at the end instead of an unanswerable one at the start.

## How the session is tracked

- `SpellCheckViewModel.ScanCompleted` is set when the scan reaches the end of the subtitle - either straight through, or by declining the wrap-back-to-top offer.
- `MainViewModel` keeps `_spellCheckSessionInProgress = !result.ScanCompleted` and passes it into the next run. It is cleared in `ResetSubtitle`, so a newly opened subtitle starts fresh.

So: closing the window early (Escape / X / Done mid-scan) leaves a session open and the next run asks; a completed run does not.

Existing tests pass (665).

🤖 Generated with [Claude Code](https://claude.com/claude-code)