### PR TITLE
Set sync point: reuse the "Video position" string for the time code box

### DIFF
--- a/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointWindow.cs
+++ b/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointWindow.cs
@@ -65,7 +65,7 @@ public class SetSyncPointWindow : Window
                 Mode = BindingMode.TwoWay,
             },
         };
-        AutomationProperties.SetName(vm.TimeCodeUpDownSyncPoint, Se.Language.Sync.SyncPointTimeCode);
+        AutomationProperties.SetName(vm.TimeCodeUpDownSyncPoint, Se.Language.General.VideoPosition);
 
         var panelTimeCode = new StackPanel
         {
@@ -73,7 +73,7 @@ public class SetSyncPointWindow : Window
             Spacing = 10,
             Children =
             {
-                UiUtil.MakeLabel(Se.Language.Sync.SyncPointTimeCode),
+                UiUtil.MakeLabel(Se.Language.General.VideoPosition),
                 vm.TimeCodeUpDownSyncPoint,
             }
         };

--- a/src/ui/Logic/Config/Language/Sync/LanguageSync.cs
+++ b/src/ui/Logic/Config/Language/Sync/LanguageSync.cs
@@ -26,7 +26,6 @@ public class LanguageSync
     public string ShowLater { get; set; }
     public string ChangeFrameRate { get; set; }
     public string SetSyncPoint { get; set; }
-    public string SyncPointTimeCode { get; set; }
     public string SyncPoints { get; set; }
     public string PointSync { get; set; }
     public string PointSyncViaOther { get; set; }
@@ -62,7 +61,6 @@ public class LanguageSync
         ShowLater = "Show later";
         ChangeFrameRate = "Change frame rate";
         SetSyncPoint = "Set sync point";
-        SyncPointTimeCode = "Sync point time code";
         SyncPoints = "Sync points";
         PointSync = "Point sync";
         PointSyncViaOther = "Point sync via other subtitle";


### PR DESCRIPTION
Follow-up to #12896.

The sync point time code box added there introduced a new `Sync.SyncPointTimeCode` string ("Sync point time code", SE4''s group label). `General.VideoPosition` ("Video position") already says the same thing and is already used for the time code box in the Go to video position dialog, so reuse it and drop the new translatable string.

Label and accessible name only - no behavior change. Builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)