### PR TITLE
Fix six bugs found in a bug hunt over today's commits

### DIFF
--- a/src/libuilogic/Http/DownloaderFactory.cs
+++ b/src/libuilogic/Http/DownloaderFactory.cs
@@ -28,34 +28,44 @@ namespace Nikse.SubtitleEdit.UiLogic.Http
         {
             var handler = new HttpClientHandler();
 
-            if (!string.IsNullOrEmpty(proxySettings.ProxyAddress))
+            if (string.IsNullOrEmpty(proxySettings.ProxyAddress))
             {
-                handler.Proxy = new BypassingWebProxy(new WebProxy(proxySettings.ProxyAddress), proxySettings.BypassList);
-                handler.UseProxy = true;
-            }
-
-            if (proxySettings.UseDefaultCredentials)
-            {
-                if (handler.Proxy != null)
+                // No proxy configured in SE - downloads still go through the system/environment
+                // proxy, so the loopback + bypass-list behavior must apply there too, same as
+                // HttpClientFactoryWithProxy.
+                var systemProxy = HttpClient.DefaultProxy;
+                if (systemProxy != null)
                 {
-                    handler.Proxy.Credentials = CredentialCache.DefaultNetworkCredentials;
+                    handler.UseProxy = true;
+                    handler.Proxy = new BypassingWebProxy(systemProxy, proxySettings.BypassList);
                 }
 
-                handler.Credentials = CredentialCache.DefaultNetworkCredentials;
-            }
-            else if (!string.IsNullOrEmpty(proxySettings.UserName) && !string.IsNullOrEmpty(proxySettings.ProxyAddress))
-            {
-                var networkCredential = string.IsNullOrWhiteSpace(proxySettings.Domain) ? new NetworkCredential(proxySettings.UserName, proxySettings.DecodePassword()) : new NetworkCredential(proxySettings.UserName, proxySettings.DecodePassword(), proxySettings.Domain);
-                var credentialCache = new CredentialCache
+                if (proxySettings.UseDefaultCredentials)
                 {
-                    {
-                        new Uri(proxySettings.ProxyAddress),
-                        proxySettings.AuthType,
-                        networkCredential
-                    }
-                };
-                handler.Credentials = credentialCache;
+                    handler.Credentials = CredentialCache.DefaultNetworkCredentials;
+                }
+
+                return handler;
             }
+
+            var proxy = new WebProxy(proxySettings.ProxyAddress);
+
+            if (!proxySettings.UseDefaultCredentials && !string.IsNullOrEmpty(proxySettings.UserName))
+            {
+                // Credentials go on the proxy itself, like in HttpClientFactoryWithProxy - a
+                // CredentialCache would need ProxySettings.AuthType, which nothing ever sets,
+                // and CredentialCache.Add throws on a null auth type.
+                proxy.Credentials = string.IsNullOrWhiteSpace(proxySettings.Domain)
+                    ? new NetworkCredential(proxySettings.UserName, proxySettings.DecodePassword())
+                    : new NetworkCredential(proxySettings.UserName, proxySettings.DecodePassword(), proxySettings.Domain);
+            }
+            else
+            {
+                proxy.UseDefaultCredentials = true;
+            }
+
+            handler.UseProxy = true;
+            handler.Proxy = new BypassingWebProxy(proxy, proxySettings.BypassList);
 
             return handler;
         }

--- a/src/libuilogic/Http/LegacyDownloader.cs
+++ b/src/libuilogic/Http/LegacyDownloader.cs
@@ -144,31 +144,27 @@ namespace Nikse.SubtitleEdit.UiLogic.Http
             }
         }
 
