### PR TITLE
Surface 7-zip unpack failures instead of hanging the download dialogs

### DIFF
--- a/src/ui/Features/Ocr/Download/DownloadGoogleLensOcrViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadGoogleLensOcrViewModel.cs
@@ -84,7 +84,19 @@ public partial class DownloadGoogleLensOcrViewModel : ObservableObject, IClosing
                     return;
                 }
 
-                Unpacker.Extract7Zip(_tempFileName, Se.GoogleLensOcrFolder, "Chrome-Lens-OCR-v3.4.0", _cancellationTokenSource, text => ProgressText = text); 
+                try
+                {
+                    Unpacker.Extract7Zip(_tempFileName, Se.GoogleLensOcrFolder, "Chrome-Lens-OCR-v3.4.0", _cancellationTokenSource, text => ProgressText = text);
+                }
+                catch (Exception exception)
+                {
+                    // Timer callbacks swallow exceptions, so an unpack failure would
+                    // otherwise hang the dialog with no error shown (#12127).
+                    Se.LogError(exception, "Google Lens OCR unpack failed");
+                    ProgressText = "Unpacking failed";
+                    Error = exception.Message;
+                    return;
+                }
 
                 OkPressed = true;
                 Close();

--- a/src/ui/Features/Ocr/Download/DownloadPaddleOcrViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadPaddleOcrViewModel.cs
@@ -119,46 +119,61 @@ public partial class DownloadPaddleOcrViewModel : ObservableObject, IClosingClea
                 }
 
                 StartIndeterminateProgress();
