### PR TITLE
SeConv: fail or warn on malformed SCC instead of writing corrupt output

### DIFF
--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -752,8 +752,17 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
             AnsiConsole.WriteLine();
             if (result.Success)
             {
-                AnsiConsole.MarkupLine($"[green]✓[/] Conversion completed successfully!");
+                if (result.Warnings.Count > 0)
+                {
+                    AnsiConsole.MarkupLine($"[yellow]⚠[/] Conversion completed with warnings");
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine($"[green]✓[/] Conversion completed successfully!");
+                }
+
                 AnsiConsole.MarkupLine($"[dim]Converted {result.SuccessfulFiles} file(s) in {elapsed}[/]");
+                PrintWarnings(result);
             }
             else
             {
@@ -779,6 +788,8 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                     }
                 }
 
+                PrintWarnings(result);
+
                 return 1;
             }
 
@@ -799,6 +810,21 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 }
             }
             return 1;
+        }
+    }
+
+    private static void PrintWarnings(ConversionResult result)
+    {
+        if (result.Warnings.Count == 0)
+        {
+            return;
+        }
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine("[yellow]Warnings:[/]");
+        foreach (var warning in result.Warnings)
+        {
+            AnsiConsole.MarkupLineInterpolated($"  [yellow]•[/] {warning}");
         }
     }
 
@@ -824,8 +850,10 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 output = f.Output,
                 success = f.Success,
                 error = f.Error,
+                warnings = f.Warnings,
             }),
             errors = result.Errors,
+            warnings = result.Warnings,
         };
         Console.WriteLine(System.Text.Json.JsonSerializer.Serialize(payload, JsonOptions));
     }

--- a/src/seconv/Core/LibSEIntegration.cs
+++ b/src/seconv/Core/LibSEIntegration.cs
@@ -58,7 +58,7 @@ internal static class LibSEIntegration
     /// Also returns the detected source format so the save side can apply
     /// <c>RemoveNativeFormatting</c> if the target is different.
     /// </summary>
-    public static (Subtitle Subtitle, SubtitleFormat Format) LoadSubtitleWithFormat(string filePath, string? encodingName = null, string? fallbackEncodingName = null)
+    public static (Subtitle Subtitle, SubtitleFormat Format) LoadSubtitleWithFormat(string filePath, string? encodingName = null, string? fallbackEncodingName = null, List<string>? warnings = null)
     {
         if (!File.Exists(filePath))
         {
@@ -92,6 +92,29 @@ internal static class LibSEIntegration
             {
                 return (csvSubtitle, new SubRip());
             }
+        }
+
+        // 0b. A file that declares the Scenarist SCC signature is SCC, full stop — decode it
+        // with the SCC parsers and never let it fall through to the generic guessers below,
+        // which would digit-scrape the raw source lines into garbage cues (#12582). The SCC
+        // parser is lenient (it skips undecodable rows and counts them), so a partially
+        // damaged file still converts, with a warning; a file where nothing decodes fails.
+        if (HasScenaristSccSignature(lines))
+        {
+            var (sccSubtitle, sccFormat, undecodableRows) = LoadBestScenaristScc(lines, filePath);
+            if (sccSubtitle.Paragraphs.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    $"File declares the Scenarist_SCC signature, but no valid captions could be decoded" +
+                    $"{(undecodableRows > 0 ? $" ({undecodableRows} undecodable row(s))" : string.Empty)}: {filePath}");
+            }
+
+            if (undecodableRows > 0)
+            {
+                warnings?.Add($"{undecodableRows} SCC caption row(s) could not be decoded and were skipped.");
+            }
+
+            return (sccSubtitle, sccFormat);
         }
 
         // 1. Try text-based formats by content sniffing
@@ -143,13 +166,61 @@ internal static class LibSEIntegration
         }
 
         // 4. Last resort: generic auto-guesser (handles freeform CSV, xlsx, ods, JSON variants, ...)
+        // Its output is only trusted when the guessed timing is plausible — the guesser scrapes
+        // numbers out of arbitrary text, and treating that as a successful conversion turns
+        // unparseable input into corrupt output that still reports success (#12582).
         var guessSubtitle = new UnknownFormatImporter { UseFrames = true }.AutoGuessImport(lines, filePath);
