### PR TITLE
Make online STT failures readable, send file last (#12860)

### DIFF
--- a/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
@@ -127,7 +127,6 @@ public class OpenAiSttService : ISttTranscriber
         var uploadFileName = NormalizeUploadFileName(fileName, effectiveFormat);
         var fileContent = new StreamContent(audioStream);
         fileContent.Headers.ContentType = new MediaTypeHeaderValue(GetMediaTypeForFormat(effectiveFormat));
-        content.Add(fileContent, "file", uploadFileName);
 
         // Add model
         if (!string.IsNullOrEmpty(_settings.Model))
@@ -173,6 +172,12 @@ public class OpenAiSttService : ISttTranscriber
         {
             content.Add(new StringContent(_settings.Prompt), "prompt");
         }
+
+        // The audio goes in last on purpose: xAI's /v1/stt documents that "file"
+        // must be the final field in the multipart form, and servers that stream
+        // the upload to a decoder generally want the parameters parsed before the
+        // payload arrives. OpenAI and friends don't care about field order.
+        content.Add(fileContent, "file", uploadFileName);
 
         // Create request
         using var request = new HttpRequestMessage(HttpMethod.Post, _settings.EndpointUrl)
@@ -672,7 +677,11 @@ public class OpenAiSttService : ISttTranscriber
             Prompt = settings.OpenAiCompatibleSttPrompt,
             Stream = settings.OpenAiCompatibleSttStream,
             AudioFormat = settings.OpenAiCompatibleSttAudioFormat,
-            Logger = Se.WriteToolsLog
+            // Forced write: the logger only fires on a hard HTTP failure, and the
+            // "write tools log" setting is off by default — without force the
+            // request params and the server's response body never reach the log
+            // the user would attach to a bug report (issue #12860).
+            Logger = log => Se.WriteToolsLog(log, true)
         };
     }
 

--- a/src/ui/Features/Video/SpeechToText/OpenRouter/OpenRouterSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/OpenRouter/OpenRouterSttService.cs
@@ -217,7 +217,9 @@ public class OpenRouterSttService : ISttTranscriber
             Temperature = (double)tools.OpenRouterSttTemperature,
             Prompt = tools.OpenRouterSttPrompt,
             TimeoutSeconds = tools.OpenRouterSttTimeoutSeconds,
-            Logger = Se.WriteToolsLog,
+            // See OpenAiSttService.GetSettingsFromConfiguration: hard-failure
+            // diagnostics must survive the default-off "write tools log" setting.
+            Logger = log => Se.WriteToolsLog(log, true),
         };
     }
 }

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -154,6 +154,16 @@ public partial class SpeechToTextViewModel : ObservableObject
     private readonly VideoInfo _videoInfo = new();
     private bool _abort;
     private CancellationTokenSource? _openAiCts;
+
+    /// <summary>
+    /// Language code reported by an online STT provider for the current run.
+    /// Post-processing needs a language, and online engines have no entry in the
+    /// shared language dropdown — so when the user leaves the per-engine hint
+    /// empty (auto-detect), this is what keeps merge/split/line-breaking from
+    /// being skipped entirely (issue #12860).
+    /// </summary>
+    private string? _onlineDetectedLanguage;
+
     private readonly List<ResultText> _resultList = new();
     private bool _useCenterChannelOnly;
 
@@ -1128,14 +1138,16 @@ public partial class SpeechToTextViewModel : ObservableObject
         // moment for these engines — there is no separate OK button.
         SaveSettings();
 
+        _onlineDetectedLanguage = null;
+
         var transcriber = engine.CreateTranscriber(out var configError);
         if (transcriber == null)
         {
             await Dispatcher.UIThread.InvokeAsync(async () =>
             {
                 await MessageBox.Show(Window!,
-                    configError ?? Se.Language.General.OpenAiCompatibleSttUrlMissing,
-                    Se.Language.General.ConfigurationRequired);
+                    Se.Language.General.ConfigurationRequired,
+                    configError ?? Se.Language.General.OpenAiCompatibleSttUrlMissing);
                 IsTranscribeEnabled = true;
             });
             return;
