### PR TITLE
Fix truncated labels and narrow controls in two spell check dialogs (#12886)

### DIFF
--- a/src/ui/Features/Shared/AddToNamesList/AddToNamesListWindow.cs
+++ b/src/ui/Features/Shared/AddToNamesList/AddToNamesListWindow.cs
@@ -8,6 +8,11 @@ namespace Nikse.SubtitleEdit.Features.Shared.AddToNamesList;
 
 public class AddToNamesListWindow : Window
 {
+    // One width for the name box, the multi-name box and the dictionary drop-down, so the
+    // dialog keeps the same size in both modes and long entries like "English (United
+    // States) [en_US]" are not truncated (#12886).
+    private const int ContentWidth = 400;
+
     public AddToNamesListWindow(AddToNamesListViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
@@ -21,14 +26,14 @@ public class AddToNamesListWindow : Window
         var labelWord = UiUtil.MakeLabel(Se.Language.Ocr.NameToAdd);
         labelWord.Bind(Label.IsVisibleProperty, new Binding(nameof(vm.IsSingleMode)));
 
-        var textBoxWord = UiUtil.MakeTextBox(200, vm, nameof(vm.Name), nameof(vm.IsSingleMode));
+        var textBoxWord = UiUtil.MakeTextBox(ContentWidth, vm, nameof(vm.Name), nameof(vm.IsSingleMode));
 
         var labelMultiNames = UiUtil.MakeLabel(Se.Language.SpellCheck.EnterOneNamePerLine);
         labelMultiNames.Bind(Label.IsVisibleProperty, new Binding(nameof(vm.IsMultiMode)));
 
         var textBoxMultiNames = new TextBox
         {
-            Width = 400,
+            Width = ContentWidth,
             Height = 250,
             AcceptsReturn = true,
             VerticalAlignment = VerticalAlignment.Stretch,
@@ -40,7 +45,8 @@ public class AddToNamesListWindow : Window
         var labelDictionary = UiUtil.MakeLabel(Se.Language.General.Dictionary).WithMarginTop(20);
         var comboBoxDictionaries = new ComboBox
         {
-            Width = 200,
+            Width = ContentWidth,
+            HorizontalAlignment = HorizontalAlignment.Left,
             [!ComboBox.SelectedItemProperty] = new Binding(nameof(vm.SelectedDictionary)) { Mode = BindingMode.TwoWay },
             [!ComboBox.ItemsSourceProperty] = new Binding(nameof(vm.Dictionaries)) { Mode = BindingMode.TwoWay },
         };

--- a/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesWindow.cs
+++ b/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesWindow.cs
@@ -71,7 +71,9 @@ public class GetDictionariesWindow : Window
         {
             ColumnDefinitions =
             {
-                new ColumnDefinition { Width = new GridLength(LabelWidth, GridUnitType.Pixel) },
+                // Auto (not a fixed width) so longer translations of the labels - e.g. Italian
+                // "Cartella installazione" for "Install folder" - are not clipped (#12886).
+                new ColumnDefinition { Width = GridLength.Auto, MinWidth = LabelWidth },
                 new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
             },
             RowDefinitions =


### PR DESCRIPTION
Addresses three of the layout reports in #12886.

## Get dictionaries (`GetDictionariesWindow`)

The details grid pinned its label column at a fixed 90 px, so labels whose translation is longer than the English text were clipped — the reported case is Italian **"Cartella installazione"** for "Install folder", but "Dizionario"/"Descrizione" are affected on the same grid.

The column is now `GridLength.Auto` with `MinWidth = 90`, so English renders exactly as before and the window — already `SizeToContent.WidthAndHeight` — grows to fit longer translations instead of cutting them off.

## Add name to names list (`AddToNamesListWindow`)

Two reports from the same dialog:

- The **"Nome da aggiungere"** ("Name to add") text box was 200 px.
- The dictionary drop-down was also 200 px, which truncated entries — they render as `SpellCheckDictionaryDisplay.Name`, e.g. `English (United States) [en_US]`, so the language code at the end was cut off.

Both were sitting next to a multi-name text box that was already 400 px, which also meant the dialog changed width whenever multi mode was toggled. All three controls now share a single `ContentWidth` const, so the dialog keeps one size in both modes.

## Notes for the reviewer

- Layout-only; no view model, storage or behaviour changes.
- Builds clean. The widths have not been eyeballed in a running Italian UI — if 400 px reads too wide for the dictionary combo, it is a one-line change.
- The remaining item in #12886 — untranslated key names (Delete/Up/Down/Space) in the shortcut editor — is **not** in this PR. Those come from raw Avalonia `Key` enum names and double as the persisted storage tokens, so fixing it needs a display-only lookup in `ShortcutManager.GetKeyDisplayName` plus new language strings. Separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)