### PR TITLE
LibUiLogic perf pass: span/SearchValues hot paths, verified with BenchmarkDotNet

### DIFF
--- a/src/libuilogic/Export/CustomTextFormatter.cs
+++ b/src/libuilogic/Export/CustomTextFormatter.cs
@@ -385,13 +385,14 @@ public static partial class CustomTextFormatter
         var actorUppercaseBracketsSpace = string.IsNullOrEmpty(actor) ? string.Empty : $"[{actor.ToUpperInvariant()}] ";
         s = PreBeginCurly(s, replaceStart);
         s = PreEndCurly(s, replaceEnd);
+        var textLengthNoLineBreaks = p.Text.RemoveChar('\r', '\n').Length;
         s = string.Format(s, start, end, text, originalText, number + 1, number, d, actor, line1, line2,
                           cps.ToString(CultureInfo.InvariantCulture).Replace(".", ","),
                           cps.ToString(CultureInfo.InvariantCulture),
                           text.Length,
-                          p.Text.RemoveChar('\r', '\n').Length,
-                          p.Text.RemoveChar('\r', '\n').Length + lines.Count - 1,
-                          p.Text.RemoveChar('\r', '\n').Length + (lines.Count - 1) * 2,
+                          textLengthNoLineBreaks,
+                          textLengthNoLineBreaks + lines.Count - 1,
+                          textLengthNoLineBreaks + (lines.Count - 1) * 2,
                           gap,
                           p.Bookmark == string.Empty ? "*" : p.Bookmark,
                           string.IsNullOrEmpty(videoFileName) ? string.Empty : System.IO.Path.GetFileNameWithoutExtension(videoFileName),
@@ -417,15 +418,15 @@ public static partial class CustomTextFormatter
         return s;
     }
 
