### PR TITLE
Allow inserting a subtitle file anywhere, not only at the end

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1016,6 +1016,7 @@
     "xShotChangedLoaded": "{0} shot changes loaded",
     "youtubeDlDownloadedSuccessfully": "\"yt-dlp\" downloaded successfully.",
     "youtubeDlNotInstalledDownloadNow": "\"yt-dlp\" is not installed and is required for playing online videos.\n\nDownload now?",
+    "promptInsertSubtitleOverlap": "The inserted lines will overlap existing lines.\n\nInsert anyway?",
     "youtubeDlOutdatedDownloadNow": "\"yt-dlp\" is outdated and may not work with online videos.\n\nDownload the current version now?",
     "insertUnicodeSymbol": "Insert Unicode symbol",
     "trimmedXLines": "Trimmed {0} subtitle lines",

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -361,6 +361,10 @@ public partial class MainViewModel :
     // position *changes*, so they track the last seen play-head position between timer ticks.
     private double _pausedCenterLastSeconds = -1;
     private double _pausedSelectLastSeconds = -1;
+
+    // The waveform position that was right-clicked when the waveform context menu opened -
+    // used to anchor "Insert subtitle file at video position..." at the clicked spot.
+    private double? _waveformContextMenuSeconds;
     private const double PlayheadMaxCorrectionFraction = 0.2; // cap catch-up to ~1.2x speed (vs the forward step)
     private const double PlayheadMaxForwardStepSeconds = 0.05; // cap one tick's advance so a starved tick can't lurch
     private const double PlayheadFreezeHoldSeconds = 0.12; // if mpv's clock hasn't moved this long, it's frozen: hold
@@ -3345,8 +3349,29 @@ public partial class MainViewModel :
             return;
         }
 
-        var videoPosition = vp.Position;
+        // Anchor the file at the right-clicked waveform position when opened from the waveform
+        // context menu; the current video position is the fallback (SE4 behavior).
+        var videoPosition = _waveformContextMenuSeconds ?? vp.Position;
+
+        // SE4 parity: inserting mid-video may collide with existing lines - warn instead of
+        // silently interleaving overlapping lines.
         var firstStartTime = subtitle.Paragraphs[0].StartTime.TotalMilliseconds;
