### PR TITLE
Image-based export: list every installed font face like SE4

### DIFF
--- a/src/libuilogic/Export/FontFaces.cs
+++ b/src/libuilogic/Export/FontFaces.cs
@@ -1,0 +1,206 @@
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.UiLogic.Export;
+
+/// <summary>
+/// Enumerates installed fonts as individual faces the way Win32/GDI (and SE4) did:
+/// one entry per named face ("Segoe UI", "Segoe UI Semibold", "Arial Black", ...), read
+/// from name ID 1 of each typeface's OpenType 'name' table. libass matches these names,
+/// so the ASSA style editor uses this list - and the image-based export dialog uses it
+/// too so every installed face is selectable (issue #12537). Skia itself groups faces
+/// under typographic family names, so resolving a face back to a typeface goes through
+/// the face map built here (family + weight/width/slant), never through the name alone.
+/// </summary>
+public static class FontFaces
+{
+    private readonly record struct FaceInfo(string SkiaFamily, int Weight, int Width, SKFontStyleSlant Slant);
+
+    private static List<string>? _facesCache;
+    private static Dictionary<string, FaceInfo>? _faceMapCache;
+    private static readonly object Gate = new();
+
+    /// <summary>All installed font faces by their Win32/GDI (name ID 1) names, sorted.</summary>
+    public static List<string> GetFontFaces()
+    {
+        if (_facesCache == null)
+        {
+            lock (Gate)
+            {
+                _facesCache ??= GetFaceMap().Keys.OrderBy(f => f).ToList();
+            }
+        }
+
+        return _facesCache;
+    }
+
+    /// <summary>
+    /// The Skia typographic family name for a face name, e.g. "Segoe UI Semibold" -> "Segoe UI".
+    /// Falls back to <paramref name="faceName"/> when unknown.
+    /// </summary>
+    public static string GetSkiaFamilyName(string faceName)
+    {
+        if (string.IsNullOrEmpty(faceName))
+        {
+            return faceName;
+        }
+
+        return GetFaceMap().TryGetValue(faceName, out var face) ? face.SkiaFamily : faceName;
+    }
+
+    /// <summary>The Win32/GDI (name ID 1) face name of a typeface; falls back to the Skia family name.</summary>
+    public static string GetFaceName(SKTypeface typeface) =>
+        ReadWin32FamilyName(typeface) ?? typeface.FamilyName;
+
+    /// <summary>
+    /// Resolves a face name to a typeface, applying bold/italic relative to the face's own
+    /// style: "Segoe UI Semibold" + bold matches the family at bold weight or heavier,
+    /// "Arial Black" + bold stays black, and italic keeps the face's weight. Unknown names
+    /// (an uninstalled font, or a plain family name from an old settings profile) fall back
+    /// to Skia's own name matching; returns null only when Skia has no match at all.
+    /// </summary>
+    public static SKTypeface? CreateTypeface(string faceName, bool bold, bool italic)
+    {
+        if (!string.IsNullOrWhiteSpace(faceName) && GetFaceMap().TryGetValue(faceName, out var face))
+        {
+            var weight = bold ? Math.Max(face.Weight, (int)SKFontStyleWeight.Bold) : face.Weight;
+            var slant = italic ? SKFontStyleSlant.Italic : face.Slant;
+            var typeface = SKFontManager.Default.MatchFamily(face.SkiaFamily, new SKFontStyle(weight, face.Width, slant));
+            if (typeface != null)
+            {
+                return typeface;
+            }
+        }
+
+        return SKTypeface.FromFamilyName(faceName, new SKFontStyle(
+            bold ? SKFontStyleWeight.Bold : SKFontStyleWeight.Normal,
+            SKFontStyleWidth.Normal,
+            italic ? SKFontStyleSlant.Italic : SKFontStyleSlant.Upright));
+    }
+
+    private static Dictionary<string, FaceInfo> GetFaceMap()
+    {
+        if (_faceMapCache == null)
+        {
+            lock (Gate)
+            {
+                _faceMapCache ??= BuildFaceMap();
+            }
+        }
+
+        return _faceMapCache;
+    }
+
+    private static Dictionary<string, FaceInfo> BuildFaceMap()
+    {
+        var map = new Dictionary<string, FaceInfo>(StringComparer.OrdinalIgnoreCase);
+        var skManager = SKFontManager.Default;
+
+        foreach (var familyName in skManager.FontFamilies)
+        {
+            using var styleSet = skManager.GetFontStyles(familyName);
+            for (var i = 0; i < styleSet.Count; i++)
+            {
+                using var typeface = styleSet.CreateTypeface(i);
+                if (typeface == null)
+                {
+                    continue;
+                }
+
+                var name = ReadWin32FamilyName(typeface) ?? typeface.FamilyName;
+                if (string.IsNullOrEmpty(name))
+                {
+                    continue;
+                }
+
+                var candidate = new FaceInfo(typeface.FamilyName, typeface.FontStyle.Weight, typeface.FontStyle.Width, typeface.FontStyle.Slant);
+
+                // Several typefaces share one face name (e.g. "Segoe UI" regular, italic and
+                // bold all carry name ID 1 "Segoe UI") - keep the most regular one so the
+                // face's base style is what the name implies.
+                if (!map.TryGetValue(name, out var existing) || Score(candidate) < Score(existing))
+                {
+                    map[name] = candidate;
+                }
+            }
+        }
+
+        return map;
+    }
+
+    // Distance from "regular": upright before italic, weight near 400, width near normal (5).
+    private static int Score(FaceInfo face) =>
+        (face.Slant == SKFontStyleSlant.Upright ? 0 : 10_000) +
+        Math.Abs(face.Weight - (int)SKFontStyleWeight.Normal) +
+        Math.Abs(face.Width - (int)SKFontStyleWidth.Normal) * 100;
+
+    /// <summary>
+    /// Reads name ID 1 (Win32/GDI family name) from the OpenType 'name' table.
+    /// Returns null when the table cannot be read (e.g. for Type1/PostScript fonts
+    /// that lack OpenType tables).
+    /// </summary>
+    internal static string? ReadWin32FamilyName(SKTypeface typeface)
+    {
+        byte[]? data;
+        try
+        {
+            data = typeface.GetTableData(0x6E616D65u); // 'name' table tag
+        }
+        catch
+        {
+            // Type1 (.pfb) and other non-OpenType fonts do not have a 'name' table;
+            // SkiaSharp throws instead of returning null for these typefaces.
+            return null;
+        }
+
+        if (data == null || data.Length < 6)
+        {
+            return null;
+        }
+
+        // name table header: format(2) count(2) stringOffset(2)
+        var count = (data[2] << 8) | data[3];
+        var stringOffset = (data[4] << 8) | data[5];
+        string? fallback = null;
+
+        for (var i = 0; i < count; i++)
+        {
+            var r = 6 + i * 12;
+            if (r + 12 > data.Length)
+            {
+                break;
+            }
+
+            int platformId = (data[r] << 8) | data[r + 1];  // 3 = Windows
+            int encodingId = (data[r + 2] << 8) | data[r + 3];  // 1 = Unicode BMP
+            int languageId = (data[r + 4] << 8) | data[r + 5];
+            int nameId = (data[r + 6] << 8) | data[r + 7];  // 1 = Win32 Family Name
+            int length = (data[r + 8] << 8) | data[r + 9];
+            int strOffset = (data[r + 10] << 8) | data[r + 11];
+
+            if (platformId != 3 || encodingId != 1 || nameId != 1)
+            {
+                continue;
+            }
+
+            var pos = stringOffset + strOffset;
+            if (pos + length > data.Length)
+            {
+                continue;
+            }
+
+            var name = Encoding.BigEndianUnicode.GetString(data, pos, length);
+            if (languageId == 0x0409)  // English (US) — prefer this over other languages
+            {
+                return name;
+            }
+
+            fallback ??= name;
+        }
+
+        return fallback;
+    }
+}

