### PR TITLE
Show green check + "Nothing to fix" when a re-scan finds nothing (#12849)

### DIFF
--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -45,6 +45,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
     [ObservableProperty] private bool _tryToGuessUnknownWords;
     [ObservableProperty] private string _step2Title;
     [ObservableProperty] private string _fixesAppliedText = string.Empty;
+    [ObservableProperty] private bool _nothingToFixIsVisible;
     [ObservableProperty] private string _editTextTotalLength = string.Empty;
     [ObservableProperty] private IBrush _editTextTotalLengthBackground = Brushes.Transparent;
 
@@ -519,6 +520,10 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         VisibleFixes.Clear();
         _previewMode = true;
         ApplyFixes();
+
+        // Confirm that the scan actually ran when it came up empty - the counters do not change in
+        // that case, so without this "Refresh available fixes" looks like a dead button (#12849).
+        NothingToFixIsVisible = SelectedProfile != null && Fixes.Count == 0;
     }
 
     private void ApplyFixes()

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Data.Converters;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
@@ -217,12 +218,48 @@ public class FixCommonErrorsWindow : Window
 
         var labelFixesApplied = UiUtil.MakeTextBlock(string.Empty);
         labelFixesApplied.Bind(TextBlock.TextProperty, new Binding(nameof(vm.FixesAppliedText)));
-        labelFixesApplied.Bind(IsVisibleProperty, new Binding(nameof(vm.Step2IsVisible)));
-        labelFixesApplied.HorizontalAlignment = HorizontalAlignment.Left;
+        labelFixesApplied.Bind(IsVisibleProperty, new Binding(nameof(vm.FixesAppliedText)) { Converter = StringConverters.IsNotNullOrEmpty });
         labelFixesApplied.VerticalAlignment = VerticalAlignment.Center;
-        grid.Children.Add(labelFixesApplied);
-        Grid.SetRow(labelFixesApplied, 2);
-        Grid.SetColumn(labelFixesApplied, 0);
+
+        // Green check + "Nothing to fix" so an empty re-scan gives visible feedback; the counters
+        // stay as they were, which on its own reads as "the button did nothing" (#12849).
+        var nothingToFixBrush = new SolidColorBrush(UiTheme.IsDarkThemeEnabled()
+            ? Color.FromRgb(0x6e, 0xcb, 0x87)
+            : Color.FromRgb(0x1e, 0x7e, 0x34));
+        var nothingToFixText = UiUtil.MakeTextBlock(Se.Language.Tools.FixCommonErrors.NothingToFix);
+        nothingToFixText.Foreground = nothingToFixBrush;
+        nothingToFixText.VerticalAlignment = VerticalAlignment.Center;
+        var nothingToFixPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 6,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children =
+            {
+                new Optris.Icons.Avalonia.Icon
+                {
+                    Value = IconNames.CheckCircle,
+                    FontSize = 16,
+                    Foreground = nothingToFixBrush,
+                    VerticalAlignment = VerticalAlignment.Center,
+                },
+                nothingToFixText,
+            },
+        };
+        nothingToFixPanel.Bind(IsVisibleProperty, new Binding(nameof(vm.NothingToFixIsVisible)));
+
+        var panelStep2Status = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 15,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children = { labelFixesApplied, nothingToFixPanel },
+        };
+        panelStep2Status.Bind(IsVisibleProperty, new Binding(nameof(vm.Step2IsVisible)));
+        grid.Children.Add(panelStep2Status);
+        Grid.SetRow(panelStep2Status, 2);
+        Grid.SetColumn(panelStep2Status, 0);
 
         grid.Children.Add(buttonPanelRight);
         Grid.SetRow(buttonPanelRight, 2);


### PR DESCRIPTION
Fixes #12849

In Fix common errors step 2, clicking **Refresh available fixes** when nothing is left to fix gave no visible feedback: the list was already empty and the counters do not change, so it was impossible to tell whether the scan ran or the button simply did not react.

Now the bottom status slot shows a green check mark plus "Nothing to fix :)" — SE4 parity.

### Text: reused, no new string

`NothingToFix` was already defined in `LanguageFixCommonErrors.cs` but had **zero references** in code. It is already translated in 30+ language files, so this lights up in every language immediately without touching the translations.

### Changes

**`FixCommonErrorsViewModel.cs`**
- New `NothingToFixIsVisible` flag, set at the end of `RefreshFixes()` as `SelectedProfile != null && Fixes.Count == 0`. Every re-scan path goes through `RefreshFixes()`, so this covers Refresh, Apply selected fixes, entering step 2, and the "guess unknown words" toggle — and it clears itself as soon as a scan finds something.

**`FixCommonErrorsWindow.cs`**
- The bottom-left status slot is now a horizontal panel holding "Fixes applied: X" plus an `mdi-check-circle` icon and the "Nothing to fix" text, following the icon+text pattern already used for the amber warning note in `AiReviewWindow`.
- Green is theme-aware: `#6ECB87` on dark (the palette green this window's chips already use), `#1E7E34` on light, so it does not wash out.
- "Fixes applied" hides itself when empty so the check mark sits flush left instead of behind a gap on the first refresh.

Counters and button states are unchanged, as the issue asked.

### Notes

- The reporter suggested dropping the `:)` emoticon. Kept the string verbatim — that is what buys the existing translations, and the green check already carries the "all good" signal. Easy to change, but it would mean editing every language file.
- Dutch shows only the icon (its `NothingToFix` value is empty), but that file has ~1400 empty keys generally — not specific to this change.

### Testing

- `dotnet build src/ui/UI.csproj` — clean, 0 warnings
- The 5 existing `FixCommonErrors` UI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
