### PR TITLE
Transparent video: live mpv preview like burn-in + apply effects to output

### DIFF
--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
@@ -7,14 +7,17 @@ using Avalonia.Skia;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Controls.VideoPlayer;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Main.Layout;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Shared.PromptTextBox;
 using Nikse.SubtitleEdit.Features.Video.BurnIn;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
@@ -99,6 +102,14 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
     private string _inputVideoFileName;
     private List<BurnInEffectItem> _selectedEffects;
 
+    public VideoPlayerControl? VideoPlayerControl { get; set; }
+    private VideoPlayerControl? _fullScreenVideoPlayerControl;
+    private LibMpvDynamicPlayer? _mpvPreviewPlayer;
+    private DispatcherTimer? _previewTimer;
+    private string _oldPreviewAssa = string.Empty;
+    private readonly string _tempPreviewAssaFileName;
+    private bool _isPreviewSubtitleLoaded;
+
     private readonly IWindowService _windowService;
     private readonly IFolderHelper _folderHelper;
     private readonly IFileHelper _fileHelper;
@@ -159,6 +170,7 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         DisplayEffect = string.Empty;
 
         _selectedEffects = new List<BurnInEffectItem>();
+        _tempPreviewAssaFileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".ass");
         _log = new StringBuilder();
         _timerGenerate = new();
         _timerGenerate.Elapsed += TimerGenerateElapsed;
@@ -619,7 +631,18 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
 
         if (!isAssa)
         {
-            SetStyleForNonAssa(subtitle);
+            var jobItem = JobItems[_jobItemIndex];
+            var fontSize = CalculateFontSize(jobItem.Width, jobItem.Height, FontFactor ?? 0);
+            foreach (var s in subtitle.Paragraphs)
+            {
+                foreach (var effect in _selectedEffects)
+                {
+                    var durationMs = (int)s.Duration.TotalMilliseconds;
+                    s.Text = effect.ApplyEffect(s.Text, jobItem.Width, jobItem.Height, fontSize, durationMs);
+                }
+            }
+
+            SetStyleForNonAssa(subtitle, jobItem.Width, jobItem.Height);
         }
 
         var assa = new AdvancedSubStationAlpha();
@@ -628,11 +651,11 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         return assaFileName;
     }
 
-    private void SetStyleForNonAssa(Subtitle sub)
+    private void SetStyleForNonAssa(Subtitle sub, int width, int height)
     {
         sub.Header = AdvancedSubStationAlpha.DefaultHeader;
         var style = AdvancedSubStationAlpha.GetSsaStyle("Default", sub.Header);
-        style.FontSize = CalculateFontSize(JobItems[_jobItemIndex].Width, JobItems[_jobItemIndex].Height, FontFactor ?? 0);
+        style.FontSize = CalculateFontSize(width, height, FontFactor ?? 0);
         style.Bold = FontIsBold;
         style.FontName = SelectedFontName;
         style.Background = FontShadowColor.ToSKColor();
@@ -662,9 +685,9 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
             AdvancedSubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(sub.Header,
                 new List<SsaStyle> { style });
         sub.Header = AdvancedSubStationAlpha.AddTagToHeader("PlayResX",
-            "PlayResX: " + (VideoWidth ?? 1920).ToString(CultureInfo.InvariantCulture), "[Script Info]", sub.Header);
+            "PlayResX: " + width.ToString(CultureInfo.InvariantCulture), "[Script Info]", sub.Header);
         sub.Header = AdvancedSubStationAlpha.AddTagToHeader("PlayResY",
-            "PlayResY: " + (VideoHeight ?? 1080).ToString(CultureInfo.InvariantCulture), "[Script Info]", sub.Header);
+            "PlayResY: " + height.ToString(CultureInfo.InvariantCulture), "[Script Info]", sub.Header);
     }
 
     private string MakeOutputFileName(string videoFileName)
@@ -1206,6 +1229,209 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
     partial void OnFontTextColorChanged(Color value) => UpdateNonAssaPreview();
     partial void OnFontOutlineColorChanged(Color value) => UpdateNonAssaPreview();
     partial void OnFontShadowColorChanged(Color value) => UpdateNonAssaPreview();
