### PR TITLE
Keep the batch convert ASSA settings between sessions

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConvertAssaViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertAssaViewModel.cs
@@ -50,11 +50,14 @@ public partial class BatchConvertAssaViewModel : ObservableObject
         SelectedBorderType = BorderTypes[0];
         _subtitle = new Subtitle();
         _subtitle.Paragraphs.Add(new Paragraph("Sample subtitle", 0, 2000));
-        Text = _subtitle.ToText(new AdvancedSubStationAlpha());
 
         UseSourceStylesIfPossible = Se.Settings.Tools.BatchConvert.AssaUseSourceStylesIfPossible;
         _subtitle.Header = Se.Settings.Tools.BatchConvert.AssaHeader;
         _subtitle.Footer = Se.Settings.Tools.BatchConvert.AssaFooter;
+
+        // Generate the source view after the saved header/footer have been applied - otherwise
+        // the window always shows the default styles instead of the saved ones (#12839).
+        Text = _subtitle.ToText(new AdvancedSubStationAlpha());
     }
 
     [RelayCommand]
@@ -64,6 +67,8 @@ public partial class BatchConvertAssaViewModel : ObservableObject
         {
             return;
         }
+
+        UpdateSubtitleFromText();
 
         var result = await _windowService.ShowDialogAsync<AssaStylesWindow, AssaStylesViewModel>(Window, vm =>
         {
@@ -85,6 +90,8 @@ public partial class BatchConvertAssaViewModel : ObservableObject
             return;
         }
 
+        UpdateSubtitleFromText();
+
         var result = await _windowService.ShowDialogAsync<AssaAttachmentsWindow, AssaAttachmentsViewModel>(Window, vm =>
         {
             vm.Initialize(_subtitle, new AdvancedSubStationAlpha(), string.Empty);
@@ -105,6 +112,8 @@ public partial class BatchConvertAssaViewModel : ObservableObject
             return;
         }
 
+        UpdateSubtitleFromText();
+
         var result = await _windowService.ShowDialogAsync<AssaPropertiesWindow, AssaPropertiesViewModel>(Window, vm =>
         {
             vm.Initialize(_subtitle, new AdvancedSubStationAlpha(), string.Empty, string.Empty);
@@ -120,11 +129,37 @@ public partial class BatchConvertAssaViewModel : ObservableObject
     [RelayCommand]
     private void Ok()
     {
+        // Pick up any hand edits made in the source view before saving.
+        UpdateSubtitleFromText();
+
         OkPressed = true;
         Se.Settings.Tools.BatchConvert.AssaUseSourceStylesIfPossible = UseSourceStylesIfPossible;
-        Se.Settings.Tools.BatchConvert.AssaHeader = _subtitle.Header;
-        Se.Settings.Tools.BatchConvert.AssaFooter = _subtitle.Footer;
+        Se.Settings.Tools.BatchConvert.AssaHeader = _subtitle.Header ?? string.Empty;
+        Se.Settings.Tools.BatchConvert.AssaFooter = _subtitle.Footer ?? string.Empty;
+        Se.SaveSettings();
         Window?.Close();
+    }
+
+    /// <summary>
+    /// Read the header/footer back from the source view, so edits made directly in the
+    /// text editor are kept and not overwritten by the last dialog result.
+    /// </summary>
+    private void UpdateSubtitleFromText()
+    {
+        if (string.IsNullOrWhiteSpace(Text))
+        {
+            return;
+        }
+
+        var sub = new Subtitle();
+        new AdvancedSubStationAlpha().LoadSubtitle(sub, Text.SplitToLines(), string.Empty);
+        if (string.IsNullOrEmpty(sub.Header))
+        {
+            return; // not parsable as ASSA - keep what we have
+        }
+
+        _subtitle.Header = sub.Header;
+        _subtitle.Footer = sub.Footer;
     }
 
     [RelayCommand]

--- a/tests/UI/Features/Tools/BatchConvert/BatchConvertAssaViewModelTests.cs
+++ b/tests/UI/Features/Tools/BatchConvert/BatchConvertAssaViewModelTests.cs
@@ -1,0 +1,81 @@
+using Avalonia.Headless.XUnit;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Tools.BatchConvert;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Tools.BatchConvert;
+
+/// <summary>
+/// Regression tests for issue #12839: the ASSA settings window in batch convert always showed
+/// the default styles, and edits typed into the source view were discarded on OK.
+/// </summary>
+public class BatchConvertAssaViewModelTests
+{
+    private const string CustomStyleName = "BatchStyle42";
+
+    [AvaloniaFact]
+    public void SavedHeader_IsShownInSourceView()
+    {
+        var header = Se.Settings.Tools.BatchConvert.AssaHeader;
+        var footer = Se.Settings.Tools.BatchConvert.AssaFooter;
+        try
+        {
+            Se.Settings.Tools.BatchConvert.AssaHeader = MakeHeaderWithStyle(CustomStyleName);
+            Se.Settings.Tools.BatchConvert.AssaFooter = string.Empty;
+
+            var viewModel = MakeViewModel();
+
+            Assert.Contains(CustomStyleName, viewModel.Text);
+        }
+        finally
+        {
+            Se.Settings.Tools.BatchConvert.AssaHeader = header;
+            Se.Settings.Tools.BatchConvert.AssaFooter = footer;
+        }
+    }
+
+    [AvaloniaFact]
+    public void Ok_KeepsEditsMadeInSourceView()
+    {
+        var header = Se.Settings.Tools.BatchConvert.AssaHeader;
+        var footer = Se.Settings.Tools.BatchConvert.AssaFooter;
+        try
+        {
+            Se.Settings.Tools.BatchConvert.AssaHeader = string.Empty;
+            Se.Settings.Tools.BatchConvert.AssaFooter = string.Empty;
+
+            var viewModel = MakeViewModel();
+            viewModel.Text = viewModel.Text.Replace("Style: Default,", $"Style: {CustomStyleName},");
+
+            viewModel.OkCommand.Execute(null);
+
+            Assert.Contains(CustomStyleName, Se.Settings.Tools.BatchConvert.AssaHeader);
+        }
+        finally
+        {
+            Se.Settings.Tools.BatchConvert.AssaHeader = header;
+            Se.Settings.Tools.BatchConvert.AssaFooter = footer;
+        }
+    }
+
+    private static BatchConvertAssaViewModel MakeViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        using var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<BatchConvertAssaViewModel>();
+    }
+
+    private static string MakeHeaderWithStyle(string styleName)
+    {
+        var format = new AdvancedSubStationAlpha();
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Sample subtitle", 0, 2000));
+        var text = format.ToText(subtitle, string.Empty);
+        format.LoadSubtitle(subtitle, text.SplitToLines(), string.Empty);
+        return subtitle.Header.Replace("Style: Default,", $"Style: {styleName},");
+    }
+}


### PR DESCRIPTION
Fixes the ASSA part of #12839 — *"The menu that manages the default ASSA settings in the batch converter resets to the default settings every time it is opened"*.

### Cause

`BatchConvertAssaViewModel`'s constructor generated the source view **before** applying the saved header/footer:

```csharp
Text = _subtitle.ToText(new AdvancedSubStationAlpha());   // <- default script info + styles

_subtitle.Header = Se.Settings.Tools.BatchConvert.AssaHeader;
_subtitle.Footer = Se.Settings.Tools.BatchConvert.AssaFooter;
```

So the window always showed the default script info and styles, no matter what had been saved.

On top of that, editing the ASSA source directly was pointless: only the *Edit styles* / *Edit properties* / *Edit attachments* dialogs wrote back to `_subtitle`, and OK saved `_subtitle.Header`/`Footer` — anything typed into the text editor was dropped.

### Changes

- Build the source text **after** the saved header/footer are applied.
- Parse the source view back into the subtitle on OK, and before opening the edit dialogs, so hand edits are kept (guarded: unparsable text leaves the current header alone).
- Flush settings to disk on OK, like `BatchConvertSettingsViewModel` does.

### Tests

Two regression tests in `BatchConvertAssaViewModelTests` — a saved custom style shows up in the source view, and an edit typed into the source view survives OK. Both fail on `main` and pass with this change.

Not covered here: the Delete-key part of the issue is [#12841](https://github.com/SubtitleEdit/subtitleedit/pull/12841), and the plain-mouse multi-select complaint is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)