### PR TITLE
OCR: add "show only forced subtitles" filter + forced column

### DIFF
--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -100,6 +100,8 @@ public partial class OcrViewModel : ObservableObject
     [ObservableProperty] private string _currentBitmapInfo;
     [ObservableProperty] private string _currentText;
     [ObservableProperty] private bool _isOcrRunning;
+    [ObservableProperty] private bool _hasForcedSubtitles;
+    [ObservableProperty] private bool _showOnlyForced;
     [ObservableProperty] private bool _isNOcrVisible;
     [ObservableProperty] private bool _isOllamaVisible;
     [ObservableProperty] private bool _isLlamaCppVisible;
@@ -166,6 +168,7 @@ public partial class OcrViewModel : ObservableObject
     public readonly List<SubtitleLineViewModel> OcredSubtitle;
 
     private IOcrSubtitle? _ocrSubtitle;
+    private List<OcrSubtitleItem> _allOcrSubtitleItems = new();
     private string _sourceFileName = string.Empty;
     private readonly INOcrCaseFixer _nOcrCaseFixer;
     private readonly IWindowService _windowService;
@@ -2132,6 +2135,7 @@ public partial class OcrViewModel : ObservableObject
         foreach (var item in itemsToRemove)
         {
             OcrSubtitleItems.Remove(item);
+            _allOcrSubtitleItems.Remove(item);
         }
 
         //foreach (var index in selectedIndices.OrderByDescending(p => p))
@@ -2158,9 +2162,11 @@ public partial class OcrViewModel : ObservableObject
 
     private void Renumber()
     {
-        for (var i = 0; i < OcrSubtitleItems.Count; i++)
+        // Renumber against the full list so numbers stay stable when the
+        // forced-only filter is active (filtered rows keep their track position).
+        for (var i = 0; i < _allOcrSubtitleItems.Count; i++)
         {
-            OcrSubtitleItems[i].Number = i + 1;
+            _allOcrSubtitleItems[i].Number = i + 1;
         }
     }
 
@@ -4440,12 +4446,34 @@ public partial class OcrViewModel : ObservableObject
         }, DispatcherPriority.Background);
     }
 
+    private void SetOcrSubtitleItems()
+    {
+        _allOcrSubtitleItems = _ocrSubtitle!.MakeOcrSubtitleItems();
+        HasForcedSubtitles = _allOcrSubtitleItems.Any(p => p.IsForced);
+        OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_allOcrSubtitleItems);
+    }
+
+    partial void OnShowOnlyForcedChanged(bool value)
+    {
+        if (_allOcrSubtitleItems.Count == 0)
+        {
+            return;
+        }
+
+        var selected = SelectedOcrSubtitleItem;
+        OcrSubtitleItems.Clear();
+        OcrSubtitleItems.AddRange(value ? _allOcrSubtitleItems.Where(p => p.IsForced) : _allOcrSubtitleItems);
+
+        var index = selected != null ? OcrSubtitleItems.IndexOf(selected) : -1;
+        SelectAndScrollToRow(index >= 0 ? index : 0);
+    }
+
     public void Initialize(List<BluRaySupParser.PcsData> subtitles, string fileName)
     {
         _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleBluRay(subtitles);
-        OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
+        SetOcrSubtitleItems();
     }
 
     public void Initialize(List<VobSubMergedPack> vobSubMergedPackList, List<SKColor> palette, string vobSubFileName)
@@ -4453,7 +4481,7 @@ public partial class OcrViewModel : ObservableObject
         _sourceFileName = vobSubFileName;
         Title = string.Format(Se.Language.Ocr.OcrX, vobSubFileName);
         _ocrSubtitle = new OcrSubtitleVobSub(vobSubMergedPackList, palette);
-        OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
+        SetOcrSubtitleItems();
         IsVobSubVisible = true;
         ApplyStoredVobSubColors();
     }
