### PR TITLE
Fix build error in statistics dashboard

### DIFF
--- a/src/ui/Features/Files/Statistics/StatisticsViewModel.cs
+++ b/src/ui/Features/Files/Statistics/StatisticsViewModel.cs
@@ -482,7 +482,7 @@ https://github.com/SubtitleEdit/subtitleedit
             Count = aboveMaximumLineLengthCount,
             Severity = StatCheckSeverity.Warning,
         });
-        if (Configuration.Settings.Tools.ListViewSyntaxColorWideLines)
+        if (Se.Settings.General.ColorTextTooWide)
         {
             Checks.Add(new StatCheckItem
             {


### PR DESCRIPTION
Main does not compile since #12518: `StatisticsViewModel` references SE4's `Configuration.Settings.Tools.ListViewSyntaxColorWideLines`, which does not exist in this code base.

Use the SE5 equivalent `Se.Settings.General.ColorTextTooWide` ("Color text if too wide (pixels)") to gate the "line too wide" statistics check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)