-                var firstFile = Path.Combine(_tempFolder, Path.GetFileName(_downloadTaskUrls[0]));
-                if (_downloadType == PaddleOcrDownloadType.Models)
+
+                try
                 {
-                    StatusText = string.Format(Se.Language.General.UnpackingX, Se.Language.General.Models);
-                    Unpacker.Extract7Zip(firstFile, Se.PaddleOcrModelsFolder, "PaddleOCR.PP-OCRv5.support.files", _cancellationTokenSource, text => ProgressText = text);
-                }
-                else if (_downloadType == PaddleOcrDownloadType.EngineCpu)
-                {
-                    StatusText = string.Format(Se.Language.General.UnpackingX, Se.Language.Ocr.PaddleOcr);
-                    Unpacker.Extract7Zip(firstFile, Se.PaddleOcrFolder, "PaddleOCR-CPU-v1.4.0", _cancellationTokenSource, text => ProgressText = text);
-                }
-                else if (_downloadType == PaddleOcrDownloadType.EngineGpu11)
-                {
-                    StatusText = string.Format(Se.Language.General.UnpackingX, Se.Language.Ocr.PaddleOcr);
-                    Unpacker.Extract7Zip(firstFile, Se.PaddleOcrFolder, "PaddleOCR-GPU-v1.4.0-CUDA-11.8", _cancellationTokenSource, text => ProgressText = text);
-                }
-                else if (_downloadType == PaddleOcrDownloadType.EngineGpu12)
-                {
-                    StatusText = string.Format(Se.Language.General.UnpackingX, Se.Language.Ocr.PaddleOcr);
-                    Unpacker.Extract7Zip(firstFile, Se.PaddleOcrFolder, "PaddleOCR-GPU-v1.4.0-CUDA-12.9", _cancellationTokenSource, text => ProgressText = text);
-                }
-                else if (_downloadType == PaddleOcrDownloadType.EngineCpuLinux)
-                {
-                    StatusText = string.Format(Se.Language.General.UnpackingX, Se.Language.Ocr.PaddleOcr);
-                    Unpacker.Extract7Zip(firstFile, Se.PaddleOcrFolder, "PaddleOCR-CPU-v1.4.0-Linux", _cancellationTokenSource, text => ProgressText = text);
-                    var binFile = Path.Combine(Se.PaddleOcrFolder, "paddleocr.bin");
-                    if (File.Exists(binFile))
+                    var firstFile = Path.Combine(_tempFolder, Path.GetFileName(_downloadTaskUrls[0]));
+                    if (_downloadType == PaddleOcrDownloadType.Models)
                     {
-                        LinuxHelper.MakeExecutable(binFile);
-                    }                    
-                }
-                else if (_downloadType == PaddleOcrDownloadType.EngineGpuLinux)
-                {
-                    StatusText = string.Format(Se.Language.General.UnpackingX, Se.Language.Ocr.PaddleOcr);
-                    Unpacker.Extract7Zip(firstFile, Se.PaddleOcrFolder, "PaddleOCR-GPU-v1.4.0-CUDA-12.9-Linux", _cancellationTokenSource, text => ProgressText = text);
-                    var binFile = Path.Combine(Se.PaddleOcrFolder, "paddleocr.bin");
-                    if (File.Exists(binFile))
-                    {
-                        LinuxHelper.MakeExecutable(binFile);
+                        StatusText = string.Format(Se.Language.General.UnpackingX, Se.Language.General.Models);
+                        Unpacker.Extract7Zip(firstFile, Se.PaddleOcrModelsFolder, "PaddleOCR.PP-OCRv5.support.files", _cancellationTokenSource, text => ProgressText = text);
                     }
+                    else if (_downloadType == PaddleOcrDownloadType.EngineCpu)
+                    {
+                        StatusText = string.Format(Se.Language.General.UnpackingX, Se.Language.Ocr.PaddleOcr);
+                        Unpacker.Extract7Zip(firstFile, Se.PaddleOcrFolder, "PaddleOCR-CPU-v1.4.0", _cancellationTokenSource, text => ProgressText = text);
+                    }
+                    else if (_downloadType == PaddleOcrDownloadType.EngineGpu11)
+                    {
+                        StatusText = string.Format(Se.Language.General.UnpackingX, Se.Language.Ocr.PaddleOcr);
+                        Unpacker.Extract7Zip(firstFile, Se.PaddleOcrFolder, "PaddleOCR-GPU-v1.4.0-CUDA-11.8", _cancellationTokenSource, text => ProgressText = text);
+                    }
+                    else if (_downloadType == PaddleOcrDownloadType.EngineGpu12)
+                    {
+                        StatusText = string.Format(Se.Language.General.UnpackingX, Se.Language.Ocr.PaddleOcr);
+                        Unpacker.Extract7Zip(firstFile, Se.PaddleOcrFolder, "PaddleOCR-GPU-v1.4.0-CUDA-12.9", _cancellationTokenSource, text => ProgressText = text);
+                    }
+                    else if (_downloadType == PaddleOcrDownloadType.EngineCpuLinux)
+                    {
+                        StatusText = string.Format(Se.Language.General.UnpackingX, Se.Language.Ocr.PaddleOcr);
+                        Unpacker.Extract7Zip(firstFile, Se.PaddleOcrFolder, "PaddleOCR-CPU-v1.4.0-Linux", _cancellationTokenSource, text => ProgressText = text);
+                        var binFile = Path.Combine(Se.PaddleOcrFolder, "paddleocr.bin");
+                        if (File.Exists(binFile))
+                        {
+                            LinuxHelper.MakeExecutable(binFile);
+                        }                    
+                    }
+                    else if (_downloadType == PaddleOcrDownloadType.EngineGpuLinux)
+                    {
+                        StatusText = string.Format(Se.Language.General.UnpackingX, Se.Language.Ocr.PaddleOcr);
+                        Unpacker.Extract7Zip(firstFile, Se.PaddleOcrFolder, "PaddleOCR-GPU-v1.4.0-CUDA-12.9-Linux", _cancellationTokenSource, text => ProgressText = text);
+                        var binFile = Path.Combine(Se.PaddleOcrFolder, "paddleocr.bin");
+                        if (File.Exists(binFile))
+                        {
+                            LinuxHelper.MakeExecutable(binFile);
+                        }
+                    }
+
+                }
+                catch (Exception exception)
+                {
+                    // Timer callbacks swallow exceptions, so an unpack failure would
+                    // otherwise hang the dialog with no error shown (#12127).
+                    Se.LogError(exception, "PaddleOCR unpack failed");
+                    StopIndeterminateProgress();
+                    ProgressText = "Unpacking failed";
+                    Error = exception.Message;
+                    return;
                 }
 
                 StopIndeterminateProgress();

--- a/src/ui/Features/Shared/DownloadLibVlcViewModel.cs
+++ b/src/ui/Features/Shared/DownloadLibVlcViewModel.cs
@@ -93,7 +93,22 @@ public partial class DownloadLibVlcViewModel : ObservableObject, IClosingCleanup
                 }
 
                 StartIndeterminateProgress();
