### PR TITLE
Add llama.cpp engine settings dialog and engine install dots

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -129,6 +129,7 @@ using Nikse.SubtitleEdit.Features.Tools.SortBy;
 using Nikse.SubtitleEdit.Features.Tools.SplitBreakLongLines;
 using Nikse.SubtitleEdit.Features.Tools.SplitSubtitle;
 using Nikse.SubtitleEdit.Features.Translate;
+using Nikse.SubtitleEdit.Features.Translate.LlamaCppEngineSettings;
 using Nikse.SubtitleEdit.Features.Video.BlankVideo;
 using Nikse.SubtitleEdit.Features.Video.BurnIn;
 using Nikse.SubtitleEdit.Features.Video.CutVideo;
@@ -427,6 +428,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<NOcrInspectViewModel>();
         collection.AddTransient<NOcrSettingsViewModel>();
         collection.AddTransient<LlamaCppOcrSettingsViewModel>();
+        collection.AddTransient<LlamaCppEngineSettingsViewModel>();
         collection.AddTransient<OcrViewModel>();
         collection.AddTransient<OmniVoiceSettingsViewModel>();
         collection.AddTransient<Qwen3TtsSettingsViewModel>();

--- a/src/ui/Features/Main/AiAssistant/AiAssistantViewModel.cs
+++ b/src/ui/Features/Main/AiAssistant/AiAssistantViewModel.cs
@@ -5,8 +5,10 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Tools.AiReview;
 using Nikse.SubtitleEdit.Features.Translate;
+using Nikse.SubtitleEdit.Features.Translate.LlamaCppEngineSettings;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using System;
 using System.Collections.ObjectModel;
@@ -162,6 +164,51 @@ public partial class AiAssistantViewModel : ObservableObject
             LlamaCppModels,
             LlamaCppServerManager.GetAllReviewModels(),
             selectedFileName);
+    }
+
+    /// <summary>
+    /// Opens the shared llama.cpp engine settings dialog (installed backend, pinned release, install
+    /// status). Its download button stops the server first - it holds llama-server open, so a running
+    /// server would block replacing the binary - then re-downloads and refreshes the model dots.
+    /// </summary>
+    [RelayCommand]
+    private async Task ShowLlamaCppEngineSettings()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        await _windowService.ShowDialogAsync<LlamaCppEngineSettingsWindow, LlamaCppEngineSettingsViewModel>(
+            Window,
+            vm => vm.Initialize(RedownloadLlamaCppEngineAsync));
+
+        RefreshLlamaCppModels();
+    }
+
+    private async Task RedownloadLlamaCppEngineAsync()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        LlamaCppServerManager.StopServer();
+
+        // Reuse the installed backend so the user is not re-asked CPU/Vulkan/CUDA on a re-download;
+        // null on a fresh install (or off Windows), which lets DownloadAsync prompt.
+        var variant = OperatingSystem.IsWindows()
+            ? DownloadHashManager.DetectLlamaCppWindowsVariant(LlamaCppServerManager.GetAndCreateFolder())
+            : null;
+
+        await LlamaCppDownloadHelper.DownloadAsync(
+            Window,
+            _windowService,
+            SelectedLlamaCppModel?.Model,
+            variant,
+            forceEngineDownload: true);
+
+        RefreshLlamaCppModels();
     }
 
     [RelayCommand]

--- a/src/ui/Features/Main/AiAssistant/AiAssistantWindow.cs
+++ b/src/ui/Features/Main/AiAssistant/AiAssistantWindow.cs
@@ -7,6 +7,7 @@ using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Styling;
+using Nikse.SubtitleEdit.Features.Tools.AiReview;
 using Nikse.SubtitleEdit.Features.Translate;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -31,6 +32,22 @@ public class AiAssistantWindow : Window
         // ---------- toolbar: engine + model settings (same engines as Tools -> AI review) ----------
         var comboEngine = UiUtil.MakeComboBox(vm.Engines, vm, nameof(vm.SelectedEngine))
             .WithAccessibleName(Se.Language.General.Engine);
+        comboEngine.ItemTemplate = AiEngineCombo.ItemTemplate();
+
+        var buttonLlamaCppEngineSettings = UiUtil.MakeButton(vm.ShowLlamaCppEngineSettingsCommand, IconNames.Settings)
+            .WithAccessibleName(Se.Language.General.LlamaCppEngineSettings);
+        ToolTip.SetTip(buttonLlamaCppEngineSettings, Se.Language.General.LlamaCppEngineSettings);
+        buttonLlamaCppEngineSettings.Bind(IsVisibleProperty, new Binding(nameof(vm.IsLlamaCppVisible)));
+
+        // The engine settings button sits directly after the engine combo, not with the model combo:
+        // it configures the engine itself (backend build, release, install state), not the model.
+        var panelEngine = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 5,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children = { comboEngine, buttonLlamaCppEngineSettings },
+        };
 
         var textBoxOllamaModel = UiUtil.MakeTextBox(190, vm, nameof(vm.OllamaModel))
             .WithAccessibleName(Se.Language.General.Model);
@@ -66,35 +83,16 @@ public class AiAssistantWindow : Window
 
         var comboLlamaCppModel = UiUtil.MakeComboBox(vm.LlamaCppModels, vm, nameof(vm.SelectedLlamaCppModel))
             .WithAccessibleName(Se.Language.General.Model);
