### PR TITLE
Replace manual byte-shifting helpers with BinaryPrimitives

### DIFF
--- a/src/libse/Cea608/GetCcDataHelper.cs
+++ b/src/libse/Cea608/GetCcDataHelper.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
 using System.IO;
 using Nikse.SubtitleEdit.Core.Common;
 
@@ -14,7 +16,7 @@ namespace Nikse.SubtitleEdit.Core.Cea608
                 var buffer = new byte[4];
                 fs.Seek((long)i, SeekOrigin.Begin);
                 fs.ReadFully(buffer, 0, buffer.Length);
-                var nalSize = GetUInt32(buffer, 0);
+                var nalSize = BinaryPrimitives.ReadUInt32BigEndian(buffer);
                 var flag = fs.ReadByte();
                 if (IsRbspNalUnitType(flag & 0x1F) && nalSize < 10_000)
                 {
@@ -144,13 +146,8 @@ namespace Nikse.SubtitleEdit.Core.Cea608
             // buffer[pos + 8], so a buffer ending right after the two magic words must not match
             return payloadType == 4 &&
                    pos + 8 < buffer.Length &&
-                   GetUInt32(buffer, pos) == 3036688711 &&
-                   GetUInt32(buffer, pos + 4) == 1094267907;
-        }
-
-        private static uint GetUInt32(byte[] buffer, int pos)
-        {
-            return (uint)((buffer[pos + 0] << 24) + (buffer[pos + 1] << 16) + (buffer[pos + 2] << 8) + buffer[pos + 3]);
+                   BinaryPrimitives.ReadUInt32BigEndian(buffer.AsSpan(pos)) == 3036688711 &&
+                   BinaryPrimitives.ReadUInt32BigEndian(buffer.AsSpan(pos + 4)) == 1094267907;
         }
     }
 }

--- a/src/libse/ContainerFormats/Mp4/Boxes/Box.cs
+++ b/src/libse/ContainerFormats/Mp4/Boxes/Box.cs
@@ -1,5 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using System;
+using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -14,54 +15,27 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
         public ulong Size;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint GetUInt(ReadOnlySpan<byte> span)
