### PR TITLE
Release v5.1.0-rc3

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,7 +3,7 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
-v5.1.0-rc3 (TBD)
+v5.1.0-rc3 (15th of July 2026)
 
 * Export: add "DVD sup (MuxMan/Scenarist)" image-based export - the classic DVD-Video subpicture .sup that DVD authoring tools import
 * Spell check: start at the current line instead of asking "Continue spell check from current line?" - the question is now only asked when an earlier spell check was left unfinished

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -17,7 +17,7 @@ public class Se
 {
     internal const int CurrentMacOsFontMigrationVersion = 1;
 
-    public static string Version { get; set; } = "v5.1.0-rc2";
+    public static string Version { get; set; } = "v5.1.0-rc3";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Prep for the next pre-release.

- `Se.cs`: bump `Version` to `v5.1.0-rc3` (the installer, macOS Info.plist and flatpak metainfo versions are derived from this during the build).
- `change-log.txt`: date the `v5.1.0-rc3` section (15th of July 2026).

After merge, the `Build and release UI` workflow will be run against `main` with tag `v5.1.0-rc3` (pre-release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)