### PR TITLE
Add MOSS-TTS (CrispASR) text-to-speech engine with voice cloning

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -155,6 +155,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.CosyVoice3CrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.F5TtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VoxCPM2CrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.MossTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.EngineSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.EncodingSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ReviewSpeech;
@@ -262,6 +263,7 @@ public static class DependencyInjectionExtensions
         collection.AddHttpClient<ICosyVoice3CrispAsrDownloadService, CosyVoice3CrispAsrDownloadService>();
         collection.AddHttpClient<IF5TtsCrispAsrDownloadService, F5TtsCrispAsrDownloadService>();
         collection.AddHttpClient<IVoxCPM2CrispAsrDownloadService, VoxCPM2CrispAsrDownloadService>();
+        collection.AddHttpClient<IMossTtsCrispAsrDownloadService, MossTtsCrispAsrDownloadService>();
         collection.AddHttpClient<IZonosTtsCrispAsrDownloadService, ZonosTtsCrispAsrDownloadService>();
         collection.AddHttpClient<IKokoroTtsCppDownloadService, KokoroTtsCppDownloadService>();
         collection.AddHttpClient<IChatterboxTtsCppDownloadService, ChatterboxTtsCppDownloadService>();
@@ -434,6 +436,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<CosyVoice3CrispAsrSettingsViewModel>();
         collection.AddTransient<F5TtsCrispAsrSettingsViewModel>();
         collection.AddTransient<VoxCPM2CrispAsrSettingsViewModel>();
+        collection.AddTransient<MossTtsCrispAsrSettingsViewModel>();
         collection.AddTransient<KokoroTtsSettingsViewModel>();
         collection.AddTransient<ChatterboxTtsSettingsViewModel>();
         collection.AddTransient<PiperSettingsViewModel>();

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -64,6 +64,8 @@ public partial class DownloadTtsViewModel : ObservableObject
     private Task? _downloadTaskF5TtsCrispAsrVoices;
     private Task? _downloadTaskVoxCPM2CrispAsrModels;
     private Task? _downloadTaskVoxCPM2CrispAsrVoices;
+    private Task? _downloadTaskMossTtsCrispAsrModels;
+    private Task? _downloadTaskMossTtsCrispAsrVoices;
     private Task? _downloadTaskZonosTtsCrispAsrModels;
     private Task? _downloadTaskZonosTtsCrispAsrVoices;
     private Task? _downloadTaskOmniVoice;
@@ -83,6 +85,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     private readonly ICosyVoice3CrispAsrDownloadService _cosyVoice3CrispAsrDownloadService;
     private readonly IF5TtsCrispAsrDownloadService _f5TtsCrispAsrDownloadService;
     private readonly IVoxCPM2CrispAsrDownloadService _voxCPM2CrispAsrDownloadService;
+    private readonly IMossTtsCrispAsrDownloadService _mossTtsCrispAsrDownloadService;
     private readonly IZonosTtsCrispAsrDownloadService _zonosTtsCrispAsrDownloadService;
     private readonly IOmniVoiceDownloadService _omniVoiceDownloadService;
     private readonly CancellationTokenSource _cancellationTokenSource;
@@ -98,6 +101,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     private readonly MemoryStream _downloadStreamCosyVoice3CrispAsrVoices;
     private readonly MemoryStream _downloadStreamF5TtsCrispAsrVoices;
     private readonly MemoryStream _downloadStreamVoxCPM2CrispAsrVoices;
+    private readonly MemoryStream _downloadStreamMossTtsCrispAsrVoices;
     private readonly MemoryStream _downloadStreamZonosTtsCrispAsrVoices;
     private readonly MemoryStream _downloadStreamOmniVoice;
     private readonly MemoryStream _downloadStreamOmniVoices;
@@ -116,6 +120,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         ICosyVoice3CrispAsrDownloadService cosyVoice3CrispAsrDownloadService,
         IF5TtsCrispAsrDownloadService f5TtsCrispAsrDownloadService,
         IVoxCPM2CrispAsrDownloadService voxCPM2CrispAsrDownloadService,
+        IMossTtsCrispAsrDownloadService mossTtsCrispAsrDownloadService,
         IZonosTtsCrispAsrDownloadService zonosTtsCrispAsrDownloadService,
         IOmniVoiceDownloadService omniVoiceDownloadService)
     {
@@ -129,6 +134,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         _cosyVoice3CrispAsrDownloadService = cosyVoice3CrispAsrDownloadService;
         _f5TtsCrispAsrDownloadService = f5TtsCrispAsrDownloadService;
         _voxCPM2CrispAsrDownloadService = voxCPM2CrispAsrDownloadService;
+        _mossTtsCrispAsrDownloadService = mossTtsCrispAsrDownloadService;
         _zonosTtsCrispAsrDownloadService = zonosTtsCrispAsrDownloadService;
         _omniVoiceDownloadService = omniVoiceDownloadService;
         _zipUnpacker = zipUnpacker;
@@ -147,6 +153,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         _downloadStreamCosyVoice3CrispAsrVoices = new MemoryStream();
         _downloadStreamF5TtsCrispAsrVoices = new MemoryStream();
         _downloadStreamVoxCPM2CrispAsrVoices = new MemoryStream();
+        _downloadStreamMossTtsCrispAsrVoices = new MemoryStream();
         _downloadStreamZonosTtsCrispAsrVoices = new MemoryStream();
         _downloadStreamOmniVoice = new MemoryStream();
         _downloadStreamOmniVoices = new MemoryStream();
@@ -1182,6 +1189,92 @@ public partial class DownloadTtsViewModel : ObservableObject
                 Close();
             }
 
+            // MOSS-TTS mirrors VoxCPM2: model first, then a voices ZIP from the shared
+            // qwen3-tts.cpp voice pack (same 24 kHz mono format the cloning backends want).
+            if (_downloadTaskMossTtsCrispAsrModels is { IsCompletedSuccessfully: true })
+            {
+                _timer.Stop();
+                _downloadTaskMossTtsCrispAsrModels = null;
+
+                var voicesFolder = MossTtsCrispAsr.GetSetVoicesFolder();
+                var voicesAlreadyInstalled = Directory.Exists(voicesFolder)
+                    && Directory.EnumerateFiles(voicesFolder, "*.wav").Any();
+                if (voicesAlreadyInstalled)
+                {
+                    OkPressed = true;
+                    Close();
+                    return;
+                }
+
+                TitleText = "Downloading MOSS-TTS (CrispASR) voices";
+                ProgressValue = 0;
+                ProgressText = Se.Language.General.StartingDotDotDot;
+                var voicesProgress = new Progress<float>(number =>
+                {
+                    var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+                    var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+                    ProgressValue = percentage;
+                    ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+                });
+                _downloadTaskMossTtsCrispAsrVoices = _qwen3TtsCppDownloadService.DownloadVoices(
+                    _downloadStreamMossTtsCrispAsrVoices, voicesProgress, _cancellationTokenSource.Token);
+                _timer.Start();
+            }
+            else if (_downloadTaskMossTtsCrispAsrModels is { IsFaulted: true })
+            {
+                _timer.Stop();
+                var ex = _downloadTaskMossTtsCrispAsrModels.Exception?.InnerException ?? _downloadTaskMossTtsCrispAsrModels.Exception;
+                if (ex is OperationCanceledException)
+                {
+                    ProgressText = "Download canceled";
+                    Close();
+                }
+                else
+                {
+                    ProgressText = "Download failed";
+                    Error = ex?.Message ?? "Unknown error";
+                }
+            }
+
+            if (_downloadTaskMossTtsCrispAsrVoices is { IsCompletedSuccessfully: true })
+            {
+                _timer.Stop();
+                if (_downloadStreamMossTtsCrispAsrVoices.Length > 0)
+                {
+                    var voicesFolder = MossTtsCrispAsr.GetSetVoicesFolder();
+                    try
+                    {
+                        _downloadStreamMossTtsCrispAsrVoices.Position = 0;
+                        _zipUnpacker.UnpackZipStream(_downloadStreamMossTtsCrispAsrVoices, voicesFolder, string.Empty, false, new List<string>(), null);
+                        ResampleVoicesTo24kHz(voicesFolder);
+                    }
+                    catch (Exception ex)
+                    {
+                        Se.LogError(ex);
+                    }
+                    _downloadStreamMossTtsCrispAsrVoices.Dispose();
+                }
+                OkPressed = true;
+                Close();
+            }
+            else if (_downloadTaskMossTtsCrispAsrVoices is { IsFaulted: true })
+            {
+                _timer.Stop();
+                if (_cancellationTokenSource.IsCancellationRequested)
+                {
+                    ProgressText = "Download canceled";
+                    Close();
+                    return;
+                }
+                var ex = _downloadTaskMossTtsCrispAsrVoices.Exception?.InnerException ?? _downloadTaskMossTtsCrispAsrVoices.Exception;
+                if (ex != null)
+                {
+                    Se.LogError(ex);
+                }
+                OkPressed = true;
+                Close();
+            }
+
             if (_downloadTaskOmniVoice is { IsCompletedSuccessfully: true })
             {
                 _timer.Stop();
@@ -1857,6 +1950,29 @@ public partial class DownloadTtsViewModel : ObservableObject
 
         _downloadTaskVoxCPM2CrispAsrModels =
             _voxCPM2CrispAsrDownloadService.DownloadModels(VoxCPM2CrispAsr.GetSetModelsFolder(), resolved, downloadProgress, titleProgress, _cancellationTokenSource.Token);
+    }
+
+    public void StartDownloadMossTtsCrispAsrModels(string? modelKey = null)
+    {
+        var resolved = MossTtsCrispAsr.ResolveModelKey(modelKey);
+        var modelFileName = MossTtsCrispAsr.GetModelFileName(resolved);
+        TitleText = $"Downloading MOSS-TTS (CrispASR) model ({resolved}): {modelFileName}";
+
+        var downloadProgress = new Progress<float>(number =>
+        {
+            var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+            var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+            ProgressValue = percentage;
+            ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+        });
+
+        var titleProgress = new Action<string>(title =>
+        {
+            Dispatcher.UIThread.Post(() => TitleText = title);
+        });
+
+        _downloadTaskMossTtsCrispAsrModels =
+            _mossTtsCrispAsrDownloadService.DownloadModels(MossTtsCrispAsr.GetSetModelsFolder(), resolved, downloadProgress, titleProgress, _cancellationTokenSource.Token);
     }
 
     public void StartDownloadOmniVoice(string windowsVariant = OmniVoiceDownloadService.WindowsVariantVulkan)

