### PR TITLE
Add IMSC 1.1 image profile image-based export

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -18,6 +18,7 @@ v5.1.0-rc5 (TBD)
 * Update CrispASR to v0.8.12
 * Export PGS/VobSub: list every installed font face like SE4 ("Segoe UI Semibold", "Arial Black", ...) - the list only had font family names, hiding named faces, and a picked face now also renders with its own weight - thx robertmajsky
 * Add EBU-TT-D subtitle format (read + write) - the TTML distribution profile used by European broadcasters (BBC iPlayer, ARD/ZDF, NPO) and HbbTV
+* Export image-based: add IMSC 1.1 image profile - a single self-contained TTML file with base64 PNG subtitles (smpte:image), for streaming/broadcast image-subtitle delivery
 * Command line (seconv): --multiple-replace now also accepts the multiple-replace rules exported from the GUI (.template JSON or .csv), not only the legacy XML - thx BagronkeN
 * Shortcuts: a user-assigned F10 shortcut is no longer overridden by the menu-bar focus toggle (the menu stays reachable via Alt) - thx Khaztaroth
 * Fix reading decimal values in some XML-based formats (e.g. Final Cut Pro, JacoSub) on locales with a comma decimal separator

--- a/docs/features/file.md
+++ b/docs/features/file.md
@@ -105,7 +105,9 @@ Export subtitles in Cavena 890 format.
 
 ### Export image-based
 
-Export subtitles as images (BDN XML, VobSub, Blu-ray SUP, Final Cut Pro + image, etc.).
+Export subtitles as images (BDN XML, VobSub, Blu-ray SUP, Final Cut Pro + image, IMSC 1.1 image profile, etc.).
+
+The **IMSC 1.1 image profile** export writes a single self-contained TTML file with each subtitle embedded as a base64 PNG (`smpte:image` / `smpte:backgroundImage`), media timebase, and percentage-positioned regions — the standardized image-subtitle carriage for streaming and broadcast delivery.
 
 <!-- Screenshot: Export image-based window -->
 ![Export Image Based](../screenshots/export-image-based.png)

