### PR TITLE
OCR fix lists: adopt the safest community rules from #12644

### DIFF
--- a/Dictionaries/eng_OCRFixReplaceList.xml
+++ b/Dictionaries/eng_OCRFixReplaceList.xml
@@ -3395,6 +3395,12 @@
 		<RegEx find="(2 )(nd\b)" replaceWith="2$2" />
 		<RegEx find="(3 )(rd\b)" replaceWith="3$2" />
 		<RegEx find="([456789])( th\b)" replaceWith="$1th" />
+		<!-- ü misread as ii: Fiihrer/Obergruppenfiihrer etc. (from #12644) -->
+		<RegEx find="iihrer" replaceWith="ührer" />
+		<!-- ñ misread as fi: Sefior/sefiorita, compafiero (from #12644) -->
+		<RegEx find="\b([Ss])efior" replaceWith="${1}eñor" />
+		<RegEx find="ompafier" replaceWith="ompañer" />
+		<RegEx find="ompafiar" replaceWith="ompañar" />
 	</RegularExpressions>
 	<RegularExpressionsIfSpelledCorrectly>
 		<RegEx find="\[([A-Zl]+)\]" replaceAllFrom="l" replaceAllTo="I" spellCheck="$1" replaceWith="[$1]" />		

--- a/Dictionaries/fra_OCRFixReplaceList.xml
+++ b/Dictionaries/fra_OCRFixReplaceList.xml
@@ -267,7 +267,23 @@
   </PartialLines>
   <BeginLines />
   <EndLines />
-  <RegularExpressions />
+  <RegularExpressions>
+    <!-- From #12644 (community-contributed, safety-reviewed) -->
+    <!-- "Il y a" misread as "ILy a" -->
+    <RegEx find="\bILy a\b" replaceWith="Il y a" />
+    <!-- d'ou is always d'où -->
+    <RegEx find="\b([Dd])'([Oo])u\b" replaceWith="${1}'${2}ù" />
+    <!-- S misread as 5 in S'il -->
+    <RegEx find="5 *'il\b" replaceWith="S'il" />
+    <!-- spaced apostrophe: s 'il / s 'ils -->
+    <RegEx find="([Ss]) 'il(s?)\b" replaceWith="${1}'il${2}" />
+    <!-- l misread as I in l'a -->
+    <RegEx find="\bI'a\b" replaceWith="l'a" />
+    <!-- spaced apostrophe after t' before vowel/h: "Je t' aime" -->
+    <RegEx find=" t' ([aehiouyéèêàùâîôûAEHIOUYÉÈÊÀÙÂÎÔÛ])" replaceWith=" t'${1}" />
+    <!-- S misread as 5 in SOS (letter O only - never the number 505) -->
+    <RegEx find="\b5(\.*)O(\.*)5(\.*)\b" replaceWith="S${1}O${2}S${3}" />
+  </RegularExpressions>
   <RegularExpressionsIfSpelledCorrectly>
 
     <!-- ============================================================ -->
@@ -372,5 +388,10 @@
     <!-- inLondon → in London -->
     <RegEx find="\bin([A-Z][a-zæøåöäéèàùâêîôûëïœç]+)\b" spellCheck="$1" replaceWith="in $1" />
 
+
+    <!-- From #12644: è/à misread - only applied when the fixed word is in the dictionary -->
+    <RegEx find="\b([MmPp])[eéêë]re\b" spellCheck="${1}ère" replaceWith="${1}ère" />
+    <RegEx find="\b([Tt])r[eéêë]s\b" spellCheck="${1}rès" replaceWith="${1}rès" />
+    <RegEx find="\bL[äáâ]\b" spellCheck="Là" replaceWith="Là" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/nld_OCRFixReplaceList.xml
+++ b/Dictionaries/nld_OCRFixReplaceList.xml
@@ -108,6 +108,8 @@
     <Word from="ziin" to="zijn" />
     <Word from="zonderjou" to="zonder jou" />
     <Word from="Zonderjou" to="Zonder jou" />
+    <!-- from #12644 -->
+    <Word from="wanner" to="wanneer" />
   </WholeWords>
   <PartialWordsAlways />
   <PartialWords>
@@ -137,6 +139,8 @@
     <RegEx find="\beIk" replaceWith="elk" />
     <RegEx find="\bler(land|se|s|)\b" replaceWith="Ier$1" />
     <RegEx find="comite\b" replaceWith="comité" />
+    <!-- doubled apostrophe before 'n / 't (from #12644) -->
+    <RegEx find="''([nt])\b" replaceWith="'${1}" />
   </RegularExpressions>
   <RegularExpressionsIfSpelledCorrectly>
 

--- a/Dictionaries/spa_OCRFixReplaceList.xml
+++ b/Dictionaries/spa_OCRFixReplaceList.xml
@@ -366,6 +366,9 @@
     <Word from="Bartomeu" to="Bertomeu" />
     <Word from="Iocalizarlo" to="localizarlo" />
     <Word from="Ilámame" to="llámame" />
+    <!-- ! misread as l (from #12644) -->
+    <Word from="niñal" to="niña!" />
+    <Word from="túl" to="tú!" />
   </WholeWords>
   <PartialWordsAlways />
   <PartialWords />
@@ -948,5 +951,7 @@
     <RegEx find="\Bi(log[ao]s?\b)" replaceWith="í$1" />
     <RegEx find="\bIes\b" replaceWith="les" />
     <RegEx find="\bIos\b" replaceWith="los" />
+    <!-- ü misread as ii: Fiihrer/Obergruppenfiihrer etc. (from #12644) -->
+    <RegEx find="iihrer" replaceWith="ührer" />
   </RegularExpressions>
 </OCRFixReplaceList>


### PR DESCRIPTION
Adopts the strictly-safe subset of fraternl's community OCR fix lists from #12644 into the shipped `Dictionaries/*_OCRFixReplaceList.xml` files.

## Selection bar

Only rules that fix **unambiguous OCR errors** and cannot fire on legitimate text. Every adopted rule was behaviorally verified in .NET (fix cases + must-not-change cases, all passing) and deduped against the shipped lists.

## Adopted

| Lang | Rule | Fixes |
|---|---|---|
| eng | `iihrer` → `ührer` | Fiihrer/Obergruppenfiihrer (ü misread as ii) |
| eng | `\b([Ss])efior` → `${1}eñor` | Sefior/sefiorita (ñ misread as fi) |
| eng | `ompafier/ompafiar` → `ompañ…` | compafiero, acompafiar |
| fra | `\bILy a\b` → `Il y a` | classic merge |
| fra | `d'ou` → `d'où` | always wrong in French |
| fra | `5 *'il` → `S'il`, `s 'il(s)` → `s'il(s)`, `I'a` → `l'a`, `t' a…` → `t'a…` | 5/S, spaced apostrophes, I/l |
| fra | `5O5` → `SOS` | **narrowed**: letter O only — the contributed rule also matched the number 505 |
| fra | mère/père, très, Là | in `RegularExpressionsIfSpelledCorrectly` — double-gated by the dictionary |
| spa | `iihrer` → `ührer`; `niñal`→`niña!`, `túl`→`tú!` | ü and !-as-l |
| nld | `''n/''t` → `'n/'t`; `wanner`→`wanneer` | doubled apostrophe, non-word |

## Deliberately not adopted

- **Style rules**: imperative "Stop." → "Stop!" (60+ rules), `'n` → `een` rewrites, music-symbol removal, `…`→`...`, a.m./degree spacing — not OCR errors.
- **Rules that corrupt legitimate text**: `he cause`→`because` (matches "did he cause"), `solucionario`→`solucionarlo` (real word), `Neel`→`Nee!` (a name), `gebeurd hier`→`gebeurt` (can be valid word order), `EI`→`El` (real Spanish usage, e.g. "EI" as acronym), `5O5` with `[O0]` (number 505), accepted spellings facade/voila/deja vu, `\bAil\b`→All ("ail" is a word), `and 1`→`and I` (digits are legit).
- **Buggy rules** in the contributed files: doubled `${3}`, a replacement inserting a literal `$[`, a `\r?n` typo.

XML well-formed, all regexes compile, 132 OCR tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)