### PR TITLE
Deduplicate TimeCode's frame formatters and make three Subtitle operations linear

### DIFF
--- a/src/libse/Common/Subtitle.cs
+++ b/src/libse/Common/Subtitle.cs
@@ -430,9 +430,13 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public void AdjustDisplayTimeUsingPercent(double percent, List<int> selectedIndexes, List<double> shotChanges = null, bool enforceDurationLimits = true)
         {
+            // List.Contains per paragraph made this O(paragraphs * selection) - quadratic with
+            // "select all". The ascending walk has to stay: each iteration reads the next
+            // paragraph's (possibly already adjusted) start time.
+            var selected = selectedIndexes == null ? null : new HashSet<int>(selectedIndexes);
             for (int i = 0; i < Paragraphs.Count; i++)
             {
-                if (selectedIndexes == null || selectedIndexes.Contains(i))
+                if (selected == null || selected.Contains(i))
                 {
                     double nextStartMilliseconds = double.MaxValue;
                     if (i + 1 < Paragraphs.Count)
@@ -630,9 +634,12 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public void SetFixedDuration(List<int> selectedIndexes, double fixedDurationMilliseconds, List<double> shotChanges = null)
         {
+            // See AdjustDisplayTimeUsingPercent: probing a set instead of the list keeps this
+            // linear when the whole subtitle is selected.
+            var selected = selectedIndexes == null ? null : new HashSet<int>(selectedIndexes);
             for (var i = 0; i < Paragraphs.Count; i++)
             {
-                if (selectedIndexes == null || selectedIndexes.Contains(i))
+                if (selected == null || selected.Contains(i))
                 {
                     var p = GetParagraphOrDefault(i);
                     if (p == null)
@@ -790,14 +797,10 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
 
             var firstNumber = Paragraphs[0].Number;
-            for (var i = Paragraphs.Count - 1; i >= 0; i--)
-            {
-                var p = Paragraphs[i];
-                if (p.Text.IsOnlyControlCharactersOrWhiteSpace())
-                {
-                    Paragraphs.RemoveAt(i);
-                }
-            }
+
+            // RemoveAt shifts every following element, so removing k lines one at a time was
+            // O(paragraphs * k). RemoveAll compacts in a single pass.
+            Paragraphs.RemoveAll(p => p.Text.IsOnlyControlCharactersOrWhiteSpace());
 
             if (count != Paragraphs.Count)
             {

--- a/src/libse/Common/TimeCode.cs
+++ b/src/libse/Common/TimeCode.cs
@@ -362,93 +362,47 @@ namespace Nikse.SubtitleEdit.Core.Common
             return pre + s;
         }
 
-        public string ToHHMMSSFF()
+        public string ToHHMMSSFF() => ToFrameString(':');
+
+        public string ToHHMMSS() => ToFrameString(':', includeFrames: false);
+
+        public string ToHHMMSSFFDropFrame() => ToFrameString(';');
+
+        public string ToSSFF() => ToFrameString(':', includeHoursAndMinutes: false);
+
+        public string ToHHMMSSPeriodFF() => ToFrameString('.');
+
+        // The five frame-based formats above were five copies of this method that differed only
+        // in the separator and which components they include - including the "rounds up to a whole
+        // second" carry, which is easy to get subtly wrong in one copy only.
+        private string ToFrameString(char frameSeparator, bool includeHoursAndMinutes = true, bool includeFrames = true)
         {
-            string s;
             var ts = TimeSpan;
             var frameRate = Configuration.Settings.General.CurrentFrameRate;
             var frames = Math.Round(ts.Milliseconds / (BaseUnit / frameRate));
-            if (frames >= frameRate - 0.001)
-            {
-                var newTs = ts.Add(new TimeSpan(0, 0, 1));
-                s = FormatFrameTime(newTs.Days * 24 + newTs.Hours, newTs.Minutes, newTs.Seconds, 0, ':');
-            }
-            else
-            {
-                s = FormatFrameTime(ts.Days * 24 + ts.Hours, ts.Minutes, ts.Seconds, SubtitleFormat.MillisecondsToFramesMaxFrameRate(ts.Milliseconds), ':');
-            }
 
-            return PrefixSign(s);
-        }
-
-        public string ToHHMMSS()
-        {
             string s;
-            var ts = TimeSpan;
-            var frameRate = Configuration.Settings.General.CurrentFrameRate;
-            var frames = Math.Round(ts.Milliseconds / (BaseUnit / frameRate));
             if (frames >= frameRate - 0.001)
             {
-                var newTs = ts.Add(new TimeSpan(0, 0, 1));
-                s = FormatFrameTime(newTs.Days * 24 + newTs.Hours, newTs.Minutes, newTs.Seconds, 0, ':', includeFrames: false);
+                // Carry into the next second. ToSSFF deliberately does not carry into
+                // minutes/hours, matching what it did as a separate method.
+                if (includeHoursAndMinutes)
+                {
+                    var newTs = ts.Add(new TimeSpan(0, 0, 1));
+                    s = FormatFrameTime(newTs.Days * 24 + newTs.Hours, newTs.Minutes, newTs.Seconds, 0, frameSeparator, true, includeFrames);
+                }
+                else
+                {
+                    s = FormatFrameTime(0, 0, ts.Seconds + 1, 0, frameSeparator, false, includeFrames);
+                }
             }
             else
             {
-                s = FormatFrameTime(ts.Days * 24 + ts.Hours, ts.Minutes, ts.Seconds, 0, ':', includeFrames: false);
-            }
-            return PrefixSign(s);
-        }
-
-        public string ToHHMMSSFFDropFrame()
-        {
-            string s;
-            var ts = TimeSpan;
-            var frameRate = Configuration.Settings.General.CurrentFrameRate;
-            var frames = Math.Round(ts.Milliseconds / (BaseUnit / frameRate));
-            if (frames >= frameRate - 0.001)
-            {
-                var newTs = ts.Add(new TimeSpan(0, 0, 1));
-                s = FormatFrameTime(newTs.Days * 24 + newTs.Hours, newTs.Minutes, newTs.Seconds, 0, ';');
-            }
-            else
-            {
-                s = FormatFrameTime(ts.Days * 24 + ts.Hours, ts.Minutes, ts.Seconds, SubtitleFormat.MillisecondsToFramesMaxFrameRate(ts.Milliseconds), ';');
-            }
-            return PrefixSign(s);
-        }
-
-        public string ToSSFF()
-        {
-            string s;
-            var ts = TimeSpan;
-            var frameRate = Configuration.Settings.General.CurrentFrameRate;
-            var frames = Math.Round(ts.Milliseconds / (BaseUnit / frameRate));
-            if (frames >= frameRate - 0.001)
-            {
-                s = FormatFrameTime(0, 0, ts.Seconds + 1, 0, ':', includeHoursAndMinutes: false);
-            }
-            else
-            {
-                s = FormatFrameTime(0, 0, ts.Seconds, SubtitleFormat.MillisecondsToFramesMaxFrameRate(ts.Milliseconds), ':', includeHoursAndMinutes: false);
-            }
-
-            return PrefixSign(s);
-        }
-
-        public string ToHHMMSSPeriodFF()
-        {
-            string s;
-            var ts = TimeSpan;
-            var frameRate = Configuration.Settings.General.CurrentFrameRate;
-            var frames = Math.Round(ts.Milliseconds / (BaseUnit / frameRate));
-            if (frames >= frameRate - 0.001)
-            {
-                var newTs = ts.Add(new TimeSpan(0, 0, 1));
-                s = FormatFrameTime(newTs.Days * 24 + newTs.Hours, newTs.Minutes, newTs.Seconds, 0, '.');
-            }
-            else
-            {
-                s = FormatFrameTime(ts.Days * 24 + ts.Hours, ts.Minutes, ts.Seconds, SubtitleFormat.MillisecondsToFramesMaxFrameRate(ts.Milliseconds), '.');
+                // ToHHMMSS drops the frame component entirely, so it never computed one.
+                var frameComponent = includeFrames ? SubtitleFormat.MillisecondsToFramesMaxFrameRate(ts.Milliseconds) : 0;
+                s = includeHoursAndMinutes
+                    ? FormatFrameTime(ts.Days * 24 + ts.Hours, ts.Minutes, ts.Seconds, frameComponent, frameSeparator, true, includeFrames)
+                    : FormatFrameTime(0, 0, ts.Seconds, frameComponent, frameSeparator, false, includeFrames);
             }
 
             return PrefixSign(s);
@@ -481,7 +435,37 @@ namespace Nikse.SubtitleEdit.Core.Common
             return new string(buffer.Slice(0, pos));
         }
 
-        private string PrefixSign(string time) => TotalMilliseconds >= 0 ? time : $"-{time.RemoveChar('-')}";
+        // The negative path used to be $"-{time.RemoveChar('-')}", which allocated a char[], the
+        // stripped string and the interpolated result on top of the string being fixed up - 208
+        // bytes where the positive path costs 48. Write the sign and the kept characters straight
+        // into one buffer instead. The formatters above never produce a time longer than their
+        // stack buffers, so a rented span is not worth it.
+        private string PrefixSign(string time)
+        {
+            if (TotalMilliseconds >= 0)
+            {
+                return time;
+            }
+
+            const int maxStackChars = 64;
+            if (time.Length >= maxStackChars)
+            {
+                return "-" + time.RemoveChar('-'); // not reachable from the formatters; no unbounded stackalloc
+            }
+
+            Span<char> buffer = stackalloc char[time.Length + 1];
+            buffer[0] = '-';
+            var pos = 1;
+            foreach (var c in time)
+            {
+                if (c != '-')
+                {
+                    buffer[pos++] = c;
+                }
+            }
+
+            return new string(buffer.Slice(0, pos));
+        }
 
         public string ToDisplayString()
         {

--- a/tests/benchmarks/SubtitleBenchmarks.cs
+++ b/tests/benchmarks/SubtitleBenchmarks.cs
@@ -1,0 +1,78 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// Subtitle-level bulk operations. The "selected indices" ones are what "adjust display time" and
+/// "set fixed duration" run when the user has a large selection - typically Ctrl+A.
+/// </summary>
+[MemoryDiagnoser]
+public class SubtitleBenchmarks
+{
+    private List<Paragraph> _source = new();
+    private List<int> _allIndices = new();
+
+    [Params(1000, 5000)]
+    public int Lines { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _source = new List<Paragraph>(Lines);
+        var startMs = 1000.0;
+        for (var i = 0; i < Lines; i++)
+        {
+            var text = i % 9 == 0 ? "   " : "Line number " + (i + 1);
+            _source.Add(new Paragraph(text, startMs, startMs + 1800));
+            startMs += 2000;
+        }
+
+        _allIndices = Enumerable.Range(0, Lines).ToList();
+    }
+
+    private Subtitle Fresh()
+    {
+        var s = new Subtitle();
+        foreach (var p in _source)
+        {
+            s.Paragraphs.Add(new Paragraph(p, false));
+        }
+
+        return s;
+    }
+
+    [Benchmark]
+    public int AdjustDisplayTimeUsingPercent()
+    {
+        var s = Fresh();
+        s.AdjustDisplayTimeUsingPercent(120, _allIndices);
+        return s.Paragraphs.Count;
+    }
+
+    [Benchmark]
+    public int SetFixedDuration()
+    {
+        var s = Fresh();
+        s.SetFixedDuration(_allIndices, 2000);
+        return s.Paragraphs.Count;
+    }
+
+    [Benchmark]
+    public int RemoveEmptyLines()
+    {
+        var s = Fresh();
+        return s.RemoveEmptyLines();
+    }
+
+    [Benchmark]
+    public int GetFastHashCode()
+    {
+        var s = Fresh();
+        return s.GetFastHashCode(string.Empty);
+    }
+
+    /// <summary>Baseline for the three above: how much of them is just building the subtitle.</summary>
+    [Benchmark]
+    public int BuildOnly() => Fresh().Paragraphs.Count;
+}

--- a/tests/benchmarks/TimeCodeBenchmarks.cs
+++ b/tests/benchmarks/TimeCodeBenchmarks.cs
@@ -1,0 +1,40 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// TimeCode's display and parse paths. The ToString family runs for every start/end/duration/gap
+/// cell the subtitle grid repaints and for the waveform paragraph labels; ParseToMilliseconds is
+/// the shared parse entry for many format importers, called per line while loading.
+/// </summary>
+[MemoryDiagnoser]
+public class TimeCodeBenchmarks
+{
+    private readonly TimeCode _tc = new TimeCode(1, 23, 45, 678);
+    private readonly TimeCode _short = new TimeCode(0, 0, 2, 500);
+    private readonly TimeCode _negative = new TimeCode(-90_000);
+
+    [Benchmark] public string ToStringInvariant() => _tc.ToString(false);
+    [Benchmark] public string ToStringLocalized() => _tc.ToString(true);
+    [Benchmark] public string ToShortStringLocalized() => _short.ToShortString(true);
+    [Benchmark] public string ToStringNegative() => _negative.ToString(false);
+    [Benchmark] public string ToHHMMSSFF() => _tc.ToHHMMSSFF();
+    [Benchmark] public string ToShortStringHHMMSSFF() => _tc.ToShortStringHHMMSSFF();
+
+    /// <summary>Every component getter builds its own TimeSpan from TotalMilliseconds.</summary>
+    [Benchmark]
+    public int ReadAllComponents() => _tc.Hours + _tc.Minutes + _tc.Seconds + _tc.Milliseconds;
+
+    /// <summary>What SubRip's ms-as-frames fixup does per paragraph: read then write.</summary>
+    [Benchmark]
+    public double RoundTripMilliseconds()
+    {
+        var tc = new TimeCode(3_723_456);
+        tc.Milliseconds = tc.Milliseconds;
+        return tc.TotalMilliseconds;
+    }
+
+    [Benchmark] public double ParseToMilliseconds() => TimeCode.ParseToMilliseconds("01:23:45,678");
+    [Benchmark] public double ParseHHMMSSFF() => TimeCode.ParseHHMMSSFFToMilliseconds("01:23:45:12");
+}

--- a/tests/libse/Core/SubtitleBulkOperationTests.cs
+++ b/tests/libse/Core/SubtitleBulkOperationTests.cs
@@ -1,0 +1,120 @@
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace LibSETests.Core;
+
+/// <summary>
+/// AdjustDisplayTimeUsingPercent and SetFixedDuration probe a set of selected indices rather than
+/// the caller's list, and RemoveEmptyLines compacts in one pass. These pin the behaviour that
+/// makes those safe: only selected lines move, the ascending walk still sees the neighbour it just
+/// adjusted, indices outside the subtitle are ignored, and renumbering survives.
+/// </summary>
+public class SubtitleBulkOperationTests
+{
+    private static Subtitle Make(params (double startMs, double endMs)[] times)
+    {
+        var s = new Subtitle();
+        var number = 1;
+        foreach (var (startMs, endMs) in times)
+        {
+            s.Paragraphs.Add(new Paragraph("Line " + number, startMs, endMs) { Number = number });
+            number++;
+        }
+
+        return s;
+    }
+
+    [Fact]
+    public void AdjustDisplayTimeUsingPercent_OnlyTouchesSelectedLines()
+    {
+        var s = Make((0, 1000), (5000, 6000), (10_000, 11_000));
+
+        s.AdjustDisplayTimeUsingPercent(200, new List<int> { 1 }, enforceDurationLimits: false);
+
+        Assert.Equal(1000, s.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal(7000, s.Paragraphs[1].EndTime.TotalMilliseconds);
+        Assert.Equal(11_000, s.Paragraphs[2].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void AdjustDisplayTimeUsingPercent_IgnoresIndicesOutsideTheSubtitle()
+    {
+        var s = Make((0, 1000), (5000, 6000));
+
+        s.AdjustDisplayTimeUsingPercent(200, new List<int> { -5, 0, 99 }, enforceDurationLimits: false);
+
+        Assert.Equal(2000, s.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal(6000, s.Paragraphs[1].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void AdjustDisplayTimeUsingPercent_AcceptsAnUnsortedSelection()
+    {
+        var ascending = Make((0, 1000), (5000, 6000), (10_000, 11_000));
+        var descending = Make((0, 1000), (5000, 6000), (10_000, 11_000));
+
+        ascending.AdjustDisplayTimeUsingPercent(150, new List<int> { 0, 1, 2 }, enforceDurationLimits: false);
+        descending.AdjustDisplayTimeUsingPercent(150, new List<int> { 2, 1, 0 }, enforceDurationLimits: false);
+
+        for (var i = 0; i < ascending.Paragraphs.Count; i++)
+        {
+            Assert.Equal(ascending.Paragraphs[i].EndTime.TotalMilliseconds, descending.Paragraphs[i].EndTime.TotalMilliseconds);
+        }
+    }
+
+    [Fact]
+    public void SetFixedDuration_OnlyTouchesSelectedLines()
+    {
+        var s = Make((0, 1000), (5000, 6000), (10_000, 11_000));
+
+        s.SetFixedDuration(new List<int> { 2 }, 2500);
+
+        Assert.Equal(1000, s.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal(6000, s.Paragraphs[1].EndTime.TotalMilliseconds);
+        Assert.Equal(12_500, s.Paragraphs[2].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void SetFixedDuration_NullSelectionMeansEveryLine()
+    {
+        var s = Make((0, 1000), (5000, 6000));
+
+        s.SetFixedDuration(null, 2000);
+
+        Assert.Equal(2000, s.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal(7000, s.Paragraphs[1].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void RemoveEmptyLines_RemovesBlankAndControlCharacterLinesAndRenumbers()
+    {
+        var s = new Subtitle();
+        s.Paragraphs.Add(new Paragraph("first", 0, 1000) { Number = 5 });
+        s.Paragraphs.Add(new Paragraph("   ", 2000, 3000) { Number = 6 });
+        s.Paragraphs.Add(new Paragraph(string.Empty, 4000, 5000) { Number = 7 });
+        s.Paragraphs.Add(new Paragraph("\t\r\n", 6000, 7000) { Number = 8 });
+        s.Paragraphs.Add(new Paragraph("last", 8000, 9000) { Number = 9 });
+
+        var removed = s.RemoveEmptyLines();
+
+        Assert.Equal(3, removed);
+        Assert.Equal(2, s.Paragraphs.Count);
+        Assert.Equal("first", s.Paragraphs[0].Text);
+        Assert.Equal("last", s.Paragraphs[1].Text);
+
+        // Renumbered from the first paragraph's original number.
+        Assert.Equal(5, s.Paragraphs[0].Number);
+        Assert.Equal(6, s.Paragraphs[1].Number);
+    }
+
+    [Fact]
+    public void RemoveEmptyLines_LeavesANonEmptySubtitleAlone()
+    {
+        var s = new Subtitle();
+        s.Paragraphs.Add(new Paragraph("a", 0, 1000) { Number = 3 });
+        s.Paragraphs.Add(new Paragraph("b", 2000, 3000) { Number = 4 });
+
+        Assert.Equal(0, s.RemoveEmptyLines());
+        Assert.Equal(2, s.Paragraphs.Count);
+        Assert.Equal(3, s.Paragraphs[0].Number); // no renumber when nothing was removed
+    }
+}

--- a/tests/libse/Core/TimeCodeFormatTests.cs
+++ b/tests/libse/Core/TimeCodeFormatTests.cs
@@ -1,0 +1,81 @@
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace LibSETests.Core;
+
+/// <summary>
+/// The five frame-based formatters share one implementation. These pin their output - especially
+/// the "frames round up to a whole second" carry, and the fact that ToSSFF carries into seconds
+/// only, never into minutes or hours.
+/// </summary>
+public class TimeCodeFormatTests : IDisposable
+{
+    private readonly double _originalFrameRate = Configuration.Settings.General.CurrentFrameRate;
+
+    public TimeCodeFormatTests()
+    {
+        Configuration.Settings.General.CurrentFrameRate = 25;
+    }
+
+    public void Dispose()
+    {
+        Configuration.Settings.General.CurrentFrameRate = _originalFrameRate;
+    }
+
+    [Theory]
+    // totalMs,   HHMMSSFF,      HHMMSS,     DropFrame,      SSFF,    PeriodFF
+    [InlineData(0, "00:00:00:00", "00:00:00", "00:00:00;00", "00:00", "00:00:00.00")]
+    [InlineData(500, "00:00:00:13", "00:00:00", "00:00:00;13", "00:13", "00:00:00.13")]
+    // 999 ms rounds to 25 frames at 25 fps, i.e. a whole second - every formatter must carry.
+    [InlineData(999, "00:00:01:00", "00:00:01", "00:00:01;00", "01:00", "00:00:01.00")]
+    [InlineData(59_999, "00:01:00:00", "00:01:00", "00:01:00;00", "60:00", "00:01:00.00")]
+    [InlineData(3_600_000, "01:00:00:00", "01:00:00", "01:00:00;00", "00:00", "01:00:00.00")]
+    [InlineData(90_061_500, "25:01:01:13", "25:01:01", "25:01:01;13", "01:13", "25:01:01.13")]
+    public void FrameFormatters_Match(double totalMilliseconds, string hhmmssff, string hhmmss,
+        string dropFrame, string ssff, string periodFf)
+    {
+        var tc = new TimeCode(totalMilliseconds);
+
+        Assert.Equal(hhmmssff, tc.ToHHMMSSFF());
+        Assert.Equal(hhmmss, tc.ToHHMMSS());
+        Assert.Equal(dropFrame, tc.ToHHMMSSFFDropFrame());
+        Assert.Equal(ssff, tc.ToSSFF());
+        Assert.Equal(periodFf, tc.ToHHMMSSPeriodFF());
+    }
+
+    /// <summary>
+    /// ToSSFF carries into the seconds field without touching minutes or hours: at 59.999 s it
+    /// reports "60:00", not "00:00". That is long-standing behaviour, pinned here so the shared
+    /// implementation cannot quietly "fix" it.
+    /// </summary>
+    [Fact]
+    public void ToSSFF_CarriesIntoSecondsOnly()
+    {
+        Assert.Equal("60:00", new TimeCode(59_999).ToSSFF());
+        Assert.Equal("00:00", new TimeCode(3_600_000).ToSSFF());
+    }
+
+    [Theory]
+    [InlineData(-1000, "-00:00:01:00")]
+    [InlineData(-90_000, "-00:01:30:00")]
+    public void FrameFormatters_PrefixASingleSign(double totalMilliseconds, string expected)
+    {
+        Assert.Equal(expected, new TimeCode(totalMilliseconds).ToHHMMSSFF());
+    }
+
+    [Theory]
+    [InlineData(-1000, "-00:00:01,000")]
+    [InlineData(-3_723_456, "-01:02:03,456")]
+    public void ToString_PrefixesASingleSign(double totalMilliseconds, string expected)
+    {
+        Assert.Equal(expected, new TimeCode(totalMilliseconds).ToString(false));
+    }
+
+    [Fact]
+    public void ToShortStringHHMMSSFF_DropsLeadingZeroGroups()
+    {
+        Assert.Equal("00:00", new TimeCode(0).ToShortStringHHMMSSFF());
+        Assert.Equal("01:00", new TimeCode(999).ToShortStringHHMMSSFF());
+        Assert.Equal("01:00:00", new TimeCode(59_999).ToShortStringHHMMSSFF());
+        Assert.Equal("01:00:00:00", new TimeCode(3_600_000).ToShortStringHHMMSSFF());
+    }
+}


### PR DESCRIPTION
Two independent commits in libse: a duplication cleanup in `TimeCode`, and three quadratic `Subtitle` operations made linear.

Both were verified by differential sweep rather than by trusting the test suites — each change either merges hand-copied code or alters how a numeric transform is driven, so "the tests still pass" is not strong enough evidence on its own.

## `Subtitle`: three quadratic operations → linear

`AdjustDisplayTimeUsingPercent` and `SetFixedDuration` walked every paragraph and asked `List<int>.Contains` whether its index was selected — O(paragraphs × selection), so quadratic whenever the user selects everything and runs "adjust display time" or "set fixed duration". They now probe a `HashSet` built once. The ascending walk is preserved deliberately: each iteration reads the next paragraph's possibly-already-adjusted start time.

`RemoveEmptyLines` removed matches one at a time with `RemoveAt`, and each `RemoveAt` shifts every following element, so removing k lines cost O(paragraphs × k). `RemoveAll` compacts in a single pass.

BenchmarkDotNet, 5000 lines, net of the subtitle-building cost each benchmark shares:

| | before | after | |
| --- | --- | --- | --- |
| `AdjustDisplayTimeUsingPercent` | 893 µs | **63 µs** | 14× |
| `SetFixedDuration` | 940 µs | **48 µs** | 20× |
| `RemoveEmptyLines` | 136 µs | **22 µs** | 6× |

All three now scale linearly (5× the lines costs ~5×, not ~20×). The two `HashSet`s cost ~91 KB at 5000 lines.

**Verification:** swept 37 932 result rows — 5 subtitle sizes × 3 seeds × 5 selection shapes (null, all, sparse, reverse-ordered, and containing out-of-range indices) across `AdjustDisplayTimeUsingPercent`, `SetFixedDuration`, `AdjustDisplayTimeUsingSeconds` and `RemoveEmptyLines`, with deliberately overlapping paragraphs — before and after. Output byte-identical.

## `TimeCode`: five frame formatters → one

`ToHHMMSSFF`, `ToHHMMSS`, `ToHHMMSSFFDropFrame`, `ToSSFF` and `ToHHMMSSPeriodFF` were five hand-copied bodies differing only in the separator character and which components they include — including five copies of the "frames round up to a whole second" carry, exactly the kind of detail that gets fixed in one copy and not the others. **73 lines removed, 57 added.**

Two long-standing quirks are preserved and now pinned by tests: `ToSSFF` carries into the seconds field only (59.999 s renders `"60:00"`, never into minutes), and `ToHHMMSS` never computes a frame component.

**Verification:** swept 12 696 cases (8 frame rates × ~1590 time values covering negatives, both sides of the frame-carry boundary, day rollover and `MaxTime`) through all five formatters plus `ToShortStringHHMMSSFF`/`ToString`/`ToShortString`, before and after. Output byte-identical.

Also rewrites `PrefixSign`'s negative branch. It was `$"-{time.RemoveChar('-')}"`, which allocated a `char[]`, the stripped string and the interpolated result on top of the string being fixed up; it now writes the sign and the kept characters into one stack buffer, with a length guard so the `stackalloc` cannot be unbounded.

| | before | after |
| --- | --- | --- |
| `TimeCode.ToString` on a negative value | 33.9 ns / 208 B | **28.5 ns / 104 B** |

Nothing else in `TimeCode` moved — it had already been through an optimisation pass (span parsing, stack-buffer formatting), and the rest measured unchanged. `TimeCodeBenchmarks` is added so that stays visible.

## Tests

713 libse + 813 UI tests pass. New: `TimeCodeFormatTests` (all five formatters across the carry boundary, the `ToSSFF` quirk, sign handling) and `SubtitleBulkOperationTests` (only selected lines move, selection order is irrelevant, out-of-range indices ignored, renumbering preserved).

## Found while measuring, not fixed

`AdjustDisplayTimeUsingSeconds` throws `IndexOutOfRangeException` on an out-of-range selected index — it iterates the caller's list and hands each index to `AdjustDisplayTimeUsingMilliseconds`, which does `Paragraphs[idx]` unguarded. `AdjustDisplayTimeUsingPercent` and `SetFixedDuration` iterate paragraphs instead and so ignore stray indices. The sweep hit this immediately; I excluded the combination rather than quietly changing behaviour. Pre-existing, in code this PR does not touch.

Smaller observations, also untouched:

1. `GetIndex(Paragraph)` falls back to a linear scan with five fuzzy comparisons per paragraph (id, ±1 neighbour, time match, number+time, text+time). Correct, but expensive if any caller invokes it in a loop.
2. `InsertParagraphInCorrectTimeOrder` linear-scans a list that is already start-time sorted; `BinarySearch` would do.
3. `Parse`/`LoadSubtitle` enumerate `AllSubtitleFormats` twice with `p.Name.StartsWith("Unknown")` per format per call. The list is cached so this is small, but the two passes could be one partition.
4. `RemoveParagraphsByIndices` has the same `RemoveAt`-per-item shape as `RemoveEmptyLines` had. Removals are usually few, so it is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
