### PR TITLE
Fix four bugs found in a bug hunt over today's afternoon commits

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -15284,6 +15284,9 @@ public partial class MainViewModel :
             SelectedEncodingDisplayName = SelectedEncoding.DisplayName,
             SubtitleHeader = _subtitle.Header,
             SubtitleFooter = _subtitle.Footer,
+            SubtitleFileNameOriginal = _subtitleFileNameOriginal,
+            SubtitleHeaderOriginal = _subtitleOriginal?.Header,
+            SubtitleFooterOriginal = _subtitleOriginal?.Footer,
         };
     }
 
@@ -15303,6 +15306,15 @@ public partial class MainViewModel :
 
         _subtitle.Header = undoRedoObject.SubtitleHeader;
         _subtitle.Footer = undoRedoObject.SubtitleFooter;
+
+        // Restore the original-subtitle file-level state too - the undo hash covers it,
+        // so leaving it untouched makes the restored state hash-mismatch its own entry,
+        // and the next Undo() clears the redo timeline as "unrecorded changes" (#12952).
+        _subtitleFileNameOriginal = undoRedoObject.SubtitleFileNameOriginal;
+        _subtitleOriginal ??= new Subtitle();
+        _subtitleOriginal.Header = undoRedoObject.SubtitleHeaderOriginal;
+        _subtitleOriginal.Footer = undoRedoObject.SubtitleFooterOriginal;
+
         SelectAndScrollToRow(undoRedoObject.SelectedLines.First());
     }
 

--- a/src/ui/Features/Ocr/Engines/PaddleOcr.cs
+++ b/src/ui/Features/Ocr/Engines/PaddleOcr.cs
@@ -264,6 +264,37 @@ public partial class PaddleOcr
         // Add all processed items back to the original collection
         _batchFileNames.AddRange(batchFileNamesList);
 
+        // Resolve the executable before building the command line. When the standalone
+        // binary is absent (no standalone build exists on macOS, and batch convert always
+        // requests PaddleOcrStandalone), the run falls back to the pip-installed Python
+        // CLI - and the whole I/O protocol below (result-file polling vs stdout parsing,
+        // cls model, mkldnn) must follow the binary actually launched, not the engine
+        // requested, or the fallback run exits successfully with zero parseable results.
+        // The disk-scanning resolver only runs when neither standalone binary exists.
+        string paddleOcrPath;
+        if (engineType == OcrEngineType.PaddleOcrStandalone)
+        {
+            var standaloneExe = Path.Combine(Se.PaddleOcrFolder, "paddleocr.exe");
+            var standaloneBin = Path.Combine(Se.PaddleOcrFolder, "paddleocr.bin");
+            if (File.Exists(standaloneExe))
+            {
+                paddleOcrPath = standaloneExe;
+            }
+            else if (File.Exists(standaloneBin))
+            {
+                paddleOcrPath = standaloneBin;
+            }
+            else
+            {
+                paddleOcrPath = GetPaddleOcrPytonPath();
+                engineType = OcrEngineType.PaddleOcrPython;
+            }
+        }
+        else
+        {
+            paddleOcrPath = GetPaddleOcrPytonPath();
+        }
+
         // Subtitles are always horizontal, so the Python engine skips text-line
         // orientation classification: it is noticeably faster and avoids loading the
         // extra cls model. The standalone engine keeps the original behavior.
@@ -297,21 +328,6 @@ public partial class PaddleOcr
             // The bundled standalone build is known-good and faster with MKL-DNN, so only
             // disable it for the Python engine.
             parameters += " --enable_mkldnn False";
-        }
-
-        var paddleOcrPath = Path.Combine(Se.PaddleOcrFolder, "paddleocr.bin");
-        if (engineType != OcrEngineType.PaddleOcrStandalone || !File.Exists(paddleOcrPath))
-        {
-            // Also the fallback when the standalone binary is missing (no standalone build
-            // exists on macOS, and batch convert always requests PaddleOcrStandalone), so
-            // resolve the pip-installed CLI instead of relying on a bare "paddleocr".
-            paddleOcrPath = GetPaddleOcrPytonPath();
-        }
-
-        if (engineType == OcrEngineType.PaddleOcrStandalone &&
-            File.Exists(Path.Combine(Se.PaddleOcrFolder, "paddleocr.exe")))
-        {
-            paddleOcrPath = Path.Combine(Se.PaddleOcrFolder, "paddleocr.exe");
         }
 
         var process = new Process
@@ -665,7 +681,7 @@ public partial class PaddleOcr
 
         var foundFiles = possiblePaths
             .Where(Directory.Exists)
-            .SelectMany(baseDir => Directory.GetFiles(baseDir, executableName, SearchOption.AllDirectories))
+            .SelectMany(baseDir => SafeGetFiles(baseDir, executableName))
             .Concat(GetCliShimCandidates(executableName))
             .Distinct()
             .ToList();
@@ -697,6 +713,20 @@ public partial class PaddleOcr
         }
 
         return foundFiles.Last();
