### PR TITLE
Add shortcut to toggle subtitles on video player

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -2457,6 +2457,30 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private void ToggleSubtitlesOnVideoPlayer()
+    {
+        var vp = GetVideoPlayerControl();
+        if (vp?.VideoPlayer is not LibMpvDynamicPlayer mpv)
+        {
+            return;
+        }
+
+        _mpvReloader.SubtitlesVisible = !_mpvReloader.SubtitlesVisible;
+        mpv.SetSubtitleVisibility(_mpvReloader.SubtitlesVisible);
+
+        if (_mpvReloader.SubtitlesVisible)
+        {
+            ShowStatus(Se.Language.Video.SubtitlesOnVideoPlayerOn);
+        }
+        else
+        {
+            ShowStatus(Se.Language.Video.SubtitlesOnVideoPlayerOff);
+        }
+
+        _shortcutManager.ClearKeys();
+    }
+
+    [RelayCommand]
     private async Task CopySubtitlePathToClipboard()
     {
         if (Window == null || Window.Clipboard == null || string.IsNullOrEmpty(_subtitleFileName))
@@ -12574,6 +12598,7 @@ public partial class MainViewModel :
             (nameof(TogglePlayPauseCommand),        TogglePlayPauseCommand),
             (nameof(TogglePlayPause2Command),       TogglePlayPause2Command),
             (nameof(VideoToggleBrightnessCommand),  VideoToggleBrightnessCommand),
+            (nameof(ToggleSubtitlesOnVideoPlayerCommand), ToggleSubtitlesOnVideoPlayerCommand),
         };
 
         var bindings = new List<(string name, List<string> keys, IRelayCommand command)>(commands.Length);

--- a/src/ui/Logic/Config/Language/Video/LanguageVideo.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageVideo.cs
@@ -67,6 +67,9 @@ public class LanguageVideo
     public string PickOnlineSubtitleFetching { get; set; }
     public string PickOnlineSubtitleNoneFound { get; set; }
     public string ToggleCurrentSubtitleWhilePlaying { get; set; }
+    public string ToggleSubtitlesOnVideoPlayer { get; set; }
+    public string SubtitlesOnVideoPlayerOn { get; set; }
+    public string SubtitlesOnVideoPlayerOff { get; set; }
     public string OnlyMkvCanSupportEmbeddedSubtitleEditing { get; set; }
     public string ReEncodeInfo { get; set; }
     public string ReEncodeGeneratingVideoX { get; set; }
@@ -137,6 +140,9 @@ public class LanguageVideo
         PickOnlineSubtitleFetching = "Downloading subtitles...";
         PickOnlineSubtitleNoneFound = "No subtitles found for this URL.";
         ToggleCurrentSubtitleWhilePlaying = "Toggle current subtitle while playing";
+        ToggleSubtitlesOnVideoPlayer = "Toggle subtitles on video player";
+        SubtitlesOnVideoPlayerOn = "Subtitles on video player: on";
+        SubtitlesOnVideoPlayerOff = "Subtitles on video player: off";
         OnlyMkvCanSupportEmbeddedSubtitleEditing = "Only Matroska (.mkv, .webm) files are supported for editing embedded subtitles.";
         ReEncodeInfo = "Re-encoding can make subtitling smoother:" + Environment.NewLine +
                        "• Smaller resolution (high resolutions make subtitling slow)" + Environment.NewLine +

--- a/src/ui/Logic/Media/IMpvReloader.cs
+++ b/src/ui/Logic/Media/IMpvReloader.cs
@@ -10,4 +10,5 @@ public interface IMpvReloader
     Task RefreshMpv(LibMpvDynamicPlayer mpv, Subtitle subtitle, Subtitle? subtitleSecondary, SubtitleFormat uiFormat);
     void Reset();
     bool SmpteMode { get; set; }
+    bool SubtitlesVisible { get; set; }
 }

--- a/src/ui/Logic/Media/MpvReloader.cs
+++ b/src/ui/Logic/Media/MpvReloader.cs
@@ -13,6 +13,7 @@ namespace Nikse.SubtitleEdit.Logic.Media;
 public class MpvReloader : IMpvReloader
 {
     public bool SmpteMode { get; set; }
+    public bool SubtitlesVisible { get; set; } = true;
     public int VideoWidth { get; set; } = 1280;
     public int VideoHeight { get; set; } = 720;
 
@@ -182,6 +183,10 @@ public class MpvReloader : IMpvReloader
                 }
                 _mpvTextOld = text;
             }
+
+            // Re-assert visibility so a hidden preview stays hidden on a freshly
+            // created player (fullscreen/undock create a new mpv instance).
+            mpvContext.SetSubtitleVisibility(SubtitlesVisible);
             _subtitlePrev = subtitle;
         }
         catch (Exception exception)

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -474,6 +474,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.ZoomLayoutOutCommand), Se.Language.Options.Shortcuts.LayoutZoomOut },
         { nameof(MainViewModel.OpenSecondarySubtitleCommand), Se.Language.Video.OpenSecondarySubtitleOnVideoPlayer },
         { nameof(MainViewModel.ToggleCurrentSubtitleWhilePlayingCommand), Se.Language.Video.ToggleCurrentSubtitleWhilePlaying },
+        { nameof(MainViewModel.ToggleSubtitlesOnVideoPlayerCommand), Se.Language.Video.ToggleSubtitlesOnVideoPlayer },
         { nameof(MainViewModel.ToggleSmpteTimingCommand), Se.Language.Main.Menu.SmpteTiming },
     };
     }
@@ -867,6 +868,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.ZoomLayoutOutCommand, nameof(vm.ZoomLayoutOutCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.OpenSecondarySubtitleCommand, nameof(vm.OpenSecondarySubtitleCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.ToggleCurrentSubtitleWhilePlayingCommand, nameof(vm.ToggleCurrentSubtitleWhilePlayingCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.ToggleSubtitlesOnVideoPlayerCommand, nameof(vm.ToggleSubtitlesOnVideoPlayerCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.ToggleSmpteTimingCommand, nameof(vm.ToggleSmpteTimingCommand), ShortcutCategory.General, ShortcutGroup.Video);
 
         return shortcuts;

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -1692,6 +1692,11 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         DoMpvCommand("sub-remove");
     }
 
+    public void SetSubtitleVisibility(bool visible)
+    {
+        DoMpvCommand("set", "sub-visibility", visible ? "yes" : "no");
+    }
+
     public void SubReload()
     {
         DoMpvCommand("sub-reload");


### PR DESCRIPTION
Adds a configurable shortcut (Options → Shortcuts → Video: **Toggle subtitles on video player**) that temporarily hides/shows the subtitle overlay on the mpv video player, as requested in discussion [#12689](https://github.com/SubtitleEdit/subtitleedit/discussions/12689).

- New `LibMpvDynamicPlayer.SetSubtitleVisibility` using mpv's `sub-visibility` property
- `MpvReloader` re-asserts the visibility state after `sub-add`/`sub-reload`, so a hidden preview stays hidden on freshly created players (fullscreen/undock create a new mpv instance)
- Forwarded into the fullscreen video window's shortcut bindings, since fullscreen is where previewing mostly happens
- Session-only: subtitles are always visible again after restart (it's a "temporarily hide" toggle, not a setting)
- Status bar shows "Subtitles on video player: on/off" on toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)