### PR TITLE
Add SE4-style regex snippet context menu to find/replace

### DIFF
--- a/src/ui/Features/Edit/Find/FindWindow.cs
+++ b/src/ui/Features/Edit/Find/FindWindow.cs
@@ -204,7 +204,17 @@ public class FindWindow : Window
                        .Focus();
         });
 
-        Opened += delegate { vm.FocusSearchBox(); };
+        Opened += delegate
+        {
+            vm.FocusSearchBox();
+
+            // The AutoCompleteBox's inner TextBox only exists after the template is applied.
+            var innerTextBox = textBoxFind.GetVisualDescendants().OfType<TextBox>().FirstOrDefault();
+            if (innerTextBox != null)
+            {
+                RegexContextFlyout.Attach(innerTextBox, vm, () => vm.FindMode == FindService.FindMode.RegularExpression);
+            }
+        };
         AddHandler(KeyDownEvent, vm.OnKeyDown, RoutingStrategies.Tunnel);
         Closing += (_, _) => vm.SaveSettings();
     }

--- a/src/ui/Features/Edit/MultipleReplace/EditRuleWindow.cs
+++ b/src/ui/Features/Edit/MultipleReplace/EditRuleWindow.cs
@@ -80,7 +80,10 @@ public class EditRuleWindow : Window
         grid.Add(buttonPanel, 4, 0, 1, 2);
 
         Content = grid;
-        
+
+        RegexContextFlyout.Attach(textBoxFindWhat, vm, () => vm.IsRegularExpression);
+        RegexContextFlyout.Attach(textBoxReplaceWith, vm, () => vm.IsRegularExpression, isReplaceBox: true);
+
         Activated += delegate { textBoxFindWhat.Focus(); }; // hack to make OnKeyDown work
         KeyDown += vm.OnKeyDown;
         Loaded += (s, e) => { Title = vm.Title; };

--- a/src/ui/Features/Edit/Replace/ReplaceWindow.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceWindow.cs
@@ -205,8 +205,17 @@ public class ReplaceWindow : Window
                        .Focus();
         });
 
