### PR TITLE
Add llama.cpp OCR engine to Batch convert and seconv

### DIFF
--- a/docs/features/batch-convert.md
+++ b/docs/features/batch-convert.md
@@ -59,6 +59,7 @@ Supported OCR engines in Batch Convert:
 - BinaryOcr
 - Tesseract
 - Ollama
+- llama.cpp (curated OCR vision models — GLM-OCR, LightOnOCR, PaddleOCR-VL; a local `llama-server` is started automatically)
 - PaddleOCR (Windows and Linux only)
 
 Subtitle Edit 5 can auto-detect language and pixels-are-space settings for nOcr/BinaryOcr in many batch workflows. This reduces the amount of manual setup needed when converting many image-based subtitle files with similar fonts.

--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -53,6 +53,7 @@ seconv movie.sup subrip --ocr-engine:tesseract --ocr-language:eng  # OCR a Blu-R
 seconv movie.sup subrip --ocr-engine:nocr --ocr-db:Latin.nocr      # OCR via nOCR
 seconv movie.sup subrip --ocr-engine:binaryocr --ocr-db:Latin.db   # OCR via BinaryOCR
 seconv movie.sup subrip --ocr-engine:ollama --ollama-model:llama3.2-vision
+seconv movie.sup subrip --ocr-engine:llamacpp                      # OCR via llama.cpp (auto-starts llama-server)
 
 seconv subs.srt bluraysup --resolution:1920x1080                   # render text → Blu-Ray sup
 seconv subs.srt bdnxml --resolution:1920x1080                      # render text → BDN-XML
@@ -194,16 +195,19 @@ If two tracks share a language, the track number is added: `movie.#3.eng.srt`.
 | `nocr` | In-process | Built-in nOCR matcher. Required: `--ocr-db:<path-to-Latin.nocr>`. |
 | `binaryocr` *(alias: `binary`)* | In-process | Built-in BinaryOCR matcher (different accuracy profile, similar speed). Required: `--ocr-db:<path-to-Latin.db>`. |
 | `ollama` | HTTP | Local Ollama server with a vision-capable model (e.g. `llama3.2-vision`, `qwen2.5vl`). Configure via `--ollama-url` (default `http://localhost:11434/api/chat`) and `--ollama-model` (default `llama3.2-vision`). Pass `--ocr-language` as a human name like `English`. |
+| `llamacpp` *(aliases: `llama.cpp`, `llama`)* | HTTP | llama.cpp with a curated OCR vision model (GLM-OCR, LightOnOCR, PaddleOCR-VL). With no `--ocr-url`, seconv finds `llama-server` (SE data folder next to seconv, installed SE data folder, then `PATH`) and an installed OCR model, starts the server on a free loopback port, and stops it at exit. seconv never downloads engines/models — install them via the SE UI's OCR window (engine "llama.cpp") or point `--ocr-url` at a running server. Pass `--ocr-language` as a human name like `English`. |
 | `paddle` *(alias: `paddleocr`)* | Subprocess | Install via `pip install paddleocr`; ensure the `paddleocr` binary is on `PATH`. Pass `--ocr-language` as a short code (`en`, `de`, …). |
 
 | Option | Description |
 |---|---|
-| `--ocr-engine:<engine>` | `tesseract` (default) \| `nocr` \| `binaryocr` \| `ollama` \| `paddle` |
-| `--ocr-language:<lang>` | Tesseract: ISO 639-2 (`eng`, `deu`); Paddle: short (`en`); Ollama: human (`English`) |
+| `--ocr-engine:<engine>` | `tesseract` (default) \| `nocr` \| `binaryocr` \| `ollama` \| `llamacpp` \| `paddle` |
+| `--ocr-language:<lang>` | Tesseract: ISO 639-2 (`eng`, `deu`); Paddle: short (`en`); Ollama/llama.cpp: human (`English`) |
 | `--ocr-db:<path>` | OCR database file: `.nocr` for `nocr`, `.db` for `binaryocr` (required for both) |
 | `--dictionary-folder:<path>` | Folder with Hunspell dictionaries + `*_OCRFixReplaceList.xml`; enables the "Fix common OCR errors" pass of `--fix-common-errors` (English is bundled, so this is only needed for other languages) |
 | `--ollama-url:<url>` | Default `http://localhost:11434/api/chat` |
 | `--ollama-model:<model>` | Default `llama3.2-vision` |
+| `--ocr-model:<model>` | llama.cpp OCR model: curated `.gguf` file name (e.g. `GLM-OCR-Q8_0.gguf`) or a full path to a `.gguf` with its `mmproj` sidecar next to it. Default: the first downloaded OCR model. |
+| `--ocr-url:<url>` | llama.cpp: endpoint of an already-running `llama-server` (a bare `host:port` is completed to `/v1/chat/completions`); skips the local auto-start. |
 | `--time-codes-only` | Image sources (`.sup`, VobSub `.sub`/`.idx`, MKV PGS/VobSub, MP4 VobSub, TS DVB-sub) → text format with time codes only and empty text. **Skips OCR entirely** — no OCR engine required. Ignored for text inputs and image output targets. |
 | `--no-vobsub-isolate-colors` | Disable VobSub OCR colour isolation, which is **on by default**. Isolation rebuilds each subpicture as a crisp black-on-white bitmap via histogram-based colour analysis — the most frequent opaque colour (the glyph fill) becomes black and the gray outline / anti-alias colours collapse into the white background, which helps on discs whose outlines otherwise melt adjacent characters together (`Yuri` → `Yurl`). Pass this flag to OCR the raw palette instead. Ignored for non-VobSub sources and with `--time-codes-only`. |
 
@@ -224,6 +228,11 @@ seconv movie.sup subrip --ocr-engine:nocr --ocr-db:"C:\Users\me\AppData\Roaming\
 
 # BinaryOCR
 seconv movie.sup subrip --ocr-engine:binaryocr --ocr-db:"C:\Users\me\AppData\Roaming\Subtitle Edit\Ocr\Latin.db"
