### PR TITLE
Fix garbled import of grayscale images (InpaintDelogo)

### DIFF
--- a/src/ui/Features/Files/ImportImages/ImportImageItem.cs
+++ b/src/ui/Features/Files/ImportImages/ImportImageItem.cs
@@ -70,7 +70,9 @@ public partial class ImportImageItem : ObservableObject
 
     internal SKBitmap GetBitmap()
     {
-        return SKBitmap.Decode(Bytes);
+        // Normalize to BGRA - InpaintDelogo emits 8-bit grayscale PNGs, which
+        // SKBitmap.Decode would keep as 1-byte/pixel Gray8 (issue #12694).
+        return Logic.SkBitmapExtensions.DecodeToBgra8888(Bytes);
     }
 }
 

--- a/src/ui/Logic/SkBitmapExtensions.cs
+++ b/src/ui/Logic/SkBitmapExtensions.cs
@@ -9,6 +9,24 @@ namespace Nikse.SubtitleEdit.Logic;
 
 internal static class SkBitmapExtensions
 {
+    /// <summary>
+    /// Decodes an image to 32-bit BGRA regardless of the source format. SKBitmap.Decode
+    /// preserves the file's color type (e.g. an 8-bit grayscale PNG decodes to Gray8,
+    /// 1 byte/pixel), but SE's pixel-walking code assumes 4 bytes/pixel throughout -
+    /// grayscale images from InpaintDelogo rendered as noise (issue #12694).
+    /// </summary>
+    public static SKBitmap DecodeToBgra8888(byte[] imageBytes)
+    {
+        using var codec = SKCodec.Create(new MemoryStream(imageBytes));
+        if (codec == null)
+        {
+            return new SKBitmap(1, 1, SKColorType.Bgra8888, SKAlphaType.Premul);
+        }
+
+        var info = new SKImageInfo(codec.Info.Width, codec.Info.Height, SKColorType.Bgra8888, SKAlphaType.Premul);
+        return SKBitmap.Decode(codec, info) ?? new SKBitmap(1, 1, SKColorType.Bgra8888, SKAlphaType.Premul);
+    }
+
     public static SKBitmap MakeImageBrighter(SKBitmap bitmap, float brightnessIncrease = 0.25f)
     {
         using var canvas = new SKCanvas(bitmap);
@@ -171,6 +189,18 @@ internal static class SkBitmapExtensions
         if (skBitmap.Width <= 0 || skBitmap.Height <= 0)
         {
             return new WriteableBitmap(new PixelSize(1, 1), Vector.One, PixelFormat.Bgra8888, AlphaFormat.Premul);
+        }
+
+        // The row loop below reads 4 bytes per pixel; anything narrower (Gray8 from a
+        // grayscale PNG, Rgb565, ...) would render as noise and read past the pixel
+        // buffer (issue #12694). Convert first.
+        if (skBitmap.ColorType != SKColorType.Bgra8888)
+        {
+            using var converted = skBitmap.Copy(SKColorType.Bgra8888);
+            if (converted != null)
+            {
+                return converted.ToAvaloniaBitmap();
+            }
         }
 
         var bitmap = new WriteableBitmap(

--- a/tests/UI/Logic/SkBitmapExtensionsTests.cs
+++ b/tests/UI/Logic/SkBitmapExtensionsTests.cs
@@ -1,0 +1,80 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Logic;
+using SkiaSharp;
+using System.Runtime.InteropServices;
+
+namespace UITests.Logic;
+
+public class SkBitmapExtensionsTests
+{
+    // An 8-bit grayscale source, as InpaintDelogo emits (issue #12694): left half black,
+    // right half white.
+    private static SKBitmap MakeGray8Bitmap(int width = 32, int height = 8)
+    {
+        var bitmap = new SKBitmap(new SKImageInfo(width, height, SKColorType.Gray8, SKAlphaType.Opaque));
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                bitmap.SetPixel(x, y, x < width / 2 ? SKColors.Black : SKColors.White);
+            }
+        }
+
+        return bitmap;
+    }
+
+    [Fact]
+    public void DecodeToBgra8888NormalizesGrayscalePng()
+    {
+        using var gray = MakeGray8Bitmap();
+        using var image = SKImage.FromBitmap(gray);
+        using var png = image.Encode(SKEncodedImageFormat.Png, 100);
+
+        // Sanity: a plain decode keeps the file's 1-byte/pixel format - the trap the
+        // helper exists to avoid.
+        using (var plain = SKBitmap.Decode(png.ToArray()))
+        {
+            Assert.Equal(SKColorType.Gray8, plain.ColorType);
+        }
+
+        using var decoded = SkBitmapExtensions.DecodeToBgra8888(png.ToArray());
+
+        Assert.Equal(SKColorType.Bgra8888, decoded.ColorType);
+        Assert.Equal(32, decoded.Width);
+        Assert.Equal(8, decoded.Height);
+        Assert.Equal((byte)0, decoded.GetPixel(0, 0).Red);
+        Assert.Equal((byte)255, decoded.GetPixel(31, 0).Red);
+    }
+
+    [AvaloniaFact]
+    public void ToAvaloniaBitmapConvertsGray8WithoutGarbling()
+    {
+        using var gray = MakeGray8Bitmap();
+
+        var avaloniaBitmap = gray.ToAvaloniaBitmap();
+
+        Assert.Equal(32, avaloniaBitmap.PixelSize.Width);
+        Assert.Equal(8, avaloniaBitmap.PixelSize.Height);
+
+        // Read back the BGRA pixels: left half black, right half white - the old
+        // 4-bytes/pixel walk over a 1-byte/pixel buffer produced neither.
+        var buffer = new byte[32 * 8 * 4];
+        var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+        try
+        {
+            avaloniaBitmap.CopyPixels(
+                new Avalonia.PixelRect(0, 0, 32, 8),
+                handle.AddrOfPinnedObject(),
+                buffer.Length,
+                32 * 4);
+        }
+        finally
+        {
+            handle.Free();
+        }
+
+        Assert.Equal(0, buffer[0]); // first pixel blue channel: black
+        Assert.Equal(255, buffer[3]); // first pixel alpha: opaque
+        Assert.Equal(255, buffer[31 * 4]); // last pixel of row 0, blue channel: white
+    }
+}


### PR DESCRIPTION
Fixes #12694

InpaintDelogo emits 8-bit grayscale PNGs. `SKBitmap.Decode` faithfully keeps them as `Gray8` (1 byte/pixel), but `ToAvaloniaBitmap` walks pixel rows with `uint*` — a hard 4-bytes/pixel assumption — so the images rendered as quarter-width noise and the loop read past the pixel buffer (SE 4 was unaffected because GDI+ normalized to 32-bit ARGB on load).

- New `SkBitmapExtensions.DecodeToBgra8888()` decodes any image straight to BGRA via `SKCodec`; `ImportImageItem.GetBitmap()` (the import-images/OCR path) uses it, so OCR engines also see 32-bit pixels.
- `ToAvaloniaBitmap` now converts any non-`Bgra8888` bitmap with `Copy()` before the unsafe row copy — closes the out-of-bounds read for all other callers.

Verified on the reporter's sample zip: decodes to readable 1120×140 BGRA ("- Comment ça va ? / - On fait aller."). New tests cover both the decode normalization and a Gray8 round-trip through `ToAvaloniaBitmap` with pixel readback. Full suite passes (1,591 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)