### PR TITLE
Add "Copy subtitle" to waveform (Ctrl+C and context menu)

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -117,6 +117,7 @@
     "convertingXofYDotDoDot": "Converting {0:#,###,##0}/{1:#,###,##0}...",
     "copy": "Copy",
     "copyImageToClipboard": "Copy image to clipboard",
+    "copySubtitleText": "Copy subtitle",
     "copyTextToClipboard": "Copy text to clipboard",
     "couldNotSaveFileXErrorY": "Could not save file \"{0}\". Error: {1}",
     "count": "Count",

--- a/src/ui/Features/Main/Layout/InitWaveform.cs
+++ b/src/ui/Features/Main/Layout/InitWaveform.cs
@@ -183,6 +183,14 @@ public class InitWaveform
             flyout.Items.Add(insertAfterMenuItem);
             vm.MenuItemAudioVisualizerInsertAfter = insertAfterMenuItem;
 
+            var copyTextMenuItem = new MenuItem
+            {
+                Header = Se.Language.General.CopySubtitleText,
+                Command = vm.WaveformCopyTextToClipboardCommand,
+            };
+            flyout.Items.Add(copyTextMenuItem);
+            vm.MenuItemAudioVisualizerCopyText = copyTextMenuItem;
+
             var separator1 = new Separator();
             flyout.Items.Add(separator1);
             vm.MenuItemAudioVisualizerSeparator1 = separator1;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -458,6 +458,7 @@ public partial class MainViewModel :
     public MenuItem MenuItemAudioVisualizerSpeechToTextSelectedLines { get; set; }
     public MenuItem MenuItemAudioVisualizerSpeechToTextNewSelection { get; set; }
     public MenuItem MenuItemAudioVisualizerExtractAudio { get; set; }
+    public MenuItem MenuItemAudioVisualizerCopyText { get; set; }
     public ITextBoxWrapper EditTextBoxOriginal { get; set; }
     public ITextBoxWrapper EditTextBox { get; set; }
     public StackPanel PanelSingleLineLengthsOriginal { get; set; }
@@ -553,6 +554,7 @@ public partial class MainViewModel :
         MenuItemAudioVisualizerSpeechToTextSelectedLines = new MenuItem();
         MenuItemAudioVisualizerSpeechToTextNewSelection = new MenuItem();
         MenuItemAudioVisualizerExtractAudio = new MenuItem();
+        MenuItemAudioVisualizerCopyText = new MenuItem();
         MenuItemStyles = new MenuItem();
         MenuItemActors = new MenuItem();
         AudioTraksMenuItem = new MenuItem();
@@ -4997,6 +4999,23 @@ public partial class MainViewModel :
         await ClipboardHelper.SetTextAsync(Window, sb.ToString());
 
         ShowStatus(string.Format("{0} lines copied to clipboard", selectedItems.Count));
+    }
+
+    /// <summary>
+    /// Copies the full text of the currently selected subtitle (the one shown in the edit box and
+    /// highlighted on the waveform) to the clipboard. Wired to Ctrl+C while the waveform is focused
+    /// and to the waveform context menu's "Copy subtitle" item.
+    /// </summary>
+    [RelayCommand]
+    private async Task WaveformCopyTextToClipboard()
+    {
+        var selectedSubtitle = SelectedSubtitle;
+        if (Window == null || selectedSubtitle == null)
+        {
+            return;
+        }
+
+        await ClipboardHelper.SetTextAsync(Window, selectedSubtitle.Text);
     }
 
     [RelayCommand]
@@ -23282,6 +23301,7 @@ public partial class MainViewModel :
         MenuItemAudioVisualizerSpeechToTextSelectedLines.IsVisible = false;
         MenuItemAudioVisualizerSpeechToTextNewSelection.IsVisible = false;
         MenuItemAudioVisualizerExtractAudio.IsVisible = false;
+        MenuItemAudioVisualizerCopyText.IsVisible = false;
 
         if (e.NewParagraph != null)
         {
@@ -23316,6 +23336,7 @@ public partial class MainViewModel :
         {
             MenuItemAudioVisualizerInsertBefore.IsVisible = true;
             MenuItemAudioVisualizerInsertAfter.IsVisible = true;
+            MenuItemAudioVisualizerCopyText.IsVisible = true;
             MenuItemAudioVisualizerSeparator1.IsVisible = true;
             MenuItemAudioVisualizerDelete.IsVisible = true;
             MenuItemAudioVisualizerSplit.IsVisible = true;

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -117,6 +117,7 @@ public class LanguageGeneral
     public string ConvertingXofYDotDoDot { get; set; }
     public string Copy { get; set; }
     public string CopyImageToClipboard { get; set; }
+    public string CopySubtitleText { get; set; }
     public string CopyTextToClipboard { get; set; }
     public string CouldNotSaveFileXErrorY { get; set; }
     public string CouldNotOpenFileXErrorY { get; set; }
@@ -882,6 +883,7 @@ public class LanguageGeneral
         ConvertingXofYDotDoDot = "Converting {0:#,###,##0}/{1:#,###,##0}...";
         Copy = "Copy";
         CopyImageToClipboard = "Copy image to clipboard";
+        CopySubtitleText = "Copy subtitle";
         CopyTextToClipboard = "Copy text to clipboard";
         CouldNotSaveFileXErrorY = "Could not save file \"{0}\". Error: {1}";
         CouldNotOpenFileXErrorY = "Could not open file \"{0}\". Error: {1}";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -416,6 +416,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.WaveformInsertAtPositionAndFocusTextBoxCommand), Se.Language.General.InsertAtPositionAndFocusTextBox },
         { nameof(MainViewModel.WaveformInsertAtPositionNoFocusTextBoxCommand), Se.Language.General.InsertAtPositionNoFocusTextBox },
         { nameof(MainViewModel.WaveformPasteFromClipboardCommand), Se.Language.General.WaveformPasteFromClipboard },
