### PR TITLE
Fix three bugs: timecode whitespace regression, culture parsing, F10 shortcut override

### DIFF
--- a/src/libse/Common/TimeCode.cs
+++ b/src/libse/Common/TimeCode.cs
@@ -133,30 +133,26 @@ namespace Nikse.SubtitleEdit.Core.Common
             return count;
         }
 
-        // Mirrors the old PadRight(3, '0') + int.TryParse for the fraction part: "5" -> 500,
-        // "12" -> 120, three or more digits parse as-is. Appending zeros after trailing
-        // whitespace made the old parse fail, so a short part with trailing whitespace must
-        // still fail here.
+        // The fraction part parses like PadRight(3, '0') + int.TryParse always did: "5" -> 500,
+        // "12" -> 120, three or more digits as-is. Padding into a stack buffer keeps the exact
+        // historical semantics for odd inputs too - " " pads to " 00" (leading whitespace, parses
+        // as 0) while "5 " pads to "5 0" (embedded whitespace, fails); a hand-rolled whitespace
+        // check here previously got the all-whitespace case wrong.
         private static bool TryParsePaddedMilliseconds(ReadOnlySpan<char> part, out int milliseconds)
         {
-            if (part.Length < 3)
+            if (part.Length >= 3)
             {
-                if (part.Length > 0 && char.IsWhiteSpace(part[part.Length - 1]))
-                {
-                    milliseconds = 0;
-                    return false;
-                }
-
-                if (!int.TryParse(part, out milliseconds))
-                {
-                    return false;
-                }
-
-                milliseconds *= part.Length == 1 ? 100 : 10;
-                return true;
+                return int.TryParse(part, out milliseconds);
             }
 
-            return int.TryParse(part, out milliseconds);
+            Span<char> padded = stackalloc char[3];
+            part.CopyTo(padded);
+            for (var i = part.Length; i < 3; i++)
+            {
+                padded[i] = '0';
+            }
+
+            return int.TryParse(padded, out milliseconds);
         }
 
         public TimeCode()

