### PR TITLE
Replace remaining object lock fields with System.Threading.Lock

### DIFF
--- a/src/libse/SubtitleFormats/SubtitleFormat.cs
+++ b/src/libse/SubtitleFormats/SubtitleFormat.cs
@@ -23,15 +23,18 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         /// makes concurrent access real. A lock rather than a lazy/volatile publish because the
         /// build deliberately assigns <see cref="_allSubtitleFormats"/> before ordering it, so
         /// <see cref="GetOrderedFormatsList"/> can re-enter this property through
-        /// <c>Utilities.GetSubtitleFormatByFriendlyName</c>; the lock is re-entrant on the same
+        /// <c>Utilities.GetSubtitleFormatByFriendlyName</c>; Monitor is re-entrant on the same
         /// thread, so that keeps working, while another thread can no longer observe the
         /// intermediate unordered list.
         /// </summary>
-#if NET9_0_OR_GREATER
-        private static readonly System.Threading.Lock SubtitleFormatsLock = new System.Threading.Lock();
-#else
+        /// <remarks>
+        /// Stays a plain <see cref="object"/> - unlike the rest of the code base, which uses
+        /// <c>System.Threading.Lock</c> - because LibSE also targets netstandard2.1, where that
+        /// type does not exist. Guarding one field with <c>#if NET9_0_OR_GREATER</c> is not worth
+        /// the target-framework conditional: the lock is taken a handful of times at start-up, so
+        /// there is nothing to gain from the faster primitive.
+        /// </remarks>
         private static readonly object SubtitleFormatsLock = new object();
-#endif
 
         protected static readonly char[] SplitCharColon = { ':' };
 

--- a/src/libse/SubtitleFormats/SubtitleFormat.cs
+++ b/src/libse/SubtitleFormats/SubtitleFormat.cs
@@ -23,11 +23,15 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         /// makes concurrent access real. A lock rather than a lazy/volatile publish because the
         /// build deliberately assigns <see cref="_allSubtitleFormats"/> before ordering it, so
         /// <see cref="GetOrderedFormatsList"/> can re-enter this property through
-        /// <c>Utilities.GetSubtitleFormatByFriendlyName</c>; Monitor is re-entrant on the same
+        /// <c>Utilities.GetSubtitleFormatByFriendlyName</c>; the lock is re-entrant on the same
         /// thread, so that keeps working, while another thread can no longer observe the
         /// intermediate unordered list.
         /// </summary>
+#if NET9_0_OR_GREATER
+        private static readonly System.Threading.Lock SubtitleFormatsLock = new System.Threading.Lock();
+#else
         private static readonly object SubtitleFormatsLock = new object();
+#endif
 
         protected static readonly char[] SplitCharColon = { ':' };
 

--- a/src/libuilogic/Export/FontFaces.cs
+++ b/src/libuilogic/Export/FontFaces.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 
 namespace Nikse.SubtitleEdit.UiLogic.Export;
 
@@ -21,7 +22,7 @@ public static class FontFaces
 
     private static List<string>? _facesCache;
     private static Dictionary<string, FaceInfo>? _faceMapCache;
-    private static readonly object Gate = new();
+    private static readonly Lock Gate = new();
 
     /// <summary>All installed font faces by their Win32/GDI (name ID 1) names, sorted.</summary>
     public static List<string> GetFontFaces()

--- a/src/ui/Features/Ocr/Engines/PaddleOcr.cs
+++ b/src/ui/Features/Ocr/Engines/PaddleOcr.cs
@@ -29,7 +29,7 @@ public partial class PaddleOcr
     private CancellationToken _cancellationToken;
     private readonly Stopwatch _batchStopwatch = new();
     private readonly StringBuilder _errorOutput = new();
-    private readonly object _errorLock = new();
+    private readonly Lock _errorLock = new();
 
     public static List<string> UrlsWindowsCpu =
         ["https://github.com/timminator/PaddleOCR-Standalone/releases/download/v1.4.0/PaddleOCR-CPU-v1.4.0.7z"];

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -750,7 +750,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         item.Subtitle = new Subtitle();
         var results = new Paragraph[totalCount];
         var processedCount = 0;
-        var lockObj = new object();
+        var lockObj = new Lock();
 
         Parallel.For(0, totalCount, new ParallelOptions
         {
@@ -1015,7 +1015,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         var totalCount = imageSubtitles.Count;
         var results = new Paragraph[totalCount];
         var processedCount = 0;
-        var lockObj = new object();
+        var lockObj = new Lock();
 
         Parallel.For(
             0,

--- a/src/ui/Features/Video/TextToSpeech/Engines/CrispAsrTtsProvenance.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CrispAsrTtsProvenance.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
@@ -150,7 +151,7 @@ public static class CrispAsrTtsProvenance
     }
 
     private static readonly Dictionary<string, bool> SupportCache = new();
-    private static readonly object SupportCacheLock = new();
+    private static readonly Lock SupportCacheLock = new();
 
     /// <summary>
     /// How <see cref="SupportsMarkingOptOut"/> gets the binary's help text. Swappable so the flag


### PR DESCRIPTION
## Summary
- Finishes the codebase's migration to the .NET 9+ `System.Threading.Lock` type (54 `Lock` fields already existed) by converting the last four `object` lock fields and two method-local lock objects
- `SubtitleFormat.SubtitleFormatsLock` (libse) is guarded with `#if NET9_0_OR_GREATER` because LibSE also targets `netstandard2.1`, where `Lock` does not exist; the `#else` branch keeps the original `object` declaration
- Converts `FontFaces.Gate`, `PaddleOcr._errorLock` (which previously sat alongside an already-migrated `Lock _lock` in the same class), `CrispAsrTtsProvenance.SupportCacheLock`, and both `lockObj` locals guarding `Parallel.For` progress counters in `BatchConverter`
- All fields were verified to be lock-only (no `Monitor.Wait/Pulse`, never passed or reassigned), so `lock (...)` statements need no changes

## Test plan
- [x] `dotnet build SubtitleEdit.sln` succeeds with no warnings (both LibSE target frameworks compile; no CS9216 "Lock converted to object" warnings)
- [x] `dotnet test tests/libse/LibSETests.csproj` passes (745/745)
- [x] `dotnet test tests/UI/UITests.csproj` passes (906/907, 1 pre-existing skip)
- [ ] Batch convert with OCR still reports progress correctly (exercises the `BatchConverter` locals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)