### PR TITLE
Show "Analyzing..." during Fix common errors re-scan (#12849)

### DIFF
--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -27,6 +27,12 @@ namespace Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
 
 public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
 {
+    // A scan often takes only a frame or two, so "Analyzing..." has to be held for a moment to be seen at all.
+    private const int AnalysingMinimumVisibleMilliseconds = 250;
+
+    // Long enough for the dispatcher to get a frame out before the scan blocks the UI thread again.
+    private const int AnalysingPaintDelayMilliseconds = 20;
+
     [ObservableProperty] private string _searchText;
     [ObservableProperty] private ObservableCollection<LanguageDisplayItem> _languages;
     [ObservableProperty] private LanguageDisplayItem? _selectedLanguage;
@@ -46,6 +52,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
     [ObservableProperty] private string _step2Title;
     [ObservableProperty] private string _fixesAppliedText = string.Empty;
     [ObservableProperty] private bool _nothingToFixIsVisible;
+    [ObservableProperty] private bool _analysingIsVisible;
     [ObservableProperty] private string _editTextTotalLength = string.Empty;
     [ObservableProperty] private IBrush _editTextTotalLengthBackground = Brushes.Transparent;
 
@@ -66,6 +73,8 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
     private bool _previewMode = true;
     public List<int> DeleteIndices = new();
     private List<FixDisplayItem> _oldFixes = new();
+    private bool _nothingToFix;
+    private bool _isAnalysing;
     private LanguageDisplayItem _oldSelectedLanguage;
     private int _totalErrors;
     private int _totalFixes;
@@ -199,19 +208,22 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
     }
 
     [RelayCommand]
-    public void DoRefreshFixes()
+    public async Task DoRefreshFixes()
     {
-        RefreshFixes();
+        await RunScanWithFeedbackAsync(RefreshFixes);
     }
 
     [RelayCommand]
-    private void DoApplyFixes()
+    private async Task DoApplyFixes()
     {
-        _previewMode = false;
-        ApplyFixes();
+        await RunScanWithFeedbackAsync(() =>
+        {
+            _previewMode = false;
+            ApplyFixes();
 
-        RefreshFixes();
-        FixesAppliedText = string.Format(_language.XFixesApplied, _totalFixes);
+            RefreshFixes();
+            FixesAppliedText = string.Format(_language.XFixesApplied, _totalFixes);
+        });
     }
 
     [RelayCommand]
@@ -221,21 +233,33 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         Step1IsVisible = true;
     }
 
+    // Used when step 1 is skipped at startup - the window is not up yet, so there is nothing to flash on.
     private void ShowStep2()
+    {
+        EnterStep2();
+        RefreshFixes();
+    }
+
+    private async Task ShowStep2Async()
+    {
+        EnterStep2();
+        await RunScanWithFeedbackAsync(RefreshFixes);
+    }
+
+    private void EnterStep2()
     {
         Step1IsVisible = false;
         Step2IsVisible = true;
         _oldSelectedLanguage = SelectedLanguage!;
         _totalFixes = 0;
         FixesAppliedText = string.Empty;
-        RefreshFixes();
     }
 
     [RelayCommand]
-    private void ToApplyFixes()
+    private async Task ToApplyFixes()
     {
         SaveProfiles();
-        ShowStep2();
+        await ShowStep2Async();
     }
 
     [RelayCommand]
@@ -435,12 +459,15 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
     }
 
     [RelayCommand]
-    public void ApplySelectedFixes()
+    public async Task ApplySelectedFixes()
     {
-        _previewMode = false;
-        ApplyFixes();
+        await RunScanWithFeedbackAsync(() =>
+        {
+            _previewMode = false;
+            ApplyFixes();
 
-        RefreshFixes();
+            RefreshFixes();
+        });
     }
 
     partial void OnSelectedParagraphChanged(SubtitleLineViewModel? oldValue, SubtitleLineViewModel? newValue)
@@ -470,7 +497,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         // Re-scan so the fix list reflects the toggle right away; while step 1 is up there is no list yet.
         if (Step2IsVisible)
         {
-            RefreshFixes();
+            _ = RunScanWithFeedbackAsync(RefreshFixes);
         }
     }
 
@@ -513,6 +540,36 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         EditTextTotalLengthBackground = info.TotalBackground;
     }
 
