### PR TITLE
Add 4 Parakeet and 1 Kyutai model to the CrispASR speech-to-text engines

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrKyutai.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrKyutai.cs
@@ -53,6 +53,37 @@ public class CrispAsrKyutai : CrispAsrEngineBase
                     "https://huggingface.co/cstr/kyutai-stt-1b-GGUF/resolve/main/kyutai-stt-1b.gguf"
                 ],
             },
+
+            // 48-layer 2.6b variant: English only (unlike the en+fr 1b above) and a 3.5 s
+            // lookahead, so it trades latency for accuracy - fine for file transcription.
+            // File names carry no "-en" suffix even though the repo does.
+            new WhisperModel
+            {
+                Name = "kyutai-stt-2.6b-q4_k.gguf",
+                Size = "1.47 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/kyutai-stt-2.6b-en-GGUF/resolve/main/kyutai-stt-2.6b-q4_k.gguf"
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "kyutai-stt-2.6b-q8_0.gguf",
+                Size = "2.70 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/kyutai-stt-2.6b-en-GGUF/resolve/main/kyutai-stt-2.6b-q8_0.gguf"
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "kyutai-stt-2.6b-f16.gguf",
+                Size = "5.01 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/kyutai-stt-2.6b-en-GGUF/resolve/main/kyutai-stt-2.6b-f16.gguf"
+                ],
+            },
        };
 
     public override string Extension => string.Empty;

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
@@ -140,6 +140,128 @@ public class CrispAsrParakeet : CrispAsrEngineBase
                     "https://huggingface.co/cstr/parakeet-rnnt-1.1b-GGUF/resolve/main/parakeet-rnnt-1.1b-f16.gguf",
                 ],
             },
+
+            // Largest TDT variant - the accuracy ceiling for this backend, at roughly
+            // double the download of tdt-0.6b-v3.
+            new WhisperModel
+            {
+                Name = "parakeet-tdt-1.1b-q4_k.gguf",
+                Size = "652 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/parakeet-tdt-1.1b-GGUF/resolve/main/parakeet-tdt-1.1b-q4_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "parakeet-tdt-1.1b-q8_0.gguf",
+                Size = "1.07 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/parakeet-tdt-1.1b-GGUF/resolve/main/parakeet-tdt-1.1b-q8_0.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "parakeet-tdt-1.1b.gguf",
+                Size = "2.00 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/parakeet-tdt-1.1b-GGUF/resolve/main/parakeet-tdt-1.1b.gguf",
+                ],
+            },
+
+            // v2 predates the multilingual v3: English only, but trained for mixed-case
+            // output with punctuation, which suits subtitling better than a bare lowercase
+            // transcript. Worth keeping alongside v3 for English-only jobs.
+            new WhisperModel
+            {
+                Name = "parakeet-tdt-0.6b-v2-q4_k.gguf",
+                Size = "379 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/parakeet-tdt-0.6b-v2-GGUF/resolve/main/parakeet-tdt-0.6b-v2-q4_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "parakeet-tdt-0.6b-v2-q8_0.gguf",
+                Size = "634 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/parakeet-tdt-0.6b-v2-GGUF/resolve/main/parakeet-tdt-0.6b-v2-q8_0.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "parakeet-tdt-0.6b-v2.gguf",
+                Size = "1.15 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/parakeet-tdt-0.6b-v2-GGUF/resolve/main/parakeet-tdt-0.6b-v2.gguf",
+                ],
+            },
+
+            // Smallest model on this backend by a wide margin - the q4_k build is 75 MB,
+            // for low-end CPUs where even the 0.6b variants are too slow. TDT head, so
+            // native timestamps still apply.
+            new WhisperModel
+            {
+                Name = "parakeet-tdt_ctc-110m-q4_k.gguf",
+                Size = "75 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/parakeet-tdt_ctc-110m-GGUF/resolve/main/parakeet-tdt_ctc-110m-q4_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "parakeet-tdt_ctc-110m-q8_0.gguf",
+                Size = "121 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/parakeet-tdt_ctc-110m-GGUF/resolve/main/parakeet-tdt_ctc-110m-q8_0.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "parakeet-tdt_ctc-110m.gguf",
+                Size = "219 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/parakeet-tdt_ctc-110m-GGUF/resolve/main/parakeet-tdt_ctc-110m.gguf",
+                ],
+            },
+
+            // Hybrid TDT+CTC at 1.1b - same TDT decoding path (and native timestamps) as
+            // parakeet-tdt-1.1b, with a CTC head available to the runtime.
+            new WhisperModel
+            {
+                Name = "parakeet-tdt_ctc-1.1b-q4_k.gguf",
+                Size = "654 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/parakeet-tdt_ctc-1.1b-GGUF/resolve/main/parakeet-tdt_ctc-1.1b-q4_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "parakeet-tdt_ctc-1.1b-q8_0.gguf",
+                Size = "1.07 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/parakeet-tdt_ctc-1.1b-GGUF/resolve/main/parakeet-tdt_ctc-1.1b-q8_0.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "parakeet-tdt_ctc-1.1b.gguf",
+                Size = "2.00 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/parakeet-tdt_ctc-1.1b-GGUF/resolve/main/parakeet-tdt_ctc-1.1b.gguf",
+                ],
+            },
        };
 
     public override string Extension => string.Empty;


