### PR TITLE
Remember position/size for fix-list tool windows

### DIFF
--- a/src/ui/Features/Edit/ModifySelection/ModifySelectionWindow.cs
+++ b/src/ui/Features/Edit/ModifySelection/ModifySelectionWindow.cs
@@ -66,6 +66,9 @@ public class ModifySelectionWindow : Window
             }
         };
         KeyDown += vm.KeyDown;
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private static Border MakeRulesView(ModifySelectionViewModel vm, out TextBox textBoxRuleText)

--- a/src/ui/Features/Files/Compare/CompareWindow.cs
+++ b/src/ui/Features/Files/Compare/CompareWindow.cs
@@ -147,6 +147,9 @@ public class CompareWindow : Window
             vm.LeftDataGrid.SelectionChanged += vm.LeftDataGridSelectionChanged;
             vm.RightDataGrid.SelectionChanged += vm.RightDataGridSelectionChanged;
         }
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private Control MakeSubtitlesView(ObservableCollection<CompareItem> leftSubtitles, string v, object fileGridOnDragOverLeft, object fileGridOnDropLeft)

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
@@ -104,6 +104,9 @@ public class ExportImageBasedWindow : Window
         KeyUp += (_, e) => vm.OnKeyUp(e);
         Loaded += (_, e) => vm.OnLoaded();
         Closing += (_, e) => vm.OnClosing();
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private Border MakeSubtitlesView(ExportImageBasedViewModel vm)

--- a/src/ui/Features/Files/Statistics/StatisticsWindow.cs
+++ b/src/ui/Features/Files/Statistics/StatisticsWindow.cs
@@ -91,5 +91,8 @@ public class StatisticsWindow : Window
 
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
         KeyDown += vm.KeyDown;
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 }

--- a/src/ui/Features/Options/WordLists/WordListsWindow.cs
+++ b/src/ui/Features/Options/WordLists/WordListsWindow.cs
@@ -73,6 +73,9 @@ public class WordListsWindow : Window
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
         Closing += (s, e) => _vm.Closing();
         Loaded += (s, e) => vm.Loaded();
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     // Panel header with the list's icon on a colored rounded square plus a count badge in the

--- a/src/ui/Features/Shared/SourceView/SourceViewWindow.cs
+++ b/src/ui/Features/Shared/SourceView/SourceViewWindow.cs
@@ -79,5 +79,8 @@ public class SourceViewWindow : Window
 
         Opened += delegate { Avalonia.Threading.Dispatcher.UIThread.Post(vm.FocusEditor); };
         KeyDown += (_, e) => vm.OnKeyDown(e);
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 }

--- a/src/ui/Features/SpellCheck/FindDoubleLines/FindDoubleLinesWindow.cs
+++ b/src/ui/Features/SpellCheck/FindDoubleLines/FindDoubleLinesWindow.cs
@@ -53,6 +53,9 @@ public class FindDoubleLinesWindow : Window
         Activated += delegate { buttonCancel.Focus(); }; // hack to make OnKeyDown work
 
         KeyDown += (s, e) => vm.OnKeyDown(e);
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private static Border MakeGridView(FindDoubleLinesViewModel vm)

--- a/src/ui/Features/SpellCheck/FindDoubleWords/FindDoubleWordsWindow.cs
+++ b/src/ui/Features/SpellCheck/FindDoubleWords/FindDoubleWordsWindow.cs
@@ -54,6 +54,9 @@ public class FindDoubleWordsWindow : Window
         Activated += delegate { buttonCancel.Focus(); }; // hack to make OnKeyDown work
 
         KeyDown += (s, e) => vm.OnKeyDown(e);
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private static Border MakeGridView(FindDoubleWordsViewModel vm)

--- a/src/ui/Features/Ssa/SsaStylesWindow.cs
+++ b/src/ui/Features/Ssa/SsaStylesWindow.cs
@@ -64,6 +64,9 @@ public class SsaStylesWindow : Window
 
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
         KeyDown += vm.KeyDown;
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private static Grid MakeLeftView(SsaStylesViewModel vm)

