### PR TITLE
seconv: use canonical kebab-case flags in list-fce-rules output

### DIFF
--- a/src/seconv/Core/ListHelpers.cs
+++ b/src/seconv/Core/ListHelpers.cs
@@ -72,7 +72,7 @@ internal static class ListHelpers
 
     public static void PrintFixCommonErrorsRules()
     {
-        AnsiConsole.MarkupLine("[bold cyan]FixCommonErrors rule IDs (pass via --FixCommonErrorsRules)[/]");
+        AnsiConsole.MarkupLine("[bold cyan]FixCommonErrors rule IDs (pass via --fix-common-errors-rules)[/]");
         AnsiConsole.WriteLine();
         var table = new Table().Border(TableBorder.Rounded);
         table.AddColumn("[yellow]Rule ID[/]");
@@ -101,11 +101,11 @@ internal static class ListHelpers
             "[green]--fce-language:<code>[/][dim]. Naming a gated rule selects it but does not bypass the gate.[/]");
         AnsiConsole.MarkupLine(
             "\n[dim]Examples:[/]\n" +
-            "  [dim]--FixCommonErrors[/]                                       [dim]# all rules (gates active)[/]\n" +
-            "  [dim]--FixCommonErrorsRules:FixCommas,FixEllipsesStart[/]       [dim]# only these two[/]\n" +
-            "  [dim]--FixCommonErrorsRules:all,-FixDanishLetterI[/]            [dim]# all except one[/]\n" +
-            "  [dim]--FixCommonErrors --fce-language:es[/]                     [dim]# force Spanish gate[/]\n" +
-            "  [dim]--FixCommonErrorsRules:FixSpanishInvertedQuestionAndExclamationMarks --fce-language:es[/]  [dim]# force a named gated rule[/]");
+            "  [dim]--fix-common-errors[/]                                          [dim]# all rules (gates active)[/]\n" +
+            "  [dim]--fix-common-errors-rules:FixCommas,FixEllipsesStart[/]         [dim]# only these two[/]\n" +
+            "  [dim]--fix-common-errors-rules:all,-FixDanishLetterI[/]              [dim]# all except one[/]\n" +
+            "  [dim]--fix-common-errors --fce-language:es[/]                        [dim]# force Spanish gate[/]\n" +
+            "  [dim]--fix-common-errors-rules:FixSpanishInvertedQuestionAndExclamationMarks --fce-language:es[/]  [dim]# force a named gated rule[/]");
     }
 
     public static void PrintOcrEngines()


### PR DESCRIPTION
Fixes #12789.

The `list-fce-rules` header and examples suggested the SE4 back-compat fallback spellings (`--FixCommonErrors`, `--FixCommonErrorsRules`) and even mixed registers in one line (`--FixCommonErrors --fce-language:es`). They now use the canonical kebab-case forms (`--fix-common-errors`, `--fix-common-errors-rules`), matching the help display and option descriptions; example comment columns re-aligned. Verified with a live `seconv list-fce-rules` run.

These six strings were the only user-facing output in seconv using the fallback spellings — everything else already used canonical forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)