--- a/src/libuilogic/Export/ImageRenderer.cs
+++ b/src/libuilogic/Export/ImageRenderer.cs
@@ -75,13 +75,15 @@ public static class ImageRenderer
 
         var segments = ParseTextWithStyling(text, fontColor);
 
-        // Create fonts. SKTypeface.FromFamilyName can return null when the family is not
-        // found (and on some platforms when no default is available); fall back to the
-        // default typeface so we never hand a null typeface to SKFont / SKShaper.
-        using var regularTypeface = ResolveTypeface(fontName, SKFontStyle.Normal);
-        using var boldTypeface = ResolveTypeface(fontName, SKFontStyle.Bold);
-        using var italicTypeface = ResolveTypeface(fontName, SKFontStyle.Italic);
-        using var boldItalicTypeface = ResolveTypeface(fontName, SKFontStyle.BoldItalic);
+        // Create fonts. The font name is a face name from FontFaces (e.g. "Segoe UI
+        // Semibold", "Arial Black"), so resolution goes through the face map - bold and
+        // italic are applied relative to the face's own weight/slant (issue #12537).
+        // Falls back to the default typeface so we never hand a null typeface to
+        // SKFont / SKShaper.
+        using var regularTypeface = ResolveTypeface(fontName, bold: false, italic: false);
+        using var boldTypeface = ResolveTypeface(fontName, bold: true, italic: false);
+        using var italicTypeface = ResolveTypeface(fontName, bold: false, italic: true);
+        using var boldItalicTypeface = ResolveTypeface(fontName, bold: true, italic: true);
 
         using var regularFont = new SKFont(ip.IsBold ? boldTypeface : regularTypeface, fontSize);
         using var boldFont = new SKFont(boldTypeface, fontSize);
