### PR TITLE
Pilot: TableView instead of DataGrid in the OCR subtitle grid

### DIFF
--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -159,7 +159,7 @@ public partial class OcrViewModel : ObservableObject
     [ObservableProperty] string _unknownWordsRemoveCurrentText;
 
     public Window? Window { get; set; }
-    public DataGrid SubtitleGrid { get; set; }
+    public TableView SubtitleGrid { get; set; }
 
     // Rebuild the combo row visuals after a download finishes so the install-status dots
     // reflect the current on-disk state instead of the snapshot taken when first realised.
@@ -230,7 +230,7 @@ public partial class OcrViewModel : ObservableObject
             .Select(p => p.EnglishName)
             .OrderBy(p => p));
         SelectedOllamaLanguage = "English";
-        SubtitleGrid = new DataGrid();
+        SubtitleGrid = new TableView();
         CurrentBitmapInfo = string.Empty;
         CurrentText = string.Empty;
         ProgressText = string.Empty;
@@ -4363,10 +4363,10 @@ public partial class OcrViewModel : ObservableObject
             e.Handled = true;
             if (ImageMaxHeight < 300)
             {
+                // TableView rows auto-size to their content, so changing the bound
+                // Image Max sizes re-measures the rows - no explicit RowHeight needed.
                 ImageMaxHeight *= 1.1;
                 ImageMaxWidth *= 1.1;
-                var rowHeight = CalculateRowHeight();
-                Dispatcher.UIThread.Post(() => SubtitleGrid.RowHeight = rowHeight);
             }
         }
         else if ((e.Key == Key.Subtract || e.Key == Key.OemMinus) && e.KeyModifiers.HasFlag(KeyModifiers.Control))
@@ -4376,8 +4376,6 @@ public partial class OcrViewModel : ObservableObject
             {
                 ImageMaxHeight *= 0.9;
                 ImageMaxWidth *= 0.9;
-                var rowHeight = CalculateRowHeight();
-                Dispatcher.UIThread.Post(() => SubtitleGrid.RowHeight = rowHeight);
             }
         }
         else if (e.Key == Key.V && e.KeyModifiers.HasFlag(KeyModifiers.Control) && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
@@ -4446,10 +4444,9 @@ public partial class OcrViewModel : ObservableObject
                 SubtitleGrid.SelectedIndex = indexToScroll;
 
                 // Post ScrollIntoView as a second background task so it runs after
-                // the DataGrid has processed the selection change and updated its layout.
-                var item = OcrSubtitleItems[indexToScroll];
+                // the grid has processed the selection change and updated its layout.
                 Dispatcher.UIThread.Post(
-                    () => SubtitleGrid.ScrollIntoView(item, null),
+                    () => SubtitleGrid.ScrollIntoView(indexToScroll),
                     DispatcherPriority.Background);
             }
         }, DispatcherPriority.Background);
@@ -4583,26 +4580,6 @@ public partial class OcrViewModel : ObservableObject
         Title = string.Format(Se.Language.Ocr.OcrX, "DivX");
         _ocrSubtitle = new OcrSubtitleDivX(list, fileName);
         SetOcrSubtitleItems();
-    }
-
-    private double CalculateRowHeight()
-    {
-        var firstItem = OcrSubtitleItems.FirstOrDefault();
-        if (firstItem == null)
-        {
-            return ImageMaxHeight + 10;
-        }
-
-        var bitmap = firstItem.GetSkBitmap();
-        var natW = (double)bitmap.Width;
-        var natH = (double)bitmap.Height;
-        if (natW <= 0 || natH <= 0)
-        {
-            return ImageMaxHeight + 10;
-        }
-
-        var scale = Math.Min(ImageMaxWidth / natW, ImageMaxHeight / natH);
-        return natH * scale + 10;
     }
 
     internal void EngineSelectionChanged(object? sender, SelectionChangedEventArgs e)
@@ -4875,7 +4852,7 @@ public partial class OcrViewModel : ObservableObject
             {
                 SelectedOcrSubtitleItem = OcrSubtitleItems[0];
                 SubtitleGrid.SelectedIndex = 0;
-                SubtitleGrid.ScrollIntoView(SelectedOcrSubtitleItem, null);
+                SubtitleGrid.ScrollIntoView(0);
                 TrackChanged();
             }
         });

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -7,6 +7,7 @@ using Avalonia.Data;
 using Avalonia.Data.Converters;
 using Avalonia.Input;
 using Avalonia.Layout;
