### PR TITLE
Add former country names (en, nl, de, fr, es, pt) and load the region specific names lists

### DIFF
--- a/Dictionaries/de_names.xml
+++ b/Dictionaries/de_names.xml
@@ -3,6 +3,7 @@
 <names>
   <blacklist />
   <name>Abelard</name>
+  <name>Abessinien</name>
   <name>Ada</name>
   <name>Adal</name>
   <name>Adalard</name>
@@ -252,9 +253,11 @@
   <name>Burlin</name>
   <name>Burnard</name>
   <name>Burnell</name>
+  <name>Byzanz</name>
   <name>Cabo Verde</name>
   <name>Caicos-Inseln</name>
   <name>Ceuta und Melilla</name>
+  <name>Ceylon</name>
   <name>Chlodwig</name>
   <name>Chriselda</name>
   <name>Clarimond</name>
@@ -469,6 +472,7 @@
   <name>Garry</name>
   <name>Garvyn</name>
   <name>GB</name>
+  <name>Gallien</name>
   <name>Geneve</name>
   <name>Genevie</name>
   <name>Genivee</name>
@@ -653,6 +657,7 @@
   <name>Joli</name>
   <name>Jordanien</name>
   <name>Josefa</name>
+  <name>Jugoslawien</name>
   <name>Jurgen</name>
   <name>Kaimaninseln</name>
   <name>Kaiser</name>
@@ -679,6 +684,7 @@
   <name>Karola</name>
   <name>Karolina</name>
   <name>Karoline</name>
+  <name>Karthago</name>
   <name>Kasachstan</name>
   <name>Katar</name>
   <name>Katchen</name>
@@ -707,6 +713,7 @@
   <name>Kongo-Kinshasa</name>
   <name>Konni</name>
   <name>Konrad</name>
+  <name>Konstantinopel</name>
   <name>Kord</name>
   <name>Kort</name>
   <name>Kroatien</name>
@@ -858,6 +865,7 @@
   <name>Meinyard</name>
   <name>Melanesien</name>
   <name>Melisande</name>
+  <name>Mesopotamien</name>
   <name>Mexiko</name>
   <name>Mikronesien</name>
   <name>Mikronesisches Inselgebiet</name>
@@ -905,6 +913,7 @@
   <name>Norwegen</name>
   <name>Ostafrika</name>
   <name>Ostasien</name>
+  <name>Ostdeutschland</name>
   <name>Österreich</name>
   <name>Osteuropa</name>
   <name>Osttimor</name>
@@ -919,6 +928,7 @@
   <name>Peppi</name>
   <name>Per</name>
   <name>Perahta</name>
+  <name>Persien</name>
   <name>Petronilla</name>
   <name>Petronille</name>
   <name>Philipinna</name>
@@ -929,6 +939,7 @@
   <name>Pjotr Tschaikowski</name>
   <name>Polen</name>
   <name>Polynesien</name>
+  <name>Preußen</name>
   <name>Raimond</name>
   <name>Raimundo</name>
   <name>Rainart</name>
@@ -950,6 +961,7 @@
   <name>Renke</name>
   <name>Republik Kongo</name>
   <name>Republik Moldau</name>
+  <name>Rhodesien</name>
   <name>Réunion</name>
   <name>Reymond</name>
   <name>Reymundo</name>
@@ -1045,6 +1057,7 @@
   <name>Serilda</name>
   <name>Sherman</name>
   <name>Shermon</name>
+  <name>Siam</name>
   <name>Sibirien</name>
   <name>Sicilien</name>
   <name>Siegfried</name>
@@ -1069,6 +1082,7 @@
   <name>Solvig</name>
   <name>Sonderverwaltungsregion Hongkong</name>
   <name>Sonderverwaltungsregion Macau</name>
+  <name>Sowjetunion</name>
   <name>Spanien</name>
   <name>Spengler</name>
   <name>Spitzbergen</name>
@@ -1132,6 +1146,7 @@
   <name>Tschaikowski</name>
   <name>Tschechien</name>
   <name>Tschechische Republik</name>
+  <name>Tschechoslowakei</name>
   <name>Tugenda</name>
   <name>Tunesien</name>
   <name>Türkei</name>
@@ -1203,6 +1218,7 @@
   <name>Wendel</name>
   <name>Westafrika</name>
   <name>Westasien</name>
+  <name>Westdeutschland</name>
   <name>Westeuropa</name>
   <name>Westsahara</name>
   <name>Wido</name>
@@ -1244,6 +1260,7 @@
   <name>Wolfrik</name>
   <name>Yseult</name>
   <name>Zacharia</name>
+  <name>Zaire</name>
   <name>Zelig</name>
   <name>Zentralafrika</name>
   <name>Zentralafrikanische Republik</name>

--- a/Dictionaries/en_names.xml
+++ b/Dictionaries/en_names.xml
@@ -13,6 +13,7 @@
 	<name>Abbie</name>
 	<name>Abi</name>
 	<name>Abril</name>
+	<name>Abyssinia</name>
 	<name>Ada</name>
 	<name>Adalyn</name>
 	<name>Adalynn</name>
