### PR TITLE
Fix five silent-failure and asset-resolution faults

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -645,7 +645,13 @@ public partial class MainViewModel :
         SetVideoOffsetText = Se.Language.Main.Menu.SetVideoOffset;
         WaveformGeneratingText = string.Empty;
 
-        themeInitializer.UpdateThemesIfNeeded().ConfigureAwait(true);
+        // Deliberately not awaited - the constructor has to return so the window can show. The
+        // continuation is what matters: without it a failure to unpack Themes.zip was an
+        // unobserved task exception, leaving every toolbar icon to fail later with nothing in
+        // the log explaining why.
+        _ = themeInitializer.UpdateThemesIfNeeded().ContinueWith(
+            t => Se.LogError(t.Exception!, "Could not unpack themes"),
+            TaskContinuationOptions.OnlyOnFaulted);
         Dispatcher.UIThread.Post(async void () =>
         {
             try

--- a/src/ui/Features/Options/Settings/WaveformThemes/WaveformThemesViewModel.cs
+++ b/src/ui/Features/Options/Settings/WaveformThemes/WaveformThemesViewModel.cs
@@ -3,10 +3,12 @@ using Avalonia.Media;
 using Avalonia.Platform.Storage;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Shared.PromptTextBox;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -196,10 +198,6 @@ public partial class WaveformThemesViewModel : ObservableObject
         }
 
         var path = files[0].Path.LocalPath;
-        if (!File.Exists(path))
-        {
-            return;
-        }
 
         try
         {
@@ -210,16 +208,33 @@ public partial class WaveformThemesViewModel : ObservableObject
             });
             if (dto == null)
             {
-                return;
+                throw new InvalidOperationException("Not a waveform theme file.");
             }
 
             var theme = dto.ToThemeDisplay(Path.GetFileNameWithoutExtension(path));
             Themes.Add(theme);
             SelectedTheme = theme;
         }
-        catch
+        catch (Exception exception)
         {
-            // Silently ignore malformed files
+            // The user picked this file, so a failure has to be reported - silently doing
+            // nothing looks identical to a successful import of an empty theme.
+            await ShowFileErrorAsync(Se.Language.General.CouldNotOpenFileXErrorY, path, exception);
+        }
+    }
+
+    private async Task ShowFileErrorAsync(string format, string path, Exception exception)
+    {
+        Se.LogError(exception, string.Format(format, path, exception.Message));
+
+        if (Window != null)
+        {
+            await MessageBox.Show(
+                Window,
+                Se.Language.General.Error,
+                string.Format(format, path, exception.Message),
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
         }
     }
 
@@ -277,9 +292,10 @@ public partial class WaveformThemesViewModel : ObservableObject
             var json = JsonSerializer.Serialize(dto, new JsonSerializerOptions { WriteIndented = true });
             File.WriteAllText(file.Path.LocalPath, json);
         }
-        catch
+        catch (Exception exception)
         {
-            // Silently ignore write errors
+            await ShowFileErrorAsync(
+                Se.Language.General.CouldNotSaveFileXErrorY, file.Path.LocalPath, exception);
         }
     }
 

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngineBase.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngineBase.cs
@@ -1,5 +1,6 @@
 using Avalonia.Platform;
 using Nikse.SubtitleEdit.Core.AudioToText;
+using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -58,18 +59,29 @@ public abstract class CrispAsrEngineBase : ICrispAsrEngine
 
     public virtual async Task<string> GetHelpText()
     {
+        // The per-backend asset name is derived from Name, so a backend added without its
+        // matching .txt would throw straight into the caller's RelayCommand. Fall back to the
+        // shared text instead - missing help is not worth taking the dialog down for.
         var assetName = $"{Name.Replace(" ", string.Empty)}.txt";
         var uri = new Uri($"avares://SubtitleEdit/Assets/SpeechToText/{assetName}");
         var commonUri = new Uri("avares://SubtitleEdit/Assets/SpeechToText/CrispASRCommon.txt");
 
-        await using var headerStream = AssetLoader.Open(uri);
-        using var headerReader = new StreamReader(headerStream);
-        var header = await headerReader.ReadToEndAsync();
+        var header = string.Empty;
+        try
+        {
+            await using var headerStream = AssetLoader.Open(uri);
+            using var headerReader = new StreamReader(headerStream);
+            header = (await headerReader.ReadToEndAsync()).TrimEnd();
+        }
+        catch
+        {
+            Se.LogError($"No help text asset \"{assetName}\" for speech-to-text backend \"{Name}\".");
+        }
 
         await using var commonStream = AssetLoader.Open(commonUri);
         using var commonReader = new StreamReader(commonStream);
         var common = await commonReader.ReadToEndAsync();
 
-        return header.TrimEnd() + Environment.NewLine + common;
+        return header.Length == 0 ? common : header + Environment.NewLine + common;
     }
 }

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -119,6 +119,7 @@ public class LanguageGeneral
     public string CopyImageToClipboard { get; set; }
     public string CopyTextToClipboard { get; set; }
     public string CouldNotSaveFileXErrorY { get; set; }