+
+    internal void Loaded()
+    {
+        Dispatcher.UIThread.Post(LoadVideoPreview);
+    }
+
+    /// <summary>
+    /// Builds the ASSA text for the live preview from the current style/effect settings.
+    /// This mirrors <see cref="MakeAssa"/> but is independent of the job pipeline
+    /// so it can run while the user is still tweaking settings.
+    /// </summary>
+    private string? GeneratePreviewAssaText()
+    {
+        if (_subtitle.Paragraphs.Count == 0)
+        {
+            return null;
+        }
+
+        var width = VideoWidth ?? 1920;
+        var height = VideoHeight ?? 1080;
+
+        var subtitle = new Subtitle(_subtitle, false);
+        var isAssa = _subtitleFormat is { Name: AdvancedSubStationAlpha.NameOfFormat };
+        if (!isAssa)
+        {
+            var fontSize = CalculateFontSize(width, height, FontFactor ?? 0);
+            foreach (var s in subtitle.Paragraphs)
+            {
+                foreach (var effect in _selectedEffects)
+                {
+                    var durationMs = (int)s.Duration.TotalMilliseconds;
+                    s.Text = effect.ApplyEffect(s.Text, width, height, fontSize, durationMs);
+                }
+            }
+
+            SetStyleForNonAssa(subtitle, width, height);
+        }
+
+        var assa = new AdvancedSubStationAlpha();
+        return assa.ToText(subtitle, string.Empty);
+    }
+
+    private async void LoadVideoPreview()
+    {
+        if (VideoPlayerControl == null ||
+            string.IsNullOrWhiteSpace(VideoFileName) ||
+            !File.Exists(VideoFileName))
+        {
+            return;
+        }
+
+        try
+        {
+            await VideoPlayerControl.Open(VideoFileName);
+            await VideoPlayerControl.WaitForPlayersReadyAsync();
+            SetActivePreviewPlayer(VideoPlayerControl.VideoPlayer as LibMpvDynamicPlayer, alreadyHasSubtitle: false);
+
+            // Seek to the first subtitle so the user immediately sees styled text.
+            if (_subtitle.Paragraphs.Count > 0)
+            {
+                VideoPlayerControl.SetPosition(_subtitle.Paragraphs[0].StartTime.TotalSeconds + 0.05);
+            }
+
+            StartPreviewTimer();
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, "Failed to start transparent-video preview");
+        }
+    }
+
+    private void StartPreviewTimer()
+    {
+        _previewTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(500) };
+        _previewTimer.Tick += (_, _) =>
+        {
+            if (_mpvPreviewPlayer == null || _loading)
+            {
+                return;
+            }
+
+            string? assaText;
+            try
+            {
+                assaText = GeneratePreviewAssaText();
+            }
+            catch
+            {
+                return; // ignore transient errors while the user is editing settings
+            }
+
+            if (string.IsNullOrEmpty(assaText) || assaText == _oldPreviewAssa)
+            {
+                return;
+            }
+
+            _oldPreviewAssa = assaText;
+            File.WriteAllText(_tempPreviewAssaFileName, assaText);
+            if (!_isPreviewSubtitleLoaded)
+            {
+                _isPreviewSubtitleLoaded = true;
+                _mpvPreviewPlayer.SubAdd(_tempPreviewAssaFileName);
+            }
+            else
+            {
+                _mpvPreviewPlayer.SubReload();
+            }
+        };
+        _previewTimer.Start();
+    }
+
+    /// <summary>
+    /// Points the live-preview timer at a specific mpv player (the embedded one or the
+    /// fullscreen one). Forces a refresh on the next tick so the styled subtitle is
+    /// (re)applied to the now-active player.
+    /// </summary>
+    private void SetActivePreviewPlayer(LibMpvDynamicPlayer? mpv, bool alreadyHasSubtitle)
+    {
+        _mpvPreviewPlayer = mpv;
+        _isPreviewSubtitleLoaded = alreadyHasSubtitle;
+        _oldPreviewAssa = string.Empty;
+    }
+
+    [RelayCommand]
+    private void PreviewFullScreen()
+    {
+        var control = VideoPlayerControl;
+        if (control == null || control.IsFullScreen ||
+            string.IsNullOrWhiteSpace(VideoFileName) || !File.Exists(VideoFileName) ||
+            _fullScreenVideoPlayerControl != null)
+        {
+            return;
+        }
+
+        control.VideoPlayer.Pause();
+        var position = control.Position;
+        var volume = control.Volume;
+
+        // Mirror the main window: use a separate fullscreen player rather than
+        // reparenting the embedded one (avoids airspace/reparent issues).
+        _fullScreenVideoPlayerControl = InitVideoPlayer.MakeVideoPlayer();
+        _fullScreenVideoPlayerControl.IsFullScreen = true;
+
+        var fullScreenWindow = new FullScreenVideoWindow(
+            _fullScreenVideoPlayerControl,
+            VideoFileName,
+            string.Empty,
+            position,
+            volume,
+            () =>
+            {
+                var fs = _fullScreenVideoPlayerControl;
+                _fullScreenVideoPlayerControl = null;
+                if (fs != null)
+                {
+                    control.SetPosition(fs.Position);
+                }
+
+                // The embedded player kept its file + subtitle loaded, so reload (not re-add).
+                SetActivePreviewPlayer(control.VideoPlayer as LibMpvDynamicPlayer, alreadyHasSubtitle: true);
+            });
+        fullScreenWindow.Show(Window!);
+
+        // Once the fullscreen player has opened the file, route the preview to it so
+        // style/effect changes keep updating live while fullscreen.
+        var fsControl = _fullScreenVideoPlayerControl;
+        Dispatcher.UIThread.Post(async () =>
+        {
+            await fsControl.WaitForPlayersReadyAsync();
+            if (_fullScreenVideoPlayerControl == fsControl) // still fullscreen (not closed in the meantime)
+            {
+                SetActivePreviewPlayer(fsControl.VideoPlayer as LibMpvDynamicPlayer, alreadyHasSubtitle: false);
+            }
+        });
+    }
+
+    public void CleanupPreview()
+    {
+        _previewTimer?.Stop();
+        _previewTimer = null;
+        _mpvPreviewPlayer = null;
+
+        try
+        {
+            VideoPlayerControl?.Close();
+        }
+        catch
+        {
+            // ignore
+        }
+
+        try
+        {
+            if (File.Exists(_tempPreviewAssaFileName))
+            {
+                File.Delete(_tempPreviewAssaFileName);
+            }
+        }
+        catch
+        {
+            // ignore
+        }
+    }
 
     internal void ComboBoxChanged(object? sender, SelectionChangedEventArgs e)
     {

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesWindow.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesWindow.cs
@@ -7,6 +7,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Threading;
 using Nikse.SubtitleEdit.Controls;
+using Nikse.SubtitleEdit.Features.Main.Layout;
 using Nikse.SubtitleEdit.Features.Video.BurnIn;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -126,6 +127,12 @@ public class TransparentSubtitlesWindow : Window
         {
             if (e.PropertyName == nameof(vm.IsBatchMode))
             {
+                if (vm.IsBatchMode)
+                {
+                    // The player is hidden in batch mode - stop its audio too.
+                    vm.VideoPlayerControl?.VideoPlayer.Pause();
+                }
+
                 UpdateGrowAreas();
                 LockMinimumToContentSize(); // batch mode needs more width; re-fit and re-lock the minimum
             }
@@ -133,8 +140,15 @@ public class TransparentSubtitlesWindow : Window
         UpdateGrowAreas();
 
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
+        Loaded += (_, _) => vm.Loaded();
 
         Opened += (_, _) => LockMinimumToContentSize();
+    }
+
+    protected override void OnClosing(WindowClosingEventArgs e)
+    {
+        base.OnClosing(e);
+        _vm.CleanupPreview();
     }
 
     private void LockMinimumToContentSize()
@@ -402,7 +416,8 @@ public class TransparentSubtitlesWindow : Window
     {
         var checkBoxCut = UiUtil.MakeCheckBox(Se.Language.Video.BurnIn.Cut, vm, nameof(vm.IsCutActive));
 
-        var buttonCutFrom = UiUtil.MakeButtonBrowse(vm.BrowseCutFromCommand).WithMarginTop(10).WithRightAlignment();
+        var buttonCutFrom = UiUtil.MakeButtonBrowse(vm.BrowseCutFromCommand);
+        buttonCutFrom.VerticalAlignment = VerticalAlignment.Center;
         var labelFromTime = UiUtil.MakeLabel(Se.Language.Video.BurnIn.FromTime);
         var timeUpDownFrom = new TimeCodeUpDown
         {
@@ -411,7 +426,8 @@ public class TransparentSubtitlesWindow : Window
             VerticalAlignment = VerticalAlignment.Center,
         };
 
-        var buttonCutTo = UiUtil.MakeButtonBrowse(vm.BrowseCutToCommand).WithMarginTop(10).WithRightAlignment();
+        var buttonCutTo = UiUtil.MakeButtonBrowse(vm.BrowseCutToCommand);
+        buttonCutTo.VerticalAlignment = VerticalAlignment.Center;
         var labelToTime = UiUtil.MakeLabel(Se.Language.Video.BurnIn.ToTime);
         var timeUpDownTo = new TimeCodeUpDown
         {
@@ -427,11 +443,10 @@ public class TransparentSubtitlesWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
                 new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
                 new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
             },
@@ -443,22 +458,38 @@ public class TransparentSubtitlesWindow : Window
 
         grid.Add(checkBoxCut, 0, 0);
 
-        grid.Add(buttonCutFrom, 1, 1);
-        grid.Add(labelFromTime, 2, 0);
-        grid.Add(timeUpDownFrom, 2, 1);
+        grid.Add(labelFromTime, 1, 0);
+        grid.Add(timeUpDownFrom, 1, 1);
+        grid.Add(buttonCutFrom, 1, 2);
 
-        grid.Add(buttonCutTo, 3, 1);
-        grid.Add(labelToTime, 4, 0);
-        grid.Add(timeUpDownTo, 4, 1);
+        grid.Add(labelToTime, 2, 0);
+        grid.Add(timeUpDownTo, 2, 1);
+        grid.Add(buttonCutTo, 2, 2);
 
-        return UiUtil.MakeBorderForControl(grid).WithMarginRight(5);
+        return UiUtil.MakeBorderForControl(grid).WithMarginBottom(5).WithMarginRight(5);
     }
 
     private static Border MakePreviewView(TransparentSubtitlesViewModel vm)
     {
-
         var labelPreview = UiUtil.MakeLabel(Se.Language.General.Preview);
 
+        // Live preview (single mode): the loaded video plays in an embedded mpv player
+        // while the current style/effects are generated as an ASSA subtitle and rendered
+        // on top via libass (sub-add/sub-reload) - see TransparentSubtitlesViewModel.LoadVideoPreview.
+        // Single mode always has a video (no video forces batch mode), so the player can
+        // fully replace the old static image preview there.
+        vm.VideoPlayerControl = InitVideoPlayer.MakeVideoPlayer();
+        vm.VideoPlayerControl.FullScreenIsVisible = true;
+        vm.VideoPlayerControl.FullScreenCommand = vm.PreviewFullScreenCommand;
+        vm.VideoPlayerControl.MinWidth = 480;
+        vm.VideoPlayerControl.MinHeight = 270;
+        vm.VideoPlayerControl.HorizontalAlignment = HorizontalAlignment.Stretch;
+        vm.VideoPlayerControl.VerticalAlignment = VerticalAlignment.Stretch;
+        vm.VideoPlayerControl.Bind(Visual.IsVisibleProperty,
+            new Binding(nameof(vm.IsBatchMode)) { Source = vm, Converter = new InverseBooleanConverter() });
+
+        // Batch mode fallback: batch items are separate files (possibly with no video at
+        // all), so show a static image rendered from the current style settings instead.
         var image = new Image
         {
             [!Image.SourceProperty] = new Binding(nameof(vm.ImagePreview)),
@@ -478,6 +509,7 @@ public class TransparentSubtitlesWindow : Window
             MinWidth = 300,
             Height = double.NaN,
         };
+        scrollViewer.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsBatchMode)) { Source = vm });
 
         var grid = new Grid
         {
@@ -497,6 +529,7 @@ public class TransparentSubtitlesWindow : Window
         };
 
         grid.Add(labelPreview, 0, 0);