--- a/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
@@ -1,0 +1,906 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// MOSS-TTS v1.5 (OpenMOSS-Team, Fudan) run through the CrispASR runtime. Qwen3-8B backbone
+/// emitting 32 RVQ audio codebooks under a delay pattern, decoded by a 1.6B pure-transformer
+/// codec (MOSS-Audio-Tokenizer) at 24 kHz, Apache-2.0, with zero-shot voice cloning from a
+/// user-supplied reference WAV. CrispASR ships it as the <c>moss-tts</c> backend
+/// (cstr/moss-tts-v1.5-GGUF on Hugging Face). Requested in #12617.
+///
+/// The repo ships two quants of the backbone plus a shared codec companion:
+///   - Backbone : moss-tts-v1.5-{q4_k,f16}.gguf  (we stage the one the user picks)
+///   - Codec    : moss-tts-v1.5-codec.gguf       (~3.5 GB; shared by both quants)
+/// crispasr resolves the codec from sibling/cache/registry, but we pass <c>--codec-model</c>
+/// explicitly when both files are staged locally so resolution never silently falls back to a
+/// network fetch. <see cref="Nikse.SubtitleEdit.Logic.Download.MossTtsCrispAsrDownloadService"/>
+/// stages both with size + SHA-256 verification before first synth; <c>-m auto --auto-download</c>
+/// is the slower fallback used only when a required file is missing at startup.
+///
+/// CLI usage (upstream README):
+///   crispasr --backend moss-tts -m moss-tts-v1.5-q4_k.gguf \
+///       --codec-model moss-tts-v1.5-codec.gguf \
+///       --voice reference.wav \
+///       --tts "Hello, how are you today?" --tts-output out.wav
+///
+/// Cloning is zero-shot from audio alone; an adjacent .txt transcription (ref-text) is optional
+/// but improves quality, so we pass <c>--ref-text</c> when a sidecar is present (same layout as
+/// VoxCPM2 / F5-TTS / Qwen3 CustomVoice).
+///
+/// Verified against the pinned v0.8.13 binary on Apple M4 / Metal:
+/// - basic synth: 3.6 s of 24 kHz mono in 22 s wall (cold start incl. model load)
+/// - cloning: --voice + --ref-text produces intelligible output in the reference voice
+///   (round-trip transcription matches); consent is logged server-side
+/// - server mode: SE's exact launch args + /v1/audio/speech payload return HTTP 200 with a
+///   valid 24 kHz WAV at RTF≈1.7; `voice` resolves as the file stem inside --voice-dir
+///   (same name-not-path rule as VoxCPM2)
+/// </summary>
+public class MossTtsCrispAsr : ITtsEngine
+{
+    public string Name => "MOSS-TTS (CrispASR)";
+    public string Description => "MOSS-TTS v1.5 24 kHz TTS with zero-shot voice cloning, via CrispASR";
+    public bool HasLanguageParameter => false;
+    public bool HasApiKey => false;
+    public bool HasRegion => false;
+    public bool HasModel => true;
+    public bool HasKeyFile => false;
+
+    // Two backbone quants — Q4_K is the default (~7 GB), F16 the reference (~17 GB). Both also
+    // need the shared ~3.5 GB codec companion, so the labels carry the combined footprint.
+    public const string ModelKeyQ4K = "Q4_K (~10.5 GB incl. codec)";
+    public const string ModelKeyF16 = "F16 (~20.5 GB incl. codec)";
+    public const string DefaultModelKey = ModelKeyQ4K;
+
+    public const string ModelQ4KFileName = "moss-tts-v1.5-q4_k.gguf";
+    public const string ModelF16FileName = "moss-tts-v1.5-f16.gguf";
+    public const string CodecFileName = "moss-tts-v1.5-codec.gguf";
+
+    public const string BackendName = "moss-tts";
+
+    // Like the other CrispASR cloning backends, the reference audio is passed via the startup
+    // --voice flag, so the server is torn down and restarted when the selected voice or ref-text
+    // changes (keyed by (model, voice, ref-text) below).
+    private static readonly bool UseStartupVoiceFlags = true;
+
+    /// <summary>
+    /// All filenames that must be present in <see cref="GetSetModelsFolder"/> for the chosen
+    /// quant: the picked backbone plus the shared codec companion. Listed backbone-first so the
+    /// download dialog reports the bigger file before the codec.
+    /// </summary>
+    public static string[] GetRequiredFileNames(string? modelKey) => new[]
+    {
+        GetModelFileName(modelKey),
+        CodecFileName,
+    };
+
+    // Exact byte sizes from the HF tree API (cstr/moss-tts-v1.5-GGUF). Same truncation guard as
+    // the other CrispASR TTS engines — a partial file crashes the loader at server startup.
+    private static readonly Dictionary<string, long> ExpectedFileSizes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [ModelQ4KFileName] = 7001179808L,
+        [ModelF16FileName] = 16985720416L,
+        [CodecFileName] = 3549253856L,
+    };
+
+    public static string ResolveModelKey(string? modelKey)
+    {
+        if (string.IsNullOrEmpty(modelKey))
+        {
+            var saved = Se.Settings.Video.TextToSpeech.MossTtsCrispAsrModel;
+            return string.IsNullOrEmpty(saved) ? DefaultModelKey : ResolveModelKey(saved);
+        }
+
+        return modelKey switch
+        {
+            ModelKeyF16 => ModelKeyF16,
+            _ => ModelKeyQ4K,
+        };
+    }
+
+    public static string GetModelFileName(string? modelKey) => ResolveModelKey(modelKey) switch
+    {
+        ModelKeyF16 => ModelF16FileName,
+        _ => ModelQ4KFileName,
+    };
+
+    public static bool IsValidLocalModelFile(string path, string fileName)
+    {
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
+        if (!ExpectedFileSizes.TryGetValue(fileName, out var expected))
+        {
+            return true;
+        }
+
+        try
+        {
+            return new FileInfo(path).Length == expected;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static readonly HttpClient HttpClient = new()
+    {
+        Timeout = TimeSpan.FromMinutes(30),
+    };
+    private static readonly SemaphoreSlim ServerLock = new(1, 1);
+    private static Process? _serverProcess;
+    private static int _serverPort;
+    private static string? _serverLaunchCommand;
+    private static string? _serverModelKey;
+    // Only used when UseStartupVoiceFlags is true. Changing the reference WAV means tear-down +
+    // restart so the new --voice path takes effect.
+    private static string? _serverVoicePath;
+    private static string? _serverRefText;
+    private static bool _processExitHooked;
+    private static readonly StringBuilder _serverLog = new();
+
+    private static string ServerBaseUrl => $"http://127.0.0.1:{_serverPort}";
+
+    public Task<bool> IsInstalled(string? region)
+    {
+        return Task.FromResult(File.Exists(GetCrispAsrExecutable()));
+    }
+
+    public override string ToString() => Name;
+
+    public static string GetCrispAsrExecutable()
+    {
+        return new CrispAsrCohere().GetExecutable();
+    }
+
+    public static DownloadHashManager.UpdateStatus GetEngineUpdateStatus()
+    {
+        var exe = GetCrispAsrExecutable();
+        if (!File.Exists(exe))
+        {
+            return DownloadHashManager.UpdateStatus.Unknown;
+        }
+
+        var folder = Path.GetDirectoryName(exe);
+        return string.IsNullOrEmpty(folder)
+            ? DownloadHashManager.UpdateStatus.Unknown
+            : DownloadHashManager.GetSidecarStatus(folder);
+    }
+
+    public static string GetSetFolder()
+    {
+        if (!Directory.Exists(Se.TextToSpeechFolder))
+        {
+            Directory.CreateDirectory(Se.TextToSpeechFolder);
+        }
+
+        var folder = Path.Combine(Se.TextToSpeechFolder, "MossTtsCrispAsr");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public static string GetSetModelsFolder()
+    {
+        var modelsFolder = Path.Combine(Se.CrispAsrFolder, "models");
+        if (!Directory.Exists(modelsFolder))
+        {
+            Directory.CreateDirectory(modelsFolder);
+        }
+
+        return modelsFolder;
+    }
+
+    public static string GetSetVoicesFolder()
+    {
+        var voicesFolder = Path.Combine(GetSetFolder(), "voices");
+        if (!Directory.Exists(voicesFolder))
+        {
+            Directory.CreateDirectory(voicesFolder);
+        }
+
+        SeedVoicesFromQwen3TtsCppIfEmpty(voicesFolder);
+        return voicesFolder;
+    }
+
+    private static bool _voiceSeedAttempted;
+
+    /// <summary>
+    /// One-time best-effort seed of WAV reference voices from qwen3-tts.cpp's voices folder so
+    /// the voice combo isn't empty on first run. Copies the .wav (resampled to 24 kHz mono —
+    /// MOSS-TTS's native rate) and any .txt transcription sidecar.
+    /// </summary>
+    private static void SeedVoicesFromQwen3TtsCppIfEmpty(string voicesFolder)
+    {
+        if (_voiceSeedAttempted)
+        {
+            return;
+        }
+        _voiceSeedAttempted = true;
+
+        try
+        {
+            if (Directory.EnumerateFiles(voicesFolder, "*.wav").Any())
+            {
+                return;
+            }
+
+            var sourceFolder = Qwen3TtsCpp.GetSetVoicesFolder();
+            if (!Directory.Exists(sourceFolder) || !Directory.EnumerateFiles(sourceFolder, "*.wav").Any())
+            {
+                return;
+            }
+
+            foreach (var src in Directory.GetFiles(sourceFolder, "*.wav"))
+            {
+                var dest = Path.Combine(voicesFolder, Path.GetFileName(src));
+
+                if (!File.Exists(dest))
+                {
+                    try
+                    {
+                        // qwen3-tts.cpp voice pack ships at 16 kHz; resample to MOSS-TTS's
+                        // native 24 kHz mono on seed.
+                        var ffmpeg = FfmpegGenerator.ConvertToMono24kHzWav(src, dest);
+                        if (!ffmpeg.Start())
+                        {
+                            File.Copy(src, dest);
+                        }
+                        else
+                        {
+                            ffmpeg.WaitForExit();
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Se.LogError(ex, $"MOSS-TTS (CrispASR): resample seed '{src}' failed; falling back to plain copy");
+                        try { if (!File.Exists(dest))
+                        {
+                            File.Copy(src, dest);
+                        } } catch { }
+                    }
+                }
+
+                var sidecar = Path.ChangeExtension(src, ".txt");
+                if (File.Exists(sidecar))
+                {
+                    var sidecarDest = Path.ChangeExtension(dest, ".txt");
+                    if (!File.Exists(sidecarDest))
+                    {
+                        // The qwen3-tts.cpp voice pack's .txt sidecars are Wikimedia attribution
+                        // blurbs, not spoken transcriptions - used as ref-text they produce
+                        // runaway, off-voice output, and being non-empty they also defeat the
+                        // missing-transcription prompt. Same filter Qwen3 (CrispASR) applies.
+                        try
+                        {
+                            if (!Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(File.ReadAllText(sidecar)))
+                            {
+                                File.Copy(sidecar, sidecarDest);
+                            }
+                        }
+                        catch { }
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "MOSS-TTS (CrispASR): voice seeding from qwen3-tts.cpp folder failed");
+        }
+    }
+
+    public static string GetModelPath(string? modelKey = null) =>
+        Path.Combine(GetSetModelsFolder(), GetModelFileName(modelKey));
+
+    public static string GetCodecPath() =>
+        Path.Combine(GetSetModelsFolder(), CodecFileName);
+
+    public static string GetCrispAsrCacheFolder() =>
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".cache", "crispasr");
+
+    public static bool TrySeedModelFromCrispAsrCache(string fileName, string destinationPath)
+    {
+        if (IsValidLocalModelFile(destinationPath, fileName))
+        {
+            return true;
+        }
+
+        try
+        {
+            if (File.Exists(destinationPath))
+            {
+                Se.LogError($"MOSS-TTS (CrispASR): removing wrong-sized local model file {destinationPath}");
+                File.Delete(destinationPath);
+            }
+
+            var cachePath = Path.Combine(GetCrispAsrCacheFolder(), fileName);
+            if (!IsValidLocalModelFile(cachePath, fileName))
+            {
+                return false;
+            }
+
+            File.Copy(cachePath, destinationPath);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"MOSS-TTS (CrispASR): cache seed copy failed for {fileName}");
+            return false;
+        }
+    }
+
+    public static bool AreModelsInstalled(string? modelKey = null)
+    {
+        var modelsFolder = GetSetModelsFolder();
+        foreach (var name in GetRequiredFileNames(modelKey))
+        {
+            if (!IsValidLocalModelFile(Path.Combine(modelsFolder, name), name))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public Task<Voice[]> GetVoices(string language)
+    {
+        var result = new List<Voice>();
+
+        // Voice cloning only — no built-in default voice. The combo is empty until the user
+        // imports a reference WAV (or the qwen3-tts.cpp voice seed runs above).
+        var voicesFolder = GetSetVoicesFolder();
+        if (Directory.Exists(voicesFolder))
+        {
+            foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
+            {
+                var name = Path.GetFileNameWithoutExtension(file).Replace('_', ' ');
+                result.Add(new Voice(new MossTtsVoice(name, file)));
+            }
+        }
+
+        return Task.FromResult(result.ToArray());
+    }
+
+    public bool IsVoiceInstalled(Voice voice) => true;
+
+    public Task<string[]> GetRegions() => Task.FromResult(Array.Empty<string>());
+
+    public Task<string[]> GetModels() => Task.FromResult(new[] { ModelKeyQ4K, ModelKeyF16 });
+
+    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(Array.Empty<TtsLanguage>());
+
+    public Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken) =>
+        GetVoices(language);
+
+    public async Task<TtsResult> Speak(
+        string text,
+        string outputFolder,
+        Voice voice,
+        TtsLanguage? language,
+        string? region,
+        string? model,
+        CancellationToken cancellationToken)
+    {
+        if (voice.EngineVoice is not MossTtsVoice mossVoice)
+        {
+            throw new ArgumentException("Voice is not a MossTtsVoice");
+        }
+
+        if (string.IsNullOrEmpty(mossVoice.FilePath))
+        {
+            throw new InvalidOperationException(
+                "MOSS-TTS (CrispASR) requires a reference voice WAV. "
+                + "Import one via the voice settings, then pick it in the voice combo. "
+                + "Reference WAV should be mono (3-10 s of clean speech); an adjacent .txt file "
+                + "with the spoken transcription is optional but improves cloning quality.");
+        }
+
+        var refText = TryReadRefText(mossVoice.FilePath);
+        var modelKey = ResolveModelKey(model);
+        await EnsureServerRunningAsync(modelKey, mossVoice.FilePath, refText, cancellationToken);
+
+        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+
+        var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.MossTtsCrispAsrSpeed, 0.25, 4.0);
+        var payload = new Dictionary<string, object>
+        {
+            ["input"] = text,
+            ["response_format"] = "wav",
+            // The OpenAI-compat server resolves `voice` as a NAME listed by /v1/voices (the file
+            // stem inside --voice-dir). Passing a full path makes the server hang indefinitely,
+            // so send the reference WAV's base name — it lives in the voices folder = --voice-dir.
+            ["voice"] = Path.GetFileNameWithoutExtension(mossVoice.FilePath),
+            ["speed"] = speed,
+            // Voice cloning is gated behind a consent attestation (the server returns HTTP 400
+            // consent_required without it). The user supplies their own reference voice by
+            // importing a WAV into SE, which is the act being attested here.
+            ["consent_attestation"] = "I have the speaker's consent, or it is my own voice.",
+            // Skip the audible AI-disclosure prefix CrispASR otherwise prepends to cloned audio;
+            // SE surfaces the AI-generated nature in its UI. The inaudible watermark + C2PA
+            // provenance metadata stay embedded regardless (defaults to true server-side).
+            ["spoken_disclaimer"] = false,
+        };
+        if (!string.IsNullOrEmpty(refText))
+        {
+            payload["ref_text"] = refText;
+        }
+
+        var body = JsonSerializer.Serialize(payload);
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        Se.WriteToolsLog($"MOSS-TTS (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (voice={mossVoice}, refTextLen={refText.Length}, textLen={text.Length})");
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await HttpClient.PostAsync($"{ServerBaseUrl}/v1/audio/speech", content, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            var serverLog = SnapshotServerLog();
+            var launchCommand = _serverLaunchCommand;
+            var died = _serverProcess?.HasExited == true;
+            if (died)
+            {
+                StopServerInternal();
+            }
+
+            var failMsg = $"MOSS-TTS (CrispASR) request failed — Voice: {mossVoice}, Text: {text}, "
+                + $"RequestJson: {body}, ServerExited: {died}, ServerLog: {serverLog}"
+                + LaunchCmdSuffix(launchCommand);
+            Se.LogError(ex, failMsg);
+            Se.WriteToolsLog(failMsg);
+
+            throw new InvalidOperationException(
+                (died
+                    ? "MOSS-TTS (CrispASR) — the crispasr server crashed during synthesis."
+                    : "MOSS-TTS (CrispASR) request failed — the connection to the crispasr server was dropped.")
+                + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}")
+                + LaunchCmdSuffix(launchCommand),
+                ex);
+        }
+
+        using (response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await SafeReadErrorAsync(response, cancellationToken);
+                var serverLog = SnapshotServerLog();
+                var launchCommand = _serverLaunchCommand;
+                var errMsg = $"MOSS-TTS (CrispASR) server error {(int)response.StatusCode} {response.StatusCode} — "
+                    + $"Voice: {mossVoice}, Text: {text}, RequestJson: {body}, "
+                    + $"ResponseBody: {errorBody}, ServerLog: {serverLog}"
+                    + LaunchCmdSuffix(launchCommand);
+                Se.LogError(errMsg);
+                Se.WriteToolsLog(errMsg);
+                throw new InvalidOperationException(
+                    $"MOSS-TTS (CrispASR) synthesis failed ({(int)response.StatusCode}): {errorBody}"
+                    + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}")
+                    + LaunchCmdSuffix(launchCommand));
+            }
+
+            await using var fileStream = File.Create(outputFileName);
+            await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            await contentStream.CopyToAsync(fileStream, cancellationToken);
+        }
+
+        return new TtsResult(outputFileName, text);
+    }
+
+    private static string TryReadRefText(string wavPath)
+    {
+        try
+        {
+            var sidecar = Path.ChangeExtension(wavPath, ".txt");
+            if (!File.Exists(sidecar))
+            {
+                return string.Empty;
+            }
+
+            // Sidecars written by pre-filter seeding can be Wikimedia attribution blurbs, not
+            // transcriptions - treat them as "no transcript" (same read-time filter Qwen3
+            // CrispASR applies) so they neither poison ref-text nor suppress the prompt.
+            var text = File.ReadAllText(sidecar).Trim();
+            return Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(text) ? string.Empty : text;
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+
+    private static string FormatLaunchCommand(string exe, System.Collections.ObjectModel.Collection<string> args)
+    {
+        static string Quote(string s) =>
+            !string.IsNullOrEmpty(s) && s.IndexOfAny(new[] { ' ', '\t' }) >= 0
+                ? "\"" + s.Replace("\"", "\\\"") + "\""
+                : s;
+
+        var sb = new StringBuilder(Quote(exe));
+        foreach (var a in args)
+        {
+            sb.Append(' ').Append(Quote(a));
+        }
+        return sb.ToString();
+    }
+
+    private static string LaunchCmdSuffix(string? launchCommand) =>
+        string.IsNullOrEmpty(launchCommand)
+            ? string.Empty
+            : $"{Environment.NewLine}Launch command: {launchCommand}";
+
+    private static async Task<string> SafeReadErrorAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            return await response.Content.ReadAsStringAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            return $"<failed to read error body: {ex.Message}>";
+        }
+    }
+
+    private static async Task EnsureServerRunningAsync(string modelKey, string voicePath, string refText, CancellationToken ct)
+    {
+        bool MatchesCurrent() =>
+            _serverProcess is { HasExited: false } && _serverPort != 0
+            && string.Equals(_serverModelKey, modelKey, StringComparison.OrdinalIgnoreCase)
+            && (!UseStartupVoiceFlags
+                || (string.Equals(_serverVoicePath, voicePath, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(_serverRefText, refText, StringComparison.Ordinal)));
+
+        if (MatchesCurrent())
+        {
+            return;
+        }
+
+        await ServerLock.WaitAsync(ct);
+        try
+        {
+            if (MatchesCurrent())
+            {
+                return;
+            }
+
+            if (_serverProcess != null)
+            {
+                StopServerInternal();
+            }
+
+            var exe = GetCrispAsrExecutable();
+            if (!File.Exists(exe))
+            {
+                throw new FileNotFoundException(
+                    "CrispASR executable not found. Install CrispASR via Video → Audio to text first.", exe);
+            }
+
+            var modelPath = GetModelPath(modelKey);
+            var hasLocalModel = AreModelsInstalled(modelKey);
+
+            var port = FindFreeLoopbackPort();
+            var psi = new ProcessStartInfo
+            {
+                WorkingDirectory = Path.GetDirectoryName(exe) ?? GetSetFolder(),
+                FileName = exe,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+            };
+            psi.ArgumentList.Add("--server");
+            psi.ArgumentList.Add("--backend");
+            psi.ArgumentList.Add(BackendName);
+            psi.ArgumentList.Add("-m");
+            psi.ArgumentList.Add(hasLocalModel ? modelPath : "auto");
+            if (hasLocalModel)
+            {
+                // Pin the staged codec explicitly so resolution never silently falls back to a
+                // registry/network fetch (it also lives as a sibling of the backbone).
+                psi.ArgumentList.Add("--codec-model");
+                psi.ArgumentList.Add(GetCodecPath());
+            }
+            else
+            {
+                psi.ArgumentList.Add("--auto-download");
+            }
+            psi.ArgumentList.Add("--host");
+            psi.ArgumentList.Add("127.0.0.1");
+            psi.ArgumentList.Add("--port");
+            psi.ArgumentList.Add(port.ToString());
+            psi.ArgumentList.Add("--voice-dir");
+            psi.ArgumentList.Add(GetSetVoicesFolder());
+
+            if (UseStartupVoiceFlags)
+            {
+                psi.ArgumentList.Add("--voice");
+                psi.ArgumentList.Add(voicePath);
+                if (!string.IsNullOrEmpty(refText))
+                {
+                    psi.ArgumentList.Add("--ref-text");
+                    psi.ArgumentList.Add(refText);
+                }
+            }
+
+            var process = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start crispasr (moss-tts)");
+
+            var launchCommand = FormatLaunchCommand(exe, psi.ArgumentList);
+            _serverLaunchCommand = launchCommand;
+            Se.WriteToolsLog("MOSS-TTS (CrispASR) server starting — "
+                + $"PID: {process.Id}, "
+                + $"Cmd: {launchCommand}");
+
+            lock (_serverLog) _serverLog.Clear();
+            process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
+            };
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
+            };
+            process.BeginErrorReadLine();
+            process.BeginOutputReadLine();
+
+            _serverProcess = process;
+            _serverPort = port;
+            _serverModelKey = modelKey;
+            _serverVoicePath = voicePath;
+            _serverRefText = refText;
+            HookProcessExitOnce();
+
+            // First-run auto-download (backbone + codec is up to ~20.5 GB) needs a generous
+            // timeout; the 8B backbone also takes a while to load from disk.
+            var deadline = DateTime.UtcNow.AddMinutes(hasLocalModel ? 10 : 60);
+            while (DateTime.UtcNow < deadline)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (process.HasExited)
+                {
+                    var tail = SnapshotServerLog();
+                    var exitCode = process.ExitCode;
+                    var exitedLaunchCommand = _serverLaunchCommand;
+                    _serverProcess = null;
+                    _serverPort = 0;
+                    _serverLaunchCommand = null;
+                    _serverModelKey = null;
+                    _serverVoicePath = null;
+                    _serverRefText = null;
+                    throw new InvalidOperationException(
+                        $"crispasr (moss-tts) exited during startup (code {exitCode}). Output: {tail}"
+                        + LaunchCmdSuffix(exitedLaunchCommand));
+                }
+                if (await ProbeHealthAsync(port, TimeSpan.FromSeconds(2), ct))
+                {
+                    return;
+                }
+                await Task.Delay(TimeSpan.FromSeconds(1), ct);
+            }
+
+            var lastOutput = SnapshotServerLog();
+            var timeoutLaunchCommand = _serverLaunchCommand;
+            StopServerInternal();
+            throw new TimeoutException(
+                $"crispasr (moss-tts) did not report healthy within {(hasLocalModel ? 10 : 60)} minutes. Last output: {lastOutput}"
+                + LaunchCmdSuffix(timeoutLaunchCommand));
+        }
+        finally
+        {
+            ServerLock.Release();
+        }
+    }
+
+    private static string SnapshotServerLog()
+    {
+        lock (_serverLog)
+        {
+            var s = _serverLog.ToString().TrimEnd();
+            return s.Length > 2000 ? s[^2000..] : s;
+        }
+    }
+
+    private static async Task<bool> ProbeHealthAsync(int port, TimeSpan timeout, CancellationToken ct)
+    {
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(timeout);
+            using var resp = await HttpClient.GetAsync($"http://127.0.0.1:{port}/health", cts.Token);
+            return resp.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static int FindFreeLoopbackPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private static void HookProcessExitOnce()
+    {
+        if (_processExitHooked)
+        {
+            return;
+        }
+        _processExitHooked = true;
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
+    }
+
+    public static void StopServer() => StopServerInternal();
+
+    private static void StopServerInternal()
+    {
+        var p = _serverProcess;
+        _serverProcess = null;
+        _serverPort = 0;
+        _serverLaunchCommand = null;
+        _serverModelKey = null;
+        _serverVoicePath = null;
+        _serverRefText = null;
+        if (p == null)
+        {
+            return;
+        }
+        try
+        {
+            if (!p.HasExited)
+            {
+                p.Kill(entireProcessTree: true);
+                p.WaitForExit(2000);
+            }
+        }
+        catch
+        {
+            // best effort
+        }
+        finally
+        {
+            p.Dispose();
+        }
+    }
+
+    private static string GetUniqueDestinationFileName(string folder, string baseName)
+    {
+        var candidate = Path.Combine(folder, baseName + ".wav");
+        if (!File.Exists(candidate))
+        {
+            return candidate;
+        }
+
+        var number = 1;
+        do
+        {
+            candidate = Path.Combine(folder, $"{baseName}_{number}.wav");
+            number++;
+        } while (File.Exists(candidate));
+
+        return candidate;
+    }
+
+    public bool ImportVoice(string fileName) => ImportVoice(fileName, string.Empty);
+
+    /// <summary>
+    /// Imports <paramref name="fileName"/> as a MOSS-TTS reference voice. When
+    /// <paramref name="transcript"/> is non-empty it's written to the destination .txt sidecar
+    /// (improves cloning quality); when empty, falls back to copying any .txt sidecar that
+    /// already lives next to the source WAV.
+    /// </summary>
+    public bool ImportVoice(string fileName, string transcript)
+    {
+        if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
+        {
+            return false;
+        }
+
+        var voicesFolder = GetSetVoicesFolder();
+        var baseName = Path.GetFileNameWithoutExtension(fileName);
+        var destinationFileName = GetUniqueDestinationFileName(voicesFolder, baseName);
+
+        // Resample to MOSS-TTS's native 24 kHz mono on import via ffmpeg regardless of source
+        // format.
+        try
+        {
+            var process = FfmpegGenerator.ConvertToMono24kHzWav(fileName, destinationFileName);
+            if (!process.Start())
+            {
+                return false;
+            }
+
+            process.WaitForExit();
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "MOSS-TTS (CrispASR) voice import failed (ffmpeg conversion).");
+            return false;
+        }
+
+        if (!File.Exists(destinationFileName))
+        {
+            return false;
+        }
+
+        try
+        {
+            var destSidecar = Path.ChangeExtension(destinationFileName, ".txt");
+            if (!string.IsNullOrWhiteSpace(transcript))
+            {
+                File.WriteAllText(destSidecar, transcript.Trim());
+            }
+            else
+            {
+                var sourceSidecar = Path.ChangeExtension(fileName, ".txt");
+                if (File.Exists(sourceSidecar) && !File.Exists(destSidecar))
+                {
+                    File.Copy(sourceSidecar, destSidecar);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "MOSS-TTS (CrispASR) voice import: failed to write .txt sidecar");
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Writes <paramref name="transcript"/> to <c>&lt;voice&gt;.txt</c> next to the supplied
+    /// voice WAV inside the voices folder. Used to retro-fit a transcription onto a voice that
+    /// was already imported (or seeded) without a full re-import.
+    /// </summary>
+    public static bool TryWriteRefTextSidecar(string voiceWavPath, string transcript)
+    {
+        if (string.IsNullOrEmpty(voiceWavPath) || string.IsNullOrWhiteSpace(transcript))
+        {
+            return false;
+        }
+
+        try
+        {
+            var sidecar = Path.ChangeExtension(voiceWavPath, ".txt");
+            File.WriteAllText(sidecar, transcript.Trim());
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"MOSS-TTS (CrispASR): failed to write ref-text sidecar for '{voiceWavPath}'");
+            return false;
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/MossTtsCrispAsrSettings/MossTtsCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/MossTtsCrispAsrSettings/MossTtsCrispAsrSettingsViewModel.cs
@@ -1,0 +1,234 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.MossTtsCrispAsrSettings;
+
+public partial class MossTtsCrispAsrSettingsViewModel : ObservableObject
+{
+    private static IBrush Green() => new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50));
+    private static IBrush Amber() => new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00));
+    private static IBrush Red() => new SolidColorBrush(Color.FromRgb(0xF4, 0x43, 0x36));
+    private static IBrush Grey() => new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E));
+
+    private readonly IWindowService _windowService;
+    private readonly IFolderHelper _folderHelper;
+
+    [ObservableProperty] private string _engineLabel = string.Empty;
+    [ObservableProperty] private IBrush _engineBrush = Grey();
+    [ObservableProperty] private string _engineDownloadButtonText = string.Empty;
+
+    [ObservableProperty] private string _modelQ4KLabel = string.Empty;
+    [ObservableProperty] private IBrush _modelQ4KBrush = Grey();
+
+    [ObservableProperty] private string _modelF16Label = string.Empty;
+    [ObservableProperty] private IBrush _modelF16Brush = Grey();
+
+    [ObservableProperty] private string _voicesLabel = string.Empty;
+
+    [ObservableProperty] private double _speed = 1.0;
+
+    public string SpeedLabel => $"Speed {Speed:0.00}x";
+
+    partial void OnSpeedChanged(double value)
+    {
+        OnPropertyChanged(nameof(SpeedLabel));
+        Se.Settings.Video.TextToSpeech.MossTtsCrispAsrSpeed = Math.Clamp(value, 0.25, 4.0);
+    }
+
+    [ObservableProperty] private string _modelsFolder = string.Empty;
+    [ObservableProperty] private string _voicesFolder = string.Empty;
+    [ObservableProperty] private bool _isEngineInstalled;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public MossTtsCrispAsrSettingsViewModel(IWindowService windowService, IFolderHelper folderHelper)
+    {
+        _windowService = windowService;
+        _folderHelper = folderHelper;
+    }
+
+    public void Initialize()
+    {
+        ModelsFolder = MossTtsCrispAsr.GetSetModelsFolder();
+        VoicesFolder = MossTtsCrispAsr.GetSetVoicesFolder();
+        Speed = Math.Clamp(Se.Settings.Video.TextToSpeech.MossTtsCrispAsrSpeed, 0.25, 4.0);
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        var exe = MossTtsCrispAsr.GetCrispAsrExecutable();
+        IsEngineInstalled = File.Exists(exe);
+
+        if (!IsEngineInstalled)
+        {
+            EngineLabel = "CrispASR not installed";
+            EngineBrush = Red();
+            EngineDownloadButtonText = "Download CrispASR";
+        }
+        else if (MossTtsCrispAsr.GetEngineUpdateStatus() == DownloadHashManager.UpdateStatus.UpdateAvailable)
+        {
+            EngineLabel = "CrispASR - update available";
+            EngineBrush = Amber();
+            EngineDownloadButtonText = "Update CrispASR";
+        }
+        else
+        {
+            EngineLabel = "CrispASR";
+            EngineBrush = Green();
+            EngineDownloadButtonText = "Re-download CrispASR";
+        }
+
+        if (IsEngineInstalled)
+        {
+            var baseLabel = EngineLabel;
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    var version = CrispAsrVersion.TryGet(exe);
+                    if (string.IsNullOrEmpty(version))
+                    {
+                        return;
+                    }
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        if (EngineLabel == baseLabel)
+                        {
+                            EngineLabel = baseLabel.Replace("CrispASR", $"CrispASR v{version}");
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Se.LogError(ex, "MossTtsCrispAsrSettings: CrispASR version probe failed");
+                }
+            });
+        }
+
+        ApplyModelStatus(
+            MossTtsCrispAsr.AreModelsInstalled(MossTtsCrispAsr.ModelKeyQ4K),
+            IsEngineInstalled,
+            label => ModelQ4KLabel = label,
+            brush => ModelQ4KBrush = brush);
+
+        ApplyModelStatus(
+            MossTtsCrispAsr.AreModelsInstalled(MossTtsCrispAsr.ModelKeyF16),
+            IsEngineInstalled,
+            label => ModelF16Label = label,
+            brush => ModelF16Brush = brush);
+
+        try
+        {
+            var wavCount = Directory.Exists(VoicesFolder)
+                ? Directory.GetFiles(VoicesFolder, "*.wav").Length
+                : 0;
+            VoicesLabel = wavCount == 0
+                ? "No voices imported"
+                : (wavCount == 1 ? "1 voice imported" : $"{wavCount} voices imported");
+        }
+        catch
+        {
+            VoicesLabel = string.Empty;
+        }
+    }
+
+    private static void ApplyModelStatus(bool fileInstalled, bool engineInstalled, Action<string> setLabel, Action<IBrush> setBrush)
+    {
+        if (fileInstalled)
+        {
+            setLabel("Installed");
+            setBrush(Green());
+            return;
+        }
+
+        if (!engineInstalled)
+        {
+            setLabel("CrispASR required");
+            setBrush(Grey());
+            return;
+        }
+
+        setLabel("Auto-download on first use");
+        setBrush(Grey());
+    }
+
+    [RelayCommand]
+    private async Task RedownloadEngine()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        await TtsVoiceInstaller.EnsureCrispAsrForMossTts(Window, _windowService, forceRedownload: true);
+        Refresh();
+    }
+
+    [RelayCommand]
+    private async Task OpenModelsFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(ModelsFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, ModelsFolder);
+        }
+        catch
+        {
+            // best-effort UX
+        }
+    }
+
+    [RelayCommand]
+    private async Task OpenVoicesFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(VoicesFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, VoicesFolder);
+        }
+        catch
+        {
+            // best-effort UX
+        }
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/MossTtsCrispAsrSettings/MossTtsCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/MossTtsCrispAsrSettings/MossTtsCrispAsrSettingsWindow.cs
@@ -1,0 +1,260 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.MossTtsCrispAsrSettings;
+
+public class MossTtsCrispAsrSettingsWindow : Window
+{
+    private const int LabelWidth = 150;
+    private const int ValueWidth = 360;
+
+    private readonly MossTtsCrispAsrSettingsViewModel _vm;
+
+    public MossTtsCrispAsrSettingsWindow(MossTtsCrispAsrSettingsViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = "MOSS-TTS (CrispASR) settings";
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        MinWidth = 580;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        Content = BuildContent(vm);
+
+        var ok = UiUtil.MakeButtonOk(vm.OkCommand);
+        Activated += delegate { ok.Focus(); };
+    }
+
+    private Border BuildContent(MossTtsCrispAsrSettingsViewModel vm)
+    {
+        var header = BuildHeader();
+        var details = BuildDetails(vm);
+        var actions = BuildActions(vm);
+
+        var stack = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 14,
+            Children = { header, details, actions },
+        };
+
+        var outerGrid = new Grid
+        {
+            Margin = UiUtil.MakeWindowMargin(),
+        };
+        outerGrid.Children.Add(stack);
+
+        return new Border
+        {
+            Child = outerGrid,
+            Padding = new Thickness(4),
+        };
+    }
+
+    private static StackPanel BuildHeader()
+    {
+        var title = new TextBlock
+        {
+            Text = "MOSS-TTS (CrispASR)",
+            FontSize = 18,
+            FontWeight = FontWeight.SemiBold,
+        };
+
+        var subtitle = new TextBlock
+        {
+            Text = new MossTtsCrispAsr().Description,
+            FontSize = 12,
+            Opacity = 0.75,
+            Margin = new Thickness(0, 2, 0, 0),
+        };
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 0,
+            Children = { title, subtitle },
+        };
+    }
+
+    private static Border BuildDetails(MossTtsCrispAsrSettingsViewModel vm)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(LabelWidth, GridUnitType.Pixel) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnSpacing = 12,
+            RowSpacing = 10,
+        };
+
+        grid.Add(MakeLabel("Engine"), 0, 0);
+        var enginePanel = MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel));
+        var engineButton = UiUtil.MakeButton(string.Empty, vm.RedownloadEngineCommand)
+            .WithIconLeft(IconNames.Download)
+            .WithMarginLeft(12);
+        engineButton.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.EngineDownloadButtonText)));
+        enginePanel.Children.Add(engineButton);
+        grid.Add(enginePanel, 0, 1);
+
+        grid.Add(MakeLabel("Model " + MossTtsCrispAsr.ModelKeyQ4K), 1, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.ModelQ4KBrush), nameof(vm.ModelQ4KLabel)), 1, 1);
+
+        grid.Add(MakeLabel("Model " + MossTtsCrispAsr.ModelKeyF16), 2, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.ModelF16Brush), nameof(vm.ModelF16Label)), 2, 1);
+
+        grid.Add(MakeLabel("Voices"), 3, 0);
+        var voicesText = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.VoicesLabel)),
+        };
+        grid.Add(voicesText, 3, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.Speed), 4, 0);
+        grid.Add(MakeSpeedPanel(), 4, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 5, 0);
+        var folderText = new TextBox
+        {
+            IsReadOnly = true,
+            Width = ValueWidth,
+            BorderThickness = new Thickness(0),
+            Background = Brushes.Transparent,
+            Padding = new Thickness(0),
+            VerticalContentAlignment = VerticalAlignment.Center,
+            FontSize = 12,
+            [!TextBox.TextProperty] = new Binding(nameof(vm.ModelsFolder)),
+        };
+        grid.Add(folderText, 5, 1);
+
+        return new Border
+        {
+            Child = grid,
+            Padding = new Thickness(14),
+            CornerRadius = new CornerRadius(6),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
+        };
+    }
+
+    private static StackPanel MakeSpeedPanel()
+    {
+        var slider = new Slider
+        {
+            Minimum = 0.5,
+            Maximum = 2.0,
+            Width = 220,
+            TickFrequency = 0.05,
+            IsSnapToTickEnabled = true,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Slider.ValueProperty] = new Binding(nameof(MossTtsCrispAsrSettingsViewModel.Speed)),
+        };
+        var label = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            Width = 80,
+            [!TextBlock.TextProperty] = new Binding(nameof(MossTtsCrispAsrSettingsViewModel.SpeedLabel)),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { slider, label },
+        };
+    }
+
+    private static StackPanel MakeStatusPanel(string brushBindingPath, string labelBindingPath)
+    {
+        var dot = new Ellipse
+        {
+            Width = 10,
+            Height = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Ellipse.FillProperty] = new Binding(brushBindingPath),
+        };
+        var text = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(labelBindingPath),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { dot, text },
+        };
+    }
+
+    private static Grid BuildActions(MossTtsCrispAsrSettingsViewModel vm)
+    {
+        var openModelsFolder = UiUtil.MakeButton(Se.Language.General.OpenContainingFolder, vm.OpenModelsFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var openVoicesFolder = UiUtil.MakeButton("Voices folder", vm.OpenVoicesFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var close = UiUtil.MakeButton(Se.Language.General.Close, vm.OkCommand);
+
+        var leftPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Children = { openModelsFolder, openVoicesFolder },
+        };
+
+        var rightPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Spacing = 8,
+            Children = { close },
+        };
+
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+        };
+        grid.Add(leftPanel, 0, 0);
+        grid.Add(rightPanel, 0, 2);
+        return grid;
+    }
+
+    private static TextBlock MakeLabel(string text) => new()
+    {
+        Text = text,
+        Opacity = 0.7,
+        VerticalAlignment = VerticalAlignment.Center,
+    };
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -21,6 +21,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.EncodingSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.F5TtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VoxCPM2CrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.MossTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.KokoroTtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.PiperSettings;
@@ -235,6 +236,10 @@ public partial class TextToSpeechViewModel : ObservableObject
             // CrispASR v0.7.0, so synthesis is fast enough for the TTS-from-subtitles workflow.
             new VoxCPM2CrispAsr(),
 
