### PR TITLE
Add "Remove/replace Unicode characters" tool (SE 4 plugin port)

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -124,6 +124,7 @@ using Nikse.SubtitleEdit.Features.Tools.MergeTwoSubtitles;
 using Nikse.SubtitleEdit.Features.Tools.MergeSubtitlesWithSameText;
 using Nikse.SubtitleEdit.Features.Tools.MergeSubtitlesWithSameTimeCodes;
 using Nikse.SubtitleEdit.Features.Tools.RemoveTextForHearingImpaired;
+using Nikse.SubtitleEdit.Features.Tools.RemoveUnicodeCharacters;
 using Nikse.SubtitleEdit.Features.Tools.Renumber;
 using Nikse.SubtitleEdit.Features.Tools.SortBy;
 using Nikse.SubtitleEdit.Features.Tools.SplitBreakLongLines;
@@ -470,6 +471,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<PromptUnknownWordViewModel>();
         collection.AddTransient<ReEncodeVideoViewModel>();
         collection.AddTransient<RemoveTextForHearingImpairedViewModel>();
+        collection.AddTransient<RemoveUnicodeCharactersViewModel>();
         collection.AddTransient<RenumberViewModel>();
         collection.AddTransient<ReplaceViewModel>();
         collection.AddTransient<RestoreAutoBackupViewModel>();

--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -531,6 +531,11 @@ public static class InitMenu
                 Header = l.ConvertActors,
                 Command = vm.ShowToolsConvertActorsCommand,
             },