-        public static WebProxy GetProxy()
+        public static IWebProxy GetProxy()
         {
-            if (string.IsNullOrEmpty(Configuration.Settings.Proxy.ProxyAddress))
+            var proxySettings = Configuration.Settings.Proxy;
+            if (string.IsNullOrEmpty(proxySettings.ProxyAddress))
             {
                 return null;
             }
 
-            var proxy = new WebProxy(Configuration.Settings.Proxy.ProxyAddress);
-            if (!string.IsNullOrEmpty(Configuration.Settings.Proxy.UserName))
+            var proxy = new WebProxy(proxySettings.ProxyAddress);
+            if (!proxySettings.UseDefaultCredentials && !string.IsNullOrEmpty(proxySettings.UserName))
             {
-                if (string.IsNullOrEmpty(Configuration.Settings.Proxy.Domain))
-                {
-                    proxy.Credentials = new NetworkCredential(Configuration.Settings.Proxy.UserName, Configuration.Settings.Proxy.DecodePassword());
-                }
-                else
-                {
-                    proxy.Credentials = new NetworkCredential(Configuration.Settings.Proxy.UserName, Configuration.Settings.Proxy.DecodePassword(), Configuration.Settings.Proxy.Domain);
-                }
+                proxy.Credentials = string.IsNullOrEmpty(proxySettings.Domain)
+                    ? new NetworkCredential(proxySettings.UserName, proxySettings.DecodePassword())
+                    : new NetworkCredential(proxySettings.UserName, proxySettings.DecodePassword(), proxySettings.Domain);
             }
             else
             {
                 proxy.UseDefaultCredentials = true;
             }
 
-            return proxy;
+            return new BypassingWebProxy(proxy, proxySettings.BypassList);
         }
     }
 }

--- a/src/ui/Features/Assa/FontCollector/FontCollectorViewModel.cs
+++ b/src/ui/Features/Assa/FontCollector/FontCollectorViewModel.cs
@@ -124,6 +124,11 @@ public partial class FontCollectorViewModel : ObservableObject
         {
             var wanted = items.ToDictionary(i => i.FontName, i => i, StringComparer.OrdinalIgnoreCase);
 
+            // item.FoundFiles is only mutated in posted UI updates, so it cannot be used for
+            // duplicate checks on this thread - the family and face name of a regular font are
+            // usually identical, and both would queue an Add before either has run.
+            var found = items.ToDictionary(i => i, i => new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+
             foreach (var fontFile in EnumerateFontFiles())
             {
                 if (cancellationToken.IsCancellationRequested)
@@ -145,7 +150,7 @@ public partial class FontCollectorViewModel : ObservableObject
                     {
                         if (!string.IsNullOrEmpty(name) &&
                             wanted.TryGetValue(name, out var item) &&
-                            !item.FoundFiles.Contains(fontFile, StringComparer.OrdinalIgnoreCase))
+                            found[item].Add(fontFile))
                         {
                             var file = fontFile;
                             Dispatcher.UIThread.Post(() =>

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8360,6 +8360,9 @@ public partial class MainViewModel :
             Subtitles[i].Text = result.Rows[i].TranslatedText;
         }
 
+        // The subtitle language just changed, so the cached auto-trim language is stale (issue #12144).
+        _autoTrimLanguageCode = null;
+
         if (!wasOldTranslationChanged)
         {
             _changeSubtitleHashOriginal = GetFastHashOriginal();
@@ -8467,6 +8470,9 @@ public partial class MainViewModel :
             }
         }
 
+        // The translated lines changed language, so the cached auto-trim language is stale (issue #12144).
+        _autoTrimLanguageCode = null;
+
         _updateAudioVisualizer = true;
     }
 
@@ -8501,6 +8507,9 @@ public partial class MainViewModel :
             Subtitles[i].OriginalText = Subtitles[i].Text;
             Subtitles[i].Text = result.Rows[i].TranslatedText;
         }
+
+        // The subtitle language just changed, so the cached auto-trim language is stale (issue #12144).
+        _autoTrimLanguageCode = null;
 
         _subtitleFileNameOriginal = _subtitleFileName;
         _subtitleOriginal ??= new Subtitle();
@@ -12583,6 +12592,13 @@ public partial class MainViewModel :
             // and the audio track menu disagree after leaving fullscreen (issue #12844).
             ReapplySelectedAudioTrack(control);
             var _ = Task.Run(LoadAudioTrackMenuItems);
+
+            // Same for subtitle visibility: the toggle shortcut only reached the fullscreen
+            // player, so the docked player must be brought back in line with the shared state.
+            if (control!.VideoPlayer is LibMpvDynamicPlayer dockedMpv)
+            {
+                dockedMpv.SetSubtitleVisibility(_mpvReloader.SubtitlesVisible);
+            }
 
             Dispatcher.UIThread.Post(() => SubtitleGrid.Focus());
         }, toggleKeys, showMediaInfoKeys, showMediaInformationOwnedBy, extraBindings, ReapplySelectedAudioTrack);

