### PR TITLE
Follow small paused seeks so the waveform cursor stays centered (#12742)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -21761,11 +21761,22 @@ public partial class MainViewModel :
             var rawStableMs = (nowTimestamp - _playheadLastRawChangeTs) / (double)Stopwatch.Frequency * 1000.0;
             var gap = rawPosition - _playheadEstimateSeconds;
 
-            if (!_playheadValid || Math.Abs(gap) < 0.002 || Math.Abs(gap) >= PlayheadResyncThresholdSeconds)
+            if (!_playheadValid || Math.Abs(gap) >= PlayheadResyncThresholdSeconds)
             {
-                // Invalid, a sub-visible gap, or a real discontinuity (a seek while paused): snap.
+                // Invalid state, or a real discontinuity (a big seek while paused): snap, and treat the
+                // pause as settled. (No sub-visible < 2 ms snap here: it would flip _playheadPausedSettled
+                // early if mpv's position crossed the frozen spot mid-wind-down, and the seek-follow branch
+                // below would then track the rest of the wind-down - the very drift #12740 removed.)
                 _playheadEstimateSeconds = rawPosition;
                 _playheadPausedSettled = true;
+            }
+            else if (_playheadPausedSettled && rawChanged)
+            {
+                // Already settled after the pause, and mpv's position just moved: this is a real seek
+                // while paused (millisecond nudge, frame step, native mpv frame step) - not the pause
+                // wind-down. Follow it so the cursor lands on the stepped frame and stays centered
+                // (#12742 follow-up). Snapping, rather than easing, puts the cursor on the frame at once.
+                _playheadEstimateSeconds = rawPosition;
             }
             else if (!_playheadPausedSettled && !vp.IsPlaying && rawStableMs >= PlayheadPausedSettleStableMs)
             {
@@ -21775,8 +21786,8 @@ public partial class MainViewModel :
                 // numeric time display had already stopped (#12740). Just mark settled so we stop watching.
                 _playheadPausedSettled = true;
             }
-            // else: still winding down, or already settled with a small residual -> hold frozen (no
-            // easing, no delayed snap => no post-pause drift).
+            // else: still winding down, or settled with a standing residual and raw at rest -> hold frozen
+            // (no easing, no delayed snap => no post-pause drift).
 
             _playheadValid = true;
         }


### PR DESCRIPTION
## Regression from #12742 (RC13), reported [here](https://github.com/SubtitleEdit/subtitleedit/pull/12742#issuecomment-5057641350)

@Surlime found that after RC13, the waveform cursor **doesn't stay centered on small paused step-seeks** — both millisecond mode and frame mode. The waveform scrolls to the new position but the blue cursor is left behind / off-center.

### Root cause

RC13's #12740 fix stopped the paused branch of `UpdatePlayheadEstimate` from reconciling the interpolated cursor to mpv's position for gaps below the resync threshold. That's correct for mpv's **post-pause wind-down**, but it also stranded the cursor after a small **user seek** while paused:

- ms nudge / snapped frame step → `SetVideoPositionSeconds` moves `vp.Position` and re-centers the waveform, but never pins the playhead.
- native frame step → `mpv.StepOneFrameBack/Forward` moves mpv, nothing pins.

So the cursor (`_playheadEstimateSeconds`) was held at the old spot while the waveform centered on the new one → off-center. Pre-RC13 the paused branch *eased* the cursor onto the new position; RC13 removed that.

### The fix

The two events look identical ("a small position change while paused") but `_playheadPausedSettled` already distinguishes them: the wind-down is the `settled == false` window; a real step-seek happens later, `settled == true`. So:

- **settled + mpv position actually changed** → real paused seek → follow it (snap onto the stepped frame, cursor stays centered).
- **winding down** (`settled == false`) → keep holding → **#12740 stays fixed**.

Handled at the estimate level so it covers all step paths uniformly (snapped frame step, ms nudge, and the native mpv frame step, which doesn't expose its landing position synchronously for a pin-based fix).

Also dropped the sub-visible `< 2 ms` snap from the discontinuity branch: it set `settled = true`, which — if mpv's position crossed the frozen spot mid-wind-down — would let the new seek-follow branch track the rest of the wind-down and bring the #12740 drift back. The snap was invisible anyway; removing it keeps `settled` owned solely by a real discontinuity, the 100 ms wind-down rest, or `PinPlayheadTo`.

Net: **pauses hold** (no expected motion → no drift), **seeks follow** (cursor lands on the frame and stays centered).

### Testing

Builds clean (0 warnings). Timing/mpv-dependent UI with no estimator unit tests, so it needs a manual check:
- Frame-step and ms-step while paused (both center modes) → cursor lands on the stepped frame and stays centered.
- Regression check for #12740: pause with mouse/Space → no residual cursor drift after the time display stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)