### PR TITLE
Restore live spell check in the syntax highlighting text box

### DIFF
--- a/src/ui/Controls/SyntaxHighlightingTextBox.cs
+++ b/src/ui/Controls/SyntaxHighlightingTextBox.cs
@@ -1,4 +1,6 @@
 using Avalonia.Controls;
+using Avalonia.Input;
+using Nikse.SubtitleEdit.Features.SpellCheck;
 using System;
 
 namespace Nikse.SubtitleEdit.Controls;
@@ -9,13 +11,62 @@ namespace Nikse.SubtitleEdit.Controls;
 /// It behaves exactly like a normal text box (alignment, selection, IME, context menu) -
 /// the coloring is done by <see cref="SyntaxHighlightingTextPresenter"/>, which the
 /// ":syntaxHighlighting" style in Styles.axaml swaps in for the default text presenter.
+/// The presenter also renders live spell check underlines when armed via
+/// <see cref="EnableSpellCheck"/>.
 /// </summary>
 public class SyntaxHighlightingTextBox : TextBox
 {
     protected override Type StyleKeyOverride => typeof(TextBox);
 
+    /// <summary>
+    /// The presenter from the applied template; registers itself when attached to the
+    /// visual tree so spell check refreshes can invalidate the cached text layout.
+    /// </summary>
+    internal SyntaxHighlightingTextPresenter? SyntaxPresenter { get; set; }
+
+    public ISpellCheckManager? SpellCheckManager { get; private set; }
+
+    public bool IsSpellCheckEnabled { get; private set; }
+
     public SyntaxHighlightingTextBox()
     {
         PseudoClasses.Add(":syntaxHighlighting");
+    }
+
+    public void EnableSpellCheck(ISpellCheckManager spellCheckManager)
+    {
+        SpellCheckManager = spellCheckManager;
+        IsSpellCheckEnabled = true;
+        RefreshSpellCheck();
+    }
+
+    public void DisableSpellCheck()
+    {
+        IsSpellCheckEnabled = false;
+        RefreshSpellCheck();
+    }
+
+    /// <summary>
+    /// Re-evaluates the underlines (e.g. after "Add to user dictionary" / "Ignore all").
+    /// </summary>
+    public void RefreshSpellCheck()
+    {
+        SyntaxPresenter?.InvalidateSpellCheck();
+    }
+
+    /// <summary>
+    /// The character index under the pointer, or null when there is no text layout yet.
+    /// </summary>
+    public int? GetCharIndexAtPoint(PointerEventArgs e)
+    {
+        var presenter = SyntaxPresenter;
+        if (presenter == null)
+        {
+            return null;
+        }
+
+        var point = e.GetPosition(presenter);
+        var hit = presenter.TextLayout.HitTestPoint(point);
+        return hit.TextPosition;
     }
 }

--- a/src/ui/Controls/SyntaxHighlightingTextPresenter.cs
+++ b/src/ui/Controls/SyntaxHighlightingTextPresenter.cs
@@ -4,6 +4,7 @@ using Avalonia.Media;
 using Avalonia.Media.Immutable;
 using Avalonia.Media.TextFormatting;
 using Avalonia.Utilities;
+using Nikse.SubtitleEdit.Features.SpellCheck;
 using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Collections.Generic;
@@ -54,6 +55,27 @@ public class SyntaxHighlightingTextPresenter : TextPresenter
     private IBrush? _cachedForeground;
     private FontFeatureCollection? _cachedFontFeatures;
 
