### PR TITLE
Fix auto-imported Matroska tracks staying "Untitled" (#12848)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -16703,8 +16703,9 @@ public partial class MainViewModel :
                     {
                         if (!IsImageSubtitleTrack(result.SelectedMatroskaTrack))
                         {
-                            _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
-                            _converted = true;
+                            // File name + "converted" flag are set by LoadMatroskaSubtitle itself, so the
+                            // auto-import (single track) path gets them too - it used to stay "Untitled"
+                            // until the first save (#12848).
                             SelectAndScrollToRow(0);
 
                             if (Se.Settings.Video.AutoOpen)
@@ -16827,7 +16828,7 @@ public partial class MainViewModel :
                 {
                     VideoCloseFile();
                     ResetSubtitle();
-                    _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
+                    _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName) + SelectedSubtitleFormat.Extension;
                     _converted = true;
                     ReplaceSubtitles(result.OcredSubtitle);
                     Renumber();
@@ -16865,6 +16866,11 @@ public partial class MainViewModel :
         _subtitle = subtitle;
         _subtitle.Renumber();
         ReplaceSubtitles(_subtitle.Paragraphs.Select(p => new SubtitleLineViewModel(p, SelectedSubtitleFormat)));
+
+        // Provisional file name (video name + subtitle extension) right after the import, like SE4 -
+        // ResetSubtitle above cleared it, and only the "pick track" path used to restore it, so an
+        // auto-imported single track showed "Untitled" in the title bar and save prompt (#12848).
+        _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName) + SelectedSubtitleFormat.Extension;
         _converted = true;
 
         return true;
@@ -16970,7 +16976,10 @@ public partial class MainViewModel :
             {
                 VideoCloseFile();
                 ResetSubtitle();
-                _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
+                // ResetSubtitle clears _converted; without setting it again Ctrl+S could write straight
+                // to the (extension-less) container name instead of going to "Save as".
+                _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName) + SelectedSubtitleFormat.Extension;
+                _converted = true;
                 ReplaceSubtitles(result.OcredSubtitle);
                 Renumber();
                 SelectAndScrollToRow(0);
@@ -17042,7 +17051,8 @@ public partial class MainViewModel :
             {
                 VideoCloseFile();
                 ResetSubtitle();
-                _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName);
+                _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName) + SelectedSubtitleFormat.Extension;
+                _converted = true;
                 ReplaceSubtitles(result.OcredSubtitle);
                 SelectAndScrollToRow(0);
                 if (Se.Settings.Video.AutoOpen && fileName.EndsWith(".mkv", StringComparison.OrdinalIgnoreCase))
@@ -17122,12 +17132,9 @@ public partial class MainViewModel :
         _subtitle.Renumber();
         ReplaceSubtitles(_subtitle.Paragraphs.Select(p => new SubtitleLineViewModel(p, SelectedSubtitleFormat)));
 
-
-        if (matroska.Path.EndsWith(".mkv", StringComparison.OrdinalIgnoreCase) ||
-            matroska.Path.EndsWith(".mks", StringComparison.OrdinalIgnoreCase))
-        {
-            _subtitleFileName = matroska.Path.Remove(matroska.Path.Length - 4) + SelectedSubtitleFormat.Extension;
-        }
+        // Any container extension, not just the four-char .mkv/.mks - a TextST track in e.g. a .webm
+        // otherwise kept the empty file name from ResetSubtitle and showed up as "Untitled" (#12848).
+        _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(matroska.Path) + SelectedSubtitleFormat.Extension;
 
         SelectAndScrollToRow(0);
 
@@ -17190,7 +17197,7 @@ public partial class MainViewModel :
         {
             VideoCloseFile();
             ResetSubtitle();
-            _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(vobSubFileName);
+            _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(vobSubFileName) + SelectedSubtitleFormat.Extension;
             _converted = true;
             ReplaceSubtitles(result.OcredSubtitle);
             SelectAndScrollToRow(0);


### PR DESCRIPTION
Fixes #12848.

### The bug

When an `.mkv` contains exactly one subtitle track, the "Pick Matroska track" window is skipped and `ImportSubtitleFromMatroskaFile` takes its single-track branch — which never assigned `_subtitleFileName`. Only the multi-track branch did, *after* `LoadMatroskaSubtitle` returned. `ResetSubtitle` had just cleared the field, so the title bar and the "Do you want to save changes to ...?" prompt both fell back to `Untitled` until the first save. SE4 assigns a provisional name (`<video name>` + subtitle extension) right away, hence the parity report.

### The fix

`LoadMatroskaSubtitle`'s text path sets the name itself, so both branches get it:

```csharp
_subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName) + SelectedSubtitleFormat.Extension;
_converted = true;
```

`SelectedSubtitleFormat` is the track's own format there (`ResetSubtitle(format)` just applied it), so an SRT track yields `*NAME.srt` and an ASS track `*NAME.ass`. The duplicate assignment in the multi-track branch is removed — it ran afterwards and would have overwritten the name with an extension-less one.

### Related issues fixed in the same area

- **TextST** only got a name when the container ended in `.mkv`/`.mks`, via `Remove(Length - 4)`. Now uses `GetPathAndFileNameWithoutExtension`, so a TextST track in any other container is named too.
- **`_converted` was never restored** on the DVB-from-mkv and VobSub-from-mkv OCR-result paths, unlike the PGS and VobSub-file ones. Since `ResetSubtitle()` clears it, Ctrl+S there could write straight to the extension-less container name instead of going to "Save as".
- **Extension consistency**: all four OCR-result paths now append `SelectedSubtitleFormat.Extension`, like the text paths already did.

### Testing

- `dotnet build src/ui/UI.csproj` — clean.
- `dotnet test tests/UI/UITests.csproj` — 828 passed.
- Verified the recent-files menu filters on `File.Exists` (`InitMenu.UpdateRecentFiles`), so a provisional name that is never saved cannot leave a dead entry; and that "Save as" strips known subtitle extensions (`GetFileNameWithoutExtension`), so the added extension does not double up in the suggested name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)