### PR TITLE
Scroll bar: pause trough hold paging when the thumb reaches the cursor

### DIFF
--- a/src/ui/Logic/DataGridScrollBarBehavior.cs
+++ b/src/ui/Logic/DataGridScrollBarBehavior.cs
@@ -6,6 +6,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 
 namespace Nikse.SubtitleEdit.Logic;
@@ -26,6 +27,13 @@ namespace Nikse.SubtitleEdit.Logic;
 ///
 /// The DataGrid hooks the scroll bar's Scroll event (not ValueChanged) to refresh its
 /// rows, so a programmatic jump also invokes the grid's internal ProcessVerticalScroll.
+///
+/// Press-and-hold on the trough is also handled here rather than left to the theme's
+/// trough RepeatButton. That button keeps repeating while IsPressed, and Button only
+/// re-evaluates IsPressed on PointerMoved — with a stationary cursor no move event
+/// arrives as the thumb slides under it, so it pages straight past the cursor to the
+/// end. This class pages toward the cursor and pauses when the thumb reaches it,
+/// resuming only if the pointer moves further along, like the Windows scroll bar.
 /// </summary>
 public static class DataGridScrollBarBehavior
 {
@@ -89,57 +97,144 @@ public static class DataGridScrollBarBehavior
                 }
             };
 
-            // Shift + trough click jumps to the click position, matching the Windows scroll
-            // bar. Tunnel so this runs before the trough repeat button starts paging.
+            // One state instance per applied template: a re-template wires a fresh scroll
+            // bar with fresh state, and the discarded template's timer dies with its capture.
+            var holdState = new TroughHoldState();
+
+            // Shift + trough click jumps to the click position, a plain trough press pages
+            // and repeats toward the cursor, both matching the Windows scroll bar. Tunnel so
+            // this runs before the theme's trough repeat button can engage.
             verticalScrollBar.AddHandler(
                 InputElement.PointerPressedEvent,
-                (_, args) => JumpToClickPosition(grid, verticalScrollBar, args),
+                (_, args) =>
+                {
+                    if ((args.KeyModifiers & KeyModifiers.Shift) != 0)
+                    {
+                        JumpToClickPosition(grid, verticalScrollBar, args);
+                    }
+                    else
+                    {
+                        StartTroughHoldPaging(grid, verticalScrollBar, holdState, args);
+                    }
+                },
                 RoutingStrategies.Tunnel);
+
+            verticalScrollBar.PointerMoved += (_, args) =>
+            {
+                if (holdState.IsActive)
+                {
+                    holdState.PointerPosition = args.GetPosition(verticalScrollBar);
+                }
+            };
+
+            verticalScrollBar.PointerReleased += (_, args) =>
+            {
+                if (holdState.IsActive && args.InitialPressMouseButton == MouseButton.Left)
+                {
+                    StopTroughHoldPaging(holdState);
+                    args.Pointer.Capture(null);
+                    args.Handled = true;
+                }
+            };
+
+            verticalScrollBar.PointerCaptureLost += (_, _) => StopTroughHoldPaging(holdState);
         };
