### PR TITLE
Add Qwen 3.6 35B-A3B (IQ2_M) to the llama.cpp translate and review lists

### DIFF
--- a/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
+++ b/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
@@ -114,6 +114,18 @@ public static class LlamaCppServerManager
             "https://huggingface.co/bartowski/Qwen_Qwen3.5-9B-GGUF/resolve/main/Qwen_Qwen3.5-9B-Q8_0.gguf",
             ChatTemplate: "chatml", NoJinja: true),
 
+        // Qwen 3.6 35B-A3B - a mixture-of-experts model: 35B total but only ~3B active per token, so
+        // it generates fast even fully on CPU. That makes it the option for machines with plenty of
+        // RAM but no usable GPU. The catch is the quant: UD-IQ2_M is 2-bit, and low-bit hurts MoE
+        // more than dense models (few active params means little redundancy to absorb the error), so
+        // translation quality may well trail the much smaller Qwen 3.5 9B Q4_K_M - hence the note in
+        // the display name. IQ2_M is nonetheless the smallest Qwen 3.6 build available; every other
+        // quant of this model is larger, not smaller. Its GGUF reports architecture "qwen35moe" (the
+        // Qwen 3.5 MoE arch), which the pinned engine already supports.
+        new LlamaCppModel("Qwen 3.6 35B-A3B (IQ2_M) - fast on CPU, 2-bit quality", "Qwen3.6-35B-A3B-UD-IQ2_M.gguf", "11.5 GB",
+            "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-IQ2_M.gguf",
+            ChatTemplate: "chatml", NoJinja: true),
+
         // Hy-MT2 (Tencent Hunyuan-MT 2, 2026) - translation-specialized, official GGUFs, Apache-2.0.
         // Excellent for its 33+5 supported languages (CJK, major European/Asian) but has NO Nordic
         // languages (Danish/Swedish/Norwegian/Finnish), no Greek/Romanian/Hungarian - generation in
@@ -144,7 +156,7 @@ public static class LlamaCppServerManager
 
     // Models for the AI review tool (proofreading). Translation-tuned models (TranslateGemma,
     // Aya) are deliberately absent - proofreading needs general instruction-following and strict
-    // JSON output, where the plain instruct models are much stronger. Kept to <= 10 GB.
+    // JSON output, where the plain instruct models are much stronger. Kept to <= 12 GB.
     public static readonly IReadOnlyList<LlamaCppModel> ReviewModels = new[]
     {
         new LlamaCppModel("Qwen 3.5 4B (Q4_K_M)", "Qwen_Qwen3.5-4B-Q4_K_M.gguf", "2.8 GB",
@@ -158,6 +170,10 @@ public static class LlamaCppServerManager
             ChatTemplate: "chatml", NoJinja: true),
         new LlamaCppModel("Qwen 3.5 9B (Q8_0)", "Qwen_Qwen3.5-9B-Q8_0.gguf", "9.8 GB",
             "https://huggingface.co/bartowski/Qwen_Qwen3.5-9B-GGUF/resolve/main/Qwen_Qwen3.5-9B-Q8_0.gguf",
+            ChatTemplate: "chatml", NoJinja: true),
+        // MoE, ~3B active - fast on CPU; see the note in TranslateModels for the 2-bit caveat.
+        new LlamaCppModel("Qwen 3.6 35B-A3B (IQ2_M) - fast on CPU, 2-bit quality", "Qwen3.6-35B-A3B-UD-IQ2_M.gguf", "11.5 GB",
+            "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-IQ2_M.gguf",
             ChatTemplate: "chatml", NoJinja: true),
         new LlamaCppModel("Gemma 3 4B it (Q4_K_M)", "google_gemma-3-4b-it-Q4_K_M.gguf", "2.5 GB",
             "https://huggingface.co/bartowski/google_gemma-3-4b-it-GGUF/resolve/main/google_gemma-3-4b-it-Q4_K_M.gguf",


### PR DESCRIPTION
Adds `Qwen 3.6 35B-A3B (IQ2_M) - fast on CPU, 2-bit quality` (11.5 GB) to both `TranslateModels` and `ReviewModels`, with the same `chatml` + `NoJinja` handling as the other Qwen entries. The review list's size ceiling goes from 10 GB to 12 GB.

### Why

A mixture-of-experts model: 35B total but only ~3B active per token, so it generates fast even fully on CPU. That serves machines with plenty of RAM but no usable GPU — a niche the other entries, all dense, don't cover.

### The tradeoff

UD-IQ2_M is a 2-bit quant, and low-bit hurts MoE more than dense models — few active params leave little redundancy to absorb the quantization error. Quality may well trail the much smaller Qwen 3.5 9B Q4_K_M (5.7 GB) already in both lists, at twice the RAM.

The caveat is in the **display name**, not just a code comment, following the Hy-MT2 precedent (`- 33 languages, no Nordic`): users picking from a dropdown can't see comments, and 35B oversells what a 2-bit quant actually delivers.

IQ2_M is nonetheless the smallest Qwen 3.6 build published — every other quant is larger, not smaller (IQ3_XXS 13.2 GB, Q2_K_XL 12.2 GB, Q4_K_M 22.1 GB).

### Verification

Static only — the model was not downloaded and no translation or review was run.

- The GGUF header reports `general.architecture = qwen35moe` (parsed directly from the file's first 4 KB via a range request) — Qwen 3.6 reuses the Qwen 3.5 MoE arch
- `qwen35moe` confirmed present in the pinned engine `b10035`, so no engine bump is needed
- File name and size from a `HEAD` request against the actual download URL
- Builds clean

The `chatml` + `NoJinja` choice is inherited by analogy from the Qwen 3/3.5 entries rather than directly verified — reasonable given the shared arch, but it's the one assumption here not backed by a check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)