### PR TITLE
seconv: map FCE rule IDs to GUI labels + restore --apply-min-gap docs

### DIFF
--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -477,6 +477,15 @@ Operations run after the structural transforms (offset, fps, renumber, adjust-du
 seconv *.srt subrip --remove-text-for-hi --merge-same-texts --split-long-lines --overwrite
 ```
 
+#### `--apply-min-gap` vs `--fix-common-errors-rules:FixOverlappingDisplayTimes`
+
+Both touch boundary timings but solve different problems:
+
+- **`--apply-min-gap[:<ms>]`** walks every pair of adjacent paragraphs and, when the gap is shorter than `<ms>`, **shortens the previous cue's end time** to open it up. It does **not** move the next cue's start. Pairs are also **skipped** when shortening would drop the previous cue below `General.SubtitleMinimumDisplayMilliseconds` — so this is best-effort, not a hard guarantee. Use it for delivery specs (e.g. broadcast standards that ask for 2 frames between cues) while accepting that minimum-display-duration collisions are left alone.
+- **`FixOverlappingDisplayTimes`** is one rule inside Fix Common Errors and only resolves cases where a paragraph's end > the next paragraph's start (a true overlap). It does *not* enforce a non-zero minimum gap once overlaps are gone.
+
+In most batch pipelines `--apply-min-gap` is the better choice; reach for the FCE rule when you specifically want to keep the tight gaps the source already has and only repair true overlaps.
+
 ### FixCommonErrors rule selection
 
 `--fix-common-errors` (no value) runs all 39 rules. Pass `--fix-common-errors-rules:<list>` to pick a subset — supplying that option implies `--fix-common-errors`.
@@ -498,7 +507,54 @@ There are two ways to override the gate:
 
 **Rule selection is CLI-only.** The set of rules is chosen with `--fix-common-errors-rules`, not through the `--settings` JSON. The settings file shapes *how* the rules behave (line length, min gap, dialog/continuation style, CPS — see [Settings JSON](#settings-json)); it does not select which rules run.
 
-`FixCommonOcrErrors` is intentionally excluded — it requires UI-side spell-check and OCR-engine setup that seconv doesn't carry.
+`FixCommonOcrErrors` runs only when a dictionary folder is available — bundled for English, or supplied via `--dictionary-folder` for other languages (see [OCR options](#ocr)). Without one, that rule is skipped and every other rule still runs.
+
+#### Rule ID ↔ GUI equivalent
+
+The CLI rule IDs match the check-box rules in the desktop app's *Fix Common Errors* window. If you prototyped a fix set in the GUI, use this table (or `seconv list-fce-rules`, which prints the same three columns) to find the matching `--fix-common-errors-rules` IDs. *Language gate* marks rules that only run for one detected language (override with `--fce-language`, or by naming the rule).
+
+| Rule ID | GUI equivalent | Language gate |
+|---|---|---|
+| `AddMissingQuotes` | Add missing quotes (") | — |
+| `Fix3PlusLines` | Fix subtitles with more than two lines | — |
+| `FixAloneLowercaseIToUppercaseI` | Fix alone lowercase 'i' to 'I' (English) | en only |
+| `FixCommas` | Fix commas | — |
+| `FixContinuationStyle` | Fix continuation style | — |
+| `FixDanishLetterI` | Fix Danish letter 'i' | da only |
+| `FixDialogsOnOneLine` | Split dialogs on one line | — |
+| `FixDoubleApostrophes` | Fix double apostrophe characters ('') to a single quote (") | — |
+| `FixDoubleDash` | Fix '--' -> '...' | — |
+| `FixDoubleGreaterThan` | Remove '>>' | — |
+| `FixEllipsesStart` | Remove leading '...' | — |
+| `FixEmptyLines` | Remove empty lines/unused line breaks | — |
+| `FixHyphensInDialog` | Fix dash in dialogs via style | — |
+| `FixHyphensRemoveDashSingleLine` | Remove dialog dashes in single lines | — |
+| `FixInvalidItalicTags` | Fix invalid italic tags | — |
+| `FixLongDisplayTimes` | Fix long display times | — |
+| `FixLongLines` | Break long lines | — |
+| `FixMissingOpenBracket` | Fix missing [ or ( in line | — |
+| `FixMissingPeriodsAtEndOfLine` | Add period after lines where next line starts with uppercase letter | — |
+| `FixMissingSpaces` | Fix missing spaces | — |
+| `FixMusicNotation` | Replace music symbols with preferred symbol | — |
+| `FixOverlappingDisplayTimes` | Fix overlapping display times | — |
+| `FixShortDisplayTimes` | Fix short display times | — |
+| `FixShortGaps` | Fix short gaps | — |
+| `FixShortLines` | Remove line breaks in short texts with only one sentence | — |
+| `FixShortLinesAll` | Remove line breaks in short texts (all except dialogs) | — |
+| `FixShortLinesPixelWidth` | Unbreak subtitles that can fit on one line (pixel width) | — |
+| `FixSpanishInvertedQuestionAndExclamationMarks` | Fix Spanish inverted question and exclamation marks | es only |
+| `FixStartWithUppercaseLetterAfterColon` | Start with uppercase letter after colon/semicolon | — |
+| `FixStartWithUppercaseLetterAfterParagraph` | Start with uppercase letter after paragraph | — |
+| `FixStartWithUppercaseLetterAfterPeriodInsideParagraph` | Start with uppercase letter after period inside paragraph | — |
+| `FixTurkishAnsiToUnicode` | Fix Turkish ANSI (Icelandic) letters to Unicode | tr only |
+| `FixUnnecessaryLeadingDots` | Remove unnecessary leading dots | — |
+| `FixUnneededPeriods` | Remove unneeded periods | — |
+| `FixUnneededSpaces` | Remove unneeded spaces | — |
+| `FixUppercaseIInsideWords` | Fix uppercase 'i' inside lowercase words (OCR error) | — |
+| `NormalizeStrings` | Normalize strings | — |
+| `RemoveDialogFirstLineInNonDialogs` | Remove start dash in first line for non-dialogs | — |
+| `RemoveSpaceBetweenNumbers` | Remove space between numbers | — |
+| `FixCommonOcrErrors` | Fix common OCR errors (using OCR replace list) | — |
 
 ## Output format aliases
 

--- a/src/seconv/Core/FixCommonErrorsRunner.cs
+++ b/src/seconv/Core/FixCommonErrorsRunner.cs
@@ -51,6 +51,60 @@ internal static class FixCommonErrorsRunner
         };
 
     /// <summary>
+    /// Maps each CLI rule ID to the label the GUI's <em>Fix Common Errors</em> window shows for
+    /// the same rule, so users who prototyped in the desktop app can find the matching
+    /// <c>--fix-common-errors-rules</c> ID (issue #11037 review). Single source of truth for the
+    /// <c>list-fce-rules</c> "GUI equivalent" column and the published rule-mapping table.
+    /// Kept in sync with the GUI strings in <c>LanguageFixCommonErrors</c> /
+    /// <c>FixCommonErrorsViewModel.MakeDefaultRules</c>; a test asserts every
+    /// <see cref="AvailableRuleIds"/> entry has a label here.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> GuiLabels { get; } =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [nameof(AddMissingQuotes)] = "Add missing quotes (\")",
+            [nameof(Fix3PlusLines)] = "Fix subtitles with more than two lines",
+            [nameof(FixAloneLowercaseIToUppercaseI)] = "Fix alone lowercase 'i' to 'I' (English)",
+            [nameof(FixCommas)] = "Fix commas",
+            [nameof(FixContinuationStyle)] = "Fix continuation style",
+            [nameof(FixDanishLetterI)] = "Fix Danish letter 'i'",
+            [nameof(FixDialogsOnOneLine)] = "Split dialogs on one line",
+            [nameof(FixDoubleApostrophes)] = "Fix double apostrophe characters ('') to a single quote (\")",
+            [nameof(FixDoubleDash)] = "Fix '--' -> '...'",
+            [nameof(FixDoubleGreaterThan)] = "Remove '>>'",
+            [nameof(FixEllipsesStart)] = "Remove leading '...'",
+            [nameof(FixEmptyLines)] = "Remove empty lines/unused line breaks",
+            [nameof(FixHyphensInDialog)] = "Fix dash in dialogs via style",
+            [nameof(FixHyphensRemoveDashSingleLine)] = "Remove dialog dashes in single lines",
+            [nameof(FixInvalidItalicTags)] = "Fix invalid italic tags",
+            [nameof(FixLongDisplayTimes)] = "Fix long display times",
+            [nameof(FixLongLines)] = "Break long lines",
+            [nameof(FixMissingOpenBracket)] = "Fix missing [ or ( in line",
+            [nameof(FixMissingPeriodsAtEndOfLine)] = "Add period after lines where next line starts with uppercase letter",
+            [nameof(FixMissingSpaces)] = "Fix missing spaces",
+            [nameof(FixMusicNotation)] = "Replace music symbols with preferred symbol",
+            [nameof(FixOverlappingDisplayTimes)] = "Fix overlapping display times",
+            [nameof(FixShortDisplayTimes)] = "Fix short display times",
+            [nameof(FixShortGaps)] = "Fix short gaps",
+            [nameof(FixShortLines)] = "Remove line breaks in short texts with only one sentence",
+            [nameof(FixShortLinesAll)] = "Remove line breaks in short texts (all except dialogs)",
+            [nameof(FixShortLinesPixelWidth)] = "Unbreak subtitles that can fit on one line (pixel width)",
+            [nameof(FixSpanishInvertedQuestionAndExclamationMarks)] = "Fix Spanish inverted question and exclamation marks",
+            [nameof(FixStartWithUppercaseLetterAfterColon)] = "Start with uppercase letter after colon/semicolon",
+            [nameof(FixStartWithUppercaseLetterAfterParagraph)] = "Start with uppercase letter after paragraph",
+            [nameof(FixStartWithUppercaseLetterAfterPeriodInsideParagraph)] = "Start with uppercase letter after period inside paragraph",
+            [nameof(FixTurkishAnsiToUnicode)] = "Fix Turkish ANSI (Icelandic) letters to Unicode",
+            [nameof(FixUnnecessaryLeadingDots)] = "Remove unnecessary leading dots",
+            [nameof(FixUnneededPeriods)] = "Remove unneeded periods",
+            [nameof(FixUnneededSpaces)] = "Remove unneeded spaces",
+            [nameof(FixUppercaseIInsideWords)] = "Fix uppercase 'i' inside lowercase words (OCR error)",
+            [nameof(NormalizeStrings)] = "Normalize strings",
+            [nameof(RemoveDialogFirstLineInNonDialogs)] = "Remove start dash in first line for non-dialogs",
+            [nameof(RemoveSpaceBetweenNumbers)] = "Remove space between numbers",
+            [OcrFixRuleId] = "Fix common OCR errors (using OCR replace list)",
+        };
+
+    /// <summary>
     /// Runs every available rule against the subtitle. Equivalent to
     /// <c>Run(subtitle, null)</c>.
     /// </summary>

--- a/src/seconv/Core/ListHelpers.cs
+++ b/src/seconv/Core/ListHelpers.cs
@@ -76,21 +76,28 @@ internal static class ListHelpers
         AnsiConsole.WriteLine();
         var table = new Table().Border(TableBorder.Rounded);
         table.AddColumn("[yellow]Rule ID[/]");
+        table.AddColumn("[yellow]GUI equivalent[/]");
         table.AddColumn("[yellow]Language gate[/]");
 
         var gates = FixCommonErrorsRunner.LanguageGates;
+        var guiLabels = FixCommonErrorsRunner.GuiLabels;
         foreach (var id in FixCommonErrorsRunner.AvailableRuleIds)
         {
+            // GUI equivalent: the checkbox label the desktop Fix Common Errors window shows for
+            // this rule, so users who prototyped in the GUI can find the matching CLI ID (#11037).
+            var gui = guiLabels.TryGetValue(id, out var label) ? $"[cyan]{label.EscapeMarkup()}[/]" : "[dim]—[/]";
+
             // Language-gated rules only run when the subtitle's language (auto-detected, or
             // forced via --fce-language) matches. Mark them so the gate is discoverable from
             // the CLI without reading the source.
             var gate = gates.TryGetValue(id, out var lang) ? $"[magenta]{lang} only[/]" : "[dim]—[/]";
-            table.AddRow($"[green]{id}[/]", gate);
+            table.AddRow($"[green]{id}[/]", gui, gate);
         }
 
         AnsiConsole.Write(table);
         AnsiConsole.MarkupLine(
-            "\n[dim]Language-gated rules run only when the subtitle auto-detects to that language.[/]\n" +
+            "\n[dim]The GUI equivalent is the checkbox label in the desktop Fix Common Errors window.[/]\n" +
+            "[dim]Language-gated rules run only when the subtitle auto-detects to that language.[/]\n" +
             "[dim]Force it with[/] [green]--fce-language:<code>[/][dim], or bypass the gate by naming the rule explicitly.[/]");
         AnsiConsole.MarkupLine(
             "\n[dim]Examples:[/]\n" +

--- a/tests/seconv/Core/FixCommonErrorsRunnerTest.cs
+++ b/tests/seconv/Core/FixCommonErrorsRunnerTest.cs
@@ -156,6 +156,34 @@ public class FixCommonErrorsRunnerTest
         Assert.Contains("NotARealRule", ex.Message);
     }
 
+    // Issue #11037 review: users prototype in the GUI, then script. Every rule the CLI
+    // can run must expose a GUI-equivalent label so `list-fce-rules` / the docs can map
+    // CLI IDs back to the desktop window's check-boxes. This guards against a new rule
+    // being added to the runner without a matching label.
+    [Fact]
+    public void GuiLabels_CoversEveryAvailableRule_WithNonEmptyText()
+    {
+        foreach (var id in FixCommonErrorsRunner.AvailableRuleIds)
+        {
+            Assert.True(
+                FixCommonErrorsRunner.GuiLabels.TryGetValue(id, out var label),
+                $"Rule '{id}' has no GUI-equivalent label in FixCommonErrorsRunner.GuiLabels.");
+            Assert.False(string.IsNullOrWhiteSpace(label), $"GUI label for '{id}' is empty.");
+        }
+    }
+
+    [Fact]
+    public void GuiLabels_HasNoLabelForUnknownRule()
+    {
+        // Keep the map tight to the rule set — a stray key would silently drift from
+        // AvailableRuleIds and never surface in list-fce-rules.
+        var available = new HashSet<string>(FixCommonErrorsRunner.AvailableRuleIds, System.StringComparer.OrdinalIgnoreCase);
+        foreach (var id in FixCommonErrorsRunner.GuiLabels.Keys)
+        {
+            Assert.Contains(id, available);
+        }
+    }
+
     // -------------------------------------------------------------------------
     // Issue #11037 item 3: language-conditional rules should mirror the GUI's
     // Fix Common Errors window — Spanish-only rules don't run on non-Spanish


### PR DESCRIPTION
Follow-up to the [#11300 review](https://github.com/SubtitleEdit/subtitleedit/pull/11300#issuecomment-5056200950) (issue #11037). After the earlier FCE follow-ups (#12745, `--fce-language`), @Hlsgs raised two remaining loose ends. This picks them up.

## Item 3 — CLI rule ID ↔ GUI equivalent

> One remaining idea about `--fix-common-errors-rules` would be to have, either in the docs or `seconv list-fce-rules`, a 1:1 matching between the CLI name and the GUI semantic equivalent. […] since most users would probably test in the GUI before committing to scripting, I suspect some head-scratching would ensue.

The CLI rule IDs (`FixEmptyLines`) and the desktop *Fix Common Errors* check-box labels ("Remove empty lines/unused line breaks") don't match by name, so users who prototype in the GUI can't easily find the matching `--fix-common-errors-rules` IDs. Fixed on **both** surfaces:

- **`FixCommonErrorsRunner.GuiLabels`** — a single source-of-truth dictionary mapping every rule ID to its GUI label (mirrored from `LanguageFixCommonErrors` / `FixCommonErrorsViewModel.MakeDefaultRules`).
- **`seconv list-fce-rules`** now prints a **GUI equivalent** column (between Rule ID and Language gate).
- **`docs/reference/command-line.md`** gets a full **Rule ID ↔ GUI equivalent** mapping table.

```
╭───────────────────────────────┬──────────────────────────────┬───────────────╮
│ Rule ID                       │ GUI equivalent               │ Language gate │
├───────────────────────────────┼──────────────────────────────┼───────────────┤
│ FixEmptyLines                 │ Remove empty lines/unused    │ —             │
│                               │ line breaks                  │               │
│ FixSpanishInvertedQuestionAnd │ Fix Spanish inverted         │ es only       │
│ ExclamationMarks              │ question and exclamation     │               │
│                               │ marks                        │               │
╰───────────────────────────────┴──────────────────────────────┴───────────────╯
```

## Item 4 — restore `--apply-min-gap` vs `FixOverlappingDisplayTimes`

> Not sure if that's supposed to be the case, but I'm still not seeing the `--apply-min-gap` vs `FixOverlappingDisplayTimes` stuff in the command-line.md.

Correct — the "when to use which" explainer shipped in #11300's README but was dropped when the reference was consolidated into `command-line.md` (only the option row survived, same failure mode as the `Settings.json` callout #12745 had to restore). Restored as a subsection under **Operations**.

## Bonus correctness fix

The FCE section carried a stale note claiming `FixCommonOcrErrors` is "intentionally excluded." It actually runs when a dictionary folder is available (English bundled, other languages via `--dictionary-folder`, since #11744) — and it would have contradicted the new mapping table, which lists it. Corrected to describe the real behaviour.

## Test plan

- [x] `FixCommonErrorsRunner.GuiLabels` covers exactly `AvailableRuleIds` — 2 new tests (every rule has a non-empty label; no stray keys), so adding a rule without a label fails CI
- [x] Full `SeConvTests` suite: 263/263 pass
- [x] `seconv list-fce-rules` renders the third column correctly
- [x] Build clean, 0 warnings

Refs #11037, #11300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)