+    // Live spell check: the red underline decoration matches SpellCheckUnderlineTransformer's
+    // (the AvaloniaEdit editor), so both editors underline identically.
+    private static readonly TextDecorationCollection SpellCheckUnderline = new()
+    {
+        new TextDecoration
+        {
+            Location = TextDecorationLocation.Underline,
+            Stroke = new ImmutableSolidColorBrush(Colors.Red),
+            StrokeThickness = 1.5,
+            StrokeLineCap = PenLineCap.Round,
+            StrokeThicknessUnit = TextDecorationUnit.FontRecommended,
+        },
+    };
+
+    // Underlined variants of the span properties they replace, keyed by the (cached, reused)
+    // originals. Hunspell results are cached per text: they are only recomputed when the text
+    // changes or InvalidateSpellCheck is called, not on every selection/caret layout pass.
+    private readonly Dictionary<TextRunProperties, GenericTextRunProperties> _underlinedPropertiesCache = new();
+    private string? _spellCheckedText;
+    private List<SpellCheckWord> _spellCheckedWords = new();
+
     private GenericTextRunProperties GetDefaultProperties(Typeface typeface)
     {
         if (_defaultProperties is null ||
@@ -72,6 +94,7 @@ public class SyntaxHighlightingTextPresenter : TextPresenter
                 foregroundBrush: Foreground,
                 fontFeatures: FontFeatures);
             _tokenPropertiesCache.Clear();
+            _underlinedPropertiesCache.Clear();
         }
 
         return _defaultProperties;
@@ -120,6 +143,13 @@ public class SyntaxHighlightingTextPresenter : TextPresenter
         var isPassword = PasswordChar != default(char) && !RevealPassword;
 
         var textStyleOverrides = isPassword ? null : BuildSyntaxSpans(text, typeface);
+
+        // Spell check underlines are skipped during IME composition: the combined text has the
+        // preedit string spliced in at the caret, so the word positions would not line up.
+        if (!isPassword && string.IsNullOrEmpty(preeditText))
+        {
+            textStyleOverrides = ApplySpellCheckUnderlines(textStyleOverrides, text, typeface);
+        }
 
         if (!string.IsNullOrEmpty(preeditText))
         {
@@ -201,6 +231,121 @@ public class SyntaxHighlightingTextPresenter : TextPresenter
         }
 
         return spans;
+    }
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+
+        // Register with the owning text box so it can invalidate the underlines (enable/disable,
+        // "Add to user dictionary", "Ignore all") and hit test words for the context menu.
+        if (TemplatedParent is SyntaxHighlightingTextBox box)
+        {
+            box.SyntaxPresenter = this;
+        }
+    }
+
+    /// <summary>
+    /// Drops the cached hunspell results and rebuilds the text layout - called when the spell
+    /// check state changes without the text changing.
+    /// </summary>
+    public void InvalidateSpellCheck()
+    {
+        _spellCheckedText = null;
+        _spellCheckedWords.Clear();
+        InvalidateTextLayout();
+    }
+
+    /// <summary>
+    /// Overlays the red spell check underline on every misspelled word, preserving the
+    /// underlying span's foreground (so a misspelled word inside a colored tag keeps its color).
+    /// </summary>
+    private List<ValueSpan<TextRunProperties>>? ApplySpellCheckUnderlines(List<ValueSpan<TextRunProperties>>? spans, string? text, Typeface typeface)
+    {
+        if (string.IsNullOrEmpty(text) ||
+            TemplatedParent is not SyntaxHighlightingTextBox { IsSpellCheckEnabled: true, SpellCheckManager: { } spellCheckManager })
+        {
+            return spans;
+        }
+
+        if (_spellCheckedText != text)
+        {
+            _spellCheckedText = text;
+            _spellCheckedWords = SpellCheckUnderlineTransformer.GetMisspelledWords(text, spellCheckManager);
+        }
+
+        if (_spellCheckedWords.Count == 0)
+        {
+            return spans;
+        }
+
+        spans ??= new List<ValueSpan<TextRunProperties>> { new(0, text.Length, GetDefaultProperties(typeface)) };
+
+        foreach (var word in _spellCheckedWords)
+        {
+            spans = OverlayUnderline(spans, word.Index, word.Length);
+        }
+
+        return spans;
+    }
+
+    /// <summary>
+    /// Splits the spans overlapping [start, start+length) and swaps the overlapped segments'
+    /// properties for underlined copies. Spans stay sorted and non-overlapping.
+    /// </summary>
+    private List<ValueSpan<TextRunProperties>> OverlayUnderline(List<ValueSpan<TextRunProperties>> spans, int start, int length)
+    {
+        var end = start + length;
+        var result = new List<ValueSpan<TextRunProperties>>(spans.Count + 2);
+
+        foreach (var span in spans)
+        {
+            var spanStart = span.Start;
+            var spanEnd = span.Start + span.Length;
+
+            if (spanEnd <= start || spanStart >= end)
+            {
+                result.Add(span);
+                continue;
+            }
+
+            if (spanStart < start)
+            {
+                result.Add(new ValueSpan<TextRunProperties>(spanStart, start - spanStart, span.Value));
+            }
+
+            var overlapStart = Math.Max(spanStart, start);
+            var overlapEnd = Math.Min(spanEnd, end);
+            result.Add(new ValueSpan<TextRunProperties>(overlapStart, overlapEnd - overlapStart, GetUnderlinedProperties(span.Value)));
+
+            if (spanEnd > end)
+            {
+                result.Add(new ValueSpan<TextRunProperties>(end, spanEnd - end, span.Value));
+            }
+        }
+
+        return result;
+    }
+
+    private GenericTextRunProperties GetUnderlinedProperties(TextRunProperties baseProperties)
+    {
+        if (!_underlinedPropertiesCache.TryGetValue(baseProperties, out var properties))
+        {
+            if (_underlinedPropertiesCache.Count > 256)
+            {
+                _underlinedPropertiesCache.Clear();
+            }
+
+            properties = new GenericTextRunProperties(
+                baseProperties.Typeface,
+                baseProperties.FontRenderingEmSize,
+                SpellCheckUnderline,
+                baseProperties.ForegroundBrush,
+                fontFeatures: _cachedFontFeatures);
+            _underlinedPropertiesCache[baseProperties] = properties;
+        }
+
+        return properties;
     }
 
     /// <summary>

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -16024,16 +16024,13 @@ public partial class MainViewModel :
 
         var dictionaryLoaded = _liveSpellCheckDictionaryFileName != null;
 
