### PR TITLE
Speed up four UI hot paths, verified with BenchmarkDotNet

### DIFF
--- a/src/ui/Features/Edit/ModifySelection/ModifySelectionRule.cs
+++ b/src/ui/Features/Edit/ModifySelection/ModifySelectionRule.cs
@@ -27,6 +27,13 @@ public class ModifySelectionRule
     public double DefaultValue { get; set; }
     public List<MultiSelectItem> MultiSelectItems { get; set; }
 
+    // IsMatch runs against every line on the preview timer, so the regex is compiled once per
+    // (pattern, options) instead of going through the static Regex cache per line. A null
+    // cached regex with matching key means the pattern failed to parse.
+    private Regex? _cachedRegex;
+    private string? _cachedRegexPattern;
+    private RegexOptions _cachedRegexOptions;
+
     public ModifySelectionRule()
     {
         Name = string.Empty;
@@ -319,15 +326,22 @@ public class ModifySelectionRule
                     return false;
                 }
 
-                try
+                var options = HasMatchCase && MatchCase ? RegexOptions.None : RegexOptions.IgnoreCase;
+                if (_cachedRegexPattern != Text || _cachedRegexOptions != options)
                 {
-                    var options = HasMatchCase && MatchCase ? RegexOptions.None : RegexOptions.IgnoreCase;
-                    return Regex.IsMatch(text, Text, options);
+                    _cachedRegexPattern = Text;
+                    _cachedRegexOptions = options;
+                    try
+                    {
+                        _cachedRegex = new Regex(Text, options | RegexOptions.Compiled);
+                    }
+                    catch
+                    {
+                        _cachedRegex = null;
+                    }
                 }
-                catch
-                {
-                    return false;
-                }
+
+                return _cachedRegex != null && _cachedRegex.IsMatch(text);
 
             case RuleType.Odd:
                 return (item.Number % 2) == 1;
@@ -363,13 +377,13 @@ public class ModifySelectionRule
                 return item.Gap > Number;
 
             case RuleType.ExactlyOneLine:
-                return (text?.Split('\n').Length ?? 0) == 1;
+                return CountLines(text) == 1;
 
             case RuleType.ExactlyTwoLines:
-                return (text?.Split('\n').Length ?? 0) == 2;
+                return CountLines(text) == 2;
 
             case RuleType.MoreThanTwoLines:
-                return (text?.Split('\n').Length ?? 0) > 2;
+                return CountLines(text) > 2;
 
             case RuleType.Bookmarked:
                 return !string.IsNullOrEmpty(item.Bookmark);
@@ -391,7 +405,7 @@ public class ModifySelectionRule
                     return false;
                 }
 
-                return MultiSelectItems.Any(p => p.Apply && p.Name == item.Style);
+                return AnyApplied(item.Style);
 
             case RuleType.Actor:
                 if (string.IsNullOrEmpty(item.Actor))
@@ -399,10 +413,29 @@ public class ModifySelectionRule
                     return false;
                 }
 
-                return MultiSelectItems.Any(p => p.Apply && p.Name == item.Actor);
+                return AnyApplied(item.Actor);
 
             default:
                 return false;
         }
+    }
+
+    private bool AnyApplied(string name)
+    {
+        foreach (var multiSelectItem in MultiSelectItems)
+        {
+            if (multiSelectItem.Apply && multiSelectItem.Name == name)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Same result as text.Split('\n').Length without materializing the parts.
+    private static int CountLines(string text)
+    {
+        return text.AsSpan().Count('\n') + 1;
     }
 }

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -75,6 +75,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
     private bool _previewMode = true;
     public List<int> DeleteIndices = new();
     private List<FixDisplayItem> _oldFixes = new();
+    private HashSet<(Guid? id, string action)>? _allowedFixLookup;
     private FixRuleDisplayItem? _currentRunningRule;
     private bool _nothingToFix;
     private bool _isAnalysing;
@@ -595,6 +596,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         }
 
         _totalErrors = 0;
+        _allowedFixLookup = null; // fix selection may have changed since the last pass
 
         var subtitle = _previewMode ? new Subtitle(FixedSubtitle, false) : FixedSubtitle;
         foreach (var paragraph in subtitle.Paragraphs)
@@ -862,8 +864,22 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
             return true;
         }
 
