### PR TITLE
Update Qwen3 ASR CPP engine to v0.1.7 (Vulkan crash fix + ggml 0.17.0, #12815)

### DIFF
--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -561,7 +561,8 @@ public static class DownloadHashManager
             // recognized and offered the update (issue #11375).
             [Qwen3AsrCpp.Windows] = new[]
             {
-                "4b0e23b2124c3e64c00dbc727bdfd86f7deca4a802edec9e6470701892371942", // v0.1.6 (current download URL)
+                "2899cfd563b8343fde6b74b617f32b17a26b611e1187c91ba416334364075af7", // v0.1.7 (current download URL)
+                "4b0e23b2124c3e64c00dbc727bdfd86f7deca4a802edec9e6470701892371942", // v0.1.6
                 "4382904b6110e3ba636f927f484a0545a66783f4fd29fd514fd3ce05ba0f0b30", // v0.1.5
                 "d660e2ba5628a883bfff9e57729e8001f4f6e6d9c256cc87e43a13a9ed4ba39d", // v0.1.4
                 "dc57c16975cc34a0cf86dcf2b231f68c5dbab2ecc899ca4313af5e0fbe3bde31", // v0.1.3
@@ -571,7 +572,8 @@ public static class DownloadHashManager
             },
             [Qwen3AsrCpp.WindowsVulkan] = new[]
             {
-                "b5ee87d7f9290f0fec651f727fb015bff14ca4e297df83e46c64f489e2ca64f5", // v0.1.6 (current download URL)
+                "b1bff40ba1c7f0103c6016c4845481053686761f0c375eb71612d1f07192099b", // v0.1.7 (current download URL)
+                "b5ee87d7f9290f0fec651f727fb015bff14ca4e297df83e46c64f489e2ca64f5", // v0.1.6
                 "c608f9c00ed5e2f568d75045b9f3079dc2f2b4b064925dce77f53e0626d06100", // v0.1.5
                 "19ddde3eb5392fb376fa3af53795c36286eddbebdfc84ded1ebea9be8f883a51", // v0.1.4
                 "8a0a80135221d31036fdaf76fcefb226d3035e42d27d7a6046e3478816b8c537", // v0.1.3
@@ -579,7 +581,8 @@ public static class DownloadHashManager
             },
             [Qwen3AsrCpp.MacArm64] = new[]
             {
-                "cf594a18afc7bfa42c8e784d83842c842177310289471ad211ca58e3d3c0642a", // v0.1.6 (current download URL)
+                "a4355282cbde03d99ddc1be7724a2e0fd2520ad6d07e875bb4a01ce4f8a83fcd", // v0.1.7 (current download URL)
+                "cf594a18afc7bfa42c8e784d83842c842177310289471ad211ca58e3d3c0642a", // v0.1.6
                 "e01a1b3aee6105dbaaa5612b77001a1d17e3f3654bd5f0f47fdf9a38e340fdb0", // v0.1.5
                 "6b7d9bb8d9ce70196b137c432d1e7d6a8ee3181f696b56a17d11f297d4e61850", // v0.1.4
                 "dbea2f1fff20af26cb0531f0a166609f64102e08288a8c73fada1425ae0e2876", // v0.1.3
@@ -589,7 +592,8 @@ public static class DownloadHashManager
             },
             [Qwen3AsrCpp.MacX64] = new[]
             {
-                "ebe8afd2fce42c1dc7780a96f45757dc1eabf1c94dc639cf8a8664cc807f4b78", // v0.1.6 (current download URL)
+                "8295b7c36fd49fe6073d9a05b126a66ac1a5eaf0cc2768d45a5145f3d6a07fae", // v0.1.7 (current download URL)
+                "ebe8afd2fce42c1dc7780a96f45757dc1eabf1c94dc639cf8a8664cc807f4b78", // v0.1.6
                 "94aef4605ebc6d0933d0d2d741f994afd2ad51e5a1f4603b1f37cb7425dda565", // v0.1.5
                 "bc41b07cd3229784d48096924303d3339d051d1f92655bed6773bc5ab77e8037", // v0.1.4
                 "69b71827980c83f8c3bff455062f7aad4978555205f2cde09c9599adcae96abd", // v0.1.3
@@ -598,7 +602,8 @@ public static class DownloadHashManager
             },
             [Qwen3AsrCpp.Linux] = new[]
             {
-                "6dccfe589febd6001b37b9be9248227f1278a966c94e86606b159867ca78f5d3", // v0.1.6 (current download URL)
+                "d6843919444f447b5b4cc307565f07cdec4a233e8584f1cb88ded6d5413f5caa", // v0.1.7 (current download URL)
+                "6dccfe589febd6001b37b9be9248227f1278a966c94e86606b159867ca78f5d3", // v0.1.6
                 "abaae9b655fc8b4c50ab21df4a1e7e7354b69506aff67f0a6a0d2df4eb7a1091", // v0.1.5
                 "cd7c1c3ce9f4a2b3fcebbc0bee1d4db14e49e907ecb7dbfcfa5c814b9e304534", // v0.1.4
                 "cdafe9326f05d97887b036ff2df6028fb1265f6affb4c792b77739b3ba176fe5", // v0.1.3
@@ -608,7 +613,8 @@ public static class DownloadHashManager
             },
             [Qwen3AsrCpp.LinuxVulkan] = new[]
             {
-                "c455b92c8143416abfd201024c1707c0b52350e410908c6b718c8cea4eae44ff", // v0.1.6 (current download URL)
+                "4c3147af8e9077f8758d9ed86c23f213b22ccbc0df1d8990f27308e34279f831", // v0.1.7 (current download URL)
+                "c455b92c8143416abfd201024c1707c0b52350e410908c6b718c8cea4eae44ff", // v0.1.6
                 "aae44a23a2ccdd6bc0b43e8d0f97651ee215b435e07f330bc19197d715e28e3b", // v0.1.5
                 "195c0224f6bec2dec31c1b595f1826e737d67300749c699f1aacdeaa228c5fc1", // v0.1.4
                 "14d8fbdd109e44ea5be4a053083dd9fb869577fed596eba623a2a3875bc2e5f3", // v0.1.3
@@ -616,7 +622,8 @@ public static class DownloadHashManager
             },
             [Qwen3AsrCpp.LinuxArm64] = new[]
             {
-                "4127c2567b6512a4377ff5b3b077468d915fcf76ab156458ec7be81d5e5690e0", // v0.1.6 (current download URL)
+                "1a67596e18da7ad5ad2adcca72ce5986033120ba25835493a92b52885a6c1903", // v0.1.7 (current download URL)
+                "4127c2567b6512a4377ff5b3b077468d915fcf76ab156458ec7be81d5e5690e0", // v0.1.6
                 "b54a89bff6b26ac0d2471f7b1fcdb7e6be6bde6570e358e76daf60f0156516f8", // v0.1.5
                 "dd488714fd1582a33a79ecefe3f6d69e9214a32fa4a54a195c1aaaf0167300cc", // v0.1.4
                 "3df6f2e470b66b57f4b335abd62c67695b0f679f0c5c538d8258aba0393ab4ea", // v0.1.3
@@ -625,7 +632,8 @@ public static class DownloadHashManager
             },
             [Qwen3AsrCpp.WindowsExecutable] = new[]
             {
-                "8f9e0f8c85e2c95fe0627d442dd15908d36ae9c0076ab4109e84c00ec6f2ab78", // v0.1.6 (current download URL)
+                "0abdde2ebb6cea8059aa8fe3b7ed61277b9c17bfa223715c431320c575e653c6", // v0.1.7 (current download URL)
+                "8f9e0f8c85e2c95fe0627d442dd15908d36ae9c0076ab4109e84c00ec6f2ab78", // v0.1.6
                 "29dba7a3808eb18f787486104a6d542e32fd32b4c177cc4f6e9c262d5ac1b46d", // v0.1.5
                 "fabfbeba21f7bece38a8beff3947f4a2aed1d189fab7d5ba5e67e8f761292039", // v0.1.4
                 "73d54bda5cc4addf2673dff330afd447f860ed035beacf61455b1eb6ebd2af18", // v0.1.3
@@ -635,7 +643,8 @@ public static class DownloadHashManager
             },
             [Qwen3AsrCpp.WindowsVulkanExecutable] = new[]
             {
-                "998b0577d5d3cbe35917603f86a72acf201f5010757ed611216574eb67d3570e", // v0.1.6 (current download URL)
+                "eba7c228d04a3124e48bcb6342bb372a2fc5338a344e2ee8bd3971518ea4e780", // v0.1.7 (current download URL)
+                "998b0577d5d3cbe35917603f86a72acf201f5010757ed611216574eb67d3570e", // v0.1.6
                 "38546750d753666cc767c4ccafa483e1fff83ddd5feed6f7945a8a35acea3e8f", // v0.1.5
                 "6011e77f1b881c409447d0fbd5314f6306f439358ed0d2bd914cb397ed6443c4", // v0.1.4
                 "4913668d5524a44ce8d42bf5620cefb0c8a8347e5484ce8f659433d0b147d60d", // v0.1.3
@@ -643,7 +652,8 @@ public static class DownloadHashManager
             },
             [Qwen3AsrCpp.MacArm64Executable] = new[]
             {
-                "e2cd42381858a853ece9ca6f00eab4fb940b34efbfc5d6b5a332fae6371fb90c", // v0.1.6 (current download URL)
+                "0c637dad09da1198c755d75f4d0e52d74443220743ee4c5f396c8a95ecc41d2a", // v0.1.7 (current download URL)
+                "e2cd42381858a853ece9ca6f00eab4fb940b34efbfc5d6b5a332fae6371fb90c", // v0.1.6
                 "2c8ea51851a6ac70ab4971e0d32c314e17eb916cb6b0ead64fb36761924e4de2", // v0.1.5
                 "bdd5051aed56e4abfcc4d3dfce550e3a818fd446a1da58d37c5d2b32e8e5d570", // v0.1.4
                 "f3e811d4932946c3fb1b517e21387b239b6010584e7b30f4b979d3d7e2593307", // v0.1.3
@@ -652,7 +662,8 @@ public static class DownloadHashManager
             },
             [Qwen3AsrCpp.MacX64Executable] = new[]
             {
-                "eff1cf91866b6168f5544dec6018fe339cd60cb9acba5003fc0142e240f96172", // v0.1.6 (current download URL)
+                "e4b9c56a373656d67ca0ef0ef383ccc75b62b788b323bdd43f922f351a3864c1", // v0.1.7 (current download URL)
+                "eff1cf91866b6168f5544dec6018fe339cd60cb9acba5003fc0142e240f96172", // v0.1.6
                 "6ab8faa6170c202b0faef8d943f7a1ee9ae7d0e5906c6f40ba7a64944d54762f", // v0.1.5
                 "e3c4002c68dfa3ee773ebf7d177f97c910c6126f56097b8cf2da8882163007d9", // v0.1.4
                 "472db2846b47289fccfe77bbc2392df555ab49f7aafb047dbbfc31b939da8069", // v0.1.3
@@ -660,7 +671,7 @@ public static class DownloadHashManager
             },
             [Qwen3AsrCpp.LinuxExecutable] = new[]
             {
-                "a02d9e2ba60201ad8e778dca9a9f7ca1f5cafc145955488a1b2c611615b997ba", // v0.1.6 (current download URL)
+                "a02d9e2ba60201ad8e778dca9a9f7ca1f5cafc145955488a1b2c611615b997ba", // v0.1.7 / v0.1.6 (current download URL)
                 "b7d9f1450eba98f8e1a63ae2e9cfbf79c5ceea648d981b31636e25eb0e1d8b0b", // v0.1.5
                 "1378d1d968446b19452f7463007b6707cbfa703e025b1309650fc928d1972ddc", // v0.1.4 / v0.1.3
                 "959c7a807902d4fc17426818204224f500d5dc29716cad6bc924281f19cbf01b", // v0.1.2
@@ -669,7 +680,7 @@ public static class DownloadHashManager
             },
             [Qwen3AsrCpp.LinuxVulkanExecutable] = new[]
             {
-                "a02d9e2ba60201ad8e778dca9a9f7ca1f5cafc145955488a1b2c611615b997ba", // v0.1.6 (current download URL)
+                "a02d9e2ba60201ad8e778dca9a9f7ca1f5cafc145955488a1b2c611615b997ba", // v0.1.7 / v0.1.6 (current download URL)
                 "b7d9f1450eba98f8e1a63ae2e9cfbf79c5ceea648d981b31636e25eb0e1d8b0b", // v0.1.5
                 "1378d1d968446b19452f7463007b6707cbfa703e025b1309650fc928d1972ddc", // v0.1.4
                 "618432a1d4da28a500e51aa1c7706e33ef4c32c8875aeb7b2f0c9044cef5f51e", // v0.1.3
@@ -677,7 +688,7 @@ public static class DownloadHashManager
             },
             [Qwen3AsrCpp.LinuxArm64Executable] = new[]
             {
-                "fe453c7f30efc717fbfb2b9d4ff4ff5d50f862300d8c390d6e4c0066c31e6c60", // v0.1.6 (current download URL)
+                "fe453c7f30efc717fbfb2b9d4ff4ff5d50f862300d8c390d6e4c0066c31e6c60", // v0.1.7 / v0.1.6 (current download URL)
                 "bcb155a93474b074897c7680a2c2cfdbfe1cf4478652db5a4bec8c83cf688541", // v0.1.5
                 "a6087e81c1975cecb644391130e2efb3cef3442b12928abd333c8fe856a6226d", // v0.1.4 / v0.1.3
                 "f1a5318f740108c21b597493ad28bf2cc430d9f5fa0d19b5d741d47a6781a2b5", // v0.1.2 / v0.1.1

--- a/src/ui/Logic/Download/Qwen3AsrCppDownloadService.cs
+++ b/src/ui/Logic/Download/Qwen3AsrCppDownloadService.cs
@@ -18,12 +18,15 @@ public class Qwen3AsrCppDownloadService : IQwen3AsrCppDownloadService
 
     // Built by https://github.com/niksedk/qwen3-asr.cpp (.github/workflows/release.yml) — these
     // are the binaries with the JSON word-truncation fix (issue #11717) plus the valid-JSON fix
-    // for non-finite/oversized timestamps (issue #11375), on the ggml 0.15.3 backend. v0.1.6
-    // merges upstream (mixed-CJK tokenization fix, multilingual alignment encoding, tokenizer-
-    // config GGUF vocab, thread-count propagation). CPU for every platform, plus Vulkan (GPU)
-    // for win64 and linux-x64. When bumping: also prepend the new archive + executable hashes
-    // in DownloadHashManager (Qwen3AsrCpp keys) so the update prompt fires for old installs.
-    private const string ReleaseUrlBase = "https://github.com/niksedk/qwen3-asr.cpp/releases/download/v0.1.6/";
+    // for non-finite/oversized timestamps (issue #11375). v0.1.6 merged upstream (mixed-CJK
+    // tokenization fix, multilingual alignment encoding, tokenizer-config GGUF vocab, thread-
+    // count propagation). v0.1.7 fixes the Vulkan (discrete GPU) crash where the engine produced
+    // no output JSON — weights are now uploaded to a device-local buffer instead of wrapped from
+    // an unreadable host pointer (issue #12815) — and bumps the ggml backend to 0.17.0. CPU for
+    // every platform, plus Vulkan (GPU) for win64 and linux-x64. When bumping: also prepend the
+    // new archive + executable hashes in DownloadHashManager (Qwen3AsrCpp keys) so the update
+    // prompt fires for old installs.
+    private const string ReleaseUrlBase = "https://github.com/niksedk/qwen3-asr.cpp/releases/download/v0.1.7/";
     private const string WindowsUrl = ReleaseUrlBase + "qwen3-asr-cpp-win64.zip";
     private const string WindowsVulkanUrl = ReleaseUrlBase + "qwen3-asr-cpp-win64-vulkan.zip";
     private const string MacArmUrl = ReleaseUrlBase + "qwen3-asr-cpp-mac.zip";


### PR DESCRIPTION
Points the **Qwen3 ASR CPP** engine download at the [v0.1.7 release](https://github.com/niksedk/qwen3-asr.cpp/releases/tag/v0.1.7) of `niksedk/qwen3-asr.cpp`.

## What v0.1.7 brings

- **Fixes the discrete-GPU (Vulkan) crash** reported in #12815: on a discrete GPU (e.g. RTX 5060 / Windows) the engine printed its header, died after ~2s, and wrote no output JSON, so SE showed *"Could not find output JSON file"* (CPU build worked). Root cause: model weights were only uploaded to a device-local buffer for CUDA; every other GPU — including Vulkan — wrapped the mmap'd weights via a host pointer the device can't read, crashing at graph-compute. v0.1.7 uploads weights to a device-local buffer for all discrete GPUs (niksedk/qwen3-asr.cpp#8).
- **Bumps the ggml backend to v0.17.0** (niksedk/qwen3-asr.cpp#9), pulling in a batch of upstream Vulkan/CUDA reliability fixes.

All 7 targets built green on the release run (both Vulkan builds included).

## Changes here

- `Qwen3AsrCppDownloadService.cs`: bump the release URL base `v0.1.6 → v0.1.7`; refresh the explanatory comment.
- `DownloadHashManager.cs`: prepend the v0.1.7 archive + executable SHA-256 hashes at index 0 of all 14 `Qwen3AsrCpp` lists (7 archives + 7 executables), demoting the previous `(current download URL)` markers, so new installs read as current and older installs are offered the update.
  - The Linux, Linux-Vulkan and Linux-ARM64 **CLI executables are byte-identical to v0.1.6** (the fix lives in the ggml shared libs, not the CLI), so those three executable entries are relabelled `v0.1.7 / v0.1.6` rather than duplicated. The **archive** hashes — which drive the update prompt via the `.installed.sha256` sidecar — all changed, so the update prompt fires on every platform.

All hashes were computed from the published v0.1.7 release assets (downloaded via `gh release download`; archive = SHA-256 of the `.zip`, executable = SHA-256 of the extracted `qwen3-asr-cli[.exe]`).

## Testing

- `dotnet build src/ui/UI.csproj -c Release` — 0 warnings, 0 errors.
- Companion SE diagnostics PR #12818 surfaces the engine exit code + a CPU-build hint if a GPU run ever crashes again.

Fixes #12815

🤖 Generated with [Claude Code](https://claude.com/claude-code)