+            // MOSS-TTS (CrispASR) — Qwen3-8B backbone + 1.6B transformer codec at 24 kHz with
+            // zero-shot voice cloning, via the moss-tts backend (#12617).
+            new MossTtsCrispAsr(),
+
             new ZonosTtsCrispAsr(),
 
             new ChatterboxTtsCpp(),
@@ -406,6 +411,10 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             Se.Settings.Video.TextToSpeech.VoxCPM2CrispAsrModel = SelectedModel ?? VoxCPM2CrispAsr.DefaultModelKey;
         }
+        else if (SelectedEngine is MossTtsCrispAsr)
+        {
+            Se.Settings.Video.TextToSpeech.MossTtsCrispAsrModel = SelectedModel ?? MossTtsCrispAsr.DefaultModelKey;
+        }
         else if (SelectedEngine is OmniVoiceTtsCpp)
         {
             Se.Settings.Video.TextToSpeech.OmniVoiceTtsCppInstruction = (Instruction ?? string.Empty).Trim();
@@ -563,6 +572,7 @@ public partial class TextToSpeechViewModel : ObservableObject
         string? wavPath = null;
         bool isCosyVoice3 = false;
         bool isVoxCPM2 = false;
+        bool isMossTts = false;
         bool isQwen3Clone = false;
         if (voice.EngineVoice is CosyVoice3Voice cosy && !string.IsNullOrEmpty(cosy.FilePath) && string.IsNullOrEmpty(cosy.RefText))
         {
@@ -584,6 +594,15 @@ public partial class TextToSpeechViewModel : ObservableObject
             {
                 wavPath = vox.FilePath;
                 isVoxCPM2 = true;
+            }
+        }
+        else if (voice.EngineVoice is MossTtsVoice moss && !string.IsNullOrEmpty(moss.FilePath))
+        {
+            var existing = TryReadRefTextSibling(moss.FilePath);
+            if (string.IsNullOrEmpty(existing))
+            {
+                wavPath = moss.FilePath;
+                isMossTts = true;
             }
         }
         else if (voice.EngineVoice is Voices.Qwen3TtsVoice qwen3 && !string.IsNullOrEmpty(qwen3.FilePath))
@@ -642,6 +661,10 @@ public partial class TextToSpeechViewModel : ObservableObject
             else if (isVoxCPM2)
             {
                 written = VoxCPM2CrispAsr.TryWriteRefTextSidecar(wavPath, result.Text);
+            }
+            else if (isMossTts)
+            {
+                written = MossTtsCrispAsr.TryWriteRefTextSidecar(wavPath, result.Text);
             }
             else if (isQwen3Clone)
             {
@@ -1010,6 +1033,10 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             VoxCPM2CrispAsr.StopServer();
         }
+        if (keepAlive is not MossTtsCrispAsr)
+        {
+            MossTtsCrispAsr.StopServer();
+        }
         if (keepAlive is not ZonosTtsCrispAsr)
         {
             ZonosTtsCrispAsr.StopServer();
@@ -1217,6 +1244,10 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             await _windowService.ShowDialogAsync<VoxCPM2CrispAsrSettingsWindow, VoxCPM2CrispAsrSettingsViewModel>(Window!, vm => vm.Initialize());
         }
+        else if (SelectedEngine is MossTtsCrispAsr)
+        {
+            await _windowService.ShowDialogAsync<MossTtsCrispAsrSettingsWindow, MossTtsCrispAsrSettingsViewModel>(Window!, vm => vm.Initialize());
+        }
         else if (SelectedEngine is KokoroTtsCpp)
         {
             await _windowService.ShowDialogAsync<KokoroTtsSettingsWindow, KokoroTtsSettingsViewModel>(Window!, vm => vm.Initialize());
@@ -1309,6 +1340,9 @@ public partial class TextToSpeechViewModel : ObservableObject
             case VoxCPM2CrispAsr:
                 await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadVoxCPM2CrispAsrModels(VoxCPM2CrispAsr.ResolveModelKey(SelectedModel)));
                 break;
+            case MossTtsCrispAsr:
+                await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadMossTtsCrispAsrModels(MossTtsCrispAsr.ResolveModelKey(SelectedModel)));
+                break;
             case ZonosTtsCrispAsr:
                 await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadZonosTtsCrispAsrModels());
                 break;
