### PR TITLE
Fix four bugs found in a bug hunt over recent commits

### DIFF
--- a/src/seconv/Core/LibSEIntegration.cs
+++ b/src/seconv/Core/LibSEIntegration.cs
@@ -172,6 +172,7 @@ internal static class LibSEIntegration
         var guessSubtitle = new UnknownFormatImporter { UseFrames = true }.AutoGuessImport(lines, filePath);
         if (guessSubtitle.Paragraphs.Count > 0 && HasPlausibleGuessedTiming(guessSubtitle))
         {
+            guessSubtitle.Paragraphs.RemoveAll(p => p.EndTime.TotalMilliseconds < p.StartTime.TotalMilliseconds);
             return (guessSubtitle, new SubRip());
         }
 
@@ -219,7 +220,13 @@ internal static class LibSEIntegration
 
     private static bool HasPlausibleGuessedTiming(Subtitle subtitle)
     {
-        return subtitle.Paragraphs.All(p => p.EndTime.TotalMilliseconds >= p.StartTime.TotalMilliseconds)
+        // Match UnknownFormatImporter's own tolerance: it accepts a guess containing up to
+        // two inverted cues (typos in an otherwise valid file), so rejecting the whole file
+        // for a single inverted cue would fail input that used to convert. Reject only when
+        // inversions dominate; the caller drops the inverted cues from the result.
+        var inverted = subtitle.Paragraphs.Count(p => p.EndTime.TotalMilliseconds < p.StartTime.TotalMilliseconds);
+        return inverted <= 2
+               && inverted < subtitle.Paragraphs.Count
                && subtitle.Paragraphs.Any(p => p.EndTime.TotalMilliseconds > 0);
     }
 

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -1821,7 +1821,7 @@ public partial class OcrViewModel : ObservableObject
         if (result.OkPressed)
         {
             _preProcessingSettings = result.PreProcessingSettings;
-            foreach (var item in OcrSubtitleItems)
+            foreach (var item in _allOcrSubtitleItems) // not OcrSubtitleItems - it may be filtered to forced-only
             {
                 item.PreProcessingSettings = _preProcessingSettings;
             }
@@ -1901,7 +1901,7 @@ public partial class OcrViewModel : ObservableObject
             ? OcrSubtitleItems.IndexOf(SelectedOcrSubtitleItem)
             : -1;
 
-        foreach (var item in OcrSubtitleItems)
+        foreach (var item in _allOcrSubtitleItems) // not OcrSubtitleItems - it may be filtered to forced-only
         {
             item.InvalidateBitmap();
         }

--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -851,13 +851,21 @@ public partial class BurnInViewModel : ObservableObject
             return inputSubtitle;
         }
 
-        var subtitle = new Subtitle();
+        var subtitle = new Subtitle
+        {
+            Header = inputSubtitle.Header, // keep ASSA styles + PlayRes
+            Footer = inputSubtitle.Footer,
+        };
+
         foreach (var p in inputSubtitle.Paragraphs)
         {
-            if (p.StartTime.TotalMilliseconds >= CutFrom.TotalMilliseconds &&
-                p.EndTime.TotalMilliseconds <= CutTo.TotalMilliseconds)
+            if (p.EndTime.TotalMilliseconds > CutFrom.TotalMilliseconds &&
+                p.StartTime.TotalMilliseconds < CutTo.TotalMilliseconds)
             {
-                subtitle.Paragraphs.Add(new Paragraph(p));
+                var paragraph = new Paragraph(p);
+                paragraph.StartTime.TotalMilliseconds = Math.Max(paragraph.StartTime.TotalMilliseconds, CutFrom.TotalMilliseconds);
+                paragraph.EndTime.TotalMilliseconds = Math.Min(paragraph.EndTime.TotalMilliseconds, CutTo.TotalMilliseconds);
+                subtitle.Paragraphs.Add(paragraph);
             }
         }
 

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -172,6 +172,7 @@ public partial class SpeechToTextViewModel : ObservableObject
     private StringBuilder _ffmpegLog = new();
     private readonly Lock _lockObj = new();
     private int _batchIndex = -1;
+    private IList<SpeechToTextJobItem> _jobItems = new List<SpeechToTextJobItem>(); // items for the current run: aliases BatchItems in batch mode, a standalone single item otherwise
     private string _error;
     private List<AudioClip>? _audioClips;
     private bool _audioClipsAutoStart;
