### PR TITLE
Fix "Open containing folder" opening desktop on Windows

### DIFF
--- a/src/ui/Logic/Media/IFolderHelper.cs
+++ b/src/ui/Logic/Media/IFolderHelper.cs
@@ -90,7 +90,7 @@ public class FolderHelper : IFolderHelper
             var startInfo = new ProcessStartInfo
             {
                 FileName = "explorer.exe",
-                Arguments = @"/select, " + selectedFile,
+                Arguments = $"/select,\"{selectedFile}\"",
                 UseShellExecute = false,
                 CreateNoWindow = true
             };


### PR DESCRIPTION
## Summary
- Fixes #12615 — "Open Containing Folder" from the Batch Convert window (and everywhere else, since `FolderHelper.OpenFolderWithFileSelected` is shared) opened the Desktop instead of the file's folder on Windows.
- Cause: the `explorer.exe` arguments were built as `/select, <path>` without quotes, so any path containing spaces was split into multiple arguments and Explorer fell back to its default folder.
- Fix: quote the path (`/select,"<path>"`), matching what the macOS branch and `OpenFolder` already do.

## Test plan
- [x] `dotnet build src/ui/UI.csproj -c Release` — 0 warnings, 0 errors
- [ ] On Windows: Batch Convert → add a file whose path contains spaces → right-click → Open containing folder → Explorer opens the folder with the file selected (needs a Windows machine; developed on macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)