### PR TITLE
Restore total seconds/milliseconds time codes in export custom text format

### DIFF
--- a/docs/features/file.md
+++ b/docs/features/file.md
@@ -85,7 +85,23 @@ Export subtitle text without time codes.
 
 ### Export custom text format
 
-Export using a customizable text template.
+Export using a customizable text template. A template has a header, a per-subtitle text part, and a footer.
+
+Placeholders for the text part include `{start}`, `{end}`, `{text}`, `{number}`, `{number-1}`, `{duration}`, `{gap}`, `{actor}`, `{text-line-1}`, `{text-line-2}`, `{text-length}`, `{cps-period}`, `{bookmark}`, `{media-file-name}`, `{text-csv}`, and `{tab}`.
+
+The time code format is built from these letters (anything else is kept as-is):
+
+| Letters | Meaning |
+|---------|---------|
+| `hh` / `h` | hours |
+| `mm` / `m` | minutes |
+| `ss` / `s` | seconds |
+| `zzz` | milliseconds / fraction of a second |
+| `ff` / `f` | frames (uses the current frame rate) |
+
+So `hh:mm:ss,zzz` gives `00:01:01,160` and `hh:mm:ss:ff` gives `00:01:01:04`.
+
+A time code format that *starts* with `s`'s or `z`'s means totals instead of clock components: `ss.zzz` gives total seconds `61.160`, `ss.zzzzzz` gives `61.160000` (Audacity/Tenacity label style), `ss` gives `61`, and `zzz` gives total milliseconds `61160`. A format of exactly `ff` gives total frames.
 
 ### Export to Blu-ray SUP
 

--- a/src/libuilogic/Export/CustomTextFormatter.cs
+++ b/src/libuilogic/Export/CustomTextFormatter.cs
@@ -131,7 +131,11 @@ public static partial class CustomTextFormatter
         var isNegative = timeCode.TotalMilliseconds < 0;
         var result = template;
 
-        // Replace milliseconds/fractional seconds (z's)
+        // Replace a leading run of s's/z's with total seconds/milliseconds,
+        // e.g. "ss.zzz" => "61.160" and "zzz" => "61160" (SE 4.x semantics)
+        result = ReplaceLeadingTotal(result, timeCode);
+
+        // Replace fractional seconds (z's)
         result = ReplaceMilliseconds(result, timeCode);
 
         // Replace seconds (s's)
@@ -149,6 +153,67 @@ public static partial class CustomTextFormatter
         return result;
     }
 
+    /// <summary>
+    /// Template starts with a run of 's' or 'z' that means a total (total seconds
+    /// or total milliseconds) rather than a clock component: "ss.zzz", "zzz", "s".
+    /// A single leading 's'/'z' only counts when it is the whole template, so
+    /// literal text like "s: hh:mm:ss" is left alone.
+    /// </summary>
+    internal static bool HasLeadingTotalRun(string template)
+    {
+        return GetLeadingTotalRunLength(template) > 0;
+    }
+
+    private static int GetLeadingTotalRunLength(string template)
+    {
+        if (template.Length == 0)
+        {
+            return 0;
+        }
+
+        var c = template[0];
+        if (c != 's' && c != 'z')
+        {
+            return 0;
+        }
+
+        var run = 1;
+        while (run < template.Length && template[run] == c)
+        {
+            run++;
+        }
+
+        return run >= 2 || run == template.Length ? run : 0;
+    }
+
+    private static string ReplaceLeadingTotal(string template, TimeCode timeCode)
+    {
+        var run = GetLeadingTotalRunLength(template);
+        if (run == 0)
+        {
+            return template;
+        }
+
+        var rest = template.Substring(run);
+        long total;
+        if (template[0] == 'z')
+        {
+            total = (long)Math.Round(Math.Abs(timeCode.TotalMilliseconds), MidpointRounding.AwayFromZero);
+        }
+        else if (rest.Contains('z'))
+        {
+            // A fractional part follows, so the seconds must not be rounded up:
+            // 61.960 as "ss.zzz" is "61.960", not "62.960"
+            total = (long)Math.Floor(Math.Abs(timeCode.TotalSeconds));
+        }
+        else
+        {
+            total = (long)Math.Round(Math.Abs(timeCode.TotalSeconds), MidpointRounding.AwayFromZero);
+        }
+
+        return total.ToString(CultureInfo.InvariantCulture).PadLeft(run, '0') + rest;
+    }
+
     private static string ReplaceMilliseconds(string template, TimeCode timeCode)
     {
         if (template.IndexOf('z') < 0)
@@ -156,69 +221,18 @@ public static partial class CustomTextFormatter
             return template;
         }
 
