### PR TITLE
Fix seek silence jumping to wrong position when waveform is scrolled

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -3392,7 +3392,7 @@ public class AudioVisualizer : Control
 
             if (hitCount > length)
             {
-                var seconds = RelativeXPositionToSeconds(i - (length / 2));
+                var seconds = SampleIndexToSeconds(i - (length / 2));
                 if (seconds >= 0)
                 {
                     StartPositionSeconds = seconds;
@@ -3428,7 +3428,7 @@ public class AudioVisualizer : Control
                 hitCount++;
                 if (hitCount > length)
                 {
-                    var seconds = RelativeXPositionToSeconds(i + length / 2);
+                    var seconds = SampleIndexToSeconds(i + length / 2);
                     if (seconds >= 0)
                     {
                         StartPositionSeconds = seconds;


### PR DESCRIPTION
Fixes #12493

The waveform/spectrogram "seek silence" feature (dialog + forward/back shortcuts) landed at the wrong position whenever the waveform was scrolled past the start or zoomed.

`FindDataBelowThreshold` and `FindDataBelowThresholdBack` converted the found *sample index* to seconds with `RelativeXPositionToSeconds`, which is a screen-pixel conversion: it adds `StartPositionSeconds` and divides by `ZoomFactor`. That made the result correct only at scroll position 0 with zoom 100% — matching the "works only partially" report. SE4 used `SampleIndexToSeconds` here, and the third sibling function (`FindDataBelowThresholdBackForStart`) already does so in v5.

Two-word fix: use `SampleIndexToSeconds` at both call sites, as in SE4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)