-                Unpacker.Extract7Zip(_tempFileName, Se.VlcFolder, "vlc-3.0.23", _cancellationTokenSource, text => ProgressText = text);
+
+                try
+                {
+                    Unpacker.Extract7Zip(_tempFileName, Se.VlcFolder, "vlc-3.0.23", _cancellationTokenSource, text => ProgressText = text);
+                }
+                catch (Exception exception)
+                {
+                    // Timer callbacks swallow exceptions, so an unpack failure would
+                    // otherwise hang the dialog with no error shown (#12127).
+                    Se.LogError(exception, "libVLC unpack failed");
+                    StopIndeterminateProgress();
+                    ProgressText = "Unpacking failed";
+                    Error = exception.Message;
+                    return;
+                }
+
                 StopIndeterminateProgress();
 
                 OkPressed = true;

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -116,156 +116,176 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
             }
 
             _timer.Stop();
-            // IsCompletedSuccessfully (not the broader IsCompleted, which is also true for
-            // Faulted/Canceled tasks) so a download that threw - e.g. Faster-Whisper-XXL's
-            // PlatformNotSupportedException on Linux ARM64 or macOS - falls through to the
-            // IsFaulted branch below instead of unpacking a file that was never downloaded,
-            // which left the dialog stuck on "Unpacking..." indefinitely.
-            if (_downloadTask is { IsCompletedSuccessfully: true } && Engine != null)
+
+            try
             {
-                if (Engine.Name == WhisperEnginePurfviewFasterWhisperXxl.StaticName)
-                {
-                    var dir = Engine.GetAndCreateWhisperFolder();
-                    var tempFileName = Path.Combine(dir, Engine.Name + ".7z");
-
-                    TitleText = Se.Language.General.Unpacking7ZipArchiveDotDotDot;
-                    StartIndeterminateProgress();
-                    Unpacker.Extract7Zip(tempFileName, dir, "Faster-Whisper-XXL", _cancellationTokenSource, text => ProgressText = text);
-                    StopIndeterminateProgress();
-
-                    try
-                    {
-                        File.Delete(tempFileName);
-
-                        var path = Engine.GetExecutable();
-                        MakeExecutable(path);
-                    }
-                    catch
-                    {
-                        // ignore
-                    }
-
-                    if (_cancellationTokenSource.IsCancellationRequested)
-                    {
-                        Cancel();
-                        return;
-                    }
-
-                    DownloadAndUnpackSileroVad(dir);
-
-                    OkPressed = true;
-                    Close();
-                }
-                else if (Engine.Name == WhisperEngineCTranslate2.StaticName)
-                {
-                    var dir = Engine.GetAndCreateWhisperFolder();
-
-                    TitleText = string.Format(Se.Language.General.UnpackingX, Engine.Name);
-                    StartIndeterminateProgress();
-                    Unpack(dir, string.Empty);
-                    StopIndeterminateProgress();
-
-                    if (_cancellationTokenSource.IsCancellationRequested)
-                    {
-                        Cancel();
-                        return;
-                    }
-
-                    DownloadAndUnpackSileroVad(dir);
-
-                    OkPressed = true;
-                    Close();
-                }
-                else
-                {
-                    if (_downloadStream.Length == 0)
-                    {
-                        ProgressText = "Download failed";
-                        Error = "No data received";
-                        return;
-                    }
-
-                    var folder = Engine.GetAndCreateWhisperFolder();
-                    var skipFolder = Engine is ICrispAsrEngine
-                        ? OperatingSystem.IsLinux()
-                            ? (RuntimeInformation.ProcessArchitecture == Architecture.Arm64
-                                ? "crispasr-linux-arm64"
-                                : CrispAsrWindowsVariant switch
-                                {
-                                    "cuda"   => "crispasr-linux-x86_64-cuda",
-                                    "cuda13" => "crispasr-linux-x86_64-cuda13",
-                                    "vulkan" => "crispasr-linux-x86_64-vulkan",
-                                    "hip"    => "crispasr-linux-x86_64-hip",
-                                    _        => "crispasr-linux-x86_64",
-                                })
-                            : OperatingSystem.IsMacOS()
-                                ? "crispasr-macos"
-                                : CrispAsrWindowsVariant switch
-                                {
-                                    "cuda"       => "crispasr-windows-x86_64-cuda",
-                                    "cpu"        => "crispasr-windows-x86_64-cpu",
-                                    "cpu-legacy" => "crispasr-windows-x86_64-cpu-legacy",
-                                    "vulkan"     => "crispasr-windows-x86_64-vulkan",
-                                    _            => Engine.UnpackSkipFolder,
-                                }
-                        : Engine.UnpackSkipFolder;
-
-                    if (Engine is ICrispAsrEngine)
-                    {
-                        WriteCrispAsrInstalledHash(folder);
-                        RemoveStaleCrispAsrBinaries(folder);
-                    }
-                    else if (Engine is WhisperEngineCpp or WhisperEngineCppCuBlas or WhisperEngineCppVulkan)
-                    {
-                        WriteWhisperCppInstalledHash(folder);
-                    }
-                    else if (Engine is Qwen3AsrCppEngine)
-                    {
-                        // Sidecar powers the update prompt (issue #11375 - broken-JSON builds
-                        // stayed installed forever because nothing recognized them as outdated).
-                        DownloadHashManager.WriteSidecar(folder,
-                            DownloadHashManager.ResolveQwen3AsrCppKey(Qwen3AsrUseVulkan), _downloadStream);
-                    }
-
-                    TitleText = Se.Language.Video.AudioToText.UnpackingSpeechToTextEngine;
-                    Unpack(folder, skipFolder);
-
-                    if (Engine is not (ChatLlmCppEngine or Qwen3AsrCppEngine))
-                    {
-                        DownloadAndUnpackSileroVad(folder);
-                    }
-
-                    OkPressed = true;
-                    Close();
-                }
-
-                return;
+                ProcessDownloadState();
             }
