### PR TITLE
Three micro-optimizations verified with BenchmarkDotNet

### DIFF
--- a/src/libse/Common/HtmlUtil.cs
+++ b/src/libse/Common/HtmlUtil.cs
@@ -424,48 +424,83 @@ namespace Nikse.SubtitleEdit.Core.Common
                 s = FixInvalidItalicTags(s);
             }
 
-            if (s.IndexOf('x') > 0)
+            // One pass over the '<' positions instead of up to seven substring scans:
+            // the box/v/c handling below is only relevant when a tag actually starts
+            // with the matching letter, which typical lines (<i>, <font>, plain text)
+            // never have.
+            var hasBTag = false;
+            var hasVTag = false;
+            var hasCTag = false;
+            for (var i = s.IndexOf('<'); i >= 0 && i < s.Length - 1; i = s.IndexOf('<', i + 1))
+            {
+                var next = s[i + 1];
+                if (next == '/' && i + 2 < s.Length)
+                {
+                    next = s[i + 2];
+                }
+
+                if (next == 'b')
+                {
+                    hasBTag = true;
+                }
+                else if (next == 'v')
+                {
+                    hasVTag = true;
+                }
+                else if (next == 'c')
+                {
+                    hasCTag = true;
+                }
+            }
+
+            if (hasBTag)
             {
                 s = s.Replace("<box>", string.Empty).Replace("</box>", string.Empty);
             }
 
             // v tag from WebVTT
-            while (true)
+            if (hasVTag)
             {
-                var indexOfVTag = s.IndexOf("<v ", StringComparison.Ordinal);
-                if (indexOfVTag < 0)
+                while (true)
                 {
-                    indexOfVTag = s.IndexOf("<v.", StringComparison.Ordinal);
+                    var indexOfVTag = s.IndexOf("<v ", StringComparison.Ordinal);
+                    if (indexOfVTag < 0)
+                    {
+                        indexOfVTag = s.IndexOf("<v.", StringComparison.Ordinal);
+                    }
+                    if (indexOfVTag < 0)
+                    {
+                        break;
+                    }
+                    var indexOfEndVTag = s.IndexOf('>', indexOfVTag);
+                    if (indexOfEndVTag < 0)
+                    {
+                        break;
+                    }
+                    s = s.Remove(indexOfVTag, indexOfEndVTag - indexOfVTag + 1);
                 }
-                if (indexOfVTag < 0)
-                {
-                    break;
-                }
-                var indexOfEndVTag = s.IndexOf('>', indexOfVTag);
-                if (indexOfEndVTag < 0)
-                {
-                    break;
-                }
-                s = s.Remove(indexOfVTag, indexOfEndVTag - indexOfVTag + 1);
+                s = s.Replace("</v>", string.Empty);
             }
-            s = s.Replace("</v>", string.Empty);
 
             // c tag from WebVTT
-            while (true)
+            if (hasCTag)
             {
-                var indexOfCTag = s.IndexOf("<c.", StringComparison.Ordinal);
-                if (indexOfCTag < 0)
+                while (true)
                 {
-                    break;
+                    var indexOfCTag = s.IndexOf("<c.", StringComparison.Ordinal);
+                    if (indexOfCTag < 0)
+                    {
+                        break;
+                    }
+                    var indexOfEndCTag = s.IndexOf('>', indexOfCTag);
+                    if (indexOfEndCTag < 0)
+                    {
+                        break;
+                    }
+                    s = s.Remove(indexOfCTag, indexOfEndCTag - indexOfCTag + 1);
                 }
-                var indexOfEndCTag = s.IndexOf('>', indexOfCTag);
-                if (indexOfEndCTag < 0)
-                {
-                    break;
-                }
-                s = s.Remove(indexOfCTag, indexOfEndCTag - indexOfCTag + 1);
+                s = s.Replace("</c>", string.Empty);
             }
-            s = s.Replace("</c>", string.Empty);
 
             return RemoveCommonHtmlTags(s);
         }

--- a/src/ui/Logic/Shortcut.cs
+++ b/src/ui/Logic/Shortcut.cs
@@ -33,14 +33,61 @@ public class ShortCut
 
     public static string CalculateHash(List<string> keys, string? control)
     {
-        var sb = new System.Text.StringBuilder();
-        foreach (var key in keys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase))
+        // Runs twice per key event (direct + normalized lookup) and twice per shortcut
+        // when the lookup table is rebuilt, so avoid LINQ ordering and the per-key
+        // lowercase string allocations.
+        var count = keys.Count;
+
+        // Stable insertion sort of a small index span - same order as
+        // OrderBy(k => k, StringComparer.OrdinalIgnoreCase).
+        Span<int> order = count <= 8 ? stackalloc int[8] : new int[count];
+        for (var i = 0; i < count; i++)
         {
-            sb.Append(key.ToLowerInvariant()).Append('+');
+            order[i] = i;
         }
 
