### PR TITLE
Change casing - fix names: refactor name finding, speed up preview

### DIFF
--- a/src/libse/Common/StrippableText.cs
+++ b/src/libse/Common/StrippableText.cs
@@ -126,7 +126,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             return id;
         }
 
-        private void ReplaceNames1Remove(List<string> nameList, List<string> replaceIds, List<string> replaceNames, List<string> originalNames)
+        private void ReplaceNames1Remove(IEnumerable<string> nameList, List<string> replaceIds, List<string> replaceNames, List<string> originalNames)
         {
             if (Post.StartsWith('.'))
             {
@@ -186,7 +186,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
         }
 
-        private void ReplacAssaTagsRemove(List<string> nameList, List<string> replaceIds, List<string> replaceNames, List<string> originalNames)
+        private void ReplacAssaTagsRemove(List<string> replaceIds, List<string> replaceNames, List<string> originalNames)
         {
             int idName = 1000;
             var idx = 0;
@@ -221,13 +221,13 @@ namespace Nikse.SubtitleEdit.Core.Common
         }
 
         private static readonly char[] ExpectedCharsArray = { '.', '!', '?', ':', ';', ')', ']', '}', '(', '[', '{' };
-        public void FixCasing(List<string> nameList, bool changeNameCases, bool makeUppercaseAfterBreak, bool checkLastLine, string lastLine, double millisecondsFromLast = 0)
+        public void FixCasing(IEnumerable<string> nameList, bool changeNameCases, bool makeUppercaseAfterBreak, bool checkLastLine, string lastLine, double millisecondsFromLast = 0)
         {
             var replaceIds = new List<string>();
             var replaceNames = new List<string>();
             var originalNames = new List<string>();
             ReplaceNames1Remove(nameList, replaceIds, replaceNames, originalNames);
-            ReplacAssaTagsRemove(nameList, replaceIds, replaceNames, originalNames);
+            ReplacAssaTagsRemove(replaceIds, replaceNames, originalNames);
 
             if (checkLastLine && ShouldStartWithUpperCase(lastLine, millisecondsFromLast))
             {

--- a/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
+++ b/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
@@ -163,29 +163,39 @@ public partial class FixNamesViewModel : ObservableObject
     private void GeneratePreview()
     {
         var hits = new List<FixNameHitItem>();
+
+        // reusable array
+        var processingNames = new string[1];
+
+        // filter out non-active name to avoid extra processing
+        var activeNameItems = Names.Where(n => n.IsChecked).ToArray();
+        
         foreach (var p in _subtitle.Paragraphs)
         {
             var text = p.Text;
-            foreach (var item in Names)
+            foreach (var item in activeNameItems)
             {
-                var name = item.Name;
+                // no extra processing if paragraph doesn't contain name
+                if (!text.Contains(item.Name, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
 
                 var textNoTags = HtmlUtil.RemoveHtmlTags(text, true);
+                
+                // has letter and not already uppercase
                 if (textNoTags != textNoTags.ToUpperInvariant())
                 {
-                    if (item.IsChecked && text != null && text.Contains(name, StringComparison.OrdinalIgnoreCase) && name.Length > 1 && name != name.ToLowerInvariant())
-                    {
-                        var st = new StrippableText(text);
-                        st.FixCasing(new List<string> { name }, true, false, false, string.Empty);
-                        text = st.MergedString;
-                    }
+                    var st = new StrippableText(text);
+                    processingNames[0] = item.Name;
+                    st.FixCasing(processingNames, true, false, false, string.Empty);
+                    text = st.MergedString;
                 }
             }
 
-            if (text != p.Text && p.Text != null && text != null)
+            if (text != p.Text)
             {
-                var hit = new FixNameHitItem(p.Text, p.Number, p.Text, text, true);
-                hits.Add(hit);
+                hits.Add(new FixNameHitItem(p.Text, p.Number, p.Text, text, true));
             }
         }
 

--- a/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
+++ b/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
@@ -35,7 +35,8 @@ public partial class FixNamesViewModel : ObservableObject
     private NameList? _nameList;
     private List<string> _nameListInclMulti;
     private string _language;
-    private const string ExpectedEndChars = " ,.!?:;…')]<-\"\r\n";
+    private const string PrefixChars = "([ --'>\r\n¿¡\"”“„";
+    private const string SuffixChars = " ,.!?:;…')]<-\"\r\n";
     private readonly HashSet<string> _usedNames;
     private string _oldNames;
     private readonly System.Timers.Timer _previewTimer;
@@ -92,7 +93,6 @@ public partial class FixNamesViewModel : ObservableObject
     private void FindAllNames()
     {
         var text = HtmlUtil.RemoveHtmlTags(_subtitle.GetAllTexts());
-        var textToLower = text.ToLowerInvariant();
 
         _nameListInclMulti = _nameList!.GetAllNames(); // Will contains both one word names and multi names
         foreach (var s in ExtraNames.Split(','))
@@ -106,69 +106,58 @@ public partial class FixNamesViewModel : ObservableObject
 
         _usedNames.Clear();
         var names = new List<FixNameItem>();
+
+        string[] commonWords = ["US", "Lane", "Bill", "Rose"];
+        const string english = "en";
+        const string dont = "don't";
+
         foreach (var name in _nameListInclMulti)
         {
-            var startIndex = textToLower.IndexOf(name.ToLowerInvariant(), StringComparison.Ordinal);
-            if (startIndex >= 0)
+            var startIndex = text.IndexOf(name, StringComparison.OrdinalIgnoreCase);
+
+            // filter out invalid names
+            if (name.Length <= 1 || name == name.ToLowerInvariant())
             {
-                while (startIndex >= 0 && startIndex < text.Length &&
-                       textToLower.Substring(startIndex).Contains(name.ToLowerInvariant()) && name.Length > 1 && name != name.ToLowerInvariant())
+                continue;
+            }
+
+            while (startIndex >= 0)
+            {
+                if (IsWordBoundary(text, startIndex, name) && !text.AsSpan().Slice(startIndex, name.Length).Equals(name, StringComparison.Ordinal)) // do not add names where casing already is correct
                 {
-                    var startOk = startIndex == 0 || "([ --'>\r\n¿¡\"”“„".Contains(text[startIndex - 1]);
-                    if (startOk)
+                    if (!_usedNames.Contains(name))
                     {
-                        var end = startIndex + name.Length;
-                        var endOk = end <= text.Length;
-                        if (endOk)
+                        bool skip = false;
+                        var isChecked = true;
+                        if (_language.StartsWith(english, StringComparison.OrdinalIgnoreCase))
                         {
-                            endOk = end == text.Length || ExpectedEndChars.Contains(text[end]);
+                            skip = text.AsSpan()[startIndex..].StartsWith(dont, StringComparison.OrdinalIgnoreCase);
+                            isChecked = !commonWords.Contains(name);
                         }
 
-                        if (endOk && text.Substring(startIndex, name.Length) != name) // do not add names where casing already is correct
+                        if (!skip)
                         {
-                            if (!_usedNames.Contains(name))
-                            {
-                                var skip = false;
-                                var isChecked = true;
-                                if (_language.StartsWith("en", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    var isDont = text.Substring(startIndex).StartsWith("don't", StringComparison.InvariantCultureIgnoreCase);
-                                    if (isDont)
-                                    {
-                                        skip = true;
-                                    }
-
-                                    var commonNamesAndWords = new List<string>
-                                    {
-                                        "US",
-                                        "Lane",
-                                        "Bill",
-                                        "Rose",
-                                    };
-                                    if (commonNamesAndWords.Contains(name))
-                                    {
-                                        isChecked = false;
-                                    }
-                                }
-
-                                if (!skip)
-                                {
-                                    _usedNames.Add(name);
-                                    names.Add(new FixNameItem(name, isChecked));
-                                    break; // break while
-                                }
-                            }
+                            _usedNames.Add(name);
+                            names.Add(new FixNameItem(name, isChecked));
+                            break; // break while
                         }
                     }
-
-                    startIndex = textToLower.IndexOf(name.ToLowerInvariant(), startIndex + 2, StringComparison.Ordinal);
                 }
+
+                startIndex = text.IndexOf(name, startIndex + name.Length, StringComparison.OrdinalIgnoreCase);
             }
         }
 
         Names.Clear();
         Names.AddRange(names);
-        NamesCount = string.Format("Names: {0:#,##0}", Names.Count);
+        NamesCount = $"Names: {Names.Count:#,##0}";
+    }
+
+    private bool IsWordBoundary(string text, int startIndex, string name)
+    {
+        var afterNameIndex = startIndex + name.Length;
+        return (startIndex == 0 || PrefixChars.Contains(text[startIndex - 1]))
+               && (afterNameIndex == text.Length || (afterNameIndex < text.Length && SuffixChars.Contains(text[afterNameIndex])));
     }
 
     private void GeneratePreview()
@@ -204,7 +193,7 @@ public partial class FixNamesViewModel : ObservableObject
         {
             Hits.Clear();
             Hits.AddRange(hits);
-            HitCount = string.Format("Hits: {0:#,##0}", Hits.Count);
+            HitCount = $"Hits: {Hits.Count:#,##0}";
         });
     }
 

--- a/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
+++ b/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
@@ -37,6 +37,7 @@ public partial class FixNamesViewModel : ObservableObject
     private string _language;
     private const string PrefixChars = "([ --'>\r\n¿¡\"”“„";
     private const string SuffixChars = " ,.!?:;…')]<-\"\r\n";
+    private static readonly string[] CommonWords = ["US", "Lane", "Bill", "Rose"];
     private readonly HashSet<string> _usedNames;
     private string _oldNames;
     private readonly System.Timers.Timer _previewTimer;
@@ -107,32 +108,30 @@ public partial class FixNamesViewModel : ObservableObject
         _usedNames.Clear();
         var names = new List<FixNameItem>();
 
-        string[] commonWords = ["US", "Lane", "Bill", "Rose"];
         const string english = "en";
         const string dont = "don't";
 
         foreach (var name in _nameListInclMulti)
         {
-            var startIndex = text.IndexOf(name, StringComparison.OrdinalIgnoreCase);
-
             // filter out invalid names
             if (name.Length <= 1 || name == name.ToLowerInvariant())
             {
                 continue;
             }
 
+            var startIndex = text.IndexOf(name, StringComparison.OrdinalIgnoreCase);
             while (startIndex >= 0)
             {
                 if (IsWordBoundary(text, startIndex, name) && !text.AsSpan().Slice(startIndex, name.Length).Equals(name, StringComparison.Ordinal)) // do not add names where casing already is correct
                 {
                     if (!_usedNames.Contains(name))
                     {
-                        bool skip = false;
+                        var skip = false;
                         var isChecked = true;
                         if (_language.StartsWith(english, StringComparison.OrdinalIgnoreCase))
                         {
                             skip = text.AsSpan()[startIndex..].StartsWith(dont, StringComparison.OrdinalIgnoreCase);
-                            isChecked = !commonWords.Contains(name);
+                            isChecked = !CommonWords.Contains(name);
                         }
 
                         if (!skip)
@@ -153,11 +152,11 @@ public partial class FixNamesViewModel : ObservableObject
         NamesCount = $"Names: {Names.Count:#,##0}";
     }
 
-    private bool IsWordBoundary(string text, int startIndex, string name)
+    private static bool IsWordBoundary(string text, int startIndex, string name)
     {
         var afterNameIndex = startIndex + name.Length;
         return (startIndex == 0 || PrefixChars.Contains(text[startIndex - 1]))
-               && (afterNameIndex == text.Length || (afterNameIndex < text.Length && SuffixChars.Contains(text[afterNameIndex])));
+               && (afterNameIndex == text.Length || SuffixChars.Contains(text[afterNameIndex]));
     }
 
     private void GeneratePreview()
@@ -169,7 +168,7 @@ public partial class FixNamesViewModel : ObservableObject
 
         // filter out non-active name to avoid extra processing
         var activeNameItems = Names.Where(n => n.IsChecked).ToArray();
-        
+
         foreach (var p in _subtitle.Paragraphs)
         {
             var text = p.Text;
@@ -182,7 +181,7 @@ public partial class FixNamesViewModel : ObservableObject
                 }
 
                 var textNoTags = HtmlUtil.RemoveHtmlTags(text, true);
-                
+
                 // has letter and not already uppercase
                 if (textNoTags != textNoTags.ToUpperInvariant())
                 {

--- a/tests/libse/Common/StrippableTextFixCasingTest.cs
+++ b/tests/libse/Common/StrippableTextFixCasingTest.cs
@@ -1,0 +1,210 @@
+using System.Collections;
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace LibSETests.Common;
+
+public class StrippableTextFixCasingTest
+{
+    private static string FixNames(string text, IEnumerable<string> names, bool changeNameCases = true)
+    {
+        var st = new StrippableText(text);
+        st.FixCasing(names, changeNameCases, false, false, string.Empty);
+        return st.MergedString;
+    }
+
+    [Fact]
+    public void FixCasing_FixesLowercaseName()
+    {
+        Assert.Equal("hello Bob", FixNames("hello bob", new List<string> { "Bob" }));
+    }
+
+    [Fact]
+    public void FixCasing_FixesNameAtStartOfText()
+    {
+        Assert.Equal("Bob went home", FixNames("bob went home", new List<string> { "Bob" }));
+    }
+
+    [Fact]
+    public void FixCasing_FixesNameFollowedByPunctuation()
+    {
+        Assert.Equal("Hi, Bob!", FixNames("Hi, bob!", new List<string> { "Bob" }));
+    }
+
+    [Fact]
+    public void FixCasing_FixesUppercaseNameToProperCase()
+    {
+        Assert.Equal("hello Bob", FixNames("hello BOB", new List<string> { "Bob" }));
+    }
+
+    [Fact]
+    public void FixCasing_LeavesOriginalCasingWhenChangeNameCasesIsFalse()
+    {
+        Assert.Equal("hello BOB", FixNames("hello BOB", new List<string> { "Bob" }, changeNameCases: false));
+    }
+
+    [Fact]
+    public void FixCasing_FixesMultipleNames()
+    {
+        Assert.Equal("hello Bob and Alice", FixNames("hello bob and alice", new List<string> { "Bob", "Alice" }));
+    }
+
+    [Fact]
+    public void FixCasing_DoesNotReplaceNameEmbeddedInsideAnotherWord()
+    {
+        // "bob" inside "bobsled" is not a whole word, so it must be left untouched.
+        Assert.Equal("the bobsled race", FixNames("the bobsled race", new List<string> { "Bob" }));
+    }
+
+    [Fact]
+    public void FixCasing_DoesNotTreatDontAsTheNameDon()
+    {
+        // English contraction "don't" must not be capitalised to "Don't" for the name "Don".
+        Assert.Equal("I don't know", FixNames("I don't know", new List<string> { "Don" }));
+    }
+
+    [Fact]
+    public void FixCasing_FixesDonWhenItReallyIsTheName()
+    {
+        Assert.Equal("Hi Don", FixNames("Hi don", new List<string> { "Don" }));
+    }
+
+    [Fact]
+    public void FixCasing_PreservesLeadingAssaTag()
+    {
+        // The {\an8} block is stripped into Pre and must survive verbatim.
+        Assert.Equal("{\\an8}Bob", FixNames("{\\an8}bob", new List<string> { "Bob" }));
+    }
+
+    [Fact]
+    public void FixCasing_PreservesInlineAssaTag()
+    {
+        // Inline ASSA override tags are protected while the name after them is fixed.
+        Assert.Equal("hello {\\i1} Bob", FixNames("hello {\\i1} bob", new List<string> { "Bob" }));
+    }
+
+    [Fact]
+    public void FixCasing_NoNamesLeavesTextUnchanged()
+    {
+        Assert.Equal("nothing to do here", FixNames("nothing to do here", new List<string>()));
+    }
+
+    [Theory]
+    [InlineData("bob", "Bob")]
+    [InlineData("hello bob", "hello Bob")]
+    [InlineData("\"bob\"", "\"Bob\"")]
+    [InlineData("(bob)", "(Bob)")]
+    [InlineData("bob, come here", "Bob, come here")]
+    public void FixCasing_HandlesWordBoundaries(string input, string expected)
+    {
+        Assert.Equal(expected, FixNames(input, new List<string> { "Bob" }));
+    }
+
+    [Fact]
+    public void FixCasing_CapitalizesAfterSentenceBreakWhenRequested()
+    {
+        var st = new StrippableText("hello. world");
+        st.FixCasing(new List<string>(), true, makeUppercaseAfterBreak: true, false, string.Empty);
+        Assert.Equal("hello. World", st.MergedString);
+    }
+
+    [Fact]
+    public void FixCasing_CapitalizesFirstLetterWhenPreviousLineWasClosed()
+    {
+        var st = new StrippableText("hello");
+        st.FixCasing(new List<string>(), true, false, checkLastLine: true, "Previous sentence.");
+        Assert.Equal("Hello", st.MergedString);
+    }
+
+    [Fact]
+    public void FixCasing_DoesNotCapitalizeFirstLetterWhenPreviousLineWasOpen()
+    {
+        var st = new StrippableText("hello");
+        st.FixCasing(new List<string>(), true, false, checkLastLine: true, "an unfinished line");
+        Assert.Equal("hello", st.MergedString);
+    }
+
+    // --- IEnumerable<string> signature change ---------------------------------
+
+    public static IEnumerable<object[]> EnumerableVariants()
+    {
+        yield return new object[] { new List<string> { "Bob", "Alice" } };
+        yield return new object[] { new[] { "Bob", "Alice" } };
+        yield return new object[] { new HashSet<string> { "Bob", "Alice" } };
+        yield return new object[] { new[] { "Bob", "Alice" }.Where(n => n.Length > 0) };
+        yield return new object[] { YieldNames("Bob", "Alice") };
+    }
+
+    [Theory]
+    [MemberData(nameof(EnumerableVariants))]
+    public void FixCasing_ProducesSameResultForAnyEnumerableType(IEnumerable<string> names)
+    {
+        Assert.Equal("hello Bob and Alice", FixNames("hello bob and alice", names));
+    }
+
+    [Fact]
+    public void FixCasing_EnumeratesNameListExactlyOnce()
+    {
+        var counting = new CountingEnumerable(new[] { "Bob" });
+        var st = new StrippableText("hello bob");
+        st.FixCasing(counting, true, false, false, string.Empty);
+
+        Assert.Equal("hello Bob", st.MergedString);
+        Assert.Equal(1, counting.EnumerationCount);
+    }
+
+    [Fact]
+    public void FixCasing_WorksWithSingleUseEnumerable()
+    {
+        // The refactor iterates the name list once; a source that can only be
+        // enumerated a single time must therefore not throw.
+        var singleUse = new SingleUseEnumerable(new[] { "Bob" });
+        var st = new StrippableText("hello bob");
+        st.FixCasing(singleUse, true, false, false, string.Empty);
+        Assert.Equal("hello Bob", st.MergedString);
+    }
+
+    private static IEnumerable<string> YieldNames(params string[] names)
+    {
+        foreach (var name in names)
+        {
+            yield return name;
+        }
+    }
+
+    private sealed class CountingEnumerable : IEnumerable<string>
+    {
+        private readonly IEnumerable<string> _inner;
+        public int EnumerationCount { get; private set; }
+
+        public CountingEnumerable(IEnumerable<string> inner) => _inner = inner;
+
+        public IEnumerator<string> GetEnumerator()
+        {
+            EnumerationCount++;
+            return _inner.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private sealed class SingleUseEnumerable : IEnumerable<string>
+    {
+        private readonly IEnumerable<string> _inner;
+        private bool _enumerated;
+
+        public SingleUseEnumerable(IEnumerable<string> inner) => _inner = inner;
+
+        public IEnumerator<string> GetEnumerator()
+        {
+            if (_enumerated)
+            {
+                throw new InvalidOperationException("This enumerable can only be enumerated once.");
+            }
+
+            _enumerated = true;
+            return _inner.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}


### PR DESCRIPTION
## Summary
- Refactor `FindAllNames()`: replace the lowercased text copy and repeated `Substring` allocations with a single case-insensitive `IndexOf` scan, and extract the boundary checks into an `IsWordBoundary` helper with `PrefixChars`/`SuffixChars` constants
- Skip invalid name-list entries (single character or all-lowercase) before searching
- Optimize `GeneratePreview()`: pre-filter to checked names only, skip paragraphs that don't contain the name, and reuse a single-element array for `FixCasing` calls
- Widen `StrippableText.FixCasing` to accept `IEnumerable<string>` and drop the unused name-list parameter from `ReplacAssaTagsRemove`

## Test plan
- [x] Open Tools > Change casing > Fix names on a subtitle with mis-cased names (e.g. "peter" in text, "Peter" in name list) — the name is listed and the preview shows the corrected casing
- [x] Correctly cased names are not listed
- [x] With an English subtitle, detected names are checked by default except the ambiguous words US, Lane, Bill, Rose
- [x] Occurrences inside "don't" are not suggested as fixes for the name "Don"
- [x] Toggling name checkboxes updates the hits preview, and applying only changes casing of checked names

🤖 Generated with [Claude Code](https://claude.com/claude-code)