-        // "^z+$" for a non-empty template == "no non-'z' character present".
-        var isPureZMode = template.AsSpan().IndexOfAnyExcept('z') < 0;
-
-        return ZRunRegex.Replace(template, match =>
-        {
-            var zCount = match.Value.Length;
-
-            if (isPureZMode)
-            {
-                return FormatTotalMilliseconds(timeCode, zCount);
-            }
-            else
-            {
-                return FormatFractionalSeconds(timeCode, zCount);
-            }
-        });
-    }
-
-    private static string FormatTotalMilliseconds(TimeCode timeCode, int desiredLength)
-    {
-        var totalMilliseconds = Math.Abs(Math.Round(timeCode.TotalMilliseconds, MidpointRounding.AwayFromZero));
-        var ms = (long)totalMilliseconds;
-        var msString = ms.ToString();
-
-        return desiredLength <= msString.Length
-            ? msString
-            : msString.PadLeft(desiredLength, '0');
+        // Any remaining z-run is a fraction of a second (a leading total run was already replaced)
+        return ZRunRegex.Replace(template, match => FormatFractionalSeconds(timeCode, match.Value.Length));
     }
 
     private static string FormatFractionalSeconds(TimeCode timeCode, int desiredLength)
     {
-        var absoluteSeconds = Math.Abs(timeCode.TotalSeconds);
-        var fractionalSeconds = absoluteSeconds - Math.Floor(absoluteSeconds);
-
-        string fracString;
-
-        if (fractionalSeconds == 0)
-        {
-            fracString = "000";
-        }
-        else
-        {
-            fracString = fractionalSeconds
-                .ToString(CultureInfo.InvariantCulture)
-                .Split('.')[1]
-                .TrimEnd('0');
-
-            // Ensure at least 3 digits for milliseconds
-            if (fracString.Length < 3)
-            {
-                fracString = fracString.PadRight(3, '0');
-            }
-        }
-
-        // Return exactly the requested number of digits
-        if (desiredLength <= fracString.Length)
-        {
-            return fracString.Substring(0, desiredLength);
-        }
-        else
-        {
-            return fracString.PadRight(desiredLength, '0');
-        }
+        // The milliseconds component is the fraction of the second, exact to three digits;
+        // computing "TotalSeconds - floor" instead loses precision (61.160 => "61.159...")
+        var fracString = Math.Abs(timeCode.Milliseconds).ToString("000", CultureInfo.InvariantCulture);
+        return desiredLength <= fracString.Length
+            ? fracString.Substring(0, desiredLength)
+            : fracString.PadRight(desiredLength, '0');
     }
 
     private static string ReplaceSeconds(string template, TimeCode timeCode)
@@ -228,23 +242,9 @@ public static partial class CustomTextFormatter
             return template;
         }
 
