### PR TITLE
Add ASSA font collector

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -293,6 +293,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<AssaImageColorPickerViewModel>();
         collection.AddTransient<AssaProgressBarViewModel>();
         collection.AddTransient<AssaPropertiesViewModel>();
+        collection.AddTransient<Features.Assa.FontCollector.FontCollectorViewModel>();
         collection.AddTransient<AssaResolutionResamplerViewModel>();
         collection.AddTransient<AssaSetPositionViewModel>();
         collection.AddTransient<AssaSingleStyleViewModel>();

--- a/src/ui/Features/Assa/FontCollector/FontCollectorItem.cs
+++ b/src/ui/Features/Assa/FontCollector/FontCollectorItem.cs
@@ -1,0 +1,29 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Assa.FontCollector;
+
+public partial class FontCollectorItem : ObservableObject
+{
+    [ObservableProperty] private string _fontName;
+    [ObservableProperty] private string _usedIn;
+    [ObservableProperty] private string _status;
+    [ObservableProperty] private string _fileDisplay;
+
+    public List<string> FoundFiles { get; } = new();
+
+    public FontCollectorItem(string fontName, string usedIn)
+    {
+        _fontName = fontName;
+        _usedIn = usedIn;
+        _status = string.Empty;
+        _fileDisplay = string.Empty;
+    }
+
+    public void UpdateFileDisplay()
+    {
+        FileDisplay = string.Join(", ", FoundFiles.Select(Path.GetFileName));
+    }
+}

