### PR TITLE
Add "Show selected lines earlier/later" to subtitle grid context menu

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1017,6 +1017,12 @@ public static partial class InitListViewAndEditBox
                 },
                 new MenuItem
                 {
+                    Header = Se.Language.Main.Menu.ShowSelectedLinesEarlierLater,
+                    Command = vm.ShowSyncAdjustAllTimesSelectedLinesCommand,
+                    DataContext = vm,
+                },
+                new MenuItem
+                {
                     Header = Se.Language.Main.Menu.VisualSync,
                     Command = vm.ShowVisualSyncSelectedLinesCommand,
                     DataContext = vm,

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8112,6 +8112,17 @@ public partial class MainViewModel :
     [RelayCommand]
     private void ShowSyncAdjustAllTimes()
     {
+        ShowAdjustAllTimes(forceSelectedLines: false);
+    }
+
+    [RelayCommand]
+    private void ShowSyncAdjustAllTimesSelectedLines()
+    {
+        ShowAdjustAllTimes(forceSelectedLines: true);
+    }
+
+    private void ShowAdjustAllTimes(bool forceSelectedLines)
+    {
         if (Window == null)
         {
             return;
@@ -8126,6 +8137,11 @@ public partial class MainViewModel :
 
         if (_adjustAllTimesViewModel != null && _adjustAllTimesViewModel.Window != null && _adjustAllTimesViewModel.Window.IsVisible)
         {
+            if (forceSelectedLines)
+            {
+                _adjustAllTimesViewModel.SelectAdjustSelectedLines();
+            }
+
             _adjustAllTimesViewModel.Window.Activate();
             return;
         }
@@ -8134,7 +8150,7 @@ public partial class MainViewModel :
         {
             _adjustAllTimesViewModel = vm;
             var selectedCount = SubtitleGrid.SelectedItems.Count;
-            vm.Initialize(this, selectedCount); // uses call from IAdjustCallback: Adjust
+            vm.Initialize(this, selectedCount, forceSelectedLines); // uses call from IAdjustCallback: Adjust
         });
     }
 

--- a/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesViewModel.cs
+++ b/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesViewModel.cs
@@ -33,9 +33,16 @@ public partial class AdjustAllTimesViewModel : ObservableObject
         StatusText = string.Empty;
     }
 
-    public void Initialize(IAdjustCallback adjustCallback, int selectedLinesCount)
+    public void Initialize(IAdjustCallback adjustCallback, int selectedLinesCount, bool forceSelectedLines = false)
     {
         _adjustCallback = adjustCallback;
+
+        if (forceSelectedLines)
+        {
+            SelectAdjustSelectedLines();
+            return;
+        }
+
         if (selectedLinesCount > 1)
         {
             AdjustSelectedLines = true;
@@ -53,6 +60,13 @@ public partial class AdjustAllTimesViewModel : ObservableObject
             AdjustSelectedLines = choice == "Selected";
             AdjustSelectedLinesAndForward = choice == "SelectedAndForward";
         }
+    }
+
+    internal void SelectAdjustSelectedLines()
+    {
+        AdjustAll = false;
+        AdjustSelectedLinesAndForward = false;
+        AdjustSelectedLines = true;
     }
 
     private void LoadSettings()

--- a/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
@@ -112,6 +112,7 @@ public class LanguageMainMenu
 
     public string Synchronization { get; set; }
     public string AdjustAllTimes { get; set; }
+    public string ShowSelectedLinesEarlierLater { get; set; }
     public string ChangeFrameRate { get; set; }
     public string ChangeSpeed { get; set; }
     public string VisualSync { get; set; }
@@ -254,6 +255,7 @@ public class LanguageMainMenu
 
         Synchronization = "S_ynchronization";
         AdjustAllTimes = "_Adjust all times...";
+        ShowSelectedLinesEarlierLater = "Show selected lines earlier/later...";
         VisualSync = "_Visual sync...";
         PointSync = "_Point sync...";
         PointSyncViaOther = "Point sync via _other subtitle...";


### PR DESCRIPTION
A user reported searching in vain for "show selected lines earlier/later" — the adjust-all-times window supports selected lines, but it was only reachable via the Synchronization menu.

This adds a "Show selected lines earlier/later..." entry to the subtitle grid's "Selected lines" context submenu (next to Visual sync). It opens the existing adjust-all-times window with the "selected lines" radio preselected, overriding the remembered line-selection choice for that entry point. If the window is already open, invoking the menu item switches it to selected-lines mode and activates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)