+
+# llama.cpp — auto-starts a local llama-server with a downloaded OCR model
+seconv movie.sup subrip --ocr-engine:llamacpp
+seconv movie.sup subrip --ocr-engine:llamacpp --ocr-model:GLM-OCR-Q8_0.gguf
+seconv movie.sup subrip --ocr-engine:llamacpp --ocr-url:http://127.0.0.1:8080
 
 # MKV with image (PGS or VobSub) tracks — OCR runs automatically
 seconv movie.mkv subrip --ocr-engine:tesseract --ocr-language:eng

--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -95,16 +95,24 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         public bool PlainTextNoBlankLine { get; init; }
 
         [CommandOption("--ocr-engine|--ocrengine")]
-        [Description("OCR engine: tesseract | nocr | binaryocr | ollama | paddle (default: tesseract)")]
+        [Description("OCR engine: tesseract | nocr | binaryocr | ollama | llamacpp | paddle (default: tesseract)")]
         public string? OcrEngine { get; init; }
 
         [CommandOption("--ocr-language|--ocrlanguage")]
-        [Description("Language for OCR (Tesseract: ISO 639-2 like eng/deu; Paddle: en/de; Ollama: human name like English)")]
+        [Description("Language for OCR (Tesseract: ISO 639-2 like eng/deu; Paddle: en/de; Ollama/llama.cpp: human name like English)")]
         public string? OcrLanguage { get; init; }
 
         [CommandOption("--ocr-db|--ocrdb")]
         [Description("Path to a .nocr file (--ocr-engine=nocr) or .db file (--ocr-engine=binaryocr)")]
         public string? OcrDb { get; init; }
+
+        [CommandOption("--ocr-model|--ocrmodel")]
+        [Description("llama.cpp OCR model: curated .gguf file name or full path (default: first downloaded OCR model)")]
+        public string? OcrModel { get; init; }
+
+        [CommandOption("--ocr-url|--ocrurl")]
+        [Description("llama.cpp OCR: endpoint of an already-running llama-server; skips the local auto-start")]
+        public string? OcrUrl { get; init; }
 
         [CommandOption("--dictionary-folder|--dictionaryfolder")]
         [Description("Folder with Hunspell dictionaries + *_OCRFixReplaceList.xml; enables the 'Fix common OCR errors' pass of --fix-common-errors")]
@@ -393,14 +401,24 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 return 1;
             }
 
-            // Validate --ocr-engine: tesseract | nocr | binaryocr | ollama | paddle
-            var supportedEngines = new[] { "tesseract", "nocr", "binaryocr", "binary", "ollama", "paddle", "paddleocr" };
+            // Validate --ocr-engine: tesseract | nocr | binaryocr | ollama | llamacpp | paddle
+            var supportedEngines = new[] { "tesseract", "nocr", "binaryocr", "binary", "ollama", "llamacpp", "llama.cpp", "llama", "paddle", "paddleocr" };
             if (!string.IsNullOrWhiteSpace(settings.OcrEngine) &&
                 !supportedEngines.Contains(settings.OcrEngine, StringComparer.OrdinalIgnoreCase))
             {
                 AnsiConsole.MarkupLine(
                     $"[red]Error: OCR engine '{settings.OcrEngine.EscapeMarkup()}' is not supported (pass via --ocr-engine). " +
-                    $"Use one of: {string.Join(", ", supportedEngines)}.[/]");
+                    "Use one of: tesseract, nocr, binaryocr, ollama, llamacpp, paddle.[/]");
+                return 1;
+            }
+
+            // --ocr-model/--ocr-url only apply to the llama.cpp OCR engine - fail fast instead
+            // of silently ignoring them under the default (tesseract) engine.
+            var isLlamaCppOcr = !string.IsNullOrWhiteSpace(settings.OcrEngine) &&
+                                settings.OcrEngine.Trim().ToLowerInvariant() is "llamacpp" or "llama.cpp" or "llama";
+            if ((!string.IsNullOrWhiteSpace(settings.OcrModel) || !string.IsNullOrWhiteSpace(settings.OcrUrl)) && !isLlamaCppOcr)
+            {
+                AnsiConsole.MarkupLine("[red]Error: --ocr-model/--ocr-url require --ocr-engine:llamacpp.[/]");
                 return 1;
             }
 
@@ -649,6 +667,8 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 PgsIsolateColors = !settings.NoPgsIsolateColors,
                 OllamaUrl = settings.OllamaUrl,
                 OllamaModel = settings.OllamaModel,
+                OcrUrl = settings.OcrUrl,
+                OcrModel = settings.OcrModel,
                 TranslateTo = settings.TranslateTo,
                 TranslateFrom = settings.TranslateFrom,
                 TranslateEngine = settings.TranslateEngine,

--- a/src/seconv/Core/AutoTranslateRunner.cs
+++ b/src/seconv/Core/AutoTranslateRunner.cs
@@ -192,38 +192,7 @@ internal sealed class AutoTranslateRunner
     /// </summary>
     private static LlamaCppModel ResolveLocalLlamaCpp(string? requestedModel)
     {
-        // Folder candidates in priority order: portable SE (seconv sits next to SubtitleEdit,
-        // data folder = exe folder), then the installed GUI's data folder.
-        var candidates = new[]
-        {
-            Path.Combine(AppContext.BaseDirectory, "llama.cpp"),
-            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Subtitle Edit", "llama.cpp"),
-        };
-
-        var exeName = OperatingSystem.IsWindows() ? "llama-server.exe" : "llama-server";
-        var folder = candidates.FirstOrDefault(c => File.Exists(Path.Combine(c, exeName)));
-        if (folder != null)
-        {
-            LlamaCppServerManager.FolderOverride = folder;
-        }
-        else
-        {
-            // No SE-managed install; fall back to llama.cpp from the system PATH
-            // (brew install llama.cpp / winget install ggml.llamacpp / apt).
-            var pathExe = FindOnPath(exeName);
-            if (pathExe == null)
-            {
-                throw new InvalidOperationException(
-                    "llama-server not found. Either: download llama.cpp in Subtitle Edit (Auto-translate > llama.cpp), " +
-                    "install it on PATH (e.g. `brew install llama.cpp` or `winget install ggml.llamacpp`), " +
-                    "or point --translate-url at an already-running llama-server.");
-            }
-
-            LlamaCppServerManager.ExecutableOverride = pathExe;
-            // Models still live in an SE data folder; prefer one that exists.
-            LlamaCppServerManager.FolderOverride = candidates.FirstOrDefault(Directory.Exists) ?? candidates[0];
-        }
-
+        LlamaCppLocal.EnsureServerBinary("Auto-translate > llama.cpp", "--translate-url");
         return ResolveLlamaCppModel(requestedModel);
     }
 
