### PR TITLE
Speed up the waveform render and the subtitle grid hot paths

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -1999,12 +1999,45 @@ public class AudioVisualizer : Control
     // Pooled x positions for the grid, so the per-frame collection below doesn't allocate.
     private readonly List<double> _gridLineXPositions = new(256);
 
+    // Cached grid geometry. Same reasoning as the waveform cache below: the grid is a few hundred
+    // figures and depends only on the view state, but Render runs at ~60 fps while the cursor
+    // moves - so without this we rebuilt (and threw away) the whole StreamGeometry every frame.
+    private Geometry? _gridLinesGeometry;
+    private GridLinesCacheKey _gridLinesCacheKey;
+
+    private readonly record struct GridLinesCacheKey(
+        double Width,
+        double Height,
+        double StartPositionSeconds,
+        double ZoomFactor,
+        int SampleRate,
+        bool FrameMode,
+        double FrameRate);
+
     private void DrawAllGridLines(DrawingContext context, ref RenderContext renderCtx)
     {
         if (!DrawGridLines)
         {
             return;
         }
+
+        var cacheKey = new GridLinesCacheKey(
+            renderCtx.Width,
+            renderCtx.Height,
+            renderCtx.StartPositionSeconds,
+            renderCtx.ZoomFactor,
+            renderCtx.SampleRate,
+            Se.Settings.General.UseFrameMode,
+            Se.Settings.General.CurrentFrameRate);
+
+        if (_gridLinesGeometry != null && _gridLinesCacheKey.Equals(cacheKey))
+        {
+            context.DrawGeometry(null, _paintGridLines, _gridLinesGeometry);
+            return;
+        }
+
+        _gridLinesGeometry = null;
+        _gridLinesCacheKey = cacheKey;
 
         var width = renderCtx.Width;
         var height = renderCtx.Height;
@@ -2110,6 +2143,7 @@ public class AudioVisualizer : Control
             }
         }
 
+        _gridLinesGeometry = geom;
         context.DrawGeometry(null, _paintGridLines, geom);
     }
 
