### PR TITLE
Improve language auto-detection for short subtitles

### DIFF
--- a/src/libse/Common/LanguageAutoDetect.cs
+++ b/src/libse/Common/LanguageAutoDetect.cs
@@ -23,9 +23,13 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         private static int GetCount(string text, params string[] words)
         {
+            // Case-insensitive so a keyword still matches when it falls at the start of a
+            // sentence (capitalized). This matters most on short/single-line subtitles, where
+            // a large share of words are sentence-initial and case-sensitive matching used to
+            // miss them (e.g. "Você"/"Burada" not matching the lowercase list entries).
             var pattern = "\\b(" + string.Join("|", words) + ")\\b";
-            var regex = WordCountRegexCache.GetOrAdd(pattern, p =>
-                new Regex(p, RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.Compiled));
+            var regex = WordCountRegexCache.GetOrAdd("(?i)" + pattern, p =>
+                new Regex(pattern, RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.Compiled | RegexOptions.IgnoreCase));
             return regex.Matches(text).Count;
         }
 
@@ -268,6 +272,35 @@ namespace Nikse.SubtitleEdit.Core.Common
             "yang", "tahu", "bisa", "akan", "tahun", "tapi", "dengan", "untuk", "rumah", "dalam", "sudah", "bertemu"
         };
 
+        // Catalan — distinctive words that don't collide with Spanish/French/Italian/Portuguese
+        // (accents matter: "què"/"gràcies"/"això" won't match the Spanish "qué"/"gracias").
+        private static readonly string[] AutoDetectWordsCatalan =
+        {
+            "què", "això", "amb", "però", "molt", "moltes", "molts", "gràcies", "aquest", "aquesta", "aquestes",
+            "nosaltres", "vosaltres", "vull", "puc", "pots", "sóc", "ets", "són", "fer", "fas", "fem", "tinc",
+            "tens", "seva", "teu", "meu", "ara", "res", "també", "perquè", "sisplau", "endavant", "ningú",
+            "sempre", "doncs", "gairebé", "cadascú"
+        };
+
+        // Tagalog / Filipino — distinctive Austronesian function words; low overlap with European
+        // languages. Spanish loanwords ("para", "pero") are intentionally left out to avoid collisions.
+        private static readonly string[] AutoDetectWordsTagalog =
+        {
+            "ang", "ng", "mga", "ako", "ikaw", "siya", "kami", "tayo", "kayo", "sila", "ito", "iyan", "iyon",
+            "dito", "diyan", "doon", "hindi", "wala", "mayroon", "meron", "salamat", "kumusta", "bakit", "ano",
+            "sino", "saan", "kailan", "paano", "gusto", "alam", "ginagawa", "talaga", "naman", "kasi", "namin",
+            "natin", "ninyo", "nila", "niya", "kaya", "dahil", "ganito", "ganyan", "kung", "kapag", "mahal"
+        };
+
+        // Afrikaans — only words that are NOT also valid Dutch, so a Dutch clip is never mistaken
+        // for Afrikaans (the Dutch list is small; shared words like "maak"/"goed"/"weet" would leak).
+        private static readonly string[] AutoDetectWordsAfrikaans =
+        {
+            "nie", "baie", "jy", "jou", "ek", "moenie", "dankie", "asseblief", "hoekom", "hierdie", "daardie",
+            "sal", "vir", "hulle", "saam", "gesels", "meisie", "altyd", "regtig", "aandag", "vinnig", "seblief",
+            "nogal", "sommer", "elkeen"
+        };
+
         private static readonly string[] AutoDetectWordsThai =
         {
             "ผู้กอง", "โรเบิร์ต", "วิตตอเรีย", "เข้าใจมั้ย", "คุณตำรวจ", "ราเชล", "เพื่อน", "เลดดิส", "พระเจ้า", "เท็ดดี้", "หัวหน้า", "แอนดรูว์", "ขอโทษครับ", "ขอบคุณ", "วาร์กัส", "ทุกคน",
@@ -444,13 +477,33 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         private static string AutoDetectGoogleLanguage(string text, int bestCount)
         {
+            // Score-based selection instead of first-match-wins: every language block below is
+            // evaluated and records a candidate via Consider(); the candidate with the most
+            // keyword hits wins (ties keep the earlier/higher-priority language via strict '>').
+            // This fixes short-file mis-detection where an ambiguous token used to hand the clip
+            // to whichever language happened to sit earliest in the fixed scan order (e.g. a short
+            // Portuguese clip returning "es"). The per-language disambiguation guards (es vs pt/fr,
+            // ru vs bg/uk/mk, hr vs sr/sl, cs vs sk, ...) are preserved exactly; only the outer
+            // control flow changed from returning on the first hit to picking the strongest.
+            var best = string.Empty;
+            var bestScore = -1;
+
+            void Consider(string languageCode, int score)
+            {
+                if (score > bestScore)
+                {
+                    best = languageCode;
+                    bestScore = score;
+                }
+            }
+
             var count = GetCount(text, AutoDetectWordsEnglish);
             if (count > bestCount)
             {
                 var dutchCount = GetCount(text, AutoDetectWordsDutch);
                 if (dutchCount < count)
                 {
-                    return "en";
+                    Consider("en", count);
                 }
             }
 
@@ -465,10 +518,12 @@ namespace Nikse.SubtitleEdit.Core.Common
                 {
                     if (icelandicCount > count * 1.5)
                     {
-                        return "is";
+                        Consider("is", count);
                     }
-
-                    return "da";
+                    else
+                    {
+                        Consider("da", count);
+                    }
                 }
             }
 
@@ -480,14 +535,14 @@ namespace Nikse.SubtitleEdit.Core.Common
                 var swedishCount = GetCount(text, AutoDetectWordsSwedish);
                 if (danishCount < 2 && dutchCount < count && swedishCount < count)
                 {
-                    return "no";
+                    Consider("no", count);
                 }
             }
 
             count = GetCount(text, AutoDetectWordsSwedish);
             if (count > bestCount)
             {
-                return "sv";
+                Consider("sv", count);
             }
 
             count = GetCount(text, AutoDetectWordsSpanish);
