### PR TITLE
Surround only the selected text with music symbols (#12873)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -10751,6 +10751,14 @@ public partial class MainViewModel :
             return;
         }
 
+        // Only surround the selected text when editing a single line with part of the text
+        // selected - like SE 4 does (#12873).
+        if (selectedItems.Count == 1 && SurroundTextBoxSelection(surroundLeft, surroundRight))
+        {
+            _updateAudioVisualizer = true;
+            return;
+        }
+
         var first = selectedItems.First();
         first.Text = Utilities.ToggleSymbols(surroundLeft, first.Text, surroundRight, out var added);
 
@@ -10762,6 +10770,12 @@ public partial class MainViewModel :
         }
 
         _updateAudioVisualizer = true;
+    }
+
+    private bool SurroundTextBoxSelection(string surroundLeft, string surroundRight)
+    {
+        var tb = GetFocusedTextBoxWrapper();
+        return tb != null && TextBoxSurroundToggler.ToggleSelection(tb, surroundLeft, surroundRight);
     }
 
     [RelayCommand]

--- a/src/ui/Features/Shared/TextBoxUtils/TextBoxSelectionUtils.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/TextBoxSelectionUtils.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace Nikse.SubtitleEdit.Features.Shared.TextBoxUtils;
+
+public static class TextBoxSelectionUtils
+{
+    /// <summary>
+    /// Moves leading/trailing white-space (spaces and new-lines) of a selection outside the
+    /// tags/symbols to be added, so " 'word'" becomes " &lt;i&gt;'word'&lt;/i&gt;" instead of
+    /// "&lt;i&gt; 'word'&lt;/i&gt;".
+    /// </summary>
+    public static string SplitOuterWhiteSpace(string selectedText, out string pre, out string post)
+    {
+        pre = string.Empty;
+        post = string.Empty;
+
+        while (selectedText.EndsWith(' ') || selectedText.EndsWith(Environment.NewLine, StringComparison.Ordinal) ||
+               selectedText.StartsWith(' ') || selectedText.StartsWith(Environment.NewLine, StringComparison.Ordinal))
+        {
+            if (selectedText.EndsWith(' '))
+            {
+                post = " " + post;
+                selectedText = selectedText.Remove(selectedText.Length - 1);
+            }
+
+            if (selectedText.EndsWith(Environment.NewLine, StringComparison.Ordinal))
+            {
+                post = Environment.NewLine + post;
+                selectedText = selectedText.Remove(selectedText.Length - Environment.NewLine.Length);
+            }
+
+            if (selectedText.StartsWith(' '))
+            {
+                pre += " ";
+                selectedText = selectedText.Remove(0, 1);
+            }
+
+            if (selectedText.StartsWith(Environment.NewLine, StringComparison.Ordinal))
+            {
+                pre += Environment.NewLine;
+                selectedText = selectedText.Remove(0, Environment.NewLine.Length);
+            }
+        }
+
+        return selectedText;
+    }
+}

--- a/src/ui/Features/Shared/TextBoxUtils/TextBoxSurroundToggler.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/TextBoxSurroundToggler.cs
@@ -1,0 +1,61 @@
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Core.Common;
+using System;
+
+namespace Nikse.SubtitleEdit.Features.Shared.TextBoxUtils;
+
+/// <summary>
+/// Toggles a "surround with" pair - like music symbols "♪" - on the selected part of the text
+/// in a text box (SE 4 parity, see issue #12873).
+/// </summary>
+public static class TextBoxSurroundToggler
+{
+    /// <summary>
+    /// Adds (or removes again) the surround symbols around the selected text only.
+    /// Returns false when there is nothing selected, or when the whole text is selected -
+    /// the caller should then surround the whole subtitle line(s) instead.
+    /// </summary>
+    public static bool ToggleSelection(ITextBoxWrapper? tb, string surroundLeft, string surroundRight)
+    {
+        if (tb?.Text == null ||
+            string.IsNullOrEmpty(surroundLeft) && string.IsNullOrEmpty(surroundRight))
+        {
+            return false;
+        }
+
+        var selectionStart = Math.Min(tb.SelectionStart, tb.SelectionEnd);
+        var selectionEnd = Math.Max(tb.SelectionStart, tb.SelectionEnd);
+        var selectionLength = selectionEnd - selectionStart;
+
+        if (selectionLength <= 0 || selectionLength >= tb.Text.Length)
+        {
+            return false;
+        }
+
+        // Keep leading/trailing white-space (and new-lines) outside the symbols.
+        var selectedText = TextBoxSelectionUtils.SplitOuterWhiteSpace(
+            tb.Text.Substring(selectionStart, selectionLength), out var pre, out var post);
+
+        if (selectedText.Length == 0)
+        {
+            return false;
+        }
+
+        // "ToggleSymbols" keeps italic/bold/font tags of the selection outside the symbols,
+        // so "<i>Hello</i>" becomes "<i>♪ Hello ♪</i>".
+        var newText = pre + Utilities.ToggleSymbols(surroundLeft, selectedText, surroundRight, out _) + post;
+
+        tb.Text = tb.Text
+            .Remove(selectionStart, selectionLength)
+            .Insert(selectionStart, newText);
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            tb.Focus();
+            tb.SelectionStart = selectionStart;
+            tb.SelectionEnd = selectionStart + newText.Length;
+        });
+
+        return true;
+    }
+}