@@ -1371,6 +1405,9 @@ public partial class TextToSpeechViewModel : ObservableObject
                 ? DownloadDotStatus.UpToDate
                 : DownloadDotStatus.NotInstalled,
             VoxCPM2CrispAsr => VoxCPM2CrispAsr.AreModelsInstalled(modelKey)
+                ? DownloadDotStatus.UpToDate
+                : DownloadDotStatus.NotInstalled,
+            MossTtsCrispAsr => MossTtsCrispAsr.AreModelsInstalled(modelKey)
                 ? DownloadDotStatus.UpToDate
                 : DownloadDotStatus.NotInstalled,
             ZonosTtsCrispAsr => ZonosTtsCrispAsr.AreModelsInstalled()
@@ -3201,6 +3238,16 @@ public partial class TextToSpeechViewModel : ObservableObject
             else if (SelectedEngine is VoxCPM2CrispAsr)
             {
                 SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.VoxCPM2CrispAsrModel);
+                if (string.IsNullOrEmpty(SelectedModel))
+                {
+                    SelectedModel = Models.FirstOrDefault();
+                }
+                IsEngineSettingsVisible = true;
+                IsModelDownloadVisible = true;
+            }
+            else if (SelectedEngine is MossTtsCrispAsr)
+            {
+                SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.MossTtsCrispAsrModel);
                 if (string.IsNullOrEmpty(SelectedModel))
                 {
                     SelectedModel = Models.FirstOrDefault();

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -189,6 +189,8 @@ public class TextToSpeechWindow : Window
                 return StatusDots.From(engine.IsInstalled(null).Result, F5TtsCrispAsr.GetEngineUpdateStatus());
             case VoxCPM2CrispAsr:
                 return StatusDots.From(engine.IsInstalled(null).Result, VoxCPM2CrispAsr.GetEngineUpdateStatus());
+            case MossTtsCrispAsr:
+                return StatusDots.From(engine.IsInstalled(null).Result, MossTtsCrispAsr.GetEngineUpdateStatus());
             case ZonosTtsCrispAsr:
                 return StatusDots.From(engine.IsInstalled(null).Result, ZonosTtsCrispAsr.GetEngineUpdateStatus());
             case OmniVoiceTtsCpp:

--- a/src/ui/Features/Video/TextToSpeech/TtsEngineInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsEngineInstaller.cs
@@ -414,6 +414,44 @@ public static class TtsEngineInstaller
             return true;
         }
 
