### PR TITLE
Fix common errors: context menu with applied-rule details + rule filter

### DIFF
--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -10,6 +10,7 @@ using Nikse.SubtitleEdit.Core.Interfaces;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Config.Language.Tools;
@@ -73,6 +74,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
     private bool _previewMode = true;
     public List<int> DeleteIndices = new();
     private List<FixDisplayItem> _oldFixes = new();
+    private FixRuleDisplayItem? _currentRunningRule;
     private bool _nothingToFix;
     private bool _isAnalysing;
     private LanguageDisplayItem _oldSelectedLanguage;
@@ -604,9 +606,12 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
             if (fix.IsSelected)
             {
                 var fixCommonError = fix.GetFixCommonErrorFunction();
+                _currentRunningRule = fix;
                 fixCommonError.Fix(subtitle, this);
             }
         }
+
+        _currentRunningRule = null;
 
         Paragraphs.Clear();
         Paragraphs.AddRange(FixedSubtitle.Paragraphs.Select(p => new SubtitleLineViewModel(p, _subtitleFormat) { IsCpsColumnVisible = false }));
@@ -860,6 +865,63 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         return allowFix;
     }
 
+    [RelayCommand]
+    private async Task ShowRuleDetails()
+    {
+        var selectedFix = SelectedFix;
+        if (selectedFix == null || Window == null)
+        {
+            return;
+        }
+
+        var lineFixes = Fixes
+            .Where(f => f.Paragraph.Id == selectedFix.Paragraph.Id)
+            .OrderBy(f => f.ActionDisplay, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var sb = new StringBuilder();
+        foreach (var fix in lineFixes)
+        {
+            sb.AppendLine(fix.ActionDisplay);
+
+            if (!string.IsNullOrEmpty(fix.RuleName) && fix.RuleName != fix.ActionDisplay)
+            {
+                sb.AppendLine("  " + string.Format(_language.RuleX, fix.RuleName));
+            }
+
+            if (!string.IsNullOrEmpty(fix.RuleExample))
+            {
+                sb.AppendLine("  " + string.Format(_language.ExampleX, fix.RuleExample));
+            }
+
+            sb.AppendLine("  " + Se.Language.General.Before + ": " + fix.Before);
+            sb.AppendLine("  " + Se.Language.General.After + ": " + fix.After);
+            sb.AppendLine();
+        }
+
+        await MessageBox.Show(
+            Window,
+            string.Format(_language.AppliedRulesForLineX, selectedFix.Number),
+            sb.ToString().TrimEnd(),
+            MessageBoxButtons.OK);
+    }
+
+    [RelayCommand]
+    private void FilterBySelectedFixRule()
+    {
+        var selectedFix = SelectedFix;
+        if (selectedFix == null)
+        {
+            return;
+        }
+
+        var chip = FixChips.FirstOrDefault(c => c.Action == selectedFix.ActionDisplay);
+        if (chip != null)
+        {
+            SetFixFilter(chip);
+        }
+    }
+
     public void AddFixToListView(Paragraph p, string action, string before, string after)
     {
         if (!_previewMode)
@@ -870,7 +932,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         var oldFix = _oldFixes.FirstOrDefault(f => f.Paragraph.Id == p.Id && f.Action == action);
         var isSelected = oldFix is not { IsSelected: false };
 
-        AddFix(new FixDisplayItem(p, p.Number, action, before, after, isSelected));
+        AddFix(MakeFixDisplayItem(p, action, before, after, isSelected));
     }
 
     public void AddFixToListView(Paragraph p, string action, string before, string after, bool isChecked)
@@ -887,7 +949,20 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
             isSelected = false;
         }
 
