### PR TITLE
Auto-translate via llama.cpp: add Hy-MT2 models + per-model prompt/sampling

### DIFF
--- a/src/libse/AutoTranslate/LlamaCppTranslate.cs
+++ b/src/libse/AutoTranslate/LlamaCppTranslate.cs
@@ -45,16 +45,28 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
 
         public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrWhiteSpace(Configuration.Settings.Tools.LlamaCppPrompt))
+            string prompt;
+            var modelPrompt = Configuration.Settings.Tools.LlamaCppModelPrompt;
+            if (!string.IsNullOrWhiteSpace(modelPrompt))
             {
-                Configuration.Settings.Tools.LlamaCppPrompt = new ToolsSettings().LlamaCppPrompt;
+                // A curated model with its own trained-in prompt (e.g. Hy-MT2). The "codes" this
+                // engine receives are already English language names - ListLanguages() puts the
+                // name in TranslationPair.Code - which is exactly what these templates expect.
+                prompt = string.Format(modelPrompt, sourceLanguageCode, targetLanguageCode);
             }
-            var prompt = string.Format(Configuration.Settings.Tools.LlamaCppPrompt, sourceLanguageCode, targetLanguageCode);
+            else
+            {
+                if (string.IsNullOrWhiteSpace(Configuration.Settings.Tools.LlamaCppPrompt))
+                {
+                    Configuration.Settings.Tools.LlamaCppPrompt = new ToolsSettings().LlamaCppPrompt;
+                }
+                prompt = string.Format(Configuration.Settings.Tools.LlamaCppPrompt, sourceLanguageCode, targetLanguageCode);
+            }
 
             // No "model" field: llama-server serves the single model it was started with, and for a
             // remote server the user's own llama-server does the same. Sending one would only risk a
             // mismatch with whatever that server has loaded.
-            var input = "{ \"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
+            var input = "{ \"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]" + MakeSamplingJson() + "}";
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
@@ -86,6 +98,35 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             outputText = ChatGptTranslate.RemovePreamble(text, outputText);
             outputText = ChatGptTranslate.DecodeUnicodeEscapes(outputText);
             return outputText.Trim();
