### PR TITLE
Respect single line max length in rebalance long lines

### DIFF
--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
@@ -26,6 +26,7 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
     [ObservableProperty] private int _maxNumberOfLines;
 
     [ObservableProperty] private bool _rebalanceLongLines;
+    [ObservableProperty] private int _unbreakLinesShorterThan;
 
     [ObservableProperty] private string _fixesInfo;
 
@@ -34,6 +35,7 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
     public List<SubtitleLineViewModel> AllSubtitlesFixed { get; set; }
 
     private List<SubtitleLineViewModel> _allSubtitles;
+    private string _languageCode = "en";
 
     private readonly System.Timers.Timer _previewTimer;
     private volatile bool _isClosing;
@@ -128,10 +130,18 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
 
             if (RebalanceLongLines)
             {
+                // AutoBreakLine keeps text on one line only when it is strictly shorter than the
+                // unbreak threshold, so a threshold at or above the single line max length means
+                // "keep any text that fits on one line" - and capping there also prevents merging
+                // to a single line that would exceed the max length (#12910).
+                var mergeLinesShorterThan = UnbreakLinesShorterThan >= SingleLineMaxLength
+                    ? SingleLineMaxLength + 1
+                    : UnbreakLinesShorterThan;
+
                 for (var index = 0; index < AllSubtitlesFixed.Count; index++)
                 {
                     var item = AllSubtitlesFixed[index];
-                    var rebalancedText = Utilities.AutoBreakLine(item.Text, SingleLineMaxLength, Se.Settings.General.UnbreakLinesShorterThan, "en");
+                    var rebalancedText = Utilities.AutoBreakLine(item.Text, SingleLineMaxLength, mergeLinesShorterThan, _languageCode);
                     if (rebalancedText != item.Text)
                     {
                         rebalanceCount++;
@@ -581,6 +591,7 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
     {
         SingleLineMaxLength = Se.Settings.General.SubtitleLineMaximumLength;
         MaxNumberOfLines = Se.Settings.General.MaxNumberOfLines;
+        UnbreakLinesShorterThan = Se.Settings.General.UnbreakLinesShorterThan;
         SplitLongLines = Se.Settings.Tools.SplitRebalanceLongLinesSplit;
         RebalanceLongLines = Se.Settings.Tools.SplitRebalanceLongLinesRebalance;
     }
@@ -628,6 +639,14 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
     public void Initialize(List<SubtitleLineViewModel> toList)
     {
         _allSubtitles = toList;
+
+        var subtitle = new Subtitle();
+        foreach (var line in toList)
+        {
+            subtitle.Paragraphs.Add(new Paragraph(line.Text, line.StartTime.TotalMilliseconds, line.EndTime.TotalMilliseconds));
+        }
+        _languageCode = LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(subtitle) ?? "en";
+
         _previewTimer.Start();
     }
 

--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesWindow.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesWindow.cs
@@ -71,6 +71,7 @@ public class SplitBreakLongLinesWindow : Window
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
@@ -100,6 +101,15 @@ public class SplitBreakLongLinesWindow : Window
         var numericUpDownMaxNumberOfLines = UiUtil.MakeNumericUpDownInt(1, 10, 2, 130, vm, nameof(vm.MaxNumberOfLines));
         numericUpDownMaxNumberOfLines.ValueChanged += (s, e) => vm.SetChanged();
 
+        var labelUnbreakLinesShorterThan = UiUtil.MakeLabel(Se.Language.Options.Settings.UnbreakSubtitlesShortThan);
+        var numericUpDownUnbreakLinesShorterThan = UiUtil.MakeNumericUpDownInt(1, 1000, 33, 130, vm, nameof(vm.UnbreakLinesShorterThan));
+        numericUpDownUnbreakLinesShorterThan.ValueChanged += (s, e) => vm.SetChanged();
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            ToolTip.SetTip(labelUnbreakLinesShorterThan, Se.Language.Tools.SplitBreakLongLines.UnbreakLinesShorterThanHint);
+            ToolTip.SetTip(numericUpDownUnbreakLinesShorterThan, Se.Language.Tools.SplitBreakLongLines.UnbreakLinesShorterThanHint);
+        }
+
         grid.Add(checkBoxSplitLongLines, 0);
         grid.Add(labelSingleLineMaxLength, 0, 1);
         grid.Add(numericUpDownSingleLineMaxLength, 0, 2);
@@ -107,6 +117,9 @@ public class SplitBreakLongLinesWindow : Window
         grid.Add(checkBoxRebalanceLongLines, 1);
         grid.Add(labelMaxNumberOfLines, 1, 1);
         grid.Add(numericUpDownMaxNumberOfLines, 1, 2);
+
+        grid.Add(labelUnbreakLinesShorterThan, 2, 1);
+        grid.Add(numericUpDownUnbreakLinesShorterThan, 2, 2);
 
         return grid;
     }

--- a/src/ui/Logic/Config/Language/Tools/LanguageSplitBreakLongLines.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageSplitBreakLongLines.cs
@@ -10,6 +10,7 @@ public class LanguageSplitBreakLongLines
     public string SplitIntoXLines { get; set; }
     public string LinesSplitX { get; set; }
     public string LinesSplitXLinesRebalancedY { get; set; }
+    public string UnbreakLinesShorterThanHint { get; set; }
 
     public LanguageSplitBreakLongLines()
     {
@@ -21,5 +22,6 @@ public class LanguageSplitBreakLongLines
         SplitIntoXLines = "Split into {0} lines: '{1}' → '{2}...'";
         LinesSplitX = "Lines split: {0}";
         LinesSplitXLinesRebalancedY = "Lines split: {0}, lines rebalanced: {1}";
+        UnbreakLinesShorterThanHint = "Text shorter than this stays on (or is merged to) a single line - set it to the single line max length to keep any text that fits on one line unbroken";
     }
 }


### PR DESCRIPTION
Fixes #12910

The "Rebalance long lines" pass only kept text on a single line when it was shorter than the hidden "Unbreak subtitles shorter than" setting (default 33), so text that fit within the single line max length (e.g. 36 chars with max 43) was still force-split into two lines — `TextSplit.AutoBreak` has no "fits on one line" case, the unbreak threshold is the only gate.

Changes:

- **Expose "Unbreak subtitles shorter than" in the Split/rebalance long lines dialog** (initialized from general settings), so the threshold that actually decides one-vs-two lines is visible and adjustable. Setting it equal to the single line max length gives exactly the behavior requested in the issue: text that fits stays on (or is merged to) one line, longer text splits balanced. A hint tooltip explains this (guarded by ShowHints).
- **Boundary fix**: threshold values at/above the single line max length are treated as "max + 1", so a text of exactly max length also stays on one line, and merging can never produce a single line longer than the max.
- **Use the subtitle's detected language** for line-break rules (`Utilities.CanBreak`) instead of hardcoded "en".

Default behavior is unchanged (threshold still 33 unless the user raises it).

Verified against libse with the issue's examples (max 43):

| Text | Before | After (threshold 43) |
|---|---|---|
| "Ovako radite sa svim delovima testa." (36) | split in 2 | one line |
| "I poslednji deo stavljam od gore." (33) | split in 2 | one line |
| "Zatim stavljam krpu i ostavljam ovako da stoji 60 minuta." (57) | 2 balanced lines | 2 balanced lines |

🤖 Generated with [Claude Code](https://claude.com/claude-code)