### PR TITLE
Fourth round of libse micro-optimizations (BenchmarkDotNet-verified)

### DIFF
--- a/src/libse/Common/StrippableText.cs
+++ b/src/libse/Common/StrippableText.cs
@@ -20,101 +20,103 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public StrippableText(string input, string stripStartCharacters, string stripEndCharacters)
         {
+            // A StrippableText is constructed per paragraph in several FixCommonErrors rules,
+            // so strip by moving [start, end) cursors over the input. The previous version did
+            // "Pre += text[0]; text = text.Remove(0, 1)" per stripped character (and the
+            // mirrored Substring dance at the end), reallocating the whole remaining string for
+            // every dash/quote/bracket/tag - quadratic on decorated lines. The cursor logic
+            // below mirrors the old flow exactly; only the final three Substring calls allocate.
             OriginalText = input;
             var text = input;
+            var start = 0;
+            var end = text.Length;
 
-            Pre = string.Empty;
-            if (text.Length > 0 && ("<{" + stripStartCharacters).Contains(text[0]))
+            if (end > 0 && ("<{" + stripStartCharacters).Contains(text[0]))
             {
-                int beginLength;
+                int beginStart;
                 do
                 {
-                    beginLength = text.Length;
+                    beginStart = start;
 
-                    while (text.Length > 0 && stripStartCharacters.Contains(text[0]))
+                    while (start < end && stripStartCharacters.Contains(text[start]))
                     {
-                        Pre += text[0];
-                        text = text.Remove(0, 1);
+                        start++;
                     }
 
                     // ASS/SSA codes like {\an9}
-                    int endIndex = text.IndexOf('}');
-                    if (endIndex > 0 && text.StartsWith("{\\", StringComparison.Ordinal))
+                    int endIndex = text.IndexOf('}', start);
+                    if (endIndex > start && start + 1 < end && text[start] == '{' && text[start + 1] == '\\')
                     {
-                        int nextStartIndex = text.IndexOf('{', 2);
+                        int nextStartIndex = start + 2 < end ? text.IndexOf('{', start + 2) : -1;
                         if (nextStartIndex == -1 || nextStartIndex > endIndex)
                         {
-                            endIndex++;
-                            Pre += text.Substring(0, endIndex);
-                            text = text.Remove(0, endIndex);
+                            start = endIndex + 1;
                         }
                     }
 
                     // tags like <i> or <font face="Segoe Print" color="#ff0000">
-                    endIndex = text.IndexOf('>');
-                    if (text.StartsWith('<') && endIndex >= 2)
+                    endIndex = start < end ? text.IndexOf('>', start) : -1;
+                    if (start < end && text[start] == '<' && endIndex - start >= 2)
                     {
-                        endIndex++;
-                        Pre += text.Substring(0, endIndex);
-                        text = text.Remove(0, endIndex);
+                        start = endIndex + 1;
                     }
                 }
-                while (text.Length < beginLength);
+                while (start > beginStart);
             }
 
-            Post = string.Empty;
-            if (text.Length > 0 && (">" + stripEndCharacters).Contains(text[text.Length - 1]))
+            if (end > start && (">" + stripEndCharacters).Contains(text[end - 1]))
             {
-                int beginLength;
+                int beginEnd;
                 do
                 {
-                    beginLength = text.Length;
+                    beginEnd = end;
 
-                    while (text.Length > 0 && stripEndCharacters.Contains(text[text.Length - 1]))
+                    while (end > start && stripEndCharacters.Contains(text[end - 1]))
                     {
-                        Post = text[text.Length - 1] + Post;
-                        text = text.Substring(0, text.Length - 1);
+                        end--;
                     }
 
-                    if (text.EndsWith('>'))
+                    if (end > start && text[end - 1] == '>')
                     {
                         // tags </i> </b> </u>
-                        if (text.EndsWith("</i>", StringComparison.OrdinalIgnoreCase) ||
-                            text.EndsWith("</b>", StringComparison.OrdinalIgnoreCase) ||
-                            text.EndsWith("</u>", StringComparison.OrdinalIgnoreCase))
+                        if (end - start >= 4 && text[end - 4] == '<' && text[end - 3] == '/' &&
+                            (EndsWithTag(text, end, "</i>") || EndsWithTag(text, end, "</b>") || EndsWithTag(text, end, "</u>")))
                         {
-                            Post = text.Substring(text.Length - 4) + Post;
-                            text = text.Substring(0, text.Length - 4);
+                            end -= 4;
                         }
 
                         // tag </font>
-                        if (text.EndsWith("</font>", StringComparison.OrdinalIgnoreCase))
+                        if (end - start >= 7 && EndsWithTag(text, end, "</font>"))
                         {
-                            Post = text.Substring(text.Length - 7) + Post;
-                            text = text.Substring(0, text.Length - 7);
+                            end -= 7;
                         }
 
-                        if (text.EndsWith('>'))
+                        if (end > start && text[end - 1] == '>')
                         {
-                            var lastIndexOfStart = text.LastIndexOf("<");
-                            if (lastIndexOfStart >= 0)
+                            var lastIndexOfStart = text.LastIndexOf('<', end - 1);
+                            if (lastIndexOfStart >= start)
                             {
-                                var tag = text.Substring(lastIndexOfStart);
+                                var tag = text.Substring(lastIndexOfStart, end - lastIndexOfStart);
                                 tag = tag.TrimStart('<').TrimEnd('>');
                                 if (tag.StartsWith("/c.", StringComparison.Ordinal) && !tag.Contains(' ') && !tag.Contains('\n'))
                                 {
-                                    Post = text.Substring(lastIndexOfStart) + Post;
-                                    text = text.Substring(0, lastIndexOfStart);
+                                    end = lastIndexOfStart;
                                 }
                             }
                         }
                     }
                 }
-                while (text.Length < beginLength);
+                while (end < beginEnd);
             }
 
-            StrippedText = text;
+            Pre = text.Substring(0, start);
+            Post = text.Substring(end);
+            StrippedText = text.Substring(start, end - start);
         }
