### PR TITLE
TableView sweep batch 1: header-click sorter + 21 non-sorting dialog grids

### DIFF
--- a/src/ui/Features/Files/Compare/CompareViewModel.cs
+++ b/src/ui/Features/Files/Compare/CompareViewModel.cs
@@ -43,8 +43,8 @@ public partial class CompareViewModel : ObservableObject
 
     public Window? Window { get; internal set; }
     public bool OkPressed { get; private set; }
-    public DataGrid? LeftDataGrid { get; set; } = new();
-    public DataGrid? RightDataGrid { get; set; } = new();
+    public TableView? LeftGrid { get; set; } = new();
+    public TableView? RightGrid { get; set; } = new();
 
     private IFileHelper _fileHelper;
     private IFolderHelper _folderHelper;
@@ -109,7 +109,7 @@ public partial class CompareViewModel : ObservableObject
         AddColoringAndCountDifferences();
         SetTextStackPanels();
         IsExportVisible = LeftSubtitles.Count > 0 && RightSubtitles.Count > 0;
-        SelectAndScrollToRow(LeftDataGrid, 0);
+        SelectAndScrollToRow(LeftGrid, 0);
     }
 
     private void SetTextStackPanels()
@@ -639,7 +639,7 @@ public partial class CompareViewModel : ObservableObject
             idx--;
             if (LeftSubtitles[idx].HasDifference)
             {
-                SelectAndScrollToRow(LeftDataGrid, idx);
+                SelectAndScrollToRow(LeftGrid, idx);
                 return;
             }
         }
@@ -665,7 +665,7 @@ public partial class CompareViewModel : ObservableObject
             idx++;
             if (LeftSubtitles[idx].HasDifference)
             {
-                SelectAndScrollToRow(LeftDataGrid, idx);
+                SelectAndScrollToRow(LeftGrid, idx);
                 return;
             }
         }
@@ -855,7 +855,7 @@ public partial class CompareViewModel : ObservableObject
         }
     }
 
-    internal void LeftDataGridSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    internal void LeftGridSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
         if (e.AddedItems.Count == 0)
         {
@@ -871,11 +871,11 @@ public partial class CompareViewModel : ObservableObject
         var idx = LeftSubtitles.IndexOf(selection);
         Dispatcher.UIThread.Post(() =>
         {
-            SelectAndScrollToRow(RightDataGrid, idx);
+            SelectAndScrollToRow(RightGrid, idx);
         });
     }
 
-    internal void RightDataGridSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    internal void RightGridSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
         if (e.AddedItems.Count == 0)
         {
@@ -891,25 +891,28 @@ public partial class CompareViewModel : ObservableObject
         var idx = RightSubtitles.IndexOf(selection);
         Dispatcher.UIThread.Post(() =>
         {
-            SelectAndScrollToRow(LeftDataGrid, idx);
+            SelectAndScrollToRow(LeftGrid, idx);
         });
     }
 
-    private void SelectAndScrollToRow(DataGrid? datagrid, int index)
+    private void SelectAndScrollToRow(TableView? tableView, int index)
     {
-        if (index < 0 || datagrid == null)
+        if (index < 0 || tableView == null)
         {
             return;
         }
 
         Dispatcher.UIThread.Post(() =>
         {
-            if (datagrid.SelectedIndex != index)
+            if (tableView.SelectedIndex != index)
             {
-                datagrid.SelectedIndex = index;
+                tableView.SelectedIndex = index;
             }
 
-            datagrid.ScrollIntoView(datagrid.SelectedItem, null);
+            if (tableView.SelectedItem is { } item)
+            {
+                tableView.ScrollIntoView(item);
+            }
         });
     }
 

--- a/src/ui/Features/Files/Compare/CompareWindow.cs
+++ b/src/ui/Features/Files/Compare/CompareWindow.cs
@@ -140,12 +140,12 @@ public class CompareWindow : Window
         Activated += delegate { Dispatcher.UIThread.Post(() => buttonOk.Focus()); }; // hack to make OnKeyDown work
         KeyDown += vm.KeyDown;
 
-        vm.LeftDataGrid = (leftView.Child as Border)?.Child as DataGrid;
-        vm.RightDataGrid = (rightView.Child as Border)?.Child as DataGrid;
-        if (vm.LeftDataGrid != null && vm.RightDataGrid != null)
+        vm.LeftGrid = (leftView.Child as Border)?.Child as TableView;
+        vm.RightGrid = (rightView.Child as Border)?.Child as TableView;
+        if (vm.LeftGrid != null && vm.RightGrid != null)
         {
-            vm.LeftDataGrid.SelectionChanged += vm.LeftDataGridSelectionChanged;
-            vm.RightDataGrid.SelectionChanged += vm.RightDataGridSelectionChanged;
+            vm.LeftGrid.SelectionChanged += vm.LeftGridSelectionChanged;
+            vm.RightGrid.SelectionChanged += vm.RightGridSelectionChanged;
         }
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };
@@ -190,22 +190,18 @@ public class CompareWindow : Window
 
     private static Border MakeSubtitlesView(ObservableCollection<CompareItem> items, string selectedBinding, Delegate fileGridOnDragOver, Delegate fileGridOnDrop)
     {
-        var dg = new DataGrid
-        {
-            ItemsSource = items,
-            CanUserSortColumns = false,
-            IsReadOnly = true,
-            SelectionMode = DataGridSelectionMode.Single,
-            Height = double.NaN,
-            Margin = new Thickness(2)
-        };
+        var dg = TableViewExtras.MakeTableView(multiSelect: false);
+        dg.ItemsSource = items;
+        dg.Height = double.NaN;
+        dg.Margin = new Thickness(2);
 
         // Number column
-        dg.Columns.Add(new DataGridTemplateColumn
+        dg.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.NumberSymbol,
-            Width = new DataGridLength(50),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(50),
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
             CellTemplate = new FuncDataTemplate<CompareItem>((item, ns) =>
             {
                 var border = new Border
@@ -226,11 +222,12 @@ public class CompareWindow : Window
         });
 
         // StartTime column
-        dg.Columns.Add(new DataGridTemplateColumn
+        dg.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Show,
-            Width = new DataGridLength(120),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(120),
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
             CellTemplate = new FuncDataTemplate<CompareItem>((item, ns) =>
             {
                 var border = new Border
@@ -251,11 +248,12 @@ public class CompareWindow : Window
         });
 
         // EndTime column
-        dg.Columns.Add(new DataGridTemplateColumn
+        dg.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Hide,
-            Width = new DataGridLength(120),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(120),
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
             CellTemplate = new FuncDataTemplate<CompareItem>((item, ns) =>
             {
                 var border = new Border
@@ -276,11 +274,12 @@ public class CompareWindow : Window
         });
 
         // Text column
-        dg.Columns.Add(new DataGridTemplateColumn
+        dg.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Text,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Star),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(1, GridUnitType.Star),
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
             CellTemplate = new FuncDataTemplate<CompareItem>((item, ns) =>
             {
                 var border = new Border
@@ -301,12 +300,12 @@ public class CompareWindow : Window
             })
         });
 
-        dg.Bind(DataGrid.SelectedItemProperty, new Binding(selectedBinding)
+        dg.Bind(TableView.SelectedItemProperty, new Binding(selectedBinding)
         {
             Mode = BindingMode.TwoWay
         });
 
-        // hack to make drag and drop work on the DataGrid - also on empty rows
+        // hack to make drag and drop work on the grid - also on empty rows
         var dropHost = new Border
         {
             Background = Brushes.Transparent,

--- a/src/ui/Features/Files/ExportCustomTextFormat/ExportCustomTextFormatWindow.cs
+++ b/src/ui/Features/Files/ExportCustomTextFormat/ExportCustomTextFormatWindow.cs
@@ -86,34 +86,34 @@ public class ExportCustomTextFormatWindow : Window
 
         grid.Add(UiUtil.MakeLabel(Se.Language.File.Export.CustomTextFormats), 0);
 
-        var dataGrid = new DataGrid
-        {
-            Height = double.NaN, // auto size inside scroll viewer
-            Margin = new Thickness(2),
-            ItemsSource = vm.CustomFormats, // Use ItemsSource instead of Items
-            CanUserSortColumns = false,
-            IsReadOnly = true,
-            SelectionMode = DataGridSelectionMode.Extended,
-            DataContext = vm,
-        };
+        var dataGrid = TableViewExtras.MakeTableView();
+        dataGrid.Height = double.NaN; // auto size inside scroll viewer
+        dataGrid.Margin = new Thickness(2);
+        dataGrid.ItemsSource = vm.CustomFormats;
+        dataGrid.DataContext = vm;
 
         dataGrid.DoubleTapped += vm.OnCustomFormatGridDoubleTapped;
 
         // Columns
-        dataGrid.Columns.Add(new DataGridTextColumn
+        // The DataGrid sized the name column to content (Auto); TableView treats Auto
+        // as star, so use a fixed width that fits typical format names.
+        dataGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Name,
             Binding = new Binding(nameof(CustomFormatItem.Name)),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(140),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
-        dataGrid.Columns.Add(new DataGridTextColumn
+        dataGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Text,
             Binding = new Binding(nameof(CustomFormatItem.FormatParagraph)),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Star) // star sizing to take all available space
+            Width = new GridLength(1, GridUnitType.Star), // star sizing to take all available space
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
-        dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedCustomFormat))
+        dataGrid.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedCustomFormat))
         {
             Source = vm,
             Mode = BindingMode.TwoWay
@@ -130,7 +130,11 @@ public class ExportCustomTextFormatWindow : Window
             {
                 var target = e.Key == Key.Home ? items[0] : items[^1];
                 dataGrid.SelectedItem = target;
-                dataGrid.ScrollIntoView(target, null);
+                if (target is { } scrollTarget)
+                {
+                    dataGrid.ScrollIntoView(scrollTarget);
+                }
+
                 e.Handled = true;
             }
         }, Avalonia.Interactivity.RoutingStrategies.Tunnel);

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
@@ -107,7 +107,7 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
-    public DataGrid SubtitleGrid { get; set; }
+    public TableView SubtitleGrid { get; set; }
 
     private List<SubtitleLineViewModel>? _selectedSubtitles;
     private bool _dirty;
@@ -162,7 +162,7 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
         SelectedContentAlignment = ContentAlignments[0];
         LineSpacings = new ObservableCollection<int>(Enumerable.Range(-50, 501));
         SelectedLineSpacing = 0;
-        SubtitleGrid = new DataGrid();
+        SubtitleGrid = new TableView();
         Title = string.Empty;
         BitmapPreview = new SKBitmap(1, 1, false).ToAvaloniaBitmap();
         OutlineColor = Colors.Black;

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
@@ -111,16 +111,11 @@ public class ExportImageBasedWindow : Window
 
     private Border MakeSubtitlesView(ExportImageBasedViewModel vm)
     {
-        vm.SubtitleGrid = new DataGrid
-        {
-            Height = double.NaN, // auto size inside scroll viewer
-            Margin = new Thickness(2),
-            ItemsSource = vm.Subtitles, // Use ItemsSource instead of Items
-            CanUserSortColumns = false,
-            IsReadOnly = true,
-            SelectionMode = DataGridSelectionMode.Extended,
-            DataContext = vm.Subtitles,
-        };
+        vm.SubtitleGrid = TableViewExtras.MakeTableView();
+        vm.SubtitleGrid.Height = double.NaN; // auto size inside scroll viewer
+        vm.SubtitleGrid.Margin = new Thickness(2);
+        vm.SubtitleGrid.ItemsSource = vm.Subtitles;
+        vm.SubtitleGrid.DataContext = vm.Subtitles;
 
         //   vm.SubtitleGrid.DoubleTapped += vm.OnSubtitleGridDoubleTapped;
 
@@ -128,33 +123,39 @@ public class ExportImageBasedWindow : Window
         var shortTimeConverter = new TimeSpanToDisplayShortConverter();
 
         // Columns
-        vm.SubtitleGrid.Columns.Add(new DataGridTextColumn
+        vm.SubtitleGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.NumberSymbol,
             Binding = new Binding(nameof(SubtitleLineViewModel.Number)),
-            Width = new DataGridLength(50),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(50),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
-        vm.SubtitleGrid.Columns.Add(new DataGridTextColumn
+        vm.SubtitleGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Show,
             Binding = new Binding(nameof(SubtitleLineViewModel.StartTime)) { Converter = fullTimeConverter },
-            Width = new DataGridLength(120),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(120),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
-        vm.SubtitleGrid.Columns.Add(new DataGridTextColumn
+        vm.SubtitleGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Hide,
             Binding = new Binding(nameof(SubtitleLineViewModel.EndTime)) { Converter = fullTimeConverter },
-            Width = new DataGridLength(120),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(120),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
 
-        vm.SubtitleGrid.Columns.Add(new DataGridTemplateColumn
+        // The DataGrid sized this column to content (Auto); TableView treats Auto as
+        // star, so use a fixed width that fits the short duration format.
+        vm.SubtitleGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Duration,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(90),
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
             CellTemplate = new FuncDataTemplate<SubtitleLineViewModel>((value, nameScope) =>
             {
                 var border = new Border
@@ -175,11 +176,12 @@ public class ExportImageBasedWindow : Window
             })
         });
 
-        vm.SubtitleGrid.Columns.Add(new DataGridTemplateColumn
+        vm.SubtitleGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Text,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Star),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(1, GridUnitType.Star),
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
             CellTemplate = new FuncDataTemplate<SubtitleLineViewModel>((value, nameScope) =>
             {
                 var border = new Border
@@ -201,7 +203,7 @@ public class ExportImageBasedWindow : Window
         });
 
         vm.SubtitleGrid.DataContext = vm.Subtitles;
-        vm.SubtitleGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle))
+        vm.SubtitleGrid.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle))
         {
             Source = vm,
             Mode = BindingMode.TwoWay

--- a/src/ui/Features/Files/ImportCsvXlsxCustomColumns/ImportCsvXlsxCustomColumnsWindow.cs
+++ b/src/ui/Features/Files/ImportCsvXlsxCustomColumns/ImportCsvXlsxCustomColumnsWindow.cs
@@ -13,8 +13,8 @@ namespace Nikse.SubtitleEdit.Features.Files.ImportCsvXlsxCustomColumns;
 
 public class ImportCsvXlsxCustomColumnsWindow : Window
 {
-    private readonly DataGrid _dataGrid;
-    private readonly DataGrid _previewGrid;
+    private readonly TableView _sourceGrid;
+    private readonly TableView _previewGrid;
 
     public ImportCsvXlsxCustomColumnsWindow(ImportCsvXlsxCustomColumnsViewModel vm)
     {
@@ -40,34 +40,17 @@ public class ImportCsvXlsxCustomColumnsWindow : Window
             Spacing = 10,
         };
 
-        _dataGrid = new DataGrid
-        {
-            AutoGenerateColumns = false,
-            SelectionMode = DataGridSelectionMode.Single,
-            CanUserResizeColumns = true,
-            CanUserSortColumns = false,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Stretch,
-            Width = double.NaN,
-            Height = double.NaN,
-            HeadersVisibility = DataGridHeadersVisibility.Column,
-            DataContext = vm,
-            ItemsSource = vm.Rows,
-        };
+        _sourceGrid = TableViewExtras.MakeTableView(multiSelect: false);
+        _sourceGrid.Width = double.NaN;
+        _sourceGrid.Height = double.NaN;
+        _sourceGrid.DataContext = vm;
+        _sourceGrid.ItemsSource = vm.Rows;
 
-        _previewGrid = new DataGrid
-        {
-            AutoGenerateColumns = false,
-            SelectionMode = DataGridSelectionMode.Single,
-            CanUserResizeColumns = true,
-            CanUserSortColumns = false,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Stretch,
-            Width = double.NaN,
-            Height = double.NaN,
-            DataContext = vm,
-            ItemsSource = vm.PreviewSubtitles,
-        };
+        _previewGrid = TableViewExtras.MakeTableView(multiSelect: false);
+        _previewGrid.Width = double.NaN;
+        _previewGrid.Height = double.NaN;
+        _previewGrid.DataContext = vm;
+        _previewGrid.ItemsSource = vm.PreviewSubtitles;
         BuildPreviewColumns(_previewGrid);
 
         var labelPreview = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.PreviewCount)).WithAlignmentTop();
@@ -107,7 +90,7 @@ public class ImportCsvXlsxCustomColumnsWindow : Window
         };
 
         grid.Add(topPanel, 0);
-        grid.Add(UiUtil.MakeBorderForControlNoPadding(_dataGrid), 1);
+        grid.Add(UiUtil.MakeBorderForControlNoPadding(_sourceGrid), 1);
         grid.Add(splitter, 2);
         grid.Add(labelPreview, 3);
         grid.Add(UiUtil.MakeBorderForControlNoPadding(_previewGrid), 4);
