### PR TITLE
Drop redundant "(?i)" prefix from LanguageAutoDetect regex cache key

### DIFF
--- a/src/libse/Common/LanguageAutoDetect.cs
+++ b/src/libse/Common/LanguageAutoDetect.cs
@@ -28,8 +28,8 @@ namespace Nikse.SubtitleEdit.Core.Common
             // a large share of words are sentence-initial and case-sensitive matching used to
             // miss them (e.g. "Você"/"Burada" not matching the lowercase list entries).
             var pattern = "\\b(" + string.Join("|", words) + ")\\b";
-            var regex = WordCountRegexCache.GetOrAdd("(?i)" + pattern, p =>
-                new Regex(pattern, RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.Compiled | RegexOptions.IgnoreCase));
+            var regex = WordCountRegexCache.GetOrAdd(pattern, p =>
+                new Regex(p, RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.Compiled | RegexOptions.IgnoreCase));
             return regex.Matches(text).Count;
         }
 


### PR DESCRIPTION
## Summary

Small cleanup in `LanguageAutoDetect.GetCount`.

- The `"(?i)"` prefix was only ever part of the **cache key** — it was never passed to `new Regex`, so it had no effect on matching. Case-insensitivity comes entirely from `RegexOptions.IgnoreCase`.
- It also can't be serving as a collision guard: `GetCountContains` is the only other user of the shared `WordCountRegexCache`, and it keys on bare characters (`"シ"`, `"是"`), never on `\b(...)\b` alternations.
- Keying on the pattern itself lets the factory lambda use its `p` parameter instead of closing over the outer `pattern` variable.

No behavior change.

## Test plan

- [ ] `dotnet build src/libse/LibSE.csproj` succeeds
- [ ] `dotnet test tests/libse/LibSETests.csproj --filter "FullyQualifiedName~LanguageAutoDetect"` passes (74 tests)
- [ ] Language auto-detection still returns the same language on sample subtitles

🤖 Generated with [Claude Code](https://claude.com/claude-code)