### PR TITLE
Three more libse micro-optimizations (BenchmarkDotNet-verified)

### DIFF
--- a/src/libse/Common/StringExtensions.cs
+++ b/src/libse/Common/StringExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Core.Common.TextLengthCalculator;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -282,35 +283,78 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return s;
             }
 
-            const char whiteSpace = ' ';
-            var k = -1;
-            for (var i = s.Length - 1; i >= 0; i--)
+            // Rules (unchanged): a leading space run is kept as-is; an interior/trailing run
+            // collapses to one space, or to nothing when a line break precedes or follows it.
+            // Single-pass rewrite - the previous reverse scan called string.Remove per space
+            // run, allocating a new string for every run on space-heavy lines.
+            var len = s.Length;
+            var first = 0;
+            while (first < len && s[first] == ' ')
             {
-                var ch = s[i];
-                if (k < 2)
+                first++;
+            }
+
+            // Find the first run that needs a change; most lines have none and return the
+            // original instance without allocating.
+            var changeAt = -1;
+            for (var i = first; i < len; i++)
+            {
+                if (s[i] != ' ')
                 {
-                    if (ch == whiteSpace)
-                    {
-                        k = i + 1;
-                    }
+                    continue;
                 }
-                else if (ch != whiteSpace)
+
+                var runStart = i;
+                while (i + 1 < len && s[i + 1] == ' ')
                 {
-                    // only keep white space if it doesn't succeed/precede CRLF
-                    var skipCount = (ch == '\n' || ch == '\r') || (k < s.Length && (s[k] == '\n' || s[k] == '\r')) ? 1 : 2;
+                    i++;
+                }
 
-                    // extra space found
-                    if (k - (i + skipCount) >= 1)
-                    {
-                        s = s.Remove(i + 1, k - (i + skipCount));
-                    }
-
-                    // Reset remove length.
-                    k = -1;
+                var runEnd = i + 1;
+                var before = s[runStart - 1];
+                var removeAll = before == '\n' || before == '\r' || (runEnd < len && (s[runEnd] == '\n' || s[runEnd] == '\r'));
+                if (runEnd - runStart != (removeAll ? 0 : 1))
+                {
+                    changeAt = runStart;
+                    break;
                 }
             }
 
-            return s;
+            if (changeAt < 0)
+            {
+                return s;
+            }
+
+            var buffer = ArrayPool<char>.Shared.Rent(len);
+            s.AsSpan(0, changeAt).CopyTo(buffer);
+            var pos = changeAt;
+            for (var i = changeAt; i < len; i++)
+            {
+                var ch = s[i];
+                if (ch != ' ')
+                {
+                    buffer[pos++] = ch;
+                    continue;
+                }
+
+                var runStart = i;
+                while (i + 1 < len && s[i + 1] == ' ')
+                {
+                    i++;
+                }
+
+                var runEnd = i + 1;
+                var before = s[runStart - 1]; // runStart >= changeAt >= 1 (leading run was skipped)
+                var removeAll = before == '\n' || before == '\r' || (runEnd < len && (s[runEnd] == '\n' || s[runEnd] == '\r'));
+                if (!removeAll)
+                {
+                    buffer[pos++] = ' ';
+                }
+            }
+
+            var result = new string(buffer, 0, pos);
+            ArrayPool<char>.Shared.Return(buffer);
+            return result;
         }
 
         // note: replace both input and output variable type with ReadOnlySpan<char> when in more modern .NET

