### PR TITLE
Add sync point time code box to Set sync point (SE4 parity)

### DIFF
--- a/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
+++ b/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
@@ -1,8 +1,10 @@
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Controls;
 using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
 using Nikse.SubtitleEdit.Controls.VideoPlayer;
 using Nikse.SubtitleEdit.Features.Main;
@@ -26,6 +28,7 @@ public partial class SetSyncPointViewModel : ObservableObject
     [ObservableProperty] private bool _isAudioVisualizerVisible;
     [ObservableProperty] private string _title;
     [ObservableProperty] private string _videoInfo;
+    [ObservableProperty] private TimeSpan _syncPointTimeCode;
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
@@ -33,6 +36,7 @@ public partial class SetSyncPointViewModel : ObservableObject
     public VideoPlayerControl VideoPlayerControl { get; set; }
     public AudioVisualizer AudioVisualizer { get; set; }
     public ComboBox ComboBoxSubtitle { get; set; }
+    public TimeCodeUpDown TimeCodeUpDownSyncPoint { get; set; }
 
     private readonly IWindowService _windowService;
 
@@ -40,6 +44,8 @@ public partial class SetSyncPointViewModel : ObservableObject
     private DispatcherTimer _positionTimer = new DispatcherTimer();
     private List<SubtitleLineViewModel> _subtitleLines = new List<SubtitleLineViewModel>();
     private bool _updateAudioVisualizer;
+    private bool _updateTimeCodeFromVideo;
+    private bool _timeCodeUpDownFocused;
 
     public SetSyncPointViewModel(IWindowService windowService)
     {
@@ -51,6 +57,7 @@ public partial class SetSyncPointViewModel : ObservableObject
         VideoPlayerControl = new VideoPlayerControl(new EmptyVideoPlayer());
         AudioVisualizer = new AudioVisualizer();
         ComboBoxSubtitle = new ComboBox();
+        TimeCodeUpDownSyncPoint = new TimeCodeUpDown();
         Paragraphs = new ObservableCollection<SubtitleDisplayItem>();
 
         // Toggle play/pause on surface click
@@ -129,6 +136,14 @@ public partial class SetSyncPointViewModel : ObservableObject
         {
             UpdateAudioVisualizer(VideoPlayerControl.VideoPlayer, AudioVisualizer, SelectedParagraphIndex);
 
+            // Follow the video position - but leave the time code alone while the user is typing
+            // in it (a running video moves on its own, so then the box should still follow).
+            var isEditingTimeCode = TimeCodeUpDownSyncPoint.IsKeyboardFocusWithin && !VideoPlayerControl.IsPlaying;
+            if (!isEditingTimeCode)
+            {
+                UpdateTimeCodeFromVideoPosition();
+            }
+
             if (_updateAudioVisualizer)
             {
                 AudioVisualizer.InvalidateVisual();
@@ -178,38 +193,71 @@ public partial class SetSyncPointViewModel : ObservableObject
         }
     }
 
+    /// <summary>
+    /// Single entry point for moving the video - keeps the sync point time code box in sync
+    /// with the video position, also while the box has focus (where the timer leaves it alone).
+    /// </summary>
+    private void SetVideoPosition(double seconds)
+    {
+        VideoPlayerControl.Position = Math.Max(0, seconds);
+        UpdateTimeCodeFromVideoPosition();
+        _updateAudioVisualizer = true;
+    }
+
+    private void UpdateTimeCodeFromVideoPosition()
+    {
+        var position = TimeSpan.FromSeconds(Math.Max(0, VideoPlayerControl.Position));
+        if (Math.Abs((position - SyncPointTimeCode).TotalMilliseconds) < 1)
+        {
+            return;
+        }
+
+        _updateTimeCodeFromVideo = true;
+        SyncPointTimeCode = position;
+        _updateTimeCodeFromVideo = false;
+    }
+
+    partial void OnSyncPointTimeCodeChanged(TimeSpan value)
+    {
+        if (_updateTimeCodeFromVideo)
+        {
+            return;
+        }
+
+        // The user typed/spun a new time code - move the video there
+        VideoPlayerControl.Position = Math.Max(0, value.TotalSeconds);
+        _updateAudioVisualizer = true;
+    }
+
     [RelayCommand]
     private void LeftOneSecondBack()
     {
-        VideoPlayerControl.Position = Math.Max(0, VideoPlayerControl.Position - 1);
-        _updateAudioVisualizer = true;
+        SetVideoPosition(VideoPlayerControl.Position - 1);
     }
 
     [RelayCommand]
     private void LeftOneSecondForward()
     {
-        VideoPlayerControl.Position = Math.Max(0, VideoPlayerControl.Position + 1);
-        _updateAudioVisualizer = true;
+        SetVideoPosition(VideoPlayerControl.Position + 1);
     }
 
     [RelayCommand]
     private void LeftHalfSecondBack()
     {
-        VideoPlayerControl.Position = Math.Max(0, VideoPlayerControl.Position - 0.5);
-        _updateAudioVisualizer = true;
+        SetVideoPosition(VideoPlayerControl.Position - 0.5);
     }
 
     [RelayCommand]
     private void LeftHalfSecondForward()
     {
-        VideoPlayerControl.Position = Math.Max(0, VideoPlayerControl.Position + 0.5);
-        _updateAudioVisualizer = true;
+        SetVideoPosition(VideoPlayerControl.Position + 0.5);
     }
 
     [RelayCommand]
     private async Task PlayTwoSecondsAndBackLeft()
     {
         await PlayAndBack(VideoPlayerControl, 2000);
+        UpdateTimeCodeFromVideoPosition();
         _updateAudioVisualizer = true;
     }
 
@@ -238,9 +286,8 @@ public partial class SetSyncPointViewModel : ObservableObject
         }
 
         SelectedParagraphIndex = Paragraphs.IndexOf(s);
