### PR TITLE
Leave the configured gap when extending lines to a shot change

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7423,54 +7423,44 @@ public partial class MainViewModel :
             return;
         }
 
+        var gapMs = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
+        var maxDurationMs = Se.Settings.General.SubtitleMaximumDisplayMilliseconds;
         foreach (var line in selectedLines)
         {
             var idx = Subtitles.IndexOf(line);
             var next = Subtitles.GetOrNull(idx + 1);
-            var shotChange = AudioVisualizer.ShotChanges.FirstOrDefault(s => s > line.EndTime.TotalSeconds - 0.01);
-            if (next == null && shotChange == 0)
+
+            // Leave the configured "out cues" gap before the shot change (Beautify time codes
+            // profile, two frames by default) - same as SE 4.x. Without it the line ends exactly
+            // on the shot change frame.
+            var candidateEndMs = ShotChangesHelper.GetNextShotChangeMinusGapInMs(
+                AudioVisualizer.ShotChanges,
+                new TimeCode(line.EndTime.TotalMilliseconds));
+
+            // Upper bound for the new end: the next shot change and, if present, the next
+            // subtitle's start minus the configured gap. Whichever is earlier wins so we never
+            // push the end past either constraint.
+            if (next != null)
+            {
+                var nextStartMinusGapMs = next.StartTime.TotalMilliseconds - gapMs;
+                candidateEndMs = candidateEndMs.HasValue
+                    ? Math.Min(candidateEndMs.Value, nextStartMinusGapMs)
+                    : nextStartMinusGapMs;
+            }
+
+            if (candidateEndMs == null)
             {
                 continue;
             }
 
-            if (shotChange == 0)
+            var newEndMs = candidateEndMs.Value;
+            var newDurationMs = newEndMs - line.StartTime.TotalMilliseconds;
+            if (newDurationMs <= 0 || newDurationMs > maxDurationMs)
             {
-                var newDuration = next!.StartTime - line.StartTime;
-                if (newDuration.TotalMilliseconds <= Se.Settings.General.SubtitleMaximumDisplayMilliseconds)
-                {
-                    line.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
-                }
-
                 continue;
             }
 
-            if (next == null)
-            {
-                var newDuration = TimeSpan.FromSeconds(shotChange) - line.StartTime;
-                if (newDuration.TotalMilliseconds <= Se.Settings.General.SubtitleMaximumDisplayMilliseconds)
-                {
-                    line.EndTime = TimeSpan.FromSeconds(shotChange);
-                }
-
-                continue;
-            }
-
-            if (TimeSpan.FromSeconds(shotChange) < next.StartTime)
-            {
-                var newDuration = TimeSpan.FromSeconds(shotChange) - line.StartTime;
-                if (newDuration.TotalMilliseconds <= Se.Settings.General.SubtitleMaximumDisplayMilliseconds)
-                {
-                    line.EndTime = TimeSpan.FromSeconds(shotChange);
-                }
-            }
-            else
-            {
-                var newDuration = next.StartTime - line.StartTime;
-                if (newDuration.TotalMilliseconds <= Se.Settings.General.SubtitleMaximumDisplayMilliseconds)
-                {
-                    line.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
-                }
-            }
+            line.EndTime = TimeSpan.FromMilliseconds(newEndMs);
         }
 
         _updateAudioVisualizer = true;
@@ -7593,7 +7583,13 @@ public partial class MainViewModel :
             // present, the previous subtitle's end plus the configured gap.
             // Whichever is later wins so we never pull the start back past
             // either constraint.
-            double? candidateStartMs = shotChange.HasValue ? shotChange.Value * 1000.0 : null;
+            //
+            // The shot change gets the configured "in cues" gap (Beautify time
+            // codes profile, two frames by default) so the line starts after the
+            // shot change rather than exactly on it - same as SE 4.x.
+            double? candidateStartMs = shotChange.HasValue
+                ? shotChange.Value * 1000.0 + TimeCodesBeautifierUtils.GetInCuesGapMs()
+                : null;
             if (prev != null)
             {
                 var prevEndPlusGapMs = prev.EndTime.TotalMilliseconds + gapMs;


### PR DESCRIPTION
Reported by @torvchen in discussion #11744 ([comment](https://github.com/SubtitleEdit/subtitleedit/discussions/11744#discussioncomment-17700794)):

> the shortcut "Extend selected lines to next shot change (or subtitle)" no longer leaves the configured two-frame gap before the shot change. Even though "Beautify Time Codes" is set up to leave a two-frame gap, the shortcut extends all the way to the edge. (In SE4, it correctly left the two-frame gap before the shot change).

## Root cause

`ExtendSelectedLinesToNextShotChangeOrNextSubtitle` picked the raw shot change and assigned it verbatim, never consulting the Beautify time codes profile. Same in `ExtendSelectedLinesToPreviousShotChange`.

The tell is inside the same method: the "extend to next **subtitle**" branch *did* subtract a gap (`MinimumBetweenLines`) — only the shot-change branch subtracted nothing.

SE 4.x applied the gap through `ShotChangeHelper.GetNextShotChangeMinusGapInMs` / `GetPreviousShotChangePlusGapInMs` (see `b9ee584b4:src/ui/Forms/Main.cs:20147` and `:20199`). The SE5 port reimplemented the lookup inline and dropped the gap — and the SE5 copies of those helpers in `src/ui/Logic/Media/ShotChangesHelper.cs` had **no callers anywhere in `src/ui`**, which is what pinned this down. The settings plumbing was fine the whole time; nothing was reading it.

## Changes

**Next shot change** now goes through `GetNextShotChangeMinusGapInMs` (applies `OutCuesGap`), and takes the earlier of that and `next.StartTime - MinimumBetweenLines` — matching SE4's `Math.Min` over two gap-adjusted candidates.

This also fixes a second latent bug: the old if/else tree compared an **un-gapped** shot change against `next.StartTime` when choosing which bound to use, so it could pick the wrong one. The old code additionally treated `shotChange == 0` as "no shot change found", conflating a real shot change at t=0 — the nullable helper does not.

**Previous shot change** keeps its existing strict "shot change strictly before the current start" lookup — that strictness is deliberate (there is a comment explaining it prevents "extend to previous" from moving the start *forward*), so I did not swap it for the helper's tolerance-based lookup. It just adds `InCuesGap`. Slightly asymmetric with the next-direction change, but preserving the earlier fix seemed more important than symmetry.

## Testing

`dotnet build src/ui/UI.csproj` succeeds, 0 warnings/errors.

⚠️ **Not verified at runtime.** The changed code is in `MainViewModel` and is not unit-testable without significant scaffolding, and there is no existing test coverage for shot-change extension. Worth a manual check: load a video with shot changes, set the Beautify time codes profile to a 2-frame gap, and confirm the extend shortcuts now stop two frames short of the shot change in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)