+            new MenuItem
+            {
+                Header = l.RemoveUnicodeCharacters,
+                Command = vm.ShowToolsRemoveUnicodeCharactersCommand,
+            },
         };
         foreach (var item in tools.OrderBy(p => p.Header?.ToString()?.Replace("_", string.Empty)))
         {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -119,6 +119,7 @@ using Nikse.SubtitleEdit.Features.Tools.BridgeGaps;
 using Nikse.SubtitleEdit.Features.Tools.ChangeCasing;
 using Nikse.SubtitleEdit.Features.Tools.ChangeFormatting;
 using Nikse.SubtitleEdit.Features.Tools.ConvertActors;
+using Nikse.SubtitleEdit.Features.Tools.RemoveUnicodeCharacters;
 using Nikse.SubtitleEdit.Features.Tools.AiReview;
 using Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
 using Nikse.SubtitleEdit.Features.Tools.FixNetflixErrors;
@@ -5132,6 +5133,29 @@ public partial class MainViewModel :
         var idx = SelectedSubtitleIndex ?? 0;
         var result =
             await ShowDialogAsync<ConvertActorsWindow, ConvertActorsViewModel>(vm => { vm.Initialize(Subtitles.ToList(), SelectedSubtitleFormat); });
+
+        if (result.OkPressed)
+        {
+            ApplyFixedSubtitle(result.FixedSubtitle, idx);
+        }
+    }
+
+    [RelayCommand]
+    private async Task ShowToolsRemoveUnicodeCharacters()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        if (IsEmpty)
+        {
+            ShowSubtitleNotLoadedMessage();
+            return;
+        }
+
+        var idx = SelectedSubtitleIndex ?? 0;
+        var result = await ShowDialogAsync<RemoveUnicodeCharactersWindow, RemoveUnicodeCharactersViewModel>(vm => { vm.Initialize(Subtitles.ToList()); });
 
         if (result.OkPressed)
         {

--- a/src/ui/Features/Tools/RemoveUnicodeCharacters/RemoveUnicodeCharacterItem.cs
+++ b/src/ui/Features/Tools/RemoveUnicodeCharacters/RemoveUnicodeCharacterItem.cs
@@ -1,0 +1,20 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Nikse.SubtitleEdit.Features.Tools.RemoveUnicodeCharacters;
+
+public partial class RemoveUnicodeCharacterItem : ObservableObject
+{
+    [ObservableProperty] private bool _isChecked = true;
+    [ObservableProperty] private string _replaceWith = string.Empty;
+
+    /// <summary>The character (one rune - may be a surrogate pair, e.g. an emoji).</summary>
+    public string Character { get; init; } = string.Empty;
+
+    /// <summary>Code point display, e.g. "U+266A".</summary>
+    public string CodeDisplay { get; init; } = string.Empty;
+
+    public int Count { get; init; }
+
+    /// <summary>Line numbers the character occurs in, e.g. "1, 5, 7".</summary>
+    public string LinesDisplay { get; init; } = string.Empty;
+}

--- a/src/ui/Features/Tools/RemoveUnicodeCharacters/RemoveUnicodeCharactersViewModel.cs
+++ b/src/ui/Features/Tools/RemoveUnicodeCharacters/RemoveUnicodeCharactersViewModel.cs
@@ -1,0 +1,178 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Tools.RemoveUnicodeCharacters;
+
+/// <summary>
+/// SE 5 port of the SE 4 "Remove Unicode characters" plugin: finds every character above
+/// Latin-1 (code point &gt; 255) in the subtitle and lets the user remove or replace each
+/// one. Characters are scanned per rune, so surrogate pairs (emoji etc.) are treated as one
+/// character instead of two broken halves.
+/// </summary>
+public partial class RemoveUnicodeCharactersViewModel : ObservableObject
+{
+    [ObservableProperty] private ObservableCollection<RemoveUnicodeCharacterItem> _characters;
+    [ObservableProperty] private RemoveUnicodeCharacterItem? _selectedCharacter;
+    [ObservableProperty] private string _statusText;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+    public List<SubtitleLineViewModel> FixedSubtitle { get; set; }
+
+    private List<SubtitleLineViewModel> _allSubtitles;
+
+    public RemoveUnicodeCharactersViewModel()
+    {
+        Characters = new ObservableCollection<RemoveUnicodeCharacterItem>();
+        StatusText = string.Empty;
+        FixedSubtitle = new List<SubtitleLineViewModel>();
+        _allSubtitles = new List<SubtitleLineViewModel>();
+    }
+
+    public void Initialize(List<SubtitleLineViewModel> subtitles)
+    {
+        _allSubtitles = subtitles.Select(p => new SubtitleLineViewModel(p)).ToList();
+
+        var replaceList = Se.Settings.Tools.RemoveUnicodeCharacters.ReplaceList;
+        var totalCount = 0;
+        var found = new Dictionary<string, (int Count, List<int> Lines)>();
+        for (var i = 0; i < _allSubtitles.Count; i++)
+        {
+            var lineNumber = i + 1;
+            foreach (var rune in _allSubtitles[i].Text.EnumerateRunes())
+            {
+                if (rune.Value <= 255)
+                {
+                    continue;
+                }
+
+                totalCount++;
+                var key = rune.ToString();
+                if (!found.TryGetValue(key, out var entry))
+                {
+                    entry = (0, new List<int>());
+                }
+
+                entry.Count++;
+                if (entry.Lines.Count == 0 || entry.Lines[entry.Lines.Count - 1] != lineNumber)
+                {
+                    entry.Lines.Add(lineNumber);
+                }
+
+                found[key] = entry;
+            }
+        }
+
+        Characters.Clear();
+        foreach (var kvp in found.OrderBy(p => p.Key, System.StringComparer.Ordinal))
+        {
+            var codePoint = System.Text.Rune.GetRuneAt(kvp.Key, 0).Value;
+            Characters.Add(new RemoveUnicodeCharacterItem
+            {
+                Character = kvp.Key,
+                CodeDisplay = "U+" + codePoint.ToString(codePoint <= 0xFFFF ? "X4" : "X6"),
+                Count = kvp.Value.Count,
+                LinesDisplay = string.Join(", ", kvp.Value.Lines),
+                ReplaceWith = replaceList.FirstOrDefault(p => p.Character == kvp.Key)?.ReplaceWith ?? string.Empty,
+            });
+        }
+
+        StatusText = totalCount == 0
+            ? Se.Language.Tools.RemoveUnicodeCharacters.NoCharactersFound
+            : string.Format(Se.Language.Tools.RemoveUnicodeCharacters.CharactersFoundX, totalCount);
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        var replacements = Characters
+            .Where(c => c.IsChecked)
+            .ToDictionary(c => c.Character, c => c.ReplaceWith ?? string.Empty);
+
+        FixedSubtitle = _allSubtitles.Select(vm =>
+        {
+            var updated = new SubtitleLineViewModel(vm);
+            foreach (var kvp in replacements)
+            {
+                updated.Text = updated.Text.Replace(kvp.Key, kvp.Value);
+            }
+
+            return updated;
+        }).ToList();
+
+        SaveSettings();
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void SelectAll()
+    {
+        foreach (var item in Characters)
+        {
+            item.IsChecked = true;
+        }
+    }
+
+    [RelayCommand]
+    private void InvertSelection()
+    {
+        foreach (var item in Characters)
+        {
+            item.IsChecked = !item.IsChecked;
+        }
+    }
+
+    /// <summary>
+    /// Remembers non-empty "replace with" mappings for the next run; entries for characters
+    /// not present in this subtitle are kept untouched.
+    /// </summary>
+    private void SaveSettings()
+    {
+        var replaceList = Se.Settings.Tools.RemoveUnicodeCharacters.ReplaceList;
+        foreach (var item in Characters)
+        {
+            var existing = replaceList.FirstOrDefault(p => p.Character == item.Character);
+            if (!string.IsNullOrEmpty(item.ReplaceWith))
+            {
+                if (existing != null)
+                {
+                    existing.ReplaceWith = item.ReplaceWith;
+                }
+                else
+                {
+                    replaceList.Add(new SeUnicodeReplaceListItem { Character = item.Character, ReplaceWith = item.ReplaceWith });
+                }
+            }
+            else if (existing != null)
+            {
+                replaceList.Remove(existing);
+            }
+        }
+
+        Se.SaveSettings();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Tools/RemoveUnicodeCharacters/RemoveUnicodeCharactersWindow.cs
+++ b/src/ui/Features/Tools/RemoveUnicodeCharacters/RemoveUnicodeCharactersWindow.cs
@@ -1,0 +1,135 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Tools.RemoveUnicodeCharacters;
+
+public class RemoveUnicodeCharactersWindow : Window
+{
+    public RemoveUnicodeCharactersWindow(RemoveUnicodeCharactersViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.Tools.RemoveUnicodeCharacters.Title;
+        CanResize = true;
+        Width = 800;
+        Height = 600;
+        MinWidth = 600;
+        MinHeight = 400;
+        vm.Window = this;
+        DataContext = vm;
+
+        var l = Se.Language.Tools.RemoveUnicodeCharacters;
+        var dataGrid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            SelectionMode = DataGridSelectionMode.Single,
+            CanUserResizeColumns = true,
+            CanUserSortColumns = true,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            Width = double.NaN,
+            Height = double.NaN,
+            DataContext = vm,
+            ItemsSource = vm.Characters,
+            Columns =
+            {
+                new DataGridTemplateColumn
+                {
+                    Header = Se.Language.General.Apply,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    IsReadOnly = false,
+                    Width = new DataGridLength(55),
+                    CellTemplate = new FuncDataTemplate<RemoveUnicodeCharacterItem>((_, _) =>
+                        new CheckBox
+                        {
+                            Focusable = false,
+                            HorizontalAlignment = HorizontalAlignment.Center,
+                            VerticalAlignment = VerticalAlignment.Center,
+                            [!CheckBox.IsCheckedProperty] = new Binding(nameof(RemoveUnicodeCharacterItem.IsChecked)) { Mode = BindingMode.TwoWay },
+                        }),
+                },
+                new DataGridTextColumn
+                {
+                    Header = l.Character,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(RemoveUnicodeCharacterItem.Character)),
+                    IsReadOnly = true,
+                },
+                new DataGridTextColumn
+                {
+                    Header = "Unicode",
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(RemoveUnicodeCharacterItem.CodeDisplay)),
+                    IsReadOnly = true,
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.Count,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(RemoveUnicodeCharacterItem.Count)),
+                    IsReadOnly = true,
+                },
+                new DataGridTextColumn
+                {
+                    Header = l.ReplaceWith,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(RemoveUnicodeCharacterItem.ReplaceWith)) { Mode = BindingMode.TwoWay },
+                    IsReadOnly = false,
+                    Width = new DataGridLength(120),
+                },
+                new DataGridTextColumn
+                {
+                    Header = l.Lines,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(RemoveUnicodeCharacterItem.LinesDisplay)),
+                    IsReadOnly = true,
+                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
+                },
+            },
+        };
+        _ = new DataGridCheckboxMultiSelect<RemoveUnicodeCharacterItem>(dataGrid,
+            item => item.IsChecked, (item, v) => item.IsChecked = v);
+
+        var buttonSelectAll = UiUtil.MakeButton(Se.Language.General.SelectAll, vm.SelectAllCommand);
+        var buttonInvertSelection = UiUtil.MakeButton(Se.Language.General.InvertSelection, vm.InvertSelectionCommand);
+        var panelSelection = UiUtil.MakeHorizontalPanel(buttonSelectAll, buttonInvertSelection);
+
+        var labelStatus = UiUtil.MakeLabel(string.Empty).WithBindText(vm, nameof(vm.StatusText)).WithAlignmentTop();
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            ColumnSpacing = 10,
+            RowSpacing = 10,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGrid), 0);
+        grid.Add(panelSelection, 1);
+        grid.Add(labelStatus, 2);
+        grid.Add(panelButtons, 2);
+
+        Content = grid;
+
+        Activated += delegate { buttonOk.Focus(); };
+        KeyDown += (_, e) => vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
@@ -63,6 +63,7 @@ public class LanguageMainMenu
     public string SnapAllTimesToFrames { get; set; }
     public string Renumber { get; set; }
     public string RemoveTextForHearingImpaired { get; set; }