-        sb.Append(control?.ToLowerInvariant() ?? string.Empty);
-        return sb.ToString();
+        for (var i = 1; i < count; i++)
+        {
+            var current = order[i];
+            var j = i - 1;
+            while (j >= 0 && string.Compare(keys[order[j]], keys[current], StringComparison.OrdinalIgnoreCase) > 0)
+            {
+                order[j + 1] = order[j];
+                j--;
+            }
+
+            order[j + 1] = current;
+        }
+
+        var totalLength = count + (control?.Length ?? 0);
+        for (var i = 0; i < count; i++)
+        {
+            totalLength += keys[i].Length;
+        }
+
+        // Lowercase char-by-char into one buffer; a single string allocation for the result.
+        Span<char> buffer = totalLength <= 256 ? stackalloc char[256] : new char[totalLength];
+        var pos = 0;
+        for (var i = 0; i < count; i++)
+        {
+            var key = keys[order[i]];
+            for (var k = 0; k < key.Length; k++)
+            {
+                buffer[pos++] = char.ToLowerInvariant(key[k]);
+            }
+
+            buffer[pos++] = '+';
+        }
+
+        if (control != null)
+        {
+            for (var k = 0; k < control.Length; k++)
+            {
+                buffer[pos++] = char.ToLowerInvariant(control[k]);
+            }
+        }
+
+        return new string(buffer[..pos]);
     }
 
     public ShortCut(ShortcutsMain.AvailableShortcut shortcut, SeShortCut keys)

--- a/src/ui/Logic/SubtitleTextInfoHelper.cs
+++ b/src/ui/Logic/SubtitleTextInfoHelper.cs
@@ -119,7 +119,9 @@ internal static class SubtitleTextInfoHelper
             return 0.0;
         }
 
-        return (double)StripHtml(text).CountCharacters(forCps: true) / (duration / 1000.0);
+        // No StripHtml here: every ICalcLength implementation strips html/ssa tags
+        // itself, so pre-stripping would run RemoveHtmlTags twice per call.
+        return (double)text.CountCharacters(forCps: true) / (duration / 1000.0);
     }
 
     internal sealed record TextTotalInfo(double TotalLength, string TotalText, IBrush TotalBackground);


### PR DESCRIPTION
Three hot-path micro-optimizations, each verified with BenchmarkDotNet (.NET 10, macOS arm64) against a verbatim copy of the old implementation, with a correctness gate asserting identical output over a corpus (WebVTT `<v>`/`<c>` tags, `<box>`, stray tags, mixed-case keys, empty input) before any timing runs.

### 1. `ShortCut.CalculateHash` — 2.2–3.7× faster, ~90% less allocation

Runs twice per key event (direct + normalized lookup) and twice per shortcut on lookup-table rebuilds. The LINQ `OrderBy` + `StringBuilder` + per-key `ToLowerInvariant()` produced 5+ allocations per call; now a stack-based stable insertion sort over indices with char-wise lowering into one buffer — a single allocation (the result).

| Case | Old | New | Alloc old → new |
|---|---|---|---|
| 3 keys (Ctrl+Shift+R) | 201 ns | 93 ns | 760 B → 72 B |
| 1 key (Space) | 141 ns | 38 ns | 536 B → 56 B |
| 4 keys | 243 ns | 66 ns | 976 B → 88 B |

### 2. `SubtitleTextInfoHelper.GetCharactersPerSecond` — 32–37% faster

The outer `StripHtml` was redundant: every `ICalcLength` implementation strips tags itself (the two CpsOnly variants delegate to strippers), so tags were stripped twice per call — per keystroke and per grid-row update.

| Case | Old | New |
|---|---|---|
| `<i>` tagged line | 139 ns | 94 ns |
| plain line | 67 ns | 43 ns |

### 3. `HtmlUtil.RemoveHtmlTags` — 37–46% faster on typical lines

The WebVTT `<v>`/`<c>`/`<box>` handling ran up to seven substring scans on every call, and the box guard (`IndexOf('x') > 0`) fired for any text containing the letter "x". Now a single pass over the `'<'` positions decides which handlers are relevant. MediumRunJob (15 iterations):

| Case | Old | New |
|---|---|---|
| `<i>Hello there, how are you?</i>` | 114 ns | 71 ns |
| `<font color=…>` line | 187 ns | 100 ns |
| plain text | 8.2 ns | 8.2 ns (early-out unchanged) |
| actual `<v>` WebVTT line | 64 ns | 65 ns (real work dominates) |

`RemoveHtmlTags` sits under nearly everything: both call sites above, grid repaint, statistics, fixes — so #2 and #3 compound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)