@@ -2238,7 +2272,6 @@ public class AudioVisualizer : Control
 
     private void BuildWaveFormFancy(double waveformHeight, ref RenderContext renderCtx)
     {
-        _isSelectedHelper.Reset(AllSelectedParagraphs, renderCtx.SampleRate);
         var isSelectedHelper = _isSelectedHelper;
         var halfWaveformHeight = waveformHeight / 2;
         var div = renderCtx.SampleRate * renderCtx.ZoomFactor;
@@ -2263,6 +2296,8 @@ public class AudioVisualizer : Control
         var startSample = renderCtx.StartPositionSeconds * renderCtx.SampleRate;
         var samplesPerPixel = renderCtx.SampleRate / div;
         var yScaleHalf = verticalZoomFactor / highestPeak * halfWaveformHeight;
+
+        isSelectedHelper.Reset(AllSelectedParagraphs, renderCtx.SampleRate, (int)startSample, (int)(startSample + width * samplesPerPixel));
 
         // Calculate the threshold for color transitions (as a fraction of the highest peak)
         var lowThreshold = highestPeak * 0.3;
@@ -2410,7 +2445,6 @@ public class AudioVisualizer : Control
 
     private void BuildWaveFormClassic(double waveformHeight, ref RenderContext renderCtx)
     {
-        _isSelectedHelper.Reset(AllSelectedParagraphs, renderCtx.SampleRate);
         var isSelectedHelper = _isSelectedHelper;
         var halfWaveformHeight = waveformHeight / 2;
         var div = renderCtx.SampleRate * renderCtx.ZoomFactor;
@@ -2433,6 +2467,8 @@ public class AudioVisualizer : Control
         var startSample = renderCtx.StartPositionSeconds * renderCtx.SampleRate;
         var samplesPerPixel = renderCtx.SampleRate / div;
         var yScaleHalf = verticalZoomFactor / highestPeak * halfWaveformHeight;
+
+        isSelectedHelper.Reset(AllSelectedParagraphs, renderCtx.SampleRate, (int)startSample, (int)(startSample + width * samplesPerPixel));
 
         var unselectedLines = _classicUnselectedLines;
         var selectedLines = _classicSelectedLines;
@@ -2643,14 +2679,21 @@ public class AudioVisualizer : Control
         var endPositionMilliseconds = RelativeXPositionToSecondsOptimized(renderCtx.Width, renderCtx.SampleRate, renderCtx.StartPositionSeconds, renderCtx.ZoomFactor) * 1000.0;
 
         // List.Contains per visible paragraph is O(selection) - with "select all" on a large
-        // subtitle that is millions of compares per frame, so probe a set instead.
+        // subtitle that is millions of compares per frame, so probe a set instead. Only the
+        // paragraphs inside the visible window are ever probed, so hashing the rest of a
+        // "select all" is pure waste: two time compares are far cheaper than a HashSet insert.
         _selectedParagraphsRenderSet.Clear();
         var allSelected = AllSelectedParagraphs;
         if (allSelected != null)
         {
-            foreach (var selected in allSelected)
+            for (var i = 0; i < allSelected.Count; i++)
             {
-                _selectedParagraphsRenderSet.Add(selected);
+                var selected = allSelected[i];
+                if (selected.EndTime.TotalMilliseconds >= startPositionMilliseconds &&
+                    selected.StartTime.TotalMilliseconds <= endPositionMilliseconds)
+                {
+                    _selectedParagraphsRenderSet.Add(selected);
+                }
             }
         }
 
@@ -3643,6 +3686,7 @@ public class AudioVisualizer : Control
         _paragraphFormattedTextCache.Clear();
         _paragraphTextCache.Clear();
         _waveformCacheValid = false;
+        _gridLinesGeometry = null;
 
         _paintText = new SolidColorBrush(Se.Settings.Waveform.WaveformTextColor.FromHexToColor());
         _typeface = new Typeface(UiUtil.GetDefaultFontName(), FontStyle.Normal, Se.Settings.Waveform.WaveformTextFontBold ? FontWeight.Bold : FontWeight.Normal);

--- a/src/ui/Controls/AudioVisualizerControl/IsSelectedHelper.cs
+++ b/src/ui/Controls/AudioVisualizerControl/IsSelectedHelper.cs
@@ -11,22 +11,47 @@ public class IsSelectedHelper
     private int _lastPosition = int.MaxValue;
     private SelectionRange _nextSelection;
 
-    public void Reset(List<SubtitleLineViewModel> paragraphs, int sampleRate)
+    /// <summary>
+    /// Loads the selection ranges that can affect the sample window
+    /// [<paramref name="windowStartSample"/>, <paramref name="windowEndSample"/>] - i.e. the
+    /// horizontal span the waveform is about to draw.
+    /// </summary>
+    /// <remarks>
+    /// Keeping only the ranges that intersect the window matters: <see cref="FindNextSelection"/>
+    /// re-scans every loaded range each time the per-pixel walk passes the current one, so with
+    /// "select all" on a large subtitle the unfiltered list turned the waveform rebuild into
+    /// O(pixels x selection). Filtering is exact, not an approximation - <see cref="IsSelected"/>
+    /// is only ever asked about positions inside the window, and a range outside it can never
+    /// contain one.
+    /// </remarks>
+    public void Reset(List<SubtitleLineViewModel> paragraphs, int sampleRate, int windowStartSample, int windowEndSample)
     {
-        _rangeCount = paragraphs.Count;
-        if (_ranges.Length < _rangeCount)
+        var count = paragraphs.Count;
+        if (_ranges.Length < count)
         {
-            Array.Resize(ref _ranges, _rangeCount);
+            Array.Resize(ref _ranges, count);
         }
 
-        for (var index = 0; index < _rangeCount; index++)
+        var kept = 0;
+        for (var index = 0; index < count; index++)
         {
             var p = paragraphs[index];
             var start = (int)Math.Round(p.StartTime.TotalSeconds * sampleRate);
+            if (start > windowEndSample)
+            {
+                continue;
+            }
+
             var end = (int)Math.Round(p.EndTime.TotalSeconds * sampleRate);
-            _ranges[index] = new SelectionRange(start, end);
+            if (end < windowStartSample)
+            {
+                continue;
+            }
+
+            _ranges[kept++] = new SelectionRange(start, end);
         }
 
+        _rangeCount = kept;
         _lastPosition = int.MaxValue;
         _nextSelection = new SelectionRange(int.MaxValue, int.MaxValue);
     }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -21438,6 +21438,23 @@ public partial class MainViewModel :
         SubtitleGridSelectionChanged();
     }
 
+    /// <summary>
+    /// Index of <paramref name="item"/> in <see cref="Subtitles"/>, probing the grid's own
+    /// selected index first. ObservableCollection.IndexOf is a linear scan with a virtual
+    /// Equals per element; this runs on every selection change (so on every arrow key), and
+    /// the grid already knows the answer whenever the item is the current single selection.
+    /// </summary>
+    private int IndexOfSubtitle(SubtitleLineViewModel item)
+    {
+        var hinted = SubtitleGrid.SelectedIndex;
+        if (hinted >= 0 && hinted < Subtitles.Count && ReferenceEquals(Subtitles[hinted], item))
+        {
+            return hinted;
+        }
+
+        return Subtitles.IndexOf(item);
+    }
+
     private void SubtitleGridSelectionChanged()
     {
         var selectedItems = SubtitleGrid.SelectedItems;
@@ -21495,7 +21512,7 @@ public partial class MainViewModel :
             return;
         }
 
-        var idx = Subtitles.IndexOf(item);
+        var idx = IndexOfSubtitle(item);
         StatusTextRight = $"{(idx + 1):N0}/{Subtitles.Count:N0}";
         if (item == SelectedSubtitle && item.Text == EditText)
         {
@@ -21540,32 +21557,11 @@ public partial class MainViewModel :
         var cps = SubtitleTextInfoHelper.GetCharactersPerSecond(text, item.StartTime, item.EndTime);
 
         var lines = text.SplitToLines();
-        PanelSingleLineLengthsOriginal.Children.Clear();
-        PanelSingleLineLengthsOriginal.Children.Add(UiUtil.MakeTextBlock(Se.Language.Main.SingleLineLength)
-            .WithFontSize(12)
-            .WithPadding(2));
-        var first = true;
-        for (var i = 0; i < lines.Count; i++)
-        {
-            if (first)
-            {
-                first = false;
-            }
-            else
-            {
-                PanelSingleLineLengthsOriginal.Children.Add(UiUtil.MakeTextBlock("/").WithFontSize(12).WithPadding(2));
-            }
-
-            var lineLength = SubtitleTextInfoHelper.GetLineLength(lines[i]);
-            var tb = UiUtil.MakeTextBlock(lineLength.ToString(CultureInfo.InvariantCulture)).WithFontSize(12).WithPadding(2);
-            if (Se.Settings.General.ColorTextTooLong &&
-                lineLength > Se.Settings.General.SubtitleLineMaximumLength)
-            {
-                tb.Background = _errorBrush;
-            }
-
-            PanelSingleLineLengthsOriginal.Children.Add(tb);
-        }
+        SubtitleTextInfoHelper.FillLineLengthPanel(
+            PanelSingleLineLengthsOriginal,
+            lines,
+            Se.Settings.General.ColorTextTooLong,
+            Se.Settings.General.SubtitleLineMaximumLength);
 
         EditTextCharactersPerSecondOriginal = string.Format(Se.Language.Main.CharactersPerSecond, $"{cps:0.0}");
         EditTextTotalLengthOriginal = string.Format(Se.Language.Main.TotalCharacters, totalLength);

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -235,13 +235,28 @@ public partial class SubtitleLineViewModel : ObservableObject
         return p;
     }
 
+    // Read-time memo, see CharactersPerSecond below: the pixel-width column binding re-reads this
+    // on every cell repaint and each read shapes every line with HarfBuzz.
+    private string? _pixelWidthCacheText;
+    private string? _pixelWidthCacheFontName;
+    private int _pixelWidthCacheFontSize;
+    private int _pixelWidthCacheValue;
+
     public int PixelWidth
     {
         get
         {
-            if (!Se.Settings.General.ShowColumnPixelWidth && !Se.Settings.General.ColorTextTooWide)
+            var general = Se.Settings.General;
+            if (!general.ShowColumnPixelWidth && !general.ColorTextTooWide)
             {
                 return 0;
+            }
+
+            if (ReferenceEquals(_pixelWidthCacheText, Text) &&
+                _pixelWidthCacheFontName == general.ColorTextTooWideFontName &&
+                _pixelWidthCacheFontSize == general.ColorTextTooWideFontSize)
+            {
+                return _pixelWidthCacheValue;
             }
 
             var text = HtmlUtil.RemoveHtmlTags(Text, true);
@@ -256,6 +271,10 @@ public partial class SubtitleLineViewModel : ObservableObject
                 }
             }
 
+            _pixelWidthCacheText = Text;
+            _pixelWidthCacheFontName = general.ColorTextTooWideFontName;
+            _pixelWidthCacheFontSize = general.ColorTextTooWideFontSize;
+            _pixelWidthCacheValue = maxWidth;
             return maxWidth;
         }
     }
@@ -326,6 +345,44 @@ public partial class SubtitleLineViewModel : ObservableObject
         }
     }
 