+    public string RemoveUnicodeCharacters { get; set; }
     public string ConvertActors { get; set; }
     public string JoinSubtitles { get; set; }
     public string SplitSubtitle { get; set; }
@@ -196,6 +197,7 @@ public class LanguageMainMenu
         SnapAllTimesToFrames = "Snap all times to frames";
         Renumber = "Renumber...";
         RemoveTextForHearingImpaired = "_Remove text for hearing impaired...";
+        RemoveUnicodeCharacters = "Remove/replace _Unicode characters...";
         ConvertActors = "Convert actors...";
         ChangeCasing = "_Change casing...";
         ChangeFormatting = "Change formatting...";

--- a/src/ui/Logic/Config/Language/Tools/LanguageRemoveUnicodeCharacters.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageRemoveUnicodeCharacters.cs
@@ -1,0 +1,21 @@
+namespace Nikse.SubtitleEdit.Logic.Config.Language;
+
+public class LanguageRemoveUnicodeCharacters
+{
+    public string Title { get; set; }
+    public string Character { get; set; }
+    public string ReplaceWith { get; set; }
+    public string Lines { get; set; }
+    public string CharactersFoundX { get; set; }
+    public string NoCharactersFound { get; set; }
+
+    public LanguageRemoveUnicodeCharacters()
+    {
+        Title = "Remove/replace Unicode characters";
+        Character = "Character";
+        ReplaceWith = "Replace with";
+        Lines = "Lines";
+        CharactersFoundX = "Unicode characters found: {0}";
+        NoCharactersFound = "No Unicode characters found";
+    }
+}