+    public string CouldNotOpenFileXErrorY { get; set; }
     public string Count { get; set; }
     public string Cps { get; set; }
     public string CurrentSubtitle { get; set; }
@@ -880,6 +881,7 @@ public class LanguageGeneral
         CopyImageToClipboard = "Copy image to clipboard";
         CopyTextToClipboard = "Copy text to clipboard";
         CouldNotSaveFileXErrorY = "Could not save file \"{0}\". Error: {1}";
+        CouldNotOpenFileXErrorY = "Could not open file \"{0}\". Error: {1}";
         Count = "Count";
         Cps = "Chars/sec";
         CurrentSubtitle = "Current subtitle";

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -75,11 +75,21 @@ public class Se
         var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
         var programFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
 
+        // Portable mode - keeping data next to the executable - is a Windows notion: a zip
+        // install that lives outside Program Files. Off Windows both folder paths come back
+        // empty, and StartsWith(string.Empty) is always true, so every install already counted
+        // as "in Program Files" and used the per-user data folder. That is the behaviour we
+        // want off Windows, but it was reached by accident; state it outright, because flipping
+        // it would move the data folder out from under existing macOS and Linux installs.
         IsInstalledInProgramFiles =
-            ExePath.StartsWith(programFiles, StringComparison.OrdinalIgnoreCase) ||
-            ExePath.StartsWith(programFilesX86, StringComparison.OrdinalIgnoreCase);
+            !OperatingSystem.IsWindows() ||
+            IsUnder(ExePath, programFiles) ||
+            IsUnder(ExePath, programFilesX86);
 
         IsPortable = !IsInstalledInProgramFiles;
+
+        static bool IsUnder(string path, string root) =>
+            !string.IsNullOrEmpty(root) && path.StartsWith(root, StringComparison.OrdinalIgnoreCase);
 
         DataFolder = IsPortable
             ? ExePath

--- a/src/ui/Logic/Initializers/LanguageInitializer.cs
+++ b/src/ui/Logic/Initializers/LanguageInitializer.cs
@@ -19,8 +19,12 @@ public class LanguageInitializer() : ILanguageInitializer
     {
         if (await NeedsUpdate())
         {
-            await Unpack();
-            WriteNewVersionFile();
+            // Only stamp the version once everything actually landed. Stamping regardless would
+            // mark a half-unpacked folder as current, and this version would then never retry.
+            if (await Unpack())
+            {
+                WriteNewVersionFile();
+            }
         }
     }
 
@@ -71,13 +75,16 @@ public class LanguageInitializer() : ILanguageInitializer
         return false;
     }
 
-    private async Task Unpack()
+    /// <returns><see langword="true"/> when every language file was written.</returns>
+    private async Task<bool> Unpack()
     {
         var outputDir = Se.TranslationFolder;
         if (!Directory.Exists(outputDir))
         {
             Directory.CreateDirectory(outputDir);
         }
+
+        var allWritten = true;
 
         foreach (var uri in AssetLoader.GetAssets(LanguagesFolderUri, null))
         {
@@ -97,7 +104,10 @@ public class LanguageInitializer() : ILanguageInitializer
             catch
             {
                 Se.LogError($"Could not unpack language file \"{fileName}\".");
+                allWritten = false;
             }
         }
+
+        return allWritten;
     }
 }

--- a/src/ui/Logic/Initializers/SevenZipInitializer.cs
+++ b/src/ui/Logic/Initializers/SevenZipInitializer.cs
@@ -23,8 +23,12 @@ public class SevenZipInitializer() : ISevenZipInitializer
         {
             if (await NeedsUpdate(outputDir))
             {
-                await UnpackWindows(outputDir);
-                WriteNewVersionFile(outputDir);
+                // Only stamp the version once the unpack succeeded - otherwise a failed unpack
+                // is recorded as current and 7-Zip is never retried for this version.
+                if (await UnpackWindows(outputDir))
+                {
+                    WriteNewVersionFile(outputDir);
+                }
             }
         }
 
@@ -32,8 +36,10 @@ public class SevenZipInitializer() : ISevenZipInitializer
         {
             if (await NeedsUpdate(outputDir))
             {
-                await UnpackLinux64(outputDir);
-                WriteNewVersionFile(outputDir);
+                if (await UnpackLinux64(outputDir))
+                {
+                    WriteNewVersionFile(outputDir);
+                }
             }
         }
     }