@@ -1158,8 +1170,8 @@ public partial class SpeechToTextViewModel : ObservableObject
             await Dispatcher.UIThread.InvokeAsync(async () =>
             {
                 await MessageBox.Show(Window!,
-                    string.Format(Se.Language.General.OpenAiCompatibleSttUrlNotResponding, probeError),
-                    Se.Language.General.TranscriptionError);
+                    Se.Language.General.TranscriptionError,
+                    string.Format(Se.Language.General.OpenAiCompatibleSttUrlNotResponding, probeError));
                 IsTranscribeEnabled = true;
             });
             return;
@@ -1206,6 +1218,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             else
             {
                 var response = await service.TranscribeAsync(audioFileName, language, null, segmentProgress, cancellationToken);
+                RememberDetectedLanguage(response);
                 IngestTranscriptionResponse(
                     response,
                     subtitle,
@@ -1272,9 +1285,12 @@ public partial class SpeechToTextViewModel : ObservableObject
         catch (HttpRequestException ex)
         {
             // Log the full exception before simplifying the dialog text — the
-            // response body (e.g. DashScope's error code) is the only clue to
-            // what actually failed, and the dialog may hide it.
-            Se.WriteToolsLog($"Online STT transcription failed ({engine.Name}): {ex}");
+            // response body (e.g. DashScope's error code, or xAI's "check the
+            // URL" for a wrong endpoint path) is the only clue to what actually
+            // failed. Force the write: "write tools log" is off by default, so
+            // without it the server's answer is gone the moment the user closes
+            // the dialog (issue #12860).
+            Se.WriteToolsLog($"Online STT transcription failed ({engine.Name}): {ex}", true);
 
             var message = ex.Message;
             if (message.Contains("401") || message.Contains("Unauthorized"))
@@ -1294,7 +1310,7 @@ public partial class SpeechToTextViewModel : ObservableObject
 
             await Dispatcher.UIThread.InvokeAsync(async () =>
             {
-                await MessageBox.Show(Window!, message, Se.Language.General.TranscriptionError);
+                await MessageBox.Show(Window!, Se.Language.General.TranscriptionError, message);
                 IsTranscribeEnabled = true;
             });
         }
@@ -1303,11 +1319,11 @@ public partial class SpeechToTextViewModel : ObservableObject
             // Raised by the online STT services when their own timeout fires
             // (distinct from a user cancel, which arrives as
             // OperationCanceledException above).
-            Se.WriteToolsLog($"Online STT transcription timed out ({engine.Name}): {ex.Message}");
+            Se.WriteToolsLog($"Online STT transcription timed out ({engine.Name}): {ex.Message}", true);
 
             await Dispatcher.UIThread.InvokeAsync(async () =>
             {
-                await MessageBox.Show(Window!, Se.Language.General.RequestTimeout, Se.Language.General.TranscriptionError);
+                await MessageBox.Show(Window!, Se.Language.General.TranscriptionError, Se.Language.General.RequestTimeout);
                 IsTranscribeEnabled = true;
             });
 
@@ -1332,11 +1348,11 @@ public partial class SpeechToTextViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            Se.WriteToolsLog($"Online STT transcription failed ({engine.Name}): {ex}");
+            Se.WriteToolsLog($"Online STT transcription failed ({engine.Name}): {ex}", true);
 
             await Dispatcher.UIThread.InvokeAsync(async () =>
             {
-                await MessageBox.Show(Window!, $"{Se.Language.General.TranscriptionFailed}: {ex.Message}", "Error");
+                await MessageBox.Show(Window!, Se.Language.General.TranscriptionError, $"{Se.Language.General.TranscriptionFailed}: {ex.Message}");
                 IsTranscribeEnabled = true;
             });
         }
@@ -1553,6 +1569,7 @@ public partial class SpeechToTextViewModel : ObservableObject
                 var chunkResponse = await service.TranscribeAsync(
                     chunkPath, language, null, offsettingProgress, cancellationToken);
 
+                RememberDetectedLanguage(chunkResponse);
                 IngestTranscriptionResponse(
                     chunkResponse,
                     subtitle,
@@ -1842,17 +1859,57 @@ public partial class SpeechToTextViewModel : ObservableObject
     /// <summary>
     /// The language hint configured for the selected online STT engine, or null
     /// for local engines. Online engines don't use the shared language dropdown
-    /// (it's nulled out), so post-processing reads the per-engine setting instead.
+    /// (it's nulled out), so post-processing reads the per-engine setting instead
+    /// — falling back to the language the provider detected when that setting is
+    /// left empty.
     /// </summary>
     private string? GetOnlineEngineLanguageHint()
     {
-        return GetEffectiveSelectedEngine() switch
+        var configured = GetEffectiveSelectedEngine() switch
         {
             OpenRouterSttEngine => Se.Settings.Tools.OpenRouterSttLanguage,
             DashScopeQwen3SttEngine => Se.Settings.Tools.DashScopeSttLanguage,
             OpenAiCompatibleSttEngine => Se.Settings.Tools.OpenAiCompatibleSttLanguage,
             _ => null,
         };
+
+        if (configured == null || !string.IsNullOrWhiteSpace(configured))
+        {
+            return configured;
+        }
+
+        // Hint left empty (auto-detect): use whatever language the provider said
+        // it recognized, so post-processing still runs (issue #12860).
+        return _onlineDetectedLanguage;
+    }
+
+    /// <summary>
+    /// Note the language an online provider reported for this run. Providers are
+    /// inconsistent here — OpenAI's verbose_json says "english" while others send
+    /// "en" — so a full name is mapped back to its whisper language code. The
+    /// first non-empty value wins; later chunks don't overwrite it.
+    /// </summary>
+    private void RememberDetectedLanguage(OpenAiCompatibleSttResponse response)
+    {
+        if (!string.IsNullOrEmpty(_onlineDetectedLanguage) || string.IsNullOrWhiteSpace(response.Language))
+        {
+            return;
+        }
+
+        var reported = response.Language.Trim();
+        if (reported.Length == 2)
+        {
+            _onlineDetectedLanguage = reported.ToLowerInvariant();
+            return;
+        }
+
+        var match = WhisperLanguage.Languages.FirstOrDefault(p =>
+            p.Name.Equals(reported, StringComparison.OrdinalIgnoreCase) ||
+            p.Code.Equals(reported, StringComparison.OrdinalIgnoreCase));
+        if (match != null)
+        {
+            _onlineDetectedLanguage = match.Code;
+        }
     }
 
     private WavePeakData2? MakeWavePeaks()

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -591,6 +591,7 @@ public class Se
         Configuration.Settings.Tools.OpenAiCompatibleSttPrompt = Settings.Tools.OpenAiCompatibleSttPrompt;
         Configuration.Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection = Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection;
         Configuration.Settings.Tools.OpenAiCompatibleSttStream = Settings.Tools.OpenAiCompatibleSttStream;
+        Configuration.Settings.Tools.OpenAiCompatibleSttAudioFormat = Settings.Tools.OpenAiCompatibleSttAudioFormat;
 
         Configuration.Settings.Tools.OpenRouterSttApiKey = Settings.Tools.OpenRouterSttApiKey;
         Configuration.Settings.Tools.OpenRouterSttModel = Settings.Tools.OpenRouterSttModel;

--- a/tests/UI/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttServiceTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttServiceTests.cs
@@ -511,6 +511,56 @@ public class OpenAiSttServiceTests
         }
     }
 