-
-            if (_downloadTask is { IsFaulted: true })
+            catch (Exception exception)
             {
-                var ex = _downloadTask.Exception?.InnerException ?? _downloadTask.Exception;
-                if (ex is OperationCanceledException)
+                // An exception thrown from a timer callback is swallowed silently, and the
+                // timer was already stopped above - so without this catch the dialog would
+                // hang forever with no error shown, e.g. when the 7-zip unpack fails on the
+                // Flatpak build (#12127).
+                StopIndeterminateProgress();
+                Se.LogError(exception, "Speech-to-text engine download/unpack failed");
+                ProgressText = "Unpacking failed";
+                Error = exception.Message;
+            }
+        }
+    }
+
+    private void ProcessDownloadState()
+    {
+        // IsCompletedSuccessfully (not the broader IsCompleted, which is also true for
+        // Faulted/Canceled tasks) so a download that threw - e.g. Faster-Whisper-XXL's
+        // PlatformNotSupportedException on Linux ARM64 or macOS - falls through to the
+        // IsFaulted branch below instead of unpacking a file that was never downloaded,
+        // which left the dialog stuck on "Unpacking..." indefinitely.
+        if (_downloadTask is { IsCompletedSuccessfully: true } && Engine != null)
+        {
+            if (Engine.Name == WhisperEnginePurfviewFasterWhisperXxl.StaticName)
+            {
+                var dir = Engine.GetAndCreateWhisperFolder();
+                var tempFileName = Path.Combine(dir, Engine.Name + ".7z");
+
+                TitleText = Se.Language.General.Unpacking7ZipArchiveDotDotDot;
+                StartIndeterminateProgress();
+                Unpacker.Extract7Zip(tempFileName, dir, "Faster-Whisper-XXL", _cancellationTokenSource, text => ProgressText = text);
+                StopIndeterminateProgress();
+
+                try
                 {
-                    ProgressText = "Download canceled";
-                    Close();
+                    File.Delete(tempFileName);
+
+                    var path = Engine.GetExecutable();
+                    MakeExecutable(path);
                 }
-                else
+                catch
+                {
+                    // ignore
+                }
+
+                if (_cancellationTokenSource.IsCancellationRequested)
+                {
+                    Cancel();
+                    return;
+                }
+
+                DownloadAndUnpackSileroVad(dir);
+
+                OkPressed = true;
+                Close();
+            }
+            else if (Engine.Name == WhisperEngineCTranslate2.StaticName)
+            {
+                var dir = Engine.GetAndCreateWhisperFolder();
+
+                TitleText = string.Format(Se.Language.General.UnpackingX, Engine.Name);
+                StartIndeterminateProgress();
+                Unpack(dir, string.Empty);
+                StopIndeterminateProgress();
+
+                if (_cancellationTokenSource.IsCancellationRequested)
+                {
+                    Cancel();
+                    return;
+                }
+
+                DownloadAndUnpackSileroVad(dir);
+
+                OkPressed = true;
+                Close();
+            }
+            else
+            {
+                if (_downloadStream.Length == 0)
                 {
                     ProgressText = "Download failed";
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = "No data received";
+                    return;
                 }
 
-                return;
+                var folder = Engine.GetAndCreateWhisperFolder();
+                var skipFolder = Engine is ICrispAsrEngine
+                    ? OperatingSystem.IsLinux()
+                        ? (RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                            ? "crispasr-linux-arm64"
+                            : CrispAsrWindowsVariant switch
+                            {
+                                "cuda"   => "crispasr-linux-x86_64-cuda",
+                                "cuda13" => "crispasr-linux-x86_64-cuda13",
+                                "vulkan" => "crispasr-linux-x86_64-vulkan",
+                                "hip"    => "crispasr-linux-x86_64-hip",
+                                _        => "crispasr-linux-x86_64",
+                            })
+                        : OperatingSystem.IsMacOS()
+                            ? "crispasr-macos"
+                            : CrispAsrWindowsVariant switch
+                            {
+                                "cuda"       => "crispasr-windows-x86_64-cuda",
+                                "cpu"        => "crispasr-windows-x86_64-cpu",
+                                "cpu-legacy" => "crispasr-windows-x86_64-cpu-legacy",
+                                "vulkan"     => "crispasr-windows-x86_64-vulkan",
+                                _            => Engine.UnpackSkipFolder,
+                            }
+                    : Engine.UnpackSkipFolder;
+
+                if (Engine is ICrispAsrEngine)
+                {
+                    WriteCrispAsrInstalledHash(folder);
+                    RemoveStaleCrispAsrBinaries(folder);
+                }
+                else if (Engine is WhisperEngineCpp or WhisperEngineCppCuBlas or WhisperEngineCppVulkan)
+                {
+                    WriteWhisperCppInstalledHash(folder);
+                }
+                else if (Engine is Qwen3AsrCppEngine)
+                {
+                    // Sidecar powers the update prompt (issue #11375 - broken-JSON builds
+                    // stayed installed forever because nothing recognized them as outdated).
+                    DownloadHashManager.WriteSidecar(folder,
+                        DownloadHashManager.ResolveQwen3AsrCppKey(Qwen3AsrUseVulkan), _downloadStream);
+                }
+
+                TitleText = Se.Language.Video.AudioToText.UnpackingSpeechToTextEngine;
+                Unpack(folder, skipFolder);
+
+                if (Engine is not (ChatLlmCppEngine or Qwen3AsrCppEngine))
+                {
+                    DownloadAndUnpackSileroVad(folder);
+                }
+
+                OkPressed = true;
+                Close();
             }
 
-            // Guard the restart: OnClosingCleanup may have disposed the timer while this
-            // handler ran, and Start() on a disposed timer throws ObjectDisposedException,
-            // crashing the app from a thread-pool thread. (#12739)
-            if (!_isClosing)
+            return;
+        }
+
+        if (_downloadTask is { IsFaulted: true })
+        {
+            var ex = _downloadTask.Exception?.InnerException ?? _downloadTask.Exception;
+            if (ex is OperationCanceledException)
             {
-                _timer.Start();
+                ProgressText = "Download canceled";
+                Close();
             }
+            else
+            {
+                ProgressText = "Download failed";
+                Error = ex?.Message ?? "Unknown error";
+            }
+
+            return;
+        }
+
+        // Guard the restart: OnClosingCleanup may have disposed the timer while this
+        // handler ran, and Start() on a disposed timer throws ObjectDisposedException,
+        // crashing the app from a thread-pool thread. (#12739)
+        if (!_isClosing)
+        {
+            _timer.Start();
         }
     }
 

