### PR TITLE
Stop rebuilding waveform geometry every frame during playback (#12888)

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -1886,6 +1886,24 @@ public class AudioVisualizer : Control
         return formatted;
     }
 
+    // Anchored timeline cache (see DrawWaveForm for the anchoring scheme). Rebuilding the tick
+    // lists + two StreamGeometry objects and resolving a label per ~5 s of visible audio on every
+    // ~60 fps render added up, worst when zoomed far out (hundreds of labels per frame); now the
+    // layout is built once per 256 px block and replayed with a translation while scrolling.
+    private readonly List<(FormattedText Text, double X, double Y)> _timeLineLabels = new(128);
+    private Geometry? _timeLineMajorGeometry;
+    private Geometry? _timeLineMinorGeometry;
+    private TimeLineCacheKey _timeLineCacheKey;
+    private bool _timeLineCacheValid;
+
+    private readonly record struct TimeLineCacheKey(
+        double Width,
+        double Height,
+        double AnchorPixel,
+        double ZoomFactor,
+        int SampleRate,
+        double VideoOffsetMs);
+
     private void DrawTimeLine(DrawingContext context, ref RenderContext renderCtx)
     {
         if (renderCtx.SampleRate == 0)
@@ -1896,28 +1914,64 @@ public class AudioVisualizer : Control
         // The timeline ruler stays second-based also in frame mode (SE4 parity, #12573): a
         // frame-aligned ruler labeled HH:MM:SS:FF at 10-frame steps was much harder to read.
         // Only the optional gridlines are frame-aligned in frame mode (DrawAllGridLines).
+        var n = renderCtx.ZoomFactor * renderCtx.SampleRate; // pixels per second
+        if (n <= 0)
+        {
+            return;
+        }
 
-        // Hoist loop-invariants: renderCtx is a ref struct, and n (pixels per second) was being
-        // recomputed every iteration. With sampleRate != 0 guaranteed above, SecondsToXPositionOptimized
-        // reduces to Math.Round(seconds * n), so inline it.
-        var startPosSeconds = renderCtx.StartPositionSeconds;
-        var n = renderCtx.ZoomFactor * renderCtx.SampleRate;
-        var imageHeight = renderCtx.Height;
-        var width = renderCtx.Width;
+        var startPixel = renderCtx.StartPositionSeconds * n;
+        var anchorPixel = Math.Floor(startPixel / WaveformCachePadPixels) * WaveformCachePadPixels;
+        var offsetPixels = Math.Floor(startPixel - anchorPixel);
 
-        var seconds = Math.Ceiling(startPosSeconds) - startPosSeconds;
-        var position = (int)Math.Round(seconds * n, MidpointRounding.AwayFromZero);
+        var cacheKey = new TimeLineCacheKey(
+            renderCtx.Width,
+            renderCtx.Height,
+            anchorPixel,
+            renderCtx.ZoomFactor,
+            renderCtx.SampleRate,
+            Se.Settings.General.CurrentVideoOffsetInMs);
 
+        if (!_timeLineCacheValid || !_timeLineCacheKey.Equals(cacheKey))
+        {
+            BuildTimeLine(anchorPixel / n, renderCtx.Width + WaveformCachePadPixels, n, renderCtx.Height);
+            _timeLineCacheKey = cacheKey;
+            _timeLineCacheValid = true;
+        }
+
+        using (context.PushTransform(Matrix.CreateTranslation(-offsetPixels, 0)))
+        {
+            var labels = _timeLineLabels;
+            for (var i = 0; i < labels.Count; i++)
+            {
+                var label = labels[i];
+                context.DrawText(label.Text, new Point(label.X, label.Y));
+            }
+
+            if (_timeLineMajorGeometry != null)
+            {
+                context.DrawGeometry(null, _paintTimeLine, _timeLineMajorGeometry);
+            }
+
+            if (_timeLineMinorGeometry != null)
+            {
+                context.DrawGeometry(null, _paintTimeLine, _timeLineMinorGeometry);
+            }
+        }
+    }
+
+    private void BuildTimeLine(double startPosSeconds, double width, double n, double imageHeight)
+    {
         var majorTicks = _timeLineMajorTicks;
         var minorTicks = _timeLineMinorTicks;
         majorTicks.Clear();
         minorTicks.Clear();
+        _timeLineLabels.Clear();
 
+        var seconds = Math.Ceiling(startPosSeconds) - startPosSeconds;
+        var position = (int)Math.Round(seconds * n, MidpointRounding.AwayFromZero);
         var drawMinor = n > 64;
 
-        // Collect ticks first; draw text directly with cached FormattedText (single
-        // DrawText call per label is fine — the per-frame cost was the FormattedText
-        // allocation, not the DrawText call).
         while (position < width)
         {
             if (n > 38 || (int)Math.Round(startPosSeconds + seconds) % 5 == 0)
@@ -1927,7 +1981,7 @@ public class AudioVisualizer : Control
                 var timeText = GetDisplayTime(startPosSeconds + seconds);
                 var formattedText = GetCachedTimeLineText(timeText);
                 var textY = Math.Max(0, imageHeight - formattedText.Height - 2);
-                context.DrawText(formattedText, new Point(position + 2, textY));
+                _timeLineLabels.Add((formattedText, position + 2, textY));
             }
 
             seconds += 0.5;
@@ -1942,8 +1996,8 @@ public class AudioVisualizer : Control
             position = (int)Math.Round(seconds * n, MidpointRounding.AwayFromZero);
         }
 