-        comboLlamaCppModel.Bind(IsVisibleProperty, new Binding(nameof(vm.IsLlamaCppVisible)));
-        comboLlamaCppModel.ItemTemplate = new FuncDataTemplate<LlamaCppModelDisplay>((item, _) =>
-        {
-            var panel = new StackPanel
-            {
-                Orientation = Orientation.Horizontal,
-                Spacing = 7,
-                VerticalAlignment = VerticalAlignment.Center,
-            };
-            if (item != null)
-            {
-                panel.Children.Add(new Avalonia.Controls.Shapes.Ellipse
-                {
-                    Width = 8,
-                    Height = 8,
-                    VerticalAlignment = VerticalAlignment.Center,
-                    Fill = item.IsInstalled
-                        ? new SolidColorBrush(Color.FromRgb(0x5c, 0xb8, 0x5c))
-                        : new SolidColorBrush(Color.FromArgb(0x50, 0x80, 0x88, 0x90)),
-                });
-                panel.Children.Add(new TextBlock
-                {
-                    Text = item.DisplayText,
-                    VerticalAlignment = VerticalAlignment.Center,
-                });
-            }
+        // Shared dot template, so the install colours here match auto-translate, AI review and the
+        // engine settings dialog rather than this window's former bespoke green/grey pair.
+        comboLlamaCppModel.ItemTemplate = StatusDots.ComboItemTemplate<LlamaCppModelDisplay>(
+            m => m.Model.DisplayName,
+            m => string.IsNullOrEmpty(m.Model.Url)
+                ? (string.IsNullOrEmpty(m.Model.Size) ? Se.Language.General.Custom : $"{Se.Language.General.Custom}, {m.Model.Size}")
+                : (string.IsNullOrEmpty(m.Model.Size) ? null : m.Model.Size),
+            m => m.IsInstalled ? DownloadDotStatus.UpToDate : DownloadDotStatus.NotInstalled);
 
-            return panel;
-        });
+        comboLlamaCppModel.Bind(IsVisibleProperty, new Binding(nameof(vm.IsLlamaCppVisible)));
 
         var languageChip = new Border
         {
@@ -125,7 +123,7 @@ public class AiAssistantWindow : Window
         var labelEngine = UiUtil.MakeTextBlock(Se.Language.General.Engine).WithMarginRight(2);
         labelEngine.VerticalAlignment = VerticalAlignment.Center;
         toolbar.Add(labelEngine, 0, 0);
-        toolbar.Add(comboEngine, 0, 1);
+        toolbar.Add(panelEngine, 0, 1);
         toolbar.Add(panelOllama, 0, 2);
         toolbar.Add(comboLlamaCppModel, 0, 3);
         toolbar.Add(panelOpenAiCompatible, 0, 4);

--- a/src/ui/Features/Tools/AiReview/AiEngineCombo.cs
+++ b/src/ui/Features/Tools/AiReview/AiEngineCombo.cs
@@ -1,0 +1,40 @@
+using Avalonia.Controls.Templates;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.LlamaCpp;
+
+namespace Nikse.SubtitleEdit.Features.Tools.AiReview;
+
+/// <summary>
+/// The engine combo shared by Tools -> AI review and the subtitle text box AI assistant. Both list
+/// the same three engines as plain strings, so the install-status dot lives here rather than being
+/// duplicated (and drifting) in each window.
+/// </summary>
+public static class AiEngineCombo
+{
+    /// <summary>
+    /// Renders "[dot] engine name". Only llama.cpp is downloadable, so it is the only row with a dot:
+    /// grey when nothing is installed, amber when the pinned release is newer than the installed
+    /// build, green otherwise. Ollama and OpenAI-compatible are external services SE does not
+    /// install, so they get <see cref="DownloadDotStatus.None"/> and an empty dot slot.
+    /// </summary>
+    public static FuncDataTemplate<string> ItemTemplate()
+    {
+        return StatusDots.ComboItemTemplate<string>(
+            name => name,
+            _ => null,
+            GetDotStatus);
+    }
+
+    private static DownloadDotStatus GetDotStatus(string engineName)
+    {
+        if (engineName != SeAiReview.EngineLlamaCpp)
+        {
+            return DownloadDotStatus.None;
+        }
+
+        return StatusDots.From(
+            LlamaCppServerManager.IsEngineInstalled(),
+            LlamaCppUpdateStatus.GetEngineUpdateStatus());
+    }
+}

--- a/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
@@ -6,8 +6,10 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Translate;
+using Nikse.SubtitleEdit.Features.Translate.LlamaCppEngineSettings;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using System;
 using System.Collections.Generic;
@@ -172,6 +174,51 @@ public partial class AiReviewViewModel : ObservableObject
             LlamaCppModels,
             LlamaCppServerManager.GetAllReviewModels(),
             selectedFileName);
