### PR TITLE
Add a target-language dropdown to MOSS-TTS (CrispASR)

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
@@ -45,6 +45,12 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 /// but improves quality, so we pass <c>--ref-text</c> when a sidecar is present (same layout as
 /// VoxCPM2 / F5-TTS / Qwen3 CustomVoice).
 ///
+/// The target language is offered as a combo (<see cref="MossTtsLanguages"/>) and passed as the
+/// startup <c>-l</c> flag — <c>/v1/audio/speech</c> has no per-request language field, so it is
+/// part of the server key like the voice. Without it the model's prompt carries
+/// <c>- Language: None</c>, which is what SE did until #12757 surfaced heavily accented
+/// cross-lingual clones.
+///
 /// Verified against the pinned v0.8.13 binary on Apple M4 / Metal:
 /// - basic synth: 3.6 s of 24 kHz mono in 22 s wall (cold start incl. model load)
 /// - cloning: --voice + --ref-text produces intelligible output in the reference voice
@@ -57,7 +63,7 @@ public class MossTtsCrispAsr : ITtsEngine
 {
     public string Name => "MOSS-TTS (CrispASR)";
     public string Description => "MOSS-TTS v1.5 24 kHz TTS with zero-shot voice cloning, via CrispASR";
-    public bool HasLanguageParameter => false;
+    public bool HasLanguageParameter => true;
     public bool HasApiKey => false;
     public bool HasRegion => false;
     public bool HasModel => true;
@@ -156,6 +162,8 @@ public class MossTtsCrispAsr : ITtsEngine
     // restart so the new --voice path takes effect.
     private static string? _serverVoicePath;
     private static string? _serverRefText;
+    // Value of the startup -l flag (empty = Auto / no flag); part of the server key.
+    private static string? _serverLanguageArg;
     private static bool _processExitHooked;
     private static readonly StringBuilder _serverLog = new();
 
@@ -411,7 +419,7 @@ public class MossTtsCrispAsr : ITtsEngine
 
     public Task<string[]> GetModels() => Task.FromResult(new[] { ModelKeyQ4K, ModelKeyF16 });
 
-    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(Array.Empty<TtsLanguage>());
+    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(MossTtsLanguages.All);
 
     public Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken) =>
         GetVoices(language);
@@ -441,7 +449,8 @@ public class MossTtsCrispAsr : ITtsEngine
 
         var refText = TryReadRefText(mossVoice.FilePath);
         var modelKey = ResolveModelKey(model);
-        await EnsureServerRunningAsync(modelKey, mossVoice.FilePath, refText, cancellationToken);
+        var languageArg = MossTtsLanguages.ResolveLanguageArg(language);
+        await EnsureServerRunningAsync(modelKey, mossVoice.FilePath, refText, languageArg, cancellationToken);
 
         var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
 
@@ -450,7 +459,7 @@ public class MossTtsCrispAsr : ITtsEngine
 
         var body = JsonSerializer.Serialize(payload);
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
-        Se.WriteToolsLog($"MOSS-TTS (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (voice={mossVoice}, refTextLen={refText.Length}, textLen={text.Length})");
+        Se.WriteToolsLog($"MOSS-TTS (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (voice={mossVoice}, refTextLen={refText.Length}, textLen={text.Length}, language={(string.IsNullOrEmpty(languageArg) ? "(auto)" : languageArg)})");
 
         HttpResponseMessage response;
         try
@@ -603,11 +612,15 @@ public class MossTtsCrispAsr : ITtsEngine
         }
     }
 
