### PR TITLE
Default exports to the source file's folder

### DIFF
--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
@@ -378,7 +378,9 @@ public partial class ExportImageBasedViewModel : ObservableObject
             var suggestedFileName = string.Empty;
             if (!string.IsNullOrWhiteSpace(_subtitleFileName))
             {
-                suggestedFileName = System.IO.Path.GetFileNameWithoutExtension(_subtitleFileName);
+                // Keep the folder: the picker uses it as the start location and shows only the
+                // file name, so the export defaults next to the subtitle being exported.
+                suggestedFileName = Utilities.GetPathAndFileNameWithoutExtension(_subtitleFileName);
             }
                 
             fileOrFolderName = await _fileHelper.PickSaveSubtitleFile(Window!, _exportImageHandler.Extension,

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -3984,16 +3984,20 @@ public partial class MainViewModel :
         _updateAudioVisualizer = true;
     }
 
+    // Path-qualified on purpose: every caller feeds this straight to a save picker, which
+    // strips the directory off the suggested name and uses it as the start folder - so an
+    // export defaults to the folder of the current subtitle (or video) instead of wherever
+    // a picker was last used.
     private string GetNewFileName()
     {
         if (!string.IsNullOrEmpty(_subtitleFileName))
         {
-            return Path.GetFileNameWithoutExtension(_subtitleFileName);
+            return Utilities.GetPathAndFileNameWithoutExtension(_subtitleFileName);
         }
 
         if (!string.IsNullOrEmpty(_videoFileName))
         {
-            return Path.GetFileNameWithoutExtension(_videoFileName);
+            return Utilities.GetPathAndFileNameWithoutExtension(_videoFileName);
         }
 
         return string.Empty;

--- a/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackViewModel.cs
+++ b/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackViewModel.cs
@@ -127,7 +127,7 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
         }
         else if (trackInfo.CodecId == MatroskaTrackType.BluRay && subtitles != null && _matroskaFile != null)
         {
-            var suggestedFileName = Path.GetFileNameWithoutExtension(_fileName);
+            var suggestedFileName = Utilities.GetPathAndFileNameWithoutExtension(_fileName);
             var fileName = await _fileHelper.PickSaveSubtitleFile(Window, ".sup", suggestedFileName, Se.Language.General.SaveFileAsTitle);
             if (string.IsNullOrEmpty(fileName))
             {
@@ -185,7 +185,7 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
         var sub = new Subtitle();
         Utilities.LoadMatroskaTextSubtitle(trackInfo, _matroskaFile, subtitles, sub);
         var rawText = format.ToText(sub, string.Empty);
-        var suggestedFileName = Path.GetFileNameWithoutExtension(_fileName);
+        var suggestedFileName = Utilities.GetPathAndFileNameWithoutExtension(_fileName);
         var fileName = await _fileHelper.PickSaveSubtitleFile(window, format.Extension, suggestedFileName, Se.Language.General.SaveFileAsTitle);
 
         if (!string.IsNullOrEmpty(fileName))

--- a/src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs
+++ b/src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs
@@ -95,7 +95,7 @@ public partial class PickMp4TrackViewModel : ObservableObject
             return;
         }
 
-        var suggestedFileName = Path.GetFileNameWithoutExtension(_fileName);
+        var suggestedFileName = Utilities.GetPathAndFileNameWithoutExtension(_fileName);
 
         if (track.Mdia.IsVobSubSubtitle)
         {

--- a/src/ui/Logic/Media/FileHelper.cs
+++ b/src/ui/Logic/Media/FileHelper.cs
@@ -260,10 +260,13 @@ namespace Nikse.SubtitleEdit.Logic.Media
             var options = new FilePickerSaveOptions
             {
                 Title = title,
-                SuggestedFileName = suggestedFileName,
+                SuggestedFileName = Path.GetFileName(suggestedFileName),
                 FileTypeChoices = MakeSaveFilePickerFileTypes(currentFormat),
                 DefaultExtension = currentFormat.Extension.TrimStart('.')
             };
+
+            await SetSuggestedStartLocation(topLevel, options, suggestedFileName);
+
             var file = await NativePickers.SaveFilePickerAsync(topLevel, options);
 
             if (file != null)
@@ -280,9 +283,6 @@ namespace Nikse.SubtitleEdit.Logic.Media
             string suggestedFileName,
             string title)
         {
-            var suggestedStartLocationPath = Path.GetDirectoryName(suggestedFileName); 
-            suggestedFileName = Path.GetFileName(suggestedFileName);
-            
             var topLevel = TopLevel.GetTopLevel(sender)!;
             var filePickerFileTypes = MakeSaveFilePickerAllFileTypes(currentFormat);
             var defaultChoice = filePickerFileTypes
@@ -290,25 +290,12 @@ namespace Nikse.SubtitleEdit.Logic.Media
             var options = new FilePickerSaveOptions
             {
                 Title = title,
-                SuggestedFileName = suggestedFileName,
+                SuggestedFileName = Path.GetFileName(suggestedFileName),
                 FileTypeChoices = filePickerFileTypes,
                 SuggestedFileType = defaultChoice,
             };
 
-            if (!string.IsNullOrEmpty(suggestedStartLocationPath))
-            {
-                try
-                {
-                    var folder = await topLevel.StorageProvider.TryGetFolderFromPathAsync(suggestedStartLocationPath);
-                    if (folder != null)
-                    {
-                        options.SuggestedStartLocation = folder;
-                    }
-                }
-                catch
-                {
-                }
-            }
+            await SetSuggestedStartLocation(topLevel, options, suggestedFileName);
 
             // Use SaveFilePickerWithResultAsync instead of SaveFilePickerAsync
             var result = await topLevel.StorageProvider.SaveFilePickerWithResultAsync(options);
@@ -326,6 +313,33 @@ namespace Nikse.SubtitleEdit.Logic.Media
                 FileName = AddMissingExtension(result.File.Path.LocalPath, subtitleFormat.Extension),
                 SubtitleFormat = subtitleFormat,
             };
+        }
+
+        /// <summary>
+        /// Open the save picker in the folder of <paramref name="suggestedFileName"/> when it is
+        /// path-qualified, so e.g. exporting a track from a .mkv defaults to the folder holding
+        /// that .mkv instead of wherever the picker was last used. A bare file name is a no-op.
+        /// </summary>
+        private static async Task SetSuggestedStartLocation(TopLevel topLevel, FilePickerSaveOptions options, string suggestedFileName)
+        {
+            var suggestedStartLocationPath = Path.GetDirectoryName(suggestedFileName);
+            if (string.IsNullOrEmpty(suggestedStartLocationPath))
+            {
+                return;
+            }
+
+            try
+            {
+                var folder = await topLevel.StorageProvider.TryGetFolderFromPathAsync(suggestedStartLocationPath);
+                if (folder != null)
+                {
+                    options.SuggestedStartLocation = folder;
+                }
+            }
+            catch
+            {
+                // ignore - the picker falls back to its default folder
+            }
         }
 
         private static string AddMissingExtension(string fileName, string extension)
