### PR TITLE
Show MKV progress for PGS tracks and surface extraction errors

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -16700,8 +16700,24 @@ public partial class MainViewModel :
     {
         if (matroskaSubtitleInfo.CodecId.Equals("S_HDMV/PGS", StringComparison.OrdinalIgnoreCase))
         {
-            var pgsSubtitle =
-                _bluRayHelper.LoadBluRaySubFromMatroska(matroskaSubtitleInfo, matroska, out var errorMessage);
+            // Off the UI thread with progress, like the other track types - a PGS track in a
+            // large mkv otherwise froze the window with no feedback (#6772).
+            var pgsError = string.Empty;
+            var pgsSubtitle = await ExtractFromMatroskaAsync(
+                matroska,
+                cb =>
+                {
+                    var list = _bluRayHelper.LoadBluRaySubFromMatroska(matroskaSubtitleInfo, matroska, out var err, cb);
+                    pgsError = err;
+                    return list;
+                });
+
+            if (!string.IsNullOrEmpty(pgsError))
+            {
+                // Was silently swallowed before, leaving an empty OCR window with no hint why.
+                await MessageBox.Show(Window!, Se.Language.General.Error, pgsError, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return false;
+            }
 
             Dispatcher.UIThread.Post(async () =>
             {
@@ -16942,11 +16958,12 @@ public partial class MainViewModel :
     private const long MatroskaProgressWindowMinFileSize = 25 * 1024 * 1024; // 25 MB
 
     /// <summary>
-    /// Extracts a Matroska track's blocks on a background thread so the UI stays
-    /// responsive, showing a determinate "Please wait..." window with percentage
-    /// progress for large files. Must be called on the UI thread.
+    /// Runs a Matroska extraction on a background thread so the UI stays responsive,
+    /// showing a determinate "Please wait..." window with percentage progress for large
+    /// files. The callback handed to <paramref name="extract"/> drives that progress bar.
+    /// Must be called on the UI thread.
     /// </summary>
-    private async Task<List<MatroskaSubtitle>> ExtractMatroskaSubtitleAsync(MatroskaFile matroska, int trackNumber)
+    private async Task<T> ExtractFromMatroskaAsync<T>(MatroskaFile matroska, Func<MatroskaFile.LoadMatroskaCallback, T> extract)
     {
         PleaseWaitViewModel? pleaseWaitVm = null;
         long fileSize = 0;
@@ -16968,12 +16985,21 @@ public partial class MainViewModel :
         try
         {
             var vm = pleaseWaitVm;
-            return await Task.Run(() => matroska.GetSubtitle(trackNumber, (pos, total) => vm?.ReportProgress(pos, total)));
+            return await Task.Run(() => extract((pos, total) => vm?.ReportProgress(pos, total)));
         }
         finally
         {
             pleaseWaitVm?.Close();
         }
+    }
+
+    /// <summary>
+    /// Extracts a Matroska track's blocks off the UI thread, with progress. See
+    /// <see cref="ExtractFromMatroskaAsync{T}"/>.
+    /// </summary>
+    private Task<List<MatroskaSubtitle>> ExtractMatroskaSubtitleAsync(MatroskaFile matroska, int trackNumber)
+    {
+        return ExtractFromMatroskaAsync(matroska, cb => matroska.GetSubtitle(trackNumber, cb));
     }
 
     private async Task<bool> LoadTextSTFromMatroska(MatroskaTrackInfo matroskaSubtitleInfo, MatroskaFile matroska)

--- a/src/ui/Logic/BluRayHelper.cs
+++ b/src/ui/Logic/BluRayHelper.cs
@@ -9,7 +9,7 @@ namespace Nikse.SubtitleEdit.Logic;
 
 public class BluRayHelper : IBluRayHelper
 {
-    public List<BluRaySupParser.PcsData> LoadBluRaySubFromMatroska(MatroskaTrackInfo track, MatroskaFile matroska, out string errorMessage)
+    public List<BluRaySupParser.PcsData> LoadBluRaySubFromMatroska(MatroskaTrackInfo track, MatroskaFile matroska, out string errorMessage, MatroskaFile.LoadMatroskaCallback? progressCallback = null)
     {
         errorMessage = string.Empty;
         if (track.ContentEncodingType == 1)
@@ -18,7 +18,7 @@ public class BluRayHelper : IBluRayHelper
             return new List<BluRaySupParser.PcsData>();
         }
 
-        var sub = matroska.GetSubtitle(track.TrackNumber, null);
+        var sub = matroska.GetSubtitle(track.TrackNumber, progressCallback);
         var noOfErrors = 0;
         var lastError = string.Empty;
         var subtitle = new Subtitle();

--- a/src/ui/Logic/IBluRayHelper.cs
+++ b/src/ui/Logic/IBluRayHelper.cs
@@ -6,5 +6,5 @@ namespace Nikse.SubtitleEdit.Logic;
 
 public interface IBluRayHelper
 {
-    List<BluRaySupParser.PcsData> LoadBluRaySubFromMatroska(MatroskaTrackInfo track, MatroskaFile matroska, out string errorMessage);
+    List<BluRaySupParser.PcsData> LoadBluRaySubFromMatroska(MatroskaTrackInfo track, MatroskaFile matroska, out string errorMessage, MatroskaFile.LoadMatroskaCallback? progressCallback = null);
 }


### PR DESCRIPTION
Follow-up to #6772 / #12193, and the other half of a report on [discussion #11744](https://github.com/SubtitleEdit/subtitleedit/discussions/11744) ("The window no longer shows progress when loading a subtitle from an mkv file").

## Problem

The Matroska progress window covered text, DVB, VobSub and TextST tracks, but `MainViewModel.LoadMatroskaSubtitle`'s `S_HDMV/PGS` branch called `_bluRayHelper.LoadBluRaySubFromMatroska(...)` **synchronously on the UI thread**, and `BluRayHelper` passed `null` as the progress callback. Opening a large mkv with a Blu-ray subtitle track froze the window with no feedback — and PGS is the common case for rips.

Single-track files hit this hardest: the track picker (which got its own progress window in #12193) never opens, so nothing warms the cluster cache first.

## Changes

- Generalized `ExtractMatroskaSubtitleAsync` into `ExtractFromMatroskaAsync<T>`, which runs any extraction off-thread behind the same 25 MB-gated determinate `PleaseWaitWindow`. `ExtractMatroskaSubtitleAsync` is now a one-liner over it, so existing behaviour is unchanged.
- Routed the PGS path through it.
- `LoadBluRaySubFromMatroska` takes an optional `MatroskaFile.LoadMatroskaCallback`; the two other callers (`BinaryEditViewModel`, `SpellCheckViewModel`) are unaffected.
- Stopped discarding its `errorMessage` — `"Encrypted content not supported"` was silently swallowed, leaving an empty OCR window with no hint why. Now shown in a message box, and the OCR window is not opened.

## Testing

Built clean. Verified against a real 166 MB single-PGS-track mkv by logging the process's visible windows from launch:

```
2992ms  Untitled - Subtitle Edit v5.1.0-rc9
3119ms  <untitled Avalonia window, 376x123>      <-- PleaseWaitWindow
3833ms  OCR - ...\a.mkv                          <-- 618 lines parsed
```

The progress window now appears during the parse and closes when the OCR window opens; extraction still produces the same 618 lines.

**Not verified at runtime:** the encrypted-content message box — I have no encrypted mkv to test with. That path is reached only when `track.ContentEncodingType == 1`.

## Still without MKV progress (not in this PR)

Batch convert, binary edit, the embedded-subtitles preview, the track picker's Export command, `BluRaySupParser.ParseBluRaySupFromMatroska`, and the `seconv` CLI. Also, the 25 MB constant and the show/report/close pattern are now duplicated in `MainViewModel` and `PickMatroskaTrackViewModel` — worth unifying separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
