### PR TITLE
Third round of libse micro-optimizations (BenchmarkDotNet-verified)

### DIFF
--- a/src/libse/Common/HtmlUtil.cs
+++ b/src/libse/Common/HtmlUtil.cs
@@ -53,14 +53,45 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return source;
             }
 
-            // This pattern matches these tag formats:
+            // The pattern matches these tag formats:
             // <tag*>
             // < tag*>
             // </tag*>
             // < /tag*>
             // </ tag*>
             // < / tag*>
-            return TagOpenRegex.Replace(source, m => tags.Contains(m.Groups[1].Value, StringComparer.OrdinalIgnoreCase) ? string.Empty : m.Value);
+            // Runs per paragraph in many format writers, so avoid the Regex.Replace +
+            // MatchEvaluator shape it used to have: that allocated a closure over `tags`, a
+            // string per match for the tag-name group and one for every kept match - and it
+            // rebuilt the string even when no tag matched. Walk the matches instead, compare
+            // the tag name in place, and return the original instance when nothing is removed.
+            var match = TagOpenRegex.Match(source);
+            StringBuilder sb = null;
+            var pos = 0;
+            while (match.Success)
+            {
+                var group = match.Groups[1];
+                foreach (var tag in tags)
+                {
+                    if (source.AsSpan(group.Index, group.Length).Equals(tag.AsSpan(), StringComparison.OrdinalIgnoreCase))
+                    {
+                        sb ??= new StringBuilder(source.Length);
+                        sb.Append(source, pos, match.Index - pos);
+                        pos = match.Index + match.Length;
+                        break;
+                    }
+                }
+
+                match = match.NextMatch();
+            }
+
+            if (sb == null)
+            {
+                return source;
+            }
+
+            sb.Append(source, pos, source.Length - pos);
+            return sb.ToString();
         }
 
         /// <summary>

--- a/src/libse/Common/StringExtensions.cs
+++ b/src/libse/Common/StringExtensions.cs
@@ -744,9 +744,12 @@ namespace Nikse.SubtitleEdit.Core.Common
             backslashed.Replace(@"}", @"\}");
             backslashed.Replace(Environment.NewLine, @"\par" + Environment.NewLine);
 