-        var allowFix = Fixes.Any(f => f.Paragraph.Id == p.Id && f.Action == action && f.IsSelected);
-        return allowFix;
+        // Every fix rule probes this once per paragraph during apply, so a linear scan of
+        // Fixes made the pass O(paragraphs x rules x fixes). Fixes is stable while applying
+        // (AddFixToListView is a no-op outside preview mode), so one lookup set per pass is safe.
+        if (_allowedFixLookup == null)
+        {
+            _allowedFixLookup = new HashSet<(Guid? id, string action)>(Fixes.Count);
+            foreach (var fix in Fixes)
+            {
+                if (fix.IsSelected)
+                {
+                    _allowedFixLookup.Add((fix.Paragraph.Id, fix.Action));
+                }
+            }
+        }
+
+        return _allowedFixLookup.Contains((p.Id, action));
     }
 
     [RelayCommand]

--- a/src/ui/Logic/Media/SubtitleImageAdjuster.cs
+++ b/src/ui/Logic/Media/SubtitleImageAdjuster.cs
@@ -21,56 +21,45 @@ public static class SubtitleImageAdjuster
         var brightnessAdjust = brightness; // -100 to 100
         var contrastAdjust = (contrast + 100) / 100.0f; // Convert -100 to 100 range to 0 to 2 multiplier
 
-        // Build lookup table for gamma correction
+        // Brightness, contrast and gamma are each a pure function of a single channel byte,
+        // so the whole chain collapses into one 256-entry lookup table.
         var gammaLookup = new byte[256];
         for (int i = 0; i < 256; i++)
         {
             gammaLookup[i] = (byte)Math.Clamp(Math.Pow(i / 255.0, 1.0 / gamma) * 255.0, 0, 255);
         }
 
+        var channelLookup = new byte[256];
+        for (int i = 0; i < 256; i++)
+        {
+            var value = (byte)Math.Clamp(i + brightnessAdjust, 0, 255);
+            value = (byte)Math.Clamp(((value - 128) * contrastAdjust) + 128, 0, 255);
+            channelLookup[i] = gammaLookup[value];
+        }
+
         unsafe
         {
-            var originalPixels = originalBitmap.GetPixels();
-            var adjustedPixels = adjustedBitmap.GetPixels();
+            var originalPixels = (uint*)originalBitmap.GetPixels();
+            var adjustedPixels = (uint*)adjustedBitmap.GetPixels();
+            var pixelCount = originalBitmap.Width * originalBitmap.Height;
 
-            for (int y = 0; y < originalBitmap.Height; y++)
+            for (int index = 0; index < pixelCount; index++)
             {
-                for (int x = 0; x < originalBitmap.Width; x++)
+                var pixel = originalPixels[index];
+                var alpha = pixel & 0xFF000000u;
+
+                // Skip transparent pixels
+                if (alpha == 0)
                 {
-                    var index = y * originalBitmap.Width + x;
-                    var pixel = ((uint*)originalPixels)[index];
-
-                    var a = (byte)((pixel >> 24) & 0xFF);
-                    var r = (byte)((pixel >> 16) & 0xFF);
-                    var g = (byte)((pixel >> 8) & 0xFF);
-                    var b = (byte)(pixel & 0xFF);
-
-                    // Skip transparent pixels
-                    if (a == 0)
-                    {
-                        ((uint*)adjustedPixels)[index] = pixel;
-                        continue;
-                    }
-
-                    // Apply brightness
-                    r = (byte)Math.Clamp(r + brightnessAdjust, 0, 255);
-                    g = (byte)Math.Clamp(g + brightnessAdjust, 0, 255);
-                    b = (byte)Math.Clamp(b + brightnessAdjust, 0, 255);
-
-                    // Apply contrast
-                    r = (byte)Math.Clamp(((r - 128) * contrastAdjust) + 128, 0, 255);
-                    g = (byte)Math.Clamp(((g - 128) * contrastAdjust) + 128, 0, 255);
-                    b = (byte)Math.Clamp(((b - 128) * contrastAdjust) + 128, 0, 255);
-
-                    // Apply gamma
-                    r = gammaLookup[r];
-                    g = gammaLookup[g];
-                    b = gammaLookup[b];
-
-                    // Reconstruct pixel
-                    var adjustedPixel = (uint)((a << 24) | (r << 16) | (g << 8) | b);
-                    ((uint*)adjustedPixels)[index] = adjustedPixel;
+                    adjustedPixels[index] = pixel;
+                    continue;
                 }
+
+                var r = channelLookup[(byte)(pixel >> 16)];
+                var g = channelLookup[(byte)(pixel >> 8)];
+                var b = channelLookup[(byte)pixel];
+
+                adjustedPixels[index] = alpha | ((uint)r << 16) | ((uint)g << 8) | b;
             }
         }
 
