### PR TITLE
Three grid-render micro-optimizations: live spell check, row brushes

### DIFF
--- a/src/libuilogic/SpellCheck/SpellChecker.cs
+++ b/src/libuilogic/SpellCheck/SpellChecker.cs
@@ -32,7 +32,9 @@ public class SpellChecker : ISpellChecker, IDoSpell
 
     private WordList? _hunspellWeCantSpell;
     protected SpellCheckWordLists? WordLists;
-    protected readonly HashSet<string> SkipAllList = new();
+    // Case-insensitive so per-word membership tests need no ToUpperInvariant allocation -
+    // IsWordCorrect runs per word per grid cell repaint with live spell check on.
+    protected readonly HashSet<string> SkipAllList = new(StringComparer.OrdinalIgnoreCase);
     protected readonly Dictionary<string, string> ChangeAllDictionary = new();
     private string _twoLetterLanguageCode = string.Empty;
 
@@ -305,8 +307,8 @@ public class SpellChecker : ISpellChecker, IDoSpell
     {
         var word = spellCheckWord.Text;
 
-        if (SkipAllList.Contains(word.ToUpperInvariant()) ||
-            (word.StartsWith('\'') || word.EndsWith('\'')) && SkipAllList.Contains(word.Trim('\'').ToUpperInvariant()))
+        if (SkipAllList.Contains(word) ||
+            (word.StartsWith('\'') || word.EndsWith('\'')) && SkipAllList.Contains(word.Trim('\'')))
         {
             NoOfSkippedWords++;
             return true;

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -305,15 +305,17 @@ public partial class SubtitleLineViewModel : ObservableObject
                 return _transparentBrush;
             }
 
-            // Avalonia re-evaluates this getter on every cell repaint; strip HTML once
-            // and reuse across all settings-enabled branches below.
+            // Avalonia re-evaluates this getter on every cell repaint; strip HTML and split
+            // into lines once and reuse across all settings-enabled branches below.
             string? stripped = null;
+            List<string>? strippedLines = null;
 
             if (Se.Settings.General.ColorTextTooLong)
             {
                 stripped = SubtitleTextInfoHelper.StripHtml(Text);
+                strippedLines = stripped.SplitToLines();
 
-                foreach (var line in stripped.SplitToLines())
+                foreach (var line in strippedLines)
                 {
                     if (SubtitleTextInfoHelper.GetLineLength(line) > Se.Settings.General.SubtitleLineMaximumLength)
                     {
@@ -325,7 +327,8 @@ public partial class SubtitleLineViewModel : ObservableObject
             if (Se.Settings.General.ColorTextTooWide)
             {
                 stripped ??= SubtitleTextInfoHelper.StripHtml(Text);
-                foreach (var line in stripped.SplitToLines())
+                strippedLines ??= stripped.SplitToLines();
+                foreach (var line in strippedLines)
                 {
                     if (CalculatePixelWidth(line) > Se.Settings.General.ColorTextTooWidePixels)
                     {
@@ -337,7 +340,8 @@ public partial class SubtitleLineViewModel : ObservableObject
             if (Se.Settings.General.ColorTextTooManyLines)
             {
                 stripped ??= SubtitleTextInfoHelper.StripHtml(Text);
-                if (stripped.SplitToLines().Count > Se.Settings.General.MaxNumberOfLines)
+                strippedLines ??= stripped.SplitToLines();
+                if (strippedLines.Count > Se.Settings.General.MaxNumberOfLines)
                 {
                     return _errorBrush;
                 }

--- a/src/ui/Features/SpellCheck/SpellCheckManager.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckManager.cs
@@ -127,8 +127,8 @@ public class SpellCheckManager : SpellChecker, ISpellCheckManager
         var word = spellCheckWord.Text;
         var text = p.Text;
 
-        if (SkipAllList.Contains(word.ToUpperInvariant()) ||
-            (word.StartsWith('\'') || word.EndsWith('\'')) && SkipAllList.Contains(word.Trim('\'').ToUpperInvariant()))
+        if (SkipAllList.Contains(word) ||
+            (word.StartsWith('\'') || word.EndsWith('\'')) && SkipAllList.Contains(word.Trim('\'')))
         {
             NoOfSkippedWords++;
             return true;

--- a/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia.Controls.Documents;
 using Avalonia.Data.Converters;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.SpellCheck;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -44,6 +45,18 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
     private static SolidColorBrush CharsBrush => GetBrush(SubtitleSyntaxTokenizer.CharsColor);
     private static SolidColorBrush ValuesBrush => GetBrush(SubtitleSyntaxTokenizer.ValuesColor);
     private static SolidColorBrush StyleBrush => GetBrush(SubtitleSyntaxTokenizer.StyleColor);
+
+    // One shared wavy-red underline for all misspelled words - a brush + decoration +
+    // collection used to be allocated per misspelled word on every cell repaint.
+    private static readonly TextDecoration MisspelledDecoration = new()
+    {
+        Location = TextDecorationLocation.Underline,
+        Stroke = new ImmutableSolidColorBrush(Colors.Red),
+        StrokeThickness = 1.5,
+        StrokeLineCap = PenLineCap.Round,
+    };
+
+    private static readonly TextDecorationCollection MisspelledDecorations = new() { MisspelledDecoration };
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
@@ -118,10 +131,13 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                     continue;
                 }
 
-                // First pass: check if there are any misspelled words in this run
-                var hasMisspelledWords = false;
-                foreach (var word in words)
+                // Single spell-check pass: remember each word's verdict so the run-splitting
+                // below doesn't run IsSpecialPattern + the Hunspell lookup a second time per
+                // word - this converter runs per text cell on every grid repaint.
+                bool[]? misspelled = null;
+                for (var wordIndex = 0; wordIndex < words.Count; wordIndex++)
                 {
+                    var word = words[wordIndex];
                     if (string.IsNullOrWhiteSpace(word.Text) || word.Length < 2)
                     {
                         continue;
@@ -129,13 +145,13 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
 
                     if (!IsSpecialPattern(word, runText) && !_spellCheckManager.IsWordCorrect(word, runText))
                     {
-                        hasMisspelledWords = true;
-                        break;
+                        misspelled ??= new bool[words.Count];
+                        misspelled[wordIndex] = true;
                     }
                 }
 
                 // If no misspelled words, keep the run as-is to preserve color inheritance
-                if (!hasMisspelledWords)
+                if (misspelled == null)
                 {
                     newInlines.Add(run);
                     continue;
@@ -143,8 +159,9 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
 
                 // Second pass: break up the run and add underlines to misspelled words
                 var lastIndex = 0;
-                foreach (var word in words)
+                for (var wordIndex = 0; wordIndex < words.Count; wordIndex++)
                 {
+                    var word = words[wordIndex];
                     if (string.IsNullOrWhiteSpace(word.Text) || word.Length < 2)
                     {
                         continue;
@@ -158,34 +175,22 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                         newInlines.Add(beforeRun);
                     }
 
-                    // Check if word is misspelled and not a special pattern
-                    var isMisspelled = !IsSpecialPattern(word, runText) && !_spellCheckManager.IsWordCorrect(word, runText);
-
                     // Create run for the word
                     var wordRun = CreateRunFromTemplate(run, word.Text);
-                    if (isMisspelled)
+                    if (misspelled[wordIndex])
                     {
-                        // Apply wavy red underline for misspelled words
-                        var wavyUnderline = new TextDecoration
-                        {
-                            Location = TextDecorationLocation.Underline,
-                            Stroke = new SolidColorBrush(Colors.Red),
-                            StrokeThickness = 1.5,
-                            StrokeLineCap = PenLineCap.Round
-                        };
-
-                        // Add to existing decorations instead of replacing them
+                        // Apply the shared wavy red underline - add to existing decorations
+                        // instead of replacing them
                         if (wordRun.TextDecorations == null || wordRun.TextDecorations.Count == 0)
                         {
-                            wordRun.TextDecorations = new TextDecorationCollection { wavyUnderline };
+                            wordRun.TextDecorations = MisspelledDecorations;
                         }
                         else
                         {
-                            var decorations = new List<TextDecoration>(wordRun.TextDecorations)
+                            wordRun.TextDecorations = new TextDecorationCollection(wordRun.TextDecorations)
                             {
-                                wavyUnderline
+                                MisspelledDecoration
                             };
-                            wordRun.TextDecorations = new TextDecorationCollection(decorations);
                         }
                     }
 
@@ -253,8 +258,18 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
 
     private static bool IsSpecialPattern(SpellCheckWord word, string text)
     {
-        // Skip numbers
-        if (word.Text.All(c => char.IsDigit(c) || c == '.' || c == ',' || c == '-'))
+        // Skip numbers - plain loop, this runs per word per cell repaint (no LINQ enumerator)
+        var isNumber = true;
+        foreach (var c in word.Text)
+        {
+            if (!char.IsDigit(c) && c != '.' && c != ',' && c != '-')
+            {
+                isNumber = false;
+                break;
+            }
+        }
+
+        if (isNumber)
         {
             return true;
         }


### PR DESCRIPTION
Follow-up to the libse round (#12642) — three micro-optimizations on the subtitle grid's hottest render paths, benchmarked against the **real classes** (a `SpellCheckManager` with the en_US dictionary, the actual converter and view model).

## BenchmarkDotNet (ShortRun, .NET 10, Apple M4)

| Benchmark | Before | After | Δ |
|---|---|---|---|
| Grid text cell, line with misspellings | 16,451 ns / 34.0 KB | 9,628 ns / 23.4 KB | **1.7× faster, −31% alloc** |
| Grid text cell, correct line | 4,407 ns / 6.7 KB | 3,881 ns / 6.3 KB | ~12% faster |
| `TextBackgroundBrush` getter | 4,093 ns / 4,968 B | ~same (noise) / 4,440 B | **−11% alloc** |
| `IsWordCorrect` skip-list hit | 77.1 ns / 304 B | 71.9 ns / 264 B | ~7% faster |

## Changes

1. **Live spell check converter** (`TextWithSubtitleSyntaxHighlightingConverter`): ran `IsSpecialPattern` + the Hunspell lookup **twice per word** (a has-errors probe pass, then the run-splitting pass re-checked everything), and allocated a `SolidColorBrush` + `TextDecoration` + collection **per misspelled word per repaint**. Now: single pass with remembered verdicts, one shared static decoration (`ImmutableSolidColorBrush`, same pattern the tokenizer brushes already use), and the numeric check without a LINQ closure. Side effect: the manager's skip/correct counters are no longer double-counted by grid renders.
2. **`SubtitleLineViewModel.TextBackgroundBrush`**: the stripped text was `SplitToLines()`'d up to three times across the too-long/too-wide/too-many-lines branches; split once and reuse.
3. **`SkipAllList` case-insensitivity** (`SpellChecker` + `SpellCheckManager`): membership tests upper-cased every word — one string allocation per word per repaint. The set now uses `StringComparer.OrdinalIgnoreCase` with direct lookups. Semantics identical: `AddIgnoreWord` always stored the uppercase variant, so reads were already effectively case-insensitive; the add/remove variant loops collapse into harmless no-ops.

## Testing

- 713 UI + 14 libuilogic tests pass; build clean.
- Converter output verified structurally identical (same runs, same decoration properties) — only allocation identity changes (shared immutable decoration instance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)