--- a/src/ui/Features/Video/TextToSpeech/Engines/Piper.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Piper.cs
@@ -143,7 +143,6 @@ public class Piper : ITtsEngine
         var json = File.ReadAllText(voiceFileName);
         var parser = new SeJsonParser();
         var arr = parser.GetRootElements(json);
-        AddCustomVoices(result);
 
         foreach (var element in arr)
         {
@@ -172,6 +171,10 @@ public class Piper : ITtsEngine
                 }
             }
         }
+
+        // Must run after the official voices are parsed - the "already known" filter
+        // compares against them, so downloaded official models are not re-listed as custom.
+        AddCustomVoices(result);
 
         return result.ToArray();
     }


### PR DESCRIPTION
An adversarial review of today's ~25 commits (parallel review agents per commit cluster, findings verified by hand, differential testing on the perf pass) surfaced six real bugs. This PR fixes all six; full solution builds clean and all 1,974 tests pass.

## Fixes

**1. Auto-trim used a stale detected language after auto-translate** (regression in 890c6bdfe)
The cached `_autoTrimLanguageCode` was reset on file load and `ReplaceSubtitles`, but all three translate paths rewrite `Subtitles[i].Text` in place — so after translating e.g. English→Dutch, the per-selection trim still ran with `"en"` and collapsed Dutch `ze 's avonds` to `ze's avonds`, the exact issue #12144 defect the commit fixed. The cache is now invalidated after each translate.

**2. Piper listed every downloaded official voice as a phantom "Custom" voice** (6f06fefc0)
`AddCustomVoices` ran before the official list was parsed, so its "already known" filter compared against an empty list. Once any official voice was downloaded, its `.onnx` in the Piper folder was re-listed as "Custom - <model>" forever. The call now runs after parsing, as the doc comment intended.

**3. Font collector showed found files twice ("Arial.ttf, Arial.ttf")** (51d1e091e)
For regular fonts, the family name and Win32 face name are usually identical, and the duplicate check read `item.FoundFiles` on the scan thread before the queued `Dispatcher.UIThread.Post` adds had run — so both name matches queued an add. Found files are now tracked in a scan-thread `HashSet` per item, which also covers .ttc collections where several faces of one family share a file.

**4. Subtitle-visibility toggle desynced the docked player after fullscreen** (e78241064)
The toggle shortcut only sent `sub-visibility` to the active (fullscreen) mpv instance; leaving fullscreen restored position/volume/audio-track but not visibility, so the docked player disagreed with the shared state and the next toggle press visibly did nothing. The fullscreen close callback now re-asserts visibility on the docked player — same pattern as the issue #12844 audio-track fix.

**5. Downloads crashed when a proxy + username was configured**
`DownloaderFactory` built a `CredentialCache` keyed on `ProxySettings.AuthType`, which nothing in v5 ever assigns — `CredentialCache.Add` throws `ArgumentNullException` on a null auth type, so every download client crashed for authenticated-proxy users (unless "Use system credentials" was checked). Credentials now go on the `WebProxy` itself, exactly like `HttpClientFactoryWithProxy`.

**6. Bypass list + loopback bypass didn't apply to downloads via the system proxy** (gap vs. e091184bf / 14cfaf78e)
`DownloaderFactory.CreateHandler` only wrapped the proxy in `BypassingWebProxy` when an in-app proxy address was configured; with only a system/environment proxy, downloads ignored the bypass list and localhost URLs still went through the proxy. The system proxy is now wrapped too (matching `HttpClientFactoryWithProxy`), and the legacy downloader's `WebClient` path gets the same treatment.

## Verification

- `dotnet build SubtitleEdit.sln` — 0 errors
- `dotnet test` — 1,974/1,974 pass (LibSE 736, UI 932, SeConv 279, LibUiLogic 27)

Note: with fix 5, `ProxySettings.AuthType` in libse is now entirely unused — left in place since it is public NuGet API; can be removed in a future libse cleanup if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)