### PR TITLE
seconv: fix output-filename/output-folder, legacy /convert, silent settings warnings, translate-url

### DIFF
--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -474,6 +474,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
             // Load --settings:path.json overrides into libse Configuration before any conversion.
             // --profile <name> selects a named overlay from the same file.
             var imageStyle = new ImageExportStyle();
+            var settingsWarnings = new List<string>();
             if (!string.IsNullOrWhiteSpace(settings.SettingsPath))
             {
                 try
@@ -485,12 +486,21 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                     // Unknown keys are ignored by the JSON reader, which used to mean a typo - or a
                     // key from a newer seconv - silently produced default output (issue #12437).
                     var unknownKeys = seConvSettings.GetUnknownKeys().ToList();
-                    if (unknownKeys.Count > 0 && !silent)
+                    if (unknownKeys.Count > 0)
                     {
-                        AnsiConsole.MarkupLineInterpolated(
-                            $"[yellow]Warning: ignoring unknown key(s) in --settings file: {string.Join(", ", unknownKeys)}[/]");
-                        AnsiConsole.MarkupLine(
-                            "[yellow]Check for typos, or update seconv if the key was added in a newer version.[/]");
+                        // Also recorded in the result warnings below, so --quiet and --json
+                        // consumers see it too — the typo-produces-default-output failure this
+                        // warning exists for hits scripted runs hardest.
+                        settingsWarnings.Add(
+                            $"Ignoring unknown key(s) in --settings file: {string.Join(", ", unknownKeys)}. " +
+                            "Check for typos, or update seconv if the key was added in a newer version.");
+                        if (!silent)
+                        {
+                            AnsiConsole.MarkupLineInterpolated(
+                                $"[yellow]Warning: ignoring unknown key(s) in --settings file: {string.Join(", ", unknownKeys)}[/]");
+                            AnsiConsole.MarkupLine(
+                                "[yellow]Check for typos, or update seconv if the key was added in a newer version.[/]");
+                        }
                     }
                 }
                 catch (Exception ex)
@@ -748,6 +758,14 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
             var converter = new SubtitleConverter();
             var result = await converter.ConvertAsync(options);
             stopwatch.Stop();
+
+            // Surface settings-file warnings in the machine-readable output too; in non-silent
+            // mode they were already printed above, but --quiet/--json would otherwise drop
+            // them entirely (the silent-typo failure from issue #12437).
+            if (settingsWarnings.Count > 0 && silent)
+            {
+                result.Warnings.InsertRange(0, settingsWarnings);
+            }
 
             var elapsed = FormatElapsed(stopwatch.Elapsed);
 

--- a/src/seconv/Core/AutoTranslateRunner.cs
+++ b/src/seconv/Core/AutoTranslateRunner.cs
@@ -61,10 +61,9 @@ internal sealed class AutoTranslateRunner
                 if (!string.IsNullOrEmpty(url))
                 {
                     // User-managed server. LlamaCppTranslate posts to the URL as-is, so accept a
-                    // bare host:port and complete it to the chat/completions endpoint.
-                    tools.LlamaCppApiUrl = url.Contains("/v1/", StringComparison.OrdinalIgnoreCase)
-                        ? url
-                        : url.TrimEnd('/') + "/v1/chat/completions";
+                    // bare host:port or an OpenAI-style ".../v1" base and complete either to the
+                    // chat/completions endpoint (without doubling an already-present /v1).
+                    tools.LlamaCppApiUrl = CompleteChatCompletionsUrl(url);
                 }
                 else
                 {
@@ -168,6 +167,26 @@ internal sealed class AutoTranslateRunner
                 subtitle.Paragraphs[i].Text = rows[i].TranslatedText;
             }
         }
