### PR TITLE
Fix inverted I/1-to-l OCR rule and extend the Dutch replace list

### DIFF
--- a/Dictionaries/nld_OCRFixReplaceList.xml
+++ b/Dictionaries/nld_OCRFixReplaceList.xml
@@ -8,9 +8,13 @@
     <Word from="AIlemachtig" to="Allemachtig" />
     <Word from="AIles" to="Alles" />
     <Word from="AIs" to="Als" />
+    <Word from="also" to="alsof" />
+    <Word from="Also" to="Alsof" />
     <Word from="benje" to="ben je" />
     <Word from="Brittannie" to="Brittannië" />
     <Word from="cliche" to="cliché" />
+    <Word from="continuiteit" to="continuïteit" />
+    <Word from="Continuiteit" to="Continuïteit" />
     <Word from="dankje" to="dank je" />
     <Word from="Dankje" to="Dank je" />
     <Word from="datnietkunnen" to="dat niet kunnen" />
@@ -21,17 +25,23 @@
     <Word from="eindetegemoet" to="einde tegemoet" />
     <Word from="Ervanaf" to="Ervan af" />
     <Word from="essentiile" to="essentiële" />
+    <Word from="geimporteerd" to="geïmporteerd" />
+    <Word from="Geimporteerd" to="Geïmporteerd" />
     <Word from="genant" to="gênant" />
     <Word from="gevaI" to="geval" />
     <Word from="Girard" to="Gérard" />
     <Word from="goedgeinformeerde" to="goedgeïnformeerde" />
     <Word from="Grigoire" to="Grégoire" />
+    <Word from="hadhaar" to="had haar" />
+    <Word from="Hadhaar" to="Had haar" />
     <Word from="heefthem" to="heeft hem" />
     <Word from="heeftme" to="heeft me" />
     <Word from="herfraseren" to="parafraseren" />
     <Word from="hi" to="hè" />
     <Word from="hii" to="hij" />
     <Word from="hiinog" to="hij nog" />
+    <Word from="hijeen" to="hij een" />
+    <Word from="Hijeen" to="Hij een" />
     <Word from="Iafaard" to="lafaard" />
     <Word from="Iafaards" to="lafaards" />
     <Word from="Iang" to="lang" />
@@ -58,6 +68,8 @@
     <Word from="Italie" to="Italië" />
     <Word from="Iuisteren" to="luisteren" />
     <Word from="Iukt" to="lukt" />
+    <Word from="jijeen" to="jij een" />
+    <Word from="Jijeen" to="Jij een" />
     <Word from="Jolitis" to="Jolités" />
     <Word from="kamervragen" to="Kamervragen" />
     <Word from="komtje" to="komt je" />
@@ -69,6 +81,8 @@
     <Word from="lerland" to="Ierland" />
     <Word from="lerse" to="Ierse" />
     <Word from="liht" to="licht" />
+    <Word from="lijsst" to="lijst" />
+    <Word from="Lijsst" to="Lijst" />
     <Word from="ln" to="In" />
     <Word from="ls" to="Is" />
     <Word from="luisterje" to="luister je" />
@@ -79,6 +93,10 @@
     <Word from="metjou" to="met jou" />
     <Word from="metmii" to="met mij" />
     <Word from="mii" to="mij" />
+    <Word from="mijnjonge" to="mijn jonge" />
+    <Word from="Mijnjonge" to="Mijn jonge" />
+    <Word from="moestenhaar" to="moesten haar" />
+    <Word from="Moestenhaar" to="Moesten haar" />
     <Word from="nietbedrogen" to="niet bedrogen" />
     <Word from="nietwilt" to="niet wilt" />
     <Word from="officiele" to="officiële" />
@@ -87,6 +105,8 @@
     <Word from="Omdatjij" to="Omdat jij" />
     <Word from="ondrrwerp" to="onderwerp" />
     <Word from="ondrrzoek" to="onderzoek" />
+    <Word from="oplicten" to="oplichten" />
+    <Word from="Oplicten" to="Oplichten" />
     <Word from="ovrrheidsgeld" to="overheidsgeld" />
     <Word from="padvinderijpunten" to="padvinderspunten" />
     <Word from="paranoide" to="paranoïde" />
@@ -95,7 +115,15 @@
     <Word from="Scive" to="Scève" />
     <Word from="stillouden" to="stilhouden" />
     <Word from="Terzake" to="Ter zake" />
+    <Word from="totziens" to="tot ziens" />
+    <Word from="Totziens" to="Tot ziens" />
     <Word from="trgen" to="tegen" />
+    <Word from="verkening" to="verkenning" />
+    <Word from="Verkening" to="Verkenning" />
+    <Word from="verpleterende" to="verpletterende" />
+    <Word from="Verpleterende" to="Verpletterende" />
+    <Word from="voorbijken" to="voorbijkomen" />
+    <Word from="Voorbijken" to="Voorbijkomen" />
     <Word from="voorje" to="voor je" />
     <Word from="voormii" to="voor mij" />
     <Word from="wachtje" to="wacht je" />
@@ -106,6 +134,10 @@
     <Word from="Zii" to="Zij" />
     <Word from="Ziiheeft" to="Zij heeft" />
     <Word from="ziin" to="zijn" />
+    <Word from="zijeen" to="zij een" />
+    <Word from="Zijeen" to="Zij een" />
+    <Word from="zijnjonge" to="zijn jonge" />
+    <Word from="Zijnjonge" to="Zijn jonge" />
     <Word from="zonderjou" to="zonder jou" />
     <Word from="Zonderjou" to="Zonder jou" />
   </WholeWords>
