### PR TITLE
Fix Chatterbox TTS rejecting every custom voice

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -307,7 +307,12 @@ public class ChatterboxTtsCpp : ITtsEngine
         var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
         var inputText = text;
 
-        // Per /v1/audio/speech: send full reference WAV path as the `voice` field.
+        // Send the bare file name as the `voice` field, not the path: the crispasr server rejects
+        // anything with a path separator ("'voice' must not contain '..', a leading '/' or '~', or
+        // path separators" - HTTP 400 invalid_voice), which used to fail every imported voice.
+        // The chatterbox backend then opens that name relative to its working directory, which is
+        // why the server is started in the voices folder (see EnsureServerRunningAsync). The name
+        // must keep its .wav extension - the backend does not append one.
         // Empty string falls back to the model's baked default voice.
         var payload = new Dictionary<string, object>
         {
@@ -316,7 +321,7 @@ public class ChatterboxTtsCpp : ITtsEngine
         };
         if (!string.IsNullOrEmpty(chatterboxVoice.FilePath))
         {
-            payload["voice"] = chatterboxVoice.FilePath;
+            payload["voice"] = Path.GetFileName(chatterboxVoice.FilePath);
 
             // Chatterbox gates voice cloning behind a consent attestation (CrispASR
             // returns HTTP 400 consent_required without it). The user supplies their
@@ -466,7 +471,13 @@ public class ChatterboxTtsCpp : ITtsEngine
             var port = FindFreeLoopbackPort();
             var psi = new ProcessStartInfo
             {
-                WorkingDirectory = Path.GetDirectoryName(exe) ?? GetSetFolder(),
+                // Run in the voices folder: the chatterbox backend opens the `voice` of a
+                // /v1/audio/speech request relative to its working directory. It does not resolve it
+                // against --voice-dir (that only backs the /v1/voices endpoints), and the server
+                // rejects a `voice` containing path separators, so this is what lets an imported
+                // reference WAV be found at all. Every path passed below is absolute, so nothing
+                // else depends on the working directory.
+                WorkingDirectory = GetSetVoicesFolder(),
                 FileName = exe,
                 UseShellExecute = false,
                 CreateNoWindow = true,
@@ -489,11 +500,10 @@ public class ChatterboxTtsCpp : ITtsEngine
             psi.ArgumentList.Add(port.ToString());
             // The crispasr server gates /v1/audio/speech requests with a `voice` field
             // behind --voice-dir being set ("warning: --voice-dir not set; … will reject
-            // requests with a 'voice' field"). Imported reference-WAV cloning sends an
-            // absolute path as `voice`, which the chatterbox backend resolves directly,
-            // but the server-level gate still applies. Pointing --voice-dir at our
-            // voices folder satisfies the gate and also makes /v1/voices reflect the
-            // imported WAVs.
+            // requests with a 'voice' field"). Pointing --voice-dir at our voices folder
+            // satisfies the gate and also makes /v1/voices reflect the imported WAVs. It
+            // does not make the chatterbox backend look the voice up in there though -
+            // that is what the working directory above is for.
             psi.ArgumentList.Add("--voice-dir");
             psi.ArgumentList.Add(GetSetVoicesFolder());
 


### PR DESCRIPTION
Text to speech → CrispASR Chatterbox failed for **every** imported voice:

```
Chatterbox TTS synthesis failed (400): {"error": {"message": "'voice' must not contain '..',
a leading '/' or '~', or path separators", "type": "invalid_request_error",
"code": "invalid_voice", "param": "voice"}}
```

## What was wrong

SE sent the **absolute path** of the reference WAV as the `voice` field. That matched the crispasr build this code was written against (the old comment even says "send full reference WAV path as the `voice` field"), but the current server validates `voice` and rejects any path separator.

Sending only the file name gets past the validator - but then the chatterbox backend fails to find it, because it opens `voice` **relative to its working directory**. It does *not* resolve it against `--voice-dir`; that flag only backs the `/v1/voices` endpoints and the server-level gate. SE started the server in the CrispASR executable's folder, so the file was not there:

```
chatterbox: native WAV cloning failed.
  Tried 24 kHz: could not open: G5_2_1A.M1U1.wav
```

Both had to change together, which is why this was not a one-liner.

## Fix

- Send `Path.GetFileName(...)` as `voice`, keeping the `.wav` extension (the backend appends none - an extension-less name fails to open).
- Start the crispasr server with its working directory set to the voices folder. Every path SE passes it (`-m`, `--codec-model`, `--voice-dir`) is absolute, so nothing else depends on the working directory.

## Verification (against the shipped crispasr binary, chatterbox backend)

| `voice` | working dir | result |
|---|---|---|
| absolute path | CrispASR folder | **HTTP 400** `invalid_voice` (the reported bug) |
| `G5_2_1A.M1U1.wav` | CrispASR folder | **HTTP 500** `synthesis failed (backend returned empty audio)`, log: `could not open` |
| `G5_2_1A.M1U1` (no ext) | voices folder | **HTTP 500**, log: `could not open: G5_2_1A.M1U1` |
| `G5_2_1A.M1U1.wav` | voices folder | **HTTP 200**, 57,802 byte `WAVE audio, Microsoft PCM, 16 bit, mono 24000 Hz` ✅ |

The last row is exactly what this PR now sends.

Worth noting for later: `GET /v1/voices` lists voices *without* the extension (`{"name": "G5_2_1A.M1U1", "format": "wav"}`), so if a future crispasr resolves `voice` against `--voice-dir` properly, the expected value may become the extension-less name. The current build needs the extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)