### PR TITLE
Performance: three libse micro-optimizations (verified with BenchmarkDotNet)

### DIFF
--- a/src/libse/Common/AssaResampler.cs
+++ b/src/libse/Common/AssaResampler.cs
@@ -185,7 +185,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         private static string FixMethodFourParameters(decimal sourceWidth, decimal targetWidth, decimal sourceHeight, decimal targetHeight, string input, string tag)
         {
-            var regex = new Regex("\\\\" + tag + "\\s*\\(\\s*[-+]?\\d+[\\.\\d+]*\\s*,\\s*[-+]?\\d+[\\.\\d+]*\\s*,\\s*[-+]?\\d+[\\.\\d+]*\\s*,\\s*[-+]?\\d+[\\.\\d+]*\\s*\\)");
+            var regex = GetCachedRegex("\\\\" + tag + "\\s*\\(\\s*[-+]?\\d+[\\.\\d+]*\\s*,\\s*[-+]?\\d+[\\.\\d+]*\\s*,\\s*[-+]?\\d+[\\.\\d+]*\\s*,\\s*[-+]?\\d+[\\.\\d+]*\\s*\\)");
             var s = input;
             var match = regex.Match(s);
             while (match.Success)
@@ -221,7 +221,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         private static string FixMethodSixParametersFourActive(decimal sourceWidth, decimal targetWidth, decimal sourceHeight, decimal targetHeight, string input, string tag)
         {
-            var regex = new Regex("\\\\" + tag + "\\s*\\(\\s*[-+]?\\d+[\\.\\d+]*\\s*,\\s*[-+]?\\d+[\\.\\d+]*\\s*,\\s*[-+]?\\d+[\\.\\d+]*\\s*,\\s*[-+]?\\d+[\\.\\d+]*\\s*,\\s*[-+]?\\d+[\\.\\d+]*\\s*,\\s*[-+]?\\d+[\\.\\d+]*\\s*\\)");
+            var regex = GetCachedRegex("\\\\" + tag + "\\s*\\(\\s*[-+]?\\d+[\\.\\d+]*\\s*,\\s*[-+]?\\d+[\\.\\d+]*\\s*,\\s*[-+]?\\d+[\\.\\d+]*\\s*,\\s*[-+]?\\d+[\\.\\d+]*\\s*,\\s*[-+]?\\d+[\\.\\d+]*\\s*,\\s*[-+]?\\d+[\\.\\d+]*\\s*\\)");
             var s = input;
             var match = regex.Match(s);
             while (match.Success)
@@ -261,7 +261,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         private static string FixMethodTwoParameters(decimal sourceWidth, decimal targetWidth, decimal sourceHeight, decimal targetHeight, string input, string tag)
         {
-            var regex = new Regex("\\\\" + tag + "\\s*\\(\\s*[-+]?\\d+[\\.\\d+]*\\s*,\\s*[-+]?\\d+[\\.\\d+]*\\s*\\)");
+            var regex = GetCachedRegex("\\\\" + tag + "\\s*\\(\\s*[-+]?\\d+[\\.\\d+]*\\s*,\\s*[-+]?\\d+[\\.\\d+]*\\s*\\)");
             var s = input;
             var match = regex.Match(s);
             while (match.Success)
@@ -291,7 +291,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         private static string FixTagWithNumber(decimal sourceHeight, decimal targetHeight, string input, string tag)
         {
-            var regex = new Regex("\\\\" + tag + "[-+]?\\d+[\\.\\d+]*[}\\\\]");
+            var regex = GetCachedRegex("\\\\" + tag + "[-+]?\\d+[\\.\\d+]*[}\\\\]");
             var s = input;
             var match = regex.Match(s);
             while (match.Success)

--- a/src/libse/Common/LanguageAutoDetect.cs
+++ b/src/libse/Common/LanguageAutoDetect.cs
@@ -1,5 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Core.DetectEncoding;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -11,11 +12,18 @@ namespace Nikse.SubtitleEdit.Core.Common
     public static class LanguageAutoDetect
     {
 
+        // One detection run probes ~40+ distinct word-list patterns - far more than fit in the
+        // built-in regex cache (Regex.CacheSize is 15), so with the static Regex.Matches API
+        // every AutoDetectGoogleLanguage call re-parsed every large alternation pattern from
+        // scratch. The word lists are fixed for the app lifetime, so cache compiled instances.
+        private static readonly ConcurrentDictionary<string, Regex> WordCountRegexCache = new ConcurrentDictionary<string, Regex>();
+
         private static int GetCount(string text, params string[] words)
         {
-            var options = RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture;
             var pattern = "\\b(" + string.Join("|", words) + ")\\b";
-            return Regex.Matches(text, pattern, options).Count;
+            var regex = WordCountRegexCache.GetOrAdd(pattern, p =>
+                new Regex(p, RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.Compiled));
+            return regex.Matches(text).Count;
         }
 
         private static int GetCountContains(string text, params string[] words)
@@ -23,7 +31,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             int count = 0;
             foreach (var w in words)
             {
-                var regEx = new Regex(w);
+                var regEx = WordCountRegexCache.GetOrAdd(w, p => new Regex(p, RegexOptions.Compiled));
                 count += regEx.Matches(text).Count;
             }
             return count;

--- a/src/libse/SubtitleFormats/SubtitleFormat.cs
+++ b/src/libse/SubtitleFormats/SubtitleFormat.cs
@@ -397,7 +397,30 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public bool IsFrameBased => !IsTimeBased;
 
-        public string FriendlyName => $"{Name} ({Extension})";
+        private string _friendlyName;
+        private string _friendlyNameExtension;
+
+        /// <summary>
+        /// "Name (Extension)" - cached because it is accessed in loops over all ~300 formats
+        /// (FromName, GetSubtitleFormatByFriendlyName, format combo boxes) and interpolation
+        /// allocated a new string on every access. A few formats have a settings-dependent
+        /// Extension (MPlayer2, TimedText), so the cache is keyed on the Extension instance:
+        /// constants are interned and the settings values keep their instance until changed.
+        /// </summary>
+        public string FriendlyName
+        {
+            get
+            {
+                var extension = Extension;
+                if (_friendlyName == null || !ReferenceEquals(_friendlyNameExtension, extension))
+                {
+                    _friendlyNameExtension = extension;
+                    _friendlyName = $"{Name} ({extension})";
+                }
+
+                return _friendlyName;
+            }
+        }
 
         public int ErrorCount => _errorCount;
 


### PR DESCRIPTION
Three micro-optimizations, each verified with BenchmarkDotNet (v0.15.8, .NET 10): the "Old" column is the previous code's kernel replicated verbatim in the bench harness; "New" calls the actual patched libse code.

| Benchmark (per operation) | Old | New | Speedup | Alloc old | Alloc new |
|---|---|---|---|---|---|
| Language detection sweep (40+ word lists, 8 KB text) | 494.5 ms | 8.6 ms | **~58×** | 1,049 KB | 127 KB |
| ASSA resample, one tagged line (pos/org/move/clip) | 20.6 µs | 3.1 µs | **~6.7×** | 42.3 KB | 4.6 KB |
| Format lookup scan over all ~300 formats | 6.5 µs | 5.4 µs | ~1.2× | 22.2 KB | **0.5 KB (−98%)** |

### 1. `LanguageAutoDetect` — cache compiled regexes

One detection probes ~40+ large alternation patterns (hundreds of words each) via static `Regex.Matches`. That exceeds the built-in regex cache (`Regex.CacheSize` = 15), so **every** `AutoDetectGoogleLanguage` call re-parsed every pattern — on every subtitle open, live-spell-check re-arm, and speech-to-text setup. Now cached in a `ConcurrentDictionary` with `RegexOptions.Compiled` (bounded — the word lists are fixed for the app lifetime). `GetCountContains` gets the same treatment.

### 2. `AssaResampler` — stop compiling regexes per line

`FixMethodTwoParameters`/`FourParameters`/`SixParametersFourActive`/`FixTagWithNumber` built `new Regex("\\\\" + tag + …)` per call — 6–8 regex compiles **per dialogue line** during resolution resampling — even though the class already had a `GetCachedRegex` pattern cache these four sites bypassed. They now use it. (The "New" benchmark runs the full real `ResampleOverrideTagsPosition` including the value rewriting the "Old" kernel skips, so the real gain is understated if anything.)

### 3. `SubtitleFormat.FriendlyName` — cache the interpolation

`FriendlyName => $"{Name} ({Extension})"` allocated a new string on every access, and `FromName`/`GetSubtitleFormatByFriendlyName` loop it over all ~300 formats. Now cached per instance — **reference-guarded on `Extension`**, because `MPlayer2`/`TimedText*` extensions are settings-dependent and a naive cache would go stale when those settings change (constants are interned, settings values keep their instance until changed, so the guard is exact). The win here is allocation elimination; time is dominated by the string comparisons either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)