### PR TITLE
Fix alternating row color update on system theme change

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -50,6 +50,8 @@ public static partial class InitListViewAndEditBox
             vm.SubtitleGrid.ItemsSource = null;
         }
 
+        vm.SubtitleGridAlternatingRowBrush = null;
+
         var mainGrid = new Grid
         {
             RowDefinitions = new RowDefinitions("*,Auto"),
@@ -107,7 +109,7 @@ public static partial class InitListViewAndEditBox
         var booleanAndConverter = BooleanAndConverter.Instance;
 
         // Optional alternating row background (Options > Settings > Appearance)
-        IBrush? alternatingRowBrush = null;
+        SolidColorBrush? alternatingRowBrush = null;
         if (Se.Settings.Appearance.GridAlternatingRows)
         {
             var isDark = Application.Current?.ActualThemeVariant == ThemeVariant.Dark;
@@ -119,6 +121,7 @@ public static partial class InitListViewAndEditBox
                 if (!string.IsNullOrWhiteSpace(altColorHex))
                 {
                     alternatingRowBrush = new SolidColorBrush(altColorHex.FromHexToColor());
+                    vm.SubtitleGridAlternatingRowBrush = alternatingRowBrush;
                 }
             }
             catch

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1,4 +1,5 @@
 using Nikse.SubtitleEdit.UiLogic.Export;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
@@ -6,6 +7,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.Styling;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using AvaloniaEdit;
@@ -282,6 +284,7 @@ public partial class MainViewModel :
 
     public DataGrid SubtitleGrid { get; set; }
     public Border? SubtitleGridDropHost { get; set; }
+    public SolidColorBrush? SubtitleGridAlternatingRowBrush { get; set; }
     public Window? Window { get; set; }
     public Grid ContentGrid { get; set; }
     public MainView? MainView { get; set; }
@@ -8922,6 +8925,23 @@ public partial class MainViewModel :
     private void OnSystemThemeChanged()
     {
         RebuildToolbar();
+
+        // The rows keep a shared brush, rather than a theme-resource binding. Updating its
+        // Color notifies every realized row without rebuilding the grid (and losing its state).
+        if (SubtitleGridAlternatingRowBrush != null)
+        {
+            var colorHex = Application.Current?.ActualThemeVariant == ThemeVariant.Dark
+                ? Se.Settings.Appearance.GridAlternatingRowColorDark
+                : Se.Settings.Appearance.GridAlternatingRowColor;
+            try
+            {
+                SubtitleGridAlternatingRowBrush.Color = colorHex.FromHexToColor();
+            }
+            catch
+            {
+                // Keep the current brush color when the configured value is invalid.
+            }
+        }
 
         // The syntax highlighting scheme is theme-dependent. The edit box re-colors itself
         // (its presenter keys its caches on the theme), but the grid rows hold converted


### PR DESCRIPTION
## Problem

With `Use alternating row colors in grid` enabled, switching the system theme could leave the subtitle grid using the alternating-row color from the previous theme.

## Cause & Fix

The index-based row background binding implemented in #12486 uses a shared `SolidColorBrush`. That keeps the alternating pattern synchronized, but the brush itself was not updated when the application theme changed.

This change retains a reference to that brush in `MainViewModel` and updates its `Color` during the theme refresh. Since realized rows share the brush instance, their alternating backgrounds update immediately without rebuilding the grid or losing grid state.

The stored brush reference is cleared before a grid rebuild, and remains unset when alternating row colors are disabled.

## Screenshots

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/a53327a5-d9a3-48c6-876a-fbb8d45ec857"> | <video src="https://github.com/user-attachments/assets/b57d64b8-c1c6-497c-b0c2-d617bc6118bf"> |
| Switching the system theme leaves alternating rows using the previous theme's color. | Alternating rows update immediately to the configured color for the new theme. |

## Testing

- Tested on Windows 11 and Fedora 44 (x64, local build).