### PR TITLE
Performance hunt: cut allocations in libse, LibUiLogic and main-window hot paths

### DIFF
--- a/src/libse/Common/ContinuationUtilities.cs
+++ b/src/libse/Common/ContinuationUtilities.cs
@@ -6,13 +6,56 @@ using System.Text.RegularExpressions;
 
 namespace Nikse.SubtitleEdit.Core.Common
 {
-    public static class ContinuationUtilities
+    public static partial class ContinuationUtilities
     {
+        // SanitizeString runs several times per paragraph pair in the continuation fixes; the
+        // static Regex.Replace overloads went through the global regex cache (a lock + key
+        // hash per call), and the music-symbol loop even rebuilt its pattern strings per call.
+#if NET7_0_OR_GREATER
+        [GeneratedRegex("<.*?>")]
+        private static partial Regex HtmlTagRegexGen();
+        private static readonly Regex HtmlTagRegex = HtmlTagRegexGen();
+
+        [GeneratedRegex("\\(.*?\\)", RegexOptions.Singleline)]
+        private static partial Regex ParenthesesRegexGen();
+        private static readonly Regex ParenthesesRegex = ParenthesesRegexGen();
+
+        [GeneratedRegex("\\[.*?\\]", RegexOptions.Singleline)]
+        private static partial Regex SquareBracketsRegexGen();
+        private static readonly Regex SquareBracketsRegex = SquareBracketsRegexGen();
+
+        [GeneratedRegex("\\{.*?\\}")]
+        private static partial Regex CurlyBracesRegexGen();
+        private static readonly Regex CurlyBracesRegex = CurlyBracesRegexGen();
+#else
+        private static readonly Regex HtmlTagRegex = new Regex("<.*?>", RegexOptions.Compiled);
+        private static readonly Regex ParenthesesRegex = new Regex("\\(.*?\\)", RegexOptions.Compiled | RegexOptions.Singleline);
+        private static readonly Regex SquareBracketsRegex = new Regex("\\[.*?\\]", RegexOptions.Compiled | RegexOptions.Singleline);
+        private static readonly Regex CurlyBracesRegex = new Regex("\\{.*?\\}", RegexOptions.Compiled);
+#endif
+
+        // One per char in MusicSymbols ("♪♫#*¶"), same "\x.*?\x" patterns the loop built.
+        private static readonly Regex[] MusicSymbolRegexes = BuildMusicSymbolRegexes();
+
+        private static Regex[] BuildMusicSymbolRegexes()
+        {
+            var regexes = new Regex[MusicSymbols.Length];
+            for (var i = 0; i < MusicSymbols.Length; i++)
+            {
+                var c = MusicSymbols[i];
+                regexes[i] = new Regex("\\" + c + ".*?\\" + c, RegexOptions.Compiled | RegexOptions.Singleline);
+            }
+
+            return regexes;
+        }
+
         private static readonly string Dashes = "-‐–—";
         private static readonly string Quotes = "'\"“”‘’«»‹›„“‚‘";
         private static readonly string SingleQuotes = "'‘’‘";
         private static readonly string DoubleQuotes = "''‘‘’’‚‚‘‘";
-        private static readonly string MusicSymbols = "♪♫#*¶";
+        // const (not static readonly) so MusicSymbolRegexes above can reference it from its
+        // field initializer regardless of declaration order.
+        private const string MusicSymbols = "♪♫#*¶";
         private static readonly string ExplanationQuotes = "'\"“”‘’«»‹›";
 
         private static readonly List<string> LanguagesWithoutCaseDistinction = new List<string>
@@ -50,16 +93,16 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
 
             var checkString = input;
-            checkString = Regex.Replace(checkString, "<.*?>", string.Empty);
-            checkString = Regex.Replace(checkString, "\\(.*?\\)", string.Empty, RegexOptions.Singleline);
-            checkString = Regex.Replace(checkString, "\\[.*?\\]", string.Empty, RegexOptions.Singleline);
-            checkString = Regex.Replace(checkString, "\\{.*?\\}", string.Empty);
+            checkString = HtmlTagRegex.Replace(checkString, string.Empty);
+            checkString = ParenthesesRegex.Replace(checkString, string.Empty);
+            checkString = SquareBracketsRegex.Replace(checkString, string.Empty);
+            checkString = CurlyBracesRegex.Replace(checkString, string.Empty);
 
             if (Configuration.Settings.General.FixContinuationStyleIgnoreLyrics)
             {
-                foreach (var c in MusicSymbols)
+                foreach (var regex in MusicSymbolRegexes)
                 {
-                    checkString = Regex.Replace(checkString, "\\" + c + ".*?\\" + c, string.Empty, RegexOptions.Singleline);
+                    checkString = regex.Replace(checkString, string.Empty);
                 }
             }
 
@@ -181,7 +224,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         public static string ExtractParagraphOnly(string input, bool removeDashes)
         {
             var checkString = input;
-            checkString = Regex.Replace(checkString, "\\{.*?\\}", string.Empty);
+            checkString = CurlyBracesRegex.Replace(checkString, string.Empty);
             checkString = checkString.Trim();
 
             // Remove string elevation
@@ -1254,7 +1297,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         public static bool IsArabicInsert(string originalInput, string sanitizedInput)
         {
             var input = ExtractParagraphOnly(originalInput);
-            input = Regex.Replace(input, "<.*?>", string.Empty);
+            input = HtmlTagRegex.Replace(input, string.Empty);
 
             if (input.Length >= 2)
             {

--- a/src/libse/Common/HtmlUtil.cs
+++ b/src/libse/Common/HtmlUtil.cs
@@ -1664,6 +1664,13 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// <returns>A new string without ASS and SSA alignment tags.</returns>
         public static string RemoveAssAlignmentTags(string s)
         {
+            // Every pattern below contains a backslash, so plain text (the common case in
+            // batch convert) skips all 45 Replace scans.
+            if (s.IndexOf('\\') < 0)
+            {
+                return s;
+            }
+
             return s.Replace("{\\an1}", string.Empty) // ASS tags alone
                 .Replace("{\\an2}", string.Empty)
                 .Replace("{\\an3}", string.Empty)
@@ -1722,14 +1729,49 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// <returns>A new string with all ASSA color tags removed.</returns>
         public static string RemoveAssaColor(string input)
         {
+            // Every pattern requires a backslash; the static Regex.Replace overloads also went
+            // through the global regex cache (a lock + key hash per call) on every line.
+            if (input.IndexOf('\\') < 0)
+            {
+                return input;
+            }
+
             var text = input;
-            text = Regex.Replace(text, "\\\\alpha&H.{1,2}&\\\\", "\\");
-            text = Regex.Replace(text, "{\\\\1c&[abcdefghABCDEFGH\\d]*&}", string.Empty);
-            text = Regex.Replace(text, "{\\\\c&[abcdefghABCDEFGH\\d]*&}", string.Empty);
-            text = Regex.Replace(text, "\\\\c&[abcdefghABCDEFGH\\d]*&", string.Empty);
-            text = Regex.Replace(text, "\\\\1c&[abcdefghABCDEFGH\\d]*&", string.Empty);
+            text = AssaAlphaTagRegex.Replace(text, "\\");
+            text = Assa1cBraceRegex.Replace(text, string.Empty);
+            text = AssaCBraceRegex.Replace(text, string.Empty);
+            text = AssaCRegex.Replace(text, string.Empty);
+            text = Assa1cRegex.Replace(text, string.Empty);
             return text;
         }
+
+#if NET7_0_OR_GREATER
+        [GeneratedRegex("\\\\alpha&H.{1,2}&\\\\")]
+        private static partial Regex AssaAlphaTagRegexGen();
+        private static readonly Regex AssaAlphaTagRegex = AssaAlphaTagRegexGen();
+
+        [GeneratedRegex("{\\\\1c&[abcdefghABCDEFGH\\d]*&}")]
+        private static partial Regex Assa1cBraceRegexGen();
+        private static readonly Regex Assa1cBraceRegex = Assa1cBraceRegexGen();
+
+        [GeneratedRegex("{\\\\c&[abcdefghABCDEFGH\\d]*&}")]
+        private static partial Regex AssaCBraceRegexGen();
+        private static readonly Regex AssaCBraceRegex = AssaCBraceRegexGen();
+
+        [GeneratedRegex("\\\\c&[abcdefghABCDEFGH\\d]*&")]
+        private static partial Regex AssaCRegexGen();
+        private static readonly Regex AssaCRegex = AssaCRegexGen();
+
+        [GeneratedRegex("\\\\1c&[abcdefghABCDEFGH\\d]*&")]
+        private static partial Regex Assa1cRegexGen();
+        private static readonly Regex Assa1cRegex = Assa1cRegexGen();
+#else
+        private static readonly Regex AssaAlphaTagRegex = new Regex("\\\\alpha&H.{1,2}&\\\\", RegexOptions.Compiled);
+        private static readonly Regex Assa1cBraceRegex = new Regex("{\\\\1c&[abcdefghABCDEFGH\\d]*&}", RegexOptions.Compiled);
+        private static readonly Regex AssaCBraceRegex = new Regex("{\\\\c&[abcdefghABCDEFGH\\d]*&}", RegexOptions.Compiled);
+        private static readonly Regex AssaCRegex = new Regex("\\\\c&[abcdefghABCDEFGH\\d]*&", RegexOptions.Compiled);
+        private static readonly Regex Assa1cRegex = new Regex("\\\\1c&[abcdefghABCDEFGH\\d]*&", RegexOptions.Compiled);
+#endif
 
         /// <summary>
         /// Gets the closing HTML tag for the specified opening tag.

--- a/src/libse/Common/TextSplit.cs
+++ b/src/libse/Common/TextSplit.cs
@@ -11,6 +11,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         private readonly int _singleLineMaxLength;
         private const string EndLineChars = ".!?…؟。？！";
         private const string Commas = ",،，、";
+        private static readonly char[] PeriodQuestionExclamation = { '.', '?', '!' };
 
         public TextSplit(string text, int singleLineMaxLength, string language)
         {
@@ -84,28 +85,50 @@ namespace Nikse.SubtitleEdit.Core.Common
             return GetBestLengthSplit();
         }
 
+        // The methods below need "the first element with the smallest key", which used to be
+        // Where(...).OrderBy(...).FirstOrDefault() - a full O(n log n) sort (plus the LINQ
+        // machinery) to pick element 0. OrderBy is stable, so a strictly-less linear scan
+        // returns exactly the same candidate.
+        private static TextSplitResult MinBy(List<TextSplitResult> splits, Predicate<TextSplitResult> filter, Func<TextSplitResult, double> key)
+        {
+            TextSplitResult best = null;
+            var bestDiff = double.MaxValue;
+            foreach (var p in splits)
+            {
+                if (filter != null && !filter(p))
+                {
+                    continue;
+                }
+
+                var diff = key(p);
+                if (diff < bestDiff)
+                {
+                    bestDiff = diff;
+                    best = p;
+                }
+            }
+
+            return best;
+        }
+
         private string GetBestDialog()
         {
-            var orderedArray = _splits.Where(IsDialog).OrderBy(p => p.DiffFromAveragePixel());
-            var best = orderedArray.FirstOrDefault();
+            var best = MinBy(_splits, IsDialog, p => p.DiffFromAveragePixel());
             return best != null ? string.Join(Environment.NewLine, best.Lines) : null;
         }
 
         private string GetBestEnding(string chars)
         {
-            var orderedArray = _splits.Where(p => p.IsLineLengthOkay(_singleLineMaxLength) && EndsWith(p, chars)).OrderBy(p => p.DiffFromAveragePixel());
-            var best = orderedArray.FirstOrDefault();
+            var best = MinBy(_splits, p => p.IsLineLengthOkay(_singleLineMaxLength) && EndsWith(p, chars), p => p.DiffFromAveragePixel());
             return best != null ? string.Join(Environment.NewLine, best.Lines) : null;
         }
 
         private string GetBestPixelSplit()
         {
-            var orderedArray = _splits.Where(p => p.IsLineLengthOkay(_singleLineMaxLength)).OrderBy(p => p.DiffFromAveragePixel());
-            var best = orderedArray.FirstOrDefault();
+            var best = MinBy(_splits, p => p.IsLineLengthOkay(_singleLineMaxLength), p => p.DiffFromAveragePixel());
             if (best != null && !best.IsBottomHeavy && Configuration.Settings.Tools.AutoBreakUsePixelWidth && Configuration.Settings.Tools.AutoBreakPreferBottomHeavy)
             {
-                orderedArray = _splits.Where(p => p.IsLineLengthOkay(_singleLineMaxLength)).OrderBy(p => p.DiffFromAveragePixelBottomHeavy());
-                best = orderedArray.FirstOrDefault() ?? best;
+                best = MinBy(_splits, p => p.IsLineLengthOkay(_singleLineMaxLength), p => p.DiffFromAveragePixelBottomHeavy()) ?? best;
             }
 
             return best != null ? string.Join(Environment.NewLine, best.Lines) : null;
@@ -113,15 +136,13 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         private string GetBestLengthSplit()
         {
-            var orderedArray = _splits.OrderBy(p => p.DiffFromAverage());
-            var best = orderedArray.FirstOrDefault();
+            var best = MinBy(_splits, null, p => p.DiffFromAverage());
             if (best != null)
             {
                 return string.Join(Environment.NewLine, best.Lines);
             }
 
-            orderedArray = _allSplits.OrderBy(p => p.DiffFromAverage());
-            best = orderedArray.FirstOrDefault();
+            best = MinBy(_allSplits, null, p => p.DiffFromAverage());
             return best != null ? string.Join(Environment.NewLine, best.Lines) : null;
         }
 
@@ -241,7 +262,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
 
                 // check for period in last part of current
-                var lastPeriodIdx = p.Text.LastIndexOfAny(new[] { '.', '?', '!' });
+                var lastPeriodIdx = p.Text.LastIndexOfAny(PeriodQuestionExclamation);
                 if (lastPeriodIdx > 3 && lastPeriodIdx > p.Text.Length - maxMoveChunkSize)
                 {
                     var newCurrentText = p.Text.Substring(0, lastPeriodIdx + 1).Trim();
@@ -282,7 +303,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
 
                 // check for period in beginning of next
-                var firstPeriodIdx = next.Text.IndexOfAny(new[] { '.', '?', '!' });
+                var firstPeriodIdx = next.Text.IndexOfAny(PeriodQuestionExclamation);
                 if (firstPeriodIdx >= 3 && firstPeriodIdx < maxMoveChunkSize)
                 {
                     var newCurrentText = next.Text.Substring(0, firstPeriodIdx + 1).Trim();

--- a/src/libse/Common/TextSplitResult.cs
+++ b/src/libse/Common/TextSplitResult.cs
@@ -1,7 +1,6 @@
 ﻿using SkiaSharp;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Nikse.SubtitleEdit.Core.Common
 {
@@ -29,8 +28,35 @@ namespace Nikse.SubtitleEdit.Core.Common
         public List<int> LengthCharacters { get; set; }
         public bool IsBottomHeavy => LengthPixels[1] + 2 > LengthPixels[0]; // allow a small diff of 2 pixels
         public static float SpaceLengthPixels { get; set; }
-        public double TotalLength => Lines.Sum(p => p.Length);
-        public double TotalLengthPixels => LengthPixels.Sum(p => p) - SpaceLengthPixels;
+        public double TotalLength => SumLengths(Lines);
+        public double TotalLengthPixels => SumPixels(LengthPixels) - SpaceLengthPixels;
+
+        // These run inside the per-candidate sort keys of TextSplit (one candidate per space in
+        // the line), where the LINQ Sum overloads allocated a closure and a boxed enumerator
+        // per call - for lists that always hold two elements.
+        private static double SumLengths(List<string> lines)
+        {
+            double total = 0;
+            for (var i = 0; i < lines.Count; i++)
+            {
+                total += lines[i].Length;
+            }
+
+            return total;
+        }
+
+        private static float SumPixels(List<float> pixels)
+        {
+            // Accumulate in double and round to float at the end - same as Enumerable.Sum's
+            // float overload, so the value is bit-identical to what the LINQ call produced.
+            double total = 0;
+            for (var i = 0; i < pixels.Count; i++)
+            {
+                total += pixels[i];
+            }
+
+            return (float)total;
+        }
 
         private List<float> _lengthPixels;
         private bool _pixelsMeasured;
@@ -144,14 +170,28 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public double DiffFromAverage()
         {
-            var avg = TotalLength / Lines.Count;
-            return Lines.Sum(line => Math.Abs(avg - line.Length));
+            var lines = Lines;
+            var avg = SumLengths(lines) / lines.Count;
+            double diff = 0;
+            for (var i = 0; i < lines.Count; i++)
+            {
+                diff += Math.Abs(avg - lines[i].Length);
+            }
+
+            return diff;
         }
 
         public double DiffFromAveragePixel()
         {
-            var avg = TotalLengthPixels / Lines.Count;
-            return LengthPixels.Sum(w => Math.Abs(avg - w));
+            var pixels = LengthPixels;
+            var avg = (double)(SumPixels(pixels) - SpaceLengthPixels) / Lines.Count;
+            double diff = 0;
+            for (var i = 0; i < pixels.Count; i++)
+            {
+                diff += Math.Abs(avg - pixels[i]);
+            }
+
+            return diff;
         }
 
         public double DiffFromAveragePixelBottomHeavy()

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -625,9 +625,9 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
 
             var s = RemoveLineBreaks(text);
-            while (s.Contains("  "))
+            if (s.Contains("  ", StringComparison.Ordinal))
             {
-                s = s.Replace("  ", " ");
+                s = CollapseSpaceRuns(s);
             }
 
             if (s.CountCharacters(false) < mergeLinesShorterThan)
@@ -660,16 +660,17 @@ namespace Nikse.SubtitleEdit.Core.Common
                             || tagSpan.StartsWith("<i".AsSpan(), StringComparison.OrdinalIgnoreCase)
                             || tagSpan.StartsWith("</i".AsSpan(), StringComparison.OrdinalIgnoreCase);
                 }
-                else if (letter == '{' && s.Substring(six).StartsWith("{\\"))
+                else if (letter == '{' && six + 1 < s.Length && s[six + 1] == '\\')
                 {
-                    var tagString = s.Substring(six);
-                    var endIndexAssTag = tagString.IndexOf('}') + 1;
-                    if (endIndexAssTag > 0)
+                    // Used to Substring the whole remainder (twice) per '{' and probe it with
+                    // the culture-sensitive StartsWith(string).
+                    var closeIdx = s.IndexOf('}', six);
+                    if (closeIdx >= 0)
                     {
-                        tagString = tagString.Substring(0, endIndexAssTag);
+                        var tagString = s.Substring(six, closeIdx - six + 1);
                         AddOrAppendHtmlTag(htmlTags, six, tagString);
 
-                        s = s.Remove(six, endIndexAssTag);
+                        s = s.Remove(six, closeIdx - six + 1);
                         continue;
                     }
                 }
@@ -715,6 +716,37 @@ namespace Nikse.SubtitleEdit.Core.Common
             s = s.Replace(" " + Environment.NewLine, Environment.NewLine);
             s = s.Replace(Environment.NewLine + " ", Environment.NewLine);
             return s.TrimEnd();
+        }
+
+        // Collapses every run of two or more spaces to a single space in one pass - the same
+        // result the old `while (Contains("  ")) Replace("  ", " ")` loop converged on, which
+        // allocated a new string per pass (O(n * runs) on space-heavy lines).
+        private static string CollapseSpaceRuns(string s)
+        {
+            var buffer = new char[s.Length];
+            var pos = 0;
+            var previousWasSpace = false;
+            for (var i = 0; i < s.Length; i++)
+            {
+                var ch = s[i];
+                if (ch == ' ')
+                {
+                    if (previousWasSpace)
+                    {
+                        continue;
+                    }
+
+                    previousWasSpace = true;
+                }
+                else
+                {
+                    previousWasSpace = false;
+                }
+
+                buffer[pos++] = ch;
+            }
+
+            return new string(buffer, 0, pos);
         }
 
         // Patterns for RemoveLineBreaks - static so the per-call "</i> " + Environment.NewLine
@@ -876,6 +908,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 var writeIdx = 0;
                 var i = 0;
                 var len = input.Length;
+                var modified = false;
 
                 while (i < len)
                 {
@@ -892,6 +925,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                                 input.AsSpan(i, closingBrace - i + 1).StartsWith("{Kara Effector".AsSpan()))
                             {
                                 i = closingBrace + 1;
+                                modified = true;
                                 continue;
                             }
                         }
@@ -908,12 +942,14 @@ namespace Nikse.SubtitleEdit.Core.Common
                             }
 
                             i += 2;
+                            modified = true;
                             continue;
                         }
                         if (next == 'h')
                         {
                             rented[writeIdx++] = ' ';
                             i += 2;
+                            modified = true;
                             continue;
                         }
                     }
@@ -923,7 +959,10 @@ namespace Nikse.SubtitleEdit.Core.Common
                     i++;
                 }
 
-                var result = new string(rented, 0, writeIdx);
+                // A line can pass the '{'/'\\' fast check above without containing anything to
+                // strip (e.g. a stray backslash) - every char was copied verbatim then, so
+                // return the input instead of an identical copy.
+                var result = modified ? new string(rented, 0, writeIdx) : input;
 
                 if (removeDrawingTags && result.StartsWith("m ", StringComparison.Ordinal))
                 {
@@ -1357,6 +1396,11 @@ namespace Nikse.SubtitleEdit.Core.Common
         public static readonly string LowercaseLetters = Configuration.Settings.General.UppercaseLetters.ToLowerInvariant() + "αβγδεζηθικλμνξοπρσςτυφχψωήάόέ";
         public static readonly string LowercaseLettersWithNumbers = LowercaseLetters + "0123456789";
         public static readonly string AllLetters = UppercaseLetters + LowercaseLetters;
+
+        // QualifiesForMerge runs per adjacent paragraph pair in the merge fixes; concatenating
+        // this ~135-char set (plus a one-char Substring) on every call added two allocations
+        // per pair. Declared after AllLetters - static field initializers run in order.
+        private static readonly string LineContinuationEndChars = AllLetters + "…,-$%";
         public static readonly string AllLettersAndNumbers = UppercaseLetters + LowercaseLettersWithNumbers;
 
         public static SKColor GetColorFromUserName(string userName)
@@ -3295,7 +3339,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
                     var lastChar = s[s.Length - 1];
                     var isLineContinuation = s.EndsWith("...", StringComparison.Ordinal) ||
-                                              (AllLetters + "…,-$%").Contains(s.Substring(s.Length - 1)) ||
+                                              LineContinuationEndChars.IndexOf(lastChar) >= 0 ||
                                               (CalcCjk.IsCjk(lastChar) && !IsCjkSentenceEnding(lastChar));
 
                     if (s.EndsWith('♪') || nextText.StartsWith('♪'))

--- a/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
@@ -143,10 +143,6 @@ $@"
 [Events]
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text";
 
-            const string timeCodeFormat = "{0}:{1:00}:{2:00}.{3:00}"; // h:mm:ss.cc
-            const string paragraphWriteFormat = "Dialogue: {9},{0},{1},{3},{4},{5},{6},{7},{8},{2}";
-            const string commentWriteFormat = "Comment: {9},{0},{1},{3},{4},{5},{6},{7},{8},{2}";
-
             var sb = new StringBuilder();
             var isValidAssHeader = !string.IsNullOrEmpty(subtitle.Header) && subtitle.Header.Contains("[V4+ Styles]");
             var styles = new List<string>();
@@ -208,16 +204,20 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                 styles = GetStylesFromHeader(header);
             }
 
+            // List.Contains is a linear scan and runs up to three times per paragraph below;
+            // styled files routinely carry hundreds of styles, so probe a set instead. The
+            // default string comparer matches List.Contains' ordinal equality and is null-safe
+            // (p.Extra can be null on the second probe).
+            var styleSet = new HashSet<string>(styles);
+            var hasDefaultStyle = styleSet.Contains("Default");
             foreach (var p in subtitle.Paragraphs)
             {
-                var start = MakeTimeCode(timeCodeFormat, p.StartTime);
-                var end = MakeTimeCode(timeCodeFormat, p.EndTime);
                 var style = "Default";
-                if (!string.IsNullOrEmpty(p.Extra) && isValidAssHeader && styles.Contains(p.Extra))
+                if (!string.IsNullOrEmpty(p.Extra) && isValidAssHeader && styleSet.Contains(p.Extra))
                 {
                     style = p.Extra;
                 }
-                else if (styles.Count > 0 && !styles.Contains(style) && styles.Contains(p.Extra))
+                else if (styles.Count > 0 && !hasDefaultStyle && styleSet.Contains(p.Extra))
                 {
                     style = p.Extra;
                 }
@@ -226,7 +226,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                     style = styles[0];
                 }
 
-                if (fromTtml && !string.IsNullOrEmpty(p.Style) && isValidAssHeader && styles.Contains(p.Style))
+                if (fromTtml && !string.IsNullOrEmpty(p.Style) && isValidAssHeader && styleSet.Contains(p.Style))
                 {
                     style = p.Style;
                 }
@@ -262,14 +262,20 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                 }
 
                 var text = p.Text.Replace(Environment.NewLine, "\\N");
-                if (p.IsComment)
-                {
-                    sb.AppendFormat(commentWriteFormat, start, end, FormatText(text), style, actor, marginL, marginR, marginV, effect, p.Layer).AppendLine();
-                }
-                else
-                {
-                    sb.AppendFormat(paragraphWriteFormat, start, end, FormatText(text), style, actor, marginL, marginR, marginV, effect, p.Layer).AppendLine();
-                }
+                // Layout: "(Dialogue|Comment): {layer},{start},{end},{style},{actor},{marginL},{marginR},{marginV},{effect},{text}".
+                // Appending directly skips AppendFormat's per-call format parsing, the object[10]
+                // and the boxed layer, plus the two intermediate time-code strings.
+                sb.Append(p.IsComment ? "Comment: " : "Dialogue: ");
+                sb.Append(p.Layer).Append(',');
+                AppendTimeCode(sb, p.StartTime).Append(',');
+                AppendTimeCode(sb, p.EndTime).Append(',');
+                sb.Append(style).Append(',');
+                sb.Append(actor).Append(',');
+                sb.Append(marginL).Append(',');
+                sb.Append(marginR).Append(',');
+                sb.Append(marginV).Append(',');
+                sb.Append(effect).Append(',');
+                sb.Append(FormatText(text)).AppendLine();
             }
 
             if (!string.IsNullOrEmpty(subtitle.Footer) &&
@@ -279,20 +285,51 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                 sb.AppendLine(subtitle.Footer);
             }
 
-            return sb.ToString().Trim() + Environment.NewLine;
+            // Trim inside the builder instead of "sb.ToString().Trim() + newline", which
+            // allocated the whole multi-megabyte output twice more.
+            TrimBuilder(sb);
+            return sb.Append(Environment.NewLine).ToString();
         }
 
