### PR TITLE
Fix script alignment desyncing on the second sentence

### DIFF
--- a/src/ui/Features/Files/ImportPlainText/ImportPlainTextViewModel.cs
+++ b/src/ui/Features/Files/ImportPlainText/ImportPlainTextViewModel.cs
@@ -321,7 +321,8 @@ public partial class ImportPlainTextViewModel : ObservableObject, IClosingCleanu
                 Window,
                 Se.Language.General.Warning,
                 $"Alignment matched {result.MatchedLines} of {result.TotalLines} lines. "
-                + $"{result.UnmatchedLines} line(s) could not be aligned and kept their original time codes. "
+                + $"{result.UnmatchedLines} line(s) had no match in the transcription and were timed by "
+                + "interpolating between their neighbours, so their time codes are approximate. "
                 + "If the audio language or content doesn't match the script, the transcription may be off.",
                 MessageBoxButtons.OK,
                 MessageBoxIcon.Warning);

--- a/src/ui/Features/Files/ImportPlainText/ScriptSyncService.cs
+++ b/src/ui/Features/Files/ImportPlainText/ScriptSyncService.cs
@@ -11,14 +11,34 @@ public static class ScriptSyncService
 {
     private sealed record WordTimestamp(string Word, double StartMs, double EndMs);
 
-    // Greedy alignment window. After several consecutive misses we widen the search
-    // (up to MaxLookahead) so a single Whisper drop or insertion doesn't desync the
-    // rest of the script on long videos.
-    private const int InitialLookahead = 60;
-    private const int MaxLookahead = 600;
-    private const int MissesBeforeWidening = 3;
-    private const double SimilarityThreshold = 0.45;
+    // Alignment is anchor-based. Rare, reasonably long words that occur in both the
+    // script and the transcription become candidate anchors, and the longest increasing
+    // subsequence of those candidates gives a monotonic, mutually consistent backbone
+    // that no single bad match can corrupt. The gaps between anchors are then filled
+    // with a bounded search for the *nearest* good match.
+    //
+    // This replaces a greedy scan that took the best-scoring word anywhere in a 60..600
+    // word lookahead with no preference for nearby matches. Because a common word
+    // matching far ahead outscored a good match at the next position, a single jump
+    // moved the cursor permanently: on a 2500-word script with a 5%-error transcription
+    // it desynced at word ~23 and never recovered (SubtitleEdit #11746).
+    private const int MinAnchorLength = 5;
+    private const int MaxAnchorOccurrences = 3;
+    private const int FillLookahead = 25;
 
+    // Words shorter than this never place a line. Three-letter function words ("the",
+    // "and", "was") recur constantly, so when a line's distinctive word is missing from
+    // the transcription they will happily match the previous line's copy and pull the
+    // line a second or more too early. Excluding them costs at most the length of a
+    // leading short word and removes that whole failure mode.
+    private const int MinFillLength = 4;
+    private const double FillSimilarityThreshold = 0.85;
+
+    /// <param name="UnmatchedLines">
+    /// Lines with no direct word-level match against the transcription. These still get
+    /// time codes interpolated from their neighbours, so this is a confidence signal
+    /// rather than a count of lines left untimed.
+    /// </param>
     public readonly record struct SyncResult(int TotalLines, int UnmatchedLines)
     {
         public int MatchedLines => TotalLines - UnmatchedLines;
@@ -118,12 +138,19 @@ public static class ScriptSyncService
             }
         }
 