-        VideoPlayerControl.Position = s.Subtitle.StartTime.TotalSeconds;
+        SetVideoPosition(s.Subtitle.StartTime.TotalSeconds);
         CenterWaveform(VideoPlayerControl, AudioVisualizer);
-        _updateAudioVisualizer = true;
     }
 
     [RelayCommand]
@@ -275,8 +322,7 @@ public partial class SetSyncPointViewModel : ObservableObject
 
     public void AudioVisualizerLeftPositionChanged(object sender, AudioVisualizer.PositionEventArgs e)
     {
-        VideoPlayerControl.Position = e.PositionInSeconds;
-        _updateAudioVisualizer = true;
+        SetVideoPosition(e.PositionInSeconds);
     }
 
     internal void OnClosing()
@@ -296,10 +342,9 @@ public partial class SetSyncPointViewModel : ObservableObject
         }
 
         var selected = Paragraphs[selectedIndex];
-        VideoPlayerControl.Position = selected.Subtitle.StartTime.TotalSeconds;
+        SetVideoPosition(selected.Subtitle.StartTime.TotalSeconds);
         AudioVisualizer.CurrentVideoPositionSeconds = selected.Subtitle.StartTime.TotalSeconds;
         CenterWaveform(VideoPlayerControl, AudioVisualizer);
-        _updateAudioVisualizer = true;
     }
 
     internal async void OnLoaded()
