### PR TITLE
Fix dead shortcuts (Ctrl+F/Ctrl+H) after closing a dialog

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14743,9 +14743,45 @@ public partial class MainViewModel :
             PauseVideoAndFreezePlayhead(videoPlayerControl);
         }
 
-        var result = await _windowService.ShowDialogAsync<TWindow, TViewModel>(owner ?? Window!, configureViewModel, configureWindow);
+        var usedOwner = owner ?? Window!;
+        var result = await _windowService.ShowDialogAsync<TWindow, TViewModel>(usedOwner, configureViewModel, configureWindow);
         _shortcutManager.ClearKeys();
+        if (usedOwner == Window)
+        {
+            RestoreFocusAfterDialogClose();
+        }
+
         return result;
+    }
+
+    /// <summary>
+    /// After a modal dialog closes, Avalonia restores keyboard focus to the owner's previously
+    /// focused element - but when that element is gone (e.g. a menu item in a since-closed
+    /// popup when the dialog was launched from the menu bar), the restore silently fails and
+    /// focus lands on the bare Window. Key events then route only to the Window - never through
+    /// MainView, where the shortcut KeyDown handler lives - so every shortcut (Ctrl+F, Ctrl+H,
+    /// ...) goes dead until the user clicks a control (#12634). Fall back to the subtitle grid,
+    /// like the menu-bar deactivation restore does. Deferred so a flow-specific focus set by
+    /// the dialog's caller afterwards wins; skipped while another (follow-up) dialog is active -
+    /// its own wrapper call runs the same restore when it closes.
+    /// </summary>
+    private void RestoreFocusAfterDialogClose()
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (Window is not { IsActive: true })
+            {
+                return;
+            }
+
+            var focused = Window.FocusManager?.GetFocusedElement();
+            if (focused is Control control && control != Window)
+            {
+                return; // focus survived inside a real control - leave it be
+            }
+
+            SubtitleGrid?.Focus();
+        });
     }
 
     private void SplitSelectedLine(bool atVideoPosition, bool atTextBoxPosition)


### PR DESCRIPTION
Fixes #12634 — after closing a dialog (the reporter's case: spell check), Ctrl+F / Ctrl+H (and every other shortcut) did nothing until clicking a control in the main window.

## Root cause

Main-window shortcuts are handled by a `KeyDown` handler attached to `MainView`, so they only fire while keyboard focus is on an element **inside** the view. When a modal dialog closes, Avalonia restores focus to the owner's previously focused element — but when that element no longer exists (e.g. a menu item in a since-closed popup, when the dialog was launched from the menu bar), the restore silently fails and focus lands on the bare `Window`. Key events then route only to the Window, never through `MainView`, and every shortcut goes dead. This explains the "sometimes": toolbar-launched dialogs restore focus to a still-alive toolbar button and keep working; menu-launched ones don't.

## Fix

Central, in the `ShowDialogAsync` wrapper all main-window dialogs go through: after a dialog owned by the main window closes, a deferred check restores focus to the subtitle grid **only** when focus did not survive on a real control — the same fallback the menu-bar deactivation restore already uses (#11745). Flow-specific focus set by a dialog's caller wins (it runs after the posted restore), and the restore is skipped while a follow-up dialog is active — that dialog's own wrapper call re-runs it on close.

## Testing

- Build clean; all 21 Main UI tests pass.
- Manual check recommended on Windows: launch spell check from the **menu bar**, close with Done, press Ctrl+F without clicking first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)