@@ -275,21 +244,5 @@ internal sealed class AutoTranslateRunner
         }
 
         return installed;
-    }
-
-    private static string? FindOnPath(string exeName)
-    {
-        var pathEnv = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
-        var separator = OperatingSystem.IsWindows() ? ';' : ':';
-        foreach (var dir in pathEnv.Split(separator, StringSplitOptions.RemoveEmptyEntries))
-        {
-            var candidate = Path.Combine(dir.Trim(), exeName);
-            if (File.Exists(candidate))
-            {
-                return candidate;
-            }
-        }
-
-        return null;
     }
 }

--- a/src/seconv/Core/ListHelpers.cs
+++ b/src/seconv/Core/ListHelpers.cs
@@ -1,4 +1,5 @@
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using Spectre.Console;
 using System.Text;
 
@@ -117,12 +118,19 @@ internal static class ListHelpers
             "[green]ollama[/]",
             "HTTP",
             "Local Ollama with vision model. --ollama-url, --ollama-model");
+
+        var llamaCppServer = LlamaCppLocal.TryEnsureServerBinary() ? "installed ✓" : "not found";
+        var llamaCppModels = LlamaCppServerManager.OcrModels.Count(LlamaCppServerManager.IsModelInstalled);
+        table.AddRow(
+            "[green]llamacpp[/]",
+            "HTTP",
+            $"llama-server ({llamaCppServer}) + OCR model ({llamaCppModels} installed) — download via SE's OCR window, or --ocr-url. --ocr-model, --ocr-url");
         table.AddRow(
             "[green]paddle[/] / [green]paddleocr[/]",
             "subprocess",
             $"`paddleocr` binary on PATH ({paddle}) — `pip install paddleocr`");
 
         AnsiConsole.Write(table);
-        AnsiConsole.MarkupLine("\n[dim]Pass language via --ocr-language (Tesseract: ISO 639-2; Paddle: en/de/fr/...; Ollama: human name).[/]");
+        AnsiConsole.MarkupLine("\n[dim]Pass language via --ocr-language (Tesseract: ISO 639-2; Paddle: en/de/fr/...; Ollama/llama.cpp: human name).[/]");
     }
 }