@@ -122,20 +105,23 @@ public class ImportCsvXlsxCustomColumnsWindow : Window
 
     private void RebuildSourceGridColumns(ImportCsvXlsxCustomColumnsViewModel vm)
     {
-        _dataGrid.Columns.Clear();
+        _sourceGrid.Columns.Clear();
 
         for (var i = 0; i < vm.Columns.Count; i++)
         {
             var def = vm.Columns[i];
-            var column = new DataGridTextColumn
+
+            // The DataGrid sized these columns to content (Auto); TableView treats Auto
+            // as star, so use a fixed width that fits the role ComboBox in the header.
+            var column = new SeTableViewColumn
             {
                 Header = MakeColumnHeader(def),
-                CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+                CellTheme = UiUtil.TableViewCellTheme,
+                HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
                 Binding = new Binding($"Cells[{i}]"),
-                IsReadOnly = true,
-                Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
+                Width = new GridLength(140),
             };
-            _dataGrid.Columns.Add(column);
+            _sourceGrid.Columns.Add(column);
         }
     }
 
@@ -184,57 +170,59 @@ public class ImportCsvXlsxCustomColumnsWindow : Window
         };
     }
 
-    private static void BuildPreviewColumns(DataGrid grid)
+    private static void BuildPreviewColumns(TableView grid)
     {
+        // The DataGrid sized these columns to content (Auto); TableView treats Auto as
+        // star, so the narrow columns get fixed widths and Text stays the star column.
         var fullTimeConverter = new TimeSpanToDisplayFullConverter();
         var shortTimeConverter = new TimeSpanToDisplayShortConverter();
-        grid.Columns.Add(new DataGridTextColumn
+        grid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.NumberSymbol,
-            CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
             Binding = new Binding(nameof(SubtitleLineViewModel.Number)),
-            IsReadOnly = true,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
+            Width = new GridLength(50),
         });
-        grid.Columns.Add(new DataGridTextColumn
+        grid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Show,
-            CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
             Binding = new Binding(nameof(SubtitleLineViewModel.StartTime)) { Converter = fullTimeConverter, Mode = BindingMode.OneWay },
-            IsReadOnly = true,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
+            Width = new GridLength(120),
         });
-        grid.Columns.Add(new DataGridTextColumn
+        grid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Hide,
-            CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
             Binding = new Binding(nameof(SubtitleLineViewModel.EndTime)) { Converter = fullTimeConverter, Mode = BindingMode.OneWay },
-            IsReadOnly = true,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
+            Width = new GridLength(120),
         });
-        grid.Columns.Add(new DataGridTextColumn
+        grid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Duration,
-            CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
             Binding = new Binding(nameof(SubtitleLineViewModel.Duration)) { Converter = shortTimeConverter, Mode = BindingMode.OneWay },
-            IsReadOnly = true,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
+            Width = new GridLength(90),
         });
-        grid.Columns.Add(new DataGridTextColumn
+        grid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Actor,
-            CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
             Binding = new Binding(nameof(SubtitleLineViewModel.Actor)),
-            IsReadOnly = true,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
+            Width = new GridLength(120),
         });
-        grid.Columns.Add(new DataGridTextColumn
+        grid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Text,
-            CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
             Binding = new Binding(nameof(SubtitleLineViewModel.Text)),
-            IsReadOnly = true,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Star),
+            Width = new GridLength(1, GridUnitType.Star),
         });
     }
 

--- a/src/ui/Features/Files/RestoreAutoBackup/RestoreAutoBackupViewModel.cs
+++ b/src/ui/Features/Files/RestoreAutoBackup/RestoreAutoBackupViewModel.cs
@@ -169,7 +169,7 @@ public partial class RestoreAutoBackupViewModel : ObservableObject
         }
     }
 
-    public void DataGridSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    public void GridSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
         IsOkButtonEnabled = e.AddedItems.Count > 0;
     }

--- a/src/ui/Features/Files/RestoreAutoBackup/RestoreAutoBackupWindow.cs
+++ b/src/ui/Features/Files/RestoreAutoBackup/RestoreAutoBackupWindow.cs
@@ -23,34 +23,37 @@ public class RestoreAutoBackupWindow : Window
         vm.Window = this;
         DataContext = vm;
 
-        var dataGrid = new DataGrid
+        var dataGrid = TableViewExtras.MakeTableView(multiSelect: false);
+        dataGrid.Width = double.NaN;
+        dataGrid.Height = double.NaN;
+        dataGrid.DataContext = vm;
+
+        // The DataGrid sized these columns to content (Auto); TableView treats Auto as
+        // star, so the narrow columns get fixed widths and the file name is the star column.
+        dataGrid.Columns.AddRange(new[]
         {
-            Width = double.NaN,
-            Height = double.NaN,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Stretch,
-            SelectionMode = DataGridSelectionMode.Single,
-            IsReadOnly = true,
-            DataContext = vm,
-            AutoGenerateColumns = false,
-            Columns =
-            {
-                new DataGridTextColumn
+                new SeTableViewColumn
                 {
                     Header = Se.Language.General.DateAndTime,
                     Binding = new Binding(nameof(DisplayFile.DateAndTime)),
-                    CellTheme = UiUtil.DataGridNoBorderCellTheme,
+                    Width = new GridLength(160),
+                    CellTheme = UiUtil.TableViewCellTheme,
+                    HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
                 },
-                new DataGridTextColumn
+                new SeTableViewColumn
                 {
                     Header = Se.Language.General.FileName,
                     Binding = new Binding(nameof(DisplayFile.FileName)),
-                    CellTheme = UiUtil.DataGridNoBorderCellTheme,
+                    Width = new GridLength(1, GridUnitType.Star),
+                    CellTheme = UiUtil.TableViewCellTheme,
+                    HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
                 },
-                new DataGridTemplateColumn
+                new SeTableViewColumn
                 {
                     Header = Se.Language.General.FileExtension,
-                    CellTheme = UiUtil.DataGridNoBorderCellTheme,
+                    Width = new GridLength(110),
+                    CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+                    HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
                     CellTemplate = new FuncDataTemplate<DisplayFile>((item, _) =>
                     {
                         if (item == null)
@@ -80,20 +83,20 @@ public class RestoreAutoBackupWindow : Window
                             },
                         };
                     }),
-                    Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
                 },
-                new DataGridTextColumn
+                new SeTableViewColumn
                 {
                     Header = Se.Language.General.Size,
                     Binding = new Binding(nameof(DisplayFile.Size)),
-                    CellTheme = UiUtil.DataGridNoBorderCellTheme,
+                    Width = new GridLength(90),
+                    CellTheme = UiUtil.TableViewCellTheme,
+                    HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
                 }
-            }
-        };
+        });
 
-        dataGrid.Bind(DataGrid.ItemsSourceProperty, new Binding(nameof(vm.Files)));
-        dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedFile)));
-        dataGrid.SelectionChanged += vm.DataGridSelectionChanged;
+        dataGrid.Bind(TableView.ItemsSourceProperty, new Binding(nameof(vm.Files)));
+        dataGrid.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedFile)));
+        dataGrid.SelectionChanged += vm.GridSelectionChanged;
 
         var linkOpenFolder = UiUtil.MakeLink(Se.Language.File.RestoreAutoBackup.OpenAutoBackupFolder, vm.OpenFolderCommand);
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -69,7 +69,7 @@ public partial class BinaryEditViewModel : ObservableObject
 
     public Window? Window { get; set; }
     public Menu? Menu { get; set; }
-    public DataGrid? SubtitleGrid { get; set; }
+    public TableView? SubtitleGrid { get; set; }
     public VideoPlayerControl? VideoPlayerControl { get; set; }
     public Image? SubtitleOverlayImage { get; set; }
     public Border? VideoContentBorder { get; set; }
@@ -1849,10 +1849,10 @@ public partial class BinaryEditViewModel : ObservableObject
         {
             Dispatcher.UIThread.Post(() =>
             {
-                if (SubtitleGrid == null || selectedItems == null) return;
-                SubtitleGrid.SelectedItems.Clear();
+                if (SubtitleGrid?.SelectedItems is not { } gridSelection || selectedItems == null) return;
+                gridSelection.Clear();
                 foreach (var item in selectedItems)
-                    SubtitleGrid.SelectedItems.Add(item);
+                    gridSelection.Add(item);
             });
         }
 
@@ -1922,10 +1922,10 @@ public partial class BinaryEditViewModel : ObservableObject
         {
             Dispatcher.UIThread.Post(() =>
             {
-                if (SubtitleGrid == null || selectedItems == null) return;
-                SubtitleGrid.SelectedItems.Clear();
+                if (SubtitleGrid?.SelectedItems is not { } gridSelection || selectedItems == null) return;
+                gridSelection.Clear();
                 foreach (var item in selectedItems)
-                    SubtitleGrid.SelectedItems.Add(item);
+                    gridSelection.Add(item);
             });
         }
 
@@ -2064,7 +2064,7 @@ public partial class BinaryEditViewModel : ObservableObject
     [RelayCommand]
     private void InsertBefore()
     {
-        if (Window == null || SubtitleGrid?.SelectedItems.Count != 1)
+        if (Window == null || SubtitleGrid?.SelectedItems?.Count != 1)
         {
             return;
         }
@@ -2087,7 +2087,7 @@ public partial class BinaryEditViewModel : ObservableObject
     [RelayCommand]
     private void InsertAfter()
     {
-        if (Window == null || SubtitleGrid?.SelectedItems.Count != 1)
+        if (Window == null || SubtitleGrid?.SelectedItems?.Count != 1)
         {
             return;
         }
@@ -2110,7 +2110,7 @@ public partial class BinaryEditViewModel : ObservableObject
     [RelayCommand]
     private void ToggleForced()
     {
-        if (Window == null || SubtitleGrid == null || SubtitleGrid.SelectedItems.Count <= 0)
+        if (Window == null || SubtitleGrid?.SelectedItems is not { Count: > 0 })
         {
             return;
         }
@@ -2141,7 +2141,7 @@ public partial class BinaryEditViewModel : ObservableObject
     private List<int> GetSelectedIndices() =>
         GetSelectedItems().Select(item => Subtitles.IndexOf(item)).Where(i => i >= 0).ToList();
 
-    // Adding many rows to a realized DataGrid's SelectedItems is O(n) visual work per
+    // Adding many rows to a realized grid's SelectedItems is O(n) visual work per
     // row, so selecting all forced/non-forced lines on a large file hangs (#11529).
     // Detaching ItemsSource de-realizes the rows so the adds only touch the grid's
     // internal selection table; a single layout pass repaints after we reattach.
@@ -2165,10 +2165,10 @@ public partial class BinaryEditViewModel : ObservableObject
         SubtitleGrid.ItemsSource = null;
         SubtitleGrid.ItemsSource = itemsSource;
 
-        SubtitleGrid.SelectedItems.Clear();
+        SubtitleGrid.SelectedItems?.Clear();
         foreach (var item in items)
         {
-            SubtitleGrid.SelectedItems.Add(item);
+            SubtitleGrid.SelectedItems?.Add(item);
         }
 
         if (preserveScroll && scrollViewer != null)
@@ -2569,7 +2569,10 @@ public partial class BinaryEditViewModel : ObservableObject
                 return;
             }
 
-            SubtitleGrid?.Focus();
+            if (SubtitleGrid != null)
+            {
+                TableViewExtras.FocusRow(SubtitleGrid);
+            }
         });
     }
 
@@ -2783,11 +2786,14 @@ public partial class BinaryEditViewModel : ObservableObject
                 SubtitleGrid.SelectedIndex = index;
             }
 
-            SubtitleGrid.ScrollIntoView(SubtitleGrid.SelectedItem, null);
+            if (SubtitleGrid.SelectedItem is { } selectedItem)
+            {
+                SubtitleGrid.ScrollIntoView(selectedItem);
+            }
         });
     }
 
-    internal void OnDataGridKeyDown(KeyEventArgs e)
+    internal void OnSubtitleGridKeyDown(KeyEventArgs e)
     {
         if (e.Key == Key.Delete)
         {
@@ -2867,7 +2873,7 @@ public partial class BinaryEditViewModel : ObservableObject
         IsInsertBeforeVisible = selectedCount == 1;
     }
 
-    internal void OnDataGridDoubleTapped(TappedEventArgs e)
+    internal void OnSubtitleGridDoubleTapped(TappedEventArgs e)
     {
         var vp = VideoPlayerControl;
         var item = SubtitleGrid?.SelectedItem as BinarySubtitleItem;

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -9,6 +9,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using System;
 using System.Collections;
+using System.Linq;
 using Nikse.SubtitleEdit.Controls;
 using Nikse.SubtitleEdit.Controls.VideoPlayer;
 using Nikse.SubtitleEdit.Features.Main.Layout;
@@ -418,41 +419,43 @@ public class BinaryEditWindow : Window
         {
             RowDefinitions =
             {
-                new RowDefinition(GridLength.Star), // DataGrid
+                new RowDefinition(GridLength.Star), // Subtitle grid
                 new RowDefinition(GridLength.Auto), // Controls
             },
             Margin = new Thickness(5),
         };
 
-        // DataGrid for subtitle lines
-        var dataGrid = new DataGrid
-        {
-            Height = double.NaN,
-            CanUserSortColumns = false,
-            IsReadOnly = true,
-            SelectionMode = DataGridSelectionMode.Extended,
-            CanUserResizeColumns = true,
-            GridLinesVisibility = UiUtil.GetGridLinesVisibility(),
-            VerticalGridLinesBrush = UiUtil.GetBorderBrush(),
-            HorizontalGridLinesBrush = UiUtil.GetBorderBrush(),
-            FontSize = Se.Settings.Appearance.SubtitleGridFontSize,
-        };
+        // Grid for subtitle lines (grid lines come from the TableView cell themes)
+        var dataGrid = TableViewExtras.MakeTableView();
+        dataGrid.Height = double.NaN;
+        dataGrid.FontSize = Se.Settings.Appearance.SubtitleGridFontSize;
 
-        dataGrid.Bind(DataGrid.ItemsSourceProperty, new Binding(nameof(vm.Subtitles)));
-        dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle)) { Mode = BindingMode.Default });
-        dataGrid.DoubleTapped += (_, e) => vm.OnDataGridDoubleTapped(e);
+        dataGrid.Bind(TableView.ItemsSourceProperty, new Binding(nameof(vm.Subtitles)));
+        dataGrid.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle)) { Mode = BindingMode.Default });
+        dataGrid.DoubleTapped += (_, e) => vm.OnSubtitleGridDoubleTapped(e);
 
-        dataGrid.KeyDown += (_, e) => vm.OnDataGridKeyDown(e);
+        dataGrid.KeyDown += (_, e) => vm.OnSubtitleGridKeyDown(e);
         dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
         {
             if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
             {
                 var target = e.Key == Key.Home ? items[0] : items[^1];
                 dataGrid.SelectedItem = target;
-                dataGrid.ScrollIntoView(target, null);
+                if (target != null)
+                {
+                    dataGrid.ScrollIntoView(target);
+                }
+
                 e.Handled = true;
             }
         }, Avalonia.Interactivity.RoutingStrategies.Tunnel);
+
+        // The DataGridCheckboxMultiSelect helper the DataGrid used provided extended
+        // selection (native ListBox behavior on TableView) plus Space toggling the
+        // Forced checkbox for the selected rows - keep the Space shortcut.
+        TableViewExtras.AddSpaceToggle<BinarySubtitleItem>(dataGrid,
+            item => item.IsForced,
+            (item, value) => item.IsForced = value);
 
         var flyout = new MenuFlyout();
         dataGrid.ContextFlyout = flyout;
@@ -643,26 +646,25 @@ public class BinaryEditWindow : Window
 
         vm.SubtitleGrid = dataGrid;
         dataGrid.SelectionChanged += vm.SubtitleGridSelectionChanged;
-        _ = new DataGridCheckboxMultiSelect<BinarySubtitleItem>(
-            dataGrid,
-            item => item.IsForced,
-            (item, v) => item.IsForced = v);
 
         var dataGridBorder = UiUtil.MakeBorderForControlNoPadding(dataGrid);
         dataGridBorder.Margin = new Thickness(0, 0, 0, 5);
 
-        // Columns: Forced, Number, Show, Duration, Text, Image
+        // Columns: Zone, Forced, Number, Show, Duration, Image. All columns go through
+        // the manager because the zone column toggles visibility with the position map.
+        var columnManager = new TableViewColumnManager(dataGrid);
+
         // Position-monitor zone dot (green = active picture, amber = bottom bar,
         // red = top bar) so problem lines are visible directly in the grid.
         // Only shown while the right panel is in "Position map" mode.
-        var zoneColumn = new DataGridTemplateColumn
+        var zoneColumn = new SeTableViewColumn
         {
             Header = string.Empty,
-            Width = new DataGridLength(30),
+            Width = new GridLength(30),
             MinWidth = 26,
-            IsReadOnly = true,
             IsVisible = vm.IsPositionMonitorActive,
-            CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
             CellTemplate = new Avalonia.Controls.Templates.FuncDataTemplate<BinarySubtitleItem>((_, _) =>
                 new Ellipse
                 {
@@ -673,7 +675,7 @@ public class BinaryEditWindow : Window
                     [!Shape.FillProperty] = new Binding(nameof(BinarySubtitleItem.ZoneBrush)),
                 }),
         };
-        dataGrid.Columns.Add(zoneColumn);
+        columnManager.Add(zoneColumn);
         vm.PropertyChanged += (_, e) =>
         {
             if (e.PropertyName == nameof(vm.IsPositionMonitorActive))
@@ -682,12 +684,13 @@ public class BinaryEditWindow : Window
             }
         };
 