@@ -381,26 +395,12 @@ namespace Nikse.SubtitleEdit.Logic.Media
             var options = new FilePickerSaveOptions
             {
                 Title = title,
-                SuggestedFileName = suggestedFileName,
+                SuggestedFileName = Path.GetFileName(suggestedFileName),
                 FileTypeChoices = MakeSaveFilePickerFileTypes(extension, extension),
                 DefaultExtension = extension.TrimStart('.')
             };
 
-            var suggestedStartLocationPath = Path.GetDirectoryName(suggestedFileName);
-            if (!string.IsNullOrEmpty(suggestedStartLocationPath))
-            {
-                try
-                {
-                    var folder = await topLevel.StorageProvider.TryGetFolderFromPathAsync(suggestedStartLocationPath);
-                    if (folder != null)
-                    {
-                        options.SuggestedStartLocation = folder;
-                    }
-                }
-                catch
-                {
-                }
-            }
+            await SetSuggestedStartLocation(topLevel, options, suggestedFileName);
 
             var file = await NativePickers.SaveFilePickerAsync(topLevel, options);
 
@@ -432,26 +432,12 @@ namespace Nikse.SubtitleEdit.Logic.Media
             var options = new FilePickerSaveOptions
             {
                 Title = title,
-                SuggestedFileName = System.IO.Path.GetFileName(suggestedFileName),
+                SuggestedFileName = Path.GetFileName(suggestedFileName),
                 FileTypeChoices = MakeSaveFilePickerFileTypes(fileTypes),
                 DefaultExtension = defaultExtension.TrimStart('.'),
             };
 
-            var suggestedStartLocationPath = Path.GetDirectoryName(suggestedFileName);
-            if (!string.IsNullOrEmpty(suggestedStartLocationPath))
-            {
-                try
-                {
-                    var folder = await topLevel.StorageProvider.TryGetFolderFromPathAsync(suggestedStartLocationPath);
-                    if (folder != null)
-                    {
-                        options.SuggestedStartLocation = folder;
-                    }
-                }
-                catch
-                {
-                }
-            }
+            await SetSuggestedStartLocation(topLevel, options, suggestedFileName);
 
             var file = await NativePickers.SaveFilePickerAsync(topLevel, options);
 


### PR DESCRIPTION
Exporting a track from the **Matroska track picker** suggested only a bare file name, so the save dialog opened wherever it was last used rather than in the folder holding the `.mkv`. The same applied to the **MP4 track picker**, the **main-window export flows**, and **image-based export**. All now pass the source path, so the picker starts next to the file being exported.

### FileHelper cleanup

The four save pickers had drifted apart: `PickSaveFile` and `PickSaveSubtitleFileAs` set `SuggestedStartLocation` with inline copies of the same try/catch, while both `PickSaveSubtitleFile` overloads never set it at all — which is why passing a path made no difference before.

Folded into one `SetSuggestedStartLocation` helper used by all four. Every picker now also runs `SuggestedFileName` through `Path.GetFileName`, so a path-qualified suggestion sets the start folder instead of leaking the whole path into the file-name box. Passing a bare file name behaves exactly as before, so callers that were not updated are unaffected.

Also fixes a latent double-strip: `PickSaveSubtitleFileAs` had already reduced its variable to a directory, so it now passes the original path to the helper rather than a directory that would get `GetDirectoryName` applied twice.

### Call sites updated

- `PickMatroskaTrackViewModel` — BluRay `.sup` export and text-track export
- `PickMp4TrackViewModel` — VobSub `.sup` export and text export
- `MainViewModel.GetNewFileName()` — feeds ~9 export flows (Cavena, PAC, EBU-STL, CapMakerPlus, save-as, …); every caller passes it straight to a save picker
- `ExportImageBasedViewModel` — stopped stripping the directory off a subtitle path it already had in full

`PickTsTrack` and `PickVobSubLanguage` have no export button, so there is nothing to change there. The remaining bare-name callers are single-image "save image as" pickers (`OcrViewModel`, `ShowImageViewModel`, and the per-image save in image export), left as-is.

### Testing

Builds clean. Not exercised in the GUI — worth opening an `.mkv` from a folder other than the last-used save folder and checking that both the track-picker export and a main-window export land beside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)