### PR TITLE
seconv: gate language-specific FCE rules by language, not by naming

### DIFF
--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -498,12 +498,11 @@ seconv movie.srt subrip --fix-common-errors --fce-language:es                # f
 seconv list-fce-rules                                                        # show rule IDs (marks language gates)
 ```
 
-**Language-specific rules.** A few rules only make sense for one language and mirror the GUI's *Fix Common Errors* window, which only offers them when the detected language matches: `FixAloneLowercaseIToUppercaseI` (English), `FixDanishLetterI` (Danish), `FixSpanishInvertedQuestionAndExclamationMarks` (Spanish), and `FixTurkishAnsiToUnicode` (Turkish). `seconv list-fce-rules` marks each gated rule with its language in a *Language gate* column. In the default all-rules pass these run only when auto-detection agrees, so e.g. the Spanish inverted-`¿` fix never lands on English content (issue #11037).
+**Language-specific rules.** A few rules only make sense for one language and mirror the GUI's *Fix Common Errors* window, which only offers them when the detected language matches: `FixAloneLowercaseIToUppercaseI` (English), `FixDanishLetterI` (Danish), `FixSpanishInvertedQuestionAndExclamationMarks` (Spanish), and `FixTurkishAnsiToUnicode` (Turkish). `seconv list-fce-rules` marks each gated rule with its language in a *Language gate* column. These run **only when the language matches** — so e.g. the Spanish inverted-`¿` fix never lands on English content (issue #11037). This holds however the rule was selected: naming it in `--fix-common-errors-rules` picks it into the run but does **not** bypass the gate, which makes mixed-language batches safe (a Spanish rule in your rule set self-skips on the English and French files).
 
-There are two ways to override the gate:
+The language is auto-detected from the content. To force it:
 
-- **`--fce-language:<code>`** forces the language used for *all* gated rules (and the OCR-fix pass). Use it when a genuinely Spanish/Danish/Turkish file mis-detects (e.g. it's too short) so the right rule still runs. Accepts a two-letter code, three-letter code, or English name (`es`, `spa`, `Spanish`); an unrecognized value warns and falls back to auto-detection.
-- **Naming a gated rule explicitly** in `--fix-common-errors-rules` forces just that rule on, regardless of the detected language.
+- **`--fce-language:<code>`** forces the language used for *all* gated rules (and the OCR-fix pass). Use it when a genuinely Spanish/Danish/Turkish file mis-detects (e.g. it's too short), or to run a named language rule on content that would auto-detect as something else. Accepts a two-letter code, three-letter code, or English name (`es`, `spa`, `Spanish`); an unrecognized value warns and falls back to auto-detection.
 
 **Rule selection is CLI-only.** The set of rules is chosen with `--fix-common-errors-rules`, not through the `--settings` JSON. The settings file shapes *how* the rules behave (line length, min gap, dialog/continuation style, CPS — see [Settings JSON](#settings-json)); it does not select which rules run.
 

--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -523,18 +523,13 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
 
             // Resolve FCE rule selection. Passing --FixCommonErrorsRules implicitly
             // enables --FixCommonErrors so users don't have to specify both.
-            // We also parse out which rules the user named by hand — that's a separate
-            // signal from the resolved set so language-conditional rules can bypass
-            // their gate when explicitly requested (see FixCommonErrorsRunner.Run).
             IReadOnlyList<string> fceRules = [];
-            IReadOnlyList<string> fceExplicitlyNamed = [];
             var fceRequested = settings.FixCommonErrors || !string.IsNullOrWhiteSpace(settings.FixCommonErrorsRules);
             if (fceRequested)
             {
                 try
                 {
                     fceRules = FixCommonErrorsRunner.ResolveRuleIds(settings.FixCommonErrorsRules);
-                    fceExplicitlyNamed = FixCommonErrorsRunner.ParseExplicitlyNamedRules(settings.FixCommonErrorsRules);
                 }
                 catch (ArgumentException ex)
                 {
@@ -650,7 +645,6 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 Overwrite = settings.Overwrite,
                 Operations = operations,
                 FixCommonErrorsRules = fceRules,
-                FixCommonErrorsExplicitlyNamedRules = fceExplicitlyNamed,
                 FixCommonErrorsLanguage = settings.FixCommonErrorsLanguage,
                 DeleteFirst = settings.DeleteFirst,
                 DeleteLast = settings.DeleteLast,

--- a/src/seconv/Core/FixCommonErrorsRunner.cs
+++ b/src/seconv/Core/FixCommonErrorsRunner.cs
@@ -39,7 +39,9 @@ internal static class FixCommonErrorsRunner
     /// <c>--fce-language</c>) matches the mapped two-letter ISO code. Single source of truth
     /// for both the runtime gate (<see cref="IsLanguageOnlyRule"/>) and the <c>list-fce-rules</c>
     /// display. Mirrors the GUI's per-language rule additions in <c>FixCommonErrorsViewModel</c>.
-    /// A gated rule can always be forced by naming it explicitly in <c>--FixCommonErrorsRules</c>.
+    /// A gated rule runs only when the language matches — auto-detected from the content, or
+    /// forced with <c>--fce-language:&lt;code&gt;</c>. Naming it in <c>--FixCommonErrorsRules</c>
+    /// selects it but does not bypass the gate (issue #11037).
     /// </summary>
     public static IReadOnlyDictionary<string, string> LanguageGates { get; } =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -111,30 +113,15 @@ internal static class FixCommonErrorsRunner
     public static void RunAll(Subtitle subtitle) => Run(subtitle, null);
 
     /// <summary>
-    /// Back-compat overload. Pass <c>null</c> or an empty collection to run all rules
-    /// (gates language-conditional rules to their language). When a non-empty list is
-    /// passed, every entry is treated as both <em>wanted</em> and <em>explicitly named</em> —
-    /// language gates are bypassed for those rules. Rules execute in canonical order,
-    /// not caller order, to keep behaviour stable across invocations.
-    /// </summary>
-    public static void Run(Subtitle subtitle, IReadOnlyCollection<string>? ruleIds)
-        => Run(subtitle, ruleIds, explicitlyNamedRules: ruleIds);
-
-    /// <summary>
-    /// Runs the specified rules.
-    /// <para><paramref name="ruleIds"/> selects which rules execute (<c>null</c>/empty = all).</para>
-    /// <para><paramref name="explicitlyNamedRules"/> lists rules the user named by hand —
-    /// these bypass language gating. <c>null</c> means "no signal, treat <paramref name="ruleIds"/>
-    /// as explicit" (back-compat); an empty collection means "no rule was explicitly named"
-    /// (the CLI's implicit <c>--FixCommonErrors</c> path), which keeps language gates active.</para>
-    /// The split matters because the CLI pre-resolves a bare <c>--FixCommonErrors</c> to
-    /// the full rule list, so a <c>wanted == null</c> check alone would never fire for the
-    /// default path — see <see cref="ParseExplicitlyNamedRules"/>.
+    /// Runs the specified rules. <paramref name="ruleIds"/> selects which rules execute
+    /// (<c>null</c>/empty = all). Language-conditional rules run only when the language matches
+    /// (see <paramref name="languageOverride"/> / auto-detect); selecting one by name does not
+    /// bypass its gate. Rules execute in canonical order, not caller order, to keep behaviour
+    /// stable across invocations.
     /// </summary>
     public static void Run(
         Subtitle subtitle,
         IReadOnlyCollection<string>? ruleIds,
-        IReadOnlyCollection<string>? explicitlyNamedRules,
         string? languageOverride = null)
     {
         if (subtitle == null || subtitle.Paragraphs.Count == 0)
@@ -146,23 +133,6 @@ internal static class FixCommonErrorsRunner
         if (ruleIds != null && ruleIds.Count > 0)
         {
             wanted = new HashSet<string>(ruleIds, StringComparer.OrdinalIgnoreCase);
-        }
-
-        // null = treat wanted as explicit (back-compat path used by direct callers / tests).
-        // empty = "user named nothing" — keeps language gates fully active.
-        // non-empty = exact set of rules the user typed by hand.
-        HashSet<string>? explicitlyNamed;
-        if (explicitlyNamedRules == null)
-        {
-            explicitlyNamed = wanted;
-        }
-        else if (explicitlyNamedRules.Count == 0)
-        {
-            explicitlyNamed = null;
-        }
-        else
-        {
-            explicitlyNamed = new HashSet<string>(explicitlyNamedRules, StringComparer.OrdinalIgnoreCase);
         }
 
         // --fce-language forces the language used for gating (and OCR-fix), so a genuinely
@@ -183,7 +153,7 @@ internal static class FixCommonErrorsRunner
         var previousSnapshot = Snapshot(subtitle);
         for (var pass = 0; pass < MaxPasses; pass++)
         {
-            RunSinglePass(subtitle, wanted, explicitlyNamed, language, callbacks);
+            RunSinglePass(subtitle, wanted, language, callbacks);
 
             var snapshot = Snapshot(subtitle);
             if (snapshot == previousSnapshot)
@@ -251,7 +221,6 @@ internal static class FixCommonErrorsRunner
     private static void RunSinglePass(
         Subtitle subtitle,
         HashSet<string>? wanted,
-        HashSet<string>? explicitlyNamed,
         string language,
         EmptyFixCallback callbacks)
     {
@@ -266,9 +235,9 @@ internal static class FixCommonErrorsRunner
             // (FixCommonErrorsViewModel.cs:359-377), which only surfaces these rules
             // when the detected language matches. Running e.g. the Spanish inverted-mark
             // fix on French content would insert ¿ / ¡ on every question — issue #11037.
-            // The user can still opt in explicitly by naming the rule in --FixCommonErrorsRules.
-            if (IsLanguageOnlyRule(id, language)
-                && (explicitlyNamed == null || !explicitlyNamed.Contains(id)))
+            // Naming the rule in --FixCommonErrorsRules selects it but does not bypass the
+            // gate; force a mismatching language with --fce-language:<code> instead.
+            if (IsLanguageOnlyRule(id, language))
             {
                 continue;
             }
@@ -313,29 +282,9 @@ internal static class FixCommonErrorsRunner
     }
 
     /// <summary>
-    /// Extracts the rule IDs a user named by hand in a <c>--FixCommonErrorsRules</c> spec.
-    /// Returns an empty list for null / empty / whitespace / <c>all</c> specs (= no rule
-    /// was explicitly named). Negative tokens (<c>-FixCommas</c>) and the literal <c>all</c>
-    /// are excluded — only positive, named rules count as "explicit". Unknown rule names
-    /// are kept as-is here; <see cref="ResolveRuleIds"/> is responsible for validation.
-    /// </summary>
-    public static IReadOnlyList<string> ParseExplicitlyNamedRules(string? spec)
-    {
-        if (string.IsNullOrWhiteSpace(spec))
-        {
-            return [];
-        }
-
-        return spec.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Where(t => !t.StartsWith('-') && !"all".Equals(t, StringComparison.OrdinalIgnoreCase))
-            .ToArray();
-    }
-
-    /// <summary>
     /// Returns true when <paramref name="ruleId"/> is a language-conditional rule
     /// that should not run because the detected language doesn't match. Mirrors
     /// the GUI's per-language rule additions in <c>FixCommonErrorsViewModel</c>.
-    /// Bypassable via explicit <c>--FixCommonErrorsRules</c>.
     /// </summary>
     private static bool IsLanguageOnlyRule(string ruleId, string language)
         => LanguageGates.TryGetValue(ruleId, out var required)

--- a/src/seconv/Core/LibSEIntegration.cs
+++ b/src/seconv/Core/LibSEIntegration.cs
@@ -561,9 +561,7 @@ internal static class LibSEIntegration
     /// <summary>
     /// Applies subtitle operations/transformations. <paramref name="fixCommonErrorsRules"/>
     /// is consulted only when <c>fixcommonerrors</c> is in the operation list — pass
-    /// <c>null</c> or empty to run all FCE rules. <paramref name="fixCommonErrorsExplicitlyNamedRules"/>
-    /// is the set of rules the user named by hand (used to bypass FCE language gating);
-    /// pass empty for "no explicit selection" (implicit-all CLI path).
+    /// <c>null</c> or empty to run all FCE rules.
     /// <paramref name="fixCommonErrorsLanguage"/> forces the language used for FCE gating /
     /// OCR-fix (from <c>--fce-language</c>); pass <c>null</c> to auto-detect from content.
     /// </summary>
@@ -571,7 +569,6 @@ internal static class LibSEIntegration
         Subtitle subtitle,
         List<string> operations,
         IReadOnlyList<string>? fixCommonErrorsRules = null,
-        IReadOnlyList<string>? fixCommonErrorsExplicitlyNamedRules = null,
         string? fixCommonErrorsLanguage = null)
     {
         if (subtitle == null || operations == null || operations.Count == 0)
@@ -581,7 +578,7 @@ internal static class LibSEIntegration
 
         foreach (var operation in operations)
         {
-            ApplyOperation(subtitle, operation, fixCommonErrorsRules, fixCommonErrorsExplicitlyNamedRules, fixCommonErrorsLanguage);
+            ApplyOperation(subtitle, operation, fixCommonErrorsRules, fixCommonErrorsLanguage);
         }
     }
 
@@ -589,13 +586,12 @@ internal static class LibSEIntegration
         Subtitle subtitle,
         string operation,
         IReadOnlyList<string>? fixCommonErrorsRules,
-        IReadOnlyList<string>? fixCommonErrorsExplicitlyNamedRules,
         string? fixCommonErrorsLanguage)
     {
         switch (operation.ToLowerInvariant())
         {
             case "fixcommonerrors":
-                FixCommonErrorsRunner.Run(subtitle, fixCommonErrorsRules, fixCommonErrorsExplicitlyNamedRules, fixCommonErrorsLanguage);
+                FixCommonErrorsRunner.Run(subtitle, fixCommonErrorsRules, fixCommonErrorsLanguage);
                 break;
 
             case "removetextforhi":

--- a/src/seconv/Core/ListHelpers.cs
+++ b/src/seconv/Core/ListHelpers.cs
@@ -97,15 +97,15 @@ internal static class ListHelpers
         AnsiConsole.Write(table);
         AnsiConsole.MarkupLine(
             "\n[dim]The GUI equivalent is the checkbox label in the desktop Fix Common Errors window.[/]\n" +
-            "[dim]Language-gated rules run only when the subtitle auto-detects to that language.[/]\n" +
-            "[dim]Force it with[/] [green]--fce-language:<code>[/][dim], or bypass the gate by naming the rule explicitly.[/]");
+            "[dim]Language-gated rules run only when the language matches — auto-detected, or forced with[/] " +
+            "[green]--fce-language:<code>[/][dim]. Naming a gated rule selects it but does not bypass the gate.[/]");
         AnsiConsole.MarkupLine(
             "\n[dim]Examples:[/]\n" +
             "  [dim]--FixCommonErrors[/]                                       [dim]# all rules (gates active)[/]\n" +
             "  [dim]--FixCommonErrorsRules:FixCommas,FixEllipsesStart[/]       [dim]# only these two[/]\n" +
             "  [dim]--FixCommonErrorsRules:all,-FixDanishLetterI[/]            [dim]# all except one[/]\n" +
             "  [dim]--FixCommonErrors --fce-language:es[/]                     [dim]# force Spanish gate[/]\n" +
-            "  [dim]--FixCommonErrorsRules:FixSpanishInvertedQuestionAndExclamationMarks[/]  [dim]# bypass gate[/]");
+            "  [dim]--FixCommonErrorsRules:FixSpanishInvertedQuestionAndExclamationMarks --fce-language:es[/]  [dim]# force a named gated rule[/]");
     }
 
     public static void PrintOcrEngines()

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -721,7 +721,6 @@ internal class SubtitleConverter
                 subtitle,
                 options.Operations,
                 options.FixCommonErrorsRules,
-                options.FixCommonErrorsExplicitlyNamedRules,
                 options.FixCommonErrorsLanguage);
         }
 
@@ -844,14 +843,6 @@ internal record class ConversionOptions
     /// Resolve via <see cref="FixCommonErrorsRunner.ResolveRuleIds"/>.
     /// </summary>
     public IReadOnlyList<string> FixCommonErrorsRules { get; init; } = [];
-
-    /// <summary>
-    /// Rules the user named by hand in <c>--FixCommonErrorsRules</c>. Used to bypass
-    /// language gating for explicitly-requested rules. Populate via
-    /// <see cref="FixCommonErrorsRunner.ParseExplicitlyNamedRules"/>. Empty means
-    /// "implicit all-rules pass" (gates stay active).
-    /// </summary>
-    public IReadOnlyList<string> FixCommonErrorsExplicitlyNamedRules { get; init; } = [];
 
     /// <summary>
     /// Forces the language used for FCE gating and OCR-fix (from <c>--fce-language</c>).

--- a/tests/seconv/Core/FixCommonErrorsRunnerTest.cs
+++ b/tests/seconv/Core/FixCommonErrorsRunnerTest.cs
@@ -185,10 +185,10 @@ public class FixCommonErrorsRunnerTest
     }
 
     // -------------------------------------------------------------------------
-    // Issue #11037 item 3: language-conditional rules should mirror the GUI's
-    // Fix Common Errors window — Spanish-only rules don't run on non-Spanish
-    // content in the default "all rules" pass, but the user can still opt in
-    // via an explicit --FixCommonErrorsRules list.
+    // Issue #11037 item 3: language-conditional rules mirror the GUI's Fix Common
+    // Errors window — Spanish-only rules run only when the language matches
+    // (auto-detected, or forced via --fce-language). Naming a gated rule in
+    // --FixCommonErrorsRules selects it but does not bypass its language gate.
     // -------------------------------------------------------------------------
 
     [Fact]
@@ -222,50 +222,48 @@ public class FixCommonErrorsRunnerTest
     }
 
     [Fact]
-    public void Run_WithExplicitSpanishRule_AppliesEvenOnNonSpanishText()
+    public void Run_NamingSpanishRule_DoesNotBypassGateOnNonSpanish()
     {
-        // Opt-in path: --FixCommonErrorsRules:FixSpanishInvertedQuestionAndExclamationMarks
-        // runs the rule regardless of detected language.
+        // Selecting the Spanish rule by name no longer forces it past the language gate:
+        // on English content it stays gated off, so no leading '¿' is inserted (#11037).
         var sub = new Subtitle();
         sub.Paragraphs.Add(new Paragraph("Are you coming home tonight?", 0, 3000));
         sub.Renumber();
 
         FixCommonErrorsRunner.Run(sub, new[] { "FixSpanishInvertedQuestionAndExclamationMarks" });
 
-        Assert.Contains('¿', sub.Paragraphs[0].Text);
+        Assert.DoesNotContain('¿', sub.Paragraphs[0].Text);
+        Assert.DoesNotContain('¡', sub.Paragraphs[0].Text);
     }
 
     [Fact]
     public void Run_CliImplicitPath_GatesSpanishOnNonSpanish()
     {
-        // Regression for Copilot review on #11300: ConvertCommand pre-resolves a bare
-        // --FixCommonErrors to the full rule list via ResolveRuleIds(null), then passes
-        // that into Run. With the old single-arg overload, wanted was non-null so the
-        // gate never fired and Spanish marks landed on English content.
-        // The new explicitlyNamedRules=[] signal restores the gate for that path.
+        // ConvertCommand pre-resolves a bare --FixCommonErrors to the full rule list via
+        // ResolveRuleIds(null), then passes that into Run. The Spanish rule must stay gated
+        // off on English content even though it is in the resolved "wanted" set.
         var sub = new Subtitle();
         sub.Paragraphs.Add(new Paragraph("Are you coming home tonight?", 0, 3000));
         sub.Renumber();
 
         var allRules = FixCommonErrorsRunner.AvailableRuleIds;
-        FixCommonErrorsRunner.Run(sub, allRules, explicitlyNamedRules: []);
+        FixCommonErrorsRunner.Run(sub, allRules);
 
         Assert.DoesNotContain('¿', sub.Paragraphs[0].Text);
         Assert.DoesNotContain('¡', sub.Paragraphs[0].Text);
     }
 
     [Fact]
-    public void Run_CliExplicitPath_ApplySpanishEvenOnNonSpanish()
+    public void Run_NamingSpanishRule_WithFceLanguage_AppliesOnNonSpanish()
     {
-        // CLI path with --FixCommonErrorsRules:FixSpanishInvertedQuestionAndExclamationMarks
-        // forwards the named rule as both wanted and explicitly-named, so the gate is
-        // bypassed and the rule fires on English content.
+        // The escape hatch: naming the rule and forcing --fce-language:es opens the gate,
+        // so the rule fires even on content that auto-detects as English.
         var sub = new Subtitle();
         sub.Paragraphs.Add(new Paragraph("Are you coming home tonight?", 0, 3000));
         sub.Renumber();
 
         var rules = new[] { "FixSpanishInvertedQuestionAndExclamationMarks" };
-        FixCommonErrorsRunner.Run(sub, rules, explicitlyNamedRules: rules);
+        FixCommonErrorsRunner.Run(sub, rules, languageOverride: "es");
 
         Assert.Contains('¿', sub.Paragraphs[0].Text);
     }
@@ -280,7 +278,7 @@ public class FixCommonErrorsRunnerTest
         sub.Renumber();
 
         var allRules = FixCommonErrorsRunner.AvailableRuleIds;
-        FixCommonErrorsRunner.Run(sub, allRules, explicitlyNamedRules: [], languageOverride: "es");
+        FixCommonErrorsRunner.Run(sub, allRules, languageOverride: "es");
 
         Assert.Contains('¿', sub.Paragraphs[0].Text);
     }
@@ -294,7 +292,7 @@ public class FixCommonErrorsRunnerTest
         sub.Renumber();
 
         var allRules = FixCommonErrorsRunner.AvailableRuleIds;
-        FixCommonErrorsRunner.Run(sub, allRules, explicitlyNamedRules: [], languageOverride: "Spanish");
+        FixCommonErrorsRunner.Run(sub, allRules, languageOverride: "Spanish");
 
         Assert.Contains('¿', sub.Paragraphs[0].Text);
     }
@@ -328,29 +326,6 @@ public class FixCommonErrorsRunnerTest
         Assert.Equal("da", gates["FixDanishLetterI"]);
         Assert.Equal("es", gates["FixSpanishInvertedQuestionAndExclamationMarks"]);
         Assert.Equal("tr", gates["FixTurkishAnsiToUnicode"]);
-    }
-
-    [Fact]
-    public void ParseExplicitlyNamedRules_NullOrAllOrNegations_ReturnsEmpty()
-    {
-        // "implicit-all" spec forms — nothing the user named by hand.
-        Assert.Empty(FixCommonErrorsRunner.ParseExplicitlyNamedRules(null));
-        Assert.Empty(FixCommonErrorsRunner.ParseExplicitlyNamedRules(""));
-        Assert.Empty(FixCommonErrorsRunner.ParseExplicitlyNamedRules("   "));
-        Assert.Empty(FixCommonErrorsRunner.ParseExplicitlyNamedRules("all"));
-        Assert.Empty(FixCommonErrorsRunner.ParseExplicitlyNamedRules("all,-FixDanishLetterI"));
-        Assert.Empty(FixCommonErrorsRunner.ParseExplicitlyNamedRules("-FixCommas,-FixDanishLetterI"));
-    }
-
-    [Fact]
-    public void ParseExplicitlyNamedRules_PositiveTokens_AreCapturedExactly()
-    {
-        var named = FixCommonErrorsRunner.ParseExplicitlyNamedRules(
-            "FixSpanishInvertedQuestionAndExclamationMarks,-FixDanishLetterI,FixCommas");
-
-        Assert.Equal(
-            new[] { "FixSpanishInvertedQuestionAndExclamationMarks", "FixCommas" },
-            named);
     }
 
     [Fact]


### PR DESCRIPTION
## What

Language-conditional Fix Common Errors rules (`FixSpanishInvertedQuestionAndExclamationMarks`, `FixDanishLetterI`, `FixTurkishAnsiToUnicode`, `FixAloneLowercaseIToUppercaseI`) now run **only when the subtitle language matches** — auto-detected from content, or forced with `--fce-language:<code>`. Naming a gated rule in `--fix-common-errors-rules` selects it into the run but no longer bypasses its language gate.

## Why

Follow-up to #11037. Previously, naming a language rule was a *hard force* — it ran regardless of detected language. That conflated two jobs: *selecting* a rule into a custom subset and *forcing* it past its gate. The practical fallout was the mixed-language batch case: if your custom rule set included the Spanish inverted-mark fix, it fired on the English and French files too (`¿Are you coming home tonight?`), and the only escape was the fragile `--fix-common-errors-rules:all,-<~100 other rules>` pattern.

With this change a gated rule in a custom set **self-skips** the files where its language doesn't apply, which is what auto-detection was already good at — naming the rule no longer opts out of it.

## Behavior change

Scripts that named a language rule expecting it to run *regardless* of language must now add `--fce-language:<code>`. That flag becomes the single, explicit way to force a mismatching language (e.g. a genuinely Spanish file that's too short to auto-detect).

```console
# named Spanish rule on English content
$ seconv en.srt subrip --fix-common-errors-rules:FixSpanishInvertedQuestionAndExclamationMarks --overwrite
Are you coming home tonight?          # gated off — was "¿Are you coming home tonight?"

# force it with --fce-language
$ seconv en.srt subrip --fix-common-errors-rules:FixSpanishInvertedQuestionAndExclamationMarks --fce-language:es --overwrite
¿Are you coming home tonight?
```

## Changes

- `FixCommonErrorsRunner`: gate now skips a language-only rule purely on language mismatch. Removed the now-dead `explicitlyNamedRules` parameter and the `ParseExplicitlyNamedRules` helper.
- `LibSEIntegration` / `SubtitleConverter` / `ConvertCommand`: removed the `FixCommonErrorsExplicitlyNamedRules` plumbing that only existed to feed the bypass.
- `list-fce-rules` help + `docs/reference/command-line.md`: reworded to document the gate-always-applies model; `--fce-language` is the sole force path.
- Tests: flipped the two that asserted the old force behavior, added coverage for "named + `--fce-language:es` → applies", removed the obsolete parser tests.

Verified end-to-end on the issue's English sample; seconv build clean (0 warnings), FCE + integration/converter tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)