-        dataGrid.Columns.Add(new DataGridTemplateColumn
+        columnManager.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Forced,
-            Width = new DataGridLength(90),
+            Width = new GridLength(90),
             MinWidth = 80,
-            CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
             CellTemplate = new Avalonia.Controls.Templates.FuncDataTemplate<BinarySubtitleItem>((_, _) =>
                 new Border
                 {
@@ -702,42 +705,41 @@ public class BinaryEditWindow : Window
                 }),
         });
 
-        dataGrid.Columns.Add(new DataGridTextColumn
+        columnManager.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.NumberSymbol,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
+            Width = new GridLength(50), // was Auto; TableView treats Auto as star
             MinWidth = 40,
-            IsReadOnly = true,
             Binding = new Binding(nameof(BinarySubtitleItem.Number)),
-            CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
 
-        dataGrid.Columns.Add(new DataGridTextColumn
+        columnManager.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Show,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
+            Width = new GridLength(120), // was Auto; TableView treats Auto as star
             MinWidth = 100,
-            IsReadOnly = true,
             Binding = new Binding(nameof(BinarySubtitleItem.StartTime)) { Converter = new TimeSpanToDisplayFullConverter() },
-            CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
 
-        dataGrid.Columns.Add(new DataGridTextColumn
+        columnManager.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Duration,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
+            Width = new GridLength(90), // was Auto; TableView treats Auto as star
             MinWidth = 60,
-            IsReadOnly = true,
             Binding = new Binding(nameof(BinarySubtitleItem.Duration)) { Converter = new TimeSpanToDisplayShortConverter() },
-            CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
 
-        dataGrid.Columns.Add(new DataGridTemplateColumn
+        columnManager.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Image,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Star),
+            Width = new GridLength(1, GridUnitType.Star),
             MinWidth = 80,
-            IsReadOnly = true,
             CellTemplate = new Avalonia.Controls.Templates.FuncDataTemplate<BinarySubtitleItem>((_, _) =>
             {
                 var image = new Image
@@ -759,7 +761,8 @@ public class BinaryEditWindow : Window
                     Child = image,
                 };
             }),
-            CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
 
         mainGrid.Add(dataGridBorder, 0);

--- a/src/ui/Features/Shared/Bookmarks/BookmarksListWindow.cs
+++ b/src/ui/Features/Shared/Bookmarks/BookmarksListWindow.cs
@@ -69,16 +69,11 @@ public class BookmarksListWindow : Window
 
     private static Border MakeBookmarkGridView(BookmarksListViewModel vm)
     {
-        var dataGrid = new DataGrid
-        {
-            Height = double.NaN, // auto size inside scroll viewer
-            Margin = new Thickness(2),
-            ItemsSource = vm.Subtitles, // Use ItemsSource instead of Items
-            CanUserSortColumns = false,
-            IsReadOnly = true,
-            SelectionMode = DataGridSelectionMode.Extended,
-            DataContext = vm.Subtitles,
-        };
+        var dataGrid = TableViewExtras.MakeTableView();
+        dataGrid.Height = double.NaN; // auto size inside scroll viewer
+        dataGrid.Margin = new Thickness(2);
+        dataGrid.ItemsSource = vm.Subtitles;
+        dataGrid.DataContext = vm.Subtitles;
 
         dataGrid.DoubleTapped += vm.OnBookmarksGridDoubleTapped;
 
@@ -86,23 +81,27 @@ public class BookmarksListWindow : Window
         var shortTimeConverter = new TimeSpanToDisplayShortConverter();
 
         // Columns
-        dataGrid.Columns.Add(new DataGridTextColumn
+        dataGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.NumberSymbol,
             Binding = new Binding(nameof(SubtitleLineViewModel.Number)),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(50), // was Auto; TableView treats Auto as star
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
-        dataGrid.Columns.Add(new DataGridTextColumn
+        dataGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Text,
             Binding = new Binding(nameof(SubtitleLineViewModel.Bookmark)),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Star) // star sizing to take all available space
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(1, GridUnitType.Star) // star sizing to take all available space
         });
-        dataGrid.Columns.Add(new DataGridTemplateColumn
+        dataGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Delete,
-            CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
             CellTemplate = new FuncDataTemplate<SubtitleLineViewModel>((item, _) =>
             {
                 var deleteButton = new Button
@@ -115,11 +114,10 @@ public class BookmarksListWindow : Window
                 Optris.Icons.Avalonia.Attached.SetIcon(deleteButton, IconNames.Trash);
                 return deleteButton;
             }),
-            Width = new DataGridLength(1, DataGridLengthUnitType.Auto)
+            Width = new GridLength(80) // was Auto; TableView treats Auto as star
         });
 
-        dataGrid.DataContext = vm.Subtitles;
-        dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle))
+        dataGrid.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle))
         {
             Source = vm,
             Mode = BindingMode.TwoWay
@@ -133,7 +131,11 @@ public class BookmarksListWindow : Window
             {
                 var target = e.Key == Key.Home ? items[0] : items[^1];
                 dataGrid.SelectedItem = target;
-                dataGrid.ScrollIntoView(target, null);
+                if (target != null)
+                {
+                    dataGrid.ScrollIntoView(target);
+                }
+
                 e.Handled = true;
             }
         }, Avalonia.Interactivity.RoutingStrategies.Tunnel);

--- a/src/ui/Features/Shared/ErrorList/ErrorListWindow.cs
+++ b/src/ui/Features/Shared/ErrorList/ErrorListWindow.cs
@@ -58,16 +58,11 @@ public class ErrorListWindow : Window
 
     private static Border MakeErrorsGridView(ErrorListViewModel vm)
     {
-        var dataGrid = new DataGrid
-        {
-            Height = double.NaN, // auto size inside scroll viewer
-            Margin = new Thickness(2),
-            ItemsSource = vm.Subtitles, // Use ItemsSource instead of Items
-            CanUserSortColumns = false,
-            IsReadOnly = true,
-            SelectionMode = DataGridSelectionMode.Extended,
-            DataContext = vm.Subtitles,
-        };
+        var dataGrid = TableViewExtras.MakeTableView();
+        dataGrid.Height = double.NaN; // auto size inside scroll viewer
+        dataGrid.Margin = new Thickness(2);
+        dataGrid.ItemsSource = vm.Subtitles;
+        dataGrid.DataContext = vm.Subtitles;
 
         dataGrid.DoubleTapped += vm.OnBookmarksGridDoubleTapped;
 
@@ -75,29 +70,32 @@ public class ErrorListWindow : Window
         var shortTimeConverter = new TimeSpanToDisplayShortConverter();
 
         // Columns
-        dataGrid.Columns.Add(new DataGridTextColumn
+        dataGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.NumberSymbol,
             Binding = new Binding(nameof(ErrorListItem.Number)),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(50), // was Auto; TableView treats Auto as star
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
-        dataGrid.Columns.Add(new DataGridTextColumn
+        dataGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Text,
             Binding = new Binding(nameof(ErrorListItem.Text)),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Star) // star sizing to take all available space
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(1, GridUnitType.Star) // star sizing to take all available space
         });
-        dataGrid.Columns.Add(new DataGridTextColumn
+        dataGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Error,
             Binding = new Binding(nameof(ErrorListItem.Error)),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Star) // star sizing to take all available space
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(1, GridUnitType.Star) // star sizing to take all available space
         });
 
-        dataGrid.DataContext = vm.Subtitles;
-        dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle))
+        dataGrid.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle))
         {
             Source = vm,
             Mode = BindingMode.TwoWay
@@ -111,7 +109,11 @@ public class ErrorListWindow : Window
             {
                 var target = e.Key == Key.Home ? items[0] : items[^1];
                 dataGrid.SelectedItem = target;
-                dataGrid.ScrollIntoView(target, null);
+                if (target != null)
+                {
+                    dataGrid.ScrollIntoView(target);
+                }
+
                 e.Handled = true;
             }
         }, Avalonia.Interactivity.RoutingStrategies.Tunnel);

--- a/src/ui/Features/Shared/FindText/FindTextViewModel.cs
+++ b/src/ui/Features/Shared/FindText/FindTextViewModel.cs
@@ -24,7 +24,7 @@ public partial class FindTextViewModel : ObservableObject, IClosingCleanup
     public Window? Window { get; set; }
 
     public bool OkPressed { get; private set; }
-    public DataGrid SubtitleGrid { get; internal set; }
+    public TableView SubtitleGrid { get; internal set; }
 
     private List<SubtitleLineViewModel> _allSubtitles;
     private bool _dirty;
@@ -36,7 +36,7 @@ public partial class FindTextViewModel : ObservableObject, IClosingCleanup
         _allSubtitles = new List<SubtitleLineViewModel>();
         Subtitles = new ObservableCollection<SubtitleLineViewModel>();
         Title = string.Empty;
-        SubtitleGrid = new DataGrid();
+        SubtitleGrid = new TableView();
         SearchText = string.Empty;
         _updateLock = new Lock();
         _searchTimer = new System.Timers.Timer();
@@ -118,7 +118,7 @@ public partial class FindTextViewModel : ObservableObject, IClosingCleanup
 
     internal void OnSubtitleGridDoubleTapped(object? sender, TappedEventArgs e)
     {
-        if (sender is DataGrid grid && grid.SelectedItem != null)
+        if (sender is TableView grid && grid.SelectedItem != null)
         {
             if (grid.SelectedItem is SubtitleLineViewModel selectedItem)
             {

--- a/src/ui/Features/Shared/FindText/FindTextWindow.cs
+++ b/src/ui/Features/Shared/FindText/FindTextWindow.cs
@@ -69,56 +69,53 @@ public class FindTextWindow : Window
 
     private static Border MakeSubtitlesView(FindTextViewModel vm)
     {
-        vm.SubtitleGrid = new DataGrid
-        {
-            Height = double.NaN, // auto size inside scroll viewer
-            Width = double.NaN,
-            HorizontalAlignment= HorizontalAlignment.Stretch,
-            Margin = new Thickness(2),
-            ItemsSource = vm.Subtitles, // Use ItemsSource instead of Items
-            CanUserSortColumns = false,
-            IsReadOnly = true,
-            SelectionMode = DataGridSelectionMode.Single,
-            DataContext = vm.Subtitles,
-        };
+        vm.SubtitleGrid = TableViewExtras.MakeTableView(multiSelect: false);
+        vm.SubtitleGrid.Height = double.NaN; // auto size inside scroll viewer
+        vm.SubtitleGrid.Width = double.NaN;
+        vm.SubtitleGrid.Margin = new Thickness(2);
+        vm.SubtitleGrid.ItemsSource = vm.Subtitles;
 
         var fullTimeConverter = new TimeSpanToDisplayFullConverter();
         var shortTimeConverter = new TimeSpanToDisplayShortConverter();
 
         // Columns
-        vm.SubtitleGrid.Columns.Add(new DataGridTextColumn
+        vm.SubtitleGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.NumberSymbol,
             Binding = new Binding(nameof(SubtitleLineViewModel.Number)),
-            Width = new DataGridLength(50),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(50),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
-        vm.SubtitleGrid.Columns.Add(new DataGridTextColumn
+        vm.SubtitleGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Show,
             Binding = new Binding(nameof(SubtitleLineViewModel.StartTime)) { Converter = fullTimeConverter },
-            Width = new DataGridLength(120),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(120),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
 
-        vm.SubtitleGrid.Columns.Add(new DataGridTextColumn
+        vm.SubtitleGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Duration,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(90), // was Auto; TableView treats Auto as star
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
             Binding = new Binding(nameof(SubtitleLineViewModel.Duration)) { Converter = shortTimeConverter },
         });
 
-        vm.SubtitleGrid.Columns.Add(new DataGridTextColumn
+        vm.SubtitleGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Text,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Star),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(1, GridUnitType.Star),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
             Binding = new Binding(nameof(SubtitleLineViewModel.Text)),
         });
 
         vm.SubtitleGrid.DataContext = vm.Subtitles;
-        vm.SubtitleGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle))
+        vm.SubtitleGrid.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle))
         {
             Source = vm,
             Mode = BindingMode.TwoWay

--- a/src/ui/Features/SpellCheck/FindDoubleLines/FindDoubleLinesWindow.cs
+++ b/src/ui/Features/SpellCheck/FindDoubleLines/FindDoubleLinesWindow.cs
@@ -60,54 +60,56 @@ public class FindDoubleLinesWindow : Window
 
     private static Border MakeGridView(FindDoubleLinesViewModel vm)
     {
-        var dataGrid = new DataGrid
-        {
-            Height = double.NaN,
-            Margin = new Thickness(2),
-            ItemsSource = vm.Subtitles,
-            CanUserSortColumns = false,
-            IsReadOnly = true,
-            SelectionMode = DataGridSelectionMode.Extended,
-            DataContext = vm.Subtitles,
-        };
+        var tableView = TableViewExtras.MakeTableView();
+        tableView.Height = double.NaN;
+        tableView.Margin = new Thickness(2);
+        tableView.ItemsSource = vm.Subtitles;
+        tableView.DataContext = vm.Subtitles;
 
-        dataGrid.DoubleTapped += vm.OnBookmarksGridDoubleTapped;
+        tableView.DoubleTapped += vm.OnBookmarksGridDoubleTapped;
 
-        // Columns
-        dataGrid.Columns.Add(new DataGridTextColumn
+        // Columns (the DataGrid sized the number column to content; TableView treats
+        // Auto as star, so it gets a fixed width instead)
+        tableView.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.NumberSymbol,
             Binding = new Binding(nameof(DoubleLineItem.Number)),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(60),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
-        dataGrid.Columns.Add(new DataGridTextColumn
+        tableView.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Text,
             Binding = new Binding(nameof(DoubleLineItem.Text)),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Star),
+            Width = new GridLength(1, GridUnitType.Star),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
 
-        dataGrid.DataContext = vm.Subtitles;
-        dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle))
+        tableView.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle))
         {
             Source = vm,
             Mode = BindingMode.TwoWay
         });
-        dataGrid.SelectionChanged += vm.GridSelectionChanged;
-        dataGrid.DoubleTapped += (s, e) => vm.GoToCommand.Execute(null);
-        dataGrid.KeyDown += (s, e) => vm.GridKeyDown(e);
-        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        tableView.SelectionChanged += vm.GridSelectionChanged;
+        tableView.DoubleTapped += (s, e) => vm.GoToCommand.Execute(null);
+        tableView.KeyDown += (s, e) => vm.GridKeyDown(e);
+        tableView.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
         {
-            if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            if (e.Key is Key.Home or Key.End && tableView.ItemsSource is IList items && items.Count > 0)
             {
                 var target = e.Key == Key.Home ? items[0] : items[^1];
-                dataGrid.SelectedItem = target;
-                dataGrid.ScrollIntoView(target, null);
+                tableView.SelectedItem = target;
+                if (target != null)
+                {
+                    tableView.ScrollIntoView(target);
+                }
+
                 e.Handled = true;
             }
         }, Avalonia.Interactivity.RoutingStrategies.Tunnel);
 
-        return UiUtil.MakeBorderForControlNoPadding(dataGrid);
+        return UiUtil.MakeBorderForControlNoPadding(tableView);
     }
 }

--- a/src/ui/Features/SpellCheck/FindDoubleWords/FindDoubleWordsWindow.cs
+++ b/src/ui/Features/SpellCheck/FindDoubleWords/FindDoubleWordsWindow.cs
@@ -6,7 +6,6 @@ using Avalonia.Layout;
 using System.Collections;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
-using Nikse.SubtitleEdit.Logic.ValueConverters;
 
 namespace Nikse.SubtitleEdit.Features.SpellCheck.FindDoubleWords;
 
@@ -61,64 +60,64 @@ public class FindDoubleWordsWindow : Window
 
     private static Border MakeGridView(FindDoubleWordsViewModel vm)
     {
-        var dataGrid = new DataGrid
-        {
-            Height = double.NaN, // auto size inside scroll viewer
-            Margin = new Thickness(2),
-            ItemsSource = vm.Subtitles, // Use ItemsSource instead of Items
-            CanUserSortColumns = false,
-            IsReadOnly = true,
-            SelectionMode = DataGridSelectionMode.Extended,
-            DataContext = vm.Subtitles,
-        };
+        var tableView = TableViewExtras.MakeTableView();
+        tableView.Height = double.NaN; // auto size inside scroll viewer
+        tableView.Margin = new Thickness(2);
+        tableView.ItemsSource = vm.Subtitles;
+        tableView.DataContext = vm.Subtitles;
 
-        dataGrid.DoubleTapped += vm.OnBookmarksGridDoubleTapped;
+        tableView.DoubleTapped += vm.OnBookmarksGridDoubleTapped;
 
-        var fullTimeConverter = new TimeSpanToDisplayFullConverter();
-        var shortTimeConverter = new TimeSpanToDisplayShortConverter();
-
-        // Columns
-        dataGrid.Columns.Add(new DataGridTextColumn
+        // Columns (the DataGrid sized the number column to content; TableView treats
+        // Auto as star, so it gets a fixed width instead)
+        tableView.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.NumberSymbol,
             Binding = new Binding(nameof(DoubleWordItem.Number)),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(60),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
-        dataGrid.Columns.Add(new DataGridTextColumn
+        tableView.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Text,
             Binding = new Binding(nameof(DoubleWordItem.Text)),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Star) // star sizing to take all available space
+            Width = new GridLength(1, GridUnitType.Star), // star sizing to take all available space
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
-        dataGrid.Columns.Add(new DataGridTextColumn
+        tableView.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.DoubleWords,
             Binding = new Binding(nameof(DoubleWordItem.Hit)),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Star) // star sizing to take all available space
+            Width = new GridLength(1, GridUnitType.Star), // star sizing to take all available space
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
 
-        dataGrid.DataContext = vm.Subtitles;
-        dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle))
+        tableView.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle))
         {
             Source = vm,
             Mode = BindingMode.TwoWay
         });
