### PR TITLE
Offer the translated file name when saving after auto-translate

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -311,6 +311,12 @@ public partial class MainViewModel :
     private string? _subtitleFileName;
     private string? _subtitleFileNameOriginal;
     private bool _converted;
+
+    // A file name the app derived on the user's behalf (auto-translate picking a target
+    // language) that must win over the "guess from video or subtitle" SaveAsBehavior
+    // setting - that setting answers "no name yet, what do we suggest?", and here there is
+    // one. Consumed and cleared by the next "Save as".
+    private string? _saveAsFileNameSuggestion;
     private Subtitle _subtitle;
     private Subtitle? _subtitleSecondary;
     private Subtitle _subtitleOriginal;
@@ -1840,6 +1846,7 @@ public partial class MainViewModel :
         _subtitleFileNameOriginal = string.Empty;
         _subtitleOriginal = new Subtitle();
         _changeSubtitleHashOriginal = GetFastHashOriginal();
+        _saveAsFileNameSuggestion = null;
 
         _visibleLayers = null;
         ShowLayerFilterIcon = false;
@@ -8273,6 +8280,11 @@ public partial class MainViewModel :
             }
 
             _subtitleFileName = Path.Combine(directory, nameWithoutExt + "." + targetLanguageCode + extension);
+
+            // Saving must offer the translated name, not the video's name - otherwise the
+            // default video-first SaveAsBehavior suggests overwriting the subtitle that was
+            // just translated from.
+            _saveAsFileNameSuggestion = _subtitleFileName;
         }
         else
         {
@@ -17585,7 +17597,13 @@ public partial class MainViewModel :
     {
         var newFileName = "New";
         var behavior = Se.Settings.General.SaveAsBehavior;
-        if (behavior == nameof(SaveAsBehaviourType.UseSubtitleFileNameThenVideoFileName))
+
+        // An app-derived name (auto-translate) beats the behavior setting - see the field comment.
+        if (!string.IsNullOrEmpty(_saveAsFileNameSuggestion))
+        {
+            newFileName = GetFileNameWithoutExtension(_saveAsFileNameSuggestion);
+        }
+        else if (behavior == nameof(SaveAsBehaviourType.UseSubtitleFileNameThenVideoFileName))
         {
             if (!string.IsNullOrEmpty(_subtitleFileName))
             {
@@ -17702,6 +17720,7 @@ public partial class MainViewModel :
         _subtitleFileName = saveAsResult.FileName;
         _subtitle.FileName = saveAsResult.FileName;
         _converted = false;
+        _saveAsFileNameSuggestion = null;
         _lastOpenSaveFormat = saveAsResult.SubtitleFormat;
 
         // When "Save as" targets a different format than the one currently loaded, convert the source


### PR DESCRIPTION
Auto-translate renames the subtitle to the target language (`movie.srt` → `movie.es.srt`, stripping any existing language code first) and sets `_converted = true` so that saving goes through **Save as** instead of overwriting.

That second part works. The name, however, was thrown away: `SaveSubtitleAs` picks its suggestion from `Se.Settings.General.SaveAsBehavior`, which defaults to `UseVideoFileNameThenSubtitleFileName`. With a video loaded — the usual case when translating — it suggested the **video's** name, so the `.es` postfix vanished and the dialog offered to overwrite the subtitle that had just been translated *from*. The language-code append block that could have re-added it is gated on `SaveAsAppendLanguageCode`, which defaults to `None`.

Repro before this change: open `movie.mkv` + `movie.srt`, auto-translate to Spanish, Ctrl+S → dialog suggests `movie.srt`.

### Fix

A name the app derived on the user's behalf now wins over the behavior setting. That setting answers "there is no name yet — guess from the video or the subtitle?", which no longer applies once the user has picked a target language.

`_saveAsFileNameSuggestion` is set by auto-translate, consumed by the next **Save as**, and cleared both on a successful save and in `ResetSubtitle`, so it cannot leak into an unrelated save. Cancelling the dialog keeps it, since the subtitle is still translated.

Untouched: the two paths that translate without knowing a target language — copy/paste translate and entering translator mode manually — clear `_subtitleFileName` entirely and still fall back to the behavior setting. The setting itself is unchanged for every other flow.

### Testing

Builds clean. Not exercised in the GUI — worth checking the repro above, plus that a normal Save as (no translation) still follows the configured behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)