### PR TITLE
Machine-readable ffmpeg progress for shot changes, burn-in, re-encode and transparent subtitles

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -112,7 +112,6 @@ public partial class BurnInViewModel : ObservableObject
     private Subtitle _subtitle = new();
     private bool _loading = true;
     private readonly StringBuilder _log;
-    private static readonly Regex FrameFinderRegex = new(@"[Ff]rame=\s*\d+", RegexOptions.Compiled);
     private long _startTicks;
     private long _processedFrames;
     private Process? _ffmpegProcess;
@@ -741,6 +740,10 @@ public partial class BurnInViewModel : ObservableObject
         }
 
         var workingDirectory = Path.GetDirectoryName(jobItem.AssaSubtitleFileName) ?? string.Empty;
+        // Machine-readable progress on stdout ("frame=N" etc.) instead of scraping the
+        // human-readable stderr stats, which drift between ffmpeg versions.
+        ffmpegParameters = FfmpegProgressTracker.ProgressArguments + " " + ffmpegParameters;
+
         return FfmpegGenerator.GetProcess(ffmpegParameters, OutputHandler, workingDirectory);
     }
 
@@ -766,25 +769,20 @@ public partial class BurnInViewModel : ObservableObject
             return;
         }
 
-        _log?.AppendLine(outLine.Data);
-
-        var match = FrameFinderRegex.Match(outLine.Data);
-        if (!match.Success)
+        if (FfmpegProgressTracker.TryGetFrame(outLine.Data, out var frame))
         {
-            return;
-        }
-
-        var arr = match.Value.Split('=');
-        if (arr.Length != 2)
-        {
-            return;
-        }
-
-        if (long.TryParse(arr[1].Trim(), out var f))
-        {
-            _processedFrames = f;
+            _processedFrames = frame;
             ProgressValue = _processedFrames * 100.0 / JobItems[_jobItemIndex].TotalFrames;
+            return;
         }
+
+        // Keep the twice-a-second "-progress" key/value spam out of the user-facing log.
+        if (FfmpegProgressTracker.IsProgressLine(outLine.Data))
+        {
+            return;
+        }
+
+        _log?.AppendLine(outLine.Data);
     }
 
     private ObservableCollection<BurnInJobItem> GetCurrentVideoAsJobItems(string outputVideoFileName)

--- a/src/ui/Features/Video/ReEncodeVideo/ReEncodeVideoViewModel.cs
+++ b/src/ui/Features/Video/ReEncodeVideo/ReEncodeVideoViewModel.cs
@@ -49,7 +49,6 @@ public partial class ReEncodeVideoViewModel : ObservableObject
 
     private Subtitle _subtitle = new();
     private readonly StringBuilder _log;
-    private static readonly Regex FrameFinderRegex = new(@"[Ff]rame=\s*\d+", RegexOptions.Compiled);
     private long _startTicks;
     private long _processedFrames;
     private Process? _ffmpegProcess;
@@ -300,6 +299,10 @@ public partial class ReEncodeVideoViewModel : ObservableObject
             ffmpegParameters = result.Text.Trim();
         }
 
+        // Machine-readable progress on stdout ("frame=N" etc.) instead of scraping the
+        // human-readable stderr stats, which drift between ffmpeg versions.
+        ffmpegParameters = FfmpegProgressTracker.ProgressArguments + " " + ffmpegParameters;
+
         _ffmpegProcess = FfmpegGenerator.GetProcess(ffmpegParameters, OutputHandler);
 #pragma warning disable CA1416 // Validate platform compatibility
         _ffmpegProcess.Start();
@@ -317,25 +320,20 @@ public partial class ReEncodeVideoViewModel : ObservableObject
             return;
         }
 
-        _log?.AppendLine(outLine.Data);
-
-        var match = FrameFinderRegex.Match(outLine.Data);
-        if (!match.Success)
+        if (FfmpegProgressTracker.TryGetFrame(outLine.Data, out var frame))
         {
-            return;
-        }
-
-        var arr = match.Value.Split('=');
-        if (arr.Length != 2)
-        {
-            return;
-        }
-
-        if (long.TryParse(arr[1].Trim(), out var f))
-        {
-            _processedFrames = f;
+            _processedFrames = frame;
             ProgressValue = _processedFrames * 100.0 / JobItems[_jobItemIndex].TotalFrames;
+            return;
         }
+
+        // Keep the twice-a-second "-progress" key/value spam out of the user-facing log.
+        if (FfmpegProgressTracker.IsProgressLine(outLine.Data))
+        {
+            return;
+        }
+
+        _log?.AppendLine(outLine.Data);
     }
 
     private ObservableCollection<BurnInJobItem> GetCurrentVideoAsJobItems(string outputVideoFileName)

