### PR TITLE
Fix image format conversion issues from #12761

### DIFF
--- a/src/libse/BluRaySup/BluRaySupParser.cs
+++ b/src/libse/BluRaySup/BluRaySupParser.cs
@@ -179,7 +179,9 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
                     return new SKBitmap(1, 1);
                 }
 
-                var bm = new SKBitmap(w, h, SKColorType.Rgba8888, SKAlphaType.Opaque);
+                // Unpremul (not Premul) as FillPixels/PutPixelFast below write straight, non-premultiplied RGBA.
+                // Opaque here would make Skia drop the alpha channel when encoding (transparent areas turn black).
+                var bm = new SKBitmap(w, h, SKColorType.Rgba8888, SKAlphaType.Unpremul);
                 var pixelPtr = bm.GetPixels(); // Writable pixel buffer
                 if (pixelPtr == IntPtr.Zero)
                 {

--- a/src/libse/SubtitleFormats/BdnXml.cs
+++ b/src/libse/SubtitleFormats/BdnXml.cs
@@ -101,7 +101,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     var position = string.Empty;
                     foreach (XmlNode graphic in node.SelectNodes("Graphic"))
                     {
-                        if (graphic.Attributes["X"] != null || graphic.Attributes["Y"] != null)
+                        if (graphic.Attributes["X"] != null && graphic.Attributes["Y"] != null)
                         {
                             position = graphic.Attributes["X"].InnerText + "," + graphic.Attributes["Y"].InnerText;
                         }
@@ -138,8 +138,81 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
             }
 
+            // keep the source xml around so callers can read the video size, see TryGetVideoSize
+            subtitle.Header = xmlString;
+
             subtitle.Renumber();
         }
 
+        /// <summary>
+        /// Reads the video size from a BDN xml "Description/Format" node, e.g. VideoFormat="1080p" or VideoFormat="1920x1080".
+        /// </summary>
+        /// <param name="xmlString">Raw BDN xml - typically <see cref="Subtitle.Header"/> after a <see cref="LoadSubtitle"/> call.</param>
+        public static bool TryGetVideoSize(string xmlString, out int width, out int height)
+        {
+            width = 0;
+            height = 0;
+
+            if (string.IsNullOrEmpty(xmlString) || !xmlString.Contains("<BDN"))
+            {
+                return false;
+            }
+
+            try
+            {
+                var xml = new XmlDocument { XmlResolver = null };
+                xml.LoadXml(xmlString);
+                var videoFormat = xml.DocumentElement?.SelectSingleNode("Description/Format")?.Attributes?["VideoFormat"]?.InnerText;
+                if (string.IsNullOrWhiteSpace(videoFormat))
+                {
+                    return false;
+                }
+
+                switch (videoFormat.Trim().ToLowerInvariant())
+                {
+                    case "480i":
+                    case "480p":
+                        width = 720;
+                        height = 480;
+                        return true;
+                    case "576i":
+                    case "576p":
+                        width = 720;
+                        height = 576;
+                        return true;
+                    case "720p":
+                        width = 1280;
+                        height = 720;
+                        return true;
+                    case "1080i":
+                    case "1080p":
+                        width = 1920;
+                        height = 1080;
+                        return true;
+                    case "2160p":
+                        width = 3840;
+                        height = 2160;
+                        return true;
+                }
+
+                // "1920x1080" style, as written by the Subtitle Edit BDN xml exporter for non-standard sizes
+                var parts = videoFormat.Split('x', 'X');
+                if (parts.Length == 2 &&
+                    int.TryParse(parts[0].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var w) &&
+                    int.TryParse(parts[1].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var h) &&
+                    w > 0 && h > 0)
+                {
+                    width = w;
+                    height = h;
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(ex.Message);
+            }
+
+            return false;
+        }
     }
 }

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleBdn.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleBdn.cs
@@ -1,19 +1,25 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 
 namespace Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
 
 public class OcrSubtitleBdn : IOcrSubtitle
 {
+    private static readonly SKPointI NoPosition = new SKPointI(-1, -1);
+    private static readonly SKSizeI NoScreenSize = new SKSizeI(-1, -1);
+
     public int Count { get; private set; }
     private readonly Subtitle _bdnXmlSubtitle;
     private readonly string _bdnFileName;
     private readonly bool _isSon;
     private readonly bool _makeTransparent;
     private readonly bool _autoTransparentBackground;
+    private SKSizeI? _screenSize;
 
     public OcrSubtitleBdn(Subtitle subtitle, string bdnFileName, bool isSon, bool makeTransparent = false, bool autoTransparentBackground = false)
     {
@@ -308,11 +314,40 @@ public class OcrSubtitleBdn : IOcrSubtitle
 
     public SKPointI GetPosition(int index)
     {
-        return new SKPointI(-1, -1);
+        if (index < 0 || index >= _bdnXmlSubtitle.Paragraphs.Count)
+        {
+            return NoPosition;
+        }
+
+        // BdnXml.LoadSubtitle puts the graphic "X,Y" in Extra - but Extra holds an image file name
+        // for the Dost/TimedTextImage input this class is also used for, so only take it when it parses.
+        var extra = _bdnXmlSubtitle.Paragraphs[index].Extra;
+        if (string.IsNullOrEmpty(extra))
+        {
+            return NoPosition;
+        }
+
+        var parts = extra.Split(',');
+        if (parts.Length == 2 &&
+            int.TryParse(parts[0].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var x) &&
+            int.TryParse(parts[1].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var y) &&
+            x >= 0 && y >= 0)
+        {
+            return new SKPointI(x, y);
+        }
+
+        return NoPosition;
     }
 
     public SKSizeI GetScreenSize(int index)
     {
-        return new SKSizeI(-1, -1);
+        if (_screenSize == null)
+        {
+            _screenSize = BdnXml.TryGetVideoSize(_bdnXmlSubtitle.Header, out var width, out var height)
+                ? new SKSizeI(width, height)
+                : NoScreenSize;
+        }
+
+        return _screenSize.Value;
     }
 }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAlpha/BinaryAdjustAlphaViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAlpha/BinaryAdjustAlphaViewModel.cs
@@ -133,9 +133,12 @@ public partial class BinaryAdjustAlphaViewModel : ObservableObject, IDisposable
         }
     }
 