--- a/src/seconv/Core/LlamaCppLocal.cs
+++ b/src/seconv/Core/LlamaCppLocal.cs
@@ -1,0 +1,78 @@
+using Nikse.SubtitleEdit.Logic.LlamaCpp;
+
+namespace SeConv.Core;
+
+/// <summary>
+/// Locates a local llama-server binary for the llama.cpp translate/OCR engines without
+/// downloading anything: the Subtitle Edit data folders are probed first (so an install done
+/// via the SE GUI is picked up automatically), then the system PATH.
+/// </summary>
+internal static class LlamaCppLocal
+{
+    /// <summary>
+    /// Resolves llama-server and points <see cref="LlamaCppServerManager"/> at it (folder or
+    /// executable override). Throws with download instructions when nothing is found;
+    /// <paramref name="guiDownloadHint"/> names the SE window that installs llama.cpp
+    /// (e.g. "Auto-translate &gt; llama.cpp") and <paramref name="urlOption"/> the CLI option
+    /// that skips the local auto-start (e.g. "--translate-url").
+    /// </summary>
+    public static void EnsureServerBinary(string guiDownloadHint, string urlOption)
+    {
+        if (!TryEnsureServerBinary())
+        {
+            throw new InvalidOperationException(
+                $"llama-server not found. Either: download llama.cpp in Subtitle Edit ({guiDownloadHint}), " +
+                "install it on PATH (e.g. `brew install llama.cpp` or `winget install ggml.llamacpp`), " +
+                $"or point {urlOption} at an already-running llama-server.");
+        }
+    }
+
+    /// <summary>Same as <see cref="EnsureServerBinary"/> but returns false instead of throwing.</summary>
+    public static bool TryEnsureServerBinary()
+    {
+        // Folder candidates in priority order: portable SE (seconv sits next to SubtitleEdit,
+        // data folder = exe folder), then the installed GUI's data folder.
+        var candidates = new[]
+        {
+            Path.Combine(AppContext.BaseDirectory, "llama.cpp"),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Subtitle Edit", "llama.cpp"),
+        };
+
+        var exeName = OperatingSystem.IsWindows() ? "llama-server.exe" : "llama-server";
+        var folder = candidates.FirstOrDefault(c => File.Exists(Path.Combine(c, exeName)));
+        if (folder != null)
+        {
+            LlamaCppServerManager.FolderOverride = folder;
+            return true;
+        }
+
+        // No SE-managed install; fall back to llama.cpp from the system PATH
+        // (brew install llama.cpp / winget install ggml.llamacpp / apt).
+        var pathExe = FindOnPath(exeName);
+        if (pathExe == null)
+        {
+            return false;
+        }
+
+        LlamaCppServerManager.ExecutableOverride = pathExe;
+        // Models still live in an SE data folder; prefer one that exists.
+        LlamaCppServerManager.FolderOverride = candidates.FirstOrDefault(Directory.Exists) ?? candidates[0];
+        return true;
+    }
+
+    private static string? FindOnPath(string exeName)
+    {
+        var pathEnv = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        var separator = OperatingSystem.IsWindows() ? ';' : ':';
+        foreach (var dir in pathEnv.Split(separator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var candidate = Path.Combine(dir.Trim(), exeName);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/seconv/Core/LlamaCppOcrEngine.cs
+++ b/src/seconv/Core/LlamaCppOcrEngine.cs
@@ -1,0 +1,225 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.LlamaCpp;
+using SkiaSharp;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace SeConv.Core;
+
+/// <summary>
+/// OCR via llama.cpp with a vision model (GLM-OCR, LightOnOCR, PaddleOCR-VL). With
+/// <c>--ocr-url</c> the engine posts to an already-running llama-server; otherwise it finds
+/// the llama-server binary (Subtitle Edit's data folder next to seconv, the installed SE data
+/// folder, then the system PATH) and an installed OCR model, starts the server on a free
+/// loopback port on first use, and lets <see cref="LlamaCppServerManager"/> kill it at process
+/// exit. seconv never downloads engines or models (consistent with its Tesseract/Paddle
+/// policy) — missing pieces fail fast with instructions instead.
+/// </summary>
+internal sealed class LlamaCppOcrEngine : IOcrEngine
+{
+    public string Name => "llama.cpp";
+
+    // Same default prompt as the UI's llama.cpp OCR (SeOcr.LlamaCppOcrPrompt).
+    private const string PromptTemplate = "Extract all text exactly as written. The language is {language}. Preserve line breaks.";
+
+    private readonly HttpClient _httpClient;
+    private readonly string _language;
+    private readonly string _modelName;
+    private readonly string? _url;          // non-null = user-managed server via --ocr-url
+    private readonly LlamaCppModel? _model; // non-null = local server mode; started on first Recognize
+    private readonly bool _quiet;
+
+    private LlamaCppOcrEngine(string? url, LlamaCppModel? model, string modelName, string? language, bool quiet)
+    {
+        _url = url;
+        _model = model;
+        _modelName = modelName;
+        _language = string.IsNullOrWhiteSpace(language) ? "English" : language;
+        _quiet = quiet;
+        _httpClient = new HttpClient
+        {
+            Timeout = TimeSpan.FromMinutes(25),
+        };
+        _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
+    }
+
+    /// <summary>
+    /// Validates the setup up front so a broken install fails before any image is OCR'ed:
+    /// either a user-managed server URL, or a resolved local llama-server + installed OCR
+    /// model. Throws <see cref="InvalidOperationException"/> with an actionable message.
+    /// </summary>
+    public static LlamaCppOcrEngine Create(ConversionOptions options)
+    {
+        if (options.Verbose)
+        {
+            LlamaCppServerManager.LogAction = m => Console.WriteLine("  " + m);
+        }
+
+        var url = options.OcrUrl?.Trim();
+        if (!string.IsNullOrEmpty(url))
+        {
+            // User-managed server: accept a bare host:port and complete it to the
+            // chat/completions endpoint (same convention as --translate-url).
+            var fullUrl = url.Contains("/v1/", StringComparison.OrdinalIgnoreCase)
+                ? url
+                : url.TrimEnd('/') + "/v1/chat/completions";
+            var modelName = string.IsNullOrWhiteSpace(options.OcrModel)
+                ? "glmocr"
+                : Path.GetFileNameWithoutExtension(options.OcrModel.Trim());
+            return new LlamaCppOcrEngine(fullUrl, null, modelName, options.OcrLanguage, options.Quiet);
+        }
+
+        LlamaCppLocal.EnsureServerBinary("the OCR window > llama.cpp", "--ocr-url");
+        var model = ResolveOcrModel(options.OcrModel);
+        return new LlamaCppOcrEngine(null, model, Path.GetFileNameWithoutExtension(model.FileName), options.OcrLanguage, options.Quiet);
+    }
+
+    public string Recognize(SKBitmap bitmap)
+    {
+        if (bitmap is null || bitmap.Width == 0 || bitmap.Height == 0)
+        {
+            return string.Empty;
+        }
+
+        var url = _url;
+        if (_model != null)
+        {
+            // Reuses the already-running server across files in the same run (the server
+            // manager is a no-op when the model matches).
+            if (!LlamaCppServerManager.IsServerRunning && !_quiet)
+            {
+                Console.WriteLine($"  Starting llama-server with model {Path.GetFileName(_model.FileName)} (stops at exit)...");
+            }
+
+            LlamaCppServerManager.EnsureServerRunningAsync(_model, CancellationToken.None).GetAwaiter().GetResult();
+            url = LlamaCppServerManager.ApiUrl;
+        }
+
+        using var padded = PadToSquare(bitmap);
+        using var image = SKImage.FromBitmap(padded);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 90);
+        var base64 = Convert.ToBase64String(data.ToArray());
+
+        var prompt = PromptTemplate.Replace("{language}", _language);
+        var body = "{ \"model\": \"" + Escape(_modelName) + "\", \"temperature\": 0, \"messages\": [ { \"role\": \"user\", \"content\": [ " +
+                   "{ \"type\": \"text\", \"text\": \"" + Escape(prompt) + "\" }, " +
+                   "{ \"type\": \"image_url\", \"image_url\": { \"url\": \"data:image/png;base64," + base64 + "\" } } " +
+                   "] } ] }";
+
+        using var content = new StringContent(body, Encoding.UTF8);
+        content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+
+        var resp = _httpClient.PostAsync(url, content).GetAwaiter().GetResult();
+        var bodyBytes = resp.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult();
+        var json = Encoding.UTF8.GetString(bodyBytes).Trim();
+        if (!resp.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException($"llama.cpp returned {(int)resp.StatusCode}: {json}");
+        }
+
+        var parser = new SeJsonParser();
+        var contents = parser.GetAllTagsByNameAsStrings(json, "content");
+        var text = string.Join(string.Empty, contents).Trim();
+        text = text.Replace("\\n", Environment.NewLine).Replace("\\\"", "\"");
+        return text.Trim();
+    }
+
+    /// <summary>
+    /// Resolves <c>--ocr-model</c> to an installed model: a full <c>.gguf</c> path (needs its
+    /// mmproj vision-projector sidecar next to it), a curated OCR model by file/display name,
+    /// or - when omitted - the first installed curated OCR model.
+    /// </summary>
+    internal static LlamaCppModel ResolveOcrModel(string? requestedModel)
+    {
+        var curatedNames = string.Join(", ", LlamaCppServerManager.OcrModels.Select(m => m.FileName));
+
+        if (!string.IsNullOrWhiteSpace(requestedModel))
+        {
+            var name = requestedModel.Trim();
+
+            // Full path to a .gguf: use it directly, but require the mmproj sidecar - a vision
+            // model served without its projector can't see the image at all.
+            if (Path.IsPathRooted(name) || name.Contains(Path.DirectorySeparatorChar) || name.Contains(Path.AltDirectorySeparatorChar))
+            {
+                if (!File.Exists(name))
+                {
+                    throw new InvalidOperationException($"OCR model file not found: {name}");
+                }
+
+                var fullPath = Path.GetFullPath(name);
+                var mmproj = FindMmprojSidecar(fullPath);
+                if (mmproj == null)
+                {
+                    var fileName = Path.GetFileName(fullPath);
+                    var stem = Path.GetFileNameWithoutExtension(fullPath);
+                    throw new InvalidOperationException(
+                        $"No vision projector found next to {fullPath}. llama.cpp OCR models need their mmproj sidecar; " +
+                        $"expected 'mmproj-{fileName}' or '{stem}-mmproj.gguf' in the same folder.");
+                }
+
+                return new LlamaCppModel(Path.GetFileName(fullPath), fullPath, string.Empty, Url: string.Empty,
+                    MmprojFileName: mmproj);
+            }
+
+            // Name: match the curated OCR models (with or without .gguf).
+            var model = LlamaCppServerManager.OcrModels.FirstOrDefault(m => m.FileName.Equals(name, StringComparison.OrdinalIgnoreCase))
+                        ?? LlamaCppServerManager.OcrModels.FirstOrDefault(m => m.FileName.Equals(name + ".gguf", StringComparison.OrdinalIgnoreCase))
+                        ?? LlamaCppServerManager.OcrModels.FirstOrDefault(m => m.DisplayName.Equals(name, StringComparison.OrdinalIgnoreCase));
+            if (model == null || !LlamaCppServerManager.IsModelInstalled(model))
+            {
+                throw new InvalidOperationException(
+                    $"OCR model '{name}' not found in {LlamaCppServerManager.GetAndCreateModelsFolder()}. " +
+                    "Download one in Subtitle Edit (OCR window > llama.cpp) or pass a full path via --ocr-model. " +
+                    $"Curated models: {curatedNames}.");
+            }
+
+            return model;
+        }
+
+        // No model given: pick the first installed curated OCR model.
+        var installed = LlamaCppServerManager.OcrModels.FirstOrDefault(LlamaCppServerManager.IsModelInstalled);
+        if (installed == null)
+        {
+            throw new InvalidOperationException(
+                $"No llama.cpp OCR model found in {LlamaCppServerManager.GetAndCreateModelsFolder()}. " +
+                "Download one in Subtitle Edit (OCR window > llama.cpp) or pass --ocr-model:<path.gguf>. " +
+                $"Curated models: {curatedNames}.");
+        }
+
+        return installed;
+    }
+
+    private static string? FindMmprojSidecar(string modelPath)
+    {
+        // Both curated sidecar conventions: "mmproj-<file>" (GLM-OCR, LightOnOCR) and
+        // "<stem>-mmproj.gguf" (PaddleOCR-VL).
+        var dir = Path.GetDirectoryName(modelPath)!;
+        var candidates = new[]
+        {
+            Path.Combine(dir, "mmproj-" + Path.GetFileName(modelPath)),
+            Path.Combine(dir, Path.GetFileNameWithoutExtension(modelPath) + "-mmproj.gguf"),
+        };
+        return candidates.FirstOrDefault(File.Exists);
+    }
+
+    private static string Escape(string s) =>
+        s.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\n", "\\n").Replace("\r", "\\r");
+
+    private static SKBitmap PadToSquare(SKBitmap source)
+    {
+        var margin = (int)(Math.Max(source.Width, source.Height) * 0.2);
+        var side = Math.Max(source.Width, source.Height) + margin;
+        var info = new SKImageInfo(side, side, SKColorType.Rgba8888, SKAlphaType.Opaque);
+        var square = new SKBitmap(info);
+        using var canvas = new SKCanvas(square);
+        canvas.Clear(SKColors.Black);
+        var left = (side - source.Width) / 2f;
+        var top = (side - source.Height) / 2f;
+        canvas.DrawBitmap(source, new SKRect(left, top, left + source.Width, top + source.Height));
+        canvas.Flush();
+        return square;
+    }
+
+    public void Dispose() => _httpClient.Dispose();
+}

--- a/src/seconv/Core/OcrEngineFactory.cs
+++ b/src/seconv/Core/OcrEngineFactory.cs
@@ -16,9 +16,10 @@ internal static class OcrEngineFactory
             "nocr" => new NOcrOcrEngine(ResolveOcrDbPath(options, "nocr", ".nocr")),
             "binaryocr" or "binary" => new BinaryOcrOcrEngine(ResolveOcrDbPath(options, "binaryocr", ".db")),
             "ollama" => new OllamaOcrEngine(options.OllamaUrl, options.OllamaModel, options.OcrLanguage),
+            "llamacpp" or "llama.cpp" or "llama" => LlamaCppOcrEngine.Create(options),
             "paddle" or "paddleocr" => PaddleOcrEngine.Create(options.OcrLanguage),
             _ => throw new InvalidOperationException(
-                $"OCR engine '{options.OcrEngine}' is not supported. Use one of: tesseract, nocr, binaryocr, ollama, paddle.")
+                $"OCR engine '{options.OcrEngine}' is not supported. Use one of: tesseract, nocr, binaryocr, ollama, llamacpp, paddle.")
         };
     }
 

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -919,6 +919,12 @@ internal record class ConversionOptions
     /// <summary>Ollama vision model (default <c>llama3.2-vision</c>).</summary>
     public string? OllamaModel { get; init; }
 