+        var hasOverlap = subtitle.Paragraphs.Select(p => new
+        {
+            Start = p.StartTime.TotalMilliseconds - firstStartTime + videoPosition * 1000.0,
+            End = p.EndTime.TotalMilliseconds - firstStartTime + videoPosition * 1000.0,
+        }).Any(n => Subtitles.Any(p =>
+            n.Start < p.EndTime.TotalMilliseconds && n.End > p.StartTime.TotalMilliseconds));
+        if (hasOverlap)
+        {
+            var answer = await MessageBox.Show(Window, Se.Language.General.Warning,
+                Se.Language.Main.PromptInsertSubtitleOverlap, MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+            if (answer != MessageBoxResult.Yes)
+            {
+                return;
+            }
+        }
+
         foreach (var p in subtitle.Paragraphs)
         {
             var newParagraph = new SubtitleLineViewModel(p, SelectedSubtitleFormat);
@@ -3385,11 +3410,15 @@ public partial class MainViewModel :
             return;
         }
 
-        // Shift the inserted lines so the first one starts 1 second after the selected (last) line,
-        // mirroring the binary-edit "insert subtitle after current line" behaviour and avoiding overlap.
+        // Keep the file's own time codes so pre-timed subtitles land at their real positions
+        // (SE4 behavior - e.g. inserting finished song lyrics midway through a concert video,
+        // see discussion #11744). Only shift when the file would start before the selected line
+        // ends, and then just enough to clear it plus the minimum gap.
         var oldLastTime = selectedItem.EndTime.TotalMilliseconds;
         var newFirstTime = subtitle.Paragraphs[0].StartTime.TotalMilliseconds;
-        var timeOffset = oldLastTime - newFirstTime + 1000;
+        var timeOffset = newFirstTime < oldLastTime
+            ? oldLastTime - newFirstTime + Se.Settings.General.MinimumBetweenLines.Milliseconds
+            : 0;
         foreach (var p in subtitle.Paragraphs)
         {
             var newParagraph = new SubtitleLineViewModel(p, SelectedSubtitleFormat);
@@ -19345,8 +19374,9 @@ public partial class MainViewModel :
             IsSubtitleGridDataMenuVisible = true;
             IsMergeWithNextOrPreviousVisible = SubtitleGrid.SelectedItems.Count == 1;
             IsInsertLineNoSelectionVisible = false;
-            // Only on the last line, single selection — like SE4's "insert subtitle file after this line".
-            IsInsertSubtitleFileAfterLineVisible = SubtitleGrid.SelectedItems.Count == 1 && idx == count - 1;
+            // Any single selected line, not only the last - a pre-timed file keeps its own time
+            // codes, so inserting midway is a normal workflow (discussion #11744).
+            IsInsertSubtitleFileAfterLineVisible = SubtitleGrid.SelectedItems.Count == 1;
 
             if (IsFormatAssa || IsFormatSsa)
             {
@@ -22772,6 +22802,10 @@ public partial class MainViewModel :
 
     public void AudioVisualizerFlyoutMenuOpening(object sender, AudioVisualizer.ContextEventArgs e)
     {
+        // Remembered so "Insert subtitle file at video position..." anchors the file at the
+        // right-clicked waveform position instead of wherever the play-head happens to be.
+        _waveformContextMenuSeconds = e.PositionInSeconds;
+
         MenuItemAudioVisualizerInsertNewSelection.IsVisible = false;
         MenuItemAudioVisualizerPasteNewSelection.IsVisible = false;
         MenuIteminsertSubtitleFileAtPositionMenuItem.IsVisible = false;
@@ -22805,12 +22839,10 @@ public partial class MainViewModel :
         var selectedIdx = SubtitleGrid.SelectedIndex;
         var isLast = selectedIdx >= 0 && selectedIdx == Subtitles.Count - 1;
 
+        // Available anywhere on the timeline, not only past the last subtitle - the insert
+        // warns about overlaps and pre-timed files are commonly inserted midway (#11744).
         var vp = GetVideoPlayerControl();
-        if (vp != null && !string.IsNullOrEmpty(_videoFileName))
-        {
-            var lastSeconds = Subtitles.LastOrDefault()?.EndTime.TotalSeconds ?? 0;
-            MenuIteminsertSubtitleFileAtPositionMenuItem.IsVisible = vp.Position > lastSeconds;
-        }
+        MenuIteminsertSubtitleFileAtPositionMenuItem.IsVisible = vp != null && !string.IsNullOrEmpty(_videoFileName);
 
         if (subtitlesAtPosition.Count > 0)
         {

--- a/src/ui/Logic/Config/Language/Main/LanguageMain.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMain.cs
@@ -85,6 +85,7 @@ public class LanguageMain
     public string XShotChangedLoaded { get; set; }
     public string YoutubeDlDownloadedSuccessfully { get; set; }
     public string YoutubeDlNotInstalledDownloadNow { get; set; }
+    public string PromptInsertSubtitleOverlap { get; set; }
     public string YoutubeDlOutdatedDownloadNow { get; set; }
     public string InsertUnicodeSymbol { get; set; }
     public string TrimmedXLines { get; set; }
@@ -213,6 +214,7 @@ public class LanguageMain
         XShotChangedLoaded = "{0} shot changes loaded";
         YoutubeDlDownloadedSuccessfully = "\"yt-dlp\" downloaded successfully.";
         YoutubeDlNotInstalledDownloadNow = "\"yt-dlp\" is not installed and is required for playing online videos.\n\nDownload now?";
+        PromptInsertSubtitleOverlap = "The inserted lines will overlap existing lines.\n\nInsert anyway?";
         YoutubeDlOutdatedDownloadNow = "\"yt-dlp\" is outdated and may not work with online videos.\n\nDownload the current version now?";
         InsertUnicodeSymbol = "Insert Unicode symbol";
         TrimmedXLines = "Trimmed {0} subtitle lines";


### PR DESCRIPTION
Addresses point 1 from [discussion #11744](https://github.com/SubtitleEdit/subtitleedit/discussions/11744#discussioncomment-17672309): inserting a pre-prepared subtitle file midway (e.g. finished song lyrics for a concert video) worked in SE4 but v5 only offered it after the last line.

### Subtitle grid

- "Insert subtitle after current line..." now shows for **any** single selected line, not only the last one.
- SE4 timing semantics restored: the inserted file **keeps its own time codes** so pre-timed lines land at their real positions (this is the "automatically arranged according to the timing" behavior from the discussion). It is only shifted when the file would start before the selected line ends — and then just enough to clear it plus the minimum gap. Previously it was always force-shifted to selected line end + 1 second.
- Lines are inserted in chronological order, so they interleave correctly with the following lines.

### Waveform

- "Insert subtitle file at video position..." now shows **anywhere** on the timeline (previously only when the position was past the last subtitle).
- It anchors the file at the **right-clicked waveform position** instead of wherever the play-head happens to be.
- SE4 parity: warns with a Yes/No prompt before inserting lines that would overlap existing ones (new `PromptInsertSubtitleOverlap` language string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)