### PR TITLE
Raise video margin limit from 50 to 1000

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -276,10 +276,10 @@ public class BurnInWindow : Window
 
         var labelMargin = UiUtil.MakeLabel(Se.Language.General.Margin);
         var labelMarginHorizontal = UiUtil.MakeLabel(Se.Language.General.Horizontal);
-        var textBoxMarginHorizontal = UiUtil.MakeNumericUpDownInt(0, 50, 0, 130, vm, nameof(vm.FontMarginHorizontal));
+        var textBoxMarginHorizontal = UiUtil.MakeNumericUpDownInt(0, 1000, 0, 130, vm, nameof(vm.FontMarginHorizontal));
         textBoxMarginHorizontal.ValueChanged += vm.NumericUpDownChanged;
         var labelMarginVertical = UiUtil.MakeLabel(Se.Language.General.Vertical).WithMarginLeft(5);
-        var textBoxMarginVertical = UiUtil.MakeNumericUpDownInt(0, 50, 0, 130, vm, nameof(vm.FontMarginVertical));
+        var textBoxMarginVertical = UiUtil.MakeNumericUpDownInt(0, 1000, 0, 130, vm, nameof(vm.FontMarginVertical));
         textBoxMarginVertical.ValueChanged += vm.NumericUpDownChanged;
         var panelMargin = new StackPanel
         {

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesWindow.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesWindow.cs
@@ -235,10 +235,10 @@ public class TransparentSubtitlesWindow : Window
 
         var labelMargin = UiUtil.MakeLabel(Se.Language.General.Margin);
         var labelMarginHorizontal = UiUtil.MakeLabel(Se.Language.General.Horizontal);
-        var textBoxMarginHorizontal = UiUtil.MakeNumericUpDownInt(0, 50, 0, 130, vm, nameof(vm.FontMarginHorizontal));
+        var textBoxMarginHorizontal = UiUtil.MakeNumericUpDownInt(0, 1000, 0, 130, vm, nameof(vm.FontMarginHorizontal));
         textBoxMarginHorizontal.ValueChanged += vm.NumericUpDownChanged;
         var labelMarginVertical = UiUtil.MakeLabel(Se.Language.General.Vertical).WithMarginLeft(5);
-        var textBoxMarginVertical = UiUtil.MakeNumericUpDownInt(0, 50, 0, 130, vm, nameof(vm.FontMarginVertical));
+        var textBoxMarginVertical = UiUtil.MakeNumericUpDownInt(0, 1000, 0, 130, vm, nameof(vm.FontMarginVertical));
         textBoxMarginVertical.ValueChanged += vm.NumericUpDownChanged;
         var panelMargin = new StackPanel
         {


### PR DESCRIPTION
## Summary
- Raise the max horizontal/vertical margin from 50 to 1000 in the "Generate video with burned-in subtitles" window
- Same fix in the "Generate subtitles with transparent video" window, which had the identical cap

The ASSA styles window already allows margins up to 1000, and these margin values feed directly into the generated ASSA style, so the 50 cap was purely a UI constraint.

Fixes #12480

🤖 Generated with [Claude Code](https://claude.com/claude-code)