### PR TITLE
Three libse micro-optimizations: ASSA tag parsing, control-char strip, RemoveChar

### DIFF
--- a/src/libse/Common/StringExtensions.cs
+++ b/src/libse/Common/StringExtensions.cs
@@ -815,13 +815,14 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public static string RemoveChar(this string value, params char[] charsToRemove)
         {
-            var h = new HashSet<char>(charsToRemove);
+            // Callers pass a handful of literal chars (3-13), so a vectorized linear probe
+            // beats allocating and hashing a HashSet per call.
             char[] array = new char[value.Length];
             int arrayIndex = 0;
             for (int i = 0; i < value.Length; i++)
             {
                 char ch = value[i];
-                if (!h.Contains(ch))
+                if (Array.IndexOf(charsToRemove, ch) < 0)
                 {
                     array[arrayIndex++] = ch;
                 }

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -3362,8 +3362,31 @@ namespace Nikse.SubtitleEdit.Core.Common
             return text;
         }
 
+        private static readonly char[] UnicodeControlCharsAndNoBreakSpace = { '\u200E', '\u200F', '\u202A', '\u202B', '\u202C', '\u202D', '\u202E', '\u00A0' };
+
+#if NET8_0_OR_GREATER
+        private static readonly System.Buffers.SearchValues<char> UnicodeControlCharsAndNoBreakSpaceSearchValues =
+            System.Buffers.SearchValues.Create(UnicodeControlCharsAndNoBreakSpace);
+#endif
+
         public static string RemoveUnicodeControlChars(string input)
         {
+            // Runs per line in fix passes and auto-break, and most lines contain none of the
+            // eight characters - bail with the original instance after one vectorized scan
+            // instead of eight chained Replace scans. Lines that do contain one keep the
+            // chained Replaces: .NET's vectorized Replace beats a scalar rewrite loop.
+#if NET8_0_OR_GREATER
+            if (!input.AsSpan().ContainsAny(UnicodeControlCharsAndNoBreakSpaceSearchValues))
+            {
+                return input;
+            }
+#else
+            if (input.AsSpan().IndexOfAny(UnicodeControlCharsAndNoBreakSpace) < 0)
+            {
+                return input;
+            }
+#endif
+
             return input.Replace("\u200E", string.Empty)
                 .Replace("\u200F", string.Empty)
                 .Replace("\u202A", string.Empty)

--- a/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
@@ -1125,19 +1125,28 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
             {
                 for (var i = 0; i < 10; i++) // just look ten times...
                 {
+                    // Each pattern check below is a single IndexOf (the old Contains-then-IndexOf
+                    // did every scan twice), and an iteration that changes nothing breaks out -
+                    // this runs per dialogue line on ASSA/SSA load, and a plain line used to pay
+                    // all ten iterations' scans for nothing.
+                    var changed = false;
+
                     bool italic;
-                    if (text.Contains(@"{\i1\"))
+                    var italicStart = text.IndexOf(@"{\i1\", StringComparison.Ordinal);
+                    if (italicStart >= 0)
                     {
-                        var start = text.IndexOf(@"{\i1\", StringComparison.Ordinal);
-                        text = text.Remove(start, 4).Insert(start, "<i>{");
+                        text = text.Remove(italicStart, 4).Insert(italicStart, "<i>{");
+                        changed = true;
                     }
 
-                    if (text.Contains(@"{\fn"))
+                    var fontNameStart = text.IndexOf(@"{\fn", StringComparison.Ordinal);
+                    if (fontNameStart >= 0)
                     {
-                        var start = text.IndexOf(@"{\fn", StringComparison.Ordinal);
+                        var start = fontNameStart;
                         var end = text.IndexOf('}', start);
                         if (end > 0 && !text.Substring(start).StartsWith("{\\fn}", StringComparison.Ordinal))
                         {
+                            changed = true;
                             var fontName = text.Substring(start + 4, end - (start + 4));
                             var extraTags = string.Empty;
                             CheckAndAddSubTags(ref fontName, ref extraTags, out var unknownTags, out italic);
@@ -1176,9 +1185,10 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                         }
                     }
 
-                    if (text.Contains(@"{\fs"))
+                    var fontSizeStart = text.IndexOf(@"{\fs", StringComparison.Ordinal);
+                    if (fontSizeStart >= 0)
                     {
-                        var start = text.IndexOf(@"{\fs", StringComparison.Ordinal);
+                        var start = fontSizeStart;
                         var end = text.IndexOf('}', start);
                         if (end > 0 && !text.Substring(start).StartsWith("{\\fs}", StringComparison.Ordinal))
                         {
@@ -1187,6 +1197,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                             CheckAndAddSubTags(ref fontSize, ref extraTags, out var unknownTags, out italic);
                             if (float.TryParse(fontSize, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out _))
                             {
+                                changed = true;
                                 text = text.Remove(start, end - start + 1);
                                 if (italic)
                                 {
@@ -1223,12 +1234,14 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                         }
                     }
 
-                    if (text.Contains(@"{\c"))
+                    var colorStart = text.IndexOf(@"{\c", StringComparison.Ordinal);
+                    if (colorStart >= 0)
                     {
-                        var start = text.IndexOf(@"{\c", StringComparison.Ordinal);
+                        var start = colorStart;
                         var end = text.IndexOf('}', start);
                         if (end > 0 && !text.Substring(start).StartsWith("{\\c}", StringComparison.Ordinal) && !text.Substring(start).StartsWith("{\\clip", StringComparison.Ordinal))
                         {
+                            changed = true;
                             var color = text.Substring(start + 4, end - (start + 4));
                             var extraTags = string.Empty;
                             CheckAndAddSubTags(ref color, ref extraTags, out var unknownTags, out italic);
@@ -1267,12 +1280,14 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                         }
                     }
 
-                    if (text.Contains(@"{\1c")) // "1" specifices primary color
+                    var primaryColorStart = text.IndexOf(@"{\1c", StringComparison.Ordinal); // "1" specifices primary color
+                    if (primaryColorStart >= 0)
                     {
-                        var start = text.IndexOf(@"{\1c", StringComparison.Ordinal);
+                        var start = primaryColorStart;
                         var end = text.IndexOf('}', start);
                         if (end > 0 && !text.Substring(start).StartsWith("{\\1c}", StringComparison.Ordinal))
                         {
+                            changed = true;
                             var color = text.Substring(start + 5, end - (start + 5));
                             var extraTags = string.Empty;
                             CheckAndAddSubTags(ref color, ref extraTags, out var unknownTags, out italic);
@@ -1309,6 +1324,11 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                                 text += "</font>";
                             }
                         }
+                    }
+
+                    if (!changed)
+                    {
+                        break; // nothing matched - the remaining iterations would scan for nothing
                     }
                 }
             }


### PR DESCRIPTION
Follow-up to #12638, same spirit — three semantics-preserving micro-optimizations on per-line paths, measured with BenchmarkDotNet and verified **output-identical** against the previous implementations over a corpus of 25 ASSA tag patterns, control-char inputs, and RemoveChar cases (old vs new outputs diffed byte-for-byte).

## BenchmarkDotNet (ShortRun, .NET 10, Apple M4)

| Benchmark | Before | After | Δ |
|---|---|---|---|
| `GetFormattedText` — plain ASSA line | 260.6 ns / 80 B | 110.7 ns / 80 B | **2.4× faster** |
| `GetFormattedText` — tagged line (`\fn`,`\fs`,`\c`,`\i`) | 1363.1 ns / 4528 B | 965.6 ns / 4528 B | **1.4× faster** |
| `RemoveUnicodeControlChars` — clean line (common case) | 34.8 ns / 0 B | 13.5 ns / 0 B | **2.6× faster** |
| `RemoveUnicodeControlChars` — line with RTL marker + NBSP | 62.6 ns / 432 B | 63.7 ns / 432 B | ~unchanged |
| `RemoveChar(params char[])` | 130.3 ns / 536 B | 97.7 ns / 304 B | **1.3× faster, −43% alloc** |

## Changes

1. **`AdvancedSubStationAlpha.GetFormattedText`** (runs per dialogue line on every ASSA/SSA load): each of the five pattern checks did `Contains` and then re-derived the position with `IndexOf` — two full scans per pattern — and the outer loop always ran all ten iterations even when nothing matched. Now a single `IndexOf` per pattern and a no-change `break`.
2. **`Utilities.RemoveUnicodeControlChars`** (per line in fix passes and auto-break): eight chained `Replace` scans even when the text contains none of the eight characters. Now gated behind one vectorized `SearchValues` scan (`netstandard2.1` falls back to span `IndexOfAny`). The rare repair path keeps the chained `Replace`s — a scalar rewrite loop was benchmarked and *lost* to .NET's vectorized `Replace` (82 ns vs 64 ns), so it was rejected.
3. **`StringExtensions.RemoveChar(params char[])`** (fix passes, several format parsers): allocated + hashed a `HashSet<char>` per call for the 3–13 literal chars callers pass; a vectorized `Array.IndexOf` probe is faster and drops the set allocation.

## Testing

- Differential check: old vs new outputs identical across the corpus (via `git stash` swap).
- libse 574/574, seconv 244/244 tests pass; UI builds clean, both libse TFMs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)