### PR TITLE
Word spell check: honor the selected language dictionary

### DIFF
--- a/src/ui/Features/SpellCheck/WordSpellCheck.cs
+++ b/src/ui/Features/SpellCheck/WordSpellCheck.cs
@@ -11,6 +11,7 @@ public sealed class WordSpellCheck : IWordSpellChecker, IDisposable
 {
     private dynamic? _wordApp;
     private dynamic? _managedDocument;
+    private dynamic? _mainDictionary;
     private bool _disposed;
     private WordSpellCheckLanguage? _currentLanguage;
 
@@ -20,6 +21,7 @@ public sealed class WordSpellCheck : IWordSpellChecker, IDisposable
         set
         {
             _currentLanguage = value;
+            _mainDictionary = null;
 
             if (_wordApp == null || value == null)
             {
@@ -29,14 +31,17 @@ public sealed class WordSpellCheck : IWordSpellChecker, IDisposable
             try
             {
                 EnsureDocumentOpen();
-                if (value != null)
-                {
-                    _managedDocument!.Content.LanguageID = value.LanguageId;
-                }
+                _managedDocument!.Content.LanguageID = value!.LanguageId;
+
+                // Application.CheckSpelling/GetSpellingSuggestions on a bare string ignore the
+                // document language and use Word's default proofing dictionary, so the selected
+                // language's dictionary must be passed explicitly as MainDictionary (issue #12769).
+                _mainDictionary = _wordApp!.Languages[value.LanguageId].ActiveSpellingDictionary;
             }
             catch
             {
-                // ignored
+                // ignored - _mainDictionary stays null and spell check falls back to
+                // Word's default proofing language
             }
         }
     }
@@ -93,6 +98,11 @@ public sealed class WordSpellCheck : IWordSpellChecker, IDisposable
 
         try
         {
+            if (_mainDictionary != null)
+            {
+                return (bool)_wordApp!.CheckSpelling(word, MainDictionary: _mainDictionary);
+            }
+
             return (bool)_wordApp!.CheckSpelling(word);
         }
         catch
@@ -148,7 +158,9 @@ public sealed class WordSpellCheck : IWordSpellChecker, IDisposable
 
         try
         {
-            var spellingSuggestions = _wordApp!.GetSpellingSuggestions(word);
+            var spellingSuggestions = _mainDictionary != null
+                ? _wordApp!.GetSpellingSuggestions(word, MainDictionary: _mainDictionary)
+                : _wordApp!.GetSpellingSuggestions(word);
             foreach (var suggestion in spellingSuggestions)
             {
                 suggestions.Add((string)suggestion.Name);
@@ -187,6 +199,12 @@ public sealed class WordSpellCheck : IWordSpellChecker, IDisposable
         {
             try
             {
+                if (_mainDictionary != null)
+                {
+                    Marshal.ReleaseComObject(_mainDictionary);
+                    _mainDictionary = null;
+                }
+
                 if (_managedDocument != null)
                 {
                     _managedDocument.Close(false); // false = don't save changes


### PR DESCRIPTION
Fixes #12769

The MS Word spell-check provider ignored the language picked in the Dictionary combo box: `Application.CheckSpelling(word)` and `Application.GetSpellingSuggestions(word)` on a bare string always check against Word's *default* proofing dictionary. Setting `Content.LanguageID` on the hidden document (what the `CurrentLanguage` setter did) has no effect on those application-level calls. With Russian selected on an English Office install, every word was checked against the English dictionary — every word flagged as misspelled with an empty suggestions list, exactly what the issue reports.

The fix caches the selected language's `ActiveSpellingDictionary` when `CurrentLanguage` is set and passes it as the `MainDictionary` argument to both `CheckSpelling` and `GetSpellingSuggestions`. If the dictionary can't be resolved (e.g. proofing tools for that language are not installed in Office), the code falls back to the previous default-language behavior. The cached COM object is released in `Dispose`.

Why this never reproduced with the default setup: the Hunspell engine (the default provider) works correctly — verified WeCantSpell.Hunspell 7.0.1 against the catalog's `ru_RU` dictionary using words from the reporter's own sample file (15/15 accepted, sensible suggestions). The bug only affects the opt-in "Microsoft Word" engine, which is Windows-only. The reporter's screenshot shows the plain language name "Russian" in the Dictionary combo — a display format only the Word provider produces (`language.NameLocal`); the Hunspell path always renders names like "Russian (Russia) [ru_RU]".

Note: implemented and built on macOS, where Word COM can't run — needs a quick verification on Windows with Office installed (select Russian in the spell-check window's Dictionary combo and check a Russian subtitle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)