### PR TITLE
Add advanced local-LLM auto-translate engines (llama.cpp + Ollama) with batch context and schema-forced output

### DIFF
--- a/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
+++ b/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
@@ -239,6 +239,7 @@ public static class LlamaCppServerManager
     private static Process? _serverProcess;
     private static int _serverPort;
     private static string? _serverModelPath;
+    private static int _serverContextSize;
     private static bool _processExitHooked;
     private static readonly StringBuilder _serverLog = new();
 
@@ -450,10 +451,12 @@ public static class LlamaCppServerManager
     /// Starts (or reuses) a llama-server for the given model and points
     /// <see cref="Core.Settings.ToolsSettings.LlamaCppApiUrl"/> at it. Throws on failure.
     /// </summary>
-    public static async Task EnsureServerRunningAsync(LlamaCppModel model, CancellationToken cancellationToken)
+    public const int DefaultContextSize = 8192;
+
+    public static async Task EnsureServerRunningAsync(LlamaCppModel model, CancellationToken cancellationToken, int contextSize = DefaultContextSize)
     {
         var modelPath = GetModelPath(model.FileName);
-        if (IsServerRunning && _serverModelPath == modelPath)
+        if (IsServerRunning && _serverModelPath == modelPath && _serverContextSize == contextSize)
         {
             Configuration.Settings.Tools.LlamaCppApiUrl = ApiUrl;
             return;
@@ -462,7 +465,7 @@ public static class LlamaCppServerManager
         await ServerLock.WaitAsync(cancellationToken);
         try
         {
-            if (IsServerRunning && _serverModelPath == modelPath)
+            if (IsServerRunning && _serverModelPath == modelPath && _serverContextSize == contextSize)
             {
                 Configuration.Settings.Tools.LlamaCppApiUrl = ApiUrl;
                 return;
@@ -520,7 +523,25 @@ public static class LlamaCppServerManager
             psi.ArgumentList.Add("-ngl");
             psi.ArgumentList.Add("99");
             psi.ArgumentList.Add("-c");
-            psi.ArgumentList.Add("8192");
+            psi.ArgumentList.Add(contextSize.ToString(CultureInfo.InvariantCulture));
+            // SE is the server's only client, but llama-server defaults to 4 parallel slots,
+            // which silently splits -c four ways (8192 became 2048 usable tokens per request).
+            psi.ArgumentList.Add("-np");
+            psi.ArgumentList.Add("1");
+            // Keep the full KV cache for sliding-window-attention models (Gemma, Qwen 3.5);
+            // without this their prompt cache only works on byte-identical requests and
+            // cache_prompt reuse is lost entirely. Costs some KV memory at these context sizes.
+            psi.ArgumentList.Add("--swa-full");
+            if (mmprojPath == null)
+            {
+                // Chunk-level KV-cache reuse after the first diverging token; together with the
+                // clients' cache_prompt this keeps repeated prompt prefixes (system prompt,
+                // rolling context) from being re-ingested every request. Auto-disables with a
+                // warning on models whose context cannot shift. Not combined with multimodal -
+                // vision chunks cannot be shifted.
+                psi.ArgumentList.Add("--cache-reuse");
+                psi.ArgumentList.Add("256");
+            }
             if (model.NoJinja)
             {
                 psi.ArgumentList.Add("--no-jinja");
@@ -561,6 +582,7 @@ public static class LlamaCppServerManager
             _serverProcess = process;
             _serverPort = port;
             _serverModelPath = modelPath;
+            _serverContextSize = contextSize;
             HookProcessExitOnce();
 
             var deadline = DateTime.UtcNow.AddMinutes(5);

--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -435,6 +435,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<NOcrSettingsViewModel>();
         collection.AddTransient<LlamaCppOcrSettingsViewModel>();
         collection.AddTransient<LlamaCppEngineSettingsViewModel>();
+        collection.AddTransient<Features.Translate.LlamaCppAdvanced.LlamaCppAdvancedSettingsViewModel>();
         collection.AddTransient<OcrViewModel>();
         collection.AddTransient<OmniVoiceSettingsViewModel>();
         collection.AddTransient<Qwen3TtsSettingsViewModel>();

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -154,6 +154,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             new OpenAiCompatibleTranslate(),
             new LmStudioTranslate(),
             new OllamaTranslate(),
+            new OllamaAdvancedTranslate(),
             new LlamaCppTranslate(),
             new LlamaCppAdvancedTranslate(),
             new AnthropicTranslate(),
@@ -398,6 +399,12 @@ public partial class AutoTranslateViewModel : ObservableObject
             Configuration.Settings.Tools.OllamaModel = apiModel.Trim();
             Se.Settings.AutoTranslate.OllamaUrl = apiUrl.Trim();
             Se.Settings.AutoTranslate.OllamaModel = apiModel.Trim();
+        }
+
+        if (engineType == typeof(OllamaAdvancedTranslate))
+        {
+            Se.Settings.AutoTranslate.OllamaAdvancedUrl = apiUrl.Trim();
+            Se.Settings.AutoTranslate.OllamaAdvancedModel = apiModel.Trim();
         }
 
         if (engineType == typeof(AnthropicTranslate))
@@ -1407,7 +1414,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             // schema-forced JSON reply and rolling context, so MergeAndSplitHelper's merge/split
             // heuristics are not needed (and would break the line alignment the schema guarantees).
             // "Translate current line" still goes through the regular single-line path below.
-            if (translator is LlamaCppAdvancedTranslate advancedTranslator && !_onlyCurrentLine)
+            if (translator is AdvancedTranslatorBase advancedTranslator && !_onlyCurrentLine)
             {
                 while (index < Rows.Count)
                 {
@@ -1636,6 +1643,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             OllamaTranslate => settings.OllamaApiUrl,
             LlamaCppTranslate => settings.LlamaCppApiUrl,
             LlamaCppAdvancedTranslate => settings.LlamaCppApiUrl,
+            OllamaAdvancedTranslate => Se.Settings.AutoTranslate.OllamaAdvancedUrl,
             AnthropicTranslate => settings.AnthropicApiUrl,
             GroqTranslate => settings.GroqUrl,
             OpenRouterTranslate => settings.OpenRouterUrl,
@@ -2009,6 +2017,30 @@ public partial class AutoTranslateViewModel : ObservableObject
             ModelIsVisible = true;
             ButtonModelIsVisible = true;
             ModelText = Se.Settings.AutoTranslate.OllamaModel;
+
+            return;
+        }
+
+        if (engineType == typeof(OllamaAdvancedTranslate))
+        {
+            ModelBrowseIsVisible = true;
+            LlamaCppAdvancedButtonIsVisible = true;
+
+            if (string.IsNullOrEmpty(Se.Settings.AutoTranslate.OllamaAdvancedUrl))
+            {
+                Se.Settings.AutoTranslate.OllamaAdvancedUrl = "http://localhost:11434/v1/chat/completions";
+            }
+
+            FillUrls(new List<string>
+            {
+                Se.Settings.AutoTranslate.OllamaAdvancedUrl.TrimEnd('/'),
+            });
+
+            // Same installed-model list as the classic Ollama engine - only the endpoint differs.
+            _apiModels = Se.Settings.AutoTranslate.OllamaModels.Split(',').ToList();
+            ModelIsVisible = true;
+            ButtonModelIsVisible = true;
+            ModelText = Se.Settings.AutoTranslate.OllamaAdvancedModel;
 
             return;
         }

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -11,6 +11,7 @@ using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.UiLogic.Translate;
 using Nikse.SubtitleEdit.Features.Ocr;
 using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Translate.LlamaCppAdvanced;
 using Nikse.SubtitleEdit.Features.Translate.LlamaCppEngineSettings;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
@@ -101,6 +102,7 @@ public partial class AutoTranslateViewModel : ObservableObject
     [ObservableProperty] private DeepLFormalityItem? _selectedFormality;
     [ObservableProperty] private bool _formalityIsVisible;
     [ObservableProperty] private bool _llamaCppButtonsAreVisible;
+    [ObservableProperty] private bool _llamaCppAdvancedButtonIsVisible;
     [ObservableProperty] private bool _llamaCppRemoteToggleIsVisible;
     [ObservableProperty] private bool _llamaCppUseRemoteServer;
     [ObservableProperty] private string _llamaCppServerButtonText = "Start server";
@@ -153,6 +155,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             new LmStudioTranslate(),
             new OllamaTranslate(),
             new LlamaCppTranslate(),
+            new LlamaCppAdvancedTranslate(),
             new AnthropicTranslate(),
             new GroqTranslate(),
             new OpenRouterTranslate(),
@@ -365,7 +368,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             Configuration.Settings.Tools.LmStudioModel = apiModel.Trim();
         }
 
-        if (engineType == typeof(LlamaCppTranslate))
+        if (engineType == typeof(LlamaCppTranslate) || engineType == typeof(LlamaCppAdvancedTranslate))
         {
             Se.Settings.AutoTranslate.LlamaCppUseRemoteServer = LlamaCppUseRemoteServer;
             if (LlamaCppUseRemoteServer)
@@ -829,7 +832,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         {
             await UpdateCrispAsrEngineAsync();
         }
-        else if (SelectedAutoTranslator is LlamaCppTranslate && GetLlamaCppEngineUpdate() is var (key, _))
+        else if (SelectedAutoTranslator is LlamaCppTranslate or LlamaCppAdvancedTranslate && GetLlamaCppEngineUpdate() is var (key, _))
         {
             await UpdateLlamaCppEngineAsync(key);
         }
@@ -857,6 +860,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         {
             CrispAsrMadladTranslate => CrispAsrTranslateDownloadHelper.IsEngineUpdateAvailable(),
             LlamaCppTranslate => GetLlamaCppEngineUpdate() != null,
+            LlamaCppAdvancedTranslate => GetLlamaCppEngineUpdate() != null,
             _ => false,
         };
     }
@@ -994,6 +998,23 @@ public partial class AutoTranslateViewModel : ObservableObject
         RefreshEngineUpdateButton();
     }
 
+    /// <summary>
+    /// Opens the advanced engine's batch/context/sampling settings dialog (the sub-window of the
+    /// "llama.cpp advanced" engine).
+    /// </summary>
+    [RelayCommand]
+    private async Task ShowLlamaCppAdvancedSettings()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        await _windowService.ShowDialogAsync<LlamaCppAdvancedSettingsWindow, LlamaCppAdvancedSettingsViewModel>(
+            Window,
+            vm => vm.Initialize());
+    }
+
     [RelayCommand]
     private async Task OpenLlamaCppModelsFolder()
     {
@@ -1054,7 +1075,12 @@ public partial class AutoTranslateViewModel : ObservableObject
 
         try
         {
-            await LlamaCppServerManager.EnsureServerRunningAsync(model, _cancellationTokenSource.Token);
+            // The advanced engine stuffs history/synopsis/glossary into every request, so it gets
+            // a user-configurable (default larger) server context; everything else keeps the default.
+            var contextSize = SelectedAutoTranslator is LlamaCppAdvancedTranslate
+                ? Math.Clamp(Se.Settings.AutoTranslate.LlamaCppAdvanced.ContextSize, 2048, 262144)
+                : LlamaCppServerManager.DefaultContextSize;
+            await LlamaCppServerManager.EnsureServerRunningAsync(model, _cancellationTokenSource.Token, contextSize);
         }
         catch (Exception ex)
         {
@@ -1286,7 +1312,7 @@ public partial class AutoTranslateViewModel : ObservableObject
 
         _cancellationTokenSource = new CancellationTokenSource();
 
-        if (engineType == typeof(LlamaCppTranslate))
+        if (engineType == typeof(LlamaCppTranslate) || engineType == typeof(LlamaCppAdvancedTranslate))
         {
             if (Se.Settings.AutoTranslate.LlamaCppUseRemoteServer)
             {
@@ -1376,6 +1402,38 @@ public partial class AutoTranslateViewModel : ObservableObject
                                       _onlyCurrentLine;
 
             var index = start;
+
+            // The advanced llama.cpp engine runs its own batch loop: numbered batches with a
+            // schema-forced JSON reply and rolling context, so MergeAndSplitHelper's merge/split
+            // heuristics are not needed (and would break the line alignment the schema guarantees).
+            // "Translate current line" still goes through the regular single-line path below.
+            if (translator is LlamaCppAdvancedTranslate advancedTranslator && !_onlyCurrentLine)
+            {
+                while (index < Rows.Count)
+                {
+                    if (_abort || cancellationToken.IsCancellationRequested)
+                    {
+                        Dispatcher.UIThread.Invoke(() => IsTranslateEnabled = true);
+                        break;
+                    }
+
+                    var translatedCount = await advancedTranslator.TranslateBatchAsync(Rows, index, sourceLanguage.Code, targetLanguage.Code, cancellationToken);
+                    index += translatedCount;
+                    _translationProgressIndex = index;
+
+                    var advancedProgressIndex = index;
+                    Dispatcher.UIThread.Invoke(() =>
+                    {
+                        ProgressValue = (double)advancedProgressIndex * 100 / Rows.Count;
+                        ProgressText = $"{(int)ProgressValue} %";
+                        HasTranslatedSomething = true;
+                        SelectAndScrollToRow(advancedProgressIndex - 1);
+                    });
+                }
+
+                return; // the finally block below reports completion
+            }
+
             var linesTranslated = 0;
             var errorCount = 0;
             var noErrorCount = 0;
@@ -1577,6 +1635,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             LmStudioTranslate => settings.LmStudioApiUrl,
             OllamaTranslate => settings.OllamaApiUrl,
             LlamaCppTranslate => settings.LlamaCppApiUrl,
+            LlamaCppAdvancedTranslate => settings.LlamaCppApiUrl,
             AnthropicTranslate => settings.AnthropicApiUrl,
             GroqTranslate => settings.GroqUrl,
             OpenRouterTranslate => settings.OpenRouterUrl,
@@ -1678,6 +1737,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         SelectedCrispAsrModel = null;
         LlamaCppModelComboIsVisible = false;
         LlamaCppButtonsAreVisible = false;
+        LlamaCppAdvancedButtonIsVisible = false;
         LlamaCppRemoteToggleIsVisible = false;
         LlamaCppModels.Clear();
         SelectedLlamaCppModel = null;
@@ -1886,11 +1946,15 @@ public partial class AutoTranslateViewModel : ObservableObject
             return;
         }
 
-        if (engineType == typeof(LlamaCppTranslate))
+        if (engineType == typeof(LlamaCppTranslate) || engineType == typeof(LlamaCppAdvancedTranslate))
         {
             // The remote toggle is always available for llama.cpp; its current value decides
             // whether we show the local model/server controls or a plain API URL field (#11584).
             LlamaCppRemoteToggleIsVisible = true;
+
+            // Batch/context/sampling options only exist on the advanced engine; they apply to
+            // local and remote servers alike.
+            LlamaCppAdvancedButtonIsVisible = engineType == typeof(LlamaCppAdvancedTranslate);
             _suppressLlamaCppRemoteToggle = true;
             LlamaCppUseRemoteServer = Se.Settings.AutoTranslate.LlamaCppUseRemoteServer;
             _suppressLlamaCppRemoteToggle = false;
@@ -2126,7 +2190,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         Se.Settings.AutoTranslate.LlamaCppUseRemoteServer = value;
 
         // Swap the llama.cpp panel between the local model/server controls and the remote URL field.
-        if (SelectedAutoTranslator is LlamaCppTranslate)
+        if (SelectedAutoTranslator is LlamaCppTranslate or LlamaCppAdvancedTranslate)
         {
             SetAutoTranslatorEngine(SelectedAutoTranslator);
         }

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -7,6 +7,7 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
+using Nikse.SubtitleEdit.Features.Translate.LlamaCppAdvanced;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Logic;
@@ -221,6 +222,7 @@ public class AutoTranslateWindow : Window
         switch (translator)
         {
             case LlamaCppTranslate:
+            case LlamaCppAdvancedTranslate:
                 return StatusDots.From(
                     LlamaCppServerManager.IsEngineInstalled(),
                     LlamaCppUpdateStatus.GetEngineUpdateStatus());
@@ -302,6 +304,15 @@ public class AutoTranslateWindow : Window
         ToolTip.SetTip(buttonLlamaCppEngineSettings, Se.Language.General.LlamaCppEngineSettings);
         buttonLlamaCppEngineSettings.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.LlamaCppButtonsAreVisible)));
 
+        var buttonLlamaCppAdvancedSettings = UiUtil.MakeButton(Se.Language.Translate.AdvancedDotDotDot, vm.ShowLlamaCppAdvancedSettingsCommand)
+            .WithMarginLeft(5)
+            .WithAccessibleName(Se.Language.Translate.AdvancedSettings);
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            ToolTip.SetTip(buttonLlamaCppAdvancedSettings, Se.Language.Translate.AdvancedSettings);
+        }
+        buttonLlamaCppAdvancedSettings.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.LlamaCppAdvancedButtonIsVisible)));
+
         var settingsPanel = new WrapPanel
         {
             Orientation = Orientation.Horizontal,
@@ -350,6 +361,7 @@ public class AutoTranslateWindow : Window
         settingsPanel.Children.Add(buttonLlamaCppServer);
         settingsPanel.Children.Add(buttonLlamaCppOpenFolder);
         settingsPanel.Children.Add(buttonLlamaCppEngineSettings);
+        settingsPanel.Children.Add(buttonLlamaCppAdvancedSettings);
 
         var settingsButton = UiUtil.MakeButton(vm.OpenSettingsCommand, IconNames.Settings, Se.Language.General.Settings);
         settingsButton.HorizontalAlignment = HorizontalAlignment.Right;

--- a/src/ui/Features/Translate/LlamaCppAdvanced/AdvancedTranslatorBase.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/AdvancedTranslatorBase.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
+using Nikse.SubtitleEdit.UiLogic.Translate;
+
+namespace Nikse.SubtitleEdit.Features.Translate.LlamaCppAdvanced;
+
+/// <summary>
+/// Shared batch/context translation loop of the "advanced" local-LLM engines: sends numbered
+/// batches with a rolling history of already-translated lines plus user-configured
+/// synopsis/glossary/style, and requires a schema-constrained JSON reply so line alignment is
+/// guaranteed. The Auto-translate loop calls <see cref="TranslateBatchAsync"/> directly; the
+/// plain <see cref="Translate"/> path (used for "translate current line") is a context-free
+/// batch of one. Subclasses only supply the endpoint and, where the server needs one, the
+/// model name.
+/// </summary>
+public abstract class AdvancedTranslatorBase : IAutoTranslator, IDisposable
+{
+    private LlamaCppAdvancedClient? _client;
+
+    public abstract string Name { get; }
+    public abstract string Url { get; }
+    public string Error { get; set; } = string.Empty;
+    public int MaxCharacters => 1000;
+
+    /// <summary>The chat-completions endpoint to call (read per request, after any server startup).</summary>
+    protected abstract string GetApiUrl();
+
+    /// <summary>The "model" request field; null for single-model servers like llama-server.</summary>
+    protected virtual string? GetModel() => null;
+
+    public void Initialize()
+    {
+        _client?.Dispose();
+        _client = new LlamaCppAdvancedClient();
+    }
+
+    public List<TranslationPair> GetSupportedSourceLanguages()
+    {
+        return ChatGptTranslate.ListLanguages();
+    }
+
+    public List<TranslationPair> GetSupportedTargetLanguages()
+    {
+        return ChatGptTranslate.ListLanguages();
+    }
+
+    public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+    {
+        var lines = new List<LlamaCppAdvancedProtocol.BatchLine> { new(1, text.Trim()) };
+        var map = await TranslateLinesAsync(lines, new List<LlamaCppAdvancedProtocol.HistoryPair>(), sourceLanguageCode, targetLanguageCode, cancellationToken);
+        return map.TryGetValue(1, out var translation) ? translation : string.Empty;
+    }
+
+    /// <summary>
+    /// Translates the next batch starting at <paramref name="index"/>, writing results into the
+    /// rows, and returns the number of rows translated (always at least 1, or throws). On an
+    /// invalid reply the batch is retried once, then halved - a model that cannot manage a full
+    /// batch often still manages a smaller one.
+    /// </summary>
+    public async Task<int> TranslateBatchAsync(ObservableCollection<TranslateRow> rows, int index, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+    {
+        var settings = Se.Settings.AutoTranslate.LlamaCppAdvanced;
+        var batchSize = Math.Clamp(settings.BatchSize, 1, 50);
+        var count = Math.Min(batchSize, rows.Count - index);
+        return await TranslateChunkAsync(rows, index, count, sourceLanguageCode, targetLanguageCode, cancellationToken);
+    }
+
+    private async Task<int> TranslateChunkAsync(ObservableCollection<TranslateRow> rows, int index, int count, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+    {
+        var lines = new List<LlamaCppAdvancedProtocol.BatchLine>(count);
+        for (var i = 0; i < count; i++)
+        {
+            lines.Add(new LlamaCppAdvancedProtocol.BatchLine(i + 1, rows[index + i].Text));
+        }
+
+        // Translation-tuned models (TranslateGemma) can echo history into a lone line's
+        // translation, so the single-line case - including bisection retries - goes context-free.
+        var history = count > 1 ? CollectHistory(rows, index) : new List<LlamaCppAdvancedProtocol.HistoryPair>();
+        var map = await TranslateLinesAsync(lines, history, sourceLanguageCode, targetLanguageCode, cancellationToken);
+        if (IsComplete(map, lines))
+        {
+            for (var i = 0; i < count; i++)
+            {
+                var translation = map[i + 1];
+                rows[index + i].TranslatedText = translation.Length > 0 ? translation : rows[index + i].Text;
+            }
+
+            return count;
+        }
+
+        if (count > 1)
+        {
+            // The model could not fill the full batch - translate the first half only; the outer
+            // loop calls again for the rest (with the successful half now part of the history).
+            return await TranslateChunkAsync(rows, index, count / 2, sourceLanguageCode, targetLanguageCode, cancellationToken);
+        }
+
+        throw new HttpRequestException("No usable translation in " + Name + " reply" +
+                                       (string.IsNullOrEmpty(Error) ? string.Empty : ": " + Error));
+    }
+
+    private async Task<Dictionary<int, string>> TranslateLinesAsync(List<LlamaCppAdvancedProtocol.BatchLine> lines, List<LlamaCppAdvancedProtocol.HistoryPair> history, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+    {
+        var client = _client ?? throw new InvalidOperationException("Initialize() not called");
+        var settings = Se.Settings.AutoTranslate.LlamaCppAdvanced;
+        var url = GetApiUrl();
+
+        // The "codes" this engine receives are English language names (ListLanguages puts the
+        // name in TranslationPair.Code), which is what the prompt expects.
+        var systemPrompt = LlamaCppAdvancedProtocol.BuildSystemPrompt(sourceLanguageCode, targetLanguageCode, settings);
+        var userContent = LlamaCppAdvancedProtocol.BuildUserContent(history, lines);
+        var responseFormat = LlamaCppAdvancedProtocol.BuildResponseFormatJson(lines);
+
+        var map = new Dictionary<int, string>();
+        for (var attempt = 0; attempt < 2 && !cancellationToken.IsCancellationRequested; attempt++)
+        {
+            try
+            {
+                var reply = await client.ChatAsync(url, systemPrompt, userContent, responseFormat, cancellationToken, GetModel());
+                map = LlamaCppAdvancedProtocol.ParseTranslations(reply);
+                if (IsComplete(map, lines))
+                {
+                    return map;
+                }
+
+                Error = reply;
+            }
+            catch (HttpRequestException)
+            {
+                Error = client.Error;
+                if (attempt == 1)
+                {
+                    throw;
+                }
+            }
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        return map;
+    }
+
+    /// <summary>
+    /// The rolling context: the last N already-translated rows immediately before the batch.
+    /// </summary>
+    private static List<LlamaCppAdvancedProtocol.HistoryPair> CollectHistory(ObservableCollection<TranslateRow> rows, int index)
+    {
+        var settings = Se.Settings.AutoTranslate.LlamaCppAdvanced;
+        var maxPairs = Math.Clamp(settings.HistoryPairs, 0, 50);
+        var history = new List<LlamaCppAdvancedProtocol.HistoryPair>(maxPairs);
+        for (var i = index - 1; i >= 0 && history.Count < maxPairs; i--)
+        {
+            if (!string.IsNullOrEmpty(rows[i].TranslatedText))
+            {
+                history.Add(new LlamaCppAdvancedProtocol.HistoryPair(rows[i].Text, rows[i].TranslatedText));
+            }
+        }
+
+        history.Reverse();
+        return history;
+    }
+
+    /// <summary>Every requested line number must be present, and non-empty for non-empty sources.</summary>
+    private static bool IsComplete(Dictionary<int, string> map, List<LlamaCppAdvancedProtocol.BatchLine> lines)
+    {
+        foreach (var line in lines)
+        {
+            if (!map.TryGetValue(line.Number, out var translation))
+            {
+                return false;
+            }
+
+            if (translation.Length == 0 && !string.IsNullOrWhiteSpace(line.Text) && lines.Count > 1)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public void Dispose()
+    {
+        _client?.Dispose();
+    }
+}

--- a/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedClient.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedClient.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.UiLogic.Http;
+
+namespace Nikse.SubtitleEdit.Features.Translate.LlamaCppAdvanced;
+
+/// <summary>
+/// OpenAI-compatible chat-completions client for the advanced llama.cpp translate engine.
+/// Requests grammar-constrained structured output (response_format json_schema); servers that
+/// reject it (older llama.cpp, Ollama, other OpenAI-compatible endpoints) get a json_object and
+/// finally a plain retry. cache_prompt is set explicitly so llama-server reuses the KV cache for
+/// the stable prompt prefix across batches.
+/// </summary>
+public class LlamaCppAdvancedClient : IDisposable
+{
+    private readonly HttpClient _httpClient;
+
+    public string Error { get; private set; } = string.Empty;
+
+    public LlamaCppAdvancedClient()
+    {
+        _httpClient = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
+        _httpClient.Timeout = TimeSpan.FromMinutes(15);
+    }
+
+    public async Task<string> ChatAsync(string url, string systemPrompt, string userContent, string? responseFormatJson, CancellationToken cancellationToken)
+    {
+        Error = string.Empty;
+
+        var response = await PostAsync(url, BuildRequestJson(systemPrompt, userContent, responseFormatJson), cancellationToken);
+        if (!response.ok && responseFormatJson != null && !cancellationToken.IsCancellationRequested)
+        {
+            response = await PostAsync(url, BuildRequestJson(systemPrompt, userContent, "{\"type\":\"json_object\"}"), cancellationToken);
+        }
+
+        if (!response.ok && responseFormatJson != null && !cancellationToken.IsCancellationRequested)
+        {
+            response = await PostAsync(url, BuildRequestJson(systemPrompt, userContent, null), cancellationToken);
+        }
+
+        if (!response.ok)
+        {
+            Error = response.body;
+            SeLogger.Error("llama.cpp advanced translate: engine call failed: " + response.body);
+            throw new HttpRequestException(ShortError(response.body));
+        }
+
+        return ExtractContent(response.body);
+    }
+
+    /// <summary>
+    /// No "model" field: llama-server serves the single model it was started with, and a remote
+    /// llama.cpp server does the same - sending one would only risk a mismatch.
+    /// </summary>
+    private static string BuildRequestJson(string systemPrompt, string userContent, string? responseFormatJson)
+    {
+        using var stream = new System.IO.MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WriteBoolean("stream", false);
+            writer.WriteBoolean("cache_prompt", true);
+
+            WriteSampling(writer);
+
+            if (responseFormatJson != null)
+            {
+                writer.WritePropertyName("response_format");
+                writer.WriteRawValue(responseFormatJson);
+            }
+
+            writer.WriteStartArray("messages");
+            writer.WriteStartObject();
+            writer.WriteString("role", "system");
+            writer.WriteString("content", systemPrompt);
+            writer.WriteEndObject();
+            writer.WriteStartObject();
+            writer.WriteString("role", "user");
+            writer.WriteString("content", userContent);
+            writer.WriteEndObject();
+            writer.WriteEndArray();
+
+            writer.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    /// <summary>
+    /// Advanced-settings sampling overrides first, then the curated model's recommended values
+    /// (persisted as Tools.LlamaCppModel* when the engine was selected), then server defaults -
+    /// except temperature, which bottoms out at 0.2: the server default (0.8) drifts terminology
+    /// across batches ("the Chief" became three different Danish words in testing), while 0.0-0.2
+    /// stayed consistent with no downside.
+    /// </summary>
+    private static void WriteSampling(Utf8JsonWriter writer)
+    {
+        var advanced = Se.Settings.AutoTranslate.LlamaCppAdvanced;
+        var tools = Configuration.Settings.Tools;
+
+        var temperature = advanced.Temperature >= 0 ? advanced.Temperature
+            : tools.LlamaCppModelTemperature >= 0 ? tools.LlamaCppModelTemperature
+            : 0.2;
+        WriteNumberIfSet(writer, "temperature", temperature);
+        WriteNumberIfSet(writer, "top_p", advanced.TopP >= 0 ? advanced.TopP : tools.LlamaCppModelTopP);
+        WriteNumberIfSet(writer, "top_k", advanced.TopK >= 0 ? advanced.TopK : tools.LlamaCppModelTopK);
+        WriteNumberIfSet(writer, "repeat_penalty", advanced.RepeatPenalty >= 0 ? advanced.RepeatPenalty : tools.LlamaCppModelRepeatPenalty);
+        WriteNumberIfSet(writer, "max_tokens", advanced.MaxTokens > 0 ? advanced.MaxTokens : -1);
+    }
+
+    private static void WriteNumberIfSet(Utf8JsonWriter writer, string name, double value)
+    {
+        if (value >= 0)
+        {
+            writer.WriteNumber(name, value);
+        }
+    }
+
+    private async Task<(bool ok, string body)> PostAsync(string url, string json, CancellationToken cancellationToken)
+    {
+        var content = new StringContent(json, Encoding.UTF8);
+        content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, url) { Content = content };
+            var result = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            var body = await result.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            return (result.IsSuccessStatusCode, body);
+        }
+        catch (Exception e) when (e is not OperationCanceledException)
+        {
+            return (false, e.Message);
+        }
+    }
+
+    private static string ExtractContent(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.TryGetProperty("choices", out var choices) &&
+                choices.ValueKind == JsonValueKind.Array &&
+                choices.GetArrayLength() > 0 &&
+                choices[0].TryGetProperty("message", out var message) &&
+                message.TryGetProperty("content", out var contentElement))
+            {
+                return contentElement.GetString() ?? string.Empty;
+            }
+        }
+        catch (JsonException)
+        {
+            // fall through - treat the raw body as content
+        }
+
+        return json;
+    }
+
+    private static string ShortError(string body)
+    {
+        var s = (body ?? string.Empty).Trim();
+        return s.Length > 300 ? s.Substring(0, 300) + "..." : s;
+    }
+
+    public void Dispose()
+    {
+        _httpClient.Dispose();
+    }
+}

--- a/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedClient.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedClient.cs
@@ -30,19 +30,19 @@ public class LlamaCppAdvancedClient : IDisposable
         _httpClient.Timeout = TimeSpan.FromMinutes(15);
     }
 
-    public async Task<string> ChatAsync(string url, string systemPrompt, string userContent, string? responseFormatJson, CancellationToken cancellationToken)
+    public async Task<string> ChatAsync(string url, string systemPrompt, string userContent, string? responseFormatJson, CancellationToken cancellationToken, string? model = null)
     {
         Error = string.Empty;
 
-        var response = await PostAsync(url, BuildRequestJson(systemPrompt, userContent, responseFormatJson), cancellationToken);
+        var response = await PostAsync(url, BuildRequestJson(systemPrompt, userContent, responseFormatJson, model), cancellationToken);
         if (!response.ok && responseFormatJson != null && !cancellationToken.IsCancellationRequested)
         {
-            response = await PostAsync(url, BuildRequestJson(systemPrompt, userContent, "{\"type\":\"json_object\"}"), cancellationToken);
+            response = await PostAsync(url, BuildRequestJson(systemPrompt, userContent, "{\"type\":\"json_object\"}", model), cancellationToken);
         }
 
         if (!response.ok && responseFormatJson != null && !cancellationToken.IsCancellationRequested)
         {
-            response = await PostAsync(url, BuildRequestJson(systemPrompt, userContent, null), cancellationToken);
+            response = await PostAsync(url, BuildRequestJson(systemPrompt, userContent, null, model), cancellationToken);
         }
 
         if (!response.ok)
@@ -56,15 +56,21 @@ public class LlamaCppAdvancedClient : IDisposable
     }
 
     /// <summary>
-    /// No "model" field: llama-server serves the single model it was started with, and a remote
-    /// llama.cpp server does the same - sending one would only risk a mismatch.
+    /// The "model" field is only written when the caller supplies one (Ollama requires it;
+    /// llama-server serves the single model it was started with, and sending one would only
+    /// risk a mismatch). cache_prompt is llama.cpp-specific; other servers ignore it.
     /// </summary>
-    private static string BuildRequestJson(string systemPrompt, string userContent, string? responseFormatJson)
+    private static string BuildRequestJson(string systemPrompt, string userContent, string? responseFormatJson, string? model)
     {
         using var stream = new System.IO.MemoryStream();
         using (var writer = new Utf8JsonWriter(stream))
         {
             writer.WriteStartObject();
+            if (!string.IsNullOrWhiteSpace(model))
+            {
+                writer.WriteString("model", model);
+            }
+
             writer.WriteBoolean("stream", false);
             writer.WriteBoolean("cache_prompt", true);
 

--- a/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedProtocol.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedProtocol.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Translate.LlamaCppAdvanced;
+
+/// <summary>
+/// The wire format for the advanced llama.cpp engine: numbered lines in, a JSON object mapping
+/// each line number to its translation out. The system prompt is deliberately ordered
+/// stable-parts-first (instructions, synopsis, glossary) so llama-server's automatic prefix
+/// KV-cache reuse (cache_prompt) only has to re-ingest the per-batch tail of each request.
+/// </summary>
+public static class LlamaCppAdvancedProtocol
+{
+    public const string DefaultPrompt =
+        "You are a professional subtitle translator. Translate each subtitle line from {0} to {1}. " +
+        "Preserve meaning, tone and style; do not censor the translation. " +
+        "Keep formatting tags exactly as they are.";
+
+    private const string ProtocolText =
+        "\n\nThe user message is a JSON object. \"history\" holds recent already-translated lines (source and translation) - " +
+        "use them only for context and consistency (names, pronouns, formality), do not re-translate them. " +
+        "\"lines\" holds the lines to translate now, each with a line number \"n\" and its \"text\" " +
+        "(a \"\\n\" inside a text is a line break inside that subtitle).\n" +
+        "Answer with ONLY a JSON object mapping every line number to its translation, e.g. " +
+        "{\"1\":\"...\",\"2\":\"...\"}. Include each line number exactly once and nothing else.";
+
+    public record HistoryPair(string Source, string Target);
+    public record BatchLine(int Number, string Text);
+
+    /// <summary>
+    /// Builds the system prompt. Placeholders are replaced (not string.Format'ed) so braces in
+    /// subtitle tags or user-edited prompts cannot throw a FormatException.
+    /// </summary>
+    public static string BuildSystemPrompt(string sourceLanguage, string targetLanguage, SeLlamaCppAdvanced settings)
+    {
+        var instructions = string.IsNullOrWhiteSpace(settings.Prompt) ? DefaultPrompt : settings.Prompt;
+        var sb = new StringBuilder(instructions.Replace("{0}", sourceLanguage).Replace("{1}", targetLanguage));
+
+        if (settings.KeepLineBreaks)
+        {
+            sb.Append(" Keep the same number of line breaks in each translation as in its source line.");
+        }
+
+        if (settings.Formality == SeLlamaCppAdvanced.FormalityFormal)
+        {
+            sb.Append(" Use formal address (e.g. German \"Sie\", French \"vous\", Spanish \"usted\").");
+        }
+        else if (settings.Formality == SeLlamaCppAdvanced.FormalityInformal)
+        {
+            sb.Append(" Use informal address (e.g. German \"du\", French \"tu\", Spanish \"tú\").");
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.Synopsis))
+        {
+            sb.Append("\n\nAbout the content being translated:\n").Append(settings.Synopsis.Trim());
+        }
+
+        var glossary = ParseGlossary(settings.Glossary);
+        if (glossary.Count > 0)
+        {
+            sb.Append("\n\nGlossary - always translate these terms exactly as given:");
+            foreach (var pair in glossary)
+            {
+                sb.Append('\n').Append(pair.Key).Append(" = ").Append(pair.Value);
+            }
+        }
+
+        sb.Append(ProtocolText);
+        return sb.ToString();
+    }
+
+    /// <summary>Glossary text box format: one "source term = translation" per line.</summary>
+    public static List<KeyValuePair<string, string>> ParseGlossary(string glossary)
+    {
+        var result = new List<KeyValuePair<string, string>>();
+        foreach (var line in (glossary ?? string.Empty).SplitToLines())
+        {
+            var idx = line.IndexOf('=');
+            if (idx <= 0)
+            {
+                continue;
+            }
+
+            var source = line.Substring(0, idx).Trim();
+            var target = line.Substring(idx + 1).Trim();
+            if (source.Length > 0 && target.Length > 0)
+            {
+                result.Add(new KeyValuePair<string, string>(source, target));
+            }
+        }
+
+        return result;
+    }
+
+    public static string BuildUserContent(List<HistoryPair> history, List<BatchLine> lines)
+    {
+        using var stream = new System.IO.MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+
+            writer.WriteStartArray("history");
+            foreach (var pair in history)
+            {
+                writer.WriteStartObject();
+                writer.WriteString("source", ToWireText(pair.Source));
+                writer.WriteString("translation", ToWireText(pair.Target));
+                writer.WriteEndObject();
+            }
+            writer.WriteEndArray();
+
+            writer.WriteStartArray("lines");
+            foreach (var line in lines)
+            {
+                writer.WriteStartObject();
+                writer.WriteNumber("n", line.Number);
+                writer.WriteString("text", ToWireText(line.Text));
+                writer.WriteEndObject();
+            }
+            writer.WriteEndArray();
+
+            writer.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    /// <summary>
+    /// The response_format value for llama-server: an OpenAI-style json_schema requiring exactly
+    /// the batch's line numbers as keys. llama.cpp compiles this to a grammar, so the reply is
+    /// guaranteed to be a parseable object with all keys present.
+    /// </summary>
+    public static string BuildResponseFormatJson(IReadOnlyList<BatchLine> lines)
+    {
+        using var stream = new System.IO.MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("type", "json_schema");
+            writer.WriteStartObject("json_schema");
+            writer.WriteString("name", "translations");
+            writer.WriteBoolean("strict", true);
+            writer.WriteStartObject("schema");
+            writer.WriteString("type", "object");
+
+            writer.WriteStartObject("properties");
+            foreach (var line in lines)
+            {
+                writer.WriteStartObject(line.Number.ToString(CultureInfo.InvariantCulture));
+                writer.WriteString("type", "string");
+                writer.WriteEndObject();
+            }
+            writer.WriteEndObject();
+
+            writer.WriteStartArray("required");
+            foreach (var line in lines)
+            {
+                writer.WriteStringValue(line.Number.ToString(CultureInfo.InvariantCulture));
+            }
+            writer.WriteEndArray();
+
+            writer.WriteBoolean("additionalProperties", false);
+            writer.WriteEndObject(); // schema
+            writer.WriteEndObject(); // json_schema
+            writer.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    /// <summary>
+    /// Parses the model reply into number → translation. Tolerates markdown fences and stray
+    /// prose around the JSON object (the plain-text fallback path has no grammar guarantee).
+    /// </summary>
+    public static Dictionary<int, string> ParseTranslations(string responseText)
+    {
+        var result = new Dictionary<int, string>();
+        var json = ExtractJsonObject(responseText);
+        if (json == null)
+        {
+            return result;
+        }
+
+        using var doc = JsonDocument.Parse(json);
+        if (doc.RootElement.ValueKind != JsonValueKind.Object)
+        {
+            return result;
+        }
+
+        foreach (var property in doc.RootElement.EnumerateObject())
+        {
+            if (property.Value.ValueKind == JsonValueKind.String &&
+                int.TryParse(property.Name, NumberStyles.Integer, CultureInfo.InvariantCulture, out var number))
+            {
+                result[number] = FromWireText(property.Value.GetString());
+            }
+        }
+
+        return result;
+    }
+
+    private static string ToWireText(string text)
+    {
+        return (text ?? string.Empty).Replace(Environment.NewLine, "\n");
+    }
+
+    private static string FromWireText(string? text)
+    {
+        return (text ?? string.Empty).Replace("\r\n", "\n").Replace("\n", Environment.NewLine).Trim();
+    }
+
+    private static string? ExtractJsonObject(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return null;
+        }
+
+        var start = text.IndexOf('{');
+        var end = text.LastIndexOf('}');
+        if (start < 0 || end <= start)
+        {
+            return null;
+        }
+
+        var candidate = text.Substring(start, end - start + 1);
+        try
+        {
+            using var _ = JsonDocument.Parse(candidate);
+            return candidate;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsViewModel.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsViewModel.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.ObjectModel;
+using Avalonia.Controls;
+using Avalonia.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Translate.LlamaCppAdvanced;
+
+/// <summary>
+/// Edits the global settings of the advanced llama.cpp translate engine: context options
+/// (synopsis, glossary, rolling history), batch/style options and sampling overrides.
+/// </summary>
+public partial class LlamaCppAdvancedSettingsViewModel : ObservableObject
+{
+    [ObservableProperty] private string _synopsis = string.Empty;
+    [ObservableProperty] private string _glossary = string.Empty;
+    [ObservableProperty] private int _historyPairs;
+    [ObservableProperty] private int _batchSize;
+    [ObservableProperty] private bool _keepLineBreaks;
+    [ObservableProperty] private ObservableCollection<string> _formalities = new();
+    [ObservableProperty] private string? _selectedFormality;
+    [ObservableProperty] private string _prompt = string.Empty;
+    [ObservableProperty] private double? _temperature;
+    [ObservableProperty] private double? _topP;
+    [ObservableProperty] private int _topK;
+    [ObservableProperty] private double? _repeatPenalty;
+    [ObservableProperty] private int _maxTokens;
+    [ObservableProperty] private int _contextSize;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public void Initialize()
+    {
+        var settings = Se.Settings.AutoTranslate.LlamaCppAdvanced;
+
+        Formalities = new ObservableCollection<string>
+        {
+            SeLlamaCppAdvanced.FormalityDefault,
+            SeLlamaCppAdvanced.FormalityFormal,
+            SeLlamaCppAdvanced.FormalityInformal,
+        };
+        SelectedFormality = Formalities.Contains(settings.Formality) ? settings.Formality : Formalities[0];
+
+        Synopsis = settings.Synopsis;
+        Glossary = settings.Glossary;
+        HistoryPairs = settings.HistoryPairs;
+        BatchSize = settings.BatchSize;
+        KeepLineBreaks = settings.KeepLineBreaks;
+        Prompt = settings.Prompt;
+        Temperature = settings.Temperature;
+        TopP = settings.TopP;
+        TopK = settings.TopK;
+        RepeatPenalty = settings.RepeatPenalty;
+        MaxTokens = settings.MaxTokens;
+        ContextSize = settings.ContextSize;
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        var settings = Se.Settings.AutoTranslate.LlamaCppAdvanced;
+        settings.Synopsis = Synopsis?.Trim() ?? string.Empty;
+        settings.Glossary = Glossary?.Trim() ?? string.Empty;
+        settings.HistoryPairs = Math.Clamp(HistoryPairs, 0, 50);
+        settings.BatchSize = Math.Clamp(BatchSize, 1, 50);
+        settings.KeepLineBreaks = KeepLineBreaks;
+        settings.Formality = SelectedFormality ?? SeLlamaCppAdvanced.FormalityDefault;
+        settings.Prompt = Prompt?.Trim() ?? string.Empty;
+        settings.Temperature = Temperature ?? -1;
+        settings.TopP = TopP ?? -1;
+        settings.TopK = TopK;
+        settings.RepeatPenalty = RepeatPenalty ?? -1;
+        settings.MaxTokens = MaxTokens;
+        settings.ContextSize = Math.Clamp(ContextSize, 2048, 262144);
+        Se.SaveSettings();
+
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsWindow.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsWindow.cs
@@ -1,0 +1,236 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Translate.LlamaCppAdvanced;
+
+public class LlamaCppAdvancedSettingsWindow : Window
+{
+    private const int LabelWidth = 170;
+    private const int EditorWidth = 420;
+
+    private readonly LlamaCppAdvancedSettingsViewModel _vm;
+
+    public LlamaCppAdvancedSettingsWindow(LlamaCppAdvancedSettingsViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.Translate.AdvancedSettings;
+        // Explicit width: WidthAndHeight sizing comes out too wide on macOS.
+        Width = 660;
+        SizeToContent = SizeToContent.Height;
+        CanResize = false;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        Content = BuildContent(vm);
+    }
+
+    private static Border BuildContent(LlamaCppAdvancedSettingsViewModel vm)
+    {
+        var header = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Children =
+            {
+                new TextBlock
+                {
+                    Text = Se.Language.Translate.AdvancedSettings,
+                    FontSize = 18,
+                    FontWeight = FontWeight.SemiBold,
+                },
+                new TextBlock
+                {
+                    Text = Se.Language.Translate.AdvancedSettingsSubtitle,
+                    FontSize = 12,
+                    Opacity = 0.75,
+                    Margin = new Thickness(0, 2, 0, 0),
+                },
+            },
+        };
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var buttonPanel = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        var stack = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 12,
+            Children =
+            {
+                header,
+                MakeCard(BuildContextSection(vm)),
+                MakeCard(BuildSamplingSection(vm)),
+                buttonPanel,
+            },
+        };
+
+        return new Border
+        {
+            Child = stack,
+            Padding = UiUtil.MakeWindowMargin(),
+        };
+    }
+
+    private static Grid BuildContextSection(LlamaCppAdvancedSettingsViewModel vm)
+    {
+        var grid = MakeFormGrid(6);
+
+        var synopsisBox = MakeMultilineTextBox(vm, nameof(vm.Synopsis), 56);
+        SetHint(synopsisBox, Se.Language.Translate.SynopsisHint);
+        AddRow(grid, 0, Se.Language.Translate.Synopsis, synopsisBox);
+
+        var glossaryBox = MakeMultilineTextBox(vm, nameof(vm.Glossary), 76);
+        glossaryBox.Watermark = Se.Language.Translate.GlossaryHint;
+        SetHint(glossaryBox, Se.Language.Translate.GlossaryHint);
+        AddRow(grid, 1, Se.Language.Translate.Glossary, glossaryBox);
+
+        var promptBox = MakeMultilineTextBox(vm, nameof(vm.Prompt), 56);
+        promptBox.Watermark = LlamaCppAdvancedProtocol.DefaultPrompt;
+        SetHint(promptBox, Se.Language.Translate.CustomPromptHint);
+        AddRow(grid, 2, Se.Language.Translate.PromptText, promptBox);
+
+        AddRow(grid, 3, Se.Language.Translate.PreviousLinesAsContext,
+            UiUtil.MakeNumericUpDownInt(0, 50, 12, 120, vm, nameof(vm.HistoryPairs)));
+
+        AddRow(grid, 4, Se.Language.Translate.LinesPerBatch,
+            UiUtil.MakeNumericUpDownInt(1, 50, 10, 120, vm, nameof(vm.BatchSize)));
+
+        var stylePanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 16,
+            Children =
+            {
+                UiUtil.MakeComboBox(vm.Formalities, vm, nameof(vm.SelectedFormality)).WithWidth(120),
+                UiUtil.MakeCheckBox(Se.Language.Translate.KeepLineBreaks, vm, nameof(vm.KeepLineBreaks)),
+            },
+        };
+        AddRow(grid, 5, Se.Language.General.Formality, stylePanel);
+
+        return grid;
+    }
+
+    private static Grid BuildSamplingSection(LlamaCppAdvancedSettingsViewModel vm)
+    {
+        var grid = MakeFormGrid(5);
+
+        var samplingHeader = new TextBlock
+        {
+            Text = Se.Language.Translate.SamplingParameters + " (" + Se.Language.Translate.MinusOneMeansDefault + ")",
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(0, 0, 0, 4),
+        };
+        grid.Add(samplingHeader, 0, 0);
+        Grid.SetColumnSpan(samplingHeader, 2);
+
+        var samplingPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 10,
+            Children =
+            {
+                MakeSmallLabel(Se.Language.Translate.Temperature),
+                UiUtil.MakeNumericUpDownTwoDecimals(-1, 2, 100, vm, nameof(vm.Temperature)),
+                MakeSmallLabel(Se.Language.Translate.TopP),
+                UiUtil.MakeNumericUpDownTwoDecimals(-1, 1, 100, vm, nameof(vm.TopP)),
+                MakeSmallLabel(Se.Language.Translate.TopK),
+                UiUtil.MakeNumericUpDownInt(-1, 500, -1, 100, vm, nameof(vm.TopK)),
+                MakeSmallLabel(Se.Language.Translate.RepeatPenalty),
+                UiUtil.MakeNumericUpDownTwoDecimals(-1, 3, 100, vm, nameof(vm.RepeatPenalty)),
+            },
+        };
+        grid.Add(samplingPanel, 1, 0);
+        Grid.SetColumnSpan(samplingPanel, 2);
+
+        AddRow(grid, 2, Se.Language.Translate.MaxTokensPerReply,
+            UiUtil.MakeNumericUpDownInt(-1, 32768, -1, 120, vm, nameof(vm.MaxTokens)));
+
+        AddRow(grid, 3, Se.Language.Translate.ServerContextSizeTokens,
+            UiUtil.MakeNumericUpDownInt(2048, 262144, 16384, 120, vm, nameof(vm.ContextSize)));
+
+        return grid;
+    }
+
+    private static Grid MakeFormGrid(int rows)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(LabelWidth, GridUnitType.Pixel) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            ColumnSpacing = 12,
+            RowSpacing = 10,
+        };
+
+        for (var i = 0; i < rows; i++)
+        {
+            grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) });
+        }
+
+        return grid;
+    }
+
+    private static void AddRow(Grid grid, int row, string label, Control editor)
+    {
+        var labelBlock = new TextBlock
+        {
+            Text = label,
+            Opacity = 0.7,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        grid.Add(labelBlock, row, 0);
+        grid.Add(editor, row, 1);
+    }
+
+    private static TextBlock MakeSmallLabel(string text) => new()
+    {
+        Text = text,
+        Opacity = 0.7,
+        VerticalAlignment = VerticalAlignment.Center,
+    };
+
+    private static TextBox MakeMultilineTextBox(LlamaCppAdvancedSettingsViewModel vm, string propertyPath, double height)
+    {
+        var textBox = UiUtil.MakeTextBox(EditorWidth, vm, propertyPath);
+        textBox.Height = height;
+        textBox.AcceptsReturn = true;
+        textBox.TextWrapping = TextWrapping.Wrap;
+        textBox.VerticalContentAlignment = VerticalAlignment.Top;
+        return textBox;
+    }
+
+    private static void SetHint(Control control, string hint)
+    {
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            ToolTip.SetTip(control, hint);
+        }
+    }
+
+    private static Border MakeCard(Control child)
+    {
+        return new Border
+        {
+            Child = child,
+            Padding = new Thickness(14),
+            CornerRadius = new CornerRadius(6),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
+        };
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsWindow.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsWindow.cs
@@ -20,7 +20,7 @@ public class LlamaCppAdvancedSettingsWindow : Window
         UiUtil.InitializeWindow(this, GetType().Name);
         Title = Se.Language.Translate.AdvancedSettings;
         // Explicit width: WidthAndHeight sizing comes out too wide on macOS.
-        Width = 660;
+        Width = 680;
         SizeToContent = SizeToContent.Height;
         CanResize = false;
 
@@ -119,7 +119,24 @@ public class LlamaCppAdvancedSettingsWindow : Window
 
     private static Grid BuildSamplingSection(LlamaCppAdvancedSettingsViewModel vm)
     {
-        var grid = MakeFormGrid(5);
+        // Four columns (label, editor, label, editor) so the four sampling values sit in a
+        // 2x2 block instead of one long row that overflows the window width.
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(110, GridUnitType.Pixel) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnSpacing = 12,
+            RowSpacing = 10,
+        };
+        for (var i = 0; i < 5; i++)
+        {
+            grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) });
+        }
 
         var samplingHeader = new TextBlock
         {
@@ -128,32 +145,28 @@ public class LlamaCppAdvancedSettingsWindow : Window
             Margin = new Thickness(0, 0, 0, 4),
         };
         grid.Add(samplingHeader, 0, 0);