--- a/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsWindow.cs
+++ b/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsWindow.cs
@@ -63,6 +63,9 @@ public class ApplyDurationLimitsWindow : Window
 
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
         KeyDown += vm.KeyDown;
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private static Grid MakeControlsView(ApplyDurationLimitsViewModel vm)

--- a/src/ui/Features/Tools/ApplyMinGap/ApplyMinGapWindow.cs
+++ b/src/ui/Features/Tools/ApplyMinGap/ApplyMinGapWindow.cs
@@ -66,6 +66,9 @@ public class ApplyMinGapWindow : Window
 
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
         KeyDown += (_, e) => vm.OnKeyDown(e);
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private static Border MakeSubtitleView(ApplyMinGapViewModel vm)

--- a/src/ui/Features/Tools/BridgeGaps/BridgeGapsWindow.cs
+++ b/src/ui/Features/Tools/BridgeGaps/BridgeGapsWindow.cs
@@ -80,6 +80,9 @@ public class BridgeGapsWindow : Window
 
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
         KeyDown += (_, e) => vm.OnKeyDown(e);
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private Border MakeSubtitleView(BridgeGapsViewModel vm)

--- a/src/ui/Features/Tools/ChangeCasing/FixNamesWindow.cs
+++ b/src/ui/Features/Tools/ChangeCasing/FixNamesWindow.cs
@@ -103,6 +103,9 @@ public class FixNamesWindow : Window
         grid.Add(panelButtonsBottom, row, 0);
 
         Content = grid;
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private static Border MakeNamesView(FixNamesViewModel vm)

--- a/src/ui/Features/Tools/ChangeFormatting/ChangeFormattingWindow.cs
+++ b/src/ui/Features/Tools/ChangeFormatting/ChangeFormattingWindow.cs
@@ -80,6 +80,9 @@ public class ChangeFormattingWindow : Window
 
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
         KeyDown += (_, e) => vm.OnKeyDown(e);
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private static Border MakeSubtitleView(ChangeFormattingViewModel vm)

--- a/src/ui/Features/Tools/ConvertActors/ConvertActorsWindow.cs
+++ b/src/ui/Features/Tools/ConvertActors/ConvertActorsWindow.cs
@@ -132,6 +132,9 @@ public class ConvertActorsWindow : Window
 
         Activated += delegate { buttonOk.Focus(); };
         KeyDown += (_, e) => vm.OnKeyDown(e);
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private static Border MakeSubtitleView(ConvertActorsViewModel vm)

--- a/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsWindow.cs
@@ -86,6 +86,9 @@ public class FixNetflixErrorsWindow : Window
         Content = grid;
 
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private static Border MakeSettingsView(FixNetflixErrorsViewModel vm)

--- a/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
+++ b/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
@@ -62,6 +62,9 @@ public class MergeContinuationLinesWindow : Window
         KeyDown += vm.KeyDown;
         Loaded += delegate { vm.Loaded(); };
         Closed += delegate { vm.OnClosed(); };
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private static Grid MakeControlsView(MergeContinuationLinesViewModel vm)

--- a/src/ui/Features/Tools/MergeShortLines/MergeShortLinesWindow.cs
+++ b/src/ui/Features/Tools/MergeShortLines/MergeShortLinesWindow.cs
@@ -55,6 +55,9 @@ public class MergeShortLinesWindow : Window
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
         KeyDown += vm.KeyDown;
         Loaded += delegate { vm.Loaded(); };
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private static Grid MakeControlsView(MergeShortLinesViewModel vm)

--- a/src/ui/Features/Tools/MergeSubtitlesWithSameText/MergeSameTextWindow.cs
+++ b/src/ui/Features/Tools/MergeSubtitlesWithSameText/MergeSameTextWindow.cs
@@ -62,6 +62,9 @@ public class MergeSameTextWindow : Window
 
         Activated += delegate { buttonCancel.Focus(); }; // hack to make OnKeyDown work
         KeyDown += vm.OnKeyDown;
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private static StackPanel MakeControlsView(MergeSameTextViewModel vm)

