### PR TITLE
Multi-target libse: netstandard2.1 + net10.0

### DIFF
--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -588,7 +588,7 @@ seconv movie.srt customtext --custom-format:lines-template.xml --output-filename
 
 ```
 src/
-├── libse/        Core subtitle library (NuGet-shippable, netstandard2.1)
+├── libse/        Core subtitle library (NuGet-shippable, netstandard2.1;net10.0)
 ├── libuilogic/   Shared headless logic (BatchConverter pipeline, OCR matchers, image renderer)
 ├── seconv/       This CLI
 └── ui/           Avalonia desktop UI (not referenced by seconv)

--- a/installer/flatpak/generate-nuget-sources.sh
+++ b/installer/flatpak/generate-nuget-sources.sh
@@ -228,7 +228,8 @@ for src in data:
             added.append(entry)
         break
 
-# netstandard2.1 reference assemblies (LibSE targets netstandard2.1). The system
+# netstandard2.1 reference assemblies (LibSE multi-targets netstandard2.1;net10.0,
+# and the netstandard2.1 leg still builds during restore/build). The system
 # SDK used by the fallback path resolves these from its bundled packs without
 # downloading, so they never get captured here — but the flatpak SDK needs them
 # from the offline feed, otherwise restore fails with NU1101. The version is tied

--- a/src/libse/Cea608/GetCcDataHelper.cs
+++ b/src/libse/Cea608/GetCcDataHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using Nikse.SubtitleEdit.Core.Common;
 
 namespace Nikse.SubtitleEdit.Core.Cea608
 {
@@ -12,7 +13,7 @@ namespace Nikse.SubtitleEdit.Core.Cea608
             {
                 var buffer = new byte[4];
                 fs.Seek((long)i, SeekOrigin.Begin);
-                fs.Read(buffer, 0, buffer.Length);
+                fs.ReadFully(buffer, 0, buffer.Length);
                 var nalSize = GetUInt32(buffer, 0);
                 var flag = fs.ReadByte();
                 if (IsRbspNalUnitType(flag & 0x1F) && nalSize < 10_000)
@@ -42,7 +43,7 @@ namespace Nikse.SubtitleEdit.Core.Cea608
 
             var buffer = new byte[endPos - startPos];
             fs.Seek((long)startPos, SeekOrigin.Begin);
-            fs.Read(buffer, 0, buffer.Length);
+            fs.ReadFully(buffer, 0, buffer.Length);
 
             for (var x = startPos; x < endPos; x++)
             {

--- a/src/libse/Common/FileUtil.cs
+++ b/src/libse/Common/FileUtil.cs
@@ -360,7 +360,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             using (var fs = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
                 var buffer = new byte[11];
-                fs.Read(buffer, 0, buffer.Length);
+                fs.ReadFully(buffer, 0, buffer.Length);
                 return Encoding.ASCII.GetString(buffer, 0, buffer.Length) == "d8:announce";
             }
         }
@@ -375,7 +375,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             using (var fs = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
                 var buffer = new byte[2];
-                fs.Read(buffer, 0, buffer.Length);
+                fs.ReadFully(buffer, 0, buffer.Length);
                 return buffer[0] == 0x50 // P
                        && buffer[1] == 0x47; // G
             }
@@ -433,7 +433,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             using (var fs = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
                 var buffer = new byte[4];
-                fs.Read(buffer, 0, buffer.Length);
+                fs.ReadFully(buffer, 0, buffer.Length);
                 return VobSubParser.IsPrivateStream2(buffer, 0);
             }
         }
@@ -448,7 +448,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             using (var fs = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
                 var buffer = new byte[4];
-                fs.Read(buffer, 0, buffer.Length);
+                fs.ReadFully(buffer, 0, buffer.Length);
                 return VobSubParser.IsMpeg2PackHeader(buffer)
                        || VobSubParser.IsPrivateStream1(buffer, 0);
             }
@@ -579,7 +579,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             using (var fs = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
                 var buffer = new byte[3];
-                fs.Read(buffer, 0, buffer.Length);
+                fs.ReadFully(buffer, 0, buffer.Length);
                 return buffer[0] == 0xef && buffer[1] == 0xbb && buffer[2] == 0xbf;
             }
         }
@@ -890,7 +890,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             using (var fs = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
                 var buffer = new byte[4];
-                fs.Read(buffer, 0, buffer.Length);
+                fs.ReadFully(buffer, 0, buffer.Length);
 
                 // 1a 45 df a3
                 return buffer[0] == 0x1a && buffer[1] == 0x45 && buffer[2] == 0xdf && buffer[3] == 0xa3;

--- a/src/libse/Common/IfoParser.cs
+++ b/src/libse/Common/IfoParser.cs
@@ -157,7 +157,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
                 var buffer = new byte[12];
                 _fs.Position = 0;
-                _fs.Read(buffer, 0, 12);
+                _fs.ReadFully(buffer, 0, 12);
                 string id = Encoding.UTF8.GetString(buffer);
                 if (id != "DVDVIDEO-VTS")
                 {
@@ -210,7 +210,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 audioStream.LanguageTypeSpecified = Convert.ToInt32(MidStr(data, 4, 2));
                 audioStream.CodingMode = _arrayOfAudioMode[(BinToInt(MidStr(data, 0, 3)))];
                 audioStream.Channels = BinToInt(MidStr(data, 13, 3)) + 1;
-                _fs.Read(buffer, 0, 2);
+                _fs.ReadFully(buffer, 0, 2);
                 audioStream.LanguageCode = new string(new[] { Convert.ToChar(buffer[0]), Convert.ToChar(buffer[1]) });
                 var language = DvdSubtitleLanguage.GetLanguageOrNull(audioStream.LanguageCode);
                 if (language != null)
@@ -230,10 +230,10 @@ namespace Nikse.SubtitleEdit.Core.Common
             _fs.Position += 2;
             for (int i = 0; i < _vtsVobs.NumberOfSubtitles; i++)
             {
-                _fs.Read(buffer, 0, 2);
+                _fs.ReadFully(buffer, 0, 2);
                 var languageTwoLetter = new string(new[] { Convert.ToChar(buffer[0]), Convert.ToChar(buffer[1]) });
                 _vtsVobs.Subtitles.Add(DvdSubtitleLanguage.GetNativeLanguageName(languageTwoLetter));
-                _fs.Read(buffer, 0, 2); // reserved for language code extension + code extension
+                _fs.ReadFully(buffer, 0, 2); // reserved for language code extension + code extension
 
                 //switch (buffer[0])      // 4, 8, 10-12 unused
                 //{
@@ -324,7 +324,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 {
                     // read and save full subpicture stream info inside program chain
                     var subtitle = new byte[4];
-                    _fs.Read(subtitle, 0, 4);
+                    _fs.ReadFully(subtitle, 0, 4);
                     programChain.SubtitlesAvailable.Add(subtitle);
                 }
 
@@ -335,7 +335,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 for (int colorNumber = 0; colorNumber < 16; colorNumber++)
                 {
                     var colors = new byte[4];
-                    _fs.Read(colors, 0, 4);
+                    _fs.ReadFully(colors, 0, 4);
                     int y = colors[1] - 16;
                     int cr = colors[2] - 128;
                     int cb = colors[3] - 128;

--- a/src/libse/Common/LanguageAutoDetect.cs
+++ b/src/libse/Common/LanguageAutoDetect.cs
@@ -1836,7 +1836,9 @@ namespace Nikse.SubtitleEdit.Core.Common
                     }
                     else if (bom[0] == 0x2b && bom[1] == 0x2f && bom[2] == 0x76 && (bom[3] == 0x38 || bom[3] == 0x39 || bom[3] == 0x2b || bom[3] == 0x2f)) // utf-7
                     {
+#pragma warning disable SYSLIB0001 // legacy subtitle files may still be UTF-7 encoded; only used when the file carries a UTF-7 BOM
                         encoding = Encoding.UTF7;
+#pragma warning restore SYSLIB0001
                     }
                     else if (file.Length > bom.Length)
                     {
@@ -1848,7 +1850,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
                         file.Position = 0;
                         var buffer = new byte[length];
-                        file.Read(buffer, 0, buffer.Length);
+                        file.ReadFully(buffer, 0, buffer.Length);
 
                         if (IsUtf8(buffer, out var couldBeUtf8))
                         {

--- a/src/libse/Common/ManagedBitmap.cs
+++ b/src/libse/Common/ManagedBitmap.cs
@@ -44,12 +44,12 @@ namespace Nikse.SubtitleEdit.Core.Common
         public ManagedBitmap(Stream stream)
         {
             byte[] buffer = new byte[8];
-            stream.Read(buffer, 0, buffer.Length);
+            stream.ReadFully(buffer, 0, buffer.Length);
             Width = buffer[4] << 8 | buffer[5];
             Height = buffer[6] << 8 | buffer[7];
             _colors = new SKColor[Width * Height];
             buffer = new byte[Width * Height * 4];
-            stream.Read(buffer, 0, buffer.Length);
+            stream.ReadFully(buffer, 0, buffer.Length);
             int start = 0;
             for (int i = 0; i < _colors.Length; i++)
             {

--- a/src/libse/Common/StreamExtensions.cs
+++ b/src/libse/Common/StreamExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System.IO;
+
+namespace Nikse.SubtitleEdit.Core.Common
+{
+    public static class StreamExtensions
+    {
+        /// <summary>
+        /// Reads <paramref name="count"/> bytes from the stream into <paramref name="buffer"/>,
+        /// looping until the requested count is read or the end of the stream is reached.
+        /// Unlike a single <see cref="Stream.Read(byte[], int, int)"/> call, this never returns
+        /// fewer bytes than requested while more data is available.
+        /// </summary>
+        /// <returns>The total number of bytes read; less than <paramref name="count"/> only at end of stream.</returns>
+        public static int ReadFully(this Stream stream, byte[] buffer, int offset, int count)
+        {
+            var total = 0;
+            while (total < count)
+            {
+                var bytesRead = stream.Read(buffer, offset + total, count - total);
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+
+                total += bytesRead;
+            }
+
+            return total;
+        }
+    }
+}

--- a/src/libse/Common/TarHeader.cs
+++ b/src/libse/Common/TarHeader.cs
@@ -19,7 +19,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         {
             _stream = stream;
             var buffer = new byte[HeaderSize];
-            stream.Read(buffer, 0, HeaderSize);
+            stream.ReadFully(buffer, 0, HeaderSize);
             FilePosition = stream.Position;
 
             FileName = Encoding.ASCII.GetString(buffer, 0, 100)
@@ -39,7 +39,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         {
             var buffer = new byte[FileSizeInBytes];
             _stream.Position = FilePosition;
-            _stream.Read(buffer, 0, buffer.Length);
+            _stream.ReadFully(buffer, 0, buffer.Length);
             File.WriteAllBytes(fileName, buffer);
         }
 

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
@@ -175,12 +174,6 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
 
             return 0;
-        }
-
-        public static void SetSecurityProtocol()
-        {
-            ServicePointManager.Expect100Continue = true;
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
         }
 
         public static bool IsBetweenNumbers(string s, int position)
@@ -3408,7 +3401,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         {
             using (var ms = new MemoryStream(buffer))
             {
-                using (var sha512 = new SHA512Managed())
+                using (var sha512 = SHA512.Create())
                 {
                     var hash = sha512.ComputeHash(ms);
                     var hashString = new StringBuilder(128);

--- a/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
+++ b/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Nikse.SubtitleEdit.Core.Common;
 
 namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
 {
@@ -261,7 +262,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
                         break;
                     case ElementId.CodecPrivate:
                         codecPrivateRaw = new byte[element.DataSize];
-                        _stream.Read(codecPrivateRaw, 0, codecPrivateRaw.Length);
+                        _stream.ReadFully(codecPrivateRaw, 0, codecPrivateRaw.Length);
                         break;
                     case ElementId.ContentEncodings:
                         contentCompressionAlgorithm = 0; // default value
@@ -646,7 +647,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
             // save subtitle data
             var dataLength = (int)(blockElement.EndPosition - _stream.Position);
             var data = new byte[dataLength];
-            _stream.Read(data, 0, dataLength);
+            _stream.ReadFully(data, 0, dataLength);
 
             var subtitle = new MatroskaSubtitle(data, (long)Math.Round(GetTimeScaledToMilliseconds(clusterTimeCode + timeCode)));
             return new MatroskaSubtitleBlock(trackNumber, subtitle);
@@ -843,7 +844,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
             var result = (ulong)(unsetFirstBit ? first & (0xFF >> length) : first);
             if (length > 1)
             {
-                _stream.Read(_buffer, 0, length - 1);
+                _stream.ReadFully(_buffer, 0, length - 1);
                 for (var i = 0; i < length - 1; i++)
                 {
                     result = (result << 8) | _buffer[i];
@@ -905,7 +906,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
         /// <returns>A 2-byte signed integer read from the current stream.</returns>
         private short ReadInt16()
         {
-            _stream.Read(_buffer, 0, 2);
+            _stream.ReadFully(_buffer, 0, 2);
             return (short)(_buffer[0] << 8 | _buffer[1]);
         }
 
@@ -916,7 +917,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
         /// <returns>A 4-byte floating point value read from the current stream.</returns>
         private float ReadFloat32()
         {
-            _stream.Read(_buffer, 0, 4);
+            _stream.ReadFully(_buffer, 0, 4);
             int value = BinaryPrimitives.ReadInt32BigEndian(_buffer);
             return BitConverter.Int32BitsToSingle(value);
         }
@@ -928,7 +929,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
         /// <returns>A 8-byte floating point value read from the current stream.</returns>
         private double ReadFloat64()
         {
-            _stream.Read(_buffer, 0, 8);
+            _stream.ReadFully(_buffer, 0, 8);
             long value = BinaryPrimitives.ReadInt64BigEndian(_buffer);
             return BitConverter.Int64BitsToDouble(value);
         }
@@ -943,12 +944,12 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
         {
             if (length <= _buffer.Length)
             {
-                _stream.Read(_buffer, 0, (int)length);
+                _stream.ReadFully(_buffer, 0, (int)length);
                 return encoding.GetString(_buffer.AsSpan(0, (int)length));
             }
 
             var buffer = new byte[length];
-            _stream.Read(buffer, 0, (int)length);
+            _stream.ReadFully(buffer, 0, (int)length);
             return encoding.GetString(buffer.AsSpan()); 
         }
     }

--- a/src/libse/ContainerFormats/Mp4/Boxes/Mdia.cs
+++ b/src/libse/ContainerFormats/Mp4/Boxes/Mdia.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using Nikse.SubtitleEdit.Core.Common;
 
 namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
 {
@@ -55,7 +56,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                 else if (Name == "hdlr")
                 {
                     Buffer = new byte[Size - 4];
-                    fs.Read(Buffer, 0, Buffer.Length);
+                    fs.ReadFully(Buffer, 0, Buffer.Length);
                     HandlerType = GetString(8, 4);
                     if (Size > 25)
                     {

--- a/src/libse/ContainerFormats/Mp4/Boxes/Stbl.cs
+++ b/src/libse/ContainerFormats/Mp4/Boxes/Stbl.cs
@@ -61,7 +61,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                     if (handlerType != "soun")
                     {
                         Buffer = new byte[Size - 4];
-                        fs.Read(Buffer, 0, Buffer.Length);
+                        fs.ReadFully(Buffer, 0, Buffer.Length);
                         int version = Buffer[0];
                         var totalEntries = GetUInt(4);
 
@@ -82,7 +82,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                     if (handlerType != "soun")
                     {
                         Buffer = new byte[Size - 4];
-                        fs.Read(Buffer, 0, Buffer.Length);
+                        fs.ReadFully(Buffer, 0, Buffer.Length);
                         int version = Buffer[0];
                         var totalEntries = GetUInt(4);
 
@@ -101,7 +101,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                 else if (Name == "stsz") // sample sizes
                 {
                     Buffer = new byte[Size - 4];
-                    fs.Read(Buffer, 0, Buffer.Length);
+                    fs.ReadFully(Buffer, 0, Buffer.Length);
                     int version = Buffer[0];
                     var uniformSizeOfEachSample = GetUInt(4);
                     var numberOfSampleSizes = GetUInt(8);
@@ -121,7 +121,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                     //https://developer.apple.com/library/mac/#documentation/QuickTime/QTFF/QTFFChap2/qtff2.html#//apple_ref/doc/uid/TP40000939-CH204-SW1
 
                     Buffer = new byte[Size - 4];
-                    fs.Read(Buffer, 0, Buffer.Length);
+                    fs.ReadFully(Buffer, 0, Buffer.Length);
                     int version = Buffer[0];
                     var numberOfSampleTimes = GetUInt(4);
                     for (var i = 0; i < numberOfSampleTimes; i++)
@@ -147,7 +147,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                 else if (Name == "ctts") // composition time offset (PTS = DTS + offset); needed when B-frames make storage order differ from display order
                 {
                     Buffer = new byte[Size - 4];
-                    fs.Read(Buffer, 0, Buffer.Length);
+                    fs.ReadFully(Buffer, 0, Buffer.Length);
                     int version = Buffer[0];
                     var numberOfEntries = GetUInt(4);
                     for (var i = 0; i < numberOfEntries; i++)
@@ -173,7 +173,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                 else if (Name == "stsc") // sample table sample to chunk map
                 {
                     Buffer = new byte[Size - 4];
-                    fs.Read(Buffer, 0, Buffer.Length);
+                    fs.ReadFully(Buffer, 0, Buffer.Length);
                     int version = Buffer[0];
                     var numberOfSampleTimes = GetUInt(4);
                     for (var i = 0; i < numberOfSampleTimes; i++)
@@ -303,7 +303,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                         {
                             fs.Seek((long)sampleOffset, SeekOrigin.Begin);
                             var buffer = new byte[2];
-                            fs.Read(buffer, 0, buffer.Length);
+                            fs.ReadFully(buffer, 0, buffer.Length);
                             var textSize = (uint)GetWord(buffer, 0);
 
                             if (textSize > 0)
@@ -318,7 +318,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                                     {
                                         buffer = new byte[textSize + 2];
                                         fs.Seek((long)sampleOffset, SeekOrigin.Begin);
-                                        fs.Read(buffer, 0, buffer.Length);
+                                        fs.ReadFully(buffer, 0, buffer.Length);
                                         SubPictures.Add(new SubPicture(buffer)); // TODO: Where is palette?
                                         paragraphs.Add(p);
                                     }
@@ -326,7 +326,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                                 else
                                 {
                                     buffer = new byte[textSize];
-                                    fs.Read(buffer, 0, buffer.Length);
+                                    fs.ReadFully(buffer, 0, buffer.Length);
                                     p.Text = GetString(buffer, 0, (int)textSize).TrimEnd();
 
                                     if (_mdia.IsClosedCaption)

--- a/src/libse/ContainerFormats/Mp4/Boxes/Stsd.cs
+++ b/src/libse/ContainerFormats/Mp4/Boxes/Stsd.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using Nikse.SubtitleEdit.Core.Common;
 
 namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
 {
@@ -10,7 +11,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
             Position = (ulong)fs.Position;
 
             Buffer = new byte[8];
-            fs.Read(Buffer, 0, Buffer.Length);
+            fs.ReadFully(Buffer, 0, Buffer.Length);
             NumberOfEntries = GetUInt(4);
 
             while (fs.Position < (long)maximumLength)

--- a/src/libse/ContainerFormats/Mp4/Boxes/Vttc.cs
+++ b/src/libse/ContainerFormats/Mp4/Boxes/Vttc.cs
@@ -37,7 +37,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                     if (length > 0 && length < 5000)
                     {
                         var buffer = new byte[length];
-                        fs.Read(buffer, 0, length);
+                        fs.ReadFully(buffer, 0, length);
                         var s = Encoding.UTF8.GetString(buffer);
                         s = string.Join(Environment.NewLine, s.SplitToLines());
                         Data.Payload = s.Trim();
@@ -55,7 +55,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                     if (length > 0 && length < 5000)
                     {
                         var buffer = new byte[length];
-                        fs.Read(buffer, 0, length);
+                        fs.ReadFully(buffer, 0, length);
                         var s = Encoding.UTF8.GetString(buffer);
                         s = string.Join(Environment.NewLine, s.SplitToLines());
                         Data.Style = s.Trim();

--- a/src/libse/ContainerFormats/Mp4/Mp4Parser.cs
+++ b/src/libse/ContainerFormats/Mp4/Mp4Parser.cs
@@ -786,7 +786,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
                         if (readLength > 10 && readLength < 1_000_000)
                         {
                             var buffer = new byte[readLength];
-                            fs.Read(buffer, 0, readLength);
+                            fs.ReadFully(buffer, 0, readLength);
                             list.Add(Encoding.UTF8.GetString(buffer));
                         }
                     }

--- a/src/libse/ContainerFormats/RiffParser.cs
+++ b/src/libse/ContainerFormats/RiffParser.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.IO;
-using System.Runtime.Serialization;
 
 namespace Nikse.SubtitleEdit.Core.ContainerFormats
 {
@@ -22,11 +21,6 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats
 
         public RiffParserException(string message, Exception inner)
             : base(message, inner)
-        {
-        }
-
-        public RiffParserException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
         {
         }
     }

--- a/src/libse/ContainerFormats/TransportStream/ProgramMapTableParser.cs
+++ b/src/libse/ContainerFormats/TransportStream/ProgramMapTableParser.cs
@@ -50,7 +50,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
 
                 // check for Topfield .rec file
                 ms.Seek(position, SeekOrigin.Begin);
-                ms.Read(m2TsTimeCodeBuffer, 0, 3);
+                ms.ReadFully(m2TsTimeCodeBuffer, 0, 3);
                 if (m2TsTimeCodeBuffer[0] == 0x54 && m2TsTimeCodeBuffer[1] == 0x46 && m2TsTimeCodeBuffer[2] == 0x72)
                 {
                     position = 3760;
@@ -66,11 +66,11 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
 
                     if (isM2TransportStream)
                     {
-                        ms.Read(m2TsTimeCodeBuffer, 0, m2TsTimeCodeBuffer.Length);
+                        ms.ReadFully(m2TsTimeCodeBuffer, 0, m2TsTimeCodeBuffer.Length);
                         position += m2TsTimeCodeBuffer.Length;
                     }
 
-                    ms.Read(packetBuffer, 0, packetLength);
+                    ms.ReadFully(packetBuffer, 0, packetLength);
                     if (packetBuffer[0] == Packet.SynchronizationByte)
                     {
                         var packet = new Packet(packetBuffer);

--- a/src/libse/ContainerFormats/TransportStream/TransportStreamParser.cs
+++ b/src/libse/ContainerFormats/TransportStream/TransportStreamParser.cs
@@ -66,7 +66,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
 
             // check for Topfield .rec file
             ms.Seek(position, SeekOrigin.Begin);
-            ms.Read(m2TsTimeCodeBuffer, 0, 3);
+            ms.ReadFully(m2TsTimeCodeBuffer, 0, 3);
             var topfieldCheck = m2TsTimeCodeBuffer.AsSpan(0, 3);
             if (topfieldCheck[0] == 0x54 && topfieldCheck[1] == 0x46 && topfieldCheck[2] == 0x72)
             {
@@ -79,7 +79,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
             {
                 if (_isM2TransportStream)
                 {
-                    ms.Read(m2TsTimeCodeBuffer, 0, m2TsTimeCodeBuffer.Length);
+                    ms.ReadFully(m2TsTimeCodeBuffer, 0, m2TsTimeCodeBuffer.Length);
                     position += m2TsTimeCodeBuffer.Length;
                 }
 
@@ -579,7 +579,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
             var buffer = ArrayPool<byte>.Shared.Rent(requiredLength);
             try
             {
-                ms.Read(buffer, 0, requiredLength);
+                ms.ReadFully(buffer, 0, requiredLength);
                 var span = buffer.AsSpan(0, requiredLength);
                 
                 // Check for standard 188-byte packets

--- a/src/libse/Http/LegacyDownloader.cs
+++ b/src/libse/Http/LegacyDownloader.cs
@@ -7,6 +7,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nikse.SubtitleEdit.Core.Common;
 
+#pragma warning disable SYSLIB0014 // this downloader intentionally uses the legacy WebRequest/WebClient stack (Settings.General.UseLegacyDownloader fallback)
+
 namespace Nikse.SubtitleEdit.Core.Http
 {
     public class LegacyDownloader : IDownloader

--- a/src/libse/LibSE.csproj
+++ b/src/libse/LibSE.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFrameworks>netstandard2.1;net10.0</TargetFrameworks>
 		<RootNamespace>Nikse.SubtitleEdit.Core</RootNamespace>
 		<AssemblyName>libse</AssemblyName>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -48,10 +48,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
 		<PackageReference Include="SkiaSharp" Version="3.119.4" />
-		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="UTF.Unknown" Version="2.6.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+		<PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/libse/LibSE.csproj
+++ b/src/libse/LibSE.csproj
@@ -52,10 +52,6 @@
 		<PackageReference Include="UTF.Unknown" Version="2.6.0" />
 	</ItemGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-		<PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-	</ItemGroup>
-
 	<ItemGroup>
 		<None Include="$(MSBuildThisFileDirectory)LICENSE.txt" Pack="true" PackagePath="" />
 		<None Include="$(MSBuildThisFileDirectory)Readme.md" Pack="true" PackagePath="" />

--- a/src/libse/SubtitleFormats/TextST.cs
+++ b/src/libse/SubtitleFormats/TextST.cs
@@ -1096,7 +1096,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             // check for Topfield .rec file
             ms.Seek(position, SeekOrigin.Begin);
-            ms.Read(m2TsTimeCodeBuffer, 0, 3);
+            ms.ReadFully(m2TsTimeCodeBuffer, 0, 3);
             if (m2TsTimeCodeBuffer[0] == 0x54 && m2TsTimeCodeBuffer[1] == 0x46 && m2TsTimeCodeBuffer[2] == 0x72)
             {
                 position = 3760;
@@ -1172,7 +1172,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 ms.Seek(0, SeekOrigin.Begin);
                 var buffer = new byte[192 + 192 + 5];
-                ms.Read(buffer, 0, buffer.Length);
+                ms.ReadFully(buffer, 0, buffer.Length);
                 if (buffer[0] == Packet.SynchronizationByte && buffer[188] == Packet.SynchronizationByte)
                 {
                     return false;

--- a/src/libse/VobSub/VobSubParser.cs
+++ b/src/libse/VobSub/VobSubParser.cs
@@ -49,7 +49,7 @@ namespace Nikse.SubtitleEdit.Core.VobSub
             {
                 var header = new byte[4];
                 ms.Seek(position, SeekOrigin.Begin);
-                ms.Read(header, 0, header.Length);
+                ms.ReadFully(header, 0, header.Length);
                 if (IsMpeg2PackHeader(header))
                 {
                     if (!IsStartOfMpeg2Pack(ms, position))
@@ -68,20 +68,20 @@ namespace Nikse.SubtitleEdit.Core.VobSub
                     // find how much stuffing there is
                     byte[] mpeg2HeaderBuffer = new byte[Mpeg2Header.Length];
                     ms.Seek(position, SeekOrigin.Begin);
-                    ms.Read(mpeg2HeaderBuffer, 0, mpeg2HeaderBuffer.Length);
+                    ms.ReadFully(mpeg2HeaderBuffer, 0, mpeg2HeaderBuffer.Length);
                     int stuffingBytes = mpeg2HeaderBuffer[13] & 0b111;
                     ms.Seek(stuffingBytes, SeekOrigin.Current);
 
                     // skip stuffing and go to pes packet length
                     byte[] pesPacketHeaderBuffer = new byte[6];
-                    ms.Read(pesPacketHeaderBuffer, 0, pesPacketHeaderBuffer.Length);
+                    ms.ReadFully(pesPacketHeaderBuffer, 0, pesPacketHeaderBuffer.Length);
                     int packetLength = (int)(Helper.GetEndian(pesPacketHeaderBuffer, 4, 2) & 0xffff);
 
                     // create a new clean buffer without the stuffing.
                     byte[] cleanBuffer = new byte[mpeg2HeaderBuffer.Length + pesPacketHeaderBuffer.Length + packetLength];
                     Buffer.BlockCopy(mpeg2HeaderBuffer, 0, cleanBuffer, 0, mpeg2HeaderBuffer.Length);
                     Buffer.BlockCopy(pesPacketHeaderBuffer, 0, cleanBuffer, mpeg2HeaderBuffer.Length, pesPacketHeaderBuffer.Length);
-                    ms.Read(cleanBuffer, mpeg2HeaderBuffer.Length + pesPacketHeaderBuffer.Length, packetLength);
+                    ms.ReadFully(cleanBuffer, mpeg2HeaderBuffer.Length + pesPacketHeaderBuffer.Length, packetLength);
                     // since we are cutting out the mpeg header stuffing bytes
                     // update the cleaned data to say we don't have any.
                     cleanBuffer[13] = (byte)(cleanBuffer[13] & 0b1111_1000);
@@ -96,7 +96,7 @@ namespace Nikse.SubtitleEdit.Core.VobSub
                 else if (IsPaddingStream(header, 0))
                 {
                     byte[] pesPacketLengthBuffer = new byte[2];
-                    ms.Read(pesPacketLengthBuffer, 0, pesPacketLengthBuffer.Length);
+                    ms.ReadFully(pesPacketLengthBuffer, 0, pesPacketLengthBuffer.Length);
                     position += PacketizedElementaryStream.HeaderLength + Helper.GetEndian(pesPacketLengthBuffer, 0, pesPacketLengthBuffer.Length);
                 }
                 else
@@ -127,7 +127,7 @@ namespace Nikse.SubtitleEdit.Core.VobSub
             // fingerprint the mpeg2 header
             var buffer = new byte[Mpeg2Header.Length];
             ms.Seek(position, SeekOrigin.Begin);
-            ms.Read(buffer, 0, buffer.Length);
+            ms.ReadFully(buffer, 0, buffer.Length);
             if (!IsMpeg2PackHeader(buffer))
             {
                 return false;
@@ -171,7 +171,7 @@ namespace Nikse.SubtitleEdit.Core.VobSub
             // fingerprint the private stream 1
             var privateStreamBuffer = new byte[9];
             ms.Seek(buffer[13] & 0b111, SeekOrigin.Current);
-            ms.Read(privateStreamBuffer, 0, privateStreamBuffer.Length);
+            ms.ReadFully(privateStreamBuffer, 0, privateStreamBuffer.Length);
             if (!IsPrivateStream1(privateStreamBuffer, 0))
             {
                 return false;
@@ -239,7 +239,7 @@ namespace Nikse.SubtitleEdit.Core.VobSub
                             {
                                 long position = p.FilePosition;
                                 fs.Seek(position, SeekOrigin.Begin);
-                                fs.Read(buffer, 0, 0x0800);
+                                fs.ReadFully(buffer, 0, 0x0800);
                                 if (IsSubtitlePack(buffer) || IsPrivateStream1(buffer, 0))
                                 {
                                     var vsp = new VobSubPack(buffer, p);
@@ -266,7 +266,7 @@ namespace Nikse.SubtitleEdit.Core.VobSub
                                             currentSubPictureStreamId != vsp.PacketizedElementaryStream.SubPictureStreamId.Value) && position < fs.Length)
                                     {
                                         fs.Seek(position, SeekOrigin.Begin);
-                                        fs.Read(buffer, 0, 0x800);
+                                        fs.ReadFully(buffer, 0, 0x800);
                                         vsp = new VobSubPack(buffer, p); // idx position?
 
                                         if (vsp.PacketizedElementaryStream != null && vsp.PacketizedElementaryStream.SubPictureStreamId.HasValue && currentSubPictureStreamId == vsp.PacketizedElementaryStream.SubPictureStreamId.Value)

--- a/tests/libse/SubtitleFormats/EbuTtDTest.cs
+++ b/tests/libse/SubtitleFormats/EbuTtDTest.cs
@@ -100,7 +100,7 @@ public class EbuTtDTest
         // First format whose IsMine claims the document wins - EbuTtD must beat the
         // generic TTML formats for its own output.
         var lines = raw.SplitToLines();
-        SubtitleFormat detected = null;
+        SubtitleFormat? detected = null;
         foreach (var candidate in SubtitleFormat.AllSubtitleFormats)
         {
             if (candidate.IsMine(lines, null))


### PR DESCRIPTION
## Summary
- `LibSE.csproj` now multi-targets `netstandard2.1;net10.0`. All in-repo consumers (UI, LibUiLogic, SeConv, tests) target `net10.0` and automatically pick the `net10.0` build via project reference; the NuGet package keeps `netstandard2.1` for external consumers.
- `Microsoft.Win32.Registry` removed entirely — libse has no Registry usage (the only `Microsoft.Win32` consumers are in `src/ui`, which gets the types from the .NET 10 framework).
- `System.Net.Http` 4.3.4 removed entirely — redundant on both targets (netstandard2.1 provides `HttpClient` in-box) and it carried known CVEs.
- All analyzer warnings surfaced by the new `net10.0` target are fixed (see below) — the solution builds with **0 warnings, 0 errors**.
- Updated TFM mention in `docs/reference/command-line.md` and the stale comment in `installer/flatpak/generate-nuget-sources.sh`.

## Warning fixes
The `net10.0` leg surfaced analyzer warnings on pre-existing code that the netstandard2.1 target could not see; all are addressed:
- **CA2022 (58 sites)**: `Stream.Read` return values were ignored, a latent partial-read hazard (`Read` may legally return fewer bytes than requested). Added a `Stream.ReadFully` extension that loops until the requested count or end of stream, and switched every flagged call site to it. Behavior for truncated files is preserved (no new exceptions).
- **SYSLIB0021**: `SHA512Managed` → `SHA512.Create()`.
- **SYSLIB0051**: dropped the obsolete `SerializationInfo` constructor from `RiffParserException`.
- **SYSLIB0014**: removed `Utilities.SetSecurityProtocol()` (dead code, no callers); suppressed with justification in `LegacyDownloader`, which intentionally uses the legacy `WebRequest`/`WebClient` stack as the `UseLegacyDownloader` fallback.
- **SYSLIB0001**: suppressed with justification for the UTF-7 branch in `LanguageAutoDetect` BOM sniffing — legacy subtitle files may still be UTF-7 encoded.
- **CS8600**: annotated a nullable local in `EbuTtDTest` (pre-existing, last remaining solution warning).

## Benefits
- **Compile-time wins for free**: the netstandard2.1 assembly already ran on the .NET 10 BCL at runtime via type forwarding, so there is no big automatic throughput jump — but compiling against `net10.0` lets the compiler bind to better codegen with no source changes: interpolated strings use `DefaultInterpolatedStringHandler` instead of `string.Format` (no boxing, fewer allocations), and call sites pick up faster overloads that don't exist in netstandard2.1 (e.g. `params ReadOnlySpan<T>` overloads of `string.Join`/`string.Concat`).
- **Modern API access**: `Span`-based overloads, `[GeneratedRegex]`, `SearchValues`, `string.Create`, etc. become usable in libse hot paths behind `#if NET10_0_OR_GREATER`.
- **Cleaner dependency graph**: `System.Net.Http` 4.3.4 and its transitive `runtime.*` subtree, plus `Microsoft.Win32.Registry`, no longer ship at all (smaller flatpak offline restore too).
- **Better tooling**: platform-compatibility analyzers and trimming analysis work properly against a `net10.0` assembly; netstandard predates both — and the new warnings they surfaced are now fixed.
- **No breakage**: the netstandard2.1 leg still builds from the same sources, keeping the NuGet package compatible and the shared code honest.

Note: `installer/flatpak/nuget-sources.json` becomes stale but is regenerated by CI on every run (non-fatal by design).

## Test plan
- [x] `dotnet build SubtitleEdit.sln -c Release` succeeds with **0 warnings, 0 errors**
- [x] Both `src/libse/bin/<config>/netstandard2.1/libse.dll` and `net10.0/libse.dll` are produced with 0 warnings each (clean builds of each leg)
- [x] `dotnet test tests/libse/LibSETests.csproj` passes (569/569)
- [x] `dotnet test tests/libuilogic/LibUiLogicTests.csproj` passes (14/14)
- [x] `dotnet test tests/seconv/SeConvTests.csproj` passes (242/242)
- [x] `dotnet test tests/UI/UITests.csproj` — 673 pass; the 20 SpellCheck failures are pre-existing on `main` (verified with this change stashed)
- [x] `dotnet pack src/libse/LibSE.csproj` produces a package containing both `lib/netstandard2.1` and `lib/net10.0`, with per-TFM dependency groups in the nuspec

🤖 Generated with [Claude Code](https://claude.com/claude-code)
