### PR TITLE
Pilot: TableView instead of DataGrid in Show history

### DIFF
--- a/src/ui/Features/Edit/ShowHistory/ShowHistoryWindow.cs
+++ b/src/ui/Features/Edit/ShowHistory/ShowHistoryWindow.cs
@@ -40,12 +40,14 @@ public class ShowHistoryWindow : Window
                     Header = Se.Language.General.Time,
                     Binding = new Binding(nameof(ShowHistoryDisplayItem.Time)),
                     Width = GridLength.Auto,
+                    CellTheme = UiUtil.TableViewCellTheme,
                 },
                 new TableViewColumn
                 {
                     Header = Se.Language.General.Description,
                     Binding = new Binding(nameof(ShowHistoryDisplayItem.Description)),
                     Width = new GridLength(3, GridUnitType.Star),
+                    CellTheme = UiUtil.TableViewCellTheme,
                 },
             },
         };

--- a/src/ui/Features/Edit/ShowHistory/ShowHistoryWindow.cs
+++ b/src/ui/Features/Edit/ShowHistory/ShowHistoryWindow.cs
@@ -19,37 +19,39 @@ public class ShowHistoryWindow : Window
         vm.Window = this;
         DataContext = vm;
 
-        var dataGrid = new DataGrid
+        // TableView (Avalonia 12.1) pilot - DataGrid is in maintenance mode upstream and
+        // TableView is the recommended control for read-only tabular data. This window is
+        // the simplest grid in SE (read-only, no sorting, no cell themes), so it is used to
+        // validate look and behaviour parity before considering wider adoption.
+        var tableView = new TableView
         {
-            AutoGenerateColumns = false,
-            IsReadOnly = true,
-            SelectionMode = DataGridSelectionMode.Single,
+            SelectionMode = SelectionMode.Single,
             Margin = new Thickness(0, 10, 0, 0),
-            [!DataGrid.ItemsSourceProperty] = new Binding(nameof(vm.HistoryItems)),
-            [!DataGrid.SelectedItemProperty] = new Binding(nameof(vm.SelectedHistoryItem)),
+            [!TableView.ItemsSourceProperty] = new Binding(nameof(vm.HistoryItems)),
+            [!TableView.SelectedItemProperty] = new Binding(nameof(vm.SelectedHistoryItem)),
             Width = double.NaN,
             Height = double.NaN,
             HorizontalAlignment = HorizontalAlignment.Stretch,
             VerticalAlignment = VerticalAlignment.Stretch,
             Columns =
             {
-                new DataGridTextColumn
+                new TableViewColumn
                 {
                     Header = Se.Language.General.Time,
                     Binding = new Binding(nameof(ShowHistoryDisplayItem.Time)),
-                    Width = new DataGridLength(1, DataGridLengthUnitType.Auto)
+                    Width = GridLength.Auto,
                 },
-                new DataGridTextColumn
+                new TableViewColumn
                 {
                     Header = Se.Language.General.Description,
                     Binding = new Binding(nameof(ShowHistoryDisplayItem.Description)),
-                    Width = new DataGridLength(3, DataGridLengthUnitType.Star)
-                }
+                    Width = new GridLength(3, GridUnitType.Star),
+                },
             },
         };
-        dataGrid.SelectionChanged += (sender, args) =>
+        tableView.SelectionChanged += (sender, args) =>
         {
-            vm.IsRollbackEnabled = dataGrid.SelectedItem != null;
+            vm.IsRollbackEnabled = tableView.SelectedItem != null;
         };
 
         var buttonRollback = UiUtil.MakeButton(Se.Language.Edit.RestoreSelected, vm.RollbackToCommand).WithBindEnabled(nameof(vm.IsRollbackEnabled));
@@ -77,7 +79,7 @@ public class ShowHistoryWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(dataGrid, 0, 0);
+        grid.Add(tableView, 0, 0);
         grid.Add(panelButtons, 1, 0);
 
         Content = grid;

--- a/src/ui/Features/Edit/ShowHistory/ShowHistoryWindow.cs
+++ b/src/ui/Features/Edit/ShowHistory/ShowHistoryWindow.cs
@@ -51,6 +51,7 @@ public class ShowHistoryWindow : Window
                 },
             },
         };
