### PR TITLE
Help system: respect custom help shortcut, wire F1 in more windows, add five new help pages

### DIFF
--- a/docs/features/ai-assistant.md
+++ b/docs/features/ai-assistant.md
@@ -1,0 +1,31 @@
+# AI Assistant
+
+Get AI help with the current subtitle line — fix errors, shorten it to fit the reading speed, change the tone, or ask a free-form question about it.
+
+- **Open:** The robot button in the text editor's button row, or right-click the text box → **AI assistant**
+
+<!-- Screenshot: AI assistant window (ai-assistant.png, not yet taken) -->
+
+The assistant works on the **currently selected line only**. The three lines before and after are sent along as read-only context so the model understands the dialogue, but they are never changed.
+
+## Quick Actions
+
+- **Fix errors** — Correct spelling, grammar, and punctuation in the detected language without rephrasing; names, slang, formatting tags, and line breaks are kept
+- **Fit reading speed** — Rephrase the line shorter so it fits your maximum line length and characters/second settings, keeping the exact meaning
+- **More formal** / **More casual** — Rewrite the line's register while keeping the meaning, tags, and line breaks
+
+You can also type your own request in the **Ask** box — either an instruction ("split this into two sentences") or a question ("what does this idiom mean?").
+
+## Applying the Result
+
+The model's answer appears in the **Suggestion** box, where you can still edit it. Nothing changes until you press **Apply to line**. Applied changes go through the normal undo history. If the model produced hidden reasoning, an info button shows it.
+
+## Engines
+
+The assistant shares its engine configuration with [AI Review](ai-review.md) — changing it here changes it there too:
+
+- **llama.cpp** (default) — Fully local; pick a model from the download list, and Subtitle Edit manages the server. The gear button opens the llama.cpp engine settings
+- **Ollama** — Uses a running Ollama server (`http://localhost:11434` by default); the **...** button lists the models on your server
+- **OpenAI-compatible** — Any OpenAI-compatible endpoint: enter URL, model, and (if needed) API key
+
+The robot button can be hidden under Options → Settings → Appearance → **Text box: show AI assistant button**.

--- a/docs/features/auto-translate-advanced.md
+++ b/docs/features/auto-translate-advanced.md
@@ -1,0 +1,41 @@
+# Auto Translate: Advanced Local Engines
+
+The **llama.cpp advanced (local LLM)** and **Ollama advanced (local LLM)** engines translate in batches with surrounding context, a synopsis, and a glossary — giving more consistent names, pronouns, and terminology than line-by-line translation. This page covers their **Advanced...** settings dialog and the llama.cpp engine settings.
+
+See [Auto Translate](auto-translate.md) for the translation window itself.
+
+## Advanced Settings
+
+With an advanced engine selected, click **Advanced...** in the engine settings row.
+
+<!-- Screenshot: Advanced settings window (auto-translate-advanced.png, not yet taken) -->
+
+### Context
+
+- **Synopsis** — Optional description of the content (genre, setting, tone), included in every request so the model picks a fitting style
+- **Glossary** — Terms the model must translate a certain way, one per line: `source term = translation`
+- **Prompt text** — Custom system instructions replacing the built-in prompt (`{0}` = source language, `{1}` = target language); leave empty to use the built-in prompt
+- **Previous lines as context** — How many already-translated lines before the batch are sent as history for consistency (default 12)
+- **Lines per batch** — Subtitle lines per request (default 10). If the model returns an invalid reply, the batch is retried and then halved automatically
+- **Formality** — Default, Formal, or Informal; adds an instruction to use e.g. "Sie"/"vous"/"usted" or "du"/"tu"/"tú"
+- **Keep line breaks** — Ask the model to keep the same number of line breaks per line
+
+### Sampling Parameters
+
+`-1` means the model/server default is used.
+
+- **Temperature** — Randomness. When unset, Subtitle Edit uses the curated value for the model, or 0.2 — low temperatures keep terminology consistent across batches
+- **Top-p**, **Top-k**, **Repeat penalty** — Standard sampling options, passed through when set
+- **Max tokens per reply** — Response length cap; unset means no cap is sent
+- **Server context size (tokens)** — The context window for the locally started llama.cpp server (default 16384). Bigger batches, more history, and a long synopsis/glossary need more context. Only affects the local llama.cpp server; Ollama manages its own context
+
+## llama.cpp Engine Settings
+
+For the local llama.cpp engines, the gear button opens an info dialog about the bundled llama.cpp server build:
+
+- **Backend** — The detected build (e.g. CUDA, Vulkan, CPU, or Metal on macOS)
+- **Status** — Whether the pinned release is installed and up to date
+- **Release** — The llama.cpp release Subtitle Edit is pinned to
+- **Install folder** — Where the server binaries live
+
+Use **Download** / **Update** / **Re-download...** to (re)install the server build, for example after a graphics driver change. The same dialog is used by [AI Review](ai-review.md) and the [AI Assistant](ai-assistant.md).