+    /// <summary>llama.cpp OCR: endpoint of an already-running llama-server; skips the local auto-start.</summary>
+    public string? OcrUrl { get; init; }
+
+    /// <summary>llama.cpp OCR model: curated <c>.gguf</c> file name or full path (default: first installed OCR model).</summary>
+    public string? OcrModel { get; init; }
+
     /// <summary>Auto-translate target language (code or English name). Non-null enables translation.</summary>
     public string? TranslateTo { get; init; }
 

--- a/src/seconv/Helpers/HelpDisplay.cs
+++ b/src/seconv/Helpers/HelpDisplay.cs
@@ -39,9 +39,11 @@ internal static class HelpDisplay
         ShowParameter("--teletext-only", "Process teletext only");
         ShowParameter("--teletext-only-page:<page number>", "Teletext page number");
         ShowParameter("--track-number:<track list>", "Comma separated track number list");
-        ShowParameter("--ocr-engine:<engine>", "OCR engine: tesseract | nocr | binaryocr | ollama | paddle");
+        ShowParameter("--ocr-engine:<engine>", "OCR engine: tesseract | nocr | binaryocr | ollama | llamacpp | paddle");
         ShowParameter("--ocr-language:<lang>", "Language for OCR (e.g. eng, deu, spa)");
         ShowParameter("--ocr-db:<path>", ".nocr (--ocr-engine=nocr) or .db (--ocr-engine=binaryocr)");
