### PR TITLE
Shortcuts dialog: readable category text in light mode, wider category column, button hints

### DIFF
--- a/src/ui/Features/Options/Shortcuts/ShortcutGroup.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutGroup.cs
@@ -1,4 +1,6 @@
+using Avalonia;
 using Avalonia.Media;
+using Avalonia.Styling;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -83,6 +85,19 @@ public static class ShortcutGroupUi
     {
         var color = ((SolidColorBrush)GetBrush(group)).Color;
         return new SolidColorBrush(color, 0.28);
+    }
+
+    // Text variant of the group color: on the light theme the mid-saturation tones are too
+    // faint for body text (#12778), so darken them; on dark the plain group color is fine.
+    public static IBrush GetTextBrush(ShortcutGroup group)
+    {
+        var color = ((SolidColorBrush)GetBrush(group)).Color;
+        if (Application.Current?.ActualThemeVariant == ThemeVariant.Dark)
+        {
+            return new SolidColorBrush(color);
+        }
+
+        return new SolidColorBrush(Color.FromRgb((byte)(color.R * 0.55), (byte)(color.G * 0.55), (byte)(color.B * 0.55)));
     }
 
     // Mid-saturation tones picked to stay readable on both the dark and light theme.

--- a/src/ui/Features/Options/Shortcuts/ShortcutTreeNode.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutTreeNode.cs
@@ -13,6 +13,7 @@ public partial class ShortcutTreeNode : ObservableObject
     [ObservableProperty] private string _groupIconName;
     [ObservableProperty] private IBrush _groupBrush;
     [ObservableProperty] private IBrush _groupSoftBrush;
+    [ObservableProperty] private IBrush _groupTextBrush;
     [ObservableProperty] private string _title;
     [ObservableProperty] private string _displayShortcut;
     [ObservableProperty] private List<string> _keyParts;
@@ -49,6 +50,7 @@ public partial class ShortcutTreeNode : ObservableObject
         GroupIconName = ShortcutGroupUi.GetIconName(shortcut.Group);
         GroupBrush = ShortcutGroupUi.GetBrush(shortcut.Group);
         GroupSoftBrush = ShortcutGroupUi.GetSoftBrush(shortcut.Group);
+        GroupTextBrush = ShortcutGroupUi.GetTextBrush(shortcut.Group);
         // "Everywhere" pills are dimmed so context-scoped shortcuts stand out while scrolling.
         ActiveInOpacity = shortcut.Category == ShortcutCategory.General ? 0.55 : 1.0;
     }

--- a/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
@@ -245,16 +245,17 @@ public class ShortcutsWindow : Window
                     IsReadOnly = true,
                     CellTemplate = new FuncDataTemplate<ShortcutTreeNode>((_, _) =>
                     {
-                        // Category name in the group color so the grouping reads at a glance.
+                        // Category name in the group color so the grouping reads at a glance
+                        // (text variant: darkened on the light theme for contrast, #12778).
                         var text = new TextBlock
                         {
                             FontSize = 12,
                             FontWeight = FontWeight.Medium,
                             VerticalAlignment = VerticalAlignment.Center,
-                            Margin = new Thickness(2, 0, 6, 0),
+                            Margin = new Thickness(2, 0, 14, 0),
                         };
                         text.Bind(TextBlock.TextProperty, new Binding(nameof(ShortcutTreeNode.GroupName)));
-                        text.Bind(TextBlock.ForegroundProperty, new Binding(nameof(ShortcutTreeNode.GroupBrush)));
+                        text.Bind(TextBlock.ForegroundProperty, new Binding(nameof(ShortcutTreeNode.GroupTextBrush)));
                         return text;
                     }),
                 },
@@ -464,12 +465,22 @@ public class ShortcutsWindow : Window
 
         // browse button
         var buttonBrowse = UiUtil.MakeButtonBrowse(vm.ShowGetKeyCommand);
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            ToolTip.SetTip(buttonBrowse, Se.Language.Options.Shortcuts.DetectKey);
+        }
+
         editPanel.Children.Add(buttonBrowse);
         buttonBrowse.Bind(IsEnabledProperty, new Binding(nameof(vm.IsControlsEnabled)) { Source = vm });
         buttonBrowse.Margin = new Thickness(0, 0, 9, 0);
 
         // configure button
         var buttonConfig = UiUtil.MakeButton(vm.ConfigureCommand, IconNames.Settings);
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            ToolTip.SetTip(buttonConfig, Se.Language.Options.Shortcuts.Settings);
+        }
+
         editPanel.Children.Add(buttonConfig);
         buttonConfig.Bind(IsEnabledProperty, new Binding(nameof(vm.IsControlsEnabled)) { Source = vm });
         buttonConfig.Bind(IsVisibleProperty, new Binding(nameof(vm.IsConfigureVisible)) { Source = vm });


### PR DESCRIPTION
Addresses the category-column contrast issue from #12778, plus two small polish items.

- **Darker category text on the light theme**: new `ShortcutGroupUi.GetTextBrush()` keeps the plain group color on the dark theme but darkens the same hue to 55% brightness on light, so category names like "Subtitle list view" are readable instead of near-invisible pastel. Icons and chips keep their existing colors.
- **Category column slightly wider**: cell right margin bumped from 6 to 14 px for breathing room after the longest name.
- **Hints for the "..." and gear buttons** in the edit panel ("Detect key" / "Settings", existing translated strings), guarded by `Se.Settings.Appearance.ShowHints` like other button hints.

Not addressed from #12778: the intermittent column-resize gripper issue, the chip label truncation regression, and the column-reorder feature request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)