+    [Fact]
+    public async Task TranscribeAsync_SendsFileAsLastMultipartField()
+    {
+        // Issue #12860: xAI's /v1/stt documents that "file" must be the final
+        // field in the multipart form — parameters written after the payload are
+        // not seen. Harmless for OpenAI, which ignores field order.
+        var fieldOrder = new List<string>();
+        using var handler = new StubHandler(async (req, ct) =>
+        {
+            if (req.Content is MultipartFormDataContent multipart)
+            {
+                foreach (var part in multipart)
+                {
+                    var name = part.Headers.ContentDisposition?.Name?.Trim('"') ?? string.Empty;
+                    if (!string.IsNullOrEmpty(name))
+                    {
+                        fieldOrder.Add(name);
+                    }
+
+                    if (name == "file")
+                    {
+                        // Drain so the request completes cleanly.
+                        await part.ReadAsByteArrayAsync(ct);
+                    }
+                }
+            }
+            return JsonResponse("""{"text":"ok"}""");
+        });
+        using var client = new HttpClient(handler);
+        var settings = MakeSettings();
+        settings.Prompt = "names: Nikse";
+        settings.Temperature = 0.5;
+        var service = new OpenAiSttService(client, settings);
+
+        var ct = TestContext.Current.CancellationToken;
+        var wav = MakeTinyWav();
+        try
+        {
+            await service.TranscribeAsync(wav, cancellationToken: ct);
+
+            Assert.Contains("model", fieldOrder);
+            Assert.Contains("prompt", fieldOrder);
+            Assert.Equal("file", fieldOrder[^1]);
+        }
+        finally
+        {
+            File.Delete(wav);
+        }
+    }
+
     [Theory]
     [InlineData("mp3", "audio/mpeg")]
     [InlineData("m4a", "audio/mp4")]