+    // Read-time memo for the text error highlight, same idea as the CPS/WPM memos above: the
+    // grid re-reads this getter on every cell repaint, and each evaluation strips html, splits
+    // into lines and (with ColorTextTooWide on) shapes every line with HarfBuzz. The key is the
+    // text plus every setting the answer depends on, so a settings change simply recomputes on
+    // the next read. Only the verdict is memoized, never the brush - the error brush instance is
+    // replaced when the user picks another error color.
+    private string? _textErrorCacheText;
+    private TextErrorSettings _textErrorCacheSettings;
+    private bool _textErrorCacheValue;
+
+    private readonly record struct TextErrorSettings(
+        bool ColorTextTooLong,
+        int MaxLineLength,
+        bool ColorTextTooWide,
+        int MaxPixelWidth,
+        string FontName,
+        int FontSize,
+        bool ColorTextTooManyLines,
+        int MaxNumberOfLines,
+        string? LengthStrategy)
+    {
+        public static TextErrorSettings Current()
+        {
+            var general = Se.Settings.General;
+            return new TextErrorSettings(
+                general.ColorTextTooLong,
+                general.SubtitleLineMaximumLength,
+                general.ColorTextTooWide,
+                general.ColorTextTooWidePixels,
+                general.ColorTextTooWideFontName,
+                general.ColorTextTooWideFontSize,
+                general.ColorTextTooManyLines,
+                general.MaxNumberOfLines,
+                // GetLineLength counts through this strategy, so it belongs in the key too.
+                Configuration.Settings.General.CpsLineLengthStrategy);
+        }
+    }
+
     public IBrush TextBackgroundBrush
     {
         get
@@ -335,50 +392,62 @@ public partial class SubtitleLineViewModel : ObservableObject
                 return _transparentBrush;
             }
 
-            // Avalonia re-evaluates this getter on every cell repaint; strip HTML and split
-            // into lines once and reuse across all settings-enabled branches below.
-            string? stripped = null;
-            List<string>? strippedLines = null;
-
-            if (Se.Settings.General.ColorTextTooLong)
+            var settings = TextErrorSettings.Current();
+            if (!ReferenceEquals(_textErrorCacheText, Text) || !_textErrorCacheSettings.Equals(settings))
             {
-                stripped = SubtitleTextInfoHelper.StripHtml(Text);
-                strippedLines = stripped.SplitToLines();
-
-                foreach (var line in strippedLines)
-                {
-                    if (SubtitleTextInfoHelper.GetLineLength(line) > Se.Settings.General.SubtitleLineMaximumLength)
-                    {
-                        return _errorBrush;
-                    }
-                }
+                _textErrorCacheText = Text;
+                _textErrorCacheSettings = settings;
+                _textErrorCacheValue = HasTextError(Text, settings);
             }
 
-            if (Se.Settings.General.ColorTextTooWide)
-            {
-                stripped ??= SubtitleTextInfoHelper.StripHtml(Text);
-                strippedLines ??= stripped.SplitToLines();
-                foreach (var line in strippedLines)
-                {
-                    if (CalculatePixelWidth(line) > Se.Settings.General.ColorTextTooWidePixels)
-                    {
-                        return _errorBrush;
-                    }
-                }
-            }
-
-            if (Se.Settings.General.ColorTextTooManyLines)
-            {
-                stripped ??= SubtitleTextInfoHelper.StripHtml(Text);
-                strippedLines ??= stripped.SplitToLines();
-                if (strippedLines.Count > Se.Settings.General.MaxNumberOfLines)
-                {
-                    return _errorBrush;
-                }
-            }
-
-            return _transparentBrush;
+            return _textErrorCacheValue ? _errorBrush : _transparentBrush;
         }
+    }
+
+    private static bool HasTextError(string text, TextErrorSettings settings)
+    {
+        // Strip HTML and split into lines once and reuse across all settings-enabled branches.
+        string? stripped = null;
+        List<string>? strippedLines = null;
+
+        if (settings.ColorTextTooLong)
+        {
+            stripped = SubtitleTextInfoHelper.StripHtml(text);
+            strippedLines = stripped.SplitToLines();
+
+            foreach (var line in strippedLines)
+            {
+                if (SubtitleTextInfoHelper.GetLineLength(line) > settings.MaxLineLength)
+                {
+                    return true;
+                }
+            }
+        }
+
+        if (settings.ColorTextTooWide)
+        {
+            stripped ??= SubtitleTextInfoHelper.StripHtml(text);
+            strippedLines ??= stripped.SplitToLines();
+            foreach (var line in strippedLines)
+            {
+                if (CalculatePixelWidth(line) > settings.MaxPixelWidth)
+                {
+                    return true;
+                }
+            }
+        }
+
+        if (settings.ColorTextTooManyLines)
+        {
+            stripped ??= SubtitleTextInfoHelper.StripHtml(text);
+            strippedLines ??= stripped.SplitToLines();
+            if (strippedLines.Count > settings.MaxNumberOfLines)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static readonly Dictionary<(string name, int size), (SKFont font, SKShaper shaper)> _fontCache = [];

--- a/src/ui/Logic/SubtitleTextInfoHelper.cs
+++ b/src/ui/Logic/SubtitleTextInfoHelper.cs
@@ -57,27 +57,7 @@ internal static class SubtitleTextInfoHelper
         var lines = cleanText.SplitToLines();
         var lineCount = lines.Count;
 
-        var children = new List<Control>(1 + lineCount + Math.Max(0, lineCount - 1));
-        children.Add(UiUtil.MakeTextBlock(Se.Language.Main.SingleLineLength).WithFontSize(12).WithPadding(2));
-        for (var i = 0; i < lineCount; i++)
-        {
-            if (i > 0)
-            {
-                children.Add(UiUtil.MakeTextBlock("/").WithFontSize(12).WithPadding(2));
-            }
-
-            var lineLength = GetLineLength(lines[i]);
-            var tb = UiUtil.MakeTextBlock(lineLength.ToString(CultureInfo.InvariantCulture)).WithFontSize(12).WithPadding(2);
-            if (colorTextTooLong && lineLength > maxLineLength)
-            {
-                tb.Background = _errorBrush;
-            }
-
-            children.Add(tb);
-        }
-
-        panel.Children.Clear();
-        panel.Children.AddRange(children);
+        FillLineLengthPanel(panel, lines, colorTextTooLong, maxLineLength);
 
         var totalBackground = colorTextTooLong && totalLength > maxLineLength * lineCount
             ? _errorBrush
@@ -86,6 +66,73 @@ internal static class SubtitleTextInfoHelper
             totalLength,
             string.Format(Se.Language.Main.TotalCharacters, totalLength),
             totalBackground);
+    }
+
+    /// <summary>
+    /// Fills <paramref name="panel"/> with the "Single line length: 12 / 30" labels, reusing the
+    /// text blocks that are already there.
+    /// </summary>
+    /// <remarks>
+    /// This runs on every keystroke in the edit box (and on every selection change), so the old
+    /// Clear + rebuild threw away a handful of TextBlocks and re-added them to the logical and
+    /// visual tree each time. Rewriting Text/Background in place keeps the tree untouched, so
+    /// typing only costs a measure of the labels that actually changed.
+    /// </remarks>
+    internal static void FillLineLengthPanel(StackPanel panel, List<string> lines, bool colorTextTooLong, int maxLineLength)
+    {
+        var children = panel.Children;
+        var needed = 1 + lines.Count + Math.Max(0, lines.Count - 1);
+        while (children.Count > needed)
+        {
+            children.RemoveAt(children.Count - 1);
+        }
+
+        var index = 0;
+        SetLabel(children, ref index, Se.Language.Main.SingleLineLength, null);
+        for (var i = 0; i < lines.Count; i++)
+        {
+            if (i > 0)
+            {
+                SetLabel(children, ref index, "/", null);
+            }
+
+            var lineLength = GetLineLength(lines[i]);
+            SetLabel(children,
+                ref index,
+                lineLength.ToString(CultureInfo.InvariantCulture),
+                colorTextTooLong && lineLength > maxLineLength ? _errorBrush : null);
+        }
+    }
+
+    private static void SetLabel(Avalonia.Controls.Controls children, ref int index, string text, IBrush? background)
+    {
+        if (index < children.Count && children[index] is TextBlock existing)
+        {
+            if (existing.Text != text)
+            {
+                existing.Text = text;
+            }
+
+            if (!ReferenceEquals(existing.Background, background))
+            {
+                existing.Background = background;
+            }
+        }
+        else
+        {
+            var tb = UiUtil.MakeTextBlock(text).WithFontSize(12).WithPadding(2);
+            tb.Background = background;
+            if (index < children.Count)
+            {
+                children[index] = tb; // a foreign control ended up in the panel - replace it
+            }
+            else
+            {
+                children.Add(tb);
+            }
+        }
+
+        index++;
     }
 
     internal static void UpdateGaps(IList<SubtitleLineViewModel> items)