@@ -498,7 +553,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                                                      "jantar", "conheço", "atenção", "foste", "milhões", "devias", "ganhar", "raios"); // not spanish words
                 if (frenchCount < 2 && portugueseCount < 2)
                 {
-                    return "es";
+                    Consider("es", count);
                 }
             }
 
@@ -508,7 +563,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 var frenchCount = GetCount(text, "[Cc]'est", "pas", "vous", "pour", "suis", "Pourquoi", "maison", "souviens", "quelque"); // not italian words
                 if (frenchCount < 2)
                 {
-                    return "it";
+                    Consider("it", count);
                 }
             }
 
@@ -518,7 +573,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 var romanianCount = GetCount(text, "[Vv]reau", "[Ss]înt", "[Aa]cum", "pentru", "domnule", "aici");
                 if (romanianCount < 5)
                 {
-                    return "fr";
+                    Consider("fr", count);
                 }
             }
 
@@ -528,22 +583,36 @@ namespace Nikse.SubtitleEdit.Core.Common
                 var slovenianCount = GetCount(text, AutoDetectWordsSlovenian);
                 if (slovenianCount > count)
                 {
-                    return "sl";
+                    Consider("sl", count);
                 }
+                else
+                {
+                    Consider("pt", count); // Portuguese
+                }
+            }
 
-                return "pt"; // Portuguese
+            count = GetCount(text, AutoDetectWordsCatalan);
+            if (count > bestCount)
+            {
+                Consider("ca", count); // Catalan
             }
 
             count = GetCount(text, AutoDetectWordsGerman);
             if (count > bestCount)
             {
-                return "de";
+                Consider("de", count);
             }
 
             count = GetCount(text, AutoDetectWordsDutch);
             if (count > bestCount)
             {
-                return "nl";
+                Consider("nl", count);
+            }
+
+            count = GetCount(text, AutoDetectWordsAfrikaans);
+            if (count > bestCount)
+            {
+                Consider("af", count); // Afrikaans
             }
 
             count = GetCount(text, AutoDetectWordsPolish);
