### PR TITLE
Add default save location setting

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17789,6 +17789,8 @@ public partial class MainViewModel :
             }
         }
 
+        newFileName = ApplyDefaultSaveLocation(newFileName);
+
         var title = Se.Language.General.SaveFileAsTitle;
         if (ShowColumnOriginalText)
         {
@@ -17849,6 +17851,37 @@ public partial class MainViewModel :
         var result = await SaveSubtitle();
         AddToRecentFiles(true);
         return result;
+    }
+
+    /// <summary>
+    /// Points the "Save as" suggestion at the folder chosen by the default-save-location
+    /// setting (#12212). The picker opens in the suggestion's folder, so replacing the
+    /// directory part is enough; a bare file name makes the OS picker use its last folder.
+    /// </summary>
+    private string ApplyDefaultSaveLocation(string fileName)
+    {
+        var location = Se.Settings.General.DefaultSaveLocation;
+        if (location == nameof(DefaultSaveLocationType.LastUsedFolder))
+        {
+            return Path.GetFileName(fileName);
+        }
+
+        string? folder = null;
+        if (location == nameof(DefaultSaveLocationType.VideoFileFolder) && !string.IsNullOrEmpty(_videoFileName))
+        {
+            folder = Path.GetDirectoryName(_videoFileName);
+        }
+        else if (location == nameof(DefaultSaveLocationType.SubtitleFileFolder) && !string.IsNullOrEmpty(_subtitleFileName))
+        {
+            folder = Path.GetDirectoryName(_subtitleFileName);
+        }
+        else if (location == nameof(DefaultSaveLocationType.CustomFolder) &&
+                 Directory.Exists(Se.Settings.General.DefaultSaveLocationCustomFolder))
+        {
+            folder = Se.Settings.General.DefaultSaveLocationCustomFolder;
+        }
+
+        return string.IsNullOrEmpty(folder) ? fileName : Path.Combine(folder, Path.GetFileName(fileName));
     }
 
     private string GetFileNameWithoutExtension(string fileName)

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -329,6 +329,29 @@ public class SettingsPage : UserControl
                 }
             }),
 
+            new SettingsItem(Se.Language.Options.Settings.DefaultSaveLocation, () => new ComboBox
+            {
+                MinWidth = 200,
+                DataContext = _vm,
+                [!ItemsControl.ItemsSourceProperty] = new Binding(nameof(_vm.DefaultSaveLocationTypes)),
+                [!SelectingItemsControl.SelectedItemProperty] = new Binding(nameof(_vm.SelectedDefaultSaveLocationType))
+                {
+                    Mode = BindingMode.TwoWay,
+                }
+            }),
+
+            new SettingsItem(Se.Language.Options.Settings.DefaultSaveLocationCustomFolder, () => new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing = 5,
+                [!Control.IsEnabledProperty] = new Binding(nameof(_vm.IsDefaultSaveLocationCustomFolderEnabled)) { Source = _vm },
+                Children =
+                {
+                    UiUtil.MakeTextBox(250, _vm, nameof(_vm.DefaultSaveLocationCustomFolder)),
+                    UiUtil.MakeButtonBrowse(_vm.BrowseDefaultSaveLocationFolderCommand),
+                }
+            }),
+
             MakeSeparator(),
             MakeCheckboxSetting(Se.Language.Options.Settings.AutoSave, nameof(_vm.AutoSave)),
             MakeCheckboxSetting(Se.Language.Options.Settings.AutoBackupOn, nameof(_vm.AutoBackupOn)),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -157,6 +157,10 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _subtitleGridCenterSelectedRow;
 
     [ObservableProperty] private ObservableCollection<string> _saveAsBehaviorTypes;
+    [ObservableProperty] private ObservableCollection<string> _defaultSaveLocationTypes;
+    [ObservableProperty] private string _selectedDefaultSaveLocationType;
+    [ObservableProperty] private string _defaultSaveLocationCustomFolder = string.Empty;
+    [ObservableProperty] private bool _isDefaultSaveLocationCustomFolderEnabled;
     [ObservableProperty] private string _selectedSaveAsBehaviorType;
 
     [ObservableProperty] private ObservableCollection<string> _saveAsAppendLanguageCode;
@@ -574,6 +578,16 @@ public partial class SettingsViewModel : ObservableObject
         ];
         SelectedSaveAsBehaviorType = SaveAsBehaviorTypes[0];
 
