### PR TITLE
Add "Go to video position..." to Video menu

### DIFF
--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -683,6 +683,12 @@ public static class InitMenu
                 new Separator(),
                 new MenuItem
                 {
+                    Header = Se.Language.Video.GoToVideoPositionDotDotDot,
+                    Command = vm.ShowGoToVideoPositionCommand,
+                },
+                new Separator(),
+                new MenuItem
+                {
                     Header = l.SpeechToText,
                     Command = vm.ShowSpeechToTextWhisperCommand,
                 },

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -330,6 +330,8 @@ public static class InitNativeMacMenu
         videoItems.Items.Add(state.AudioTracksItem);
 
         videoItems.Items.Add(new NativeMenuItemSeparator());
+        videoItems.Items.Add(Item(Clean(Se.Language.Video.GoToVideoPositionDotDotDot), v => v.ShowGoToVideoPositionCommand));
+        videoItems.Items.Add(new NativeMenuItemSeparator());
         videoItems.Items.Add(Item(Clean(l.SpeechToText), v => v.ShowSpeechToTextWhisperCommand));
         videoItems.Items.Add(Item(Clean(l.TextToSpeech), v => v.ShowVideoTextToSpeechCommand));
         videoItems.Items.Add(Item(Clean(l.VideoOcr), v => v.ShowVideoOcrCommand));

--- a/src/ui/Logic/Config/Language/Video/LanguageVideo.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageVideo.cs
@@ -11,6 +11,7 @@ public class LanguageVideo
     public LanguageShotChanges ShotChanges { get; set; } = new();
     public LanguageVideoOcr VideoOcr { get; set; } = new();
     public string GoToVideoPosition { get; set; }
+    public string GoToVideoPositionDotDotDot { get; set; }
     public string GenerateBlankVideoDotDotDot { get; set; }
     public string GenerateBlankVideoTitle { get; set; }
     public string ReEncodeVideoForBetterSubtitlingTitle { get; set; }
@@ -81,6 +82,7 @@ public class LanguageVideo
     {
 
         GoToVideoPosition = "Go to video position";
+        GoToVideoPositionDotDotDot = "Go to video position...";
         GenerateBlankVideoTitle = "Generate blank video";
         GenerateBlankVideoDotDotDot = "Generate blank video...";
         ReEncodeVideoForBetterSubtitlingTitle = "Re-encode video for better subtitling";


### PR DESCRIPTION
The `ShowGoToVideoPositionCommand` dialog and its configurable shortcut already existed, but there was no menu entry, so the feature was hard to discover.

- Adds **Go to video position...** to the Video menu (regular menu + native macOS menu)
- New language string `Video.GoToVideoPositionDotDotDot`
- The user-assigned shortcut shows next to the menu item automatically via the existing gesture wiring

Part of the v5.2.0 plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)