### PR TITLE
Reopen original subtitle on start-up too (#12705)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -15559,6 +15559,7 @@ public partial class MainViewModel :
                         if (result.OkPressed)
                         {
                             VideoCloseFile();
+                            ResetSubtitle();
                             _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
                             _converted = true;
                             ReplaceSubtitles(result.OcredSubtitle);
@@ -15606,6 +15607,7 @@ public partial class MainViewModel :
                     if (result.OkPressed)
                     {
                         VideoCloseFile();
+                        ResetSubtitle();
                         _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
                         _converted = true;
                         ReplaceSubtitles(result.OcredSubtitle);
@@ -16481,6 +16483,7 @@ public partial class MainViewModel :
             if (result.OkPressed)
             {
                 VideoCloseFile();
+                ResetSubtitle();
                 _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
                 ReplaceSubtitles(result.OcredSubtitle);
                 SelectAndScrollToRow(0);
@@ -16779,6 +16782,7 @@ public partial class MainViewModel :
                 if (result.OkPressed)
                 {
                     VideoCloseFile();
+                    ResetSubtitle();
                     _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
                     _converted = true;
                     ReplaceSubtitles(result.OcredSubtitle);
@@ -16993,6 +16997,7 @@ public partial class MainViewModel :
             if (result.OkPressed)
             {
                 VideoCloseFile();
+                ResetSubtitle();
                 _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
                 ReplaceSubtitles(result.OcredSubtitle);
                 SelectAndScrollToRow(0);
@@ -17140,6 +17145,7 @@ public partial class MainViewModel :
         if (result.OkPressed)
         {
             VideoCloseFile();
+            ResetSubtitle();
             _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(vobSubFileName);
             _converted = true;
             ReplaceSubtitles(result.OcredSubtitle);
@@ -18114,6 +18120,14 @@ public partial class MainViewModel :
 
                         await SubtitleOpen(first.SubtitleFileName, first.VideoFileName, first.SelectedLine, null, skipLoadVideo, first.AudioTrack);
                         await SeekVideoToSelectedLineAsync();
+
+                        // Restore the original/translator-mode file too - otherwise only the
+                        // translation comes back on start-up, unlike the Reopen menu (issue #12705).
+                        if (!string.IsNullOrEmpty(first.SubtitleFileNameOriginal) &&
+                            File.Exists(first.SubtitleFileNameOriginal))
+                        {
+                            await SubtitleOpenOriginal(first.SelectedLine, first.SubtitleFileNameOriginal);
+                        }
 
                         SetRecentFileProperties(first);
                     }


### PR DESCRIPTION
Fixes the first point of #12705: "the app does not remember the last opened subtitle pair - only the translated subtitle is restored, not the original".

### Start-up restore dropped the original

`CommandFileReopen` (the Reopen menu) restores both files, but the "open last file on start" path only opened `first.SubtitleFileName` and stopped there — the original was in the recent-file entry but never loaded. Mirrored the Reopen logic.

Recent-file entries are keyed on the **pair** `(SubtitleFileName, SubtitleFileNameOriginal)` (`SeFile.cs`), so this also decayed over time: starting up without the original meant the next `AddToRecentFiles` wrote an empty original, which didn't match the existing paired entry, inserted a second one, and pushed the paired entry down the 25-item list until it fell off. Loading the original before any later recent-files write stops that too.

### Missing `ResetSubtitle()` in six OCR-import paths

While checking how translator mode is torn down: six image-import paths set `_subtitleFileName` and call `ReplaceSubtitles` **without** `ResetSubtitle()` — BluRay `.sup`, raw PGS, transport stream, Matroska PGS, Matroska VobSub, and VobSub `.sub/.idx`. The other eight OCR sites already follow `VideoCloseFile(); ResetSubtitle(); _subtitleFileName = …`.

Without it, opening one of those while translator mode was active left the previous original subtitle attached, so the recent-files entry recorded a pair that was never open together. Not reachable from the plain-text open path — `SubtitleOpen` already calls `ResetSubtitle()`.

### Testing

Builds clean. Not exercised in the GUI — worth a manual check of: open translation + original, restart with "open last file on start" enabled; and opening a `.sup` while an original is loaded.

The other two points of #12705 (missing-space detection, editing original subtitles) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)