### PR TITLE
Add "Remove" to actor context menu + configurable shortcut

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14573,6 +14573,9 @@ public partial class MainViewModel :
     private void SetActor10() => SetActorByIndex(9);
 
     [RelayCommand]
+    private void RemoveActor() => SetActorForSelectedLines(string.Empty);
+
+    [RelayCommand]
     private async Task SetNewActor()
     {
         var result = await ShowDialogAsync<PromptTextBoxWindow, PromptTextBoxViewModel>(vm =>
@@ -19346,6 +19349,18 @@ public partial class MainViewModel :
                     Header = Se.Language.General.NewDotDotDot,
                     Command = SetNewActorForSelectedLinesCommand,
                 });
+
+                var removeActorMenuItem = new MenuItem
+                {
+                    Header = Se.Language.General.Remove,
+                    Command = RemoveActorCommand,
+                };
+                var removeActorShortcut = usedShortcuts.FirstOrDefault(s => ReferenceEquals(s.Action, RemoveActorCommand));
+                if (removeActorShortcut != null)
+                {
+                    removeActorMenuItem.InputGesture = InitMenu.ToKeyGesture(removeActorShortcut);
+                }
+                MenuItemActors.Items.Add(removeActorMenuItem);
             }
         }
 

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -395,6 +395,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.SetActor9Command), string.Format(Se.Language.Options.Shortcuts.SetActorXY, "9", Se.Settings.Actor9) },
         { nameof(MainViewModel.SetActor10Command), string.Format(Se.Language.Options.Shortcuts.SetActorXY, "10", Se.Settings.Actor10) },
         { nameof(MainViewModel.SetNewActorCommand), Se.Language.Options.Shortcuts.SetNewActor },
+        { nameof(MainViewModel.RemoveActorCommand), Se.Language.General.Actor + " - " + Se.Language.General.Remove },
         { nameof(MainViewModel.SurroundWith1Command), string.Format(Se.Language.Options.Shortcuts.SurroundWithXY,  Se.Settings.Surround1Left, Se.Settings.Surround1Right) },
         { nameof(MainViewModel.SurroundWith2Command), string.Format(Se.Language.Options.Shortcuts.SurroundWithXY,  Se.Settings.Surround2Left, Se.Settings.Surround2Right) },
         { nameof(MainViewModel.SurroundWith3Command), string.Format(Se.Language.Options.Shortcuts.SurroundWithXY,  Se.Settings.Surround3Left, Se.Settings.Surround3Right) },
@@ -779,6 +780,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.SetActor9Command, nameof(vm.SetActor9Command), ShortcutCategory.SubtitleGrid);
         AddShortcut(shortcuts, vm.SetActor10Command, nameof(vm.SetActor10Command), ShortcutCategory.SubtitleGrid);
         AddShortcut(shortcuts, vm.SetNewActorCommand, nameof(vm.SetNewActorCommand), ShortcutCategory.SubtitleGrid);
+        AddShortcut(shortcuts, vm.RemoveActorCommand, nameof(vm.RemoveActorCommand), ShortcutCategory.SubtitleGrid);
         AddShortcut(shortcuts, vm.SurroundWith1Command, nameof(vm.SurroundWith1Command), ShortcutCategory.SubtitleGridAndTextBox);
         AddShortcut(shortcuts, vm.SurroundWith2Command, nameof(vm.SurroundWith2Command), ShortcutCategory.SubtitleGridAndTextBox);
         AddShortcut(shortcuts, vm.SurroundWith3Command, nameof(vm.SurroundWith3Command), ShortcutCategory.SubtitleGridAndTextBox);


### PR DESCRIPTION
Fixes #12502

Previously there was no way to clear the actor from a line — users had to create a dummy actor to blank it out.

Changes:
- The subtitle grid context menu "Actors" submenu now has a **Remove** item (after "New...") that clears the actor on all selected lines.
- Added a matching configurable shortcut (`RemoveActor`, subtitle grid category, shown as "Actor - Remove" in the shortcuts list). If a key is assigned, the gesture is displayed next to the menu item like the SetActor 1-10 items.
- No new language tags — reuses `General.Actor` and `General.Remove`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)