### PR TITLE
seconv: fix VobSub OCR isolation, MKV VobSub image passthrough, durations, silent drops

### DIFF
--- a/src/libse/Common/VobSubColorIsolation.cs
+++ b/src/libse/Common/VobSubColorIsolation.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using SkiaSharp;
 
@@ -14,20 +15,25 @@ namespace Nikse.SubtitleEdit.Core.Common
     /// unpredictably from disc to disc, there is no fixed colour to strip in an unattended
     /// batch run.
     ///
-    /// This pass rebuilds a crisp black-on-white bitmap purely from pixel frequency:
-    /// transparent pixels are the background, the most common opaque colour is the main text
-    /// body (kept as black), and every other opaque colour (the outline / anti-alias tiers)
-    /// collapses into the white background. The result is a clean binary mask that OCR
-    /// engines recognise far more reliably. Used by both the seconv CLI
-    /// (<c>--no-vobsub-isolate-colors</c> to disable) and the Batch Convert UI.
+    /// This pass rebuilds a crisp black-on-white bitmap from plane topology: transparent
+    /// pixels are the background, and of the opaque colours the one that is most *interior*
+    /// — the smallest fraction of its pixels bordering the transparent background — is the
+    /// glyph fill (kept as black); every other opaque colour (the outline / anti-alias
+    /// tiers, which by construction wrap the fill and face the background) collapses into
+    /// the white background. The result is a clean binary mask that OCR engines recognise
+    /// far more reliably. Used by both the seconv CLI (<c>--no-vobsub-isolate-colors</c> to
+    /// disable) and the Batch Convert UI.
     /// </summary>
     public static class VobSubColorIsolation
     {
         /// <summary>
-        /// Returns a new opaque black-on-white bitmap in which only the dominant opaque colour
-        /// (the glyph fill) is kept as foreground. The caller owns the returned bitmap. When the
-        /// source has no opaque pixels (a blank / clear frame) a solid white bitmap is returned
-        /// so downstream OCR simply sees nothing.
+        /// Returns a new opaque black-on-white bitmap in which only the glyph-fill colour
+        /// plane is kept as foreground. The fill is identified as the opaque colour with the
+        /// lowest background-adjacency ratio — with a real palette the outline can hold more
+        /// pixels than the fill (issue #12772 part 3), so frequency alone picks the wrong
+        /// plane, but the fill is always the innermost one. The caller owns the returned
+        /// bitmap. When the source has no opaque pixels (a blank / clear frame) a solid white
+        /// bitmap is returned so downstream OCR simply sees nothing.
         /// </summary>
         /// <param name="source">Rendered VobSub bitmap; a transparent background is expected.</param>
         /// <param name="alphaThreshold">Pixels with alpha below this are treated as background.</param>
@@ -37,9 +43,12 @@ namespace Nikse.SubtitleEdit.Core.Common
             var height = source.Height;
             var result = new SKBitmap(new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Opaque));
 
-            // Tally every opaque colour. Key on RGB only (alpha already gates the background)
-            // so anti-aliasing tiers that share a hue but differ in coverage still merge.
+            // Tally every opaque colour and how many of its pixels touch the transparent
+            // background (4-neighbourhood; the bitmap edge counts as background). Key on RGB
+            // only (alpha already gates the background) so anti-aliasing tiers that share a
+            // hue but differ in coverage still merge.
             var counts = new Dictionary<uint, int>();
+            var borderCounts = new Dictionary<uint, int>();
             for (var y = 0; y < height; y++)
             {
                 for (var x = 0; x < width; x++)
@@ -51,6 +60,16 @@ namespace Nikse.SubtitleEdit.Core.Common
                     }
                     var key = (uint)((c.Red << 16) | (c.Green << 8) | c.Blue);
                     counts[key] = counts.TryGetValue(key, out var n) ? n + 1 : 1;
