### PR TITLE
Fix six bugs found in a code audit (SAMI crash, WebVTT/TTML parsing, mkv/translate/STT dialog state)

### DIFF
--- a/src/libse/SubtitleFormats/Sami.cs
+++ b/src/libse/SubtitleFormats/Sami.cs
@@ -249,7 +249,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             int styleStart = allInputLower.IndexOf("<style", StringComparison.Ordinal);
             if (styleStart > 0)
             {
-                int styleEnd = allInputLower.IndexOf("</style>", StringComparison.Ordinal);
+                int styleEnd = allInputLower.IndexOf("</style>", styleStart, StringComparison.Ordinal);
                 if (styleEnd > 0)
                 {
                     subtitle.Header = allInput.Substring(styleStart, styleEnd - styleStart + 8);
@@ -259,7 +259,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             const string syncTag = "<sync start=";
             const string syncTagEnc = "<sync encrypted=\"true\" start=";
             int syncStartPos = allInputLower.IndexOf(syncTag, StringComparison.Ordinal);
-            bool hasEncryptedTags = allInput.IndexOf(syncTagEnc, StringComparison.Ordinal) >= 0;
+            bool hasEncryptedTags = allInputLower.IndexOf(syncTagEnc, StringComparison.Ordinal) >= 0;
             int index = syncStartPos + syncTag.Length;
 
             int syncStartPosEnc = -1;

--- a/src/libse/SubtitleFormats/TimedText10.cs
+++ b/src/libse/SubtitleFormats/TimedText10.cs
@@ -1112,21 +1112,19 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         private static readonly Regex _endsWithTreeDigits = new Regex(@"\d\d\d$");
         private static readonly Regex FixAmpersandRegex = new Regex("&(?!amp;)", RegexOptions.Compiled);
+        private static readonly char[] FractionSeparators = { '.', ',' };
+        private static readonly char[] TimePartSeparators = { ':', ';' };
         private static bool IsFrames(string timeCode)
         {
-            if (timeCode.Length == 12 && (timeCode[8] == '.' || timeCode[8] == ',')) // 00:00:08.292 or 00:00:08,292
+            var lastFractionSeparator = timeCode.LastIndexOfAny(FractionSeparators);
+            if (lastFractionSeparator >= 0 && lastFractionSeparator > timeCode.LastIndexOfAny(TimePartSeparators))
             {
-                return false;
-            }
-
-            if (timeCode.Length == 11 && timeCode[8] == '.') // 00:00:08.12 (last part is milliseconds / 10)
-            {
-                return false;
+                return false; // '.'/',' after the last ':'/';' starts a fraction of a second, not a frame count - e.g. 00:00:08.292 or 00:00:01.5
             }
 
             if (_endsWithTreeDigits.IsMatch(timeCode))
             {
-                return false;
+                return false; // e.g. 00:00:08:292 - last part is milliseconds
             }
 
             if (timeCode.Split(':', '.', ',', ';').Length < 4)
@@ -1387,7 +1385,23 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 hours = 0;
             }
 
-            return new TimeCode(hours, int.Parse(parts[1]), int.Parse(parts[2]), parts.Length > 3 ? int.Parse(parts[3]) : 0);
+            var milliseconds = 0;
+            if (parts.Length > 3)
+            {
+                var fractionSeparatorIndex = s.LastIndexOfAny(FractionSeparators);
+                if (fractionSeparatorIndex > s.LastIndexOfAny(TimePartSeparators))
+                {
+                    // '.'/',' starts a fraction of a second with any number of digits (TTML spec)
+                    var fraction = double.Parse(parts[3], CultureInfo.InvariantCulture);
+                    milliseconds = (int)Math.Round(fraction * Math.Pow(10, 3 - parts[3].Length));
+                }
+                else
+                {
+                    milliseconds = int.Parse(parts[3]); // legacy: 00:00:08:123 - last part is milliseconds
+                }
+            }
+
+            return new TimeCode(hours, int.Parse(parts[1]), int.Parse(parts[2]), milliseconds);
         }
 
         public override List<string> AlternateExtensions => new List<string> { ".itt", ".dfxp", ".ttml" };

--- a/src/libse/SubtitleFormats/WebVTT.cs
+++ b/src/libse/SubtitleFormats/WebVTT.cs
@@ -17,6 +17,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         private static readonly Regex RegexTimeCodes = new Regex(@"^-?\d+:-?\d+:-?\d+\.-?\d+\s*-->\s*-?\d+:-?\d+:-?\d+\.-?\d+", RegexOptions.Compiled);
         private static readonly Regex RegexTimeCodesMiddle = new Regex(@"^-?\d+:-?\d+\.-?\d+\s*-->\s*-?\d+:-?\d+:-?\d+\.-?\d+", RegexOptions.Compiled);
         private static readonly Regex RegexTimeCodesShort = new Regex(@"^-?\d+:-?\d+\.-?\d+\s*-->\s*-?\d+:-?\d+\.-?\d+", RegexOptions.Compiled);
+        private static readonly Regex RegexTimeCodesEndShort = new Regex(@"^-?\d+:-?\d+:-?\d+\.-?\d+\s*-->\s*-?\d+:-?\d+\.-?\d+", RegexOptions.Compiled);
         private static readonly Regex RegexShortArrow = new Regex(@"-->\s*", RegexOptions.Compiled);
         private static readonly Regex RegexRemoveCTags = new Regex(@"\</?c([a-zA-Z\._\-\d%#]*)\>", RegexOptions.Compiled);
         private static readonly Regex RegexRemoveTimeCodes = new Regex(@"\<\d+:\d+:\d+\.\d+\>", RegexOptions.Compiled); // <00:00:10.049>
@@ -267,6 +268,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     s = "00:" + RegexShortArrow.Replace(s, "--> 00:", 1);
                 }
 
