### PR TITLE
Batch convert: brightness, alpha, and color adjustments for image output

### DIFF
--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAlpha/BinaryAdjustAlphaViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAlpha/BinaryAdjustAlphaViewModel.cs
@@ -5,6 +5,7 @@ using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.Logic.Config;
 using SkiaSharp;
 using System;
@@ -110,7 +111,7 @@ public partial class BinaryAdjustAlphaViewModel : ObservableObject, IDisposable
         CheckeredBackgroundBitmap = CreateCheckeredBackground(originalBitmap.Width, originalBitmap.Height);
         oldBg?.Dispose();
 
-        using var adjustedBitmap = AdjustAlpha(originalBitmap, (float)AlphaAdjustment, (byte)TransparencyThreshold);
+        using var adjustedBitmap = SubtitleImageAdjuster.AdjustAlpha(originalBitmap, (float)AlphaAdjustment, (byte)TransparencyThreshold);
         var old = PreviewBitmap;
         PreviewBitmap = adjustedBitmap.ToAvaloniaBitmap();
         old?.Dispose();
@@ -126,67 +127,13 @@ public partial class BinaryAdjustAlphaViewModel : ObservableObject, IDisposable
             }
 
             using var originalBitmap = subtitle.Bitmap.ToSkBitmap();
-            using var adjustedBitmap = AdjustAlpha(originalBitmap, (float)AlphaAdjustment, (byte)TransparencyThreshold);
+            using var adjustedBitmap = SubtitleImageAdjuster.AdjustAlpha(originalBitmap, (float)AlphaAdjustment, (byte)TransparencyThreshold);
             var old = subtitle.Bitmap;
             subtitle.Bitmap = adjustedBitmap.ToAvaloniaBitmap();
             old?.Dispose();
         }
     }
 
-    private static SKBitmap AdjustAlpha(SKBitmap premultipliedBitmap, float alphaAdjustment, byte transparencyThreshold)
-    {
-        // Work in straight alpha: changing A while leaving premultiplied R, G and B alone
-        // would produce RGB > A, which Skia renders as clipped, over-bright edges.
-        using var originalBitmap = premultipliedBitmap.ToUnpremultiplied();
-        var adjustedBitmap = new SKBitmap(originalBitmap.Width, originalBitmap.Height, SKColorType.Bgra8888, SKAlphaType.Unpremul);
-
-        unsafe
-        {
-            var originalPixels = originalBitmap.GetPixels();
-            var adjustedPixels = adjustedBitmap.GetPixels();
-
-            for (int y = 0; y < originalBitmap.Height; y++)
-            {
-                for (int x = 0; x < originalBitmap.Width; x++)
-                {
-                    var index = y * originalBitmap.Width + x;
-                    var pixel = ((uint*)originalPixels)[index];
-
-                    var a = (byte)((pixel >> 24) & 0xFF);
-                    var r = (byte)((pixel >> 16) & 0xFF);
-                    var g = (byte)((pixel >> 8) & 0xFF);
-                    var b = (byte)(pixel & 0xFF);
-                    
-                    // Skip if already fully transparent
-                    if (a == 0)
-                    {
-                        ((uint*)adjustedPixels)[index] = pixel;
-                        continue;
-                    }
-                    
-                    // Apply alpha adjustment (additive)
-                    float newAlpha = a + alphaAdjustment;
-                    
-                    // Clamp to valid range
-                    newAlpha = Math.Clamp(newAlpha, 0, 255);
-                    
-                    // Apply transparency threshold
-                    if (newAlpha < transparencyThreshold)
-                    {
-                        newAlpha = 0;
-                    }
-                    
-                    a = (byte)newAlpha;
-                    
-                    // Reconstruct pixel
-                    var adjustedPixel = (uint)((a << 24) | (r << 16) | (g << 8) | b);
-                    ((uint*)adjustedPixels)[index] = adjustedPixel;
-                }
-            }
-        }
-
-        return adjustedBitmap;
-    }
 
     public static Bitmap CreateCheckeredBackground(int width, int height)
     {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustBrightness/BinaryAdjustBrightnessViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustBrightness/BinaryAdjustBrightnessViewModel.cs
@@ -5,6 +5,7 @@ using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.Logic.Config;
 using SkiaSharp;
 using System;
@@ -113,7 +114,7 @@ public partial class BinaryAdjustBrightnessViewModel : ObservableObject, IDispos
 
         var firstSubtitle = _subtitles[0];
         using var originalBitmap = firstSubtitle.Bitmap!.ToSkBitmap();
-        using var adjustedBitmap = AdjustBrightness(originalBitmap, (float)Brightness, (float)Contrast, (float)(Gamma / 100.0));
+        using var adjustedBitmap = SubtitleImageAdjuster.AdjustBrightness(originalBitmap, (float)Brightness, (float)Contrast, (float)(Gamma / 100.0));
         var old = PreviewBitmap;
         PreviewBitmap = adjustedBitmap.ToAvaloniaBitmap();
         old?.Dispose();
@@ -129,79 +130,13 @@ public partial class BinaryAdjustBrightnessViewModel : ObservableObject, IDispos
             }
 
             using var originalBitmap = subtitle.Bitmap.ToSkBitmap();