-        Grid.SetColumnSpan(samplingHeader, 2);
+        Grid.SetColumnSpan(samplingHeader, 4);
 
-        var samplingPanel = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            Spacing = 10,
-            Children =
-            {
-                MakeSmallLabel(Se.Language.Translate.Temperature),
-                UiUtil.MakeNumericUpDownTwoDecimals(-1, 2, 100, vm, nameof(vm.Temperature)),
-                MakeSmallLabel(Se.Language.Translate.TopP),
-                UiUtil.MakeNumericUpDownTwoDecimals(-1, 1, 100, vm, nameof(vm.TopP)),
-                MakeSmallLabel(Se.Language.Translate.TopK),
-                UiUtil.MakeNumericUpDownInt(-1, 500, -1, 100, vm, nameof(vm.TopK)),
-                MakeSmallLabel(Se.Language.Translate.RepeatPenalty),
-                UiUtil.MakeNumericUpDownTwoDecimals(-1, 3, 100, vm, nameof(vm.RepeatPenalty)),
-            },
-        };
-        grid.Add(samplingPanel, 1, 0);
-        Grid.SetColumnSpan(samplingPanel, 2);
+        grid.Add(MakeSmallLabel(Se.Language.Translate.Temperature), 1, 0);
+        grid.Add(UiUtil.MakeNumericUpDownTwoDecimals(-1, 2, 110, vm, nameof(vm.Temperature)), 1, 1);
+        grid.Add(MakeSmallLabel(Se.Language.Translate.TopP), 1, 2);
+        grid.Add(UiUtil.MakeNumericUpDownTwoDecimals(-1, 1, 110, vm, nameof(vm.TopP)), 1, 3);
 