+        DefaultSaveLocationTypes =
+        [
+            Se.Language.Options.Settings.DefaultSaveLocationSourceFileFolder,
+            Se.Language.Options.Settings.DefaultSaveLocationLastUsedFolder,
+            Se.Language.Options.Settings.DefaultSaveLocationVideoFileFolder,
+            Se.Language.Options.Settings.DefaultSaveLocationSubtitleFileFolder,
+            Se.Language.Options.Settings.DefaultSaveLocationCustomFolder,
+        ];
+        SelectedDefaultSaveLocationType = DefaultSaveLocationTypes[0];
+
         SaveAsAppendLanguageCode =
         [
             Se.Language.General.None,
@@ -708,6 +722,8 @@ public partial class SettingsViewModel : ObservableObject
         SubtitleGridCenterSelectedRow = Se.Settings.General.SubtitleGridCenterSelectedRow;
         SelectedSaveAsBehaviorType = MapFromSelectedSaveAsBehavior(Se.Settings.General.SaveAsBehavior);
         SelectedSaveAsAppendLanguageCode = MapFromSelectedSaveAsAppendLanguageCode(Se.Settings.General.SaveAsAppendLanguageCode);
+        SelectedDefaultSaveLocationType = MapFromDefaultSaveLocation(Se.Settings.General.DefaultSaveLocation);
+        DefaultSaveLocationCustomFolder = Se.Settings.General.DefaultSaveLocationCustomFolder ?? string.Empty;
         AutoConvertToUtf8 = general.AutoConvertToUtf8;
         ForceCrLfOnSave = general.ForceCrLfOnSave;
         AutoTrimWhiteSpace = general.AutoTrimWhiteSpace;
@@ -1164,6 +1180,76 @@ public partial class SettingsViewModel : ObservableObject
         return Se.Language.General.Default;
     }
 
