### PR TITLE
Point sync: Home/End jumps to first/last line

### DIFF
--- a/src/ui/Features/Sync/PointSync/PointSyncWindow.cs
+++ b/src/ui/Features/Sync/PointSync/PointSyncWindow.cs
@@ -104,6 +104,7 @@ public class PointSyncWindow : Window
         };
 
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedSyncPoint)));
+        UiUtil.AttachHomeEndNavigation(dataGrid);
 
         var menuItemDelete = new MenuItem
         {
@@ -183,6 +184,7 @@ public class PointSyncWindow : Window
             },
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle)));
+        UiUtil.AttachHomeEndNavigation(dataGrid);
 
         return UiUtil.MakeBorderForControlNoPadding(dataGrid);
     }

--- a/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherWindow.cs
+++ b/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherWindow.cs
@@ -107,6 +107,7 @@ public class PointSyncViaOtherWindow : Window
             },
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedSyncPoint)));
+        UiUtil.AttachHomeEndNavigation(dataGrid);
 
         var menuItemDelete = new MenuItem
         {
@@ -209,6 +210,7 @@ public class PointSyncViaOtherWindow : Window
             },
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle)));
+        UiUtil.AttachHomeEndNavigation(dataGrid);
 
         grid.Add(panelHeader, 0);
         grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGrid), 1);
@@ -308,6 +310,7 @@ public class PointSyncViaOtherWindow : Window
             },
         };
         dataGridSubtitle.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedOtherSubtitle)));
+        UiUtil.AttachHomeEndNavigation(dataGridSubtitle);
 
         // Clicking a line in the left grid scrolls this grid to the matching time (#12529)
         // without touching its selection.

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -19,6 +19,7 @@ using Nikse.SubtitleEdit.Logic.ValueConverters;
 using Optris.Icons.Avalonia;
 using SkiaSharp;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -3108,5 +3109,36 @@ public static class UiUtil
                 e.Handled = true;
             }
         }, RoutingStrategies.Tunnel, handledEventsToo: true);
+    }
+
+    /// <summary>
+    /// Makes Home/End jump to the first/last row of <paramref name="dataGrid"/> and select it.
+    /// Avalonia's DataGrid only moves the cell cursor, which is why this is needed. Tunnel
+    /// phase so the grid's own navigation does not consume the key first.
+    /// </summary>
+    public static void AttachHomeEndNavigation(DataGrid dataGrid)
+    {
+        if (dataGrid == null)
+        {
+            return;
+        }
+
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key is not (Key.Home or Key.End) || e.Source is TextBox)
+            {
+                return;
+            }
+
+            if (dataGrid.ItemsSource is not IList items || items.Count == 0)
+            {
+                return;
+            }
+
+            var target = e.Key == Key.Home ? items[0] : items[^1];
+            dataGrid.SelectedItem = target;
+            dataGrid.ScrollIntoView(target, null);
+            e.Handled = true;
+        }, RoutingStrategies.Tunnel);
     }
 }


### PR DESCRIPTION
Reported on [discussion #11744](https://github.com/SubtitleEdit/subtitleedit/discussions/11744#discussioncomment-17701649): the point sync tool has no Home/End keyboard navigation, making it cumbersome to pick sync points near the end of a long subtitle.

## Changes

- New `UiUtil.AttachHomeEndNavigation(DataGrid)` — a shared version of the Home/End snippet already copy-pasted into ~30 windows, with an added `e.Source is TextBox` guard so it does not steal the keys from a cell being edited.
- Attached to all five grids in `PointSyncViaOtherWindow` (left / sync points / right) and `PointSyncWindow` (subtitles / sync points).

Shift+Home/End range selection is intentionally left out — these grids are `SelectionMode.Single`. `DataGridCheckboxMultiSelect` keeps its own richer version for multi-select grids.

Side benefit: the left grid's selection is bound to `SelectedSubtitle`, so Home/End there also scrolls the other grid to the matching time, per #12529.

## Not included

Migrating the ~30 inline copies to the new helper — unrelated churn for this fix, worth a separate pass.

The same discussion also asked for the right list to follow the left selection; that was already fixed in 0ae53806e (#12529) and ships in 5.1.

## Testing

Built clean. Ran the app and verified Home/End in the "Point sync via another subtitle" window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