+    }
+
+    /// <summary>
+    /// Opens the shared llama.cpp engine settings dialog (installed backend, pinned release, install
+    /// status). Its download button stops the server first - it holds llama-server open, so a running
+    /// server would block replacing the binary - then re-downloads and refreshes the model dots.
+    /// </summary>
+    [RelayCommand]
+    private async Task ShowLlamaCppEngineSettings()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        await _windowService.ShowDialogAsync<LlamaCppEngineSettingsWindow, LlamaCppEngineSettingsViewModel>(
+            Window,
+            vm => vm.Initialize(RedownloadLlamaCppEngineAsync));
+
+        RefreshLlamaCppModels();
+    }
+
+    private async Task RedownloadLlamaCppEngineAsync()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        LlamaCppServerManager.StopServer();
+
+        // Reuse the installed backend so the user is not re-asked CPU/Vulkan/CUDA on a re-download;
+        // null on a fresh install (or off Windows), which lets DownloadAsync prompt.
+        var variant = OperatingSystem.IsWindows()
+            ? DownloadHashManager.DetectLlamaCppWindowsVariant(LlamaCppServerManager.GetAndCreateFolder())
+            : null;
+
+        await LlamaCppDownloadHelper.DownloadAsync(
+            Window,
+            _windowService,
+            SelectedLlamaCppModel?.Model,
+            variant,
+            forceEngineDownload: true);
+
+        RefreshLlamaCppModels();
     }
 
     private void SaveSettings()

--- a/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
@@ -32,6 +32,7 @@ public class AiReviewWindow : Window
         // ---------- toolbar ----------
         var comboEngine = UiUtil.MakeComboBox(vm.Engines, vm, nameof(vm.SelectedEngine))
             .WithAccessibleName(Se.Language.General.Engine);
+        comboEngine.ItemTemplate = AiEngineCombo.ItemTemplate();
 
         var textBoxOllamaModel = UiUtil.MakeTextBox(220, vm, nameof(vm.OllamaModel))
             .WithAccessibleName(Se.Language.General.Model);
@@ -67,35 +68,31 @@ public class AiReviewWindow : Window
 
         var comboLlamaCppModel = UiUtil.MakeComboBox(vm.LlamaCppModels, vm, nameof(vm.SelectedLlamaCppModel))
             .WithAccessibleName(Se.Language.General.Model);
-        comboLlamaCppModel.Bind(IsVisibleProperty, new Binding(nameof(vm.IsLlamaCppVisible)));
-        comboLlamaCppModel.ItemTemplate = new FuncDataTemplate<Features.Translate.LlamaCppModelDisplay>((item, _) =>
-        {
-            var panel = new StackPanel
-            {
-                Orientation = Orientation.Horizontal,
-                Spacing = 7,
-                VerticalAlignment = VerticalAlignment.Center,
-            };
-            if (item != null)
-            {
-                panel.Children.Add(new Avalonia.Controls.Shapes.Ellipse
-                {
-                    Width = 8,
-                    Height = 8,
-                    VerticalAlignment = VerticalAlignment.Center,
-                    Fill = item.IsInstalled
-                        ? new SolidColorBrush(Color.FromRgb(0x5c, 0xb8, 0x5c))
-                        : new SolidColorBrush(Color.FromArgb(0x50, 0x80, 0x88, 0x90)),
-                });
-                panel.Children.Add(new TextBlock
-                {
-                    Text = item.DisplayText,
-                    VerticalAlignment = VerticalAlignment.Center,
-                });
-            }
+        // Shared dot template, so the install colours here match auto-translate and the engine
+        // settings dialog rather than this window's former bespoke green/grey pair.
+        comboLlamaCppModel.ItemTemplate = StatusDots.ComboItemTemplate<Features.Translate.LlamaCppModelDisplay>(
+            m => m.Model.DisplayName,
+            m => string.IsNullOrEmpty(m.Model.Url)
+                ? (string.IsNullOrEmpty(m.Model.Size) ? Se.Language.General.Custom : $"{Se.Language.General.Custom}, {m.Model.Size}")
+                : (string.IsNullOrEmpty(m.Model.Size) ? null : m.Model.Size),
+            m => m.IsInstalled ? DownloadDotStatus.UpToDate : DownloadDotStatus.NotInstalled);
 
-            return panel;
-        });
+        comboLlamaCppModel.Bind(IsVisibleProperty, new Binding(nameof(vm.IsLlamaCppVisible)));
+
+        var buttonLlamaCppEngineSettings = UiUtil.MakeButton(vm.ShowLlamaCppEngineSettingsCommand, IconNames.Settings)
+            .WithAccessibleName(Se.Language.General.LlamaCppEngineSettings);
+        ToolTip.SetTip(buttonLlamaCppEngineSettings, Se.Language.General.LlamaCppEngineSettings);
+        buttonLlamaCppEngineSettings.Bind(IsVisibleProperty, new Binding(nameof(vm.IsLlamaCppVisible)));
+
+        // The engine settings button sits directly after the engine combo, not with the model combo:
+        // it configures the engine itself (backend build, release, install state), not the model.
+        var panelEngine = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 5,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children = { comboEngine, buttonLlamaCppEngineSettings },
+        };
 
         var languageChip = new Border
         {
@@ -128,7 +125,7 @@ public class AiReviewWindow : Window
         var labelEngine = UiUtil.MakeTextBlock(Se.Language.General.Engine).WithMarginRight(2);
         labelEngine.VerticalAlignment = VerticalAlignment.Center;
         toolbar.Add(labelEngine, 0, 0);
-        toolbar.Add(comboEngine, 0, 1);
+        toolbar.Add(panelEngine, 0, 1);
         toolbar.Add(panelOllama, 0, 2);
         toolbar.Add(comboLlamaCppModel, 0, 3);
         toolbar.Add(panelOpenAiCompatible, 0, 4);

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -11,6 +11,7 @@ using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Core.Translate;
 using Nikse.SubtitleEdit.Features.Ocr;
 using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Translate.LlamaCppEngineSettings;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Logic.LlamaCpp;
@@ -967,6 +968,32 @@ public partial class AutoTranslateViewModel : ObservableObject
         }
 
         RefreshDownloadDots?.Invoke();