@@ -4463,7 +4491,7 @@ public partial class OcrViewModel : ObservableObject
         _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleMp4VobSub(mp4SubtitleTrack, paragraphs);
-        OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
+        SetOcrSubtitleItems();
     }
 
     public void Initialize(List<VobSubMergedPack> mergedVobSubPacks, List<SKColor> palette, MatroskaTrackInfo matroskaSubtitleInfo, string fileName)
@@ -4471,7 +4499,7 @@ public partial class OcrViewModel : ObservableObject
         _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleVobSub(mergedVobSubPacks, palette);
-        OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
+        SetOcrSubtitleItems();
         IsVobSubVisible = true;
         ApplyStoredVobSubColors();
     }
@@ -4481,7 +4509,7 @@ public partial class OcrViewModel : ObservableObject
         _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleMkvDvb(matroskaSubtitleInfo, subtitle, subtitleImages);
-        OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
+        SetOcrSubtitleItems();
     }
 
     public void Initialize(MatroskaTrackInfo matroskaSubtitleInfo, List<BluRaySupParser.PcsData> pcsDataList, string fileName)
@@ -4489,7 +4517,7 @@ public partial class OcrViewModel : ObservableObject
         _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleMkvBluRay(matroskaSubtitleInfo, pcsDataList);
-        OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
+        SetOcrSubtitleItems();
     }
 
     public void Initialize(IList<IBinaryParagraphWithPosition> list, string fileName)
@@ -4497,7 +4525,7 @@ public partial class OcrViewModel : ObservableObject
         _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleIBinaryParagraph(list);
-        OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
+        SetOcrSubtitleItems();
     }
 
     public void InitializeBdn(Subtitle subtitle, string fileName, bool isSon)
@@ -4505,7 +4533,7 @@ public partial class OcrViewModel : ObservableObject
         _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleBdn(subtitle, fileName, isSon);
-        OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
+        SetOcrSubtitleItems();
     }
 
     public void InitializeWebVtt(Subtitle subtitle, string fileName)
@@ -4513,7 +4541,7 @@ public partial class OcrViewModel : ObservableObject
         _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleWebVttImages(subtitle, fileName);
-        OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
+        SetOcrSubtitleItems();
     }
 
     public void InitializeSpDvdSup(string fileName)
@@ -4521,7 +4549,7 @@ public partial class OcrViewModel : ObservableObject
         _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleSpDvdSupImages(fileName);
-        OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
+        SetOcrSubtitleItems();
     }
 
     internal void Initialize(TransportStreamParser tsParser, List<TransportStreamSubtitle> subtitles, string fileName)
@@ -4529,7 +4557,7 @@ public partial class OcrViewModel : ObservableObject
         _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleTransportStream(tsParser, subtitles, fileName);
-        OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
+        SetOcrSubtitleItems();
     }
 
     internal void Initialize(List<ImportImageItem> images)
@@ -4537,7 +4565,7 @@ public partial class OcrViewModel : ObservableObject
         _sourceFileName = string.Empty;
         Title = string.Format(Se.Language.Ocr.OcrX, Se.Language.General.Images);
         _ocrSubtitle = new OcrImportImage(images);
-        OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
+        SetOcrSubtitleItems();
     }
 
     internal void InitializeDivX(List<XSub> list, string fileName)
@@ -4545,7 +4573,7 @@ public partial class OcrViewModel : ObservableObject
         _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, "DivX");
         _ocrSubtitle = new OcrSubtitleDivX(list, fileName);
-        OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_ocrSubtitle.MakeOcrSubtitleItems());
+        SetOcrSubtitleItems();
     }
 
     private double CalculateRowHeight()

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -195,12 +195,20 @@ public class OcrWindow : Window
         Attached.SetIcon(toggleButtonFallbackDatabase, IconNames.DatabaseArrowRight);
         ToolTip.SetTip(toggleButtonFallbackDatabase, Se.Language.Ocr.FallbackOcrDatabase);
 
