### PR TITLE
Speech to text: live progress for CrispASR transcriptions

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -3611,9 +3611,13 @@ public partial class SpeechToTextViewModel : ObservableObject
                 }
             }
 
+            // --print-progress: crispasr streams "crispasr: progress = NN% (i/n slices)" lines
+            // in real time (parsed in OutputHandler), while the transcript segments only print
+            // once the whole file is done - without this the progress bar sat idle for the
+            // entire run and jumped straight to 100%.
             var crispParams = string.IsNullOrWhiteSpace(crispArgs)
-                ? $"--backend {crispAsrEngine.BackendName} {langPart}-m \"{crispModel}\"{alignerPart}{vadPart} -f \"{waveFileName}\" --output-srt"
-                : $"--backend {crispAsrEngine.BackendName} {langPart}-m \"{crispModel}\"{alignerPart}{vadPart} -f \"{waveFileName}\" --output-srt {crispArgs}";
+                ? $"--backend {crispAsrEngine.BackendName} {langPart}-m \"{crispModel}\"{alignerPart}{vadPart} -f \"{waveFileName}\" --output-srt --print-progress"
+                : $"--backend {crispAsrEngine.BackendName} {langPart}-m \"{crispModel}\"{alignerPart}{vadPart} -f \"{waveFileName}\" --output-srt --print-progress {crispArgs}";
 
             Se.WriteToolsLog($"{exe} {crispParams}");
 
@@ -4085,6 +4089,24 @@ public partial class SpeechToTextViewModel : ObservableObject
                     var pctString = arr[1].Trim().TrimEnd('%').TrimEnd();
                     if (double.TryParse(pctString, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture,
                             out var pct))
+                    {
+                        _endSeconds = _videoInfo.TotalSeconds * pct / 100.0;
+                        _showProgressPct = pct;
+                    }
+                }
+            }
+            else if (line.StartsWith("crispasr: progress =", StringComparison.OrdinalIgnoreCase))
+            {
+                // crispasr --print-progress: "crispasr: progress =  14% (1/7 slices)" - streamed
+                // per 30 s slice for every ASR backend, while the transcript segments only print
+                // after the whole file is processed, so this is the only live progress source.
+                var arr = line.Split('=');
+                if (arr.Length == 2)
+                {
+                    var pctString = arr[1].TrimStart();
+                    var pctEnd = pctString.IndexOf('%');
+                    if (pctEnd > 0 && double.TryParse(pctString[..pctEnd], NumberStyles.AllowDecimalPoint,
+                            CultureInfo.InvariantCulture, out var pct))
                     {
                         _endSeconds = _videoInfo.TotalSeconds * pct / 100.0;
                         _showProgressPct = pct;


### PR DESCRIPTION
CrispASR prints transcript segments only **after** the whole file is processed, so SE's segment-timestamp progress tracking never moved during a run — the progress bar sat idle for the entire transcription and jumped straight to 100% at the end.

## Changes

- Pass `--print-progress` on the CrispASR command line. The runtime then streams `crispasr: progress =  NN% (i/n slices)` lines in real time, one per 30-second slice, for **every** ASR backend.
- Add a parser branch for that format in `OutputHandler` — the existing branches only matched whisper.cpp's `whisper_full: progress =` and the faster-whisper percent formats. It feeds the same `_showProgressPct`/`_endSeconds` machinery, so the time-remaining estimate works too.

## Verification

Tested headlessly against the pinned v0.8.13 binary with a 3-minute clip:
- `whisper` and `fun-asr-mlt-nano` backends both stream the progress lines live (t=2s, 3s, 5s, …) while segments arrive only at the end (all at t=33s).
- No `whisper_full: progress =` lines are emitted alongside, so there's no double-parsing conflict.
- Build clean; all 85 SpeechToText UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)