### PR TITLE
seconv: apply the .idx palette when decoding VobSub, accept .idx input (#12772)

### DIFF
--- a/src/seconv/Core/BitmapSubtitleLoader.cs
+++ b/src/seconv/Core/BitmapSubtitleLoader.cs
@@ -90,6 +90,16 @@ internal static class BitmapSubtitleLoader
         var items = new List<BitmapSubtitleItem>(packs.Count);
         foreach (var pack in packs)
         {
+            // Without the .idx CLUT, SubPicture.GetBitmap skips both the SetColor and
+            // SetContrast (per-plane alpha) display commands, so normally-transparent
+            // outline/anti-alias planes render opaque and fuse into the glyphs — the
+            // garbled OCR in issue #12772 ('-'→'=', 'S'→'$'). Mirrors the GUI, which
+            // always passes VobSubParser.IdxPalette.
+            if (parser.IdxPalette.Count > 0)
+            {
+                pack.Palette = parser.IdxPalette;
+            }
+
             var bmp = pack.GetBitmap();
             if (bmp is null)
             {
@@ -136,6 +146,11 @@ internal static class BitmapSubtitleLoader
                 $"VobSub MKV track #{track.TrackNumber} is compressed (content encoding 1), which isn't supported.");
         }
 
+        // The track's CodecPrivate holds the .idx text, including the CLUT palette. Without
+        // it SubPicture.GetBitmap skips SetColor/SetContrast and renders normally-transparent
+        // planes opaque (issue #12772) — same fix as LoadVobSub; mirrors the GUI MKV path.
+        var palette = GetVobSubIdxPalette(track.GetCodecPrivate());
+
         var sub = matroska.GetSubtitle(track.TrackNumber, null);
         var packs = new List<VobSubMergedPack>(sub.Count);
         foreach (var p in sub)
@@ -143,6 +158,7 @@ internal static class BitmapSubtitleLoader
             packs.Add(new VobSubMergedPack(p.GetData(track), TimeSpan.FromMilliseconds(p.Start), 32, null)
             {
                 EndTime = TimeSpan.FromMilliseconds(p.End),
+                Palette = palette,
             });
 
             // Fix overlapping time codes (some Handbrake versions emit them) by clamping the
@@ -173,6 +189,21 @@ internal static class BitmapSubtitleLoader
             throw new InvalidOperationException($"No VobSub subtitles in MKV track #{track.TrackNumber}.");
         }
         return items;
+    }
+
+    /// <summary>
+    /// Palette (CLUT) from a Matroska VobSub track's CodecPrivate .idx text, or null when the
+    /// track carries none — <see cref="SubPicture.GetBitmap"/> then falls back to its defaults.
+    /// </summary>
+    internal static List<SKColor>? GetVobSubIdxPalette(string? codecPrivate)
+    {
+        if (string.IsNullOrWhiteSpace(codecPrivate))
+        {
+            return null;
+        }
+
+        var palette = new Idx(codecPrivate.SplitToLines()).Palette;
+        return palette.Count > 0 ? palette : null;
     }
 
     /// <summary>

--- a/src/seconv/Core/ContainerSubtitleLoader.cs
+++ b/src/seconv/Core/ContainerSubtitleLoader.cs
@@ -86,6 +86,22 @@ internal static class ContainerSubtitleLoader
             return null;
         }
 
