### PR TITLE
Strip .gitkeep from the macOS bundle before signing

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -610,6 +610,14 @@ jobs:
           app="./SubtitleEdit-${{ matrix.arch_label }}.app"
           cp -R "./installer/macBundle/SubtitleEdit.app" "$app"
 
+          # .gitkeep only exists so git tracks the empty Contents/MacOS folder.
+          # codesign treats every file in MacOS/ as code, so leaving it in place
+          # makes `codesign --verify --deep --strict` fail the whole bundle with
+          # "code object is not signed at all". Unsigned builds never hit this,
+          # because they strip the signature instead of verifying it.
+          # .DS_Store can arrive the same way and is unsignable for the same reason.
+          find "$app" \( -name ".gitkeep" -o -name ".DS_Store" \) -delete
+
           cp "./publish/macos-${{ matrix.arch }}/SubtitleEdit" "$app/Contents/MacOS/"
           cp "./publish/macos-${{ matrix.arch }}/"*.dylib "$app/Contents/MacOS/" 2>/dev/null || true
           chmod +x "$app/Contents/MacOS/SubtitleEdit"


### PR DESCRIPTION
Both macOS jobs failed in the first signed build ([run 29929308249](https://github.com/SubtitleEdit/subtitleedit/actions/runs/29929308249)):

```
./SubtitleEdit-x64.app: code object is not signed at all
In subcomponent: .../SubtitleEdit-x64.app/Contents/MacOS/.gitkeep
```

`Contents/MacOS/.gitkeep` is tracked only to keep the empty directory in git. `codesign` treats every file under `MacOS/` as code, so it fails `codesign --verify --deep --strict` for the whole bundle. Unsigned builds never hit this — they run `codesign --remove-signature` rather than verifying.

Verified locally against the real Developer ID certificate: assembled bundle fails verification with `.gitkeep` present (exit 1), passes without it (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)