### PR TITLE
Update change log for v5.1.0-rc6

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,15 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.1.0-rc6 (17th of July 2026)
+
+* Waveform: new option "Center video position also while paused" (Settings - Waveform/spectrogram) - restores SE4's center/lock mode: with "Mouse-wheel sets video position" on, scrubbing keeps the cursor centered so the waveform scrolls as one continuous strip, and "select current subtitle" also applies while scrubbing paused - thx Asztec00
+* Open video from URL: the "Download yt-dlp" button is now only shown when an update is actually available - it was always visible, even with the latest yt-dlp installed
+* Open video from URL: add "Save..." button to the "Pick subtitle to download" window - saves the selected downloaded subtitle file as-is to a location of your choice
+* MP4 track picker: the "Export..." button now works - text tracks save as SubRip, VobSub image tracks export to Blu-ray .sup
+
+-----------------------------------------------------------------------------------------------------
+
 v5.1.0-rc5 (17th of July 2026)
 
 * Subtitle text box: tag coloring (HTML/ASSA) now uses a new native text box - same colors as before, but centering, IME/CJK input, right-to-left and the context menu work exactly like the normal text box, and toggling right-to-left no longer turns off tag coloring

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -17,7 +17,7 @@ public class Se
 {
     internal const int CurrentMacOsFontMigrationVersion = 1;
 
-    public static string Version { get; set; } = "v5.1.0-rc5";
+    public static string Version { get; set; } = "v5.1.0-rc6";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Change log entries for v5.1.0-rc6 — covers everything merged since the v5.1.0-rc5 tag (PRs #12559, #12560, #12562).

🤖 Generated with [Claude Code](https://claude.com/claude-code)