### PR TITLE
Update change log

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -6,6 +6,8 @@ Subtitle Edit Changelog
 v5.1.0-rc3 (TBD)
 
 * Spell check: start at the current line instead of asking "Continue spell check from current line?" - the question is now only asked when an earlier spell check was left unfinished
+* Names: load the region specific names list - the Portuguese lists (pt_PT_names.xml and pt_BR_names.xml, ~4800 names each) were never read, as only a neutral pt_names.xml was looked for
+* Names: add former countries like Yugoslavia, Czechoslovakia and Persia to the English, Dutch, German, French, Spanish and Portuguese names lists - thx fraternl
 * Spell check: fix the spell check window opening blank - no word, no text and no suggestions - unless the first line was selected
 * Live spell check: add spell check items to the subtitle grid context menu - suggestions, add to user dictionary and ignore all
 * Live spell check: picking a dictionary now also updates the subtitle grid, and no longer hides the spell check items in the text box context menu


### PR DESCRIPTION
Adds #12466 to the `v5.1.0-rc3` section - as two entries, since it is both a data change and a behaviour change:

* Names: load the region specific names list - the Portuguese lists (pt_PT_names.xml and pt_BR_names.xml, ~4800 names each) were never read, as only a neutral pt_names.xml was looked for
* Names: add former countries like Yugoslavia, Czechoslovakia and Persia to the English, Dutch, German, French, Spanish and Portuguese names lists - thx fraternl

🤖 Generated with [Claude Code](https://claude.com/claude-code)