### PR TITLE
Update change log for rc4

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -6,6 +6,11 @@ Subtitle Edit Changelog
 v5.1.0-rc4 (TBD)
 
 * Live spell check: only show the subtitle grid spell check items (suggestions, add to user dictionary, ignore all) when a single line is selected
+* Waveform: fix "Seek silence" jumping far past the actual silence when the waveform was scrolled or zoomed - thx AdiOpi
+* Shortcuts: the search now accepts modifier keys in any order with optional spaces around "+" (e.g. "shift+control" or "ctrl+r"), and shortcuts always show their keys in canonical order (Control, Alt, Shift, Win) - also in the duplicate-shortcut warning - thx GrampaWildWilly
+* Generate transparent video: live video preview like burn-in - the styled subtitles render over the playing video while settings are tweaked - thx MbuguaDavid
+* Generate transparent video: fix the selected effects not being applied to the generated video, and compact the cut panel
+* Performance: faster shortcut key lookup and HTML tag stripping (subtitle grid, characters-per-second and per-keystroke text info)
 
 -----------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Adds the rc4 entries for everything merged since v5.1.0-rc3, enumerated from the PR merge commits on main that are not ancestors of the rc3 tag:

- #12495 — seek silence position fix (#12493, thx AdiOpi)
- #12496 — shortcuts search tolerance + canonical key order (#12492, thx GrampaWildWilly)
- #12497 — transparent video live preview, effects fix, compact cut panel (#12490, thx MbuguaDavid)
- #12498 — micro-optimizations (shortcut hash, CPS double-strip, RemoveHtmlTags)

(#12488 was already in the section.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)