+
+        // True when text[..end] ends with the given lowercase tag, ignoring case.
+        private static bool EndsWithTag(string text, int end, string tag) =>
+            string.Compare(text, end - tag.Length, tag, 0, tag.Length, StringComparison.OrdinalIgnoreCase) == 0;
 
         private static string GetAndInsertNextId(List<string> replaceIds, List<string> replaceNames, string name, int idName)
         {

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -675,37 +675,69 @@ namespace Nikse.SubtitleEdit.Core.Common
             return s.TrimEnd();
         }
 
+        // Patterns for RemoveLineBreaks - static so the per-call "</i> " + Environment.NewLine
+        // + "<i>" style concatenations (an allocation per pattern, per call) are gone.
+        private static readonly string ItalicCloseSpaceNewLineItalicOpen = "</i> " + Environment.NewLine + "<i>";
+        private static readonly string ItalicCloseNewLineSpaceItalicOpen = "</i>" + Environment.NewLine + " <i>";
+        private static readonly string ItalicCloseNewLineItalicOpen = "</i>" + Environment.NewLine + "<i>";
+        private static readonly string NewLineSpaceItalicClose = Environment.NewLine + " </i>";
+        private static readonly string NewLineSpaceBoldClose = Environment.NewLine + " </b>";
+        private static readonly string NewLineSpaceUnderlineClose = Environment.NewLine + " </u>";
+        private static readonly string NewLineSpaceFontClose = Environment.NewLine + " </font>";
+        private static readonly string SpaceNewLineItalicClose = " " + Environment.NewLine + "</i>";
+        private static readonly string SpaceNewLineBoldClose = " " + Environment.NewLine + "</b>";
+        private static readonly string SpaceNewLineUnderlineClose = " " + Environment.NewLine + "</u>";
+        private static readonly string SpaceNewLineFontClose = " " + Environment.NewLine + "</font>";
+        private static readonly string NewLineItalicClose = Environment.NewLine + "</i>";
+        private static readonly string NewLineBoldClose = Environment.NewLine + "</b>";
+        private static readonly string NewLineUnderlineClose = Environment.NewLine + "</u>";
+        private static readonly string NewLineFontClose = Environment.NewLine + "</font>";
+        private static readonly string ItalicCloseNewLine = "</i>" + Environment.NewLine;
+        private static readonly string BoldCloseNewLine = "</b>" + Environment.NewLine;
+        private static readonly string UnderlineCloseNewLine = "</u>" + Environment.NewLine;
+        private static readonly string FontCloseNewLine = "</font>" + Environment.NewLine;
+        private static readonly string SpaceNewLine = " " + Environment.NewLine;
+        private static readonly string NewLineSpace = Environment.NewLine + " ";
+
         public static string RemoveLineBreaks(string input)
         {
             var s = HtmlUtil.FixUpperTags(input);
 
-            s = s.Replace("</i> " + Environment.NewLine + "<i>", Environment.NewLine);
-            s = s.Replace("</i>" + Environment.NewLine + " <i>", Environment.NewLine);
-            s = s.Replace("</i>" + Environment.NewLine + "<i>", Environment.NewLine);
-
-            s = s.Replace(Environment.NewLine + " </i>", "</i>" + Environment.NewLine);
-            s = s.Replace(Environment.NewLine + " </b>", "</b>" + Environment.NewLine);
-            s = s.Replace(Environment.NewLine + " </u>", "</u>" + Environment.NewLine);
-            s = s.Replace(Environment.NewLine + " </font>", "</font>" + Environment.NewLine);
-
-            s = s.Replace(" " + Environment.NewLine + "</i>", "</i>" + Environment.NewLine);
-            s = s.Replace(" " + Environment.NewLine + "</b>", "</b>" + Environment.NewLine);
-            s = s.Replace(" " + Environment.NewLine + "</u>", "</u>" + Environment.NewLine);
-            s = s.Replace(" " + Environment.NewLine + "</font>", "</font>" + Environment.NewLine);
-
-            s = s.Replace(Environment.NewLine + "</i>", "</i>" + Environment.NewLine);
-            s = s.Replace(Environment.NewLine + "</b>", "</b>" + Environment.NewLine);
-            s = s.Replace(Environment.NewLine + "</u>", "</u>" + Environment.NewLine);
-            s = s.Replace(Environment.NewLine + "</font>", "</font>" + Environment.NewLine);
-
-            while (s.Contains(" " + Environment.NewLine))
+            // Runs for every auto-broken line. Every pattern below contains a line break, so
+            // single-line input (common when cleaning imported/translated text) skips all 15
+            // replaces and the two collapse loops.
+            if (s.IndexOf('\n') < 0)
             {
-                s = s.Replace(" " + Environment.NewLine, Environment.NewLine);
+                return s.Trim();
             }
 
-            while (s.Contains(Environment.NewLine + " "))
+            s = s.Replace(ItalicCloseSpaceNewLineItalicOpen, Environment.NewLine);
+            s = s.Replace(ItalicCloseNewLineSpaceItalicOpen, Environment.NewLine);
+            s = s.Replace(ItalicCloseNewLineItalicOpen, Environment.NewLine);
+
+            s = s.Replace(NewLineSpaceItalicClose, ItalicCloseNewLine);
+            s = s.Replace(NewLineSpaceBoldClose, BoldCloseNewLine);
+            s = s.Replace(NewLineSpaceUnderlineClose, UnderlineCloseNewLine);
+            s = s.Replace(NewLineSpaceFontClose, FontCloseNewLine);
+
+            s = s.Replace(SpaceNewLineItalicClose, ItalicCloseNewLine);
+            s = s.Replace(SpaceNewLineBoldClose, BoldCloseNewLine);
+            s = s.Replace(SpaceNewLineUnderlineClose, UnderlineCloseNewLine);
+            s = s.Replace(SpaceNewLineFontClose, FontCloseNewLine);
+
+            s = s.Replace(NewLineItalicClose, ItalicCloseNewLine);
+            s = s.Replace(NewLineBoldClose, BoldCloseNewLine);
+            s = s.Replace(NewLineUnderlineClose, UnderlineCloseNewLine);
+            s = s.Replace(NewLineFontClose, FontCloseNewLine);
+
+            while (s.Contains(SpaceNewLine))
             {
-                s = s.Replace(Environment.NewLine + " ", Environment.NewLine);
+                s = s.Replace(SpaceNewLine, Environment.NewLine);
+            }
+
+            while (s.Contains(NewLineSpace))
+            {
+                s = s.Replace(NewLineSpace, Environment.NewLine);
             }
 
             s = s.Replace(Environment.NewLine, " ");

--- a/src/libse/Forms/FixCommonErrors/FixUppercaseIInsideWords.cs
+++ b/src/libse/Forms/FixCommonErrors/FixUppercaseIInsideWords.cs
@@ -117,17 +117,22 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             callbacks.UpdateFixStatus(uppercaseIsInsideLowercaseWords, Language.FixUppercaseIInsideLowercaseWords);
         }
 