@@ -147,6 +148,7 @@
 	<name>Ashlyn</name>
 	<name>Ashlynn</name>
 	<name>Ashtyn</name>
+	<name>Assyria</name>
 	<name>Athens</name>
 	<name>Atlantic</name>
 	<name>Atticus</name>
@@ -185,6 +187,7 @@
 	<name>Azerbaijani</name>
 	<name>Azerbaijanis</name>
 	<name>Azog</name>
+	<name>Babylonia</name>
 	<name>Bacharach</name>
 	<name>Baggins</name>
 	<name>Bahamian</name>
@@ -241,6 +244,7 @@
 	<name>Boba Fett</name>
 	<name>Boca Chica</name>
 	<name>Bodhi</name>
+	<name>Bohemia</name>
 	<name>Bolinski</name>
 	<name>Bolivian</name>
 	<name>Bolivians</name>
@@ -308,6 +312,7 @@
 	<name>Burnham</name>
 	<name>Burundian</name>
 	<name>Burundians</name>
+	<name>Byzantium</name>
 	<name>C.I.A.</name>
 	<name>C.S.I.</name>
 	<name>Cade</name>
@@ -351,6 +356,7 @@
 	<name>Carly</name>
 	<name>Carmelo</name>
 	<name>Carolyn</name>
+	<name>Carthage</name>
 	<name>Casen</name>
 	<name>Cassablanca</name>
 	<name>Cassandra</name>
@@ -370,6 +376,7 @@
 	<name>Central Asia</name>
 	<name>Ceuta &amp; Melilla</name>
 	<name>Ceuta and Melilla</name>
+	<name>Ceylon</name>
 	<name>Chadian</name>
 	<name>Chadians</name>
 	<name>Chana</name>
@@ -418,6 +425,7 @@
 	<name>Congolese</name>
 	<name>Connelly</name>
 	<name>Connery</name>
+	<name>Constantinople</name>
 	<name>Cook Islands</name>
 	<name>Copenhagen</name>
 	<name>Corban</name>
@@ -442,6 +450,7 @@
 	<name>Czech Republic</name>
 	<name>Czech</name>
 	<name>Czechia</name>
+	<name>Czechoslovakia</name>
 	<name>Czechs</name>
 	<name>Côte d’Ivoire</name>
 	<name>D'arcy</name>
@@ -453,6 +462,7 @@
 	<name>Dacca</name>
 	<name>Dahlia</name>
 	<name>Dahmer</name>
+	<name>Dahomey</name>
 	<name>Dalia</name>
 	<name>Damari</name>
 	<name>Damarion</name>
@@ -514,6 +524,7 @@
 	<name>E.T.</name>
 	<name>Ean</name>
 	<name>Earl Grey</name>
+	<name>East Germany</name>
 	<name>East Timor</name>
 	<name>East Timorese</name>
 	<name>Eastern Africa</name>
@@ -662,6 +673,7 @@
 	<name>Gambians</name>
 	<name>Garfield</name>
 	<name>Gauge</name>
+	<name>Gaul</name>
 	<name>Gavyn</name>
 	<name>Genesis</name>
 	<name>Georgian</name>
@@ -1325,6 +1337,7 @@
 	<name>Melanesia</name>
 	<name>Melany</name>
 	<name>Melina</name>
+	<name>Mesopotamia</name>
 	<name>Messiah</name>
 	<name>Mexicans</name>
 	<name>Miah</name>
@@ -1359,6 +1372,7 @@
 	<name>Mongolians</name>
 	<name>Montenegrins</name>
 	<name>Monégasque</name>
+	<name>Moravia</name>
 	<name>Moria</name>
 	<name>Moriah</name>
 	<name>Moroccans</name>
@@ -1432,6 +1446,7 @@
 	<name>Nova Scotia</name>
 	<name>Novak Djokovic</name>
 	<name>Nutella</name>
+	<name>Nyasaland</name>
 	<name>Nyla</name>
 	<name>Nylah</name>
 	<name>Nùñez</name>
@@ -1484,9 +1499,11 @@
 	<name>Pepperdine</name>
 	<name>Peridea</name>
 	<name>Perla</name>
+	<name>Persia</name>
 	<name>Perth</name>
 	<name>Peruvians</name>
 	<name>Philippines</name>
+	<name>Phoenicia</name>
 	<name>Pichushkin</name>
 	<name>Pickton</name>
 	<name>Pinella</name>
@@ -1498,6 +1515,7 @@
 	<name>Poles</name>
 	<name>Polish</name>
 	<name>Polynesia</name>
+	<name>Pomerania</name>
 	<name>Pont de l'Alma</name>
 	<name>Port Morsby</name>
 	<name>Port of Spain</name>
@@ -1516,6 +1534,7 @@
 	<name>President Ronald Reagan</name>
 	<name>President Trump</name>
 	<name>Princess</name>
+	<name>Prussia</name>
 	<name>Puerto Ricans</name>
 	<name>Pusan</name>
 	<name>Pycroft</name>
@@ -1560,6 +1579,7 @@
 	<name>Reyna</name>
 	<name>Rhett</name>
 	<name>Rhiannon</name>