-            using var adjustedBitmap = AdjustBrightness(originalBitmap, (float)Brightness, (float)Contrast, (float)(Gamma / 100.0));
+            using var adjustedBitmap = SubtitleImageAdjuster.AdjustBrightness(originalBitmap, (float)Brightness, (float)Contrast, (float)(Gamma / 100.0));
             var old = subtitle.Bitmap;
             subtitle.Bitmap = adjustedBitmap.ToAvaloniaBitmap();
             old?.Dispose();
         }
     }
 
-    private static SKBitmap AdjustBrightness(SKBitmap premultipliedBitmap, float brightness, float contrast, float gamma)
-    {
-        // Work in straight alpha: premultiplied color already carries the pixel's alpha, so
-        // brightening it would scale with transparency and could push RGB above A (halos).
-        using var originalBitmap = premultipliedBitmap.ToUnpremultiplied();
-        var adjustedBitmap = new SKBitmap(originalBitmap.Width, originalBitmap.Height, SKColorType.Bgra8888, SKAlphaType.Unpremul);
-
-        // Normalize values for calculations
-        var brightnessAdjust = brightness; // -100 to 100
-        var contrastAdjust = (contrast + 100) / 100.0f; // Convert -100 to 100 range to 0 to 2 multiplier
-        
-        // Build lookup table for gamma correction
-        var gammaLookup = new byte[256];
-        for (int i = 0; i < 256; i++)
-        {
-            gammaLookup[i] = (byte)Math.Clamp(Math.Pow(i / 255.0, 1.0 / gamma) * 255.0, 0, 255);
-        }
-
-        unsafe
-        {
-            var originalPixels = originalBitmap.GetPixels();
-            var adjustedPixels = adjustedBitmap.GetPixels();
-            
-            for (int y = 0; y < originalBitmap.Height; y++)
-            {
-                for (int x = 0; x < originalBitmap.Width; x++)
-                {
-                    var index = y * originalBitmap.Width + x;
-                    var pixel = ((uint*)originalPixels)[index];
-                    
-                    var a = (byte)((pixel >> 24) & 0xFF);
-                    var r = (byte)((pixel >> 16) & 0xFF);
-                    var g = (byte)((pixel >> 8) & 0xFF);
-                    var b = (byte)(pixel & 0xFF);
-                    
-                    // Skip transparent pixels
-                    if (a == 0)
-                    {
-                        ((uint*)adjustedPixels)[index] = pixel;
-                        continue;
-                    }
-                    
-                    // Apply brightness
-                    r = (byte)Math.Clamp(r + brightnessAdjust, 0, 255);
-                    g = (byte)Math.Clamp(g + brightnessAdjust, 0, 255);
-                    b = (byte)Math.Clamp(b + brightnessAdjust, 0, 255);
-                    
-                    // Apply contrast
-                    r = (byte)Math.Clamp(((r - 128) * contrastAdjust) + 128, 0, 255);
-                    g = (byte)Math.Clamp(((g - 128) * contrastAdjust) + 128, 0, 255);
-                    b = (byte)Math.Clamp(((b - 128) * contrastAdjust) + 128, 0, 255);
-                    
-                    // Apply gamma
-                    r = gammaLookup[r];
-                    g = gammaLookup[g];
-                    b = gammaLookup[b];
-                    
-                    // Reconstruct pixel
-                    var adjustedPixel = (uint)((a << 24) | (r << 16) | (g << 8) | b);
-                    ((uint*)adjustedPixels)[index] = adjustedPixel;
-                }
-            }
-        }
-
-        return adjustedBitmap;
-    }
 
     [RelayCommand]
     private void Ok()

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorViewModel.cs
@@ -7,6 +7,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Shared.ColorPicker;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.Logic.Config;
 using SkiaSharp;
 using System;
@@ -102,7 +103,7 @@ public partial class BinaryAdjustColorViewModel : ObservableObject, IDisposable
         }
 
         using var originalBitmap = _subtitles[0].Bitmap!.ToSkBitmap();
-        using var coloredBitmap = ColorBitmap(originalBitmap, SelectedColor.R, SelectedColor.G, SelectedColor.B);
+        using var coloredBitmap = SubtitleImageAdjuster.Colorize(originalBitmap, SelectedColor.R, SelectedColor.G, SelectedColor.B);
         var old = PreviewBitmap;
         PreviewBitmap = coloredBitmap.ToAvaloniaBitmap();
         old?.Dispose();