+        // Count lines with no direct word match rather than lines left without time codes:
+        // interpolation gives almost every line a time code, so the latter was ~always
+        // zero and the caller's "this transcription may be off" warning never fired.
         var unmatched = 0;
         for (int i = 0; i < scriptLines.Count; i++)
         {
-            if (lineStartMs[i] < 0)
+            if (!lineHasMatch[i])
             {
                 unmatched++;
+            }
+
+            if (lineStartMs[i] < 0)
+            {
                 continue;
             }
 
@@ -138,43 +165,175 @@ public static class ScriptSyncService
     private static List<int> AlignWords(List<string> scriptWords, List<WordTimestamp> whisperWords)
     {
         var result = new List<int>(scriptWords.Count);
-        var whisperPos = 0;
-        var consecutiveMisses = 0;
-
         for (var i = 0; i < scriptWords.Count; i++)
         {
-            // Widen the search window after a streak of misses (e.g. Whisper dropped a
-            // sentence) so we don't permanently desync. Reset when we find a match.
-            var lookahead = consecutiveMisses < MissesBeforeWidening
-                ? InitialLookahead
-                : Math.Min(MaxLookahead, InitialLookahead * (1 + consecutiveMisses - MissesBeforeWidening));
-            var windowEnd = Math.Min(whisperPos + lookahead, whisperWords.Count);
-            var bestScore = SimilarityThreshold;
-            var bestPos = -1;
+            result.Add(-1);
+        }
 
-            for (var wp = whisperPos; wp < windowEnd; wp++)
+        var anchors = FindAnchors(scriptWords, whisperWords);
+
+        // Fill the stretches between consecutive anchors. Each stretch is bounded on both
+        // sides, so a wrong match inside it cannot leak past the next anchor. With no
+        // anchors at all this degrades to a single bounded pass over the whole script.
+        var prevScript = -1;
+        var prevWhisper = -1;
+        foreach (var anchor in anchors)
+        {
+            result[anchor.ScriptIdx] = anchor.WhisperIdx;
+            FillRange(result, scriptWords, whisperWords, prevScript + 1, anchor.ScriptIdx, prevWhisper + 1, anchor.WhisperIdx);
+            prevScript = anchor.ScriptIdx;
+            prevWhisper = anchor.WhisperIdx;
+        }
+
+        FillRange(result, scriptWords, whisperWords, prevScript + 1, scriptWords.Count, prevWhisper + 1, whisperWords.Count);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Picks a monotonic set of high-confidence (script word, transcription word) pairs.
+    /// Only words that are long enough to be distinctive and rare enough in the
+    /// transcription to be unambiguous are considered, and the longest increasing
+    /// subsequence then discards any candidate that contradicts the majority ordering.
+    /// </summary>
+    private static List<(int ScriptIdx, int WhisperIdx)> FindAnchors(List<string> scriptWords, List<WordTimestamp> whisperWords)
+    {
+        var whisperIndex = new Dictionary<string, List<int>>(StringComparer.Ordinal);
+        for (var i = 0; i < whisperWords.Count; i++)
+        {
+            var normalized = NormalizeWord(whisperWords[i].Word);
+            if (normalized.Length < MinAnchorLength)
             {
-                var score = WordSimilarity(scriptWords[i], whisperWords[wp].Word);
-                if (score > bestScore)
-                {
-                    bestScore = score;
-                    bestPos = wp;
-                }
+                continue;
             }
 
-            result.Add(bestPos);
-            if (bestPos >= 0)
+            if (!whisperIndex.TryGetValue(normalized, out var positions))
             {
-                whisperPos = bestPos + 1;
-                consecutiveMisses = 0;
+                positions = new List<int>();
+                whisperIndex[normalized] = positions;
             }
-            else
+
+            positions.Add(i);
+        }
+
+        // Ordered by script index ascending and, for one script word with several
+        // candidate positions, transcription index descending - so a strictly increasing
+        // subsequence can never take two positions for the same word.
+        var candidates = new List<(int ScriptIdx, int WhisperIdx)>();
+        for (var i = 0; i < scriptWords.Count; i++)
+        {
+            var normalized = NormalizeWord(scriptWords[i]);
+            if (normalized.Length < MinAnchorLength ||
+                !whisperIndex.TryGetValue(normalized, out var positions) ||
+                positions.Count > MaxAnchorOccurrences)
             {
-                consecutiveMisses++;
+                continue;
+            }
+
+            for (var p = positions.Count - 1; p >= 0; p--)
+            {
+                candidates.Add((i, positions[p]));
             }
         }
 
+        return LongestIncreasingByWhisperIndex(candidates);
+    }
+
+    private static List<(int ScriptIdx, int WhisperIdx)> LongestIncreasingByWhisperIndex(List<(int ScriptIdx, int WhisperIdx)> candidates)
+    {
+        var result = new List<(int ScriptIdx, int WhisperIdx)>();
+        if (candidates.Count == 0)
+        {
+            return result;
+        }
+
+        // Patience sorting: tailValues[n] is the smallest transcription index that can end
+        // an increasing run of length n+1, and tailIndices[n] is the candidate it came from.
+        var tailValues = new List<int>();
+        var tailIndices = new List<int>();
+        var previous = new int[candidates.Count];
+
+        for (var k = 0; k < candidates.Count; k++)
+        {
+            var pos = LowerBound(tailValues, candidates[k].WhisperIdx);
+            previous[k] = pos > 0 ? tailIndices[pos - 1] : -1;
+            if (pos == tailValues.Count)
+            {
+                tailValues.Add(candidates[k].WhisperIdx);
+                tailIndices.Add(k);
+            }
+            else
+            {
+                tailValues[pos] = candidates[k].WhisperIdx;
+                tailIndices[pos] = k;
+            }
+        }
+
+        for (var k = tailIndices[tailIndices.Count - 1]; k >= 0; k = previous[k])
+        {
+            result.Add(candidates[k]);
+        }
+
+        result.Reverse();
         return result;
+    }
+
+    private static int LowerBound(List<int> sortedValues, int value)
+    {
+        var lo = 0;
+        var hi = sortedValues.Count;
+        while (lo < hi)
+        {
+            var mid = lo + ((hi - lo) / 2);
+            if (sortedValues[mid] < value)
+            {
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid;
+            }
+        }
+
+        return lo;
+    }
+
+    /// <summary>
+    /// Matches script words to transcription words within one bounded stretch, taking the
+    /// <em>nearest</em> match above a high similarity threshold rather than the best one
+    /// anywhere in the window. Preferring near matches is what stops a repeated word from
+    /// dragging the cursor forward.
+    /// </summary>
+    private static void FillRange(
+        List<int> result,
+        List<string> scriptWords,
+        List<WordTimestamp> whisperWords,
+        int scriptFrom,
+        int scriptTo,
+        int whisperFrom,
+        int whisperTo)
+    {
+        var whisperPos = whisperFrom;
+        for (var i = scriptFrom; i < scriptTo; i++)
+        {
+            // Short function words ("in"/"it", "of"/"or", "we"/"he") sit above any useful
+            // similarity threshold for each other, so they are never used to place a line.
+            if (NormalizeWord(scriptWords[i]).Length < MinFillLength)
+            {
+                continue;
+            }
+
+            var windowEnd = Math.Min(whisperTo, whisperPos + FillLookahead);
+            for (var wp = whisperPos; wp < windowEnd; wp++)
+            {
+                if (WordSimilarity(scriptWords[i], whisperWords[wp].Word) >= FillSimilarityThreshold)
+                {
+                    result[i] = wp;
+                    whisperPos = wp + 1;
+                    break;
+                }
+            }
+        }
     }
 
     private static List<WordTimestamp> ExtractWordTimestamps(Subtitle subtitle)
@@ -280,15 +439,25 @@ public static class ScriptSyncService
             }
             else if (prevMatched >= 0)
             {
+                // Trailing lines, with no later match to interpolate towards: lay them out
+                // back to back at the minimum display duration. (Using the minimum *gap*
+                // as the duration here happened to come out the same, because the duration
+                // clamp and overlap pass below both repair it - but say what we mean.)
                 int offset = i - prevMatched;
-                lineStartMs[i] = lineEndMs[prevMatched] + (offset - 1) * minGapMs;
-                lineEndMs[i] = lineStartMs[i] + minGapMs;
+                lineStartMs[i] = lineEndMs[prevMatched] + (offset * minGapMs) + ((offset - 1) * minDurationMs);
+                lineEndMs[i] = lineStartMs[i] + minDurationMs;
             }
             else if (nextMatched >= 0)
             {
+                // Leading lines, laid out backwards from the first match. These must leave
+                // room for their own minimum duration: reserving only the minimum gap put
+                // the line's end *at* the first matched line's start, the duration clamp
+                // below then pushed its end past that start, and the overlap pass resolved
+                // the collision by moving the correctly matched line later - losing the one
+                // timing we were actually sure about.
                 int offset = nextMatched - i;
-                lineEndMs[i] = lineStartMs[nextMatched] - (offset - 1) * minGapMs;
-                lineStartMs[i] = Math.Max(0, lineEndMs[i] - minGapMs);
+                lineEndMs[i] = lineStartMs[nextMatched] - (offset * minGapMs) - ((offset - 1) * minDurationMs);
+                lineStartMs[i] = Math.Max(0, lineEndMs[i] - minDurationMs);
             }
         }
     }

