### PR TITLE
Time code box: reject non-ASCII digits and consume full IME commits

### DIFF
--- a/src/ui/Controls/TimeCodeUpDown.cs
+++ b/src/ui/Controls/TimeCodeUpDown.cs
@@ -254,50 +254,61 @@ namespace Nikse.SubtitleEdit.Controls
                 return;
             }
 
-            var c = e.Text[0];
-            if (!char.IsDigit(c))
-            {
-                e.Handled = true;
-                return;
-            }
-
             var caret = _textBox.CaretIndex;
+            var chars = _textBuffer.ToCharArray();
+            var changed = false;
 
-            // Skip separators (colons, commas, dots)
-            while (caret < _textBuffer.Length && IsSeparator(_textBuffer[caret]))
+            // An IME commit (or an X11 compose sequence) can deliver several characters in one
+            // event, so consume the whole string instead of only the first character.
+            foreach (var c in e.Text)
             {
+                // The mask holds ASCII digits only. char.IsDigit() also accepts full-width and
+                // Arabic-Indic digits, which every ParseTime() branch then fails to parse - that
+                // silently reset the time code to zero - so match the ASCII range explicitly.
+                if (c is < '0' or > '9')
+                {
+                    continue;
+                }
+
+                // Skip separators (colons, commas, dots)
+                while (caret < chars.Length && IsSeparator(chars[caret]))
+                {
+                    caret++;
+                }
+
+                if (caret >= chars.Length)
+                {
+                    break;
+                }
+
+                // Overwrite character at current position
+                chars[caret] = c;
+                changed = true;
+
+                // Move to next editable position
                 caret++;
+                while (caret < chars.Length && IsSeparator(chars[caret]))
+                {
+                    caret++;
+                }
             }
 
-            if (caret >= _textBuffer.Length)
+            e.Handled = true;
+
+            if (!changed)
             {
-                e.Handled = true;
                 return;
             }
 
-            // Overwrite character at current position
-            var chars = _textBuffer.ToCharArray();
-            chars[caret] = c;
             _textBuffer = new string(chars);
-
             _textBox.Text = _textBuffer;
-
-            // Move to next editable position
-            var nextPos = caret + 1;
-            while (nextPos < _textBuffer.Length && IsSeparator(_textBuffer[nextPos]))
-            {
-                nextPos++;
-            }
-
-            _textBox.CaretIndex = Math.Min(nextPos, _textBuffer.Length);
+            _textBox.CaretIndex = Math.Min(caret, _textBuffer.Length);
 
             // Update the bound value
             var newValue = ParseTime(_textBuffer);
             _isUpdatingFromValue = true;
             SetValue(ValueProperty, newValue);
             _isUpdatingFromValue = false;
-
-            e.Handled = true;
         }
 
         // The text box is masked and edits character-by-character via OnTextInput, but paste bypasses


### PR DESCRIPTION
## Problem

`TimeCodeUpDown.OnTextInput` gated input on `char.IsDigit(c)`, which accepts far more than ASCII:

```
U+FF11 '１'  IsDigit=True   ASCII range=False
U+0663 '٣'   IsDigit=True   ASCII range=False
U+0966 '०'   IsDigit=True   ASCII range=False
int.TryParse("１２") = False
TimeSpan.TryParseExact("００:00:00:000", @"hh\:mm\:ss\:fff") = False
```

So those characters were written straight into the mask buffer — but every branch of `ParseTime` then fails to parse them (`TimeSpan.TryParseExact`, and `int.TryParse` on each part) and falls through to `return TimeSpan.Zero`.

Net effect: typing a single digit into a start/end time **silently resets the time code to 00:00:00,000**, while the corrupted character stays visible in the box. Reachable from a CJK IME in full-width mode, or an Arabic keyboard layout (SE ships an Arabic localization).

Separately, only `e.Text[0]` was consumed. An IME commit or an X11 compose sequence can deliver several characters in one event, and everything after the first was silently dropped.

## Fix

1. Match the ASCII range explicitly (`c is < '0' or > '9'`) so non-ASCII digits are rejected at input instead of corrupting the buffer downstream.
2. Loop over the whole of `e.Text`, so a multi-character commit fills consecutive mask positions.

The value is committed once after the loop, and `Handled = true` is still set unconditionally — the control's take-over-entirely behaviour is unchanged.

## Verification

Build clean. The mask-edit algorithm was exercised standalone across 11 cases, all passing:

| case | input | result |
|---|---|---|
| single digit at 0 | `1`@0 | `10:00:00:000` |
| digit lands on separator | `5`@2 | `00:50:00:000` |
| multi-char IME commit | `123`@0 | `12:30:00:000` |
| full-width digit rejected | `１`@0 | unchanged |
| Arabic-Indic rejected | `٣`@0 | unchanged |
| Devanagari rejected | `०`@0 | unchanged |
| letter rejected | `a`@0 | unchanged |
| mixed ASCII/full-width | `1１2`@0 | `12:00:00:000` |
| caret at end, no-op | `9`@12 | unchanged |
| overflow past end stops | `999`@10 | `00:00:00:099` |
| fills whole mask | `123456789012`@0 | `12:34:56:789` |

The resulting buffer parses as a valid time code in every case.

Found while investigating #12334 (Linux dead keys). That issue itself is an upstream Avalonia X11 limitation and is **not** addressed here — this is an independent bug noticed along the way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)