--- a/src/ui/Logic/Config/Language/Tools/LanguageTools.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageTools.cs
@@ -28,6 +28,7 @@ public class LanguageTools
     public LanguageNetflixCheckAndFix NetflixCheckAndFix { get; set; } = new();
     public LanguageImageBasedEdit ImageBasedEdit { get; set; } = new();
     public LanguageRemoveTextForHearingImpaired RemoveTextForHearingImpaired { get; set; } = new();
+    public LanguageRemoveUnicodeCharacters RemoveUnicodeCharacters { get; set; } = new();
     public string PickAlignmentTitle { get; set; }
     public string PickFontNameTitle { get; set; }
     public string ColorPickerTitle { get; set; }

--- a/src/ui/Logic/Config/SeRemoveUnicodeCharacters.cs
+++ b/src/ui/Logic/Config/SeRemoveUnicodeCharacters.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace Nikse.SubtitleEdit.Logic.Config;
+
+public class SeUnicodeReplaceListItem
+{
+    public string Character { get; set; } = string.Empty;
+    public string ReplaceWith { get; set; } = string.Empty;
+}
+
+public class SeRemoveUnicodeCharacters
+{
+    /// <summary>
+    /// Remembered "replace with" mappings for the remove/replace Unicode characters tool -
+    /// characters found in a subtitle are prefilled from this list (an empty/missing entry
+    /// means remove). Mirrors the SE 4 "Remove Unicode characters" plugin's replace list.
+    /// </summary>
+    public List<SeUnicodeReplaceListItem> ReplaceList { get; set; } = new()
+    {
+        new SeUnicodeReplaceListItem { Character = "♪", ReplaceWith = "#" },
+        new SeUnicodeReplaceListItem { Character = "♫", ReplaceWith = "#" },
+    };
+}

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -18,6 +18,7 @@ public class SeTools
     public SeBatchConvert BatchConvert { get; set; } = new();
     public SeChangeCasing ChangeCasing { get; set; } = new();
     public SeRemoveTextForHi RemoveTextForHi { get; set; } = new();