-    private static async Task EnsureServerRunningAsync(string modelKey, string voicePath, string refText, CancellationToken ct)
+    private static async Task EnsureServerRunningAsync(string modelKey, string voicePath, string refText, string languageArg, CancellationToken ct)
     {
+        // Language joins (model, voice, ref-text) in the server key: /v1/audio/speech has no
+        // per-request `language` field, so the only way to reach moss-tts with one is the startup
+        // -l flag — which means switching language needs a fresh server, same as switching voice.
         bool MatchesCurrent() =>
             _serverProcess is { HasExited: false } && _serverPort != 0
             && string.Equals(_serverModelKey, modelKey, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(_serverLanguageArg, languageArg, StringComparison.OrdinalIgnoreCase)
             && (!UseStartupVoiceFlags
                 || (string.Equals(_serverVoicePath, voicePath, StringComparison.OrdinalIgnoreCase)
                     && string.Equals(_serverRefText, refText, StringComparison.Ordinal)));
@@ -674,6 +687,14 @@ public class MossTtsCrispAsr : ITtsEngine
             psi.ArgumentList.Add(GetSetVoicesFolder());
             CrispAsrTtsProvenance.AddServerMarkingArgs(psi.ArgumentList, exe);
 
+            // Target language for the prompt's "- Language:" field. Empty = Auto (no flag), which
+            // leaves the field at "None" and lets the model infer from the text.
+            if (!string.IsNullOrEmpty(languageArg))
+            {
+                psi.ArgumentList.Add("-l");
+                psi.ArgumentList.Add(languageArg);
+            }
+
             if (UseStartupVoiceFlags)
             {
                 psi.ArgumentList.Add("--voice");
@@ -711,6 +732,7 @@ public class MossTtsCrispAsr : ITtsEngine
             _serverModelKey = modelKey;
             _serverVoicePath = voicePath;
             _serverRefText = refText;
+            _serverLanguageArg = languageArg;
             HookProcessExitOnce();
 
             // First-run auto-download (backbone + codec is up to ~20.5 GB) needs a generous
@@ -730,6 +752,7 @@ public class MossTtsCrispAsr : ITtsEngine
                     _serverModelKey = null;
                     _serverVoicePath = null;
                     _serverRefText = null;
+                    _serverLanguageArg = null;
                     throw new InvalidOperationException(
                         $"crispasr (moss-tts) exited during startup (code {exitCode}). Output: {tail}"
                         + LaunchCmdSuffix(exitedLaunchCommand));
@@ -813,6 +836,7 @@ public class MossTtsCrispAsr : ITtsEngine
         _serverModelKey = null;
         _serverVoicePath = null;
         _serverRefText = null;
+        _serverLanguageArg = null;
         if (p == null)
         {
             return;

--- a/src/ui/Features/Video/TextToSpeech/Engines/MossTtsLanguages.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/MossTtsLanguages.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// The 20 languages MOSS-TTS v1.5 is trained on (the <c>language:</c> list in the
+/// OpenMOSS-Team/MOSS-TTS model card front matter — the card's own prose table drops Hebrew), plus
+/// an "Auto" entry that leaves the choice to the model.
+///
+/// MOSS-TTS takes the language as a plain-text field in its prompt: crispasr's moss-tts backend
+/// reads <c>params.language</c>, runs it through <c>crispasr_iso_to_english_lang()</c> and writes
+/// the result into the <c>&lt;user_inst&gt;</c> block as <c>- Language:\n&lt;name&gt;</c>
+/// (src/moss_tts.cpp). With no language passed the field is literally <c>None</c>, which is what
+/// every SE synthesis did before this list existed — the likely cause of the heavy accent users
+/// reported on cross-lingual clones (#12757), where a reference WAV in one language was asked to
+/// read text in another.
+///
+/// <para>
+/// <b>Why some codes are ISO and some are spelled out.</b> crispasr's ISO→English map
+/// (src/core/lang_names.h) covers only 17 codes; of MOSS-TTS's 20 languages it misses he, hu, fa,
+/// cs, da, sv and el. Unmapped values pass through verbatim, so sending "hu" would put the bare code
+/// in the prompt — exactly what that header warns is unreliable ("de" reads as the English word
+/// "of"). Those six therefore send the English name instead, which passes through unchanged. The
+/// name arrives lowercased (crispasr lowercases the <c>-l</c> value in cli.cpp) but that is far
+/// better than a two-letter code. If crispasr ever adds the missing codes, sending the names keeps
+/// working, so nothing here has to change.
+/// </para>
+///
+/// Display names are taken from <see cref="OmniVoiceLanguages"/> so the two engines label the same
+/// language identically in the UI; only Arabic is absent there (it lists regional Arabics but no
+/// macrolanguage entry) and is spelled out locally.
+/// </summary>
+internal static class MossTtsLanguages
+{
+    /// <summary>
+    /// Code for the "Auto" entry — an empty code means no <c>-l</c> flag is passed and MOSS-TTS
+    /// infers the language from the text itself (the pre-existing behaviour).
+    /// </summary>
+    public const string AutoCode = "";
+
+    public static readonly TtsLanguage Auto = new("Auto", AutoCode);
+
+    /// <summary>
+    /// (ISO-639-1 code, value sent as <c>-l</c>) for each supported language. The two differ only
+    /// for the six languages crispasr cannot spell out itself — see the class remarks.
+    /// </summary>
+    private static readonly (string Iso, string Arg)[] Supported =
+    {
+        ("zh", "zh"),
+        ("en", "en"),
+        ("de", "de"),
+        ("es", "es"),
+        ("fr", "fr"),
+        ("ja", "ja"),
+        ("it", "it"),
+        ("he", "hebrew"),
+        ("hu", "hungarian"),
+        ("ko", "ko"),
+        ("ru", "ru"),
+        ("fa", "persian"),
+        ("ar", "ar"),
+        ("pl", "pl"),
+        ("pt", "pt"),
+        ("cs", "czech"),
+        ("da", "danish"),
+        ("sv", "swedish"),
+        ("el", "greek"),
+        ("tr", "tr"),
+    };
+
+    // OmniVoice's 646-entry table has no macrolanguage "ar" (only regional Arabics), so the one
+    // display name that cannot be reused is supplied here.
+    private static readonly Dictionary<string, string> ExtraDisplayNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["ar"] = "Arabic",
+    };
+
+    /// <summary>
+    /// "Auto" first, then the 20 supported languages sorted by display name. Auto stays first so
+    /// the combo's default selection preserves the old no-language behaviour.
+    /// </summary>
+    public static readonly TtsLanguage[] All = Build();
+
+    private static TtsLanguage[] Build()
+    {
+        var omniNames = OmniVoiceLanguages.All.ToDictionary(l => l.Code, l => l.Name, StringComparer.OrdinalIgnoreCase);
+
+        var languages = Supported
+            .Select(s => new TtsLanguage(ResolveDisplayName(omniNames, s.Iso), s.Arg))
+            .OrderBy(l => l.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        languages.Insert(0, Auto);
+        return languages.ToArray();
+    }
+
+    private static string ResolveDisplayName(IReadOnlyDictionary<string, string> omniNames, string iso)
+    {
+        if (omniNames.TryGetValue(iso, out var name))
+        {
+            return name;
+        }
+
+        return ExtraDisplayNames.TryGetValue(iso, out var extra) ? extra : iso;
+    }
+
+    /// <summary>
+    /// The value to pass to crispasr's <c>-l</c> for <paramref name="language"/>, or an empty
+    /// string when no flag should be passed (Auto, an unknown entry, or nothing selected).
+    /// </summary>
+    public static string ResolveLanguageArg(TtsLanguage? language)
+    {
+        var code = language?.Code;
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            return string.Empty;
+        }
+
+        // Guard against a language object left over from another engine (the view model can hold
+        // one while switching engines): only values this engine actually advertises are passed on.
+        return All.Any(l => string.Equals(l.Code, code, StringComparison.OrdinalIgnoreCase))
+            ? code
+            : string.Empty;
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -416,6 +416,7 @@ public partial class TextToSpeechViewModel : ObservableObject
         else if (SelectedEngine is MossTtsCrispAsr)
         {
             Se.Settings.Video.TextToSpeech.MossTtsCrispAsrModel = SelectedModel ?? MossTtsCrispAsr.DefaultModelKey;
+            Se.Settings.Video.TextToSpeech.MossTtsCrispAsrLanguage = SelectedLanguage?.Name ?? string.Empty;
         }
         else if (SelectedEngine is OmniVoiceTtsCpp)
         {
@@ -3275,9 +3276,15 @@ public partial class TextToSpeechViewModel : ObservableObject
 
                 // OmniVoice has 646 alphabetically-sorted languages; the first entry ("Abadi") is
                 // a useless default. Default to English so the engine is usable out of the box.
-                SelectedLanguage = engine is OmniVoiceTtsCpp
-                    ? Languages.FirstOrDefault(l => l.Code == "en") ?? Languages.FirstOrDefault()
-                    : Languages.FirstOrDefault();
+                // MOSS-TTS restores the saved pick (its list leads with "Auto", which is also the
+                // right fallback - it reproduces the pre-language-selection behaviour).
+                SelectedLanguage = engine switch
+                {
+                    OmniVoiceTtsCpp => Languages.FirstOrDefault(l => l.Code == "en") ?? Languages.FirstOrDefault(),
+                    MossTtsCrispAsr => Languages.FirstOrDefault(l => l.Name == Se.Settings.Video.TextToSpeech.MossTtsCrispAsrLanguage)
+                                       ?? Languages.FirstOrDefault(),
+                    _ => Languages.FirstOrDefault(),
+                };
             }
             else if (SelectedVoice == null)
             {
@@ -3608,6 +3615,8 @@ public partial class TextToSpeechViewModel : ObservableObject
             return;
         }
 
+        var previousLanguageName = SelectedLanguage?.Name;
+
         Dispatcher.UIThread.PostSafe(async () =>
         {
             if (engine.HasLanguageParameter)
@@ -3619,7 +3628,10 @@ public partial class TextToSpeechViewModel : ObservableObject
                     Languages.Add(language);
                 }
 
-                SelectedLanguage = Languages.FirstOrDefault(p => p.Name == Se.Settings.Video.TextToSpeech.ElevenLabsLanguage);
+                // Keep the language the user already picked when it survives the model switch -
+                // otherwise a MOSS-TTS quant change (Q4_K <-> F16) silently re-selects English.
+                SelectedLanguage = Languages.FirstOrDefault(p => p.Name == previousLanguageName)
+                                   ?? Languages.FirstOrDefault(p => p.Name == Se.Settings.Video.TextToSpeech.ElevenLabsLanguage);
                 if (SelectedLanguage == null)
                 {
                     SelectedLanguage = Languages.FirstOrDefault(p => p.Code == "en");

--- a/src/ui/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/ui/Logic/Config/SeVideoTextToSpeech.cs
@@ -44,6 +44,8 @@ public class SeVideoTextToSpeech
     public double VoxCPM2CrispAsrSpeed { get; set; }
     public string MossTtsCrispAsrModel { get; set; }
     public double MossTtsCrispAsrSpeed { get; set; }
+    // Display name of the picked MOSS-TTS target language ("Auto" = let the model infer it).
+    public string MossTtsCrispAsrLanguage { get; set; }
     public string OmniVoiceTtsCppVulkanPath { get; set; }
     public string OmniVoiceTtsCppInstruction { get; set; }
     public string ChatterboxModel { get; set; }
@@ -133,6 +135,7 @@ public class SeVideoTextToSpeech
         VoxCPM2CrispAsrSpeed = 1.0;
         MossTtsCrispAsrModel = "Q4_K (~10.5 GB incl. codec)";
         MossTtsCrispAsrSpeed = 1.0;
+        MossTtsCrispAsrLanguage = string.Empty;
         OmniVoiceTtsCppVulkanPath = string.Empty;
         OmniVoiceTtsCppInstruction = string.Empty;
         ChatterboxModel = "Base";

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -2266,14 +2266,7 @@ public static class UiUtil
             });
         }
 
-        control.AddHandler(InputElement.PointerWheelChangedEvent, (s, e) =>
-        {
-            control.Value = Math.Clamp((control.Value ?? 0) + (e.Delta.Y > 0 ? control.Increment : -control.Increment),
-                                        control.Minimum,
-                                        control.Maximum);
-            e.Handled = true;
-        });
-
+        MakeNumeriUpDownMouseWheelHandler(control);
         ForwardAutomationNameToInnerTextBox(control);
 
         return control;
@@ -2317,14 +2310,7 @@ public static class UiUtil
             });
         }
 
-        control.AddHandler(InputElement.PointerWheelChangedEvent, (s, e) =>
-        {
-            control.Value = Math.Clamp((control.Value ?? 0) + (e.Delta.Y > 0 ? control.Increment : -control.Increment),
-                                        control.Minimum,
-                                        control.Maximum);
-            e.Handled = true;
-        });
-
+        MakeNumeriUpDownMouseWheelHandler(control);
         ForwardAutomationNameToInnerTextBox(control);
 
         return control;
@@ -2450,11 +2436,23 @@ public static class UiUtil
         return control;
     }
 
