### PR TITLE
Stop menus and flyouts from leaving shortcuts dead

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -207,6 +207,9 @@ public class AudioVisualizer : Control
     // Reads the user setting directly (like SnapToFrames) so the "Snap to shot changes"
     // checkbox actually takes effect, and does so live without re-wiring at every call site.
     public bool SnapToShotChanges => Se.Settings.Waveform.SnapToShotChanges;
+    // Defaults to true for the dialogs that host a waveform without touching this (visual sync,
+    // point sync, cut video) - there, hovering focuses so the waveform takes keys right away.
+    // The main window and the TTS review window assign it from Se.Settings.Waveform instead.
     public bool FocusOnMouseOver { get; set; } = true;
     public int WaveformHeightPercentage { get; set; } = 50;
     public Color WaveformFancyHighColor { get; set; } = Colors.Orange;

--- a/src/ui/Features/Main/Layout/InitWaveform.cs
+++ b/src/ui/Features/Main/Layout/InitWaveform.cs
@@ -112,11 +112,6 @@ public class InitWaveform
             vm.AudioVisualizer.OnGenerateWaveformRequested += vm.AudioVisualizerOnGenerateWaveformRequested;
 
             vm.AudioVisualizer.FlyoutMenuOpening += vm.AudioVisualizerFlyoutMenuOpening;
-
-            // The waveform's context flyout is created once and reused, so when it closes its
-            // menu items can keep keyboard focus while detached from the visual tree - which
-            // leaves every shortcut dead until the user clicks something (#11744).
-            vm.AudioVisualizer.MenuFlyout.Closed += (_, _) => vm.RestoreFocusIfLost();
         }
         else
         {
@@ -321,6 +316,12 @@ public class InitWaveform
                 Command = vm.WaveformShowWaveformAndSpectrogramCommand,
             }.BindIsVisible(vm, nameof(vm.ShowWaveformWaveformAndSpectrogram));
             flyout.Items.Add(showWaveformAndSpectrogramMenuItem);
+
+            // The flyout is reused across openings, so its menu items can keep keyboard focus
+            // after it closes while being detached from the visual tree - which leaves every
+            // shortcut dead until the user clicks something (#11744). Hooked here rather than
+            // on the control's initial flyout, which this replaces on every layout rebuild.
+            flyout.Closed += (_, _) => vm.RestoreFocusIfLost();
 
             vm.AudioVisualizer.MenuFlyout = flyout;
         }

--- a/src/ui/Features/Main/Layout/InitWaveform.cs
+++ b/src/ui/Features/Main/Layout/InitWaveform.cs
@@ -112,6 +112,11 @@ public class InitWaveform
             vm.AudioVisualizer.OnGenerateWaveformRequested += vm.AudioVisualizerOnGenerateWaveformRequested;
 
             vm.AudioVisualizer.FlyoutMenuOpening += vm.AudioVisualizerFlyoutMenuOpening;
+
+            // The waveform's context flyout is created once and reused, so when it closes its
+            // menu items can keep keyboard focus while detached from the visual tree - which
+            // leaves every shortcut dead until the user clicks something (#11744).
+            vm.AudioVisualizer.MenuFlyout.Closed += (_, _) => vm.RestoreFocusIfLost();
         }
         else
         {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14748,24 +14748,26 @@ public partial class MainViewModel :
         _shortcutManager.ClearKeys();
         if (usedOwner == Window)
         {
-            RestoreFocusAfterDialogClose();
+            RestoreFocusIfLost();
         }
 
         return result;
     }
 
     /// <summary>
-    /// After a modal dialog closes, Avalonia restores keyboard focus to the owner's previously
-    /// focused element - but when that element is gone (e.g. a menu item in a since-closed
-    /// popup when the dialog was launched from the menu bar), the restore silently fails and
-    /// focus lands on the bare Window. Key events then route only to the Window - never through
-    /// MainView, where the shortcut KeyDown handler lives - so every shortcut (Ctrl+F, Ctrl+H,
-    /// ...) goes dead until the user clicks a control (#12634). Fall back to the subtitle grid,
-    /// like the menu-bar deactivation restore does. Deferred so a flow-specific focus set by
-    /// the dialog's caller afterwards wins; skipped while another (follow-up) dialog is active -
-    /// its own wrapper call runs the same restore when it closes.
+    /// Puts keyboard focus back on the subtitle grid when a closing dialog, menu or context
+    /// flyout left it nowhere useful.
+    ///
+    /// Avalonia restores focus to the previously focused element, but when that element is gone
+    /// (e.g. a menu item in a since-closed popup) the restore silently fails and focus lands on
+    /// the bare Window - or stays on the detached MenuItem itself. Key events then never route
+    /// through MainView, where the shortcut KeyDown handler lives, so every shortcut goes dead
+    /// until the user clicks a control (#12634, #11744).
+    ///
+    /// Deferred so a flow-specific focus set by the caller afterwards wins; skipped while another
+    /// (follow-up) dialog is active - its own wrapper call runs the same restore when it closes.
     /// </summary>
