### PR TITLE
Word spell check: check words in a range so the selected language is used

### DIFF
--- a/src/ui/Features/SpellCheck/WordSpellCheck.cs
+++ b/src/ui/Features/SpellCheck/WordSpellCheck.cs
@@ -189,6 +189,19 @@ public sealed class WordSpellCheck : IWordSpellChecker, IDisposable
         {
             range.NoProofing = false;
             range.LanguageID = _currentLanguage.LanguageId;
+
+            try
+            {
+                // If "Detect language automatically" is on, Word re-detects the language of text as
+                // it arrives and would override the LanguageID just set. LanguageDetected = true
+                // marks the range as already determined, so Word leaves it alone. Done per range
+                // rather than via Application.CheckLanguage, which is a persisted user preference.
+                range.LanguageDetected = true;
+            }
+            catch
+            {
+                // ignored - not available unless Word is set up for multilingual editing
+            }
         }
 
         // Word caches proofing state per document; force a re-check of the new text and language.

--- a/src/ui/Features/SpellCheck/WordSpellCheck.cs
+++ b/src/ui/Features/SpellCheck/WordSpellCheck.cs
@@ -3,6 +3,7 @@ using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Features.SpellCheck;
@@ -11,39 +12,19 @@ public sealed class WordSpellCheck : IWordSpellChecker, IDisposable
 {
     private dynamic? _wordApp;
     private dynamic? _managedDocument;
-    private dynamic? _mainDictionary;
     private bool _disposed;
+    private bool _comFailureLogged;
     private WordSpellCheckLanguage? _currentLanguage;
 
+    /// <summary>
+    /// The language whose dictionary words are checked against. Only cached here - the language is
+    /// applied per check in <see cref="PrepareRange"/>, because <c>LanguageID</c> is character
+    /// formatting and only means anything on a range that actually contains text.
+    /// </summary>
     public WordSpellCheckLanguage? CurrentLanguage
     {
         get => _currentLanguage;
-        set
-        {
-            _currentLanguage = value;
-            _mainDictionary = null;
-
-            if (_wordApp == null || value == null)
-            {
-                return;
-            }
-
-            try
-            {
-                EnsureDocumentOpen();
-                _managedDocument!.Content.LanguageID = value!.LanguageId;
-
-                // Application.CheckSpelling/GetSpellingSuggestions on a bare string ignore the
-                // document language and use Word's default proofing dictionary, so the selected
-                // language's dictionary must be passed explicitly as MainDictionary (issue #12769).
-                _mainDictionary = _wordApp!.Languages[value.LanguageId].ActiveSpellingDictionary;
-            }
-            catch
-            {
-                // ignored - _mainDictionary stays null and spell check falls back to
-                // Word's default proofing language
-            }
-        }
+        set => _currentLanguage = value;
     }
 
     public static bool IsWordInstalled()
@@ -98,15 +79,12 @@ public sealed class WordSpellCheck : IWordSpellChecker, IDisposable
 
         try
         {
-            if (_mainDictionary != null)
-            {
-                return (bool)_wordApp!.CheckSpelling(word, MainDictionary: _mainDictionary);
-            }
-
-            return (bool)_wordApp!.CheckSpelling(word);
+            var range = PrepareRange(word);
+            return (int)range!.SpellingErrors.Count == 0;
         }
-        catch
+        catch (Exception exception)
         {
+            LogComFailureOnce(exception, $"Word spell check failed for \"{word}\"");
             return true;
         }
     }
@@ -158,20 +136,65 @@ public sealed class WordSpellCheck : IWordSpellChecker, IDisposable
 
         try
         {
-            var spellingSuggestions = _mainDictionary != null
-                ? _wordApp!.GetSpellingSuggestions(word, MainDictionary: _mainDictionary)
-                : _wordApp!.GetSpellingSuggestions(word);
-            foreach (var suggestion in spellingSuggestions)
+            var range = PrepareRange(word);
+            foreach (var suggestion in range!.GetSpellingSuggestions())
             {
                 suggestions.Add((string)suggestion.Name);
             }
         }
-        catch
+        catch (Exception exception)
         {
-            // ignored
+            LogComFailureOnce(exception, $"Word spell check suggestions failed for \"{word}\"");
         }
 
         return suggestions;
