### PR TITLE
Self-repair the unpacked theme folder when an icon file is missing

### DIFF
--- a/src/ui/Features/Main/Layout/InitToolbar.cs
+++ b/src/ui/Features/Main/Layout/InitToolbar.cs
@@ -13,6 +13,7 @@ using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using SkiaSharp;
+using System;
 using System.IO;
 using System.Linq;
 
@@ -568,11 +569,43 @@ public static class InitToolbar
             EnsureImagePath();
         }
 
-        return new Image
+        var filePath = Path.Combine(_imagePath, image + ".png");
+        try
         {
-            Source = MakeOneColor(Path.Combine(_imagePath, image + ".png")),
-            Stretch = Stretch.Uniform,
-        };
+            return new Image
+            {
+                Source = MakeOneColor(filePath),
+                Stretch = Stretch.Uniform,
+            };
+        }
+        catch (Exception e) when (e is FileNotFoundException or DirectoryNotFoundException)
+        {
+            // The unpacked theme folder can lag behind the app (an icon added between releases
+            // without a version bump made every startup crash here, since version.txt said the
+            // folder was current). Repair by re-unpacking Themes.zip and retry once; if the icon
+            // is still missing, show a blank image rather than killing the MainView build.
+            if (Logic.Initializers.ThemeInitializer.TryRepair(filePath))
+            {
+                try
+                {
+                    return new Image
+                    {
+                        Source = MakeOneColor(filePath),
+                        Stretch = Stretch.Uniform,
+                    };
+                }
+                catch (Exception retryException)
+                {
+                    Se.LogError(retryException, $"Theme image \"{filePath}\" still missing after re-unpacking Themes.zip");
+                }
+            }
+            else
+            {
+                Se.LogError(e, $"Could not load theme image \"{filePath}\"");
+            }
+
+            return new Image { Stretch = Stretch.Uniform };
+        }
     }
 
     private static unsafe Bitmap MakeOneColor(string filePath)

--- a/src/ui/Logic/Initializers/ThemeInitializer.cs
+++ b/src/ui/Logic/Initializers/ThemeInitializer.cs
@@ -14,6 +14,37 @@ public interface IThemeInitializer
 
 public class ThemeInitializer(IZipUnpacker zipUnpacker) : IThemeInitializer
 {
+    private static int _repairAttempted;
+
+    /// <summary>
+    /// Recovery path for a theme folder that claims to be current (version.txt matches) but is
+    /// missing files - e.g. an icon added between releases without a version bump, or a user
+    /// deleting files by hand. Re-unpacks Themes.zip over the existing folder. At most one
+    /// attempt per process, so a zip that is itself missing the file cannot loop.
+    /// </summary>
+    public static bool TryRepair(string missingFileName)
+    {
+        if (System.Threading.Interlocked.Exchange(ref _repairAttempted, 1) == 1)
+        {
+            return false;
+        }
+
+        try
+        {
+            Se.LogError($"Theme image \"{missingFileName}\" missing - re-unpacking Themes.zip to \"{Se.ThemesFolder}\"");
+            var zipUri = new Uri("avares://SubtitleEdit/Assets/Themes.zip");
+            using var zipStream = AssetLoader.Open(zipUri);
+            new Compression.ZipUnpacker().UnpackZipStream(zipStream, Se.ThemesFolder);
+            WriteNewVersionFile();
+            return true;
+        }
+        catch (Exception e)
+        {
+            Se.LogError(e, $"Re-unpacking Themes.zip to \"{Se.ThemesFolder}\" failed");
+            return false;
+        }
+    }
+
     public async Task UpdateThemesIfNeeded()
     {
         if (await NeedsUpdate())


### PR DESCRIPTION
## Problem
Since the new optional toolbar icons landed (147cf6e52, after the v5.1.0 tag), any install whose unpacked `Themes` folder predates the icon **crashes at startup**: `Themes/version.txt` still matches `Se.Version` ("v5.1.0"), so `ThemeInitializer` skips re-unpacking, and MainView dies on `FileNotFoundException` while building the toolbar. The process exits with only an error-log.txt entry - no visible error.

This hits anyone running a dev build over an existing 5.1.0 install today, and would hit real users any time a new theme image ships without a version bump (or a user deletes a file by hand).

## Fix
- `ThemeInitializer.TryRepair`: static one-shot repair that re-unpacks Themes.zip over the existing folder and rewrites version.txt. Guarded by an `Interlocked` flag so a zip that itself lacks the file can't loop.
- `InitToolbar.MakeImage` (the single choke point all toolbar icons go through): catch `FileNotFoundException`/`DirectoryNotFoundException`, repair, retry once; if still missing, log and return a blank `Image` instead of killing the MainView build.

Normal startup is unchanged - no extra file checks; the repair code only runs when a load actually fails. (`MessageBox` already had its own try/catch around its icon load.)

## Verified
Deleted `AssaStyle.png` from all unpacked theme folders while version.txt claimed current (the exact crash scenario), launched: app starts, error-log.txt records the repair, Themes.zip is re-unpacked, and the retry loads the restored icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)