+    }
+
+    /// <summary>
+    /// Opens the llama.cpp engine settings dialog (installed backend, pinned release, install status).
+    /// Its download button routes back through <see cref="UpdateLlamaCppEngineAsync"/> so the running
+    /// server is stopped first and the model list and status dots refresh afterwards.
+    /// </summary>
+    [RelayCommand]
+    private async Task ShowLlamaCppEngineSettings()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        // Pass the key of the outdated install when there is one, so the re-download picks the same
+        // backend. Otherwise pass empty: UpdateLlamaCppEngineAsync then falls back to detecting the
+        // variant from the install folder, and to asking the user when nothing is installed yet.
+        var installedKey = GetLlamaCppEngineUpdate()?.key ?? string.Empty;
+
+        await _windowService.ShowDialogAsync<LlamaCppEngineSettingsWindow, LlamaCppEngineSettingsViewModel>(
+            Window,
+            vm => vm.Initialize(() => UpdateLlamaCppEngineAsync(installedKey)));
+
+        RefreshDownloadDots?.Invoke();
+        RefreshEngineUpdateButton();
     }
 
     [RelayCommand]

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -294,6 +294,12 @@ public class AutoTranslateWindow : Window
             .WithMarginLeft(5);
         buttonLlamaCppOpenFolder.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.LlamaCppButtonsAreVisible)));
 