--- a/docs/features/auto-translate.md
+++ b/docs/features/auto-translate.md
@@ -74,6 +74,8 @@ Depending on the selected engine, you may need to provide:
 - **API URL** — Custom endpoint URL (for self-hosted services)
 - **Model** — Specific model to use (for AI engines)
 
+The **llama.cpp advanced** and **Ollama advanced** engines translate in batches with context, synopsis, and glossary support — see [Advanced Local Engines](auto-translate-advanced.md).
+
 ## Translation Review
 
 The translation grid shows the original text alongside the translated text. You can edit individual translations before accepting them.

--- a/docs/features/binary-edit.md
+++ b/docs/features/binary-edit.md
@@ -1,0 +1,52 @@
+# Edit Image-based Subtitle
+
+Edit image-based subtitles — Blu-ray SUP, VobSub, DVB, BDN XML — directly, without OCR: adjust timing and position, resize, recolor, set forced flags, and export to a range of image-based formats.
+
+- **Menu:** File → Import → Image-based subtitle for edit...
+- **Also:** The **Edit/export...** button in the [OCR window](ocr.md) opens the loaded subtitle here
+- **Shortcut:** Configurable (no default)
+
+<!-- Screenshot: Edit image-based subtitle window (binary-edit.png, not yet taken) -->
+
+## Supported Files
+
+- Blu-ray SUP (`.sup`)
+- VobSub (`.sub` + `.idx`)
+- Transport stream (`.ts`) with DVB subtitles
+- Matroska (`.mkv`/`.mks`) with PGS, VobSub, or DVB tracks
+- BDN XML (`.xml`)
+
+## Window Layout
+
+The subtitle list shows the forced flag, number, start time, duration, and the image itself. Below it you can edit the selected line's show time, duration, X/Y position, and the screen size. Double-click a line to seek the video to it; Delete removes selected lines.
+
+The right panel toggles between:
+
+- **Video** — Video preview with the subtitle image overlaid at its real position; drag the image with the mouse to move it. A matching video file next to the subtitle is opened automatically
+- **Position map** — An overview of where all subtitles sit on screen, with clickable counts for lines in the picture, bottom bar, and top bar. Pick a letterbox aspect ratio (or a custom bar height) and a title-safe margin to check that positioned subtitles stay inside the bars
+
+## Tools
+
+From the Tools menu (all lines) or the right-click menu (selected lines):
+
+- **Alignment** / **Center horizontally** / **Top align** / **Bottom align** — Reposition using the margins from the window's Options → Settings
+- **Resize images...** — Scale the bitmaps by a percentage
+- **Crop images** — Trim transparent borders
+- **Adjust brightness...** / **Adjust alpha (transparency)...** / **Adjust color...** — Image corrections with live preview
+- **Adjust durations...** / **Apply duration limits...** — Same duration tools as for text subtitles
+- **Set text** — Replace a line's image with newly rendered text (font, colors, outline, shadow, box)
+- **Append subtitle...** — Append another image-based file, keeping its time codes or offsetting them
+- **Sort by start time**, **Toggle forced**, **Select forced/non-forced lines**, **Import time codes...**
+
+The Synchronization menu offers **Adjust all times**, **Change frame rate**, and **Change speed**.
+
+## Export
+
+There is no in-place save — use File → Export:
+
+- **Blu-ray (sup)**, **VobSub (sub/idx)**
+- **BDN/xml**, **DOST/png**, **Final Cut Pro + image**
+- **IMSC 1.1 image profile**, **WebVTT png**
+- **Images with HTML index**, **Images with time code**
+
+The **Export** button under the list saves the selected line's image as a PNG. Closing with unexported changes asks for confirmation.

