### PR TITLE
Add Q6_K and Q8_0 quants to MOSS-TTS text-to-speech engine

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
@@ -26,9 +26,9 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 /// user-supplied reference WAV. CrispASR ships it as the <c>moss-tts</c> backend
 /// (cstr/moss-tts-v1.5-GGUF on Hugging Face). Requested in #12617.
 ///
-/// The repo ships two quants of the backbone plus a shared codec companion:
-///   - Backbone : moss-tts-v1.5-{q4_k,f16}.gguf  (we stage the one the user picks)
-///   - Codec    : moss-tts-v1.5-codec.gguf       (~3.5 GB; shared by both quants)
+/// The repo ships four quants of the backbone plus a shared codec companion:
+///   - Backbone : moss-tts-v1.5-{q4_k,q6_k,q8_0,f16}.gguf  (we stage the one the user picks)
+///   - Codec    : moss-tts-v1.5-codec.gguf                 (~3.5 GB; shared by all quants)
 /// crispasr resolves the codec from sibling/cache/registry, but we pass <c>--codec-model</c>
 /// explicitly when both files are staged locally so resolution never silently falls back to a
 /// network fetch. <see cref="Nikse.SubtitleEdit.Logic.Download.MossTtsCrispAsrDownloadService"/>
@@ -69,13 +69,18 @@ public class MossTtsCrispAsr : ITtsEngine
     public bool HasModel => true;
     public bool HasKeyFile => false;
 
-    // Two backbone quants — Q4_K is the default (~7 GB), F16 the reference (~17 GB). Both also
+    // Four backbone quants — Q4_K is the default (~7 GB), F16 the reference (~17 GB), with
+    // Q6_K/Q8_0 in between (added upstream 2026-07-27, TTS round-trip validated; #12905). All
     // need the shared ~3.5 GB codec companion, so the labels carry the combined footprint.
     public const string ModelKeyQ4K = "Q4_K (~10.5 GB incl. codec)";
+    public const string ModelKeyQ6K = "Q6_K (~12.3 GB incl. codec)";
+    public const string ModelKeyQ8 = "Q8_0 (~14.0 GB incl. codec)";
     public const string ModelKeyF16 = "F16 (~20.5 GB incl. codec)";
     public const string DefaultModelKey = ModelKeyQ4K;
 
     public const string ModelQ4KFileName = "moss-tts-v1.5-q4_k.gguf";
+    public const string ModelQ6KFileName = "moss-tts-v1.5-q6_k.gguf";
+    public const string ModelQ8FileName = "moss-tts-v1.5-q8_0.gguf";
     public const string ModelF16FileName = "moss-tts-v1.5-f16.gguf";
     public const string CodecFileName = "moss-tts-v1.5-codec.gguf";
 
@@ -102,6 +107,8 @@ public class MossTtsCrispAsr : ITtsEngine
     private static readonly Dictionary<string, long> ExpectedFileSizes = new(StringComparer.OrdinalIgnoreCase)
     {
         [ModelQ4KFileName] = 7001179808L,
+        [ModelQ6KFileName] = 8791885472L,
+        [ModelQ8FileName] = 10474063520L,
         [ModelF16FileName] = 16985720416L,
         [CodecFileName] = 3549253856L,
     };
@@ -116,6 +123,8 @@ public class MossTtsCrispAsr : ITtsEngine
 
         return modelKey switch
         {
+            ModelKeyQ6K => ModelKeyQ6K,
+            ModelKeyQ8 => ModelKeyQ8,
             ModelKeyF16 => ModelKeyF16,
             _ => ModelKeyQ4K,
         };
@@ -123,6 +132,8 @@ public class MossTtsCrispAsr : ITtsEngine
 
     public static string GetModelFileName(string? modelKey) => ResolveModelKey(modelKey) switch
     {
+        ModelKeyQ6K => ModelQ6KFileName,
+        ModelKeyQ8 => ModelQ8FileName,
         ModelKeyF16 => ModelF16FileName,
         _ => ModelQ4KFileName,
     };
@@ -417,7 +428,7 @@ public class MossTtsCrispAsr : ITtsEngine
 
     public Task<string[]> GetRegions() => Task.FromResult(Array.Empty<string>());
 
-    public Task<string[]> GetModels() => Task.FromResult(new[] { ModelKeyQ4K, ModelKeyF16 });
+    public Task<string[]> GetModels() => Task.FromResult(new[] { ModelKeyQ4K, ModelKeyQ6K, ModelKeyQ8, ModelKeyF16 });
 
     public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(MossTtsLanguages.All);
 

