### PR TITLE
Fix Alt+drag killing all shortcuts, and run alignment shortcuts in the text box

### DIFF
--- a/src/ui/Features/Main/MainView.cs
+++ b/src/ui/Features/Main/MainView.cs
@@ -121,6 +121,11 @@ public class MainView : ViewBase
         AddHandler(KeyDownEvent, _vm.OnKeyDownHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: false);
         AddHandler(KeyUpEvent, _vm.OnKeyUpHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: true);
 
+        // Tunnelling, and handledEventsToo since controls like the waveform mark their presses handled:
+        // needed to see that Alt was held for a mouse gesture and cancel the menu-bar activation that
+        // would otherwise fire on the Alt release (discussion #11744).
+        AddHandler(PointerPressedEvent, _vm.OnPointerPressedHandler, RoutingStrategies.Tunnel, handledEventsToo: true);
+
         return root;
     }
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -302,6 +302,7 @@ public partial class MainViewModel :
     FindViewModel? _findViewModel;
     Control? _findPreviousFocus;
     Control? _focusBeforeMainMenu;
+    readonly AltMenuActivationGuard _altMenuActivationGuard = new();
     bool _findClosingProgrammatically;
     ReplaceViewModel? _replaceViewModel;
     Control? _replacePreviousFocus;
@@ -20299,6 +20300,7 @@ public partial class MainViewModel :
         // every shortcut afterwards (Ctrl+I, Find, Replace, ...) unable to match until the set was
         // cleared by some other action (issue #11548).
         _shortcutManager.ClearKeys();
+        _altMenuActivationGuard.Reset();
 
         // A task switch (Alt+Tab) must also drop any active menu-bar state. Otherwise Avalonia leaves
         // the access-key underlines / selection armed and they reappear when the window is re-activated,
@@ -20337,20 +20339,29 @@ public partial class MainViewModel :
             return TopLevel.GetTopLevel(menuItem) != null;
         }
 
-        if (ReferenceEquals(focusedElement, Menu))
+        return IsWithinMainMenu(focusedElement as Visual);
+    }
+
+    /// <summary>
+    /// True when <paramref name="visual"/> is the main menu itself or lives inside it. Drop-down items
+    /// are hosted in a popup, so they are not covered here - callers that need them check for a focused
+    /// <see cref="MenuItem"/> (see <see cref="IsMainMenuFocused"/>) or for an open menu.
+    /// </summary>
+    private bool IsWithinMainMenu(Visual? visual)
+    {
+        if (Menu == null)
         {
-            return true;
+            return false;
         }
 
-        var parent = (focusedElement as Avalonia.Visual)?.GetVisualParent();
-        while (parent != null)
+        while (visual != null)
         {
-            if (ReferenceEquals(parent, Menu))
+            if (ReferenceEquals(visual, Menu))
             {
                 return true;
             }
 
-            parent = parent.GetVisualParent();
+            visual = visual.GetVisualParent();
         }
 
         return false;
@@ -20893,12 +20904,49 @@ public partial class MainViewModel :
         ReferenceEquals(command, TextBoxSelectAllCommand) ||
         ReferenceEquals(command, TextBoxDeleteSelectionCommand);
 
+    /// <summary>
+    /// Tunnelling pointer handler that tells <see cref="_altMenuActivationGuard"/> when Alt was used as
+    /// a mouse modifier (e.g. Alt+drag in the waveform), so the menu-bar activation Avalonia performs on
+    /// the following Alt release can be undone again (discussion #11744).
+    /// </summary>
+    internal void OnPointerPressedHandler(object? sender, PointerPressedEventArgs e)
+    {
+        if (!e.KeyModifiers.HasFlag(KeyModifiers.Alt))
+        {
+            return; // plain clicks arm nothing, and this runs on every press in the window
+        }
+
+        var isMenuPress = Menu is { IsOpen: true } || IsWithinMainMenu(e.Source as Visual);
+        _altMenuActivationGuard.NotifyPointerPressed(true, isMenuPress);
+
+        // The clicked control takes focus while the press is being handled, so read the resulting focus
+        // afterwards - that is where focus must return when the activation is undone. Posted at Normal
+        // priority, which runs before the next input event (the Alt release) is dispatched.
+        Dispatcher.UIThread.Post(() =>
+            _altMenuActivationGuard.NotifyFocusAfterPointerPress(Window?.FocusManager?.GetFocusedElement() as Control));
+    }
+
     public void OnKeyUpHandler(object? sender, KeyEventArgs e)
     {
         if (_setEndAtKeyUpLine != null)
         {
             _setEndAtKeyUpLine = null;
             _setEndAtKeyUpLineGoToNext = false;
+        }
+
+        // Undo the menu-bar activation Avalonia performs when Alt is released after an Alt+click/drag.
+        // Its AccessKeyHandler runs in the window's tunnel phase, so the menu is already open and
+        // focused by the time we get here - without this, IsMainMenuFocused() in OnKeyDownHandler
+        // swallows every shortcut until the user clicks something (discussion #11744).
+        if (_altMenuActivationGuard.TryConsumeAltRelease(e.Key, out var focusToRestore) &&
+            (Menu is { IsOpen: true } || IsMainMenuFocused()))
+        {
+            if (focusToRestore is { IsEffectivelyVisible: true })
+            {
+                _focusBeforeMainMenu = focusToRestore;
+            }
+
+            DeactivateMainMenu();
         }
 
         _shortcutManager.OnKeyReleased(this, e);

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -79,6 +79,7 @@ public partial class BinaryEditViewModel : ObservableObject
 
     private ScrollViewer? _subtitleGridScrollViewer;
     private Control? _focusBeforeMenu;
+    private readonly AltMenuActivationGuard _altMenuActivationGuard = new();
 
     private readonly IFileHelper _fileHelper;
     private readonly IFolderHelper _folderHelper;
@@ -2448,8 +2449,63 @@ public partial class BinaryEditViewModel : ObservableObject
         }
     }
 