+    }
+
+    // A conda/Python tree can contain unreadable directories or reparse-point cycles;
+    // a resolver failure must degrade to "not found here", never abort the OCR run.
+    private static string[] SafeGetFiles(string baseDir, string fileName)
+    {
+        try
+        {
+            return Directory.GetFiles(baseDir, fileName, SearchOption.AllDirectories);
+        }
+        catch
+        {
+            return Array.Empty<string>();
+        }
     }
 
     // A GUI app launched from Finder/launchd does not inherit the shell PATH, so

--- a/src/ui/Logic/UndoRedo/UndoRedoItem.cs
+++ b/src/ui/Logic/UndoRedo/UndoRedoItem.cs
@@ -12,6 +12,14 @@ public class UndoRedoItem
     public string? SelectedEncodingDisplayName { get; set; }
     public string? SubtitleHeader { get; set; }
     public string? SubtitleFooter { get; set; }
+
+    // The original-subtitle file-level state must be part of the snapshot: the undo
+    // hash covers it (GetFastHashOriginal), so if restore leaves it untouched the
+    // restored state can never hash-match its own entry, and the next Undo() treats
+    // the mismatch as unrecorded changes and clears the redo timeline (#12952).
+    public string? SubtitleFileNameOriginal { get; set; }
+    public string? SubtitleHeaderOriginal { get; set; }
+    public string? SubtitleFooterOriginal { get; set; }
     public int[] SelectedLines { get; set; }
     public int CaretIndex { get; set; }
     public int SelectionLength { get; set; }
@@ -56,6 +64,9 @@ public class UndoRedoItem
             SelectedEncodingDisplayName = item.SelectedEncodingDisplayName,
             SubtitleHeader = item.SubtitleHeader,
             SubtitleFooter = item.SubtitleFooter,
+            SubtitleFileNameOriginal = item.SubtitleFileNameOriginal,
+            SubtitleHeaderOriginal = item.SubtitleHeaderOriginal,
+            SubtitleFooterOriginal = item.SubtitleFooterOriginal,
             // Preserve the original timestamp — every Clone() used to overwrite
             // Created with DateTime.Now via the constructor, so any UI that
             // displays Created (or any logic that relies on the chronological

--- a/src/ui/Logic/UndoRedo/UndoRedoManager.cs
+++ b/src/ui/Logic/UndoRedo/UndoRedoManager.cs
@@ -374,7 +374,19 @@ public sealed class UndoRedoManager : IUndoRedoManager
                 Math.Abs(o.EndTime.TotalMilliseconds - n.EndTime.TotalMilliseconds) > 0.5;
             var bookmarkChanged = o.Bookmark != n.Bookmark;
 
-            if (!textChanged && !timingChanged && !bookmarkChanged)
+            // Same rule as OriginalText above: every field the undo hash covers must be
+            // compared here, or changing it (assigning a style/actor/layer) shifts the
+            // hash without recording an entry - undo then reverts it bundled into the
+            // previous action, and the detector re-snapshots every tick until the next
+            // text or timing edit.
+            var metadataChanged =
+                o.Style != n.Style ||
+                o.Extra != n.Extra ||
+                o.Actor != n.Actor ||
+                o.Layer != n.Layer ||
+                o.Number != n.Number;
+
+            if (!textChanged && !timingChanged && !bookmarkChanged && !metadataChanged)
             {
                 continue;
             }
@@ -392,6 +404,21 @@ public sealed class UndoRedoManager : IUndoRedoManager
 
         if (changedLines.Count == 0)
         {
+            // File-level state (file name, encoding, headers, original-subtitle file
+            // properties) is also part of the undo hash and can change with no line
+            // changes at all - e.g. loading an original subtitle sets its file name.
+            if (prev.SubtitleFileName != next.SubtitleFileName ||
+                prev.SelectedEncodingDisplayName != next.SelectedEncodingDisplayName ||
+                prev.SubtitleHeader != next.SubtitleHeader ||
+                prev.SubtitleFooter != next.SubtitleFooter ||
+                prev.SubtitleFileNameOriginal != next.SubtitleFileNameOriginal ||
+                prev.SubtitleHeaderOriginal != next.SubtitleHeaderOriginal ||
+                prev.SubtitleFooterOriginal != next.SubtitleFooterOriginal)
+            {
+                next.Description = "File properties changed";
+                return true;
+            }
+
             return false;
         }
 

--- a/tests/UI/Logic/UndoRedo/UndoRedoManagerTests.cs
+++ b/tests/UI/Logic/UndoRedo/UndoRedoManagerTests.cs
@@ -15,11 +15,16 @@ public class UndoRedoManagerTests
         public int Hash { get; set; }
         public bool Typing { get; set; }
         public SubtitleLineViewModel[] Subtitles { get; set; } = [];
+        public string? FileNameOriginal { get; set; }
 
         public int GetFastHash() => Hash;
         public bool IsTyping() => Typing;
-        public UndoRedoItem MakeUndoRedoObject(string description) =>
-            MakeItem(description, Hash, Subtitles);
+        public UndoRedoItem MakeUndoRedoObject(string description)
+        {
+            var item = MakeItem(description, Hash, Subtitles);
+            item.SubtitleFileNameOriginal = FileNameOriginal;
+            return item;
+        }
     }
 
     private sealed class BlockingHashClient : IUndoRedoClient
