### PR TITLE
Add more proxy settings: domain, system credentials, bypass list

### DIFF
--- a/src/libse/Common/BypassingWebProxy.cs
+++ b/src/libse/Common/BypassingWebProxy.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Linq;
+using System.Net;
+
+namespace Nikse.SubtitleEdit.Core.Common
+{
+    /// <summary>
+    /// Wraps another proxy so loopback urls (localhost, 127.x, [::1]) and hosts from the
+    /// user's proxy bypass list always connect directly - .NET Framework bypassed loopback
+    /// implicitly, modern .NET does not.
+    /// </summary>
+    public sealed class BypassingWebProxy : IWebProxy
+    {
+        private readonly IWebProxy _inner;
+        private readonly string[] _bypassHosts;
+
+        public BypassingWebProxy(IWebProxy inner, string bypassList)
+        {
+            _inner = inner;
+            _bypassHosts = SplitBypassList(bypassList);
+        }
+
+        /// <summary>
+        /// Splits a user-entered bypass list (semicolon, comma, or space separated) into
+        /// host names; leading "*." or "." wildcards are stripped since sub domains of a
+        /// listed host are always bypassed too.
+        /// </summary>
+        public static string[] SplitBypassList(string bypassList)
+        {
+            if (string.IsNullOrWhiteSpace(bypassList))
+            {
+                return Array.Empty<string>();
+            }
+
+            return bypassList
+                .Split(new[] { ';', ',', ' ' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(p => p.Trim().TrimStart('*').TrimStart('.'))
+                .Where(p => p.Length > 0)
+                .ToArray();
+        }
+
+        public ICredentials Credentials
+        {
+            get => _inner.Credentials;
+            set => _inner.Credentials = value;
+        }
+
+        public Uri GetProxy(Uri destination) => IsBypassed(destination) ? null : _inner.GetProxy(destination);
+
+        public bool IsBypassed(Uri host)
+        {
+            if (host.IsLoopback || _inner.IsBypassed(host))
+            {
+                return true;
+            }
+
+            foreach (var bypassHost in _bypassHosts)
+            {
+                if (host.Host.Equals(bypassHost, StringComparison.OrdinalIgnoreCase) ||
+                    host.Host.EndsWith("." + bypassHost, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/libse/Common/HttpClientHandlerExtensions.cs
+++ b/src/libse/Common/HttpClientHandlerExtensions.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Net.Http;
 using System.Net;
 
@@ -8,11 +7,10 @@ namespace Nikse.SubtitleEdit.Core.Common
     {
         public static HttpClient CreateHttpClientWithProxy()
         {
-            var proxyAddress = Configuration.Settings.Proxy.ProxyAddress;
+            var proxySettings = Configuration.Settings.Proxy;
+            var proxyAddress = proxySettings.ProxyAddress;
             if (string.IsNullOrEmpty(proxyAddress))
             {
-                // Wrap the system/environment proxy so loopback urls (localhost, 127.x, [::1])
-                // always connect directly - .NET Framework did this implicitly, modern .NET does not
 #if NETSTANDARD
                 var systemProxy = WebRequest.DefaultWebProxy;
 #else
@@ -26,7 +24,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 var defaultHandler = new HttpClientHandler
                 {
                     UseProxy = true,
-                    Proxy = new LoopbackBypassingProxy(systemProxy),
+                    Proxy = new BypassingWebProxy(systemProxy, proxySettings.BypassList),
                 };
 
                 return new HttpClient(defaultHandler);
@@ -35,11 +33,11 @@ namespace Nikse.SubtitleEdit.Core.Common
             var handler = new HttpClientHandler();
             var proxy = new WebProxy(proxyAddress);
 
-            var userName = Configuration.Settings.Proxy.UserName;
-            var password = Configuration.Settings.Proxy.DecodePassword();
-            var domain = Configuration.Settings.Proxy.Domain;
+            var userName = proxySettings.UserName;
+            var password = proxySettings.DecodePassword();
+            var domain = proxySettings.Domain;
 
-            if (!string.IsNullOrEmpty(userName))
+            if (!proxySettings.UseDefaultCredentials && !string.IsNullOrEmpty(userName))
             {
                 proxy.Credentials = string.IsNullOrEmpty(domain)
                     ? new NetworkCredential(userName, password)
@@ -51,29 +49,9 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
 
             handler.UseProxy = true;
-            handler.Proxy = new LoopbackBypassingProxy(proxy);
+            handler.Proxy = new BypassingWebProxy(proxy, proxySettings.BypassList);
 
             return new HttpClient(handler);
-        }
-
-        private sealed class LoopbackBypassingProxy : IWebProxy
-        {
-            private readonly IWebProxy _inner;
-
-            public LoopbackBypassingProxy(IWebProxy inner)
-            {
-                _inner = inner;
-            }
-
-            public ICredentials Credentials
-            {
-                get => _inner.Credentials;
-                set => _inner.Credentials = value;
-            }
-
-            public Uri GetProxy(Uri destination) => IsBypassed(destination) ? null : _inner.GetProxy(destination);
-
-            public bool IsBypassed(Uri host) => host.IsLoopback || _inner.IsBypassed(host);
         }
     }
 }

--- a/src/libse/Http/DownloaderFactory.cs
+++ b/src/libse/Http/DownloaderFactory.cs
@@ -29,7 +29,7 @@ namespace Nikse.SubtitleEdit.Core.Http
 
             if (!string.IsNullOrEmpty(proxySettings.ProxyAddress))
             {
-                handler.Proxy = new WebProxy(proxySettings.ProxyAddress);
+                handler.Proxy = new BypassingWebProxy(new WebProxy(proxySettings.ProxyAddress), proxySettings.BypassList);
                 handler.UseProxy = true;
             }
 

--- a/src/libse/Settings/ProxySettings.cs
+++ b/src/libse/Settings/ProxySettings.cs
@@ -11,6 +11,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
         public string UserName { get; set; }
         public string Password { get; set; }
         public string Domain { get; set; }
+        public string BypassList { get; set; }
 
         public string DecodePassword()
         {

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -13,6 +13,7 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Shared.PickLanguage;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.ValueConverters;
 using Optris.Icons.Avalonia;
 using System;
 using System.Collections.Generic;
@@ -746,8 +747,20 @@ public class SettingsPage : UserControl
         sections.Add(new SettingsSection(Se.Language.Options.Settings.Network, IconNames.Network, "#6bb84e",
         [
             new SettingsItem(Se.Language.Options.Settings.ProxyAddress, () => UiUtil.MakeTextBox(250, _vm, nameof(_vm.ProxyAddress))),
-            new SettingsItem(Se.Language.Options.Settings.Username, () => UiUtil.MakeTextBox(250, _vm, nameof(_vm.ProxyUserName))),
-            new SettingsItem(Se.Language.Options.Settings.Password, () => UiUtil.MakeTextBox(250, _vm, nameof(_vm.ProxyPassword))),
+            MakeCheckboxSetting(Se.Language.Options.Settings.ProxyUseSystemCredentials, nameof(_vm.ProxyUseDefaultCredentials)),
+            new SettingsItem(Se.Language.Options.Settings.Username, () => MakeProxyCredentialTextBox(nameof(_vm.ProxyUserName))),
+            new SettingsItem(Se.Language.Options.Settings.Password, () => MakeProxyCredentialTextBox(nameof(_vm.ProxyPassword))),
+            new SettingsItem(Se.Language.Options.Settings.ProxyDomain, () => MakeProxyCredentialTextBox(nameof(_vm.ProxyDomain))),
+            new SettingsItem(Se.Language.Options.Settings.ProxyBypassList, () =>
+            {
+                var textBox = UiUtil.MakeTextBox(250, _vm, nameof(_vm.ProxyBypassList));
+                if (Se.Settings.Appearance.ShowHints)
+                {
+                    ToolTip.SetTip(textBox, Se.Language.Options.Settings.ProxyBypassListHint);
+                }
+
+                return textBox;
+            }),
         ]));
 
         if (OperatingSystem.IsWindows())
@@ -1167,6 +1180,18 @@ public class SettingsPage : UserControl
 
         numericUpDown.ValueChanged += (s, e) => valueChanged.Invoke();
         return numericUpDown;
+    }
+
+    private TextBox MakeProxyCredentialTextBox(string bindingProperty)
+    {
+        var textBox = UiUtil.MakeTextBox(250, _vm, bindingProperty);
+        textBox[!Control.IsEnabledProperty] = new Binding(nameof(_vm.ProxyUseDefaultCredentials))
+        {
+            Source = _vm,
+            Converter = new InverseBooleanConverter(),
+        };
+
+        return textBox;
     }
 
     private NumericUpDown MakeNumericUpDown(string bindingProperty, Action valueChanged)

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -263,6 +263,9 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private string _proxyAddress = string.Empty;
     [ObservableProperty] private string _proxyUserName = string.Empty;
     [ObservableProperty] private string _proxyPassword = string.Empty;
+    [ObservableProperty] private string _proxyDomain = string.Empty;
+    [ObservableProperty] private bool _proxyUseDefaultCredentials;
+    [ObservableProperty] private string _proxyBypassList = string.Empty;
     [ObservableProperty] private int _waveformTextFontSize;
     [ObservableProperty] private bool _waveformTextFontBold;
     [ObservableProperty] private Color _waveformTextColor;
@@ -979,6 +982,9 @@ public partial class SettingsViewModel : ObservableObject
         ProxyAddress = Se.Settings.General.ProxyAddress ?? string.Empty;
         ProxyUserName = Se.Settings.General.ProxyUserName ?? string.Empty;
         ProxyPassword = Se.Settings.General.ProxyPassword ?? string.Empty;
+        ProxyDomain = Se.Settings.General.ProxyDomain ?? string.Empty;
+        ProxyUseDefaultCredentials = Se.Settings.General.ProxyUseDefaultCredentials;
+        ProxyBypassList = Se.Settings.General.ProxyBypassList ?? string.Empty;
         SetFfmpegStatus();
         SetLibMpvStatus();
         SetLibVlcStatus();
@@ -1694,6 +1700,9 @@ public partial class SettingsViewModel : ObservableObject
         general.ProxyAddress = ProxyAddress;
         general.ProxyUserName = ProxyUserName;
         general.ProxyPassword = ProxyPassword;
+        general.ProxyDomain = ProxyDomain;
+        general.ProxyUseDefaultCredentials = ProxyUseDefaultCredentials;
+        general.ProxyBypassList = ProxyBypassList;
 
         general.CurrentProfile = SelectedProfile;
         general.Profiles.Clear();

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -195,6 +195,10 @@ public class LanguageSettings
     public string ProxyAddress { get; set; }
     public string Username { get; set; }
     public string Password { get; set; }
+    public string ProxyDomain { get; set; }
+    public string ProxyUseSystemCredentials { get; set; }
+    public string ProxyBypassList { get; set; }
+    public string ProxyBypassListHint { get; set; }
 
     public string DefaultFormat { get; set; }
     public string DefaultSaveAsFormat { get; set; }
@@ -528,6 +532,10 @@ public class LanguageSettings
         ProxyAddress = "Proxy address";
         Username = "Username";
         Password = "Password";
+        ProxyDomain = "Domain";
+        ProxyUseSystemCredentials = "Use system credentials";
+        ProxyBypassList = "Bypass proxy for";
+        ProxyBypassListHint = "Semicolon separated host names that connect directly, e.g. \"internal.company.com;example.org\"";
 
         ShowStopButton = "Show stop button";
         ShowFullscreenButton = "Show full-screen button";

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -581,6 +581,9 @@ public class Se
 
         Configuration.Settings.Proxy.ProxyAddress = Settings.General.ProxyAddress ?? string.Empty;
         Configuration.Settings.Proxy.UserName = Settings.General.ProxyUserName ?? string.Empty;
+        Configuration.Settings.Proxy.Domain = Settings.General.ProxyDomain ?? string.Empty;
+        Configuration.Settings.Proxy.UseDefaultCredentials = Settings.General.ProxyUseDefaultCredentials;
+        Configuration.Settings.Proxy.BypassList = Settings.General.ProxyBypassList ?? string.Empty;
         if (!string.IsNullOrEmpty(Settings.General.ProxyPassword))
         {
             Configuration.Settings.Proxy.EncodePassword(Settings.General.ProxyPassword);

--- a/src/ui/Logic/Config/SeGeneral.cs
+++ b/src/ui/Logic/Config/SeGeneral.cs
@@ -93,6 +93,9 @@ public class SeGeneral
     public string ProxyAddress { get; set; }
     public string ProxyUserName { get; set; }
     public string ProxyPassword { get; set; }
+    public string ProxyDomain { get; set; }
+    public bool ProxyUseDefaultCredentials { get; set; }
+    public string ProxyBypassList { get; set; }
 
     public bool ShowColumnStartTime { get; set; }
     public bool ShowColumnEndTime { get; set; }
@@ -207,6 +210,8 @@ public class SeGeneral
         ProxyAddress = string.Empty;
         ProxyUserName = string.Empty;
         ProxyPassword = string.Empty;
+        ProxyDomain = string.Empty;
+        ProxyBypassList = string.Empty;
 
         ShowColumnStartTime = true;
         ShowColumnEndTime = true;


### PR DESCRIPTION
Answers the "do we need more proxy settings?" question from the v5.2.0 plan:

- **Settings → Network** now exposes **Domain** (NTLM) and a **Use system credentials** checkbox — libse's `ProxySettings` already supported both, but the v5 UI never set them, so `proxy.UseDefaultCredentials` was unreachable
- New **Bypass proxy for** setting: semicolon-separated hosts (subdomains included) that always connect directly — applied to both a configured proxy and the system/environment proxy
- The loopback-bypassing wrapper from #12927 is extracted into a shared `BypassingWebProxy` and now also used by `DownloaderFactory`, so downloads get the same loopback + bypass-list behavior
- Username/password/domain fields are disabled while "Use system credentials" is checked
- Bypass-list tooltip is guarded by `ShowHints`

🤖 Generated with [Claude Code](https://claude.com/claude-code)