--- a/src/libse/SubtitleFormats/AribB36.cs
+++ b/src/libse/SubtitleFormats/AribB36.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -235,7 +236,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         else if (code.EndsWith(" S"))
                         {
                             double d;
-                            if (double.TryParse(code.TrimEnd('S'), out d))
+                            if (double.TryParse(code.TrimEnd('S'), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out d))
                             {
                                 DurationInSeconds = d;
                             }

--- a/src/libse/SubtitleFormats/CaptionateMs.cs
+++ b/src/libse/SubtitleFormats/CaptionateMs.cs
@@ -108,7 +108,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     if (node.Attributes["time"] != null)
                     {
                         string start = node.Attributes["time"].InnerText;
-                        double startMilliseconds = double.Parse(start);
+                        double startMilliseconds = double.Parse(start, CultureInfo.InvariantCulture);
                         if (p != null)
                         {
                             p.EndTime.TotalMilliseconds = startMilliseconds - 1;

--- a/src/libse/SubtitleFormats/ClqttJson.cs
+++ b/src/libse/SubtitleFormats/ClqttJson.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -69,7 +70,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     try
                     {
-                        frameRate = double.Parse(fpsString.Replace("FPS_", "")) / 100.0;
+                        frameRate = double.Parse(fpsString.Replace("FPS_", ""), CultureInfo.InvariantCulture) / 100.0;
                     }
                     catch
                     {

--- a/src/libse/SubtitleFormats/DCinemaSmpte2007.cs
+++ b/src/libse/SubtitleFormats/DCinemaSmpte2007.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Xml;
 using System.Xml.Schema;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -86,7 +87,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             if (!string.IsNullOrEmpty(ss.CurrentDCinemaEditRate))
             {
                 var temp = ss.CurrentDCinemaEditRate.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-                if (temp.Length == 2 && double.TryParse(temp[0], out var d1) && double.TryParse(temp[1], out var d2))
+                if (temp.Length == 2 && double.TryParse(temp[0], NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var d1) && double.TryParse(temp[1], NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var d2))
                 {
                     _frameRate = d1 / d2;
                 }

--- a/src/libse/SubtitleFormats/DCinemaSmpte2010.cs
+++ b/src/libse/SubtitleFormats/DCinemaSmpte2010.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Schema;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -86,7 +87,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             if (!string.IsNullOrEmpty(ss.CurrentDCinemaEditRate))
             {
                 var temp = ss.CurrentDCinemaEditRate.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-                if (temp.Length == 2 && double.TryParse(temp[0], out var d1) && double.TryParse(temp[1], out var d2))
+                if (temp.Length == 2 && double.TryParse(temp[0], NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var d1) && double.TryParse(temp[1], NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var d2))
                 {
                     _frameRate = d1 / d2;
                 }

--- a/src/libse/SubtitleFormats/DCinemaSmpte2014.cs
+++ b/src/libse/SubtitleFormats/DCinemaSmpte2014.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Xml;
 using System.Xml.Schema;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -82,7 +83,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             if (!string.IsNullOrEmpty(ss.CurrentDCinemaEditRate))
             {
                 var temp = ss.CurrentDCinemaEditRate.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-                if (temp.Length == 2 && double.TryParse(temp[0], out var d1) && double.TryParse(temp[1], out var d2))
+                if (temp.Length == 2 && double.TryParse(temp[0], NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var d1) && double.TryParse(temp[1], NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var d2))
                 {
                     _frameRate = d1 / d2;
                 }

--- a/src/libse/SubtitleFormats/DlDd.cs
+++ b/src/libse/SubtitleFormats/DlDd.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -37,7 +38,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     try
                     {
-                        var timeCodeIn = new TimeCode(Convert.ToDouble(node.Attributes["data-time"].InnerText));
+                        var timeCodeIn = new TimeCode(Convert.ToDouble(node.Attributes["data-time"].InnerText, CultureInfo.InvariantCulture));
                         var timeCodeOut = new TimeCode(timeCodeIn.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(node.InnerText));
                         var p = new Paragraph(timeCodeIn, timeCodeOut, Utilities.AutoBreakLine(node.InnerText));
                         subtitle.Paragraphs.Add(p);

--- a/src/libse/SubtitleFormats/FinalCutProImage.cs
+++ b/src/libse/SubtitleFormats/FinalCutProImage.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -35,7 +36,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     try
                     {
-                        var frameRate = double.Parse(xml.DocumentElement.SelectSingleNode("sequence/rate/timebase").InnerText);
+                        var frameRate = double.Parse(xml.DocumentElement.SelectSingleNode("sequence/rate/timebase").InnerText, CultureInfo.InvariantCulture);
                         if (frameRate > 10 && frameRate < 2000)
                         {
                             Configuration.Settings.General.CurrentFrameRate = frameRate;

--- a/src/libse/SubtitleFormats/FinalCutProTest2Xml.cs
+++ b/src/libse/SubtitleFormats/FinalCutProTest2Xml.cs
@@ -176,7 +176,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     try
                     {
-                        frameRate = double.Parse(xml.DocumentElement.SelectSingleNode("sequence/rate/timebase").InnerText);
+                        frameRate = double.Parse(xml.DocumentElement.SelectSingleNode("sequence/rate/timebase").InnerText, CultureInfo.InvariantCulture);
                     }
                     catch
                     {
@@ -194,7 +194,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             XmlNode timebase = rate?.SelectSingleNode("timebase");
                             if (timebase != null)
                             {
-                                frameRate = double.Parse(timebase.InnerText);
+                                frameRate = double.Parse(timebase.InnerText, CultureInfo.InvariantCulture);
                             }
 
                             double startFrame = 0;
@@ -202,13 +202,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             XmlNode startNode = generatorItemNode.SelectSingleNode("start");
                             if (startNode != null)
                             {
-                                startFrame = double.Parse(startNode.InnerText);
+                                startFrame = double.Parse(startNode.InnerText, CultureInfo.InvariantCulture);
                             }
 
                             XmlNode endNode = generatorItemNode.SelectSingleNode("end");
                             if (endNode != null)
                             {
-                                endFrame = double.Parse(endNode.InnerText);
+                                endFrame = double.Parse(endNode.InnerText, CultureInfo.InvariantCulture);
                             }
 
                             string text = string.Empty;
@@ -290,7 +290,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                                     text = "<i>" + text + "</i>";
                                 }
 
-                                subtitle.Paragraphs.Add(new Paragraph(text, Convert.ToDouble((startFrame / frameRate) * 1000), Convert.ToDouble((endFrame / frameRate) * 1000)));
+                                subtitle.Paragraphs.Add(new Paragraph(text, Convert.ToDouble((startFrame / frameRate) * 1000, CultureInfo.InvariantCulture), Convert.ToDouble((endFrame / frameRate) * 1000, CultureInfo.InvariantCulture)));
                             }
                         }
                     }

--- a/src/libse/SubtitleFormats/FinalCutProTextXml.cs
+++ b/src/libse/SubtitleFormats/FinalCutProTextXml.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -258,7 +259,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     try
                     {
-                        frameRate = double.Parse(xml.DocumentElement.SelectSingleNode("sequence/rate/timebase").InnerText);
+                        frameRate = double.Parse(xml.DocumentElement.SelectSingleNode("sequence/rate/timebase").InnerText, CultureInfo.InvariantCulture);
                     }
                     catch
                     {
@@ -278,7 +279,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                                 XmlNode timebase = rate.SelectSingleNode("timebase");
                                 if (timebase != null)
                                 {
-                                    frameRate = double.Parse(timebase.InnerText);
+                                    frameRate = double.Parse(timebase.InnerText, CultureInfo.InvariantCulture);
                                 }
                             }
 
@@ -287,13 +288,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             XmlNode startNode = generatorItemNode.SelectSingleNode("start");
                             if (startNode != null)
                             {
-                                startFrame = double.Parse(startNode.InnerText);
+                                startFrame = double.Parse(startNode.InnerText, CultureInfo.InvariantCulture);
                             }
 
                             XmlNode endNode = generatorItemNode.SelectSingleNode("end");
                             if (endNode != null)
                             {
-                                endFrame = double.Parse(endNode.InnerText);
+                                endFrame = double.Parse(endNode.InnerText, CultureInfo.InvariantCulture);
                             }
 
                             string text = string.Empty;
@@ -375,7 +376,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                                     text = "<i>" + text + "</i>";
                                 }
 
-                                subtitle.Paragraphs.Add(new Paragraph(text, Convert.ToDouble((startFrame / frameRate) * 1000), Convert.ToDouble((endFrame / frameRate) * 1000)));
+                                subtitle.Paragraphs.Add(new Paragraph(text, Convert.ToDouble((startFrame / frameRate) * 1000, CultureInfo.InvariantCulture), Convert.ToDouble((endFrame / frameRate) * 1000, CultureInfo.InvariantCulture)));
                             }
                         }
                     }

--- a/src/libse/SubtitleFormats/FinalCutProXCM.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXCM.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -128,11 +129,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 var arr = duration.Value.TrimEnd('s').Split('/');
                 if (arr.Length == 2)
                 {
-                    return TimeCode.FromSeconds(long.Parse(arr[0]) / double.Parse(arr[1]));
+                    return TimeCode.FromSeconds(long.Parse(arr[0]) / double.Parse(arr[1], CultureInfo.InvariantCulture));
                 }
                 else if (arr.Length == 1)
                 {
-                    return TimeCode.FromSeconds(float.Parse(arr[0]));
+                    return TimeCode.FromSeconds(float.Parse(arr[0], CultureInfo.InvariantCulture));
                 }
             }
             return new TimeCode();

--- a/src/libse/SubtitleFormats/FinalCutProXXml.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXXml.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -162,11 +163,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 var arr = duration.Value.TrimEnd('s').Split('/');
                 if (arr.Length == 2)
                 {
-                    return TimeCode.FromSeconds(long.Parse(arr[0]) / double.Parse(arr[1]));
+                    return TimeCode.FromSeconds(long.Parse(arr[0]) / double.Parse(arr[1], CultureInfo.InvariantCulture));
                 }
                 else if (arr.Length == 1)
                 {
-                    return TimeCode.FromSeconds(float.Parse(arr[0]));
+                    return TimeCode.FromSeconds(float.Parse(arr[0], CultureInfo.InvariantCulture));
                 }
             }
             return new TimeCode();

--- a/src/libse/SubtitleFormats/FinalCutProXml.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXml.cs
@@ -474,7 +474,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     try
                     {
-                        frameRate = double.Parse(xml.DocumentElement.SelectSingleNode("sequence/rate/timebase").InnerText);
+                        frameRate = double.Parse(xml.DocumentElement.SelectSingleNode("sequence/rate/timebase").InnerText, CultureInfo.InvariantCulture);
                     }
                     catch
                     {
@@ -494,7 +494,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                                 XmlNode timebase = rate.SelectSingleNode("timebase");
                                 if (timebase != null)
                                 {
-                                    frameRate = double.Parse(timebase.InnerText);
+                                    frameRate = double.Parse(timebase.InnerText, CultureInfo.InvariantCulture);
                                 }
                             }
 
@@ -503,13 +503,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             XmlNode startNode = generatorItemNode.SelectSingleNode("start");
                             if (startNode != null)
                             {
-                                startFrame = double.Parse(startNode.InnerText);
+                                startFrame = double.Parse(startNode.InnerText, CultureInfo.InvariantCulture);
                             }
 
                             XmlNode endNode = generatorItemNode.SelectSingleNode("end");
                             if (endNode != null)
                             {
-                                endFrame = double.Parse(endNode.InnerText);
+                                endFrame = double.Parse(endNode.InnerText, CultureInfo.InvariantCulture);
                             }
 
                             string text = string.Empty;
@@ -635,7 +635,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                                     text = "<i>" + text + "</i>";
                                 }
 
