### PR TITLE
Fix xUnit analyzer warnings in UndoRedoManagerTests

### DIFF
--- a/tests/UI/Logic/UndoRedo/UndoRedoManagerTests.cs
+++ b/tests/UI/Logic/UndoRedo/UndoRedoManagerTests.cs
@@ -502,26 +502,27 @@ public class UndoRedoManagerTests
     }
 
     [Fact]
-    public void CheckForChanges_OverlappingTick_ReturnsWithoutCallingClient()
+    public async Task CheckForChanges_OverlappingTick_ReturnsWithoutCallingClient()
     {
         // Regression for issue #12683: the 250ms timer keeps firing while a previous
         // tick is still blocked inside the client (marshaling to a busy UI thread);
         // each overlapping tick stacked another blocked thread-pool thread — the
         // reported dump had 492 threads. Overlapping ticks must bail immediately.
+        var cancellationToken = TestContext.Current.CancellationToken;
         var client = new BlockingHashClient();
         var manager = new UndoRedoManager();
         manager.SetupChangeDetection(client, TimeSpan.FromHours(1));
         manager.StartChangeDetection();
 
-        var firstTick = Task.Run(() => manager.CheckForChanges(null));
-        Assert.True(client.HashEntered.Wait(TimeSpan.FromSeconds(10)));
+        var firstTick = Task.Run(() => manager.CheckForChanges(null), cancellationToken);
+        Assert.True(client.HashEntered.Wait(TimeSpan.FromSeconds(10), cancellationToken));
 
         manager.CheckForChanges(null); // overlapping tick while the first is blocked
 
         Assert.Equal(1, Volatile.Read(ref client.HashCalls));
 
         client.ReleaseHash.Set();
-        Assert.True(firstTick.Wait(TimeSpan.FromSeconds(10)));
+        await firstTick.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Fixes the last 4 compiler warnings in the solution, all in `UndoRedoManagerTests.CheckForChanges_OverlappingTick_ReturnsWithoutCallingClient`:

- 3× xUnit1051: `Task.Run`, `ManualResetEventSlim.Wait`, and the final wait now pass `TestContext.Current.CancellationToken` so test cancellation stays responsive.
- 1× xUnit1031: the blocking `firstTick.Wait(...)` is replaced by making the test async and awaiting `firstTick.WaitAsync(...)` (throws `TimeoutException` on timeout, so the assertion semantics are preserved).

Full solution rebuild is now 0 warnings; all 29 UndoRedoManager tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)