### PR TITLE
Move Google Cloud Vision OCR service and Http downloader to libuilogic

### DIFF
--- a/src/libuilogic/AutoTranslate/GoogleTranslateV2.cs
+++ b/src/libuilogic/AutoTranslate/GoogleTranslateV2.cs
@@ -1,5 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
-using Nikse.SubtitleEdit.Core.Http;
+using Nikse.SubtitleEdit.UiLogic.Http;
 using Nikse.SubtitleEdit.UiLogic.Translate;
 using System;
 using System.Collections.Generic;

--- a/src/libuilogic/AutoTranslate/MicrosoftTranslator.cs
+++ b/src/libuilogic/AutoTranslate/MicrosoftTranslator.cs
@@ -1,5 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
-using Nikse.SubtitleEdit.Core.Http;
+using Nikse.SubtitleEdit.UiLogic.Http;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.UiLogic.Translate;
 using System;

--- a/src/libuilogic/AutoTranslate/NoLanguageLeftBehindApi.cs
+++ b/src/libuilogic/AutoTranslate/NoLanguageLeftBehindApi.cs
@@ -1,5 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
-using Nikse.SubtitleEdit.Core.Http;
+using Nikse.SubtitleEdit.UiLogic.Http;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.UiLogic.Translate;
 using System;

--- a/src/libuilogic/Http/DownloaderFactory.cs
+++ b/src/libuilogic/Http/DownloaderFactory.cs
@@ -4,7 +4,7 @@ using System.Net.Http;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Settings;
 