-                                subtitle.Paragraphs.Add(new Paragraph(text, Convert.ToDouble((startFrame / frameRate) * 1000), Convert.ToDouble((endFrame / frameRate) * 1000)));
+                                subtitle.Paragraphs.Add(new Paragraph(text, Convert.ToDouble((startFrame / frameRate) * 1000, CultureInfo.InvariantCulture), Convert.ToDouble((endFrame / frameRate) * 1000, CultureInfo.InvariantCulture)));
                             }
                         }
                     }

--- a/src/libse/SubtitleFormats/FinalCutProXml13.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXml13.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -186,11 +187,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 var arr = duration.Value.TrimEnd('s').Split('/');
                 if (arr.Length == 2)
                 {
-                    return TimeCode.FromSeconds(long.Parse(arr[0]) / double.Parse(arr[1]));
+                    return TimeCode.FromSeconds(long.Parse(arr[0]) / double.Parse(arr[1], CultureInfo.InvariantCulture));
                 }
                 else if (arr.Length == 1)
                 {
-                    return TimeCode.FromSeconds(float.Parse(arr[0]));
+                    return TimeCode.FromSeconds(float.Parse(arr[0], CultureInfo.InvariantCulture));
                 }
             }
             return new TimeCode();

--- a/src/libse/SubtitleFormats/FinalCutProXml14.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXml14.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -174,11 +175,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 var arr = duration.Value.TrimEnd('s').Split('/');
                 if (arr.Length == 2)
                 {
-                    return TimeCode.FromSeconds(long.Parse(arr[0]) / double.Parse(arr[1]));
+                    return TimeCode.FromSeconds(long.Parse(arr[0]) / double.Parse(arr[1], CultureInfo.InvariantCulture));
                 }
                 else if (arr.Length == 1)
                 {
-                    return TimeCode.FromSeconds(float.Parse(arr[0]));
+                    return TimeCode.FromSeconds(float.Parse(arr[0], CultureInfo.InvariantCulture));
                 }
             }
             return new TimeCode();

