### PR TITLE
Fix async/await bugs found in bughunt

### DIFF
--- a/src/ui/Features/Files/ImportImages/ImportImagesViewModel.cs
+++ b/src/ui/Features/Files/ImportImages/ImportImagesViewModel.cs
@@ -206,11 +206,20 @@ public partial class ImportImagesViewModel : ObservableObject
         }
     }
 
-    internal void FileGridTapped()
+    internal async void FileGridTapped()
     {
         if (Images.Count == 0)
         {
-            FileImport().ConfigureAwait(false);
+            try
+            {
+                await FileImport();
+            }
+            catch (Exception exception)
+            {
+                // async void: a throw from the picker/import would otherwise be lost
+                // (or crash), leaving the tap silently doing nothing.
+                Se.LogError(exception, "Import images via grid tap failed");
+            }
         }
     }
 }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -313,6 +313,7 @@ public partial class MainViewModel :
 
     private bool _updateAudioVisualizer;
     private bool _mpvPreviewDirty = true; // true = subtitle preview needs refresh in mpv
+    private bool _mpvPreviewRefreshBusy; // a refresh is in flight; skip ticks until it lands
     private string? _subtitleFileName;
     private string? _subtitleFileNameOriginal;
     private bool _converted;
@@ -18879,7 +18880,10 @@ public partial class MainViewModel :
                         break;
                     }
 
-                    await Task.Delay(100, _videoOpenTokenSource.Token).ConfigureAwait(false);
+                    // Deliberately NOT the cancellation token: cancel almost always lands
+                    // while this delay is pending, and a token here would throw us out of
+                    // the loop before the Kill above ever runs, orphaning ffmpeg.
+                    await Task.Delay(100, CancellationToken.None).ConfigureAwait(false);
                 }
 
                 if (!_videoOpenTokenSource.IsCancellationRequested && AudioVisualizer != null && AudioVisualizer.ShotChanges != null)
@@ -22277,7 +22281,7 @@ public partial class MainViewModel :
             AutoSaveTick(mainHash, originalHash);
 
             var vp = GetVideoPlayerControl();
-            if (!_mpvPreviewDirty || vp == null)
+            if (!_mpvPreviewDirty || vp == null || _mpvPreviewRefreshBusy)
             {
                 return;
             }
@@ -22297,7 +22301,7 @@ public partial class MainViewModel :
                     subtitle.Paragraphs.RemoveAll(p => !_visibleLayers!.Contains(p.Layer));
                 }
 
-                _mpvReloader.RefreshMpv(mpv, subtitle, _subtitleSecondary, SelectedSubtitleFormat).ConfigureAwait(false);
+                RunPreviewRefresh(() => _mpvReloader.RefreshMpv(mpv, subtitle, _subtitleSecondary, SelectedSubtitleFormat));
             }
             else if (vp.VideoPlayer is LibVlcDynamicPlayer vlc)
             {
@@ -22308,10 +22312,28 @@ public partial class MainViewModel :
                     subtitle.Paragraphs.RemoveAll(p => !_visibleLayers!.Contains(p.Layer));
                 }
 
-                _vlcReloader.RefreshVlc(vlc, subtitle, _subtitleSecondary, SelectedSubtitleFormat).ConfigureAwait(false);
+                RunPreviewRefresh(() => _vlcReloader.RefreshVlc(vlc, subtitle, _subtitleSecondary, SelectedSubtitleFormat));
             }
         };
         _slowTimer.Start();
+    }
+
+    private async void RunPreviewRefresh(Func<Task> refresh)
+    {
+        _mpvPreviewRefreshBusy = true;
+        try
+        {
+            await refresh();
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, "Video preview subtitle refresh failed");
+            _mpvPreviewDirty = true; // retry on a later tick
+        }
+        finally
+        {
+            _mpvPreviewRefreshBusy = false;
+        }
     }
 
     // Auto-save (saves the actual open file) state. Debounced: we only write once edits have

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17952,7 +17952,10 @@ public partial class MainViewModel :
 
     private void ShowStatus(string message, int delayMs = 3000)
     {
-        Task.Run(() => ShowStatusWithWaitAsync(message, delayMs));
+        // Post (not Task.Run) so the _statusFadeCts cancel/swap below is serialized
+        // on the UI thread — two rapid calls racing on the field from thread-pool
+        // threads could leave a stale timer alive to clear the newer message early.
+        Dispatcher.UIThread.Post(() => _ = ShowStatusWithWaitAsync(message, delayMs));
     }
 
     private async Task ShowStatusWithWaitAsync(string message, int delayMs = 3000)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -22304,7 +22304,7 @@ public partial class MainViewModel :
                     subtitle.Paragraphs.RemoveAll(p => !_visibleLayers!.Contains(p.Layer));
                 }
 
