### PR TITLE
Add BenchmarkDotNet benchmark project

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,77 @@
+name: Run benchmarks
+
+# Benchmarks are not run on every push - they take a few minutes per runner and the results are
+# only meaningful when someone is actually looking at them. This triggers manually, plus on PRs
+# that touch the benchmark project itself so a change to a benchmark gets validated.
+on:
+  workflow_dispatch:
+    inputs:
+      filter:
+        description: 'BenchmarkDotNet filter (e.g. *BinaryPrimitives* or * for everything)'
+        required: true
+        default: '*'
+        type: string
+  pull_request:
+    paths:
+      - 'tests/benchmarks/**'
+      - '.github/workflows/benchmarks.yml'
+
+concurrency:
+  group: benchmarks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: ${{ matrix.label }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            label: linux-x64
+          - runner: windows-latest
+            label: windows-x64
+          - runner: macos-latest
+            label: macos-arm64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Run benchmarks
+        shell: bash
+        # BenchmarkDotNet refuses to produce numbers from a Debug build, hence -c Release.
+        run: |
+          dotnet run --project tests/benchmarks/LibSEBenchmarks.csproj -c Release -- \
+            --filter '${{ inputs.filter || '*' }}' \
+            --artifacts ./BenchmarkDotNet.Artifacts
+
+      - name: Publish results to job summary
+        if: always()
+        shell: bash
+        run: |
+          echo "## Benchmark results - ${{ matrix.label }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          shopt -s nullglob
+          reports=(./BenchmarkDotNet.Artifacts/results/*-report-github.md)
+          if [ ${#reports[@]} -eq 0 ]; then
+            echo "_No report produced - see the job log._" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          for report in "${reports[@]}"; do
+            cat "$report" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+          done
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-${{ matrix.label }}
+          path: ./BenchmarkDotNet.Artifacts/results/
+          if-no-files-found: warn

--- a/SubtitleEdit.sln
+++ b/SubtitleEdit.sln
@@ -154,6 +154,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibUiLogic", "src\libuilogi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibUiLogicTests", "tests\libuilogic\LibUiLogicTests.csproj", "{0057680B-1C69-43FC-9546-2DD11743940A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibSEBenchmarks", "tests\benchmarks\LibSEBenchmarks.csproj", "{61BE9943-809C-445A-AA0D-EC15EBDEEC20}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -260,6 +262,18 @@ Global
 		{0057680B-1C69-43FC-9546-2DD11743940A}.Release|x64.Build.0 = Release|Any CPU
 		{0057680B-1C69-43FC-9546-2DD11743940A}.Release|x86.ActiveCfg = Release|Any CPU
 		{0057680B-1C69-43FC-9546-2DD11743940A}.Release|x86.Build.0 = Release|Any CPU
+		{61BE9943-809C-445A-AA0D-EC15EBDEEC20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{61BE9943-809C-445A-AA0D-EC15EBDEEC20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{61BE9943-809C-445A-AA0D-EC15EBDEEC20}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{61BE9943-809C-445A-AA0D-EC15EBDEEC20}.Debug|x64.Build.0 = Debug|Any CPU
+		{61BE9943-809C-445A-AA0D-EC15EBDEEC20}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{61BE9943-809C-445A-AA0D-EC15EBDEEC20}.Debug|x86.Build.0 = Debug|Any CPU
+		{61BE9943-809C-445A-AA0D-EC15EBDEEC20}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{61BE9943-809C-445A-AA0D-EC15EBDEEC20}.Release|Any CPU.Build.0 = Release|Any CPU
+		{61BE9943-809C-445A-AA0D-EC15EBDEEC20}.Release|x64.ActiveCfg = Release|Any CPU
+		{61BE9943-809C-445A-AA0D-EC15EBDEEC20}.Release|x64.Build.0 = Release|Any CPU
+		{61BE9943-809C-445A-AA0D-EC15EBDEEC20}.Release|x86.ActiveCfg = Release|Any CPU
+		{61BE9943-809C-445A-AA0D-EC15EBDEEC20}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -277,6 +291,7 @@ Global
 		{6F6414CD-28F6-430C-B855-68B7573ACC4F} = {8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}
 		{C8ABD588-56D6-49EF-A85C-187FD9E803F6} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{0057680B-1C69-43FC-9546-2DD11743940A} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{61BE9943-809C-445A-AA0D-EC15EBDEEC20} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {27E960EC-896F-428C-95A2-C250321C16D5}

--- a/tests/benchmarks/BinaryPrimitivesBenchmarks.cs
+++ b/tests/benchmarks/BinaryPrimitivesBenchmarks.cs
@@ -1,0 +1,196 @@
+﻿using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+
+namespace Nikse.SubtitleEdit.Benchmarks
+{
+    /// <summary>
+    /// Compares the hand-rolled byte-shifting helpers that libse used to carry against the
+    /// <see cref="BinaryPrimitives"/> calls that replaced them.
+    ///
+    /// The "Legacy" methods below are verbatim copies of the removed helpers (Box.GetUInt,
+    /// Box.GetUInt64, Box.GetWord, GetCcDataHelper.GetUInt32, Tx3gTextOnly.GetUInt and
+    /// VobSub.Helper.GetLittleEndian32) so the comparison stays apples-to-apples after those
+    /// helpers were deleted from the library.
+    ///
+    /// Each benchmark sweeps a 64 KB buffer so the measured cost is the read itself rather than
+    /// BenchmarkDotNet's per-invocation overhead; OperationsPerInvoke normalizes back to ns/read.
+    /// </summary>
+    // No MemoryDiagnoser: every benchmark reads primitives out of a buffer allocated once in
+    // GlobalSetup, so allocation is zero by construction and measuring it only slows the run.
+    [CategoriesColumn]
+    [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+    [HideColumns("Error", "StdDev", "Median", "RatioSD")]
+    public class BinaryPrimitivesBenchmarks
+    {
+        private const int BufferSize = 64 * 1024;
+        private const int Reads16 = BufferSize / 2;
+        private const int Reads32 = BufferSize / 4;
+        private const int Reads64 = BufferSize / 8;
+
+        private byte[] _buffer = null!;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            // Deterministic pseudo-random content; the values matter only in that they exercise
+            // every byte lane, so a fixed seed keeps runs comparable.
+            _buffer = new byte[BufferSize];
+            new Random(20260722).NextBytes(_buffer);
+
+            // Fail loudly if the two implementations ever stop agreeing - a benchmark comparing
+            // two different results is worse than no benchmark at all.
+            for (var i = 0; i + 8 <= BufferSize; i++)
+            {
+                var span = _buffer.AsSpan(i);
+                if (LegacyGetUInt32BigEndian(_buffer, i) != BinaryPrimitives.ReadUInt32BigEndian(span) ||
+                    LegacyGetUInt64BigEndian(span) != BinaryPrimitives.ReadUInt64BigEndian(span) ||
+                    LegacyGetWord(span) != BinaryPrimitives.ReadUInt16BigEndian(span) ||
+                    LegacyGetLittleEndian32(_buffer, i) != BinaryPrimitives.ReadInt32LittleEndian(span))
+                {
+                    throw new InvalidOperationException($"Legacy and BinaryPrimitives reads disagree at offset {i}.");
+                }
+            }
+        }
+
+        // ---- 32-bit big-endian (MP4 box sizes, CEA-608 NAL sizes, tx3g box lengths) ----
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = Reads32), BenchmarkCategory("UInt32BE")]
+        public ulong Legacy_UInt32BigEndian()
+        {
+            ulong sum = 0;
+            var buffer = _buffer;
+            for (var i = 0; i < BufferSize; i += 4)
+            {
+                sum += LegacyGetUInt32BigEndian(buffer, i);
+            }
+
+            return sum;
+        }
+
+        [Benchmark(OperationsPerInvoke = Reads32), BenchmarkCategory("UInt32BE")]
+        public ulong BinaryPrimitives_UInt32BigEndian()
+        {
+            ulong sum = 0;
+            var span = _buffer.AsSpan();
+            for (var i = 0; i < BufferSize; i += 4)
+            {
+                sum += BinaryPrimitives.ReadUInt32BigEndian(span.Slice(i));
+            }
+
+            return sum;
+        }
+
+        // ---- 64-bit big-endian (MP4 large-box sizes) ----
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = Reads64), BenchmarkCategory("UInt64BE")]
+        public ulong Legacy_UInt64BigEndian()
+        {
+            ulong sum = 0;
+            var span = _buffer.AsSpan();
+            for (var i = 0; i < BufferSize; i += 8)
+            {
+                sum += LegacyGetUInt64BigEndian(span.Slice(i));
+            }
+
+            return sum;
+        }
+
+        [Benchmark(OperationsPerInvoke = Reads64), BenchmarkCategory("UInt64BE")]
+        public ulong BinaryPrimitives_UInt64BigEndian()
+        {
+            ulong sum = 0;
+            var span = _buffer.AsSpan();
+            for (var i = 0; i < BufferSize; i += 8)
+            {
+                sum += BinaryPrimitives.ReadUInt64BigEndian(span.Slice(i));
+            }
+
+            return sum;
+        }
+
+        // ---- 16-bit big-endian (tx3g text sizes) ----
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = Reads16), BenchmarkCategory("UInt16BE")]
+        public ulong Legacy_WordBigEndian()
+        {
+            ulong sum = 0;
+            var span = _buffer.AsSpan();
+            for (var i = 0; i < BufferSize; i += 2)
+            {
+                sum += (ulong)LegacyGetWord(span.Slice(i));
+            }
+
+            return sum;
+        }
+
+        [Benchmark(OperationsPerInvoke = Reads16), BenchmarkCategory("UInt16BE")]
+        public ulong BinaryPrimitives_WordBigEndian()
+        {
+            ulong sum = 0;
+            var span = _buffer.AsSpan();
+            for (var i = 0; i < BufferSize; i += 2)
+            {
+                sum += BinaryPrimitives.ReadUInt16BigEndian(span.Slice(i));
+            }
+
+            return sum;
+        }
+
+        // ---- 32-bit little-endian (VobSub SP header timestamps) ----
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = Reads32), BenchmarkCategory("Int32LE")]
+        public long Legacy_Int32LittleEndian()
+        {
+            long sum = 0;
+            var buffer = _buffer;
+            for (var i = 0; i < BufferSize; i += 4)
+            {
+                sum += LegacyGetLittleEndian32(buffer, i);
+            }
+
+            return sum;
+        }
+
+        [Benchmark(OperationsPerInvoke = Reads32), BenchmarkCategory("Int32LE")]
+        public long BinaryPrimitives_Int32LittleEndian()
+        {
+            long sum = 0;
+            var span = _buffer.AsSpan();
+            for (var i = 0; i < BufferSize; i += 4)
+            {
+                sum += BinaryPrimitives.ReadInt32LittleEndian(span.Slice(i));
+            }
+
+            return sum;
+        }
+
+        // ---- verbatim copies of the removed helpers ----
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint LegacyGetUInt32BigEndian(byte[] buffer, int pos)
+        {
+            return (uint)((buffer[pos + 0] << 24) + (buffer[pos + 1] << 16) + (buffer[pos + 2] << 8) + buffer[pos + 3]);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong LegacyGetUInt64BigEndian(ReadOnlySpan<byte> span)
+        {
+            return (ulong)span[0] << 56 | (ulong)span[1] << 48 | (ulong)span[2] << 40 | (ulong)span[3] << 32 |
+                   (ulong)span[4] << 24 | (ulong)span[5] << 16 | (ulong)span[6] << 8 | span[7];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int LegacyGetWord(ReadOnlySpan<byte> span)
+        {
+            return (span[0] << 8) | span[1];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int LegacyGetLittleEndian32(byte[] buffer, int index)
+        {
+            return buffer[index + 3] << 24 | buffer[index + 2] << 16 | buffer[index + 1] << 8 | buffer[index + 0];
+        }
+    }
+}

--- a/tests/benchmarks/LibSEBenchmarks.csproj
+++ b/tests/benchmarks/LibSEBenchmarks.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <!-- BenchmarkDotNet requires an optimized build; guard against accidental Debug runs. -->
+    <Optimize Condition="'$(Configuration)' == 'Release'">true</Optimize>
+    <ServerGarbageCollection>false</ServerGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\libse\LibSE.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/benchmarks/Program.cs
+++ b/tests/benchmarks/Program.cs
@@ -1,0 +1,12 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace Nikse.SubtitleEdit.Benchmarks
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        }
+    }
+}

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -1,0 +1,43 @@
+﻿# LibSE benchmarks
+
+[BenchmarkDotNet](https://benchmarkdotnet.org/) micro-benchmarks for libse hot paths.
+
+## Running
+
+Benchmarks **must** be run in Release; BenchmarkDotNet refuses to produce numbers from a Debug build.
+
+```bash
+# everything
+dotnet run --project tests/benchmarks -c Release -- --filter '*'
+
+# one class
+dotnet run --project tests/benchmarks -c Release -- --filter '*BinaryPrimitives*'
+
+# quick pass while iterating (3 warmups / 3 iterations - indicative, not publishable)
+dotnet run --project tests/benchmarks -c Release -- --filter '*' --job short
+```
+
+Results land in `BenchmarkDotNet.Artifacts/results/` as markdown, HTML and CSV.
+
+## A note on reading the numbers
+
+These benchmarks measure individual binary reads, which land in the sub-nanosecond range - close
+to the floor of what BenchmarkDotNet can resolve on a single call. Each benchmark therefore sweeps
+a 64 KB buffer and uses `OperationsPerInvoke` to normalize back to ns/read, so the reported figure
+reflects the read itself rather than harness overhead.
+
+Ratios between implementations are meaningful; absolute values are machine-specific and will differ
+between architectures. Endianness intrinsics in particular differ sharply between arm64 (`rev`) and
+x64 (`movbe`/`bswap`), so numbers from an Apple Silicon machine do not transfer to a CI x64 runner.
+
+## Benchmarks
+
+### `BinaryPrimitivesBenchmarks`
+
+Compares the hand-rolled byte-shifting helpers libse used to carry against the
+`System.Buffers.Binary.BinaryPrimitives` calls that replaced them.
+
+The legacy implementations are kept in the benchmark file as verbatim private copies, because the
+originals were deleted from the library. `GlobalSetup` asserts that both implementations agree on
+every offset of the test buffer before any timing runs - a benchmark comparing two implementations
+that return different values would be meaningless.


### PR DESCRIPTION
## Summary

Adds `tests/benchmarks` — a BenchmarkDotNet project for libse hot paths — plus a `Run benchmarks` workflow, with a first suite motivated by #12716 (replacing hand-rolled byte-shifting helpers with `BinaryPrimitives`).

`BinaryPrimitivesBenchmarks` compares the removed helpers against the `BinaryPrimitives` calls that replace them. The legacy implementations are kept as verbatim private copies inside the benchmark, since #12716 deletes the originals from libse — so this project builds and runs against `main` as well, independent of whether #12716 merges.

`GlobalSetup` asserts that both implementations agree on every offset of the test buffer before any timing runs, so the benchmark also guards #12716's byte-exactness claim rather than just timing it.

## Workflow

`.github/workflows/benchmarks.yml` runs the suite on `linux-x64`, `windows-x64` and `macos-arm64`. It triggers on `workflow_dispatch` (with a filter input) and on PRs touching `tests/benchmarks/**` — deliberately *not* on every push, since a full run costs a few minutes per runner and the numbers only matter when someone is reading them. Results go to the job summary and are uploaded as artifacts.

## Results

Ratio vs the legacy shift-chain, lower is better, 1.00 = legacy baseline. Each benchmark sweeps a 64 KB buffer with `OperationsPerInvoke` normalizing back to ns/read.

| Category | linux-x64<br>Xeon 6973P | windows-x64<br>EPYC 7763 | macos-arm64<br>M1 (virtual) |
|--- |---: |---: |---: |
| Int32LE | 0.48 | 0.48 | 0.66 |
| UInt16BE | 0.89 | 0.91 | 1.07 |
| UInt32BE | 0.73 | 0.47 | 0.76 |
| UInt64BE | 0.47 | 0.33 | 0.51 |

`BinaryPrimitives` wins in nearly every category, and the win is larger on x64 than arm64 — up to 3x on the 64-bit read. That fits `movbe`/`bswap` collapsing a chain of 8 byte loads, shifts and ors into roughly one instruction, so the widest read gains the most.

The 16-bit case is a wash everywhere (0.89–1.07); a 2-byte swap was never going to be a bottleneck. The 1.07 on the macos-arm64 runner is noise at sub-nanosecond scale on a shared virtual runner, not a real regression.

These are sub-nanosecond, machine-specific measurements — the ratios are the signal, not the absolute values. Both implementations allocate nothing.

## Test plan

- `dotnet build tests/benchmarks/LibSEBenchmarks.csproj -c Release` — clean, 0 warnings
- Full suite run locally on `main` and on the #12716 branch — identical results
- CI run green on all three runners; `GlobalSetup` equality assertion passes on x64 and arm64
- `BenchmarkDotNet.Artifacts/` was already in `.gitignore`
- Project added to the solution under the existing `tests` folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)