--- a/src/ui/Logic/SevenZipExtractor/Unpacker.cs
+++ b/src/ui/Logic/SevenZipExtractor/Unpacker.cs
@@ -19,16 +19,20 @@ public static class Unpacker
             updateProgressText(Se.Language.General.Unpacking7ZipArchiveDotDotDot);
         });
 
-        if (OperatingSystem.IsWindows())
+        if (OperatingSystem.IsWindows() ||
+            (OperatingSystem.IsLinux() && RuntimeInformation.ProcessArchitecture == Architecture.X64))
         {
-            Unpack7ZipVia77zExecutable(tempFileName, dir, skipFolderLevel, cancellationTokenSource, updateProgressText);
-            return;
-        }
-
-        if (OperatingSystem.IsLinux() && RuntimeInformation.ProcessArchitecture == Architecture.X64)
-        {
-            Unpack7ZipVia77zExecutable(tempFileName, dir, skipFolderLevel, cancellationTokenSource, updateProgressText);
-            return;
+            try
+            {
+                Unpack7ZipVia77zExecutable(tempFileName, dir, skipFolderLevel, cancellationTokenSource, updateProgressText);
+                return;
+            }
+            catch (Exception exception)
+            {
+                // e.g. bundled 7zr/7za missing or not executable (seen in Flatpak) - fall
+                // back to the managed extractor instead of failing the whole install.
+                Se.LogError(exception, $"7-zip executable extraction of \"{tempFileName}\" failed, falling back to managed extraction");
+            }
         }
 
         if (OperatingSystem.IsMacOS())
