### PR TITLE
Reference Linux Skia natives in libse/libuilogic test projects

### DIFF
--- a/tests/libse/LibSETests.csproj
+++ b/tests/libse/LibSETests.csproj
@@ -89,6 +89,15 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.v3" Version="3.2.2" />
+
+    <!--
+      libse's bitmap code (BluRay sup / VobSub decoding, OCR binarize) goes through SkiaSharp, and
+      the SkiaSharp package bundles the macOS/Windows natives but NOT Linux - src\ui and src\seconv
+      each reference the Linux assets themselves for exactly that reason (issue #11872). Without
+      this the test run dies on Linux with "Unable to load shared library 'libSkiaSharp'". Pinned to
+      the same version as the managed SkiaSharp wrapper to avoid an ABI mismatch (cf. #11864, #11931).
+    -->
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/libuilogic/LibUiLogicTests.csproj
+++ b/tests/libuilogic/LibUiLogicTests.csproj
@@ -19,6 +19,17 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.v3" Version="3.2.2" />
+
+    <!--
+      libuilogic's OCR / image export paths go through SkiaSharp + SkiaSharp.HarfBuzz, and those
+      packages bundle the macOS/Windows natives but NOT Linux - src\ui and src\seconv each reference
+      the Linux assets themselves for exactly that reason (issue #11872). Without this the test run
+      dies on Linux with "Unable to load shared library 'libSkiaSharp'". Pinned to the same versions
+      as the managed SkiaSharp / HarfBuzzSharp wrappers (3.119.4 / 8.3.1.5) to avoid a native/managed
+      ABI mismatch (cf. issues #11864, #11931).
+    -->
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- `SkiaSharp` bundles the macOS and Windows natives but **not** the Linux ones. `src/ui` and `src/seconv` already reference `SkiaSharp.NativeAssets.Linux` explicitly for that reason (#11872), but the test projects never did — so `LibSETests` and `LibUiLogicTests` ran with the managed wrapper and no `libSkiaSharp.so` beside it.
- On Linux that made every bitmap-touching test fail with `System.DllNotFoundException : Unable to load shared library 'libSkiaSharp'` — 8 in `LibSETests` (BluRay sup parsing, VobSub `SubPicture`, OCR binarize) and 5 in `LibUiLogicTests` (image splitter, IMSC image export).
- Adds `SkiaSharp.NativeAssets.Linux` to both test projects, plus `HarfBuzzSharp.NativeAssets.Linux` to `LibUiLogicTests` since `libuilogic` uses `SkiaSharp.HarfBuzz`.
- Versions are pinned to the same ones as the managed wrappers (3.119.4 / 8.3.1.5) to avoid a native/managed ABI mismatch, matching what `src/seconv` already does (cf. #11864, #11931).

Test-project-only change: no production project or shipped package is touched, and the native assets are RID-scoped so Windows and macOS builds are unaffected.

## Test plan

- [x] Linux (`mcr.microsoft.com/dotnet/sdk:10.0` container, no `libSkiaSharp.so` installed system-wide): `dotnet test tests/libse/LibSETests.csproj` → **745/745 passed** (was 737 passed / 8 failed)
- [x] Linux, same container: `dotnet test tests/libuilogic/LibUiLogicTests.csproj` → **18/18 passed** (was 13 passed / 5 failed)
- [x] Windows: `dotnet test tests/libse/LibSETests.csproj` → 745/745 passed, no regression
- [x] Windows: `dotnet test tests/libuilogic/LibUiLogicTests.csproj` → 18/18 passed, no regression

To reproduce the original failure, run either test project on Linux before this change; the first bitmap test aborts with a `DllNotFoundException` for `libSkiaSharp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
