### PR TITLE
Fix event handler leak by stopping timers on window close

### DIFF
--- a/src/ui/Features/Assa/AssaStylesViewModel.cs
+++ b/src/ui/Features/Assa/AssaStylesViewModel.cs
@@ -24,7 +24,7 @@ using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Assa;
 
-public partial class AssaStylesViewModel : ObservableObject
+public partial class AssaStylesViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private string _title;
     [ObservableProperty] private ObservableCollection<StyleDisplay> _fileStyles;
@@ -63,6 +63,7 @@ public partial class AssaStylesViewModel : ObservableObject
     private IApplyAssaStyles? _applyAssaStyles;
     private Subtitle _subtitle;
     private string _subtitleFileName;
+    private volatile bool _isClosing;
     private readonly System.Timers.Timer _timerUpdatePreview;
     private readonly List<string> _extraCategories = new();
 
@@ -101,9 +102,21 @@ public partial class AssaStylesViewModel : ObservableObject
 
     private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _timerUpdatePreview.Stop();
         UpdatePreview();
-        _timerUpdatePreview.Start();
+
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this
+        // handler ran, and Start() on a disposed timer throws ObjectDisposedException,
+        // crashing the app from a thread-pool thread. (#12739)
+        if (!_isClosing)
+        {
+            _timerUpdatePreview.Start();
+        }
     }
 
     [RelayCommand]
@@ -874,8 +887,13 @@ public partial class AssaStylesViewModel : ObservableObject
 
     private void Close()
     {
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Dispatcher.UIThread.Post(() => { Window?.Close(); });
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
     }
 
     public void Initialize(

--- a/src/ui/Features/Assa/AssaStylesViewModel.cs
+++ b/src/ui/Features/Assa/AssaStylesViewModel.cs
@@ -96,12 +96,14 @@ public partial class AssaStylesViewModel : ObservableObject
         RebuildStorageCategories();
 
         _timerUpdatePreview = new System.Timers.Timer(500);
-        _timerUpdatePreview.Elapsed += (s, e) =>
-        {
-            _timerUpdatePreview.Stop();
-            UpdatePreview();
-            _timerUpdatePreview.Start();
-        };
+        _timerUpdatePreview.Elapsed += TimerUpdatePreviewElapsed;
+    }
+
+    private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        _timerUpdatePreview.Stop();
+        UpdatePreview();
+        _timerUpdatePreview.Start();
     }
 
     [RelayCommand]
@@ -872,6 +874,7 @@ public partial class AssaStylesViewModel : ObservableObject
 
     private void Close()
     {
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Dispatcher.UIThread.Post(() => { Window?.Close(); });
     }
 

--- a/src/ui/Features/Edit/ModifySelection/ModifySelectionViewModel.cs
+++ b/src/ui/Features/Edit/ModifySelection/ModifySelectionViewModel.cs
@@ -4,6 +4,7 @@ using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -47,18 +48,20 @@ public partial class ModifySelectionViewModel : ObservableObject
         LoadSettings();
 
         _previewTimer = new System.Timers.Timer(250);
-        _previewTimer.Elapsed += (sender, args) =>
+        _previewTimer.Elapsed += PreviewTimerElapsed;
+    }
+
+    private void PreviewTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        _previewTimer.Stop();
+
+        if (_isDirty)
         {
-            _previewTimer.Stop();
+            _isDirty = false;
+            UpdatePreview();
+        }
 
-            if (_isDirty)
-            {
-                _isDirty = false;
-                UpdatePreview();
-            }
-
-            _previewTimer.Start();
-        };
+        _previewTimer.Start();
     }
 
     private void UpdatePreview()
@@ -163,12 +166,14 @@ public partial class ModifySelectionViewModel : ObservableObject
 
         SaveSettings();
         OkPressed = true;
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
@@ -177,6 +182,7 @@ public partial class ModifySelectionViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _previewTimer.StopAndDispose(PreviewTimerElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Edit/ModifySelection/ModifySelectionViewModel.cs
+++ b/src/ui/Features/Edit/ModifySelection/ModifySelectionViewModel.cs
@@ -12,7 +12,7 @@ using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Edit.ModifySelection;
 
-public partial class ModifySelectionViewModel : ObservableObject
+public partial class ModifySelectionViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<ModifySelectionRule> _rules;
     [ObservableProperty] private ModifySelectionRule? _selectedRule;
@@ -32,6 +32,7 @@ public partial class ModifySelectionViewModel : ObservableObject
 
     private List<SubtitleLineViewModel> _allSubtitles;
     private readonly System.Timers.Timer _previewTimer;
+    private volatile bool _isClosing;
     private readonly Dictionary<RuleType, double> _ruleNumbers;
     private RuleType? _activeRuleType;
     private bool _isDirty;
@@ -53,6 +54,11 @@ public partial class ModifySelectionViewModel : ObservableObject
 
     private void PreviewTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _previewTimer.Stop();
 
         if (_isDirty)
@@ -61,7 +67,17 @@ public partial class ModifySelectionViewModel : ObservableObject
             UpdatePreview();
         }
 
-        _previewTimer.Start();
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this handler ran (#12739).
+        if (!_isClosing)
+        {
+            _previewTimer.Start();
+        }
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
     }
 
     private void UpdatePreview()
@@ -166,14 +182,12 @@ public partial class ModifySelectionViewModel : ObservableObject
 
         SaveSettings();
         OkPressed = true;
-        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
-        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
@@ -182,7 +196,6 @@ public partial class ModifySelectionViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _previewTimer.StopAndDispose(PreviewTimerElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Files/ExportCustomTextFormat/EditCustomTextFormatViewModel.cs
+++ b/src/ui/Features/Files/ExportCustomTextFormat/EditCustomTextFormatViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.UiLogic.Export;
 using System.Collections.Generic;
@@ -70,16 +71,18 @@ public partial class EditCustomTextFormatViewModel : ObservableObject
         _subtitleTitle = string.Empty;
 
         _previewTimer = new System.Timers.Timer(500);
-        _previewTimer.Elapsed += (sender, args) =>
-        {
-            if (SelectedCustomFormat == null)
-            {
-                PreviewText = string.Empty;
-                return;
-            }
+        _previewTimer.Elapsed += PreviewTimerElapsed;
+    }
 
-            PreviewText = CustomTextFormatter.GenerateCustomText(SelectedCustomFormat.ToTemplate(), _subtitles.Where(s => s.Paragraph != null).Select(s => s.Paragraph!).ToList(), _subtitleTitle, _videoFileName ?? string.Empty);
-        };
+    private void PreviewTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        if (SelectedCustomFormat == null)
+        {
+            PreviewText = string.Empty;
+            return;
+        }
+
+        PreviewText = CustomTextFormatter.GenerateCustomText(SelectedCustomFormat.ToTemplate(), _subtitles.Where(s => s.Paragraph != null).Select(s => s.Paragraph!).ToList(), _subtitleTitle, _videoFileName ?? string.Empty);
     }
 
 
@@ -134,7 +137,7 @@ public partial class EditCustomTextFormatViewModel : ObservableObject
             return;
         }
 
-        _previewTimer.Stop();
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         OkPressed = true;
         Window?.Close();
     }
@@ -142,7 +145,7 @@ public partial class EditCustomTextFormatViewModel : ObservableObject
     [RelayCommand]
     private void Cancel()
     {
-        _previewTimer.Stop();
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
@@ -151,6 +154,7 @@ public partial class EditCustomTextFormatViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _previewTimer.StopAndDispose(PreviewTimerElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Files/ExportCustomTextFormat/EditCustomTextFormatViewModel.cs
+++ b/src/ui/Features/Files/ExportCustomTextFormat/EditCustomTextFormatViewModel.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Files.ExportCustomTextFormat;
 
-public partial class EditCustomTextFormatViewModel : ObservableObject
+public partial class EditCustomTextFormatViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private CustomFormatItem? _selectedCustomFormat;
     [ObservableProperty] private string _previewText;
@@ -85,6 +85,11 @@ public partial class EditCustomTextFormatViewModel : ObservableObject
         PreviewText = CustomTextFormatter.GenerateCustomText(SelectedCustomFormat.ToTemplate(), _subtitles.Where(s => s.Paragraph != null).Select(s => s.Paragraph!).ToList(), _subtitleTitle, _videoFileName ?? string.Empty);
     }
 
+    public void OnClosingCleanup()
+    {
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
+    }
+
 
     [RelayCommand]
     private void InsertHeaderTag(string tag)
@@ -137,7 +142,6 @@ public partial class EditCustomTextFormatViewModel : ObservableObject
             return;
         }
 
-        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         OkPressed = true;
         Window?.Close();
     }
