### PR TITLE
Fix VTTC language auto-detect fallback in container loader

### DIFF
--- a/src/seconv/Core/ContainerSubtitleLoader.cs
+++ b/src/seconv/Core/ContainerSubtitleLoader.cs
@@ -290,24 +290,23 @@ internal static class ContainerSubtitleLoader
         if (parser.VttcSubtitle is { } vttc && vttc.Paragraphs.Count > 0)
         {
             vttc.Renumber();
-            var lang = SanitizeLang(parser.VttcLanguage)
-                ?? LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(vttc)
-                ?? string.Empty;
-            tracks.Add(new LoadedTrack(vttc, new SubRip(), lang, null));
+            var lang = SanitizeLang(parser.VttcLanguage);
+            lang = string.IsNullOrEmpty(lang) ? LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(vttc) : lang;
+            tracks.Add(new LoadedTrack(vttc, new SubRip(), lang ?? string.Empty, null));
         }
 
-        foreach (var trak in parser.GetSubtitleTracks())
+        foreach (var track in parser.GetSubtitleTracks())
         {
-            var trackId = (int)trak.Tkhd.TrackId;
+            var trackId = (int)track.Tkhd.TrackId;
             if (options.TrackNumbers.Count > 0 && !options.TrackNumbers.Contains(trackId))
             {
                 continue;
             }
-            if (trak.Mdia.IsVobSubSubtitle)
+            if (track.Mdia.IsVobSubSubtitle)
             {
                 try
                 {
-                    var vobSub = ImageOcrLoader.LoadMp4VobSub(trak, options);
+                    var vobSub = ImageOcrLoader.LoadMp4VobSub(track, options);
                     if (vobSub.Paragraphs.Count > 0)
                     {
                         var vobLang = LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(vobSub) ?? string.Empty;
@@ -321,7 +320,7 @@ internal static class ContainerSubtitleLoader
                 continue;
             }
 
-            var paragraphs = trak.Mdia.Minf.Stbl.GetParagraphs();
+            var paragraphs = track.Mdia.Minf.Stbl.GetParagraphs();
             if (paragraphs.Count == 0)
             {
                 continue;


### PR DESCRIPTION
## Summary
- `SanitizeLang` always returns a non-null string (empty when no language is declared), so the `?? LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(...)` fallback for VTTC tracks was dead code — subtitles from containers without a declared language ended up with an empty language instead of an auto-detected one. Now falls back to auto-detection when the sanitized language is null or empty.
- Rename local variable `trak` to `track` in the MP4 track loop.

## Test plan
- [ ] Convert an MP4/container file containing a VTTC subtitle track with no declared language and verify the output language is auto-detected instead of empty
- [ ] Convert a container whose VTTC track declares a language and verify the declared language is still used
- [ ] Verify MP4 VobSub and text subtitle tracks still convert as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)