+
+                    var touchesBackground =
+                        x == 0 || source.GetPixel(x - 1, y).Alpha < alphaThreshold ||
+                        x == width - 1 || source.GetPixel(x + 1, y).Alpha < alphaThreshold ||
+                        y == 0 || source.GetPixel(x, y - 1).Alpha < alphaThreshold ||
+                        y == height - 1 || source.GetPixel(x, y + 1).Alpha < alphaThreshold;
+                    if (touchesBackground)
+                    {
+                        borderCounts[key] = borderCounts.TryGetValue(key, out var b) ? b + 1 : 1;
+                    }
                 }
             }
 
@@ -63,17 +82,48 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return result;
             }
 
-            // Most frequent opaque colour = the glyph fill (the "second tier" once the
-            // transparent background is excluded). Ties resolve to the lowest colour key so the
-            // output is deterministic regardless of dictionary iteration order.
-            var foreground = 0u;
-            var best = -1;
+            // The glyph fill is the most interior plane: lowest share of its pixels facing
+            // the transparent background. The outline faces the background on (at least) its
+            // outer edge, and the anti-alias tier is the boundary itself, so both score
+            // higher. Planes too small to be the text body (speckle, stray anti-alias
+            // colours) are ignored unless nothing bigger exists. Ties resolve to the lowest
+            // colour key so the output is deterministic regardless of dictionary order.
+            var opaqueTotal = 0;
             foreach (var kv in counts)
             {
-                if (kv.Value > best || (kv.Value == best && kv.Key < foreground))
+                opaqueTotal += kv.Value;
+            }
+            var minPlane = Math.Max(16, opaqueTotal / 20);
+
+            var foreground = 0u;
+            var bestRatio = double.MaxValue;
+            var considered = 0;
+            foreach (var kv in counts)
+            {
+                if (kv.Value < minPlane)
                 {
-                    best = kv.Value;
+                    continue;
+                }
+                considered++;
+                var ratio = borderCounts.TryGetValue(kv.Key, out var b) ? (double)b / kv.Value : 0.0;
+                if (ratio < bestRatio || (Math.Abs(ratio - bestRatio) < 0.0001 && kv.Key < foreground))
+                {
+                    bestRatio = ratio;
                     foreground = kv.Key;
+                }
+            }
+
+            if (considered == 0)
+            {
+                // Every plane was speckle-sized; fall back to the most frequent colour.
+                var best = -1;
+                foreach (var kv in counts)
+                {
+                    if (kv.Value > best || (kv.Value == best && kv.Key < foreground))
+                    {
+                        best = kv.Value;
+                        foreground = kv.Key;
+                    }
                 }
             }
 

--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -123,7 +123,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         public bool TimeCodesOnly { get; init; }
 
         [CommandOption("--no-vobsub-isolate-colors|--novobsubisolatecolors")]
-        [Description("Disable VobSub OCR colour isolation (on by default). Isolation binarises each subpicture to black-on-white by keeping the most frequent opaque colour (glyph fill) and dropping the outline/anti-alias colours; pass this to OCR the raw palette instead")]
+        [Description("Disable VobSub OCR colour isolation (on by default). Isolation binarises each subpicture to black-on-white by keeping the innermost colour plane (glyph fill) and dropping the outline/anti-alias colours; pass this to OCR the raw palette instead")]
         public bool NoVobSubIsolateColors { get; init; }
 
         [CommandOption("--no-pgs-isolate-colors|--nopgsisolatecolors")]

--- a/src/seconv/Core/BitmapSubtitleLoader.cs
+++ b/src/seconv/Core/BitmapSubtitleLoader.cs
@@ -88,6 +88,7 @@ internal static class BitmapSubtitleLoader
         var screenHeight = isPal ? 576 : 480;
 
         var items = new List<BitmapSubtitleItem>(packs.Count);