--- a/tests/UI/Controls/IsSelectedHelperTests.cs
+++ b/tests/UI/Controls/IsSelectedHelperTests.cs
@@ -1,0 +1,119 @@
+using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
+using Nikse.SubtitleEdit.Features.Main;
+using System;
+using System.Collections.Generic;
+
+namespace UITests.Controls;
+
+/// <summary>
+/// The waveform asks this helper once per horizontal pixel whether the sample under that pixel
+/// belongs to a selected line. Reset only loads the ranges that intersect the window about to be
+/// drawn, which is what keeps a "select all" from turning every waveform rebuild into
+/// O(pixels x selection) - so these tests check that the filtering never changes an answer for a
+/// position inside the window.
+/// </summary>
+public class IsSelectedHelperTests
+{
+    private const int SampleRate = 100;
+
+    private static SubtitleLineViewModel Line(double startSeconds, double endSeconds) => new()
+    {
+        Text = "text",
+        StartTime = TimeSpan.FromSeconds(startSeconds),
+        EndTime = TimeSpan.FromSeconds(endSeconds),
+    };
+
+    [Fact]
+    public void IsSelected_InsideAndOutsideARange()
+    {
+        var helper = new IsSelectedHelper();
+        var selection = new List<SubtitleLineViewModel> { Line(10, 12) };
+
+        helper.Reset(selection, SampleRate, 5 * SampleRate, 20 * SampleRate);
+
+        Assert.False(helper.IsSelected((int)(9.5 * SampleRate)));
+        Assert.True(helper.IsSelected(10 * SampleRate));
+        Assert.True(helper.IsSelected(11 * SampleRate));
+        Assert.True(helper.IsSelected(12 * SampleRate));
+        Assert.False(helper.IsSelected((int)(12.5 * SampleRate)));
+    }
+
+    [Fact]
+    public void IsSelected_WalksMultipleRangesInOnePass()
+    {
+        var helper = new IsSelectedHelper();
+        var selection = new List<SubtitleLineViewModel> { Line(10, 11), Line(13, 14), Line(16, 17) };
+
+        helper.Reset(selection, SampleRate, 5 * SampleRate, 20 * SampleRate);
+
+        Assert.True(helper.IsSelected((int)(10.5 * SampleRate)));
+        Assert.False(helper.IsSelected(12 * SampleRate));
+        Assert.True(helper.IsSelected((int)(13.5 * SampleRate)));
+        Assert.False(helper.IsSelected(15 * SampleRate));
+        Assert.True(helper.IsSelected((int)(16.5 * SampleRate)));
+        Assert.False(helper.IsSelected(18 * SampleRate));
+    }
+
+    [Fact]
+    public void IsSelected_IgnoresSelectionOutsideTheWindow()
+    {
+        var helper = new IsSelectedHelper();
+        var selection = new List<SubtitleLineViewModel>
+        {
+            Line(0, 1),      // before the window
+            Line(30, 31),    // inside
+            Line(500, 501),  // after the window
+        };
+
+        helper.Reset(selection, SampleRate, 20 * SampleRate, 40 * SampleRate);
+
+        Assert.True(helper.IsSelected((int)(30.5 * SampleRate)));
+        Assert.False(helper.IsSelected(25 * SampleRate));
+        Assert.False(helper.IsSelected(35 * SampleRate));
+    }
+
+    [Fact]
+    public void IsSelected_KeepsRangesThatOnlyOverlapTheWindowEdges()
+    {
+        var helper = new IsSelectedHelper();
+        var selection = new List<SubtitleLineViewModel>
+        {
+            Line(10, 25),  // starts before the window, ends inside
+            Line(35, 60),  // starts inside, ends after the window
+        };
+
+        helper.Reset(selection, SampleRate, 20 * SampleRate, 40 * SampleRate);
+
+        Assert.True(helper.IsSelected(21 * SampleRate));
+        Assert.False(helper.IsSelected(30 * SampleRate));
+        Assert.True(helper.IsSelected(39 * SampleRate));
+    }
+
+    [Fact]
+    public void IsSelected_IsFalseWithoutSelection()
+    {
+        var helper = new IsSelectedHelper();
+
+        helper.Reset(new List<SubtitleLineViewModel>(), SampleRate, 0, 40 * SampleRate);
+
+        Assert.False(helper.IsSelected(0));
+        Assert.False(helper.IsSelected(10 * SampleRate));
+    }
+
+    [Fact]
+    public void Reset_ShrinkingSelection_DropsThePreviousRanges()
+    {
+        var helper = new IsSelectedHelper();
+        var selection = new List<SubtitleLineViewModel> { Line(10, 11), Line(13, 14) };
+
+        helper.Reset(selection, SampleRate, 5 * SampleRate, 20 * SampleRate);
+        Assert.True(helper.IsSelected((int)(13.5 * SampleRate)));
+
+        // The backing array is reused across resets, so a shorter selection must not leave the
+        // old ranges visible past the new count.
+        helper.Reset(new List<SubtitleLineViewModel> { Line(10, 11) }, SampleRate, 5 * SampleRate, 20 * SampleRate);
+
+        Assert.True(helper.IsSelected((int)(10.5 * SampleRate)));
+        Assert.False(helper.IsSelected((int)(13.5 * SampleRate)));
+    }
+}

