### PR TITLE
Fix light title bar in non-modal windows on dark theme

### DIFF
--- a/src/ui/Logic/WindowsService.cs
+++ b/src/ui/Logic/WindowsService.cs
@@ -87,11 +87,16 @@ namespace Nikse.SubtitleEdit.Logic
             var window = CreateWindow<T>();
 
             configure?.Invoke(window);
-            window.Show();
-            window.Focus();
 
+            // Must run before Show(): ApplyScaleToWindow sets the Windows dark-mode title bar, and
+            // DWM does not repaint the caption once the window is on screen - it only picks up the
+            // change on the next activation. Applying afterwards leaves a light title bar until the
+            // window loses and regains focus. (#12665)
             ApplyRightToLeftSettings(window);
             UiTheme.ApplyScaleToWindow(window);
+
+            window.Show();
+            window.Focus();
 
             return window;
         }
@@ -114,11 +119,13 @@ namespace Nikse.SubtitleEdit.Logic
             configureViewModel?.Invoke(window, viewModel);
 
             window.WindowStartupLocation = WindowStartupLocation.CenterOwner; //TODO: does this work on mac?
-            window.Show(owner);
-            window.Focus();
 
+            // Must run before Show() - see the note in ShowWindow<T>. (#12665)
             ApplyRightToLeftSettings(window);
             UiTheme.ApplyScaleToWindow(window);
+
+            window.Show(owner);
+            window.Focus();
 
             return viewModel;
         }
@@ -139,11 +146,12 @@ namespace Nikse.SubtitleEdit.Logic
             var window = (T)w;
             configureViewModel?.Invoke(window, viewModel);
 
-            window.Show();
-            window.Focus();
-
+            // Must run before Show() - see the note in ShowWindow<T>. (#12665)
             ApplyRightToLeftSettings(window);
             UiTheme.ApplyScaleToWindow(window);
+
+            window.Show();
+            window.Focus();
 
             return viewModel;
         }


### PR DESCRIPTION
Fixes #12665, reported by @Surlime.

## Root cause

Windows dark mode for the OS-drawn title bar goes through `UiTheme.ApplyScaleToWindow` → `ApplyTitleBarTheme` → `DwmSetWindowAttribute`. DWM does **not** repaint the caption when the attribute changes after the window is already mapped — it only picks it up on the next activation change. That is exactly the "fixes itself when the window loses and regains focus" in the report.

The modal and non-modal paths in `WindowsService` did this in opposite orders:

| Path | Order | Result |
|---|---|---|
| `ShowDialogAsync` | apply **then** `ShowDialog` | handle not created yet → deferred to `Opened` → dark caption from first paint ✅ |
| `ShowWindow` / `ShowIndependentWindow` | `Show()` **then** apply | handle exists → applied post-show → light caption until refocus ❌ |

This is why the reporter only saw it on non-modal pop-ups.

## Fix

Move `ApplyRightToLeftSettings` + `UiTheme.ApplyScaleToWindow` above `Show()` in all three non-modal methods, matching the modal path. No new code — a reordering plus a comment explaining why the ordering is load-bearing, since that is presumably how the two paths drifted apart.

Also fixes the same inconsistency for right-to-left layouts, which was being applied post-show on those paths too.

## Affected windows

Reported: Adjust all times, Find, Find next (reuses the Find window), Replace — all via `ShowWindow<T, TViewModel>`.

Not reported but same defect: `PleaseWaitWindow`, `GeneratingAudioWindow` (short-lived, less noticeable), and the undocked audio visualizer / video player via `ShowIndependentWindow` (long-lived, likely visible).

The other `ApplyScaleToWindow` call sites (`Program.cs`, `MainWindowFactory`, `MessageBox`) already run pre-show and are unchanged.

## Testing

`dotnet build src/ui/UI.csproj` succeeds, 0 warnings/errors.

⚠️ **Not verified at runtime** — this is Windows-only DWM behavior and I am on macOS. Needs a check on Windows 11 with the dark theme before merging: open Find / Replace / Adjust all times and confirm the title bar is dark on first paint, and that the undocked video player and audio visualizer are too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)