### PR TITLE
Hide "Download yt-dlp" button in Open from URL when already up to date

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -6443,18 +6443,34 @@ public partial class MainViewModel :
             }
         }
 
+        var ytDlpUpdatedFromUrlWindow = false;
         var result = await ShowDialogAsync<OpenFromUrlWindow, OpenFromUrlViewModel>(vm =>
         {
             // Reuse the existing install/update prompt for the window's manual
             // "Download yt-dlp" button. Pick the message by current install state
             // and own the dialogs off the URL window so they nest correctly.
-            vm.DownloadOrUpdateYtDlpRequested = () =>
+            vm.DownloadOrUpdateYtDlpRequested = async () =>
             {
                 var message = File.Exists(YtDlpDownloadService.GetFullFileName())
                     ? Se.Language.Main.YoutubeDlOutdatedDownloadNow
                     : Se.Language.Main.YoutubeDlNotInstalledDownloadNow;
-                return PromptToDownloadYtDlp(message, vm.Window);
+                if (await PromptToDownloadYtDlp(message, vm.Window))
+                {
+                    vm.IsDownloadYtDlpVisible = false;
+                    ytDlpUpdatedFromUrlWindow = true;
+                }
             };
+
+            // Only surface the "Download yt-dlp" button when the background
+            // version check finds the install outdated — with the latest version
+            // already on disk there is nothing to download.
+            outdatedCheckTask?.ContinueWith(t =>
+            {
+                if (t.Status == TaskStatus.RanToCompletion && t.Result)
+                {
+                    Dispatcher.UIThread.Post(() => vm.IsDownloadYtDlpVisible = true);
+                }
+            }, TaskScheduler.Default);
         });
 
         if (!result.OkPressed || result.SelectedMode is null)
@@ -6499,8 +6515,10 @@ public partial class MainViewModel :
 
         // If a newer yt-dlp is available, offer the upgrade — but open the video
         // regardless of the user's choice. The installed binary still works, so a
-        // declined or failed update must not abort the open.
-        if (isOutdated)
+        // declined or failed update must not abort the open. Skip the prompt when
+        // the user already updated via the URL window's button — the background
+        // check result predates that update.
+        if (isOutdated && !ytDlpUpdatedFromUrlWindow)
         {
             await PromptToDownloadYtDlp(Se.Language.Main.YoutubeDlOutdatedDownloadNow);
         }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -6595,8 +6595,17 @@ public partial class MainViewModel :
             return;
         }
 
+        // The picker's "Save..." button needs a video-derived name suggestion —
+        // the downloaded files themselves are named "sub.en.vtt" in a temp dir.
+        string? suggestedFileNameBase = null;
+        if (!string.IsNullOrEmpty(_videoFileName))
+        {
+            suggestedFileNameBase = Path.GetFileNameWithoutExtension(
+                MakeSubtitleFileNameFromVideo(_videoFileName, languageCode: null));
+        }
+
         var pickerResult = await ShowDialogAsync<PickOnlineSubtitleWindow, PickOnlineSubtitleViewModel>(
-            vm => { vm.Initialize(subtitles); });
+            vm => { vm.Initialize(subtitles, suggestedFileNameBase); });
 
         if (!pickerResult.OkPressed || string.IsNullOrEmpty(pickerResult.SelectedSubtitlePath))
         {

--- a/src/ui/Features/Video/OpenFromUrl/OpenFromUrlViewModel.cs
+++ b/src/ui/Features/Video/OpenFromUrl/OpenFromUrlViewModel.cs
@@ -18,6 +18,13 @@ public partial class OpenFromUrlViewModel : ObservableObject
     [ObservableProperty] private string _url;
     [ObservableProperty] private bool _downloadSubtitles;
 
+    /// <summary>
+    /// The "Download yt-dlp" button is hidden unless the caller's background
+    /// version check finds yt-dlp missing or outdated — an up-to-date install
+    /// has nothing to download.
+    /// </summary>
+    [ObservableProperty] private bool _isDownloadYtDlpVisible;
+
     public Window? Window { get; set; }
 
     public OpenFromUrlMode? SelectedMode { get; private set; }

--- a/src/ui/Features/Video/OpenFromUrl/OpenFromUrlWindow.cs
+++ b/src/ui/Features/Video/OpenFromUrl/OpenFromUrlWindow.cs
@@ -82,6 +82,7 @@ public class OpenFromUrlWindow : Window
         var downloadYtDlpButton = UiUtil.MakeButton(
             string.Format(Se.Language.General.DownloadX, "yt-dlp"),
             vm.DownloadYtDlpCommand);
+        downloadYtDlpButton[!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsDownloadYtDlpVisible));
         var cancelBar = UiUtil.MakeButtonBar(downloadYtDlpButton, UiUtil.MakeButtonCancel(vm.CancelCommand));
 
         var content = new StackPanel

--- a/src/ui/Features/Video/OpenFromUrl/PickOnlineSubtitle/PickOnlineSubtitleViewModel.cs
+++ b/src/ui/Features/Video/OpenFromUrl/PickOnlineSubtitle/PickOnlineSubtitleViewModel.cs
@@ -3,13 +3,19 @@ using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Shared.PromptFileSaved;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
+using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Video.OpenFromUrl.PickOnlineSubtitle;
 
@@ -26,8 +32,15 @@ public partial class PickOnlineSubtitleViewModel : ObservableObject
     public bool OkPressed { get; private set; }
     public string? SelectedSubtitlePath { get; private set; }
 
