### PR TITLE
seconv: add `dump-settings`, restore --settings schema docs, fix --help crash

### DIFF
--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -73,6 +73,7 @@ seconv list-encodings       # list text encodings
 seconv list-pac-codepages   # list PAC code pages
 seconv list-ocr-engines     # list OCR engines + installation status
 seconv list-fce-rules       # list FixCommonErrors rule IDs
+seconv dump-settings        # print a full --settings JSON with libse defaults
 seconv info <file>          # print format/encoding/duration/language for a file
 seconv lint <pattern>       # validate subtitle(s); exit 1 if issues found
 seconv --help               # show help
@@ -362,6 +363,14 @@ Available template tokens: `{title}`, `{number}`, `{start}`, `{end}`, `{duration
 
 #### Settings JSON
 
+> **This is seconv's own schema — not the Subtitle Edit GUI's `Settings.json`.** The desktop app's settings file uses different key names (e.g. the GUI's `IsRemoveTextUppercaseLineOn` is `removeIfAllUppercase` here) and a different structure; feeding it to `--settings` won't do what you expect (unrecognized keys are ignored with a warning). To get a correct starter file, run **`seconv dump-settings`** — it prints this whole schema populated with the current libse defaults:
+>
+> ```bash
+> seconv dump-settings > my-settings.json   # edit, then: --settings:my-settings.json
+> ```
+
+The keys and defaults below are exactly what `dump-settings` emits:
+
 ```json
 {
   "general": {
@@ -477,6 +486,10 @@ seconv movie.srt subrip --fix-common-errors-rules:FixCommas,FixMissingSpaces
 seconv movie.srt subrip --fix-common-errors-rules:all,-FixDanishLetterI      # all except one
 seconv list-fce-rules                                                        # show rule IDs
 ```
+
+**Language-specific rules.** A few rules only make sense for one language and mirror the GUI's *Fix Common Errors* window, which only offers them when the detected language matches: `FixAloneLowercaseIToUppercaseI` (English), `FixDanishLetterI` (Danish), `FixSpanishInvertedQuestionAndExclamationMarks` (Spanish), and `FixTurkishAnsiToUnicode` (Turkish). In the default all-rules pass these run only when auto-detection agrees, so e.g. the Spanish inverted-`¿` fix never lands on English content (issue #11037). Naming such a rule explicitly in `--fix-common-errors-rules` currently forces it on regardless of the detected language.
+
+**Rule selection is CLI-only.** The set of rules is chosen with `--fix-common-errors-rules`, not through the `--settings` JSON. The settings file shapes *how* the rules behave (line length, min gap, dialog/continuation style, CPS — see [Settings JSON](#settings-json)); it does not select which rules run.
 
 `FixCommonOcrErrors` is intentionally excluded — it requires UI-side spell-check and OCR-engine setup that seconv doesn't carry.
 

--- a/src/seconv/Core/SeConvSettings.cs
+++ b/src/seconv/Core/SeConvSettings.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Enums;
+using SkiaSharp;
 
 namespace SeConv.Core;
 
@@ -49,6 +50,112 @@ internal sealed class SeConvSettings
         return JsonSerializer.Deserialize<SeConvSettings>(json, JsonOptions)
             ?? throw new InvalidDataException($"Settings file is empty or null: {path}");
     }
+
+    /// <summary>
+    /// Serializes a complete settings file populated with the current libse defaults —
+    /// every key seconv understands, with its correct (camelCase) name and default value.
+    /// Backs <c>seconv dump-settings</c>, which users redirect to a file as a starting point
+    /// (issue #11037): it teaches the schema, so no one has to guess that the key is
+    /// <c>removeIfAllUppercase</c> and not the GUI's <c>IsRemoveTextUppercaseLineOn</c>.
+    /// <para>Built by mirroring <see cref="Configuration.Settings"/> (the same source
+    /// <see cref="ApplyBaseSections"/> writes back into) and a fresh <see cref="ImageExportStyle"/>,
+    /// so the output round-trips through <see cref="Load"/> with zero unknown keys — the dump
+    /// can never drift from what the loader accepts.</para>
+    /// </summary>
+    public static string DumpDefaults()
+    {
+        var s = Configuration.Settings;
+        var g = s.General;
+        var hi = s.RemoveTextForHearingImpaired;
+        var style = new ImageExportStyle();
+
+        var defaults = new SeConvSettings
+        {
+            General = new GeneralSection
+            {
+                SubtitleLineMaximumLength = g.SubtitleLineMaximumLength,
+                SubtitleMinimumDisplayMilliseconds = g.SubtitleMinimumDisplayMilliseconds,
+                SubtitleMaximumDisplayMilliseconds = g.SubtitleMaximumDisplayMilliseconds,
+                CurrentFrameRate = g.CurrentFrameRate,
+                DefaultFrameRate = g.DefaultFrameRate,
+                MinimumMillisecondsBetweenLines = g.MinimumMillisecondsBetweenLines,
+                MaxNumberOfLines = g.MaxNumberOfLines,
+                MergeLinesShorterThan = g.MergeLinesShorterThan,
+                SubtitleMaximumCharactersPerSeconds = g.SubtitleMaximumCharactersPerSeconds,
+                SubtitleOptimalCharactersPerSeconds = g.SubtitleOptimalCharactersPerSeconds,
+                SubtitleMaximumWordsPerMinute = g.SubtitleMaximumWordsPerMinute,
+                DialogStyle = g.DialogStyle.ToString(),
+                ContinuationStyle = g.ContinuationStyle.ToString(),
+            },
+            Tools = new ToolsSection
+            {
+                MergeShortLinesMaxGap = s.Tools.MergeShortLinesMaxGap,
+                MergeShortLinesOnlyContinuous = s.Tools.MergeShortLinesOnlyContinuous,
+            },
+            RemoveTextForHearingImpaired = new RemoveHiSection
+            {
+                RemoveTextBetweenBrackets = hi.RemoveTextBetweenBrackets,
+                RemoveTextBetweenParentheses = hi.RemoveTextBetweenParentheses,
+                RemoveTextBetweenCurlyBrackets = hi.RemoveTextBetweenCurlyBrackets,
+                RemoveTextBetweenQuestionMarks = hi.RemoveTextBetweenQuestionMarks,
+                RemoveTextBetweenCustom = hi.RemoveTextBetweenCustom,
+                RemoveTextBetweenCustomBefore = hi.RemoveTextBetweenCustomBefore,
+                RemoveTextBetweenCustomAfter = hi.RemoveTextBetweenCustomAfter,
+                RemoveTextBetweenOnlySeparateLines = hi.RemoveTextBetweenOnlySeparateLines,
+                RemoveTextBeforeColon = hi.RemoveTextBeforeColon,
+                RemoveTextBeforeColonOnlyIfUppercase = hi.RemoveTextBeforeColonOnlyIfUppercase,
+                RemoveTextBeforeColonOnlyOnSeparateLine = hi.RemoveTextBeforeColonOnlyOnSeparateLine,
+                RemoveInterjections = hi.RemoveInterjections,
+                RemoveInterjectionsOnlyOnSeparateLine = hi.RemoveInterjectionsOnlyOnSeparateLine,
+                RemoveIfContains = hi.RemoveIfContains,
+                RemoveIfAllUppercase = hi.RemoveIfAllUppercase,
+                RemoveIfContainsText = hi.RemoveIfContainsText,
+                RemoveIfOnlyMusicSymbols = hi.RemoveIfOnlyMusicSymbols,
+            },
+            ExportImages = new ExportImagesSection
+            {
+                FontName = style.FontName,
+                FontSize = style.FontSize,
+                FontColor = ToHex(style.FontColor),
+                IsBold = style.IsBold,
+                OutlineColor = ToHex(style.OutlineColor),
+                OutlineWidth = style.OutlineWidth,
+                ShadowColor = ToHex(style.ShadowColor),
+                ShadowWidth = style.ShadowWidth,
+                BackgroundColor = ToHex(style.BackgroundColor),
+                BackgroundCornerRadius = style.BackgroundCornerRadius,
+                // EffectiveBoxType resolves the null "auto" into the concrete default (none),
+                // so the dumped file shows a real, editable value rather than a blank.
+                BoxType = style.EffectiveBoxType.ToString(),
+                BoxPaddingLeft = style.BoxPaddingLeft,
+                BoxPaddingRight = style.BoxPaddingRight,
+                BoxPaddingTop = style.BoxPaddingTop,
+                BoxPaddingBottom = style.BoxPaddingBottom,
+                LineSpacingPercent = style.LineSpacingPercent,
+                Alignment = style.Alignment.ToString(),
+                ContentAlignment = style.ContentAlignment.ToString(),
+                // BottomTopMargin / LeftRightMargin left unset: their default is "5% of the
+                // screen", not a fixed pixel count, so there is no honest number to emit.
+            },
+        };
+
+        var options = new JsonSerializerOptions(JsonOptions)
+        {
+            WriteIndented = true,
+            // Omit the null "auto" values (margins) rather than writing `null`, so every key
+            // in the file is a concrete, copy-paste-ready default.
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            // Print non-ASCII (e.g. the ¶ HI separator) literally instead of as ¶ — this
+            // is a file for humans to read and edit. Safe here: the output is written to a file,
+            // not embedded in HTML.
+            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        };
+
+        return JsonSerializer.Serialize(defaults, options);
+    }
+
+    // "#AARRGGBB" — the fully-qualified form ExportImagesSection.ApplyTo parses back exactly.
+    private static string ToHex(SKColor c) => $"#{c.Alpha:X2}{c.Red:X2}{c.Green:X2}{c.Blue:X2}";
 
     /// <summary>
     /// Keys in the JSON that match no known section or property - typos, or keys from a newer

--- a/src/seconv/Helpers/HelpDisplay.cs
+++ b/src/seconv/Helpers/HelpDisplay.cs
@@ -98,6 +98,7 @@ internal static class HelpDisplay
         ShowParameter("list-pac-codepages", "List PAC code pages (--pac-codepage values)");
         ShowParameter("list-ocr-engines", "List OCR engines + installation status");
         ShowParameter("list-fce-rules", "List FixCommonErrors rule IDs");
+        ShowParameter("dump-settings", "Print a full --settings JSON with libse defaults (redirect to a file)");
         ShowParameter("info <file>", "Print format / encoding / duration / language info");
         ShowParameter("lint <pattern>", "Validate subtitle(s); exit 1 if any issues found");
 
@@ -166,11 +167,22 @@ internal static class HelpDisplay
         // Pad based on the visible length (param.Length) rather than the markup-escaped
         // length: Spectre.Console renders "[[" / "]]" as single chars, so columns drift
         // if we let the formatter pad against the escaped string.
-        var escapedParam = param.Replace("<", "[[").Replace(">", "]]");
-        var escapedDescription = description.Replace("<", "[[").Replace(">", "]]");
+        // Escape literal square brackets ('[' -> '[[') BEFORE turning '<'/'>' into display
+        // brackets, so an option like "--apply-min-gap[:<ms>]" doesn't feed Spectre a stray
+        // "[:" it reads as a broken markup tag (which threw mid-render and truncated --help).
+        var escapedParam = EscapeForMarkup(param);
+        var escapedDescription = EscapeForMarkup(description);
         var pad = Math.Max(1, ParamColumnWidth - param.Length);
         AnsiConsole.MarkupLine($"  [yellow]{escapedParam}[/]{new string(' ', pad)}[dim]{escapedDescription}[/]");
     }
+
+    // Renders literal '[' ']' and the '<value>' convention as visible square brackets.
+    // Spectre uses '[[' / ']]' as the escape for a literal '[' / ']', so both the real
+    // brackets and the angle-bracket placeholders map onto that same doubled form.
+    // Literal-bracket escaping must run first, or the '[[' produced from '<' gets escaped again.
+    private static string EscapeForMarkup(string text) =>
+        text.Replace("[", "[[").Replace("]", "]]")
+            .Replace("<", "[[").Replace(">", "]]");
 
     private static void ShowExample(string command, string description)
     {

--- a/src/seconv/Program.cs
+++ b/src/seconv/Program.cs
@@ -64,6 +64,18 @@ internal class Program
                 ListHelpers.PrintFixCommonErrorsRules();
                 return 0;
             }
+            if (first.Equals("dump-settings", StringComparison.OrdinalIgnoreCase) ||
+                first.Equals("default-settings", StringComparison.OrdinalIgnoreCase))
+            {
+                // Pure JSON to stdout so `seconv dump-settings > my.json` yields a clean file;
+                // the usage hint goes to stderr so it never lands in the redirected output.
+                Console.Out.WriteLine(SeConvSettings.DumpDefaults());
+                Console.Error.WriteLine(
+                    "// Above: seconv's settings schema with the current libse defaults. " +
+                    "Redirect to a file and pass it via --settings:<path.json>. " +
+                    "Note: these are seconv's key names, not the SE GUI's Settings.json.");
+                return 0;
+            }
             if (first.Equals("info", StringComparison.OrdinalIgnoreCase))
             {
                 return RunInfoCommand(args.Skip(1).ToArray());

--- a/src/seconv/README.md
+++ b/src/seconv/README.md
@@ -35,6 +35,7 @@ seconv movie.mkv subrip --track-number:3                         # extract MKV t
 seconv movie.sup subrip --ocr-engine:tesseract --ocr-language:eng # OCR a Blu-ray .sup
 seconv movie.sup subrip --time-codes-only                        # timing only, no OCR
 seconv subs.srt bluraysup --resolution:1920x1080                 # render text → Blu-ray sup
+seconv dump-settings > my.json                                   # starter --settings file (libse defaults)
 ```
 
 Run `seconv` with no arguments for built-in help, or `seconv formats` to list every format.

--- a/tests/seconv/Core/SeConvSettingsDumpTest.cs
+++ b/tests/seconv/Core/SeConvSettingsDumpTest.cs
@@ -1,0 +1,110 @@
+using System.Text.Json;
+using Nikse.SubtitleEdit.Core.Common;
+using SeConv.Core;
+using Xunit;
+
+namespace SeConvTests.Core;
+
+/// <summary>
+/// Tests for <c>seconv dump-settings</c> (<see cref="SeConvSettings.DumpDefaults"/>).
+/// The dump exists to teach the schema (issue #11037): a user who tried the SE GUI's
+/// <c>Settings.json</c> keys should be able to run one command and get a correct starter
+/// file. The core guarantee is that the dump round-trips through <see cref="SeConvSettings.Load"/>
+/// with zero unknown keys — it can never advertise a key the loader would reject.
+/// </summary>
+public class SeConvSettingsDumpTest
+{
+    [Fact]
+    public void DumpDefaults_IsValidJson_WithAllFourSections()
+    {
+        var json = SeConvSettings.DumpDefaults();
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.Equal(JsonValueKind.Object, root.ValueKind);
+        Assert.True(root.TryGetProperty("general", out _));
+        Assert.True(root.TryGetProperty("tools", out _));
+        Assert.True(root.TryGetProperty("removeTextForHearingImpaired", out _));
+        Assert.True(root.TryGetProperty("exportImages", out _));
+    }
+
+    [Fact]
+    public void DumpDefaults_RoundTripsThroughLoad_WithNoUnknownKeys()
+    {
+        var json = SeConvSettings.DumpDefaults();
+
+        var path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, json);
+            var loaded = SeConvSettings.Load(path);
+
+            // The whole point: every key the dump emits is one the loader recognizes.
+            Assert.Empty(loaded.GetUnknownKeys());
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void DumpDefaults_UsesSeconvKeyNames_NotGuiKeyNames()
+    {
+        // Issue #11037: the reporter fed seconv the GUI's "IsRemoveTextUppercaseLineOn".
+        // The dump must show seconv's actual key, "removeIfAllUppercase".
+        var json = SeConvSettings.DumpDefaults();
+
+        Assert.Contains("removeIfAllUppercase", json);
+        Assert.DoesNotContain("IsRemoveTextUppercaseLineOn", json);
+    }
+
+    [Fact]
+    public void DumpDefaults_ReflectsCurrentLibseDefaults()
+    {
+        var json = SeConvSettings.DumpDefaults();
+
+        var path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, json);
+            var loaded = SeConvSettings.Load(path);
+
+            // Values come straight from Configuration.Settings, so they must match it.
+            var general = Configuration.Settings.General;
+            Assert.Equal(general.SubtitleLineMaximumLength, loaded.General!.SubtitleLineMaximumLength);
+            Assert.Equal(general.MinimumMillisecondsBetweenLines, loaded.General!.MinimumMillisecondsBetweenLines);
+            Assert.Equal(general.MaxNumberOfLines, loaded.General!.MaxNumberOfLines);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void DumpDefaults_ExportImagesColorsAndEnums_ParseBack()
+    {
+        // Colors are emitted as #AARRGGBB and enums as their names; both must survive a
+        // load + apply cycle so a dumped file actually drives image export.
+        var json = SeConvSettings.DumpDefaults();
+
+        var path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, json);
+            var loaded = SeConvSettings.Load(path);
+
+            var style = new ImageExportStyle();
+            loaded.ApplyExportImages(style);
+
+            // A fresh style applied with dumped defaults stays the default (Arial, white text).
+            Assert.Equal("Arial", style.FontName);
+            Assert.Equal(SkiaSharp.SKColors.White, style.FontColor);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #11300 (which closed items from #11037). An external user, @Hlsgs, [reviewed the merged PR](https://github.com/SubtitleEdit/subtitleedit/pull/11300#issuecomment-5044863582) and raised a few loose ends: they couldn't find the docs, they wanted a full defaults `settings.json` to start from, and they asked how the seconv `--settings` schema relates to the GUI's `Settings.json`. This picks those up.

## `seconv dump-settings`

Prints a complete `--settings` JSON populated with the **current libse defaults** — every key seconv understands, with its correct camelCase name and default value. This is the "starter file" Hlsgs asked for, and it directly cures the root confusion behind #11037 (the reporter had used the GUI key `IsRemoveTextUppercaseLineOn`; seconv's key is `removeIfAllUppercase`).

```bash
seconv dump-settings > my-settings.json     # edit, then --settings:my-settings.json
```

- Pure JSON to **stdout** so the redirect yields a clean file; the usage hint goes to **stderr**.
- Built by mirroring `Configuration.Settings` + a fresh `ImageExportStyle`, so the output **round-trips through `SeConvSettings.Load` with zero unknown keys** — the dump can never drift from what the loader accepts (a test enforces this).

<details>
<summary>Sample output</summary>

```json
{
  "general": {
    "subtitleLineMaximumLength": 43,
    "minimumMillisecondsBetweenLines": 24,
    "maxNumberOfLines": 2,
    "dialogStyle": "DashBothLinesWithSpace",
    "continuationStyle": "None"
  },
  "tools": { "mergeShortLinesMaxGap": 250, "mergeShortLinesOnlyContinuous": true },
  "removeTextForHearingImpaired": {
    "removeTextBetweenBrackets": true,
    "removeIfAllUppercase": false
  },
  "exportImages": {
    "fontName": "Arial", "fontSize": 50, "fontColor": "#FFFFFFFF",
    "alignment": "BottomCenter", "contentAlignment": "Center"
  }
}
```
(abridged — the real dump lists every key)
</details>

## Docs

- **Restored the "this is seconv's schema, not the GUI's `Settings.json`" callout** under *Settings JSON* — it was lost in the earlier reference de-duplication, and it's exactly the guidance Hlsgs went looking for. Now points at `dump-settings`.
- Documented the **language-gated FCE rules** (`FixAloneLowercaseIToUppercaseI`, `FixDanishLetterI`, `FixSpanishInvertedQuestionAndExclamationMarks`, `FixTurkishAnsiToUnicode`) and clarified that rule **selection is CLI-only** (`--fix-common-errors-rules`) while `--settings` shapes rule **behaviour** — answering Hlsgs's "can rules go in the settings file?" honestly.
- Added `dump-settings` to the help screen, the reference subcommand list, and the README quick-start.

## Fix `--help` crash (pre-existing on `main`)

`seconv --help` currently throws a Spectre markup exception partway through and truncates its own output — the `[` in `--apply-min-gap[:<ms>]` was passed to Spectre unescaped and read as a broken markup tag. Because the crash happens *before* the Subcommands section, the new `dump-settings` help line wouldn't render without this fix. `ShowParameter` now escapes literal square brackets before mapping the `<value>` convention onto display brackets.

## Test plan

- [x] 5 new `SeConvSettingsDumpTest` cases (valid JSON, round-trips with no unknown keys, uses seconv key names not GUI ones, reflects live libse defaults, exportImages colors/enums parse back)
- [x] Full `SeConvTests` suite: 249/249 pass
- [x] `seconv dump-settings > f.json` then `--settings:f.json` on a real convert → no unknown-key warnings
- [x] `seconv --help` renders end-to-end with no exception; `--apply-min-gap[:<ms>]` and `dump-settings` display correctly

## Not in this PR (left for discussion)

Hlsgs also made a design argument that naming a language-specific rule in `--fix-common-errors-rules` should still respect the language gate (whitelist = "allowed to run *if applicable*"), rather than force the rule on — so a mixed-language batch doesn't need the fragile `all,-` pattern. That's a behaviour change to what #11300 deliberately shipped, so I've left it out here and will follow up in the issue thread; a `--language` override is the likely companion.

Refs #11037, #11300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)