### PR TITLE
Replace RuntimeInformation.IsOSPlatform with OperatingSystem helpers

### DIFF
--- a/src/ui/Features/Main/Layout/InitVideoPlayer.cs
+++ b/src/ui/Features/Main/Layout/InitVideoPlayer.cs
@@ -9,7 +9,6 @@ using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.VideoPlayers;
 using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 using System;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Features.Main.Layout;
 
@@ -160,7 +159,7 @@ public static class InitVideoPlayer
     /// </summary>
     public static VideoPlayerControl MakeVideoPlayerPreferNonNative()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Se.Settings.Video.VideoPlayer != VideoPlayerName.MpvOpenGl)
+        if (OperatingSystem.IsWindows() && Se.Settings.Video.VideoPlayer != VideoPlayerName.MpvOpenGl)
         {
             var player = new LibMpvDynamicPlayer();
             if (player.CanLoad())

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -170,7 +170,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
@@ -790,7 +789,7 @@ public partial class MainViewModel :
     {
         LibMpvDynamicPlayer.MpvPath = Se.DataFolder;
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             var newFileName = DownloadLibMpvViewModel.GetFallbackLibMpvFileName(false);
             if (string.IsNullOrEmpty(Se.Settings.General.LibMpvPath) || !File.Exists(Se.Settings.General.LibMpvPath) || File.Exists(newFileName))
@@ -17868,7 +17867,7 @@ public partial class MainViewModel :
             Layout.InitNativeMacMenu.Sync(this);
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && string.IsNullOrEmpty(Se.Settings.General.LibMpvPath))
+        if (OperatingSystem.IsWindows() && string.IsNullOrEmpty(Se.Settings.General.LibMpvPath))
         {
             Dispatcher.UIThread.Post(async void () =>
             {
@@ -19836,7 +19835,7 @@ public partial class MainViewModel :
 
     private bool TryHandleMacTextDelete(KeyEventArgs keyEventArgs, Func<KeyEventArgs, bool> isKeyMatch, Func<ITextBoxWrapper, bool> deleteAction)
     {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || !isKeyMatch(keyEventArgs))
+        if (!OperatingSystem.IsMacOS() || !isKeyMatch(keyEventArgs))
         {
             return false;
         }
@@ -20123,7 +20122,7 @@ public partial class MainViewModel :
             return false;
         }
 
-        var isMac = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+        var isMac = OperatingSystem.IsMacOS();
         var navModifiers = e.KeyModifiers & ~KeyModifiers.Shift;
         var isWordNav = navModifiers == KeyModifiers.Control || (isMac && navModifiers == KeyModifiers.Alt);
         var isLineNav = isMac && navModifiers == KeyModifiers.Meta;
@@ -20447,7 +20446,7 @@ public partial class MainViewModel :
                 if ((keyEventArgs.Key == Key.Left || keyEventArgs.Key == Key.Right)
                     && (keyEventArgs.KeyModifiers == KeyModifiers.None
                         || keyEventArgs.KeyModifiers == KeyModifiers.Control
-                        || (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                        || (OperatingSystem.IsMacOS()
                             && (keyEventArgs.KeyModifiers == KeyModifiers.Alt
                                 || keyEventArgs.KeyModifiers == (KeyModifiers.Shift | KeyModifiers.Alt)))))
                 {

--- a/src/ui/Features/Ocr/Download/DownloadCrispEmbedViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadCrispEmbedViewModel.cs
@@ -74,7 +74,7 @@ public partial class DownloadCrispEmbedViewModel : ObservableObject
     {
         _isModelDownload = false;
         _engineVariant = variant;
-        var displayName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || variant == "cuda"
+        var displayName = OperatingSystem.IsWindows() || variant == "cuda"
             ? $"{CrispEmbedEngine.StaticName} {_engineVariant}".TrimEnd()
             : CrispEmbedEngine.StaticName;
         TitleText = string.Format(Se.Language.General.DownloadingX, displayName);
@@ -168,14 +168,14 @@ public partial class DownloadCrispEmbedViewModel : ObservableObject
         _zipUnpacker.UnpackZipStream(_downloadStream, folder, string.Empty, false, new List<string>(), null);
         _downloadStream.Dispose();
 
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows())
         {
             foreach (var name in CrispEmbedEngine.BinaryBaseNames)
             {
                 var path = Path.Combine(folder, name);
                 if (File.Exists(path))
                 {
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                    if (OperatingSystem.IsMacOS())
                     {
                         MacHelper.MakeExecutable(path);
                     }
@@ -230,7 +230,7 @@ public partial class DownloadCrispEmbedViewModel : ObservableObject
                 var ext = Path.GetExtension(file).ToLowerInvariant();
                 var name = Path.GetFileName(file);
                 var isBinary = ext is ".exe" or ".dll" or ".so" or ".dylib"
-                    || (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    || (!OperatingSystem.IsWindows()
                         && Array.IndexOf(CrispEmbedEngine.BinaryBaseNames, name) >= 0);
                 if (!isBinary)
                 {
@@ -267,7 +267,7 @@ public partial class DownloadCrispEmbedViewModel : ObservableObject
         {
             _downloadTask = _downloadService.DownloadModel(_model.Url, _modelTempFileName, downloadProgress, _cancellationTokenSource.Token);
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        else if (OperatingSystem.IsWindows())
         {
             _downloadTask = _engineVariant switch
             {
@@ -276,7 +276,7 @@ public partial class DownloadCrispEmbedViewModel : ObservableObject
                 _ => _downloadService.DownloadEngineWindowsVulkan(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
             };
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+        else if (OperatingSystem.IsLinux()
                  && _engineVariant == "cuda"
                  && RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
         {

--- a/src/ui/Features/Ocr/Engines/CrispEmbedEngine.cs
+++ b/src/ui/Features/Ocr/Engines/CrispEmbedEngine.cs
@@ -37,17 +37,17 @@ public static class CrispEmbedEngine
     {
         get
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (OperatingSystem.IsWindows())
             {
                 return "~5 MB – 691 MB";
             }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (OperatingSystem.IsLinux())
             {
                 return "~8 MB";
             }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            if (OperatingSystem.IsMacOS())
             {
                 return "~6 MB";
             }
@@ -87,7 +87,7 @@ public static class CrispEmbedEngine
 
     public static string GetServerExecutableFileName()
     {
-        return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "crispembed-server.exe" : "crispembed-server";
+        return OperatingSystem.IsWindows() ? "crispembed-server.exe" : "crispembed-server";
     }
 
     public static string GetServerExecutable()

--- a/src/ui/Features/Ocr/Engines/TesseractOcr.cs
+++ b/src/ui/Features/Ocr/Engines/TesseractOcr.cs
@@ -5,7 +5,6 @@ using SkiaSharp;
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,7 +24,7 @@ public class TesseractOcr
 
     public static string GetExecutablePath()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             var windowsPath = Path.Combine(Se.TesseractFolder, "tesseract.exe");
             return File.Exists(windowsPath) ? windowsPath : "tesseract.exe";
@@ -129,7 +128,7 @@ public class TesseractOcr
             catch (System.ComponentModel.Win32Exception ex)
             {
                 Error = $"Could not start Tesseract at \"{_executablePath}\": {ex.Message}." +
-                        (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                        (OperatingSystem.IsWindows()
                             ? string.Empty
                             : " Make sure Tesseract is installed (e.g. \"brew install tesseract\" on macOS, \"apt install tesseract-ocr\" on Linux).");
                 return string.Empty;

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -4159,7 +4159,7 @@ public partial class OcrViewModel : ObservableObject
 
     private async Task<bool> CheckAndDownloadTesseract()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             var tesseractExe = Path.Combine(Se.TesseractFolder, "tesseract.exe");
             if (File.Exists(tesseractExe))
@@ -4213,7 +4213,7 @@ public partial class OcrViewModel : ObservableObject
             // ignore
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             await MessageBox.Show(
                 Window!,
@@ -4225,7 +4225,7 @@ public partial class OcrViewModel : ObservableObject
                 MessageBoxIcon.Information);
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             await MessageBox.Show(
                 Window!,

--- a/src/ui/Features/Options/Settings/VideoPlayerItem.cs
+++ b/src/ui/Features/Options/Settings/VideoPlayerItem.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -27,7 +26,7 @@ public partial class VideoPlayerItem : ObservableObject
         var result = new List<VideoPlayerItem>();
         result.Add(new VideoPlayerItem { Name = Se.Language.Options.Settings.MpvOpenGl, Code = VideoPlayerName.MpvOpenGl });
 
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (!OperatingSystem.IsMacOS())
         {
             result.Add(new VideoPlayerItem { Name = Se.Language.Options.Settings.MpvWidRendering, Code = VideoPlayerName.MpvWid });
         }

--- a/src/ui/Features/Shared/DownloadFfmpegViewModel.cs
+++ b/src/ui/Features/Shared/DownloadFfmpegViewModel.cs
@@ -11,7 +11,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
@@ -90,7 +89,7 @@ public partial class DownloadFfmpegViewModel : ObservableObject
 
                 UnpackFfmpeg(ffmpegFileName);
 
-                if (File.Exists(ffmpegFileName) && RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                if (File.Exists(ffmpegFileName) && OperatingSystem.IsMacOS())
                 {
                     MacHelper.MakeExecutable(ffmpegFileName);
                 }
@@ -132,12 +131,12 @@ public partial class DownloadFfmpegViewModel : ObservableObject
 
     public static string GetFfmpegFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return Path.Combine(Se.FfmpegFolder, "ffmpeg.exe");
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             var paths = new List<string>
             {
@@ -159,7 +158,7 @@ public partial class DownloadFfmpegViewModel : ObservableObject
             }
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             var paths = new List<string>
             {

--- a/src/ui/Features/Shared/DownloadLibMpvViewModel.cs
+++ b/src/ui/Features/Shared/DownloadLibMpvViewModel.cs
@@ -9,7 +9,6 @@ using Nikse.SubtitleEdit.Logic.Download;
 using System;
 using System.Globalization;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
@@ -156,7 +155,7 @@ public partial class DownloadLibMpvViewModel : ObservableObject
 
     public static string GetLibMpvFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return Path.Combine(Se.DataFolder, "libmpv-2.dll");
         }
@@ -172,7 +171,7 @@ public partial class DownloadLibMpvViewModel : ObservableObject
             Directory.CreateDirectory(newFolder);
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return Path.Combine(newFolder, "libmpv-2.dll");
         }

--- a/src/ui/Features/Shared/DownloadYtDlpViewModel.cs
+++ b/src/ui/Features/Shared/DownloadYtDlpViewModel.cs
@@ -8,7 +8,6 @@ using Nikse.SubtitleEdit.Logic.Download;
 using System;
 using System.Globalization;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
@@ -65,11 +64,11 @@ public partial class DownloadYtDlpViewModel : ObservableObject
                 _done = true;
 
                 var fileName = YtDlpDownloadService.GetFullFileName();
-                if (File.Exists(fileName) && RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                if (File.Exists(fileName) && OperatingSystem.IsMacOS())
                 {
                     MacHelper.MakeExecutable(fileName);
                 }
-                else if (File.Exists(fileName) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                else if (File.Exists(fileName) && OperatingSystem.IsLinux())
                 {
                     LinuxHelper.MakeExecutable(fileName);
                 }

--- a/src/ui/Features/Shared/TextBoxUtils/TextEditorWrapper.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/TextEditorWrapper.cs
@@ -66,7 +66,7 @@ public class TextEditorWrapper : ITextBoxWrapper
         // Only apply on macOS: Option+Arrow is the word navigation key there.
         // On Windows/Linux, Ctrl+Arrow is used and AvaloniaEdit's default behavior
         // already matches the platform convention.
-        if (!isAlt || isCtrl || (e.Key != Key.Right && e.Key != Key.Left) || !RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (!isAlt || isCtrl || (e.Key != Key.Right && e.Key != Key.Left) || !OperatingSystem.IsMacOS())
             return;
 
         var document = textArea.Document;

--- a/src/ui/Features/Shared/TextBoxUtils/TextEditorWrapper.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/TextEditorWrapper.cs
@@ -9,7 +9,6 @@ using Nikse.SubtitleEdit.Features.SpellCheck;
 using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Linq;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Features.Shared.TextBoxUtils;
 

--- a/src/ui/Features/SpellCheck/WordSpellCheck.cs
+++ b/src/ui/Features/SpellCheck/WordSpellCheck.cs
@@ -42,7 +42,7 @@ public sealed class WordSpellCheck : IWordSpellChecker, IDisposable
 
     public static bool IsWordInstalled()
     {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows())
         {
             return false;
         }
@@ -60,7 +60,7 @@ public sealed class WordSpellCheck : IWordSpellChecker, IDisposable
 
     public bool Initialize()
     {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows())
         {
             return false;
         }

--- a/src/ui/Features/Translate/DownloadLlamaCppViewModel.cs
+++ b/src/ui/Features/Translate/DownloadLlamaCppViewModel.cs
@@ -12,7 +12,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -208,11 +207,11 @@ public partial class DownloadLlamaCppViewModel : ObservableObject
             return;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             MacHelper.MakeExecutable(path);
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        else if (OperatingSystem.IsLinux())
         {
             LinuxHelper.MakeExecutable(path);
         }

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -179,11 +179,11 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
 
                     var folder = Engine.GetAndCreateWhisperFolder();
                     var skipFolder = Engine is ICrispAsrEngine
-                        ? RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                        ? OperatingSystem.IsLinux()
                             ? (CrispAsrWindowsVariant == "cuda" && RuntimeInformation.ProcessArchitecture != Architecture.Arm64
                                 ? "crispasr-linux-x86_64-cuda"
                                 : "crispasr-linux-x86_64")
-                            : RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                            : OperatingSystem.IsMacOS()
                                 ? "crispasr-macos"
                                 : CrispAsrWindowsVariant switch
                                 {
@@ -252,11 +252,11 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
     {
         if (File.Exists(path))
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            if (OperatingSystem.IsMacOS())
             {
                 MacHelper.MakeExecutable(path);
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            else if (OperatingSystem.IsLinux())
             {
                 LinuxHelper.MakeExecutable(path);
             }
@@ -288,7 +288,7 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
                 var ext = Path.GetExtension(file).ToLowerInvariant();
                 var name = Path.GetFileName(file);
                 var isBinary = ext is ".exe" or ".dll" or ".so" or ".dylib"
-                    || (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    || (!OperatingSystem.IsWindows()
                         && (name == "crispasr" || name == "crispasr-quantize"));
                 if (!isBinary)
                 {
@@ -362,7 +362,7 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
         _zipUnpacker.UnpackZipStream(_downloadStream, folder, skipFolderLevel, false, new List<string>(), null);
         _downloadStream.Dispose();
 
-        if (Engine == null || (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && !RuntimeInformation.IsOSPlatform(OSPlatform.Linux)))
+        if (Engine == null || (!OperatingSystem.IsMacOS() && !OperatingSystem.IsLinux()))
         {
             return;
         }
@@ -433,9 +433,9 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
     public void StartDownload()
     {
         var displayName = Engine is ICrispAsrEngine
-            ? RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? OperatingSystem.IsWindows()
                 ? "Crisp ASR " + CrispAsrWindowsVariant
-                : RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && CrispAsrWindowsVariant == "cuda"
+                : OperatingSystem.IsLinux() && CrispAsrWindowsVariant == "cuda"
                     ? "Crisp ASR cuda"
                     : "Crisp ASR"
             : Engine?.Name;
@@ -487,7 +487,7 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
         }
         else if (Engine is ICrispAsrEngine)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (OperatingSystem.IsWindows())
             {
                 _downloadTask = CrispAsrWindowsVariant switch
                 {
@@ -497,7 +497,7 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
                     _            => _crispAsrDownloadService.DownloadEngineWindowsVulkan(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
                 };
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+            else if (OperatingSystem.IsLinux()
                      && CrispAsrWindowsVariant == "cuda"
                      && RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
             {

--- a/src/ui/Features/Video/SpeechToText/Engines/ChatLlmCppEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/ChatLlmCppEngine.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Avalonia.Platform;
 using Nikse.SubtitleEdit.Core.AudioToText;
@@ -158,7 +157,7 @@ public class ChatLlmCppEngine : ISpeechToTextEngine
 
     public string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "main.exe";
         }
@@ -175,15 +174,15 @@ public class ChatLlmCppEngine : ISpeechToTextEngine
     {
         get
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (OperatingSystem.IsWindows())
             {
                 return "~2 MB";
             }
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (OperatingSystem.IsLinux())
             {
                 return "~3 MB";
             }
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            if (OperatingSystem.IsMacOS())
             {
                 return "~1 MB";
             }

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrArk.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrArk.cs
@@ -1,8 +1,8 @@
 using Nikse.SubtitleEdit.Core.AudioToText;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 
@@ -145,7 +145,7 @@ public class CrispAsrArk : CrispAsrEngineBase
 
     internal static string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "crispasr.exe";
         }

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrCanary.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrCanary.cs
@@ -1,8 +1,8 @@
 ﻿using Nikse.SubtitleEdit.Core.AudioToText;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 
@@ -159,7 +159,7 @@ public class CrispAsrCanary : CrispAsrEngineBase
 
     internal static string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "crispasr.exe";
         }

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrCohere.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrCohere.cs
@@ -1,8 +1,8 @@
 ﻿using Nikse.SubtitleEdit.Core.AudioToText;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 
@@ -235,7 +235,7 @@ public class CrispAsrCohere : CrispAsrEngineBase
 
     internal static string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "crispasr.exe";
         }

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngineBase.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngineBase.cs
@@ -3,7 +3,6 @@ using Nikse.SubtitleEdit.Core.AudioToText;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
@@ -34,15 +33,15 @@ public abstract class CrispAsrEngineBase : ICrispAsrEngine
     {
         get
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (OperatingSystem.IsWindows())
             {
                 return "~3 MB – 684 MB"; // CPU – CUDA depending on variant chosen at download time
             }
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (OperatingSystem.IsLinux())
             {
                 return "~5 MB";
             }
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            if (OperatingSystem.IsMacOS())
             {
                 return "~4 MB";
             }

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrFireRed.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrFireRed.cs
@@ -1,8 +1,8 @@
 ﻿using Nikse.SubtitleEdit.Core.AudioToText;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 
@@ -179,7 +179,7 @@ public class CrispAsrFireRed : CrispAsrEngineBase
 
     internal static string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "crispasr.exe";
         }

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrFunAsrMltNano.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrFunAsrMltNano.cs
@@ -1,8 +1,8 @@
 using Nikse.SubtitleEdit.Core.AudioToText;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 
@@ -154,7 +154,7 @@ public class CrispAsrFunAsrMltNano : CrispAsrEngineBase
 
     internal static string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "crispasr.exe";
         }

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrFunAsrNano.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrFunAsrNano.cs
@@ -1,8 +1,8 @@
 using Nikse.SubtitleEdit.Core.AudioToText;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 
@@ -128,7 +128,7 @@ public class CrispAsrFunAsrNano : CrispAsrEngineBase
 
     internal static string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "crispasr.exe";
         }

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrGlm.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrGlm.cs
@@ -1,8 +1,8 @@
 ﻿using Nikse.SubtitleEdit.Core.AudioToText;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 
@@ -143,7 +143,7 @@ public class CrispAsrGlm : CrispAsrEngineBase
 
     internal static string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "crispasr.exe";
         }

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrGranite.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrGranite.cs
@@ -1,8 +1,8 @@
 ﻿using Nikse.SubtitleEdit.Core.AudioToText;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 
@@ -175,7 +175,7 @@ public class CrispAsrGranite : CrispAsrEngineBase
 
     internal static string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "crispasr.exe";
         }

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrKyutai.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrKyutai.cs
@@ -1,8 +1,8 @@
 using Nikse.SubtitleEdit.Core.AudioToText;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 
@@ -126,7 +126,7 @@ public class CrispAsrKyutai : CrispAsrEngineBase
 
     internal static string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "crispasr.exe";
         }

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrMadlad.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrMadlad.cs
@@ -1,8 +1,8 @@
 using Nikse.SubtitleEdit.Core.AudioToText;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 
@@ -107,7 +107,7 @@ public class CrispAsrMadlad : CrispAsrEngineBase
 
     internal static string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "crispasr.exe";
         }

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrMega.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrMega.cs
@@ -1,8 +1,8 @@
 using Nikse.SubtitleEdit.Core.AudioToText;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 
@@ -125,7 +125,7 @@ public class CrispAsrMega : CrispAsrEngineBase
 
     internal static string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "crispasr.exe";
         }

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrMossDiarize.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrMossDiarize.cs
@@ -1,8 +1,8 @@
 using Nikse.SubtitleEdit.Core.AudioToText;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 
@@ -120,7 +120,7 @@ public class CrispAsrMossDiarize : CrispAsrEngineBase
 
     internal static string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "crispasr.exe";
         }

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrOmni.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrOmni.cs
@@ -1,8 +1,8 @@
 using Nikse.SubtitleEdit.Core.AudioToText;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 
@@ -300,7 +300,7 @@ public class CrispAsrOmni : CrispAsrEngineBase
 
     internal static string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "crispasr.exe";
         }

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
@@ -1,8 +1,8 @@
 ﻿using Nikse.SubtitleEdit.Core.AudioToText;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 
@@ -213,7 +213,7 @@ public class CrispAsrParakeet : CrispAsrEngineBase
 
     internal static string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "crispasr.exe";
         }

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrQwen3.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrQwen3.cs
@@ -1,8 +1,8 @@
 ﻿using Nikse.SubtitleEdit.Core.AudioToText;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 
@@ -213,7 +213,7 @@ public class CrispAsrQwen3 : CrispAsrEngineBase
 
     internal static string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "crispasr.exe";
         }

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrSenseVoice.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrSenseVoice.cs
@@ -1,8 +1,8 @@
 ﻿using Nikse.SubtitleEdit.Core.AudioToText;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 
@@ -131,7 +131,7 @@ public class CrispAsrSenseVoice : CrispAsrEngineBase
 
     internal static string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "crispasr.exe";
         }

--- a/src/ui/Features/Video/SpeechToText/Engines/MlxWhisperMac.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/MlxWhisperMac.cs
@@ -78,7 +78,7 @@ public class MlxWhisperMac : ISpeechToTextEngine
 
     public bool IsEngineInstalled()
     {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (!OperatingSystem.IsMacOS())
         {
             return false;
         }

--- a/src/ui/Features/Video/SpeechToText/Engines/MlxWhisperMac.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/MlxWhisperMac.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Avalonia.Platform;
 using Nikse.SubtitleEdit.Core.AudioToText;

--- a/src/ui/Features/Video/SpeechToText/Engines/ParakeetCppEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/ParakeetCppEngine.cs
@@ -4,7 +4,6 @@ using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
@@ -152,7 +151,7 @@ public class ParakeetCppEngine : ISpeechToTextEngine
     }
 
     public string GetExecutableFileName() =>
-        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "parakeet.exe" : "parakeet";
+        OperatingSystem.IsWindows() ? "parakeet.exe" : "parakeet";
 
     public bool CanBeDownloaded() => true;
 

--- a/src/ui/Features/Video/SpeechToText/Engines/Qwen3AsrCppEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/Qwen3AsrCppEngine.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Avalonia.Platform;
 using Nikse.SubtitleEdit.Core.AudioToText;
@@ -202,7 +201,7 @@ public class Qwen3AsrCppEngine : ISpeechToTextEngine
 
     public string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "qwen3-asr-cli.exe";
         }

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperCppEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperCppEngine.cs
@@ -2,7 +2,6 @@ using Nikse.SubtitleEdit.Core.AudioToText;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
@@ -22,7 +21,7 @@ public class WhisperCppEngine : ISpeechToTextEngine
             new WhisperEngineCpp(),
         };
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             _backends.Add(new WhisperEngineCppCuBlas());
             _backends.Add(new WhisperEngineCppVulkan());

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCTranslate2.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCTranslate2.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Avalonia.Platform;
 using Nikse.SubtitleEdit.Core.AudioToText;
@@ -68,7 +67,7 @@ public class WhisperEngineCTranslate2 : ISpeechToTextEngine
     {
         string fullPath = Path.Combine(GetAndCreateWhisperFolder(), GetExecutableFileName());
 
-        if (!File.Exists(fullPath) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (!File.Exists(fullPath) && OperatingSystem.IsLinux())
         {
             string[] paths = ["/usr/bin/whisper-cli", "usr/local/bin/"];
             foreach (var path in paths)
@@ -131,7 +130,7 @@ public class WhisperEngineCTranslate2 : ISpeechToTextEngine
 
     internal static string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "whisper-ctranslate2.exe";
         }
@@ -148,15 +147,15 @@ public class WhisperEngineCTranslate2 : ISpeechToTextEngine
     {
         get
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (OperatingSystem.IsWindows())
             {
                 return "~103 MB";
             }
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (OperatingSystem.IsLinux())
             {
                 return "~149 MB";
             }
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            if (OperatingSystem.IsMacOS())
             {
                 return "~76 MB";
             }

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCpp.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCpp.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Avalonia.Platform;
 using Nikse.SubtitleEdit.Core.AudioToText;
@@ -81,7 +80,7 @@ public class WhisperEngineCpp : ISpeechToTextEngine
     {
         var fullPath = Path.Combine(GetAndCreateWhisperFolder(), GetExecutableFileName());
 
-        if (!File.Exists(fullPath) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (!File.Exists(fullPath) && OperatingSystem.IsLinux())
         {
             string[] paths = ["/usr/bin/whisper-cli", "usr/local/bin/"];
             foreach (var path in paths)
@@ -179,7 +178,7 @@ public class WhisperEngineCpp : ISpeechToTextEngine
 
     private static string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "whisper-cli.exe";
         }
@@ -197,15 +196,15 @@ public class WhisperEngineCpp : ISpeechToTextEngine
         get
         {
             // matches WhisperDownloadService.GetUrl() — the BLAS Windows build, Vulkan Linux build, or universal Mac build.
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (OperatingSystem.IsWindows())
             {
                 return "~14 MB";
             }
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (OperatingSystem.IsLinux())
             {
                 return "~18 MB";
             }
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            if (OperatingSystem.IsMacOS())
             {
                 return "~3 MB";
             }

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCppCuBlas.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCppCuBlas.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Avalonia.Platform;
 using Nikse.SubtitleEdit.Core.AudioToText;
@@ -86,7 +85,7 @@ public class WhisperEngineCppCuBlas : ISpeechToTextEngine
     {
         string fullPath = Path.Combine(GetAndCreateWhisperFolder(), GetExecutableFileName());
 
-        if (!File.Exists(fullPath) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (!File.Exists(fullPath) && OperatingSystem.IsLinux())
         {
             string[] paths = ["/usr/bin/whisper-cli", "usr/local/bin/"];
             foreach (var path in paths)
@@ -156,7 +155,7 @@ public class WhisperEngineCppCuBlas : ISpeechToTextEngine
 
     private static string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "whisper-cli.exe";
         }
@@ -175,11 +174,11 @@ public class WhisperEngineCppCuBlas : ISpeechToTextEngine
         {
             // Windows: cuBLAS 12.4 binary bundle (CUDA libs included).
             // Linux: thin Vulkan-CUDA bundle since the CUDA toolkit is system-installed.
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (OperatingSystem.IsWindows())
             {
                 return "~436 MB";
             }
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (OperatingSystem.IsLinux())
             {
                 return "~37 MB";
             }

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCppVulkan.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCppVulkan.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Avalonia.Platform;
 using Nikse.SubtitleEdit.Core.AudioToText;
@@ -90,7 +89,7 @@ public class WhisperEngineCppVulkan : ISpeechToTextEngine
     {
         string fullPath = Path.Combine(GetAndCreateWhisperFolder(), GetExecutableFileName());
 
-        if (!File.Exists(fullPath) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (!File.Exists(fullPath) && OperatingSystem.IsLinux())
         {
             string[] paths = ["/usr/bin/whisper-cli", "usr/local/bin/"];
             foreach (var path in paths)
@@ -160,7 +159,7 @@ public class WhisperEngineCppVulkan : ISpeechToTextEngine
 
     private static string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "whisper-cli.exe";
         }
@@ -173,7 +172,7 @@ public class WhisperEngineCppVulkan : ISpeechToTextEngine
         return true;
     }
 
-    public string DownloadSizeText => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+    public string DownloadSizeText => OperatingSystem.IsWindows()
         ? "~16 MB"
         : string.Empty;
 

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEnginePurfviewFasterWhisperXxl.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEnginePurfviewFasterWhisperXxl.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Avalonia.Platform;
 using Nikse.SubtitleEdit.Core.AudioToText;
@@ -223,7 +222,7 @@ public class WhisperEnginePurfviewFasterWhisperXxl : ISpeechToTextEngine
 
     public string GetExecutableFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return "faster-whisper-xxl.exe";
         }
@@ -241,11 +240,11 @@ public class WhisperEnginePurfviewFasterWhisperXxl : ISpeechToTextEngine
         get
         {
             // Bundles full CUDA + Python runtime, so the archive is large.
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (OperatingSystem.IsWindows())
             {
                 return "~1.4 GB";
             }
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (OperatingSystem.IsLinux())
             {
                 return "~1.6 GB";
             }

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -201,12 +201,12 @@ public partial class SpeechToTextViewModel : ObservableObject
         _fileHelper = fileHelper;
 
         Engines = [new WhisperCppEngine()];
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             Engines.Add(new WhisperEnginePurfviewFasterWhisperXxl());
             Engines.Add(new WhisperEngineConstMe());
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
+        else if (OperatingSystem.IsLinux() &&
                  RuntimeInformation.ProcessArchitecture == Architecture.X64)
         {
             // Purfview only ships Windows and Linux x86_64 builds - there is no Linux ARM64
@@ -214,16 +214,16 @@ public partial class SpeechToTextViewModel : ObservableObject
             Engines.Add(new WhisperEnginePurfviewFasterWhisperXxl());
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-            (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && RuntimeInformation.ProcessArchitecture == Architecture.Arm64) ||
-            (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && RuntimeInformation.ProcessArchitecture == Architecture.X64))
+        if (OperatingSystem.IsWindows() ||
+            (OperatingSystem.IsMacOS() && RuntimeInformation.ProcessArchitecture == Architecture.Arm64) ||
+            (OperatingSystem.IsLinux() && RuntimeInformation.ProcessArchitecture == Architecture.X64))
         {
             Engines.Add(new WhisperEngineCTranslate2());
         }
 
         // MLX Whisper runs Whisper on the Apple GPU / Neural Engine and is arm64-only, so offer it
         // only on Apple Silicon.
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
+        if (OperatingSystem.IsMacOS() &&
             RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
         {
             Engines.Add(new MlxWhisperMac());
@@ -239,9 +239,9 @@ public partial class SpeechToTextViewModel : ObservableObject
         Engines.Add(new OpenRouterSttEngine());
         Engines.Add(new DashScopeQwen3SttEngine());
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-            RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
-            RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsWindows() ||
+            OperatingSystem.IsLinux() ||
+            OperatingSystem.IsMacOS())
         {
             //Engines.Add(new ChatLlmCppEngine());
             Engines.Add(new Qwen3AsrCppEngine());
@@ -2414,7 +2414,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             }
         }
         else if (engine is ICrispAsrEngine
-                 && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                 && OperatingSystem.IsLinux()
                  && RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
         {
             var linuxAnswer = await PromptCrispAsrLinuxVariantAsync(CrispAsrEngine.StaticName);
@@ -2932,7 +2932,7 @@ public partial class SpeechToTextViewModel : ObservableObject
                     }
                 }
                 else if (engine is ICrispAsrEngine
-                         && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                         && OperatingSystem.IsLinux()
                          && RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
                 {
                     var crispVariant = await PromptCrispAsrLinuxVariantAsync(engine.Name);
@@ -3844,7 +3844,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             process.StartInfo.EnvironmentVariables["GGML_VULKAN_DEVICE"] = cppVulkanDevice;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             if (!string.IsNullOrEmpty(Se.Settings.General.FfmpegPath) &&
                 process.StartInfo.EnvironmentVariables["Path"] != null)
@@ -3869,7 +3869,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             }
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             if (!string.IsNullOrEmpty(whisperFolder) && process.StartInfo.EnvironmentVariables["Path"] != null)
             {
@@ -4487,7 +4487,7 @@ public partial class SpeechToTextViewModel : ObservableObject
         }
 
         var crispVariant = DownloadHashManager.GetCrispAsrVariant(key)
-                           ?? (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "vulkan" : string.Empty);
+                           ?? (OperatingSystem.IsWindows() ? "vulkan" : string.Empty);
 
         await _windowService.ShowDialogAsync<DownloadSpeechToTextEngineWindow, DownloadSpeechToTextEngineViewModel>(
             Window!, viewModel =>
@@ -4667,11 +4667,11 @@ public partial class SpeechToTextViewModel : ObservableObject
         try
         {
             string? variant = null;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (OperatingSystem.IsWindows())
             {
                 variant = DownloadHashManager.DetectCrispAsrWindowsVariant(folder);
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+            else if (OperatingSystem.IsLinux()
                      && RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
             {
                 variant = DownloadHashManager.DetectCrispAsrLinuxVariant(folder);

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -201,7 +201,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 }
 
                 var path = Piper.GetPiperExecutableFileName();
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                if (OperatingSystem.IsLinux())
                 {
                     if (File.Exists(path))
                     {
@@ -209,7 +209,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                         FixSymbolicLink(path);
                     }
                 }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                else if (OperatingSystem.IsMacOS())
                 {
                     if (File.Exists(path))
                     {
@@ -324,14 +324,14 @@ public partial class DownloadTtsViewModel : ObservableObject
                 }
 
                 var exePath = Qwen3TtsCpp.GetExecutableFileName();
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                if (OperatingSystem.IsLinux())
                 {
                     if (File.Exists(exePath))
                     {
                         LinuxHelper.MakeExecutable(exePath);
                     }
                 }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                else if (OperatingSystem.IsMacOS())
                 {
                     if (File.Exists(exePath))
                     {
@@ -476,14 +476,14 @@ public partial class DownloadTtsViewModel : ObservableObject
                 }
 
                 var exePath = KokoroTtsCpp.GetExecutableFileName();
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                if (OperatingSystem.IsLinux())
                 {
                     if (File.Exists(exePath))
                     {
                         LinuxHelper.MakeExecutable(exePath);
                     }
                 }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                else if (OperatingSystem.IsMacOS())
                 {
                     if (File.Exists(exePath))
                     {
@@ -1216,7 +1216,7 @@ public partial class DownloadTtsViewModel : ObservableObject
 
                 var exePath = OmniVoiceTtsCpp.GetExecutableFileName();
                 var codecExePath = OmniVoiceTtsCpp.GetCodecExecutableFileName();
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                if (OperatingSystem.IsLinux())
                 {
                     if (File.Exists(exePath))
                     {
@@ -1227,7 +1227,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                         LinuxHelper.MakeExecutable(codecExePath);
                     }
                 }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                else if (OperatingSystem.IsMacOS())
                 {
                     if (File.Exists(exePath))
                     {

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -11,7 +11,6 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -128,7 +127,7 @@ public class ChatterboxTtsCpp : ITtsEngine
         }
 
         var folder = Path.GetDirectoryName(exe);
-        var variant = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && folder != null
+        var variant = OperatingSystem.IsWindows() && folder != null
             ? DownloadHashManager.DetectCrispAsrWindowsVariant(folder)
             : null;
         var key = DownloadHashManager.ResolveCrispAsrExecutableKey(variant);

--- a/src/ui/Logic/ClipboardHelper.cs
+++ b/src/ui/Logic/ClipboardHelper.cs
@@ -151,15 +151,15 @@ public static class ClipboardHelper
 
     public static async Task CopyImageToClipboard(Bitmap bitmap)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             await CopyImageToClipboardWindows(bitmap);
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        else if (OperatingSystem.IsLinux())
         {
             await CopyImageToClipboardLinux(bitmap);
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        else if (OperatingSystem.IsMacOS())
         {
             await CopyImageToClipboardMacOS(bitmap);
         }

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 
@@ -137,7 +136,7 @@ public class Se
 
     private static string ResolveTesseractFolder()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return Path.Combine(DataFolder, "Tesseract550");
         }

--- a/src/ui/Logic/Download/ChatLlmDownloadService.cs
+++ b/src/ui/Logic/Download/ChatLlmDownloadService.cs
@@ -49,12 +49,12 @@ public class ChatLlmDownloadService : IChatLlmDownloadService
 
     private static string GetUrl()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return WindowsUrl;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
             {
@@ -64,7 +64,7 @@ public class ChatLlmDownloadService : IChatLlmDownloadService
             return LinuxUrl;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             switch (RuntimeInformation.ProcessArchitecture)
             {

--- a/src/ui/Logic/Download/CrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/CrispAsrDownloadService.cs
@@ -67,17 +67,17 @@ public class CrispAsrDownloadService : ICrispAsrDownloadService
 
     private static string GetUrl()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return WindowsVulkanUrl;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? LinuxArmUrl : LinuxUrl;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return MacUrl; 
         }

--- a/src/ui/Logic/Download/CrispEmbedDownloadService.cs
+++ b/src/ui/Logic/Download/CrispEmbedDownloadService.cs
@@ -66,17 +66,17 @@ public class CrispEmbedDownloadService : ICrispEmbedDownloadService
 
     private static string GetUrl()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return WindowsVulkanUrl;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? LinuxArmUrl : LinuxUrl;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return MacUrl;
         }

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -1548,7 +1548,7 @@ public static class DownloadHashManager
     /// </summary>
     public static string? ResolveCrispAsrKey(string? variant)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
             {
@@ -1561,12 +1561,12 @@ public static class DownloadHashManager
             return CrispAsr.Linux;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return CrispAsr.MacOs;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return variant switch
             {
@@ -1608,12 +1608,12 @@ public static class DownloadHashManager
     /// </summary>
     public static string? ResolveQwen3AsrCppKey(bool useVulkan)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return useVulkan ? Qwen3AsrCpp.WindowsVulkan : Qwen3AsrCpp.Windows;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
             {
@@ -1623,7 +1623,7 @@ public static class DownloadHashManager
             return useVulkan ? Qwen3AsrCpp.LinuxVulkan : Qwen3AsrCpp.Linux;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? Qwen3AsrCpp.MacArm64 : Qwen3AsrCpp.MacX64;
         }
@@ -1686,7 +1686,7 @@ public static class DownloadHashManager
     /// </summary>
     public static string? ResolveCrispEmbedKey(string? variant)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
             {
@@ -1699,12 +1699,12 @@ public static class DownloadHashManager
             return CrispEmbed.Linux;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return CrispEmbed.MacOs;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return variant switch
             {
@@ -1760,7 +1760,7 @@ public static class DownloadHashManager
     /// </summary>
     public static string? ResolveCrispAsrExecutableKey(string? variant)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
             {
@@ -1773,12 +1773,12 @@ public static class DownloadHashManager
             return CrispAsr.LinuxExecutable;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return CrispAsr.MacOsExecutable;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return variant switch
             {
@@ -1924,7 +1924,7 @@ public static class DownloadHashManager
             return null;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return whisperChoice switch
             {
@@ -1935,12 +1935,12 @@ public static class DownloadHashManager
             };
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return whisperChoice == WhisperChoice.Cpp ? WhisperCpp.MacOs : null;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             return whisperChoice switch
             {
@@ -1966,7 +1966,7 @@ public static class DownloadHashManager
             return null;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return whisperChoice switch
             {
@@ -1977,7 +1977,7 @@ public static class DownloadHashManager
             };
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return whisperChoice == WhisperChoice.Cpp ? WhisperCpp.MacOsExecutable : null;
         }
@@ -1991,7 +1991,7 @@ public static class DownloadHashManager
     /// </summary>
     public static string? ResolveLlamaCppKey(string? variant)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return variant switch
             {
@@ -2002,7 +2002,7 @@ public static class DownloadHashManager
             };
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
             {
@@ -2012,7 +2012,7 @@ public static class DownloadHashManager
             return variant == "vulkan" ? LlamaCpp.LinuxVulkan : LlamaCpp.LinuxCpu;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
                 ? LlamaCpp.MacOsArm64
@@ -2045,19 +2045,19 @@ public static class DownloadHashManager
     /// </summary>
     public static string? ResolveLlamaCppExecutableKey()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return LlamaCpp.WindowsExecutable;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
                 ? LlamaCpp.LinuxArm64Executable
                 : LlamaCpp.LinuxExecutable;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
                 ? LlamaCpp.MacOsArm64Executable
@@ -2074,7 +2074,7 @@ public static class DownloadHashManager
     /// </summary>
     public static string? ResolveOmniVoiceKey(string? windowsVariant)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return windowsVariant switch
             {
@@ -2085,12 +2085,12 @@ public static class DownloadHashManager
             };
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return OmniVoice.MacOs;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
                 ? OmniVoice.LinuxArm64
@@ -2106,7 +2106,7 @@ public static class DownloadHashManager
     /// </summary>
     public static string? ResolveQwen3TtsCppKey(string? windowsVariant)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return windowsVariant switch
             {
@@ -2117,12 +2117,12 @@ public static class DownloadHashManager
             };
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return Qwen3TtsCpp.MacOs;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
                 ? Qwen3TtsCpp.LinuxArm64
@@ -2138,17 +2138,17 @@ public static class DownloadHashManager
     /// </summary>
     public static string? ResolveKokoroTtsCppKey()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return KokoroTtsCpp.Windows;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return KokoroTtsCpp.MacOs;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
                 ? KokoroTtsCpp.LinuxArm64
@@ -2164,17 +2164,17 @@ public static class DownloadHashManager
     /// </summary>
     public static string? ResolvePiperKey()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return Piper.Windows;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return Piper.MacOs;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
                 ? Piper.LinuxArm64

--- a/src/ui/Logic/Download/FfmpegDownloadService.cs
+++ b/src/ui/Logic/Download/FfmpegDownloadService.cs
@@ -27,12 +27,12 @@ public class FfmpegDownloadService : IFfmpegDownloadService
 
     private static string GetFfmpegUrl()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return WindowsUrl;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             switch (RuntimeInformation.ProcessArchitecture)
             {

--- a/src/ui/Logic/Download/KokoroTtsCppDownloadService.cs
+++ b/src/ui/Logic/Download/KokoroTtsCppDownloadService.cs
@@ -95,17 +95,17 @@ public class KokoroTtsCppDownloadService : IKokoroTtsCppDownloadService
 
     private static string GetUrl()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return WindowsUrl;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? LinuxArmUrl : LinuxUrl;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return MacUrl;
         }

--- a/src/ui/Logic/Download/LibMpvDownloadService .cs
+++ b/src/ui/Logic/Download/LibMpvDownloadService .cs
@@ -28,7 +28,7 @@ public class LibMpvDownloadService : ILibMpvDownloadService
 
     private static string GetUrl()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return WindowsUrl;
         }
@@ -36,7 +36,7 @@ public class LibMpvDownloadService : ILibMpvDownloadService
         throw new PlatformNotSupportedException("Unsupported platform for libmpv download." + Environment.NewLine +
             RuntimeInformation.OSDescription);
 
-        //if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        //if (OperatingSystem.IsMacOS())
         //{
         //    switch (RuntimeInformation.ProcessArchitecture)
         //    {

--- a/src/ui/Logic/Download/OmniVoiceDownloadService.cs
+++ b/src/ui/Logic/Download/OmniVoiceDownloadService.cs
@@ -114,7 +114,7 @@ public class OmniVoiceDownloadService : IOmniVoiceDownloadService
 
     private static string GetUrl(string windowsVariant)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return windowsVariant switch
             {
@@ -124,12 +124,12 @@ public class OmniVoiceDownloadService : IOmniVoiceDownloadService
             };
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return MacOsUrl;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
                 ? LinuxArm64Url

--- a/src/ui/Logic/Download/PaddleOcrDownloadService.cs
+++ b/src/ui/Logic/Download/PaddleOcrDownloadService.cs
@@ -37,7 +37,7 @@ public class PaddleOcrDownloadService : IPaddleOcrDownloadService
     {
         var url = DownloadWindowsEngineCpuUrl;
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
             {
@@ -54,7 +54,7 @@ public class PaddleOcrDownloadService : IPaddleOcrDownloadService
     {
         var url = DownloadWindowsEngineGpuUrl;
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
             {

--- a/src/ui/Logic/Download/Qwen3AsrCppDownloadService.cs
+++ b/src/ui/Logic/Download/Qwen3AsrCppDownloadService.cs
@@ -48,7 +48,7 @@ public class Qwen3AsrCppDownloadService : IQwen3AsrCppDownloadService
             return false;
         }
 
-        return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+        return OperatingSystem.IsWindows() || OperatingSystem.IsLinux();
     }
 
     public async Task DownloadEngine(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken, bool useVulkan = false)
@@ -58,12 +58,12 @@ public class Qwen3AsrCppDownloadService : IQwen3AsrCppDownloadService
 
     private static string GetUrl(bool useVulkan)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return useVulkan ? WindowsVulkanUrl : WindowsUrl;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
             {
@@ -73,7 +73,7 @@ public class Qwen3AsrCppDownloadService : IQwen3AsrCppDownloadService
             return useVulkan ? LinuxVulkanUrl : LinuxUrl;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? MacArmUrl : MacX64Url;
         }

--- a/src/ui/Logic/Download/Qwen3TtsCppDownloadService.cs
+++ b/src/ui/Logic/Download/Qwen3TtsCppDownloadService.cs
@@ -127,7 +127,7 @@ public class Qwen3TtsCppDownloadService : IQwen3TtsCppDownloadService
 
     private static string GetUrl(string windowsVariant)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return windowsVariant switch
             {
@@ -137,12 +137,12 @@ public class Qwen3TtsCppDownloadService : IQwen3TtsCppDownloadService
             };
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? LinuxArmUrl : LinuxUrl;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return MacUrl;
         }

--- a/src/ui/Logic/Download/TesseractDownloadService.cs
+++ b/src/ui/Logic/Download/TesseractDownloadService.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Net.Http;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Nikse.SubtitleEdit.Logic.Compression;
@@ -29,12 +28,12 @@ public class TesseractDownloadService : ITesseractDownloadService
 
     private static string GetTesseractUrl()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return WindowsUrl;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return MacUrl;
         }

--- a/src/ui/Logic/Download/WhisperDownloadService.cs
+++ b/src/ui/Logic/Download/WhisperDownloadService.cs
@@ -74,7 +74,7 @@ public class WhisperDownloadService : IWhisperDownloadService
     {
         var url = DownloadUrlPurfviewFasterWhisperXxl;
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
             {
@@ -84,7 +84,7 @@ public class WhisperDownloadService : IWhisperDownloadService
             url = DownloadUrlPurfviewFasterWhisperXxlLinux;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             throw new PlatformNotSupportedException("MacOS not supported.");
         }
@@ -109,17 +109,17 @@ public class WhisperDownloadService : IWhisperDownloadService
 
     private static string GetUrlTranslate2()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return WindowCTranslate2;
         }
         
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+        if (OperatingSystem.IsMacOS() && RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
         {
             return MacArmCTranslate2;
         }
         
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && RuntimeInformation.ProcessArchitecture == Architecture.X64)
+        if (OperatingSystem.IsLinux() && RuntimeInformation.ProcessArchitecture == Architecture.X64)
         {
             return LinuxCTranslate2;
         }
@@ -129,7 +129,7 @@ public class WhisperDownloadService : IWhisperDownloadService
 
     private static string GetUrlCppVulkan()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return WindowsUrlCppVulkan;
         }
@@ -139,12 +139,12 @@ public class WhisperDownloadService : IWhisperDownloadService
     
     private static string GetUrl()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return WindowsUrl;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
             {
@@ -154,7 +154,7 @@ public class WhisperDownloadService : IWhisperDownloadService
             return LinuxUrl;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             switch (RuntimeInformation.ProcessArchitecture)
             {
@@ -172,12 +172,12 @@ public class WhisperDownloadService : IWhisperDownloadService
 
     private static string GetUrlCuBlas()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return WindowsUrlCuBlass;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
             {

--- a/src/ui/Logic/Download/YtDlpDownloadService.cs
+++ b/src/ui/Logic/Download/YtDlpDownloadService.cs
@@ -93,19 +93,19 @@ public class YtDlpDownloadService : IYtDlpDownloadService
 
     public static string GetFullFileName()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return Path.Combine(Se.DataFolder, "yt-dlp.exe");
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
                 ? Path.Combine(Se.DataFolder, "yt-dlp_linux_aarch64")
                 : Path.Combine(Se.DataFolder, "yt-dlp_linux");
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return Path.Combine(Se.DataFolder, "yt-dlp_macos");
         }
@@ -114,17 +114,17 @@ public class YtDlpDownloadService : IYtDlpDownloadService
     }
     private static string GetUrl()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return WindowsUrl;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? LinuxArmUrl : LinuxUrl;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return MacUrl;
         }

--- a/src/ui/Logic/LinuxHelper.cs
+++ b/src/ui/Logic/LinuxHelper.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Logic;
 
@@ -19,7 +18,7 @@ public static class LinuxHelper
         try
         {
             // Verify we are actually on a Unix-like system
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (!OperatingSystem.IsWindows())
             {
                 // Get current permissions
                 var currentMode = File.GetUnixFileMode(filePath);

--- a/src/ui/Logic/Media/FfmpegHelper.cs
+++ b/src/ui/Logic/Media/FfmpegHelper.cs
@@ -3,7 +3,6 @@ using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 
 namespace Nikse.SubtitleEdit.Logic.Media;
@@ -21,7 +20,7 @@ public static class FfmpegHelper
 
     public static bool IsFfmpegInstalled()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             return true;
         }
@@ -64,7 +63,7 @@ public static class FfmpegHelper
     /// </summary>
     public static string GetSystemFfmpegPath()
     {
-        var exeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "ffmpeg.exe" : "ffmpeg";
+        var exeName = OperatingSystem.IsWindows() ? "ffmpeg.exe" : "ffmpeg";
         var pathValue = Environment.GetEnvironmentVariable("PATH");
         if (string.IsNullOrEmpty(pathValue))
         {

--- a/src/ui/Logic/Media/FileHelper.cs
+++ b/src/ui/Logic/Media/FileHelper.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Logic.Media
@@ -648,7 +647,7 @@ namespace Nikse.SubtitleEdit.Logic.Media
 
             try
             {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                if (OperatingSystem.IsWindows())
                 {
                     // Windows: use explorer with the file path
                     Process.Start(new ProcessStartInfo
@@ -657,7 +656,7 @@ namespace Nikse.SubtitleEdit.Logic.Media
                         UseShellExecute = true
                     });
                 }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                else if (OperatingSystem.IsMacOS())
                 {
                     // macOS: use 'open' command
                     Process.Start(new ProcessStartInfo
@@ -667,7 +666,7 @@ namespace Nikse.SubtitleEdit.Logic.Media
                         UseShellExecute = false
                     });
                 }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                else if (OperatingSystem.IsLinux())
                 {
                     // Linux: use 'xdg-open' command
                     Process.Start(new ProcessStartInfo

--- a/src/ui/Logic/Media/IFolderHelper.cs
+++ b/src/ui/Logic/Media/IFolderHelper.cs
@@ -1,8 +1,8 @@
 ﻿using System.Diagnostics;
 using Avalonia.Controls;
 using Avalonia.Platform.Storage;
+using System;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Logic.Media;
@@ -37,7 +37,7 @@ public class FolderHelper : IFolderHelper
 
     public async Task OpenFolder(Window window, string folder)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             var startInfo = new ProcessStartInfo
             {
@@ -51,7 +51,7 @@ public class FolderHelper : IFolderHelper
             return;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             var startInfo = new ProcessStartInfo
             {
@@ -71,7 +71,7 @@ public class FolderHelper : IFolderHelper
     
     public async Task OpenFolderWithFileSelected(Window window, string selectedFile)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             var startInfo = new ProcessStartInfo
             {
@@ -85,7 +85,7 @@ public class FolderHelper : IFolderHelper
             return;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             var startInfo = new ProcessStartInfo
             {

--- a/src/ui/Logic/Platform/Windows/SystemMenu.cs
+++ b/src/ui/Logic/Platform/Windows/SystemMenu.cs
@@ -35,7 +35,7 @@ public static class SystemMenu
 
     public static void Show(Window window)
     {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows())
         {
             return;
         }

--- a/src/ui/Logic/Platform/Windows/WindowsDarkMode.cs
+++ b/src/ui/Logic/Platform/Windows/WindowsDarkMode.cs
@@ -20,7 +20,7 @@ public static class WindowsDarkMode
 
     public static void Apply(IntPtr hwnd, bool dark)
     {
-        if (hwnd == IntPtr.Zero || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (hwnd == IntPtr.Zero || !OperatingSystem.IsWindows())
         {
             return;
         }

--- a/src/ui/Logic/Plugins/PluginCatalog.cs
+++ b/src/ui/Logic/Plugins/PluginCatalog.cs
@@ -2,7 +2,6 @@ using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Text.Json;
 
 namespace Nikse.SubtitleEdit.Logic.Plugins;
@@ -86,12 +85,12 @@ public class PluginCatalog : IPluginCatalog
             return null;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return executables.Windows;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return executables.Macos;
         }

--- a/src/ui/Logic/Plugins/PluginPlatform.cs
+++ b/src/ui/Logic/Plugins/PluginPlatform.cs
@@ -16,15 +16,15 @@ public static class PluginPlatform
     public static string? GetCurrentKey()
     {
         string os;
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             os = "win";
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        else if (OperatingSystem.IsMacOS())
         {
             os = "osx";
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        else if (OperatingSystem.IsLinux())
         {
             os = "linux";
         }

--- a/src/ui/Logic/Plugins/PluginRunner.cs
+++ b/src/ui/Logic/Plugins/PluginRunner.cs
@@ -2,7 +2,6 @@ using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -122,7 +121,7 @@ public class PluginRunner : IPluginRunner
     // arrives without its +x bit. Set it here before launching.
     private static void EnsureExecutable(string path)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return;
         }

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -2,9 +2,9 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Options.Shortcuts;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Logic;
 
@@ -955,7 +955,7 @@ public static class ShortcutsMain
 
     private static string GetCommandOrWin()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
         {
             return "Win";
         }

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -26,7 +26,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Logic;
 
@@ -3022,7 +3021,7 @@ public static class UiUtil
 
     internal static bool TryHandleWindowSystemMenu(KeyEventArgs e, Window? window)
     {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || window == null)
+        if (!OperatingSystem.IsWindows() || window == null)
         {
             return false;
         }
@@ -3046,7 +3045,7 @@ public static class UiUtil
     /// </summary>
     internal static void RegisterWindowsSystemMenuClassHandler()
     {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || _windowsSystemMenuClassHandlerRegistered)
+        if (!OperatingSystem.IsWindows() || _windowsSystemMenuClassHandlerRegistered)
         {
             return;
         }

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicNativeControl.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicNativeControl.cs
@@ -36,12 +36,12 @@ public class LibMpvDynamicNativeControl : NativeControlHost
     private IntPtr _originalWndProc = IntPtr.Zero;
 
     // Linux still needs the temporary hide/show workaround during live resize.
-    private static bool ShouldHideNativeControlDuringResize => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+    private static bool ShouldHideNativeControlDuringResize => OperatingSystem.IsLinux();
 
     // On Windows, use a dedicated child HWND for the embedded renderer instead of
     // the parent host handle. Reusing the parent handle makes native video jump to
     // the top-left corner during live resize.
-    private static bool ShouldUseOwnedChildHandle => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+    private static bool ShouldUseOwnedChildHandle => OperatingSystem.IsWindows();
 
     public LibMpvDynamicPlayer? Player => _mpvPlayer;
 
@@ -227,7 +227,7 @@ public class LibMpvDynamicNativeControl : NativeControlHost
             System.Diagnostics.Debug.WriteLine($"Failed to set wid: {_mpvPlayer.GetErrorString(err)}");
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             _mpvPlayer.SetOptionString("vo", "xv,x11,gpu");
         }
@@ -240,7 +240,7 @@ public class LibMpvDynamicNativeControl : NativeControlHost
         _mpvPlayer.SetOptionString("keep-open", "always");
         _mpvPlayer.SetOptionString("background-color", "#000000");
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (OperatingSystem.IsLinux())
         {
             _mpvPlayer.SetOptionString("idle", "yes");
             _mpvPlayer.SetOptionString("force-window", "yes");
@@ -261,15 +261,15 @@ public class LibMpvDynamicNativeControl : NativeControlHost
 
     private static string GetWindowIdString(IntPtr handle)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return handle.ToString();
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        else if (OperatingSystem.IsLinux())
         {
             return handle.ToString();
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        else if (OperatingSystem.IsMacOS())
         {
             return handle.ToString();
         }
@@ -398,7 +398,7 @@ public class LibMpvDynamicNativeControl : NativeControlHost
     protected override void OnPointerPressed(PointerPressedEventArgs e)
     {
         base.OnPointerPressed(e);
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+        if (!OperatingSystem.IsWindows() &&
             e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
         {
             TogglePlayPause();

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -203,15 +203,15 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
     private static string[] GetLibraryNames()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return ["libmpv-2.dll"];
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        else if (OperatingSystem.IsLinux())
         {
             return ["libmpv.so.2", "libmpv.so"];
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        else if (OperatingSystem.IsMacOS())
         {
             return ["libmpv.dylib", "libmpv.2.dylib"];
         }
@@ -223,7 +223,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
     private static string[] GetLibraryPaths()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return
             [
@@ -232,7 +232,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
                 string.Empty,
             ];
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        else if (OperatingSystem.IsLinux())
         {
             return
             [
@@ -252,7 +252,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
                 "/lib/arm-linux-gnueabihf",
             ];
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        else if (OperatingSystem.IsMacOS())
         {
             return
             [

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/NativeMethods.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/NativeMethods.cs
@@ -33,10 +33,10 @@ internal static class NativeMethods
 
     static NativeMethods()
     {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows())
         {
             // On macOS, system libraries are in libSystem.dylib
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            if (OperatingSystem.IsMacOS())
             {
                 var libSystemNames = new[] { "libSystem.dylib", "libSystem.B.dylib" };
                 foreach (var name in libSystemNames)
@@ -149,7 +149,7 @@ internal static class NativeMethods
     // POSIX function wrappers
     internal static IntPtr setlocale(int category, string locale)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             throw new PlatformNotSupportedException("setlocale is not supported on Windows");
         }
@@ -158,7 +158,7 @@ internal static class NativeMethods
 
     internal static IntPtr dlopen(string filename, int flags)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             throw new PlatformNotSupportedException("dlopen is not supported on Windows");
         }
@@ -167,7 +167,7 @@ internal static class NativeMethods
 
     internal static IntPtr dlclose(IntPtr handle)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             throw new PlatformNotSupportedException("dlclose is not supported on Windows");
         }
@@ -176,7 +176,7 @@ internal static class NativeMethods
 
     internal static IntPtr dlsym(IntPtr handle, string symbol)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             throw new PlatformNotSupportedException("dlsym is not supported on Windows");
         }
@@ -185,7 +185,7 @@ internal static class NativeMethods
 
     internal static string? dlerror()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             throw new PlatformNotSupportedException("dlerror is not supported on Windows");
         }
@@ -196,7 +196,7 @@ internal static class NativeMethods
     // Cross-platform wrappers
     internal static IntPtr CrossLoadLibrary(string fileName)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             // For VLC on Windows, we need to help LoadLibrary find dependencies
             var directory = Path.GetDirectoryName(fileName);
@@ -247,7 +247,7 @@ internal static class NativeMethods
 
             return handle;
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        else if (OperatingSystem.IsMacOS())
         {
             // On macOS, try using .NET's NativeLibrary.TryLoad first which handles @rpath and other macOS-specific features
             if (NativeLibrary.TryLoad(fileName, out var handle))
@@ -299,7 +299,7 @@ internal static class NativeMethods
 
     internal static void CrossFreeLibrary(IntPtr handle)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             FreeLibrary(handle);
         }
@@ -311,7 +311,7 @@ internal static class NativeMethods
 
     internal static IntPtr CrossGetProcAddress(IntPtr handle, string name)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return GetProcAddress(handle, name);
         }

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/PlatformCursorManager.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/PlatformCursorManager.cs
@@ -54,11 +54,11 @@ public static class PlatformCursorManager
     {
         try
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (OperatingSystem.IsWindows())
             {
                 ForceArrowCursorWindows();
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            else if (OperatingSystem.IsLinux())
             {
                 ForceArrowCursorLinux();
             }

--- a/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicNativeControl.cs
+++ b/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicNativeControl.cs
@@ -31,8 +31,8 @@ public class LibVlcDynamicNativeControl : NativeControlHost
     // Extended Window Styles
     private const uint WS_EX_TRANSPARENT = 0x00000020;
 
-    private static bool ShouldUseOwnedChildHandle => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-    private static bool ShouldUseOwnedX11Child => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+    private static bool ShouldUseOwnedChildHandle => OperatingSystem.IsWindows();
+    private static bool ShouldUseOwnedX11Child => OperatingSystem.IsLinux();
 
     public LibVlcDynamicPlayer? Player => _vlcPlayer;
 

--- a/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicPlayer.cs
@@ -241,15 +241,15 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayer
 
     private static string[] GetLibraryNames()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return ["libvlc.dll"];
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        else if (OperatingSystem.IsLinux())
         {
             return ["libvlc.so"];
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        else if (OperatingSystem.IsMacOS())
         {
             return ["libvlc.dylib"];
         }
@@ -261,7 +261,7 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayer
 
     private static string[] GetLibraryPaths()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             return
             [
@@ -272,7 +272,7 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayer
                 string.Empty,
             ];
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        else if (OperatingSystem.IsLinux())
         {
             return
             [
@@ -292,7 +292,7 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayer
                 "/snap/vlc/current/usr/lib",
             ];
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        else if (OperatingSystem.IsMacOS())
         {
             return
             [
@@ -1076,7 +1076,7 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayer
             return;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OperatingSystem.IsWindows())
         {
             _libvlc_media_player_set_hwnd?.Invoke(_mediaPlayer, _windowHandle);
             System.Diagnostics.Debug.WriteLine($"Set HWND: {_windowHandle}");

--- a/tests/UI/Features/Video/SpeechToText/Engines/WhisperCppEngineTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/Engines/WhisperCppEngineTests.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using Nikse.SubtitleEdit.Core.AudioToText;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -12,7 +11,7 @@ public class WhisperCppEngineTests
     {
         var engine = new WhisperCppEngine();
 
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows())
         {
             Assert.False(engine.TrySelectBackendChoice(WhisperChoice.CppCuBlas));
             Assert.IsType<WhisperEngineCpp>(engine.SelectedBackend);
@@ -39,7 +38,7 @@ public class WhisperCppEngineTests
             var engine = new WhisperCppEngine();
             var expectedBackend = engine.SelectedBackend;
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (OperatingSystem.IsWindows())
             {
                 Assert.True(engine.TrySelectBackendChoice(WhisperChoice.CppVulkan));
                 expectedBackend = engine.SelectedBackend;


### PR DESCRIPTION
## Summary
- Replace all `RuntimeInformation.IsOSPlatform(OSPlatform.Windows/Linux/OSX)` calls with `OperatingSystem.IsWindows()/IsLinux()/IsMacOS()` across `src/ui` and `tests/UI` (264 occurrences, 78 files)
- Remove `using System.Runtime.InteropServices;` where no longer needed
- `OperatingSystem.IsWindows()` and friends are the more modern API (introduced in .NET 5) compared to `RuntimeInformation.IsOSPlatform()`: the calls are recognized by the platform-compatibility analyzer (CA1416) as platform guards, are simpler to read with no string/struct comparison involved, and the JIT treats them as constants, so unreachable platform branches can be eliminated entirely
- `libse` is untouched, since its `netstandard2.1` target does not have the `OperatingSystem.Is*` API

## Test plan
- [x] `dotnet build SubtitleEdit.sln` succeeds with 0 warnings/errors
- [x] Run the app on Windows: video player (mpv/vlc) loads, download services (ffmpeg, Whisper, etc.) resolve the correct platform URLs
- [ ] Spot-check Linux/macOS-specific paths still compile (platform checks are runtime, so behavior is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)