--- a/docs/features/edit.md
+++ b/docs/features/edit.md
@@ -152,8 +152,7 @@ Select or deselect subtitle lines based on rules (e.g., text contains, duration,
 
 - **Menu:** Edit → Modify selection...
 
-<!-- Screenshot: Modify selection window -->
-![Modify Selection](../screenshots/modify-selection.png)
+See [Modify Selection](modify-selection.md) for the full list of rules and selection actions.
 
 ## Select All
 

--- a/docs/features/file.md
+++ b/docs/features/file.md
@@ -65,13 +65,9 @@ Import time codes from another subtitle file, applying them to the current text.
 
 ### Import plain text
 
-Import plain text and create subtitle lines from it.
+Import plain text and create subtitle lines from it, with optional forced-aligner timing against the video's audio.
 
-- Split by line breaks, sentence endings, or fixed length
-- Set duration and gap settings
-
-<!-- Screenshot: Import plain text window -->
-![Import Plain Text](../screenshots/import-plain-text.png)
+See [Import Plain Text](import-plain-text.md) for details.
 
 ### Import images
 

--- a/docs/features/import-plain-text.md
+++ b/docs/features/import-plain-text.md
@@ -1,0 +1,50 @@
+# Import Plain Text
+
+Turn a plain text file — or pasted text — into subtitle lines, with generated time codes. The time codes can then be aligned to the actual audio with a forced aligner or via speech to text.
+
+- **Menu:** File → Import → Plain text...
+- **Shortcut:** Configurable (no default)
+
+<!-- Screenshot: Import plain text window -->
+![Import Plain Text](../screenshots/import-plain-text.png)
+
+## Importing Text
+
+Paste or type text into the edit box, or click **Import...** to load a text file. Tick **Import from multiple text files (one file is one subtitle)** to switch to a file list where each file becomes one subtitle line — useful for batch workflows; `.txt` and `.rtf` files can also be dragged onto the list, and time codes embedded in file names are picked up automatically.
+
+## Options
+
+- **Split text at** — How the text is divided into subtitles:
+  - **Auto** — Splits into subtitles using your max line length and line count settings, breaking preferentially at sentence endings, then at commas and other pauses
+  - **Blank lines** — Each paragraph (text between blank lines) becomes one subtitle
+  - **One line is one subtitle**
+  - **Two lines are one subtitle**
+- **Gap (ms)** — Pause inserted between generated subtitles
+- **Use fixed duration** / **Fixed duration (ms)** — Give every subtitle the same duration instead of calculating it from text length
+
+Without fixed duration, each subtitle's duration is calculated from its text length using your optimal characters/second setting, clamped between the minimum and maximum display duration. Lines are laid out sequentially starting at zero.
+
+The preview grid updates as you change options and shows the resulting subtitles with their time codes.
+
+## Aligning Time Codes to the Audio
+
+Sequential time codes from text length are only a starting point. If you have the video, two buttons at the bottom can time the text against the actual speech:
+
+### Align time codes via forced aligner...
+
+A forced aligner matches the text you already have against the audio, without transcribing it first — this is fast and keeps your text exactly as written. Long videos are aligned in windowed chunks, so any length works.
+
+Setup dialog:
+
+- **Engine** — Uses the Crisp ASR engine; click **Download / update engine...** if it is not installed yet
+- **Aligner model** — Pick an alignment model. The wav2vec2 aligners are language-specific and small (~200–300 MB); the Canary CTC and Qwen3 forced aligner models are multilingual
+
+Missing models are downloaded automatically when you press OK. Progress is shown per window and line while aligning. If the script is longer than the speech in the video, the trailing lines cannot be aligned and a warning tells you how many lines were matched.
+
+### Align time codes via "Speech to text"...
+
+Runs normal [speech to text](speech-to-text.md) on the video, then matches your script against the transcript. Useful when the forced aligner does not support your language. Lines that cannot be matched get interpolated time codes.
+
+## OK / Result
+
+Pressing **OK** replaces the currently loaded subtitle with the imported lines. Save your current work first if you need it.

--- a/docs/features/modify-selection.md
+++ b/docs/features/modify-selection.md
@@ -1,0 +1,59 @@
+# Modify Selection
+
+Select or deselect subtitle lines based on rules — text content, duration, characters per second, gaps, line count, bookmarks, styles, actors, and more.
+
+- **Menu:** Edit → Modify selection...
+- **Shortcut:** Configurable (no default)
+
+<!-- Screenshot: Modify selection window -->
+![Modify Selection](../screenshots/modify-selection.png)
+
+## How It Works
+
+1. Pick a **rule** and, where relevant, enter a text or number to match against.
+2. Choose how the matches should affect the current selection (new/add/subtract/intersect).
+3. The preview list updates automatically and shows every matching line. All matches start checked — uncheck **Apply** on a row to leave that line out.
+4. Click **OK** to apply the selection in the subtitle grid.
+
+## Rules
+
+Text rules:
+
+- **Contains** — Text contains the entered string
+- **Starts with** — Text starts with the entered string
+- **Ends with** — Text ends with the entered string
+- **Not contains** — Text does not contain the entered string
+- **Regular expression** — Text matches the entered regex (case-insensitive; an invalid pattern matches nothing)
+- **All uppercase** — Text has letters and none of them are lowercase
+- **Blank lines** — Text is empty or whitespace only
+
+For **Contains**, **Starts with**, **Ends with**, **Not contains**, and **Bookmark contains**, a **Case sensitive** checkbox is shown. Text rules with an empty text box match nothing.
+
+Timing and length rules (the number box sets the threshold):
+
+- **Duration in ms <** / **Duration in ms >** — Display duration below/above the threshold
+- **CPS <** / **CPS >** — Characters per second below/above the threshold
+- **Single line max length <** / **Single line max length >** — Longest line in the subtitle below/above the threshold (defaults to the max-length setting)
+- **Pixel length >** — Rendered width in pixels above the threshold
+- **Gap in ms <** / **Gap in ms >** — Gap to the next subtitle below/above the threshold
+
+Structure rules:
+
+- **Odd number** / **Even number** — Line number is odd/even
+- **Exactly one line** / **Exactly two lines** / **More than two lines** — Number of text lines in the subtitle
+
+Metadata rules:
+
+- **Bookmarked** — Line has a bookmark
+- **Bookmark contains** — Bookmark text contains the entered string
+- **Style** — Line uses one of the checked styles (list built from the styles present in the file; ASSA subtitles)
+- **Actor** — Line has one of the checked actors
+
+## Selection Actions
+
+- **New selection** — Select only the matching lines
+- **Add to selection** — Keep the current selection and add the matches
+- **Subtract from selection** — Remove the matches from the current selection
+- **Intersect with selection** — Keep only currently selected lines that also match
+
+The rule, text, number, and selection mode are remembered between sessions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,11 +13,15 @@ Subtitle Edit is a free, open-source editor for video subtitles. This is the doc
 
 ### File Operations
 - [File Menu](features/file.md) — New, Open, Save, Import, Export
+- [Import Plain Text](features/import-plain-text.md) — Create subtitles from text, with forced-aligner timing
+- [Edit Image-based Subtitle](features/binary-edit.md) — Edit Blu-ray SUP/VobSub/DVB subtitles without OCR
 
 ### Editing
-- [Edit Menu](features/edit.md) — Find, Replace, Multiple Replace, Modify Selection, History
+- [Edit Menu](features/edit.md) — Find, Replace, Multiple Replace, History
+- [Modify Selection](features/modify-selection.md) — Select lines by rules: text, duration, CPS, gaps, styles, actors
 - [Subtitle Grid](features/subtitle-grid.md) — Working with the subtitle list/grid
 - [Text Editor](features/text-editor.md) — Editing subtitle text
+- [AI Assistant](features/ai-assistant.md) — AI help for the current line: fix errors, fit reading speed, change tone
 
 ### Tools
 - [AI Review](features/ai-review.md) — Proofread with a local LLM (llama.cpp, Ollama, or any OpenAI-compatible endpoint)
@@ -69,6 +73,7 @@ Subtitle Edit is a free, open-source editor for video subtitles. This is the doc
 
 ### Translation
 - [Auto Translate](features/auto-translate.md) — Automatic subtitle translation
+- [Auto Translate: Advanced Local Engines](features/auto-translate-advanced.md) — Batch/context settings for the llama.cpp and Ollama advanced engines
 - [Copy/Paste Translate](features/copy-paste-translate.md) — Translate via copy/paste workflow
 
 ### Spell Check

--- a/src/ui/Features/Assa/AssaApplyCustomOverrideTags/AssaApplyCustomOverrideTagsViewModel.cs
+++ b/src/ui/Features/Assa/AssaApplyCustomOverrideTags/AssaApplyCustomOverrideTagsViewModel.cs
@@ -317,6 +317,11 @@ public partial class AssaApplyCustomOverrideTagsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/assa-override-tags");
+        }
     }
 
     internal void ComboBoxParagraphsChanged(object? sender, SelectionChangedEventArgs e)