@@ -145,7 +149,6 @@ public partial class EditCustomTextFormatViewModel : ObservableObject
     [RelayCommand]
     private void Cancel()
     {
-        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
@@ -154,7 +157,6 @@ public partial class EditCustomTextFormatViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _previewTimer.StopAndDispose(PreviewTimerElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
@@ -29,7 +29,7 @@ using System.Timers;
 
 namespace Nikse.SubtitleEdit.Features.Files.ExportImageBased;
 
-public partial class ExportImageBasedViewModel : ObservableObject
+public partial class ExportImageBasedViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private string _title;
     [ObservableProperty] private ObservableCollection<SubtitleLineViewModel> _subtitles;
@@ -659,8 +659,12 @@ public partial class ExportImageBasedViewModel : ObservableObject
 
     private void Close()
     {
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Dispatcher.UIThread.Post(() => { Window?.Close(); });
+    }
+
+    public void OnClosingCleanup()
+    {
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
     }
 
     public void Initialize(

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
@@ -659,6 +659,7 @@ public partial class ExportImageBasedViewModel : ObservableObject
 
     private void Close()
     {
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Dispatcher.UIThread.Post(() => { Window?.Close(); });
     }
 

--- a/src/ui/Features/Files/ExportImageBased/ImageBasedPreviewViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ImageBasedPreviewViewModel.cs
@@ -12,7 +12,7 @@ using System.Timers;
 
 namespace Nikse.SubtitleEdit.Features.Files.ExportImageBased;
 
-public partial class ImageBasedPreviewViewModel : ObservableObject
+public partial class ImageBasedPreviewViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private Bitmap _bitmapPreview;
     [ObservableProperty] private string _title;
@@ -38,6 +38,11 @@ public partial class ImageBasedPreviewViewModel : ObservableObject
         UpdateTitle();
     }
 
+    public void OnClosingCleanup()
+    {
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
+    }
+
     public void Initialize(SKBitmap bitmap, int width, int height, int x, int y)
     {
         var skBitmap = new SKBitmap(width, height, true);
@@ -54,7 +59,6 @@ public partial class ImageBasedPreviewViewModel : ObservableObject
     [RelayCommand]
     private void Ok()
     {
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Dispatcher.UIThread.Post(() =>
         {
             Window?.Close();
@@ -66,7 +70,6 @@ public partial class ImageBasedPreviewViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Files/ExportImageBased/ImageBasedPreviewViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ImageBasedPreviewViewModel.cs
@@ -54,6 +54,7 @@ public partial class ImageBasedPreviewViewModel : ObservableObject
     [RelayCommand]
     private void Ok()
     {
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Dispatcher.UIThread.Post(() =>
         {
             Window?.Close();
@@ -65,6 +66,7 @@ public partial class ImageBasedPreviewViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Files/ExportPlainText/ExportPlainTextViewModel.cs
+++ b/src/ui/Features/Files/ExportPlainText/ExportPlainTextViewModel.cs
@@ -17,7 +17,7 @@ using Nikse.SubtitleEdit.Logic.Media;
 
 namespace Nikse.SubtitleEdit.Features.Files.ExportPlainText;
 
-public partial class ExportPlainTextViewModel : ObservableObject
+public partial class ExportPlainTextViewModel : ObservableObject, IClosingCleanup
 {
     // settings controls
     [ObservableProperty] private bool _formatTextNone;
@@ -51,6 +51,7 @@ public partial class ExportPlainTextViewModel : ObservableObject
     private string? _videoFileName;
     private string _title;
     private readonly System.Timers.Timer _timerUpdatePreview;
+    private volatile bool _isClosing;
     private bool _dirty;
     private string? _subtitleFileName;
 
@@ -140,6 +141,11 @@ public partial class ExportPlainTextViewModel : ObservableObject
 
     private void TimerUpdatePreviewElapsed(object? sender, ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _timerUpdatePreview.Stop();
 
         if (_dirty)
@@ -148,7 +154,18 @@ public partial class ExportPlainTextViewModel : ObservableObject
             PreviewText = GetExportText();
         }
 
-        _timerUpdatePreview.Start();
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this handler
+        // ran, and Start() on a disposed timer throws ObjectDisposedException. (#12739)
+        if (!_isClosing)
+        {
+            _timerUpdatePreview.Start();
+        }
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
     }
 
     private string GetExportText()
@@ -283,7 +300,6 @@ public partial class ExportPlainTextViewModel : ObservableObject
     {
         SaveSettings();
         OkPressed = true;
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -291,7 +307,6 @@ public partial class ExportPlainTextViewModel : ObservableObject
     private void Cancel()
     {
         SaveSettings();
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -300,7 +315,6 @@ public partial class ExportPlainTextViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Files/ExportPlainText/ExportPlainTextViewModel.cs
+++ b/src/ui/Features/Files/ExportPlainText/ExportPlainTextViewModel.cs
@@ -283,6 +283,7 @@ public partial class ExportPlainTextViewModel : ObservableObject
     {
         SaveSettings();
         OkPressed = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -290,6 +291,7 @@ public partial class ExportPlainTextViewModel : ObservableObject
     private void Cancel()
     {
         SaveSettings();
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -298,6 +300,7 @@ public partial class ExportPlainTextViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Files/ImportPlainText/ImportPlainTextViewModel.cs
+++ b/src/ui/Features/Files/ImportPlainText/ImportPlainTextViewModel.cs
@@ -381,6 +381,7 @@ public partial class ImportPlainTextViewModel : ObservableObject
 
     private void Close()
     {
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Dispatcher.UIThread.Post(() =>
         {
             Window?.Close();

--- a/src/ui/Features/Files/ImportPlainText/ImportPlainTextViewModel.cs
+++ b/src/ui/Features/Files/ImportPlainText/ImportPlainTextViewModel.cs
@@ -20,7 +20,7 @@ using System.Timers;
 
 namespace Nikse.SubtitleEdit.Features.Files.ImportPlainText;
 
-public partial class ImportPlainTextViewModel : ObservableObject
+public partial class ImportPlainTextViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<SubtitleLineViewModel> _subtitles;
     [ObservableProperty] private SubtitleLineViewModel? _selectedSubtitle;
@@ -381,11 +381,15 @@ public partial class ImportPlainTextViewModel : ObservableObject
 
     private void Close()
     {
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Dispatcher.UIThread.Post(() =>
         {
             Window?.Close();
         });
+    }
+
+    public void OnClosingCleanup()
+    {
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
     }
 
     internal void KeyDown(object? sender, KeyEventArgs e)

--- a/src/ui/Features/Files/ManualChosenEncoding/ManualChosenEncodingViewModel.cs
+++ b/src/ui/Features/Files/ManualChosenEncoding/ManualChosenEncodingViewModel.cs
@@ -42,19 +42,21 @@ public partial class ManualChosenEncodingViewModel : ObservableObject
         _fileBuffer = [];
 
         _timerSearch = new System.Timers.Timer(500);
-        _timerSearch.Elapsed += (s, e) =>
+        _timerSearch.Elapsed += TimerSearchElapsed;
+    }
+
+    private void TimerSearchElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        _timerSearch.Stop();
+        if (_dirty)
         {
-            _timerSearch.Stop();
-            if (_dirty)
+            Dispatcher.UIThread.Invoke(() =>
             {
-                Dispatcher.UIThread.Invoke(() =>
-                {
-                    _dirty = false;
-                    UpdateSearchEncodings();
-                });
-            }
-            _timerSearch.Start();
-        };
+                _dirty = false;
+                UpdateSearchEncodings();
+            });
+        }
+        _timerSearch.Start();
     }
 
     private void UpdateSearchEncodings()
@@ -89,12 +91,14 @@ public partial class ManualChosenEncodingViewModel : ObservableObject
     private void Ok()
     {
         OkPressed = true;
+        _timerSearch.StopAndDispose(TimerSearchElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
+        _timerSearch.StopAndDispose(TimerSearchElapsed);
         Window?.Close();
     }
 
@@ -103,6 +107,7 @@ public partial class ManualChosenEncodingViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _timerSearch.StopAndDispose(TimerSearchElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Files/ManualChosenEncoding/ManualChosenEncodingViewModel.cs
+++ b/src/ui/Features/Files/ManualChosenEncoding/ManualChosenEncodingViewModel.cs
@@ -14,7 +14,7 @@ using System.Text;
 
 namespace Nikse.SubtitleEdit.Features.Files.ManualChosenEncoding;
 
-public partial class ManualChosenEncodingViewModel : ObservableObject
+public partial class ManualChosenEncodingViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private string _searchText;
     [ObservableProperty] private ObservableCollection<TextEncoding> _encodings;
@@ -30,6 +30,7 @@ public partial class ManualChosenEncodingViewModel : ObservableObject
     private byte[] _fileBuffer;
     private List<TextEncoding> _allEncodings;
     private bool _dirty;
+    private volatile bool _isClosing;
     private readonly System.Timers.Timer _timerSearch;
 
     public ManualChosenEncodingViewModel()
@@ -47,6 +48,11 @@ public partial class ManualChosenEncodingViewModel : ObservableObject
 
     private void TimerSearchElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _timerSearch.Stop();
         if (_dirty)
         {
@@ -56,7 +62,19 @@ public partial class ManualChosenEncodingViewModel : ObservableObject
                 UpdateSearchEncodings();
             });
         }
-        _timerSearch.Start();
+
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this handler
+        // ran, and Start() on a disposed timer throws ObjectDisposedException. (#12739)
+        if (!_isClosing)
+        {
+            _timerSearch.Start();
+        }
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _timerSearch.StopAndDispose(TimerSearchElapsed);
     }
 
     private void UpdateSearchEncodings()
@@ -91,14 +109,12 @@ public partial class ManualChosenEncodingViewModel : ObservableObject
     private void Ok()
     {
         OkPressed = true;
-        _timerSearch.StopAndDispose(TimerSearchElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
-        _timerSearch.StopAndDispose(TimerSearchElapsed);
         Window?.Close();
     }
 
@@ -107,7 +123,6 @@ public partial class ManualChosenEncodingViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _timerSearch.StopAndDispose(TimerSearchElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Ocr/Download/DownloadCrispEmbedViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadCrispEmbedViewModel.cs
@@ -23,7 +23,7 @@ namespace Nikse.SubtitleEdit.Features.Ocr.Download;
 /// Downloads either the CrispEmbed engine binaries (release archive, variant-aware, with an
 /// .installed.sha256 sidecar for update tracking) or a single GGUF model (streamed to disk).
 /// </summary>
-public partial class DownloadCrispEmbedViewModel : ObservableObject
+public partial class DownloadCrispEmbedViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private string _titleText;
     [ObservableProperty] private double _progressValue;
@@ -303,9 +303,13 @@ public partial class DownloadCrispEmbedViewModel : ObservableObject
     {
         _cancellationTokenSource?.Cancel();
         _done = true;
-        _timer.StopAndDispose(OnTimerOnElapsed);
         DeleteTempModelFile();
         Close();
+    }
+
+    public void OnClosingCleanup()
+    {
+        _timer.StopAndDispose(OnTimerOnElapsed);
     }
 
     private void DeleteTempModelFile()

--- a/src/ui/Features/Ocr/Download/DownloadCrispEmbedViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadCrispEmbedViewModel.cs
@@ -303,7 +303,7 @@ public partial class DownloadCrispEmbedViewModel : ObservableObject
     {
         _cancellationTokenSource?.Cancel();
         _done = true;
-        _timer.Stop();
+        _timer.StopAndDispose(OnTimerOnElapsed);
         DeleteTempModelFile();
         Close();
     }

--- a/src/ui/Features/Ocr/Download/DownloadGoogleLensOcrViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadGoogleLensOcrViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.Logic.SevenZipExtractor;
@@ -120,7 +121,7 @@ public partial class DownloadGoogleLensOcrViewModel : ObservableObject
     {
         _cancellationTokenSource?.Cancel();
         _done = true;
-        _timer.Stop();
+        _timer.StopAndDispose(OnTimerOnElapsed);
         Close();
     }
 

--- a/src/ui/Features/Ocr/Download/DownloadGoogleLensOcrViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadGoogleLensOcrViewModel.cs
@@ -17,7 +17,7 @@ using Timer = System.Timers.Timer;
 
 namespace Nikse.SubtitleEdit.Features.Ocr.Download;
 
-public partial class DownloadGoogleLensOcrViewModel : ObservableObject
+public partial class DownloadGoogleLensOcrViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private double _progressValue;
     [ObservableProperty] private string _progressText;
@@ -121,8 +121,12 @@ public partial class DownloadGoogleLensOcrViewModel : ObservableObject
     {
         _cancellationTokenSource?.Cancel();
         _done = true;
-        _timer.StopAndDispose(OnTimerOnElapsed);
         Close();
+    }
+
+    public void OnClosingCleanup()
+    {
+        _timer.StopAndDispose(OnTimerOnElapsed);
     }
 
     public void StartDownload()

--- a/src/ui/Features/Ocr/Download/DownloadPaddleOcrViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadPaddleOcrViewModel.cs
@@ -20,7 +20,7 @@ using Timer = System.Timers.Timer;
 
 namespace Nikse.SubtitleEdit.Features.Ocr.Download;
 
-public partial class DownloadPaddleOcrViewModel : ObservableObject
+public partial class DownloadPaddleOcrViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private double _progressValue;
     [ObservableProperty] private string _progressText;
@@ -231,8 +231,12 @@ public partial class DownloadPaddleOcrViewModel : ObservableObject
     {
         _cancellationTokenSource?.Cancel();
         _done = true;
-        _timer.StopAndDispose(OnTimerOnElapsed);
         Close();
+    }
+
+    public void OnClosingCleanup()
+    {
+        _timer.StopAndDispose(OnTimerOnElapsed);
     }
 
     public void StartDownload()

--- a/src/ui/Features/Ocr/Download/DownloadPaddleOcrViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadPaddleOcrViewModel.cs
@@ -231,7 +231,7 @@ public partial class DownloadPaddleOcrViewModel : ObservableObject
     {
         _cancellationTokenSource?.Cancel();
         _done = true;
-        _timer.Stop();
+        _timer.StopAndDispose(OnTimerOnElapsed);
         Close();
     }
 

--- a/src/ui/Features/Ocr/Download/DownloadTesseractModelViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadTesseractModelViewModel.cs
@@ -19,7 +19,7 @@ using Timer = System.Timers.Timer;
 
 namespace Nikse.SubtitleEdit.Features.Ocr.Download;
 
-public partial class DownloadTesseractModelViewModel : ObservableObject
+public partial class DownloadTesseractModelViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<TesseractDictionary> _tesseractDictionaryItems;
     [ObservableProperty] private TesseractDictionary? _selectedTesseractDictionaryItem;
@@ -133,8 +133,12 @@ public partial class DownloadTesseractModelViewModel : ObservableObject
     {
         _cancellationTokenSource?.Cancel();
         _done = true;
-        _timer.StopAndDispose(OnTimerOnElapsed);
         Close();
+    }
+
+    public void OnClosingCleanup()
+    {
+        _timer.StopAndDispose(OnTimerOnElapsed);
     }
 
     [RelayCommand]

--- a/src/ui/Features/Ocr/Download/DownloadTesseractModelViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadTesseractModelViewModel.cs
@@ -4,6 +4,7 @@ using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
 using System;
@@ -132,7 +133,7 @@ public partial class DownloadTesseractModelViewModel : ObservableObject
     {
         _cancellationTokenSource?.Cancel();
         _done = true;
-        _timer.Stop();
+        _timer.StopAndDispose(OnTimerOnElapsed);
         Close();
     }
 

--- a/src/ui/Features/Ocr/Download/DownloadTesseractViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadTesseractViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Compression;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
@@ -122,7 +123,7 @@ public partial class DownloadTesseractViewModel : ObservableObject
     {
         _cancellationTokenSource?.Cancel();
         _done = true;
-        _timer.Stop();
+        _timer.StopAndDispose(OnTimerOnElapsed);
         Close();
     }
 

--- a/src/ui/Features/Ocr/Download/DownloadTesseractViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadTesseractViewModel.cs
@@ -17,7 +17,7 @@ using Timer = System.Timers.Timer;
 
 namespace Nikse.SubtitleEdit.Features.Ocr.Download;
 
-public partial class DownloadTesseractViewModel : ObservableObject
+public partial class DownloadTesseractViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private double _progress;
     [ObservableProperty] private string _statusText;
@@ -123,8 +123,12 @@ public partial class DownloadTesseractViewModel : ObservableObject
     {
         _cancellationTokenSource?.Cancel();
         _done = true;
-        _timer.StopAndDispose(OnTimerOnElapsed);
         Close();
+    }
+
+    public void OnClosingCleanup()
+    {
+        _timer.StopAndDispose(OnTimerOnElapsed);
     }
 
     public void StartDownload()

--- a/src/ui/Features/Ocr/PreProcessingViewModel.cs
+++ b/src/ui/Features/Ocr/PreProcessingViewModel.cs
@@ -53,15 +53,17 @@ public partial class PreProcessingViewModel : ObservableObject
         OneColorDarknessThreshold = preProcessingSettings.OneColorDarknessThreshold;
 
         SourceBitmap = sourceBitmap.ToAvaloniaBitmap();
-        
-        _timerUpdatePreview.Elapsed += (s, e) =>
-        {
-            _timerUpdatePreview.Stop();
-            UpdatePreview();
-            _timerUpdatePreview.Start();
-        };
+
+        _timerUpdatePreview.Elapsed += TimerUpdatePreviewElapsed;
         _timerUpdatePreview.Start();
         _dirty = true;
+    }
+
+    private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        _timerUpdatePreview.Stop();
+        UpdatePreview();
+        _timerUpdatePreview.Start();
     }
 
     private void UpdatePreview()
@@ -82,6 +84,7 @@ public partial class PreProcessingViewModel : ObservableObject
         UpdateSettings();
 
         OkPressed = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -102,6 +105,7 @@ public partial class PreProcessingViewModel : ObservableObject
     [RelayCommand]
     private void Cancel()
     {
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -110,6 +114,7 @@ public partial class PreProcessingViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Ocr/PreProcessingViewModel.cs
+++ b/src/ui/Features/Ocr/PreProcessingViewModel.cs
@@ -8,7 +8,7 @@ using SkiaSharp;
 
 namespace Nikse.SubtitleEdit.Features.Ocr;
 
-public partial class PreProcessingViewModel : ObservableObject
+public partial class PreProcessingViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private bool _cropTransparentColors;
     [ObservableProperty] private bool _inverseColors;
@@ -27,6 +27,7 @@ public partial class PreProcessingViewModel : ObservableObject
     public bool OkPressed { get; private set; }
 
     private bool _dirty;
+    private volatile bool _isClosing;
     private readonly System.Timers.Timer _timerUpdatePreview;
 
     public PreProcessingViewModel()
@@ -61,9 +62,21 @@ public partial class PreProcessingViewModel : ObservableObject
 
     private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _timerUpdatePreview.Stop();
         UpdatePreview();
-        _timerUpdatePreview.Start();
+
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this
+        // handler ran, and Start() on a disposed timer throws ObjectDisposedException,
+        // crashing the app from a thread-pool thread. (#12739)
+        if (!_isClosing)
+        {
+            _timerUpdatePreview.Start();
+        }
     }
 
     private void UpdatePreview()
@@ -84,8 +97,13 @@ public partial class PreProcessingViewModel : ObservableObject
         UpdateSettings();
 
         OkPressed = true;
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
     }
 
     private void UpdateSettings()
@@ -105,7 +123,6 @@ public partial class PreProcessingViewModel : ObservableObject
     [RelayCommand]
     private void Cancel()
     {
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -114,7 +131,6 @@ public partial class PreProcessingViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Options/Settings/CustomContinuationStyleViewModel.cs
+++ b/src/ui/Features/Options/Settings/CustomContinuationStyleViewModel.cs
@@ -63,19 +63,20 @@ public partial class CustomContinuationStyleViewModel : ObservableObject
         };
 
         _previewTimer = new System.Timers.Timer(500);
-        _previewTimer.Elapsed += (sender, args) =>
+        _previewTimer.Elapsed += PreviewTimerElapsed;
+    }
+
+    private void PreviewTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        _previewTimer.Stop();
+
+        if (_isDirty)
         {
-            _previewTimer.Stop();
+            Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(UpdatePreview);
+            _isDirty = false;
+        }
 
-            if (_isDirty)
-            {
-                Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(UpdatePreview);
-                _isDirty = false;
-            }
-
-            _previewTimer.Start();
-        };
-
+        _previewTimer.Start();
     }
 
     public void Initialize(CustomContinuationStyle style)
@@ -200,12 +201,14 @@ public partial class CustomContinuationStyleViewModel : ObservableObject
     private void Ok()
     {
         OkPressed = true;
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
@@ -290,6 +293,7 @@ public partial class CustomContinuationStyleViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _previewTimer.StopAndDispose(PreviewTimerElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Options/Settings/CustomContinuationStyleViewModel.cs
+++ b/src/ui/Features/Options/Settings/CustomContinuationStyleViewModel.cs
@@ -11,7 +11,7 @@ using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Options.Settings;
 
-public partial class CustomContinuationStyleViewModel : ObservableObject
+public partial class CustomContinuationStyleViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<string> _preAndSuffixes;
 
@@ -37,6 +37,7 @@ public partial class CustomContinuationStyleViewModel : ObservableObject
     public StackPanel PanelPreview { get; internal set; }
 
     private bool _isDirty;
+    private volatile bool _isClosing;
     private readonly System.Timers.Timer _previewTimer;
 
     public CustomContinuationStyleViewModel()
@@ -68,6 +69,11 @@ public partial class CustomContinuationStyleViewModel : ObservableObject
 
     private void PreviewTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _previewTimer.Stop();
 
         if (_isDirty)
@@ -76,7 +82,17 @@ public partial class CustomContinuationStyleViewModel : ObservableObject
             _isDirty = false;
         }
 
-        _previewTimer.Start();
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this handler ran (#12739).
+        if (!_isClosing)
+        {
+            _previewTimer.Start();
+        }
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
     }
 
     public void Initialize(CustomContinuationStyle style)
@@ -201,14 +217,12 @@ public partial class CustomContinuationStyleViewModel : ObservableObject
     private void Ok()
     {
         OkPressed = true;
-        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
-        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
@@ -293,7 +307,6 @@ public partial class CustomContinuationStyleViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _previewTimer.StopAndDispose(PreviewTimerElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Options/Settings/SyntaxColorTooWideSettings/SyntaxColorTooWideSettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SyntaxColorTooWideSettings/SyntaxColorTooWideSettingsViewModel.cs
@@ -11,7 +11,7 @@ using System.Collections.ObjectModel;
 
 namespace Nikse.SubtitleEdit.Features.Options.Settings.SyntaxColorTooWideSettings;
 
-public partial class SyntaxColorTooWideSettingsViewModel : ObservableObject
+public partial class SyntaxColorTooWideSettingsViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<string> _fonts = [];
     [ObservableProperty] private string _selectedFont = string.Empty;
@@ -26,6 +26,7 @@ public partial class SyntaxColorTooWideSettingsViewModel : ObservableObject
     public bool OkPressed { get; private set; }
 
     private bool _previewDirty;
+    private volatile bool _isClosing;
     private readonly System.Timers.Timer _updateTimer;
 
     public SyntaxColorTooWideSettingsViewModel()
@@ -40,13 +41,29 @@ public partial class SyntaxColorTooWideSettingsViewModel : ObservableObject
 
     private void UpdateTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _updateTimer.Stop();
         if (_previewDirty)
         {
             _previewDirty = false;
             UpdatePreview();
         }
-        _updateTimer.Start();
+
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this handler ran (#12739).
+        if (!_isClosing)
+        {
+            _updateTimer.Start();
+        }
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _updateTimer.StopAndDispose(UpdateTimerElapsed);
     }
 
     internal void Initialize(int tooWidePixels, string fontName, int fontSize)
@@ -175,7 +192,6 @@ public partial class SyntaxColorTooWideSettingsViewModel : ObservableObject
     [RelayCommand]
     private void Ok()
     {
-        _updateTimer.StopAndDispose(UpdateTimerElapsed);
         OkPressed = true;
         Window?.Close();
     }
@@ -183,7 +199,6 @@ public partial class SyntaxColorTooWideSettingsViewModel : ObservableObject
     [RelayCommand]
     private void Cancel()
     {
-        _updateTimer.StopAndDispose(UpdateTimerElapsed);
         Window?.Close();
     }
 
@@ -192,7 +207,6 @@ public partial class SyntaxColorTooWideSettingsViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _updateTimer.StopAndDispose(UpdateTimerElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Options/Settings/SyntaxColorTooWideSettings/SyntaxColorTooWideSettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SyntaxColorTooWideSettings/SyntaxColorTooWideSettingsViewModel.cs
@@ -35,16 +35,18 @@ public partial class SyntaxColorTooWideSettingsViewModel : ObservableObject
         _imagePreview = new SKBitmap(1, 1, true).ToAvaloniaBitmap();
 
         _updateTimer = new System.Timers.Timer(300);
-        _updateTimer.Elapsed += (_, _) =>
+        _updateTimer.Elapsed += UpdateTimerElapsed;
+    }
+
+    private void UpdateTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        _updateTimer.Stop();
+        if (_previewDirty)
         {
-            _updateTimer.Stop();
-            if (_previewDirty)
-            {
-                _previewDirty = false;
-                UpdatePreview();
-            }
-            _updateTimer.Start();
-        };
+            _previewDirty = false;
+            UpdatePreview();
+        }
+        _updateTimer.Start();
     }
 
     internal void Initialize(int tooWidePixels, string fontName, int fontSize)
@@ -173,7 +175,7 @@ public partial class SyntaxColorTooWideSettingsViewModel : ObservableObject
     [RelayCommand]
     private void Ok()
     {
-        _updateTimer.Stop();
+        _updateTimer.StopAndDispose(UpdateTimerElapsed);
         OkPressed = true;
         Window?.Close();
     }
@@ -181,7 +183,7 @@ public partial class SyntaxColorTooWideSettingsViewModel : ObservableObject
     [RelayCommand]
     private void Cancel()
     {
-        _updateTimer.Stop();
+        _updateTimer.StopAndDispose(UpdateTimerElapsed);
         Window?.Close();
     }
 
@@ -190,7 +192,7 @@ public partial class SyntaxColorTooWideSettingsViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _updateTimer.Stop();
+            _updateTimer.StopAndDispose(UpdateTimerElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Shared/DownloadFfmpegViewModel.cs
+++ b/src/ui/Features/Shared/DownloadFfmpegViewModel.cs
@@ -198,7 +198,7 @@ public partial class DownloadFfmpegViewModel : ObservableObject
     {
         _cancellationTokenSource?.Cancel();
         _done = true;
-        _timer.Stop();
+        _timer.StopAndDispose(OnTimerOnElapsed);
         Close();
     }
 

--- a/src/ui/Features/Shared/DownloadFfmpegViewModel.cs
+++ b/src/ui/Features/Shared/DownloadFfmpegViewModel.cs
@@ -18,7 +18,7 @@ using Timer = System.Timers.Timer;
 
 namespace Nikse.SubtitleEdit.Features.Shared;
 
-public partial class DownloadFfmpegViewModel : ObservableObject
+public partial class DownloadFfmpegViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private double _progress;
     [ObservableProperty] private string _statusText;
@@ -198,8 +198,12 @@ public partial class DownloadFfmpegViewModel : ObservableObject
     {
         _cancellationTokenSource?.Cancel();
         _done = true;
-        _timer.StopAndDispose(OnTimerOnElapsed);
         Close();
+    }
+
+    public void OnClosingCleanup()
+    {
+        _timer.StopAndDispose(OnTimerOnElapsed);
     }
 
     public void StartDownload()

--- a/src/ui/Features/Shared/DownloadLibMpvViewModel.cs
+++ b/src/ui/Features/Shared/DownloadLibMpvViewModel.cs
@@ -17,7 +17,7 @@ using Timer = System.Timers.Timer;
 
 namespace Nikse.SubtitleEdit.Features.Shared;
 
-public partial class DownloadLibMpvViewModel : ObservableObject
+public partial class DownloadLibMpvViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private double _progress;
     [ObservableProperty] private string _statusText;
@@ -193,8 +193,12 @@ public partial class DownloadLibMpvViewModel : ObservableObject
     {
         _cancellationTokenSource?.Cancel();
         _done = true;
-        _timer.StopAndDispose(OnTimerOnElapsed);
         Close();
+    }
+
+    public void OnClosingCleanup()
+    {
+        _timer.StopAndDispose(OnTimerOnElapsed);
     }
 
     public void StartDownload()

--- a/src/ui/Features/Shared/DownloadLibMpvViewModel.cs
+++ b/src/ui/Features/Shared/DownloadLibMpvViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Compression;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
@@ -192,7 +193,7 @@ public partial class DownloadLibMpvViewModel : ObservableObject
     {
         _cancellationTokenSource?.Cancel();
         _done = true;
-        _timer.Stop();
+        _timer.StopAndDispose(OnTimerOnElapsed);
         Close();
     }
 

--- a/src/ui/Features/Shared/DownloadLibVlcViewModel.cs
+++ b/src/ui/Features/Shared/DownloadLibVlcViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.Logic.SevenZipExtractor;
@@ -145,7 +146,7 @@ public partial class DownloadLibVlcViewModel : ObservableObject
     {
         _cancellationTokenSource?.Cancel();
         _done = true;
-        _timer.Stop();
+        _timer.StopAndDispose(OnTimerOnElapsed);
         Close();
     }
 

--- a/src/ui/Features/Shared/DownloadLibVlcViewModel.cs
+++ b/src/ui/Features/Shared/DownloadLibVlcViewModel.cs
@@ -17,7 +17,7 @@ using Timer = System.Timers.Timer;
 
 namespace Nikse.SubtitleEdit.Features.Shared;
 
-public partial class DownloadLibVlcViewModel : ObservableObject
+public partial class DownloadLibVlcViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private double _progressValue;
     [ObservableProperty] private string _progressText;
@@ -146,8 +146,12 @@ public partial class DownloadLibVlcViewModel : ObservableObject
     {
         _cancellationTokenSource?.Cancel();
         _done = true;
-        _timer.StopAndDispose(OnTimerOnElapsed);
         Close();
+    }
+
+    public void OnClosingCleanup()
+    {
+        _timer.StopAndDispose(OnTimerOnElapsed);
     }
 
     public void StartDownload()

--- a/src/ui/Features/Shared/DownloadYtDlpViewModel.cs
+++ b/src/ui/Features/Shared/DownloadYtDlpViewModel.cs
@@ -16,7 +16,7 @@ using Timer = System.Timers.Timer;
 
 namespace Nikse.SubtitleEdit.Features.Shared;
 
-public partial class DownloadYtDlpViewModel : ObservableObject
+public partial class DownloadYtDlpViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private double _progress;
     [ObservableProperty] private string _statusText;
@@ -116,8 +116,12 @@ public partial class DownloadYtDlpViewModel : ObservableObject
     {
         _cancellationTokenSource?.Cancel();
         _done = true;
-        _timer.StopAndDispose(OnTimerOnElapsed);
         Close();
+    }
+
+    public void OnClosingCleanup()
+    {
+        _timer.StopAndDispose(OnTimerOnElapsed);
     }
 
     public void StartDownload()

--- a/src/ui/Features/Shared/DownloadYtDlpViewModel.cs
+++ b/src/ui/Features/Shared/DownloadYtDlpViewModel.cs
@@ -116,7 +116,7 @@ public partial class DownloadYtDlpViewModel : ObservableObject
     {
         _cancellationTokenSource?.Cancel();
         _done = true;
-        _timer.Stop();
+        _timer.StopAndDispose(OnTimerOnElapsed);
         Close();
     }
 

--- a/src/ui/Features/Shared/FindText/FindTextViewModel.cs
+++ b/src/ui/Features/Shared/FindText/FindTextViewModel.cs
@@ -80,12 +80,14 @@ public partial class FindTextViewModel : ObservableObject
     private void Ok()
     {
         OkPressed = true;
+        _searchTimer.StopAndDispose(_searchTimer_Elapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
+        _searchTimer.StopAndDispose(_searchTimer_Elapsed);
         Window?.Close();
     }
 
@@ -94,6 +96,7 @@ public partial class FindTextViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _searchTimer.StopAndDispose(_searchTimer_Elapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Shared/FindText/FindTextViewModel.cs
+++ b/src/ui/Features/Shared/FindText/FindTextViewModel.cs
@@ -13,7 +13,7 @@ using System.Threading;
 
 namespace Nikse.SubtitleEdit.Features.Shared.FindText;
 
-public partial class FindTextViewModel : ObservableObject
+public partial class FindTextViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private string _title;
     [ObservableProperty] private string _searchText;
@@ -68,6 +68,11 @@ public partial class FindTextViewModel : ObservableObject
         }
     }
 
+    public void OnClosingCleanup()
+    {
+        _searchTimer.StopAndDispose(_searchTimer_Elapsed);
+    }
+
     internal void Initialize(List<SubtitleLineViewModel> subtitleLines, string title)
     {
         Title = title;
@@ -80,14 +85,12 @@ public partial class FindTextViewModel : ObservableObject
     private void Ok()
     {
         OkPressed = true;
-        _searchTimer.StopAndDispose(_searchTimer_Elapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
-        _searchTimer.StopAndDispose(_searchTimer_Elapsed);
         Window?.Close();
     }
 
@@ -96,7 +99,6 @@ public partial class FindTextViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _searchTimer.StopAndDispose(_searchTimer_Elapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Shared/PickFontName/PickFontNameViewModel.cs
+++ b/src/ui/Features/Shared/PickFontName/PickFontNameViewModel.cs
@@ -42,21 +42,23 @@ public partial class PickFontNameViewModel : ObservableObject
         ImagePreview = new SKBitmap(1, 1, true).ToAvaloniaBitmap();
 
         _timerUpdate = new System.Timers.Timer(500);
-        _timerUpdate.Elapsed += (s, e) =>
+        _timerUpdate.Elapsed += TimerUpdateElapsed;
+    }
+
+    private void TimerUpdateElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        _timerUpdate.Stop();
+        if (_dirtySearch)
         {
-            _timerUpdate.Stop();
-            if (_dirtySearch)
-            {
-                _dirtySearch = false;
-                UpdateSearch();
-            }
-            if (_dirtyPreview)
-            {
-                _dirtyPreview = false;
-                UpdatePreview();
-            }
-            _timerUpdate.Start();
-        };
+            _dirtySearch = false;
+            UpdateSearch();
+        }
+        if (_dirtyPreview)
+        {
+            _dirtyPreview = false;
+            UpdatePreview();
+        }
+        _timerUpdate.Start();
     }
 
     internal void Initialize(bool isFontSizeVisible = false, bool isFontBoldVisible = false)
@@ -157,12 +159,14 @@ public partial class PickFontNameViewModel : ObservableObject
     private void Ok()
     {
         OkPressed = true;
+        _timerUpdate.StopAndDispose(TimerUpdateElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
+        _timerUpdate.StopAndDispose(TimerUpdateElapsed);
         Window?.Close();
     }
 
@@ -171,6 +175,7 @@ public partial class PickFontNameViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _timerUpdate.StopAndDispose(TimerUpdateElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Shared/PickFontName/PickFontNameViewModel.cs
+++ b/src/ui/Features/Shared/PickFontName/PickFontNameViewModel.cs
@@ -13,7 +13,7 @@ using System.Collections.ObjectModel;
 
 namespace Nikse.SubtitleEdit.Features.Shared.PickFontName;
 
-public partial class PickFontNameViewModel : ObservableObject
+public partial class PickFontNameViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private string _searchText;
     [ObservableProperty] private ObservableCollection<string> _fontNames;
@@ -30,6 +30,7 @@ public partial class PickFontNameViewModel : ObservableObject
 
     private List<string> _allFontNames;
     private readonly System.Timers.Timer _timerUpdate;
+    private volatile bool _isClosing;
     private bool _dirtySearch;
     private bool _dirtyPreview;
 
@@ -47,6 +48,11 @@ public partial class PickFontNameViewModel : ObservableObject
 
     private void TimerUpdateElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _timerUpdate.Stop();
         if (_dirtySearch)
         {
@@ -58,7 +64,18 @@ public partial class PickFontNameViewModel : ObservableObject
             _dirtyPreview = false;
             UpdatePreview();
         }
-        _timerUpdate.Start();
+
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this handler ran (#12739).
+        if (!_isClosing)
+        {
+            _timerUpdate.Start();
+        }
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _timerUpdate.StopAndDispose(TimerUpdateElapsed);
     }
 
     internal void Initialize(bool isFontSizeVisible = false, bool isFontBoldVisible = false)
@@ -159,14 +176,12 @@ public partial class PickFontNameViewModel : ObservableObject
     private void Ok()
     {
         OkPressed = true;
-        _timerUpdate.StopAndDispose(TimerUpdateElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
-        _timerUpdate.StopAndDispose(TimerUpdateElapsed);
         Window?.Close();
     }
 
@@ -175,7 +190,6 @@ public partial class PickFontNameViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _timerUpdate.StopAndDispose(TimerUpdateElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Shared/SourceView/SourceViewViewModel.cs
+++ b/src/ui/Features/Shared/SourceView/SourceViewViewModel.cs
@@ -52,38 +52,40 @@ public partial class SourceViewViewModel : ObservableObject
         PasteCommand = new RelayCommand(() => SourceViewTextBox.Paste());
 
         _cursorTimer = new System.Timers.Timer(200);
-        _cursorTimer.Elapsed += (sender, args) =>
+        _cursorTimer.Elapsed += CursorTimerElapsed;
+    }
+
+    private void CursorTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        if (SourceViewTextBox == null)
         {
-            if (SourceViewTextBox == null)
+            return;
+        }
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            var caretIndex = SourceViewTextBox.CaretIndex;
+            var text = SourceViewTextBox.Text ?? string.Empty;
+
+            // Calculate line and column
+            var lineNumber = 1;
+            var columnNumber = 1;
+
+            for (int i = 0; i < Math.Min(caretIndex, text.Length); i++)
             {
-                return;
+                if (text[i] == '\n')
+                {
+                    lineNumber++;
+                    columnNumber = 1;
+                }
+                else if (text[i] != '\r') // Skip carriage return
+                {
+                    columnNumber++;
+                }
             }
 
-            Dispatcher.UIThread.Post(() =>
-            {
-                var caretIndex = SourceViewTextBox.CaretIndex;
-                var text = SourceViewTextBox.Text ?? string.Empty;
-
-                // Calculate line and column
-                var lineNumber = 1;
-                var columnNumber = 1;
-
-                for (int i = 0; i < Math.Min(caretIndex, text.Length); i++)
-                {
-                    if (text[i] == '\n')
-                    {
-                        lineNumber++;
-                        columnNumber = 1;
-                    }
-                    else if (text[i] != '\r') // Skip carriage return
-                    {
-                        columnNumber++;
-                    }
-                }
-
-                LineAndColumnInfo = string.Format(Se.Language.General.LineXColumnY, lineNumber, columnNumber);
-            });
-        };
+            LineAndColumnInfo = string.Format(Se.Language.General.LineXColumnY, lineNumber, columnNumber);
+        });
     }
 
     internal void Initialize(
@@ -309,6 +311,7 @@ public partial class SourceViewViewModel : ObservableObject
         if (string.IsNullOrEmpty(text))
         {
             OkPressed = false;
+            _cursorTimer.StopAndDispose(CursorTimerElapsed);
             Window?.Close();
             return;
         }
@@ -321,6 +324,7 @@ public partial class SourceViewViewModel : ObservableObject
             Subtitle.Paragraphs.Clear();
             Subtitle.Paragraphs.AddRange(subtitle.Paragraphs);
             OkPressed = true;
+            _cursorTimer.StopAndDispose(CursorTimerElapsed);
             Window?.Close();
             return;
         }
@@ -331,6 +335,7 @@ public partial class SourceViewViewModel : ObservableObject
             Subtitle.Paragraphs.Clear();
             Subtitle.Paragraphs.AddRange(subtitle.Paragraphs);
             OkPressed = true;
+            _cursorTimer.StopAndDispose(CursorTimerElapsed);
             Window?.Close();
             return;
         }
@@ -378,6 +383,7 @@ public partial class SourceViewViewModel : ObservableObject
     [RelayCommand]
     private void Cancel()
     {
+        _cursorTimer.StopAndDispose(CursorTimerElapsed);
         Window?.Close();
     }
 
@@ -386,6 +392,7 @@ public partial class SourceViewViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _cursorTimer.StopAndDispose(CursorTimerElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Shared/SourceView/SourceViewViewModel.cs
+++ b/src/ui/Features/Shared/SourceView/SourceViewViewModel.cs
@@ -19,7 +19,7 @@ using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Shared.SourceView;
 
-public partial class SourceViewViewModel : ObservableObject
+public partial class SourceViewViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private string _title;
     [ObservableProperty] private string _text;
@@ -86,6 +86,11 @@ public partial class SourceViewViewModel : ObservableObject
 
             LineAndColumnInfo = string.Format(Se.Language.General.LineXColumnY, lineNumber, columnNumber);
         });
+    }
+
+    public void OnClosingCleanup()
+    {
+        _cursorTimer.StopAndDispose(CursorTimerElapsed);
     }
 
     internal void Initialize(
@@ -311,7 +316,6 @@ public partial class SourceViewViewModel : ObservableObject
         if (string.IsNullOrEmpty(text))
         {
             OkPressed = false;
-            _cursorTimer.StopAndDispose(CursorTimerElapsed);
             Window?.Close();
             return;
         }
@@ -324,7 +328,6 @@ public partial class SourceViewViewModel : ObservableObject
             Subtitle.Paragraphs.Clear();
             Subtitle.Paragraphs.AddRange(subtitle.Paragraphs);
             OkPressed = true;
-            _cursorTimer.StopAndDispose(CursorTimerElapsed);
             Window?.Close();
             return;
         }
@@ -335,7 +338,6 @@ public partial class SourceViewViewModel : ObservableObject
             Subtitle.Paragraphs.Clear();
             Subtitle.Paragraphs.AddRange(subtitle.Paragraphs);
             OkPressed = true;
-            _cursorTimer.StopAndDispose(CursorTimerElapsed);
             Window?.Close();
             return;
         }
@@ -383,7 +385,6 @@ public partial class SourceViewViewModel : ObservableObject
     [RelayCommand]
     private void Cancel()
     {
-        _cursorTimer.StopAndDispose(CursorTimerElapsed);
         Window?.Close();
     }
 
@@ -392,7 +393,6 @@ public partial class SourceViewViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _cursorTimer.StopAndDispose(CursorTimerElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs
+++ b/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs
@@ -158,7 +158,7 @@ public partial class GetDictionariesViewModel : ObservableObject
 
     private void Close()
     {
-        _timer.Stop();
+        _timer.StopAndDispose(OnTimerOnElapsed);
         Dispatcher.UIThread.Post(() => { Window?.Close(); });
     }
 

--- a/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs
+++ b/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs
@@ -23,7 +23,7 @@ using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Features.SpellCheck.GetDictionaries;
 
-public partial class GetDictionariesViewModel : ObservableObject
+public partial class GetDictionariesViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<GetSpellCheckDictionaryDisplay> _dictionaries;
     [ObservableProperty] private GetSpellCheckDictionaryDisplay? selectedDictionary;
@@ -158,8 +158,12 @@ public partial class GetDictionariesViewModel : ObservableObject
 
     private void Close()
     {
-        _timer.StopAndDispose(OnTimerOnElapsed);
         Dispatcher.UIThread.Post(() => { Window?.Close(); });
+    }
+
+    public void OnClosingCleanup()
+    {
+        _timer.StopAndDispose(OnTimerOnElapsed);
     }
 
     /// <summary>
@@ -409,7 +413,6 @@ public partial class GetDictionariesViewModel : ObservableObject
     [RelayCommand]
     private void Ok()
     {
-        _timer.Stop();
         Close();
     }
 
@@ -417,7 +420,6 @@ public partial class GetDictionariesViewModel : ObservableObject
     private void Cancel()
     {
         _cancellationTokenSource.Cancel();
-        _timer.Stop();
         _done = true;
         Close();
     }

--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -866,6 +866,11 @@ public partial class SpellCheckViewModel : ObservableObject
         OkPressed = true;
         Se.Settings.SpellCheck.LastLanguageDictionaryName = SelectedDictionary?.Name;
         Se.Settings.SpellCheck.LastLanguageDictionaryFile = SelectedDictionary?.DictionaryFileName;
+        if (_statusTimer != null)
+        {
+            _statusTimer.StopAndDispose(StatusTimerElapsed);
+        }
+
         Dispatcher.UIThread.Invoke(() => { Window?.Close(); });
     }
 
@@ -874,6 +879,11 @@ public partial class SpellCheckViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            if (_statusTimer != null)
+            {
+                _statusTimer.StopAndDispose(StatusTimerElapsed);
+            }
+
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))
@@ -1108,24 +1118,26 @@ public partial class SpellCheckViewModel : ObservableObject
         _statusTimer?.Dispose();
 
         _statusTimer = new System.Timers.Timer(3000);
-        _statusTimer.Elapsed += (sender, e) =>
-        {
-            Dispatcher.UIThread.Post(() =>
-            {
-                try
-                {
-                    StatusText = string.Empty;
-                    _statusTimer?.Dispose();
-                    _statusTimer = null;
-                }
-                catch
-                {
-                    // ignore
-                }
-            });
-        };
+        _statusTimer.Elapsed += StatusTimerElapsed;
         _statusTimer.AutoReset = false;
         _statusTimer.Start();
+    }
+
+    private void StatusTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            try
+            {
+                StatusText = string.Empty;
+                _statusTimer?.Dispose();
+                _statusTimer = null;
+            }
+            catch
+            {
+                // ignore
+            }
+        });
     }
 
     internal void ListBoxSuggestionsDoubleTapped(object? sender, TappedEventArgs e)

