### PR TITLE
Allow assigning shortcuts to waveform seek video back/forward buttons

### DIFF
--- a/src/ui/Features/Main/Layout/InitWaveform.cs
+++ b/src/ui/Features/Main/Layout/InitWaveform.cs
@@ -670,7 +670,7 @@ public class InitWaveform
             VerticalAlignment = VerticalAlignment.Center,
             Command = vm.WaveformVideoSeekBackCommand,
             FontWeight = FontWeight.Bold,
-            [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.SeekBackHint, shortcuts),
+            [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.SeekBackHint, shortcuts, nameof(vm.WaveformVideoSeekBackCommand)),
         };
         Attached.SetIcon(buttonSeekBack, IconNames.ChevronDoubleLeft);
         AutomationProperties.SetName(buttonSeekBack, string.Format(languageHints.SeekBackHint, string.Empty).TrimEnd());
@@ -700,7 +700,7 @@ public class InitWaveform
             VerticalAlignment = VerticalAlignment.Center,
             Command = vm.WaveformVideoSeekForwardCommand,
             FontWeight = FontWeight.Bold,
-            [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.SeekForwardHint, shortcuts),
+            [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.SeekForwardHint, shortcuts, nameof(vm.WaveformVideoSeekForwardCommand)),
         };
         Attached.SetIcon(buttonSeekForward, IconNames.ChevronDoubleRight);
         AutomationProperties.SetName(buttonSeekForward, string.Format(languageHints.SeekForwardHint, string.Empty).TrimEnd());

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12332,6 +12332,8 @@ public partial class MainViewModel :
             (nameof(VideoOneSecondForwardCommand),  VideoOneSecondForwardCommand),
             (nameof(VideoOneFrameBackCommand),      VideoOneFrameBackCommand),
             (nameof(VideoOneFrameForwardCommand),   VideoOneFrameForwardCommand),
+            (nameof(WaveformVideoSeekBackCommand),  WaveformVideoSeekBackCommand),
+            (nameof(WaveformVideoSeekForwardCommand), WaveformVideoSeekForwardCommand),
             (nameof(VideoMoveCustom1BackCommand),   VideoMoveCustom1BackCommand),
             (nameof(VideoMoveCustom1ForwardCommand),VideoMoveCustom1ForwardCommand),
             (nameof(VideoMoveCustom2BackCommand),   VideoMoveCustom2BackCommand),

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -249,6 +249,10 @@ public static class ShortcutsMain
 
         { nameof(MainViewModel.VideoOneFrameBackCommand), Se.Language.General.VideoOneFrameBack },
         { nameof(MainViewModel.VideoOneFrameForwardCommand),  Se.Language.General.VideoOneFrameForward },
+        // Waveform toolbar seek buttons - reuse the button hint strings ("Seek video backward {0}")
+        // with the shortcut placeholder blanked out, same as their automation names in InitWaveform.
+        { nameof(MainViewModel.WaveformVideoSeekBackCommand), string.Format(Se.Language.Main.Waveform.SeekBackHint, string.Empty).TrimEnd() },
+        { nameof(MainViewModel.WaveformVideoSeekForwardCommand), string.Format(Se.Language.Main.Waveform.SeekForwardHint, string.Empty).TrimEnd() },
         { nameof(MainViewModel.Video100MsBackCommand), Se.Language.General.Video100MsBack },
         { nameof(MainViewModel.Video100MsForwardCommand),  Se.Language.General.Video100MsForward },
         { nameof(MainViewModel.Video500MsBackCommand), Se.Language.General.Video500MsBack },
@@ -640,6 +644,8 @@ public static class ShortcutsMain
 
         AddShortcut(shortcuts, vm.VideoOneFrameBackCommand, nameof(vm.VideoOneFrameBackCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.VideoOneFrameForwardCommand, nameof(vm.VideoOneFrameForwardCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.WaveformVideoSeekBackCommand, nameof(vm.WaveformVideoSeekBackCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.WaveformVideoSeekForwardCommand, nameof(vm.WaveformVideoSeekForwardCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.Video100MsBackCommand, nameof(vm.Video100MsBackCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.Video100MsForwardCommand, nameof(vm.Video100MsForwardCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.Video500MsBackCommand, nameof(vm.Video500MsBackCommand), ShortcutCategory.General, ShortcutGroup.Video);


### PR DESCRIPTION
Fixes #12350

The `<<` / `>>` "Seek video backward/forward" buttons below the waveform could only be triggered by mouse. This makes them assignable keyboard shortcuts.

Changes:
- `WaveformVideoSeekBackCommand` / `WaveformVideoSeekForwardCommand` are now configurable shortcuts under General > Video, listed as "Seek video backward" / "Seek video forward".
- The toolbar button tooltips now show the assigned key combo (the `{0}` placeholder in the existing hint strings was previously always blank for these two buttons).
- The shortcuts also work in the fullscreen video window, like the other video seek shortcuts.

No new language tags — the shortcut names reuse the existing `SeekBackHint`/`SeekForwardHint` strings with the placeholder blanked out, same as the buttons' automation names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)