### PR TITLE
Make Delete remove the selected files in batch convert

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -2609,6 +2609,16 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         IsOpenContainingFolderVisible = FileGrid.SelectedItems.Count == 1;
     }
 
+    internal void FileGridKeyDown(object? sender, KeyEventArgs e)
+    {
+        // Delete removes the selected files, like the "Remove" button/context menu item.
+        if (e.Key == Key.Delete && e.Source is not TextBox && !IsConverting)
+        {
+            e.Handled = true;
+            RemoveSelectedFilesCommand.Execute(null);
+        }
+    }
+
     internal void ComboBoxSubtitleFormatPointerPressed(object? sender, PointerPressedEventArgs e)
     {
         // Open the format picker on right-click (or Mac Ctrl+left-click), like the main window's

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
@@ -220,6 +220,7 @@ public class BatchConvertWindow : Window
             },
         };
         dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedBatchItem)) { Source = vm });
+        dataGrid.KeyDown += vm.FileGridKeyDown;
         vm.FileGrid = dataGrid;
         _ = new DataGridCheckboxMultiSelect<BatchConvertItem>(dataGrid);
 


### PR DESCRIPTION
The files grid in the **Batch convert** window had no `Delete` key handler, so pressing <kbd>Delete</kbd> did nothing — files could only be removed with the *Remove* button or the context menu.

`Delete` now runs the same `RemoveSelectedFiles` command (respecting `PromptBeforeDelete`), matching how the other list windows behave. It is ignored while a conversion is running, and while a text box has focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)