### PR TITLE
Fix CosyVoice3 ref-text: reuse the voice pack transcripts, sanitize STT ones

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
@@ -246,10 +246,31 @@ public class CosyVoice3CrispAsr : ITtsEngine
         }
 
         SeedVoicesFromQwen3TtsCppIfEmpty(voicesFolder);
+        NormalizeVoiceTranscriptsOnce(voicesFolder);
         return voicesFolder;
     }
 
     private static bool _voiceSeedAttempted;
+    private static bool _voicesNormalized;
+
+    /// <summary>
+    /// One-time per session: drop unusable ref-text sidecars and backfill missing transcriptions
+    /// from the sibling OmniVoice pack (same generic reference WAVs, real transcripts). CosyVoice3
+    /// needs ref-text more than any sibling — it fails outright without one — yet it was the engine
+    /// that never ran this, so of the seeded voices only the single one that happened to ship a real
+    /// transcript was usable. Browsing the voice combo fired the missing-transcript prompt once per
+    /// voice, and MOSS-TTS had the identical bug fixed this way.
+    /// </summary>
+    private static void NormalizeVoiceTranscriptsOnce(string voicesFolder)
+    {
+        if (_voicesNormalized)
+        {
+            return;
+        }
+        _voicesNormalized = true;
+
+        Qwen3TtsCrispAsr.NormalizeVoiceTranscripts(voicesFolder);
+    }
 
     /// <summary>
     /// One-time best-effort seed of WAV reference voices from qwen3-tts.cpp's voices folder.
@@ -317,7 +338,7 @@ public class CosyVoice3CrispAsr : ITtsEngine
                         // missing-transcription prompt. Same filter Qwen3 (CrispASR) applies.
                         try
                         {
-                            if (!Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(File.ReadAllText(sidecar)))
+                            if (!Qwen3TtsCrispAsr.LooksLikeUnusableTranscript(File.ReadAllText(sidecar)))
                             {
                                 File.Copy(sidecar, sidecarDest);
                             }
@@ -423,7 +444,7 @@ public class CosyVoice3CrispAsr : ITtsEngine
             // transcriptions - treat them as "no transcript" (same read-time filter Qwen3
             // CrispASR applies) so they neither poison ref-text nor suppress the prompt.
             var text = File.ReadAllText(sidecar).Trim();
-            return Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(text) ? string.Empty : text;
+            return Qwen3TtsCrispAsr.LooksLikeUnusableTranscript(text) ? string.Empty : text;
         }
         catch
         {

--- a/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
@@ -190,10 +190,29 @@ public class F5TtsCrispAsr : ITtsEngine
         }
 
         SeedVoicesFromQwen3TtsCppIfEmpty(voicesFolder);
+        NormalizeVoiceTranscriptsOnce(voicesFolder);
         return voicesFolder;
     }
 
     private static bool _voiceSeedAttempted;
+    private static bool _voicesNormalized;
+
+    /// <summary>
+    /// One-time per session: drop unusable ref-text sidecars and backfill missing transcriptions
+    /// from the sibling OmniVoice pack (same generic reference WAVs, real transcripts), so browsing
+    /// the voice combo does not fire the missing-transcript prompt once per seeded voice. Same fix
+    /// MOSS-TTS already carried.
+    /// </summary>
+    private static void NormalizeVoiceTranscriptsOnce(string voicesFolder)
+    {
+        if (_voicesNormalized)
+        {
+            return;
+        }
+        _voicesNormalized = true;
+
+        Qwen3TtsCrispAsr.NormalizeVoiceTranscripts(voicesFolder);
+    }
 
     /// <summary>
     /// One-time best-effort seed of WAV reference voices from qwen3-tts.cpp's voices folder.
