### PR TITLE
Allow Escape to close the source view window

### DIFF
--- a/src/ui/Features/Shared/SourceView/SourceViewWindow.cs
+++ b/src/ui/Features/Shared/SourceView/SourceViewWindow.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using AvaloniaEdit;
 using Nikse.SubtitleEdit.Logic;
@@ -78,7 +79,9 @@ public class SourceViewWindow : Window
         Content = grid;
 
         Opened += delegate { Avalonia.Threading.Dispatcher.UIThread.Post(vm.FocusEditor); };
-        KeyDown += (_, e) => vm.OnKeyDown(e);
+
+        // Tunnel, as the AvaloniaEdit text area consumes Escape before it can bubble up to the window.
+        AddHandler(KeyDownEvent, (_, e) => vm.OnKeyDown(e), RoutingStrategies.Tunnel);
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };
         Loaded += delegate { UiUtil.RestoreWindowPosition(this); };


### PR DESCRIPTION
## Summary
- `SourceViewWindow` subscribed to `KeyDown`, a bubble-phase handler that ignores already-handled events. The focused AvaloniaEdit text area consumes Escape first, so `SourceViewViewModel.OnKeyDown` never ran and the window stayed open.
- Switched to a tunnel-phase `AddHandler(KeyDownEvent, ..., RoutingStrategies.Tunnel)` so the window sees the key before the editor — the same pattern `FindWindow` and `ReplaceWindow` already use.
- Only the advanced editor path was affected; the plain `TextBox` fallback used for source over 2 MB does not consume Escape, so Escape already worked there.

## Test plan
- [x] Open a subtitle, then open the source view (`Ctrl+U` / menu).
- [x] Click into the text editor and press `Esc` — the window closes without applying changes.
- [x] Reopen, press `Esc` without clicking into the editor — the window still closes.
- [x] Reopen, edit the source, click OK — the changes are still applied (no regression to the OK path).
- [ ] With a subtitle whose source exceeds 2 MB (plain `TextBox` fallback), confirm `Esc` still closes the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)