### PR TITLE
Fix CrispASR TTS voice cloning: random voices, garbled audio, broken engines (#12757)

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
@@ -487,23 +487,21 @@ public class CosyVoice3CrispAsr : ITtsEngine
         var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
 
         var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrSpeed, 0.25, 4.0);
+        // Deliberately NO `voice` / `ref_text` field: for cloning, voiceArg is an absolute WAV
+        // path, which the server rejects outright (HTTP 400, "'voice' must not contain … path
+        // separators" — path-traversal guard), so every clone synthesis failed. The backend gets
+        // both voice (preset name or WAV path) and ref-text from the startup --voice/--ref-text
+        // flags instead, and the server restarts on (voiceArg, ref-text) change — see
+        // EnsureServerRunningAsync. Same bug family as MOSS-TTS #12757.
         var payload = new Dictionary<string, object>
         {
             ["input"] = text,
             ["response_format"] = "wav",
-            ["voice"] = voiceArg,
             ["speed"] = speed,
         };
         if (isClone)
         {
-            // ref_text mirrors the F5-TTS payload guess. CosyVoice3's voice + ref_text are
-            // baked at server startup (see EnsureServerRunningAsync) so this field is mostly
-            // informational, but we send it for logging + future server versions that read it
-            // per-request.
-            payload["ref_text"] = cosyVoice.RefText;
-            // Cloning is gated behind a consent attestation (CrispASR v0.7.0 returns HTTP 400
-            // consent_required without it). The user supplies their own reference voice by
-            // importing a WAV into SE, which is the act being attested here.
+            // Attests the user's own imported reference; the server logs it for cloned synthesis.
             payload["consent_attestation"] = "I have the speaker's consent, or it is my own voice.";
             // Skip the audible AI-disclosure prefix CrispASR otherwise prepends to cloned audio;
             // SE surfaces the AI-generated nature in its UI. The inaudible watermark + C2PA

--- a/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
@@ -379,28 +379,24 @@ public class F5TtsCrispAsr : ITtsEngine
         var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
 
         var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.F5TtsCrispAsrSpeed, 0.25, 4.0);
+        // Deliberately NO `voice` / `ref_text` field: the server rejects absolute paths outright
+        // (HTTP 400, "'voice' must not contain … path separators" — path-traversal guard), so
+        // sending f5Voice.FilePath failed every synthesis. The f5-tts backend reads the reference
+        // from the startup --voice / --ref-text flags (no bare-name resolution), and the server
+        // restarts on (voice, ref-text) change — see EnsureServerRunningAsync. Same bug family as
+        // MOSS-TTS #12757.
         var payload = new Dictionary<string, object>
         {
             ["input"] = text,
             ["response_format"] = "wav",
-            ["voice"] = f5Voice.FilePath,
             ["speed"] = speed,
-            // F5-TTS gates voice cloning behind a consent attestation (CrispASR v0.7.0 returns
-            // HTTP 400 consent_required without it). The user supplies their own reference voice
-            // by importing a WAV into SE, which is the act being attested here.
+            // Attests the user's own imported reference; the server logs it for cloned synthesis.
             ["consent_attestation"] = "I have the speaker's consent, or it is my own voice.",
             // Skip the audible AI-disclosure prefix CrispASR otherwise prepends to cloned audio;
             // SE surfaces the AI-generated nature in its UI. The inaudible watermark + C2PA
             // provenance metadata stay embedded regardless (defaults to true server-side).
             ["spoken_disclaimer"] = false,
         };
-        if (!string.IsNullOrEmpty(refText))
-        {
-            // TODO: verify field name. CrispASR's CLI uses `--ref-text`; the OpenAI-compat
-            // server may expose this as `ref_text`, `ref-text`, or `instructions`. Adjust
-            // once a real synth round-trip confirms which key the backend reads.
-            payload["ref_text"] = refText;
-        }
 
         var body = JsonSerializer.Serialize(payload);
         using var content = new StringContent(body, Encoding.UTF8, "application/json");

