### PR TITLE
Add symbol presets to "Remove text for hearing impaired" fields (SE 4 parity)

### DIFF
--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
@@ -15,6 +15,11 @@ namespace Nikse.SubtitleEdit.Features.Tools.RemoveTextForHearingImpaired;
 
 public class RemoveTextForHearingImpairedWindow : Window
 {
+    // Same presets the SE 4 combo boxes offered - awkward characters to type, and they cover
+    // nearly every real use of these fields. All three fields stay free text.
+    private static readonly string[] SymbolPresets = ["¶", "♪", "♫"];
+    private static readonly string[] ContainsPresets = ["¶", "♪", "♫", "♪,♫"];
+
     private readonly RemoveTextForHearingImpairedViewModel _vm;
 
     public RemoveTextForHearingImpairedWindow(RemoveTextForHearingImpairedViewModel vm)
@@ -117,9 +122,9 @@ public class RemoveTextForHearingImpairedWindow : Window
         var comboBoxParentheses = UiUtil.MakeCheckBox(Se.Language.Tools.RemoveTextForHearingImpaired.Parentheses, vm, nameof(vm.IsRemoveParenthesesOn));
 
         var checkBoxCustom = UiUtil.MakeCheckBox(string.Empty, vm, nameof(vm.IsRemoveCustomOn));
-        var textBoxCustomStart = UiUtil.MakeTextBox(30, vm, nameof(vm.CustomStart));
+        var textBoxCustomStart = UiUtil.MakeEditableComboBox(80, SymbolPresets, vm, nameof(vm.CustomStart));
         var labelAnd = UiUtil.MakeLabel(Se.Language.Tools.RemoveTextForHearingImpaired.And);
-        var textBoxCustomEnd = UiUtil.MakeTextBox(30, vm, nameof(vm.CustomEnd));
+        var textBoxCustomEnd = UiUtil.MakeEditableComboBox(80, SymbolPresets, vm, nameof(vm.CustomEnd));
         var panelCustom = new StackPanel
         {
             Orientation = Orientation.Horizontal,
@@ -221,7 +226,7 @@ public class RemoveTextForHearingImpairedWindow : Window
     private static Border MakeLineContainsView(RemoveTextForHearingImpairedViewModel vm)
     {
         var comboBoxLineContains = UiUtil.MakeCheckBox(Se.Language.Tools.RemoveTextForHearingImpaired.IfLineContains, vm, nameof(vm.IsRemoveTextContainsOn));
-        var textBoxContains = UiUtil.MakeTextBox(120, vm, nameof(vm.TextContains)).WithMarginLeft(5);
+        var textBoxContains = UiUtil.MakeEditableComboBox(150, ContainsPresets, vm, nameof(vm.TextContains)).WithMarginLeft(5);
         var panelContains = new StackPanel
         {
             Orientation = Orientation.Horizontal,

--- a/src/ui/Logic/UiTheme.cs
+++ b/src/ui/Logic/UiTheme.cs
@@ -509,6 +509,33 @@ public static class UiTheme
                 }
             },
 
+            // The two styles above paint every text box's inner PART_BorderElement with an
+            // opaque fill on hover/focus. Inside an editable ComboBox the text box covers the
+            // whole text column, on top of the combo's border, so that fill wipes the border
+            // out on hover, while the drop-down is open, and after selecting (the box keeps
+            // focus) - only the stretch around the arrow, which the text box does not cover,
+            // survives. Fluent guards against exactly this with inline
+            // TextControlBackgroundFocused/PointerOver=Transparent resources on the inner text
+            // box, but the styles above set the border element directly, bypassing resources -
+            // so undo them for text boxes hosted inside a ComboBox template. Later in the
+            // collection = wins over the two styles above.
+            new Style(x => x.OfType<ComboBox>().Template().OfType<TextBox>()
+                .Class(":focus").Template().OfType<Border>().Name("PART_BorderElement"))
+            {
+                Setters =
+                {
+                    new Setter(Border.BackgroundProperty, Brushes.Transparent)
+                }
+            },
+            new Style(x => x.OfType<ComboBox>().Template().OfType<TextBox>()
+                .Class(":pointerover").Template().OfType<Border>().Name("PART_BorderElement"))
+            {
+                Setters =
+                {
+                    new Setter(Border.BackgroundProperty, Brushes.Transparent)
+                }
+            },
+
             // Button
             new Style(x => x.OfType<Button>())
             {

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -638,6 +638,35 @@ public static class UiUtil
         return MakeComboBox(sourceItems, viewModal, propertySelectedPath, null);
     }
 
+    /// <summary>
+    /// A text box with a drop-down of preset values - the user can still type anything.
+    /// Use where a handful of values cover most cases but the field is free text, e.g. the
+    /// music/pilcrow symbols in "Remove text for hearing impaired" (SE 4 parity).
+    /// </summary>
+    public static ComboBox MakeEditableComboBox(double width, IEnumerable<string> presets, object viewModel,
+        string propertyTextPath)
+    {
+        var comboBox = new ComboBox
+        {
+            Width = width,
+            IsEditable = true,
+            ItemsSource = presets.ToList(),
+            DataContext = viewModel,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Center,
+            HorizontalContentAlignment = HorizontalAlignment.Left,
+            VerticalContentAlignment = VerticalAlignment.Center,
+        };
+
+        comboBox.Bind(ComboBox.TextProperty, new Binding
+        {
+            Path = propertyTextPath,
+            Mode = BindingMode.TwoWay,
+        });
+
+        return comboBox;
+    }
+
     public static TextBox MakeTextBox(double width, object viewModel, string propertyTextPath)
     {
         return MakeTextBox(width, viewModel, propertyTextPath, null);
@@ -1575,6 +1604,7 @@ public static class UiUtil
         control.Margin = new Thickness(marginLeft, m.Top, m.Right, m.Bottom);
         return control;
     }
+
 
     public static CheckBox WithMarginLeft(this CheckBox control, int marginLeft)
     {


### PR DESCRIPTION
Reported by @mogan616 in discussion #11744 ([comment](https://github.com/SubtitleEdit/subtitleedit/discussions/11744#discussioncomment-17701649)):

> In the "remove text for hearing impaired" window, not having a dropdown with common symbols for the "between" and "contains" options adds work where a click could solve it before.

## Changes

**Symbol presets restored.** SE 4 used editable combo boxes here (`RemoveTextForHearImpaired.Designer.cs`) with `¶ ♪ ♫` preloaded (plus `♪,♫` for "if line contains"); SE 5 had plain text boxes. New `UiUtil.MakeEditableComboBox` builds an `IsEditable` ComboBox with `Text` two-way bound — same preset lists, all three fields stay free text.

**Dark-theme fix for editable combos.** Using `IsEditable` exposed a real theme bug: the combo's border vanished on hover, while the drop-down was open, and after selecting a value — only the stretch around the arrow survived.

Root cause: `ApplyLighterDark` paints every TextBox's inner `PART_BorderElement` with an opaque fill on `:focus`/`:pointerover`. An editable combo hosts `PART_EditableTextBox` covering the whole text column (grid column 0) on top of the combo's border, while the arrow glyph sits in column 1 — hence the border being wiped everywhere except around the arrow. Fluent guards against exactly this with inline `TextControlBackgroundFocused/PointerOver = Transparent` **resources** on the inner text box, but SE's styles set the border element **directly**, bypassing the resource guard.

Fix: two counter-styles scoped to `ComboBox /template/ TextBox /template/ Border#PART_BorderElement` that keep the inner fill transparent. Normal text boxes keep their focus/hover fill; non-editable combos never show the inner text box, so they are unaffected.

The template facts above were read from the installed Avalonia 12.1.0 (Fluent dll strings + the 12.1.0 tag's `ComboBox.xaml`) — notably, master's template differs (`Border#Background` naming), so master-based selectors silently match nothing on 12.1.

## Testing

Verified in the running app on macOS (dark theme): border now holds on hover, with the drop-down open, and after selecting; typing free text still works and persists; ordinary text boxes and non-editable combos unchanged. Light theme not separately tested — the counter-styles live only in `ApplyLighterDark`, so other themes are untouched by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)