### PR TITLE
seconv: fix dump-settings mangling non-ASCII on Windows

### DIFF
--- a/src/seconv/Core/SeConvSettings.cs
+++ b/src/seconv/Core/SeConvSettings.cs
@@ -145,10 +145,10 @@ internal sealed class SeConvSettings
             // Omit the null "auto" values (margins) rather than writing `null`, so every key
             // in the file is a concrete, copy-paste-ready default.
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-            // Print non-ASCII (e.g. the ¶ HI separator) literally instead of as ¶ — this
-            // is a file for humans to read and edit. Safe here: the output is written to a file,
-            // not embedded in HTML.
-            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            // Non-ASCII (e.g. the ¶ HI separator) is escaped as ¶ (the default encoder):
+            // the dump goes through Console.Out, and on Windows a literal ¶ was written in the
+            // OEM codepage as raw byte 0x14, breaking the file's round-trip (#12793). ASCII-only
+            // output is immune to console codepages, and JSON parsers unescape it identically.
         };
 
         return JsonSerializer.Serialize(defaults, options);

--- a/src/seconv/Program.cs
+++ b/src/seconv/Program.cs
@@ -14,6 +14,19 @@ internal class Program
         // libHarfBuzzSharp deep-binds its own hb_* symbols and doesn't crash on Linux (#11864).
         Nikse.SubtitleEdit.UiLogic.HarfBuzzNativeFix.Apply();
 
+        // On Windows the console defaults to the legacy OEM codepage, which mangles any
+        // non-ASCII output (file names, previews - and it wrote the ¶ HI separator in
+        // dump-settings as raw byte 0x14, #12793). Redirected output stays UTF-8 too.
+        // Skipped when stdout is not attached to a console handle it can configure.
+        try
+        {
+            Console.OutputEncoding = System.Text.Encoding.UTF8;
+        }
+        catch (Exception)
+        {
+            // No console (service/pipe edge cases) - keep the default encoding.
+        }
+
         // Encoding code pages and the headless EBU UI helper are wired by the
         // module initializer in SeConv.Core.Bootstrap.
 


### PR DESCRIPTION
Fixes #12793.

The `^T` the reporter saw is the pilcrow `¶` (the legitimate libse default for the three remove-HI keys) written as raw byte 0x14: the dump's serializer emitted `¶` literally (`UnsafeRelaxedJsonEscaping`), and on Windows `Console.Out` defaults to the legacy OEM codepage where `¶` is 0x14. The redirected file then wasn't valid UTF-8, and reading it back turned `¶` into a control character — silently changing those settings.

Two changes:

- **`dump-settings` now escapes non-ASCII** as `\uXXXX` (default JSON encoder): the output is pure ASCII and immune to console codepages, and any JSON parser unescapes it identically. Verified: keys emit `\u00B6` and round-trip back to `¶`.
- **`Console.OutputEncoding` is set to UTF-8 at startup** (guarded try/catch for consoleless edge cases), so every other seconv output path carrying non-ASCII — file names, previews, table output — is correct on Windows too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)