### PR TITLE
Dedup ref-text cues by whole words, not raw substrings

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -774,18 +774,61 @@ public partial class TextToSpeechViewModel : ObservableObject
 
             // Skip a cue the result already covers: identical karaoke repeats, and the growing
             // prefixes some word-timestamp modes emit. Cheap because ref-text stays short.
-            if (parts.Any(p => p.Contains(text, StringComparison.OrdinalIgnoreCase)))
+            if (parts.Any(p => CoversWords(p, text)))
             {
                 continue;
             }
 
             // Conversely, drop an earlier part this cue supersedes.
-            parts.RemoveAll(p => text.Contains(p, StringComparison.OrdinalIgnoreCase));
+            parts.RemoveAll(p => CoversWords(text, p));
             parts.Add(text);
         }
 
         return string.Join(' ', parts);
     }
+
+    /// <summary>
+    /// True when <paramref name="inner"/>'s words appear as a contiguous run inside
+    /// <paramref name="outer"/>'s words.
+    /// </summary>
+    /// <remarks>
+    /// Whole words, not raw substrings: a plain <c>Contains</c> also matches inside a word, so a
+    /// cue of "Yes" was dropped by a later "Yesterday we left.", and "I" — about as common as cues
+    /// get — by any later cue containing "It". The ref-text then no longer matched the reference
+    /// audio, which is the mismatch that degrades cloning in the first place.
+    /// </remarks>
+    private static bool CoversWords(string outer, string inner)
+    {
+        var outerWords = SplitWords(outer);
+        var innerWords = SplitWords(inner);
+        if (innerWords.Length == 0 || innerWords.Length > outerWords.Length)
+        {
+            return false;
+        }
+
+        for (var start = 0; start + innerWords.Length <= outerWords.Length; start++)
+        {
+            var matched = true;
+            for (var i = 0; i < innerWords.Length; i++)
+            {
+                if (!string.Equals(outerWords[start + i], innerWords[i], StringComparison.OrdinalIgnoreCase))
+                {
+                    matched = false;
+                    break;
+                }
+            }
+
+            if (matched)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string[] SplitWords(string text) =>
+        text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
 
     private static ObservableCollection<string> BuildKeywordOptions(string[] keywords)
     {

--- a/tests/UI/Features/Video/TextToSpeech/RefTextFromTranscriptionTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/RefTextFromTranscriptionTests.cs
@@ -71,6 +71,21 @@ public class RefTextFromTranscriptionTests
         Assert.Equal("Real text.", refText);
     }
 
+    [Theory]
+    [InlineData("Yes", "Yesterday we left.", "Yes Yesterday we left.")]
+    [InlineData("I", "It is fine.", "I It is fine.")]
+    [InlineData("No", "Nothing happened.", "No Nothing happened.")]
+    [InlineData("an", "Another day.", "an Another day.")]
+    public void KeepsAShortCueThatIsOnlyASubstringOfALaterWord(string first, string second, string expected)
+    {
+        // Dedup is by whole words. Matching raw substrings dropped "Yes" into "Yesterday" and "I"
+        // into "It" — losing words the speaker actually said, so the ref-text stopped matching the
+        // reference audio.
+        var refText = TextToSpeechViewModel.BuildRefTextFromTranscription(new[] { first, second });
+
+        Assert.Equal(expected, refText);
+    }
+
     [Fact]
     public void CollapsesGrowingPrefixCues()
     {


### PR DESCRIPTION
Follow-up to #12852, found while bug-hunting the code that PR added.

## The bug

`BuildRefTextFromTranscription` deduplicates the cues of a transcription before joining them into cloning ref-text. It decided a cue was already covered with a plain `string.Contains` — which also matches **inside a word**. So any cue whose text was a substring of a later cue's word was silently deleted:

| cues | should be | was |
|---|---|---|
| `"Yes"` + `"Yesterday we left."` | `Yes Yesterday we left.` | `Yesterday we left.` |
| `"No"` + `"Nothing happened."` | `No Nothing happened.` | `Nothing happened.` |
| **`"I"` + `"It is fine."`** | `I It is fine.` | `It is fine.` |

`"I"` is the damaging case — about as common as an English subtitle cue gets, and it disappears into any later cue containing "It".

The consequence is the exact failure the dedup exists to prevent: the joined ref-text omits words the speaker actually said, so it stops matching the reference audio, and a mismatched ref-text is what degrades zero-shot cloning quality.

## The fix

Containment is now checked over **word sequences** — a cue counts as covered only when its words appear as a contiguous run inside another cue's words, compared case-insensitively.

The two behaviours #12852 added this dedup for are unaffected, because both are whole-word matches:

- **karaoke repeats** (faster-whisper `--highlight_words`, whisper.cpp `-owts`) — after tag stripping the cues are identical, so they still collapse to one sentence;
- **growing-prefix cues** — `"I really"` → `"I really like"` → `"I really like that."` still collapse to the longest.

## Tests

New `[Theory]` with the four substring-collision cases above, alongside the existing karaoke/prefix/markup coverage. 871/871 UI tests pass.

## Note for the reviewer

Two things I checked in the same pass that are **not** bugs, so nobody re-opens them:

- `Qwen3TtsCrispAsr` reads `Qwen3TtsCppInstruction`, a different engine's setting — deliberate and documented at `TextToSpeechViewModel.cs:450`, so switching between the two Qwen3 engines keeps the instruction.
- The `RemoveAll`-then-`Add` in this method looks like it would scramble cue order when a later cue supersedes an earlier one. It does not — dropping the subsumed cue and appending the survivor yields the correct sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)