+        if (ext == ".idx")
+        {
+            // 5.0.0 accepted the .idx of a VobSub pair as the input file; keep that working
+            // by redirecting to the companion .sub (which holds the actual subpictures) and
+            // using the given .idx for timing + palette (issue #12772).
+            var subPath = Path.ChangeExtension(filePath, ".sub");
+            if (!File.Exists(subPath))
+            {
+                throw new InvalidOperationException(
+                    $"VobSub '.idx' input has no companion '.sub' ({Path.GetFileName(subPath)}) — "
+                    + "the .idx only holds timing and palette; the subtitle images live in the .sub.");
+            }
+
+            return LoadVobSub(subPath, filePath, options);
+        }
+
         if (ext is ".ts" or ".m2ts" or ".mts")
         {
             return LoadTransportStream(filePath, options);

--- a/src/seconv/Core/ImageOcrLoader.cs
+++ b/src/seconv/Core/ImageOcrLoader.cs
@@ -221,6 +221,7 @@ internal static class ImageOcrLoader
         IReadOnlyList<BitmapSubtitleLoader.BitmapSubtitleItem> items, IOcrEngine? ocr, bool isolateColors = false)
     {
         var subtitle = new Subtitle();
+        var blankCount = 0;
         foreach (var item in items)
         {
             string text;
@@ -243,7 +244,20 @@ internal static class ImageOcrLoader
                 subtitle.Paragraphs.Add(new LibSeParagraph(
                     text, item.StartTime.TotalMilliseconds, item.EndTime.TotalMilliseconds));
             }
+            else
+            {
+                blankCount++;
+            }
         }
+
+        if (blankCount > 0)
+        {
+            // Issue #12772: these used to vanish without a trace, making it look like the
+            // source had fewer subtitles than the GUI sees.
+            AnsiConsole.MarkupLine(
+                $"[yellow]Note: {blankCount} image(s) produced no OCR text and were dropped.[/]");
+        }
+
         subtitle.Renumber();
         return subtitle;
     }

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -320,6 +320,22 @@ internal class SubtitleConverter
             return false;
         }
 