@@ -1618,7 +1619,7 @@ public partial class SpeechToTextViewModel : ObservableObject
     {
         if (IsBatchMode)
         {
-            return string.Format(Se.Language.Video.AudioToText.TranscribingXOfY, _batchIndex + 1, BatchItems.Count);
+            return string.Format(Se.Language.Video.AudioToText.TranscribingXOfY, _batchIndex + 1, _jobItems.Count);
         }
         else
         {
@@ -1628,7 +1629,7 @@ public partial class SpeechToTextViewModel : ObservableObject
 
     private void StartNext(Subtitle? transcribedSubtitle)
     {
-        var currentItem = BatchItems[_batchIndex];
+        var currentItem = _jobItems[_batchIndex];
         if (transcribedSubtitle != null && transcribedSubtitle.Paragraphs.Count > 0)
         {
             currentItem.Status = Se.Language.General.Converted;
@@ -1644,7 +1645,7 @@ public partial class SpeechToTextViewModel : ObservableObject
         _filesToDelete.Clear();
 
         _batchIndex++;
-        if (_batchIndex < BatchItems.Count)
+        if (_batchIndex < _jobItems.Count)
         {
             ProgressValue = 0;
             _startTicks = 0;
@@ -1656,7 +1657,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             ElapsedText = string.Empty;
             EstimatedText = string.Empty;
 
-            var jobItem = BatchItems[_batchIndex];
+            var jobItem = _jobItems[_batchIndex];
             _videoFileName = jobItem.InputVideoFileName;
             _videoInfo.TotalMilliseconds = jobItem.MediaInfo.Duration.TotalMilliseconds;
             _videoInfo.TotalSeconds = jobItem.MediaInfo.Duration.TotalSeconds;
@@ -1682,8 +1683,8 @@ public partial class SpeechToTextViewModel : ObservableObject
             return;
         }
 
-        var convertedJobs = BatchItems.Count(p => p.Status == Se.Language.General.Converted);
-        var failed = BatchItems.Count(p => p.Status != Se.Language.General.Converted);
+        var convertedJobs = _jobItems.Count(p => p.Status == Se.Language.General.Converted);
+        var failed = _jobItems.Count(p => p.Status != Se.Language.General.Converted);
 
         Dispatcher.UIThread.Invoke<Task>(async () =>
         {
@@ -3265,19 +3266,24 @@ public partial class SpeechToTextViewModel : ObservableObject
                 return;
             }
 
-            BatchItems.Clear(); // may hold stale items from an earlier batch-mode session
-            BatchItems.Add(new SpeechToTextJobItem(_videoFileName, string.Empty, mediaInfo));
+            // do not touch BatchItems here - it holds the user's queued batch list
+            _jobItems = new List<SpeechToTextJobItem> { new SpeechToTextJobItem(_videoFileName, string.Empty, mediaInfo) };
         }
+        else
+        {
+            _jobItems = BatchItems;
+        }
+
         _batchIndex = 0;
 
-        if (BatchItems.Count == 0)
+        if (_jobItems.Count == 0)
         {
             return;
         }
 
         if (IsBatchMode)
         {
-            var jobItem = BatchItems[0];
+            var jobItem = _jobItems[0];
             Dispatcher.UIThread.Post(() =>
             {
                 if (BatchGrid == null)
@@ -3291,11 +3297,11 @@ public partial class SpeechToTextViewModel : ObservableObject
         }
 
 
-        _videoFileName = BatchItems[0].InputVideoFileName;
-        _videoInfo.TotalMilliseconds = BatchItems[0].MediaInfo.Duration.TotalMilliseconds;
-        _videoInfo.TotalSeconds = BatchItems[0].MediaInfo.Duration.TotalSeconds;
-        _videoInfo.Width = BatchItems[0].MediaInfo.Dimension.Width;
-        _videoInfo.Height = BatchItems[0].MediaInfo.Dimension.Height;
+        _videoFileName = _jobItems[0].InputVideoFileName;
+        _videoInfo.TotalMilliseconds = _jobItems[0].MediaInfo.Duration.TotalMilliseconds;
+        _videoInfo.TotalSeconds = _jobItems[0].MediaInfo.Duration.TotalSeconds;
+        _videoInfo.Width = _jobItems[0].MediaInfo.Dimension.Width;
+        _videoInfo.Height = _jobItems[0].MediaInfo.Dimension.Height;
 
         ProgressOpacity = 1;
         ProgressText = Se.Language.General.GeneratingAudioFile;

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
@@ -486,13 +486,21 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
             return inputSubtitle;
         }
 
-        var subtitle = new Subtitle();
+        var subtitle = new Subtitle
+        {
+            Header = inputSubtitle.Header, // keep ASSA styles + PlayRes
+            Footer = inputSubtitle.Footer,
+        };
+
         foreach (var p in inputSubtitle.Paragraphs)
         {
-            if (p.StartTime.TotalMilliseconds >= CutFrom.TotalMilliseconds &&
-                p.EndTime.TotalMilliseconds <= CutTo.TotalMilliseconds)
+            if (p.EndTime.TotalMilliseconds > CutFrom.TotalMilliseconds &&
+                p.StartTime.TotalMilliseconds < CutTo.TotalMilliseconds)
             {
-                subtitle.Paragraphs.Add(new Paragraph(p));
+                var paragraph = new Paragraph(p);
+                paragraph.StartTime.TotalMilliseconds = Math.Max(paragraph.StartTime.TotalMilliseconds, CutFrom.TotalMilliseconds);
+                paragraph.EndTime.TotalMilliseconds = Math.Min(paragraph.EndTime.TotalMilliseconds, CutTo.TotalMilliseconds);
+                subtitle.Paragraphs.Add(paragraph);
             }
         }
 

--- a/tests/seconv/Core/MalformedSccTest.cs
+++ b/tests/seconv/Core/MalformedSccTest.cs
@@ -115,4 +115,23 @@ public class MalformedSccTest : IDisposable
 
         Assert.Contains("Unable to determine subtitle format", ex.Message);
     }
+
+    // The flip side of the plausibility gate: UnknownFormatImporter itself tolerates up to
+    // two inverted cues (typos in an otherwise valid file), so one bad pair must not fail
+    // the whole conversion - the inverted cue is dropped, the rest converts.
+    [Fact]
+    public void UnknownFormatGuess_SingleInvertedCue_LoadsAndDropsInvertedCue()
+    {
+        var path = WriteFile("freeform-one-typo.txt",
+            "log entry alpha 0:00:01.0 0:00:03.0 Hello there\n" +
+            "log entry beta 0:00:04.0 0:00:06.0 Second line\n" +
+            "log entry gamma 0:00:09.0 0:00:07.0 Inverted typo\n" +
+            "log entry delta 0:00:10.0 0:00:12.0 Fourth line\n");
+
+        var (subtitle, _) = LibSEIntegration.LoadSubtitleWithFormat(path);
+
+        Assert.Equal(3, subtitle.Paragraphs.Count);
+        Assert.DoesNotContain(subtitle.Paragraphs, p => p.Text.Contains("Inverted typo"));
+        Assert.All(subtitle.Paragraphs, p => Assert.True(p.EndTime.TotalMilliseconds >= p.StartTime.TotalMilliseconds));
+    }
 }


### PR DESCRIPTION
## Summary
Bug hunt over recent commits (f8f6be219, 43dceaa66, e63d2cda6, fc8a79e69) — four confirmed bugs, all fixed:

**1. OCR "show only forced" filter desync** (`OcrViewModel.cs`, from f8f6be219)
`ShowPreProcessing` and `RefreshOcrSubtitleItemBitmaps` iterated `OcrSubtitleItems`, which becomes the forced-only subset when the filter is on — hidden items never received pre-processing settings and kept stale old-palette bitmaps after a VobSub color change, so OCR ran half-preprocessed/half-raw. Both writers now iterate `_allOcrSubtitleItems`.

**2. Burn-in / transparent-video cut strips ASSA styles and drops boundary lines** (`BurnInViewModel.cs`, `TransparentSubtitlesViewModel.cs`, from 43dceaa66)
`GetSubtitleBasedOnCut` copied only paragraphs into a fresh `Subtitle`, losing the header — `AdvancedSubStationAlpha.ToText` then substituted the default header, so every Dialogue line referenced nonexistent styles and `\pos`/margins scaled against the wrong PlayRes. It also required full containment in the cut window, silently omitting lines straddling a boundary. The header/footer are now preserved and straddling lines are clipped to the window.

**3. Single-mode transcribe wipes the batch queue** (`SpeechToTextViewModel.cs`, from e63d2cda6)
The fix for the old "single run hijacks BatchItems[0]" bug cleared `BatchItems` — the batch grid's backing store — so queuing files, running one single-mode job, and switching back to batch mode lost the whole queue. The pipeline now runs off a `_jobItems` list that aliases `BatchItems` in batch mode (identical live semantics) and holds a standalone item in single mode, leaving the queue untouched.

**4. SeConv rejects a whole file over one inverted cue** (`LibSEIntegration.cs`, from fc8a79e69)
`HasPlausibleGuessedTiming` required *all* cues to have end ≥ start, but `UnknownFormatImporter` itself deliberately tolerates up to two inverted cues — one typo'd timestamp in an otherwise valid freeform file failed the entire conversion. The gate now matches the importer's tolerance and the inverted cues are dropped from the result (the #12582 garbage-input case still throws, covered by the existing test).

## Test plan
- [x] `dotnet build SubtitleEdit.sln -c Release` — 0 warnings, 0 errors
- [x] seconv tests 243/243 (incl. new regression test `UnknownFormatGuess_SingleInvertedCue_LoadsAndDropsInvertedCue`), libse 569/569, libuilogic 14/14
- [x] End-to-end: freeform file with one inverted cue now converts via seconv, bad cue dropped; #12582 reproducer still fails as intended
- [ ] Manual UI check: OCR forced filter + pre-processing/VobSub colors; burn-in `.ass` with custom styles + cut; STT batch queue surviving a single-mode run

🤖 Generated with [Claude Code](https://claude.com/claude-code)