-    private static SKBitmap AdjustAlpha(SKBitmap originalBitmap, float alphaAdjustment, byte transparencyThreshold)
+    private static SKBitmap AdjustAlpha(SKBitmap premultipliedBitmap, float alphaAdjustment, byte transparencyThreshold)
     {
-        var adjustedBitmap = new SKBitmap(originalBitmap.Width, originalBitmap.Height, SKColorType.Bgra8888, SKAlphaType.Premul);
+        // Work in straight alpha: changing A while leaving premultiplied R, G and B alone
+        // would produce RGB > A, which Skia renders as clipped, over-bright edges.
+        using var originalBitmap = premultipliedBitmap.ToUnpremultiplied();
+        var adjustedBitmap = new SKBitmap(originalBitmap.Width, originalBitmap.Height, SKColorType.Bgra8888, SKAlphaType.Unpremul);
 
         unsafe
         {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustBrightness/BinaryAdjustBrightnessViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustBrightness/BinaryAdjustBrightnessViewModel.cs
@@ -136,9 +136,12 @@ public partial class BinaryAdjustBrightnessViewModel : ObservableObject, IDispos
         }
     }
 
-    private static SKBitmap AdjustBrightness(SKBitmap originalBitmap, float brightness, float contrast, float gamma)
+    private static SKBitmap AdjustBrightness(SKBitmap premultipliedBitmap, float brightness, float contrast, float gamma)
     {
-        var adjustedBitmap = new SKBitmap(originalBitmap.Width, originalBitmap.Height, SKColorType.Bgra8888, SKAlphaType.Premul);
+        // Work in straight alpha: premultiplied color already carries the pixel's alpha, so
+        // brightening it would scale with transparency and could push RGB above A (halos).
+        using var originalBitmap = premultipliedBitmap.ToUnpremultiplied();
+        var adjustedBitmap = new SKBitmap(originalBitmap.Width, originalBitmap.Height, SKColorType.Bgra8888, SKAlphaType.Unpremul);
 
         // Normalize values for calculations
         var brightnessAdjust = brightness; // -100 to 100

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustBrightness/BinaryAdjustBrightnessWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustBrightness/BinaryAdjustBrightnessWindow.cs
@@ -208,6 +208,10 @@ public class BinaryAdjustBrightnessWindow : Window
 
         vm.PreviewImage = image;
 
-        return UiUtil.MakeBorderForControl(scrollViewer);
+        // Image based subtitles are light or dark text on a transparent background, both
+        // invisible on a matching flat backdrop - use the mid-gray checkerboard (issue #12692).
+        var border = UiUtil.MakeBorderForControl(scrollViewer);
+        border.Background = UiUtil.GetCheckerboardBrush();
+        return border;
     }
 }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorViewModel.cs
@@ -125,13 +125,17 @@ public partial class BinaryAdjustColorViewModel : ObservableObject, IDisposable
         }
     }
 
