### PR TITLE
Point sync via other: sorted points, working delete, time jump, button icon

### DIFF
--- a/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherViewModel.cs
+++ b/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherViewModel.cs
@@ -37,6 +37,9 @@ public partial class PointSyncViaOtherViewModel : ObservableObject
     public bool OkPressed { get; private set; }
     public string WindowTitle { get; private set; }
 
+    /// <summary>Set by the window; scrolls the "other subtitle" grid to a line without selecting it.</summary>
+    public Action<SubtitleLineViewModel>? ScrollOtherToLine { get; set; }
+
     private readonly IFileHelper _fileHelper;
     private readonly IWindowService _windowService;
 
@@ -75,6 +78,52 @@ public partial class PointSyncViaOtherViewModel : ObservableObject
     private void Close()
     {
         Dispatcher.UIThread.Post(() => { Window?.Close(); });
+    }
+
+    // Clicking a line in the left grid scrolls the other grid to the matching time (#12529).
+    // Only the view scrolls - the other grid's selection is the user's pick for the next sync
+    // point, so it must not change. The time is offset by the nearest existing sync point so
+    // the jump still lands right when the two files drift apart.
+    partial void OnSelectedSubtitleChanged(SubtitleLineViewModel? value)
+    {
+        if (value == null || Othersubtitles.Count == 0)
+        {
+            return;
+        }
+
+        var leftTime = value.StartTime;
+        SyncPoint? nearestPoint = null;
+        var nearestDistance = TimeSpan.MaxValue;
+        foreach (var syncPoint in SyncPoints)
+        {
+            var distance = (syncPoint.LeftStartTime - leftTime).Duration();
+            if (distance < nearestDistance)
+            {
+                nearestDistance = distance;
+                nearestPoint = syncPoint;
+            }
+        }
+
+        var targetTime = nearestPoint == null
+            ? leftTime
+            : leftTime + (nearestPoint.RightStartTime - nearestPoint.LeftStartTime);
+
+        SubtitleLineViewModel? closest = null;
+        var closestDiff = TimeSpan.MaxValue;
+        foreach (var line in Othersubtitles)
+        {
+            var diff = (line.StartTime - targetTime).Duration();
+            if (diff < closestDiff)
+            {
+                closestDiff = diff;
+                closest = line;
+            }
+        }
+
+        if (closest != null)
+        {
+            ScrollOtherToLine?.Invoke(closest);
+        }
     }
 
     [RelayCommand]
@@ -146,7 +195,22 @@ public partial class PointSyncViaOtherViewModel : ObservableObject
             left, Subtitles.IndexOf(left),
             right, Othersubtitles.IndexOf(right));
 
-        SyncPoints.Add(syncPoint);
+        // A line has at most one sync point (setting it again re-points it), and the list
+        // stays in chronological order (#12529).
+        var existing = SyncPoints.FirstOrDefault(p => p.LeftIndex == syncPoint.LeftIndex);
+        if (existing != null)
+        {
+            SyncPoints.Remove(existing);
+        }
+
+        var insertAt = 0;
+        while (insertAt < SyncPoints.Count && SyncPoints[insertAt].LeftIndex < syncPoint.LeftIndex)
+        {
+            insertAt++;
+        }
+
+        SyncPoints.Insert(insertAt, syncPoint);
+        SelectedSyncPoint = syncPoint;
         IsOkEnabled = true;
     }
 
@@ -245,13 +309,4 @@ public partial class PointSyncViaOtherViewModel : ObservableObject
         }
     }
 
-    internal void PointSyncContextMenuOpening(object? sender, EventArgs e)
-    {
-        if (SyncPoints.Count == 0)
-        {
-            return;
-        }
-
-        DeleteSelectedPointSync();
-    }
 }

--- a/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherWindow.cs
+++ b/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherWindow.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.Input;
 using Avalonia.Layout;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
@@ -104,19 +105,29 @@ public class PointSyncViaOtherWindow : Window
                 },
             },
         };
+        dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedSyncPoint)));
 
-        var flyout = new MenuFlyout();
-        flyout.Opening += vm.PointSyncContextMenuOpening;
-        dataGrid.ContextFlyout = flyout;
-        UiUtil.AttachMacContextFlyoutHandler(dataGrid);
         var menuItemDelete = new MenuItem
         {
             Header = Se.Language.General.Delete,
             DataContext = vm,
             Command = vm.DeleteSelectedPointSyncCommand,
         };
+        var flyout = new MenuFlyout { Items = { menuItemDelete } };
+        flyout.Opening += (_, _) => menuItemDelete.IsEnabled = vm.SelectedSyncPoint != null;
+        dataGrid.ContextFlyout = flyout;
+        UiUtil.AttachMacContextFlyoutHandler(dataGrid);
+        dataGrid.KeyDown += (_, e) =>
+        {
+            if (e.Key is Key.Delete or Key.Back)
+            {
+                e.Handled = true;
+                vm.DeleteSelectedPointSyncCommand.Execute(null);
+            }
+        };
 
-        var buttonSetSyncPoint = UiUtil.MakeButton(Se.Language.Sync.SetSyncPoint, vm.SetSyncPointCommand);
+        var buttonSetSyncPoint = UiUtil.MakeButton(Se.Language.Sync.SetSyncPoint, vm.SetSyncPointCommand)
+            .WithIconLeft(IconNames.ArrowLeftRightBold);
 
         grid.Add(buttonSetSyncPoint, 0);
         grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGrid), 1);
@@ -284,6 +295,10 @@ public class PointSyncViaOtherWindow : Window
             },
         };
         dataGridSubtitle.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedOtherSubtitle)));
+
+        // Clicking a line in the left grid scrolls this grid to the matching time (#12529)
+        // without touching its selection.
+        vm.ScrollOtherToLine = line => dataGridSubtitle.ScrollIntoView(line, null);
 
         grid.Add(panelOtherHeader, 0);
         grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGridSubtitle), 1);


### PR DESCRIPTION
Fixes #12529.

All three reported gaps in the "Point sync via another subtitle" window, plus an icon for the "Set sync point" button.

## 1. Sync points are chronologically sorted

`SetSyncPoint` appended in click order. Points now insert at their chronological position (by left line index), and setting a point for a line that already has one **re-points that line** instead of stacking a duplicate. The new point is also selected in the list.

## 2. Deleting a sync point actually works

This turned out to be a triple bug — the delete UI was fully wired in spirit but dead in practice:
- the Delete `MenuItem` was created but **never added** to the context flyout (right-click showed nothing),
- the flyout's `Opening` handler called `DeleteSelectedPointSync()` directly — delete-on-right-click with no visible menu,
- the sync-point grid never bound its selection to `SelectedSyncPoint`, so the delete command always saw `null` and did nothing anyway.

Now: right-click shows a Delete item (disabled when nothing is selected), the grid selection is bound, and **Delete/Backspace** on the grid also removes the selected point.

## 3. Clicking a line in the left grid jumps the other grid

Selecting a line on the left scrolls the other subtitle's grid to the line closest in time — **view only**: the other grid's selection is deliberately untouched, since that selection is the user's pick for the next sync point. The target time is offset by the nearest existing sync point, so once one or more points are set the jump lands correctly even when the two subtitles drift apart over the runtime.

## 4. Icon

"Set sync point" gets the left/right-arrows icon (`mdi-arrow-left-right-bold`), matching the "time → time" pairing the button creates.

Builds clean; the dock/window flow is unchanged. Worth a quick manual pass over the three behaviors since this window has no automated tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)