+                if (isTimeCode && RegexTimeCodesEndShort.IsMatch(s))
+                {
+                    s = RegexShortArrow.Replace(s, "--> 00:", 1); // start has hours, end is without hours
+                }
+
                 if (isNextTimeCode && Utilities.IsNumber(s) && p?.Text.Length > 0)
                 {
                     numbers++;
@@ -312,6 +318,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 else if (p != null && hadEmptyLine &&
                          (RegexTimeCodesMiddle.IsMatch(next) ||
                           RegexTimeCodesShort.IsMatch(next) ||
+                          RegexTimeCodesEndShort.IsMatch(next) ||
                           RegexTimeCodes.IsMatch(next)))
                 {
                     // can both be number or an "identifier" which can be text

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -1272,13 +1272,17 @@ public partial class AutoTranslateViewModel : ObservableObject
         }
 
         var sourceLanguage = translator.GetSupportedSourceLanguages()
-            .FirstOrDefault(p => p.Name.Equals(SelectedSourceLanguage?.ToString() ?? string.Empty, StringComparison.InvariantCultureIgnoreCase));
+            .FirstOrDefault(p => p.Code == SelectedSourceLanguage?.Code);
 
         var targetLanguage = translator.GetSupportedTargetLanguages()
-            .FirstOrDefault(p => p.Name.Equals(SelectedTargetLanguage?.ToString() ?? string.Empty, StringComparison.InvariantCultureIgnoreCase));
+            .FirstOrDefault(p => p.Code == SelectedTargetLanguage?.Code);
 
         if (sourceLanguage == null || targetLanguage == null)
         {
+            _translationInProgress = false;
+            IsTranslateEnabled = true;
+            IsProgressEnabled = false;
+            StatusText = Se.Language.Translate.ReadyToTranslate;
             return false;
         }
 

--- a/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditViewModel.cs
+++ b/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditViewModel.cs
@@ -180,7 +180,7 @@ public partial class EmbeddedSubtitlesEditViewModel : ObservableObject
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Error);
 
-                IsGenerating = true;
+                IsGenerating = false;
                 ProgressValue = 0;
             });
 

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -3265,6 +3265,7 @@ public partial class SpeechToTextViewModel : ObservableObject
                 return;
             }
 
+            BatchItems.Clear(); // may hold stale items from an earlier batch-mode session
             BatchItems.Add(new SpeechToTextJobItem(_videoFileName, string.Empty, mediaInfo));
         }
         _batchIndex = 0;

