### PR TITLE
Fix missing closing tag when setting ASSA font name on selected text

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12874,8 +12874,7 @@ public partial class MainViewModel :
         }
 
         var isAssa = SelectedSubtitleFormat is AdvancedSubStationAlpha;
-        var isWebVtt = SelectedSubtitleFormat is WebVTT;
-        if (selectionLength == 0)
+        if (selectionLength == 0 || selectionLength == tb.Text.Length)
         {
             tb.Text = _fontNameService.SetFontName(tb.Text, result.SelectedFontName, isAssa);
         }
@@ -12883,6 +12882,12 @@ public partial class MainViewModel :
         {
             var selectedText = tb.Text.Substring(selectionStart, selectionLength);
             selectedText = _fontNameService.SetFontName(selectedText, result.SelectedFontName, isAssa);
+
+            if (isAssa)
+            {
+                selectedText += "{\\fn}"; // reset to style font name after the selection
+            }
+
             tb.Text = tb.Text
                 .Remove(selectionStart, selectionLength)
                 .Insert(selectionStart, selectedText);


### PR DESCRIPTION
Fixes #12592

Applying a font name via right-click on a text selection in the edit textbox only inserted the opening `{\fnName}` override tag, so the font change bled into the rest of the line.

Changes in `TextBoxFontName()`:
- Append the empty `{\fn}` reset tag after the selection for ASSA, restoring the style's font. This is the same idiom libse already uses when converting `</font>` to ASSA tags, and it keeps tracking the style if its font is later changed (unlike baking in the current style font name).
- Treat a selection spanning the whole text as whole-line application (no pointless trailing reset tag), mirroring the existing color handler.
- Remove the unused `isWebVtt` local.

Result: `{\fnArial}SELECTED TEXT{\fn}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)