-    public PickOnlineSubtitleViewModel()
+    private readonly IFileHelper _fileHelper;
+    private readonly IWindowService _windowService;
+
+    private string? _suggestedFileNameBase;
+
+    public PickOnlineSubtitleViewModel(IFileHelper fileHelper, IWindowService windowService)
     {
+        _fileHelper = fileHelper;
+        _windowService = windowService;
         Tracks = new ObservableCollection<OnlineSubtitleTrackDisplay>();
         PreviewRows = new ObservableCollection<OnlineSubtitleCueDisplay>();
         StatusText = string.Empty;
@@ -37,9 +50,13 @@ public partial class PickOnlineSubtitleViewModel : ObservableObject
     /// <summary>
     /// Initializes the picker with pre-downloaded subtitle files. The picker
     /// itself never spawns yt-dlp — it's purely a chooser over what's on disk.
+    /// <paramref name="suggestedFileNameBase"/> is the video-derived name (no
+    /// extension) used as the save-as suggestion for the "Save..." button; the
+    /// downloaded files themselves have useless temp-dir names like "sub.en.vtt".
     /// </summary>
-    public void Initialize(IReadOnlyList<DownloadedSubtitleInfo> subtitles)
+    public void Initialize(IReadOnlyList<DownloadedSubtitleInfo> subtitles, string? suggestedFileNameBase = null)
     {
+        _suggestedFileNameBase = suggestedFileNameBase;
         Tracks.Clear();
         PreviewRows.Clear();
 
@@ -126,6 +143,49 @@ public partial class PickOnlineSubtitleViewModel : ObservableObject
             Se.LogError(ex, $"Failed to parse subtitle for preview: {track.FilePath}");
             StatusText = ex.Message;
         }
+    }
+
+    /// <summary>
+    /// Saves the selected track's file to a user-chosen location as-is (a plain
+    /// copy, no format conversion). Needed because the downloaded files live in
+    /// a temp directory the caller deletes right after the picker closes.
+    /// </summary>
+    [RelayCommand]
+    private async Task Save()
+    {
+        var selected = SelectedTrack;
+        if (selected is null || string.IsNullOrEmpty(selected.FilePath) || Window is null)
+        {
+            return;
+        }
+
+        var baseName = string.IsNullOrEmpty(_suggestedFileNameBase)
+            ? Path.GetFileNameWithoutExtension(selected.FilePath)
+            : _suggestedFileNameBase;
+        var suggestedFileName = string.IsNullOrEmpty(selected.LanguageCode)
+            ? baseName
+            : baseName + "." + selected.LanguageCode;
+
+        var fileName = await _fileHelper.PickSaveSubtitleFile(
+            Window, "." + selected.Format, suggestedFileName, Se.Language.General.SaveFileAsTitle);
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return;
+        }
+
+        try
+        {
+            File.Copy(selected.FilePath, fileName, overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"Failed to save downloaded subtitle to {fileName}");
+            await MessageBox.Show(Window, Se.Language.General.Error, ex.Message);
+            return;
+        }
+
+        _ = await _windowService.ShowDialogAsync<PromptFileSavedWindow, PromptFileSavedViewModel>(Window,
+            vm => { vm.Initialize(Se.Language.General.SubtitleFileSaved, string.Format(Se.Language.General.SubtitleFileSavedToX, fileName), fileName, true, true); });
     }
 
     [RelayCommand]

--- a/src/ui/Features/Video/OpenFromUrl/PickOnlineSubtitle/PickOnlineSubtitleWindow.cs
+++ b/src/ui/Features/Video/OpenFromUrl/PickOnlineSubtitle/PickOnlineSubtitleWindow.cs
@@ -30,10 +30,12 @@ public class PickOnlineSubtitleWindow : Window
 
         var statusBar = MakeStatusBar(vm);
 
+        var buttonSave = UiUtil.MakeButton(Se.Language.General.SaveDotDotDot, vm.SaveCommand);
+        buttonSave.Bind(IsEnabledProperty, new Binding(nameof(vm.IsOkEnabled)));
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
         buttonOk.Bind(IsEnabledProperty, new Binding(nameof(vm.IsOkEnabled)));
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
-        var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+        var panelButtons = UiUtil.MakeButtonBar(buttonSave, buttonOk, buttonCancel);
 
         var splitGrid = new Grid
         {


### PR DESCRIPTION
### Problem

The "Open video from URL" window always showed a "Download yt-dlp" button, even when the latest yt-dlp was already installed.

### Fix

- The button is now hidden by default and only appears when the background `yt-dlp --version` outdated-check (which already runs while the dialog is open) reports the install as outdated.
- After a successful update via the button, it hides again.
- The redundant "yt-dlp is outdated" prompt after submitting a URL is skipped when the user already updated through the button (the background check result predates that update).

Note: when yt-dlp is missing entirely, the install prompt already blocks before this window opens, so the always-visible button never had a purpose in the up-to-date case.

### Also: "Save..." button in the online subtitle picker

The "Pick subtitle to download" window now has a "Save..." button (mirroring the export button in the Matroska track picker) that saves the selected downloaded subtitle file as-is (plain copy, no format conversion) to a user-chosen location. Needed because the downloaded files live in a temp directory that is deleted right after the picker closes. The save-as suggestion uses a video-derived name with language code (e.g. `MyVideo.en.vtt`) instead of the temp-dir `sub.en.vtt` naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)