+        if (engine is MossTtsCrispAsr)
+        {
+            if (!await TtsVoiceInstaller.EnsureCrispAsrForMossTts(window, windowService, forceRedownload: false))
+            {
+                return false;
+            }
+
+            var mossModelKey = MossTtsCrispAsr.ResolveModelKey(model);
+            if (!MossTtsCrispAsr.AreModelsInstalled(mossModelKey))
+            {
+                var answer = await MessageBox.Show(
+                    window,
+                    "Download MOSS-TTS (CrispASR) model?",
+                    $"{Environment.NewLine}\"MOSS-TTS (CrispASR)\" ({mossModelKey}) requires a model.{Environment.NewLine}{Environment.NewLine}Download model?",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (answer != MessageBoxResult.Yes)
+                {
+                    return false;
+                }
+
+                var dlResult = await windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(window, vm => vm.StartDownloadMossTtsCrispAsrModels(mossModelKey));
+                if (!dlResult.OkPressed || !MossTtsCrispAsr.AreModelsInstalled(mossModelKey))
+                {
+                    return false;
+                }
+
+                await Dispatcher.UIThread.InvokeAsync(async () =>
+                {
+                    await refreshVoices();
+                });
+                return true;
+            }
+
+            return true;
+        }
+
         if (engine is KokoroTtsCpp)
         {
             if (!await engine.IsInstalled(region))

--- a/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
@@ -140,6 +140,16 @@ public static class TtsVoiceInstaller
             minVersionNote: "v0.7.0 or newer");
 
     /// <summary>
+    /// Ensures the CrispASR runtime that MOSS-TTS (CrispASR) runs on is installed.
+    /// The moss-tts backend ships in CrispASR v0.8.13+ (SE's pinned release).
+    /// </summary>
+    public static Task<bool> EnsureCrispAsrForMossTts(Window? window, IWindowService windowService, bool forceRedownload)
+        => EnsureCrispAsrAsync(window, windowService, forceRedownload,
+            engineDisplayName: "MOSS-TTS (CrispASR)",
+            extraCapabilityCheck: null,
+            minVersionNote: "v0.8.13 or newer");
+
+    /// <summary>
     /// Shared CrispASR install/update flow used by all TTS engines that sit on the
     /// CrispASR runtime. Prompts refer to <paramref name="engineDisplayName"/> so users
     /// see the right engine name. <paramref name="extraCapabilityCheck"/> lets the caller

--- a/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
@@ -214,6 +214,28 @@ public partial class VoiceSettingsViewModel : ObservableObject
                 ? voxEngine.ImportVoice(fileName, (result.Text ?? string.Empty).Trim())
                 : voxEngine.ImportVoice(fileName);
         }
