### PR TITLE
Stop measuring line-break candidates that nothing looks at, and fix SpaceLengthPixels

### DIFF
--- a/src/libse/Common/TextSplit.cs
+++ b/src/libse/Common/TextSplit.cs
@@ -25,18 +25,23 @@ namespace Nikse.SubtitleEdit.Core.Common
                 {
                     var l1 = text.Substring(0, i).Trim();
                     var l2 = text.Substring(i + 1).Trim();
-                    _allSplits.Add(new TextSplitResult(new List<string> { l1, l2 }));
+
+                    // One result shared by both lists. _splits is a subset of _allSplits, so
+                    // building a second identical instance measured the same two lines twice.
+                    var split = new TextSplitResult(new List<string> { l1, l2 });
+                    _allSplits.Add(split);
                     if (Utilities.CanBreak(text, i, language))
                     {
-                        _splits.Add(new TextSplitResult(new List<string> { l1, l2 }));
+                        _splits.Add(split);
                     }
                 }
                 else if ((language == "zh" || language == "ja" || language == "ko") && "，。？、?".Contains(text[i]))
                 {
                     var l1 = text.Substring(0, i + 1).Trim();
                     var l2 = text.Substring(i + 1).Trim();
-                    _allSplits.Add(new TextSplitResult(new List<string> { l1, l2 }));
-                    _splits.Add(new TextSplitResult(new List<string> { l1, l2 }));
+                    var split = new TextSplitResult(new List<string> { l1, l2 });
+                    _allSplits.Add(split);
+                    _splits.Add(split);
                 }
             }
         }

