### PR TITLE
Fix undo wiping all original subtitle text

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -10907,7 +10907,7 @@ public partial class MainViewModel :
         var result =
             await ShowDialogAsync<ShowHistoryWindow, ShowHistoryViewModel>(vm => { vm.Initialize(_undoRedoManager); });
 
-        if (result.OkPressed && result.SelectedHistoryItem != null && result.SelectedHistoryItem.Hash != GetFastHash())
+        if (result.OkPressed && result.SelectedHistoryItem != null && result.SelectedHistoryItem.Hash != GetUndoRedoHash())
         {
             var undoCount = _undoRedoManager.UndoCount;
             for (var i = 0; i < undoCount; i++)
@@ -15119,7 +15119,7 @@ public partial class MainViewModel :
         return new UndoRedoItem(
             description,
             Subtitles.Select(p => new SubtitleLineViewModel(p)).ToArray(),
-            GetFastHash(),
+            GetUndoRedoHash(),
             _subtitleFileName,
             [SelectedSubtitleIndex ?? 0],
             1,
@@ -18909,6 +18909,26 @@ public partial class MainViewModel :
         }
 
         return false;
+    }
+
+    // Hash used by undo change detection. Undo snapshots capture and restore OriginalText,
+    // so the hash must cover the original too - with only GetFastHash, loading or editing an
+    // original never produced an undo entry, and the first Ctrl+Z restored a pre-load
+    // snapshot, wiping the whole original column (#12786). Save-tracking still uses
+    // GetFastHash/GetFastHashOriginal separately.
+    int IUndoRedoClient.GetFastHash() => GetUndoRedoHash();
+
+    public int GetUndoRedoHash()
+    {
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            return Dispatcher.UIThread.Invoke(GetUndoRedoHash);
+        }
+
+        unchecked
+        {
+            return GetFastHash() * 31 + GetFastHashOriginal();
+        }
     }
 
     public int GetFastHash()


### PR DESCRIPTION
Fixes #12786.

**Root cause:** the undo change-detection hash (`GetFastHash`) covers only the translation — `OriginalText` is excluded because save-tracking handles the original separately via `GetFastHashOriginal`. But undo snapshots capture **and restore** `OriginalText` per line. So loading (or editing) an original subtitle never created a new undo entry, and the first Ctrl+Z restored a snapshot taken before the original was loaded — emptying the entire original column.

**Fix:** the `IUndoRedoClient` hash is now an explicit interface implementation returning a combined translation+original hash (`GetUndoRedoHash`), used consistently for change detection, the snapshot's stored `Hash`, and the ShowHistory comparison. `GetFastHash`/`GetFastHashOriginal` and all save-change tracking are unchanged.

Side effects (both correct undo semantics): loading an original now creates an undo entry (Ctrl+Z right after deliberately undoes the load), and edits to original text are now undoable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)