+        var skipped = 0;
         foreach (var pack in packs)
         {
             // Without the .idx CLUT, SubPicture.GetBitmap skips both the SetColor and
@@ -103,11 +104,37 @@ internal static class BitmapSubtitleLoader
             var bmp = pack.GetBitmap();
             if (bmp is null)
             {
+                skipped++;
                 continue;
             }
-            items.Add(new BitmapSubtitleItem(pack.StartTimeCode, pack.EndTimeCode, bmp, screenWidth, screenHeight));
+
+            // Use the EndTime *property*, not EndTimeCode: many discs omit the subpicture's
+            // own delay command, so EndTimeCode is start + 0 (issue #12772 part 3: 740 of
+            // 1115 zero-duration cues in the .sup export). MergeVobSubPacks has already
+            // repaired EndTime for missing/negative/over-long delays — the same times the
+            // GUI shows.
+            items.Add(new BitmapSubtitleItem(
+                new TimeCode(pack.StartTime.TotalMilliseconds),
+                new TimeCode(pack.EndTime.TotalMilliseconds),
+                bmp,
+                screenWidth,
+                screenHeight));
         }
+        WarnSkippedBitmaps(skipped, "VobSub");
         return items;
+    }
+
+    /// <summary>
+    /// Issue #12772 part 3: undecodable subpictures used to vanish silently, making the
+    /// output look like it had fewer subtitles than the GUI sees. Surface the count.
+    /// </summary>
+    private static void WarnSkippedBitmaps(int skipped, string what)
+    {
+        if (skipped > 0)
+        {
+            Spectre.Console.AnsiConsole.MarkupLine(
+                $"[yellow]Note: {skipped} {what} subpicture(s) could not be decoded to a bitmap and were dropped.[/]");
+        }
     }
 
     /// <summary>
@@ -149,7 +176,9 @@ internal static class BitmapSubtitleLoader
         // The track's CodecPrivate holds the .idx text, including the CLUT palette. Without
         // it SubPicture.GetBitmap skips SetColor/SetContrast and renders normally-transparent
         // planes opaque (issue #12772) — same fix as LoadVobSub; mirrors the GUI MKV path.
-        var palette = GetVobSubIdxPalette(track.GetCodecPrivate());
+        var codecPrivate = track.GetCodecPrivate();
+        var palette = GetVobSubIdxPalette(codecPrivate);
+        var (screenWidth, screenHeight) = GetVobSubIdxScreenSize(codecPrivate);
 
         var sub = matroska.GetSubtitle(track.TrackNumber, null);
         var packs = new List<VobSubMergedPack>(sub.Count);
@@ -170,25 +199,57 @@ internal static class BitmapSubtitleLoader
         }
 
         var items = new List<BitmapSubtitleItem>(packs.Count);
+        var skipped = 0;
         foreach (var pack in packs)
         {
             var bmp = pack.GetBitmap();
             if (bmp is null)
             {
+                skipped++;
                 continue;
             }
             // Use the block-derived Start/End (TimeSpan), not StartTimeCode/EndTimeCode which
             // are based on the SubPicture delay and only correct for .sub+.idx sources.
+            // Screen size comes from the CodecPrivate "size:" line so an image output
+            // (e.g. bluraysup) keeps the DVD frame instead of defaulting to 1920x1080.
             items.Add(new BitmapSubtitleItem(
                 new TimeCode(pack.StartTime.TotalMilliseconds),
                 new TimeCode(pack.EndTime.TotalMilliseconds),
-                bmp));
+                bmp,
+                screenWidth,
+                screenHeight));
         }
+        WarnSkippedBitmaps(skipped, "MKV VobSub");
         if (items.Count == 0)
         {
             throw new InvalidOperationException($"No VobSub subtitles in MKV track #{track.TrackNumber}.");
         }
         return items;
