### PR TITLE
Update CrispASR to v0.8.20 and add three Linux GPU builds

### DIFF
--- a/src/ui/Features/Shared/MessageBox.cs
+++ b/src/ui/Features/Shared/MessageBox.cs
@@ -21,6 +21,7 @@ public enum MessageBoxResult
     Custom1,
     Custom2,
     Custom3,
+    Custom4,
 }
 
 public enum MessageBoxButtons
@@ -52,7 +53,7 @@ public class MessageBox : Window
     private readonly bool _hasOnlyOk;
     private readonly bool _hasNo;
 
-    private MessageBox(string title, string message, MessageBoxButtons buttons, MessageBoxIcon icon, string? custom1 = null, string? custom2 = null, string? custom3 = null)
+    private MessageBox(string title, string message, MessageBoxButtons buttons, MessageBoxIcon icon, string? custom1 = null, string? custom2 = null, string? custom3 = null, string? custom4 = null)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
         Title = title;
@@ -168,6 +169,11 @@ public class MessageBox : Window
             AddButton(custom3, MessageBoxResult.Custom3);
         }
 
+        if (!string.IsNullOrEmpty(custom4))
+        {
+            AddButton(custom4, MessageBoxResult.Custom4);
+        }
+
         // Add buttons based on MessageBoxButtons
         switch (buttons)
         {
@@ -239,9 +245,10 @@ public class MessageBox : Window
         MessageBoxIcon icon = MessageBoxIcon.None,
         string? custom1 = null,
         string? custom2 = null,
-        string? custom3 = null)
+        string? custom3 = null,
+        string? custom4 = null)
     {
-        var msgBox = new MessageBox(title, message, buttons, icon, custom1, custom2, custom3);
+        var msgBox = new MessageBox(title, message, buttons, icon, custom1, custom2, custom3, custom4);
 
         // Keep the message box above undocked tool windows (audio visualizer / video player),
         // which float on top of the main window via KeepTopmostWhileOwnerActive. Without this the

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -36,7 +36,8 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
 
     /// <summary>
     /// CrispASR download variant. On Windows: "cpu", "cpu-legacy", "vulkan", or "cuda" (defaults to "vulkan").
-    /// On Linux x86_64: "cuda" or null/empty for the default CPU build. Ignored on macOS / Linux ARM64.
+    /// On Linux x86_64: "cuda", "cuda13", "vulkan", "hip", or null/empty for the default CPU build.
+    /// Ignored on macOS / Linux ARM64.
     /// </summary>
     public string CrispAsrWindowsVariant { get; set; } = "vulkan";
 
@@ -180,9 +181,16 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
                     var folder = Engine.GetAndCreateWhisperFolder();
                     var skipFolder = Engine is ICrispAsrEngine
                         ? OperatingSystem.IsLinux()
-                            ? (CrispAsrWindowsVariant == "cuda" && RuntimeInformation.ProcessArchitecture != Architecture.Arm64
-                                ? "crispasr-linux-x86_64-cuda"
-                                : "crispasr-linux-x86_64")
+                            ? (RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                                ? "crispasr-linux-arm64"
+                                : CrispAsrWindowsVariant switch
+                                {
+                                    "cuda"   => "crispasr-linux-x86_64-cuda",
+                                    "cuda13" => "crispasr-linux-x86_64-cuda13",
+                                    "vulkan" => "crispasr-linux-x86_64-vulkan",
+                                    "hip"    => "crispasr-linux-x86_64-hip",
+                                    _        => "crispasr-linux-x86_64",
+                                })
                             : OperatingSystem.IsMacOS()
                                 ? "crispasr-macos"
                                 : CrispAsrWindowsVariant switch
@@ -435,8 +443,10 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
         var displayName = Engine is ICrispAsrEngine
             ? OperatingSystem.IsWindows()
                 ? "Crisp ASR " + CrispAsrWindowsVariant
-                : OperatingSystem.IsLinux() && CrispAsrWindowsVariant == "cuda"
-                    ? "Crisp ASR cuda"
+                : OperatingSystem.IsLinux()
+                  && RuntimeInformation.ProcessArchitecture != Architecture.Arm64
+                  && CrispAsrWindowsVariant is "cuda" or "cuda13" or "vulkan" or "hip"
+                    ? "Crisp ASR " + CrispAsrWindowsVariant
                     : "Crisp ASR"
             : Engine?.Name;
         TitleText = string.Format(Se.Language.General.DownloadingX, displayName);
@@ -498,10 +508,16 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
                 };
             }
             else if (OperatingSystem.IsLinux()
-                     && CrispAsrWindowsVariant == "cuda"
-                     && RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
+                     && RuntimeInformation.ProcessArchitecture != Architecture.Arm64
+                     && CrispAsrWindowsVariant is "cuda" or "cuda13" or "vulkan" or "hip")
             {
-                _downloadTask = _crispAsrDownloadService.DownloadEngineLinuxCuda(_downloadStream, downloadProgress, _cancellationTokenSource.Token);
+                _downloadTask = CrispAsrWindowsVariant switch
+                {
+                    "cuda13" => _crispAsrDownloadService.DownloadEngineLinuxCuda13(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
+                    "vulkan" => _crispAsrDownloadService.DownloadEngineLinuxVulkan(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
+                    "hip"    => _crispAsrDownloadService.DownloadEngineLinuxHip(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
+                    _        => _crispAsrDownloadService.DownloadEngineLinuxCuda(_downloadStream, downloadProgress, _cancellationTokenSource.Token),
+                };
             }
             else
             {

--- a/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsViewModel.cs
@@ -183,7 +183,14 @@ public partial class SpeechToTextEngineSettingsViewModel : ObservableObject
                     return "Linux ARM64 (CPU)";
                 }
                 var linuxVariant = DownloadHashManager.DetectCrispAsrLinuxVariant(folder);
-                return linuxVariant == "cuda" ? "Linux x64 (CUDA)" : "Linux x64 (CPU)";
+                return linuxVariant switch
+                {
+                    "cuda" => "Linux x64 (CUDA)",
+                    "cuda13" => "Linux x64 (CUDA 13)",
+                    "vulkan" => "Linux x64 (Vulkan)",
+                    "hip" => "Linux x64 (ROCm)",
+                    _ => "Linux x64 (CPU)",
+                };
             }
 
             var winVariant = DownloadHashManager.DetectCrispAsrWindowsVariant(folder);

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -2495,7 +2495,8 @@ public partial class SpeechToTextViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Linux x86_64 build prompt: CPU vs CUDA. Returns "cuda", empty string for the default CPU build,
+    /// Linux x86_64 build prompt: CPU, Vulkan (any GPU), CUDA (NVIDIA) or ROCm (AMD).
+    /// Returns "vulkan" / "cuda" / "cuda13" / "hip", empty string for the default CPU build,
     /// or null when the user cancels.
     /// </summary>
     private async Task<string?> PromptCrispAsrLinuxVariantAsync(string engineName)
@@ -2507,12 +2508,43 @@ public partial class SpeechToTextViewModel : ObservableObject
             MessageBoxButtons.Cancel,
             MessageBoxIcon.Question,
             "CPU",
-            "CUDA");
+            "Vulkan",
+            "CUDA",
+            "ROCm");
+
+        if (answer == MessageBoxResult.Custom3)
+        {
+            return await PromptCrispAsrLinuxCudaVersionAsync();
+        }
 
         return answer switch
         {
             MessageBoxResult.Custom1 => string.Empty,
-            MessageBoxResult.Custom2 => "cuda",
+            MessageBoxResult.Custom2 => "vulkan",
+            MessageBoxResult.Custom4 => "hip",
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Follow-up prompt after the user picks "CUDA" in the Linux CrispASR variant selector.
+    /// Returns "cuda" (CUDA 12 build) or "cuda13", or null when the user cancels.
+    /// </summary>
+    private async Task<string?> PromptCrispAsrLinuxCudaVersionAsync()
+    {
+        var answer = await MessageBox.Show(
+            Window!,
+            "CrispASR CUDA build",
+            $"{Environment.NewLine}CUDA 12 works with most current NVIDIA drivers.{Environment.NewLine}{Environment.NewLine}Pick CUDA 13 only if your driver stack is built for CUDA 13.",
+            MessageBoxButtons.Cancel,
+            MessageBoxIcon.Question,
+            "CUDA 12",
+            "CUDA 13");
+
+        return answer switch
+        {
+            MessageBoxResult.Custom1 => "cuda",
+            MessageBoxResult.Custom2 => "cuda13",
             _ => null,
         };
     }

--- a/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
@@ -10,6 +10,7 @@ using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Download;
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech;
@@ -141,7 +142,7 @@ public static class TtsVoiceInstaller
 
     /// <summary>
     /// Ensures the CrispASR runtime that MOSS-TTS (CrispASR) runs on is installed.
-    /// The moss-tts backend ships in CrispASR v0.8.13+ (SE's pinned release).
+    /// The moss-tts backend ships in CrispASR v0.8.13 and newer (SE pins v0.8.20).
     /// </summary>
     public static Task<bool> EnsureCrispAsrForMossTts(Window? window, IWindowService windowService, bool forceRedownload)
         => EnsureCrispAsrAsync(window, windowService, forceRedownload,
@@ -184,9 +185,20 @@ public static class TtsVoiceInstaller
         {
             // Already installed - re-download with the variant the user originally picked.
             var folder = crispAsrEngine.GetAndCreateWhisperFolder();
-            crispVariant = (Configuration.IsRunningOnWindows
-                ? DownloadHashManager.DetectCrispAsrWindowsVariant(folder)
-                : null) ?? "vulkan";
+            if (Configuration.IsRunningOnWindows)
+            {
+                crispVariant = DownloadHashManager.DetectCrispAsrWindowsVariant(folder) ?? "vulkan";
+            }
+            else if (Configuration.IsRunningOnLinux && RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
+            {
+                // Empty means the default CPU build; the GPU builds ("cuda" / "cuda13" /
+                // "vulkan" / "hip") are only detectable via sidecar or executable hash.
+                crispVariant = DownloadHashManager.DetectCrispAsrLinuxVariant(folder) ?? string.Empty;
+            }
+            else
+            {
+                crispVariant = string.Empty; // ignored on macOS / Linux ARM64
+            }
 
             var versionRequirement = !string.IsNullOrEmpty(minVersionNote)
                 ? $" needs CrispASR {minVersionNote}"
@@ -261,6 +273,16 @@ public static class TtsVoiceInstaller
                 }
             }
         }
+        else if (Configuration.IsRunningOnLinux && RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
+        {
+            var linuxAnswer = await PromptCrispAsrLinuxVariantAsync(window, engineDisplayName);
+            if (linuxAnswer == null)
+            {
+                return false;
+            }
+
+            crispVariant = linuxAnswer;
+        }
         else
         {
             var answer = await MessageBox.Show(
@@ -275,7 +297,7 @@ public static class TtsVoiceInstaller
                 return false;
             }
 
-            crispVariant = "vulkan"; // ignored on non-Windows
+            crispVariant = string.Empty; // ignored on macOS / Linux ARM64
         }
 
         var dlVm = await windowService.ShowDialogAsync<DownloadSpeechToTextEngineWindow, DownloadSpeechToTextEngineViewModel>(
@@ -315,6 +337,52 @@ public static class TtsVoiceInstaller
         {
             MessageBoxResult.Custom1 => "cpu",
             MessageBoxResult.Custom2 => "cpu-legacy",
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Linux x86_64 build prompt: CPU, Vulkan (any GPU), CUDA (NVIDIA) or ROCm (AMD).
+    /// Returns "vulkan" / "cuda" / "cuda13" / "hip", empty string for the default CPU build,
+    /// or null when the user cancels.
+    /// </summary>
+    private static async Task<string?> PromptCrispAsrLinuxVariantAsync(Window window, string engineDisplayName)
+    {
+        var answer = await MessageBox.Show(
+            window,
+            "Download CrispASR?",
+            $"{Environment.NewLine}\"{engineDisplayName}\" runs through the CrispASR runtime. Select a build to download:",
+            MessageBoxButtons.Cancel,
+            MessageBoxIcon.Question,
+            "CPU",
+            "Vulkan",
+            "CUDA",
+            "ROCm");
+
+        if (answer == MessageBoxResult.Custom3)
+        {
+            var cudaAnswer = await MessageBox.Show(
+                window,
+                "CrispASR CUDA build",
+                $"{Environment.NewLine}CUDA 12 works with most current NVIDIA drivers.{Environment.NewLine}{Environment.NewLine}Pick CUDA 13 only if your driver stack is built for CUDA 13.",
+                MessageBoxButtons.Cancel,
+                MessageBoxIcon.Question,
+                "CUDA 12",
+                "CUDA 13");
+
+            return cudaAnswer switch
+            {
+                MessageBoxResult.Custom1 => "cuda",
+                MessageBoxResult.Custom2 => "cuda13",
+                _ => null,
+            };
+        }
+
+        return answer switch
+        {
+            MessageBoxResult.Custom1 => string.Empty,
+            MessageBoxResult.Custom2 => "vulkan",
+            MessageBoxResult.Custom4 => "hip",
             _ => null,
         };
     }

--- a/src/ui/Logic/Download/CrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/CrispAsrDownloadService.cs
@@ -15,20 +15,26 @@ public interface ICrispAsrDownloadService
     Task DownloadEngineWindowsCpu(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
     Task DownloadEngineWindowsCpuLegacy(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
     Task DownloadEngineLinuxCuda(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
+    Task DownloadEngineLinuxCuda13(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
+    Task DownloadEngineLinuxVulkan(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
+    Task DownloadEngineLinuxHip(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
 }
 
 public class CrispAsrDownloadService : ICrispAsrDownloadService
 {
     private readonly HttpClient _httpClient;
 
-    private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.15/crispasr-windows-x86_64-cuda.zip";
-    private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.15/crispasr-windows-x86_64-vulkan.zip";
-    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.15/crispasr-windows-x86_64-cpu.zip";
-    private const string WindowsCpuLegacyUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.15/crispasr-windows-x86_64-cpu-legacy.zip";
-    private const string MacUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.15/crispasr-macos.tar.gz";
-    private const string LinuxUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.15/crispasr-linux-x86_64.tar.gz";
-    private const string LinuxCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.15/crispasr-linux-x86_64-cuda.tar.gz";
-    private const string LinuxArmUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.15/crispasr-linux-arm64.tar.gz";
+    private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.20/crispasr-windows-x86_64-cuda.zip";
+    private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.20/crispasr-windows-x86_64-vulkan.zip";
+    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.20/crispasr-windows-x86_64-cpu.zip";
+    private const string WindowsCpuLegacyUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.20/crispasr-windows-x86_64-cpu-legacy.zip";
+    private const string MacUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.20/crispasr-macos.tar.gz";
+    private const string LinuxUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.20/crispasr-linux-x86_64.tar.gz";
+    private const string LinuxCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.20/crispasr-linux-x86_64-cuda.tar.gz";
+    private const string LinuxCuda13Url = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.20/crispasr-linux-x86_64-cuda13.tar.gz";
+    private const string LinuxVulkanUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.20/crispasr-linux-x86_64-vulkan.tar.gz";
+    private const string LinuxHipUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.20/crispasr-linux-x86_64-hip.tar.gz";
+    private const string LinuxArmUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.20/crispasr-linux-arm64.tar.gz";
 
     public CrispAsrDownloadService(HttpClient httpClient)
     {
@@ -63,6 +69,21 @@ public class CrispAsrDownloadService : ICrispAsrDownloadService
     public async Task DownloadEngineLinuxCuda(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
     {
         await DownloadHelper.DownloadFileAsync(_httpClient, LinuxCudaUrl, stream, progress, cancellationToken);
+    }
+
+    public async Task DownloadEngineLinuxCuda13(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        await DownloadHelper.DownloadFileAsync(_httpClient, LinuxCuda13Url, stream, progress, cancellationToken);
+    }
+
+    public async Task DownloadEngineLinuxVulkan(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        await DownloadHelper.DownloadFileAsync(_httpClient, LinuxVulkanUrl, stream, progress, cancellationToken);
+    }
+
+    public async Task DownloadEngineLinuxHip(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        await DownloadHelper.DownloadFileAsync(_httpClient, LinuxHipUrl, stream, progress, cancellationToken);
     }
 
     private static string GetUrl()

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -38,6 +38,9 @@ public static class DownloadHashManager
         public const string MacOs = "CrispAsr.MacOs";
         public const string Linux = "CrispAsr.Linux";
         public const string LinuxCuda = "CrispAsr.Linux.Cuda";
+        public const string LinuxCuda13 = "CrispAsr.Linux.Cuda13";
+        public const string LinuxVulkan = "CrispAsr.Linux.Vulkan";
+        public const string LinuxHip = "CrispAsr.Linux.Hip";
         public const string LinuxArm = "CrispAsr.Linux.Arm";
 
         // Hashes of the unpacked main executable (crispasr.exe / crispasr) — used to detect the
@@ -49,6 +52,9 @@ public static class DownloadHashManager
         public const string MacOsExecutable = "CrispAsr.MacOs.Executable";
         public const string LinuxExecutable = "CrispAsr.Linux.Executable";
         public const string LinuxCudaExecutable = "CrispAsr.Linux.Cuda.Executable";
+        public const string LinuxCuda13Executable = "CrispAsr.Linux.Cuda13.Executable";
+        public const string LinuxVulkanExecutable = "CrispAsr.Linux.Vulkan.Executable";
+        public const string LinuxHipExecutable = "CrispAsr.Linux.Hip.Executable";
         public const string LinuxArmExecutable = "CrispAsr.Linux.Arm.Executable";
     }
 
@@ -280,7 +286,8 @@ public static class DownloadHashManager
             // otherwise users will be prompted to "update" to the same version they just got.
             [CrispAsr.WindowsCuda] = new[]
             {
-                "478a74780a514ede1d5cc2d66074252e94855c90628f3feafee0caa378ed2e4b", // v0.8.15 (current download URL)
+                "8f59bc6d124397db38d0ff4d6a53a99c5a502ccdfd5ca563064d0d53138bda20", // v0.8.20 (current download URL)
+                "478a74780a514ede1d5cc2d66074252e94855c90628f3feafee0caa378ed2e4b", // v0.8.15
                 "454c748f2b8b7ecbcb6b6f41d90440df5f26f979c57410eb7a953156cd710094", // v0.8.13
                 "218b574a107b954283548ee0f753414b01d23686a360edf84b0ddb459b10f0eb", // v0.8.12
                 "b1d850975bb6a48f192e9a2da0ec8362c3668b811fc087a1cb1f164833bd3ced", // v0.8.11
@@ -315,7 +322,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.WindowsVulkan] = new[]
             {
-                "a13e9714e8b8a6318c32b56442b914338d39aeafd088b7fd49262daccfd74d5b", // v0.8.15 (current download URL)
+                "676952e1459cd75de2d70450f5417eb7076d1cdb58299085599d3e19dd3b523f", // v0.8.20 (current download URL)
+                "a13e9714e8b8a6318c32b56442b914338d39aeafd088b7fd49262daccfd74d5b", // v0.8.15
                 "33d2806c0ddd23b41fe681be5cf9e06eb31888826caa2267759d2f353bfa9e82", // v0.8.13
                 "900c8211aade1bd5086d51f3155eb09b4e9d81c0f905b3a02e65c3cb692175fe", // v0.8.12
                 "d37725a7ff1e46a3d0fd8a44457a59043635b94c0ece43ccdcc093d4765f4d18", // v0.8.11
@@ -350,7 +358,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.WindowsCpu] = new[]
             {
-                "652bd964381ef716e0fd06bb975a7a4775855111d47bd29e0abb56c8e3515885", // v0.8.15 (current download URL)
+                "463df25f8b201566dc3cea9b1bb94ae45e85fd887e068bf4875e99de01c8aae7", // v0.8.20 (current download URL)
+                "652bd964381ef716e0fd06bb975a7a4775855111d47bd29e0abb56c8e3515885", // v0.8.15
                 "13ad85c008ae74a189f7e1472082a527e4020a18c51f61d1b00e7ec5c72b358d", // v0.8.13
                 "d6ff6adcfd2df2e90081466fceabce5a22dfd70c9e50d1fba59d54cf27db7483", // v0.8.12
                 "3722297ec384c6255d8cdff8f87b1de10a45e6bdf30147937a3cffd22ae5d6bf", // v0.8.11
@@ -378,7 +387,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.WindowsCpuLegacy] = new[]
             {
-                "d1673ae438eb6a87e5b9f8392686a2b6b31a82ce2fe3c5b9164ed685274815e5", // v0.8.15 (current download URL)
+                "11cd2dd552bbb22b8f8df5cb3b6a9c2191e3b0417df6a112a83678bbecc07995", // v0.8.20 (current download URL)
+                "d1673ae438eb6a87e5b9f8392686a2b6b31a82ce2fe3c5b9164ed685274815e5", // v0.8.15
                 "f9f682223b93437a8a68d1a9d99149ceecf53040c53a1210ed413544c2685462", // v0.8.13
                 "7782a5017c3297be07e254e0fa31bb1bc3fcc9b46650657e73e57ef45140a13f", // v0.8.12
                 "cbb11d7f12d814d35517539ac965a62392abc695e5284212186ed7bd2593af97", // v0.8.11
@@ -412,7 +422,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.MacOs] = new[]
             {
-                "80c0a4fdbc1c44de08c4a92cf04d9301192e65b96d84f4e26d1a9f57e1703f14", // v0.8.15 (current download URL)
+                "ce7c4837314ba378007da4b3a4019cc5e80678a900e8b442a60026140942a285", // v0.8.20 (current download URL)
+                "80c0a4fdbc1c44de08c4a92cf04d9301192e65b96d84f4e26d1a9f57e1703f14", // v0.8.15
                 "943b290c616e9d901e77d52ddd573433e46cbe75bb911fab9965b9a7a5985cb6", // v0.8.13
                 "8bdbefba837d151c1e42b85c16d89e48526149a25fb0f16d26f7f5948c9413a5", // v0.8.12
                 "f41c78816cb2598693030790c5cfd54a51ce7593e2efff47e0899e8f48c00d59", // v0.8.11
@@ -447,7 +458,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.Linux] = new[]
             {
-                "ecae0527284423c3908a0dbb6bac8046a2206298dc7849e6eb0390cd4a711a30", // v0.8.15 (current download URL)
+                "4a0a772ea1903d4d65682506c42c36356fe3806189d08b9f9f09af590e29babf", // v0.8.20 (current download URL)
+                "ecae0527284423c3908a0dbb6bac8046a2206298dc7849e6eb0390cd4a711a30", // v0.8.15
                 "5b4ef551e6a3808611157af24f237de611b68b910238ef28aa2f602a28b20c54", // v0.8.13
                 "5163e89d84eee3f10e6e22c5c82f87668bc358fc029782e873660716d3069cc6", // v0.8.12
                 "05fad4ff617ad18d2959751a85a38fed3bc6047fcfc96ae973a844cdfaaf81d0", // v0.8.11
@@ -482,7 +494,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.LinuxCuda] = new[]
             {
-                "e89f460523ac8ef9018a1e7d120b974d51c252b98b7c8be02f5e6e593f296dc4", // v0.8.15 (current download URL)
+                "620dc66a75e4774cb645b6ee642c6dff61123e9939d762ba1d89ff8cffe6f81a", // v0.8.20 (current download URL)
+                "e89f460523ac8ef9018a1e7d120b974d51c252b98b7c8be02f5e6e593f296dc4", // v0.8.15
                 "780b25b90c2f4351589817ade07c8ca6bb855e2d496e6d216e382da38c42186d", // v0.8.13
                 "6c4add67ce38b9e208184301aa9f986544b46ef116dfc356afd80348b9560882", // v0.8.12
                 "4daaaf5c79c5a94925a43659ad614baa2f6b8a70fb962cf38da6262e40e01f85", // v0.8.11
@@ -506,9 +519,22 @@ public static class DownloadHashManager
                 "9a493e0f19421e3b73307a48113dd18c326756dfe751bd3a9bc4bc8d049137d1", // v0.6.8
                 "0e2ebbcb8012285a8c2089c5254d61f8e4e870e3397f220bcd9708ec569f3037", // v0.6.7 (first SE-tracked Linux CUDA build)
             },
+            [CrispAsr.LinuxCuda13] = new[]
+            {
+                "2bb3d45a3623fd6422624b4912c1b1f903f59a6563c7e6acfdea9e5fb96f6743", // v0.8.20 (current download URL, first SE-tracked build)
+            },
+            [CrispAsr.LinuxVulkan] = new[]
+            {
+                "0dd956a1a7f7beb0c715cdd2f0d028d6de64a23427a923be7f7f5c57cfabc903", // v0.8.20 (current download URL, first SE-tracked build)
+            },
+            [CrispAsr.LinuxHip] = new[]
+            {
+                "427dc48c311fba3aa05436185bfefa879ddf20510e1b72d4da2b0f43a4a49c63", // v0.8.20 (current download URL, first SE-tracked build)
+            },
             [CrispAsr.LinuxArm] = new[]
             {
-                "7d9a0740631fab57289b36e5970a792853c45da7a386d729be875212709de034", // v0.8.15 (current download URL)
+                "61604a17ffe17f8683d79fe41cf482886d9ed4215557b6fdf7f78dff74ec088a", // v0.8.20 (current download URL)
+                "7d9a0740631fab57289b36e5970a792853c45da7a386d729be875212709de034", // v0.8.15
                 "bb58272a2463e36bfb94d6c237e6a472c8ce7ecf3a6b2c521927a5f676a849ed", // v0.8.13 (v0.8.11/v0.8.12 shipped no linux-arm64 build)
                 "535e5b460318d6ea49676b0401d4f90fec089df8c5f90a8551a83dc84fad98fe", // v0.8.10
                 "72872630b5ad93e11916b7871d686a3f8697377a2ee4e43ff7bbba8ddb915bc1", // v0.8.9
@@ -701,7 +727,8 @@ public static class DownloadHashManager
             // SHA-256 of crispasr.exe / crispasr extracted from each archive above.
             [CrispAsr.WindowsCudaExecutable] = new[]
             {
-                "281df85cca3920b6a1c6aa5b51c94285677efd4cdcf17e837a2b5754db6ae2c5", // v0.8.15 (current download URL)
+                "a82f91533889968c8d6f3db75938629ed52722664decf962f703e675d6c59816", // v0.8.20 (current download URL)
+                "281df85cca3920b6a1c6aa5b51c94285677efd4cdcf17e837a2b5754db6ae2c5", // v0.8.15
                 "9911d530345d10ceecb31c152a87911ec964909921134b1bfe26ffa942da403a", // v0.8.13
                 "e2a64859bf3294f96a7b0573b7226abe0d50b11ea76b6c67c6520c515f79b4c9", // v0.8.12
                 "e494ab0bcc88224c394bcfb6dc896e18a4ada6f4c16dda5d9b51dadf65e031ea", // v0.8.11
@@ -721,7 +748,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.WindowsVulkanExecutable] = new[]
             {
-                "a8d8674b3a0c382cfda8970f097206473ad474577d30cbf3e8710ca21a187017", // v0.8.15 (current download URL)
+                "55b76d3939d0c57fb89de23241527f4e5b8356f3a10afc51bc1a526fce148606", // v0.8.20 (current download URL)
+                "a8d8674b3a0c382cfda8970f097206473ad474577d30cbf3e8710ca21a187017", // v0.8.15
                 "685b1182fe7a6226fb9f815008d26606bb3a007a02aa436a84051584197ddd38", // v0.8.13
                 "6cc81f63014ed5665b69e93de14f97a96e68a3d6b4a7c06ecf9ffd7bd52cbcdf", // v0.8.12
                 "e12f58bd5a8e3c48239abcb066782221e1f81abc50c4c488908582edc05ae32d", // v0.8.11
@@ -756,7 +784,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.WindowsCpuExecutable] = new[]
             {
-                "eaa950290b928f336db843482c8900543f92055b2137a2870b42ee07d70f2750", // v0.8.15 (current download URL)
+                "da33481ffc04bd418cca05a017a3fe6990eefc0438b0c1059fa3910468f32ac5", // v0.8.20 (current download URL)
+                "eaa950290b928f336db843482c8900543f92055b2137a2870b42ee07d70f2750", // v0.8.15
                 "3426e1d1fc33883e7b4e59a46b424d811154e101c0a4f09807a0f51d362672a6", // v0.8.13
                 "2ba6be52a0ab0554b584eadfbf39635fcb839a7eabf9aec6e37fde0f12ab8788", // v0.8.12
                 "bc01019cd77664ab6ef065b2ce3745a9057aad2b7f42271e5a4f9c1deb4d5b81", // v0.8.11
@@ -784,7 +813,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.WindowsCpuLegacyExecutable] = new[]
             {
-                "753922b46caf301ccbc76775ce12192245843b307104c3a8e638ac8b9d5e0bd0", // v0.8.15 (current download URL)
+                "4be44ebb28222e7303c241d43129eebfe2a4aa6219f4c8dbdec54adeb4d99112", // v0.8.20 (current download URL)
+                "753922b46caf301ccbc76775ce12192245843b307104c3a8e638ac8b9d5e0bd0", // v0.8.15
                 "7dd11cea38d1299e472c8a0cc892ba23e149a36aeb4d7efe49270b9a018fd9e0", // v0.8.13
                 "9ed3e627931bf598f5abc0a4132027602c97e1240ea83a62a9a683fba71b7422", // v0.8.12
                 "345a8951ff97d304d4647f068b20eb3aa7cfe2a19dc45f131581d6946e4bee13", // v0.8.11
@@ -818,7 +848,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.LinuxExecutable] = new[]
             {
-                "04153e5ba883e68ecbe7a83465ed4381d3546615b7661db96fbe987a8918f166", // v0.8.15 (current download URL)
+                "0d37ad0b75a878ae42b5e88c379124340ff36b08515a8ccce7d6419e24916e84", // v0.8.20 (current download URL)
+                "04153e5ba883e68ecbe7a83465ed4381d3546615b7661db96fbe987a8918f166", // v0.8.15
                 "20a8445c0b6735cbe743eeff8bfa882478f28acc4354b7ade2cde9e70e194a60", // v0.8.13
                 "7415b2caee1a1cdc2236703c89edae50276095e94aff77bb7beae5f4907693f3", // v0.8.12
                 "4938b4a1a27b3822c118fc945fbd925337ab7cbdf2fe0d368fbbebd4f90923ad", // v0.8.11
@@ -853,7 +884,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.MacOsExecutable] = new[]
             {
-                "10ff8bc07c6c9f2151278f093350d3bab4b9659440c968024ec1588c90da9bec", // v0.8.15 (current download URL)
+                "26cf44c6293a5d0281bc6a918b1e087b4021e7f4afd2890c4f67eee8ac329a0f", // v0.8.20 (current download URL)
+                "10ff8bc07c6c9f2151278f093350d3bab4b9659440c968024ec1588c90da9bec", // v0.8.15
                 "11fb0c4c2d6c9d6abb20a09c2517c6599516387e2b3344dcb99c1bd5f49663d6", // v0.8.13
                 "e6e9cb008e9f2cd73747c88c27f3da3628cd5cd214d885f01a7a682d26b3b821", // v0.8.12
                 "7adc14432cf93c5c8d9a798527f3b3c12134b2129f8df3a72ffaacae6288edb3", // v0.8.11
@@ -888,7 +920,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.LinuxCudaExecutable] = new[]
             {
-                "f526b0c2cdd7bfc8205f658aee976ced1a2afe70a4a31aa25b1ef6cb48175496", // v0.8.15 (current download URL)
+                "5ab1ad8a37fca03d963c3fc1f3b6b7ace541c078df3e3f371a46737ebdfc6b45", // v0.8.20 (current download URL)
+                "f526b0c2cdd7bfc8205f658aee976ced1a2afe70a4a31aa25b1ef6cb48175496", // v0.8.15
                 "7e1370bc422be5b087022ac59913ee4b74a1058cea20685c3c1ad2142a324efa", // v0.8.13
                 "ac9015b0c1608869416b3a14d0bf263a862b8d1b7cf2a599dcb5ccd3d7d82f29", // v0.8.12
                 "fec843fc44c9d1f575e096e0b3e790d7ead12a3b36ee4cd327d9714e6d7d9372", // v0.8.11
@@ -912,9 +945,22 @@ public static class DownloadHashManager
                 "363864a0f41e7f61a930c8f070e1b1357dc9b86063f747b719651890b446d0a7", // v0.6.8
                 "6af1d3dace190fd7047ce90634764c80bf2fb6d64094e2a5821afe8e0c74bb65", // v0.6.7 (first SE-tracked Linux CUDA build)
             },
+            [CrispAsr.LinuxCuda13Executable] = new[]
+            {
+                "d82fd05883f37fbf75878c14629b8d3d388f1586d64b52cbe2eeda3472f736c3", // v0.8.20 (current download URL, first SE-tracked build)
+            },
+            [CrispAsr.LinuxVulkanExecutable] = new[]
+            {
+                "ac97955896cb5bdad91a109e771cc7dee351b4d8aea57eedfed76896836fc914", // v0.8.20 (current download URL, first SE-tracked build)
+            },
+            [CrispAsr.LinuxHipExecutable] = new[]
+            {
+                "7075f1581bdf1542ba25b9fa9119a1ebe58fda8f5423aeb68344c6b587ac9101", // v0.8.20 (current download URL, first SE-tracked build)
+            },
             [CrispAsr.LinuxArmExecutable] = new[]
             {
-                "8af30ea0fb610ea5b7a7bcd767070469f6daa74f3b86be45f53dd9e3cb3c5176", // v0.8.15 (current download URL)
+                "f7cf43213ebbb298d373f67573a9e38a6445924804afa36d724cedf74251f9c7", // v0.8.20 (current download URL)
+                "8af30ea0fb610ea5b7a7bcd767070469f6daa74f3b86be45f53dd9e3cb3c5176", // v0.8.15
                 "36457053e4b96f36a26ac2aa809f484521924f4be31e14a5f0c05fc1c9790149", // v0.8.13 (v0.8.11/v0.8.12 shipped no linux-arm64 build)
                 "6acb44b3838020b5ad1a544b59b9649712bc91e8117c8299bcc9cb8b9b40b40e", // v0.8.10
                 "1097775f68dbccfdf8c01fb04ed9f6ea4c880c521cab619bd2f971beffdcf5fd", // v0.8.9
@@ -1581,7 +1627,7 @@ public static class DownloadHashManager
     /// <summary>
     /// Resolves the CrispASR hash key for the current OS and variant.
     /// On Windows the variant selects between cuda, vulkan, cpu, and cpu-legacy.
-    /// On Linux x86_64 the variant selects between cuda and the default CPU build.
+    /// On Linux x86_64 the variant selects between cuda, cuda13, vulkan, hip, and the default CPU build.
     /// On Linux ARM64 the variant is ignored (only one build).
     /// Returns null if the platform / variant combination is unknown.
     /// </summary>
@@ -1593,11 +1639,14 @@ public static class DownloadHashManager
             {
                 return CrispAsr.LinuxArm;
             }
-            if (variant == "cuda")
+            return variant switch
             {
-                return CrispAsr.LinuxCuda;
-            }
-            return CrispAsr.Linux;
+                "cuda" => CrispAsr.LinuxCuda,
+                "cuda13" => CrispAsr.LinuxCuda13,
+                "vulkan" => CrispAsr.LinuxVulkan,
+                "hip" => CrispAsr.LinuxHip,
+                _ => CrispAsr.Linux,
+            };
         }
 
         if (OperatingSystem.IsMacOS())
@@ -1623,7 +1672,8 @@ public static class DownloadHashManager
     /// <summary>
     /// Reverse of <see cref="ResolveCrispAsrKey"/> — returns the variant string matching the
     /// given hash key. For Windows: "cuda" / "vulkan" / "cpu" / "cpu-legacy". For Linux x86_64:
-    /// "cuda" for the CUDA build, empty string for the default CPU build. Returns null otherwise.
+    /// "cuda" / "cuda13" / "vulkan" / "hip" for the GPU builds, empty string for the default CPU
+    /// build. Returns null otherwise.
     /// </summary>
     public static string? GetCrispAsrVariant(string key)
     {
@@ -1634,6 +1684,9 @@ public static class DownloadHashManager
             CrispAsr.WindowsCpu or CrispAsr.WindowsCpuExecutable => "cpu",
             CrispAsr.WindowsCpuLegacy or CrispAsr.WindowsCpuLegacyExecutable => "cpu-legacy",
             CrispAsr.LinuxCuda or CrispAsr.LinuxCudaExecutable => "cuda",
+            CrispAsr.LinuxCuda13 or CrispAsr.LinuxCuda13Executable => "cuda13",
+            CrispAsr.LinuxVulkan or CrispAsr.LinuxVulkanExecutable => "vulkan",
+            CrispAsr.LinuxHip or CrispAsr.LinuxHipExecutable => "hip",
             CrispAsr.Linux or CrispAsr.LinuxExecutable => string.Empty,
             CrispAsr.LinuxArm or CrispAsr.LinuxArmExecutable => string.Empty,
             _ => null,
@@ -1805,11 +1858,14 @@ public static class DownloadHashManager
             {
                 return CrispAsr.LinuxArmExecutable;
             }
-            if (variant == "cuda")
+            return variant switch
             {
-                return CrispAsr.LinuxCudaExecutable;
-            }
-            return CrispAsr.LinuxExecutable;
+                "cuda" => CrispAsr.LinuxCudaExecutable,
+                "cuda13" => CrispAsr.LinuxCuda13Executable,
+                "vulkan" => CrispAsr.LinuxVulkanExecutable,
+                "hip" => CrispAsr.LinuxHipExecutable,
+                _ => CrispAsr.LinuxExecutable,
+            };
         }
 
         if (OperatingSystem.IsMacOS())
@@ -1890,10 +1946,10 @@ public static class DownloadHashManager
 
     /// <summary>
     /// Detects which Linux CrispASR variant is installed.
-    /// Returns "cuda" for the statically-linked CUDA build, or null for the default CPU build.
-    /// The Linux CUDA archive ships only crispasr + crispasr-quantize with CUDA libs linked in,
-    /// so there is no backend .so to detect by filename — we use the .installed.sha256 sidecar,
-    /// falling back to matching the crispasr binary against the known CUDA executable hashes.
+    /// Returns "cuda" / "cuda13" / "vulkan" / "hip" for the GPU builds, or null for the default
+    /// CPU build. Every Linux archive ships just crispasr + crispasr-quantize with the backend
+    /// linked in, so there is no backend .so to detect by filename — we use the .installed.sha256
+    /// sidecar, falling back to matching the crispasr binary against the known GPU executable hashes.
     /// </summary>
     public static string? DetectCrispAsrLinuxVariant(string installFolder)
     {
@@ -1902,14 +1958,29 @@ public static class DownloadHashManager
             return null;
         }
 
+        var gpuVariants = new[]
+        {
+            (Key: CrispAsr.LinuxCuda, ExecutableKey: CrispAsr.LinuxCudaExecutable, Variant: "cuda"),
+            (Key: CrispAsr.LinuxCuda13, ExecutableKey: CrispAsr.LinuxCuda13Executable, Variant: "cuda13"),
+            (Key: CrispAsr.LinuxVulkan, ExecutableKey: CrispAsr.LinuxVulkanExecutable, Variant: "vulkan"),
+            (Key: CrispAsr.LinuxHip, ExecutableKey: CrispAsr.LinuxHipExecutable, Variant: "hip"),
+        };
+
         var sidecarKey = TryReadInstalledKey(installFolder);
-        if (sidecarKey == CrispAsr.LinuxCuda)
+        if (sidecarKey != null)
         {
-            return "cuda";
-        }
-        if (sidecarKey == CrispAsr.Linux)
-        {
-            return null;
+            if (sidecarKey == CrispAsr.Linux)
+            {
+                return null;
+            }
+
+            foreach (var gpu in gpuVariants)
+            {
+                if (sidecarKey == gpu.Key)
+                {
+                    return gpu.Variant;
+                }
+            }
         }
 
         var exe = Path.Combine(installFolder, "crispasr");
@@ -1921,11 +1992,14 @@ public static class DownloadHashManager
         var exeHash = ComputeSha256(exe);
         if (exeHash != null)
         {
-            foreach (var cuda in GetKnownHashes(CrispAsr.LinuxCudaExecutable))
+            foreach (var gpu in gpuVariants)
             {
-                if (cuda.Equals(exeHash, StringComparison.OrdinalIgnoreCase))
+                foreach (var known in GetKnownHashes(gpu.ExecutableKey))
                 {
-                    return "cuda";
+                    if (known.Equals(exeHash, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return gpu.Variant;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Updates the pinned CrispASR release from v0.8.15 to [v0.8.20](https://github.com/CrispStrobe/CrispASR/releases/tag/v0.8.20), and offers the Linux GPU builds that SE has never exposed.

## Version bump

All eight download URLs move to v0.8.20. Every archive and executable hash was computed from the actual download and verified against GitHub's asset digests; the macOS binary was run headlessly and self-reports `version: 0.8.20`. The new hashes go in at index 0 with the previous entries relabelled, so existing installs get the update prompt exactly once.

## New Linux builds

v0.8.20 ships `vulkan`, `hip`, `cuda13` and `avx512` Linux x86_64 builds that SE did not offer. The Linux download prompt grows from CPU/CUDA to **CPU / Vulkan / CUDA / ROCm**, with a **CUDA 12 vs CUDA 13** follow-up mirroring the existing CPU standard/legacy follow-up. Fitting that row needed a fourth custom button in `MessageBox`.

Windows is unchanged: the release ships exactly the four Windows assets SE already offers.

All Linux GPU builds are statically linked with no backend `.so`, so install detection remains sidecar-first with an executable-hash fallback, exactly as it already was for Linux CUDA. The engine-settings row now reports `Linux x64 (Vulkan)` / `(ROCm)` / `(CUDA 13)`.

## Two fixes found along the way

- **Linux ARM64 unpacked into the wrong place.** The skip-folder was hardcoded to `crispasr-linux-x86_64`, which does not match that archive's `crispasr-linux-arm64/` prefix, so nothing was stripped and `crispasr` ended up one level deeper than `GetExecutable()` looks. The skip folder is now chosen per architecture.
- **`TtsVoiceInstaller` passed `"vulkan"` as an ignored-on-non-Windows placeholder.** With Vulkan now meaningful on Linux that would silently pull the 60 MB Vulkan build, so it passes empty (CPU) instead, and re-downloads detect the installed Linux variant rather than guessing. Fresh TTS installs on Linux also get the build choice they previously lacked.

## Testing

`dotnet build` clean, CrispASR/DownloadHashManager tests pass (6/6). Only the macOS binary could be exercised here — the Linux and Windows download paths are untested at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)