@@ -118,53 +119,13 @@ public partial class BinaryAdjustColorViewModel : ObservableObject, IDisposable
             }
 
             using var originalBitmap = subtitle.Bitmap.ToSkBitmap();
-            using var coloredBitmap = ColorBitmap(originalBitmap, SelectedColor.R, SelectedColor.G, SelectedColor.B);
+            using var coloredBitmap = SubtitleImageAdjuster.Colorize(originalBitmap, SelectedColor.R, SelectedColor.G, SelectedColor.B);
             var old = subtitle.Bitmap;
             subtitle.Bitmap = coloredBitmap.ToAvaloniaBitmap();
             old?.Dispose();
         }
     }
 
-    private static SKBitmap ColorBitmap(SKBitmap premultipliedBitmap, byte r, byte g, byte b)
-    {
-        var redPercent = r * 100.0 / 255;
-        var greenPercent = g * 100.0 / 255;
-        var bluePercent = b * 100.0 / 255;
-
-        // Work in straight alpha: the "total" brightness test below is meaningless on
-        // premultiplied color, where a faint anti-aliased pixel falls under the threshold
-        // and keeps its original color, leaving a fringe around the recolored text.
-        using var originalBitmap = premultipliedBitmap.ToUnpremultiplied();
-        var adjustedBitmap = new SKBitmap(originalBitmap.Width, originalBitmap.Height, SKColorType.Bgra8888, SKAlphaType.Unpremul);
-
-        unsafe
-        {
-            var srcPixels = originalBitmap.GetPixels();
-            var dstPixels = adjustedBitmap.GetPixels();
-
-            for (int i = 0; i < originalBitmap.Width * originalBitmap.Height; i++)
-            {
-                var pixel = ((uint*)srcPixels)[i];
-
-                var a = (byte)((pixel >> 24) & 0xFF);
-                var pr = (byte)((pixel >> 16) & 0xFF);
-                var pg = (byte)((pixel >> 8) & 0xFF);
-                var pb = (byte)(pixel & 0xFF);
-
-                int total = pr + pg + pb;
-                if (total > 100 && a > 0)
-                {
-                    pr = (byte)Math.Min(255, redPercent * total / 100);
-                    pg = (byte)Math.Min(255, greenPercent * total / 100);
-                    pb = (byte)Math.Min(255, bluePercent * total / 100);
-                }
-
-                ((uint*)dstPixels)[i] = (uint)((a << 24) | (pr << 16) | (pg << 8) | pb);
-            }
-        }
-
-        return adjustedBitmap;
-    }
 
     [RelayCommand]
     private void Ok()

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertConfig.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertConfig.cs
@@ -46,6 +46,7 @@ public class BatchConvertConfig
     public ApplyDurationLimitsSettings ApplyDurationLimits { get; set; }
     public AutoBalanceLinesSettings AutoBalanceLines { get; set; }
     public SortBySettings SortBy { get; set; }
+    public AdjustImageColorsSettings AdjustImageColors { get; set; }
 
     public BatchConvertConfig()
     {
@@ -82,6 +83,7 @@ public class BatchConvertConfig
         ApplyDurationLimits = new ApplyDurationLimitsSettings();
         AutoBalanceLines = new AutoBalanceLinesSettings();
         SortBy = new SortBySettings();
+        AdjustImageColors = new AdjustImageColorsSettings();
     }
 
     public bool IsTargetFormatImageBased =>
@@ -360,6 +362,26 @@ public class BatchConvertConfig
         public SortBySettings()
         {
             SortBy = "Number";
+        }
+    }
+
+    public class AdjustImageColorsSettings
+    {
+        public bool IsActive { get; set; }
+        public bool AdjustBrightness { get; set; }
+        public double Brightness { get; set; }
+        public double Contrast { get; set; }
+        public double Gamma { get; set; }
+        public bool AdjustAlpha { get; set; }
+        public double AlphaAdjustment { get; set; }
+        public double TransparencyThreshold { get; set; }
+        public bool AdjustColor { get; set; }
+        public Color ColorValue { get; set; }
+
+        public AdjustImageColorsSettings()
+        {
+            Gamma = 100; // 1.0
+            ColorValue = Colors.White;
         }
     }
 }

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertFunction.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertFunction.cs
@@ -61,6 +61,7 @@ public partial class BatchConvertFunction : ObservableObject
             MakeFunction(BatchConvertFunctionType.ApplyDurationLimits, Se.Language.Tools.ApplyDurationLimits.Title, ViewApplyDurationLimits.Make(vm), activeFunctions),
             MakeFunction(BatchConvertFunctionType.AutoBalanceLines, Se.Language.General.AutoBalanceLines, ViewAutoBalanceLines.Make(vm), activeFunctions),
             MakeFunction(BatchConvertFunctionType.SortBy, Se.Language.Tools.SortBy.Title, ViewSortBy.Make(vm), activeFunctions),
