### PR TITLE
Fix network/proxy bugs: proxy password decoding, null proxy NRE, and translator request issues

### DIFF
--- a/src/libse/AutoTranslate/DeepLXTranslate.cs
+++ b/src/libse/AutoTranslate/DeepLXTranslate.cs
@@ -109,7 +109,7 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
 
         private static StringContent MakeContent(string text, string sourceLanguageCode, string targetLanguageCode)
         {
-            var input = "{ \"source_lang\": \"" + sourceLanguageCode + "\", \"target_lang\": \"" + targetLanguageCode + "\", \"text\": \"" + Json.EncodeJsonText(text.Trim(), "\\n") + "\" }]}";
+            var input = "{ \"source_lang\": \"" + sourceLanguageCode + "\", \"target_lang\": \"" + targetLanguageCode + "\", \"text\": \"" + Json.EncodeJsonText(text.Trim(), "\\n") + "\" }";
             var content = new StringContent(input, Encoding.UTF8);
             return content;
         }

--- a/src/libse/AutoTranslate/MicrosoftTranslator.cs
+++ b/src/libse/AutoTranslate/MicrosoftTranslator.cs
@@ -129,19 +129,22 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
 
         private static string GetAccessToken(string apiKey, string tokenEndpoint)
         {
-            using (var httpClient = DownloaderFactory.MakeHttpClient())
+            return Task.Run(async () =>
             {
-                httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                httpClient.DefaultRequestHeaders.TryAddWithoutValidation(SecurityHeaderName, apiKey);
-                var response = httpClient.PostAsync(tokenEndpoint, new StringContent(string.Empty)).Result;
-                var result = response.Content.ReadAsStringAsync().Result;
-                if (!response.IsSuccessStatusCode)
+                using (var httpClient = DownloaderFactory.MakeHttpClient())
                 {
-                    SeLogger.Error($"{StaticName}: Error getting access token via {tokenEndpoint} and API key {apiKey}: {result}");
-                }
+                    httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                    httpClient.DefaultRequestHeaders.TryAddWithoutValidation(SecurityHeaderName, apiKey);
+                    var response = await httpClient.PostAsync(tokenEndpoint, new StringContent(string.Empty)).ConfigureAwait(false);
+                    var result = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        SeLogger.Error($"{StaticName}: Error getting access token via {tokenEndpoint} and API key {apiKey}: {result}");
+                    }
 
-                return response.Content.ReadAsStringAsync().Result;
-            }
+                    return result;
+                }
+            }).GetAwaiter().GetResult();
         }
 
         private static List<TranslationPair> GetTranslationPairs()
@@ -151,14 +154,17 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                 return _translationPairs;
             }
 
-            using (var httpClient = DownloaderFactory.MakeHttpClient())
+            return Task.Run(async () =>
             {
-                httpClient.DefaultRequestHeaders.Add("user-agent", "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36");
-                httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json; charset=UTF-8");
-                var json = httpClient.GetStringAsync(LanguagesUrl).Result;
-                _translationPairs = FillTranslationPairsFromJson(json);
-                return _translationPairs;
-            }
+                using (var httpClient = DownloaderFactory.MakeHttpClient())
+                {
+                    httpClient.DefaultRequestHeaders.Add("user-agent", "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36");
+                    httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json; charset=UTF-8");
+                    var json = await httpClient.GetStringAsync(LanguagesUrl).ConfigureAwait(false);
+                    _translationPairs = FillTranslationPairsFromJson(json);
+                    return _translationPairs;
+                }
+            }).GetAwaiter().GetResult();
         }
 
         private static List<TranslationPair> FillTranslationPairsFromJson(string json)

--- a/src/libse/Grammar/LanguageToolsDictionary.cs
+++ b/src/libse/Grammar/LanguageToolsDictionary.cs
@@ -58,7 +58,7 @@ namespace Nikse.SubtitleEdit.Core.Grammar
                 new LanguageToolsDictionary
                 {
                     TwoLetterIsoCode = "it",
-                    Url = "https://github.com/languagetool-org/languagetool/raw/master/languagetool-language-modules/lt/src/main/resources/org/languagetool/rules/lt/grammar.xml",
+                    Url = "https://github.com/languagetool-org/languagetool/raw/master/languagetool-language-modules/it/src/main/resources/org/languagetool/rules/it/grammar.xml",
                     LocalName = "it.xml"
                 }
             };

--- a/src/libse/Http/DownloaderFactory.cs
+++ b/src/libse/Http/DownloaderFactory.cs
@@ -40,7 +40,7 @@ namespace Nikse.SubtitleEdit.Core.Http
             }
             else if (!string.IsNullOrEmpty(proxySettings.UserName) && !string.IsNullOrEmpty(proxySettings.ProxyAddress))
             {
-                var networkCredential = string.IsNullOrWhiteSpace(proxySettings.Domain) ? new NetworkCredential(proxySettings.UserName, proxySettings.Password) : new NetworkCredential(proxySettings.UserName, proxySettings.Password, proxySettings.Domain);
+                var networkCredential = string.IsNullOrWhiteSpace(proxySettings.Domain) ? new NetworkCredential(proxySettings.UserName, proxySettings.DecodePassword()) : new NetworkCredential(proxySettings.UserName, proxySettings.DecodePassword(), proxySettings.Domain);
                 var credentialCache = new CredentialCache
                 {
                     {

--- a/src/libse/Http/DownloaderFactory.cs
+++ b/src/libse/Http/DownloaderFactory.cs
@@ -35,7 +35,11 @@ namespace Nikse.SubtitleEdit.Core.Http
 
             if (proxySettings.UseDefaultCredentials)
             {
-                handler.Proxy.Credentials = CredentialCache.DefaultNetworkCredentials;
+                if (handler.Proxy != null)
+                {
+                    handler.Proxy.Credentials = CredentialCache.DefaultNetworkCredentials;
+                }
+
                 handler.Credentials = CredentialCache.DefaultNetworkCredentials;
             }
             else if (!string.IsNullOrEmpty(proxySettings.UserName) && !string.IsNullOrEmpty(proxySettings.ProxyAddress))


### PR DESCRIPTION
Fixes five verified bugs in libse's network/translation code, one commit each:

- **Decode base64 proxy password in `DownloaderFactory`** — `NetworkCredential` was built from the stored base64-encoded password, so authenticated proxies always got 407s via the default downloader (`LegacyDownloader` and `HttpClientHandlerExtensions` already call `DecodePassword()`).
- **Guard proxy credentials against null proxy** — `handler.Proxy.Credentials` threw `NullReferenceException` when *Use default credentials* was enabled without a proxy address, since `handler.Proxy` is only assigned when an address is set.
- **Fix Italian grammar rules URL** — the `it` entry pointed at the Lithuanian (`lt`) LanguageTool module path.
- **Fix malformed DeepLX request JSON** — the request body ended with a stray `]}`; it only worked because the DeepLX server's decoder ignores trailing tokens.
- **Make MicrosoftTranslator blocking calls deadlock-safe** — `GetAccessToken`/`GetTranslationPairs` blocked with `.Result` on `HttpClient` calls; they are reached from the synchronous `IAutoTranslator` members, so the awaited chains now run via `Task.Run(...)` with `ConfigureAwait(false)` to stay off any captured UI context.

Build succeeds; all 499 libse tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)