### PR TITLE
Set v5.1.0-rc4 release date

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,7 +3,7 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
-v5.1.0-rc4 (TBD)
+v5.1.0-rc4 (16th of July 2026)
 
 * Live spell check: only show the subtitle grid spell check items (suggestions, add to user dictionary, ignore all) when a single line is selected
 * Waveform: fix "Seek silence" jumping far past the actual silence when the waveform was scrolled or zoomed - thx AdiOpi


### PR DESCRIPTION
Sets the v5.1.0-rc4 change-log date to 16th of July 2026. Se.cs Version was already bumped to v5.1.0-rc4 in the "Start v5.1.0-rc4" commit, so no code change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)