### PR TITLE
Prepare v5.1.0-rc17

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,25 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.1.0-rc17 (27th of July 2026)
+
+* Update llama.cpp to b10142 and offer the CUDA 13 build on Windows
+* Update CrispASR to v0.8.23 - fixes garbled/hung CosyVoice3, Qwen3-TTS and Zonos audio on the Vulkan build, and voice cloning now needs to be enabled in settings - thx CrispStrobe
+* Add 4 Parakeet and 1 Kyutai speech-to-text model to the CrispASR engines
+* MOSS-TTS: add a target language dropdown, so cross-lingual voice clones are no longer heavily accented - thx subof
+* Fix CosyVoice3, VoxCPM2 and F5-TTS asking for a voice transcription the voice pack already ships, and fix ref-text cues being dropped when one was a substring of a word in another
+* Speech to text: don't fail the Faster-Whisper model download when preprocessor_config.json is missing - thx oep42
+* Speech to text: make online/OpenAI-compatible server failures readable, and send the audio file last - thx acc4github
+* Restore type-a-number line navigation in the subtitle grid - thx SiriosDev
+* Fix common errors: show a green check and "Nothing to fix" when a re-scan finds nothing - thx Davanix
+* Fix auto-imported Matroska tracks staying "Untitled" until the first save - thx Davanix
+* Keep the selected audio track when going fullscreen or undocking - thx routineCode
+* Update the OCR fix replace list with new entries - thx diomed
+* Update the French translation - thx Need74
+* Linux/macOS: stop the app data folder from being resolved against the working directory - thx ivandrofly
+
+-----------------------------------------------------------------------------------------------------
+
 v5.1.0-rc16 (26th of July 2026)
 
 * Add Georgian, Armenian, Luxembourgish and Faroese spell check dictionaries

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -17,7 +17,7 @@ public class Se
 {
     internal const int CurrentMacOsFontMigrationVersion = 1;
 
-    public static string Version { get; set; } = "v5.1.0-rc16";
+    public static string Version { get; set; } = "v5.1.0-rc17";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Change log entry and version bump for **v5.1.0-rc17**.

## What

- `change-log.txt`: new rc17 section dated 27th of July 2026.
- `Se.cs`: `Version` → `v5.1.0-rc17`.

No other file referenced the old `rc16` string.

## How the entry was built

Enumerated every commit reachable from `main` but not from the `v5.1.0-rc16` tag, then mapped the PR merges (#12845 - #12871) to user-facing lines, with credits taken from the linked issue reporters rather than the PR authors.

Two judgment calls a reviewer may want to overrule:

- **#12867** (reference Linux Skia natives in the libse/libuilogic test projects) is omitted as build-internal - it changes nothing a user can observe.
- **#12862** (dedup ref-text cues by whole words) is folded into the CosyVoice3/VoxCPM2/F5-TTS ref-text line, since it is the same voice-cloning chain and was found while bug-hunting #12852.

## Note on the branch

The changes were made while `update/llama-cpp-b10142` was still checked out, but that branch's PR (#12871) had already merged, so this is a fresh branch off current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)