### PR TITLE
Add GigaAM speech-to-text engine for Russian via onnx-asr

### DIFF
--- a/src/libuilogic/AudioToText/WhisperChoice.cs
+++ b/src/libuilogic/AudioToText/WhisperChoice.cs
@@ -15,6 +15,7 @@
         public const string PurfviewFasterWhisperXxl = "Purfview's Faster-Whisper-XXL";
         public const string ChatLlm = "Chat LLM";
         public const string Qwen3AsrCpp = "Qwen3 ASR CPP";
+        public const string GigaAm = "GigaAM";
         public const string ParakeetCpp = "Parakeet.cpp";
         public const string CrispAsrParakeet = "Crisp ASR Parakeet";
         public const string CrispAsrCanary = "Crisp ASR Canary";

--- a/src/ui/Assets/SpeechToText/GigaAM.txt
+++ b/src/ui/Assets/SpeechToText/GigaAM.txt
@@ -1,0 +1,32 @@
+GigaAM (Russian speech-to-text)
+
+GigaAM is Sber's "Giga Acoustic Model" family (https://huggingface.co/ai-sage/GigaAM-v3),
+which substantially outperforms Whisper on Russian speech. Subtitle Edit runs the ONNX
+exports of these models through the "onnx-asr" Python package on the CPU - no GPU needed.
+
+Installation
+------------
+Install Python 3.10+ and then:
+
+    pip3 install "onnx-asr[cpu,hub]"
+
+Subtitle Edit finds the package by probing for a Python that can "import onnx_asr".
+If you installed it with pipx, a virtual environment, or conda, it is found automatically
+when the "onnx-asr" command is on your PATH or at ~/.local/bin/onnx-asr.
+
+Models
+------
+Models are downloaded from Hugging Face automatically on first use:
+
+    gigaam-v3-e2e-rnnt   best quality, with punctuation and capitalization (recommended)
+    gigaam-v3-e2e-ctc    faster, with punctuation and capitalization
+    gigaam-v3-rnnt       lowercase text without punctuation
+    gigaam-v3-ctc        lowercase text without punctuation, fastest
+    gigaam-v2-rnnt       previous generation
+    gigaam-v2-ctc        previous generation
+
+The default engine argument "--quantization int8" uses the small int8 exports
+(~230 MB); clear it to use the full-precision exports (~0.9 GB) instead.
+
+Long audio is segmented with the Silero VAD (also bundled with onnx-asr), and
+oversized speech segments are split into subtitle-sized cues at word boundaries.