--- a/src/ui/Features/Video/TextToSpeech/Engines/IndexTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/IndexTtsCrispAsr.cs
@@ -398,15 +398,18 @@ public class IndexTtsCrispAsr : ITtsEngine
         // Qwen3 CustomVoice there is no `ref-text` parameter. v1.5 has no `instructions`
         // (emotion control) — that's IndexTTS-2 which isn't in CrispASR yet.
         var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.IndexTtsCrispAsrSpeed, 0.25, 4.0);
+        // Deliberately NO `voice` field: the server rejects absolute paths outright (HTTP 400,
+        // "'voice' must not contain … path separators" — path-traversal guard), so sending
+        // indexVoice.FilePath failed every synthesis. The indextts backend loads the reference
+        // once at init from the startup --voice flag anyway (per-request voice is never re-read),
+        // and the server restarts on voice change — see EnsureServerRunningAsync. Same bug family
+        // as MOSS-TTS #12757.
         var payload = new Dictionary<string, object>
         {
             ["input"] = inputText,
             ["response_format"] = "wav",
-            ["voice"] = indexVoice.FilePath,
             ["speed"] = speed,
-            // IndexTTS gates voice cloning behind a consent attestation (CrispASR v0.7.0 returns
-            // HTTP 400 consent_required without it). The user supplies their own reference voice
-            // by importing a WAV into SE, which is the act being attested here.
+            // Attests the user's own imported reference; the server logs it for cloned synthesis.
             ["consent_attestation"] = "I have the speaker's consent, or it is my own voice.",
             // Skip the audible AI-disclosure prefix CrispASR otherwise prepends to cloned audio;
             // SE surfaces the AI-generated nature in its UI. The inaudible watermark + C2PA

--- a/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
@@ -446,28 +446,7 @@ public class MossTtsCrispAsr : ITtsEngine
         var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
 
         var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.MossTtsCrispAsrSpeed, 0.25, 4.0);
-        var payload = new Dictionary<string, object>
-        {
-            ["input"] = text,
-            ["response_format"] = "wav",
-            // The OpenAI-compat server resolves `voice` as a NAME listed by /v1/voices (the file
-            // stem inside --voice-dir). Passing a full path makes the server hang indefinitely,
-            // so send the reference WAV's base name — it lives in the voices folder = --voice-dir.
-            ["voice"] = Path.GetFileNameWithoutExtension(mossVoice.FilePath),
-            ["speed"] = speed,
-            // Voice cloning is gated behind a consent attestation (the server returns HTTP 400
-            // consent_required without it). The user supplies their own reference voice by
-            // importing a WAV into SE, which is the act being attested here.
-            ["consent_attestation"] = "I have the speaker's consent, or it is my own voice.",
-            // Skip the audible AI-disclosure prefix CrispASR otherwise prepends to cloned audio;
-            // SE surfaces the AI-generated nature in its UI. The inaudible watermark + C2PA
-            // provenance metadata stay embedded regardless (defaults to true server-side).
-            ["spoken_disclaimer"] = false,
-        };
-        if (!string.IsNullOrEmpty(refText))
-        {
-            payload["ref_text"] = refText;
-        }
+        var payload = BuildSpeakPayload(text, speed);
 
         var body = JsonSerializer.Serialize(payload);
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
@@ -528,6 +507,46 @@ public class MossTtsCrispAsr : ITtsEngine
         }
 
         return new TtsResult(outputFileName, text);