@@ -83,7 +89,8 @@ public class SevenZipInitializer() : ISevenZipInitializer
         return false;
     }
 
-    private static async Task UnpackWindows(string outputDir)
+    /// <returns><see langword="true"/> when 7-Zip was unpacked.</returns>
+    private static async Task<bool> UnpackWindows(string outputDir)
     {
         try
         {
@@ -96,14 +103,17 @@ public class SevenZipInitializer() : ISevenZipInitializer
             await using var zipStream = AssetLoader.Open(zipUri);
             var zipUnpacker = new ZipUnpacker();
             zipUnpacker.UnpackZipStream(zipStream, outputDir);
+            return true;
         }
-        catch
+        catch (Exception exception)
         {
-            // Ignore
+            Se.LogError(exception, $"Could not unpack 7-Zip into \"{outputDir}\".");
+            return false;
         }
     }
 
-    private static async Task UnpackLinux64(string outputDir)
+    /// <returns><see langword="true"/> when 7-Zip was unpacked.</returns>
+    private static async Task<bool> UnpackLinux64(string outputDir)
     {
         try
         {
@@ -116,10 +126,12 @@ public class SevenZipInitializer() : ISevenZipInitializer
             await using var zipStream = AssetLoader.Open(zipUri);
             var zipUnpacker = new ZipUnpacker();
             zipUnpacker.UnpackZipStream(zipStream, outputDir);
+            return true;
         }
-        catch
+        catch (Exception exception)
         {
-            // Ignore
+            Se.LogError(exception, $"Could not unpack 7-Zip into \"{outputDir}\".");
+            return false;
         }
     }
 }

--- a/tests/UI/Features/Video/SpeechToText/Engines/CrispAsrHelpTextTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/Engines/CrispAsrHelpTextTests.cs
@@ -1,0 +1,41 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+namespace UITests.Features.Video.SpeechToText.Engines;
+
+/// <summary>
+/// <see cref="CrispAsrEngineBase.GetHelpText"/> derives its asset name from <c>Name</c>, so a
+/// backend whose .txt is missing used to throw straight into the caller's RelayCommand. Help
+/// text is not worth taking the dialog down for - it must degrade to the shared text instead.
+/// </summary>
+public class CrispAsrHelpTextTests
+{
+    /// <summary>
+    /// MADLAD has no CrispASRMADLAD.txt - it drives the shared download windows and is
+    /// deliberately not registered as an STT backend, so it is the natural probe for the
+    /// missing-asset path.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task GetHelpText_FallsBackToCommonText_WhenBackendAssetIsMissing()
+    {
+        var engine = new CrispAsrMadlad();
+
+        var helpText = await engine.GetHelpText();
+
+        // Wording from CrispASRCommon.txt: the shared text survives even with no backend header.
+        Assert.False(string.IsNullOrWhiteSpace(helpText));
+        Assert.Contains("--threads", helpText);
+    }
+
+    /// <summary>A backend that does ship a .txt must still get its own header plus the common text.</summary>
+    [AvaloniaFact]
+    public async Task GetHelpText_IncludesBackendHeader_WhenAssetExists()
+    {
+        var engine = new CrispAsrParakeet();
+
+        var helpText = await engine.GetHelpText();
+
+        // From CrispASRParakeet.txt, i.e. the per-backend header rather than only the common text.
+        Assert.Contains("Parakeet", helpText);
+    }
+}

--- a/tests/UI/Logic/Config/DataFolderLocationTests.cs
+++ b/tests/UI/Logic/Config/DataFolderLocationTests.cs
@@ -1,0 +1,47 @@
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Logic.Config;
+
+/// <summary>
+/// Pins where user data lives. The portable check used to rely on
+/// <c>ExePath.StartsWith(programFilesX86)</c> with an empty path off Windows, which is always
+/// true - so every non-Windows install landed in the per-user folder by accident. That outcome
+/// is the intended one and is now explicit; these tests exist because "correcting" the check
+/// into real portable detection would move the data folder out from under existing macOS and
+/// Linux users, losing their settings, dictionaries and themes.
+/// </summary>
+public class DataFolderLocationTests
+{
+    [Fact]
+    public void NonWindows_IsNeverPortable_AndUsesThePerUserDataFolder()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var expected = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Subtitle Edit");
+
+        Assert.False(Se.IsPortable);
+        Assert.Equal(expected, Se.DataFolder);
+    }
+
+    /// <summary>
+    /// Every runtime folder hangs off DataFolder, so pinning that pins the rest. Guards against
+    /// a stray absolute or working-directory-relative path creeping back in.
+    /// </summary>
+    [Fact]
+    public void RuntimeFolders_AreAllUnderTheDataFolder()
+    {
+        string[] folders = [Se.ThemesFolder, Se.TranslationFolder, Se.OcrFolder, Se.SevenZipFolder];
+
+        foreach (var folder in folders)
+        {
+            Assert.True(
+                Path.IsPathRooted(folder),
+                $"\"{folder}\" is not an absolute path - it would resolve against the working directory.");
+            Assert.StartsWith(Se.DataFolder, folder, StringComparison.Ordinal);
+        }
+    }
+}


