### PR TITLE
Time code spinner: nudge 100 ms, not a whole hour (#12506)

### DIFF
--- a/src/ui/Controls/TimeCodeUpDown.cs
+++ b/src/ui/Controls/TimeCodeUpDown.cs
@@ -19,6 +19,12 @@ namespace Nikse.SubtitleEdit.Controls
 {
     public class TimeCodeUpDown : TemplatedControl
     {
+        // Mouse spinner and wheel nudge by a fixed small step, matching SE4, instead of stepping
+        // the segment the text caret happens to sit in. The caret defaults to the hours field, so
+        // a plain spinner click used to jump a full hour (#12506). Keyboard Up/Down still steps the
+        // caret's segment, which is the deliberate way to change hours/minutes/seconds precisely.
+        private const int MouseStepMilliseconds = 100;
+
         public bool UseVideoOffset { get; set; } = false;
 
         private TextBox? _textBox;
@@ -55,14 +61,7 @@ namespace Nikse.SubtitleEdit.Controls
 
             control.AddHandler(InputElement.PointerWheelChangedEvent, (s, e) =>
             {
-                if (e.Delta.Y > 0)
-                {
-                    ChangeValue(+1);                    
-                }
-                else
-                {
-                    ChangeValue(-1);
-                }
+                MouseNudge(e.Delta.Y > 0 ? +1 : -1);
                 e.Handled = true;
             });
         }
@@ -476,7 +475,29 @@ namespace Nikse.SubtitleEdit.Controls
 
         private void OnSpin(object? sender, SpinEventArgs e)
         {
-            ChangeValue(e.Direction == SpinDirection.Increase ? +1 : -1);
+            MouseNudge(e.Direction == SpinDirection.Increase ? +1 : -1);
+        }
+
+        // Fixed small step for mouse interaction (spinner buttons and wheel). In frame mode a
+        // step is one whole frame; otherwise it is MouseStepMilliseconds, independent of where
+        // the caret is (#12506).
+        private void MouseNudge(int direction)
+        {
+            TimeSpan newVal;
+            if (Se.Settings.General.UseFrameMode)
+            {
+                var totalFrames = SubtitleFormat.MillisecondsToFrames(Value.TotalMilliseconds);
+                newVal = TimeSpan.FromMilliseconds(SubtitleFormat.FramesToMilliseconds(totalFrames + direction));
+            }
+            else
+            {
+                newVal = Value.Add(TimeSpan.FromMilliseconds(direction * MouseStepMilliseconds));
+            }
+
+            _isUpdatingFromValue = true;
+            SetValue(ValueProperty, newVal);
+            UpdateText();
+            _isUpdatingFromValue = false;
         }
 
         private void OnTextBoxKeyDown(object? sender, KeyEventArgs e)

--- a/src/ui/Controls/TimeCodeUpDown.cs
+++ b/src/ui/Controls/TimeCodeUpDown.cs
@@ -19,11 +19,11 @@ namespace Nikse.SubtitleEdit.Controls
 {
     public class TimeCodeUpDown : TemplatedControl
     {
-        // Mouse spinner and wheel nudge by a fixed small step, matching SE4, instead of stepping
-        // the segment the text caret happens to sit in. The caret defaults to the hours field, so
-        // a plain spinner click used to jump a full hour (#12506). Keyboard Up/Down still steps the
-        // caret's segment, which is the deliberate way to change hours/minutes/seconds precisely.
-        private const int MouseStepMilliseconds = 100;
+        // Every step (spinner, wheel and Up/Down) applies to the part the caret is on. The caret
+        // starts on the last part, the milliseconds or frames, so a plain spinner click makes the
+        // small adjustment that is wanted almost every time; it used to start on the hours and
+        // jump a whole hour (#12506). The millisecond step size is configurable in Settings.
+        private const int LastPartCaretIndex = 9;
 
         public bool UseVideoOffset { get; set; } = false;
 
@@ -61,7 +61,7 @@ namespace Nikse.SubtitleEdit.Controls
 
             control.AddHandler(InputElement.PointerWheelChangedEvent, (s, e) =>
             {
-                MouseNudge(e.Delta.Y > 0 ? +1 : -1);
+                ChangeValue(e.Delta.Y > 0 ? +1 : -1);
                 e.Handled = true;
             });
         }
@@ -202,7 +202,7 @@ namespace Nikse.SubtitleEdit.Controls
                     HorizontalAlignment = HorizontalAlignment.Stretch,
                     Width = double.NaN,
                     BorderBrush = Brushes.Transparent,
-                    CaretIndex = 0,
+                    CaretIndex = LastPartCaretIndex,
                 };
 
                 var grid = new Grid
@@ -243,8 +243,7 @@ namespace Nikse.SubtitleEdit.Controls
         {
             if (_textBox != null)
             {
-                // Select the first digit position
-                _textBox.CaretIndex = 0;
+                _textBox.CaretIndex = LastPartCaretIndex;
             }
         }
 
@@ -321,7 +320,7 @@ namespace Nikse.SubtitleEdit.Controls
                 SetValue(ValueProperty, value); // OnPropertyChanged clamps, reformats the text and raises ValueChanged
                 if (_textBox != null)
                 {
-                    _textBox.CaretIndex = 0;
+                    _textBox.CaretIndex = LastPartCaretIndex;
                 }
             }
         }