-                RunPreviewRefresh(() => _mpvReloader.RefreshMpv(mpv, subtitle, _subtitleSecondary, SelectedSubtitleFormat));
+                _ = RunPreviewRefresh(() => _mpvReloader.RefreshMpv(mpv, subtitle, _subtitleSecondary, SelectedSubtitleFormat));
             }
             else if (vp.VideoPlayer is LibVlcDynamicPlayer vlc)
             {
@@ -22315,13 +22315,13 @@ public partial class MainViewModel :
                     subtitle.Paragraphs.RemoveAll(p => !_visibleLayers!.Contains(p.Layer));
                 }
 
-                RunPreviewRefresh(() => _vlcReloader.RefreshVlc(vlc, subtitle, _subtitleSecondary, SelectedSubtitleFormat));
+                _ = RunPreviewRefresh(() => _vlcReloader.RefreshVlc(vlc, subtitle, _subtitleSecondary, SelectedSubtitleFormat));
             }
         };
         _slowTimer.Start();
     }
 
-    private async void RunPreviewRefresh(Func<Task> refresh)
+    private async Task RunPreviewRefresh(Func<Task> refresh)
     {
         _mpvPreviewRefreshBusy = true;
         try

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -4764,21 +4764,32 @@ public partial class OcrViewModel : ObservableObject
         {
             e.Cancel = true;
 
-            var result = await MessageBox.Show(
-                Window!,
-                "Discard OCR result?",
-                "Some items have OCR text. Close and discard the OCR result?",
-                MessageBoxButtons.YesNo,
-                MessageBoxIcon.Question);
-
-            if (result == MessageBoxResult.Yes)
+            try
             {
-                _forceClose = true;
-                SaveSettings();
-                UiUtil.SaveWindowPosition(Window);
-                Window?.Close();
+                var result = await MessageBox.Show(
+                    Window!,
+                    "Discard OCR result?",
+                    "Some items have OCR text. Close and discard the OCR result?",
+                    MessageBoxButtons.YesNo,
+                    MessageBoxIcon.Question);
+
+                if (result != MessageBoxResult.Yes)
+                {
+                    return;
+                }
+            }
+            catch (Exception exception)
+            {
+                // async void closing handler: a throw after e.Cancel = true would
+                // otherwise leave a window that can never be closed. Log and fall
+                // through to force close.
+                Se.LogError(exception, "OCR close prompt failed");
             }
 
+            _forceClose = true;
+            SaveSettings();
+            UiUtil.SaveWindowPosition(Window);
+            Window?.Close();
             return;
         }
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -246,6 +246,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     private CancellationToken _cancellationToken;
     private CancellationTokenSource _cancellationTokenSource;
     private CancellationTokenSource _addFilesCancellationTokenSource = new();
+    private CancellationTokenSource? _statusClearCts; // supersedes the pending status-clear timer
     private List<string> _encodings;
     private List<string> _targetFormatsWithSettings;
 
@@ -2297,14 +2298,36 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         });
     }
 
-    private async Task ShowStatus(string statusText)
+    private Task ShowStatus(string statusText)
     {
-        StatusText = statusText;
-        var _ = Task.Run(async () =>
+        // Post so callers on background threads (the convert Task.Run) set the
+        // bound property on the UI thread, and so the supersede logic below is
+        // serialized — a new status must cancel the previous clear timer, or an
+        // older 6-second timer would wipe a newer message early.
+        Dispatcher.UIThread.Post(() =>
         {
-            await Task.Delay(6000, _cancellationToken).ConfigureAwait(false);
-            StatusText = string.Empty;
-        }); 
+            StatusText = statusText;
+            _statusClearCts?.Cancel();
+            var cts = new CancellationTokenSource();
+            _statusClearCts = cts;
+            _ = ClearStatusAfterDelay(cts.Token);
+        });
+
+        return Task.CompletedTask;
+    }
+
+    private async Task ClearStatusAfterDelay(CancellationToken token)
+    {
+        try
+        {
+            await Task.Delay(6000, token);
+        }
+        catch (OperationCanceledException)
+        {
+            return; // superseded by a newer status message
+        }
+
+        StatusText = string.Empty;
     }
 
     internal void FileGridOnDragOver(object? sender, DragEventArgs e)