-    private static SKBitmap ColorBitmap(SKBitmap originalBitmap, byte r, byte g, byte b)
+    private static SKBitmap ColorBitmap(SKBitmap premultipliedBitmap, byte r, byte g, byte b)
     {
         var redPercent = r * 100.0 / 255;
         var greenPercent = g * 100.0 / 255;
         var bluePercent = b * 100.0 / 255;
 
-        var adjustedBitmap = new SKBitmap(originalBitmap.Width, originalBitmap.Height, SKColorType.Bgra8888, SKAlphaType.Premul);
+        // Work in straight alpha: the "total" brightness test below is meaningless on
+        // premultiplied color, where a faint anti-aliased pixel falls under the threshold
+        // and keeps its original color, leaving a fringe around the recolored text.
+        using var originalBitmap = premultipliedBitmap.ToUnpremultiplied();
+        var adjustedBitmap = new SKBitmap(originalBitmap.Width, originalBitmap.Height, SKColorType.Bgra8888, SKAlphaType.Unpremul);
 
         unsafe
         {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorWindow.cs
@@ -115,6 +115,10 @@ public class BinaryAdjustColorWindow : Window
 
         scrollViewer.Content = image;
 
-        return UiUtil.MakeBorderForControl(scrollViewer);
+        // Image based subtitles are light or dark text on a transparent background, both
+        // invisible on a matching flat backdrop - use the mid-gray checkerboard (issue #12692).
+        var border = UiUtil.MakeBorderForControl(scrollViewer);
+        border.Background = UiUtil.GetCheckerboardBrush();
+        return border;
     }
 }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -740,7 +740,18 @@ public class BinaryEditWindow : Window
                     Stretch = Stretch.Uniform,
                     [!Image.SourceProperty] = new Binding(nameof(BinarySubtitleItem.Bitmap)),
                 };
-                return image;
+
+                // Subtitle bitmaps are light or dark text on a transparent background, both
+                // invisible on a matching flat row backdrop - use the mid-gray checkerboard
+                // so any content shows in either theme (issue #12692).
+                return new Border
+                {
+                    Background = UiUtil.GetCheckerboardBrush(),
+                    CornerRadius = new CornerRadius(3),
+                    Padding = new Thickness(2),
+                    HorizontalAlignment = HorizontalAlignment.Left,
+                    Child = image,
+                };
             }),
             CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
         });

--- a/src/ui/Features/Shared/BinaryEdit/BinaryResizeImages/BinaryResizeImagesWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryResizeImages/BinaryResizeImagesWindow.cs
@@ -141,6 +141,10 @@ public class BinaryResizeImagesWindow : Window
 
         vm.PreviewImage = image;
 
-        return UiUtil.MakeBorderForControl(scrollViewer);
+        // Image based subtitles are light or dark text on a transparent background, both
+        // invisible on a matching flat backdrop - use the mid-gray checkerboard (issue #12692).
+        var border = UiUtil.MakeBorderForControl(scrollViewer);
+        border.Background = UiUtil.GetCheckerboardBrush();
+        return border;
     }
 }

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -1586,6 +1586,33 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         };
     }
 