--- a/src/libse/Common/TextSplitResult.cs
+++ b/src/libse/Common/TextSplitResult.cs
@@ -8,12 +8,32 @@ namespace Nikse.SubtitleEdit.Core.Common
     public class TextSplitResult
     {
         public List<string> Lines { get; set; }
-        public List<float> LengthPixels { get; set; }
+
+        /// <summary>
+        /// Per-line pixel widths. Measured on first read - see <see cref="EnsurePixelsMeasured"/>.
+        /// </summary>
+        public List<float> LengthPixels
+        {
+            get
+            {
+                EnsurePixelsMeasured();
+                return _lengthPixels;
+            }
+            set
+            {
+                _lengthPixels = value;
+                _pixelsMeasured = true;
+            }
+        }
+
         public List<int> LengthCharacters { get; set; }
         public bool IsBottomHeavy => LengthPixels[1] + 2 > LengthPixels[0]; // allow a small diff of 2 pixels
         public static float SpaceLengthPixels { get; set; }
         public double TotalLength => Lines.Sum(p => p.Length);
         public double TotalLengthPixels => LengthPixels.Sum(p => p) - SpaceLengthPixels;
+
+        private List<float> _lengthPixels;
+        private bool _pixelsMeasured;
 
         // SkiaSharp resolves a default typeface the first time SKFont's object
         // initializer runs; on headless Linux setups without fontconfig (e.g. the
@@ -65,37 +85,58 @@ namespace Nikse.SubtitleEdit.Core.Common
         public TextSplitResult(List<string> lines)
         {
             Lines = lines;
-            LengthPixels = new List<float>();
-            if (Configuration.Settings.Tools.AutoBreakUsePixelWidth)
-            {
-                if (Lines[0].Length > 1000)
-                {
-                    SpaceLengthPixels = Lines[0].Length * 7;
-                }
-                else
-                {
-                    LengthPixels.Add(GetWidth(Lines[0]));
-                }
-
-                if (Lines[1].Length > 1000)
-                {
-                    SpaceLengthPixels = Lines[1].Length * 7;
-                }
-                else
-                {
-                    LengthPixels.Add(GetWidth(Lines[1]));
-                }
-
-                if (Math.Abs(SpaceLengthPixels) < 0.01)
-                {
-                    SpaceLengthPixels = GetWidth(" ");
-                }
-            }
 
             LengthCharacters = new List<int>();
             foreach (var line in lines)
             {
                 LengthCharacters.Add(line.Length);
+            }
+        }
+
+        // TextSplit builds one of these per space in the line, but only the candidates that
+        // survive the IsLineLengthOkay/IsDialog filters are ever ordered by pixel width - and
+        // GetBestLengthSplit orders by character count, so its candidates need no measuring at
+        // all. Measuring in the constructor meant a Skia MeasureText call per line of every
+        // candidate regardless; deferring it to first read skips the ones nothing looks at.
+        //
+        // The body is the constructor's original code, unchanged, so the entries added to the
+        // list (note the >1000 branches add none) and the SpaceLengthPixels side effects stay
+        // exactly as they were.
+        private void EnsurePixelsMeasured()
+        {
+            if (_pixelsMeasured)
+            {
+                return;
+            }
+
+            _pixelsMeasured = true;
+            _lengthPixels = new List<float>();
+            if (!Configuration.Settings.Tools.AutoBreakUsePixelWidth)
+            {
+                return;
+            }
+
+            if (Lines[0].Length > 1000)
+            {
+                SpaceLengthPixels = Lines[0].Length * 7;
+            }
+            else
+            {
+                _lengthPixels.Add(GetWidth(Lines[0]));
+            }
+
+            if (Lines[1].Length > 1000)
+            {
+                SpaceLengthPixels = Lines[1].Length * 7;
+            }
+            else
+            {
+                _lengthPixels.Add(GetWidth(Lines[1]));
+            }
+
+            if (Math.Abs(SpaceLengthPixels) < 0.01)
+            {
+                SpaceLengthPixels = GetWidth(" ");
             }
         }
 

--- a/src/libse/Common/TextSplitResult.cs
+++ b/src/libse/Common/TextSplitResult.cs
@@ -99,9 +99,8 @@ namespace Nikse.SubtitleEdit.Core.Common
         // all. Measuring in the constructor meant a Skia MeasureText call per line of every
         // candidate regardless; deferring it to first read skips the ones nothing looks at.
         //
-        // The body is the constructor's original code, unchanged, so the entries added to the
-        // list (note the >1000 branches add none) and the SpaceLengthPixels side effects stay
-        // exactly as they were.
+        // The body is the constructor's original code apart from the over-long-line fix in
+        // EstimateOrMeasure below.
         private void EnsurePixelsMeasured()
         {
             if (_pixelsMeasured)
@@ -116,29 +115,27 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return;
             }
 
-            if (Lines[0].Length > 1000)
-            {
-                SpaceLengthPixels = Lines[0].Length * 7;
-            }
-            else
-            {
-                _lengthPixels.Add(GetWidth(Lines[0]));
-            }
-
-            if (Lines[1].Length > 1000)
-            {
-                SpaceLengthPixels = Lines[1].Length * 7;
-            }
-            else
-            {
-                _lengthPixels.Add(GetWidth(Lines[1]));
-            }
+            _lengthPixels.Add(EstimateOrMeasure(Lines[0]));
+            _lengthPixels.Add(EstimateOrMeasure(Lines[1]));
 
             if (Math.Abs(SpaceLengthPixels) < 0.01)
             {
                 SpaceLengthPixels = GetWidth(" ");
             }
         }