--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -33,7 +33,7 @@ using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Features.SpellCheck;
 
-public partial class SpellCheckViewModel : ObservableObject
+public partial class SpellCheckViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private string _lineText;
     [ObservableProperty] private string _wholeText;
@@ -866,11 +866,6 @@ public partial class SpellCheckViewModel : ObservableObject
         OkPressed = true;
         Se.Settings.SpellCheck.LastLanguageDictionaryName = SelectedDictionary?.Name;
         Se.Settings.SpellCheck.LastLanguageDictionaryFile = SelectedDictionary?.DictionaryFileName;
-        if (_statusTimer != null)
-        {
-            _statusTimer.StopAndDispose(StatusTimerElapsed);
-        }
-
         Dispatcher.UIThread.Invoke(() => { Window?.Close(); });
     }
 
@@ -879,11 +874,6 @@ public partial class SpellCheckViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            if (_statusTimer != null)
-            {
-                _statusTimer.StopAndDispose(StatusTimerElapsed);
-            }
-
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))
@@ -1114,13 +1104,18 @@ public partial class SpellCheckViewModel : ObservableObject
     {
         StatusText = statusText;
 
-        _statusTimer?.Stop();
-        _statusTimer?.Dispose();
+        _statusTimer?.StopAndDispose(StatusTimerElapsed);
 
         _statusTimer = new System.Timers.Timer(3000);
         _statusTimer.Elapsed += StatusTimerElapsed;
         _statusTimer.AutoReset = false;
         _statusTimer.Start();
+    }
+
+    public void OnClosingCleanup()
+    {
+        _statusTimer?.StopAndDispose(StatusTimerElapsed);
+        _statusTimer = null;
     }
 
     private void StatusTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)