--- a/tests/UI/Features/Main/SubtitleLineViewModelCacheTests.cs
+++ b/tests/UI/Features/Main/SubtitleLineViewModelCacheTests.cs
@@ -1,0 +1,138 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// <see cref="SubtitleLineViewModel.TextBackgroundBrush"/> memoizes its verdict across cell
+/// repaints, so these tests pin down that the memo still notices a changed setting (and a
+/// changed error colour) for an otherwise unchanged line.
+/// </summary>
+public class SubtitleLineViewModelCacheTests
+{
+    private static Color ColorOf(IBrush brush) => Assert.IsType<SolidColorBrush>(brush).Color;
+
+    [AvaloniaFact]
+    public void TextBackgroundBrush_FollowsMaxLineLengthChange()
+    {
+        var originalSettings = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.General.ColorTextTooLong = true;
+            Se.Settings.General.SubtitleLineMaximumLength = 100;
+
+            var vm = new SubtitleLineViewModel
+            {
+                Text = "Hello there, world.",
+                StartTime = TimeSpan.Zero,
+                EndTime = TimeSpan.FromSeconds(2),
+            };
+
+            Assert.Equal(Colors.Transparent, ColorOf(vm.TextBackgroundBrush));
+
+            Se.Settings.General.SubtitleLineMaximumLength = 5;
+
+            Assert.NotEqual(Colors.Transparent, ColorOf(vm.TextBackgroundBrush));
+        }
+        finally
+        {
+            Se.Settings = originalSettings;
+        }
+    }
+
+    [AvaloniaFact]
+    public void TextBackgroundBrush_FollowsMaxNumberOfLinesChange()
+    {
+        var originalSettings = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.General.ColorTextTooLong = false;
+            Se.Settings.General.ColorTextTooWide = false;
+            Se.Settings.General.ColorTextTooManyLines = true;
+            Se.Settings.General.MaxNumberOfLines = 3;
+
+            var vm = new SubtitleLineViewModel
+            {
+                Text = "Line one" + Environment.NewLine + "Line two",
+                StartTime = TimeSpan.Zero,
+                EndTime = TimeSpan.FromSeconds(2),
+            };
+
+            Assert.Equal(Colors.Transparent, ColorOf(vm.TextBackgroundBrush));
+
+            Se.Settings.General.MaxNumberOfLines = 1;
+
+            Assert.NotEqual(Colors.Transparent, ColorOf(vm.TextBackgroundBrush));
+        }
+        finally
+        {
+            Se.Settings = originalSettings;
+        }
+    }
+
+    [AvaloniaFact]
+    public void TextBackgroundBrush_FollowsErrorColorChange()
+    {
+        var originalSettings = Se.Settings;
+        var originalErrorColor = SubtitleLineViewModel.ErrorColor;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.General.ColorTextTooLong = true;
+            Se.Settings.General.SubtitleLineMaximumLength = 5;
+            SubtitleLineViewModel.ErrorColor = Colors.Red;
+
+            var vm = new SubtitleLineViewModel
+            {
+                Text = "Hello there, world.",
+                StartTime = TimeSpan.Zero,
+                EndTime = TimeSpan.FromSeconds(2),
+            };
+
+            Assert.Equal(Colors.Red, ColorOf(vm.TextBackgroundBrush));
+
+            SubtitleLineViewModel.ErrorColor = Colors.Green;
+
+            Assert.Equal(Colors.Green, ColorOf(vm.TextBackgroundBrush));
+        }
+        finally
+        {
+            SubtitleLineViewModel.ErrorColor = originalErrorColor;
+            Se.Settings = originalSettings;
+        }
+    }
+
+    [AvaloniaFact]
+    public void TextBackgroundBrush_FollowsTextChange()
+    {
+        var originalSettings = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.General.ColorTextTooLong = true;
+            Se.Settings.General.SubtitleLineMaximumLength = 10;
+
+            var vm = new SubtitleLineViewModel
+            {
+                Text = "Short",
+                StartTime = TimeSpan.Zero,
+                EndTime = TimeSpan.FromSeconds(2),
+            };
+
+            Assert.Equal(Colors.Transparent, ColorOf(vm.TextBackgroundBrush));
+
+            vm.Text = "A line that is clearly longer than ten characters.";
+
+            Assert.NotEqual(Colors.Transparent, ColorOf(vm.TextBackgroundBrush));
+        }
+        finally
+        {
+            Se.Settings = originalSettings;
+        }
+    }
+}

--- a/tests/UI/Features/Main/SubtitleMetricsRegressionTests.cs
+++ b/tests/UI/Features/Main/SubtitleMetricsRegressionTests.cs
@@ -1,3 +1,4 @@
+using Avalonia.Headless.XUnit;
 using Avalonia.Media;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Common.TextLengthCalculator;
@@ -65,7 +66,10 @@ public class SubtitleMetricsRegressionTests
         }
     }
 