+        var buttonLlamaCppEngineSettings = UiUtil.MakeButton(vm.ShowLlamaCppEngineSettingsCommand, IconNames.Settings)
+            .WithMarginLeft(5)
+            .WithAccessibleName(Se.Language.General.LlamaCppEngineSettings);
+        ToolTip.SetTip(buttonLlamaCppEngineSettings, Se.Language.General.LlamaCppEngineSettings);
+        buttonLlamaCppEngineSettings.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.LlamaCppButtonsAreVisible)));
+
         var settingsPanel = new WrapPanel
         {
             Orientation = Orientation.Horizontal,
@@ -334,6 +340,7 @@ public class AutoTranslateWindow : Window
         settingsPanel.Children.Add(buttonDownloadLlamaCpp);
         settingsPanel.Children.Add(buttonLlamaCppServer);
         settingsPanel.Children.Add(buttonLlamaCppOpenFolder);
+        settingsPanel.Children.Add(buttonLlamaCppEngineSettings);
 
         var settingsButton = UiUtil.MakeButton(vm.OpenSettingsCommand, IconNames.Settings, Se.Language.General.Settings);
         settingsButton.HorizontalAlignment = HorizontalAlignment.Right;

--- a/src/ui/Features/Translate/LlamaCppEngineSettings/LlamaCppEngineSettingsViewModel.cs
+++ b/src/ui/Features/Translate/LlamaCppEngineSettings/LlamaCppEngineSettingsViewModel.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.LlamaCpp;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace Nikse.SubtitleEdit.Features.Translate.LlamaCppEngineSettings;
+
+/// <summary>
+/// Shows which llama.cpp build is installed (backend variant, pinned release tag, install folder)
+/// and whether it is up to date, mirroring the per-engine text-to-speech settings dialogs.
+/// </summary>
+public partial class LlamaCppEngineSettingsViewModel : ObservableObject
+{
+    private readonly IFolderHelper _folderHelper;
+
+    private Func<Task>? _redownloadAsync;
+
+    [ObservableProperty] private string _backendLabel = string.Empty;
+    [ObservableProperty] private string _statusLabel = string.Empty;
+    [ObservableProperty] private IBrush _statusBrush = Brushes.Gray;
+    [ObservableProperty] private string _releaseTag = LlamaCppDownloadService.ReleaseTag;
+    [ObservableProperty] private string _installFolder = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DownloadButtonLabel))]
+    private bool _isInstalled;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DownloadButtonLabel))]
+    private DownloadHashManager.UpdateStatus _engineUpdateStatus;
+
+    // "Download" when not installed, "Update" when a newer engine release is available,
+    // otherwise "Re-download".
+    public string DownloadButtonLabel
+    {
+        get
+        {
+            if (!IsInstalled)
+            {
+                return Se.Language.General.Download;
+            }
+
+            return EngineUpdateStatus == DownloadHashManager.UpdateStatus.UpdateAvailable
+                ? Se.Language.General.Update
+                : Se.Language.General.Redownload;
+        }
+    }
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public LlamaCppEngineSettingsViewModel(IFolderHelper folderHelper)
+    {
+        _folderHelper = folderHelper;
+    }
+
+    /// <summary>
+    /// <paramref name="redownloadAsync"/> is supplied by the caller so the download runs through the
+    /// same flow the caller already owns (stopping the server first, refreshing its model list and
+    /// status dots afterwards) instead of this dialog duplicating it.
+    /// </summary>
+    public void Initialize(Func<Task> redownloadAsync)
+    {
+        _redownloadAsync = redownloadAsync;
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        InstallFolder = LlamaCppServerManager.GetAndCreateFolder();
+        IsInstalled = LlamaCppServerManager.IsEngineInstalled();
+        BackendLabel = IsInstalled ? DetectInstalledBackend(InstallFolder) : Se.Language.General.NotInstalled;
+        EngineUpdateStatus = IsInstalled
+            ? LlamaCppUpdateStatus.GetEngineUpdateStatus()
+            : DownloadHashManager.UpdateStatus.Unknown;
+        ApplyStatus(EngineUpdateStatus, IsInstalled);
+    }
+
+    private void ApplyStatus(DownloadHashManager.UpdateStatus status, bool installed)
+    {
+        if (!installed)
+        {
+            StatusLabel = Se.Language.General.NotInstalled;
+            StatusBrush = new SolidColorBrush(Color.FromRgb(0xF4, 0x43, 0x36));   // red
+            return;
+        }
+
+        switch (status)
+        {
+            case DownloadHashManager.UpdateStatus.UpToDate:
+                StatusLabel = Se.Language.General.UpToDate;
+                StatusBrush = new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50)); // green
+                break;
+            case DownloadHashManager.UpdateStatus.UpdateAvailable:
+                StatusLabel = Se.Language.General.UpdateAvailable;
+                StatusBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00)); // amber
+                break;
+            default:
+                StatusLabel = Se.Language.General.UnknownNoInstallRecord;
+                StatusBrush = new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E)); // grey
+                break;
+        }
+    }
+
+    /// <summary>
+    /// llama.cpp ships CPU/Vulkan/CUDA builds into one folder, so the backend cannot be inferred from
+    /// the folder alone. Only Windows has a proven detector (<see cref="DownloadHashManager.DetectLlamaCppWindowsVariant"/>,
+    /// which reads the shipped ggml backend DLLs); elsewhere we report OS+arch only rather than guess.
+    /// </summary>
+    private static string DetectInstalledBackend(string folder)
+    {
+        if (Configuration.IsRunningOnMac)
+        {
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? "macOS ARM64 (Metal)"
+                : "macOS x64";
+        }
+
+        if (Configuration.IsRunningOnLinux)
+        {
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? "Linux ARM64"
+                : "Linux x64";
+        }
+
+        return DownloadHashManager.DetectLlamaCppWindowsVariant(folder) switch
+        {
+            "cuda" => "Windows x64 (CUDA)",
+            "vulkan" => "Windows x64 (Vulkan)",
+            "cpu" => "Windows x64 (CPU)",
+            _ => "Windows x64",
+        };
+    }
+
+    [RelayCommand]
+    private async Task Redownload()
+    {
+        if (_redownloadAsync == null)
+        {
+            return;
+        }
+
+        await _redownloadAsync();
+        Refresh();
+    }
+
+    [RelayCommand]
+    private async Task OpenFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(InstallFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, InstallFolder);
+        }
+        catch
+        {
+            // ignore - best-effort UX, the path label is still shown
+        }
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Translate/LlamaCppEngineSettings/LlamaCppEngineSettingsWindow.cs
+++ b/src/ui/Features/Translate/LlamaCppEngineSettings/LlamaCppEngineSettingsWindow.cs
@@ -1,0 +1,218 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Translate.LlamaCppEngineSettings;
+
+public class LlamaCppEngineSettingsWindow : Window
+{
+    private const int LabelWidth = 110;
+    private const int ValueWidth = 360;
+
+    private readonly LlamaCppEngineSettingsViewModel _vm;
+
+    public LlamaCppEngineSettingsWindow(LlamaCppEngineSettingsViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.General.LlamaCppEngineSettings;
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        MinWidth = 540;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        Content = BuildContent(vm);
+
+        var ok = UiUtil.MakeButtonOk(vm.OkCommand);
+        Activated += delegate { ok.Focus(); };
+    }
+
+    private static Border BuildContent(LlamaCppEngineSettingsViewModel vm)
+    {
+        var stack = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 14,
+            Children = { BuildHeader(), BuildDetails(vm), BuildActions(vm) },
+        };
+
+        var outerGrid = new Grid
+        {
+            Margin = UiUtil.MakeWindowMargin(),
+        };
+        outerGrid.Children.Add(stack);
+
+        return new Border
+        {
+            Child = outerGrid,
+            Padding = new Thickness(4),
+        };
+    }
+
+    private static StackPanel BuildHeader()
+    {
+        var title = new TextBlock
+        {
+            Text = "llama.cpp",
+            FontSize = 18,
+            FontWeight = FontWeight.SemiBold,
+        };
+
+        var subtitle = new TextBlock
+        {
+            Text = Se.Language.General.LlamaCppEngineSettingsSubtitle,
+            FontSize = 12,
+            Opacity = 0.75,
+            Margin = new Thickness(0, 2, 0, 0),
+        };
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 0,
+            Children = { title, subtitle },
+        };
+    }
+
+    private static Border BuildDetails(LlamaCppEngineSettingsViewModel vm)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(LabelWidth, GridUnitType.Pixel) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnSpacing = 12,
+            RowSpacing = 10,
+        };
+
+        grid.Add(MakeLabel(Se.Language.General.Backend), 0, 0);
+        grid.Add(MakeValue(nameof(vm.BackendLabel)), 0, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.Status), 1, 0);
+        var statusDot = new Ellipse
+        {
+            Width = 10,
+            Height = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Ellipse.FillProperty] = new Binding(nameof(vm.StatusBrush)),
+        };
+        var statusText = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(8, 0, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.StatusLabel)),
+        };
+        var statusPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { statusDot, statusText },
+        };
+        grid.Add(statusPanel, 1, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.Release), 2, 0);
+        var releaseText = new TextBlock
+        {
+            FontFamily = new FontFamily("Cascadia Mono,Consolas,Menlo,Monaco,monospace"),
+            FontSize = 12,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.ReleaseTag)),
+        };
+        grid.Add(releaseText, 2, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 3, 0);
+        var folderText = new TextBox
+        {
+            IsReadOnly = true,
+            Width = ValueWidth,
+            BorderThickness = new Thickness(0),
+            Background = Brushes.Transparent,
+            Padding = new Thickness(0),
+            VerticalContentAlignment = VerticalAlignment.Center,
+            FontSize = 12,
+            [!TextBox.TextProperty] = new Binding(nameof(vm.InstallFolder)),
+        };
+        grid.Add(folderText, 3, 1);
+
+        return new Border
+        {
+            Child = grid,
+            Padding = new Thickness(14),
+            CornerRadius = new CornerRadius(6),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
+        };
+    }
+
+    private static Grid BuildActions(LlamaCppEngineSettingsViewModel vm)
+    {
+        var redownload = UiUtil.MakeButton(string.Empty, vm.RedownloadCommand)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.DownloadButtonLabel));
+        var openFolder = UiUtil.MakeButton(Se.Language.General.OpenContainingFolder, vm.OpenFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var close = UiUtil.MakeButton(Se.Language.General.Close, vm.OkCommand);
+
+        var leftPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Children = { redownload, openFolder },
+        };
+
+        var rightPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Spacing = 8,
+            Children = { close },
+        };
+
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+        };
+        grid.Add(leftPanel, 0, 0);
+        grid.Add(rightPanel, 0, 2);
+        return grid;
+    }
+
+    private static TextBlock MakeLabel(string text) => new()
+    {
+        Text = text,
+        Opacity = 0.7,
+        VerticalAlignment = VerticalAlignment.Center,
+    };
+
+    private static TextBlock MakeValue(string bindingPath) => new()
+    {
+        FontWeight = FontWeight.SemiBold,
+        VerticalAlignment = VerticalAlignment.Center,
+        [!TextBlock.TextProperty] = new Binding(bindingPath),
+    };
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -399,6 +399,8 @@ public class LanguageGeneral
     public string PickLayer { get; set; }
     public string PickOllamaModel { get; set; }
     public string LlamaCppUseRemoteServer { get; set; }
