### PR TITLE
Use source-generated regexes for hot/startup regex batch in libse

### DIFF
--- a/src/libse/Common/FfmpegMediaInfo.cs
+++ b/src/libse/Common/FfmpegMediaInfo.cs
@@ -9,7 +9,7 @@ using System.Text.RegularExpressions;
 
 namespace Nikse.SubtitleEdit.Core.Common
 {
-    public class FfmpegMediaInfo
+    public partial class FfmpegMediaInfo
     {
         public List<FfmpegTrackInfo> Tracks { get; set; }
 
@@ -17,10 +17,28 @@ namespace Nikse.SubtitleEdit.Core.Common
         public TimeCode Duration { get; set; }
         public decimal FramesRate { get; set; } 
 
+#if NET7_0_OR_GREATER
+        [GeneratedRegex(@"\d\d+x\d\d+")]
+        private static partial Regex ResolutionRegexGen();
+        private static readonly Regex ResolutionRegex = ResolutionRegexGen();
+
+        [GeneratedRegex(@"Duration: \d+[:\.,]\d+[:\.,]\d+[:\.,]\d+")]
+        private static partial Regex DurationRegexGen();
+        private static readonly Regex DurationRegex = DurationRegexGen();
+
+        [GeneratedRegex(@" \d+\.\d+ fps")]
+        private static partial Regex Fps1RegexGen();
+        private static readonly Regex Fps1Regex = Fps1RegexGen();
+
+        [GeneratedRegex(@" \d+ fps")]
+        private static partial Regex Fps2RegexGen();
+        private static readonly Regex Fps2Regex = Fps2RegexGen();
+#else
         private static readonly Regex ResolutionRegex = new Regex(@"\d\d+x\d\d+", RegexOptions.Compiled);
         private static readonly Regex DurationRegex = new Regex(@"Duration: \d+[:\.,]\d+[:\.,]\d+[:\.,]\d+", RegexOptions.Compiled);
         private static readonly Regex Fps1Regex = new Regex(@" \d+\.\d+ fps", RegexOptions.Compiled);
         private static readonly Regex Fps2Regex = new Regex(@" \d+ fps", RegexOptions.Compiled);
+#endif
 
         private FfmpegMediaInfo()
         {

--- a/src/libse/Common/HtmlUtil.cs
+++ b/src/libse/Common/HtmlUtil.cs
@@ -11,7 +11,7 @@ namespace Nikse.SubtitleEdit.Core.Common
     /// <summary>
     /// HTML specific string manipulations.
     /// </summary>
-    public static class HtmlUtil
+    public static partial class HtmlUtil
     {
         /// <summary>
         /// Represents the HTML tag used for italic text formatting.
@@ -38,7 +38,13 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// </summary>
         public static string TagCyrillicI => "\u0456"; // Cyrillic Small Letter Byelorussian-Ukrainian i (http://graphemica.com/%D1%96)
 
+#if NET7_0_OR_GREATER
+        [GeneratedRegex(@"<\s*(?:/\s*)?(\w+)[^>]*>")]
+        private static partial Regex TagOpenRegexGen();
+        private static readonly Regex TagOpenRegex = TagOpenRegexGen();
+#else
         private static readonly Regex TagOpenRegex = new Regex(@"<\s*(?:/\s*)?(\w+)[^>]*>", RegexOptions.Compiled);
+#endif
 
         /// <summary>
         /// Remove all of the specified opening and closing tags from the source HTML string.
@@ -1526,7 +1532,13 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// </summary>
         /// <param name="input">The string from which to remove color tags.</param>
         /// <returns>A new string with color tags removed.</returns>
+#if NET7_0_OR_GREATER
+        [GeneratedRegex("[ ]*(COLOR|color|Color)=[\"']*[#\\dA-Za-z]*[\"']*[ ]*")]
+        private static partial Regex ColorAttributeRegexGen();
+        private static readonly Regex ColorAttributeRegex = ColorAttributeRegexGen();
+#else
         private static readonly Regex ColorAttributeRegex = new Regex("[ ]*(COLOR|color|Color)=[\"']*[#\\dA-Za-z]*[\"']*[ ]*", RegexOptions.Compiled);
+#endif
 
         public static string RemoveColorTags(string input)
         {
@@ -1575,10 +1587,28 @@ namespace Nikse.SubtitleEdit.Core.Common
             return s.Trim();
         }
 
+#if NET7_0_OR_GREATER
+        [GeneratedRegex("[ ]*(FACE|face|Face)=[\"']*[\\d\\p{L} ]*[\"']*[ ]*")]
+        private static partial Regex FontFaceAttributeRegexGen();
+        private static readonly Regex FontFaceAttributeRegex = FontFaceAttributeRegexGen();
+
+        [GeneratedRegex("{\\\\fn[a-zA-Z \\d]+}")]
+        private static partial Regex AssaFontNameOnlyTagRegexGen();
+        private static readonly Regex AssaFontNameOnlyTagRegex = AssaFontNameOnlyTagRegexGen();
+
+        [GeneratedRegex("\\\\fn[a-zA-Z \\d]+}")]
+        private static partial Regex AssaFontNameLastTagRegexGen();
+        private static readonly Regex AssaFontNameLastTagRegex = AssaFontNameLastTagRegexGen();
+
+        [GeneratedRegex("\\\\fn[a-zA-Z \\d]+\\\\")]
+        private static partial Regex AssaFontNameInnerTagRegexGen();
+        private static readonly Regex AssaFontNameInnerTagRegex = AssaFontNameInnerTagRegexGen();
+#else
         private static readonly Regex FontFaceAttributeRegex = new Regex("[ ]*(FACE|face|Face)=[\"']*[\\d\\p{L} ]*[\"']*[ ]*", RegexOptions.Compiled);
         private static readonly Regex AssaFontNameOnlyTagRegex = new Regex("{\\\\fn[a-zA-Z \\d]+}", RegexOptions.Compiled);
         private static readonly Regex AssaFontNameLastTagRegex = new Regex("\\\\fn[a-zA-Z \\d]+}", RegexOptions.Compiled);
         private static readonly Regex AssaFontNameInnerTagRegex = new Regex("\\\\fn[a-zA-Z \\d]+\\\\", RegexOptions.Compiled);
+#endif
 
         /// <summary>
         /// Remove font tag from HTML or ASSA.

--- a/src/libse/Common/RegexUtils.cs
+++ b/src/libse/Common/RegexUtils.cs
@@ -4,17 +4,29 @@ using System.Text.RegularExpressions;
 
 namespace Nikse.SubtitleEdit.Core.Common
 {
-    public static class RegexUtils
+    public static partial class RegexUtils
     {
         // Others classes may want to use this regex.
+#if NET7_0_OR_GREATER
+        [GeneratedRegex(@"\bi\b")]
+        private static partial Regex LittleIRegexGen();
+        public static readonly Regex LittleIRegex = LittleIRegexGen();
+#else
         public static readonly Regex LittleIRegex = new Regex(@"\bi\b", RegexOptions.Compiled);
+#endif
 
         /// <summary>
         /// Will be constructed only once.
         /// </summary>
-        public static class DanishLetterI
+        public static partial class DanishLetterI
         {
+#if NET7_0_OR_GREATER
+            [GeneratedRegex(@"\bi(dag|går|morgen|alt|gang|stand|øvrigt)\b")]
+            private static partial Regex DanishLetterIRegexGen();
+            public static readonly Regex DanishLetterIRegex = DanishLetterIRegexGen();
+#else
             public static readonly Regex DanishLetterIRegex = new Regex(@"\bi(dag|går|morgen|alt|gang|stand|øvrigt)\b", RegexOptions.Compiled);
+#endif
 
             private static readonly IList<Regex> RegexList;
 

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -17,7 +17,7 @@ using System.Xml;
 
 namespace Nikse.SubtitleEdit.Core.Common
 {
-    public static class Utilities
+    public static partial class Utilities
     {
         /// <summary>
         /// Cached environment new line characters for faster lookup.
@@ -52,6 +52,47 @@ namespace Nikse.SubtitleEdit.Core.Common
             return newText;
         }
 
+#if NET7_0_OR_GREATER
+        [GeneratedRegex(@"\b\d+[\.:;] \d+\b")]
+        private static partial Regex NumberSeparatorNumberRegExGen();
+        private static readonly Regex NumberSeparatorNumberRegEx = NumberSeparatorNumberRegExGen();
+
+        [GeneratedRegex("^\\d+$")]
+        private static partial Regex RegexIsNumberGen();
+        private static readonly Regex RegexIsNumber = RegexIsNumberGen();
+
+        [GeneratedRegex("^\\d+x\\d+$")]
+        private static partial Regex RegexIsEpisodeNumberGen();
+        private static readonly Regex RegexIsEpisodeNumber = RegexIsEpisodeNumberGen();
+
+        [GeneratedRegex(@"(\d) (\.)")]
+        private static partial Regex RegexNumberSpacePeriodGen();
+        private static readonly Regex RegexNumberSpacePeriod = RegexNumberSpacePeriodGen();
+
+        [GeneratedRegex(@"(1) (st)\b")]
+        private static partial Regex RegexOrdinalStGen();
+        private static readonly Regex RegexOrdinalSt = RegexOrdinalStGen();
+
+        [GeneratedRegex(@"(2) (nd)\b")]
+        private static partial Regex RegexOrdinalNdGen();
+        private static readonly Regex RegexOrdinalNd = RegexOrdinalNdGen();
+
+        [GeneratedRegex(@"(3) (rd)\b")]
+        private static partial Regex RegexOrdinalRdGen();
+        private static readonly Regex RegexOrdinalRd = RegexOrdinalRdGen();
+
+        [GeneratedRegex(@"([0456789]) (th)\b")]
+        private static partial Regex RegexOrdinalThGen();
+        private static readonly Regex RegexOrdinalTh = RegexOrdinalThGen();
+
+        [GeneratedRegex(@"\bو ")]
+        private static partial Regex RegexArabicWawSpaceGen();
+        private static readonly Regex RegexArabicWawSpace = RegexArabicWawSpaceGen();
+
+        [GeneratedRegex(@"[a-z] \. [A-Z]")]
+        private static partial Regex RegexLetterSpacePeriodSpaceLetterGen();
+        private static readonly Regex RegexLetterSpacePeriodSpaceLetter = RegexLetterSpacePeriodSpaceLetterGen();
+#else
         private static readonly Regex NumberSeparatorNumberRegEx = new Regex(@"\b\d+[\.:;] \d+\b", RegexOptions.Compiled);
         private static readonly Regex RegexIsNumber = new Regex("^\\d+$", RegexOptions.Compiled);
         private static readonly Regex RegexIsEpisodeNumber = new Regex("^\\d+x\\d+$", RegexOptions.Compiled);
@@ -62,6 +103,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         private static readonly Regex RegexOrdinalTh = new Regex(@"([0456789]) (th)\b", RegexOptions.Compiled);
         private static readonly Regex RegexArabicWawSpace = new Regex(@"\bو ", RegexOptions.Compiled);
         private static readonly Regex RegexLetterSpacePeriodSpaceLetter = new Regex(@"[a-z] \. [A-Z]", RegexOptions.Compiled);
+#endif
 
         public static string[] VideoFileExtensions { get; } = { ".avi", ".mkv", ".wmv", ".mpg", ".mpeg", ".divx", ".mp4", ".asf", ".flv", ".mov", ".m4v", ".vob", ".ogv", ".webm", ".ts", ".tts", ".m2ts", ".mts", ".avs", ".mxf" };
         public static string[] AudioFileExtensions { get; } = { ".mp3", ".wav", ".wma", ".ogg", ".mpa", ".m4a", ".ape", ".aiff", ".flac", ".aac", ".ac3", ".eac3", ".mka", ".opus", ".adts", ".m4b" };
@@ -1557,7 +1599,13 @@ namespace Nikse.SubtitleEdit.Core.Common
             return Uri.UnescapeDataString(text);
         }
 
+#if NET7_0_OR_GREATER
+        [GeneratedRegex(@"\d\d+")]
+        private static partial Regex TwoOrMoreDigitsNumberGen();
+        private static readonly Regex TwoOrMoreDigitsNumber = TwoOrMoreDigitsNumberGen();
+#else
         private static readonly Regex TwoOrMoreDigitsNumber = new Regex(@"\d\d+", RegexOptions.Compiled);
+#endif
         private const string PrePostStringsToReverse = @"-— !?.…""،,():;[]+~*/<>&^%$#\\|'";
 
         public static string ReverseStartAndEndingForRightToLeft(string s)
@@ -2299,7 +2347,13 @@ namespace Nikse.SubtitleEdit.Core.Common
             return sb.ToString();
         }
 
+#if NET7_0_OR_GREATER
+        [GeneratedRegex(@"(?<=\b\d+) \d(?!/\d)")]
+        private static partial Regex RemoveSpaceBetweenNumbersRegexGen();
+        private static readonly Regex RemoveSpaceBetweenNumbersRegex = RemoveSpaceBetweenNumbersRegexGen();
+#else
         private static readonly Regex RemoveSpaceBetweenNumbersRegex = new Regex(@"(?<=\b\d+) \d(?!/\d)", RegexOptions.Compiled);
+#endif
 
         public static string RemoveSpaceBetweenNumbers(string text)
         {

--- a/src/libse/Common/WebVttHelper.cs
+++ b/src/libse/Common/WebVttHelper.cs
@@ -8,10 +8,20 @@ using System.Text.RegularExpressions;
 
 namespace Nikse.SubtitleEdit.Core.Common
 {
-    public static class WebVttHelper
+    public static partial class WebVttHelper
     {
+#if NET7_0_OR_GREATER
+        [GeneratedRegex("\\([\\.\\p{L}\\d#_-]+\\)")]
+        private static partial Regex NameRegexGen();
+        private static readonly Regex NameRegex = NameRegexGen();
+
+        [GeneratedRegex("{[ \\.\\p{L}\\d:#\\s,_;:\\-\\(\\)]+}")]
+        private static partial Regex PropertiesRegexGen();
+        private static readonly Regex PropertiesRegex = PropertiesRegexGen();
+#else
         private static readonly Regex NameRegex = new Regex("\\([\\.\\p{L}\\d#_-]+\\)", RegexOptions.Compiled);
         private static readonly Regex PropertiesRegex = new Regex("{[ \\.\\p{L}\\d:#\\s,_;:\\-\\(\\)]+}", RegexOptions.Compiled);
+#endif
 
         public static List<WebVttStyle> GetStyles(string header)
         {

--- a/src/libse/Common/WebVttToAssa.cs
+++ b/src/libse/Common/WebVttToAssa.cs
@@ -8,10 +8,20 @@ using System.Text.RegularExpressions;
 
 namespace Nikse.SubtitleEdit.Core.Common
 {
-    public static class WebVttToAssa
+    public static partial class WebVttToAssa
     {
+#if NET7_0_OR_GREATER
+        [GeneratedRegex("<c\\.[a-z-_\\.A-Z#\\d]+>")]
+        private static partial Regex LineTagRegexGen();
+        private static readonly Regex LineTagRegex = LineTagRegexGen();
+
+        [GeneratedRegex(@"</?c[a-z-_\.A-Z#\d]*>")]
+        private static partial Regex LineTagRegexMoreGen();
+        private static readonly Regex LineTagRegexMore = LineTagRegexMoreGen();
+#else
         private static readonly Regex LineTagRegex = new Regex("<c\\.[a-z-_\\.A-Z#\\d]+>", RegexOptions.Compiled);
         private static readonly Regex LineTagRegexMore = new Regex(@"</?c[a-z-_\.A-Z#\d]*>", RegexOptions.Compiled);
+#endif
 
         public static Subtitle Convert(Subtitle webVttSubtitle, SsaStyle defaultStyle, int videoWidth, int videoHeight)
         {

--- a/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
@@ -10,11 +10,23 @@ using System.Xml;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
-    public class AdvancedSubStationAlpha : SubtitleFormat
+    public partial class AdvancedSubStationAlpha : SubtitleFormat
     {
+#if NET7_0_OR_GREATER
+        [GeneratedRegex(@"\\p[123456789]")]
+        private static partial Regex RegexDrawStartGen();
+        private static readonly Regex RegexDrawStart = RegexDrawStartGen();
+#else
         private static readonly Regex RegexDrawStart = new Regex(@"\\p[123456789]", RegexOptions.Compiled);
+#endif
 
+#if NET7_0_OR_GREATER
+        [GeneratedRegex("ScriptType: *v4.00")]
+        private static partial Regex ScriptTypeFinderGen();
+        private static readonly Regex ScriptTypeFinder = ScriptTypeFinderGen();
+#else
         private static readonly Regex ScriptTypeFinder = new Regex("ScriptType: *v4.00", RegexOptions.Compiled);
+#endif
         public string Errors { get; private set; }
 
         public static string DefaultStyle

--- a/src/libse/SubtitleFormats/SubRip.cs
+++ b/src/libse/SubtitleFormats/SubRip.cs
@@ -7,15 +7,25 @@ using System.Text.RegularExpressions;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
-    public class SubRip : SubtitleFormat
+    public partial class SubRip : SubtitleFormat
     {
         public string Errors { get; private set; }
         private StringBuilder _errors;
         private int _lineNumber;
         private bool _isMsFrames;
         private bool _isWsrt;
+#if NET7_0_OR_GREATER
+        [GeneratedRegex(@"<3\d>")]
+        private static partial Regex _regExWsrtItalicStartGen();
+        private static readonly Regex _regExWsrtItalicStart = _regExWsrtItalicStartGen();
+
+        [GeneratedRegex(@"</3\d>")]
+        private static partial Regex _regExWsrtItalicEndGen();
+        private static readonly Regex _regExWsrtItalicEnd = _regExWsrtItalicEndGen();
+#else
         private static Regex _regExWsrtItalicStart = new Regex(@"<3\d>", RegexOptions.Compiled);
         private static Regex _regExWsrtItalicEnd = new Regex(@"</3\d>", RegexOptions.Compiled);
+#endif
 
         private enum ExpectingLine
         {

--- a/src/libse/SubtitleFormats/WebVTT.cs
+++ b/src/libse/SubtitleFormats/WebVTT.cs
@@ -12,8 +12,45 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
     /// <summary>
     /// https://w3c.github.io/webvtt/
     /// </summary>
-    public class WebVTT : SubtitleFormat
+    public partial class WebVTT : SubtitleFormat
     {
+#if NET7_0_OR_GREATER
+        [GeneratedRegex(@"^-?\d+:-?\d+:-?\d+\.-?\d+\s*-->\s*-?\d+:-?\d+:-?\d+\.-?\d+")]
+        private static partial Regex RegexTimeCodesGen();
+        private static readonly Regex RegexTimeCodes = RegexTimeCodesGen();
+
+        [GeneratedRegex(@"^-?\d+:-?\d+\.-?\d+\s*-->\s*-?\d+:-?\d+:-?\d+\.-?\d+")]
+        private static partial Regex RegexTimeCodesMiddleGen();
+        private static readonly Regex RegexTimeCodesMiddle = RegexTimeCodesMiddleGen();
+
+        [GeneratedRegex(@"^-?\d+:-?\d+\.-?\d+\s*-->\s*-?\d+:-?\d+\.-?\d+")]
+        private static partial Regex RegexTimeCodesShortGen();
+        private static readonly Regex RegexTimeCodesShort = RegexTimeCodesShortGen();
+
+        [GeneratedRegex(@"^-?\d+:-?\d+:-?\d+\.-?\d+\s*-->\s*-?\d+:-?\d+\.-?\d+")]
+        private static partial Regex RegexTimeCodesEndShortGen();
+        private static readonly Regex RegexTimeCodesEndShort = RegexTimeCodesEndShortGen();
+
+        [GeneratedRegex(@"-->\s*")]
+        private static partial Regex RegexShortArrowGen();
+        private static readonly Regex RegexShortArrow = RegexShortArrowGen();
+
+        [GeneratedRegex(@"\</?c([a-zA-Z\._\-\d%#]*)\>")]
+        private static partial Regex RegexRemoveCTagsGen();
+        private static readonly Regex RegexRemoveCTags = RegexRemoveCTagsGen();
+
+        [GeneratedRegex(@"\<\d+:\d+:\d+\.\d+\>")] // <00:00:10.049>
+        private static partial Regex RegexRemoveTimeCodesGen();
+        private static readonly Regex RegexRemoveTimeCodes = RegexRemoveTimeCodesGen();
+
+        [GeneratedRegex(@"(\{\\an\d\})[\s\r\n]+")]
+        private static partial Regex RegexTagsPlusWhiteSpaceGen();
+        private static readonly Regex RegexTagsPlusWhiteSpace = RegexTagsPlusWhiteSpaceGen();
+
+        [GeneratedRegex(@"::cue\(([a-zA-Z\._\-\d%#]*)\)\s*{")]
+        private static partial Regex RegexCueLineGen();
+        private static readonly Regex RegexCueLine = RegexCueLineGen();
+#else
         private static readonly Regex RegexTimeCodes = new Regex(@"^-?\d+:-?\d+:-?\d+\.-?\d+\s*-->\s*-?\d+:-?\d+:-?\d+\.-?\d+", RegexOptions.Compiled);
         private static readonly Regex RegexTimeCodesMiddle = new Regex(@"^-?\d+:-?\d+\.-?\d+\s*-->\s*-?\d+:-?\d+:-?\d+\.-?\d+", RegexOptions.Compiled);
         private static readonly Regex RegexTimeCodesShort = new Regex(@"^-?\d+:-?\d+\.-?\d+\s*-->\s*-?\d+:-?\d+\.-?\d+", RegexOptions.Compiled);
@@ -23,6 +60,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         private static readonly Regex RegexRemoveTimeCodes = new Regex(@"\<\d+:\d+:\d+\.\d+\>", RegexOptions.Compiled); // <00:00:10.049>
         private static readonly Regex RegexTagsPlusWhiteSpace = new Regex(@"(\{\\an\d\})[\s\r\n]+", RegexOptions.Compiled);
         private static readonly Regex RegexCueLine = new Regex(@"::cue\(([a-zA-Z\._\-\d%#]*)\)\s*{", RegexOptions.Compiled);
+#endif
 
         public static readonly Dictionary<string, SKColor> DefaultColorClasses = new Dictionary<string, SKColor>
         {
@@ -892,8 +930,18 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return null;
         }
 
+#if NET7_0_OR_GREATER
+        [GeneratedRegex(@"<c.[a-z]*>")]
+        private static partial Regex RegexWebVttColorGen();
+        private static readonly Regex RegexWebVttColor = RegexWebVttColorGen();
+
+        [GeneratedRegex(@"<c.[a-z0123456789]*>")]
+        private static partial Regex RegexWebVttColorHexGen();
+        private static readonly Regex RegexWebVttColorHex = RegexWebVttColorHexGen();
+#else
         private static readonly Regex RegexWebVttColor = new Regex(@"<c.[a-z]*>", RegexOptions.Compiled);
         private static readonly Regex RegexWebVttColorHex = new Regex(@"<c.[a-z0123456789]*>", RegexOptions.Compiled);
+#endif
 
         internal static string ColorWebVttToHtml(string text)
         {
@@ -941,10 +989,28 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return res;
         }
 
+#if NET7_0_OR_GREATER
+        [GeneratedRegex("<font color=\"[a-z]*\">")]
+        private static partial Regex RegexHtmlColorGen();
+        private static readonly Regex RegexHtmlColor = RegexHtmlColorGen();
+
+        [GeneratedRegex("<font color=[a-z]*>")]
+        private static partial Regex RegexHtmlColor2Gen();
+        private static readonly Regex RegexHtmlColor2 = RegexHtmlColor2Gen();
+
+        [GeneratedRegex("<font color=\"#[ABCDEFabcdef\\d]*\">")]
+        private static partial Regex RegexHtmlColor3Gen();
+        private static readonly Regex RegexHtmlColor3 = RegexHtmlColor3Gen();
+
+        [GeneratedRegex("<font color=\"[A-Za-z]*\">")]
+        private static partial Regex RegexHtmlColor4Gen();
+        private static readonly Regex RegexHtmlColor4 = RegexHtmlColor4Gen();
+#else
         private static readonly Regex RegexHtmlColor = new Regex("<font color=\"[a-z]*\">", RegexOptions.Compiled);
         private static readonly Regex RegexHtmlColor2 = new Regex("<font color=[a-z]*>", RegexOptions.Compiled);
         private static readonly Regex RegexHtmlColor3 = new Regex("<font color=\"#[ABCDEFabcdef\\d]*\">", RegexOptions.Compiled);
         private static readonly Regex RegexHtmlColor4 = new Regex("<font color=\"[A-Za-z]*\">", RegexOptions.Compiled);
+#endif
 
         private static string ColorHtmlToWebVtt(string text)
         {


### PR DESCRIPTION
Converts 47 static `RegexOptions.Compiled` regexes in libse to `[GeneratedRegex]` source generators on net7+, covering the classes hit at startup and in hot parsing paths:

- `HtmlUtil` (6) — tag open/color/face/ASSA font-name regexes used by `RemoveHtmlTags` and friends
- `Utilities` (12) — number/ordinal/spacing regexes used by line breaking and fixes
- `RegexUtils` (2) — `LittleIRegex`, `DanishLetterIRegex` (the Danish phrase list goes through a runtime pattern transform, so it stays as-is)
- `WebVTT` (15) — time code + color/tag cleanup regexes
- `SubRip` (2), `AdvancedSubStationAlpha` (2), `FfmpegMediaInfo` (4), `WebVttToAssa` (2), `WebVttHelper` (2)

The netstandard2.1 build keeps the existing `Compiled` fields via `#if NET7_0_OR_GREATER` guards; all call sites are unchanged (the generated accessor is assigned to the same static field).

**Why:** benchmarked on a batch of these exact patterns over a subtitle-line corpus (.NET 10, Apple Silicon): ~14–15% faster `IsMatch`/`Replace`/`Matches`, identical allocations, and it removes the ~0.6 ms + ~14 KB per-regex first-use IL-emit/JIT cost that `RegexOptions.Compiled` pays lazily at runtime — for this batch alone that's ~5 ms of startup/first-file-open work moved to build time.

Both TFMs build with zero warnings (no generator fallback diagnostics), and all 745 libse tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)