### PR TITLE
RTL hit testing: resolve clicks on tag elements from the line geometry

### DIFF
--- a/src/AvaloniaEdit/AvaloniaEdit/Rendering/VisualLine.cs
+++ b/src/AvaloniaEdit/AvaloniaEdit/Rendering/VisualLine.cs
@@ -538,14 +538,26 @@ namespace AvaloniaEdit.Rendering
                 }
             }
 
+            // A right-to-left line whose first strong character comes from a drawable object run
+            // (the atomic tag elements used in RTL mode) resolves to a left-to-right embedding
+            // level inside Avalonia: the run carries no text, so the formatter feeds the bidi
+            // algorithm a run of 'a' on its behalf, and rule P2/P3 latches onto that as the first
+            // strong character regardless of the paragraph direction. Reordering still uses the
+            // paragraph level, so the line renders correctly, but every direction-dependent hit
+            // API on it answers with the left-to-right convention, which puts clicks on a tag
+            // several columns away from the tag. GetTextBounds is unaffected, so resolve the hit
+            // from the geometry instead. Left-to-right lines keep using the fast path.
+            if (TextView.FlowDirection == FlowDirection.RightToLeft
+                && TryGetVisualColumnFromBounds(textLine, xPos, out var columnFromBounds))
+            {
+                return columnFromBounds;
+            }
+
             var ch = textLine.GetCharacterHitFromDistance(xPos);
 
             if (ch.TrailingLength > 0)
             {
-                // Avalonia resolves hits on drawable object runs (e.g. the atomic tag elements
-                // used in right-to-left mode) with the left-to-right trailing convention even in
-                // right-to-left lines, which inverts which half of the object maps to which
-                // side. Snap to whichever caret boundary is actually nearer to the position.
+                // Snap to whichever caret boundary is actually nearer to the position.
                 var leadingColumn = ch.FirstCharacterIndex;
                 var trailingColumn = ch.FirstCharacterIndex + ch.TrailingLength;
                 var leadingX = textLine.GetDistanceFromCharacterHit(new CharacterHit(leadingColumn));
@@ -554,6 +566,67 @@ namespace AvaloniaEdit.Rendering
             }
 
             return ch.FirstCharacterIndex;