-        dataGrid.SelectionChanged += vm.GridSelectionChanged;
-        dataGrid.DoubleTapped += (s, e) => vm.GoToCommand.Execute(null);
-        dataGrid.KeyDown += (s, e) => vm.GridKeyDown(e);
-        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        tableView.SelectionChanged += vm.GridSelectionChanged;
+        tableView.DoubleTapped += (s, e) => vm.GoToCommand.Execute(null);
+        tableView.KeyDown += (s, e) => vm.GridKeyDown(e);
+        tableView.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
         {
-            if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            if (e.Key is Key.Home or Key.End && tableView.ItemsSource is IList items && items.Count > 0)
             {
                 var target = e.Key == Key.Home ? items[0] : items[^1];
-                dataGrid.SelectedItem = target;
-                dataGrid.ScrollIntoView(target, null);
+                tableView.SelectedItem = target;
+                if (target != null)
+                {
+                    tableView.ScrollIntoView(target);
+                }
+
                 e.Handled = true;
             }
         }, Avalonia.Interactivity.RoutingStrategies.Tunnel);
 
-        return UiUtil.MakeBorderForControlNoPadding(dataGrid);
+        return UiUtil.MakeBorderForControlNoPadding(tableView);
     }
 }

--- a/src/ui/Features/Tools/BatchConvert/BatchErrorList/BatchErrorListWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchErrorList/BatchErrorListWindow.cs
@@ -8,7 +8,6 @@ using System.Collections;
 using Nikse.SubtitleEdit.Features.Tools.BatchConvert.BatchErrorList;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
-using Nikse.SubtitleEdit.Logic.ValueConverters;
 
 namespace Nikse.SubtitleEdit.Features.Shared.ErrorList;
 
@@ -60,51 +59,48 @@ public class BatchErrorListWindow : Window
 
     private static Border MakeErrorsGridView(BatchErrorListViewModel vm)
     {
-        var dataGrid = new DataGrid
-        {
-            Height = double.NaN, // auto size inside scroll viewer
-            Margin = new Thickness(2),
-            ItemsSource = vm.Subtitles, // Use ItemsSource instead of Items
-            CanUserSortColumns = false,
-            IsReadOnly = true,
-            SelectionMode = DataGridSelectionMode.Extended,
-            DataContext = vm.Subtitles,
-        };
+        var dataGrid = TableViewExtras.MakeTableView();
+        dataGrid.Height = double.NaN; // auto size inside scroll viewer
+        dataGrid.Margin = new Thickness(2);
+        dataGrid.ItemsSource = vm.Subtitles;
+        dataGrid.DataContext = vm.Subtitles;
 
-        var fullTimeConverter = new TimeSpanToDisplayFullConverter();
-        var shortTimeConverter = new TimeSpanToDisplayShortConverter();
-
-        // Columns
-        dataGrid.Columns.Add(new DataGridTextColumn
+        // Columns - the number column was content-sized (Auto) on the DataGrid; TableView
+        // treats Auto as star, so it gets a fixed width instead.
+        dataGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.FileName,
             Binding = new Binding(nameof(BatchErrorListItem.FileName)),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Star) 
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(1, GridUnitType.Star)
         });
-        dataGrid.Columns.Add(new DataGridTextColumn
+        dataGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.NumberSymbol,
             Binding = new Binding(nameof(BatchErrorListItem.Number)),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(60)
         });
-        dataGrid.Columns.Add(new DataGridTextColumn
+        dataGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Text,
             Binding = new Binding(nameof(BatchErrorListItem.Text)),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Star) 
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(1, GridUnitType.Star)
         });
-        dataGrid.Columns.Add(new DataGridTextColumn
+        dataGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Error,
             Binding = new Binding(nameof(BatchErrorListItem.Error)),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Star) 
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(1, GridUnitType.Star)
         });
 
-        dataGrid.DataContext = vm.Subtitles;
-        dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle))
+        dataGrid.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle))
         {
             Source = vm,
             Mode = BindingMode.TwoWay
@@ -112,11 +108,11 @@ public class BatchErrorListWindow : Window
         dataGrid.SelectionChanged += vm.GridSelectionChanged;
         dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
         {
-            if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0 &&
+                (e.Key == Key.Home ? items[0] : items[^1]) is { } target)
             {
-                var target = e.Key == Key.Home ? items[0] : items[^1];
                 dataGrid.SelectedItem = target;
-                dataGrid.ScrollIntoView(target, null);
+                dataGrid.ScrollIntoView(target);
                 e.Handled = true;
             }
         }, RoutingStrategies.Tunnel);

--- a/src/ui/Features/Tools/ChangeCasing/FixNamesWindow.cs
+++ b/src/ui/Features/Tools/ChangeCasing/FixNamesWindow.cs
@@ -9,6 +9,8 @@ using Avalonia.Media;
 using Avalonia.Threading;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Tools.ChangeCasing;
 
@@ -110,19 +112,19 @@ public class FixNamesWindow : Window
 
     private static Border MakeNamesView(FixNamesViewModel vm)
     {
-        var dataGrid = new DataGrid
-        {
-            Height = double.NaN,
-            ItemsSource = vm.Names,
-            CanUserSortColumns = false,
-            SelectionMode = DataGridSelectionMode.Single,
-            DataContext = vm,
-        };
+        // The DataGrid this replaces used DataGridCheckboxMultiSelect for extended
+        // selection + Space toggling; shift/ctrl multi-select is native ListBox behavior
+        // on TableView, so only the Space toggle needs wiring (TableViewExtras.AddSpaceToggle).
+        var dataGrid = TableViewExtras.MakeTableView();
+        dataGrid.Height = double.NaN;
+        dataGrid.ItemsSource = vm.Names;
+        dataGrid.DataContext = vm;
 
-        dataGrid.Columns.Add(new DataGridTemplateColumn
+        dataGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Enabled,
-            CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
             CellTemplate = new FuncDataTemplate<FixNameItem>(static (item, _) =>
             new Border
             {
@@ -135,19 +137,20 @@ public class FixNamesWindow : Window
                     HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center,
                 }
             }),
-            Width = new DataGridLength(1, DataGridLengthUnitType.Auto)
+            // Content-sized (Auto) on the DataGrid; TableView treats Auto as star.
+            Width = new GridLength(80)
         });
 
-        dataGrid.Columns.Add(new DataGridTextColumn
+        dataGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Name,
             Binding = new Binding(nameof(FixNameItem.Name)),
-            Width = new DataGridLength(1, DataGridLengthUnitType.Star),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
-            IsReadOnly = true,
+            Width = new GridLength(1, GridUnitType.Star),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
 
-        _ = new DataGridCheckboxMultiSelect<FixNameItem>(dataGrid,
+        TableViewExtras.AddSpaceToggle<FixNameItem>(dataGrid,
             item => item.IsChecked, (item, v) => item.IsChecked = v);
 
         var flyout = new MenuFlyout();
@@ -162,21 +165,16 @@ public class FixNamesWindow : Window
 
     private static Border MakeHitsView(FixNamesViewModel vm)
     {
-        var dataGrid = new DataGrid
-        {
-            Height = double.NaN,
-            ItemsSource = vm.Hits,
-            CanUserSortColumns = false,
-            IsReadOnly = false,
-            SelectionMode = DataGridSelectionMode.Single,
-            DataContext = vm,
-        };
+        var dataGrid = TableViewExtras.MakeTableView();
+        dataGrid.Height = double.NaN;
+        dataGrid.ItemsSource = vm.Hits;
+        dataGrid.DataContext = vm;
 
-        dataGrid.Columns.Add(new DataGridTemplateColumn
+        dataGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Apply,
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
-            IsReadOnly = false,
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
             CellTemplate = new FuncDataTemplate<FixNameHitItem>(static (_, _) => new Border
             {
                 Background = Brushes.Transparent, // Prevents highlighting
@@ -188,34 +186,35 @@ public class FixNamesWindow : Window
                     HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center,
                 }
             }),
-            Width = new DataGridLength(1, DataGridLengthUnitType.Auto)
+            // Content-sized (Auto) on the DataGrid; TableView treats Auto as star.
+            Width = new GridLength(80)
         });
-        dataGrid.Columns.Add(new DataGridTextColumn
+        dataGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Name,
             Binding = new Binding(nameof(FixNameHitItem.LineIndexDisplay)),
-            Width = new DataGridLength(140),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
-            IsReadOnly = true
+            Width = new GridLength(140),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
-        dataGrid.Columns.Add(new DataGridTextColumn
+        dataGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Before,
             Binding = new Binding(nameof(FixNameHitItem.Before)),
-            Width = new DataGridLength(220),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
-            IsReadOnly = true
+            Width = new GridLength(220),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
-        dataGrid.Columns.Add(new DataGridTextColumn
+        dataGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.After,
             Binding = new Binding(nameof(FixNameHitItem.After)),
-            Width = new DataGridLength(1, DataGridLengthUnitType.Star),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
-            IsReadOnly = true
+            Width = new GridLength(1, GridUnitType.Star),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
 
-        _ = new DataGridCheckboxMultiSelect<FixNameHitItem>(dataGrid,
+        TableViewExtras.AddSpaceToggle<FixNameHitItem>(dataGrid,
             item => item.IsEnabled, (item, v) => item.IsEnabled = v);
 
         var flyout = new MenuFlyout();
@@ -227,6 +226,7 @@ public class FixNamesWindow : Window
         var border = UiUtil.MakeBorderForControlNoPadding(dataGrid);
         return border;
     }
+
 
     protected override void OnKeyDown(Avalonia.Input.KeyEventArgs e)
     {

--- a/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
+++ b/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
@@ -10,6 +10,7 @@ using Avalonia.Threading;
 using Avalonia.Media;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Tools.MergeContinuationLines;
 
@@ -126,78 +127,79 @@ public class MergeContinuationLinesWindow : Window
             .WithMarginTop(10)
             .WithMarginLeft(10);
 
-        var dataGrid = new DataGrid
+        // The DataGrid this replaces used DataGridCheckboxMultiSelect for extended
+        // selection + Space toggling; shift/ctrl multi-select is native ListBox behavior
+        // on TableView, so only the Space toggle needs wiring (below).
+        var dataGrid = TableViewExtras.MakeTableView();
+        dataGrid.Width = double.NaN;
+        dataGrid.Height = double.NaN;
+        dataGrid.DataContext = vm;
+        dataGrid.ItemsSource = vm.Candidates;
+
+        // The checkbox and number columns were content-sized (Auto) on the DataGrid;
+        // TableView treats Auto as star, so they get fixed widths instead.
+        dataGrid.Columns.Add(new SeTableViewColumn
         {
-            AutoGenerateColumns = false,
-            SelectionMode = DataGridSelectionMode.Single,
-            CanUserResizeColumns = true,
-            CanUserSortColumns = false,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Stretch,
-            Width = double.NaN,
-            Height = double.NaN,
-            DataContext = vm,
-            ItemsSource = vm.Candidates,
-            Columns =
+            Header = Se.Language.Tools.MergeContinuationLines.ColumnMerge,
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            CellTemplate = new FuncDataTemplate<MergeContinuationLinesCandidate>((_, _) =>
             {
-                new DataGridTemplateColumn
+                return new Border
                 {
-                    Header = Se.Language.Tools.MergeContinuationLines.ColumnMerge,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    CellTemplate = new FuncDataTemplate<MergeContinuationLinesCandidate>((_, _) =>
+                    Background = Brushes.Transparent,
+                    Padding = new Thickness(4),
+                    Child = new CheckBox
                     {
-                        return new Border
+                        Focusable = false,
+                        [!ToggleButton.IsCheckedProperty] = new Binding(nameof(MergeContinuationLinesCandidate.IsSelected))
                         {
-                            Background = Brushes.Transparent,
-                            Padding = new Thickness(4),
-                            Child = new CheckBox
-                            {
-                                Focusable = false,
-                                [!ToggleButton.IsCheckedProperty] = new Binding(nameof(MergeContinuationLinesCandidate.IsSelected))
-                                {
-                                    Mode = BindingMode.TwoWay,
-                                },
-                                HorizontalAlignment = HorizontalAlignment.Center,
-                            },
-                        };
-                    }),
-                    Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.NumberSymbol,
-                    Binding = new Binding(nameof(MergeContinuationLinesCandidate.Number)),
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    IsReadOnly = true,
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.Tools.MergeContinuationLines.ColumnFirst,
-                    Binding = new Binding(nameof(MergeContinuationLinesCandidate.Text1)),
-                    CellTheme = UiUtil.DataGridNoBorderCellTheme,
-                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
-                    IsReadOnly = true,
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.Tools.MergeContinuationLines.ColumnSecond,
-                    Binding = new Binding(nameof(MergeContinuationLinesCandidate.Text2)),
-                    CellTheme = UiUtil.DataGridNoBorderCellTheme,
-                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
-                    IsReadOnly = true,
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.Tools.MergeContinuationLines.ColumnMerged,
-                    Binding = new Binding(nameof(MergeContinuationLinesCandidate.MergedTextDisplay)),
-                    CellTheme = UiUtil.DataGridNoBorderCellTheme,
-                    Width = new DataGridLength(1.4, DataGridLengthUnitType.Star),
-                    IsReadOnly = true,
-                },
-            },
-        };
-        _ = new DataGridCheckboxMultiSelect<MergeContinuationLinesCandidate>(dataGrid,
-            item => item.IsSelected, (item, v) => item.IsSelected = v);
+                            Mode = BindingMode.TwoWay,
+                        },
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                    },
+                };
+            }),
+            Width = new GridLength(80),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.NumberSymbol,
+            Binding = new Binding(nameof(MergeContinuationLinesCandidate.Number)),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(60),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.Tools.MergeContinuationLines.ColumnFirst,
+            Binding = new Binding(nameof(MergeContinuationLinesCandidate.Text1)),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(1, GridUnitType.Star),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.Tools.MergeContinuationLines.ColumnSecond,
+            Binding = new Binding(nameof(MergeContinuationLinesCandidate.Text2)),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(1, GridUnitType.Star),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.Tools.MergeContinuationLines.ColumnMerged,
+            Binding = new Binding(nameof(MergeContinuationLinesCandidate.MergedTextDisplay)),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(1.4, GridUnitType.Star),
+        });
+
+        // Space toggles the checkbox of every selected row - the piece of the old
+        // DataGridCheckboxMultiSelect helper that TableView does not provide natively.
+        TableViewExtras.AddSpaceToggle<MergeContinuationLinesCandidate>(dataGrid,
+            item => item.IsSelected,
+            (item, value) => item.IsSelected = value);
 
         grid.Add(labelInfo, 0);
         grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGrid), 1);

--- a/src/ui/Features/Tools/MergeTwoSubtitles/MergeTwoSubtitlesWindow.cs
+++ b/src/ui/Features/Tools/MergeTwoSubtitles/MergeTwoSubtitlesWindow.cs
@@ -123,62 +123,53 @@ public class MergeTwoSubtitlesWindow : Window
 
         var fullTimeConverter = new TimeSpanToDisplayFullConverter();
 
