### PR TITLE
Keep the selected audio track when going fullscreen or undocking

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -971,6 +971,23 @@ public partial class MainViewModel :
         }
     }
 
+    /// <summary>
+    /// Pushes the currently selected audio track (<see cref="_audioTrack"/>) to <paramref name="player"/>.
+    /// Going fullscreen and undocking both create a brand new player that re-opens the video file, and a
+    /// freshly opened mpv always starts on its own default track - so a second language picked via
+    /// "Video > Audio tracks" was silently replaced by the first one (issue #12844).
+    /// </summary>
+    internal void ReapplySelectedAudioTrack(VideoPlayerControl? player)
+    {
+        var audioTrack = _audioTrack;
+        if (audioTrack == null || player?.VideoPlayer is not LibMpvDynamicPlayer mpv)
+        {
+            return;
+        }
+
+        mpv.SetAudioTrack(audioTrack.Id);
+    }
+
     private void RefreshSubtitlePreview()
     {
         _mpvReloader.Reset();
@@ -5968,6 +5985,11 @@ public partial class MainViewModel :
     {
         AreVideoControlsUndocked = false;
         var videoFileName = _videoFileName ?? string.Empty;
+
+        // Re-docking re-opens the video in the rebuilt layout's player, and VideoOpenFile clears
+        // _audioTrack on entry - so remember the selected track now and ask for it back, or the
+        // undocked window's second language turns back into the first one (issue #12844).
+        var desiredAudioTrackId = _audioTrack?.Id ?? -1;
         VideoCloseFile();
 
         if (_videoPlayerUndockedViewModel != null)
@@ -5987,7 +6009,7 @@ public partial class MainViewModel :
 
         if (!string.IsNullOrEmpty(videoFileName))
         {
-            Dispatcher.UIThread.Post(async void () => { await VideoOpenFile(videoFileName); });
+            Dispatcher.UIThread.Post(async void () => { await VideoOpenFile(videoFileName, desiredAudioTrackId); });
             RefreshSubtitlePreview();
         }
     }
@@ -12462,8 +12484,15 @@ public partial class MainViewModel :
             control!.Position = _fullScreenVideoPlayerControl.Position;
             control!.Volume = _fullScreenVideoPlayerControl.Volume;
             _fullScreenVideoPlayerControl = null;
+
+            // A track switched while fullscreen (toggle-audio-track shortcut) only ever reached the
+            // fullscreen player, so hand it to the player we are going back to - otherwise playback
+            // and the audio track menu disagree after leaving fullscreen (issue #12844).
+            ReapplySelectedAudioTrack(control);
+            var _ = Task.Run(LoadAudioTrackMenuItems);
+
             Dispatcher.UIThread.Post(() => SubtitleGrid.Focus());
-        }, toggleKeys, showMediaInfoKeys, showMediaInformationOwnedBy, extraBindings);
+        }, toggleKeys, showMediaInfoKeys, showMediaInformationOwnedBy, extraBindings, ReapplySelectedAudioTrack);
         fullScreenWindow.Show(Window!);
         _shortcutManager.ClearKeys();
 

--- a/src/ui/Features/Shared/FullScreenVideoPlayer.cs
+++ b/src/ui/Features/Shared/FullScreenVideoPlayer.cs
@@ -28,7 +28,8 @@ public class FullScreenVideoWindow : Window
         List<string>? toggleShortcutKeys = null,
         List<string>? showMediaInformationKeys = null,
         Action<Window>? showMediaInformation = null,
-        IReadOnlyList<(string name, List<string> keys, IRelayCommand command)>? extraBindings = null)
+        IReadOnlyList<(string name, List<string> keys, IRelayCommand command)>? extraBindings = null,
+        Action<Controls.VideoPlayer.VideoPlayerControl>? onPlayerReady = null)
     {
         WindowState = WindowState.FullScreen;
         WindowDecorations = WindowDecorations.None;
@@ -216,6 +217,11 @@ public class FullScreenVideoWindow : Window
             videoPlayer.VideoPlayer.Position = position;
             videoPlayer.Position = position;
             videoPlayer.Volume = volume;
+
+            // Position and volume are not the only state the fresh player starts over with -
+            // let the caller re-apply whatever else it tracks (the selected audio track, #12844).
+            onPlayerReady?.Invoke(videoPlayer);
+
             Dispatcher.UIThread.Post(() =>
             {
                 videoPlayer.VideoPlayer.Position = position;

--- a/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
+++ b/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
@@ -189,6 +189,10 @@ public partial class VideoPlayerUndockedViewModel : ObservableObject
 
                 videoPlayerControl.Volume = _originalVolume;
                 videoPlayerControl.Position = _originalPosition;
+
+                // Undocking opens the video in a new player, which starts on mpv's default audio
+                // track - re-apply the track the user picked in the main window (issue #12844).
+                MainViewModel?.ReapplySelectedAudioTrack(videoPlayerControl);
             });
         }
 


### PR DESCRIPTION
Fixes #12844

Fullscreen and undock do not move the existing video player — they create a new one and re-open the video file, and a freshly opened mpv always starts on its own default audio track. Position and volume were carried over to the new player, the selected audio track was not, so a second language picked via *Video > Audio tracks* silently fell back to the first one until the user left fullscreen again.

A new `MainViewModel.ReapplySelectedAudioTrack(...)` pushes `_audioTrack` to a given player (mpv only, matching `PickAudioTrack`). It is called on every path that swaps players:

- **Entering fullscreen** — `FullScreenVideoWindow` gained an optional `onPlayerReady` callback, invoked in the `Loaded` handler right after the existing position/volume restore (i.e. after `WaitForPlayersReadyAsync` and the settle delay). The window itself stays ignorant of track logic.
- **Leaving fullscreen** — a track toggled by shortcut while fullscreen only ever reached the fullscreen player, so it is now handed to the player we return to, plus an audio-track menu refresh. It runs after `_fullScreenVideoPlayerControl = null` so `GetVideoPlayerControl()` resolves to the docked player.
- **Undocking** the video player.
- **Re-docking** it, where `VideoOpenFile` clears `_audioTrack` on entry — the track id is captured up front and passed back in as `desiredAudioTrackId`. Without this the undock fix only held in one direction, and it also keeps the waveform on the right track since peak filenames key off `FfIndex`.

This mirrors what `SetLayout` already does for layout rebuilds.

Not included: the fullscreen player also skips `ReapplyPlaybackSpeed()`, so a non-default playback speed likely reverts to 1.0x in fullscreen. Same root cause, separate symptom, left for its own change.

Not verified in the GUI — checking it needs a multi-track video, fullscreen, and an ear on the audio. Builds clean; the 830 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