-    [Fact]
+    // Reading SolidColorBrush.Color goes through Avalonia's dispatcher affinity check, so this
+    // one has to run on the UI thread - as a plain [Fact] it only passed when xUnit happened to
+    // schedule it there.
+    [AvaloniaFact]
     public void StrategyAwareLineLength_IsConsistentBetweenHighlightAndErrors()
     {
         var originalSettings = Se.Settings;

--- a/tests/UI/Logic/SubtitleTextInfoHelperPanelTests.cs
+++ b/tests/UI/Logic/SubtitleTextInfoHelperPanelTests.cs
@@ -1,0 +1,76 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// The single-line-length panel is refilled on every keystroke in the edit box, so it reuses the
+/// text blocks that are already there instead of clearing and rebuilding the panel. These tests
+/// pin down that reuse produces the same children as a rebuild would - in particular when the
+/// line count shrinks (leftover labels must go) and when an error highlight has to be dropped.
+/// </summary>
+public class SubtitleTextInfoHelperPanelTests
+{
+    private static List<string> LabelTexts(StackPanel panel)
+        => panel.Children.Cast<TextBlock>().Select(t => t.Text ?? string.Empty).ToList();
+
+    [AvaloniaFact]
+    public void Refill_WithFewerLines_DropsLeftoverLabels()
+    {
+        var panel = new StackPanel();
+        var header = Se.Language.Main.SingleLineLength;
+
+        SubtitleTextInfoHelper.FillLineLengthPanel(panel, new List<string> { "abc", "de", "f" }, false, 100);
+        Assert.Equal(new List<string> { header, "3", "/", "2", "/", "1" }, LabelTexts(panel));
+
+        SubtitleTextInfoHelper.FillLineLengthPanel(panel, new List<string> { "abcd" }, false, 100);
+        Assert.Equal(new List<string> { header, "4" }, LabelTexts(panel));
+
+        SubtitleTextInfoHelper.FillLineLengthPanel(panel, new List<string> { "ab", "cde" }, false, 100);
+        Assert.Equal(new List<string> { header, "2", "/", "3" }, LabelTexts(panel));
+    }
+
+    [AvaloniaFact]
+    public void Refill_ClearsErrorBackground_WhenLineIsNoLongerTooLong()
+    {
+        var panel = new StackPanel();
+
+        SubtitleTextInfoHelper.FillLineLengthPanel(panel, new List<string> { "abcdef" }, true, 3);
+        var lengthLabel = (TextBlock)panel.Children[1];
+        Assert.NotNull(lengthLabel.Background);
+
+        SubtitleTextInfoHelper.FillLineLengthPanel(panel, new List<string> { "ab" }, true, 3);
+        Assert.Same(lengthLabel, panel.Children[1]);
+        Assert.Null(lengthLabel.Background);
+    }
+
+    [AvaloniaFact]
+    public void Refill_ReusesTheSameTextBlockInstances()
+    {
+        var panel = new StackPanel();
+
+        SubtitleTextInfoHelper.FillLineLengthPanel(panel, new List<string> { "abc" }, false, 100);
+        var before = panel.Children.ToList();
+
+        SubtitleTextInfoHelper.FillLineLengthPanel(panel, new List<string> { "abcd" }, false, 100);
+
+        Assert.Equal(before, panel.Children.ToList());
+        Assert.Equal("4", ((TextBlock)panel.Children[1]).Text);
+    }
+
+    [AvaloniaFact]
+    public void Refill_ReplacesAForeignControl()
+    {
+        var panel = new StackPanel();
+        panel.Children.Add(new Border { Background = Brushes.Red });
+
+        SubtitleTextInfoHelper.FillLineLengthPanel(panel, new List<string> { "abc" }, false, 100);
+
+        Assert.Equal(new List<string> { Se.Language.Main.SingleLineLength, "3" }, LabelTexts(panel));
+    }
+}

--- a/tests/benchmarks/IsSelectedHelperBenchmarks.cs
+++ b/tests/benchmarks/IsSelectedHelperBenchmarks.cs
@@ -1,0 +1,60 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
+using Nikse.SubtitleEdit.Features.Main;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// Mirrors what the waveform's per-pixel loop does: reset the helper with the current
+/// selection, then probe it once per horizontal pixel with a monotonically increasing
+/// sample position. Runs on every waveform geometry rebuild (scroll / zoom / resize /
+/// selection change), so with "select all" on a large subtitle it is squarely in the
+/// scrolling hot path.
+/// </summary>
+[MemoryDiagnoser]
+public class IsSelectedHelperBenchmarks
+{
+    private const int SampleRate = 100;
+    private const int WidthPixels = 1600;
+
+    private readonly IsSelectedHelper _helper = new();
+    private List<SubtitleLineViewModel> _selection = new();
+    private double _startSample;
+    private double _samplesPerPixel;
+
+    [Params(1, 100, 5000)]
+    public int SelectedLines { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var all = SubtitleFactory.Make(Math.Max(SelectedLines, 1));
+        _selection = all;
+
+        // Show a ~40 second window somewhere in the middle of the selection.
+        var middle = all[all.Count / 2];
+        _startSample = middle.StartTime.TotalSeconds * SampleRate;
+        _samplesPerPixel = 40.0 * SampleRate / WidthPixels;
+    }
+
+    [Benchmark]
+    public void ResetOnly() => _helper.Reset(_selection, SampleRate, (int)_startSample, (int)(_startSample + WidthPixels * _samplesPerPixel));
+
+    [Benchmark]
+    public int ResetAndScan()
+    {
+        _helper.Reset(_selection, SampleRate, (int)_startSample, (int)(_startSample + WidthPixels * _samplesPerPixel));
+
+        var selected = 0;
+        for (var x = 0; x < WidthPixels; x++)
+        {
+            var pos = (int)(_startSample + x * _samplesPerPixel);
+            if (_helper.IsSelected(pos))
+            {
+                selected++;
+            }
+        }
+
+        return selected;
+    }
+}

--- a/tests/benchmarks/Program.cs
+++ b/tests/benchmarks/Program.cs
@@ -1,0 +1,5 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+
+public partial class Program;

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -1,0 +1,35 @@
+# UI benchmarks
+
+BenchmarkDotNet harness for the hot paths in the subtitle grid and the waveform. Deliberately
+**not** part of `SubtitleEdit.sln`: it references the UI app project, and a normal solution build
+should not pay for a benchmark host.
+
+Run everything:
+
+```bash
+dotnet run -c Release --project tests/benchmarks/UiBenchmarks.csproj -- --filter '*'
+```
+
+Run one class, quickly (3 iterations instead of the default ~15):
+
+```bash
+dotnet run -c Release --project tests/benchmarks/UiBenchmarks.csproj -- --filter '*IsSelectedHelper*' --job short
+```
+
+Reports land in `tests/benchmarks/BenchmarkDotNet.Artifacts/results/` (gitignored). Pass
+`--artifacts <dir>` to put them somewhere else.
+
+## What is covered
+
+| Benchmark | Hot path it stands in for |
+| --- | --- |
+| `IsSelectedHelperBenchmarks` | The waveform's per-pixel "is this sample selected" probe, run on every geometry rebuild (scroll / zoom / resize / selection change). |
+| `WaveformSelectionBenchmarks` | The selected-paragraph hash set that `DrawParagraphs` builds every frame. |
+| `SubtitleLineViewModelBenchmarks` | The row getters the grid re-reads as rows are recycled - text error highlight and CPS. |
+| `SubtitleGridSelectionBenchmarks` | What `SubtitleGridSelectionChanged` does per selection change: copy the selection, find the line's index. |
+| `WaveformBufferBenchmarks` | The 50 ms position timer's refill of the waveform's subtitle buffer. |
+
+Benchmarks that model a collection the app gets from Avalonia (e.g. `DataGrid.SelectedItems`)
+reproduce its interface surface rather than substituting a `List<T>` - `SelectedItems` only
+implements the non-generic `IList`, which is what makes `Cast<T>().ToList()` slow there, and a
+`List<T>` stand-in would silently measure LINQ's fast path instead.

--- a/tests/benchmarks/SubtitleFactory.cs
+++ b/tests/benchmarks/SubtitleFactory.cs
@@ -1,0 +1,38 @@
+using Nikse.SubtitleEdit.Features.Main;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+internal static class SubtitleFactory
+{
+    private static readonly string[] Sentences =
+    {
+        "It was the best of times, it was the worst of times.",
+        "<i>Are you coming with us?</i>",
+        "- No.\r\n- Then stay here and wait.",
+        "I told you already, this is not going to work out the way you think it will.",
+        "Hello.",
+        "{\\an8}Somewhere in Denmark",
+    };
+
+    /// <summary>Builds a realistic, start-time sorted list of subtitle lines.</summary>
+    public static List<SubtitleLineViewModel> Make(int count)
+    {
+        var list = new List<SubtitleLineViewModel>(count);
+        var startMs = 1000.0;
+        for (var i = 0; i < count; i++)
+        {
+            var text = Sentences[i % Sentences.Length];
+            var durationMs = 1200 + i % 7 * 350;
+            list.Add(new SubtitleLineViewModel
+            {
+                Number = i + 1,
+                Text = text,
+                StartTime = TimeSpan.FromMilliseconds(startMs),
+                EndTime = TimeSpan.FromMilliseconds(startMs + durationMs),
+            });
+            startMs += durationMs + 120;
+        }
+
+        return list;
+    }
+}

--- a/tests/benchmarks/SubtitleGridSelectionBenchmarks.cs
+++ b/tests/benchmarks/SubtitleGridSelectionBenchmarks.cs
@@ -1,0 +1,103 @@
+using System.Collections;
+using System.Collections.ObjectModel;
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Features.Main;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// The two allocations/scans that MainViewModel.SubtitleGridSelectionChanged does on every
+/// selection change - so on every arrow key, and on every Ctrl+A.
+/// </summary>
+[MemoryDiagnoser]
+public class SubtitleGridSelectionBenchmarks
+{
+    private ObservableCollection<SubtitleLineViewModel> _subtitles = new();
+    private IList _selectedItems = Array.Empty<SubtitleLineViewModel>();
+    private SubtitleLineViewModel _lastItem = new();
+
+    [Params(1000, 5000)]
+    public int Lines { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var lines = SubtitleFactory.Make(Lines);
+        _subtitles = new ObservableCollection<SubtitleLineViewModel>(lines);
+
+        // Worst case for IndexOf: the selected line sits at the end of the subtitle.
+        _lastItem = lines[^1];
+
+        // Avalonia's DataGridSelectedItemsCollection implements only the non-generic IList, so
+        // Enumerable.Cast cannot take its "already IEnumerable<T>" fast path and ToList cannot
+        // use ICollection<T>.CopyTo. Benchmarking a plain List<T> here would measure neither.
+        _selectedItems = new NonGenericList(lines);
+    }
+
+    /// <summary>Old: LINQ Cast + ToList (no capacity hint, extra iterator).</summary>
+    [Benchmark(Baseline = true)]
+    public int CastToList() => _selectedItems.Cast<SubtitleLineViewModel>().ToList().Count;
+
+    /// <summary>New: preallocated list, plain foreach.</summary>
+    [Benchmark]
+    public int PreallocatedCopy()
+    {
+        var list = new List<SubtitleLineViewModel>(_selectedItems.Count);
+        foreach (SubtitleLineViewModel item in _selectedItems)
+        {
+            list.Add(item);
+        }
+
+        return list.Count;
+    }
+
+    /// <summary>Preallocated list filled through AddRange(Cast&lt;T&gt;()).</summary>
+    [Benchmark]
+    public int PreallocatedAddRange()
+    {
+        var list = new List<SubtitleLineViewModel>(_selectedItems.Count);
+        list.AddRange(_selectedItems.Cast<SubtitleLineViewModel>());
+        return list.Count;
+    }
+
+    /// <summary>Only exposes the non-generic collection interfaces, like Avalonia's SelectedItems.</summary>
+    private sealed class NonGenericList : IList
+    {
+        private readonly List<SubtitleLineViewModel> _inner;
+
+        public NonGenericList(List<SubtitleLineViewModel> inner) => _inner = inner;
+
+        public int Count => _inner.Count;
+        public bool IsFixedSize => false;
+        public bool IsReadOnly => false;
+        public bool IsSynchronized => false;
+        public object SyncRoot => this;
+        public object? this[int index] { get => _inner[index]; set => throw new NotSupportedException(); }
+        public IEnumerator GetEnumerator() => _inner.GetEnumerator();
+        public int Add(object? value) => throw new NotSupportedException();
+        public void Clear() => throw new NotSupportedException();
+        public bool Contains(object? value) => throw new NotSupportedException();
+        public void CopyTo(Array array, int index) => throw new NotSupportedException();
+        public int IndexOf(object? value) => throw new NotSupportedException();
+        public void Insert(int index, object? value) => throw new NotSupportedException();
+        public void Remove(object? value) => throw new NotSupportedException();
+        public void RemoveAt(int index) => throw new NotSupportedException();
+    }
+
+    /// <summary>Old: linear scan through the whole ObservableCollection.</summary>
+    [Benchmark]
+    public int LinearIndexOf() => _subtitles.IndexOf(_lastItem);
+
+    /// <summary>New: trust the grid's own selected index, verify it, only then fall back.</summary>
+    [Benchmark]
+    public int HintedIndexOf()
+    {
+        var hinted = _subtitles.Count - 1;
+        if (hinted >= 0 && hinted < _subtitles.Count && ReferenceEquals(_subtitles[hinted], _lastItem))
+        {
+            return hinted;
+        }
+
+        return _subtitles.IndexOf(_lastItem);
+    }
+}

--- a/tests/benchmarks/SubtitleLineViewModelBenchmarks.cs
+++ b/tests/benchmarks/SubtitleLineViewModelBenchmarks.cs
@@ -1,0 +1,53 @@
+using Avalonia.Media;
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// The grid re-reads these getters on every cell repaint (scrolling the subtitle grid,
+/// any row invalidation), for every visible row.
+/// </summary>
+[MemoryDiagnoser]
+public class SubtitleLineViewModelBenchmarks
+{
+    private List<SubtitleLineViewModel> _lines = new();
+
+    /// <summary>Rows visible in the grid at once - that is how many getters run per repaint.</summary>
+    [Params(30)]
+    public int VisibleRows { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Se.Settings.General.ColorTextTooLong = true;
+        Se.Settings.General.ColorTextTooManyLines = true;
+        Se.Settings.General.ColorTextTooWide = false; // HarfBuzz shaping; measured separately
+        _lines = SubtitleFactory.Make(VisibleRows);
+    }
+
+    [Benchmark]
+    public IBrush TextBackgroundBrush()
+    {
+        IBrush? last = null;
+        for (var i = 0; i < _lines.Count; i++)
+        {
+            last = _lines[i].TextBackgroundBrush;
+        }
+
+        return last!;
+    }
+
+    [Benchmark]
+    public double CharactersPerSecond()
+    {
+        var sum = 0.0;
+        for (var i = 0; i < _lines.Count; i++)
+        {
+            sum += _lines[i].CharactersPerSecond;
+        }
+
+        return sum;
+    }
+}

--- a/tests/benchmarks/UiBenchmarks.csproj
+++ b/tests/benchmarks/UiBenchmarks.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Deliberately not part of SubtitleEdit.sln: it references the UI app project, and a full
+    solution build should not pay for a benchmark host. Run it explicitly:
+
+      dotnet run -c Release (project) tests/benchmarks/UiBenchmarks.csproj (filter) *
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>UiBenchmarks</AssemblyName>
+    <RootNamespace>Nikse.SubtitleEdit.Benchmarks</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\libse\LibSE.csproj" />
+    <ProjectReference Include="..\..\src\ui\UI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/benchmarks/WaveformBufferBenchmarks.cs
+++ b/tests/benchmarks/WaveformBufferBenchmarks.cs
@@ -1,0 +1,47 @@
+using System.Collections.ObjectModel;
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// MainViewModel's 50 ms position timer refills a scratch list with every subtitle line and then
+/// re-checks that it is still start-time sorted, 20 times a second, before handing it to the
+/// waveform. This measures what that per-tick pass actually costs.
+/// </summary>
+[MemoryDiagnoser]
+public class WaveformBufferBenchmarks
+{
+    private ObservableCollection<SubtitleLineViewModel> _subtitles = new();
+    private readonly List<SubtitleLineViewModel> _buffer = new();
+
+    [Params(1000, 5000, 20000)]
+    public int Lines { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _subtitles = new ObservableCollection<SubtitleLineViewModel>(SubtitleFactory.Make(Lines));
+        _buffer.Capacity = Lines;
+    }
+
+    [Benchmark]
+    public int RefillAndSortCheck()
+    {
+        var subtitle = _buffer;
+        subtitle.Clear();
+        if (subtitle.Capacity < _subtitles.Count)
+        {
+            subtitle.Capacity = _subtitles.Count;
+        }
+
+        for (var i = 0; i < _subtitles.Count; i++)
+        {
+            subtitle.Add(_subtitles[i]);
+        }
+
+        ListSortUtil.SortIfNeeded(subtitle, static (a, b) => a.StartTime.Ticks.CompareTo(b.StartTime.Ticks));
+        return subtitle.Count;
+    }
+}

--- a/tests/benchmarks/WaveformSelectionBenchmarks.cs
+++ b/tests/benchmarks/WaveformSelectionBenchmarks.cs
@@ -1,0 +1,62 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Features.Main;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// AudioVisualizer.DrawParagraphs builds a hash set of the selected paragraphs on every frame so
+/// the per-paragraph "am I selected" probe is O(1). Only paragraphs inside the visible window are
+/// ever probed, so hashing the whole selection is waste - these two benchmarks are the before and
+/// after of that filter.
+/// </summary>
+[MemoryDiagnoser]
+public class WaveformSelectionBenchmarks
+{
+    private readonly HashSet<SubtitleLineViewModel> _set = new();
+    private List<SubtitleLineViewModel> _selection = new();
+    private double _windowStartMs;
+    private double _windowEndMs;
+
+    [Params(1, 100, 5000)]
+    public int SelectedLines { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _selection = SubtitleFactory.Make(Math.Max(SelectedLines, 1));
+
+        // A ~40 second window in the middle, i.e. what fits on screen.
+        var middle = _selection[_selection.Count / 2];
+        _windowStartMs = middle.StartTime.TotalMilliseconds;
+        _windowEndMs = _windowStartMs + 40_000;
+    }
+
+    [Benchmark(Baseline = true)]
+    public int HashWholeSelection()
+    {
+        _set.Clear();
+        foreach (var selected in _selection)
+        {
+            _set.Add(selected);
+        }
+
+        return _set.Count;
+    }
+
+    [Benchmark]
+    public int HashVisibleWindowOnly()
+    {
+        _set.Clear();
+        for (var i = 0; i < _selection.Count; i++)
+        {
+            var selected = _selection[i];
+            if (selected.EndTime.TotalMilliseconds >= _windowStartMs &&
+                selected.StartTime.TotalMilliseconds <= _windowEndMs)
+            {
+                _set.Add(selected);
+            }
+        }
+
+        return _set.Count;
+    }
+}


### PR DESCRIPTION
Six performance fixes in the waveform render loop and the subtitle grid, each measured with a BenchmarkDotNet harness added under `tests/benchmarks`.

The harness is deliberately **not** in `SubtitleEdit.sln` — it references the UI app project, so a normal solution build should not pay for a benchmark host. See [tests/benchmarks/README.md](tests/benchmarks/README.md) for how to run it.

### Waveform

**`IsSelectedHelper.Reset` only loads the selection ranges that intersect the sample window about to be drawn.** `FindNextSelection` re-scans every loaded range whenever the per-pixel walk passes the current one, so a "select all" turned each geometry rebuild (scroll / zoom / resize / selection change) into O(pixels × selection). The filter is exact rather than an approximation: `IsSelected` is only ever asked about positions inside the window, and a range outside it can never contain one.

**`DrawParagraphs` only hashes the selected paragraphs inside the visible window.** The rest can never be probed, and two time compares are far cheaper than a `HashSet` insert.

**`DrawAllGridLines` caches its `StreamGeometry`.** It is a few hundred figures that depend only on width / height / zoom / scroll position / frame mode, but `Render` runs at ~60 fps while the cursor moves, so the whole geometry was rebuilt and thrown away every frame. Keyed on the view state and cleared in `ResetCache()` alongside the existing waveform caches.

### Subtitle grid

**`SubtitleLineViewModel.TextBackgroundBrush` memoizes its verdict**, the same read-time pattern the `CharactersPerSecond` / `WordsPerMinute` getters already use. The grid re-reads it on every cell repaint, and each read stripped html, split into lines and — with `ColorTextTooWide` on — shaped every line with HarfBuzz. Only the verdict is cached, never the brush, so a changed error colour still shows through; the key covers every setting the answer depends on, including the CPS line-length strategy. `PixelWidth` gets the same treatment.

**The single-line-length labels are rewritten in place** instead of Clear + rebuild. This runs on every keystroke in the edit box, and the old version dropped a handful of `TextBlock`s out of the logical and visual tree and re-added them each time. `MakeSubtitleTextInfoOriginal` now shares the same helper instead of duplicating the loop.

**`SubtitleGridSelectionChanged`** copies the selection into a preallocated list (`DataGrid.SelectedItems` implements only the non-generic `IList`, so `Cast<T>().ToList()` cannot use `ICollection<T>.CopyTo` and grows from empty), and resolves the line's index via the grid's own `SelectedIndex` before falling back to the linear scan.

### Measurements

Apple M4, .NET 10, BenchmarkDotNet 0.15.8. Waveform numbers are MediumRun (15 iterations × 2 launches); the `TextBackgroundBrush` before/after is ShortRun.

| Benchmark | Case | Before | After |
| --- | --- | --- | --- |
| `IsSelectedHelperBenchmarks` | 5000 selected lines, 1600 px | 82.1 µs | 11.6 µs |
| `WaveformSelectionBenchmarks` | 5000 selected lines | 35.3 µs | 8.7 µs |
| `WaveformSelectionBenchmarks` | 100 selected lines | 600 ns | 191 ns |
| `SubtitleLineViewModelBenchmarks` | 30 visible rows | 3055 ns / 3880 B | 145 ns / 0 B |
| `SubtitleGridSelectionBenchmarks` | index of, 5000 lines | 5.4 µs | 3.3 ns |
| `SubtitleGridSelectionBenchmarks` | copy selection, 5000 lines | 35.7 µs | 29.0 µs |

`DrawAllGridLines` and the label-panel reuse are not in the table — both need a live render / layout pass, so they are reasoned rather than measured. `WaveformBufferBenchmarks` covers the 50 ms position timer's buffer refill; it is included as a measurement only, nothing there was changed.

### Tests

813 UI tests + 694 libse tests pass. New coverage for the behavioural risk in each change:

- `IsSelectedHelperTests` — the window filtering, including ranges that only overlap an edge and a shrinking selection reusing the backing array.
- `SubtitleLineViewModelCacheTests` — the memo noticing a changed max line length, max lines, error colour and text.
- `SubtitleTextInfoHelperPanelTests` — label reuse across growing and shrinking line counts, dropping a stale error highlight, and replacing a foreign control.

Also switches `StrategyAwareLineLength_IsConsistentBetweenHighlightAndErrors` to `[AvaloniaFact]` — it reads `SolidColorBrush.Color`, which needs the UI thread, and only passed when xUnit happened to schedule it there.

Manually verified in the running app: waveform scroll/zoom with a large selection, grid lines while scrolling and toggling frame mode, error highlighting after changing the Options limits, and the length labels while typing across line-break changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
