### PR TITLE
Add "Visual sync" to subtitle grid "Selected lines" context menu

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1030,6 +1030,12 @@ public static partial class InitListViewAndEditBox
                 },
                 new MenuItem
                 {
+                    Header = Se.Language.Main.Menu.VisualSync,
+                    Command = vm.ShowVisualSyncSelectedLinesCommand,
+                    DataContext = vm,
+                },
+                new MenuItem
+                {
                     Header = Se.Language.Main.Menu.RemoveTextForHearingImpaired,
                     Command = vm.RemoveTextForHearingImpairedSelectedLinesCommand,
                     DataContext = vm,

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7830,6 +7830,56 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private async Task ShowVisualSyncSelectedLines()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        if (IsEmpty)
+        {
+            ShowSubtitleNotLoadedMessage();
+            return;
+        }
+
+        var selectedLines = SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>()
+            .OrderBy(p => p.StartTime.TotalMilliseconds)
+            .ToList();
+        if (selectedLines.Count == 0)
+        {
+            return;
+        }
+
+        var result = await ShowDialogAsync<VisualSyncWindow, VisualSyncViewModel>(vm =>
+        {
+            var paragraphs = selectedLines.Select(p => new SubtitleLineViewModel(p)).ToList();
+            vm.Initialize(paragraphs, _videoFileName, _subtitleFileName, AudioVisualizer, _audioTrack?.Id ?? -1);
+        });
+
+        if (!result.OkPressed)
+        {
+            return;
+        }
+
+        // Only the selected lines were synced - copy the new time codes back onto those rows and leave the rest of the subtitle alone.
+        foreach (var synced in result.Paragraphs.Select(p => p.Subtitle))
+        {
+            var line = Subtitles.FirstOrDefault(p => p.Id == synced.Id);
+            if (line == null)
+            {
+                continue;
+            }
+
+            line.StartTime = synced.StartTime;
+            line.EndTime = synced.EndTime;
+            line.UpdateDuration();
+        }
+
+        _updateAudioVisualizer = true;
+    }
+
+    [RelayCommand]
     private async Task ShowSyncChangeFrameRate()
     {
         if (Window == null)


### PR DESCRIPTION
Fixes #10719

Visual sync could only be applied to the whole subtitle, which made it impossible to fix a file where different segments are off by different amounts - syncing one segment reset the previous correction.

This adds **Visual sync...** to the subtitle grid context menu under **Selected lines** (right after "Beautify time codes..."). It opens the existing Visual Sync window with only the selected lines, and on OK the new time codes are written back onto exactly those rows - the rest of the subtitle is untouched.

No new language tags: the menu item reuses the existing `Main.Menu.VisualSync` string.

Note: the overlap fix inside the Visual Sync window only runs across the lines it was given, so the last synced line can end up overlapping the first line after the selection - same as "Beautify time codes" on selected lines does today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)