@@ -156,13 +158,13 @@ public static class ImageRenderer
         return bitmapWithMargins;
     }
 
-    // SKTypeface.FromFamilyName may return null when the requested family is missing.
-    // Passing a null typeface into SKFont / SKShaper risks a native crash, so fall back
-    // to the default typeface.
-    private static SKTypeface ResolveTypeface(string fontName, SKFontStyle style)
+    // FontFaces.CreateTypeface may return null when the requested face is missing and Skia
+    // has no name match either. Passing a null typeface into SKFont / SKShaper risks a
+    // native crash, so fall back to the default typeface.
+    private static SKTypeface ResolveTypeface(string fontName, bool bold, bool italic)
     {
-        return SKTypeface.FromFamilyName(fontName, style)
-            ?? SKTypeface.FromFamilyName(null, style)
+        return FontFaces.CreateTypeface(fontName, bold, italic)
+            ?? SKTypeface.FromFamilyName(null, bold ? SKFontStyle.Bold : SKFontStyle.Normal)
             ?? SKTypeface.Default;
     }
 

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
@@ -127,7 +127,11 @@ public partial class ExportImageBasedViewModel : ObservableObject
         _windowService = windowService;
 
         Subtitles = new ObservableCollection<SubtitleLineViewModel>();
-        FontFamilies = new ObservableCollection<string>(FontHelper.GetSystemFonts());
+        // Individual face names ("Segoe UI Semibold", "Arial Black", ...) like the ASSA style
+        // editor and SE4's GDI list - Avalonia's font list only has typographic family names,
+        // which hid every named face from this dialog (issue #12537). ImageRenderer resolves
+        // these via FontFaces, so a face renders with its own weight.
+        FontFamilies = new ObservableCollection<string>(FontHelper.GetLibAssaFonts());
         SelectedFontFamily = FontFamilies.FirstOrDefault();
         FontSizes = new ObservableCollection<int>(Enumerable.Range(15, 486));
         SelectedFontSize = 26;

--- a/src/ui/Logic/FontHelper.cs
+++ b/src/ui/Logic/FontHelper.cs
@@ -1,9 +1,8 @@
 using Avalonia.Media;
+using Nikse.SubtitleEdit.UiLogic.Export;
 using SkiaSharp;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Nikse.SubtitleEdit.Logic;
 
@@ -14,53 +13,22 @@ public static class FontHelper
         return FontManager.Current.SystemFonts.Select(p => p.Name).OrderBy(f => f).ToList();
     }
 