### PR DESCRIPTION
## What changed

Five models added to two existing CrispASR engines. These are `Models` list entries only — both backends are already wired up, and SE is pinned to CrispASR v0.8.23, so there are no runtime, settings, DI, or download-service changes.

**`CrispAsrParakeet`** (`--backend parakeet`), each with q4_k / q8_0 / full quants:

| Model | Sizes | Rationale |
|---|---|---|
| `parakeet-tdt-1.1b` | 652 MB / 1.07 GB / 2.00 GB | Largest TDT variant — accuracy ceiling for this backend |
| `parakeet-tdt-0.6b-v2` | 379 MB / 634 MB / 1.15 GB | English-only, but trained for mixed-case output with punctuation, which is better raw material for subtitles than v3's multilingual output |
| `parakeet-tdt_ctc-110m` | 75 MB / 121 MB / 219 MB | New size/speed floor — an order of magnitude below anything previously offered, for low-end CPUs |
| `parakeet-tdt_ctc-1.1b` | 654 MB / 1.07 GB / 2.00 GB | Hybrid TDT+CTC at 1.1b |

**`CrispAsrKyutai`** (`--backend kyutai-stt`): `kyutai-stt-2.6b` at 1.47 / 2.70 / 5.01 GB — 48-layer English-only variant, alongside the existing en+fr 1b.

## Why these five

CrispASR publishes more GGUF conversions for these two backends than SE surfaced. All five are listed in CrispASR's own set of variants the respective backend accepts.

## Two candidates deliberately excluded

- **`parakeet-ctc-1.1b-ja`** — pure CTC. CrispASR's feature matrix separates native timestamps (TDT/RNNT) from CTC timestamps, and `HasNativeTimestamps` is declared per *engine*, not per model (`CrispAsrParakeet.cs:18`). Adding a pure-CTC model to that list would make the flag untrue for it. Everything added here is TDT-headed, so the flag stays accurate. This is worth a maintainer opinion: if per-model timestamp capability is wanted, the CTC variants become available too, but that is a larger change than this PR.
- **`parakeet_de_med`** — not present in CrispASR's list of variants the `parakeet` backend accepts. It would download successfully and then fail at transcribe time.

## Verification performed

- `dotnet build src/ui/UI.csproj` — succeeded, 0 warnings, 0 errors.
- All 15 new download URLs HEAD-checked: every one resolves, and every `Content-Length` matches the `Size` string in the code. (Checked deliberately, since #12856 was itself a correction of stale sizes.)

## Known limitations

- **Not run end-to-end.** No model here has actually been used to transcribe audio. The variant names come from CrispASR's supported list and the files download, but inference is unverified. `parakeet-tdt_ctc-110m-q4_k` is the cheap smoke test at 75 MB.
- Language coverage per model is not separately declared — both engines expose one language list for all their models, which is the existing pattern (the current `parakeet-tdt-0.6b-ja` entries have the same property). `kyutai-stt-2.6b` is English-only while the Kyutai engine offers en+fr.
- Sizes are from the current HF revisions and will drift if the repos are re-quantized.

## Note

This change was materially AI-assisted (Claude Opus 5), per the repository's AI contributor guidelines.