--- a/src/ui/Features/Video/TextToSpeech/MossTtsCrispAsrSettings/MossTtsCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/MossTtsCrispAsrSettings/MossTtsCrispAsrSettingsViewModel.cs
@@ -34,6 +34,12 @@ public partial class MossTtsCrispAsrSettingsViewModel : ObservableObject
     [ObservableProperty] private string _modelQ4KLabel = string.Empty;
     [ObservableProperty] private IBrush _modelQ4KBrush = Grey();
 
+    [ObservableProperty] private string _modelQ6KLabel = string.Empty;
+    [ObservableProperty] private IBrush _modelQ6KBrush = Grey();
+
+    [ObservableProperty] private string _modelQ8Label = string.Empty;
+    [ObservableProperty] private IBrush _modelQ8Brush = Grey();
+
     [ObservableProperty] private string _modelF16Label = string.Empty;
     [ObservableProperty] private IBrush _modelF16Brush = Grey();
 
@@ -126,6 +132,18 @@ public partial class MossTtsCrispAsrSettingsViewModel : ObservableObject
             IsEngineInstalled,
             label => ModelQ4KLabel = label,
             brush => ModelQ4KBrush = brush);
+
+        ApplyModelStatus(
+            MossTtsCrispAsr.AreModelsInstalled(MossTtsCrispAsr.ModelKeyQ6K),
+            IsEngineInstalled,
+            label => ModelQ6KLabel = label,
+            brush => ModelQ6KBrush = brush);
+
+        ApplyModelStatus(
+            MossTtsCrispAsr.AreModelsInstalled(MossTtsCrispAsr.ModelKeyQ8),
+            IsEngineInstalled,
+            label => ModelQ8Label = label,
+            brush => ModelQ8Brush = brush);
 
         ApplyModelStatus(
             MossTtsCrispAsr.AreModelsInstalled(MossTtsCrispAsr.ModelKeyF16),

--- a/src/ui/Features/Video/TextToSpeech/MossTtsCrispAsrSettings/MossTtsCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/MossTtsCrispAsrSettings/MossTtsCrispAsrSettingsWindow.cs
@@ -104,6 +104,8 @@ public class MossTtsCrispAsrSettingsWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnSpacing = 12,
             RowSpacing = 10,
@@ -121,22 +123,28 @@ public class MossTtsCrispAsrSettingsWindow : Window
         grid.Add(MakeLabel("Model " + MossTtsCrispAsr.ModelKeyQ4K), 1, 0);
         grid.Add(MakeStatusPanel(nameof(vm.ModelQ4KBrush), nameof(vm.ModelQ4KLabel)), 1, 1);
 
-        grid.Add(MakeLabel("Model " + MossTtsCrispAsr.ModelKeyF16), 2, 0);
-        grid.Add(MakeStatusPanel(nameof(vm.ModelF16Brush), nameof(vm.ModelF16Label)), 2, 1);
+        grid.Add(MakeLabel("Model " + MossTtsCrispAsr.ModelKeyQ6K), 2, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.ModelQ6KBrush), nameof(vm.ModelQ6KLabel)), 2, 1);
 
-        grid.Add(MakeLabel("Voices"), 3, 0);
+        grid.Add(MakeLabel("Model " + MossTtsCrispAsr.ModelKeyQ8), 3, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.ModelQ8Brush), nameof(vm.ModelQ8Label)), 3, 1);
+
+        grid.Add(MakeLabel("Model " + MossTtsCrispAsr.ModelKeyF16), 4, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.ModelF16Brush), nameof(vm.ModelF16Label)), 4, 1);
+
+        grid.Add(MakeLabel("Voices"), 5, 0);
         var voicesText = new TextBlock
         {
             VerticalAlignment = VerticalAlignment.Center,
             FontWeight = FontWeight.SemiBold,
             [!TextBlock.TextProperty] = new Binding(nameof(vm.VoicesLabel)),
         };
-        grid.Add(voicesText, 3, 1);
+        grid.Add(voicesText, 5, 1);
 
-        grid.Add(MakeLabel(Se.Language.General.Speed), 4, 0);
-        grid.Add(MakeSpeedPanel(), 4, 1);
+        grid.Add(MakeLabel(Se.Language.General.Speed), 6, 0);
+        grid.Add(MakeSpeedPanel(), 6, 1);
 
-        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 5, 0);
+        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 7, 0);
         var folderText = new TextBox
         {
             IsReadOnly = true,
@@ -148,7 +156,7 @@ public class MossTtsCrispAsrSettingsWindow : Window
             FontSize = 12,
             [!TextBox.TextProperty] = new Binding(nameof(vm.ModelsFolder)),
         };