+            MakeFunction(BatchConvertFunctionType.AdjustImageColors, Se.Language.Tools.BatchConvert.AdjustImageColorsTitle, ViewAdjustImageColors.Make(vm), activeFunctions),
         }.ToArray();
     }
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertFunctionType.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertFunctionType.cs
@@ -27,4 +27,5 @@ public enum BatchConvertFunctionType
     ApplyDurationLimits,
     AutoBalanceLines,
     SortBy,
+    AdjustImageColors,
 }

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -178,6 +178,17 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     [ObservableProperty] private bool _mergeSameTimeMergeDialog;
     [ObservableProperty] private bool _mergeSameTimeAutoBreak;
 
+    // Adjust image brightness/alpha/color (image-based target formats only)
+    [ObservableProperty] private bool _imageAdjustBrightnessOn;
+    [ObservableProperty] private double _imageAdjustBrightness;
+    [ObservableProperty] private double _imageAdjustContrast;
+    [ObservableProperty] private double _imageAdjustGamma;
+    [ObservableProperty] private bool _imageAdjustAlphaOn;
+    [ObservableProperty] private double _imageAdjustAlpha;
+    [ObservableProperty] private double _imageAdjustAlphaThreshold;
+    [ObservableProperty] private bool _imageAdjustColorOn;
+    [ObservableProperty] private Color _imageAdjustColorValue = Colors.White;
+
     // Fix right-to-left
     [ObservableProperty] private bool _rtlFixViaUniCode;
     [ObservableProperty] private bool _rtlRemoveUniCode;
@@ -616,6 +627,17 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         Se.Settings.Tools.BatchConvert.SortBy = SelectedSortByOption?.Key ?? "Number";
         Se.Settings.Tools.BatchConvert.SortByDescending = SortByDescending;
 
+        // Adjust image brightness/alpha/color
+        Se.Settings.Tools.BatchConvert.ImageAdjustBrightnessOn = ImageAdjustBrightnessOn;
+        Se.Settings.Tools.BatchConvert.ImageAdjustBrightness = ImageAdjustBrightness;
+        Se.Settings.Tools.BatchConvert.ImageAdjustContrast = ImageAdjustContrast;
+        Se.Settings.Tools.BatchConvert.ImageAdjustGamma = ImageAdjustGamma;
+        Se.Settings.Tools.BatchConvert.ImageAdjustAlphaOn = ImageAdjustAlphaOn;
+        Se.Settings.Tools.BatchConvert.ImageAdjustAlpha = ImageAdjustAlpha;
+        Se.Settings.Tools.BatchConvert.ImageAdjustAlphaThreshold = ImageAdjustAlphaThreshold;
+        Se.Settings.Tools.BatchConvert.ImageAdjustColorOn = ImageAdjustColorOn;
+        Se.Settings.Tools.BatchConvert.ImageAdjustColorValue = ImageAdjustColorValue.ToString();
+
         // Fix right-to-left
         if (RtlFixViaUniCode)
         {
@@ -781,6 +803,20 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
 
         // Remove line breaks
         RemoveLineBreaksOnlyShortLines = Se.Settings.Tools.BatchConvert.RemoveLineBreaksOnlyShortLines;
+
+        // Adjust image brightness/alpha/color
+        ImageAdjustBrightnessOn = Se.Settings.Tools.BatchConvert.ImageAdjustBrightnessOn;
+        ImageAdjustBrightness = Se.Settings.Tools.BatchConvert.ImageAdjustBrightness;
+        ImageAdjustContrast = Se.Settings.Tools.BatchConvert.ImageAdjustContrast;
+        ImageAdjustGamma = Se.Settings.Tools.BatchConvert.ImageAdjustGamma;
+        ImageAdjustAlphaOn = Se.Settings.Tools.BatchConvert.ImageAdjustAlphaOn;
+        ImageAdjustAlpha = Se.Settings.Tools.BatchConvert.ImageAdjustAlpha;
+        ImageAdjustAlphaThreshold = Se.Settings.Tools.BatchConvert.ImageAdjustAlphaThreshold;
+        ImageAdjustColorOn = Se.Settings.Tools.BatchConvert.ImageAdjustColorOn;
+        if (Color.TryParse(Se.Settings.Tools.BatchConvert.ImageAdjustColorValue, out var imageAdjustColor))
+        {
+            ImageAdjustColorValue = imageAdjustColor;
+        }
 
         // ASSA change resolution
         AssaChangeResolutionTargetWidth = Se.Settings.Tools.BatchConvert.AssaChangeResolutionTargetWidth;
@@ -2157,6 +2193,20 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
                 IsActive = activeFunctions.Contains(BatchConvertFunctionType.SortBy),
                 SortBy = SelectedSortByOption?.Key ?? "Number",
                 Descending = SortByDescending,
+            },
+
+            AdjustImageColors = new BatchConvertConfig.AdjustImageColorsSettings
+            {
+                IsActive = activeFunctions.Contains(BatchConvertFunctionType.AdjustImageColors),
+                AdjustBrightness = ImageAdjustBrightnessOn,
+                Brightness = ImageAdjustBrightness,
+                Contrast = ImageAdjustContrast,
+                Gamma = ImageAdjustGamma,
+                AdjustAlpha = ImageAdjustAlphaOn,
+                AlphaAdjustment = ImageAdjustAlpha,
+                TransparencyThreshold = ImageAdjustAlphaThreshold,
+                AdjustColor = ImageAdjustColorOn,
+                ColorValue = ImageAdjustColorValue,
             },
         };
     }

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -1348,6 +1348,53 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         }
     }
 