--- a/src/libse/Common/TimeCode.cs
+++ b/src/libse/Common/TimeCode.cs
@@ -24,20 +24,30 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// <returns>Total milliseconds.</returns>
         public static double ParseToMilliseconds(string text)
         {
-            var parts = text.Split(TimeSplitChars, StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length == 4)
+            // Shared time-code parse entry for many format importers, called per line while
+            // loading - tokenize with spans instead of Split (string[] + a substring per part
+            // + a PadRight copy for the fraction).
+            Span<int> starts = stackalloc int[MaxTimeParts];
+            Span<int> lengths = stackalloc int[MaxTimeParts];
+            var count = SplitTimeParts(text, starts, lengths);
+            var s = text.AsSpan();
+
+            if (count == 4)
             {
-                var msString = parts[3].PadRight(3,'0');
-                if (int.TryParse(parts[0], out var hours) && int.TryParse(parts[1], out var minutes) && int.TryParse(parts[2], out var seconds) && int.TryParse(msString, out var milliseconds))
+                if (int.TryParse(s.Slice(starts[0], lengths[0]), out var hours) &&
+                    int.TryParse(s.Slice(starts[1], lengths[1]), out var minutes) &&
+                    int.TryParse(s.Slice(starts[2], lengths[2]), out var seconds) &&
+                    TryParsePaddedMilliseconds(s.Slice(starts[3], lengths[3]), out var milliseconds))
                 {
                     return new TimeSpan(0, hours, minutes, seconds, milliseconds).TotalMilliseconds;
                 }
             }
 
-            if (parts.Length == 3)
+            if (count == 3)
             {
-                var msString = parts[2].PadRight(3, '0');
-                if (int.TryParse(parts[0], out var minutes) && int.TryParse(parts[1], out var seconds) && int.TryParse(msString, out var milliseconds))
+                if (int.TryParse(s.Slice(starts[0], lengths[0]), out var minutes) &&
+                    int.TryParse(s.Slice(starts[1], lengths[1]), out var seconds) &&
+                    TryParsePaddedMilliseconds(s.Slice(starts[2], lengths[2]), out var milliseconds))
                 {
                     return new TimeSpan(0, 0, minutes, seconds, milliseconds).TotalMilliseconds;
                 }
@@ -48,10 +58,17 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public static double ParseHHMMSSFFToMilliseconds(string text)
         {
-            var parts = text.Split(TimeSplitChars, StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length == 4)
+            Span<int> starts = stackalloc int[MaxTimeParts];
+            Span<int> lengths = stackalloc int[MaxTimeParts];
+            var count = SplitTimeParts(text, starts, lengths);
+            var s = text.AsSpan();
+
+            if (count == 4)
             {
-                if (int.TryParse(parts[0], out var hours) && int.TryParse(parts[1], out var minutes) && int.TryParse(parts[2], out var seconds) && int.TryParse(parts[3], out var frames))
+                if (int.TryParse(s.Slice(starts[0], lengths[0]), out var hours) &&
+                    int.TryParse(s.Slice(starts[1], lengths[1]), out var minutes) &&
+                    int.TryParse(s.Slice(starts[2], lengths[2]), out var seconds) &&
+                    int.TryParse(s.Slice(starts[3], lengths[3]), out var frames))
                 {
                     return new TimeCode(hours, minutes, seconds, SubtitleFormat.FramesToMillisecondsMax999(frames)).TotalMilliseconds;
                 }
@@ -61,16 +78,85 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public static double ParseHHMMSSToMilliseconds(string text)
         {
-            var parts = text.Split(TimeSplitChars, StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length == 3)
+            Span<int> starts = stackalloc int[MaxTimeParts];
+            Span<int> lengths = stackalloc int[MaxTimeParts];
+            var count = SplitTimeParts(text, starts, lengths);
+            var s = text.AsSpan();
+
+            if (count == 3)
             {
-                if (int.TryParse(parts[0], out var hours) && int.TryParse(parts[1], out var minutes) && int.TryParse(parts[2], out var seconds))
+                if (int.TryParse(s.Slice(starts[0], lengths[0]), out var hours) &&
+                    int.TryParse(s.Slice(starts[1], lengths[1]), out var minutes) &&
+                    int.TryParse(s.Slice(starts[2], lengths[2]), out var seconds))
                 {
                     return new TimeCode(hours, minutes, seconds, 0).TotalMilliseconds;
                 }
             }
 
             return 0;
+        }
+
+        // One extra slot beyond the longest accepted shape (4 parts), so a 5th part is
+        // representable and makes the count checks above fail like Split's array length did.
+        private const int MaxTimeParts = 5;
+
+        // Tokenizes like text.Split(TimeSplitChars, RemoveEmptyEntries) without allocating.
+        // Returns the part count; more parts than fit are counted (not stored) so callers
+        // still see "not 3/4 parts" for over-long inputs.
+        private static int SplitTimeParts(string text, Span<int> starts, Span<int> lengths)
+        {
+            var count = 0;
+            var start = -1;
+            for (var i = 0; i <= text.Length; i++)
+            {
+                var isSeparator = i == text.Length || text[i] == ':' || text[i] == ',' || text[i] == '.';
+                if (isSeparator)
+                {
+                    if (start >= 0)
+                    {
+                        if (count < starts.Length)
+                        {
+                            starts[count] = start;
+                            lengths[count] = i - start;
+                        }
+
+                        count++;
+                        start = -1;
+                    }
+                }
+                else if (start < 0)
+                {
+                    start = i;
+                }
+            }
+
+            return count;
+        }
+
+        // Mirrors the old PadRight(3, '0') + int.TryParse for the fraction part: "5" -> 500,
+        // "12" -> 120, three or more digits parse as-is. Appending zeros after trailing
+        // whitespace made the old parse fail, so a short part with trailing whitespace must
+        // still fail here.
+        private static bool TryParsePaddedMilliseconds(ReadOnlySpan<char> part, out int milliseconds)
+        {
+            if (part.Length < 3)
+            {
+                if (part.Length > 0 && char.IsWhiteSpace(part[part.Length - 1]))
+                {
+                    milliseconds = 0;
+                    return false;
+                }
+
+                if (!int.TryParse(part, out milliseconds))
+                {
+                    return false;
+                }
+
+                milliseconds *= part.Length == 1 ? 100 : 10;
+                return true;
+            }
+
+            return int.TryParse(part, out milliseconds);
         }
 
         public TimeCode()

--- a/src/libse/Forms/FixCommonErrors/FixMissingSpaces.cs
+++ b/src/libse/Forms/FixCommonErrors/FixMissingSpaces.cs
@@ -20,6 +20,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         private static readonly Regex FixMissingSpacesReColon = new Regex(@"[^\s\d]\:[\p{Ll}\p{Lu}]", RegexOptions.Compiled);
         private static readonly Regex FixMissingSpacesReColonWithAfter = new Regex(@"[^\s\d]\:[\p{Ll}\p{Lu}]+", RegexOptions.Compiled);
         private static readonly Regex Url = new Regex(@"\w\.(?:com|net|org)\b", RegexOptions.Compiled);
+        private static readonly Regex FixMissingSpacesReFontStart = new Regex("[!\\.,?]<font[ colrsizeabcdef#0123456789\"=]+>\\p{L}", RegexOptions.Compiled);
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {
@@ -351,14 +352,13 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 
                 if (p.Text.IndexOf('<') >= 0) // fix: You!<font color="#ffff00">Well, bye!</font>
                 {
-                    var regexFontStart = new Regex("[!\\.,?]<font[ colrsizeabcdef#0123456789\"=]+>\\p{L}");
-                    var matchFontStart = regexFontStart.Match(p.Text);
+                    var matchFontStart = FixMissingSpacesReFontStart.Match(p.Text);
                     var jumpOut = 0;
                     var oldText = p.Text;
                     while (matchFontStart.Success && jumpOut < 10)
                     {
                         p.Text = p.Text.Insert(matchFontStart.Index + 1, " ");
-                        matchFontStart = regexFontStart.Match(p.Text, matchFontStart.Index + 1);
+                        matchFontStart = FixMissingSpacesReFontStart.Match(p.Text, matchFontStart.Index + 1);
                         jumpOut++;
                     }
 


### PR DESCRIPTION
Round two, same method as #12530: pick hot-path micro-inefficiencies, fix, prove output identity, benchmark (.NET 10, Apple M4).

## 1. `FixMissingSpaces` font-tag regex — 53× faster on its branch

The class declares all its regexes as `static readonly ... RegexOptions.Compiled` — except one: the font-tag pattern was built with `new Regex(...)` **per paragraph** containing `<` inside the FixCommonErrors loop. Hoisted to match its siblings.

| Method | Mean | Ratio | Allocated | Alloc Ratio |
|---|---:|---:|---:|---:|
| Old (`new Regex` per call) | 7,203.8 ns | 1.00 | 27,528 B | 1.00 |
| New (static compiled) | 134.9 ns | **0.02** | 624 B | **0.02** |

## 2. `TimeCode.ParseToMilliseconds` + `ParseHHMMSSFF`/`ParseHHMMSS` — 1.7× faster, allocation-free

The shared time-code parse entry behind many format importers (SubRip and ASSA have their own fast paths since #12530; everything else funnels here per line). `Split(TimeSplitChars)` allocated a `string[]` + a substring per part + a `PadRight(3, '0')` copy for the fraction. Now a stack-based tokenizer with `int.TryParse(ReadOnlySpan<char>)`; the `PadRight` scaling semantics (including its trailing-whitespace failure mode) are preserved exactly.

| Method | Mean | Ratio | Allocated | Alloc Ratio |
|---|---:|---:|---:|---:|
| Old (Split + PadRight) | 13.25 µs | 1.00 | 46,416 B | 1.00 |
| New (span tokenizer) | 7.60 µs | **0.57** | 0 B | **0.00** |

## 3. `StringExtensions.FixExtraSpaces` — 1.3× faster, −77% allocations

Called per line via `Utilities.RemoveUnneededSpaces` (FixCommonErrors, auto-break, import cleanup). The reverse scan called `string.Remove` once per space run — a fresh string per run on space-heavy OCR lines. Now a single forward pass into a pooled buffer; lines needing no change return the original instance with zero allocation.

| Method | Mean | Ratio | Allocated | Alloc Ratio |
|---|---:|---:|---:|---:|
| Old (Remove per run) | 380.2 ns | 1.00 | 2,568 B | 1.00 |
| New (single pass) | 285.0 ns | **0.75** | 584 B | **0.23** |

## Correctness

- **FixExtraSpaces**: exhaustive brute force — all 87,381 strings up to length 8 over `{' ', 'a', '\n', '\r'}` plus 2,000 random 0–120-char lines, byte-identical vs the old implementation (leading-run, CRLF-adjacent and trailing-run rules all preserved).
- **Time-code parses**: 60k+ inputs including hostile shapes (empty parts, `+`/`-` signs, embedded whitespace, 4+ digit fractions, over-long part counts, non-numerics) — identical results across all three methods.
- **Regex**: match success/index parity over the trigger texts (same pattern, so this pins the hoist itself).
- All 485 libse tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)