+    public SeRemoveUnicodeCharacters RemoveUnicodeCharacters { get; set; } = new();
     public SeMergeSameTimeCode MergeSameTimeCode { get; set; } = new();
     public SeMergeSameText MergeSameText { get; set; } = new();
 

--- a/tests/UI/Features/Tools/RemoveUnicodeCharacters/RemoveUnicodeCharactersViewModelTests.cs
+++ b/tests/UI/Features/Tools/RemoveUnicodeCharacters/RemoveUnicodeCharactersViewModelTests.cs
@@ -1,0 +1,84 @@
+using Avalonia.Headless.XUnit;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Tools.RemoveUnicodeCharacters;
+
+namespace UITests.Features.Tools.RemoveUnicodeCharacters;
+
+public class RemoveUnicodeCharactersViewModelTests
+{
+    private static RemoveUnicodeCharactersViewModel Resolve()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        return services.BuildServiceProvider().GetRequiredService<RemoveUnicodeCharactersViewModel>();
+    }
+
+    private static List<SubtitleLineViewModel> MakeLines(params string[] texts)
+    {
+        return texts.Select((t, i) => new SubtitleLineViewModel { Text = t, Number = i + 1 }).ToList();
+    }
+
+    [AvaloniaFact]
+    public void FindsOnlyCharactersAboveLatin1AndGroupsThem()
+    {
+        var vm = Resolve();
+        vm.Initialize(MakeLines("♪ Hello ♪", "Café", "OK 👍"));
+
+        // é is 0xE9 (Latin-1) and must not be listed; ♪ is grouped with count 2;
+        // 👍 is a surrogate pair and must appear as one character.
+        Assert.Equal(2, vm.Characters.Count);
+
+        var note = vm.Characters.Single(c => c.Character == "♪");
+        Assert.Equal(2, note.Count);
+        Assert.Equal("1", note.LinesDisplay);
+        Assert.Equal("U+266A", note.CodeDisplay);
+        Assert.Equal("#", note.ReplaceWith); // prefilled from the default replace list
+
+        var emoji = vm.Characters.Single(c => c.Character == "👍");
+        Assert.Equal(1, emoji.Count);
+        Assert.Equal("3", emoji.LinesDisplay);
+        Assert.Equal("U+01F44D", emoji.CodeDisplay);
+        Assert.Equal(string.Empty, emoji.ReplaceWith);
+    }
+
+    [AvaloniaFact]
+    public void OkReplacesCheckedAndKeepsUncheckedCharacters()
+    {
+        var vm = Resolve();
+        vm.Initialize(MakeLines("♪ La la ♪", "你好 world", "Café"));
+
+        // ♪ replaced via the default replace list ("#"), 你 removed, 好 left unchecked.
+        vm.Characters.Single(c => c.Character == "好").IsChecked = false;
+        vm.OkCommand.Execute(null);
+
+        Assert.True(vm.OkPressed);
+        Assert.Equal("# La la #", vm.FixedSubtitle[0].Text);
+        Assert.Equal("好 world", vm.FixedSubtitle[1].Text);
+        Assert.Equal("Café", vm.FixedSubtitle[2].Text);
+    }
+
+    [AvaloniaFact]
+    public void NoUnicodeCharactersGivesEmptyListAndStatus()
+    {
+        var vm = Resolve();
+        vm.Initialize(MakeLines("Hello", "Café"));
+
+        Assert.Empty(vm.Characters);
+        Assert.False(string.IsNullOrEmpty(vm.StatusText));
+    }
+
+    [AvaloniaFact]
+    public void InvertSelectionFlipsAllItems()
+    {
+        var vm = Resolve();
+        vm.Initialize(MakeLines("♪你"));
+
+        Assert.All(vm.Characters, c => Assert.True(c.IsChecked));
+        vm.InvertSelectionCommand.Execute(null);
+        Assert.All(vm.Characters, c => Assert.False(c.IsChecked));
+        vm.SelectAllCommand.Execute(null);
+        Assert.All(vm.Characters, c => Assert.True(c.IsChecked));
+    }
+}