--- a/src/ui/Features/Video/ShotChanges/ShotChangesViewModel.cs
+++ b/src/ui/Features/Video/ShotChanges/ShotChangesViewModel.cs
@@ -49,6 +49,7 @@ public partial class ShotChangesViewModel : ObservableObject, IClosingCleanup
 
     private string _videoFileName = string.Empty;
     private Process? _ffmpegProcess;
+    private FfmpegProgressTracker? _progressTracker;
     private readonly System.Timers.Timer _timerGenerate;
     private bool _doAbort;
     private FfmpegMediaInfo2? _mediaInfo;
@@ -149,6 +150,16 @@ public partial class ShotChangesViewModel : ObservableObject, IClosingCleanup
         var argumentsFormat = Se.Settings.Video.ShowChangesFFmpegArguments;
         var arguments = string.Format(argumentsFormat, _videoFileName, threshold);
 
+        // Detected-scene-change times only tick forward when a cut is found, so in long cut-less
+        // stretches the progress bar used to freeze. Ask ffmpeg for machine-readable progress on
+        // stdout instead and drive a smooth percentage from "out_time_us" vs. the video duration.
+        _progressTracker = null;
+        if (_duration is { TotalSeconds: > 0 })
+        {
+            _progressTracker = new FfmpegProgressTracker(_duration.TotalSeconds);
+            arguments = FfmpegProgressTracker.ProgressArguments + " " + arguments;
+        }
+
         ProgressValue = 0;
         ProgressText = Se.Language.General.StartingDotDotDot;
         _ffmpegProcess = FfmpegGenerator.GetProcess(arguments, OutputHandler);
@@ -168,6 +179,28 @@ public partial class ShotChangesViewModel : ObservableObject, IClosingCleanup
             return;
         }
 
+        var tracker = _progressTracker;
+        if (tracker != null)
+        {
+            if (tracker.TryGetNewPercent(outLine.Data, out var percent))
+            {
+                Dispatcher.UIThread.Post(() =>
+                {
+                    if (IsGenerating)
+                    {
+                        ProgressValue = percent;
+                        ProgressText = $"{percent}%";
+                    }
+                });
+                return;
+            }
+
+            if (FfmpegProgressTracker.IsProgressLine(outLine.Data))
+            {
+                return;
+            }
+        }
+
         Log.AppendLine(outLine.Data);
         var match = TimeRegex.Match(outLine.Data);
         if (match.Success)
@@ -183,10 +216,12 @@ public partial class ShotChangesViewModel : ObservableObject, IClosingCleanup
                         FfmpegLines.Add(item);
                         FfmpegLinesGrid.ScrollIntoView(item);
 
-                        if (_duration != null)
+                        // Fallback only: with the progress tracker active, "out_time_us" drives a
+                        // smooth percentage; detected-cut times would make it jump around.
+                        if (tracker == null && _duration != null)
                         {
                             var pct = seconds / _duration.TotalSeconds * 100;
-                            ProgressValue = seconds / _duration.TotalSeconds * 100;
+                            ProgressValue = pct;
                             ProgressText = $"{pct:0}%";
                         }
                     });

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
@@ -92,7 +92,6 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
     private Subtitle _subtitle = new();
     private bool _loading = true;
     private readonly StringBuilder _log;
-    private static readonly Regex FrameFinderRegex = new(@"[Ff]rame=\s*\d+", RegexOptions.Compiled);
     private long _startTicks;
     private long _processedFrames;
     private Process? _ffmpegProcess;
@@ -486,6 +485,10 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         }
 
         var workingDirectory = Path.GetDirectoryName(jobItem.AssaSubtitleFileName) ?? string.Empty;
+        // Machine-readable progress on stdout ("frame=N" etc.) instead of scraping the
+        // human-readable stderr stats, which drift between ffmpeg versions.
+        ffmpegParameters = FfmpegProgressTracker.ProgressArguments + " " + ffmpegParameters;
+
         return FfmpegGenerator.GetProcess(ffmpegParameters, OutputHandler, workingDirectory);
     }
 
@@ -580,25 +583,20 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
             return;
         }
 
-        _log?.AppendLine(outLine.Data);
-
-        var match = FrameFinderRegex.Match(outLine.Data);
-        if (!match.Success)
+        if (FfmpegProgressTracker.TryGetFrame(outLine.Data, out var frame))
         {
-            return;
-        }
-
-        var arr = match.Value.Split('=');
-        if (arr.Length != 2)
-        {
-            return;
-        }
-
-        if (long.TryParse(arr[1].Trim(), out var f))
-        {
-            _processedFrames = f;
+            _processedFrames = frame;
             ProgressValue = _processedFrames * 100.0 / JobItems[_jobItemIndex].TotalFrames;
+            return;
         }