@@ -490,6 +495,48 @@ public class UndoRedoManagerTests
         withOriginal.OriginalText = "hej";
         client.Hash = 2;
         client.Subtitles = [withOriginal];
+        manager.CheckForChanges(null);
+
+        Assert.Equal(2, manager.UndoCount);
+    }
+
+    [Fact]
+    public void CheckForChanges_AddsEntry_WhenOnlyStyleChanges()
+    {
+        var lines1 = new[] { MakeLine("hello") };
+        var client = new FakeClient { Hash = 1, Subtitles = lines1 };
+        var manager = new UndoRedoManager();
+        manager.SetupChangeDetection(client, TimeSpan.FromHours(1));
+        manager.StartChangeDetection();
+        manager.Do(MakeItem("initial", 1, lines1));
+
+        // Assigning an ASSA style changes no text or timing, but the hash covers Style -
+        // without a recorded entry the next undo reverts the style bundled into the
+        // previous action, and the detector re-snapshots every tick (#12952 mechanism).
+        var restyled = MakeLine("hello");
+        restyled.Style = "Signs";
+        client.Hash = 2;
+        client.Subtitles = [restyled];
+        manager.CheckForChanges(null);
+
+        Assert.Equal(2, manager.UndoCount);
+    }
+
+    [Fact]
+    public void CheckForChanges_AddsEntry_WhenOnlyOriginalFileStateChanges()
+    {
+        var lines = new[] { MakeLine("hello") };
+        var client = new FakeClient { Hash = 1, Subtitles = lines };
+        var manager = new UndoRedoManager();
+        manager.SetupChangeDetection(client, TimeSpan.FromHours(1));
+        manager.StartChangeDetection();
+        manager.Do(MakeItem("initial", 1, lines));
+
+        // Loading an original subtitle whose lines happen to be identical still sets the
+        // original file name, which the hash covers - a snapshot must be recorded or the
+        // stack diverges and the second undo clears the redo timeline (#12952).
+        client.Hash = 2;
+        client.FileNameOriginal = "original.srt";
         manager.CheckForChanges(null);
 
         Assert.Equal(2, manager.UndoCount);


### PR DESCRIPTION
A second adversarial bug hunt over today's afternoon commits (the two features, the two fixes, the MLX Whisper removal, and a fresh re-review of #12968) found the features, the removal, and #12968 clean — but confirmed four bugs in the two fix commits. This PR fixes all four; the solution builds clean and all 1,977 tests pass (including two new regression tests).

## Fixes

**1. Paddle OCR on macOS batch convert: launched but silently produced empty subtitles** (follow-up to the #12953 fix)
The launch fix resolved the pip CLI when `paddleocr.bin` was missing, but the whole I/O protocol stayed keyed on the *requested* engine type — and batch convert always requests `PaddleOcrStandalone`. The resolved Python CLI ran without `--save_path` while the stdout parser waited for the legacy `ppocr INFO:` format the 3.x CLI never emits, so the run exited 0 with zero parsed results and the batch item got an empty subtitle. The executable is now resolved before the command line is built, and a standalone→Python fallback switches the engine type so the result-file protocol, `--enable_mkldnn False`, and the cls-model skip all follow the binary actually launched.

**2. Windows standalone Paddle OCR ran a full Python-environment disk scan on every batch**
On Windows the standalone binary is `paddleocr.exe`, never `.bin`, so the `.bin` fallback check always sent standalone runs through `GetPaddleOcrPytonPath()` — a recursive scan of AppData Python/conda trees with no try/catch — before the `.exe` check overwrote the result. The `.exe`/`.bin` checks now run first and the resolver only when neither exists; the recursive scan is also wrapped so unreadable directories degrade to "not found" instead of throwing out of the OCR run.

**3. Undo still permanently lost the original column on double-undo** (the remaining half of #12952)
The undo hash covers `_subtitleFileNameOriginal` and the original subtitle's header/footer, but snapshots never captured them and restore never touched them. After load original → Ctrl+Z, the live hash could never match the restored entry again, so the second Ctrl+Z took the "unrecorded changes" branch — which clears the redo list, destroying the entry holding the originals; Ctrl+Y then restored nothing. `UndoRedoItem` now captures the original file-level state and `RestoreUndoRedoState` restores it, so the restored state hash-matches its own entry.

**4. Style/actor/layer changes never produced undo entries**
`DetectContentChanges` compared only text/timing/bookmark while the hash also covers `Style`, `Extra`, `Actor`, `Layer`, `Number`, file name, encoding, and headers. Assigning a style or actor shifted the hash without recording an entry — undo reverted it bundled into the previous action, and the change detector re-snapshotted the whole subtitle every 250 ms until the next text edit. The comparison now covers every hashed field, with a file-level fallback ("File properties changed") for changes with no line diffs.

## Tests

Two new regression tests in `UndoRedoManagerTests`: a style-only change and an original-file-state-only change must each record an undo entry. Full suite: 1,977/1,977 pass, 0 build errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)