### PR TITLE
Skip auto-backup tick while a save is still in flight

### DIFF
--- a/src/ui/Logic/AutoBackupService.cs
+++ b/src/ui/Logic/AutoBackupService.cs
@@ -25,6 +25,7 @@ public partial class AutoBackupService : IAutoBackupService
 {
     private MainViewModel? _mainViewModel;
     private System.Timers.Timer? _timerAutoBackup;
+    private int _backupInFlight;
     // Source-generated rather than RegexOptions.Compiled: this type is constructed from the
     // MainViewModel ctor, and Compiled emits IL at construction time on the start-up path
     // (~3.6 ms and 13 KB, vs ~1.7 ms and zero allocation here) for a pattern only used when
@@ -60,9 +61,28 @@ public partial class AutoBackupService : IAutoBackupService
                     return;
                 }
 
+                // A save on a very large subtitle can outlive the timer interval; skip this
+                // tick rather than write concurrently (two saves in the same wall-clock
+                // second would also collide on the same timestamped filename). The next
+                // tick picks up newer state anyway.
+                if (Interlocked.CompareExchange(ref _backupInFlight, 1, 0) != 0)
+                {
+                    return;
+                }
+
                 var saveFormat = vm.SelectedSubtitleFormat;
                 var subtitle = new Subtitle(vm.GetUpdateSubtitle(), false);
-                Task.Run(() => SaveAutoBackup(subtitle, saveFormat));
+                Task.Run(() =>
+                {
+                    try
+                    {
+                        SaveAutoBackup(subtitle, saveFormat);
+                    }
+                    finally
+                    {
+                        Interlocked.Exchange(ref _backupInFlight, 0);
+                    }
+                });
             });
         };
         _timerAutoBackup.Start();


### PR DESCRIPTION
## Summary
- Fixes the concurrent auto-backup write race identified by @ivandrofly in #12971: a save on a very large subtitle can outlive the timer interval, so the per-tick `Task.Run` could run two backup writes at once — and two saves in the same wall-clock second collide on the same timestamped filename (a sharing violation silently swallowed by the `catch`, i.e. a lost backup)
- Guards with an `Interlocked` in-flight flag instead of a channel: if a save is still running when the timer fires, the tick is skipped entirely — the next tick (≥ 1 minute later) picks up newer state anyway
- Compared to the bounded-channel approach in #12971 this is ~6 lines instead of ~25, needs no reader loop or writer-completion lifecycle in `StopAutobackup()`, never blocks a threadpool thread, skips even the UI-thread snapshot copy when busy, and the `finally`-based flag reset can't be skipped by an exception (the channel's fire-and-forget reader loop would die permanently on an unhandled throw)
- Trade-off: a skipped snapshot waits for the next tick instead of being written the moment the in-flight save finishes — for a backup with a ≥ 1-minute interval that difference doesn't matter

Closes #12971 — thanks @ivandrofly for spotting the race.

## Test plan
- [x] Builds with 0 errors
- [x] Enable auto-backup with a 1-minute interval, edit a subtitle, verify a backup file appears after the interval
- [x] Verify backups are only written when the subtitle has unsaved changes
- [x] Toggle auto-backup off and confirm no further backup files are written

🤖 Generated with [Claude Code](https://claude.com/claude-code)