### PR TITLE
Start v5.1.0-rc4

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,12 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.1.0-rc4 (TBD)
+
+* Live spell check: only show the subtitle grid spell check items (suggestions, add to user dictionary, ignore all) when a single line is selected
+
+-----------------------------------------------------------------------------------------------------
+
 v5.1.0-rc3 (15th of July 2026)
 
 * Export: add "DVD sup (MuxMan/Scenarist)" image-based export - the classic DVD-Video subpicture .sup that DVD authoring tools import

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -17,7 +17,7 @@ public class Se
 {
     internal const int CurrentMacOsFontMigrationVersion = 1;
 
-    public static string Version { get; set; } = "v5.1.0-rc3";
+    public static string Version { get; set; } = "v5.1.0-rc4";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Open the next pre-release cycle.

- `Se.cs`: bump `Version` to `v5.1.0-rc4`.
- `change-log.txt`: add a new `v5.1.0-rc4 (TBD)` section with the single-line grid spell check menu fix (#12488).

🤖 Generated with [Claude Code](https://claude.com/claude-code)