@@ -84,48 +73,33 @@ public static class SubtitleImageAdjuster
         using var originalBitmap = premultipliedBitmap.ToUnpremultiplied();
         var adjustedBitmap = new SKBitmap(originalBitmap.Width, originalBitmap.Height, SKColorType.Bgra8888, SKAlphaType.Unpremul);
 
+        // The new alpha is a pure function of the old alpha byte - one 256-entry lookup table.
+        var alphaLookup = new byte[256];
+        for (int i = 0; i < 256; i++)
+        {
+            var newAlpha = Math.Clamp(i + alphaAdjustment, 0, 255);
+            alphaLookup[i] = newAlpha < transparencyThreshold ? (byte)0 : (byte)newAlpha;
+        }
+
         unsafe
         {
-            var originalPixels = originalBitmap.GetPixels();
-            var adjustedPixels = adjustedBitmap.GetPixels();
+            var originalPixels = (uint*)originalBitmap.GetPixels();
+            var adjustedPixels = (uint*)adjustedBitmap.GetPixels();
+            var pixelCount = originalBitmap.Width * originalBitmap.Height;
 
-            for (int y = 0; y < originalBitmap.Height; y++)
+            for (int index = 0; index < pixelCount; index++)
             {
-                for (int x = 0; x < originalBitmap.Width; x++)
+                var pixel = originalPixels[index];
+                var a = (byte)(pixel >> 24);
+
+                // Skip if already fully transparent
+                if (a == 0)
                 {
-                    var index = y * originalBitmap.Width + x;
-                    var pixel = ((uint*)originalPixels)[index];
-
-                    var a = (byte)((pixel >> 24) & 0xFF);
-                    var r = (byte)((pixel >> 16) & 0xFF);
-                    var g = (byte)((pixel >> 8) & 0xFF);
-                    var b = (byte)(pixel & 0xFF);
-
-                    // Skip if already fully transparent
-                    if (a == 0)
-                    {
-                        ((uint*)adjustedPixels)[index] = pixel;
-                        continue;
-                    }
-
-                    // Apply alpha adjustment (additive)
-                    float newAlpha = a + alphaAdjustment;
-
-                    // Clamp to valid range
-                    newAlpha = Math.Clamp(newAlpha, 0, 255);
-
-                    // Apply transparency threshold
-                    if (newAlpha < transparencyThreshold)
-                    {
-                        newAlpha = 0;
-                    }
-
-                    a = (byte)newAlpha;
-
-                    // Reconstruct pixel
-                    var adjustedPixel = (uint)((a << 24) | (r << 16) | (g << 8) | b);
-                    ((uint*)adjustedPixels)[index] = adjustedPixel;
+                    adjustedPixels[index] = pixel;
+                    continue;
                 }
+
+                adjustedPixels[index] = (pixel & 0x00FFFFFFu) | ((uint)alphaLookup[a] << 24);
             }
         }
 
@@ -144,29 +118,42 @@ public static class SubtitleImageAdjuster
         using var originalBitmap = premultipliedBitmap.ToUnpremultiplied();
         var adjustedBitmap = new SKBitmap(originalBitmap.Width, originalBitmap.Height, SKColorType.Bgra8888, SKAlphaType.Unpremul);
 