+        { nameof(MainViewModel.WaveformCopyTextToClipboardCommand), Se.Language.General.CopySubtitleText },
         { nameof(MainViewModel.FocusSelectedLineCommand), Se.Language.General.FocusSelectedLine },
         { nameof(MainViewModel.PlayFromStartOfVideoCommand), Se.Language.General.PlayFromStartOfVideo },
         { nameof(MainViewModel.VideoPlayFromJustBeforeTextCommand), Se.Language.General.PlayFromJustBeforeText },
@@ -808,6 +809,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.WaveformInsertAtPositionAndFocusTextBoxCommand, nameof(vm.WaveformInsertAtPositionAndFocusTextBoxCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.WaveformInsertAtPositionNoFocusTextBoxCommand, nameof(vm.WaveformInsertAtPositionNoFocusTextBoxCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.WaveformPasteFromClipboardCommand, nameof(vm.WaveformPasteFromClipboardCommand), ShortcutCategory.Waveform);
+        AddShortcut(shortcuts, vm.WaveformCopyTextToClipboardCommand, nameof(vm.WaveformCopyTextToClipboardCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.FocusSelectedLineCommand, nameof(vm.FocusSelectedLineCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.PlayFromStartOfVideoCommand, nameof(vm.PlayFromStartOfVideoCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.VideoPlayFromJustBeforeTextCommand, nameof(vm.VideoPlayFromJustBeforeTextCommand), ShortcutCategory.General, ShortcutGroup.Video);
@@ -924,6 +926,7 @@ public static class ShortcutsMain
             new(nameof(vm.ShowToolsRemoveTextForHearingImpairedCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.H)], ShortcutCategory.General),
             new(nameof(vm.ShowSyncAdjustAllTimesCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.A)], ShortcutCategory.General),
             new(nameof(vm.WaveformPasteFromClipboardCommand), [cmd, nameof(Avalonia.Input.Key.V)], ShortcutCategory.Waveform),
+            new(nameof(vm.WaveformCopyTextToClipboardCommand), [cmd, nameof(Avalonia.Input.Key.C)], ShortcutCategory.Waveform),
             new(nameof(vm.FillSelectedLinesWithClipboardCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.V)], ShortcutCategory.SubtitleGrid),
 
             // Tools / dialogs (V4 defaults)


### PR DESCRIPTION
## What

Adds the ability to copy the currently selected subtitle's full text from the audio waveform, in two ways:

1. **Ctrl+C** while the waveform is focused copies the selected subtitle (the one shown in the edit box and highlighted on the waveform) to the clipboard.
2. A new **"Copy subtitle"** item in the waveform right-click context menu, shown for the focused subtitle alongside Delete / Insert before / Insert after / Split / Merge.

Both copy `SelectedSubtitle.Text` via `ClipboardHelper.SetTextAsync`.

## Why

There was no way to copy a subtitle's text directly from the waveform. Ctrl+C on the focused waveform did nothing, and the context menu had no copy action.

## How

- New `WaveformCopyTextToClipboard` relay command in `MainViewModel`.
- Registered in the **Waveform** shortcut category with a default **Ctrl+C** binding (mirrors the existing `WaveformPasteFromClipboardCommand` Ctrl+V binding). It's remappable under Options → Shortcuts.
- New `MenuItem` in `InitWaveform.MakeWaveformContextMenu`, with visibility toggled in `AudioVisualizerFlyoutMenuOpening` (same condition as Delete/Insert for the focused subtitle).
- New `CopySubtitleText` string ("Copy subtitle") in `LanguageGeneral` + `English.json`.

## Testing

Built (Debug + Release, 0 errors/warnings from these changes) and verified in the running app: focusing a subtitle on the waveform and pressing Ctrl+C, and the new context-menu item, both copy the subtitle text.

## Images

<img width="265" height="500" alt="image" src="https://github.com/user-attachments/assets/5cbd2aff-4575-4f85-8125-f3b9f6118045" />