+    /// <summary>
+    /// Applies the "Adjust image brightness/alpha/color" function to a source image
+    /// before export. Returns the input untouched when the function is off.
+    /// </summary>
+    private SKBitmap ApplyImageAdjustments(SKBitmap bitmap)
+    {
+        var settings = _config.AdjustImageColors;
+        if (!settings.IsActive)
+        {
+            return bitmap;
+        }
+
+        var result = bitmap;
+
+        if (settings.AdjustBrightness)
+        {
+            var old = result;
+            result = Logic.Media.SubtitleImageAdjuster.AdjustBrightness(old, (float)settings.Brightness, (float)settings.Contrast, (float)(settings.Gamma / 100.0));
+            if (!ReferenceEquals(old, bitmap))
+            {
+                old.Dispose();
+            }
+        }
+
+        if (settings.AdjustAlpha)
+        {
+            var old = result;
+            result = Logic.Media.SubtitleImageAdjuster.AdjustAlpha(old, (float)settings.AlphaAdjustment, (byte)Math.Clamp(settings.TransparencyThreshold, 0, 255));
+            if (!ReferenceEquals(old, bitmap))
+            {
+                old.Dispose();
+            }
+        }
+
+        if (settings.AdjustColor)
+        {
+            var old = result;
+            result = Logic.Media.SubtitleImageAdjuster.Colorize(old, settings.ColorValue.R, settings.ColorValue.G, settings.ColorValue.B);
+            if (!ReferenceEquals(old, bitmap))
+            {
+                old.Dispose();
+            }
+        }
+
+        return result;
+    }
+
     private void WriteToImageBasedFormat(BatchConvertItem item, IOcrSubtitle? imageSubtitle, CancellationToken cancellationToken)
     {
         if (imageSubtitle == null)
@@ -1383,7 +1430,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                 ScreenHeight = imageSubtitle.GetScreenSize(i).Height,
                 BottomTopMargin = 0,
                 LeftRightMargin = 0,
-                Bitmap = imageSubtitle.GetBitmap(i),
+                Bitmap = ApplyImageAdjustments(imageSubtitle.GetBitmap(i)),
             };
             var position = imageSubtitle.GetPosition(i);
             if (position.X >= 0 && position.Y >= 0)

