### PR TITLE
Stop preview timer when closing Convert Actors window with Esc

### DIFF
--- a/src/ui/Features/Tools/ConvertActors/ConvertActorsViewModel.cs
+++ b/src/ui/Features/Tools/ConvertActors/ConvertActorsViewModel.cs
@@ -323,6 +323,7 @@ public partial class ConvertActorsViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _timerUpdatePreview.Stop();
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))


### PR DESCRIPTION
## Summary
- Stop `_timerUpdatePreview` in the Escape key handler before closing the Convert Actors window, matching what the OK and Cancel buttons already do.

## The leak

`ConvertActorsViewModel` runs a self-restarting `System.Timers.Timer` (500 ms) whose `Elapsed` lambda captures the ViewModel to refresh the preview grid. An enabled `System.Timers.Timer` is rooted by the runtime's timer queue, so while the timer runs, the lambda — and through it the entire ViewModel with its subtitle collections — cannot be garbage-collected.

The OK and Cancel buttons call `_timerUpdatePreview.Stop()` before closing, but closing the window with **Esc** went straight to `Window?.Close()` without stopping the timer. The timer then kept firing every 500 ms for the lifetime of the process, keeping the dead ViewModel in memory — one leaked ViewModel and running timer per Esc-closed window.

Once stopped, the timer is no longer rooted, so the ViewModel becomes collectible.

## Image

<img width="919" height="202" alt="image" src="https://github.com/user-attachments/assets/f7c7b66c-d29a-4cb2-9980-7c47741e997c" />



## Test plan
- [x] Open Tools > Convert actors with a subtitle loaded
- [x] Close the window with Esc
- [x] Set a breakpoint (or add a temporary log) in the timer's `Elapsed` handler and confirm it no longer fires after the window is closed
- [x] Verify OK and Cancel still close the window and behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)