### PR TITLE
Announce grid rule violations in the row's accessible name

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -138,15 +138,18 @@ public static partial class InitListViewAndEditBox
             new Binding(nameof(SubtitleLineViewModel.IsHidden)) { Converter = inverseBooleanConverter });
 
         // Expose "number: text" as the row's accessible name so screen readers announce
-        // something meaningful when the row takes focus (issue #13015).
+        // something meaningful when the row takes focus (issue #13015). The error summary
+        // is appended because the grid's cell tints are the only other signal for rule
+        // violations, and color never reaches the accessibility tree.
         TableViewExtras.BindRowProperty(vm.SubtitleGrid, AutomationProperties.NameProperty,
             new MultiBinding
             {
-                StringFormat = "{0}: {1}",
+                StringFormat = "{0}: {1}{2}",
                 Bindings =
                 {
                     new Binding(nameof(SubtitleLineViewModel.Number)),
                     new Binding(nameof(SubtitleLineViewModel.Text)),
+                    new Binding(nameof(SubtitleLineViewModel.AccessibleErrorText)),
                 },
             });
 

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -548,11 +548,13 @@ public partial class SubtitleLineViewModel : ObservableObject
 
         OnPropertyChanged(nameof(GapBackgroundBrush));
         OnPropertyChanged(nameof(EndTimeBackgroundBrush));
+        OnPropertyChanged(nameof(AccessibleErrorText));
     }
 
     partial void OnPreviousGapChanged(double value)
     {
         OnPropertyChanged(nameof(StartTimeBackgroundBrush));
+        OnPropertyChanged(nameof(AccessibleErrorText));
     }
 
     public IBrush GapBackgroundBrush
@@ -566,6 +568,74 @@ public partial class SubtitleLineViewModel : ObservableObject
             }
 
             return _transparentBrush;
+        }
+    }
+
+    /// <summary>
+    /// Screen-reader text for the rule violations the grid shows as cell tints.
+    /// The tints are color-only, so this mirrors the *BackgroundBrush conditions
+    /// and is appended to the row's AutomationProperties.Name binding (empty when
+    /// the line is clean). English on purpose, same as GetErrors/the error list.
+    /// </summary>
+    public string AccessibleErrorText
+    {
+        get
+        {
+            var general = Se.Settings.General;
+            StringBuilder? errors = null;
+
+            void Add(string error)
+            {
+                errors ??= new StringBuilder(" - ");
+                if (errors.Length > 3)
+                {
+                    errors.Append(", ");
+                }
+
+                errors.Append(error);
+            }
+
+            if (general.ColorTimeCodeOverlap && PreviousGap < 0)
+            {
+                Add("overlap with previous");
+            }
+
+            if (general.ColorTimeCodeOverlap && Gap < 0)
+            {
+                Add("overlap with next");
+            }
+            else if (general.ColorGapTooShort && Gap < general.MinimumBetweenLines.GetMilliseconds())
+            {
+                Add("gap too short");
+            }
+
+            if (general.ColorDurationTooShort && Duration.TotalMilliseconds < general.SubtitleMinimumDisplayMilliseconds)
+            {
+                Add("duration too short");
+            }
+
+            if (general.ColorDurationTooLong && Duration.TotalMilliseconds > general.SubtitleMaximumDisplayMilliseconds)
+            {
+                Add("duration too long");
+            }
+
+            if (general.ColorCharactersPerSecond && CharactersPerSecond > general.SubtitleMaximumCharactersPerSeconds)
+            {
+                Add("CPS " + Math.Round(CharactersPerSecond, 1));
+            }
+
+            if (general.ColorWordsPerMinute && WordsPerMinute > general.SubtitleMaximumWordsPerMinute)
+            {
+                Add("WPM " + Math.Round(WordsPerMinute));
+            }
+
+            // TextBackgroundBrush caches the expensive HarfBuzz width check by (Text, settings).
+            if (!ReferenceEquals(TextBackgroundBrush, _transparentBrush))
+            {
+                Add("text too long or wide");
+            }
+
+            return errors?.ToString() ?? string.Empty;
         }
     }
 
@@ -673,6 +743,7 @@ public partial class SubtitleLineViewModel : ObservableObject
             OnPropertyChanged(nameof(CpsBackgroundBrush));
             OnPropertyChanged(nameof(WordsPerMinute));
             OnPropertyChanged(nameof(WpmBackgroundBrush));
+            OnPropertyChanged(nameof(AccessibleErrorText));
         }
     }
 
@@ -693,6 +764,7 @@ public partial class SubtitleLineViewModel : ObservableObject
             OnPropertyChanged(nameof(DurationBackgroundBrush));
             OnPropertyChanged(nameof(CpsBackgroundBrush));
             OnPropertyChanged(nameof(WpmBackgroundBrush));
+            OnPropertyChanged(nameof(AccessibleErrorText));
         }
     }
 
@@ -707,6 +779,7 @@ public partial class SubtitleLineViewModel : ObservableObject
         OnPropertyChanged(nameof(WordsPerMinute));
         OnPropertyChanged(nameof(WpmBackgroundBrush));
         OnPropertyChanged(nameof(PixelWidth));
+        OnPropertyChanged(nameof(AccessibleErrorText));
     }
 
     public void RefreshText()
@@ -733,6 +806,7 @@ public partial class SubtitleLineViewModel : ObservableObject
         OnPropertyChanged(nameof(WpmBackgroundBrush));
         OnPropertyChanged(nameof(GapBackgroundBrush));
         OnPropertyChanged(nameof(PixelWidth));
+        OnPropertyChanged(nameof(AccessibleErrorText));
 
         // The grid Text/OriginalText columns render through a converter that honors the
         // "single line" + separator appearance settings, so re-notify them too; otherwise


### PR DESCRIPTION
Follow-up to #13022 — the screen-reader half of accessibility-scan item 1 (color-only error signaling in the subtitle grid).

The grid signals overlap/CPS/WPM/duration/gap/text-length violations only through cell background tints, which never reach the accessibility tree — a screen reader user can navigate a whole file and never learn a line overlaps or runs too fast.

- New `SubtitleLineViewModel.AccessibleErrorText` mirrors the `*BackgroundBrush` conditions exactly (same settings toggles, same thresholds, reusing the cached HarfBuzz text-width check), producing e.g. `" - overlap with next, CPS 32.4"` or empty when clean.
- Appended to the row's `AutomationProperties.Name` MultiBinding, so focusing a row announces "214: some text - overlap with next, CPS 32.4".
- Change notifications are raised at exactly the sites that raise the brush notifications, so the announced state can't drift from the visible tints.

Strings are English by design, matching `GetErrors`/the error-list wording. The visual side of scan item 1 (tooltips, a warning glyph, and the near-invisible 20%-alpha default ErrorColor) is left for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)