### PR TITLE
RTL caret movement: flip Left/Right like Avalonia does

### DIFF
--- a/src/AvaloniaEdit/AvaloniaEdit/Editing/CaretNavigationCommandHandler.cs
+++ b/src/AvaloniaEdit/AvaloniaEdit/Editing/CaretNavigationCommandHandler.cs
@@ -238,6 +238,21 @@ namespace AvaloniaEdit.Editing
 
         internal static TextViewPosition GetNewCaretPosition(TextView textView, TextViewPosition caretPosition, CaretMovementType direction, bool enableVirtualSpace, ref double desiredXPos)
         {
+            // In a right-to-left editor the Left key must still move the caret visually left, which
+            // is logically forward. Avalonia's own TextPresenter.MoveCaretHorizontal flips the
+            // logical direction the same way for a RightToLeft control, so flipping here keeps the
+            // editor consistent with every other Avalonia text control. Only the single character
+            // steps flip: Avalonia does not flip whole word movement either, so that is left alone.
+            if (textView.FlowDirection == Avalonia.Media.FlowDirection.RightToLeft)
+            {
+                direction = direction switch
+                {
+                    CaretMovementType.CharLeft => CaretMovementType.CharRight,
+                    CaretMovementType.CharRight => CaretMovementType.CharLeft,
+                    _ => direction
+                };
+            }
+
             switch (direction)
             {
                 case CaretMovementType.None:

--- a/tests/UI/Logic/Accessibility/EditBoxAccessibilityNameTests.cs
+++ b/tests/UI/Logic/Accessibility/EditBoxAccessibilityNameTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Avalonia;
 using Avalonia.Automation;
@@ -5,6 +6,7 @@ using Avalonia.Automation.Peers;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
+using Avalonia.Markup.Xaml.Styling;
 using Avalonia.Themes.Fluent;
 using Avalonia.VisualTree;
 using Nikse.SubtitleEdit.Controls;
@@ -22,6 +24,14 @@ public class TestApp : Application
         // The custom up/down controls embed a ButtonSpinner + TextBox that need a
         // theme to resolve their templates when shown in a headless window.
         Styles.Add(new FluentTheme());
+
+        // AvaloniaEdit brings its own theme; without it a TextEditor gets no template and
+        // never materializes its TextArea, so tests over the editor see nothing (same include
+        // Program.cs adds at startup).
+        Styles.Add(new StyleInclude(new Uri("avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml", UriKind.Absolute))
+        {
+            Source = new Uri("avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml"),
+        });
 
         // Windows built in code use Attached.SetIcon; without the providers Program.cs
         // registers at startup, constructing such a window throws KeyNotFoundException.

--- a/tests/UI/Logic/RightToLeftCaretNavigationTests.cs
+++ b/tests/UI/Logic/RightToLeftCaretNavigationTests.cs
@@ -1,0 +1,89 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Avalonia.Threading;
+using AvaloniaEdit;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// The subtitle text box (with color tags on) is an AvaloniaEdit TextEditor. In a right-to-left
+/// editor the Left key must move the caret visually left, which is logically forward. Avalonia's
+/// own TextPresenter.MoveCaretHorizontal flips the logical direction for a RightToLeft control,
+/// so the editor has to do the same or its arrows run backwards against every other text box in
+/// the app (follow-up to the RTL rendering fix, #12386 / #12434).
+///
+/// These drive the same routed commands that the Left/Right key bindings invoke.
+/// </summary>
+public class RightToLeftCaretNavigationTests
+{
+    private const string Arabic = "مرحبا بالعالم";
+    private const string English = "hello world";
+
+    private static TextEditor ShowEditor(string text, FlowDirection flowDirection)
+    {
+        var editor = new TextEditor
+        {
+            FlowDirection = flowDirection,
+            Text = text,
+        };
+
+        // A full window layout pass is what materializes the editor's template, so the TextArea
+        // and its TextView actually enter the visual tree and inherit FlowDirection.
+        var window = new Window { Content = editor, Width = 400, Height = 200 };
+        window.Show();
+        window.Measure(new Avalonia.Size(400, 200));
+        window.Arrange(new Avalonia.Rect(0, 0, 400, 200));
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(flowDirection, editor.TextArea.TextView.FlowDirection);
+
+        return editor;
+    }
+
+    [AvaloniaFact]
+    public void RightToLeft_MoveLeft_MovesCaretLogicallyForward()
+    {
+        var editor = ShowEditor(Arabic, FlowDirection.RightToLeft);
+        editor.CaretOffset = 5;
+
+        EditingCommands.MoveLeftByCharacter.Execute(null, editor.TextArea);
+
+        // Visually left on a right-to-left line is the next character logically.
+        Assert.Equal(6, editor.CaretOffset);
+    }
+
+    [AvaloniaFact]
+    public void RightToLeft_MoveRight_MovesCaretLogicallyBackward()
+    {
+        var editor = ShowEditor(Arabic, FlowDirection.RightToLeft);
+        editor.CaretOffset = 5;
+
+        EditingCommands.MoveRightByCharacter.Execute(null, editor.TextArea);
+
+        Assert.Equal(4, editor.CaretOffset);
+    }
+
+    [AvaloniaFact]
+    public void LeftToRight_MoveLeft_StillMovesCaretBackward()
+    {
+        var editor = ShowEditor(English, FlowDirection.LeftToRight);
+        editor.CaretOffset = 5;
+
+        EditingCommands.MoveLeftByCharacter.Execute(null, editor.TextArea);
+
+        // Left-to-right must be untouched by the flip.
+        Assert.Equal(4, editor.CaretOffset);
+    }
+
+    [AvaloniaFact]
+    public void LeftToRight_MoveRight_StillMovesCaretForward()
+    {
+        var editor = ShowEditor(English, FlowDirection.LeftToRight);
+        editor.CaretOffset = 5;
+
+        EditingCommands.MoveRightByCharacter.Execute(null, editor.TextArea);
+
+        Assert.Equal(6, editor.CaretOffset);
+    }
+}


### PR DESCRIPTION
Follow-up to #12551, targeted at that branch since the change lives inside the vendored AvaloniaEdit.

With the rendering fix in place the glyphs reorder correctly, but the arrows still stepped the logical column, so on a right-to-left line Left moved the caret visually **right**.

Avalonia's own `TextPresenter.MoveCaretHorizontal` flips the logical direction when the control is `RightToLeft`:

```csharp
if (FlowDirection == FlowDirection.RightToLeft)
{
    direction = direction == LogicalDirection.Forward ?
        LogicalDirection.Backward : LogicalDirection.Forward;
}
```

The editor did not, so its arrows ran backwards against every other Avalonia text control. This does the same flip in `CaretNavigationCommandHandler.GetNewCaretPosition`.

Only the single character steps flip. Avalonia does not flip whole word movement either, and Subtitle Edit already corrects word and line movement for both edit boxes in `TryHandleRightToLeftCaretNavigation`, so flipping words here as well would fight it.

## Tests

Four headless cases over a real `TextEditor`, driving the same routed commands the Left/Right key bindings invoke:

- right-to-left: Left moves logically forward, Right moves logically backward
- left-to-right: both unchanged

Verified they genuinely catch the bug: with the flip disabled the two RTL cases fail (RTL Left lands on 4 instead of 6) and the LTR ones still pass. Full UI suite is green (693 tests).

The shared test app now also includes AvaloniaEdit's theme. Without it a `TextEditor` gets no template, never materializes its `TextArea`, and anything testing the editor silently sees nothing.