--- a/src/libse/SubtitleFormats/FinalCutProXml14Text.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXml14Text.cs
@@ -195,11 +195,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 var arr = duration.Value.TrimEnd('s').Split('/');
                 if (arr.Length == 2)
                 {
-                    return TimeCode.FromSeconds(long.Parse(arr[0]) / double.Parse(arr[1]));
+                    return TimeCode.FromSeconds(long.Parse(arr[0]) / double.Parse(arr[1], CultureInfo.InvariantCulture));
                 }
                 if (arr.Length == 1)
                 {
-                    return TimeCode.FromSeconds(float.Parse(arr[0]));
+                    return TimeCode.FromSeconds(float.Parse(arr[0], CultureInfo.InvariantCulture));
                 }
             }
             return new TimeCode();

--- a/src/libse/SubtitleFormats/FinalCutProXml15.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXml15.cs
@@ -558,11 +558,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     var arr = duration.Value.TrimEnd('s').TrimEnd('m').Split('/');
                     if (arr.Length == 2)
                     {
-                        return TimeCode.FromSeconds((long.Parse(arr[0]) * 1000.0) / (double.Parse(arr[1]) * 1000.0));
+                        return TimeCode.FromSeconds((long.Parse(arr[0]) * 1000.0) / (double.Parse(arr[1], CultureInfo.InvariantCulture) * 1000.0));
                     }
                     if (arr.Length == 1)
                     {
-                        return TimeCode.FromSeconds(float.Parse(arr[0]) * 1000.0);
+                        return TimeCode.FromSeconds(float.Parse(arr[0], CultureInfo.InvariantCulture) * 1000.0);
                     }
                 }
                 else
@@ -570,11 +570,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     var arr = duration.Value.TrimEnd('s').Split('/');
                     if (arr.Length == 2)
                     {
-                        return TimeCode.FromSeconds(long.Parse(arr[0]) / double.Parse(arr[1]));
+                        return TimeCode.FromSeconds(long.Parse(arr[0]) / double.Parse(arr[1], CultureInfo.InvariantCulture));
                     }
                     if (arr.Length == 1)
                     {
-                        return TimeCode.FromSeconds(float.Parse(arr[0]));
+                        return TimeCode.FromSeconds(float.Parse(arr[0], CultureInfo.InvariantCulture));
                     }
                 }
             }

--- a/src/libse/SubtitleFormats/FinalCutProXmlGap.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXmlGap.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -134,12 +135,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 var arr = duration.Value.TrimEnd('s').Split('/');
                 if (arr.Length == 2)
                 {
-                    return TimeCode.FromSeconds(long.Parse(arr[0]) / double.Parse(arr[1]));
+                    return TimeCode.FromSeconds(long.Parse(arr[0]) / double.Parse(arr[1], CultureInfo.InvariantCulture));
                 }
 
                 if (arr.Length == 1)
                 {
-                    return TimeCode.FromSeconds(float.Parse(arr[0]));
+                    return TimeCode.FromSeconds(float.Parse(arr[0], CultureInfo.InvariantCulture));
                 }
             }
             return new TimeCode();

--- a/src/libse/SubtitleFormats/FlashXml.cs
+++ b/src/libse/SubtitleFormats/FlashXml.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -166,7 +167,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             if (s.EndsWith('s'))
             {
                 s = s.TrimEnd('s');
-                return TimeCode.FromSeconds(double.Parse(s));
+                return TimeCode.FromSeconds(double.Parse(s, CultureInfo.InvariantCulture));
             }
             var parts = s.Split(new[] { ':', '.', ',' });
             return new TimeCode(int.Parse(parts[0]), int.Parse(parts[1]), int.Parse(parts[2]), int.Parse(parts[3]));

--- a/src/libse/SubtitleFormats/JacoSub.cs
+++ b/src/libse/SubtitleFormats/JacoSub.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -110,7 +111,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             int hours = int.Parse(tokens[0]);
             int minutes = int.Parse(tokens[1]);
             int seconds = int.Parse(tokens[2]);
-            int milliseconds = FramesToMilliseconds(double.Parse(tokens[3]));
+            int milliseconds = FramesToMilliseconds(double.Parse(tokens[3], CultureInfo.InvariantCulture));
 
             return new TimeCode(hours, minutes, seconds, milliseconds);
         }

