### PR TITLE
Add DVD sup export for MuxMan/Scenarist DVD authoring

### DIFF
--- a/src/libse/VobSub/DvdSupWriter.cs
+++ b/src/libse/VobSub/DvdSupWriter.cs
@@ -1,0 +1,89 @@
+using Nikse.SubtitleEdit.Core.BluRaySup;
+using Nikse.SubtitleEdit.Core.Common;
+using SkiaSharp;
+using System;
+using System.IO;
+
+namespace Nikse.SubtitleEdit.Core.VobSub
+{
+    /// <summary>
+    /// Writes a DVD-Video subpicture stream (.sup) as imported by DVD authoring tools like
+    /// MuxMan and Scenarist: each subtitle is a 10-byte header - "SP", 32-bit little-endian
+    /// PTS in 90 kHz and 4 reserved bytes - followed by the same subpicture unit that
+    /// <see cref="VobSubWriter"/> muxes into MPEG-PS packets (see <see cref="SpHeader"/> for
+    /// the reading side). Display duration is embedded in the unit's control sequences, and
+    /// colors are CLUT indices 0-3, so the final palette is set in the authoring tool.
+    /// </summary>
+    public class DvdSupWriter : IDisposable
+    {
+        private FileStream _supFile;
+        private readonly int _screenWidth;
+        private readonly int _screenHeight;
+        private readonly int _bottomMargin;
+        private readonly int _leftRightMargin;
+        private readonly SKColor _background = SKColors.Transparent;
+        private readonly SKColor _pattern;
+        private readonly SKColor _emphasis1;
+        private readonly bool _useInnerAntiAliasing;
+
+        public DvdSupWriter(string fileName, int screenWidth, int screenHeight, int bottomMargin, int leftRightMargin, SKColor pattern, SKColor emphasis1, bool useInnerAntiAliasing)
+        {
+            _screenWidth = screenWidth;
+            _screenHeight = screenHeight;
+            _bottomMargin = bottomMargin;
+            _leftRightMargin = leftRightMargin;
+            _pattern = pattern;
+            _emphasis1 = emphasis1;
+            _useInnerAntiAliasing = useInnerAntiAliasing;
+            _supFile = new FileStream(fileName, FileMode.Create);
+        }
+
+        public void WriteParagraph(Paragraph p, SKBitmap bmp, BluRayContentAlignment alignment, SKPoint? overridePosition = null)
+        {
+            var nbmp = new NikseBitmap(bmp);
+            var emphasis2 = nbmp.ConvertToFourColors(_background, _pattern, _emphasis1, _useInnerAntiAliasing);
+            var twoPartBuffer = nbmp.RunLengthEncodeForDvd(_background, _pattern, _emphasis1, emphasis2);
+            var subPictureUnit = VobSubWriter.GetSubImageBuffer(twoPartBuffer, nbmp, p, alignment, overridePosition,
+                _screenWidth, _screenHeight, _bottomMargin, _leftRightMargin, _background, _pattern, _emphasis1, emphasis2);
+
+            _supFile.WriteByte((byte)'S');
+            _supFile.WriteByte((byte)'P');
+
+            var pts = (uint)Math.Round(p.StartTime.TotalMilliseconds * 90.0);
+            _supFile.WriteByte((byte)pts);
+            _supFile.WriteByte((byte)(pts >> 8));
+            _supFile.WriteByte((byte)(pts >> 16));
+            _supFile.WriteByte((byte)(pts >> 24));
+
+            _supFile.WriteByte(0); // 4 reserved bytes (DTS - not used for subpictures)
+            _supFile.WriteByte(0);
+            _supFile.WriteByte(0);
+            _supFile.WriteByte(0);
+
+            _supFile.Write(subPictureUnit, 0, subPictureUnit.Length);
+        }
+
+        private void ReleaseManagedResources()
+        {
+            if (_supFile != null)
+            {
+                _supFile.Dispose();
+                _supFile = null;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                ReleaseManagedResources();
+            }
+        }
+    }
+}

--- a/src/libse/VobSub/VobSubWriter.cs
+++ b/src/libse/VobSub/VobSubWriter.cs
@@ -80,7 +80,9 @@ namespace Nikse.SubtitleEdit.Core.VobSub
             stream.WriteByte((byte)(i % 256));
         }
 