+	<name>Rhodesia</name>
 	<name>Rhys</name>
 	<name>Ridgeland</name>
 	<name>Ridgemont</name>	
@@ -1675,11 +1695,13 @@
 	<name>Sherlyn</name>
 	<name>Shiloh</name>
 	<name>Shumway</name>
+	<name>Siam</name>
 	<name>Siberia</name>
 	<name>Siena</name>
 	<name>Sienna</name>
 	<name>Sierra Leonean</name>
 	<name>Sierra Leoneans</name>
+	<name>Silesia</name>
 	<name>Simon Cowell</name>
 	<name>Singapore</name>
 	<name>Singaporean</name>
@@ -1724,6 +1746,7 @@
 	<name>Southern Africa</name>
 	<name>Southern Asia</name>
 	<name>Southern Europe</name>
+	<name>Soviet Union</name>
 	<name>Spain</name>
 	<name>Spaniards</name>
 	<name>Spanish</name>
@@ -1779,6 +1802,7 @@
 	<name>Talon</name>
 	<name>Tamia</name>
 	<name>Tamils</name>
+	<name>Tanganyika</name>
 	<name>Tanzanian</name>
 	<name>Tanzanians</name>
 	<name>Taraji</name>
@@ -1826,6 +1850,7 @@
 	<name>Tongans</name>
 	<name>Tooley</name>
 	<name>Toppan</name>
+	<name>Transvaal</name>
 	<name>Trevon</name>
 	<name>Trey</name>
 	<name>Trinidad &amp; Tobago</name>
@@ -1858,6 +1883,7 @@
 	<name>UK</name>
 	<name>UN</name>
 	<name>US</name>
+	<name>USSR</name>
 	<name>Uber</name>
 	<name>Ugandan</name>
 	<name>Ugandans</name>
@@ -1871,6 +1897,7 @@
 	<name>United Nations</name>
 	<name>United States of America</name>
 	<name>United States</name>
+	<name>Upper Volta</name>
 	<name>Uriah</name>
 	<name>Uriel</name>
 	<name>Urijah</name>
@@ -1912,6 +1939,7 @@
 	<name>Welsh</name>
 	<name>Wembley</name>
 	<name>Wes</name>
+	<name>West Germany</name>
 	<name>Western Africa</name>
 	<name>Western Asia</name>
 	<name>Western Europe</name>
@@ -1954,6 +1982,7 @@
 	<name>Yesenia</name>
 	<name>Yokohama</name>
 	<name>Yoselin</name>
+	<name>Yugoslavia</name>
 	<name>Yuliana</name>
 	<name>Yusuf</name>
 	<name>Zachariah</name>
@@ -1962,10 +1991,12 @@
 	<name>Zackery</name>
 	<name>Zaiden</name>
 	<name>Zain</name>
+	<name>Zaire</name>
 	<name>Zambian</name>
 	<name>Zambians</name>
 	<name>Zander</name>
 	<name>Zaniyah</name>
+	<name>Zanzibar</name>
 	<name>Zara</name>
 	<name>Zarah</name>
 	<name>Zaria</name>

--- a/Dictionaries/es_names.xml
+++ b/Dictionaries/es_names.xml
@@ -6,6 +6,7 @@
   <name>Aarón</name>
   <name>Abdulabri</name>
   <name>Abi</name>
+  <name>Abisinia</name>
   <name>Abu</name>
   <name>Aby</name>
   <name>Abyssiania</name>
@@ -146,6 +147,7 @@
   <name>Birmania</name>
   <name>Biscione</name>
   <name>Biskek</name>
+  <name>Bizancio</name>
   <name>Bjarne</name>
   <name>Black</name>
   <name>Blanc</name>
@@ -215,12 +217,14 @@
   <name>Caron</name>
   <name>Carreiro</name>
   <name>Carrington</name>
+  <name>Cartago</name>
   <name>Carver</name>
   <name>Casso</name>
   <name>Casson</name>
   <name>Castilla</name>
   <name>Catar</name>
   <name>Caterina</name>
+  <name>Ceilán</name>
   <name>Celso</name>
   <name>Cemre</name>
   <name>Centroamérica</name>
@@ -230,6 +234,7 @@
   <name>Champagne</name>
   <name>Charger</name>
   <name>Chateau</name>
+  <name>Checoslovaquia</name>
   <name>Chelmsford</name>
   <name>Chemicals</name>
   <name>Chequia</name>
@@ -394,6 +399,7 @@
   <name>Gabón</name>
   <name>Gadafi</name>
   <name>Gaddafi</name>
+  <name>Galia</name>
   <name>Galicia</name>
   <name>Gammelgård</name>
   <name>Gårdmand</name>
@@ -734,6 +740,7 @@
   <name>Mercuri</name>
   <name>Mercy</name>
   <name>Merve</name>
+  <name>Mesopotamia</name>
   <name>Metropole</name>
   <name>Mette</name>
   <name>México</name>
@@ -855,6 +862,7 @@
   <name>Pensilvania</name>
   <name>Pepete</name>
   <name>Pernille</name>