+    }
+
+    /// <summary>
+    /// Builds the <c>/v1/audio/speech</c> JSON payload. Extracted so the #12757 fix (no per-request
+    /// <c>voice</c> field) is unit-testable without a running crispasr server.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately sends NO <c>voice</c> or <c>ref_text</c> field. The crispasr <c>moss-tts</c>
+    /// backend loads the clone reference from the server's startup <c>--voice &lt;path&gt;</c>
+    /// (and <c>--ref-text</c>) flags — which <see cref="EnsureServerRunningAsync"/> always passes,
+    /// restarting the server whenever the selected voice changes. A per-request <c>voice</c> value
+    /// OVERRIDES that startup path with a bare NAME the moss backend then tries to open as a file;
+    /// it fails (<c>crispasr[moss-tts]: failed to load reference audio</c>) and SILENTLY falls back
+    /// to zero-shot, so every line comes out in a different random voice — the #12757 bug (voices
+    /// even flipping male/female). A per-request full path is rejected outright (HTTP 400,
+    /// "'voice' must not contain … path separators"), so omitting the field is the only way to
+    /// clone. Verified end-to-end against crispasr 0.8.20: with no <c>voice</c> field the server
+    /// logs <c>cloning voice from '…/Arnold.wav'</c> and every line holds the reference speaker.
+    ///
+    /// Also sends NO <c>seed</c>: the reference conditioning already keeps the speaker consistent,
+    /// and letting the server re-roll each call means an occasional bad render of a short line
+    /// (MOSS-TTS Q4_K sometimes rushes the words + trails silence) comes out clean on regenerate —
+    /// a fixed seed would lock that bad render in permanently.
+    /// </remarks>
+    internal static Dictionary<string, object> BuildSpeakPayload(string text, double speed)
+    {
+        return new Dictionary<string, object>
+        {
+            ["input"] = text,
+            ["response_format"] = "wav",
+            ["speed"] = speed,
+            // Voice cloning is gated behind a consent attestation (the server returns HTTP 400
+            // consent_required without it). The user supplies their own reference voice by
+            // importing a WAV into SE, which is the act being attested here.
+            ["consent_attestation"] = "I have the speaker's consent, or it is my own voice.",
+            // Skip the audible AI-disclosure prefix CrispASR otherwise prepends to cloned audio;
+            // SE surfaces the AI-generated nature in its UI. The inaudible watermark + C2PA
+            // provenance metadata stay embedded regardless (defaults to true server-side).
+            ["spoken_disclaimer"] = false,
+        };
     }
 
     private static string TryReadRefText(string wavPath)

--- a/src/ui/Features/Video/TextToSpeech/Engines/VibeVoiceCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VibeVoiceCrispAsr.cs
@@ -376,21 +376,27 @@ public class VibeVoiceCrispAsr : ITtsEngine
         // OpenAI-compatible /v1/audio/speech payload. CrispASR's vibevoice backends look at:
         //   - `input`             — the text to synthesise
         //   - `response_format`   — "wav"
-        //   - `voice`             — absolute WAV path or filename in --voice-dir
+        //   - `voice`             — see below
         //   - `speed`             — server-side linear resample of the synth output (0.25-4.0).
         //                           VibeVoice 1.5B tends to be on the slow side; default is 1.1
         //                           and the user can override in the engine settings dialog.
         // VibeVoice does not use `instructions` or `ref-text` (those are qwen3-tts-only).
+        //
+        // `voice` must be the extension-less STEM of the reference file: the server rejects
+        // absolute paths outright (HTTP 400, "'voice' must not contain … path separators" —
+        // path-traversal guard), so the full FilePath SE used to send failed every synthesis.
+        // The vibevoice backend resolves a bare name (no path separators, no .wav/.gguf suffix)
+        // against --voice-dir as <stem>.gguf then <stem>.wav, loading the WAV-clone path per
+        // request — which is why this engine, unlike the others, needs no startup --voice flag
+        // or server restart on voice change. Same bug family as MOSS-TTS #12757.
         var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.VibeVoiceCrispAsrSpeed, 0.25, 4.0);
         var payload = new Dictionary<string, object>
         {
             ["input"] = inputText,
             ["response_format"] = "wav",
-            ["voice"] = vibeVoice.FilePath,
+            ["voice"] = Path.GetFileNameWithoutExtension(vibeVoice.FilePath),
             ["speed"] = speed,
-            // VibeVoice gates voice cloning behind a consent attestation (CrispASR v0.7.0 returns
-            // HTTP 400 consent_required without it). The user supplies their own reference voice
-            // by importing a WAV into SE, which is the act being attested here.
+            // Attests the user's own imported reference; the server logs it for cloned synthesis.
             ["consent_attestation"] = "I have the speaker's consent, or it is my own voice.",
             // Skip the audible AI-disclosure prefix CrispASR otherwise prepends to cloned audio;
             // SE surfaces the AI-generated nature in its UI. The inaudible watermark + C2PA

--- a/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
@@ -418,30 +418,25 @@ public class VoxCPM2CrispAsr : ITtsEngine
         var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
 
         var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.VoxCPM2CrispAsrSpeed, 0.25, 4.0);