-    private static List<string>? _libAssaFontsCache;
-    private static Dictionary<string, string>? _libAssaToSkiaMapCache;
-
     /// <summary>
     /// Returns font family names compatible with libass.
     /// Unlike Avalonia/Skia, which surfaces the typographic family name (e.g. "Copperplate Gothic"),
     /// libass on Windows matches against the Win32/GDI family name stored in name ID 1
     /// (e.g. "Copperplate Gothic Bold", "Copperplate Gothic Light").
-    /// This method reads name ID 1 directly from each typeface's OpenType 'name' table so
-    /// the result is correct on Windows, Linux, and macOS.
-    /// Result is cached after the first call.
+    /// Implemented by <see cref="FontFaces"/> (libuilogic), which reads name ID 1 directly from
+    /// each typeface's OpenType 'name' table so the result is correct on Windows, Linux, and
+    /// macOS. Result is cached after the first call.
     /// </summary>
-    public static List<string> GetLibAssaFonts() => _libAssaFontsCache ??= BuildLibAssaFonts();
-
-    private static List<string> BuildLibAssaFonts()
-    {
-        var fonts = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var skManager = SKFontManager.Default;
-
-        foreach (var familyName in skManager.FontFamilies)
-        {
-            using var styleSet = skManager.GetFontStyles(familyName);
-            for (var i = 0; i < styleSet.Count; i++)
-            {
-                using var typeface = styleSet.CreateTypeface(i);
-                if (typeface == null)
-                {
-                    continue;
-                }
-
-                var name = ReadWin32FamilyName(typeface) ?? typeface.FamilyName;
-                if (!string.IsNullOrEmpty(name))
-                {
-                    fonts.Add(name);
-                }
-            }
-        }
-
-        return fonts.OrderBy(f => f).ToList();
-    }
+    public static List<string> GetLibAssaFonts() => FontFaces.GetFontFaces();
 
     /// <summary>
     /// Returns the libass-compatible (Win32/GDI, name ID 1) family name for a single typeface.
     /// Falls back to <see cref="SKTypeface.FamilyName"/> when the name table cannot be read.
     /// </summary>
-    public static string GetLibAssaFontName(SKTypeface typeface) =>
-        ReadWin32FamilyName(typeface) ?? typeface.FamilyName;
+    public static string GetLibAssaFontName(SKTypeface typeface) => FontFaces.GetFaceName(typeface);
 
     /// <summary>
     /// Given a libass-compatible (Win32/GDI, name ID 1) font family name,
@@ -69,110 +37,6 @@ public static class FontHelper
     /// Falls back to <paramref name="libAssaFontName"/> when no match is found.
     /// Result is cached after the first call.
     /// </summary>