+        // Static so the loop conditions below don't rebuild "NewLine + punctuation" (a concat
+        // plus a fresh string) on every single character step of the word scan.
+        private static readonly string WordBoundaryCharsBefore = Environment.NewLine + @" ,.!?""'=()[]/-¿¡«»“”>—";
+        private static readonly string WordBoundaryCharsAfter = Environment.NewLine + @" ,.!?:;""'=()[]/-«»“”<—";
+
         private static string GetWholeWord(string text, int index)
         {
             int start = index;
-            while (start > 0 && !(Environment.NewLine + @" ,.!?""'=()[]/-¿¡«»“”>—").Contains(text[start - 1]) ||
+            while (start > 0 && !WordBoundaryCharsBefore.Contains(text[start - 1]) ||
                    start > 1 && text[start - 1] == '\'' && char.IsLetter(text[start - 2]))
             {
                 start--;
             }
 
             int end = index;
-            while (end + 1 < text.Length && !(Environment.NewLine + @" ,.!?:;""'=()[]/-«»“”<—").Contains(text[end + 1]) ||
+            while (end + 1 < text.Length && !WordBoundaryCharsAfter.Contains(text[end + 1]) ||
                    end + 2 < text.Length && text[end + 1] == '\'' && char.IsLetter(text[end + 2]))
             {
                 end++;


### PR DESCRIPTION
Same method as #12530/#12533/#12541: fresh hot-path scan, three fixes, A/B output-identity proof, BenchmarkDotNet numbers (.NET 10, Apple M4).

## 1. `StrippableText` constructor — 1.6× faster, −50% allocations (quadratic → linear)

Constructed per paragraph by several FixCommonErrors rules (casing, uppercase-I, start-with-uppercase, HI removal). The edge-stripping loops did `Pre += text[0]; text = text.Remove(0, 1)` per character — and the mirror image at the end — reallocating the whole remaining string for every stripped dash/quote/bracket/tag: **quadratic** in the decoration length. Now moves `[start, end)` cursors over the input and allocates exactly three substrings at the end; the flow (char strip ↔ `{\an9}` ↔ `<tag>` alternation, `</i>`/`</font>`/`/c.` handling) mirrors the old logic exactly.

| Method | Mean | Ratio | Allocated | Alloc Ratio |
|---|---:|---:|---:|---:|
| Old | 761.4 ns | 1.00 | 5.11 KB | 1.00 |
| New | 461.7 ns | **0.61** | 2.55 KB | **0.50** |

## 2. `Utilities.RemoveLineBreaks` — 2.7× faster, −89% allocations

Runs for every auto-broken line (`AutoBreakLine` on import, merge, auto-balance). Fifteen unconditional `Replace` calls each built their pattern with `"</i> " + Environment.NewLine + "<i>"`-style concatenation — one to two allocations per pattern per call, plus two more inside `while` conditions. Patterns are now static fields, and single-line input (every pattern contains a line break) skips the block entirely.

| Method | Mean | Ratio | Allocated | Alloc Ratio |
|---|---:|---:|---:|---:|
| Old | 1,238.2 ns | 1.00 | 7,376 B | 1.00 |
| New | 450.9 ns | **0.36** | 832 B | **0.11** |

## 3. `FixUppercaseIInsideWords.GetWholeWord` — 4.2× faster, −95% allocations

Called per regex match while fixing OCR I/l confusion. Both scan loops evaluated `(Environment.NewLine + @" ,.!?...").Contains(ch)` in the loop condition — rebuilding the boundary string **on every character step**. Hoisted to two static fields.

| Method | Mean | Ratio | Allocated | Alloc Ratio |
|---|---:|---:|---:|---:|
| Old | 448.6 ns | 1.00 | 6,032 B | 1.00 |
| New | 105.6 ns | **0.24** | 272 B | **0.05** |

## Correctness

- **StrippableText**: 50,000 randomized decorated lines (strip chars, ASSA `{\an8}`/`{\i1}` tags, `<font …>`, `</c.yellow>`, unmatched `<`/`>`/`{`) — `Pre`/`StrippedText`/`Post` all byte-identical to the old implementation, plus the `Pre + StrippedText + Post == input` invariant asserted on every case.
- **RemoveLineBreaks**: 50,000 random tag/newline/space combos — identical output (the early-out is provably equivalent: every removed pattern contains a line break).
- **GetWholeWord**: every index of several sample texts (apostrophes, guillemets, em-dash, line breaks) — identical.
- All 485 libse + 233 seconv tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)