+        ShowParameter("--ocr-model:<model>", "llamacpp OCR .gguf file name/path (default: first downloaded OCR model)");
+        ShowParameter("--ocr-url:<url>", "Endpoint of an already-running llama-server for OCR (skips the auto-start)");
         ShowParameter("--time-codes-only", "Image sources (.sup/VobSub/PGS/DVB) -> text with time codes only; skips OCR");
         ShowParameter("--no-vobsub-isolate-colors", "Disable VobSub OCR colour isolation (on by default; isolation binarises to black-on-white, dropping outline colours)");
         ShowParameter("--no-pgs-isolate-colors", "Disable PGS/DVB-sub OCR colour isolation (on by default; isolation binarises to black-on-white so the white glyph fill survives the OCR canvas)");
@@ -119,6 +121,9 @@ internal static class HelpDisplay
         ShowExample(
             "seconv movie.sup subrip --ocr-engine:nocr --ocr-db:Latin.nocr",
             "OCR a Blu-Ray .sup using nOCR");
+        ShowExample(
+            "seconv movie.sup subrip --ocr-engine:llamacpp",
+            "OCR a Blu-Ray .sup via llama.cpp (auto-starts a local llama-server)");
         ShowExample(
             "seconv movie.sup subrip --time-codes-only",
             "Extract only the time codes from a .sup (no OCR; empty text)");

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
@@ -5,8 +5,10 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Ocr;
 using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Translate;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.UiLogic.Ocr;
 using System;
@@ -57,12 +59,16 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<string> _ollamaModels;
     [ObservableProperty] private string? _selectedOllamaModel;
 
+    [ObservableProperty] private ObservableCollection<LlamaCppModelDisplay> _llamaCppOcrModels;
+    [ObservableProperty] private LlamaCppModelDisplay? _selectedLlamaCppOcrModel;
+
     [ObservableProperty] bool _isOcrLanguageVisible;
     [ObservableProperty] bool _isTesseractOcrVisible;
     [ObservableProperty] bool _isPaddleOCrVisible;
     [ObservableProperty] bool _isBinaryOcrVisible;
     [ObservableProperty] bool _isNOcrVisible;
     [ObservableProperty] bool _isOllamaVisible;
+    [ObservableProperty] bool _isLlamaCppVisible;
 
     public Window? Window { get; set; }
 
@@ -77,7 +83,7 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         encodings.Insert(0, EncodingHelper.TryToUseSourceEncoding);
         TargetEncodings = new ObservableCollection<string>(encodings);
 
-        OcrEngines = new ObservableCollection<string> { "nOcr", "BinaryOcr", "Tesseract", "Ollama" };
+        OcrEngines = new ObservableCollection<string> { "nOcr", "BinaryOcr", "Tesseract", "Ollama", "llama.cpp" };
         if (!OperatingSystem.IsMacOS())
         {
             OcrEngines.Add("PaddleOCR");
@@ -117,6 +123,9 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
             BinaryOcrFallbackNOcrDatabases.Add(db);
         }
         OllamaModels = new ObservableCollection<string>(Se.Settings.Ocr.OllamaModels);
+        LlamaCppOcrModels = new ObservableCollection<LlamaCppModelDisplay>();
+        SelectedLlamaCppOcrModel = LlamaCppDownloadHelper.PopulateModels(
+            LlamaCppOcrModels, LlamaCppServerManager.OcrModels, Se.Settings.Ocr.LlamaCppOcrModel);
 
         _folderHelper = folderHelper;
         _windowService = windowService;
@@ -226,6 +235,11 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
             Se.Settings.Ocr.OllamaModel = SelectedOllamaModel;
         }
 
+        if (ocrEngine == "llama.cpp" && SelectedLlamaCppOcrModel != null)
+        {
+            Se.Settings.Ocr.LlamaCppOcrModel = SelectedLlamaCppOcrModel.Model.FileName;
+        }
+
         Se.SaveSettings();
     }
 
@@ -281,6 +295,18 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
             return;
         }
 
+        // The batch run itself never prompts/downloads, so make sure the llama.cpp engine and
+        // the selected OCR model are on disk now (offering the download dialog if not).
+        if (SelectedOcrEngine == "llama.cpp")
+        {
+            var ready = await LlamaCppDownloadHelper.EnsureReadyAsync(Window!, _windowService,
+                SelectedLlamaCppOcrModel?.Model.FileName, LlamaCppServerManager.OcrModels, persistAsTranslateModel: false);
+            if (!ready)
+            {
+                return;
+            }
+        }
+
         SaveSettings();
         OkPressed = true;
         Window?.Close();
@@ -324,12 +350,13 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
             return;
         }
 