@@ -552,16 +621,18 @@ namespace Nikse.SubtitleEdit.Core.Common
                 var czechWordsCount = GetCount(text, AutoDetectWordsCzech);
                 if (czechWordsCount > count)
                 {
-                    return "cs";
+                    Consider("cs", count);
                 }
-
-                return "pl";
+                else
+                {
+                    Consider("pl", count);
+                }
             }
 
             count = GetCount(text, AutoDetectWordsGreek);
             if (count > bestCount)
             {
-                return "el"; // Greek
+                Consider("el", count); // Greek
             }
 
             count = GetCount(text, AutoDetectWordsRussian);
@@ -574,41 +645,44 @@ namespace Nikse.SubtitleEdit.Core.Common
                 {
                     if (ukrainianCount > bulgarianCount && ukrainianCount > macedonianCount)
                     {
-                        return "uk"; // Ukrainian
+                        Consider("uk", count); // Ukrainian
                     }
-
-                    if (macedonianCount > bulgarianCount && macedonianCount > ukrainianCount)
+                    else if (macedonianCount > bulgarianCount && macedonianCount > ukrainianCount)
                     {
-                        return "mk"; // Macedonian
+                        Consider("mk", count); // Macedonian
                     }
-
-                    return "bg"; // Bulgarian
+                    else
+                    {
+                        Consider("bg", count); // Bulgarian
+                    }
                 }
-
-                if (ukrainianCount > count)
+                else if (ukrainianCount > count)
                 {
-                    return "uk"; // Ukrainian
+                    Consider("uk", count); // Ukrainian
                 }
-
-                var serbianCount = GetCount(text, AutoDetectWordsSerbianCyrillic);
-                if (serbianCount > count)
+                else
                 {
-                    return "sr"; // Serbian
+                    var serbianCount = GetCount(text, AutoDetectWordsSerbianCyrillic);
+                    var serbianWordsOnlyCount = GetCount(text, AutoDetectWordsSerbianCyrillicOnly);
+                    if (serbianCount > count)
+                    {
+                        Consider("sr", count); // Serbian
+                    }
+                    else if (serbianWordsOnlyCount > 1)
+                    {
+                        Consider("sr", count); // Serbian
+                    }
+                    else
+                    {
+                        Consider("ru", count); // Russian
+                    }
                 }
-
-                var serbianWordsOnlyCount = GetCount(text, AutoDetectWordsSerbianCyrillicOnly);
-                if (serbianWordsOnlyCount > 1)
-                {
-                    return "sr"; // Serbian
-                }
-
-                return "ru"; // Russian
             }
 
             count = GetCount(text, AutoDetectWordsUkrainian);
             if (count > bestCount)
             {
-                return "uk"; // Ukrainian
+                Consider("uk", count); // Ukrainian
             }
 
             count = GetCount(text, AutoDetectWordsBulgarian);
@@ -617,16 +691,18 @@ namespace Nikse.SubtitleEdit.Core.Common
                 var macedonianCount = GetCount(text, AutoDetectWordsMacedonian);
                 if (macedonianCount > count)
                 {
-                    return "mk";
+                    Consider("mk", count);
                 }
-
-                return "bg"; // Bulgarian
+                else
+                {
+                    Consider("bg", count); // Bulgarian
+                }
             }
 
             count = GetCount(text, AutoDetectWordsAlbanian);
             if (count > bestCount)
             {
-                return "sq"; // Albanian
+                Consider("sq", count); // Albanian
             }
 
             count = GetCount(text, AutoDetectWordsArabic);
@@ -636,20 +712,20 @@ namespace Nikse.SubtitleEdit.Core.Common
                 var farsiCount = GetCount(text, AutoDetectWordsFarsi);
                 if (hebrewCount < count && farsiCount < count)
                 {
-                    return "ar"; // Arabic
+                    Consider("ar", count); // Arabic
                 }
             }
 
             count = GetCount(text, AutoDetectWordsHebrew);
             if (count > bestCount)
             {
-                return "he"; // Hebrew
+                Consider("he", count); // Hebrew
             }
 
             count = GetCount(text, AutoDetectWordsFarsi);
             if (count > bestCount)
             {
-                return "fa"; // Farsi (Persian)
+                Consider("fa", count); // Farsi (Persian)
             }
 
             count = GetCount(text, AutoDetectWordsCroatianAndSerbian);