--- a/src/ui/Features/Ssa/SsaStylesViewModel.cs
+++ b/src/ui/Features/Ssa/SsaStylesViewModel.cs
@@ -23,7 +23,7 @@ using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Ssa;
 
-public partial class SsaStylesViewModel : ObservableObject
+public partial class SsaStylesViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private string _title;
     [ObservableProperty] private ObservableCollection<StyleDisplay> _fileStyles;
@@ -58,6 +58,7 @@ public partial class SsaStylesViewModel : ObservableObject
     private IApplySsaStyles? _applySsaStyles;
     private Subtitle _subtitle;
     private string _subtitleFileName;
+    private volatile bool _isClosing;
     private readonly System.Timers.Timer _timerUpdatePreview;
 
     public SsaStylesViewModel(IFileHelper fileHelper, IWindowService windowService)
@@ -87,9 +88,21 @@ public partial class SsaStylesViewModel : ObservableObject
 
     private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _timerUpdatePreview.Stop();
         UpdatePreview();
-        _timerUpdatePreview.Start();
+
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this
+        // handler ran, and Start() on a disposed timer throws ObjectDisposedException,
+        // crashing the app from a thread-pool thread. (#12739)
+        if (!_isClosing)
+        {
+            _timerUpdatePreview.Start();
+        }
     }
 
     [RelayCommand]
@@ -567,8 +580,13 @@ public partial class SsaStylesViewModel : ObservableObject
 
     private void Close()
     {
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Dispatcher.UIThread.Post(() => { Window?.Close(); });
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
     }
 
     public void Initialize(

--- a/src/ui/Features/Ssa/SsaStylesViewModel.cs
+++ b/src/ui/Features/Ssa/SsaStylesViewModel.cs
@@ -82,12 +82,14 @@ public partial class SsaStylesViewModel : ObservableObject
         LoadSettings();
 
         _timerUpdatePreview = new System.Timers.Timer(500);
-        _timerUpdatePreview.Elapsed += (s, e) =>
-        {
-            _timerUpdatePreview.Stop();
-            UpdatePreview();
-            _timerUpdatePreview.Start();
-        };
+        _timerUpdatePreview.Elapsed += TimerUpdatePreviewElapsed;
+    }
+
+    private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        _timerUpdatePreview.Stop();
+        UpdatePreview();
+        _timerUpdatePreview.Start();
     }
 
     [RelayCommand]
@@ -565,6 +567,7 @@ public partial class SsaStylesViewModel : ObservableObject
 
     private void Close()
     {
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Dispatcher.UIThread.Post(() => { Window?.Close(); });
     }
 

--- a/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsViewModel.cs
+++ b/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsViewModel.cs
@@ -58,18 +58,20 @@ public partial class ApplyDurationLimitsViewModel : ObservableObject
         LoadSettings();
 
         _previewTimer = new System.Timers.Timer(250);
-        _previewTimer.Elapsed += (sender, args) =>
+        _previewTimer.Elapsed += PreviewTimerElapsed;
+    }
+
+    private void PreviewTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        _previewTimer.Stop();
+
+        if (_isDirty)
         {
-            _previewTimer.Stop();
+            _isDirty = false;
+            UpdatePreview();
+        }
 
-            if (_isDirty)
-            {
-                _isDirty = false;
-                UpdatePreview();
-            }
-
-            _previewTimer.Start();
-        };
+        _previewTimer.Start();
     }
 
     private void UpdatePreview()
@@ -227,12 +229,14 @@ public partial class ApplyDurationLimitsViewModel : ObservableObject
             OkPressed = true;
         }
 
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
@@ -241,6 +245,7 @@ public partial class ApplyDurationLimitsViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _previewTimer.StopAndDispose(PreviewTimerElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsViewModel.cs
+++ b/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsViewModel.cs
@@ -15,7 +15,7 @@ using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Tools.ApplyDurationLimits;
 
-public partial class ApplyDurationLimitsViewModel : ObservableObject
+public partial class ApplyDurationLimitsViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<ApplyDurationLimitItem> _fixes;
     [ObservableProperty] private ApplyDurationLimitItem? _selectedFix;
@@ -42,6 +42,7 @@ public partial class ApplyDurationLimitsViewModel : ObservableObject
     private List<SubtitleLineViewModel> _allSubtitles;
 
     private readonly System.Timers.Timer _previewTimer;
+    private volatile bool _isClosing;
     private bool _isDirty;
     private List<double> _shotChanges;
 
@@ -63,6 +64,11 @@ public partial class ApplyDurationLimitsViewModel : ObservableObject
 
     private void PreviewTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _previewTimer.Stop();
 
         if (_isDirty)
@@ -71,7 +77,19 @@ public partial class ApplyDurationLimitsViewModel : ObservableObject
             UpdatePreview();
         }
 
-        _previewTimer.Start();
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this handler ran,
+        // and Start() on a disposed timer throws ObjectDisposedException (no longer swallowed on
+        // modern .NET), crashing the app from a thread-pool thread. (#12739)
+        if (!_isClosing)
+        {
+            _previewTimer.Start();
+        }
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
     }
 
     private void UpdatePreview()
@@ -229,14 +247,12 @@ public partial class ApplyDurationLimitsViewModel : ObservableObject
             OkPressed = true;
         }
 
