### PR TITLE
Download 64-bit libVLC on Windows x64

### DIFF
--- a/src/ui/Logic/Download/LibVlcDownloadService.cs
+++ b/src/ui/Logic/Download/LibVlcDownloadService.cs
@@ -16,7 +16,8 @@ public interface ILibVlcDownloadService
 
 public class LibVlcDownloadService(HttpClient httpClient) : ILibVlcDownloadService
 {
-    private const string WindowsUrl = "https://get.videolan.org/vlc/3.0.23/win32/vlc-3.0.23-win32.7z";
+    private const string WindowsX64Url = "https://get.videolan.org/vlc/3.0.23/win64/vlc-3.0.23-win64.7z";
+    private const string WindowsX86Url = "https://get.videolan.org/vlc/3.0.23/win32/vlc-3.0.23-win32.7z";
     private const string MacX64Url = "https://github.com/SubtitleEdit/support-files/releases/download/vlc3/libvlc-osx64.7z";
 
     public async Task DownloadLibVlc(string destinationFileName, IProgress<float>? progress, CancellationToken cancellationToken)
@@ -33,7 +34,15 @@ public class LibVlcDownloadService(HttpClient httpClient) : ILibVlcDownloadServi
     {
         if (OperatingSystem.IsWindows())
         {
-            return WindowsUrl;
+            switch (RuntimeInformation.ProcessArchitecture)
+            {
+                case Architecture.X64:
+                    return WindowsX64Url;
+                case Architecture.X86:
+                    return WindowsX86Url;
+                default:
+                    throw new PlatformNotSupportedException("Unsupported Windows architecture.");
+            }
         }
 
         if (OperatingSystem.IsMacOS())


### PR DESCRIPTION
## Summary

The in-app VLC downloader (`LibVlcDownloadService`) hardcoded the **win32** URL for all Windows users. Subtitle Edit ships as x64, and a 64-bit process cannot load a 32-bit `libvlc.dll`, so `LibVlcDynamicPlayer.LoadLibraryInternal` failed on the freshly downloaded files and SE kept prompting that a download was required — exactly the report in #12001 (files present in the VLC folder, still "not recognized"). The reporter later worked around it by manually installing win64 VLC.

## Change

- Select the VLC 3.0.23 archive by `RuntimeInformation.ProcessArchitecture`: win64 for x64, win32 for x86, `PlatformNotSupportedException` otherwise (VideoLAN publishes no Windows arm64 build of VLC 3) — same pattern as `FfmpegDownloadService`.
- Both archives share the same top-level `vlc-3.0.23` folder name, so the extraction in `DownloadLibVlcViewModel` needs no change; a re-download overwrites a previously downloaded win32 copy in place.

Verified the win64 URL resolves (HTTP 200, ~38 MB).

Fixes #12001

🤖 Generated with [Claude Code](https://claude.com/claude-code)