+    }
+
+    // Per scroll bar state for a press-and-hold on the trough, captured by that scroll
+    // bar's handlers. The direction is latched at press time (Windows-style) because
+    // re-deciding it per tick would ping-pong around the cursor once a page overshoots.
+    private sealed class TroughHoldState
+    {
+        public DispatcherTimer? Timer;
+        public bool IsActive;
+        public bool PageDown;
+        public Point PointerPosition; // last pointer position, in scroll bar coordinates
+    }
+
+    private static void StartTroughHoldPaging(DataGrid grid, ScrollBar verticalScrollBar, TroughHoldState holdState, PointerPressedEventArgs e)
+    {
+        if (holdState.IsActive ||
+            !e.GetCurrentPoint(verticalScrollBar).Properties.IsLeftButtonPressed ||
+            !TryGetTroughPress(verticalScrollBar, e, out _, out _, out var isBelowThumb))
+        {
+            return;
+        }
+
+        holdState.IsActive = true;
+        holdState.PageDown = isBelowThumb;
+        holdState.PointerPosition = e.GetPosition(verticalScrollBar);
+        e.Pointer.Capture(verticalScrollBar);
+
+        PageOnce(grid, verticalScrollBar, isBelowThumb);
+
+        // First repeat after the RepeatButton default delay, then its default rate, so the
+        // grid's trough feels the same as every other Avalonia scroll bar in the app.
+        var timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(300) };
+        timer.Tick += (_, _) =>
+        {
+            timer.Interval = TimeSpan.FromMilliseconds(100);
+            TickTroughHoldPaging(grid, verticalScrollBar, holdState);
+        };
+        holdState.Timer = timer;
+        timer.Start();
+
+        // Keep the trough repeat button from setting IsPressed and starting its own repeat.
+        e.Handled = true;
+    }
+
+    private static void TickTroughHoldPaging(DataGrid grid, ScrollBar verticalScrollBar, TroughHoldState holdState)
+    {
+        var track = verticalScrollBar.GetVisualDescendants().OfType<Track>().FirstOrDefault();
+        var thumb = track?.Thumb;
+        if (track == null || thumb == null)
+        {
+            return;
+        }
+
+        var posY = verticalScrollBar.TranslatePoint(holdState.PointerPosition, track)?.Y;
+        if (posY == null)
+        {
+            return;
+        }
+
+        // Pause (not stop) once the thumb has reached the pointer: paging resumes if the
+        // pointer moves further in the latched direction, like the Windows scroll bar.
+        var shouldPage = holdState.PageDown
+            ? posY > thumb.Bounds.Y + thumb.Bounds.Height
+            : posY < thumb.Bounds.Y;
+        if (shouldPage)
+        {
+            PageOnce(grid, verticalScrollBar, holdState.PageDown);
+        }
+    }
+
+    private static void PageOnce(DataGrid grid, ScrollBar verticalScrollBar, bool pageDown)
+    {
+        var delta = pageDown ? verticalScrollBar.LargeChange : -verticalScrollBar.LargeChange;
+        verticalScrollBar.Value = Math.Clamp(verticalScrollBar.Value + delta, verticalScrollBar.Minimum, verticalScrollBar.Maximum);
+        ProcessVerticalScrollMethod?.Invoke(grid, new object[] { ScrollEventType.EndScroll });
+    }
+
+    private static void StopTroughHoldPaging(TroughHoldState holdState)
+    {
+        holdState.Timer?.Stop();
+        holdState.Timer = null;
+        holdState.IsActive = false;
     }
 
     private static void JumpToClickPosition(DataGrid grid, ScrollBar verticalScrollBar, PointerPressedEventArgs e)
     {
-        if ((e.KeyModifiers & KeyModifiers.Shift) == 0 ||
-            !e.GetCurrentPoint(verticalScrollBar).Properties.IsLeftButtonPressed)
+        if (!e.GetCurrentPoint(verticalScrollBar).Properties.IsLeftButtonPressed ||
+            !TryGetTroughPress(verticalScrollBar, e, out var track, out var posY, out _))
         {
             return;
-        }
-
-        var track = verticalScrollBar.GetVisualDescendants().OfType<Track>().FirstOrDefault();
-        if (track == null || track.Bounds.Height <= 0)
-        {
-            return;
-        }
-
-        var range = verticalScrollBar.Maximum - verticalScrollBar.Minimum;
-        if (double.IsNaN(range) || range <= 0)
-        {
-            return;
-        }
-
-        // Only a trough click should jump. Ignore clicks that land outside the track (the line
-        // step arrows) or on the thumb itself (which begins a normal drag); without this guard a
-        // Shift+click on an arrow or the thumb would fling the view to min or max. (#12438 review)
-        var posY = e.GetPosition(track).Y;
-        if (posY < 0 || posY > track.Bounds.Height)
-        {
-            return;
-        }
-
-        var thumb = track.Thumb;
-        if (thumb != null)
-        {
-            var thumbTop = thumb.Bounds.Y;
-            if (posY >= thumbTop && posY <= thumbTop + thumb.Bounds.Height)
-            {
-                return;
-            }
         }
 
         // Center the thumb on the cursor: subtract half the thumb length and scale by the
         // travel the thumb actually has (track height minus thumb length).
-        var thumbLength = thumb?.Bounds.Height ?? 0;
+        var range = verticalScrollBar.Maximum - verticalScrollBar.Minimum;
+        var thumbLength = track.Thumb?.Bounds.Height ?? 0;
         var travel = Math.Max(1, track.Bounds.Height - thumbLength);
         var offset = posY - (thumbLength / 2.0);
         var fraction = Math.Clamp(offset / travel, 0.0, 1.0);
@@ -149,6 +244,59 @@ public static class DataGridScrollBarBehavior
 
         ProcessVerticalScrollMethod?.Invoke(grid, new object[] { ScrollEventType.EndScroll });
         e.Handled = true;
+    }
+
+    /// <summary>
+    /// Returns the track and the press's track-relative Y for a genuine trough press, or
+    /// false for presses outside the track (the line step arrows), on the thumb itself
+    /// (which begins a normal drag), or when there is nothing to scroll; without this guard
+    /// a press on an arrow or the thumb would jump or page unexpectedly. (#12438 review)
+    /// Shared by the shift+click jump and the plain press hold-paging so both agree on
+    /// what counts as the trough.
+    /// </summary>
+    private static bool TryGetTroughPress(ScrollBar verticalScrollBar, PointerEventArgs e, out Track track, out double posY, out bool isBelowThumb)
+    {
+        track = null!;
+        posY = 0;
+        isBelowThumb = false;
+
+        var foundTrack = verticalScrollBar.GetVisualDescendants().OfType<Track>().FirstOrDefault();
+        if (foundTrack == null || foundTrack.Bounds.Height <= 0)
+        {
+            return false;
+        }
+
+        var range = verticalScrollBar.Maximum - verticalScrollBar.Minimum;
+        if (double.IsNaN(range) || range <= 0)
+        {
+            return false;
+        }
+
+        var y = e.GetPosition(foundTrack).Y;
+        if (y < 0 || y > foundTrack.Bounds.Height)
+        {
+            return false;
+        }
+
+        var thumb = foundTrack.Thumb;
+        if (thumb != null)
+        {
+            var thumbTop = thumb.Bounds.Y;
+            if (y >= thumbTop && y <= thumbTop + thumb.Bounds.Height)
+            {
+                return false;
+            }
+
+            isBelowThumb = y > thumbTop + thumb.Bounds.Height;
+        }
+        else
+        {
+            isBelowThumb = true;
+        }
+
+        track = foundTrack;
+        posY = y;
+        return true;
     }
 
     private static void SyncLargeChange(ScrollBar verticalScrollBar)