-        IsOcrLanguageVisible = ocrEngine != "nOcr" && ocrEngine != "BinaryOcr" && ocrEngine != "Ollama";
+        IsOcrLanguageVisible = ocrEngine != "nOcr" && ocrEngine != "BinaryOcr" && ocrEngine != "Ollama" && ocrEngine != "llama.cpp";
         IsTesseractOcrVisible = ocrEngine == "Tesseract";
         IsPaddleOCrVisible = ocrEngine == "PaddleOCR";
         IsBinaryOcrVisible = ocrEngine == "BinaryOcr";
         IsNOcrVisible = ocrEngine == "nOcr";
         IsOllamaVisible = ocrEngine == "Ollama";
+        IsLlamaCppVisible = ocrEngine == "llama.cpp";
 
         if (ocrEngine == "Tesseract")
         {
@@ -396,6 +423,11 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
             }
 
             SelectedOllamaModel = OllamaModels.FirstOrDefault(p => p == current) ?? OllamaModels.FirstOrDefault();
+        }
+
+        if (ocrEngine == "llama.cpp" && SelectedLlamaCppOcrModel == null)
+        {
+            SelectedLlamaCppOcrModel = LlamaCppOcrModels.FirstOrDefault();
         }
     }
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Layout;
+using Nikse.SubtitleEdit.Features.Translate;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -101,6 +102,10 @@ public class BatchConvertSettingsWindow : Window
         var labelLlamaCppModel = UiUtil.MakeLabel(Se.Language.General.Model).WithBindVisible(vm, nameof(vm.IsLlamaCppVisible)).WithMarginLeft(10);
         var comboBoxLlamaCppModels = UiUtil.MakeComboBox(vm.LlamaCppOcrModels, vm, nameof(vm.SelectedLlamaCppOcrModel))
             .WithBindVisible(nameof(vm.IsLlamaCppVisible));
+        comboBoxLlamaCppModels.ItemTemplate = StatusDots.ComboItemTemplate<LlamaCppModelDisplay>(
+            model => model.Model.DisplayName,
+            model => model.Model.Size,
+            model => model.IsInstalled ? DownloadDotStatus.UpToDate : DownloadDotStatus.NotInstalled);
         var panelOcrEngine = new StackPanel
         {
             Orientation = Orientation.Horizontal,

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
@@ -98,11 +98,14 @@ public class BatchConvertSettingsWindow : Window
         var comboBoxOllamaModels = UiUtil.MakeComboBox(vm.OllamaModels, vm, nameof(vm.SelectedOllamaModel))
             .WithBindVisible(nameof(vm.IsOllamaVisible));
         var buttonOllamaModelBrowse = UiUtil.MakeButtonBrowse(vm.PickOllamaModelCommand, nameof(vm.IsOllamaVisible)).WithMarginLeft(3);
+        var labelLlamaCppModel = UiUtil.MakeLabel(Se.Language.General.Model).WithBindVisible(vm, nameof(vm.IsLlamaCppVisible)).WithMarginLeft(10);
+        var comboBoxLlamaCppModels = UiUtil.MakeComboBox(vm.LlamaCppOcrModels, vm, nameof(vm.SelectedLlamaCppOcrModel))
+            .WithBindVisible(nameof(vm.IsLlamaCppVisible));
         var panelOcrEngine = new StackPanel
         {
             Orientation = Orientation.Horizontal,
             Margin = new Avalonia.Thickness(0, 30, 0, 0),
-            Children = { labelOcrEngine, comboBoxOcrEngine, labelOcLanguage, comboBoxTesseractLanguages, labelTesseractEngineMode, comboBoxTesseractEngineMode, comboBoxPaddleLanguages, labelBinaryOcrDatabase, comboBoxBinaryOcrDatabases, labelBinaryOcrFallback, comboBoxBinaryOcrFallback, labelNOcrDatabase, comboBoxNOcrDatabases, labelNOcrFallback, comboBoxNOcrFallback, labelOllamaModel, comboBoxOllamaModels, buttonOllamaModelBrowse }
+            Children = { labelOcrEngine, comboBoxOcrEngine, labelOcLanguage, comboBoxTesseractLanguages, labelTesseractEngineMode, comboBoxTesseractEngineMode, comboBoxPaddleLanguages, labelBinaryOcrDatabase, comboBoxBinaryOcrDatabases, labelBinaryOcrFallback, comboBoxBinaryOcrFallback, labelNOcrDatabase, comboBoxNOcrDatabases, labelNOcrFallback, comboBoxNOcrFallback, labelOllamaModel, comboBoxOllamaModels, buttonOllamaModelBrowse, labelLlamaCppModel, comboBoxLlamaCppModels }
         };
         comboBoxOcrEngine.SelectionChanged += (s, e) => vm.OnOcrEngineChanged();
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -25,6 +25,7 @@ using Nikse.SubtitleEdit.Features.Tools.SplitBreakLongLines;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Dictionaries;
+using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using Nikse.SubtitleEdit.UiLogic.Ocr;
 using SkiaSharp;
 using System;
@@ -313,6 +314,10 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             else if (Se.Settings.Tools.BatchConvert.OcrEngine.Equals("Ollama", StringComparison.OrdinalIgnoreCase))
             {
                 await RunOllamaOcr(imageSubtitle, item, cancellationToken);
+            }
+            else if (Se.Settings.Tools.BatchConvert.OcrEngine.Equals("llama.cpp", StringComparison.OrdinalIgnoreCase))
+            {
+                await RunLlamaCppOcr(imageSubtitle, item, cancellationToken);
             }
             else
             {
@@ -1281,6 +1286,63 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             item.Subtitle.Paragraphs.All(p => string.IsNullOrWhiteSpace(p.Text)))
         {
             item.Status = Se.Language.Ocr.OllamaModelLikelyWrong;
+        }
+    }
+
+    private async Task RunLlamaCppOcr(IOcrSubtitle imageSubtitles, BatchConvertItem item, CancellationToken cancellationToken)
+    {
+        // Curated OCR model from settings (picked in batch convert settings / the OCR window).
+        // The batch run never downloads - the settings dialog prompts for that on OK.
+        var model = LlamaCppServerManager.OcrModels.FirstOrDefault(m => m.FileName == Se.Settings.Ocr.LlamaCppOcrModel)
+                    ?? LlamaCppServerManager.OcrModels.FirstOrDefault(LlamaCppServerManager.IsModelInstalled);
+        if (model == null || !LlamaCppServerManager.IsEngineInstalled() || !LlamaCppServerManager.IsModelInstalled(model))
+        {
+            item.Status = Se.Language.Ocr.LlamaCppNotDownloaded;
+            return;
+        }
+
+        try
+        {
+            // Reused across items/files in the same batch run; killed at app exit.
+            await LlamaCppServerManager.EnsureServerRunningAsync(model, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            item.Status = string.Format(Se.Language.General.ErrorX, ex.Message);
+            return;
+        }
+
+        var engine = new LlamaCppOcr(Se.Settings.Ocr.LlamaCppOcrTimeoutMinutes);
+        var url = LlamaCppServerManager.ApiUrl;
+        var modelName = Path.GetFileNameWithoutExtension(model.FileName);
+        var language = Se.Settings.Ocr.OllamaLanguage;
+        var prompt = Se.Settings.Ocr.LlamaCppOcrPrompt;
+        item.Subtitle = new Subtitle();
+        var cancelled = false;
+        for (var i = 0; i < imageSubtitles.Count; i++)
+        {
+            var pct = (i + 1) * 100 / imageSubtitles.Count;
+            item.Status = string.Format(Se.Language.General.OcrPercentX, pct);
+            var bitmap = imageSubtitles.GetBitmap(i);
+            var text = await engine.Ocr(bitmap, url, modelName, language, prompt, cancellationToken);
+            var p = new Paragraph(text, imageSubtitles.GetStartTime(i).TotalMilliseconds, imageSubtitles.GetEndTime(i).TotalMilliseconds);
+            item.Subtitle.Paragraphs.Add(p);
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                item.Status = Se.Language.General.Cancelled;
+                cancelled = true;
+                break;
+            }
+        }
+
+        // Every line blank means the server/model setup is broken (e.g. served without its
+        // vision projector) - flag the file so the user notices instead of ending up with a
+        // silently-empty subtitle.
+        if (!cancelled && item.Subtitle.Paragraphs.Count > 0 &&
+            item.Subtitle.Paragraphs.All(p => string.IsNullOrWhiteSpace(p.Text)))
+        {
+            item.Status = Se.Language.Ocr.LlamaCppReturnedNoText;
         }
     }
 