-        if (guessSubtitle.Paragraphs.Count > 0)
+        if (guessSubtitle.Paragraphs.Count > 0 && HasPlausibleGuessedTiming(guessSubtitle))
         {
             return (guessSubtitle, new SubRip());
         }
 
         throw new InvalidOperationException($"Unable to determine subtitle format for: {filePath}");
+    }
+
+    private static bool HasScenaristSccSignature(List<string> lines)
+    {
+        var firstNonBlank = lines.FirstOrDefault(l => !string.IsNullOrWhiteSpace(l));
+        return firstNonBlank != null && firstNonBlank.TrimStart().StartsWith("Scenarist_SCC", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Decodes an SCC file with both timing variants (non-drop and drop-frame) and keeps the
+    /// better result: more decoded captions wins, then fewer undecodable rows.
+    /// </summary>
+    private static (Subtitle Subtitle, SubtitleFormat Format, int UndecodableRows) LoadBestScenaristScc(List<string> lines, string filePath)
+    {
+        (Subtitle Subtitle, SubtitleFormat Format, int UndecodableRows) Load(SubtitleFormat format)
+        {
+            var subtitle = new Subtitle();
+            format.LoadSubtitle(subtitle, lines, filePath);
+            return (subtitle, format, format.ErrorCount);
+        }
+
+        var regular = Load(new ScenaristClosedCaptions());
+        var dropFrame = Load(new ScenaristClosedCaptionsDropFrame());
+        if (dropFrame.Subtitle.Paragraphs.Count > regular.Subtitle.Paragraphs.Count
+            || (dropFrame.Subtitle.Paragraphs.Count == regular.Subtitle.Paragraphs.Count
+                && regular.Subtitle.Paragraphs.Count > 0
+                && dropFrame.UndecodableRows < regular.UndecodableRows))
+        {
+            return dropFrame;
+        }
+
+        // Nothing decoded either way: report the variant that at least matched time codes,
+        // so the error carries the undecodable-row count.
+        if (regular.Subtitle.Paragraphs.Count == 0 && dropFrame.UndecodableRows > regular.UndecodableRows)
+        {
+            return dropFrame;
+        }
+
+        return regular;
+    }
+
+    private static bool HasPlausibleGuessedTiming(Subtitle subtitle)
+    {
+        return subtitle.Paragraphs.All(p => p.EndTime.TotalMilliseconds >= p.StartTime.TotalMilliseconds)
+               && subtitle.Paragraphs.Any(p => p.EndTime.TotalMilliseconds > 0);
     }
 
     /// <summary>

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -81,12 +81,22 @@ internal class SubtitleConverter
                         {
                             AnsiConsole.MarkupInterpolated($"[dim]{fileIndex}:[/] [cyan]{Path.GetFileName(inputFile)}[/] [dim]->[/] [green]{outputFile}[/]...");
                         }
-                        await ConvertFileAsync(inputFile, outputFile, options);
+                        var warnings = new List<string>();
+                        await ConvertFileAsync(inputFile, outputFile, options, warnings);
                         result.SuccessfulFiles++;
-                        result.Files.Add(new FileConversionResult(inputFile, outputFile, true, null));
+                        result.Files.Add(new FileConversionResult(inputFile, outputFile, true, null, warnings.Count > 0 ? warnings : null));
+                        foreach (var warning in warnings)
+                        {
+                            result.Warnings.Add($"{Path.GetFileName(inputFile)}: {warning}");
+                        }
+
                         if (!options.Quiet)
                         {
                             AnsiConsole.MarkupLine(" [green]done.[/]");
+                            foreach (var warning in warnings)
+                            {
+                                AnsiConsole.MarkupLineInterpolated($"   [yellow]warning: {warning}[/]");
+                            }
                         }
                     }
                     else
@@ -576,7 +586,7 @@ internal class SubtitleConverter
         return files;
     }
 