--- a/src/ui/Logic/DataGridScrollBarBehavior.cs
+++ b/src/ui/Logic/DataGridScrollBarBehavior.cs
@@ -28,16 +28,18 @@ namespace Nikse.SubtitleEdit.Logic;
 /// The DataGrid hooks the scroll bar's Scroll event (not ValueChanged) to refresh its
 /// rows, so a programmatic jump also invokes the grid's internal ProcessVerticalScroll.
 ///
-/// Press-and-hold on the trough is also handled here rather than left to the theme's
-/// trough RepeatButton. That button keeps repeating while IsPressed, and Button only
-/// re-evaluates IsPressed on PointerMoved — with a stationary cursor no move event
-/// arrives as the thumb slides under it, so it pages straight past the cursor to the
-/// end. This class pages toward the cursor and pauses when the thumb reaches it,
-/// resuming only if the pointer moves further along, like the Windows scroll bar.
+/// Press-and-hold is handled here too: the theme's trough RepeatButton repeats while
+/// IsPressed, and Button only re-evaluates IsPressed on PointerMoved, so with a stationary
+/// cursor it pages past the cursor to the end (issue #12894). This pages toward the cursor
+/// and pauses when the thumb reaches it.
 /// </summary>
 public static class DataGridScrollBarBehavior
 {
     private const string VerticalScrollBarPartName = "PART_VerticalScrollbar";
+
+    // Avalonia's RepeatButton defaults, so the trough repeats like every other scroll bar.
+    private static readonly TimeSpan RepeatDelay = TimeSpan.FromMilliseconds(300);
+    private static readonly TimeSpan RepeatInterval = TimeSpan.FromMilliseconds(100);
 
     private static readonly MethodInfo? ProcessVerticalScrollMethod = typeof(DataGrid).GetMethod(
         "ProcessVerticalScroll",
@@ -57,6 +59,10 @@ public static class DataGridScrollBarBehavior
     // scroll bar once, and the discarded template's scroll bar (with its handlers) is dropped.
     private static readonly AttachedProperty<bool> WiredProperty =
         AvaloniaProperty.RegisterAttached<DataGrid, bool>("TroughPagingWired", typeof(DataGridScrollBarBehavior));
+
+    // Non-null only while the left button is held on that scroll bar's trough.
+    private static readonly AttachedProperty<TroughHoldState?> HoldStateProperty =
+        AvaloniaProperty.RegisterAttached<ScrollBar, TroughHoldState?>("TroughHoldState", typeof(DataGridScrollBarBehavior));
 
     public static void SetEnableTroughPaging(DataGrid grid, bool value) => grid.SetValue(EnableTroughPagingProperty, value);
 
@@ -97,13 +103,7 @@ public static class DataGridScrollBarBehavior
                 }
             };
 
-            // One state instance per applied template: a re-template wires a fresh scroll
-            // bar with fresh state, and the discarded template's timer dies with its capture.
-            var holdState = new TroughHoldState();
-
-            // Shift + trough click jumps to the click position, a plain trough press pages
-            // and repeats toward the cursor, both matching the Windows scroll bar. Tunnel so
-            // this runs before the theme's trough repeat button can engage.
+            // Tunnel so this runs before the theme's trough repeat button can engage.
             verticalScrollBar.AddHandler(
                 InputElement.PointerPressedEvent,
                 (_, args) =>
@@ -114,118 +114,149 @@ public static class DataGridScrollBarBehavior
                     }
                     else
                     {
-                        StartTroughHoldPaging(grid, verticalScrollBar, holdState, args);
+                        StartTroughHoldPaging(grid, verticalScrollBar, args);
                     }
                 },
                 RoutingStrategies.Tunnel);
 
             verticalScrollBar.PointerMoved += (_, args) =>
             {
-                if (holdState.IsActive)
+                if (GetHoldState(verticalScrollBar) is { } state)
                 {
-                    holdState.PointerPosition = args.GetPosition(verticalScrollBar);
+                    state.PointerPosition = args.GetPosition(verticalScrollBar);
                 }
             };
 
             verticalScrollBar.PointerReleased += (_, args) =>
             {
-                if (holdState.IsActive && args.InitialPressMouseButton == MouseButton.Left)
+                if (GetHoldState(verticalScrollBar) != null && args.InitialPressMouseButton == MouseButton.Left)
                 {
-                    StopTroughHoldPaging(holdState);
+                    StopTroughHoldPaging(verticalScrollBar);
                     args.Pointer.Capture(null);
                     args.Handled = true;
                 }
             };
 