--- a/src/libuilogic/Export/ExportHandlerImscImage.cs
+++ b/src/libuilogic/Export/ExportHandlerImscImage.cs
@@ -1,0 +1,163 @@
+using Nikse.SubtitleEdit.Core.Common;
+using System.Globalization;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.UiLogic.Export;
+
+/// <summary>
+/// IMSC 1.1 image profile (TTML Profiles for Internet Media Subtitles and Captions 1.1, image
+/// profile). Emits a single self-contained TTML file: each cue is a cropped PNG embedded as a
+/// base64 &lt;smpte:image&gt; in the head, referenced from a &lt;div smpte:backgroundImage&gt; in
+/// the body, positioned by a per-cue region with percentage origin/extent. Media timebase.
+/// This is the standardized image-subtitle carriage used for streaming/broadcast delivery, and
+/// round-trips through SE's Timed Text Base64 Image reader.
+/// Spec: https://www.w3.org/TR/ttml-imsc1.1/
+/// </summary>
+public class ExportHandlerImscImage : IExportHandler
+{
+    public ExportImageType ExportImageType => ExportImageType.ImscImage;
+    public string Extension => ".ttml";
+    public bool UseFileName => true;
+    public string Title => string.Format("Export to {0}", "IMSC 1.1 image profile");
+
+    private string _fileName = string.Empty;
+    private int _width = 1920;
+    private int _height = 1080;
+    private int _count;
+    private readonly StringBuilder _images = new();
+    private readonly StringBuilder _regions = new();
+    private readonly StringBuilder _divs = new();
+
+    public void WriteHeader(string fileOrFolderName, ImageParameter imageParameter)
+    {
+        _fileName = fileOrFolderName;
+        _width = imageParameter.ScreenWidth > 0 ? imageParameter.ScreenWidth : 1920;
+        _height = imageParameter.ScreenHeight > 0 ? imageParameter.ScreenHeight : 1080;
+        _count = 0;
+        _images.Clear();
+        _regions.Clear();
+        _divs.Clear();
+    }
+
+    public void CreateParagraph(ImageParameter param)
+    {
+    }
+
+    public void WriteParagraph(ImageParameter param)
+    {
+        var id = _count;
+        _count++;
+
+        var base64 = Convert.ToBase64String(param.Bitmap.ToPngArray());
+        _images.Append("      <smpte:image xml:id=\"img").Append(id).Append("\" imagetype=\"PNG\" encoding=\"Base64\">")
+            .Append(base64).Append("</smpte:image>").Append('\n');
+
+        GetPlacement(param, out var x, out var y);
+        var originX = Pct(x, _width);
+        var originY = Pct(y, _height);
+        var extentX = Pct(param.Bitmap.Width, _width);
+        var extentY = Pct(param.Bitmap.Height, _height);
+
+        _regions.Append("      <region xml:id=\"region").Append(id).Append("\" tts:origin=\"")
+            .Append(originX).Append(' ').Append(originY).Append("\" tts:extent=\"")
+            .Append(extentX).Append(' ').Append(extentY).Append("\"/>").Append('\n');
+
+        _divs.Append("      <div smpte:backgroundImage=\"#img").Append(id).Append("\" region=\"region").Append(id)
+            .Append("\" begin=\"").Append(ToTimeCode(param.StartTime)).Append("\" end=\"").Append(ToTimeCode(param.EndTime))
+            .Append("\" ttm:role=\"caption\"/>").Append('\n');
+    }
+
+    public void WriteFooter()
+    {
+        var sb = new StringBuilder();
+        sb.Append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        sb.Append("<tt xmlns=\"http://www.w3.org/ns/ttml\" xmlns:tts=\"http://www.w3.org/ns/ttml#styling\" ")
+            .Append("xmlns:ttp=\"http://www.w3.org/ns/ttml#parameter\" xmlns:ttm=\"http://www.w3.org/ns/ttml#metadata\" ")
+            .Append("xmlns:smpte=\"http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt\" ")
+            .Append("ttp:profile=\"http://www.w3.org/ns/ttml/profile/imsc1/image\" ttp:timeBase=\"media\" ")
+            .Append("tts:extent=\"").Append(_width.ToString(CultureInfo.InvariantCulture)).Append("px ")
+            .Append(_height.ToString(CultureInfo.InvariantCulture)).Append("px\" xml:lang=\"en\">\n");
+        sb.Append("  <head>\n");
+        sb.Append("    <metadata>\n");
+        sb.Append(_images);
+        sb.Append("    </metadata>\n");
+        sb.Append("    <layout>\n");
+        sb.Append(_regions);
+        sb.Append("    </layout>\n");
+        sb.Append("  </head>\n");
+        sb.Append("  <body>\n");
+        sb.Append(_divs);
+        sb.Append("  </body>\n");
+        sb.Append("</tt>\n");
+
+        File.WriteAllText(_fileName, sb.ToString(), new UTF8Encoding(false));
+    }
+
+    // Top-left placement of the cue bitmap on the screen, mirroring the BDN XML handler's
+    // alignment/override logic so all image exporters position cues the same way.
+    private void GetPlacement(ImageParameter param, out int x, out int y)
+    {
+        x = (_width - param.Bitmap.Width) / 2;
+        y = _height - (param.Bitmap.Height + param.BottomTopMargin);
+        switch (param.Alignment)
+        {
+            case ExportAlignment.BottomLeft:
+                x = 0;
+                break;
+            case ExportAlignment.BottomRight:
+                x = _width - param.Bitmap.Width;
+                break;
+            case ExportAlignment.MiddleCenter:
+                y = (_height - param.Bitmap.Height) / 2;
+                break;
+            case ExportAlignment.MiddleLeft:
+                x = 0;
+                y = (_height - param.Bitmap.Height) / 2;
+                break;
+            case ExportAlignment.MiddleRight:
+                x = _width - param.Bitmap.Width;
+                y = (_height - param.Bitmap.Height) / 2;
+                break;
+            case ExportAlignment.TopCenter:
+                y = 0;
+                break;
+            case ExportAlignment.TopLeft:
+                x = 0;
+                y = 0;
+                break;
+            case ExportAlignment.TopRight:
+                x = _width - param.Bitmap.Width;
+                y = 0;
+                break;
+        }
+
+        if (param.OverridePosition.HasValue &&
+            param.OverridePosition.Value.X >= 0 && param.OverridePosition.Value.X < _width &&
+            param.OverridePosition.Value.Y >= 0 && param.OverridePosition.Value.Y < _height)
+        {
+            x = param.OverridePosition.Value.X;
+            y = param.OverridePosition.Value.Y;
+        }
+
+        if (x < 0)
+        {
+            x = 0;
+        }
+
+        if (y < 0)
+        {
+            y = 0;
+        }
+    }
+
+    private static string Pct(int value, int total)
+    {
+        var pct = total > 0 ? value * 100.0 / total : 0.0;
+        return pct.ToString("0.##", CultureInfo.InvariantCulture) + "%";
+    }
+
+    private static string ToTimeCode(TimeSpan time)
+    {
+        return $"{(int)time.TotalHours:00}:{time.Minutes:00}:{time.Seconds:00}.{time.Milliseconds:000}";
+    }
+}

