### PR TITLE
Show API url in auto-translate error details and widen the URL box

### DIFF
--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -1494,6 +1494,15 @@ public partial class AutoTranslateViewModel : ObservableObject
             {
                 var details = new System.Text.StringBuilder();
 
+                // Lead with the endpoint actually used - reports often only show the error
+                // dialog, and a wrong URL/port is invisible without it (#12907).
+                var configuredApiUrl = GetConfiguredApiUrl(translator);
+                if (!string.IsNullOrWhiteSpace(configuredApiUrl))
+                {
+                    details.AppendLine("API url: " + configuredApiUrl);
+                    details.AppendLine();
+                }
+
                 try
                 {
                     var json = translator.Error;
@@ -1553,6 +1562,37 @@ public partial class AutoTranslateViewModel : ObservableObject
                 SelectAndScrollToRow(Rows.IndexOf(lastTranslatedRow));
             }
         }
+    }
+
+    /// <summary>
+    /// The endpoint the given engine reads at Initialize, mirroring the SaveSettings blocks.
+    /// Empty for engines without a configurable URL (and for Papago, whose "URL" is a client ID).
+    /// </summary>
+    private static string GetConfiguredApiUrl(IAutoTranslator translator)
+    {
+        var settings = Configuration.Settings.Tools;
+        return translator switch
+        {
+            DeepLTranslate => settings.AutoTranslateDeepLUrl,
+            LibreTranslate => settings.AutoTranslateLibreUrl,
+            NoLanguageLeftBehindApi => settings.AutoTranslateNllbApiUrl,
+            NoLanguageLeftBehindServe => settings.AutoTranslateNllbServeUrl,
+            ChatGptTranslate => settings.ChatGptUrl,
+            OpenAiCompatibleTranslate => settings.OpenAiCompatibleTranslateUrl,
+            LmStudioTranslate => settings.LmStudioApiUrl,
+            OllamaTranslate => settings.OllamaApiUrl,
+            LlamaCppTranslate => settings.LlamaCppApiUrl,
+            AnthropicTranslate => settings.AnthropicApiUrl,
+            GroqTranslate => settings.GroqUrl,
+            OpenRouterTranslate => settings.OpenRouterUrl,
+            LaraTranslate => settings.LaraUrl,
+            PerplexityTranslate => settings.PerplexityUrl,
+            NvidiaTranslate => settings.NvidiaUrl,
+            MistralTranslate => settings.AutoTranslateMistralUrl,
+            DeepSeekTranslate => settings.DeepSeekUrl,
+            BaiduTranslate => settings.BaiduUrl,
+            _ => string.Empty,
+        };
     }
 
     private void SelectAndScrollToRow(int index)

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -327,7 +327,14 @@ public class AutoTranslateWindow : Window
         settingsPanel.Children.Add(checkBoxLlamaCppRemote);
 
         settingsPanel.Children.Add(UiUtil.MakeTextBlock(Se.Language.General.Url, vm, null, nameof(vm.ApiUrlIsVisible)).WithMarginRight(5));
-        settingsPanel.Children.Add(UiUtil.MakeTextBox(200, vm, nameof(vm.ApiUrlText), nameof(vm.ApiUrlIsVisible)).WithMarginRight(15).WithAccessibleName(Se.Language.General.Url));
+        // Wide enough for typical ".../v1/chat/completions" endpoints, with the full value in a
+        // tooltip - a clipped URL hid a broken endpoint in #12907.
+        var textBoxApiUrl = UiUtil.MakeTextBox(300, vm, nameof(vm.ApiUrlText), nameof(vm.ApiUrlIsVisible)).WithMarginRight(15).WithAccessibleName(Se.Language.General.Url);
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            textBoxApiUrl.Bind(ToolTip.TipProperty, new Binding(nameof(vm.ApiUrlText)));
+        }
+        settingsPanel.Children.Add(textBoxApiUrl);
 
         settingsPanel.Children.Add(UiUtil.MakeTextBlock(Se.Language.General.Model, vm, null, nameof(vm.ModelIsVisible)).WithMarginRight(5));
         settingsPanel.Children.Add(UiUtil.MakeTextBox(150, vm, nameof(vm.ModelText), nameof(vm.ModelIsVisible)).WithAccessibleName(Se.Language.General.Model));


### PR DESCRIPTION
### What

Two diagnosability improvements to the auto-translate window, motivated by #12907:

1. The translation-error dialog's technical details now start with an `API url:` line showing the endpoint the selected engine was configured with, resolved per engine type (LM Studio, OpenAI Compatible, Ollama, ChatGPT, llama.cpp, DeepL, Libre, NLLB, Anthropic, Groq, OpenRouter, Lara, Perplexity, Nvidia, Mistral, DeepSeek, Baidu). Engines without a URL are skipped, Papago is excluded because its URL field holds a client ID, and API keys are never included.
2. The URL textbox is widened from 200 px to 300 px so typical `.../v1/chat/completions` endpoints are fully visible, and (when hints are enabled) a tooltip shows the full bound value for anything still clipped.

### Why

In #12907 both local engines failed with the generic error dialog, and even the reporter's settings screenshots couldn't show whether the URL was wrong — the textbox clips exactly the part that matters. With this change a single screenshot of the expanded details names the endpoint, turning "not much to go on" reports into one-line fixes.

### Notes for review

- The URL line is added in the `DoTranslate` catch block, before the existing API error/response section, so it appears even when the failure is a connection error and `translator.Error` is empty.
- The tooltip follows the project convention of gating hints behind `Se.Settings.Appearance.ShowHints`.
- Built with 0 warnings/errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)