@@ -662,66 +738,75 @@ namespace Nikse.SubtitleEdit.Core.Common
                 {
                     if (slovenianCount > croatianCount)
                     {
-                        return "sl";
+                        Consider("sl", count);
                     }
-
-                    return "hr"; // Croatian
+                    else
+                    {
+                        Consider("hr", count); // Croatian
+                    }
                 }
-
-                if (slovenianCount > count)
+                else if (slovenianCount > count)
                 {
-                    return "sl";
+                    Consider("sl", count);
                 }
-
-                return "sr"; // Serbian
+                else
+                {
+                    Consider("sr", count); // Serbian
+                }
             }
 
             count = GetCount(text, AutoDetectWordsVietnamese);
             if (count > bestCount)
             {
-                return "vi"; // Vietnamese
+                Consider("vi", count); // Vietnamese
             }
 
             count = GetCount(text, AutoDetectWordsHungarian);
             if (count > bestCount)
             {
-                return "hu"; // Hungarian
+                Consider("hu", count); // Hungarian
             }
 
             count = GetCount(text, AutoDetectWordsTurkish);
             if (count > bestCount)
             {
-                return "tr"; // Turkish
+                Consider("tr", count); // Turkish
             }
 
             count = GetCount(text, AutoDetectWordsIndonesian);
             if (count > bestCount)
             {
-                return "id"; // Indonesian
+                Consider("id", count); // Indonesian
+            }
+
+            count = GetCount(text, AutoDetectWordsTagalog);
+            if (count > bestCount)
+            {
+                Consider("tl", count); // Tagalog / Filipino
             }
 
             count = GetCount(text, AutoDetectWordsThai);
             if (count > 10 || count > bestCount)
             {
-                return "th"; // Thai
+                Consider("th", count); // Thai
             }
 
             count = GetCount(text, AutoDetectWordsKorean);
             if (count > 10 || count > bestCount)
             {
-                return "ko"; // Korean
+                Consider("ko", count); // Korean
             }
 
             count = GetCount(text, AutoDetectWordsFinnish);
             if (count > bestCount)
             {
-                return "fi"; // Finnish
+                Consider("fi", count); // Finnish
             }
 
             count = GetCount(text, AutoDetectWordsRomanian);
             if (count > bestCount)
             {
-                return "ro"; // Romanian
+                Consider("ro", count); // Romanian
             }
 
             count = GetCountContains(text, "シ", "ュ", "シン", "シ", "ン", "ユ");
@@ -730,7 +815,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             count += GetCountContains(text, "シ", "ュ", "シ", "ン", "だ", "う");
             if (count > bestCount * 2)
             {
-                return "ja"; // Japanese - not tested...
+                Consider("ja", count); // Japanese - not tested...
             }
 
             count = GetCountContains(text, "是", "是早", "吧", "的", "爱", "上好");
@@ -739,7 +824,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             count += GetCountContains(text, "来", "卡", "拉", "吐", "滚", "他");
             if (count > bestCount * 2)
             {
-                return "zh"; // Chinese (simplified) - not tested...
+                Consider("zh", count); // Chinese (simplified) - not tested...
             }
 
             count = GetCount(text, AutoDetectWordsCzechAndSlovak);
@@ -750,19 +835,20 @@ namespace Nikse.SubtitleEdit.Core.Common
                 var estonianCount = GetCount(text, AutoDetectWordsEstonian);
                 if (estonianCount > count && estonianCount > lithuanianCount && estonianCount > finnishCount)
                 {
-                    return "et";
+                    Consider("et", count);
                 }
-
-                if (lithuanianCount <= count && finnishCount < count)
+                else if (lithuanianCount <= count && finnishCount < count)
                 {
                     int czechWordsCount = GetCount(text, AutoDetectWordsCzech);
                     int slovakWordsCount = GetCount(text, AutoDetectWordsSlovak);
                     if (czechWordsCount >= slovakWordsCount)
                     {
-                        return "cs"; // Czech
+                        Consider("cs", count); // Czech
                     }
-
-                    return "sk"; // Slovak
+                    else
+                    {
+                        Consider("sk", count); // Slovak
+                    }
                 }
             }
 
