### PR TITLE
Apply the DataGrid scroll bar behavior app wide via one style (#12438 follow-up)

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -97,7 +97,8 @@ public static partial class InitListViewAndEditBox
             FontSize = Se.Settings.Appearance.SubtitleGridFontSize,
         };
 
-        DataGridScrollBarBehavior.EnableTroughPageScroll(vm.SubtitleGrid);
+        // Trough paging and shift+click jump now come from the app-wide DataGrid style
+        // (DataGridScrollBarBehavior.EnableTroughPaging in Styles.axaml), so no per-grid call here.
 
         // hack to make drag and drop work on the DataGrid - also on empty rows
         var dropHost = new Border

--- a/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
@@ -335,7 +335,7 @@ public class ShortcutsWindow : Window
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedNode)) { Source = vm });
         dataGrid.SelectionChanged += vm.ShortcutsDataGrid_SelectionChanged;
         dataGrid.DoubleTapped += vm.ShortcutsDataGridDoubleTapped;
-        DataGridScrollBarBehavior.EnableTroughPageScroll(dataGrid);
+        // Trough paging and shift+click jump now come from the app-wide DataGrid style (Styles.axaml).
         var borderDataGrid = UiUtil.MakeBorderForControlNoPadding(dataGrid).WithMarginBottom(5);
 
         var flyout = new MenuFlyout();

--- a/src/ui/Logic/DataGridScrollBarBehavior.cs
+++ b/src/ui/Logic/DataGridScrollBarBehavior.cs
@@ -43,8 +43,10 @@ public static class DataGridScrollBarBehavior
     public static readonly AttachedProperty<bool> EnableTroughPagingProperty =
         AvaloniaProperty.RegisterAttached<DataGrid, bool>("EnableTroughPaging", typeof(DataGridScrollBarBehavior));
 
-    // Marks a grid already wired so a second set of the property (or a re-templated grid) does
-    // not stack a second handler.
+    // Marks a grid already wired so that setting the attached property to true more than once does
+    // not subscribe to TemplateApplied a second time and stack a second set of scroll bar handlers.
+    // A normal re-template needs no guard: the single subscription re-runs and wires the fresh
+    // scroll bar once, and the discarded template's scroll bar (with its handlers) is dropped.
     private static readonly AttachedProperty<bool> WiredProperty =
         AvaloniaProperty.RegisterAttached<DataGrid, bool>("TroughPagingWired", typeof(DataGridScrollBarBehavior));
 

--- a/src/ui/Logic/DataGridScrollBarBehavior.cs
+++ b/src/ui/Logic/DataGridScrollBarBehavior.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
@@ -26,13 +27,42 @@ namespace Nikse.SubtitleEdit.Logic;
 /// The DataGrid hooks the scroll bar's Scroll event (not ValueChanged) to refresh its
 /// rows, so a programmatic jump also invokes the grid's internal ProcessVerticalScroll.
 /// </summary>
-internal static class DataGridScrollBarBehavior
+public static class DataGridScrollBarBehavior
 {
     private const string VerticalScrollBarPartName = "PART_VerticalScrollbar";
 
     private static readonly MethodInfo? ProcessVerticalScrollMethod = typeof(DataGrid).GetMethod(
         "ProcessVerticalScroll",
         BindingFlags.NonPublic | BindingFlags.Instance);
+
+    /// <summary>
+    /// Attach the trough paging and shift+click jump to a DataGrid. Set once, application wide,
+    /// from a single DataGrid style in Styles.axaml so every grid gets the Windows-standard
+    /// scroll bar behavior without each window wiring it by hand (requested on #12438).
+    /// </summary>
+    public static readonly AttachedProperty<bool> EnableTroughPagingProperty =
+        AvaloniaProperty.RegisterAttached<DataGrid, bool>("EnableTroughPaging", typeof(DataGridScrollBarBehavior));
+
+    // Marks a grid already wired so a second set of the property (or a re-templated grid) does
+    // not stack a second handler.
+    private static readonly AttachedProperty<bool> WiredProperty =
+        AvaloniaProperty.RegisterAttached<DataGrid, bool>("TroughPagingWired", typeof(DataGridScrollBarBehavior));
+
+    public static void SetEnableTroughPaging(DataGrid grid, bool value) => grid.SetValue(EnableTroughPagingProperty, value);
+
+    public static bool GetEnableTroughPaging(DataGrid grid) => grid.GetValue(EnableTroughPagingProperty);
+
+    static DataGridScrollBarBehavior()
+    {
+        EnableTroughPagingProperty.Changed.AddClassHandler<DataGrid>((grid, e) =>
+        {
+            if (e.NewValue is true && !grid.GetValue(WiredProperty))
+            {
+                grid.SetValue(WiredProperty, true);
+                EnableTroughPageScroll(grid);
+            }
+        });
+    }
 
     public static void EnableTroughPageScroll(DataGrid grid)
     {

--- a/src/ui/Styles.axaml
+++ b/src/ui/Styles.axaml
@@ -1,5 +1,10 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:logic="clr-namespace:Nikse.SubtitleEdit.Logic;assembly=SubtitleEdit">
+    <!-- Windows-standard scroll bar for every grid: trough click pages, shift+click jumps (#12438). -->
+    <Style Selector="DataGrid">
+        <Setter Property="logic:DataGridScrollBarBehavior.EnableTroughPaging" Value="True"/>
+    </Style>
     <Styles.Resources>
         <SolidColorBrush x:Key="DataGridRowHoveredBackgroundColor" Color="Transparent"/>
         <x:Double x:Key="DataGridRowSelectedUnfocusedBackgroundOpacity">0.2</x:Double>


### PR DESCRIPTION
Follow-up to #12438, requested by @GrampaWildWilly and approved by @niksedk on that thread.

Right now the trough paging and Shift+click jump are wired into only two grids (the main subtitle grid and the Shortcuts grid), so every other grid window still pages a single line and has no Shift+click jump.

This applies the behavior app wide from one place:
- DataGridScrollBarBehavior gains an EnableTroughPaging attached property.
- A single DataGrid style in Styles.axaml sets it to True, so every current and future grid picks up the behavior automatically.
- The two explicit per-window calls are removed since the style now covers them; a wired guard prevents double attachment if the property is ever set twice.

No behavior change for the subtitle and Shortcuts grids, they just get it via the style now instead of a direct call. Every other grid window (Batch convert, Compare, Multiple replace, OCR, and the rest) gains trough paging and the Shift+click jump.

Testing scope: this compiles clean and reuses the exact mechanism already shipped and confirmed on the subtitle and Shortcuts grids in #12438; I have not click-tested all of the other grid windows individually.