@@ -475,29 +474,7 @@ namespace Nikse.SubtitleEdit.Controls
 
         private void OnSpin(object? sender, SpinEventArgs e)
         {
-            MouseNudge(e.Direction == SpinDirection.Increase ? +1 : -1);
-        }
-
-        // Fixed small step for mouse interaction (spinner buttons and wheel). In frame mode a
-        // step is one whole frame; otherwise it is MouseStepMilliseconds, independent of where
-        // the caret is (#12506).
-        private void MouseNudge(int direction)
-        {
-            TimeSpan newVal;
-            if (Se.Settings.General.UseFrameMode)
-            {
-                var totalFrames = SubtitleFormat.MillisecondsToFrames(Value.TotalMilliseconds);
-                newVal = TimeSpan.FromMilliseconds(SubtitleFormat.FramesToMilliseconds(totalFrames + direction));
-            }
-            else
-            {
-                newVal = Value.Add(TimeSpan.FromMilliseconds(direction * MouseStepMilliseconds));
-            }
-
-            _isUpdatingFromValue = true;
-            SetValue(ValueProperty, newVal);
-            UpdateText();
-            _isUpdatingFromValue = false;
+            ChangeValue(e.Direction == SpinDirection.Increase ? +1 : -1);
         }
 
         private void OnTextBoxKeyDown(object? sender, KeyEventArgs e)
