### PR TITLE
Apply extend to line before/after to all selected lines

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14579,36 +14579,54 @@ public partial class MainViewModel :
     [RelayCommand]
     private void ExtendSelectedToPrevious()
     {
-        var s = SelectedSubtitle;
-        var idx = SelectedSubtitleIndex;
-        if (s == null || idx == null || idx == 0 || LockTimeCodes)
+        var selectedItems = _selectedSubtitles?.ToList() ?? [];
+        if (selectedItems.Count == 0 || LockTimeCodes)
         {
             return;
         }
 
-        var prev = Subtitles[idx.Value - 1];
-        s.SetStartTimeOnly(TimeSpan.FromMilliseconds(prev.EndTime.TotalMilliseconds + Se.Settings.General.MinimumBetweenLines.GetMilliseconds()));
+        var gapMs = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
+        foreach (var item in selectedItems)
+        {
+            var prev = Subtitles.GetOrNull(Subtitles.IndexOf(item) - 1);
+            if (prev == null)
+            {
+                continue;
+            }
+
+            item.SetStartTimeOnly(TimeSpan.FromMilliseconds(prev.EndTime.TotalMilliseconds + gapMs));
+        }
+
         _updateAudioVisualizer = true;
     }
 
     [RelayCommand]
     private void ExtendSelectedToNext()
     {
-        var s = SelectedSubtitle;
-        var idx = SelectedSubtitleIndex;
-        if (s == null || idx == null || idx >= Subtitles.Count - 1 || LockTimeCodes)
+        var selectedItems = _selectedSubtitles?.ToList() ?? [];
+        if (selectedItems.Count == 0 || LockTimeCodes)
         {
             return;
         }
 
-        var next = Subtitles.GetOrNull(idx.Value + 1);
-        if (next == null)
+        var gapMs = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
+        foreach (var item in selectedItems)
         {
-            return;
+            var idx = Subtitles.IndexOf(item);
+            if (idx < 0)
+            {
+                continue;
+            }
+
+            var next = Subtitles.GetOrNull(idx + 1);
+            if (next == null)
+            {
+                continue;
+            }
+
+            item.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - gapMs);
         }
 
-        s.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds -
-                                              Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
         _updateAudioVisualizer = true;
     }
 
@@ -19831,8 +19849,12 @@ public partial class MainViewModel :
         var count = Subtitles.Count;
         MenuItemMergeAsDialog.IsVisible = SubtitleGrid.SelectedItems.Count == 2;
         MenuItemMerge.IsVisible = SubtitleGrid.SelectedItems.Count > 1;
-        MenuItemExtendToLineBefore.IsVisible = SubtitleGrid.SelectedItems.Count == 1 && Subtitles.Count > 1 && idx > 0;
-        MenuItemExtendToLineAfter.IsVisible = SubtitleGrid.SelectedItems.Count == 1 && Subtitles.Count > 1 && idx < count - 1;
+        // With 2+ lines selected at least one of them has a neighbor on either side,
+        // so the focused-index boundary check only applies to single selection (#12981)
+        MenuItemExtendToLineBefore.IsVisible = Subtitles.Count > 1 &&
+            (SubtitleGrid.SelectedItems.Count > 1 || (SubtitleGrid.SelectedItems.Count == 1 && idx > 0));
+        MenuItemExtendToLineAfter.IsVisible = Subtitles.Count > 1 &&
+            (SubtitleGrid.SelectedItems.Count > 1 || (SubtitleGrid.SelectedItems.Count == 1 && idx < count - 1));
         AreAssaContentMenuItemsVisible = false;
         ShowAutoTranslateSelectedLines = SubtitleGrid.SelectedItems.Count > 0 && ShowColumnOriginalText;
         HasMultipleLinesSelected = SubtitleGrid.SelectedItems.Count > 1;


### PR DESCRIPTION
Fixes #12981

In SE 4.x, "Extend/shorten to line after" (and "to line before") applied to every selected line, which made batch re-syncing (e.g. LRC files) quick. In 5.x:

- the context menu items were hidden unless exactly one line was selected, and
- the underlying commands (also bound to shortcuts) only ever adjusted the focused line.

### Changes

- `ExtendSelectedToNext` / `ExtendSelectedToPrevious` now iterate the tracked multi-selection, setting each selected line's end to its next neighbor's start minus the minimum gap (resp. start to its previous neighbor's end plus the gap). Since extend-to-next only moves end times while reading start times (and vice versa for extend-to-previous), adjacent selected lines don't interfere and the loop is order independent — matching SE 4.x behavior where a contiguous selection ends up gap-to-gap.
- The context menu items are now shown for multi-selections; the focused-index boundary check (first/last line) still applies to single selection, where it's meaningful.

First/last lines without a neighbor are skipped, `LockTimeCodes` still blocks the commands, and undo works via the existing change-detection polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)