### PR TITLE
Use globs for the remaining Assets entries in UI.csproj

### DIFF
--- a/src/ui/UI.csproj
+++ b/src/ui/UI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
 		<TargetFramework>net10.0</TargetFramework>
@@ -57,180 +57,27 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Remove="Assets\Dictionaries.zip" />
-		<None Remove="Assets\FileTypes\ass.ico" />
-		<None Remove="Assets\FileTypes\dfxp.ico" />
-		<None Remove="Assets\FileTypes\itt.ico" />
-		<None Remove="Assets\FileTypes\lrc.ico" />
-		<None Remove="Assets\FileTypes\sbv.ico" />
-		<None Remove="Assets\FileTypes\smi.ico" />
-		<None Remove="Assets\FileTypes\srt.ico" />
-		<None Remove="Assets\FileTypes\ssa.ico" />
-		<None Remove="Assets\FileTypes\stl.ico" />
-		<None Remove="Assets\FileTypes\sub.ico" />
-		<None Remove="Assets\FileTypes\sup.ico" />
-		<None Remove="Assets\FileTypes\vtt.ico" />
-		<None Remove="Assets\HunspellDictionaries.json" />
-		<None Remove="Assets\Languages\*.json" />
-		<None Remove="Assets\NetflixGlyphs.zip" />
-		<None Remove="Assets\SevenZip\7z-linux64.zip" />
-		<None Remove="Assets\SevenZip\7zaWindows64.zip" />
-		<None Remove="Assets\SevenZip\7zrLinux64.zip" />
-		<None Remove="Assets\SevenZip\7zxa.dll" />
-		<None Remove="Assets\TextToSpeech\AllTalkVoices.json" />
-		<None Remove="Assets\TextToSpeech\AzureVoices.json" />
-		<None Remove="Assets\TextToSpeech\ElevenLabsVoices.json" />
-		<None Remove="Assets\TextToSpeech\MistralVoices.json" />
-		<None Remove="Assets\TextToSpeech\MurfVoices.json" />
-		<None Remove="Assets\TextToSpeech\PiperVoices.json" />
-		<None Remove="Assets\Themes.zip" />
-		<None Remove="Assets\SpeechToText\PurfviewFasterWhisper.txt" />
-		<None Remove="Assets\SpeechToText\PurfviewFasterWhisperXXL.txt" />
-		<None Remove="Assets\SpeechToText\WhisperCPP.txt" />
-		<None Remove="Assets\SpeechToText\WhisperOpenAI.txt" />
-		<None Remove="Styles.xaml" />
-		<AvaloniaResource Include="Assets\Dictionaries.zip" />
+		<!--
+		  Everything under Assets ships as an embedded Avalonia resource. These are globs
+		  rather than a file-per-line list so a newly added asset cannot be forgotten - that
+		  is exactly how ChineseTraditional.json ended up missing from builds (issue #12722).
+		  Assets\Themes\** is excluded in the ItemGroup near the top of this file.
+		  The patterns are scoped by extension on purpose: a bare * would also sweep up
+		  stray files such as the .DS_Store that macOS drops into these folders.
+		-->
+		<None Remove="Assets\**" />
+		<AvaloniaResource Include="Assets\*.ico" />
+		<AvaloniaResource Include="Assets\*.json" />
+		<AvaloniaResource Include="Assets\*.png" />
+		<AvaloniaResource Include="Assets\*.zip" />
+		<AvaloniaResource Include="Assets\FileTypes\*.ico" />
 		<AvaloniaResource Include="Assets\Languages\*.json" />
-		<AvaloniaResource Include="Assets\Layout\Layout01.png" />
-		<AvaloniaResource Include="Assets\Layout\Layout02.png" />
-		<AvaloniaResource Include="Assets\Layout\Layout03.png" />
-		<AvaloniaResource Include="Assets\Layout\Layout04.png" />
-		<AvaloniaResource Include="Assets\Layout\Layout05.png" />
-		<AvaloniaResource Include="Assets\Layout\Layout06.png" />
-		<AvaloniaResource Include="Assets\Layout\Layout07.png" />
-		<AvaloniaResource Include="Assets\Layout\Layout08.png" />
-		<AvaloniaResource Include="Assets\Layout\Layout09.png" />
-		<AvaloniaResource Include="Assets\Layout\Layout10.png" />
-		<AvaloniaResource Include="Assets\Layout\Layout11.png" />
-		<AvaloniaResource Include="Assets\Layout\Layout12.png" />
-		<AvaloniaResource Include="Assets\NetflixGlyphs.zip" />
-		<AvaloniaResource Include="Assets\SevenZip\7zaWindows64.zip" />
-		<AvaloniaResource Include="Assets\SevenZip\7zrLinux64.zip" />
-		<AvaloniaResource Include="Assets\SpeechToText\CrispASRCommon.txt">
-		  <CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\CrispASRCanary.txt">
-		  <CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\CrispASRQwen3.txt">
-		  <CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\CrispASRCohere.txt">
-		  <CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\CrispASRFireRed.txt">
-		  <CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\CrispASRFun-ASRNano.txt">
-		  <CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\CrispASRFun-ASRMLTNano.txt">
-		  <CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\CrispASRGLM.txt">
-		  <CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\CrispASRGranite.txt">
-		  <CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\CrispASRParakeet.txt">
-		  <CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\CrispASROmni.txt">
-		  <CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\CrispASRKyutai.txt">
-		  <CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\CrispASRMega.txt">
-		  <CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\CrispASRMOSSDiarize.txt">
-		  <CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\CrispASRSenseVoice.txt">
-		  <CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\CrispASRARK.txt">
-		  <CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\Themes.zip" />
-		<AvaloniaResource Include="Assets\SpeechToText\PurfviewFasterWhisper.txt">
-			<CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\PurfviewFasterWhisperXXL.txt">
-			<CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\Qwen3ASRCPP.txt" />
-		<AvaloniaResource Include="Assets\SpeechToText\WhisperConst-me.txt">
-			<CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\WhisperCPPcuBLAS.txt">
-		  <CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\WhisperCPPVulkan.txt">
-		  <CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\WhisperCPP.txt">
-			<CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\ChatLLM.cpp.txt">
-		  <CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\WhisperOpenAI.txt">
-			<CopyToOutputDirectory></CopyToOutputDirectory>
-		</AvaloniaResource>
-		<AvaloniaResource Include="Assets\SpeechToText\OpenRouter.txt" />
-		<AvaloniaResource Include="Assets\SpeechToText\AlibabaQwen3Asr.txt" />
+		<AvaloniaResource Include="Assets\Layout\*.png" />
+		<AvaloniaResource Include="Assets\SevenZip\*.zip" />
+		<AvaloniaResource Include="Assets\SpeechToText\*.py" />
+		<AvaloniaResource Include="Assets\SpeechToText\*.txt" />
+		<AvaloniaResource Include="Assets\TextToSpeech\*.json" />
 		<Content Include="SE.ico" />
-		<None Remove="Assets\Ocr.zip" />
-		<AvaloniaResource Include="Assets\Ocr.zip" />
-		<None Remove="Assets\about.png" />
-		<AvaloniaResource Include="Assets\about.png" />
-		<None Remove="Assets\about1.png" />
-		<AvaloniaResource Include="Assets\about1.png" />
-		<None Remove="Assets\about2.png" />
-		<AvaloniaResource Include="Assets\about2.png" />
-		<None Remove="Assets\about3.png" />
-		<AvaloniaResource Include="Assets\about3.png" />
-		<None Remove="Assets\SpeechToText\WhisperCTranslate2.txt" />
-		<AvaloniaResource Include="Assets\SpeechToText\WhisperCTranslate2.txt" />
-		<None Remove="Assets\SpeechToText\MLXWhisper.txt" />
-		<AvaloniaResource Include="Assets\SpeechToText\MLXWhisper.txt" />
-		<None Remove="Assets\SpeechToText\mlx_whisper_transcribe.py" />
-		<AvaloniaResource Include="Assets\SpeechToText\mlx_whisper_transcribe.py" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<AvaloniaResource Include="Assets\FileTypes\ass.ico" />
-		<AvaloniaResource Include="Assets\FileTypes\dfxp.ico" />
-		<AvaloniaResource Include="Assets\FileTypes\itt.ico" />
-		<AvaloniaResource Include="Assets\FileTypes\lrc.ico" />
-		<AvaloniaResource Include="Assets\FileTypes\sbv.ico" />
-		<AvaloniaResource Include="Assets\FileTypes\smi.ico" />
-		<AvaloniaResource Include="Assets\FileTypes\srt.ico" />
-		<AvaloniaResource Include="Assets\FileTypes\ssa.ico" />
-		<AvaloniaResource Include="Assets\FileTypes\stl.ico" />
-		<AvaloniaResource Include="Assets\FileTypes\sub.ico" />
-		<AvaloniaResource Include="Assets\FileTypes\sup.ico" />
-		<AvaloniaResource Include="Assets\FileTypes\vtt.ico" />
-		<AvaloniaResource Include="Assets\SE.png" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<None Remove="Assets\se.ico" />
-		<AvaloniaResource Include="Assets\se.ico" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<AvaloniaResource Include="Assets\HunspellDictionaries.json" />
-		<AvaloniaResource Include="Assets\TextToSpeech\AllTalkVoices.json" />
-		<AvaloniaResource Include="Assets\TextToSpeech\AzureVoices.json" />
-		<AvaloniaResource Include="Assets\TextToSpeech\ElevenLabsVoices.json" />
-		<AvaloniaResource Include="Assets\TextToSpeech\MistralVoices.json" />
-		<AvaloniaResource Include="Assets\TextToSpeech\MurfVoices.json" />
-		<AvaloniaResource Include="Assets\TextToSpeech\GoogleVoices.json" />
-		<AvaloniaResource Include="Assets\TextToSpeech\PiperVoices.json" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/UI/Logic/EmbeddedAssetsTests.cs
+++ b/tests/UI/Logic/EmbeddedAssetsTests.cs
@@ -1,0 +1,97 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Platform;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// Guards the <c>Assets</c> globs in <c>UI.csproj</c>: every file under <c>src/ui/Assets</c>
+/// must actually be embedded as an Avalonia resource. Traditional Chinese was missing from the
+/// language picker because <c>ChineseTraditional.json</c> sat in the folder but was never listed
+/// in the csproj (issue #12722), and the failure was silent at run-time. A file that no glob
+/// covers - a new extension, or a new sub-folder - fails here instead of shipping unnoticed.
+/// </summary>
+public class EmbeddedAssetsTests
+{
+    /// <summary><c>Assets\Themes\**</c> is deliberately excluded from the build.</summary>
+    private const string ExcludedFolder = "Themes";
+
+    [AvaloniaFact]
+    public void EveryAssetOnDisk_IsEmbedded()
+    {
+        var missing = GetAssetsOnDisk()
+            .Except(GetEmbeddedAssets(), StringComparer.Ordinal)
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(
+            missing.Count == 0,
+            "These files exist under src/ui/Assets but are not embedded as Avalonia resources. " +
+            "Add a matching <AvaloniaResource Include=\"...\" /> glob in src/ui/UI.csproj:" +
+            Environment.NewLine + string.Join(Environment.NewLine, missing));
+    }
+
+    [AvaloniaFact]
+    public void EveryEmbeddedAsset_ExistsOnDisk()
+    {
+        var stale = GetEmbeddedAssets()
+            .Except(GetAssetsOnDisk(), StringComparer.Ordinal)
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(
+            stale.Count == 0,
+            "These resources are embedded but have no file under src/ui/Assets:" +
+            Environment.NewLine + string.Join(Environment.NewLine, stale));
+    }
+
+    /// <summary>
+    /// Asset paths relative to the Assets folder, using '/' separators. Dot-files are skipped:
+    /// macOS drops a .DS_Store into these folders and it is neither tracked nor shipped.
+    /// </summary>
+    private static IEnumerable<string> GetAssetsOnDisk()
+    {
+        var root = GetAssetsFolder();
+        var excluded = Path.Combine(root, ExcludedFolder) + Path.DirectorySeparatorChar;
+
+        return Directory
+            .EnumerateFiles(root, "*", SearchOption.AllDirectories)
+            .Where(p => !p.StartsWith(excluded, StringComparison.Ordinal))
+            .Where(p => !Path.GetFileName(p).StartsWith('.'))
+            .Select(p => Path.GetRelativePath(root, p).Replace(Path.DirectorySeparatorChar, '/'));
+    }
+
+    /// <summary>Embedded asset paths relative to the Assets folder, using '/' separators.</summary>
+    private static IEnumerable<string> GetEmbeddedAssets()
+    {
+        const string prefix = "/Assets/";
+
+        return AssetLoader
+            .GetAssets(new Uri("avares://SubtitleEdit/Assets"), null)
+            .Select(uri => Uri.UnescapeDataString(uri.AbsolutePath))
+            .Where(p => p.StartsWith(prefix, StringComparison.Ordinal))
+            .Select(p => p[prefix.Length..])
+            .Where(p => !p.StartsWith(ExcludedFolder + "/", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Walks up from the test output directory to the repository root and returns the
+    /// <c>src/ui/Assets</c> folder. Throws when it cannot be found.
+    /// </summary>
+    private static string GetAssetsFolder()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "src", "ui", "Assets");
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            $"Could not locate 'src/ui/Assets' walking up from '{AppContext.BaseDirectory}'.");
+    }
+}

--- a/tests/UI/Logic/LanguageJsonFilesTests.cs
+++ b/tests/UI/Logic/LanguageJsonFilesTests.cs
@@ -1,6 +1,4 @@
-using Avalonia.Headless.XUnit;
-using Avalonia.Platform;
-using System.Text.Json;
+﻿using System.Text.Json;
 
 namespace UITests.Logic;
 
@@ -43,27 +41,6 @@ public class LanguageJsonFilesTests
 
         Assert.NotEmpty(files);
         Assert.Contains(files, f => Path.GetFileName(f) == "English.json");
-    }
-
-    /// <summary>
-    /// Every file in the Languages folder must be embedded as an Avalonia resource and be
-    /// discoverable by folder enumeration - that is what unpacks the translations at start-up.
-    /// A file added to the folder but not shipped would silently never reach the language picker.
-    /// </summary>
-    [AvaloniaFact]
-    public void EmbeddedLanguageAssets_MatchLanguagesFolder()
-    {
-        var onDisk = Directory.GetFiles(GetLanguagesFolder(), "*.json")
-            .Select(Path.GetFileName)
-            .OrderBy(f => f, StringComparer.Ordinal);
-
-        var embedded = AssetLoader
-            .GetAssets(new Uri("avares://SubtitleEdit/Assets/Languages"), null)
-            .Select(uri => Path.GetFileName(Uri.UnescapeDataString(uri.AbsolutePath)))
-            .Where(f => f.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
-            .OrderBy(f => f, StringComparer.Ordinal);
-
-        Assert.Equal(onDisk, embedded);
     }
 
     /// <summary>


### PR DESCRIPTION
Follow-up to #12724 (now merged). Pure cleanup: no behaviour change, no bug fixed here. #12724 fixed the one asset that had actually drifted (`ChineseTraditional.json`); this removes the conditions that let it drift.

## Changes

The rest of the Assets tree was listed a file per line across three `ItemGroup`s — 193 lines. Replaced with extension-scoped globs per folder:

```xml
<AvaloniaResource Include="Assets\FileTypes\*.ico" />
<AvaloniaResource Include="Assets\Layout\*.png" />
<AvaloniaResource Include="Assets\SpeechToText\*.txt" />
...
```

Scoped by extension rather than a bare `*` on purpose: a bare wildcard would also sweep up the `.DS_Store` files macOS drops into these folders (gitignored, but present in working copies). `Assets\Themes\**` stays excluded as before.

Also drops three dead `<None Remove>` entries for files that no longer exist: `SevenZip\7z-linux64.zip`, `SevenZip\7zxa.dll`, and `Styles.xaml` (the file is `Styles.axaml`, picked up by Avalonia's own glob).

## New test

`EmbeddedAssetsTests` asserts the embedded resource set and the files under `src/ui/Assets` are the same set **in both directions**, so an asset that no glob covers fails the build rather than shipping unnoticed. It supersedes the language-specific check from #12724, which it now covers — that one is removed here to avoid duplicate assertions. The JSON-validity tests in `LanguageJsonFilesTests` stay.

## Verification

- Generated Avalonia resource manifest is **byte-identical** before and after — 102 resources, in both Debug and Release. Diffed the actual generated file, not just the count.
- Full UI test suite: 719/719 pass.

## Out of scope — found while surveying, not fixed here

Two look like real bugs, both in the code→asset direction, which these globs and the new test do **not** cover (they only check that files on disk get embedded):

1. **`ParakeetCppEngine.GetHelpText()` throws.** `ParakeetCppEngine.cs:162` derives the asset name from `StaticName` (`"Parakeet.cpp"`) → `Parakeet.cpp.txt`, which does not exist — the file is `CrispASRParakeet.txt`. `AssetLoader.Open` at line 165 has no try/catch. The same derivation also misses for `WhisperEngineOpenAiCompatible` (`OpenAICompatibleServer.txt`), though there a catch returns fallback text.
2. **`MessageBox` icons never load.** `MessageBox.cs:95` uses `$"Assets/Themes/Dark/{icon}.png"` — a relative filesystem path, not an `avares://` URI, pointing into the one folder excluded from the build — inside an empty catch.

Minor: `Assets/SE.png` is embedded but has no reference in any `.cs` or `.axaml`.

Happy to fix any of these in a separate PR — left out to keep this one a no-op cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)