### PR TITLE
Set all language files version to v5.1.0

### DIFF
--- a/src/ui/Assets/Languages/Arabic.json
+++ b/src/ui/Assets/Languages/Arabic.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "العربية",
-  "version": "v5.1.0-beta11",
+  "version": "v5.1.0",
   "translatedBy": "",
   "cultureName": "ar",
   "general": {

--- a/src/ui/Assets/Languages/Bulgarian.json
+++ b/src/ui/Assets/Languages/Bulgarian.json
@@ -1,6 +1,6 @@
 {
   "title": "Subtitle Edit",
-  "version": "v5.1.0-rc8",
+  "version": "v5.1.0",
   "translatedBy": "",
   "cultureName": "bg-BG",
   "general": {

--- a/src/ui/Assets/Languages/ChineseSimplified.json
+++ b/src/ui/Assets/Languages/ChineseSimplified.json
@@ -1,6 +1,6 @@
 {
   "title": "Subtitle Edit",
-  "version": "5",
+  "version": "v5.1.0",
   "translatedBy": "wuwufei | FeiXJ | Leon Cheung | larsenlouis | VK | nkh0472 | 蒙太奇字幕组（MontageSubs）",
   "cultureName": "zh-Hans",
   "general": {

--- a/src/ui/Assets/Languages/ChineseTraditional.json
+++ b/src/ui/Assets/Languages/ChineseTraditional.json
@@ -1,6 +1,6 @@
 {
   "title": "Subtitle Edit",
-  "version": "v5.1.0-rc8",
+  "version": "v5.1.0",
   "translatedBy": "昇 | BAWAN | 風逸蘭 | Jackie Lam | SiderealArt",
   "cultureName": "zh-Hant",
   "general": {

--- a/src/ui/Assets/Languages/Czech.json
+++ b/src/ui/Assets/Languages/Czech.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.1.0-beta2",
+  "version": "v5.1.0",
   "translatedBy": "Matěj Fouma",
   "cultureName": "cs-CZ",
   "general": {

--- a/src/ui/Assets/Languages/Danish.json
+++ b/src/ui/Assets/Languages/Danish.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.0.0",
+  "version": "v5.1.0",
   "translatedBy": "",
   "cultureName": "da-DK",
   "general": {

--- a/src/ui/Assets/Languages/Dutch.json
+++ b/src/ui/Assets/Languages/Dutch.json
@@ -2,7 +2,7 @@
   "Title": "Subtitle Edit",
   "TranslatedBy": "",
   "CultureName": "nl-NL",
-  "version": "v5.0.0",
+  "version": "v5.1.0",
   "General": {
     "SelectNonForcedLines": "Niet-geforceerde regels selecteren",
     "SelectForcedLines": "Geforceerde regels selecteren",

--- a/src/ui/Assets/Languages/Finnish.json
+++ b/src/ui/Assets/Languages/Finnish.json
@@ -1,6 +1,6 @@
 {
   "title": "Subtitle Edit",
-  "version": "v5.0.0",
+  "version": "v5.1.0",
   "translatedBy": "LibreTranslate",
   "cultureName": "fi-FI",
   "general": {

--- a/src/ui/Assets/Languages/French.json
+++ b/src/ui/Assets/Languages/French.json
@@ -1,6 +1,6 @@
 {
   "title": "Subtitle Edit",
-  "version": "v5.1.0-rc8",
+  "version": "v5.1.0",
   "translatedBy": "Need74 . ( V5.1.0-rc8, 27.07.2026)",
   "cultureName": "fr-FR",
   "general": {

--- a/src/ui/Assets/Languages/German.json
+++ b/src/ui/Assets/Languages/German.json
@@ -1,6 +1,6 @@
 {
   "Title": "Subtitle Edit",
-  "version": "v5.0.0",
+  "version": "v5.1.0",
   "TranslatedBy": "\u00DCbersetzt von Christoph Kitsche. \u00DCberarbeitet von Netspark und Stephan Lenhart.",
   "CultureName": "de-DE",
   "General": {

--- a/src/ui/Assets/Languages/Greek.json
+++ b/src/ui/Assets/Languages/Greek.json
@@ -1,6 +1,6 @@
 {
   "title": "Subtitle Edit",
-  "version": "v5.1.0-rc8",
+  "version": "v5.1.0",
   "translatedBy": "Claude (Anthropic)",
   "cultureName": "el-GR",
   "general": {

--- a/src/ui/Assets/Languages/Hebrew.json
+++ b/src/ui/Assets/Languages/Hebrew.json
@@ -1,6 +1,6 @@
 {
   "title": "עברית",
-  "version": "v5.0.0",
+  "version": "v5.1.0",
   "translatedBy": "Antigravity & cdtauman",
   "cultureName": "he-IL",
   "general": {

--- a/src/ui/Assets/Languages/Hungarian.json
+++ b/src/ui/Assets/Languages/Hungarian.json
@@ -1,6 +1,6 @@
 {
   "title": "Subtitle Edit",
-  "version": "v5.0.0",
+  "version": "v5.1.0",
   "translatedBy": "Zityi's Translator Te@m",
   "cultureName": "hu-HU",
   "general": {

--- a/src/ui/Assets/Languages/Indonesian.json
+++ b/src/ui/Assets/Languages/Indonesian.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.1.0-rc8",
+  "version": "v5.1.0",
   "translatedBy": "Claude (Anthropic)",
   "cultureName": "id-ID",
   "general": {

--- a/src/ui/Assets/Languages/Italian.json
+++ b/src/ui/Assets/Languages/Italian.json
@@ -1,6 +1,6 @@
 {
   "Title": "SubtitleEdit",
-  "Version": "v. 5.1.0 RC8",
+  "version": "v5.1.0",
   "TranslatedBy": "v. 27.07.2026 di bovirus",
   "CultureName": "it-IT",
   "General": {

--- a/src/ui/Assets/Languages/Japanese.json
+++ b/src/ui/Assets/Languages/Japanese.json
@@ -1,6 +1,6 @@
 {
   "title": "Subtitle Edit",
-  "version": "v5.0.0",
+  "version": "v5.1.0",
   "translatedBy": "",
   "cultureName": "jp-JP",
   "general": {

--- a/src/ui/Assets/Languages/Korean.json
+++ b/src/ui/Assets/Languages/Korean.json
@@ -1,6 +1,6 @@
 {
   "title": "Subtitle Edit",
-  "version": "v5.1.0-rc8",
+  "version": "v5.1.0",
   "translatedBy": "Hack茶ん, 12시27분(@12si27)",
   "cultureName": "ko-KR",
   "general": {

--- a/src/ui/Assets/Languages/Macedonian.json
+++ b/src/ui/Assets/Languages/Macedonian.json
@@ -1,6 +1,6 @@
 {
   "title": "Уредување на титлови",
-  "version": "v5.0.0",
+  "version": "v5.1.0",
   "translatedBy": "Кирил Жежоски",
   "cultureName": "mk-MK",
   "general": {

--- a/src/ui/Assets/Languages/Norwegian.json
+++ b/src/ui/Assets/Languages/Norwegian.json
@@ -2,7 +2,7 @@
   "Title": "Subtitle Edit",
   "TranslatedBy": "Gemini",
   "CultureName": "nb-NO",
-  "version": "v5.0.0",
+  "version": "v5.1.0",
   "General": {
     "SelectNonForcedLines": "Velg ikke-tvungne linjer",
     "SelectForcedLines": "Velg tvungne linjer",

--- a/src/ui/Assets/Languages/Persian.json
+++ b/src/ui/Assets/Languages/Persian.json
@@ -1,6 +1,6 @@
 {
   "title": "Subtitle Edit",
-  "version": "v5.1.0-beta15",
+  "version": "v5.1.0",
   "translatedBy": "رامتین جوکار",
   "cultureName": "fa-IR",
   "general": {

--- a/src/ui/Assets/Languages/Polish.json
+++ b/src/ui/Assets/Languages/Polish.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.1.0-rc17",
+  "version": "v5.1.0",
   "translatedBy": "Adam Malich - 27.07.2026",
   "cultureName": "pl-PL",
   "general": {

--- a/src/ui/Assets/Languages/Portuguese (Brazil).json
+++ b/src/ui/Assets/Languages/Portuguese (Brazil).json
@@ -1,6 +1,6 @@
 {
   "Title": "Subtitle Edit",
-  "Version": "v5.1.0-beta13",
+  "version": "v5.1.0",
   "TranslatedBy": "igorruckert",
   "CultureName": "pt-BR",
   "General": {

--- a/src/ui/Assets/Languages/Portuguese.json
+++ b/src/ui/Assets/Languages/Portuguese.json
@@ -1,6 +1,6 @@
 {
   "title": "Subtitle Edit",
-  "version": "v5.0.0",
+  "version": "v5.1.0",
   "translatedBy": "Hugo Carvalho (hugok79) e Filipe Mota (BlackSpirits)\nE-mail: hugokarvalho@hotmail.com / blackspirits@gmail.com\nAntigo tradutor: Marco Barbosa (moob)",
   "cultureName": "pt-PT",
   "general": {

--- a/src/ui/Assets/Languages/Romanian.json
+++ b/src/ui/Assets/Languages/Romanian.json
@@ -1,6 +1,6 @@
 {
   "title": "Subtitle Edit",
-  "version": "v5.0.0",
+  "version": "v5.1.0",
   "translatedBy": "zildan v1 05.04.26",
   "cultureName": "ro-RO",
   "general": {

--- a/src/ui/Assets/Languages/Russian.json
+++ b/src/ui/Assets/Languages/Russian.json
@@ -1,6 +1,6 @@
 {
   "title": "Subtitle Edit",
-  "version": "v5.1.0-rc8",
+  "version": "v5.1.0",
   "translatedBy": "",
   "cultureName": "ru-RU",
   "general": {

--- a/src/ui/Assets/Languages/Spanish.json
+++ b/src/ui/Assets/Languages/Spanish.json
@@ -2,7 +2,7 @@
   "Title": "Subtitle Edit",
   "TranslatedBy": "Gemini",
   "CultureName": "es-ES",
-  "version": "v5.0.0",
+  "version": "v5.1.0",
   "General": {
     "SelectNonForcedLines": "Seleccionar líneas no forzadas",
     "SelectForcedLines": "Seleccionar líneas forzadas",

--- a/src/ui/Assets/Languages/Swedish.json
+++ b/src/ui/Assets/Languages/Swedish.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.0.0",
+  "version": "v5.1.0",
   "translatedBy": "Claude (Opus 4.7)",
   "cultureName": "sv-SE",
   "general": {

--- a/src/ui/Assets/Languages/Thai.json
+++ b/src/ui/Assets/Languages/Thai.json
@@ -1,6 +1,6 @@
 {
   "title": "Subtitle Edit",
-  "version": "v5.1.0-rc8",
+  "version": "v5.1.0",
   "translatedBy": "Claude (Anthropic)",
   "cultureName": "th-TH",
   "general": {

--- a/src/ui/Assets/Languages/Turkish.json
+++ b/src/ui/Assets/Languages/Turkish.json
@@ -1,6 +1,6 @@
 {
   "title": "Subtitle Edit",
-  "version": "v5.1.0-rc8",
+  "version": "v5.1.0",
   "translatedBy": "Utku Gogus; Son güncelleme: Ahmet Murat Özhan (19.07.2026)",
   "cultureName": "tr-TR",
   "general": {

--- a/src/ui/Assets/Languages/Ukrainian.json
+++ b/src/ui/Assets/Languages/Ukrainian.json
@@ -1,6 +1,6 @@
 {
   "title": "Subtitle Edit",
-  "version": "v5.0.0",
+  "version": "v5.1.0",
   "translatedBy": "Kilo Code",
   "cultureName": "uk-UA",
   "general": {

--- a/src/ui/Assets/Languages/Vietnamese.json
+++ b/src/ui/Assets/Languages/Vietnamese.json
@@ -1,6 +1,6 @@
 {
   "title": "Subtitle Edit",
-  "version": "v5.1.0-rc8",
+  "version": "v5.1.0",
   "translatedBy": "Claude (Anthropic)",
   "cultureName": "vi-VN",
   "general": {


### PR DESCRIPTION
## What changed

Updates the `version` field to `"v5.1.0"` in all 31 non-English language JSON files under `src/ui/Assets/Languages` (English was already at v5.1.0). One line changed per file; file encodings (BOM state) are preserved.

## Notes for review

- **Italian.json** and **Portuguese (Brazil).json** used a capitalized `"Version"` key (with values `"v. 5.1.0 RC8"` and `"v5.1.0-beta13"`); both are normalized to the lowercase `"version"` key to match English and the other files.
- **ChineseSimplified.json** previously had just `"5"` as its version; it is now `"v5.1.0"` like the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)