+        // Deliberately NO `voice` / `ref_text` field: the voxcpm2 backend treats a per-request
+        // `voice` as a FILE PATH (read_wav_mono_pcm16) that OVERRIDES the startup --voice, so the
+        // bare stem SE used to send failed to load and silently fell back to zero-shot — a random
+        // speaker per line, the same bug MOSS-TTS had (#12757). With the field omitted the backend
+        // falls back to the init-time --voice path (server mode never sets tts_voice_clone_consent,
+        // so the empty-voice branch resolves to voice_path_) and clones the reference. The server
+        // restarts on (voice, ref-text) change — see EnsureServerRunningAsync.
         var payload = new Dictionary<string, object>
         {
             ["input"] = text,
             ["response_format"] = "wav",
-            // The OpenAI-compat server resolves `voice` as a NAME listed by /v1/voices (the file
-            // stem inside --voice-dir). Passing a full path makes the server hang indefinitely,
-            // so send the reference WAV's base name — it lives in the voices folder = --voice-dir.
-            ["voice"] = Path.GetFileNameWithoutExtension(voxVoice.FilePath),
             ["speed"] = speed,
-            // VoxCPM2 gates voice cloning behind a consent attestation (CrispASR v0.7.0 returns
-            // HTTP 400 consent_required without it). The user supplies their own reference voice
-            // by importing a WAV into SE, which is the act being attested here.
+            // Attests the user's own imported reference; the server logs it for cloned synthesis.
             ["consent_attestation"] = "I have the speaker's consent, or it is my own voice.",
             // Skip the audible AI-disclosure prefix CrispASR otherwise prepends to cloned audio;
             // SE surfaces the AI-generated nature in its UI. The inaudible watermark + C2PA
             // provenance metadata stay embedded regardless (defaults to true server-side).
             ["spoken_disclaimer"] = false,
         };
-        if (!string.IsNullOrEmpty(refText))
-        {
-            // TODO: verify field name against a real v0.7.0 binary — the OpenAI-compat server
-            // may expose this as ref_text / ref-text / instructions.
-            payload["ref_text"] = refText;
-        }
 
         var body = JsonSerializer.Serialize(payload);
         using var content = new StringContent(body, Encoding.UTF8, "application/json");

--- a/src/ui/Features/Video/TextToSpeech/Engines/ZonosTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ZonosTtsCrispAsr.cs
@@ -345,22 +345,18 @@ public class ZonosTtsCrispAsr : ITtsEngine
         var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
         var inputText = text;
 