+    public string LlamaCppEngineSettings { get; set; }
+    public string LlamaCppEngineSettingsSubtitle { get; set; }
     public string PickOutputFolder { get; set; }
     public string PickResolutionFromCurrentVideo { get; set; }
     public string PickResolutionFromVideoDotDotDot { get; set; }
@@ -1161,6 +1163,8 @@ public class LanguageGeneral
         PickLayer = "Set layer";
         PickOllamaModel = "Pick Ollama model";
         LlamaCppUseRemoteServer = "Use external server (URL)";
+        LlamaCppEngineSettings = "llama.cpp engine settings";
+        LlamaCppEngineSettingsSubtitle = "Local llama.cpp server build";
         PickOutputFolder = "Pick output folder";
         PickResolutionFromCurrentVideo = "Pick resolution from current video";
         PickResolutionFromVideoDotDotDot = "Pick resolution from video...";

--- a/src/ui/Logic/Download/LlamaCppDownloadService.cs
+++ b/src/ui/Logic/Download/LlamaCppDownloadService.cs
@@ -16,8 +16,13 @@ public interface ILlamaCppDownloadService
 
 public class LlamaCppDownloadService(HttpClient httpClient) : ILlamaCppDownloadService
 {
-    private const string Version = "b10035";
-    private const string BaseUrl = "https://github.com/ggml-org/llama.cpp/releases/download/" + Version + "/";
+    /// <summary>
+    /// The pinned llama.cpp release tag. Public so the engine settings dialog can show which build
+    /// SE downloads; index 0 of every <see cref="DownloadHashManager.LlamaCpp"/> hash list must match it.
+    /// </summary>
+    public const string ReleaseTag = "b10035";
+
+    private const string BaseUrl = "https://github.com/ggml-org/llama.cpp/releases/download/" + ReleaseTag + "/";
 
     public const string VariantCpu = "cpu";
     public const string VariantVulkan = "vulkan";
@@ -81,9 +86,9 @@ public class LlamaCppDownloadService(HttpClient httpClient) : ILlamaCppDownloadS
         {
             return variant switch
             {
-                VariantCuda => BaseUrl + "llama-" + Version + "-bin-win-cuda-12.4-x64.zip",
-                VariantVulkan => BaseUrl + "llama-" + Version + "-bin-win-vulkan-x64.zip",
-                _ => BaseUrl + "llama-" + Version + "-bin-win-cpu-x64.zip",
+                VariantCuda => BaseUrl + "llama-" + ReleaseTag + "-bin-win-cuda-12.4-x64.zip",
+                VariantVulkan => BaseUrl + "llama-" + ReleaseTag + "-bin-win-vulkan-x64.zip",
+                _ => BaseUrl + "llama-" + ReleaseTag + "-bin-win-cpu-x64.zip",
             };
         }
 
@@ -97,20 +102,20 @@ public class LlamaCppDownloadService(HttpClient httpClient) : ILlamaCppDownloadS
                 }
 
                 return variant == VariantVulkan