-        var dataGrid = new DataGrid
+        var dataGrid = TableViewExtras.MakeTableView(multiSelect: false);
+        dataGrid.Width = double.NaN;
+        dataGrid.Height = double.NaN;
+        dataGrid.DataContext = vm;
+
+        dataGrid.Columns.Add(new SeTableViewColumn
         {
-            AutoGenerateColumns = false,
-            SelectionMode = DataGridSelectionMode.Single,
-            CanUserResizeColumns = true,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Stretch,
-            Width = double.NaN,
-            Height = double.NaN,
-            DataContext = vm,
-            ItemsSource = null,
-            Columns =
-            {
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.NumberSymbol,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    Binding = new Binding(nameof(MergeTwoSubtitlesDisplayItem.Number)),
-                    IsReadOnly = true,
-                    Width = new DataGridLength(60, DataGridLengthUnitType.Pixel),
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.StartTime,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    Binding = new Binding(nameof(MergeTwoSubtitlesDisplayItem.StartTime)) { Converter = fullTimeConverter },
-                    IsReadOnly = true,
-                    Width = new DataGridLength(120, DataGridLengthUnitType.Pixel),
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.EndTime,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    Binding = new Binding(nameof(MergeTwoSubtitlesDisplayItem.EndTime)) { Converter = fullTimeConverter },
-                    IsReadOnly = true,
-                    Width = new DataGridLength(120, DataGridLengthUnitType.Pixel),
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.Text,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    Binding = new Binding(nameof(MergeTwoSubtitlesDisplayItem.Text)),
-                    IsReadOnly = true,
-                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
-                },
-            },
-        };
-        dataGrid.Bind(DataGrid.ItemsSourceProperty, new Binding(itemsPath) { Source = vm });
-        dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(selectedItemPath) { Source = vm });
+            Header = Se.Language.General.NumberSymbol,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(MergeTwoSubtitlesDisplayItem.Number)),
+            Width = new GridLength(60),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.StartTime,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(MergeTwoSubtitlesDisplayItem.StartTime)) { Converter = fullTimeConverter },
+            Width = new GridLength(120),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.EndTime,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(MergeTwoSubtitlesDisplayItem.EndTime)) { Converter = fullTimeConverter },
+            Width = new GridLength(120),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Text,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(MergeTwoSubtitlesDisplayItem.Text)),
+            Width = new GridLength(1, GridUnitType.Star),
+        });
+
+        dataGrid.Bind(TableView.ItemsSourceProperty, new Binding(itemsPath) { Source = vm });
+        dataGrid.Bind(TableView.SelectedItemProperty, new Binding(selectedItemPath) { Source = vm });
         dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
         {
-            if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0 &&
+                (e.Key == Key.Home ? items[0] : items[^1]) is { } target)
             {
-                var target = e.Key == Key.Home ? items[0] : items[^1];
                 dataGrid.SelectedItem = target;
-                dataGrid.ScrollIntoView(target, null);
+                dataGrid.ScrollIntoView(target);
                 e.Handled = true;
             }
         }, RoutingStrategies.Tunnel);

--- a/src/ui/Features/Tools/SortBy/SortByWindow.cs
+++ b/src/ui/Features/Tools/SortBy/SortByWindow.cs
@@ -171,68 +171,64 @@ public class SortByWindow : Window
         var fullTimeConverter = new TimeSpanToDisplayFullConverter();
         var shortTimeConverter = new TimeSpanToDisplayShortConverter();
         var twoDecimalConverter = new DoubleToTwoDecimalConverter();
-        var dataGridSubtitle = new DataGrid
-        {
-            AutoGenerateColumns = false,
-            SelectionMode = DataGridSelectionMode.Single,
-            CanUserResizeColumns = true,
-            CanUserSortColumns = false,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Stretch,
-            Width = double.NaN,
-            Height = double.NaN,
-            DataContext = vm,
-            ItemsSource = vm.Subtitles,
-            Columns =
-            {
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.NumberSymbol,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    Binding = new Binding(nameof(SubtitleLineViewModel.Number)),
-                    IsReadOnly = true,
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.Show,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    Binding = new Binding(nameof(SubtitleLineViewModel.StartTime)) { Converter = fullTimeConverter },
-                    IsReadOnly = true,
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.Duration,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    Binding = new Binding(nameof(SubtitleLineViewModel.Duration)) { Converter = shortTimeConverter },
-                    IsReadOnly = true,
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.Text,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    Binding = new Binding(nameof(SubtitleLineViewModel.Text)),
-                    IsReadOnly = true,
-                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.Cps,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    Binding = new Binding(nameof(SubtitleLineViewModel.CharactersPerSecond)) { Converter = twoDecimalConverter },
-                    IsReadOnly = true,
-                },
-            },
-        };
+        var dataGridSubtitle = TableViewExtras.MakeTableView(multiSelect: false);
+        dataGridSubtitle.Width = double.NaN;
+        dataGridSubtitle.Height = double.NaN;
+        dataGridSubtitle.DataContext = vm;
+        dataGridSubtitle.ItemsSource = vm.Subtitles;
 
-        dataGridSubtitle.Bind(DataGrid.ItemsSourceProperty, new Binding(nameof(SortByViewModel.Subtitles)) { Mode = BindingMode.TwoWay });
-        dataGridSubtitle.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(SortByViewModel.SelectedSubtitle)) { Mode = BindingMode.TwoWay });
+        // The number, show, duration and CPS columns were content-sized (Auto) on the
+        // DataGrid; TableView treats Auto as star, so they get fixed widths instead.
+        dataGridSubtitle.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.NumberSymbol,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(SubtitleLineViewModel.Number)),
+            Width = new GridLength(60),
+        });
+        dataGridSubtitle.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Show,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(SubtitleLineViewModel.StartTime)) { Converter = fullTimeConverter },
+            Width = new GridLength(120),
+        });
+        dataGridSubtitle.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Duration,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(SubtitleLineViewModel.Duration)) { Converter = shortTimeConverter },
+            Width = new GridLength(90),
+        });
+        dataGridSubtitle.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Text,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(SubtitleLineViewModel.Text)),
+            Width = new GridLength(1, GridUnitType.Star),
+        });
+        dataGridSubtitle.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Cps,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(SubtitleLineViewModel.CharactersPerSecond)) { Converter = twoDecimalConverter },
+            Width = new GridLength(80),
+        });
+
+        dataGridSubtitle.Bind(TableView.ItemsSourceProperty, new Binding(nameof(SortByViewModel.Subtitles)) { Mode = BindingMode.TwoWay });
+        dataGridSubtitle.Bind(TableView.SelectedItemProperty, new Binding(nameof(SortByViewModel.SelectedSubtitle)) { Mode = BindingMode.TwoWay });
         dataGridSubtitle.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
         {
-            if (e.Key is Key.Home or Key.End && dataGridSubtitle.ItemsSource is IList items && items.Count > 0)
+            if (e.Key is Key.Home or Key.End && dataGridSubtitle.ItemsSource is IList items && items.Count > 0 &&
+                (e.Key == Key.Home ? items[0] : items[^1]) is { } target)
             {
-                var target = e.Key == Key.Home ? items[0] : items[^1];
                 dataGridSubtitle.SelectedItem = target;
-                dataGridSubtitle.ScrollIntoView(target, null);
+                dataGridSubtitle.ScrollIntoView(target);
                 e.Handled = true;
             }
         }, RoutingStrategies.Tunnel);

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -109,7 +109,7 @@ public partial class AutoTranslateViewModel : ObservableObject
     [ObservableProperty] private string _llamaCppDownloadButtonText = string.Empty;
     [ObservableProperty] private string _crispAsrDownloadButtonText = string.Empty;
 
-    public DataGrid? RowGrid { get; set; }
+    public TableView? RowGrid { get; set; }
 
     private CancellationTokenSource _cancellationTokenSource;
     private bool _translationInProgress = false;
@@ -1735,7 +1735,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             }
 
             await Task.Delay(5);
-            RowGrid.ScrollIntoView(Rows[scrollIndex], null);
+            RowGrid.ScrollIntoView(Rows[scrollIndex]);
         });
     }
 
@@ -2421,7 +2421,7 @@ public partial class AutoTranslateViewModel : ObservableObject
 
     /// <summary>
     /// Marshals row writes from the background translation loop to the UI thread -
-    /// the rows are DataGrid-bound and Avalonia bindings are not thread-safe.
+    /// the rows are grid-bound and Avalonia bindings are not thread-safe.
     /// </summary>
     private static void ApplyRowUpdateOnUiThread(Action action)
     {

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -39,7 +39,7 @@ public class AutoTranslateWindow : Window
         vm.Window = this;
         _vm = vm;
 
-        var dataGridCard = BuildDataGridCard(vm);
+        var rowGridCard = BuildRowGridCard(vm);
         var controlsCard = BuildControlsCard(vm);
         var apiConfigCard = BuildApiConfigCard(vm);
         var footer = BuildFooter(vm);
@@ -52,8 +52,8 @@ public class AutoTranslateWindow : Window
         };
 
         var row = 0;
-        grid.Children.Add(dataGridCard);
-        Grid.SetRow(dataGridCard, row++);
+        grid.Children.Add(rowGridCard);
+        Grid.SetRow(rowGridCard, row++);
 
         grid.Children.Add(controlsCard);
         Grid.SetRow(controlsCard, row++);
@@ -380,7 +380,7 @@ public class AutoTranslateWindow : Window
         return MakeCard(grid);
     }
 
-    private Border BuildDataGridCard(AutoTranslateViewModel vm)
+    private Border BuildRowGridCard(AutoTranslateViewModel vm)
     {
         var contextMenu = new MenuFlyout
         {
@@ -394,62 +394,62 @@ public class AutoTranslateWindow : Window
             }
         };
 
-        var dataGrid = new DataGrid
+        var tableView = TableViewExtras.MakeTableView();
+        tableView.Height = double.NaN;
+        tableView.ContextFlyout = contextMenu;
+        tableView.DataContext = vm;
+
+        // The DataGrid sized the number and show columns to content (Auto); TableView
+        // treats Auto as star, so they get fixed widths instead.
+        tableView.Columns.Add(new SeTableViewColumn
         {
-            Height = double.NaN,
-            CanUserSortColumns = false,
-            ContextFlyout = contextMenu,
-            DataContext = vm,
-            IsReadOnly = true,
-            AutoGenerateColumns = false,
-            Columns =
-            {
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.NumberSymbol,
-                    Binding = new Binding(nameof(TranslateRow.Number)),
-                    Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.Show,
-                    Binding = new Binding(nameof(TranslateRow.Show)),
-                    Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.Duration,
-                    Binding = new Binding(nameof(TranslateRow.Duration)),
-                    Width = new DataGridLength(80),
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.Text,
-                    Binding = new Binding(nameof(TranslateRow.Text)),
-                    Width = new DataGridLength(200, DataGridLengthUnitType.Star),
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.Translation,
-                    Binding = new Binding(nameof(TranslateRow.TranslatedText)),
-                    Width = new DataGridLength(200, DataGridLengthUnitType.Star),
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                }
-            }
-        };
+            Header = Se.Language.General.NumberSymbol,
+            Binding = new Binding(nameof(TranslateRow.Number)),
+            Width = new GridLength(60),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+        });
+        tableView.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Show,
+            Binding = new Binding(nameof(TranslateRow.Show)),
+            Width = new GridLength(110),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+        });
+        tableView.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Duration,
+            Binding = new Binding(nameof(TranslateRow.Duration)),
+            Width = new GridLength(80),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+        });
+        tableView.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Text,
+            Binding = new Binding(nameof(TranslateRow.Text)),
+            Width = new GridLength(1, GridUnitType.Star),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+        });
+        tableView.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Translation,
+            Binding = new Binding(nameof(TranslateRow.TranslatedText)),
+            Width = new GridLength(1, GridUnitType.Star),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+        });
 
-        dataGrid.Bind(DataGrid.ItemsSourceProperty, new Binding(nameof(vm.Rows)));
-        dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedTranslateRow)));
-        UiUtil.AttachMacContextFlyoutHandler(dataGrid);
-        dataGrid.WithAccessibleName(Se.Language.General.Lines);
-        vm.RowGrid = dataGrid;
+        tableView.Bind(TableView.ItemsSourceProperty, new Binding(nameof(vm.Rows)));
+        tableView.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedTranslateRow)));
+        UiUtil.AttachMacContextFlyoutHandler(tableView);
+        tableView.WithAccessibleName(Se.Language.General.Lines);
+        vm.RowGrid = tableView;
 
-        var dataGridBorder = UiUtil.MakeBorderForControlNoPadding(dataGrid);
-        return MakeCard(dataGridBorder, new Thickness(1));
+        var tableViewBorder = UiUtil.MakeBorderForControlNoPadding(tableView);
+        return MakeCard(tableViewBorder, new Thickness(1));
     }
 
     private Control BuildFooter(AutoTranslateViewModel vm)

--- a/src/ui/Features/Translate/CopyPasteTranslateViewModel.cs
+++ b/src/ui/Features/Translate/CopyPasteTranslateViewModel.cs
@@ -27,7 +27,7 @@ public partial class CopyPasteTranslateViewModel : ObservableObject
     public Window? Window { get; set; }
 
     public bool OkPressed { get; private set; }
-    public DataGrid SubtitleGrid { get; internal set; }
+    public TableView SubtitleGrid { get; internal set; }
 
     private readonly IWindowService _windowService;
 
@@ -35,7 +35,7 @@ public partial class CopyPasteTranslateViewModel : ObservableObject
     {
         _windowService = windowService;
 
-        SubtitleGrid = new DataGrid();
+        SubtitleGrid = new TableView();
         Subtitles = new ObservableCollection<SubtitleLineViewModel>();
         Rows = new ObservableCollection<TranslateRow>();
         MaxBlockSize = Se.Settings.AutoTranslate.CopyPasteMaxBlockSize;
@@ -81,7 +81,7 @@ public partial class CopyPasteTranslateViewModel : ObservableObject
         }
 
         var log = new StringBuilder();
-        var selectedItems = SubtitleGrid.SelectedItems.Cast<SubtitleLineViewModel>().ToList();
+        var selectedItems = SubtitleGrid.SelectedItems?.Cast<SubtitleLineViewModel>().ToList() ?? new List<SubtitleLineViewModel>();
         var startIndex = selectedItems.Count <= 0 ? 0 : Subtitles.IndexOf(selectedItems[0]);
         var start = startIndex;
         var index = startIndex;
@@ -134,7 +134,7 @@ public partial class CopyPasteTranslateViewModel : ObservableObject
         Dispatcher.UIThread.Post(() =>
         {
             SubtitleGrid.SelectedIndex = index;
-            SubtitleGrid.ScrollIntoView(SubtitleGrid.SelectedItem, null);
+            SubtitleGrid.ScrollIntoView(index);
         });
     }
 

--- a/src/ui/Features/Translate/CopyPasteTranslateWindow.cs
+++ b/src/ui/Features/Translate/CopyPasteTranslateWindow.cs
@@ -105,58 +105,57 @@ public class CopyPasteTranslateWindow : Window
 
     private static Border MakeSubtitlesView(CopyPasteTranslateViewModel vm)
     {
-        vm.SubtitleGrid = new DataGrid
-        {
-            Height = double.NaN, // auto size inside scroll viewer
-            Margin = new Thickness(2),
-            ItemsSource = vm.Subtitles, // Use ItemsSource instead of Items
-            CanUserSortColumns = false,
-            IsReadOnly = true,
-            SelectionMode = DataGridSelectionMode.Single,
-            DataContext = vm.Subtitles,
-        };
+        vm.SubtitleGrid = TableViewExtras.MakeTableView(multiSelect: false);
+        vm.SubtitleGrid.Height = double.NaN; // auto size inside scroll viewer
+        vm.SubtitleGrid.Margin = new Thickness(2);
+        vm.SubtitleGrid.ItemsSource = vm.Subtitles;
+        vm.SubtitleGrid.DataContext = vm.Subtitles;
 
         var fullTimeConverter = new TimeSpanToDisplayFullConverter();
         var shortTimeConverter = new TimeSpanToDisplayShortConverter();
 
-        vm.SubtitleGrid.Columns.Add(new DataGridTextColumn
+        vm.SubtitleGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.NumberSymbol,
             Binding = new Binding(nameof(SubtitleLineViewModel.Number)),
-            Width = new DataGridLength(50),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(50),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
-        vm.SubtitleGrid.Columns.Add(new DataGridTextColumn
+        vm.SubtitleGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Show,
             Binding = new Binding(nameof(SubtitleLineViewModel.StartTime)) { Converter = fullTimeConverter },
-            Width = new DataGridLength(120),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(120),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
-        vm.SubtitleGrid.Columns.Add(new DataGridTextColumn
+        vm.SubtitleGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Duration,
             Binding = new Binding(nameof(SubtitleLineViewModel.Duration)) { Converter = shortTimeConverter },
-            Width = new DataGridLength(120),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(120),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
-        vm.SubtitleGrid.Columns.Add(new DataGridTextColumn
+        vm.SubtitleGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Text,
             Binding = new Binding(nameof(SubtitleLineViewModel.OriginalText)),
-            Width = new DataGridLength(1, DataGridLengthUnitType.Star),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(1, GridUnitType.Star),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
-        vm.SubtitleGrid.Columns.Add(new DataGridTextColumn
+        vm.SubtitleGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Translation,
             Binding = new Binding(nameof(SubtitleLineViewModel.Text)),
-            Width = new DataGridLength(1, DataGridLengthUnitType.Star),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(1, GridUnitType.Star),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
 
-        vm.SubtitleGrid.DataContext = vm.Subtitles;
-        vm.SubtitleGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle))
+        vm.SubtitleGrid.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle))
         {
             Source = vm,
             Mode = BindingMode.TwoWay

--- a/src/ui/Features/Video/ShotChanges/ShotChangeListWindow.cs
+++ b/src/ui/Features/Video/ShotChanges/ShotChangeListWindow.cs
@@ -61,51 +61,50 @@ public class ShotChangeListWindow : Window
 
     private static Border MakeBookmarkGridView(ShotChangeListViewModel vm)
     {
-        var dataGrid = new DataGrid
-        {
-            Height = double.NaN, // auto size inside scroll viewer
-            Margin = new Thickness(2),
-            ItemsSource = vm.ShotChanges, // Use ItemsSource instead of Items
-            CanUserSortColumns = false,
-            IsReadOnly = true,
-            SelectionMode = DataGridSelectionMode.Extended,
-            DataContext = vm,
-        };
+        var tableView = TableViewExtras.MakeTableView();
+        tableView.Height = double.NaN; // auto size inside scroll viewer
+        tableView.Margin = new Thickness(2);
+        tableView.ItemsSource = vm.ShotChanges;
+        tableView.DataContext = vm;
 
-        dataGrid.DoubleTapped += vm.OnShotChangeGridDoubleTapped;
-
-        var fullTimeConverter = new TimeSpanToDisplayFullConverter();
-        var shortTimeConverter = new TimeSpanToDisplayShortConverter();
+        tableView.DoubleTapped += vm.OnShotChangeGridDoubleTapped;
 
         // Columns
-        dataGrid.Columns.Add(new DataGridTextColumn
+        tableView.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.NumberSymbol,
             Binding = new Binding(nameof(ShotChangeItem.Index)),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(60),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
-        dataGrid.Columns.Add(new DataGridTextColumn
+        tableView.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Text,
             Binding = new Binding(nameof(ShotChangeItem.TimeText)),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
-            Width = new DataGridLength(1, DataGridLengthUnitType.Star) // star sizing to take all available space
+            Width = new GridLength(1, GridUnitType.Star), // star sizing to take all available space
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
-        dataGrid.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(vm.SelectedShotChange))
+        tableView.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedShotChange))
         {
             Source = vm,
             Mode = BindingMode.TwoWay
         });
-        dataGrid.SelectionChanged += vm.GridSelectionChanged;
-        dataGrid.DoubleTapped += (s, e) => vm.GoToCommand.Execute(null);
-        dataGrid.KeyDown += (s, e) => vm.GridKeyDown(e);
-        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        tableView.SelectionChanged += vm.GridSelectionChanged;
+        tableView.DoubleTapped += (s, e) => vm.GoToCommand.Execute(null);
+        tableView.KeyDown += (s, e) => vm.GridKeyDown(e);
+        tableView.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
         {
-            if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
+            if (e.Key is Key.Home or Key.End && tableView.ItemsSource is IList items && items.Count > 0)
             {
                 var target = e.Key == Key.Home ? items[0] : items[^1];
-                dataGrid.SelectedItem = target;
-                dataGrid.ScrollIntoView(target, null);
+                if (target != null)
+                {
+                    tableView.SelectedItem = target;
+                    tableView.ScrollIntoView(target);
+                }
+
                 e.Handled = true;
             }
         }, Avalonia.Interactivity.RoutingStrategies.Tunnel);
@@ -121,10 +120,10 @@ public class ShotChangeListWindow : Window
             }
         };
         flyout.Items.Add(deleteMenuItem);