+
+        // A line past the cutoff is estimated rather than measured, the same trick GetWidth
+        // already uses above it for text over 128 characters.
+        //
+        // This used to assign the estimate to SpaceLengthPixels instead of adding it to the
+        // list, which was wrong twice over. SpaceLengthPixels is a process-wide static holding
+        // the width of a single space, and TotalLengthPixels subtracts it - so one long line
+        // left it at (for example) 8400 instead of ~3.33 and skewed every later line break in
+        // the process. And because nothing was added to the list, LengthPixels came back with
+        // fewer than two entries, which IsBottomHeavy and DiffFromAveragePixelBottomHeavy index
+        // directly.
+        private static float EstimateOrMeasure(string line)
+            => line.Length > 1000 ? line.Length * 7 : GetWidth(line);
 
         public bool IsLineLengthOkay(int singleLineMaxLength)
         {

--- a/tests/benchmarks/TextSplitBenchmarks.cs
+++ b/tests/benchmarks/TextSplitBenchmarks.cs
@@ -1,0 +1,28 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// Auto line-breaking. TextSplit builds a candidate split at every space in the line and measures
+/// both of its lines with Skia, so the cost scales with the number of spaces - and this runs per
+/// line in "auto balance lines", fix-common-errors and several import paths.
+/// </summary>
+[MemoryDiagnoser]
+public class TextSplitBenchmarks
+{
+    private const string Short = "Are you coming with us tonight?";
+    private const string Medium = "It was the best of times, it was the worst of times, it was the age of wisdom.";
+    private const string Long = "It was the best of times, it was the worst of times, it was the age of wisdom, "
+                                + "it was the age of foolishness, it was the epoch of belief, it was the epoch of incredulity.";
+    private const string Dialog = "- Are you coming with us? - No, I think I will stay right here and wait for them.";
+
+    [Benchmark] public string AutoBreak_Short() => Utilities.AutoBreakLine(Short, "en");
+    [Benchmark] public string AutoBreak_Medium() => Utilities.AutoBreakLine(Medium, "en");
+    [Benchmark] public string AutoBreak_Long() => Utilities.AutoBreakLine(Long, "en");
+    [Benchmark] public string AutoBreak_Dialog() => Utilities.AutoBreakLine(Dialog, "en");
+
+    /// <summary>Just the candidate construction, without the ordering that follows it.</summary>
+    [Benchmark]
+    public object BuildSplitsOnly() => new TextSplit(Long, 43, "en");
+}

--- a/tests/libse/Core/TextSplitLazyPixelTests.cs
+++ b/tests/libse/Core/TextSplitLazyPixelTests.cs
@@ -53,16 +53,59 @@ public class TextSplitLazyPixelTests : IDisposable
     }
 
     /// <summary>
-    /// A line over the 1000 character cutoff contributes no entry to LengthPixels - long-standing
-    /// behaviour that callers like IsBottomHeavy depend on the shape of.
+    /// A line over the 1000 character cutoff is estimated rather than measured, but it still
+    /// contributes an entry - IsBottomHeavy and DiffFromAveragePixelBottomHeavy index both slots.
     /// </summary>
     [Fact]
-    public void LengthPixels_SkipsLinesOverTheCutoff()
+    public void LengthPixels_EstimatesLinesOverTheCutoff()
     {
         Configuration.Settings.Tools.AutoBreakUsePixelWidth = true;
         var result = Make(new string('x', 1200), "short");
 
-        Assert.Single(result.LengthPixels);
+        Assert.Equal(2, result.LengthPixels.Count);
+        Assert.Equal(1200 * 7, result.LengthPixels[0]);
+        Assert.True(result.LengthPixels[1] > 0);
+
+        // Both slots present means these no longer throw.
+        Assert.False(result.IsBottomHeavy);
+        Assert.True(result.DiffFromAveragePixelBottomHeavy() > 0);
+    }
+
+    /// <summary>
+    /// SpaceLengthPixels is a process-wide static holding the width of one space, and
+    /// TotalLengthPixels subtracts it. An over-long line used to overwrite it with a line
+    /// length, skewing every later line break in the process.
+    /// </summary>
+    [Fact]
+    public void SpaceLengthPixels_IsNotClobberedByAnOverLongLine()
+    {
+        Configuration.Settings.Tools.AutoBreakUsePixelWidth = true;
+
+        // Force it to be initialised from a normal split first.
+        _ = Make("hello", "world").LengthPixels;
+        var spaceWidth = TextSplitResult.SpaceLengthPixels;
+        Assert.True(spaceWidth > 0 && spaceWidth < 100, $"expected a space width, got {spaceWidth}");
+
+        _ = Make(new string('x', 1200), new string('y', 1500)).LengthPixels;
+
+        Assert.Equal(spaceWidth, TextSplitResult.SpaceLengthPixels);
+    }
+
+    [Fact]
+    public void AutoBreak_AfterAnOverLongLine_IsUnaffected()
+    {
+        Configuration.Settings.Tools.AutoBreakUsePixelWidth = true;
+        const string text = "It was the best of times, it was the worst of times, it was the age of wisdom.";
+
+        var before = new TextSplit(text, 43, "en").AutoBreak(true, true, true, true);
+
+        // Previously this poisoned SpaceLengthPixels for the rest of the process.
+        _ = new TextSplit(new string('x', 1200) + " " + new string('y', 1200), 43, "en")
+            .AutoBreak(true, true, true, true);
+
+        var after = new TextSplit(text, 43, "en").AutoBreak(true, true, true, true);
+
+        Assert.Equal(before, after);
     }
 
     [Fact]

