### PR TITLE
seconv: add --fce-language override and mark language-gated FCE rules

### DIFF
--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -459,6 +459,7 @@ Operations run after the structural transforms (offset, fps, renumber, adjust-du
 | `--delete-contains:<word>` | Delete entries containing the given word |
 | `--fix-common-errors` | Fix common subtitle errors (all 39 rules) |
 | `--fix-common-errors-rules:<list>` | Run a subset of FCE rules (CSV; supports `all,-RuleId`) |
+| `--fce-language:<code>` | Force the language for FCE language-gated rules (code or English name, e.g. `es` / `Spanish`); default: auto-detect from content |
 | `--fix-rtl-via-unicode-chars` | Fix RTL via Unicode characters |
 | `--merge-same-texts` | Merge entries with same text |
 | `--merge-same-time-codes` | Merge entries with same time codes |
@@ -484,10 +485,16 @@ seconv *.srt subrip --remove-text-for-hi --merge-same-texts --split-long-lines -
 seconv movie.srt subrip --fix-common-errors                                  # all rules
 seconv movie.srt subrip --fix-common-errors-rules:FixCommas,FixMissingSpaces
 seconv movie.srt subrip --fix-common-errors-rules:all,-FixDanishLetterI      # all except one
-seconv list-fce-rules                                                        # show rule IDs
+seconv movie.srt subrip --fix-common-errors --fce-language:es                # force the Spanish gate
+seconv list-fce-rules                                                        # show rule IDs (marks language gates)
 ```
 
-**Language-specific rules.** A few rules only make sense for one language and mirror the GUI's *Fix Common Errors* window, which only offers them when the detected language matches: `FixAloneLowercaseIToUppercaseI` (English), `FixDanishLetterI` (Danish), `FixSpanishInvertedQuestionAndExclamationMarks` (Spanish), and `FixTurkishAnsiToUnicode` (Turkish). In the default all-rules pass these run only when auto-detection agrees, so e.g. the Spanish inverted-`¿` fix never lands on English content (issue #11037). Naming such a rule explicitly in `--fix-common-errors-rules` currently forces it on regardless of the detected language.
+**Language-specific rules.** A few rules only make sense for one language and mirror the GUI's *Fix Common Errors* window, which only offers them when the detected language matches: `FixAloneLowercaseIToUppercaseI` (English), `FixDanishLetterI` (Danish), `FixSpanishInvertedQuestionAndExclamationMarks` (Spanish), and `FixTurkishAnsiToUnicode` (Turkish). `seconv list-fce-rules` marks each gated rule with its language in a *Language gate* column. In the default all-rules pass these run only when auto-detection agrees, so e.g. the Spanish inverted-`¿` fix never lands on English content (issue #11037).
+
+There are two ways to override the gate:
+
+- **`--fce-language:<code>`** forces the language used for *all* gated rules (and the OCR-fix pass). Use it when a genuinely Spanish/Danish/Turkish file mis-detects (e.g. it's too short) so the right rule still runs. Accepts a two-letter code, three-letter code, or English name (`es`, `spa`, `Spanish`); an unrecognized value warns and falls back to auto-detection.
+- **Naming a gated rule explicitly** in `--fix-common-errors-rules` forces just that rule on, regardless of the detected language.
 
 **Rule selection is CLI-only.** The set of rules is chosen with `--fix-common-errors-rules`, not through the `--settings` JSON. The settings file shapes *how* the rules behave (line length, min gap, dialog/continuation style, CPS — see [Settings JSON](#settings-json)); it does not select which rules run.
 

--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -329,6 +329,10 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         [Description("Comma-separated FCE rule IDs (or 'all,-RuleId' to subtract). See: seconv list-fce-rules")]
         public string? FixCommonErrorsRules { get; init; }
 
+        [CommandOption("--fce-language|--FixCommonErrorsLanguage")]
+        [Description("Force the language for FCE language-gated rules (code or English name, e.g. es or Spanish); default: auto-detect from content")]
+        public string? FixCommonErrorsLanguage { get; init; }
+
         [CommandOption("--fix-rtl-via-unicode-chars|--FixRtlViaUnicodeChars")]
         [Description("Fix RTL via Unicode characters")]
         public bool FixRtlViaUnicodeChars { get; init; }
@@ -537,6 +541,16 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                     AnsiConsole.MarkupLineInterpolated($"[red]Error: {ex.Message}[/]");
                     return 1;
                 }
+
+                // A supplied --fce-language that can't be resolved falls back to auto-detect;
+                // warn so a typo ("--fce-language:spanihs") isn't silently ignored.
+                if (!silent
+                    && !string.IsNullOrWhiteSpace(settings.FixCommonErrorsLanguage)
+                    && FixCommonErrorsRunner.NormalizeLanguageOverride(settings.FixCommonErrorsLanguage) == null)
+                {
+                    AnsiConsole.MarkupLineInterpolated(
+                        $"[yellow]Warning: --fce-language '{settings.FixCommonErrorsLanguage}' not recognized; falling back to auto-detected language.[/]");
+                }
             }
 
             // Build operations list. Operations run in the order the user typed them and
@@ -637,6 +651,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 Operations = operations,
                 FixCommonErrorsRules = fceRules,
                 FixCommonErrorsExplicitlyNamedRules = fceExplicitlyNamed,
+                FixCommonErrorsLanguage = settings.FixCommonErrorsLanguage,
                 DeleteFirst = settings.DeleteFirst,
                 DeleteLast = settings.DeleteLast,
                 DeleteContains = settings.DeleteContains,

--- a/src/seconv/Core/FixCommonErrorsRunner.cs
+++ b/src/seconv/Core/FixCommonErrorsRunner.cs
@@ -4,6 +4,7 @@ using Nikse.SubtitleEdit.Core.Interfaces;
 using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
 using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 using SkiaSharp;
+using System.Globalization;
 
 namespace SeConv.Core;
 
@@ -32,6 +33,22 @@ internal static class FixCommonErrorsRunner
 
     public static IReadOnlyList<string> AvailableRuleIds { get; } =
         Rules.Select(r => r.Id).Append(OcrFixRuleId).ToArray();
+
+    /// <summary>
+    /// Rules that only run when the subtitle's language (auto-detected, or forced via
+    /// <c>--fce-language</c>) matches the mapped two-letter ISO code. Single source of truth
+    /// for both the runtime gate (<see cref="IsLanguageOnlyRule"/>) and the <c>list-fce-rules</c>
+    /// display. Mirrors the GUI's per-language rule additions in <c>FixCommonErrorsViewModel</c>.
+    /// A gated rule can always be forced by naming it explicitly in <c>--FixCommonErrorsRules</c>.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> LanguageGates { get; } =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [nameof(FixAloneLowercaseIToUppercaseI)] = "en",
+            [nameof(FixDanishLetterI)] = "da",
+            [nameof(FixSpanishInvertedQuestionAndExclamationMarks)] = "es",
+            [nameof(FixTurkishAnsiToUnicode)] = "tr",
+        };
 
     /// <summary>
     /// Runs every available rule against the subtitle. Equivalent to
@@ -63,7 +80,8 @@ internal static class FixCommonErrorsRunner
     public static void Run(
         Subtitle subtitle,
         IReadOnlyCollection<string>? ruleIds,
-        IReadOnlyCollection<string>? explicitlyNamedRules)
+        IReadOnlyCollection<string>? explicitlyNamedRules,
+        string? languageOverride = null)
     {
         if (subtitle == null || subtitle.Paragraphs.Count == 0)
         {
@@ -93,7 +111,12 @@ internal static class FixCommonErrorsRunner
             explicitlyNamed = new HashSet<string>(explicitlyNamedRules, StringComparer.OrdinalIgnoreCase);
         }
 
-        var language = LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(subtitle) ?? "en";
+        // --fce-language forces the language used for gating (and OCR-fix), so a genuinely
+        // Spanish/Danish/Turkish file that auto-detects wrong still gets its per-language
+        // rule. Falls back to content auto-detection, then "en".
+        var language = NormalizeLanguageOverride(languageOverride)
+            ?? LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(subtitle)
+            ?? "en";
         var callbacks = new EmptyFixCallback
         {
             Language = language,
@@ -261,19 +284,36 @@ internal static class FixCommonErrorsRunner
     /// Bypassable via explicit <c>--FixCommonErrorsRules</c>.
     /// </summary>
     private static bool IsLanguageOnlyRule(string ruleId, string language)
+        => LanguageGates.TryGetValue(ruleId, out var required)
+           && !required.Equals(language, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Normalizes a user-supplied <c>--fce-language</c> value to a two-letter ISO code so it can
+    /// match the <see cref="LanguageGates"/> map. Accepts a two-letter code (<c>es</c>), a
+    /// three-letter code (<c>spa</c>), or an English name (<c>Spanish</c>). Returns <c>null</c>
+    /// for null/blank input (no override) or when the value can't be resolved — the caller then
+    /// falls back to content auto-detection.
+    /// </summary>
+    internal static string? NormalizeLanguageOverride(string? value)
     {
-        return ruleId switch
+        if (string.IsNullOrWhiteSpace(value))
         {
-            "FixAloneLowercaseIToUppercaseI"
-                => !"en".Equals(language, StringComparison.OrdinalIgnoreCase),
-            "FixDanishLetterI"
-                => !"da".Equals(language, StringComparison.OrdinalIgnoreCase),
-            "FixSpanishInvertedQuestionAndExclamationMarks"
-                => !"es".Equals(language, StringComparison.OrdinalIgnoreCase),
-            "FixTurkishAnsiToUnicode"
-                => !"tr".Equals(language, StringComparison.OrdinalIgnoreCase),
-            _ => false,
-        };
+            return null;
+        }
+
+        var v = value.Trim();
+        if (v.Length == 2)
+        {
+            return v.ToLowerInvariant();
+        }
+
+        var culture = CultureInfo.GetCultures(CultureTypes.NeutralCultures)
+            .FirstOrDefault(c =>
+                c.TwoLetterISOLanguageName.Equals(v, StringComparison.OrdinalIgnoreCase)
+                || c.ThreeLetterISOLanguageName.Equals(v, StringComparison.OrdinalIgnoreCase)
+                || c.EnglishName.Equals(v, StringComparison.OrdinalIgnoreCase));
+
+        return culture?.TwoLetterISOLanguageName;
     }
 
     /// <summary>

--- a/src/seconv/Core/LibSEIntegration.cs
+++ b/src/seconv/Core/LibSEIntegration.cs
@@ -564,12 +564,15 @@ internal static class LibSEIntegration
     /// <c>null</c> or empty to run all FCE rules. <paramref name="fixCommonErrorsExplicitlyNamedRules"/>
     /// is the set of rules the user named by hand (used to bypass FCE language gating);
     /// pass empty for "no explicit selection" (implicit-all CLI path).
+    /// <paramref name="fixCommonErrorsLanguage"/> forces the language used for FCE gating /
+    /// OCR-fix (from <c>--fce-language</c>); pass <c>null</c> to auto-detect from content.
     /// </summary>
     public static void ApplyOperations(
         Subtitle subtitle,
         List<string> operations,
         IReadOnlyList<string>? fixCommonErrorsRules = null,
-        IReadOnlyList<string>? fixCommonErrorsExplicitlyNamedRules = null)
+        IReadOnlyList<string>? fixCommonErrorsExplicitlyNamedRules = null,
+        string? fixCommonErrorsLanguage = null)
     {
         if (subtitle == null || operations == null || operations.Count == 0)
         {
@@ -578,7 +581,7 @@ internal static class LibSEIntegration
 
         foreach (var operation in operations)
         {
-            ApplyOperation(subtitle, operation, fixCommonErrorsRules, fixCommonErrorsExplicitlyNamedRules);
+            ApplyOperation(subtitle, operation, fixCommonErrorsRules, fixCommonErrorsExplicitlyNamedRules, fixCommonErrorsLanguage);
         }
     }
 
@@ -586,12 +589,13 @@ internal static class LibSEIntegration
         Subtitle subtitle,
         string operation,
         IReadOnlyList<string>? fixCommonErrorsRules,
-        IReadOnlyList<string>? fixCommonErrorsExplicitlyNamedRules)
+        IReadOnlyList<string>? fixCommonErrorsExplicitlyNamedRules,
+        string? fixCommonErrorsLanguage)
     {
         switch (operation.ToLowerInvariant())
         {
             case "fixcommonerrors":
-                FixCommonErrorsRunner.Run(subtitle, fixCommonErrorsRules, fixCommonErrorsExplicitlyNamedRules);
+                FixCommonErrorsRunner.Run(subtitle, fixCommonErrorsRules, fixCommonErrorsExplicitlyNamedRules, fixCommonErrorsLanguage);
                 break;
 
             case "removetextforhi":

--- a/src/seconv/Core/ListHelpers.cs
+++ b/src/seconv/Core/ListHelpers.cs
@@ -76,18 +76,29 @@ internal static class ListHelpers
         AnsiConsole.WriteLine();
         var table = new Table().Border(TableBorder.Rounded);
         table.AddColumn("[yellow]Rule ID[/]");
+        table.AddColumn("[yellow]Language gate[/]");
 
+        var gates = FixCommonErrorsRunner.LanguageGates;
         foreach (var id in FixCommonErrorsRunner.AvailableRuleIds)
         {
-            table.AddRow($"[green]{id}[/]");
+            // Language-gated rules only run when the subtitle's language (auto-detected, or
+            // forced via --fce-language) matches. Mark them so the gate is discoverable from
+            // the CLI without reading the source.
+            var gate = gates.TryGetValue(id, out var lang) ? $"[magenta]{lang} only[/]" : "[dim]—[/]";
+            table.AddRow($"[green]{id}[/]", gate);
         }
 
         AnsiConsole.Write(table);
         AnsiConsole.MarkupLine(
+            "\n[dim]Language-gated rules run only when the subtitle auto-detects to that language.[/]\n" +
+            "[dim]Force it with[/] [green]--fce-language:<code>[/][dim], or bypass the gate by naming the rule explicitly.[/]");
+        AnsiConsole.MarkupLine(
             "\n[dim]Examples:[/]\n" +
-            "  [dim]--FixCommonErrors[/]                                       [dim]# all rules[/]\n" +
+            "  [dim]--FixCommonErrors[/]                                       [dim]# all rules (gates active)[/]\n" +
             "  [dim]--FixCommonErrorsRules:FixCommas,FixEllipsesStart[/]       [dim]# only these two[/]\n" +
-            "  [dim]--FixCommonErrorsRules:all,-FixDanishLetterI[/]            [dim]# all except one[/]");
+            "  [dim]--FixCommonErrorsRules:all,-FixDanishLetterI[/]            [dim]# all except one[/]\n" +
+            "  [dim]--FixCommonErrors --fce-language:es[/]                     [dim]# force Spanish gate[/]\n" +
+            "  [dim]--FixCommonErrorsRules:FixSpanishInvertedQuestionAndExclamationMarks[/]  [dim]# bypass gate[/]");
     }
 
     public static void PrintOcrEngines()

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -721,7 +721,8 @@ internal class SubtitleConverter
                 subtitle,
                 options.Operations,
                 options.FixCommonErrorsRules,
-                options.FixCommonErrorsExplicitlyNamedRules);
+                options.FixCommonErrorsExplicitlyNamedRules,
+                options.FixCommonErrorsLanguage);
         }
 
         if (options.BridgeGapsMaxMs.HasValue && options.BridgeGapsMaxMs.Value > 0)
@@ -851,6 +852,13 @@ internal record class ConversionOptions
     /// "implicit all-rules pass" (gates stay active).
     /// </summary>
     public IReadOnlyList<string> FixCommonErrorsExplicitlyNamedRules { get; init; } = [];
+
+    /// <summary>
+    /// Forces the language used for FCE gating and OCR-fix (from <c>--fce-language</c>).
+    /// Null/blank = auto-detect from subtitle content. Accepts a two-letter code, three-letter
+    /// code, or English name (see <see cref="FixCommonErrorsRunner.NormalizeLanguageOverride"/>).
+    /// </summary>
+    public string? FixCommonErrorsLanguage { get; init; }
     public int? DeleteFirst { get; init; }
     public int? DeleteLast { get; init; }
     public string? DeleteContains { get; init; }

--- a/src/seconv/Helpers/HelpDisplay.cs
+++ b/src/seconv/Helpers/HelpDisplay.cs
@@ -77,6 +77,7 @@ internal static class HelpDisplay
         ShowParameter("--delete-contains:<word>", "Delete entries containing specified word");
         ShowParameter("--fix-common-errors", "Fix common subtitle errors (all rules)");
         ShowParameter("--fix-common-errors-rules:<list>", "FCE rule IDs (csv); supports 'all,-RuleId'. List: seconv list-fce-rules");
+        ShowParameter("--fce-language:<code>", "Force language for FCE language-gated rules (e.g. es or Spanish); default: auto-detect");
         ShowParameter("--dictionary-folder:<path>", "Hunspell dictionaries + *_OCRFixReplaceList.xml; enables the 'Fix common OCR errors' FCE pass");
         ShowParameter("--fix-rtl-via-unicode-chars", "Fix RTL via Unicode characters");
         ShowParameter("--merge-same-texts", "Merge entries with same text");

--- a/tests/seconv/Core/FixCommonErrorsRunnerTest.cs
+++ b/tests/seconv/Core/FixCommonErrorsRunnerTest.cs
@@ -243,6 +243,66 @@ public class FixCommonErrorsRunnerTest
     }
 
     [Fact]
+    public void Run_WithFceLanguageOverride_ForcesGateOnNonSpanish()
+    {
+        // --fce-language:es forces the Spanish gate open even for content that would
+        // auto-detect as something else — the escape hatch for short/mis-detected files.
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("Are you coming home tonight?", 0, 3000));
+        sub.Renumber();
+
+        var allRules = FixCommonErrorsRunner.AvailableRuleIds;
+        FixCommonErrorsRunner.Run(sub, allRules, explicitlyNamedRules: [], languageOverride: "es");
+
+        Assert.Contains('¿', sub.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void Run_WithFceLanguageOverride_AcceptsEnglishName()
+    {
+        // The override normalizes an English name ("Spanish") to its two-letter code.
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("Are you coming home tonight?", 0, 3000));
+        sub.Renumber();
+
+        var allRules = FixCommonErrorsRunner.AvailableRuleIds;
+        FixCommonErrorsRunner.Run(sub, allRules, explicitlyNamedRules: [], languageOverride: "Spanish");
+
+        Assert.Contains('¿', sub.Paragraphs[0].Text);
+    }
+
+    [Theory]
+    [InlineData("es", "es")]
+    [InlineData("ES", "es")]
+    [InlineData("spa", "es")]
+    [InlineData("Spanish", "es")]
+    [InlineData("English", "en")]
+    public void NormalizeLanguageOverride_ResolvesCodesAndNames(string input, string expected)
+    {
+        Assert.Equal(expected, FixCommonErrorsRunner.NormalizeLanguageOverride(input));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("spanihs")]
+    public void NormalizeLanguageOverride_BlankOrUnknown_ReturnsNull(string? input)
+    {
+        Assert.Null(FixCommonErrorsRunner.NormalizeLanguageOverride(input));
+    }
+
+    [Fact]
+    public void LanguageGates_MapExpectedRulesToCodes()
+    {
+        var gates = FixCommonErrorsRunner.LanguageGates;
+        Assert.Equal("en", gates["FixAloneLowercaseIToUppercaseI"]);
+        Assert.Equal("da", gates["FixDanishLetterI"]);
+        Assert.Equal("es", gates["FixSpanishInvertedQuestionAndExclamationMarks"]);
+        Assert.Equal("tr", gates["FixTurkishAnsiToUnicode"]);
+    }
+
+    [Fact]
     public void ParseExplicitlyNamedRules_NullOrAllOrNegations_ReturnsEmpty()
     {
         // "implicit-all" spec forms — nothing the user named by hand.


### PR DESCRIPTION
Follow-up to #11300 (issue #11037). The FCE language-conditional rules (Spanish/Danish/Turkish/English) were gated purely on content auto-detection, with the only escape hatch being to name the gated rule explicitly. Two gaps from the review discussion remained:

- No way to force the gate language, so a genuinely Spanish/Danish/Turkish file that mis-detects (e.g. too short) silently skipped its per-language rule.
- The gate was invisible from the CLI: `list-fce-rules` showed only bare IDs.

## Changes

- Add `--fce-language:<code>` (alias `--FixCommonErrorsLanguage`) to force the language used for FCE gating and the OCR-fix pass. Accepts a two-letter code, three-letter code, or English name (`es` / `spa` / `Spanish`); an unrecognized value warns and falls back to auto-detection.
- Make the gate mapping a single source of truth (`FixCommonErrorsRunner.LanguageGates`), consumed by both the runtime gate and the display.
- `list-fce-rules` now shows a **Language gate** column plus override examples.
- Document both override paths in `docs/reference/command-line.md` and `--help`.

## Testing

261 seconv tests pass (12 new covering the override, the code/name normalizer, and the gate map).

🤖 Generated with [Claude Code](https://claude.com/claude-code)