### PR TITLE
Shortcuts: tolerant key search + canonical modifier order

### DIFF
--- a/src/ui/Features/Options/Shortcuts/GetKeyViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/GetKeyViewModel.cs
@@ -91,43 +91,39 @@ public partial class GetKeyViewModel : ObservableObject
         // bindable distinct from main Delete and from numpad-Decimal (NumLock on).
         var keyName = ShortcutManager.GetShortcutKeyName(e);
 
-        PressedKey = keyName;
-        PressedKeyOnly = PressedKey;
+        PressedKeyOnly = keyName;
         IsControlPressed = e.KeyModifiers.HasFlag(KeyModifiers.Control);
         IsAltPressed = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
         IsShiftPressed = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
         IsWinPressed = _isWinDown;
 
-        if (e.KeyModifiers.HasFlag(KeyModifiers.Shift) &&
-            PressedKey != Key.LeftShift.ToString() &&
-            PressedKey != Key.RightShift.ToString())
-        {
-            PressedKey = "Shift+";
-            infoText = shiftLabel + " + ";       
-        }
-        
-        if (e.KeyModifiers.HasFlag(KeyModifiers.Control) &&
-            PressedKey != Key.LeftCtrl.ToString() &&
-            PressedKey != Key.RightCtrl.ToString())
+        // Build the chord in canonical modifier order: Control, Alt, Shift, Win
+        PressedKey = string.Empty;
+
+        if (IsControlPressed)
         {
             PressedKey += "Ctrl+";
             infoText += ctrlLabel + " + ";
         }
 
-        if (e.KeyModifiers.HasFlag(KeyModifiers.Alt) &&
-            PressedKey != Key.LeftAlt.ToString() &&
-            PressedKey != Key.RightAlt.ToString())
+        if (IsAltPressed)
         {
             PressedKey += "Alt+";
-            infoText += altLabel + " + ";  
+            infoText += altLabel + " + ";
         }
 
-        if (_isWinDown)
+        if (IsShiftPressed)
+        {
+            PressedKey += "Shift+";
+            infoText += shiftLabel + " + ";
+        }
+
+        if (IsWinPressed)
         {
             PressedKey += "Win+";
-            infoText += winLabel + " + ";       
+            infoText += winLabel + " + ";
         }
-        
+
         PressedKey += keyName;
         infoText += keyName;
 

--- a/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
@@ -308,7 +308,7 @@ public partial class ShortcutsViewModel : ObservableObject
     {
         if (shortCut.Keys.Count > 0)
         {
-            var keys = shortCut.Keys.Select(k => ShortcutManager.GetKeyDisplayName(k)).ToList();
+            var keys = ShortcutManager.OrderKeys(shortCut.Keys).Select(k => ShortcutManager.GetKeyDisplayName(k)).ToList();
             return string.Join(" + ", keys);
         }
 
@@ -939,7 +939,7 @@ public partial class ShortcutsViewModel : ObservableObject
                 continue;
             }
 
