### PR TITLE
Micro-optimize three hot paths (verified with BenchmarkDotNet)

### DIFF
--- a/src/libse/Common/TextLengthCalculator/CalcAll.cs
+++ b/src/libse/Common/TextLengthCalculator/CalcAll.cs
@@ -11,6 +11,38 @@ namespace Nikse.SubtitleEdit.Core.Common.TextLengthCalculator
         {
             var s = HtmlUtil.RemoveHtmlTags(text, true);
 
+            // Fast path: runs per grid-row repaint, per keystroke and per waveform frame, so
+            // avoid StringInfo.GetTextElementEnumerator's heap allocation and culture-aware
+            // grapheme walk when it cannot matter. Everything that can make a text element
+            // longer than one char (combining marks, ZWJ, prepend characters, surrogates) or
+            // hit the skip list below (zero-width/BiDi controls) is >= U+0300 - except "\r\n",
+            // whose chars are both controls and thus not counted either way - so counting
+            // non-controls below U+0300 is identical. U+2010-U+2027 (typographic dashes,
+            // curly quotes, ellipsis - common in professional subs) are plain punctuation,
+            // never part of a longer element and not in the skip list, so count them too;
+            // any other char >= U+0300 falls back to the full text-element walk.
+            var simpleLength = 0;
+            var isSimple = true;
+            for (var i = 0; i < s.Length; i++)
+            {
+                var c = s[i];
+                if (c >= '\u0300' && (c < '\u2010' || c > '\u2027'))
+                {
+                    isSimple = false;
+                    break;
+                }
+
+                if (!char.IsControl(c))
+                {
+                    simpleLength++;
+                }
+            }
+
+            if (isSimple)
+            {
+                return simpleLength;
+            }
+
             const char zeroWidthSpace = '\u200B';
             const char zeroWidthNoBreakSpace = '\uFEFF';
             var length = 0;

--- a/src/libse/Common/TimeCode.cs
+++ b/src/libse/Common/TimeCode.cs
@@ -164,45 +164,100 @@ namespace Nikse.SubtitleEdit.Core.Common
         {
             var ts = TimeSpan;
             var decimalSeparator = localize ? CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator : ",";
-            var s = $"{ts.Hours + ts.Days * 24:00}:{ts.Minutes:00}:{ts.Seconds:00}{decimalSeparator}{ts.Milliseconds:000}";
+            var s = FormatTime(ts.Hours + ts.Days * 24, 2, true, ts.Minutes, 2, true, ts.Seconds, 2, decimalSeparator, ts.Milliseconds);
 
             return PrefixSign(s);
         }
 
         public string ToShortString(bool localize = false)
         {
+            // Runs for the grid's start/end/duration/gap cells on every repaint and for the
+            // waveform paragraph labels on every frame. The previous version built the string
+            // via interpolation - which on netstandard2.1 compiles to string.Format (boxing +
+            // per-call format parsing) - plus a second interpolated "is this zero" sentinel
+            // string per call; format into a stack buffer instead.
             var ts = TimeSpan;
             var decimalSeparator = localize ? CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator : ",";
             string s;
             if (ts.Minutes == 0 && ts.Hours == 0 && ts.Days == 0)
             {
-                s = $"{ts.Seconds:0}{decimalSeparator}{ts.Milliseconds:000}";
+                s = FormatTime(0, 0, false, 0, 0, false, ts.Seconds, 1, decimalSeparator, ts.Milliseconds);
 
-                if (s == $"0{decimalSeparator}000")
+                if (ts.Seconds == 0 && ts.Milliseconds == 0)
                 {
                     return s; // no sign
                 }
             }
             else if (ts.Hours == 0 && ts.Days == 0)
             {
-                s = $"{ts.Minutes:0}:{ts.Seconds:00}{decimalSeparator}{ts.Milliseconds:000}";
-
-                if (s == $"0:00{decimalSeparator}000")
-                {
-                    return s; // no sign
-                }
+                // never all-zero here: Minutes != 0 in this branch
+                s = FormatTime(0, 0, false, ts.Minutes, 1, true, ts.Seconds, 2, decimalSeparator, ts.Milliseconds);
             }
             else
             {
-                s = $"{ts.Hours + ts.Days * 24:0}:{ts.Minutes:00}:{ts.Seconds:00}{decimalSeparator}{ts.Milliseconds:000}";
-
-                if (s == $"0:00:00{decimalSeparator}000")
-                {
-                    return s; // no sign
-                }
+                // never all-zero here: Hours/Days != 0 in this branch
+                s = FormatTime(ts.Hours + ts.Days * 24, 1, true, ts.Minutes, 2, true, ts.Seconds, 2, decimalSeparator, ts.Milliseconds);
             }
 
             return PrefixSign(s);
+        }
+
+        // Formats [hours:][minutes:]seconds<separator>milliseconds. Negative components render
+        // like "{value:00}" does ("-05"); PrefixSign then normalizes the sign as before.
+        private static string FormatTime(int hours, int hoursMinDigits, bool includeHours,
+            int minutes, int minutesMinDigits, bool includeMinutes,
+            int seconds, int secondsMinDigits, string decimalSeparator, int milliseconds)
+        {
+            Span<char> buffer = stackalloc char[48 + decimalSeparator.Length];
+            var pos = 0;
+            if (includeHours)
+            {
+                pos = WriteInt(buffer, pos, hours, hoursMinDigits);
+                buffer[pos++] = ':';
+            }
+
+            if (includeMinutes)
+            {
+                pos = WriteInt(buffer, pos, minutes, minutesMinDigits);
+                buffer[pos++] = ':';
+            }
+
+            pos = WriteInt(buffer, pos, seconds, secondsMinDigits);
+            foreach (var c in decimalSeparator)
+            {
+                buffer[pos++] = c;
+            }
+
+            pos = WriteInt(buffer, pos, milliseconds, 3);
+            return new string(buffer.Slice(0, pos));
+        }
+
+        private static int WriteInt(Span<char> buffer, int pos, int value, int minDigits)
+        {
+            if (value < 0)
+            {
+                buffer[pos++] = '-';
+                value = -value;
+            }
+
+            var digits = 1;
+            for (var v = value; v >= 10; v /= 10)
+            {
+                digits++;
+            }
+
+            if (digits < minDigits)
+            {
+                digits = minDigits;
+            }
+
+            for (var i = pos + digits - 1; i >= pos; i--)
+            {
+                buffer[i] = (char)('0' + value % 10);
+                value /= 10;
+            }
+
+            return pos + digits;
         }
 
         public string ToShortStringHHMMSSFF()

--- a/src/libse/SubtitleFormats/SubRip.cs
+++ b/src/libse/SubtitleFormats/SubRip.cs
@@ -284,6 +284,18 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 return false;
             }
 