+    private static Subtitle? TryLoadBdnXml(string fileName)
+    {
+        try
+        {
+            var lines = FileUtil.ReadAllLinesShared(fileName, LanguageAutoDetect.GetEncodingFromFile(fileName));
+            var bdnXml = new BdnXml();
+            if (!bdnXml.IsMine(lines, fileName))
+            {
+                return null;
+            }
+
+            var subtitle = new Subtitle();
+            bdnXml.LoadSubtitle(subtitle, lines, fileName);
+            if (subtitle.Paragraphs.Count == 0)
+            {
+                return null;
+            }
+
+            subtitle.OriginalFormat = bdnXml;
+            return subtitle;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     // Parses a file and appends the resulting item(s) to _allBatchItems only (no UI-bound
     // collection touched), so it is safe to call from a background thread. Returns the items
     // added for this file; callers add them to the visible BatchItems on the UI thread.
@@ -1605,6 +1632,19 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         if (ext == ".sub" && FileUtil.IsVobSub(fileName))
         {
             format = BatchConverter.FormatVobSub;
+        }
+
+        if (ext == ".xml" && fileInfo.Length < 20_000_000)
+        {
+            // BDN xml only lives in SubtitleFormat.GetTextOtherFormats(), so neither Subtitle.Parse
+            // nor the GetBinaryFormats() fallback below would ever find it. The "<BDN" requirement in
+            // BdnXml.LoadSubtitle keeps this from stealing other xml formats like TTML.
+            var bdnSubtitle = TryLoadBdnXml(fileName);
+            if (bdnSubtitle != null)
+            {
+                format = BatchConverter.FormatBdnXml;
+                subtitle = bdnSubtitle;
+            }
         }
 
         if (ext == ".mkv" || ext == ".mks")

--- a/src/ui/Logic/SkBitmapExtensions.cs
+++ b/src/ui/Logic/SkBitmapExtensions.cs
@@ -169,6 +169,34 @@ internal static class SkBitmapExtensions
         return data.ToArray();
     }
 
+    /// <summary>
+    /// Returns a Bgra8888/Unpremul copy, i.e. with straight (non-premultiplied) color values.
+    /// <see cref="ToSkBitmap"/> hands back premultiplied pixels, where R, G and B are already
+    /// scaled by A. Per-pixel editing math (brightness, color, alpha) needs straight values:
+    /// scaled color makes an operation's strength depend on the pixel's alpha, and storing a
+    /// changed alpha next to unscaled color yields RGB > A, which Skia renders as clipped
+    /// halos. <see cref="ToAvaloniaBitmap"/> premultiplies again on the way back.
+    /// </summary>
+    public static SKBitmap ToUnpremultiplied(this SKBitmap bitmap)
+    {
+        if (bitmap.Width <= 0 || bitmap.Height <= 0)
+        {
+            return bitmap.Copy();
+        }
+
+        var info = new SKImageInfo(bitmap.Width, bitmap.Height, SKColorType.Bgra8888, SKAlphaType.Unpremul);
+        var unpremultiplied = new SKBitmap(info);
+        using var image = SKImage.FromBitmap(bitmap);
+        if (image == null || !image.ReadPixels(info, unpremultiplied.GetPixels(), unpremultiplied.RowBytes, 0, 0))
+        {
+            // Conversion failed - hand back a plain copy so callers still get valid pixels.
+            unpremultiplied.Dispose();
+            return bitmap.Copy();
+        }
+
+        return unpremultiplied;
+    }
+
     // Original simple code for ToAvaloniaBitmap :
     //public static Bitmap ToAvaloniaBitmapOld(this SKBitmap skBitmap)
     //{

--- a/tests/UI/Features/Ocr/OcrSubtitleBdnTests.cs
+++ b/tests/UI/Features/Ocr/OcrSubtitleBdnTests.cs
@@ -1,0 +1,148 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
+using SkiaSharp;
+
+namespace UITests.Features.Ocr;
+
+public class OcrSubtitleBdnTests : IDisposable
+{
+    private readonly string _dir;
+
+    public OcrSubtitleBdnTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "se_bdn_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_dir, true);
+        }
+        catch
+        {
+            // best-effort
+        }
+    }
+
+    private void WritePng(string name, int width, int height)
+    {
+        using var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Unpremul);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            using var paint = new SKPaint { Color = SKColors.White };
+            canvas.DrawRect(1, 1, width - 2, height - 2, paint);
+        }
+
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var fs = File.Create(Path.Combine(_dir, name));
+        data.SaveTo(fs);
+    }
+
+    private string WriteBdnXml(string videoFormat = "1080p")
+    {
+        WritePng("0001.png", 400, 60);
+        WritePng("0002.png", 300, 60);
+
+        var path = Path.Combine(_dir, "index.xml");
+        File.WriteAllText(path, $"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <BDN Version="0.93">
+            <Description>
+            <Name Title="subtitle_exp" Content=""/>
+            <Language Code="eng"/>
+            <Format VideoFormat="{videoFormat}" FrameRate="25" DropFrame="false"/>
+            <Events Type="Graphic" FirstEventInTC="00:00:01:00" LastEventOutTC="00:00:06:00" NumberofEvents="2"/>
+            </Description>
+            <Events>
+            <Event InTC="00:00:01:00" OutTC="00:00:03:00" Forced="False">
+            <Graphic Width="400" Height="60" X="760" Y="930">0001.png</Graphic>
+            </Event>
+            <Event InTC="00:00:04:00" OutTC="00:00:06:00" Forced="True">
+            <Graphic Width="300" Height="60" X="810" Y="930">0002.png</Graphic>
+            </Event>
+            </Events>
+            </BDN>
+            """);
+        return path;
+    }
+
+    private static (Subtitle Subtitle, OcrSubtitleBdn Ocr) Load(string path)
+    {
+        var lines = FileUtil.ReadAllLinesShared(path, LanguageAutoDetect.GetEncodingFromFile(path));
+        var bdnXml = new BdnXml();
+        Assert.True(bdnXml.IsMine(lines, path));
+
+        var subtitle = new Subtitle();
+        bdnXml.LoadSubtitle(subtitle, lines, path);
+        return (subtitle, new OcrSubtitleBdn(subtitle, path, isSon: false));
+    }
+
+    [Fact]
+    public void ReadsGraphicsTimingsAndForcedFlag()
+    {
+        var (subtitle, ocr) = Load(WriteBdnXml());
+
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+        Assert.Equal(2, ocr.Count);
+
+        Assert.Equal(TimeSpan.FromSeconds(1), ocr.GetStartTime(0));
+        Assert.Equal(TimeSpan.FromSeconds(3), ocr.GetEndTime(0));
+        Assert.False(ocr.GetIsForced(0));
+        Assert.True(ocr.GetIsForced(1));
+
+        using var bitmap = ocr.GetBitmap(0);
+        Assert.Equal(400, bitmap.Width);
+        Assert.Equal(60, bitmap.Height);
+        Assert.Equal(0, bitmap.GetPixel(0, 0).Alpha); // transparent border survives the round trip
+        Assert.Equal(255, bitmap.GetPixel(200, 30).Alpha);
+    }
+
+    // Both used to be hard-coded to -1, so a BDN xml converted to Blu-ray sup lost every position.
+    [Fact]
+    public void ReadsPositionAndScreenSize()
+    {
+        var (_, ocr) = Load(WriteBdnXml());
+
+        Assert.Equal(760, ocr.GetPosition(0).X);
+        Assert.Equal(930, ocr.GetPosition(0).Y);
+        Assert.Equal(810, ocr.GetPosition(1).X);
+
+        Assert.Equal(1920, ocr.GetScreenSize(0).Width);
+        Assert.Equal(1080, ocr.GetScreenSize(0).Height);
+    }
+
+    [Fact]
+    public void ReportsNoScreenSizeWhenVideoFormatIsUnknown()
+    {
+        var (_, ocr) = Load(WriteBdnXml("something-else"));
+
+        Assert.Equal(-1, ocr.GetScreenSize(0).Width);
+        Assert.Equal(-1, ocr.GetScreenSize(0).Height);
+    }
+
+    // OcrSubtitleBdn is shared with the Dost/TimedTextImage import, where Extra is an image
+    // path rather than an "X,Y" pair - that must not be mistaken for a position.
+    [Fact]
+    public void IgnoresNonPositionExtra()
+    {
+        var (subtitle, ocr) = Load(WriteBdnXml());
+        subtitle.Paragraphs[0].Extra = "file://0001.png";
+
+        Assert.Equal(-1, ocr.GetPosition(0).X);
+        Assert.Equal(-1, ocr.GetPosition(0).Y);
+    }
+
+    [Fact]
+    public void ReturnsNoPositionForOutOfRangeIndex()
+    {
+        var (_, ocr) = Load(WriteBdnXml());
+
+        Assert.Equal(-1, ocr.GetPosition(-1).X);
+        Assert.Equal(-1, ocr.GetPosition(99).X);
+    }
+}

--- a/tests/UI/Logic/SkBitmapExtensionsTests.cs
+++ b/tests/UI/Logic/SkBitmapExtensionsTests.cs
@@ -114,4 +114,99 @@ public class SkBitmapExtensionsTests
         Assert.Equal(255, buffer[3]); // first pixel alpha: opaque
         Assert.Equal(255, buffer[31 * 4]); // last pixel of row 0, blue channel: white
     }
+
+    // A premultiplied half-transparent white pixel, i.e. what ToSkBitmap hands the
+    // Binary edit image tools: straight (255,255,255,128) is stored as (128,128,128,128).
+    private static SKBitmap MakePremultipliedHalfTransparentWhite(int width = 1, int height = 1)
+    {
+        var bitmap = new SKBitmap(new SKImageInfo(width, height, SKColorType.Bgra8888, SKAlphaType.Premul));
+        var bytes = new byte[width * height * 4];
+        for (var i = 0; i < width * height; i++)
+        {
+            bytes[i * 4] = 128; // blue
+            bytes[i * 4 + 1] = 128; // green
+            bytes[i * 4 + 2] = 128; // red
+            bytes[i * 4 + 3] = 128; // alpha
+        }
+
+        Marshal.Copy(bytes, 0, bitmap.GetPixels(), bytes.Length);
+        return bitmap;
+    }
+
+    [Fact]
+    public void ToUnpremultipliedRecoversStraightColor()
+    {
+        using var premultiplied = MakePremultipliedHalfTransparentWhite();
+
+        using var straight = premultiplied.ToUnpremultiplied();
+
+        Assert.Equal(SKAlphaType.Unpremul, straight.AlphaType);
+        Assert.Equal(SKColorType.Bgra8888, straight.ColorType);
+
+        var pixel = straight.GetPixel(0, 0);
+        Assert.Equal((byte)255, pixel.Red);
+        Assert.Equal((byte)255, pixel.Green);
+        Assert.Equal((byte)255, pixel.Blue);
+        Assert.Equal((byte)128, pixel.Alpha);
+    }
+
+    // The image tools index pixels as y * Width + x, which assumes tightly packed rows.
+    [Theory]
+    [InlineData(1)]
+    [InlineData(7)]
+    [InlineData(401)]
+    [InlineData(911)]
+    public void ToUnpremultipliedKeepsRowsTightlyPacked(int width)
+    {
+        using var premultiplied = MakePremultipliedHalfTransparentWhite(width, 3);
+
+        using var straight = premultiplied.ToUnpremultiplied();
+
+        Assert.Equal(width * 4, straight.RowBytes);
+        Assert.Equal((byte)255, straight.GetPixel(width - 1, 2).Red);
+    }
+
+    [Fact]
+    public void ToUnpremultipliedHandlesEmptyBitmap()
+    {
+        using var empty = new SKBitmap(0, 0);
+
+        using var straight = empty.ToUnpremultiplied();
+
+        Assert.NotNull(straight);
+    }
+
+    // Lowering alpha in straight space and letting ToAvaloniaBitmap premultiply again must
+    // keep R,G,B <= A. Editing the premultiplied bytes directly left RGB at 128 with A at 64,
+    // which Skia renders as clipped, over-bright edges.
+    [AvaloniaFact]
+    public void AlphaEditRoundTripStaysValidPremultiplied()
+    {
+        using var premultiplied = MakePremultipliedHalfTransparentWhite();
+        using var straight = premultiplied.ToUnpremultiplied();
+
+        // What the image tools do: change alpha only, colour is left alone.
+        using var edited = new SKBitmap(new SKImageInfo(1, 1, SKColorType.Bgra8888, SKAlphaType.Unpremul));
+        var source = straight.GetPixel(0, 0);
+        Marshal.Copy(new[] { (byte)source.Blue, (byte)source.Green, (byte)source.Red, (byte)64 }, 0, edited.GetPixels(), 4);
+
+        var avaloniaBitmap = edited.ToAvaloniaBitmap();
+
+        var buffer = new byte[4];
+        var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+        try
+        {
+            avaloniaBitmap.CopyPixels(new Avalonia.PixelRect(0, 0, 1, 1), handle.AddrOfPinnedObject(), buffer.Length, 4);
+        }
+        finally
+        {
+            handle.Free();
+        }
+
+        var alpha = buffer[3];
+        Assert.Equal(64, alpha);
+        Assert.True(buffer[0] <= alpha, $"blue {buffer[0]} exceeds alpha {alpha}");
+        Assert.True(buffer[1] <= alpha, $"green {buffer[1]} exceeds alpha {alpha}");
+        Assert.True(buffer[2] <= alpha, $"red {buffer[2]} exceeds alpha {alpha}");
+    }
 }

--- a/tests/libse/BluRaySup/BluRaySupParserTest.cs
+++ b/tests/libse/BluRaySup/BluRaySupParserTest.cs
@@ -1,4 +1,5 @@
 using Nikse.SubtitleEdit.Core.BluRaySup;
+using SkiaSharp;
 using System.IO;
 using System.Text;
 
@@ -189,5 +190,74 @@ public class BluRaySupParserTest
         var pcsList = Parse(ms);
 
         Assert.Single(pcsList); // the empty clearing PCS was removed, not inflated
+    }
+
+    // Palette entry 0 transparent, entry 1 opaque - "00 84 00" is a run of four palette-0 pixels.
+    private static byte[] MakeOdsPayloadWithTransparentRun()
+    {
+        var rle = new byte[18];
+        for (var row = 0; row < 2; row++)
+        {
+            var o = row * 9;
+            rle[o] = 0x01;
+            rle[o + 1] = 0x01;
+            rle[o + 2] = 0x01;
+            rle[o + 3] = 0x01;
+            rle[o + 4] = 0x00; // 00 84 00 -> four times palette entry 0
+            rle[o + 5] = 0x84;
+            rle[o + 6] = 0x00;
+            // rle[o + 7] and [o + 8] stay 0x00 0x00 = end of line
+        }
+
+        var payload = new byte[11 + rle.Length];
+        payload[3] = 0xC0; // first and last in sequence
+        payload[6] = (byte)(rle.Length + 4);
+        payload[8] = 0x08; // width 8
+        payload[10] = 0x02; // height 2
+        rle.CopyTo(payload, 11);
+        return payload;
+    }
+
+    private static byte[] MakePdsPayloadWithTransparentEntry()
+    {
+        return new byte[]
+        {
+            0x00, 0x00,                   // palette id, version
+            0x00, 0xEB, 0x80, 0x80, 0x00, // entry 0: transparent (alpha 0)
+            0x01, 0x10, 0x80, 0x80, 0xFF, // entry 1: black, opaque
+        };
+    }
+
+    // Transparent palette entries are forced to black (BluRaySupParser.DecodePalette), so an
+    // alpha-less bitmap turns the whole background into a solid black block - see issue #12761.
+    [Fact]
+    public void DecodedImageKeepsTransparency()
+    {
+        var ms = new MemoryStream();
+        WriteSegment(ms, 0x16, Pts1, MakePcsPayload(1, withObject: true));
+        WriteSegment(ms, 0x17, Pts1, MakeWdsPayload());
+        WriteSegment(ms, 0x14, Pts1, MakePdsPayloadWithTransparentEntry());
+        WriteSegment(ms, 0x15, Pts1, MakeOdsPayloadWithTransparentRun());
+        WriteSegment(ms, 0x80, Pts1, System.Array.Empty<byte>());
+        WriteSegment(ms, 0x16, Pts2, MakePcsPayload(0, withObject: false));
+        WriteSegment(ms, 0x80, Pts2, System.Array.Empty<byte>());
+        ms.Position = 0;
+
+        var pcs = Assert.Single(Parse(ms));
+        using var bitmap = pcs.GetBitmap();
+
+        Assert.NotEqual(SKAlphaType.Opaque, bitmap.AlphaType);
+        Assert.Equal(255, bitmap.GetPixel(0, 0).Alpha); // drawn pixel
+        Assert.Equal(0, bitmap.GetPixel(4, 0).Alpha);   // transparent run
+        Assert.Equal(0, bitmap.GetPixel(7, 1).Alpha);
+
+        // the symptom users see is in the encoded png, so pin that too
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var decoded = SKBitmap.Decode(data.ToArray());
+        Assert.Equal(255, decoded.GetPixel(0, 0).Alpha);
+        Assert.Equal(0, decoded.GetPixel(4, 0).Alpha);
+
+        ms.Dispose();
     }
 }

--- a/tests/libse/SubtitleFormats/BdnXmlTest.cs
+++ b/tests/libse/SubtitleFormats/BdnXmlTest.cs
@@ -1,0 +1,93 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace LibSETests.SubtitleFormats;
+
+public class BdnXmlTest
+{
+    private static string MakeBdnXml(string videoFormat, string graphicAttributes)
+    {
+        return """
+               <?xml version="1.0" encoding="UTF-8"?>
+               <BDN Version="0.93">
+               <Description>
+               <Name Title="subtitle_exp" Content=""/>
+               <Language Code="eng"/>
+               <Format VideoFormat="@VIDEOFORMAT@" FrameRate="25" DropFrame="false"/>
+               <Events Type="Graphic" FirstEventInTC="00:00:01:00" LastEventOutTC="00:00:03:00" NumberofEvents="1"/>
+               </Description>
+               <Events>
+               <Event InTC="00:00:01:00" OutTC="00:00:03:00" Forced="False">
+               <Graphic Width="400" Height="60" @GRAPHICATTRIBUTES@>0001.png</Graphic>
+               </Event>
+               </Events>
+               </BDN>
+               """
+            .Replace("@VIDEOFORMAT@", videoFormat)
+            .Replace("@GRAPHICATTRIBUTES@", graphicAttributes);
+    }
+
+    private static Subtitle Load(string xml)
+    {
+        var subtitle = new Subtitle();
+        new BdnXml().LoadSubtitle(subtitle, xml.SplitToLines(), "test.xml");
+        return subtitle;
+    }
+
+    [Fact]
+    public void LoadsGraphicFileNameAndPosition()
+    {
+        var subtitle = Load(MakeBdnXml("1080p", "X=\"760\" Y=\"930\""));
+
+        var p = Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("0001.png", p.Text);
+        Assert.Equal("760,930", p.Extra);
+        Assert.Equal(1000, p.StartTime.TotalMilliseconds);
+        Assert.Equal(3000, p.EndTime.TotalMilliseconds);
+    }
+
+    // "X" without "Y" used to throw a NullReferenceException, which dropped the whole event.
+    [Fact]
+    public void LoadsGraphicWithOnlyOneOfXAndY()
+    {
+        var subtitle = Load(MakeBdnXml("1080p", "X=\"760\""));
+
+        var p = Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("0001.png", p.Text);
+        Assert.True(string.IsNullOrEmpty(p.Extra));
+    }
+
+    [Theory]
+    [InlineData("1080p", 1920, 1080)]
+    [InlineData("1080i", 1920, 1080)]
+    [InlineData("720p", 1280, 720)]
+    [InlineData("576i", 720, 576)]
+    [InlineData("480p", 720, 480)]
+    [InlineData("2160p", 3840, 2160)]
+    [InlineData("1440x1080", 1440, 1080)] // the Subtitle Edit exporter writes this for non-standard sizes
+    public void ReadsVideoSize(string videoFormat, int expectedWidth, int expectedHeight)
+    {
+        var subtitle = Load(MakeBdnXml(videoFormat, "X=\"0\" Y=\"0\""));
+
+        Assert.True(BdnXml.TryGetVideoSize(subtitle.Header, out var width, out var height));
+        Assert.Equal(expectedWidth, width);
+        Assert.Equal(expectedHeight, height);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-size")]
+    public void ReturnsFalseForUnknownVideoSize(string videoFormat)
+    {
+        var subtitle = Load(MakeBdnXml(videoFormat, "X=\"0\" Y=\"0\""));
+
+        Assert.False(BdnXml.TryGetVideoSize(subtitle.Header, out _, out _));
+    }
+
+    [Fact]
+    public void ReturnsFalseForNonBdnXml()
+    {
+        Assert.False(BdnXml.TryGetVideoSize("<Subtitle><Paragraph/></Subtitle>", out _, out _));
+        Assert.False(BdnXml.TryGetVideoSize(null, out _, out _));
+    }
+}


### PR DESCRIPTION
Fixes the three problems reported in #12761, plus the fallout the first one had been hiding.

### 1. `sup` → BDN xml produced black backgrounds

`SupDecoder.DecodeImage` allocated the bitmap as `SKAlphaType.Opaque`, so Skia dropped the alpha channel when encoding. Transparent palette entries are deliberately forced to black by `DecodePalette` ("to not mess with scaling algorithms"), so every exported PNG background became a solid black block.

Confirmed against the reporter's own attachments — the exported PNG is `8-bit RGB` where the source is `RGBA`, and the pixel histogram accounts for it exactly:

| | source | exported |
|---|---|---|
| transparent `(0,0,0,0)` | 28 987 | 0 |
| black `(0,0,0,255)` | 8 108 | **37 798** = 28 987 + 8 108 |
| text fill `(180,180,180)` | 9 732 | 9 732 unchanged |

Opaque pixels keep their RGB exactly, so this is purely alpha loss. Fixed by using `Unpremul`, which matches the straight (non-premultiplied) RGBA that `FillPixels`/`PutPixelFast` write — `Premul` would brighten anti-aliased edges.

This is an SE4 → SE5 regression: `771236c50` replaced GDI+'s `new Bitmap(w, h)` (which defaults to `Format32bppArgb`) with the Opaque `SKBitmap`. Because it's in libse, the fix covers the GUI, seconv and libuilogic at once.

It also revives alpha-dependent code that had silently stopped working: `BluRaySupPicture.EncodeImage` (sup re-encode, keys on `Alpha == 0`), `NikseBitmap.ConvertToFourColors` (sup → VobSub, keys on `alpha < 10`), and the `QualifiesForMerge` ink-extent heuristic, whose `height > 110 || width > 300` guard was effectively always true.

### 2. BDN xml could not be used as input

`BdnXml` is registered only in `SubtitleFormat.GetTextOtherFormats()`, which neither `Subtitle.Parse` nor the `GetBinaryFormats()` fallback consults — so batch convert left the format as `Unknown` and failed with a generic error, even though `BatchConverter` already had a `FormatBdnXml` branch and `OcrSubtitleBdn` could already read the images.

Added detection by extension (the `<BDN` requirement in `LoadSubtitle` keeps it from stealing TTML and friends), and filled in `OcrSubtitleBdn.GetPosition`/`GetScreenSize`, which were hard-coded to `-1` and would have dropped every subtitle position on conversion. Also fixed a `||` that should have been `&&` in `BdnXml.LoadSubtitle`, where a `Graphic` with `X` but no `Y` threw and discarded the whole event.

### 3. Premultiplied-pixel math in the Binary edit image tools

Pre-existing, but much more visible now that PGS bitmaps carry real alpha. `ToSkBitmap` hands back premultiplied pixels, where R, G and B are already scaled by A, but all three tools treated them as straight colour values:

- **alpha** — changed A and left RGB alone, giving `RGB > A` (Skia renders that as clipped, over-bright edges)
- **brightness** — brightened `colour × alpha`, so the effect scaled with transparency and overflowed A
- **colour** — its `total > 100` brightness threshold tested premultiplied RGB, so faint anti-aliased pixels fell under it and kept their original colour, leaving a fringe around recoloured text

Fixed at the root with a `ToUnpremultiplied()` helper; `ToAvaloniaBitmap` already premultiplies on the way back. The per-pixel arithmetic in each tool is unchanged — it was always straight-alpha math, it just wasn't being fed straight-alpha values.

### 4. Preview backings

The brightness, colour and resize previews and the Binary edit grid thumbnails had no backdrop, so light text on a now-transparent background is invisible in a light theme. They now use the same `UiUtil.GetCheckerboardBrush()` the OCR window already uses for this (#12692).

## Tests

- `DecodedImageKeepsTransparency` builds a synthetic PGS stream with a transparent palette entry and asserts alpha survives both decode **and** PNG encode. Verified it fails on the old line and passes on the new one.
- `BdnXmlTest` (11) — graphic/position parsing, the `X`-without-`Y` case, and video-size parsing for both `1080p` and `1920x1080` forms.
- `OcrSubtitleBdnTests` (5) — end-to-end with real PNGs on disk, including that a Dost-style file path in `Extra` is not mistaken for a position.
- `SkBitmapExtensionsTests` (+7) — the unpremultiply contract, the premultiplied round trip staying valid, and that rows stay tightly packed for odd widths (the tools index pixels as `y * Width + x`).

libse 674, libuilogic 18, seconv 261, UI 763 — all passing. The 20 UI failures on this machine are pre-existing SpellCheck/dictionary tests that also fail on a clean `main`.

## Notes for review

- The three transform methods are `private static`, so the tests pin the helper contract rather than the tools themselves. The failure mode is visual, so the alpha/brightness/colour sliders are worth an eyeball on a real `.sup`.
- **Not** fixed here, flagged deliberately: `seconv/Core/TesseractOcrEngine.cs` clears to white before compositing, so with `--no-pgs-isolate-colors` white glyph fill now lands on white. The default path uses `BinarizeForOcr` and is unaffected. The likely fix is clearing to black, matching the Ollama/LlamaCpp engines, but that also changes VobSub behaviour and the white choice is documented as deliberate, so it wants validation against real Tesseract.
- Also pre-existing and untouched: `OcrSubtitleBluRay.GetPosition` doesn't compensate the load-time crop the way `OcrSubtitleVobSub` does (shared with DVB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)