-        AddRow(grid, 2, Se.Language.Translate.MaxTokensPerReply,
-            UiUtil.MakeNumericUpDownInt(-1, 32768, -1, 120, vm, nameof(vm.MaxTokens)));
+        grid.Add(MakeSmallLabel(Se.Language.Translate.TopK), 2, 0);
+        grid.Add(UiUtil.MakeNumericUpDownInt(-1, 500, -1, 110, vm, nameof(vm.TopK)), 2, 1);
+        grid.Add(MakeSmallLabel(Se.Language.Translate.RepeatPenalty), 2, 2);
+        grid.Add(UiUtil.MakeNumericUpDownTwoDecimals(-1, 3, 110, vm, nameof(vm.RepeatPenalty)), 2, 3);
 
-        AddRow(grid, 3, Se.Language.Translate.ServerContextSizeTokens,
-            UiUtil.MakeNumericUpDownInt(2048, 262144, 16384, 120, vm, nameof(vm.ContextSize)));
+        var maxTokens = UiUtil.MakeNumericUpDownInt(-1, 32768, -1, 150, vm, nameof(vm.MaxTokens));
+        grid.Add(MakeSmallLabel(Se.Language.Translate.MaxTokensPerReply), 3, 0);
+        grid.Add(maxTokens, 3, 1);
+        Grid.SetColumnSpan(maxTokens, 3);
+
+        var contextSize = UiUtil.MakeNumericUpDownInt(2048, 262144, 16384, 150, vm, nameof(vm.ContextSize));
+        contextSize.Increment = 2048;
+        grid.Add(MakeSmallLabel(Se.Language.Translate.ServerContextSizeTokens), 4, 0);
+        grid.Add(contextSize, 4, 1);
+        Grid.SetColumnSpan(contextSize, 3);
 
         return grid;
     }

