### PR TITLE
Disable DeepSeek thinking mode by default + migrate removed model IDs

### DIFF
--- a/src/libse/AutoTranslate/AvalAi.cs
+++ b/src/libse/AutoTranslate/AvalAi.cs
@@ -65,7 +65,6 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             // DeepSeek
             "deepseek-v4-pro",
             "deepseek-v4-flash",
-            "deepseek-chat",
 
             // Other notable models
             "qwen3.6-max"

--- a/src/libse/AutoTranslate/DeepSeekTranslate.cs
+++ b/src/libse/AutoTranslate/DeepSeekTranslate.cs
@@ -65,13 +65,24 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
                 model = Models[0];
                 Configuration.Settings.Tools.DeepSeekModel = model;
             }
+            else if (model == "deepseek-chat") // removed 2026/07/24
+            {
+                model = "deepseek-v4-flash";
+                Configuration.Settings.Tools.DeepSeekModel = model;
+            }
+            else if (model == "deepseek-reasoner") // removed 2026/07/24
+            {
+                model = "deepseek-v4-pro";
+                Configuration.Settings.Tools.DeepSeekModel = model;
+            }
 
             if (string.IsNullOrEmpty(Configuration.Settings.Tools.DeepSeekPrompt))
             {
                 Configuration.Settings.Tools.DeepSeekPrompt = new ToolsSettings().DeepSeekPrompt;
             }
             var prompt = string.Format(Configuration.Settings.Tools.DeepSeekPrompt, sourceLanguageCode, targetLanguageCode);
-            var input = "{\"model\": \"" + model + "\",\"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
+            // v4 models default to thinking mode - disable it to keep translations fast and cheap
+            var input = "{\"model\": \"" + model + "\",\"thinking\": {\"type\": \"disabled\"},\"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
 
             int[] retryDelays = { 2555, 5007, 9013 };
             HttpResponseMessage result = null;


### PR DESCRIPTION
Fixes #12807

DeepSeek removed the `deepseek-chat`/`deepseek-reasoner` aliases on 2026/07/24, and the v4 replacement models (`deepseek-v4-flash`/`deepseek-v4-pro`) default to thinking mode server-side ([API docs](https://api-docs.deepseek.com/api/create-chat-completion): `thinking.type` defaults to `"enabled"` on both models), adding reasoning latency and paid reasoning tokens to every subtitle batch.

Changes:

- **`DeepSeekTranslate`**: send `"thinking": {"type": "disabled"}` in the chat completions payload, restoring instant non-reasoning translation as requested in the issue.
- **`DeepSeekTranslate`**: users who configured DeepSeek before May still have `deepseek-chat` (or `deepseek-reasoner`) saved in settings, which now fails with model-not-found since the alias removal. These are mapped to `deepseek-v4-flash`/`deepseek-v4-pro` at translate time.
- **`AvalAi`**: dropped the stale `deepseek-chat` entry from the model list.

Note on the "Reasoning Effort" setting suggested in the issue comments: DeepSeek's `reasoning_effort` only accepts `"high"`/`"max"` (with on/off controlled by the separate `thinking` object), so a generic OFF/Light/Medium/High/Max control doesn't map onto their API. A cross-engine reasoning setting would be a separate feature; anyone wanting a reasoning translator can still use `deepseek-v4-pro` via OpenRouter.

Output parsing is unaffected either way — DeepSeek returns reasoning in a separate `reasoning_content` field and `SeJsonParser` matches the `content` property name exactly; the win here is speed and cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)