-            var keysCombination = string.Join("+", shortcut.Keys.Select(ShortcutManager.NormalizeKeyToken).OrderBy(k => k));
+            var keysCombination = string.Join("+", ShortcutManager.OrderKeys(shortcut.Keys.Select(ShortcutManager.NormalizeKeyToken)));
             if (string.IsNullOrWhiteSpace(keysCombination))
             {
                 continue;
@@ -1063,11 +1063,6 @@ public partial class ShortcutsViewModel : ObservableObject
 
         var keys = new List<string>();
 
-        if (ShiftIsSelected)
-        {
-            keys.Add("Shift");
-        }
-
         if (CtrlIsSelected)
         {
             keys.Add("Ctrl");
@@ -1076,6 +1071,11 @@ public partial class ShortcutsViewModel : ObservableObject
         if (AltIsSelected)
         {
             keys.Add("Alt");
+        }
+
+        if (ShiftIsSelected)
+        {
+            keys.Add("Shift");
         }
 
         if (WinIsSelected)
@@ -1156,7 +1156,76 @@ public partial class ShortcutsViewModel : ObservableObject
 
         var title = MakeDisplayName(p);
         return title.Contains(searchText, StringComparison.InvariantCultureIgnoreCase) ||
-               title.Replace('-', ' ').Contains(searchText.Replace('-', ' '), StringComparison.InvariantCultureIgnoreCase);
+               title.Replace('-', ' ').Contains(searchText.Replace('-', ' '), StringComparison.InvariantCultureIgnoreCase) ||
+               IsKeyCombinationMatch(searchText, p);
+    }
+
+    /// <summary>
+    /// Matches searches like "Control+Shift+R", "shift + ctrl" or "alt+h" against the
+    /// shortcut's keys — modifiers in any order, spaces around '+' optional, and
+    /// aliases like "ctrl" accepted.
+    /// </summary>
+    private static bool IsKeyCombinationMatch(string searchText, ShortCut p)
+    {
+        if (!searchText.Contains('+') || p.Keys.Count == 0)
+        {
+            return false;
+        }
+
+        var tokens = searchText.Split('+', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (tokens.Length == 0)
+        {
+            return false;
+        }
+
+        // Each search token must match a distinct key; longer tokens first so
+        // "control" claims the Control key before a short token like "r" can.
+        var unmatchedKeys = p.Keys.Select(ShortcutManager.NormalizeKeyToken).ToList();
+        foreach (var token in tokens.OrderByDescending(t => t.Length))
+        {
+            var index = unmatchedKeys.FindIndex(k => KeyMatchesSearchToken(k, token));
+            if (index < 0)
+            {
+                return false;
+            }
+
+            unmatchedKeys.RemoveAt(index);
+        }
+
+        return true;
+    }
+
+    private static bool KeyMatchesSearchToken(string key, string token)
+    {
+        var normalizedToken = token.ToLowerInvariant() switch
+        {
+            "ctrl" or "control" => "Control",
+            "alt" or "option" or "opt" => "Alt",
+            "shift" => "Shift",
+            "win" or "windows" or "cmd" or "command" or "meta" or "super" => "Win",
+            _ => token,
+        };
+
+        if (key.Equals(normalizedToken, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        // A bare digit should match its stored "D4"-style token
+        if (normalizedToken.Length == 1 && char.IsDigit(normalizedToken[0]))
+        {
+            return key.Equals("D" + normalizedToken, StringComparison.OrdinalIgnoreCase);
+        }
+
+        // Single characters must match exactly (or the display name, so pasted
+        // mac symbols like "⇧" work) - else "r" would match "Control"
+        if (normalizedToken.Length == 1)
+        {
+            return ShortcutManager.GetKeyDisplayName(key).Equals(normalizedToken, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return key.StartsWith(normalizedToken, StringComparison.OrdinalIgnoreCase) ||
+               ShortcutManager.GetKeyDisplayName(key).Contains(normalizedToken, StringComparison.OrdinalIgnoreCase);
     }
 
     internal void ShortcutsDataGrid_SelectionChanged(object? sender, SelectionChangedEventArgs e)

--- a/src/ui/Logic/ShortcutManager.cs
+++ b/src/ui/Logic/ShortcutManager.cs
@@ -53,6 +53,30 @@ public class ShortcutManager : IShortcutManager
         return key;
     }
 
+    /// <summary>
+    /// Orders shortcut key tokens canonically — Control, Alt, Shift, Win, then regular
+    /// keys — so a shortcut always reads the same way regardless of stored order.
+    /// </summary>
+    public static List<string> OrderKeys(IEnumerable<string> keys)
+    {
+        return keys
+            .OrderBy(GetCanonicalKeyRank)
+            .ThenBy(NormalizeKeyToken, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static int GetCanonicalKeyRank(string key)
+    {
+        return NormalizeKeyToken(key) switch
+        {
+            "Control" => 0,
+            "Alt" => 1,
+            "Shift" => 2,
+            "Win" => 3,
+            _ => 4,
+        };
+    }
+
     public static Key GetShortcutKey(KeyEventArgs e)
     {
         return GetShortcutKey(e.Key, e.PhysicalKey);

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -2779,7 +2779,7 @@ public static class UiUtil
         var shortcutString = string.Empty;
         if (shortcut is { Keys.Count: > 0 })
         {
-            shortcutString = string.Join("+", shortcut.Keys.Select(k => ShortcutManager.GetKeyDisplayName(k.ToString())));
+            shortcutString = string.Join("+", ShortcutManager.OrderKeys(shortcut.Keys).Select(k => ShortcutManager.GetKeyDisplayName(k)));
             shortcutString = $"({shortcutString})";
         }
 


### PR DESCRIPTION
Addresses the search and naming-convention parts of #12492.

**Tolerant search.** Key-combination searches now go through a dedicated matcher when the search text contains `+`:
- Modifier order no longer matters — `Shift + Control` and `Control + Shift` find the same hits.
- Spaces around `+` are optional (none, one, or many all work).
- Common aliases are accepted: `ctrl`/`control`, `alt`/`option`, `win`/`cmd`/`meta`/`super`.
- Each search token must match a distinct key, so a search for `r` can't accidentally match the "r" inside "Control"; bare digits match their stored `D4`-style tokens.

Plain text searches over shortcut names behave exactly as before.

**Canonical key order.** Shortcut keys are now always presented as Control, Alt, Shift, Win, then the regular key — via a shared `ShortcutManager.OrderKeys` helper used by:
- the shortcuts list and its search text,
- tooltip/menu hint strings (`UiUtil.MakeShortcutsString`),
- the duplicate-shortcut warning on OK — this previously sorted tokens *alphabetically*, which is where the odd `Control+R+Shift` in the report came from,
- the press-a-key dialog, and
- the key list saved when editing a shortcut (was Shift, Ctrl, Alt, Win).

Also fixes a small bug in the press-a-key dialog where the key name leaked into the chord string when Shift wasn't held (e.g. Ctrl+R produced `RCtrl+R`).

Verified the matcher and ordering with a standalone harness covering the exact scenarios from the issue (18 checks, all passing), plus a clean build.

Note: the actual Ctrl+Shift+R collision reported in the issue isn't reproducible from current defaults — only multiple replace binds it now — so it likely comes from an older RC default persisting in the reporter's settings file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)