-        private static string MakeTimeCode(string timeCodeFormat, TimeCode timeCode)
+        // Writes "h:mm:ss.cc". Replaces string.Format over a TimeCode whose Hours/Minutes/
+        // Seconds getters each re-ran the TimeSpan conversion (~7 conversions and 4 boxes per
+        // call, twice per paragraph on save).
+        private static StringBuilder AppendTimeCode(StringBuilder sb, TimeCode timeCode)
         {
-            var tc = new TimeCode(timeCode.Hours, timeCode.Minutes, timeCode.Seconds, timeCode.Milliseconds);
-            var fragment = (int)Math.Round(timeCode.Milliseconds / 10.0, MidpointRounding.AwayFromZero);
+            var ts = timeCode.TimeSpan;
+            var fragment = (int)Math.Round(ts.Milliseconds / 10.0, MidpointRounding.AwayFromZero);
             if (fragment >= 100)
             {
-                tc = new TimeCode(tc.Hours, tc.Minutes, tc.Seconds + 1, 0);
+                ts = new TimeSpan(ts.Days, ts.Hours, ts.Minutes, ts.Seconds, 0).Add(TimeSpan.FromSeconds(1));
                 fragment = 0;
             }
 
-            return string.Format(timeCodeFormat, tc.Hours, tc.Minutes, tc.Seconds, fragment);
+            AppendNumber(sb, ts.Days * 24 + ts.Hours, 1);
+            sb.Append(':');
+            AppendNumber(sb, ts.Minutes, 2);
+            sb.Append(':');
+            AppendNumber(sb, ts.Seconds, 2);
+            sb.Append('.');
+            AppendNumber(sb, fragment, 2);
+            return sb;
+        }
+
+        // Matches "{0:00}"-style formatting: sign first, then the absolute value padded with
+        // leading zeros to minDigits.
+        private static void AppendNumber(StringBuilder sb, int value, int minDigits)
+        {
+            if (value < 0)
+            {
+                sb.Append('-');
+                value = -value;
+            }
+
+            if (minDigits >= 2 && value < 10)
+            {
+                sb.Append('0');
+            }
+
+            sb.Append(value);
         }
 
         public static string GetHeaderAndStylesFromSubStationAlpha(string header)