+        else if (_engine is MossTtsCrispAsr mossEngine)
+        {
+            // MOSS-TTS clones zero-shot from audio alone; a transcription (ref-text) is optional
+            // but improves quality, so prompt like VoxCPM2 while allowing an empty answer.
+            var transcript = TryReadSiblingTranscript(fileName) ?? string.Empty;
+            var audioFileName = fileName;
+            var result = await _windowService.ShowDialogAsync<PromptTextBoxWindow, PromptTextBoxViewModel>(Window!, vm =>
+            {
+                vm.Initialize(
+                    Se.Language.Video.TextToSpeech.VoiceCloneTranscriptTitle,
+                    transcript,
+                    500,
+                    150);
+                vm.ConfigureExtraButton(
+                    Se.Language.Video.TextToSpeech.UseSpeechToTextDotDotDot,
+                    () => RunSpeechToTextAsync(audioFileName));
+            });
+
+            ok = result.OkPressed
+                ? mossEngine.ImportVoice(fileName, (result.Text ?? string.Empty).Trim())
+                : mossEngine.ImportVoice(fileName);
+        }
         else
         {
             ok = _engine.ImportVoice(fileName);
@@ -369,6 +391,7 @@ public partial class VoiceSettingsViewModel : ObservableObject
                                || engine.GetType() == typeof(CosyVoice3CrispAsr)
                                || engine.GetType() == typeof(F5TtsCrispAsr)
                                || engine.GetType() == typeof(VoxCPM2CrispAsr)
+                               || engine.GetType() == typeof(MossTtsCrispAsr)
                                || engine.GetType() == typeof(ZonosTtsCrispAsr)
                                || engine.GetType() == typeof(ChatterboxTtsCpp)
                                || engine.GetType() == typeof(OmniVoiceTtsCpp);

--- a/src/ui/Features/Video/TextToSpeech/Voices/MossTtsVoice.cs
+++ b/src/ui/Features/Video/TextToSpeech/Voices/MossTtsVoice.cs
@@ -1,0 +1,24 @@
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+
+public class MossTtsVoice
+{
+    public string Voice { get; set; }
+    public string FilePath { get; set; }
+
+    public override string ToString()
+    {
+        return Voice;
+    }
+
+    public MossTtsVoice()
+    {
+        Voice = string.Empty;
+        FilePath = string.Empty;
+    }
+
+    public MossTtsVoice(string voice, string filePath)
+    {
+        Voice = voice;
+        FilePath = filePath;
+    }
+}

--- a/src/ui/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/ui/Logic/Config/SeVideoTextToSpeech.cs
@@ -42,6 +42,8 @@ public class SeVideoTextToSpeech
     public double F5TtsCrispAsrSpeed { get; set; }
     public string VoxCPM2CrispAsrModel { get; set; }
     public double VoxCPM2CrispAsrSpeed { get; set; }
+    public string MossTtsCrispAsrModel { get; set; }
+    public double MossTtsCrispAsrSpeed { get; set; }
     public string OmniVoiceTtsCppVulkanPath { get; set; }
     public string OmniVoiceTtsCppInstruction { get; set; }
     public string ChatterboxModel { get; set; }
@@ -121,6 +123,8 @@ public class SeVideoTextToSpeech
         F5TtsCrispAsrSpeed = 1.0;
         VoxCPM2CrispAsrModel = "Q4_K (~1.7 GB)";
         VoxCPM2CrispAsrSpeed = 1.0;
+        MossTtsCrispAsrModel = "Q4_K (~10.5 GB incl. codec)";
+        MossTtsCrispAsrSpeed = 1.0;
         OmniVoiceTtsCppVulkanPath = string.Empty;
         OmniVoiceTtsCppInstruction = string.Empty;
         ChatterboxModel = "Base";

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -217,6 +217,15 @@ public static class DownloadHashManager
         public const string ModelQ4K = "VoxCPM2CrispAsr.ModelQ4K";
         public const string ModelF16 = "VoxCPM2CrispAsr.ModelF16";
         public const string Ref = "VoxCPM2CrispAsr.Ref";
+    }
+
+    public static class MossTtsCrispAsr
+    {
+        // SHA-256 of each GGUF the moss-tts backend needs: the two backbone quants and the
+        // shared moss-tts-v1.5-codec.gguf companion. Hashes are the HF LFS oid from the tree API.
+        public const string ModelQ4K = "MossTtsCrispAsr.ModelQ4K";
+        public const string ModelF16 = "MossTtsCrispAsr.ModelF16";
+        public const string Codec = "MossTtsCrispAsr.Codec";
     }
 
     public static class KokoroTtsCpp