--- a/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
+++ b/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
@@ -301,9 +301,19 @@ public partial class FixNamesViewModel : ObservableObject, IClosingCleanup
         }
     }
 
-    internal void OnLoaded(RoutedEventArgs e)
+    internal async void OnLoaded(RoutedEventArgs e)
     {
-        DictionaryLoader.UnpackIfNotFound().ConfigureAwait(false);
+        try
+        {
+            // Must finish before NameList reads Se.DictionariesFolder — on first
+            // run the folder is only populated by this unpack.
+            await DictionaryLoader.UnpackIfNotFound();
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, "Failed to unpack bundled dictionaries");
+        }
+
         _nameList = new NameList(Se.DictionariesFolder, _language, false, string.Empty);
 
         ExtraNames = Se.Settings.Tools.ChangeCasing.ExtraNames;

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -31,6 +31,25 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
     [ObservableProperty] private string _progressText;
     [ObservableProperty] private string _error;
 
+    /// <summary>
+    /// The download/unpack flow runs on the System.Timers.Timer elapsed thread and
+    /// sets bound properties (TitleText, ProgressValue, ...) directly from it, and
+    /// its Progress callbacks fire on thread-pool threads. Avalonia bindings are not
+    /// thread-safe, so marshal every change notification to the UI thread here
+    /// instead of wrapping the ~20 individual property writes in Post.
+    /// </summary>
+    protected override void OnPropertyChanged(System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            base.OnPropertyChanged(e);
+        }
+        else
+        {
+            Dispatcher.UIThread.Post(() => base.OnPropertyChanged(e));
+        }
+    }
+
     public Window? Window { get; set; }
     public bool OkPressed { get; internal set; }
     public ISpeechToTextEngine? Engine { get; internal set; }

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
@@ -446,7 +446,19 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject, ICl
 
     internal async void StartDownload()
     {
-        await Task.Delay(200);
-        Download();
+        try
+        {
+            await Task.Delay(200);
+            Download();
+        }
+        catch (Exception exception)
+        {
+            // async void: without this catch a throw from Download() (bad URL list,
+            // path failure) would land in the dispatcher unhandled and crash the app,
+            // with the caller unable to observe it.
+            Se.LogError(exception, "Speech-to-text model download failed to start");
+            ProgressText = "Download failed";
+            Error = exception.Message;
+        }
     }
 }

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -1156,13 +1156,30 @@ public partial class SpeechToTextViewModel : ObservableObject
         ProgressText = Se.Language.Video.AudioToText.Transcribing;
         ProgressValue = 5;
 
-        var probeError = await ProbeOpenAiUrlAsync(engine.ProbeUrl, cancellationToken);
-        if (probeError != null)
+        string? probeError;
+        try
         {
-            LogToConsole($"Online STT endpoint probe failed: {probeError}. Retrying...");
-            // Brief delay so transient DNS/socket hiccups have a chance to recover before retrying.
-            await Task.Delay(300, cancellationToken);
             probeError = await ProbeOpenAiUrlAsync(engine.ProbeUrl, cancellationToken);
+            if (probeError != null)
+            {
+                LogToConsole($"Online STT endpoint probe failed: {probeError}. Retrying...");
+                // Brief delay so transient DNS/socket hiccups have a chance to recover before retrying.
+                await Task.Delay(300, cancellationToken);
+                probeError = await ProbeOpenAiUrlAsync(engine.ProbeUrl, cancellationToken);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // This runs as a fire-and-forget task, so a cancel during the probe phase
+            // (up to two 8-second probes) must reset the UI here — nothing downstream
+            // will, and the window would otherwise be stuck on a live progress bar.
+            LogToConsole("Transcription cancelled by user");
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                IsTranscribeEnabled = true;
+                HideProgressBar();
+            });
+            return;
         }
 
         if (probeError != null)

