### PR TITLE
Make ComboBox dropdowns follow the UI scale setting

### DIFF
--- a/src/ui/Logic/UiTheme.cs
+++ b/src/ui/Logic/UiTheme.cs
@@ -295,6 +295,17 @@ public static class UiTheme
         ltcMenuItemStyle.Setters.Add(new Setter(Layoutable.MinHeightProperty, 32.0));
         styles.Add(ltcMenuItemStyle);
 
+        // Scale ComboBox dropdown items too — the dropdown popup renders outside the
+        // LayoutTransformControl, so the window scale transform never reaches it (#13010).
+        // ComboBoxItems only ever appear inside that popup, so no LTC reset counterpart is
+        // needed. Skipped at 100% so windows with locally restyled combos keep their look.
+        if (Math.Abs(factor - 1.0) > 0.0001)
+        {
+            var comboBoxItemStyle = new Style(x => x.OfType<ComboBoxItem>());
+            comboBoxItemStyle.Setters.Add(new Setter(TemplatedControl.FontSizeProperty, 14.0 * factor));
+            styles.Add(comboBoxItemStyle);
+        }
+
         _layoutScaleMenuStyle = styles;
         Application.Current.Styles.Add(styles);
     }

--- a/tests/UI/Logic/ComboBoxDropDownScaleTests.cs
+++ b/tests/UI/Logic/ComboBoxDropDownScaleTests.cs
@@ -1,0 +1,70 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// ComboBox dropdown popups render outside the LayoutTransformControl that scales window
+/// content, so the UI scale setting never reached them (#13010). An app-level ComboBoxItem
+/// style now bakes in the scaled font size. At 100% no style is added at all, so windows
+/// that locally restyle their combos (e.g. the burn-in window's compact 12.5) keep their look.
+/// </summary>
+public class ComboBoxDropDownScaleTests
+{
+    private static ComboBoxItem FirstDropDownItem(double scaleFactor)
+    {
+        UiTheme.SetLayoutScale(scaleFactor);
+
+        var comboBox = new ComboBox { ItemsSource = new[] { "One", "Two" } };
+        var window = new Window { Content = comboBox, Width = 300, Height = 200 };
+        window.Show();
+        window.UpdateLayout();
+
+        comboBox.IsDropDownOpen = true;
+        AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+        Dispatcher.UIThread.RunJobs();
+
+        var item = (ComboBoxItem?)comboBox.ContainerFromIndex(0);
+        Assert.NotNull(item);
+        return item;
+    }
+
+    [AvaloniaTheory]
+    [InlineData(0.9)]
+    [InlineData(1.5)]
+    public void DropDownItems_FollowLayoutScale(double factor)
+    {
+        try
+        {
+            var item = FirstDropDownItem(factor);
+            Assert.Equal(14.0 * factor, item.FontSize, precision: 3);
+        }
+        finally
+        {
+            UiTheme.SetLayoutScale(1.0);
+        }
+    }
+
+    [AvaloniaFact]
+    public void DropDownItems_At100Percent_KeepInheritedFontSize()
+    {
+        try
+        {
+            var item = FirstDropDownItem(1.0);
+            var comboBox = (ComboBox)item.Parent!;
+
+            // No style override at 100%: items still inherit from the combo, so a window
+            // that locally shrinks its combos keeps matching dropdowns.
+            comboBox.FontSize = 12.5;
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal(12.5, item.FontSize, precision: 3);
+        }
+        finally
+        {
+            UiTheme.SetLayoutScale(1.0);
+        }
+    }
+}


### PR DESCRIPTION
Fixes the remaining part of #13010.

Dropdown menus already follow the UI scale on main (the popup `MenuItem` scale style landed after v5.1.0), but ComboBox dropdowns — e.g. format/encoding/frame rate in the toolbar — did not: the dropdown popup renders outside the `LayoutTransformControl` that scales window content, so its items stayed at the default size regardless of the UI scale setting.

This adds a scaled `ComboBoxItem` font-size style alongside the existing popup `MenuItem` scale style in `UiTheme.ApplyMenuScaleStyle`. `ComboBoxItem`s only ever appear inside the dropdown popup, so no `LayoutTransformControl` reset counterpart is needed. The style is skipped entirely at 100% scale so windows that locally restyle their combos (e.g. the burn-in window's compact 12.5 combos) keep their exact current look.

Headless tests cover both sides: dropdown items get `14 × factor` at 90%/150%, and at 100% items still inherit the combo's font size (no override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)