@@ -1269,6 +1278,20 @@ public static class DownloadHashManager
             [VoxCPM2CrispAsr.Ref] = new[]
             {
                 "9b024ef9a109075aa8ac7219c097a1b1b1bed23d3230b33a902e162c2c10c5f8", // voxcpm2-ref.gguf
+            },
+
+            // MOSS-TTS (CrispASR) — cstr/moss-tts-v1.5-GGUF on HuggingFace.
+            [MossTtsCrispAsr.ModelQ4K] = new[]
+            {
+                "9e7fb9ed28339be5327dce16f9bd53c67220cbf119a9c767f513d28d1fa80547", // moss-tts-v1.5-q4_k.gguf
+            },
+            [MossTtsCrispAsr.ModelF16] = new[]
+            {
+                "6da9920aae627b308e8c111a3ab3cbd0456fe79c6e0cec3b49ab92ce8642938a", // moss-tts-v1.5-f16.gguf
+            },
+            [MossTtsCrispAsr.Codec] = new[]
+            {
+                "9cb5aa788dfb8fb0d46323898fb8dba57fb85d9c1f615019949c7f00a4bd5382", // moss-tts-v1.5-codec.gguf
             },
 
             // Kokoro TTS — https://github.com/niksedk/kokoro.cpp/releases

