### PR TITLE
Fix Paddle OCR launch on macOS (paddleocr not found from GUI)

### DIFF
--- a/src/ui/Features/Ocr/Engines/PaddleOcr.cs
+++ b/src/ui/Features/Ocr/Engines/PaddleOcr.cs
@@ -302,18 +302,16 @@ public partial class PaddleOcr
         var paddleOcrPath = Path.Combine(Se.PaddleOcrFolder, "paddleocr.bin");
         if (engineType != OcrEngineType.PaddleOcrStandalone || !File.Exists(paddleOcrPath))
         {
-            paddleOcrPath = "paddleocr";
+            // Also the fallback when the standalone binary is missing (no standalone build
+            // exists on macOS, and batch convert always requests PaddleOcrStandalone), so
+            // resolve the pip-installed CLI instead of relying on a bare "paddleocr".
+            paddleOcrPath = GetPaddleOcrPytonPath();
         }
 
         if (engineType == OcrEngineType.PaddleOcrStandalone &&
             File.Exists(Path.Combine(Se.PaddleOcrFolder, "paddleocr.exe")))
         {
             paddleOcrPath = Path.Combine(Se.PaddleOcrFolder, "paddleocr.exe");
-        }
-
-        if (engineType == OcrEngineType.PaddleOcrPython)
-        {
-            paddleOcrPath = GetPaddleOcrPytonPath();
         }
 
         var process = new Process
@@ -326,6 +324,9 @@ public partial class PaddleOcr
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 CreateNoWindow = true,
+                // A GUI app launched from Finder inherits "/" as current directory; use a
+                // writable folder so relative writes from the tool cannot fail.
+                WorkingDirectory = Path.GetTempPath(),
             },
         };
 
@@ -665,6 +666,7 @@ public partial class PaddleOcr
         var foundFiles = possiblePaths
             .Where(Directory.Exists)
             .SelectMany(baseDir => Directory.GetFiles(baseDir, executableName, SearchOption.AllDirectories))
+            .Concat(GetCliShimCandidates(executableName))
             .Distinct()
             .ToList();
 
@@ -695,6 +697,54 @@ public partial class PaddleOcr
         }
 
         return foundFiles.Last();
+    }
+
+    // A GUI app launched from Finder/launchd does not inherit the shell PATH, so
+    // Process.Start("paddleocr") cannot find pip/Homebrew installs even though the
+    // command works fine in a terminal (#12953). Probe the standard CLI-shim
+    // directories directly, plus whatever PATH the process does have.
+    private static IEnumerable<string> GetCliShimCandidates(string executableName)
+    {
+        var candidates = new List<string>();
+
+        if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            candidates.Add(Path.Combine(home, ".local", "bin", executableName)); // pip install --user / pipx
+            candidates.Add("/usr/local/bin/" + executableName); // Homebrew (Intel) / system pip
+            candidates.Add("/opt/homebrew/bin/" + executableName); // Homebrew (Apple Silicon)
+            candidates.Add("/usr/bin/" + executableName); // system package manager
+            candidates.Add("/opt/local/bin/" + executableName); // MacPorts
+
+            // macOS "pip install --user": ~/Library/Python/X.Y/bin/paddleocr
+            var macUserPython = Path.Combine(home, "Library", "Python");
+            if (Directory.Exists(macUserPython))
+            {
+                try
+                {
+                    candidates.AddRange(Directory.GetFiles(macUserPython, executableName, SearchOption.AllDirectories));
+                }
+                catch
+                {
+                    // ignore access errors
+                }
+            }
+        }
+
+        var pathEnv = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        foreach (var dir in pathEnv.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            try
+            {
+                candidates.Add(Path.Combine(dir.Trim(), executableName));
+            }
+            catch
+            {
+                // ignore malformed PATH entries
+            }
+        }
+
+        return candidates.Where(File.Exists);
     }
 
     // Resolves the Python environment root for a "paddleocr" launcher:


### PR DESCRIPTION
Fixes #12953

## Cause

`Process.Start("paddleocr")` with `UseShellExecute = false` resolves against the process's own PATH — and a macOS app launched from Finder only gets `/usr/bin:/bin:/usr/sbin:/sbin`, so a pip/Homebrew-installed `paddleocr` is never found ("An error occurred trying to start process 'paddleocr' with working directory '/'"). `GetPaddleOcrPytonPath()` only scanned `/Library/Frameworks/Python.framework`, `/usr/local/Cellar/python`, `/opt/homebrew/Cellar/python` (which doesn't match Homebrew's actual `python@3.x` keg names) and conda roots — missing every standard shim location.

## Fix

- New `GetCliShimCandidates()`: probes `~/.local/bin`, `/usr/local/bin`, `/opt/homebrew/bin`, `/usr/bin`, `/opt/local/bin` (MacPorts), `~/Library/Python/X.Y/bin` (pip install --user), plus every directory on the process PATH. Candidates feed into the existing usable-environment filter (`HasPythonInterpreter`/`HasPaddleBackend`), so a shim whose env lacks the paddle backend is still deprioritized.
- The "standalone binary missing" fallback now runs the same resolver instead of returning the bare `paddleocr` name — this also covers batch convert, which always requests `PaddleOcrStandalone` (no standalone build exists on macOS).
- The OCR process now gets a writable working directory (`Path.GetTempPath()`) instead of inheriting `/` from Finder.

Verified by build; I don't have a paddleocr install on this machine to run end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)