+    }
+
+    /// <summary>
+    /// Video frame size from a Matroska VobSub track's CodecPrivate .idx text ("size: 720x576"),
+    /// or the DVD PAL default when the line is missing or malformed.
+    /// </summary>
+    internal static (int Width, int Height) GetVobSubIdxScreenSize(string? codecPrivate)
+    {
+        if (!string.IsNullOrWhiteSpace(codecPrivate))
+        {
+            foreach (var line in codecPrivate.SplitToLines())
+            {
+                if (line.StartsWith("size:", StringComparison.OrdinalIgnoreCase))
+                {
+                    var parts = line.Substring(5).Trim().Split('x');
+                    if (parts.Length == 2 &&
+                        int.TryParse(parts[0].Trim(), out var w) && w > 0 &&
+                        int.TryParse(parts[1].Trim(), out var h) && h > 0)
+                    {
+                        return (w, h);
+                    }
+                }
+            }
+        }
+        return (720, 576);
     }
 
     /// <summary>

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -409,40 +409,48 @@ internal class SubtitleConverter
             return false;
         }
 
-        var pgsTracks = matroska.GetTracks(true)
-            .Where(t => t.CodecId.Equals("S_HDMV/PGS", StringComparison.OrdinalIgnoreCase))
+        // Both bitmap track kinds are eligible for image-to-image: PGS, and VobSub (whose
+        // subpictures previously fell through to the OCR pipeline and were re-rasterised as
+        // text at the default font — issue #12772 part 3).
+        var bitmapTracks = matroska.GetTracks(true)
+            .Where(t => t.CodecId.Equals("S_HDMV/PGS", StringComparison.OrdinalIgnoreCase)
+                        || t.CodecId.Equals("S_VOBSUB", StringComparison.OrdinalIgnoreCase))
             .Where(t => !options.ForcedOnly || t.IsForced)
             .Where(t => options.TrackNumbers.Count == 0 || options.TrackNumbers.Contains(t.TrackNumber))
             .ToList();
 
-        if (pgsTracks.Count == 0)
+        if (bitmapTracks.Count == 0)
         {
-            // MKV has no PGS tracks usable for image-to-image; fall through so the regular
+            // MKV has no bitmap tracks usable for image-to-image; fall through so the regular
             // container loader can handle text tracks / OCR-friendly tracks.
             return false;
         }
 
-        if (pgsTracks.Count > 1 && !string.IsNullOrEmpty(options.OutputFilename))
+        if (bitmapTracks.Count > 1 && !string.IsNullOrEmpty(options.OutputFilename))
         {
             throw new InvalidOperationException(
                 "--output-filename can only target a single track. Use --track-number to select one.");
         }
 
