### PR TITLE
Fix 429 handling for LLM translate engines (#12921)

### DIFF
--- a/src/libse/AutoTranslate/AnthropicTranslate.cs
+++ b/src/libse/AutoTranslate/AnthropicTranslate.cs
@@ -77,11 +77,26 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             }
             var prompt = string.Format(Json.EncodeJsonText(Configuration.Settings.Tools.AnthropicPrompt), sourceLanguageCode, targetLanguageCode);
             var input = "{ \"model\": \"" + model + "\", \"max_tokens\": 1024, \"messages\": [{ \"role\": \"user\", \"content\": \"" + prompt + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
-            var content = new StringContent(input, Encoding.UTF8);
-            content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-            var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
-            var json = Encoding.UTF8.GetString(bytes).Trim();
+
+            int[] retryDelays = { 2555, 5007, 9013 };
+            HttpResponseMessage result = null;
+            var json = string.Empty;
+            for (var attempt = 0; attempt <= retryDelays.Length; attempt++)
+            {
+                var content = new StringContent(input, Encoding.UTF8);
+                content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
+                var bytes = await result.Content.ReadAsByteArrayAsync();
+                json = Encoding.UTF8.GetString(bytes).Trim();
+
+                if (!DeepLTranslate.ShouldRetry(result, json) || attempt == retryDelays.Length)
+                {
+                    break;
+                }
+
+                await Task.Delay(retryDelays[attempt], cancellationToken);
+            }
+
             if (!result.IsSuccessStatusCode)
             {
                 Error = json;

--- a/src/libse/AutoTranslate/ChatGptTranslate.cs
+++ b/src/libse/AutoTranslate/ChatGptTranslate.cs
@@ -112,11 +112,26 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             }
             var prompt = string.Format(Configuration.Settings.Tools.ChatGptPrompt, sourceLanguageCode, targetLanguageCode);
             var input = "{\"model\": \"" + Json.EncodeJsonText(model) + "\",\"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
-            var content = new StringContent(input, Encoding.UTF8);
-            content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-            var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
-            var json = Encoding.UTF8.GetString(bytes).Trim();
+
+            int[] retryDelays = { 2555, 5007, 9013 };
+            HttpResponseMessage result = null;
+            var json = string.Empty;
+            for (var attempt = 0; attempt <= retryDelays.Length; attempt++)
+            {
+                var content = new StringContent(input, Encoding.UTF8);
+                content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
+                var bytes = await result.Content.ReadAsByteArrayAsync();
+                json = Encoding.UTF8.GetString(bytes).Trim();
+
+                if (!DeepLTranslate.ShouldRetry(result, json) || attempt == retryDelays.Length)
+                {
+                    break;
+                }
+
+                await Task.Delay(retryDelays[attempt], cancellationToken);
+            }
+
             if (!result.IsSuccessStatusCode)
             {
                 Error = json;

--- a/src/libse/AutoTranslate/GroqTranslate.cs
+++ b/src/libse/AutoTranslate/GroqTranslate.cs
@@ -90,11 +90,26 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             }
             var prompt = string.Format(Configuration.Settings.Tools.GroqPrompt, sourceLanguageCode, targetLanguageCode);
             var input = "{\"model\": \"" + model + "\",\"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
-            var content = new StringContent(input, Encoding.UTF8);
-            content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-            var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
-            var json = Encoding.UTF8.GetString(bytes).Trim();
+
+            int[] retryDelays = { 2555, 5007, 9013 };
+            HttpResponseMessage result = null;
+            var json = string.Empty;
+            for (var attempt = 0; attempt <= retryDelays.Length; attempt++)
+            {
+                var content = new StringContent(input, Encoding.UTF8);
+                content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
+                var bytes = await result.Content.ReadAsByteArrayAsync();
+                json = Encoding.UTF8.GetString(bytes).Trim();
+
+                if (!DeepLTranslate.ShouldRetry(result, json) || attempt == retryDelays.Length)
+                {
+                    break;
+                }
+
+                await Task.Delay(retryDelays[attempt], cancellationToken);
+            }
+
             if (!result.IsSuccessStatusCode)
             {
                 Error = json;

--- a/src/libse/AutoTranslate/MistralTranslate.cs
+++ b/src/libse/AutoTranslate/MistralTranslate.cs
@@ -79,11 +79,26 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             }
             var prompt = string.Format(Configuration.Settings.Tools.AutoTranslateMistralPrompt, sourceLanguageCode, targetLanguageCode);
             var input = "{\"model\": \"" + model + "\",\"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