--- a/src/ui/Features/Edit/ModifySelection/ModifySelectionViewModel.cs
+++ b/src/ui/Features/Edit/ModifySelection/ModifySelectionViewModel.cs
@@ -198,6 +198,11 @@ public partial class ModifySelectionViewModel : ObservableObject, IClosingCleanu
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/modify-selection");
+        }
     }
 
     internal void Initialize(List<SubtitleLineViewModel> subtitleLineViewModels, List<SubtitleLineViewModel> selectedItems)

--- a/src/ui/Features/Files/ImportPlainText/ForcedAlignerSetup/ForcedAlignerSetupViewModel.cs
+++ b/src/ui/Features/Files/ImportPlainText/ForcedAlignerSetup/ForcedAlignerSetupViewModel.cs
@@ -185,5 +185,10 @@ public partial class ForcedAlignerSetupViewModel : ObservableObject
         {
             Cancel();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/import-plain-text", "align-time-codes-via-forced-aligner");
+        }
     }
 }

--- a/src/ui/Features/Files/ImportPlainText/ImportPlainTextViewModel.cs
+++ b/src/ui/Features/Files/ImportPlainText/ImportPlainTextViewModel.cs
@@ -618,6 +618,11 @@ public partial class ImportPlainTextViewModel : ObservableObject, IClosingCleanu
         {
             Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/import-plain-text");
+        }
     }
 
     internal void FileGridOnDragOver(object? sender, DragEventArgs e)