--- a/tests/libse/SubtitleFormats/SamiTest.cs
+++ b/tests/libse/SubtitleFormats/SamiTest.cs
@@ -1,0 +1,68 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace LibSETests.SubtitleFormats;
+
+public class SamiTest
+{
+    private static Subtitle LoadSamiSubtitle(string content)
+    {
+        var subtitle = new Subtitle();
+        var format = new Sami();
+        var lines = new List<string>(content.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None));
+        format.LoadSubtitle(subtitle, lines, null);
+        return subtitle;
+    }
+
+    [Fact]
+    public void LoadSubtitleDoesNotThrowWhenStyleEndTagOccursBeforeStyleStartTag()
+    {
+        // A stray "</style>" before the "<style>" block used to produce a negative
+        // substring length (crashing IsMine/format detection with ArgumentOutOfRangeException)
+        var content = "x</style>\r\n" +
+                      "<style type=\"text/css\">\r\n" +
+                      "<sync start=1000><p class=enuscc>Hello\r\n" +
+                      "<sync start=3000><p class=enuscc>&nbsp;";
+
+        var subtitle = LoadSamiSubtitle(content);
+
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("Hello", subtitle.Paragraphs[0].Text);
+        Assert.Equal(1000, subtitle.Paragraphs[0].StartTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void IsMineDoesNotThrowWhenStyleEndTagOccursBeforeStyleStartTag()
+    {
+        var lines = new List<string>
+        {
+            "x</style>",
+            "<style type=\"text/css\">",
+            "<sync start=1000><p class=enuscc>Hello",
+            "<sync start=3000><p class=enuscc>&nbsp;",
+        };
+
+        Assert.True(new Sami().IsMine(lines, "test.smi"));
+    }
+
+    [Fact]
+    public void LoadSubtitleSupportsEncryptedSyncTagsInAnyCasing()
+    {
+        var content = "<SAMI>\r\n" +
+                      "<BODY>\r\n" +
+                      "<SYNC Encrypted=\"true\" Start=1000><P Class=ENUSCC>Hello world\r\n" +
+                      "<SYNC Encrypted=\"true\" Start=3000><P Class=ENUSCC>&nbsp;\r\n" +
+                      "</BODY>\r\n" +
+                      "</SAMI>";
+
+        var subtitle = LoadSamiSubtitle(content);
+
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("Hello world", subtitle.Paragraphs[0].Text);
+        Assert.Equal(1000, subtitle.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(3000, subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+    }
+}

--- a/tests/libse/SubtitleFormats/TimedText10Test.cs
+++ b/tests/libse/SubtitleFormats/TimedText10Test.cs
@@ -1,0 +1,88 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace LibSETests.SubtitleFormats;
+
+public class TimedText10Test
+{
+    private static Subtitle LoadTimedTextSubtitle(string xml)
+    {
+        var subtitle = new Subtitle();
+        var format = new TimedText10();
+        var lines = new List<string>(xml.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None));
+        format.LoadSubtitle(subtitle, lines, null);
+        return subtitle;
+    }
+
+    private static string MakeTtml(string begin, string end)
+    {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n" +
+               "<tt xmlns=\"http://www.w3.org/ns/ttml\">\r\n" +
+               "  <body>\r\n" +
+               "    <div>\r\n" +
+               $"      <p begin=\"{begin}\" end=\"{end}\">Hello</p>\r\n" +
+               "    </div>\r\n" +
+               "  </body>\r\n" +
+               "</tt>";
+    }
+
+    [Fact]
+    public void GetTimeCodeOneDigitFractionIsFractionOfSecond()
+    {
+        // ".5" is half a second per the TTML spec - not 5 frames, not 5 ms
+        var timeCode = TimedText10.GetTimeCode("00:00:01.5", false);
+        Assert.Equal(1500, timeCode.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void GetTimeCodeFourDigitFractionIsFractionOfSecond()
+    {
+        var timeCode = TimedText10.GetTimeCode("00:00:05.9463", false);
+        Assert.Equal(5946, timeCode.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void GetTimeCodeThreeDigitFractionIsMilliseconds()
+    {
+        var timeCode = TimedText10.GetTimeCode("00:01:39.946", false);
+        Assert.Equal(99946, timeCode.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void GetTimeCodeTwoDigitFractionIsFractionOfSecond()
+    {
+        var timeCode = TimedText10.GetTimeCode("00:00:08.12", false);
+        Assert.Equal(8120, timeCode.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void GetTimeCodeColonSeparatedLastPartIsMilliseconds()
+    {
+        // legacy/malformed files use a colon before the milliseconds
+        var timeCode = TimedText10.GetTimeCode("00:00:08:123", false);
+        Assert.Equal(8123, timeCode.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void LoadSubtitleParsesOneDigitFractionAsFractionOfSecond()
+    {
+        var subtitle = LoadTimedTextSubtitle(MakeTtml("00:00:01.5", "00:00:03.5"));
+
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Equal(1500, subtitle.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(3500, subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void LoadSubtitleParsesFourDigitFractionAsFractionOfSecond()
+    {
+        var subtitle = LoadTimedTextSubtitle(MakeTtml("00:00:05.9463", "00:00:08.1000"));
+
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Equal(5946, subtitle.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(8100, subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+    }
+}

--- a/tests/libse/SubtitleFormats/WebVttTest.cs
+++ b/tests/libse/SubtitleFormats/WebVttTest.cs
@@ -44,6 +44,21 @@ public class WebVttTest
     }
 
     [Fact]
+    public void LoadSubtitleSupportsHourlessEndTimestamp()
+    {
+        // WebVTT allows each timestamp independently to omit the hour part
+        var vtt = "WEBVTT\r\n\r\n00:00:05.000 --> 00:10.000\r\nHello there\r\n\r\n00:11.000 --> 00:00:14.000\r\nSecond cue";
+        var subtitle = LoadWebVttSubtitle(vtt);
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+        Assert.Equal("Hello there", subtitle.Paragraphs[0].Text);
+        Assert.Equal(5000, subtitle.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(10000, subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal("Second cue", subtitle.Paragraphs[1].Text);
+        Assert.Equal(11000, subtitle.Paragraphs[1].StartTime.TotalMilliseconds);
+        Assert.Equal(14000, subtitle.Paragraphs[1].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
     public void LoadSubtitleDoesNotMergeCuesWithDifferentTimeCodes()
     {
         var vtt = "WEBVTT\r\n\r\n00:00:01.000 --> 00:00:04.000\r\nHello\r\n\r\n00:00:05.000 --> 00:00:08.000\r\nWorld";


### PR DESCRIPTION
Fixes six bugs found in a systematic code audit. The three parser fixes come with unit tests (10 new tests; full libse/seconv/libuilogic suites pass).

## Core parsers (libse)

1. **SAMI: crash on malformed file breaks format auto-detection.** `LoadSubtitle` looked up `</style>` from the start of the input, so a stray `</style>` before the `<style>` block produced a negative substring length and `IsMine` threw `ArgumentOutOfRangeException` — and since `Subtitle.Parse` probes formats unguarded, such a file broke loading in general. The lookup now starts at the `<style` position. Bonus one-word fix in the same method: the encrypted-sync-tag probe searched the original-case input for a lowercase literal, so `<SYNC Encrypted="true" ...>` files loaded 0 lines.

2. **WebVTT: valid cue silently dropped.** WebVTT allows each timestamp independently to omit the hour part, but only "short → short" and "short → long" were normalized; a "long → short" line (`00:00:05.000 --> 00:10.000`) matched no regex and the cue was lost. Added the missing normalization (and the corresponding look-ahead check).

3. **TimedText10: fractional seconds misparsed for 1-digit and 4+-digit fractions.** Per the TTML spec the digits after `.` are a fraction of a second with any number of digits, but only 2- and 3-digit fractions were handled: `begin="00:00:01.5"` was routed to the frames path (1209 ms at 23.976 fps instead of 1500 ms) and `begin="00:00:05.9463"` was read as 9463 whole milliseconds (14463 ms instead of 5946 ms). `IsFrames` now treats a `.`/`,` after the last `:`/`;` as a fraction, and `GetTimeCode` scales fraction digits to milliseconds. The legacy colon-milliseconds heuristic (`00:00:08:123`) is preserved and pinned by a test.

## UI dialog state

4. **Embedded subtitles (mkv): dialog locked after a failed generate.** The ffmpeg-failure branch set `IsGenerating = true` instead of `false` (the MP4 sibling gets it right), leaving the Generate button permanently disabled so the user could never retry.

5. **Auto-translate: languages with underscores in the engine name never matched.** The lookup compared the engine's `Name` to the display `ToString()` (which lowercases and replaces underscores), so e.g. Google Translate V1's `CHINESE_SIMPLIFIED` could never match — pressing Translate did nothing and the failure path left the dialog stuck on "Translating…" with the button disabled. Now matches by `Code` and resets state when the lookup fails.

6. **Speech to text: single-mode transcribe could process the wrong file.** Single mode appended the current video to `BatchItems` but the pipeline consumes `BatchItems[0]`; leftover items from an earlier batch-mode session (mode switching never cleared the list) meant a previously queued file was transcribed and its transcript loaded against the open video. The queue is now cleared when a single-mode transcribe starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)