### PR TITLE
Keep source folder in file name after OCR import

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -15289,7 +15289,7 @@ public partial class MainViewModel :
                         if (result.OkPressed)
                         {
                             VideoCloseFile();
-                            _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
+                            _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
                             _converted = true;
                             ReplaceSubtitles(result.OcredSubtitle);
                             SelectAndScrollToRow(0);
@@ -15921,7 +15921,7 @@ public partial class MainViewModel :
             {
                 VideoCloseFile();
                 ResetSubtitle();
-                _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
+                _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
                 _converted = true;
                 _subtitle.Paragraphs.Clear();
                 ReplaceSubtitles(result.OcredSubtitle);
@@ -15965,7 +15965,7 @@ public partial class MainViewModel :
             {
                 VideoCloseFile();
                 ResetSubtitle();
-                _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
+                _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
                 _converted = true;
                 _subtitle.Paragraphs.Clear();
                 ReplaceSubtitles(result.OcredSubtitle);
@@ -15986,7 +15986,7 @@ public partial class MainViewModel :
             {
                 VideoCloseFile();
                 ResetSubtitle();
-                _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
+                _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
                 _converted = true;
                 _subtitle.Paragraphs.Clear();
                 ReplaceSubtitles(result.OcredSubtitle);
@@ -16007,7 +16007,7 @@ public partial class MainViewModel :
             {
                 VideoCloseFile();
                 ResetSubtitle();
-                _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
+                _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
                 _converted = true;
                 _subtitle.Paragraphs.Clear();
                 ReplaceSubtitles(result.OcredSubtitle);
@@ -16061,7 +16061,7 @@ public partial class MainViewModel :
             {
                 VideoCloseFile();
                 ResetSubtitle();
-                _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
+                _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
                 _converted = true;
                 _subtitle.Paragraphs.Clear();
                 ReplaceSubtitles(result.OcredSubtitle);
@@ -16126,7 +16126,7 @@ public partial class MainViewModel :
                 await VideoOpenFile(fileName);
             }
 
-            _subtitleFileName = Path.GetFileNameWithoutExtension(fileName) + SelectedSubtitleFormat.Extension;
+            _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName) + SelectedSubtitleFormat.Extension;
             _converted = true;
             return;
         }
@@ -16142,7 +16142,7 @@ public partial class MainViewModel :
                 ResetSubtitle();
                 SelectAndScrollToRow(0);
                 SetSubtitles(result.TeletextSubtitle);
-                _subtitleFileName = Path.GetFileNameWithoutExtension(fileName) + SelectedSubtitleFormat.Extension;
+                _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName) + SelectedSubtitleFormat.Extension;
                 _converted = true;
                 if (Se.Settings.Video.AutoOpen)
                 {
@@ -16171,7 +16171,7 @@ public partial class MainViewModel :
             if (result.OkPressed)
             {
                 VideoCloseFile();
-                _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
+                _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
                 ReplaceSubtitles(result.OcredSubtitle);
                 SelectAndScrollToRow(0);
             }
@@ -16294,7 +16294,7 @@ public partial class MainViewModel :
                 {
                     VideoCloseFile();
                     ResetSubtitle();
-                    _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
+                    _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
                     _converted = true;
                     ReplaceSubtitles(result.OcredSubtitle);
                     Renumber();
@@ -16307,7 +16307,7 @@ public partial class MainViewModel :
         {
             VideoCloseFile();
             ResetSubtitle();
-            _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
+            _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
             _converted = true;
             _subtitle.Paragraphs.Clear();
             _subtitle.Paragraphs.AddRange(mp4SubtitleTrack.Mdia.Minf.Stbl.GetParagraphs());
@@ -16346,7 +16346,7 @@ public partial class MainViewModel :
                     {
                         if (!IsImageSubtitleTrack(result.SelectedMatroskaTrack))
                         {
-                            _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
+                            _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
                             _converted = true;
                             SelectAndScrollToRow(0);
 
@@ -16453,7 +16453,7 @@ public partial class MainViewModel :
                 if (result.OkPressed)
                 {
                     VideoCloseFile();
-                    _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
+                    _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
                     _converted = true;
                     ReplaceSubtitles(result.OcredSubtitle);
                     Renumber();
@@ -16596,7 +16596,7 @@ public partial class MainViewModel :
             {
                 VideoCloseFile();
                 ResetSubtitle();
-                _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
+                _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
                 ReplaceSubtitles(result.OcredSubtitle);
                 Renumber();
                 SelectAndScrollToRow(0);
@@ -16667,7 +16667,7 @@ public partial class MainViewModel :
             if (result.OkPressed)
             {
                 VideoCloseFile();
-                _subtitleFileName = Path.GetFileNameWithoutExtension(fileName);
+                _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
                 ReplaceSubtitles(result.OcredSubtitle);
                 SelectAndScrollToRow(0);
                 if (Se.Settings.Video.AutoOpen && fileName.EndsWith(".mkv", StringComparison.OrdinalIgnoreCase))
@@ -16804,7 +16804,7 @@ public partial class MainViewModel :
         if (result.OkPressed)
         {
             VideoCloseFile();
-            _subtitleFileName = Path.GetFileNameWithoutExtension(vobSubFileName);
+            _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(vobSubFileName);
             _converted = true;
             ReplaceSubtitles(result.OcredSubtitle);
             SelectAndScrollToRow(0);


### PR DESCRIPTION
Fixes #12464
Fixes #12265

After OCR'ing an image-based subtitle (VobSub `.sub`, BluRay `.sup`, Matroska tracks, MP4, transport stream, DivX, DOST, WebVTT thumbnails, SP DVD sup), the main view model stored only the base name in `_subtitleFileName`:

```csharp
_subtitleFileName = Path.GetFileNameWithoutExtension(fileName); // "SomeMovie" - directory lost
```

So when the "Save as" dialog opened (explicitly, or via the save-changes prompt on close), `PickSaveSubtitleFileAs` had no directory to derive `SuggestedStartLocation` from and the native dialog fell back to the OS default / last-used folder (e.g. `Documents`) instead of the source file's folder.

This PR switches all 16 OCR-import completion sites to `Utilities.GetPathAndFileNameWithoutExtension(fileName)`, matching the pattern the IsmtDfxp, `.mcc`, and Matroska text-track paths already use. `PickSaveSubtitleFileAs` already splits a path-qualified suggested name into start location + file name, so the dialog now opens in the source folder with the right name pre-filled.

`_converted` is untouched, so the Save-as prompt still appears as before - nothing is saved silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)