### PR TITLE
Add option to center waveform video position also while paused

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2503,6 +2503,7 @@
       "errorBackgroundColor": "Error background color",
       "waveformDrawGridLines": "Draw grid lines",
       "waveformCenterVideoPosition": "Center video position",
+      "waveformCenterVideoPositionAlsoWhenPaused": "Center video position also while paused",
       "waveformShowToolbar": "Show toolbar",
       "waveformShowToolbarEdit": "Edit toolbar...",
       "waveformShowToolbarEditLabel": "Toolbar items",

--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -707,9 +707,15 @@ public class AudioVisualizer : Control
                 newVideoPosition = WavePeaks.LengthInSeconds;
             }
 
-            // Follow the play-head: scroll the view only when it would leave the visible range.
+            // Follow the play-head: with center-also-while-paused the view scrolls on every
+            // step so the cursor stays pinned to the middle (SE 4's locked/center mode) and
+            // the waveform reads as one continuous strip; otherwise scroll only when the
+            // play-head would leave the visible range.
             var visibleSeconds = EndPositionSeconds - StartPositionSeconds;
-            if (visibleSeconds > 0 && (newVideoPosition < StartPositionSeconds || newVideoPosition > EndPositionSeconds))
+            var keepCentered = Se.Settings.Waveform.CenterVideoPosition &&
+                               Se.Settings.Waveform.CenterVideoPositionAlsoWhenPaused;
+            if (visibleSeconds > 0 &&
+                (keepCentered || newVideoPosition < StartPositionSeconds || newVideoPosition > EndPositionSeconds))
             {
                 var followStart = newVideoPosition - visibleSeconds / 2;
                 StartPositionSeconds = followStart < 0 ? 0 : followStart;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -356,6 +356,11 @@ public partial class MainViewModel :
     private const double PlayheadSeekPinTimeoutMs = 600;
     private const double PlayheadResyncThresholdSeconds = 0.5; // drift beyond this = real discontinuity -> snap
     private const double PlayheadDriftCorrection = 0.05; // gentle pull toward mpv when its clock is live
+
+    // "Center video position also while paused": paused centering/selection only reacts to
+    // position *changes*, so they track the last seen play-head position between timer ticks.
+    private double _pausedCenterLastSeconds = -1;
+    private double _pausedSelectLastSeconds = -1;
     private const double PlayheadMaxCorrectionFraction = 0.2; // cap catch-up to ~1.2x speed (vs the forward step)
     private const double PlayheadMaxForwardStepSeconds = 0.05; // cap one tick's advance so a starved tick can't lurch
     private const double PlayheadFreezeHoldSeconds = 0.12; // if mpv's clock hasn't moved this long, it's frozen: hold
@@ -21320,6 +21325,54 @@ public partial class MainViewModel :
     // clock so the line keeps gliding through the resume gap. Elapsed time uses Stopwatch
     // (sub-microsecond) not Environment.TickCount64 (~15 ms on Windows), whose coarse steps would
     // make the cursor advance unevenly.
+    /// <summary>
+    /// Selects (and scrolls to) the subtitle covering the play-head position, preferring the
+    /// first line under 20 seconds so a full-length karaoke/credits line doesn't hog the
+    /// selection. <paramref name="subtitle"/> must be sorted by start time. No-op when the
+    /// current selection already covers the position.
+    /// </summary>
+    private void SelectCurrentSubtitleAtPlayhead(double mediaPlayerSeconds, List<SubtitleLineViewModel> subtitle)
+    {
+        var ss = SelectedSubtitle;
+        if (ss != null && mediaPlayerSeconds >= ss.StartTime.TotalSeconds &&
+            mediaPlayerSeconds <= ss.EndTime.TotalSeconds && ss.Duration.TotalSeconds <= 20)
+        {
+            return;
+        }
+
+        SubtitleLineViewModel? firstMatch = null;
+        var matchFound = false;
+        for (var i = 0; i < subtitle.Count; i++)
+        {
+            var p = subtitle[i];
+            if (p.StartTime.TotalSeconds > mediaPlayerSeconds)
+            {
+                break; // sorted by start time, no later line can contain the position
+            }
+
+            if (mediaPlayerSeconds >= p.StartTime.TotalSeconds &&
+                mediaPlayerSeconds <= p.EndTime.TotalSeconds)
+            {
+                if (firstMatch == null)
+                {
+                    firstMatch = p;
+                }
+
+                if (p.Duration.TotalSeconds < 20)
+                {
+                    matchFound = true;
+                    SelectAndScrollToSubtitle(p);
+                    break;
+                }
+            }
+        }
+
+        if (!matchFound && firstMatch != null)
+        {
+            SelectAndScrollToSubtitle(firstMatch);
+        }
+    }
+
     private double UpdatePlayheadEstimate(VideoPlayerControl vp)
     {
         var rawPosition = vp.VideoPlayer.Position;
@@ -21644,48 +21697,26 @@ public partial class MainViewModel :
 
                     else if (SelectCurrentSubtitleWhilePlaying && _playSelectionItem == null)
                     {
-                        var ss = SelectedSubtitle;
-                        if (ss == null || mediaPlayerSeconds < ss.StartTime.TotalSeconds ||
-                            mediaPlayerSeconds > ss.EndTime.TotalSeconds || ss.Duration.TotalSeconds > 20)
-                        {
-                            SubtitleLineViewModel? firstMatch = null;
-                            var matchFound = false;
-                            for (var i = 0; i < subtitle.Count; i++)
-                            {
-                                var p = subtitle[i];
-                                if (p.StartTime.TotalSeconds > mediaPlayerSeconds)
-                                {
-                                    break; // sorted by start time, no later line can contain the position
-                                }
-
-                                if (mediaPlayerSeconds >= p.StartTime.TotalSeconds &&
-                                    mediaPlayerSeconds <= p.EndTime.TotalSeconds)
-                                {
-                                    if (firstMatch == null)
-                                    {
-                                        firstMatch = p;
-                                    }
-
-                                    if (p.Duration.TotalSeconds < 20)
-                                    {
-                                        matchFound = true;
-                                        SelectAndScrollToSubtitle(p);
-                                        break;
-                                    }
-                                }
-                            }
-
-                            if (!matchFound && firstMatch != null)
-                            {
-                                SelectAndScrollToSubtitle(firstMatch);
-                            }
-                        }
+                        SelectCurrentSubtitleAtPlayhead(mediaPlayerSeconds, subtitle);
                     }
                 }
                 else
                 {
                     Optris.Icons.Avalonia.Attached.SetIcon(ButtonWaveformPlay, IconNames.Play);
                     ResetPlaySelection();
+
+                    // "Center also while paused" scrub-editing (SE 4's locked mode): while the user
+                    // wheels through the waveform, keep selecting the line under the centered cursor.
+                    // Only react to position *changes* — otherwise this would immediately steal back
+                    // the selection when the user picks a different line in the grid while paused.
+                    if (WaveformCenter && Se.Settings.Waveform.CenterVideoPositionAlsoWhenPaused &&
+                        SelectCurrentSubtitleWhilePlaying &&
+                        Math.Abs(mediaPlayerSeconds - _pausedSelectLastSeconds) > 0.001)
+                    {
+                        SelectCurrentSubtitleAtPlayhead(mediaPlayerSeconds, subtitle);
+                    }
+
+                    _pausedSelectLastSeconds = mediaPlayerSeconds;
                 }
 
                 _avLastScrolling = isAvScrolloing;
@@ -21728,11 +21759,19 @@ public partial class MainViewModel :
                 // In "center waveform on current position" mode the waveform scrolls to keep the cursor
                 // centered. Drive that scroll here at ~60 fps, in lockstep with the cursor, so it glides
                 // smoothly instead of jumping in 20 fps steps from the heavy 50 ms timer.
-                if (WaveformCenter && vp.IsPlaying && av.WavePeaks != null)
+                // With "center also while paused" on, paused position changes (wheel scrub, waveform
+                // clicks, shortcuts) recenter too — but only on actual changes, so the user can still
+                // scroll around the waveform freely while the play-head is at rest.
+                var centerPausedChange = WaveformCenter && !vp.IsPlaying &&
+                                         Se.Settings.Waveform.CenterVideoPositionAlsoWhenPaused &&
+                                         Math.Abs(est - _pausedCenterLastSeconds) > 0.001;
+                if (WaveformCenter && av.WavePeaks != null && (vp.IsPlaying || centerPausedChange))
                 {
                     var halfSeconds = (av.EndPositionSeconds - av.StartPositionSeconds) / 2.0;
                     av.StartPositionSeconds = Math.Max(0, est - halfSeconds);
                 }
+
+                _pausedCenterLastSeconds = est;
             }
         };
         _cursorTimer.Start();

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -530,6 +530,7 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformMouseWheelSetsVideoPosition, nameof(_vm.WaveformMouseWheelSetsVideoPosition)),
             new SettingsItem(Se.Language.Options.Settings.WaveformMouseWheelVideoPositionStep,
                 () => UiUtil.MakeComboBox(_vm.WaveformMouseWheelVideoPositionSteps, _vm, nameof(_vm.SelectedWaveformMouseWheelVideoPositionStep))),