+  <name>Persia</name>
   <name>Perséfone</name>
   <name>Perú</name>
   <name>Perugino</name>
@@ -931,6 +939,7 @@
   <name>Road</name>
   <name>Roco</name>
   <name>Roddenberry</name>
+  <name>Rodesia</name>
   <name>Rogo</name>
   <name>Rohan</name>
   <name>Rohypnol</name>
@@ -1005,6 +1014,7 @@
   <name>Shaozu</name>
   <name>Shkuro</name>
   <name>Shona</name>
+  <name>Siam</name>
   <name>Sid</name>
   <name>Sierra Leona</name>
   <name>Signora</name>
@@ -1155,6 +1165,7 @@
   <name>Ulrik</name>
   <name>Umal</name>
   <name>Unión Europea</name>
+  <name>Unión Soviética</name>
   <name>Urbino</name>
   <name>URSS</name>
   <name>Uzbekistán</name>
@@ -1217,7 +1228,9 @@
   <name>Yu</name>
   <name>Yuans</name>
   <name>YUNNAN</name>
+  <name>Yugoslavia</name>
   <name>Zabalda</name>
+  <name>Zaire</name>
   <name>Zanu</name>
   <name>Zarrategui</name>
   <name>Zavrov</name>

--- a/Dictionaries/fr_names.xml
+++ b/Dictionaries/fr_names.xml
@@ -15,6 +15,7 @@
   <name>Abigaïl</name>
   <name>Abondance</name>
   <name>Absalon</name>
+  <name>Abyssinie</name>
   <name>Acace</name>
   <name>Acaciane</name>
   <name>Acacie</name>
@@ -371,6 +372,7 @@
   <name>Brunon</name>
   <name>Bruxelles</name>
   <name>Bulgarie</name>
+  <name>Byzance</name>
   <name>Calixte</name>
   <name>Calliste</name>
   <name>Cambodge</name>
@@ -385,9 +387,11 @@
   <name>Caribert</name>
   <name>Carle</name>
   <name>Carloman</name>
+  <name>Carthage</name>
   <name>Cassandre</name>
   <name>Cassien</name>
   <name>Cathaline</name>
+  <name>Ceylan</name>
   <name>Cécile</name>
   <name>Cédric</name>
   <name>Célestin</name>
@@ -433,6 +437,7 @@
   <name>Constance</name>
   <name>Constant</name>
   <name>Constantin</name>
+  <name>Constantinople</name>
   <name>Copenhague</name>
   <name>Coralie</name>
   <name>Coraline</name>
@@ -813,6 +818,7 @@
   <name>Murielle</name>
   <name>Myanmar</name>
   <name>Mylène</name>
+  <name>Mésopotamie</name>
   <name>Nadège</name>
   <name>Naël</name>
   <name>Namibie</name>
@@ -865,6 +871,8 @@
   <name>Pauline</name>
   <name>Pays-Bas</name>
   <name>Pays-Bas caribéens</name>
+  <name>Perse</name>
+  <name>Prusse</name>
   <name>Pécine</name>
   <name>Pélagie</name>
   <name>Pénélope</name>
@@ -899,6 +907,7 @@
   <name>Raymonde</name>
   <name>RD Congo</name>
   <name>RDC</name>
+  <name>Rhodésie</name>
   <name>Régine</name>
   <name>région micronésienne</name>
   <name>régions éloignées de l’Océanie</name>
@@ -952,6 +961,7 @@
   <name>Sénégal</name>
   <name>Serbie</name>
   <name>Serge</name>
+  <name>Siam</name>
   <name>Séverin</name>
   <name>Séverine</name>
   <name>Sibylle</name>
@@ -995,6 +1005,7 @@
   <name>Taurin</name>
   <name>Tchad</name>
   <name>Tchaïkovski</name>
+  <name>Tchécoslovaquie</name>
   <name>Tchéquie</name>
   <name>Terres australes françaises</name>
   <name>Territoire britannique de l’océan Indien</name>
@@ -1030,6 +1041,7 @@
   <name>Ulrich</name>
   <name>Ulysse</name>
   <name>Union européenne</name>
+  <name>Union soviétique</name>
   <name>Urbain</name>
   <name>Uther</name>
   <name>Valentin</name>
@@ -1056,6 +1068,7 @@
   <name>Yémen</name>
   <name>Yoann</name>
   <name>Yolande</name>
+  <name>Yougoslavie</name>
   <name>Ysaline</name>
   <name>Yse</name>
   <name>Ysé</name>
@@ -1068,6 +1081,7 @@
   <name>Zacharie</name>
   <name>Zaché</name>
   <name>Zambie</name>
+  <name>Zaïre</name>
   <name>Zéphir</name>
   <name>Zéphirin</name>
   <name>Zoé</name>

--- a/Dictionaries/nl_names.xml
+++ b/Dictionaries/nl_names.xml
@@ -18,6 +18,7 @@
     <name>Tor</name>
     <name>Welk</name>
   </blacklist>
+  <name>Abessinië</name>
   <name>Afghanistan</name>
   <name>Afrika</name>
   <name>Åland</name>