-                    ? BaseUrl + "llama-" + Version + "-bin-ubuntu-vulkan-arm64.tar.gz"
-                    : BaseUrl + "llama-" + Version + "-bin-ubuntu-arm64.tar.gz";
+                    ? BaseUrl + "llama-" + ReleaseTag + "-bin-ubuntu-vulkan-arm64.tar.gz"
+                    : BaseUrl + "llama-" + ReleaseTag + "-bin-ubuntu-arm64.tar.gz";
             }
 
             return variant == VariantVulkan
-                ? BaseUrl + "llama-" + Version + "-bin-ubuntu-vulkan-x64.tar.gz"
-                : BaseUrl + "llama-" + Version + "-bin-ubuntu-x64.tar.gz";
+                ? BaseUrl + "llama-" + ReleaseTag + "-bin-ubuntu-vulkan-x64.tar.gz"
+                : BaseUrl + "llama-" + ReleaseTag + "-bin-ubuntu-x64.tar.gz";
         }
 
         if (OperatingSystem.IsMacOS())
         {
             return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
-                ? BaseUrl + "llama-" + Version + "-bin-macos-arm64.tar.gz"
-                : BaseUrl + "llama-" + Version + "-bin-macos-x64.tar.gz";
+                ? BaseUrl + "llama-" + ReleaseTag + "-bin-macos-arm64.tar.gz"
+                : BaseUrl + "llama-" + ReleaseTag + "-bin-macos-x64.tar.gz";
         }
 
         throw new PlatformNotSupportedException("llama.cpp download is not supported on this platform.");

