### PR TITLE
Make Paragraph.Id a Guid? and speed up reading .srt files

### DIFF
--- a/src/libse/Common/Paragraph.cs
+++ b/src/libse/Common/Paragraph.cs
@@ -37,7 +37,17 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public int Layer { get; set; }
 
-        public string Id { get; }
+        /// <summary>
+        /// Identity of this paragraph, stable for its lifetime. Nullable so a paragraph can
+        /// explicitly carry "no id".
+        /// </summary>
+        /// <remarks>
+        /// A Guid rather than its string form: the value lives inline in the object, so reading a
+        /// subtitle no longer allocates a 36-char string per paragraph (~96 bytes each - a
+        /// measurable share of the allocation for loading a large file), and the callers that
+        /// compared ids no longer round-trip through string.
+        /// </remarks>
+        public Guid? Id { get; }
 
         public string Language { get; set; }
 
@@ -49,9 +59,9 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public bool IsDefault => Math.Abs(StartTime.TotalMilliseconds) < 0.01 && Math.Abs(EndTime.TotalMilliseconds) < 0.01 && string.IsNullOrEmpty(Text);
 
-        private static string GenerateId()
+        private static Guid GenerateId()
         {
-            return Guid.NewGuid().ToString();
+            return Guid.NewGuid();
         }
 
         public Paragraph() : this(new TimeCode(), new TimeCode(), string.Empty)

--- a/src/libse/Common/Subtitle.cs
+++ b/src/libse/Common/Subtitle.cs
@@ -91,7 +91,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             return Paragraphs[index];
         }
 
-        public Paragraph GetParagraphOrDefaultById(string id)
+        public Paragraph GetParagraphOrDefaultById(Guid? id)
         {
             return Paragraphs.Find(p => p.Id == id);
         }
@@ -832,10 +832,11 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// </summary>
         /// <param name="ids">IDs of paragraphs/lines to delete</param>
         /// <returns>Number of lines deleted</returns>
-        public int RemoveParagraphsByIds(IEnumerable<string> ids)
+        public int RemoveParagraphsByIds(IEnumerable<Guid?> ids)
         {
             var beforeCount = Paragraphs.Count;
-            Paragraphs = Paragraphs.Where(p => !ids.Contains(p.Id)).ToList();
+            var idSet = new HashSet<Guid?>(ids);
+            Paragraphs = Paragraphs.Where(p => !idSet.Contains(p.Id)).ToList();
             return beforeCount - Paragraphs.Count;
         }
 
@@ -860,7 +861,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                     Paragraphs = Paragraphs.OrderBy(p => p.DurationTotalMilliseconds).ThenBy(p => p.Number).ToList();
                     break;
                 case SubtitleSortCriteria.Gap:
