### PR TITLE
Clamp windows to the screen working area; scrollable Whisper post-processing

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessingWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessingWindow.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Layout;
@@ -162,11 +163,34 @@ public class SpeechToTextPostProcessingWindow : Window
         grid.Add(numericBeamSize, row, 1, 1, 2);
         row++;
         grid.Add(labelBeamSizeNote, row, 0, 1, 3);
-        row++;
 
-        grid.Add(buttonPanel, row, 0, 1, 3);
+        // The settings scroll while the OK/Cancel bar stays pinned, so the dialog
+        // remains usable when the screen is too small for the full form (e.g. high
+        // DPI) and the window gets height-clamped to the working area.
+        var scrollViewer = new ScrollViewer
+        {
+            Content = grid,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+        };
 
-        Content = grid;
+        var outerGrid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+        };
+        buttonPanel.Margin = new Avalonia.Thickness(10, 0, 10, 10);
+        outerGrid.Add(scrollViewer, 0, 0);
+        outerGrid.Add(buttonPanel, 1, 0);
+
+        Content = outerGrid;
 
         Activated += delegate { Focus(); }; // hack to make OnKeyDown work
     }

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -2790,6 +2790,93 @@ public static class UiUtil
     {
         window.Icon = GetSeIcon();
         window.Name = name;
+
+        // On small or high-DPI screens (e.g. 1920x1080 at 150% = 1280x853 DIPs of
+        // working area) SizeToContent windows can measure taller/wider than the screen,
+        // leaving the bottom buttons unreachable - Avalonia does not cap them itself.
+        // Clamp once when opened, and once more at Background priority so windows that
+        // re-fit themselves in a posted callback (LockMinimumToContentSize in e.g. the
+        // burn-in window runs at Loaded priority) get clamped again afterwards.
+        window.Opened += (_, _) =>
+        {
+            ClampToWorkingArea(window);
+            Dispatcher.UIThread.Post(() => ClampToWorkingArea(window), DispatcherPriority.Background);
+        };
+    }
+
+    private static void ClampToWorkingArea(Window window)
+    {
+        if (window.WindowState != WindowState.Normal)
+        {
+            return;
+        }
+
+        var screen = window.Screens.ScreenFromWindow(window) ?? window.Screens.Primary;
+        if (screen == null)
+        {
+            return;
+        }
+
+        var scale = window.DesktopScaling;
+        if (scale <= 0)
+        {
+            return;
+        }
+
+        // Window sizes are in DIPs, the working area in physical pixels. Compare the
+        // full frame so OS decorations (title bar, borders) are accounted for.
+        var workingArea = screen.WorkingArea;
+        var frameSize = window.FrameSize ?? window.Bounds.Size;
+        var frameExtraWidth = Math.Max(0, frameSize.Width - window.Bounds.Width);
+        var frameExtraHeight = Math.Max(0, frameSize.Height - window.Bounds.Height);
+        var maxWidth = workingArea.Width / scale - frameExtraWidth;
+        var maxHeight = workingArea.Height / scale - frameExtraHeight;
+        if (maxWidth <= 0 || maxHeight <= 0)
+        {
+            return;
+        }
+
+        // A minimum size larger than the screen makes the window impossible to shrink
+        // (e.g. windows that lock MinWidth/MinHeight to their measured content size).
+        if (window.MinWidth > maxWidth)
+        {
+            window.MinWidth = maxWidth;
+        }
+
+        if (window.MinHeight > maxHeight)
+        {
+            window.MinHeight = maxHeight;
+        }
+
+        if (window.Bounds.Width > maxWidth || window.Bounds.Height > maxHeight)
+        {
+            // Stop content-driven sizing before shrinking, or the next measure pass
+            // would just grow the window back.
+            window.SizeToContent = SizeToContent.Manual;
+            if (window.Bounds.Width > maxWidth)
+            {
+                window.Width = maxWidth;
+            }
+
+            if (window.Bounds.Height > maxHeight)
+            {
+                window.Height = maxHeight;
+            }
+        }
+
+        // Keep the whole frame inside the working area so the bottom buttons stay
+        // reachable (a centered too-tall window overflows both top and bottom).
+        var frameWidthPx = (int)Math.Round(Math.Min(frameSize.Width, maxWidth + frameExtraWidth) * scale);
+        var frameHeightPx = (int)Math.Round(Math.Min(frameSize.Height, maxHeight + frameExtraHeight) * scale);
+        var maxX = workingArea.X + workingArea.Width - frameWidthPx;
+        var maxY = workingArea.Y + workingArea.Height - frameHeightPx;
+        var x = Math.Min(Math.Max(window.Position.X, workingArea.X), Math.Max(workingArea.X, maxX));
+        var y = Math.Min(Math.Max(window.Position.Y, workingArea.Y), Math.Max(workingArea.Y, maxY));
+        var position = new PixelPoint(x, y);
+        if (position != window.Position)
+        {
+            window.Position = position;
+        }
     }
 
     public static void SaveWindowPosition(Window? window)


### PR DESCRIPTION
Fixes #12500

**Global working-area clamp.** Every window passes through `UiUtil.InitializeWindow`, which now hooks `Opened` and clamps the window to its screen's working area: `Width`/`Height`, `MinWidth`/`MinHeight` (a min larger than the screen makes a window impossible to shrink — this is what bit the burn-in window, whose `LockMinimumToContentSize` locks the minimum to measured content), and `Position` (a centered too-tall window overflows top *and* bottom; now the frame is pushed fully inside so the buttons stay reachable). Sizes are compared frame-to-working-area with DPI scaling (`DesktopScaling`) since window sizes are DIPs and screen bounds physical pixels. A second clamp runs at `Background` dispatcher priority to catch windows that re-fit themselves in a posted callback (the `LockMinimumToContentSize` pattern posts at `Loaded` priority).

**Scrollable Whisper post-processing dialog.** Its settings form is taller than a 150%-DPI 1080p working area, so clamping alone would clip it. The settings grid now lives in a vertical `ScrollViewer` with the OK/Cancel bar pinned beneath — content scrolls, buttons never leave the screen. Other affected dialogs (e.g. Advanced speech-to-text parameters) already have star-sized scrolling middles, so the global clamp is sufficient for them.

No blanket ScrollViewer around all windows, deliberately: a vertical scroller measures its child with infinite height, which breaks star-sized layouts (DataGrid virtualization, embedded players, waveforms). Form-style dialogs can opt in as needed like the post-processing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)