### PR TITLE
Update change log for v5.1.0-rc5

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,8 +3,11 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
-v5.1.0-rc5 (TBD)
+v5.1.0-rc5 (17th of July 2026)
 
+* Subtitle text box: tag coloring (HTML/ASSA) now uses a new native text box - same colors as before, but centering, IME/CJK input, right-to-left and the context menu work exactly like the normal text box, and toggling right-to-left no longer turns off tag coloring
+* Subtitle text box: fix crash while typing an unterminated attribute quote (e.g. <font color=") with tag coloring enabled
+* Source view: add context menu to the text editor - thx pdjdev
 * Point sync via other subtitle: sync points are now chronologically sorted, and setting a point on a line that already has one re-points it instead of adding a duplicate - thx fraternl
 * Point sync via other subtitle: fix deleting a sync point - the context menu now shows Delete (and Delete/Backspace on the list works) instead of silently removing the point on right-click - thx fraternl
 * Point sync via other subtitle: clicking a line in the left list scrolls the other subtitle's list to the matching time (selection is left untouched) - thx fraternl


### PR DESCRIPTION
Adds the v5.1.0-rc5 entries for the new syntax highlighting text box (#12556) and the missing Source View context menu entry (#12550, thx pdjdev), and sets the release date. Se.cs already carries v5.1.0-rc5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)