-            verticalScrollBar.PointerCaptureLost += (_, _) => StopTroughHoldPaging(holdState);
+            // Covers a release outside the window, window deactivation and a re-template mid-hold.
+            verticalScrollBar.PointerCaptureLost += (_, _) => StopTroughHoldPaging(verticalScrollBar);
         };
     }
 
-    // Per scroll bar state for a press-and-hold on the trough, captured by that scroll
-    // bar's handlers. The direction is latched at press time (Windows-style) because
-    // re-deciding it per tick would ping-pong around the cursor once a page overshoots.
+    // State for a press-and-hold on one scroll bar's trough. The direction is latched at press
+    // time (Windows-style): re-deciding it per tick would ping-pong once a page overshoots.
     private sealed class TroughHoldState
     {
-        public DispatcherTimer? Timer;
-        public bool IsActive;
-        public bool PageDown;
-        public Point PointerPosition; // last pointer position, in scroll bar coordinates
+        public required DispatcherTimer Timer { get; init; }
+        public required IPointer Pointer { get; init; }
+        public required Track Track { get; init; }
+        public required bool PageDown { get; init; }
+        public Point PointerPosition { get; set; } // in scroll bar coordinates
     }
 
-    private static void StartTroughHoldPaging(DataGrid grid, ScrollBar verticalScrollBar, TroughHoldState holdState, PointerPressedEventArgs e)
+    private static void StartTroughHoldPaging(DataGrid grid, ScrollBar verticalScrollBar, PointerPressedEventArgs e)
     {
-        if (holdState.IsActive ||
+        // Without ProcessVerticalScroll a page would move the thumb but not the rows, so leave
+        // the press to the theme's repeat button instead of swallowing it.
+        if (ProcessVerticalScrollMethod == null ||
+            GetHoldState(verticalScrollBar) != null ||
             !e.GetCurrentPoint(verticalScrollBar).Properties.IsLeftButtonPressed ||
-            !TryGetTroughPress(verticalScrollBar, e, out _, out _, out var isBelowThumb))
+            !TryGetTroughPress(verticalScrollBar, e, out var track, out _, out var isBelowThumb))
         {
             return;
         }
 
-        holdState.IsActive = true;
-        holdState.PageDown = isBelowThumb;
-        holdState.PointerPosition = e.GetPosition(verticalScrollBar);
-        e.Pointer.Capture(verticalScrollBar);
+        var timer = new DispatcherTimer { Interval = RepeatDelay };
+        var state = new TroughHoldState
+        {
+            Timer = timer,
+            Pointer = e.Pointer,
+            Track = track,
+            PageDown = isBelowThumb,
+            PointerPosition = e.GetPosition(verticalScrollBar),
+        };
 
-        PageOnce(grid, verticalScrollBar, isBelowThumb);
-
-        // First repeat after the RepeatButton default delay, then its default rate, so the
-        // grid's trough feels the same as every other Avalonia scroll bar in the app.
-        var timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(300) };
         timer.Tick += (_, _) =>
         {
-            timer.Interval = TimeSpan.FromMilliseconds(100);
-            TickTroughHoldPaging(grid, verticalScrollBar, holdState);
+            timer.Interval = RepeatInterval;
+            TickTroughHoldPaging(grid, verticalScrollBar, state);
         };
-        holdState.Timer = timer;
+
+        verticalScrollBar.SetValue(HoldStateProperty, state);
+        e.Pointer.Capture(verticalScrollBar);
+        PageOnce(grid, verticalScrollBar, state.PageDown);
         timer.Start();
 
         // Keep the trough repeat button from setting IsPressed and starting its own repeat.
         e.Handled = true;
     }
 
