### PR TITLE
Use SearchValues for RTL-letter and unicode-control-char scans

### DIFF
--- a/src/libse/Common/LanguageAutoDetect.cs
+++ b/src/libse/Common/LanguageAutoDetect.cs
@@ -1934,6 +1934,10 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         private static readonly char[] RightToLeftLetters = string.Concat(AutoDetectWordsArabic.Concat(AutoDetectWordsHebrew).Concat(AutoDetectWordsFarsi).Concat(AutoDetectWordsUrdu)).Distinct().ToArray();
 
+#if NET8_0_OR_GREATER
+        private static readonly System.Buffers.SearchValues<char> RightToLeftLetterSearchValues = System.Buffers.SearchValues.Create(RightToLeftLetters);
+#endif
+
         public static bool CouldBeRightToLeftLanguage(Subtitle subtitle)
         {
             const int maxNumberOfLinesToCheck = 20;
@@ -1950,6 +1954,9 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public static bool ContainsRightToLeftLetter(string text)
         {
+#if NET8_0_OR_GREATER
+            return text.AsSpan().ContainsAny(RightToLeftLetterSearchValues);
+#else
             foreach (var letter in RightToLeftLetters)
             {
                 if (text.Contains(letter))
@@ -1958,6 +1965,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
             }
             return false;
+#endif
         }
 
         public static string GetEncodingViaLetter(string text)

--- a/src/libse/Common/StringExtensions.cs
+++ b/src/libse/Common/StringExtensions.cs
@@ -13,6 +13,10 @@ namespace Nikse.SubtitleEdit.Core.Common
     {
         public static char[] UnicodeControlChars { get; } = { '\u200E', '\u200F', '\u202A', '\u202B', '\u202C', '\u202D', '\u202E' };
 
+#if NET8_0_OR_GREATER
+        private static readonly SearchValues<char> UnicodeControlCharsSearchValues = SearchValues.Create(UnicodeControlChars);
+#endif
+
         public static bool LineStartsWithHtmlTag(this string text, bool threeLengthTag, bool includeFont = false)
         {
             if (text == null || !threeLengthTag && !includeFont)
@@ -435,7 +439,11 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public static bool ContainsUnicodeControlChars(this string s)
         {
+#if NET8_0_OR_GREATER
+            return s.AsSpan().ContainsAny(UnicodeControlCharsSearchValues);
+#else
             return s.Contains(UnicodeControlChars);
+#endif
         }
 
         public static bool ContainsNonStandardNewLines(this string s)
@@ -503,7 +511,11 @@ namespace Nikse.SubtitleEdit.Core.Common
             for (var index = 0; index < max; index++)
             {
                 var ch = s[index];
+#if NET8_0_OR_GREATER
+                if (!char.IsControl(ch) && !char.IsWhiteSpace(ch) && !UnicodeControlCharsSearchValues.Contains(ch))
+#else
                 if (!char.IsControl(ch) && !char.IsWhiteSpace(ch) && !UnicodeControlChars.Contains(ch))
+#endif
                 {
                     return false;
                 }


### PR DESCRIPTION
## Summary
- `LanguageAutoDetect.ContainsRightToLeftLetter` scanned the text once per RTL letter (67 distinct chars from the Arabic/Hebrew/Farsi/Urdu word lists) — worst case on plain LTR text, and it runs per grid-cell render via `TextToFlowDirectionConverter`. On .NET 8+ it now does a single vectorized `ContainsAny` pass over a precomputed `SearchValues<char>` set.
- `StringExtensions.ContainsUnicodeControlChars` (7-char non-ASCII `IndexOfAny`) and `IsOnlyControlCharactersOrWhiteSpace` (LINQ array `Contains` per character inside the loop) now use a shared static `SearchValues<char>` as well.
- The `netstandard2.1` target keeps the existing code via `#if NET8_0_OR_GREATER`; only the .NET 10 build (what the app ships) takes the fast path.
- Release-build micro-benchmark on typical LTR text: 728 ms → 214 ms per 1M `ContainsRightToLeftLetter` calls (~3.4×).

## Test plan
- [x] `dotnet build src/libse/LibSE.csproj` — both TFMs (`netstandard2.1`, `net10.0`) build clean
- [x] `dotnet test tests/libse/LibSETests.csproj` — all tests pass (569/569 locally)
- [ ] Load an Arabic or Hebrew subtitle — list view/text box flow direction still switches to RTL
- [x] Load an English subtitle — flow direction stays LTR
- [ ] Text containing RTL/LTR markers (U+200E/U+200F etc.) is still detected by remove-unicode-control-chars handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)