### PR TITLE
Hold waveform playhead frozen after pause instead of snapping (#12740)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -21727,10 +21727,11 @@ public partial class MainViewModel :
             // (before mpv's IsPlaying flips ~100 ms later) so the cursor stops on the keypress instead
             // of gliding on (#12033 follow-up). mpv then keeps decoding for ~100-200 ms and its reported
             // position settles a little past (or, if we'd extrapolated ahead, behind) the frozen spot.
-            // We hold the cursor dead-frozen through that wind-down and, the moment mpv's clock comes to
-            // rest, snap once to that final frame. Landing in a single step at settle - instead of easing
-            // toward it a few hundred ms later - keeps all cursor motion coincident with the pause, so the
-            // cursor no longer drifts forward/backward after the time display has already stopped (#12740).
+            // We hold the cursor dead-frozen at the keypress instant and do NOT reconcile that small
+            // residual: the video frame stopped where the cursor is, and any later move toward mpv's
+            // settled frame - whether eased or snapped in one step - reads as the cursor drifting a
+            // moment after the numeric time display has already stopped (#12740). Only a real
+            // discontinuity (a seek while paused, beyond the resync threshold) moves the cursor now.
             if (!vp.IsPlaying)
             {
                 if (_playheadWasPlaying)
@@ -21768,12 +21769,14 @@ public partial class MainViewModel :
             }
             else if (!_playheadPausedSettled && !vp.IsPlaying && rawStableMs >= PlayheadPausedSettleStableMs)
             {
-                // mpv's clock has come to rest at the true paused frame: land on it, once, then hold.
-                _playheadEstimateSeconds = rawPosition;
+                // mpv's clock has come to rest after the pause wind-down. Hold the cursor at the frozen
+                // keypress spot rather than snapping to mpv's settled frame: the video stopped where the
+                // cursor already is, and snapping here showed as the cursor shifting slightly after the
+                // numeric time display had already stopped (#12740). Just mark settled so we stop watching.
                 _playheadPausedSettled = true;
             }
             // else: still winding down, or already settled with a small residual -> hold frozen (no
-            // easing => no post-pause drift).
+            // easing, no delayed snap => no post-pause drift).
 
             _playheadValid = true;
         }


### PR DESCRIPTION
## Follow-up to #12742 (RC13) for #12740

The reporter [confirmed on the issue](https://github.com/SubtitleEdit/subtitleedit/issues/12740#issuecomment-5057958561) that RC13 *"significantly improved"* the post-pause playhead drift, but a **small residual movement still happens intermittently** when pausing with the mouse Play/Pause button: the numeric time display stops and the button flips to Play, then the waveform playhead shifts slightly *a moment later*.

### Root cause of the residual

RC13 (`3dae503f5`) replaced the old easing drift with a single **snap** to mpv's settled frame once its clock came to rest. But that snap fires ~100 ms after the keypress freeze — *after* the numeric time display (bound directly to mpv's `Position`) has already settled — so it still reads as the cursor shifting a moment after pausing, in either direction depending on where mpv's wind-down lands relative to the frozen spot.

The gap is structural: mpv keeps decoding ~100–200 ms after a pause, so its final reported frame is a little past (or behind) the keypress-frozen estimate. You can have **zero post-pause motion** *or* an **exact match** to mpv's settled frame, not both — mpv itself moves the number after the display already showed it.

### The change

Match SE 4's behavior (stop immediately, stay put): hold the cursor dead-frozen at the keypress instant and no longer reconcile that sub-frame wind-down residual. The settle branch now just marks the pause settled instead of moving the estimate onto mpv's raw position.

The offset left behind is **static and visually indistinguishable**; the delayed snap was not.

### Scope / safety

Only the wind-down reconciliation changes — it's gated on `!_playheadPausedSettled`, a flag cleared *only* by pause commands and the play→pause edge, so every other path is behaviorally identical to RC13:

- **Freeze-on-keypress** (#12033/#12233) — untouched.
- **Pinned seeks** (`PinPlayheadTo`: waveform click, stop, next/prev cue) — untouched.
- **Real discontinuities** (a seek while paused beyond the resync threshold) — still snap.

### Testing

Builds clean (0 warnings). This is timing/mpv-dependent UI with no estimator unit tests, so it needs a manual check: pause repeatedly with the mouse Play/Pause button and confirm the playhead no longer shifts after the time display stops — and, as a regression check, that frame-step / nudge / waveform-click while paused still move the cursor normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)