### PR TITLE
Burn-in: log the ffmpeg command line, and never let ffmpeg wait on stdin

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -313,7 +313,9 @@ public partial class BurnInViewModel : ObservableObject
         {
             var percentage = (int)Math.Round((double)_processedFrames / JobItems[_jobItemIndex].TotalFrames * 100.0,
                 MidpointRounding.AwayFromZero);
-            percentage = Math.Clamp(percentage, 0, 100);
+            // Cap at 99 while ffmpeg is still running: the frame total can be underestimated
+            // (VFR sources), and "100%" that never finishes reads as a hang in bug reports.
+            percentage = Math.Clamp(percentage, 0, 99);
 
             var durationMs = (DateTime.UtcNow.Ticks - _startTicks) / 10_000;
             var msPerFrame = (float)durationMs / _processedFrames;
@@ -345,11 +347,7 @@ public partial class BurnInViewModel : ObservableObject
             }
 
             _ffmpegProcess = process;
-#pragma warning disable CA1416 // Validate platform compatibility
-            _ffmpegProcess.Start();
-#pragma warning restore CA1416 // Validate platform compatibility
-            _ffmpegProcess.BeginOutputReadLine();
-            _ffmpegProcess.BeginErrorReadLine();
+            StartFfmpegProcess(process, "two-pass encode (pass 2)");
 
             _timerGenerate.Start();
         });
@@ -377,7 +375,9 @@ public partial class BurnInViewModel : ObservableObject
         {
             var percentage = (int)Math.Round((double)_processedFrames / JobItems[_jobItemIndex].TotalFrames * 100.0,
                 MidpointRounding.AwayFromZero);
-            percentage = Math.Clamp(percentage, 0, 100);
+            // Cap at 99 while ffmpeg is still running: the frame total can be underestimated
+            // (VFR sources), and "100%" that never finishes reads as a hang in bug reports.
+            percentage = Math.Clamp(percentage, 0, 99);
 
             var durationMs = (DateTime.UtcNow.Ticks - _startTicks) / 10_000;
             var msPerFrame = (float)durationMs / _processedFrames;
@@ -402,6 +402,7 @@ public partial class BurnInViewModel : ObservableObject
         ProgressText = string.Empty;
 
         var jobItem = JobItems[_jobItemIndex];
+        Se.WriteToolsLog($"Burn-in ffmpeg finished with exit code {_ffmpegProcess.ExitCode} for \"{jobItem.OutputVideoFileName}\"");
 
         if (!File.Exists(jobItem.OutputVideoFileName))
         {
@@ -564,11 +565,7 @@ public partial class BurnInViewModel : ObservableObject
         }
 
         _ffmpegProcess = process;
-#pragma warning disable CA1416 // Validate platform compatibility
-        _ffmpegProcess.Start();
-#pragma warning restore CA1416 // Validate platform compatibility
-        _ffmpegProcess.BeginOutputReadLine();
-        _ffmpegProcess.BeginErrorReadLine();
+        StartFfmpegProcess(process, "two-pass analyze (pass 1)");
         _startTicks = DateTime.UtcNow.Ticks;
 
         return true;
@@ -666,11 +663,7 @@ public partial class BurnInViewModel : ObservableObject
         }
 
         _ffmpegProcess = process;
-#pragma warning disable CA1416 // Validate platform compatibility
-        _ffmpegProcess.Start();
-#pragma warning restore CA1416 // Validate platform compatibility
-        _ffmpegProcess.BeginOutputReadLine();
-        _ffmpegProcess.BeginErrorReadLine();
+        StartFfmpegProcess(process, "encode");
 
         return true;
     }
@@ -748,6 +741,21 @@ public partial class BurnInViewModel : ObservableObject
 
         var workingDirectory = Path.GetDirectoryName(jobItem.AssaSubtitleFileName) ?? string.Empty;
         return FfmpegGenerator.GetProcess(ffmpegParameters, OutputHandler, workingDirectory);
+    }
+
+    /// <summary>
+    /// Starts an ffmpeg pass with its full command line written to the tools log. Burn-in hangs
+    /// and failures were undiagnosable from user reports: the command was only logged on the
+    /// missing-output-file path, and a wedged ffmpeg logged nothing at all.
+    /// </summary>
+    private void StartFfmpegProcess(Process process, string stage)
+    {
+        Se.WriteToolsLog($"Burn-in {stage}: \"{process.StartInfo.FileName}\" {process.StartInfo.Arguments}");
+#pragma warning disable CA1416 // Validate platform compatibility
+        process.Start();
+#pragma warning restore CA1416 // Validate platform compatibility
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
     }
 
     private void OutputHandler(object sendingProcess, DataReceivedEventArgs outLine)

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -1004,6 +1004,14 @@ public class FfmpegGenerator
 
         processMakeVideo.StartInfo.Arguments = processMakeVideo.StartInfo.Arguments.Trim();
 
+        // Never let ffmpeg wait on a console prompt: stdin is inherited (not redirected), so an
+        // interactive question - e.g. "File exists. Overwrite? [y/N]" when user-edited custom
+        // parameters lack -y - blocks forever with the UI stuck at the last progress value.
+        if (!processMakeVideo.StartInfo.Arguments.Contains("-nostdin"))
+        {
+            processMakeVideo.StartInfo.Arguments = "-nostdin " + processMakeVideo.StartInfo.Arguments;
+        }
+
         SetupDataReceiveHandler(dataReceivedHandler, processMakeVideo);
 
         return processMakeVideo;
@@ -1026,6 +1034,14 @@ public class FfmpegGenerator
         };
 
         processMakeVideo.StartInfo.Arguments = processMakeVideo.StartInfo.Arguments.Trim();
+
+        // Never let ffmpeg wait on a console prompt: stdin is inherited (not redirected), so an
+        // interactive question - e.g. "File exists. Overwrite? [y/N]" when user-edited custom
+        // parameters lack -y - blocks forever with the UI stuck at the last progress value.
+        if (!processMakeVideo.StartInfo.Arguments.Contains("-nostdin"))
+        {
+            processMakeVideo.StartInfo.Arguments = "-nostdin " + processMakeVideo.StartInfo.Arguments;
+        }
 
         SetupDataReceiveHandler(dataReceivedHandler, processMakeVideo);
 


### PR DESCRIPTION
Prompted by a user report of burn-in encoding "staying at 100% endlessly". That state was **undiagnosable**: the ffmpeg command line was only written to the tools log on the missing-output-file path, so a wedged ffmpeg logged nothing at all.

## Changes

1. **Log the command line on start** for each burn-in pass (one-pass encode, two-pass analyze, two-pass encode) and the **exit code on finish** — the first thing needed from any "stuck"/"failed" report.
2. **`-nostdin` in `FfmpegGenerator.GetProcess`** (both overloads, so all video tools benefit): stdin is inherited rather than redirected, so any interactive ffmpeg question — most plausibly `File exists. Overwrite? [y/N]` when user-edited **custom parameters** lack `-y` — blocks forever with the UI frozen at its last progress value. This is my leading theory for the report: the burn-in window lets users edit the ffmpeg parameters ("Prompt for ffmpeg parameters and generate"), and a hand-edited command without `-y` hangs exactly this way.
3. **Cap the displayed percentage at 99 while running**: the frame total can be underestimated (VFR sources), so encoding that is still progressing can sit at "100%" and read as a hang.

## Testing

- Build clean; all 713 UI tests pass.
- `-nostdin` is prepended only when not already present, and applies to the shared process factory used by burn-in, cut, re-encode, transparent subtitles, embedded subtitles, shot changes and video OCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)