### PR TITLE
Remember last-used speech-to-text language

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -251,7 +251,15 @@ public partial class SpeechToTextViewModel : ObservableObject
         SelectedEngine = Engines[0];
 
         Languages = new ObservableCollection<WhisperLanguage>(GetEngineLanguages(GetEffectiveSelectedEngine()));
-        SelectedLanguage = PickDefaultLanguage(Languages);
+
+        // Restore the last-used language (SE4 behavior, #11744) - EngineChanged keeps the
+        // current selection on engine switches, so the initial selection must already be the
+        // remembered one, not the English default.
+        var savedLanguageCode = Se.Settings.Tools.AudioToText.WhisperLanguageCode;
+        SelectedLanguage = (string.IsNullOrEmpty(savedLanguageCode)
+                               ? null
+                               : Languages.FirstOrDefault(p => p.Code == savedLanguageCode))
+                           ?? PickDefaultLanguage(Languages);
 
         Models = new ObservableCollection<SpeechToTextModelDisplay>();
 
@@ -4264,16 +4272,21 @@ public partial class SpeechToTextViewModel : ObservableObject
             Languages.Add(l);
         }
 
-        var savedCode = Se.Settings.Tools.AudioToText.WhisperLanguageCode;
+        // Keep the user's current in-session choice when switching engine/backend - jumping
+        // back to the last *saved* language on every settings change forced the user to
+        // re-pick the language each time (#11744). The saved code is only the fallback when
+        // the new engine does not offer the current language.
         WhisperLanguage? language = null;
-        if (!string.IsNullOrEmpty(savedCode))
+        if (SelectedLanguage is { } prev)
         {
-            language = Enumerable.FirstOrDefault<WhisperLanguage>(Languages, p => p.Code == savedCode);
+            language = Enumerable.FirstOrDefault<WhisperLanguage>(Languages, p => p.Code == prev.Code)
+                       ?? Enumerable.FirstOrDefault<WhisperLanguage>(Languages, p => string.Equals(p.Name, prev.Name, StringComparison.OrdinalIgnoreCase));
         }
 
-        if (language == null && SelectedLanguage is { } prev)
+        var savedCode = Se.Settings.Tools.AudioToText.WhisperLanguageCode;
+        if (language == null && !string.IsNullOrEmpty(savedCode))
         {
-            language = Enumerable.FirstOrDefault<WhisperLanguage>(Languages, p => string.Equals(p.Name, prev.Name, StringComparison.OrdinalIgnoreCase));
+            language = Enumerable.FirstOrDefault<WhisperLanguage>(Languages, p => p.Code == savedCode);
         }
 
         SelectedLanguage = language ?? PickDefaultLanguage(Languages);
@@ -4706,7 +4719,12 @@ public partial class SpeechToTextViewModel : ObservableObject
         _audioClipsAutoStart = autoStart;
         ResultAudioClips = audioClips.Select(ac => new AudioClip(ac)).ToList();
 
-        if (language != null)
+        // The remembered last-used language wins (SE4 behavior, #11744): the language
+        // auto-detected from the selected lines' existing text is only used before any
+        // transcription has been run - it must not override the user's choice on every run.
+        var savedCode = Se.Settings.Tools.AudioToText.WhisperLanguageCode;
+        var hasRememberedLanguage = !string.IsNullOrEmpty(savedCode) && Languages.Any(p => p.Code == savedCode);
+        if (language != null && !hasRememberedLanguage)
         {
             var match = Languages.FirstOrDefault(p => p.Code == language)
                         ?? Languages.FirstOrDefault(p => string.Equals(p.Name, language, StringComparison.OrdinalIgnoreCase));


### PR DESCRIPTION
Addresses point 2 from [discussion #11744](https://github.com/SubtitleEdit/subtitleedit/discussions/11744#discussioncomment-17672309): the speech-to-text input language kept resetting — "Every time you adjust the recognition settings, you have to manually adjust the target language as well; there's no longer a feature to remember the last selection (in 4.x, it would remember which target language was used last time)."

Three separate causes, all fixed in `SpeechToTextViewModel`:

1. **Window open**: the constructor selected the English default; the saved `WhisperLanguageCode` was only applied later via `EngineChanged`. The remembered language is now restored directly when the language list is first built.
2. **Engine/backend switch**: `EngineChanged` preferred the last *saved* code over the user's current in-session selection, so changing any recognition setting jumped the language back to whatever the previous transcription used. The current selection now wins (matched by code, then name); the saved code is only the fallback when the new engine doesn't offer that language.
3. **Selected lines flow**: `InitializeBatch` force-overrode the selection with the language auto-detected from the selected lines' existing text on every run — this is the "automatically locked" part of the report. The auto-detected language is now only used when no transcription has ever been run (no remembered language yet); after that, the remembered choice wins.

The language is persisted on transcribe (existing `SaveSettings` path), so "last used" means the last actual transcription — same as SE4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)