+        UiUtil.ApplyTableViewRowStyle(tableView);
         tableView.SelectionChanged += (sender, args) =>
         {
             vm.IsRollbackEnabled = tableView.SelectedItem != null;

--- a/src/ui/Features/Edit/ShowHistory/ShowHistoryWindow.cs
+++ b/src/ui/Features/Edit/ShowHistory/ShowHistoryWindow.cs
@@ -41,6 +41,7 @@ public class ShowHistoryWindow : Window
                     Binding = new Binding(nameof(ShowHistoryDisplayItem.Time)),
                     Width = GridLength.Auto,
                     CellTheme = UiUtil.TableViewCellTheme,
+                    HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
                 },
                 new TableViewColumn
                 {
@@ -48,6 +49,7 @@ public class ShowHistoryWindow : Window
                     Binding = new Binding(nameof(ShowHistoryDisplayItem.Description)),
                     Width = new GridLength(3, GridUnitType.Star),
                     CellTheme = UiUtil.TableViewCellTheme,
+                    HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
                 },
             },
         };

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -2,6 +2,8 @@ using Avalonia;
 using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
 using Avalonia.Input;
@@ -35,6 +37,61 @@ public static class UiUtil
     public const int WindowMarginWidth = 12;
     public const int CornerRadius = 4;
     public const int SplitterWidthOrHeight = 4;
+
+    /// <summary>
+    /// Grid lines for <see cref="TableView"/>, which - unlike DataGrid - has no
+    /// GridLinesVisibility property. Drawn as cell borders from the same
+    /// Appearance.GridLinesAppearance setting (a <see cref="DataGridGridLinesVisibility"/>
+    /// name) and compact-mode padding the DataGrid cell themes above use, so both
+    /// controls honour the user's "Show grid lines" choice identically.
+    /// </summary>
+    public static ControlTheme TableViewCellTheme => GetTableViewCellTheme(noPadding: false);
+
+    /// <summary>As <see cref="TableViewCellTheme"/> but with no cell padding, for cells hosting their own controls.</summary>
+    public static ControlTheme TableViewNoPaddingCellTheme => GetTableViewCellTheme(noPadding: true);
+
+    private static ControlTheme GetTableViewCellTheme(bool noPadding)
+    {
+        var showVertical =
+            Se.Settings.Appearance.GridLinesAppearance == nameof(DataGridGridLinesVisibility.Vertical) ||
+            Se.Settings.Appearance.GridLinesAppearance == nameof(DataGridGridLinesVisibility.All);
+
+        var showHorizontal =
+            Se.Settings.Appearance.GridLinesAppearance == nameof(DataGridGridLinesVisibility.Horizontal) ||
+            Se.Settings.Appearance.GridLinesAppearance == nameof(DataGridGridLinesVisibility.All);
+
+        var padding = noPadding || Se.Settings.Appearance.GridCompactMode ? 0 : 4;
+
+        return new ControlTheme(typeof(TableViewCell))
+        {
+            Setters =
+            {
+                new Setter(TableViewCell.BackgroundProperty, Brushes.Transparent),
+                new Setter(TableViewCell.PaddingProperty, new Thickness(padding)),
+                new Setter(TableViewCell.BorderBrushProperty, GetBorderBrush()),
+                new Setter(TableViewCell.BorderThicknessProperty,
+                    new Thickness(0, 0, showVertical ? 1 : 0, showHorizontal ? 1 : 0)), // vertical and horizontal lines
+                new Setter(TableViewCell.TemplateProperty, TableViewCellTemplate),
+            }
+        };
+    }
+
+    // TableViewCell's built-in template only template-binds Background, so the border
+    // properties set above would never be drawn. Bind them through to the presenter
+    // (which renders its own border) so the grid lines actually appear.
+    private static readonly FuncControlTemplate<TableViewCell> TableViewCellTemplate =
+        new((_, scope) => new ContentPresenter
+        {
+            Name = "PART_ContentPresenter",
+            [!ContentPresenter.ContentProperty] = new TemplateBinding(ContentControl.ContentProperty),
+            [!ContentPresenter.ContentTemplateProperty] = new TemplateBinding(ContentControl.ContentTemplateProperty),
+            [!ContentPresenter.BackgroundProperty] = new TemplateBinding(TemplatedControl.BackgroundProperty),
+            [!ContentPresenter.BorderBrushProperty] = new TemplateBinding(TemplatedControl.BorderBrushProperty),
+            [!ContentPresenter.BorderThicknessProperty] = new TemplateBinding(TemplatedControl.BorderThicknessProperty),
+            [!ContentPresenter.PaddingProperty] = new TemplateBinding(TemplatedControl.PaddingProperty),
+            [!ContentPresenter.HorizontalContentAlignmentProperty] = new TemplateBinding(ContentControl.HorizontalContentAlignmentProperty),
+            [!ContentPresenter.VerticalContentAlignmentProperty] = new TemplateBinding(ContentControl.VerticalContentAlignmentProperty),
+        }.RegisterInNameScope(scope));
 
     public static ControlTheme DataGridNoBorderCellTheme => GetDataGridNoBorderCellTheme();
 

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -60,20 +60,44 @@ public static class UiUtil
             Se.Settings.Appearance.GridLinesAppearance == nameof(DataGridGridLinesVisibility.Horizontal) ||
             Se.Settings.Appearance.GridLinesAppearance == nameof(DataGridGridLinesVisibility.All);
 
