### PR TITLE
Prepare v5.1.0-rc18

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,22 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.1.0-rc18 (28th of July 2026)
+
+* Set sync point: add a time code box so the sync point can be typed directly (SE4 parity)
+* Fix CrispASR text to speech freezing the app on every generation - thx subof
+* Speech to text: point at the Model field when an OpenAI-compatible server rejects it - thx acc4github
+* Surround only the selected text with music symbols - thx fraternl
+* Fix common errors: flash "Analyzing..." on every re-scan - thx Davanix
+* Restore the SE4 order of the two split items in the text box right-click menu - thx Chouu
+* Fix truncated labels and narrow controls in two spell check dialogs - thx bovirus
+* Fix the subtitle grid scroll bar paging past the cursor when holding the trough - thx ivandrofly
+* Fill in the missing Dutch translations - thx Albertos22
+* Update the Italian translation - thx bovirus
+* Improve the Polish translation of the OCR embedded subtitles dialog - thx potplayer-fanpack
+
+-----------------------------------------------------------------------------------------------------
+
 v5.1.0-rc17 (27th of July 2026)
 
 * Update llama.cpp to b10142 and offer the CUDA 13 build on Windows

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -17,7 +17,7 @@ public class Se
 {
     internal const int CurrentMacOsFontMigrationVersion = 1;
 
-    public static string Version { get; set; } = "v5.1.0-rc17";
+    public static string Version { get; set; } = "v5.1.0-rc18";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Adds the `v5.1.0-rc18` change log section and bumps `Se.Version`.

The entry set was compiled by ancestor-checking every merged PR's merge commit against the `v5.1.0-rc17` tag — 13 PRs merged since it: #12874, #12876, #12881, #12882, #12883, #12884, #12885, #12887, #12890, #12891, #12895, #12896, #12897.

Two are not listed separately:
- #12897 is a string-reuse refactor of #12896, so both are covered by the single "Set sync point" line.
- #12884 (remaining `object` lock fields → `System.Threading.Lock`) is internal only, with no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)