### PR TITLE
Update change log

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -18,7 +18,7 @@ v5.1.0-rc5 (TBD)
 * Update CrispASR to v0.8.12
 * Export PGS/VobSub: list every installed font face like SE4 ("Segoe UI Semibold", "Arial Black", ...) - the list only had font family names, hiding named faces, and a picked face now also renders with its own weight - thx robertmajsky
 * Add EBU-TT-D subtitle format (read + write) - the TTML distribution profile used by European broadcasters (BBC iPlayer, ARD/ZDF, NPO) and HbbTV
-* Export image-based: add IMSC 1.1 image profile - a single self-contained TTML file with base64 PNG subtitles (smpte:image), for streaming/broadcast image-subtitle delivery
+* Export image-based: add IMSC 1.1 image profile - a single self-contained TTML file with base64 PNG subtitles (smpte:image), for streaming/broadcast image-subtitle delivery (in File > Export and the image/binary subtitle editor)
 * Command line (seconv): --multiple-replace now also accepts the multiple-replace rules exported from the GUI (.template JSON or .csv), not only the legacy XML - thx BagronkeN
 * Shortcuts: a user-assigned F10 shortcut is no longer overridden by the menu-bar focus toggle (the menu stays reachable via Alt) - thx Khaztaroth
 * Fix reading decimal values in some XML-based formats (e.g. Final Cut Pro, JacoSub) on locales with a comma decimal separator


### PR DESCRIPTION
Notes that the IMSC 1.1 image profile export (#12547) is now also available in the image/binary subtitle editor (#12548). The other merges since the last changelog update (EBU-TT-D, seconv multiple-replace, F10/culture fixes, perf rounds) already have entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)