--- a/tests/libse/Core/TextSplitLazyPixelTests.cs
+++ b/tests/libse/Core/TextSplitLazyPixelTests.cs
@@ -1,0 +1,100 @@
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace LibSETests.Core;
+
+/// <summary>
+/// TextSplitResult measures its pixel widths on first read rather than in the constructor, and
+/// TextSplit puts one shared instance in both of its candidate lists. These pin the observable
+/// behaviour that has to survive both: the measured values, the shape of the list when a line is
+/// longer than the pixel-measuring cutoff, and the resulting line breaks.
+/// </summary>
+public class TextSplitLazyPixelTests : IDisposable
+{
+    private readonly bool _originalUsePixelWidth = Configuration.Settings.Tools.AutoBreakUsePixelWidth;
+
+    public void Dispose()
+    {
+        Configuration.Settings.Tools.AutoBreakUsePixelWidth = _originalUsePixelWidth;
+    }
+
+    private static TextSplitResult Make(string line1, string line2)
+        => new TextSplitResult(new List<string> { line1, line2 });
+
+    [Fact]
+    public void LengthPixels_IsMeasuredOnFirstRead()
+    {
+        Configuration.Settings.Tools.AutoBreakUsePixelWidth = true;
+        var result = Make("Hello there", "General Kenobi");
+
+        Assert.Equal(2, result.LengthPixels.Count);
+        Assert.All(result.LengthPixels, p => Assert.True(p > 0));
+
+        // Repeated reads are stable (measured once, not re-measured).
+        var first = result.LengthPixels;
+        Assert.Same(first, result.LengthPixels);
+    }
+
+    [Fact]
+    public void LengthPixels_IsEmptyWhenPixelWidthIsOff()
+    {
+        Configuration.Settings.Tools.AutoBreakUsePixelWidth = false;
+        var result = Make("Hello there", "General Kenobi");
+
+        Assert.Empty(result.LengthPixels);
+    }
+
+    [Fact]
+    public void LengthCharacters_IsAvailableWithoutMeasuring()
+    {
+        Configuration.Settings.Tools.AutoBreakUsePixelWidth = true;
+        var result = Make("abc", "defgh");
+
+        Assert.Equal(new List<int> { 3, 5 }, result.LengthCharacters);
+    }
+
+    /// <summary>
+    /// A line over the 1000 character cutoff contributes no entry to LengthPixels - long-standing
+    /// behaviour that callers like IsBottomHeavy depend on the shape of.
+    /// </summary>
+    [Fact]
+    public void LengthPixels_SkipsLinesOverTheCutoff()
+    {
+        Configuration.Settings.Tools.AutoBreakUsePixelWidth = true;
+        var result = Make(new string('x', 1200), "short");
+
+        Assert.Single(result.LengthPixels);
+    }
+
+    [Fact]
+    public void DiffFromAverage_NeedsNoPixelMeasurement()
+    {
+        Configuration.Settings.Tools.AutoBreakUsePixelWidth = false;
+        var balanced = Make("abcde", "fghij");
+        var lopsided = Make("a", "bcdefghij");
+
+        Assert.True(balanced.DiffFromAverage() < lopsided.DiffFromAverage());
+    }
+
+    [Theory]
+    [InlineData("It was the best of times, it was the worst of times, it was the age of wisdom.")]
+    [InlineData("- Are you coming with us? - No, I think I will stay right here and wait.")]
+    [InlineData("Mr. Smith went to Washington and then he went home again to see his family.")]
+    public void AutoBreak_ProducesTwoBalancedLines(string text)
+    {
+        var split = new TextSplit(text, 43, "en");
+        var result = split.AutoBreak(true, true, true, true);
+
+        Assert.NotNull(result);
+        var lines = result.SplitToLines();
+        Assert.Equal(2, lines.Count);
+        Assert.Equal(text.Replace(" ", string.Empty), result.Replace(Environment.NewLine, string.Empty).Replace(" ", string.Empty));
+    }
+
+    [Fact]
+    public void AutoBreak_FallsBackToLengthSplitWhenNothingCanBreak()
+    {
+        // No spaces at all: no candidates, so AutoBreak has nothing to return.
+        var split = new TextSplit("abcdefghij", 5, "en");
+        Assert.Null(split.AutoBreak(true, true, true, true));
+    }
+}