+using Avalonia.Media;
 using Avalonia.Styling;
 using Nikse.SubtitleEdit.Features.Ocr.Engines;
 using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
@@ -18,6 +19,8 @@ using Optris.Icons.Avalonia;
 using System;
 using System.Collections;
 using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
 using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
 using MenuItem = Avalonia.Controls.MenuItem;
 using Nikse.SubtitleEdit.UiLogic.Ocr;
@@ -412,6 +415,25 @@ public class OcrWindow : Window
         // replaces: no column sorting (TableView has none), and extended selection
         // (shift/ctrl-click, shift+arrows) is native ListBox behavior instead of
         // DataGridCheckboxMultiSelect.
+        //
+        // TableView has no content-based column sizing either - GridLength.Auto is
+        // treated as 1* by its layout helper - so the narrow columns get pixel widths
+        // measured from their widest content (the VM is initialized before the window
+        // ctor, so the items are available here).
+        const double cellChrome = 16; // cell padding/margins + slack
+        double MeasureWidth(string text) =>
+            new FormattedText(text, CultureInfo.CurrentUICulture, FlowDirection.LeftToRight,
+                Typeface.Default, 14, null).Width;
+        double ColumnWidth(string header, string widestCellText) =>
+            Math.Max(MeasureWidth(header), MeasureWidth(widestCellText)) + cellChrome;
+
+        var lastItem = vm.OcrSubtitleItems.LastOrDefault();
+        var maxDuration = vm.OcrSubtitleItems.Count > 0 ? vm.OcrSubtitleItems.Max(p => p.Duration) : TimeSpan.Zero;
+        var numberWidth = ColumnWidth(Se.Language.General.NumberSymbol, vm.OcrSubtitleItems.Count.ToString());
+        var showWidth = ColumnWidth(Se.Language.General.Show,
+            fullTimeConverter.Convert(lastItem?.StartTime ?? TimeSpan.Zero, typeof(string), null, CultureInfo.CurrentUICulture) as string ?? string.Empty);
+        var durationWidth = ColumnWidth(Se.Language.General.Duration,
+            shortTimeConverter.Convert(maxDuration, typeof(string), null, CultureInfo.CurrentUICulture) as string ?? string.Empty);
         var dataGridSubtitle = new TableView
         {
             SelectionMode = SelectionMode.Multiple,
@@ -429,7 +451,7 @@ public class OcrWindow : Window
             dataGridSubtitle.Columns.Add(new TableViewColumn
             {
                 Header = Se.Language.General.Forced,
-                Width = GridLength.Auto,
+                Width = new GridLength(MeasureWidth(Se.Language.General.Forced) + cellChrome),
                 CellTheme = UiUtil.TableViewNoPaddingCellTheme,
                 HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
                 CellTemplate = new FuncDataTemplate<OcrSubtitleItem>((_, _) =>
@@ -448,7 +470,7 @@ public class OcrWindow : Window
                 new TableViewColumn
                 {
                     Header = Se.Language.General.NumberSymbol,
-                    Width = GridLength.Auto,
+                    Width = new GridLength(numberWidth),
                     CellTheme = UiUtil.TableViewCellTheme,
                     HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
                     Binding = new Binding(nameof(OcrSubtitleItem.Number)),
@@ -456,7 +478,7 @@ public class OcrWindow : Window
                 new TableViewColumn
                 {
                     Header = Se.Language.General.Show,
-                    Width = GridLength.Auto,
+                    Width = new GridLength(showWidth),
                     CellTheme = UiUtil.TableViewCellTheme,
                     HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
                     Binding = new Binding(nameof(OcrSubtitleItem.StartTime)) { Converter = fullTimeConverter },
@@ -464,7 +486,7 @@ public class OcrWindow : Window
                 new TableViewColumn
                 {
                     Header = Se.Language.General.Duration,
-                    Width = GridLength.Auto,
+                    Width = new GridLength(durationWidth),
                     CellTheme = UiUtil.TableViewCellTheme,
                     HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
                     Binding = new Binding(nameof(OcrSubtitleItem.Duration)) { Converter = shortTimeConverter },
@@ -472,7 +494,7 @@ public class OcrWindow : Window
                 new TableViewColumn
                 {
                     Header = Se.Language.General.Image,
-                    Width = GridLength.Auto,
+                    Width = new GridLength(vm.ImageMaxWidth + cellChrome),
                     CellTheme = UiUtil.TableViewNoPaddingCellTheme,
                     HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
                     CellTemplate = new FuncDataTemplate<OcrSubtitleItem>((item, _) =>
@@ -539,6 +561,18 @@ public class OcrWindow : Window
                     })
                 },
         });
+
+        // The image thumbnails scale with Ctrl+plus/minus (Image.MaxWidth/MaxHeight are
+        // bound to the VM) - keep the pixel-sized image column in step with the zoom.
+        var imageColumn = dataGridSubtitle.Columns[dataGridSubtitle.Columns.Count - 2];
+        vm.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName == nameof(vm.ImageMaxWidth))
+            {
+                imageColumn.Width = new GridLength(vm.ImageMaxWidth + cellChrome);
+            }
+        };
+
         UiUtil.ApplyTableViewRowStyle(dataGridSubtitle);
         dataGridSubtitle.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedOcrSubtitleItem)) { Source = vm });
         dataGridSubtitle.KeyDown += vm.SubtitleGridKeyDown;

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -405,61 +405,76 @@ public class OcrWindow : Window
     {
         var fullTimeConverter = new TimeSpanToDisplayFullConverter();
         var shortTimeConverter = new TimeSpanToDisplayShortConverter();
-        var dataGridSubtitle = new DataGrid
+
+        // TableView (Avalonia 12.1) pilot #2, after Show history (#12704): this is SE's
+        // heaviest grid - virtualized template columns with per-row bitmaps - chosen to
+        // judge TableView's scrolling against DataGrid's. Differences vs the DataGrid it
+        // replaces: no column sorting (TableView has none), and extended selection
+        // (shift/ctrl-click, shift+arrows) is native ListBox behavior instead of
+        // DataGridCheckboxMultiSelect.
+        var dataGridSubtitle = new TableView
         {
-            AutoGenerateColumns = false,
-            SelectionMode = DataGridSelectionMode.Extended,
+            SelectionMode = SelectionMode.Multiple,
             CanUserResizeColumns = true,
-            CanUserSortColumns = true,
             HorizontalAlignment = HorizontalAlignment.Stretch,
             VerticalAlignment = VerticalAlignment.Stretch,
             Width = double.NaN,
             Height = double.NaN,
             DataContext = vm,
             ItemsSource = vm.OcrSubtitleItems,
-            Columns =
+        };
+
+        if (vm.HasForcedSubtitles)
+        {
+            dataGridSubtitle.Columns.Add(new TableViewColumn
             {
-                new DataGridTemplateColumn
-                {
-                    Header = Se.Language.General.Forced,
-                    IsReadOnly = true,
-                    IsVisible = vm.HasForcedSubtitles,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    CellTemplate = new FuncDataTemplate<OcrSubtitleItem>((_, _) =>
-                        new CheckBox
-                        {
-                            [!ToggleButton.IsCheckedProperty] = new Binding(nameof(OcrSubtitleItem.IsForced)) { Mode = BindingMode.OneWay },
-                            HorizontalAlignment = HorizontalAlignment.Center,
-                            IsHitTestVisible = false,
-                            Focusable = false,
-                        }),
-                },
-                new DataGridTextColumn
+                Header = Se.Language.General.Forced,
+                Width = GridLength.Auto,
+                CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+                HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+                CellTemplate = new FuncDataTemplate<OcrSubtitleItem>((_, _) =>
+                    new CheckBox
+                    {
+                        [!ToggleButton.IsCheckedProperty] = new Binding(nameof(OcrSubtitleItem.IsForced)) { Mode = BindingMode.OneWay },
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        IsHitTestVisible = false,
+                        Focusable = false,
+                    }),
+            });
+        }
+
+        dataGridSubtitle.Columns.AddRange(new[]
+        {
+                new TableViewColumn
                 {
                     Header = Se.Language.General.NumberSymbol,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Width = GridLength.Auto,
+                    CellTheme = UiUtil.TableViewCellTheme,
+                    HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
                     Binding = new Binding(nameof(OcrSubtitleItem.Number)),
-                    IsReadOnly = true,
                 },
-                new DataGridTextColumn
+                new TableViewColumn
                 {
                     Header = Se.Language.General.Show,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Width = GridLength.Auto,
+                    CellTheme = UiUtil.TableViewCellTheme,
+                    HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
                     Binding = new Binding(nameof(OcrSubtitleItem.StartTime)) { Converter = fullTimeConverter },
-                    IsReadOnly = true,
                 },
-                new DataGridTextColumn
+                new TableViewColumn
                 {
                     Header = Se.Language.General.Duration,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Width = GridLength.Auto,
+                    CellTheme = UiUtil.TableViewCellTheme,
+                    HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
                     Binding = new Binding(nameof(OcrSubtitleItem.Duration)) { Converter = shortTimeConverter },
-                    IsReadOnly = true,
                 },
-                new DataGridTemplateColumn
+                new TableViewColumn
                 {
                     Header = Se.Language.General.Image,
-                    IsReadOnly = true,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Width = GridLength.Auto,
+                    CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+                    HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
                     CellTemplate = new FuncDataTemplate<OcrSubtitleItem>((item, _) =>
                     {
                         var stackPanel = new StackPanel
@@ -497,12 +512,12 @@ public class OcrWindow : Window
                         return stackPanel;
                     })
                 },
-                new DataGridTemplateColumn
+                new TableViewColumn
                 {
                     Header = Se.Language.General.Text,
-                    IsReadOnly = true,
-                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                    Width = new GridLength(1, GridUnitType.Star),
+                    CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+                    HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
                     CellTemplate = new FuncDataTemplate<OcrSubtitleItem>((item, _) =>
                     {
                         var contentPresenter = new ContentPresenter
@@ -523,16 +538,15 @@ public class OcrWindow : Window
                         return contentPresenter;
                     })
                 },
-            },
-        };
-        dataGridSubtitle.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedOcrSubtitleItem)) { Source = vm });
+        });
+        UiUtil.ApplyTableViewRowStyle(dataGridSubtitle);
+        dataGridSubtitle.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedOcrSubtitleItem)) { Source = vm });
         dataGridSubtitle.KeyDown += vm.SubtitleGridKeyDown;
         dataGridSubtitle.DoubleTapped += (s, e) => vm.SubtitleGridDoubleTapped();
         dataGridSubtitle.AddHandler(InputElement.PointerPressedEvent, vm.DataGridSubtitleMacPointerPressed, Avalonia.Interactivity.RoutingStrategies.Tunnel);
         dataGridSubtitle.AddHandler(InputElement.PointerReleasedEvent, vm.DataGridSubtitleMacPointerReleased, Avalonia.Interactivity.RoutingStrategies.Tunnel);
         dataGridSubtitle.SelectionChanged += vm.SubtitleGridSelectionChanged;
         vm.SubtitleGrid = dataGridSubtitle;
