### PR TITLE
Expand the libse NuGet readme

### DIFF
--- a/src/libse/Readme.md
+++ b/src/libse/Readme.md
@@ -1,19 +1,68 @@
 ﻿# libse
 
-## How to load a subtitle file
-```csharp
-var subtitle = Subtitle.Parse(fileName);
-var numberOfSubtitleLines = subtitle.Paragraphs.Count;
-var firstText = subtitle.Paragraphs.First().Text;
-var firstStartMilliseconds = subtitle.Paragraphs.First().StartTime.TotalMilliseconds;
+`libse` is the subtitle engine behind [Subtitle Edit](https://github.com/SubtitleEdit/subtitleedit) —
+a general-purpose .NET library for reading, writing, converting, and fixing subtitles.
+
+- **300+ subtitle formats**: SubRip (.srt), Advanced SubStation Alpha (.ass), WebVTT (.vtt),
+  SAMI, EBU STL, PAC, Cavena 890, Timed Text / TTML, DFXP, SCC, and many more
+- **Image-based and container formats**: Blu-ray SUP, VobSub (.sub/.idx), DVB subtitles in
+  transport streams, Matroska (.mkv), MP4, MXF
+- **Fixing and formatting**: fix common errors, auto-break/unbreak lines, remove text for
+  hearing impaired, remove interjections, merge/split lines, bridge gaps, beautify time codes
+- **Detection**: subtitle format auto-detection, text encoding detection, language auto-detection
+- Targets **.NET Standard 2.1** and **.NET 10**, MIT licensed
+
+## Install
+
+```
+dotnet add package libse
 ```
 
-## How to save a subtitle file
+## Load a subtitle file
+
+The format and text encoding are detected automatically:
+
+```csharp
+var subtitle = Subtitle.Parse(fileName); // null if not a known subtitle format
+var numberOfLines = subtitle.Paragraphs.Count;
+var firstText = subtitle.Paragraphs.First().Text;
+var firstStartMs = subtitle.Paragraphs.First().StartTime.TotalMilliseconds;
+var formatName = subtitle.OriginalFormat.FriendlyName; // e.g. "SubRip (.srt)"
+```
+
+## Save / convert a subtitle file
+
+Every format can serialize a `Subtitle` via `ToText`, so converting is just loading with one
+format and saving with another:
+
 ```csharp
 File.WriteAllText("new.srt", new SubRip().ToText(subtitle, "untitled"));
+File.WriteAllText("new.vtt", new WebVTT().ToText(subtitle, "untitled"));
+```
+
+All formats are available via `SubtitleFormat.AllSubtitleFormats`.
+
+## Common operations
+
+```csharp
+// Shift all cues 1.5 seconds later
+subtitle.AddTimeToAllParagraphs(TimeSpan.FromSeconds(1.5));
+
+// Re-time frame-based cues after a frame rate change
+subtitle.ChangeFrameRate(25.0, 23.976);
+
+// Auto-break a long line into two balanced lines
+var broken = Utilities.AutoBreakLine("This is a very long subtitle line that should be broken into two nicely balanced lines");
+
+// Strip formatting
+var plain = HtmlUtil.RemoveHtmlTags(text, alsoSsaTags: true);
+
+// Detect the language of a subtitle
+var languageCode = LanguageAutoDetect.AutoDetectGoogleLanguage(subtitle); // e.g. "en"
 ```
 
 ## License
+
 `libse` is licensed under the MIT License, so it is free to use for both personal and commercial software.
 You are free to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the library
 without any restrictions, as long as the original copyright notice and license are included.


### PR DESCRIPTION
Readies the package readme for nuget.org. The old readme was just two code snippets; the new one covers:

- What the library is (the subtitle engine behind Subtitle Edit) and its feature areas: 300+ text formats, image-based/container formats (Blu-ray SUP, VobSub, DVB/TS, Matroska, MP4, MXF), fixing/formatting, and the three auto-detections (format, encoding, language)
- Target frameworks (.NET Standard 2.1 + .NET 10) and MIT licensing
- `dotnet add package libse`
- Verified examples: load with auto-detection (incl. `OriginalFormat`), convert between formats via `ToText`, `SubtitleFormat.AllSubtitleFormats`, time shift, frame-rate re-timing, `Utilities.AutoBreakLine`, `HtmlUtil.RemoveHtmlTags`, `LanguageAutoDetect`

**Every code sample was compiled and executed** against the current library in a scratch console project — outputs checked (e.g. `FriendlyName` documented as `"SubRip (.srt)"`, its actual value). `AllSubtitleFormats` counts 332 formats, so the "300+" claim is accurate.

## Publish-readiness check (no changes needed)
- `dotnet pack` clean on both TFMs; nupkg contains Icon.png, LICENSE.txt, Readme.md, XML docs for both TFMs; snupkg produced
- nuspec metadata correct: description, tags, MIT license file, repo URL + commit (SourceLink), dependencies (SkiaSharp, UTF.Unknown) per TFM
- `publish-nuget.yml` workflow: manual dispatch with mandatory explicit version (semver-validated), runs libse tests before packing, `ContinuousIntegrationBuild=true`, artifact upload for inspection, trusted publishing (OIDC) to nuget.org gated behind a checkbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)