### PR TITLE
release: macOS app is signed and notarized, drop unsigned note

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -889,7 +889,7 @@ jobs:
             1. Read and fix requirements, please see [System Requirements](https://github.com/SubtitleEdit/subtitleedit#-system-requirements)
             2. Download the appropriate package for your platform
             3. Extract the archive (or use installer if available)
-            4. Run the executable (on macOS, the app is unsigned - see [System Requirements](https://github.com/SubtitleEdit/subtitleedit#-system-requirements) for how to allow it).
+            4. Run the executable (on macOS, the app is signed and notarized by Apple - just drag it to Applications and open it).
       
             ### Change Log
             See the full [Change Log](https://raw.githubusercontent.com/SubtitleEdit/subtitleedit/refs/heads/main/change-log.txt) for details.


### PR DESCRIPTION
## What

The auto-generated GitHub Release body hardcoded a note telling macOS users the app is unsigned and pointing them at the workaround for opening unsigned apps:

> Run the executable (on macOS, the app is unsigned - see System Requirements for how to allow it).

## Why

The macOS DMGs are now codesigned, notarized, and stapled in the release workflow (nested binaries + app bundle signed inside-out, DMG signed, `notarytool submit --wait`, `stapler staple`). The "unsigned" note is stale and misleading — users can just drag the app to Applications and open it.

## Change

Updated the single hardcoded line in `.github/workflows/build-ui.yml` release notes.

Note: the `SIGNING_AVAILABLE != "true"` fallback paths (bundling `README-macOS.txt` / `fix-unsigned-app.sh`, `codesign --remove-signature`) are intentionally left in place as graceful degradation when signing secrets are absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)