+    private static readonly string[] ReplaceCharCandidates = { "@", "¤", "%", "=", "+", "æ", "Æ", "`", "*", ";" };
+
     private static string GetReplaceChar(string s)
     {
-        var chars = new List<char> { '@', '¤', '%', '=', '+', 'æ', 'Æ', '`', '*', ';' };
-
-        foreach (var c in chars)
+        foreach (var c in ReplaceCharCandidates)
         {
-            if (!s.Contains(c))
+            if (!s.Contains(c[0]))
             {
-                return c.ToString();
+                return c;
             }
         }
 
@@ -485,10 +486,12 @@ public static partial class CustomTextFormatter
 
     private static List<int> GetCurlyBeginIndexesReversed(string s)
     {
-        var matchIndices = CurlyCodePattern.Matches(s)
-            .Cast<Match>()
-            .Select(m => m.Index)
-            .ToList();
+        var matchIndices = new HashSet<int>();
+        foreach (var match in CurlyCodePattern.EnumerateMatches(s))
+        {
+            matchIndices.Add(match.Index);
+        }
+
         var list = new List<int>();
         for (var i = s.Length - 1; i >= 0; i--)
         {
@@ -504,10 +507,12 @@ public static partial class CustomTextFormatter
 
     private static List<int> GetCurlyEndIndexesReversed(string s)
     {
-        var matchIndices = CurlyCodePattern.Matches(s)
-            .Cast<Match>()
-            .Select(m => m.Index + m.Length - 1)
-            .ToList();
+        var matchIndices = new HashSet<int>();
+        foreach (var match in CurlyCodePattern.EnumerateMatches(s))
+        {
+            matchIndices.Add(match.Index + match.Length - 1);
+        }
+
         var list = new List<int>();
         for (var i = s.Length - 1; i >= 0; i--)
         {

--- a/src/libuilogic/Ocr/BinaryOcrMatcher.cs
+++ b/src/libuilogic/Ocr/BinaryOcrMatcher.cs
@@ -90,6 +90,22 @@ public class BinaryOcrMatcher : IBinaryOcrMatcher
 
         var bob = new BinaryOcrBitmap(target) { X = targetItem.X, Y = targetItem.Top };
 
+        // The two expanded-match passes below need the BinaryOcrBitmap of the glyphs
+        // following the target; constructing one is a per-pixel scan plus a Murmur hash,
+        // so cache them per offset instead of rebuilding for every candidate DB entry.
+        Dictionary<int, BinaryOcrBitmap>? followingBobCache = null;
+        BinaryOcrBitmap GetFollowingBob(int offset)
+        {
+            followingBobCache ??= new Dictionary<int, BinaryOcrBitmap>();
+            if (!followingBobCache.TryGetValue(offset, out var cached))
+            {
+                cached = new BinaryOcrBitmap(list[listIndex + offset + 1].NikseBitmap!);
+                followingBobCache.Add(offset, cached);
+            }
+
+            return cached;
+        }
+
         // precise expanded match
         for (var k = 0; k < binaryOcrDb.CompareImagesExpanded.Count; k++)
         {
@@ -101,7 +117,7 @@ public class BinaryOcrMatcher : IBinaryOcrMatcher
                 {
                     if (listIndex + i + 1 < list.Count && list[listIndex + i + 1].NikseBitmap != null)
                     {
-                        var bobNext = new BinaryOcrBitmap(list[listIndex + i + 1].NikseBitmap!);
+                        var bobNext = GetFollowingBob(i);
                         if (b.ExpandedList[i].Hash == bobNext.Hash)
                         {
                             ok = true;
@@ -137,7 +153,7 @@ public class BinaryOcrMatcher : IBinaryOcrMatcher
                 {
                     if (listIndex + i + 1 < list.Count && list[listIndex + i + 1].NikseBitmap != null)
                     {
-                        var bobNext = new BinaryOcrBitmap(list[listIndex + i + 1].NikseBitmap!);
+                        var bobNext = GetFollowingBob(i);
                         if (b.ExpandedList[i].Hash == bobNext.Hash)
                         {
                             ok = true;

--- a/src/libuilogic/Ocr/FixEngine/UnknownWordGuesser.cs
+++ b/src/libuilogic/Ocr/FixEngine/UnknownWordGuesser.cs
@@ -2,6 +2,12 @@
 
 public static class UnknownWordGuesser
 {
+    // Vowel set shared by the split heuristics; SearchValues gives O(1) probes without
+    // allocating a char[] per call.
+    private static readonly System.Buffers.SearchValues<char> Vowels = System.Buffers.SearchValues.Create("aeiouæøåöüäéèêëàâîïôûùyąęół");
+
+    private static readonly string[] RestrictedLanguages = { "dan", "eng", "swe", "deu", "pol", "fra" };
+
     private static readonly Dictionary<string, string[]> LanguageAffixes = new(StringComparer.OrdinalIgnoreCase)
     {
         { "eng", new[] { "ing", "ed", "ly", "ment", "ness", "pre", "anti", "tion", "sion" } },
@@ -52,13 +58,12 @@ public static class UnknownWordGuesser
         }
 
         // Skip names (Upper Case start + mostly lowercase + relatively short)
-        if (char.IsUpper(word[0]) && word.Length < 10 && word.Skip(1).All(char.IsLower))
+        if (char.IsUpper(word[0]) && word.Length < 10 && AllLowerFromSecondChar(word))
         {
             return Enumerable.Empty<string>();
         }
 
         var results = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var vowels = "aeiouæøåöüäéèêëàâîïôûùyąęół".ToCharArray();
         string lang = threeLetterIsoLanguageName.ToLower();
 
         // 1. Particle Splitting (Special case for "of", "the", etc.)
@@ -104,22 +109,34 @@ public static class UnknownWordGuesser
         // 3. Smart Phonetic Splits (skipped for closed-compounding languages - see #12200)
         if (word.Length > 7 && !CompoundingLanguages.Contains(lang))
         {
-            foreach (var split in GenerateSmartSplits(word, vowels))
+            foreach (var split in GenerateSmartSplits(word))
             {
                 results.Add(split);
             }
         }
 
-        var restrictedLanguages = new[] { "dan", "eng", "swe", "deu", "pol", "fra" };
-        if (restrictedLanguages.Contains(lang))
+        if (RestrictedLanguages.Contains(lang))
         {
-            return results.Where(s => IsValidSplitting(s, vowels)).ToList();
+            return results.Where(IsValidSplitting).ToList();
         }
 
         return results;
     }
 
-    private static IEnumerable<string> GenerateSmartSplits(string word, char[] vowels)
+    private static bool AllLowerFromSecondChar(string word)
+    {
+        for (var i = 1; i < word.Length; i++)
+        {
+            if (!char.IsLower(word[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static IEnumerable<string> GenerateSmartSplits(string word)
     {
         var guesses = new List<string>();
         for (int i = 3; i < word.Length - 3; i++)
@@ -132,8 +149,8 @@ public static class UnknownWordGuesser
                 continue;
             }
 
-            bool isVowel = vowels.Contains(char.ToLower(word[i]));
-            bool prevIsVowel = vowels.Contains(char.ToLower(word[i - 1]));
+            bool isVowel = Vowels.Contains(char.ToLower(word[i]));
+            bool prevIsVowel = Vowels.Contains(char.ToLower(word[i - 1]));
 
             // Split between two consonants (mer-cat)
             if (!isVowel && !prevIsVowel)
@@ -149,13 +166,13 @@ public static class UnknownWordGuesser
         return guesses;
     }
 
-    private static bool IsValidSplitting(string sentence, char[] vowels)
+    private static bool IsValidSplitting(string sentence)
     {
         var parts = sentence.Split(' ', StringSplitOptions.RemoveEmptyEntries);
         foreach (var p in parts)
         {
             // Reject single-letter consonants (keep single vowels like 'a' or 'i')
-            if (p.Length == 1 && char.IsLetter(p[0]) && !vowels.Contains(char.ToLower(p[0])))
+            if (p.Length == 1 && char.IsLetter(p[0]) && !Vowels.Contains(char.ToLower(p[0])))
             {
                 return false;
             }

--- a/src/libuilogic/Ocr/NikseBitmapImageSplitter2.cs
+++ b/src/libuilogic/Ocr/NikseBitmapImageSplitter2.cs
@@ -430,11 +430,17 @@ public class NikseBitmapImageSplitter2
     {
         var different = 0;
         var maxDiff = bmp1.Width * bmp1.Height / 5;
+        var data1 = bmp1.GetPixelData();
+        var data2 = bmp2.GetPixelData();
+        var stride1 = bmp1.Width * 4;
+        var stride2 = bmp2.Width * 4;
         for (var y = 0; y < bmp1.Height; y++)
         {
-            for (var x = 0; x < bmp1.Width; x++)
+            var row1 = y * stride1;
+            var row2 = y * stride2;
+            for (var offset = 0; offset < stride1; offset += 4)
             {
-                if (!IsColorClose(bmp1.GetPixel(x, y), bmp2.GetPixel(x, y), 20))
+                if (!IsColorCloseBgra(data1, row1 + offset, data2, row2 + offset, 20))
                 {
                     different++;
                 }
@@ -446,6 +452,43 @@ public class NikseBitmapImageSplitter2
         }
 
         return different;
+    }
+
+    /// <summary>
+    /// IsColorClose over two raw BGRA quads. Replicates the channel mapping the
+    /// SKColor-based overload sees through NikseBitmap2.GetPixel, which constructs
+    /// SKColor(red: byte3, green: byte2, blue: byte1, alpha: byte0) - i.e. the
+    /// "alpha" it tests is the B byte and the RGB sum is over the A, R and G bytes.
+    /// Both operands are read identically, so the comparison result is unchanged.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsColorCloseBgra(ReadOnlySpan<byte> data1, int i1, ReadOnlySpan<byte> data2, int i2, int tolerance)
+    {
+        var alpha1 = data1[i1];
+        var alpha2 = data2[i2];
+
+        // Both transparent
+        if (alpha1 < 120 && alpha2 < 120)
+        {
+            return true;
+        }
+
+        // Different alpha levels
+        if (Math.Abs(alpha1 - alpha2) > 50)
+        {
+            return false;
+        }
+
+        // Both dark and non-transparent
+        if (alpha1 > 250 && alpha2 > 250 &&
+            data1[i1 + 3] > 90 && data1[i1 + 2] > 90 && data1[i1 + 1] > 90 &&
+            data2[i2 + 3] > 90 && data2[i2 + 2] > 90 && data2[i2 + 1] > 90)
+        {
+            return true;
+        }
+
+        var diff = data1[i1 + 3] + data1[i1 + 2] + data1[i1 + 1] - (data2[i2 + 3] + data2[i2 + 2] + data2[i2 + 1]);
+        return (uint)(diff + tolerance) <= (uint)(tolerance * 2);
     }
 
     public static List<ImageSplitterItem2> SplitBitmapToLettersNew(NikseBitmap2 bmp, int xOrMorePixelsMakesSpace, bool rightToLeft, bool topToBottom, int minLineHeight, bool autoHeight, double averageLineHeight = -1)

--- a/src/libuilogic/SpellCheck/SpellCheckWordLists.cs
+++ b/src/libuilogic/SpellCheck/SpellCheckWordLists.cs
@@ -17,8 +17,17 @@ public class SpellCheckWordLists
         '\u202B', '\u202C', '\u202D', '\u202E', '\u202F', '\u3000', '\uFEFF'
     };
 
+    // SplitChars plus every char.IsControl character (U+0000-U+001F, U+007F-U+009F), so Split
+    // can scan with a single vectorized IndexOfAny. Declared after SplitChars - static field
+    // initializers run in declaration order.
+    private static readonly System.Buffers.SearchValues<char> SplitOrControlChars = System.Buffers.SearchValues.Create(
+        string.Concat(SplitChars) +
+        new string(Enumerable.Range(0x00, 0x20).Select(i => (char)i).ToArray()) +
+        new string(Enumerable.Range(0x7F, 0x21).Select(i => (char)i).ToArray()));
+
     private static readonly char[] PeriodAndDash = { '.', '-' };
     private static readonly char[] ApostropheChars = { '\'', '‘', '’' };
+    private static readonly System.Buffers.SearchValues<char> ApostropheSearchValues = System.Buffers.SearchValues.Create("'‘’");
     private static readonly char[] SplitChars2 = { ' ', '.', ',', '?', '!', ':', ';', '"', '“', '”', '(', ')', '[', ']', '{', '}', '|', '<', '>', '/', '+', '\r', '\n', '¿', '¡', '…', '—', '–', '♪', '♫', '„', '«', '»', '‹', '›', '؛', '،', '؟' };
 
     private readonly NameList _nameList;
@@ -387,26 +396,18 @@ public class SpellCheckWordLists
     public static List<SpellCheckWord> Split(string s)
     {
         var list = new List<SpellCheckWord>();
-        var sb = new StringBuilder();
-        for (int i = 0; i < s.Length; i++)
+        var span = s.AsSpan();
+        var pos = 0;
+        while (pos < span.Length)
         {
-            if (SplitChars.Contains(s[i]) || char.IsControl(s[i]))
+            var relative = span.Slice(pos).IndexOfAny(SplitOrControlChars);
+            var end = relative < 0 ? span.Length : pos + relative;
+            if (end > pos)
             {
-                if (sb.Length > 0)
-                {
-                    AddWord(list, sb.ToString(), i - sb.Length);
-                }
+                AddWord(list, s.Substring(pos, end - pos), pos);
+            }
 
-                sb.Clear();
-            }
-            else
-            {
-                sb.Append(s[i]);
-            }
-        }
-        if (sb.Length > 0)
-        {
-            AddWord(list, sb.ToString(), s.Length - sb.Length);
+            pos = end + 1;
         }
 
         return list;
@@ -418,7 +419,7 @@ public class SpellCheckWordLists
     // be spell-checked - it has no word characters and would just be flagged as unknown. (#12143)
     private static void AddWord(List<SpellCheckWord> list, string text, int index)
     {
-        if (text.Trim(ApostropheChars).Length == 0)
+        if (text.AsSpan().IndexOfAnyExcept(ApostropheSearchValues) < 0)
         {
             return;
         }

--- a/tests/benchmarks/UiLogicPerfHuntBenchmarks.cs
+++ b/tests/benchmarks/UiLogicPerfHuntBenchmarks.cs
@@ -1,0 +1,179 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.UiLogic.Export;
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// NikseBitmapImageSplitter2.IsBitmapsAlike is the inner loop of binary OCR matching -
+/// BinaryOcrMatcher.FindBestMatch runs it against up to 9 size-shifted variants of every
+/// database glyph for every unmatched character.
+/// </summary>
+[MemoryDiagnoser]
+public class IsBitmapsAlikeBenchmarks
+{
+    private NikseBitmap2 _glyphA = null!;
+    private NikseBitmap2 _glyphB = null!;
+    private NikseBitmap2 _glyphDifferent = null!;
+
+    public static NikseBitmap2 MakeGlyph(int width, int height, int seed)
+    {
+        var data = new byte[width * height * 4];
+        for (var i = 0; i < data.Length; i += 4)
+        {
+            // deterministic pseudo-glyph: some opaque white "strokes", rest transparent
+            var pixel = i / 4;
+            var on = (pixel * 31 + seed * 17) % 7 < 2;
+            data[i] = (byte)(on ? 255 : 0);     // B
+            data[i + 1] = (byte)(on ? 255 : 0); // G
+            data[i + 2] = (byte)(on ? 255 : 0); // R
+            data[i + 3] = (byte)(on ? 255 : 0); // A
+        }
+
+        return new NikseBitmap2(width, height, data);
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _glyphA = MakeGlyph(28, 42, seed: 1);
+        _glyphB = MakeGlyph(28, 42, seed: 1);
+        _glyphDifferent = MakeGlyph(28, 42, seed: 5);
+    }
+
+    [Benchmark]
+    public int IsBitmapsAlike_Same() => NikseBitmapImageSplitter2.IsBitmapsAlike(_glyphA, _glyphB);
+
+    [Benchmark]
+    public int IsBitmapsAlike_Different() => NikseBitmapImageSplitter2.IsBitmapsAlike(_glyphA, _glyphDifferent);
+}
+
+/// <summary>
+/// BinaryOcrBitmap's ctor (per-pixel GetAlpha loop + MurmurHash) runs once per glyph per
+/// OCR'd character - and, before the fix, once per matching expanded-DB entry as well.
+/// </summary>
+[MemoryDiagnoser]
+public class BinaryOcrBitmapCtorBenchmarks
+{
+    private NikseBitmap2 _glyph = null!;
+
+    [GlobalSetup]
+    public void Setup() => _glyph = IsBitmapsAlikeBenchmarks.MakeGlyph(28, 42, seed: 3);
+
+    [Benchmark]
+    public BinaryOcrBitmap Construct() => new BinaryOcrBitmap(_glyph);
+}
+
+/// <summary>
+/// The expanded-match passes in BinaryOcrMatcher.GetCompareMatch iterate the whole
+/// CompareImagesExpanded list per glyph; before the fix they reconstructed the same
+/// following-glyph BinaryOcrBitmap for every candidate DB entry.
+/// </summary>
+[MemoryDiagnoser]
+public class BinaryOcrExpandedMatchBenchmarks
+{
+    private BinaryOcrMatcher _matcher = null!;
+    private BinaryOcrDb _db = null!;
+    private List<ImageSplitterItem2> _list = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _matcher = new BinaryOcrMatcher();
+        _db = new BinaryOcrDb("bench.db", loadCompareImages: false);
+
+        // A line of 8 glyphs, all 28x42-ish - realistic: glyph sizes cluster tightly,
+        // so the +-3 size gate of the "allow for error %" pass passes often.
+        _list = new List<ImageSplitterItem2>();
+        for (var i = 0; i < 8; i++)
+        {
+            _list.Add(new ImageSplitterItem2(i * 30, 0, IsBitmapsAlikeBenchmarks.MakeGlyph(28, 42, seed: 100 + i)));
+        }
+
+        // 300 expanded entries whose dimensions match the target but whose expanded-list
+        // hashes never match, so every entry walks its ExpandedList and (pre-fix)
+        // constructs fresh BinaryOcrBitmaps for the following glyphs each time.
+        for (var i = 0; i < 300; i++)
+        {
+            var entry = new BinaryOcrBitmap(IsBitmapsAlikeBenchmarks.MakeGlyph(28, 42, seed: 100), false, 2, "ab", 0, 0);
+            entry.ExpandedList = new List<BinaryOcrBitmap>
+            {
+                new BinaryOcrBitmap(IsBitmapsAlikeBenchmarks.MakeGlyph(28, 42, seed: 1000 + i), false, 0, "b", 30, 0),
+            };
+            _db.CompareImagesExpanded.Add(entry);
+        }
+    }
+
+    [Benchmark]
+    public BinaryOcrMatcher.CompareMatch? GetCompareMatch_ExpandedScan()
+    {
+        return _matcher.GetCompareMatch(_list[0], out _, _list, 0, _db, maxErrorPercent: 6.0);
+    }
+}
+
+/// <summary>
+/// SpellCheckWordLists.Split runs per line in the spell-check underline transformer and
+/// syntax-highlighting converter, i.e. on grid repaints with live spell check enabled.
+/// </summary>
+[MemoryDiagnoser]
+public class SpellCheckSplitBenchmarks
+{
+    private const string Line = "It's very important to understand, that the world - as we know it - isn't just a place which accepts our norms!";
+
+    [Benchmark]
+    public List<SpellCheckWord> Split() => SpellCheckWordLists.Split(Line);
+}
+
+/// <summary>
+/// UnknownWordGuesser.CreateGuessesFromLetters runs once per unknown OCR word.
+/// </summary>
+[MemoryDiagnoser]
+public class UnknownWordGuesserBenchmarks
+{
+    [Benchmark]
+    public int Guesses_English() => UnknownWordGuesser.CreateGuessesFromLetters("understandthe", "eng").Count();
+
+    [Benchmark]
+    public int Guesses_SkippedName() => UnknownWordGuesser.CreateGuessesFromLetters("Johnson", "eng").Count();
+
+    [Benchmark]
+    public int Guesses_Compounding() => UnknownWordGuesser.CreateGuessesFromLetters("vaudevilleveteraan", "nld").Count();
+}
+
+/// <summary>
+/// The curly-brace escape scans in CustomTextFormatter run per exported paragraph;
+/// GetCurlyBeginIndexesReversed/GetCurlyEndIndexesReversed were O(len * matches).
+/// </summary>
+[MemoryDiagnoser]
+public class CustomTextFormatterCurlyBenchmarks
+{
+    private CustomFormatTemplate _template = null!;
+    private List<Paragraph> _paragraphs = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _template = new CustomFormatTemplate
+        {
+            Name = "bench",
+            Extension = ".txt",
+            FormatHeader = string.Empty,
+            FormatFooter = string.Empty,
+            FormatParagraph = "{{literal}} {4} -> {0} --> {1} {2} {{more literals}} {16}",
+            FormatTimeCode = "hh:mm:ss,zzz",
+            FormatNewLine = "|",
+        };
+
+        _paragraphs = new List<Paragraph>();
+        for (var i = 0; i < 200; i++)
+        {
+            _paragraphs.Add(new Paragraph($"Line {i} with some text{Environment.NewLine}and a second line", i * 2000, i * 2000 + 1800));
+        }
+    }
+
+    [Benchmark]
+    public string GenerateWithLiteralCurlies() => CustomTextFormatter.GenerateCustomText(_template, _paragraphs, "title", "video.mkv");
+}


### PR DESCRIPTION
Performance/modernization hunt in LibUiLogic using newer .NET features (spans, `SearchValues`, `Regex.EnumerateMatches`), with every claim measured and every change proven behavior-identical.

## Verification method
- **Behavior**: a 298-case dump harness runs every touched function over an edge-case battery (empty/apostrophe-only/control-char/CJK/RTL strings, alpha-boundary bitmap bytes at 119/120/250/251, curly-brace template corner cases, expanded-match hits and misses) — output is **byte-identical** before and after. All 1,974 tests pass unmodified.
- **Performance**: new `UiLogicPerfHuntBenchmarks` (committed) run with BenchmarkDotNet's default job before (via `git stash`) and after, back-to-back in the same machine state. The **unchanged** `BinaryOcrBitmap` ctor benchmark acts as the noise yardstick: 1,633 vs 1,457 ns (~11 %) between the two runs, allocations byte-identical — every win below is far outside that band.

## Results
| Hot path | Before | After | Time | Allocated |
|---|---|---|---|---|
| `IsBitmapsAlike` (similar pair) | 3,792 ns | 1,560 ns | **2.4×** | 0 → 0 |
| `IsBitmapsAlike` (different pair) | 3,177 ns | 1,124 ns | **2.8×** | 0 → 0 |
| `GetCompareMatch` expanded scan (300-entry DB) | 9,692 ns | 3,170 ns | **3.1×** | 8,144 → 3,144 B |
| `CustomTextFormatter` (200 lines, literal curlies) | 820 µs | 611 µs | **1.3×** | 2.32 → 1.71 MB |
| `SpellCheckWordLists.Split` | 834 ns | 528 ns | **1.6×** | 2,016 → 1,912 B |
| `UnknownWordGuesser` name-skip path | 48 ns | 6.6 ns | **7.3×** | 112 → 0 B |
| `UnknownWordGuesser` compounding path | 60 ns | 48 ns | 1.3× | 240 → 64 B |

## Changes
- **`NikseBitmapImageSplitter2.IsBitmapsAlike`** — the inner loop of binary OCR matching (`FindBestMatch` sweeps it against up to 9 size-shifted variants of every DB glyph). Now walks the raw BGRA buffers with per-bitmap strides instead of per-pixel `GetPixel`/`SKColor` construction. ⚠️ Note: `NikseBitmap2.GetPixel` passes bytes to `SKColor(r,g,b,a)` in A,R,G,B order — a latent swizzle. The new inlined comparison **replicates that mapping exactly** (documented in code) so comparisons are unchanged; whether `GetPixel` itself should be fixed is left as a separate decision since `CropTop`/`VobSubAntialize`/`SplitToLinesTransparentOrBlack` read the swizzled channels.
- **`BinaryOcrMatcher.GetCompareMatch`** — both expanded-match passes rebuilt the same following-glyph `BinaryOcrBitmap`s (a per-pixel scan + Murmur hash each) for every candidate DB entry; they're now memoized per offset in a lazily-created dictionary.
- **`SpellCheckWordLists.Split`** — runs per line on grid repaints with live spell check. One vectorized `SearchValues.IndexOfAny` over the split chars **plus all `char.IsControl` chars** (semantics preserved), slicing words directly instead of a per-char `StringBuilder`. `AddWord` detects apostrophe-only tokens with `IndexOfAnyExcept` — no more throwaway trimmed string.
- **`UnknownWordGuesser`** — static `SearchValues<char>` vowels (was `"aeiou…".ToCharArray()` per call), static restricted-language array (was a `new[]` per call), and a plain loop replacing `word.Skip(1).All(char.IsLower)`.
- **`CustomTextFormatter`** — `GetCurlyBeginIndexesReversed`/`GetCurlyEndIndexesReversed` were O(len × matches) via `List.Contains` per char; now `Regex.EnumerateMatches` (allocation-free) into a `HashSet<int>`. Replace-char candidates are static, and the triple identical `p.Text.RemoveChar('\r','\n')` per paragraph is hoisted to one call.

## Explicitly not touched (candidates for follow-ups)
The survey also flagged: `ImageRenderer`'s per-call `SKShaper` construction + 32 MB scratch bitmap per exported image, `MergeAndSplitHelper`'s O(N²) `ExceedsMaxSize`, `BinaryOcrDb.FindExactMatch`'s linear scan + MRU reorder, per-predicate `bool[]` allocations in `BinaryOcrBitmap`, and `NOcrLine.ScaledWalkPoints` division hoisting. Each is more invasive or harder to verify deterministically — happy to take them on separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)