### PR TITLE
Always bypass proxy for loopback urls

### DIFF
--- a/src/libse/Common/HttpClientHandlerExtensions.cs
+++ b/src/libse/Common/HttpClientHandlerExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+using System;
+using System.Net.Http;
 using System.Net;
 
 namespace Nikse.SubtitleEdit.Core.Common
@@ -7,11 +8,28 @@ namespace Nikse.SubtitleEdit.Core.Common
     {
         public static HttpClient CreateHttpClientWithProxy()
         {
-
             var proxyAddress = Configuration.Settings.Proxy.ProxyAddress;
             if (string.IsNullOrEmpty(proxyAddress))
             {
-                return new HttpClient();
+                // Wrap the system/environment proxy so loopback urls (localhost, 127.x, [::1])
+                // always connect directly - .NET Framework did this implicitly, modern .NET does not
+#if NETSTANDARD
+                var systemProxy = WebRequest.DefaultWebProxy;
+#else
+                var systemProxy = HttpClient.DefaultProxy;
+#endif
+                if (systemProxy == null)
+                {
+                    return new HttpClient();
+                }
+
+                var defaultHandler = new HttpClientHandler
+                {
+                    UseProxy = true,
+                    Proxy = new LoopbackBypassingProxy(systemProxy),
+                };
+
+                return new HttpClient(defaultHandler);
             }
 
             var handler = new HttpClientHandler();
@@ -33,9 +51,29 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
 
             handler.UseProxy = true;
-            handler.Proxy = proxy;
+            handler.Proxy = new LoopbackBypassingProxy(proxy);
 
             return new HttpClient(handler);
+        }
+
+        private sealed class LoopbackBypassingProxy : IWebProxy
+        {
+            private readonly IWebProxy _inner;
+
+            public LoopbackBypassingProxy(IWebProxy inner)
+            {
+                _inner = inner;
+            }
+
+            public ICredentials Credentials
+            {
+                get => _inner.Credentials;
+                set => _inner.Credentials = value;
+            }
+
+            public Uri GetProxy(Uri destination) => IsBypassed(destination) ? null : _inner.GetProxy(destination);
+
+            public bool IsBypassed(Uri host) => host.IsLoopback || _inner.IsBypassed(host);
         }
     }
 }


### PR DESCRIPTION
Fixes #12907

## What

Requests to loopback destinations (`localhost`, `127.0.0.0/8`, `[::1]`) now always connect directly, never through a proxy. Both branches of `HttpClientFactoryWithProxy.CreateHttpClientWithProxy()` are covered:

- **No SE proxy configured**: the system/environment proxy (`HTTP_PROXY`, Windows proxy settings) is wrapped in a `LoopbackBypassingProxy` decorator instead of returning a bare `HttpClient`.
- **SE proxy configured**: the explicit `WebProxy` is wrapped in the same decorator.

Non-loopback traffic is delegated to the inner proxy unchanged, including credentials.

## Why

In #12907 a user behind a corporate Squid proxy found all local API engines (LM Studio, KoboldCpp, Ollama, OpenAI compatible) broken in SE 5 while SE 4.x worked on the same network. SE 5 routed requests aimed at `http://127.0.0.1:5001` through the proxy; Squid then tried to connect to 127.0.0.1 *on the proxy server*, got connection refused, and returned its 503 error page — which surfaced as the "API response: `<html>...`" error.

This is a .NET Framework → modern .NET behavior change:

- .NET Framework's `WebProxy.IsBypassedManual` starts with `if (host.IsLoopback) return true; // bypass localhost from using a proxy.` — loopback was unconditionally bypassed, so SE 4.x never touched the proxy for local urls.
- Modern .NET dropped that special case: `WebProxy` only bypasses loopback if `BypassProxyOnLocal` is set (default false), and the environment-variable proxy only honors an explicit `NO_PROXY`.

Browsers behave like .NET Framework here (Chrome/WinINet have implicit localhost bypass rules that cannot be turned off) — proxying loopback is never meaningful, since the proxy would connect to its own 127.0.0.1.

## Verification

Tested with a local `HttpListener` on `127.0.0.1:8765` and a blackhole `HTTP_PROXY=http://192.0.2.1:9999`:

| Client | Result |
|---|---|
| Plain `new HttpClient()` (old behavior) | FAILED — request routed into the proxy, timed out |
| Factory client, no SE proxy | OK — connected directly |
| Factory client, SE proxy set to blackhole | OK — connected directly |

`LibSE.csproj` builds clean on both `netstandard2.1` (uses `WebRequest.DefaultWebProxy`, since `HttpClient.DefaultProxy` is unavailable there) and `net10.0`.

One factory call site covers all ~27 clients (every translate engine, OpenAI-compatible speech to text, AI review), so this fixes every local API at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)