### PR TITLE
Add the missing OpenAICompatibleServer.txt help text

### DIFF
--- a/src/ui/Assets/SpeechToText/OpenAICompatibleServer.txt
+++ b/src/ui/Assets/SpeechToText/OpenAICompatibleServer.txt
@@ -1,0 +1,32 @@
+OpenAI Compatible Server speech-to-text
+
+Sends audio to any server that implements OpenAI's /v1/audio/transcriptions
+API - OpenAI itself, a hosted provider, or a transcription server running on
+your own machine.
+
+Setup:
+1. Enter the STT Endpoint URL, for example:
+     http://localhost:8000/v1/audio/transcriptions   (local server)
+     https://api.openai.com/v1/audio/transcriptions  (OpenAI)
+2. Enter the API Key. Local servers usually need no key - leave it empty.
+3. Enter the Model the server expects, for example whisper-1.
+
+Only the endpoint URL is required; everything else has a working default.
+
+Settings:
+- Language Hint (e.g. en, de, es) can improve accuracy; leave empty to auto-detect.
+- Prompt gives the model context, such as names or spellings it should get right.
+- Temperature defaults to 0, which gives the most consistent transcript.
+- Extra Headers passes additional HTTP headers, one per line, for servers that
+  need them.
+- Timeout defaults to 300 seconds.
+- Stream response sends 'stream=true' to receive live text deltas (SSE). Turn it
+  off for servers that reject the 'stream' parameter, such as Groq.
+- Audio upload format defaults to MP3. OpenAI caps uploads at 25 MB, so MP3/M4A/
+  WebM (Opus) are recommended for long videos; WAV is lossless but ~5x larger.
+
+Audio larger than 24 MB is split into chunks of about 23 MB and transcribed in
+sequence, then joined back into one subtitle.
+
+See https://platform.openai.com/docs/guides/speech-to-text for the API these
+servers implement.

--- a/tests/UI/Features/Video/SpeechToText/Engines/OpenAiCompatibleSttEngineTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/Engines/OpenAiCompatibleSttEngineTests.cs
@@ -1,0 +1,27 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+namespace UITests.Features.Video.SpeechToText.Engines;
+
+/// <summary>
+/// <see cref="OpenAiCompatibleSttEngine"/> derives its help asset name from
+/// <c>StaticName</c> - "OpenAI Compatible Server" becomes OpenAICompatibleServer.txt. Nothing
+/// checks that name at compile time, and the load falls back to a hard-coded blurb on any
+/// failure, so a missing or renamed asset shows placeholder text rather than failing. That is
+/// exactly what happened: the asset was absent and the fallback served in its place.
+/// </summary>
+public class OpenAiCompatibleSttEngineTests
+{
+    [AvaloniaFact]
+    public async Task GetHelpText_ReturnsTheEmbeddedAsset_NotTheFallback()
+    {
+        var engine = new OpenAiCompatibleSttEngine();
+
+        var helpText = await engine.GetHelpText();
+
+        // Wording from the asset; absent from the fallback blurb in the catch.
+        Assert.Contains("/v1/audio/transcriptions", helpText);
+        Assert.Contains("STT Endpoint URL", helpText);
+        Assert.DoesNotContain("Supports any OpenAI-compatible STT API endpoint.", helpText);
+    }
+}


### PR DESCRIPTION
Last item from the survey in #12725 / #12726.

`OpenAiCompatibleSttEngine` derives its help asset name from `StaticName` — `"OpenAI Compatible Server"` → `OpenAICompatibleServer.txt` — but that file has never existed. The load sits behind a catch that returns a three-line blurb, so **every user of this engine has been seeing placeholder text** instead of real help:

```
OpenAI Compatible Speech-to-Text service.

Configure the endpoint URL and API key in Settings > Tools > Audio to Text.
Supports any OpenAI-compatible STT API endpoint.
```

(That fallback is also misleading — these settings are edited in the Audio to text window itself, not under Settings > Tools.)

## The content is taken from the code, not invented

Everything in the new file is sourced from the repo:

| Content | Source |
|---|---|
| Field names — STT Endpoint URL, API Key, Model, Language Hint, Prompt, Temperature, Extra Headers, Timeout, Stream response, Audio upload format | the English labels in `LanguageGeneral.cs:1493-1511` |
| Defaults — `localhost:8000` endpoint, `whisper-1`, 300 s, temperature 0, MP3 | `ToolsSettings.cs:548-557` |
| "only the endpoint URL is required" | `OpenAiSttService.IsConfigured` |
| Groq / `stream` note and the 25 MB upload note | the existing `...StreamHint` / `...AudioFormatHint` tooltips |
| 24 MB threshold, ~23 MB chunks | `OpenAiSttChunker.DefaultThresholdBytes` / `DefaultChunkSizeBytes` |
| API doc link | the engine's own `Url` property |

Format follows `OpenRouter.txt`, the closest sibling (online engine, prose + Setup + notes). No BOM, matching the other files in that folder.

I deliberately did not name specific third-party server projects, since I could not verify their current names from this repo.

## No csproj change needed

The `Assets\SpeechToText\*.txt` glob from #12725 picks the new file up automatically — this is the first asset added since, and it confirms the globs do what they were meant to.

## Verification

- New test asserts the engine serves the **asset** and not the fallback. Checked in both directions: it passes with the file, and fails when the file is removed.
- Full UI test suite: 720/720 pass.

The `catch` and its fallback text are left in place as a safety net; it is simply no longer reached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)