--- a/src/ui/Assets/SpeechToText/gigaam_transcribe.py
+++ b/src/ui/Assets/SpeechToText/gigaam_transcribe.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Subtitle Edit - GigaAM (onnx-asr) helper.
+
+Transcribes an audio file with Sber's GigaAM Russian speech models through the
+`onnx-asr` pip package (https://github.com/istupakov/onnx-asr) and writes an
+SRT into the output directory, named <audio-basename>.srt, which Subtitle Edit
+then loads.
+
+GigaAM accepts short utterances only, so long-form audio is segmented with the
+Silero VAD bundled with onnx-asr; each speech segment comes back with start/end
+times in seconds. VAD segments can still be far longer than a subtitle should
+be, so oversized segments are split into cues at word boundaries, allocating
+time proportionally to character counts (GigaAM's plain CTC/RNNT heads expose
+no word timestamps; the v3 "e2e" heads add punctuation, which improves the
+split points).
+
+Each cue is printed as `[MM:SS.mmm --> MM:SS.mmm] text` so the host can show
+live progress and, if needed, recover the transcript from stdout.
+"""
+import argparse
+import os
+import sys
+
+
+def fmt_timestamp(seconds, sep=","):
+    if seconds < 0:
+        seconds = 0.0
+    total_ms = int(round(seconds * 1000))
+    hours, total_ms = divmod(total_ms, 3600000)
+    minutes, total_ms = divmod(total_ms, 60000)
+    secs, millis = divmod(total_ms, 1000)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}{sep}{millis:03d}"
+
+
+def fmt_short(seconds):
+    if seconds < 0:
+        seconds = 0.0
+    total_ms = int(round(seconds * 1000))
+    minutes, total_ms = divmod(total_ms, 60000)
+    secs, millis = divmod(total_ms, 1000)
+    return f"{minutes:02d}:{secs:02d}.{millis:03d}"
+
+
+def split_segment(start, end, text, max_chars, max_duration):
+    """Split one VAD segment into subtitle-sized cues at word boundaries.
+
+    Without word timestamps the only usable clock is the segment span, so each
+    cue's times are interpolated proportionally to its share of the characters.
+    Break points prefer sentence-ending punctuation, then commas, then the
+    max-chars limit.
+    """
+    text = " ".join(text.split())
+    duration = max(end - start, 0.001)
+    if not text:
+        return []
+    if len(text) <= max_chars and duration <= max_duration:
+        return [(start, end, text)]
+
+    words = text.split(" ")
+
+    # Target cue count from both limits, then greedy-fill by words, preferring
+    # to end a cue after punctuation once it is at least half full.
+    cues = []
+    current = []
+    current_len = 0
+    max_cue_chars = max(max_chars, 1)
+    for i, word in enumerate(words):
+        extra = len(word) + (1 if current else 0)
+        if current and current_len + extra > max_cue_chars:
+            cues.append(" ".join(current))
+            current = [word]
+            current_len = len(word)
+            continue
+
+        current.append(word)
+        current_len += extra
+
+        at_punct = word and word[-1] in ".!?…"
+        soft_punct = word and word[-1] in ",;:"
+        if current_len >= max_cue_chars // 2 and at_punct:
+            cues.append(" ".join(current))
+            current = []
+            current_len = 0
+        elif current_len >= (max_cue_chars * 3) // 4 and soft_punct:
+            cues.append(" ".join(current))
+            current = []
+            current_len = 0
+
+    if current:
+        cues.append(" ".join(current))
+
+    # Interpolate times proportionally to character counts.
+    total_chars = sum(len(c) for c in cues) or 1
+    result = []
+    t = start
+    for cue in cues:
+        share = duration * len(cue) / total_chars
+        cue_end = min(t + share, end)
+        result.append((t, cue_end, cue))
+        t = cue_end
+
+    # Cues longer than max_duration (a slow-speech VAD span with little text)
+    # are clamped by ear: keep the start, cap the display duration.
+    clamped = []
+    for s, e, cue in result:
+        if e - s > max_duration:
+            e = s + max_duration
+        clamped.append((s, e, cue))
+
+    return clamped
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="GigaAM (onnx-asr) transcription helper for Subtitle Edit")
+    parser.add_argument("--audio", required=True, help="Path to the input audio file (wav)")
+    parser.add_argument("--model", default="gigaam-v3-e2e-rnnt",
+                        help="onnx-asr model id (e.g. gigaam-v3-e2e-rnnt, gigaam-v3-ctc, gigaam-v2-rnnt)")
+    parser.add_argument("--quantization", default=None,
+                        help="Model quantization, e.g. int8 (smaller download, faster on CPU); omit for full precision")
+    parser.add_argument("--output-dir", default=None,
+                        help="Directory for the subtitle file (default: audio's folder)")
+    parser.add_argument("--max-cue-chars", type=int, default=84,
+                        help="Max characters per subtitle cue before a forced break (two 42-char lines)")
+    parser.add_argument("--max-cue-duration", type=float, default=7.0,
+                        help="Max seconds per subtitle cue")
+    args, unknown = parser.parse_known_args()
+    if unknown:
+        print(f"warning: ignoring unknown arguments: {' '.join(unknown)}", flush=True)
+
+    try:
+        import onnx_asr
+    except ImportError:
+        print('error: onnx-asr not found - install it with: pip3 install "onnx-asr[cpu,hub]"',
+              file=sys.stderr)
+        return 3
+
+    if not os.path.isfile(args.audio):
+        print(f"error: audio file not found: {args.audio}", file=sys.stderr)
+        return 2
+
+    quantization = args.quantization
+    if quantization in ("", "none", "None"):
+        quantization = None
+
+    print(f"Loading model '{args.model}' (downloaded from Hugging Face on first use; "
+          "this can take a while)...", flush=True)
+    try:
+        model = onnx_asr.load_model(args.model, quantization=quantization)
+    except Exception as e:
+        print(f"error: could not load model '{args.model}': {e}", file=sys.stderr)
+        return 4
+
+    print("Loading Silero VAD...", flush=True)
+    try:
+        vad = onnx_asr.load_vad("silero")
+    except Exception as e:
+        print(f"error: could not load Silero VAD: {e}", file=sys.stderr)
+        return 5
+
+    print("Transcribing...", flush=True)
+    cues = []
+    try:
+        for res in model.with_vad(vad).recognize(args.audio):
+            for s, e, text in split_segment(
+                    res.start, res.end, res.text, args.max_cue_chars, args.max_cue_duration):
+                cues.append((s, e, text))
+                print(f"[{fmt_short(s)} --> {fmt_short(e)}] {text}", flush=True)
+    except Exception as e:
+        print(f"error: transcription failed: {e}", file=sys.stderr)
+        return 6
+
+    out_dir = args.output_dir or os.path.dirname(os.path.abspath(args.audio))
+    base = os.path.splitext(os.path.basename(args.audio))[0]
+    out_path = os.path.join(out_dir, base + ".srt")
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        for i, (s, e, text) in enumerate(cues, start=1):
+            f.write(f"{i}\n{fmt_timestamp(s)} --> {fmt_timestamp(e)}\n{text}\n\n")
+
+    print(f"Wrote {len(cues)} cues to {out_path}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ui/Features/Video/SpeechToText/Engines/GigaAmEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/GigaAmEngine.cs
@@ -1,0 +1,422 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Platform;
+using Nikse.SubtitleEdit.UiLogic.AudioToText;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+/// <summary>
+/// Speech-to-text engine for Russian driving the GigaAM models (Sber's "Giga Acoustic Model",
+/// https://huggingface.co/ai-sage/GigaAM-v3) through the pip-installed "onnx-asr" Python package
+/// (https://github.com/istupakov/onnx-asr). GigaAM v2/v3 substantially outperform Whisper on
+/// Russian; onnx-asr runs the ONNX exports on CPU via onnxruntime on all platforms. Because the
+/// package is a library, transcription runs a small bundled helper script
+/// (<c>gigaam_transcribe.py</c>) via python, which segments the audio with Silero VAD and writes
+/// an SRT next to the input audio. Installation is detected by importing the package
+/// (<c>python3 -c "import onnx_asr"</c>); models are downloaded automatically from Hugging Face
+/// on first use.
+/// </summary>
+public class GigaAmEngine : ISpeechToTextEngine
+{
+    public static string StaticName => "GigaAM";
+    public string Name => StaticName;
+    public string Choice => WhisperChoice.GigaAm;
+    public string Url => "https://github.com/istupakov/onnx-asr";
+
+    private const string TranscribeScriptName = "gigaam_transcribe.py";
+
+    // The console-script shim pip/pipx installs for the package (onnx-asr --help).
+    private const string CliShimName = "onnx-asr";
+
+    private static bool? _isOnnxAsrInstalled;
+
+    // The python interpreter that can actually "import onnx_asr". Resolved during the install
+    // check and reused for transcription so both use the same Python (see GetExecutable).
+    private static string? _resolvedPython;
+
+    // GigaAM is a Russian model family (the default engine args request int8 weights;
+    // clear them to use the full-precision ONNX exports instead).
+    public List<WhisperLanguage> Languages => new() { new WhisperLanguage("ru", "russian") };
+
+    // Model names are onnx-asr model ids; the package downloads the ONNX exports from
+    // Hugging Face (istupakov/gigaam-*-onnx) automatically on first use. Sizes are the
+    // int8 download sizes requested by the default "--quantization int8" engine argument
+    // (full-precision exports are ~0.9 GB). The "e2e" v3 variants output punctuation and
+    // capitalization; the plain models output normalized lowercase text.
+    public List<WhisperModel> Models => new List<WhisperModel>
+    {
+        new WhisperModel { Name = "gigaam-v3-e2e-rnnt", Size = "233 MB" },
+        new WhisperModel { Name = "gigaam-v3-e2e-ctc", Size = "225 MB" },
+        new WhisperModel { Name = "gigaam-v3-rnnt", Size = "229 MB" },
+        new WhisperModel { Name = "gigaam-v3-ctc", Size = "225 MB" },
+        new WhisperModel { Name = "gigaam-v2-rnnt", Size = "240 MB" },
+        new WhisperModel { Name = "gigaam-v2-ctc", Size = "236 MB" },
+    };
+
+    public string Extension => string.Empty;
+    public string UnpackSkipFolder => string.Empty;
+
+    public string CommandLineParameter
+    {
+        get => Se.Settings.Tools.AudioToText.CommandLineParameterGigaAm;
+        set => Se.Settings.Tools.AudioToText.CommandLineParameterGigaAm = value;
+    }
+
+    public bool IsEngineInstalled()
+    {
+        if (_isOnnxAsrInstalled.HasValue)
+        {
+            return _isOnnxAsrInstalled.Value;
+        }
+
+        // onnx-asr is often installed into a user/venv/pipx Python rather than the first
+        // interpreter on PATH, so checking a single fixed interpreter wrongly reports
+        // "not installed". Probe each candidate and pick the first one that can import
+        // the package; remember it for transcription.
+        foreach (var python in GetPythonCandidates())
+        {
+            if (CanImportOnnxAsr(python))
+            {
+                _resolvedPython = python;
+                _isOnnxAsrInstalled = true;
+                return true;
+            }
+        }
+
+        _isOnnxAsrInstalled = false;
+        return false;
+    }
+
+    private static bool CanImportOnnxAsr(string python)
+    {
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo(python, "-c \"import onnx_asr\"")
+                {
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    CreateNoWindow = true,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                }
+            };
+
+#pragma warning disable CA1416
+            process.Start();
+            if (!process.WaitForExit(10_000))
+            {
+                process.Kill(true);
+                return false;
+            }
+#pragma warning restore CA1416
+
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// The python interpreters to probe for onnx-asr, in priority order: the interpreter behind
+    /// an installed <c>onnx-asr</c> CLI shim (covers pipx / venv / conda on Mac/Linux), then the
+    /// per-platform standard installs, and finally PATH resolution.
+    /// </summary>
+    private static IEnumerable<string> GetPythonCandidates()
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var candidates = new List<string>();
+
+        void Add(string path)
+        {
+            if (!string.IsNullOrEmpty(path) && seen.Add(path))
+            {
+                candidates.Add(path);
+            }
+        }
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        if (OperatingSystem.IsWindows())
+        {
+            // Windows python.org installs: %LocalAppData%\Programs\Python\Python3XX\python.exe
+            var pythonRoot = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Programs", "Python");
+            if (Directory.Exists(pythonRoot))
+            {
+                foreach (var versionDir in Directory.GetDirectories(pythonRoot).OrderByDescending(p => p))
+                {
+                    Add(Path.Combine(versionDir, "python.exe"));
+                }
+            }
+
+            Add("python"); // resolved via PATH
+            return candidates.Where(p => p == "python" || File.Exists(p));
+        }
+
+        // Highest priority: the exact interpreter behind an installed onnx-asr CLI shim. pipx,
+        // a hand-made venv, and conda all install the package into an isolated environment that
+        // none of the shared interpreters below can import, so probing them alone reports "not
+        // found" even though the user did install it. The shim's shebang names the one
+        // interpreter that can import the package.
+        foreach (var interpreter in GetShebangInterpreters())
+        {
+            Add(interpreter);
+        }
+
+        Add("/opt/homebrew/bin/python3");
+        Add("/usr/local/bin/python3");
+
+        const string frameworkDir = "/Library/Frameworks/Python.framework/Versions";
+        if (Directory.Exists(frameworkDir))
+        {
+            foreach (var versionDir in Directory.GetDirectories(frameworkDir).OrderByDescending(p => p))
+            {
+                Add(Path.Combine(versionDir, "bin", "python3"));
+            }
+        }
+
+        if (!string.IsNullOrEmpty(home))
+        {
+            Add(Path.Combine(home, ".pyenv", "shims", "python3"));
+        }
+
+        Add("/usr/bin/python3");
+        Add("python3"); // resolved via PATH
+
+        return candidates.Where(p => p == "python3" || File.Exists(p));
+    }
+
+    /// <summary>
+    /// Interpreters discovered by reading the shebang of an installed <c>onnx-asr</c> CLI shim.
+    /// A pip/pipx/venv/conda console script starts with <c>#!/abs/path/to/that/env/bin/python</c>,
+    /// which points at the exact interpreter that can <c>import onnx_asr</c> - the one case the
+    /// fixed interpreter list cannot cover, because an isolated environment's package is not
+    /// importable from Homebrew/system Python.
+    /// </summary>
+    private static IEnumerable<string> GetShebangInterpreters()
+    {
+        var result = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var shim in GetCliShimCandidates())
+        {
+            try
+            {
+                if (!File.Exists(shim))
+                {
+                    continue;
+                }
+
+                // Read only the first line - a console script is tiny, but a same-named non-script
+                // file on one of these paths shouldn't be slurped whole.
+                using var reader = new StreamReader(shim);
+                var firstLine = reader.ReadLine();
+                if (firstLine == null || !firstLine.StartsWith("#!", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                // "#!/path/to/python" or "#!/path/to/python -E ...": take the interpreter token.
+                // The "#!/usr/bin/env python3" form names no specific environment, so its first
+                // token ("/usr/bin/env") is filtered out by the python-name check below - the bare
+                // "python3" PATH candidate already covers that case.
+                var interpreterPath = firstLine.Substring(2).Trim().Split(' ', '\t')[0];
+                if (Path.IsPathRooted(interpreterPath) &&
+                    Path.GetFileName(interpreterPath).StartsWith("python", StringComparison.OrdinalIgnoreCase) &&
+                    File.Exists(interpreterPath) &&
+                    seen.Add(interpreterPath))
+                {
+                    result.Add(interpreterPath);
+                }
+            }
+            catch
+            {
+                // Unreadable / permission-denied shim - skip and try the next candidate.
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Locations an installed <c>onnx-asr</c> console-script shim commonly lives: pipx and
+    /// "pip install --user" write it to <c>~/.local/bin</c>; a Homebrew-managed Python writes it
+    /// into its own bin. The PATH is also scanned so a shim on the user's PATH is found when
+    /// Subtitle Edit is launched from a shell.
+    /// </summary>
+    private static IEnumerable<string> GetCliShimCandidates()
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrEmpty(home))
+        {
+            var localBin = Path.Combine(home, ".local", "bin", CliShimName);
+            if (seen.Add(localBin))
+            {
+                yield return localBin;
+            }
+        }
+
+        foreach (var dir in new[] { "/opt/homebrew/bin", "/usr/local/bin" })
+        {
+            var shim = Path.Combine(dir, CliShimName);
+            if (seen.Add(shim))
+            {
+                yield return shim;
+            }
+        }
+
+        var pathEnv = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(pathEnv))
+        {
+            yield break;
+        }
+
+        foreach (var dir in pathEnv.Split(Path.PathSeparator))
+        {
+            if (string.IsNullOrEmpty(dir))
+            {
+                continue;
+            }
+
+            string shim;
+            try
+            {
+                shim = Path.Combine(dir, CliShimName);
+            }
+            catch
+            {
+                continue; // malformed PATH entry (illegal characters)
+            }
+
+            if (seen.Add(shim))
+            {
+                yield return shim;
+            }
+        }
+    }
+
+    public override string ToString()
+    {
+        return Name;
+    }
+
+    public string GetAndCreateWhisperFolder()
+    {
+        var baseFolder = Se.SpeechToTextFolder;
+        if (!Directory.Exists(baseFolder))
+        {
+            Directory.CreateDirectory(baseFolder);
+        }
+
+        var folder = Path.Combine(baseFolder, "GigaAm");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel)
+    {
+        // onnx-asr downloads models itself into the Hugging Face cache.
+        return GetAndCreateWhisperFolder();
+    }
+
+    public string GetExecutable()
+    {
+        // The engine drives the onnx-asr *library* through python (see the class summary), so the
+        // executable is the Python interpreter. Prefer the interpreter that actually has onnx-asr
+        // importable (resolved during the install check) so detection and transcription stay in sync.
+        if (_resolvedPython != null)
+        {
+            return _resolvedPython;
+        }
+
+        IsEngineInstalled();
+        if (_resolvedPython != null)
+        {
+            return _resolvedPython;
+        }
+
+        // Not installed in any probed interpreter; return a sensible default so the "pip install
+        // onnx-asr" guidance points at a real interpreter.
+        return GetPythonCandidates().FirstOrDefault() ?? (OperatingSystem.IsWindows() ? "python" : "python3");
+    }
+
+    /// <summary>
+    /// Extracts the bundled transcription helper script to the engine folder and returns its path.
+    /// The script is rewritten on every call so it always matches the running build.
+    /// </summary>
+    public string GetTranscribeScript()
+    {
+        var scriptPath = Path.Combine(GetAndCreateWhisperFolder(), TranscribeScriptName);
+
+        var uri = new Uri($"avares://SubtitleEdit/Assets/SpeechToText/{TranscribeScriptName}");
+        using var stream = AssetLoader.Open(uri);
+        using var fileStream = File.Create(scriptPath);
+        stream.CopyTo(fileStream);
+
+        return scriptPath;
+    }
+
+    public bool IsModelInstalled(WhisperModel model)
+    {
+        // onnx-asr resolves models by id and downloads them from Hugging Face on first use,
+        // so any of the supported models can be used right away.
+        return true;
+    }
+
+    public string GetModelForCmdLine(string modelName)
+    {
+        if (string.IsNullOrWhiteSpace(modelName))
+        {
+            return "gigaam-v3-e2e-rnnt";
+        }
+
+        return modelName;
+    }
+
+    public async Task<string> GetHelpText()
+    {
+        var assetName = $"{StaticName.Replace(" ", string.Empty)}.txt";
+        var uri = new Uri($"avares://SubtitleEdit/Assets/SpeechToText/{assetName}");
+
+        try
+        {
+            await using var stream = AssetLoader.Open(uri);
+            using var reader = new StreamReader(stream);
+            var contents = await reader.ReadToEndAsync();
+            return contents;
+        }
+        catch
+        {
+            return "GigaAM transcribes Russian speech via the \"onnx-asr\" Python library.\n\n" +
+                   "Install it with: pip3 install \"onnx-asr[cpu,hub]\"\n\n" +
+                   "Models (GigaAM v2/v3 ONNX exports) are downloaded from Hugging Face on first use.\n" +
+                   "Tip: the v3 \"e2e\" models output punctuation and capitalization.";
+        }
+    }
+
+    public string GetWhisperModelDownloadFileName(WhisperModel whisperModel, string url)
+    {
+        return string.Empty;
+    }
+
+    public bool CanBeDownloaded()
+    {
+        return false;
+    }
+}

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineFactory.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineFactory.cs
@@ -52,6 +52,11 @@ public static class WhisperEngineFactory
             return new Qwen3AsrCppEngine();
         }
 
+        if (staticName == GigaAmEngine.StaticName)
+        {
+            return new GigaAmEngine();
+        }
+
         if (staticName == OpenAiCompatibleSttEngine.StaticName)
         {
             return new OpenAiCompatibleSttEngine();

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -261,6 +261,9 @@ public partial class SpeechToTextViewModel : ObservableObject
             Engines.Add(new Qwen3AsrCppEngine());
         }
 
+        // Russian ASR via the pip-installed "onnx-asr" package (CPU, all platforms).
+        Engines.Add(new GigaAmEngine());
+
         Engines.Add(new CrispAsrEngine());
 
         SelectedEngine = Engines[0];
@@ -3056,6 +3059,24 @@ public partial class SpeechToTextViewModel : ObservableObject
                     return;
                 }
 
+                if (engine is GigaAmEngine)
+                {
+                    // pip-managed engine - Subtitle Edit cannot download it. Same detection model
+                    // as MLX Whisper: SE looks for a Python that can import onnx_asr.
+                    await MessageBox.Show(
+                        Window!,
+                        $"{engine.Name} not found",
+                        "Subtitle Edit could not find a Python that can import the \"onnx_asr\" package." + Environment.NewLine +
+                        Environment.NewLine +
+                        "If it is not installed yet, install it with:" + Environment.NewLine +
+                        "    pip3 install \"onnx-asr[cpu,hub]\"" + Environment.NewLine +
+                        Environment.NewLine +
+                        "If you installed it with pipx, a virtual environment, or conda, Subtitle Edit finds it " +
+                        "automatically only when the \"onnx-asr\" command is on your PATH or at " +
+                        "~/.local/bin/onnx-asr (where pipx puts it).");
+                    return;
+                }
+
 
                 if (engine is ICrispAsrEngine && Configuration.IsRunningOnWindows)
                 {
@@ -3884,6 +3905,64 @@ public partial class SpeechToTextViewModel : ObservableObject
                    $" --max-cps {audioToText.WhisperCueMaxCps.ToString(CultureInfo.InvariantCulture)}";
         }
 
+        if (engine is GigaAmEngine gigaAm)
+        {
+            // onnx-asr is a library, not a CLI, so we run a bundled helper script via python.
+            // It segments the audio with Silero VAD, transcribes with GigaAM and writes
+            // "<audio-basename>.srt" into the audio's folder, which GetResultFromSrt then picks up.
+            var gigaAmPython = gigaAm.GetExecutable();
+            var gigaAmScript = gigaAm.GetTranscribeScript();
+            var gigaAmOutputDir = Path.GetDirectoryName(waveFileName) ?? string.Empty;
+            var gigaAmCueSettings = Se.Settings.Tools.AudioToText;
+            var gigaAmExtraArgs = engine.CommandLineParameter;
+            var gigaAmExtraPart = string.IsNullOrWhiteSpace(gigaAmExtraArgs) ? string.Empty : " " + gigaAmExtraArgs.Trim();
+
+            var gigaAmParameters =
+                $"\"{gigaAmScript}\" --audio \"{waveFileName}\" --model {gigaAm.GetModelForCmdLine(model)} " +
+                $"--output-dir \"{gigaAmOutputDir}\"" +
+                $" --max-cue-chars {gigaAmCueSettings.WhisperCueMaxChars}" +
+                $" --max-cue-duration {gigaAmCueSettings.WhisperCueMaxSeconds.ToString(CultureInfo.InvariantCulture)}" +
+                gigaAmExtraPart;
+
+            Se.WriteToolsLog($"{gigaAmPython} {gigaAmParameters}");
+
+            var gigaAmProcess = new Process
+            {
+                StartInfo = new ProcessStartInfo(gigaAmPython, gigaAmParameters)
+                {
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    CreateNoWindow = true,
+                    UseShellExecute = false,
+                }
+            };
+
+            gigaAmProcess.StartInfo.EnvironmentVariables["PYTHONIOENCODING"] = "utf-8";
+            gigaAmProcess.StartInfo.EnvironmentVariables["PYTHONUTF8"] = "1";
+            gigaAmProcess.StartInfo.EnvironmentVariables["PYTHONUNBUFFERED"] = "1";
+
+            if (dataReceivedHandler != null)
+            {
+                gigaAmProcess.StartInfo.StandardOutputEncoding = Encoding.UTF8;
+                gigaAmProcess.StartInfo.StandardErrorEncoding = Encoding.UTF8;
+                gigaAmProcess.StartInfo.RedirectStandardOutput = true;
+                gigaAmProcess.StartInfo.RedirectStandardError = true;
+                gigaAmProcess.OutputDataReceived += dataReceivedHandler;
+                gigaAmProcess.ErrorDataReceived += dataReceivedHandler;
+            }
+
+#pragma warning disable CA1416
+            gigaAmProcess.Start();
+#pragma warning restore CA1416
+
+            if (dataReceivedHandler != null)
+            {
+                gigaAmProcess.BeginOutputReadLine();
+                gigaAmProcess.BeginErrorReadLine();
+            }
+
+            return gigaAmProcess;
+        }
+
         if (engine is MlxWhisperMac mlxWhisperMac)
         {
             // mlx-whisper is a library, not a CLI, so we run a bundled helper script via python3.
@@ -4597,6 +4676,14 @@ public partial class SpeechToTextViewModel : ObservableObject
             // Kept to one line here; the blocking dialog on transcribe explains the pipx/venv
             // detection caveat in full (#12209).
             EngineDownloadHint = "mlx-whisper not found - install with \"pip3 install mlx-whisper\", or ensure the \"mlx_whisper\" command is on your PATH";
+            IsEngineDownloadButtonVisible = false;
+            return;
+        }
+
+        if (engine is GigaAmEngine && !isInstalled)
+        {
+            // pip-managed engine - Subtitle Edit cannot download it, so show install help instead.
+            EngineDownloadHint = "onnx-asr not found - install with \"pip3 install onnx-asr[cpu,hub]\", or ensure the \"onnx-asr\" command is on your PATH";
             IsEngineDownloadButtonVisible = false;
             return;
         }

--- a/src/ui/Logic/Config/SeAudioToText.cs
+++ b/src/ui/Logic/Config/SeAudioToText.cs
@@ -42,6 +42,8 @@ public class SeAudioToText
     public string CommandLineParameterPurfviewFasterWhisperXxl { get; set; } = "--standard";
     public string CommandLineParameterOpenAi { get; set; } = string.Empty;
     public string CommandLineParameterQwen3AsrCpp { get; set; } = string.Empty;
+    // int8 exports are ~230 MB vs ~0.9 GB full precision and faster on CPU; clear to use full precision.
+    public string CommandLineParameterGigaAm { get; set; } = "--quantization int8";
     public string CommandLineParameterChatLlm { get; set; } = string.Empty;
     public string CommandLineParameterCrispAsrCanary { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrCohere { get; set; } = "--max-len 50 --split-on-punct";


### PR DESCRIPTION
Fixes #12957

Adds a **GigaAM** audio-to-text engine for Russian, running Sber's [GigaAM v2/v3](https://huggingface.co/ai-sage/GigaAM-v3) models through the pip-installed [onnx-asr](https://github.com/istupakov/onnx-asr) package (onnxruntime CPU, all platforms) — the route suggested in the issue. GigaAM is a Conformer architecture, so whisper.cpp/llama.cpp cannot run it and CrispASR has no backend for it; onnx-asr is the practical path.

## How it works

Same pattern as MLX Whisper (pip-managed library + bundled helper script):

- **Detection**: probes for a Python that can `import onnx_asr` — including the interpreter behind the `onnx-asr` CLI shim's shebang (covers pipx/venv/conda), Homebrew, python.org framework builds, pyenv, `%LocalAppData%\Programs\Python` on Windows, and PATH. Friendly "pip3 install onnx-asr[cpu,hub]" guidance when not found.
- **Transcription**: `gigaam_transcribe.py` segments long audio with Silero VAD (GigaAM only accepts short utterances), transcribes each speech segment, splits oversized segments into subtitle-sized cues at word/punctuation boundaries (proportional timing — the CTC/RNNT heads expose no word timestamps), prints live `[MM:SS.mmm --> MM:SS.mmm] text` progress, and writes `<audio>.srt`, which the existing `GetResultFromSrt` picks up.
- **Models** (auto-downloaded from HF on first use): `gigaam-v3-e2e-rnnt` (default — punctuation + capitalization), `gigaam-v3-e2e-ctc`, `gigaam-v3-rnnt/ctc`, `gigaam-v2-rnnt/ctc`. Default engine argument `--quantization int8` keeps downloads at ~230 MB (clear it for the ~0.9 GB full-precision exports).

## Verification

Tested end-to-end headless on macOS (venv + `onnx-asr` 0.12.0, Russian audio synthesized with `say -v Milena`):

- `gigaam-v3-ctc`: correct lowercase transcription, 4 correctly-timed cues written to SRT
- `gigaam-v3-e2e-rnnt` (default): correct transcription **with punctuation/capitalization** — "Сегодня мы проверяем распознавание русской речи."
- Cue-splitting unit-checked: a 25 s / 233-char VAD segment splits into 4 cues, all ≤ 84 chars and ≤ 7 s, breaking at sentence punctuation

🤖 Generated with [Claude Code](https://claude.com/claude-code)