### PR TITLE
Add export support for Audacity/Tenacity labels

### DIFF
--- a/src/libse/SubtitleFormats/AudacityLabels.cs
+++ b/src/libse/SubtitleFormats/AudacityLabels.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Text;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -34,7 +35,21 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override string ToText(Subtitle subtitle, string title)
         {
-            throw new NotImplementedException();
+            var sb = new StringBuilder();
+            foreach (var p in subtitle.Paragraphs)
+            {
+                var text = HtmlUtil.RemoveHtmlTags(p.Text, true)
+                    .Replace(Environment.NewLine, " ")
+                    .Replace('\t', ' ');
+                sb.AppendLine($"{EncodeTimeCode(p.StartTime)}\t{EncodeTimeCode(p.EndTime)}\t{text}");
+            }
+
+            return sb.ToString();
+        }
+
+        private static string EncodeTimeCode(TimeCode timeCode)
+        {
+            return timeCode.TotalSeconds.ToString("0.000000", CultureInfo.InvariantCulture);
         }
     }
 }

--- a/src/libse/SubtitleFormats/SubtitleFormat.cs
+++ b/src/libse/SubtitleFormats/SubtitleFormat.cs
@@ -94,6 +94,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     new AdobeEncoreWithLineNumbersNtsc(),
                     new AdvancedSubStationAlpha(),
                     new AQTitle(),
+                    new AudacityLabels(),
                     new AvidCaption(),
                     new AvidCaptionDropFrame(),
                     new AvidDvd(),
@@ -766,7 +767,6 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 new JsonArchtime(),
                 new Rdf1(),
                 new CombinedXml(),
-                new AudacityLabels(),
                 new Fte(),
                 new ClqttJson(),
             };


### PR DESCRIPTION
Implements `AudacityLabels.ToText` — previously the format was import-only (`ToText` threw `NotImplementedException`), so there was no way to export labels for Audacity or Tenacity.

**Changes**
- `AudacityLabels.ToText` writes tab-separated `start<TAB>end<TAB>text` with timestamps as total seconds with six decimals (e.g. `61.160000`), matching Audacity's own label export. Formatting tags are stripped and line breaks flattened to spaces, since labels are single-line plain text.
- Moved `AudacityLabels` from the load-only `GetTextOtherFormats()` bucket into `AllSubtitleFormats`, so it shows up in the save-format list and batch convert.

**Notes**
- No auto-detect conflicts: the nearby tab-separated formats all use colon-based clock time codes, which `AudacityLabels`' strict invariant `double.TryParse` rejects, and their regexes reject bare decimal seconds. Verified that a labels file auto-detects as "Audacity labels" and `.srt` still detects as SubRip.
- Round-trip verified: export → import is lossless to the millisecond.

Discussed in #12978

🤖 Generated with [Claude Code](https://claude.com/claude-code)