-        AddFix(new FixDisplayItem(p, p.Number, action, before, after, isSelected));
+        AddFix(MakeFixDisplayItem(p, action, before, after, isSelected));
+    }
+
+    /// <summary>
+    /// Stamps the fix with the rule that is currently running (set by the ApplyFixes loop)
+    /// so the rule-details popup can show which step-1 rule produced it.
+    /// </summary>
+    private FixDisplayItem MakeFixDisplayItem(Paragraph p, string action, string before, string after, bool isSelected)
+    {
+        return new FixDisplayItem(p, p.Number, action, before, after, isSelected)
+        {
+            RuleName = _currentRunningRule?.Name ?? string.Empty,
+            RuleExample = _currentRunningRule?.Example ?? string.Empty,
+        };
     }
 
     public void LogStatus(string sender, string message)

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -471,6 +471,22 @@ public class FixCommonErrorsWindow : Window
         };
         AutomationProperties.SetName(dataGridFixes, Se.Language.Tools.FixCommonErrors.Fixes);
         dataGridFixes.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(_vm.SelectedFix)));
+        dataGridFixes.ContextMenu = new ContextMenu
+        {
+            Items =
+            {
+                new MenuItem
+                {
+                    Header = Se.Language.Tools.FixCommonErrors.RuleDetailsDotDotDot,
+                    Command = _vm.ShowRuleDetailsCommand,
+                },
+                new MenuItem
+                {
+                    Header = Se.Language.Tools.FixCommonErrors.ShowOnlyThisRule,
+                    Command = _vm.FilterBySelectedFixRuleCommand,
+                },
+            },
+        };
         _ = new DataGridCheckboxMultiSelect<FixDisplayItem>(dataGridFixes,
             item => item.IsSelected, (item, v) => item.IsSelected = v,
             onFocusedItemChanged: item =>

--- a/src/ui/Features/Tools/FixCommonErrors/FixDisplayItem.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixDisplayItem.cs
@@ -20,6 +20,12 @@ public partial class FixDisplayItem : ObservableObject
     [ObservableProperty] private int _number;
     public Paragraph Paragraph { get; set; }
 
+    /// <summary>Name of the rule (step 1 display item) that produced this fix.</summary>
+    public string RuleName { get; set; } = string.Empty;
+
+    /// <summary>The rule's example text from step 1, shown in the rule-details popup.</summary>
+    public string RuleExample { get; set; } = string.Empty;
+
     public FixDisplayItem(Paragraph p, int number, string action, string before, string after, bool isChecked)
     {
         Paragraph = p;

--- a/src/ui/Logic/Config/Language/Tools/LanguageFixCommonErrors.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageFixCommonErrors.cs
@@ -15,6 +15,11 @@ public class LanguageFixCommonErrors
     public string Log { get; set; }
     public string Function { get; set; }
     public string RemovedEmptyLine { get; set; }
+    public string RuleDetailsDotDotDot { get; set; }
+    public string ShowOnlyThisRule { get; set; }
+    public string AppliedRulesForLineX { get; set; }
+    public string RuleX { get; set; }
+    public string ExampleX { get; set; }
     public string RemovedEmptyLineAtTop { get; set; }
     public string RemovedEmptyLineAtBottom { get; set; }
     public string RemovedEmptyLineInMiddle { get; set; }
@@ -153,6 +158,11 @@ public class LanguageFixCommonErrors
         Log = "Log";
         Function = "Function";
         RemovedEmptyLine = "Remove empty line";
+        RuleDetailsDotDotDot = "Rule details...";
+        ShowOnlyThisRule = "Show only fixes from this rule";
+        AppliedRulesForLineX = "Applied rule(s) for line {0}";
+        RuleX = "Rule: {0}";
+        ExampleX = "Example: {0}";
         RemovedEmptyLineAtTop = "Remove empty line at top";
         RemovedEmptyLineAtBottom = "Remove empty line at bottom";
         RemovedEmptyLineInMiddle = "Remove empty line in middle";


### PR DESCRIPTION
From the v5.2.0 plan: *Fix common errors, rules view, context menu that show details about the applied rule(s)*.

Right-clicking a fix in step 2 now offers:

- **Rule details...** — popup listing every rule applied to that line: rule name, the step-1 example, and the before/after text of each fix. Each `FixDisplayItem` is stamped with the producing rule while the `ApplyFixes` loop runs (`_currentRunningRule`), so the fix→rule mapping is exact instead of guessed from the action label.
- **Show only fixes from this rule** — activates the matching filter chip (the existing per-rule chips act as the rules view; this ties the two together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)