+    }
+
+    /// <summary>
+    /// Logs the first Word COM failure only - a broken Word automation session fails for every
+    /// word, and one entry is enough to diagnose it without flooding the log.
+    /// </summary>
+    private void LogComFailureOnce(Exception exception, string message)
+    {
+        if (_comFailureLogged)
+        {
+            return;
+        }
+
+        _comFailureLogged = true;
+        Se.LogError(exception, message);
+    }
+
+    /// <summary>
+    /// Puts <paramref name="word"/> into the managed document and returns the range holding it,
+    /// formatted with the selected language.
+    /// </summary>
+    /// <remarks>
+    /// <c>Application.CheckSpelling</c>/<c>GetSpellingSuggestions</c> on a bare string are
+    /// application-level calls with no range to take a language from, so they always used Word's
+    /// default proofing dictionary - with e.g. Russian selected every word was checked against
+    /// English and flagged (issue #12769). The range equivalents pick "the main dictionary that
+    /// corresponds to the language formatting of the first word in the range", so the text has to
+    /// exist *before* LanguageID is set - setting it on an empty document formats nothing.
+    /// </remarks>
+    private dynamic PrepareRange(string word)
+    {
+        EnsureDocumentOpen();
+
+        _managedDocument!.Content.Text = word;
+
+        // Re-fetch so the range covers the text just inserted rather than the empty content.
+        var range = _managedDocument.Content;
+        if (_currentLanguage != null)
+        {
+            range.NoProofing = false;
+            range.LanguageID = _currentLanguage.LanguageId;
+        }
+
+        // Word caches proofing state per document; force a re-check of the new text and language.
+        _managedDocument.SpellingChecked = false;
+
+        return range;
     }
 
     /// <summary>
@@ -199,12 +222,6 @@ public sealed class WordSpellCheck : IWordSpellChecker, IDisposable
         {
             try
             {
-                if (_mainDictionary != null)
-                {
-                    Marshal.ReleaseComObject(_mainDictionary);
-                    _mainDictionary = null;
-                }
-
                 if (_managedDocument != null)
                 {
                     _managedDocument.Close(false); // false = don't save changes


### PR DESCRIPTION
Second attempt at #12769 — the rc15 fix (d2a278925) did not work; the reporter confirmed on a build that contains it that Russian still flags every word, while Hunspell works fine.

### Why the first fix failed

`Application.CheckSpelling` / `Application.GetSpellingSuggestions` take a **bare string**. They are application-level calls with no range to read a language from, so they always use Word's default proofing dictionary. Passing `MainDictionary` swaps the *word list* but not the language's proofing engine.

The accompanying `_managedDocument.Content.LanguageID = ...` was also a no-op: `LanguageID` is character formatting, and the managed document is empty at that point — there are no characters to format.

### What this does instead

Back to what SE4's `WordSpellChecker` did (removed in 878d1670f), adapted to the per-word `IWordSpellChecker` interface:

1. put the word in the document,
2. set `LanguageID` on the range that actually holds it,
3. read `Range.SpellingErrors` / `Range.GetSpellingSuggestions()`.

The range is also marked `LanguageDetected = true`. If the user has "Detect language automatically" enabled, Word otherwise re-detects the language of incoming text and overrides the `LanguageID` we just set — back to the wrong dictionary. This is done per range rather than via `Application.CheckLanguage`, which is a persisted user preference and would change the user's own Word setup.

Per the Word VBA docs for `Range.GetSpellingSuggestions`, when no main dictionary is given Word uses *"the main dictionary that corresponds to the language formatting of the first word in the range"* — which is exactly the behaviour we want, engine included. `MainDictionary` is dropped entirely.

`SpellingChecked = false` is set so Word re-checks after the text and language change rather than reusing cached proofing state.

### Also

The previous `catch { }` swallowed COM failures silently, so a failed dictionary lookup looked identical to no fix at all. The first failure is now logged via `Se.LogError` (once per instance, so a broken Word session doesn't flood the log).

### Testing

- `dotnet build src/ui/UI.csproj` — clean, 0 warnings
- `dotnet test tests/UI/UITests.csproj --filter FullyQualifiedName~SpellCheck` — 50/50 pass

⚠️ **Needs verification on Windows.** This is Word COM interop and I could not exercise it on macOS; the existing tests do not cover the Word backend. Given rc15 already burned one attempt, this should be confirmed against Word with Russian proofing tools installed before it ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
