### PR TITLE
Fix alpha-channel check in IsImageOnlyTransparent and CopyRectangle rect math

### DIFF
--- a/src/libse/Common/NikseBitmap.cs
+++ b/src/libse/Common/NikseBitmap.cs
@@ -1178,7 +1178,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public NikseBitmap CopyRectangle(SKRect section)
         {
-            var rect = new SKRectI((int)section.Left, (int)section.Top, (int)section.Width, (int)section.Height);
+            var rect = new SKRectI((int)section.Left, (int)section.Top, (int)section.Right, (int)section.Bottom);
             return CopyRectangle(rect);
         }
 

--- a/src/libse/Common/NikseBitmap.cs
+++ b/src/libse/Common/NikseBitmap.cs
@@ -1186,12 +1186,12 @@ namespace Nikse.SubtitleEdit.Core.Common
         {
             if (section.Bottom > Height)
             {
-                section = new SKRectI(section.Left, section.Top, section.Width, Height - section.Top);
+                section = new SKRectI(section.Left, section.Top, section.Right, Height);
             }
 
-            if (section.Width + section.Left > Width)
+            if (section.Right > Width)
             {
-                section = new SKRectI(section.Left, section.Top, Width - section.Left, section.Height);
+                section = new SKRectI(section.Left, section.Top, Width, section.Bottom);
             }
 
             var newBitmapData = new byte[section.Width * section.Height * 4];

--- a/src/libse/Common/NikseBitmap.cs
+++ b/src/libse/Common/NikseBitmap.cs
@@ -1492,7 +1492,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         {
             for (int i = 0; i < _bitmapData.Length; i += 4)
             {
-                if (_bitmapData[i] != 0) // check alpha
+                if (_bitmapData[i + 3] != 0) // check alpha
                 {
                     return false;
                 }

--- a/src/libuilogic/Ocr/NikseBitmap2.cs
+++ b/src/libuilogic/Ocr/NikseBitmap2.cs
@@ -1547,7 +1547,7 @@ public class NikseBitmap2
     {
         for (var i = 0; i < _bitmapData.Length; i += 4)
         {
-            if (_bitmapData[i] != 0) // check alpha
+            if (_bitmapData[i + 3] != 0) // check alpha
             {
                 return false;
             }

--- a/tests/libse/Core/NikseBitmapTest.cs
+++ b/tests/libse/Core/NikseBitmapTest.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using SkiaSharp;
 
 namespace LibSETests.Core;
 
@@ -30,6 +31,104 @@ public class NikseBitmapTest
                     Assert.Equal(c1, c);
                 else
                     Assert.Equal(c2, c);
+            }
+        }
+    }
+
+    [Fact]
+    public void IsImageOnlyTransparentEmptyBitmapReturnsTrue()
+    {
+        var nbmp = new NikseBitmap(5, 5);
+        Assert.True(nbmp.IsImageOnlyTransparent());
+    }
+
+    [Fact]
+    public void IsImageOnlyTransparentOpaqueBlackReturnsFalse()
+    {
+        // Regression: the check used to read the blue byte instead of alpha, so an
+        // opaque all-black (or any blue-less) image was reported as fully transparent.
+        var nbmp = new NikseBitmap(5, 5);
+        for (int y = 0; y < nbmp.Height; y++)
+        {
+            for (int x = 0; x < nbmp.Width; x++)
+            {
+                nbmp.SetPixel(x, y, ColorUtils.FromArgb(255, 0, 0, 0));
+            }
+        }
+
+        Assert.False(nbmp.IsImageOnlyTransparent());
+    }
+
+    [Fact]
+    public void IsImageOnlyTransparentSingleVisiblePixelReturnsFalse()
+    {
+        var nbmp = new NikseBitmap(5, 5);
+        nbmp.SetPixel(3, 2, ColorUtils.FromArgb(1, 0, 0, 0));
+        Assert.False(nbmp.IsImageOnlyTransparent());
+    }
+
+    private static NikseBitmap MakeNumberedBitmap(int width, int height)
+    {
+        // Every pixel gets a unique opaque color derived from its coordinates.
+        var nbmp = new NikseBitmap(width, height);
+        for (int y = 0; y < height; y++)
+        {
+            for (int x = 0; x < width; x++)
+            {
+                nbmp.SetPixel(x, y, ColorUtils.FromArgb(255, x, y, 100));
+            }
+        }
+
+        return nbmp;
+    }
+
+    [Fact]
+    public void CopyRectangleOffsetRectCopiesCorrectPixels()
+    {
+        var source = MakeNumberedBitmap(10, 10);
+        var copy = source.CopyRectangle(new SKRectI(2, 3, 7, 8));
+
+        Assert.Equal(5, copy.Width);
+        Assert.Equal(5, copy.Height);
+        for (int y = 0; y < copy.Height; y++)
+        {
+            for (int x = 0; x < copy.Width; x++)
+            {
+                Assert.Equal(source.GetPixel(x + 2, y + 3), copy.GetPixel(x, y));
+            }
+        }
+    }
+
+    [Fact]
+    public void CopyRectangleRectExceedingBoundsIsClamped()
+    {
+        var source = MakeNumberedBitmap(10, 10);
+        var copy = source.CopyRectangle(new SKRectI(4, 5, 20, 20));
+
+        Assert.Equal(6, copy.Width);
+        Assert.Equal(5, copy.Height);
+        for (int y = 0; y < copy.Height; y++)
+        {
+            for (int x = 0; x < copy.Width; x++)
+            {
+                Assert.Equal(source.GetPixel(x + 4, y + 5), copy.GetPixel(x, y));
+            }
+        }
+    }
+
+    [Fact]
+    public void CopyRectangleSkRectOverloadMatchesSkRectI()
+    {
+        var source = MakeNumberedBitmap(10, 10);
+        var copy = source.CopyRectangle(new SKRect(2, 3, 7, 8));
+
+        Assert.Equal(5, copy.Width);
+        Assert.Equal(5, copy.Height);
+        for (int y = 0; y < copy.Height; y++)
+        {
+            for (int x = 0; x < copy.Width; x++)
+            {
+                Assert.Equal(source.GetPixel(x + 2, y + 3), copy.GetPixel(x, y));
             }
         }
     }

--- a/tests/libuilogic/Ocr/NikseBitmap2Tests.cs
+++ b/tests/libuilogic/Ocr/NikseBitmap2Tests.cs
@@ -1,0 +1,42 @@
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+using SkiaSharp;
+
+namespace LibUiLogicTests.Ocr;
+
+public class NikseBitmap2Tests
+{
+    [Fact]
+    public void IsImageOnlyTransparent_EmptyBitmap_ReturnsTrue()
+    {
+        var nbmp = new NikseBitmap2(5, 5);
+        Assert.True(nbmp.IsImageOnlyTransparent());
+    }
+
+    /// <summary>
+    /// Regression: the check used to read the blue byte instead of alpha, so an opaque
+    /// blue-less image (black, yellow, red, green text) was reported as fully transparent
+    /// and its line parts got dropped by the OCR image splitter.
+    /// </summary>
+    [Fact]
+    public void IsImageOnlyTransparent_OpaqueBlack_ReturnsFalse()
+    {
+        var nbmp = new NikseBitmap2(5, 5);
+        for (var y = 0; y < nbmp.Height; y++)
+        {
+            for (var x = 0; x < nbmp.Width; x++)
+            {
+                nbmp.SetPixel(x, y, new SKColor(0, 0, 0, 255));
+            }
+        }
+
+        Assert.False(nbmp.IsImageOnlyTransparent());
+    }
+
+    [Fact]
+    public void IsImageOnlyTransparent_SingleVisiblePixel_ReturnsFalse()
+    {
+        var nbmp = new NikseBitmap2(5, 5);
+        nbmp.SetPixel(3, 2, new SKColor(0, 0, 0, 1));
+        Assert.False(nbmp.IsImageOnlyTransparent());
+    }
+}


### PR DESCRIPTION
Verified fixes for latent bitmap bugs, plus tests pinning them:

- **`NikseBitmap.IsImageOnlyTransparent` tested the blue byte instead of alpha** (`_bitmapData[i]` in BGRA data) — an opaque blue-less image (black/yellow/red/green text) was reported as fully transparent, dropping line parts in the OCR image splitter. The identical bug in the OCR duplicate `NikseBitmap2` is fixed in the same commit.
- **`NikseBitmap.CopyRectangle(SKRect)` passed width/height into `SKRectI`'s (left, top, right, bottom) constructor** — correct only when the section starts at the origin. The clamping statements in the `SKRectI` overload had the same `Rectangle(x, y, w, h)` → `SKRectI(l, t, r, b)` porting bug and are fixed as a follow-up commit, matching the SE 4 original's clamp-to-bitmap intent.
- **New unit tests** pin the alpha-vs-blue regression (verified to fail against the old code) and the CopyRectangle offset/clamping math, for both `NikseBitmap` and `NikseBitmap2`.

The two `FixInvalidItalicTags` commits from the original version of this PR were dropped after review — see comment below.

All 508 libse and 14 libuilogic tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)