### PR TITLE
Fix undo wiping the original subtitle text column

### DIFF
--- a/src/ui/Logic/UndoRedo/UndoRedoManager.cs
+++ b/src/ui/Logic/UndoRedo/UndoRedoManager.cs
@@ -363,7 +363,12 @@ public sealed class UndoRedoManager : IUndoRedoManager
             var o = prev.Subtitles[i];
             var n = next.Subtitles[i];
 
-            var textChanged = o.Text != n.Text;
+            // OriginalText must be compared here: the undo hash covers the original column
+            // (see GetUndoRedoHash), so if this comparison ignores it, loading or editing an
+            // original changes the hash without ever producing an undo entry - and the next
+            // undo restores a snapshot whose originals are stale or empty, wiping the whole
+            // original column (#12952).
+            var textChanged = o.Text != n.Text || o.OriginalText != n.OriginalText;
             var timingChanged =
                 Math.Abs(o.StartTime.TotalMilliseconds - n.StartTime.TotalMilliseconds) > 0.5 ||
                 Math.Abs(o.EndTime.TotalMilliseconds - n.EndTime.TotalMilliseconds) > 0.5;
@@ -406,15 +411,19 @@ public sealed class UndoRedoManager : IUndoRedoManager
         var n = next.Subtitles[line - 1];
 
         var textChanged = o.Text != n.Text;
+        var originalTextChanged = o.OriginalText != n.OriginalText;
         var timingChanged =
             Math.Abs(o.StartTime.TotalMilliseconds - n.StartTime.TotalMilliseconds) > 0.5 ||
             Math.Abs(o.EndTime.TotalMilliseconds - n.EndTime.TotalMilliseconds) > 0.5;
 
-        return (textChanged, timingChanged) switch
+        return (textChanged || originalTextChanged, timingChanged) switch
         {
             (true, true) => string.Format(Se.Language.Main.LineXTextAndTimingChanged, line),
-            (true, false) => string.Format(Se.Language.Main.LineXTextChangedFromYToZ,
-                                 line, Truncate(o.Text), Truncate(n.Text)),
+            (true, false) => textChanged
+                ? string.Format(Se.Language.Main.LineXTextChangedFromYToZ,
+                    line, Truncate(o.Text), Truncate(n.Text))
+                : string.Format(Se.Language.Main.LineXTextChangedFromYToZ,
+                    line, Truncate(o.OriginalText), Truncate(n.OriginalText)),
             (false, true) => string.Format(Se.Language.Main.LineXTimingChanged, line),
             _ => $"Line {line}: modified"
         };

--- a/tests/UI/Logic/UndoRedo/UndoRedoManagerTests.cs
+++ b/tests/UI/Logic/UndoRedo/UndoRedoManagerTests.cs
@@ -474,6 +474,28 @@ public class UndoRedoManagerTests
     }
 
     [Fact]
+    public void CheckForChanges_AddsEntry_WhenOnlyOriginalTextChanges_Issue12952()
+    {
+        var lines1 = new[] { MakeLine("hello") };
+        var client = new FakeClient { Hash = 1, Subtitles = lines1 };
+        var manager = new UndoRedoManager();
+        manager.SetupChangeDetection(client, TimeSpan.FromHours(1));
+        manager.StartChangeDetection();
+        manager.Do(MakeItem("initial", 1, lines1));
+
+        // Simulate loading an original subtitle: translation text/timings are unchanged,
+        // only OriginalText is filled. The hash covers the original, so a snapshot must be
+        // recorded - otherwise the next undo restores empty originals (#12952).
+        var withOriginal = MakeLine("hello");
+        withOriginal.OriginalText = "hej";
+        client.Hash = 2;
+        client.Subtitles = [withOriginal];
+        manager.CheckForChanges(null);
+
+        Assert.Equal(2, manager.UndoCount);
+    }
+
+    [Fact]
     public void CheckForChanges_DoesNotAddEntry_WhenHashAlreadyTracked()
     {
         var lines = new[] { MakeLine("hello") };


### PR DESCRIPTION
Fixes #12952

## Cause

The fix for #12786 made the undo hash cover the original column (`GetUndoRedoHash = GetFastHash * 31 + GetFastHashOriginal`), but `UndoRedoManager.DetectContentChanges` still only compared `Text`, timing and bookmark. So after loading (or editing) an original subtitle:

1. The change-detection tick sees a new hash and builds a snapshot **with** the original text…
2. …but `HasChanges` discards it because no `Text`/timing/bookmark differs — the undo stack still only holds the pre-load snapshot with empty originals.
3. `CanUndo` is true (live hash ≠ last recorded hash), so the first Ctrl+Z restores that pre-load snapshot and wipes the entire original column.

(Ctrl+Y right after the accidental undo brings the original back, since the live state is pushed onto the redo stack — a usable workaround for affected users.)

## Fix

- `DetectContentChanges` now also compares `OriginalText`, so original-only changes are recorded on the undo stack like any text change.
- `SingleLineDescription` shows the original-text before/after when only the original changed.
- Regression test: `CheckForChanges_AddsEntry_WhenOnlyOriginalTextChanges_Issue12952`.

All 30 `UndoRedoManagerTests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)