-        DrawVerticalLineBatch(context, _paintTimeLine, majorTicks);
-        DrawVerticalLineBatch(context, _paintTimeLine, minorTicks);
+        _timeLineMajorGeometry = BuildVerticalLineGeometry(majorTicks);
+        _timeLineMinorGeometry = BuildVerticalLineGeometry(minorTicks);
     }
 
     private readonly Pen _paintTimeLine = new Pen(Brushes.Gray, 1);
@@ -2002,13 +2056,16 @@ public class AudioVisualizer : Control
     // Cached grid geometry. Same reasoning as the waveform cache below: the grid is a few hundred
     // figures and depends only on the view state, but Render runs at ~60 fps while the cursor
     // moves - so without this we rebuilt (and threw away) the whole StreamGeometry every frame.
+    // Like the waveform cache, the geometry is anchored to a padded 256 px block and translated
+    // while the view scrolls within it, so smooth playback scrolling (center mode) replays the
+    // cache instead of rebuilding it every frame.
     private Geometry? _gridLinesGeometry;
     private GridLinesCacheKey _gridLinesCacheKey;
 
     private readonly record struct GridLinesCacheKey(
         double Width,
         double Height,
-        double StartPositionSeconds,
+        double AnchorPixel,
         double ZoomFactor,
         int SampleRate,
         bool FrameMode,
@@ -2021,10 +2078,21 @@ public class AudioVisualizer : Control
             return;
         }
 
