### PR TITLE
Live spell check: only show grid context-menu items when one line is selected

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -19378,7 +19378,11 @@ public partial class MainViewModel :
         var pointerArgs = _lastSubtitleGridPointerArgs;
         _lastSubtitleGridPointerArgs = null;
 
+        // Only offer the live spell check items for a single right-clicked line; with several
+        // lines selected the per-word suggestions/"ignore all" would be ambiguous (they act on the
+        // one clicked cell, not the selection).
         if (IsSubtitleGridFlyoutHeaderVisible ||
+            SubtitleGrid.SelectedItems.Count != 1 ||
             (!Se.Settings.Appearance.SubtitleGridLiveSpellCheck && !Se.Settings.Appearance.SubtitleTextBoxLiveSpellCheck))
         {
             return;


### PR DESCRIPTION
In the subtitle grid, the live spell check context-menu items (word suggestions, "add to user dictionary", "ignore all") were shown even when several lines were selected. Those items act on the single right-clicked cell, so with a multi-line selection they're ambiguous.

Now they're only added when exactly one row is selected (`SubtitleGrid.SelectedItems.Count == 1`), matching the codebase's convention for single-row context actions. Previous spell check items are still cleared first, so no stale items linger when the selection grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)