### PR TITLE
Start v5.1.0-rc5

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,16 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.1.0-rc5 (TBD)
+
+* Point sync via other subtitle: sync points are now chronologically sorted, and setting a point on a line that already has one re-points it instead of adding a duplicate - thx fraternl
+* Point sync via other subtitle: fix deleting a sync point - the context menu now shows Delete (and Delete/Backspace on the list works) instead of silently removing the point on right-click - thx fraternl
+* Point sync via other subtitle: clicking a line in the left list scrolls the other subtitle's list to the matching time (selection is left untouched) - thx fraternl
+* Point sync via other subtitle: icon on the "Set sync point" button
+* Performance: faster time code display in HH:MM:SS:FF mode, faster ASSA/SSA file loading, and allocation-free URL checks
+
+-----------------------------------------------------------------------------------------------------
+
 v5.1.0-rc4 (16th of July 2026)
 
 * Live spell check: only show the subtitle grid spell check items (suggestions, add to user dictionary, ignore all) when a single line is selected

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -17,7 +17,7 @@ public class Se
 {
     internal const int CurrentMacOsFontMigrationVersion = 1;
 
-    public static string Version { get; set; } = "v5.1.0-rc4";
+    public static string Version { get; set; } = "v5.1.0-rc5";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Bumps Se.cs to v5.1.0-rc5 and opens the new change-log section with everything merged since the rc4 release: the point-sync-via-other fixes (#12531, thx fraternl) and the libse micro-optimizations (#12530). Same pattern as the "Start v5.1.0-rc4" commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)