@@ -263,7 +282,7 @@ public class F5TtsCrispAsr : ITtsEngine
                         // missing-transcription prompt. Same filter Qwen3 (CrispASR) applies.
                         try
                         {
-                            if (!Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(File.ReadAllText(sidecar)))
+                            if (!Qwen3TtsCrispAsr.LooksLikeUnusableTranscript(File.ReadAllText(sidecar)))
                             {
                                 File.Copy(sidecar, sidecarDest);
                             }
@@ -471,7 +490,7 @@ public class F5TtsCrispAsr : ITtsEngine
             // transcriptions - treat them as "no transcript" (same read-time filter Qwen3
             // CrispASR applies) so they neither poison ref-text nor suppress the prompt.
             var text = File.ReadAllText(sidecar).Trim();
-            return Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(text) ? string.Empty : text;
+            return Qwen3TtsCrispAsr.LooksLikeUnusableTranscript(text) ? string.Empty : text;
         }
         catch
         {

--- a/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
@@ -316,7 +316,7 @@ public class MossTtsCrispAsr : ITtsEngine
                         // missing-transcription prompt. Same filter Qwen3 (CrispASR) applies.
                         try
                         {
-                            if (!Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(File.ReadAllText(sidecar)))
+                            if (!Qwen3TtsCrispAsr.LooksLikeUnusableTranscript(File.ReadAllText(sidecar)))
                             {
                                 File.Copy(sidecar, sidecarDest);
                             }
@@ -563,7 +563,7 @@ public class MossTtsCrispAsr : ITtsEngine
             // transcriptions - treat them as "no transcript" (same read-time filter Qwen3
             // CrispASR applies) so they neither poison ref-text nor suppress the prompt.
             var text = File.ReadAllText(sidecar).Trim();
-            return Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(text) ? string.Empty : text;
+            return Qwen3TtsCrispAsr.LooksLikeUnusableTranscript(text) ? string.Empty : text;
         }
         catch
         {

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -478,7 +478,7 @@ public class Qwen3TtsCrispAsr : ITtsEngine
                 if (File.Exists(sidecar))
                 {
                     var text = File.ReadAllText(sidecar).Trim();
-                    if (!string.IsNullOrWhiteSpace(text) && !LooksLikeAttributionBlurb(text))
+                    if (!LooksLikeUnusableTranscript(text))
                     {
                         continue; // already carries a usable transcription
                     }
@@ -536,7 +536,7 @@ public class Qwen3TtsCrispAsr : ITtsEngine
             }
 
             var text = File.ReadAllText(sidecar).Trim();
-            return string.IsNullOrWhiteSpace(text) || LooksLikeAttributionBlurb(text) ? null : text;
+            return LooksLikeUnusableTranscript(text) ? null : text;
         }
         catch
         {
@@ -587,6 +587,37 @@ public class Qwen3TtsCrispAsr : ITtsEngine
             || text.Contains("This file is licensed", StringComparison.OrdinalIgnoreCase)
             || text.Contains("Downsampled to", StringComparison.OrdinalIgnoreCase);
     }
+
+    /// <summary>
+    /// True when a <c>.txt</c> sidecar cannot be a spoken transcription of its reference WAV, so it
+    /// must be treated as "no transcript" rather than fed to a backend as ref-text.
+    /// </summary>
+    /// <remarks>
+    /// Covers <see cref="LooksLikeAttributionBlurb"/> plus anything carrying subtitle markup. A
+    /// transcript filled in via "Use speech to text…" is joined straight out of the transcription,
+    /// so an STT engine configured for karaoke output (faster-whisper's <c>--highlight_words</c>,
+    /// whisper.cpp's <c>-owts</c>) yields one cue per word, each repeating the whole sentence with
+    /// the current word wrapped in <c>&lt;u&gt;</c> — kilobytes of tag-laced repetition that reads
+    /// as a valid transcript to every other check. CosyVoice3 hands that to the s3tok tokenizer and
+    /// renders the ref-text instead of the requested line. Nothing spoken contains markup, so its
+    /// presence is a reliable tell, and dropping the sidecar lets the OmniVoice backfill replace it.
+    /// </remarks>
+    public static bool LooksLikeUnusableTranscript(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return true;
+        }
+
+        if (LooksLikeAttributionBlurb(text))
+        {
+            return true;
+        }
+
+        return SubtitleMarkupHints.Any(hint => text.Contains(hint, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static readonly string[] SubtitleMarkupHints = { "<u>", "</u>", "<i>", "</i>", "<b>", "<font", "{\\" };
 
     public static string GetTalkerPath(string? modelKey = null) =>
         Path.Combine(GetSetModelsFolder(), GetTalkerFileName(modelKey));

--- a/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
@@ -218,10 +218,29 @@ public class VoxCPM2CrispAsr : ITtsEngine
         }
 
         SeedVoicesFromQwen3TtsCppIfEmpty(voicesFolder);
+        NormalizeVoiceTranscriptsOnce(voicesFolder);
         return voicesFolder;
     }
 
     private static bool _voiceSeedAttempted;
+    private static bool _voicesNormalized;
+
+    /// <summary>
+    /// One-time per session: drop unusable ref-text sidecars and backfill missing transcriptions
+    /// from the sibling OmniVoice pack (same generic reference WAVs, real transcripts), so browsing
+    /// the voice combo does not fire the missing-transcript prompt once per seeded voice. Same fix
+    /// MOSS-TTS already carried.
+    /// </summary>
+    private static void NormalizeVoiceTranscriptsOnce(string voicesFolder)
+    {
+        if (_voicesNormalized)
+        {
+            return;
+        }
+        _voicesNormalized = true;
+
+        Qwen3TtsCrispAsr.NormalizeVoiceTranscripts(voicesFolder);
+    }
 
     /// <summary>
     /// One-time best-effort seed of WAV reference voices from qwen3-tts.cpp's voices folder so
@@ -291,7 +310,7 @@ public class VoxCPM2CrispAsr : ITtsEngine
                         // missing-transcription prompt. Same filter Qwen3 (CrispASR) applies.
                         try
                         {
-                            if (!Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(File.ReadAllText(sidecar)))
+                            if (!Qwen3TtsCrispAsr.LooksLikeUnusableTranscript(File.ReadAllText(sidecar)))
                             {
                                 File.Copy(sidecar, sidecarDest);
                             }
@@ -511,7 +530,7 @@ public class VoxCPM2CrispAsr : ITtsEngine
             // transcriptions - treat them as "no transcript" (same read-time filter Qwen3
             // CrispASR applies) so they neither poison ref-text nor suppress the prompt.
             var text = File.ReadAllText(sidecar).Trim();
-            return Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(text) ? string.Empty : text;
+            return Qwen3TtsCrispAsr.LooksLikeUnusableTranscript(text) ? string.Empty : text;
         }
         catch
         {

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -46,6 +46,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
@@ -711,7 +712,7 @@ public partial class TextToSpeechViewModel : ObservableObject
             // An attribution-blurb sidecar (pre-filter seeding) is not a transcript - report it
             // as missing so the transcript prompt still fires instead of being suppressed.
             var text = File.ReadAllText(sidecar).Trim();
-            return Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(text) ? null : text;
+            return Qwen3TtsCrispAsr.LooksLikeUnusableTranscript(text) ? null : text;
         }
         catch
         {
@@ -736,9 +737,54 @@ public partial class TextToSpeechViewModel : ObservableObject
             return null;
         }
 
-        return string.Join(' ', sttResult.TranscribedSubtitle.Paragraphs
-            .Select(p => p.Text?.Replace('\n', ' ').Replace('\r', ' ').Trim())
-            .Where(t => !string.IsNullOrWhiteSpace(t)));
+        return BuildRefTextFromTranscription(sttResult.TranscribedSubtitle.Paragraphs.Select(p => p.Text));
+    }
+
+    /// <summary>
+    /// Flattens a transcription into the single plain sentence a cloning backend wants as ref-text.
+    /// </summary>
+    /// <remarks>
+    /// Strips subtitle markup and drops cues whose text the result already contains. Both matter
+    /// because the transcription comes from whatever the user has configured under Audio to text,
+    /// and a karaoke setup — faster-whisper's <c>--highlight_words</c>, whisper.cpp's <c>-owts</c> —
+    /// emits one cue per word, each repeating the entire sentence with the current word wrapped in
+    /// <c>&lt;u&gt;</c>. Joining that raw produced kilobytes of tag-laced repetition, which
+    /// CosyVoice3 then rendered instead of the line it was asked to speak. With the markup gone
+    /// those cues are identical, so the containment check collapses them back to one sentence.
+    /// </remarks>
+    internal static string BuildRefTextFromTranscription(IEnumerable<string?> paragraphTexts)
+    {
+        var parts = new List<string>();
+        foreach (var raw in paragraphTexts)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                continue;
+            }
+
+            var text = HtmlUtil.RemoveHtmlTags(raw, true)
+                .Replace('\n', ' ')
+                .Replace('\r', ' ')
+                .Trim();
+            text = Regex.Replace(text, @"\s{2,}", " ");
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                continue;
+            }
+
+            // Skip a cue the result already covers: identical karaoke repeats, and the growing
+            // prefixes some word-timestamp modes emit. Cheap because ref-text stays short.
+            if (parts.Any(p => p.Contains(text, StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            // Conversely, drop an earlier part this cue supersedes.
+            parts.RemoveAll(p => text.Contains(p, StringComparison.OrdinalIgnoreCase));
+            parts.Add(text);
+        }
+
+        return string.Join(' ', parts);
     }
 
     private static ObservableCollection<string> BuildKeywordOptions(string[] keywords)

--- a/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
@@ -167,7 +167,7 @@ public partial class VoiceSettingsViewModel : ObservableObject
             // it. Either way show the result for a quick review/correction (clone quality is
             // sensitive to ref-text accuracy), keeping the STT button to re-run if needed.
             var transcript = TryReadSiblingTranscript(fileName);
-            if (string.IsNullOrWhiteSpace(transcript) || Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(transcript))
+            if (Qwen3TtsCrispAsr.LooksLikeUnusableTranscript(transcript))
             {
                 transcript = await RunSpeechToTextAsync(fileName) ?? string.Empty;
             }
@@ -330,7 +330,7 @@ public partial class VoiceSettingsViewModel : ObservableObject
             // transcriptions - pre-filling the transcript prompt with one poisons the
             // ref-text when the user just clicks OK. Treat a blurb as "no transcript".
             var text = File.ReadAllText(siblingTextFile);
-            return Qwen3TtsCrispAsr.LooksLikeAttributionBlurb(text) ? null : text;
+            return Qwen3TtsCrispAsr.LooksLikeUnusableTranscript(text) ? null : text;
         }
         catch
         {

--- a/tests/UI/Features/Video/TextToSpeech/RefTextFromTranscriptionTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/RefTextFromTranscriptionTests.cs
@@ -1,0 +1,160 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+namespace UITests.Features.Video.TextToSpeech;
+
+/// <summary>
+/// Turning a transcription into cloning ref-text. The transcription comes from whatever the user
+/// has configured under Audio to text, so a karaoke setup (faster-whisper
+/// <c>--highlight_words</c>, whisper.cpp <c>-owts</c>) emits one cue per word, each repeating the
+/// whole sentence with the current word underlined. Joined raw that became kilobytes of tag-laced
+/// repetition, which CosyVoice3 rendered instead of the line it was asked to speak.
+/// </summary>
+public class RefTextFromTranscriptionTests
+{
+    [Fact]
+    public void CollapsesKaraokeWordHighlightCues()
+    {
+        // Shape faster-whisper --highlight_words produces: same sentence per cue, moving <u>.
+        var cues = new[]
+        {
+            "<u>being</u> a silent person, I said",
+            "being <u>a</u> silent person, I said",
+            "being a <u>silent</u> person, I said",
+            "being a silent <u>person,</u> I said",
+            "being a silent person, <u>I</u> said",
+            "being a silent person, I <u>said</u>",
+        };
+
+        var refText = TextToSpeechViewModel.BuildRefTextFromTranscription(cues);
+
+        Assert.Equal("being a silent person, I said", refText);
+    }
+
+    [Fact]
+    public void KeepsDistinctSentencesInOrder()
+    {
+        var cues = new[] { "First sentence.", "Second sentence.", "Third one." };
+
+        var refText = TextToSpeechViewModel.BuildRefTextFromTranscription(cues);
+
+        Assert.Equal("First sentence. Second sentence. Third one.", refText);
+    }
+
+    [Fact]
+    public void StripsFormattingAndAssaTags()
+    {
+        var cues = new[] { "<i>Hello</i> {\\an8}there", "<font color=\"#ff0000\">friend</font>" };
+
+        var refText = TextToSpeechViewModel.BuildRefTextFromTranscription(cues);
+
+        Assert.Equal("Hello there friend", refText);
+    }
+
+    [Fact]
+    public void JoinsMultiLineCuesOntoOneLine()
+    {
+        var cues = new[] { "first line\nsecond line" };
+
+        var refText = TextToSpeechViewModel.BuildRefTextFromTranscription(cues);
+
+        Assert.Equal("first line second line", refText);
+    }
+
+    [Fact]
+    public void SkipsEmptyAndWhitespaceCues()
+    {
+        var cues = new[] { "  ", null, "Real text.", string.Empty, "<i></i>" };
+
+        var refText = TextToSpeechViewModel.BuildRefTextFromTranscription(cues);
+
+        Assert.Equal("Real text.", refText);
+    }
+
+    [Fact]
+    public void CollapsesGrowingPrefixCues()
+    {
+        // Some word-timestamp modes emit a sentence that grows cue by cue.
+        var cues = new[] { "I really", "I really like", "I really like that." };
+
+        var refText = TextToSpeechViewModel.BuildRefTextFromTranscription(cues);
+
+        Assert.Equal("I really like that.", refText);
+    }
+
+    [Fact]
+    public void ResultStaysPlausibleAsRefTextForAShortClip()
+    {
+        // Regression guard on the observed failure: 40 karaoke cues off one sentence used to
+        // produce ~1.5 kB of ref-text. It must come back down to the sentence itself.
+        var sentence = "I really like that. I really like hearing that.";
+        var words = sentence.Split(' ');
+        var cues = new string[words.Length];
+        for (var i = 0; i < words.Length; i++)
+        {
+            var copy = (string[])words.Clone();
+            copy[i] = "<u>" + copy[i] + "</u>";
+            cues[i] = string.Join(' ', copy);
+        }
+
+        var refText = TextToSpeechViewModel.BuildRefTextFromTranscription(cues);
+
+        Assert.Equal(sentence, refText);
+        Assert.DoesNotContain("<u>", refText);
+    }
+}
+
+/// <summary>
+/// A sidecar that cannot be a spoken transcription must read as "no transcript" so it is never
+/// passed as ref-text and the OmniVoice backfill can replace it.
+/// </summary>
+public class UnusableTranscriptTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void EmptyIsUnusable(string? text)
+    {
+        Assert.True(Qwen3TtsCrispAsr.LooksLikeUnusableTranscript(text));
+    }
+
+    [Fact]
+    public void AttributionBlurbIsUnusable()
+    {
+        Assert.True(Qwen3TtsCrispAsr.LooksLikeUnusableTranscript(
+            "https://commons.wikimedia.org/wiki/File:Clint_Eastwood.flac\nDescription\nEnglish: The speaking voice of Clint Eastwood."));
+    }
+
+    [Fact]
+    public void KaraokeMarkupIsUnusable()
+    {
+        // The real corruption: a karaoke transcription written straight into the sidecar. It is
+        // neither empty nor a blurb, so it used to survive normalization untouched.
+        Assert.True(Qwen3TtsCrispAsr.LooksLikeUnusableTranscript(
+            "<u>being</u> a silent person, I said, it's not that I said, I wish I could do that, it's just being"));
+    }
+
+    [Theory]
+    [InlineData("<i>italic</i> text")]
+    [InlineData("<font color=\"#ff0000\">coloured</font>")]
+    [InlineData("{\\an8}positioned")]
+    public void OtherSubtitleMarkupIsUnusable(string text)
+    {
+        Assert.True(Qwen3TtsCrispAsr.LooksLikeUnusableTranscript(text));
+    }
+
+    [Fact]
+    public void PlainSpokenTranscriptIsUsable()
+    {
+        Assert.False(Qwen3TtsCrispAsr.LooksLikeUnusableTranscript(
+            "being a silent person, I said, it's not that I said, I wish I could do that."));
+    }
+
+    [Fact]
+    public void TextWithAngleBracketsButNoTagsIsUsable()
+    {
+        // "<" alone is not markup — do not throw away a real transcript over punctuation.
+        Assert.False(Qwen3TtsCrispAsr.LooksLikeUnusableTranscript("five < ten and ten > five"));
+    }
+}