--- a/src/ui/Features/Assa/FontCollector/FontCollectorViewModel.cs
+++ b/src/ui/Features/Assa/FontCollector/FontCollectorViewModel.cs
@@ -1,0 +1,300 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Assa.FontCollector;
+
+public partial class FontCollectorViewModel : ObservableObject
+{
+    [ObservableProperty] private ObservableCollection<FontCollectorItem> _fontItems;
+    [ObservableProperty] private string _statusText;
+    [ObservableProperty] private bool _isScanning;
+
+    public Window? Window { get; set; }
+
+    private static readonly Regex FontNameTagRegex = new(@"\\fn(?<name>[^\\}]+)", RegexOptions.Compiled);
+    private static readonly string[] FontFileExtensions = { ".ttf", ".otf", ".ttc", ".otc" };
+
+    private readonly IFolderHelper _folderHelper;
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+
+    public FontCollectorViewModel(IFolderHelper folderHelper)
+    {
+        _folderHelper = folderHelper;
+        FontItems = new ObservableCollection<FontCollectorItem>();
+        StatusText = string.Empty;
+    }
+
+    public void Initialize(Subtitle subtitle)
+    {
+        CollectFontNames(subtitle);
+        IsScanning = true;
+        StatusText = Se.Language.Assa.FontCollectorScanning;
+
+        var items = FontItems.ToList();
+        _ = Task.Run(() => ScanSystemFonts(items, _cancellationTokenSource.Token));
+    }
+
+    /// <summary>
+    /// Collects the font names an ASSA renderer would need: fonts of styles that are
+    /// actually used by lines, plus inline <c>\fn</c> overrides.
+    /// </summary>
+    private void CollectFontNames(Subtitle subtitle)
+    {
+        var usage = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+        void AddUsage(string fontName, string usedIn)
+        {
+            fontName = fontName.Trim().TrimStart('@'); // "@" prefix = vertical variant of the same font
+            if (fontName.Length == 0)
+            {
+                return;
+            }
+
+            if (!usage.TryGetValue(fontName, out var list))
+            {
+                list = new List<string>();
+                usage[fontName] = list;
+            }
+
+            if (!list.Contains(usedIn))
+            {
+                list.Add(usedIn);
+            }
+        }
+
+        var header = subtitle.Header ?? string.Empty;
+        var usedStyleNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var paragraph in subtitle.Paragraphs)
+        {
+            usedStyleNames.Add(string.IsNullOrEmpty(paragraph.Extra) ? "Default" : paragraph.Extra);
+
+            foreach (Match match in FontNameTagRegex.Matches(paragraph.Text))
+            {
+                AddUsage(match.Groups["name"].Value, string.Format(Se.Language.Assa.FontCollectorInlineLineX, paragraph.Number));
+            }
+        }
+
+        if (header.Contains("[V4", StringComparison.Ordinal))
+        {
+            foreach (var styleName in AdvancedSubStationAlpha.GetStylesFromHeader(header))
+            {
+                if (!usedStyleNames.Contains(styleName))
+                {
+                    continue;
+                }
+
+                var style = AdvancedSubStationAlpha.GetSsaStyle(styleName, header);
+                AddUsage(style.FontName, string.Format(Se.Language.Assa.FontCollectorStyleX, styleName));
+            }
+        }
+
+        foreach (var kvp in usage.OrderBy(p => p.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            FontItems.Add(new FontCollectorItem(kvp.Key, string.Join(", ", kvp.Value)));
+        }
+    }
+
+    /// <summary>
+    /// Scans the platform font directories and matches each font file's family/face names
+    /// against the collected font names. Skia has no file-path API, so files are read
+    /// directly; both the typographic family name and the Win32/GDI face name (what libass
+    /// matches) are checked.
+    /// </summary>
+    private void ScanSystemFonts(List<FontCollectorItem> items, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var wanted = items.ToDictionary(i => i.FontName, i => i, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var fontFile in EnumerateFontFiles())
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                // A collection (.ttc/.otc) holds several faces; plain files have one at index 0.
+                for (var index = 0; index < 30; index++)
+                {
+                    using var typeface = SKTypeface.FromFile(fontFile, index);
+                    if (typeface == null)
+                    {
+                        break;
+                    }
+
+                    var names = new[] { typeface.FamilyName, FontHelper.GetLibAssaFontName(typeface) };
+                    foreach (var name in names)
+                    {
+                        if (!string.IsNullOrEmpty(name) &&
+                            wanted.TryGetValue(name, out var item) &&
+                            !item.FoundFiles.Contains(fontFile, StringComparer.OrdinalIgnoreCase))
+                        {
+                            var file = fontFile;
+                            Dispatcher.UIThread.Post(() =>
+                            {
+                                item.FoundFiles.Add(file);
+                                item.UpdateFileDisplay();
+                                item.Status = Se.Language.Assa.FontCollectorFound;
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, "Font collector scan failed");
+        }
+        finally
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                foreach (var item in FontItems)
+                {
+                    if (item.FoundFiles.Count == 0)
+                    {
+                        item.Status = Se.Language.Assa.FontCollectorNotFound;
+                    }
+                }
+
+                IsScanning = false;
+                var foundCount = FontItems.Count(i => i.FoundFiles.Count > 0);
+                StatusText = string.Format(Se.Language.Assa.FontCollectorXOfYFontsFound, foundCount, FontItems.Count);
+            });
+        }
+    }
+
+    private static IEnumerable<string> EnumerateFontFiles()
+    {
+        foreach (var folder in GetFontFolders().Where(Directory.Exists))
+        {
+            IEnumerable<string> files;
+            try
+            {
+                files = Directory.EnumerateFiles(folder, "*.*", new EnumerationOptions
+                {
+                    RecurseSubdirectories = true,
+                    IgnoreInaccessible = true,
+                });
+            }
+            catch
+            {
+                continue;
+            }
+
+            foreach (var file in files)
+            {
+                if (FontFileExtensions.Contains(Path.GetExtension(file), StringComparer.OrdinalIgnoreCase))
+                {
+                    yield return file;
+                }
+            }
+        }
+    }
+
+    private static List<string> GetFontFolders()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var folders = new List<string>();
+
+        if (OperatingSystem.IsWindows())
+        {
+            folders.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "Fonts"));
+            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            folders.Add(Path.Combine(localAppData, "Microsoft", "Windows", "Fonts"));
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            folders.Add("/System/Library/Fonts");
+            folders.Add("/Library/Fonts");
+            folders.Add(Path.Combine(home, "Library", "Fonts"));
+        }
+        else
+        {
+            folders.Add("/usr/share/fonts");
+            folders.Add("/usr/local/share/fonts");
+            folders.Add(Path.Combine(home, ".fonts"));
+            folders.Add(Path.Combine(home, ".local", "share", "fonts"));
+        }
+
+        return folders;
+    }
+
+    [RelayCommand]
+    private async Task CopyFontsToFolder()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var files = FontItems.SelectMany(i => i.FoundFiles).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        if (files.Count == 0)
+        {
+            await MessageBox.Show(Window, Se.Language.Assa.FontCollectorTitle, Se.Language.Assa.FontCollectorNoFontsToCopy, MessageBoxButtons.OK);
+            return;
+        }
+
+        var folder = await _folderHelper.PickFolderAsync(Window, Se.Language.Assa.FontCollectorCopyFontsToFolder);
+        if (string.IsNullOrEmpty(folder))
+        {
+            return;
+        }
+
+        var copied = 0;
+        try
+        {
+            foreach (var file in files)
+            {
+                File.Copy(file, Path.Combine(folder, Path.GetFileName(file)), overwrite: true);
+                copied++;
+            }
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, "Font collector copy failed");
+            await MessageBox.Show(Window, Se.Language.General.Error, exception.Message, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return;
+        }
+
+        await MessageBox.Show(
+            Window,
+            Se.Language.Assa.FontCollectorTitle,
+            string.Format(Se.Language.Assa.FontCollectorXFontFilesCopiedToY, copied, folder),
+            MessageBoxButtons.OK);
+    }
+
+    [RelayCommand]
+    private void Close()
+    {
+        _cancellationTokenSource.Cancel();
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Close();
+        }
+    }
+}

