### PR TITLE
STT: don't fail Faster-Whisper model download on missing preprocessor_config.json

### DIFF
--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
@@ -133,10 +133,10 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject, ICl
                     return;
                 }
 
-                // A 404 (FileNotFoundException) on an optional file isn't fatal: each model
-                // ships only one of vocabulary.txt / vocabulary.json, but the URL list asks for
-                // both, so one always 404s. Skip it and continue, like faster-whisper-xxl.exe
-                // does - only model.bin is required. (#12133 follow-up)
+                // A 404 (FileNotFoundException) on an optional file isn't fatal: the URL list is
+                // the union of file names across all models, so every model 404s on some of them.
+                // Skip those and continue, like faster-whisper-xxl.exe does - only model.bin is
+                // required. (#12133 follow-up, #8703)
                 if (ex is FileNotFoundException && IsOptionalFile(_downloadUrls[_downloadIndex]))
                 {
                     DeletePartialDownload();
@@ -161,9 +161,11 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject, ICl
         }
     }
 
-    // Files a model may or may not ship. A model provides exactly one vocabulary variant,
-    // but the URL list requests both, so a 404 on one of these is expected, not an error.
-    private static readonly string[] OptionalFileNames = { "vocabulary.txt", "vocabulary.json" };
+    // Files a model may or may not ship, so a 404 on one of these is expected, not an error.
+    // A model provides exactly one vocabulary variant, but the URL list requests both. And the
+    // older Systran/faster-whisper-* repos (tiny ... large-v2) ship no preprocessor_config.json
+    // at all - faster-whisper then falls back to the default feature extractor settings.
+    private static readonly string[] OptionalFileNames = { "vocabulary.txt", "vocabulary.json", "preprocessor_config.json" };
 
     private static bool IsOptionalFile(string url)
     {


### PR DESCRIPTION
Fixes #8703

## Problem

Downloading e.g. **large-v2** for the Purfview Faster-Whisper-XXL engine fails at the very end with `Download failed: preprocessor_config.json`, after all the other files have already been fetched. Users work around it by downloading that one file by hand.

## Cause

`WhisperPurfviewFasterWhisperModel` builds every model's URL list from one fixed filename array, which is the *union* of file names across all models:

```
model.bin, config.json, vocabulary.txt, vocabulary.json, tokenizer.json, preprocessor_config.json
```

No HF repo ships all six, so every model 404s on some of them. The 404 handler in `DownloadSpeechToTextModelsViewModel` only whitelisted the two vocabulary variants (added in #12133), so a missing `preprocessor_config.json` was fatal:

| Repo | ships `preprocessor_config.json`? |
|---|---|
| `Systran/faster-whisper-{tiny,base,small,medium,large-v1,large-v2}` (+ `.en`) | **no** |
| `Systran/faster-whisper-large-v3`, all `faster-distil-*`, `NbAiLab/nb-whisper-*`, mobiuslabs turbo | yes |

```
$ curl -I https://huggingface.co/Systran/faster-whisper-large-v2/resolve/main/preprocessor_config.json
HTTP/2 404
x-error-code: EntryNotFound
```

Because `preprocessor_config.json` is *last* in the array, everything else downloads fine and only the final file fails — which is why fetching that one file manually completes the model.

## Fix

Add `preprocessor_config.json` to `OptionalFileNames`. faster-whisper falls back to the default feature extractor settings when the file is absent — `Systran/faster-whisper-large-v2` has never shipped it and works fine — so a 404 here is expected, matching the existing rule that only `model.bin` is required.

`WhisperCTranslate2Model` uses a different file list that never requests `preprocessor_config.json`, so that engine is unaffected.

## Note

The issue was closed in 2024 as not-reproducible; it was re-reported on v5.1.0-rc16 in https://github.com/SubtitleEdit/subtitleedit/issues/8703#issuecomment-5085102091. The 2024 report also covered a `vocabulary.txt` 404 on large-v3, which #12133 already fixed — this covers the remaining half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)