-        grid.Add(folderText, 5, 1);
+        grid.Add(folderText, 7, 1);
 
         return new Border
         {

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -227,9 +227,11 @@ public static class DownloadHashManager
 
     public static class MossTtsCrispAsr
     {
-        // SHA-256 of each GGUF the moss-tts backend needs: the two backbone quants and the
+        // SHA-256 of each GGUF the moss-tts backend needs: the four backbone quants and the
         // shared moss-tts-v1.5-codec.gguf companion. Hashes are the HF LFS oid from the tree API.
         public const string ModelQ4K = "MossTtsCrispAsr.ModelQ4K";
+        public const string ModelQ6K = "MossTtsCrispAsr.ModelQ6K";
+        public const string ModelQ8 = "MossTtsCrispAsr.ModelQ8";
         public const string ModelF16 = "MossTtsCrispAsr.ModelF16";
         public const string Codec = "MossTtsCrispAsr.Codec";
     }
@@ -1448,6 +1450,14 @@ public static class DownloadHashManager
             [MossTtsCrispAsr.ModelQ4K] = new[]
             {
                 "9e7fb9ed28339be5327dce16f9bd53c67220cbf119a9c767f513d28d1fa80547", // moss-tts-v1.5-q4_k.gguf
+            },
+            [MossTtsCrispAsr.ModelQ6K] = new[]
+            {
+                "5004d550a08c6d39aba1efdf72459a9da90b25e67c1ce62d6b08ef3ea22b85e8", // moss-tts-v1.5-q6_k.gguf
+            },
+            [MossTtsCrispAsr.ModelQ8] = new[]
+            {
+                "25a69f762ad67b3dee2191b2f3fa8d3fdb3433d6f2938aaae0efc23921408ba4", // moss-tts-v1.5-q8_0.gguf
             },
             [MossTtsCrispAsr.ModelF16] = new[]
             {

--- a/src/ui/Logic/Download/MossTtsCrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/MossTtsCrispAsrDownloadService.cs
@@ -29,6 +29,8 @@ public class MossTtsCrispAsrDownloadService : IMossTtsCrispAsrDownloadService
     private static readonly Dictionary<string, string> ModelUrls = new(StringComparer.OrdinalIgnoreCase)
     {
         [MossTtsCrispAsr.ModelQ4KFileName] = RepoBase + MossTtsCrispAsr.ModelQ4KFileName,
+        [MossTtsCrispAsr.ModelQ6KFileName] = RepoBase + MossTtsCrispAsr.ModelQ6KFileName,
+        [MossTtsCrispAsr.ModelQ8FileName] = RepoBase + MossTtsCrispAsr.ModelQ8FileName,
         [MossTtsCrispAsr.ModelF16FileName] = RepoBase + MossTtsCrispAsr.ModelF16FileName,
         [MossTtsCrispAsr.CodecFileName] = RepoBase + MossTtsCrispAsr.CodecFileName,
     };
@@ -99,6 +101,14 @@ public class MossTtsCrispAsrDownloadService : IMossTtsCrispAsrDownloadService
         if (string.Equals(fileName, MossTtsCrispAsr.ModelQ4KFileName, StringComparison.OrdinalIgnoreCase))
         {
             return DownloadHashManager.MossTtsCrispAsr.ModelQ4K;
+        }
+        if (string.Equals(fileName, MossTtsCrispAsr.ModelQ6KFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.MossTtsCrispAsr.ModelQ6K;
+        }
+        if (string.Equals(fileName, MossTtsCrispAsr.ModelQ8FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.MossTtsCrispAsr.ModelQ8;
         }
         if (string.Equals(fileName, MossTtsCrispAsr.ModelF16FileName, StringComparison.OrdinalIgnoreCase))
         {


### PR DESCRIPTION
### What

Adds the two new mid-range backbone quants from cstr/moss-tts-v1.5-GGUF (published 2026-07-27) to the MOSS-TTS (CrispASR `moss-tts` backend) engine:

- **Q6_K** — ~8.8 GB backbone, ~12.3 GB incl. the shared codec
- **Q8_0** — ~10.5 GB backbone, ~14.0 GB incl. the shared codec

They slot between the existing ~7 GB Q4_K default and the ~17 GB F16 reference; both reuse the shared ~3.5 GB `moss-tts-v1.5-codec.gguf` companion.

### Why

Q4_K is a big quality step down from F16, but F16 doesn't fit on many machines. The new quants give users a middle ground.

### How

- Model keys, file names, expected file sizes, and key/file resolution in `MossTtsCrispAsr`
- Download URLs and file-to-hash-key mapping in `MossTtsCrispAsrDownloadService`
- SHA-256 entries in `DownloadHashManager` (taken from the Hugging Face LFS oids)
- Two new status rows in the MOSS-TTS settings window

### Notes for review

- Both quants were TTS round-trip validated headlessly against the pinned crispasr release binary (#12905).
- Q4_K stays the default model key; existing installs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)