### PR TITLE
Make waveform scroll work while playing in center mode

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -212,6 +212,11 @@ public class AudioVisualizer : Control
     // The main window and the TTS review window assign it from Se.Settings.Waveform instead.
     public bool FocusOnMouseOver { get; set; } = true;
     public int WaveformHeightPercentage { get; set; } = 50;
+
+    // Lets the wheel handler ask the host whether the video is playing, so a plain scroll in
+    // "center video position" mode can turn into a seek that keeps the play-head centered
+    // (#12864). Hosts without a video player (or that never set this) keep plain scrolling.
+    public Func<bool>? GetIsVideoPlaying { get; set; }
     public Color WaveformFancyHighColor { get; set; } = Colors.Orange;
 
     private Color _paragraphBackground = Color.FromArgb(90, 70, 70, 70);
@@ -752,6 +757,16 @@ public class AudioVisualizer : Control
                 videoPosition = StartPositionSeconds + halfWidthInSeconds;
             }
             OnVideoPositionChanged?.Invoke(this, new PositionEventArgs { PositionInSeconds = videoPosition });
+        }
+        else if (Se.Settings.Waveform.CenterVideoPosition && WavePeaks != null && GetIsVideoPlaying?.Invoke() == true)
+        {
+            // Center mode while playing: the ~60 fps cursor timer re-centers the view on the
+            // play-head every tick, so a plain scroll used to snap straight back - scrolling
+            // only worked while paused (#12864). Honor the scroll by seeking the video to the
+            // new view center instead: the play-head stays pinned to the middle and the video
+            // follows the scroll, matching SE 4. Paused scrolling stays free (no seek).
+            var halfWidthInSeconds = (Bounds.Width / 2) / (WavePeaks.SampleRate * ZoomFactor);
+            OnVideoPositionChanged?.Invoke(this, new PositionEventArgs { PositionInSeconds = StartPositionSeconds + halfWidthInSeconds });
         }
 
         InvalidateVisual();

--- a/src/ui/Features/Main/Layout/InitWaveform.cs
+++ b/src/ui/Features/Main/Layout/InitWaveform.cs
@@ -73,6 +73,7 @@ public class InitWaveform
                 WaveformHeightPercentage = settings.SpectrogramCombinedWaveformHeight,
             };
 
+            vm.AudioVisualizer.GetIsVideoPlaying = () => vm.GetVideoPlayerControl()?.IsPlaying == true;
             vm.AudioVisualizer.OnNewSelectionInsert += vm.AudioVisualizerOnNewSelectionInsert;
             vm.AudioVisualizer.OnVideoPositionChanged += vm.AudioVisualizerOnVideoPositionChanged;
             vm.AudioVisualizer.OnToggleSelection += vm.AudioVisualizerOnToggleSelection;


### PR DESCRIPTION
Part of #12864 ("While the video is playing, mouse scroll doesn't work if the cursor is on the waveform (only works when the video is paused)").

### Problem

With **Center video position** on, the ~60 fps cursor timer re-centers the waveform view on the play-head every tick while playing, so any plain mouse-wheel scroll over the waveform was snapped back within 16 ms — scrolling effectively only worked while paused.

### Fix

Instead of suppressing the centering, a plain wheel scroll while playing now seeks the video to the new view center: the play-head stays pinned to the middle and the video follows the scroll, matching SE 4's locked/center behavior (the issue's own words: "it should stay in the center and the video is supposed to change"). The existing seek pinning (`PinPlayheadTo`) holds the view stable until mpv arrives, so rapid wheeling doesn't flicker or rubber-band.

- `AudioVisualizer` gets a `GetIsVideoPlaying` delegate so the wheel handler can ask the host for playback state; only the main window wires it up.
- Dialogs hosting a waveform (visual sync, point sync, cut video, TTS review) never set the delegate and keep plain scrolling.
- Paused scrolling is unchanged (still free scrolling, no seek).
- The `MouseWheelSetsVideoPosition` (SE 4 wheel-seeks) path and Ctrl/Cmd-scroll are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)