### PR TITLE
Take point sync left times from original timings, not previewed grid

### DIFF
--- a/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherViewModel.cs
+++ b/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherViewModel.cs
@@ -91,7 +91,12 @@ public partial class PointSyncViaOtherViewModel : ObservableObject
             return;
         }
 
-        var leftTime = value.StartTime;
+        // Compare in original-time space: sync points store original left times, and the
+        // grid line may show previewed times after "Apply" (#12942).
+        var leftIndexInGrid = Subtitles.IndexOf(value);
+        var leftTime = leftIndexInGrid >= 0 && leftIndexInGrid < _originalSubtitles.Count
+            ? _originalSubtitles[leftIndexInGrid].StartTime
+            : value.StartTime;
         SyncPoint? nearestPoint = null;
         var nearestDistance = TimeSpan.MaxValue;
         foreach (var syncPoint in SyncPoints)
@@ -191,8 +196,12 @@ public partial class PointSyncViaOtherViewModel : ObservableObject
             return;
         }
 
+        // Sync points are applied to the original timings, so the left time must come from
+        // the original line - the grid line may already show previewed times after "Apply",
+        // which would bake the previous offset into the new point (#12942).
+        var leftIndex = Subtitles.IndexOf(left);
         var syncPoint = new SyncPoint(
-            left, Subtitles.IndexOf(left),
+            _originalSubtitles[leftIndex], leftIndex,
             right, Othersubtitles.IndexOf(right));
 
         // A line has at most one sync point (setting it again re-points it), and the list


### PR DESCRIPTION
Fixes #12942

In \"Point sync via other subtitle\", \"Apply sync\" previews the synced times in the left grid (recomputed from the original timings, so repeated clicks don't stack). But a sync point captured the left line's start time from that live grid — so a point set *after* an apply had the previous offset baked into its left time, while `PointSyncer` applies the diff to the original timings. The anchor line then landed off by the earlier offset (the timing risk the reporter describes).

Changes in `PointSyncViaOtherViewModel`:

- `SetSyncPoint` now snapshots the left time from `_originalSubtitles` instead of the (possibly previewed) grid line, so single- and multi-point paths both work in original-time space. The sync-point list also displays the original left time, matching what the sync actually maps from.
- The scroll-to-matching-line heuristic (`OnSelectedSubtitleChanged`) now compares in the same original-time space, so it still lands on the right line in the other grid after an apply.

With this, keeping the sync point listed after Apply (the SE4 difference reported) is genuinely safe: Apply is an idempotent preview and re-applying or adding points can no longer shift timings unexpectedly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)