### PR TITLE
Fix alternating row colors becoming out of sync after editing rows

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -4,6 +4,7 @@ using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Data.Converters;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
@@ -153,6 +154,11 @@ public static partial class InitListViewAndEditBox
             }
         }
 
+        // Convert row indexes to alternating background brushes when the option is enabled.
+        var alternatingRowBrushConverter = alternatingRowBrush == null
+            ? null
+            : new FuncValueConverter<int, IBrush>(index => index % 2 == 1 ? alternatingRowBrush : Brushes.Transparent);
+
         // Set up data binding for row visibility based on IsHidden property
         vm.SubtitleGrid.LoadingRow += (sender, e) =>
         {
@@ -161,11 +167,15 @@ public static partial class InitListViewAndEditBox
                 Converter = inverseBooleanConverter
             });
 
-            // Tint every other row. Rows are recycled on scroll, so LoadingRow re-fires with the
-            // updated index. Selection still wins because :selected overrides BackgroundRectangle.Fill.
-            if (alternatingRowBrush != null)
+            // Tint every other row. Binding to Index keeps the color in sync when rows are recycled,
+            // inserted, or removed. Selection still wins because :selected overrides BackgroundRectangle.Fill.
+            if (alternatingRowBrushConverter != null)
             {
-                e.Row.Background = e.Row.Index % 2 == 1 ? alternatingRowBrush : Brushes.Transparent;
+                e.Row.Bind(DataGridRow.BackgroundProperty, new Binding(nameof(DataGridRow.Index))
+                {
+                    Source = e.Row,
+                    Converter = alternatingRowBrushConverter,
+                });
             }
         };
 


### PR DESCRIPTION
## Problem

With `Use alternating row colors in grid` enabled, adding or removing subtitle rows could leave the grid’s alternating background pattern out of sync until the grid was recreated or rows were recycled by scrolling.

## Cause & Fix

Row backgrounds were assigned only when `LoadingRow` was raised, so already visible rows could retain colors calculated from their previous indexes after an insertion or removal.

Add an index-to-brush converter:

```csharp
var alternatingRowBrushConverter = alternatingRowBrush == null
    ? null
    : new FuncValueConverter<int, IBrush>(
        index => index % 2 == 1 ? alternatingRowBrush : Brushes.Transparent);
```

Bind each row background to its live `DataGridRow.Index` through this converter, keeping the alternating pattern synchronized as rows are inserted, removed, or recycled.

## Screenshots

|Before|After|
|---|---|
|<video src="https://github.com/user-attachments/assets/3c7fe46b-cb24-49ec-adf6-c9ba2f86f8e2">|<video src="https://github.com/user-attachments/assets/93a0d48d-bf60-4bb3-9661-7df24740b4ee">|
|the alternating pattern could become misaligned after editing rows.|the pattern remains consistent.|



## Testing

- Tested on Windows 11 x64, local Release build.
- Edited an SRT file with 5,000 cues.
- Verified the alternating-row option both when enabled and disabled.