### PR TITLE
Fix remaining bugs from the code audit (OCR forced-filter/delete, MicroDVD, burn-in cut, TTS review)

### DIFF
--- a/src/libse/SubtitleFormats/MicroDvd.cs
+++ b/src/libse/SubtitleFormats/MicroDvd.cs
@@ -68,10 +68,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 if (index >= 0 && index + 1 < line.Length)
                 {
                     var indexOfBrackets = line.IndexOf("{}", StringComparison.Ordinal);
-                    if (indexOfBrackets >= 0 && indexOfBrackets < index)
+                    while (indexOfBrackets >= 0 && indexOfBrackets < index)
                     {
                         line = line.Insert(indexOfBrackets + 1, "0"); // set empty time codes to zero
                         index++;
+                        indexOfBrackets = line.IndexOf("{}", StringComparison.Ordinal); // both time codes may be empty
                     }
 
                     while (line.Contains(' ') && line.IndexOf(' ') < index)

--- a/src/ui/Features/Ocr/OcrSubtitleItem.cs
+++ b/src/ui/Features/Ocr/OcrSubtitleItem.cs
@@ -90,6 +90,9 @@ public partial class OcrSubtitleItem : ObservableObject
 
     public bool IsForced => _ocrSubtitle.GetIsForced(_index);
 
+    /// <summary>Index into the underlying IOcrSubtitle source - stable across filtering/deletion of the view collection.</summary>
+    public int SourceIndex => _index;
+
     public SKPointI GetPosition()
     {
         return _ocrSubtitle.GetPosition(_index);

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -1863,9 +1863,7 @@ public partial class OcrViewModel : ObservableObject
             return;
         }
 
-        var previewSubPicture = vobSub.GetSubPicture(SelectedOcrSubtitleItem != null
-            ? Math.Max(0, OcrSubtitleItems.IndexOf(SelectedOcrSubtitleItem))
-            : 0);
+        var previewSubPicture = vobSub.GetSubPicture(SelectedOcrSubtitleItem?.SourceIndex ?? 0);
 
         var result = await _windowService.ShowDialogAsync<VobSubColorChooser.VobSubColorChooserWindow, VobSubColorChooser.VobSubColorChooserViewModel>(
             Window,
@@ -2103,6 +2101,11 @@ public partial class OcrViewModel : ObservableObject
     [RelayCommand]
     private void DeleteSelectedLines()
     {
+        if (IsOcrRunning)
+        {
+            return; // the OCR loops hold indices into OcrSubtitleItems - deleting mid-run shifts them
+        }
+
         var selectedItems = SubtitleGrid.SelectedItems;
         if (selectedItems == null || selectedItems.Count == 0)
         {
@@ -2148,7 +2151,7 @@ public partial class OcrViewModel : ObservableObject
         var toRemove = new List<UnknownWordItem>();
         foreach (var unknownWord in UnknownWords)
         {
-            if (!OcrSubtitleItems.Contains(unknownWord.Item))
+            if (!_allOcrSubtitleItems.Contains(unknownWord.Item)) // OcrSubtitleItems may be filtered to forced-only
             {
                 toRemove.Add(unknownWord);
             }

--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -818,6 +818,7 @@ public partial class BurnInViewModel : ObservableObject
         var isAssa = subtitleFileName.EndsWith(".ass", StringComparison.OrdinalIgnoreCase);
 
         var subtitle = Subtitle.Parse(subtitleFileName);
+        subtitle = GetSubtitleBasedOnCut(subtitle);
 
         if (!isAssa)
         {
@@ -838,6 +839,31 @@ public partial class BurnInViewModel : ObservableObject
         var assaFileName = Path.Combine(Path.GetTempFileName() + assa.Extension);
         File.WriteAllText(assaFileName, assa.ToText(subtitle, string.Empty));
         return assaFileName;
+    }
+
+    // The "-ss" input seek makes ffmpeg restart timestamps at zero, so the burned-in
+    // subtitle must be limited to the cut window and shifted accordingly (same as
+    // TransparentSubtitlesViewModel.GetSubtitleBasedOnCut).
+    private Subtitle GetSubtitleBasedOnCut(Subtitle inputSubtitle)
+    {
+        if (!IsCutActive)
+        {
+            return inputSubtitle;
+        }
+
+        var subtitle = new Subtitle();
+        foreach (var p in inputSubtitle.Paragraphs)
+        {
+            if (p.StartTime.TotalMilliseconds >= CutFrom.TotalMilliseconds &&
+                p.EndTime.TotalMilliseconds <= CutTo.TotalMilliseconds)
+            {
+                subtitle.Paragraphs.Add(new Paragraph(p));
+            }
+        }
+
+        subtitle.AddTimeToAllParagraphs(TimeSpan.FromMilliseconds(-CutFrom.TotalMilliseconds));
+
+        return subtitle;
     }
 
     private void SetStyleForNonAssa(Subtitle sub, int width, int height)

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -297,21 +297,43 @@ public partial class ReviewSpeechViewModel : ObservableObject
             return;
         }
 
-        lock (_playLock)
+        try
         {
-            _mpvContext?.Stop();
-            _mpvContext?.Dispose();
-
-            _mpvContext = new LibMpvDynamicPlayer();
-            _mpvContext.LoadLib(); 
-            var err = _mpvContext.Initialize();
-            if (err < 0)
+            lock (_playLock)
             {
-                throw new InvalidOperationException($"Failed to initialize mpv: {_mpvContext.GetErrorString(err)}");
-            }
-        }
+                _mpvContext?.Stop();
+                _mpvContext?.Dispose();
 
-        await _mpvContext.LoadAudio(fileName);
+                _mpvContext = new LibMpvDynamicPlayer();
+                _mpvContext.LoadLib();
+                var err = _mpvContext.Initialize();
+                if (err < 0)
+                {
+                    throw new InvalidOperationException($"Failed to initialize mpv: {_mpvContext.GetErrorString(err)}");
+                }
+            }
+
+            await _mpvContext.LoadAudio(fileName);
+        }
+        catch (Exception exception)
+        {
+            // An mpv load/init failure must not escape: the callers disable all rows before
+            // awaiting and only the playback timer re-enables them, so an unhandled throw
+            // leaves every play/regenerate button dead until the window is reopened.
+            SeLogger.Error(exception, $"ReviewSpeech: unable to play audio file \"{fileName}\"");
+            ResetPlaybackUiState();
+            if (Window != null)
+            {
+                await MessageBox.Show(
+                    Window,
+                    Se.Language.General.Error,
+                    "Unable to play audio: " + exception.Message,
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+
+            return;
+        }
 
         _timer.Start();
     }

--- a/tests/libse/SubtitleFormats/MicroDVDTest.cs
+++ b/tests/libse/SubtitleFormats/MicroDVDTest.cs
@@ -1,0 +1,46 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System.Collections.Generic;
+using Xunit;
+
+namespace LibSETests.SubtitleFormats;
+
+public class MicroDVDTest
+{
+    [Fact]
+    public void LoadSubtitleRepairsLineWithBothTimeCodesEmpty()
+    {
+        var format = new MicroDvd();
+        var subtitle = new Subtitle();
+        var lines = new List<string>
+        {
+            "{0}{25}First line",
+            "{}{}Second line",
+            "{50}{75}Third line",
+        };
+
+        format.LoadSubtitle(subtitle, lines, null);
+
+        Assert.Equal(0, format.ErrorCount);
+        Assert.Equal(3, subtitle.Paragraphs.Count);
+        Assert.Equal("Second line", subtitle.Paragraphs[1].Text);
+    }
+
+    [Fact]
+    public void LoadSubtitleRepairsLineWithOneTimeCodeEmpty()
+    {
+        var format = new MicroDvd();
+        var subtitle = new Subtitle();
+        var lines = new List<string>
+        {
+            "{}{25}First line",
+            "{50}{75}Second line",
+        };
+
+        format.LoadSubtitle(subtitle, lines, null);
+
+        Assert.Equal(0, format.ErrorCount);
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+        Assert.Equal("First line", subtitle.Paragraphs[0].Text);
+    }
+}


### PR DESCRIPTION
Follow-up to #12605 — fixes the remaining bugs found in the code audit.

## OCR window

1. **Forced-filter regression from #12604:** the unknown-words orphan sweep in `DeleteSelectedLines` checked membership against `OcrSubtitleItems`, which can be filtered to forced-only — deleting a visible row then permanently wiped the unknown-word entries of every hidden (non-forced, not deleted) row. Now checks the full `_allOcrSubtitleItems` list.
2. **Delete during a running OCR corrupted the run:** all OCR loops capture indices into `OcrSubtitleItems` at start, but the Delete key/context menu stayed active while OCR ran — deleting a row shifted every later index (text landing on the wrong row) and eventually threw out of the background task, leaving `IsOcrRunning` stuck true with the window in a dead "running" state. `DeleteSelectedLines` now no-ops while OCR is running (matching the other controls, which are already disabled during a run).
3. **VobSub color chooser previewed the wrong image:** it passed the item's position in the (possibly filtered or delete-mutated) grid collection into the source-indexed `GetSubPicture`. `OcrSubtitleItem` now exposes its stable `SourceIndex` and the color chooser uses it.

## Other

4. **MicroDVD:** the empty-time-code repair only fixed the first `{}`, so a `{}{}Text` line was half-repaired and then discarded as a parse error. Both codes are now repaired (unit tests added for both the single- and double-empty cases).
5. **Burn-in with cut enabled burned the wrong lines:** the `-ss` before `-i` makes ffmpeg restart timestamps at zero, but the generated ASSA kept absolute times — a 10:00→12:00 cut showed the 00:00–02:00 dialogue (or nothing). The subtitle is now limited to the cut window and shifted by −cutStart, exactly like `TransparentSubtitlesViewModel.GetSubtitleBasedOnCut` already does. The live preview is unaffected (it builds its own ASSA and passes no seek).
6. **TTS Review Speech lockup:** the play commands disable every row before awaiting `PlayAudio`, and only the playback timer re-enables them — so an mpv init/load failure threw out of the async command and left all play/regenerate buttons dead until the window was reopened (and an exception escaping an async command can tear down the Avalonia dispatcher). `PlayAudio` now catches the failure, resets the playback UI state, and shows the error, mirroring its existing missing-file handling.

Tests: 2 new MicroDVD tests; full libse (558), seconv (242), and libuilogic (14) suites pass; UI builds with zero warnings. The UI fixes (2, 3, 5, 6) were verified by inspection, not exercised in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)