--- a/src/ui/Logic/Dictionaries/DictionaryLoader.cs
+++ b/src/ui/Logic/Dictionaries/DictionaryLoader.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Nikse.SubtitleEdit.Logic.Compression;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -9,9 +10,16 @@ public static class DictionaryLoader
 {
     public static async Task UnpackIfNotFound()
     {
+        // Also unpack when the folder exists but is empty: the folder is created
+        // before the unpack runs, so an unpack that failed (or was interrupted)
+        // would otherwise never be retried.
         if (!Directory.Exists(Se.DictionariesFolder))
         {
             Directory.CreateDirectory(Se.DictionariesFolder);
+            await UnpackDictionaries();
+        }
+        else if (!Directory.EnumerateFileSystemEntries(Se.DictionariesFolder).Any())
+        {
             await UnpackDictionaries();
         }
     }

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicNativeControl.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicNativeControl.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Platform;
 using Avalonia.Threading;
+using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Runtime.InteropServices;
 using System.Timers;
@@ -445,9 +446,22 @@ public class LibMpvDynamicNativeControl : NativeControlHost
         });
     }
 
-    public void LoadFile(string path)
+    public async void LoadFile(string path)
     {
-        _mpvPlayer?.LoadFile(path);
+        if (_mpvPlayer == null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _mpvPlayer.LoadFile(path);
+        }
+        catch (Exception exception)
+        {
+            // The load task was previously discarded, hiding open failures entirely.
+            Se.LogError(exception, $"mpv failed to load video file: {path}");
+        }
     }
 
     public void TogglePlayPause()

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicOpenGlControl.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicOpenGlControl.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using Avalonia.OpenGL;
 using Avalonia.OpenGL.Controls;
 using Avalonia.Threading;
+using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Runtime.InteropServices;
 
@@ -140,9 +141,22 @@ public class LibMpvDynamicOpenGlControl : OpenGlControlBase
         base.OnOpenGlDeinit(gl);
     }
 
-    public void LoadFile(string path)
+    public async void LoadFile(string path)
     {
-        _mpvPlayer?.LoadFile(path);
+        if (_mpvPlayer == null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _mpvPlayer.LoadFile(path);
+        }
+        catch (Exception exception)
+        {
+            // The load task was previously discarded, hiding open failures entirely.
+            Se.LogError(exception, $"mpv failed to load video file: {path}");
+        }
     }
 
     public void TogglePlayPause()

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicSoftwareControl.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicSoftwareControl.cs
@@ -176,13 +176,13 @@ public class LibMpvDynamicSoftwareControl : Control
             return;
         }
 
-        var loadTask = _mpvPlayer.LoadFile(path);
-
-        // Trigger initial render
-        InvalidateVisual();
-
         try
         {
+            var loadTask = _mpvPlayer.LoadFile(path);
+
+            // Trigger initial render
+            InvalidateVisual();
+
             await loadTask;
         }
         catch (Exception exception)

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicSoftwareControl.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicSoftwareControl.cs
@@ -169,11 +169,27 @@ public class LibMpvDynamicSoftwareControl : Control
         _isInitialized = false;
     }
 
-    public void LoadFile(string path)
+    public async void LoadFile(string path)
     {
-        _mpvPlayer?.LoadFile(path);
+        if (_mpvPlayer == null)
+        {
+            return;
+        }
+
+        var loadTask = _mpvPlayer.LoadFile(path);
+
         // Trigger initial render
         InvalidateVisual();
+
+        try
+        {
+            await loadTask;
+        }
+        catch (Exception exception)
+        {
+            // The load task was previously discarded, hiding open failures entirely.
+            Se.LogError(exception, $"mpv failed to load video file: {path}");
+        }
     }
 
     public void TogglePlayPause()

--- a/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicNativeControl.cs
+++ b/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicNativeControl.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Platform;
 using Avalonia.Threading;
+using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Runtime.InteropServices;
 
@@ -284,13 +285,21 @@ public class LibVlcDynamicNativeControl : NativeControlHost
             return;
         }
 
-        await _vlcPlayer.LoadFile(path);
+        try
+        {
+            await _vlcPlayer.LoadFile(path);
 
-        // Wait a bit for VLC to parse the media information
-        // This ensures Duration and other metadata are available
-        await System.Threading.Tasks.Task.Delay(300);
+            // Wait a bit for VLC to parse the media information
+            // This ensures Duration and other metadata are available
+            await System.Threading.Tasks.Task.Delay(300);
 
-        System.Diagnostics.Debug.WriteLine($"File loaded, duration: {_vlcPlayer.Duration}s");
+            System.Diagnostics.Debug.WriteLine($"File loaded, duration: {_vlcPlayer.Duration}s");
+        }
+        catch (Exception exception)
+        {
+            // async void: a throw here would otherwise crash the process.
+            Se.LogError(exception, $"VLC failed to load video file: {path}");
+        }
     }
 
     public void TogglePlayPause()

