### PR TITLE
Fix Multiple Replace corrupting ASSA \N line breaks on Windows

### DIFF
--- a/src/libse/Common/RegexUtils.cs
+++ b/src/libse/Common/RegexUtils.cs
@@ -246,8 +246,9 @@ namespace Nikse.SubtitleEdit.Core.Common
         }
 
         /// <summary>
-        /// Performs replace on regular expression. Line breaks are normalized to "\n" for both the match
-        /// and the returned text, so the pattern and the text agree regardless of \n vs \r\n.
+        /// Performs replace on regular expression. The match runs against line-feed-normalized text,
+        /// so the pattern's \n (see <see cref="FixNewLine"/>) matches regardless of \n vs \r\n; the
+        /// returned text uses <see cref="Environment.NewLine"/> like all other paragraph text.
         /// </summary>
         /// <param name="regularExpression">Regular expression to perform replace on</param>
         /// <param name="text">Text perform replace on</param>
@@ -257,18 +258,35 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// <returns>Input string with regular expression replace applied</returns>
         public static string ReplaceNewLineSafe(Regex regularExpression, string text, string replaceWith, int count, int startIndex)
         {
-            // Match/return with line-feed-normalized line breaks so a pattern's \n (see FixNewLine)
+            // Match with line-feed-normalized line breaks so a pattern's \n (see FixNewLine)
             // matches regardless of whether the in-memory text uses \n or \r\n (#11956).
 
             // Fast path (runs per replace rule per subtitle line): text without \r or U+2028 round-trips
             // unchanged through the SplitToLines+Join normalization, so skip the four allocations.
             if (!ContainsNonLineFeedNewLine(text) && !ContainsNonLineFeedNewLine(replaceWith))
             {
-                return regularExpression.Replace(text, replaceWith, count, startIndex);
+                return RestorePlatformNewLines(regularExpression.Replace(text, replaceWith, count, startIndex));
             }
 
             text = regularExpression.Replace(string.Join("\n", text.SplitToLines()), replaceWith, count, startIndex);
-            return string.Join("\n", text.SplitToLines());
+            return RestorePlatformNewLines(text);
+        }
+
+        /// <summary>
+        /// Re-joins line-feed-normalized text with <see cref="Environment.NewLine"/>. The rest of
+        /// libse keeps paragraph text with platform newlines, and the format writers rely on it -
+        /// e.g. ASSA folds line breaks via <c>Replace(Environment.NewLine, "\\N")</c>, so a bare
+        /// \n left behind by the match normalization above was written as a physical newline
+        /// inside the Dialogue line, corrupting the saved file on Windows (#12620).
+        /// </summary>
+        private static string RestorePlatformNewLines(string text)
+        {
+            if (Environment.NewLine == "\n" || text.IndexOf('\n') < 0)
+            {
+                return text;
+            }
+
+            return string.Join(Environment.NewLine, text.SplitToLines());
         }
 
         public static int CountNewLineSafe(Regex regularExpression, string text)

--- a/tests/libse/Common/RegexUtilsTest.cs
+++ b/tests/libse/Common/RegexUtilsTest.cs
@@ -1,4 +1,5 @@
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using System.Text.RegularExpressions;
 using Xunit;
 