-            var content = new StringContent(input, Encoding.UTF8);
-            content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-            var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
-            var json = Encoding.UTF8.GetString(bytes).Trim();
+
+            int[] retryDelays = { 2555, 5007, 9013 };
+            HttpResponseMessage result = null;
+            var json = string.Empty;
+            for (var attempt = 0; attempt <= retryDelays.Length; attempt++)
+            {
+                var content = new StringContent(input, Encoding.UTF8);
+                content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
+                var bytes = await result.Content.ReadAsByteArrayAsync();
+                json = Encoding.UTF8.GetString(bytes).Trim();
+
+                if (!DeepLTranslate.ShouldRetry(result, json) || attempt == retryDelays.Length)
+                {
+                    break;
+                }
+
+                await Task.Delay(retryDelays[attempt], cancellationToken);
+            }
+
             if (!result.IsSuccessStatusCode)
             {
                 Error = json;

--- a/src/libse/AutoTranslate/OpenRouterTranslate.cs
+++ b/src/libse/AutoTranslate/OpenRouterTranslate.cs
@@ -97,11 +97,26 @@ namespace Nikse.SubtitleEdit.Core.AutoTranslate
             }
             var prompt = string.Format(Configuration.Settings.Tools.OpenRouterPrompt, sourceLanguageCode, targetLanguageCode);
             var input = "{\"model\": \"" + model + "\",\"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
-            var content = new StringContent(input, Encoding.UTF8);
-            content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-            var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
-            var json = Encoding.UTF8.GetString(bytes).Trim();
+
+            int[] retryDelays = { 2555, 5007, 9013 };
+            HttpResponseMessage result = null;
+            var json = string.Empty;
+            for (var attempt = 0; attempt <= retryDelays.Length; attempt++)
+            {
+                var content = new StringContent(input, Encoding.UTF8);
+                content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
+                var bytes = await result.Content.ReadAsByteArrayAsync();
+                json = Encoding.UTF8.GetString(bytes).Trim();
+
+                if (!DeepLTranslate.ShouldRetry(result, json) || attempt == retryDelays.Length)
+                {
+                    break;
+                }
+
+                await Task.Delay(retryDelays[attempt], cancellationToken);
+            }
+
             if (!result.IsSuccessStatusCode)
             {
                 Error = json;

--- a/src/libuilogic/Translate/MergeAndSplitHelper.cs
+++ b/src/libuilogic/Translate/MergeAndSplitHelper.cs
@@ -14,6 +14,8 @@ public static partial class MergeAndSplitHelper
     private const int MaxGapBetweenContinuousLinesMs = 1000;
     private const char PeriodPlaceholder = '¤';
 
+    private static DateTime _lastTranslateCompletedUtc = DateTime.MinValue;
+
     public static bool MergeSplitProblems { get; set; }
 
     public static async Task<int> MergeAndTranslateIfPossible(
@@ -38,7 +40,9 @@ public static partial class MergeAndSplitHelper
             return 0;
         }
 
+        await DelayBetweenRequestsIfNeeded(cancellationToken);
         var mergedTranslation = await autoTranslator.Translate(mergeResult.Text, source.Code, target.Code, cancellationToken);
+        _lastTranslateCompletedUtc = DateTime.UtcNow;
 
         if (forceSingleLineMode || mergeResult.ParagraphCount == 1)
         {
@@ -46,6 +50,30 @@ public static partial class MergeAndSplitHelper
         }
 
         return TrySplitStrategies(rows, target, index, tempSubtitle, formattingList, mergeResult, mergedTranslation);
+    }
+
+    /// <summary>
+    /// Honours the user's "delay in seconds between requests" setting by waiting until that delay
+    /// has passed since the previous request finished. Cloud engines enforce strict requests-per-second
+    /// limits and answer with 429 when they are exceeded (#12921).
+    /// </summary>
+    /// <remarks>
+    /// The timestamp is not reset between runs on purpose: an idle period longer than the delay
+    /// already satisfies it, so the first request of a run never waits.
+    /// </remarks>
+    private static async Task DelayBetweenRequestsIfNeeded(CancellationToken cancellationToken)
+    {
+        var delaySeconds = Configuration.Settings.Tools.AutoTranslateDelaySeconds;
+        if (delaySeconds <= 0)
+        {
+            return;
+        }
+
+        var remaining = TimeSpan.FromSeconds(delaySeconds) - (DateTime.UtcNow - _lastTranslateCompletedUtc);
+        if (remaining > TimeSpan.Zero)
+        {
+            await Task.Delay(remaining, cancellationToken);
+        }
     }
 
     private static TranslateRow[] CreateTempSubtitle(ObservableCollection<TranslateRow> rows)

--- a/src/ui/Features/Translate/TranslateSettingsViewModel.cs
+++ b/src/ui/Features/Translate/TranslateSettingsViewModel.cs
@@ -8,6 +8,7 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 
@@ -97,6 +98,7 @@ public partial class TranslateSettingsViewModel : ObservableObject
         }
 
         Se.Settings.AutoTranslate.RequestDelaySeconds = ServerDelaySeconds ?? 0;