+        // Anchor the build to a block boundary in absolute pixel space; see DrawWaveForm.
+        var pixelsPerSecond = renderCtx.SampleRate * renderCtx.ZoomFactor;
+        var anchorPixel = 0d;
+        var offsetPixels = 0d;
+        if (pixelsPerSecond > 0)
+        {
+            var startPixel = renderCtx.StartPositionSeconds * pixelsPerSecond;
+            anchorPixel = Math.Floor(startPixel / WaveformCachePadPixels) * WaveformCachePadPixels;
+            offsetPixels = Math.Floor(startPixel - anchorPixel);
+        }
+
         var cacheKey = new GridLinesCacheKey(
             renderCtx.Width,
             renderCtx.Height,
-            renderCtx.StartPositionSeconds,
+            anchorPixel,
             renderCtx.ZoomFactor,
             renderCtx.SampleRate,
             Se.Settings.General.UseFrameMode,
@@ -2032,14 +2100,22 @@ public class AudioVisualizer : Control
 
         if (_gridLinesGeometry != null && _gridLinesCacheKey.Equals(cacheKey))
         {
-            context.DrawGeometry(null, _paintGridLines, _gridLinesGeometry);
+            using (context.PushTransform(Matrix.CreateTranslation(-offsetPixels, 0)))
+            {
+                context.DrawGeometry(null, _paintGridLines, _gridLinesGeometry);
+            }
+
             return;
         }
 
         _gridLinesGeometry = null;
         _gridLinesCacheKey = cacheKey;
 
-        var width = renderCtx.Width;
+        // Build over the padded width in anchor space; the vertical lines are laid out from the
+        // anchor position and the whole geometry is translated left by up to one pad while the
+        // view scrolls (the horizontal lines are built one pad wider for the same reason).
+        var buildStartSeconds = pixelsPerSecond > 0 ? anchorPixel / pixelsPerSecond : renderCtx.StartPositionSeconds;
+        var width = renderCtx.Width + WaveformCachePadPixels;
         var height = renderCtx.Height;
 
         // Pixel spacing between adjacent vertical lines; reused for the horizontal lines so the
@@ -2073,7 +2149,7 @@ public class AudioVisualizer : Control
             // Compute the start frame in integer space — Math.Floor in double space can land
             // on the wrong side of a boundary when StartPositionSeconds * fps rounds to
             // 24.9999... instead of exactly 25.0, which would offset every gridline by a step.
-            var startFrame = FloorWithEpsilon(renderCtx.StartPositionSeconds * fps);
+            var startFrame = FloorWithEpsilon(buildStartSeconds * fps);
             if (startFrame < 0)
             {
                 startFrame = 0;
@@ -2082,7 +2158,7 @@ public class AudioVisualizer : Control
             var firstAbsFrame = startFrame - startFrame % framesPerStep;
             for (var absFrame = firstAbsFrame; ; absFrame += framesPerStep)
             {
-                var relSeconds = absFrame / fps - renderCtx.StartPositionSeconds;
+                var relSeconds = absFrame / fps - buildStartSeconds;
                 var xPosition = SecondsToXPositionOptimized(relSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
                 if (xPosition >= width)
                 {
@@ -2097,7 +2173,7 @@ public class AudioVisualizer : Control
         }
         else
         {
-            var seconds = Math.Ceiling(renderCtx.StartPositionSeconds) - renderCtx.StartPositionSeconds - 1;
+            var seconds = Math.Ceiling(buildStartSeconds) - buildStartSeconds - 1;
             var xPosition = SecondsToXPositionOptimized(seconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
             var interval = renderCtx.ZoomFactor >= 0.4d
                 ? 0.1d
@@ -2144,7 +2220,10 @@ public class AudioVisualizer : Control
         }
 
         _gridLinesGeometry = geom;
-        context.DrawGeometry(null, _paintGridLines, geom);
+        using (context.PushTransform(Matrix.CreateTranslation(-offsetPixels, 0)))
+        {
+            context.DrawGeometry(null, _paintGridLines, geom);
+        }
     }
 
     private static readonly int[] FrameStepCandidates = { 1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000 };
@@ -2180,17 +2259,39 @@ public class AudioVisualizer : Control
 
         // Rebuild the cached geometry only when the view actually changed; otherwise (e.g. the
         // cursor moved) just replay the existing draw ops. See _waveformCacheDraws.
-        var key = BuildWaveformCacheKey(waveformHeight, ref renderCtx);
+        //
+        // The cache is anchored to a 256 px block boundary in absolute (time * pixels-per-second)
+        // space rather than to the exact scroll position: in "center video position" mode the
+        // waveform scrolls a couple of pixels every ~16 ms cursor tick during playback, so an
+        // exact-position key missed on every frame and playback re-ran the whole per-pixel build
+        // (the very thing this cache exists to avoid). Instead we build the geometry for the
+        // anchor block plus one block of padding and just translate it while the view scrolls
+        // within the padded range - the build then runs once per 256 px scrolled instead of at
+        // ~60 fps. The translation is snapped to whole pixels so the 1 px columns stay as crisp
+        // as they were when the geometry was built at the view origin.
+        var pixelsPerSecond = renderCtx.SampleRate * renderCtx.ZoomFactor;
+        var anchorPixel = 0d;
+        var offsetPixels = 0d;
+        if (pixelsPerSecond > 0)
+        {
+            var startPixel = renderCtx.StartPositionSeconds * pixelsPerSecond;
+            anchorPixel = Math.Floor(startPixel / WaveformCachePadPixels) * WaveformCachePadPixels;
+            offsetPixels = Math.Floor(startPixel - anchorPixel);
+        }
+
+        var key = BuildWaveformCacheKey(waveformHeight, anchorPixel, ref renderCtx);
         if (!_waveformCacheValid || !ReferenceEquals(_waveformCachePeaks, WavePeaks) || !key.Equals(_waveformCacheKey))
         {
             _waveformCacheDraws.Clear();
+            var buildStartSeconds = pixelsPerSecond > 0 ? anchorPixel / pixelsPerSecond : renderCtx.StartPositionSeconds;
+            var buildWidth = renderCtx.Width + WaveformCachePadPixels;
             if (WaveformDrawStyle == WaveformDrawStyle.Classic)
             {
-                BuildWaveFormClassic(waveformHeight, ref renderCtx);
+                BuildWaveFormClassic(waveformHeight, buildStartSeconds, buildWidth, ref renderCtx);
             }
             else
             {
-                BuildWaveFormFancy(waveformHeight, ref renderCtx);
+                BuildWaveFormFancy(waveformHeight, buildStartSeconds, buildWidth, ref renderCtx);
             }
 
             _waveformCacheKey = key;
@@ -2206,10 +2307,13 @@ public class AudioVisualizer : Control
             context.DrawLine(_centerLinePen, new Point(0, halfWaveformHeight), new Point(renderCtx.Width, halfWaveformHeight));
         }
 
-        for (var i = 0; i < _waveformCacheDraws.Count; i++)
+        using (context.PushTransform(Matrix.CreateTranslation(-offsetPixels, 0)))
         {
-            var draw = _waveformCacheDraws[i];
-            context.DrawGeometry(null, draw.Pen, draw.Geometry);
+            for (var i = 0; i < _waveformCacheDraws.Count; i++)
+            {
+                var draw = _waveformCacheDraws[i];
+                context.DrawGeometry(null, draw.Pen, draw.Geometry);
+            }
         }
     }
 
@@ -2270,7 +2374,7 @@ public class AudioVisualizer : Control
     private readonly Dictionary<int, FancyBatch> _fancyBatches = new(64);
     private readonly List<int> _fancyBatchKeysInUse = new(64);
 
-    private void BuildWaveFormFancy(double waveformHeight, ref RenderContext renderCtx)
+    private void BuildWaveFormFancy(double waveformHeight, double startPositionSeconds, double width, ref RenderContext renderCtx)
     {
         var isSelectedHelper = _isSelectedHelper;
         var halfWaveformHeight = waveformHeight / 2;
@@ -2290,10 +2394,11 @@ public class AudioVisualizer : Control
         // Hoist loop-invariant RenderContext fields into locals: it is a ref struct, so the JIT
         // cannot cache these reads across the loop. Also turn the per-pixel sample position into a
         // multiply (startSample + x * samplesPerPixel) instead of a division (x / div).
-        var width = renderCtx.Width;
+        // startPositionSeconds/width describe the (padded) anchor-space build range, not the live
+        // view - see the anchored cache in DrawWaveForm.
         var height = renderCtx.Height;
         var verticalZoomFactor = renderCtx.VerticalZoomFactor;
-        var startSample = renderCtx.StartPositionSeconds * renderCtx.SampleRate;
+        var startSample = startPositionSeconds * renderCtx.SampleRate;
         var samplesPerPixel = renderCtx.SampleRate / div;
         var yScaleHalf = verticalZoomFactor / highestPeak * halfWaveformHeight;
 
@@ -2443,7 +2548,7 @@ public class AudioVisualizer : Control
         }
     }
 
-    private void BuildWaveFormClassic(double waveformHeight, ref RenderContext renderCtx)
+    private void BuildWaveFormClassic(double waveformHeight, double startPositionSeconds, double width, ref RenderContext renderCtx)
     {
         var isSelectedHelper = _isSelectedHelper;
         var halfWaveformHeight = waveformHeight / 2;
@@ -2460,11 +2565,11 @@ public class AudioVisualizer : Control
 
         // Hoist loop-invariant RenderContext fields (it is a ref struct) and replace the per-pixel
         // division for the sample position with a multiply. See BuildWaveFormFancy.
-        var width = renderCtx.Width;
+        // startPositionSeconds/width describe the (padded) anchor-space build range, not the live view.
         var height = renderCtx.Height;
         var highestPeak = renderCtx.HighestPeak;
         var verticalZoomFactor = renderCtx.VerticalZoomFactor;
-        var startSample = renderCtx.StartPositionSeconds * renderCtx.SampleRate;
+        var startSample = startPositionSeconds * renderCtx.SampleRate;
         var samplesPerPixel = renderCtx.SampleRate / div;
         var yScaleHalf = verticalZoomFactor / highestPeak * halfWaveformHeight;
 
@@ -2533,6 +2638,9 @@ public class AudioVisualizer : Control
     // build the geometry once per view-state and just replay the draw calls while only the
     // cursor moves. The key captures everything that changes the waveform pixels, so any real
     // change (scroll, zoom, resize, selection, peaks, colors, style) rebuilds automatically.
+    // Scrolling is keyed on a padded anchor block, not the exact position, so smooth playback
+    // scrolling translates the cached geometry instead of rebuilding it (see DrawWaveForm).
+    private const int WaveformCachePadPixels = 256;
     private readonly List<(IPen Pen, Geometry Geometry)> _waveformCacheDraws = new(64);
     private WaveformCacheKey _waveformCacheKey;
     private bool _waveformCacheValid;
@@ -2543,7 +2651,7 @@ public class AudioVisualizer : Control
         public readonly int Width;
         public readonly double Height;
         public readonly double WaveformHeight;
-        public readonly double StartPositionSeconds;
+        public readonly double AnchorPixel;
         public readonly double ZoomFactor;
         public readonly double VerticalZoomFactor;
         public readonly double HighestPeak;
@@ -2556,14 +2664,14 @@ public class AudioVisualizer : Control
         public readonly int SelectionCount;
         public readonly long SelectionHash;
 
-        public WaveformCacheKey(int width, double height, double waveformHeight, double startPositionSeconds,
+        public WaveformCacheKey(int width, double height, double waveformHeight, double anchorPixel,
             double zoomFactor, double verticalZoomFactor, double highestPeak, int sampleRate, int displayMode,
             int drawStyle, uint colorMain, uint colorSelected, uint colorHigh, int selectionCount, long selectionHash)
         {
             Width = width;
             Height = height;
             WaveformHeight = waveformHeight;
-            StartPositionSeconds = startPositionSeconds;
+            AnchorPixel = anchorPixel;
             ZoomFactor = zoomFactor;
             VerticalZoomFactor = verticalZoomFactor;
             HighestPeak = highestPeak;
@@ -2581,7 +2689,7 @@ public class AudioVisualizer : Control
             Width == other.Width &&
             Height.Equals(other.Height) &&
             WaveformHeight.Equals(other.WaveformHeight) &&
-            StartPositionSeconds.Equals(other.StartPositionSeconds) &&
+            AnchorPixel.Equals(other.AnchorPixel) &&
             ZoomFactor.Equals(other.ZoomFactor) &&
             VerticalZoomFactor.Equals(other.VerticalZoomFactor) &&
             HighestPeak.Equals(other.HighestPeak) &&
@@ -2600,7 +2708,7 @@ public class AudioVisualizer : Control
 
     private static uint ToKeyColor(Color c) => ((uint)c.A << 24) | ((uint)c.R << 16) | ((uint)c.G << 8) | c.B;
 
-    private WaveformCacheKey BuildWaveformCacheKey(double waveformHeight, ref RenderContext renderCtx)
+    private WaveformCacheKey BuildWaveformCacheKey(double waveformHeight, double anchorPixel, ref RenderContext renderCtx)
     {
         long selectionHash = 17;
         var selection = AllSelectedParagraphs;
@@ -2615,7 +2723,7 @@ public class AudioVisualizer : Control
             (int)Math.Ceiling(renderCtx.Width),
             renderCtx.Height,
             waveformHeight,
-            renderCtx.StartPositionSeconds,
+            anchorPixel,
             renderCtx.ZoomFactor,
             renderCtx.VerticalZoomFactor,
             renderCtx.HighestPeak,
@@ -2651,11 +2759,11 @@ public class AudioVisualizer : Control
         _waveformCacheDraws.Add((pen, geom));
     }
 
-    private static void DrawVerticalLineBatch(DrawingContext context, IPen pen, List<FancyLine> lines)
+    private static Geometry? BuildVerticalLineGeometry(List<FancyLine> lines)
     {
         if (lines.Count == 0)
         {
-            return;
+            return null;
         }
 
         var geom = new StreamGeometry();
@@ -2669,7 +2777,8 @@ public class AudioVisualizer : Control
                 gctx.EndFigure(false);
             }
         }
-        context.DrawGeometry(null, pen, geom);
+
+        return geom;
     }
 
     private void DrawParagraphs(DrawingContext context, ref RenderContext renderCtx)
@@ -3687,6 +3796,7 @@ public class AudioVisualizer : Control
         _paragraphTextCache.Clear();
         _waveformCacheValid = false;
         _gridLinesGeometry = null;
+        _timeLineCacheValid = false;
 
         _paintText = new SolidColorBrush(Se.Settings.Waveform.WaveformTextColor.FromHexToColor());
         _typeface = new Typeface(UiUtil.GetDefaultFontName(), FontStyle.Normal, Se.Settings.Waveform.WaveformTextFontBold ? FontWeight.Bold : FontWeight.Normal);

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -21835,8 +21835,11 @@ public partial class MainViewModel :
         }
     }
 
-    private double UpdatePlayheadEstimate(VideoPlayerControl vp)
+    private double UpdatePlayheadEstimate(VideoPlayerControl vp, bool isPlaying)
     {
+        // isPlaying is read once by the caller and passed in: every IsPlaying get is a
+        // synchronous P/Invoke into the mpv core, and this method used to ask up to four
+        // times per 16 ms cursor tick.
         var rawPosition = vp.VideoPlayer.Position;
         if (IsSmpteTimingEnabled)
         {
@@ -21868,7 +21871,7 @@ public partial class MainViewModel :
             _playheadLastRealSeconds = rawPosition;
             _playheadLastTimestamp = nowTimestamp;
 
-            if (vp.IsPlaying)
+            if (isPlaying)
             {
                 _playheadEstimateSeconds = rawPosition;
                 return rawPosition;
@@ -21881,7 +21884,7 @@ public partial class MainViewModel :
             return _playheadEstimateSeconds;
         }
 
-        if (vp.IsPlaying && !_pauseRequested && _playheadValid && _playheadLastRealSeconds >= 0)
+        if (isPlaying && !_pauseRequested && _playheadValid && _playheadLastRealSeconds >= 0)
         {
             var elapsedSeconds = (nowTimestamp - _playheadLastTimestamp) / (double)Stopwatch.Frequency;
             if (elapsedSeconds < 0)
@@ -21953,7 +21956,7 @@ public partial class MainViewModel :
             // settled frame - whether eased or snapped in one step - reads as the cursor drifting a
             // moment after the numeric time display has already stopped (#12740). Only a real
             // discontinuity (a seek while paused, beyond the resync threshold) moves the cursor now.
-            if (!vp.IsPlaying)
+            if (!isPlaying)
             {
                 if (_playheadWasPlaying)
                 {
@@ -21999,7 +22002,7 @@ public partial class MainViewModel :
                 // (#12742 follow-up). Snapping, rather than easing, puts the cursor on the frame at once.
                 _playheadEstimateSeconds = rawPosition;
             }
-            else if (!_playheadPausedSettled && !vp.IsPlaying && rawStableMs >= PlayheadPausedSettleStableMs)
+            else if (!_playheadPausedSettled && !isPlaying && rawStableMs >= PlayheadPausedSettleStableMs)
             {
                 // mpv's clock has come to rest after the pause wind-down. Hold the cursor at the frozen
                 // keypress spot rather than snapping to mpv's settled frame: the video stopped where the
@@ -22015,7 +22018,7 @@ public partial class MainViewModel :
 
         _playheadLastRealSeconds = rawPosition;
         _playheadLastTimestamp = nowTimestamp;
-        _playheadWasPlaying = vp.IsPlaying;
+        _playheadWasPlaying = isPlaying;
         return _playheadEstimateSeconds;
     }
 
@@ -22231,7 +22234,10 @@ public partial class MainViewModel :
             // its source of truth (SelectCurrentSubtitleWhilePlaying, play-selection end detection, the
             // auto-scroll branches), and some layouts have a video player but no waveform. Only the
             // visual updates below need the AudioVisualizer.
-            var est = UpdatePlayheadEstimate(vp);
+            // Read IsPlaying once per tick - each get is a synchronous P/Invoke into the mpv core,
+            // and this tick (estimate + centering) used to issue up to six of them at ~60 fps.
+            var isPlaying = vp.IsPlaying;
+            var est = UpdatePlayheadEstimate(vp, isPlaying);
 
             var av = AudioVisualizer;
             if (av != null)
@@ -22244,10 +22250,10 @@ public partial class MainViewModel :
                 // With "center also while paused" on, paused position changes (wheel scrub, waveform
                 // clicks, shortcuts) recenter too — but only on actual changes, so the user can still
                 // scroll around the waveform freely while the play-head is at rest.
-                var centerPausedChange = WaveformCenter && !vp.IsPlaying &&
+                var centerPausedChange = WaveformCenter && !isPlaying &&
                                          Se.Settings.Waveform.CenterVideoPositionAlsoWhenPaused &&
                                          Math.Abs(est - _pausedCenterLastSeconds) > 0.001;
-                if (WaveformCenter && av.WavePeaks != null && (vp.IsPlaying || centerPausedChange))
+                if (WaveformCenter && av.WavePeaks != null && (isPlaying || centerPausedChange))
                 {
                     var halfSeconds = (av.EndPositionSeconds - av.StartPositionSeconds) / 2.0;
                     av.StartPositionSeconds = Math.Max(0, est - halfSeconds);

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -367,6 +367,16 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         return Encoding.UTF8.GetBytes(s + "\0");
     }
 
+    // Cached UTF-8 names for the hot polled properties: the UI polls these up to ~60x/s
+    // during playback (playhead cursor timer + position timers), and GetUtf8Bytes
+    // allocated a fresh byte[] per call.
+    private static readonly byte[] PropertyNameTimePos = GetUtf8Bytes("time-pos");
+    private static readonly byte[] PropertyNamePause = GetUtf8Bytes("pause");
+    private static readonly byte[] PropertyNameEofReached = GetUtf8Bytes("eof-reached");
+    private static readonly byte[] PropertyNameSpeed = GetUtf8Bytes("speed");
+    private static readonly byte[] PropertyNameDuration = GetUtf8Bytes("duration");
+    private static readonly byte[] PropertyNameVolume = GetUtf8Bytes("volume");
+
     public string GetErrorString(int error)
     {
         if (_mpvErrorString == null)
@@ -800,6 +810,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         // Reset any end-of-playback bound from a previous file (see audio-only handling below).
         SetOptionString("end", "none");
         _audioEndBound = null;
+        _lastRawTimePos = -1;
 
         await WaitForCoreInitializedAsync();
 
@@ -958,6 +969,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         _fileName = string.Empty;
         _pausedValue = null;
         _audioEndBound = null;
+        _lastRawTimePos = -1;
 
         EnsureNotDisposed();
         if (_mpv == IntPtr.Zero)
@@ -989,7 +1001,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
             try
             {
                 double pauseValue = 0;
-                var nameBytes = GetUtf8Bytes("pause");
+                var nameBytes = PropertyNamePause;
                 var err = _mpvGetPropertyDouble(_mpv, nameBytes, MPV_FORMAT_FLAG, ref pauseValue);
 
                 if (err < 0)
@@ -1019,7 +1031,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
             try
             {
                 double pauseValue = 0;
-                var nameBytes = GetUtf8Bytes("pause");
+                var nameBytes = PropertyNamePause;
                 var err = _mpvGetPropertyDouble(_mpv, nameBytes, MPV_FORMAT_FLAG, ref pauseValue);
 
                 if (err < 0)
@@ -1039,6 +1051,23 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
     private double? _pausedValue;
 
+    // Last raw time-pos seen by the Position getter/setter, used to gate the eof-reached
+    // probe below. -1 = unknown (always probe).
+    private double _lastRawTimePos = -1;
+
+    /// <summary>
+    /// Whether playback could plausibly be at the audio end bound, judged from the last seen
+    /// position. The Position getter is polled up to ~60x/s during playback and the eof-reached
+    /// probe is an extra synchronous P/Invoke into the mpv core on every one of those reads -
+    /// for audio-only files (where <see cref="_audioEndBound"/> is always set) that doubled the
+    /// polling load for the whole session. Position moves continuously and is re-read many times
+    /// a second, so gating on "last seen position near the bound" cannot miss the real EOF.
+    /// </summary>
+    private bool MightBeAtAudioEnd()
+    {
+        return _lastRawTimePos < 0 || !_audioEndBound.HasValue || _lastRawTimePos >= _audioEndBound.Value - 2.0;
+    }
+
     private bool IsEofReached()
     {
         if (_mpv == IntPtr.Zero || _mpvGetPropertyDouble == null)
@@ -1049,7 +1078,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         try
         {
             double eofValue = 0;
-            var nameBytes = GetUtf8Bytes("eof-reached");
+            var nameBytes = PropertyNameEofReached;
             var err = _mpvGetPropertyDouble(_mpv, nameBytes, MPV_FORMAT_FLAG, ref eofValue);
             if (err < 0)
             {
@@ -1073,7 +1102,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
             // earlier in the session, _pausedValue still holds that stale seek target and
             // the cache below would return it, causing the position to "jump back" to the
             // last seek when playback completes. See #10835 / #10877.
-            if (_audioEndBound.HasValue && IsEofReached())
+            if (_audioEndBound.HasValue && MightBeAtAudioEnd() && IsEofReached())
             {
                 return _audioEndBound.Value;
             }
@@ -1092,7 +1121,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
             try
             {
                 double position = 0;
-                var nameBytes = GetUtf8Bytes("time-pos");
+                var nameBytes = PropertyNameTimePos;
                 var err = _mpvGetPropertyDouble(_mpv, nameBytes, MPV_FORMAT_DOUBLE, ref position);
 
                 if (err < 0)
@@ -1100,6 +1129,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
                     return 0;
                 }
 
+                _lastRawTimePos = position;
                 return position;
             }
             catch
@@ -1110,6 +1140,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         set
         {
             _pausedValue = value;
+            _lastRawTimePos = value; // keep the eof-reached gate accurate across seeks
             EnsureNotDisposed();
             if (_mpv == IntPtr.Zero)
             {
@@ -1137,7 +1168,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
             try
             {
                 double duration = 0;
-                var nameBytes = GetUtf8Bytes("duration");
+                var nameBytes = PropertyNameDuration;
                 var err = _mpvGetPropertyDouble(_mpv, nameBytes, MPV_FORMAT_DOUBLE, ref duration);
 
                 if (err < 0)
@@ -1169,7 +1200,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
             try
             {
                 double volume = 100;
-                var nameBytes = GetUtf8Bytes("volume");
+                var nameBytes = PropertyNameVolume;
                 var err = _mpvGetPropertyDouble(_mpv, nameBytes, MPV_FORMAT_DOUBLE, ref volume);
 
                 if (err < 0)
@@ -1218,7 +1249,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
             try
             {
                 var speed = 1.0;
-                var nameBytes = GetUtf8Bytes("speed");
+                var nameBytes = PropertyNameSpeed;
                 var err = _mpvGetPropertyDouble(_mpv, nameBytes, MPV_FORMAT_DOUBLE, ref speed);
 
                 if (err < 0)

--- a/tests/benchmarks/AudioVisualizerRenderBenchmarks.cs
+++ b/tests/benchmarks/AudioVisualizerRenderBenchmarks.cs
@@ -1,0 +1,187 @@
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.Media;
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// Runs one real playback frame of <see cref="AudioVisualizer.Render"/>, headlessly but with the
+/// real Skia backend, exactly the way the app's ~60 fps cursor timer drives it: advance the
+/// playhead, scroll the view (center mode), refresh the paragraph window on every third frame
+/// (the 50 ms position timer), then record the frame into a DrawingGroup drawing context.
+///
+/// Recording, deliberately not rasterizing: in the app, Render() records into the compositor's
+/// deferred list on the UI thread and Skia rasterizes on the render thread - the playback
+/// stutter this benchmark exists for was UI-thread saturation from the per-pixel geometry
+/// build inside Render(). Rasterizing here (e.g. into a RenderTargetBitmap) would bury that
+/// cost under raster work the UI thread never pays.
+///
+/// Three scenarios:
+///  - StaticViewPlaybackFrame (baseline): the view stands still and only the cursor moves; the
+///    caches hit on almost every frame on both old and new code, so this is the floor - the
+///    unavoidable per-frame cost of re-recording the scene.
+///  - CenterModePlaybackFrame: "center video position" is on, so StartPositionSeconds moves a
+///    couple of pixels every frame. This is the pathological path - before the anchored caches,
+///    every one of these frames missed the waveform/grid/timeline caches and re-ran the full
+///    per-pixel geometry build; after, it should cost the same as the static baseline (the
+///    rebuild runs once per 256 px block, ~every 2 s of playback at default zoom).
+///  - ForcedRebuildFrame: jumps the view far enough every frame that the caches miss on both
+///    old and new code. This is what one old center-mode frame cost - compare it against the
+///    static baseline to isolate the geometry-build cost the anchored caches removed.
+///
+/// The waveform is speech-like (bursts of loud peaks) so the fancy style produces its glow
+/// batches - the worst case called out in the cache comments.
+/// </summary>
+[MemoryDiagnoser]
+public class AudioVisualizerRenderBenchmarks
+{
+    private const double HeightPx = 220;
+    private const double FrameSeconds = 1 / 60.0;
+    private const int PeaksPerSecond = 126; // Se.Settings.Waveform.WaveformMinimumSampleRate default
+    private const int PeaksLengthSeconds = 3600;
+
+    private static bool _avaloniaInitialized;
+
+    private AudioVisualizer _audioVisualizer = null!;
+    private List<SubtitleLineViewModel> _subtitles = null!;
+    private readonly List<SubtitleLineViewModel> _noSelection = new();
+    private double _positionSeconds;
+    private double _viewSeconds;
+    private int _frameIndex;
+
+    [Params(1600, 3200)]
+    public int WidthPx { get; set; }
+
+    [Params(WaveformDrawStyle.Classic, WaveformDrawStyle.Fancy)]
+    public WaveformDrawStyle Style { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        if (!_avaloniaInitialized)
+        {
+            _avaloniaInitialized = true;
+            AppBuilder.Configure<Application>()
+                .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false })
+                .UseSkia()
+                .WithInterFont()
+                .SetupWithoutStarting();
+        }
+
+        _audioVisualizer = new AudioVisualizer
+        {
+            WaveformDrawStyle = Style,
+            WavePeaks = MakeSpeechLikePeaks(),
+        };
+        _audioVisualizer.Measure(new Size(WidthPx, HeightPx));
+        _audioVisualizer.Arrange(new Rect(0, 0, WidthPx, HeightPx));
+
+        _subtitles = SubtitleFactory.Make(2000);
+        _viewSeconds = WidthPx / (double)PeaksPerSecond; // ZoomFactor is 1.0
+        _positionSeconds = 10;
+        _frameIndex = 0;
+    }
+
+    [Benchmark]
+    public void CenterModePlaybackFrame()
+    {
+        _positionSeconds += FrameSeconds;
+        if (_positionSeconds > PeaksLengthSeconds - _viewSeconds - 5)
+        {
+            _positionSeconds = 10;
+        }
+
+        var startSeconds = Math.Max(0, _positionSeconds - _viewSeconds / 2.0);
+        if (++_frameIndex % 3 == 0)
+        {
+            // What the 50 ms position timer does: refresh the visible paragraph window.
+            _audioVisualizer.SetPosition(startSeconds, _subtitles, _positionSeconds, -1, _noSelection);
+        }
+        else
+        {
+            // What the ~60 fps cursor timer does: glide the cursor and the centered scroll.
+            _audioVisualizer.StartPositionSeconds = startSeconds;
+            _audioVisualizer.CurrentVideoPositionSeconds = _positionSeconds;
+        }
+
+        RenderFrame();
+    }
+
+    [Benchmark]
+    public void ForcedRebuildFrame()
+    {
+        // Alternate between two views ~100 s apart: different cache anchors on the new code,
+        // different exact positions on the old, so both rebuild the full geometry every frame.
+        // Everything else mirrors the other scenarios (paragraph refresh on every third frame)
+        // so the difference against the static baseline is purely the geometry rebuild.
+        _frameIndex++;
+        var startSeconds = (_frameIndex & 1) == 0 ? 100.0 : 200.0;
+        var cursorSeconds = startSeconds + _viewSeconds / 2.0;
+        if (_frameIndex % 3 == 0)
+        {
+            _audioVisualizer.SetPosition(startSeconds, _subtitles, cursorSeconds, -1, _noSelection);
+        }
+        else
+        {
+            _audioVisualizer.StartPositionSeconds = startSeconds;
+            _audioVisualizer.CurrentVideoPositionSeconds = cursorSeconds;
+        }
+
+        RenderFrame();
+    }
+
+    [Benchmark(Baseline = true)]
+    public void StaticViewPlaybackFrame()
+    {
+        const double viewStart = 10;
+        _positionSeconds += FrameSeconds;
+        if (_positionSeconds > viewStart + _viewSeconds - 1)
+        {
+            _positionSeconds = viewStart + 1;
+        }
+
+        if (++_frameIndex % 3 == 0)
+        {
+            _audioVisualizer.SetPosition(viewStart, _subtitles, _positionSeconds, -1, _noSelection);
+        }
+        else
+        {
+            _audioVisualizer.CurrentVideoPositionSeconds = _positionSeconds;
+        }
+
+        RenderFrame();
+    }
+
+    private void RenderFrame()
+    {
+        // Record only - see the class summary. The DrawingGroup context is a plain
+        // display-list recorder, so this measures what Render() costs the UI thread.
+        var drawingGroup = new DrawingGroup();
+        using var context = drawingGroup.Open();
+        _audioVisualizer.Render(context);
+    }
+
+    /// <summary>
+    /// Speech-like peaks: ~300 ms bursts of loud audio separated by ~200 ms of near-silence,
+    /// with deterministic pseudo-noise inside the bursts. Loud enough that the fancy style
+    /// crosses its medium/high amplitude thresholds and emits glow geometry.
+    /// </summary>
+    private static WavePeakData2 MakeSpeechLikePeaks()
+    {
+        var random = new Random(42);
+        var peaks = new WavePeak2[PeaksPerSecond * PeaksLengthSeconds];
+        for (var i = 0; i < peaks.Length; i++)
+        {
+            var seconds = i / (double)PeaksPerSecond;
+            var inBurst = seconds % 0.5 < 0.3;
+            var amplitude = inBurst ? random.Next(4000, 28000) : random.Next(0, 900);
+            peaks[i] = new WavePeak2((short)amplitude, (short)-random.Next(amplitude / 2, amplitude + 1));
+        }
+
+        return new WavePeakData2(PeaksPerSecond, peaks);
+    }
+}

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -28,6 +28,7 @@ Reports land in `tests/benchmarks/BenchmarkDotNet.Artifacts/results/` (gitignore
 | `SubtitleLineViewModelBenchmarks` | The row getters the grid re-reads as rows are recycled - text error highlight and CPS. |
 | `SubtitleGridSelectionBenchmarks` | What `SubtitleGridSelectionChanged` does per selection change: copy the selection, find the line's index. |
 | `WaveformBufferBenchmarks` | The 50 ms position timer's refill of the waveform's subtitle buffer. |
+| `AudioVisualizerRenderBenchmarks` | One full playback frame of the real `AudioVisualizer.Render` (headless, real Skia, record-only): static view vs center-mode scrolling vs a forced geometry rebuild. |
 
 Benchmarks that model a collection the app gets from Avalonia (e.g. `DataGrid.SelectedItems`)
 reproduce its interface surface rather than substituting a `List<T>` - `SelectedItems` only

--- a/tests/benchmarks/UiBenchmarks.csproj
+++ b/tests/benchmarks/UiBenchmarks.csproj
@@ -19,6 +19,9 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <!-- Headless platform with the real Skia backend, so AudioVisualizerRenderBenchmarks can
+         run the actual Render() pass (StreamGeometry, FormattedText) without a window. -->
+    <PackageReference Include="Avalonia.Headless" Version="12.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Follow-up to the performance feedback in #12888 (laggy playback with large WAV files, i.e. waveform-dominated sessions).

### The problem

During playback the smooth-cursor timer invalidates the `AudioVisualizer` at ~60 fps. The waveform, gridline and timeline caches were keyed on the **exact** `StartPositionSeconds` — so in *center video position* mode, where the view scrolls a couple of pixels every 16 ms tick, **every frame missed the cache** and re-ran the full per-pixel waveform build + `StreamGeometry` allocations (plus glow batches in the fancy style). On wide windows that saturates the UI thread and shows up as the stuttery playback reported for SE5.

### The fix

Anchor the caches to 256 px blocks in absolute (time × pixels-per-second) space:

- build the geometry once for the anchor block **plus one block of padding**,
- replay it each frame with a whole-pixel translation while the view scrolls within the padded range,
- rebuild only when the view crosses into the next block (~once per few seconds of playback instead of ~60×/s).

Applied to the waveform (classic + fancy), the optional gridlines, and the timeline ruler — the ruler previously also rebuilt its tick lists + two `StreamGeometry` and resolved a label per ~5 s of visible audio *per frame*, which was significant when zoomed far out.

### mpv polling reduction on the UI thread

Every mpv property get is a synchronous P/Invoke into the mpv core (it takes the core lock, which can spike during decode/seek):

- `UpdatePlayheadEstimate` + the cursor tick read `IsPlaying` up to 6× per 16 ms tick → now read once per tick and passed down.
- The `Position` getter probed `eof-reached` on **every** read whenever an audio end bound was set — i.e. for the whole session with audio-only files (exactly the large-WAV case from the issue). The probe is now gated to when the last seen position is within 2 s of the bound; position is polled ~60×/s and moves continuously, so the real EOF can't be missed.
- Cached the UTF-8 property-name buffers for the hot polled properties (`time-pos`, `pause`, `eof-reached`, `speed`, `duration`, `volume`) instead of allocating a fresh `byte[]` per call.

### Notes

- Non-center playback already mostly hit the caches; the win there is the timeline ruler and the reduced polling.
- All cache-key inputs (zoom, size, colors, selection, frame mode, video offset) still force a rebuild, and `ResetCache()` invalidates the new timeline cache too.
- Builds clean; all 908 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)