### PR DESCRIPTION
Fixes the diagnosability problem behind #12860, plus three related fixes found alongside it.

## What the reporter saw

A 404 from the OpenAI Compatible Server engine (Grok), shown as a dialog with the error truncated in the **title bar** and the word "Transcription Error" as the body.

The 404 itself is server-side: xAI only implements `POST /v1/stt`. `POST https://api.x.ai/v1/audio/transcriptions` answers `404 The requested resource was not found. Please check the URL and try again.` — which is exactly the body SE received, and exactly the part the dialog cut off. SE's request shape hasn't changed since the commit that made Grok work (`git diff 9a1332b7f0 HEAD` on `OpenAiSttService.cs` touches only the timeout/CTS refactor), so this isn't a regression — it's an unreadable error message.

## Changes

- **Dialog argument order.** `MessageBox.Show` is `(owner, title, message)`, but the five online-STT error paths passed `(message, title)`. The status, sanitized endpoint and response body the service already assembles now land in the readable body. Local-engine call sites in the same file were already correct.
- **Force-write online STT failures to the tools log.** `Se.WriteToolsLog` returns early unless the default-off "write tools log" setting is on, so the response body was lost as soon as the dialog closed. Same treatment as the Qwen3 output-JSON dump in #11375. Applied to the ViewModel's catch blocks and to the per-request param logging in the OpenAI-compatible and OpenRouter services. DashScope's logger is left alone — it also carries progress messages, which shouldn't be forced.
- **Send the audio as the last multipart field.** xAI's `/v1/stt` documents that `file` must be the final field; SE added it first, before `model`/`language`/`response_format`. OpenAI and friends ignore field order. Covered by a new test.
- **Language fallback for post-processing.** `PostProcess` bails out entirely with no language code, and for online engines the only source was the per-engine language hint. Left empty (auto-detect, the default), merge/split/line-breaking never ran — the "OpenRouter output is one big chunk" half of the report. The provider's detected language (`response.Language`) is now used as the fallback, with a full name like `"english"` mapped back to its whisper code.
- **`OpenAiCompatibleSttAudioFormat` was missing from `UpdateLibSeSettings`**, so `GetSettingsFromConfiguration` always read libse's default. Currently masked by `ResolveEffectiveFormat` trusting the file extension, but it's a live inconsistency.

## Testing

`dotnet test tests/UI/UITests.csproj` — 869 passed, including the new `TranscribeAsync_SendsFileAsLastMultipartField`.

For the reporter, the workaround is still to set the endpoint to `https://api.x.ai/v1/stt` and clear the Model field (xAI documents no `model` parameter); with this change the dialog says so itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)