--- a/tests/UI/Features/LlamaCppEngineSettingsButtonTests.cs
+++ b/tests/UI/Features/LlamaCppEngineSettingsButtonTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using Nikse.SubtitleEdit.Features.Main.AiAssistant;
+using Nikse.SubtitleEdit.Features.Tools.AiReview;
+using Nikse.SubtitleEdit.Features.Translate;
+using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features;
+
+/// <summary>
+/// The llama.cpp engine settings button is added in code-built toolbars and is only shown when the
+/// llama.cpp engine is selected, so a wrong grid index, a dropped child or a stale visibility binding
+/// is invisible until the window is actually constructed. These tests assert the button reaches the
+/// logical tree and is effectively visible, which a build alone cannot prove.
+/// </summary>
+public class LlamaCppEngineSettingsButtonTests
+{
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static IEnumerable<Button> AllButtons(Control root)
+    {
+        return root.GetLogicalDescendants().OfType<Button>();
+    }
+
+    private static Button? FindEngineSettingsButton(Control root)
+    {
+        return AllButtons(root).FirstOrDefault(b =>
+            AutomationProperties.GetName(b) == Se.Language.General.LlamaCppEngineSettings);
+    }
+
+    [AvaloniaFact]
+    public void AiReviewWindow_HasLlamaCppEngineSettingsButton()
+    {
+        var vm = new AiReviewViewModel(new WindowService(new NullServiceProvider()));
+        var window = new AiReviewWindow(vm);
+
+        var button = FindEngineSettingsButton(window);
+
+        Assert.NotNull(button);
+        Assert.True(vm.IsLlamaCppVisible, "llama.cpp is the default engine, so its controls must be visible.");
+        Assert.True(button!.IsVisible);
+    }
+
+    [AvaloniaFact]
+    public void AiAssistantWindow_HasLlamaCppEngineSettingsButton()
+    {
+        var vm = new AiAssistantViewModel(new WindowService(new NullServiceProvider()));
+        var window = new AiAssistantWindow(vm);
+
+        var button = FindEngineSettingsButton(window);
+
+        Assert.NotNull(button);
+        Assert.True(vm.IsLlamaCppVisible, "llama.cpp is the default engine, so its controls must be visible.");
+        Assert.True(button!.IsVisible);
+    }
+
+    /// <summary>
+    /// The engine combos in both windows list plain strings and shipped with no ItemTemplate at all,
+    /// so the llama.cpp row had no install dot. Assert the template is applied and that it produces a
+    /// dot for llama.cpp but none for the external services.
+    /// </summary>
+    [AvaloniaFact]
+    public void AiEngineCombo_ShowsDotForLlamaCppOnly()
+    {
+        var template = AiEngineCombo.ItemTemplate();
+
+        var llamaCpp = template.Build(SeAiReview.EngineLlamaCpp);
+        var ollama = template.Build(SeAiReview.EngineOllama);
+
+        Assert.NotNull(llamaCpp);
+        Assert.NotNull(ollama);
+        Assert.Single(llamaCpp!.GetLogicalDescendants().OfType<Ellipse>());
+        Assert.Empty(ollama!.GetLogicalDescendants().OfType<Ellipse>());
+    }
+
+    [AvaloniaFact]
+    public void AiReviewWindow_EngineComboHasDotTemplate()
+    {
+        var vm = new AiReviewViewModel(new WindowService(new NullServiceProvider()));
+        var window = new AiReviewWindow(vm);
+
+        var engineCombo = window.GetLogicalDescendants().OfType<ComboBox>()
+            .First(c => AutomationProperties.GetName(c) == Se.Language.General.Engine);
+
+        Assert.NotNull(engineCombo.ItemTemplate);
+    }
+
+    [AvaloniaFact]
+    public void AiAssistantWindow_EngineComboHasDotTemplate()
+    {
+        var vm = new AiAssistantViewModel(new WindowService(new NullServiceProvider()));
+        var window = new AiAssistantWindow(vm);
+
+        var engineCombo = window.GetLogicalDescendants().OfType<ComboBox>()
+            .First(c => AutomationProperties.GetName(c) == Se.Language.General.Engine);
+
+        Assert.NotNull(engineCombo.ItemTemplate);
+    }
+
+    /// <summary>
+    /// Auto-translate builds its llama.cpp controls into a WrapPanel that is hidden unless the
+    /// llama.cpp engine is selected and the "use external server" toggle is off, so assert the
+    /// button is constructed rather than that it is visible on a default (non-llama.cpp) engine.
+    /// </summary>
+    [AvaloniaFact]
+    public void AutoTranslateWindow_HasLlamaCppEngineSettingsButton()
+    {
+        var vm = new AutoTranslateViewModel(new WindowService(new NullServiceProvider()), new FolderHelper());
+        var window = new AutoTranslateWindow(vm);
+
+        Assert.NotNull(FindEngineSettingsButton(window));
+    }
+
+    /// <summary>
+    /// Selecting a non-llama.cpp engine must hide the button along with the model combo - the two
+    /// live in one panel, so this also guards against the button being re-parented out of it.
+    /// </summary>
+    [AvaloniaFact]
+    public void AiReviewWindow_HidesEngineSettingsButtonForOtherEngines()
+    {
+        var vm = new AiReviewViewModel(new WindowService(new NullServiceProvider()));
+        var window = new AiReviewWindow(vm);
+
+        vm.SelectedEngine = SeAiReview.EngineOllama;
+
+        Assert.False(vm.IsLlamaCppVisible);
+        var button = FindEngineSettingsButton(window);
+        Assert.NotNull(button);
+        Assert.False(button!.IsEffectivelyVisible);
+    }
+}


### PR DESCRIPTION
## Why

llama.cpp already tracked everything needed to report its install state — a pinned release tag in `LlamaCppDownloadService`, per-OS/variant SHA-256 lists in `DownloadHashManager`, and `LlamaCppUpdateStatus` to compare them — but there was nowhere to show it. The text-to-speech engines have had a settings dialog for this since forever; llama.cpp had none.

## What

**Engine settings dialog** — `LlamaCppEngineSettings`, mirroring `KokoroTtsSettings`:

| Row | Source |
|---|---|
| Backend | `Windows x64 (CUDA/Vulkan/CPU)` via `DetectLlamaCppWindowsVariant`; OS+arch elsewhere |
| Status | dot — red not installed, green up to date, amber update available, grey unknown |
| Release | the pinned tag (`b10035`) |
| Install folder | read-only, with Open-folder button |

The action button reads Download / Update / Re-download from the hash comparison.

**Reachable from three windows** — auto-translate, `Tools → AI review`, and the AI assistant. In the two AI windows the gear sits directly after the *engine* combo, since it configures the engine rather than the model. Each caller passes its own re-download callback so the running `llama-server` is stopped first (it holds the binary open and would block replacement) and that caller's model list refreshes afterwards.

**Engine install dots** — the AI review and AI assistant engine combos listed plain strings with **no `ItemTemplate` at all**, so llama.cpp had no install dot. New shared `AiEngineCombo` template gives llama.cpp the grey/amber/green dot and leaves Ollama / OpenAI-compatible without one, since SE doesn't install those. Both windows' model combos also move to the shared `StatusDots` palette, replacing a bespoke pair whose not-installed grey was 31% alpha and read as no dot at all.

## Notes

- The backend row only names the variant on Windows, where there's a proven detector. Linux/macOS report OS+arch rather than guess.
- Server launch parameters (`-ngl 99`, `-c 8192`, host/port) remain hardcoded in `LlamaCppServerManager` — out of scope here.

## Testing

735 tests pass. New `LlamaCppEngineSettingsButtonTests` constructs each window headlessly and asserts the gear reaches the logical tree and the engine combo has a template — neither a build nor a smoke run catches a dropped child or a missing `ItemTemplate`, which is exactly how the absent engine dot went unnoticed.

Not visually verified — the dialog's spacing and dot rendering still want a human eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)