+        // Each output channel is a pure function of total = r+g+b (0..765) - three lookup tables
+        // replace the per-pixel double math.
+        var totalLookupR = new byte[766];
+        var totalLookupG = new byte[766];
+        var totalLookupB = new byte[766];
+        for (int total = 0; total < 766; total++)
+        {
+            totalLookupR[total] = (byte)Math.Min(255, redPercent * total / 100);
+            totalLookupG[total] = (byte)Math.Min(255, greenPercent * total / 100);
+            totalLookupB[total] = (byte)Math.Min(255, bluePercent * total / 100);
+        }
+
         unsafe
         {
-            var srcPixels = originalBitmap.GetPixels();
-            var dstPixels = adjustedBitmap.GetPixels();
+            var srcPixels = (uint*)originalBitmap.GetPixels();
+            var dstPixels = (uint*)adjustedBitmap.GetPixels();
+            var pixelCount = originalBitmap.Width * originalBitmap.Height;
 
-            for (int i = 0; i < originalBitmap.Width * originalBitmap.Height; i++)
+            for (int i = 0; i < pixelCount; i++)
             {
-                var pixel = ((uint*)srcPixels)[i];
+                var pixel = srcPixels[i];
 
-                var a = (byte)((pixel >> 24) & 0xFF);
-                var pr = (byte)((pixel >> 16) & 0xFF);
-                var pg = (byte)((pixel >> 8) & 0xFF);
-                var pb = (byte)(pixel & 0xFF);
+                var a = (byte)(pixel >> 24);
+                var pr = (byte)(pixel >> 16);
+                var pg = (byte)(pixel >> 8);
+                var pb = (byte)pixel;
 
                 int total = pr + pg + pb;
                 if (total > 100 && a > 0)
                 {
-                    pr = (byte)Math.Min(255, redPercent * total / 100);
-                    pg = (byte)Math.Min(255, greenPercent * total / 100);
-                    pb = (byte)Math.Min(255, bluePercent * total / 100);
+                    pr = totalLookupR[total];
+                    pg = totalLookupG[total];
+                    pb = totalLookupB[total];
                 }
 
-                ((uint*)dstPixels)[i] = (uint)((a << 24) | (pr << 16) | (pg << 8) | pb);
+                dstPixels[i] = (uint)((a << 24) | (pr << 16) | (pg << 8) | pb);
             }
         }
 

--- a/src/ui/Logic/TextMeasurer.cs
+++ b/src/ui/Logic/TextMeasurer.cs
@@ -1,18 +1,33 @@
-﻿using SkiaSharp;
+using SkiaSharp;
+using System.Collections.Generic;
 
 namespace Nikse.SubtitleEdit.Logic;
 
 public static class TextMeasurer
 {
+    // Callers (statistics, batch convert) measure thousands of lines with the same font, and
+    // SKTypeface.FromFamilyName is a font-manager lookup - cache the font per (family, size,
+    // weight). The lock also serializes MeasureText, which SKFont does not allow concurrently.
+    private static readonly object CacheLock = new();
+    private static readonly Dictionary<(string family, float size, SKFontStyleWeight weight), SKFont> FontCache = new();
+
     public static SKSize MeasureString(string text, string fontFamily, float fontSize, SKFontStyleWeight weight = SKFontStyleWeight.Normal)
     {
-        using var typeface = SKTypeface.FromFamilyName(fontFamily, weight, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright);
-        using var font = new SKFont(typeface, fontSize);
+        lock (CacheLock)
+        {
+            var key = (fontFamily, fontSize, weight);
+            if (!FontCache.TryGetValue(key, out var font))
+            {
+                var typeface = SKTypeface.FromFamilyName(fontFamily, weight, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright);
+                font = new SKFont(typeface, fontSize);
+                FontCache[key] = font;
+            }
 
-        float width = font.MeasureText(text);
-        var metrics = font.Metrics;
-        float height = metrics.Descent - metrics.Ascent;
+            float width = font.MeasureText(text);
+            var metrics = font.Metrics;
+            float height = metrics.Descent - metrics.Ascent;
 
-        return new SKSize(width, height);
+            return new SKSize(width, height);
+        }
     }
 }

--- a/src/ui/UI.csproj
+++ b/src/ui/UI.csproj
@@ -89,5 +89,8 @@
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
 			<_Parameter1>UITests</_Parameter1>
 		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>UiBenchmarks</_Parameter1>