@@ -136,6 +168,7 @@
     <RegEx find="\bls(?=\p{Ll}{2})" replaceWith="Is" />
     <RegEx find="\beIk" replaceWith="elk" />
     <RegEx find="\bler(land|se|s|)\b" replaceWith="Ier$1" />
+    <RegEx find="\biij" replaceWith="lij" />
     <RegEx find="comite\b" replaceWith="comité" />
   </RegularExpressions>
   <RegularExpressionsIfSpelledCorrectly>

--- a/src/libuilogic/Ocr/FixEngine/OcrFixReplaceList2.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixReplaceList2.cs
@@ -810,7 +810,8 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
                 {
                     if (word[match.Index + 1] == 'I' || word[match.Index + 1] == '1')
                     {
-                        var doFix = word[match.Index + 1] != 'I' && match.Index >= 1 && word.AsSpan(match.Index - 1).StartsWith("Mc", StringComparison.Ordinal);
+                        // Keep the capital I of Mc/Mac names (McIntyre, MacIntosh)
+                        var doFix = !(word[match.Index + 1] == 'I' && match.Index >= 1 && word.AsSpan(match.Index - 1).StartsWith("Mc", StringComparison.Ordinal));
                         if (word[match.Index + 1] == 'I' && match.Index >= 2 && word.AsSpan(match.Index - 2).StartsWith("Mac", StringComparison.Ordinal))
                         {
                             doFix = false;

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixIor1InsideLowerCaseWordTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixIor1InsideLowerCaseWordTests.cs
@@ -1,0 +1,41 @@
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+// Regression tests for https://github.com/SubtitleEdit/subtitleedit/issues/12996
+// A 2014 refactor inverted the Mc/Mac-name guard in FixIor1InsideLowerCaseWord, so the
+// hardcoded "uppercase I/1 after a lowercase letter becomes l" rule never fired. The old
+// WinForms engine had a second, correct line-level copy that masked this; the SE 5 OCR
+// pipeline only has this word-level copy, so llama/Tesseract output like "heleboeI"
+// reached users unfixed.
+public class OcrFixIor1InsideLowerCaseWordTests
+{
+    [Theory]
+    [InlineData("heleboeI", "heleboel")]
+    [InlineData("boeI", "boel")]
+    [InlineData("teIt", "telt")]
+    [InlineData("sequeI", "sequel")]
+    [InlineData("geveI", "gevel")]
+    [InlineData("he1p", "help")]
+    public void UppercaseIOr1AfterLowercaseLetter_IsFixedToLowercaseL(string input, string expected)
+    {
+        Assert.Equal(expected, OcrFixReplaceList2.FixIor1InsideLowerCaseWord(input));
+    }
+
+    [Theory]
+    [InlineData("McIntyre")]
+    [InlineData("MacIntosh")]
+    public void McAndMacNames_KeepTheirCapitalI(string input)
+    {
+        Assert.Equal(input, OcrFixReplaceList2.FixIor1InsideLowerCaseWord(input));
+    }
+
+    [Theory]
+    [InlineData("MI6")] // starts-and-ends-with-number style guards
+    [InlineData("2Ic")]
+    [InlineData("a1b2")]
+    public void WordsWithOtherDigits_AreLeftAlone(string input)
+    {
+        Assert.Equal(input, OcrFixReplaceList2.FixIor1InsideLowerCaseWord(input));
+    }
+}


### PR DESCRIPTION
Fixes #12996

## The bug

`FixIor1InsideLowerCaseWord` — the hardcoded rule that turns an uppercase `I` or a `1` after a lowercase letter into `l` — has been dead since 2014. Commit `f8a40c77a` collapsed the original

```csharp
bool doFix = true;
if (char == 'I' && preceded by "Mc") doFix = false;
```

into `doFix = char != 'I' && ... StartsWith("Mc")`, a botched negation: `I` was never fixed, and `1` only in the nonsense case "preceded by Mc". Nobody noticed because the WinForms engine had a second, correct line-level copy of the rule (`sequeI of → sequel of` in `FixOcrErrorsViaHardcodedRules`) that masked it — but that pass was not ported to the SE 5 OCR pipeline, so `heleboeI`, `boeI`, `teIt` etc. from #12996 reached users unfixed. This restores the original semantics (fix always, except the capital I of Mc/Mac names) and covers it with tests.

## Dutch replace list

Adds the generalizable fixes from #12996 to `nld_OCRFixReplaceList.xml`:

- Merged particle words: `hadhaar`, `moestenhaar`, `hijeen`/`zijeen`/`jijeen`, `mijnjonge`/`zijnjonge`, `totziens`
- Missing diaeresis: `geimporteerd`, `continuiteit`
- Misreads: `verkening`, `verpleterende`, `oplicten`, `lijsst`, `voorbijken`, `also → alsof`
- RegEx `\biij → lij` for the leading l→i misread (`iijf → lijf`, `iijkt → lijkt`)

Not included: the reporter's `bietetap → bietensap` and `gestukt → gestuct` (content-specific to their subtitle), and their `oeI`/`eeI`/`teIt` regexes (obsolete once the engine rule works). `also → alsof` is the one judgement call — "also" is not Dutch, but it would rewrite quoted English inside Dutch subs; drop it if that feels too aggressive.

## Noticed while here (not addressed)

`nld_OCRFixReplaceList.xml` contains **two** `<RegularExpressionsIfSpelledCorrectly>` sections (added in `9c67f2762`), and both loaders use `SelectSingleNode`, so the entire second section — ~175 lines of Dutch-specific rules — is silently dead. Making it live is a behavioral decision (some of those rules are aggressive), so it's left out of this PR.

## Testing

- New `OcrFixIor1InsideLowerCaseWordTests` (11 cases: fixes, Mc/Mac exclusions, digit guards)
- Full `UITests` (959) and `LibUiLogicTests` (45) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)