+        if (ext == ".idx")
+        {
+            // Accept the .idx of a VobSub pair as input (5.0.0 did): redirect to the
+            // companion .sub and use this .idx for timing + palette (issue #12772).
+            var subPath = Path.ChangeExtension(inputFile, ".sub");
+            if (!File.Exists(subPath))
+            {
+                throw new InvalidOperationException(
+                    $"VobSub '.idx' input has no companion '.sub' ({Path.GetFileName(subPath)}) — "
+                    + "the .idx only holds timing and palette; the subtitle images live in the .sub.");
+            }
+
+            return await PassThroughSingleStreamAsync(subPath, options, result, fileIndex,
+                () => BitmapSubtitleLoader.LoadVobSub(subPath, inputFile, isPal: true));
+        }
+
         if (ext is ".mkv" or ".mks")
         {
             return await PassThroughMatroskaPgsAsync(inputFile, options, result, fileIndex);

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -156,7 +156,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                             if (trackId == track.TrackNumber.ToString(CultureInfo.InvariantCulture))
                             {
                                 var vobSubs = LoadVobSubFromMatroska(track, matroska, out var idx);
-                                imageSubtitle = new OcrSubtitleVobSub(vobSubs)
+                                imageSubtitle = new OcrSubtitleVobSub(vobSubs, idx?.Palette)
                                 {
                                     IsolateColors = Se.Settings.Tools.BatchConvert.VobSubIsolateColors,
                                 };

--- a/tests/seconv/Core/VobSubPaletteTest.cs
+++ b/tests/seconv/Core/VobSubPaletteTest.cs
@@ -1,0 +1,164 @@
+using Nikse.SubtitleEdit.Core.BluRaySup;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.VobSub;
+using SeConv.Core;
+using SkiaSharp;
+using Xunit;
+using Paragraph = Nikse.SubtitleEdit.Core.Common.Paragraph;
+
+namespace SeConvTests.Core;
+
+/// <summary>
+/// Issue #12772: seconv decoded VobSub subpictures without the .idx palette (CLUT).
+/// With a null CLUT, <see cref="SubPicture.GetBitmap"/> skips both the SetColor and the
+/// SetContrast (per-plane alpha) display control commands, so normally-transparent
+/// outline/anti-alias planes render opaque and fuse into the glyphs — garbling OCR
+/// ('-' read as '=', 'S' as '$'). These tests lock down that the palette from the .idx
+/// (or a Matroska track's CodecPrivate) actually reaches the decoder, and that a '.idx'
+/// file is accepted as input again (a 5.0.0 regression).
+/// </summary>
+public class VobSubPaletteTest : IDisposable
+{
+    private readonly string _tempRoot;
+
+    public VobSubPaletteTest()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "VobPal_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+        {
+            Directory.Delete(_tempRoot, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Writes a one-cue VobSub .sub/.idx pair whose pattern (glyph fill) colour is
+    /// <paramref name="pattern"/>. The .idx palette line puts that colour at CLUT
+    /// index 1, which is where the subpicture's SetColor command points the pattern.
+    /// </summary>
+    private string WritePair(SKColor pattern)
+    {
+        var subPath = Path.Combine(_tempRoot, "cue.sub");
+        using (var writer = new VobSubWriter(
+                   subPath, 720, 576, bottomMargin: 10, leftRightMargin: 10, languageStreamId: 32,
+                   pattern, SKColors.Black, useInnerAntiAliasing: false, DvdSubtitleLanguage.English))
+        {
+            using var bmp = new SKBitmap(new SKImageInfo(120, 40, SKColorType.Rgba8888, SKAlphaType.Unpremul));
+            bmp.Erase(SKColors.Transparent);
+            using (var canvas = new SKCanvas(bmp))
+            using (var paint = new SKPaint { Color = pattern })
+            {
+                canvas.DrawRect(new SKRect(20, 10, 100, 30), paint);
+            }
+
+            var p = new Paragraph(string.Empty, 1000, 3000);
+            writer.WriteParagraph(p, bmp, BluRayContentAlignment.BottomCenter);
+            writer.WriteIdxFile();
+        }
+
+        return subPath;
+    }
+
+    private static bool ContainsColor(SKBitmap bmp, SKColor color)
+    {
+        for (var y = 0; y < bmp.Height; y++)
+        {
+            for (var x = 0; x < bmp.Width; x++)
+            {
+                var c = bmp.GetPixel(x, y);
+                if (c.Alpha > 200 && c.Red == color.Red && c.Green == color.Green && c.Blue == color.Blue)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    [Fact]
+    public void LoadVobSub_AppliesIdxPalette_ToDecodedBitmaps()
+    {
+        // Write a cue whose fill is pure red — a colour that only exists in the .idx
+        // CLUT. Without the palette the decoder falls back to black/white defaults,
+        // so a red pixel in the decoded bitmap proves the CLUT was applied.
+        var red = new SKColor(255, 0, 0);
+        var subPath = WritePair(red);
+        var idxPath = Path.ChangeExtension(subPath, ".idx");
+        Assert.True(File.Exists(idxPath));
+
+        var items = BitmapSubtitleLoader.LoadVobSub(subPath, idxPath, isPal: true);
+
+        Assert.Single(items);
+        Assert.True(ContainsColor(items[0].Bitmap, red),
+            "decoded bitmap has no pixel in the .idx palette's pattern colour — the CLUT was not applied");
+        foreach (var item in items)
+        {
+            item.Dispose();
+        }
+    }
+
+    [Fact]
+    public void GetVobSubIdxPalette_ParsesCodecPrivate_AndRejectsBlank()
+    {
+        var codecPrivate = "size: 720x576\n"
+            + "palette: 000000, ff0000, 00ff00, 0000ff, 828282, 828282, 828282, ffffff, "
+            + "828282, bababa, 828282, 828282, 828282, 828282, 828282, 828282";
+
+        var palette = BitmapSubtitleLoader.GetVobSubIdxPalette(codecPrivate);
+
+        Assert.NotNull(palette);
+        Assert.Equal(16, palette.Count);
+        Assert.Equal(new SKColor(255, 0, 0), palette[1]);
+        Assert.Equal(new SKColor(0, 255, 0), palette[2]);
+
+        Assert.Null(BitmapSubtitleLoader.GetVobSubIdxPalette(null));
+        Assert.Null(BitmapSubtitleLoader.GetVobSubIdxPalette(string.Empty));
+        Assert.Null(BitmapSubtitleLoader.GetVobSubIdxPalette("size: 720x576"));
+    }
+
+    [Fact]
+    public async Task ConvertAsync_IdxInput_RoutesToVobSubPair()
+    {
+        // 5.0.0 accepted the .idx of a pair as the input; rc13 rejected it with
+        // "Unable to determine subtitle format". Image → image (VobSub → Blu-ray SUP)
+        // exercises the routing without needing an OCR engine.
+        var subPath = WritePair(new SKColor(255, 0, 0));
+        var idxPath = Path.ChangeExtension(subPath, ".idx");
+        var outputFolder = Path.Combine(_tempRoot, "out");
+        Directory.CreateDirectory(outputFolder);
+
+        var result = await new SubtitleConverter().ConvertAsync(new ConversionOptions
+        {
+            Patterns = [idxPath],
+            Format = "Bluraysup",
+            OutputFolder = outputFolder,
+            Overwrite = true,
+        });
+
+        Assert.True(result.Success, string.Join("; ", result.Errors));
+        Assert.Single(Directory.GetFiles(outputFolder, "*.sup"));
+    }
+
+    [Fact]
+    public async Task ConvertAsync_IdxInput_WithoutSub_ErrorsWithGuidance()
+    {
+        var idxPath = Path.Combine(_tempRoot, "orphan.idx");
+        await File.WriteAllTextAsync(idxPath, "# VobSub index file, v7 (do not modify this line!)",
+            TestContext.Current.CancellationToken);
+
+        var result = await new SubtitleConverter().ConvertAsync(new ConversionOptions
+        {
+            Patterns = [idxPath],
+            Format = "Bluraysup",
+            Overwrite = true,
+        });
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Errors, e => e.Contains("companion '.sub'"));
+    }
+}


### PR DESCRIPTION
Fixes the VobSub half of #12772 (part 2 of #12291).

## Root cause

seconv decoded VobSub subpictures **without the .idx palette (CLUT)**. When `SubPicture.GetBitmap` gets a null CLUT it skips both the `SetColor` **and** the `SetContrast` (per-plane alpha) display control commands — so the normally-transparent outline/anti-alias planes rendered fully opaque and fused into the glyphs. That's the reported garbling (`-`→`=`, `S`→`$`, `o`→`0`, stray braces), and why it looked like misweaved interlace fields (the shadow plane offsets differently on second lines). The GUI always passes `VobSubParser.IdxPalette`, which is why it OCRs the same file cleanly.

One cause explains all three findings in the report:
- colour isolation A/B differed but stayed garbled — the junk planes are baked in before isolation
- VobSub → `.sup` → PGS-OCR stayed garbled — the conversion path uses the same paletteless decode
- ~10% of entries vanished — badly-fused bitmaps OCR to blank, and blanks were silently dropped

## Changes

- `BitmapSubtitleLoader.LoadVobSub`: apply `VobSubParser.IdxPalette` to each merged pack before decoding (mirrors the GUI `.sub`/`.idx` OCR path)
- `BitmapSubtitleLoader.LoadMatroskaVobSub`: parse the palette from the track's CodecPrivate .idx text (mirrors the GUI MKV path)
- GUI `BatchConverter`: pass the already-parsed CodecPrivate palette on the MKV VobSub batch path (same latent bug)
- Accept a `.idx` as input again (5.0.0 did; rc13 failed with *Unable to determine subtitle format*): both dispatchers redirect to the companion `.sub`, using the given `.idx` for timing + palette, with a clear error when the `.sub` is missing
- Print a note when OCR-blank images are dropped instead of silently losing entries

(The `--help` Spectre markup crash from the report was already fixed on main in 1919d4ab2.)

## Tests

New `VobSubPaletteTest` (tests/seconv):
- round-trips a `.sub`/`.idx` pair via `VobSubWriter` with a red CLUT fill and asserts the decoded bitmap contains the palette colour (fails on main, passes with the fix — verified both ways)
- CodecPrivate palette parsing incl. blank/absent palette
- `.idx` input routes to the VobSub pair end-to-end (image → Blu-ray SUP, no OCR engine needed)
- orphan `.idx` (no `.sub`) errors with guidance

All 276 seconv tests pass; UI builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)