### PR TITLE
Point at the Model field when an STT server rejects it (#12877)

### DIFF
--- a/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
@@ -222,9 +222,14 @@ public class OpenAiSttService : ISttTranscriber
                 $"Status: {statusCode} {response.StatusCode}{Environment.NewLine}" +
                 $"RequestParams: {paramSummary}{Environment.NewLine}" +
                 $"ResponseBody: {errorContent}");
+            // Carry the status code on the exception: the caller turns a 4xx that
+            // complains about "model" into a hint about the Model field, and
+            // sniffing the number back out of the message is fragile (issue #12877).
             throw new HttpRequestException(
                 $"STT request failed with status {statusCode} ({response.StatusCode}) " +
-                $"calling {safeEndpoint}. Response: {errorContent}");
+                $"calling {safeEndpoint}. Response: {errorContent}",
+                null,
+                response.StatusCode);
         }
 
         // Check if streaming (SSE)

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -1307,6 +1307,10 @@ public partial class SpeechToTextViewModel : ObservableObject
             {
                 message = Se.Language.General.RequestTimeout;
             }
+            else if (IsModelRejectedByServer(ex, engine))
+            {
+                message += Environment.NewLine + Environment.NewLine + Se.Language.General.OpenAiCompatibleSttModelRejectedHint;
+            }
 
             await Dispatcher.UIThread.InvokeAsync(async () =>
             {
@@ -1814,6 +1818,15 @@ public partial class SpeechToTextViewModel : ObservableObject
 
         if (string.IsNullOrWhiteSpace(languageCode))
         {
+            // Last resort: read the language off the transcript itself. Providers
+            // that never report one leave the hint fallback empty - xAI's /v1/stt
+            // documents its "language" response field as "currently empty" - and
+            // without a code the whole post-processing step is skipped (#12877).
+            languageCode = LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(transcript);
+        }
+
+        if (string.IsNullOrWhiteSpace(languageCode))
+        {
             return transcript;
         }
 
@@ -1910,6 +1923,37 @@ public partial class SpeechToTextViewModel : ObservableObject
         {
             _onlineDetectedLanguage = match.Code;
         }
+    }
+
+    /// <summary>
+    /// True when a failed OpenAI-compatible STT request looks like the server
+    /// turning down the configured model name. Endpoints differ on this: xAI's
+    /// /v1/stt has no "model" parameter and answers 404 for any value sent,
+    /// while others accept only their own ids - so the fix is to clear the
+    /// field, which isn't something the raw server message says (issue #12877).
+    /// </summary>
+    private static bool IsModelRejectedByServer(HttpRequestException ex, ISpeechToTextEngine engine)
+    {
+        if (engine is not OpenAiCompatibleSttEngine)
+        {
+            return false;
+        }
+
+        var model = Se.Settings.Tools.OpenAiCompatibleSttModel;
+        if (string.IsNullOrWhiteSpace(model))
+        {
+            return false;
+        }
+
+        if (ex.StatusCode is not { } status || (int)status < 400 || (int)status >= 500)
+        {
+            return false;
+        }
+
+        // The message holds the server's response body, so an error naming the
+        // model we sent - or just talking about models at all - points at the field.
+        return ex.Message.Contains(model.Trim(), StringComparison.OrdinalIgnoreCase) ||
+               ex.Message.Contains("model", StringComparison.OrdinalIgnoreCase);
     }
 
     private WavePeakData2? MakeWavePeaks()

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -741,6 +741,7 @@ public class LanguageGeneral
     public string OpenAiCompatibleSttLanguage { get; set; }
     public string OpenAiCompatibleSttTemperature { get; set; }
     public string OpenAiCompatibleSttPrompt { get; set; }
+    public string OpenAiCompatibleSttModelRejectedHint { get; set; }
     public string DashScopeSttRegion { get; set; }
     public string DashScopeSttEnableWords { get; set; }
     public string DashScopeSttRegionKeyHint { get; set; }
@@ -1505,6 +1506,7 @@ public class LanguageGeneral
         OpenAiCompatibleSttLanguage = "Language Hint";
         OpenAiCompatibleSttTemperature = "Temperature";
         OpenAiCompatibleSttPrompt = "Prompt";
+        OpenAiCompatibleSttModelRejectedHint = "The server rejected the model name. Not every OpenAI compatible endpoint takes a model - xAI's https://api.x.ai/v1/stt, for one, has no 'model' parameter at all. Try clearing the Model field.";
         DashScopeSttRegion = "Region";
         DashScopeSttEnableWords = "Word-level timestamps";
         DashScopeSttRegionKeyHint = "Note: Alibaba Cloud Model Studio API keys are region-specific - make sure the selected region matches the region where the API key was created (China vs. International).";

--- a/tests/UI/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttServiceTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttServiceTests.cs
@@ -373,6 +373,43 @@ public class OpenAiSttServiceTests
         {
             var ex = await Assert.ThrowsAsync<HttpRequestException>(() => service.TranscribeAsync(wav, cancellationToken: ct));
             Assert.Contains("401", ex.Message);
+            Assert.Equal(HttpStatusCode.Unauthorized, ex.StatusCode);
+        }
+        finally
+        {
+            File.Delete(wav);
+        }
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_ModelRejected_KeepsStatusAndBody()
+    {
+        // xAI's /v1/stt has no "model" parameter and answers 404 for any value
+        // sent; the caller needs both the status and the body to tell the user
+        // which field to clear (issue #12877).
+        using var handler = new StubHandler((req, ct) =>
+        {
+            var resp = new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent(
+                    "{\"error\":\"The model 'grok-voice-latest' does not exist or your team does not have access to it\"}",
+                    Encoding.UTF8,
+                    "application/json"),
+            };
+            return Task.FromResult(resp);
+        });
+        using var client = new HttpClient(handler);
+        var settings = MakeSettings();
+        settings.Model = "grok-voice-latest";
+        var service = new OpenAiSttService(client, settings);
+
+        var ct = TestContext.Current.CancellationToken;
+        var wav = MakeTinyWav();
+        try
+        {
+            var ex = await Assert.ThrowsAsync<HttpRequestException>(() => service.TranscribeAsync(wav, cancellationToken: ct));
+            Assert.Equal(HttpStatusCode.NotFound, ex.StatusCode);
+            Assert.Contains("grok-voice-latest", ex.Message);
         }
         finally
         {


### PR DESCRIPTION
Follow-up to #12860. Fixes #12877.

### What the reporter hit

Their `Model` field held `grok-voice-latest` — xAI's realtime *speech-to-speech* model, not a transcription model. xAI's `POST /v1/stt` documents no `model` parameter at all and answers 404 for any value sent, so every request failed with a message that never says which setting to change. Clearing the field is the correct configuration, not a workaround.

It only surfaced now because the #12860 fix moved the audio to the **last** multipart field (`file` "must be the last field in the multipart form" per xAI's REST reference). Before that, `model` was written after the audio and never reached xAI's parameter parsing — which is why the same value appeared to work for months.

### Changes

- **`OpenAiSttService`** — carry `response.StatusCode` on the thrown `HttpRequestException` instead of leaving the caller to sniff the number back out of the message.
- **`SpeechToTextViewModel`** — when an OpenAI-compatible STT request fails 4xx and the server's body names the model we sent (or just talks about models), append a hint that some endpoints take no `model` and the field can be cleared.
- **`SpeechToTextViewModel.PostProcess`** — fall back to `LanguageAutoDetect.AutoDetectGoogleLanguageOrNull` on the transcript when neither the per-engine hint nor the provider supplies a language. xAI documents its `language` response field as *"Currently empty — language detection is not yet enabled"*, so the provider-detected fallback added in #12860 can never fire there and merge/split/casing was silently skipped on every Grok run.

### Verification

Full UI suite green (907 tests), plus two temporary integration tests against a local whisper.cpp-backed OpenAI-compatible server (`whisper-cli` + `tiny.en`, real `say`-generated speech) that enforced xAI's two rules:

- multipart order observed on the wire: `model, response_format, timestamp_granularities[], timestamp_granularities[], file` — audio last, as required
- unknown model → `404` with the model name in the body; `ex.StatusCode` now arrives as `NotFound`, so the hint fires
- empty model → real transcript, 35 words grouped into 3 timed segments, `"language": ""` → `AutoDetectGoogleLanguageOrNull` returns `en`, so post-processing runs where it previously bailed out

Also run against **upstream whisper.cpp `whisper-server`** (started with `--inference-path /v1/audio/transcriptions`, same model and audio) — a third-party server implementation rather than a purpose-built stub. SE's request is accepted both with the default `whisper-1` model and with the field empty, and its `verbose_json` parses into 5 timed segments with `"language": "english"`, which the existing provider-detected fallback already maps to a code — so the new auto-detect step correctly stays out of the way there.

The integration tests needed a live server and were not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
