### PR TITLE
TTS: fix voice-clone transcript prompt storm and silent voice switch

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
@@ -223,10 +223,30 @@ public class MossTtsCrispAsr : ITtsEngine
         }
 
         SeedVoicesFromQwen3TtsCppIfEmpty(voicesFolder);
+        NormalizeVoiceTranscriptsOnce(voicesFolder);
         return voicesFolder;
     }
 
     private static bool _voiceSeedAttempted;
+    private static bool _voicesNormalized;
+
+    /// <summary>
+    /// One-time per session: drop attribution-blurb sidecars and backfill missing transcriptions
+    /// from the sibling OmniVoice pack (same generic reference WAVs, real transcripts). Without
+    /// this every seeded voice was transcript-less, so merely browsing the voice combo fired the
+    /// missing-transcript prompt once per voice ("prompts several times for transcript") and
+    /// synth ran without ref-text, degrading the clone.
+    /// </summary>
+    private static void NormalizeVoiceTranscriptsOnce(string voicesFolder)
+    {
+        if (_voicesNormalized)
+        {
+            return;
+        }
+        _voicesNormalized = true;
+
+        Qwen3TtsCrispAsr.NormalizeVoiceTranscripts(voicesFolder);
+    }
 
     /// <summary>
     /// One-time best-effort seed of WAV reference voices from qwen3-tts.cpp's voices folder so

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -560,6 +560,12 @@ public partial class TextToSpeechViewModel : ObservableObject
 
     private bool _isPromptingForRefText;
 
+    // Reference WAVs whose transcript prompt the user dismissed this session. Selection changes
+    // re-fire the prompt (engine switch, voice-list refresh, re-picking the same voice), so
+    // without this memory a declined prompt kept coming back - "prompts several times for
+    // transcript". Cancel now means "not for this voice, stop asking" until the window reopens.
+    private readonly HashSet<string> _refTextPromptDeclined = new(StringComparer.OrdinalIgnoreCase);
+
     private async Task EnsureClonedVoiceRefTextAsync(Voice? voice)
     {
         if (_isPromptingForRefText || Window == null || voice == null)
@@ -618,7 +624,7 @@ public partial class TextToSpeechViewModel : ObservableObject
             }
         }
 
-        if (string.IsNullOrEmpty(wavPath))
+        if (string.IsNullOrEmpty(wavPath) || _refTextPromptDeclined.Contains(wavPath))
         {
             return;
         }
@@ -650,6 +656,7 @@ public partial class TextToSpeechViewModel : ObservableObject
 
             if (!result.OkPressed || string.IsNullOrWhiteSpace(result.Text))
             {
+                _refTextPromptDeclined.Add(wavPath);
                 return;
             }
 
@@ -1565,12 +1572,21 @@ public partial class TextToSpeechViewModel : ObservableObject
             return;
         }
 
+        // Keep the user's current pick across the refresh: this runs right after the ref-text
+        // prompt and after the voice-settings dialog, and re-selecting by the *saved* settings
+        // voice - only written on Generate/Test voice/OK, so stale mid-session - silently
+        // switched the combo to another voice. The user then generated with a different voice
+        // than the one they had just picked and transcribed.
+        var currentVoiceName = SelectedVoice?.Name;
+
         Voices.Clear();
         foreach (var voice in voices)
         {
             Voices.Add(voice);
         }
-        SelectedVoice = Voices.FirstOrDefault(v => v.Name == Se.Settings.Video.TextToSpeech.Voice) ?? Voices.FirstOrDefault();
+        SelectedVoice = Voices.FirstOrDefault(v => v.Name == currentVoiceName)
+                        ?? Voices.FirstOrDefault(v => v.Name == Se.Settings.Video.TextToSpeech.Voice)
+                        ?? Voices.FirstOrDefault();
         VoiceCount = Voices.Count;
         VoiceCountInfo = string.Format(Se.Language.Video.TextToSpeech.XVoices, Voices.Count);
         IsVoiceCountVisible = Voices.Count > 0;

--- a/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
@@ -326,7 +326,11 @@ public partial class VoiceSettingsViewModel : ObservableObject
 
         try
         {
-            return File.ReadAllText(siblingTextFile);
+            // Voice-pack sidecars can be Wikimedia attribution blurbs, not spoken
+            // transcriptions - pre-filling the transcript prompt with one poisons the
+            // ref-text when the user just clicks OK. Treat a blurb as "no transcript".
+            var text = File.ReadAllText(siblingTextFile);
+            return Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(text) ? null : text;
         }
         catch
         {


### PR DESCRIPTION
Fixes the MOSS-TTS voice-cloning issues: the transcript prompt appearing repeatedly, and generation coming out in a different voice than the one picked. Four wiring fixes, most shared with the sibling clone engines (CosyVoice3, F5-TTS, VoxCPM2, Qwen3 clone):

## Fixes

1. **Silent voice switch (the "different voice" bug)** — `RefreshVoices` re-selected the combo by the *saved settings* voice name (only written on Generate/Test voice/OK, so stale mid-session), falling back to the first voice. It runs right after the ref-text prompt and after the voice-settings dialog, so it silently swapped the user's just-picked voice out of the combo; the next synth used a different voice. The refresh now preserves the current selection first, then saved name, then first.
2. **Transcript-less seeded voices (the prompt storm's root)** — MOSS seeded reference WAVs from the qwen3-tts.cpp pack but only filtered their attribution-blurb sidecars, never backfilling real transcripts from the OmniVoice pack like Qwen3 (CrispASR) does. Every seeded voice was transcript-less: each voice selection fired the missing-transcript prompt, and synthesis ran without ref-text — exactly the "generic/off voice" failure mode of these models. MOSS now runs the same `NormalizeVoiceTranscripts` pass once per session.
3. **Cancel not remembered** — a dismissed transcript prompt re-fired on every selection change onto the same WAV (engine switch, list refresh, re-pick). Declined prompts are now remembered for the window session.
4. **Blurb poisoning on import** — the import dialog pre-filled the transcript prompt with attribution blurbs from sibling `.txt` files; OK'ing one poisoned the ref-text. The prefill now filters blurbs like the Qwen3 import branch already did.

## Testing

- Build clean, 0 warnings; all 14 TextToSpeech UI tests pass.
- Server-side wiring verified by inspection: the (model, voice path, ref-text) restart key, `/v1/audio/speech` voice-stem resolution against `--voice-dir`, and the read-time blurb filter are all correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)