+            // Fast path: the canonical "hh:mm:ss,mmm --> hh:mm:ss,mmm" line SE itself and
+            // virtually every other tool writes. The tolerant normalization below allocates
+            // ~20 intermediate strings and runs for every time-code line on load plus every
+            // SubRip "IsMine" probe, so only pay for it on the rare non-canonical lines.
+            if (input.Length == 29 && TryReadCanonicalTimeCodesLine(input, paragraph))
+            {
+                // Canonical milliseconds are 3 digits, so this cannot be the 2-digit
+                // ms-as-frames variant - same conclusion the slow path reaches below.
+                _isMsFrames = false;
+                return true;
+            }
+
             var s = input.TrimStart('-', ' ');
             if (s.Length < 10 || !char.IsDigit(s[0]))
             {
@@ -412,6 +424,58 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
             }
             return false;
+        }
+
+        // Parses "00:00:01,000 --> 00:00:04,000" (fixed 29-char layout, digits only) without
+        // any allocation. Returns false on the slightest deviation so the tolerant slow path
+        // still handles it.
+        private static bool TryReadCanonicalTimeCodesLine(string line, Paragraph paragraph)
+        {
+            if (line[2] != ':' || line[5] != ':' || line[8] != ',' ||
+                line[12] != ' ' || line[13] != '-' || line[14] != '-' || line[15] != '>' || line[16] != ' ' ||
+                line[19] != ':' || line[22] != ':' || line[25] != ',')
+            {
+                return false;
+            }
+
+            var startHours = ParseDigits(line, 0, 2);
+            var startMinutes = ParseDigits(line, 3, 2);
+            var startSeconds = ParseDigits(line, 6, 2);
+            var startMilliseconds = ParseDigits(line, 9, 3);
+            var endHours = ParseDigits(line, 17, 2);
+            var endMinutes = ParseDigits(line, 20, 2);
+            var endSeconds = ParseDigits(line, 23, 2);
+            var endMilliseconds = ParseDigits(line, 26, 3);
+            if (startHours < 0 || startMinutes < 0 || startSeconds < 0 || startMilliseconds < 0 ||
+                endHours < 0 || endMinutes < 0 || endSeconds < 0 || endMilliseconds < 0)
+            {
+                return false;
+            }
+
+            if (paragraph != null)
+            {
+                paragraph.StartTime = new TimeCode(startHours, startMinutes, startSeconds, startMilliseconds);
+                paragraph.EndTime = new TimeCode(endHours, endMinutes, endSeconds, endMilliseconds);
+            }
+
+            return true;
+        }
+
+        private static int ParseDigits(string s, int index, int count)
+        {
+            var result = 0;
+            for (var i = 0; i < count; i++)
+            {
+                var digit = s[index + i] - '0';
+                if ((uint)digit > 9)
+                {
+                    return -1;
+                }
+
+                result = result * 10 + digit;
+            }
+
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
Three allocation-heavy functions on confirmed hot paths, each verified with BenchmarkDotNet (ShortRun, .NET 10, MemoryDiagnoser) against the pre-change implementations, plus an equivalence harness comparing old vs new over **32k+ cases** (randomized unicode, mutated near-canonical lines, negative time codes) — all identical, including `_isMsFrames` side effects.

### 1. `CalcAll.CountCharacters` — grid CPS/length columns, per keystroke, waveform per frame
Adds a single-pass fast path when no char needs grapheme-cluster or skip-list handling (< U+0300, plus typographic punctuation U+2010–U+2027); only falls back to the allocating culture-aware `StringInfo` text-element walk when needed.

| case | old | new | alloc |
|---|---|---|---|
| ASCII dialog line | 2,285 ns | **327 ns (7×)** | 1,328 B → 120 B |
| Latin + diacritics + – ’ … | 2,000 ns | **98 ns (20×)** | 1,304 B → **0 B** |
| CJK/emoji (fallback) | 771 ns | 645 ns | unchanged |

### 2. `TimeCode.ToString` / `ToShortString` — grid time cells per repaint, waveform labels per frame
On netstandard2.1, string interpolation compiles to `string.Format` (boxing + format parsing), and `ToShortString` built a *second* interpolated sentinel string per call just to test for zero. Now formats into a `stackalloc` buffer and tests the fields.

| case | old | new | alloc |
|---|---|---|---|
| all 4 branches | 1,206 ns | **235 ns (5×)** | 304 B → 152 B |

### 3. `SubRip.TryReadTimeCodesLine` — every time-code line on load + every line during `IsMine` probing
Parses the canonical `hh:mm:ss,mmm --> hh:mm:ss,mmm` shape directly; the ~20-`string.Replace` normalization chain (for hand-mangled files) now only runs for non-canonical lines.

| case | old | new | alloc |
|---|---|---|---|
| canonical line | 731 ns | **31 ns (23×)** | 904 B → 48 B |
| non-canonical / plain text | unchanged within noise | | |

Benchmark/equivalence harness: BenchmarkDotNet 0.14, baselines extracted verbatim from git HEAD; SubRip equivalence exercises the real product method via reflection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)