@@ -772,61 +858,63 @@ namespace Nikse.SubtitleEdit.Core.Common
                 var estonianCount = GetCount(text, AutoDetectWordsEstonian);
                 if (estonianCount > count)
                 {
-                    return "et";
+                    Consider("et", count);
                 }
-
-                return "sl";
+                else
+                {
+                    Consider("sl", count);
+                }
             }
 
             count = GetCount(text, AutoDetectWordsEstonian);
             if (count > bestCount)
             {
-                return "et";
+                Consider("et", count);
             }
 
             count = GetCount(text, AutoDetectWordsLatvian);
             if (count > bestCount * 1.2)
             {
-                return "lv";
+                Consider("lv", count);
             }
 
             count = GetCount(text, AutoDetectWordsLithuanian);
             if (count > bestCount)
             {
-                return "lt";
+                Consider("lt", count);
             }
 
             count = GetCount(text, AutoDetectWordsHindi);
             if (count > bestCount)
             {
-                return "hi";
+                Consider("hi", count);
             }
 
             count = GetCount(text, AutoDetectWordsUrdu);
             if (count > bestCount)
             {
-                return "ur";
+                Consider("ur", count);
             }
 
             count = GetCount(text, AutoDetectWordsSinhalese);
             if (count > bestCount)
             {
-                return "si";
+                Consider("si", count);
             }
 
             count = GetCount(text, AutoDetectWordsMacedonian);
             if (count > bestCount)
             {
-                return "mk";
+                Consider("mk", count);
             }
 
             count = GetCount(text, AutoDetectWordsIcelandic);
             if (count > bestCount)
             {
-                return "is";
+                Consider("is", count);
             }
 
-            return string.Empty;
+            return best;
         }
 
         public static string AutoDetectGoogleLanguage(Subtitle subtitle)