+    /// <summary>
+    /// Tunnelling pointer handler that tells <see cref="_altMenuActivationGuard"/> when Alt was used as
+    /// a mouse modifier, so the menu-bar activation Avalonia performs on the following Alt release can
+    /// be undone again (discussion #11744).
+    /// </summary>
+    internal void OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!e.KeyModifiers.HasFlag(KeyModifiers.Alt))
+        {
+            return; // plain clicks arm nothing, and this runs on every press in the window
+        }
+
+        var isMenuPress = Menu is { IsOpen: true } || IsWithinMenu(e.Source as Visual);
+        _altMenuActivationGuard.NotifyPointerPressed(true, isMenuPress);
+
+        // The clicked control takes focus while the press is being handled, so read the resulting focus
+        // afterwards - that is where focus must return when the activation is undone.
+        Dispatcher.UIThread.Post(() =>
+            _altMenuActivationGuard.NotifyFocusAfterPointerPress(Window?.FocusManager?.GetFocusedElement() as Control));
+    }
+
+    private bool IsWithinMenu(Visual? visual)
+    {
+        if (Menu == null)
+        {
+            return false;
+        }
+
+        while (visual != null)
+        {
+            if (ReferenceEquals(visual, Menu))
+            {
+                return true;
+            }
+
+            visual = visual.GetVisualParent();
+        }
+
+        return false;
+    }
+
     public void OnKeyUp(KeyEventArgs e)
     {
+        // Undo the menu-bar activation Avalonia performs when Alt is released after an Alt+click/drag -
+        // otherwise the IsMenuFocused() guard in OnKeyDown swallows every shortcut until the user clicks
+        // something (discussion #11744).
+        if (_altMenuActivationGuard.TryConsumeAltRelease(e.Key, out var focusToRestore) &&
+            (Menu is { IsOpen: true } || IsMenuFocused()))
+        {
+            if (focusToRestore is { IsEffectivelyVisible: true })
+            {
+                _focusBeforeMenu = focusToRestore;
+            }
+
+            DeactivateMenu();
+        }
+
         _shortcutManager.OnKeyReleased(this, e);
     }
 
@@ -2518,6 +2574,7 @@ public partial class BinaryEditViewModel : ObservableObject
         // A task switch (Alt+Tab) must drop any active menu-bar state, otherwise Avalonia leaves
         // the access-key underlines / selection armed and they reappear when the window is re-activated
         // (#11745 beta-2 feedback).