--- a/src/ui/Features/Assa/FontCollector/FontCollectorWindow.cs
+++ b/src/ui/Features/Assa/FontCollector/FontCollectorWindow.cs
@@ -1,0 +1,116 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Assa.FontCollector;
+
+public class FontCollectorWindow : Window
+{
+    private readonly FontCollectorViewModel _vm;
+
+    public FontCollectorWindow(FontCollectorViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.Assa.FontCollectorTitle;
+        CanResize = true;
+        Width = 800;
+        Height = 500;
+        MinWidth = 600;
+        MinHeight = 400;
+        WindowStartupLocation = WindowStartupLocation.CenterOwner;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        var dataGrid = new DataGrid
+        {
+            AutoGenerateColumns = false,
+            CanUserResizeColumns = true,
+            CanUserSortColumns = true,
+            IsReadOnly = true,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            Width = double.NaN,
+            Height = double.NaN,
+            DataContext = vm,
+            ItemsSource = vm.FontItems,
+            Columns =
+            {
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.FontName,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(FontCollectorItem.FontName)),
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.Assa.FontCollectorUsedIn,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(FontCollectorItem.UsedIn)),
+                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.General.Status,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(FontCollectorItem.Status)),
+                },
+                new DataGridTextColumn
+                {
+                    Header = Se.Language.Assa.FontCollectorFontFiles,
+                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Binding = new Binding(nameof(FontCollectorItem.FileDisplay)),
+                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
+                },
+            },
+        };
+
+        var statusText = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            Opacity = 0.8,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.StatusText)),
+        };
+
+        var buttonCopy = UiUtil.MakeButton(Se.Language.Assa.FontCollectorCopyFontsToFolderDotDotDot, vm.CopyFontsToFolderCommand);
+        var buttonBar = UiUtil.MakeButtonBar(
+            buttonCopy,
+            UiUtil.MakeButtonDone(vm.CloseCommand));
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            RowSpacing = 5,
+            ColumnSpacing = 5,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        grid.Add(dataGrid, 0, 0, 1, 2);
+        grid.Add(statusText, 1, 0);
+        grid.Add(buttonBar, 1, 1);
+
+        Content = grid;
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -912,6 +912,11 @@ public static class InitMenu
             },
             new MenuItem
             {
+                Header = l.AssaFontCollector,
+                Command = vm.ShowAssaFontCollectorCommand,
+            },
+            new MenuItem
+            {
                 Header = l.AssaProperties,
                 Command = vm.ShowAssaPropertiesCommand,
             },

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -416,6 +416,7 @@ public static class InitNativeMacMenu
             Item(Clean(l.AssaApplyAdvancedEffects), v => v.ShowAssaApplyAdvancedEffectCommand),
             Item(Clean(l.AssaApplyCustomOverrideTags), v => v.ShowAssaApplyCustomOverrideTagsCommand),
             Item(Clean(l.AssaDraw), v => v.ShowAssaDrawCommand),