### PR DESCRIPTION
Three reported symptoms — CosyVoice3 asking for a transcription the voice pack already ships, asking repeatedly, and the test voice speaking the transcription instead of the test text — turned out to be one chain.

## 1. The transcripts already existed; three engines never looked

CosyVoice3, VoxCPM2 and F5-TTS seed their voices folder from the qwen3-tts.cpp pack but never called `Qwen3TtsCrispAsr.NormalizeVoiceTranscripts`, which MOSS-TTS has called since its own *"prompts several times for transcript"* bug. So of the 18 seeded voices only the one that happened to ship a real transcription was usable — the rest carried a Wikimedia attribution blurb (filtered to "no transcript") or nothing at all.

CosyVoice3 needs ref-text more than any sibling — it fails outright without one — yet it was the engine that never ran this, so merely browsing the voice combo fired the missing-transcript prompt once per voice. Meanwhile the sibling **OmniVoice pack ships all 18 with real transcripts**.

Dry-run of the fix against a real installation:

```
already ok=1   backfilled=17   left unresolved=0
```

CosyVoice3 goes from 1 usable transcript to 18 of 18, with nothing left to prompt for.

## 2. Filling one in via "Use speech to text…" corrupted it

The ref-text was joined from the raw cue text, so an Audio-to-text setup configured for karaoke output — faster-whisper `--highlight_words`, whisper.cpp `-owts` — emits one cue per word, each repeating the whole sentence with the current word wrapped in `<u>`. Joined raw, that wrote **4.3 kB of tag-laced repetition** as ref-text:

```
<u>being</u> a silent person, I said, … it's just being <u>a</u> silent person, I said, … (×40)
```

CosyVoice3 handed that to the s3tok tokenizer and rendered the reference text instead of the requested line — the "test voice uses the transcription as the test text" symptom. `TestVoice` was always passing `VoiceTestText` correctly; the ref-text was the problem.

`BuildRefTextFromTranscription` now strips subtitle markup and drops cues the result already contains, which collapses karaoke cues back to the single sentence they came from.

## 3. That corruption was invisible to every existing check

Such a sidecar is neither empty nor an attribution blurb, so it survived normalization and kept being used as ref-text. `LooksLikeUnusableTranscript` now also rejects subtitle markup — nothing spoken contains `<u>`, `<i>`, `<font` or `{\` — so the file is dropped and backfilled from OmniVoice instead.

## Tests

17 new tests in `RefTextFromTranscriptionTests` and `UnusableTranscriptTests`: karaoke collapse, growing-prefix cues, markup and ASSA stripping, multi-line cues, distinct sentences preserved in order, the blurb and karaoke rejections, and a guard that plain text containing `<` or `>` as punctuation is *not* discarded as markup. 867/867 UI tests pass.

## Not fixed here

A separate CosyVoice3 defect remains, reported upstream as [CrispStrobe/CrispASR#310](https://github.com/CrispStrobe/CrispASR/issues/310): on the `--voice ref.wav` clone path the reference transcript's tail is re-spoken before the requested text, on roughly half of short inputs, on both LLM quants, with baked presets unaffected. That one is in the engine's zero-shot prompt handling, not in SE — verified on Metal with crispasr 0.8.23, and a correct transcript does not avoid it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)