### PR TITLE
Make all Shortcuts window columns sortable

### DIFF
--- a/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
@@ -177,7 +177,8 @@ public class ShortcutsWindow : Window
                 {
                     Header = language.ActiveIn,
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    CanUserSort = false,
+                    // Template columns need an explicit SortMemberPath to be sortable (#12431).
+                    SortMemberPath = nameof(ShortcutTreeNode.ActiveIn),
                     IsReadOnly = true,
                     CellTemplate = new FuncDataTemplate<ShortcutTreeNode>((_, _) =>
                     {
@@ -207,7 +208,7 @@ public class ShortcutsWindow : Window
                 {
                     Header = string.Empty,
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    CanUserSort = false,
+                    SortMemberPath = nameof(ShortcutTreeNode.GroupName),
                     CanUserResize = false,
                     IsReadOnly = true,
                     CellTemplate = new FuncDataTemplate<ShortcutTreeNode>((_, _) =>
@@ -240,7 +241,7 @@ public class ShortcutsWindow : Window
                 {
                     Header = Se.Language.General.Category,
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    CanUserSort = false,
+                    SortMemberPath = nameof(ShortcutTreeNode.GroupName),
                     IsReadOnly = true,
                     CellTemplate = new FuncDataTemplate<ShortcutTreeNode>((_, _) =>
                     {
@@ -271,7 +272,7 @@ public class ShortcutsWindow : Window
                 {
                     Header = Se.Language.General.Shortcut,
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    CanUserSort = false,
+                    SortMemberPath = nameof(ShortcutTreeNode.DisplayShortcut),
                     IsReadOnly = true,
                     Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
                     CellTemplate = new FuncDataTemplate<ShortcutTreeNode>((_, _) =>


### PR DESCRIPTION
Related to #12507

Previously only the Name column in the Shortcuts window was sortable. The other columns (Active in, group icon, Category, Shortcut) were template columns with `CanUserSort = false`.

Changes:
- All columns are now sortable by clicking the header. Template columns need an explicit `SortMemberPath` to be sortable (same fix as #12431):
  - **Active in** sorts by the `ActiveIn` text
  - **Group icon** and **Category** sort by the category name
  - **Shortcut** sorts by the shortcut display string (unassigned rows group together)
- Since the grid collection is filtered by mutating it in place, an active sort persists while filtering by category chip or search text — so sorting *within* a category (mentioned in the issue) works as well.

No new language tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)