-        {
-            // Big-endian byte order (network byte order)
-            return (uint)(span[0] << 24 | span[1] << 16 | span[2] << 8 | span[3]);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public uint GetUInt(int index)
         {
-            return GetUInt(Buffer.AsSpan(index));
+            return BinaryPrimitives.ReadUInt32BigEndian(Buffer.AsSpan(index));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetInt(int index)
         {
-            return (int)GetUInt(Buffer.AsSpan(index));
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ulong GetUInt64(ReadOnlySpan<byte> span)
-        {
-            // Big-endian byte order
-            return (ulong)span[0] << 56 | (ulong)span[1] << 48 | (ulong)span[2] << 40 | (ulong)span[3] << 32 |
-                   (ulong)span[4] << 24 | (ulong)span[5] << 16 | (ulong)span[6] << 8 | span[7];
+            return BinaryPrimitives.ReadInt32BigEndian(Buffer.AsSpan(index));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ulong GetUInt64(int index)
         {
-            return GetUInt64(Buffer.AsSpan(index));
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int GetWord(byte[] buffer, int index)
-        {
-            return GetWord(buffer.AsSpan(index));
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int GetWord(ReadOnlySpan<byte> span)
-        {
-            return (span[0] << 8) | span[1];
+            return BinaryPrimitives.ReadUInt64BigEndian(Buffer.AsSpan(index));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetWord(int index)
         {
-            return GetWord(Buffer.AsSpan(index));
+            return BinaryPrimitives.ReadUInt16BigEndian(Buffer.AsSpan(index));
         }
 
         public string GetString(int index, int count)
@@ -111,7 +85,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
             }
 
             var span = Buffer.AsSpan(0, 8);
-            Size = GetUInt(span);
+            Size = BinaryPrimitives.ReadUInt32BigEndian(span);
             Name = Encoding.UTF8.GetString(span.Slice(4, 4));
 
             if (Size == 0)
@@ -127,7 +101,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                     return false;
                 }
 
-                Size = GetUInt64(Buffer.AsSpan(0, 8)) - 8;
+                Size = BinaryPrimitives.ReadUInt64BigEndian(Buffer.AsSpan(0, 8)) - 8;
             }
 
             Position = (ulong)fs.Position + Size - 8;

--- a/src/libse/ContainerFormats/Mp4/Boxes/Stbl.cs
+++ b/src/libse/ContainerFormats/Mp4/Boxes/Stbl.cs
@@ -3,6 +3,7 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Core.VobSub;
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -269,7 +270,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                                 if (fs.Read(boxHeader, 0, 8) < 8)
                                     break;
 
-                                var boxSize = GetUInt(boxHeader.AsSpan(0, 4));
+                                var boxSize = BinaryPrimitives.ReadUInt32BigEndian(boxHeader.AsSpan(0, 4));
                                 var boxName = GetString(boxHeader, 4, 4);
                                 if (boxSize < 8)
                                     break;
@@ -304,7 +305,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                             fs.Seek((long)sampleOffset, SeekOrigin.Begin);
                             var buffer = new byte[2];
                             fs.ReadFully(buffer, 0, buffer.Length);
-                            var textSize = (uint)GetWord(buffer, 0);
+                            var textSize = (uint)BinaryPrimitives.ReadUInt16BigEndian(buffer);
 
                             if (textSize > 0)
                             {

--- a/src/libse/SubtitleFormats/Tx3gTextOnly.cs
+++ b/src/libse/SubtitleFormats/Tx3gTextOnly.cs
@@ -1,5 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -17,11 +18,6 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             throw new NotImplementedException();
         }
 
-        public static int GetUInt(byte[] buffer, int index)
-        {
-            return (buffer[index] << 24) + (buffer[index + 1] << 16) + (buffer[index + 2] << 8) + buffer[index + 3];
-        }
-
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             subtitle.Paragraphs.Clear();
@@ -29,9 +25,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 var buffer = FileUtil.ReadAllBytesShared(fileName);
                 int i = 0;
-                while (i  + 4 < buffer.Length)
+                while (i + 4 < buffer.Length)
                 {
-                    var boxLength = GetUInt(buffer, i);
+                    var boxLength = BinaryPrimitives.ReadInt32BigEndian(buffer.AsSpan(i));
                     if (boxLength > 500 || i + 4 + boxLength > buffer.Length)
                     {
                         break;

--- a/src/libse/VobSub/Helper.cs
+++ b/src/libse/VobSub/Helper.cs
@@ -45,10 +45,5 @@ namespace Nikse.SubtitleEdit.Core.VobSub
 
             return 0;
         }
-
-        public static int GetLittleEndian32(byte[] buffer, int index)
-        {
-            return (buffer[index + 3] << 24 | buffer[index + 2] << 16 | buffer[index + 1] << 8 | buffer[index + 0]);
-        }
     }
 }

--- a/src/libse/VobSub/SpHeader.cs
+++ b/src/libse/VobSub/SpHeader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers.Binary;
 
 namespace Nikse.SubtitleEdit.Core.VobSub
 {
@@ -15,7 +16,7 @@ namespace Nikse.SubtitleEdit.Core.VobSub
         public SpHeader(byte[] buffer)
         {
             Identifier = System.Text.Encoding.ASCII.GetString(buffer, 0, 2);
-            int startMilliseconds = (int)Math.Round(Helper.GetLittleEndian32(buffer, 2) / 90.0);
+            int startMilliseconds = (int)Math.Round(BinaryPrimitives.ReadInt32LittleEndian(buffer.AsSpan(2)) / 90.0);
             StartTime = TimeSpan.FromMilliseconds(startMilliseconds);
             NextBlockPosition = Helper.GetEndianWord(buffer, 10) - 4;
             ControlSequencePosition = Helper.GetEndianWord(buffer, 12) - 4;


### PR DESCRIPTION
## Summary
- Remove hand-rolled endian read helpers in libse that duplicate `System.Buffers.Binary.BinaryPrimitives` (available on both `netstandard2.1` and `net10.0` targets)
- `Box` (MP4): static `GetUInt`/`GetUInt64`/`GetWord` span helpers removed; instance readers now delegate to `BinaryPrimitives.Read*BigEndian`
- `GetCcDataHelper`: private `GetUInt32` removed in favor of `ReadUInt32BigEndian`
- VobSub `Helper.GetLittleEndian32` removed; `SpHeader` uses `ReadInt32LittleEndian`
- `Tx3gTextOnly`: `GetUInt` removed in favor of `ReadInt32BigEndian`

## Notes
- All replacements are byte-exact equivalents of the removed helpers (endianness, signedness, and widening preserved)
- Removed methods include a few `public static` helpers on the NuGet-published libse assembly (`Box.GetUInt`/`GetUInt64`/`GetWord`, `Helper.GetLittleEndian32`, `Tx3gTextOnly.GetUInt`) — technically a breaking API change for external consumers

## Test plan
- `dotnet build src/libse/LibSE.csproj` — clean, both targets
- `dotnet test tests/libse/LibSETests.csproj` — 618/618 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)