+        }
+
+        /// <summary>
+        /// Resolves a horizontal position to a visual column using the columns' rendered bounds,
+        /// for right-to-left lines where Avalonia's character-hit APIs answer with the wrong
+        /// directional convention (see <see cref="GetVisualColumn(TextLine, double, bool)"/>).
+        /// Returns false when the position is not over any column, leaving the caller on its
+        /// normal path.
+        /// </summary>
+        private bool TryGetVisualColumnFromBounds(TextLine textLine, double xPos, out int column)
+        {
+            column = 0;
+
+            // textLine.Length counts the end-of-line marker run, which is not a real text column
+            // and is laid out at the paragraph origin; including it would corrupt both the hit
+            // test and the neighbour direction check below.
+            var firstColumn = textLine.FirstTextSourceIndex;
+            var endColumn = Math.Min(firstColumn + textLine.Length, VisualLengthWithEndOfLineMarker);
+
+            for (var i = firstColumn; i < endColumn; i++)
+            {
+                if (!TryGetColumnRect(textLine, i, out var rect)
+                    || xPos < rect.Left || xPos > rect.Right)
+                {
+                    continue;
+                }
+
+                // Which edge is this column's logical start cannot be read from
+                // TextBounds.FlowDirection, which is derived from the same mis-resolved embedding
+                // level. The rendered order is reliable, so take the direction from a neighbour:
+                // a column laid out to the left of this one means this one reads right-to-left.
+                var readsRightToLeft = true;
+                if (i + 1 < endColumn && TryGetColumnRect(textLine, i + 1, out var nextRect))
+                {
+                    readsRightToLeft = nextRect.Left < rect.Left;
+                }
+                else if (i > firstColumn && TryGetColumnRect(textLine, i - 1, out var previousRect))
+                {
+                    readsRightToLeft = previousRect.Left > rect.Left;
+                }
+
+                var leadingX = readsRightToLeft ? rect.Right : rect.Left;
+                var trailingX = readsRightToLeft ? rect.Left : rect.Right;
+
+                column = Math.Abs(xPos - leadingX) <= Math.Abs(xPos - trailingX) ? i : i + 1;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryGetColumnRect(TextLine textLine, int column, out Rect rect)
+        {
+            foreach (var bounds in textLine.GetTextBounds(column, 1))
+            {
+                rect = bounds.Rectangle;
+                return true;
+            }
+
+            rect = default;
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
Follow-up to #12553, against the same branch since the change is inside the vendored AvaloniaEdit.

`TaggedLine_DragFromRightEdge_SelectsFromDocumentStart` is currently red on this branch. It is not a bad test: it found a real bug. Worth knowing up front that the PR's CI never got to run it, because AppVeyor reports "unable to build non-mergeable pull request" over the `change-log.txt` conflict, so the failure is invisible from here.

## What is wrong

A line that starts with a formatting tag resolves to a **left-to-right embedding level** inside Avalonia, even when the paragraph is right-to-left.

The tag is a drawable run carrying no text. `TextFormatterImpl.ShapeTextRuns` needs characters to run the bidi algorithm over, so for a run with empty text it substitutes `new string('a', textRun.Length)`. `'a'` is a strong left-to-right character, and `BidiAlgorithm.ResolveEmbeddingLevel` implements Unicode rule P2/P3: it returns on the **first strong character** and does not consult `ParagraphEmbeddingLevel` at all. So `{\an8}` at the start of the line decides the resolved direction for the whole line.

Reordering still uses the paragraph level, which is why the line renders correctly and `TaggedLine_TagsKeepLiteralLayout` passes. But `_resolvedFlowDirection` is what `GetDistanceFromCharacterHit` and `GetCharacterHitFromDistance` consult for drawable runs (`GetDirection` cannot infer direction from a non-shaped run, so it falls back to it), and both then answer with the left-to-right convention.

## What that does to the user

On the test's own line, `{\an8}<i>هذا اختبار.</i>`, the tag renders at x 343 to 400. Every click on it lands several columns away:

| click x | resolved offset | expected |
|--------:|----------------:|---------:|
| 396 | 6 | 0 |
| 390 | 9 | 0 or 6 |
| 370 | 10 | 0 or 6 |
| 350 | 14 | 0 or 6 |

So clicking the tag puts the caret in the middle of the Arabic text. The existing snap in `GetVisualColumn` only runs when `TrailingLength > 0`; these hits come back with `trail = 0`, so it never engages.

## The fix

`GetTextBounds` is not affected by the mis-resolved level (the geometry is built from the reordered runs), so for right-to-left lines the hit is resolved from the rendered bounds instead: find the column whose rectangle contains the position, then snap to the nearer caret boundary. Left-to-right lines keep the existing fast path untouched.

One detail worth flagging: the column's reading direction is deliberately **not** read from `TextBounds.FlowDirection`, because that is derived from the same wrong embedding level. It reports `LeftToRight` for the Arabic columns in this line. The rendered order is reliable, so the direction comes from where the neighbouring column sits. The scan is also bounded by `VisualLengthWithEndOfLineMarker`, since `textLine.Length` counts the end-of-line marker run, which is laid out at the paragraph origin and otherwise corrupts both the containment test and the neighbour check.

After the change, the same clicks resolve to 0, 0, 6, 6, and a click at the far left (the logical end in RTL) resolves to the end of the document rather than to the last tag.

## Verification

- The failing test passes. Reverting only this change makes it fail again, so the test is pinning this and nothing else.
- Full UI suite 709/709, whole solution 1456 tests, 0 warnings.
- Also checked and found **not** to be a problem, so no change made: I suspected `BackgroundGeometryBuilder` line 255 (`left = line.Width`) would paint selection on the wrong side of a wrapped RTL line, since it uses a width where an x position is wanted and ignores `TextLine.Start`. A pixel probe over a three-line wrapped Arabic selection shows the highlight tracking the text correctly, so it does not manifest in practice. It is still off by `Start` on paper, and only harmless because the rectangle overlaps text that is already selected.
- `TextLine.Start` semantics used by `IsPastLineEnd` were confirmed against Avalonia 12.1.0's `GetParagraphOffsetX`: it is a non-negative offset from the left edge in every alignment, and `TextAlignment.Start` normalizes to `Right` for RTL, so the ink really does span `[Start, Start + width]` and the left edge really is the logical end.

The underlying Avalonia behaviour (P2/P3 latching onto a substituted `'a'` from a text-less run) looks worth reporting upstream separately. A drawable run has no inherent direction, so arguably it should not be able to decide the paragraph's.
