### PR TITLE
Batch convert: status column as colored badges

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
@@ -177,13 +177,45 @@ public class BatchConvertWindow : Window
                     IsReadOnly = true,
                     Width = new DataGridLength(170, DataGridLengthUnitType.Pixel),
                 },
-                new DataGridTextColumn
+                new DataGridTemplateColumn
                 {
                     Header = Se.Language.General.Status,
                     CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    Binding = new Binding(nameof(BatchConvertItem.Status)),
+                    // Template columns need an explicit SortMemberPath to be sortable (#12431).
+                    SortMemberPath = nameof(BatchConvertItem.Status),
                     IsReadOnly = true,
                     Width = new DataGridLength(120, DataGridLengthUnitType.Pixel),
+                    CellTemplate = new FuncDataTemplate<BatchConvertItem>((_, _) =>
+                    {
+                        // Status as a colored badge: green converted, red errors, gray cancelled;
+                        // in-progress statuses render as plain text (converter returns unset).
+                        var text = new TextBlock
+                        {
+                            FontSize = 11,
+                            VerticalAlignment = VerticalAlignment.Center,
+                        };
+                        text.Bind(TextBlock.TextProperty, new Binding(nameof(BatchConvertItem.Status)));
+                        text.Bind(TextBlock.ForegroundProperty, new Binding(nameof(BatchConvertItem.Status))
+                        {
+                            Converter = new BatchConvertStatusColorConverter(),
+                        });
+
+                        var pill = new Border
+                        {
+                            CornerRadius = new CornerRadius(99),
+                            Padding = new Thickness(8, 1, 8, 2),
+                            Margin = new Thickness(4, 0, 4, 0),
+                            HorizontalAlignment = HorizontalAlignment.Left,
+                            VerticalAlignment = VerticalAlignment.Center,
+                            Child = text,
+                        };
+                        pill.Bind(Border.BackgroundProperty, new Binding(nameof(BatchConvertItem.Status))
+                        {
+                            Converter = new BatchConvertStatusColorConverter(),
+                            ConverterParameter = "background",
+                        });
+                        return pill;
+                    }),
                 },
             },
         };

--- a/src/ui/Logic/ValueConverters/BatchConvertStatusColorConverter.cs
+++ b/src/ui/Logic/ValueConverters/BatchConvertStatusColorConverter.cs
@@ -1,0 +1,63 @@
+using Avalonia;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Globalization;
+
+namespace Nikse.SubtitleEdit.Logic.ValueConverters;
+
+/// <summary>
+/// Colors the batch convert status column as a badge: green for converted, red for errors,
+/// gray for cancelled. In-progress and idle statuses ("-", "OCR 42%", ...) stay unstyled -
+/// bind with ConverterParameter "background" for the badge fill, anything else for the text color.
+/// Mid-saturation tones picked to stay readable on both the dark and light theme.
+/// </summary>
+public class BatchConvertStatusColorConverter : IValueConverter
+{
+    private static readonly SolidColorBrush SuccessForeground = new(Color.Parse("#3fae74"));
+    private static readonly SolidColorBrush SuccessBackground = new(Color.Parse("#3fae74"), 0.16);
+    private static readonly SolidColorBrush ErrorForeground = new(Color.Parse("#e05c5c"));
+    private static readonly SolidColorBrush ErrorBackground = new(Color.Parse("#e05c5c"), 0.14);
+    private static readonly SolidColorBrush CancelledForeground = new(Color.Parse("#8494a4"));
+    private static readonly SolidColorBrush CancelledBackground = new(Color.Parse("#8494a4"), 0.16);
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        var status = value as string;
+        var isBackground = parameter as string == "background";
+
+        if (string.IsNullOrEmpty(status) || status == "-")
+        {
+            return AvaloniaProperty.UnsetValue;
+        }
+
+        if (status == Se.Language.General.Converted)
+        {
+            return isBackground ? SuccessBackground : SuccessForeground;
+        }
+
+        if (status == Se.Language.General.Cancelled)
+        {
+            return isBackground ? CancelledBackground : CancelledForeground;
+        }
+
+        // "Error: {0}" - match on the part before the placeholder so translated texts work too.
+        var errorPrefix = string.Format(Se.Language.General.ErrorX, string.Empty).Trim();
+        if (status == Se.Language.General.NoSubtitlesFound ||
+            status == Se.Language.Ocr.OllamaModelLikelyWrong ||
+            (errorPrefix.Length > 0 && status.StartsWith(errorPrefix, StringComparison.OrdinalIgnoreCase)) ||
+            status.StartsWith("BinaryOcr database not found", StringComparison.Ordinal))
+        {
+            return isBackground ? ErrorBackground : ErrorForeground;
+        }
+
+        // In-progress statuses (OCR percentages etc.) keep the default text color, no badge.
+        return AvaloniaProperty.UnsetValue;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
From the Batch convert concept preview - just the status badges:

- The Status column renders as a rounded badge: **green** for Converted, **red** for errors ("Error: ...", no subtitles found, missing OCR database, wrong Ollama model), **gray** for Cancelled.
- In-progress statuses (OCR percentages, "-") keep the default text color with no badge, so the colors only appear when there is an outcome to report.
- Error matching keys on the localized "Error: {0}" prefix, so it works for translated UI languages.
- Column stays sortable (`SortMemberPath`, per #12431). No new language tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)