### PR TITLE
Text to speech: custom voice models for Piper

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/Piper.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Piper.cs
@@ -143,6 +143,7 @@ public class Piper : ITtsEngine
         var json = File.ReadAllText(voiceFileName);
         var parser = new SeJsonParser();
         var arr = parser.GetRootElements(json);
+        AddCustomVoices(result);
 
         foreach (var element in arr)
         {
@@ -173,6 +174,40 @@ public class Piper : ITtsEngine
         }
 
         return result.ToArray();
+    }
+
+    /// <summary>
+    /// Lists user-added voice models (a <c>.onnx</c> + <c>.onnx.json</c> pair dropped in the
+    /// Piper folder, e.g. via "Import voice") that are not part of the official voice list.
+    /// Model/Config hold bare file names - Speak runs piper with the Piper folder as working
+    /// directory, so bare names resolve the same way as downloaded voices.
+    /// </summary>
+    private static void AddCustomVoices(List<Voice> result)
+    {
+        var knownModelNames = result
+            .Select(v => v.EngineVoice)
+            .OfType<PiperVoice>()
+            .Select(v => v.ModelShort)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var modelFileName in Directory.GetFiles(GetSetPiperFolder(), "*.onnx"))
+        {
+            var modelNameOnly = Path.GetFileName(modelFileName);
+            if (knownModelNames.Contains(modelNameOnly))
+            {
+                continue;
+            }
+
+            var configFileName = modelFileName + ".json";
+            if (!File.Exists(configFileName))
+            {
+                continue;
+            }
+
+            var voiceName = Path.GetFileNameWithoutExtension(modelFileName);
+            var piperVoice = new PiperVoice(voiceName, "Custom", "custom", modelNameOnly, Path.GetFileName(configFileName));
+            result.Add(new Voice(piperVoice));
+        }
     }
 
     public async Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken)
@@ -278,8 +313,42 @@ public class Piper : ITtsEngine
         return Task.FromResult(Array.Empty<string>());
     }
 
+    /// <summary>
+    /// Imports a custom Piper voice: a <c>.onnx</c> model with its <c>.onnx.json</c> config as
+    /// a sibling file. Both are copied into the Piper folder and the voice shows up in the
+    /// voice list (via <see cref="AddCustomVoices"/>) as "Custom - name".
+    /// </summary>
     public bool ImportVoice(string fileName)
     {
-        return false;
+        if (!fileName.EndsWith(".onnx", StringComparison.OrdinalIgnoreCase) || !File.Exists(fileName))
+        {
+            return false;
+        }
+
+        var configFileName = fileName + ".json";
+        if (!File.Exists(configFileName))
+        {
+            return false;
+        }
+
+        try
+        {
+            var piperFolder = GetSetPiperFolder();
+            var targetModel = Path.Combine(piperFolder, Path.GetFileName(fileName));
+            var targetConfig = Path.Combine(piperFolder, Path.GetFileName(configFileName));
+
+            if (!string.Equals(Path.GetFullPath(fileName), Path.GetFullPath(targetModel), StringComparison.OrdinalIgnoreCase))
+            {
+                File.Copy(fileName, targetModel, overwrite: true);
+                File.Copy(configFileName, targetConfig, overwrite: true);
+            }
+
+            return true;
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, "Failed to import Piper voice: " + fileName);
+            return false;
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
@@ -58,7 +58,17 @@ public partial class VoiceSettingsViewModel : ObservableObject
             return;
         }
 
-        var fileName = await _fileHelper.PickOpenFile(Window!, "Open audio file (for clone)", Se.Language.General.AudioFiles, "*.wav;*.mp3");
+        string fileName;
+        if (_engine is Piper)
+        {
+            // Piper voices are trained models (.onnx + .onnx.json), not audio to clone from.
+            fileName = await _fileHelper.PickOpenFile(Window!, Se.Language.Video.TextToSpeech.ImportPiperVoiceTitle, "Piper voice model", "*.onnx");
+        }
+        else
+        {
+            fileName = await _fileHelper.PickOpenFile(Window!, "Open audio file (for clone)", Se.Language.General.AudioFiles, "*.wav;*.mp3");
+        }
+
         if (string.IsNullOrEmpty(fileName))
         {
             return;
@@ -236,6 +246,19 @@ public partial class VoiceSettingsViewModel : ObservableObject
                 ? mossEngine.ImportVoice(fileName, (result.Text ?? string.Empty).Trim())
                 : mossEngine.ImportVoice(fileName);
         }
+        else if (_engine is Piper piperEngine)
+        {
+            ok = piperEngine.ImportVoice(fileName);
+            if (!ok)
+            {
+                // The only user-fixable failure: the .onnx.json config is not next to the model.
+                await MessageBox.Show(
+                    Window,
+                    Se.Language.Video.TextToSpeech.PiperVoiceConfigMissingTitle,
+                    string.Format(Se.Language.Video.TextToSpeech.PiperVoiceConfigMissingMessage, Path.GetFileName(fileName) + ".json"));
+                return;
+            }
+        }
         else
         {
             ok = _engine.ImportVoice(fileName);
@@ -259,7 +282,7 @@ public partial class VoiceSettingsViewModel : ObservableObject
             return;
         }
 