+        grid.Add(vm.VideoPlayerControl, 1, 0);
         grid.Add(scrollViewer, 1, 0);
 
         return UiUtil.MakeBorderForControl(grid).WithMarginBottom(5).WithMarginRight(5);


### PR DESCRIPTION
Fixes #12490

**Live video preview.** The preview area showed a static Skia-rendered "This is a test" image (and a blank 1×1 bitmap for ASSA input), which can't match the libass-rendered ffmpeg output. This ports the burn-in preview approach: in single mode the loaded video plays in an embedded mpv player while a 500 ms timer regenerates an ASSA file from the current style/effect settings and `sub-add`/`sub-reload`s it — so the preview shows the real subtitles with the real renderer, including the fullscreen preview. Single mode always has a video (opening the dialog without one forces batch mode), so the player fully replaces the static image there. Batch mode keeps the static image preview, since batch items are separate files that may have no video at all; the player pauses when switching to batch so hidden audio doesn't keep playing.

**Effects now actually apply.** The dialog has an Effects picker, but `MakeAssa` never applied the selected effects to the generated video (burn-in does). Generation and the new live preview now both apply them.

**Compact cut panel.** The cut panel now uses burn-in's 3-row layout with the browse buttons inline next to the time fields.

Preview internals (`GeneratePreviewAssaText`, timer, fullscreen routing, cleanup) mirror `BurnInViewModel`'s proven implementation; `SetStyleForNonAssa` was refactored to take width/height like its burn-in counterpart. Build is clean — needs a quick visual check of the dialog (single mode preview, batch fallback, fullscreen) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)