--- a/src/ui/Logic/Download/MossTtsCrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/MossTtsCrispAsrDownloadService.cs
@@ -1,0 +1,161 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Logic.Download;
+
+public interface IMossTtsCrispAsrDownloadService
+{
+    Task DownloadModels(string modelsFolder, string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Downloads the GGUFs the moss-tts backend needs — the picked backbone quant plus the shared
+/// moss-tts-v1.5-codec.gguf companion — into SE's CrispASR/models folder. Staging both ourselves
+/// gives the user a single SE progress dialog instead of crispasr's silent --auto-download. Same
+/// .part + size-check + optional SHA-256 verify pattern as VoxCPM2/CosyVoice3/F5-TTS.
+/// </summary>
+public class MossTtsCrispAsrDownloadService : IMossTtsCrispAsrDownloadService
+{
+    private const string RepoBase = "https://huggingface.co/cstr/moss-tts-v1.5-GGUF/resolve/main/";
+
+    private readonly HttpClient _httpClient;
+
+    private static readonly Dictionary<string, string> ModelUrls = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [MossTtsCrispAsr.ModelQ4KFileName] = RepoBase + MossTtsCrispAsr.ModelQ4KFileName,
+        [MossTtsCrispAsr.ModelF16FileName] = RepoBase + MossTtsCrispAsr.ModelF16FileName,
+        [MossTtsCrispAsr.CodecFileName] = RepoBase + MossTtsCrispAsr.CodecFileName,
+    };
+
+    public MossTtsCrispAsrDownloadService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task DownloadModels(string modelsFolder, string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken)
+    {
+        // Destinations are derived from MossTtsCrispAsr.GetSetModelsFolder() so cache-seed
+        // adoption and SE-managed downloads converge on the same canonical location.
+        modelsFolder = MossTtsCrispAsr.GetSetModelsFolder();
+
+        var required = MossTtsCrispAsr.GetRequiredFileNames(modelKey);
+
+        // Seed any matching files already in crispasr's --auto-download cache before deciding
+        // what to fetch.
+        await Task.Run(() =>
+        {
+            foreach (var fileName in required)
+            {
+                var dest = Path.Combine(modelsFolder, fileName);
+                MossTtsCrispAsr.TrySeedModelFromCrispAsrCache(fileName, dest);
+                EnsureRemovedIfInvalid(dest, fileName);
+            }
+        }, cancellationToken);
+
+        var missing = new List<string>();
+        foreach (var fileName in required)
+        {
+            var dest = Path.Combine(modelsFolder, fileName);
+            if (!MossTtsCrispAsr.IsValidLocalModelFile(dest, fileName))
+            {
+                missing.Add(fileName);
+            }
+        }
+
+        var step = 0;
+        foreach (var fileName in missing)
+        {
+            step++;
+            titleProgress?.Invoke($"Downloading MOSS-TTS (CrispASR) models ({step}/{missing.Count}): {fileName}");
+            var dest = Path.Combine(modelsFolder, fileName);
+            await DownloadAndVerify(dest, fileName, progress, cancellationToken);
+        }
+    }
+
+    private async Task DownloadAndVerify(string finalPath, string fileName, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        var partPath = finalPath + ".part";
+        try
+        {
+            await DownloadHelper.DownloadFileAsync(_httpClient, GetUrl(fileName), partPath, progress, cancellationToken);
+            await VerifyFile(partPath, GetHashKey(fileName), fileName, cancellationToken);
+            File.Move(partPath, finalPath);
+        }
+        catch
+        {
+            TryDelete(partPath);
+            throw;
+        }
+    }
+
+    private static string? GetHashKey(string fileName)
+    {
+        if (string.Equals(fileName, MossTtsCrispAsr.ModelQ4KFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.MossTtsCrispAsr.ModelQ4K;
+        }
+        if (string.Equals(fileName, MossTtsCrispAsr.ModelF16FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.MossTtsCrispAsr.ModelF16;
+        }
+        if (string.Equals(fileName, MossTtsCrispAsr.CodecFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.MossTtsCrispAsr.Codec;
+        }
+        return null;
+    }
+
+    private static async Task VerifyFile(string filePath, string? key, string fileName, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            return;
+        }
+
+        var expected = DownloadHashManager.GetLatestKnownHash(key);
+        if (string.IsNullOrEmpty(expected))
+        {
+            return;
+        }
+
+        string actual;
+        await using (var stream = File.OpenRead(filePath))
+        {
+            actual = await DownloadHashManager.ComputeSha256Async(stream, cancellationToken);
+        }
+
+        if (!string.Equals(expected, actual, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new IOException(
+                $"MOSS-TTS (CrispASR) model {fileName} failed integrity check (expected SHA-256 {expected}, got {actual}).");
+        }
+    }
+
+    private static string GetUrl(string fileName)
+    {
+        if (!ModelUrls.TryGetValue(fileName, out var url))
+        {
+            throw new ArgumentException($"Unknown MOSS-TTS (CrispASR) model: {fileName}", nameof(fileName));
+        }
+        return url;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try { File.Delete(path); } catch { /* best-effort cleanup */ }
+    }
+
+    private static void EnsureRemovedIfInvalid(string path, string fileName)
+    {
+        if (!File.Exists(path) || MossTtsCrispAsr.IsValidLocalModelFile(path, fileName))
+        {
+            return;
+        }
+        TryDelete(path);
+    }
+}


### PR DESCRIPTION
## Summary
Closes #12617 — adds **MOSS-TTS v1.5** ([OpenMOSS-Team](https://huggingface.co/cstr/moss-tts-v1.5-GGUF), Apache-2.0) as a TTS engine via the CrispASR `moss-tts` backend, including zero-shot **voice cloning** from a user-imported reference WAV (with optional transcript sidecar, same flow as VoxCPM2/F5-TTS).

- Engine: 24 kHz output; Qwen3-8B backbone + 1.6B transformer codec; served through crispasr `--server` with the OpenAI-compatible `/v1/audio/speech` endpoint
- Models: `moss-tts-v1.5-q4_k.gguf` (~7 GB, default) or `f16` (~17 GB), plus the shared `moss-tts-v1.5-codec.gguf` (~3.5 GB), staged by a download service with byte-size + SHA-256 verification (hashes = HF LFS oids); crispasr's `--auto-download` remains the fallback
- Full registration: engine list, DI, install/download flow with size prompts, install-status dots, settings window (speed slider, model status, folders), voice import with transcript prompt + speech-to-text assist, ref-text sidecar retrofit

## Verification (headless, pinned CrispASR v0.8.13, Apple M4/Metal)
- Both GGUFs hash-verified against the HuggingFace LFS oids after download
- Basic synth: valid 24 kHz mono WAV
- **Voice cloning**: `--voice ref.wav --ref-text "..."` produces intelligible output in the reference voice — round-trip ASR transcription matches the requested text; consent attestation is logged server-side
- Server mode with SE's **exact** launch args and JSON payload (`consent_attestation`, `spoken_disclaimer: false`, `voice` as file stem per the VoxCPM2 name-not-path rule): HTTP 200, RTF≈1.7
- Noted difference vs VoxCPM2: a request without `consent_attestation` is *not* rejected when the server was started with `--voice`; SE always sends the attestation regardless

## Test plan
- [x] `dotnet build src/ui/UI.csproj -c Release` — 0 warnings, 0 errors
- [x] Headless engine verification as above
- [ ] Manual UI pass: engine appears in the combo with install dots, model download dialog stages backbone + codec, voice import → clone → generate waveform row

🤖 Generated with [Claude Code](https://claude.com/claude-code)