### PR TITLE
Memoize CPS/WPM per subtitle row across grid repaint reads

### DIFF
--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -260,6 +260,20 @@ public partial class SubtitleLineViewModel : ObservableObject
         }
     }
 
+    // Read-time memo for CPS/WPM: each value is read by its own column binding AND by the
+    // Cps/Wpm/Duration background brushes during the same row repaint, and every computation
+    // strips html tags and walks the text. Keyed on the exact inputs, so any Text or time
+    // change simply recomputes on the next read - no invalidation wiring to get wrong.
+    private string? _cpsCacheText;
+    private TimeSpan _cpsCacheStart;
+    private TimeSpan _cpsCacheEnd;
+    private double _cpsCacheValue;
+
+    private string? _wpmCacheText;
+    private TimeSpan _wpmCacheStart;
+    private TimeSpan _wpmCacheEnd;
+    private double _wpmCacheValue;
+
     public double CharactersPerSecond
     {
         get
@@ -274,7 +288,15 @@ public partial class SubtitleLineViewModel : ObservableObject
                 return 999.0;
             }
 
-            return SubtitleTextInfoHelper.GetCharactersPerSecond(Text, StartTime, EndTime);
+            if (!ReferenceEquals(_cpsCacheText, Text) || _cpsCacheStart != StartTime || _cpsCacheEnd != EndTime)
+            {
+                _cpsCacheText = Text;
+                _cpsCacheStart = StartTime;
+                _cpsCacheEnd = EndTime;
+                _cpsCacheValue = SubtitleTextInfoHelper.GetCharactersPerSecond(Text, StartTime, EndTime);
+            }
+
+            return _cpsCacheValue;
         }
     }
 
@@ -292,7 +314,15 @@ public partial class SubtitleLineViewModel : ObservableObject
                 return 999.0;
             }
 
-            return 60.0 / Duration.TotalSeconds * Text.CountWords();
+            if (!ReferenceEquals(_wpmCacheText, Text) || _wpmCacheStart != StartTime || _wpmCacheEnd != EndTime)
+            {
+                _wpmCacheText = Text;
+                _wpmCacheStart = StartTime;
+                _wpmCacheEnd = EndTime;
+                _wpmCacheValue = 60.0 / Duration.TotalSeconds * Text.CountWords();
+            }
+
+            return _wpmCacheValue;
         }
     }
 


### PR DESCRIPTION
Follow-up to #12653 — the last big per-row render cost in the subtitle grid.

`CharactersPerSecond` is read by its own column binding **and** by the CPS/Duration background brushes during the same row repaint (`DurationBackgroundBrush` falls back to the CPS check when the CPS column is hidden); `WordsPerMinute` likewise by its column and brush. Every read stripped HTML tags and walked the text again.

Each value is now cached keyed on its exact inputs — `Text` (reference), `StartTime`, `EndTime` — checked at read time, so any change simply recomputes on the next read. No invalidation wiring to get wrong.

## BenchmarkDotNet (ShortRun, .NET 10, Apple M4)

One row repaint = CPS + WPM + the three dependent brush getters on the real view model:

| Scenario | Before | After | Δ |
|---|---|---|---|
| Unchanged text (scrolling steady state) | 565.6 ns / 760 B | **13.6 ns / 0 B** | **42× faster, allocation-free** |
| Text changed before every repaint (typing) | 581.2 ns / 908 B | 240.8 ns / 464 B | **2.4× faster** |

All 713 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)