### PR TITLE
Trim libse GeneralSettings/ToolsSettings to what the library reads

### DIFF
--- a/src/libse/Settings/GeneralSettings.cs
+++ b/src/libse/Settings/GeneralSettings.cs
@@ -1,90 +1,26 @@
 using Nikse.SubtitleEdit.Core.Common;
-using Nikse.SubtitleEdit.Core.Common.TextLengthCalculator;
 using Nikse.SubtitleEdit.Core.Enums;
-using SkiaSharp;
 using System;
-using System.Collections.Generic;
 
 namespace Nikse.SubtitleEdit.Core.Settings
 {
     public class GeneralSettings
     {
-        public List<RulesProfile> Profiles { get; set; }
-        public string CurrentProfile { get; set; }
-        public bool ShowToolbarNew { get; set; }
-        public bool ShowToolbarOpen { get; set; }
-        public bool ShowToolbarOpenVideo { get; set; }
-        public bool ShowToolbarSave { get; set; }
-        public bool ShowToolbarSaveAs { get; set; }
-        public bool ShowToolbarFind { get; set; }
-        public bool ShowToolbarReplace { get; set; }
-        public bool ShowToolbarFixCommonErrors { get; set; }
-        public bool ShowToolbarRemoveTextForHi { get; set; }
-        public bool ShowToolbarToggleSourceView { get; set; }
-        public bool ShowToolbarVisualSync { get; set; }
-        public bool ShowToolbarBurnIn { get; set; }
-        public bool ShowToolbarSpellCheck { get; set; }
-        public bool ShowToolbarNetflixGlyphCheck { get; set; }
-        public bool ShowToolbarBeautifyTimeCodes { get; set; }
-        public bool ShowToolbarSettings { get; set; }
-        public bool ShowToolbarHelp { get; set; }
 
-        public int LayoutNumber { get; set; }
-        public string LayoutSizes { get; set; }
-        public bool ShowVideoPlayer { get; set; }
-        public bool ShowAudioVisualizer { get; set; }
-        public bool ShowWaveform { get; set; }
-        public bool ShowSpectrogram { get; set; }
-        public bool CombineSpectrogramAndWaveform { get; set; }
-        public bool ShowFrameRate { get; set; }
-        public bool ShowVideoControls { get; set; }
-        public bool TextAndOrigianlTextBoxesSwitched { get; set; }
         public double DefaultFrameRate { get; set; }
         public double CurrentFrameRate { get; set; }
         public string DefaultSubtitleFormat { get; set; }
-        public string DefaultSaveAsFormat { get; set; }
         public string FavoriteSubtitleFormats { get; set; }
         public string DefaultEncoding { get; set; }
-        public bool AutoConvertToUtf8 { get; set; }
         public bool AutoGuessAnsiEncoding { get; set; }
-        public string TranslationAutoSuffixes { get; set; }
-        public string TranslationAutoSuffixDefault { get; set; }
-        public string SystemSubtitleFontNameOverride { get; set; }
-        public int SystemSubtitleFontSizeOverride { get; set; }
 
-        public string SubtitleFontName { get; set; }
-        public int SubtitleTextBoxFontSize { get; set; }
-        public bool SubtitleTextBoxSyntaxColor { get; set; }
-        public SKColor SubtitleTextBoxHtmlColor { get; set; }
-        public SKColor SubtitleTextBoxAssColor { get; set; }
-        public int SubtitleListViewFontSize { get; set; }
-        public bool SubtitleTextBoxFontBold { get; set; }
-        public bool SubtitleListViewFontBold { get; set; }
-        public SKColor SubtitleFontColor { get; set; }
-        public SKColor SubtitleBackgroundColor { get; set; }
-        public string MeasureFontName { get; set; }
-        public int MeasureFontSize { get; set; }
-        public bool MeasureFontBold { get; set; }
         public int SubtitleLineMaximumPixelWidth { get; set; }
-        public bool CenterSubtitleInTextBox { get; set; }
-        public bool ShowRecentFiles { get; set; }
-        public bool RememberSelectedLine { get; set; }
-        public bool StartLoadLastFile { get; set; }
-        public bool StartRememberPositionAndSize { get; set; }
-        public string StartPosition { get; set; }
-        public string StartSize { get; set; }
-        public bool StartInSourceView { get; set; }
-        public bool RemoveBlankLinesWhenOpening { get; set; }
-        public bool RemoveBadCharsWhenOpening { get; set; }
         public int SubtitleLineMaximumLength { get; set; }
         public int MaxNumberOfLines { get; set; }
-        public int MaxNumberOfLinesPlusAbort { get; set; }
         public int MergeLinesShorterThan { get; set; }
         public int SubtitleMinimumDisplayMilliseconds { get; set; }
         public int SubtitleMaximumDisplayMilliseconds { get; set; }
         public int MinimumMillisecondsBetweenLines { get; set; }
-        public int SetStartEndHumanDelay { get; set; }
-        public bool AutoWrapLineWhileTyping { get; set; }
         public double SubtitleMaximumCharactersPerSeconds { get; set; }
         public double SubtitleOptimalCharactersPerSeconds { get; set; }
         public string CpsLineLengthStrategy { get; set; }
@@ -110,211 +46,38 @@ namespace Nikse.SubtitleEdit.Core.Settings
         public bool FixContinuationStyleUncheckInsertsLowercase { get; set; }
         public bool FixContinuationStyleHideContinuationCandidatesWithoutName { get; set; }
         public bool FixContinuationStyleIgnoreLyrics { get; set; }
-        public string SpellCheckLanguage { get; set; }
-        public string VideoPlayer { get; set; }
-        public int VideoPlayerDefaultVolume { get; set; }
         public string VideoPlayerPreviewFontName { get; set; }
         public int VideoPlayerPreviewFontSize { get; set; }
-        public int VideoPlayerPreviewBoxHeight { get; set; }
         public bool VideoPlayerPreviewFontBold { get; set; }
-        public bool VideoPlayerShowStopButton { get; set; }
-        public bool VideoPlayerShowFullscreenButton { get; set; }
-        public bool VideoPlayerShowMuteButton { get; set; }
-        public string Language { get; set; }
-        public string ListViewLineSeparatorString { get; set; }
-        public int ListViewDoubleClickAction { get; set; }
-        public string SaveAsUseFileNameFrom { get; set; }
         public string UppercaseLetters { get; set; }
-        public int DefaultAdjustMilliseconds { get; set; }
-        public bool AutoRepeatOn { get; set; }
-        public int AutoRepeatCount { get; set; }
-        public bool AutoContinueOn { get; set; }
-        public int AutoContinueDelay { get; set; }
-        public bool ReturnToStartAfterRepeat { get; set; }
-        public bool SyncListViewWithVideoWhilePlaying { get; set; }
-        public int AutoBackupSeconds { get; set; }
-        public int AutoBackupDeleteAfterMonths { get; set; }
-        public string SpellChecker { get; set; }
-        public bool AllowEditOfOriginalSubtitle { get; set; }
-        public bool PromptDeleteLines { get; set; }
-        public bool Undocked { get; set; }
-        public string UndockedVideoPosition { get; set; }
-        public bool UndockedVideoFullscreen { get; set; }
-        public string UndockedWaveformPosition { get; set; }
-        public string UndockedVideoControlsPosition { get; set; }
-        public bool WaveformCenter { get; set; }
-        public bool WaveformAutoGenWhenOpeningVideo { get; set; }
-        public int WaveformUpdateIntervalMs { get; set; }
-        public int SmallDelayMilliseconds { get; set; }
-        public int LargeDelayMilliseconds { get; set; }
-        public bool ShowOriginalAsPreviewIfAvailable { get; set; }
-        public int LastPacCodePage { get; set; }
-        public string OpenSubtitleExtraExtensions { get; set; }
-        public bool ListViewColumnsRememberSize { get; set; }
 
-        public int ListViewNumberWidth { get; set; }
-        public int ListViewStartWidth { get; set; }
-        public int ListViewEndWidth { get; set; }
-        public int ListViewDurationWidth { get; set; }
-        public int ListViewCpsWidth { get; set; }
-        public int ListViewWpmWidth { get; set; }
-        public int ListViewGapWidth { get; set; }
-        public int ListViewActorWidth { get; set; }
-        public int ListViewRegionWidth { get; set; }
-        public int ListViewTextWidth { get; set; }
-
-        public int ListViewNumberDisplayIndex { get; set; } = -1;
-        public int ListViewStartDisplayIndex { get; set; } = -1;
-        public int ListViewEndDisplayIndex { get; set; } = -1;
-        public int ListViewDurationDisplayIndex { get; set; } = -1;
-        public int ListViewCpsDisplayIndex { get; set; } = -1;
-        public int ListViewWpmDisplayIndex { get; set; } = -1;
-        public int ListViewGapDisplayIndex { get; set; } = -1;
-        public int ListViewActorDisplayIndex { get; set; } = -1;
-        public int ListViewRegionDisplayIndex { get; set; } = -1;
-        public int ListViewTextDisplayIndex { get; set; } = -1;
-
-        public bool DirectShowDoubleLoad { get; set; }
         public string VlcWaveTranscodeSettings { get; set; }
-        public string VlcLocation { get; set; }
-        public string VlcLocationRelative { get; set; }
-        public string MpvVideoOutputWindows { get; set; }
-        public string MpvVideoOutputLinux { get; set; }
-        public string MpvVideoVf { get; set; }
-        public string MpvVideoAf { get; set; }
-        public string MpvExtraOptions { get; set; }
-        public bool MpvLogging { get; set; }
-        public bool MpvHandlesPreviewText { get; set; }
-        public SKColor MpvPreviewTextPrimaryColor { get; set; }
-        public SKColor MpvPreviewTextOutlineColor { get; set; }
-        public SKColor MpvPreviewTextBackgroundColor { get; set; }
-        public decimal MpvPreviewTextOutlineWidth { get; set; }
-        public decimal MpvPreviewTextShadowWidth { get; set; }
-        public bool MpvPreviewTextOpaqueBox { get; set; }
-        public string MpvPreviewTextOpaqueBoxStyle { get; set; }
-        public string MpvPreviewTextAlignment { get; set; }
-        public int MpvPreviewTextMarginVertical { get; set; }
-        public string MpcHcLocation { get; set; }
-        public string MkvMergeLocation { get; set; }
         public bool UseFFmpegForWaveExtraction { get; set; }
         public bool FFmpegUseCenterChannelOnly { get; set; }
         public string FFmpegLocation { get; set; }
-        public string FFmpegSceneThreshold { get; set; }
         public bool UseTimeFormatHHMMSSFF { get; set; }
-        public int SplitBehavior { get; set; }
         public bool SplitRemovesDashes { get; set; }
-        public int ClearStatusBarAfterSeconds { get; set; }
-        public string Company { get; set; }
-        public bool MoveVideo100Or500MsPlaySmallSample { get; set; }
-        public bool DisableVideoAutoLoading { get; set; }
-        public bool DisableShowingLoadErrors { get; set; }
-        public bool AllowVolumeBoost { get; set; }
         public int NewEmptyDefaultMs { get; set; }
-        public bool NewEmptyUseAutoDuration { get; set; }
         public bool RightToLeftMode { get; set; }
-        public string LastSaveAsFormat { get; set; }
-        public bool CheckForUpdates { get; set; }
-        public DateTime LastCheckForUpdates { get; set; }
-        public bool AutoSave { get; set; }
-        public string PreviewAssaText { get; set; }
-        public string TagsInToggleHiTags { get; set; }
-        public string TagsInToggleCustomTags { get; set; }
-        public bool ShowProgress { get; set; }
-        public bool ShowNegativeDurationInfoOnSave { get; set; }
-        public bool ShowFormatRequiresUtf8Warning { get; set; }
-        public long DefaultVideoOffsetInMs { get; set; }
-        public string DefaultVideoOffsetInMsList { get; set; }
-        public long CurrentVideoOffsetInMs { get; set; }
         public bool CurrentVideoIsSmpte { get; set; }
-        public bool AutoSetVideoSmpteForTtml { get; set; }
-        public bool AutoSetVideoSmpteForTtmlPrompt { get; set; }
-        public string TitleBarAsterisk { get; set; } // Show asteriks "before" or "after" file name (any other value will hide asteriks)
         public bool TitleBarFullFileName { get; set; } // Show full file name with path or just file name
-        public bool MeasurementConverterCloseOnInsert { get; set; }
-        public string MeasurementConverterCategories { get; set; }
-        public bool SubtitleTextBoxAutoVerticalScrollBars { get; set; }
-        public int SubtitleTextBoxMaxHeight { get; set; }
-        public bool AllowLetterShortcutsInTextBox { get; set; }
-        public SKColor DarkThemeForeColor { get; set; }
-        public SKColor DarkThemeBackColor { get; set; }
-        public SKColor DarkThemeSelectedBackgroundColor { get; set; }
-        public SKColor DarkThemeDisabledColor { get; set; }
-        public SKColor LastColorPickerColor { get; set; }
-        public SKColor LastColorPickerColor1 { get; set; }
-        public SKColor LastColorPickerColor2 { get; set; }
-        public SKColor LastColorPickerColor3 { get; set; }
-        public SKColor LastColorPickerColor4 { get; set; }
-        public SKColor LastColorPickerColor5 { get; set; }
-        public SKColor LastColorPickerColor6 { get; set; }
-        public SKColor LastColorPickerColor7 { get; set; }
-        public SKColor LastColorPickerDropper { get; set; }
-        public string ToolbarIconTheme { get; set; }
-        public bool UseDarkTheme { get; set; }
-        public bool DarkThemeShowListViewGridLines { get; set; }
-        public bool ShowBetaStuff { get; set; }
-        public bool DebugTranslationSync { get; set; }
         public bool UseLegacyDownloader { get; set; }
-        public bool UseLegacyHtmlColor { get; set; } = true;
         public string DefaultLanguages { get; set; }
 
         public GeneralSettings()
         {
-            ShowToolbarNew = true;
-            ShowToolbarOpen = true;
-            ShowToolbarSave = true;
-            ShowToolbarSaveAs = false;
-            ShowToolbarFind = true;
-            ShowToolbarReplace = true;
-            ShowToolbarFixCommonErrors = false;
-            ShowToolbarVisualSync = true;
-            ShowToolbarSpellCheck = true;
-            ShowToolbarNetflixGlyphCheck = true;
-            ShowToolbarBeautifyTimeCodes = false;
-            ShowToolbarSettings = true;
-            ShowToolbarHelp = true;
-            ShowToolbarToggleSourceView = false;
-            ShowVideoPlayer = true;
-            ShowAudioVisualizer = true;
-            ShowWaveform = true;
-            ShowSpectrogram = true;
-            ShowFrameRate = false;
-            ShowVideoControls = true;
             DefaultFrameRate = 23.976;
             CurrentFrameRate = DefaultFrameRate;
-            SubtitleFontName = "Tahoma";
-            SubtitleTextBoxFontSize = 12;
-            SubtitleListViewFontSize = 10;
-            SubtitleTextBoxSyntaxColor = false;
-            SubtitleTextBoxHtmlColor = SKColors.CornflowerBlue;
-            SubtitleTextBoxAssColor = SKColors.BlueViolet;
-            SubtitleTextBoxFontBold = true;
-            SubtitleFontColor = SKColors.Black;
-            MeasureFontName = "Arial";
-            MeasureFontSize = 24;
-            MeasureFontBold = false;
             SubtitleLineMaximumPixelWidth = 576;
-            SubtitleBackgroundColor = SKColors.White;
-            CenterSubtitleInTextBox = false;
             DefaultSubtitleFormat = "SubRip";
             DefaultEncoding = TextEncoding.Utf8WithBom;
-            AutoConvertToUtf8 = false;
             AutoGuessAnsiEncoding = true;
-            TranslationAutoSuffixes = ";.translation;_translation;.en;_en";
-            TranslationAutoSuffixDefault = "<Auto>";
-            ShowRecentFiles = true;
-            RememberSelectedLine = true;
-            StartLoadLastFile = true;
-            StartRememberPositionAndSize = true;
             SubtitleLineMaximumLength = 43;
             MaxNumberOfLines = 2;
-            MaxNumberOfLinesPlusAbort = 1;
             MergeLinesShorterThan = 33;
             SubtitleMinimumDisplayMilliseconds = 1000;
             SubtitleMaximumDisplayMilliseconds = 8 * 1000;
-            RemoveBadCharsWhenOpening = true;
             MinimumMillisecondsBetweenLines = 24;
-            SetStartEndHumanDelay = 100;
-            AutoWrapLineWhileTyping = false;
             SubtitleMaximumCharactersPerSeconds = 25.0;
             SubtitleOptimalCharactersPerSeconds = 15.0;
             SubtitleMaximumWordsPerMinute = 400;
@@ -339,501 +102,23 @@ namespace Nikse.SubtitleEdit.Core.Settings
             FixContinuationStyleUncheckInsertsLowercase = true;
             FixContinuationStyleHideContinuationCandidatesWithoutName = true;
             FixContinuationStyleIgnoreLyrics = true;
-            SpellCheckLanguage = null;
-            VideoPlayer = string.Empty;
-            VideoPlayerDefaultVolume = 75;
             VideoPlayerPreviewFontName = "Tahoma";
             VideoPlayerPreviewFontSize = 12;
-            VideoPlayerPreviewBoxHeight = 57;
             VideoPlayerPreviewFontBold = true;
-            VideoPlayerShowStopButton = true;
-            VideoPlayerShowMuteButton = true;
-            VideoPlayerShowFullscreenButton = true;
-            ListViewLineSeparatorString = "<br />";
-            ListViewDoubleClickAction = 1;
-            SaveAsUseFileNameFrom = "video";
             UppercaseLetters = "ABCDEFGHIJKLMNOPQRSTUVWZYXÆØÃÅÄÖÉÈÁÂÀÇÊÍÓÔÕÚŁАБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯĞİŞÜÙÁÌÑÎΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩ";
-            DefaultAdjustMilliseconds = 1000;
-            AutoRepeatOn = true;
-            AutoRepeatCount = 2;
-            AutoContinueOn = false;
-            AutoContinueDelay = 2;
-            ReturnToStartAfterRepeat = false;
-            SyncListViewWithVideoWhilePlaying = false;
-            AutoBackupSeconds = 60 * 5;
-            AutoBackupDeleteAfterMonths = 3;
-            SpellChecker = "hunspell";
-            AllowEditOfOriginalSubtitle = true;
-            PromptDeleteLines = true;
-            Undocked = false;
-            UndockedVideoPosition = "-32000;-32000";
-            UndockedWaveformPosition = "-32000;-32000";
-            UndockedVideoControlsPosition = "-32000;-32000";
-            WaveformUpdateIntervalMs = 40;
-            SmallDelayMilliseconds = 500;
-            LargeDelayMilliseconds = 5000;
-            OpenSubtitleExtraExtensions = "*.mp4;*.m4v;*.mkv;*.ts"; // matroska/mp4/m4v files (can contain subtitles)
-            ListViewColumnsRememberSize = true;
-            DirectShowDoubleLoad = true;
             VlcWaveTranscodeSettings = "acodec=s16l"; // "acodec=s16l,channels=1,ab=64,samplerate=8000";
-            MpvVideoOutputWindows = string.Empty; // could also be e.g. "gpu" or "directshow"
-            MpvVideoOutputLinux = "x11"; // could also be e.g. "x11";
-            MpvHandlesPreviewText = true;
-            MpvPreviewTextPrimaryColor = SKColors.White;
-            MpvPreviewTextOutlineColor = SKColors.Black;
-            MpvPreviewTextBackgroundColor = SKColors.Black;
-            MpvPreviewTextOutlineWidth = 1;
-            MpvPreviewTextShadowWidth = 1;
-            MpvPreviewTextOpaqueBox = false;
-            MpvPreviewTextOpaqueBoxStyle = "1";
-            MpvPreviewTextAlignment = "2";
-            MpvPreviewTextMarginVertical = 10;
-            FFmpegSceneThreshold = "0.4"; // threshold for generating shot changes - 0.2 is sensitive (more shot changes), 0.6 is less sensitive (fewer shot changes)
             UseTimeFormatHHMMSSFF = false;
-            SplitBehavior = 1; // 0=take gap from left, 1=divide evenly, 2=take gap from right
             SplitRemovesDashes = true;
-            ClearStatusBarAfterSeconds = 10;
-            MoveVideo100Or500MsPlaySmallSample = false;
-            DisableVideoAutoLoading = false;
-            NewEmptyUseAutoDuration = true;
             RightToLeftMode = false;
-            LastSaveAsFormat = string.Empty;
-            SystemSubtitleFontNameOverride = string.Empty;
-            CheckForUpdates = true;
-            LastCheckForUpdates = DateTime.Now;
-            ShowProgress = false;
-            ShowNegativeDurationInfoOnSave = true;
-            ShowFormatRequiresUtf8Warning = true;
-            DefaultVideoOffsetInMs = 10 * 60 * 60 * 1000;
-            DefaultVideoOffsetInMsList = "36000000;3600000";
-            DarkThemeForeColor = new SKColor(155, 155, 155);
-            DarkThemeBackColor = new SKColor(30, 30, 30);
-            DarkThemeSelectedBackgroundColor = new SKColor(24, 52, 75);
-            DarkThemeDisabledColor = new SKColor(120, 120, 120);
-            LastColorPickerColor = SKColors.Yellow;
-            LastColorPickerColor1 = SKColors.Red;
-            LastColorPickerColor2 = SKColors.Green;
-            LastColorPickerColor3 = SKColors.Blue;
-            LastColorPickerColor4 = SKColors.White;
-            LastColorPickerColor5 = SKColors.Black;
-            LastColorPickerColor6 = SKColors.Cyan;
-            LastColorPickerColor7 = new SKColor(255, 140, 0); // DarkOrange
-            LastColorPickerDropper = SKColors.Transparent;
-            ToolbarIconTheme = "Auto";
-            UseDarkTheme = false;
-            DarkThemeShowListViewGridLines = false;
-            AutoSetVideoSmpteForTtml = true;
-            AutoSetVideoSmpteForTtmlPrompt = true;
-            TitleBarAsterisk = "before";
-            MeasurementConverterCloseOnInsert = true;
-            MeasurementConverterCategories = "Length;Kilometers;Meters";
-            PreviewAssaText = "ABCDEFGHIJKL abcdefghijkl 123";
-            TagsInToggleHiTags = "[;]";
-            TagsInToggleCustomTags = "(Æ)";
-            SubtitleTextBoxMaxHeight = 300;
-            ShowBetaStuff = false;
-            DebugTranslationSync = false;
             NewEmptyDefaultMs = 2000;
             DialogStyle = DialogType.DashBothLinesWithSpace;
             ContinuationStyle = ContinuationStyle.None;
 
             if (Configuration.IsRunningOnLinux)
             {
-                SubtitleFontName = Configuration.DefaultLinuxFontName;
                 VideoPlayerPreviewFontName = Configuration.DefaultLinuxFontName;
             }
 
-            Profiles = new List<RulesProfile>();
-            CurrentProfile = "Default";
-            Profiles.Add(new RulesProfile
-            {
-                Name = CurrentProfile,
-                SubtitleLineMaximumLength = SubtitleLineMaximumLength,
-                MaxNumberOfLines = MaxNumberOfLines,
-                MergeLinesShorterThan = MergeLinesShorterThan,
-                SubtitleMaximumCharactersPerSeconds = (decimal)SubtitleMaximumCharactersPerSeconds,
-                SubtitleOptimalCharactersPerSeconds = (decimal)SubtitleOptimalCharactersPerSeconds,
-                SubtitleMaximumDisplayMilliseconds = SubtitleMaximumDisplayMilliseconds,
-                SubtitleMinimumDisplayMilliseconds = SubtitleMinimumDisplayMilliseconds,
-                SubtitleMaximumWordsPerMinute = (decimal)SubtitleMaximumWordsPerMinute,
-                CpsLineLengthStrategy = CpsLineLengthStrategy,
-                MinimumMillisecondsBetweenLines = MinimumMillisecondsBetweenLines,
-                DialogStyle = DialogStyle,
-                ContinuationStyle = ContinuationStyle
-            });
-            AddExtraProfiles(Profiles);
-        }
-
-        public static void AddExtraProfiles(List<RulesProfile> profiles)
-        {
-            profiles.Add(new RulesProfile
-            {
-                Name = "Netflix (English)",
-                SubtitleLineMaximumLength = 42,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 43,
-                SubtitleMaximumCharactersPerSeconds = 20,
-                SubtitleOptimalCharactersPerSeconds = 15,
-                SubtitleMaximumDisplayMilliseconds = 7007,
-                SubtitleMinimumDisplayMilliseconds = 833,
-                SubtitleMaximumWordsPerMinute = 240,
-                CpsLineLengthStrategy = string.Empty,
-                MinimumMillisecondsBetweenLines = 83, // 2 frames for 23.976 fps videos
-                DialogStyle = DialogType.DashBothLinesWithoutSpace,
-                ContinuationStyle = ContinuationStyle.NoneLeadingTrailingEllipsis
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "Netflix (Other languages)",
-                SubtitleLineMaximumLength = 42,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 43,
-                SubtitleMaximumCharactersPerSeconds = 17,
-                SubtitleOptimalCharactersPerSeconds = 12,
-                SubtitleMaximumDisplayMilliseconds = 7007,
-                SubtitleMinimumDisplayMilliseconds = 833,
-                SubtitleMaximumWordsPerMinute = 204,
-                CpsLineLengthStrategy = string.Empty,
-                MinimumMillisecondsBetweenLines = 83, // 2 frames for 23.976 fps videos
-                DialogStyle = DialogType.DashBothLinesWithSpace,
-                ContinuationStyle = ContinuationStyle.NoneLeadingTrailingEllipsis
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "Netflix (Dutch)",
-                SubtitleLineMaximumLength = 42,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 43,
-                SubtitleMaximumCharactersPerSeconds = 17,
-                SubtitleOptimalCharactersPerSeconds = 12,
-                SubtitleMaximumDisplayMilliseconds = 7007,
-                SubtitleMinimumDisplayMilliseconds = 833,
-                SubtitleMaximumWordsPerMinute = 204,
-                CpsLineLengthStrategy = string.Empty,
-                MinimumMillisecondsBetweenLines = 83, // 2 frames for 23.976 fps videos
-                DialogStyle = DialogType.DashSecondLineWithoutSpace,
-                ContinuationStyle = ContinuationStyle.LeadingTrailingEllipsis
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "Netflix (Simplified Chinese)",
-                SubtitleLineMaximumLength = 16,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 17,
-                SubtitleMaximumCharactersPerSeconds = 9,
-                SubtitleOptimalCharactersPerSeconds = 9,
-                SubtitleMaximumDisplayMilliseconds = 7007,
-                SubtitleMinimumDisplayMilliseconds = 833,
-                SubtitleMaximumWordsPerMinute = 100,
-                CpsLineLengthStrategy = "CalcAll",
-                MinimumMillisecondsBetweenLines = 83, // 2 frames for 23.976 fps videos
-                DialogStyle = DialogType.DashBothLinesWithoutSpace,
-                ContinuationStyle = ContinuationStyle.LeadingTrailingEllipsis
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "Amazon Prime (English/Spanish/French)",
-                SubtitleLineMaximumLength = 42,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 43,
-                SubtitleMaximumCharactersPerSeconds = 17,
-                SubtitleOptimalCharactersPerSeconds = 12,
-                SubtitleMaximumDisplayMilliseconds = 7007,
-                SubtitleMinimumDisplayMilliseconds = 1000,
-                SubtitleMaximumWordsPerMinute = 204,
-                CpsLineLengthStrategy = string.Empty,
-                MinimumMillisecondsBetweenLines = 83, // 2 frames for 23.976 fps videos
-                DialogStyle = DialogType.DashBothLinesWithSpace,
-                ContinuationStyle = ContinuationStyle.NoneLeadingTrailingEllipsis,
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "Amazon Prime (Arabic)",
-                SubtitleLineMaximumLength = 42,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 43,
-                SubtitleMaximumCharactersPerSeconds = 20,
-                SubtitleOptimalCharactersPerSeconds = 12,
-                SubtitleMaximumDisplayMilliseconds = 7007,
-                SubtitleMinimumDisplayMilliseconds = 1000,
-                SubtitleMaximumWordsPerMinute = 240,
-                CpsLineLengthStrategy = typeof(CalcAll).Name,
-                MinimumMillisecondsBetweenLines = 83, // 2 frames for 23.976 fps videos
-                DialogStyle = DialogType.DashBothLinesWithSpace,
-                ContinuationStyle = ContinuationStyle.NoneLeadingTrailingEllipsis,
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "Amazon Prime (Danish)",
-                SubtitleLineMaximumLength = 42,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 43,
-                SubtitleMaximumCharactersPerSeconds = 17,
-                SubtitleOptimalCharactersPerSeconds = 12,
-                SubtitleMaximumDisplayMilliseconds = 7007,
-                SubtitleMinimumDisplayMilliseconds = 1000,
-                SubtitleMaximumWordsPerMinute = 204,
-                CpsLineLengthStrategy = string.Empty,
-                MinimumMillisecondsBetweenLines = 83, // 2 frames for 23.976 fps videos
-                DialogStyle = DialogType.DashBothLinesWithoutSpace,
-                ContinuationStyle = ContinuationStyle.NoneLeadingTrailingEllipsis,
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "Amazon Prime (Dutch)",
-                SubtitleLineMaximumLength = 42,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 43,
-                SubtitleMaximumCharactersPerSeconds = 17,
-                SubtitleOptimalCharactersPerSeconds = 12,
-                SubtitleMaximumDisplayMilliseconds = 7007,
-                SubtitleMinimumDisplayMilliseconds = 1000,
-                SubtitleMaximumWordsPerMinute = 204,
-                CpsLineLengthStrategy = string.Empty,
-                MinimumMillisecondsBetweenLines = 83, // 2 frames for 23.976 fps videos
-                DialogStyle = DialogType.DashSecondLineWithoutSpace,
-                ContinuationStyle = ContinuationStyle.OnlyTrailingEllipsis,
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "TikTok/YouTube-shorts (9:16)",
-                SubtitleLineMaximumLength = 24,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 0,
-                SubtitleMaximumCharactersPerSeconds = 25,
-                SubtitleOptimalCharactersPerSeconds = 18,
-                SubtitleMaximumDisplayMilliseconds = 5000,
-                SubtitleMinimumDisplayMilliseconds = 700,
-                SubtitleMaximumWordsPerMinute = 300,
-                CpsLineLengthStrategy = string.Empty,
-                MinimumMillisecondsBetweenLines = 0,
-                DialogStyle = DialogType.DashBothLinesWithSpace,
-                ContinuationStyle = ContinuationStyle.None
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "Arte (German/English)",
-                SubtitleLineMaximumLength = 40,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 41,
-                SubtitleMaximumCharactersPerSeconds = 20,
-                SubtitleOptimalCharactersPerSeconds = 12,
-                SubtitleMaximumDisplayMilliseconds = 10000,
-                SubtitleMinimumDisplayMilliseconds = 1000,
-                SubtitleMaximumWordsPerMinute = 240,
-                CpsLineLengthStrategy = string.Empty,
-                MinimumMillisecondsBetweenLines = 200, // 5 frames for 25 fps videos
-                DialogStyle = DialogType.DashBothLinesWithSpace,
-                ContinuationStyle = ContinuationStyle.None
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "Dutch professional subtitles (23.976/24 fps)",
-                SubtitleLineMaximumLength = 42,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 43,
-                SubtitleMaximumCharactersPerSeconds = 15,
-                SubtitleOptimalCharactersPerSeconds = 11,
-                SubtitleMaximumDisplayMilliseconds = 7007,
-                SubtitleMinimumDisplayMilliseconds = 1400,
-                SubtitleMaximumWordsPerMinute = 180,
-                CpsLineLengthStrategy = string.Empty,
-                MinimumMillisecondsBetweenLines = 125,
-                DialogStyle = DialogType.DashSecondLineWithoutSpace,
-                ContinuationStyle = ContinuationStyle.OnlyTrailingDots
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "Dutch professional subtitles (25 fps)",
-                SubtitleLineMaximumLength = 42,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 43,
-                SubtitleMaximumCharactersPerSeconds = 15,
-                SubtitleOptimalCharactersPerSeconds = 11,
-                SubtitleMaximumDisplayMilliseconds = 7000,
-                SubtitleMinimumDisplayMilliseconds = 1400,
-                SubtitleMaximumWordsPerMinute = 180,
-                CpsLineLengthStrategy = string.Empty,
-                MinimumMillisecondsBetweenLines = 120,
-                DialogStyle = DialogType.DashSecondLineWithoutSpace,
-                ContinuationStyle = ContinuationStyle.OnlyTrailingDots
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "Dutch fansubs (23.976/24 fps)",
-                SubtitleLineMaximumLength = 45,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 46,
-                SubtitleMaximumCharactersPerSeconds = 22.5m,
-                SubtitleOptimalCharactersPerSeconds = 12,
-                SubtitleMaximumDisplayMilliseconds = 7007,
-                SubtitleMinimumDisplayMilliseconds = 1200,
-                SubtitleMaximumWordsPerMinute = 300,
-                CpsLineLengthStrategy = string.Empty,
-                MinimumMillisecondsBetweenLines = 125,
-                DialogStyle = DialogType.DashSecondLineWithSpace,
-                ContinuationStyle = ContinuationStyle.OnlyTrailingDots
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "Dutch fansubs (25 fps)",
-                SubtitleLineMaximumLength = 45,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 46,
-                SubtitleMaximumCharactersPerSeconds = 22.5m,
-                SubtitleOptimalCharactersPerSeconds = 12,
-                SubtitleMaximumDisplayMilliseconds = 7000,
-                SubtitleMinimumDisplayMilliseconds = 1200,
-                SubtitleMaximumWordsPerMinute = 300,
-                CpsLineLengthStrategy = string.Empty,
-                MinimumMillisecondsBetweenLines = 120,
-                DialogStyle = DialogType.DashSecondLineWithSpace,
-                ContinuationStyle = ContinuationStyle.OnlyTrailingDots
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "Danish professional subtitles (23.976/24 fps)",
-                SubtitleLineMaximumLength = 40,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 41,
-                SubtitleMaximumCharactersPerSeconds = 15,
-                SubtitleOptimalCharactersPerSeconds = 10,
-                SubtitleMaximumDisplayMilliseconds = 8008,
-                SubtitleMinimumDisplayMilliseconds = 2002,
-                SubtitleMaximumWordsPerMinute = 180,
-                CpsLineLengthStrategy = string.Empty,
-                MinimumMillisecondsBetweenLines = 125,
-                DialogStyle = DialogType.DashBothLinesWithSpace,
-                ContinuationStyle = ContinuationStyle.LeadingTrailingDashDots
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "Danish professional subtitles (25 fps)",
-                SubtitleLineMaximumLength = 40,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 41,
-                SubtitleMaximumCharactersPerSeconds = 15,
-                SubtitleOptimalCharactersPerSeconds = 10,
-                SubtitleMaximumDisplayMilliseconds = 8000,
-                SubtitleMinimumDisplayMilliseconds = 2000,
-                SubtitleMaximumWordsPerMinute = 180,
-                CpsLineLengthStrategy = string.Empty,
-                MinimumMillisecondsBetweenLines = 120,
-                DialogStyle = DialogType.DashBothLinesWithSpace,
-                ContinuationStyle = ContinuationStyle.LeadingTrailingDashDots
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "SDI (Dutch)",
-                SubtitleLineMaximumLength = 37,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 38,
-                SubtitleMaximumCharactersPerSeconds = 18.75m,
-                SubtitleOptimalCharactersPerSeconds = 12,
-                SubtitleMaximumDisplayMilliseconds = 7000,
-                SubtitleMinimumDisplayMilliseconds = 1320,
-                SubtitleMaximumWordsPerMinute = 225,
-                CpsLineLengthStrategy = string.Empty,
-                MinimumMillisecondsBetweenLines = 160,
-                DialogStyle = DialogType.DashSecondLineWithoutSpace,
-                ContinuationStyle = ContinuationStyle.OnlyTrailingDots
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "SW2 (French) (23.976/24 fps)",
-                SubtitleLineMaximumLength = 40,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 41,
-                SubtitleMaximumCharactersPerSeconds = 25,
-                SubtitleOptimalCharactersPerSeconds = 18,
-                SubtitleMaximumDisplayMilliseconds = 5005,
-                SubtitleMinimumDisplayMilliseconds = 792,
-                SubtitleMaximumWordsPerMinute = 300,
-                CpsLineLengthStrategy = string.Empty,
-                MinimumMillisecondsBetweenLines = 125,
-                DialogStyle = DialogType.DashBothLinesWithSpace,
-                ContinuationStyle = ContinuationStyle.None
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "SW2 (French) (25 fps)",
-                SubtitleLineMaximumLength = 40,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 41,
-                SubtitleMaximumCharactersPerSeconds = 25,
-                SubtitleOptimalCharactersPerSeconds = 18,
-                SubtitleMaximumDisplayMilliseconds = 5000,
-                SubtitleMinimumDisplayMilliseconds = 800,
-                SubtitleMaximumWordsPerMinute = 300,
-                CpsLineLengthStrategy = string.Empty,
-                MinimumMillisecondsBetweenLines = 120,
-                DialogStyle = DialogType.DashBothLinesWithSpace,
-                ContinuationStyle = ContinuationStyle.None
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "SW3 (French) (23.976/24 fps)",
-                SubtitleLineMaximumLength = 40,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 41,
-                SubtitleMaximumCharactersPerSeconds = 25,
-                SubtitleOptimalCharactersPerSeconds = 18,
-                SubtitleMaximumDisplayMilliseconds = 5005,
-                SubtitleMinimumDisplayMilliseconds = 792,
-                SubtitleMaximumWordsPerMinute = 300,
-                CpsLineLengthStrategy = string.Empty,
-                MinimumMillisecondsBetweenLines = 167,
-                DialogStyle = DialogType.DashBothLinesWithSpace,
-                ContinuationStyle = ContinuationStyle.None
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "SW3 (French) (25 fps)",
-                SubtitleLineMaximumLength = 40,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 41,
-                SubtitleMaximumCharactersPerSeconds = 25,
-                SubtitleOptimalCharactersPerSeconds = 18,
-                SubtitleMaximumDisplayMilliseconds = 5000,
-                SubtitleMinimumDisplayMilliseconds = 800,
-                SubtitleMaximumWordsPerMinute = 300,
-                CpsLineLengthStrategy = string.Empty,
-                MinimumMillisecondsBetweenLines = 160,
-                DialogStyle = DialogType.DashBothLinesWithSpace,
-                ContinuationStyle = ContinuationStyle.None
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "SW4 (French) (23.976/24 fps)",
-                SubtitleLineMaximumLength = 40,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 41,
-                SubtitleMaximumCharactersPerSeconds = 25,
-                SubtitleOptimalCharactersPerSeconds = 18,
-                SubtitleMaximumDisplayMilliseconds = 5005,
-                SubtitleMinimumDisplayMilliseconds = 792,
-                SubtitleMaximumWordsPerMinute = 300,
-                CpsLineLengthStrategy = string.Empty,
-                MinimumMillisecondsBetweenLines = 250,
-                DialogStyle = DialogType.DashBothLinesWithSpace,
-                ContinuationStyle = ContinuationStyle.None
-            });
-            profiles.Add(new RulesProfile
-            {
-                Name = "SW4 (French) (25 fps)",
-                SubtitleLineMaximumLength = 40,
-                MaxNumberOfLines = 2,
-                MergeLinesShorterThan = 41,
-                SubtitleMaximumCharactersPerSeconds = 25,
-                SubtitleOptimalCharactersPerSeconds = 18,
-                SubtitleMaximumDisplayMilliseconds = 5000,
-                SubtitleMinimumDisplayMilliseconds = 800,
-                SubtitleMaximumWordsPerMinute = 300,
-                CpsLineLengthStrategy = string.Empty,
-                MinimumMillisecondsBetweenLines = 240,
-                DialogStyle = DialogType.DashBothLinesWithSpace,
-                ContinuationStyle = ContinuationStyle.None
-            });
         }
     }
 }