-        dataGrid.ContextFlyout = flyout;
-        UiUtil.AttachMacContextFlyoutHandler(dataGrid);
+        tableView.ContextFlyout = flyout;
+        UiUtil.AttachMacContextFlyoutHandler(tableView);
 
-        return UiUtil.MakeBorderForControl(dataGrid);
+        return UiUtil.MakeBorderForControl(tableView);
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Video/ShotChanges/ShotChangesViewModel.cs
+++ b/src/ui/Features/Video/ShotChanges/ShotChangesViewModel.cs
@@ -44,7 +44,7 @@ public partial class ShotChangesViewModel : ObservableObject, IClosingCleanup
     public double LastSeconds { get; private set; }
     public bool OkPressed { get; private set; }
     private StringBuilder Log { get; set; } = new StringBuilder();
-    public DataGrid DataGridFfmpegLines { get; set; }
+    public TableView FfmpegLinesGrid { get; set; }
     public static readonly Regex TimeRegex = new Regex(@"pts_time:\d+[.,]*\d*", RegexOptions.Compiled);
 
     private string _videoFileName = string.Empty;
@@ -60,7 +60,7 @@ public partial class ShotChangesViewModel : ObservableObject, IClosingCleanup
     public ShotChangesViewModel()
     {
         FfmpegLines = new ObservableCollection<TimeItem>();
-        DataGridFfmpegLines = new DataGrid();
+        FfmpegLinesGrid = new TableView();
         ProgressText = string.Empty;
         TimeCodeSeconds = true;
         _frameRate = 23.976;
@@ -181,7 +181,7 @@ public partial class ShotChangesViewModel : ObservableObject, IClosingCleanup
                     {
                         var item = new TimeItem(seconds, FfmpegLines.Count);
                         FfmpegLines.Add(item);
-                        DataGridFfmpegLines.ScrollIntoView(item, null);
+                        FfmpegLinesGrid.ScrollIntoView(item);
 
                         if (_duration != null)
                         {

--- a/src/ui/Features/Video/ShotChanges/ShotChangesWindow.cs
+++ b/src/ui/Features/Video/ShotChanges/ShotChangesWindow.cs
@@ -98,31 +98,28 @@ public class ShotChangesWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        var dataGrid = new DataGrid
-        {
-            Height = double.NaN, // auto size inside scroll viewer
-            Margin = new Thickness(2),
-            ItemsSource = vm.FfmpegLines, // Use ItemsSource instead of Items
-            CanUserSortColumns = false,
-            IsReadOnly = true,
-            SelectionMode = DataGridSelectionMode.Extended,
-            DataContext = vm,
-        };
-        dataGrid.Columns.Add(new DataGridTextColumn
+        var tableView = TableViewExtras.MakeTableView();
+        tableView.Height = double.NaN; // auto size inside scroll viewer
+        tableView.Margin = new Thickness(2);
+        tableView.ItemsSource = vm.FfmpegLines;
+        tableView.DataContext = vm;
+        tableView.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.NumberSymbol,
             Binding = new Binding(nameof(TimeItem.Number)),
-            Width = new DataGridLength(50),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(50),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
-        dataGrid.Columns.Add(new DataGridTextColumn
+        tableView.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.Video.ShotChanges.ShotChangeTimeCode,
             Binding = new Binding(nameof(TimeItem.TimeText)),
-            Width = new DataGridLength(1, DataGridLengthUnitType.Star),
-            CellTheme = UiUtil.DataGridNoBorderCellTheme,
+            Width = new GridLength(1, GridUnitType.Star),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
-        vm.DataGridFfmpegLines = dataGrid;
+        vm.FfmpegLinesGrid = tableView;
 
         var labelSensitivity = UiUtil.MakeLabel(Se.Language.General.Sensitivity);
         var sliderSensitivity = new Slider
@@ -180,7 +177,7 @@ public class ShotChangesWindow : Window
         gridProgress.Add(progressBar, 0);
         gridProgress.Add(progressText, 0);
 
-        grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGrid), 0);
+        grid.Add(UiUtil.MakeBorderForControlNoPadding(tableView), 0);
         grid.Add(panelSensitivity, 1);
         grid.Add(gridProgress, 2);
 

--- a/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceMappingWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceMappingWindow.cs
@@ -139,189 +139,177 @@ public class ActorVoiceMappingWindow : Window
 
     private static Border BuildGrid(ActorVoiceMappingViewModel vm)
     {
-        var dataGrid = new DataGrid
+        var tableView = TableViewExtras.MakeTableView(multiSelect: false);
+        tableView[!TableView.ItemsSourceProperty] = new Binding(nameof(vm.Rows));
+        tableView[!TableView.SelectedItemProperty] = new Binding(nameof(vm.SelectedRow)) { Mode = BindingMode.TwoWay };
+        tableView.Columns.Add(new SeTableViewColumn
         {
-            AutoGenerateColumns = false,
-            IsReadOnly = false,
-            HeadersVisibility = DataGridHeadersVisibility.Column,
-            GridLinesVisibility = DataGridGridLinesVisibility.Horizontal,
-            CanUserReorderColumns = false,
-            CanUserResizeColumns = true,
-            CanUserSortColumns = false,
-            SelectionMode = DataGridSelectionMode.Single,
-            RowHeight = 38,
-            [!DataGrid.ItemsSourceProperty] = new Binding(nameof(vm.Rows)),
-            [!DataGrid.SelectedItemProperty] = new Binding(nameof(vm.SelectedRow)) { Mode = BindingMode.TwoWay },
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Stretch,
-            Columns =
+            Header = Se.Language.Video.TextToSpeech.ActorOrVoice,
+            Binding = new Binding(nameof(ActorVoiceRow.Actor)),
+            Width = new GridLength(180),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+        });
+        tableView.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Engine,
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            CellTemplate = new FuncDataTemplate<ActorVoiceRow>((row, _) =>
             {
-                new DataGridTextColumn
+                if (row == null)
                 {
-                    Header = Se.Language.Video.TextToSpeech.ActorOrVoice,
-                    Binding = new Binding(nameof(ActorVoiceRow.Actor)),
-                    Width = new DataGridLength(180, DataGridLengthUnitType.Pixel),
-                    IsReadOnly = true,
-                    CellTheme = UiUtil.DataGridNoBorderCellTheme,
-                },
-                new DataGridTemplateColumn
+                    return new TextBlock();
+                }
+
+                var combo = new ComboBox
                 {
-                    Header = Se.Language.General.Engine,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    CellTemplate = new FuncDataTemplate<ActorVoiceRow>((row, _) =>
+                    ItemsSource = vm.Engines,
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                    Margin = new Thickness(4, 2),
+                    MinWidth = 160,
+                    DisplayMemberBinding = new Binding(nameof(ITtsEngine.Name)),
+                    [!SelectingItemsControl.SelectedItemProperty] = new Binding(nameof(ActorVoiceRow.SelectedEngine))
                     {
-                        if (row == null)
-                        {
-                            return new TextBlock();
-                        }
-
-                        var combo = new ComboBox
-                        {
-                            ItemsSource = vm.Engines,
-                            HorizontalAlignment = HorizontalAlignment.Stretch,
-                            Margin = new Thickness(4, 2),
-                            MinWidth = 160,
-                            DisplayMemberBinding = new Binding(nameof(ITtsEngine.Name)),
-                            [!SelectingItemsControl.SelectedItemProperty] = new Binding(nameof(ActorVoiceRow.SelectedEngine))
-                            {
-                                Mode = BindingMode.TwoWay,
-                            },
-                        };
-                        return combo;
-                    }),
-                    Width = new DataGridLength(200, DataGridLengthUnitType.Pixel),
-                },
-                new DataGridTemplateColumn
+                        Mode = BindingMode.TwoWay,
+                    },
+                };
+                return combo;
+            }),
+            Width = new GridLength(200),
+        });
+        tableView.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Model,
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            CellTemplate = new FuncDataTemplate<ActorVoiceRow>((row, _) =>
+            {
+                if (row == null)
                 {
-                    Header = Se.Language.General.Model,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    CellTemplate = new FuncDataTemplate<ActorVoiceRow>((row, _) =>
-                    {
-                        if (row == null)
-                        {
-                            return new TextBlock();
-                        }
+                    return new TextBlock();
+                }
 
-                        // Hidden for engines without a model concept (Piper, Edge TTS, ...).
-                        // Empty cell is a clearer "n/a" than a disabled combo full of nothing.
-                        var combo = new ComboBox
-                        {
-                            HorizontalAlignment = HorizontalAlignment.Stretch,
-                            Margin = new Thickness(4, 2),
-                            MinWidth = 140,
-                            [!ItemsControl.ItemsSourceProperty] = new Binding(nameof(ActorVoiceRow.Models)),
-                            [!SelectingItemsControl.SelectedItemProperty] = new Binding(nameof(ActorVoiceRow.SelectedModel))
-                            {
-                                Mode = BindingMode.TwoWay,
-                            },
-                            [!Visual.IsVisibleProperty] = new Binding(nameof(ActorVoiceRow.HasModel))
-                            {
-                                Mode = BindingMode.OneWay,
-                            },
-                        };
-                        return combo;
-                    }),
-                    Width = new DataGridLength(170, DataGridLengthUnitType.Pixel),
-                },
-                new DataGridTemplateColumn
+                // Hidden for engines without a model concept (Piper, Edge TTS, ...).
+                // Empty cell is a clearer "n/a" than a disabled combo full of nothing.
+                var combo = new ComboBox
                 {
-                    Header = Se.Language.General.Voice,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    CellTemplate = new FuncDataTemplate<ActorVoiceRow>((row, _) =>
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                    Margin = new Thickness(4, 2),
+                    MinWidth = 140,
+                    [!ItemsControl.ItemsSourceProperty] = new Binding(nameof(ActorVoiceRow.Models)),
+                    [!SelectingItemsControl.SelectedItemProperty] = new Binding(nameof(ActorVoiceRow.SelectedModel))
                     {
-                        if (row == null)
-                        {
-                            return new TextBlock();
-                        }
-
-                        // Single IsEnabled binding via the row's combined IsVoiceComboReady
-                        // (= IsVoiceComboEnabled && !IsBusy). Avalonia's Bind() replaces an
-                        // existing binding on the same property, so binding twice (once to
-                        // IsVoiceComboEnabled and once to !IsBusy) would silently drop the
-                        // first.
-                        var combo = new ComboBox
-                        {
-                            HorizontalAlignment = HorizontalAlignment.Stretch,
-                            Margin = new Thickness(4, 2),
-                            MinWidth = 200,
-                            [!ItemsControl.ItemsSourceProperty] = new Binding(nameof(ActorVoiceRow.Voices)),
-                            [!SelectingItemsControl.SelectedItemProperty] = new Binding(nameof(ActorVoiceRow.SelectedVoice))
-                            {
-                                Mode = BindingMode.TwoWay,
-                            },
-                            [!InputElement.IsEnabledProperty] = new Binding(nameof(ActorVoiceRow.IsVoiceComboReady))
-                            {
-                                Mode = BindingMode.OneWay,
-                            },
-                            DisplayMemberBinding = new Binding(nameof(Voice.Name)),
-                        };
-
-                        var busy = new TextBlock
-                        {
-                            Text = "…",
-                            VerticalAlignment = VerticalAlignment.Center,
-                            HorizontalAlignment = HorizontalAlignment.Center,
-                            Margin = new Thickness(4),
-                            Opacity = 0.6,
-                            [!Visual.IsVisibleProperty] = new Binding(nameof(ActorVoiceRow.IsBusy))
-                            {
-                                Mode = BindingMode.OneWay,
-                            },
-                        };
-
-                        return new Grid
-                        {
-                            HorizontalAlignment = HorizontalAlignment.Stretch,
-                            Children = { combo, busy },
-                        };
-                    }),
-                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
-                },
-                new DataGridTemplateColumn
+                        Mode = BindingMode.TwoWay,
+                    },
+                    [!Visual.IsVisibleProperty] = new Binding(nameof(ActorVoiceRow.HasModel))
+                    {
+                        Mode = BindingMode.OneWay,
+                    },
+                };
+                return combo;
+            }),
+            Width = new GridLength(170),
+        });
+        tableView.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Voice,
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            CellTemplate = new FuncDataTemplate<ActorVoiceRow>((row, _) =>
+            {
+                if (row == null)
                 {
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    CellTemplate = new FuncDataTemplate<ActorVoiceRow>((row, _) =>
+                    return new TextBlock();
+                }
+
+                // Single IsEnabled binding via the row's combined IsVoiceComboReady
+                // (= IsVoiceComboEnabled && !IsBusy). Avalonia's Bind() replaces an
+                // existing binding on the same property, so binding twice (once to
+                // IsVoiceComboEnabled and once to !IsBusy) would silently drop the
+                // first.
+                var combo = new ComboBox
+                {
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                    Margin = new Thickness(4, 2),
+                    MinWidth = 200,
+                    [!ItemsControl.ItemsSourceProperty] = new Binding(nameof(ActorVoiceRow.Voices)),
+                    [!SelectingItemsControl.SelectedItemProperty] = new Binding(nameof(ActorVoiceRow.SelectedVoice))
                     {
-                        if (row == null)
-                        {
-                            return new TextBlock();
-                        }
+                        Mode = BindingMode.TwoWay,
+                    },
+                    [!InputElement.IsEnabledProperty] = new Binding(nameof(ActorVoiceRow.IsVoiceComboReady))
+                    {
+                        Mode = BindingMode.OneWay,
+                    },
+                    DisplayMemberBinding = new Binding(nameof(Voice.Name)),
+                };
 
-                        // Per-row "..." button → opens ActorVoiceRowSettingsWindow for voice
-                        // instruction + OmniVoice keyword picker. Disabled for engines that have
-                        // no advanced settings so the user doesn't open an empty dialog.
-                        var settingsBtn = UiUtil.MakeButton(vm.ShowRowSettingsCommand, IconNames.Settings,
-                            Se.Language.Video.TextToSpeech.ActorVoicesRowSettingsTitle);
-                        settingsBtn.CommandParameter = row;
-                        settingsBtn.Margin = new Thickness(4, 2);
-                        settingsBtn.Bind(InputElement.IsEnabledProperty, new Binding(nameof(ActorVoiceRow.HasAdvancedSettings))
-                        {
-                            Mode = BindingMode.OneWay,
-                        });
+                var busy = new TextBlock
+                {
+                    Text = "…",
+                    VerticalAlignment = VerticalAlignment.Center,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    Margin = new Thickness(4),
+                    Opacity = 0.6,
+                    [!Visual.IsVisibleProperty] = new Binding(nameof(ActorVoiceRow.IsBusy))
+                    {
+                        Mode = BindingMode.OneWay,
+                    },
+                };
 
-                        var testBtn = UiUtil.MakeButton(vm.TestRowCommand, "fa-solid fa-play", Se.Language.Video.TextToSpeech.TestVoice);
-                        testBtn.CommandParameter = row;
-                        testBtn.Margin = new Thickness(4, 2);
-                        testBtn.Bind(InputElement.IsEnabledProperty, new Binding(nameof(ActorVoiceRow.SelectedVoice))
-                        {
-                            Mode = BindingMode.OneWay,
-                            Converter = new NotNullConverter(),
-                        });
+                return new Grid
+                {
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                    Children = { combo, busy },
+                };
+            }),
+            Width = new GridLength(1, GridUnitType.Star),
+        });
+        tableView.Columns.Add(new SeTableViewColumn
+        {
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            CellTemplate = new FuncDataTemplate<ActorVoiceRow>((row, _) =>
+            {
+                if (row == null)
+                {
+                    return new TextBlock();
+                }
 
-                        return new StackPanel
-                        {
-                            Orientation = Orientation.Horizontal,
-                            HorizontalAlignment = HorizontalAlignment.Center,
-                            Spacing = 4,
-                            Children = { settingsBtn, testBtn },
-                        };
-                    }),
-                    Width = new DataGridLength(110, DataGridLengthUnitType.Pixel),
-                },
-            },
-        };
+                // Per-row "..." button → opens ActorVoiceRowSettingsWindow for voice
+                // instruction + OmniVoice keyword picker. Disabled for engines that have
+                // no advanced settings so the user doesn't open an empty dialog.
+                var settingsBtn = UiUtil.MakeButton(vm.ShowRowSettingsCommand, IconNames.Settings,
+                    Se.Language.Video.TextToSpeech.ActorVoicesRowSettingsTitle);
+                settingsBtn.CommandParameter = row;
+                settingsBtn.Margin = new Thickness(4, 2);
+                settingsBtn.Bind(InputElement.IsEnabledProperty, new Binding(nameof(ActorVoiceRow.HasAdvancedSettings))
+                {
+                    Mode = BindingMode.OneWay,
+                });
 
