### PR TITLE
Remember position/size for ASSA styles/attachments windows

### DIFF
--- a/src/ui/Features/Assa/AssaAttachmentsWindow.cs
+++ b/src/ui/Features/Assa/AssaAttachmentsWindow.cs
@@ -71,6 +71,9 @@ public class AssaAttachmentsWindow : Window
 
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
         KeyDown += vm.KeyDown;
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private static Border MakeLeftView(AssaAttachmentsViewModel vm)

--- a/src/ui/Features/Assa/AssaStylesWindow.cs
+++ b/src/ui/Features/Assa/AssaStylesWindow.cs
@@ -63,6 +63,9 @@ public class AssaStylesWindow : Window
 
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
         KeyDown += vm.KeyDown;
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private static Grid MakeLeftView(AssaStylesViewModel vm)

--- a/src/ui/Features/Ssa/SsaAttachmentsWindow.cs
+++ b/src/ui/Features/Ssa/SsaAttachmentsWindow.cs
@@ -71,6 +71,9 @@ public class SsaAttachmentsWindow : Window
 
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
         KeyDown += vm.KeyDown;
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     private static Border MakeLeftView(SsaAttachmentsViewModel vm)


### PR DESCRIPTION
Follow-up to #12657, reported by @Davanix after RC10: the "Advanced Sub Station Alpha styles" and "Advanced Sub Station Alpha attachments" windows still open at their default size and lose the maximized state.

Same root cause as the original bug — window position persistence is opt-in per dialog, and these windows never wired up the hooks:

```csharp
Closing += delegate { UiUtil.SaveWindowPosition(this); };
Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
```

`UiUtil.SaveWindowPosition` keys off `window.Name`, which `UiUtil.InitializeWindow(this, GetType().Name)` already sets in all of these — the hooks were the only missing piece.

Of the four sibling windows (ASSA/SSA × styles/attachments), only `SsaStylesWindow` had them, which is why plain "Sub Station Alpha styles" behaved while the ASSA one did not. Fixed the other three:

- `AssaStylesWindow` — reported
- `AssaAttachmentsWindow` — reported
- `SsaAttachmentsWindow` — not reported, same defect, included for consistency

## Testing

`dotnet build src/ui/UI.csproj` succeeds, 0 warnings/errors. Not verified at runtime — that needs maximizing each window in the running app and reopening it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)