+    /// <summary>
+    /// Lets the mouse wheel step a <see cref="NumericUpDown"/> - but only while it has keyboard
+    /// focus. Without that guard, scrolling a dialog with the pointer merely passing over a numeric
+    /// field silently changed the value and swallowed the scroll, so e.g. "Waveform text font size"
+    /// walked down to its minimum of 10 while the user scrolled the settings page (issue #12864).
+    /// </summary>
     private static void MakeNumeriUpDownMouseWheelHandler(NumericUpDown control)
     {
         control.AddHandler(InputElement.PointerWheelChangedEvent, (s, e) =>
         {
-            control.Value = Math.Clamp((control.Value ?? 0) + (e.Delta.Y > 0 ? control.Increment : -control.Increment),
+            if (!control.IsKeyboardFocusWithin)
+            {
+                return;
+            }
+
+            var current = control.Value ?? Math.Clamp(0m, control.Minimum, control.Maximum);
+            control.Value = Math.Clamp(current + (e.Delta.Y > 0 ? control.Increment : -control.Increment),
                                         control.Minimum,
                                         control.Maximum);
             e.Handled = true;

--- a/tests/UI/Features/Video/TextToSpeech/Engines/MossTtsCrispAsrTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/MossTtsCrispAsrTests.cs
@@ -1,3 +1,4 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 
 namespace UITests.Features.Video.TextToSpeech.Engines;
@@ -72,5 +73,84 @@ public class MossTtsCrispAsrTests
         Assert.False(payload.ContainsKey("marking_attestation"));
         Assert.False(payload.ContainsKey("spoken_disclaimer"));
         Assert.Equal("hello", payload["input"]);
+    }
+
+    [Fact]
+    public void Languages_LeadWithAutoThenTheTwentySupportedLanguages()
+    {
+        // "Auto" must stay first: the view model falls back to the first entry, and Auto is the
+        // pre-existing behaviour (no -l flag, prompt says "- Language: None").
+        var all = MossTtsLanguages.All;
+
+        Assert.Equal("Auto", all[0].Name);
+        Assert.Equal(string.Empty, all[0].Code);
+        Assert.Equal(21, all.Length);
+    }
+
+    [Fact]
+    public void Languages_ReuseOmniVoiceDisplayNames()
+    {
+        // The display strings come from the shared OmniVoice table so both engines label the same
+        // language identically; Arabic is the one entry that table lacks.
+        var names = MossTtsLanguages.All.Select(l => l.Name).ToList();
+
+        Assert.Contains("German", names);
+        Assert.Contains("Chinese", names);
+        Assert.Contains("Persian", names);
+        Assert.Contains("Arabic", names);
+        Assert.DoesNotContain(names, n => n.Length <= 2);
+    }
+
+    [Theory]
+    [InlineData("German", "de")]
+    [InlineData("Chinese", "zh")]
+    [InlineData("Arabic", "ar")]
+    public void Languages_SendIsoCodeWhenCrispAsrCanSpellItOut(string displayName, string expectedArg)
+    {
+        // crispasr maps these codes to an English name itself (src/core/lang_names.h), so the code
+        // is what reaches the prompt as "German" / "Chinese" / "Arabic".
+        var language = MossTtsLanguages.All.Single(l => l.Name == displayName);
+
+        Assert.Equal(expectedArg, language.Code);
+    }
+
+    [Theory]
+    [InlineData("Hebrew", "hebrew")]
+    [InlineData("Hungarian", "hungarian")]
+    [InlineData("Persian", "persian")]
+    [InlineData("Czech", "czech")]
+    [InlineData("Danish", "danish")]
+    [InlineData("Swedish", "swedish")]
+    [InlineData("Greek", "greek")]
+    public void Languages_SpellOutTheCodesCrispAsrCannotMap(string displayName, string expectedArg)
+    {
+        // he/hu/fa/cs/da/sv/el are missing from crispasr's ISO map, so a code would land in the prompt
+        // verbatim as a bare two letters - unreliable in an LLM prompt. Send the name instead.
+        var language = MossTtsLanguages.All.Single(l => l.Name == displayName);
+
+        Assert.Equal(expectedArg, language.Code);
+    }
+
+    [Fact]
+    public void ResolveLanguageArg_AutoOrNull_PassesNoFlag()
+    {
+        Assert.Equal(string.Empty, MossTtsLanguages.ResolveLanguageArg(null));
+        Assert.Equal(string.Empty, MossTtsLanguages.ResolveLanguageArg(MossTtsLanguages.Auto));
+    }
+
+    [Fact]
+    public void ResolveLanguageArg_ForeignLanguage_PassesNoFlag()
+    {
+        // Switching engines can leave a language from another engine's list selected (OmniVoice has
+        // 646 of them); only codes MOSS-TTS actually supports may reach the server.
+        Assert.Equal(string.Empty, MossTtsLanguages.ResolveLanguageArg(new TtsLanguage("Abadi", "kbt")));
+    }
+
+    [Fact]
+    public void ResolveLanguageArg_SupportedLanguage_PassesItThrough()
+    {
+        var german = MossTtsLanguages.All.Single(l => l.Name == "German");
+
+        Assert.Equal("de", MossTtsLanguages.ResolveLanguageArg(german));
     }
 }


### PR DESCRIPTION
Follow-up to #12757, from [subof's report](https://github.com/CrispStrobe/CrispASR/issues/304#issuecomment-5085601061) that cross-lingual MOSS-TTS clones come out heavily accented.

## Why

MOSS-TTS takes the target language as a plain-text field in its prompt. crispasr's `moss-tts` backend reads `params.language`, spells it out via `crispasr_iso_to_english_lang()`, and writes it into the `<user_inst>` block as `- Language: <name>` ([moss_tts.cpp](https://github.com/CrispStrobe/CrispASR/blob/master/src/moss_tts.cpp#L940)).

SE never passed one, and `whisper_params.language` defaults to `auto` — which the backend treats as "unset". So **every MOSS-TTS synthesis SE has ever done ran with `- Language: None`**. That fits the reported symptom: a reference WAV in one language asked to read text in another has nothing telling it which language it is supposed to be speaking.

`POST /v1/audio/speech` has no per-request `language` field, so the only way to reach the backend is the server's startup `-l` flag.

## What

- **New combo** for MOSS-TTS (`HasLanguageParameter`), led by **Auto** — passes no flag and reproduces the previous behaviour, so nothing changes for anyone who does not touch it.
- 20 languages from the `language:` front matter of the [OpenMOSS-Team/MOSS-TTS](https://huggingface.co/OpenMOSS-Team/MOSS-TTS) model card. Its own prose table lists only 19 — Hebrew is missing there.
- Display names are **reused from `OmniVoiceLanguages`** so both engines label the same language identically. Arabic is the one entry that table lacks (it has regional Arabics but no macrolanguage row) and is spelled out locally.
- Language joins `(model, voice, ref-text)` in the server key, so switching it restarts the server — same as switching voice.
- The pick is persisted (`MossTtsCrispAsrLanguage`).

### Why some entries send a name instead of a code

crispasr's ISO→English map ([lang_names.h](https://github.com/CrispStrobe/CrispASR/blob/master/src/core/lang_names.h)) covers 17 codes; of MOSS-TTS's 20 languages it misses `he`, `hu`, `fa`, `cs`, `da`, `sv`, `el`. Unmapped values pass through verbatim, so sending `hu` would put a bare two-letter code in the prompt — precisely what that header warns is unreliable ("de" reads as the English word "of"). Those seven send the English name, which also passes through verbatim. If crispasr later adds the missing codes, nothing here has to change.

## Drive-by

`SelectedModelChanged` rebuilt the language list and then re-selected from the ElevenLabs setting or plain English, discarding whatever was picked. With MOSS-TTS now having languages, flipping Q4_K ↔ F16 would have silently reset the language; it now keeps the current pick when it survives the reload.

## Verification

- 21 unit tests in `MossTtsCrispAsrTests` (list shape, name reuse, code-vs-name split, `ResolveLanguageArg` including the guard against a language left selected from another engine); full UI suite green at 889.
- Headless against the pinned **v0.8.23** binary on Apple M4 / Metal: `-l de` is accepted by the `moss-tts` backend and synthesis completes normally (exit 0, valid 24 kHz WAV).
- I could not confirm the prompt text empirically — moss-tts never logs it, and unlike the backends listed in `docs/server.md` it is not seed-deterministic (two identical `--seed 42` runs produced different audio), so an A/B on output bytes proves nothing either way. The wiring above is read from crispasr's source.

## Not in scope

Two other things in the same report, both upstream:

- **CosyVoice3 language** — not possible from SE. `crispasr_backend_cosyvoice3.cpp` never touches `params.language` and `cosyvoice3_tts.cpp` has no language conditioning at all.
- **MOSS-TTS Q6/Q8** — `cstr/moss-tts-v1.5-GGUF` only has `q4_k`, `f16` and the codec. The Q6_K/Q8_0 files are in `OpenMOSS-Team/MOSS-TTS-GGUF`, a different conversion with separate `embeddings`/`lm_heads`/`tokenizer` dirs; SE pins exact filename + size + SHA-256, so they would have to be published in cstr's repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)