-        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
-        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
@@ -245,7 +261,6 @@ public partial class ApplyDurationLimitsViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _previewTimer.StopAndDispose(PreviewTimerElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/ApplyMinGap/ApplyMinGapViewModel.cs
+++ b/src/ui/Features/Tools/ApplyMinGap/ApplyMinGapViewModel.cs
@@ -15,7 +15,7 @@ using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Tools.ApplyMinGap;
 
-public partial class ApplyMinGapViewModel : ObservableObject
+public partial class ApplyMinGapViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<ApplyMinGapItem> _subtitles;
     [ObservableProperty] private ApplyMinGapItem? _selectedSubtitle;
@@ -29,6 +29,7 @@ public partial class ApplyMinGapViewModel : ObservableObject
     public bool OkPressed { get; private set; }
 
     private readonly System.Timers.Timer _timerUpdatePreview;
+    private volatile bool _isClosing;
     private bool _dirty;
     private readonly List<SubtitleLineViewModel> _allSubtitles;
 
@@ -57,13 +58,31 @@ public partial class ApplyMinGapViewModel : ObservableObject
 
     private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _timerUpdatePreview.Stop();
         if (_dirty)
         {
             _dirty = false;
             UpdatePreview();
         }
-        _timerUpdatePreview.Start();
+
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this handler ran,
+        // and Start() on a disposed timer throws ObjectDisposedException (no longer swallowed on
+        // modern .NET), crashing the app from a thread-pool thread. (#12739)
+        if (!_isClosing)
+        {
+            _timerUpdatePreview.Start();
+        }
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
     }
 
     private void UpdatePreview()
@@ -136,14 +155,12 @@ public partial class ApplyMinGapViewModel : ObservableObject
     {
         SaveSettings();
         OkPressed = true;
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -152,7 +169,6 @@ public partial class ApplyMinGapViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/ApplyMinGap/ApplyMinGapViewModel.cs
+++ b/src/ui/Features/Tools/ApplyMinGap/ApplyMinGapViewModel.cs
@@ -52,16 +52,18 @@ public partial class ApplyMinGapViewModel : ObservableObject
 
         _allSubtitles = new List<SubtitleLineViewModel>();  
         _timerUpdatePreview = new System.Timers.Timer(500);
-        _timerUpdatePreview.Elapsed += (s, e) =>
+        _timerUpdatePreview.Elapsed += TimerUpdatePreviewElapsed;
+    }
+
+    private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        _timerUpdatePreview.Stop();
+        if (_dirty)
         {
-            _timerUpdatePreview.Stop();
-            if (_dirty)
-            {
-                _dirty = false;
-                UpdatePreview();
-            }
-            _timerUpdatePreview.Start();
-        };
+            _dirty = false;
+            UpdatePreview();
+        }
+        _timerUpdatePreview.Start();
     }
 
     private void UpdatePreview()
@@ -134,12 +136,14 @@ public partial class ApplyMinGapViewModel : ObservableObject
     {
         SaveSettings();
         OkPressed = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -148,6 +152,7 @@ public partial class ApplyMinGapViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -403,22 +403,24 @@ public partial class BatchConvertViewModel : ObservableObject
         LoadSettings();
         FilterComboBoxChanged();
         _filesTimer = new System.Timers.Timer(250);
-        _filesTimer.Elapsed += (sender, args) =>
-        {
-            Dispatcher.UIThread.Post(() =>
-            {
-                _filesTimer.Stop();
-
-                if (_isFilesDirty)
-                {
-                    _isFilesDirty = false;
-                    UpdateFilteredFiles();
-                }
-
-                _filesTimer.Start();
-            });
-        };
+        _filesTimer.Elapsed += FilesTimerElapsed;
         _filesTimer.Start();
+    }
+
+    private void FilesTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            _filesTimer.Stop();
+
+            if (_isFilesDirty)
+            {
+                _isFilesDirty = false;
+                UpdateFilteredFiles();
+            }
+
+            _filesTimer.Start();
+        });
     }
 
     private void UpdateFilteredFiles()
@@ -835,6 +837,7 @@ public partial class BatchConvertViewModel : ObservableObject
     {
         SaveSettings();
         OkPressed = true;
+        _filesTimer.StopAndDispose(FilesTimerElapsed);
         Window?.Close();
     }
 
@@ -1861,6 +1864,7 @@ public partial class BatchConvertViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _filesTimer.StopAndDispose(FilesTimerElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -49,7 +49,7 @@ using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
 
 namespace Nikse.SubtitleEdit.Features.Tools.BatchConvert;
 
-public partial class BatchConvertViewModel : ObservableObject
+public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<BatchConvertItem> _batchItems;
     [ObservableProperty] private BatchConvertItem? _selectedBatchItem;
@@ -237,6 +237,7 @@ public partial class BatchConvertViewModel : ObservableObject
     private List<BatchConvertItem> _allBatchItems;
     private readonly System.Timers.Timer _filesTimer;
     private bool _isFilesDirty;
+    private volatile bool _isClosing;
     private readonly IWindowService _windowService;
     private readonly IFileHelper _fileHelper;
     private readonly IFolderHelper _folderHelper;
@@ -409,8 +410,18 @@ public partial class BatchConvertViewModel : ObservableObject
 
     private void FilesTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         Dispatcher.UIThread.Post(() =>
         {
+            if (_isClosing)
+            {
+                return;
+            }
+
             _filesTimer.Stop();
 
             if (_isFilesDirty)
@@ -419,8 +430,20 @@ public partial class BatchConvertViewModel : ObservableObject
                 UpdateFilteredFiles();
             }
 
-            _filesTimer.Start();
+            // Guard the restart: OnClosingCleanup may have disposed the timer while this posted
+            // action was queued, and Start() on a disposed timer throws ObjectDisposedException
+            // (no longer swallowed on modern .NET), crashing the UI thread. (#12739)
+            if (!_isClosing)
+            {
+                _filesTimer.Start();
+            }
         });
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _filesTimer.StopAndDispose(FilesTimerElapsed);
     }
 
     private void UpdateFilteredFiles()
@@ -837,7 +860,6 @@ public partial class BatchConvertViewModel : ObservableObject
     {
         SaveSettings();
         OkPressed = true;
-        _filesTimer.StopAndDispose(FilesTimerElapsed);
         Window?.Close();
     }
 
@@ -1864,7 +1886,6 @@ public partial class BatchConvertViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _filesTimer.StopAndDispose(FilesTimerElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
@@ -65,9 +65,21 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
 
     private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        // Dispose() (wired from the window's Closing) may run on the UI thread while this handler
+        // runs on a thread-pool thread; Start() on the disposed timer throws ObjectDisposedException
+        // (no longer swallowed on modern .NET), so bail out and never restart once disposed. (#12739)
+        if (_disposed)
+        {
+            return;
+        }
+
         if (!_dirty || _updateInProgress)
         {
-            _timerUpdatePreview.Start();
+            if (!_disposed)
+            {
+                _timerUpdatePreview.Start();
+            }
+
             return;
         }
 
@@ -75,7 +87,11 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
         {
             if (!_dirty || _updateInProgress)
             {
-                _timerUpdatePreview.Start();
+                if (!_disposed)
+                {
+                    _timerUpdatePreview.Start();
+                }
+
                 return;
             }
 
@@ -527,8 +543,11 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
             AudioVisualizerOriginal.InvalidateVisual();
             AudioVisualizerBeautified.InvalidateVisual();
 
-            _timerUpdatePreview.Start();
-            StartPositionTimer();
+            if (!_disposed)
+            {
+                _timerUpdatePreview.Start();
+                StartPositionTimer();
+            }
         });
     }
 

--- a/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
@@ -60,7 +60,18 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
 
         _timerUpdatePreview = new System.Timers.Timer(500);
         _timerUpdatePreview.AutoReset = false;
-        _timerUpdatePreview.Elapsed += (s, e) =>
+        _timerUpdatePreview.Elapsed += TimerUpdatePreviewElapsed;
+    }
+
+    private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        if (!_dirty || _updateInProgress)
+        {
+            _timerUpdatePreview.Start();
+            return;
+        }
+
+        lock (_timerLock)
         {
             if (!_dirty || _updateInProgress)
             {
@@ -68,20 +79,11 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
                 return;
             }
 
-            lock (_timerLock)
-            {
-                if (!_dirty || _updateInProgress)
-                {
-                    _timerUpdatePreview.Start();
-                    return;
-                }
+            _dirty = false;
+            _updateInProgress = true;
+        }
 
-                _dirty = false;
-                _updateInProgress = true;
-            }
-
-            UpdatePreview();
-        };
+        UpdatePreview();
     }
 
     private void UpdatePreview()
@@ -597,7 +599,7 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
     private void Ok()
     {
         StopPositionTimer();
-        _timerUpdatePreview.Stop();
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
 
         // Apply final beautification to commit the result back to _allSubtitles
         var subtitle = BuildSubtitleFromRows();
@@ -620,7 +622,7 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
     private void Cancel()
     {
         StopPositionTimer();
-        _timerUpdatePreview.Stop();
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -663,7 +665,6 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
 
         _disposed = true;
         StopPositionTimer();
-        _timerUpdatePreview.Stop();
-        _timerUpdatePreview.Dispose();
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
     }
 }

--- a/src/ui/Features/Tools/BridgeGaps/BridgeGapsViewModel.cs
+++ b/src/ui/Features/Tools/BridgeGaps/BridgeGapsViewModel.cs
@@ -45,16 +45,18 @@ public partial class BridgeGapsViewModel : ObservableObject
         LoadSettings();
 
         _timerUpdatePreview = new System.Timers.Timer(500);
-        _timerUpdatePreview.Elapsed += (s, e) =>
+        _timerUpdatePreview.Elapsed += TimerUpdatePreviewElapsed;
+    }
+
+    private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        _timerUpdatePreview.Stop();
+        if (_dirty)
         {
-            _timerUpdatePreview.Stop();
-            if (_dirty)
-            {
-                _dirty = false;
-                UpdatePreview();
-            }
-            _timerUpdatePreview.Start();
-        };
+            _dirty = false;
+            UpdatePreview();
+        }
+        _timerUpdatePreview.Start();
     }
 
     private void UpdatePreview()
@@ -139,12 +141,14 @@ public partial class BridgeGapsViewModel : ObservableObject
     {
         SaveSettings();
         OkPressed = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -153,6 +157,7 @@ public partial class BridgeGapsViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/BridgeGaps/BridgeGapsViewModel.cs
+++ b/src/ui/Features/Tools/BridgeGaps/BridgeGapsViewModel.cs
@@ -14,7 +14,7 @@ using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Tools.BridgeGaps;
 
-public partial class BridgeGapsViewModel : ObservableObject
+public partial class BridgeGapsViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<BridgeGapDisplayItem> _subtitles;
     [ObservableProperty] private BridgeGapDisplayItem? _selectedSubtitle;
@@ -30,6 +30,7 @@ public partial class BridgeGapsViewModel : ObservableObject
 
     private readonly System.Timers.Timer _timerUpdatePreview;
     private bool _dirty;
+    private volatile bool _isClosing;
     private Dictionary<string, string> _dic;
 
 
@@ -50,13 +51,31 @@ public partial class BridgeGapsViewModel : ObservableObject
 
     private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _timerUpdatePreview.Stop();
         if (_dirty)
         {
             _dirty = false;
             UpdatePreview();
         }
-        _timerUpdatePreview.Start();
+
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this handler ran,
+        // and Start() on a disposed timer throws ObjectDisposedException (no longer swallowed on
+        // modern .NET), crashing the app from a thread-pool thread. (#12739)
+        if (!_isClosing)
+        {
+            _timerUpdatePreview.Start();
+        }
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
     }
 
     private void UpdatePreview()
@@ -141,14 +160,12 @@ public partial class BridgeGapsViewModel : ObservableObject
     {
         SaveSettings();
         OkPressed = true;
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -157,7 +174,6 @@ public partial class BridgeGapsViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
+++ b/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
@@ -63,18 +63,20 @@ public partial class FixNamesViewModel : ObservableObject
         Subtitle = new Subtitle();
 
         _previewTimer = new System.Timers.Timer(500);
-        _previewTimer.Elapsed += (sender, args) =>
+        _previewTimer.Elapsed += PreviewTimerElapsed;
+    }
+
+    private void PreviewTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        var namesString = string.Join(' ', Names.Where(p => p.IsChecked).Select(p => p.Name));
+        if (namesString != _oldNames && !_loading)
         {
-            var namesString = string.Join(' ', Names.Where(p => p.IsChecked).Select(p => p.Name));
-            if (namesString != _oldNames && !_loading)
+            lock (_lock)
             {
-                lock (_lock)
-                {
-                    GeneratePreview();
-                    _oldNames = namesString;
-                }
+                GeneratePreview();
+                _oldNames = namesString;
             }
-        };
+        }
     }
 
     internal void Initialize(Subtitle subtitle)
@@ -268,12 +270,14 @@ public partial class FixNamesViewModel : ObservableObject
         Info = $"Change casing - lines changed: {noOfLinesChanged}";
 
         OkPressed = true;
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     public void Cancel()
     {
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 

--- a/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
+++ b/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
@@ -17,7 +17,7 @@ using System.Threading;
 
 namespace Nikse.SubtitleEdit.Features.Tools.ChangeCasing;
 
-public partial class FixNamesViewModel : ObservableObject
+public partial class FixNamesViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<FixNameItem> _names;
     [ObservableProperty] private ObservableCollection<FixNameHitItem> _hits;
@@ -77,6 +77,11 @@ public partial class FixNamesViewModel : ObservableObject
                 _oldNames = namesString;
             }
         }
+    }
+
+    public void OnClosingCleanup()
+    {
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
     }
 
     internal void Initialize(Subtitle subtitle)
@@ -270,14 +275,12 @@ public partial class FixNamesViewModel : ObservableObject
         Info = $"Change casing - lines changed: {noOfLinesChanged}";
 
         OkPressed = true;
-        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     public void Cancel()
     {
-        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 

--- a/src/ui/Features/Tools/ChangeFormatting/ChangeFormattingViewModel.cs
+++ b/src/ui/Features/Tools/ChangeFormatting/ChangeFormattingViewModel.cs
@@ -49,16 +49,18 @@ public partial class ChangeFormattingViewModel : ObservableObject
         LoadSettings();
 
         _timerUpdatePreview = new System.Timers.Timer(500);
-        _timerUpdatePreview.Elapsed += (s, e) =>
+        _timerUpdatePreview.Elapsed += TimerUpdatePreviewElapsed;
+    }
+
+    private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        _timerUpdatePreview.Stop();
+        if (_dirty)
         {
-            _timerUpdatePreview.Stop();
-            if (_dirty)
-            {
-                _dirty = false;
-                UpdatePreview();
-            }
-            _timerUpdatePreview.Start();
-        };
+            _dirty = false;
+            UpdatePreview();
+        }
+        _timerUpdatePreview.Start();
     }
 
     private void UpdatePreview()
@@ -120,12 +122,14 @@ public partial class ChangeFormattingViewModel : ObservableObject
         FixedSubtitle = Subtitles.Select(p => new SubtitleLineViewModel(p.SubtitleLineViewModel)).ToList();
         SaveSettings();
         OkPressed = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -134,6 +138,7 @@ public partial class ChangeFormattingViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/ChangeFormatting/ChangeFormattingViewModel.cs
+++ b/src/ui/Features/Tools/ChangeFormatting/ChangeFormattingViewModel.cs
@@ -14,7 +14,7 @@ using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Tools.ChangeFormatting;
 
-public partial class ChangeFormattingViewModel : ObservableObject
+public partial class ChangeFormattingViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<ChangeFormattingDisplayItem> _subtitles;
     [ObservableProperty] private ChangeFormattingDisplayItem? _selectedSubtitle;
@@ -34,6 +34,7 @@ public partial class ChangeFormattingViewModel : ObservableObject
     public List<SubtitleLineViewModel> FixedSubtitle { get; set; }
 
     private readonly System.Timers.Timer _timerUpdatePreview;
+    private volatile bool _isClosing;
     private bool _dirty;
     private SubtitleFormat _format = new SubRip();
 
@@ -54,13 +55,31 @@ public partial class ChangeFormattingViewModel : ObservableObject
 
     private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _timerUpdatePreview.Stop();
         if (_dirty)
         {
             _dirty = false;
             UpdatePreview();
         }