--- a/src/ui/Features/Tools/MergeSubtitlesWithSameTimeCodes/MergeSameTimeCodesWindow.cs
+++ b/src/ui/Features/Tools/MergeSubtitlesWithSameTimeCodes/MergeSameTimeCodesWindow.cs
@@ -66,6 +66,9 @@ public class MergeSameTimeCodesWindow : Window
 
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
         KeyDown += _vm.OnKeyDown;
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private static StackPanel MakeControlsView(MergeSameTimeCodesViewModel vm)

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
@@ -77,6 +77,9 @@ public class RemoveTextForHearingImpairedWindow : Window
         Content = grid;
 
         Activated += delegate { (vm.IsApplyVisible ? buttonDone : buttonOk).Focus(); }; // hack to make OnKeyDown work
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private StackPanel MakeSettingsView(RemoveTextForHearingImpairedViewModel vm)

--- a/src/ui/Features/Tools/SortBy/SortByWindow.cs
+++ b/src/ui/Features/Tools/SortBy/SortByWindow.cs
@@ -63,6 +63,9 @@ public class SortByWindow : Window
 
         Loaded += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
         KeyDown += (_, e) => vm.OnKeyDown(e);
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private Grid MakeSortControls(SortByViewModel vm)

--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesWindow.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesWindow.cs
@@ -58,6 +58,9 @@ public class SplitBreakLongLinesWindow : Window
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
         KeyDown += vm.KeyDown;
         Loaded += (_, _)  => vm.Loaded();
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private static Grid MakeControlsView(SplitBreakLongLinesViewModel vm)

--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -170,6 +170,16 @@ public class BurnInWindow : Window
         KeyDown += (_, e) => vm.OnKeyDown(e);
 
         Opened += (_, _) => LockMinimumToContentSize();
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+
+        // LockMinimumToContentSize sets Width/Height from a callback posted at Loaded priority, so
+        // restoring in a plain Loaded handler would be overwritten. Post at Background (which runs
+        // after Loaded) so the saved size wins, clamped by the content minimum set just before.
+        Loaded += delegate
+        {
+            Dispatcher.UIThread.Post(() => UiUtil.RestoreWindowPosition(this), DispatcherPriority.Background);
+        };
     }
 
     private void LockMinimumToContentSize()


### PR DESCRIPTION
Fixes #12657

The "Remove text for hearing impaired" window never wired up the position hooks that other dialogs (Fix common errors, Multiple replace, Settings) use, so it always reopened at the default 910x640 and lost the maximized state — both within a session and across restarts. SE4 remembered it.

```csharp
Closing += delegate { UiUtil.SaveWindowPosition(this); };
Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
```

`UiUtil.RestoreWindowPosition` already handles the maximized/fullscreen cases and honors `Se.Settings.General.RememberPositionAndSize`; `UiUtil.InitializeWindow(this, GetType().Name)` already sets the `Name` used as the settings key, so no other changes were needed.

## Second commit: the rest of the family

Checking the wider codebase, this was not a one-off — 43 windows had the hooks and 75 resizable ones did not. The second commit adds them to every window built the same way as the one in the issue (resizable, DataGrid-of-fixes, the kind users maximize):

Apply duration limits · Apply minimum gap · Bridge gaps · Change casing/fix names · Change formatting · Convert actors · Fix Netflix errors · Merge continuation lines · Merge short lines · Merge same text · Merge same time codes · Sort by · Split/break long lines · Find double lines · Find double words · Modify selection · Compare · SSA styles

All 18 already call `UiUtil.InitializeWindow` and none use `SizeToContent`, so the same two lines are sufficient. Remaining unconverted windows are mostly small `Pick*` choosers where a remembered size is low value.

Note: the settings key is `GetType().Name`, so a window reused in two contexts (e.g. RTHI from the menu vs. from Batch convert) shares one saved entry.

Build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Third commit

Statistics, Word lists, Source view, Export image based — same two lines.

Burn-in needed different handling: it uses `SizeToContent` and re-fits itself via `LockMinimumToContentSize`, which sets `Width`/`Height` from a callback posted at `Loaded` priority. A plain `Loaded` handler would be overwritten, so the restore is posted at `Background` priority (which runs after `Loaded`), clamped by the content minimum set just before.