-        // OpenAI-compatible /v1/audio/speech payload. CrispASR's zonos-tts backend uses:
-        //   - `input`             — the text to synthesise
-        //   - `response_format`   — "wav"
-        //   - `voice`             — absolute WAV path or filename in --voice-dir
-        // The server-mode backend ignores the request `voice` field, so we still pass it
-        // (for logging / future server fix) but the reference audio actually used is the
-        // --voice path baked in at server startup — see EnsureServerRunningAsync. Zonos
-        // transcribes the reference internally (eSpeak), so there is no `ref-text` parameter.
+        // OpenAI-compatible /v1/audio/speech payload. Zonos transcribes the reference internally
+        // (eSpeak), so there is no `ref-text` parameter.
+        // Deliberately NO `voice` field: the server rejects absolute paths outright (HTTP 400,
+        // "'voice' must not contain … path separators" — path-traversal guard), so sending
+        // zonosVoice.FilePath failed every synthesis. The zonos backend loads the reference at
+        // init from the startup --voice flag, and the server restarts on voice change — see
+        // EnsureServerRunningAsync. Same bug family as MOSS-TTS #12757.
         var payload = new Dictionary<string, object>
         {
             ["input"] = inputText,
             ["response_format"] = "wav",
-            ["voice"] = zonosVoice.FilePath,
-            // Zonos gates voice cloning behind a consent attestation (CrispASR v0.7.0 returns
-            // HTTP 400 consent_required without it). The user supplies their own reference voice
-            // by importing a WAV into SE, which is the act being attested here.
+            // Attests the user's own imported reference; the server logs it for cloned synthesis.
             ["consent_attestation"] = "I have the speaker's consent, or it is my own voice.",
             // Skip the audible AI-disclosure prefix CrispASR otherwise prepends to cloned audio;
             // SE surfaces the AI-generated nature in its UI. The inaudible watermark + C2PA

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -2574,9 +2574,14 @@ public partial class TextToSpeechViewModel : ObservableObject
         var rawText = _castKind == ActorVoiceDetector.CastKind.WebVttVoices
             ? ActorVoiceDetector.StripWebVttVoiceTags(paragraph.Text)
             : paragraph.Text;
+        // Strip formatting markup (<i>…</i>, <font …>, {\an8}, …) before synthesis. TTS engines
+        // don't interpret subtitle tags, and some — notably MOSS-TTS (CrispASR) — vocalize them
+        // ("<i>" spoken as "I") or run away into garbled audio rather than ignoring them (#12757).
+        // No engine should ever receive them, so strip HTML + SSA/ASS tags centrally.
+        var cleanText = HtmlUtil.RemoveHtmlTags(rawText, alsoSsaTags: true);
         // Unbreak line endings centrally so every engine sees a single flowing line —
         // many TTS engines otherwise insert weird pauses on \r\n.
-        var text = Utilities.UnbreakLine(rawText);
+        var text = Utilities.UnbreakLine(cleanText);
 
         // Fallbacks must carry the panel's instruction, not "": TtsInstructionSwap swaps the
         // engine's saved instruction to whatever is passed here for the duration of the Speak

--- a/tests/UI/Features/Video/TextToSpeech/Engines/MossTtsCrispAsrTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/MossTtsCrispAsrTests.cs
@@ -1,0 +1,49 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+namespace UITests.Features.Video.TextToSpeech.Engines;
+
+public class MossTtsCrispAsrTests
+{
+    [Fact]
+    public void BuildSpeakPayload_DoesNotSendVoiceField()
+    {
+        // #12757: a per-request `voice` (bare name) makes the moss-tts backend fail to load the
+        // reference and fall back to zero-shot (random/male-female-flipping voice). The clone must
+        // come from the server's startup --voice flag, so the payload must NOT carry `voice`.
+        var payload = MossTtsCrispAsr.BuildSpeakPayload("hello", 1.0);
+
+        Assert.False(payload.ContainsKey("voice"));
+    }
+
+    [Fact]
+    public void BuildSpeakPayload_DoesNotSendRefTextField()
+    {
+        // ref-text is likewise supplied via the startup --ref-text flag, not per request.
+        var payload = MossTtsCrispAsr.BuildSpeakPayload("hello", 1.0);
+
+        Assert.False(payload.ContainsKey("ref_text"));
+    }
+
+    [Fact]
+    public void BuildSpeakPayload_DoesNotSendSeed()
+    {
+        // No seed: the reference conditioning keeps the speaker consistent, and letting the server
+        // re-roll each call means a bad render of a short line comes out clean on regenerate rather
+        // than being locked in permanently by a fixed seed (#12757 follow-up).
+        var payload = MossTtsCrispAsr.BuildSpeakPayload("hello", 1.0);
+
+        Assert.False(payload.ContainsKey("seed"));
+    }
+
+    [Fact]
+    public void BuildSpeakPayload_CarriesCoreFields()
+    {
+        var payload = MossTtsCrispAsr.BuildSpeakPayload("hello world", 1.25);
+
+        Assert.Equal("hello world", payload["input"]);
+        Assert.Equal("wav", payload["response_format"]);
+        Assert.Equal(1.25, payload["speed"]);
+        Assert.Equal(false, payload["spoken_disclaimer"]);
+        Assert.True(payload.ContainsKey("consent_attestation"));
+    }
+}


### PR DESCRIPTION
Fixes the two bugs that made MOSS-TTS unusable in [#12757](https://github.com/SubtitleEdit/subtitleedit/issues/12757) — voices changing every line (even flipping male/female) and garbled audio — then extends the same fix to five more CrispASR cloning engines found broken the same way. Diagnosed end-to-end against crispasr 0.8.20 (live server + round-trip ASR) and the crispasr source at the binary's exact commit (`c1c3009a`).

## Bug 1 — MOSS-TTS: the reference voice was never loaded (random voice every line)

SE sent the reference as a per-request `voice` = *bare name* (`"Arnold"`). The crispasr `moss-tts` backend treats `tts_voice` as a **file path**, not a `--voice-dir` name — so the bare name fails to load and the backend **silently falls back to zero-shot** (a fresh random speaker every call):

```
crispasr[moss-tts]: failed to load reference audio 'Arnold'
```

A per-request *path* is rejected too (`HTTP 400 "'voice' must not contain … path separators"` — the server's path-traversal guard). Verified live:

| per-request `voice` | server log | result |
|---|---|---|
| `"Arnold"` (what SE sent) | `failed to load reference` | zero-shot ✗ |
| `"Arnold.wav"` | `failed to load reference` | zero-shot ✗ |
| full path | — | HTTP 400 ✗ |
| **omitted** | **`cloning voice from '…/Arnold.wav'`** | reference speaker ✓ |

**Fix:** stop sending per-request `voice`/`ref_text`/`seed` — rely on the startup `--voice`/`--ref-text` flags SE already passes and re-launches per voice change. Confirmed cold: every line holds the reference speaker (f0 ~115 Hz vs a drifting 129–210 Hz before). No `seed`: the reference conditioning keeps the speaker consistent, and staying non-deterministic lets a rare bad render of a short line come out clean on **regenerate** instead of being locked in.

## Bug 2 — garbled audio on formatting tags

MOSS-TTS **vocalizes** subtitle markup: `<i>Get to the chopper!</i>` → *"I … Get to the chopper"* (2× length, sometimes a runaway); `{\an8}The mission begins now.` → *"IT made the mission begins now"*. Plain text was clean (**0/12 garbled** in a round-trip ASR test), so tags were the sole cause.

**Fix:** strip HTML + SSA/ASS tags centrally in `ResolveVoiceForParagraph` via `HtmlUtil.RemoveHtmlTags(text, alsoSsaTags: true)`, so every engine receives clean text.

## Audit of the other cloning engines (same bug family)

Cross-checked each engine's payload against its backend's voice resolution at `c1c3009a`:

| Engine | sent as `voice` | result on 0.8.20 | fix |
|---|---|---|---|
| **VoxCPM2** | bare stem | overrides startup path → **silent zero-shot** (identical to MOSS) | omit `voice`/`ref_text` |
| **IndexTTS** | absolute path | **HTTP 400 every synthesis** | omit `voice` |
| **F5-TTS** | absolute path | **HTTP 400** | omit `voice`/`ref_text` |
| **Zonos** | absolute path | **HTTP 400** | omit `voice` |
| **CosyVoice3** (clone) | absolute path | **HTTP 400** (presets were fine) | omit `voice`/`ref_text` |
| **VibeVoice** | absolute path | **HTTP 400** | send extension-less **stem** (its backend resolves bare names via `--voice-dir`; it passes no startup `--voice`) |
| Chatterbox | `name.wav` + CWD = voices dir | correct as-is | — |
| Qwen3 (Base / CustomVoice) | stem / speaker name | correct as-is (Base resolves via voice-dir; CustomVoice = built-in speakers) | — |

All the omit-voice engines load the reference from the startup `--voice` flag (verified per backend: indextts/zonos at init; f5/voxcpm2/cosyvoice3 per synth with empty-voice fallback to the init path — server mode never sets `tts_voice_clone_consent`, so the fallback holds) and already restart their server on voice change. MOSS verified live end-to-end; the other five verified at source level against the exact binary commit (their models aren't staged locally).

## Tests

`MossTtsCrispAsrTests` — payload omits `voice`, `ref_text`, and `seed`; core fields present. All TTS tests pass; UI build clean, 0 warnings.

## Known limitation

MOSS-TTS **Q4_K** has intrinsic quality wobble on very short phrases (occasional rushed delivery); regenerating usually gives a good take, and F16 is more robust.

## Upstream note

`moss-tts`/`indextts`/`f5`/`voxcpm2` have no bare-name→`--voice-dir` resolution (unlike `qwen3-tts`/`vibevoice`). Worth reporting upstream so per-request named voices work uniformly; this SE change makes cloning correct today regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)