-        _ = new DataGridCheckboxMultiSelect<OcrSubtitleItem>(dataGridSubtitle);
 
         // Create a Flyout for the DataGrid
         var flyout = new MenuFlyout();

--- a/src/ui/Logic/UiTheme.cs
+++ b/src/ui/Logic/UiTheme.cs
@@ -734,6 +734,16 @@ public static class UiTheme
                 }
             },
 
+            // TableView header - same brushes as the DataGrid header above
+            new Style(x => x.OfType<TableViewColumnHeader>())
+            {
+                Setters =
+                {
+                    new Setter(TableViewColumnHeader.BackgroundProperty, new SolidColorBrush(bgColorHeader)),
+                    new Setter(TableViewColumnHeader.ForegroundProperty, new SolidColorBrush(foreColor))
+                }
+            },
+
             // ButtonSpinner
             new Style(x => x.OfType<ButtonSpinner>())
             {
@@ -854,6 +864,15 @@ public static class UiTheme
                 }
             },
 
+            // TableView header - same brush as the DataGrid header above
+            new Style(x => x.OfType<TableViewColumnHeader>())
+            {
+                Setters =
+                {
+                    new Setter(TableViewColumnHeader.BackgroundProperty, new SolidColorBrush(headerColor))
+                }
+            },
+
             // ButtonSpinner - slightly off-white for consistency (used by TimeCodeUpDown and SecondsUpDown)
             new Style(x => x.OfType<ButtonSpinner>())
             {
@@ -966,6 +985,15 @@ public static class UiTheme
                 Setters =
                 {
                     new Setter(DataGridColumnHeader.BackgroundProperty, new SolidColorBrush(lightPurple))
+                }
+            },
+
+            // TableView header - same brush as the DataGrid header above
+            new Style(x => x.OfType<TableViewColumnHeader>())
+            {
+                Setters =
+                {
+                    new Setter(TableViewColumnHeader.BackgroundProperty, new SolidColorBrush(lightPurple))
                 }
             },
 

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -97,7 +97,10 @@ public static class UiUtil
         {
             Setters =
             {
-                new Setter(TableViewColumnHeader.BackgroundProperty, Brushes.Transparent),
+                // Match the DataGrid header background: the Fluent DataGrid resource by
+                // default; SE's custom themes (lighter dark, classic gray, pastel) override
+                // both header types with the same brush via app styles in UiTheme.
+                new Setter(TableViewColumnHeader.BackgroundProperty, GetDataGridHeaderBackgroundBrush()),
                 new Setter(TableViewColumnHeader.PaddingProperty, new Thickness(4, 2, 4, 4)),
                 new Setter(TableViewColumnHeader.BorderBrushProperty, GetBorderBrush()),
                 // Both header lines always show, independently of the grid-lines setting: the
@@ -108,6 +111,19 @@ public static class UiUtil
                 new Setter(TableViewColumnHeader.TemplateProperty, TableViewColumnHeaderTemplate),
             }
         };
