### PR TITLE
Fix FixInvalidItalicTags leaving some two-line stray-tag shapes unrepaired

### DIFF
--- a/src/libse/Common/HtmlUtil.cs
+++ b/src/libse/Common/HtmlUtil.cs
@@ -1165,29 +1165,25 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
             }
 
+            // </i>Foo</i>     (two lines with only stray "</i>" tags - the subtitle was
+            // </i>Bar</i>      meant to be italic, so italicize each line that has a tag)
             if (noOfLines == 2 && italicBeginTagCount == 0 && italicEndTagCount == 4)
             {
                 var lines = text.SplitToLines();
-                if (lines.Count == 2 &&
-                    lines[0].StartsWith("</i>", StringComparison.InvariantCulture) && lines[1].EndsWith("</i>", StringComparison.InvariantCulture) &&
-                    lines[1].StartsWith("</i>", StringComparison.InvariantCulture) && lines[1].EndsWith("</i>", StringComparison.InvariantCulture))
+                if (lines.Count == 2)
                 {
-                    var s1 = lines[0].Replace("</i>", string.Empty);
-                    var s2 = lines[1].Replace("</i>", string.Empty);
-                    text = "<i>" + s1.Trim() + "</i>" + Environment.NewLine + "<i>" + s2.Trim() + "</i>";
+                    text = ItalicizeLineRemovingStrayTag(lines[0], endTag) + Environment.NewLine + ItalicizeLineRemovingStrayTag(lines[1], endTag);
                 }
             }
 
+            // <i>Foo<i>     (two lines with only stray "<i>" tags)
+            // <i>Bar<i>
             if (noOfLines == 2 && italicBeginTagCount == 4 && italicEndTagCount == 0)
             {
                 var lines = text.SplitToLines();
-                if (lines.Count == 2 &&
-                    lines[0].StartsWith("<i>", StringComparison.InvariantCulture) && lines[1].EndsWith("<i>", StringComparison.InvariantCulture) &&
-                    lines[1].StartsWith("<i>", StringComparison.InvariantCulture) && lines[1].EndsWith("<i>", StringComparison.InvariantCulture))
+                if (lines.Count == 2)
                 {
-                    var s1 = lines[0].Replace("<i>", string.Empty);
-                    var s2 = lines[1].Replace("<i>", string.Empty);
-                    text = "<i>" + s1.Trim() + "</i>" + Environment.NewLine + "<i>" + s2.Trim() + "</i>";
+                    text = ItalicizeLineRemovingStrayTag(lines[0], beginTag) + Environment.NewLine + ItalicizeLineRemovingStrayTag(lines[1], beginTag);
                 }
             }
 
@@ -1240,6 +1236,22 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
 
             return preTags + text;
+        }
+
+        /// <summary>
+        /// Used by <see cref="FixInvalidItalicTags"/> for two-line subtitles that contain only
+        /// stray copies of a single italic tag (e.g. four "</i>" and no "<i>"): the tags carry no
+        /// pairing information, so a line containing the tag was meant to be italic - strip the
+        /// stray tags and wrap the whole line in proper tags. Lines without the tag are kept as-is.
+        /// </summary>
+        private static string ItalicizeLineRemovingStrayTag(string line, string strayTag)
+        {
+            if (!line.Contains(strayTag))
+            {
+                return line;
+            }
+
+            return "<i>" + line.Replace(strayTag, string.Empty).Trim() + "</i>";
         }
 
         /// <summary>

--- a/tests/libse/Core/HtmlUtilTest.cs
+++ b/tests/libse/Core/HtmlUtilTest.cs
@@ -113,6 +113,28 @@ public class HtmlUtilTest
         Assert.Equal("<i>Hello</i> d", HtmlUtil.FixInvalidItalicTags(s));
     }
 