+    }
+
+    /// <summary>
+    /// Completes a user-supplied --translate-url to the full chat/completions endpoint.
+    /// Accepts a bare <c>host:port</c>, an OpenAI-style <c>.../v1</c> base (with or without
+    /// trailing slash), or an already-complete <c>.../chat/completions</c> URL — the old
+    /// <c>Contains("/v1/")</c> check missed the no-trailing-slash base form and produced
+    /// <c>.../v1/v1/chat/completions</c>.
+    /// </summary>
+    internal static string CompleteChatCompletionsUrl(string url)
+    {
+        var trimmed = url.TrimEnd('/');
+        if (trimmed.EndsWith("/chat/completions", StringComparison.OrdinalIgnoreCase))
+        {
+            return trimmed;
+        }
+
+        return trimmed.EndsWith("/v1", StringComparison.OrdinalIgnoreCase)
+            ? trimmed + "/chat/completions"
+            : trimmed + "/v1/chat/completions";
     }
 
     internal static TranslationPair ResolveLanguage(List<TranslationPair> languages, string requested, string kind)

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -771,7 +771,11 @@ internal class SubtitleConverter
         string baseName;
         if (!string.IsNullOrEmpty(options.OutputFilename))
         {
-            baseName = options.OutputFilename;
+            // A relative --output-filename still lands in --output-folder; an absolute
+            // one wins outright.
+            baseName = !string.IsNullOrEmpty(options.OutputFolder) && !Path.IsPathRooted(options.OutputFilename)
+                ? Path.Combine(options.OutputFolder, options.OutputFilename)
+                : options.OutputFilename;
         }
         else
         {

--- a/src/seconv/Program.cs
+++ b/src/seconv/Program.cs
@@ -120,12 +120,20 @@ internal class Program
     /// Skips path-like arguments (anything containing a path separator after the leading
     /// slash) so Unix absolute paths and Windows drive paths pass through unchanged.
     /// </summary>
-    private static string[] ConvertLegacyArguments(string[] args)
+    internal static string[] ConvertLegacyArguments(string[] args)
     {
         var converted = new List<string>();
 
         foreach (var arg in args)
         {
+            // SE 4.x invocations start with a "/convert" verb; modern seconv has no such
+            // option, so drop the token entirely — the remaining pattern/format positionals
+            // and rewritten /option:value args match the modern grammar.
+            if (arg.Equals("/convert", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
             if (arg.StartsWith('/') && arg != "/?" && arg != "/help" && !LooksLikePath(arg))
             {
                 converted.Add("--" + arg.Substring(1));

--- a/tests/seconv/Core/AutoTranslateRunnerTest.cs
+++ b/tests/seconv/Core/AutoTranslateRunnerTest.cs
@@ -225,4 +225,18 @@ public class AutoTranslateRunnerTest : IDisposable
         Assert.Equal("de", AutoTranslateRunner.ResolveLanguage(languages, "german", "target").TwoLetterIsoLanguageName);
         Assert.Throws<InvalidOperationException>(() => AutoTranslateRunner.ResolveLanguage(languages, "klingon", "target"));
     }
+
+    // The OpenAI-style ".../v1" base (no trailing slash) used to fail the old "/v1/" check
+    // and come out as ".../v1/v1/chat/completions".
+    [Theory]
+    [InlineData("http://localhost:8080", "http://localhost:8080/v1/chat/completions")]
+    [InlineData("http://localhost:8080/", "http://localhost:8080/v1/chat/completions")]
+    [InlineData("http://localhost:8080/v1", "http://localhost:8080/v1/chat/completions")]
+    [InlineData("http://localhost:8080/v1/", "http://localhost:8080/v1/chat/completions")]
+    [InlineData("http://localhost:8080/v1/chat/completions", "http://localhost:8080/v1/chat/completions")]
+    [InlineData("http://localhost:8080/V1/Chat/Completions", "http://localhost:8080/V1/Chat/Completions")]
+    public void CompleteChatCompletionsUrl_CompletesWithoutDoublingV1(string input, string expected)
+    {
+        Assert.Equal(expected, AutoTranslateRunner.CompleteChatCompletionsUrl(input));
+    }
 }

--- a/tests/seconv/Core/LegacyArgumentsTest.cs
+++ b/tests/seconv/Core/LegacyArgumentsTest.cs
@@ -1,0 +1,33 @@
+using Xunit;
+
+namespace SeConvTests.Core;
+
+public class LegacyArgumentsTest
+{
+    [Fact]
+    public void ConvertLegacyArguments_DropsConvertVerb()
+    {
+        // SE 4.x: `SubtitleEdit /convert sub.srt sami /overwrite`. The verb has no modern
+        // equivalent option; it used to be rewritten to the nonexistent "--convert", which
+        // consumed the pattern slot and failed the whole invocation.
+        var result = SeConv.Program.ConvertLegacyArguments(["/convert", "sub.srt", "sami", "/overwrite"]);
+
+        Assert.Equal(["sub.srt", "sami", "--overwrite"], result);
+    }
+
+    [Fact]
+    public void ConvertLegacyArguments_DropsConvertVerbCaseInsensitive()
+    {
+        var result = SeConv.Program.ConvertLegacyArguments(["/Convert", "sub.srt", "sami"]);
+
+        Assert.Equal(["sub.srt", "sami"], result);
+    }
+
+    [Fact]
+    public void ConvertLegacyArguments_RewritesSlashOptionsAndKeepsPaths()
+    {
+        var result = SeConv.Program.ConvertLegacyArguments(["/encoding:utf-8", "/etc/subs/a.srt", "/?"]);
+
+        Assert.Equal(["--encoding:utf-8", "/etc/subs/a.srt", "/?"], result);
+    }
+}

--- a/tests/seconv/Core/OutputFileNameTest.cs
+++ b/tests/seconv/Core/OutputFileNameTest.cs
@@ -89,4 +89,29 @@ public class OutputFileNameTest : IDisposable
 
         Assert.Equal(explicitOutput, result);
     }
+
+    [Fact]
+    public void Resolve_RelativeOutputFilenameWithOutputFolder_CombinesThem()
+    {
+        var input = Path.Combine(_tempRoot, "input.srt");
+        File.WriteAllText(input, "");
+
+        var result = SubtitleConverter.ResolveOutputFileName(input, Opts(overwrite: true, outputFilename: "renamed.vtt"));
+
+        Assert.Equal(Path.Combine(_tempRoot, "renamed.vtt"), result);
+    }
+
+    [Fact]
+    public void Resolve_AbsoluteOutputFilename_IgnoresOutputFolder()
+    {
+        var input = Path.Combine(_tempRoot, "input.srt");
+        File.WriteAllText(input, "");
+        var other = Path.Combine(_tempRoot, "elsewhere");
+        Directory.CreateDirectory(other);
+        var absolute = Path.Combine(other, "renamed.vtt");
+
+        var result = SubtitleConverter.ResolveOutputFileName(input, Opts(overwrite: true, outputFilename: absolute));
+
+        Assert.Equal(absolute, result);
+    }
 }


### PR DESCRIPTION
Fixes four seconv bugs found in a targeted bug hunt:

1. **`--output-filename` ignored `--output-folder`** — `ResolveOutputFileName` used the filename verbatim, so `--output-folder /out --output-filename final.srt` wrote `./final.srt`. A relative filename now combines with the output folder; an absolute one still wins.
2. **Legacy `/convert` syntax was broken** — the verb was rewritten to the nonexistent `--convert`, which consumed the pattern slot and failed every SE4-style invocation with *Missing required argument 'pattern'*. The token is now dropped (case-insensitively).
3. **Unknown-settings-key warning swallowed in `--quiet`/`--json`** — the #12437 warning was gated on `!silent` and never added to `result.Warnings`, so scripted runs (the main consumers of `--settings`) got the silent typo-produces-default-output failure back. Settings warnings are now prepended to the result warnings in silent modes and show up in the JSON `warnings` array.
4. **`--translate-url:.../v1` doubled to `.../v1/v1/chat/completions`** — the completion check only recognized `"/v1/"` with a trailing slash. New `CompleteChatCompletionsUrl` handles bare `host:port`, `/v1` base with/without trailing slash, and already-complete endpoints.

Tested: 272/272 seconv tests pass (11 new: output-path combination, legacy-args rewriting, URL completion). All three CLI repros verified against the built binary (`/convert` exit 0, `out/final.srt` created, JSON `warnings` populated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)