--- a/src/ui/Features/Main/AiAssistant/AiAssistantViewModel.cs
+++ b/src/ui/Features/Main/AiAssistant/AiAssistantViewModel.cs
@@ -491,6 +491,11 @@ public partial class AiAssistantViewModel : ObservableObject
             _cancellationTokenSource?.Cancel();
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/ai-assistant");
+        }
     }
 
     internal void OnClosing()

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1271,7 +1271,7 @@ public partial class MainViewModel :
     [RelayCommand]
     private async Task ShowHelp()
     {
-        UiUtil.ShowHelp("index");
+        UiUtil.ShowHelp("features/main-window");
     }
 
     [RelayCommand]

--- a/src/ui/Features/Options/Plugins/GetPluginsViewModel.cs
+++ b/src/ui/Features/Options/Plugins/GetPluginsViewModel.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Plugins;
 using System;
@@ -176,6 +177,11 @@ public partial class GetPluginsViewModel : ObservableObject
         {
             e.Handled = true;
             Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("plugin");
         }
     }
 }

--- a/src/ui/Features/Options/Plugins/PluginManagerViewModel.cs
+++ b/src/ui/Features/Options/Plugins/PluginManagerViewModel.cs
@@ -308,6 +308,11 @@ public partial class PluginManagerViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("plugin");
+        }
     }
 
     // Cancel an in-flight Update-All loop when the manager window closes — without

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -2434,6 +2434,13 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
+        if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/binary-edit");
+            return;
+        }
+
         // Handle shortcuts
         _shortcutManager.OnKeyPressed(this, e);
         if (_shortcutManager.GetActiveKeys().Count == 0)

--- a/src/ui/Features/Tools/MergeTwoSubtitles/MergeTwoSubtitlesViewModel.cs
+++ b/src/ui/Features/Tools/MergeTwoSubtitles/MergeTwoSubtitlesViewModel.cs
@@ -667,6 +667,11 @@ public partial class MergeTwoSubtitlesViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/merge-two-subtitles");
+        }
     }
 }
 

--- a/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsViewModel.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsViewModel.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
 namespace Nikse.SubtitleEdit.Features.Translate.LlamaCppAdvanced;
@@ -93,6 +94,11 @@ public partial class LlamaCppAdvancedSettingsViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/auto-translate-advanced");
         }
     }
 }