@@ -345,31 +390,67 @@ public partial class SetSyncPointViewModel : ObservableObject
         else if (e.Key == Key.Left && e.KeyModifiers.HasFlag(KeyModifiers.Control))
         {
             e.Handled = true;
-            VideoPlayerControl.Position = Math.Max(0, VideoPlayerControl.Position - 1);
-            _updateAudioVisualizer = true;
+            SetVideoPosition(VideoPlayerControl.Position - 1);
         }
         else if (e.Key == Key.Right && e.KeyModifiers.HasFlag(KeyModifiers.Control))
         {
             e.Handled = true;
-            VideoPlayerControl.Position += 1;
-            _updateAudioVisualizer = true;
+            SetVideoPosition(VideoPlayerControl.Position + 1);
         }
         else if (e.Key == Key.Left && e.KeyModifiers.HasFlag(KeyModifiers.Alt))
         {
             e.Handled = true;
-            VideoPlayerControl.Position = Math.Max(0, VideoPlayerControl.Position - 0.5);
-            _updateAudioVisualizer = true;
+            SetVideoPosition(VideoPlayerControl.Position - 0.5);
         }
         else if (e.Key == Key.Right && e.KeyModifiers.HasFlag(KeyModifiers.Alt))
         {
             e.Handled = true;
-            VideoPlayerControl.Position += 0.5;
-            _updateAudioVisualizer = true;
+            SetVideoPosition(VideoPlayerControl.Position + 0.5);
         }
+    }
+
+    /// <summary>
+    /// Tunnel-stage KeyUp twin of <see cref="OnKeyDownHandler"/>. Avalonia's Button raises OnClick
+    /// from OnKeyUp on Space whenever the button is focused - it does not check that the button also
+    /// saw the KeyDown - so a handled KeyDown alone still let a focused button click on Space release.
+    /// </summary>
+    internal void OnKeyUpHandler(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Space)
+        {
+            e.Handled = true;
+        }
+    }
+
+    /// <summary>
+    /// Puts the caret in the sync point time code box, so the window has a focused element for
+    /// key handling (and the time code can be typed right away) without arming a button.
+    /// </summary>
+    internal void FocusTimeCodeUpDown()
+    {
+        if (_timeCodeUpDownFocused)
+        {
+            return; // only on first activation - do not steal focus back on every re-activation
+        }
+
+        _timeCodeUpDownFocused = true;
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            // The inner text box is the element that actually takes keyboard focus
+            var textBox = TimeCodeUpDownSyncPoint.GetVisualDescendants().OfType<TextBox>().FirstOrDefault();
+            if (textBox != null)
+            {
+                textBox.Focus();
+                return;
+            }
+
+            TimeCodeUpDownSyncPoint.Focus();
+        });
     }
 
     internal void AudioVisualizerOnPrimarySingleClicked(object sender, ParagraphNullableEventArgs e)
     {
-        VideoPlayerControl.Position = e.Seconds;
+        SetVideoPosition(e.Seconds);
     }
 }

--- a/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointWindow.cs
+++ b/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointWindow.cs
@@ -1,6 +1,9 @@
+using Avalonia.Automation;
 using Avalonia.Controls;
+using Avalonia.Data;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
+using Nikse.SubtitleEdit.Controls;
 using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
 using Nikse.SubtitleEdit.Features.Main.Layout;
 using Nikse.SubtitleEdit.Logic;
@@ -54,6 +57,27 @@ public class SetSyncPointWindow : Window
         comboBoxLeft.HorizontalAlignment = HorizontalAlignment.Stretch;
         vm.ComboBoxSubtitle = comboBoxLeft;
 
+        vm.TimeCodeUpDownSyncPoint = new TimeCodeUpDown
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            [!TimeCodeUpDown.ValueProperty] = new Binding(nameof(vm.SyncPointTimeCode))
+            {
+                Mode = BindingMode.TwoWay,
+            },
+        };
+        AutomationProperties.SetName(vm.TimeCodeUpDownSyncPoint, Se.Language.Sync.SyncPointTimeCode);
+
+        var panelTimeCode = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 10,
+            Children =
+            {
+                UiUtil.MakeLabel(Se.Language.Sync.SyncPointTimeCode),
+                vm.TimeCodeUpDownSyncPoint,
+            }
+        };
+
         var panelLeftButtons = new StackPanel
         {
             Orientation = Orientation.Horizontal,
@@ -78,6 +102,7 @@ public class SetSyncPointWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }, // video player
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // audio visualizer
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // combo box
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // sync point time code
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // buttons
             },
             ColumnDefinitions =