-namespace Nikse.SubtitleEdit.Core.Http
+namespace Nikse.SubtitleEdit.UiLogic.Http
 {
     public static class DownloaderFactory
     {

--- a/src/libuilogic/Http/HttpClientDownloader.cs
+++ b/src/libuilogic/Http/HttpClientDownloader.cs
@@ -7,7 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Nikse.SubtitleEdit.Core.Http
+namespace Nikse.SubtitleEdit.UiLogic.Http
 {
     public class HttpClientDownloader : IDownloader
     {

--- a/src/libuilogic/Http/IDownloader.cs
+++ b/src/libuilogic/Http/IDownloader.cs
@@ -5,7 +5,7 @@ using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Nikse.SubtitleEdit.Core.Http
+namespace Nikse.SubtitleEdit.UiLogic.Http
 {
     public interface IDownloader : IDisposable
     {

--- a/src/libuilogic/Http/LegacyDownloader.cs
+++ b/src/libuilogic/Http/LegacyDownloader.cs
@@ -9,7 +9,7 @@ using Nikse.SubtitleEdit.Core.Common;
 
 #pragma warning disable SYSLIB0014 // this downloader intentionally uses the legacy WebRequest/WebClient stack (Settings.General.UseLegacyDownloader fallback)
 
-namespace Nikse.SubtitleEdit.Core.Http
+namespace Nikse.SubtitleEdit.UiLogic.Http
 {
     public class LegacyDownloader : IDownloader
     {

--- a/src/libuilogic/Ocr/OcrHelper.cs
+++ b/src/libuilogic/Ocr/OcrHelper.cs
@@ -1,7 +1,7 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using System;
 
-namespace Nikse.SubtitleEdit.Core.VobSub.Ocr
+namespace Nikse.SubtitleEdit.UiLogic.Ocr
 {
     public static class OcrHelper
     {

--- a/src/libuilogic/Ocr/Service/GoogleCloudVisionApi.cs
+++ b/src/libuilogic/Ocr/Service/GoogleCloudVisionApi.cs
@@ -1,5 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
-using Nikse.SubtitleEdit.Core.Http;
+using Nikse.SubtitleEdit.UiLogic.Http;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
@@ -12,7 +12,7 @@ using System.Runtime.Serialization;
 using System.Runtime.Serialization.Json;
 using System.Text;
 
-namespace Nikse.SubtitleEdit.Core.VobSub.Ocr.Service
+namespace Nikse.SubtitleEdit.UiLogic.Ocr.Service
 {
     /// <summary>
     /// OCR via Google Cloud Vision API - see https://cloud.google.com/vision/docs/ocr

--- a/src/libuilogic/Ocr/Service/GoogleOcrService.cs
+++ b/src/libuilogic/Ocr/Service/GoogleOcrService.cs
@@ -1,7 +1,7 @@
 ﻿using SkiaSharp;
 using System.Collections.Generic;
 
-namespace Nikse.SubtitleEdit.Core.VobSub.Ocr.Service
+namespace Nikse.SubtitleEdit.UiLogic.Ocr.Service
 {
     public class GoogleOcrService : IOcrStrategy
     {

--- a/src/libuilogic/Ocr/Service/IOcrStrategy.cs
+++ b/src/libuilogic/Ocr/Service/IOcrStrategy.cs
@@ -1,7 +1,7 @@
 ﻿using SkiaSharp;
 using System.Collections.Generic;
 
-namespace Nikse.SubtitleEdit.Core.VobSub.Ocr.Service
+namespace Nikse.SubtitleEdit.UiLogic.Ocr.Service
 {
     public interface IOcrStrategy
     {

--- a/src/libuilogic/Ocr/Service/OcrException.cs
+++ b/src/libuilogic/Ocr/Service/OcrException.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net;
 
-namespace Nikse.SubtitleEdit.Core.VobSub.Ocr.Service
+namespace Nikse.SubtitleEdit.UiLogic.Ocr.Service
 {
     public class OcrException : Exception
     {

--- a/src/libuilogic/Ocr/Service/OcrLanguage.cs
+++ b/src/libuilogic/Ocr/Service/OcrLanguage.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
 using Nikse.SubtitleEdit.Core.Common;
 
-namespace Nikse.SubtitleEdit.Core.VobSub.Ocr.Service
+namespace Nikse.SubtitleEdit.UiLogic.Ocr.Service
 {
     public class OcrLanguage
     {

--- a/src/ui/Features/Ocr/Engines/GoogleVisionOcr.cs
+++ b/src/ui/Features/Ocr/Engines/GoogleVisionOcr.cs
@@ -1,6 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
-using Nikse.SubtitleEdit.Core.VobSub.Ocr;
-using Nikse.SubtitleEdit.Core.VobSub.Ocr.Service;
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+using Nikse.SubtitleEdit.UiLogic.Ocr.Service;
 using Nikse.SubtitleEdit.Logic;
 using SkiaSharp;
 using System;

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -14,7 +14,7 @@ using Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Core.VobSub;
-using Nikse.SubtitleEdit.Core.VobSub.Ocr.Service;
+using Nikse.SubtitleEdit.UiLogic.Ocr.Service;
 using Nikse.SubtitleEdit.Features.Files.ImportImages;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Ocr.BinaryOcr;

--- a/tests/libuilogic/GoogleCloudVision/GoogleCloudVisionJsonToLinesTest.cs
+++ b/tests/libuilogic/GoogleCloudVision/GoogleCloudVisionJsonToLinesTest.cs
@@ -1,8 +1,8 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
-using Nikse.SubtitleEdit.Core.VobSub.Ocr.Service;
+using Nikse.SubtitleEdit.UiLogic.Ocr.Service;
 using System;
 
-namespace LibSETests.GoogleCloudVision;
+namespace LibUiLogicTests.GoogleCloudVision;
 
 public class GoogleCloudVisionJsonToLinesTest
 {


### PR DESCRIPTION
Third step of stripping app logic out of **libse** (stacked on #12943 → #12941; GitHub retargets as they merge, so only this PR's own diff is shown).

## Moved
- `libse/VobSub/Ocr/` → `libuilogic/Ocr/` — `OcrHelper` joins the existing OCR code (`Nikse.SubtitleEdit.UiLogic.Ocr`), and the `Service/` classes (`GoogleCloudVisionApi`, `GoogleOcrService`, `IOcrStrategy`, `OcrException`, `OcrLanguage`) land in `libuilogic/Ocr/Service/`. They call an external OCR web service and had exactly two consumers, both ui OCR code (`GoogleVisionOcr` engine, `OcrViewModel`) — nothing in libse used them. With this, all OCR engine code lives in libuilogic.
- `libse/Http/` → `libuilogic/Http/` (`IDownloader`, `HttpClientDownloader`, `LegacyDownloader`, `DownloaderFactory`). `GoogleCloudVisionApi` was its **last** libse consumer — the others are AutoTranslate engines that moved in #12943 — so the proxy-aware downloader goes with it rather than sitting orphaned in the NuGet package.
- `GoogleCloudVisionJsonToLinesTest` moves from LibSETests to LibUiLogicTests (libse suite 745 → 743, libuilogic 18 → 20).

All `git mv` (11 renames), using-statement swaps only in the 5 modified consumer files.

## Left in libse, on purpose
- `ProxySettings` — plain data, still read by the moved downloader and the proxy helpers below.
- `Common/HttpClientFactoryWithProxy` + `BypassingWebProxy` — used by ~28 files (all libuilogic/ui after this PR, zero in libse). Candidate for a follow-up move to `UiLogic.Http`, but it touches every AutoTranslate engine's usings, so kept out of this diff.

## Verified
- `dotnet build`: libse standalone (both TFMs incl. netstandard2.1), libuilogic, UI, seconv — all clean
- All tests pass: libse 743, libuilogic 20, seconv 279, UI 932 (total unchanged: 1,974)

🤖 Generated with [Claude Code](https://claude.com/claude-code)