+        var toggleButtonShowOnlyForced = new ToggleButton();
+        Attached.SetIcon(toggleButtonShowOnlyForced, IconNames.Filter);
+        ToolTip.SetTip(toggleButtonShowOnlyForced, Se.Language.Ocr.ShowOnlyForcedSubtitles);
+        toggleButtonShowOnlyForced.Bind(ToggleButton.IsCheckedProperty, new Binding(nameof(vm.ShowOnlyForced)));
+        toggleButtonShowOnlyForced.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.HasForcedSubtitles)));
+        toggleButtonShowOnlyForced.Bind(InputElement.IsEnabledProperty, new Binding(nameof(vm.IsOcrRunning)) { Converter = new InverseBooleanConverter() });
+
         var panelRight = new StackPanel
         {
             Orientation = Orientation.Horizontal,
             HorizontalAlignment = HorizontalAlignment.Right,
             Children =
             {
+                toggleButtonShowOnlyForced,
                 toggleButtonCaptureAlignment,
                 toggleButtonPreProcessing,
                 toggleButtonVobSubColors,
@@ -409,6 +417,21 @@ public class OcrWindow : Window
             ItemsSource = vm.OcrSubtitleItems,
             Columns =
             {
+                new DataGridTemplateColumn
+                {
+                    Header = Se.Language.General.Forced,
+                    IsReadOnly = true,
+                    IsVisible = vm.HasForcedSubtitles,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    CellTemplate = new FuncDataTemplate<OcrSubtitleItem>((_, _) =>
+                        new CheckBox
+                        {
+                            [!ToggleButton.IsCheckedProperty] = new Binding(nameof(OcrSubtitleItem.IsForced)) { Mode = BindingMode.OneWay },
+                            HorizontalAlignment = HorizontalAlignment.Center,
+                            IsHitTestVisible = false,
+                            Focusable = false,
+                        }),
+                },
                 new DataGridTextColumn
                 {
                     Header = Se.Language.General.NumberSymbol,

--- a/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
+++ b/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
@@ -68,6 +68,7 @@ public class LanguageOcr
     public string Binarize { get; set; }
     public string BorderSize { get; set; }
     public string CaptureTopAlign { get; set; }
+    public string ShowOnlyForcedSubtitles { get; set; }
     public string OcrImage { get; set; }
     public string OneColor { get; set; }
     public string DarknessThreshold { get; set; }
@@ -180,6 +181,7 @@ public class LanguageOcr
         Binarize = "Binarize";
         BorderSize = "Border size";
         CaptureTopAlign = "Auto-detect ASSA alignment";
+        ShowOnlyForcedSubtitles = "Show only forced subtitles";
         OcrImage = "OCR image";
         OneColor = "One color (white)";
         DarknessThreshold = "Darkness threshold";


### PR DESCRIPTION
Fixes #12601

In v4 the OCR window had a checkbox to process only forced subtitles; v5 was missing this.

Changes to the OCR window, only active when the loaded track actually contains forced lines (PGS/Blu-ray sup, VobSub, DVB via TS, BDN XML — sources without a forced flag are unaffected):

- A **filter toggle button** (top right, filter icon, tooltip "Show only forced subtitles") that limits the list to forced lines only. Since OCR, export, and OK all operate on the visible list, this means only forced lines are OCR'ed and returned — same behavior as v4.
- A read-only **Forced column** (matching the checkbox column in the Binary Edit window) so it is visible which lines are forced.
- Line numbers stay stable while filtered (they keep their position in the full track), and toggling the filter off restores the full list with any already-OCR'ed text intact.
- The toggle is disabled while OCR is running; deleted lines are removed from the underlying full list so they don't reappear when the filter is switched off.

Binary Edit already supports forced flags (toggle forced, select forced/non-forced lines, forced column), so no changes were needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)