### PR TITLE
Reuse StringBuilder instances in loops in UI

### DIFF
--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectBounceIn.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectBounceIn.cs
@@ -24,6 +24,7 @@ public class AdvancedEffectBounceIn : IAdvancedEffectDisplay
     public List<SubtitleLineViewModel> ApplyEffect(string header, List<SubtitleLineViewModel> subtitles, int width, int height, WavePeakData2? wavePeaks)
     {
         var result = new List<SubtitleLineViewModel>();
+        var sb = new StringBuilder();
 
         foreach (var sub in subtitles)
         {
@@ -53,7 +54,7 @@ public class AdvancedEffectBounceIn : IAdvancedEffectDisplay
                 line.StartTime = sub.StartTime.Add(TimeSpan.FromMilliseconds(i * staggerMs));
                 line.EndTime = sub.EndTime;
 
-                var sb = new StringBuilder();
+                sb.Clear();
                 for (int j = 0; j < chars.Length; j++)
                 {
                     if (chars[j] == '\n')

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFancyKaraoke.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFancyKaraoke.cs
@@ -71,6 +71,7 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
         string header, List<SubtitleLineViewModel> subtitles, int width, int height, WavePeakData2? wavePeaks)
     {
         var result = new List<SubtitleLineViewModel>();
+        var sb = new StringBuilder();
         foreach (var sub in subtitles)
         {
             // If auto mode is enabled, attempt auto-sequencing by words.
@@ -89,7 +90,7 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
             var parsed = ParseActiveWord(sub.Text);
             var newSub = new SubtitleLineViewModel(sub, generateNewId: true);
             string posTags = ExtractPositionalTags(sub.Text);
-            var sb = new StringBuilder();
+            sb.Clear();
             if (!string.IsNullOrEmpty(posTags))
             {
                 sb.Append(posTags);
@@ -192,6 +193,7 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
         }
 
         var result = new List<SubtitleLineViewModel>();
+        var sb = new StringBuilder();
 
         for (int w = 0; w < wordCount; w++)
         {
@@ -204,7 +206,7 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
             line.EndTime = end;
 
             // Build text for this word index
-            var sb = new StringBuilder();
+            sb.Clear();
             if (!string.IsNullOrEmpty(posTags))
             {
                 sb.Append(posTags);
@@ -390,10 +392,11 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
     private static List<(string Tags, string Text)> BuildSegments(string text)
     {
         var result = new List<(string Tags, string Text)>();
+        var tags = new StringBuilder();
         int pos = 0;
         while (pos < text.Length)
         {
-            var tags = new StringBuilder();
+            tags.Clear();
             while (pos < text.Length && text[pos] == '{')
             {
                 int end = text.IndexOf('}', pos);

--- a/src/ui/Features/Assa/AssaAttachmentsViewModel.cs
+++ b/src/ui/Features/Assa/AssaAttachmentsViewModel.cs
@@ -262,33 +262,33 @@ public partial class AssaAttachmentsViewModel : ObservableObject
                 {
                     AddToListIfNotEmpty(attachments, attachmentContent.ToString(), attachmentFileName, category);
                     attachmentOn = false;
-                    attachmentContent = new StringBuilder();
+                    attachmentContent.Clear();
                     attachmentFileName = string.Empty;
                 }
                 else if (s == string.Empty)
                 {
                     AddToListIfNotEmpty(attachments, attachmentContent.ToString(), attachmentFileName, category);
-                    attachmentContent = new StringBuilder();
+                    attachmentContent.Clear();
                     attachmentFileName = string.Empty;
                 }
                 else if (s.Equals("[Fonts]", StringComparison.OrdinalIgnoreCase))
                 {
                     AddToListIfNotEmpty(attachments, attachmentContent.ToString(), attachmentFileName, category);
-                    attachmentContent = new StringBuilder();
+                    attachmentContent.Clear();
                     attachmentFileName = string.Empty;
                     category = Se.Language.General.Fonts;
                 }
                 else if (s.Equals("[Graphics]", StringComparison.OrdinalIgnoreCase))
                 {
                     AddToListIfNotEmpty(attachments, attachmentContent.ToString(), attachmentFileName, category);
-                    attachmentContent = new StringBuilder();
+                    attachmentContent.Clear();
                     attachmentFileName = string.Empty;
                     category = Se.Language.Assa.Graphics;
                 }
                 else if (s.StartsWith("filename:") || s.StartsWith("fontname:"))
                 {
                     AddToListIfNotEmpty(attachments, attachmentContent.ToString(), attachmentFileName, category);
-                    attachmentContent = new StringBuilder();
+                    attachmentContent.Clear();
                     attachmentFileName = s.Remove(0, 9).Trim();
                 }
                 else
@@ -300,14 +300,14 @@ public partial class AssaAttachmentsViewModel : ObservableObject
             {
                 category = Se.Language.General.Fonts;
                 attachmentOn = true;
-                attachmentContent = new StringBuilder();
+                attachmentContent.Clear();
                 attachmentFileName = string.Empty;
             }
             else if (s.Equals("[Graphics]", StringComparison.OrdinalIgnoreCase))
             {
                 category = Se.Language.Assa.Graphics;
                 attachmentOn = true;
-                attachmentContent = new StringBuilder();
+                attachmentContent.Clear();
                 attachmentFileName = string.Empty;
             }
         }

--- a/src/ui/Features/Assa/AssaDraw/AssaDrawViewModel.cs
+++ b/src/ui/Features/Assa/AssaDraw/AssaDrawViewModel.cs
@@ -713,10 +713,13 @@ public partial class AssaDrawViewModel : ObservableObject
         }
 
         // Generate paragraphs with style names
+        var sbDraw = new StringBuilder();
+        var sbErase = new StringBuilder();
+        var finalText = new StringBuilder();
         foreach (var layer in layers)
         {
-            var sbDraw = new StringBuilder();
-            var sbErase = new StringBuilder();
+            sbDraw.Clear();
+            sbErase.Clear();
             var firstShape = layer.FirstOrDefault(p => !p.IsEraser);
 
             // Collect draw shapes (normal shapes)
@@ -739,7 +742,7 @@ public partial class AssaDrawViewModel : ObservableObject
             // Build the final text with draw and optionally iclip
             if (!string.IsNullOrEmpty(drawText) || !string.IsNullOrEmpty(eraseText))
             {
-                var finalText = new StringBuilder();
+                finalText.Clear();
 
                 // Add iclip if we have erase shapes
                 if (!string.IsNullOrEmpty(eraseText))

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -6388,6 +6388,7 @@ public partial class MainViewModel :
         // Update selected lines with transcribed text
         var newLines = new List<SubtitleLineViewModel>();
         var deleteLines = new List<SubtitleLineViewModel>();
+        var sb = new StringBuilder();
         for (var i = 0; i < selectedItems.Count; i++)
         {
             var selectedLine = selectedItems[i];
@@ -6408,7 +6409,7 @@ public partial class MainViewModel :
                 else
                 {
                     // single line update
-                    var sb = new StringBuilder();
+                    sb.Clear();
                     foreach (var line in transcribedLine.Transcription.Paragraphs)
                     {
                         sb.AppendLine(line.Text);

--- a/src/ui/Features/Ocr/Engines/GoogleVisionOcr.cs
+++ b/src/ui/Features/Ocr/Engines/GoogleVisionOcr.cs
@@ -249,10 +249,11 @@ public class GoogleVisionOcr
 
                 // Merge lines ordered by X
                 var sb = new StringBuilder();
+                var sbLine = new StringBuilder();
                 var spaceThreshold = Math.Max(12, annotations.Average(p => p.Width) / 2.7);
                 foreach (var line in lines)
                 {
-                    var sbLine = new StringBuilder();
+                    sbLine.Clear();
                     last = null;
                     foreach (var l in line.OrderBy(p => p.Vertices.Min(p2 => p2.X)))
                     {

--- a/src/ui/Features/Ssa/SsaAttachmentsViewModel.cs
+++ b/src/ui/Features/Ssa/SsaAttachmentsViewModel.cs
@@ -262,33 +262,33 @@ public partial class SsaAttachmentsViewModel : ObservableObject
                 {
                     AddToListIfNotEmpty(attachments, attachmentContent.ToString(), attachmentFileName, category);
                     attachmentOn = false;
-                    attachmentContent = new StringBuilder();
+                    attachmentContent.Clear();
                     attachmentFileName = string.Empty;
                 }
                 else if (s == string.Empty)
                 {
                     AddToListIfNotEmpty(attachments, attachmentContent.ToString(), attachmentFileName, category);
-                    attachmentContent = new StringBuilder();
+                    attachmentContent.Clear();
                     attachmentFileName = string.Empty;
                 }
                 else if (s.Equals("[Fonts]", StringComparison.OrdinalIgnoreCase))
                 {
                     AddToListIfNotEmpty(attachments, attachmentContent.ToString(), attachmentFileName, category);
-                    attachmentContent = new StringBuilder();
+                    attachmentContent.Clear();
                     attachmentFileName = string.Empty;
                     category = Se.Language.General.Fonts;
                 }
                 else if (s.Equals("[Graphics]", StringComparison.OrdinalIgnoreCase))
                 {
                     AddToListIfNotEmpty(attachments, attachmentContent.ToString(), attachmentFileName, category);
-                    attachmentContent = new StringBuilder();
+                    attachmentContent.Clear();
                     attachmentFileName = string.Empty;
                     category = Se.Language.Assa.Graphics;
                 }
                 else if (s.StartsWith("filename:") || s.StartsWith("fontname:"))
                 {
                     AddToListIfNotEmpty(attachments, attachmentContent.ToString(), attachmentFileName, category);
-                    attachmentContent = new StringBuilder();
+                    attachmentContent.Clear();
                     attachmentFileName = s.Remove(0, 9).Trim();
                 }
                 else
@@ -300,14 +300,14 @@ public partial class SsaAttachmentsViewModel : ObservableObject
             {
                 category = Se.Language.General.Fonts;
                 attachmentOn = true;
-                attachmentContent = new StringBuilder();
+                attachmentContent.Clear();
                 attachmentFileName = string.Empty;
             }
             else if (s.Equals("[Graphics]", StringComparison.OrdinalIgnoreCase))
             {
                 category = Se.Language.Assa.Graphics;
                 attachmentOn = true;
-                attachmentContent = new StringBuilder();
+                attachmentContent.Clear();
                 attachmentFileName = string.Empty;
             }
         }

--- a/src/ui/Features/Video/SpeechToText/WhisperCppJson.cs
+++ b/src/ui/Features/Video/SpeechToText/WhisperCppJson.cs
@@ -96,13 +96,14 @@ public class TranscriptionSegment
             return result;
         }
 
+        var textBuilder = new StringBuilder();
         foreach (var token in Tokens)
         {
             var startMs = TimeCode.ParseToMilliseconds(token.Timestamps.From);
             var endMs = TimeCode.ParseToMilliseconds(token.Timestamps.To);
 
             // Build text with underlined active word
-            var textBuilder = new StringBuilder();
+            textBuilder.Clear();
             foreach (var t in Tokens)
             {
                 if (t == token)


### PR DESCRIPTION
## Summary
- Hoist `StringBuilder` declarations out of loops and reuse them via `Clear()` instead of allocating a new instance every iteration (`AdvancedEffectBounceIn`, `AdvancedEffectFancyKaraoke`, `AssaDrawViewModel.GenerateSubtitle`, `MainViewModel` audio-clip transcription, `GoogleVisionOcr`, `WhisperCppJson`)
- Replace `attachmentContent = new StringBuilder()` reset assignments with `attachmentContent.Clear()` in `AssaAttachmentsViewModel.ListAttachments` and `SsaAttachmentsViewModel.ListAttachments` (7 sites each)
- No behavior change: builders never escape an iteration (only `.ToString()` results are stored)

## Benchmarks

BenchmarkDotNet 0.14.0, .NET 10, Release, `[MemoryDiagnoser]` — this branch vs parent commit 2131a6b (full details in [this comment](https://github.com/SubtitleEdit/subtitleedit/pull/12920#issuecomment-5109210304)):

| Benchmark | Allocated before | Allocated after | Alloc change | Time change |
|---|---:|---:|---:|---:|
| `AdvancedEffectBounceIn.ApplyEffect` | 2,625.8 KB | 1,410.9 KB | **−46%** | −12% |
| `TranscriptionSegment.ToUnderlineActiveWords` | 67.2 KB | 43.0 KB | **−36%** | −14% |
| `FancyKaraoke.ApplyEffect` (markup mode) | 50.8 KB | 37.0 KB | **−27%** | ~flat |
| `FancyKaraoke.ApplyEffect` (auto-word mode) | 411.8 KB | 305.6 KB | **−26%** | −11% |
| `Assa`/`SsaAttachmentsViewModel.ListAttachments` | 713.1 KB | 618.1 KB | **−13%** | −5% to −16% |
| `GoogleVisionOcr.JsonToStringList` | 1,381.4 KB | 1,381.4 KB | ~0 | flat |

No regressions found (apparent timing regressions in the initial short run were verified as noise with 20-iteration runs on both builds). `MainViewModel`/`AssaDrawViewModel` are not benchmarkable in isolation (DI-heavy) but follow the identical pattern.

## Test plan
- [x] `dotnet build src/ui/UI.csproj` succeeds
- [x] `dotnet test tests/UI/UITests.csproj` passes — 913/913 (1 skipped)
- [x] `dotnet test tests/libse/LibSETests.csproj` passes — 745/745
- [ ] AppVeyor CI green
- [ ] Manual smoke test: open ASSA attachments dialog on a file with multiple fonts/graphics; apply Bounce In / Fancy Karaoke advanced effects; draw + erase shapes in ASSA Draw — verify results unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
