### PR TITLE
Reuse StringBuilder instances in loops in SubtitleFormats

### DIFF
--- a/src/libse/SubtitleFormats/BdnXml.cs
+++ b/src/libse/SubtitleFormats/BdnXml.cs
@@ -91,13 +91,14 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
             }
 
+            var textBuilder = new StringBuilder();
             foreach (XmlNode node in xml.DocumentElement.SelectNodes("Events/Event"))
             {
                 try
                 {
                     var start = node.Attributes["InTC"].InnerText;
                     var end = node.Attributes["OutTC"].InnerText;
-                    var textBuilder = new StringBuilder();
+                    textBuilder.Clear();
                     var position = string.Empty;
                     foreach (XmlNode graphic in node.SelectNodes("Graphic"))
                     {

--- a/src/libse/SubtitleFormats/CaptionsInc.cs
+++ b/src/libse/SubtitleFormats/CaptionsInc.cs
@@ -127,6 +127,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             int i = 256;
             Paragraph last = null;
+            var sb = new StringBuilder();
             while (i < buffer.Length - 20)
             {
                 var p = new Paragraph();
@@ -182,7 +183,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 if (!textEnd)
                 {
                     i -= 2;
-                    var sb = new StringBuilder();
+                    sb.Clear();
                     while (!textEnd && i < buffer.Length - 20)
                     {
                         if (buffer[i] == 0x14 && buffer[i + 1] == 0x2c) // text end

--- a/src/libse/SubtitleFormats/DCinemaInterop.cs
+++ b/src/libse/SubtitleFormats/DCinemaInterop.cs
@@ -149,6 +149,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             var mainListFont = xml.DocumentElement.SelectSingleNode("Font");
             var no = 0;
+            var txt = new StringBuilder();
+            var html = new StringBuilder();
             foreach (var p in subtitle.Paragraphs)
             {
                 if (!string.IsNullOrEmpty(p.Text))
@@ -261,8 +263,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         textNode.Attributes.Append(direction);
 
                         var i = 0;
-                        var txt = new StringBuilder();
-                        var html = new StringBuilder();
+                        txt.Clear();
+                        html.Clear();
                         XmlNode nodeTemp = xml.CreateElement("temp");
                         while (i < line.Length)
                         {
@@ -687,6 +689,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 System.Diagnostics.Debug.WriteLine(exception.Message);
             }
 
+            var pText = new StringBuilder();
             foreach (XmlNode node in xml.DocumentElement.SelectNodes("//Subtitle"))
             {
                 try
@@ -696,7 +699,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                                        node.ParentNode.Attributes["Italic"].InnerText.Equals("yes", StringComparison.OrdinalIgnoreCase);
 
                     var textLines = new List<SubtitleLine>();
-                    var pText = new StringBuilder();
+                    pText.Clear();
                     var vAlignment = string.Empty;
                     var lastVPosition = string.Empty;
                     var extra = string.Empty;

--- a/src/libse/SubtitleFormats/DCinemaSmpte2007.cs
+++ b/src/libse/SubtitleFormats/DCinemaSmpte2007.cs
@@ -200,6 +200,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             XmlNode mainListFont = xml.DocumentElement.SelectSingleNode("dcst:SubtitleList/dcst:Font", nsmgr);
             int no = 0;
+            var txt = new StringBuilder();
+            var html = new StringBuilder();
             foreach (Paragraph p in subtitle.Paragraphs)
             {
                 if (p.Text != null)
@@ -305,8 +307,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         textNode.Attributes.Append(direction);
 
                         var i = 0;
-                        var txt = new StringBuilder();
-                        var html = new StringBuilder();
+                        txt.Clear();
+                        html.Clear();
                         var nodeTemp = xml.CreateElement("temp");
                         while (i < line.Length)
                         {
@@ -701,12 +703,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 System.Diagnostics.Debug.WriteLine(exception.Message);
             }
 
+            var pText = new StringBuilder();
             foreach (XmlNode node in xml.DocumentElement.SelectNodes("//Subtitle"))
             {
                 try
                 {
                     var textLines = new List<DCinemaInterop.SubtitleLine>();
-                    var pText = new StringBuilder();
+                    pText.Clear();
                     var vAlignment = string.Empty;
                     string lastVPosition = string.Empty;
                     foreach (XmlNode innerNode in node.ChildNodes)

--- a/src/libse/SubtitleFormats/DCinemaSmpte2010.cs
+++ b/src/libse/SubtitleFormats/DCinemaSmpte2010.cs
@@ -200,6 +200,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             XmlNode mainListFont = xml.DocumentElement.SelectSingleNode("dcst:SubtitleList/dcst:Font", nsmgr);
             var no = 0;
+            var txt = new StringBuilder();
+            var html = new StringBuilder();
             foreach (var p in subtitle.Paragraphs)
             {
                 if (p.Text != null)
@@ -305,8 +307,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         textNode.Attributes.Append(direction);
 
                         var i = 0;
-                        var txt = new StringBuilder();
-                        var html = new StringBuilder();
+                        txt.Clear();
+                        html.Clear();
                         XmlNode nodeTemp = xml.CreateElement("temp");
                         while (i < line.Length)
                         {
@@ -737,12 +739,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 System.Diagnostics.Debug.WriteLine(exception.Message);
             }
 
+            var pText = new StringBuilder();
             foreach (XmlNode node in xml.DocumentElement.SelectNodes("//Subtitle"))
             {
                 try
                 {
                     var textLines = new List<DCinemaInterop.SubtitleLine>();
-                    var pText = new StringBuilder();
+                    pText.Clear();
                     var vAlignment = string.Empty;
                     var lastVPosition = string.Empty;
                     foreach (XmlNode innerNode in node.ChildNodes)

--- a/src/libse/SubtitleFormats/DCinemaSmpte2014.cs
+++ b/src/libse/SubtitleFormats/DCinemaSmpte2014.cs
@@ -204,6 +204,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             XmlNode mainListFont = xml.DocumentElement.SelectSingleNode("dcst:SubtitleList/dcst:Font", nsmgr);
             int no = 0;
+            var txt = new StringBuilder();
+            var html = new StringBuilder();
             foreach (Paragraph p in subtitle.Paragraphs)
             {
                 if (p.Text != null)
@@ -309,8 +311,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         textNode.Attributes.Append(direction);
 
                         int i = 0;
-                        var txt = new StringBuilder();
-                        var html = new StringBuilder();
+                        txt.Clear();
+                        html.Clear();
                         XmlNode nodeTemp = xml.CreateElement("temp");
                         while (i < line.Length)
                         {
@@ -715,12 +717,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 System.Diagnostics.Debug.WriteLine(exception.Message);
             }
 
+            var pText = new StringBuilder();
             foreach (XmlNode node in xml.DocumentElement.SelectNodes("//Subtitle"))
             {
                 try
                 {
                     var textLines = new List<DCinemaInterop.SubtitleLine>();
-                    var pText = new StringBuilder();
+                    pText.Clear();
                     var vAlignment = string.Empty;
                     string lastVPosition = string.Empty;
                     foreach (XmlNode innerNode in node.ChildNodes)

--- a/src/libse/SubtitleFormats/ELRStudioClosedCaption.cs
+++ b/src/libse/SubtitleFormats/ELRStudioClosedCaption.cs
@@ -58,6 +58,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             subtitle.Header = null;
             var buffer = FileUtil.ReadAllBytesShared(fileName);
             var i = 128;
+            var sb = new StringBuilder();
             while (i < buffer.Length - 40)
             {
                 // 00 00 FE FF FF FF (00 00 01 = sub number 1)
@@ -74,7 +75,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         i += 9;
 
                         // seek to text
-                        var sb = new StringBuilder();
+                        sb.Clear();
                         while (i < buffer.Length - 10 && !IsSubNumber(buffer, i, out _))
                         {
                             if (buffer[i] >= 9 && buffer[i + 1] == 0 && buffer[i + 2] == 0x44)

--- a/src/libse/SubtitleFormats/ESubXf.cs
+++ b/src/libse/SubtitleFormats/ESubXf.cs
@@ -297,7 +297,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     string start = node.Attributes["display"].InnerText;
                     string end = node.Attributes["clear"].InnerText;
-                    sb = new StringBuilder();
+                    sb.Clear();
                     var hregion = node.SelectSingleNode("esub-xf:hregion", ns);
                     var topAlign = hregion.Attributes["vposition"]?.Value == "top";
                     foreach (XmlNode lineNode in node.SelectNodes("esub-xf:hregion/esub-xf:line", ns))

--- a/src/libse/SubtitleFormats/EZTSubtitlesProject.cs
+++ b/src/libse/SubtitleFormats/EZTSubtitlesProject.cs
@@ -134,11 +134,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
 
             var splitChars = new[] { ':' };
+            var textBuilder = new StringBuilder();
             foreach (XmlNode subNode in subtitles.SelectNodes("Subtitle"))
             {
                 var inCue = subNode.Attributes["incue"];
                 var outCue = subNode.Attributes["outcue"];
-                var textBuilder = new StringBuilder();
+                textBuilder.Clear();
                 var rowsNode = subNode.SelectSingleNode("Rows");
                 if (inCue == null || outCue == null || rowsNode == null)
                 {

--- a/src/libse/SubtitleFormats/Ebu.cs
+++ b/src/libse/SubtitleFormats/Ebu.cs
@@ -2112,6 +2112,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             var list = new List<EbuTextTimingInformation>();
             var index = startOfTextAndTimingBlock;
+            var sb = new StringBuilder();
             while (index + ttiSize <= buffer.Length)
             {
                 var tti = new EbuTextTimingInformation
@@ -2143,7 +2144,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 var open = header.DisplayStandardCode != "1" && header.DisplayStandardCode != "2";
                 var closed = header.DisplayStandardCode != "0";
                 var max = i + 112;
-                var sb = new StringBuilder();
+                sb.Clear();
                 var lastWasNewLine = false;
                 while (i < max)
                 {

--- a/src/libse/SubtitleFormats/FinalCutProXml14Text.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXml14Text.cs
@@ -64,10 +64,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             xml.LoadXml(xmlStructure);
             XmlNode videoNode = xml.DocumentElement.SelectSingleNode("//project/sequence/spine/gap");
             int number = 1;
+            var trimmedTitle = new StringBuilder();
             foreach (Paragraph p in subtitle.Paragraphs)
             {
                 XmlNode video = xml.CreateElement("video");
-                var trimmedTitle = new StringBuilder();
+                trimmedTitle.Clear();
                 foreach (var ch in HtmlUtil.RemoveHtmlTags(p.Text, true))
                 {
                     if (CharUtils.IsEnglishAlphabet(ch) || char.IsDigit(ch))

--- a/src/libse/SubtitleFormats/FinalCutProXmlGap.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXmlGap.cs
@@ -92,6 +92,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 xml.LoadXml(sb.ToString().Trim());
 
+                var text = new StringBuilder();
                 foreach (XmlNode node in xml.SelectNodes("fcpxml/project/sequence/spine/gap"))
                 {
                     try
@@ -104,7 +105,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                                 var p = new Paragraph();
                                 p.StartTime = DecodeTime(title.Attributes["offset"]);
                                 p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + DecodeTime(title.Attributes["duration"]).TotalMilliseconds;
-                                var text = new StringBuilder();
+                                text.Clear();
                                 foreach (XmlNode textNode in textNodes)
                                 {
                                     text.AppendLine(textNode.InnerText);

--- a/src/libse/SubtitleFormats/GooglePlayJson.cs
+++ b/src/libse/SubtitleFormats/GooglePlayJson.cs
@@ -59,6 +59,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 return;
             }
 
+            var text = new StringBuilder();
             foreach (var k in dictionary.Keys)
             {
                 if (k != "events" || !(dictionary[k] is List<object> captionGroups))
@@ -73,7 +74,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         continue;
                     }
 
-                    var text = new StringBuilder();
+                    text.Clear();
                     var start = -1d;
                     var dur = -1d;
                     foreach (var lineKey in line.Keys)

--- a/src/libse/SubtitleFormats/HollyStarJson.cs
+++ b/src/libse/SubtitleFormats/HollyStarJson.cs
@@ -112,6 +112,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var json = allText.Substring(startIndex);
             var parser = new SeJsonParser();
             var items = parser.GetArrayElementsByName(json, "SubtitleItems");
+            var text = new StringBuilder();
             foreach (var item in items)
             {
                 var textLines = parser.GetArrayElementsByName(item, "TextLines");
@@ -119,7 +120,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 var hideTime = parser.GetAllTagsByNameAsStrings(item, "HideTime");
                 if (textLines.Count > 0 && showTime.Count == 1 && hideTime.Count == 1 && long.TryParse(showTime[0], out var startMs) && long.TryParse(hideTime[0], out var endMs))
                 {
-                    var text = new StringBuilder();
+                    text.Clear();
                     foreach (var line in textLines)
                     {
                         text.AppendLine(Json.DecodeJsonText(line));

--- a/src/libse/SubtitleFormats/HtmlSamiArray.cs
+++ b/src/libse/SubtitleFormats/HtmlSamiArray.cs
@@ -37,6 +37,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
             subtitle.Paragraphs.Clear();
+            var sb = new StringBuilder();
             foreach (string line in lines)
             {
                 var pos0 = line.IndexOf("[0] = ", StringComparison.Ordinal);
@@ -45,7 +46,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 if (pos0 >= 0 && pos1 >= 0 && pos2 >= 0)
                 {
                     var p = new Paragraph();
-                    var sb = new StringBuilder();
+                    sb.Clear();
 
                     for (int i = pos0 + 6; i < line.Length && char.IsDigit(line[i]); i++)
                     {

--- a/src/libse/SubtitleFormats/JsonType19.cs
+++ b/src/libse/SubtitleFormats/JsonType19.cs
@@ -64,7 +64,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 var s = string.Empty;
                 if (idx > 0)
                 {
-                    sb = new StringBuilder();
+                    sb.Clear();
                     var arr = parser.GetArrayElements(element.Substring(idx));
                     foreach (var line in arr)
                     {

--- a/src/libse/SubtitleFormats/JsonType5.cs
+++ b/src/libse/SubtitleFormats/JsonType5.cs
@@ -126,19 +126,21 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var times = Json.ReadArray(allText, "text_tees");
             var texts = Json.ReadArray(allText, "text_content");
 
+            var textSb = new StringBuilder();
+            var innerSb = new StringBuilder();
             for (var i = 0; i < Math.Min(times.Count, texts.Count); i++)
             {
                 var text = texts[i];
                 if (text.StartsWith('['))
                 {
                     var textLines = Json.ReadArray("{\"text\":" + texts[i] + "}", "text");
-                    var textSb = new StringBuilder();
+                    textSb.Clear();
                     foreach (string line in textLines)
                     {
                         var t = Json.DecodeJsonText(line);
                         if (t.StartsWith("[\"", StringComparison.Ordinal) && t.EndsWith("\"]", StringComparison.Ordinal))
                         {
-                            var innerSb = new StringBuilder();
+                            innerSb.Clear();
                             var innerTextLines = Json.ReadArray("{\"text\":" + t + "}", "text");
                             foreach (string innerLine in innerTextLines)
                             {

--- a/src/libse/SubtitleFormats/JsonTypeOnlyLoad4.cs
+++ b/src/libse/SubtitleFormats/JsonTypeOnlyLoad4.cs
@@ -40,7 +40,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             foreach (var subtitleItem in subtitleArray)
             {
                 var contentItems = parser.GetArrayElementsByName(subtitleItem, "content");
-                sb = new StringBuilder();
+                sb.Clear();
                 foreach (var content in contentItems)
                 {
                     foreach (var textElement in parser.GetArrayElementsByName(content, "text"))

--- a/src/libse/SubtitleFormats/JsonTypeOnlyLoad5.cs
+++ b/src/libse/SubtitleFormats/JsonTypeOnlyLoad5.cs
@@ -38,9 +38,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             subtitle.Paragraphs.Clear();
             var parser = new SeJsonParser();
             var subtitleArray = parser.GetArrayElementsByName(text, "Paragraphs");
+            var content = new StringBuilder();
             foreach (var subtitleItem in subtitleArray)
             {
-                var content = new StringBuilder();
+                content.Clear();
                 var paragraphLines = parser.GetArrayElementsByName(subtitleItem, "Lines");
                 var start = parser.GetFirstObject(subtitleItem, "Start");
                 var end = parser.GetFirstObject(subtitleItem, "End");

--- a/src/libse/SubtitleFormats/NciCaption.cs
+++ b/src/libse/SubtitleFormats/NciCaption.cs
@@ -77,12 +77,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             int i = 128;
             var encoding = Encoding.GetEncoding(1252);
+            var sb = new StringBuilder();
             while (i < buffer.Length - 66)
             {
                 if (buffer[i] == 0xff && buffer[i + 1] == 0xff && buffer[i + 3] != 0xff && buffer[i - 1] != 0xff && buffer[i + 64] == 0xff && buffer[i + 65] == 0xff)
                 {
                     var p = new Paragraph();
-                    var sb = new StringBuilder();
+                    sb.Clear();
                     int j = i + 4;
                     while (j < i + 64)
                     {

--- a/src/libse/SubtitleFormats/PListCaption.cs
+++ b/src/libse/SubtitleFormats/PListCaption.cs
@@ -119,12 +119,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             XmlDocument xml = new XmlDocument { XmlResolver = null };
             xml.LoadXml(sb.ToString().Trim());
             string lastKey = string.Empty;
+            var pText = new StringBuilder();
             foreach (XmlNode node in xml.DocumentElement.SelectNodes("array/dict"))
             {
                 try
                 {
                     Paragraph p = new Paragraph();
-                    var pText = new StringBuilder();
+                    pText.Clear();
                     foreach (XmlNode innerNode in node.ChildNodes)
                     {
                         if (innerNode.Name == "key")

--- a/src/libse/SubtitleFormats/Sami.cs
+++ b/src/libse/SubtitleFormats/Sami.cs
@@ -275,6 +275,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             var p = new Paragraph();
             const string expectedChars = @"""'0123456789";
+            var className = new StringBuilder();
+            var total = new StringBuilder();
+            var partial = new StringBuilder();
             while (syncStartPos >= 0)
             {
                 string millisecondsAsString = string.Empty;
@@ -321,7 +324,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 string textToLower = text.ToLowerInvariant();
                 if (textToLower.Contains(" class="))
                 {
-                    var className = new StringBuilder();
+                    className.Clear();
                     int startClass = textToLower.IndexOf(" class=", StringComparison.Ordinal);
                     int indexClass = startClass + 7;
                     while (indexClass < textToLower.Length && (Utilities.LowercaseLettersWithNumbers + @"'""").Contains(textToLower[indexClass]))
@@ -408,8 +411,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
                 if (text.Contains('<') && text.Contains('>'))
                 {
-                    var total = new StringBuilder();
-                    var partial = new StringBuilder();
+                    total.Clear();
+                    partial.Clear();
                     bool tagOn = false;
                     for (int i = 0; i < text.Length && i < 999; i++)
                     {

--- a/src/libse/SubtitleFormats/StructuredTitles.cs
+++ b/src/libse/SubtitleFormats/StructuredTitles.cs
@@ -167,11 +167,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         private static void FixItalics(Subtitle subtitle)
         {
+            var sb = new StringBuilder();
             foreach (var p in subtitle.Paragraphs)
             {
                 if (p.Text.Contains('<') && p.Text.Contains('>'))
                 {
-                    var sb = new StringBuilder();
+                    sb.Clear();
                     foreach (var line in p.Text.SplitToLines())
                     {
                         if (line.StartsWith('<') && line.EndsWith('>'))

--- a/src/libse/SubtitleFormats/TimedText.cs
+++ b/src/libse/SubtitleFormats/TimedText.cs
@@ -157,11 +157,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
             bool couldBeFrames = true;
             bool couldBeMillisecondsWithMissingLastDigit = true;
+            var pText = new StringBuilder();
             foreach (XmlNode node in div.ChildNodes)
             {
                 try
                 {
-                    var pText = new StringBuilder();
+                    pText.Clear();
                     var styleName = string.Empty;
                     if (node.Attributes?["style"] != null)
                     {

--- a/src/libse/SubtitleFormats/TimedText10.cs
+++ b/src/libse/SubtitleFormats/TimedText10.cs
@@ -851,12 +851,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             var topRegions = GetRegionsTopFromHeader(xml);
             XmlNode lastDiv = null;
+            var pText = new StringBuilder();
             foreach (XmlNode node in body.SelectNodes("//ttml:p", nsmgr))
             {
                 try
                 {
                     // Parse and convert paragraph text
-                    var pText = new StringBuilder();
+                    pText.Clear();
                     ReadParagraph(pText, node, styles, xml);
 
                     // Time codes

--- a/src/libse/SubtitleFormats/TimedText200604.cs
+++ b/src/libse/SubtitleFormats/TimedText200604.cs
@@ -163,11 +163,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var nsmgr = new XmlNamespaceManager(xml.NameTable);
             nsmgr.AddNamespace("ttaf1", xml.DocumentElement.NamespaceURI);
             var fixOverlap = false;
+            var pText = new StringBuilder();
             foreach (XmlNode node in xml.DocumentElement.SelectNodes("//ttaf1:p", nsmgr))
             {
                 try
                 {
-                    var pText = new StringBuilder();
+                    pText.Clear();
                     foreach (XmlNode innerNode in node.ChildNodes)
                     {
                         switch (innerNode.Name)

--- a/src/libse/SubtitleFormats/TimedText200604Ooyala.cs
+++ b/src/libse/SubtitleFormats/TimedText200604Ooyala.cs
@@ -169,11 +169,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var nsmgr = new XmlNamespaceManager(xml.NameTable);
             nsmgr.AddNamespace("ttaf1", xml.DocumentElement.NamespaceURI);
 
+            var pText = new StringBuilder();
             foreach (XmlNode node in xml.DocumentElement.SelectNodes("//ttaf1:p", nsmgr))
             {
                 try
                 {
-                    var pText = new StringBuilder();
+                    pText.Clear();
                     foreach (XmlNode innerNode in node.ChildNodes)
                     {
                         switch (innerNode.Name)

--- a/src/libse/SubtitleFormats/TimedTextImage.cs
+++ b/src/libse/SubtitleFormats/TimedTextImage.cs
@@ -76,11 +76,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             bool couldBeFrames = true;
             bool couldBeMillisecondsWithMissingLastDigit = true;
+            var pText = new StringBuilder();
             foreach (XmlNode node in body.ChildNodes)
             {
                 try
                 {
-                    var pText = new StringBuilder();
+                    pText.Clear();
                     foreach (XmlNode innerNode in node.ChildNodes)
                     {
                         if (innerNode.Name == "image" || innerNode.Name.EndsWith(":image", StringComparison.Ordinal))

--- a/src/libse/SubtitleFormats/TimedTextImscRosetta.cs
+++ b/src/libse/SubtitleFormats/TimedTextImscRosetta.cs
@@ -406,6 +406,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
             }
 
+            var textBuilder = new StringBuilder();
             foreach (XmlNode divNode in body.SelectNodes("ttml:div", namespaceManager))
             {
                 TimedText10.ExtractTimeCodes(divNode, subtitle, out var begin, out var end);
@@ -425,7 +426,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     var alignmentTag = GetAlignmentTagFromRegionAndStyle(paragraphStyle, regionDisplayAlign, originY, extentY);
                     
                     // Read all <p> nodes and combine them with line breaks
-                    var textBuilder = new StringBuilder();
+                    textBuilder.Clear();
                     for (int i = 0; i < pNodes.Count; i++)
                     {
                         if (i > 0)

--- a/src/libse/SubtitleFormats/TimedTextNoNs.cs
+++ b/src/libse/SubtitleFormats/TimedTextNoNs.cs
@@ -316,12 +316,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             Configuration.Settings.SubtitleSettings.TimedText10TimeCodeFormatSource = null;
 
             XmlNode lastDiv = null;
+            var pText = new StringBuilder();
             foreach (XmlNode node in body.SelectNodes("//p"))
             {
                 try
                 {
                     // Parse and convert paragraph text
-                    var pText = new StringBuilder();
+                    pText.Clear();
                     ReadParagraph(pText, node);
 
                     // Time codes

--- a/src/libse/SubtitleFormats/TmpegEncXml.cs
+++ b/src/libse/SubtitleFormats/TmpegEncXml.cs
@@ -493,11 +493,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
             }
 
+            var pText = new StringBuilder();
             foreach (XmlNode node in xml.DocumentElement.SelectNodes("Subtitle/SubtitleItem"))
             {
                 try
                 {
-                    var pText = new StringBuilder();
+                    pText.Clear();
                     foreach (XmlNode innerNode in node.SelectSingleNode("Text").ChildNodes)
                     {
                         if (innerNode.Name == "br")

--- a/src/libse/SubtitleFormats/TwentyThreeJson.cs
+++ b/src/libse/SubtitleFormats/TwentyThreeJson.cs
@@ -84,6 +84,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var json = allText.Substring(startIndex);
             var parser = new SeJsonParser();
             var items = parser.GetArrayElementsByName(json, "subtitles");
+            var text = new StringBuilder();
             foreach (var item in items)
             {
                 var textLines = parser.GetArrayElementsByName(item, "text");
@@ -93,7 +94,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     double.TryParse(beginTime[0], NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var startSeconds) &&
                     double.TryParse(endTime[0], NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var endSeconds))
                 {
-                    var text = new StringBuilder();
+                    text.Clear();
                     foreach (var line in textLines)
                     {
                         text.AppendLine(Json.DecodeJsonText(line));

--- a/src/libse/SubtitleFormats/UniversalSubtitleFormat.cs
+++ b/src/libse/SubtitleFormats/UniversalSubtitleFormat.cs
@@ -130,6 +130,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 return;
             }
 
+            var text = new StringBuilder();
             foreach (XmlNode node in xml.DocumentElement.SelectNodes("subtitles/subtitle"))
             {
                 try
@@ -137,7 +138,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     string start = node.Attributes["start"].InnerText;
                     string stop = node.Attributes["stop"].InnerText;
 
-                    var text = new StringBuilder();
+                    text.Clear();
                     foreach (XmlNode innerNode in node.SelectSingleNode("text").ChildNodes)
                     {
                         switch (innerNode.Name.Replace("tt:", string.Empty))

--- a/src/libse/SubtitleFormats/UnknownSubtitle102.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle102.cs
@@ -25,6 +25,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             sb.AppendLine();
             const string writeFormat = "         {0}    {1} ";
             int pageNumber = 1;
+            var text = new StringBuilder();
             for (var index = 0; index < subtitle.Paragraphs.Count; index++)
             {
                 var p = subtitle.Paragraphs[index];
@@ -32,7 +33,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 var start = p.StartTime.Hours.ToString().PadLeft(2, '0') + ":" +
                             p.StartTime.Minutes.ToString().PadLeft(2, '0') + ":" +
                             p.StartTime.Seconds.ToString().PadLeft(2, '0');
-                var text = new StringBuilder(Utilities.UnbreakLine(HtmlUtil.RemoveHtmlTags(p.Text, true)));
+                text.Clear();
+                text.Append(Utilities.UnbreakLine(HtmlUtil.RemoveHtmlTags(p.Text, true)));
                 while (text.Length < (73 - 17))
                 {
                     text.Append(" ");

--- a/src/libse/SubtitleFormats/UnknownSubtitle103.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle103.cs
@@ -24,13 +24,15 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             sb.AppendLine();
             sb.AppendLine();
             string writeFormat = string.Empty.PadLeft(16, ' ') + "{0} ";
+            var text = new StringBuilder();
             for (var index = 0; index < subtitle.Paragraphs.Count; index++)
             {
                 var p = subtitle.Paragraphs[index];
                 var start = p.StartTime.Hours.ToString().PadLeft(2, '0') + ":" +
                             p.StartTime.Minutes.ToString().PadLeft(2, '0') + ":" +
                             p.StartTime.Seconds.ToString().PadLeft(2, '0');
-                var text = new StringBuilder(Utilities.UnbreakLine(HtmlUtil.RemoveHtmlTags(p.Text, true)));
+                text.Clear();
+                text.Append(Utilities.UnbreakLine(HtmlUtil.RemoveHtmlTags(p.Text, true)));
                 while (text.Length < (73 - 17))
                 {
                     text.Append(" ");

--- a/src/libse/SubtitleFormats/UnknownSubtitle11.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle11.cs
@@ -82,6 +82,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override string ToText(Subtitle subtitle, string title)
         {
             var sb = new StringBuilder();
+            var lineSb = new StringBuilder();
             foreach (Paragraph p in subtitle.Paragraphs)
             {
                 sb.Append('{');
@@ -98,7 +99,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 bool italicOn = false;
                 bool boldOn = false;
                 bool underlineOn = false;
-                var lineSb = new StringBuilder();
+                lineSb.Clear();
                 foreach (string line in parts)
                 {
                     if (count > 0)
@@ -176,6 +177,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
+            var lineSb = new StringBuilder();
             foreach (string line in lines)
             {
                 string s = RemoveIllegalSpacesAndFixEmptyCodes(line);
@@ -196,7 +198,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             string post = string.Empty;
                             string[] parts = text.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
                             int count = 0;
-                            var lineSb = new StringBuilder();
+                            lineSb.Clear();
                             foreach (string s2 in parts)
                             {
                                 if (count > 0)

--- a/src/libse/SubtitleFormats/UnknownSubtitle22.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle22.cs
@@ -70,7 +70,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             p.Text = sb.ToString().Trim();
                             subtitle.Paragraphs.Add(p);
                         }
-                        sb = new StringBuilder();
+                        sb.Clear();
                         string[] arr = s.Split('\t');
                         if (arr.Length == 4)
                         {

--- a/src/libse/SubtitleFormats/UnknownSubtitle43.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle43.cs
@@ -90,11 +90,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var xml = new XmlDocument { XmlResolver = null };
             xml.LoadXml(sb.ToString().Trim());
 
+            var pText = new StringBuilder();
             foreach (XmlNode node in xml.DocumentElement.SelectNodes("subtitle"))
             {
                 try
                 {
-                    var pText = new StringBuilder();
+                    pText.Clear();
                     foreach (XmlNode innerNode in node.ChildNodes)
                     {
                         switch (innerNode.Name)

--- a/src/libse/SubtitleFormats/UnknownSubtitle44.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle44.cs
@@ -23,10 +23,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var sb = new StringBuilder();
             int index = 0;
             int index2 = 0;
+            var text = new StringBuilder();
             foreach (Paragraph p in subtitle.Paragraphs)
             {
                 index++;
-                var text = new StringBuilder();
+                text.Clear();
                 text.Append(HtmlUtil.RemoveHtmlTags(p.Text.Replace(Environment.NewLine, " ")));
                 while (text.Length < 34)
                 {

--- a/src/libse/SubtitleFormats/UnknownSubtitle70.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle70.cs
@@ -84,6 +84,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override string ToText(Subtitle subtitle, string title)
         {
             var sb = new StringBuilder();
+            var lineSb = new StringBuilder();
+            var pre = new StringBuilder();
             foreach (Paragraph p in subtitle.Paragraphs)
             {
                 sb.Append('[');
@@ -100,7 +102,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 bool italicOn = false;
                 bool boldOn = false;
                 bool underlineOn = false;
-                var lineSb = new StringBuilder();
+                lineSb.Clear();
                 foreach (string line in parts)
                 {
                     if (count > 0)
@@ -112,7 +114,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     bool alreadyBold = boldOn;
                     bool alreadyUnderline = underlineOn;
 
-                    var pre = new StringBuilder();
+                    pre.Clear();
                     string s = line;
                     for (int i = 0; i < 5; i++)
                     {
@@ -340,6 +342,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             Errors = null;
             _lineNumber = 0;
 
+            var lineSb = new StringBuilder();
+            var pre = new StringBuilder();
             foreach (string line in lines)
             {
                 _lineNumber++;
@@ -361,7 +365,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             string post = string.Empty;
                             string[] parts = text.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
                             int count = 0;
-                            var lineSb = new StringBuilder();
+                            lineSb.Clear();
 
                             foreach (string s2 in parts)
                             {
@@ -371,7 +375,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                                 }
 
                                 s = s2.Trim();
-                                var pre = new StringBuilder();
+                                pre.Clear();
                                 string singlePost = string.Empty;
                                 for (int i = 0; i < 5; i++)
                                 {

--- a/src/libse/SubtitleFormats/UnknownSubtitle97.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle97.cs
@@ -23,9 +23,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             //\t\t-ENOUGH!
             const string writeFormat = "{0:00}:{1:00}:{2:00} {3}";
             var sb = new StringBuilder();
+            var textBuilder = new StringBuilder();
             foreach (var p in subtitle.Paragraphs)
             {
-                var textBuilder = new StringBuilder();
+                textBuilder.Clear();
                 var list = p.Text.SplitToLines();
                 for (var index = 0; index < list.Count; index++)
                 {

--- a/src/libse/SubtitleFormats/UnknownSubtitle99.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle99.cs
@@ -61,7 +61,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             subtitle.Paragraphs.Add(p);
                         }
 
-                        text = new StringBuilder();
+                        text.Clear();
                         var arr = s.Split(':');
                         if (arr.Length == 4)
                         {

--- a/src/libse/SubtitleFormats/WinCaps32.cs
+++ b/src/libse/SubtitleFormats/WinCaps32.cs
@@ -42,12 +42,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             const int blockSize = 528;
             int i = 100;
             byte[] buffer = FileUtil.ReadAllBytesShared(fileName);
+            var sb = new StringBuilder();
             while (i < buffer.Length - blockSize)
             {
                 if (buffer[i] == 0x10 && buffer[i + 1] == 0 && buffer[i + 2] == 1) // subtitle block
                 {
                     var p = new Paragraph();
-                    var sb = new StringBuilder();
+                    sb.Clear();
                     int idx = i;
                     int nextPosition = idx + blockSize;
                     while (idx < nextPosition)


### PR DESCRIPTION
## Summary
- Hoist `StringBuilder` declarations out of per-paragraph/per-line loops in ~40 subtitle format implementations and reuse them via `Clear()` instead of allocating a new instance every iteration
- Replace `sb = new StringBuilder()` reset assignments inside loops with `sb.Clear()` (`ESubXf`, `JsonType19`, `JsonTypeOnlyLoad4`, `UnknownSubtitle22`, `UnknownSubtitle99`)
- For seeded constructors inside loops (`UnknownSubtitle102`/`103`), reuse a hoisted builder with `Clear()` + `Append(...)`
- No behavior change: builders never escape an iteration (only `.ToString()` results are used); self-referential patterns like `sb = new StringBuilder(sb.ToString().TrimEnd())` were deliberately left untouched

## Benchmarks

BenchmarkDotNet 0.14.0, .NET 10, Release, `[MemoryDiagnoser]` — this branch vs parent commit 2131a6b. Aggregate round-trip over the changed formats (100-paragraph subtitle → `ToText` → `LoadSubtitle`; 40 formats exercisable via `ToText`, 32 via `LoadSubtitle` — the rest are binary/file-backed or don't round-trip) plus individual benchmarks for the heaviest-changed formats:

| Benchmark | Allocated before | Allocated after | Alloc change | Time change |
|---|---:|---:|---:|---:|
| All 40 formats `ToText` (aggregate) | 44.55 MB | 43.97 MB | −1.3% | −3.8%¹ |
| All 32 formats `LoadSubtitle` (aggregate) | 42.09 MB | 41.30 MB | −1.9% | flat¹ |
| `UnknownSubtitle70.ToText` | 147.3 KB | 94.0 KB | **−36%** | −12% |
| `UnknownSubtitle70.LoadSubtitle` | 156.8 KB | 103.5 KB | **−34%** | flat |
| `Sami.LoadSubtitle` | 1,170.9 KB | 1,128.7 KB | −3.6% | flat |
| `DCinemaInterop.ToText` | 3,491 KB | 3,409 KB | −2.4% | −4%¹ |
| `DCinemaInterop.LoadSubtitle` | 1,276 KB | 1,248 KB | −2.2% | −11%¹ |

¹ Verified with 15-iteration runs on both builds; the initial 3-iteration pass showed unstable means (including a phantom 2.5× aggregate speedup that was machine noise).

Most of these serializers are XML-DOM dominated, so the hoisted builders are a small slice of total allocations — hence low single-digit aggregate savings, with `UnknownSubtitle70` (−35%) as the standout where per-line/per-tag builders were the main allocation. No regressions.

## Test plan
- [x] `dotnet build src/libse/LibSE.csproj` succeeds
- [x] `dotnet test tests/libse/LibSETests.csproj` passes — 745/745 (includes format round-trip tests)
- [x] `dotnet test tests/UI/UITests.csproj` passes — 913/913 (1 skipped)
- [ ] AppVeyor CI green
- [ ] Manual smoke test: load/save a few affected formats (TimedText, DCinema, SAMI, EBU STL) and verify output text is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