+    }
+
+    private static IBrush GetDataGridHeaderBackgroundBrush()
+    {
+        if (Application.Current != null &&
+            Application.Current.TryGetResource("DataGridColumnHeaderBackgroundBrush",
+                Application.Current.ActualThemeVariant, out var resource) &&
+            resource is IBrush brush)
+        {
+            return brush;
+        }
+
+        return Brushes.Transparent;
     }
 
     // Mirrors the built-in header template (content + resize thumb) but routes the border

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -93,10 +93,6 @@ public static class UiUtil
 
     private static ControlTheme GetTableViewColumnHeaderTheme()
     {
-        var showVertical =
-            Se.Settings.Appearance.GridLinesAppearance == nameof(DataGridGridLinesVisibility.Vertical) ||
-            Se.Settings.Appearance.GridLinesAppearance == nameof(DataGridGridLinesVisibility.All);
-
         return new ControlTheme(typeof(TableViewColumnHeader))
         {
             Setters =
@@ -104,9 +100,11 @@ public static class UiUtil
                 new Setter(TableViewColumnHeader.BackgroundProperty, Brushes.Transparent),
                 new Setter(TableViewColumnHeader.PaddingProperty, new Thickness(4, 2, 4, 4)),
                 new Setter(TableViewColumnHeader.BorderBrushProperty, GetBorderBrush()),
-                // The bottom line always shows: it separates the header from the first row the way
-                // DataGrid's header does, independently of the horizontal grid-line setting.
-                new Setter(TableViewColumnHeader.BorderThicknessProperty, new Thickness(0, 0, showVertical ? 1 : 0, 1)),
+                // Both header lines always show, independently of the grid-lines setting: the
+                // bottom line separates the header from the first row and the right line
+                // separates the column headers from each other, the way DataGrid's header
+                // (with its always-on separators) does.
+                new Setter(TableViewColumnHeader.BorderThicknessProperty, new Thickness(0, 0, 1, 1)),
                 new Setter(TableViewColumnHeader.TemplateProperty, TableViewColumnHeaderTemplate),
             }
         };

