### PR TITLE
Keep start dash when dialog follows a bracket or parenthesis

### DIFF
--- a/src/libse/Forms/FixCommonErrors/RemoveDialogFirstLineInNonDialogs.cs
+++ b/src/libse/Forms/FixCommonErrors/RemoveDialogFirstLineInNonDialogs.cs
@@ -131,14 +131,14 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         }
 
         /// <summary>
-        /// True if a dash follows the end of a sentence, like "Hi there. - Hello!".
+        /// True if a dash follows the end of a sentence, like "Hi there. - Hello!" or "[phone rings] - Hello!".
         /// </summary>
         private static bool StartsSentenceWithDash(string text)
         {
             for (var i = 2; i < text.Length; i++)
             {
                 if (text[i - 1] == ' ' && IsDash(text[i]) &&
-                    (text[i - 2] == '.' || text[i - 2] == '!' || text[i - 2] == '?'))
+                    (text[i - 2] == '.' || text[i - 2] == '!' || text[i - 2] == '?' || text[i - 2] == ']' || text[i - 2] == ')'))
                 {
                     return true;
                 }

--- a/tests/libse/Forms/FixCommonErrors/RemoveDialogFirstLineInNonDialogsTest.cs
+++ b/tests/libse/Forms/FixCommonErrors/RemoveDialogFirstLineInNonDialogsTest.cs
@@ -50,6 +50,14 @@ public class RemoveDialogFirstLineInNonDialogsTest
         Assert.Equal(input, Fix(input));
     }
 
+    [Theory]
+    [InlineData("- [phone rings] - Hello!")]
+    [InlineData("- (sighs) - Who's there?")]
+    public void KeepsStartDash_WhenDialogFollowsBracketOrParenthesis(string input)
+    {
+        Assert.Equal(input, Fix(input));
+    }
+
     [Fact]
     public void KeepsStartDash_WhenSecondLineUsesAnotherDashCharacter()
     {


### PR DESCRIPTION
## Summary
- Treat `]` and `)` as sentence endings in `StartsSentenceWithDash`, so lines like `- [phone rings] - Hello!` are recognized as one-line dialogs and the leading dash is kept by "Remove start dash in non dialogs"
- Add test `KeepsStartDash_WhenDialogFollowsBracketOrParenthesis` covering bracket and parenthesis cases

## Test plan
- [x] Run `dotnet test tests/libse/LibSETests.csproj --filter "FullyQualifiedName~RemoveDialogFirstLineInNonDialogsTest"` — all tests pass
- [ ] In Fix Common Errors with "Remove start dash in non dialogs" enabled, verify `- [phone rings] - Hello!` is left unchanged
- [ ] Verify a plain non-dialog like `- Hi there!` still has its leading dash removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)