### PR TITLE
Bundle 7zr in the Flatpak and prefer a system 7-zip on Linux

### DIFF
--- a/installer/flatpak/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/dk.nikse.subtitleedit.yaml
@@ -342,6 +342,25 @@ modules:
         url: https://raw.githubusercontent.com/notofonts/noto-cjk/f8d157532fbfaeda587e826d4cd5b21a49186f7c/Sans/OTC/NotoSansCJK-Regular.ttc
         sha256: b76b0433203017ca80401b2ee0dd69350349871c4b19d504c34dbdd80541690a
 
+  # --- 7-Zip (7zr) ---
+  #
+  # SE unpacks downloaded engines/models from .7z archives. The portable build
+  # extracts a bundled 7zr into the writable app data folder at first use and
+  # executes it from there - which fails on noexec home/data mounts and only
+  # exists for x86_64. Building 7zr into /app/bin gives a read-only,
+  # always-executable binary that Unpacker prefers over the extracted one,
+  # and enables fast .7z extraction on ARM64 too.
+  - name: sevenzip
+    buildsystem: simple
+    build-commands:
+      - make -C CPP/7zip/Bundles/Alone7z -f makefile.gcc
+      - install -Dm755 CPP/7zip/Bundles/Alone7z/_o/7zr /app/bin/7zr
+    sources:
+      - type: archive
+        url: https://github.com/ip7z/7zip/releases/download/25.01/7z2501-src.tar.xz
+        sha256: ed087f83ee789c1ea5f39c464c55a5c9d4008deb0efe900814f2df262b82c36e
+        strip-components: 0
+
   # --- SubtitleEdit application ---
 
   - name: subtitleedit

--- a/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
@@ -342,6 +342,25 @@ modules:
         url: https://raw.githubusercontent.com/notofonts/noto-cjk/f8d157532fbfaeda587e826d4cd5b21a49186f7c/Sans/OTC/NotoSansCJK-Regular.ttc
         sha256: b76b0433203017ca80401b2ee0dd69350349871c4b19d504c34dbdd80541690a
 
+  # --- 7-Zip (7zr) ---
+  #
+  # SE unpacks downloaded engines/models from .7z archives. The portable build
+  # extracts a bundled 7zr into the writable app data folder at first use and
+  # executes it from there - which fails on noexec home/data mounts and only
+  # exists for x86_64. Building 7zr into /app/bin gives a read-only,
+  # always-executable binary that Unpacker prefers over the extracted one,
+  # and enables fast .7z extraction on ARM64 too.
+  - name: sevenzip
+    buildsystem: simple
+    build-commands:
+      - make -C CPP/7zip/Bundles/Alone7z -f makefile.gcc
+      - install -Dm755 CPP/7zip/Bundles/Alone7z/_o/7zr /app/bin/7zr
+    sources:
+      - type: archive
+        url: https://github.com/ip7z/7zip/releases/download/25.01/7z2501-src.tar.xz
+        sha256: ed087f83ee789c1ea5f39c464c55a5c9d4008deb0efe900814f2df262b82c36e
+        strip-components: 0
+
   # --- SubtitleEdit application ---
 
   - name: subtitleedit

--- a/src/ui/Logic/SevenZipExtractor/Unpacker.cs
+++ b/src/ui/Logic/SevenZipExtractor/Unpacker.cs
@@ -19,6 +19,27 @@ public static class Unpacker
             updateProgressText(Se.Language.General.Unpacking7ZipArchiveDotDotDot);
         });
 
+        if (OperatingSystem.IsLinux())
+        {
+            // Prefer a pre-installed 7-zip (e.g. /app/bin/7zr bundled in the Flatpak, or a
+            // distro p7zip) - it lives on a read-only, always-executable mount, unlike the
+            // 7zr unpacked to the app data folder below, which can fail on noexec setups.
+            // Also the only fast path on Linux ARM64, where no 7zr asset is bundled.
+            var linuxSevenZipPath = GetLinuxSevenZipPath();
+            if (linuxSevenZipPath != null)
+            {
+                try
+                {
+                    Unpack7ZipViaSystemExecutable(linuxSevenZipPath, tempFileName, dir, skipFolderLevel, cancellationTokenSource, updateProgressText);
+                    return;
+                }
+                catch (Exception exception)
+                {
+                    Se.LogError(exception, $"System 7-zip extraction of \"{tempFileName}\" failed, trying next extraction method");
+                }
+            }
+        }
+
         if (OperatingSystem.IsWindows() ||
             (OperatingSystem.IsLinux() && RuntimeInformation.ProcessArchitecture == Architecture.X64))
         {
@@ -53,6 +74,30 @@ public static class Unpacker
         }
 
         Extract7ZipSlow(tempFileName, dir, skipFolderLevel, cancellationTokenSource, updateProgressText);
+    }
+
+    private static string? GetLinuxSevenZipPath()
+    {
+        // 7zr (7z-archives only) and 7zz/7z (full) all support "x <archive> -o<dir> -y"
+        var paths = new[]
+        {
+            "/app/bin/7zr",   // bundled in the Flatpak
+            "/usr/bin/7zr",
+            "/usr/bin/7zz",
+            "/usr/bin/7z",
+            "/usr/local/bin/7zz",
+            "/usr/local/bin/7z"
+        };
+
+        foreach (var path in paths)
+        {
+            if (File.Exists(path))
+            {
+                return path;
+            }
+        }
+
+        return null;
     }
 
     private static string? GetMacSevenZipPath()


### PR DESCRIPTION
Stacked on #12764 (includes its commit; merge that first and this diff reduces to the 7zr changes).

Follow-up to the [Flathub stuck-download report](https://github.com/SubtitleEdit/subtitleedit/pull/12127#issuecomment-5060968813): the portable build extracts a bundled x86_64-only `7zr` into the writable app data folder at first use and executes it from there — which fails on `noexec` home/data mounts (a plausible cause of the report), and leaves Linux ARM64 with only the slow managed extractor for 1+ GB engine archives.

## Changes

- **Flatpak manifests** (CI + flathub): new `sevenzip` module building `7zr` from the official 7-Zip 25.01 source (`CPP/7zip/Bundles/Alone7z`, `makefile.gcc`) into `/app/bin/7zr`. Read-only, always-executable mount, built per-arch so aarch64 is covered too. Build recipe and the resulting binary verified locally (compiles cleanly, round-trips a `7zr a` / `7zr x`).
- **`Unpacker.Extract7Zip`**: on Linux, prefer a pre-installed 7-zip (`/app/bin/7zr`, then distro `7zr`/`7zz`/`7z` in /usr/bin and /usr/local/bin) via the existing system-executable path — mirroring what macOS already does with Homebrew `7zz` — before falling back to the extracted-asset `7zr` and then the managed extractor from #12764. This also benefits non-Flatpak Linux installs with p7zip present.

## Files

- `installer/flatpak/dk.nikse.subtitleedit.yaml`
- `installer/flatpak/flathub/dk.nikse.subtitleedit.yaml`
- `src/ui/Logic/SevenZipExtractor/Unpacker.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)