### PR TITLE
Source View: add a context menu for the advanced text editor

### DIFF
--- a/src/ui/Features/Shared/SourceView/SourceViewViewModel.cs
+++ b/src/ui/Features/Shared/SourceView/SourceViewViewModel.cs
@@ -32,6 +32,9 @@ public partial class SourceViewViewModel : ObservableObject
 
     public SubtitleFormat _subtitleFormat { get; private set; }
     public ITextBoxWrapper SourceViewTextBox { get; set; }
+    public IRelayCommand CutCommand { get; }
+    public IRelayCommand CopyCommand { get; }
+    public IRelayCommand PasteCommand { get; }
 
     private readonly System.Timers.Timer _cursorTimer;
     private int _initialCaretIndex;
@@ -44,6 +47,9 @@ public partial class SourceViewViewModel : ObservableObject
         LineAndColumnInfo = string.Empty;
         Subtitle = new Subtitle();
         _subtitleFormat = new SubRip();
+        CutCommand = new RelayCommand(() => SourceViewTextBox.Cut());
+        CopyCommand = new RelayCommand(() => SourceViewTextBox.Copy());
+        PasteCommand = new RelayCommand(() => SourceViewTextBox.Paste());
 
         _cursorTimer = new System.Timers.Timer(200);
         _cursorTimer.Elapsed += (sender, args) =>

--- a/src/ui/Features/Shared/SourceView/SourceViewWindow.cs
+++ b/src/ui/Features/Shared/SourceView/SourceViewWindow.cs
@@ -1,7 +1,9 @@
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Layout;
+using AvaloniaEdit;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
 
 namespace Nikse.SubtitleEdit.Features.Shared.SourceView;
 
@@ -18,6 +20,23 @@ public class SourceViewWindow : Window
         CanResize = true;
         vm.Window = this;
         DataContext = vm;
+
+        // Add a context menu for the advanced text editor.
+        if (vm.SourceViewTextBox.TextControl is TextEditor textEditor)
+        {
+            var textBoxContextFlyout = new MenuFlyout
+            {
+                Placement = PlacementMode.Pointer,
+                Items =
+                {
+                    new MenuItem { Header = Se.Language.General.Cut, Command = vm.CutCommand },
+                    new MenuItem { Header = Se.Language.General.Copy, Command = vm.CopyCommand },
+                    new MenuItem { Header = Se.Language.General.Paste, Command = vm.PasteCommand },
+                },
+            };
+            textEditor.ContextFlyout = textBoxContextFlyout;
+            UiUtil.AttachMacContextFlyoutHandler(textEditor);
+        }
 
         var contentBorder = new Border
         {


### PR DESCRIPTION
## Summary

Adds a Cut, Copy, and Paste context menu to Source View when it uses AvaloniaEdit's advanced text editor.

## Background

For source text up to 2,000,000 characters, Source View uses AvaloniaEdit's `TextEditor`, which does not provide a default context menu. As a result, right-clicking the source text did not expose the standard clipboard actions.

## Implementation

A `MenuFlyout` with Cut, Copy, and Paste actions is added only when Source View uses AvaloniaEdit's `TextEditor`.

The large-file `TextBox` path is left unchanged to retain its built-in context menu. The macOS context-flyout helper is attached to the advanced editor for Ctrl+Click support.

## Screenshot

| |
| --- |
| <video src="https://github.com/user-attachments/assets/b6cd4646-c29a-40ad-8569-5ce8c8e7eea9"> |

## Testing

Tested on Windows 11 x64 (local build).