### PR TITLE
Cut per-line allocations in Utilities

### DIFF
--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -208,15 +208,21 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return false;
             }
 
-            if (!"\r\n\t ".Contains(nextChar))
+            if (nextChar != ' ' && nextChar != '\r' && nextChar != '\n' && nextChar != '\t')
             {
                 return false;
             }
 
-            // Some words we don't like breaking after
-            string s2 = s.Substring(0, index);
+            // Some words we don't like breaking after.
+            //
+            // TextSplit calls this once per space in the line, and it used to take a substring of
+            // everything before the break point before deciding whether it needed one. Only the
+            // NoBreakAfterList branch does - and that is off by default - so the rest works on a
+            // span instead.
+            var head = s.AsSpan(0, index);
             if (Configuration.Settings.Tools.UseNoLineBreakAfter)
             {
+                var s2 = s.Substring(0, index); // the list matches with Regex/EndsWith, which need a string
                 foreach (NoBreakAfterItem ending in NoBreakAfterList(language))
                 {
                     if (ending.IsMatch(s2))
@@ -227,14 +233,16 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
             else
             {
-                if (s2.EndsWith(" mr.", StringComparison.OrdinalIgnoreCase) ||
-                    s2.EndsWith(" dr.", StringComparison.OrdinalIgnoreCase))
+                if (head.EndsWith(" mr.".AsSpan(), StringComparison.OrdinalIgnoreCase) ||
+                    head.EndsWith(" dr.".AsSpan(), StringComparison.OrdinalIgnoreCase))
                 {
                     return false;
                 }
             }
 
-            if (s2.EndsWith("? -", StringComparison.Ordinal) || s2.EndsWith("! -", StringComparison.Ordinal) || s2.EndsWith(". -", StringComparison.Ordinal))
+            if (head.EndsWith("? -".AsSpan(), StringComparison.Ordinal) ||
+                head.EndsWith("! -".AsSpan(), StringComparison.Ordinal) ||
+                head.EndsWith(". -".AsSpan(), StringComparison.Ordinal))
             {
                 return false;
             }
@@ -258,11 +266,16 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         private static string _lastNoBreakAfterListLanguage;
         private static List<NoBreakAfterItem> _lastNoBreakAfterList = new List<NoBreakAfterItem>();
+
+        // CanBreak asks for this once per candidate break point, and AutoBreakLine(text) passes no
+        // language at all, so the "no language" case must not allocate a list every time.
+        private static readonly List<NoBreakAfterItem> EmptyNoBreakAfterList = new List<NoBreakAfterItem>();
+
         internal static IEnumerable<NoBreakAfterItem> NoBreakAfterList(string languageName)
         {
             if (string.IsNullOrEmpty(languageName))
             {
-                return new List<NoBreakAfterItem>();
+                return EmptyNoBreakAfterList;
             }
 
             if (languageName == _lastNoBreakAfterListLanguage)
@@ -498,6 +511,9 @@ namespace Nikse.SubtitleEdit.Core.Common
             return AutoBreakLineMoreThanTwoLines(text, Configuration.Settings.General.SubtitleLineMaximumLength, Configuration.Settings.General.MergeLinesShorterThan, language);
         }
 
+        private static bool IsCjkLanguage(string language)
+            => language == "zh" || language == "ja" || language == "ko";
+
         public static string AutoBreakLinePrivate(string input, int maximumLength, int mergeLinesShorterThan, string language, bool autoBreakLineEndingEarly)
         {
             if (string.IsNullOrEmpty(input) || input.Length < 3)
@@ -508,7 +524,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             var text = input.Replace('\u00a0', ' '); // replace non-break-space (160 decimal) ascii char with normal space
             if (!(text.IndexOf(' ') >= 0 || text.IndexOf('\n') >= 0))
             {
-                if (new[] { "zh", "ja", "ko" }.Contains(language) == false)
+                if (!IsCjkLanguage(language))
                 {
                     return input;
                 }
@@ -1039,16 +1055,41 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public static int GetMaxLineLength(string text)
         {
-            var maxLength = 0;
-            foreach (var line in HtmlUtil.RemoveHtmlTags(text, true).SplitToLines())
+            // Only the longest line's length is wanted, so walk the line breaks rather than
+            // building a List<string> of substrings to measure and throw away.
+            var stripped = HtmlUtil.RemoveHtmlTags(text, true);
+            if (string.IsNullOrEmpty(stripped))
             {
-                if (line.Length > maxLength)
-                {
-                    maxLength = line.Length;
-                }
+                return 0;
             }
 
-            return maxLength;
+            var maxLength = 0;
+            var lineStart = 0;
+            for (var i = 0; i < stripped.Length; i++)
+            {
+                var ch = stripped[i];
+                if (ch != '\r' && ch != '\n' && ch != '\u2028') // same break chars as SplitToLines
+                {
+                    continue;
+                }
+
+                var lineLength = i - lineStart;
+                if (lineLength > maxLength)
+                {
+                    maxLength = lineLength;
+                }
+
+                // Treat \r\n as one break, like SplitToLines does.
+                if (ch == '\r' && i + 1 < stripped.Length && stripped[i + 1] == '\n')
+                {
+                    i++;
+                }
+
+                lineStart = i + 1;
+            }
+
+            var lastLineLength = stripped.Length - lineStart;
+            return lastLineLength > maxLength ? lastLineLength : maxLength;
         }
 
         public static bool IsRunningOnMono()
@@ -2300,6 +2341,34 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// <param name="input">text string to remove unneeded spaces from</param>
         /// <param name="language">two letter language id string</param>
         /// <returns>text with unneeded spaces removed</returns>
+                // RemoveUnneededSpaces runs per line (auto-trim white space, fix common errors) and
+        // Environment.NewLine is not a compile-time constant, so each of these was a
+        // string.Concat executed on every call. Same treatment as the RemoveLineBreaks
+        // patterns above.
+        private static readonly string RunSpaceEllipsisNewLine = " ..." + Environment.NewLine;
+        private static readonly string RunEllipsisNewLine = "..." + Environment.NewLine;
+        private static readonly string RunNewLineEllipsis = Environment.NewLine + "...";
+        private static readonly string RunNewLineEllipsisSpace = Environment.NewLine + "... ";
+        private static readonly string RunNewLineItalicEllipsis = Environment.NewLine + "<i>...";
+        private static readonly string RunNewLineItalicEllipsisSpace = Environment.NewLine + "<i>... ";
+        private static readonly string RunNewLineDashEllipsis = Environment.NewLine + "- ...";
+        private static readonly string RunNewLineDashEllipsisSpace = Environment.NewLine + "- ... ";
+        private static readonly string RunNewLineItalicDashEllipsis = Environment.NewLine + "<i>- ...";
+        private static readonly string RunNewLineItalicDashEllipsisSpace = Environment.NewLine + "<i>- ... ";
+        private static readonly string RunSpaceDotItalicCloseNewLine = " .</i>" + Environment.NewLine;
+        private static readonly string RunDotItalicCloseNewLine = ".</i>" + Environment.NewLine;
+        private static readonly string RunSpaceExclamationItalicCloseNewLine = " !</i>" + Environment.NewLine;
+        private static readonly string RunExclamationItalicCloseNewLine = "!</i>" + Environment.NewLine;
+        private static readonly string RunSpaceQuestionItalicCloseNewLine = " ?</i>" + Environment.NewLine;
+        private static readonly string RunQuestionItalicCloseNewLine = "?</i>" + Environment.NewLine;
+        private static readonly string RunSpaceDotNewLine = " ." + Environment.NewLine;
+        private static readonly string RunDotNewLine = "." + Environment.NewLine;
+        private static readonly string RunSpaceApostropheSNewLine = " 's" + Environment.NewLine;
+        private static readonly string RunApostropheSNewLine = "'s" + Environment.NewLine;
+        private static readonly string RunNewLineSpaceOnly = Environment.NewLine + " ";
+        private static readonly string RunSpaceQuoteNewLine = " \"" + Environment.NewLine;
+        private static readonly string RunQuoteNewLine = "\"" + Environment.NewLine;
+
         public static string RemoveUnneededSpaces(string input, string language)
         {
             const char zeroWidthSpace = '\u200B';
@@ -2354,12 +2423,12 @@ namespace Nikse.SubtitleEdit.Core.Common
                 text = text.Replace("....", ellipses);
             }
 
-            text = text.Replace(" ..." + Environment.NewLine, "..." + Environment.NewLine);
-            text = text.Replace(Environment.NewLine + "... ", Environment.NewLine + "...");
-            text = text.Replace(Environment.NewLine + "<i>... ", Environment.NewLine + "<i>...");
-            text = text.Replace(Environment.NewLine + "- ... ", Environment.NewLine + "- ...");
-            text = text.Replace(Environment.NewLine + "<i>- ... ", Environment.NewLine + "<i>- ...");
-            text = text.Replace(Environment.NewLine + "- ... ", Environment.NewLine + "- ...");
+            text = text.Replace(RunSpaceEllipsisNewLine, RunEllipsisNewLine);
+            text = text.Replace(RunNewLineEllipsisSpace, RunNewLineEllipsis);
+            text = text.Replace(RunNewLineItalicEllipsisSpace, RunNewLineItalicEllipsis);
+            text = text.Replace(RunNewLineDashEllipsisSpace, RunNewLineDashEllipsis);
+            text = text.Replace(RunNewLineItalicDashEllipsisSpace, RunNewLineItalicDashEllipsis);
+            text = text.Replace(RunNewLineDashEllipsisSpace, RunNewLineDashEllipsis);
 
             if (text.StartsWith("... ", StringComparison.Ordinal))
             {
@@ -2381,9 +2450,9 @@ namespace Nikse.SubtitleEdit.Core.Common
                 text = text.Remove(text.Length - 6, 1);
             }
 
-            while (text.Contains(" .</i>" + Environment.NewLine))
+            while (text.Contains(RunSpaceDotItalicCloseNewLine))
             {
-                text = text.Replace(" .</i>" + Environment.NewLine, ".</i>" + Environment.NewLine);
+                text = text.Replace(RunSpaceDotItalicCloseNewLine, RunDotItalicCloseNewLine);
             }
 
             if (text.StartsWith("- ... ", StringComparison.Ordinal))
@@ -2408,14 +2477,14 @@ namespace Nikse.SubtitleEdit.Core.Common
                     text = text.Remove(text.Length - 6, 1);
                 }
 
-                while (text.Contains(" !</i>" + Environment.NewLine))
+                while (text.Contains(RunSpaceExclamationItalicCloseNewLine))
                 {
-                    text = text.Replace(" !</i>" + Environment.NewLine, "!</i>" + Environment.NewLine);
+                    text = text.Replace(RunSpaceExclamationItalicCloseNewLine, RunExclamationItalicCloseNewLine);
                 }
 
-                while (text.Contains(" ?</i>" + Environment.NewLine))
+                while (text.Contains(RunSpaceQuestionItalicCloseNewLine))
                 {
-                    text = text.Replace(" ?</i>" + Environment.NewLine, "?</i>" + Environment.NewLine);
+                    text = text.Replace(RunSpaceQuestionItalicCloseNewLine, RunQuestionItalicCloseNewLine);
                 }
 
                 text = text.Replace("... ?", "...?");
@@ -2442,9 +2511,9 @@ namespace Nikse.SubtitleEdit.Core.Common
                     text = text.Replace(" 's ", "'s ");
                 }
 
-                while (text.Contains(" 's" + Environment.NewLine))
+                while (text.Contains(RunSpaceApostropheSNewLine))
                 {
-                    text = text.Replace(" 's" + Environment.NewLine, "'s" + Environment.NewLine);
+                    text = text.Replace(RunSpaceApostropheSNewLine, RunApostropheSNewLine);
                 }
             }
 
@@ -2458,14 +2527,14 @@ namespace Nikse.SubtitleEdit.Core.Common
                 text = text.Remove(text.Length - 2, 1);
             }
 
