### PR TITLE
Keep keyboard focus in the grid on Home/End jumps

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -15578,6 +15578,12 @@ public partial class MainViewModel :
         _shiftSelectAnchorIndex = -1;
         _shiftSelectCurrentIndex = -1;
 
+        // A long scroll recycles the focused TableViewRow container, silently dropping
+        // keyboard focus out of the grid (End followed by Home would then do nothing,
+        // as the key handler is gated on IsSubtitleGridFocused). Capture the focus
+        // state now and put focus back on the newly selected row after the scroll.
+        var subtitleGridHadFocus = IsSubtitleGridFocused();
+
         lock (_scrollLock)
         {
             _pendingScrollIndex = index;
@@ -15606,6 +15612,11 @@ public partial class MainViewModel :
                 else
                 {
                     EnsureRowFullyVisibleInSubtitleGrid(itemToScroll);
+                }
+
+                if (subtitleGridHadFocus)
+                {
+                    Dispatcher.UIThread.Post(() => TableViewExtras.FocusRow(SubtitleGrid));
                 }
             }
         });
@@ -21671,6 +21682,11 @@ public partial class MainViewModel :
         SelectGridRange(startIdx, endIdx, _shiftSelectCurrentIndex);
 
         SubtitleGrid.ScrollIntoView(Subtitles[_shiftSelectCurrentIndex]);
+
+        // Shift+Home/End/PageUp/PageDown can scroll the previously focused row container
+        // out of the realized range, which drops keyboard focus out of the grid and kills
+        // the next grid shortcut - re-focus the moving end of the selection after layout.
+        Dispatcher.UIThread.Post(() => TableViewExtras.FocusRow(SubtitleGrid));
 
         SubtitleGridSelectionChanged();
     }

--- a/src/ui/Logic/TableViewExtras.cs
+++ b/src/ui/Logic/TableViewExtras.cs
@@ -340,6 +340,14 @@ public static class TableViewExtras
 
             tableView.SelectedItem = target;
             tableView.ScrollIntoView(target);
+
+            // The jump can scroll the currently focused row container out of the realized
+            // range, dropping keyboard focus out of the TableView entirely (the next
+            // Home/End would then never reach this handler). The key came through the
+            // TableView, so focus belongs inside it - move it to the target row once
+            // layout has realized the container.
+            Dispatcher.UIThread.Post(() => FocusRow(tableView));
+
             e.Handled = true;
         }, Avalonia.Interactivity.RoutingStrategies.Tunnel);
     }


### PR DESCRIPTION
Follow-up to #13017. Since row containers took keyboard focus (#13015), a long Home/End scroll recycles the focused TableViewRow container and keyboard focus silently drops out of the grid. The main window key handler is gated on IsSubtitleGridFocused, so pressing End and then Home left the last row selected.

Fixes:
- `SelectAndScrollToRow` re-focuses the newly selected row after the scroll, guarded by the grid's prior focus state so other callers never steal focus from the text box.
- `HandleShiftArrowSelection` (Shift+Home/End/PageUp/PageDown) re-focuses the moving end of the selection.
- `TableViewExtras.AttachHomeEndNavigation` (shared helper for the other grids) re-focuses the target row.

All three post the refocus via the dispatcher so it runs after layout has realized the target container; `FocusRow` falls back to focusing the TableView itself otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)