### PR TITLE
Disable ligatures in the syntax highlighting text box

### DIFF
--- a/src/ui/Controls/SyntaxHighlightingTextBox.cs
+++ b/src/ui/Controls/SyntaxHighlightingTextBox.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Media;
 using Nikse.SubtitleEdit.Features.SpellCheck;
 using System;
 
@@ -31,6 +32,14 @@ public class SyntaxHighlightingTextBox : TextBox
     public SyntaxHighlightingTextBox()
     {
         PseudoClasses.Add(":syntaxHighlighting");
+
+        // Turn off standard/contextual ligatures: with e.g. DejaVu Sans, "ffi" is otherwise
+        // shaped into the single ﬃ glyph, and since the caret and mouse hit testing work on
+        // glyph clusters, the three letters behave as one un-enterable character (#12585).
+        // An edit box must navigate per character. Required ligatures ("rlig", used by e.g.
+        // Arabic lam-alef) and contextual alternates ("calt", cursive joining forms) are
+        // deliberately left on - they are script-critical and do not merge Latin letters.
+        FontFeatures = FontFeatureCollection.Parse("-liga, -clig");
     }
 
     public void EnableSpellCheck(ISpellCheckManager spellCheckManager)

--- a/tests/UI/Controls/SyntaxHighlightingTextBoxTests.cs
+++ b/tests/UI/Controls/SyntaxHighlightingTextBoxTests.cs
@@ -1,0 +1,41 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Headless.XUnit;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Controls;
+
+namespace UITests.Controls;
+
+public class SyntaxHighlightingTextBoxTests
+{
+    // Ligatures merge letter sequences like "ffi" into one glyph cluster, making the caret
+    // and mouse selection treat them as a single character (#12585) - the edit box must
+    // disable standard/contextual ligatures ("liga"/"clig") while keeping script-critical
+    // features (e.g. "rlig") untouched.
+    [AvaloniaFact]
+    public void DisablesStandardAndContextualLigatures()
+    {
+        var textBox = new SyntaxHighlightingTextBox();
+
+        Assert.NotNull(textBox.FontFeatures);
+        var features = textBox.FontFeatures!.ToList();
+        Assert.Equal(2, features.Count);
+        Assert.All(features, f => Assert.Equal(0, f.Value));
+        Assert.Contains(features, f => f.Tag == "liga");
+        Assert.Contains(features, f => f.Tag == "clig");
+    }
+
+    // The presenter builds its text runs from its own FontFeatures property, so the value
+    // set on the text box must reach the templated presenter via property inheritance.
+    [AvaloniaFact]
+    public void FontFeaturesReachTheTemplatedPresenter()
+    {
+        var textBox = new SyntaxHighlightingTextBox();
+        var window = new Window { Content = textBox, Width = 320, Height = 120 };
+        window.Show();
+        textBox.ApplyTemplate();
+
+        var presenter = textBox.GetVisualDescendants().OfType<TextPresenter>().Single();
+        Assert.Same(textBox.FontFeatures, presenter.FontFeatures);
+    }
+}


### PR DESCRIPTION
Fixes #12585.

**Analysis:** the report ("ffi behaves as one letter, becomes ﬃ") is font shaping, not text corruption — the `Text` still contains three characters. The new `SyntaxHighlightingTextBox` renders through Avalonia's text shaper with the font's default OpenType features, so with a ligature-rich font (DejaVu Sans and friends on Linux — hence CachyOS) HarfBuzz merges "ffi" into the single ﬃ glyph. Caret movement and mouse hit testing operate on glyph clusters, so the three letters become one un-enterable unit.

**Fix:** the text box now sets `FontFeatures = FontFeatureCollection.Parse("-liga, -clig")` — standard and contextual ligatures off, which is what code/text editors conventionally do (an edit box must navigate per character). Deliberately left on: `rlig` (required ligatures, e.g. Arabic lam-alef — script-critical) and `calt` (contextual alternates / cursive joining) — neither merges Latin letter sequences.

**Verification:**
- Runtime-checked (reflection harness against Avalonia 12.1.0) that `Parse("-liga, -clig")` yields `liga=0` and `clig=0` spanning the whole text.
- Headless test asserts the features are set, and a second test asserts the value reaches the templated `TextPresenter` via property inheritance — that's the exact instance `SyntaxHighlightingTextPresenter` builds all its `GenericTextRunProperties` from (default, token colors, spell-check underline, selection, and IME preedit runs all pass `fontFeatures: FontFeatures`).
- A true end-to-end shaping test isn't possible in CI: the headless test host uses stub drawing (no HarfBuzz). Worth a quick manual check on a Linux box with DejaVu Sans if available.

All 691 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)