@@ -1021,6 +1109,21 @@ namespace Nikse.SubtitleEdit.Core.Common
                 {
                     LanguageCode = "id",
                     Words = AutoDetectWordsIndonesian,
+                },
+                new LanguageForAutoDetect
+                {
+                    LanguageCode = "tl",
+                    Words = AutoDetectWordsTagalog,
+                },
+                new LanguageForAutoDetect
+                {
+                    LanguageCode = "ca",
+                    Words = AutoDetectWordsCatalan,
+                },
+                new LanguageForAutoDetect
+                {
+                    LanguageCode = "af",
+                    Words = AutoDetectWordsAfrikaans,
                 },
                 new LanguageForAutoDetect
                 {

--- a/tests/libse/Core/LanguageAutoDetectShortFileTest.cs
+++ b/tests/libse/Core/LanguageAutoDetectShortFileTest.cs
@@ -1,0 +1,179 @@
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace LibSETests.Core;
+
+/// <summary>
+/// Characterization tests for language auto-detection on *short* subtitles (a handful
+/// of lines), focused on the most-used subtitle languages. Short files are the weak
+/// spot: the detector's threshold is <c>paragraphs.Count / 14</c> (== 0 below 14 lines),
+/// and it returns the first language whose keyword count clears that threshold — a fixed
+/// priority order (English, Danish, Norwegian, Swedish, Spanish, ...), not an argmax.
+/// So a couple of ambiguous tokens can hand a short clip to the wrong (earlier) language.
+///
+/// These tests assert the language a human would obviously pick. Any that fail mark a
+/// real short-file detection gap to improve.
+/// </summary>
+public class LanguageAutoDetectShortFileTest
+{
+    private static string? Detect(params string[] lines)
+    {
+        var sub = new Subtitle();
+        var start = 0;
+        foreach (var line in lines)
+        {
+            sub.Paragraphs.Add(new Paragraph(line, start, start + 2000));
+            start += 2500;
+        }
+
+        sub.Renumber();
+        return LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(sub);
+    }
+
+    [Fact]
+    public void ShortEnglish()
+    {
+        Assert.Equal("en", Detect(
+            "What are you doing here?",
+            "I thought you would know."));
+    }
+
+    [Fact]
+    public void ShortSpanish()
+    {
+        Assert.Equal("es", Detect(
+            "¿Qué estás haciendo aquí?",
+            "No lo sé, muchas gracias."));
+    }
+
+    [Fact]
+    public void ShortPortuguese()
+    {
+        Assert.Equal("pt", Detect(
+            "O que você está fazendo?",
+            "Não sei, muito obrigado."));
+    }
+
+    [Fact]
+    public void ShortFrench()
+    {
+        Assert.Equal("fr", Detect(
+            "Qu'est-ce que tu fais ici?",
+            "Je ne sais pas, merci."));
+    }
+
+    [Fact]
+    public void ShortGerman()
+    {
+        Assert.Equal("de", Detect(
+            "Was machst du hier?",
+            "Ich weiß es nicht, danke."));
+    }
+
+    [Fact]
+    public void ShortItalian()
+    {
+        Assert.Equal("it", Detect(
+            "Cosa stai facendo qui?",
+            "Non lo so, grazie mille."));
+    }
+
+    [Fact]
+    public void ShortDutch()
+    {
+        Assert.Equal("nl", Detect(
+            "Wat ben je hier aan het doen?",
+            "Ik weet het niet, alleen jij."));
+    }
+
+    [Fact]
+    public void ShortRussian()
+    {
+        Assert.Equal("ru", Detect(
+            "Что ты здесь делаешь?",
+            "Я не знаю, спасибо."));
+    }
+
+    [Fact]
+    public void ShortArabic()
+    {
+        Assert.Equal("ar", Detect(
+            "ماذا تفعل هنا؟",
+            "لا أعرف، شكرا لك."));
+    }
+
+    [Fact]
+    public void ShortTurkish()
+    {
+        Assert.Equal("tr", Detect(
+            "Burada ne yapıyorsun?",
+            "Bilmiyorum, teşekkür ederim."));
+    }
+
+    [Fact]
+    public void ShortPolish()
+    {
+        Assert.Equal("pl", Detect(
+            "Co ty tu robisz?",
+            "Nie wiem, dziękuję bardzo."));
+    }
+
+    // Even shorter — a single line. This is the hardest case and most likely to be
+    // undetectable (null) or wrong.
+    [Fact]
+    public void SingleLineSpanish()
+    {
+        Assert.Equal("es", Detect("¿Dónde está mi dinero, señor?"));
+    }
+
+    [Fact]
+    public void SingleLinePortuguese()
+    {
+        Assert.Equal("pt", Detect("Você não sabe o que está acontecendo."));
+    }
+
+    [Fact]
+    public void SingleLineFrench()
+    {
+        Assert.Equal("fr", Detect("Pourquoi est-ce que vous êtes ici?"));
+    }
+
+    // Broader coverage of the most-subtitled languages, written from natural two-line
+    // dialogue (not tailored to the detector's word lists). These are the languages a
+    // short clip currently resolves correctly; they guard against regressions.
+    [Theory]
+    // Nordic
+    [InlineData("da", "Hvad laver du her?", "Det ved jeg ikke, mange tak.")]
+    [InlineData("sv", "Vad gör du här?", "Jag vet inte, tack så mycket.")]
+    [InlineData("no", "Hva gjør du her?", "Jeg vet ikke, tusen takk.")]
+    [InlineData("fi", "Mitä sinä teet täällä?", "En tiedä, kiitos paljon.")]
+    // Central / Eastern Europe (Latin)
+    [InlineData("sk", "Čo tu robíš?", "Neviem, ďakujem pekne.")]
+    [InlineData("hu", "Mit csinálsz itt?", "Nem tudom, köszönöm szépen.")]
+    [InlineData("ro", "Ce faci aici?", "Nu știu, mulțumesc mult.")]
+    [InlineData("hr", "Što radiš ovdje?", "Ne znam, hvala lijepo.")]
+    [InlineData("sl", "Kaj delaš tukaj?", "Ne vem, hvala lepa.")]
+    [InlineData("et", "Mida sa siin teed?", "Ma ei tea, suur tänu.")]
+    // Cyrillic
+    [InlineData("bg", "Какво правиш тук?", "Не знам, благодаря.")]
+    [InlineData("sr", "Шта радиш овде?", "Не знам, хвала.")]
+    // Greek
+    [InlineData("el", "Τι κάνεις εδώ;", "Δεν ξέρω, ευχαριστώ πολύ.")]
+    // Middle East
+    [InlineData("he", "מה אתה עושה כאן?", "אני לא יודע, תודה רבה.")]
+    // Asia
+    [InlineData("ja", "ここで何をしているの？", "わからない、ありがとう。")]
+    [InlineData("zh", "你在这里做什么？", "我不知道，谢谢你。")]
+    [InlineData("ko", "여기서 뭐 하고 있어요?", "몰라요, 감사합니다.")]
+    [InlineData("vi", "Bạn đang làm gì ở đây?", "Tôi không biết, cảm ơn.")]
+    [InlineData("id", "Apa yang kamu lakukan di sini?", "Aku tidak tahu, terima kasih.")]
+    [InlineData("th", "คุณกำลังทำอะไรอยู่ที่นี่", "ฉันไม่รู้ ขอบคุณมาก")]
+    [InlineData("hi", "तुम यहाँ क्या कर रहे हो?", "मुझे नहीं पता, धन्यवाद।")]
+    // Newly added word-lists
+    [InlineData("ca", "Què fas aquí?", "No ho sé, moltes gràcies.")]        // Catalan
+    [InlineData("tl", "Ano ang ginagawa mo dito?", "Hindi ko alam, salamat.")] // Tagalog / Filipino
+    [InlineData("af", "Wat maak jy hier?", "Ek weet nie, baie dankie.")]    // Afrikaans
+    public void ShortClip(string expected, string line1, string line2)
+    {
+        Assert.Equal(expected, Detect(line1, line2));
+    }
+}


### PR DESCRIPTION
## Problem

Language auto-detection was weak on **short files** (< ~14 lines). `AutoDetectGoogleLanguage` used a **first-match-wins** scan over a fixed priority order (English, Danish, …, Spanish 5th, Portuguese 8th), gated by a threshold of `paragraphs.Count / 14` — which is `0` below 14 lines. So a single ambiguous token handed a short clip to whichever language sat *earliest* in the order (e.g. a short Portuguese clip → `es`), and case-sensitive keyword matching missed sentence-initial capitalized words.

## Changes (`LanguageAutoDetect`)

1. **Score-based selection instead of first-match-wins.** Every language block now records a candidate via a `Consider()` helper; the candidate with the most keyword hits wins (strict `>` so ties keep the earlier/higher-priority language). All the hand-tuned pairwise disambiguation guards (es↔pt/fr, ru↔bg/uk/mk, hr↔sr/sl, cs↔sk, da↔no/sv/is …) are **preserved exactly** — only the outer control flow changed.

2. **Case-insensitive keyword matching**, so a keyword still matches at the start of a sentence. Biggest impact on short/single-line subtitles, where most words are sentence-initial.

3. **Three new languages:** Catalan (`ca`), Tagalog/Filipino (`tl`), Afrikaans (`af`) — previously misdetected as garbage or `null`. Each word-list is collision-aware so it never steals a close relative:
   - **Afrikaans** uses only words that aren't also valid Dutch (the Dutch list is small; shared words would leak).
   - **Catalan** relies on accents to separate from Spanish (`què`/`gràcies` ≠ `qué`/`gracias`).
   - **Tagalog** uses distinctive Austronesian function words (Spanish loanwords excluded).
   - Also registered in `GetLanguagesWithCount`.

## Tests

New `LanguageAutoDetectShortFileTest` — 38 short-clip cases across the most-subtitled languages, written from natural dialogue (not tailored to the word lists). Before: short Portuguese/Turkish/etc. mis-detected; after: correct.

**Full libse suite: 661 pass. seconv: 261 pass. No regressions.**

## Still missing (not in this PR)

Probing surfaced other gaps left for a follow-up: Tamil/Telugu (`null` — script not in the letter fallback), and close-relative conflations on short clips (Ukrainian→`ru`, Persian→`ar`, Azerbaijani→`tr`, Malay→`id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)