-        _timerUpdatePreview.Start();
+
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this handler ran,
+        // and Start() on a disposed timer throws ObjectDisposedException (no longer swallowed on
+        // modern .NET), crashing the app from a thread-pool thread. (#12739)
+        if (!_isClosing)
+        {
+            _timerUpdatePreview.Start();
+        }
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
     }
 
     private void UpdatePreview()
@@ -122,14 +141,12 @@ public partial class ChangeFormattingViewModel : ObservableObject
         FixedSubtitle = Subtitles.Select(p => new SubtitleLineViewModel(p.SubtitleLineViewModel)).ToList();
         SaveSettings();
         OkPressed = true;
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -138,7 +155,6 @@ public partial class ChangeFormattingViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/ConvertActors/ConvertActorsViewModel.cs
+++ b/src/ui/Features/Tools/ConvertActors/ConvertActorsViewModel.cs
@@ -15,7 +15,7 @@ using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Tools.ConvertActors;
 
-public partial class ConvertActorsViewModel : ObservableObject
+public partial class ConvertActorsViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<ConvertActorsDisplayItem> _subtitles;
     [ObservableProperty] private ConvertActorsDisplayItem? _selectedSubtitle;
@@ -38,6 +38,7 @@ public partial class ConvertActorsViewModel : ObservableObject
     public List<SubtitleLineViewModel> FixedSubtitle { get; set; }
 
     private readonly System.Timers.Timer _timerUpdatePreview;
+    private volatile bool _isClosing;
     private bool _dirty;
     private SubtitleFormat _format = new SubRip();
 
@@ -66,13 +67,31 @@ public partial class ConvertActorsViewModel : ObservableObject
 
     private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _timerUpdatePreview.Stop();
         if (_dirty)
         {
             _dirty = false;
             UpdatePreview();
         }
-        _timerUpdatePreview.Start();
+
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this handler ran,
+        // and Start() on a disposed timer throws ObjectDisposedException (no longer swallowed on
+        // modern .NET), crashing the app from a thread-pool thread. (#12739)
+        if (!_isClosing)
+        {
+            _timerUpdatePreview.Start();
+        }
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
     }
 
     partial void OnSelectedFromTypeChanged(ConvertActorTypeDisplay? value) => _dirty = true;
@@ -267,8 +286,6 @@ public partial class ConvertActorsViewModel : ObservableObject
     [RelayCommand]
     private void Ok()
     {
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
-
         var checkedChanges = Subtitles
             .Where(s => s.IsChecked && !s.IsNextParagraph)
             .ToDictionary(s => s.OriginalId, s => s);
@@ -316,7 +333,6 @@ public partial class ConvertActorsViewModel : ObservableObject
     [RelayCommand]
     private void Cancel()
     {
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -325,7 +341,6 @@ public partial class ConvertActorsViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/ConvertActors/ConvertActorsViewModel.cs
+++ b/src/ui/Features/Tools/ConvertActors/ConvertActorsViewModel.cs
@@ -61,16 +61,18 @@ public partial class ConvertActorsViewModel : ObservableObject
         LoadSettings();
 
         _timerUpdatePreview = new System.Timers.Timer(500);
-        _timerUpdatePreview.Elapsed += (s, e) =>
+        _timerUpdatePreview.Elapsed += TimerUpdatePreviewElapsed;
+    }
+
+    private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        _timerUpdatePreview.Stop();
+        if (_dirty)
         {
-            _timerUpdatePreview.Stop();
-            if (_dirty)
-            {
-                _dirty = false;
-                UpdatePreview();
-            }
-            _timerUpdatePreview.Start();
-        };
+            _dirty = false;
+            UpdatePreview();
+        }
+        _timerUpdatePreview.Start();
     }
 
     partial void OnSelectedFromTypeChanged(ConvertActorTypeDisplay? value) => _dirty = true;
@@ -265,7 +267,7 @@ public partial class ConvertActorsViewModel : ObservableObject
     [RelayCommand]
     private void Ok()
     {
-        _timerUpdatePreview.Stop();
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
 
         var checkedChanges = Subtitles
             .Where(s => s.IsChecked && !s.IsNextParagraph)
@@ -314,7 +316,7 @@ public partial class ConvertActorsViewModel : ObservableObject
     [RelayCommand]
     private void Cancel()
     {
-        _timerUpdatePreview.Stop();
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -323,7 +325,7 @@ public partial class ConvertActorsViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _timerUpdatePreview.Stop();
+            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesViewModel.cs
+++ b/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesViewModel.cs
@@ -11,7 +11,7 @@ using System.Collections.ObjectModel;
 
 namespace Nikse.SubtitleEdit.Features.Tools.MergeContinuationLines;
 
-public partial class MergeContinuationLinesViewModel : ObservableObject
+public partial class MergeContinuationLinesViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<MergeContinuationLinesCandidate> _candidates;
     [ObservableProperty] private MergeContinuationLinesCandidate? _selectedCandidate;
@@ -27,6 +27,7 @@ public partial class MergeContinuationLinesViewModel : ObservableObject
     private List<SubtitleLineViewModel> _allSubtitles;
     private string? _language;
     private readonly System.Timers.Timer _previewTimer;
+    private volatile bool _isClosing;
     private bool _isDirty;
 
     public MergeContinuationLinesViewModel()
@@ -45,13 +46,29 @@ public partial class MergeContinuationLinesViewModel : ObservableObject
 
     private void PreviewTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _previewTimer.Stop();
         if (_isDirty)
         {
             _isDirty = false;
             UpdatePreview();
         }
-        _previewTimer.Start();
+
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this handler ran (#12739).
+        if (!_isClosing)
+        {
+            _previewTimer.Start();
+        }
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
     }
 
     public void Initialize(List<SubtitleLineViewModel> subtitles, string? language, int? maxGapMs = null, int? maxCharacters = null)
@@ -97,22 +114,13 @@ public partial class MergeContinuationLinesViewModel : ObservableObject
     {
         AllSubtitlesFixed = MergeContinuationLinesHelper.Apply(_allSubtitles, Candidates, _language);
         OkPressed = true;
-        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
-        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
-    }
-
-    // Called from the window's Closed event. Stops the recurring preview timer so the VM
-    // (and the subtitles it references) can be garbage-collected after the dialog goes away.
-    internal void OnClosed()
-    {
-        _previewTimer.StopAndDispose(PreviewTimerElapsed);
     }
 
     [RelayCommand]
@@ -143,7 +151,6 @@ public partial class MergeContinuationLinesViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _previewTimer.StopAndDispose(PreviewTimerElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesViewModel.cs
+++ b/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesViewModel.cs
@@ -40,16 +40,18 @@ public partial class MergeContinuationLinesViewModel : ObservableObject
         MaxCharacters = Se.Settings.General.SubtitleLineMaximumLength * Se.Settings.General.MaxNumberOfLines;
 
         _previewTimer = new System.Timers.Timer(250);
-        _previewTimer.Elapsed += (_, _) =>
+        _previewTimer.Elapsed += PreviewTimerElapsed;
+    }
+
+    private void PreviewTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        _previewTimer.Stop();
+        if (_isDirty)
         {
-            _previewTimer.Stop();
-            if (_isDirty)
-            {
-                _isDirty = false;
-                UpdatePreview();
-            }
-            _previewTimer.Start();
-        };
+            _isDirty = false;
+            UpdatePreview();
+        }
+        _previewTimer.Start();
     }
 
     public void Initialize(List<SubtitleLineViewModel> subtitles, string? language, int? maxGapMs = null, int? maxCharacters = null)
@@ -95,12 +97,14 @@ public partial class MergeContinuationLinesViewModel : ObservableObject
     {
         AllSubtitlesFixed = MergeContinuationLinesHelper.Apply(_allSubtitles, Candidates, _language);
         OkPressed = true;
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
@@ -108,8 +112,7 @@ public partial class MergeContinuationLinesViewModel : ObservableObject
     // (and the subtitles it references) can be garbage-collected after the dialog goes away.
     internal void OnClosed()
     {
-        _previewTimer.Stop();
-        _previewTimer.Dispose();
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
     }
 
     [RelayCommand]
@@ -140,6 +143,7 @@ public partial class MergeContinuationLinesViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _previewTimer.StopAndDispose(PreviewTimerElapsed);
             Window?.Close();
         }
     }

--- a/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
+++ b/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
@@ -61,7 +61,6 @@ public class MergeContinuationLinesWindow : Window
         Activated += delegate { buttonOk.Focus(); };
         KeyDown += vm.KeyDown;
         Loaded += delegate { vm.Loaded(); };
-        Closed += delegate { vm.OnClosed(); };
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };
         Loaded += delegate { UiUtil.RestoreWindowPosition(this); };

--- a/src/ui/Features/Tools/MergeShortLines/MergeShortLinesViewModel.cs
+++ b/src/ui/Features/Tools/MergeShortLines/MergeShortLinesViewModel.cs
@@ -11,7 +11,7 @@ using System.Collections.ObjectModel;
 
 namespace Nikse.SubtitleEdit.Features.Tools.MergeShortLines;
 
-public partial class MergeShortLinesViewModel : ObservableObject
+public partial class MergeShortLinesViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<MergeShortLinesItem> _fixes;
     [ObservableProperty] private MergeShortLinesItem? _selectedFix;
@@ -32,6 +32,7 @@ public partial class MergeShortLinesViewModel : ObservableObject
     private List<SubtitleLineViewModel> _allSubtitles;
 
     private readonly System.Timers.Timer _previewTimer;
+    private volatile bool _isClosing;
     private bool _isDirty;
     private List<double> _shotChanges;
 
@@ -52,6 +53,11 @@ public partial class MergeShortLinesViewModel : ObservableObject
 
     private void PreviewTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _previewTimer.Stop();
 
         if (_isDirty)
@@ -60,7 +66,17 @@ public partial class MergeShortLinesViewModel : ObservableObject
             UpdatePreview();
         }
 
-        _previewTimer.Start();
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this handler ran (#12739).
+        if (!_isClosing)
+        {
+            _previewTimer.Start();
+        }
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
     }
 
     private void UpdatePreview()
@@ -136,14 +152,12 @@ public partial class MergeShortLinesViewModel : ObservableObject
 
         SaveSettings();
         OkPressed = true;
-        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
-        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
@@ -152,7 +166,6 @@ public partial class MergeShortLinesViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _previewTimer.StopAndDispose(PreviewTimerElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/MergeShortLines/MergeShortLinesViewModel.cs
+++ b/src/ui/Features/Tools/MergeShortLines/MergeShortLinesViewModel.cs
@@ -47,18 +47,20 @@ public partial class MergeShortLinesViewModel : ObservableObject
         LoadSettings();
 
         _previewTimer = new System.Timers.Timer(250);
-        _previewTimer.Elapsed += (sender, args) =>
+        _previewTimer.Elapsed += PreviewTimerElapsed;
+    }
+
+    private void PreviewTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        _previewTimer.Stop();
+
+        if (_isDirty)
         {
-            _previewTimer.Stop();
+            _isDirty = false;
+            UpdatePreview();
+        }
 
-            if (_isDirty)
-            {
-                _isDirty = false;
-                UpdatePreview();
-            }
-
-            _previewTimer.Start();
-        };
+        _previewTimer.Start();
     }
 
     private void UpdatePreview()
@@ -134,12 +136,14 @@ public partial class MergeShortLinesViewModel : ObservableObject
 
         SaveSettings();
         OkPressed = true;
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
@@ -148,6 +152,7 @@ public partial class MergeShortLinesViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _previewTimer.StopAndDispose(PreviewTimerElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/MergeSubtitlesWithSameText/MergeSameTextViewModel.cs
+++ b/src/ui/Features/Tools/MergeSubtitlesWithSameText/MergeSameTextViewModel.cs
@@ -13,7 +13,7 @@ using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Tools.MergeSubtitlesWithSameText;
 
-public partial class MergeSameTextViewModel : ObservableObject
+public partial class MergeSameTextViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<MergeDisplayItem> _mergeItems;
     [ObservableProperty] private MergeDisplayItem? _selectedMergeItem;
@@ -30,6 +30,7 @@ public partial class MergeSameTextViewModel : ObservableObject
     public DataGrid SubtitleGrid { get; set; }
 
     private readonly System.Timers.Timer _timerUpdatePreview;
+    private volatile bool _isClosing;
     private bool _dirty;
     private List<SubtitleLineViewModel> _subtitles;
 
@@ -49,6 +50,11 @@ public partial class MergeSameTextViewModel : ObservableObject
 
     private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _timerUpdatePreview.Stop();
         if (_dirty)
         {
@@ -58,7 +64,18 @@ public partial class MergeSameTextViewModel : ObservableObject
                 UpdatePreview();
             });
         }
-        _timerUpdatePreview.Start();
+
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this handler ran (#12739).
+        if (!_isClosing)
+        {
+            _timerUpdatePreview.Start();
+        }
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
     }
 
     public void Initialize(List<SubtitleLineViewModel> subtitles)
@@ -240,14 +257,12 @@ public partial class MergeSameTextViewModel : ObservableObject
         SaveSettings();
         ResultSubtitles = BuildResultSubtitles();
         OkPressed = true;
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -279,7 +294,6 @@ public partial class MergeSameTextViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/MergeSubtitlesWithSameText/MergeSameTextViewModel.cs
+++ b/src/ui/Features/Tools/MergeSubtitlesWithSameText/MergeSameTextViewModel.cs
@@ -44,19 +44,21 @@ public partial class MergeSameTextViewModel : ObservableObject
 
         _subtitles = new List<SubtitleLineViewModel>();
         _timerUpdatePreview = new System.Timers.Timer(250);
-        _timerUpdatePreview.Elapsed += (s, e) =>
+        _timerUpdatePreview.Elapsed += TimerUpdatePreviewElapsed;
+    }
+
+    private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        _timerUpdatePreview.Stop();
+        if (_dirty)
         {
-            _timerUpdatePreview.Stop();
-            if (_dirty)
+            Dispatcher.UIThread.Invoke(() =>
             {
-                Dispatcher.UIThread.Invoke(() =>
-                {
-                    _dirty = false;
-                    UpdatePreview();
-                });
-            }
-            _timerUpdatePreview.Start();
-        };
+                _dirty = false;
+                UpdatePreview();
+            });
+        }
+        _timerUpdatePreview.Start();
     }
 
     public void Initialize(List<SubtitleLineViewModel> subtitles)
@@ -238,12 +240,14 @@ public partial class MergeSameTextViewModel : ObservableObject
         SaveSettings();
         ResultSubtitles = BuildResultSubtitles();
         OkPressed = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -275,6 +279,7 @@ public partial class MergeSameTextViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/MergeSubtitlesWithSameTimeCodes/MergeSameTimeCodesViewModel.cs
+++ b/src/ui/Features/Tools/MergeSubtitlesWithSameTimeCodes/MergeSameTimeCodesViewModel.cs
@@ -48,19 +48,21 @@ public partial class MergeSameTimeCodesViewModel : ObservableObject
         _language = "en";
         _subtitles = new List<SubtitleLineViewModel>();
         _timerUpdatePreview = new System.Timers.Timer(500);
-        _timerUpdatePreview.Elapsed += (s, e) =>
+        _timerUpdatePreview.Elapsed += TimerUpdatePreviewElapsed;
+    }
+
+    private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        _timerUpdatePreview.Stop();
+        if (_dirty)
         {
-            _timerUpdatePreview.Stop();
-            if (_dirty)
+            Dispatcher.UIThread.Invoke(() =>
             {
-                Dispatcher.UIThread.Invoke(() =>
-                {
-                    _dirty = false;
-                    UpdatePreview();
-                });
-            }
-            _timerUpdatePreview.Start();
-        };
+                _dirty = false;
+                UpdatePreview();
+            });
+        }
+        _timerUpdatePreview.Start();
     }
 
     public void Initialize(List<SubtitleLineViewModel> subtitles, Subtitle subtitle)
