### PR TITLE
Finalize v5.1.0-rc13 changelog

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -19,6 +19,10 @@ v5.1.0-rc13 (23rd of July 2026)
 * Add the missing help text for OpenAI-compatible server
 * Remove the dead Parakeet.cpp engine
 * Faster SHA-256 hashing and byte parsing via one-shot HashData and BinaryPrimitives - thx ivandrofly
+* Fix the waveform playhead drifting slightly forward or backward just after pausing - thx Davanix
+* Stop and dispose dialog timers on every window-close path, fixing a leak and a rare close-time crash - thx ivandrofly
+* OCR: keep the preview checkerboard backdrop out of the character grid
+* macOS: strip a stray .gitkeep from the app bundle so code signing succeeds
 
 -----------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
rc13 was prepared but never built/released (latest release is rc12). Four PRs merged since the rc13 prep and weren't in any changelog section yet — folding them into rc13 before cutting the build:

- #12742 — waveform playhead drift after pausing
- #12739 — dialog timer leak + rare close-time crash
- #12737 — OCR grid checkerboard
- #12736 — macOS bundle .gitkeep signing fix

No version bump (Se.cs is already v5.1.0-rc13). After merge I'll dispatch the UI release build for v5.1.0-rc13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)