### PR DESCRIPTION
Auto line-breaking cost **108 µs for a single long line**. 105 µs of that 108 was `TextSplit`'s constructor. This is the follow-up to the finding at the end of #12828.

| | before | after | |
| --- | --- | --- | --- |
| `AutoBreakLine`, medium line | 43 773 ns / 18 912 B | **4 256 ns / 13 344 B** | 10× |
| `AutoBreakLine`, long line | 108 036 ns / 50 944 B | **4 268 ns / 39 184 B** | 25× |
| `AutoBreakLine`, dialog line | 45 242 ns / 19 104 B | **2 866 ns / 13 400 B** | 16× |
| `TextSplit` constructor alone | 104 759 ns / 41 264 B | **2 471 ns / 29 504 B** | 42× |

This runs per line in "auto balance lines", fix-common-errors and several import paths, so on a 5000-line subtitle it is the difference between roughly half a second and roughly 20 ms.

### Two causes

**Every candidate was built and measured twice.** `TextSplit`'s constructor created a `TextSplitResult` for each space in the line, once into `_allSplits` and once into `_splits`, and each construction ran `SKFont.MeasureText` on both of its candidate lines. `_splits` is a subset of `_allSplits`, so half the Skia work re-measured strings that had just been measured. Both lists now hold the same instance per candidate.

**Measurement was eager.** Every candidate was measured whether or not anything read the widths — and most are never read. `GetBestPixelSplit` and friends order only the candidates that survive `IsLineLengthOkay`, and `GetBestLengthSplit` orders by character count and never touches pixels at all. Measurement now happens on first read of `LengthPixels`.

The deferred body is the constructor's original code, moved unchanged, so which entries land in the list (note the >1000 character branches add none, which `IsBottomHeavy` depends on) and the `SpaceLengthPixels` side effects are preserved.

### Verification

Swept 599 cases — 12 corpora × 3 max lengths × 6 languages through `AutoBreakLine`, plus `TextSplit.AutoBreak` under four flag combinations — before and after. Byte-identical.

724 libse + 815 UI tests pass, including 13 new ones pinning the lazy measurement: values are measured and stable across reads, the list is empty when `AutoBreakUsePixelWidth` is off, `LengthCharacters` needs no measuring, a >1000 character line still contributes no entry, `DiffFromAverage` works without any pixel measurement, and auto-break still produces two balanced lines with the text preserved.

### The `SpaceLengthPixels` bug, now fixed (second commit)

My first sweep **did not** come out identical, which is how this surfaced.

`TextSplitResult.SpaceLengthPixels` is a `public static float` holding the pixel width of one space (~3.33), which `TotalLengthPixels` subtracts. The branch for lines past the 1000 character cutoff assigned its estimate to that static instead of adding it to the line's own width list:

```csharp
if (Lines[0].Length > 1000)
{
    SpaceLengthPixels = Lines[0].Length * 7;   // a line length, into the space width
}
```

Wrong twice over:

1. **The static was left holding a line length.** A single 1200 character line set it to **8400** instead of ~3.33, and since it is never reset, every later line break in the process was computed against the corrupt value.
2. **Nothing was added to `LengthPixels`.** The list came back with fewer than two entries, while `IsBottomHeavy` and `DiffFromAveragePixelBottomHeavy` index both slots directly.

The estimate now goes where the measurement would have — an over-long line contributes `Length * 7` to `LengthPixels`, the same shape `GetWidth` already uses for text over 128 characters — and `SpaceLengthPixels` is only ever the width of a space again.

Evidence:

| check | result |
| --- | --- |
| fixed vs original, no over-long line in the corpus | 599 rows **byte-identical** |
| fixed with an over-long line first vs fixed without one | 598 shared rows **identical** — cross-contamination gone |
| `SpaceLengthPixels` at end of sweep | **3.33**, where the original left **8400** |

Against the original *with* an over-long line in the corpus, 288 rows differ. That is the bug being fixed, not a regression: those are the lines the original computed against the poisoned static.

Four tests cover it: the over-long line now contributes an entry and the estimate is exact, `IsBottomHeavy`/`DiffFromAveragePixelBottomHeavy` no longer throw, `SpaceLengthPixels` survives an over-long line, and an auto-break gives the same answer before and after one is processed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
