### PR TITLE
Correct stale CrispASR comments and download sizes

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngineBase.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngineBase.cs
@@ -25,10 +25,12 @@ public abstract class CrispAsrEngineBase : ICrispAsrEngine
     public abstract bool CanBeDownloaded();
 
     /// <summary>
-    /// CrispASR ships several Windows variants of very different sizes (CPU ~3 MB, Vulkan
-    /// ~25 MB, CUDA ~684 MB), and the variant is picked at download time rather than now.
-    /// We surface the smallest reasonable number and note that it varies so the user has a
-    /// floor without being misled by the CUDA bundle.
+    /// CrispASR ships several builds per platform whose sizes differ by two orders of magnitude,
+    /// and the variant is picked at download time rather than now — so Windows and Linux get a
+    /// range rather than a single number that would either understate the GPU bundles or scare
+    /// users off the CPU one. Figures are the v0.8.23 release assets
+    /// (<see cref="Nikse.SubtitleEdit.Logic.Download.CrispAsrDownloadService"/> holds the pin);
+    /// they drift with every release, so treat them as indicative.
     /// </summary>
     public virtual string DownloadSizeText
     {
@@ -36,15 +38,17 @@ public abstract class CrispAsrEngineBase : ICrispAsrEngine
         {
             if (OperatingSystem.IsWindows())
             {
-                return "~3 MB – 684 MB"; // CPU – CUDA depending on variant chosen at download time
+                // CPU ~7 MB, Vulkan ~33 MB, CUDA ~695 MB.
+                return "~7 MB – 695 MB";
             }
             if (OperatingSystem.IsLinux())
             {
-                return "~5 MB";
+                // CPU ~24 MB (arm64 ~22 MB), Vulkan ~59 MB, ROCm ~89 MB, CUDA 13 ~205 MB, CUDA 12 ~271 MB.
+                return "~24 MB – 271 MB";
             }
             if (OperatingSystem.IsMacOS())
             {
-                return "~4 MB";
+                return "~14 MB";
             }
             return string.Empty;
         }

--- a/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
@@ -31,10 +31,11 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 ///       --ref-text "Transcript of the reference audio" \
 ///       --tts "Hello, how are you today?" --tts-output out.wav
 ///
-/// Server-mode flag layout is unconfirmed in CrispASR 0.6.12's README. This implementation
-/// assumes the same per-request payload shape Qwen3 CustomVoice uses (voice = WAV path,
-/// ref_text = transcription) and falls back to a startup --voice / --ref-text if needed
-/// (toggle <see cref="UseStartupVoiceFlags"/> below). Verify against an actual 0.6.12 binary.
+/// Server mode takes the reference from the startup <c>--voice</c> / <c>--ref-text</c> flags, not
+/// from the request: the payload carries no <c>voice</c> or <c>ref_text</c> field at all (see
+/// <see cref="UseStartupVoiceFlags"/> and the remarks on the payload builder). Re-verified against
+/// crispasr 0.8.23 — the server logs the clone reference at startup and every line holds that
+/// speaker.
 /// </summary>
 public class F5TtsCrispAsr : ITtsEngine
 {

--- a/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
@@ -41,8 +41,9 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 ///
 /// Cloning is zero-shot from audio alone; an adjacent .txt transcription (ref-text) is optional
 /// but improves quality, so we pass <c>--ref-text</c> when a sidecar is present (same layout as
-/// F5-TTS / Qwen3 CustomVoice). Server-mode payload shape mirrors the other CrispASR TTS engines
-/// and should be verified against an actual v0.7.0 binary.
+/// F5-TTS / Qwen3 CustomVoice). Verified against crispasr 0.8.23: the reference comes from the
+/// startup <c>--voice</c> flag — the server logs "loaded reference audio '&lt;path&gt;'" and
+/// resamples it to 16 kHz — and the request carries no <c>voice</c> field.
 /// </summary>
 public class VoxCPM2CrispAsr : ITtsEngine
 {
@@ -66,10 +67,10 @@ public class VoxCPM2CrispAsr : ITtsEngine
 
     public const string BackendName = "voxcpm2-tts";
 
-    // Confirmed-by-analogy with F5-TTS/IndexTTS: the cloning backends read the reference audio
-    // from the startup --voice flag, so the server is torn down and restarted when the selected
-    // voice or ref-text changes (keyed by (model, voice, ref-text) below). Verify against a real
-    // v0.7.0 binary; if voxcpm2-tts honours a per-request voice field this can be set to false.
+    // Confirmed on crispasr 0.8.23: voxcpm2-tts reads the reference audio from the startup --voice
+    // flag, so the server is torn down and restarted when the selected voice or ref-text changes
+    // (keyed by (model, voice, ref-text) below). A per-request full path also hangs the server, so
+    // startup flags are the only workable shape here.
     private static readonly bool UseStartupVoiceFlags = true;
 
     /// <summary>


### PR DESCRIPTION
Documentation-only, found while auditing the CrispASR integration against the pinned v0.8.23 build. No behaviour change.

## Stale "verify this" comments

Three comments still asked a future reader to verify behaviour against a CrispASR 0.6.12 / v0.7.0 binary — and the F5-TTS one **contradicted the field comment ten lines below it**, which already recorded the confirmed answer. Rather than delete the notes, I re-ran the checks against 0.8.23 so the replacements state something true:

- **F5-TTS** (`F5TtsCrispAsr.cs`) — "Server-mode flag layout is unconfirmed in CrispASR 0.6.12's README … Verify against an actual 0.6.12 binary." The reference comes from the startup `--voice` / `--ref-text` flags and the request carries no `voice` or `ref_text` field; re-verified on 0.8.23 with a live server.
- **VoxCPM2** (`VoxCPM2CrispAsr.cs`, two comments) — "should be verified against an actual v0.7.0 binary" and "Confirmed-by-analogy with F5-TTS/IndexTTS … Verify against a real v0.7.0 binary". Started a 0.8.23 `voxcpm2-tts` server with SE's exact flags; synthesis is clean and the server logs

  ```
  crispasr[voxcpm2-tts]: resampled reference '…/female_06.wav' from 24000 Hz to 16000 Hz
  crispasr[voxcpm2-tts]: loaded reference audio '…/female_06.wav' (137538 samples @ 16 kHz)
  ```

  The second comment also now records that a per-request full path hangs the server, so startup flags are the only workable shape.

## Stale download sizes

`CrispAsrEngineBase.DownloadSizeText` was quoting v0.6-era asset sizes on every platform:

| platform | was | v0.8.23 actual |
|---|---|---|
| Windows | ~3 MB – 684 MB | **~7 MB – 695 MB** |
| Linux | ~5 MB (flat) | **~24 MB – 271 MB** |
| macOS | ~4 MB | **~14 MB** |

Linux was the worst: a flat "~5 MB" that predates the GPU builds v0.8.20 added, against a 271 MB CUDA 12 archive — off by more than 50×. Linux now gets a range like Windows, per-variant figures live in a comment (Vulkan ~59 MB, ROCm ~89 MB, CUDA 13 ~205 MB, arm64 ~22 MB), and the summary says the figures are indicative and drift per release so the next reader does not treat them as exact.

867/867 UI tests pass.

## Not in this PR

Other findings from the same audit, left alone deliberately:

- SE never passes `--punc-model`, so `funasr` produces subtitles with **no punctuation** and `funasr`/`firered-asr` produce **ALL CAPS** (casing is fixable via the existing `WhisperPostProcessingFixCasing`, which defaults to off). Verified that `--punc-model auto` restores punctuation but not casing.
- `moss-diarize` speaker labels land inside the cue text (`(Speaker 2) And so, my fellow Americans,`) with no mapping to SE's Actor field.
- 23 ASR backends present in v0.8.23 that SE does not expose (`voxtral`, `nemotron`, `moonshine`, `paraformer`, `reazonspeech`, `granite-4.1-plus`, `vibevoice-bitnet`, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)