@@ -56,16 +57,19 @@
   <name>Britse Maagdeneilanden</name>
   <name>Bulgarije</name>
   <name>Bulgarĳe</name>
+  <name>Byzantium</name>
   <name>Caicoseilanden</name>
   <name>Cambodja</name>
   <name>Canada</name>
   <name>Canarische Eilanden</name>
   <name>Caribisch gebied</name>
   <name>Caribisch Nederland</name>
+  <name>Carthago</name>
   <name>Centraal-Afrika</name>
   <name>Centraal-Afrikaanse Republiek</name>
   <name>Centraal-Azië</name>
   <name>Ceuta en Melilla</name>
+  <name>Ceylon</name>
   <name>Chili</name>
   <name>Christmaseiland</name>
   <name>Clipperton</name>
@@ -73,6 +77,7 @@
   <name>Comoren</name>
   <name>Congo-Brazzaville</name>
   <name>Congo-Kinshasa</name>
+  <name>Constantinopel</name>
   <name>Cookeilanden</name>
   <name>Corsica</name>
   <name>Curaçao</name>
@@ -107,6 +112,7 @@
   <name>Franse Gebieden in de zuidelĳke Indische Oceaan</name>
   <name>Frans-Guyana</name>
   <name>Frans-Polynesië</name>
+  <name>Gallië</name>
   <name>Georgië</name>
   <name>Griekenland</name>
   <name>Groenland</name>
@@ -134,6 +140,7 @@
   <name>Italië</name>
   <name>Ivoorkust</name>
   <name>Jemen</name>
+  <name>Joegoslavië</name>
   <name>Jordanië</name>
   <name>Kaaimaneilanden</name>
   <name>Kaapverdië</name>
@@ -163,6 +170,7 @@
   <name>Marshalleilanden</name>
   <name>Mauritanië</name>
   <name>Melanesië</name>
+  <name>Mesopotamië</name>
   <name>Micronesische regio</name>
   <name>Midden-Amerika</name>
   <name>Moldavië</name>
@@ -191,6 +199,7 @@
   <name>Oezbekistan</name>
   <name>Oost-Afrika</name>
   <name>Oost-Azië</name>
+  <name>Oost-Duitsland</name>
   <name>Oostenrijk</name>
   <name>Oostenrĳk</name>
   <name>Oost-Europa</name>
@@ -201,14 +210,17 @@
   <name>Papoea-Nieuw-Guinea</name>
   <name>Parijs</name>
   <name>Parĳs</name>
+  <name>Perzië</name>
   <name>Pitcairneilanden</name>
   <name>Pjotr Iljitsj Tsjajkovski</name>
   <name>Pjotr Tsjajkovski</name>
   <name>Polen</name>
   <name>Polynesië</name>
+  <name>Pruisen</name>
   <name>Republiek Congo</name>
   <name>Republiek Ivoorkust</name>
   <name>Republiek Kaapverdië</name>
+  <name>Rhodesië</name>
   <name>Réunion</name>
   <name>Roemenië</name>
   <name>Rusland</name>
@@ -223,6 +235,7 @@
   <name>Saoedi-Arabië</name>
   <name>Sardinië</name>
   <name>Servië</name>
+  <name>Siam</name>
   <name>Siberië</name>
   <name>Sicilië</name>
   <name>Singapore</name>
@@ -234,6 +247,7 @@
   <name>Soedan</name>
   <name>Solzjenitsyn</name>
   <name>Somalië</name>
+  <name>Sovjet-Unie</name>
   <name>Spanje</name>
   <name>Spitsbergen</name>
   <name>Stille Oceaan</name>
@@ -249,6 +263,7 @@
   <name>Tsjajkovski</name>
   <name>Tsjechië</name>
   <name>Tsjechische Republiek</name>
+  <name>Tsjecho-Slowakije</name>
   <name>Tsjetsjenië</name>
   <name>Tunesië</name>
   <name>Turkije</name>
@@ -270,9 +285,11 @@
   <name>Wenen</name>
   <name>West-Afrika</name>
   <name>West-Azië</name>
+  <name>West-Duitsland</name>
   <name>Westelijke Sahara</name>
   <name>Westelĳke Sahara</name>
   <name>West-Europa</name>
+  <name>Zaïre</name>
   <name>Zuid-Afrika</name>
   <name>Zuid-Amerika</name>
   <name>Zuid-Azië</name>

--- a/Dictionaries/pt_BR_names.xml
+++ b/Dictionaries/pt_BR_names.xml
@@ -12,6 +12,7 @@
   <name>Abelino</name>
   <name>Abimael</name>
   <name>Abissail</name>
+  <name>Abissínia</name>
   <name>Abna</name>
   <name>Abraão</name>
   <name>Abraim</name>
@@ -692,6 +693,7 @@
   <name>Birmânia</name>
   <name>Bitia</name>
   <name>Biute</name>
+  <name>Bizâncio</name>
   <name>Blacina</name>
   <name>Blandina</name>
   <name>Blásia</name>
@@ -783,6 +785,7 @@
   <name>Canto</name>
   <name>Capilupi</name>
   <name>Cardia</name>
