### PR TITLE
Restore SE4 order of the two split items in the text box menu (#12888)

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1433,14 +1433,16 @@ public static partial class InitListViewAndEditBox
 
         flyoutTextBox.Items.Add(new Separator());
 
-        var menuItemTextBoxSplitAtCursor = new MenuItem { Header = Se.Language.General.SplitLineAtTextBoxCursorPosition };
-        menuItemTextBoxSplitAtCursor.Command = vm.SplitAtTextBoxCursorPositionCommand;
-        flyoutTextBox.Items.Add(menuItemTextBoxSplitAtCursor);
-
+        // Keep the SE4 order here: "at cursor/video position" first, then "at cursor position".
+        // Swapping them broke muscle memory for people coming from SE4 (see issue #12888).
         var menuItemTextBoxSplitAtCursorAndVideoPosition = new MenuItem { Header = Se.Language.General.SplitLineAtVideoAndTextBoxPosition };
         menuItemTextBoxSplitAtCursorAndVideoPosition.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsTextBoxSplitAtCursorAndVideoPositionVisible)));
         menuItemTextBoxSplitAtCursorAndVideoPosition.Command = vm.SplitAtVideoPositionAndTextBoxCursorPositionCommand;
         flyoutTextBox.Items.Add(menuItemTextBoxSplitAtCursorAndVideoPosition);
+
+        var menuItemTextBoxSplitAtCursor = new MenuItem { Header = Se.Language.General.SplitLineAtTextBoxCursorPosition };
+        menuItemTextBoxSplitAtCursor.Command = vm.SplitAtTextBoxCursorPositionCommand;
+        flyoutTextBox.Items.Add(menuItemTextBoxSplitAtCursor);
 
         flyoutTextBox.Items.Add(new Separator());
 


### PR DESCRIPTION
Addresses item 3 of #12888.

## What changed

In the subtitle text box context menu, the two split entries were listed as:

1. Split line at text box cursor position
2. Split line at video and text box position

SE4 has them the other way round — `contextMenuStripTextBoxListView` adds `toolStripMenuItemSplitViaWaveform` ("Split text at cursor/waveform position") first, then `toolStripMenuItemSplitTextAtCursor` ("Split text at cursor position"). This PR swaps them back so the order matches.

## Why

From the issue: the reversed order "breaks muscle memory and makes the workflow a PITA" for people coming from v4.

## Notes for the reviewer

- The video-position item keeps its `IsVisible` binding to `IsTextBoxSplitAtCursorAndVideoPositionVisible`, which `TextBoxContextOpening` only sets true when a video is loaded and the playhead sits inside the selected line. So with no video, "at text box cursor position" is still the only split entry — same as SE4.
- Nothing indexes into this flyout: the spell-check items in `TextBoxContextOpening` are inserted at index 0 and removed by `Tag`, so they are unaffected by the reordering.
- Only the text box flyout is touched. The list view and waveform split menus are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
