### PR TITLE
Deserialize JSON directly from streams instead of via strings

### DIFF
--- a/src/seconv/Core/SeConvSettings.cs
+++ b/src/seconv/Core/SeConvSettings.cs
@@ -46,8 +46,8 @@ internal sealed class SeConvSettings
             throw new FileNotFoundException($"Settings file not found: {path}", path);
         }
 
-        var json = File.ReadAllText(path);
-        return JsonSerializer.Deserialize<SeConvSettings>(json, JsonOptions)
+        using var stream = File.OpenRead(path);
+        return JsonSerializer.Deserialize<SeConvSettings>(stream, JsonOptions)
             ?? throw new InvalidDataException($"Settings file is empty or null: {path}");
     }
 

--- a/src/ui/Features/Options/Settings/ProfilesViewModel.cs
+++ b/src/ui/Features/Options/Settings/ProfilesViewModel.cs
@@ -117,8 +117,8 @@ public partial class ProfilesViewModel : ObservableObject
         List<ProfileDisplay>? imported = null;
         try
         {
-            var json = System.IO.File.ReadAllText(fileName);
-            var temp = JsonSerializer.Deserialize<ProfileImportExport>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            await using var stream = System.IO.File.OpenRead(fileName);
+            var temp = await JsonSerializer.DeserializeAsync<ProfileImportExport>(stream, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
             if (temp == null)
             {
                 imported = new List<ProfileDisplay>();

--- a/src/ui/Features/Options/Settings/WaveformThemes/WaveformThemesViewModel.cs
+++ b/src/ui/Features/Options/Settings/WaveformThemes/WaveformThemesViewModel.cs
@@ -201,8 +201,8 @@ public partial class WaveformThemesViewModel : ObservableObject
 
         try
         {
-            var json = File.ReadAllText(path);
-            var dto = JsonSerializer.Deserialize<WaveformThemeDto>(json, new JsonSerializerOptions
+            await using var stream = File.OpenRead(path);
+            var dto = await JsonSerializer.DeserializeAsync<WaveformThemeDto>(stream, new JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true,
             });

--- a/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
@@ -331,7 +331,7 @@ public partial class ShortcutsViewModel : ObservableObject
 
         try
         {
-            var json = await System.IO.File.ReadAllTextAsync(fileName, System.Text.Encoding.UTF8);
+            await using var stream = System.IO.File.OpenRead(fileName);
             var options = new System.Text.Json.JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true,
@@ -339,7 +339,7 @@ public partial class ShortcutsViewModel : ObservableObject
                 AllowTrailingCommas = true,
             };
 
-            var importedShortcuts = System.Text.Json.JsonSerializer.Deserialize<List<SeShortCut>>(json, options);
+            var importedShortcuts = await System.Text.Json.JsonSerializer.DeserializeAsync<List<SeShortCut>>(stream, options);
             if (importedShortcuts == null || importedShortcuts.Count == 0)
             {
                 await MessageBox.Show(Window, Se.Language.General.Error, "No shortcuts found in file.", MessageBoxButtons.OK, MessageBoxIcon.Error);

--- a/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs
+++ b/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs
@@ -278,17 +278,13 @@ public partial class GetDictionariesViewModel : ObservableObject, IClosingCleanu
     {
         var uri = new Uri("avares://SubtitleEdit/Assets/HunspellDictionaries.json");
         using var stream = AssetLoader.Open(uri);
-        using var reader = new StreamReader(stream);
-
-        var jsonContent = reader.ReadToEnd();
-
         var options = new JsonSerializerOptions
         {
             PropertyNameCaseInsensitive = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
 
-        var dictionaries = JsonSerializer.Deserialize<List<GetSpellCheckDictionaryDisplay>>(jsonContent, options);
+        var dictionaries = JsonSerializer.Deserialize<List<GetSpellCheckDictionaryDisplay>>(stream, options);
         foreach (var dictionary in dictionaries ?? new List<GetSpellCheckDictionaryDisplay>())
         {
             Dictionaries.Add(dictionary);

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1628,8 +1628,8 @@ public partial class TextToSpeechViewModel : ObservableObject
             return;
         }
 
-        var json = await File.ReadAllTextAsync(fileName, _cancellationToken);
-        var importExport = JsonSerializer.Deserialize<TtsImportExport>(json);
+        await using var stream = File.OpenRead(fileName);
+        var importExport = await JsonSerializer.DeserializeAsync<TtsImportExport>(stream, cancellationToken: _cancellationToken);
         if (importExport == null)
         {
             var answer = await MessageBox.Show(

--- a/src/ui/Logic/Ocr/GoogleLens/CookieManager.cs
+++ b/src/ui/Logic/Ocr/GoogleLens/CookieManager.cs
@@ -15,8 +15,8 @@ public static class CookieManager
         {
             if (File.Exists(CookieFileName))
             {
-                var json = File.ReadAllText(CookieFileName);
-                var cookies = JsonSerializer.Deserialize<Dictionary<string, Cookie>>(json);
+                using var stream = File.OpenRead(CookieFileName);
+                var cookies = JsonSerializer.Deserialize<Dictionary<string, Cookie>>(stream);
                 if (cookies != null)
                 {
                     Console.WriteLine($"Loaded {cookies.Count} cookies from {CookieFileName}");


### PR DESCRIPTION
Reading a whole JSON file (or embedded asset) into a `string` only to hand that string to `JsonSerializer` allocates the payload twice — once as UTF-16 text, and again while the serializer transcodes it back to UTF-8 to parse it. The `Stream` overloads read UTF-8 straight from the source, so this drops the intermediate string at every such call site.

| File | Change |
| --- | --- |
| `SpellCheck/GetDictionaries/GetDictionariesViewModel.cs` | drop `StreamReader.ReadToEnd()` on the `HunspellDictionaries.json` asset stream |
| `seconv/Core/SeConvSettings.cs` | `File.ReadAllText` → `File.OpenRead` |
| `Logic/Ocr/GoogleLens/CookieManager.cs` | `File.ReadAllText` → `File.OpenRead` |
| `Options/Settings/WaveformThemes/WaveformThemesViewModel.cs` | → `DeserializeAsync` |
| `Options/Settings/ProfilesViewModel.cs` | → `DeserializeAsync` |
| `Options/Shortcuts/ShortcutsViewModel.cs` | → `DeserializeAsync` |
| `Video/TextToSpeech/TextToSpeechViewModel.cs` | → `DeserializeAsync`, keeps the cancellation token |

The four sites already inside `async` methods use `DeserializeAsync`, so importing a settings / profile / waveform-theme / TTS file no longer blocks the UI thread on file I/O. The explicit `Encoding.UTF8` in the shortcuts import goes away with it — the stream overload handles UTF-8 and its BOM.

`SettingsImportExportViewModel` deliberately keeps its string: `TryReadExportSourceOs` needs the same JSON a second time, so streaming there would just mean reading the file twice.

No behaviour change. Solution builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)