-    private void RestoreFocusAfterDialogClose()
+    internal void RestoreFocusIfLost()
     {
         Dispatcher.UIThread.Post(() =>
         {
@@ -14775,9 +14777,12 @@ public partial class MainViewModel :
             }
 
             var focused = Window.FocusManager?.GetFocusedElement();
-            if (focused is Control control && control != Window)
+
+            // GetTopLevel is null for a control that has been detached from the visual tree,
+            // which is how a closed popup's menu item looks while still holding focus.
+            if (focused is Control control && control != Window && TopLevel.GetTopLevel(control) != null)
             {
-                return; // focus survived inside a real control - leave it be
+                return; // focus survived inside a real, on-screen control - leave it be
             }
 
             SubtitleGrid?.Focus();
@@ -20143,9 +20148,12 @@ public partial class MainViewModel :
 
         // A focused MenuItem belongs to a menu/flyout being navigated; let it keep the keys.
         // (Drop-down items are hosted in a popup, so a visual-parent walk to Menu would miss them.)
-        if (focusedElement is MenuItem)
+        // Only while it is actually on screen though: when a menu or context flyout closes, its
+        // items are detached from the visual tree but can remain the focused element - and a stale
+        // MenuItem here would swallow every shortcut until the user clicked something (#11744).
+        if (focusedElement is MenuItem menuItem)
         {
-            return true;
+            return TopLevel.GetTopLevel(menuItem) != null;
         }
 
         if (ReferenceEquals(focusedElement, Menu))

--- a/src/ui/Logic/Config/SeWaveform.cs
+++ b/src/ui/Logic/Config/SeWaveform.cs
@@ -126,6 +126,12 @@ public class SeWaveform
         SpectrogramStyle = nameof(SeSpectrogramStyle.Classic);
         LastDisplayMode = nameof(WaveformDisplayMode.OnlyWaveform);
         WaveformDrawStyle = Controls.AudioVisualizerControl.WaveformDrawStyle.Fancy.ToString();
+        // Off by default: focus-follows-mouse on the main waveform would steal keyboard focus
+        // while the user is typing in the edit box. Stated explicitly because the control's own
+        // property defaults to true for the dialogs that do not read this setting - for the main
+        // window and the TTS review window, this value is the one that wins.
+        FocusOnMouseOver = false;
+
         RightClickSelectsSubtitle = true;
         SingleClickAction = WaveformSingleClickActionType.SetVideoPositionAndPauseAndSelectSubtitle.ToString();
         DoubleClickAction = nameof(WaveformDoubleClickActionType.None);

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -678,7 +678,10 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.WaveformHorizontalZoomOutCommand, nameof(vm.WaveformHorizontalZoomOutCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.WaveformVerticalZoomInCommand, nameof(vm.WaveformVerticalZoomInCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.WaveformVerticalZoomOutCommand, nameof(vm.WaveformVerticalZoomOutCommand), ShortcutCategory.Waveform);
-        AddShortcut(shortcuts, vm.ToggleShotChangesAtVideoPositionCommand, nameof(vm.ToggleShotChangesAtVideoPositionCommand), ShortcutCategory.Waveform);
+        // General, not Waveform: it acts on the video position, not on anything the waveform has
+        // selected, and every other shot change command is General too. As a Waveform shortcut it
+        // only fired while the waveform had keyboard focus, which it often never gets (#11744).
+        AddShortcut(shortcuts, vm.ToggleShotChangesAtVideoPositionCommand, nameof(vm.ToggleShotChangesAtVideoPositionCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.ShowWaveformSeekSilenceCommand, nameof(vm.ShowWaveformSeekSilenceCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.SeekSilenceBackCommand, nameof(vm.SeekSilenceBackCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.SeekSilenceForwardCommand, nameof(vm.SeekSilenceForwardCommand), ShortcutCategory.Waveform);


### PR DESCRIPTION
Reported by @torvchen in discussion #11744 ([comment](https://github.com/SubtitleEdit/subtitleedit/discussions/11744#discussioncomment-17700794)):

> there are more shortcuts that randomly stop responding [...] Toggle play/pause, Video one frame back/forward, Go to previous/next shot change [...] Also, "Toggle shot changes at video position" doesn't always respond without first clicking on the waveform.

## Root cause

The main shortcut `KeyDown` handler is registered on **`MainView`** (`MainView.cs:121`), a `UserControl` — not the `Window`. A routed key event only reaches it when `MainView` is an ancestor of the focused element. If focus lands anywhere else, *every* shortcut is silently dead. All five shortcuts the reporter lists are `ShortcutCategory.General` and need no particular focus, so their dying points at the route, not the commands.

PR #12635 already fixed one instance of this (focus landing on the bare `Window` after a dialog closes). This covers two more paths into the same failure, plus one unrelated-but-adjacent bug.

## Changes

**1. Stale `MenuItem` swallowing shortcuts.** `IsMainMenuFocused()` returned `true` for *any* focused `MenuItem`, and it is checked before dispatch — so a menu or context flyout that closed while keeping focus on its now-detached item killed every shortcut until the user clicked something. It now only counts a `MenuItem` still attached to a top level.

**2. Waveform context flyout.** The waveform's `MenuFlyout` is created once in the constructor and reused (`AudioVisualizer.cs:434`), so its items can hold focus after closing. Its `Closed` event now runs the same focus restore used after dialogs. `RestoreFocusAfterDialogClose` is renamed `RestoreFocusIfLost` since it is no longer dialog-specific, and it now treats a *detached* control as lost focus too — previously it saw a stale `MenuItem`, decided "focus survived inside a real control", and left it.

**3. "Toggle shot changes at video position" needing waveform focus.** This was the only shot-change command registered as `ShortcutCategory.Waveform`, so it only fired while `AudioVisualizer.IsFocused`. The waveform self-focuses only on pointer *enter*, gated on `FocusOnMouseOver` — which is declared at `SeWaveform.cs:57` and never assigned in the constructor, so it **defaults to `false`**. Out of the box the waveform often never gets focus and this shortcut silently did nothing. It reads the video position and does not touch the waveform selection, so it is now `General` like every other shot-change command.

No migration is needed for (3): `ShortCut` takes its `Control` from the registered category (`Shortcut.cs:103`), not from the persisted `SeShortCut.ControlName`, so existing saved key bindings pick up the new category immediately.

**4. Documentation only: waveform focus-on-mouse-over defaults.** `SeWaveform.FocusOnMouseOver` was the only bool left to the CLR default in a constructor whose neighbours spell theirs out even when `false`, while `AudioVisualizer.FocusOnMouseOver` defaults to the opposite — so which default applied where was easy to misread (I misread it myself while investigating (3)). Both are now stated with a comment.

No behaviour change: the setting was already `false`, and the control keeps its `true` default for the dialogs that host a waveform without reading the setting — visual sync, point sync and cut video, 8 of the 10 construction sites. Aligning the control's default to `false` would have silently changed hover behaviour in all of them, so it is deliberately left alone.

## Not addressed

The reporter's **Alt+drag** trigger is not fixed here. The best-fitting hypothesis is that the waveform's unconditional `e.Handled = true` on pointer press (`AudioVisualizer.cs:933`) stops Avalonia's `AccessKeyHandler` cancelling its pending Alt-up, so releasing Alt activates the menu bar and `IsMainMenuFocused()` swallows everything. Change (1) does **not** cover that — during real menu-bar activation the item is legitimately attached.

I could not verify it: it depends on Avalonia internals plus Windows Alt handling, and I am on macOS. Changing `AudioVisualizer`'s pointer handling on an untested hypothesis seemed worse than leaving it, so that wants a repro on Windows first. Two other candidates for the same symptom, also untouched: a stale entry in `ShortcutManager._activeKeys` when a KeyUp is missed (poisons every lookup for up to 5s), and the waveform having no `PointerCaptureLost` handling.

## Testing

`dotnet build src/ui/UI.csproj` succeeds, 0 warnings/errors.

⚠️ **Not verified at runtime** — this is focus behavior in the running app and I have no way to drive it here. Worth checking on Windows: open and close the waveform context menu, then confirm play/pause and frame step still work; and confirm Ctrl+Alt+A toggles a shot change without clicking the waveform first. Change (1) touches the shortcut gate that #11745 added for screen-reader menu navigation, so menu keyboard navigation is worth a regression check too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
