### PR TITLE
Fix FixInvalidItalicTags eating a character before a dangling begin tag

### DIFF
--- a/src/libse/Common/HtmlUtil.cs
+++ b/src/libse/Common/HtmlUtil.cs
@@ -969,15 +969,12 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
                 else
                 {
+                    // Remove the spurious last begin tag, keeping any text around it. The old
+                    // near-end branch here did "Substring(0, lastIndex - 1) + endTag", which ate
+                    // the character before the tag and appended an unbalanced end tag
+                    // ("<i>ab</i>c<i>" became "<i>ab</i></i>" - the "c" was lost).
                     var lastIndex = text.LastIndexOf(beginTag, StringComparison.Ordinal);
-                    if (text.Length > lastIndex + endTag.Length)
-                    {
-                        text = text.Substring(0, lastIndex) + text.Substring(lastIndex - 1 + endTag.Length);
-                    }
-                    else
-                    {
-                        text = text.Substring(0, lastIndex - 1) + endTag;
-                    }
+                    text = text.Remove(lastIndex, beginTag.Length);
                 }
                 if (text.StartsWith(beginTag, StringComparison.Ordinal) && text.EndsWith(endTag, StringComparison.Ordinal) && text.Contains(endTag + Environment.NewLine + beginTag))
                 {

--- a/tests/libse/Core/HtmlUtilTest.cs
+++ b/tests/libse/Core/HtmlUtilTest.cs
@@ -91,6 +91,29 @@ public class HtmlUtilTest
     }
 
     [Fact]
+    public void FixInvalidItalicTagsDanglingStartTagAtEnd()
+    {
+        const string s = "<i>a</i><i>";
+        Assert.Equal("<i>a</i>", HtmlUtil.FixInvalidItalicTags(s));
+    }
+
+    [Fact]
+    public void FixInvalidItalicTagsDanglingStartTagKeepsCharBeforeTag()
+    {
+        // Used to become "<i>ab</i></i>" - the "c" was eaten and an extra end tag appended
+        const string s = "<i>ab</i>c<i>";
+        Assert.Equal("<i>ab</i>c", HtmlUtil.FixInvalidItalicTags(s));
+    }
+
+    [Fact]
+    public void FixInvalidItalicTagsDanglingStartTagKeepsWordBeforeTag()
+    {
+        // Used to become "<i>Hello</i> </i>" - the "d" was eaten
+        const string s = "<i>Hello</i> d<i>";
+        Assert.Equal("<i>Hello</i> d", HtmlUtil.FixInvalidItalicTags(s));
+    }
+
+    [Fact]
     public void EncodeNumericEncodesNonAsciiBmpChar()
     {
         Assert.Equal("Hi&#229;", HtmlUtil.EncodeNumeric("Hiå")); // å


### PR DESCRIPTION
Found in a bug hunt and verified against the real library. In `HtmlUtil.FixInvalidItalicTags`, the "two `<i>`, one `</i>`" repair path had an off-by-one in its near-end branch — `Substring(0, lastIndex - 1) + endTag` cut the character **before** the dangling begin tag and appended an unbalanced end tag:

| Input | Old output | New output |
|---|---|---|
| `<i>a</i><i>` | `<i>a</i</i>` (corrupted tag) | `<i>a</i>` |
| `<i>ab</i>c<i>` | `<i>ab</i></i>` (**`c` deleted**) | `<i>ab</i>c` |
| `<i>Hello</i> d<i>` | `<i>Hello</i> </i>` (**`d` deleted**) | `<i>Hello</i> d` |

This runs inside "Fix common errors" → fix invalid italic tags, so the old behavior silently destroyed subtitle text. The bug has been there since 2021 and is also present in SE4.

The fix: the sibling branch was already removing exactly the spurious begin tag in a roundabout way (`lastIndex - 1 + endTag.Length` == `lastIndex + beginTag.Length`), so both branches collapse into a single `text.Remove(lastIndex, beginTag.Length)` that keeps all surrounding text.

Unit tests added for the three corruption cases; the full LibSETests suite passes (502/502).

🤖 Generated with [Claude Code](https://claude.com/claude-code)