-    private static void TickTroughHoldPaging(DataGrid grid, ScrollBar verticalScrollBar, TroughHoldState holdState)
+    private static void TickTroughHoldPaging(DataGrid grid, ScrollBar verticalScrollBar, TroughHoldState state)
     {
-        var track = verticalScrollBar.GetVisualDescendants().OfType<Track>().FirstOrDefault();
-        var thumb = track?.Thumb;
-        if (track == null || thumb == null)
+        // A missed release, or a capture taken elsewhere, must not leave the timer paging.
+        if (state.Pointer.Captured != verticalScrollBar)
         {
+            StopTroughHoldPaging(verticalScrollBar);
             return;
         }
 
-        var posY = verticalScrollBar.TranslatePoint(holdState.PointerPosition, track)?.Y;
-        if (posY == null)
+        var thumb = state.Track.Thumb;
+        var posY = verticalScrollBar.TranslatePoint(state.PointerPosition, state.Track)?.Y;
+        if (thumb == null || posY == null)
         {
             return;
         }
 
         // Pause (not stop) once the thumb has reached the pointer: paging resumes if the
         // pointer moves further in the latched direction, like the Windows scroll bar.
-        var shouldPage = holdState.PageDown
-            ? posY > thumb.Bounds.Y + thumb.Bounds.Height
-            : posY < thumb.Bounds.Y;
-        if (shouldPage)
+        if (ShouldPage(posY.Value, thumb.Bounds, state.PageDown))
         {
-            PageOnce(grid, verticalScrollBar, holdState.PageDown);
+            PageOnce(grid, verticalScrollBar, state.PageDown);
         }
+    }
+
+    private static bool ShouldPage(double posY, Rect thumbBounds, bool pageDown)
+    {
+        return pageDown ? posY > thumbBounds.Bottom : posY < thumbBounds.Top;
     }
 
     private static void PageOnce(DataGrid grid, ScrollBar verticalScrollBar, bool pageDown)
     {
         var delta = pageDown ? verticalScrollBar.LargeChange : -verticalScrollBar.LargeChange;
-        verticalScrollBar.Value = Math.Clamp(verticalScrollBar.Value + delta, verticalScrollBar.Minimum, verticalScrollBar.Maximum);
+        var newValue = Math.Clamp(verticalScrollBar.Value + delta, verticalScrollBar.Minimum, verticalScrollBar.Maximum);
+        if (newValue == verticalScrollBar.Value)
+        {
+            return;
+        }
+
+        verticalScrollBar.Value = newValue;
         ProcessVerticalScrollMethod?.Invoke(grid, new object[] { ScrollEventType.EndScroll });
     }
 