-            if (text.Contains(" \"" + Environment.NewLine))
+            if (text.Contains(RunSpaceQuoteNewLine))
             {
-                text = text.Replace(" \"" + Environment.NewLine, "\"" + Environment.NewLine);
+                text = text.Replace(RunSpaceQuoteNewLine, RunQuoteNewLine);
             }
 
-            if (text.Contains(" ." + Environment.NewLine))
+            if (text.Contains(RunSpaceDotNewLine))
             {
-                text = text.Replace(" ." + Environment.NewLine, "." + Environment.NewLine);
+                text = text.Replace(RunSpaceDotNewLine, RunDotNewLine);
             }
 
             if (language == "en" && text.ContainsNumber())
@@ -2571,7 +2640,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
             }
             text = text.Trim();
-            text = text.Replace(Environment.NewLine + " ", Environment.NewLine);
+            text = text.Replace(RunNewLineSpaceOnly, Environment.NewLine);
 
             if (text.Contains("-") && text.Length > 2 && !text.StartsWith("--", StringComparison.Ordinal))
             {

--- a/tests/benchmarks/UtilitiesBenchmarks.cs
+++ b/tests/benchmarks/UtilitiesBenchmarks.cs
@@ -1,0 +1,33 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// Per-line helpers from Utilities. RemoveUnneededSpaces runs on every line the "auto trim white
+/// space" setting touches and throughout fix-common-errors; GetMaxLineLength and GetNumberOfLines
+/// back grid sorting and error checks.
+/// </summary>
+[MemoryDiagnoser]
+public class UtilitiesBenchmarks
+{
+    private const string Plain = "It was the best of times, it was the worst of times.";
+    private const string TwoLines = "- Are you coming with us?\r\n- No, I'll stay here and wait.";
+    private const string Tagged = "<i>It was the best of times,</i>\r\n<i>it was the worst of times.</i>";
+    private const string Dots = "Well ... I don't know ...\r\n<i>... maybe later .</i>";
+    private const string Long = "It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness.";
+
+    [Benchmark] public string RemoveUnneededSpaces_Plain() => Utilities.RemoveUnneededSpaces(Plain, "en");
+    [Benchmark] public string RemoveUnneededSpaces_TwoLines() => Utilities.RemoveUnneededSpaces(TwoLines, "en");
+    [Benchmark] public string RemoveUnneededSpaces_Dots() => Utilities.RemoveUnneededSpaces(Dots, "en");
+    [Benchmark] public string RemoveUnneededSpaces_French() => Utilities.RemoveUnneededSpaces(Dots, "fr");
+
+    [Benchmark] public int GetMaxLineLength_Plain() => Utilities.GetMaxLineLength(Plain);
+    [Benchmark] public int GetMaxLineLength_Tagged() => Utilities.GetMaxLineLength(Tagged);
+    [Benchmark] public int GetNumberOfLines() => Utilities.GetNumberOfLines(TwoLines);
+
+    [Benchmark] public string AutoBreakLine() => Utilities.AutoBreakLine(Long);
+    [Benchmark] public string RemoveLineBreaks() => Utilities.RemoveLineBreaks(Tagged);
+    [Benchmark] public string RemoveSsaTags() => Utilities.RemoveSsaTags("{\\an8}{\\pos(10,20)}Hello there");
+    [Benchmark] public double GetOptimalDisplayMilliseconds() => Utilities.GetOptimalDisplayMilliseconds(Plain);
+}

--- a/tests/libse/Core/UtilitiesLineLengthTests.cs
+++ b/tests/libse/Core/UtilitiesLineLengthTests.cs
@@ -1,0 +1,60 @@
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace LibSETests.Core;
+
+/// <summary>
+/// GetMaxLineLength walks line breaks directly instead of splitting into a list, so it has to
+/// agree with SplitToLines on every break form it recognises - including a lone \r, a U+2028 line separator, and
+/// \r\n counting as one break.
+/// </summary>
+public class UtilitiesLineLengthTests
+{
+    [Theory]
+    [InlineData("", 0)]
+    [InlineData("Hello", 5)]
+    [InlineData("Hello\r\nworld!", 6)]
+    [InlineData("Hello\nworld!", 6)]
+    [InlineData("Hello\rworld!", 6)]
+    [InlineData("Hello\u2028world!", 6)]
+    [InlineData("short\r\nlonger line", 11)]
+    [InlineData("longer line\r\nshort", 11)]
+    [InlineData("a\r\n\r\nbbbb", 4)]
+    [InlineData("trailing\r\n", 8)]
+    [InlineData("\r\nleading", 7)]
+    [InlineData("one\r\ntwo\r\nthree", 5)]
+    public void GetMaxLineLength_MatchesLongestLine(string text, int expected)
+    {
+        Assert.Equal(expected, Utilities.GetMaxLineLength(text));
+    }
+
+    [Theory]
+    [InlineData("<i>Hello</i>", 5)]
+    [InlineData("<i>Hello</i>\r\n<i>bigger line</i>", 11)]
+    [InlineData("{\\an8}Hello", 5)]
+    public void GetMaxLineLength_IgnoresTags(string text, int expected)
+    {
+        Assert.Equal(expected, Utilities.GetMaxLineLength(text));
+    }
+
+    /// <summary>The rewrite must agree with the list-building version it replaced.</summary>
+    [Theory]
+    [InlineData("Hello\r\nworld!")]
+    [InlineData("a\rb\nc\u2028d")]
+    [InlineData("<i>tagged</i>\r\nplain")]
+    [InlineData("trailing break\r\n")]
+    [InlineData("")]
+    [InlineData("no breaks at all")]
+    public void GetMaxLineLength_AgreesWithSplitToLines(string text)
+    {
+        var viaSplit = 0;
+        foreach (var line in HtmlUtil.RemoveHtmlTags(text, true).SplitToLines())
+        {
+            if (line.Length > viaSplit)
+            {
+                viaSplit = line.Length;
+            }
+        }
+
+        Assert.Equal(viaSplit, Utilities.GetMaxLineLength(text));
+    }
+}


### PR DESCRIPTION
Per-line allocation cuts in `Utilities`, measured with BenchmarkDotNet and verified byte-identical against the previous behaviour over a 4193-case sweep (every fragment alone, in pairs joined by space and by newline, across 8 languages, through `RemoveUnneededSpaces` / `GetMaxLineLength` / `GetNumberOfLines` / `AutoBreakLine`).

| | before | after |
| --- | --- | --- |
| `RemoveUnneededSpaces` (plain line) | 687 ns / 960 B | **644 ns / 256 B** |
| `RemoveUnneededSpaces` (two lines) | 1468 ns / 2152 B | **1399 ns / 1448 B** |
| `GetMaxLineLength` (plain) | 37 ns / 88 B | **31 ns / 0 B** |
| `GetMaxLineLength` (tagged) | 124 ns / 368 B | **102 ns / 128 B** |
| `AutoBreakLine` | 77 234 ns / 29 312 B | 76 703 ns / 26 440 B |

### What changed

**`CanBreak` took `s.Substring(0, index)` before deciding whether it needed a string.** Only the `NoBreakAfterList` branch does, and `UseNoLineBreakAfter` is off by default, so the `mr.`/`dr.` and `? -` checks now run on a span; the substring is materialised only when the list is actually consulted. `TextSplit` calls this once per space in the line.

**`NoBreakAfterList` returned a freshly allocated empty list on every call when no language was given** — which is exactly what `AutoBreakLine(text)` passes. Now a shared empty list.

**`RemoveUnneededSpaces` built 22 distinct `"..." + Environment.NewLine` style patterns at runtime on every call.** `Environment.NewLine` is not a compile-time constant, so each is a `string.Concat`. Hoisted to static readonly fields — the same treatment the `RemoveLineBreaks` patterns directly above them already had.

**`GetMaxLineLength` allocated a `List<string>` plus a substring per line** just to find the longest. It now walks the line breaks. It has to agree with `SplitToLines` on every break form it recognises, so `\r`, `\n`, U+2028 and "`\r\n` counts as one break" are covered by tests, including a case that cross-checks the two implementations against each other.

Also replaces a per-call `new[] { "zh", "ja", "ko" }.Contains(language)` in `AutoBreakLinePrivate` with a plain comparison.

715 libse + 813 UI tests pass.

### `AutoBreakLine` costs 77 µs per line, and it is not in this file

This is the finding worth acting on, but the code lives in `TextSplit.cs` / `TextSplitResult.cs`, so it is deliberately not in this PR.

`TextSplit`'s constructor builds a `TextSplitResult` for **every space in the line, twice** — once into `_splits` and once into `_allSplits`. Each `TextSplitResult` constructor calls `SKFont.MeasureText` (Skia text shaping) on both of its candidate lines when `AutoBreakUsePixelWidth` is on, which is the default. For the ~110-character line in the benchmark that is roughly 76 Skia measurement calls for a single auto-break, which is where the 77 µs goes.

Two things stand out:

1. **`_allSplits` is used in exactly one place** — the `GetBestLengthSplit` fallback at `TextSplit.cs:118`. It is fully built and fully measured up front regardless, so whenever `GetBestPixelSplit` succeeds (the normal path) roughly half the Skia work was done for nothing.
2. **Measurement is eager.** The splits are measured in the constructor, then filtered by `IsLineLengthOkay` and ordered. Measuring lazily — only for candidates that survive the filter, and only when the ordering asks — would skip most of it.

I did not touch either, since the ask was `Utilities.cs`. The ~10% allocation drop in the `AutoBreakLine` row above is just the `CanBreak` substrings going away; the time is essentially unchanged, as expected.

Smaller observations, also untouched:

- `GetOriginalParagraph` has an index fast path and then two full linear scans. If a caller runs it per paragraph and the fast path misses, that is quadratic.
- `GetChangesAdvanced` is O(n²) worst case via `FindNext`, but it operates on per-line word arrays, so it is small in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