-    public static string GetSkiaFontNameFromLibAssaFontName(string libAssaFontName)
-    {
-        if (string.IsNullOrEmpty(libAssaFontName))
-        {
-            return libAssaFontName;
-        }
-
-        return GetLibAssaToSkiaMap().TryGetValue(libAssaFontName, out var skiaName) ? skiaName : libAssaFontName;
-    }
-
-    private static Dictionary<string, string> GetLibAssaToSkiaMap() =>
-        _libAssaToSkiaMapCache ??= BuildLibAssaToSkiaMap();
-
-    private static Dictionary<string, string> BuildLibAssaToSkiaMap()
-    {
-        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        var skManager = SKFontManager.Default;
-
-        foreach (var familyName in skManager.FontFamilies)
-        {
-            using var styleSet = skManager.GetFontStyles(familyName);
-            for (var i = 0; i < styleSet.Count; i++)
-            {
-                using var typeface = styleSet.CreateTypeface(i);
-                if (typeface == null)
-                {
-                    continue;
-                }
-
-                var win32Name = ReadWin32FamilyName(typeface);
-                if (!string.IsNullOrEmpty(win32Name) && !map.ContainsKey(win32Name))
-                {
-                    map[win32Name] = typeface.FamilyName;
-                }
-            }
-        }
-
-        return map;
-    }
-
-    /// <summary>
-    /// Reads name ID 1 (Win32/GDI family name) from the OpenType 'name' table.
-    /// Returns null when the table cannot be read (e.g. for Type1/PostScript fonts
-    /// that lack OpenType tables).
-    /// </summary>
-    private static string? ReadWin32FamilyName(SKTypeface typeface)
-    {
-        byte[]? data;
-        try
-        {
-            data = typeface.GetTableData(0x6E616D65u); // 'name' table tag
-        }
-        catch
-        {
-            // Type1 (.pfb) and other non-OpenType fonts do not have a 'name' table;
-            // SkiaSharp throws instead of returning null for these typefaces.
-            return null;
-        }
-
-        if (data == null || data.Length < 6)
-        {
-            return null;
-        }
-
-        // name table header: format(2) count(2) stringOffset(2)
-        var count = (data[2] << 8) | data[3];
-        var stringOffset = (data[4] << 8) | data[5];
-        string? fallback = null;
-
-        for (var i = 0; i < count; i++)
-        {
-            var r = 6 + i * 12;
-            if (r + 12 > data.Length)
-            {
-                break;
-            }
-
-            int platformId = (data[r] << 8) | data[r + 1];  // 3 = Windows
-            int encodingId = (data[r + 2] << 8) | data[r + 3];  // 1 = Unicode BMP
-            int languageId = (data[r + 4] << 8) | data[r + 5];
-            int nameId = (data[r + 6] << 8) | data[r + 7];  // 1 = Win32 Family Name
-            int length = (data[r + 8] << 8) | data[r + 9];
-            int strOffset = (data[r + 10] << 8) | data[r + 11];
-
-            if (platformId != 3 || encodingId != 1 || nameId != 1)
-            {
-                continue;
-            }
-
-            var pos = stringOffset + strOffset;
-            if (pos + length > data.Length)
-            {
-                continue;
-            }
-
-            var name = Encoding.BigEndianUnicode.GetString(data, pos, length);
-            if (languageId == 0x0409)  // English (US) — prefer this over other languages
-            {
-                return name;
-            }
-
-            fallback ??= name;
-        }
-
-        return fallback;
-    }
+    public static string GetSkiaFontNameFromLibAssaFontName(string libAssaFontName) =>
+        FontFaces.GetSkiaFamilyName(libAssaFontName);
 }


### PR DESCRIPTION
Fixes #12537.

## Problem

The PGS/VobSub export dialog listed Avalonia's `FontManager` families — typographic family names only — so named faces ("Segoe UI Semibold", "Arial Black", "Roboto Light") were folded into their families and missing from the list. SE4 enumerated via GDI, which lists each face by its Win32 name; the ASSA style editor in SE5 already does the GDI-equivalent (name-ID-1 scan of every typeface's OpenType name table). Per discussion, the export dialog now uses the **same face list as the ASSA style editor** rather than a family+weight picker: SE4 parity, in-app consistency, and saved export profiles keep working since the font stays one string (regular faces carry the plain family name; unknown names fall back to Skia's own matching).

## The hidden second half

Listing the faces isn't enough — the renderer resolved fonts via `SKTypeface.FromFamilyName(name, style)`, which loses the weight for face names Skia doesn't recognize as families ("Segoe UI Semibold" would render regular). The name-table scan moves from the UI's `FontHelper` into a new `FontFaces` class in libuilogic and now records each face's Skia family + weight/width/slant; `ImageRenderer` resolves through it, applying the dialog's bold/italic toggles **relative to the face's own style** — bold on "Semibold" goes to bold-or-heavier, bold on "Black" stays black, italic keeps the face's weight. When several typefaces share one face name (regular/italic/bold all named "Segoe UI"), the most-regular one wins as the base style.

`FontHelper` delegates to `FontFaces`, so the ASSA editor, burn-in, and transparent-video windows share one cached scan. seconv's image export shares `ImageRenderer` and is fixed for free.

## Verified (headless, macOS)

- Face list: **569 faces vs 312 Skia families** — 311 entries that were invisible in the dialog before.
- Rendered `Adelle Sans Devanagari Heavy` (a face-only entry) vs its family regular: visibly heavier, wider bitmap — the weight survives all the way through the renderer, which the old resolution path lost.
- All 233 seconv + 485 libse tests pass.

Windows spot-check recommended (Segoe UI Semibold / Arial Black from the report) since face naming is platform-dependent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)