-        foreach (var track in pgsTracks)
+        foreach (var track in bitmapTracks)
         {
+            var isVobSub = track.CodecId.Equals("S_VOBSUB", StringComparison.OrdinalIgnoreCase);
             var outputFile = ResolveOutputFileName(
                 inputFile, options, ContainerSubtitleLoader.SanitizeLang(track.Language), track.TrackNumber);
 
             if (!options.Quiet)
             {
                 var trackLabel = $"#{track.TrackNumber} ";
-                AnsiConsole.MarkupInterpolated($"[dim]{fileIndex}:[/] [cyan]{Path.GetFileName(inputFile)}[/] [yellow]{trackLabel}[/][dim](PGS img→img)→[/] [green]{outputFile}[/]...");
+                var kind = isVobSub ? "VobSub" : "PGS";
+                AnsiConsole.MarkupInterpolated($"[dim]{fileIndex}:[/] [cyan]{Path.GetFileName(inputFile)}[/] [yellow]{trackLabel}[/][dim]({kind} img→img)→[/] [green]{outputFile}[/]...");
             }
 
             IReadOnlyList<BitmapSubtitleLoader.BitmapSubtitleItem>? items = null;
             try
             {
-                items = BitmapSubtitleLoader.LoadMatroskaPgs(matroska, track);
+                items = isVobSub
+                    ? BitmapSubtitleLoader.LoadMatroskaVobSub(matroska, track)
+                    : BitmapSubtitleLoader.LoadMatroskaPgs(matroska, track);
                 WritePreservedBitmaps(items, outputFile, options);
                 result.SuccessfulFiles++;
                 result.Files.Add(new FileConversionResult(inputFile, outputFile, true, null));
@@ -923,7 +931,7 @@ internal record class ConversionOptions
 
     /// <summary>
     /// VobSub OCR only: before recognition, rebuild each subpicture as a crisp black-on-white
-    /// bitmap using histogram-based colour isolation — the most frequent opaque colour (the
+    /// bitmap using histogram-based colour isolation — the innermost colour plane (the
     /// glyph fill) becomes black and the outline / anti-alias tiers collapse into the white
     /// background. Improves recognition on discs whose gray outlines otherwise melt adjacent
     /// characters together. On by default; disable with <c>--no-vobsub-isolate-colors</c> to

--- a/tests/seconv/Core/VobSubColorIsolationTest.cs
+++ b/tests/seconv/Core/VobSubColorIsolationTest.cs
@@ -107,4 +107,34 @@ public class VobSubColorIsolationTest
         Assert.Equal(SKColors.White, result.GetPixel(4, 0));
         Assert.Equal(SKColors.Black, result.GetPixel(0, 7));
     }
+
+    [Fact]
+    public void Isolate_OutlineOutnumbersFill_FillStillWins()
+    {
+        // Issue #12772 part 3: with the real .idx palette a thick outline can hold MORE
+        // pixels than the fill (3,715 outline vs 1,668 fill on the reporter's disc), so
+        // frequency-based selection kept the outline and OCR read fused blobs. The fill is
+        // the innermost plane — it must win regardless of pixel counts. Build a 16x16 frame:
+        // an 8x8 fill block (64 px) fully wrapped by a 3-pixel-thick outline ring (~300 px).
+        var fill = new SKColor(229, 229, 229);
+        var outline = new SKColor(0, 0, 0);
+        using var source = MakeBitmap(16, 16, (x, y) =>
+        {
+            if (x is >= 4 and <= 11 && y is >= 4 and <= 11)
+            {
+                return fill; // 64 pixels, entirely enclosed
+            }
+            if (x is >= 1 and <= 14 && y is >= 1 and <= 14)
+            {
+                return outline; // 132 pixels, faces the transparent background
+            }
+            return SKColors.Transparent;
+        });
+
+        using var result = VobSubColorIsolation.Isolate(source);
+
+        Assert.Equal(SKColors.Black, result.GetPixel(7, 7));    // fill kept
+        Assert.Equal(SKColors.White, result.GetPixel(2, 2));    // outline dropped
+        Assert.Equal(SKColors.White, result.GetPixel(0, 0));    // background
+    }
 }

--- a/tests/seconv/Core/VobSubPaletteTest.cs
+++ b/tests/seconv/Core/VobSubPaletteTest.cs
@@ -161,4 +161,36 @@ public class VobSubPaletteTest : IDisposable
         Assert.False(result.Success);
         Assert.Contains(result.Errors, e => e.Contains("companion '.sub'"));
     }
