### PR TITLE
Shortcuts: wrap long category tile labels instead of clipping

### DIFF
--- a/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
@@ -136,6 +136,9 @@ public class ShortcutsWindow : Window
                     FontSize = 11,
                     HorizontalAlignment = HorizontalAlignment.Center,
                     TextAlignment = TextAlignment.Center,
+                    // Long group names like "Subtitle list view & text box" must wrap to a second
+                    // line instead of clipping at the fixed tile width (#12507).
+                    TextWrapping = TextWrapping.Wrap,
                 };
                 name.Bind(TextBlock.TextProperty, new Binding(nameof(ShortcutGroupTile.Name)));
 


### PR DESCRIPTION
Related to #12507

The "Subtitle list view & text box" tile label clipped at the ampersand because the label `TextBlock` had no `TextWrapping` set. It now wraps to a second line within the fixed 92 px tile width, as suggested in the issue ("there is room up there to show the rest of that label on a second line").

🤖 Generated with [Claude Code](https://claude.com/claude-code)