--- a/src/ui/Features/Shared/TextBoxUtils/TextBoxTagToggler.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/TextBoxTagToggler.cs
@@ -75,36 +75,8 @@ public static class TextBoxTagToggler
         {
             // Move leading/trailing white-space (spaces and new-lines) outside the tag so
             // " 'word'" becomes " <i>'word'</i>" instead of "<i> 'word'</i>".
-            var pre = string.Empty;
-            var post = string.Empty;
-            var selectedText = tb.Text.Substring(selectionStart, selectionLength);
-            while (selectedText.EndsWith(' ') || selectedText.EndsWith(Environment.NewLine, StringComparison.Ordinal) ||
-                   selectedText.StartsWith(' ') || selectedText.StartsWith(Environment.NewLine, StringComparison.Ordinal))
-            {
-                if (selectedText.EndsWith(' '))
-                {
-                    post = " " + post;
-                    selectedText = selectedText.Remove(selectedText.Length - 1);
-                }
-
-                if (selectedText.EndsWith(Environment.NewLine, StringComparison.Ordinal))
-                {
-                    post = Environment.NewLine + post;
-                    selectedText = selectedText.Remove(selectedText.Length - Environment.NewLine.Length);
-                }
-
-                if (selectedText.StartsWith(' '))
-                {
-                    pre += " ";
-                    selectedText = selectedText.Remove(0, 1);
-                }
-
-                if (selectedText.StartsWith(Environment.NewLine, StringComparison.Ordinal))
-                {
-                    pre += Environment.NewLine;
-                    selectedText = selectedText.Remove(0, Environment.NewLine.Length);
-                }
-            }
+            var selectedText = TextBoxSelectionUtils.SplitOuterWhiteSpace(
+                tb.Text.Substring(selectionStart, selectionLength), out var pre, out var post);
 
             selectedText = pre + HtmlUtil.ToggleTag(selectedText, tag, false, isAssa) + post;
 

--- a/tests/UI/Features/Shared/TextBoxSurroundTogglerTests.cs
+++ b/tests/UI/Features/Shared/TextBoxSurroundTogglerTests.cs
@@ -1,0 +1,134 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Features.Shared.TextBoxUtils;
+
+namespace UITests.Features.Shared;
+
+// "Surround with ♪ ♪" (Ctrl+M) should only surround the selected text when part of the text
+// is selected in the edit box - like SE 4 does (issue #12873).
+public class TextBoxSurroundTogglerTests
+{
+    private static TextBox MakeTextBox(string text, int selectionStart, int selectionEnd)
+    {
+        return new TextBox
+        {
+            Text = text,
+            SelectionStart = selectionStart,
+            SelectionEnd = selectionEnd,
+        };
+    }
+
+    [AvaloniaFact]
+    public void ToggleSelection_FirstOfTwoLinesSelected_OnlyFirstLineGetsMusicSymbols()
+    {
+        var text = "Will never be my fool" + Environment.NewLine + "FIETSEN VERBODEN";
+        var textBox = MakeTextBox(text, 0, "Will never be my fool".Length);
+
+        var result = TextBoxSurroundToggler.ToggleSelection(new TextBoxWrapper(textBox), "♪", "♪");
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(result);
+        Assert.Equal("♪ Will never be my fool ♪" + Environment.NewLine + "FIETSEN VERBODEN", textBox.Text);
+    }
+
+    [AvaloniaFact]
+    public void ToggleSelection_ItalicLineSelected_KeepsMusicSymbolsInsideItalicTags()
+    {
+        var text = "<i>Will never be my fool</i>" + Environment.NewLine + "FIETSEN VERBODEN";
+        var textBox = MakeTextBox(text, 0, "<i>Will never be my fool</i>".Length);
+
+        var result = TextBoxSurroundToggler.ToggleSelection(new TextBoxWrapper(textBox), "♪", "♪");
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(result);
+        Assert.Equal("<i>♪ Will never be my fool ♪</i>" + Environment.NewLine + "FIETSEN VERBODEN", textBox.Text);
+    }
+
+    [AvaloniaFact]
+    public void ToggleSelection_SelectionAlreadyHasMusicSymbols_RemovesThem()
+    {
+        var text = "♪ Will never be my fool ♪" + Environment.NewLine + "FIETSEN VERBODEN";
+        var textBox = MakeTextBox(text, 0, "♪ Will never be my fool ♪".Length);
+
+        var result = TextBoxSurroundToggler.ToggleSelection(new TextBoxWrapper(textBox), "♪", "♪");
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(result);
+        Assert.Equal("Will never be my fool" + Environment.NewLine + "FIETSEN VERBODEN", textBox.Text);
+    }
+
+    [AvaloniaFact]
+    public void ToggleSelection_SelectionKeepsTrailingNewLineOutsideSymbols()
+    {
+        var text = "Line one" + Environment.NewLine + "Line two";
+        var textBox = MakeTextBox(text, 0, ("Line one" + Environment.NewLine).Length);
+
+        var result = TextBoxSurroundToggler.ToggleSelection(new TextBoxWrapper(textBox), "♪", "♪");
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(result);
+        Assert.Equal("♪ Line one ♪" + Environment.NewLine + "Line two", textBox.Text);
+    }
+
+    [AvaloniaFact]
+    public void ToggleSelection_SelectionIsRestoredAfterToggle()
+    {
+        var textBox = MakeTextBox("Hello world", 6, 11);
+
+        TextBoxSurroundToggler.ToggleSelection(new TextBoxWrapper(textBox), "♪", "♪");
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("Hello ♪ world ♪", textBox.Text);
+        Assert.Equal(6, textBox.SelectionStart);
+        Assert.Equal("♪ world ♪".Length + 6, textBox.SelectionEnd);
+    }
+
+    [AvaloniaFact]
+    public void ToggleSelection_NoSelection_ReturnsFalseAndKeepsText()
+    {
+        var textBox = MakeTextBox("Hello world", 3, 3);
+
+        var result = TextBoxSurroundToggler.ToggleSelection(new TextBoxWrapper(textBox), "♪", "♪");
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(result);
+        Assert.Equal("Hello world", textBox.Text);
+    }
+
+    [AvaloniaFact]
+    public void ToggleSelection_WholeTextSelected_ReturnsFalseAndKeepsText()
+    {
+        var textBox = MakeTextBox("Hello world", 0, "Hello world".Length);
+
+        var result = TextBoxSurroundToggler.ToggleSelection(new TextBoxWrapper(textBox), "♪", "♪");
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(result);
+        Assert.Equal("Hello world", textBox.Text);
+    }
+
+    [AvaloniaFact]
+    public void ToggleSelection_OnlyWhiteSpaceSelected_ReturnsFalseAndKeepsText()
+    {
+        var textBox = MakeTextBox("Hello world", 5, 6);
+
+        var result = TextBoxSurroundToggler.ToggleSelection(new TextBoxWrapper(textBox), "♪", "♪");
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(result);
+        Assert.Equal("Hello world", textBox.Text);
+    }
+
+    [AvaloniaFact]
+    public void ToggleSelection_NonMusicSurround_WrapsSelection()
+    {
+        var textBox = MakeTextBox("Hello world", 6, 11);
+
+        var result = TextBoxSurroundToggler.ToggleSelection(new TextBoxWrapper(textBox), "(", ")");
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(result);
+        Assert.Equal("Hello (world)", textBox.Text);
+    }
+}


### PR DESCRIPTION
Fixes #12873

### Problem

"Surround with ♪ ♪" (Ctrl+M) always applied the symbols to *every* line of the subtitle, ignoring the selection in the edit box, so surrounding only part of the text was not possible:

| | before | after |
|---|---|---|
| `<i>Will never be my fool</i>`<br>`FIETSEN VERBODEN`<br>(first line selected) | `<i>♪ Will never be my fool</i> ♪`<br>`♪ FIETSEN VERBODEN ♪` | `<i>♪ Will never be my fool ♪</i>`<br>`FIETSEN VERBODEN` |

`SurroundWith` in `MainViewModel` only worked on whole subtitle items, even though the shortcut is registered as `SubtitleGridAndTextBox` and thus also fires while editing in the text box.

### Fix

`SurroundWith` now first tries the focused edit box (main or original text), the same way `ToggleColor`/`ColorTextBoxIfSelected` already do. A partial selection is surrounded on its own via the new `TextBoxSurroundToggler`, which passes only the selected text to `Utilities.ToggleSymbols` - so italic/bold/font tags of the selection stay outside the symbols, matching SE 4.

Unchanged behavior when: nothing is selected, the whole text is selected, only white-space is selected, or multiple lines are selected in the grid - then all lines are surrounded as before.

The white-space splitting used by `TextBoxTagToggler` was moved to `TextBoxSelectionUtils` (verbatim) and is shared by both togglers.

### Tests

9 new tests in `tests/UI/Features/Shared/TextBoxSurroundTogglerTests.cs` (incl. the exact case from the issue). Full UI suite: 881 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)