--- a/src/ui/Features/Translate/LlamaCppEngineSettings/LlamaCppEngineSettingsViewModel.cs
+++ b/src/ui/Features/Translate/LlamaCppEngineSettings/LlamaCppEngineSettingsViewModel.cs
@@ -7,6 +7,7 @@ using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.Logic.LlamaCpp;
@@ -186,6 +187,11 @@ public partial class LlamaCppEngineSettingsViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/auto-translate-advanced", "llamacpp-engine-settings");
         }
     }
 }

--- a/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
+++ b/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
@@ -800,7 +800,7 @@ public partial class CutVideoViewModel : ObservableObject
                 _ = Cancel();
                 return;
             }
-            else if (keyEventArgs.Key == Key.F1)
+            else if (UiUtil.IsHelp(keyEventArgs))
             {
                 keyEventArgs.Handled = true;
                 UiUtil.ShowHelp("features/cut-video");

--- a/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
@@ -1104,7 +1104,7 @@ public partial class VideoOcrViewModel : ObservableObject
             e.Handled = true;
             _ = Cancel();
         }
-        else if (e.Key == Key.F1)
+        else if (UiUtil.IsHelp(e))
         {
             e.Handled = true;
             UiUtil.ShowHelp("features/video-ocr");

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -3298,7 +3298,45 @@ public static class UiUtil
 
     internal static bool IsHelp(KeyEventArgs e)
     {
-        return e.Key == Key.F1;
+        var shortcut = Se.Settings.Shortcuts.FirstOrDefault(s =>
+            s.ActionName == nameof(Features.Main.MainViewModel.ShowHelpCommand) && s.Keys.Count > 0);
+        if (shortcut == null)
+        {
+            return e.Key == Key.F1;
+        }
+
+        var requiredModifiers = KeyModifiers.None;
+        string? keyName = null;
+        foreach (var token in shortcut.Keys)
+        {
+            switch (ShortcutManager.NormalizeKeyToken(token))
+            {
+                case "Control":
+                    requiredModifiers |= KeyModifiers.Control;
+                    break;
+                case "Alt":
+                    requiredModifiers |= KeyModifiers.Alt;
+                    break;
+                case "Shift":
+                    requiredModifiers |= KeyModifiers.Shift;
+                    break;
+                case "Win":
+                    requiredModifiers |= KeyModifiers.Meta;
+                    break;
+                default:
+                    keyName = token;
+                    break;
+            }
+        }
+
+        // A modifier-only binding can never match a key press.
+        if (keyName == null)
+        {
+            return false;
+        }
+
+        return e.KeyModifiers == requiredModifiers &&
+               string.Equals(ShortcutManager.GetShortcutKey(e).ToString(), keyName, StringComparison.OrdinalIgnoreCase);
     }
 
     internal static bool TryHandleWindowSystemMenu(KeyEventArgs e, Window? window)


### PR DESCRIPTION
## Summary

Follow-up to a help-system audit: every \`ShowHelp\` call site mapped to an existing docs page, but several windows with docs had no way to reach them, the custom help shortcut only worked in the main window, and five significant features had no help page at all.

### Fixes
- **\`UiUtil.IsHelp\` now respects the configured help shortcut** (\`ShowHelpCommand\`, default F1) instead of hardcoding F1 — previously a remapped help key silently did nothing in every dialog. Falls back to F1 when unset.
- CutVideo/VideoOcr used raw \`Key.F1\` checks; now use \`UiUtil.IsHelp\`.
- Wired the help key in windows that had a docs page but no way to open it: **Merge two subtitles**, **ASSA apply custom override tags**, **Plugin manager**, **Get plugins**.
- Main window help now opens \`features/main-window\` instead of the docs index.

### New help pages (docs + F1 wiring)
- \`features/binary-edit\` — Edit image-based subtitle (Blu-ray SUP/VobSub/DVB/BDN XML)
- \`features/import-plain-text\` — incl. forced aligner and align-via-STT (also wired in the forced-aligner setup dialog)
- \`features/ai-assistant\` — the per-line AI assistant
- \`features/modify-selection\` — full rule list (stub in \`edit.md\` now links here)
- \`features/auto-translate-advanced\` — llama.cpp/Ollama advanced engine settings + llama.cpp engine settings dialog (deep-linked section)

All new pages are listed in the docs index; image tags reference only screenshots that exist (missing ones left as comments).

## Test plan
- \`dotnet build\` clean; UI test suite: 989 passed.
- Manual: F1 in the new/fixed windows opens the right page; remapping the help shortcut works in dialogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)