+    private static string MapFromDefaultSaveLocation(string defaultSaveLocation)
+    {
+        if (defaultSaveLocation == nameof(DefaultSaveLocationType.LastUsedFolder))
+        {
+            return Se.Language.Options.Settings.DefaultSaveLocationLastUsedFolder;
+        }
+
+        if (defaultSaveLocation == nameof(DefaultSaveLocationType.VideoFileFolder))
+        {
+            return Se.Language.Options.Settings.DefaultSaveLocationVideoFileFolder;
+        }
+
+        if (defaultSaveLocation == nameof(DefaultSaveLocationType.SubtitleFileFolder))
+        {
+            return Se.Language.Options.Settings.DefaultSaveLocationSubtitleFileFolder;
+        }
+
+        if (defaultSaveLocation == nameof(DefaultSaveLocationType.CustomFolder))
+        {
+            return Se.Language.Options.Settings.DefaultSaveLocationCustomFolder;
+        }
+
+        return Se.Language.Options.Settings.DefaultSaveLocationSourceFileFolder;
+    }
+
+    private static string MapToDefaultSaveLocation(string selectedDefaultSaveLocationType)
+    {
+        if (selectedDefaultSaveLocationType == Se.Language.Options.Settings.DefaultSaveLocationLastUsedFolder)
+        {
+            return nameof(DefaultSaveLocationType.LastUsedFolder);
+        }
+
+        if (selectedDefaultSaveLocationType == Se.Language.Options.Settings.DefaultSaveLocationVideoFileFolder)
+        {
+            return nameof(DefaultSaveLocationType.VideoFileFolder);
+        }
+
+        if (selectedDefaultSaveLocationType == Se.Language.Options.Settings.DefaultSaveLocationSubtitleFileFolder)
+        {
+            return nameof(DefaultSaveLocationType.SubtitleFileFolder);
+        }
+
+        if (selectedDefaultSaveLocationType == Se.Language.Options.Settings.DefaultSaveLocationCustomFolder)
+        {
+            return nameof(DefaultSaveLocationType.CustomFolder);
+        }
+
+        return nameof(DefaultSaveLocationType.SourceFileFolder);
+    }
+
+    partial void OnSelectedDefaultSaveLocationTypeChanged(string value)
+    {
+        IsDefaultSaveLocationCustomFolderEnabled = value == Se.Language.Options.Settings.DefaultSaveLocationCustomFolder;
+    }
+
+    [RelayCommand]
+    private async Task BrowseDefaultSaveLocationFolder()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var folder = await _folderHelper.PickFolderAsync(Window, Se.Language.Options.Settings.DefaultSaveLocation);
+        if (!string.IsNullOrEmpty(folder))
+        {
+            DefaultSaveLocationCustomFolder = folder;
+        }
+    }
+
     private static string MapFromSelectedSaveAsAppendLanguageCode(string languageAppendType)
     {
         if (languageAppendType == nameof(SaveAsLanguageAppendType.TwoLetterLanguageCode))
@@ -1466,6 +1552,8 @@ public partial class SettingsViewModel : ObservableObject
         general.SubtitleGridCenterSelectedRow = SubtitleGridCenterSelectedRow;
         general.SaveAsBehavior = MapToSaveAsBehavior(SelectedSaveAsBehaviorType);
         general.SaveAsAppendLanguageCode = MapToSaveAsAppendLanguageCode(SelectedSaveAsAppendLanguageCode);
+        general.DefaultSaveLocation = MapToDefaultSaveLocation(SelectedDefaultSaveLocationType);
+        general.DefaultSaveLocationCustomFolder = DefaultSaveLocationCustomFolder;
         general.AutoConvertToUtf8 = AutoConvertToUtf8;
         general.ForceCrLfOnSave = ForceCrLfOnSave;
         general.AutoTrimWhiteSpace = AutoTrimWhiteSpace;

--- a/src/ui/Logic/Config/DefaultSaveLocationType.cs
+++ b/src/ui/Logic/Config/DefaultSaveLocationType.cs
@@ -1,0 +1,14 @@
+namespace Nikse.SubtitleEdit.Logic.Config;
+
+public enum DefaultSaveLocationType
+{
+    /// <summary>Folder of the file the suggested name came from (subtitle or video) - the default.</summary>
+    SourceFileFolder,
+
+    /// <summary>Let the OS file picker open in whatever folder it was last used in.</summary>
+    LastUsedFolder,
+
+    VideoFileFolder,
+    SubtitleFileFolder,
+    CustomFolder,
+}

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -274,6 +274,12 @@ public class LanguageSettings
     public string SubtitleDoubleClickAction { get; set; }
     public string SubtitleGridCenterSelectedRow { get; set; }
     public string SaveAsBehavior { get; set; }
+    public string DefaultSaveLocation { get; set; }
+    public string DefaultSaveLocationSourceFileFolder { get; set; }
+    public string DefaultSaveLocationLastUsedFolder { get; set; }
+    public string DefaultSaveLocationVideoFileFolder { get; set; }
+    public string DefaultSaveLocationSubtitleFileFolder { get; set; }
+    public string DefaultSaveLocationCustomFolder { get; set; }
     public string SaveAsAppendLanguageCode { get; set; }
     public string GridGoToSubtitleAndSetVideoPosition { get; set; }
     public string GridGoToNextLine { get; set; }
@@ -605,6 +611,12 @@ public class LanguageSettings
         SubtitleDoubleClickAction = "Subtitle grid double-click action";
         SubtitleGridCenterSelectedRow = "Subtitle grid, center when selecting prev/next row";
         SaveAsBehavior = "\"Save as\" behavior";
+        DefaultSaveLocation = "Default save location";
+        DefaultSaveLocationSourceFileFolder = "Folder of subtitle/video file";
+        DefaultSaveLocationLastUsedFolder = "Last used folder";
+        DefaultSaveLocationVideoFileFolder = "Video file folder";
+        DefaultSaveLocationSubtitleFileFolder = "Subtitle file folder";
+        DefaultSaveLocationCustomFolder = "Custom folder";
         SaveAsAppendLanguageCode = "\"Save as\" append language code";
         GridGoToSubtitleAndSetVideoPosition = "Go to subtitle and set video position";
         GridGoToNextLine = "Go to next line";

--- a/src/ui/Logic/Config/SeGeneral.cs
+++ b/src/ui/Logic/Config/SeGeneral.cs
@@ -50,6 +50,8 @@ public class SeGeneral
     public bool SubtitleGridCenterSelectedRow { get; set; }
     public string SaveAsBehavior { get; set; }
     public string SaveAsAppendLanguageCode { get; set; }
+    public string DefaultSaveLocation { get; set; }
+    public string DefaultSaveLocationCustomFolder { get; set; }
     public bool AutoConvertToUtf8 { get; set; }
     public bool AutoGuessAnsiEncoding { get; set; }
     public int MaxNumberOfLinesPlusAbort { get; set; }
@@ -172,6 +174,8 @@ public class SeGeneral
         SubtitleDoubleClickAction = nameof(SubtitleDoubleClickActionType.GoToSubtitleAndPause);
         SubtitleGridCenterSelectedRow = false;
         SaveAsBehavior = nameof(SaveAsBehaviourType.UseVideoFileNameThenSubtitleFileName);
+        DefaultSaveLocation = nameof(DefaultSaveLocationType.SourceFileFolder);
+        DefaultSaveLocationCustomFolder = string.Empty;
         SaveAsAppendLanguageCode = nameof(SaveAsLanguageAppendType.None);
         AutoConvertToUtf8 = false;
         AutoGuessAnsiEncoding = true;


### PR DESCRIPTION
Adds a **Default save location** option to Settings → File, controlling which folder the "Save as" dialog opens in ([#12212](https://github.com/SubtitleEdit/subtitleedit/issues/12212)):

- **Folder of subtitle/video file** (default — today's behavior: the suggestion keeps the name-source file's folder)
- **Last used folder** — strips the directory from the suggestion so the OS picker opens in its own remembered folder
- **Video file folder** / **Subtitle file folder** — always that file's folder, regardless of which file the *name* came from
- **Custom folder** — fixed folder with a browse button (row enabled only when this option is selected; ignored if the folder no longer exists)

The existing "Save as behavior" (name suggestion) and "append language code" settings are untouched — this only affects the folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)