### PR TITLE
Qwen3 ASR: report exit code and suggest CPU build when GPU run crashes (#12815)

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -179,6 +179,7 @@ public partial class SpeechToTextViewModel : ObservableObject
     private bool _audioClipsAutoStart;
     private string _chatLlmText = string.Empty;
     private string _qwen3AsrOutputJsonPath = string.Empty;
+    private int? _qwen3AsrExitCode;
 
     private readonly IWindowService _windowService;
     private readonly IFileHelper _fileHelper;
@@ -714,6 +715,18 @@ public partial class SpeechToTextViewModel : ObservableObject
             _timerWhisper.Stop();
 
             var settings = Se.Settings.Tools.AudioToText;
+
+            // Grab the exit code before disposing - it is the key diagnostic when the engine
+            // dies without producing output (e.g. a Qwen3 ASR GPU/Vulkan crash, issue #12815).
+            try
+            {
+                _qwen3AsrExitCode = _whisperProcess.ExitCode;
+            }
+            catch
+            {
+                _qwen3AsrExitCode = null;
+            }
+
             _whisperProcess.Dispose();
 
             var engine = GetEffectiveSelectedEngine();
@@ -904,6 +917,27 @@ public partial class SpeechToTextViewModel : ObservableObject
         var jsonPath = _qwen3AsrOutputJsonPath;
         if (string.IsNullOrEmpty(jsonPath) || !File.Exists(jsonPath))
         {
+            var exitCode = _qwen3AsrExitCode;
+            var isVulkan = false;
+            try
+            {
+                var folder = new Qwen3AsrCppEngine().GetAndCreateWhisperFolder();
+                isVulkan = DownloadHashManager.IsQwen3AsrCppVulkanInstall(folder);
+            }
+            catch
+            {
+                // best-effort diagnostics only
+            }
+
+            // The engine ran but produced no output JSON - almost always a native crash of the
+            // GPU (Vulkan) build. Record the exit code (0xC0000005-style values indicate a hard
+            // crash) and force it to the tools log, since that setting is off by default and
+            // otherwise there is no record of why it failed (issue #12815).
+            var exitCodeText = exitCode.HasValue
+                ? $"exit code {exitCode.Value} (0x{(uint)exitCode.Value:X8})"
+                : "exit code unavailable";
+            Se.WriteToolsLog($"Qwen3 ASR CPP produced no output JSON; {exitCodeText}; Vulkan build: {isVulkan}", true);
+
             Dispatcher.UIThread.Invoke<Task>(async () =>
             {
                 LogToConsole($"Speech to text ({settings.WhisperChoice}) done in {_sw.Elapsed}{Environment.NewLine}");
@@ -912,7 +946,14 @@ public partial class SpeechToTextViewModel : ObservableObject
                     await MessageBox.Show(Window!, $"Unknown argument: {settings.WhisperCustomCommandLineArguments}",
                         "Unknown argument. Please check the advanced settings.");
                 }
-                LogToConsole($"Speech to text: Could not find output JSON file{Environment.NewLine}");
+                LogToConsole($"Speech to text: Could not find output JSON file ({exitCodeText}){Environment.NewLine}");
+                if (exitCode is not (null or 0))
+                {
+                    var url = new Qwen3AsrCppEngine().Url;
+                    LogToConsole(isVulkan
+                        ? $"The Qwen3 ASR GPU (Vulkan) engine crashed before producing output. Try the CPU build instead (re-download the engine and choose CPU), or report it at {url}{Environment.NewLine}"
+                        : $"The Qwen3 ASR engine crashed before producing output. Try re-running, a different model, or report it at {url}{Environment.NewLine}");
+                }
                 ProgressValue = 100;
                 IsTranscribeEnabled = true;
                 await Task.CompletedTask;
@@ -3549,6 +3590,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             var exe = qwen3Asr.GetExecutable();
             var alignerModel = qwen3Asr.ForcedAlignerModel;
             _qwen3AsrOutputJsonPath = Path.Combine(Path.GetTempPath(), $"qwen3_asr_{Guid.NewGuid():N}.json");
+            _qwen3AsrExitCode = null;
             var qwen3ExtraArgs = engine.CommandLineParameter;
 
             var qwen3Params = string.IsNullOrWhiteSpace(qwen3ExtraArgs)


### PR DESCRIPTION
## Background

Issue #12815: on a discrete GPU (RTX 5060, Windows 11) the **Qwen3 ASR CPP (GPU/Vulkan)** engine prints its header, dies after ~2 seconds, and writes no output JSON. Subtitle Edit then shows only:

> Speech to text: Could not find output JSON file

The **CPU** build works on the same file, so this is a native crash of the GPU build.

The underlying Vulkan crash is fixed engine-side in [niksedk/qwen3-asr.cpp#8](https://github.com/niksedk/qwen3-asr.cpp/pull/8) (discrete GPUs now upload weights to a device-local buffer instead of wrapping an unreadable host pointer). **This PR is the Subtitle Edit-side diagnostics half.**

## Problem in SE

When the engine produced no JSON, `ProcessQwen3AsrCppTranscription` threw away the single most useful piece of evidence:

- The process was **disposed before its exit code was read**, so a crash code (e.g. `0xC0000005` access violation) was lost.
- The missing-JSON branch forced **nothing** to the tools log (that setting is off by default), unlike the JSON-*parse*-failure branch which already force-writes.

So a crashing GPU build gave an almost information-free message and users could only stumble onto "switch to CPU" by trial and error.

## Change

- Capture `_whisperProcess.ExitCode` **before** disposing the process.
- In the missing-JSON path:
  - Log the exit code (decimal + hex, so `0xC0000005`-style crash codes are recognizable) and **force-write** it to the tools log along with whether the Vulkan build is installed.
  - When the exit code is non-zero **and** the Vulkan build is in use, tell the user the GPU build crashed and to **try the CPU build** (the known-good fallback); otherwise suggest re-running / a different model / reporting.

No behavior change on the success path or the parse-failure path.

## Testing

- `dotnet build src/ui/UI.csproj -c Release` succeeds (0 warnings, 0 errors).
- Diagnostic-only change; the crashing scenario itself is fixed engine-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)