@@ -1098,16 +1135,19 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
             return text;
         }
 
+        private static readonly char[] QuoteChars = { '"', '\'' };
+        private static readonly char[] SpaceOrGreaterThan = { ' ', '>' };
+
         private static string FormatTag(ref string text, int start, string fontTag, string tag, string ssaTagName, string endSsaTag)
         {
             if (fontTag.Contains(tag))
             {
                 var fontStart = fontTag.IndexOf(tag, StringComparison.Ordinal);
 
-                var fontEnd = fontTag.IndexOfAny(new[] { '"', '\'' }, fontStart + tag.Length);
+                var fontEnd = fontTag.IndexOfAny(QuoteChars, fontStart + tag.Length);
                 if (fontEnd < 0)
                 {
-                    fontEnd = fontTag.IndexOfAny(new[] { ' ', '>' }, fontStart + tag.Length);
+                    fontEnd = fontTag.IndexOfAny(SpaceOrGreaterThan, fontStart + tag.Length);
                 }
 
                 if (fontEnd > 0)

--- a/src/libse/SubtitleFormats/SubRip.cs
+++ b/src/libse/SubtitleFormats/SubRip.cs
@@ -61,14 +61,19 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override string ToText(Subtitle subtitle, string title)
         {
-            const string paragraphWriteFormat = "{0}{4}{1} --> {2}{4}{3}{4}{4}";
-
+            // Append the parts directly: AppendFormat re-parsed the composite format and boxed
+            // p.Number per paragraph, and "sb.ToString().Trim() + ..." allocated the whole
+            // multi-megabyte output twice more.
             var sb = new StringBuilder();
             foreach (var p in subtitle.Paragraphs)
             {
-                sb.AppendFormat(paragraphWriteFormat, p.Number, p.StartTime, p.EndTime, p.Text, Environment.NewLine);
+                sb.Append(p.Number).Append(Environment.NewLine);
+                sb.Append(p.StartTime.ToString()).Append(" --> ").Append(p.EndTime.ToString()).Append(Environment.NewLine);
+                sb.Append(p.Text).Append(Environment.NewLine).Append(Environment.NewLine);
             }
-            return sb.ToString().Trim() + Environment.NewLine + Environment.NewLine;
+
+            TrimBuilder(sb);
+            return sb.Append(Environment.NewLine).Append(Environment.NewLine).ToString();
         }
 
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)

--- a/src/libse/SubtitleFormats/SubtitleFormat.cs
+++ b/src/libse/SubtitleFormats/SubtitleFormat.cs
@@ -550,6 +550,29 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public bool BatchMode { get; set; }
         public double? BatchSourceFrameRate { get; set; }
 
+        /// <summary>
+        /// Trims leading/trailing whitespace inside the builder - the "sb.ToString().Trim()"
+        /// idiom in ToText implementations allocates the whole output an extra time.
+        /// </summary>
+        protected static void TrimBuilder(StringBuilder sb)
+        {
+            while (sb.Length > 0 && char.IsWhiteSpace(sb[sb.Length - 1]))
+            {
+                sb.Length--;
+            }
+
+            var start = 0;
+            while (start < sb.Length && char.IsWhiteSpace(sb[start]))
+            {
+                start++;
+            }
+
+            if (start > 0)
+            {
+                sb.Remove(0, start);
+            }
+        }
+
         public static string ToUtf8XmlString(XmlDocument xml, bool omitXmlDeclaration = false)
         {
             var settings = new XmlWriterSettings

--- a/src/libuilogic/Export/CustomTextFormatter.cs
+++ b/src/libuilogic/Export/CustomTextFormatter.cs
@@ -6,10 +6,20 @@ using System.Text.RegularExpressions;
 
 namespace Nikse.SubtitleEdit.UiLogic.Export;
 
-public static class CustomTextFormatter
+public static partial class CustomTextFormatter
 {
     public const string EnglishDoNotModify = "[Do not modify]";
     private static readonly Regex CurlyCodePattern = new Regex("{\\d+[,:]*[A-Z\\d-]*}", RegexOptions.Compiled);
+
+    // GetTimeCode runs three times per paragraph; the static Regex.IsMatch/Replace overloads
+    // it used went through the global regex cache (a lock + key hash) on every call.
+    [GeneratedRegex("z+")]
+    private static partial Regex ZRunRegexGen();
+    private static readonly Regex ZRunRegex = ZRunRegexGen();
+
+    [GeneratedRegex("s+")]
+    private static partial Regex SRunRegexGen();
+    private static readonly Regex SRunRegex = SRunRegexGen();
 
     public static string GenerateCustomText(CustomFormatTemplate customFormat, List<Paragraph> subtitles, string title, string videoFileName)
     {
@@ -141,9 +151,15 @@ public static class CustomTextFormatter
 
     private static string ReplaceMilliseconds(string template, TimeCode timeCode)
     {
-        var isPureZMode = Regex.IsMatch(template, @"^z+$");
+        if (template.IndexOf('z') < 0)
+        {
+            return template;
+        }
 
-        return Regex.Replace(template, @"z+", match =>
+        // "^z+$" for a non-empty template == "no non-'z' character present".
+        var isPureZMode = template.AsSpan().IndexOfAnyExcept('z') < 0;
+
+        return ZRunRegex.Replace(template, match =>
         {
             var zCount = match.Value.Length;
 
@@ -207,9 +223,14 @@ public static class CustomTextFormatter
 
     private static string ReplaceSeconds(string template, TimeCode timeCode)
     {
-        var isPureSMode = Regex.IsMatch(template, @"^s+$");
+        if (template.IndexOf('s') < 0)
+        {
+            return template;
+        }
 
-        return Regex.Replace(template, @"s+", match =>
+        var isPureSMode = template.AsSpan().IndexOfAnyExcept('s') < 0;
+
+        return SRunRegex.Replace(template, match =>
         {
             var length = match.Value.Length;
 
@@ -228,14 +249,32 @@ public static class CustomTextFormatter
 
     private static string ReplaceStandardComponents(string template, TimeCode timeCode)
     {
-        // Process longer patterns first to avoid partial matches
-        return template
-            .Replace("hh", $"{Math.Abs(timeCode.Hours):00}")
-            .Replace("mm", $"{Math.Abs(timeCode.Minutes):00}")
-            .Replace("ff", $"{SubtitleFormat.MillisecondsToFrames(timeCode.TotalMilliseconds):00}")
-            .Replace("h", $"{Math.Abs(timeCode.Hours)}")
-            .Replace("m", $"{Math.Abs(timeCode.Minutes)}")
-            .Replace("f", $"{SubtitleFormat.MillisecondsToFramesMaxFrameRate(timeCode.Milliseconds):00}");
+        // Process longer patterns first to avoid partial matches. Each component's value is
+        // only formatted when its letter occurs in the template (the replaced digits cannot
+        // introduce new pattern letters, so grouping "hh" with "h" is safe), and every
+        // TimeCode getter re-runs a TimeSpan conversion - so read them at most once.
+        var result = template;
+        if (result.IndexOf('h') >= 0)
+        {
+            var hours = Math.Abs(timeCode.Hours);
+            result = result.Replace("hh", hours.ToString("00"))
+                           .Replace("h", hours.ToString());
+        }
+
+        if (result.IndexOf('m') >= 0)
+        {
+            var minutes = Math.Abs(timeCode.Minutes);
+            result = result.Replace("mm", minutes.ToString("00"))
+                           .Replace("m", minutes.ToString());
+        }
+
+        if (result.IndexOf('f') >= 0)
+        {
+            result = result.Replace("ff", SubtitleFormat.MillisecondsToFrames(timeCode.TotalMilliseconds).ToString("00"))
+                           .Replace("f", SubtitleFormat.MillisecondsToFramesMaxFrameRate(timeCode.Milliseconds).ToString("00"));
+        }
+
+        return result;
     }
 
     internal static string GetParagraph(string template, string start, string end, string text, string originalText, int number, string actor, TimeCode duration, string gap, string timeCodeTemplate, Paragraph p, string videoFileName)

--- a/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
@@ -297,7 +297,11 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
                 isWordCorrect = true;
             }
 
-            var lineText = splitLine.GetText();
+            // Only build the line text when it can still be read: every use below is guarded by
+            // !isWordCorrect, and isWordCorrect never flips back to false. GetText walks all
+            // words of the line, so skipping it for already-correct words (the common case)
+            // saves a StringBuilder + string per word.
+            var lineText = isWordCorrect ? string.Empty : splitLine.GetText();
             if (!isWordCorrect && _spellCheckWordLists.HasNameExtended(result, lineText))
             {
                 isWordCorrect = true;

--- a/src/libuilogic/Ocr/FixEngine/OcrFixReplaceList2.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixReplaceList2.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Buffers;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 using Nikse.SubtitleEdit.Core.Common;
@@ -304,13 +305,11 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
 
         public string FixOcrErrorViaLineReplaceList(string input, Subtitle subtitle, int index, ISpellChecker spellCheckManager, List<string> wordsToIgnore, bool spelledOK)
         {
-            // Whole fromLine
-            foreach (var from in _wholeLineReplaceList.Keys)
+            // Whole fromLine - the dictionary's default comparer is the same ordinal equality
+            // the old linear key scan used.
+            if (_wholeLineReplaceList.TryGetValue(input, out var wholeLineTo))
             {
-                if (input == from)
-                {
-                    return _wholeLineReplaceList[from];
-                }
+                return wholeLineTo;
             }
 
             var newText = input;
@@ -337,11 +336,12 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
             foreach (var l in lines)
             {
                 var s = l;
-                foreach (string from in _beginLineReplaceList.Keys)
+                foreach (var kv in _beginLineReplaceList)
                 {
+                    var from = kv.Key;
                     if (s.FastIndexOf(from) >= 0)
                     {
-                        var with = _beginLineReplaceList[from];
+                        var with = kv.Value;
                         if (s.StartsWith(from, StringComparison.Ordinal))
                         {
                             s = s.Remove(0, from.Length).Insert(0, with);
@@ -366,12 +366,13 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
                 post = "</i>";
             }
 
-            foreach (var from in _endLineReplaceList.Keys)
+            foreach (var kv in _endLineReplaceList)
             {
+                var from = kv.Key;
                 if (newText.EndsWith(from, StringComparison.Ordinal))
                 {
                     var position = (newText.Length - from.Length);
-                    var toText = _endLineReplaceList[from];
+                    var toText = kv.Value;
 
                     if (!SkipAddLineEnding(subtitle, from, toText, index))
                     {
@@ -381,39 +382,39 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
             }
             newText += post;
 
-            foreach (var from in PartialLineWordBoundaryReplaceList.Keys)
+            foreach (var kv in PartialLineWordBoundaryReplaceList)
             {
-                if (newText.FastIndexOf(from) >= 0)
+                if (newText.FastIndexOf(kv.Key) >= 0)
                 {
-                    newText = ReplaceWord(newText, from, PartialLineWordBoundaryReplaceList[from]);
+                    newText = ReplaceWord(newText, kv.Key, kv.Value);
                 }
             }
 
-            foreach (var from in _partialLineAlwaysReplaceList.Keys)
+            foreach (var kv in _partialLineAlwaysReplaceList)
             {
-                if (newText.FastIndexOf(from) >= 0)
+                if (newText.FastIndexOf(kv.Key) >= 0)
                 {
-                    newText = newText.Replace(from, _partialLineAlwaysReplaceList[from]);
+                    newText = newText.Replace(kv.Key, kv.Value);
                 }
             }
 
             if (_replaceRegExes == null || _regExList.Count != _replaceRegExes.Count)
             {
-                _replaceRegExes = new List<Regex>();
-                foreach (var findWhat in _regExList.Keys)
+                _replaceRegExes = new List<Regex>(_regExList.Count);
+                foreach (var kv in _regExList)
                 {
-                    var regex = new Regex(findWhat, RegexOptions.Multiline | RegexOptions.Compiled);
+                    var regex = new Regex(kv.Key, RegexOptions.Multiline | RegexOptions.Compiled);
                     _replaceRegExes.Add(regex);
-                    newText = regex.Replace(newText, _regExList[findWhat]);
+                    newText = regex.Replace(newText, kv.Value);
                 }
             }
             else
             {
                 var i = 0;
-                foreach (var findWhat in _regExList.Keys)
+                foreach (var kv in _regExList)
                 {
                     var regex = _replaceRegExes[i];
-                    newText = regex.Replace(newText, _regExList[findWhat]);
+                    newText = regex.Replace(newText, kv.Value);
                     i++;
                 }
             }
@@ -488,22 +489,24 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
         {
             var list = new List<string>();
             var previousGuesses = new List<string>();
-            foreach (var letter in _partialWordReplaceList.Keys)
+            foreach (var kv in _partialWordReplaceList)
             {
+                var letter = kv.Key;
+                var replacement = kv.Value;
                 var indexes = new List<int>();
                 for (var i = 0; i <= word.Length - letter.Length; i++)
                 {
                     if (word.AsSpan(i).StartsWith(letter, StringComparison.Ordinal))
                     {
-                        if (i == word.Length - letter.Length && !_partialWordReplaceList[letter].Contains(' '))
+                        if (i == word.Length - letter.Length && !replacement.Contains(' '))
                         {
-                            var guess = word.Remove(i, letter.Length).Insert(i, _partialWordReplaceList[letter]);
+                            var guess = word.Remove(i, letter.Length).Insert(i, replacement);
                             AddToGuessList(list, guess);
                         }
                         else
                         {
                             indexes.Add(i);
-                            var guess = word.Remove(i, letter.Length).Insert(i, _partialWordReplaceList[letter]);
+                            var guess = word.Remove(i, letter.Length).Insert(i, replacement);
                             AddToGuessList(list, guess);
                         }
                     }
@@ -511,22 +514,22 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
 
                 if (indexes.Count > 1)
                 {
-                    if (!_partialWordReplaceList[letter].Contains(' '))
+                    if (!replacement.Contains(' '))
                     {
                         var multiGuess = word;
                         for (var i = indexes.Count - 1; i >= 0; i--)
                         {
                             var idx = indexes[i];
-                            multiGuess = multiGuess.Remove(idx, letter.Length).Insert(idx, _partialWordReplaceList[letter]);
+                            multiGuess = multiGuess.Remove(idx, letter.Length).Insert(idx, replacement);
                             AddToGuessList(list, multiGuess);
                         }
 
-                        AddToGuessList(list, word.Replace(letter, _partialWordReplaceList[letter]));
+                        AddToGuessList(list, word.Replace(letter, replacement));
                     }
                 }
                 else if (indexes.Count > 0)
                 {
-                    AddToGuessList(list, word.Replace(letter, _partialWordReplaceList[letter]));
+                    AddToGuessList(list, word.Replace(letter, replacement));
                 }
 
                 if (indexes.Count > 0)
@@ -536,7 +539,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
                         var idx = indexes[i];
                         if (idx > 1 && idx < word.Length - 2)
                         {
-                            var guess = word.Remove(idx, letter.Length).Insert(idx, _partialWordReplaceList[letter]);
+                            var guess = word.Remove(idx, letter.Length).Insert(idx, replacement);
                             AddToGuessList(list, guess);
                         }
                     }
@@ -546,9 +549,9 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
                 {
                     for (var i = 0; i < previousGuess.Length - letter.Length; i++)
                     {
-                        if (previousGuess.Substring(i).StartsWith(letter, StringComparison.Ordinal))
+                        if (previousGuess.AsSpan(i).StartsWith(letter, StringComparison.Ordinal))
                         {
-                            var guess = previousGuess.Remove(i, letter.Length).Insert(i, _partialWordReplaceList[letter]);
+                            var guess = previousGuess.Remove(i, letter.Length).Insert(i, replacement);
                             AddToGuessList(list, guess);
                         }
                     }
@@ -609,9 +612,9 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
             }
 
             //always replace list
-            foreach (var letter in _partialWordAlwaysReplaceList.Keys)
+            foreach (var kv in _partialWordAlwaysReplaceList)
             {
-                word = word.Replace(letter, _partialWordAlwaysReplaceList[letter]);
+                word = word.Replace(kv.Key, kv.Value);
             }
 
             var pre = string.Empty;
@@ -1130,6 +1133,8 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
             return true;
         }
 
+        private static readonly SearchValues<char> WordSeparatorChars = SearchValues.Create(@" ¡¿<>-""”“()[]'‘`´¶♪¿¡.…—!?,:;/");
+
         public static string ReplaceWord(string text, string word, string newWord)
         {
             if (string.IsNullOrEmpty(text) || string.IsNullOrEmpty(word))
@@ -1140,17 +1145,18 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
             var sb = new StringBuilder(text.Length);
             if (text.Contains(word))
             {
-                const string separatorChars = @" ¡¿<>-""”“()[]'‘`´¶♪¿¡.…—!?,:;/";
                 var appendFrom = 0;
                 for (var i = 0; i < text.Length; i++)
                 {
-                    if (text[i] == word[0] && i >= appendFrom && text.Substring(i).StartsWith(word, StringComparison.Ordinal))
+                    // AsSpan instead of Substring - the old code copied the whole tail of the
+                    // line for every position where the first character matched.
+                    if (text[i] == word[0] && i >= appendFrom && text.AsSpan(i).StartsWith(word, StringComparison.Ordinal))
                     {
                         var startOk = i == 0;
                         if (!startOk)
                         {
                             var prevChar = text[i - 1];
-                            startOk = char.IsPunctuation(prevChar) || char.IsWhiteSpace(prevChar) || separatorChars.Contains(prevChar);
+                            startOk = char.IsPunctuation(prevChar) || char.IsWhiteSpace(prevChar) || WordSeparatorChars.Contains(prevChar);
                         }
                         if (!startOk && word.StartsWith(' '))
                         {
@@ -1162,7 +1168,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
                             if (!endOk)
                             {
                                 var nextChar = text[i + word.Length];
-                                endOk = char.IsPunctuation(nextChar) || char.IsWhiteSpace(nextChar) || separatorChars.Contains(nextChar);
+                                endOk = char.IsPunctuation(nextChar) || char.IsWhiteSpace(nextChar) || WordSeparatorChars.Contains(nextChar);
                             }
                             if (!endOk)
                             {

--- a/src/libuilogic/Ocr/ItalicTextMerger.cs
+++ b/src/libuilogic/Ocr/ItalicTextMerger.cs
@@ -45,17 +45,20 @@ public class ItalicTextMerger
         var words = GroupIntoWords(chars);
         var segments = new List<TextSegment>();
 
-        foreach (var word in words)
+        // Indexed loop: the loop body used to call words.IndexOf(word) - a linear scan inside
+        // the loop already iterating words, i.e. O(n^2) per OCR'd line.
+        for (var wordIndex = 0; wordIndex < words.Count; wordIndex++)
         {
+            var word = words[wordIndex];
             bool shouldBeItalic = word.IsWhitespace ? false : GetMajorityItalic(word.Chars);
-            string text = string.Concat(word.Chars.Select(c => c.Text));
+            string text = ConcatCharTexts(word.Chars);
 
             // If this is whitespace, check if we can merge it with surrounding italic content
             if (word.IsWhitespace)
             {
                 // Check if previous and next non-whitespace segments are both italic
                 bool prevIsItalic = GetPreviousNonWhitespaceItalic(segments);
-                bool nextIsItalic = GetNextNonWhitespaceItalic(words, words.IndexOf(word));
+                bool nextIsItalic = GetNextNonWhitespaceItalic(words, wordIndex);
 
                 // If surrounded by italic content, include whitespace in italic
                 shouldBeItalic = prevIsItalic && nextIsItalic;
@@ -155,17 +158,20 @@ public class ItalicTextMerger
         var words = GroupIntoWords(chars);
         var segments = new List<TextSegment>();
 
-        foreach (var word in words)
+        // Indexed loop: the loop body used to call words.IndexOf(word) - a linear scan inside
+        // the loop already iterating words, i.e. O(n^2) per OCR'd line.
+        for (var wordIndex = 0; wordIndex < words.Count; wordIndex++)
         {
+            var word = words[wordIndex];
             bool shouldBeItalic = word.IsWhitespace ? false : GetMajorityItalic(word.Chars);
-            string text = string.Concat(word.Chars.Select(c => c.Text));
+            string text = ConcatCharTexts(word.Chars);
 
             // If this is whitespace, check if we can merge it with surrounding italic content
             if (word.IsWhitespace)
             {
                 // Check if previous and next non-whitespace segments are both italic
                 bool prevIsItalic = GetPreviousNonWhitespaceItalic(segments);
-                bool nextIsItalic = GetNextNonWhitespaceItalic(words, words.IndexOf(word));
+                bool nextIsItalic = GetNextNonWhitespaceItalic(words, wordIndex);
 
                 // If surrounded by italic content, include whitespace in italic
                 shouldBeItalic = prevIsItalic && nextIsItalic;
@@ -248,6 +254,7 @@ public class ItalicTextMerger
 
         var merged = new List<TextSegment>();
         var currentSegment = segments[0];
+        StringBuilder? mergedText = null; // string concat per merged segment was quadratic
 
         for (int i = 1; i < segments.Count; i++)
         {
@@ -256,18 +263,26 @@ public class ItalicTextMerger
             // Merge if both have same italic formatting
             if (currentSegment.ShouldBeItalic == nextSegment.ShouldBeItalic)
             {
-                currentSegment = new TextSegment
-                {
-                    Text = currentSegment.Text + nextSegment.Text,
-                    ShouldBeItalic = currentSegment.ShouldBeItalic,
-                    IsWhitespace = currentSegment.IsWhitespace && nextSegment.IsWhitespace
-                };
+                mergedText ??= new StringBuilder(currentSegment.Text);
+                mergedText.Append(nextSegment.Text);
+                currentSegment.IsWhitespace = currentSegment.IsWhitespace && nextSegment.IsWhitespace;
             }
             else
             {
+                if (mergedText != null)
+                {
+                    currentSegment.Text = mergedText.ToString();
+                    mergedText = null;
+                }
+
                 merged.Add(currentSegment);
                 currentSegment = nextSegment;
             }
+        }
+
+        if (mergedText != null)
+        {
+            currentSegment.Text = mergedText.ToString();
         }
 
         merged.Add(currentSegment);
@@ -281,7 +296,15 @@ public class ItalicTextMerger
             return false;
         }
 
-        int italicCount = wordChars.Count(c => c.Italic);
+        var italicCount = 0;
+        for (var i = 0; i < wordChars.Count; i++)
+        {
+            if (wordChars[i].Italic)
+            {
+                italicCount++;
+            }
+        }
+
         int nonItalicCount = wordChars.Count - italicCount;
 
         return italicCount >= nonItalicCount;
@@ -289,7 +312,36 @@ public class ItalicTextMerger
 
     private static bool IsWhitespace(string text)
     {
-        return string.IsNullOrEmpty(text) || text.All(char.IsWhiteSpace);
+        if (string.IsNullOrEmpty(text))
+        {
+            return true;
+        }
+
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (!char.IsWhiteSpace(text[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static string ConcatCharTexts(List<NOcrChar> chars)
+    {
+        if (chars.Count == 1)
+        {
+            return chars[0].Text;
+        }
+
+        var sb = new StringBuilder(chars.Count);
+        for (var i = 0; i < chars.Count; i++)
+        {
+            sb.Append(chars[i].Text);
+        }
+
+        return sb.ToString();
     }
 
     private class WordGroup

--- a/src/libuilogic/SpellCheck/SpellCheckWordLists.cs
+++ b/src/libuilogic/SpellCheck/SpellCheckWordLists.cs
@@ -26,6 +26,12 @@ public class SpellCheckWordLists
     private readonly HashSet<string> _namesListUppercase = new HashSet<string>();
     private readonly HashSet<string> _namesListWithApostrophe = new HashSet<string>();
     private readonly HashSet<string> _wordsWithDashesOrPeriods = new HashSet<string>();
+
+    // Parallel to _wordsWithDashesOrPeriods with the split parts precomputed once.
+    // IsPartOfKnownDashOrPeriodName runs per word during live spell check (and up to four
+    // times per word from the OCR fix engine); splitting every combined name on every call
+    // allocated a string[] plus one string per part, per entry, per word.
+    private readonly List<KeyValuePair<string, string[]>> _wordsWithDashesOrPeriodsParts = new List<KeyValuePair<string, string[]>>();
     private readonly HashSet<string> _userWordList = new HashSet<string>();
     private readonly HashSet<string> _userPhraseList = new HashSet<string>();
     private readonly string _dictionaryFolder;
@@ -110,8 +116,16 @@ public class SpellCheckWordLists
         {
             if (word.Contains(PeriodAndDash))
             {
-                _wordsWithDashesOrPeriods.Add(word);
+                AddWordWithDashesOrPeriods(word);
             }
+        }
+    }
+
+    private void AddWordWithDashesOrPeriods(string word)
+    {
+        if (_wordsWithDashesOrPeriods.Add(word))
+        {
+            _wordsWithDashesOrPeriodsParts.Add(new KeyValuePair<string, string[]>(word, word.Split(PeriodAndDash, StringSplitOptions.RemoveEmptyEntries)));
         }
     }
 
@@ -294,7 +308,7 @@ public class SpellCheckWordLists
             _namesListWithApostrophe.Add(word + "'");
         }
 
-        _wordsWithDashesOrPeriods.Add(word);
+        AddWordWithDashesOrPeriods(word);
 
         var namesList = new NameList(_dictionaryFolder, _languageName, false, string.Empty);
         namesList.Add(word);
@@ -353,10 +367,9 @@ public class SpellCheckWordLists
             return false;
         }
 
-        foreach (var combined in _wordsWithDashesOrPeriods)
+        foreach (var kv in _wordsWithDashesOrPeriodsParts)
         {
-            var parts = combined.Split(PeriodAndDash, StringSplitOptions.RemoveEmptyEntries);
-            if (Array.IndexOf(parts, word) >= 0 && text.Contains(combined, StringComparison.Ordinal))
+            if (Array.IndexOf(kv.Value, word) >= 0 && text.Contains(kv.Key, StringComparison.Ordinal))
             {
                 return true;
             }

--- a/src/libuilogic/SpellCheck/SpellChecker.cs
+++ b/src/libuilogic/SpellCheck/SpellChecker.cs
@@ -416,6 +416,19 @@ public class SpellChecker : ISpellChecker, IDoSpell
 
     protected static bool IsNumber(string word)
     {
+        // Same trick as IsEmailUrlOrHashTag above: this runs once per word during spell check,
+        // and an ordinary word can never match any of the three patterns. Every match must
+        // start with a digit, '-', '.', '%' (PercentageRegex accepts a bare "%"), or a
+        // currency sign; the empty string is only reachable through NumberRegex below.
+        if (word.Length > 0)
+        {
+            var c = word[0];
+            if (!char.IsDigit(c) && c != '-' && c != '.' && c != '%' && c != '$' && c != '£' && c != '€')
+            {
+                return false;
+            }
+        }
+
         return NumberRegex.IsMatch(word) || PercentageRegex.IsMatch(word) || CurrencyRegex.IsMatch(word);
     }
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -464,7 +464,19 @@ public partial class MainViewModel :
     public StackPanel PanelSingleLineLengthsOriginal { get; set; }
     public MenuItem MenuItemStyles { get; set; }
     public MenuItem MenuItemActors { get; set; }
-    public Button ButtonWaveformPlay { get; set; }
+    private Button _buttonWaveformPlay = null!;
+
+    public Button ButtonWaveformPlay
+    {
+        get => _buttonWaveformPlay;
+        set
+        {
+            // Layout (re)initialization swaps in a fresh button; forget the cached icon state
+            // so the next position-timer tick writes an explicit icon to the new control.
+            _buttonWaveformPlay = value;
+            _waveformPlayIconIsPause = null;
+        }
+    }
     public MenuItem AudioTraksMenuItem { get; set; }
     public TextWithSubtitleSyntaxHighlightingConverter SubtitleDataGridSyntaxHighlighting { get; internal set; }
 
@@ -11019,7 +11031,7 @@ public partial class MainViewModel :
             window.AddHandler(InputElement.KeyUpEvent, _shortcutManager.OnKeyReleased, RoutingStrategies.Bubble);
             window.KeyDown += async (_, e) =>
             {
-                var cmd = _shortcutManager.CheckShortcuts(e, ShortcutCategory.General.ToString());
+                var cmd = _shortcutManager.CheckShortcuts(e, CategoryGeneral);
                 if (ReferenceEquals(cmd, ShowReplaceCommand))
                 {
                     e.Handled = true;
@@ -11374,7 +11386,7 @@ public partial class MainViewModel :
             window.AddHandler(InputElement.KeyUpEvent, _shortcutManager.OnKeyReleased, RoutingStrategies.Bubble);
             window.KeyDown += async (_, e) =>
             {
-                var cmd = _shortcutManager.CheckShortcuts(e, ShortcutCategory.General.ToString());
+                var cmd = _shortcutManager.CheckShortcuts(e, CategoryGeneral);
                 if (ReferenceEquals(cmd, ShowReplaceCommand))
                 {
                     e.Handled = true;
@@ -20816,7 +20828,7 @@ public partial class MainViewModel :
             }
 
             _shortcutManager.OnKeyPressed(this, keyEventArgs);
-            if (_shortcutManager.GetActiveKeys().Count == 0)
+            if (_shortcutManager.ActiveKeyCount == 0)
             {
                 return;
             }
@@ -20846,11 +20858,8 @@ public partial class MainViewModel :
                     return;
                 }
 
-                var currentKeys = _shortcutManager.GetActiveKeys();
-                if (currentKeys.Count == 1)
+                if (_shortcutManager.TryGetSingleActiveKey(out var key))
                 {
-                    var key = currentKeys.First();
-
                     if (EditTextBox.IsFocused && key == Key.Return &&
                         keyEventArgs.KeyModifiers == KeyModifiers.None &&
                         Se.Settings.General.SubtitleTextBoxLimitNewLines)
@@ -20966,10 +20975,10 @@ public partial class MainViewModel :
                     return;
                 }
 
-                var relayCommand = _shortcutManager.CheckShortcuts(keyEventArgs, ShortcutCategory.SubtitleGrid.ToString());
+                var relayCommand = _shortcutManager.CheckShortcuts(keyEventArgs, CategorySubtitleGrid);
                 if (relayCommand == null)
                 {
-                    relayCommand = _shortcutManager.CheckShortcuts(keyEventArgs, ShortcutCategory.SubtitleGridAndTextBox.ToString());
+                    relayCommand = _shortcutManager.CheckShortcuts(keyEventArgs, CategorySubtitleGridAndTextBox);
                 }
 
                 if (relayCommand != null)
@@ -20982,7 +20991,7 @@ public partial class MainViewModel :
 
             if (AudioVisualizer != null && AudioVisualizer.IsFocused)
             {
-                var relayCommand = _shortcutManager.CheckShortcuts(keyEventArgs, ShortcutCategory.Waveform.ToString());
+                var relayCommand = _shortcutManager.CheckShortcuts(keyEventArgs, CategoryWaveform);
                 if (relayCommand != null)
                 {
                     keyEventArgs.Handled = true;
@@ -21000,7 +21009,7 @@ public partial class MainViewModel :
                 // dispatched here - they were previously registered but never run (#11906). The native
                 // clipboard commands (Cut/Copy/Paste/Select all) are skipped so Avalonia's built-in
                 // handling keeps working on whichever text box is focused.
-                var textBoxCommand = _shortcutManager.CheckShortcuts(keyEventArgs, ShortcutCategory.TextBox.ToString());
+                var textBoxCommand = _shortcutManager.CheckShortcuts(keyEventArgs, CategoryTextBox);
                 if (textBoxCommand != null && !IsNativeTextBoxClipboardCommand(textBoxCommand))
                 {
                     keyEventArgs.Handled = true;
@@ -21008,7 +21017,7 @@ public partial class MainViewModel :
                     return;
                 }
 
-                var relayCommand = _shortcutManager.CheckShortcuts(keyEventArgs, ShortcutCategory.SubtitleGridAndTextBox.ToString());
+                var relayCommand = _shortcutManager.CheckShortcuts(keyEventArgs, CategorySubtitleGridAndTextBox);
                 if (relayCommand != null)
                 {
                     keyEventArgs.Handled = true;
@@ -21017,10 +21026,7 @@ public partial class MainViewModel :
                 }
             }
 
-            var keys = _shortcutManager.GetActiveKeys().Select(p => p.ToString()).ToList();
-            var hashCode = ShortCut.CalculateHash(keys, ShortcutCategory.General.ToString());
-
-            var rc = _shortcutManager.CheckShortcuts(keyEventArgs, ShortcutCategory.General.ToString().ToLowerInvariant());
+            var rc = _shortcutManager.CheckShortcuts(keyEventArgs, CategoryGeneralLower);
             if (rc != null)
             {
                 keyEventArgs.Handled = true;
@@ -21667,7 +21673,15 @@ public partial class MainViewModel :
             return;
         }
 
-        _selectedSubtitles = selectedItems.Cast<SubtitleLineViewModel>().ToList();
+        // Typed copy with capacity - Cast<T>().ToList() allocates a cast iterator and grows
+        // the list from default capacity, on every selection change (so on every arrow key).
+        var selectedSubtitles = new List<SubtitleLineViewModel>(selectedItems.Count);
+        for (var selIdx = 0; selIdx < selectedItems.Count; selIdx++)
+        {
+            selectedSubtitles.Add((SubtitleLineViewModel)selectedItems[selIdx]!);
+        }
+
+        _selectedSubtitles = selectedSubtitles;
         if (selectedItems.Count > 1)
         {
             StatusTextRight = string.Format(Se.Language.Main.XLinesSelectedOfY, selectedItems.Count, Subtitles.Count);
@@ -21732,8 +21746,25 @@ public partial class MainViewModel :
         EditTextTotalLengthBackground = totalBg;
     }
 
+    // Repopulate the original-text info panel when the column is turned (back) on - the
+    // guard below skips the work while it is hidden, so its values can be stale here.
+    partial void OnShowColumnOriginalTextChanged(bool value)
+    {
+        if (value && SelectedSubtitle != null)
+        {
+            MakeSubtitleTextInfoOriginal(SelectedSubtitle.OriginalText, SelectedSubtitle);
+        }
+    }
+
     private void MakeSubtitleTextInfoOriginal(string text, SubtitleLineViewModel item)
     {
+        // The original column is hidden most of the time, but this ran (StripHtml, character
+        // count, SplitToLines, two string.Formats) on every selection change regardless.
+        if (!ShowColumnOriginalText)
+        {
+            return;
+        }
+
         text ??= string.Empty;
 
         text = SubtitleTextInfoHelper.StripHtml(text);
@@ -22164,7 +22195,13 @@ public partial class MainViewModel :
 
                 if (isPlaying)
                 {
-                    Optris.Icons.Avalonia.Attached.SetIcon(ButtonWaveformPlay, IconNames.Pause);
+                    // Only write the attached property when the icon actually flips - this
+                    // branch runs on every 50 ms position-timer tick.
+                    if (_waveformPlayIconIsPause != true)
+                    {
+                        _waveformPlayIconIsPause = true;
+                        Optris.Icons.Avalonia.Attached.SetIcon(ButtonWaveformPlay, IconNames.Pause);
+                    }
 
                     if (_playSelectionItem != null && mediaPlayerSeconds >= _playSelectionItem.EndSeconds)
                     {
@@ -22194,7 +22231,12 @@ public partial class MainViewModel :
                 }
                 else
                 {
-                    Optris.Icons.Avalonia.Attached.SetIcon(ButtonWaveformPlay, IconNames.Play);
+                    if (_waveformPlayIconIsPause != false)
+                    {
+                        _waveformPlayIconIsPause = false;
+                        Optris.Icons.Avalonia.Attached.SetIcon(ButtonWaveformPlay, IconNames.Play);
+                    }
+
                     ResetPlaySelection();
 
                     // "Center also while paused" scrub-editing (SE 4's locked mode): while the user
@@ -22460,11 +22502,29 @@ public partial class MainViewModel :
             text = "*" + text;
         }
 
-        if (Window != null)
+        // This runs on the 400 ms slow timer; skip the Avalonia property set (and its change
+        // machinery) when the title hasn't actually changed - which is almost every tick.
+        if (Window != null && !string.Equals(text, _lastWindowTitle, StringComparison.Ordinal))
         {
+            _lastWindowTitle = text;
             Window.Title = text;
         }
     }
+
+    // Category name strings for CheckShortcuts - Enum.ToString() allocates on every call,
+    // and the window key handler probes several categories per keystroke.
+    private static readonly string CategoryGeneral = ShortcutCategory.General.ToString();
+    private static readonly string CategoryGeneralLower = ShortcutCategory.General.ToString().ToLowerInvariant();
+    private static readonly string CategorySubtitleGrid = ShortcutCategory.SubtitleGrid.ToString();
+    private static readonly string CategorySubtitleGridAndTextBox = ShortcutCategory.SubtitleGridAndTextBox.ToString();
+    private static readonly string CategoryWaveform = ShortcutCategory.Waveform.ToString();
+    private static readonly string CategoryTextBox = ShortcutCategory.TextBox.ToString();
+
+    private string? _lastWindowTitle;
+
+    // Last state written to the waveform play/pause button icon; null until first write so
+    // the first position-timer tick always sets an explicit icon.
+    private bool? _waveformPlayIconIsPause;
 
     private void UpdateGaps()
     {

--- a/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
+++ b/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
@@ -845,8 +845,6 @@ public partial class CutVideoViewModel : ObservableObject
                 }
             }
 
-            var keys = _shortcutManager.GetActiveKeys().Select(p => p.ToString()).ToList();
-            var hashCode = ShortCut.CalculateHash(keys, ShortcutCategory.General.ToString());
             var rc = _shortcutManager.CheckShortcuts(keyEventArgs, ShortcutCategory.General.ToString().ToLowerInvariant());
             if (rc != null)
             {

--- a/src/ui/Logic/IShortcutManager.cs
+++ b/src/ui/Logic/IShortcutManager.cs
@@ -14,6 +14,8 @@ public interface IShortcutManager
     IRelayCommand? CheckShortcuts(KeyEventArgs keyEventArgs, string activeControl);
     void ClearShortcuts();
     HashSet<Key> GetActiveKeys();
+    int ActiveKeyCount { get; }
+    bool TryGetSingleActiveKey(out Key key);
     bool IsControlPressed();
     bool IsShiftPressed();
 }

--- a/src/ui/Logic/ShortcutManager.cs
+++ b/src/ui/Logic/ShortcutManager.cs
@@ -151,12 +151,13 @@ public class ShortcutManager : IShortcutManager
         // collides with Shift+,. The non-ASCII '<' next to Z is mis-reported
         // as OemComma for the same reason. Fall back to the layout-independent
         // PhysicalKey so each physical key gets a unique, stable token.
-        if (key.ToString().StartsWith("Oem", StringComparison.Ordinal))
+        var plainKeyName = key.ToString();
+        if (plainKeyName.StartsWith("Oem", StringComparison.Ordinal))
         {
             return physicalKey.ToString();
         }
 
-        return key.ToString();
+        return plainKeyName;
     }
 
     // Maps tokens that were stored before the PhysicalKey fix onto the modern
@@ -422,11 +423,29 @@ public class ShortcutManager : IShortcutManager
             return shortcut.Action;
         }
 
-        // 2. Check normalized hash with activeControl
-        var normalizedHash = CalculateNormalizedHash(currentInputKeys, activeControl);
-        if (normalizedHash != inputHash && _lookupTable!.TryGetValue(normalizedHash, out shortcut))
+        // 2. Check normalized hash with activeControl. In practice no token normalizes on a
+        // real keypress (_activeKeyNames excludes the modifier keys themselves and the
+        // modifiers appended above are already canonical), so only build the second list and
+        // hash when normalization actually changes something. NormalizeKeyToken returns the
+        // input instance for unmatched tokens, so a reference check suffices.
+        List<string>? normalizedKeys = null;
+        for (var keyIndex = 0; keyIndex < currentInputKeys.Count; keyIndex++)
         {
-            return shortcut.Action;
+            var normalized = NormalizeKeyToken(currentInputKeys[keyIndex]);
+            if (!ReferenceEquals(normalized, currentInputKeys[keyIndex]))
+            {
+                normalizedKeys ??= new List<string>(currentInputKeys);
+                normalizedKeys[keyIndex] = normalized;
+            }
+        }
+
+        if (normalizedKeys != null)
+        {
+            var normalizedHash = ShortCut.CalculateHash(normalizedKeys, activeControl);
+            if (normalizedHash != inputHash && _lookupTable!.TryGetValue(normalizedHash, out shortcut))
+            {
+                return shortcut.Action;
+            }
         }
 
         return null;
@@ -461,6 +480,27 @@ public class ShortcutManager : IShortcutManager
     }
 
     public HashSet<Key> GetActiveKeys() => [.. _activeKeys];
+
+    /// <summary>
+    /// Allocation-free alternatives to <see cref="GetActiveKeys"/> for the per-keystroke
+    /// probes in the window key handler, which only need the count or the single active key.
+    /// </summary>
+    public int ActiveKeyCount => _activeKeys.Count;
+
+    public bool TryGetSingleActiveKey(out Key key)
+    {
+        if (_activeKeys.Count == 1)
+        {
+            foreach (var k in _activeKeys)
+            {
+                key = k;
+                return true;
+            }
+        }
+
+        key = default;
+        return false;
+    }
 
     public bool IsControlPressed() => _isControlPressed;
     public bool IsShiftPressed() => _isShiftPressed;

--- a/tests/benchmarks/ContinuationUtilitiesBenchmarks.cs
+++ b/tests/benchmarks/ContinuationUtilitiesBenchmarks.cs
@@ -1,0 +1,18 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// ContinuationUtilities.SanitizeString runs several times per paragraph pair in the
+/// continuation-style and unnecessary-leading-dots fixes.
+/// </summary>
+[MemoryDiagnoser]
+public class ContinuationUtilitiesBenchmarks
+{
+    private const string Plain = "It was the best of times, it was the worst of times";
+    private const string Tagged = "<i>It was the best of times,</i>" + "\r\n" + "(sighs) it was the worst of times [groans]";
+
+    [Benchmark] public string SanitizeString_Plain() => ContinuationUtilities.SanitizeString(Plain);
+    [Benchmark] public string SanitizeString_Tagged() => ContinuationUtilities.SanitizeString(Tagged);
+}

--- a/tests/benchmarks/HtmlUtilAssaTagBenchmarks.cs
+++ b/tests/benchmarks/HtmlUtilAssaTagBenchmarks.cs
@@ -1,0 +1,21 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// Per-line ASSA tag strippers used by batch convert and image export. The "Plain" cases are
+/// the common path: ordinary subtitle text that cannot contain the tags at all.
+/// </summary>
+[MemoryDiagnoser]
+public class HtmlUtilAssaTagBenchmarks
+{
+    private const string Plain = "It was the best of times, it was the worst of times.";
+    private const string Aligned = "{\\an8}It was the best of times, it was the worst of times.";
+    private const string Colored = "{\\c&HFF0000&}It was the best of times,{\\c} it was the worst of times.";
+
+    [Benchmark] public string RemoveAssAlignmentTags_Plain() => HtmlUtil.RemoveAssAlignmentTags(Plain);
+    [Benchmark] public string RemoveAssAlignmentTags_Aligned() => HtmlUtil.RemoveAssAlignmentTags(Aligned);
+    [Benchmark] public string RemoveAssaColor_Plain() => HtmlUtil.RemoveAssaColor(Plain);
+    [Benchmark] public string RemoveAssaColor_Colored() => HtmlUtil.RemoveAssaColor(Colored);
+}

--- a/tests/benchmarks/ToTextBenchmarks.cs
+++ b/tests/benchmarks/ToTextBenchmarks.cs
@@ -1,0 +1,76 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// Saving: SubtitleFormat.ToText for the two most-used formats. ASSA gets a styled header
+/// (styles.Contains per paragraph) and SubRip the plain number/timecode/text path.
+/// </summary>
+[MemoryDiagnoser]
+public class ToTextBenchmarks
+{
+    private Subtitle _srtSubtitle = new();
+    private Subtitle _assaSubtitle = new();
+    private readonly SubRip _subRip = new();
+    private readonly AdvancedSubStationAlpha _assa = new();
+
+    [Params(1000, 10000)]
+    public int Paragraphs { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var texts = new[]
+        {
+            "It was the best of times, it was the worst of times.",
+            "<i>Are you coming with us?</i>",
+            "- No." + Environment.NewLine + "- Then stay here and wait.",
+            "1999 was a very long time ago.",
+            "Hello.",
+        };
+
+        _srtSubtitle = new Subtitle();
+        _assaSubtitle = new Subtitle();
+        var startMs = 1000.0;
+        for (var i = 0; i < Paragraphs; i++)
+        {
+            var p = new Paragraph(texts[i % texts.Length], startMs, startMs + 2000);
+            _srtSubtitle.Paragraphs.Add(p);
+
+            var assaParagraph = new Paragraph(texts[i % texts.Length], startMs, startMs + 2000)
+            {
+                Extra = "S" + (i % 100),
+            };
+            _assaSubtitle.Paragraphs.Add(assaParagraph);
+            startMs += 2100;
+        }
+
+        // A header in the shape anime/karaoke files have: many styles.
+        var header = new StringBuilder();
+        header.AppendLine("[Script Info]");
+        header.AppendLine("Title: Bench");
+        header.AppendLine("ScriptType: v4.00+");
+        header.AppendLine();
+        header.AppendLine("[V4+ Styles]");
+        header.AppendLine(SsaStyle.DefaultAssStyleFormat);
+        header.AppendLine("Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1");
+        for (var i = 0; i < 100; i++)
+        {
+            header.AppendLine($"Style: S{i},Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1");
+        }
+
+        header.AppendLine();
+        header.AppendLine("[Events]");
+        header.AppendLine("Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text");
+        _assaSubtitle.Header = header.ToString();
+    }
+
+    [Benchmark]
+    public string SubRipToText() => _subRip.ToText(_srtSubtitle, "title");
+
+    [Benchmark]
+    public string AssaToText() => _assa.ToText(_assaSubtitle, "title");
+}

--- a/tests/benchmarks/UiLogicHotPathBenchmarks.cs
+++ b/tests/benchmarks/UiLogicHotPathBenchmarks.cs
@@ -1,0 +1,102 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.UiLogic.Export;
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// OcrFixReplaceList2.ReplaceWord runs once per matching replace-list entry per OCR'd line.
+/// </summary>
+[MemoryDiagnoser]
+public class OcrReplaceWordBenchmarks
+{
+    private const string Line = "l am not sure what you mean, l said to him.";
+    private const string LineNoMatch = "The quick brown fox jumps over the lazy dog near the river bank today.";
+
+    [Benchmark]
+    public string ReplaceWord_Hit() => OcrFixReplaceList2.ReplaceWord(Line, "l", "I");
+
+    [Benchmark]
+    public string ReplaceWord_FirstCharOnlyHits() => OcrFixReplaceList2.ReplaceWord(LineNoMatch, "t", "T");
+}
+
+/// <summary>
+/// ItalicTextMerger.MergeWithItalicTags runs once per OCR'd subtitle line.
+/// </summary>
+[MemoryDiagnoser]
+public class ItalicTextMergerBenchmarks
+{
+    private List<BinaryOcrMatcher.CompareMatch> _chars = new();
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _chars = new List<BinaryOcrMatcher.CompareMatch>();
+        const string text = "This is a sample line with some italic words in it here";
+        for (var i = 0; i < text.Length; i++)
+        {
+            var italic = i > 20 && i < 35;
+            _chars.Add(new BinaryOcrMatcher.CompareMatch(text[i].ToString(), italic, 0, null));
+        }
+    }
+
+    [Benchmark]
+    public string MergeWithItalicTags() => ItalicTextMerger.MergeWithItalicTags(_chars);
+}
+
+/// <summary>
+/// SpellChecker.IsNumber runs once per word per grid repaint with live spell check on;
+/// nearly all words are plain letters and can never match any of the three regexes.
+/// </summary>
+[MemoryDiagnoser]
+public class SpellCheckerIsNumberBenchmarks
+{
+    private sealed class Probe : SpellChecker
+    {
+        public static bool IsNumberProbe(string word) => IsNumber(word);
+    }
+
+    [Benchmark] public bool IsNumber_Word() => Probe.IsNumberProbe("subtitle");
+    [Benchmark] public bool IsNumber_Number() => Probe.IsNumberProbe("1,234.56");
+}
+
+/// <summary>
+/// CustomTextFormatter.GenerateCustomText - export via a custom format template; GetTimeCode
+/// runs three times per paragraph.
+/// </summary>
+[MemoryDiagnoser]
+public class CustomTextFormatterBenchmarks
+{
+    private CustomFormatTemplate _template = new();
+    private List<Paragraph> _paragraphs = new();
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _template = new CustomFormatTemplate
+        {
+            Name = "bench",
+            Extension = ".txt",
+            FormatHeader = string.Empty,
+            FormatParagraph = "{number}\t{start}\t{end}\t{duration}\t{text}\r\n",
+            FormatFooter = string.Empty,
+            FormatTimeCode = "hh:mm:ss,zzz",
+            FormatNewLine = " ",
+        };
+
+        _paragraphs = new List<Paragraph>();
+        for (var i = 0; i < 500; i++)
+        {
+            _paragraphs.Add(new Paragraph(
+                "Hello there, this is subtitle line " + i + Environment.NewLine + "with a second line.",
+                i * 2500,
+                i * 2500 + 2000));
+        }
+    }
+
+    [Benchmark]
+    public string GenerateCustomText() => CustomTextFormatter.GenerateCustomText(_template, _paragraphs, "title", "video.mkv");
+}


### PR DESCRIPTION
A micro-optimization pass over the remaining hot paths in libse, LibUiLogic and the main view model — span/`SearchValues` modernization, LINQ-to-loop conversions in sort keys, source-generated/static regexes, cheap guards before expensive scans, and removal of dead per-keystroke work. Every change is behavior-preserving; all numbers below are measured with BenchmarkDotNet (default job, Apple Silicon, .NET 10) using the benchmarks added in `tests/benchmarks`.

## Headline numbers (before → after)

| Benchmark | Time | Allocated |
| --- | --- | --- |
| ASSA `ToText`, 1k lines | 975 µs → **264 µs (3.7×)** | 1,163 KB → **467 KB (−60 %)** |
| ASSA `ToText`, 10k lines | 10.9 ms → **3.2 ms (3.4×)** | 10.3 MB → **3.7 MB (−64 %)** |
| SubRip `ToText`, 1k lines | 306 µs → **141 µs (2.2×)** | 624 KB → **350 KB (−44 %)** |
| SubRip `ToText`, 10k lines | 4.7 ms → **2.4 ms (1.9×)** | 6.2 MB → **3.4 MB (−44 %)** |
| `RemoveAssAlignmentTags`, plain text | 436 ns → **3.9 ns (~112×)** | – |
| `RemoveAssaColor`, plain text | 290 ns → **4.4 ns (~66×)** | – |
| `RemoveAssaColor`, colored text | 386 ns → **202 ns (1.9×)** | unchanged |
| `ItalicTextMerger` per OCR line | 4.5 µs → **3.7 µs** | 18.2 KB → **14.9 KB (−18 %)** |
| `AutoBreakLine`, long line | 6.3 µs → **5.5 µs** | 32.8 KB → **28.0 KB (−15 %)** |
| `ContinuationUtilities.SanitizeString`, plain | 453 ns → **273 ns** | 264 B → **64 B** |
| Spell-check dash/period-name probe per word (300 names) | 11.9 µs → **0.63 µs (~19×)** | 37.5 KB → **0 B** |
| `SpellChecker.IsNumber` on an ordinary word | 56 ns → **~0 ns** | – |
| `OcrFixReplaceList2.ReplaceWord` (first-char hits, no match) | – | 592 B → **384 B (−35 %)** |
| Custom-format export, 500 lines | 2.07 ms → **1.72 ms** | 4.31 MB → **4.14 MB** |

## What changed

**libse**
- SubRip/ASSA `ToText`: append fields directly instead of `AppendFormat` (per-paragraph format parsing + `object[]` + boxing), write ASSA time codes from a single `TimeSpan` read (was ~7 conversions and 4 boxed ints per call), probe styles via a `HashSet` instead of up to three linear `List.Contains` per paragraph, and trim inside the `StringBuilder` instead of allocating the whole multi-megabyte output two extra times.
- `TextSplit`: `Where(...).OrderBy(...).FirstOrDefault()` (a full O(n log n) sort to take element 0) → stable linear min-scan; `TextSplitResult` sort keys drop their LINQ closures.
- `HtmlUtil`: backslash guards skip `RemoveAssAlignmentTags`' 45 `Replace` scans and `RemoveAssaColor`'s five regexes for plain text; the color regexes are static/source-generated instead of hitting the global regex cache per line.
- `ContinuationUtilities.SanitizeString`: static/source-generated regexes (the music-symbol loop also rebuilt its pattern strings on every call).
- `Utilities`: `RemoveSsaTags` returns the input when nothing was stripped; `AutoBreakLine`'s ASSA-tag scan slices instead of `Substring`-the-remainder with a culture-sensitive `StartsWith`; single-pass double-space collapse; `QualifiesForMerge` no longer concatenates its ~135-char continuation set per call.

**LibUiLogic**
- `SpellCheckWordLists`: the dash/period name parts are split once and cached — `IsPartOfKnownDashOrPeriodName` re-split every combined name on every word, and runs per word during live spell check and up to four times per word from the OCR fix engine.
- `SpellChecker.IsNumber`: first-char gate before the three regexes.
- `OcrFixReplaceList2`: `TryGetValue` for the whole-line list, dictionary-entry iteration instead of `Keys` + indexer re-lookups, `ReplaceWord` probes via `AsSpan` + `SearchValues`.
- `OcrFixEngine`: the line text is only built when a name check can still read it.
- `ItalicTextMerger`: indexed loops instead of `words.IndexOf(word)` inside the loop over `words` (O(n²) per OCR'd line), `StringBuilder` segment merging, no per-word LINQ.
- `CustomTextFormatter`: source-generated `z+`/`s+` regexes, absent-letter short-circuits, each `TimeCode` component read once.

**Main window**
- Deleted a dead per-keystroke computation in `OnKeyDownHandler` (and its CutVideo copy): a `HashSet` copy, key-name list and shortcut hash built on every keypress and never read.
- `ShortcutManager`: allocation-free `ActiveKeyCount`/`TryGetSingleActiveKey` (the key set was copied 2–3× per keystroke), the normalized-hash pass only runs when a token actually normalizes, cached category name strings.
- Selection changed: typed pre-sized copy instead of `Cast().ToList()`; the original-column text info is skipped while that column is hidden (repopulated on show).
- The window title (400 ms timer) and waveform play/pause icon (50 ms timer) are only written when they actually change.

## Verification

- All 1,956 tests pass (libse 745, libuilogic 18, UI 914, seconv 279).
- A before/after dump of every touched pure function over an edge-case battery (fragment/minute carries, negative times, comments, missing styles, null extras, ASSA tags, drawing commands, music symbols) is **byte-identical**.
- New benchmarks in `tests/benchmarks` cover the optimized paths so the numbers are reproducible: `dotnet run -c Release --project tests/benchmarks/UiBenchmarks.csproj -- --filter '*ToText*'` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)