### PR TITLE
Word spell check: recover a dead Word session instead of passing every word

### DIFF
--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -999,7 +999,9 @@ public partial class SpellCheckViewModel : ObservableObject, IClosingCleanup
             _lastSpellCheckResult = results[0];
             SelectedParagraph = results[0].Paragraph;
 
-            var suggestions = _spellCheckManager.GetSuggestions(results[0].Word.Text);
+            // Already looked up while scanning - asking again costs a second round trip to the
+            // spell-check backend (a whole document check with the MS Word backend) for nothing.
+            var suggestions = results[0].Suggestions;
             Suggestions.Clear();
             foreach (var suggestion in suggestions)
             {

--- a/src/ui/Features/SpellCheck/WordSpellCheck.cs
+++ b/src/ui/Features/SpellCheck/WordSpellCheck.cs
@@ -10,10 +10,13 @@ namespace Nikse.SubtitleEdit.Features.SpellCheck;
 
 public sealed class WordSpellCheck : IWordSpellChecker, IDisposable
 {
+    private const int MaxFailedRecoveries = 3;
+
     private dynamic? _wordApp;
     private dynamic? _managedDocument;
     private bool _disposed;
     private bool _comFailureLogged;
+    private int _failedRecoveries;
     private WordSpellCheckLanguage? _currentLanguage;
 
     /// <summary>
@@ -77,16 +80,11 @@ public sealed class WordSpellCheck : IWordSpellChecker, IDisposable
             return true;
         }
 
-        try
-        {
-            var range = PrepareRange(word);
-            return (int)range!.SpellingErrors.Count == 0;
-        }
-        catch (Exception exception)
-        {
-            LogComFailureOnce(exception, $"Word spell check failed for \"{word}\"");
-            return true;
-        }
+        return RunWithRange(
+            word,
+            range => (int)range.SpellingErrors.Count == 0,
+            true, // a word that could not be checked is left alone rather than flagged
+            $"Word spell check failed for \"{word}\"");
     }
 
     public List<WordSpellCheckLanguage> GetInstalledLanguages()
@@ -127,27 +125,87 @@ public sealed class WordSpellCheck : IWordSpellChecker, IDisposable
 
     public List<string> GetSuggestions(string word)
     {
-        var suggestions = new List<string>();
-
         if (_wordApp == null || string.IsNullOrWhiteSpace(word))
         {
-            return suggestions;
+            return new List<string>();
+        }
+
+        return RunWithRange(
+            word,
+            range =>
+            {
+                var suggestions = new List<string>();
+                foreach (var suggestion in range.GetSpellingSuggestions())
+                {
+                    suggestions.Add((string)suggestion.Name);
+                }
+
+                return suggestions;
+            },
+            new List<string>(),
+            $"Word spell check suggestions failed for \"{word}\"");
+    }
+
+    /// <summary>
+    /// Puts <paramref name="word"/> into the managed document and runs <paramref name="operation"/>
+    /// on the resulting range, returning <paramref name="fallback"/> if that cannot be done.
+    /// </summary>
+    /// <remarks>
+    /// The document is dropped and re-created on failure before retrying: Word may have been closed
+    /// or have crashed mid-run, and since a failed check leaves the word as correctly spelled, every
+    /// remaining word of the subtitle would otherwise come back without a single spelling error.
+    /// Recovery is abandoned after <see cref="MaxFailedRecoveries"/> failures in a row so a failure
+    /// that re-creating the document cannot fix does not cost a new document per word.
+    /// </remarks>
+    private T RunWithRange<T>(string word, Func<dynamic, T> operation, T fallback, string failureMessage)
+    {
+        while (true)
+        {
+            try
+            {
+                var result = operation(PrepareRange(word));
+                _failedRecoveries = 0;
+                return result;
+            }
+            catch (Exception exception)
+            {
+                LogComFailureOnce(exception, failureMessage);
+
+                if (_failedRecoveries >= MaxFailedRecoveries)
+                {
+                    return fallback;
+                }
+
+                _failedRecoveries++;
+                DiscardDocument();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Drops the tracked document so the next call opens a fresh one. Swallows errors from closing
+    /// it - the document is on its way out, and it may well be gone already.
+    /// </summary>
+    private void DiscardDocument()
+    {
+        if (_managedDocument == null)
+        {
+            return;
         }
 
         try
         {
-            var range = PrepareRange(word);
-            foreach (var suggestion in range!.GetSpellingSuggestions())
-            {
-                suggestions.Add((string)suggestion.Name);
-            }
+            _managedDocument.Close(false); // false = don't save changes
+            Marshal.ReleaseComObject(_managedDocument);
         }
-        catch (Exception exception)
+        catch
         {
-            LogComFailureOnce(exception, $"Word spell check suggestions failed for \"{word}\"");
+            // ignored
         }
-
-        return suggestions;
+        finally
+        {
+            _managedDocument = null;
+        }
     }
 
     /// <summary>
@@ -235,12 +293,7 @@ public sealed class WordSpellCheck : IWordSpellChecker, IDisposable
         {
             try
             {
-                if (_managedDocument != null)
-                {
-                    _managedDocument.Close(false); // false = don't save changes
-                    Marshal.ReleaseComObject(_managedDocument);
-                    _managedDocument = null;
-                }
+                DiscardDocument();
 
                 _wordApp.Quit();
                 Marshal.ReleaseComObject(_wordApp);


### PR DESCRIPTION
Two follow-ups to #12819, where the MS Word backend moved from `Application.CheckSpelling` to checking words in a document range.

### 1. A dead Word session made the rest of the run report no spelling errors

`DoSpell` counts a failed check as "correctly spelled", and every word now depends on the managed document — but `EnsureDocumentOpen` only checks the field for null, so the document was never re-created. Close (or crash) the hidden Word instance halfway through a subtitle and every remaining word came back correct, the dialog reported the check finished with nothing found, and the only trace was a single entry in the error log.

Failures now drop the document and retry, so the next word gets a fresh one. Recovery stops after three failures in a row — a failure a new document cannot fix (`LanguageID` throwing for the selected language, say) would otherwise cost a `Documents.Add` per word and freeze the UI for the length of the subtitle.

Still not covered: if the whole `Word.Application` is gone, `Documents.Add` keeps failing and words are again reported as correct after recovery is abandoned. Fixing that properly means telling the dialog "could not check" instead of "correct", which needs an `IWordSpellChecker` change and a UI flow of its own.

### 2. Suggestions were looked up twice per misspelled word

`CheckSpelling` fills `SpellCheckResult.Suggestions` for the word it stopped on, but nothing ever read that field and `DoSpellCheck` asked for the same word again. With the Word backend the second lookup is another text-set + range-fetch + language formatting + forced document re-proof, on the UI thread. The recompute in `ReCheckCurrentWordAfterDictionaryChange` stays — there the dictionary actually changed.

### Testing

Build clean, and the 52 spell-check tests in `UITests`/`LibUiLogicTests` pass. The Word paths are Windows COM and are unverified — they need a run on Windows with the MS Word provider selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)