@@ -283,12 +285,14 @@ public partial class MergeSameTimeCodesViewModel : ObservableObject
         SaveSettings();
         ResultSubtitles = BuildResultSubtitles();
         OkPressed = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -320,6 +324,7 @@ public partial class MergeSameTimeCodesViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/MergeSubtitlesWithSameTimeCodes/MergeSameTimeCodesViewModel.cs
+++ b/src/ui/Features/Tools/MergeSubtitlesWithSameTimeCodes/MergeSameTimeCodesViewModel.cs
@@ -14,7 +14,7 @@ using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Tools.MergeSubtitlesWithSameTimeCodes;
 
-public partial class MergeSameTimeCodesViewModel : ObservableObject
+public partial class MergeSameTimeCodesViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<MergeDisplayItem> _mergeItems;
     [ObservableProperty] private MergeDisplayItem? _selectedMergeItem;
@@ -32,6 +32,7 @@ public partial class MergeSameTimeCodesViewModel : ObservableObject
     public DataGrid SubtitleGrid { get; set; }
 
     private readonly System.Timers.Timer _timerUpdatePreview;
+    private volatile bool _isClosing;
     private bool _dirty;
     private string _language;
     private List<SubtitleLineViewModel> _subtitles;
@@ -53,6 +54,11 @@ public partial class MergeSameTimeCodesViewModel : ObservableObject
 
     private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _timerUpdatePreview.Stop();
         if (_dirty)
         {
@@ -62,7 +68,18 @@ public partial class MergeSameTimeCodesViewModel : ObservableObject
                 UpdatePreview();
             });
         }
-        _timerUpdatePreview.Start();
+
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this handler ran (#12739).
+        if (!_isClosing)
+        {
+            _timerUpdatePreview.Start();
+        }
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
     }
 
     public void Initialize(List<SubtitleLineViewModel> subtitles, Subtitle subtitle)
@@ -285,14 +302,12 @@ public partial class MergeSameTimeCodesViewModel : ObservableObject
         SaveSettings();
         ResultSubtitles = BuildResultSubtitles();
         OkPressed = true;
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -324,7 +339,6 @@ public partial class MergeSameTimeCodesViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/SortBy/SortByViewModel.cs
+++ b/src/ui/Features/Tools/SortBy/SortByViewModel.cs
@@ -59,7 +59,7 @@ public class SortCriterion : ObservableObject
     }
 }
 
-public partial class SortByViewModel : ObservableObject
+public partial class SortByViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<SubtitleLineViewModel> _subtitles;
     [ObservableProperty] private SubtitleLineViewModel? _selectedSubtitle;
@@ -75,6 +75,7 @@ public partial class SortByViewModel : ObservableObject
     public bool OkPressed { get; private set; }
 
     private readonly System.Timers.Timer _timerUpdatePreview;
+    private volatile bool _isClosing;
     private bool _dirty;
     private readonly List<SubtitleLineViewModel> _originalSubtitles;
     private Dictionary<string, string> _propertyTranslationMap;
@@ -100,13 +101,31 @@ public partial class SortByViewModel : ObservableObject
 
     private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _timerUpdatePreview.Stop();
         if (_dirty)
         {
             _dirty = false;
             UpdatePreview();
         }
-        _timerUpdatePreview.Start();
+
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this handler ran,
+        // and Start() on a disposed timer throws ObjectDisposedException (no longer swallowed on
+        // modern .NET), crashing the app from a thread-pool thread. (#12739)
+        if (!_isClosing)
+        {
+            _timerUpdatePreview.Start();
+        }
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
     }
 
     private void InitializeAvailableProperties()
@@ -366,14 +385,12 @@ public partial class SortByViewModel : ObservableObject
         
         SaveSettings();
         OkPressed = true;
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -382,7 +399,6 @@ public partial class SortByViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/SortBy/SortByViewModel.cs
+++ b/src/ui/Features/Tools/SortBy/SortByViewModel.cs
@@ -95,16 +95,18 @@ public partial class SortByViewModel : ObservableObject
         LoadSettings();
 
         _timerUpdatePreview = new System.Timers.Timer(500);
-        _timerUpdatePreview.Elapsed += (s, e) =>
+        _timerUpdatePreview.Elapsed += TimerUpdatePreviewElapsed;
+    }
+
+    private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        _timerUpdatePreview.Stop();
+        if (_dirty)
         {
-            _timerUpdatePreview.Stop();
-            if (_dirty)
-            {
-                _dirty = false;
-                UpdatePreview();
-            }
-            _timerUpdatePreview.Start();
-        };
+            _dirty = false;
+            UpdatePreview();
+        }
+        _timerUpdatePreview.Start();
     }
 
     private void InitializeAvailableProperties()
@@ -364,12 +366,14 @@ public partial class SortByViewModel : ObservableObject
         
         SaveSettings();
         OkPressed = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -378,6 +382,7 @@ public partial class SortByViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
@@ -13,7 +13,7 @@ using System.Collections.ObjectModel;
 
 namespace Nikse.SubtitleEdit.Features.Tools.SplitBreakLongLines;
 
-public partial class SplitBreakLongLinesViewModel : ObservableObject
+public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<SplitBreakLongLinesItem> _fixes;
     [ObservableProperty] private SplitBreakLongLinesItem? _selectedFix;
@@ -36,6 +36,7 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject
     private List<SubtitleLineViewModel> _allSubtitles;
 
     private readonly System.Timers.Timer _previewTimer;
+    private volatile bool _isClosing;
     private bool _isDirty;
 
     public SplitBreakLongLinesViewModel()
@@ -54,6 +55,11 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject
 
     private void PreviewTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _previewTimer.Stop();
 
         if (_isDirty)
@@ -62,7 +68,19 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject
             UpdatePreview();
         }
 
-        _previewTimer.Start();
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this handler ran,
+        // and Start() on a disposed timer throws ObjectDisposedException (no longer swallowed on
+        // modern .NET), crashing the app from a thread-pool thread. (#12739)
+        if (!_isClosing)
+        {
+            _previewTimer.Start();
+        }
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
     }
 
     private void UpdatePreview()
@@ -584,14 +602,12 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject
 
         SaveSettings();
         OkPressed = true;
-        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
-        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
@@ -600,7 +616,6 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _previewTimer.StopAndDispose(PreviewTimerElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
@@ -49,18 +49,20 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject
         LoadSettings();
 
         _previewTimer = new System.Timers.Timer(250);
-        _previewTimer.Elapsed += (sender, args) =>
+        _previewTimer.Elapsed += PreviewTimerElapsed;
+    }
+
+    private void PreviewTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        _previewTimer.Stop();
+
+        if (_isDirty)
         {
-            _previewTimer.Stop();
+            _isDirty = false;
+            UpdatePreview();
+        }
 
-            if (_isDirty)
-            {
-                _isDirty = false;
-                UpdatePreview();
-            }
-
-            _previewTimer.Start();
-        };
+        _previewTimer.Start();
     }
 
     private void UpdatePreview()
@@ -582,12 +584,14 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject
 
         SaveSettings();
         OkPressed = true;
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
+        _previewTimer.StopAndDispose(PreviewTimerElapsed);
         Window?.Close();
     }
 
@@ -596,6 +600,7 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _previewTimer.StopAndDispose(PreviewTimerElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/SplitSubtitle/SplitSubtitleViewModel.cs
+++ b/src/ui/Features/Tools/SplitSubtitle/SplitSubtitleViewModel.cs
@@ -71,16 +71,18 @@ public partial class SplitSubtitleViewModel : ObservableObject
         LoadSettings();
 
         _timerUpdatePreview = new System.Timers.Timer(500);
-        _timerUpdatePreview.Elapsed += (s, e) =>
+        _timerUpdatePreview.Elapsed += TimerUpdatePreviewElapsed;
+    }
+
+    private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        _timerUpdatePreview.Stop();
+        if (_dirty)
         {
-            _timerUpdatePreview.Stop();
-            if (_dirty)
-            {
-                _dirty = false;
-                UpdateSplit();
-            }
-            _timerUpdatePreview.Start();
-        };
+            _dirty = false;
+            UpdateSplit();
+        }
+        _timerUpdatePreview.Start();
     }
 
     public void Initialize(string fileName, Subtitle subtitle)
@@ -200,12 +202,14 @@ public partial class SplitSubtitleViewModel : ObservableObject
         });
 
         OkPressed = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -301,6 +305,7 @@ public partial class SplitSubtitleViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Tools/SplitSubtitle/SplitSubtitleViewModel.cs
+++ b/src/ui/Features/Tools/SplitSubtitle/SplitSubtitleViewModel.cs
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Tools.SplitSubtitle;
 
-public partial class SplitSubtitleViewModel : ObservableObject
+public partial class SplitSubtitleViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<SplitDisplayItem> _splitItems;
     [ObservableProperty] private SplitDisplayItem? _selectedSpiltItem;
@@ -44,6 +44,7 @@ public partial class SplitSubtitleViewModel : ObservableObject
     private string _subtitleFileName;
     private List<Subtitle> _parts;
     private readonly System.Timers.Timer _timerUpdatePreview;
+    private volatile bool _isClosing;
     private bool _dirty;
     private bool _loading;
 
@@ -76,13 +77,31 @@ public partial class SplitSubtitleViewModel : ObservableObject
 
     private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _timerUpdatePreview.Stop();
         if (_dirty)
         {
             _dirty = false;
             UpdateSplit();
         }
-        _timerUpdatePreview.Start();
+
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this handler ran,
+        // and Start() on a disposed timer throws ObjectDisposedException (no longer swallowed on
+        // modern .NET), crashing the app from a thread-pool thread. (#12739)
+        if (!_isClosing)
+        {
+            _timerUpdatePreview.Start();
+        }
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
     }
 
     public void Initialize(string fileName, Subtitle subtitle)
@@ -202,14 +221,12 @@ public partial class SplitSubtitleViewModel : ObservableObject
         });
 
         OkPressed = true;
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
     [RelayCommand]
     private void Cancel()
     {
-        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
         Window?.Close();
     }
 
@@ -305,7 +322,6 @@ public partial class SplitSubtitleViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
+++ b/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
@@ -876,6 +876,7 @@ public partial class CutVideoViewModel : ObservableObject
     internal void OnClosing()
     {
         _positionTimer.Stop();
+        _timerGenerate.StopAndDispose(TimerGenerateElapsed);
         VideoPlayer.VideoPlayer.CloseFile();
 
         if (_ffmpegListKeyFramesProcess != null && !_ffmpegListKeyFramesProcess.HasExited)

--- a/src/ui/Features/Video/OpenFromUrl/DownloadVideoFromUrlViewModel.cs
+++ b/src/ui/Features/Video/OpenFromUrl/DownloadVideoFromUrlViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
 using System;
@@ -238,7 +239,7 @@ public partial class DownloadVideoFromUrlViewModel : ObservableObject
 
             if (_downloadTask.IsCompletedSuccessfully)
             {
-                _timer.Stop();
+                _timer.StopAndDispose(OnTimerElapsed);
                 _done = true;
                 Success = File.Exists(OutputPath);
                 if (!Success)
@@ -252,7 +253,7 @@ public partial class DownloadVideoFromUrlViewModel : ObservableObject
             }
             else if (_downloadTask.IsFaulted)
             {
-                _timer.Stop();
+                _timer.StopAndDispose(OnTimerElapsed);
                 _done = true;
 
                 var ex = _downloadTask.Exception?.InnerException ?? _downloadTask.Exception;
@@ -272,7 +273,7 @@ public partial class DownloadVideoFromUrlViewModel : ObservableObject
             }
             else if (_downloadTask.IsCanceled)
             {
-                _timer.Stop();
+                _timer.StopAndDispose(OnTimerElapsed);
                 _done = true;
                 TryDeletePartial();
                 Close();

--- a/src/ui/Features/Video/OpenFromUrl/DownloadVideoFromUrlViewModel.cs
+++ b/src/ui/Features/Video/OpenFromUrl/DownloadVideoFromUrlViewModel.cs
@@ -18,7 +18,7 @@ using Timer = System.Timers.Timer;
 
 namespace Nikse.SubtitleEdit.Features.Video.OpenFromUrl;
 
-public partial class DownloadVideoFromUrlViewModel : ObservableObject
+public partial class DownloadVideoFromUrlViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private double _progress;
     [ObservableProperty] private string _statusText;
@@ -239,7 +239,7 @@ public partial class DownloadVideoFromUrlViewModel : ObservableObject
 
             if (_downloadTask.IsCompletedSuccessfully)
             {
-                _timer.StopAndDispose(OnTimerElapsed);
+                _timer.Stop();
                 _done = true;
                 Success = File.Exists(OutputPath);
                 if (!Success)
@@ -253,7 +253,7 @@ public partial class DownloadVideoFromUrlViewModel : ObservableObject
             }
             else if (_downloadTask.IsFaulted)
             {
-                _timer.StopAndDispose(OnTimerElapsed);
+                _timer.Stop();
                 _done = true;
 
                 var ex = _downloadTask.Exception?.InnerException ?? _downloadTask.Exception;
@@ -273,7 +273,7 @@ public partial class DownloadVideoFromUrlViewModel : ObservableObject
             }
             else if (_downloadTask.IsCanceled)
             {
-                _timer.StopAndDispose(OnTimerElapsed);
+                _timer.Stop();
                 _done = true;
                 TryDeletePartial();
                 Close();
@@ -311,6 +311,11 @@ public partial class DownloadVideoFromUrlViewModel : ObservableObject
 
         _cancellationTokenSource.Cancel();
         // Let the timer pick up the cancellation and close cleanly.
+    }
+
+    public void OnClosingCleanup()
+    {
+        _timer.StopAndDispose(OnTimerElapsed);
     }
 
     private void Close()

--- a/src/ui/Features/Video/ShotChanges/ShotChangesViewModel.cs
+++ b/src/ui/Features/Video/ShotChanges/ShotChangesViewModel.cs
@@ -25,7 +25,7 @@ using System.Xml;
 
 namespace Nikse.SubtitleEdit.Features.Video.ShotChanges;
 
-public partial class ShotChangesViewModel : ObservableObject
+public partial class ShotChangesViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<TimeItem> _ffmpegLines;
     [ObservableProperty] private TimeItem? _selectedFfmpegLine;
@@ -250,7 +250,6 @@ public partial class ShotChangesViewModel : ObservableObject
         {
             SaveSettings();
             OkPressed = true;
-            _timerGenerate.StopAndDispose(TimerGenerateElapsed);
             Window?.Close();
         });
     }
@@ -264,8 +263,12 @@ public partial class ShotChangesViewModel : ObservableObject
             return;
         }
 
-        _timerGenerate.StopAndDispose(TimerGenerateElapsed);
         Window?.Close();
+    }
+
+    public void OnClosingCleanup()
+    {
+        _timerGenerate.StopAndDispose(TimerGenerateElapsed);
     }
 
     /// <summary>
@@ -500,7 +503,6 @@ public partial class ShotChangesViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            _timerGenerate.StopAndDispose(TimerGenerateElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Video/ShotChanges/ShotChangesViewModel.cs
+++ b/src/ui/Features/Video/ShotChanges/ShotChangesViewModel.cs
@@ -250,6 +250,7 @@ public partial class ShotChangesViewModel : ObservableObject
         {
             SaveSettings();
             OkPressed = true;
+            _timerGenerate.StopAndDispose(TimerGenerateElapsed);
             Window?.Close();
         });
     }
