### PR TITLE
Fix Cavena890 Chinese write path so text and italics round-trip

### DIFF
--- a/src/libse/SubtitleFormats/Cavena890.cs
+++ b/src/libse/SubtitleFormats/Cavena890.cs
@@ -920,23 +920,42 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
                 else if (languageId == LanguageIdChineseTraditional || languageId == LanguageIdChineseSimplified)
                 {
+                    // The Chinese text field is UTF-16BE (the reader decodes it as byte pairs),
+                    // so every write must be a full pair to keep the pairing aligned. The old
+                    // code wrote only the high byte of each character (dropping the low byte)
+                    // and lone italic-marker bytes, so nothing could round-trip.
                     encoding = Encoding.GetEncoding(1201);
-                    if (index < 49)
+                    if (i + 3 < text.Length && text.Substring(i, 3) == "<i>")
                     {
-                        if (i + 3 < text.Length && text.Substring(i, 3) == "<i>")
+                        // In-band control code as a 0x00 XX pair - decodes to U+0088,
+                        // which FixText maps back to "<i>".
+                        if (index + 2 <= buffer.Length)
                         {
-                            buffer[index] = 0x88;
-                            skipCount = 2;
+                            buffer[index] = 0;
+                            buffer[index + 1] = 0x88;
+                            index += 2;
                         }
-                        else if (i + 4 <= text.Length && text.Substring(i, 4) == "</i>")
+
+                        skipCount = 2;
+                    }
+                    else if (i + 4 <= text.Length && text.Substring(i, 4) == "</i>")
+                    {
+                        if (index + 2 <= buffer.Length)
                         {
-                            buffer[index] = 0x98;
-                            skipCount = 3;
+                            buffer[index] = 0;
+                            buffer[index + 1] = 0x98;
+                            index += 2;
                         }
-                        else
+
+                        skipCount = 3;
+                    }
+                    else
+                    {
+                        var charBytes = encoding.GetBytes(new[] { current });
+                        if (index + charBytes.Length <= buffer.Length)
                         {
-                            buffer[index] = encoding.GetBytes(new[] { current })[0];
-                            index++;
+                            Buffer.BlockCopy(charBytes, 0, buffer, index, charBytes.Length);
+                            index += charBytes.Length;
                         }
                     }
                 }
@@ -1815,12 +1834,16 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     text = string.Empty;
                 }
 
-                var encoding = Encoding.Default; // which encoding?? Encoding.GetEncoding("ISO-8859-5")
-                text = text.Replace(encoding.GetString(new byte[] { 0x7F }), string.Empty); // Used to fill empty space upto 51 bytes
-                text = text.Replace(encoding.GetString(new byte[] { 0xBE }), "-");
+                // In-band control codes occupy a full 0x00 XX pair in the UTF-16BE text, so
+                // after decoding they appear as the corresponding U+00XX char. The old code
+                // compared against Encoding.Default.GetString(..), which is platform dependent
+                // (UTF-8 on .NET Core, where 0x88/0x98/0xBE all decode to U+FFFD - so any
+                // undecodable byte in the file was turned into "<i>").
+                text = text.Replace("\u007f", string.Empty); // Used to fill empty space upto 51 bytes
+                text = text.Replace("\u00be", "-");
                 text = FixColors(text);
