### PR TITLE
Fix CrispASR TTS freezing the app on every generation (#12878)

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/CrispAsrTtsProvenance.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CrispAsrTtsProvenance.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 
@@ -187,15 +188,29 @@ public static class CrispAsrTtsProvenance
                 return null;
             }
 
-            // crispasr prints its usage to stdout, but be indifferent to which stream it lands on.
-            var help = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+            // Drain both pipes concurrently. crispasr writes its whole ~25 KB usage dump to
+            // stderr and nothing at all to stdout, so reading stdout to EOF first deadlocked on
+            // Windows (#12878): the child blocks once the 4 KB stderr pipe is full, stdout never
+            // reaches EOF because the child cannot exit, and WaitForExit below is never even
+            // reached — the app froze on the UI thread for good. Unix escaped it only because its
+            // pipe buffer is 64 KB. Starting both reads before waiting also means the timeout
+            // actually governs the probe.
+            var stdout = process.StandardOutput.ReadToEndAsync();
+            var stderr = process.StandardError.ReadToEndAsync();
             if (!process.WaitForExit(HelpProbeTimeoutMs))
             {
                 TryKill(process);
                 return null;
             }
 
-            return help;
+            // The process has exited, so both pipes are at EOF and these are already complete.
+            // Bounded anyway so a wedged read cannot outlive the probe.
+            if (!Task.WaitAll(new Task[] { stdout, stderr }, HelpProbeTimeoutMs))
+            {
+                return null;
+            }
+
+            return stdout.Result + stderr.Result;
         }
         catch (Exception exception)
         {

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1565,7 +1565,11 @@ public partial class TextToSpeechViewModel : ObservableObject
         var testVoiceToken = generatingAudioVm.CancellationTokenSource.Token;
         try
         {
-            var result = await engine.Speak(text, _waveFolder, voice, SelectedLanguage, SelectedRegion, SelectedModel, testVoiceToken);
+            // Off the UI thread — Speak() does its server startup synchronously before its first
+            // await, so awaiting it directly kept the dispatcher busy and left the "please wait"
+            // popup above unpainted for the whole spawn (#12878).
+            var result = await Task.Run(() =>
+                engine.Speak(text, _waveFolder, voice, SelectedLanguage, SelectedRegion, SelectedModel, testVoiceToken));
             if (!testVoiceToken.IsCancellationRequested)
             {
                 if (result.Error || string.IsNullOrEmpty(result.FileName) || !File.Exists(result.FileName))

--- a/src/ui/Features/Video/TextToSpeech/TtsInstructionSwap.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsInstructionSwap.cs
@@ -32,7 +32,12 @@ public static class TtsInstructionSwap
         var previous = Swap(engine, instruction);
         try
         {
-            return await speak();
+            // Task.Run, not a bare await: every engine's Speak() runs a stretch of synchronous
+            // work before its first real await (Process.Start of the local server, --help probes,
+            // file checks), and awaiting it from a command handler runs all of that on the UI
+            // thread. That is how the CrispASR --help probe froze the whole app in #12878, and
+            // even without a deadlock it stalls the window for as long as a server takes to spawn.
+            return await Task.Run(speak);
         }
         finally
         {

--- a/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
@@ -172,7 +172,10 @@ public static class TtsVoiceInstaller
         }
 
         var isInstalled = File.Exists(ChatterboxTtsCpp.GetCrispAsrExecutable());
-        var isCapable = isInstalled && (extraCapabilityCheck?.Invoke() ?? true);
+        // Off the UI thread: the capability check SHA-256s the whole crispasr executable
+        // (hundreds of MB in the GPU builds), which visibly stalled the window on click.
+        var isCapable = isInstalled
+            && (extraCapabilityCheck == null || await Task.Run(extraCapabilityCheck));
         if (!forceRedownload && isInstalled && isCapable)
         {
             return true;

--- a/tests/UI/Features/Video/TextToSpeech/Engines/CrispAsrTtsProvenanceTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/CrispAsrTtsProvenanceTests.cs
@@ -162,6 +162,78 @@ public class CrispAsrTtsProvenanceTests
     {
         Assert.True(new SeVideoTextToSpeech().AcceptVoiceCloning);
     }
+
+    [Fact]
+    public async Task RealHelpProbe_WithLargeStderrAndEmptyStdout_DoesNotDeadlock()
+    {
+        // #12878: the real probe read stdout to EOF *before* touching stderr. crispasr writes its
+        // whole ~25 KB usage dump to stderr and nothing at all to stdout, so the child blocked once
+        // the pipe filled, stdout never reached EOF, and the probe hung forever - on the UI thread,
+        // freezing the app on every CrispASR TTS generation. Every other test here stubs
+        // HelpTextProvider, which is exactly why this went unnoticed; this one runs the real thing.
+        //
+        // 1 MB is past any platform's pipe buffer (4 KB on Windows, 64 KB on Unix), so the old
+        // sequential read deadlocks here regardless of where the suite runs.
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Skip("Needs a shebang stub; Process.Start cannot launch a .cmd with UseShellExecute=false.");
+        }
+
+        const int payloadBytes = 1024 * 1024;
+        using var stub = ShellStub.WritingToStdErr(payloadBytes);
+
+        var probe = Task.Run(() => CrispAsrTtsProvenance.HelpTextProvider(stub.Path));
+        var finished = await Task.WhenAny(
+            probe,
+            Task.Delay(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken));
+
+        Assert.True(ReferenceEquals(finished, probe), "the --help probe deadlocked");
+        Assert.Equal(payloadBytes, (await probe)?.Length);
+    }
+}
+
+/// <summary>
+/// A real executable stub (shebang script) that, given <c>--help</c>, floods stderr and writes
+/// nothing to stdout - the shape of output that deadlocked the probe in #12878. Unix only; see the
+/// skip in the test that uses it.
+/// </summary>
+internal sealed class ShellStub : IDisposable
+{
+    public string Path { get; }
+
+    private ShellStub(int stdErrBytes)
+    {
+        Path = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(),
+            "crispasr-flood-" + Guid.NewGuid().ToString("N") + ".sh");
+
+        // Generate the payload rather than embedding it, so the script stays small and the byte
+        // count exact. Nothing is written to stdout - that is the half of the shape that matters.
+        File.WriteAllText(
+            Path,
+            "#!/bin/sh\n"
+            + $"awk 'BEGIN {{ for (i = 0; i < {stdErrBytes}; i++) printf \"x\" }}' 1>&2\n");
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(
+                Path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+
+    public static ShellStub WritingToStdErr(int stdErrBytes) => new(stdErrBytes);
+
+    public void Dispose()
+    {
+        try
+        {
+            File.Delete(Path);
+        }
+        catch
+        {
+            // temp file - nothing depends on it being gone
+        }
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
Fixes #12878.

## What happens

Any CrispASR-backed TTS engine freezes the whole app the moment synthesis starts. Reported on Windows 10 with Chatterbox; it affects all ten CrispASR TTS engines and every entry point (Generate, Test voice, Review → Regenerate, Cast voice preview).

## Root cause

The `--help` capability probe added in rc17 (`8902b89e4`) reads the child's streams sequentially:

```csharp
var help = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
if (!process.WaitForExit(HelpProbeTimeoutMs)) { ... }
```

Measured against the pinned binary:

```
crispasr --help  →  stdout: 0 bytes    stderr: 25,417 bytes
```

The code comment claimed the usage goes to stdout. It does not — it all goes to stderr. On Windows the redirect pipes get the 4 KB system default, so:

1. The parent blocks in `ReadToEnd()` on stdout, which only returns at process exit.
2. The child blocks writing byte ~4097 of its 25 KB stderr dump.
3. Neither can advance, and `WaitForExit(15_000)` sits *after* the reads, so the timeout is never reached.

Unix escaped it purely because its pipe buffer is 64 KB — which is why this shipped.

The probe is reached from `AddServerMarkingArgs` while each engine builds its server launch args inside `EnsureServerRunningAsync`, and every engine's `Speak()` gets there synchronously before its first real await (`SemaphoreSlim.WaitAsync` on an uncontended lock completes inline). So the hang lands on the Avalonia UI thread. In the reporter's screenshot the blank window is `GeneratingAudioWindow` (fixed `Width = 360`): shown by `TestVoice`, then the dispatcher blocks on the very next line, so it never paints.

Speech-to-text is unaffected — `AddServerMarkingArgs` is TTS-only.

## The fix

- Drain both pipes concurrently, and start the reads before `WaitForExit` so the 15 s timeout actually governs the probe.
- Run `Speak()` off the UI thread (`TtsInstructionSwap.RunAsync` covers Generate / Review / Cast; the direct call in `TestVoice` is wrapped too). Spawning a local inference server and waiting for it to report healthy should never occupy the dispatcher, deadlock or not.
- Same for the Chatterbox capability check, which SHA-256s the whole crispasr executable (hundreds of MB in the GPU builds) — it was running synchronously on click.

## Tests

Every existing test in `CrispAsrTtsProvenanceTests` stubs `HelpTextProvider`, which is exactly why the deadlock got through. The new test runs the real `ReadHelpText` against a stub that floods stderr with 1 MB and writes nothing to stdout — past any platform's pipe buffer, so the old sequential read deadlocks everywhere, not just on Windows. Verified: it fails (30 s timeout) against the pre-fix code and passes after. Skipped on Windows, where `Process.Start` with `UseShellExecute=false` cannot launch a `.cmd` stub.

907/907 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