-        private byte[] GetSubImageBuffer(RunLengthTwoParts twoPartBuffer, NikseBitmap nbmp, Paragraph p, BluRayContentAlignment alignment, SKPoint? overridePosition)
+        internal static byte[] GetSubImageBuffer(RunLengthTwoParts twoPartBuffer, NikseBitmap nbmp, Paragraph p, BluRayContentAlignment alignment, SKPoint? overridePosition,
+            int screenWidth, int screenHeight, int bottomMargin, int leftRightMargin,
+            SKColor background, SKColor pattern, SKColor emphasis1, SKColor emphasis2)
         {
             var ms = new MemoryStream();
 
@@ -111,10 +113,10 @@ namespace Nikse.SubtitleEdit.Core.VobSub
             WriteColors(ms); // 3 bytes
 
             // Control command 4 = SetContrast
-            WriteContrast(ms); // 3 bytes
+            WriteContrast(ms, background, pattern, emphasis1, emphasis2); // 3 bytes
 
             // Control command 5 = SetDisplayArea
-            WriteDisplayArea(ms, nbmp, alignment, overridePosition); // 7 bytes
+            WriteDisplayArea(ms, nbmp, alignment, overridePosition, screenWidth, screenHeight, bottomMargin, leftRightMargin); // 7 bytes
 
             // Control command 6 = SetPixelDataAddress
             WritePixelDataAddress(ms, imageTopFieldDataAddress, imageBottomFieldDataAddress); // 5 bytes
@@ -146,7 +148,8 @@ namespace Nikse.SubtitleEdit.Core.VobSub
             var nbmp = new NikseBitmap(bmp);
             _emphasis2 = nbmp.ConvertToFourColors(_background, _pattern, _emphasis1, _useInnerAntiAliasing);
             var twoPartBuffer = nbmp.RunLengthEncodeForDvd(_background, _pattern, _emphasis1, _emphasis2);
-            var imageBuffer = GetSubImageBuffer(twoPartBuffer, nbmp, p, alignment, overridePosition);
+            var imageBuffer = GetSubImageBuffer(twoPartBuffer, nbmp, p, alignment, overridePosition,
+                _screenWidth, _screenHeight, _bottomMargin, _leftRightMargin, _background, _pattern, _emphasis1, _emphasis2);
 
             int bufferIndex = 0;
             byte vobSubId = (byte)_languageStreamId;
@@ -298,34 +301,35 @@ namespace Nikse.SubtitleEdit.Core.VobSub
             WriteEndianWord(imageBottomFieldDataAddress, stream);
         }
 