-        return UiUtil.MakeBorderForControl(dataGrid);
+                var testBtn = UiUtil.MakeButton(vm.TestRowCommand, "fa-solid fa-play", Se.Language.Video.TextToSpeech.TestVoice);
+                testBtn.CommandParameter = row;
+                testBtn.Margin = new Thickness(4, 2);
+                testBtn.Bind(InputElement.IsEnabledProperty, new Binding(nameof(ActorVoiceRow.SelectedVoice))
+                {
+                    Mode = BindingMode.OneWay,
+                    Converter = new NotNullConverter(),
+                });
+
+                return new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    Spacing = 4,
+                    Children = { settingsBtn, testBtn },
+                };
+            }),
+            Width = new GridLength(110),
+        });
+
+        return UiUtil.MakeBorderForControl(tableView);
     }
 
     private static StackPanel BuildButtons(ActorVoiceMappingViewModel vm)

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -88,7 +88,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
     private bool _suppressKeywordSync;
 
     public Window? Window { get; set; }
-    public DataGrid LineGrid { get; internal set; }
+    public TableView LineGrid { get; internal set; }
     public AudioVisualizer? AudioVisualizer { get; set; }
     public TtsStepResult[] StepResults { get; set; }
 
@@ -138,7 +138,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
         _folderHelper = folderHelper;
         _windowService = windowService;
 
-        LineGrid = new DataGrid();
+        LineGrid = new TableView();
         Lines = new ObservableCollection<ReviewRow>();
         Engines = new ObservableCollection<ITtsEngine>();
         Voices = new ObservableCollection<Voice>();
@@ -230,7 +230,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
                         nextLine.IsPlaying = true;
                         _playingRow = nextLine;
                         SelectedLine = nextLine;
-                        LineGrid.ScrollIntoView(nextLine, null);
+                        LineGrid.ScrollIntoView(nextLine);
                         await PlayAudio(nextLine.StepResult.CurrentFileName);
                     }
                     else
@@ -426,7 +426,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
         {
             SelectedLine = Lines[0];
             LineGrid.SelectedIndex = 0;
-            LineGrid.ScrollIntoView(LineGrid.SelectedItem, null);
+            LineGrid.ScrollIntoView(Lines[0]);
         }
     }
 
@@ -1882,7 +1882,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
         UiUtil.SaveWindowPosition(Window);
     }
 
-    internal void DataGridDoubleClicked()
+    internal void LineGridDoubleClicked()
     {
         var line = SelectedLine;
         if (line == null || line.IsPlaying || !line.IsPlayingEnabled)

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
@@ -35,7 +35,7 @@ public class ReviewSpeechWindow : Window
         DataContext = vm;
 
         var controls = MakeControls(vm);
-        var dataGrid = MakeDataGrid(vm);
+        var lineGridView = MakeLineGrid(vm);
         var waveform = MakeWaveform(vm);
 
         // Disabled while a regenerate runs: its progress popup is non-modal, and publishing
@@ -72,7 +72,7 @@ public class ReviewSpeechWindow : Window
         };
 
         grid.Add(controls, 0, 0);
-        grid.Add(dataGrid, 0, 1);
+        grid.Add(lineGridView, 0, 1);
         grid.Add(waveform, 1, 0, 1, 2);
         grid.Add(panelButtons, 2, 0, 1, 2);
         grid.Add(checkBoxAutoContinue, 2, 0);
@@ -83,7 +83,7 @@ public class ReviewSpeechWindow : Window
         // focused element) without arming any button: a focused button fires OnClick on bare
         // Space/Enter, and OK used to be focused here - so the first Space a user pressed
         // published the whole session instead of playing the selected line (#12093).
-        Activated += delegate { vm.LineGrid.Focus(); };
+        Activated += delegate { TableViewExtras.FocusRow(vm.LineGrid); };
 
         // Tunnel-stage handlers: see Space/R before the focused control does. KeyDown alone is
         // not enough - Avalonia's Button fires OnClick from OnKeyUp on Space (unconditionally
@@ -106,127 +106,125 @@ public class ReviewSpeechWindow : Window
         };
     }
 
-    private static Border MakeDataGrid(ReviewSpeechViewModel vm)
+    private static Border MakeLineGrid(ReviewSpeechViewModel vm)
     {
-        var dataGrid = new DataGrid
+        var lineGrid = TableViewExtras.MakeTableView(multiSelect: false);
+        lineGrid.Margin = new Thickness(0, 10, 0, 0);
+        lineGrid.Width = double.NaN;
+        lineGrid.Height = double.NaN;
+        lineGrid[!TableView.ItemsSourceProperty] = new Binding(nameof(vm.Lines));
+        lineGrid[!TableView.SelectedItemProperty] = new Binding(nameof(vm.SelectedLine)) { Mode = BindingMode.TwoWay };
+
+        // Re-enabled: OK publishes only rows with Include ticked and Export/Import
+        // round-trip the flag, so without this column an imported session's excluded
+        // rows were invisible and could never be re-included.
+        lineGrid.Columns.Add(new SeTableViewColumn
         {
-            AutoGenerateColumns = false,
-            IsReadOnly = true,
-            SelectionMode = DataGridSelectionMode.Single,
-            Margin = new Thickness(0, 10, 0, 0),
-            [!DataGrid.ItemsSourceProperty] = new Binding(nameof(vm.Lines)),
-            [!DataGrid.SelectedItemProperty] = new Binding(nameof(vm.SelectedLine)) { Mode = BindingMode.TwoWay },
-            Width = double.NaN,
-            Height = double.NaN,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Stretch,
-            Columns =
-            {
-                // Re-enabled: OK publishes only rows with Include ticked and Export/Import
-                // round-trip the flag, so without this column an imported session's excluded
-                // rows were invisible and could never be re-included.
-                new DataGridTemplateColumn
+            Header = Se.Language.General.Enabled,
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            CellTemplate = new FuncDataTemplate<ReviewRow>((item, _) =>
+                new Border
                 {
-                    Header = Se.Language.General.Enabled,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    CellTemplate = new FuncDataTemplate<ReviewRow>((item, _) =>
-                        new Border
-                        {
-                            Background = Brushes.Transparent, // Prevents highlighting
-                            Padding = new Thickness(4),
-                            Child = new CheckBox
-                            {
-                                [!ToggleButton.IsCheckedProperty] = new Binding(nameof(ReviewRow.Include)),
-                                HorizontalAlignment = HorizontalAlignment.Center
-                            }
-                        }),
-                    Width = new DataGridLength(1, DataGridLengthUnitType.Auto)
-                },
-                new DataGridTemplateColumn
-                {
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    CellTemplate = new FuncDataTemplate<ReviewRow>((item, _) =>
+                    Background = Brushes.Transparent, // Prevents highlighting
+                    Padding = new Thickness(4),
+                    Child = new CheckBox
                     {
-                        var buttonRegenerate = UiUtil.MakeButton(vm.RegenerateAudioCommand, IconNames.Recycle)
-                        .WithBindEnabled(nameof(item.IsPlayingEnabled));
-                        buttonRegenerate.CommandParameter = item;
-                        if (Se.Settings.Appearance.ShowHints)
-                        {
-                            ToolTip.SetTip(buttonRegenerate, Se.Language.Video.TextToSpeech.RegenerateAudio);
-                        }
+                        [!ToggleButton.IsCheckedProperty] = new Binding(nameof(ReviewRow.Include)),
+                        HorizontalAlignment = HorizontalAlignment.Center
+                    }
+                }),
+            Width = new GridLength(80),
+        });
+        lineGrid.Columns.Add(new SeTableViewColumn
+        {
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            CellTemplate = new FuncDataTemplate<ReviewRow>((item, _) =>
+            {
+                var buttonRegenerate = UiUtil.MakeButton(vm.RegenerateAudioCommand, IconNames.Recycle)
+                .WithBindEnabled(nameof(item.IsPlayingEnabled));
+                buttonRegenerate.CommandParameter = item;
+                if (Se.Settings.Appearance.ShowHints)
+                {
+                    ToolTip.SetTip(buttonRegenerate, Se.Language.Video.TextToSpeech.RegenerateAudio);
+                }
 
-                        var buttonHistory = UiUtil.MakeButton(vm.ShowHistoryCommand, IconNames.DotsVertical).WithBindEnabled(nameof(ReviewRow.HasHistory));
-                        buttonHistory.CommandParameter = item;
-                        buttonHistory.Bind(Button.OpacityProperty, new Binding(nameof(ReviewRow.HistoryButtonOpacity)));
-                        if (Se.Settings.Appearance.ShowHints)
-                        {
-                            ToolTip.SetTip(buttonHistory, Se.Language.General.ShowHistory);
-                        }
+                var buttonHistory = UiUtil.MakeButton(vm.ShowHistoryCommand, IconNames.DotsVertical).WithBindEnabled(nameof(ReviewRow.HasHistory));
+                buttonHistory.CommandParameter = item;
+                buttonHistory.Bind(Button.OpacityProperty, new Binding(nameof(ReviewRow.HistoryButtonOpacity)));
+                if (Se.Settings.Appearance.ShowHints)
+                {
+                    ToolTip.SetTip(buttonHistory, Se.Language.General.ShowHistory);
+                }
 
-                        var buttonPlay = UiUtil.MakeButton(vm.PlayRowCommand,"fa-solid fa-play")
-                        .WithBindIsVisible(nameof(item.IsPlaying), new InverseBooleanConverter())
-                        .WithBindEnabled(nameof(item.IsPlayingEnabled));
-                        buttonPlay.CommandParameter = item;
+                var buttonPlay = UiUtil.MakeButton(vm.PlayRowCommand,"fa-solid fa-play")
+                .WithBindIsVisible(nameof(item.IsPlaying), new InverseBooleanConverter())
+                .WithBindEnabled(nameof(item.IsPlayingEnabled));
+                buttonPlay.CommandParameter = item;
 
-                        var buttonStop = UiUtil.MakeButton(vm.StopCommand, "fa-solid fa-stop")
-                        .WithBindIsVisible(nameof(item.IsPlaying));
-                        buttonStop.CommandParameter = item;
+                var buttonStop = UiUtil.MakeButton(vm.StopCommand, "fa-solid fa-stop")
+                .WithBindIsVisible(nameof(item.IsPlaying));
+                buttonStop.CommandParameter = item;
 
-                        return new StackPanel
-                        {
-                            Orientation = Orientation.Horizontal,
-                            HorizontalAlignment = HorizontalAlignment.Center,
-                            Spacing = 5,
-                            Children =
-                            {
-                                buttonRegenerate,
-                                buttonHistory,
-                                buttonPlay,
-                                buttonStop,
-                            }
-                        };
-                    }),
-                    Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
-                },
-                new DataGridTextColumn
+                return new StackPanel
                 {
-                    Header = Se.Language.General.NumberSymbol,
-                    Binding = new Binding(nameof(ReviewRow.Number)),
-                    Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
-                    CellTheme = UiUtil.DataGridNoBorderCellTheme,
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.Voice,
-                    Binding = new Binding(nameof(ReviewRow.Voice)),
-                    Width = new DataGridLength(3, DataGridLengthUnitType.Auto),
-                    CellTheme = UiUtil.DataGridNoBorderCellTheme,
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.CharsPerSec,
-                    Binding = new Binding(nameof(ReviewRow.Cps)),
-                    Width = new DataGridLength(3, DataGridLengthUnitType.Auto),
-                    CellTheme = UiUtil.DataGridNoBorderCellTheme,
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.Speed,
-                    Binding = new Binding(nameof(ReviewRow.Speed)),
-                    Width = new DataGridLength(3, DataGridLengthUnitType.Auto),
-                    CellTheme = UiUtil.DataGridNoBorderCellTheme,
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.Text,
-                    Binding = new Binding(nameof(ReviewRow.Text)),
-                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
-                    CellTheme = UiUtil.DataGridNoBorderCellTheme,
-                },
-            },
-        };
-        dataGrid.DoubleTapped += (s, e) => vm.DataGridDoubleClicked();
-        vm.LineGrid = dataGrid;
+                    Orientation = Orientation.Horizontal,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    Spacing = 5,
+                    Children =
+                    {
+                        buttonRegenerate,
+                        buttonHistory,
+                        buttonPlay,
+                        buttonStop,
+                    }
+                };
+            }),
+            Width = new GridLength(150),
+        });
+        lineGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.NumberSymbol,
+            Binding = new Binding(nameof(ReviewRow.Number)),
+            Width = new GridLength(50),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+        });
+        lineGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Voice,
+            Binding = new Binding(nameof(ReviewRow.Voice)),
+            Width = new GridLength(150),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+        });
+        lineGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.CharsPerSec,
+            Binding = new Binding(nameof(ReviewRow.Cps)),
+            Width = new GridLength(80),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+        });
+        lineGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Speed,
+            Binding = new Binding(nameof(ReviewRow.Speed)),
+            Width = new GridLength(70),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+        });
+        lineGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Text,
+            Binding = new Binding(nameof(ReviewRow.Text)),
+            Width = new GridLength(1, GridUnitType.Star),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+        });
+        lineGrid.DoubleTapped += (s, e) => vm.LineGridDoubleClicked();
+        vm.LineGrid = lineGrid;
 
         var textBox = new TextBox
         {
@@ -261,7 +259,7 @@ public class ReviewSpeechWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(dataGrid, 0, 0);
+        grid.Add(lineGrid, 0, 0);
         grid.Add(textBox, 1, 0);
 
         return UiUtil.MakeBorderForControl(grid);

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeechHistory/ReviewSpeechHistoryWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeechHistory/ReviewSpeechHistoryWindow.cs
@@ -59,56 +59,49 @@ public class ReviewSpeechHistoryWindow : Window
 
     private static Border MakeHistoryGrid(ReviewSpeechHistoryViewModel vm)
     {
-        var dataGrid = new DataGrid
+        var tableView = TableViewExtras.MakeTableView(multiSelect: false);
+        tableView.Margin = new Thickness(0, 10, 0, 0);
+        tableView.Width = double.NaN;
+        tableView.Height = double.NaN;
+        tableView[!TableView.ItemsSourceProperty] = new Binding(nameof(vm.HistoryItems));
+        tableView[!TableView.SelectedItemProperty] = new Binding(nameof(vm.SelectedHistoryItem)) { Mode = BindingMode.TwoWay };
+        tableView.Columns.Add(new SeTableViewColumn
         {
-            AutoGenerateColumns = false,
-            IsReadOnly = true,
-            SelectionMode = DataGridSelectionMode.Single,
-            Margin = new Thickness(0, 10, 0, 0),
-            [!DataGrid.ItemsSourceProperty] = new Binding(nameof(vm.HistoryItems)),
-            [!DataGrid.SelectedItemProperty] = new Binding(nameof(vm.SelectedHistoryItem)) { Mode = BindingMode.TwoWay },
-            Width = double.NaN,
-            Height = double.NaN,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Stretch,
-            Columns =
+            Header = Se.Language.General.NumberSymbol,
+            Binding = new Binding(nameof(ReviewHistoryRow.Number)),
+            Width = new GridLength(50),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+        });
+        tableView.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Voice,
+            Binding = new Binding(nameof(ReviewHistoryRow.VoiceName)),
+            Width = new GridLength(3, GridUnitType.Star),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+        });
+        tableView.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.History,
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            CellTemplate = new FuncDataTemplate<ReviewHistoryRow>((item, _) =>
             {
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.NumberSymbol,
-                    Binding = new Binding(nameof(ReviewHistoryRow.Number)),
-                    Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
-                    CellTheme = UiUtil.DataGridNoBorderCellTheme,
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.Voice,
-                    Binding = new Binding(nameof(ReviewHistoryRow.VoiceName)),
-                    Width = new DataGridLength(3, DataGridLengthUnitType.Star),
-                    CellTheme = UiUtil.DataGridNoBorderCellTheme,
-                },
-                new DataGridTemplateColumn
-                {
-                    Header = Se.Language.General.History,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    CellTemplate = new FuncDataTemplate<ReviewHistoryRow>((item, _) =>
-                    {
-                        var buttonPlay = UiUtil.MakeButton(vm.PlayItemCommand,"fa-solid fa-play")
-                            .WithBindIsVisible(nameof(item.IsPlaying), new InverseBooleanConverter())
-                            .WithBindEnabled(nameof(item.IsPlayingEnabled));
-                        buttonPlay.CommandParameter = item;
-                        
-                        var buttonStop = UiUtil.MakeButton(vm.StopItemCommand,"fa-solid fa-stop")
-                            .WithBindIsVisible(nameof(item.IsPlaying));
-                        buttonStop.CommandParameter = item;
+                var buttonPlay = UiUtil.MakeButton(vm.PlayItemCommand,"fa-solid fa-play")
+                    .WithBindIsVisible(nameof(item.IsPlaying), new InverseBooleanConverter())
+                    .WithBindEnabled(nameof(item.IsPlayingEnabled));
+                buttonPlay.CommandParameter = item;
 
-                        return UiUtil.MakeHorizontalPanel(buttonPlay, buttonStop);
-                    }),
-                    Width = new DataGridLength(1, DataGridLengthUnitType.Auto),
-                },
-            },
-        };
+                var buttonStop = UiUtil.MakeButton(vm.StopItemCommand,"fa-solid fa-stop")
+                    .WithBindIsVisible(nameof(item.IsPlaying));
+                buttonStop.CommandParameter = item;
 