+  <name>Cartago</name>
   <name>Cárdia</name>
   <name>Cardinal</name>
   <name>Cardo</name>
@@ -848,6 +851,7 @@
   <name>Catharina</name>
   <name>Catherina</name>
   <name>Cati</name>
+  <name>Ceilão</name>
   <name>Cátia</name>
   <name>Catiana</name>
   <name>Catila</name>
@@ -1022,6 +1026,7 @@
   <name>Congo-Quinxassa</name>
   <name>Consolação</name>
   <name>Consolino</name>
+  <name>Constantinopla</name>
   <name>Constança</name>
   <name>Constância</name>
   <name>Constâncio</name>
@@ -2018,6 +2023,7 @@
   <name>Gutierre</name>
   <name>Guto</name>
   <name>Guy</name>
+  <name>Gália</name>
   <name>Habacuc</name>
   <name>Habacuque</name>
   <name>Hadassa</name>
@@ -2372,6 +2378,7 @@
   <name>Itália</name>
   <name>Ítalo</name>
   <name>Itiene</name>
+  <name>Iugoslávia</name>
   <name>Iunara</name>
   <name>Iuran</name>
   <name>Iúri</name>
@@ -3017,6 +3024,7 @@
   <name>Magno</name>
   <name>Magnólia</name>
   <name>Mago</name>
+  <name>Mesopotâmia</name>
   <name>Mágui</name>
   <name>Maguilde</name>
   <name>Maiara</name>
@@ -3857,8 +3865,10 @@
   <name>Profírio</name>
   <name>Prtik</name>
   <name>Prudência</name>
+  <name>Prússia</name>
   <name>Pureza</name>
   <name>Purificação</name>
+  <name>Pérsia</name>
   <name>Quaiela</name>
   <name>Quar</name>
   <name>Quaresma</name>
@@ -3990,6 +4000,7 @@
   <name>Robim</name>
   <name>Roboredo</name>
   <name>Roby</name>
+  <name>Rodésia</name>
   <name>Roça</name>
   <name>Roclina</name>
   <name>Roderico</name>
@@ -4456,6 +4467,7 @@
   <name>Tázia</name>
   <name>Tchaikovski</name>
   <name>Tchaina</name>
+  <name>Tchecoslováquia</name>
   <name>Tchéquia</name>
   <name>Tedi</name>
   <name>Tédi</name>
@@ -4556,6 +4568,7 @@
   <name>Umbolina</name>
   <name>Una</name>
   <name>União Europeia</name>
+  <name>União Soviética</name>
   <name>Unna</name>
   <name>Urânia</name>
   <name>Urbalina</name>
@@ -4765,6 +4778,7 @@
   <name>Zaido</name>
   <name>Zaion</name>
   <name>Zaira</name>
+  <name>Zaire</name>
   <name>Zália</name>
   <name>Zâmbia</name>
   <name>Zamorano</name>

--- a/Dictionaries/pt_PT_names.xml
+++ b/Dictionaries/pt_PT_names.xml
@@ -28,6 +28,7 @@
   <name>Abigaïl</name>
   <name>Abimael</name>
   <name>Abissail</name>
+  <name>Abissínia</name>
   <name>Abna</name>
   <name>Abraão</name>
   <name>Abraim</name>
@@ -798,6 +799,7 @@
   <name>Birmânia</name>
   <name>Bitia</name>
   <name>Biute</name>
+  <name>Bizâncio</name>
   <name>Blacina</name>
   <name>Blandina</name>
   <name>Blásia</name>
@@ -909,6 +911,7 @@
   <name>Cardo</name>
   <name>Carel</name>
   <name>Carela</name>
+  <name>Cartago</name>
   <name>Cáren</name>
   <name>Carenina</name>
   <name>Cária</name>
@@ -949,6 +952,7 @@
   <name>Carrie</name>
   <name>Carsta</name>
   <name>Cassandra</name>
+  <name>Ceilão</name>
   <name>Cássia</name>
   <name>Cassiano</name>
   <name>Cassilda</name>
@@ -1032,6 +1036,7 @@
   <name>Charlene</name>
   <name>Charli</name>
   <name>Charlie</name>
+  <name>Checoslováquia</name>
   <name>Cheila</name>
   <name>Cheldecarlo</name>
   <name>Cheldoncarlo</name>
@@ -1158,6 +1163,7 @@
   <name>Congo-Quinxassa</name>
   <name>Consolação</name>
   <name>Consolino</name>
+  <name>Constantinopla</name>
   <name>Constança</name>
   <name>Constância</name>
   <name>Constâncio</name>
@@ -2054,6 +2060,7 @@
   <name>Gerson</name>
   <name>Gerta</name>
   <name>Gerusa</name>
+  <name>Gália</name>
   <name>Gésaro</name>
   <name>Gesélia</name>
   <name>Géssi</name>
@@ -2762,6 +2769,7 @@
   <name>Judá</name>
   <name>Judia</name>
   <name>Judice</name>
+  <name>Jugoslávia</name>
   <name>Júdice</name>
   <name>Juliana</name>
   <name>Juliano</name>