--- a/src/libse/Settings/ToolsSettings.cs
+++ b/src/libse/Settings/ToolsSettings.cs
@@ -1,26 +1,18 @@
 using Nikse.SubtitleEdit.Core.Common;
-using SkiaSharp;
 using System;
-using System.Collections.Generic;
 
 namespace Nikse.SubtitleEdit.Core.Settings
 {
     public class ToolsSettings
     {
-        public List<AssaTemplateItem> AssaTagTemplates { get; set; }
-        public int EndSceneIndex { get; set; }
         public bool FixShortDisplayTimesAllowMoveStartTime { get; set; }
         public bool RemoveEmptyLinesBetweenText { get; set; }
         public string MusicSymbol { get; set; }
         public string MusicSymbolReplace { get; set; }
-        public string UnicodeSymbolsToInsert { get; set; }
-        public bool CheckOneLetterWords { get; set; }
         public bool RememberUseAlwaysList { get; set; }
         public bool OcrFixUseHardcodedRules { get; set; }
         public bool OcrGoogleCloudVisionSeHandlesTextMerge { get; set; }
         public bool OcrUseWordSplitList { get; set; }
-        public bool OcrUseWordSplitListAvoidPropercase { get; set; }
-        public string BDOpenIn { get; set; }
         public string MicrosoftBingApiId { get; set; }
         public string MicrosoftTranslatorApiKey { get; set; }
         public string MicrosoftTranslatorTokenEndpoint { get; set; }
@@ -29,7 +21,6 @@ namespace Nikse.SubtitleEdit.Core.Settings
         public string GoogleTranslateLastSourceLanguage { get; set; }
         public string GoogleTranslateLastTargetLanguage { get; set; }
         public string AutoTranslateLastName { get; set; }
-        public string AutoTranslateLastUrl { get; set; }
         public string AutoTranslateNllbApiUrl { get; set; }
         public string AutoTranslateNllbServeUrl { get; set; }
         public string AutoTranslateNllbServeModel { get; set; }
@@ -91,7 +82,6 @@ namespace Nikse.SubtitleEdit.Core.Settings
         public string OpenAiCompatibleSttLanguage { get; set; }
         public decimal OpenAiCompatibleSttTemperature { get; set; }
         public string OpenAiCompatibleSttPrompt { get; set; }
-        public bool OpenAiCompatibleSttAutoTranscribeOnAudioSelection { get; set; }
         public bool OpenAiCompatibleSttStream { get; set; }
         public string OpenAiCompatibleSttAudioFormat { get; set; }
 
@@ -140,242 +130,46 @@ namespace Nikse.SubtitleEdit.Core.Settings
         public string BaiduApiKey { get; set; }
         public int AutoTranslateDelaySeconds { get; set; }
         public int AutoTranslateMaxBytes { get; set; }
-        public string AutoTranslateStrategy { get; set; }
         public string GeminiProApiKey { get; set; }
         public string GeminiModel { get; set; }
         public string GeminiPrompt { get; set; }
-        public string TextToSpeechEngine { get; set; }
         public bool ListViewSyntaxColorWideLines { get; set; }
-        public SKColor Color1 { get; set; }
-        public SKColor Color2 { get; set; }
-        public SKColor Color3 { get; set; }
-        public SKColor Color4 { get; set; }
-        public SKColor Color5 { get; set; }
-        public SKColor Color6 { get; set; }
-        public SKColor Color7 { get; set; }
-        public SKColor Color8 { get; set; }
-        public string SplitOutputFolder { get; set; }
-        public string BatchConvertOutputFolder { get; set; }
-        public bool BatchConvertOverwriteExisting { get; set; }
-        public bool BatchConvertSaveInSourceFolder { get; set; }
-        public bool BatchConvertRemoveFormatting { get; set; }
-        public bool BatchConvertRemoveFormattingAll { get; set; }
-        public bool BatchConvertRemoveFormattingItalic { get; set; }
-        public bool BatchConvertRemoveFormattingBold { get; set; }
-        public bool BatchConvertRemoveFormattingUnderline { get; set; }
-        public bool BatchConvertRemoveFormattingFontName { get; set; }
-        public bool BatchConvertRemoveFormattingColor { get; set; }
-        public bool BatchConvertRemoveFormattingAlignment { get; set; }
-        public bool BatchConvertRemoveStyle { get; set; }
-        public bool BatchConvertBridgeGaps { get; set; }
-        public bool BatchConvertFixCasing { get; set; }
-        public bool BatchConvertRemoveTextForHI { get; set; }
-        public bool BatchConvertConvertColorsToDialog { get; set; }
-        public bool BatchConvertBeautifyTimeCodes { get; set; }
-        public bool BatchConvertAutoTranslate { get; set; }
-        public bool BatchConvertFixCommonErrors { get; set; }
-        public bool BatchConvertMultipleReplace { get; set; }
-        public bool BatchConvertFixRtl { get; set; }
-        public string BatchConvertFixRtlMode { get; set; }
-        public bool BatchConvertSplitLongLines { get; set; }
-        public bool BatchConvertAutoBalance { get; set; }
-        public bool BatchConvertSetMinDisplayTimeBetweenSubtitles { get; set; }
-        public bool BatchConvertMergeShortLines { get; set; }
-        public bool BatchConvertRemoveLineBreaks { get; set; }
-        public bool BatchConvertMergeSameText { get; set; }
-        public bool BatchConvertMergeSameTimeCodes { get; set; }
-        public bool BatchConvertChangeFrameRate { get; set; }
-        public bool BatchConvertChangeSpeed { get; set; }
-        public bool BatchConvertAdjustDisplayDuration { get; set; }
-        public bool BatchConvertApplyDurationLimits { get; set; }
-        public bool BatchConvertDeleteLines { get; set; }
-        public bool BatchConvertAssaChangeRes { get; set; }
-        public bool BatchConvertSortBy { get; set; }
-        public string BatchConvertSortByChoice { get; set; }
-        public bool BatchConvertOffsetTimeCodes { get; set; }
-        public bool BatchConvertScanFolderIncludeVideo { get; set; }
-        public string BatchConvertLanguage { get; set; }
-        public string BatchConvertFormat { get; set; }
-        public string BatchConvertAssStyles { get; set; }
-        public string BatchConvertSsaStyles { get; set; }
-        public bool BatchConvertUseStyleFromSource { get; set; }
-        public string BatchConvertExportCustomTextTemplate { get; set; }
-        public bool BatchConvertTsOverrideXPosition { get; set; }
-        public bool BatchConvertTsOverrideYPosition { get; set; }
-        public int BatchConvertTsOverrideBottomMargin { get; set; }
-        public string BatchConvertTsOverrideHAlign { get; set; }
-        public int BatchConvertTsOverrideHMargin { get; set; }
-        public bool BatchConvertTsOverrideScreenSize { get; set; }
-        public int BatchConvertTsScreenWidth { get; set; }
-        public int BatchConvertTsScreenHeight { get; set; }
-        public string BatchConvertTsFileNameAppend { get; set; }
-        public bool BatchConvertTsOnlyTeletext { get; set; }
-        public string BatchConvertMkvLanguageCodeStyle { get; set; }
-        public string BatchConvertOcrEngine { get; set; }
-        public string BatchConvertOcrLanguage { get; set; }
-        public string BatchConvertTranslateEngine { get; set; }
-        public string ExportBluRayFontName { get; set; }
-        public int ExportBluRayFontSize { get; set; }
-        public string ExportBdnXmlImageType { get; set; }
-        public string ExportBluRayVideoResolution { get; set; }
-        public SKColor ExportBorderColor { get; set; }
-        public int ExportBoxBorderSize { get; set; }
-        public string ExportBottomMarginUnit { get; set; }
-        public int ExportBottomMarginPercent { get; set; }
-        public int ExportBottomMarginPixels { get; set; }
-        public int ExportBluRayBottomMarginPercent { get; set; }
-        public int ExportBluRayBottomMarginPixels { get; set; }
-        public int ExportBluRayShadow { get; set; }
         public bool ExportBluRayRemoveSmallGaps { get; set; }
-        public string ExportCdgBackgroundImage { get; set; }
-        public int ExportCdgMarginLeft { get; set; }
-        public int ExportCdgMarginBottom { get; set; }
-        public string ExportCdgFormat { get; set; }
-        public int Export3DType { get; set; }
-        public int Export3DDepth { get; set; }
-        public SKColor BinEditBackgroundColor { get; set; }
-        public SKColor BinEditImageBackgroundColor { get; set; }
-        public int BinEditTopMargin { get; set; }
-        public int BinEditBottomMargin { get; set; }
-        public int BinEditLeftMargin { get; set; }
-        public int BinEditRightMargin { get; set; }
-        public string BinEditStartPosition { get; set; }
-        public string BinEditStartSize { get; set; }
-        public bool BinEditShowColumnGap { get; set; }
         public bool FixCommonErrorsFixOverlapAllowEqualEndStart { get; set; }
-        public string ImportTextSplitting { get; set; }
-        public string ImportTextSplittingLineMode { get; set; }
-        public string ImportTextLineBreak { get; set; }
-        public bool ImportTextMergeShortLines { get; set; }
-        public bool ImportTextAutoSplitAtBlank { get; set; }
-        public bool ImportTextRemoveLinesNoLetters { get; set; }
-        public bool ImportTextGenerateTimeCodes { get; set; }
-        public bool ImportTextAutoBreak { get; set; }
-        public bool ImportTextAutoBreakAtEnd { get; set; }
-        public decimal ImportTextGap { get; set; }
-        public decimal ImportTextAutoSplitNumberOfLines { get; set; }
-        public string ImportTextAutoBreakAtEndMarkerText { get; set; }
-        public bool ImportTextDurationAuto { get; set; }
-        public decimal ImportTextFixedDuration { get; set; }
         public string MusicSymbolStyle { get; set; }
-        public int BridgeGapMilliseconds { get; set; }
-        public int BridgeGapMillisecondsMinGap { get; set; }
-        public string ChangeCasingChoice { get; set; }
-        public bool ChangeCasingNormalFixNames { get; set; }
-        public bool ChangeCasingNormalOnlyUppercase { get; set; }
         public bool UseNoLineBreakAfter { get; set; }
-        public List<string> FindHistory { get; set; }
-        public decimal AdjustDurationSeconds { get; set; }
-        public int AdjustDurationPercent { get; set; }
-        public string AdjustDurationLast { get; set; }
-        public bool AdjustDurationExtendOnly { get; set; }
-        public bool AdjustDurationExtendEnforceDurationLimits { get; set; }
-        public bool AdjustDurationExtendCheckShotChanges { get; set; }
-        public bool ChangeSpeedAllowOverlap { get; set; }
         public bool AutoBreakCommaBreakEarly { get; set; }
         public bool AutoBreakDashEarly { get; set; }
         public bool AutoBreakLineEndingEarly { get; set; }
         public bool AutoBreakUsePixelWidth { get; set; }
         public bool AutoBreakPreferBottomHeavy { get; set; }
         public double AutoBreakPreferBottomPercent { get; set; }
-        public bool ApplyMinimumDurationLimit { get; set; }
-        public bool ApplyMinimumDurationLimitCheckShotChanges { get; set; }
-        public bool ApplyMaximumDurationLimit { get; set; }
         public int MergeShortLinesMaxGap { get; set; }
         public bool MergeShortLinesOnlyContinuous { get; set; }
-        public bool ConvertColorsToDialogRemoveColorTags { get; set; }
-        public bool ConvertColorsToDialogAddNewLines { get; set; }
-        public bool ConvertColorsToDialogReBreakLines { get; set; }
-        public string ColumnPasteColumn { get; set; }
-        public string ColumnPasteOverwriteMode { get; set; }
-        public string AssaAttachmentFontTextPreview { get; set; }
-        public string AssaSetPositionTarget { get; set; }
-        public SKColor BlankVideoColor { get; set; }
-        public bool BlankVideoUseCheckeredImage { get; set; }
-        public int BlankVideoMinutes { get; set; }
-        public decimal BlankVideoFrameRate { get; set; }
-        public SKColor AssaProgressBarForeColor { get; set; }
-        public SKColor AssaProgressBarBackColor { get; set; }
-        public SKColor AssaProgressBarTextColor { get; set; }
-        public int AssaProgressBarHeight { get; set; }
-        public int AssaProgressBarSplitterWidth { get; set; }
-        public int AssaProgressBarSplitterHeight { get; set; }
-        public string AssaProgressBarFontName { get; set; }
-        public int AssaProgressBarFontSize { get; set; }
-        public bool AssaProgressBarTopAlign { get; set; }
-        public string AssaProgressBarTextAlign { get; set; }
 
-
-        public int AssaBgBoxPaddingLeft { get; set; }
-        public int AssaBgBoxPaddingRight { get; set; }
-        public int AssaBgBoxPaddingTop { get; set; }
-        public int AssaBgBoxPaddingBottom { get; set; }
-        public int AssaBgBoxDrawingMarginV { get; set; }
-        public int AssaBgBoxDrawingMarginH { get; set; }
-        public string AssaBgBoxDrawingAlignment { get; set; }
-        public SKColor AssaBgBoxColor { get; set; }
-        public SKColor AssaBgBoxOutlineColor { get; set; }
-        public SKColor AssaBgBoxShadowColor { get; set; }
-        public SKColor AssaBgBoxTransparentColor { get; set; }
-        public string AssaBgBoxStyle { get; set; }
-        public int AssaBgBoxStyleRadius { get; set; }
-        public int AssaBgBoxStyleCircleAdjustY { get; set; }
-        public int AssaBgBoxStyleSpikesStep { get; set; }
-        public int AssaBgBoxStyleSpikesHeight { get; set; }
-        public int AssaBgBoxStyleBubblesStep { get; set; }
-        public int AssaBgBoxStyleBubblesHeight { get; set; }
-        public int AssaBgBoxOutlineWidth { get; set; }
-        public int AssaBgBoxLayer { get; set; }
-        public string AssaBgBoxDrawing { get; set; }
-        public bool AssaBgBoxDrawingFileWatch { get; set; }
-        public bool AssaBgBoxDrawingOnly { get; set; }
-
-        public bool VoskPostProcessing { get; set; }
         public string WhisperChoice { get; set; }
-        public bool WhisperIgnoreVersion { get; set; }
 
-        public bool WhisperDeleteTempFiles { get; set; }
-        public string WhisperModel { get; set; }
-        public string WhisperLanguageCode { get; set; }
         public string WhisperLocation { get; set; }
         public string WhisperCtranslate2Location { get; set; }
-        public string WhisperPurfviewFasterWhisperLocation { get; set; }
-        public string WhisperPurfviewFasterWhisperDefaultCmd { get; set; }
         public string WhisperXLocation { get; set; }
         public string WhisperStableTsLocation { get; set; }
         public string WhisperCppModelLocation { get; set; }
         public string WhisperExtraSettings { get; set; }
-        public string WhisperExtraSettingsHistory { get; set; }
-        public bool WhisperAutoAdjustTimings { get; set; }
-        public bool WhisperUseLineMaxChars { get; set; }
-        public bool WhisperPostProcessingAddPeriods { get; set; }
-        public bool WhisperPostProcessingMergeLines { get; set; }
-        public bool WhisperPostProcessingSplitLines { get; set; }
-        public bool WhisperPostProcessingFixCasing { get; set; }
-        public bool WhisperPostProcessingFixShortDuration { get; set; }
         public int AudioToTextLineMaxChars { get; set; }
         public int AudioToTextLineMaxCharsJp { get; set; }
         public int AudioToTextLineMaxCharsCn { get; set; }
-        public int BreakLinesLongerThan { get; set; }
-        public bool ConvertActorColorAdd { get; set; }
-        public SKColor ConvertActorColor { get; set; }
-        public bool ConvertActorCasing { get; set; }
 
         public ToolsSettings()
         {
-            AssaTagTemplates = new List<AssaTemplateItem>();
-            EndSceneIndex = 1;
             FixShortDisplayTimesAllowMoveStartTime = false;
             RemoveEmptyLinesBetweenText = true;
             MusicSymbol = "♪";
             MusicSymbolReplace = "â™ª,â™«," + // ♪ + ♫ in UTF-8 opened as ANSI
                                  "<s M/>,<s m/>," + // music symbols by subtitle creator
                                  "#,*,¶"; // common music symbols
-            UnicodeSymbolsToInsert = "♪;♫;—;…;°;☺;☹;♥;©;☮;☯;Σ;∞;≡;⇒;π";
             OcrFixUseHardcodedRules = true;
             OcrGoogleCloudVisionSeHandlesTextMerge = true;
             OcrUseWordSplitList = true;
-            OcrUseWordSplitListAvoidPropercase = true;
             MicrosoftTranslatorTokenEndpoint = "https://api.cognitive.microsoft.com/sts/v1.0/issueToken";
             GoogleTranslateLastTargetLanguage = "en";
             AutoTranslateNllbServeUrl = "http://127.0.0.1:6060/";
@@ -432,117 +226,17 @@ namespace Nikse.SubtitleEdit.Core.Settings
             GeminiModel = "gemini-flash-latest"; // GeminiTranslate.Models[0] in LibUiLogic
             GeminiPrompt = "Please translate the following text from {0} to {1}, keep line breaks exactly the same, do not censor the translation, only write the result:";
             AutoTranslateMaxBytes = 2000;
-            CheckOneLetterWords = true;
             ListViewSyntaxColorWideLines = false;
-            Color1 = SKColors.Yellow;
-            Color2 = new SKColor(byte.MaxValue, 0, 0);
-            Color3 = new SKColor(0, byte.MaxValue, 0);
-            Color4 = SKColors.Cyan;
-            Color5 = SKColors.Black;
-            Color6 = SKColors.White;
-            Color7 = SKColors.Orange;
-            Color8 = SKColors.Pink;
-            BatchConvertLanguage = string.Empty;
-            BatchConvertTsOverrideBottomMargin = 5; // pct
-            BatchConvertTsScreenWidth = 1920;
-            BatchConvertTsScreenHeight = 1080;
-            BatchConvertOcrEngine = "Tesseract";
-            BatchConvertOcrLanguage = "en";
-            BatchConvertTranslateEngine = "LibreTranslate"; // LibreTranslate.StaticName in LibUiLogic
-            BatchConvertTsOverrideHAlign = "center"; // left center right
-            BatchConvertTsOverrideHMargin = 5; // pct
-            BatchConvertTsFileNameAppend = ".{two-letter-country-code}";
-            BatchConvertMkvLanguageCodeStyle = "2";
-            ImportTextDurationAuto = true;
-            ImportTextGap = 84;
-            ImportTextFixedDuration = 2500;
             MusicSymbolStyle = "Double"; // 'Double' or 'Single'
-            ExportBorderColor = SKColors.Black;
-            ExportBoxBorderSize = 8;
-            ExportBottomMarginUnit = "%";
-            ExportBottomMarginPercent = 5;
-            ExportBottomMarginPixels = 15;
-            ExportBluRayBottomMarginPercent = 5;
-            ExportBluRayBottomMarginPixels = 20;
-            ExportBluRayShadow = 1;
-            Export3DType = 0;
-            Export3DDepth = 0;
-            ExportCdgMarginLeft = 160;
-            ExportCdgMarginBottom = 67;
-            BinEditBackgroundColor = SKColors.Black;
-            BinEditImageBackgroundColor = SKColors.Blue;
-            BinEditTopMargin = 10;
-            BinEditBottomMargin = 10;
-            BinEditLeftMargin = 10;
-            BinEditRightMargin = 10;
-            BridgeGapMilliseconds = 100;
-            BridgeGapMillisecondsMinGap = 24;
-            ChangeCasingNormalFixNames = true;
             UseNoLineBreakAfter = false;
-            FindHistory = new List<string>();
-            ImportTextLineBreak = "|";
-            ImportTextAutoSplitNumberOfLines = 2;
-            ImportTextAutoSplitAtBlank = true;
-            ImportTextAutoBreakAtEndMarkerText = ".!?";
-            ImportTextAutoBreakAtEnd = true;
-            AdjustDurationSeconds = 0.1m;
-            AdjustDurationPercent = 120;
-            AdjustDurationExtendOnly = true;
-            AdjustDurationExtendEnforceDurationLimits = true;
-            AdjustDurationExtendCheckShotChanges = true;
             AutoBreakCommaBreakEarly = false;
             AutoBreakDashEarly = true;
             AutoBreakLineEndingEarly = false;
             AutoBreakUsePixelWidth = true;
             AutoBreakPreferBottomHeavy = true;
             AutoBreakPreferBottomPercent = 5;
-            ApplyMinimumDurationLimit = true;
-            ApplyMinimumDurationLimitCheckShotChanges = true;
-            ApplyMaximumDurationLimit = true;
             MergeShortLinesMaxGap = 250;
             MergeShortLinesOnlyContinuous = true;
-            ConvertColorsToDialogRemoveColorTags = true;
-            ConvertColorsToDialogAddNewLines = true;
-            ConvertColorsToDialogReBreakLines = false;
-            ColumnPasteColumn = "all";
-            ColumnPasteOverwriteMode = "overwrite";
-            AssaAttachmentFontTextPreview =
-                "Hello World!" + Environment.NewLine +
-                "こんにちは世界" + Environment.NewLine +
-                "你好世界！" + Environment.NewLine +
-                "1234567890";
-            BlankVideoColor = SKColors.CadetBlue;
-            BlankVideoUseCheckeredImage = true;
-            BlankVideoMinutes = 2;
-            BlankVideoFrameRate = 23.976m;
-            AssaProgressBarForeColor = new SKColor(200, 0, 0, 200);
-            AssaProgressBarBackColor = new SKColor(80, 80, 80, 150);
-            AssaProgressBarTextColor = SKColors.White;
-            AssaProgressBarHeight = 40;
-            AssaProgressBarSplitterWidth = 2;
-            AssaProgressBarSplitterHeight = 40;
-            AssaProgressBarFontName = "Arial";
-            AssaProgressBarFontSize = 30;
-            AssaProgressBarTextAlign = "left";
-
-            AssaBgBoxPaddingLeft = 10;
-            AssaBgBoxPaddingRight = 10;
-            AssaBgBoxPaddingTop = 6;
-            AssaBgBoxPaddingBottom = 6;
-            AssaBgBoxColor = new SKColor(0, 0, 0, 200);
-            AssaBgBoxOutlineColor = new SKColor(80, 80, 80, 200);
-            AssaBgBoxShadowColor = new SKColor(0, 0, 0, 100);
-            AssaBgBoxTransparentColor = SKColors.Cyan;
-            AssaBgBoxStyle = "square";
-            AssaBgBoxStyleRadius = 30;
-            AssaBgBoxStyleCircleAdjustY = 30;
-            AssaBgBoxStyleSpikesStep = 15;
-            AssaBgBoxStyleSpikesHeight = 30;
-            AssaBgBoxStyleBubblesStep = 75;
-            AssaBgBoxStyleBubblesHeight = 40;
-            AssaBgBoxOutlineWidth = 0;
-            AssaBgBoxLayer = -11893;
-            AssaBgBoxDrawingFileWatch = true;
 
             OpenAiCompatibleSttUrl = "http://localhost:8000/v1/audio/transcriptions";
             OpenAiCompatibleSttApiKey = string.Empty;
@@ -569,18 +263,8 @@ namespace Nikse.SubtitleEdit.Core.Settings
             DashScopeSttEnableWords = false;
             DashScopeSttTimeoutSeconds = 3600;
 
-            VoskPostProcessing = true;
             WhisperChoice = Configuration.IsRunningOnWindows ? "Purfview's Faster-Whisper-XXL" : "OpenAI"; // WhisperChoice.PurfviewFasterWhisperXxl / WhisperChoice.OpenAi in LibUiLogic
-            WhisperDeleteTempFiles = true;
-            WhisperPurfviewFasterWhisperDefaultCmd = "--standard --beep_off";
             WhisperExtraSettings = "";
-            WhisperLanguageCode = "en";
-            WhisperAutoAdjustTimings = true;
-            WhisperPostProcessingAddPeriods = false;
-            WhisperPostProcessingMergeLines = true;
-            WhisperPostProcessingSplitLines = true;
-            WhisperPostProcessingFixCasing = false;
-            WhisperPostProcessingFixShortDuration = true;
             AudioToTextLineMaxChars = 86;
             AudioToTextLineMaxCharsJp = 32;
             AudioToTextLineMaxCharsCn = 36;

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -576,7 +576,6 @@ public class Se
     private static void UpdateLibSeSettings()
     {
         Configuration.Settings.General.FFmpegLocation = Settings.General.FfmpegPath;
-        Configuration.Settings.General.UseDarkTheme = Settings.Appearance.Theme == "Dark";
         Configuration.Settings.General.UseTimeFormatHHMMSSFF = Settings.General.UseFrameMode;
 
         Configuration.Settings.Proxy.ProxyAddress = Settings.General.ProxyAddress ?? string.Empty;
@@ -601,27 +600,12 @@ public class Se
 
         var stt = Settings.Tools.AudioToText;
         Configuration.Settings.Tools.WhisperChoice = stt.WhisperChoice;
-        Configuration.Settings.Tools.WhisperIgnoreVersion = stt.WhisperIgnoreVersion;
-        Configuration.Settings.Tools.WhisperDeleteTempFiles = stt.WhisperDeleteTempFiles;
-        Configuration.Settings.Tools.WhisperModel = stt.WhisperModel;
-        Configuration.Settings.Tools.WhisperLanguageCode = stt.WhisperLanguageCode;
         Configuration.Settings.Tools.WhisperLocation = stt.WhisperLocation;
         Configuration.Settings.Tools.WhisperCtranslate2Location = stt.WhisperCtranslate2Location;
-        Configuration.Settings.Tools.WhisperPurfviewFasterWhisperLocation = stt.WhisperPurfviewFasterWhisperLocation;
-        Configuration.Settings.Tools.WhisperPurfviewFasterWhisperDefaultCmd = stt.WhisperPurfviewFasterWhisperDefaultCmd;
         Configuration.Settings.Tools.WhisperXLocation = stt.WhisperXLocation;
         Configuration.Settings.Tools.WhisperStableTsLocation = stt.WhisperStableTsLocation;
         Configuration.Settings.Tools.WhisperCppModelLocation = stt.WhisperCppModelLocation;
         Configuration.Settings.Tools.WhisperExtraSettings = stt.WhisperCustomCommandLineArguments;
-        Configuration.Settings.Tools.WhisperExtraSettingsHistory = stt.WhisperExtraSettingsHistory;
-        Configuration.Settings.Tools.WhisperAutoAdjustTimings = stt.WhisperAutoAdjustTimings;
-        Configuration.Settings.Tools.WhisperUseLineMaxChars = stt.WhisperUseLineMaxChars;
-        Configuration.Settings.Tools.WhisperPostProcessingAddPeriods = stt.WhisperPostProcessingAddPeriods;
-        Configuration.Settings.Tools.WhisperPostProcessingMergeLines = stt.WhisperPostProcessingMergeLines;
-        Configuration.Settings.Tools.WhisperPostProcessingSplitLines = stt.WhisperPostProcessingSplitLines;
-        Configuration.Settings.Tools.WhisperPostProcessingFixCasing = stt.WhisperPostProcessingFixCasing;
-        Configuration.Settings.Tools.WhisperPostProcessingFixShortDuration = stt.WhisperPostProcessingFixShortDuration;
-        Configuration.Settings.Tools.VoskPostProcessing = stt.PostProcessing;
 
         Configuration.Settings.Tools.OpenAiCompatibleSttUrl = Settings.Tools.OpenAiCompatibleSttUrl;
         Configuration.Settings.Tools.OpenAiCompatibleSttApiKey = Settings.Tools.OpenAiCompatibleSttApiKey;
@@ -631,7 +615,6 @@ public class Se
         Configuration.Settings.Tools.OpenAiCompatibleSttLanguage = Settings.Tools.OpenAiCompatibleSttLanguage;
         Configuration.Settings.Tools.OpenAiCompatibleSttTemperature = Settings.Tools.OpenAiCompatibleSttTemperature;
         Configuration.Settings.Tools.OpenAiCompatibleSttPrompt = Settings.Tools.OpenAiCompatibleSttPrompt;
-        Configuration.Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection = Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection;
         Configuration.Settings.Tools.OpenAiCompatibleSttStream = Settings.Tools.OpenAiCompatibleSttStream;
         Configuration.Settings.Tools.OpenAiCompatibleSttAudioFormat = Settings.Tools.OpenAiCompatibleSttAudioFormat;
 
@@ -660,20 +643,6 @@ public class Se
             Settings.BeautifyTimeCodes.ApplyTo(Configuration.Settings.BeautifyTimeCodes);
         }
 
-        Configuration.Settings.Tools.ImportTextSplitting = Settings.Tools.ImportTextSplitting;
-        Configuration.Settings.Tools.ImportTextSplittingLineMode = Settings.Tools.ImportTextSplittingLineMode;
-        Configuration.Settings.Tools.ImportTextLineBreak = Settings.Tools.ImportTextLineBreak;
-        Configuration.Settings.Tools.ImportTextMergeShortLines = Settings.Tools.ImportTextMergeShortLines;
-        Configuration.Settings.Tools.ImportTextAutoSplitAtBlank = Settings.Tools.ImportTextAutoSplitAtBlank;
-        Configuration.Settings.Tools.ImportTextRemoveLinesNoLetters = Settings.Tools.ImportTextRemoveLinesNoLetters;
-        Configuration.Settings.Tools.ImportTextGenerateTimeCodes = Settings.Tools.ImportTextGenerateTimeCodes;
-        Configuration.Settings.Tools.ImportTextAutoBreak = Settings.Tools.ImportTextAutoBreak;
-        Configuration.Settings.Tools.ImportTextAutoBreakAtEnd = Settings.Tools.ImportTextAutoBreakAtEnd;
-        Configuration.Settings.Tools.ImportTextGap = Settings.Tools.ImportTextGap;
-        Configuration.Settings.Tools.ImportTextAutoSplitNumberOfLines = Settings.Tools.ImportTextAutoSplitNumberOfLines;
-        Configuration.Settings.Tools.ImportTextAutoBreakAtEndMarkerText = Settings.Tools.ImportTextAutoBreakAtEndMarkerText;
-        Configuration.Settings.Tools.ImportTextDurationAuto = Settings.Tools.ImportTextDurationAuto;
-        Configuration.Settings.Tools.ImportTextFixedDuration = Settings.Tools.ImportTextFixedDuration;
 
         Configuration.Settings.Tools.MusicSymbol = Settings.Tools.MusicSymbol;
         Configuration.Settings.Tools.MusicSymbolReplace = Settings.Tools.MusicSymbolReplace;


### PR DESCRIPTION
Fourth step of stripping app logic out of **libse** (stacked on #12945 → #12943 → #12941; GitHub retargets as they merge, so only this PR's own diff is shown).

## What
Removes **386 of 584** properties from `GeneralSettings` (242 → 44-ish) and `ToolsSettings`, all verified to have **no readers anywhere** in libse, libuilogic, seconv, ui, or tests. Pure deletion: **1,062 lines removed, 0 added**.

libse's `Configuration.Settings` has no persistence of its own — ui one-way-syncs from its `Se` store via `Se.UpdateLibSeSettings()`, and seconv sets specific properties from the CLI. So a property nothing reads is dead weight in the published NuGet API.

## How it was verified
Instead of grepping (which misses aliased receivers like `var g = Configuration.Settings.General;`), every auto-property was temporarily tagged `[Obsolete("SEDEL")]` and all projects + test projects were built; the resulting CS0618 warnings give a compiler-exact usage matrix (1,116 usage sites → 451 referenced properties). Also checked there is no reflection/serialization over these classes (seconv serializes its own explicit `SeConvSettings`).

- **133 properties**: never referenced at all, not even a constructor default
- **253 properties**: referenced only by their own ctor defaults and/or ui's one-way mirror writes
- **Kept 157**: read by libse algorithms (line/duration/continuation rules, format context, AutoBreak, music symbols, EBU/DCinema serialization state), libuilogic engines (Whisper locations, translate provider config, OCR fix flags), or seconv
- **Kept 41 (follow-up)**: ui feature code still reads them via `Configuration.Settings` (mostly `OpenAiCompatibleStt*`/`OpenRouterStt*`/`DashScopeStt*` engine config) — re-pointing those reads to the `Se` tree is a separate change

## Notable removals
Toolbar visibility bools, ListView column widths/display-indexes, window/layout/undocked positions, dark-theme + color-picker colors (**no `SKColor` properties remain in Settings**), mpv/VLC/video-player config, waveform/spectrogram/auto-repeat state, autosave/update-check, BatchConvert/ASSA/BinEdit/ImportText/ExportImage dialog state, FindHistory — and the `RulesProfile` list + `AddExtraProfiles` Netflix/Amazon catalog, which was duplicated verbatim in ui's `SeGeneral` (the ui copy stays).

Also deletes the 31 mirror-sync assignments in `Se.cs` that wrote to now-removed properties, and the usings (`SkiaSharp`, `System.Collections.Generic`) that nothing needs anymore.

## Verified
- `dotnet build`: libse standalone (both TFMs incl. netstandard2.1), libuilogic, UI, seconv — all clean
- All tests pass unmodified: libse 743, libuilogic 20, seconv 279, UI 932 (1,974 total — no test needed changing, confirming nothing observable was removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)