+    // Flash "Analyzing..." around a re-scan. A repeat scan that finds nothing changes nothing on
+    // screen, so without this there is still no sign that the button did anything (#12849). The scan
+    // itself runs on the UI thread - it mutates collections bound to the grid - so the status has to
+    // be painted before it starts and held for a moment after it ends.
+    private async Task RunScanWithFeedbackAsync(Action scan)
+    {
+        if (_isAnalysing)
+        {
+            return;
+        }
+
+        _isAnalysing = true;
+        try
+        {
+            NothingToFixIsVisible = false;
+            AnalysingIsVisible = true;
+            await Task.Delay(AnalysingPaintDelayMilliseconds);
+
+            scan();
+
+            await Task.Delay(AnalysingMinimumVisibleMilliseconds);
+        }
+        finally
+        {
+            AnalysingIsVisible = false;
+            NothingToFixIsVisible = _nothingToFix;
+            _isAnalysing = false;
+        }
+    }
+
     private void RefreshFixes()
     {
         _oldFixes = new List<FixDisplayItem>(Fixes);
@@ -523,7 +580,8 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
 
         // Confirm that the scan actually ran when it came up empty - the counters do not change in
         // that case, so without this "Refresh available fixes" looks like a dead button (#12849).
-        NothingToFixIsVisible = SelectedProfile != null && Fixes.Count == 0;
+        _nothingToFix = SelectedProfile != null && Fixes.Count == 0;
+        NothingToFixIsVisible = _nothingToFix && !AnalysingIsVisible;
     }
 
     private void ApplyFixes()

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -248,13 +248,20 @@ public class FixCommonErrorsWindow : Window
         };
         nothingToFixPanel.Bind(IsVisibleProperty, new Binding(nameof(vm.NothingToFixIsVisible)));
 
+        // "Analyzing..." while a re-scan runs, so a scan that ends in the same state as it started
+        // still shows that it ran - this is what SE4 does on every re-scan (#12849).
+        var analysingText = UiUtil.MakeTextBlock(Se.Language.Tools.FixCommonErrors.Analysing);
+        analysingText.VerticalAlignment = VerticalAlignment.Center;
+        analysingText.Opacity = 0.75;
+        analysingText.Bind(IsVisibleProperty, new Binding(nameof(vm.AnalysingIsVisible)));
+
         var panelStep2Status = new StackPanel
         {
             Orientation = Orientation.Horizontal,
             Spacing = 15,
             HorizontalAlignment = HorizontalAlignment.Left,
             VerticalAlignment = VerticalAlignment.Center,
-            Children = { labelFixesApplied, nothingToFixPanel },
+            Children = { labelFixesApplied, nothingToFixPanel, analysingText },
         };
         panelStep2Status.Bind(IsVisibleProperty, new Binding(nameof(vm.Step2IsVisible)));
         grid.Children.Add(panelStep2Status);


### PR DESCRIPTION
Follow-up to #12853 for https://github.com/SubtitleEdit/subtitleedit/issues/12849.

The green check + "Nothing to fix :)" only helps the first time. Click **Refresh available fixes** again with nothing left to fix and the status already reads "Nothing to fix :)" — nothing on screen changes, so the scan still looks like it never ran. That transient feedback is what the reporter was after all along: SE4 briefly shows `Analyzing...` on every re-scan, then falls back to the result.

## What this does

Flashes the existing (already translated, previously unreferenced) `Analysing` = "Analyzing..." string in the step 2 status slot around every re-scan.

The scan is synchronous and mutates `ObservableCollection`s bound to the grid, so it has to stay on the UI thread. That means the status must be painted *before* the scan starts blocking and held briefly *after* it ends — otherwise no frame containing it is ever rendered. Hence the small paint delay (20 ms) plus a 250 ms minimum-visible hold.

All four re-scan paths are covered:

- Refresh available fixes
- Apply selected fixes
- Entering step 2
- The "try to guess unknown words" toggle

The startup path that skips step 1 stays synchronous — the window is not up yet, so there is nothing to flash on.

Re-entrancy is guarded so hammering Refresh cannot overlap scans; counters and button states are otherwise unchanged.

## Test

- `dotnet build src/ui/UI.csproj` — clean
- Step 2 → apply everything → click Refresh repeatedly: "Analyzing..." shows briefly on each click, then "Nothing to fix :)" returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)