-                text = text.Replace(encoding.GetString(new byte[] { 0x88 }), "<i>");
-                text = text.Replace(encoding.GetString(new byte[] { 0x98 }), "</i>");
+                text = text.Replace("\u0088", "<i>");
+                text = text.Replace("\u0098", "</i>");
 
                 if (text.Contains("<i></i>"))
                 {

--- a/tests/libse/SubtitleFormats/Cavena890Test.cs
+++ b/tests/libse/SubtitleFormats/Cavena890Test.cs
@@ -1,0 +1,54 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace LibSETests.SubtitleFormats;
+
+public class Cavena890Test
+{
+    private static Subtitle SaveAndReload(Subtitle subtitle, int languageId)
+    {
+        var oldLanguageId = Configuration.Settings.SubtitleSettings.CurrentCavena89LanguageId;
+        Configuration.Settings.SubtitleSettings.CurrentCavena89LanguageId = languageId;
+        var path = Path.GetTempFileName();
+        try
+        {
+            new Cavena890().Save(path, subtitle, batchMode: true);
+            var loaded = new Subtitle();
+            new Cavena890().LoadSubtitle(loaded, new List<string>(), path);
+            return loaded;
+        }
+        finally
+        {
+            Configuration.Settings.SubtitleSettings.CurrentCavena89LanguageId = oldLanguageId;
+            File.Delete(path);
+        }
+    }
+
+    // The Chinese text field is UTF-16BE. The writer used to emit only the high byte of
+    // each character (and lone italic-marker bytes), so no Chinese text could round-trip.
+    [Fact]
+    public void ChineseTextRoundTrips()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("早上好", 0, 2000));
+        subtitle.Paragraphs.Add(new Paragraph("你好世界" + Environment.NewLine + "第二行", 3000, 5000));
+
+        var loaded = SaveAndReload(subtitle, Cavena890.LanguageIdChineseSimplified);
+
+        Assert.Equal(2, loaded.Paragraphs.Count);
+        Assert.Equal("早上好", loaded.Paragraphs[0].Text);
+        Assert.Equal("你好世界" + Environment.NewLine + "第二行", loaded.Paragraphs[1].Text);
+    }
+
+    [Fact]
+    public void ChineseItalicRoundTrips()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("<i>你好世界</i>", 0, 2000));
+
+        var loaded = SaveAndReload(subtitle, Cavena890.LanguageIdChineseSimplified);
+
+        Assert.Single(loaded.Paragraphs);
+        Assert.Equal("<i>你好世界</i>", loaded.Paragraphs[0].Text);
+    }
+}


### PR DESCRIPTION
Follow-up to the #12580 review, where the Chinese `index++` commit was dropped because the whole Chinese write path was found to be unable to round-trip. This fixes the path properly.

**The problem:** the Chinese text field is UTF-16BE — `FixText` trims the 0x00/0x7F fillers, forces an even length, and decodes the field with `Encoding.GetEncoding(1201)` as byte *pairs*. The writer, however, emitted only the **high byte** of each character (`encoding.GetBytes(new[] { current })[0]`) and wrote lone italic-marker bytes without advancing the index (so the next character overwrote them). No Chinese text, let alone italics, could survive a save/load cycle.

**Writer** (`GetTextAsBytes`): every character now writes its full UTF-16BE pair, and the italic markers are written as in-band `0x00 0x88` / `0x00 0x98` pairs so the byte pairing stays aligned. All writes are bounds-checked against the 51-byte field (silent truncation, as before).

**Reader** (`FixText`, Chinese branch): the marker/filler comparisons used `Encoding.Default.GetString(..)`, which is platform dependent — on .NET Core `Encoding.Default` is UTF-8, where `0x88`/`0x98`/`0xBE` each decode to U+FFFD, meaning *any undecodable byte in a real file was replaced with `<i>`*. The comparisons now match the actual decoded chars (U+0088, U+0098, U+007F, U+00BE) explicitly and deterministically.

**Compatibility notes:**
- The UTF-16BE pair layout for text is certain — it's what the reader (which handles real-world files) has always decoded.
- The `0x00 0x88` marker-pair layout is the natural in-band encoding under that pairing, but I could not verify it against files produced by real Cavena tools (no sample `.890` files in the repo). Since the old marker matching couldn't fire deterministically on any platform, no working real-file italic behavior is lost either way.

**Tests:** save→load round-trip through the public `Save`/`LoadSubtitle` API for plain Chinese text, a two-line paragraph, and an italicized line. Both tests fail against the old code. All 531 libse and 237 seconv tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
