### PR TITLE
Fix docked+undocked video anomaly from waveform toolbar settings

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -13546,7 +13546,9 @@ public partial class MainViewModel :
         var result = await _windowService.ShowDialogAsync<WaveformToolbarItemsWindow, WaveformToolbarItemsViewModel>(
             Window, vm => vm.Initialize(current));
 
-        if (!result.OkPressed)
+        // Nothing changed = nothing to save and, crucially, no layout rebuild - the rebuild is
+        // what re-docked video/waveform copies while the undocked windows were still open (#12520).
+        if (!result.OkPressed || !result.HasChanges)
         {
             return;
         }
@@ -13555,8 +13557,20 @@ public partial class MainViewModel :
         Se.SaveSettings();
 
         // Rebuild the layout so the waveform toolbar reflects the new item set/order (the toolbar
-        // is built once in InitWaveform.MakeWaveform, with no incremental update path).
-        SetLayout(Se.Settings.General.LayoutNumber);
+        // is built once in InitWaveform.MakeWaveform, with no incremental update path). While the
+        // video controls are undocked, re-run the undock flow instead of SetLayout: SetLayout
+        // rebuilds docked video/waveform panels in the main window alongside the still-open
+        // undocked windows (#12520), whereas the undock flow recreates the undocked windows (with
+        // the new toolbar) and keeps the main window on the video-less layout - same handling as
+        // the Options/Settings close path.
+        if (AreVideoControlsUndocked)
+        {
+            VideoUndockControls();
+        }
+        else
+        {
+            SetLayout(Se.Settings.General.LayoutNumber);
+        }
     }
 
 

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -2008,7 +2008,7 @@ public partial class SettingsViewModel : ObservableObject
             vm.Initialize(_waveformToolbarItems);
         });
 
-        if (result.OkPressed)
+        if (result.OkPressed && result.HasChanges)
         {
             _waveformToolbarItems = result.ResultToolbarItems;
         }

--- a/src/ui/Features/Options/Settings/WaveformToolbarItems/WaveformToolbarItemsViewModel.cs
+++ b/src/ui/Features/Options/Settings/WaveformToolbarItems/WaveformToolbarItemsViewModel.cs
@@ -23,7 +23,15 @@ public partial class WaveformToolbarItemsViewModel : ObservableObject
 
     public bool OkPressed { get; private set; }
 
+    /// <summary>
+    /// False when OK was pressed but the items are identical to what <see cref="Initialize"/>
+    /// received - callers use this to skip saving and, more importantly, the layout rebuild
+    /// (which re-docks the video controls while they are undocked, #12520).
+    /// </summary>
+    public bool HasChanges { get; private set; }
+
     private bool _updatingFromSelection;
+    private List<SeWaveformToolbarItem> _initialToolbarItems = new List<SeWaveformToolbarItem>();
 
     public WaveformToolbarItemsViewModel()
     {
@@ -74,8 +82,10 @@ public partial class WaveformToolbarItemsViewModel : ObservableObject
 
     internal void Initialize(List<SeWaveformToolbarItem> toolbarItems)
     {
+        _initialToolbarItems = toolbarItems.OrderBy(x => x.SortOrder).ToList();
+
         ToolbarItems.Clear();
-        foreach (var item in toolbarItems.OrderBy(x => x.SortOrder))
+        foreach (var item in _initialToolbarItems)
         {
             ToolbarItems.Add(new ToolbarItemDisplay(item.Type, item.IsVisible, item.FontSize, item.LeftMargin, item.RightMargin));
         }
@@ -95,8 +105,35 @@ public partial class WaveformToolbarItemsViewModel : ObservableObject
             ResultToolbarItems.Add(item);
         }
 
+        HasChanges = !AreToolbarItemsEqual(_initialToolbarItems, ResultToolbarItems);
         OkPressed = true;
         Window?.Close();
+    }
+
+    // Both lists are in display order (Initialize sorts by SortOrder; Ok builds in list order),
+    // so the SortOrder values themselves don't need comparing - only the sequence and content.
+    private static bool AreToolbarItemsEqual(List<SeWaveformToolbarItem> before, List<SeWaveformToolbarItem> after)
+    {
+        if (before.Count != after.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < before.Count; i++)
+        {
+            var a = before[i];
+            var b = after[i];
+            if (a.Type != b.Type ||
+                a.IsVisible != b.IsVisible ||
+                a.FontSize != b.FontSize ||
+                a.LeftMargin != b.LeftMargin ||
+                a.RightMargin != b.RightMargin)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     [RelayCommand]


### PR DESCRIPTION
Fixes #12520.

## Root cause

`MainViewModel.ConfigureWaveformToolbarItems` (the waveform "More" → configure toolbar path) unconditionally saved and called `SetLayout(...)` on OK — even when the user just looked at the dialog and closed it. `SetLayout` rebuilds the saved layout inside the **main window**, so with the video controls undocked it recreated docked video-player/waveform panels alongside the still-open undocked windows: exactly the "simultaneously docked & undocked" state in the report's video.

The Options → Settings close path already guards against this (`if (AreVideoControlsUndocked) VideoUndockControls(); else SetLayout(...)`) — that was the earlier Preview-phase fix the reporter remembers. This dialog's direct entry point from the waveform toolbar bypassed that guard.

## Fix

1. **Change detection in the toolbar items dialog**: `WaveformToolbarItemsViewModel` snapshots the items it was initialized with and exposes `HasChanges` (compares order, visibility, font size, margins). OK with no changes now saves nothing and leaves the layout untouched — the exact repro in the issue (open, look, close) becomes a no-op.
2. **Undocked guard for real changes**: when items did change while undocked, the handler re-runs `VideoUndockControls()` instead of `SetLayout` — the undocked windows are recreated (their waveform toolbar is rebuilt by `InitWaveform.MakeWaveform`, picking up the new item set) and the main window stays on the video-less layout. Identical handling to the Options/Settings close path.

The settings-page copy of the dialog (Options → Settings → Waveform → toolbar properties) also skips updating its pending list when nothing changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)