### PR TITLE
Move libuilogic types to the Nikse.SubtitleEdit.UiLogic namespace

### DIFF
--- a/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
+++ b/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
@@ -1,18 +1,11 @@
-using Nikse.SubtitleEdit.Core.Common;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.IO;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Net.Sockets;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+using Nikse.SubtitleEdit.Core.Common;
 
-namespace Nikse.SubtitleEdit.Logic.LlamaCpp;
+namespace Nikse.SubtitleEdit.UiLogic.LlamaCpp;
 
 /// <summary>
 /// A curated llama.cpp model that can be downloaded and served. Optional <paramref name="MmprojFileName"/>

--- a/src/libuilogic/Ocr/FixEngine/AutoGuessLevel.cs
+++ b/src/libuilogic/Ocr/FixEngine/AutoGuessLevel.cs
@@ -1,4 +1,4 @@
-﻿namespace Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+﻿namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
     public partial class OcrFixEngine
 {
     public enum AutoGuessLevel

--- a/src/libuilogic/Ocr/FixEngine/GuessUsedItem.cs
+++ b/src/libuilogic/Ocr/FixEngine/GuessUsedItem.cs
@@ -1,4 +1,4 @@
-﻿namespace Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+﻿namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
 
 public class GuessUsedItem
 {

--- a/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
@@ -1,13 +1,9 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Dictionaries;
 using Nikse.SubtitleEdit.Core.Interfaces;
-using Nikse.SubtitleEdit.Features.SpellCheck;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
-namespace Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
 
 public interface IOcrFixEngine
 {

--- a/src/libuilogic/Ocr/FixEngine/OcrFixLinePartResult.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixLinePartResult.cs
@@ -1,7 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 
-namespace Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
 
 [DebuggerDisplay("'{Word}' - {LinePartType} - pos {WordIndex} - spellcheck: {IsSpellCheckedOk}")]
 public class OcrFixLinePartResult

--- a/src/libuilogic/Ocr/FixEngine/OcrFixLinePartType.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixLinePartType.cs
@@ -1,4 +1,4 @@
-﻿namespace Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+﻿namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
 
 public enum OcrFixLinePartType
 {

--- a/src/libuilogic/Ocr/FixEngine/OcrFixLineResult.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixLineResult.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+﻿namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
 
 public class OcrFixLineResult
 {

--- a/src/libuilogic/Ocr/FixEngine/OcrFixReplaceList2.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixReplaceList2.cs
@@ -1,14 +1,10 @@
-﻿using Nikse.SubtitleEdit.Core.Common;
-using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
-using Nikse.SubtitleEdit.Features.SpellCheck;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
+﻿using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
-namespace Nikse.SubtitleEdit.Core.Dictionaries
+namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
 {
     public class OcrFixReplaceList2
     {

--- a/src/libuilogic/Ocr/FixEngine/ReplacementUsedItem.cs
+++ b/src/libuilogic/Ocr/FixEngine/ReplacementUsedItem.cs
@@ -1,4 +1,4 @@
-﻿namespace Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+﻿namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
 
 public class ReplacementUsedItem
 {

--- a/src/libuilogic/Ocr/FixEngine/SpellCheckRegex.cs
+++ b/src/libuilogic/Ocr/FixEngine/SpellCheckRegex.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using System.Xml;
 
-namespace Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
 // XML:
 //    <RegularExpressionsIfSpelledCorrectly>
 //        <RegEx find = "\b([A-Z][a-z]+)'s\b" spellCheck="$1" replaceWith="$1's" /> <!-- David's -->

--- a/src/libuilogic/Ocr/FixEngine/UnknownWordGuesser.cs
+++ b/src/libuilogic/Ocr/FixEngine/UnknownWordGuesser.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+﻿namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
 
 public static class UnknownWordGuesser
 {

--- a/src/libuilogic/SpellCheck/ISpellChecker.cs
+++ b/src/libuilogic/SpellCheck/ISpellChecker.cs
@@ -1,7 +1,4 @@
-using System.Collections.Generic;
-
-// Kept in the original UI namespace so existing references resolve unchanged.
-namespace Nikse.SubtitleEdit.Features.SpellCheck;
+namespace Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 /// <summary>
 /// Minimal spell-checking surface the OCR-fix engine (libuilogic) needs, so it does not depend on the

--- a/src/libuilogic/SpellCheck/IWordSpellChecker.cs
+++ b/src/libuilogic/SpellCheck/IWordSpellChecker.cs
@@ -1,9 +1,6 @@
 using Nikse.SubtitleEdit.Core.Interfaces;
-using System.Collections.Generic;
 
-// Kept in the original UI namespace so existing `using Nikse.SubtitleEdit.Features.SpellCheck;`
-// references keep resolving after the type moved into libuilogic (shared by UI and seconv).
-namespace Nikse.SubtitleEdit.Features.SpellCheck;
+namespace Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 public record WordSpellCheckLanguage(string Name, int LanguageId);
 

--- a/src/libuilogic/SpellCheck/SpellCheckConfig.cs
+++ b/src/libuilogic/SpellCheck/SpellCheckConfig.cs
@@ -1,8 +1,4 @@
-using System;
-
-// Kept in the original UI namespace so existing references resolve unchanged after the spell-check /
-// OCR-fix engine moved into libuilogic (shared by UI and seconv).
-namespace Nikse.SubtitleEdit.Features.SpellCheck;
+namespace Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 /// <summary>
 /// Config seam for the shared spell-check / OCR-fix engine. The UI wires these to its live

--- a/src/libuilogic/SpellCheck/SpellCheckDictionaryDisplay.cs
+++ b/src/libuilogic/SpellCheck/SpellCheckDictionaryDisplay.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Globalization;
-using System.IO;
+﻿using System.Globalization;
 using Nikse.SubtitleEdit.Core.Common;
 
-namespace Nikse.SubtitleEdit.Features.SpellCheck;
+namespace Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 public class SpellCheckDictionaryDisplay
 {

--- a/src/libuilogic/SpellCheck/SpellCheckWord.cs
+++ b/src/libuilogic/SpellCheck/SpellCheckWord.cs
@@ -1,4 +1,4 @@
-﻿namespace Nikse.SubtitleEdit.Features.SpellCheck;
+﻿namespace Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 public class SpellCheckWord
 {

--- a/src/libuilogic/SpellCheck/SpellCheckWordLists.cs
+++ b/src/libuilogic/SpellCheck/SpellCheckWordLists.cs
@@ -1,14 +1,10 @@
-﻿using Nikse.SubtitleEdit.Core.Common;
+﻿using System.Text;
+using System.Xml;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Dictionaries;
 using Nikse.SubtitleEdit.Core.Interfaces;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Xml;
 
-namespace Nikse.SubtitleEdit.Features.SpellCheck;
+namespace Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 public class SpellCheckWordLists
 {

--- a/src/libuilogic/SpellCheck/SpellChecker.cs
+++ b/src/libuilogic/SpellCheck/SpellChecker.cs
@@ -1,13 +1,9 @@
-using Nikse.SubtitleEdit.Core.Interfaces;
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
-using System.Linq;
 using System.Text.RegularExpressions;
+using Nikse.SubtitleEdit.Core.Interfaces;
 using WeCantSpell.Hunspell;
 
-namespace Nikse.SubtitleEdit.Features.SpellCheck;
+namespace Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 /// <summary>
 /// Framework-agnostic spell-checking core: Hunspell (pure-managed WeCantSpell) plus the names /

--- a/src/libuilogic/Translate/DoAutoTranslate.cs
+++ b/src/libuilogic/Translate/DoAutoTranslate.cs
@@ -1,14 +1,9 @@
-﻿using Nikse.SubtitleEdit.Core.AutoTranslate;
+﻿using System.Collections.ObjectModel;
+using Nikse.SubtitleEdit.Core.AutoTranslate;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Translate;
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Nikse.SubtitleEdit.Features.Translate;
+namespace Nikse.SubtitleEdit.UiLogic.Translate;
 
 public class DoAutoTranslate
 {

--- a/src/libuilogic/Translate/MergeAndSplitHelper.cs
+++ b/src/libuilogic/Translate/MergeAndSplitHelper.cs
@@ -1,17 +1,12 @@
-﻿using Nikse.SubtitleEdit.Core.AutoTranslate;
+﻿using System.Collections.ObjectModel;
+using System.Text;
+using System.Text.RegularExpressions;
+using Nikse.SubtitleEdit.Core.AutoTranslate;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Settings;
 using Nikse.SubtitleEdit.Core.Translate;
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Nikse.SubtitleEdit.Features.Translate;
+namespace Nikse.SubtitleEdit.UiLogic.Translate;
 
 public static partial class MergeAndSplitHelper
 {
@@ -246,7 +241,7 @@ public static partial class MergeAndSplitHelper
 
         var totalProcessed = currentRowIndex - index;
         if (totalProcessed == mergeResult.ParagraphCount &&
-            HasSameEmptyLines(rows.Skip(index).Take(totalProcessed).Select(p => p.TranslatedText).ToList(),
+            HasSameEmptyLines(rows.Skip(index).Take(totalProcessed).Select<TranslateRow, string>(p => p.TranslatedText).ToList(),
                               rows.Skip(index).Take(totalProcessed).Select(p => p.Text).ToList(), 0))
         {
             return ApplyFormattingToExistingTranslations(rows, index, formattingList, mergeResult.ParagraphCount);

--- a/src/libuilogic/Translate/MergeResult.cs
+++ b/src/libuilogic/Translate/MergeResult.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Nikse.SubtitleEdit.Features.Translate;
+﻿namespace Nikse.SubtitleEdit.UiLogic.Translate;
 
 public static partial class MergeAndSplitHelper
 {

--- a/src/libuilogic/Translate/MergeResultItem.cs
+++ b/src/libuilogic/Translate/MergeResultItem.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Nikse.SubtitleEdit.Features.Translate;
+﻿namespace Nikse.SubtitleEdit.UiLogic.Translate;
 
 public static partial class MergeAndSplitHelper
 {

--- a/src/libuilogic/Translate/TranslateRow.cs
+++ b/src/libuilogic/Translate/TranslateRow.cs
@@ -1,7 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
-using System;
 
-namespace Nikse.SubtitleEdit.Features.Translate;
+namespace Nikse.SubtitleEdit.UiLogic.Translate;
 
 public partial class TranslateRow : ObservableObject
 {

--- a/src/seconv/Core/AutoTranslateRunner.cs
+++ b/src/seconv/Core/AutoTranslateRunner.cs
@@ -1,8 +1,8 @@
 using Nikse.SubtitleEdit.Core.AutoTranslate;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Translate;
-using Nikse.SubtitleEdit.Features.Translate;
-using Nikse.SubtitleEdit.Logic.LlamaCpp;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
+using Nikse.SubtitleEdit.UiLogic.Translate;
 
 namespace SeConv.Core;
 

--- a/src/seconv/Core/FixCommonErrorsRunner.cs
+++ b/src/seconv/Core/FixCommonErrorsRunner.cs
@@ -1,8 +1,8 @@
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
 using Nikse.SubtitleEdit.Core.Interfaces;
-using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
-using Nikse.SubtitleEdit.Features.SpellCheck;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 using SkiaSharp;
 
 namespace SeConv.Core;

--- a/src/seconv/Core/ListHelpers.cs
+++ b/src/seconv/Core/ListHelpers.cs
@@ -1,7 +1,7 @@
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
-using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using Spectre.Console;
 using System.Text;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
 
 namespace SeConv.Core;
 

--- a/src/seconv/Core/LlamaCppLocal.cs
+++ b/src/seconv/Core/LlamaCppLocal.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Logic.LlamaCpp;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
 
 namespace SeConv.Core;
 

--- a/src/seconv/Core/LlamaCppOcrEngine.cs
+++ b/src/seconv/Core/LlamaCppOcrEngine.cs
@@ -1,9 +1,9 @@
 using Nikse.SubtitleEdit.Core.Common;
-using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using SkiaSharp;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
 
 namespace SeConv.Core;
 

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -1,5 +1,6 @@
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 using Spectre.Console;
 
 namespace SeConv.Core;
@@ -711,10 +712,10 @@ internal class SubtitleConverter
             // Wire the shared spell-check / OCR-fix engine (libuilogic) to seconv's options so the
             // "Fix common OCR errors" pass can run headless. Use --dictionary-folder when given, else
             // fall back to the dictionaries bundled into seconv (English out of the box) (#11744).
-            Nikse.SubtitleEdit.Features.SpellCheck.SpellCheckConfig.DictionariesFolder = () =>
+            SpellCheckConfig.DictionariesFolder = () =>
                 !string.IsNullOrEmpty(options.DictionaryFolder) ? options.DictionaryFolder : BundledDictionaries.GetFolder();
-            Nikse.SubtitleEdit.Features.SpellCheck.SpellCheckConfig.UseWordSplitList = () => true;
-            Nikse.SubtitleEdit.Features.SpellCheck.SpellCheckConfig.TreatInApostropheAsIng = () => false;
+            SpellCheckConfig.UseWordSplitList = () => true;
+            SpellCheckConfig.TreatInApostropheAsIng = () => false;
 
             LibSEIntegration.ApplyOperations(
                 subtitle,

--- a/src/ui/Controls/SyntaxHighlightingTextPresenter.cs
+++ b/src/ui/Controls/SyntaxHighlightingTextPresenter.cs
@@ -9,6 +9,7 @@ using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Controls;
 

--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -173,6 +173,9 @@ using Nikse.SubtitleEdit.UiLogic.Ocr;
 using Nikse.SubtitleEdit.Logic.Ocr;
 using Nikse.SubtitleEdit.Logic.Ocr.GoogleLens;
 using Nikse.SubtitleEdit.Logic.UndoRedo;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 using AssaApplyCustomOverrideTagsViewModel = Nikse.SubtitleEdit.Features.Assa.AssaApplyCustomOverrideTags.AssaApplyCustomOverrideTagsViewModel;
 using SpeechToTextViewModel = Nikse.SubtitleEdit.Features.Video.SpeechToText.SpeechToTextViewModel;
 using AudioVisualizerUndockedViewModel = Nikse.SubtitleEdit.Features.Shared.Undocked.AudioVisualizerUndockedViewModel;
@@ -201,8 +204,8 @@ public static class DependencyInjectionExtensions
     {
         // LlamaCppServerManager lives in libuilogic (shared with seconv) and cannot see the
         // UI's Se config - point it at the UI's llama.cpp folder and tools log explicitly.
-        Logic.LlamaCpp.LlamaCppServerManager.FolderOverride = Logic.Config.Se.LlamaCppFolder;
-        Logic.LlamaCpp.LlamaCppServerManager.LogAction = Logic.Config.Se.WriteToolsLog;
+        LlamaCppServerManager.FolderOverride = Logic.Config.Se.LlamaCppFolder;
+        LlamaCppServerManager.LogAction = Logic.Config.Se.WriteToolsLog;
 
         // Misc services
         collection.AddTransient<IBinaryOcrMatcher, BinaryOcrMatcher>();

--- a/src/ui/Features/Main/AiAssistant/AiAssistantViewModel.cs
+++ b/src/ui/Features/Main/AiAssistant/AiAssistantViewModel.cs
@@ -15,6 +15,7 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
 
 namespace Nikse.SubtitleEdit.Features.Main.AiAssistant;
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -180,6 +180,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Features.Main;
 

--- a/src/ui/Features/Ocr/FixEngine/OcrFixLineResultExtensions.cs
+++ b/src/ui/Features/Ocr/FixEngine/OcrFixLineResultExtensions.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls.Documents;
 using Avalonia.Media;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
 
 namespace Nikse.SubtitleEdit.Features.Ocr.FixEngine;
 

--- a/src/ui/Features/Ocr/LlamaCppOcrSettingsViewModel.cs
+++ b/src/ui/Features/Ocr/LlamaCppOcrSettingsViewModel.cs
@@ -11,6 +11,7 @@ using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using System;
 using System.Threading.Tasks;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
 
 namespace Nikse.SubtitleEdit.Features.Ocr;
 

--- a/src/ui/Features/Ocr/OcrSubtitleItem.cs
+++ b/src/ui/Features/Ocr/OcrSubtitleItem.cs
@@ -8,6 +8,7 @@ using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using SkiaSharp;
 using System;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
 
 namespace Nikse.SubtitleEdit.Features.Ocr;
 

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -56,6 +56,9 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Features.Ocr;
 

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -18,6 +18,7 @@ using Optris.Icons.Avalonia;
 using System;
 using System.Collections;
 using System.ComponentModel;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
 using MenuItem = Avalonia.Controls.MenuItem;
 
 namespace Nikse.SubtitleEdit.Features.Ocr;

--- a/src/ui/Features/Ocr/UnknownWordItem.cs
+++ b/src/ui/Features/Ocr/UnknownWordItem.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
 
 namespace Nikse.SubtitleEdit.Features.Ocr;
 

--- a/src/ui/Features/Options/WordLists/WordListsViewModel.cs
+++ b/src/ui/Features/Options/WordLists/WordListsViewModel.cs
@@ -17,6 +17,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
 
 namespace Nikse.SubtitleEdit.Features.Options.WordLists;
 

--- a/src/ui/Features/Shared/AddToNamesList/AddToNamesListViewModel.cs
+++ b/src/ui/Features/Shared/AddToNamesList/AddToNamesListViewModel.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Features.Shared.AddToNamesList;
 

--- a/src/ui/Features/Shared/AddToOcrReplaceList/AddToOcrReplaceListViewModel.cs
+++ b/src/ui/Features/Shared/AddToOcrReplaceList/AddToOcrReplaceListViewModel.cs
@@ -10,6 +10,8 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Threading.Tasks;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Features.Shared.AddToOcrReplaceList;
 

--- a/src/ui/Features/Shared/AddToUserDictionary/AddToUserDictionaryViewModel.cs
+++ b/src/ui/Features/Shared/AddToUserDictionary/AddToUserDictionaryViewModel.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 using Tmds.DBus.Protocol;
 
 namespace Nikse.SubtitleEdit.Features.Shared.AddToUserDictionary;

--- a/src/ui/Features/Shared/PickSpellCheckDictionary/PickSpellCheckDictionaryViewModel.cs
+++ b/src/ui/Features/Shared/PickSpellCheckDictionary/PickSpellCheckDictionaryViewModel.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Features.Shared.PickSpellCheckDictionary;
 

--- a/src/ui/Features/Shared/TextBoxUtils/ITextBoxWrapper.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/ITextBoxWrapper.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Nikse.SubtitleEdit.Features.SpellCheck;
 using System.Collections.Generic;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Features.Shared.TextBoxUtils;
 

--- a/src/ui/Features/Shared/TextBoxUtils/TextBoxWrapper.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/TextBoxWrapper.cs
@@ -5,6 +5,7 @@ using Nikse.SubtitleEdit.Features.SpellCheck;
 using Nikse.SubtitleEdit.Logic;
 using System.Collections.Generic;
 using System.Linq;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Features.Shared.TextBoxUtils;
 

--- a/src/ui/Features/Shared/TextBoxUtils/TextEditorWrapper.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/TextEditorWrapper.cs
@@ -9,6 +9,7 @@ using Nikse.SubtitleEdit.Features.SpellCheck;
 using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Linq;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Features.Shared.TextBoxUtils;
 

--- a/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs
+++ b/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs
@@ -19,6 +19,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Features.SpellCheck.GetDictionaries;
 

--- a/src/ui/Features/SpellCheck/ISpellCheckManager.cs
+++ b/src/ui/Features/SpellCheck/ISpellCheckManager.cs
@@ -1,6 +1,7 @@
 ﻿using Nikse.SubtitleEdit.Features.Main;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Features.SpellCheck;
 

--- a/src/ui/Features/SpellCheck/SpellCheckManager.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckManager.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Features.SpellCheck;
 

--- a/src/ui/Features/SpellCheck/SpellCheckResult.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckResult.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Features.SpellCheck;
 

--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -29,6 +29,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Web;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Features.SpellCheck;
 

--- a/src/ui/Features/SpellCheck/SpellCheckWordChangedEvent.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckWordChangedEvent.cs
@@ -1,5 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Features.Main;
 using System;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Features.SpellCheck;
 

--- a/src/ui/Features/SpellCheck/WordSpellCheck.cs
+++ b/src/ui/Features/SpellCheck/WordSpellCheck.cs
@@ -3,6 +3,7 @@ using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Features.SpellCheck;
 

--- a/src/ui/Features/Tools/AiReview/AiEngineCombo.cs
+++ b/src/ui/Features/Tools/AiReview/AiEngineCombo.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls.Templates;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.LlamaCpp;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
 
 namespace Nikse.SubtitleEdit.Features.Tools.AiReview;
 

--- a/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
 
 namespace Nikse.SubtitleEdit.Features.Tools.AiReview;
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
@@ -17,6 +17,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
 
 namespace Nikse.SubtitleEdit.Features.Tools.BatchConvert;
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -45,6 +45,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
 
 namespace Nikse.SubtitleEdit.Features.Tools.BatchConvert;
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -38,6 +38,8 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
+using Nikse.SubtitleEdit.UiLogic.Translate;
 
 namespace Nikse.SubtitleEdit.Features.Tools.BatchConvert;
 

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -21,6 +21,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
 
 namespace Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
 

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonOcrErrors.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonOcrErrors.cs
@@ -5,6 +5,8 @@ using Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
 using Nikse.SubtitleEdit.Features.SpellCheck;
 using Nikse.SubtitleEdit.Logic.Config;
 using System.Linq;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 {

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -29,6 +29,8 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
+using Nikse.SubtitleEdit.UiLogic.Translate;
 
 namespace Nikse.SubtitleEdit.Features.Translate;
 

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -14,6 +14,8 @@ using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using System.ComponentModel;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
+using Nikse.SubtitleEdit.UiLogic.Translate;
 
 namespace Nikse.SubtitleEdit.Features.Translate;
 

--- a/src/ui/Features/Translate/CopyPasteTranslateViewModel.cs
+++ b/src/ui/Features/Translate/CopyPasteTranslateViewModel.cs
@@ -12,6 +12,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Nikse.SubtitleEdit.UiLogic.Translate;
 
 namespace Nikse.SubtitleEdit.Features.Translate;
 

--- a/src/ui/Features/Translate/DownloadLlamaCppViewModel.cs
+++ b/src/ui/Features/Translate/DownloadLlamaCppViewModel.cs
@@ -15,6 +15,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Nikse.SubtitleEdit.UiLogic;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
 
 namespace Nikse.SubtitleEdit.Features.Translate;
 

--- a/src/ui/Features/Translate/LlamaCppDownloadHelper.cs
+++ b/src/ui/Features/Translate/LlamaCppDownloadHelper.cs
@@ -9,6 +9,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
 
 namespace Nikse.SubtitleEdit.Features.Translate;
 

--- a/src/ui/Features/Translate/LlamaCppEngineSettings/LlamaCppEngineSettingsViewModel.cs
+++ b/src/ui/Features/Translate/LlamaCppEngineSettings/LlamaCppEngineSettingsViewModel.cs
@@ -11,6 +11,7 @@ using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
 
 namespace Nikse.SubtitleEdit.Features.Translate.LlamaCppEngineSettings;
 

--- a/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
@@ -25,6 +25,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
 
 namespace Nikse.SubtitleEdit.Features.Video.VideoOcr;
 

--- a/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
@@ -12,6 +12,7 @@ using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using Nikse.SubtitleEdit.Logic.ValueConverters;
 using System.Linq;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
 
 namespace Nikse.SubtitleEdit.Features.Video.VideoOcr;
 

--- a/src/ui/Logic/Config/Language/Tools/LanguageMergeShortLines.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageMergeShortLines.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using static Nikse.SubtitleEdit.Features.Translate.MergeAndSplitHelper;
+using static Nikse.SubtitleEdit.UiLogic.Translate.MergeAndSplitHelper;
 
 namespace Nikse.SubtitleEdit.Logic.Config.Language;
 

--- a/src/ui/Logic/LlamaCpp/LlamaCppUpdateStatus.cs
+++ b/src/ui/Logic/LlamaCpp/LlamaCppUpdateStatus.cs
@@ -1,6 +1,7 @@
 using Nikse.SubtitleEdit.Logic.Download;
 using System.IO;
 using Nikse.SubtitleEdit.UiLogic;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
 
 namespace Nikse.SubtitleEdit.Logic.LlamaCpp;
 

--- a/src/ui/Logic/SpellCheckUnderlineTransformer.cs
+++ b/src/ui/Logic/SpellCheckUnderlineTransformer.cs
@@ -6,6 +6,7 @@ using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Logic;
 

--- a/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Logic.ValueConverters;
 

--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -19,6 +19,7 @@ using Optris.Icons.Avalonia.MaterialDesign;
 using System;
 using System.Linq;
 using System.Text;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit
 {
@@ -85,10 +86,10 @@ namespace Nikse.SubtitleEdit
 
                 // Wire the shared spell-check / OCR-fix engine (libuilogic) to the live UI settings so
                 // it reads the same values without depending on the UI's Se config type (#11744).
-                Nikse.SubtitleEdit.Features.SpellCheck.SpellCheckConfig.DictionariesFolder = () => Se.DictionariesFolder;
-                Nikse.SubtitleEdit.Features.SpellCheck.SpellCheckConfig.UseWordSplitList = () => Se.Settings.Ocr.UseWordSplitList;
-                Nikse.SubtitleEdit.Features.SpellCheck.SpellCheckConfig.TreatInApostropheAsIng = () => Se.Settings.Tools.SpellCheckEnglishTreatInApostropheAsIng;
-                Nikse.SubtitleEdit.Features.SpellCheck.SpellCheckConfig.LogError = msg => Se.LogError(msg);
+                SpellCheckConfig.DictionariesFolder = () => Se.DictionariesFolder;
+                SpellCheckConfig.UseWordSplitList = () => Se.Settings.Ocr.UseWordSplitList;
+                SpellCheckConfig.TreatInApostropheAsIng = () => Se.Settings.Tools.SpellCheckEnglishTreatInApostropheAsIng;
+                SpellCheckConfig.LogError = msg => Se.LogError(msg);
 
                 // Load the UI translation before any window or the macOS native menu bar is built,
                 // so the menu bar isn't constructed with the default English strings (issue #11505).

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixEngineHyphenGuessTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixEngineHyphenGuessTests.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace UITests.Features.Ocr.FixEngine;
 

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixEngineSplitLineTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixEngineSplitLineTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
 
 namespace UITests.Features.Ocr.FixEngine;
 

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixNoDictionaryReplaceListTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixNoDictionaryReplaceListTests.cs
@@ -9,6 +9,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace UITests.Features.Ocr.FixEngine;
 

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixSpellCheckRegexTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixSpellCheckRegexTests.cs
@@ -4,6 +4,8 @@ using Nikse.SubtitleEdit.Features.SpellCheck;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace UITests.Features.Ocr.FixEngine;
 

--- a/tests/UI/Features/Ocr/FixEngine/SpellCheckRegexTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/SpellCheckRegexTests.cs
@@ -1,5 +1,6 @@
 using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
 using System.Text.RegularExpressions;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
 
 namespace UITests.Features.Ocr.FixEngine;
 

--- a/tests/UI/Features/Ocr/FixEngine/UnknownWordGuesserTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/UnknownWordGuesserTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
 
 namespace UITests.Features.Ocr.FixEngine;
 

--- a/tests/UI/Features/Ocr/OcrDictionaryComboTests.cs
+++ b/tests/UI/Features/Ocr/OcrDictionaryComboTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Nikse.SubtitleEdit;
 using Nikse.SubtitleEdit.Features.Ocr;
 using Nikse.SubtitleEdit.Features.SpellCheck;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace UITests.Features.Ocr;
 

--- a/tests/UI/Features/SpellCheck/HyphenatedNameSpellCheckTests.cs
+++ b/tests/UI/Features/SpellCheck/HyphenatedNameSpellCheckTests.cs
@@ -3,6 +3,7 @@ using Nikse.SubtitleEdit.Features.SpellCheck;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.IO;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace UITests.Features.SpellCheck;
 

--- a/tests/UI/Features/SpellCheck/SpellCheckStartLineTests.cs
+++ b/tests/UI/Features/SpellCheck/SpellCheckStartLineTests.cs
@@ -4,6 +4,7 @@ using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace UITests.Features.SpellCheck;
 

--- a/tests/UI/Features/SpellCheck/SplitLoneQuoteTests.cs
+++ b/tests/UI/Features/SpellCheck/SplitLoneQuoteTests.cs
@@ -1,5 +1,6 @@
 using Nikse.SubtitleEdit.Features.SpellCheck;
 using System.Linq;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace UITests.Features.SpellCheck;
 

--- a/tests/UI/Features/SpellCheck/UserDictionaryNormalizationTests.cs
+++ b/tests/UI/Features/SpellCheck/UserDictionaryNormalizationTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace UITests.Features.SpellCheck;
 

--- a/tests/UI/Features/Tools/FixCommonErrors/FixCommonOcrErrorsTests.cs
+++ b/tests/UI/Features/Tools/FixCommonErrors/FixCommonOcrErrorsTests.cs
@@ -5,6 +5,8 @@ using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
 using Nikse.SubtitleEdit.Features.SpellCheck;
 using System.Text;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace UITests.Features.Tools.FixCommonErrors;
 

--- a/tests/libuilogic/SpellCheck/GetDictionaryLanguagesTests.cs
+++ b/tests/libuilogic/SpellCheck/GetDictionaryLanguagesTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
-using Nikse.SubtitleEdit.Features.SpellCheck;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace LibUiLogicTests.SpellCheck;
 

--- a/tests/seconv/Core/AutoTranslateRunnerTest.cs
+++ b/tests/seconv/Core/AutoTranslateRunnerTest.cs
@@ -1,6 +1,6 @@
 using Nikse.SubtitleEdit.Core.AutoTranslate;
 using Nikse.SubtitleEdit.Core.Common;
-using Nikse.SubtitleEdit.Logic.LlamaCpp;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
 using SeConv.Core;
 using Xunit;
 


### PR DESCRIPTION
## Summary
- Align every type in `src/libuilogic` with the project's declared root namespace `Nikse.SubtitleEdit.UiLogic`, replacing the compatibility namespaces kept from the original move (`Nikse.SubtitleEdit.Features.*`, `Nikse.SubtitleEdit.Logic.LlamaCpp`, `Nikse.SubtitleEdit.Core.Dictionaries`)
- Update all consumers in `src/ui`, `src/seconv`, and tests to the new namespaces
- Trim using directives now covered by `ImplicitUsings` in the libuilogic project
- Remove the now-obsolete "kept in original namespace" comments in `ISpellChecker.cs`, `IWordSpellChecker.cs`, and `SpellCheckConfig.cs`

## Test plan
- [ ] Solution builds: `dotnet build SubtitleEdit.sln`
- [ ] All tests pass: `dotnet test tests/UI/UITests.csproj` and `dotnet test tests/libse/LibSETests.csproj`
- [ ] OCR window: run OCR with "Fix OCR errors" enabled — fixes and unknown-word list behave as before
- [ ] Spell check (Tools → Spell check) still loads dictionaries and flags/corrects words
- [ ] Auto-translate with llama.cpp still starts the local server and translates
- [ ] seconv: `seconv <file> subrip /fixcommonerrors` (OCR-fix pass) still works headless

🤖 Generated with [Claude Code](https://claude.com/claude-code)