### PR TITLE
Fix four bugs found in recent-commit review

### DIFF
--- a/src/libse/BluRaySup/BluRaySupParser.cs
+++ b/src/libse/BluRaySup/BluRaySupParser.cs
@@ -745,6 +745,12 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
         /// <returns>number of valid palette entries (-1 for fault)</returns>
         private static PdsData ParsePds(byte[] buffer, SupSegment segment)
         {
+            // See ParseOds: don't read stale rented-buffer bytes on truncated segments.
+            if (segment.Size < 2)
+            {
+                return new PdsData { Message = "Empty palette" };
+            }
+
             int paletteId = buffer[0];  // 8bit palette ID (0..7)
             // 8bit palette version number (incremented for each palette change)
             int paletteUpdate = buffer[1];
@@ -777,6 +783,21 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
         /// <returns>true if this is a valid new object (neither invalid nor a fragment)</returns>
         private static OdsData ParseOds(byte[] buffer, SupSegment segment, bool forceFirst)
         {
+            // The rented segment buffer holds stale data from previous segments beyond
+            // segment.Size. A truncated ODS (< 4 header bytes) used to throw on the reads
+            // below and be skipped by the caller's catch; reading stale bytes instead can
+            // fabricate an ObjectId that overwrites a live object's image data. ObjectId -1
+            // can never match a real object, so the caller's "missing first ods" path runs.
+            if (segment.Size < 4)
+            {
+                return new OdsData
+                {
+                    ObjectId = -1,
+                    Message = "Invalid ObjectDefinitionSegment size: " + segment.Size,
+                    Fragment = new ImageObjectFragment { ImageBuffer = Array.Empty<byte>() },
+                };
+            }
+
             var objId = BigEndianInt16(buffer, 0);      // 16bit object_id
             int objVer = buffer[2];     // 16bit object_id nikse - index 2 or 1???
             int objSeq = buffer[3];     // 8bit  first_in_sequence (0x80),
@@ -854,190 +875,196 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             // Reads must be bounded by segment.Size, not buffer length: the
             // rented array is larger and holds stale data from prior segments.
             var buffer = ArrayPool<byte>.Shared.Rent(ushort.MaxValue);
-            while (ms.Read(headerBuffer, 0, headerBuffer.Length) == headerBuffer.Length)
+            try
             {
-                var segment = fromMatroskaFile ? ParseSegmentHeaderFromMatroska(headerBuffer) : ParseSegmentHeader(headerBuffer, log);
-                position += headerBuffer.Length;
-
-                try
+                while (ms.Read(headerBuffer, 0, headerBuffer.Length) == headerBuffer.Length)
                 {
-                    // Read segment data
-                    var bytesRead = ms.Read(buffer, 0, segment.Size);
-                    if (bytesRead < segment.Size)
+                    var segment = fromMatroskaFile ? ParseSegmentHeaderFromMatroska(headerBuffer) : ParseSegmentHeader(headerBuffer, log);
+                    position += headerBuffer.Length;
+
+                    try
                     {
-                        break;
-                    }
+                        // Read segment data
+                        var bytesRead = ms.Read(buffer, 0, segment.Size);
+                        if (bytesRead < segment.Size)
+                        {
+                            break;
+                        }
 
 
-#if DEBUG
-                    log.Append(segmentCount + ": ");
-#endif
+    #if DEBUG
+                        log.Append(segmentCount + ": ");
+    #endif
 
-                    switch (segment.Type)
-                    {
-                        case 0x14: // Palette
-                            if (latestPcs != null)
-                            {
-#if DEBUG
-                                log.AppendLine($"0x14 - Palette - PDS offset={position} size={segment.Size}");
-#endif
-                                var pds = ParsePds(buffer, segment);
-#if DEBUG
-                                log.AppendLine(pds.Message);
-#endif
-                                if (pds.PaletteInfo != null)
+                        switch (segment.Type)
+                        {
+                            case 0x14: // Palette
+                                if (latestPcs != null)
                                 {
-                                    if (!palettes.TryGetValue(pds.PaletteId, out var paletteList))
+    #if DEBUG
+                                    log.AppendLine($"0x14 - Palette - PDS offset={position} size={segment.Size}");
+    #endif
+                                    var pds = ParsePds(buffer, segment);
+    #if DEBUG
+                                    log.AppendLine(pds.Message);
+    #endif
+                                    if (pds.PaletteInfo != null)
                                     {
-                                        paletteList = new List<PaletteInfo>();
-                                        palettes[pds.PaletteId] = paletteList;
-                                    }
-                                    else
-                                    {
-                                        if (latestPcs.PaletteUpdate)
+                                        if (!palettes.TryGetValue(pds.PaletteId, out var paletteList))
                                         {
-                                            paletteList.RemoveAt(paletteList.Count - 1);
+                                            paletteList = new List<PaletteInfo>();
+                                            palettes[pds.PaletteId] = paletteList;
                                         }
                                         else
                                         {
-#if DEBUG
-                                            log.AppendLine("Extra Palette");
-#endif
+                                            if (latestPcs.PaletteUpdate)
+                                            {
+                                                paletteList.RemoveAt(paletteList.Count - 1);
+                                            }
+                                            else
+                                            {
+    #if DEBUG
+                                                log.AppendLine("Extra Palette");
+    #endif
+                                            }
                                         }
+                                        paletteList.Add(pds.PaletteInfo);
                                     }
-                                    paletteList.Add(pds.PaletteInfo);
                                 }
-                            }
-                            break;
+                                break;
 
-                        case 0x15: // Object Definition Segment (image bitmap data)
-                            if (latestPcs != null)
-                            {
-#if DEBUG
-                                log.AppendLine($"0x15 - Bitmap data - ODS offset={position} size={segment.Size}");
-#endif
-                                var ods = ParseOds(buffer, segment, forceFirstOds);
-#if DEBUG
-                                log.AppendLine(ods.Message);
-#endif
-                                if (!latestPcs.PaletteUpdate)
+                            case 0x15: // Object Definition Segment (image bitmap data)
+                                if (latestPcs != null)
                                 {
-                                    List<OdsData> odsList = new List<OdsData>();
-                                    if (ods.IsFirst)
+    #if DEBUG
+                                    log.AppendLine($"0x15 - Bitmap data - ODS offset={position} size={segment.Size}");
+    #endif
+                                    var ods = ParseOds(buffer, segment, forceFirstOds);
+    #if DEBUG
+                                    log.AppendLine(ods.Message);
+    #endif
+                                    if (!latestPcs.PaletteUpdate)
                                     {
-                                        odsList.Add(ods);
-                                        bitmapObjects[ods.ObjectId] = odsList;
-                                    }
-                                    else
-                                    {
-                                        if (bitmapObjects.TryGetValue(ods.ObjectId, out var odsList2))
+                                        List<OdsData> odsList = new List<OdsData>();
+                                        if (ods.IsFirst)
                                         {
-                                            odsList = odsList2;
                                             odsList.Add(ods);
+                                            bitmapObjects[ods.ObjectId] = odsList;
                                         }
                                         else
                                         {
-#if DEBUG
-                                            log.AppendLine($"INVALID ObjectId {ods.ObjectId} in ODS, offset={position}");
-#endif
+                                            if (bitmapObjects.TryGetValue(ods.ObjectId, out var odsList2))
+                                            {
+                                                odsList = odsList2;
+                                                odsList.Add(ods);
+                                            }
+                                            else
+                                            {
+    #if DEBUG
+                                                log.AppendLine($"INVALID ObjectId {ods.ObjectId} in ODS, offset={position}");
+    #endif
+                                            }
                                         }
                                     }
-                                }
-                                else
-                                {
-#if DEBUG
-                                    log.AppendLine($"Bitmap Data Ignore due to PaletteUpdate offset={position}");
-#endif
-                                }
-                                forceFirstOds = false;
-                            }
-                            break;
-
-                        case 0x16: // Picture time codes
-                            if (latestPcs != null)
-                            {
-                                if (CompletePcs(latestPcs, bitmapObjects, palettes.Count > 0 ? palettes : lastPalettes))
-                                {
-                                    pcsList.Add(latestPcs);
-                                }
-                            }
-
-#if DEBUG
-                            log.AppendLine($"0x16 - Picture codes, offset={position} size={segment.Size}");
-#endif
-                            forceFirstOds = true;
-                            var nextPcs = ParsePicture(buffer, segment);
-                            if (nextPcs.StartTime > 0 && pcsList.Count > 0 && pcsList.Last().EndTime == 0)
-                            {
-                                pcsList.Last().EndTime = nextPcs.StartTime;
-                            }
-#if DEBUG
-                            log.AppendLine(nextPcs.Message);
-#endif
-                            latestPcs = nextPcs;
-                            if (latestPcs.CompositionState == CompositionState.EpochStart)
-                            {
-                                bitmapObjects.Clear();
-                                palettes.Clear();
-                            }
-                            break;
-
-                        case 0x17: // Window display
-                            if (latestPcs != null)
-                            {
-#if DEBUG
-                                log.AppendLine($"0x17 - Window display offset={position} size={segment.Size}");
-#endif
-                                int windowCount = buffer[0];
-                                var offset = 0;
-                                for (var nextWindow = 0; nextWindow < windowCount; nextWindow++)
-                                {
-                                    if (1 + offset + 9 > segment.Size)
+                                    else
                                     {
-                                        break;
+    #if DEBUG
+                                        log.AppendLine($"Bitmap Data Ignore due to PaletteUpdate offset={position}");
+    #endif
                                     }
-
-                                    int windowId = buffer[1 + offset];
-                                    var x = BigEndianInt16(buffer, 2 + offset);
-                                    var y = BigEndianInt16(buffer, 4 + offset);
-                                    var width = BigEndianInt16(buffer, 6 + offset);
-                                    var height = BigEndianInt16(buffer, 8 + offset);
-                                    log.AppendLine(string.Format("WinId: {4}, X: {0}, Y: {1}, Width: {2}, Height: {3}", x, y, width, height, windowId));
-                                    offset += 9;
+                                    forceFirstOds = false;
                                 }
-                            }
-                            break;
+                                break;
 
-                        case 0x80:
-                            forceFirstOds = true;
-#if DEBUG
-                            log.AppendLine($"0x80 - END offset={position} size={segment.Size}");
-#endif
-                            if (latestPcs != null)
-                            {
-                                if (CompletePcs(latestPcs, bitmapObjects, palettes.Count > 0 ? palettes : lastPalettes))
+                            case 0x16: // Picture time codes
+                                if (latestPcs != null)
                                 {
-                                    pcsList.Add(latestPcs);
+                                    if (CompletePcs(latestPcs, bitmapObjects, palettes.Count > 0 ? palettes : lastPalettes))
+                                    {
+                                        pcsList.Add(latestPcs);
+                                    }
                                 }
-                                latestPcs = null;
-                            }
-                            break;
 
-                        default:
-#if DEBUG
-                            log.AppendLine($"0x?? - END offset={position} UNKNOWN SEGMENT TYPE={segment.Type}");
-#endif
-                            break;
+    #if DEBUG
+                                log.AppendLine($"0x16 - Picture codes, offset={position} size={segment.Size}");
+    #endif
+                                forceFirstOds = true;
+                                var nextPcs = ParsePicture(buffer, segment);
+                                if (nextPcs.StartTime > 0 && pcsList.Count > 0 && pcsList.Last().EndTime == 0)
+                                {
+                                    pcsList.Last().EndTime = nextPcs.StartTime;
+                                }
+    #if DEBUG
+                                log.AppendLine(nextPcs.Message);
+    #endif
+                                latestPcs = nextPcs;
+                                if (latestPcs.CompositionState == CompositionState.EpochStart)
+                                {
+                                    bitmapObjects.Clear();
+                                    palettes.Clear();
+                                }
+                                break;
+
+                            case 0x17: // Window display
+                                if (latestPcs != null)
+                                {
+    #if DEBUG
+                                    log.AppendLine($"0x17 - Window display offset={position} size={segment.Size}");
+    #endif
+                                    int windowCount = segment.Size >= 1 ? buffer[0] : 0;
+                                    var offset = 0;
+                                    for (var nextWindow = 0; nextWindow < windowCount; nextWindow++)
+                                    {
+                                        if (1 + offset + 9 > segment.Size)
+                                        {
+                                            break;
+                                        }
+
+                                        int windowId = buffer[1 + offset];
+                                        var x = BigEndianInt16(buffer, 2 + offset);
+                                        var y = BigEndianInt16(buffer, 4 + offset);
+                                        var width = BigEndianInt16(buffer, 6 + offset);
+                                        var height = BigEndianInt16(buffer, 8 + offset);
+                                        log.AppendLine(string.Format("WinId: {4}, X: {0}, Y: {1}, Width: {2}, Height: {3}", x, y, width, height, windowId));
+                                        offset += 9;
+                                    }
+                                }
+                                break;
+
+                            case 0x80:
+                                forceFirstOds = true;
+    #if DEBUG
+                                log.AppendLine($"0x80 - END offset={position} size={segment.Size}");
+    #endif
+                                if (latestPcs != null)
+                                {
+                                    if (CompletePcs(latestPcs, bitmapObjects, palettes.Count > 0 ? palettes : lastPalettes))
+                                    {
+                                        pcsList.Add(latestPcs);
+                                    }
+                                    latestPcs = null;
+                                }
+                                break;
+
+                            default:
+    #if DEBUG
+                                log.AppendLine($"0x?? - END offset={position} UNKNOWN SEGMENT TYPE={segment.Type}");
+    #endif
+                                break;
+                        }
                     }
+                    catch (IndexOutOfRangeException e)
+                    {
+                        log.Append($"Index of of range at pos {position - headerBuffer.Length}: {e.StackTrace}");
+                    }
+                    position += segment.Size;
+                    segmentCount++;
                 }
-                catch (IndexOutOfRangeException e)
-                {
-                    log.Append($"Index of of range at pos {position - headerBuffer.Length}: {e.StackTrace}");
-                }
-                position += segment.Size;
-                segmentCount++;
             }
-            ArrayPool<byte>.Shared.Return(buffer);
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
 
             if (latestPcs != null)
             {

--- a/src/libse/Common/FileUtil.cs
+++ b/src/libse/Common/FileUtil.cs
@@ -394,7 +394,16 @@ namespace Nikse.SubtitleEdit.Core.Common
             using (var fs = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
                 var buffer = new byte[64 * 1024];
-                var bytesRead = fs.Read(buffer, 0, buffer.Length);
+                // Read may return fewer bytes than requested (network shares, filter
+                // drivers) - fill until EOF or the sniff buffer is full so a partial
+                // first read can't misclassify a genuine raw PGS stream.
+                var bytesRead = 0;
+                int read;
+                while (bytesRead < buffer.Length &&
+                       (read = fs.Read(buffer, bytesRead, buffer.Length - bytesRead)) > 0)
+                {
+                    bytesRead += read;
+                }
 
                 // Each raw segment is: type (1 byte) + payload size (2 bytes, big endian) + payload.
                 // Require a chain of valid segment types to avoid false positives on other binary

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7432,10 +7432,15 @@ public partial class MainViewModel :
 
             // Leave the configured "out cues" gap before the shot change (Beautify time codes
             // profile, two frames by default) - same as SE 4.x. Without it the line ends exactly
-            // on the shot change frame.
-            var candidateEndMs = ShotChangesHelper.GetNextShotChangeMinusGapInMs(
-                AudioVisualizer.ShotChanges,
-                new TimeCode(line.EndTime.TotalMilliseconds));
+            // on the shot change frame. The lookup filters on the gap-adjusted position being
+            // strictly after the current end: GetNextShotChangeMinusGapInMs's frame tolerance
+            // could pick a shot change just BEFORE the end and, after subtracting the gap, move
+            // the end ~2-3 frames backward instead of extending.
+            var outCuesGapMs = TimeCodesBeautifierUtils.GetOutCuesGapMs();
+            var candidateEndMs = AudioVisualizer.ShotChanges
+                .Select(s => s * 1000.0 - outCuesGapMs)
+                .Cast<double?>()
+                .FirstOrDefault(ms => ms > line.EndTime.TotalMilliseconds);
 
             // Upper bound for the new end: the next shot change and, if present, the next
             // subtitle's start minus the configured gap. Whichever is earlier wins so we never
@@ -7575,21 +7580,22 @@ public partial class MainViewModel :
             // at t=0 isn't conflated with the default value. Strict `<` so
             // shot changes at or after the current start can't qualify and
             // cause "extend to previous" to actually move the start forward.
-            var shotChange = AudioVisualizer.ShotChanges
+            // The shot change gets the configured "in cues" gap (Beautify time
+            // codes profile, two frames by default) so the line starts after the
+            // shot change rather than exactly on it - same as SE 4.x. The strict
+            // comparison applies to the gap-adjusted position: comparing the raw
+            // shot change and adding the gap afterwards could land AFTER the
+            // current start and make "extend to previous" shorten the line.
+            var inCuesGapMs = TimeCodesBeautifierUtils.GetInCuesGapMs();
+            double? candidateStartMs = AudioVisualizer.ShotChanges
+                .Select(s => s * 1000.0 + inCuesGapMs)
                 .Cast<double?>()
-                .LastOrDefault(s => s < line.StartTime.TotalSeconds);
+                .LastOrDefault(ms => ms < line.StartTime.TotalMilliseconds);
 
             // Lower bound for the new start: the previous shot change and, if
             // present, the previous subtitle's end plus the configured gap.
             // Whichever is later wins so we never pull the start back past
             // either constraint.
-            //
-            // The shot change gets the configured "in cues" gap (Beautify time
-            // codes profile, two frames by default) so the line starts after the
-            // shot change rather than exactly on it - same as SE 4.x.
-            double? candidateStartMs = shotChange.HasValue
-                ? shotChange.Value * 1000.0 + TimeCodesBeautifierUtils.GetInCuesGapMs()
-                : null;
             if (prev != null)
             {
                 var prevEndPlusGapMs = prev.EndTime.TotalMilliseconds + gapMs;

--- a/src/ui/Logic/SkBitmapExtensions.cs
+++ b/src/ui/Logic/SkBitmapExtensions.cs
@@ -197,10 +197,14 @@ internal static class SkBitmapExtensions
         if (skBitmap.ColorType != SKColorType.Bgra8888)
         {
             using var converted = skBitmap.Copy(SKColorType.Bgra8888);
-            if (converted != null)
+            if (converted == null)
             {
-                return converted.ToAvaloniaBitmap();
+                // Unconvertible color type - never fall through to the 4-bytes/pixel
+                // walk below, it would read past the pixel buffer.
+                return new WriteableBitmap(new PixelSize(1, 1), Vector.One, PixelFormat.Bgra8888, AlphaFormat.Premul);
             }
+
+            return converted.ToAvaloniaBitmap();
         }
 
         var bitmap = new WriteableBitmap(

--- a/tests/libse/BluRaySup/BluRaySupParserRawPgsTest.cs
+++ b/tests/libse/BluRaySup/BluRaySupParserRawPgsTest.cs
@@ -103,6 +103,31 @@ public class BluRaySupParserRawPgsTest
     }
 
     [Fact]
+    public void TruncatedOdsSegmentDoesNotCorruptOtherObjects()
+    {
+        // A truncated ODS (fewer than the 4 header bytes) must be skipped, not parsed
+        // from stale rented-buffer bytes left by the previous segment - stale reads could
+        // fabricate an ObjectId and overwrite a real object's image data.
+        var raw = StripPgHeaders(CreateSupContent(2)).ToList();
+        raw.AddRange(new byte[] { 0x15, 0x00, 0x02, 0x00, 0x00 }); // ODS, size 2: truncated
+        raw.AddRange(new byte[] { 0x80, 0x00, 0x00 }); // END
+
+        WithTempFile(raw.ToArray(), path =>
+        {
+            var pcsDataList = BluRaySupParser.ParseRawPgsSegmentStream(path, new StringBuilder());
+            var withImages = pcsDataList.Where(p => p.PcsObjects.Count > 0).ToList();
+            Assert.Equal(2, withImages.Count);
+
+            foreach (var pcsData in withImages)
+            {
+                using var decoded = pcsData.GetBitmap();
+                Assert.Equal(64, decoded.Width); // image data intact, not clobbered
+                Assert.Equal(32, decoded.Height);
+            }
+        });
+    }
+
+    [Fact]
     public void SetPlaceholderTimingsAssignsSequentialNonOverlappingTimes()
     {
         var sup = CreateSupContent(3);


### PR DESCRIPTION
Bug-hunt sweep over recent commits; all four verified in code before fixing.

1. **Extend to previous shot change could *shorten* the line** (`MainViewModel.cs`): the lookup compared the raw shot-change position with strict `<` but added the 2-frame in-cues gap afterwards, so a start within the gap after a cut moved forward. The strict comparison now applies to the gap-adjusted position.
2. **Extend to next shot change could pull the end backward ~2–3 frames**: `GetNextShotChangeMinusGapInMs`'s one-frame tolerance can resolve to a shot change just *before* the current end, then subtracts the out-cues gap. Replaced with a strictly-forward lookup on gap-adjusted positions — the command can now only extend.
3. **BluRaySupParser stale rented-buffer reads** (from the ArrayPool perf commit): truncated ODS/PDS/WDS segments used to throw and be skipped; with the reused buffer they read stale bytes from the previous segment — a fabricated ObjectId could overwrite a live object's image with an empty one. Added `segment.Size` bounds checks (ODS returns ObjectId −1 → existing "missing first ods" path), and the rented buffer is now returned in a `finally`. Regression test appends a truncated ODS to a synthetic raw stream and asserts the real objects still decode intact.
4. **`ToAvaloniaBitmap` null-Copy fallthrough**: if `Copy(Bgra8888)` fails, the code fell through to the unsafe 4-bytes/pixel walk it was guarding; now returns a 1×1 placeholder. Plus `IsRawPgsSegmentStream` now fills its sniff buffer across partial reads (network shares).

Full suite passes (1,593 tests). The two shot-change fixes are pure-logic changes in the command bodies; worth a quick waveform sanity check in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)