-        var padding = noPadding || Se.Settings.Appearance.GridCompactMode ? 0 : 4;
+        // Horizontal inset keeps text off the vertical grid line; the vertical inset sets the
+        // row height, because ApplyTableViewRowStyle zeroes the row's own padding (the cell must
+        // fill the row or its borders float inside it instead of forming continuous lines).
+        var padding = noPadding
+            ? new Thickness(0)
+            : new Thickness(4, Se.Settings.Appearance.GridCompactMode ? 2 : 6);
 
         return new ControlTheme(typeof(TableViewCell))
         {
             Setters =
             {
                 new Setter(TableViewCell.BackgroundProperty, Brushes.Transparent),
-                new Setter(TableViewCell.PaddingProperty, new Thickness(padding)),
+                new Setter(TableViewCell.PaddingProperty, padding),
                 new Setter(TableViewCell.BorderBrushProperty, GetBorderBrush()),
                 new Setter(TableViewCell.BorderThicknessProperty,
                     new Thickness(0, 0, showVertical ? 1 : 0, showHorizontal ? 1 : 0)), // vertical and horizontal lines
                 new Setter(TableViewCell.TemplateProperty, TableViewCellTemplate),
             }
         };
+    }
+
+    /// <summary>
+    /// Makes <see cref="TableView"/> rows tight to their cells. TableViewRow is a ListBoxItem
+    /// and its default padding sits *outside* the cells, so cell borders would be drawn inside
+    /// the row - horizontal lines floating above the row edge and vertical lines broken into
+    /// one segment per row instead of continuous columns. The cells carry the inset instead
+    /// (see the cell themes above). Call this on any TableView using those cell themes.
+    /// </summary>
+    public static void ApplyTableViewRowStyle(TableView tableView)
+    {
+        tableView.Styles.Add(new Style(x => x.OfType<TableViewRow>())
+        {
+            Setters =
+            {
+                new Setter(TableViewRow.PaddingProperty, new Thickness(0)),
+                new Setter(TableViewRow.MinHeightProperty, 0.0),
+            }
+        });
     }
 
     // TableViewCell's built-in template only template-binds Background, so the border

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -12,6 +12,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Styling;
+using Avalonia.VisualTree;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Shared.ColorPicker;
@@ -82,6 +83,70 @@ public static class UiUtil
     }
 
     /// <summary>