--- a/tests/UI/Features/Ocr/OcrTableViewTests.cs
+++ b/tests/UI/Features/Ocr/OcrTableViewTests.cs
@@ -89,8 +89,16 @@ public class OcrTableViewTests
         Assert.Equal(5, tableView.Columns!.Count);
         Assert.Equal(3, tableView.ItemsSource!.Cast<object>().Count());
 
-        // The star-sized Text column fills the remaining width like the DataGrid version did.
+        // TableView has no content-based sizing (Auto acts as 1*), so the narrow columns
+        // are pixel-sized from their widest content and only Text is star-sized.
+        Assert.All(tableView.Columns.Take(4), c => Assert.True(c.Width.IsAbsolute && c.Width.Value > 0));
         Assert.True(tableView.Columns[^1].Width.IsStar);
+
+        // The image column tracks the Ctrl+plus/minus zoom via ImageMaxWidth.
+        var imageWidthBefore = tableView.Columns[3].Width.Value;
+        vm.ImageMaxWidth *= 1.1;
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(tableView.Columns[3].Width.Value > imageWidthBefore);
 
         window.Close();
     }

--- a/tests/UI/Features/Ocr/OcrTableViewTests.cs
+++ b/tests/UI/Features/Ocr/OcrTableViewTests.cs
@@ -1,0 +1,183 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Features.Ocr;
+using Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
+using SkiaSharp;
+
+namespace UITests.Features.Ocr;
+
+/// <summary>
+/// TableView pilot #2 (after Show history, #12704): the OCR subtitle grid is SE's heaviest -
+/// virtualized template columns with a bitmap per row. Asserts the behaviour the DataGrid it
+/// replaced provided: columns declared, rows realized and virtualized, cell templates
+/// resolving images, and selection round-tripping to the view model.
+/// </summary>
+public class OcrTableViewTests
+{
+    private sealed class FakeOcrSubtitle : IOcrSubtitle
+    {
+        public int Count { get; init; }
+
+        public SKBitmap GetBitmap(int index)
+        {
+            var bitmap = new SKBitmap(120, 40);
+            using var canvas = new SKCanvas(bitmap);
+            canvas.Clear(SKColors.White);
+            return bitmap;
+        }
+
+        public TimeSpan GetStartTime(int index) => TimeSpan.FromSeconds(index * 4);
+        public TimeSpan GetEndTime(int index) => TimeSpan.FromSeconds(index * 4 + 2);
+
+        public List<OcrSubtitleItem> MakeOcrSubtitleItems()
+        {
+            var items = new List<OcrSubtitleItem>(Count);
+            for (var i = 0; i < Count; i++)
+            {
+                items.Add(new OcrSubtitleItem(this, i));
+            }
+
+            return items;
+        }
+
+        public bool GetIsForced(int index) => false;
+        public SKPointI GetPosition(int index) => new(0, 0);
+        public SKSizeI GetScreenSize(int index) => new(1920, 1080);
+    }
+
+    private static OcrViewModel MakeViewModel(int itemCount)
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        var provider = services.BuildServiceProvider();
+        var vm = provider.GetRequiredService<OcrViewModel>();
+
+        var source = new FakeOcrSubtitle { Count = itemCount };
+        foreach (var item in source.MakeOcrSubtitleItems())
+        {
+            item.Text = $"Line {item.Number}";
+            vm.OcrSubtitleItems.Add(item);
+        }
+
+        return vm;
+    }
+
+    private static TableView GetTableView(Window window) =>
+        window.GetVisualDescendants().OfType<TableView>().Single();
+
+    private static OcrWindow ShowWindow(OcrViewModel vm)
+    {
+        var window = new OcrWindow(vm);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        return window;
+    }
+
+    [AvaloniaFact]
+    public void OcrWindow_TableViewDeclaresColumnsAndBindsItems()
+    {
+        var vm = MakeViewModel(3);
+        var window = ShowWindow(vm);
+        var tableView = GetTableView(window);
+
+        // No forced subtitles in the fake source, so the Forced column is not added.
+        Assert.Equal(5, tableView.Columns!.Count);
+        Assert.Equal(3, tableView.ItemsSource!.Cast<object>().Count());
+
+        // The star-sized Text column fills the remaining width like the DataGrid version did.
+        Assert.True(tableView.Columns[^1].Width.IsStar);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void OcrWindow_RowsRealizeWithImageAndText()
+    {
+        var vm = MakeViewModel(3);
+        var window = ShowWindow(vm);
+        var tableView = GetTableView(window);
+
+        var firstRow = tableView.GetVisualDescendants().OfType<TableViewRow>().First();
+        var cells = firstRow.GetVisualDescendants().OfType<TableViewCell>().ToList();
+        Assert.Equal(5, cells.Count);
+
+        // Text cells resolve through TableViewColumn.Binding.
+        var texts = firstRow.GetVisualDescendants().OfType<TextBlock>().Select(t => t.Text).ToList();
+        Assert.Contains("1", texts); // number column
+        Assert.Contains("Line 1", texts); // text column template
+
+        // The image cell template produced an Image with the fake bitmap.
+        Assert.Contains(firstRow.GetVisualDescendants().OfType<Image>(), i => i.Source != null);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void OcrWindow_SelectionRoundTripsToViewModel()
+    {
+        var vm = MakeViewModel(5);
+        var window = ShowWindow(vm);
+        var tableView = GetTableView(window);
+
+        tableView.SelectedIndex = 2;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Same(vm.OcrSubtitleItems[2], vm.SelectedOcrSubtitleItem);
+
+        vm.SelectedOcrSubtitleItem = vm.OcrSubtitleItems[4];
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(4, tableView.SelectedIndex);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void OcrWindow_VirtualizesLargeItemSources()
+    {
+        var vm = MakeViewModel(2000);
+        var window = ShowWindow(vm);
+        var tableView = GetTableView(window);
+
+        var realized = tableView.GetVisualDescendants().OfType<TableViewRow>().Count();
+        Assert.True(realized < 100, $"Expected only visible rows to be realized, got {realized}");
+
+        // Scrolling to the far end realizes rows there instead of the top.
+        tableView.ScrollIntoView(1999);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var lastRowTexts = tableView.GetVisualDescendants().OfType<TableViewRow>()
+            .SelectMany(r => r.GetVisualDescendants().OfType<TextBlock>())
+            .Select(t => t.Text)
+            .ToList();
+        Assert.Contains("Line 2000", lastRowTexts);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void OcrWindow_MultiSelectAddsToSelectedItems()
+    {
+        var vm = MakeViewModel(10);
+        var window = ShowWindow(vm);
+        var tableView = GetTableView(window);
+
+        // Extended selection is native ListBox behavior now (DataGridCheckboxMultiSelect
+        // was DataGrid-specific); the VM reads SubtitleGrid.SelectedItems for bulk actions.
+        tableView.SelectedItems!.Clear();
+        tableView.SelectedItems.Add(vm.OcrSubtitleItems[1]);
+        tableView.SelectedItems.Add(vm.OcrSubtitleItems[2]);
+        tableView.SelectedItems.Add(vm.OcrSubtitleItems[3]);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(3, vm.SubtitleGrid.SelectedItems!.Count);
+
+        window.Close();
+    }
+}


### PR DESCRIPTION
Second `TableView` pilot after #12704 (Show history), this time on the opposite end of the spectrum: the OCR subtitle grid is SE's heaviest — virtualized template columns with a per-row bitmap — and the one where DataGrid scrolling feels worst. The point of this branch is to compare scrolling behaviour by eye.

**What changed**
- `DataGrid` → `TableView` in `OcrWindow.MakeSubtitleView`. Template columns (Forced checkbox, image thumbnail, formatted text) carry over via `TableViewColumn.CellTemplate` — with a template set, the cell's content is the row item, so the existing `FuncDataTemplate<OcrSubtitleItem>`s work unchanged. Text columns (#, Show, Duration) use `TableViewColumn.Binding` with the same converters.
- The Forced column is added conditionally (`TableViewColumn` has no `IsVisible`), matching the old static `IsVisible = vm.HasForcedSubtitles`.
- `OcrViewModel.SubtitleGrid` is now typed `TableView`. `SelectedItems`/`SelectedIndex`/`Focus` are inherited from ListBox and unchanged; `ScrollIntoView(item, null)` became `ScrollIntoView(index)`.
- **Ctrl+plus/minus image zoom got simpler:** TableView rows auto-size to content, so changing the bound `ImageMaxHeight`/`ImageMaxWidth` re-measures rows directly — the `CalculateRowHeight()` → `RowHeight` dance is gone.
- `DataGridCheckboxMultiSelect` is dropped: extended selection (shift/ctrl-click, cmd-click on macOS, shift+arrows) is native ListBox behaviour with `SelectionMode.Multiple`. The Mac ctrl+click context-menu handlers, the flyout, and all VM event handlers carry over unchanged.
- Cell/header themes use the #12704 helpers, so grid lines honour the "Show grid lines" setting.

**Known losses to judge**
- **Column sorting is gone** — TableView has none (the DataGrid had `CanUserSortColumns = true`).
- Row heights are now per-row content heights rather than one uniform `RowHeight`, which is exactly the variable-height virtualization scenario worth stress-testing with scrolling.

**Verified headlessly** (5 new tests): columns declared and bound; rows realize with the image and text cell templates resolving (fake `IOcrSubtitle` with real SKBitmaps); selection round-trips both ways between grid and VM; a 2000-item source stays virtualized and `ScrollIntoView(1999)` realizes the far end; multi-select surfaces in `SelectedItems`. All 165 OCR UI tests pass.

**To judge by eye:** open a Blu-ray sup / VobSub, scroll with wheel, scrollbar drag, and keyboard; try Ctrl+plus/minus image zoom mid-list; check the OCR run auto-follow (SelectAndScrollToRow) tracks smoothly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)