+        }
+
+        /// <summary>
+        /// Model-recommended sampling parameters as extra JSON fields (empty when the selected
+        /// model defines none, keeping the server defaults - the behavior before per-model
+        /// sampling existed).
+        /// </summary>
+        private static string MakeSamplingJson()
+        {
+            var sb = new StringBuilder();
+            var tools = Configuration.Settings.Tools;
+            if (tools.LlamaCppModelTemperature >= 0)
+            {
+                sb.Append(", \"temperature\": ").Append(tools.LlamaCppModelTemperature.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            }
+            if (tools.LlamaCppModelTopP >= 0)
+            {
+                sb.Append(", \"top_p\": ").Append(tools.LlamaCppModelTopP.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            }
+            if (tools.LlamaCppModelTopK >= 0)
+            {
+                sb.Append(", \"top_k\": ").Append(tools.LlamaCppModelTopK.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            }
+            if (tools.LlamaCppModelRepeatPenalty >= 0)
+            {
+                sb.Append(", \"repeat_penalty\": ").Append(tools.LlamaCppModelRepeatPenalty.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            }
+
+            return sb.ToString();
         }
 
         public void Dispose()

--- a/src/libse/Settings/ToolsSettings.cs
+++ b/src/libse/Settings/ToolsSettings.cs
@@ -120,6 +120,11 @@ namespace Nikse.SubtitleEdit.Core.Settings
         public string LlamaCppApiUrl { get; set; }
         public string LlamaCppModel { get; set; }
         public string LlamaCppPrompt { get; set; }
+        public string LlamaCppModelPrompt { get; set; }
+        public double LlamaCppModelTemperature { get; set; }
+        public double LlamaCppModelTopP { get; set; }
+        public int LlamaCppModelTopK { get; set; }
+        public double LlamaCppModelRepeatPenalty { get; set; }
 
         public string OllamaApiUrl { get; set; }
         public string OllamaModels { get; set; }
@@ -409,6 +414,11 @@ namespace Nikse.SubtitleEdit.Core.Settings
             OpenRouterModel = OpenRouterTranslate.Models[0];
             LmStudioPrompt = "Translate from {0} to {1}, keep punctuation as input, keep line breaks exactly the same, do not censor the translation, give only the output without comments:";
             LlamaCppPrompt = "Translate from {0} to {1}, keep punctuation as input, keep line breaks exactly the same, do not censor the translation, give only the output without comments:";
+            LlamaCppModelPrompt = string.Empty;
+            LlamaCppModelTemperature = -1;
+            LlamaCppModelTopP = -1;
+            LlamaCppModelTopK = -1;
+            LlamaCppModelRepeatPenalty = -1;
             OllamaApiUrl = "http://localhost:11434/api/generate";
             OllamaModels = "llama3.2,llama3.2:1b,phi3,gemma2,qwen2,mistral";
             OllamaModel = "llama3.2";

--- a/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
+++ b/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
@@ -29,7 +29,16 @@ public sealed record LlamaCppModel(
     string? MmprojFileName = null,
     string? MmprojUrl = null,
     string? ChatTemplate = null,
-    bool NoJinja = false);
+    bool NoJinja = false,
+    // Translation prompt this model was trained on ({0} = source language English name,
+    // {1} = target language English name); null = the user's generic llama.cpp prompt.
+    // Needed for Hy-MT2, which answers in Chinese when given the generic prompt.
+    string? PromptTemplate = null,
+    // Model-recommended sampling; -1 = leave the server default.
+    double Temperature = -1,
+    double TopP = -1,
+    int TopK = -1,
+    double RepeatPenalty = -1);
 
 /// <summary>
 /// Manages the local <c>llama-server</c> process used by the llama.cpp auto-translate and OCR
@@ -38,6 +47,14 @@ public sealed record LlamaCppModel(
 /// </summary>
 public static class LlamaCppServerManager
 {
+    // Tencent's official Hy-MT2 prompt - the model is trained on exactly this phrasing and
+    // expects the TARGET language's English name ({1}); {0} (source) is unused by design.
+    // The line-break sentence is our addition to Tencent's official wording: the 7B honors it
+    // reliably, the 1.8B only sometimes - lost breaks are restored by SE's auto-break like for
+    // the other LLM engines.
+    private const string HyMt2PromptTemplate =
+        "Translate the following text into {1}. Keep line breaks exactly the same. Note that you should only output the translated result without any additional explanation:";
+
     public static readonly IReadOnlyList<LlamaCppModel> TranslateModels = new[]
     {
         new LlamaCppModel("TranslateGemma 4B (Q4_K_M)", "translategemma-4b_Q4_K_M.gguf", "2.5 GB",
@@ -51,6 +68,9 @@ public static class LlamaCppServerManager
             ChatTemplate: "gemma", NoJinja: true),
         new LlamaCppModel("TranslateGemma 12B (Q4_K_M)", "translategemma-12b-it-q4_k_m.gguf", "7.3 GB",
             "https://huggingface.co/NikolayKozloff/translategemma-12b-it-Q4_K_M-GGUF/resolve/main/translategemma-12b-it-q4_k_m.gguf",
+            ChatTemplate: "gemma", NoJinja: true),
+        new LlamaCppModel("TranslateGemma 12B (Q5_K_M)", "translategemma-12b-it-q5_k_m.gguf", "8.5 GB",
+            "https://huggingface.co/NikolayKozloff/translategemma-12b-it-Q5_K_M-GGUF/resolve/main/translategemma-12b-it-q5_k_m.gguf",
             ChatTemplate: "gemma", NoJinja: true),
 
         // Alternative model family. Qwen 3 is the strongest open model for CJK
@@ -77,6 +97,26 @@ public static class LlamaCppServerManager
         new LlamaCppModel("Qwen 3.5 9B (Q4_K_M)", "Qwen_Qwen3.5-9B-Q4_K_M.gguf", "5.7 GB",
             "https://huggingface.co/bartowski/Qwen_Qwen3.5-9B-GGUF/resolve/main/Qwen_Qwen3.5-9B-Q4_K_M.gguf",
             ChatTemplate: "chatml", NoJinja: true),
+        new LlamaCppModel("Qwen 3.5 9B (Q8_0)", "Qwen_Qwen3.5-9B-Q8_0.gguf", "9.8 GB",
+            "https://huggingface.co/bartowski/Qwen_Qwen3.5-9B-GGUF/resolve/main/Qwen_Qwen3.5-9B-Q8_0.gguf",
+            ChatTemplate: "chatml", NoJinja: true),
+
+        // Hy-MT2 (Tencent Hunyuan-MT 2, 2026) - translation-specialized, official GGUFs, Apache-2.0.
+        // Excellent for its 33+5 supported languages (CJK, major European/Asian) but has NO Nordic
+        // languages (Danish/Swedish/Norwegian/Finnish), no Greek/Romanian/Hungarian - generation in
+        // unsupported languages produces garbage, hence the coverage note in the display name.
+        // Trained on a fixed prompt (PromptTemplate below, with language NAMES - the generic prompt
+        // makes it answer in Chinese) and Tencent-recommended sampling. Embedded chat template works
+        // as-is, so no ChatTemplate/NoJinja overrides.
+        new LlamaCppModel("Hy-MT2 7B (Q4_K_M) - 33 languages, no Nordic", "Hy-MT2-7B-Q4_K_M.gguf", "4.6 GB",
+            "https://huggingface.co/tencent/Hy-MT2-7B-GGUF/resolve/main/Hy-MT2-7B-Q4_K_M.gguf",
+            PromptTemplate: HyMt2PromptTemplate, Temperature: 0.7, TopP: 0.6, TopK: 20, RepeatPenalty: 1.05),
+        new LlamaCppModel("Hy-MT2 7B (Q8_0) - 33 languages, no Nordic", "HY-MT2-7B-Q8_0.gguf", "8.0 GB",
+            "https://huggingface.co/tencent/Hy-MT2-7B-GGUF/resolve/main/HY-MT2-7B-Q8_0.gguf",
+            PromptTemplate: HyMt2PromptTemplate, Temperature: 0.7, TopP: 0.6, TopK: 20, RepeatPenalty: 1.05),
+        new LlamaCppModel("Hy-MT2 1.8B (Q8_0) - 33 languages, no Nordic", "Hy-MT2-1.8B-Q8_0.gguf", "1.9 GB",
+            "https://huggingface.co/tencent/Hy-MT2-1.8B-GGUF/resolve/main/Hy-MT2-1.8B-Q8_0.gguf",
+            PromptTemplate: HyMt2PromptTemplate, Temperature: 0.7, TopP: 0.6, TopK: 20, RepeatPenalty: 1.05),
 
         // Aya Expanse 8B (Cohere) - a dedicated multilingual model (23 languages), a good translation
         // alternative to the Gemma/Qwen families. Uses its own embedded (Cohere) chat template, so we

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -372,7 +372,18 @@ public partial class AutoTranslateViewModel : ObservableObject
                 Se.Settings.AutoTranslate.LlamaCppApiUrl = apiUrl.Trim();
             }
             // Local mode stays server-managed: the API URL is set by LlamaCppServerManager and the
-            // model is persisted via OnSelectedLlamaCppModelChanged, so nothing else to save here.
+            // model is persisted via OnSelectedLlamaCppModelChanged.
+
+            // Model-specific prompt/sampling only apply in local mode, where we know which curated
+            // model the server runs (e.g. Hy-MT2's trained-in prompt); a remote server's model is
+            // unknown and a custom .gguf carries no template, so both fall back to the generic
+            // prompt and server-default sampling.
+            var curatedModel = LlamaCppUseRemoteServer ? null : SelectedLlamaCppModel?.Model;
+            Configuration.Settings.Tools.LlamaCppModelPrompt = curatedModel?.PromptTemplate ?? string.Empty;
+            Configuration.Settings.Tools.LlamaCppModelTemperature = curatedModel?.Temperature ?? -1;
+            Configuration.Settings.Tools.LlamaCppModelTopP = curatedModel?.TopP ?? -1;
+            Configuration.Settings.Tools.LlamaCppModelTopK = curatedModel?.TopK ?? -1;
+            Configuration.Settings.Tools.LlamaCppModelRepeatPenalty = curatedModel?.RepeatPenalty ?? -1;
         }
 
         if (engineType == typeof(OllamaTranslate))


### PR DESCRIPTION
Adds Tencent's **Hy-MT2** (Hunyuan-MT 2, May 2026, Apache-2.0) translation-specialized models to the llama.cpp auto-translate catalog, plus the machinery they need.

## New models (official `tencent/*-GGUF` repos)

| Model | Size | Notes |
|---|---|---|
| Hy-MT2 7B Q4_K_M | 4.6 GB | recommended |
| Hy-MT2 7B Q8_0 | 8.0 GB | |
| Hy-MT2 1.8B Q8_0 | 1.9 GB | low-end option, noticeably weaker |
| TranslateGemma 12B Q5_K_M | 8.5 GB | quality bump, new ≤10 GB cap |
| Qwen 3.5 9B Q8_0 | 9.8 GB | quality bump, new ≤10 GB cap |

Hy-MT2 covers **33+5 languages** (CJK, major European/Asian) with benchmark-leading quality — but **no Nordic languages** (generation outside the set produces garbage), so the display names carry a coverage note.

## Per-model prompt + sampling

Hy-MT2 is trained on a fixed prompt and recommended sampling (temp 0.7 / top-p 0.6 / top-k 20 / rep 1.05); with the generic prompt it answered in Chinese during testing. New optional `PromptTemplate` + sampling fields on the curated-model record, bridged to the engine via `Tools.LlamaCppModel*` settings set at translate start. Applies to **local curated models only** — remote servers and custom `.gguf` files keep the generic prompt and server-default sampling.

## Verification (headless, real engine, live server)

- Both TFMs build; libse 574, libuilogic 14, UI 713 tests pass.
- End-to-end through the actual `LlamaCppTranslate` class against SE's pinned llama-server (b10035) running Hy-MT2: correct, natural EN↔DE/JA/ES at ~1 s/line (M4); fallback path (no template) verified unchanged.
- Found and fixed during testing: the engine's language "codes" are actually English names (`ListLanguages` puts the name in `TranslationPair.Code`), so templates format with the incoming values directly.
- Line breaks: the added keep-line-breaks sentence is honored reliably by the 7B, sometimes by the 1.8B; lost breaks are restored by SE's auto-break like for the other LLM engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)