--- a/src/libse/SubtitleFormats/Lrc.cs
+++ b/src/libse/SubtitleFormats/Lrc.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -217,7 +218,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 else if (line.StartsWith("[offset:", StringComparison.Ordinal)) // [length:How long the song is]
                 {
                     var temp = line.Replace("[offset:", string.Empty).Replace("]", string.Empty).Replace("'", string.Empty).RemoveChar(' ').TrimEnd();
-                    if (double.TryParse(temp, out var d))
+                    if (double.TryParse(temp, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var d))
                     {
                         offsetInMilliseconds = d;
                     }

--- a/src/libse/SubtitleFormats/Lrc3DigitsMs.cs
+++ b/src/libse/SubtitleFormats/Lrc3DigitsMs.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -209,7 +210,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 else if (line.StartsWith("[offset:", StringComparison.Ordinal)) // [length:How long the song is]
                 {
                     var temp = line.Replace("[offset:", string.Empty).Replace("]", string.Empty).Replace("'", string.Empty).RemoveChar(' ').TrimEnd();
-                    if (double.TryParse(temp, out var d))
+                    if (double.TryParse(temp, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var d))
                     {
                         offsetInMilliseconds = d;
                     }

--- a/src/libse/SubtitleFormats/LrcNoEndTime.cs
+++ b/src/libse/SubtitleFormats/LrcNoEndTime.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -194,7 +195,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 else if (line.StartsWith("[offset:", StringComparison.Ordinal)) // [length:How long the song is]
                 {
                     var temp = line.Replace("[offset:", string.Empty).Replace("]", string.Empty).Replace("'", string.Empty).RemoveChar(' ').TrimEnd();
-                    if (double.TryParse(temp, out var d))
+                    if (double.TryParse(temp, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var d))
                     {
                         offsetInMilliseconds = d;
                     }

--- a/src/libse/SubtitleFormats/MPlayer2.cs
+++ b/src/libse/SubtitleFormats/MPlayer2.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -141,8 +142,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             string temp = s.Substring(0, textIndex - 1);
                             string[] frames = temp.Replace("][", ":").Replace("[", string.Empty).Replace("]", string.Empty).Split(':');
 
-                            double startSeconds = double.Parse(frames[0]) / 10;
-                            double endSeconds = double.Parse(frames[1]) / 10;
+                            double startSeconds = double.Parse(frames[0], CultureInfo.InvariantCulture) / 10;
+                            double endSeconds = double.Parse(frames[1], CultureInfo.InvariantCulture) / 10;
 
                             if (Math.Abs(startSeconds) < 0.01 && subtitle.Paragraphs.Count > 0)
                             {

--- a/src/libse/SubtitleFormats/NetflixImsc11Japanese.cs
+++ b/src/libse/SubtitleFormats/NetflixImsc11Japanese.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -242,7 +243,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var frameRateAttr = xml.DocumentElement.Attributes["ttp:frameRate"];
             if (frameRateAttr != null)
             {
-                if (double.TryParse(frameRateAttr.Value, out var fr))
+                if (double.TryParse(frameRateAttr.Value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var fr))
                 {
                     if (fr > 20 && fr < 100)
                     {
@@ -265,7 +266,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             var arr = frameRateMultiplier.InnerText.Split();
                             if (arr.Length == 2 && Utilities.IsInteger(arr[0]) && Utilities.IsInteger(arr[1]) && int.Parse(arr[1]) > 0)
                             {
-                                fr = double.Parse(arr[0]) / double.Parse(arr[1]);
+                                fr = double.Parse(arr[0], CultureInfo.InvariantCulture) / double.Parse(arr[1], CultureInfo.InvariantCulture);
                                 if (fr > 20 && fr < 100)
                                 {
                                     Configuration.Settings.General.CurrentFrameRate = fr;

--- a/src/libse/SubtitleFormats/PListCaption.cs
+++ b/src/libse/SubtitleFormats/PListCaption.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -134,11 +135,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         {
                             if (lastKey == "in")
                             {
-                                p.StartTime.TotalSeconds = double.Parse(innerNode.InnerText);
+                                p.StartTime.TotalSeconds = double.Parse(innerNode.InnerText, CultureInfo.InvariantCulture);
                             }
                             else if (lastKey == "out")
                             {
-                                p.EndTime.TotalSeconds = double.Parse(innerNode.InnerText);
+                                p.EndTime.TotalSeconds = double.Parse(innerNode.InnerText, CultureInfo.InvariantCulture);
                             }
                             else if (lastKey.StartsWith("text"))
                             {

--- a/src/libse/SubtitleFormats/Rdf1.cs
+++ b/src/libse/SubtitleFormats/Rdf1.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -53,8 +54,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             continue;
                         }
 
-                        var timeCodeIn = new TimeCode(Convert.ToDouble(timeStartAttribute.InnerText));
-                        var timeCodeOut = new TimeCode(timeCodeIn.TotalMilliseconds + Convert.ToDouble(timeDurationAttribute.InnerText));
+                        var timeCodeIn = new TimeCode(Convert.ToDouble(timeStartAttribute.InnerText, CultureInfo.InvariantCulture));
+                        var timeCodeOut = new TimeCode(timeCodeIn.TotalMilliseconds + Convert.ToDouble(timeDurationAttribute.InnerText, CultureInfo.InvariantCulture));
                         var text = textNode.InnerText.Trim();
                         if (text.StartsWith("{\\rtf1 "))
                         {

--- a/src/libse/SubtitleFormats/TimedText.cs
+++ b/src/libse/SubtitleFormats/TimedText.cs
@@ -318,7 +318,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             }
                             else if (start != null && start.EndsWith("t", StringComparison.Ordinal) &&
                                      end != null && end.EndsWith("t", StringComparison.Ordinal) &&
-                                     double.TryParse(start.TrimEnd('t'), out dBegin) && double.TryParse(end.TrimEnd('t'), out dEnd))
+                                     double.TryParse(start.TrimEnd('t'), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out dBegin) && double.TryParse(end.TrimEnd('t'), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out dEnd))
                             {
                                 var p = new Paragraph(text, TimeSpan.FromTicks((long)dBegin).TotalMilliseconds, TimeSpan.FromTicks((long)dEnd).TotalMilliseconds);
                                 if (!string.IsNullOrEmpty(styleName))

--- a/src/libse/SubtitleFormats/TimedText10.cs
+++ b/src/libse/SubtitleFormats/TimedText10.cs
@@ -788,7 +788,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var frameRateAttr = xml.DocumentElement.Attributes["ttp:frameRate"];
             if (frameRateAttr != null)
             {
-                if (double.TryParse(frameRateAttr.Value, out var fr))
+                if (double.TryParse(frameRateAttr.Value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var fr))
                 {
                     if (fr > 20 && fr < 100)
                     {
@@ -811,7 +811,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             var arr = frameRateMultiplier.InnerText.Split();
                             if (arr.Length == 2 && Utilities.IsInteger(arr[0]) && Utilities.IsInteger(arr[1]) && int.Parse(arr[1]) > 0)
                             {
-                                fr = double.Parse(arr[0]) / double.Parse(arr[1]);
+                                fr = double.Parse(arr[0], CultureInfo.InvariantCulture) / double.Parse(arr[1], CultureInfo.InvariantCulture);
                                 if (fr > 20 && fr < 100)
                                 {
                                     Configuration.Settings.General.CurrentFrameRate = fr;

--- a/src/libse/SubtitleFormats/TimedTextImsc11.cs
+++ b/src/libse/SubtitleFormats/TimedTextImsc11.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -549,7 +550,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var frameRateAttr = xml.DocumentElement.Attributes["ttp:frameRate"];
             if (frameRateAttr != null)
             {
-                if (double.TryParse(frameRateAttr.Value, out var fr))
+                if (double.TryParse(frameRateAttr.Value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var fr))
                 {
                     if (fr > 20 && fr < 100)
                     {
@@ -574,7 +575,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             var arr = frameRateMultiplier.InnerText.Split();
                             if (arr.Length == 2 && Utilities.IsInteger(arr[0]) && Utilities.IsInteger(arr[1]) && int.Parse(arr[1]) > 0)
                             {
-                                fr = double.Parse(arr[0]) / double.Parse(arr[1]);
+                                fr = double.Parse(arr[0], CultureInfo.InvariantCulture) / double.Parse(arr[1], CultureInfo.InvariantCulture);
                                 if (fr > 20 && fr < 100)
                                 {
                                     Configuration.Settings.General.CurrentFrameRate = fr;

--- a/src/libse/SubtitleFormats/TimedTextImscRosetta.cs
+++ b/src/libse/SubtitleFormats/TimedTextImscRosetta.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -340,7 +341,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var frameRateAttr = xml.DocumentElement.Attributes["ttp:frameRate"];
             if (frameRateAttr != null)
             {
-                if (double.TryParse(frameRateAttr.Value, out var fr))
+                if (double.TryParse(frameRateAttr.Value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var fr))
                 {
                     if (fr > 20 && fr < 100)
                     {
@@ -365,7 +366,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             var arr = frameRateMultiplier.InnerText.Split();
                             if (arr.Length == 2 && Utilities.IsInteger(arr[0]) && Utilities.IsInteger(arr[1]) && int.Parse(arr[1]) > 0)
                             {
-                                fr = double.Parse(arr[0]) / double.Parse(arr[1]);
+                                fr = double.Parse(arr[0], CultureInfo.InvariantCulture) / double.Parse(arr[1], CultureInfo.InvariantCulture);
                                 if (fr > 20 && fr < 100)
                                 {
                                     Configuration.Settings.General.CurrentFrameRate = fr;

--- a/src/libse/SubtitleFormats/TmpegEncXml.cs
+++ b/src/libse/SubtitleFormats/TmpegEncXml.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -589,7 +590,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             if (s.EndsWith('s'))
             {
                 s = s.TrimEnd('s');
-                return TimeCode.FromSeconds(double.Parse(s));
+                return TimeCode.FromSeconds(double.Parse(s, CultureInfo.InvariantCulture));
             }
             string[] parts = s.Split(':', '.', ',');
             return new TimeCode(int.Parse(parts[0]), int.Parse(parts[1]), int.Parse(parts[2]), int.Parse(parts[3]));

--- a/src/libse/SubtitleFormats/UnknownSubtitle12.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle12.cs
@@ -40,7 +40,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         private static TimeCode DecodeTimeCode(string timeCode)
         {
-            return TimeCode.FromSeconds(double.Parse(timeCode.Trim()));
+            return TimeCode.FromSeconds(double.Parse(timeCode.Trim(), CultureInfo.InvariantCulture));
         }
 
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)

--- a/src/libse/SubtitleFormats/UnknownSubtitle19.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle19.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -19,7 +20,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         private static TimeCode DecodeTimeCode(string s)
         {
-            return TimeCode.FromSeconds(double.Parse(s));
+            return TimeCode.FromSeconds(double.Parse(s, CultureInfo.InvariantCulture));
         }
 
         public override string ToText(Subtitle subtitle, string title)

--- a/src/libse/SubtitleFormats/UnknownSubtitle25.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle25.cs
@@ -75,8 +75,8 @@ NOTE=
                         string[] arr = s.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
                         if (arr.Length == 2)
                         {
-                            double secondsSinceLast = double.Parse(arr[0]);
-                            double secondsDuration = double.Parse(arr[1]);
+                            double secondsSinceLast = double.Parse(arr[0], CultureInfo.InvariantCulture);
+                            double secondsDuration = double.Parse(arr[1], CultureInfo.InvariantCulture);
                             if (subtitle.Paragraphs.Count > 0)
                             {
                                 secondsSinceLast += subtitle.Paragraphs[subtitle.Paragraphs.Count - 1].EndTime.TotalSeconds;

--- a/src/libse/SubtitleFormats/UnknownSubtitle76.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle76.cs
@@ -97,7 +97,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public static TimeCode GetTimeCode(string s)
         {
-            return new TimeCode(Convert.ToDouble(s)); // ms
+            return new TimeCode(Convert.ToDouble(s, CultureInfo.InvariantCulture)); // ms
         }
 
     }

--- a/src/libse/SubtitleFormats/UnknownSubtitle82.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle82.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -59,8 +60,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     try
                     {
-                        var timeCodeIn = new TimeCode(Convert.ToDouble(node.Attributes["t"].InnerText));
-                        var timeCodeOut = new TimeCode(timeCodeIn.TotalMilliseconds + Convert.ToDouble(node.Attributes["d"].InnerText));
+                        var timeCodeIn = new TimeCode(Convert.ToDouble(node.Attributes["t"].InnerText, CultureInfo.InvariantCulture));
+                        var timeCodeOut = new TimeCode(timeCodeIn.TotalMilliseconds + Convert.ToDouble(node.Attributes["d"].InnerText, CultureInfo.InvariantCulture));
                         var p = new Paragraph(timeCodeIn, timeCodeOut, node.InnerText);
                         subtitle.Paragraphs.Add(p);
                     }

--- a/src/libse/SubtitleFormats/VocapiaSplit.cs
+++ b/src/libse/SubtitleFormats/VocapiaSplit.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -133,7 +134,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         private static double ParseTimeCode(string s)
         {
-            return Convert.ToDouble(s) * TimeCode.BaseUnit;
+            return Convert.ToDouble(s, CultureInfo.InvariantCulture) * TimeCode.BaseUnit;
         }
 
         public override bool HasStyleSupport => true;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -20273,7 +20273,9 @@ public partial class MainViewModel :
             // F10 toggles main-menu activation (Windows standard): the first press moves keyboard focus
             // into the menu bar, a second press deactivates it and restores the previous focus. This
             // also lets the menu be reached and read with a screen reader without a mouse (#11745).
-            if (k == Key.F10 && keyEventArgs.KeyModifiers == KeyModifiers.None)
+            // A user-assigned F10 shortcut wins over the menu toggle (#12504) - the menu stays
+            // reachable via Alt.
+            if (k == Key.F10 && keyEventArgs.KeyModifiers == KeyModifiers.None && !_shortcutManager.HasSingleKeyShortcut("F10"))
             {
                 if (IsMainMenuFocused())
                 {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -2359,8 +2359,9 @@ public partial class BinaryEditViewModel : ObservableObject
     {
         // F10 toggles menu-bar activation (Windows standard): the first press moves keyboard focus
         // into the menu bar, a second press deactivates it and restores the previous focus, so it can
-        // be reached and read without a mouse (#11745).
-        if (e.Key == Key.F10 && e.KeyModifiers == KeyModifiers.None)
+        // be reached and read without a mouse (#11745). A user-assigned F10 shortcut wins over the
+        // menu toggle (#12504) - the menu stays reachable via Alt.
+        if (e.Key == Key.F10 && e.KeyModifiers == KeyModifiers.None && !_shortcutManager.HasSingleKeyShortcut("F10"))
         {
             if (IsMenuFocused())
             {

--- a/src/ui/Logic/IShortcutManager.cs
+++ b/src/ui/Logic/IShortcutManager.cs
@@ -10,6 +10,7 @@ public interface IShortcutManager
     void OnKeyReleased(object? sender, KeyEventArgs e);
     void ClearKeys();
     void RegisterShortcut(ShortCut shortcut);
+    bool HasSingleKeyShortcut(string keyName);
     IRelayCommand? CheckShortcuts(KeyEventArgs keyEventArgs, string activeControl);
     void ClearShortcuts();
     HashSet<Key> GetActiveKeys();

--- a/src/ui/Logic/ShortcutManager.cs
+++ b/src/ui/Logic/ShortcutManager.cs
@@ -285,6 +285,24 @@ public class ShortcutManager : IShortcutManager
         _isDirty = true;
     }
 
+    /// <summary>
+    /// True when the user has assigned <paramref name="keyName"/> (alone, no modifiers) to any
+    /// action. Built-in key handling (e.g. F10 activating the menu bar) checks this so a
+    /// user-configured shortcut wins over the default behavior (#12504).
+    /// </summary>
+    public bool HasSingleKeyShortcut(string keyName)
+    {
+        foreach (var shortcut in _shortcuts)
+        {
+            if (shortcut.Keys.Count == 1 && shortcut.Keys[0].Equals(keyName, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public void ClearShortcuts()
     {
         _shortcuts.Clear();

--- a/tests/libse/Common/TimeCodeParseTest.cs
+++ b/tests/libse/Common/TimeCodeParseTest.cs
@@ -1,0 +1,34 @@
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace LibSETests.Common;
+
+public class TimeCodeParseTest
+{
+    [Theory]
+    [InlineData("0:0:1:5", 1500)]     // 4-part h:m:s:ms, "5" pads to "500"
+    [InlineData("00:00:01,000", 1000)]
+    [InlineData("00:00:01,5", 1500)]  // "5" -> "500"
+    [InlineData("00:00:01,50", 1500)] // "50" -> "500"
+    [InlineData("00:00:01,123", 1123)]
+    public void ParseToMillisecondsPadsFraction(string input, double expected)
+    {
+        Assert.Equal(expected, TimeCode.ParseToMilliseconds(input));
+    }
+
+    [Fact]
+    public void WhitespaceOnlyFractionMatchesLegacyPadRight()
+    {
+        // Regression: the legacy PadRight(3,'0') + int.Parse turned a whitespace-only fraction
+        // " " into " 00", which int.Parse reads as 0, so the seconds still count. A hand-rolled
+        // "trailing whitespace fails" shortcut got this wrong and returned 0 for the whole code.
+        Assert.Equal(1000, TimeCode.ParseToMilliseconds("0:0:1: "));
+    }
+
+    [Fact]
+    public void DigitThenSpaceFractionFails()
+    {
+        // "5 " pads to "5 0" (embedded whitespace) which int.Parse rejects, so the whole parse
+        // fails and returns 0 - unchanged from the legacy behavior.
+        Assert.Equal(0, TimeCode.ParseToMilliseconds("0:0:1:5 "));
+    }
+}


### PR DESCRIPTION
Three verified bugs found by an adversarial hunt (each reproduced before/after).

## 1. `TimeCode.ParseToMilliseconds` — whitespace-only fraction regression

Introduced by this morning's round-2 span rewrite. A whitespace-only sub-second field returned 0 instead of the legacy value:

```
ParseToMilliseconds("0:0:1: ")  // before fix: 0    after fix: 1000
```

The old `parts[3].PadRight(3,'0')` turned `" "` into `" 00"`, which `int.Parse` reads as 0 (leading whitespace tolerated), so the seconds still counted. The rewrite's hand-rolled "trailing whitespace fails" shortcut rejected it outright. Fixed by padding into a stack buffer — exact `PadRight` semantics, so `" "` → 0 but `"5 "` still fails (embedded whitespace). Reachable from malformed time codes in niche importers; low severity but a real behavior change vs. the "byte-identical" commit claim.

## 2. Culture-unsafe numeric parsing in 38 format files

`double.Parse` / `float.Parse` / `Convert.ToDouble` without `InvariantCulture`. On a comma-decimal locale (German, French, …) a decimal value like a `"1.5"` Final Cut Pro duration parses as **15** — corrupting imported timings. Swept `CultureInfo.InvariantCulture` into every single-argument numeric parse across `SubtitleFormats/`. Integer-valued fields (most FCP timebase/rational tokens, MPlayer2 deciseconds) are unchanged; the genuinely decimal ones are fixed. Verified a `de-DE` JacoSub load parses correctly.

The top-tier formats (SubRip, ASSA, WebVTT, TimedText10, EBU STL, PAC, MicroDVD, SAMI) were already invariant — this hardens the long tail.

## 3. F10 menu-focus shortcut can't be overridden — [#12504](https://github.com/SubtitleEdit/subtitleedit/issues/12504)

F10 (added in #11745 to activate the menu bar for keyboard/screen-reader access) unconditionally swallowed the key, so a user-assigned F10 action never fired. Added `IShortcutManager.HasSingleKeyShortcut(keyName)`; the built-in menu toggle now yields when the user has bound F10 to something. The menu bar stays reachable via Alt. Same guard in the main window and the binary-edit (image-sub) window.

## Verified

- Before/after repro for each.
- New `TimeCodeParseTest` (7 cases incl. the whitespace-fraction regression and the digit+space fail case).
- All 492 libse + 233 seconv tests pass; full solution builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)