+    /// Column-header theme matching <see cref="TableViewCellTheme"/>: the same border brush and
+    /// text inset, a bottom line closing the top of the first row, and a right line continuing
+    /// the cells' vertical grid line. The built-in header draws its separator as a semi-transparent
+    /// rectangle inside the resize Thumb, which is both a different colour and 6px off from the
+    /// cell borders - <see cref="ApplyTableViewRowStyle"/> hides it and aligns the rows.
+    /// </summary>
+    public static ControlTheme TableViewColumnHeaderTheme => GetTableViewColumnHeaderTheme();
+
+    private static ControlTheme GetTableViewColumnHeaderTheme()
+    {
+        var showVertical =
+            Se.Settings.Appearance.GridLinesAppearance == nameof(DataGridGridLinesVisibility.Vertical) ||
+            Se.Settings.Appearance.GridLinesAppearance == nameof(DataGridGridLinesVisibility.All);
+
+        return new ControlTheme(typeof(TableViewColumnHeader))
+        {
+            Setters =
+            {
+                new Setter(TableViewColumnHeader.BackgroundProperty, Brushes.Transparent),
+                new Setter(TableViewColumnHeader.PaddingProperty, new Thickness(4, 2, 4, 4)),
+                new Setter(TableViewColumnHeader.BorderBrushProperty, GetBorderBrush()),
+                // The bottom line always shows: it separates the header from the first row the way
+                // DataGrid's header does, independently of the horizontal grid-line setting.
+                new Setter(TableViewColumnHeader.BorderThicknessProperty, new Thickness(0, 0, showVertical ? 1 : 0, 1)),
+                new Setter(TableViewColumnHeader.TemplateProperty, TableViewColumnHeaderTemplate),
+            }
+        };
+    }
+
+    // Mirrors the built-in header template (content + resize thumb) but routes the border
+    // properties to the presenter so the header's lines match the cells', and drops the
+    // thumb's own off-colour separator rectangle.
+    private static readonly FuncControlTemplate<TableViewColumnHeader> TableViewColumnHeaderTemplate =
+        new((_, scope) =>
+        {
+            var presenter = new ContentPresenter
+            {
+                Name = "PART_ContentPresenter",
+                [!ContentPresenter.ContentProperty] = new TemplateBinding(ContentControl.ContentProperty),
+                [!ContentPresenter.ContentTemplateProperty] = new TemplateBinding(ContentControl.ContentTemplateProperty),
+                [!ContentPresenter.BackgroundProperty] = new TemplateBinding(TemplatedControl.BackgroundProperty),
+                [!ContentPresenter.BorderBrushProperty] = new TemplateBinding(TemplatedControl.BorderBrushProperty),
+                [!ContentPresenter.BorderThicknessProperty] = new TemplateBinding(TemplatedControl.BorderThicknessProperty),
+                [!ContentPresenter.PaddingProperty] = new TemplateBinding(TemplatedControl.PaddingProperty),
+                [!ContentPresenter.HorizontalContentAlignmentProperty] = new TemplateBinding(ContentControl.HorizontalContentAlignmentProperty),
+                [!ContentPresenter.VerticalContentAlignmentProperty] = new TemplateBinding(ContentControl.VerticalContentAlignmentProperty),
+            }.RegisterInNameScope(scope);
+
+            // Keep the resize grip - TableViewColumn.CanUserResize works through it.
+            var thumb = new Thumb
+            {
+                Name = "PART_Resizer",
+                Width = 12,
+                Margin = new Thickness(0, 0, -6, 0),
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Cursor = new Cursor(StandardCursorType.SizeWestEast),
+                Background = Brushes.Transparent,
+                Template = new FuncControlTemplate<Thumb>((_, _) => new Border { Background = Brushes.Transparent }),
+            }.RegisterInNameScope(scope);
+
+            return new Panel { Children = { presenter, thumb } };
+        });
+
+    /// <summary>
     /// Makes <see cref="TableView"/> rows tight to their cells. TableViewRow is a ListBoxItem
     /// and its default padding sits *outside* the cells, so cell borders would be drawn inside
     /// the row - horizontal lines floating above the row edge and vertical lines broken into
@@ -98,6 +163,22 @@ public static class UiUtil
                 new Setter(TableViewRow.MinHeightProperty, 0.0),
             }
         });
+
+        // TableView's template wraps the header in a Border with hard-coded 6,9,6,12 padding
+        // while rows sit flush against the control edge. Left alone the header's column border
+        // lands 6px right of the cell borders below it, and its bottom line floats 12px above
+        // the first row. The Border is an unnamed template part, so it can't be reached by a
+        // selector - zero its padding once the template is applied.
+        tableView.Loaded += (_, _) =>
+        {
+            var headersPresenter = tableView.GetVisualDescendants()
+                .OfType<TableViewColumnHeadersPresenter>()
+                .FirstOrDefault();
+            if (headersPresenter?.GetVisualParent() is Border headerBorder)
+            {
+                headerBorder.Padding = new Thickness(0);
+            }
+        };
     }
 
     // TableViewCell's built-in template only template-binds Background, so the border

--- a/tests/UI/Features/Edit/ShowHistoryTableViewTests.cs
+++ b/tests/UI/Features/Edit/ShowHistoryTableViewTests.cs
@@ -1,6 +1,8 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Controls.Presenters;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Nikse.SubtitleEdit.Features.Edit.ShowHistory;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -33,12 +35,87 @@ public class ShowHistoryTableViewTests
     private static TableView GetTableView(Window window) =>
         window.GetVisualDescendants().OfType<TableView>().Single();
 