### PR DESCRIPTION
Fixes #12586 — native SE 5 port of the SE 4 "Remove Unicode characters" plugin.

**What it does:** Tools → *Remove/replace Unicode characters...* scans the subtitle for every character above Latin-1 (code point > 255) and lists each one with its code point (`U+266A` style), occurrence count, and the line numbers it appears in. Each row has an Apply checkbox and an editable **Replace with** cell — empty means remove. Select all / invert selection buttons, status line with the total count. On OK the changes are applied to the subtitle via the same `ApplyFixedSubtitle` flow as Convert Actors.

**Replace list persistence:** non-empty "replace with" mappings are remembered in `Settings.json` (`Tools.RemoveUnicodeCharacters.ReplaceList`) and prefilled the next time the same character shows up — seeded with the SE 4 plugin's defaults (`♪`/`♫` → `#`). Clearing a mapping removes it from the list.

**One improvement over the SE 4 plugin:** scanning is per *rune*, not per `char` — the SE 4 plugin iterated UTF-16 code units, so an emoji showed up as two broken surrogate halves and replacing one corrupted the text. Here `👍` is listed (and removed/replaced) as one character.

**Why a standalone tool and not a Fix Common Errors rule** (per the issue discussion): the tool's detection principle is ">255 is suspect", and for Russian, Greek, Arabic, or CJK subtitles *every* character is above 255 — anything non-interactive would offer to destroy the whole file. The interactive checkable list keeps it the user's informed choice, same as the plugin. The curated-mapping side of this space is already covered by the "Normalize strings" FCE rule.

**Wiring:** feature folder under `Features/Tools/RemoveUnicodeCharacters/` (window + view model + display item, following the Convert Actors pattern), DI registration, Tools menu entry (alphabetically sorted group), language strings under `Tools.RemoveUnicodeCharacters`, settings class.

**Tests:** four view-model tests — scan groups characters and ignores Latin-1 (é), surrogate pair listed as one character with `U+01F44D`, replace/remove/unchecked-keeps behavior through OK, empty-result status, and select-all/invert. All 695 UI tests pass; full solution builds clean.

Not merging per request — the window layout is probably worth a visual once-over (built after the Convert Actors window style: 800×600, resizable, DataGrid with checkbox multi-select support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)