### PR TITLE
Fix phantom empty line in Multiple Replace preview diff (Windows)

### DIFF
--- a/src/ui/Features/Files/Compare/TextDiffHighlighter.cs
+++ b/src/ui/Features/Files/Compare/TextDiffHighlighter.cs
@@ -2,6 +2,7 @@
 using Avalonia.Controls.Documents;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Collections.Generic;
@@ -61,8 +62,27 @@ public static class TextDiffHighlighter
         return new SolidColorBrush(Color.FromRgb(230, 255, 237));
     }
 
+    // Diff and render with line-feed line breaks only. Subtitle text can carry \r\n (libse joins
+    // lines with Environment.NewLine, so CRLF on Windows) while regex-replaced text comes back
+    // \n-normalized (RegexUtils.ReplaceNewLineSafe). Diffing the raw strings then isolates the \r
+    // as a one-character "difference" run - and while \r\n inside a single Run renders as one
+    // line break, a \r/\n pair split across two runs renders as two, showing a phantom empty
+    // line (plus a red mark for the invisible \r) in the Multiple Replace preview (#12622).
+    private static string NormalizeNewLines(string text)
+    {
+        if (string.IsNullOrEmpty(text) || (text.IndexOf('\r') < 0 && text.IndexOf('\u2028') < 0))
+        {
+            return text;
+        }
+
+        return string.Join("\n", text.SplitToLines());
+    }
+
     public static (TextBlock left, TextBlock right) Compare(string text1, string text2)
     {
+        text1 = NormalizeNewLines(text1);
+        text2 = NormalizeNewLines(text2);
+
         var left = new TextBlock { TextWrapping = TextWrapping.Wrap, VerticalAlignment = VerticalAlignment.Center };
         var right = new TextBlock { TextWrapping = TextWrapping.Wrap, VerticalAlignment = VerticalAlignment.Center };
 
@@ -120,6 +140,9 @@ public static class TextDiffHighlighter
 
     public static (TextBlock before, TextBlock after) CompareReplacement(string text1, string text2)
     {
+        text1 = NormalizeNewLines(text1);
+        text2 = NormalizeNewLines(text2);
+
         var before = new TextBlock { TextWrapping = TextWrapping.Wrap, VerticalAlignment = VerticalAlignment.Center };
         var after = new TextBlock { TextWrapping = TextWrapping.Wrap, VerticalAlignment = VerticalAlignment.Center };
 

--- a/tests/UI/Features/Files/Compare/TextDiffHighlighterTests.cs
+++ b/tests/UI/Features/Files/Compare/TextDiffHighlighterTests.cs
@@ -1,11 +1,53 @@
+using Avalonia.Controls.Documents;
 using Nikse.SubtitleEdit.Features.Files.Compare;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace UITests.Features.Files.Compare;
 
 public class TextDiffHighlighterTests
 {
+    private static string JoinRuns(InlineCollection? inlines)
+        => string.Concat(inlines!.Cast<Run>().Select(r => r.Text));
+
+    [Fact]
+    public void CompareReplacement_CrLfBeforeVsLfAfter_NormalizesInsteadOfDiffingTheCr()
+    {
+        // Windows subtitle text carries \r\n while a regex replacement comes back \n-normalized
+        // (RegexUtils.ReplaceNewLineSafe). Diffing the raw strings isolated the \r in its own
+        // one-character run, and a \r/\n pair split across two runs renders as two line breaks -
+        // a phantom empty line (plus a red mark for the invisible \r) in the Multiple Replace
+        // preview's Before column (#12622).
+        var (before, after) = TextDiffHighlighter.CompareReplacement(
+            "Just don't move out\r\nof my school district, okay?",
+            "Just don't move out\nof my school district, ok?");
+
+        var beforeText = JoinRuns(before.Inlines);
+        var afterText = JoinRuns(after.Inlines);
+
+        Assert.Equal("Just don't move out\nof my school district, okay?", beforeText);
+        Assert.Equal("Just don't move out\nof my school district, ok?", afterText);
+        Assert.All(before.Inlines!.Cast<Run>(), r => Assert.DoesNotContain('\r', r.Text!));
+    }
+
+    [Fact]
+    public void Compare_CrLfVsLf_TreatedAsIdenticalText()
+    {
+        // The compare view gets one text per file: a CRLF file against an LF file must not paint
+        // every line break as a difference (same normalization as CompareReplacement, #12622).
+        var (left, right) = TextDiffHighlighter.Compare("First line\r\nSecond line", "First line\nSecond line");
+
+        var leftRun = Assert.IsType<Run>(Assert.Single(left.Inlines!));
+        var rightRun = Assert.IsType<Run>(Assert.Single(right.Inlines!));
+
+        // The identical-texts path adds a single uncolored run per side.
+        Assert.Equal("First line\nSecond line", leftRun.Text);
+        Assert.Equal("First line\nSecond line", rightRun.Text);
+        Assert.Null(leftRun.Background);
+        Assert.Null(rightRun.Background);
+    }
+
     [Fact]
     public void FindCommonParts_WhenContentIsReordered_MiddleCommon2IsSortedByText2Positions()
     {


### PR DESCRIPTION
Fixes #12622 — the Multiple Replace preview showed an extra blank line (and a small red mark) between the two lines of a subtitle in the **Before** column, while **After** rendered normally. Only regex rules, only on Windows.

## Root cause

- On Windows, paragraph text carries `\r\n` (libse joins lines with `Environment.NewLine`), while a regex replacement comes back `\n`-normalized from `RegexUtils.ReplaceNewLineSafe` (#11956). The plain-text replace paths don't normalize — hence "regex rules only".
- `TextDiffHighlighter` diffed the raw strings char by char, so the orphan `\r` became its own one-character "removed" run (the small red mark in the reporter's screenshots).
- Avalonia renders `\r\n` inside a single `Run` as one line break, but a `\r`/`\n` pair split across two runs renders as two — the phantom empty line.
- On macOS/Linux `Environment.NewLine` is already `\n`, so both sides agree — which is why the bug could not be reproduced there.

## Fix

Normalize both inputs to line-feed breaks in `Compare`/`CompareReplacement` before diffing. Display-only — the replace/apply logic is untouched. Also covers the other consumers of this class (Compare, Fix Common Errors, Netflix fixes, AI review), where a CRLF-vs-LF pair would previously paint every line break as a difference.

## Testing

- Two new unit tests: the reporter's exact Before/After shape asserting no run contains `\r`, and CRLF-vs-LF texts rendering as identical in `Compare`.
- Build clean; all diff-highlighter/compare tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)