+            Item(Clean(l.AssaFontCollector), v => v.ShowAssaFontCollectorCommand),
             Item(Clean(l.AssaProperties), v => v.ShowAssaPropertiesCommand),
             Item(Clean(l.AssaAttachments), v => v.ShowAssaAttachmentsCommand),
             Item(Clean(l.AssaStyles), v => v.ShowAssaStylesCommand),

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1407,6 +1407,20 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private async Task ShowAssaFontCollector()
+    {
+        if (Window == null || !IsFormatAssa)
+        {
+            return;
+        }
+
+        await ShowDialogAsync<Features.Assa.FontCollector.FontCollectorWindow, Features.Assa.FontCollector.FontCollectorViewModel>(vm =>
+        {
+            vm.Initialize(GetUpdateSubtitle());
+        });
+    }
+
+    [RelayCommand]
     private async Task ShowAssaProperties()
     {
         if (Window == null || !IsFormatAssa)

--- a/src/ui/Logic/Config/Language/Assa/LanguageAssa.cs
+++ b/src/ui/Logic/Config/Language/Assa/LanguageAssa.cs
@@ -46,6 +46,21 @@ public class LanguageAssa
     public string ProgressBarTakePosFromVideo { get; set; }
     public string ProgressBarPreview { get; set; }
 
+    // Font collector
+    public string FontCollectorTitle { get; set; }
+    public string FontCollectorUsedIn { get; set; }
+    public string FontCollectorFontFiles { get; set; }
+    public string FontCollectorStyleX { get; set; }
+    public string FontCollectorInlineLineX { get; set; }
+    public string FontCollectorFound { get; set; }
+    public string FontCollectorNotFound { get; set; }
+    public string FontCollectorScanning { get; set; }
+    public string FontCollectorXOfYFontsFound { get; set; }
+    public string FontCollectorCopyFontsToFolder { get; set; }
+    public string FontCollectorCopyFontsToFolderDotDotDot { get; set; }
+    public string FontCollectorNoFontsToCopy { get; set; }
+    public string FontCollectorXFontFilesCopiedToY { get; set; }
+
     // Resolution Resampler
     public string ResolutionResamplerTitle { get; set; }
     public string ResolutionResamplerSourceRes { get; set; }
@@ -260,6 +275,19 @@ public class LanguageAssa
         ProgressBarPreview = "Preview";
 
         // Resolution Resampler
+        FontCollectorTitle = "Font collector";
+        FontCollectorUsedIn = "Used in";
+        FontCollectorFontFiles = "Font file(s)";
+        FontCollectorStyleX = "Style: {0}";
+        FontCollectorInlineLineX = "Line {0}";
+        FontCollectorFound = "Found";
+        FontCollectorNotFound = "Not found";
+        FontCollectorScanning = "Scanning installed fonts...";
+        FontCollectorXOfYFontsFound = "{0} of {1} fonts found";
+        FontCollectorCopyFontsToFolder = "Copy fonts to folder";
+        FontCollectorCopyFontsToFolderDotDotDot = "Copy fonts to folder...";
+        FontCollectorNoFontsToCopy = "No font files found to copy.";
+        FontCollectorXFontFilesCopiedToY = "{0} font file(s) copied to {1}";
         ResolutionResamplerTitle = "Change resolution";
         ResolutionResamplerSourceRes = "Source resolution";
         ResolutionResamplerTargetRes = "Target resolution";

--- a/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
@@ -81,6 +81,7 @@ public class LanguageMainMenu
     public string AssaStyles { get; set; }
     public string AssaProperties { get; set; }
     public string AssaAttachments { get; set; }
+    public string AssaFontCollector { get; set; }
 
 
     public string SpellCheckTitle { get; set; }
@@ -220,6 +221,7 @@ public class LanguageMainMenu
         AssaStyles = "S_tyles...";
         AssaProperties = "P_roperties...";
         AssaAttachments = "_Attachments...";
+        AssaFontCollector = "_Font collector...";
 
         SpellCheckTitle = "_Spell check";
         FindDoubleWords = "_Find double words...";


### PR DESCRIPTION
From the v5.2.0 plan: *ASSA font collector*.

New ASSA tool (**ASSA menu → Font collector...**, shown for ASSA subtitles) that collects the fonts a renderer needs — like Aegisub's font collector:

- Gathers fonts from **styles actually used by lines** plus inline **`\fn` overrides**, with a *Used in* column (style names / line numbers)
- Scans the platform font directories in the background (Windows: `C:\Windows\Fonts` + per-user; macOS: system/library/user; Linux: `/usr/share/fonts` etc. + user dirs), matching each file's **typographic family name** and **Win32/GDI face name** (the name libass matches) against the collected names; `.ttc`/`.otc` collections are enumerated per face
- Status column shows found / not found, plus the matching font file(s)
- **Copy fonts to folder...** copies all found files to a picked folder (for muxing into an mkv or shipping alongside the subtitle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)