+        _altMenuActivationGuard.Reset();
         if (Menu is { IsOpen: true } || IsMenuFocused())
         {
             DeactivateMenu();

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Shapes;
 using Avalonia.Data;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using System;
@@ -141,6 +142,11 @@ public class BinaryEditWindow : Window
         Content = mainGrid;
         AddHandler(KeyDownEvent, (_, args) => vm.OnKeyDown(args), handledEventsToo: true);
         AddHandler(KeyUpEvent, (_, args) => vm.OnKeyUp(args), handledEventsToo: true);
+
+        // Tunnelling, and handledEventsToo since controls may mark their presses handled: needed to see
+        // that Alt was held for a mouse gesture and cancel the menu-bar activation that would otherwise
+        // fire on the Alt release (discussion #11744).
+        AddHandler(PointerPressedEvent, vm.OnPointerPressed, RoutingStrategies.Tunnel, handledEventsToo: true);
         Loaded += (_, _) =>
         {
             // Measure controls at natural (unconstrained) size so MinWidth is font-size-aware

--- a/src/ui/Logic/AltMenuActivationGuard.cs
+++ b/src/ui/Logic/AltMenuActivationGuard.cs
@@ -1,0 +1,85 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Cancels the menu-bar activation that Avalonia arms on Alt down when Alt turned out to be a mouse
+/// modifier instead - e.g. Alt+drag in the waveform to adjust a time code (discussion #11744).
+///
+/// Avalonia's AccessKeyHandler arms the activation on Alt down and only disarms it when another
+/// <em>key</em> is pressed; its pointer handler clears the access-key underlines but not the internal
+/// "showing access keys" flag, so releasing Alt after an Alt+click still runs MainMenu.Open(). The
+/// menu bar then takes keyboard focus and the window key handler hands every following key to the
+/// menu - which the user sees as "all shortcuts stopped working until I click something".
+///
+/// Windows itself cancels menu activation when Alt is combined with a mouse click; this restores that
+/// behavior. The guard is pure state: the owner wires it to a tunnelling PointerPressed handler and to
+/// its key-up handler, and undoes the activation itself when <see cref="TryConsumeAltRelease"/> says so.
+/// </summary>
+public sealed class AltMenuActivationGuard
+{
+    private bool _isArmed;
+    private Control? _focusAfterPointerPress;
+
+    /// <summary>
+    /// Call from a tunnelling PointerPressed handler on the window content.
+    /// </summary>
+    /// <param name="isAltDown">True when Alt was held during the press.</param>
+    /// <param name="isMenuPress">
+    /// True when the press belongs to the menu (the menu bar is already open, or the press landed on
+    /// it) - such a press should open the menu as usual, so no activation is cancelled.
+    /// </param>
+    public void NotifyPointerPressed(bool isAltDown, bool isMenuPress)
+    {
+        if (!isAltDown || isMenuPress)
+        {
+            return;
+        }
+
+        _isArmed = true;
+        _focusAfterPointerPress = null;
+    }
+
+    /// <summary>
+    /// Records the control that ended up with keyboard focus because of the press, so focus can be
+    /// returned there when the menu activation is undone. Read after the press has been handled (the
+    /// clicked control takes focus during the press, not before it).
+    /// </summary>
+    public void NotifyFocusAfterPointerPress(Control? focused)
+    {
+        if (_isArmed)
+        {
+            _focusAfterPointerPress = focused;
+        }
+    }
+
+    /// <summary>
+    /// True when <paramref name="key"/> ends an Alt+pointer gesture, meaning the caller should undo any
+    /// menu activation Avalonia just performed. <paramref name="focusToRestore"/> is the control that
+    /// had focus after the press, or null when it is unknown.
+    /// </summary>
+    public bool TryConsumeAltRelease(Key key, out Control? focusToRestore)
+    {
+        focusToRestore = null;
+
+        if (!_isArmed || key is not (Key.LeftAlt or Key.RightAlt))
+        {
+            return false;
+        }
+
+        focusToRestore = _focusAfterPointerPress;
+        Reset();
+        return true;
+    }
+
+    /// <summary>
+    /// Drops any armed state, e.g. when the window is deactivated by a task switch and the Alt release
+    /// never arrives.
+    /// </summary>
+    public void Reset()
+    {
+        _isArmed = false;
+        _focusAfterPointerPress = null;
+    }
+}

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -487,16 +487,18 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.DeleteSelectedLinesCommand, nameof(vm.DeleteSelectedLinesCommand), ShortcutCategory.SubtitleGrid);
         AddShortcut(shortcuts, vm.RippleDeleteSelectedLinesCommand, nameof(vm.RippleDeleteSelectedLinesCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.DuplicateSelectedLinesCommand, nameof(vm.DuplicateSelectedLinesCommand), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.ShowAlignmentPickerCommand, nameof(vm.ShowAlignmentPickerCommand), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.DoAlignmentAn1Command, nameof(vm.DoAlignmentAn1Command), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.DoAlignmentAn2Command, nameof(vm.DoAlignmentAn2Command), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.DoAlignmentAn3Command, nameof(vm.DoAlignmentAn3Command), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.DoAlignmentAn4Command, nameof(vm.DoAlignmentAn4Command), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.DoAlignmentAn5Command, nameof(vm.DoAlignmentAn5Command), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.DoAlignmentAn6Command, nameof(vm.DoAlignmentAn6Command), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.DoAlignmentAn7Command, nameof(vm.DoAlignmentAn7Command), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.DoAlignmentAn8Command, nameof(vm.DoAlignmentAn8Command), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.DoAlignmentAn9Command, nameof(vm.DoAlignmentAn9Command), ShortcutCategory.SubtitleGrid);
+        // Alignment works on the selected lines regardless of where focus is, so these are active in
+        // the text box too - not only in the subtitle grid (discussion #11744).
+        AddShortcut(shortcuts, vm.ShowAlignmentPickerCommand, nameof(vm.ShowAlignmentPickerCommand), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.DoAlignmentAn1Command, nameof(vm.DoAlignmentAn1Command), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.DoAlignmentAn2Command, nameof(vm.DoAlignmentAn2Command), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.DoAlignmentAn3Command, nameof(vm.DoAlignmentAn3Command), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.DoAlignmentAn4Command, nameof(vm.DoAlignmentAn4Command), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.DoAlignmentAn5Command, nameof(vm.DoAlignmentAn5Command), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.DoAlignmentAn6Command, nameof(vm.DoAlignmentAn6Command), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.DoAlignmentAn7Command, nameof(vm.DoAlignmentAn7Command), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.DoAlignmentAn8Command, nameof(vm.DoAlignmentAn8Command), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.DoAlignmentAn9Command, nameof(vm.DoAlignmentAn9Command), ShortcutCategory.SubtitleGridAndTextBox);
         AddShortcut(shortcuts, vm.AddOrEditBookmarkCommand, nameof(vm.AddOrEditBookmarkCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ToggleBookmarkSelectedLinesNoTextCommand, nameof(vm.ToggleBookmarkSelectedLinesNoTextCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.CopyTextFromOriginalToTranslationCommand, nameof(vm.CopyTextFromOriginalToTranslationCommand), ShortcutCategory.SubtitleGrid, ShortcutGroup.Translate);

--- a/tests/UI/Logic/AltMenuActivationGuardTests.cs
+++ b/tests/UI/Logic/AltMenuActivationGuardTests.cs
@@ -1,0 +1,93 @@
+using Avalonia.Input;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+public class AltMenuActivationGuardTests
+{
+    [Fact]
+    public void AltReleaseAfterAltPointerPressCancelsActivation()
+    {
+        var guard = new AltMenuActivationGuard();
+
+        guard.NotifyPointerPressed(isAltDown: true, isMenuPress: false);
+
+        Assert.True(guard.TryConsumeAltRelease(Key.LeftAlt, out _));
+    }
+
+    [Fact]
+    public void BareAltReleaseKeepsActivation()
+    {
+        var guard = new AltMenuActivationGuard();
+
+        Assert.False(guard.TryConsumeAltRelease(Key.LeftAlt, out _));
+    }
+
+    [Fact]
+    public void PointerPressWithoutAltKeepsActivation()
+    {
+        var guard = new AltMenuActivationGuard();
+
+        guard.NotifyPointerPressed(isAltDown: false, isMenuPress: false);
+
+        Assert.False(guard.TryConsumeAltRelease(Key.RightAlt, out _));
+    }
+
+    [Fact]
+    public void PressOnTheMenuItselfKeepsActivation()
+    {
+        var guard = new AltMenuActivationGuard();
+
+        guard.NotifyPointerPressed(isAltDown: true, isMenuPress: true);
+
+        Assert.False(guard.TryConsumeAltRelease(Key.LeftAlt, out _));
+    }
+
+    [Fact]
+    public void OnlyTheAltReleaseConsumesTheGuard()
+    {
+        var guard = new AltMenuActivationGuard();
+
+        guard.NotifyPointerPressed(isAltDown: true, isMenuPress: false);
+
+        Assert.False(guard.TryConsumeAltRelease(Key.A, out _));
+        Assert.True(guard.TryConsumeAltRelease(Key.LeftAlt, out _));
+    }
+
+    [Fact]
+    public void ConsumingIsIdempotent()
+    {
+        var guard = new AltMenuActivationGuard();
+
+        guard.NotifyPointerPressed(isAltDown: true, isMenuPress: false);
+
+        // The window handler runs on both the tunnel and the bubble pass, so the second call must
+        // not undo a menu activation the user just made on purpose.
+        Assert.True(guard.TryConsumeAltRelease(Key.LeftAlt, out _));
+        Assert.False(guard.TryConsumeAltRelease(Key.LeftAlt, out _));
+    }
+
+    [Fact]
+    public void ResetDropsArmedState()
+    {
+        var guard = new AltMenuActivationGuard();
+
+        guard.NotifyPointerPressed(isAltDown: true, isMenuPress: false);
+        guard.Reset();
+
+        Assert.False(guard.TryConsumeAltRelease(Key.LeftAlt, out _));
+    }
+
+    [Fact]
+    public void FocusIsOnlyRecordedWhileArmed()
+    {
+        var guard = new AltMenuActivationGuard();
+
+        // Not armed: a posted focus read from an earlier press must not stick around.
+        guard.NotifyFocusAfterPointerPress(null);
+        guard.NotifyPointerPressed(isAltDown: true, isMenuPress: false);
+
+        Assert.True(guard.TryConsumeAltRelease(Key.LeftAlt, out var focusToRestore));
+        Assert.Null(focusToRestore);
+    }
+}


### PR DESCRIPTION
Follow-up to the shortcut fixes in #12673, from torvchen's report in [discussion #11744](https://github.com/SubtitleEdit/subtitleedit/discussions/11744#discussioncomment-17781986): after the RC, most of the "shortcuts stop responding" cases are gone, but the Alt+drag one remains — and alignment shortcuts do nothing while the text box has focus.

## 1. Alt+drag on the waveform killed every shortcut

Root cause is in Avalonia's `AccessKeyHandler` (12.1):

- **Alt down** → `_showingAccessKeys = true` (menu-bar activation armed).
- **Mouse pressed while Alt is held** → `OnPreviewPointerPressed` runs `SetShowAccessKeys(_owner!, false)`, which clears the attached property but **not** the `_showingAccessKeys` field. Only another *key* press sets `_ignoreAltUp`; a mouse press does not.
- **Alt up** → `_showingAccessKeys` is still true → `MainMenu.Open()` → `DefaultMenuInteractionHandler.MenuOpened` → `MoveSelection(First)` focuses the first menu item.
- `IsMainMenuFocused()` in `OnKeyDownHandler` then correctly hands every following key to the menu — so all shortcuts are dead until a click closes it.

The #12673 fix covered a *stale* `MenuItem` left focused after a menu closed; here the menu is genuinely open and focused, so that guard doesn't apply. Windows itself cancels menu activation when Alt is combined with a mouse click; this restores that.

`AltMenuActivationGuard` is pure state (no UI dependency, unit tested). A tunnelling `PointerPressed` handler on the window content arms it when Alt is held, and the following Alt release closes the menu again and returns focus to the control the click focused. An Alt+click on the menu bar itself still opens the menu, and consuming is idempotent since the key handler runs on both the tunnel and bubble pass. The binary edit window had the identical menu-focus guard and the same hole, so it gets the same treatment.

Worth reporting upstream as well: `OnPreviewPointerPressed` should be `SetShowAccessKeys(_owner!, _showingAccessKeys = false)`, matching `CloseMenu()`.

## 2. Alignment shortcuts now work in the text box

The picker and `an1..an9` were registered as `ShortcutCategory.SubtitleGrid`, and that category is only dispatched while the grid has focus — so they were unreachable from the text box. They act on the selected lines regardless of focus, so they are now `SubtitleGridAndTextBox`.

Saved bindings are unaffected (settings store only the action name and keys; the category lives in code). They move to the "Subtitle grid and text box" group in the shortcuts window. As with every shortcut, a bare single-key binding still only fires in a text box when "allow single letter shortcuts in text box" is enabled.

## Testing

- New `AltMenuActivationGuardTests` (8 cases: armed/not armed, menu press, non-Alt press, wrong key, double consume, reset, focus recording).
- Full UI suite: 828 passed, 0 failed.
- Manual: Alt+drag a subtitle edge in the waveform, release Alt — shortcuts keep working and the menu bar stays closed; bare Alt and F10 still activate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
