### PR TITLE
Fix OCR "add to user dictionary" not advancing to next word (#12824)

### DIFF
--- a/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
@@ -55,7 +55,12 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
         _twoLetterIsoLanguageName = twoLetterIsoLanguageName;
         _spellCheckManager.Initialize(spellCheckDictionary.DictionaryFileName, twoLetterIsoLanguageName);
 
-        _fiveLetterName = Path.GetFileNameWithoutExtension(spellCheckDictionary.DictionaryFileName);
+        // Use the same normalized five-letter language name that the main spell checker and the OCR
+        // "add to user dictionary" write path use (e.g. es_ANY -> es_ES). Using the raw file base name
+        // here made ReloadNames() read a different *_user.xml than words were saved to, so newly added
+        // user-dictionary words were never recognized and the prompt kept re-opening the same word (#12824).
+        _fiveLetterName = spellCheckDictionary.GetFiveLetterLanguageName()
+                          ?? Path.GetFileNameWithoutExtension(spellCheckDictionary.DictionaryFileName);
 
         _threeLetterIsoLanguageName = threeLetterIsoLanguageName;
         _subtitle = subtitle;

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixEngineUserDictionaryReloadTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixEngineUserDictionaryReloadTests.cs
@@ -1,0 +1,82 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Interfaces;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Dictionaries;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+// Repro for https://github.com/SubtitleEdit/subtitleedit/issues/12824
+// "Add to user dictionary" in the OCR spell check must make the word known so the prompt advances.
+public class OcrFixEngineUserDictionaryReloadTests : IDisposable
+{
+    private readonly string _originalDictionariesFolder;
+    private readonly Func<string> _originalSpellCheckDictionariesFolder;
+    private readonly string _tempDictionariesFolder;
+
+    public OcrFixEngineUserDictionaryReloadTests()
+    {
+        _originalDictionariesFolder = Se.DictionariesFolder;
+        _originalSpellCheckDictionariesFolder = SpellCheckConfig.DictionariesFolder;
+        _tempDictionariesFolder = Path.Combine(Path.GetTempPath(), "SeOcrUserDictTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDictionariesFolder);
+        Se.DictionariesFolder = _tempDictionariesFolder;
+        SpellCheckConfig.DictionariesFolder = () => _tempDictionariesFolder;
+    }
+
+    [Theory]
+    [InlineData("en_US.dic")]   // standard five-letter dictionary
+    [InlineData("es_ANY.dic")]  // GetFiveLetterLanguageName() maps this to es_ES
+    public void AddToUserDictionary_ThenReload_MakesWordKnown(string dictionaryFileName)
+    {
+        const string line = "Hello Kryten";
+        var engine = new OcrFixEngine(new FakeSpellChecker("Hello"));
+        var dictionary = new SpellCheckDictionaryDisplay { DictionaryFileName = dictionaryFileName };
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(line, 0, 3000));
+        ((IOcrFixEngine)engine).Initialize(subtitle, "eng", dictionary);
+
+        // Before: "Kryten" is unknown.
+        var before = engine.FixOcrErrors(0, line, doTryToGuessUnknownWords: false);
+        Assert.False(before.Words.Single(w => w.Word == "Kryten").IsSpellCheckedOk);
+
+        // Simulate the OCR view model's "Add to user dictionary" handler.
+        UserWordsHelper.AddToUserDictionary("Kryten", dictionary.GetFiveLetterLanguageName() ?? "en_US");
+        engine.ReloadNames();
+
+        // After: "Kryten" should be recognized, so the prompt advances instead of re-opening.
+        var after = engine.FixOcrErrors(0, line, doTryToGuessUnknownWords: false);
+        Assert.True(after.Words.Single(w => w.Word == "Kryten").IsSpellCheckedOk);
+    }
+
+    public void Dispose()
+    {
+        Se.DictionariesFolder = _originalDictionariesFolder;
+        SpellCheckConfig.DictionariesFolder = _originalSpellCheckDictionariesFolder;
+        try
+        {
+            Directory.Delete(_tempDictionariesFolder, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private sealed class FakeSpellChecker : ISpellChecker
+    {
+        private readonly HashSet<string> _correct;
+
+        public FakeSpellChecker(params string[] correctWords)
+            => _correct = new HashSet<string>(correctWords, StringComparer.Ordinal);
+
+        public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => true;
+        public bool IsWordCorrect(string word) => _correct.Contains(word);
+        public List<string> GetSuggestions(string word) => new();
+    }
+}


### PR DESCRIPTION
Fixes #12824

## Problem
In the OCR spell-check prompt, clicking **Add to user dictionary** did not advance — the window closed briefly and reopened on the same word. **Add to names list** worked, and the word appeared not to be saved.

## Root cause
The two sides used different dictionary keys:

- **Write** — `OcrViewModel` saves the word with the *normalized* five-letter name `SelectedDictionary.GetFiveLetterLanguageName()` (e.g. `es_ANY` → `es_ES`).
- **Reload** — `OcrFixEngine.ReloadNames()` rebuilds its word lists from `_fiveLetterName`, which `Initialize` set to the *raw* file base name (`es_ANY`).

For dictionaries that `GetFiveLetterLanguageName()` remaps (`es_ANY`, `russian_aot`, `fr_classique`, `fr_toutesvariantes`, `eu`) the word was written to one `*_user.xml` but reloaded from another, so `HasUserWord` never matched, `GetNextUnknownWord` kept returning the same word, and the prompt reopened on the same line. Standard `xx_YY` dictionaries were unaffected (both names equal), so the bug only hit remapped dictionaries. `Add to names list` was fine because it updates the in-memory list directly and never touches a file.

The OCR engine was the odd one out — the main `SpellChecker` already builds its word lists with the normalized name.

## Fix
Derive `_fiveLetterName` in `OcrFixEngine.Initialize` the same way the write path and the main spell checker do. Since the engine is initialized with the same `SelectedDictionary` object the write path uses, the saved and reloaded user-dictionary files are now guaranteed to match. The `?? Path.GetFileNameWithoutExtension(...)` fallback preserves the existing empty/no-dictionary behavior.

## Test
Added `OcrFixEngineUserDictionaryReloadTests` — a `[Theory]` over `en_US.dic` and `es_ANY.dic` that adds a user word, reloads, and asserts the word becomes known. Before the fix `es_ANY.dic` failed; both pass now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)