### PR TITLE
OCR: checkerboard backdrop for image previews

### DIFF
--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -477,11 +477,12 @@ public class OcrWindow : Window
                             image.Bind(Image.MaxHeightProperty, new Binding(nameof(vm.ImageMaxHeight)) { Source = vm });
                             image.Bind(Image.MaxWidthProperty, new Binding(nameof(vm.ImageMaxWidth)) { Source = vm });
 
-                            // Subtitle bitmaps are usually light text on a transparent background, which
-                            // is invisible on a light grid - give them a dark backdrop so they show.
+                            // Subtitle bitmaps can be light or dark text on a transparent background,
+                            // both invisible on a matching flat backdrop - use the mid-gray checkerboard
+                            // so any content shows in either theme (issue #12692).
                             var imageContainer = new Border
                             {
-                                Background = new Avalonia.Media.SolidColorBrush(Avalonia.Media.Color.FromRgb(0x2D, 0x2D, 0x30)),
+                                Background = UiUtil.GetCheckerboardBrush(),
                                 CornerRadius = new CornerRadius(3),
                                 Padding = new Thickness(3),
                                 Child = image,

--- a/src/ui/Features/Ocr/PreProcessingWindow.cs
+++ b/src/ui/Features/Ocr/PreProcessingWindow.cs
@@ -148,7 +148,9 @@ public class PreProcessingWindow : Window
             MaxHeight = 200,
         };
 
-        return UiUtil.MakeBorderForControl(image);
+        var border = UiUtil.MakeBorderForControl(image);
+        border.Background = UiUtil.GetCheckerboardBrush();
+        return border;
     }
 
     private static Border MakePostProcessedImageView(PreProcessingViewModel vm)
@@ -163,6 +165,8 @@ public class PreProcessingWindow : Window
             MaxHeight = 200,
         };
 
-        return UiUtil.MakeBorderForControl(image);
+        var border = UiUtil.MakeBorderForControl(image);
+        border.Background = UiUtil.GetCheckerboardBrush();
+        return border;
     }
 }

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -1767,6 +1767,51 @@ public static class UiUtil
         };
     }
 
+    private static ImageBrush? _checkerboardBrush;
+
+    /// <summary>
+    /// Theme-independent checkerboard backdrop for image previews whose content can be pure
+    /// white, pure black or transparent (e.g. OCR bitmaps and pre-processing output). Two
+    /// mid-tone grays so both extremes stay visible in light and dark theme (issue #12692).
+    /// </summary>
+    public static ImageBrush GetCheckerboardBrush()
+    {
+        if (_checkerboardBrush != null)
+        {
+            return _checkerboardBrush;
+        }
+
+        const int tileSize = 16; // 2x2 squares of 8px
+        const int squareSize = tileSize / 2;
+        var bitmap = new Avalonia.Media.Imaging.WriteableBitmap(
+            new PixelSize(tileSize, tileSize),
+            new Vector(96, 96),
+            PixelFormat.Bgra8888,
+            AlphaFormat.Opaque);
+        using (var frameBuffer = bitmap.Lock())
+        {
+            unsafe
+            {
+                var pixels = (uint*)frameBuffer.Address;
+                for (var y = 0; y < tileSize; y++)
+                {
+                    for (var x = 0; x < tileSize; x++)
+                    {
+                        var isDark = (x / squareSize + y / squareSize) % 2 == 0;
+                        pixels[y * frameBuffer.RowBytes / 4 + x] = isDark ? 0xFF666666 : 0xFF999999;
+                    }
+                }
+            }
+        }
+
+        _checkerboardBrush = new ImageBrush(bitmap)
+        {
+            TileMode = TileMode.Tile,
+            DestinationRect = new RelativeRect(0, 0, tileSize, tileSize, RelativeUnit.Absolute),
+        };
+        return _checkerboardBrush;
+    }
+
     public static Border MakeBorderForControl(Control control)
     {
         return new Border


### PR DESCRIPTION
Fixes #12692

"One color (white)" pre-processing output was invisible (white on white) in the light theme; pure black output has the mirror problem on the dark theme, and the OCR grid's fixed dark backdrop shares it.

Adds `UiUtil.GetCheckerboardBrush()` — a cached 16 px tiled brush of mid-gray squares (#666666/#999999) chosen so both pure-white and pure-black content contrasts in either theme — and applies it behind both pre-processing preview images and the OCR list's image cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)