### PR TITLE
Fix AltGr shortcut races while typing

### DIFF
--- a/src/ui/Logic/ShortcutManager.cs
+++ b/src/ui/Logic/ShortcutManager.cs
@@ -22,6 +22,7 @@ public class ShortcutManager : IShortcutManager
     private bool _isDirty = true;
     private bool _isControlPressed = false;
     private bool _isShiftPressed = false;
+    private bool _isRightAltPressed = false;
 
     public static string GetKeyDisplayName(string key)
     {
@@ -236,6 +237,10 @@ public class ShortcutManager : IShortcutManager
         }
 
         var key = GetShortcutKey(e);
+        if (key == Key.RightAlt)
+        {
+            _isRightAltPressed = true;
+        }
 
         // Skip standalone modifier-like keys: Ctrl/Shift/Alt/Win redundantly
         // duplicate KeyEventArgs.KeyModifiers, and NumLock is a state toggle —
@@ -255,6 +260,11 @@ public class ShortcutManager : IShortcutManager
 
     public void OnKeyReleased(object? sender, KeyEventArgs e)
     {
+        if (e.Key == Key.RightAlt)
+        {
+            _isRightAltPressed = false;
+        }
+
         if (e.Key is Key.ImeProcessed or Key.ImeConvert or Key.ImeNonConvert or
             Key.ImeAccept or Key.ImeModeChange or Key.DeadCharProcessed or Key.None)
         {
@@ -277,6 +287,7 @@ public class ShortcutManager : IShortcutManager
         _activeKeyNames.Clear();
         _isControlPressed = false;
         _isShiftPressed = false;
+        _isRightAltPressed = false;
     }
 
     public void RegisterShortcut(ShortCut shortcut)
@@ -336,6 +347,23 @@ public class ShortcutManager : IShortcutManager
 
     public IRelayCommand? CheckShortcuts(KeyEventArgs keyEventArgs, string activeControl)
     {
+        // Windows reports AltGr as a synthetic LeftCtrl followed by RightAlt.
+        // Modifier transitions must not complete a shortcut using a still-held typing key.
+        if (keyEventArgs.Key is Key.LeftCtrl or Key.RightCtrl or
+            Key.LeftShift or Key.RightShift or
+            Key.LeftAlt or Key.RightAlt or
+            Key.LWin or Key.RWin or Key.NumLock)
+        {
+            return null;
+        }
+
+        // Prefer the character produced by AltGr over an equivalent Ctrl+Alt shortcut.
+        if (_isRightAltPressed &&
+            keyEventArgs.KeyModifiers.HasFlag(KeyModifiers.Control | KeyModifiers.Alt))
+        {
+            return null;
+        }
+
         if (_isDirty || _lookupTable is null)
         {
             RebuildLookupTable();

--- a/src/ui/Logic/ShortcutManager.cs
+++ b/src/ui/Logic/ShortcutManager.cs
@@ -10,6 +10,7 @@ namespace Nikse.SubtitleEdit.Logic;
 
 public class ShortcutManager : IShortcutManager
 {
+    private const KeyModifiers ControlAltModifiers = KeyModifiers.Control | KeyModifiers.Alt;
     private readonly HashSet<Key> _activeKeys = [];
     // Parallel to _activeKeys but uses the physical-key-aware string token (see
     // GetShortcutKeyName). Numpad keys collapse to NumLock-on names in Avalonia's
@@ -22,7 +23,7 @@ public class ShortcutManager : IShortcutManager
     private bool _isDirty = true;
     private bool _isControlPressed = false;
     private bool _isShiftPressed = false;
-    private bool _isRightAltPressed = false;
+    private bool _isWindowsAltGrPressed = false;
 
     public static string GetKeyDisplayName(string key)
     {
@@ -237,9 +238,19 @@ public class ShortcutManager : IShortcutManager
         }
 
         var key = GetShortcutKey(e);
-        if (key == Key.RightAlt)
+        var isRightAlt = key == Key.RightAlt || e.PhysicalKey == PhysicalKey.AltRight;
+        var isControlAltPressed = (e.KeyModifiers & ControlAltModifiers) == ControlAltModifiers;
+        if (!isControlAltPressed)
         {
-            _isRightAltPressed = true;
+            _isWindowsAltGrPressed = false;
+        }
+
+        // Track physical right Alt independently of the logical layout mapping.
+        if (OperatingSystem.IsWindows() &&
+            isRightAlt &&
+            isControlAltPressed)
+        {
+            _isWindowsAltGrPressed = true;
         }
 
         // Skip standalone modifier-like keys: Ctrl/Shift/Alt/Win redundantly
@@ -260,9 +271,11 @@ public class ShortcutManager : IShortcutManager
 
     public void OnKeyReleased(object? sender, KeyEventArgs e)
     {
-        if (e.Key == Key.RightAlt)
+        if (e.Key == Key.RightAlt ||
+            e.PhysicalKey == PhysicalKey.AltRight ||
+            (e.KeyModifiers & ControlAltModifiers) != ControlAltModifiers)
         {
-            _isRightAltPressed = false;
+            _isWindowsAltGrPressed = false;
         }
 
         if (e.Key is Key.ImeProcessed or Key.ImeConvert or Key.ImeNonConvert or
@@ -287,7 +300,7 @@ public class ShortcutManager : IShortcutManager
         _activeKeyNames.Clear();
         _isControlPressed = false;
         _isShiftPressed = false;
-        _isRightAltPressed = false;
+        _isWindowsAltGrPressed = false;
     }
 
     public void RegisterShortcut(ShortCut shortcut)
@@ -349,17 +362,18 @@ public class ShortcutManager : IShortcutManager
     {
         // Windows reports AltGr as a synthetic LeftCtrl followed by RightAlt.
         // Modifier transitions must not complete a shortcut using a still-held typing key.
-        if (keyEventArgs.Key is Key.LeftCtrl or Key.RightCtrl or
+        if (keyEventArgs.Key is (Key.LeftCtrl or Key.RightCtrl or
             Key.LeftShift or Key.RightShift or
             Key.LeftAlt or Key.RightAlt or
-            Key.LWin or Key.RWin or Key.NumLock)
+            Key.LWin or Key.RWin or Key.NumLock) &&
+            _activeKeyNames.Count > 0)
         {
             return null;
         }
 
         // Prefer the character produced by AltGr over an equivalent Ctrl+Alt shortcut.
-        if (_isRightAltPressed &&
-            keyEventArgs.KeyModifiers.HasFlag(KeyModifiers.Control | KeyModifiers.Alt))
+        if (_isWindowsAltGrPressed &&
+            (keyEventArgs.KeyModifiers & ControlAltModifiers) == ControlAltModifiers)
         {
             return null;
         }

--- a/tests/UI/Logic/ShortcutManagerTests.cs
+++ b/tests/UI/Logic/ShortcutManagerTests.cs
@@ -152,17 +152,101 @@ public class ShortcutManagerTests
         manager.OnKeyPressed(null, syntheticControl);
         Assert.Null(manager.CheckShortcuts(syntheticControl, category.ToString()));
 
-        var altGr = KeyEvent(Key.RightAlt, PhysicalKey.AltRight, KeyModifiers.Control | KeyModifiers.Alt);
+        // Keep physical right Alt authoritative even if the logical key differs.
+        var altGr = KeyEvent(Key.LeftAlt, PhysicalKey.AltRight, KeyModifiers.Control | KeyModifiers.Alt);
         manager.OnKeyPressed(null, altGr);
         Assert.Null(manager.CheckShortcuts(altGr, category.ToString()));
 
-        manager.OnKeyReleased(null, i);
+        manager.OnKeyReleased(
+            null,
+            KeyEvent(Key.I, PhysicalKey.I, KeyModifiers.Control | KeyModifiers.Alt));
         var e = KeyEvent(Key.E, PhysicalKey.E, KeyModifiers.Control | KeyModifiers.Alt);
         manager.OnKeyPressed(null, e);
-        Assert.Null(manager.CheckShortcuts(e, category.ToString()));
+        var altGrCommand = manager.CheckShortcuts(e, category.ToString());
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Null(altGrCommand);
+        }
+        else
+        {
+            Assert.Same(command, altGrCommand);
+        }
 
         manager.ClearKeys();
         manager.OnKeyPressed(null, e);
         Assert.Same(command, manager.CheckShortcuts(e, category.ToString()));
+    }
+
+    [Fact]
+    public void ShiftAltGrTypingDoesNotCompleteShortcut()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var manager = new ShortcutManager();
+        var category = ShortcutCategory.General;
+        var command = new RelayCommand(() => { });
+        manager.RegisterShortcut(new ShortCut(
+            "Save language file",
+            ["Control", "Alt", "Shift", "L"],
+            category,
+            command));
+
+        var shift = KeyEvent(Key.LeftShift, PhysicalKey.ShiftLeft, KeyModifiers.Shift);
+        manager.OnKeyPressed(null, shift);
+        var syntheticControl = KeyEvent(
+            Key.LeftCtrl,
+            PhysicalKey.ControlLeft,
+            KeyModifiers.Control | KeyModifiers.Shift);
+        manager.OnKeyPressed(null, syntheticControl);
+        var altGr = KeyEvent(
+            Key.LeftAlt,
+            PhysicalKey.AltRight,
+            KeyModifiers.Control | KeyModifiers.Alt | KeyModifiers.Shift);
+        manager.OnKeyPressed(null, altGr);
+        var l = KeyEvent(
+            Key.L,
+            PhysicalKey.L,
+            KeyModifiers.Control | KeyModifiers.Alt | KeyModifiers.Shift);
+        manager.OnKeyPressed(null, l);
+
+        Assert.Null(manager.CheckShortcuts(l, category.ToString()));
+    }
+
+    [Fact]
+    public void MissingAltGrKeyUpDoesNotBlockLaterLeftControlAltShortcut()
+    {
+        var manager = new ShortcutManager();
+        var category = ShortcutCategory.General;
+        var command = new RelayCommand(() => { });
+        manager.RegisterShortcut(new ShortCut("Left Ctrl+Alt+E", ["Control", "Alt", "E"], category, command));
+
+        var altGr = KeyEvent(Key.RightAlt, PhysicalKey.AltRight, KeyModifiers.Control | KeyModifiers.Alt);
+        manager.OnKeyPressed(null, altGr);
+
+        var leftControl = KeyEvent(Key.LeftCtrl, PhysicalKey.ControlLeft, KeyModifiers.Control);
+        manager.OnKeyPressed(null, leftControl);
+        var leftAlt = KeyEvent(Key.LeftAlt, PhysicalKey.AltLeft, KeyModifiers.Control | KeyModifiers.Alt);
+        manager.OnKeyPressed(null, leftAlt);
+        var e = KeyEvent(Key.E, PhysicalKey.E, KeyModifiers.Control | KeyModifiers.Alt);
+        manager.OnKeyPressed(null, e);
+
+        Assert.Same(command, manager.CheckShortcuts(e, category.ToString()));
+    }
+
+    [Fact]
+    public void ModifierOnlyShortcutStillWorks()
+    {
+        var manager = new ShortcutManager();
+        var category = ShortcutCategory.General;
+        var command = new RelayCommand(() => { });
+        manager.RegisterShortcut(new ShortCut("Control only", ["Control"], category, command));
+
+        var control = KeyEvent(Key.LeftCtrl, PhysicalKey.ControlLeft, KeyModifiers.Control);
+        manager.OnKeyPressed(null, control);
+
+        Assert.Same(command, manager.CheckShortcuts(control, category.ToString()));
     }
 }

--- a/tests/UI/Logic/ShortcutManagerTests.cs
+++ b/tests/UI/Logic/ShortcutManagerTests.cs
@@ -1,4 +1,6 @@
 using Avalonia.Input;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Options.Shortcuts;
 using Nikse.SubtitleEdit.Logic;
 using System.Collections.Generic;
 
@@ -6,6 +8,16 @@ namespace UITests.Logic;
 
 public class ShortcutManagerTests
 {
+    private static KeyEventArgs KeyEvent(Key key, PhysicalKey physicalKey, KeyModifiers modifiers)
+    {
+        return new KeyEventArgs
+        {
+            Key = key,
+            PhysicalKey = physicalKey,
+            KeyModifiers = modifiers,
+        };
+    }
+
     [Theory]
     [InlineData(Key.Home, PhysicalKey.NumPad7, Key.NumPad7)]
     [InlineData(Key.Left, PhysicalKey.NumPad4, Key.NumPad4)]
@@ -122,5 +134,35 @@ public class ShortcutManagerTests
         ShortcutManager.MigrateLegacyOemKeys(keys);
 
         Assert.Equal(new[] { "Control", "F5", "NumPad7", "Period" }, keys);
+    }
+
+    [Fact]
+    public void AltGrTypingDoesNotCompleteShortcuts()
+    {
+        var manager = new ShortcutManager();
+        var category = ShortcutCategory.SubtitleGridAndTextBox;
+        var command = new RelayCommand(() => { });
+        manager.RegisterShortcut(new ShortCut("Italic", ["Control", "I"], category, command));
+        manager.RegisterShortcut(new ShortCut("AltGr E", ["Control", "Alt", "E"], category, command));
+
+        var i = KeyEvent(Key.I, PhysicalKey.I, KeyModifiers.None);
+        manager.OnKeyPressed(null, i);
+
+        var syntheticControl = KeyEvent(Key.LeftCtrl, PhysicalKey.ControlLeft, KeyModifiers.Control);
+        manager.OnKeyPressed(null, syntheticControl);
+        Assert.Null(manager.CheckShortcuts(syntheticControl, category.ToString()));
+
+        var altGr = KeyEvent(Key.RightAlt, PhysicalKey.AltRight, KeyModifiers.Control | KeyModifiers.Alt);
+        manager.OnKeyPressed(null, altGr);
+        Assert.Null(manager.CheckShortcuts(altGr, category.ToString()));
+
+        manager.OnKeyReleased(null, i);
+        var e = KeyEvent(Key.E, PhysicalKey.E, KeyModifiers.Control | KeyModifiers.Alt);
+        manager.OnKeyPressed(null, e);
+        Assert.Null(manager.CheckShortcuts(e, category.ToString()));
+
+        manager.ClearKeys();
+        manager.OnKeyPressed(null, e);
+        Assert.Same(command, manager.CheckShortcuts(e, category.ToString()));
     }
 }


### PR DESCRIPTION
Fix of annoying bug which multiple times deleted my work during fast typing. I have used GPT 5.6 Sol Ultra to track down this weird behavior he has setup keystroke listener when issue occured. I have tested this fix on compiled new version (Windows 11 but same problem i had also on linux) after this PR its fixed now.

<img width="850" height="163" alt="{11485AB5-EBAE-410B-8A33-CAD32BE206A9}" src="https://github.com/user-attachments/assets/4c904aa2-1833-44e1-9d57-b529db01e764" />
"<"i">" "<"/"i">" is effect of bug. Sometimes it even randomly closed Subtitle edit.



## Summary

- Prevent modifier-key transitions from completing a shortcut with a still-held typing key.
- Treat `RightAlt` plus `Ctrl+Alt` as AltGr and prefer the produced character over a `Ctrl+Alt` shortcut.
- Preserve deliberately pressed left `Ctrl+Alt` shortcuts.
- Add regression coverage for the AltGr sequence, Shift+AltGr, lost key-up recovery, and modifier-only shortcuts.

## Root cause

On Windows, AltGr is reported as a synthetic `LeftCtrl` followed by `RightAlt`. During fast typing, the previous letter can still be present in `ShortcutManager`'s active-key set when that synthetic Ctrl event arrives.

For example, while typing Polish `ię`, the observed order was:

```text
I down
LeftCtrl down (synthetic)
RightAlt down
I up
E down
```

Before this change, the `LeftCtrl` transition completed the stale `Ctrl+I` chord and toggled italics, producing text such as `<i>Palię si</i>`. The same race can trigger any shortcut matching the previous key, so changing only the italic shortcut would leave the underlying problem.

This complements #11904, which prevents AltGr from arming the bare-Alt menu behavior but does not guard the general shortcut dispatcher. Older reports #4500 and #7707 show the same broader `AltGr`/`Ctrl+Alt` UX conflict.

## UX rationale

The fix is based on the physical right Alt key rather than the application language. Keyboard layouts can be changed while the app is running, and AltGr is also used by many non-Polish layouts. Explicit left `Ctrl+Alt` combinations continue to work.

The modifier-transition guard is platform-independent and also prevents stale-key dispatch on Linux. The extra synthetic `Ctrl+Alt` suppression is Windows-only: standard XKB exposes AltGr as LevelThree/Mod5 rather than a synthetic Ctrl+Alt pair, so extending that suppression would block legitimate Linux and macOS shortcuts.

## Validation

- `dotnet test tests/UI/UITests.csproj --no-restore --filter "FullyQualifiedName~ShortcutManagerTests"`: 43 passed.
- `dotnet test tests/UI/UITests.csproj --no-restore -c Release`: 799 passed, 0 failed, 0 skipped.
- `git diff --check`: passed.
- Windows x64 Release smoke test with the Polish Programmers layout: rapid `ię` produced no italic tags; `Shift+AltGr+L` produced `Ł` without creating `English.json` or opening Explorer; normal `Ctrl+I` and deliberate left `Ctrl+Alt+E` still worked; the app remained responsive.