@@ -93,7 +118,8 @@ public class SetSyncPointWindow : Window
         gridLeft.Add(vm.VideoPlayerControl, 0);
         gridLeft.Add(vm.AudioVisualizer, 1);
         gridLeft.Add(comboBoxLeft, 2);
-        gridLeft.Add(panelLeftButtons, 3);
+        gridLeft.Add(panelTimeCode, 3);
+        gridLeft.Add(panelLeftButtons, 4);
 
         var grid = new Grid
         {
@@ -120,9 +146,17 @@ public class SetSyncPointWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
+        // Focus the time code box, not a button, so the window receives key events without arming
+        // any button: a focused button fires OnClick on bare Space, and "Set sync point" used to be
+        // focused here - so the first Space a user pressed closed the dialog instead of playing.
+        Activated += delegate { vm.FocusTimeCodeUpDown(); };
 
         AddHandler(KeyDownEvent, vm.OnKeyDownHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: false);
+
+        // Avalonia's Button raises OnClick from OnKeyUp on Space whenever it is focused - it does
+        // not check that it also saw the KeyDown - so handling Space in OnKeyDownHandler alone is
+        // not enough to keep a focused button from clicking on Space release.
+        AddHandler(KeyUpEvent, vm.OnKeyUpHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: true);
         Loaded += (_, e) => vm.OnLoaded();
         Closing += (_, e) => vm.OnClosing();
     }

--- a/src/ui/Logic/Config/Language/Sync/LanguageSync.cs
+++ b/src/ui/Logic/Config/Language/Sync/LanguageSync.cs
@@ -26,6 +26,7 @@ public class LanguageSync
     public string ShowLater { get; set; }
     public string ChangeFrameRate { get; set; }
     public string SetSyncPoint { get; set; }
+    public string SyncPointTimeCode { get; set; }
     public string SyncPoints { get; set; }
     public string PointSync { get; set; }
     public string PointSyncViaOther { get; set; }
@@ -61,6 +62,7 @@ public class LanguageSync
         ShowLater = "Show later";
         ChangeFrameRate = "Change frame rate";
         SetSyncPoint = "Set sync point";
+        SyncPointTimeCode = "Sync point time code";
         SyncPoints = "Sync points";
         PointSync = "Point sync";
         PointSyncViaOther = "Point sync via other subtitle";


### PR DESCRIPTION
Fixes #12863

SE4 has a "Sync point time code" box in the Set sync point dialog; SE5 had no way to type an exact time code - the position could only be reached via the waveform, the nav buttons or playback.

## What

A `TimeCodeUpDown` labeled "Sync point time code", on its own row between the subtitle combo box and the nav buttons (that row already holds 5 buttons, so a localized label + box would overflow the 800 px min width). It is bound to the video position in both directions:

- **video -> box**: the existing 150 ms position timer pushes the video position into the box, so it follows playback and every seek. All position changes now go through one `SetVideoPosition` helper (nav buttons, Ctrl/Alt+arrow shortcuts, waveform click/drag, "Go to sub pos", "Find text"), so the box stays correct even while it has focus and the timer is holding off.
- **box -> video**: typing or spinning a time code seeks the video there. While the box has focus and the video is paused, the timer leaves the box alone so the digits being typed are not overwritten (a running video moves on its own, so then the box still follows).

"Set sync point" still returns `VideoPlayerControl.Position`, which is what the box displays, so the returned value and the shown time code always agree.

## Space no longer accepts the dialog

The window focused the "Set sync point" button on `Activated` while handling Space (play/pause) on KeyDown only. Avalonia raises `Button.OnClick` from `OnKeyUp` on Space whenever the button is focused - it does not check that the button also saw the KeyDown - so Space both toggled playback and accepted the dialog. Same fix as ReviewSpeechWindow (#12093): focus the time code box instead (matching SE4) and swallow Space on tunnel-stage KeyUp.

## Testing

Builds clean. Manual check in Point sync -> Set sync point: box follows playback and all seek paths, typing a time code moves the video, typed digits survive, Space plays/pauses without closing the dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)