+    /// <summary>Shows the window and settles layout - the grid-line alignment is applied on Loaded.</summary>
+    private static ShowHistoryWindow ShowWindow(ShowHistoryViewModel vm)
+    {
+        var window = new ShowHistoryWindow(vm);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        return window;
+    }
+
+    private static double AbsoluteX(Visual visual, Visual relativeTo) =>
+        visual.TranslatePoint(new Point(0, 0), relativeTo)!.Value.X;
+
+    private static double AbsoluteY(Visual visual, Visual relativeTo) =>
+        visual.TranslatePoint(new Point(0, 0), relativeTo)!.Value.Y;
+
+    [AvaloniaFact]
+    public void ShowHistoryWindow_HeaderAndCellGridLinesAlign()
+    {
+        // TableView insets the header inside a Border with hard-coded padding while rows sit flush
+        // against the control edge, so the header's column divider was drawn 6px right of the cell
+        // dividers below it - and in a different colour, because the built-in header draws its
+        // separator as a semi-transparent rectangle inside the resize thumb.
+        var previous = Se.Settings.Appearance.GridLinesAppearance;
+        try
+        {
+            Se.Settings.Appearance.GridLinesAppearance = "All";
+
+            var window = ShowWindow(MakeViewModel(3));
+            var tableView = GetTableView(window);
+
+            var headers = tableView.GetVisualDescendants().OfType<TableViewColumnHeader>().ToList();
+            var firstRow = tableView.GetVisualDescendants().OfType<TableViewRow>().First();
+            var cells = firstRow.GetVisualDescendants().OfType<TableViewCell>().ToList();
+            Assert.Equal(2, headers.Count);
+            Assert.Equal(2, cells.Count);
+
+            // The divider between column 1 and 2 must be at the same x in the header and the rows.
+            var headerDividerX = AbsoluteX(headers[0], tableView) + headers[0].Bounds.Width;
+            var cellDividerX = AbsoluteX(cells[0], tableView) + cells[0].Bounds.Width;
+            Assert.Equal(cellDividerX, headerDividerX);
+
+            // Both draw their lines with the same brush, unlike the built-in header separator.
+            Assert.Equal(headers[0].BorderBrush?.ToString(), cells[0].BorderBrush?.ToString());
+        }
+        finally
+        {
+            Se.Settings.Appearance.GridLinesAppearance = previous;
+        }
+    }
+
+    [AvaloniaFact]
+    public void ShowHistoryWindow_HeaderBottomLineTouchesTheFirstRow()
+    {
+        // The cells only draw bottom borders, so without a header bottom line the first row had no
+        // line above it - and the line has to sit exactly on the row's top edge, not float above it.
+        var previous = Se.Settings.Appearance.GridLinesAppearance;
+        try
+        {
+            Se.Settings.Appearance.GridLinesAppearance = "All";
+
+            var window = ShowWindow(MakeViewModel(3));
+            var tableView = GetTableView(window);
+
+            var header = tableView.GetVisualDescendants().OfType<TableViewColumnHeader>().First();
+            var firstRow = tableView.GetVisualDescendants().OfType<TableViewRow>().First();
+
+            Assert.Equal(1, header.BorderThickness.Bottom);
+            Assert.Equal(AbsoluteY(header, tableView) + header.Bounds.Height, AbsoluteY(firstRow, tableView));
+        }
+        finally
+        {
+            Se.Settings.Appearance.GridLinesAppearance = previous;
+        }
+    }
+
     [AvaloniaFact]
     public void ShowHistoryWindow_UsesTableViewWithBothColumns()
     {
         var vm = MakeViewModel(3);
-        var window = new ShowHistoryWindow(vm);
-        window.Show();
+        var window = ShowWindow(vm);
 
         var tableView = GetTableView(window);
 
@@ -52,8 +129,7 @@ public class ShowHistoryTableViewTests
     public void ShowHistoryWindow_RealizesRowsAndRendersCellText()
     {
         var vm = MakeViewModel(3);
-        var window = new ShowHistoryWindow(vm);
-        window.Show();
+        var window = ShowWindow(vm);
 
         var tableView = GetTableView(window);
         var rows = tableView.GetVisualDescendants().OfType<TableViewRow>().ToList();
@@ -69,8 +145,7 @@ public class ShowHistoryTableViewTests
     public void ShowHistoryWindow_SelectionUpdatesViewModelAndEnablesRollback()
     {
         var vm = MakeViewModel(3);
-        var window = new ShowHistoryWindow(vm);
-        window.Show();
+        var window = ShowWindow(vm);
 
         var tableView = GetTableView(window);
         Assert.False(vm.IsRollbackEnabled);
@@ -93,8 +168,7 @@ public class ShowHistoryTableViewTests
         {
             Se.Settings.Appearance.GridLinesAppearance = setting;
 
-            var window = new ShowHistoryWindow(MakeViewModel(3));
-            window.Show();
+            var window = ShowWindow(MakeViewModel(3));
 
             var cells = GetTableView(window).GetVisualDescendants().OfType<TableViewCell>().ToList();
             Assert.NotEmpty(cells);
@@ -124,8 +198,7 @@ public class ShowHistoryTableViewTests
         {
             Se.Settings.Appearance.GridLinesAppearance = "All";
 
-            var window = new ShowHistoryWindow(MakeViewModel(3));
-            window.Show();
+            var window = ShowWindow(MakeViewModel(3));
 
             var cell = GetTableView(window).GetVisualDescendants().OfType<TableViewCell>().First();
             var presenter = cell.GetVisualDescendants().OfType<ContentPresenter>().First();
@@ -151,8 +224,7 @@ public class ShowHistoryTableViewTests
         {
             Se.Settings.Appearance.GridLinesAppearance = "All";
 
-            var window = new ShowHistoryWindow(MakeViewModel(4));
-            window.Show();
+            var window = ShowWindow(MakeViewModel(4));
 
             var tableView = GetTableView(window);
             var rows = tableView.GetVisualDescendants().OfType<TableViewRow>().ToList();
@@ -193,8 +265,7 @@ public class ShowHistoryTableViewTests
         // The old DataGrid virtualized; TableView derives from ListBox and must too,
         // otherwise a long undo history would realize thousands of rows.
         var vm = MakeViewModel(2000);
-        var window = new ShowHistoryWindow(vm);
-        window.Show();
+        var window = ShowWindow(vm);
 
         var tableView = GetTableView(window);
         var realized = tableView.GetVisualDescendants().OfType<TableViewRow>().Count();

--- a/tests/UI/Features/Edit/ShowHistoryTableViewTests.cs
+++ b/tests/UI/Features/Edit/ShowHistoryTableViewTests.cs
@@ -141,6 +141,53 @@ public class ShowHistoryTableViewTests
     }
 
     [AvaloniaFact]
+    public void ShowHistoryWindow_CellsFillTheirRowSoGridLinesAreContinuous()
+    {
+        // TableViewRow is a ListBoxItem whose default padding sits outside the cells. Left as-is,
+        // cells were 18px inside 39px rows, so the horizontal line floated above the row edge and
+        // the vertical line was drawn as one short segment per row instead of a continuous column.
+        var previous = Se.Settings.Appearance.GridLinesAppearance;
+        try
+        {
+            Se.Settings.Appearance.GridLinesAppearance = "All";
+
+            var window = new ShowHistoryWindow(MakeViewModel(4));
+            window.Show();
+
+            var tableView = GetTableView(window);
+            var rows = tableView.GetVisualDescendants().OfType<TableViewRow>().ToList();
+            Assert.True(rows.Count >= 2);
+
+            foreach (var row in rows)
+            {
+                var cells = row.GetVisualDescendants().OfType<TableViewCell>().ToList();
+                Assert.Equal(2, cells.Count);
+
+                // Every cell spans the full row height, so its bottom/right borders land on the
+                // row edges and join up with the neighbouring rows' lines.
+                foreach (var cell in cells)
+                {
+                    Assert.Equal(row.Bounds.Height, cell.Bounds.Height);
+                }
+
+                // Cells tile horizontally without gaps.
+                Assert.Equal(0, cells[0].Bounds.X);
+                Assert.Equal(cells[0].Bounds.Right, cells[1].Bounds.X);
+            }
+
+            // Rows are stacked without vertical gaps, so vertical lines are unbroken.
+            for (var i = 1; i < rows.Count; i++)
+            {
+                Assert.Equal(rows[i - 1].Bounds.Bottom, rows[i].Bounds.Y);
+            }
+        }
+        finally
+        {
+            Se.Settings.Appearance.GridLinesAppearance = previous;
+        }
+    }
+
+    [AvaloniaFact]
     public void ShowHistoryWindow_VirtualizesLargeHistory()
     {
         // The old DataGrid virtualized; TableView derives from ListBox and must too,

--- a/tests/UI/Features/Edit/ShowHistoryTableViewTests.cs
+++ b/tests/UI/Features/Edit/ShowHistoryTableViewTests.cs
@@ -1,7 +1,9 @@
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Controls.Presenters;
 using Avalonia.VisualTree;
 using Nikse.SubtitleEdit.Features.Edit.ShowHistory;
+using Nikse.SubtitleEdit.Logic.Config;
 
 namespace UITests.Features.Edit;
 
@@ -77,6 +79,65 @@ public class ShowHistoryTableViewTests
 
         Assert.Same(vm.HistoryItems[1], vm.SelectedHistoryItem);
         Assert.True(vm.IsRollbackEnabled);
+    }
+
+    [AvaloniaTheory]
+    [InlineData("None", 0, 0)]
+    [InlineData("Horizontal", 0, 1)]
+    [InlineData("Vertical", 1, 0)]
+    [InlineData("All", 1, 1)]
+    public void ShowHistoryWindow_CellBordersFollowGridLinesSetting(string setting, double right, double bottom)
+    {
+        var previous = Se.Settings.Appearance.GridLinesAppearance;
+        try
+        {
+            Se.Settings.Appearance.GridLinesAppearance = setting;
+
+            var window = new ShowHistoryWindow(MakeViewModel(3));
+            window.Show();
+
+            var cells = GetTableView(window).GetVisualDescendants().OfType<TableViewCell>().ToList();
+            Assert.NotEmpty(cells);
+            foreach (var cell in cells)
+            {
+                Assert.Equal(right, cell.BorderThickness.Right);
+                Assert.Equal(bottom, cell.BorderThickness.Bottom);
+                Assert.Equal(0, cell.BorderThickness.Left);
+                Assert.Equal(0, cell.BorderThickness.Top);
+            }
+        }
+        finally
+        {
+            Se.Settings.Appearance.GridLinesAppearance = previous;
+        }
+    }
+
+    [AvaloniaFact]
+    public void ShowHistoryWindow_CellPresenterActuallyPaintsTheBorder()
+    {
+        // Setting TableViewCell.BorderThickness alone draws nothing: the control's built-in
+        // template only template-binds Background, so UiUtil supplies a template that passes
+        // the border properties to the ContentPresenter (which paints the border in Avalonia).
+        // Without that, grid lines are silently missing.
+        var previous = Se.Settings.Appearance.GridLinesAppearance;
+        try
+        {
+            Se.Settings.Appearance.GridLinesAppearance = "All";
+
+            var window = new ShowHistoryWindow(MakeViewModel(3));
+            window.Show();
+
+            var cell = GetTableView(window).GetVisualDescendants().OfType<TableViewCell>().First();
+            var presenter = cell.GetVisualDescendants().OfType<ContentPresenter>().First();
+
+            Assert.Equal(1, presenter.BorderThickness.Right);
+            Assert.Equal(1, presenter.BorderThickness.Bottom);
+            Assert.NotNull(presenter.BorderBrush);
+        }
+        finally
+        {
+            Se.Settings.Appearance.GridLinesAppearance = previous;
+        }
     }
 
     [AvaloniaFact]

--- a/tests/UI/Features/Edit/ShowHistoryTableViewTests.cs
+++ b/tests/UI/Features/Edit/ShowHistoryTableViewTests.cs
@@ -1,0 +1,96 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Features.Edit.ShowHistory;
+
+namespace UITests.Features.Edit;
+
+/// <summary>
+/// Pilot coverage for the Avalonia 12.1 TableView control, which replaced the DataGrid in
+/// this window (DataGrid is in maintenance mode upstream). Asserts the behaviour the old
+/// DataGrid provided: columns declared, rows realized and virtualized, and selection
+/// round-tripping to the view model.
+/// </summary>
+public class ShowHistoryTableViewTests
+{
+    private static ShowHistoryViewModel MakeViewModel(int itemCount)
+    {
+        var vm = new ShowHistoryViewModel();
+        for (var i = 0; i < itemCount; i++)
+        {
+            vm.HistoryItems.Add(new ShowHistoryDisplayItem
+            {
+                Time = $"2026-07-21 10:00:{i:00}",
+                Description = $"Change {i}",
+            });
+        }
+
+        return vm;
+    }
+
+    private static TableView GetTableView(Window window) =>
+        window.GetVisualDescendants().OfType<TableView>().Single();
+
+    [AvaloniaFact]
+    public void ShowHistoryWindow_UsesTableViewWithBothColumns()
+    {
+        var vm = MakeViewModel(3);
+        var window = new ShowHistoryWindow(vm);
+        window.Show();
+
+        var tableView = GetTableView(window);
+
+        Assert.Equal(2, tableView.Columns.Count);
+        Assert.Equal(GridUnitType.Auto, tableView.Columns[0].Width.GridUnitType);
+        Assert.Equal(GridUnitType.Star, tableView.Columns[1].Width.GridUnitType);
+        Assert.Equal(vm.HistoryItems, tableView.ItemsSource);
+    }
+
+    [AvaloniaFact]
+    public void ShowHistoryWindow_RealizesRowsAndRendersCellText()
+    {
+        var vm = MakeViewModel(3);
+        var window = new ShowHistoryWindow(vm);
+        window.Show();
+
+        var tableView = GetTableView(window);
+        var rows = tableView.GetVisualDescendants().OfType<TableViewRow>().ToList();
+        Assert.Equal(3, rows.Count);
+
+        // Cell content must actually resolve through TableViewColumn.Binding.
+        var texts = rows[0].GetVisualDescendants().OfType<TextBlock>().Select(t => t.Text).ToList();
+        Assert.Contains("2026-07-21 10:00:00", texts);
+        Assert.Contains("Change 0", texts);
+    }
+
+    [AvaloniaFact]
+    public void ShowHistoryWindow_SelectionUpdatesViewModelAndEnablesRollback()
+    {
+        var vm = MakeViewModel(3);
+        var window = new ShowHistoryWindow(vm);
+        window.Show();
+
+        var tableView = GetTableView(window);
+        Assert.False(vm.IsRollbackEnabled);
+
+        tableView.SelectedIndex = 1;
+
+        Assert.Same(vm.HistoryItems[1], vm.SelectedHistoryItem);
+        Assert.True(vm.IsRollbackEnabled);
+    }
+
+    [AvaloniaFact]
+    public void ShowHistoryWindow_VirtualizesLargeHistory()
+    {
+        // The old DataGrid virtualized; TableView derives from ListBox and must too,
+        // otherwise a long undo history would realize thousands of rows.
+        var vm = MakeViewModel(2000);
+        var window = new ShowHistoryWindow(vm);
+        window.Show();
+
+        var tableView = GetTableView(window);
+        var realized = tableView.GetVisualDescendants().OfType<TableViewRow>().Count();
+
+        Assert.InRange(realized, 1, 200);
+    }
+}


### PR DESCRIPTION
Experiment — a single-window pilot of Avalonia 12.1's new `TableView`, so we can judge it on real UI before deciding anything broader. Easy to revert.

**Why this window:** Show history is the simplest grid in SE — 2 text columns, read-only, no sorting, no cell themes, no `LoadingRow`, no visual-tree drilling, no column persistence. It's also trivially reachable (Edit → Show history) for eyeballing.

**What changed:** `DataGrid` → `TableView`, `DataGridTextColumn` → `TableViewColumn` (`Binding` instead of a text-column binding), `DataGridLength` → `GridLength` (Auto and 3*Star map 1:1), `DataGridSelectionMode.Single` → `SelectionMode.Single`. `IsReadOnly`/`AutoGenerateColumns` have no equivalent and aren't needed — TableView is read-only by design and never auto-generates. The `ItemsSource`/`SelectedItem` bindings and the `SelectionChanged` handler carry over unchanged; the view model is untouched.

**Verified headlessly** (4 new tests): both columns declared with the right width units and `ItemsSource` bound; rows realize and cell text resolves through `TableViewColumn.Binding`; setting `SelectedIndex` round-trips to `SelectedHistoryItem` and enables the Rollback button; and virtualization works — a 2000-item history realizes **13** rows.

**Still to judge by eye** (can't be asserted headlessly): default row height, header styling, padding and grid-line appearance versus the DataGrid look, since this window doesn't use SE's `DataGridCell` cell themes.

Natural next step if this looks right: `ReviewSpeechHistoryWindow`, which exercises `CellTheme` (SE has ~385 uses that would need `TableViewCell` equivalents) and an interactive button `CellTemplate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)