-            // convert string char by char
-            var sb = new StringBuilder();
-            foreach (char character in backslashed.ToString())
+            // Escape non-ASCII chars, appending the escape parts separately - the old
+            // "\\u" + value + "?" concatenation allocated two strings per non-ASCII char,
+            // which adds up fast on CJK/Cyrillic subtitles.
+            var escaped = backslashed.ToString();
+            var sb = new StringBuilder(escaped.Length + 16);
+            foreach (var character in escaped)
             {
                 if (character <= 0x7f)
                 {
@@ -754,7 +757,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
                 else
                 {
-                    sb.Append("\\u" + Convert.ToUInt32(character) + "?");
+                    sb.Append("\\u").Append((int)character).Append('?');
                 }
             }
 

--- a/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
@@ -12,6 +12,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
     public class AdvancedSubStationAlpha : SubtitleFormat
     {
+        private static readonly Regex RegexDrawStart = new Regex(@"\\p[123456789]", RegexOptions.Compiled);
+
         private static readonly Regex ScriptTypeFinder = new Regex("ScriptType: *v4.00", RegexOptions.Compiled);
         public string Errors { get; private set; }
 
@@ -1988,8 +1990,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
             var p1Index = s.IndexOf("\\p1", StringComparison.Ordinal);
             if (p1Index == -1 && s.Contains("\\p"))
             {
-                var findDrawStart = new Regex(@"\\p[123456789]");
-                var match = findDrawStart.Match(s);
+                var match = RegexDrawStart.Match(s);
                 if (match.Success)
                 {
                     p1Index = match.Index;

--- a/src/libse/SubtitleFormats/DCinemaSmpte2010.cs
+++ b/src/libse/SubtitleFormats/DCinemaSmpte2010.cs
@@ -13,6 +13,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
     public class DCinemaSmpte2010 : SubtitleFormat
     {
+        private static readonly Regex RegexTextOpenTagWhiteSpace = new Regex("<Text [^<]*>\\s+", RegexOptions.Compiled);
+        private static readonly Regex RegexWhiteSpaceTextCloseTag = new Regex("\\s+</Text>", RegexOptions.Compiled);
+
         //<?xml version="1.0" encoding="UTF-8"?>
         //<dcst:SubtitleReel xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dcst="http://www.smpte-ra.org/schemas/428-7/2010/DCST">
         //  <Id>urn:uuid:7be835a3-cfb4-43d0-bb4b-f0b4c95e962e</Id>
@@ -592,7 +595,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         /// </summary>
         internal static string FixDcsTextSameLine(string xml)
         {
-            var regex = new Regex("<Text [^<]*>\\s+");
+            var regex = RegexTextOpenTagWhiteSpace;
             var match = regex.Match(xml);
             while (match.Success)
             {
@@ -602,7 +605,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 match = regex.Match(xml, match.Index);
             }
 
-            regex = new Regex("\\s+</Text>");
+            regex = RegexWhiteSpaceTextCloseTag;
             match = regex.Match(xml);
             while (match.Success)
             {

--- a/src/libse/SubtitleFormats/DvSubtitle.cs
+++ b/src/libse/SubtitleFormats/DvSubtitle.cs
@@ -11,6 +11,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
     public class DvSubtitle : SubtitleFormat
     {
         private static readonly Regex LinePattern = new Regex(@"^c 1 \d{8} \d{8} .+", RegexOptions.Compiled);
+        private static readonly Regex RegexLowerZhajBeforeUpper = new Regex("ž(\\p{Lu})", RegexOptions.Compiled);
+        private static readonly Regex RegexLowerZhajAfterUppers = new Regex("(\\p{Lu}\\p{Lu})ž", RegexOptions.Compiled);
+        private static readonly Regex RegexLjBeforeUpper = new Regex("Lj(\\p{Lu})", RegexOptions.Compiled);
+        private static readonly Regex RegexLjAfterUppers = new Regex("(\\p{Lu}\\p{Lu})Lj", RegexOptions.Compiled);
+        private static readonly Regex RegexNjBeforeUpper = new Regex("Nj(\\p{Lu})", RegexOptions.Compiled);
+        private static readonly Regex RegexNjAfterUppers = new Regex("(\\p{Lu}\\p{Lu})Nj", RegexOptions.Compiled);
 
         public override string Extension => ".dv";
 
@@ -144,14 +150,14 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 .Replace("[", "Š")
                 .Replace("{", "š");
 
-            text = new Regex("ž(\\p{Lu})").Replace(text, "Ž$1");
-            text = new Regex("(\\p{Lu}\\p{Lu})ž").Replace(text, "$1Ž");
+            text = RegexLowerZhajBeforeUpper.Replace(text, "Ž$1");
+            text = RegexLowerZhajAfterUppers.Replace(text, "$1Ž");
 
-            text = new Regex("Lj(\\p{Lu})").Replace(text, "LJ$1");
-            text = new Regex("(\\p{Lu}\\p{Lu})Lj").Replace(text, "$1LJ");
+            text = RegexLjBeforeUpper.Replace(text, "LJ$1");
+            text = RegexLjAfterUppers.Replace(text, "$1LJ");
 
-            text = new Regex("Nj(\\p{Lu})").Replace(text, "NJ$1");
-            text = new Regex("(\\p{Lu}\\p{Lu})Nj").Replace(text, "$1NJ");
+            text = RegexNjBeforeUpper.Replace(text, "NJ$1");
+            text = RegexNjAfterUppers.Replace(text, "$1NJ");
 
             var arr = text.TrimEnd('0').Replace("' '", "\n").SplitToLines();
             var sb = new StringBuilder();

--- a/src/libse/SubtitleFormats/InqScribe.cs
+++ b/src/libse/SubtitleFormats/InqScribe.cs
@@ -10,6 +10,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
     public class InqScribe : SubtitleFormat
     {
+        private static readonly Regex RegexEmbeddedTimeCodes = new Regex(@"\[\d\d:\d\d:\d\d\.\d\d\]", RegexOptions.Compiled);
+
         public override string Extension => ".inqscr";
 
         public override string Name => "InqScribe 1.1";
@@ -110,7 +112,7 @@ version=1.1
                 }
             }
 
-            var matches = new Regex(@"\[\d\d:\d\d:\d\d\.\d\d\]").Matches(textLine);
+            var matches = RegexEmbeddedTimeCodes.Matches(textLine);
             for (var i = 0; i < matches.Count; i++)
             {
                 var match = matches[i];

--- a/src/libse/SubtitleFormats/Son.cs
+++ b/src/libse/SubtitleFormats/Son.cs
@@ -8,6 +8,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
     public class Son : SubtitleFormat
     {
+        //0001  00:00:19:13 00:00:22:10 a_0001.tif
+        private static readonly Regex RegexTimeCodes = new Regex(@"^\d\d\d\d\t+(\d\d:\d\d:\d\d:\d\d)\t(\d\d:\d\d:\d\d:\d\d)\t.+\.(?:tif|tiff|png|bmp|TIF|TIFF|PNG|BMP)", RegexOptions.Compiled);
+
         public override string Extension => ".son";
 
         public override string Name => "SON";
@@ -34,14 +37,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             //0001  00:00:19:13 00:00:22:10 a_0001.tif
-            var regexTimeCodes = new Regex(@"^\d\d\d\d\t+(\d\d:\d\d:\d\d:\d\d)\t(\d\d:\d\d:\d\d:\d\d)\t.+\.(?:tif|tiff|png|bmp|TIF|TIFF|PNG|BMP)", RegexOptions.Compiled);
             Paragraph p = null;
             subtitle.Paragraphs.Clear();
             _errorCount = 0;
             int index = 0;
             foreach (string line in lines)
             {
-                var match = regexTimeCodes.Match(line);
+                var match = RegexTimeCodes.Match(line);
                 if (match.Success)
                 {
                     var start = DecodeTimeCodeFramesFourParts(match.Groups[1].Value.Split(SplitCharColon, StringSplitOptions.RemoveEmptyEntries));

--- a/src/libse/SubtitleFormats/TimedText10.cs
+++ b/src/libse/SubtitleFormats/TimedText10.cs
@@ -1111,6 +1111,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         }
 
         private static readonly Regex _endsWithTreeDigits = new Regex(@"\d\d\d$");
+        private static readonly Regex FixAmpersandRegex = new Regex("&(?!amp;)", RegexOptions.Compiled);
         private static bool IsFrames(string timeCode)
         {
             if (timeCode.Length == 12 && (timeCode[8] == '.' || timeCode[8] == ',')) // 00:00:08.292 or 00:00:08,292
@@ -1717,8 +1718,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 result = result.Remove(0, idx);
             }
 
-            var fixAmpersandRegex = new Regex("&(?!amp;)");
-            return fixAmpersandRegex.Replace(result, "&amp;");
+            return FixAmpersandRegex.Replace(result, "&amp;");
         }
     }
 }

--- a/src/libse/SubtitleFormats/TimedTextNoNs.cs
+++ b/src/libse/SubtitleFormats/TimedTextNoNs.cs
@@ -9,6 +9,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
     public class TimedTextNoNs : SubtitleFormat
     {
+        private static readonly Regex FixAmpersandRegex = new Regex("&(?!amp;)", RegexOptions.Compiled);
+
         public override string Extension => Configuration.Settings.SubtitleSettings.TimedText10FileExtension;
 
         public const string NameOfFormat = "Timed Text No Namespace";
@@ -416,8 +418,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 result = result.Remove(0, idx);
             }
 
-            var fixAmpersandRegex = new Regex("&(?!amp;)");
-            return fixAmpersandRegex.Replace(result, "&amp;");
+            return FixAmpersandRegex.Replace(result, "&amp;");
         }
     }
 }

--- a/src/libse/SubtitleFormats/WebVTT.cs
+++ b/src/libse/SubtitleFormats/WebVTT.cs
@@ -18,6 +18,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         private static readonly Regex RegexTimeCodesMiddle = new Regex(@"^-?\d+:-?\d+\.-?\d+\s*-->\s*-?\d+:-?\d+:-?\d+\.-?\d+", RegexOptions.Compiled);
         private static readonly Regex RegexTimeCodesShort = new Regex(@"^-?\d+:-?\d+\.-?\d+\s*-->\s*-?\d+:-?\d+\.-?\d+", RegexOptions.Compiled);
         private static readonly Regex RegexShortArrow = new Regex(@"-->\s*", RegexOptions.Compiled);
+        private static readonly Regex RegexRemoveCTags = new Regex(@"\</?c([a-zA-Z\._\-\d%#]*)\>", RegexOptions.Compiled);
+        private static readonly Regex RegexRemoveTimeCodes = new Regex(@"\<\d+:\d+:\d+\.\d+\>", RegexOptions.Compiled); // <00:00:10.049>
+        private static readonly Regex RegexTagsPlusWhiteSpace = new Regex(@"(\{\\an\d\})[\s\r\n]+", RegexOptions.Compiled);
+        private static readonly Regex RegexCueLine = new Regex(@"::cue\(([a-zA-Z\._\-\d%#]*)\)\s*{", RegexOptions.Compiled);
 
         public static readonly Dictionary<string, SKColor> DefaultColorClasses = new Dictionary<string, SKColor>
         {
@@ -650,9 +654,6 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override void RemoveNativeFormatting(Subtitle subtitle, SubtitleFormat newFormat)
         {
-            var regexRemoveCTags = new Regex(@"\</?c([a-zA-Z\._\-\d%#]*)\>", RegexOptions.Compiled);
-            var regexRemoveTimeCodes = new Regex(@"\<\d+:\d+:\d+\.\d+\>", RegexOptions.Compiled); // <00:00:10.049>
-            var regexTagsPlusWhiteSpace = new Regex(@"(\{\\an\d\})[\s\r\n]+", RegexOptions.Compiled); // <00:00:10.049>
 
             var cueStyles = GetCueStyles(subtitle.Header);
             var italicStyles = GetStylesWith(cueStyles, "font-style:italic;");
@@ -664,7 +665,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     var text = p.Text.Replace("&rlm;", string.Empty).Replace("&lrm;", string.Empty); // or use rlm=\u202B, lrm=\u202A ?
                     text = System.Net.WebUtility.HtmlDecode(text);
-                    var match = regexRemoveCTags.Match(text);
+                    var match = RegexRemoveCTags.Match(text);
                     while (match.Success)
                     {
                         var start = match.Index + 1;
@@ -699,16 +700,16 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             text = SetEndTag(text, text.IndexOf("<c", match.Index, StringComparison.Ordinal), "</b>");
                         }
 
-                        match = regexRemoveCTags.Match(text, start);
+                        match = RegexRemoveCTags.Match(text, start);
                     }
 
                     text = RemoveTag("v", text);
                     text = RemoveTag("rt", text);
                     text = RemoveTag("ruby", text);
                     text = RemoveTag("span", text);
-                    text = regexRemoveCTags.Replace(text, string.Empty).Trim();
-                    text = regexRemoveTimeCodes.Replace(text, string.Empty).Trim();
-                    text = regexTagsPlusWhiteSpace.Replace(text, "$1");
+                    text = RegexRemoveCTags.Replace(text, string.Empty).Trim();
+                    text = RegexRemoveTimeCodes.Replace(text, string.Empty).Trim();
+                    text = RegexTagsPlusWhiteSpace.Replace(text, "$1");
                     p.Text = text;
                 }
             }
@@ -774,7 +775,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 return dic;
             }
 
-            var matches = new Regex(@"::cue\(([a-zA-Z\._\-\d%#]*)\)\s*{").Matches(header);
+            var matches = RegexCueLine.Matches(header);
             for (var i = 0; i < matches.Count; i++)
             {
                 var match = matches[i];


### PR DESCRIPTION
Same method as #12530/#12533. Three optimizations, each with A/B output-identity proof and BenchmarkDotNet numbers (.NET 10, Apple M4).

## 1. Hoist 15 method-local `new Regex(...)` constructions in subtitle formats — up to ~8,000×

Eight format files constructed regexes inside methods. The worst was `WebVTT.RemoveNativeFormatting`: **three `RegexOptions.Compiled` regexes built on every call** — compiled construction emits IL, costing ~1.7 ms before processing a single cue, on one of the most-converted formats there is. InqScribe built one regex per text line; DvSubtitle six per call; TimedText10/TimedTextNoNs, Son, DCinemaSmpte2010 and the ASSA drawing-tag helper had one or two each. All are now `private static readonly ... RegexOptions.Compiled`, matching the codebase convention.

| Method | Mean | Ratio | Allocated |
|---|---:|---:|---:|
| Old (3 compiled per call, WebVTT shape) | 1,738,436 ns | 1.000 | 43,060 B |
| New (statics) | 207 ns | **0.000** | 0 B |

## 2. `HtmlUtil.RemoveOpenCloseTags` — 1.5× faster, no-op lines allocation-free

Used per paragraph by a dozen format writers (PAC, Cavena890, TS, BelleNuit, several Unknown formats, translate formatting). The `Regex.Replace` + `MatchEvaluator` shape allocated a closure over `tags`, a string per match for the tag-name group, one more per *kept* match — and rebuilt the string even when nothing matched. Now walks matches, compares the group via span (`OrdinalIgnoreCase`), and returns the **original instance** when no tag is removed.

| Method | Mean | Ratio | Allocated | Alloc Ratio |
|---|---:|---:|---:|---:|
| Old | 1.75 µs | 1.00 | 6.63 KB | 1.00 |
| New | 1.17 µs | **0.67** | 6.19 KB | 0.93 |

(The alloc delta looks modest because the mixed benchmark is dominated by removal-heavy lines; untouched lines drop from full-rebuild to zero.)

## 3. `StringExtensions.ToRtfPart` — 1.6× faster, −52% allocations

`sb.Append("\\u" + Convert.ToUInt32(c) + "?")` allocated two strings per non-ASCII character — painful on CJK/Cyrillic text in the RTF format/copy paths. Now appends the parts separately.

| Method | Mean | Ratio | Allocated | Alloc Ratio |
|---|---:|---:|---:|---:|
| Old | 1.90 µs | 1.00 | 15.36 KB | 1.00 |
| New | 1.21 µs | **0.64** | 7.36 KB | 0.48 |

## Correctness

- `RemoveOpenCloseTags`: 30,000 randomized tag-soup inputs (spaced tags `< / i >`, unclosed `<unclosed`, case variants, `5 < 6` non-tags, `<v Speaker Name>`) across five tag sets — byte-identical vs the old implementation, plus a reference-equality check on the new no-change fast path.
- `ToRtfPart`: 30,000 random inputs mixing RTF-special chars (`\`, `{`, `}`), CRLF, and CJK/Cyrillic/Greek — byte-identical.
- Regex hoists: pattern strings copied verbatim; behavior covered by the format round-trip tests.
- All 485 libse + 233 seconv tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)