-        var isPureSMode = template.AsSpan().IndexOfAnyExcept('s') < 0;
-
-        return SRunRegex.Replace(template, match =>
-        {
-            var length = match.Value.Length;
-
-            if (isPureSMode)
-            {
-                var totalSeconds = (long)Math.Round(Math.Abs(timeCode.TotalSeconds), MidpointRounding.AwayFromZero);
-                return totalSeconds.ToString().PadLeft(length, '0');
-            }
-            else
-            {
-                var seconds = Math.Abs(timeCode.Seconds);
-                return seconds.ToString().PadLeft(length, '0');
-            }
-        });
+        // Any remaining s-run is the seconds clock component (a leading total run was already replaced)
+        var seconds = Math.Abs(timeCode.Seconds);
+        return SRunRegex.Replace(template, match => seconds.ToString().PadLeft(match.Value.Length, '0'));
     }
 
     private static string ReplaceStandardComponents(string template, TimeCode timeCode)
@@ -270,8 +270,15 @@ public static partial class CustomTextFormatter
 
         if (result.IndexOf('f') >= 0)
         {
-            result = result.Replace("ff", SubtitleFormat.MillisecondsToFrames(timeCode.TotalMilliseconds).ToString("00"))
-                           .Replace("f", SubtitleFormat.MillisecondsToFramesMaxFrameRate(timeCode.Milliseconds).ToString("00"));
+            if (template == "ff")
+            {
+                // The whole template is "ff" = total frames
+                return SubtitleFormat.MillisecondsToFrames(Math.Abs(timeCode.TotalMilliseconds)).ToString(CultureInfo.InvariantCulture);
+            }
+
+            var framesInSecond = SubtitleFormat.MillisecondsToFramesMaxFrameRate(Math.Abs(timeCode.Milliseconds));
+            result = result.Replace("ff", framesInSecond.ToString("00"))
+                           .Replace("f", framesInSecond.ToString(CultureInfo.InvariantCulture));
         }
 
         return result;
@@ -286,14 +293,10 @@ public static partial class CustomTextFormatter
             d = SubtitleFormat.MillisecondsToFrames(duration.TotalMilliseconds).ToString(CultureInfo.InvariantCulture);
         }
 
