### PR TITLE
Binary edit: add IMSC 1.1 image profile to the Export menu

### DIFF
--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1062,6 +1062,14 @@ public partial class BinaryEditViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private async Task ExportImscImage()
+    {
+        // Single self-contained TTML file; the binary sub's own bitmaps and X/Y placement carry
+        // straight through (DoExport sets OverridePosition), so no re-rendering is needed.
+        await DoExport(new ExportHandlerImscImage(), ".ttml");
+    }
+
+    [RelayCommand]
     private async Task ExportHtmlIndex()
     {
         await DoExport(new ExportHandlerHtmlIndex(), string.Empty, false);

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -201,6 +201,11 @@ public class BinaryEditWindow : Window
                         },
                         new MenuItem
                         {
+                            Header = "IMSC 1.1 image profile",
+                            Command = vm.ExportImscImageCommand,
+                        },
+                        new MenuItem
+                        {
                             Header = "DOST/png",
                             Command = vm.ExportDostPngCommand,
                         },

--- a/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
+++ b/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
@@ -18,6 +18,7 @@ public static class InitNativeMacMenuBinaryEdit
         var exportMenu = new NativeMenu();
         Add(exportMenu, Se.Language.General.BluRaySup, vm.ExportBluRaySupCommand);
         Add(exportMenu, Se.Language.General.BdnXml, vm.ExportBdnXmlCommand);
+        Add(exportMenu, "IMSC 1.1 image profile", vm.ExportImscImageCommand);
         Add(exportMenu, "DOST/png", vm.ExportDostPngCommand);
         Add(exportMenu, "Final Cut Pro + image", vm.ExportFcpPngCommand);
         Add(exportMenu, Se.Language.General.ImagesWithHtmlIndex, vm.ExportHtmlIndexCommand);


### PR DESCRIPTION
Follow-up to #12547: also offer the IMSC 1.1 image profile export from the **binary/image subtitle editor** (BinEdit), where PGS/VobSub/etc. are edited.

Adds an `ExportImscImage` command that runs the already-merged `ExportHandlerImscImage` through the shared `DoExport` flow, and wires it into both the window menu and the native macOS menu alongside Blu-ray SUP / BDN XML / FCP / VobSub.

Because BinEdit exports the binary sub's own bitmaps and passes each cue's real X/Y via `OverridePosition`, the IMSC regions keep the original on-screen placement — no re-rendering. Output is a single self-contained `.ttml` file (same conformant shape covered by #12547's tests, which round-trips through SE's Timed Text Base64 Image reader).

UI builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)