### PR TITLE
Refresh video position on frame mode change

### DIFF
--- a/src/ui/Forms/Main.cs
+++ b/src/ui/Forms/Main.cs
@@ -21457,6 +21457,12 @@ namespace Nikse.SubtitleEdit.Forms
                 toolStripButtonGetFrameRate.Visible = Configuration.Settings.General.ShowFrameRate;
             }
 
+            if (!timeUpDownVideoPosition.MaskedTextBox.Focused && !timeUpDownVideoPositionAdjust.MaskedTextBox.Focused)
+            {
+                timeUpDownVideoPosition.TimeCode = timeUpDownVideoPosition.TimeCode;
+                timeUpDownVideoPositionAdjust.TimeCode = timeUpDownVideoPositionAdjust.TimeCode;
+            }
+
             SaveSubtitleListviewIndices();
             SubtitleListview1.Fill(_subtitle, _subtitleOriginal);
             RestoreSubtitleListviewIndices();


### PR DESCRIPTION
Changing between ff and ms modes didn't change the timecode in the video position.

I made it change automatically only when it's not focused, because changing it while focused causes issues in setting the timecode.