@@ -38,5 +39,61 @@ public class RegexUtilsTest
     {
         var regex = new Regex(RegexUtils.FixNewLine(@"a\r\nb"));
         Assert.Equal(1, RegexUtils.CountNewLineSafe(regex, "xa\nbx"));
+    }
+
+    // #12620: the returned text must use Environment.NewLine like all other paragraph text - the
+    // format writers rely on it (ASSA folds breaks via Replace(Environment.NewLine, "\\N")), so a
+    // bare \n left behind by the match normalization was written as a physical newline inside the
+    // Dialogue line on Windows, corrupting the saved file. The reporter's repro: an ellipsis
+    // replacement on one line of a two-line ASSA paragraph.
+    [Fact]
+    public void ReplaceNewLineSafe_CrLfText_ReturnsPlatformNewLines()
+    {
+        var regex = new Regex(RegexUtils.FixNewLine(@"(?:…|\.{4,})"));
+        var result = RegexUtils.ReplaceNewLineSafe(regex, "First line…\r\nSecond line", "...");
+        Assert.Equal("First line..." + Environment.NewLine + "Second line", result);
+    }
+
+    [Fact]
+    public void ReplaceNewLineSafe_UntouchedLineBreakInLineFeedText_ReturnsPlatformNewLines()
+    {
+        var regex = new Regex(RegexUtils.FixNewLine(@"\.{4,}"));
+        var result = RegexUtils.ReplaceNewLineSafe(regex, "First line....\nSecond line", "...");
+        Assert.Equal("First line..." + Environment.NewLine + "Second line", result);
+    }
+
+    // A replacement that introduces a line break (rule splits one line into two) must come out
+    // with a platform newline too - the fast path applies here since neither input contains \r.
+    [Fact]
+    public void ReplaceNewLineSafe_ReplacementIntroducesLineBreak_ReturnsPlatformNewLines()
+    {
+        var regex = new Regex(RegexUtils.FixNewLine(@" - "));
+        var result = RegexUtils.ReplaceNewLineSafe(regex, "First part - second part", RegexUtils.FixNewLine(@"\n"));
+        Assert.Equal("First part" + Environment.NewLine + "second part", result);
+    }
+
+    [Fact]
+    public void ReplaceNewLineSafe_NoLineBreaks_ReturnsTextUnchanged()
+    {
+        var regex = new Regex("b+");
+        var result = RegexUtils.ReplaceNewLineSafe(regex, "abc", "B");
+        Assert.Equal("aBc", result);
+    }
+
+    // The reporter's end-to-end repro from #12620: replace an ellipsis on one line of a two-line
+    // ASSA paragraph, then serialize - the line break must come out as \N, not as a physical
+    // newline inside the Dialogue line. ASSA folds breaks via Replace(Environment.NewLine, "\\N"),
+    // so this only holds when ReplaceNewLineSafe returns platform newlines.
+    [Fact]
+    public void ReplaceNewLineSafe_AssaRoundTrip_KeepsBackslashN()
+    {
+        var regex = new Regex(RegexUtils.FixNewLine(@"(?:…|\.{4,})"));
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("First line…" + Environment.NewLine + "Second line", 1000, 4000));
+
+        subtitle.Paragraphs[0].Text = RegexUtils.ReplaceNewLineSafe(regex, subtitle.Paragraphs[0].Text, "...");
+        var assa = new AdvancedSubStationAlpha().ToText(subtitle, "title");
+
+        Assert.Contains("First line...\\NSecond line", assa);
     }
 }


### PR DESCRIPTION
Fixes #12620 — on Windows, a regex Multiple Replace rule touching a two-line ASSA subtitle turned the `\N` separator into a physical newline inside the Dialogue line, corrupting the saved file.

## Root cause

`RegexUtils.ReplaceNewLineSafe` matches against line-feed-normalized text (the intended #11956 behavior) but also **returned** the text re-joined with `"\n"`. Paragraph text everywhere else in libse uses `Environment.NewLine` (`\r\n` on Windows), and the format writers rely on it — ASSA folds line breaks via `Replace(Environment.NewLine, "\\N")` — so the regex-modified paragraph's bare `\n` sailed through as a raw newline in the Dialogue line. Untouched paragraphs kept `\r\n` and serialized fine, exactly matching the report (modified line corrupted, control line intact; SRT unaffected since it tolerates a raw LF).

Same underlying mismatch as the preview glitch in #12622, this time on the data side. Affects all four consumers of `ReplaceNewLineSafe`: Multiple Replace, Batch Convert's replace step, regex Find & Replace, and seconv.

## Fix

Keep the LF-normalized matching, but re-join the returned text with `Environment.NewLine` via a `RestorePlatformNewLines` helper covering both the fast and slow paths (no-op on macOS/Linux and for texts without line breaks, so the hot path stays allocation-free). Also removes a phantom-diff side effect: rules that matched but produced identical text still registered as "affected" on Windows because of the hidden `\r` vs `\n` difference.

## Testing

- 5 new tests: the reporter's exact ellipsis repro on CRLF input, an untouched line break in LF input, a replacement that introduces a line break (fast-path), a no-line-breaks passthrough, and an end-to-end ASSA round-trip asserting the Dialogue line keeps `\N`. Expectations use `Environment.NewLine`, so they exercise the real branch when run on Windows.
- Full libse (574), seconv (244) suites pass; UI builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)