@@ -3397,6 +3405,7 @@
   <name>Mavília</name>
   <name>Maxfrede</name>
   <name>Maxfredo</name>
+  <name>Mesopotâmia</name>
   <name>Máxima</name>
   <name>Maximiano</name>
   <name>Maximino</name>
@@ -4059,9 +4068,11 @@
   <name>Profírio</name>
   <name>Prtik</name>
   <name>Prudência</name>
+  <name>Prússia</name>
   <name>Pureza</name>
   <name>Purificação</name>
   <name>Pyeongyang</name>
+  <name>Pérsia</name>
   <name>Quaiela</name>
   <name>Quar</name>
   <name>Quaresma</name>
@@ -4202,6 +4213,7 @@
   <name>Rodolfo</name>
   <name>Rodrigo</name>
   <name>Rodrigues</name>
+  <name>Rodésia</name>
   <name>Roena</name>
   <name>Rogélia</name>
   <name>Rogélio</name>
@@ -4786,6 +4798,7 @@
   <name>Umbolina</name>
   <name>Una</name>
   <name>União Europeia</name>
+  <name>União Soviética</name>
   <name>Unna</name>
   <name>Urânia</name>
   <name>Urbalina</name>
@@ -4999,6 +5012,7 @@
   <name>Zaido</name>
   <name>Zaion</name>
   <name>Zaira</name>
+  <name>Zaire</name>
   <name>Zália</name>
   <name>Zâmbia</name>
   <name>Zamorano</name>

--- a/src/libse/Dictionaries/NameList.cs
+++ b/src/libse/Dictionaries/NameList.cs
@@ -28,6 +28,7 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
 
             LoadNamesList(GetLocalNamesUserFileName()); // e.g: en_names_user.xml (culture sensitive)
             LoadNamesList(GetLocalNamesFileName()); // e.g: en_names.xml (culture sensitive)
+            LoadNamesList(GetLocalCultureNamesFileName()); // e.g: pt_BR_names.xml (region specific)
             if (useOnlineNameList && !string.IsNullOrEmpty(namesUrl))
             {
                 try
@@ -100,6 +101,21 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
             }
 
             return Path.Combine(_dictionaryFolder, twoLetterIsoLanguageName + "_names.xml");
+        }
+
+        /// <summary>
+        /// Region specific names file, e.g. pt_BR_names.xml. Portuguese ships one list per region
+        /// (pt_PT / pt_BR) and no neutral pt_names.xml, so without this they were never loaded.
+        /// Returns an empty string for a neutral language name; LoadNamesList ignores a missing file.
+        /// </summary>
+        private string GetLocalCultureNamesFileName()
+        {
+            if (LanguageName.Length <= 2)
+            {
+                return string.Empty;
+            }
+
+            return Path.Combine(_dictionaryFolder, LanguageName + "_names.xml");
         }
 
         private void LoadNamesList(string fileNameOrUrl)

--- a/src/ui/Logic/Dictionaries/SeNamesList.cs
+++ b/src/ui/Logic/Dictionaries/SeNamesList.cs
@@ -28,6 +28,7 @@ public class SeNamesList : INamesList
 
         LoadNamesList(GetLocalNamesUserFileName()); // e.g: en_names_user.xml (culture sensitive)
         LoadNamesList(GetLocalNamesFileName()); // e.g: en_names.xml (culture sensitive)
+        LoadNamesList(GetLocalCultureNamesFileName()); // e.g: pt_BR_names.xml (region specific)
         LoadNamesList(Path.Combine(_dictionaryFolder, "names.xml"));
 
         foreach (var name in _blackList)
@@ -265,6 +266,21 @@ public class SeNamesList : INamesList
         }
 
         return Path.Combine(_dictionaryFolder, twoLetterIsoLanguageName + "_names.xml");
+    }
+
+    /// <summary>
+    /// Region specific names file, e.g. pt_BR_names.xml. Portuguese ships one list per region
+    /// (pt_PT / pt_BR) and no neutral pt_names.xml, so without this they were never loaded.
+    /// Returns an empty string for a neutral language name; LoadNamesList ignores a missing file.
+    /// </summary>
+    private string GetLocalCultureNamesFileName()
+    {
+        if (LanguageName.Length <= 2)
+        {
+            return string.Empty;
+        }
+
+        return Path.Combine(_dictionaryFolder, LanguageName + "_names.xml");
     }
 
     private void LoadNamesList(string fileNameOrUrl)