--- a/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAdjustImageColors.cs
+++ b/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAdjustImageColors.cs
@@ -1,0 +1,139 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Tools.BatchConvert.FunctionViews;
+
+public static class ViewAdjustImageColors
+{
+    public static Control Make(BatchConvertViewModel vm)
+    {
+        var labelHeader = new Label
+        {
+            Content = Se.Language.Tools.BatchConvert.AdjustImageColorsTitle,
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.Bold,
+        };
+
+        var labelInfo = new TextBlock
+        {
+            Text = Se.Language.Tools.BatchConvert.AdjustImageColorsInfo,
+            Opacity = 0.7,
+            FontStyle = FontStyle.Italic,
+            TextWrapping = TextWrapping.Wrap,
+        };
+
+        var brightnessPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            VerticalAlignment = VerticalAlignment.Center,
+            Spacing = 5,
+            Children =
+            {
+                MakeCheckBox(Se.Language.Tools.ImageBasedEdit.AdjustBrightness, vm, nameof(vm.ImageAdjustBrightnessOn)),
+                MakeLabel(Se.Language.Tools.ImageBasedEdit.Brightness),
+                MakeNumericUpDown(vm, nameof(vm.ImageAdjustBrightness), nameof(vm.ImageAdjustBrightnessOn), -100, 100, 1),
+                MakeLabel(Se.Language.Tools.ImageBasedEdit.Contrast),
+                MakeNumericUpDown(vm, nameof(vm.ImageAdjustContrast), nameof(vm.ImageAdjustBrightnessOn), -100, 100, 1),
+                MakeLabel(Se.Language.Tools.ImageBasedEdit.Gamma + " (%)"),
+                MakeNumericUpDown(vm, nameof(vm.ImageAdjustGamma), nameof(vm.ImageAdjustBrightnessOn), 20, 400, 5),
+            }
+        };
+
+        var alphaPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            VerticalAlignment = VerticalAlignment.Center,
+            Spacing = 5,
+            Children =
+            {
+                MakeCheckBox(Se.Language.General.AdjustAlpha, vm, nameof(vm.ImageAdjustAlphaOn)),
+                MakeLabel(Se.Language.General.AlphaAdjustment),
+                MakeNumericUpDown(vm, nameof(vm.ImageAdjustAlpha), nameof(vm.ImageAdjustAlphaOn), -255, 255, 5),
+                MakeLabel(Se.Language.General.AlphaThreshold),
+                MakeNumericUpDown(vm, nameof(vm.ImageAdjustAlphaThreshold), nameof(vm.ImageAdjustAlphaOn), 0, 255, 5),
+            }
+        };
+
+        var colorPicker = UiUtil.MakeColorPickerButton(vm, nameof(vm.ImageAdjustColorValue));
+        colorPicker[!Control.IsEnabledProperty] = new Binding(nameof(vm.ImageAdjustColorOn)) { Source = vm };
+        var colorPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            VerticalAlignment = VerticalAlignment.Center,
+            Spacing = 5,
+            Children =
+            {
+                MakeCheckBox(Se.Language.Tools.ImageBasedEdit.AdjustColor, vm, nameof(vm.ImageAdjustColorOn)),
+                colorPicker,
+            }
+        };
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnSpacing = 10,
+            RowSpacing = 10,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        grid.Add(labelHeader, 0);
+        grid.Add(labelInfo, 1);
+        grid.Add(brightnessPanel, 2);
+        grid.Add(alphaPanel, 3);
+        grid.Add(colorPanel, 4);
+
+        return grid;
+    }
+
+    private static CheckBox MakeCheckBox(string content, BatchConvertViewModel vm, string bindingProperty)
+    {
+        return new CheckBox
+        {
+            Content = content,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 0, 10, 0),
+            [!ToggleButton.IsCheckedProperty] = new Binding(bindingProperty) { Source = vm, Mode = BindingMode.TwoWay },
+        };
+    }
+
+    private static Label MakeLabel(string content)
+    {
+        return new Label
+        {
+            Content = content,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+    }
+
+    private static NumericUpDown MakeNumericUpDown(BatchConvertViewModel vm, string bindingProperty, string enabledProperty, int minimum, int maximum, int increment)
+    {
+        return new NumericUpDown
+        {
+            Width = 130,
+            Minimum = minimum,
+            Maximum = maximum,
+            Increment = increment,
+            FormatString = "0",
+            [!NumericUpDown.ValueProperty] = new Binding(bindingProperty) { Source = vm, Mode = BindingMode.TwoWay },
+            [!Control.IsEnabledProperty] = new Binding(enabledProperty) { Source = vm },
+        };
+    }
+}

--- a/src/ui/Logic/Config/Language/Tools/LanguageBatchConvert.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageBatchConvert.cs
@@ -36,6 +36,8 @@ public class LanguageBatchConvert
     public string FontSizeBounceIn { get; set; }
     public string AssaChangeResolutionOnlyAppliesToAssa { get; set; }
     public string AssaChangeStyleTitle { get; set; }
+    public string AdjustImageColorsTitle { get; set; }
+    public string AdjustImageColorsInfo { get; set; }
     public string AssaChangeStyleFromStyle { get; set; }
     public string AssaChangeStyleToStyle { get; set; }
     public string AssaChangeStyleImportStyle { get; set; }
@@ -75,6 +77,8 @@ public class LanguageBatchConvert
         FontSizeBounceIn = "Font size bounce in";
         AssaChangeResolutionOnlyAppliesToAssa = "Only applies to Advanced Sub Station Alpha (ASSA) subtitles";
         AssaChangeStyleTitle = "Change style";
+        AdjustImageColorsTitle = "Adjust image brightness/alpha/color";
+        AdjustImageColorsInfo = "Only applies when converting image-based subtitles to an image-based format (e.g. Blu-ray sup to Blu-ray sup).";
         AssaChangeStyleFromStyle = "Change style from";
         AssaChangeStyleToStyle = "to";
         AssaChangeStyleImportStyle = "Import style...";

--- a/src/ui/Logic/Config/SeBatchConvert.cs
+++ b/src/ui/Logic/Config/SeBatchConvert.cs
@@ -105,6 +105,16 @@ public class SeBatchConvert
     public string SortBy { get; set; }
     public bool SortByDescending { get; set; }
 