--- a/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedTranslate.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedTranslate.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
+using Nikse.SubtitleEdit.UiLogic.Translate;
+
+namespace Nikse.SubtitleEdit.Features.Translate.LlamaCppAdvanced;
+
+/// <summary>
+/// Batch/context-aware llama.cpp engine: sends numbered batches with a rolling history of
+/// already-translated lines plus user-configured synopsis/glossary/style, and requires a
+/// schema-constrained JSON reply so line alignment is guaranteed. The Auto-translate loop calls
+/// <see cref="TranslateBatchAsync"/> directly; the plain <see cref="Translate"/> path (used for
+/// "translate current line") is a context-free batch of one.
+/// </summary>
+public class LlamaCppAdvancedTranslate : IAutoTranslator, IDisposable
+{
+    private LlamaCppAdvancedClient? _client;
+
+    public static string StaticName { get; set; } = "llama.cpp advanced (local LLM)";
+    public override string ToString() => StaticName;
+    public string Name => StaticName;
+    public string Url => "https://github.com/ggml-org/llama.cpp";
+    public string Error { get; set; } = string.Empty;
+    public int MaxCharacters => 1000;
+
+    public void Initialize()
+    {
+        _client?.Dispose();
+        _client = new LlamaCppAdvancedClient();
+    }
+
+    public List<TranslationPair> GetSupportedSourceLanguages()
+    {
+        return ChatGptTranslate.ListLanguages();
+    }
+
+    public List<TranslationPair> GetSupportedTargetLanguages()
+    {
+        return ChatGptTranslate.ListLanguages();
+    }
+
+    public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+    {
+        var lines = new List<LlamaCppAdvancedProtocol.BatchLine> { new(1, text.Trim()) };
+        var map = await TranslateLinesAsync(lines, new List<LlamaCppAdvancedProtocol.HistoryPair>(), sourceLanguageCode, targetLanguageCode, cancellationToken);
+        return map.TryGetValue(1, out var translation) ? translation : string.Empty;
+    }
+
+    /// <summary>
+    /// Translates the next batch starting at <paramref name="index"/>, writing results into the
+    /// rows, and returns the number of rows translated (always at least 1, or throws). On an
+    /// invalid reply the batch is retried once, then halved - a model that cannot manage a full
+    /// batch often still manages a smaller one.
+    /// </summary>
+    public async Task<int> TranslateBatchAsync(ObservableCollection<TranslateRow> rows, int index, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+    {
+        var settings = Se.Settings.AutoTranslate.LlamaCppAdvanced;
+        var batchSize = Math.Clamp(settings.BatchSize, 1, 50);
+        var count = Math.Min(batchSize, rows.Count - index);
+        return await TranslateChunkAsync(rows, index, count, sourceLanguageCode, targetLanguageCode, cancellationToken);
+    }
+
+    private async Task<int> TranslateChunkAsync(ObservableCollection<TranslateRow> rows, int index, int count, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+    {
+        var lines = new List<LlamaCppAdvancedProtocol.BatchLine>(count);
+        for (var i = 0; i < count; i++)
+        {
+            lines.Add(new LlamaCppAdvancedProtocol.BatchLine(i + 1, rows[index + i].Text));
+        }
+
+        // Translation-tuned models (TranslateGemma) can echo history into a lone line's
+        // translation, so the single-line case - including bisection retries - goes context-free.
+        var history = count > 1 ? CollectHistory(rows, index) : new List<LlamaCppAdvancedProtocol.HistoryPair>();
+        var map = await TranslateLinesAsync(lines, history, sourceLanguageCode, targetLanguageCode, cancellationToken);
+        if (IsComplete(map, lines))
+        {
+            for (var i = 0; i < count; i++)
+            {
+                var translation = map[i + 1];
+                rows[index + i].TranslatedText = translation.Length > 0 ? translation : rows[index + i].Text;
+            }
+
+            return count;
+        }
+
+        if (count > 1)
+        {
+            // The model could not fill the full batch - translate the first half only; the outer
+            // loop calls again for the rest (with the successful half now part of the history).
+            return await TranslateChunkAsync(rows, index, count / 2, sourceLanguageCode, targetLanguageCode, cancellationToken);
+        }
+
+        throw new HttpRequestException("No usable translation in llama.cpp reply" +
+                                       (string.IsNullOrEmpty(Error) ? string.Empty : ": " + Error));
+    }
+
+    private async Task<Dictionary<int, string>> TranslateLinesAsync(List<LlamaCppAdvancedProtocol.BatchLine> lines, List<LlamaCppAdvancedProtocol.HistoryPair> history, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+    {
+        var client = _client ?? throw new InvalidOperationException("Initialize() not called");
+        var settings = Se.Settings.AutoTranslate.LlamaCppAdvanced;
+        var url = Configuration.Settings.Tools.LlamaCppApiUrl;
+
+        // The "codes" this engine receives are English language names (ListLanguages puts the
+        // name in TranslationPair.Code), which is what the prompt expects.
+        var systemPrompt = LlamaCppAdvancedProtocol.BuildSystemPrompt(sourceLanguageCode, targetLanguageCode, settings);
+        var userContent = LlamaCppAdvancedProtocol.BuildUserContent(history, lines);
+        var responseFormat = LlamaCppAdvancedProtocol.BuildResponseFormatJson(lines);
+
+        var map = new Dictionary<int, string>();
+        for (var attempt = 0; attempt < 2 && !cancellationToken.IsCancellationRequested; attempt++)
+        {
+            try
+            {
+                var reply = await client.ChatAsync(url, systemPrompt, userContent, responseFormat, cancellationToken);
+                map = LlamaCppAdvancedProtocol.ParseTranslations(reply);
+                if (IsComplete(map, lines))
+                {
+                    return map;
+                }
+
+                Error = reply;
+            }
+            catch (HttpRequestException)
+            {
+                Error = client.Error;
+                if (attempt == 1)
+                {
+                    throw;
+                }
+            }
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        return map;
+    }
+
+    /// <summary>
+    /// The rolling context: the last N already-translated rows immediately before the batch.
+    /// </summary>
+    private static List<LlamaCppAdvancedProtocol.HistoryPair> CollectHistory(ObservableCollection<TranslateRow> rows, int index)
+    {
+        var settings = Se.Settings.AutoTranslate.LlamaCppAdvanced;
+        var maxPairs = Math.Clamp(settings.HistoryPairs, 0, 50);
+        var history = new List<LlamaCppAdvancedProtocol.HistoryPair>(maxPairs);
+        for (var i = index - 1; i >= 0 && history.Count < maxPairs; i--)
+        {
+            if (!string.IsNullOrEmpty(rows[i].TranslatedText))
+            {
+                history.Add(new LlamaCppAdvancedProtocol.HistoryPair(rows[i].Text, rows[i].TranslatedText));
+            }
+        }
+
+        history.Reverse();
+        return history;
+    }
+
+    /// <summary>Every requested line number must be present, and non-empty for non-empty sources.</summary>
+    private static bool IsComplete(Dictionary<int, string> map, List<LlamaCppAdvancedProtocol.BatchLine> lines)
+    {
+        foreach (var line in lines)
+        {
+            if (!map.TryGetValue(line.Number, out var translation))
+            {
+                return false;
+            }
+
+            if (translation.Length == 0 && !string.IsNullOrWhiteSpace(line.Text) && lines.Count > 1)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public void Dispose()
+    {
+        _client?.Dispose();
+    }
+}

--- a/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedTranslate.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedTranslate.cs
@@ -1,186 +1,22 @@
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 using Nikse.SubtitleEdit.Core.Common;
-using Nikse.SubtitleEdit.Logic.Config;
-using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
-using Nikse.SubtitleEdit.UiLogic.Translate;
 
 namespace Nikse.SubtitleEdit.Features.Translate.LlamaCppAdvanced;
 
 /// <summary>
-/// Batch/context-aware llama.cpp engine: sends numbered batches with a rolling history of
-/// already-translated lines plus user-configured synopsis/glossary/style, and requires a
-/// schema-constrained JSON reply so line alignment is guaranteed. The Auto-translate loop calls
-/// <see cref="TranslateBatchAsync"/> directly; the plain <see cref="Translate"/> path (used for
-/// "translate current line") is a context-free batch of one.
+/// The advanced engine against SE's own llama-server (or a remote one). No "model" field:
+/// llama-server serves the single model it was started with, and sending one would only risk a
+/// mismatch. The endpoint is set by LlamaCppServerManager (local) or the URL field (remote)
+/// before Initialize is called.
 /// </summary>
-public class LlamaCppAdvancedTranslate : IAutoTranslator, IDisposable
+public class LlamaCppAdvancedTranslate : AdvancedTranslatorBase
 {
-    private LlamaCppAdvancedClient? _client;
-
     public static string StaticName { get; set; } = "llama.cpp advanced (local LLM)";
     public override string ToString() => StaticName;
-    public string Name => StaticName;
-    public string Url => "https://github.com/ggml-org/llama.cpp";
-    public string Error { get; set; } = string.Empty;
-    public int MaxCharacters => 1000;
+    public override string Name => StaticName;
+    public override string Url => "https://github.com/ggml-org/llama.cpp";
 
-    public void Initialize()
+    protected override string GetApiUrl()
     {
-        _client?.Dispose();
-        _client = new LlamaCppAdvancedClient();
-    }
-
-    public List<TranslationPair> GetSupportedSourceLanguages()
-    {
-        return ChatGptTranslate.ListLanguages();
-    }
-
-    public List<TranslationPair> GetSupportedTargetLanguages()
-    {
-        return ChatGptTranslate.ListLanguages();
-    }
-
-    public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
-    {
-        var lines = new List<LlamaCppAdvancedProtocol.BatchLine> { new(1, text.Trim()) };
-        var map = await TranslateLinesAsync(lines, new List<LlamaCppAdvancedProtocol.HistoryPair>(), sourceLanguageCode, targetLanguageCode, cancellationToken);
-        return map.TryGetValue(1, out var translation) ? translation : string.Empty;
-    }
-
-    /// <summary>
-    /// Translates the next batch starting at <paramref name="index"/>, writing results into the
-    /// rows, and returns the number of rows translated (always at least 1, or throws). On an
-    /// invalid reply the batch is retried once, then halved - a model that cannot manage a full
-    /// batch often still manages a smaller one.
-    /// </summary>
-    public async Task<int> TranslateBatchAsync(ObservableCollection<TranslateRow> rows, int index, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
-    {
-        var settings = Se.Settings.AutoTranslate.LlamaCppAdvanced;
-        var batchSize = Math.Clamp(settings.BatchSize, 1, 50);
-        var count = Math.Min(batchSize, rows.Count - index);
-        return await TranslateChunkAsync(rows, index, count, sourceLanguageCode, targetLanguageCode, cancellationToken);
-    }
-
-    private async Task<int> TranslateChunkAsync(ObservableCollection<TranslateRow> rows, int index, int count, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
-    {
-        var lines = new List<LlamaCppAdvancedProtocol.BatchLine>(count);
-        for (var i = 0; i < count; i++)
-        {
-            lines.Add(new LlamaCppAdvancedProtocol.BatchLine(i + 1, rows[index + i].Text));
-        }
-
-        // Translation-tuned models (TranslateGemma) can echo history into a lone line's
-        // translation, so the single-line case - including bisection retries - goes context-free.
-        var history = count > 1 ? CollectHistory(rows, index) : new List<LlamaCppAdvancedProtocol.HistoryPair>();
-        var map = await TranslateLinesAsync(lines, history, sourceLanguageCode, targetLanguageCode, cancellationToken);
-        if (IsComplete(map, lines))
-        {
-            for (var i = 0; i < count; i++)
-            {
-                var translation = map[i + 1];
-                rows[index + i].TranslatedText = translation.Length > 0 ? translation : rows[index + i].Text;
-            }
-
-            return count;
-        }
-
-        if (count > 1)
-        {
-            // The model could not fill the full batch - translate the first half only; the outer
-            // loop calls again for the rest (with the successful half now part of the history).
-            return await TranslateChunkAsync(rows, index, count / 2, sourceLanguageCode, targetLanguageCode, cancellationToken);
-        }
-
-        throw new HttpRequestException("No usable translation in llama.cpp reply" +
-                                       (string.IsNullOrEmpty(Error) ? string.Empty : ": " + Error));
-    }
-
-    private async Task<Dictionary<int, string>> TranslateLinesAsync(List<LlamaCppAdvancedProtocol.BatchLine> lines, List<LlamaCppAdvancedProtocol.HistoryPair> history, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
-    {
-        var client = _client ?? throw new InvalidOperationException("Initialize() not called");
-        var settings = Se.Settings.AutoTranslate.LlamaCppAdvanced;
-        var url = Configuration.Settings.Tools.LlamaCppApiUrl;
-
-        // The "codes" this engine receives are English language names (ListLanguages puts the
-        // name in TranslationPair.Code), which is what the prompt expects.
-        var systemPrompt = LlamaCppAdvancedProtocol.BuildSystemPrompt(sourceLanguageCode, targetLanguageCode, settings);
-        var userContent = LlamaCppAdvancedProtocol.BuildUserContent(history, lines);
-        var responseFormat = LlamaCppAdvancedProtocol.BuildResponseFormatJson(lines);
-
-        var map = new Dictionary<int, string>();
-        for (var attempt = 0; attempt < 2 && !cancellationToken.IsCancellationRequested; attempt++)
-        {
-            try
-            {
-                var reply = await client.ChatAsync(url, systemPrompt, userContent, responseFormat, cancellationToken);
-                map = LlamaCppAdvancedProtocol.ParseTranslations(reply);
-                if (IsComplete(map, lines))
-                {
-                    return map;
-                }
-
-                Error = reply;
-            }
-            catch (HttpRequestException)
-            {
-                Error = client.Error;
-                if (attempt == 1)
-                {
-                    throw;
-                }
-            }
-        }
-
-        cancellationToken.ThrowIfCancellationRequested();
-        return map;
-    }
-
-    /// <summary>
-    /// The rolling context: the last N already-translated rows immediately before the batch.
-    /// </summary>
-    private static List<LlamaCppAdvancedProtocol.HistoryPair> CollectHistory(ObservableCollection<TranslateRow> rows, int index)
-    {
-        var settings = Se.Settings.AutoTranslate.LlamaCppAdvanced;
-        var maxPairs = Math.Clamp(settings.HistoryPairs, 0, 50);
-        var history = new List<LlamaCppAdvancedProtocol.HistoryPair>(maxPairs);
-        for (var i = index - 1; i >= 0 && history.Count < maxPairs; i--)
-        {
-            if (!string.IsNullOrEmpty(rows[i].TranslatedText))
-            {
-                history.Add(new LlamaCppAdvancedProtocol.HistoryPair(rows[i].Text, rows[i].TranslatedText));
-            }
-        }
-
-        history.Reverse();
-        return history;
-    }
-
-    /// <summary>Every requested line number must be present, and non-empty for non-empty sources.</summary>
-    private static bool IsComplete(Dictionary<int, string> map, List<LlamaCppAdvancedProtocol.BatchLine> lines)
-    {
-        foreach (var line in lines)
-        {
-            if (!map.TryGetValue(line.Number, out var translation))
-            {
-                return false;
-            }
-
-            if (translation.Length == 0 && !string.IsNullOrWhiteSpace(line.Text) && lines.Count > 1)
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    public void Dispose()
-    {
-        _client?.Dispose();
+        return Configuration.Settings.Tools.LlamaCppApiUrl;
     }
 }

--- a/src/ui/Features/Translate/LlamaCppAdvanced/OllamaAdvancedTranslate.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/OllamaAdvancedTranslate.cs
@@ -1,0 +1,29 @@
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Translate.LlamaCppAdvanced;
+
+/// <summary>
+/// The advanced engine against Ollama's OpenAI-compatible endpoint
+/// (http://localhost:11434/v1/chat/completions - not the native /api/generate the classic
+/// Ollama engine uses). Ollama serves many models, so the "model" field is required. It ignores
+/// llama.cpp's cache_prompt (it manages its own KV cache) and recent versions accept
+/// response_format json_schema; older ones get the json_object/plain fallbacks.
+/// </summary>
+public class OllamaAdvancedTranslate : AdvancedTranslatorBase
+{
+    public static string StaticName { get; set; } = "Ollama advanced (local LLM)";
+    public override string ToString() => StaticName;
+    public override string Name => StaticName;
+    public override string Url => "https://ollama.com";
+
+    protected override string GetApiUrl()
+    {
+        return Se.Settings.AutoTranslate.OllamaAdvancedUrl;
+    }
+
+    protected override string? GetModel()
+    {
+        var model = Se.Settings.AutoTranslate.OllamaAdvancedModel;
+        return string.IsNullOrWhiteSpace(model) ? null : model.Trim();
+    }
+}

--- a/src/ui/Logic/Config/Language/Translate/LanguageTranslate.cs
+++ b/src/ui/Logic/Config/Language/Translate/LanguageTranslate.cs
@@ -29,6 +29,26 @@ public class LanguageTranslate
     public string TranslationCancelled { get; set; }
     public string SwapLanguages { get; set; }
     public string XIsAlreadyDownloadedReDownload { get; set; }
+    public string AdvancedDotDotDot { get; set; }
+    public string AdvancedSettings { get; set; }
+    public string AdvancedSettingsSubtitle { get; set; }
+    public string Context { get; set; }
+    public string Synopsis { get; set; }
+    public string SynopsisHint { get; set; }
+    public string Glossary { get; set; }
+    public string GlossaryHint { get; set; }
+    public string PreviousLinesAsContext { get; set; }
+    public string LinesPerBatch { get; set; }
+    public string KeepLineBreaks { get; set; }
+    public string SamplingParameters { get; set; }
+    public string MinusOneMeansDefault { get; set; }
+    public string Temperature { get; set; }
+    public string TopP { get; set; }
+    public string TopK { get; set; }
+    public string RepeatPenalty { get; set; }
+    public string MaxTokensPerReply { get; set; }
+    public string ServerContextSizeTokens { get; set; }
+    public string CustomPromptHint { get; set; }
 
     public LanguageTranslate()
     {
@@ -59,5 +79,25 @@ public class LanguageTranslate
         TranslationCancelled = "Translation cancelled";
         SwapLanguages = "Swap source and target languages";
         XIsAlreadyDownloadedReDownload = "{0} is already downloaded. Re-download?";
+        AdvancedDotDotDot = "Advanced...";
+        AdvancedSettings = "Advanced settings";
+        AdvancedSettingsSubtitle = "Batch, context and sampling options for the advanced llama.cpp engine";
+        Context = "Context";
+        Synopsis = "Synopsis";
+        SynopsisHint = "Optional description of the content (genre, setting, tone) - included in every request";
+        Glossary = "Glossary";
+        GlossaryHint = "One per line: source term = translation";
+        PreviousLinesAsContext = "Previous lines as context";
+        LinesPerBatch = "Lines per batch";
+        KeepLineBreaks = "Keep line breaks";
+        SamplingParameters = "Sampling parameters";
+        MinusOneMeansDefault = "-1 = model/server default";
+        Temperature = "Temperature";
+        TopP = "Top-p";
+        TopK = "Top-k";
+        RepeatPenalty = "Repeat penalty";
+        MaxTokensPerReply = "Max tokens per reply";
+        ServerContextSizeTokens = "Server context size (tokens)";
+        CustomPromptHint = "Custom instructions ({0} = source language, {1} = target language); empty = built-in prompt";
     }
 }

--- a/src/ui/Logic/Config/SeAutoTranslate.cs
+++ b/src/ui/Logic/Config/SeAutoTranslate.cs
@@ -33,6 +33,11 @@ public class SeAutoTranslate
     /// </summary>
     public bool LlamaCppUseRemoteServer { get; set; }
     public SeLlamaCppAdvanced LlamaCppAdvanced { get; set; } = new();
+
+    // The Ollama advanced engine uses Ollama's OpenAI-compatible endpoint, not the native
+    // /api/generate URL the classic Ollama engine stores in OllamaUrl.
+    public string OllamaAdvancedUrl { get; set; } = "http://localhost:11434/v1/chat/completions";
+    public string OllamaAdvancedModel { get; set; } = string.Empty;
     public string GroqUrl { get; set; }
     public string GroqPrompt { get; set; }
     public string GroqApiKey { get; set; }

--- a/src/ui/Logic/Config/SeAutoTranslate.cs
+++ b/src/ui/Logic/Config/SeAutoTranslate.cs
@@ -32,6 +32,7 @@ public class SeAutoTranslate
     /// (e.g. a GPU box) instead of downloading a model and managing a local server (#11584).
     /// </summary>
     public bool LlamaCppUseRemoteServer { get; set; }
+    public SeLlamaCppAdvanced LlamaCppAdvanced { get; set; } = new();
     public string GroqUrl { get; set; }
     public string GroqPrompt { get; set; }
     public string GroqApiKey { get; set; }

--- a/src/ui/Logic/Config/SeLlamaCppAdvanced.cs
+++ b/src/ui/Logic/Config/SeLlamaCppAdvanced.cs
@@ -1,0 +1,27 @@
+namespace Nikse.SubtitleEdit.Logic.Config;
+
+/// <summary>
+/// Settings for the "llama.cpp (advanced)" auto-translate engine: batch/context options plus
+/// sampling overrides. Sampling values of -1 mean "not set" and fall back to the curated
+/// model's recommended value, then to the server default.
+/// </summary>
+public class SeLlamaCppAdvanced
+{
+    public int BatchSize { get; set; } = 10;
+    public int HistoryPairs { get; set; } = 12;
+    public string Synopsis { get; set; } = string.Empty;
+    public string Glossary { get; set; } = string.Empty;
+    public string Formality { get; set; } = FormalityDefault;
+    public bool KeepLineBreaks { get; set; } = true;
+    public string Prompt { get; set; } = string.Empty;
+    public double Temperature { get; set; } = -1;
+    public double TopP { get; set; } = -1;
+    public int TopK { get; set; } = -1;
+    public double RepeatPenalty { get; set; } = -1;
+    public int MaxTokens { get; set; } = -1;
+    public int ContextSize { get; set; } = 16384;
+
+    public const string FormalityDefault = "Default";
+    public const string FormalityFormal = "Formal";
+    public const string FormalityInformal = "Informal";
+}


### PR DESCRIPTION
Towards #13003.

New **"llama.cpp advanced (local LLM)"** and **"Ollama advanced (local LLM)"** engines in the Auto-translate window, alongside the existing engines (llama.cpp variant shares the model list, downloads, server management and remote-server mode; Ollama variant shares the installed-model list and picker but talks to Ollama's OpenAI-compatible `/v1/chat/completions` endpoint).

### What they do
- Translate in **numbered batches** with a **rolling history** of already-translated lines, so terminology, pronouns and formality stay consistent across the file.
- Replies are **grammar-forced** via `response_format: json_schema` — llama-server compiles the schema to a grammar, so the reply always parses and every line number is present. Servers that reject it (older builds) fall back to `json_object`, then plain text.
- On an invalid reply the batch is retried once, then halved; single-line retries go history-free (translation-tuned models like TranslateGemma can echo history into a lone line).
- New **Advanced…** sub-window shared by both engines: synopsis, glossary (`term = translation` per line), history length, batch size, formality, keep-line-breaks, custom system prompt, temperature/top-p/top-k/repeat-penalty, max tokens, server context size. Settings are global (`Se.Settings.AutoTranslate.LlamaCppAdvanced`).
- The system prompt is ordered stable-parts-first and requests set `cache_prompt: true`, so llama-server reuses the KV prefix where the model architecture allows (issue #13003's prompt-caching point). Ollama ignores the field and manages its own cache.

### llama-server launch fixes (benefit OCR and AI review too)
- `-np 1` — llama-server defaults to **4 parallel slots**, silently splitting `-c` four ways: SE's `-c 8192` gave each request only 2048 usable tokens.
- `--swa-full` — sliding-window-attention models (Gemma, Qwen 3.5) otherwise lose prompt-cache reuse entirely (verified: an identical retry dropped from 318 evaluated tokens to 4).
- Context size is now per-caller; the advanced engine defaults to 16384.

### Defaults validated by live tests
EN→DA sweeps on Qwen 3.5 4B and TranslateGemma 4B (24-line dialogue with tags, line breaks and recurring terms): zero schema failures in all configs; temperature 0.7+ drifted terminology ("the Chief" became three different words), history 0 lost term consistency, batch 5 was slower with no quality gain. Defaults: **batch 10, history 12, temperature floor 0.2** (user/curated-model values take precedence). The Ollama path was verified against gemma3 via the OpenAI-compatible endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)