--- a/tests/UI/Features/SpellCheck/FormerCountryNamesTests.cs
+++ b/tests/UI/Features/SpellCheck/FormerCountryNamesTests.cs
@@ -1,0 +1,59 @@
+using Nikse.SubtitleEdit.Core.Dictionaries;
+using System;
+using System.IO;
+
+namespace UITests.Features.SpellCheck;
+
+// Former countries were missing from the names lists, so name casing never fixed them (#12465).
+// Portuguese ships its lists per region (pt_PT_names.xml / pt_BR_names.xml) and has no neutral
+// pt_names.xml, so NameList - which reduced the language to its two letter code - never loaded them.
+public class FormerCountryNamesTests
+{
+    private static string DictionariesFolder()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "Dictionaries")))
+        {
+            dir = dir.Parent;
+        }
+
+        return Path.Combine(dir!.FullName, "Dictionaries");
+    }
+
+    private static bool HasName(string language, string name)
+    {
+        var nameList = new NameList(DictionariesFolder(), language, false, string.Empty);
+        return nameList.GetNames().Contains(name) || nameList.GetMultiNames().Contains(name);
+    }
+
+    [Theory]
+    [InlineData("en_US", "Yugoslavia")]
+    [InlineData("en_US", "Czechoslovakia")]
+    [InlineData("en_US", "Soviet Union")]
+    [InlineData("nl_NL", "Joegoslavië")]
+    [InlineData("nl_NL", "Tsjecho-Slowakije")]
+    [InlineData("de_DE", "Jugoslawien")]
+    [InlineData("de_DE", "Tschechoslowakei")]
+    [InlineData("fr_FR", "Yougoslavie")]
+    [InlineData("fr_FR", "Tchécoslovaquie")]
+    [InlineData("es_ES", "Checoslovaquia")]
+    [InlineData("es_ES", "Unión Soviética")]
+    [InlineData("pt_PT", "Jugoslávia")]
+    [InlineData("pt_PT", "Checoslováquia")]
+    [InlineData("pt_BR", "Iugoslávia")]
+    [InlineData("pt_BR", "Tchecoslováquia")]
+    public void FormerCountryIsInTheNamesList(string language, string name)
+    {
+        Assert.True(HasName(language, name), $"{name} is not in the {language} names list");
+    }
+
+    [Theory]
+    [InlineData("pt_PT")]
+    [InlineData("pt_BR")]
+    public void RegionSpecificNamesFileIsLoaded(string language)
+    {
+        // Guards the region specific load. "Abelardo" is in pt_PT_names.xml and pt_BR_names.xml but
+        // not in the shared names.xml, so it can only be found when the region file itself is read.
+        Assert.True(HasName(language, "Abelardo"), $"the {language} names file was not loaded");
+    }
+}


### PR DESCRIPTION
Fixes #12465 (except Catalan - see below).

Countries that no longer exist were missing from the names lists. Note the words are mostly already in the hunspell dictionaries, so **spell check never flagged them** - what was missing is the *names list*, which drives name casing. So "yugoslavia" was never corrected to "Yugoslavia".

## Names added

| list | added |
|---|---|
| `en_names.xml` | 31 |
| `nl_names.xml` | 17 |
| `de_names.xml` | 17 |
| `fr_names.xml` | 14 |
| `es_names.xml` | 13 |
| `pt_PT_names.xml` | 14 |
| `pt_BR_names.xml` | 14 |

Includes the pairs from the issue (Joegoslavië/Tsjecho-Slowakije, Jugoslawien/Tschechoslowakei, Yougoslavie/Tchécoslovaquie, Yugoslavia/Checoslovaquia, Jugoslávia/Checoslováquia, Iugoslávia/Tchecoslováquia), Persia from fraternl's comment, and other historical states (Prussia, Rhodesia, Siam, Ceylon, Zaire, Mesopotamia, Carthage, Byzantium, Constantinople, Abyssinia, Soviet Union, East/West Germany, ...) in each language.

Each name is inserted in sorted position, so every file is pure additions - no existing line is touched and no BOM changes.

Names that collide with an ordinary lower-case word are deliberately left out: since the names list also drives name casing, French "Gaule" would capitalise "gaule" (a pole) in ordinary text.

## The Portuguese lists were never loaded

Portuguese ships its lists **per region** (`pt_PT_names.xml`, `pt_BR_names.xml`) and there is no neutral `pt_names.xml`. But `NameList` (and `SeNamesList`) reduce the language to its two-letter code and only ever look for `pt_names.xml`:

```csharp
// Converts e.g en_US => en (Neutral culture).
string twoLetterIsoLanguageName = LanguageName;
if (LanguageName.Length > 2)
{
    twoLetterIsoLanguageName = LanguageName.Substring(0, 2);
}
return Path.Combine(_dictionaryFolder, twoLetterIsoLanguageName + "_names.xml");
```

So both Portuguese lists - about **4800 names each** - are dead files that nothing reads, and adding names to them would have changed nothing. This PR loads the region specific file too. `LoadNamesList` no-ops on a missing file, so every other language is unaffected; the only lists that exist with a region suffix are the two Portuguese ones.

⚠️ This does mean ~4800 Portuguese names become active for the first time. That is presumably the point of the files, but it is a behaviour change worth knowing about.

## Verification

`FormerCountryNamesTests` asserts the names reach `NameList.GetNames()`/`GetMultiNames()` for all seven lists, plus two guards that the region specific file is actually loaded (using a name that exists only in the pt files, not in the shared `names.xml`). Without the loader fix, 6 of the 17 fail. All test suites pass (682 UI, 485 libse, 8 libuilogic, 233 seconv).

Catalan is in the issue but has no names list in the repo at all, so it is not covered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)