### PR TITLE
Reuse StringBuilder instances in loops in libse core

### DIFF
--- a/src/libse/Common/CsvUtil.cs
+++ b/src/libse/Common/CsvUtil.cs
@@ -84,19 +84,19 @@ namespace Nikse.SubtitleEdit.Core.Common
                     {
                         case ',' when !quoteOn && separator == ',':
                             lines.Add(item.ToString());
-                            item = new StringBuilder();
+                            item.Clear();
                             index++;
                             stringOn = false;
                             continue;
                         case ';' when !quoteOn && separator == ';':
                             lines.Add(item.ToString());
-                            item = new StringBuilder();
+                            item.Clear();
                             index++;
                             stringOn = false;
                             continue;
                         case '\t' when !quoteOn && separator == '\t':
                             lines.Add(item.ToString());
-                            item = new StringBuilder();
+                            item.Clear();
                             index++;
                             stringOn = false;
                             continue;
@@ -134,7 +134,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 else if (ch == separator)
                 {
                     lines.Add(item.ToString());
-                    item = new StringBuilder();
+                    item.Clear();
                     index++;
                     continue;
                 }

--- a/src/libse/Common/SeJsonParser.cs
+++ b/src/libse/Common/SeJsonParser.cs
@@ -38,6 +38,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             var max = content.Length;
             var state = new Stack<StateElement>();
             var objectName = string.Empty;
+            var sb = new StringBuilder();
             while (i < max)
             {
                 var ch = content[i];
@@ -231,7 +232,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                     }
                     else if ("+-0123456789".IndexOf(ch) >= 0)
                     {
-                        var sb = new StringBuilder();
+                        sb.Clear();
                         while ("+-0123456789.Ee".IndexOf(content[i]) >= 0 && i < max)
                         {
                             sb.Append(content[i]);
@@ -329,6 +330,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             var state = new Stack<StateElement>();
             var objectName = string.Empty;
             var start = -1;
+            var sb = new StringBuilder();
             while (i < max)
             {
                 var ch = content[i];
@@ -523,7 +525,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                     }
                     else if ("+-0123456789".IndexOf(ch) >= 0)
                     {
-                        var sb = new StringBuilder();
+                        sb.Clear();
                         while (i < max && "+-0123456789.Ee".IndexOf(content[i]) >= 0)
                         {
                             sb.Append(content[i]);
@@ -810,10 +812,8 @@ namespace Nikse.SubtitleEdit.Core.Common
                     }
                     else if ("+-0123456789".IndexOf(ch) >= 0)
                     {
-                        var sb = new StringBuilder();
                         while ("+-0123456789.Ee".IndexOf(content[i]) >= 0 && i < max)
                         {
-                            sb.Append(content[i]);
                             i++;
                         }
                         state.Pop();
@@ -930,6 +930,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             var objectName = string.Empty;
             var start = -1;
             var startSateCount = -1;
+            var sb = new StringBuilder();
             while (i < max)
             {
                 var ch = content[i];
@@ -1121,7 +1122,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                     }
                     else if ("+-0123456789".IndexOf(ch) >= 0)
                     {
-                        var sb = new StringBuilder();
+                        sb.Clear();
                         while ("+-0123456789.Ee".IndexOf(content[i]) >= 0 && i < max)
                         {
                             sb.Append(content[i]);
@@ -1455,10 +1456,8 @@ namespace Nikse.SubtitleEdit.Core.Common
                     }
                     else if ("+-0123456789".IndexOf(ch) >= 0)
                     {
-                        var sb = new StringBuilder();
                         while (i < max && "+-0123456789.Ee".IndexOf(content[i]) >= 0)
                         {
-                            sb.Append(content[i]);
                             i++;
                         }
                         state.Pop();

--- a/src/libse/Common/SeJsonValidator.cs
+++ b/src/libse/Common/SeJsonValidator.cs
@@ -209,10 +209,8 @@ namespace Nikse.SubtitleEdit.Core.Common
                     }
                     else if ("+-0123456789".IndexOf(ch) >= 0)
                     {
-                        var sb = new StringBuilder();
                         while ("+-0123456789.Ee".IndexOf(content[i]) >= 0 && i < max)
                         {
-                            sb.Append(content[i]);
                             i++;
                         }
                         state.Pop();

--- a/src/libse/Common/UnknownFormatImporter.cs
+++ b/src/libse/Common/UnknownFormatImporter.cs
@@ -608,10 +608,11 @@ namespace Nikse.SubtitleEdit.Core.Common
             if (subtitle.Paragraphs.Count > 5)
             {
                 string prefix = subtitle.Paragraphs[0].Text;
+                var newPrefix = new StringBuilder();
                 foreach (var paragraph in subtitle.Paragraphs)
                 {
                     string text = paragraph.Text.Trim();
-                    var newPrefix = new StringBuilder();
+                    newPrefix.Clear();
                     int i = 0;
                     while (i < prefix.Length && i < text.Length && text[i] == prefix[i])
                     {
@@ -771,7 +772,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                                 subtitle.Paragraphs.Add(p);
                             }
                             p = new Paragraph();
-                            sb = new StringBuilder();
+                            sb.Clear();
                             p.StartTime = DecodeTime(start);
                             p.EndTime = DecodeTime(end);
                         }

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -1613,12 +1613,13 @@ namespace Nikse.SubtitleEdit.Core.Common
             var newLines = new StringBuilder();
             var pre = new StringBuilder();
             var post = new StringBuilder();
+            var preTags = new StringBuilder();
             var lines = s.SplitToLines();
             foreach (var line in lines)
             {
                 string s2 = line;
 
-                var preTags = new StringBuilder();
+                preTags.Clear();
                 while (s2.StartsWith("{\\", StringComparison.Ordinal) && s2.IndexOf('}') > 0)
                 {
                     int end = s2.IndexOf('}') + 1;

--- a/src/libse/Common/WebVttHelper.cs
+++ b/src/libse/Common/WebVttHelper.cs
@@ -43,14 +43,14 @@ namespace Nikse.SubtitleEdit.Core.Common
                     {
                         styleOn = false;
                         AddStyle(result, currentStyle);
-                        currentStyle = new StringBuilder();
+                        currentStyle.Clear();
                     }
                     else
                     {
                         if (cueOn && s.StartsWith("::cue(", StringComparison.Ordinal))
                         {
                             AddStyle(result, currentStyle);
-                            currentStyle = new StringBuilder();
+                            currentStyle.Clear();
                         }
 
                         if (s.StartsWith("::cue(", StringComparison.Ordinal))

--- a/src/libse/ContainerFormats/TransportStream/TransportStreamParser.cs
+++ b/src/libse/ContainerFormats/TransportStream/TransportStreamParser.cs
@@ -194,12 +194,13 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
             DvbSubtitlesLookup = new SortedDictionary<int, List<TransportStreamSubtitle>>();
             if (_isM2TransportStream) // m2ts blu-ray images from PES packets
             {
+                var sb = new StringBuilder();
                 foreach (int pid in SubtitlesLookup.Keys)
                 {
                     var bdMs = new MemoryStream();
                     var list = SubtitlesLookup[pid];
                     var currentList = new List<DvbSubPes>();
-                    var sb = new StringBuilder();
+                    sb.Clear();
                     var subList = new List<TransportStreamSubtitle>();
                     var offset = (long)(firstVideoMs ?? 0); // when to use firstMs ?
                     var lastPalettes = new Dictionary<int, List<PaletteInfo>>();
@@ -333,6 +334,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
         /// </summary>
         private static void FixTeletextItalics(SortedDictionary<int, SortedDictionary<int, List<Paragraph>>> dictionary)
         {
+            var sb = new StringBuilder();
             foreach (var dic in dictionary)
             {
                 foreach (var inner in dic.Value)
@@ -344,7 +346,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
                             continue;
                         }
 
-                        var sb = new StringBuilder();
+                        sb.Clear();
                         foreach (var line in p.Text.SplitToLines())
                         {
                             var s = line.Trim();

--- a/src/libse/Forms/MoveWordUpDown.cs
+++ b/src/libse/Forms/MoveWordUpDown.cs
@@ -32,6 +32,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
             var openTags = new System.Collections.Generic.Stack<(string opening, string closing)>();
             var wordChars = new StringBuilder();
             var leadingTags = new StringBuilder();
+            var tagSb = new StringBuilder();
             var inWord = false;
             var wordEndPos = -1;
 
@@ -44,7 +45,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
                 {
                     var tagStart = i;
                     var endChar = ch == '<' ? '>' : '}';
-                    var tagSb = new StringBuilder();
+                    tagSb.Clear();
                     tagSb.Append(ch);
                     i++;
 
@@ -255,6 +256,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
             var lastWordStart = -1;
             var lastWordTags = new System.Collections.Generic.List<(string opening, string closing)>();
             var inWord = false;
+            var tagSb = new StringBuilder();
 
             for (int i = 0; i < s1Trimmed.Length; i++)
             {
@@ -264,7 +266,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
                 {
                     var tagStart = i;
                     var endChar = ch == '<' ? '>' : '}';
-                    var tagSb = new StringBuilder();
+                    tagSb.Clear();
                     tagSb.Append(ch);
                     i++;
 

--- a/src/libse/VobSub/Ocr/Service/GoogleCloudVisionApi.cs
+++ b/src/libse/VobSub/Ocr/Service/GoogleCloudVisionApi.cs
@@ -273,10 +273,11 @@ namespace Nikse.SubtitleEdit.Core.VobSub.Ocr.Service
 
                     // Merge lines ordered by X
                     var sb = new StringBuilder();
+                    var sbLine = new StringBuilder();
                     var spaceThreshold = Math.Max(12, annotations.Average(p => p.Width) / 2.7);
                     foreach (var line in lines)
                     {
-                        var sbLine = new StringBuilder();
+                        sbLine.Clear();
                         last = null;
                         foreach (var l in line.OrderBy(p => p.Vertices.Min(p2 => p2.X)))
                         {


### PR DESCRIPTION
## Summary
- Hoist `StringBuilder` declarations out of loops and reuse them via `Clear()` instead of allocating a new instance every iteration (`SeJsonParser`, `UnknownFormatImporter`, `Utilities.ReverseStartAndEndingForRightToLeft`, `TransportStreamParser`, `MoveWordUpDown`, `GoogleCloudVisionApi`)
- Replace `sb = new StringBuilder()` reset assignments with `sb.Clear()` (`CsvUtil.CsvSplit`, `WebVttHelper.GetStyles`, `UnknownFormatImporter`)
- Remove three `StringBuilder`s that were appended to but never read (`SeJsonParser.GetArrayElements`, `SeJsonParser.GetRootElements`, `SeJsonValidator`); the enclosing number-skipping loops are kept as they advance the parser index

## Test plan
- [x] `dotnet build SubtitleEdit.sln` succeeds
- [x] `dotnet test tests/libse/LibSETests.csproj` passes — 745/745
- [x] `dotnet test tests/UI/UITests.csproj` passes — 913/913 (1 skipped)
- [x] AppVeyor CI green
- [ ] Manual smoke test: load a CSV subtitle (CsvUtil), a WebVTT file with multiple `::cue` styles (WebVttHelper), a JSON-based subtitle with numeric values (SeJsonParser), and an m2ts file with subtitles (TransportStreamParser) — verify output unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)