+		</AssemblyAttribute>
 	</ItemGroup>
 </Project>

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -29,6 +29,10 @@ Reports land in `tests/benchmarks/BenchmarkDotNet.Artifacts/results/` (gitignore
 | `SubtitleGridSelectionBenchmarks` | What `SubtitleGridSelectionChanged` does per selection change: copy the selection, find the line's index. |
 | `WaveformBufferBenchmarks` | The 50 ms position timer's refill of the waveform's subtitle buffer. |
 | `AudioVisualizerRenderBenchmarks` | One full playback frame of the real `AudioVisualizer.Render` (headless, real Skia, record-only): static view vs center-mode scrolling vs a forced geometry rebuild. |
+| `TextMeasurerBenchmarks` | The per-line text measurement the statistics window and batch convert run over every line of a subtitle. |
+| `SubtitleImageAdjusterBenchmarks` | The full-frame pixel adjustments the binary-edit dialogs run on every debounced slider tick (brightness/contrast/gamma, alpha, colorize). |
+| `FixCommonErrorsAllowFixBenchmarks` | One apply pass worth of `AllowFix` probes - what every libse fix rule asks once per paragraph during "Apply selected fixes". |
+| `ModifySelectionRuleBenchmarks` | One 250 ms preview-timer tick of the modify-selection window: the selected rule evaluated against every line (regex, line-count and style rules). |
 
 Benchmarks that model a collection the app gets from Avalonia (e.g. `DataGrid.SelectedItems`)
 reproduce its interface surface rather than substituting a `List<T>` - `SelectedItems` only

--- a/tests/benchmarks/UiProjectPerfHuntBenchmarks.cs
+++ b/tests/benchmarks/UiProjectPerfHuntBenchmarks.cs
@@ -1,0 +1,257 @@
+using Avalonia;
+using Avalonia.Headless;
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Edit.ModifySelection;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Media;
+using SkiaSharp;
+using System.Reflection;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// The Statistics window measures every line of the subtitle three times over
+/// (line lengths + two GetIndicesWithSingleLineWidth passes), and batch convert measures
+/// every line of every file. Each call did a font-manager typeface lookup + SKFont alloc.
+/// </summary>
+[MemoryDiagnoser]
+public class TextMeasurerBenchmarks
+{
+    private List<string> _lines = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var sentences = new[]
+        {
+            "It was the best of times, it was the worst of times.",
+            "Are you coming with us?",
+            "- No.\n- Then stay here and wait.",
+            "I told you already, this is not going to work out the way you think it will.",
+            "Hello.",
+            "Somewhere in Denmark",
+        };
+
+        _lines = new List<string>(600);
+        for (var i = 0; i < 600; i++)
+        {
+            _lines.Add(sentences[i % sentences.Length]);
+        }
+    }
+
+    [Benchmark]
+    public float MeasureAllLines()
+    {
+        var sum = 0f;
+        foreach (var line in _lines)
+        {
+            sum += TextMeasurer.MeasureString(line, "Arial", 17f).Width;
+        }
+
+        return sum;
+    }
+}
+
+/// <summary>
+/// The binary-edit adjust dialogs run these over a full-frame bitmap on every debounced
+/// slider tick, and batch convert runs them once per subtitle image. The per-pixel
+/// brightness/contrast/gamma chain is a pure function of one input byte per channel.
+/// </summary>
+[MemoryDiagnoser]
+public class SubtitleImageAdjusterBenchmarks
+{
+    private SKBitmap _bitmap = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Subtitle-like full-frame image: mostly transparent, an opaque "text band" of
+        // antialiased blobs near the bottom (premultiplied, like the dialogs' input).
+        var info = new SKImageInfo(1920, 1080, SKColorType.Bgra8888, SKAlphaType.Premul);
+        _bitmap = new SKBitmap(info);
+        using var canvas = new SKCanvas(_bitmap);
+        canvas.Clear(SKColors.Transparent);
+
+        using var fill = new SKPaint { Color = new SKColor(255, 255, 240), IsAntialias = true };
+        using var shadow = new SKPaint { Color = new SKColor(0, 0, 0, 160), IsAntialias = true };
+        for (var i = 0; i < 60; i++)
+        {
+            var x = 80 + i % 30 * 60;
+            var y = 880 + i / 30 * 90;
+            canvas.DrawRoundRect(x + 4, y + 4, 48, 64, 8, 8, shadow);
+            canvas.DrawRoundRect(x, y, 48, 64, 8, 8, fill);
+        }
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _bitmap.Dispose();
+    }
+
+    [Benchmark]
+    public int AdjustBrightnessContrastGamma()
+    {
+        using var result = SubtitleImageAdjuster.AdjustBrightness(_bitmap, 20f, 15f, 1.2f);
+        return result.Width;
+    }
+
+    [Benchmark]
+    public int AdjustAlpha()
+    {
+        using var result = SubtitleImageAdjuster.AdjustAlpha(_bitmap, -40f, 32);
+        return result.Width;
+    }
+
+    [Benchmark]
+    public int Colorize()
+    {
+        using var result = SubtitleImageAdjuster.Colorize(_bitmap, 220, 180, 60);
+        return result.Width;
+    }
+}
+
+/// <summary>
+/// During "Apply selected fixes", every libse fix rule calls AllowFix once per paragraph
+/// (78 call sites across 42 rules), and each call scanned the whole Fixes list. This
+/// reproduces one apply pass worth of probes: every paragraph x every action type.
+/// </summary>
+[MemoryDiagnoser]
+public class FixCommonErrorsAllowFixBenchmarks
+{
+    private static readonly string[] Actions =
+    {
+        "Fix empty lines", "Fix overlapping display times", "Fix short display times",
+        "Fix long display times", "Fix invalid italic tags", "Fix unneeded spaces",
+    };
+
+    private static bool _avaloniaInitialized;
+
+    private FixCommonErrorsViewModel _viewModel = null!;
+    private List<Paragraph> _paragraphs = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        if (!_avaloniaInitialized)
+        {
+            _avaloniaInitialized = true;
+            AppBuilder.Configure<Application>()
+                .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false })
+                .UseSkia()
+                .WithInterFont()
+                .SetupWithoutStarting();
+        }
+
+        _viewModel = new FixCommonErrorsViewModel(null!, null!, null!);
+
+        _paragraphs = new List<Paragraph>(2000);
+        for (var i = 0; i < 2000; i++)
+        {
+            var p = new Paragraph($"Line {i} text goes here.", i * 2000, i * 2000 + 1500) { Number = i + 1 };
+            _paragraphs.Add(p);
+
+            // ~1.5 fixes per paragraph across the action types, most of them ticked -
+            // the shape of a real scan result.
+            _viewModel.Fixes.Add(new FixDisplayItem(p, p.Number, Actions[i % Actions.Length], "before", "after", i % 10 != 0));
+            if (i % 2 == 0)
+            {
+                _viewModel.Fixes.Add(new FixDisplayItem(p, p.Number, Actions[(i + 3) % Actions.Length], "before", "after", true));
+            }
+        }
+
+        // Put the view model in apply mode, the way DoApplyFixes does before calling ApplyFixes.
+        var previewModeField = typeof(FixCommonErrorsViewModel)
+            .GetField("_previewMode", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        previewModeField.SetValue(_viewModel, false);
+    }
+
+    [Benchmark]
+    public int AllowFixApplyPassProbes()
+    {
+        var allowed = 0;
+        foreach (var p in _paragraphs)
+        {
+            foreach (var action in Actions)
+            {
+                if (_viewModel.AllowFix(p, action))
+                {
+                    allowed++;
+                }
+            }
+        }
+
+        return allowed;
+    }
+}
+
+/// <summary>
+/// The modify-selection window re-evaluates the selected rule against every line of the
+/// subtitle on a 250 ms dirty timer while the user types. Regex rules went through the
+/// static Regex cache per line, line-count rules allocated a string[] per line, and
+/// style rules ran a LINQ Any with a closure per line.
+/// </summary>
+[MemoryDiagnoser]
+public class ModifySelectionRuleBenchmarks
+{
+    private List<SubtitleLineViewModel> _lines = null!;
+    private ModifySelectionRule _regexRule = null!;
+    private ModifySelectionRule _lineCountRule = null!;
+    private ModifySelectionRule _styleRule = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _lines = SubtitleFactory.Make(2000);
+        var styles = new[] { "Default", "Sign", "Song", "Top", "Narrator" };
+        for (var i = 0; i < _lines.Count; i++)
+        {
+            _lines[i].Style = styles[i % styles.Length];
+        }
+
+        _regexRule = new ModifySelectionRule
+        {
+            RuleType = RuleType.RegEx,
+            Text = @"\b[A-Z][a-z]+\b",
+            HasMatchCase = true,
+            MatchCase = true,
+        };
+
+        _lineCountRule = new ModifySelectionRule
+        {
+            RuleType = RuleType.ExactlyTwoLines,
+        };
+
+        _styleRule = new ModifySelectionRule
+        {
+            RuleType = RuleType.Style,
+            MultiSelectItems = styles.Select(s => new MultiSelectItem(s) { Apply = s is "Sign" or "Top" }).ToList(),
+        };
+    }
+
+    [Benchmark]
+    public int RegexRuleFullScan() => CountMatches(_regexRule);
+
+    [Benchmark]
+    public int LineCountRuleFullScan() => CountMatches(_lineCountRule);
+
+    [Benchmark]
+    public int StyleRuleFullScan() => CountMatches(_styleRule);
+
+    private int CountMatches(ModifySelectionRule rule)
+    {
+        var count = 0;
+        foreach (var line in _lines)
+        {
+            if (rule.IsMatch(line))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+}


### PR DESCRIPTION
Four hot paths in the UI project, found by a systematic sweep and verified with BenchmarkDotNet (Apple M4, default job). Outputs are proven byte-identical before/after with a dump harness over an edge-case battery (129 image-adjust parameter combos hashed, 120 text measurements, every modify-selection rule type in 5 configurations invoked twice, and a full AllowFix probe grid including deselected, duplicate and missing entries). All 939 UI tests pass.

## Numbers

| Hot path | Before | After | |
| --- | ---: | ---: | --- |
| `FixCommonErrorsViewModel.AllowFix`, one apply pass (2000 lines, 3000 fixes) | 156.1 ms / 1.56 MB | 316 µs / 0 B | ~494× |
| `SubtitleImageAdjuster.AdjustBrightness` (1920×1080, per slider tick) | 40.2 ms | 4.8 ms | 8.4× |
| `SubtitleImageAdjuster.AdjustAlpha` | 35.9 ms | 4.8 ms | 7.5× |
| `SubtitleImageAdjuster.Colorize` | 37.0 ms | 6.3 ms | 5.9× |
| `TextMeasurer.MeasureString`, 600 lines | 9.2 ms / 150 KB | 524 µs / 0 B | 17.6× |
| `ModifySelectionRule` regex rule, 2000-line scan | 177 µs / 47 KB | 62 µs / 0 B | 2.9× |
| `ModifySelectionRule` line-count rule | 50 µs / 151 KB | 15 µs / 0 B | 3.3× |
| `ModifySelectionRule` style rule | 25 µs / 47 KB | 18 µs / 0 B | 1.4× |

## What changed

- **AllowFix**: every libse fix rule (78 call sites across 42 rules) probes `AllowFix` once per paragraph during "Apply selected fixes", and each probe did a LINQ scan of the whole `Fixes` list — O(paragraphs × rules × fixes). `Fixes` is stable during apply (`AddFixToListView` early-returns outside preview mode), so the pass now builds one `HashSet<(Guid?, string)>` of the selected fixes, invalidated at the top of `ApplyFixes`.
- **SubtitleImageAdjuster**: the per-pixel brightness→contrast→gamma chain is a pure function of one channel byte, alpha of the alpha byte, and colorize of `r+g+b` (0..765) — each collapses into a lookup table built once per image, using the exact same float operations per input value, so outputs are bit-for-bit identical. Loop bounds hoisted out of the per-pixel loops (they re-read `Width`/`Height` properties per pixel, and `Colorize` re-multiplied `Width * Height` per iteration).
- **TextMeasurer**: each call did an `SKTypeface.FromFamilyName` font-manager lookup plus an `SKFont` alloc; statistics measures every line of the subtitle three times over and batch convert measures every line of every file. The font is now cached per (family, size, weight), same pattern as `SubtitleLineViewModel`'s `_fontCache`.
- **ModifySelectionRule.IsMatch** (runs against every line on the 250 ms preview timer while the user types): the regex is compiled once per (pattern, options) on the rule instead of going through the static `Regex` cache per line; the ExactlyOneLine/TwoLines/MoreThanTwoLines rules count newlines with `Span.Count` instead of allocating `Split('\n')` per line; the style/actor rules use a plain loop instead of a per-line LINQ closure.

`UI.csproj` grants `InternalsVisibleTo` to the benchmark assembly so it can reach the internal `ModifySelectionRule.IsMatch`, and the new `UiProjectPerfHuntBenchmarks.cs` keeps all four paths measurable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)