### PR TITLE
Fix false-positive ¿que→¿qué OCR accenting in Spanish (#12834)

### DIFF
--- a/Dictionaries/spa_OCRFixReplaceList.xml
+++ b/Dictionaries/spa_OCRFixReplaceList.xml
@@ -423,7 +423,7 @@
     <!-- Acentos al principio de los signos de interrogación con minúsculas -->
     <LinePart from="¿aun" to="¿aún" />
     <LinePart from="¿tu " to="¿tú " />
-    <LinePart from="¿que " to="¿qué " />
+    <!-- ¿que/¿Que -> ¿qué/¿Qué handled by a guarded RegEx (see RegularExpressions) to avoid false positives on echo questions like "¿Que nos separaremos?" (#12834) -->
     <LinePart from="¿sabes que" to="¿sabes qué" />
     <LinePart from="¿sabes adonde" to="¿sabes adónde" />
     <LinePart from="¿sabes cual" to="¿sabes cuál" />
@@ -542,7 +542,7 @@
     <LinePart from="¿estas " to="¿estás " />
     <!-- Acentos al principio de los signos de interrogación con mayúsculas -->
     <LinePart from="¿Aun" to="¿Aún" />
-    <LinePart from="¿Que " to="¿Qué " />
+    <!-- ¿Que -> ¿Qué handled by a guarded RegEx (see RegularExpressions), see #12834 -->
     <LinePart from="¿Sabes que" to="¿Sabes qué" />
     <LinePart from="¿Sabes adonde" to="¿Sabes adónde" />
     <LinePart from="¿Sabes cual" to="¿Sabes cuál" />
@@ -721,6 +721,9 @@
     <Ending from=".»." to="»." />
   </EndLines>
   <RegularExpressions>
+    <!-- Acento interrogativo: ¿que/¿Que -> ¿qué/¿Qué, pero no cuando es una pregunta de eco/reformulación
+         seguida de pronombre de sujeto o de sí/si/no (p. ej. "¿Que yo?", "¿Que tú lo sabías?", "¿Que sí?"). Ver #12834. -->
+    <RegEx find="¿([Qq])ue (?!(?i:yo|tú|usted|ustedes|él|ella|ellos|ellas|nosotros|nosotras|vosotros|vosotras|sí|si|no)\b)" replaceWith="¿$1ué " />
     <!-- Abreviaturas compuestas -->
     <RegEx find="\b[Ss](r|ra|rta)\b\.?" replaceWith="S$1." />
     <RegEx find="\b[Dd](r|ra)\b\.?" replaceWith="D$1." />


### PR DESCRIPTION
Fixes #12834.

## Problem

`spa_OCRFixReplaceList.xml` accented every `¿que `/`¿Que ` to `¿qué `/`¿Qué ` via two blunt `LinePart` rules. That corrupts valid **echo/reformulation questions** where `que` is an unaccented conjunction, e.g. `¿Que nos separaremos?` (roughly "[You're saying] that we'll separate?!") — the `qué` accent is wrong there.

## Change

Removed the two `LinePart` rules and replaced them with a single guarded rule in `<RegularExpressions>`:

```xml
<RegEx find="¿([Qq])ue (?!(?i:yo|tú|usted|ustedes|él|ella|ellos|ellas|nosotros|nosotras|vosotros|vosotras|sí|si|no)\b)" replaceWith="¿$1ué " />
```

The negative lookahead keeps the common interrogative fix but skips echo questions that open with a subject pronoun or `sí/si/no`, since the interrogative `qué` never precedes those.

| Input | Result | |
|---|---|---|
| `¿Que haces?` | `¿Qué haces?` | fixed |
| `¿que quieres?` | `¿qué quieres?` | fixed |
| `¿Que yo?` | unchanged | echo skipped |
| `¿Que tú lo sabías?` | unchanged | echo skipped |
| `¿Que sí?` / `¿Que no vienes?` | unchanged | echo skipped |

## Known limitation

The reporter's exact example `¿Que nos separaremos?` uses the **clitic** `nos`, which also appears in genuine interrogatives (`¿Qué nos importa?`, `¿Qué te pasa?`). That distinction is semantic (gap vs. complete clause), not detectable by pattern, so clitic-led echoes are left as-is — excluding clitics would silence far more correct fixes than it would save.

Only the `spa_` dictionary contained this pattern; no other language files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)