--- a/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicOpenGlControl.cs
+++ b/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicOpenGlControl.cs
@@ -1,6 +1,7 @@
 using Avalonia.Input;
 using Avalonia.OpenGL;
 using Avalonia.OpenGL.Controls;
+using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -206,12 +207,17 @@ public class LibVlcDynamicOpenGlControl : OpenGlControlBase
         base.OnOpenGlDeinit(gl);
     }
 
-    public void LoadFile(string path)
+    public async void LoadFile(string path)
     {
-        _vlcPlayer?.LoadFile(path);
-        
+        if (_vlcPlayer == null)
+        {
+            return;
+        }
+
+        var loadTask = _vlcPlayer.LoadFile(path);
+
         // Update video dimensions after loading file
-        System.Threading.Tasks.Task.Run(async () =>
+        _ = System.Threading.Tasks.Task.Run(async () =>
         {
             // Wait a bit for VLC to initialize the media
             await System.Threading.Tasks.Task.Delay(500);
@@ -221,6 +227,16 @@ public class LibVlcDynamicOpenGlControl : OpenGlControlBase
                 RequestNextFrameRendering();
             });
         });
+
+        try
+        {
+            await loadTask;
+        }
+        catch (Exception exception)
+        {
+            // The load task was previously discarded, hiding open failures entirely.
+            Se.LogError(exception, $"VLC failed to load video file: {path}");
+        }
     }
 
     public void TogglePlayPause()

--- a/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicOpenGlControl.cs
+++ b/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicOpenGlControl.cs
@@ -214,22 +214,22 @@ public class LibVlcDynamicOpenGlControl : OpenGlControlBase
             return;
         }
 
-        var loadTask = _vlcPlayer.LoadFile(path);
-
-        // Update video dimensions after loading file
-        _ = System.Threading.Tasks.Task.Run(async () =>
-        {
-            // Wait a bit for VLC to initialize the media
-            await System.Threading.Tasks.Task.Delay(500);
-            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
-            {
-                UpdateVideoDimensions();
-                RequestNextFrameRendering();
-            });
-        });
-
         try
         {
+            var loadTask = _vlcPlayer.LoadFile(path);
+
+            // Update video dimensions after loading file
+            _ = System.Threading.Tasks.Task.Run(async () =>
+            {
+                // Wait a bit for VLC to initialize the media
+                await System.Threading.Tasks.Task.Delay(500);
+                Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                {
+                    UpdateVideoDimensions();
+                    RequestNextFrameRendering();
+                });
+            });
+
             await loadTask;
         }
         catch (Exception exception)

--- a/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicSoftwareControl.cs
+++ b/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicSoftwareControl.cs
@@ -4,6 +4,7 @@ using Avalonia.Input;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
+using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Threading;
 
@@ -166,12 +167,17 @@ public class LibVlcDynamicSoftwareControl : Control
         _isInitialized = false;
     }
 
-    public void LoadFile(string path)
+    public async void LoadFile(string path)
     {
-        _vlcPlayer?.LoadFile(path);
-        
+        if (_vlcPlayer == null)
+        {
+            return;
+        }
+
+        var loadTask = _vlcPlayer.LoadFile(path);
+
         // Update video dimensions after loading file
-        System.Threading.Tasks.Task.Run(async () =>
+        _ = System.Threading.Tasks.Task.Run(async () =>
         {
             // Wait a bit for VLC to initialize the media
             await System.Threading.Tasks.Task.Delay(500);
@@ -181,6 +187,16 @@ public class LibVlcDynamicSoftwareControl : Control
                 InvalidateVisual();
             });
         });
+
+        try
+        {
+            await loadTask;
+        }
+        catch (Exception exception)
+        {
+            // The load task was previously discarded, hiding open failures entirely.
+            Se.LogError(exception, $"VLC failed to load video file: {path}");
+        }
     }
 
     public void TogglePlayPause()

