### PR TITLE
Add auto-br settings to Settings → Rules

### DIFF
--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -237,6 +237,12 @@ public class SettingsPage : UserControl
             new SettingsItem(Se.Language.Options.Settings.MaxLines, () => MakeNumericUpDownInt(nameof(_vm.MaxLines), _vm.RuleValueChanged)),
             new SettingsItem(Se.Language.Options.Settings.UnbreakSubtitlesShortThan, () => MakeNumericUpDownInt(nameof(_vm.UnbreakLinesShorterThan), _vm.RuleValueChanged)),
 
+            MakeCheckboxSetting(Se.Language.Options.Settings.AutoBreakLineEndingEarly, nameof(_vm.AutoBreakLineEndingEarly)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.AutoBreakCommaBreakEarly, nameof(_vm.AutoBreakCommaBreakEarly)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.AutoBreakDashEarly, nameof(_vm.AutoBreakDashEarly)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.AutoBreakUsePixelWidth, nameof(_vm.AutoBreakUsePixelWidth)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.AutoBreakPreferBottomHeavy, nameof(_vm.AutoBreakPreferBottomHeavy)),
+
             new SettingsItem(Se.Language.Options.Settings.DialogStyle, () => MakeComboBoxDialogStyle()),
             new SettingsItem(Se.Language.Options.Settings.ContinuationStyle, () => new StackPanel
             {

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -74,6 +74,11 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private int? _maxLines;
     [ObservableProperty] private string _colorTextTooManyLinesLabel = string.Empty;
     [ObservableProperty] private int? _unbreakLinesShorterThan;
+    [ObservableProperty] private bool _autoBreakLineEndingEarly;
+    [ObservableProperty] private bool _autoBreakCommaBreakEarly;
+    [ObservableProperty] private bool _autoBreakDashEarly;
+    [ObservableProperty] private bool _autoBreakUsePixelWidth;
+    [ObservableProperty] private bool _autoBreakPreferBottomHeavy;
 
     // "Color text if more than N lines" must track the live "Max number of lines"
     // value instead of a hardcoded "2" (#12028), including while typing (nullable/
@@ -684,6 +689,11 @@ public partial class SettingsViewModel : ObservableObject
         MinGapFrames = general.MinimumBetweenLines.Frames;
         MaxLines = general.MaxNumberOfLines;
         UnbreakLinesShorterThan = general.UnbreakLinesShorterThan;
+        AutoBreakLineEndingEarly = Se.Settings.Tools.AutoBreakLineEndingEarly;
+        AutoBreakCommaBreakEarly = Se.Settings.Tools.AutoBreakCommaBreakEarly;
+        AutoBreakDashEarly = Se.Settings.Tools.AutoBreakDashEarly;
+        AutoBreakUsePixelWidth = Se.Settings.Tools.AutoBreakUsePixelWidth;
+        AutoBreakPreferBottomHeavy = Se.Settings.Tools.AutoBreakPreferBottomHeavy;
         DialogStyle = DialogStyles.FirstOrDefault(p => p.Code == general.DialogStyle) ?? DialogStyles.First();
         ContinuationStyle = ContinuationStyles.FirstOrDefault(p => p.Code == general.ContinuationStyle) ?? ContinuationStyles.First();
         IsEditCustomContinuationStyleVisible = ContinuationStyle?.Code == nameof(Core.Enums.ContinuationStyle.Custom);
@@ -1443,6 +1453,11 @@ public partial class SettingsViewModel : ObservableObject
         general.MinimumBetweenLines.Frames = MinGapFrames ?? general.MinimumBetweenLines.Frames;
         general.MaxNumberOfLines = MaxLines ?? general.MaxNumberOfLines;
         general.UnbreakLinesShorterThan = UnbreakLinesShorterThan ?? general.UnbreakLinesShorterThan;
+        Se.Settings.Tools.AutoBreakLineEndingEarly = AutoBreakLineEndingEarly;
+        Se.Settings.Tools.AutoBreakCommaBreakEarly = AutoBreakCommaBreakEarly;
+        Se.Settings.Tools.AutoBreakDashEarly = AutoBreakDashEarly;
+        Se.Settings.Tools.AutoBreakUsePixelWidth = AutoBreakUsePixelWidth;
+        Se.Settings.Tools.AutoBreakPreferBottomHeavy = AutoBreakPreferBottomHeavy;
         general.DialogStyle = DialogStyle.Code;
         general.ContinuationStyle = ContinuationStyle.Code;
         general.CpsLineLengthStrategy = CpsLineLengthStrategy.Code;

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -110,6 +110,11 @@ public class LanguageSettings
     public string MinGapFrames { get; set; }
     public string MaxLines { get; set; }
     public string UnbreakSubtitlesShortThan { get; set; }
+    public string AutoBreakLineEndingEarly { get; set; }
+    public string AutoBreakCommaBreakEarly { get; set; }
+    public string AutoBreakDashEarly { get; set; }
+    public string AutoBreakUsePixelWidth { get; set; }
+    public string AutoBreakPreferBottomHeavy { get; set; }
     public string NewEmptyDefaultMs { get; set; }
     public string TimeCodeUpDownStepMs { get; set; }
     public string PromptBeforeDelete { get; set; }
@@ -442,6 +447,11 @@ public class LanguageSettings
         MinGapFrames = "Min gap (frames)";
         MaxLines = "Max number of lines";
         UnbreakSubtitlesShortThan = "Unbreak subtitles shorter than";
+        AutoBreakLineEndingEarly = "Auto-break early for end of sentence (.!?)";
+        AutoBreakCommaBreakEarly = "Auto-break early for comma";
+        AutoBreakDashEarly = "Auto-break early for dash (dialogs)";
+        AutoBreakUsePixelWidth = "Auto-break by pixel width";
+        AutoBreakPreferBottomHeavy = "Auto-break prefer bottom heavy";
         NewEmptyDefaultMs = "Default new subtitle duration (ms)";
         TimeCodeUpDownStepMs = "Time up/down increment (ms)";
         PromptBeforeDelete = "Prompt before delete";

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -590,6 +590,12 @@ public class Se
             Configuration.Settings.Proxy.Password = null;
         }
 
+        Configuration.Settings.Tools.AutoBreakLineEndingEarly = Settings.Tools.AutoBreakLineEndingEarly;
+        Configuration.Settings.Tools.AutoBreakCommaBreakEarly = Settings.Tools.AutoBreakCommaBreakEarly;
+        Configuration.Settings.Tools.AutoBreakDashEarly = Settings.Tools.AutoBreakDashEarly;
+        Configuration.Settings.Tools.AutoBreakUsePixelWidth = Settings.Tools.AutoBreakUsePixelWidth;
+        Configuration.Settings.Tools.AutoBreakPreferBottomHeavy = Settings.Tools.AutoBreakPreferBottomHeavy;
+
         var stt = Settings.Tools.AudioToText;
         Configuration.Settings.Tools.WhisperChoice = stt.WhisperChoice;
         Configuration.Settings.Tools.WhisperIgnoreVersion = stt.WhisperIgnoreVersion;

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -145,6 +145,13 @@ public class SeTools
 
     public List<string> FindHistory { get; set; } = new List<string>();
     public bool AllowSingleLetterShortcutsInTextbox { get; set; }
+
+    // Auto-break (auto br) - defaults must match libse ToolsSettings
+    public bool AutoBreakLineEndingEarly { get; set; } = false;
+    public bool AutoBreakCommaBreakEarly { get; set; } = false;
+    public bool AutoBreakDashEarly { get; set; } = true;
+    public bool AutoBreakUsePixelWidth { get; set; } = true;
+    public bool AutoBreakPreferBottomHeavy { get; set; } = true;
     public bool SpellCheckEnglishTreatInApostropheAsIng { get; set; } = true;
     public bool WriteToolsLog { get; set; } = false;
 


### PR DESCRIPTION
Fixes [#12923](https://github.com/SubtitleEdit/subtitleedit/issues/12923) — v5 was missing the auto-break options from 4.x. The libse auto-break logic honors `Configuration.Settings.Tools.AutoBreak*`, but the v5 UI never exposed nor mapped them, so libse always ran with its own hardcoded defaults.

**Settings → Rules** now has five checkboxes (all searchable via the settings filter):

- Auto-break early for end of sentence (.!?)
- Auto-break early for comma
- Auto-break early for dash (dialogs)
- Auto-break by pixel width
- Auto-break prefer bottom heavy

Stored in `SeTools` with defaults matching libse's, and pushed into libse in `UpdateLibSeSettings` (runs on settings load and save, so changes take effect immediately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)