### PR TITLE
Fix Space no longer toggling play/pause after clicking the player button

### DIFF
--- a/src/ui/Controls/NonSpaceButton.cs
+++ b/src/ui/Controls/NonSpaceButton.cs
@@ -1,0 +1,47 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using System;
+
+namespace Nikse.SubtitleEdit.Controls;
+
+/// <summary>
+/// A <see cref="Button"/> that never reacts to the Space key.
+/// <para>
+/// Avalonia's built-in <see cref="Button"/> both marks Space as handled on key-down and raises
+/// <see cref="Button.Click"/> on Space key-up whenever it is focused (it does not require that the
+/// same button also saw the key-down). Once such a button gains focus - e.g. after a mouse click -
+/// it swallows and/or duplicates the global "toggle play/pause" Space shortcut, so Space stops
+/// behaving as a toggle (issue #12759, same root cause as #12093).
+/// </para>
+/// <para>
+/// Using this button for player/waveform transport buttons keeps Space owned exclusively by the
+/// global shortcut, no matter which of those buttons currently has keyboard focus.
+/// </para>
+/// </summary>
+public class NonSpaceButton : Button
+{
+    // Keep the default Button styling instead of looking for a NonSpaceButton style.
+    protected override Type StyleKeyOverride => typeof(Button);
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Space)
+        {
+            e.Handled = true;
+            return;
+        }
+
+        base.OnKeyDown(e);
+    }
+
+    protected override void OnKeyUp(KeyEventArgs e)
+    {
+        if (e.Key == Key.Space)
+        {
+            e.Handled = true;
+            return;
+        }
+
+        base.OnKeyUp(e);
+    }
+}

--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -273,7 +273,9 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             };
 
             // Play
-            _buttonPlay = new Button
+            // NonSpaceButton: a focused Button would otherwise consume/duplicate the global
+            // play/pause Space shortcut once clicked with the mouse (issue #12759).
+            _buttonPlay = new NonSpaceButton
             {
                 Margin = new Thickness(0, 0, 3, 0),
                 [AutomationProperties.NameProperty] = Se.Language.General.Play,
@@ -298,7 +300,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             stackPanel.Children.Add(_buttonPlay);
 
             // Stop
-            var buttonStop = new Button
+            var buttonStop = new NonSpaceButton
             {
                 Margin = new Thickness(0, 0, 3, 0),
                 [AutomationProperties.NameProperty] = Se.Language.General.Stop,
@@ -326,7 +328,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             });
 
             // Fullscreen
-            _buttonFullScreen = new Button
+            _buttonFullScreen = new NonSpaceButton
             {
                 Margin = new Thickness(0, 0, 3, 0),
                 [AutomationProperties.NameProperty] = Se.Language.General.FullScreen,
@@ -350,7 +352,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             });
 
 
-            _buttonFullScreenCollapse = new Button()
+            _buttonFullScreenCollapse = new NonSpaceButton()
             {
                 Margin = new Thickness(0, 0, 3, 0),
                 IsVisible = false,

--- a/src/ui/Features/Main/Layout/InitWaveform.cs
+++ b/src/ui/Features/Main/Layout/InitWaveform.cs
@@ -8,6 +8,7 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Threading;
+using Nikse.SubtitleEdit.Controls;
 using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -20,33 +21,6 @@ using System.Threading.Tasks;
 using MenuItem = Avalonia.Controls.MenuItem;
 
 namespace Nikse.SubtitleEdit.Features.Main.Layout;
-
-public class NonSpaceButton : Button
-{
-    protected override Type StyleKeyOverride => typeof(Button);
-
-    protected override void OnKeyDown(KeyEventArgs e)
-    {
-        if (e.Key == Key.Space)
-        {
-            e.Handled = true;
-            return;
-        }
-
-        base.OnKeyDown(e);
-    }
-
-    protected override void OnKeyUp(KeyEventArgs e)
-    {
-        if (e.Key == Key.Space)
-        {
-            e.Handled = true;
-            return;
-        }
-
-        base.OnKeyUp(e);
-    }
-}
 
 public class InitWaveform
 {


### PR DESCRIPTION
Fixes #12759

### Problem

After clicking the **video player's Play/Pause button with the mouse**, the Space key stopped working as a play/pause toggle: playback ran only *while Space was held* and stopped *when it was released* (the reporter also saw jumpy/frame-like playback).

### Root cause

The player's transport buttons (`_buttonPlay`, `buttonStop`, `_buttonFullScreen`, `_buttonFullScreenCollapse`) were plain `Avalonia.Controls.Button`s, so a mouse click left keyboard focus on them. Avalonia 12's `Button` then, while focused:

- marks Space **handled on key-down** — the tunnel handler in `MainView` still fires the global `Space → TogglePlayPauseCommand` shortcut first, starting playback, and
- raises `Click` **on Space key-up** without checking it saw the key-down — which re-invokes `PlayOrPause()`, pausing again.

Net effect: play on press, pause on release. (Same Avalonia behavior behind #12093 / PR #12122.) SE 4 was unaffected because its transport buttons were not keyboard-focusable. The two documented workarounds — clicking the main toolbar Play/Pause or opening Settings — simply move focus off the player button.

### Fix

The waveform toolbar already avoids this via a `NonSpaceButton` subclass that swallows Space in `OnKeyDown`/`OnKeyUp`; the video player toolbar used plain `Button`s. This promotes `NonSpaceButton` from a local class in `InitWaveform.cs` to a shared control under `src/ui/Controls/` and uses it for the player's Play, Stop and both full-screen buttons. Space now stays owned by the global shortcut no matter which transport button has focus.

### Notes

- No behavior change for the waveform buttons — same type, just relocated.
- Builds clean. This is UI focus/input behavior with no unit-test seam; verified by tracing the Avalonia key routing. Manual check: click the player Play button, then press Space — it toggles normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