### PR DESCRIPTION
Items 1-5 from the survey after #12726/#12727. Common thread: each one hid a failure instead of reporting it.

## 1. Portable detection off Windows — `Se.cs:78-82`

```csharp
ExePath.StartsWith(programFilesX86, StringComparison.OrdinalIgnoreCase)
```

`ProgramFilesX86` is `""` off Windows, and `StartsWith("")` is always `true` — so `IsInstalledInProgramFiles` was `true` for *any* path, `IsPortable` was always `false`, and every non-Windows install used the per-user data folder. I confirmed this by probing the runtime rather than reasoning about it: on macOS `ProgramFiles` is `/Applications` and `ProgramFilesX86` is empty, and the check returns `true` even for a path under `/tmp`.

**Behaviour is deliberately unchanged.** That accidental outcome is the one we want. Making portable detection *real* off Windows would relocate `DataFolder` for every macOS/Linux install not sitting in `/Applications` — settings, dictionaries and themes would all appear lost. So this states the intent outright and skips empty roots, rather than "correcting" the logic into a data-loss migration. `DataFolderLocationTests` pins it so a future cleanup can't quietly flip it.

If you *do* want real portable mode off Windows, that is a separate change and needs a migration story.

## 2. Version stamped after a failed unpack — `LanguageInitializer`, `SevenZipInitializer`

Both swallowed unpack failures and then called `WriteNewVersionFile()` unconditionally. One bad first run — disk full, AV lock, read-only folder — marked the folder as current, and the assets were never retried for that version. `Unpack` now reports whether everything landed and the stamp is conditional; SevenZip logs rather than ignoring. (`Theme`/`Dictionary`/`Ocr` already propagated and retried correctly — this brings the other two in line.)

## 3. Waveform theme import/export failed silently — `WaveformThemesViewModel`

Import swallowed malformed files (`catch { // Silently ignore malformed files }`), so picking a bad file did nothing at all. Export swallowed write errors, so an unwritable path **reported success while writing nothing** — the most directly user-visible fault in this batch. Both now log and show the error, following the existing `SettingsViewModel` pattern. Adds `General.CouldNotOpenFileXErrorY`; the save path reuses the existing `CouldNotSaveFileXErrorY`.

## 4. Theme unpack was fire-and-forget — `MainViewModel:645`

`themeInitializer.UpdateThemesIfNeeded().ConfigureAwait(true);` — never awaited, result discarded, so a `Themes.zip` failure was an unobserved task exception. Every toolbar icon would then fail with nothing in the log explaining why. Still not awaited (the constructor has to return), but faults are now logged.

## 5. `CrispAsrEngineBase.GetHelpText` had no try/catch — affects all 17 Crisp backends

The asset name is derived from `Name`, so a backend shipped without its `.txt` throws straight into the caller's bare `[RelayCommand]`. Now falls back to the shared `CrispASRCommon.txt`. This is live today for `CrispAsrMadlad`, which has no `CrispASRMADLAD.txt` — currently unreachable because it is deliberately unregistered, but it is a landmine for the next backend added.

## Verification

- Full UI test suite: **728/728 pass**. Clean build in Debug and Release.
- New `CrispAsrHelpTextTests` covers both paths — missing asset falls back, present asset still gets its own header.
- New `DataFolderLocationTests` asserts `IsPortable` is false and `DataFolder` is the per-user folder off Windows, and that every runtime folder is absolute and under `DataFolder`.

## Deliberately not included

- The fire-and-forget theme unpack still **races** the toolbar build. Fixing that means restructuring startup ordering, not a one-liner.
- **No initializer prunes.** A language or theme dropped in a later version survives forever in the user's folder, and stale themes are surfaced by `SettingsViewModel.cs:431`.
- `version.txt` parsing is still unguarded in all five initializers (`new SemanticVersion` throws on malformed input).
- `OcrInitializer`'s `Latin.nocr > 1.7 MB` check correctly protects user-trained OCR data, but also freezes `Latin.db` updates as a side effect.

Also checked and **rejected** as a finding: `CheckForUpdatesViewModel:91` parsing remote version strings looked unguarded but is wrapped in `catch (ArgumentException)` with a sensible fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)