--- a/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
+++ b/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
@@ -111,6 +111,8 @@ public class LanguageOcr
     public string FallbackOcrDatabase { get; set; }
     public string ShowAllOllamaModels { get; set; }
     public string OllamaModelLikelyWrong { get; set; }
+    public string LlamaCppNotDownloaded { get; set; }
+    public string LlamaCppReturnedNoText { get; set; }
 
     public LanguageOcr()
     {
@@ -224,5 +226,7 @@ public class LanguageOcr
 
         ShowAllOllamaModels = "Show all models (not just vision-capable)";
         OllamaModelLikelyWrong = "Ollama returned no text - the selected model may not support OCR / vision";
+        LlamaCppNotDownloaded = "llama.cpp engine/model not downloaded - download via batch convert settings";
+        LlamaCppReturnedNoText = "llama.cpp returned no text - check the server and model";
     }
 }


### PR DESCRIPTION
Fixes #12521.

Follows the pattern from the llama.cpp batch translate work (#12354/#12359): the shared pieces (`LlamaCppOcr` HTTP call, `LlamaCppServerManager` model list + server lifecycle, `SeOcr` settings) already existed — this wires them into the two batch entry points.

## Batch convert

- New **llama.cpp** entry in the OCR engine list, with a picker for the curated OCR models (GLM-OCR, LightOnOCR, PaddleOCR-VL) showing install status.
- OK prompts to download the llama-server engine and/or selected model if missing (reuses `LlamaCppDownloadHelper.EnsureReadyAsync`), so the batch run itself never downloads — if something is still missing at run time the file's status says so.
- The batch runner mirrors `RunOllamaOcr`: starts/reuses the managed local server, OCRs each image, and flags the file when every line comes back blank.

## seconv

```
seconv movie.sup subrip --ocr-engine:llamacpp
seconv movie.sup subrip --ocr-engine:llamacpp --ocr-model:GLM-OCR-Q8_0.gguf
seconv movie.sup subrip --ocr-engine:llamacpp --ocr-url:http://127.0.0.1:8080
```

- New `LlamaCppOcrEngine : IOcrEngine` posting OpenAI-style chat completions with the base64 image (same request shape as the UI's `LlamaCppOcr`).
- `--ocr-model`: curated `.gguf` name, or a full path (requires its `mmproj` vision-projector sidecar next to it — both curated naming conventions are detected). Default: first installed OCR model.
- `--ocr-url`: use an already-running llama-server; a bare `host:port` is completed to `/v1/chat/completions` (same convention as `--translate-url`).
- With no `--ocr-url`, llama-server is resolved exactly like the translate engine (SE data folder next to seconv → installed SE data folder → PATH), started on a free loopback port on first use, and killed at exit. The resolution logic moved from `AutoTranslateRunner` into a shared `LlamaCppLocal` helper.
- seconv never downloads engines/models (same policy as Tesseract/Paddle) — missing pieces fail fast with instructions; `--ocr-model`/`--ocr-url` without `--ocr-engine:llamacpp` also fail fast.
- `list-ocr-engines` now reports llama-server + installed-OCR-model status; help text and docs (command-line reference, batch-convert feature page) updated.

## Verified

- `dotnet build SubtitleEdit.sln` clean; all 233 seconv tests pass.
- End-to-end on macOS: `seconv sample.sup subrip --ocr-engine:llamacpp` found the SE-installed llama-server, auto-started it with GLM-OCR + mmproj, produced correctly recognized text, and killed the server at exit (no orphan process).
- `list-ocr-engines` correctly shows `llama-server (installed ✓) + OCR model (3 installed)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)