+    // Two lines, four stray "</i>" tags, no "<i>" - each line with a tag becomes italic.
+    // The first six cases pin the long-standing behavior for shapes the old condition matched;
+    // the rest used to fall through and be returned with the invalid tags unchanged.
+    [Theory]
+    [InlineData("</i>Hello</i>|</i>World</i>", "<i>Hello</i>|<i>World</i>")]
+    [InlineData("</i>Hello|</i>a</i>World</i>", "<i>Hello</i>|<i>aWorld</i>")]
+    [InlineData("</i>Hello</i>x|</i>World</i>", "<i>Hellox</i>|<i>World</i>")]
+    [InlineData("<i>Hello<i>|<i>World<i>", "<i>Hello</i>|<i>World</i>")]
+    [InlineData("<i>Hello|<i>a<i>World<i>", "<i>Hello</i>|<i>aWorld</i>")]
+    [InlineData("<i>Hello<i>x|<i>World<i>", "<i>Hellox</i>|<i>World</i>")]
+    [InlineData("</i>Hello</i>a</i>|World</i>", "<i>Helloa</i>|<i>World</i>")]
+    [InlineData("a</i>b</i>|c</i>d</i>", "<i>ab</i>|<i>cd</i>")]
+    [InlineData("</i>Hello</i>b</i>c</i>|plain", "<i>Hellobc</i>|plain")]
+    [InlineData("<i>Hello<i>a<i>|World<i>", "<i>Helloa</i>|<i>World</i>")]
+    [InlineData("a<i>b<i>|c<i>d<i>", "<i>ab</i>|<i>cd</i>")]
+    [InlineData("<i>Hello<i>b<i>c<i>|plain", "<i>Hellobc</i>|plain")]
+    public void FixInvalidItalicTagsTwoLinesOnlyStrayTags(string input, string expected)
+    {
+        var s = input.Replace("|", Environment.NewLine);
+        Assert.Equal(expected.Replace("|", Environment.NewLine), HtmlUtil.FixInvalidItalicTags(s));
+    }
+
     [Fact]
     public void EncodeNumericEncodesNonAsciiBmpChar()
     {


### PR DESCRIPTION
Follow-up to the #12579 review, which showed that tightening the "duplicated" condition in the two-line stray-italic-tag branches was a regression. This PR fixes the underlying issue correctly.

**The problem:** the two-line branches for *only four `</i>` tags* / *only four `<i>` tags* use an asymmetric condition (`lines[1].EndsWith` checked twice, `lines[0]`'s end never checked — identical in SE 4). Shapes matching the loose condition are repaired to whole-line italics, but near-miss shapes fall through and `FixInvalidItalicTags` returns the invalid tags **unchanged**:

| Input | Before | After |
|---|---|---|
| `</i>Hello</i>a</i>` + `World</i>` | unchanged (invalid) | `<i>Helloa</i>` + `<i>World</i>` |
| `a</i>b</i>` + `c</i>d</i>` | unchanged (invalid) | `<i>ab</i>` + `<i>cd</i>` |
| `</i>Hello</i>b</i>c</i>` + `plain` | unchanged (invalid) | `<i>Hellobc</i>` + `plain` |
| (mirrors with `<i>`) | unchanged (invalid) | repaired |

**The fix:** under these count guards (exactly four copies of a single tag, two lines) the stray tags carry no pairing information — so drop the positional condition entirely and repair per line: strip the stray tags from each line containing one and wrap that line in proper `<i>...</i>`; lines without a tag are kept as-is (so a plain second line does not become italic). This matches the method's established heuristic for the single-stray-end-tag case (`Foo.</i>` → `<i>Foo.</i>`).

**Compatibility:** output is byte-identical for every shape the old condition matched (verified against current main on all six such shapes) — this only turns previously-unfixed invalid output into valid italics.

Tests: 12 new theory cases pin both the long-standing shapes and the newly repaired ones. All 520 libse, 237 seconv, and 14 libuilogic tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)