+            MakeCheckboxSetting(Se.Language.Options.Settings.WaveformCenterVideoPositionAlsoWhenPaused, nameof(_vm.WaveformCenterVideoPositionAlsoWhenPaused)),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformDrawGridLines, nameof(_vm.WaveformDrawGridLines)),
             new SettingsItem(Se.Language.Options.Settings.WaveformTextFontSize, () => UiUtil.MakeNumericUpDownInt(
                 10 ,

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -237,6 +237,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _waveformDrawGridLines;
     [ObservableProperty] private bool _waveformFocusOnMouseOver;
     [ObservableProperty] private bool _waveformCenterVideoPosition;
+    [ObservableProperty] private bool _waveformCenterVideoPositionAlsoWhenPaused;
 
     [ObservableProperty] private ObservableCollection<string> _waveformDrawStyles;
     [ObservableProperty] private string _selectedWaveformDrawStyle;
@@ -838,6 +839,7 @@ public partial class SettingsViewModel : ObservableObject
         WaveformDrawGridLines = Se.Settings.Waveform.DrawGridLines;
         WaveformFocusOnMouseOver = Se.Settings.Waveform.FocusOnMouseOver;
         WaveformCenterVideoPosition = Se.Settings.Waveform.CenterVideoPosition;
+        WaveformCenterVideoPositionAlsoWhenPaused = Se.Settings.Waveform.CenterVideoPositionAlsoWhenPaused;
         WaveformShowToolbar = Se.Settings.Waveform.ShowToolbar;
 
         if (Se.Settings.Waveform.WaveformDrawStyle == WaveformDrawStyle.Classic.ToString())
@@ -1575,6 +1577,7 @@ public partial class SettingsViewModel : ObservableObject
         Se.Settings.Waveform.DrawGridLines = WaveformDrawGridLines;
         Se.Settings.Waveform.FocusOnMouseOver = WaveformFocusOnMouseOver;
         Se.Settings.Waveform.CenterVideoPosition = WaveformCenterVideoPosition;
+        Se.Settings.Waveform.CenterVideoPositionAlsoWhenPaused = WaveformCenterVideoPositionAlsoWhenPaused;
         Se.Settings.Waveform.FocusTextBoxAfterInsertNew = WaveformFocusTextboxAfterInsertNew;
 
         if (SelectedWaveformDrawStyle == Se.Language.Waveform.WaveformDrawStyleClassic)

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -135,6 +135,7 @@ public class LanguageSettings
     public string ErrorBackgroundColor { get; set; }
     public string WaveformDrawGridLines { get; set; }
     public string WaveformCenterVideoPosition { get; set; }
+    public string WaveformCenterVideoPositionAlsoWhenPaused { get; set; }
     public string WaveformShowToolbar { get; set; }
     public string WaveformShowToolbarEdit { get; set; }
     public string WaveformShowToolbarEditLabel { get; set; }
@@ -467,6 +468,7 @@ public class LanguageSettings
         WaveformDrawGridLines = "Draw grid lines";
         WaveformFocusOnMouseOver = "Focus on mouse over";
         WaveformCenterVideoPosition = "Center video position";
+        WaveformCenterVideoPositionAlsoWhenPaused = "Center video position also while paused";
         WaveformShowToolbar = "Show toolbar";
         WaveformShowToolbarEdit = "Edit toolbar...";
         WaveformShowToolbarEditLabel = "Toolbar items";

--- a/src/ui/Logic/Config/SeWaveform.cs
+++ b/src/ui/Logic/Config/SeWaveform.cs
@@ -9,6 +9,11 @@ public class SeWaveform
 {
     public bool ShowToolbar { get; set; }
     public bool CenterVideoPosition { get; set; }
+
+    // SE 4 parity for the "Center" toggle: keep the play-head centered (and keep
+    // "select current subtitle" working) also while paused, so mouse-wheel
+    // scrubbing walks the waveform as one continuous strip.
+    public bool CenterVideoPositionAlsoWhenPaused { get; set; }
     public bool DrawGridLines { get; set; }
     public bool FocusTextBoxAfterInsertNew { get; set; }
     public int SpectrogramCombinedWaveformHeight { get; set; }


### PR DESCRIPTION
Fixes #12555.

### Problem

In SE 4 the waveform Center/lock toggle kept the play-head centered **regardless of playback state**, and the mouse wheel moved the video position instead of the view — so you could scrub through the audio as one continuous strip with the cursor pinned to the middle, and (combined with "select current subtitle") whatever line landed under the cursor was auto-selected. In v5 the Center toggle only centers during playback; while paused, wheel-scrubbing jumps half a page whenever the cursor leaves the view.

### Fix

New setting **"Center video position also while paused"** (Settings → Waveform/spectrogram, default off — no behavior change for existing users). When enabled together with the waveform Center toggle:

- **Continuous wheel scrubbing**: with "Mouse-wheel sets video position" on, every wheel step recenters the view so the waveform scrolls as one continuous strip (SE 4's locked mode) instead of jumping when the play-head exits the visible range.
- **Paused recentering**: any paused position change (waveform click, shortcuts) recenters the view on the play-head. Only actual position *changes* recenter — the view stays free to scroll around manually while the play-head is at rest, unlike SE 4's hard lock.
- **Scrub selection**: "Select current subtitle while playing" now also applies while scrubbing paused, selecting the line under the centered cursor. Change-gated so it doesn't steal back a selection the user just made in the grid.

To get the full SE 4 workflow from the issue: enable the waveform **Center** toggle, **Mouse-wheel sets video position**, **Select current subtitle while playing**, and the new option.

The select-current scan was extracted from the 50 ms timer into a shared `SelectCurrentSubtitleAtPlayhead` helper, used by both the playing and paused paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)