### PR TITLE
Correct model comments flagged in the #12857 Copilot review

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrKyutai.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrKyutai.cs
@@ -54,9 +54,13 @@ public class CrispAsrKyutai : CrispAsrEngineBase
                 ],
             },
 
-            // 48-layer 2.6b variant: English only (unlike the en+fr 1b above) and a 3.5 s
-            // lookahead, so it trades latency for accuracy - fine for file transcription.
-            // File names carry no "-en" suffix even though the repo does.
+            // 48-layer 2.6b variant with a 3.5 s lookahead, so it trades latency for
+            // accuracy - fine for file transcription. File names carry no "-en" suffix
+            // even though the repo does.
+            //
+            // English only. The Languages list above is engine-wide and is passed through
+            // as a command-line flag, so "fr" applies to the 1b model only - pair the
+            // 2.6b model with "en".
             new WhisperModel
             {
                 Name = "kyutai-stt-2.6b-q4_k.gguf",

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
@@ -141,8 +141,9 @@ public class CrispAsrParakeet : CrispAsrEngineBase
                 ],
             },
 
-            // Largest TDT variant - the accuracy ceiling for this backend, at roughly
-            // double the download of tdt-0.6b-v3.
+            // Largest TDT variant - the accuracy ceiling for this backend. Roughly
+            // 1.3x-1.6x the download of tdt-0.6b-v3 depending on quant (652 MB vs
+            // 489 MB at q4_k, 2.00 GB vs 1.26 GB unquantized).
             new WhisperModel
             {
                 Name = "parakeet-tdt-1.1b-q4_k.gguf",

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
@@ -143,7 +143,7 @@ public class CrispAsrParakeet : CrispAsrEngineBase
 
             // Largest TDT variant - the accuracy ceiling for this backend. Roughly
             // 1.3x-1.6x the download of tdt-0.6b-v3 depending on quant (652 MB vs
-            // 489 MB at q4_k, 2.00 GB vs 1.26 GB unquantized).
+            // 489 MB at q4_k, 2.00 GB vs 1.26 GB at F16).
             new WhisperModel
             {
                 Name = "parakeet-tdt-1.1b-q4_k.gguf",


### PR DESCRIPTION
Follow-up to #12857, which was merged before its Copilot review completed (the review landed 42 seconds after the merge). Both findings were valid; this addresses them. Comment-only changes, no functional difference.

## 1. Inaccurate size claim (`CrispAsrParakeet`)

The `parakeet-tdt-1.1b` comment claimed "roughly double the download of tdt-0.6b-v3". Measured against the v3 sizes already listed in the same file, the real ratio is 1.3x-1.6x:

| Quant | tdt-1.1b | tdt-0.6b-v3 | Ratio |
|---|---|---|---|
| q4_k | 652 MB | 489 MB | 1.33x |
| q8_0 | 1.07 GB | 745 MB | 1.47x |
| full | 2.00 GB | 1.26 GB | 1.59x |

Replaced with the actual figures. Worth correcting rather than deleting, since #12856 had just finished cleaning up stale size claims in this area.

## 2. Implicit language consequence (`CrispAsrKyutai`)

The comment stated the 2.6b model is English-only but left the operational consequence unsaid: `Languages` is engine-wide and is passed straight through as a command-line flag, so nothing stops a user pairing `fr` with the 2.6b model. The comment now states that `fr` applies to the 1b model only.

This is a documentation fix for a real per-model/per-engine mismatch, not a fix for the mismatch itself. Making language coverage per-model would mean changing `CrispAsrEngineBase`, and the same property already applies to the pre-existing `parakeet-tdt-0.6b-ja` entries — worth a separate issue if wanted.

## Verification

- `dotnet build src/ui/UI.csproj` - succeeded, 0 warnings, 0 errors.
- Ratios recomputed from the byte sizes on the HF revisions and cross-checked against the `Size` strings already in the file.
- Still not run end-to-end: no model in #12857 has transcribed audio yet. Unchanged by this PR.

## Note

Materially AI-assisted (Claude Opus 5), per the repository AI contributor guidelines.