-        if (timeCodeTemplate == "zzz" || timeCodeTemplate == "zz" || timeCodeTemplate == "z")
+        if (HasLeadingTotalRun(timeCodeTemplate))
         {
-            d = ((long)Math.Round(duration.TotalMilliseconds, MidpointRounding.AwayFromZero)).ToString(CultureInfo.InvariantCulture);
-        }
-
-        if (timeCodeTemplate == "sss" || timeCodeTemplate == "ss" || timeCodeTemplate == "s")
-        {
-            d = duration.Seconds.ToString(CultureInfo.InvariantCulture);
+            // Totals ("zzz", "ss", "ss.zzz", ...): the duration renders just like a time code
+            d = GetTimeCode(duration, timeCodeTemplate);
         }
         else if (timeCodeTemplate.EndsWith("ss.ff", StringComparison.Ordinal))
         {

--- a/src/ui/Features/Files/ExportCustomTextFormat/EditCustomTextFormatViewModel.cs
+++ b/src/ui/Features/Files/ExportCustomTextFormat/EditCustomTextFormatViewModel.cs
@@ -20,7 +20,17 @@ public partial class EditCustomTextFormatViewModel : ObservableObject, IClosingC
     [ObservableProperty] private string _title;
 
     public List<string> NewLineList { get; } = new() { "{newline}", "{tab}", "{cr}", "{lf}", "||" };
-    public List<string> TimeCodeList { get; } = new() { "hh:mm:ss,zzz", "ff" };
+    public List<string> TimeCodeList { get; } = new()
+    {
+        "hh:mm:ss,zzz",
+        "hh:mm:ss.zzz",
+        "hh:mm:ss:ff",
+        "ss.zzz",
+        "ss.zzzzzz",
+        "ss",
+        "zzz",
+        "ff",
+    };
     public List<string> HeaderFooterTags { get; } = new() { "{title}", "{#lines}", "{tab}", "{media-file-name}", "{media-file-name-full}", "{media-file-name-with-ext}" };
     public List<string> ParagraphTags { get; } = new()
     {

--- a/tests/libuilogic/Export/CustomTextFormatterTests.cs
+++ b/tests/libuilogic/Export/CustomTextFormatterTests.cs
@@ -1,0 +1,141 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.UiLogic.Export;
+
+namespace LibUiLogicTests.Export;
+
+public class CustomTextFormatterTests
+{
+    // 00:01:01,160 - the example from https://github.com/SubtitleEdit/subtitleedit/discussions/12978
+    private static readonly TimeCode Tc = new TimeCode(61160);
+
+    [Theory]
+    [InlineData("hh:mm:ss,zzz", "00:01:01,160")]
+    [InlineData("hh:mm:ss.zzz", "00:01:01.160")]
+    [InlineData("h:mm:ss.zz", "0:01:01.16")]
+    [InlineData("mm:ss", "01:01")]
+    public void GetTimeCode_ClockTemplates_SliceComponents(string template, string expected)
+    {
+        Assert.Equal(expected, CustomTextFormatter.GetTimeCode(Tc, template));
+    }
+
+    [Theory]
+    [InlineData("ss.zzz", "61.160")]
+    [InlineData("ss.zzzzzz", "61.160000")]
+    [InlineData("ss,zzz", "61,160")]
+    [InlineData("ss", "61")]
+    [InlineData("sss", "061")]
+    [InlineData("zzz", "61160")]
+    public void GetTimeCode_LeadingSecondsOrMillisecondsRun_MeansTotal(string template, string expected)
+    {
+        Assert.Equal(expected, CustomTextFormatter.GetTimeCode(Tc, template));
+    }
+
+    [Fact]
+    public void GetTimeCode_TotalSecondsWithFraction_DoesNotRoundUpSeconds()
+    {
+        Assert.Equal("61.960", CustomTextFormatter.GetTimeCode(new TimeCode(61960), "ss.zzz"));
+    }
+
+    [Fact]
+    public void GetTimeCode_TotalSecondsWithoutFraction_Rounds()
+    {
+        Assert.Equal("62", CustomTextFormatter.GetTimeCode(new TimeCode(61960), "ss"));
+        Assert.Equal("06", CustomTextFormatter.GetTimeCode(new TimeCode(5900), "ss"));
+    }
+
+    [Fact]
+    public void GetTimeCode_TotalMilliseconds_PadsToRunLength()
+    {
+        Assert.Equal("050", CustomTextFormatter.GetTimeCode(new TimeCode(50), "zzz"));
+        Assert.Equal("500", CustomTextFormatter.GetTimeCode(new TimeCode(500), "zzz"));
+    }
+
+    [Fact]
+    public void GetTimeCode_Negative_PrependsSign()
+    {
+        Assert.Equal("-01.500", CustomTextFormatter.GetTimeCode(new TimeCode(-1500), "ss.zzz"));
+    }
+
+    [Fact]
+    public void GetTimeCode_Frames()
+    {
+        var old = Configuration.Settings.General.CurrentFrameRate;
+        try
+        {
+            Configuration.Settings.General.CurrentFrameRate = 25;
+
+            // mixed template: frames within the second
+            Assert.Equal("00:01:01:04", CustomTextFormatter.GetTimeCode(Tc, "hh:mm:ss:ff"));
+
+            // whole template "ff": total frames
+            Assert.Equal("1529", CustomTextFormatter.GetTimeCode(Tc, "ff"));
+        }
+        finally
+        {
+            Configuration.Settings.General.CurrentFrameRate = old;
+        }
+    }
+
+    [Fact]
+    public void GenerateCustomText_TotalSecondsTemplate_MakesAudacityLabels()
+    {
+        var template = new CustomFormatTemplate
+        {
+            FormatHeader = string.Empty,
+            FormatParagraph = "{start}\t{end}\t{text}\n",
+            FormatTimeCode = "ss.zzzzzz",
+            FormatNewLine = string.Empty,
+            FormatFooter = string.Empty,
+        };
+        var paragraphs = new List<Paragraph>
+        {
+            new Paragraph("Every scan updates the entire supply chain.", 57921, 61160),
+        };
+
+        var result = CustomTextFormatter.GenerateCustomText(template, paragraphs, "title", string.Empty);
+
+        Assert.Equal("57.921000\t61.160000\tEvery scan updates the entire supply chain.\n", result);
+    }
+
+    [Fact]
+    public void GenerateCustomText_TotalSecondsTemplate_DurationIsTotalToo()
+    {
+        var template = new CustomFormatTemplate
+        {
+            FormatHeader = string.Empty,
+            FormatParagraph = "{duration}\n",
+            FormatTimeCode = "ss.zzz",
+            FormatNewLine = string.Empty,
+            FormatFooter = string.Empty,
+        };
+        var paragraphs = new List<Paragraph>
+        {
+            new Paragraph("Hi", 0, 75500), // 75.5 seconds - more than a minute
+        };
+
+        var result = CustomTextFormatter.GenerateCustomText(template, paragraphs, "title", string.Empty);
+
+        Assert.Equal("75.500\n", result);
+    }
+
+    [Fact]
+    public void GenerateCustomText_ClockTemplate_DurationIsShortened()
+    {
+        var template = new CustomFormatTemplate
+        {
+            FormatHeader = string.Empty,
+            FormatParagraph = "{duration}\n",
+            FormatTimeCode = "hh:mm:ss,zzz",
+            FormatNewLine = string.Empty,
+            FormatFooter = string.Empty,
+        };
+        var paragraphs = new List<Paragraph>
+        {
+            new Paragraph("Hi", 0, 75500),
+        };
+
+        var result = CustomTextFormatter.GenerateCustomText(template, paragraphs, "title", string.Empty);
+
+        Assert.Equal("01:15,500\n", result);
+    }
+}


### PR DESCRIPTION
Follow-up to #12978 / #12984: the Audacity labels format covered that specific need, but the underlying custom-format regression remained.

**The regression**

In SE 4.x, a time code format *starting* with a run of `s` or `z` meant a total: `ss.zzz` → `61.160` (total seconds), `zzz` → `61160` (total milliseconds). The v5 port replaced this with pure clock-component slicing, so `ss.zzz` gave `01.160` — the lossy output reported in the discussion. This PR restores the 4.x semantics:

- leading `s`-run = total seconds, zero-padded to the run length (`ss.zzzzzz` → `61.160000`, Audacity/Tenacity style)
- leading `z`-run = total milliseconds
- when a fractional part follows, the seconds floor instead of round (`61.960` stays `61.960`, not `62.960` — this one was a 4.x bug, now fixed)
- a single leading `s`/`z` only counts when it is the whole template, so literal text is left alone (matches 4.x `StartsWith("ss")`)

**Two more port regressions fixed in passing**

- `ff` in mixed templates (`hh:mm:ss:ff`) rendered *total* frames (e.g. `00:01:01:1529`); it is frames-within-second again (`00:01:01:04`). A template of exactly `ff` still means total frames.
- The fractional part was computed as `TotalSeconds - floor(TotalSeconds)`, and floating-point subtraction could render 61.160 as `…01.159`. It now uses the exact milliseconds component.

**Other changes**

- `{duration}`/`{gap}` render through `GetTimeCode` for total-style formats — this also fixes `{duration}` for pure `ss` with durations over a minute (previously showed the seconds component only).
- The time code dropdown now offers the useful presets (`hh:mm:ss.zzz`, `hh:mm:ss:ff`, `ss.zzz`, `ss.zzzzzz`, `ss`, `zzz`, `ff`) instead of just two entries, and the template letters are documented in `docs/features/file.md`.
- New unit tests cover clock templates, totals, floor-vs-round, frames, negative values, and duration rendering (18 tests; full libuilogic + seconv suites pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)