@@ -36,8 +40,15 @@ public static class Unpacker
             var macSevenZipPath = GetMacSevenZipPath();
             if (macSevenZipPath != null)
             {
-                Unpack7ZipViaSystemExecutable(macSevenZipPath, tempFileName, dir, skipFolderLevel, cancellationTokenSource, updateProgressText);
-                return;
+                try
+                {
+                    Unpack7ZipViaSystemExecutable(macSevenZipPath, tempFileName, dir, skipFolderLevel, cancellationTokenSource, updateProgressText);
+                    return;
+                }
+                catch (Exception exception)
+                {
+                    Se.LogError(exception, $"System 7zz extraction of \"{tempFileName}\" failed, falling back to managed extraction");
+                }
             }
         }
 
@@ -121,7 +132,7 @@ public static class Unpacker
             if (process.ExitCode != 0)
             {
                 var error = process.StandardError.ReadToEnd();
-                throw new Exception($"7zz extraction failed with exit code {process.ExitCode}: {error}");
+                throw new Exception($"7zz extraction failed with exit code {process.ExitCode} (command: \"{sevenZipPath}\" x \"{tempFileName}\" -o\"{extractPath}\" -y): {error}");
             }
 
             // If we need to skip folder levels, move files from temp to final destination
@@ -192,7 +203,14 @@ public static class Unpacker
                 }
             };
 
-            process.Start();
+            try
+            {
+                process.Start();
+            }
+            catch (Exception exception)
+            {
+                throw new Exception($"Could not start 7-zip (command: \"{sevenZipPath}\" x \"{tempFileName}\" -o\"{extractPath}\" -y)", exception);
+            }
 
             while (!process.StandardOutput.EndOfStream)
             {
@@ -225,7 +243,7 @@ public static class Unpacker
             if (process.ExitCode != 0)
             {
                 var error = process.StandardError.ReadToEnd();
-                throw new Exception($"7zip extraction failed with exit code {process.ExitCode}: {error}");
+                throw new Exception($"7zip extraction failed with exit code {process.ExitCode} (command: \"{sevenZipPath}\" x \"{tempFileName}\" -o\"{extractPath}\" -y): {error}");
             }
 
             // If we need to skip folder levels, move files from temp to final destination


### PR DESCRIPTION
Follow-up to #12127, prompted by [this report](https://github.com/SubtitleEdit/subtitleedit/pull/12127#issuecomment-5060968813) of a stuck download on the Flathub Linux x86_64 build (5.1.0-rc12, which already contains the #12127 fix).

## Root cause

#12127 fixed the case where the *download task* faults. But the *unpack phase* runs inside a `System.Timers.Timer` callback with no error handling. Exceptions thrown from a timer callback are swallowed silently, and since the timer is stopped at the top of the callback, any unpack failure left the dialog hanging on "Unpacking 7-zip archive..." forever with no error shown — the same symptom, new cause.

On Linux x64 the unpack path execs a bundled `7zr` binary that SE extracts from its assets at first use. There are several ways that can throw (binary missing after a failed asset unpack, sandbox unable to exec it — plausible in a Flatpak — or a non-zero exit code), and all of them previously turned into a silent hang.

## Fix

- `Unpacker.Extract7Zip` now falls back to the managed SharpCompress extractor when the bundled `7zr`/`7za.exe` (or the macOS system `7zz`) is missing or fails, logging the error **including the exact unpack command line** so failures are diagnosable from the error log.
- The four download dialogs that unpack 7z archives in timer callbacks (speech-to-text engine, Google Lens OCR, PaddleOCR, libVLC) now catch unpack exceptions, log them, and show the error in the dialog instead of hanging.

## Files

- `src/ui/Logic/SevenZipExtractor/Unpacker.cs`
- `src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs`
- `src/ui/Features/Ocr/Download/DownloadGoogleLensOcrViewModel.cs`
- `src/ui/Features/Ocr/Download/DownloadPaddleOcrViewModel.cs`
- `src/ui/Features/Shared/DownloadLibVlcViewModel.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)