### PR TITLE
Allow Escape to close the source view window

### DIFF
--- a/src/ui/Features/Shared/SourceView/SourceViewViewModel.cs
+++ b/src/ui/Features/Shared/SourceView/SourceViewViewModel.cs
@@ -388,7 +388,7 @@ public partial class SourceViewViewModel : ObservableObject, IClosingCleanup
         Window?.Close();
     }
 
-    internal void OnKeyDown(KeyEventArgs e)
+    internal void OnKeyDown(object? sender, KeyEventArgs e)
     {
         if (e.Key == Key.Escape)
         {

--- a/src/ui/Features/Shared/SourceView/SourceViewWindow.cs
+++ b/src/ui/Features/Shared/SourceView/SourceViewWindow.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using AvaloniaEdit;
 using Nikse.SubtitleEdit.Logic;
@@ -78,7 +79,7 @@ public class SourceViewWindow : Window
         Content = grid;
 
         Opened += delegate { Avalonia.Threading.Dispatcher.UIThread.Post(vm.FocusEditor); };
-        KeyDown += (_, e) => vm.OnKeyDown(e);
+        AddHandler(KeyDownEvent, vm.OnKeyDown, RoutingStrategies.Tunnel);
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };
         Loaded += delegate { UiUtil.RestoreWindowPosition(this); };


### PR DESCRIPTION
Cleaner take on #12801 by @ivandrofly — thanks!

The window subscribed to bubble-phase `KeyDown`, but the focused AvaloniaEdit text area consumes Escape first, so the handler never ran. Switched to a tunnel-phase handler and gave `OnKeyDown` the standard event-handler signature, matching the pattern `FindWindow` and `ReplaceWindow` already use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)