--- a/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicSoftwareControl.cs
+++ b/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicSoftwareControl.cs
@@ -174,22 +174,22 @@ public class LibVlcDynamicSoftwareControl : Control
             return;
         }
 
-        var loadTask = _vlcPlayer.LoadFile(path);
-
-        // Update video dimensions after loading file
-        _ = System.Threading.Tasks.Task.Run(async () =>
-        {
-            // Wait a bit for VLC to initialize the media
-            await System.Threading.Tasks.Task.Delay(500);
-            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
-            {
-                UpdateVideoDimensions();
-                InvalidateVisual();
-            });
-        });
-
         try
         {
+            var loadTask = _vlcPlayer.LoadFile(path);
+
+            // Update video dimensions after loading file
+            _ = System.Threading.Tasks.Task.Run(async () =>
+            {
+                // Wait a bit for VLC to initialize the media
+                await System.Threading.Tasks.Task.Delay(500);
+                Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                {
+                    UpdateVideoDimensions();
+                    InvalidateVisual();
+                });
+            });
+
             await loadTask;
         }
         catch (Exception exception)


### PR DESCRIPTION
Fixes eleven async/await defects found in a systematic hunt across the UI codebase (fire-and-forget tasks, lost exceptions, races across awaits, cancellation bugs, and off-UI-thread binding updates).

## User-visible bugs

- **Online STT: cancel during endpoint probe stranded the dialog.** Cancelling within the probe phase (up to two 8-second probes + retry delay) threw `OperationCanceledException` outside the fire-and-forget task's try/catch, leaving the progress bar live and transcribe disabled forever. The probe phase now has its own cancel handler that resets the UI.
- **Fix Names: name list built before dictionaries were unpacked.** `UnpackIfNotFound()` was called with a no-op `.ConfigureAwait(false)` instead of `await`, so on first run `NameList` read a folder still being unpacked and the window showed no names. Also unpack when the folder exists but is empty, since the folder is created before the unpack runs and a failed unpack was never retried.
- **Shot changes: cancelling video open orphaned ffmpeg.** The watch loop passed the video-open cancellation token to its `Task.Delay`, so cancel almost always threw out of the loop before reaching `Kill(true)`. The delay now uses `CancellationToken.None` so the kill branch runs (cancel responsiveness unchanged at ≤100 ms).
- **Video preview: failed subtitle refreshes were silent and never retried.** `RefreshMpv`/`RefreshVlc` were fired unawaited from the slow timer with `_mpvPreviewDirty` already cleared. Refreshes now run through a guarded helper that logs failures, re-marks the preview dirty for retry, and skips ticks while a refresh is in flight.
- **STT model download: `async void StartDownload` could crash the app.** A throw from `Download()` after the await (bad URL list, path failure) landed in the dispatcher unhandled, with ~14 call sites unable to observe it. Now caught, logged, and surfaced via `ProgressText`/`Error` like the llama.cpp sibling.
- **Video players: all six `LoadFile` implementations lost load failures.** Five wrappers discarded the `Task` returned by the player's `LoadFile` (blank player, nothing logged); the VLC native control awaited it in an unguarded `async void` (process crash). All now await with a logged catch, preserving the original ordering of the dimension-update task / `InvalidateVisual`.
- **OCR: a throw from the close prompt left an uncloseable window.** The discard-prompt await after `e.Cancel = true` had no handler in an `async void` closing handler. Now guarded like `BinaryEditViewModel.OnClosing`: log and force close.

## Races and thread-safety

- **Batch Convert status text:** each `ShowStatus` spawned an independent 6-second `Task.Run` clear timer, so an older timer wiped a newer message early, and `StatusText` was set from a thread-pool thread. Now posts to the UI thread and supersedes the pending clear timer via a CTS.
- **Main window status text:** `ShowStatus` ran `ShowStatusWithWaitAsync` via `Task.Run`, racing the unsynchronized `_statusFadeCts` cancel/swap. It doesn't block before its first await, so it's posted to the UI thread instead, serializing the swap.
- **STT engine download dialog:** the download/unpack flow runs on a `System.Timers.Timer` elapsed thread and set bound properties directly from it (and from `Progress` callbacks on thread-pool threads). An `OnPropertyChanged` override now marshals every change notification to the UI thread.
- **Import images:** the empty-grid tap fired `FileImport()` with a no-op `.ConfigureAwait(false)`, losing picker/import exceptions. Now awaited with a logged catch.

Builds clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)