+
+        // Keep the twice-a-second "-progress" key/value spam out of the user-facing log.
+        if (FfmpegProgressTracker.IsProgressLine(outLine.Data))
+        {
+            return;
+        }
+
+        _log?.AppendLine(outLine.Data);
     }
 
     private ObservableCollection<BurnInJobItem> GetCurrentVideoAsJobItems()

--- a/src/ui/Logic/Media/FfmpegProgressTracker.cs
+++ b/src/ui/Logic/Media/FfmpegProgressTracker.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Globalization;
+
+namespace Nikse.SubtitleEdit.Logic.Media;
+
+/// <summary>
+/// Turns ffmpeg's machine-readable progress output into a monotonic whole-number percentage.
+/// Prepend <see cref="ProgressArguments"/> to the ffmpeg command line (progress key/value lines
+/// then arrive on stdout), feed every received line to <see cref="TryGetNewPercent"/>, and update
+/// the UI only when it returns true. The percent only ever increases, so out-of-order or repeated
+/// lines never make a progress bar jump backwards.
+/// </summary>
+public sealed class FfmpegProgressTracker
+{
+    /// <summary>
+    /// Arguments to prepend to an ffmpeg command line: silences the human-readable stderr stats
+    /// and emits "key=value" progress lines (out_time_us=..., speed=..., progress=...) on stdout.
+    /// </summary>
+    public const string ProgressArguments = "-nostats -progress pipe:1";
+
+    private const string OutTimePrefix = "out_time_us=";
+
+    // Every key ffmpeg emits in a "-progress" block; used to keep these lines out of user-facing logs.
+    private static readonly string[] ProgressLinePrefixes =
+    {
+        "frame=", "fps=", "stream_", "bitrate=", "total_size=", "out_time",
+        "dup_frames=", "drop_frames=", "speed=", "progress=",
+    };
+
+    private readonly double _totalDurationSeconds;
+    private int _lastPercent = -1;
+
+    public FfmpegProgressTracker(double totalDurationSeconds)
+    {
+        _totalDurationSeconds = totalDurationSeconds;
+    }
+
+    /// <summary>
+    /// Parses one line of ffmpeg output. Returns true only when the line is an "out_time_us="
+    /// progress line that advances to a new, higher whole percent (0-100).
+    /// </summary>
+    public bool TryGetNewPercent(string? line, out int percent)
+    {
+        percent = 0;
+        if (string.IsNullOrEmpty(line) ||
+            _totalDurationSeconds <= 0 ||
+            !line.StartsWith(OutTimePrefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var value = line.Substring(OutTimePrefix.Length).Trim();
+        if (!long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var microseconds) ||
+            microseconds < 0)
+        {
+            return false;
+        }
+
+        var p = (int)Math.Round(microseconds / (_totalDurationSeconds * 10_000.0), MidpointRounding.AwayFromZero);
+        p = Math.Clamp(p, 0, 100);
+        if (p <= _lastPercent)
+        {
+            return false;
+        }
+
+        _lastPercent = p;
+        percent = p;
+        return true;
+    }
+
+    /// <summary>
+    /// Parses the processed-frame count from a "frame=N" progress line. Also tolerates the
+    /// human-readable stderr stats form ("frame=  123 fps= 25 ...") so callers still get
+    /// progress if a custom command line disables the machine-readable channel.
+    /// </summary>
+    public static bool TryGetFrame(string? line, out long frame)
+    {
+        frame = 0;
+        if (string.IsNullOrEmpty(line) || !line.StartsWith("frame=", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var i = "frame=".Length;
+        while (i < line.Length && line[i] == ' ')
+        {
+            i++;
+        }
+
+        var start = i;
+        while (i < line.Length && char.IsAsciiDigit(line[i]))
+        {
+            i++;
+        }
+
+        return i > start &&
+               long.TryParse(line.AsSpan(start, i - start), NumberStyles.Integer, CultureInfo.InvariantCulture, out frame);
+    }
+
+    /// <summary>
+    /// True when the line is part of a "-progress" key/value block (so callers can keep the
+    /// twice-a-second progress spam out of logs shown to the user).
+    /// </summary>
+    public static bool IsProgressLine(string line)
+    {
+        foreach (var prefix in ProgressLinePrefixes)
+        {
+            if (line.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/UI/Logic/FfmpegProgressTrackerTests.cs
+++ b/tests/UI/Logic/FfmpegProgressTrackerTests.cs
@@ -1,0 +1,75 @@
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace Tests.Logic;
+
+public class FfmpegProgressTrackerTests
+{
+    [Fact]
+    public void OutTime_AdvancesToNewPercent()
+    {
+        var tracker = new FfmpegProgressTracker(100); // 100 s total => 1 s = 1 %
+
+        Assert.True(tracker.TryGetNewPercent("out_time_us=25000000", out var percent));
+        Assert.Equal(25, percent);
+    }
+
+    [Fact]
+    public void Percent_IsMonotonic_NeverGoesBackwards()
+    {
+        var tracker = new FfmpegProgressTracker(100);
+
+        Assert.True(tracker.TryGetNewPercent("out_time_us=50000000", out _));
+        Assert.False(tracker.TryGetNewPercent("out_time_us=40000000", out _)); // lower
+        Assert.False(tracker.TryGetNewPercent("out_time_us=50400000", out _)); // same whole percent
+        Assert.True(tracker.TryGetNewPercent("out_time_us=51000000", out var percent));
+        Assert.Equal(51, percent);
+    }
+
+    [Fact]
+    public void OvershootAndGarbage_AreHandled()
+    {
+        var tracker = new FfmpegProgressTracker(100);
+
+        Assert.True(tracker.TryGetNewPercent("out_time_us=250000000", out var percent)); // past the end (VFR estimate)
+        Assert.Equal(100, percent);
+
+        Assert.False(tracker.TryGetNewPercent("out_time_us=N/A", out _));
+        Assert.False(tracker.TryGetNewPercent("out_time_us=-1", out _));
+        Assert.False(tracker.TryGetNewPercent(null, out _));
+        Assert.False(tracker.TryGetNewPercent("frame=123", out _));
+    }
+
+    [Fact]
+    public void ZeroDuration_NeverReportsProgress()
+    {
+        var tracker = new FfmpegProgressTracker(0);
+        Assert.False(tracker.TryGetNewPercent("out_time_us=1000000", out _));
+    }
+
+    [Theory]
+    [InlineData("frame=123", true, 123L)]
+    [InlineData("frame=  456 fps= 25 q=28.0 size=1024KiB", true, 456L)] // stderr stats fallback
+    [InlineData("Frame=7", true, 7L)]
+    [InlineData("frame=", false, 0L)]
+    [InlineData("out_time_us=1000", false, 0L)]
+    [InlineData(null, false, 0L)]
+    public void TryGetFrame_ParsesProgressAndStatsForms(string? line, bool expected, long expectedFrame)
+    {
+        Assert.Equal(expected, FfmpegProgressTracker.TryGetFrame(line, out var frame));
+        Assert.Equal(expectedFrame, frame);
+    }
+
+    [Theory]
+    [InlineData("frame=123", true)]
+    [InlineData("fps=25.0", true)]
+    [InlineData("out_time_us=1000", true)]
+    [InlineData("out_time=00:00:01.000000", true)]
+    [InlineData("speed=12.3x", true)]
+    [InlineData("progress=continue", true)]
+    [InlineData("stream_0_0_q=28.0", true)]
+    [InlineData("[Parsed_showinfo_1 @ 0x1] n: 0 pts_time:1.23", false)]
+    public void IsProgressLine_FiltersOnlyProgressBlockKeys(string line, bool expected)
+    {
+        Assert.Equal(expected, FfmpegProgressTracker.IsProgressLine(line));
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #12893: generalizes the ffmpeg `-progress pipe:1` parsing used for waveform extraction into a shared `FfmpegProgressTracker` and applies it to the remaining long-running ffmpeg features.

## Changes

- **New `FfmpegProgressTracker`** (`src/ui/Logic/Media/FfmpegProgressTracker.cs`)
  - `ProgressArguments` (`-nostats -progress pipe:1`) to prepend to any ffmpeg command line
  - Monotonic whole-percent from `out_time_us` vs. total duration (never jumps backwards, clamps overshoot from VFR duration estimates, ignores `N/A`/garbage)
  - `TryGetFrame` for frame-count-based features; tolerates the human-readable stderr stats form as a fallback for custom command lines
  - `IsProgressLine` so the twice-a-second key/value block stays out of user-facing logs
- **Shot changes**: progress was driven by the `pts_time` of *detected* cuts, so the bar froze during long stretches with no scene changes (interviews, credits). Now `out_time_us` drives a smooth percentage; the detected-cut parsing on stderr is unchanged, and the old behavior remains as a fallback when the duration is unknown.
- **Burn-in, re-encode, transparent subtitles**: replace the `[Ff]rame=\s*\d+` stderr-stats regex scrape with the structured progress channel. The stats format is meant for humans (carriage-return rewrites, drift between ffmpeg versions); the `-progress` block is stable. ETA calculation is unchanged (same frame-based math, cleaner source).
- **Tests**: `tests/UI/Logic/FfmpegProgressTrackerTests.cs` — percent math, monotonicity, overshoot, malformed input, frame parsing (both forms), log filtering. 18 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)