-        return UiUtil.MakeBorderForControlNoPadding(dataGrid);
+                return UiUtil.MakeHorizontalPanel(buttonPlay, buttonStop);
+            }),
+            Width = new GridLength(90),
+        });
+
+        return UiUtil.MakeBorderForControlNoPadding(tableView);
     }
 }

--- a/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
@@ -364,77 +364,98 @@ public class VideoOcrWindow : Window
     {
         var fullTimeConverter = new TimeSpanToDisplayFullConverter();
         var shortTimeConverter = new TimeSpanToDisplayShortConverter();
-        var dataGrid = new DataGrid
+        var tableView = TableViewExtras.MakeTableView();
+        tableView.DataContext = vm;
+        tableView.ItemsSource = vm.Lines;
+
+        tableView.Columns.Add(new SeTableViewColumn
         {
-            AutoGenerateColumns = false,
-            SelectionMode = DataGridSelectionMode.Extended,
-            CanUserResizeColumns = true,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Stretch,
-            IsReadOnly = false, // the text column is editable so OCR mistakes can be fixed in place
-            DataContext = vm,
-            ItemsSource = vm.Lines,
-            Columns =
+            Header = Se.Language.General.NumberSymbol,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(VideoOcrLineItem.Number)),
+            Width = new GridLength(50),
+        });
+        tableView.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Show,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(VideoOcrLineItem.StartTime)) { Converter = fullTimeConverter },
+            Width = new GridLength(110),
+        });
+        tableView.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Hide,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(VideoOcrLineItem.EndTime)) { Converter = fullTimeConverter },
+            Width = new GridLength(110),
+        });
+        tableView.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Duration,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(VideoOcrLineItem.Duration)) { Converter = shortTimeConverter },
+            Width = new GridLength(90),
+        });
+
+        // TableView has no cell editing, so the editable text column (OCR mistakes must stay
+        // fixable in place) becomes a borderless in-cell TextBox bound two-way.
+        tableView.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Text,
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(1, GridUnitType.Star),
+            CellTemplate = new Avalonia.Controls.Templates.FuncDataTemplate<VideoOcrLineItem>((item, _) =>
             {
-                new DataGridTextColumn
+                if (item == null)
                 {
-                    Header = Se.Language.General.NumberSymbol,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    Binding = new Binding(nameof(VideoOcrLineItem.Number)),
-                    IsReadOnly = true,
-                },
-                new DataGridTextColumn
+                    return new TextBlock();
+                }
+
+                var textBox = new TextBox
                 {
-                    Header = Se.Language.General.Show,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    Binding = new Binding(nameof(VideoOcrLineItem.StartTime)) { Converter = fullTimeConverter },
-                    IsReadOnly = true,
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.Hide,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    Binding = new Binding(nameof(VideoOcrLineItem.EndTime)) { Converter = fullTimeConverter },
-                    IsReadOnly = true,
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.Duration,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    Binding = new Binding(nameof(VideoOcrLineItem.Duration)) { Converter = shortTimeConverter },
-                    IsReadOnly = true,
-                },
-                new DataGridTextColumn
-                {
-                    Header = Se.Language.General.Text,
-                    CellTheme = UiUtil.DataGridNoBorderNoPaddingCellTheme,
-                    Binding = new Binding(nameof(VideoOcrLineItem.Text)),
-                    IsReadOnly = false,
-                    Width = new DataGridLength(1, DataGridLengthUnitType.Star),
-                },
-            },
-        };
+                    Background = Brushes.Transparent,
+                    BorderThickness = new Thickness(0),
+                    VerticalContentAlignment = VerticalAlignment.Center,
+                    [!TextBox.TextProperty] = new Binding(nameof(VideoOcrLineItem.Text)) { Mode = BindingMode.TwoWay },
+                };
+
+                // Clicking into a cell to edit should also make it the current row, so the
+                // double-tap preview seek and Delete act on the line being edited.
+                textBox.GotFocus += (_, _) => tableView.SelectedItem = item;
+                return textBox;
+            }),
+        });
 
         // Double-click a line to see the frame it came from in the preview.
-        dataGrid.DoubleTapped += (s, e) =>
+        tableView.DoubleTapped += (s, e) =>
         {
-            if (dataGrid.SelectedItem is VideoOcrLineItem item)
+            if (tableView.SelectedItem is VideoOcrLineItem item)
             {
                 vm.SeekPreview(item);
             }
         };
 
         // Delete removes the selected lines (unless a cell edit is in progress).
-        dataGrid.KeyDown += (s, e) =>
+        tableView.KeyDown += (s, e) =>
         {
             if (e.Key == Avalonia.Input.Key.Delete && e.Source is not TextBox)
             {
-                vm.DeleteLines(dataGrid.SelectedItems.OfType<VideoOcrLineItem>().ToList());
+                var selectedItems = tableView.SelectedItems;
+                if (selectedItems != null)
+                {
+                    vm.DeleteLines(selectedItems.OfType<VideoOcrLineItem>().ToList());
+                }
+
                 e.Handled = true;
             }
         };
 
-        return UiUtil.MakeBorderForControl(dataGrid);
+        return UiUtil.MakeBorderForControl(tableView);
     }
 
     private static Grid MakeProgressView(VideoOcrViewModel vm)

--- a/src/ui/Logic/TableViewExtras.cs
+++ b/src/ui/Logic/TableViewExtras.cs
@@ -297,6 +297,38 @@ public static class TableViewExtras
     }
 
     /// <summary>
+    /// Space toggles the checkbox value of every selected row - all rows checked means
+    /// uncheck all, otherwise check all. This is the piece of the DataGrid-era
+    /// CheckboxMultiSelect helper that TableView does not provide natively (extended
+    /// selection itself is native ListBox behavior).
+    /// </summary>
+    public static void AddSpaceToggle<TItem>(TableView tableView, Func<TItem, bool> getChecked, Action<TItem, bool> setChecked)
+        where TItem : class
+    {
+        tableView.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (e.Key != Key.Space)
+            {
+                return;
+            }
+
+            var selected = tableView.SelectedItems?.OfType<TItem>().ToList();
+            if (selected == null || selected.Count == 0)
+            {
+                return;
+            }
+
+            var newValue = !selected.All(getChecked);
+            foreach (var item in selected)
+            {
+                setChecked(item, newValue);
+            }
+
+            e.Handled = true;
+        }, Avalonia.Interactivity.RoutingStrategies.Tunnel);
+    }
+
+    /// <summary>
     /// Moves keyboard focus to the selected row's container when it is realized, falling
     /// back to the TableView itself. Focusing the row (not the list control) is what makes
     /// the current line visible to screen readers via UI Automation (issue #13015).

--- a/src/ui/Logic/TableViewExtras.cs
+++ b/src/ui/Logic/TableViewExtras.cs
@@ -49,6 +49,108 @@ public class SeTableViewColumn : TableViewColumn
 }
 
 /// <summary>
+/// Click-to-sort for TableView column headers (TableView itself has no sorting).
+/// Register the sortable columns with a key selector; clicking a registered header
+/// sorts the grid's ItemsSource in place (stable, toggling ascending/descending on
+/// repeated clicks) and shows an arrow in the header. Selection is preserved.
+/// Note this reorders the backing collection - unlike the DataGrid, which sorted a
+/// view - so only use it on grids where the collection order is presentation-only.
+/// </summary>
+public sealed class TableViewHeaderSorter
+{
+    private readonly TableView _tableView;
+    private readonly Dictionary<TableViewColumn, Comparison<object>> _comparisons = new();
+    private readonly Dictionary<TableViewColumn, object?> _originalHeaders = new();
+    private TableViewColumn? _sortColumn;
+    private bool _descending;
+
+    public TableViewHeaderSorter(TableView tableView)
+    {
+        _tableView = tableView;
+        tableView.AddHandler(InputElement.TappedEvent, OnTapped, Avalonia.Interactivity.RoutingStrategies.Bubble);
+    }
+
+    /// <summary>Makes <paramref name="column"/> sortable by <paramref name="key"/>.</summary>
+    public TableViewHeaderSorter AddSortable<TItem, TKey>(TableViewColumn column, Func<TItem, TKey> key)
+    {
+        return AddSortable(column, (a, b) => Comparer<TKey>.Default.Compare(key((TItem)a), key((TItem)b)));
+    }
+
+    /// <summary>Makes <paramref name="column"/> sortable by a custom comparison of the row items.</summary>
+    public TableViewHeaderSorter AddSortable(TableViewColumn column, Comparison<object> comparison)
+    {
+        _comparisons[column] = comparison;
+        _originalHeaders[column] = column.Header;
+        return this;
+    }
+
+    private void OnTapped(object? sender, TappedEventArgs e)
+    {
+        if (e.Source is not Visual source ||
+            source.FindAncestorOfType<Thumb>(includeSelf: true) != null) // resize grip
+        {
+            return;
+        }
+
+        var header = source.FindAncestorOfType<TableViewColumnHeader>(includeSelf: true);
+        if (header?.Column is not { } column || !_comparisons.TryGetValue(column, out var comparison))
+        {
+            return;
+        }
+
+        _descending = ReferenceEquals(_sortColumn, column) && !_descending;
+        _sortColumn = column;
+        Apply(comparison);
+        UpdateHeaders();
+        e.Handled = true;
+    }
+
+    private void Apply(Comparison<object> comparison)
+    {
+        if (_tableView.ItemsSource is not System.Collections.IList list || list.Count < 2)
+        {
+            return;
+        }
+
+        var comparer = Comparer<object>.Create(comparison);
+        var items = list.Cast<object>();
+        var sorted = (_descending
+            ? items.OrderByDescending(x => x, comparer)
+            : items.OrderBy(x => x, comparer)).ToList(); // OrderBy is stable in both directions
+
+        var selectedItems = _tableView.SelectedItems?.Cast<object>().ToList() ?? new List<object>();
+        var selectedItem = _tableView.SelectedItem;
+
+        list.Clear();
+        foreach (var item in sorted)
+        {
+            list.Add(item);
+        }
+
+        foreach (var item in selectedItems)
+        {
+            _tableView.SelectedItems?.Add(item);
+        }
+
+        _tableView.SelectedItem = selectedItem;
+        if (selectedItem != null)
+        {
+            _tableView.ScrollIntoView(selectedItem);
+        }
+    }
+
+    private void UpdateHeaders()
+    {
+        foreach (var (column, originalHeader) in _originalHeaders)
+        {
+            column.Header = ReferenceEquals(column, _sortColumn)
+                ? $"{originalHeader} {(_descending ? "▼" : "▲")}"
+                : originalHeader;
+        }
+    }
+}
+
+/// <summary>
 /// Owns the full, ordered column list of a <see cref="TableView"/> and keeps the
 /// control's live <see cref="TableView.Columns"/> in sync with each
 /// <see cref="SeTableViewColumn.IsVisible"/>: hidden columns are removed from the
@@ -121,16 +223,20 @@ public sealed class TableViewColumnManager
 public static class TableViewExtras
 {
     /// <summary>
-    /// Creates a TableView with SE's standard look and behavior (multi-select,
-    /// resizable columns, tight row style).
+    /// Creates a TableView with SE's standard look and behavior (multi-select by
+    /// default, resizable columns, tight row style).
     /// </summary>
-    public static TableView MakeTableView(bool alwaysSelected = true)
+    public static TableView MakeTableView(bool alwaysSelected = true, bool multiSelect = true)
     {
+        var selectionMode = multiSelect ? SelectionMode.Multiple : SelectionMode.Single;
+        if (alwaysSelected)
+        {
+            selectionMode |= SelectionMode.AlwaysSelected;
+        }
+
         var tableView = new TableView
         {
-            SelectionMode = alwaysSelected
-                ? SelectionMode.Multiple | SelectionMode.AlwaysSelected
-                : SelectionMode.Multiple,
+            SelectionMode = selectionMode,
             CanUserResizeColumns = true,
             HorizontalAlignment = HorizontalAlignment.Stretch,
             VerticalAlignment = VerticalAlignment.Stretch,


### PR DESCRIPTION
Continues the TableView migration from #13017 (main subtitle grid, issue #13015).

## What

**1. Header-click sorting for TableView** (`TableViewHeaderSorter` in `TableViewExtras`): TableView has no sorting, so this fills the gap for later batches — register sortable columns with a key selector, clicking the header sorts ascending/descending (stable) with an ▲/▼ arrow, selection preserved. It reorders the backing collection in place (TableView has no view layer), so it's for grids where collection order is presentation-only. Not yet wired anywhere — batch 2 will use it. `MakeTableView` also gained single-select support for picker dialogs.

**2. Batch 1 conversions — every dialog grid that had no sorting (21 windows):**
BinaryEdit, Bookmarks, ErrorList, FindText, Compare, ExportCustomTextFormat, ExportImageBased, ImportCsvXlsxCustomColumns, RestoreAutoBackup, BatchErrorList, FixNames, MergeContinuationLines, MergeTwoSubtitles, SortBy, FindDoubleLines, FindDoubleWords, AutoTranslate, CopyPasteTranslate, ShotChanges (list + generate), ActorVoiceMapping, ReviewSpeech, ReviewSpeechHistory, VideoOcr.

Each grid keyboard-focuses its rows now, so the #13015 screen-reader fix applies to these dialogs too.

## Notable mappings

- Former Auto-width columns → fixed pixel widths (TableView has no content sizing); the text column stays the star column. Time columns reuse the main grid's widths (Show/Hide 110–120, Duration 90).
- `DataGridCheckboxMultiSelect`: shift/ctrl extended selection is native ListBox behavior; the Space-toggles-checkbox piece moved into `TableViewExtras.AddSpaceToggle` (BinaryEdit Forced, FixNames, MergeContinuationLines). The old helper class remains for the not-yet-converted DataGrids.
- BinaryEdit's mode-dependent zone-dot column goes through `TableViewColumnManager` (TableView columns have no IsVisible).
- VideoOcr's editable Text column (TableView has no cell editing) became a borderless in-cell two-way `TextBox`; focusing it selects its row so double-tap seek and Delete act on the edited line.
- Dropped only DataGrid-isms with no behavior behind them: `IsReadOnly`, `CanUserSortColumns` (all false/no-op here), `GridLinesVisibility` overrides (cell themes follow the user's grid-lines setting), `RowHeight` (rows auto-size).

## Testing

Builds clean; no new warnings (remaining mentions of "DataGrid" in converted files are explanatory comments). Runtime smoke tests to do per dialog — the riskiest spots:

- [ ] BinaryEdit: zone column toggling, Space-toggles-Forced, insert before/after selection handling
- [ ] VideoOcr: in-cell text editing + Delete key + double-tap seek
- [ ] FixNames / MergeContinuationLines: Space toggle + checkbox columns
- [ ] Compare: two synced grids scroll/selection
- [ ] AutoTranslate: row grid context menu + scroll-follow during translation

Remaining for batch 2: the ~48 grids with `CanUserSortColumns = true` (only 3 use `SortMemberPath` deliberately: Shortcuts, BatchConvert, FixCommonErrors) — deciding per window whether to wire `TableViewHeaderSorter` or drop the nominal sorting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)