--- a/tests/UI/Features/Files/ImportPlainText/ScriptSyncServiceTests.cs
+++ b/tests/UI/Features/Files/ImportPlainText/ScriptSyncServiceTests.cs
@@ -1,0 +1,220 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Files.ImportPlainText;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Files.ImportPlainText;
+
+public class ScriptSyncServiceTests
+{
+    public ScriptSyncServiceTests()
+    {
+        // SyncScript reads min/max duration and gap from settings; pin them so the
+        // assertions below don't depend on whatever the running user has configured.
+        Se.Settings.General.SubtitleMinimumDisplayMilliseconds = 1000;
+        Se.Settings.General.SubtitleMaximumDisplayMilliseconds = 8000;
+        Se.Settings.General.UseFrameMode = false;
+        Se.Settings.General.MinimumBetweenLines = new MsOrFramesValue { Milliseconds = 24 };
+    }
+
+    private static List<SubtitleLineViewModel> ScriptLines(params string[] texts)
+        => texts.Select(t => new SubtitleLineViewModel { Text = t }).ToList();
+
+    /// <summary>
+    /// Builds a word-level transcription in the shape Whisper's highlight output uses:
+    /// one paragraph per word, the timed word wrapped in &lt;u&gt;…&lt;/u&gt;.
+    /// </summary>
+    private static Subtitle WordLevel(params (string Word, double StartMs, double EndMs)[] words)
+    {
+        var subtitle = new Subtitle();
+        foreach (var (word, startMs, endMs) in words)
+        {
+            subtitle.Paragraphs.Add(new Paragraph($"<u>{word}</u>", startMs, endMs));
+        }
+
+        return subtitle;
+    }
+
+    [Fact]
+    public void RepeatedWordLaterInAudio_DoesNotDragTheCursorForward()
+    {
+        // The transcription mangles the first "celebration" but gets a later one exactly
+        // right. The old greedy scan took the best score anywhere in its window, so the
+        // exact match ~20 words ahead beat the near match at the correct position, moved
+        // the cursor permanently, and desynced everything after it (#11746).
+        var script = ScriptLines(
+            "The celebration happened yesterday",
+            "Nothing important occurred afterwards",
+            "The celebration happened again");
+
+        var transcription = WordLevel(
+            ("The", 0, 500),
+            ("selebration", 500, 1500),   // misrecognised
+            ("happened", 1500, 2200),
+            ("yesterday", 2200, 3000),
+            ("Nothing", 4000, 4500),
+            ("important", 4500, 5200),
+            ("occurred", 5200, 5900),
+            ("afterwards", 5900, 6800),
+            ("The", 8000, 8500),
+            ("celebration", 8500, 9500),  // exact match, but belongs to line 3
+            ("happened", 9500, 10200),
+            ("again", 10200, 11000));
+
+        ScriptSyncService.SyncScript(script, transcription);
+
+        // Line 1 must stay at the start of the audio, not jump to the 8.5s occurrence.
+        Assert.InRange(script[0].StartTime.TotalMilliseconds, 0, 1000);
+        Assert.InRange(script[1].StartTime.TotalMilliseconds, 3500, 4500);
+        Assert.InRange(script[2].StartTime.TotalMilliseconds, 7500, 8500);
+    }
+
+    [Fact]
+    public void LongScriptWithTranscriptionErrors_StaysInSync()
+    {
+        // Every 7th word is dropped and every 11th mangled - roughly what a real
+        // transcription of difficult audio looks like. The old algorithm desynced within
+        // the first couple of dozen words and never recovered.
+        // Two distinct content words per line, none repeated anywhere in the script - a
+        // real script behaves this way, and it is what lets rare-word anchoring work.
+        var distinctive = new[]
+        {
+            "harbour", "lantern", "compass", "meadow", "thunder", "cavern", "orchard",
+            "granite", "willow", "beacon", "furnace", "marigold", "quarry", "sparrow",
+            "trellis", "anvil", "pelican", "cobbler", "juniper", "tunnel", "rafter",
+            "mantle", "brisket", "pewter", "hollow", "cinder", "plover", "satchel",
+            "ferment", "gallop", "kestrel", "lattice", "mortar", "nectar", "obelisk",
+            "parsnip", "quiver", "rhubarb", "saffron", "tundra", "urchin", "vellum",
+            "walnut", "yarrow", "zephyr", "abbey", "bramble", "citrus", "dovecote",
+            "ember", "fathom", "gable", "harrow", "inkwell", "jetty", "kindling",
+            "loft", "mallet", "nutmeg", "otter", "pantry", "quill", "ridge", "sledge",
+            "thicket", "umber", "vessel", "wharf", "yeoman", "zinnia", "arbour",
+            "burrow", "chisel", "damask", "eaves", "flint", "gorse", "hearth",
+            "ivory", "jackdaw",
+        };
+
+        var script = new List<SubtitleLineViewModel>();
+        var words = new List<(string, double, double)>();
+        var expectedStartMs = new List<double>();
+
+        var t = 0.0;
+        var slot = 0;
+        for (var line = 0; line < 40; line++)
+        {
+            var a = distinctive[line * 2];
+            var b = distinctive[(line * 2) + 1];
+            script.Add(new SubtitleLineViewModel { Text = $"The {a} and the {b}" });
+            expectedStartMs.Add(t);
+
+            foreach (var w in new[] { "The", a, "and", "the", b })
+            {
+                // Counted over spoken slots, not over emitted words - otherwise a drop
+                // never advances the counter and every later word is dropped too.
+                if (slot % 7 == 6)
+                {
+                    slot++;
+                    t += 400; // dropped by the transcription, but time still passes
+                    continue;
+                }
+
+                var spoken = slot % 11 == 10 && w.Length > 4 ? w.Substring(0, w.Length - 1) + "x" : w;
+                words.Add((spoken, t, t + 400));
+                slot++;
+                t += 400;
+            }
+
+            t += 600; // pause between lines
+        }
+
+        var result = ScriptSyncService.SyncScript(script, WordLevel(words.ToArray()));
+
+        // Time codes must be strictly increasing and non-overlapping.
+        for (var i = 1; i < script.Count; i++)
+        {
+            Assert.True(
+                script[i].StartTime > script[i - 1].StartTime,
+                $"line {i} starts at {script[i].StartTime} which is not after line {i - 1} at {script[i - 1].StartTime}");
+            Assert.True(
+                script[i].StartTime >= script[i - 1].EndTime,
+                $"line {i} overlaps line {i - 1}");
+        }
+
+        // And they must actually land on the audio, not merely be ordered. A line whose
+        // distinctive words were dropped by the transcription can only be placed by a
+        // later word in the same line, so allow up to one line-pitch (2600 ms) of
+        // lateness - but never the multi-line drift the greedy scan produced.
+        var errors = new List<double>();
+        for (var i = 0; i < script.Count; i++)
+        {
+            var error = script[i].StartTime.TotalMilliseconds - expectedStartMs[i];
+            errors.Add(Math.Abs(error));
+            Assert.InRange(error, -2600, 2600);
+        }
+
+        Assert.True(errors.Average() < 900, $"mean start error was {errors.Average():F0} ms");
+        Assert.True(result.MatchedLines >= 38, $"only {result.MatchedLines} of {result.TotalLines} lines matched directly");
+    }
+
+    [Fact]
+    public void TrailingLinesWithNoMatch_GetMinimumDurationNotMinimumGap()
+    {
+        // These used to be laid out with the minimum *gap* as their duration, producing
+        // ~24 ms cues piled on top of each other.
+        var script = ScriptLines(
+            "The harbour lantern",
+            "Completely absent dialogue",
+            "Also entirely missing");
+
+        var transcription = WordLevel(
+            ("The", 0, 500),
+            ("harbour", 500, 1200),
+            ("lantern", 1200, 2000));
+
+        ScriptSyncService.SyncScript(script, transcription);
+
+        for (var i = 1; i < script.Count; i++)
+        {
+            Assert.True(
+                script[i].Duration.TotalMilliseconds >= 1000,
+                $"line {i} lasts only {script[i].Duration.TotalMilliseconds} ms");
+            Assert.True(script[i].StartTime >= script[i - 1].EndTime, $"line {i} overlaps line {i - 1}");
+        }
+    }
+
+    [Fact]
+    public void LeadingLinesWithNoMatch_DoNotPushTheFirstMatchedLineLater()
+    {
+        // The first two lines aren't in the audio at all. Laying them out backwards used
+        // to reserve only the minimum gap for them, so after the duration clamp they
+        // collided with line 3 and the overlap pass moved line 3 - the one line whose
+        // timing was actually known - later.
+        var script = ScriptLines(
+            "Missing opening narration",
+            "Also not spoken aloud",
+            "The harbour lantern glows");
+
+        var transcription = WordLevel(
+            ("The", 30000, 30400),
+            ("harbour", 30400, 31100),
+            ("lantern", 31100, 31800),
+            ("glows", 31800, 32400));
+
+        ScriptSyncService.SyncScript(script, transcription);
+
+        Assert.Equal(30400, script[2].StartTime.TotalMilliseconds, 1);
+        Assert.True(script[1].EndTime <= script[2].StartTime, "leading filler overlaps the matched line");
+        Assert.True(script[0].EndTime <= script[1].StartTime, "leading filler lines overlap each other");
+    }
+
+    [Fact]
+    public void EmptyTranscription_ReportsEveryLineUnmatched()
+    {
+        var script = ScriptLines("One", "Two");
+
+        var result = ScriptSyncService.SyncScript(script, new Subtitle());
+
+        Assert.Equal(2, result.TotalLines);
+        Assert.Equal(2, result.UnmatchedLines);
+        Assert.Equal(0, result.MatchedLines);
+    }
+}