-        private void WriteDisplayArea(Stream stream, NikseBitmap nbmp, BluRayContentAlignment alignment, SKPoint? overridePosition)
+        private static void WriteDisplayArea(Stream stream, NikseBitmap nbmp, BluRayContentAlignment alignment, SKPoint? overridePosition,
+            int screenWidth, int screenHeight, int bottomMargin, int leftRightMargin)
         {
             stream.WriteByte(5);
 
             // Write 6 bytes of area - starting X, ending X, starting Y, ending Y, each 12 bits
-            ushort startX = (ushort)((_screenWidth - nbmp.Width) / 2);
-            ushort startY = (ushort)(_screenHeight - nbmp.Height - _bottomMargin);
+            ushort startX = (ushort)((screenWidth - nbmp.Width) / 2);
+            ushort startY = (ushort)(screenHeight - nbmp.Height - bottomMargin);
 
             if (alignment == BluRayContentAlignment.TopLeft || alignment == BluRayContentAlignment.TopCenter || alignment == BluRayContentAlignment.TopRight)
             {
-                startY = (ushort)_bottomMargin;
+                startY = (ushort)bottomMargin;
             }
             if (alignment == BluRayContentAlignment.MiddleLeft || alignment == BluRayContentAlignment.MiddleCenter || alignment == BluRayContentAlignment.MiddleRight)
             {
-                startY = (ushort)(_screenHeight / 2 - nbmp.Height / 2);
+                startY = (ushort)(screenHeight / 2 - nbmp.Height / 2);
             }
             if (alignment == BluRayContentAlignment.TopLeft || alignment == BluRayContentAlignment.MiddleLeft || alignment == BluRayContentAlignment.BottomLeft)
             {
-                startX = (ushort)_leftRightMargin;
+                startX = (ushort)leftRightMargin;
             }
             if (alignment == BluRayContentAlignment.TopRight || alignment == BluRayContentAlignment.MiddleRight || alignment == BluRayContentAlignment.BottomRight)
             {
-                startX = (ushort)(_screenWidth - nbmp.Width - _leftRightMargin);
+                startX = (ushort)(screenWidth - nbmp.Width - leftRightMargin);
             }
 
             if (overridePosition != null &&
-                overridePosition.Value.X >= 0 && overridePosition.Value.X < _screenWidth &&
-                overridePosition.Value.Y >= 0 && overridePosition.Value.Y < _screenHeight)
+                overridePosition.Value.X >= 0 && overridePosition.Value.X < screenWidth &&
+                overridePosition.Value.Y >= 0 && overridePosition.Value.Y < screenHeight)
             {
                 startX = (ushort)overridePosition.Value.X;
                 startY = (ushort)overridePosition.Value.Y;
@@ -342,11 +346,11 @@ namespace Nikse.SubtitleEdit.Core.VobSub
         /// <summary>
         /// Directly provides the four contrast (alpha blend) values to associate with the four pixel values. One nibble per pixel value for a total of 2 bytes. 0x0 = transparent, 0xF = opaque
         /// </summary>
-        private void WriteContrast(Stream stream)
+        private static void WriteContrast(Stream stream, SKColor background, SKColor pattern, SKColor emphasis1, SKColor emphasis2)
         {
             stream.WriteByte(4);
-            stream.WriteByte((byte)((_emphasis2.Alpha << 4) | _emphasis1.Alpha)); // emphasis2 + emphasis1
-            stream.WriteByte((byte)((_pattern.Alpha << 4) | _background.Alpha)); // pattern + background
+            stream.WriteByte((byte)((emphasis2.Alpha << 4) | emphasis1.Alpha)); // emphasis2 + emphasis1
+            stream.WriteByte((byte)((pattern.Alpha << 4) | background.Alpha)); // pattern + background
         }
 
         /// <summary>

--- a/src/libuilogic/Export/ExportHandlerDvdSup.cs
+++ b/src/libuilogic/Export/ExportHandlerDvdSup.cs
@@ -1,0 +1,80 @@
+using Nikse.SubtitleEdit.Core.BluRaySup;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.VobSub;
+
+namespace Nikse.SubtitleEdit.UiLogic.Export;
+
+public class ExportHandlerDvdSup : IExportHandler
+{
+    public ExportImageType ExportImageType => ExportImageType.DvdSup;
+    public string Extension => ".sup";
+    public bool UseFileName => true;
+    public string Title => string.Format("Export to {0}", "DVD sup");
+
+    private DvdSupWriter? _dvdSupWriter;
+
+    public void WriteHeader(string fileOrFolderName, ImageParameter imageParameter)
+    {
+        _dvdSupWriter = new DvdSupWriter(fileOrFolderName, imageParameter.ScreenWidth, imageParameter.ScreenHeight, imageParameter.BottomTopMargin, imageParameter.LeftRightMargin, imageParameter.FontColor, imageParameter.OutlineColor, true);
+    }
+
+    public void CreateParagraph(ImageParameter param)
+    {
+    }
+
+    public void WriteParagraph(ImageParameter param)
+    {
+        if (_dvdSupWriter == null)
+        {
+            throw new InvalidOperationException("DvdSupWriter is not initialized. Call WriteHeader first.");
+        }
+
+        var p = new Paragraph(param.Text, param.StartTime.TotalMilliseconds, param.EndTime.TotalMilliseconds);
+        _dvdSupWriter.WriteParagraph(p, param.Bitmap, MapAlignment(param));
+    }
+
+    private static BluRayContentAlignment MapAlignment(ImageParameter param)
+    {
+        var alignment = BluRayContentAlignment.BottomCenter;
+        switch (param.Alignment)
+        {
+            case ExportAlignment.BottomLeft:
+                alignment = BluRayContentAlignment.BottomLeft;
+                break;
+            case ExportAlignment.BottomRight:
+                alignment = BluRayContentAlignment.BottomRight;
+                break;
+            case ExportAlignment.MiddleLeft:
+                alignment = BluRayContentAlignment.MiddleLeft;
+                break;
+            case ExportAlignment.MiddleRight:
+                alignment = BluRayContentAlignment.MiddleRight;
+                break;
+            case ExportAlignment.TopLeft:
+                alignment = BluRayContentAlignment.TopLeft;
+                break;
+            case ExportAlignment.TopRight:
+                alignment = BluRayContentAlignment.TopRight;
+                break;
+            case ExportAlignment.TopCenter:
+                alignment = BluRayContentAlignment.TopCenter;
+                break;
+            case ExportAlignment.MiddleCenter:
+                alignment = BluRayContentAlignment.MiddleCenter;
+                break;
+            case ExportAlignment.BottomCenter:
+                break;
+        }
+        return alignment;
+    }
+
+    public void WriteFooter()
+    {
+        if (_dvdSupWriter == null)
+        {
+            throw new InvalidOperationException("DvdSupWriter is not initialized. Call WriteHeader first.");
+        }
+
+        _dvdSupWriter.Dispose();
+    }
+}

--- a/src/libuilogic/Export/ExportImageType.cs
+++ b/src/libuilogic/Export/ExportImageType.cs
@@ -6,6 +6,7 @@ public enum ExportImageType
     BluRaySup,
     DCinemaPng,
     Dost,
+    DvdSup,
     Fcp,
     HtmlIndex,
     ImagesWithTimeCode,

--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -251,6 +251,11 @@ public static class InitMenu
                         },
                         new MenuItem
                         {
+                            Header = Se.Language.File.Export.TitleExportDvdSup,
+                            Command = vm.ExportDvdSupCommand,
+                        },
+                        new MenuItem
+                        {
                             Header = "Final Cut Pro + image",
                             Command = vm.ExportFcpPngCommand,
                         },

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -239,6 +239,7 @@ public static class InitNativeMacMenu
         exportItems.Items.Add(Item(lExport.TitleExportDCinemaSmpte2014Png, v => v.ExportDCinemaSmpte2014PngCommand));
         exportItems.Items.Add(Item(Ebu.NameOfFormat, v => v.ExportEbuStlCommand));
         exportItems.Items.Add(Item("DOST/png", v => v.ExportDostPngCommand));