-        if (e.DataTransfer.Contains(DataFormat.File) && HasSupportedAudioFile(e))
+        if (e.DataTransfer.Contains(DataFormat.File) && HasSupportedImportFile(e))
         {
             e.DragEffects = DragDropEffects.Copy;
             IsDragOver = true;
@@ -289,7 +312,7 @@ public partial class VoiceSettingsViewModel : ObservableObject
 
         var fileName = e.DataTransfer.TryGetFiles()?
             .Select(f => f.Path.LocalPath)
-            .FirstOrDefault(IsSupportedAudioFile);
+            .FirstOrDefault(IsSupportedImportFile);
 
         if (string.IsNullOrEmpty(fileName))
         {
@@ -299,13 +322,13 @@ public partial class VoiceSettingsViewModel : ObservableObject
         Dispatcher.UIThread.PostSafe(() => ImportVoiceFromFileAsync(fileName));
     }
 
-    private static bool HasSupportedAudioFile(DragEventArgs e)
+    private bool HasSupportedImportFile(DragEventArgs e)
     {
         var files = e.DataTransfer.TryGetFiles();
-        return files != null && files.Any(f => IsSupportedAudioFile(f.Path.LocalPath));
+        return files != null && files.Any(f => IsSupportedImportFile(f.Path.LocalPath));
     }
 
-    private static bool IsSupportedAudioFile(string fileName)
+    private bool IsSupportedImportFile(string fileName)
     {
         if (string.IsNullOrEmpty(fileName))
         {
@@ -313,6 +336,13 @@ public partial class VoiceSettingsViewModel : ObservableObject
         }
 
         var ext = Path.GetExtension(fileName);
+
+        // Piper imports voice models, not audio to clone from.
+        if (_engine is Piper)
+        {
+            return string.Equals(ext, ".onnx", StringComparison.OrdinalIgnoreCase);
+        }
+
         return SupportedAudioExtensions.Any(s => string.Equals(s, ext, StringComparison.OrdinalIgnoreCase));
     }
 
@@ -388,7 +418,8 @@ public partial class VoiceSettingsViewModel : ObservableObject
     internal void Initialize(ITtsEngine engine)
     {
         _engine = engine;
-        IsImportVoiceVisible = engine.GetType() == typeof(Qwen3TtsCpp)
+        IsImportVoiceVisible = engine.GetType() == typeof(Piper)
+                               || engine.GetType() == typeof(Qwen3TtsCpp)
                                || engine.GetType() == typeof(Qwen3TtsCrispAsr)
                                || engine.GetType() == typeof(VibeVoiceCrispAsr)
                                || engine.GetType() == typeof(IndexTtsCrispAsr)

--- a/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
@@ -38,6 +38,9 @@ public class LanguageTextToSpeech
     public string ImportVoiceDotDotDot { get; set; }
     public string VoiceImportSuccessTitle { get; set; }
     public string VoiceXImported { get; set; }
+    public string ImportPiperVoiceTitle { get; set; }
+    public string PiperVoiceConfigMissingTitle { get; set; }
+    public string PiperVoiceConfigMissingMessage { get; set; }
     public string DropAudioFileHereToImportVoice { get; set; }
     public string DropAudioFileHereHint { get; set; }
     public string VoiceCloneTranscriptTitle { get; set; }
@@ -143,6 +146,9 @@ public class LanguageTextToSpeech
         ImportVoiceDotDotDot = "Import voice...";
         VoiceImportSuccessTitle = "Voice imported";
         VoiceXImported = "Voice '{0}' imported successfully";
+        ImportPiperVoiceTitle = "Open Piper voice model (.onnx)";
+        PiperVoiceConfigMissingTitle = "Config file missing";
+        PiperVoiceConfigMissingMessage = "A Piper voice needs its config file next to the model file: {0}";
         DropAudioFileHereToImportVoice = "Drop audio file here to import voice";
         DropAudioFileHereHint = ".wav or .mp3";
         VoiceCloneTranscriptTitle = "Enter transcript of the audio (required for voice cloning)";


### PR DESCRIPTION
From the v5.2.0 plan: *custom voice (Piper) on Text to Speech*.

Users can now add their own Piper voices — a trained `.onnx` model with its `.onnx.json` config (from Piper training, or third-party voices not in the official rhasspy list):

- **Import voice** is now enabled for the Piper engine, with an `.onnx` file picker (and `.onnx` drag-and-drop onto the voice settings window); model + config are copied into the Piper folder
- A missing sibling `.onnx.json` shows a clear error instead of silently failing
- `GetVoices` additionally lists any `.onnx`+`.onnx.json` pair found in the Piper folder that is not in the official voice list, shown as **Custom - <name>** — so manually dropped-in models also appear
- Synthesis works unchanged: piper already runs with bare model/config file names against the Piper folder as working directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)