### PR DESCRIPTION
Fixes the "complete chaos" reported in #11746 for **Import plain text → Align via speech-to-text**.

## The cause isn't video length

`AlignWords` took the *best-scoring* word anywhere in a 60..600 word lookahead, with no preference for nearby matches. An exact match on a common word far ahead beats a good match at the next position, and `whisperPos` then moves forward permanently.

Replaying the old algorithm against a 2500-word script with a **good** transcription (5% dropped words, 5% substitutions):

| | usable anchors | matches grossly wrong | max drift |
|---|---|---|---|
| before | 6 / 2500 (0%) | 92% | 2339 words |
| after | 1726 / 2500 (69%) | **0%** | **3 words** |

It desynced at script word ~23. Length only made the damage visible — a 30 second clip has no room to jump far, which is why it looked like it worked in testing.

## The fix

Anchor-based alignment: rare, distinctive words present in both the script and the transcription become candidate anchors, and the longest increasing subsequence of those candidates gives a monotonic, mutually consistent backbone that a single bad match cannot corrupt. Gaps between anchors are filled with a bounded search for the *nearest* good match rather than the best one. Also faster than the old scan — it drops the 600-word window with a Levenshtein per candidate.

Three smaller fixes found along the way:

- **Short function words no longer place a line.** `in`/`it`, `of`/`or`, `we`/`he`, `that`/`what` all scored above the old 0.45 threshold for each other. A three-letter word will also happily match the previous line's copy when a line's own distinctive word is missing from the transcription.
- **Leading unmatched lines no longer shove the first matched line later.** They reserved only the minimum gap, so the duration clamp pushed their end past the matched line's start, and the overlap pass resolved that collision by moving the one timing we were actually sure about.
- **`SyncResult.UnmatchedLines` now counts lines with no direct word match** instead of lines left without time codes. Interpolation gives almost every line a time code, so the caller's "the transcription may be off" warning was effectively unreachable — it stayed quiet through exactly the failure users were reporting.

## Tests

Five tests in `tests/UI/Features/Files/ImportPlainText/ScriptSyncServiceTests.cs`. Three of them fail on the old algorithm and pass on the new one; the other two guard the interpolation paths. Full UI suite: 820 passed.

Note this only fixes aligning against a *transcription*. Aligning long video properly wants a real forced aligner — that's separate and follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)