+        exportItems.Items.Add(Item(lExport.TitleExportDvdSup, v => v.ExportDvdSupCommand));
         exportItems.Items.Add(Item("Final Cut Pro + image", v => v.ExportFcpPngCommand));
         exportItems.Items.Add(Item(Se.Language.General.ImagesWithTimeCode, v => v.ExportImagesWithTimeCodeCommand));
         exportItems.Items.Add(Item(Pac.NameOfFormat, v => v.ExportPacCommand));

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -2670,6 +2670,32 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private async Task ExportDvdSup()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        if (IsEmpty)
+        {
+            ShowSubtitleNotLoadedMessage();
+            return;
+        }
+
+        IExportHandler exportHandler = new ExportHandlerDvdSup();
+        var result = await ShowDialogAsync<ExportImageBasedWindow, ExportImageBasedViewModel>(vm =>
+        {
+            vm.Initialize(exportHandler, Subtitles, _subtitleFileName, _videoFileName);
+        });
+
+        if (!result.OkPressed)
+        {
+            return;
+        }
+    }
+
+    [RelayCommand]
     private async Task ExportVobSub()
     {
         if (Window == null)

--- a/src/ui/Logic/Config/Language/File/LanguageExport.cs
+++ b/src/ui/Logic/Config/Language/File/LanguageExport.cs
@@ -10,6 +10,7 @@ public class LanguageExport
     public string PaddingLeftRight { get; set; }
     public string PaddingTopBottom { get; set; }
     public string PreviewTitle { get; set; }
+    public string TitleExportDvdSup { get; set; }
     public string TitleExportVobSub { get; set; }
     public string CustomTextFormatsDotDotDot { get; set; }
     public string PlainTextDotDotDot { get; set; }
@@ -46,6 +47,7 @@ public class LanguageExport
         PaddingLeftRight = "Padding left/right";
         PaddingTopBottom = "Padding top/bottom";
         PreviewTitle = "Preview - current size: {0}x{1}, target size: {2}x{3}, zoom: {4}%";
+        TitleExportDvdSup = "DVD sup (MuxMan/Scenarist)";
         TitleExportVobSub = "VobSub (sub/idx)";
         CustomTextFormatsDotDotDot = "_Custom text formats...";
         PlainTextDotDotDot = "_Plain text...";


### PR DESCRIPTION
Adds **File → Export → DVD sup (MuxMan/Scenarist)** — the classic DVD-Video subpicture stream (`.sup`): per subtitle a 10-byte `SP` header (32-bit little-endian PTS in 90 kHz + 4 reserved bytes) followed by the same subpicture unit that VobSub muxes into MPEG-PS packets.

This is the `.sup` flavor DVD authoring tools like MuxMan import (MuxMan takes sup/sst/vob subpicture input — the only sup export SE had was Blu-ray sup, which MuxMan rejects). Because SE renders the text to bitmaps, it also sidesteps the character-encoding corruption (Â before £, mangled accents) that pre-Unicode srt-to-sup tools like Txt2Sup/easySup/SubtitleCreator produce — see https://forum.videohelp.com/threads/420850-SRT-to-SUP-for-dvd-not-handling-foreign-language-letters

Implementation:
- `DvdSupWriter` (libse): writes the SP header per subtitle and reuses `VobSubWriter`'s subpicture-unit builder, which is made static/parameterized (no behavior change for VobSub export — same expressions, values passed from the same fields).
- `ExportHandlerDvdSup` (libuilogic): standard image-based export handler (`.sup`, file-based), same alignment mapping as the VobSub handler.
- Menu entries in the regular and native macOS File → Export menus + `TitleExportDvdSup` language string.

Verified with a round-trip harness against SE's own SP DVD sup reader (`FileUtil.IsSpDvdSup` + `SpHeader`/`SubPicture`, the same loop `OcrSubtitleSpDvdSupImages` uses): detection, paragraph count, start times (exact), durations (within DCSQ delay quantization of ~11 ms), decoded image pixels and display-area position all match. Note: colors in the subpicture unit are CLUT indices 0–3 (like any DVD sup); the final palette is assigned in the authoring tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)