### PR TITLE
Fix common errors: drop a stale Invert mention from a comment

### DIFF
--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -384,7 +384,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
 
         RebuildVisibleFixes();
         // Refresh the "N fixes, M selected" line so it reflects the newly active category,
-        // matching what Select all and Invert now act on (#12377, follow-up to #12408).
+        // matching what the Select all toggle acts on (#12377, follow-up to #12408).
         UpdateFixesSummary();
     }
 


### PR DESCRIPTION
Tidying up after my own #12435.

That PR replaced the Invert selection button on the fixes list with the Select all / none toggle, but a comment in `SetFixFilter` still says the summary matches "what Select all and Invert now act on". There is no Invert for the fixes list any more, so the comment sends the next reader looking for a command that does not exist.

The Invert selection button on the **rules** list in step 1 is a different command (`RulesInverseSelectedCommand`) and is untouched.

Comment only, no behaviour change. Builds clean, UI suite 689/689.