-        if (EditTextBox is TextEditorWrapper wrapper)
+        if (Se.Settings.Appearance.SubtitleTextBoxLiveSpellCheck && dictionaryLoaded)
         {
-            if (Se.Settings.Appearance.SubtitleTextBoxLiveSpellCheck && dictionaryLoaded)
-            {
-                wrapper.EnableSpellCheck(_spellCheckManager);
-            }
-            else
-            {
-                wrapper.DisableSpellCheck();
-            }
+            EditTextBox.EnableSpellCheck(_spellCheckManager);
+        }
+        else
+        {
+            EditTextBox.DisableSpellCheck();
         }
 
         SubtitleDataGridSyntaxHighlighting.SetSpellCheck(
@@ -16052,10 +16049,7 @@ public partial class MainViewModel :
     /// </summary>
     private void RefreshLiveSpellCheck()
     {
-        if (EditTextBox is TextEditorWrapper wrapper)
-        {
-            wrapper.RefreshSpellCheck();
-        }
+        EditTextBox.RefreshSpellCheck();
 
         foreach (var item in Subtitles)
         {
@@ -22653,8 +22647,8 @@ public partial class MainViewModel :
             // spelled correctly. It used to be nested inside the misspelled-word branch, so after
             // picking the right dictionary the words stopped being underlined and the menu item that
             // got you there disappeared with them.
-            if (EditTextBox is TextEditorWrapper wrapper &&
-                (Se.Settings.Appearance.SubtitleTextBoxLiveSpellCheck || Se.Settings.Appearance.SubtitleGridLiveSpellCheck) &&
+            var wrapper = EditTextBox;
+            if ((Se.Settings.Appearance.SubtitleTextBoxLiveSpellCheck || Se.Settings.Appearance.SubtitleGridLiveSpellCheck) &&
                 _lastTextEditorPointerArgs != null)
             {
                 // Insert spell check items at the beginning of the menu

--- a/src/ui/Features/Shared/TextBoxUtils/ITextBoxWrapper.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/ITextBoxWrapper.cs
@@ -1,4 +1,7 @@
 using Avalonia.Controls;
+using Avalonia.Input;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+using System.Collections.Generic;
 
 namespace Nikse.SubtitleEdit.Features.Shared.TextBoxUtils;
 
@@ -21,4 +24,13 @@ public interface ITextBoxWrapper
     void SelectAll();
     void ClearSelection();
     void SetAlignment(Avalonia.Media.TextAlignment alignment);
+
+    // Live spell check - a no-op for editors without underline support (plain TextBox).
+    void EnableSpellCheck(ISpellCheckManager spellCheckManager);
+    void DisableSpellCheck();
+    void RefreshSpellCheck();
+    bool IsSpellCheckEnabled { get; }
+    SpellCheckWord? GetWordAtPosition(PointerEventArgs e);
+    bool IsWordMisspelledAtOffset(int offset);
+    List<string>? GetSuggestionsForWordAtOffset(int offset);
 }

--- a/src/ui/Features/Shared/TextBoxUtils/TextBoxWrapper.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/TextBoxWrapper.cs
@@ -1,4 +1,10 @@
 using Avalonia.Controls;
+using Avalonia.Input;
+using Nikse.SubtitleEdit.Controls;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+using Nikse.SubtitleEdit.Logic;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Shared.TextBoxUtils;
 
@@ -98,5 +104,89 @@ public class TextBoxWrapper : ITextBoxWrapper
     public void SetAlignment(Avalonia.Media.TextAlignment alignment)
     {
         _textBox.TextAlignment = alignment;
+    }
+
+    // Live spell check works when the wrapped text box is a SyntaxHighlightingTextBox (the
+    // "Color tags" subtitle edit box); for a plain TextBox these are no-ops so the caller
+    // does not have to care which editor is active.
+
+    public void EnableSpellCheck(ISpellCheckManager spellCheckManager)
+    {
+        if (_textBox is SyntaxHighlightingTextBox box)
+        {
+            box.EnableSpellCheck(spellCheckManager);
+        }
+    }
+
+    public void DisableSpellCheck()
+    {
+        if (_textBox is SyntaxHighlightingTextBox box)
+        {
+            box.DisableSpellCheck();
+        }
+    }
+
+    public void RefreshSpellCheck()
+    {
+        if (_textBox is SyntaxHighlightingTextBox box)
+        {
+            box.RefreshSpellCheck();
+        }
+    }
+
+    public bool IsSpellCheckEnabled => _textBox is SyntaxHighlightingTextBox { IsSpellCheckEnabled: true };
+
+    public SpellCheckWord? GetWordAtOffset(int offset)
+    {
+        var text = Text;
+        if (string.IsNullOrEmpty(text) || offset < 0 || offset > text.Length)
+        {
+            return null;
+        }
+
+        return SpellCheckWordLists.Split(text).FirstOrDefault(w => offset >= w.Index && offset < w.Index + w.Length);
+    }
+
+    public SpellCheckWord? GetWordAtPosition(PointerEventArgs e)
+    {
+        if (_textBox is not SyntaxHighlightingTextBox box)
+        {
+            return null;
+        }
+
+        var index = box.GetCharIndexAtPoint(e);
+        return index == null ? null : GetWordAtOffset(index.Value);
+    }
+
+    public bool IsWordMisspelledAtOffset(int offset)
+    {
+        if (_textBox is not SyntaxHighlightingTextBox { IsSpellCheckEnabled: true, SpellCheckManager: { } spellCheckManager })
+        {
+            return false;
+        }
+
+        var word = GetWordAtOffset(offset);
+        if (word == null || string.IsNullOrWhiteSpace(word.Text))
+        {
+            return false;
+        }
+
+        return SpellCheckUnderlineTransformer.IsWordMisspelled(word, Text, spellCheckManager);
+    }
+
+    public List<string>? GetSuggestionsForWordAtOffset(int offset)
+    {
+        if (_textBox is not SyntaxHighlightingTextBox { SpellCheckManager: { } spellCheckManager })
+        {
+            return null;
+        }
+
+        var word = GetWordAtOffset(offset);
+        if (word == null || string.IsNullOrWhiteSpace(word.Text))
+        {
+            return null;
+        }
+
+        return spellCheckManager.GetSuggestions(word.Text);
     }
 }

--- a/src/ui/Logic/SpellCheckUnderlineTransformer.cs
+++ b/src/ui/Logic/SpellCheckUnderlineTransformer.cs
@@ -219,7 +219,22 @@ public class SpellCheckUnderlineTransformer : DocumentColorizingTransformer
     /// </summary>
     public bool IsWordMisspelled(SpellCheckWord word, string text)
     {
-        if (!_isEnabled || _spellCheckManager == null || string.IsNullOrWhiteSpace(word.Text))
+        if (!_isEnabled || _spellCheckManager == null)
+        {
+            return false;
+        }
+
+        return IsWordMisspelled(word, text, _spellCheckManager);
+    }
+
+    /// <summary>
+    /// Word-level misspelling check with the same special-pattern skipping (numbers, URLs,
+    /// words inside HTML/ASSA tags) as the underlines - shared by the AvaloniaEdit
+    /// transformer and the syntax highlighting text box.
+    /// </summary>
+    public static bool IsWordMisspelled(SpellCheckWord word, string text, ISpellCheckManager spellCheckManager)
+    {
+        if (string.IsNullOrWhiteSpace(word.Text))
         {
             return false;
         }
@@ -229,7 +244,40 @@ public class SpellCheckUnderlineTransformer : DocumentColorizingTransformer
             return false;
         }
 
-        return !_spellCheckManager.IsWordCorrect(word, text);
+        return !spellCheckManager.IsWordCorrect(word, text);
+    }
+
+    /// <summary>
+    /// The misspelled words of <paramref name="text"/> with their positions, using the same
+    /// filtering as the underline rendering.
+    /// </summary>
+    public static List<SpellCheckWord> GetMisspelledWords(string text, ISpellCheckManager spellCheckManager)
+    {
+        var result = new List<SpellCheckWord>();
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return result;
+        }
+
+        foreach (var word in SpellCheckWordLists.Split(text))
+        {
+            if (string.IsNullOrWhiteSpace(word.Text) || word.Length < 2)
+            {
+                continue;
+            }
+
+            if (IsSpecialPattern(word, text))
+            {
+                continue;
+            }
+
+            if (!spellCheckManager.IsWordCorrect(word, text))
+            {
+                result.Add(word);
+            }
+        }
+
+        return result;
     }
 
     /// <summary>


### PR DESCRIPTION
### Problem

The new native syntax highlighting text box (ab2900ced) routes through `TextBoxWrapper`, but live spell check was implemented only on `TextEditorWrapper` (the AvaloniaEdit editor) — every call site was gated on `is TextEditorWrapper`. So with "Color tags" enabled, the red underlines and the context menu spell check items (suggestions, add to user dictionary, ignore all) silently stopped working in the subtitle edit box.

### Fix

- **Underlines**: `SyntaxHighlightingTextPresenter` overlays the red underline decoration on misspelled words while preserving the underlying syntax colors (a misspelled word inside a colored tag keeps its tag color). The decoration matches `SpellCheckUnderlineTransformer`'s, so both editors underline identically. Hunspell results are cached per text — selection/caret layout passes don't re-check, only actual text changes do. Underlines are skipped during IME preedit, where the combined text's indices wouldn't line up.
- **Context menu**: `SyntaxHighlightingTextBox` gains `EnableSpellCheck`/`DisableSpellCheck`/`RefreshSpellCheck` and pointer→character hit testing via the presenter's text layout, so right-clicking a misspelled word shows suggestions/add/ignore again.
- **Shared scanning**: the word scan with special-pattern skipping (numbers, URLs, words inside HTML/ASSA tags) moved into statics on `SpellCheckUnderlineTransformer`, shared by both editors.
- **API**: the spell check surface moved into `ITextBoxWrapper` (no-ops for a plain `TextBox`), and `MainViewModel` uses the interface instead of type-checking for `TextEditorWrapper` — arming, refreshing, and the context menu now work regardless of which editor is active.

Manual test: enable "Color tags" + live spell check, type a misspelled word → red underline over the colored text; right-click it → suggestions/add to dictionary/ignore all; "Ignore all" clears the underline immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)