-    private static void StopTroughHoldPaging(TroughHoldState holdState)
+    private static TroughHoldState? GetHoldState(ScrollBar verticalScrollBar) => verticalScrollBar.GetValue(HoldStateProperty);
+
+    private static void StopTroughHoldPaging(ScrollBar verticalScrollBar)
     {
-        holdState.Timer?.Stop();
-        holdState.Timer = null;
-        holdState.IsActive = false;
+        if (GetHoldState(verticalScrollBar) is { } state)
+        {
+            state.Timer.Stop();
+            verticalScrollBar.SetValue(HoldStateProperty, null);
+        }
+    }
+
+    // The headless test dispatcher never fires a DispatcherTimer, so the tests step the repeat
+    // by hand (DataGridScrollBarTroughPagingTests).
+    internal static void TickTroughHoldPagingForTest(DataGrid grid, ScrollBar verticalScrollBar)
+    {
+        if (GetHoldState(verticalScrollBar) is { } state)
+        {
+            TickTroughHoldPaging(grid, verticalScrollBar, state);
+        }
     }
 
     private static void JumpToClickPosition(DataGrid grid, ScrollBar verticalScrollBar, PointerPressedEventArgs e)
     {
-        if (!e.GetCurrentPoint(verticalScrollBar).Properties.IsLeftButtonPressed ||
+        if (ProcessVerticalScrollMethod == null ||
+            !e.GetCurrentPoint(verticalScrollBar).Properties.IsLeftButtonPressed ||
             !TryGetTroughPress(verticalScrollBar, e, out var track, out var posY, out _))
         {
             return;
@@ -242,17 +273,15 @@ public static class DataGridScrollBarBehavior
         var newValue = verticalScrollBar.Minimum + (fraction * range);
         verticalScrollBar.Value = Math.Clamp(newValue, verticalScrollBar.Minimum, verticalScrollBar.Maximum);
 
-        ProcessVerticalScrollMethod?.Invoke(grid, new object[] { ScrollEventType.EndScroll });
+        ProcessVerticalScrollMethod.Invoke(grid, new object[] { ScrollEventType.EndScroll });
         e.Handled = true;
     }
 
     /// <summary>
-    /// Returns the track and the press's track-relative Y for a genuine trough press, or
-    /// false for presses outside the track (the line step arrows), on the thumb itself
-    /// (which begins a normal drag), or when there is nothing to scroll; without this guard
-    /// a press on an arrow or the thumb would jump or page unexpectedly. (#12438 review)
-    /// Shared by the shift+click jump and the plain press hold-paging so both agree on
-    /// what counts as the trough.
+    /// Returns the track and the press's track-relative Y for a genuine trough press, or false
+    /// for presses outside the track (the line step arrows), on the thumb itself (which begins a
+    /// normal drag), or when there is nothing to scroll (#12438 review). Shared by the shift+click
+    /// jump and the hold paging so both agree on what counts as the trough.
     /// </summary>
     private static bool TryGetTroughPress(ScrollBar verticalScrollBar, PointerEventArgs e, out Track track, out double posY, out bool isBelowThumb)
     {
@@ -281,13 +310,12 @@ public static class DataGridScrollBarBehavior
         var thumb = foundTrack.Thumb;
         if (thumb != null)
         {
-            var thumbTop = thumb.Bounds.Y;
-            if (y >= thumbTop && y <= thumbTop + thumb.Bounds.Height)
+            if (y >= thumb.Bounds.Top && y <= thumb.Bounds.Bottom)
             {
                 return false;
             }
 
-            isBelowThumb = y > thumbTop + thumb.Bounds.Height;
+            isBelowThumb = y > thumb.Bounds.Bottom;
         }
         else
         {

--- a/tests/UI/Logic/DataGridScrollBarTroughPagingTests.cs
+++ b/tests/UI/Logic/DataGridScrollBarTroughPagingTests.cs
@@ -13,10 +13,10 @@ using Nikse.SubtitleEdit.Logic;
 namespace UITests.Logic;
 
 /// <summary>
-/// A plain press on the trough of a DataGrid's vertical scroll bar must page exactly one
-/// viewport toward the cursor and stop paging on release. The theme's trough RepeatButton
-/// kept repeating past the cursor to the end because Button only re-evaluates IsPressed
-/// on PointerMoved, so DataGridScrollBarBehavior handles the press itself (#12438 follow-up).
+/// A press on the trough of a DataGrid's vertical scroll bar pages toward the cursor and pauses
+/// when the thumb reaches it, instead of running to the end of the list like the theme's trough
+/// RepeatButton did (#12894). The headless dispatcher never fires a DispatcherTimer, so the
+/// repeats are stepped by hand through TickTroughHoldPagingForTest.
 /// </summary>
 public class DataGridScrollBarTroughPagingTests
 {
@@ -57,14 +57,38 @@ public class DataGridScrollBarTroughPagingTests
         return (window, grid, scrollBar);
     }
 
+    private static Track TrackOf(ScrollBar scrollBar) => scrollBar.GetVisualDescendants().OfType<Track>().First();
+
+    // A point centered horizontally, at the given fraction down the track, in window coordinates.
+    private static Point TrackPoint(Window window, ScrollBar scrollBar, double fraction)
+    {
+        var track = TrackOf(scrollBar);
+        return track.TranslatePoint(new Point(track.Bounds.Width / 2, track.Bounds.Height * fraction), window)!.Value;
+    }
+
     private static Point TroughPointBelowThumb(Window window, ScrollBar scrollBar)
     {
-        var track = scrollBar.GetVisualDescendants().OfType<Track>().First();
-        var thumb = track.Thumb!;
+        var track = TrackOf(scrollBar);
 
-        // A point centered horizontally, well below the thumb (Value is 0, thumb at top).
-        var yInTrack = (thumb.Bounds.Y + thumb.Bounds.Height + track.Bounds.Height) / 2;
+        // Well below the thumb, which sits at the top while Value is 0.
+        var yInTrack = (track.Thumb!.Bounds.Bottom + track.Bounds.Height) / 2;
         return track.TranslatePoint(new Point(track.Bounds.Width / 2, yInTrack), window)!.Value;
+    }
+
+    private static void Repeat(Window window, DataGrid grid, ScrollBar scrollBar, int ticks)
+    {
+        for (var i = 0; i < ticks; i++)
+        {
+            DataGridScrollBarBehavior.TickTroughHoldPagingForTest(grid, scrollBar);
+            window.UpdateLayout();
+        }
+    }
+
+    // True once the thumb has caught up with the pointer, so paging should have paused.
+    private static bool ThumbReached(Window window, ScrollBar scrollBar, Point windowPoint)
+    {
+        var track = TrackOf(scrollBar);
+        return track.Thumb!.Bounds.Bottom >= window.TranslatePoint(windowPoint, track)!.Value.Y;
     }
 
     [AvaloniaFact]
@@ -72,13 +96,67 @@ public class DataGridScrollBarTroughPagingTests
     {
         var (window, _, scrollBar) = BuildShownGrid();
         Assert.True(scrollBar.Maximum > 0, "grid should have enough rows to scroll");
+        Assert.True(scrollBar.LargeChange > 1, "LargeChange should follow the viewport, not RangeBase's default");
         Assert.Equal(0, scrollBar.Value);
 
         var point = TroughPointBelowThumb(window, scrollBar);
         window.MouseDown(point, MouseButton.Left);
 
-        // One immediate page of one viewport; the repeat timer has not ticked yet.
+        // One immediate page of one viewport; the repeat has not been stepped yet.
         Assert.Equal(scrollBar.LargeChange, scrollBar.Value, 3);
+
+        window.MouseUp(point, MouseButton.Left);
+    }
+
+    [AvaloniaFact]
+    public void TroughHold_PausesWhenThumbReachesPointer()
+    {
+        var (window, grid, scrollBar) = BuildShownGrid();
+
+        var point = TroughPointBelowThumb(window, scrollBar);
+        window.MouseDown(point, MouseButton.Left);
+        Repeat(window, grid, scrollBar, 50);
+
+        Assert.True(ThumbReached(window, scrollBar, point), "the thumb should have reached the pointer");
+        Assert.True(scrollBar.Value > 0, "the hold should have paged");
+        Assert.True(scrollBar.Value < scrollBar.Maximum, $"paging ran past the pointer to the end ({scrollBar.Value} of {scrollBar.Maximum})");
+
+        window.MouseUp(point, MouseButton.Left);
+    }
+
+    [AvaloniaFact]
+    public void TroughHold_ResumesWhenPointerMovesFurther()
+    {
+        var (window, grid, scrollBar) = BuildShownGrid();
+
+        var point = TroughPointBelowThumb(window, scrollBar);
+        window.MouseDown(point, MouseButton.Left);
+        Repeat(window, grid, scrollBar, 50);
+        var pausedValue = scrollBar.Value;
+
+        var lower = TrackPoint(window, scrollBar, 0.95);
+        window.MouseMove(lower);
+        Repeat(window, grid, scrollBar, 50);
+
+        Assert.True(scrollBar.Value > pausedValue, "paging should resume when the pointer moves further down");
+
+        window.MouseUp(lower, MouseButton.Left);
+    }
+
+    [AvaloniaFact]
+    public void TroughHold_DoesNotReverseWhenPointerMovesBack()
+    {
+        var (window, grid, scrollBar) = BuildShownGrid();
+
+        var point = TroughPointBelowThumb(window, scrollBar);
+        window.MouseDown(point, MouseButton.Left);
+        Repeat(window, grid, scrollBar, 50);
+        var pausedValue = scrollBar.Value;
+
+        window.MouseMove(TrackPoint(window, scrollBar, 0.0));
+        Repeat(window, grid, scrollBar, 10);
+
+        Assert.Equal(pausedValue, scrollBar.Value);
 
         window.MouseUp(point, MouseButton.Left);
     }
@@ -86,16 +164,14 @@ public class DataGridScrollBarTroughPagingTests
     [AvaloniaFact]
     public void TroughRelease_StopsPaging()
     {
-        var (window, _, scrollBar) = BuildShownGrid();
+        var (window, grid, scrollBar) = BuildShownGrid();
 
         var point = TroughPointBelowThumb(window, scrollBar);
         window.MouseDown(point, MouseButton.Left);
         window.MouseUp(point, MouseButton.Left);
 
         var valueAfterRelease = scrollBar.Value;
-        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
-        AvaloniaHeadlessPlatform.ForceRenderTimerTick();
-        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        Repeat(window, grid, scrollBar, 10);
 
         Assert.Equal(valueAfterRelease, scrollBar.Value);
     }
@@ -103,15 +179,17 @@ public class DataGridScrollBarTroughPagingTests
     [AvaloniaFact]
     public void ThumbPress_DoesNotPage()
     {
-        var (window, _, scrollBar) = BuildShownGrid();
+        var (window, grid, scrollBar) = BuildShownGrid();
 
-        var track = scrollBar.GetVisualDescendants().OfType<Track>().First();
-        var thumb = track.Thumb!;
+        var thumb = TrackOf(scrollBar).Thumb!;
         var thumbCenter = thumb.TranslatePoint(
             new Point(thumb.Bounds.Width / 2, thumb.Bounds.Height / 2), window)!.Value;
 
         window.MouseDown(thumbCenter, MouseButton.Left);
+        Repeat(window, grid, scrollBar, 10);
+
         Assert.Equal(0, scrollBar.Value);
+
         window.MouseUp(thumbCenter, MouseButton.Left);
     }
 }

--- a/tests/UI/Logic/DataGridScrollBarTroughPagingTests.cs
+++ b/tests/UI/Logic/DataGridScrollBarTroughPagingTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml.Styling;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// A plain press on the trough of a DataGrid's vertical scroll bar must page exactly one
+/// viewport toward the cursor and stop paging on release. The theme's trough RepeatButton
+/// kept repeating past the cursor to the end because Button only re-evaluates IsPressed
+/// on PointerMoved, so DataGridScrollBarBehavior handles the press itself (#12438 follow-up).
+/// </summary>
+public class DataGridScrollBarTroughPagingTests
+{
+    private sealed record Row(int Number, string Text);
+
+    private static (Window window, DataGrid grid, ScrollBar scrollBar) BuildShownGrid()
+    {
+        // The TestApp only loads the base Fluent theme; the DataGrid template lives in its
+        // own package theme, loaded the same way Program.cs does for the real app. Must be
+        // in place before the grid attaches to a window - control themes resolve on attach.
+        if (Application.Current!.Styles.OfType<StyleInclude>().All(s => s.Source?.ToString().Contains("DataGrid") != true))
+        {
+            Application.Current.Styles.Add(new StyleInclude(new Uri("avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml", UriKind.Absolute))
+            {
+                Source = new Uri("avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml")
+            });
+        }
+
+        var grid = new DataGrid
+        {
+            ItemsSource = Enumerable.Range(1, 200).Select(i => new Row(i, $"Line {i}")).ToList(),
+            Columns =
+            {
+                new DataGridTextColumn { Header = "#", Binding = new Avalonia.Data.Binding(nameof(Row.Number)) },
+                new DataGridTextColumn { Header = "Text", Binding = new Avalonia.Data.Binding(nameof(Row.Text)) },
+            },
+        };
+        DataGridScrollBarBehavior.SetEnableTroughPaging(grid, true);
+
+        var window = new Window { Content = grid, Width = 400, Height = 300 };
+        window.Show();
+        window.UpdateLayout();
+        AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        var scrollBar = grid.GetVisualDescendants().OfType<ScrollBar>()
+            .First(s => s.Name == "PART_VerticalScrollbar");
+        return (window, grid, scrollBar);
+    }
+
+    private static Point TroughPointBelowThumb(Window window, ScrollBar scrollBar)
+    {
+        var track = scrollBar.GetVisualDescendants().OfType<Track>().First();
+        var thumb = track.Thumb!;
+
+        // A point centered horizontally, well below the thumb (Value is 0, thumb at top).
+        var yInTrack = (thumb.Bounds.Y + thumb.Bounds.Height + track.Bounds.Height) / 2;
+        return track.TranslatePoint(new Point(track.Bounds.Width / 2, yInTrack), window)!.Value;
+    }
+
+    [AvaloniaFact]
+    public void TroughPress_PagesExactlyOneViewport()
+    {
+        var (window, _, scrollBar) = BuildShownGrid();
+        Assert.True(scrollBar.Maximum > 0, "grid should have enough rows to scroll");
+        Assert.Equal(0, scrollBar.Value);
+
+        var point = TroughPointBelowThumb(window, scrollBar);
+        window.MouseDown(point, MouseButton.Left);
+
+        // One immediate page of one viewport; the repeat timer has not ticked yet.
+        Assert.Equal(scrollBar.LargeChange, scrollBar.Value, 3);
+
+        window.MouseUp(point, MouseButton.Left);
+    }
+
+    [AvaloniaFact]
+    public void TroughRelease_StopsPaging()
+    {
+        var (window, _, scrollBar) = BuildShownGrid();
+
+        var point = TroughPointBelowThumb(window, scrollBar);
+        window.MouseDown(point, MouseButton.Left);
+        window.MouseUp(point, MouseButton.Left);
+
+        var valueAfterRelease = scrollBar.Value;
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(valueAfterRelease, scrollBar.Value);
+    }
+
+    [AvaloniaFact]
+    public void ThumbPress_DoesNotPage()
+    {
+        var (window, _, scrollBar) = BuildShownGrid();
+
+        var track = scrollBar.GetVisualDescendants().OfType<Track>().First();
+        var thumb = track.Thumb!;
+        var thumbCenter = thumb.TranslatePoint(
+            new Point(thumb.Bounds.Width / 2, thumb.Bounds.Height / 2), window)!.Value;
+
+        window.MouseDown(thumbCenter, MouseButton.Left);
+        Assert.Equal(0, scrollBar.Value);
+        window.MouseUp(thumbCenter, MouseButton.Left);
+    }
+}


### PR DESCRIPTION
Fixes #12894

## Summary
- Click-and-hold on a DataGrid vertical scroll bar trough paged straight past the cursor to the end of the list. The theme's trough RepeatButton keeps repeating while IsPressed, and Button only re-evaluates IsPressed on PointerMoved, so with a stationary cursor the repeat never stopped. Invisible before #12051 (LargeChange was 1 px per tick); obvious now that a trough click pages a full viewport.
- DataGridScrollBarBehavior now handles the plain (non-shift) trough press itself: pages once immediately, repeats on a DispatcherTimer (300 ms delay, then 100 ms — Avalonia's RepeatButton defaults), and pauses when the thumb reaches the pointer, resuming only if the pointer moves further along, matching the Windows scroll bar. The paging direction is latched at press time so an overshoot cannot ping-pong around the cursor.
- Paging stops on pointer release (also outside the window, via pointer capture) and on capture loss (window deactivation, re-template mid-hold).
- Extracted the existing trough hit-testing into a shared TryGetTroughPress helper used by both the new hold paging and the shipped shift+click jump, so thumb drags, line arrows, and shift+click are unchanged.
- Added headless tests: a trough press pages exactly one viewport, release stops paging, and a press on the thumb does not page.

## Test plan
- [x] `dotnet test tests/UI/UITests.csproj` — all tests pass (3 new in DataGridScrollBarTroughPagingTests)
- [x] Load a subtitle long enough to scroll; click-hold the trough below the thumb without moving the mouse: paging pauses when the thumb reaches the cursor instead of running to the end
- [x] Still holding, move the pointer further down: paging resumes; move it above the thumb: it stays paused (no reverse)
- [x] Single trough click scrolls exactly one page; Shift+trough click still jumps to position; thumb drag, arrow buttons, and mouse wheel unchanged
- [x] Same behavior in another grid (Options → Shortcuts), since the style is app-wide
- [x] Release the mouse outside the window mid-hold and Alt+Tab mid-hold: paging stops both times

🤖 Generated with [Claude Code](https://claude.com/claude-code)