--- a/src/libuilogic/Export/ExportImageType.cs
+++ b/src/libuilogic/Export/ExportImageType.cs
@@ -10,6 +10,7 @@ public enum ExportImageType
     Fcp,
     HtmlIndex,
     ImagesWithTimeCode,
+    ImscImage,
     VobSub,
     WebVttThumbnail
 }

--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -211,6 +211,11 @@ public static class InitMenu
                         },
                         new MenuItem
                         {
+                            Header = "IMSC 1.1 image profile",
+                            Command = vm.ExportImscImageCommand,
+                        },
+                        new MenuItem
+                        {
                             Header = new CapMakerPlus().Name,
                             Command = vm.ExportCapMakerPlusCommand,
                         },

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -2514,6 +2514,32 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private async Task ExportImscImage()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        if (IsEmpty)
+        {
+            ShowSubtitleNotLoadedMessage();
+            return;
+        }
+
+        IExportHandler exportHandler = new ExportHandlerImscImage();
+        var result = await ShowDialogAsync<ExportImageBasedWindow, ExportImageBasedViewModel>(vm =>
+        {
+            vm.Initialize(exportHandler, Subtitles, _subtitleFileName, _videoFileName);
+        });
+
+        if (!result.OkPressed)
+        {
+            return;
+        }
+    }
+
+    [RelayCommand]
     private async Task ExportWebVttThumbnails()
     {
         if (Window == null)

--- a/tests/libuilogic/Export/ExportHandlerImscImageTests.cs
+++ b/tests/libuilogic/Export/ExportHandlerImscImageTests.cs
@@ -1,0 +1,117 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.UiLogic.Export;
+using SkiaSharp;
+
+namespace LibUiLogicTests.Export;
+
+public class ExportHandlerImscImageTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "imsc_img_" + Guid.NewGuid().ToString("N"));
+
+    public ExportHandlerImscImageTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, true); } catch { /* best effort */ }
+    }
+
+    private static ImageParameter Cue(int index, string text, int startMs, int endMs, int w = 300, int h = 80)
+    {
+        var bitmap = new SKBitmap(w, h);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            using var paint = new SKPaint { Color = SKColors.White, IsAntialias = true };
+            using var font = new SKFont(SKTypeface.Default, 24);
+            canvas.DrawText(text, 4, 40, font, paint);
+        }
+
+        return new ImageParameter
+        {
+            Text = text,
+            Bitmap = bitmap,
+            StartTime = TimeSpan.FromMilliseconds(startMs),
+            EndTime = TimeSpan.FromMilliseconds(endMs),
+            Index = index,
+            ScreenWidth = 1920,
+            ScreenHeight = 1080,
+            Alignment = ExportAlignment.BottomCenter,
+            BottomTopMargin = 50,
+        };
+    }
+
+    private string Export(params ImageParameter[] cues)
+    {
+        var handler = new ExportHandlerImscImage();
+        var file = Path.Combine(_dir, "out.ttml");
+        handler.WriteHeader(file, cues[0]);
+        foreach (var c in cues)
+        {
+            handler.WriteParagraph(c);
+        }
+
+        handler.WriteFooter();
+        return File.ReadAllText(file);
+    }
+
+    [Fact]
+    public void ProducesConformantImscImageProfileShape()
+    {
+        var xml = Export(
+            Cue(0, "First line", 1240, 3120),
+            Cue(1, "Second line", 4000, 6500));
+
+        Assert.Contains("ttp:profile=\"http://www.w3.org/ns/ttml/profile/imsc1/image\"", xml);
+        Assert.Contains("ttp:timeBase=\"media\"", xml);
+        Assert.Contains("<smpte:image xml:id=\"img0\" imagetype=\"PNG\" encoding=\"Base64\">", xml);
+        Assert.Contains("<smpte:image xml:id=\"img1\" imagetype=\"PNG\" encoding=\"Base64\">", xml);
+        Assert.Contains("smpte:backgroundImage=\"#img0\"", xml);
+        Assert.Contains("region=\"region0\"", xml);
+        Assert.Contains("begin=\"00:00:01.240\"", xml);
+        Assert.Contains("end=\"00:00:06.500\"", xml);
+        // Base64 PNG payload present (PNG magic "iVBOR..." is the base64 of \x89PNG)
+        Assert.Contains("iVBOR", xml);
+        // valid XML
+        var doc = new System.Xml.XmlDocument();
+        doc.LoadXml(xml);
+        Assert.NotNull(doc.DocumentElement);
+    }
+
+    [Fact]
+    public void RoundTripsThroughBase64ImageReader()
+    {
+        var xml = Export(
+            Cue(0, "First line", 1240, 3120),
+            Cue(1, "Second line", 4000, 6500));
+
+        // SE's Timed Text Base64 Image reader must accept our output and recover the cue timings.
+        var format = new TimedTextBase64Image();
+        Assert.True(format.IsMine(xml.SplitToLines(), "out.ttml"));
+
+        var sub = new Subtitle();
+        format.LoadSubtitle(sub, xml.SplitToLines(), "out.ttml");
+
+        Assert.Equal(2, sub.Paragraphs.Count);
+        Assert.Equal(1240, sub.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(3120, sub.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal(4000, sub.Paragraphs[1].StartTime.TotalMilliseconds);
+        Assert.Equal(6500, sub.Paragraphs[1].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void EmbeddedImagesAreDecodablePng()
+    {
+        var xml = Export(Cue(0, "Decode me", 0, 2000, 200, 60));
+
+        var start = xml.IndexOf("Base64\">", StringComparison.Ordinal) + "Base64\">".Length;
+        var end = xml.IndexOf("</smpte:image>", start, StringComparison.Ordinal);
+        var base64 = xml.Substring(start, end - start);
+
+        var bytes = Convert.FromBase64String(base64);
+        using var decoded = SKBitmap.Decode(bytes);
+        Assert.NotNull(decoded);
+        Assert.Equal(200, decoded.Width);
+        Assert.Equal(60, decoded.Height);
+    }
+}


### PR DESCRIPTION
Adds the **IMSC 1.1 image profile** ([W3C/ISO TTML image profile](https://www.w3.org/TR/ttml-imsc1.1/)) as an image-based export — the standardized image-subtitle carriage used for streaming and broadcast delivery, and the one widely-used image-based format SE didn't have (the gap identified in the EBU-TT-D discussion).

## What it produces

`ExportHandlerImscImage` writes a **single self-contained TTML file**:
- each cue is a cropped PNG embedded as a base64 `<smpte:image imagetype="PNG" encoding="Base64">` in `<head>`,
- referenced from a `<div smpte:backgroundImage="#imgN">` in `<body>` with `begin`/`end`,
- positioned by a per-cue `<region>` with percentage `tts:origin`/`tts:extent` computed from the cue's on-screen placement (same alignment + `OverridePosition` logic as the BDN XML handler),
- `ttp:profile=".../imsc1/image"`, `ttp:timeBase="media"`, `HH:MM:SS.mmm` times.

It reuses the shared `ImageRenderer`, so it inherits the export dialog's font / outline / shadow / box / position settings automatically.

## Wiring

- **File → Export** menu entry, and the image-based export dialog (new `ExportImageType.ImscImage`).
- Output **round-trips through SE's own Timed Text Base64 Image reader** — export then re-open recovers the cues.

## Verified

- 3 libuilogic tests: conformant profile/timebase/`smpte:image` shape, round-trip through the base64-image reader recovering **exact timings**, and embedded PNGs decoding to the right dimensions.
- Rendered a real sample and extracted the first embedded PNG — shows the correct subtitle; region math checks out (a 400×90 cue centered near the bottom → `origin 39.58% 87.04%`, `extent 20.83% 8.33%`).
- Full solution builds; all libuilogic tests pass.
- Docs (File features page) and change-log updated.

Pairs naturally with the EBU-TT-D text format added earlier — together they cover both the text and image TTML profiles European/streaming delivery asks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)