-    private async Task ConvertFileAsync(string inputFile, string outputFile, ConversionOptions options)
+    private async Task ConvertFileAsync(string inputFile, string outputFile, ConversionOptions options, List<string> warnings)
     {
         // Frame-based formats (e.g. MicroDVD) read Configuration.Settings.General.CurrentFrameRate
         // when loading. Set it before LoadSubtitle and restore in finally so concurrent or
@@ -603,7 +613,7 @@ internal class SubtitleConverter
 
                 // Load subtitle file using LibSE — keep the detected format so the
                 // save side can apply RemoveNativeFormatting when the target differs.
-                var (subtitle, sourceFormat) = LibSEIntegration.LoadSubtitleWithFormat(inputFile, resolvedOptions.Encoding, resolvedOptions.InputEncodingFallback);
+                var (subtitle, sourceFormat) = LibSEIntegration.LoadSubtitleWithFormat(inputFile, resolvedOptions.Encoding, resolvedOptions.InputEncodingFallback, warnings);
 
                 if (subtitle == null || subtitle.Paragraphs.Count == 0)
                 {
@@ -963,8 +973,12 @@ internal class ConversionResult
     public int SuccessfulFiles { get; set; }
     public int FailedFiles { get; set; }
     public List<string> Errors { get; set; } = new();
+
+    /// <summary>Non-fatal per-file issues (e.g. undecodable rows skipped); do not affect <see cref="Success"/>.</summary>
+    public List<string> Warnings { get; set; } = new();
+
     public List<FileConversionResult> Files { get; set; } = new();
     public bool Success => FailedFiles == 0 && Errors.Count == 0;
 }
 
-internal sealed record FileConversionResult(string Input, string? Output, bool Success, string? Error);
+internal sealed record FileConversionResult(string Input, string? Output, bool Success, string? Error, IReadOnlyList<string>? Warnings = null);

--- a/tests/seconv/Core/MalformedSccTest.cs
+++ b/tests/seconv/Core/MalformedSccTest.cs
@@ -1,0 +1,118 @@
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using SeConv.Core;
+using Xunit;
+
+namespace SeConvTests.Core;
+
+/// <summary>
+/// Regression tests for #12582: a file declaring the Scenarist_SCC signature must be
+/// decoded by the SCC parsers or fail - it must never fall through to the generic
+/// digit-scraping guesser, which turned malformed SCC into corrupt SRT (negative-duration
+/// cues, raw source text) while still reporting success.
+/// </summary>
+public class MalformedSccTest : IDisposable
+{
+    private readonly string _tempRoot;
+
+    // The minimal reproducer from #12582: a garbage payload row and a control-only row.
+    private const string MalformedScc =
+        "Scenarist_SCC V1.0\n" +
+        "\n" +
+        "00:00:25:00\tæ@æ@ðmBP ðnRðð÷P PÐaPP\n" +
+        "\n" +
+        "00:00:45:00\t942c 942c\n";
+
+    // One valid caption ("Hello world", display at 1s, clear at 3s).
+    private const string ValidSccRows =
+        "00:00:01:00\t9420 9420 94ae 94ae 9452 9452 97a1 97a1 c8e5 ecec ef20 f7ef f2ec 6480 942f 942f\n" +
+        "\n" +
+        "00:00:03:00\t942c 942c\n";
+
+    public MalformedSccTest()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "MalformedSccTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+    }
+
+    private string WriteFile(string name, string content)
+    {
+        var path = Path.Combine(_tempRoot, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    [Fact]
+    public void MalformedScc_NothingDecodes_Throws()
+    {
+        var path = WriteFile("invalid.scc", MalformedScc);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => LibSEIntegration.LoadSubtitleWithFormat(path));
+
+        Assert.Contains("Scenarist_SCC", ex.Message);
+        Assert.Contains("2 undecodable row(s)", ex.Message);
+    }
+
+    [Fact]
+    public void ValidScc_LoadsWithoutWarnings()
+    {
+        var path = WriteFile("valid.scc", "Scenarist_SCC V1.0\n\n" + ValidSccRows);
+        var warnings = new List<string>();
+
+        var (subtitle, format) = LibSEIntegration.LoadSubtitleWithFormat(path, warnings: warnings);
+
+        Assert.IsType<ScenaristClosedCaptions>(format);
+        var paragraph = Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("Hello world", paragraph.Text);
+        Assert.Equal(1000, paragraph.StartTime.TotalMilliseconds, precision: 0);
+        Assert.Equal(3000, paragraph.EndTime.TotalMilliseconds, precision: 0);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void PartiallyDamagedScc_LoadsDecodableRows_WithWarning()
+    {
+        var path = WriteFile("partial.scc",
+            "Scenarist_SCC V1.0\n\n" + ValidSccRows + "\n00:00:05:00\tæ@æ@ðmBP garbage row\n");
+        var warnings = new List<string>();
+
+        var (subtitle, format) = LibSEIntegration.LoadSubtitleWithFormat(path, warnings: warnings);
+
+        Assert.IsType<ScenaristClosedCaptions>(format);
+        var paragraph = Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("Hello world", paragraph.Text);
+        var warning = Assert.Single(warnings);
+        Assert.Contains("could not be decoded", warning);
+    }
+
+    [Fact]
+    public void DropFrameScc_LoadsWithDropFrameVariant()
+    {
+        var path = WriteFile("dropframe.scc",
+            "Scenarist_SCC V1.0\n\n" + ValidSccRows.Replace(":00\t", ";00\t"));
+
+        var (subtitle, format) = LibSEIntegration.LoadSubtitleWithFormat(path);
+
+        Assert.IsType<ScenaristClosedCaptionsDropFrame>(format);
+        var paragraph = Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("Hello world", paragraph.Text);
+    }
+
+    // Same corruption class without the SCC signature: the last-resort guesser scrapes
+    // digits out of arbitrary text ("V1.0" became a 42 ms -> 0 ms cue in #12582). Its
+    // output must be rejected when the guessed timing is implausible.
+    [Fact]
+    public void UnknownFormatGuess_ImplausibleTiming_Throws()
+    {
+        var path = WriteFile("not-a-subtitle.txt", MalformedScc.Replace("Scenarist_SCC", "Some_Other_Log"));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => LibSEIntegration.LoadSubtitleWithFormat(path));
+
+        Assert.Contains("Unable to determine subtitle format", ex.Message);
+    }
+}


### PR DESCRIPTION
Fixes #12582.

### Root cause

The SCC parser correctly rejected the malformed file (0 decodable captions), but format detection then fell through to the last-resort `UnknownFormatImporter`, which digit-scrapes arbitrary text: it read the header's `V1.0` as frame numbers 1→0 (producing the negative-duration cue `00:00:00,042 --> 00:00:00,000`) and emitted the raw SCC source lines as cues. SeConv reported `success: true` and exited 0.

### Fix

- **Signature lock:** a file whose first non-blank line declares `Scenarist_SCC` is decoded by the SCC parsers (non-drop and drop-frame, best result wins) and never reaches the generic guessers.
  - Partially damaged file → converts the decodable captions, exit 0, with a warning (console + `warnings` in the JSON payload, per-file and top-level): `N SCC caption row(s) could not be decoded and were skipped.`
  - Nothing decodes (the issue's repro) → the file fails with a clear error and non-zero exit; no output file is written.
- **Guesser sanity check:** `UnknownFormatImporter` output is rejected when its guessed timing is implausible (any negative-duration cue, or no cue ending after zero), so the same corruption class can't slip through for files without the SCC signature either.
- **Warnings channel:** `ConversionResult`/`FileConversionResult` now carry non-fatal warnings; they are shown per-file and in the summary, and included in `--json` output. Warnings do not affect `success` or the exit code.

### Repro before/after

`seconv invalid-scc.scc SubRip --json` on the issue's reproducer now exits 1 with:

```json
"error": "File declares the Scenarist_SCC signature, but no valid captions could be decoded (2 undecodable row(s)): ..."
```

### Tests

New `MalformedSccTest` (5 tests): malformed-SCC throw with row count, valid SCC round-trip, partial SCC with warning, drop-frame variant selection, and implausible-guess rejection for non-SCC input. Full seconv suite: **242/242 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)