### PR TITLE
Point sync: sorted points, working delete, button icon; fix file name overflow

### DIFF
--- a/src/ui/Features/Sync/PointSync/PointSyncViewModel.cs
+++ b/src/ui/Features/Sync/PointSync/PointSyncViewModel.cs
@@ -100,7 +100,23 @@ public partial class PointSyncViewModel : ObservableObject
         var syncPoint = new SyncPoint(
             selectedSubtitle, Subtitles.IndexOf(selectedSubtitle),
             subtitleOther, Subtitles.IndexOf(selectedSubtitle));
-        SyncPoints.Add(syncPoint);
+
+        // A line has at most one sync point (setting it again re-points it), and the list
+        // stays in chronological order.
+        var existing = SyncPoints.FirstOrDefault(p => p.LeftIndex == syncPoint.LeftIndex);
+        if (existing != null)
+        {
+            SyncPoints.Remove(existing);
+        }
+
+        var insertAt = 0;
+        while (insertAt < SyncPoints.Count && SyncPoints[insertAt].LeftIndex < syncPoint.LeftIndex)
+        {
+            insertAt++;
+        }
+
+        SyncPoints.Insert(insertAt, syncPoint);
+        SelectedSyncPoint = syncPoint;
         IsOkEnabled = true;
     }
 
@@ -142,15 +158,5 @@ public partial class PointSyncViewModel : ObservableObject
             e.Handled = true;
             UiUtil.ShowHelp("features/point-sync");
         }
-    }
-
-    internal void PointSyncContextMenuOpening(object? sender, EventArgs e)
-    {
-        if (SyncPoints.Count == 0)
-        {
-            return;
-        }
-
-        DeleteSelectedPointSync();
     }
 }

--- a/src/ui/Features/Sync/PointSync/PointSyncWindow.cs
+++ b/src/ui/Features/Sync/PointSync/PointSyncWindow.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.Input;
 using Avalonia.Layout;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Sync.PointSyncViaOther;
@@ -102,18 +103,29 @@ public class PointSyncWindow : Window
             },
         };
 
-        var flyout = new MenuFlyout();
-        flyout.Opening += vm.PointSyncContextMenuOpening;
-        dataGrid.ContextFlyout = flyout;
-        UiUtil.AttachMacContextFlyoutHandler(dataGrid);
+        dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedSyncPoint)));
+
         var menuItemDelete = new MenuItem
         {
             Header = Se.Language.General.Delete,
             DataContext = vm,
             Command = vm.DeleteSelectedPointSyncCommand,
         };
+        var flyout = new MenuFlyout { Items = { menuItemDelete } };
+        flyout.Opening += (_, _) => menuItemDelete.IsEnabled = vm.SelectedSyncPoint != null;
+        dataGrid.ContextFlyout = flyout;
+        UiUtil.AttachMacContextFlyoutHandler(dataGrid);
+        dataGrid.KeyDown += (_, e) =>
+        {
+            if (e.Key is Key.Delete or Key.Back)
+            {
+                e.Handled = true;
+                vm.DeleteSelectedPointSyncCommand.Execute(null);
+            }
+        };
 
-        var buttonSetSyncPoint = UiUtil.MakeButton(Se.Language.Sync.SetSyncPoint, vm.SetSyncPointCommand);
+        var buttonSetSyncPoint = UiUtil.MakeButton(Se.Language.Sync.SetSyncPoint, vm.SetSyncPointCommand)
+            .WithIconLeft(IconNames.ArrowLeftRightBold);
 
         grid.Add(buttonSetSyncPoint, 0);
         grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGrid), 1);

--- a/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherWindow.cs
+++ b/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherWindow.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Layout;
+using Avalonia.Media;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -233,14 +234,26 @@ public class PointSyncViaOtherWindow : Window
         };
 
         var buttonBrowseOther = UiUtil.MakeButtonBrowse(vm.BrowseOtherCommand);
-        var labelOtherFileName = UiUtil.MakeLabel(string.Empty).WithBindText(vm, nameof(vm.FileNameOther));
-        labelOtherFileName.VerticalAlignment = VerticalAlignment.Center;
-        var panelOtherBrowse = new StackPanel
+        // TextBlock in a star column so a long file name shrinks with an ellipsis
+        // instead of pushing under the "Find text" button.
+        var labelOtherFileName = new TextBlock
         {
-            Orientation = Orientation.Horizontal,
             VerticalAlignment = VerticalAlignment.Center,
-            Children = { buttonBrowseOther, labelOtherFileName },
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            Margin = new Thickness(5, 0, 5, 0),
         };
+        labelOtherFileName.Bind(TextBlock.TextProperty, new Binding(nameof(vm.FileNameOther)) { Source = vm });
+        var panelOtherBrowse = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        panelOtherBrowse.Add(buttonBrowseOther, 0, 0);
+        panelOtherBrowse.Add(labelOtherFileName, 0, 1);
         var buttonFindTextOther = UiUtil.MakeButton(Se.Language.Sync.FindText, vm.FindTextOtherCommand);
         buttonFindTextOther.HorizontalAlignment = HorizontalAlignment.Right;
         var panelOtherHeader = new Grid


### PR DESCRIPTION
Applies the same fixes to **Point sync** that **Point sync via other subtitle** got in #12529:

- Sync points now stay in chronological order, and setting a point for a line that already has one re-points it instead of adding a duplicate.
- Deleting a sync point works: the Delete menu item is now actually added to the context flyout (disabled without a selection) instead of the Opening handler deleting silently, the sync-point grid binds its selection to `SelectedSyncPoint`, and Delete/Backspace on the grid also removes the selected point.
- "Set sync point" button gets the left/right arrows icon.

Also in **Point sync via other subtitle**: a long file name in the right header sat in a horizontal StackPanel and overflowed under the "Find text" button — it is now a TextBlock in a star column that auto-shrinks with a character ellipsis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)