+        RegexContextFlyout.Attach(textBoxReplace, vm, () => vm.FindMode == FindService.FindMode.RegularExpression, isReplaceBox: true);
+
         Opened += delegate
         {
+            // The AutoCompleteBox's inner TextBox only exists after the template is applied.
+            var innerTextBox = textBoxFind.GetVisualDescendants().OfType<TextBox>().FirstOrDefault();
+            if (innerTextBox != null)
+            {
+                RegexContextFlyout.Attach(innerTextBox, vm, () => vm.FindMode == FindService.FindMode.RegularExpression);
+            }
+
             Avalonia.Threading.Dispatcher.UIThread.Post(() =>
             {
                 if (vm.FocusReplaceOnOpen)

--- a/src/ui/Logic/Config/Language/Edit/LanguageEdit.cs
+++ b/src/ui/Logic/Config/Language/Edit/LanguageEdit.cs
@@ -5,6 +5,7 @@ public class LanguageEdit
     public LanguageModifySelection ModifySelection { get; set; } = new();
     public LanguageMultipleReplace MultipleReplace { get; set; } = new();
     public LanguageEditFind Find { get; set; } = new();
+    public LanguageRegularExpressionContextMenu RegularExpressionContextMenu { get; set; } = new();
     public string ShowHistory { get; set; }
     public string RestoreSelected { get; set; }
 

--- a/src/ui/Logic/Config/Language/Edit/LanguageRegularExpressionContextMenu.cs
+++ b/src/ui/Logic/Config/Language/Edit/LanguageRegularExpressionContextMenu.cs
@@ -1,0 +1,35 @@
+namespace Nikse.SubtitleEdit.Logic.Config.Language.Edit;
+
+public class LanguageRegularExpressionContextMenu
+{
+    public string WordBoundary { get; set; }
+    public string NonWordBoundary { get; set; }
+    public string NewLine { get; set; }
+    public string NewLineShort { get; set; }
+    public string AnyDigit { get; set; }
+    public string NonDigit { get; set; }
+    public string AnyCharacter { get; set; }
+    public string AnyWhitespace { get; set; }
+    public string NonSpaceCharacter { get; set; }
+    public string ZeroOrMore { get; set; }
+    public string OneOrMore { get; set; }
+    public string InCharacterGroup { get; set; }
+    public string NotInCharacterGroup { get; set; }
+
+    public LanguageRegularExpressionContextMenu()
+    {
+        WordBoundary = "Word boundary (\\b)";
+        NonWordBoundary = "Non word boundary (\\B)";
+        NewLine = "New line (\\r\\n)";
+        NewLineShort = "New line (\\n)";
+        AnyDigit = "Any digit (\\d)";
+        NonDigit = "Non digit (\\D)";
+        AnyCharacter = "Any character (.)";
+        AnyWhitespace = "Any whitespace (\\s)";
+        NonSpaceCharacter = "Non space character (\\S)";
+        ZeroOrMore = "Zero or more (*)";
+        OneOrMore = "One or more (+)";
+        InCharacterGroup = "In character group ([test])";
+        NotInCharacterGroup = "Not in character group ([^test])";
+    }
+}

--- a/src/ui/Logic/RegexContextFlyout.cs
+++ b/src/ui/Logic/RegexContextFlyout.cs
@@ -30,6 +30,8 @@ public static class RegexContextFlyout
 
         vm.PropertyChanged += (_, _) => Update();
         Update();
+
+        UiUtil.AttachMacContextFlyoutHandler(textBox);
     }
 
     private static MenuFlyout MakeFindFlyout(TextBox textBox)

--- a/src/ui/Logic/RegexContextFlyout.cs
+++ b/src/ui/Logic/RegexContextFlyout.cs
@@ -1,0 +1,78 @@
+using Avalonia.Controls;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.ComponentModel;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// SE4-style context menu for regex-enabled find/replace text boxes,
+/// inserting common regex snippets at the caret.
+/// </summary>
+public static class RegexContextFlyout
+{
+    public static void Attach(TextBox textBox, INotifyPropertyChanged vm, Func<bool> isRegexMode, bool isReplaceBox = false)
+    {
+        var flyout = isReplaceBox ? MakeReplaceFlyout(textBox) : MakeFindFlyout(textBox);
+
+        void Update()
+        {
+            if (isRegexMode())
+            {
+                textBox.ContextFlyout = flyout;
+            }
+            else
+            {
+                // restore the theme's default cut/copy/paste menu
+                textBox.ClearValue(Control.ContextFlyoutProperty);
+            }
+        }
+
+        vm.PropertyChanged += (_, _) => Update();
+        Update();
+    }
+
+    private static MenuFlyout MakeFindFlyout(TextBox textBox)
+    {
+        var l = Se.Language.Edit.RegularExpressionContextMenu;
+        var flyout = new MenuFlyout();
+        AddItem(flyout, textBox, l.WordBoundary, "\\b");
+        AddItem(flyout, textBox, l.NonWordBoundary, "\\B");
+        AddItem(flyout, textBox, l.NewLine, "\\r\\n");
+        AddItem(flyout, textBox, l.AnyDigit, "\\d");
+        AddItem(flyout, textBox, l.NonDigit, "\\D");
+        AddItem(flyout, textBox, l.AnyCharacter, ".");
+        AddItem(flyout, textBox, l.AnyWhitespace, "\\s");
+        AddItem(flyout, textBox, l.NonSpaceCharacter, "\\S");
+        AddItem(flyout, textBox, l.ZeroOrMore, "*");
+        AddItem(flyout, textBox, l.OneOrMore, "+");
+        AddItem(flyout, textBox, l.InCharacterGroup, "[test]");
+        AddItem(flyout, textBox, l.NotInCharacterGroup, "[^test]");
+        return flyout;
+    }
+
+    private static MenuFlyout MakeReplaceFlyout(TextBox textBox)
+    {
+        var l = Se.Language.Edit.RegularExpressionContextMenu;
+        var flyout = new MenuFlyout();
+        AddItem(flyout, textBox, l.NewLineShort, "\\n");
+        return flyout;
+    }
+
+    private static void AddItem(MenuFlyout flyout, TextBox textBox, string header, string insertText)
+    {
+        var item = new MenuItem
+        {
+            // TextBlock header: a plain string header would eat '_' as an access-key marker.
+            Header = new TextBlock { Text = header },
+        };
+
+        item.Click += (_, _) =>
+        {
+            textBox.SelectedText = insertText;
+            textBox.Focus();
+        };
+
+        flyout.Items.Add(item);
+    }
+}


### PR DESCRIPTION
SE4 had a context menu on regex-enabled search boxes that inserted common regex snippets; this brings it back in SE5.

- New shared helper `RegexContextFlyout` builds a `MenuFlyout` inserting snippets at the caret (`\b`, `\B`, `\r\n`, `\d`, `\D`, `.`, `\s`, `\S`, `*`, `+`, `[test]`, `[^test]`), plus a single `\n` item for replace-with boxes — same set as SE4's `GetRegExContextMenu`.
- Attached in **Find**, **Replace** (find + replace-with), and **Multiple Replace**'s edit-rule dialog (find + replace-with). The menu is only active while the regular-expression mode is selected; otherwise the default cut/copy/paste menu is restored.
- New language section `Edit.RegularExpressionContextMenu` with the 13 SE4 strings (English defaults match SE4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)