+    public bool ImageAdjustBrightnessOn { get; set; }
+    public double ImageAdjustBrightness { get; set; }
+    public double ImageAdjustContrast { get; set; }
+    public double ImageAdjustGamma { get; set; } = 100;
+    public bool ImageAdjustAlphaOn { get; set; }
+    public double ImageAdjustAlpha { get; set; }
+    public double ImageAdjustAlphaThreshold { get; set; }
+    public bool ImageAdjustColorOn { get; set; }
+    public string ImageAdjustColorValue { get; set; } = "#FFFFFFFF";
+
     public SeBatchConvert()
     {
         OutputFolder = string.Empty;

--- a/src/ui/Logic/Media/SubtitleImageAdjuster.cs
+++ b/src/ui/Logic/Media/SubtitleImageAdjuster.cs
@@ -1,0 +1,175 @@
+using SkiaSharp;
+using System;
+
+namespace Nikse.SubtitleEdit.Logic.Media;
+
+/// <summary>
+/// Pixel adjustments for image-based subtitles (brightness/contrast/gamma, alpha,
+/// re-coloring). Shared by the binary-edit adjust dialogs and batch convert.
+/// All methods take a premultiplied bitmap and return a new straight-alpha bitmap.
+/// </summary>
+public static class SubtitleImageAdjuster
+{
+    public static SKBitmap AdjustBrightness(SKBitmap premultipliedBitmap, float brightness, float contrast, float gamma)
+    {
+        // Work in straight alpha: premultiplied color already carries the pixel's alpha, so
+        // brightening it would scale with transparency and could push RGB above A (halos).
+        using var originalBitmap = premultipliedBitmap.ToUnpremultiplied();
+        var adjustedBitmap = new SKBitmap(originalBitmap.Width, originalBitmap.Height, SKColorType.Bgra8888, SKAlphaType.Unpremul);
+
+        // Normalize values for calculations
+        var brightnessAdjust = brightness; // -100 to 100
+        var contrastAdjust = (contrast + 100) / 100.0f; // Convert -100 to 100 range to 0 to 2 multiplier
+
+        // Build lookup table for gamma correction
+        var gammaLookup = new byte[256];
+        for (int i = 0; i < 256; i++)
+        {
+            gammaLookup[i] = (byte)Math.Clamp(Math.Pow(i / 255.0, 1.0 / gamma) * 255.0, 0, 255);
+        }
+
+        unsafe
+        {
+            var originalPixels = originalBitmap.GetPixels();
+            var adjustedPixels = adjustedBitmap.GetPixels();
+
+            for (int y = 0; y < originalBitmap.Height; y++)
+            {
+                for (int x = 0; x < originalBitmap.Width; x++)
+                {
+                    var index = y * originalBitmap.Width + x;
+                    var pixel = ((uint*)originalPixels)[index];
+
+                    var a = (byte)((pixel >> 24) & 0xFF);
+                    var r = (byte)((pixel >> 16) & 0xFF);
+                    var g = (byte)((pixel >> 8) & 0xFF);
+                    var b = (byte)(pixel & 0xFF);
+
+                    // Skip transparent pixels
+                    if (a == 0)
+                    {
+                        ((uint*)adjustedPixels)[index] = pixel;
+                        continue;
+                    }
+
+                    // Apply brightness
+                    r = (byte)Math.Clamp(r + brightnessAdjust, 0, 255);
+                    g = (byte)Math.Clamp(g + brightnessAdjust, 0, 255);
+                    b = (byte)Math.Clamp(b + brightnessAdjust, 0, 255);
+
+                    // Apply contrast
+                    r = (byte)Math.Clamp(((r - 128) * contrastAdjust) + 128, 0, 255);
+                    g = (byte)Math.Clamp(((g - 128) * contrastAdjust) + 128, 0, 255);
+                    b = (byte)Math.Clamp(((b - 128) * contrastAdjust) + 128, 0, 255);
+
+                    // Apply gamma
+                    r = gammaLookup[r];
+                    g = gammaLookup[g];
+                    b = gammaLookup[b];
+
+                    // Reconstruct pixel
+                    var adjustedPixel = (uint)((a << 24) | (r << 16) | (g << 8) | b);
+                    ((uint*)adjustedPixels)[index] = adjustedPixel;
+                }
+            }
+        }
+
+        return adjustedBitmap;
+    }
+
+    public static SKBitmap AdjustAlpha(SKBitmap premultipliedBitmap, float alphaAdjustment, byte transparencyThreshold)
+    {
+        // Work in straight alpha: changing A while leaving premultiplied R, G and B alone
+        // would produce RGB > A, which Skia renders as clipped, over-bright edges.
+        using var originalBitmap = premultipliedBitmap.ToUnpremultiplied();
+        var adjustedBitmap = new SKBitmap(originalBitmap.Width, originalBitmap.Height, SKColorType.Bgra8888, SKAlphaType.Unpremul);
+
+        unsafe
+        {
+            var originalPixels = originalBitmap.GetPixels();
+            var adjustedPixels = adjustedBitmap.GetPixels();
+
+            for (int y = 0; y < originalBitmap.Height; y++)
+            {
+                for (int x = 0; x < originalBitmap.Width; x++)
+                {
+                    var index = y * originalBitmap.Width + x;
+                    var pixel = ((uint*)originalPixels)[index];
+
+                    var a = (byte)((pixel >> 24) & 0xFF);
+                    var r = (byte)((pixel >> 16) & 0xFF);
+                    var g = (byte)((pixel >> 8) & 0xFF);
+                    var b = (byte)(pixel & 0xFF);
+
+                    // Skip if already fully transparent
+                    if (a == 0)
+                    {
+                        ((uint*)adjustedPixels)[index] = pixel;
+                        continue;
+                    }
+
+                    // Apply alpha adjustment (additive)
+                    float newAlpha = a + alphaAdjustment;
+
+                    // Clamp to valid range
+                    newAlpha = Math.Clamp(newAlpha, 0, 255);
+
+                    // Apply transparency threshold
+                    if (newAlpha < transparencyThreshold)
+                    {
+                        newAlpha = 0;
+                    }
+
+                    a = (byte)newAlpha;
+
+                    // Reconstruct pixel
+                    var adjustedPixel = (uint)((a << 24) | (r << 16) | (g << 8) | b);
+                    ((uint*)adjustedPixels)[index] = adjustedPixel;
+                }
+            }
+        }
+
+        return adjustedBitmap;
+    }
+
+    public static SKBitmap Colorize(SKBitmap premultipliedBitmap, byte r, byte g, byte b)
+    {
+        var redPercent = r * 100.0 / 255;
+        var greenPercent = g * 100.0 / 255;
+        var bluePercent = b * 100.0 / 255;
+
+        // Work in straight alpha: the "total" brightness test below is meaningless on
+        // premultiplied color, where a faint anti-aliased pixel falls under the threshold
+        // and keeps its original color, leaving a fringe around the recolored text.
+        using var originalBitmap = premultipliedBitmap.ToUnpremultiplied();
+        var adjustedBitmap = new SKBitmap(originalBitmap.Width, originalBitmap.Height, SKColorType.Bgra8888, SKAlphaType.Unpremul);
+
+        unsafe
+        {
+            var srcPixels = originalBitmap.GetPixels();
+            var dstPixels = adjustedBitmap.GetPixels();
+
+            for (int i = 0; i < originalBitmap.Width * originalBitmap.Height; i++)
+            {
+                var pixel = ((uint*)srcPixels)[i];
+
+                var a = (byte)((pixel >> 24) & 0xFF);
+                var pr = (byte)((pixel >> 16) & 0xFF);
+                var pg = (byte)((pixel >> 8) & 0xFF);
+                var pb = (byte)(pixel & 0xFF);
+
+                int total = pr + pg + pb;
+                if (total > 100 && a > 0)
+                {
+                    pr = (byte)Math.Min(255, redPercent * total / 100);
+                    pg = (byte)Math.Min(255, greenPercent * total / 100);
+                    pb = (byte)Math.Min(255, bluePercent * total / 100);
+                }
+
+                ((uint*)dstPixels)[i] = (uint)((a << 24) | (pr << 16) | (pg << 8) | pb);
+            }
+        }
+
+        return adjustedBitmap;
+    }
+}


### PR DESCRIPTION
From the v5.2.0 plan: *brightness, alpha, and color adjustments to batch mode*.

Adds a new batch convert function **Adjust image brightness/alpha/color** that applies when converting image-based subtitles to an image-based target format (Blu-ray sup, VobSub, BDN XML, DOST, FCP, images):

- **Brightness / contrast / gamma** (gamma in %, 100 = 1.0)
- **Alpha adjustment** (additive) + **transparency threshold** (pixels below become fully transparent)
- **Re-color**: bright subtitle pixels shift toward the chosen hue; dark outlines/shadows preserved

Implementation notes:
- The three pixel transforms are extracted from the binary-edit adjust dialogs (`BinaryAdjustBrightness`/`Alpha`/`Color`) into a shared `SubtitleImageAdjuster`, and those dialogs now call it — batch and interactive behavior stay identical by construction
- Each sub-adjustment has its own enable checkbox; controls are disabled while unchecked
- Values persist in `SeBatchConvert`
- Applied in `WriteToImageBasedFormat`, i.e. only on the image→image path — a no-op for text conversions

🤖 Generated with [Claude Code](https://claude.com/claude-code)