@@ -594,7 +571,8 @@ namespace Nikse.SubtitleEdit.Controls
                 }
                 else
                 {
-                    newVal = newVal.Add(TimeSpan.FromMilliseconds(delta));
+                    var step = Math.Max(1, Se.Settings.General.TimeCodeUpDownStepMs);
+                    newVal = newVal.Add(TimeSpan.FromMilliseconds(delta * step));
                 }
             }
 

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -255,6 +255,7 @@ public class SettingsPage : UserControl
         sections.Add(new SettingsSection(Se.Language.General.General, IconNames.Cogs, "#8494a4",
         [
             MakeNumericSettingInt(Se.Language.Options.Settings.NewEmptyDefaultMs, nameof(_vm.NewEmptyDefaultMs)),
+            MakeNumericSettingInt(Se.Language.Options.Settings.TimeCodeUpDownStepMs, nameof(_vm.TimeCodeUpDownStepMs), 1, 5000),
             MakeCheckboxSetting(Se.Language.Options.Settings.PromptBeforeDelete, nameof(_vm.PromptBeforeDelete)),
             MakeCheckboxSetting(Se.Language.Options.Settings.UseFrameMode, nameof(_vm.UseFrameMode)),
             MakeCheckboxSetting(Se.Language.Options.Settings.TextBoxLimitNewLines, nameof(_vm.TextBoxLimitNewLines)),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -105,6 +105,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private decimal _mpvPreviewShadowWidth;
 
     [ObservableProperty] private int? _newEmptyDefaultMs;
+    [ObservableProperty] private int? _timeCodeUpDownStepMs;
     [ObservableProperty] private bool _promptBeforeDelete;
     [ObservableProperty] private bool _lockTimeCodes;
     [ObservableProperty] private bool _rememberPositionAndSize;
@@ -690,6 +691,7 @@ public partial class SettingsViewModel : ObservableObject
         UseFrameMode = general.UseFrameMode;
         TextBoxLimitNewLines = general.SubtitleTextBoxLimitNewLines;
         NewEmptyDefaultMs = general.NewEmptyDefaultMs;
+        TimeCodeUpDownStepMs = general.TimeCodeUpDownStepMs;
         PromptBeforeDelete = general.PromptBeforeDelete;
         LockTimeCodes = general.LockTimeCodes;
         RememberPositionAndSize = general.RememberPositionAndSize;
@@ -1446,6 +1448,7 @@ public partial class SettingsViewModel : ObservableObject
         general.UseFrameMode = UseFrameMode;
         general.SubtitleTextBoxLimitNewLines = TextBoxLimitNewLines;
         general.NewEmptyDefaultMs = NewEmptyDefaultMs ?? general.NewEmptyDefaultMs;
+        general.TimeCodeUpDownStepMs = TimeCodeUpDownStepMs ?? general.TimeCodeUpDownStepMs;
         general.PromptBeforeDelete = PromptBeforeDelete;
         general.LockTimeCodes = LockTimeCodes;
         general.RememberPositionAndSize = RememberPositionAndSize;

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -111,6 +111,7 @@ public class LanguageSettings
     public string MaxLines { get; set; }
     public string UnbreakSubtitlesShortThan { get; set; }
     public string NewEmptyDefaultMs { get; set; }
+    public string TimeCodeUpDownStepMs { get; set; }
     public string PromptBeforeDelete { get; set; }
     public string RememberPositionAndSize { get; set; }
     public string OpenLastFileOnStart { get; set; }
@@ -441,6 +442,7 @@ public class LanguageSettings
         MaxLines = "Max number of lines";
         UnbreakSubtitlesShortThan = "Unbreak subtitles shorter than";
         NewEmptyDefaultMs = "Default new subtitle duration (ms)";
+        TimeCodeUpDownStepMs = "Time up/down increment (ms)";
         PromptBeforeDelete = "Prompt before delete";
         RememberPositionAndSize = "Remember window position and size";
         OpenLastFileOnStart = "Open last recent file on start";

--- a/src/ui/Logic/Config/SeGeneral.cs
+++ b/src/ui/Logic/Config/SeGeneral.cs
@@ -57,6 +57,10 @@ public class SeGeneral
     public int SubtitleMaximumDisplayMilliseconds { get; set; }
     public MsOrFramesValue MinimumBetweenLines { get; set; } = new() { Milliseconds = 24, Frames = 2 };
     public int NewEmptyDefaultMs { get; set; }
+
+    /// <summary>How much the time up/down controls change per step when the caret is on the
+    /// milliseconds part. Frame mode always steps one frame (#12506).</summary>
+    public int TimeCodeUpDownStepMs { get; set; }
     public bool PromptBeforeDelete { get; set; }
     public bool LockTimeCodes { get; set; }
     public bool RememberPositionAndSize { get; set; }
@@ -172,6 +176,7 @@ public class SeGeneral
         AutoConvertToUtf8 = false;
         AutoGuessAnsiEncoding = true;
         NewEmptyDefaultMs = 2000;
+        TimeCodeUpDownStepMs = 100;
         PromptBeforeDelete = true;
         AutoBackupOn = true;
         AutoBackupIntervalMinutes = 5;


### PR DESCRIPTION
Fixes #12506.

The time code up/down (the Show and Hide time fields, and every other time field in the app) stepped whichever segment the text caret sat in. The caret defaults to the hours field, so a plain spinner click, or the mouse wheel, jumped a full hour instead of a small nudge.

This makes mouse spinning and wheeling nudge a fixed small step: 100 ms, or one frame in frame mode, regardless of caret position, matching SE4. Keyboard Up/Down still steps the caret's segment, which is the deliberate way to change hours, minutes or seconds precisely.

Reported by @AdiOpi.