+        Configuration.Settings.Tools.AutoTranslateDelaySeconds = (int)Math.Round(ServerDelaySeconds ?? 0, MidpointRounding.AwayFromZero);
         Se.Settings.AutoTranslate.RequestMaxBytes = MaxBytesRequest ?? 0;
         Se.Settings.AutoTranslate.EngineStrategies[AutoTranslator.Name] =
             SelectedMergeOptions == Se.Language.Translate.TranslateEachLineSeparately

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -641,6 +641,7 @@ public class Se
         Configuration.Settings.Tools.DashScopeSttTimeoutSeconds = Settings.Tools.DashScopeSttTimeoutSeconds;
 
         Configuration.Settings.Tools.AutoTranslateLastName = Settings.AutoTranslate.AutoTranslateLastName;
+        Configuration.Settings.Tools.AutoTranslateDelaySeconds = (int)Math.Round(Settings.AutoTranslate.RequestDelaySeconds, MidpointRounding.AwayFromZero);
 
         // BeautifyTimeCodes profile: skip apply on a fresh install so libse's built-in
         // default-preset values stay intact. Once the user clicks OK in the profile editor,


### PR DESCRIPTION
Fixes #12921

## What changed

Three related changes, one commit each.

**1. Retry with backoff for Mistral.** `MistralTranslate.Translate` did a single `PostAsync` followed by `EnsureSuccessStatusCode()`, so a 429 (`Rate limit exceeded`) aborted the entire run on the first hit — the exception unwound through `MergeAndSplitHelper` → `AutoTranslateViewModel` and surfaced as the error dialog in the issue, losing the rest of the file. It now uses the same retry loop the other engines use: up to 4 attempts with 2.5s / 5s / 9s backoff, breaking early via the shared `DeepLTranslate.ShouldRetry` helper (429 / 503 / the HTML 429 body).

**2. Same retry for ChatGPT, Anthropic, Groq and OpenRouter.** All four had byte-for-byte the same single-attempt request block, so they got the identical treatment. Nine engines now have retry; still without it are Perplexity, AvalAi, Lara, Papago, Baidu, MyMemory and LibreTranslate, plus the local-server engines where rate limits don't apply.

**3. Wired up "delay in seconds between requests".** The setting was shown in the translate settings dialog and persisted to `Se.Settings.AutoTranslate.RequestDelaySeconds`, but nothing read it during translation — setting it did nothing. libse already declared `Configuration.Settings.Tools.AutoTranslateDelaySeconds`, but that field was equally unused: nothing wrote it and nothing read it. Connected the three ends — `Se.cs` copies the persisted value in on startup, `TranslateSettingsViewModel.SaveValues()` also writes the libse copy so a change applies without a restart (matching what the prompt settings in that method already do), and `MergeAndSplitHelper` waits at the request site.

## Why

Mistral's free tier allows roughly one request per second, which the sequential translate loop exceeds easily. Requests are not concurrent, contrary to the issue report — but the failure path makes it worse: after `errorCount > 3` the loop flips to `forceSingleLineMode`, which really is one request per subtitle line. Retry handles the transient case; the delay setting is the mitigation for a tier whose limit SE simply cannot outrun.

The reporter's batching suggestion is already implemented — `MergeAndSplitHelper` merges up to `min(MaxCharacters, AutoTranslateMaxBytes)` chars per request.

## Notes for reviewers

- The delay is applied in `MergeAndSplitHelper` rather than the caller loops so it covers both the UI and headless seconv, and so it also covers the *second* `MergeAndTranslateIfPossible` call the loop makes after a split failure — that path issues a real API request and would otherwise slip past the throttle.
- The wait is measured from when the previous request *finished*, so it's a genuine gap between requests rather than a blind sleep. The timestamp is deliberately not reset per run: an idle gap longer than the delay already satisfies it, so the first request of a run never waits and no reset hook is needed. Default is 0 (disabled), so behaviour is unchanged unless the user sets it.
- `AutoTranslateDelaySeconds` is `int` in libse while the UI value is `decimal`, hence the rounding. The NumericUpDown only produces whole numbers, so it only matters for a hand-edited Settings.json.
- One deviation from the DeepSeek version of the retry loop: each engine's existing `ReadAsByteArrayAsync` + explicit UTF-8 decode is kept rather than switching to `ReadAsStringAsync`, so decoding stays independent of the response charset header.
- Behaviour once retries are exhausted is unchanged: `Error` is set, logged, and `EnsureSuccessStatusCode()` throws. A sustained rate limit still aborts the run, just no longer on the first hit.
- Verified `dotnet build` succeeds for both `libse.csproj` (both target frameworks) and `UI.csproj`; the two libse warnings are pre-existing in `RegexUtils.cs`. **Not tested against a live API** — I have no keys for these services. Worth a manual check that a configured delay visibly paces a run.

## Still open (not addressed here)

- `RequestMaxBytes`, the field directly below the delay in the same dialog, is still dead: `CalculateMaxChars` reads `Configuration.Settings.Tools.AutoTranslateMaxBytes` (default 2000) and nothing populates it from `RequestMaxBytes` (default 1000). Wire it the same way, or drop it from the dialog?
- `AnthropicTranslate.cs` has `SeLogger.Error($"{StaticName}: debug json: " + json)` on the *success* path, writing the full API response to the error log for every translated chunk. Looks like leftover debugging; left alone as unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