-                    var lookupDictionary = new Dictionary<string, double>();
+                    var lookupDictionary = new Dictionary<Guid?, double>();
                     for (var index = 0; index < Paragraphs.Count; index++)
                     {
                         var paragraph = Paragraphs[index];

--- a/src/libse/Forms/DurationsBridgeGaps.cs
+++ b/src/libse/Forms/DurationsBridgeGaps.cs
@@ -7,7 +7,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
 {
     public static class DurationsBridgeGaps
     {
-        public static int BridgeGaps(Subtitle subtitle, int minMsBetweenLines, bool divideEven, double maxMs, List<int> fixedIndexes, Dictionary<string, string> dic, bool useFrames)
+        public static int BridgeGaps(Subtitle subtitle, int minMsBetweenLines, bool divideEven, double maxMs, List<int> fixedIndexes, Dictionary<Guid?, string> dic, bool useFrames)
         {
             int fixedCount = 0;
             if (minMsBetweenLines > maxMs)

--- a/src/libse/SubtitleFormats/SubRip.cs
+++ b/src/libse/SubtitleFormats/SubRip.cs
@@ -226,12 +226,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             line = _regExWsrtItalicEnd.Replace(line, "</i>");
                         }
 
-                        if (_paragraph.Text.Length > 0)
-                        {
-                            _paragraph.Text += Environment.NewLine;
-                        }
-
-                        _paragraph.Text += line.Replace('\0', ' ').TrimEnd();
+                        // One string.Concat instead of two "+=" - appending the newline and the
+                        // text separately allocated an extra intermediate string per text line.
+                        var textToAppend = line.Replace('\0', ' ').TrimEnd();
+                        _paragraph.Text = _paragraph.Text.Length == 0
+                            ? textToAppend
+                            : _paragraph.Text + Environment.NewLine + textToAppend;
 
                         if (string.IsNullOrWhiteSpace(line) && Utilities.IsInteger(next) && TryReadTimeCodesLine(nextNext, null, false))
                         {
@@ -280,6 +280,21 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         private bool TryReadTimeCodesLine(string input, Paragraph paragraph, bool validate)
         {
             if (string.IsNullOrEmpty(input) || input.Length < 10)
+            {
+                return false;
+            }
+
+            // No '>' means this cannot be a time code line, so bail before the normalization
+            // below. Exact, not a heuristic: to return true the code must get past step 7 ('-')
+            // and step 8 ('>') of IsValidTimeCode *and* split into 8 numeric groups, which only
+            // the "-->" separator produces - and every separator variant normalized below
+            // ("->", "—>", "-->>", ...) contains '>' too, as does a bare ">". None of the other
+            // replacements can introduce one.
+            //
+            // Without this, any ordinary subtitle line that merely starts with a digit ("1999
+            // was a long time ago.") fell through to the ~20 allocating Replace calls, twice per
+            // line - and once more per neighbouring blank line via IsText.
+            if (input.IndexOf('>') < 0)
             {
                 return false;
             }

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -163,7 +163,7 @@ public partial class SubtitleLineViewModel : ObservableObject
         StartTime = TimeSpan.FromMilliseconds(paragraph.StartTime.TotalMilliseconds);
         EndTime = TimeSpan.FromMilliseconds(paragraph.EndTime.TotalMilliseconds);
         UpdateDuration();
-        Id = Guid.TryParse(paragraph.Id, out var guid) ? guid : Guid.NewGuid();
+        Id = paragraph.Id ?? Guid.NewGuid();
         Paragraph = paragraph;
         Bookmark = paragraph.Bookmark;
 

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -793,7 +793,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
             return true;
         }
 
-        var allowFix = Fixes.Any(f => f.Paragraph.Id.ToLowerInvariant() == p.Id.ToLowerInvariant() && f.Action == action && f.IsSelected);
+        var allowFix = Fixes.Any(f => f.Paragraph.Id == p.Id && f.Action == action && f.IsSelected);
         return allowFix;
     }
 
@@ -804,7 +804,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
             return;
         }
 
-        var oldFix = _oldFixes.FirstOrDefault(f => f.Paragraph.Id.ToLowerInvariant() == p.Id.ToLowerInvariant() && f.Action == action);
+        var oldFix = _oldFixes.FirstOrDefault(f => f.Paragraph.Id == p.Id && f.Action == action);
         var isSelected = oldFix is not { IsSelected: false };
 
         AddFix(new FixDisplayItem(p, p.Number, action, before, after, isSelected));
@@ -817,7 +817,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
             return;
         }
 
-        var oldFix = _oldFixes.FirstOrDefault(f => f.Paragraph.Id.ToLowerInvariant() == p.Id.ToLowerInvariant() && f.Action == action);
+        var oldFix = _oldFixes.FirstOrDefault(f => f.Paragraph.Id == p.Id && f.Action == action);
         var isSelected = isChecked;
         if (oldFix is { IsSelected: false })
         {

--- a/tests/benchmarks/SubRipBenchmarks.cs
+++ b/tests/benchmarks/SubRipBenchmarks.cs
@@ -1,0 +1,109 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// Reading an .srt file. Note that opening a file runs this twice: format detection calls
+/// <see cref="SubRip.IsMine"/>, which parses the whole thing, and the winning format is then
+/// asked to parse it again.
+/// </summary>
+[MemoryDiagnoser]
+public class SubRipBenchmarks
+{
+    private List<string> _canonicalLines = new();
+    private List<string> _messyLines = new();
+
+    [Params(1000, 10000)]
+    public int Paragraphs { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _canonicalLines = MakeLines(canonical: true);
+        _messyLines = MakeLines(canonical: false);
+    }
+
+    private List<string> MakeLines(bool canonical)
+    {
+        var texts = new[]
+        {
+            "It was the best of times, it was the worst of times.",
+            "<i>Are you coming with us?</i>",
+            "- No.|- Then stay here and wait.",
+            "1999 was a very long time ago.",
+            "Hello.",
+        };
+
+        var lines = new List<string>(Paragraphs * 4);
+        var startMs = 1000;
+        for (var i = 0; i < Paragraphs; i++)
+        {
+            var endMs = startMs + 2000;
+            lines.Add((i + 1).ToString());
+            lines.Add(canonical
+                ? $"{Format(startMs)} --> {Format(endMs)}"
+                // Separator and decimal-point variants the tolerant path has to normalize.
+                : $"{Format(startMs).Replace(',', '.')} -> {Format(endMs).Replace(',', '.')}");
+
+            foreach (var textLine in texts[i % texts.Length].Split('|'))
+            {
+                lines.Add(textLine);
+            }
+
+            lines.Add(string.Empty);
+            startMs = endMs + 100;
+        }
+
+        return lines;
+    }
+
+    private static string Format(int totalMs)
+    {
+        var ms = totalMs % 1000;
+        var totalSeconds = totalMs / 1000;
+        return $"{totalSeconds / 3600:00}:{totalSeconds / 60 % 60:00}:{totalSeconds % 60:00},{ms:000}";
+    }
+
+    [Benchmark]
+    public int LoadCanonical()
+    {
+        var subtitle = new Subtitle();
+        new SubRip().LoadSubtitle(subtitle, _canonicalLines, "test.srt");
+        return subtitle.Paragraphs.Count;
+    }
+
+    [Benchmark]
+    public bool IsMineCanonical() => new SubRip().IsMine(_canonicalLines, "test.srt");
+
+    /// <summary>
+    /// The app's real load path: MainViewModel builds a SubtitleLineViewModel per paragraph and
+    /// each one reads Paragraph.Id (SubtitleLineViewModel.cs:166). Kept as its own benchmark so a
+    /// future change to how ids are minted shows up here as well as in LoadCanonical.
+    /// </summary>
+    [Benchmark]
+    public int LoadCanonicalAndReadIds()
+    {
+        var subtitle = new Subtitle();
+        new SubRip().LoadSubtitle(subtitle, _canonicalLines, "test.srt");
+        var total = 0;
+        foreach (var p in subtitle.Paragraphs)
+        {
+            if (p.Id.HasValue)
+            {
+                total++;
+            }
+        }
+
+        return total;
+    }
+
+    [Benchmark]
+    public int LoadMessySeparators()
+    {
+        var subtitle = new Subtitle();
+        new SubRip().LoadSubtitle(subtitle, _messyLines, "test.srt");
+        return subtitle.Paragraphs.Count;
+    }
+}

--- a/tests/libse/Core/SubtitleTest.cs
+++ b/tests/libse/Core/SubtitleTest.cs
@@ -16,7 +16,7 @@ public class SubtitleTest
         sub.Paragraphs.Add(p2);
         sub.Paragraphs.Add(p3);
 
-        int removedCount = sub.RemoveParagraphsByIds(new List<string> { p2.Id });
+        int removedCount = sub.RemoveParagraphsByIds(new List<Guid?> { p2.Id });
         Assert.Equal(1, removedCount);
         Assert.Equal(2, sub.Paragraphs.Count);
         Assert.Equal(sub.Paragraphs[0], p1);
@@ -34,7 +34,7 @@ public class SubtitleTest
         sub.Paragraphs.Add(p2);
         sub.Paragraphs.Add(p3);
 
-        int removedCount = sub.RemoveParagraphsByIds(new List<string> { p2.Id, p3.Id });
+        int removedCount = sub.RemoveParagraphsByIds(new List<Guid?> { p2.Id, p3.Id });
         Assert.Equal(2, removedCount);
         Assert.Single(sub.Paragraphs);
         Assert.Equal(sub.Paragraphs[0], p1);


### PR DESCRIPTION
Makes `Paragraph.Id` a `Guid?` instead of a `string`, plus two fixes in the SubRip reader found while measuring. Two commits so they can be judged independently.

**⚠️ Breaking change for libse consumers** — `Paragraph.Id`, `Subtitle.RemoveParagraphsByIds`, `Subtitle.GetParagraphOrDefaultById` and `DurationsBridgeGaps.BridgeGaps` all change signature.

### `Paragraph.Id` → `Guid?`

Reading a subtitle allocated a 36-char string per paragraph (~96 bytes) just to hold the id. A `Guid` lives inline in the object, so that allocation goes away. It is still generated eagerly in the constructor, so identity behaviour is unchanged. Nullable so a paragraph can carry "no id" explicitly rather than needing `Guid.Empty` as a sentinel.

This does **not** remove the cost of *minting* the id — see the note at the bottom.

Three call sites get simpler rather than more awkward:

- [SubtitleLineViewModel.cs:166](../blob/perf/srt-read/src/ui/Features/Main/SubtitleLineViewModel.cs#L166) round-tripped Guid → string → Guid, because its own `Id` is already a `Guid`. Now a plain copy.
- [FixCommonErrorsViewModel.cs:796](../blob/perf/srt-read/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs#L796) (and 807, 820) compared ids with `ToLowerInvariant()` on both sides — two string allocations per comparison, inside an `Any()` over all fixes. Now `==`.
- `Subtitle.RemoveParagraphsByIds` took an `IEnumerable<string>` and called `Contains` on it per paragraph (O(n·m)); it now builds a `HashSet` once.

### SubRip reader

`TryReadTimeCodesLine` returns early when the line contains no `'>'`. Any ordinary subtitle line that merely *starts with a digit* ("1999 was a long time ago.") previously fell through to the ~20 allocating `Replace` calls of the tolerant normalization — twice per line, plus once more per neighbouring blank line via `IsText`.

Exact rather than a heuristic: returning true requires getting past step 7 (`'-'`) and step 8 (`'>'`) of `IsValidTimeCode` **and** splitting into 8 numeric groups, which only `-->` produces. Every separator variant the normalization accepts contains `'>'` too (`->`, `—>`, `——>`, `- >`, `->>`, `-- >`, `- ->`, `-->>`, `--->`, and a bare `>`), and none of the other replacements can introduce one.

Also collapses the two `Text +=` appends into one `string.Concat`.

### Measurements

Apple M4, .NET 10, BenchmarkDotNet 0.15.8, default job (StdDev ≤ 70 µs). 10 000 paragraphs ≈ 40 000 lines. New `SubRipBenchmarks` in the existing harness.

| `LoadCanonical` | Mean | Allocated |
| --- | --- | --- |
| before | 4195.9 µs | 4963.8 KB |
| + SubRip fixes | 3737.4 µs | 3901.3 KB |
| + `Guid?` id | **3519.6 µs** | **3041.9 KB** |

**16% faster, 39% less allocation.** `LoadMessySeparators` (a file using `.` for `,` and `->` for `-->`) goes 15 449 → 13 919 µs and 31 994 → 30 072 KB.

The `Guid?` step improves time as well as allocation, which is GC pressure: Gen0 collections per 1000 ops drop 476 → 371, Gen1 297 → 184.

`LoadCanonicalAndReadIds` exists because the app's real load path reads every id when building view models; it now matches `LoadCanonical` (3506.8 vs 3519.6 µs), i.e. reading ids is free.

694 libse + 813 UI tests pass.

### Still on the table

Found while measuring, deliberately not in this PR:

1. **`Guid.NewGuid()` is now the largest single cost of reading an .srt — ~187 ns × paragraph ≈ 1.9 ms of the remaining 3.5 ms.** This PR removed the string, not the generation. Either mint lazily, or use a per-process random base plus an interlocked counter (measured 202 → 24.6 ns, still a valid Guid, thread-safe, unique by construction in-process).
2. **Opening a file parses it twice** — `IsMine` runs a full `LoadSubtitle` and throws it away. It only needs `Paragraphs.Count > _errorCount`, so it could stop early.
3. **The tolerant time-code normalization allocates ~10 strings per call, ~3 calls per paragraph** — that is the whole messy-file cost. A span-based parser covering the common deviations would skip it.
4. **`new Paragraph()` allocates two `TimeCode` objects that `TryReadTimeCodesLine` immediately replaces** — `TimeCode` is a class, so parsing costs 4 allocations where 2 would do.
5. **`GetLastNumber` allocates a string per blank separator line.** An int comparison would change `"007"` vs `"7"` semantics, so it needs a decision.
6. **`Utilities.IsInteger` is `int.TryParse`**, called ~4–5× per line (≈200 000 times for a 40 000-line file). A digit scan is cheaper but drops the sign/whitespace tolerance.
7. **`BridgeGapsViewModel` still `.ToString()`s a Guid per row** to probe a `Dictionary<string, string>` in the UI-side `DurationsBridgeGaps2`, which could now match libse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