+
+    [Fact]
+    public void LoadVobSub_ZeroDurationCue_GetsClampedEndTime()
+    {
+        // Issue #12772 part 3: many discs omit the subpicture's own delay command, so
+        // EndTimeCode == StartTimeCode and the .sup export wrote start==end on 740 of
+        // 1,115 cues. A zero-duration cue must be extended (default duration, capped at
+        // the next cue's start).
+        var subPath = WritePair(new SKColor(255, 0, 0));
+        var idxPath = Path.ChangeExtension(subPath, ".idx");
+
+        var items = BitmapSubtitleLoader.LoadVobSub(subPath, idxPath, isPal: true);
+
+        foreach (var item in items)
+        {
+            Assert.True(item.EndTime.TotalMilliseconds > item.StartTime.TotalMilliseconds,
+                $"cue at {item.StartTime} still has a zero/negative duration");
+            item.Dispose();
+        }
+    }
+
+    [Fact]
+    public void GetVobSubIdxScreenSize_ParsesSizeLine_AndFallsBack()
+    {
+        Assert.Equal((720, 480), BitmapSubtitleLoader.GetVobSubIdxScreenSize("size: 720x480\npalette: 000000"));
+        Assert.Equal((1920, 1080), BitmapSubtitleLoader.GetVobSubIdxScreenSize("SIZE: 1920x1080"));
+
+        // Missing / malformed → DVD PAL default.
+        Assert.Equal((720, 576), BitmapSubtitleLoader.GetVobSubIdxScreenSize(null));
+        Assert.Equal((720, 576), BitmapSubtitleLoader.GetVobSubIdxScreenSize("palette: 000000"));
+        Assert.Equal((720, 576), BitmapSubtitleLoader.GetVobSubIdxScreenSize("size: banana"));
+    }
 }


### PR DESCRIPTION
Fixes the four remaining VobSub findings from #12772 ([rc14 test report](https://github.com/SubtitleEdit/subtitleedit/issues/12772#issuecomment-5066940353)). All verified against the reporter's `vobsub-5min.zip` sample — after these fixes, all four routes produce output **byte-identical** to the known-good `.idx → bluraysup → OCR` chain, with zero junk characters and zero zero-duration cues.

### 1. Direct OCR garbled → `VobSubColorIsolation.Isolate` kept the wrong plane
`Isolate` picked the **most frequent** opaque colour as the glyph fill. With the real .idx palette applied (the rc14 fix), the outline plane on this disc holds more pixels than the fill (3,715 vs 1,668 measured), so isolation kept the *outline* → fused blobs (`(Cesaremforza¥Andiamo™`). Now the fill is identified as the **innermost plane** — lowest share of pixels bordering the transparent background — which is palette- and frequency-independent. Regression test included (outline-outnumbers-fill). This also fixes the GUI Batch Convert path, which shares the libse helper.

### 2. `.mks` stayed garbled → VobSub-in-Matroska was never image-passthrough'd
`seconv file.mks bluraysup` only handled PGS tracks; a VobSub track silently fell through to the OCR pipeline and the garbled *text* was re-rasterised at the default font (that's why the .mks sup was 3.7× bigger and its bitmaps were 603×52 white-rendered text). `S_VOBSUB` tracks now route through the bitmap loader, with the DVD frame size parsed from the CodecPrivate `size:` line (new `GetVobSubIdxScreenSize`, tested). The palettes themselves were already identical between .idx and .mks — the decode was never the problem.

### 3. Zero durations (740/1115) → wrong end-time source
`LoadVobSub` emitted `EndTimeCode` = start + the subpicture's raw delay command, which many discs omit. `MergeVobSubPacks` already repairs missing/negative/over-long delays into the `EndTime` property — the same times the GUI shows — so use that.

### 4. Silent entry drops
Undecodable subpictures (`GetBitmap()` null) vanished without a trace in both VobSub loaders; they now print a yellow note with the count (OCR-blank drops were already counted in rc14).

### Sweep for the same bug classes elsewhere
- GUI Batch Convert + interactive OCR: durations OK (they read the repaired `EndTime`); isolation fixed via the shared libse change.
- MP4 VobSub: libse never parses the MP4 palette (`Stbl.cs:380` — `// TODO: Where is palette?`), so the same garbling class exists there for both GUI and seconv — pre-existing, needs a sample and format work; left as-is.
- PGS/DVB paths use the brightness-keyed binarization and are unaffected.

Tests: seconv 279 ✓ (3 new), libse 694 ✓, UI 787 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)