### PR TITLE
Auto-trim white space: use detected language so Dutch keeps " 's"

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1862,6 +1862,7 @@ public partial class MainViewModel :
         UpdateVideoOffsetStatus();
         _currentSpellCheckDictionary = null;
         _spellCheckSessionInProgress = false;
+        _autoTrimLanguageCode = null;
 
         if (format != null)
         {
@@ -16348,13 +16349,20 @@ public partial class MainViewModel :
         return true;
     }
 
+    // RemoveUnneededSpaces has language-specific rules - e.g. Dutch keeps the space in
+    // "ze 's avonds" - so auto-trim must not run with an empty language code (issue #12144).
+    // Detection is too slow for the per-selection trim in SubtitleGrid_SelectionChanged,
+    // so the code is cached here; this method re-detects on every file load and auto-save.
+    private string? _autoTrimLanguageCode;
+
     private void AutoTrimWhiteSpaces()
     {
         if (Se.Settings.General.AutoTrimWhiteSpace)
         {
+            _autoTrimLanguageCode = Subtitles.AutoDetectGoogleLanguage() ?? string.Empty;
             foreach (var item in Subtitles)
             {
-                item.Text = Utilities.RemoveUnneededSpaces(item.Text, string.Empty).Trim();
+                item.Text = Utilities.RemoveUnneededSpaces(item.Text, _autoTrimLanguageCode).Trim();
             }
         }
     }
@@ -17276,6 +17284,8 @@ public partial class MainViewModel :
     /// </summary>
     private void ReplaceSubtitles(IEnumerable<SubtitleLineViewModel> items)
     {
+        _autoTrimLanguageCode = null;
+
         // Materialize first: callers may pass a lazy query over Subtitles itself.
         var list = items as IReadOnlyList<SubtitleLineViewModel> ?? items.ToList();
 
@@ -21617,11 +21627,12 @@ public partial class MainViewModel :
 
         if (Se.Settings.General.AutoTrimWhiteSpace && e.RemovedItems.Count < 10)
         {
+            var languageCode = _autoTrimLanguageCode ??= Subtitles.AutoDetectGoogleLanguage() ?? string.Empty;
             foreach (SubtitleLineViewModel? item in e.RemovedItems)
             {
                 if (item != null)
                 {
-                    item.Text = Utilities.RemoveUnneededSpaces(item.Text, string.Empty).Trim();
+                    item.Text = Utilities.RemoveUnneededSpaces(item.Text, languageCode).Trim();
                 }
             }
         }


### PR DESCRIPTION
## Summary
Auto-trim white space called `Utilities.RemoveUnneededSpaces` with an empty language code — both in `AutoTrimWhiteSpaces()` (file load / auto-save) and in the grid selection-changed trim. That bypassed the Dutch guard in `RemoveUnneededSpaces`, so the correct Dutch `ze 's avonds` was collapsed to `ze's avonds` the moment the user left the line — the remaining repro in #12144 (Fix Common Errors itself already passes the detected language and is unaffected).

## Fix
- Detect the subtitle language and pass it to `RemoveUnneededSpaces` at both auto-trim call sites.
- Cache the detected code in `_autoTrimLanguageCode`, since the selection-changed trim runs on every selection move; the cache refreshes on every file load / auto-save and is invalidated in `ResetSubtitle` / `ReplaceSubtitles`.

## Verification
Console harness against libse:
- `RemoveUnneededSpaces("Ik hoorde ze 's avonds ruzie maken.", "")` → `ze's avonds` (the bug)
- `RemoveUnneededSpaces(..., "nl")` → `ze 's avonds` (kept)
- `LanguageAutoDetect.AutoDetectGoogleLanguage` returns `nl` even for the reporter's 2-line sample

Fixes the auto-trim part of #12144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)