@@ -263,6 +264,7 @@ public partial class ShotChangesViewModel : ObservableObject
             return;
         }
 
+        _timerGenerate.StopAndDispose(TimerGenerateElapsed);
         Window?.Close();
     }
 
@@ -498,6 +500,7 @@ public partial class ShotChangesViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+            _timerGenerate.StopAndDispose(TimerGenerateElapsed);
             Window?.Close();
         }
         else if (UiUtil.IsHelp(e))

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -23,7 +23,7 @@ using Nikse.SubtitleEdit.UiLogic;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText;
 
-public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
+public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private string _titleText;
     [ObservableProperty] private double _progressOpacity;
@@ -54,6 +54,7 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
     private readonly ICrispAsrDownloadService _crispAsrDownloadService;
     private Task? _downloadTask;
     private readonly Timer _timer;
+    private volatile bool _isClosing;
     private readonly CancellationTokenSource _cancellationTokenSource;
     private readonly MemoryStream _downloadStream;
 
@@ -109,6 +110,11 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
     {
         lock (_lockObj)
         {
+            if (_isClosing)
+            {
+                return;
+            }
+
             _timer.Stop();
             // IsCompletedSuccessfully (not the broader IsCompleted, which is also true for
             // Faulted/Canceled tasks) so a download that threw - e.g. Faster-Whisper-XXL's
@@ -253,7 +259,13 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
                 return;
             }
 
-            _timer.Start();
+            // Guard the restart: OnClosingCleanup may have disposed the timer while this
+            // handler ran, and Start() on a disposed timer throws ObjectDisposedException,
+            // crashing the app from a thread-pool thread. (#12739)
+            if (!_isClosing)
+            {
+                _timer.Start();
+            }
         }
     }
 
@@ -419,11 +431,16 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
 
     private void Close()
     {
-        _timer.StopAndDispose(OnTimerOnElapsed);
         Dispatcher.UIThread.Post(() =>
         {
             Window?.Close();
         });
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _timer.StopAndDispose(OnTimerOnElapsed);
     }
 
     [RelayCommand]
@@ -435,7 +452,6 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
     private void Cancel()
     {
         _cancellationTokenSource?.Cancel();
-        _timer.Stop();
         StopIndeterminateProgress();
         Close();
     }

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -419,6 +419,7 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject
 
     private void Close()
     {
+        _timer.StopAndDispose(OnTimerOnElapsed);
         Dispatcher.UIThread.Post(() =>
         {
             Window?.Close();

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
@@ -26,7 +26,7 @@ using Timer = System.Timers.Timer;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText;
 
-public partial class DownloadSpeechToTextModelsViewModel : ObservableObject
+public partial class DownloadSpeechToTextModelsViewModel : ObservableObject, IClosingCleanup
 {
 
     [ObservableProperty] private ObservableCollection<SpeechToTextModelDisplay> _models;
@@ -55,6 +55,7 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject
 
     private const string TemporaryFileExtension = ".$$$";
     private readonly Timer _timer;
+    private volatile bool _isClosing;
     private readonly CancellationTokenSource _cancellationTokenSource;
 
     public DownloadSpeechToTextModelsViewModel(IWhisperDownloadService whisperDownloadService, IFolderHelper folderHelper)
@@ -103,6 +104,11 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject
     {
         lock (_lockObj)
         {
+            if (_isClosing)
+            {
+                return;
+            }
+
             _timer.Stop();
 
             // IsCompletedSuccessfully, not the broader IsCompleted (also true for
@@ -145,7 +151,13 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject
                 return;
             }
 
-            _timer.Start();
+            // Guard the restart: OnClosingCleanup may have disposed the timer while this
+            // handler ran, and Start() on a disposed timer throws ObjectDisposedException,
+            // crashing the app from a thread-pool thread. (#12739)
+            if (!_isClosing)
+            {
+                _timer.Start();
+            }
         }
     }
 
@@ -169,7 +181,11 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject
             _downloadTask = _whisperDownloadService.DownloadFile(url, _downloadFileName, MakeDownloadProgress(), _cancellationTokenSource.Token);
             ProgressFileName = string.Format(Se.Language.General.FileNameX, Path.GetFileName(url));
             ProgressValue = 0;
-            _timer.Start();
+            // Guard the restart against a concurrent OnClosingCleanup disposal (#12739).
+            if (!_isClosing)
+            {
+                _timer.Start();
+            }
 
             return;
         }
@@ -261,18 +277,22 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject
 
     private void Close()
     {
-        _timer.StopAndDispose(OnTimerOnElapsed);
         Dispatcher.UIThread.Post(() =>
         {
             Window?.Close();
         });
     }
 
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _timer.StopAndDispose(OnTimerOnElapsed);
+    }
+
     [RelayCommand]
     private void Cancel()
     {
         _cancellationTokenSource?.Cancel();
-        _timer.Stop();
         OkPressed = false;
         Close();
     }

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
@@ -18,6 +18,7 @@ using Nikse.SubtitleEdit.Core.AudioToText;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.Logic.Media;
@@ -260,6 +261,7 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject
 
     private void Close()
     {
+        _timer.StopAndDispose(OnTimerOnElapsed);
         Dispatcher.UIThread.Post(() =>
         {
             Window?.Close();

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -4816,6 +4816,8 @@ public partial class SpeechToTextViewModel : ObservableObject
 
     internal void OnWindowClosing(WindowClosingEventArgs e)
     {
+        _timerWhisper.StopAndDispose(OnTimerWhisperOnElapsed);
+        _timerAudioExtract.StopAndDispose(OnTimerAudioExtractOnElapsed);
         UiUtil.SaveWindowPosition(Window);
         Task.Run(() => { DeleteTempFiles(); });
     }

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -2049,9 +2049,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     internal void OnClosing()
     {
         try { _cancellationTokenSource.Cancel(); } catch (ObjectDisposedException) { }
-        _timer.Stop();
-        _timer.Elapsed -= OnTimerOnElapsed;
-        _timer.Dispose();
+        _timer.StopAndDispose(OnTimerOnElapsed);
 
         DisposeQuietly(_downloadStream);
         DisposeQuietly(_downloadStreamModel);

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -75,6 +75,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     private string _omniVoiceVariant = OmniVoiceDownloadService.WindowsVariantVulkan;
     private string _qwen3TtsCppVariant = Qwen3TtsCppDownloadService.WindowsVariantVulkan;
     private readonly Timer _timer = new();
+    private volatile bool _isClosing;
 
     private readonly ITtsDownloadService _ttsDownloadService;
     private readonly IQwen3TtsCppDownloadService _qwen3TtsCppDownloadService;
@@ -173,6 +174,11 @@ public partial class DownloadTtsViewModel : ObservableObject
 
     private void OnTimerOnElapsed(object? sender, ElapsedEventArgs args)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         lock (_lock)
         {
             if (!_timer.Enabled)
@@ -372,7 +378,10 @@ public partial class DownloadTtsViewModel : ObservableObject
                 });
                 _downloadTaskQwen3TtsCppVoices = _qwen3TtsCppDownloadService.DownloadVoices(
                     _downloadStreamQwen3TtsCppVoices, voicesProgress, _cancellationTokenSource.Token);
-                _timer.Start();
+                if (!_isClosing)
+                {
+                    _timer.Start();
+                }
             }
             else if (_downloadTaskQwen3TtsCpp is { IsFaulted: true })
             {
@@ -2049,6 +2058,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     internal void OnClosing()
     {
         try { _cancellationTokenSource.Cancel(); } catch (ObjectDisposedException) { }
+        _isClosing = true;
         _timer.StopAndDispose(OnTimerOnElapsed);
 
         DisposeQuietly(_downloadStream);

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -1817,9 +1817,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
         var regenerateInFlight = !IsRegenerateEnabled;
 
         _skipAutoContinue = true;
-        _timer.Stop();
-        _timer.Elapsed -= OnTimerOnElapsed;
-        _timer.Dispose();
+        _timer.StopAndDispose(OnTimerOnElapsed);
         try { _cancellationTokenSource.Cancel(); } catch (ObjectDisposedException) { }
         if (!regenerateInFlight)
         {

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -119,6 +119,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
     private LibMpvDynamicPlayer? _mpvContext;
     private Lock _playLock;
     private readonly Timer _timer;
+    private volatile bool _isClosing;
     private string _videoFileName;
     private string _waveFolder;
     private CancellationTokenSource _cancellationTokenSource;
@@ -166,6 +167,11 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
     private async void OnTimerOnElapsed(object? sender, ElapsedEventArgs args)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         try
         {
             _timer.Stop();
@@ -248,7 +254,12 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 IsStopVisible = true;
             });
 
-            _timer.Start();
+            // OnClosing may have disposed the timer while this async handler awaited; Start() on a
+            // disposed timer throws ObjectDisposedException (no longer swallowed on modern .NET). (#12739)
+            if (!_isClosing)
+            {
+                _timer.Start();
+            }
         }
         catch (Exception ex)
         {
@@ -1817,6 +1828,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
         var regenerateInFlight = !IsRegenerateEnabled;
 
         _skipAutoContinue = true;
+        _isClosing = true;
         _timer.StopAndDispose(OnTimerOnElapsed);
         try { _cancellationTokenSource.Cancel(); } catch (ObjectDisposedException) { }
         if (!regenerateInFlight)

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeechHistory/ReviewSpeechHistoryViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeechHistory/ReviewSpeechHistoryViewModel.cs
@@ -198,7 +198,7 @@ public partial class ReviewSpeechHistoryViewModel : ObservableObject
 
     internal void OnWindowClosing(WindowClosingEventArgs e)
     {
-        _timer.Stop();
+        _timer.StopAndDispose(OnTimerOnElapsed);
         _cancellationTokenSource.Cancel();
         lock (_playLock)
         {

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeechHistory/ReviewSpeechHistoryViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeechHistory/ReviewSpeechHistoryViewModel.cs
@@ -30,6 +30,7 @@ public partial class ReviewSpeechHistoryViewModel : ObservableObject
     private LibMpvDynamicPlayer? _mpvContext;
     private Lock _playLock;
     private readonly System.Timers.Timer _timer;
+    private volatile bool _isClosing;
     private CancellationTokenSource _cancellationTokenSource;
     private CancellationToken _cancellationToken;
 
@@ -47,6 +48,11 @@ public partial class ReviewSpeechHistoryViewModel : ObservableObject
 
     private void OnTimerOnElapsed(object? sender, ElapsedEventArgs e)
     {
+        if (_isClosing)
+        {
+            return;
+        }
+
         _timer.Stop();
 
         // Same shape as the review window's watchdog: read mpv state under the lock (the
@@ -68,7 +74,12 @@ public partial class ReviewSpeechHistoryViewModel : ObservableObject
             return;
         }
 
-        _timer.Start();
+        // OnWindowClosing may have disposed the timer while this handler ran; Start() on a disposed
+        // timer throws ObjectDisposedException (no longer swallowed on modern .NET). (#12739)
+        if (!_isClosing)
+        {
+            _timer.Start();
+        }
     }
 
     private void StopPlay()
@@ -198,6 +209,7 @@ public partial class ReviewSpeechHistoryViewModel : ObservableObject
 
     internal void OnWindowClosing(WindowClosingEventArgs e)
     {
+        _isClosing = true;
         _timer.StopAndDispose(OnTimerOnElapsed);
         _cancellationTokenSource.Cancel();
         lock (_playLock)

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -3422,9 +3422,7 @@ public partial class TextToSpeechViewModel : ObservableObject
         // the rest of the session (ReviewSpeechViewModel already does this on close).
         try
         {
-            _timer.Stop();
-            _timer.Elapsed -= OnTimerOnElapsed;
-            _timer.Dispose();
+            _timer.StopAndDispose(OnTimerOnElapsed);
         }
         catch (Exception ex)
         {

--- a/src/ui/Logic/IClosingCleanup.cs
+++ b/src/ui/Logic/IClosingCleanup.cs
@@ -1,0 +1,16 @@
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Implemented by view models that own background <see cref="System.Timers.Timer"/>s (preview,
+/// debounce, download-progress, ...). <see cref="OnClosingCleanup"/> is invoked once from the
+/// window's <c>Closed</c> event (wired centrally in <see cref="UiUtil.InitializeWindow"/>), so the
+/// timers are stopped and disposed on every close path - OK/Cancel buttons, Escape, the title-bar
+/// close and Alt+F4 alike - without each view model having to hook them individually.
+///
+/// Implementations must be idempotent: the method may run after the view model has already torn its
+/// timers down through some other path.
+/// </summary>
+public interface IClosingCleanup
+{
+    void OnClosingCleanup();
+}

--- a/src/ui/Logic/TimerExtensions.cs
+++ b/src/ui/Logic/TimerExtensions.cs
@@ -1,0 +1,13 @@
+using System.Timers;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+public static class TimerExtensions
+{
+    public static void StopAndDispose(this Timer timer, ElapsedEventHandler elapsedHandler)
+    {
+        timer.Elapsed -= elapsedHandler;
+        timer.Stop();
+        timer.Dispose();
+    }
+}

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -2866,6 +2866,19 @@ public static class UiUtil
         window.Icon = GetSeIcon();
         window.Name = name;
 
+        // Stop and dispose any background timers the view model owns the moment the window closes,
+        // whatever the close path (buttons, Escape, title-bar X, Alt+F4). Without this a running
+        // System.Timers.Timer keeps its (captured) view model - and the whole closed window - alive
+        // and ticking. Wired here, in the one place every window funnels through, so individual
+        // dialogs don't each have to remember to do it. (#12739)
+        window.Closed += (_, _) =>
+        {
+            if (window.DataContext is IClosingCleanup cleanup)
+            {
+                cleanup.OnClosingCleanup();
+            }
+        };
+
         // On small or high-DPI screens (e.g. 1920x1080 at 150% = 1280x853 DIPs of
         // working area) SizeToContent windows can measure taller/wider than the screen,
         // leaving the bottom buttons unreachable - Avalonia does not cap them itself.


### PR DESCRIPTION
## Summary
- Add `TimerExtensions.StopAndDispose(this System.Timers.Timer, ElapsedEventHandler)` — unsubscribes the `Elapsed` handler, stops, and disposes the timer in one call
- Convert lambda `Elapsed` handlers to named instance methods across all dialog view models that run debounce/preview/progress `System.Timers.Timer`s, so the handler can be unsubscribed
- Call `StopAndDispose` in every window-close path (OK, Cancel, Escape, `OnClosing`/`Close()` funnels) — 51 view models across Tools, Video, Files, Shared, OCR, SpellCheck, SSA/ASSA, Options, and Edit features
- Prevents closed windows from being kept alive and ticking by their timers; extends the pattern started in #12715 (Convert Actors)
- Intentionally untouched: app-lifetime timers (`MainViewModel`, `AutoBackupService`), the locally-scoped `using var` timer in `VideoOcrViewModel`, and `DispatcherTimer`s

## Test plan
- [ ] Open a Tools dialog with a live preview (e.g. Bridge gaps, Merge short lines, Sort by, Change formatting), close via OK, Cancel, and Escape — no preview updates or errors after close, and reopening works normally
- [ ] Open Tools > Batch convert, add files, close via OK/Escape — the file scan timer no longer ticks after close
- [ ] Run a download dialog (e.g. FFmpeg, libmpv, Tesseract, Whisper models) to completion and also cancel one mid-download — no timer ticks after the window closes
- [ ] Video > Speech to text / Text to speech / Cut video / Shot changes: close mid-idle and after a run — no background activity remains
- [ ] File > Export (image based / plain text) and Import plain text: close each dialog and verify no further preview updates fire
- [ ] Spell check: close the window and confirm the status text timer stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)