### PR TITLE
Honor ASSA override tags in image based export

### DIFF
--- a/src/libuilogic/Export/ExportTextTags.cs
+++ b/src/libuilogic/Export/ExportTextTags.cs
@@ -1,0 +1,214 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using SkiaSharp;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Nikse.SubtitleEdit.UiLogic.Export;
+
+/// <summary>
+/// Prepares subtitle text for image based export (Blu-ray sup, VobSub, BDN-XML, ...).
+/// <para>
+/// <see cref="ImageRenderer"/> only understands HTML style tags, so ASSA override tags used
+/// to reach it as literal glyphs - "{\an8}Hi" was drawn as "{\an8}Hi" at the bottom of the
+/// frame (issue #13025). <see cref="GetAlignment"/> and <see cref="ApplyPositionTag"/> read
+/// the position out of the text and <see cref="ToRenderableText"/> turns the rest into what
+/// the renderer can draw.
+/// </para>
+/// </summary>
+public static class ExportTextTags
+{
+    // "{\pos(10,20)}", also inside a multi tag block and with decimals ("{\an8\pos(10.5,20)}")
+    private static readonly Regex PositionTagRegex = new(
+        @"\\pos\(\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*\)",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Returns the alignment from a leading "{\anX}" tag - also inside a multi tag block
+    /// like "{\an8\i1}" or "{\pos(10,20)\an8}" - or <paramref name="fallback"/> when there is none.
+    /// </summary>
+    public static ExportAlignment GetAlignment(string? text, ExportAlignment fallback)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return fallback;
+        }
+
+        var s = text.TrimStart();
+        if (s.Length < 5 || s[0] != '{')
+        {
+            return fallback;
+        }
+
+        var blockEnd = s.IndexOf('}');
+        if (blockEnd < 0)
+        {
+            return fallback;
+        }
+
+        var block = s.Substring(0, blockEnd);
+
+        var idx = block.IndexOf("\\an", StringComparison.Ordinal);
+        if (idx >= 0 && idx + 3 < block.Length)
+        {
+            return FromDigit(block[idx + 3], fallback);
+        }
+
+        // Malformed variant with the leading backslash missing ("{an8\i1}") - stripped by
+        // HtmlUtil.RemoveAssAlignmentTags, so read it here too.
+        if (block.StartsWith("{an", StringComparison.Ordinal) && block.Length > 3)
+        {
+            return FromDigit(block[3], fallback);
+        }
+
+        return fallback;
+    }
+
+    /// <summary>
+    /// Converts the text to what <see cref="ImageRenderer"/> can draw: alignment tags are
+    /// removed (already read by <see cref="GetAlignment"/>), ASSA italic/bold/color/font tags
+    /// become their HTML equivalents, and anything left over is dropped rather than drawn.
+    /// </summary>
+    public static string ToRenderableText(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return string.Empty;
+        }
+
+        var s = HtmlUtil.RemoveAssAlignmentTags(text);
+
+        // Only ASSA input pays for this - and only ASSA input may lose a lone "\n"/"\h" to
+        // RemoveSsaTags below, which would be wrong for e.g. a plain "C:\new" in an SRT.
+        // Tested on the original text: removing the alignment tags can be what takes the
+        // last "{\" away.
+        if (text.Contains("{\\", StringComparison.Ordinal))
+        {
+            // "{\i1}" -> "<i>", "{\b1}" -> "<b>", "{\c&H0000FF&}" -> "<font color=\"#ff0000\">", ...
+            s = AdvancedSubStationAlpha.GetFormattedText(s);
+
+            // Whatever GetFormattedText left behind: tags it does not translate, and every tag
+            // on a line it considers too complex (\pos, \fad, \k, \clip, drawings) - it returns
+            // those unchanged, and drawn as text they are worse than not drawn at all.
+            s = Utilities.RemoveSsaTags(s);
+
+            // "{\an8\an8}" leaves an empty block behind, which RemoveSsaTags keeps (no backslash).
+            s = s.Replace("{}", string.Empty);
+        }
+
+        // The renderer has no underline, so "<u>" would be drawn as literal text.
+        return HtmlUtil.RemoveOpenCloseTags(s, HtmlUtil.TagUnderline);
+    }
+
+    /// <summary>
+    /// Reads the anchor point of a "{\pos(x,y)}" tag, in script coordinates.
+    /// </summary>
+    public static bool TryGetPosition(string? text, out float x, out float y)
+    {
+        x = 0;
+        y = 0;
+
+        if (string.IsNullOrEmpty(text) || !text.Contains("\\pos(", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var match = PositionTagRegex.Match(text);
+        return match.Success
+               && float.TryParse(match.Groups[1].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out x)
+               && float.TryParse(match.Groups[2].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out y);
+    }
+
+    /// <summary>
+    /// Sets <see cref="ImageParameter.OverridePosition"/> from a "{\pos(x,y)}" tag, if there is one.
+    /// <para>
+    /// Call this after the bitmap has been rendered: "\pos" gives the anchor point of the text
+    /// for the current alignment ("{\an8\pos(x,y)}" puts x,y at the top center of the text), so
+    /// the bitmap's top left corner can only be worked out once its size is known.
+    /// </para>
+    /// <para>
+    /// The coordinates are in the script's own resolution - pass PlayResX/PlayResY as
+    /// <paramref name="scriptWidth"/>/<paramref name="scriptHeight"/> (see
+    /// <see cref="GetScriptResolution"/>) when exporting to a different canvas size.
+    /// </para>
+    /// </summary>
+    public static void ApplyPositionTag(ImageParameter ip, string? text, int scriptWidth = 0, int scriptHeight = 0)
+    {
+        if (!TryGetPosition(text, out var x, out var y) || ip.ScreenWidth <= 0 || ip.ScreenHeight <= 0)
+        {
+            return;
+        }
+
+        if (scriptWidth > 0 && scriptHeight > 0)
+        {
+            x = x * ip.ScreenWidth / scriptWidth;
+            y = y * ip.ScreenHeight / scriptHeight;
+        }
+
+        var width = ip.Bitmap?.Width ?? 0;
+        var height = ip.Bitmap?.Height ?? 0;
+
+        var left = ip.Alignment switch
+        {
+            ExportAlignment.TopLeft or ExportAlignment.MiddleLeft or ExportAlignment.BottomLeft => x,
+            ExportAlignment.TopRight or ExportAlignment.MiddleRight or ExportAlignment.BottomRight => x - width,
+            _ => x - width / 2f,
+        };
+
+        var top = ip.Alignment switch
+        {
+            ExportAlignment.TopLeft or ExportAlignment.TopCenter or ExportAlignment.TopRight => y,
+            ExportAlignment.MiddleLeft or ExportAlignment.MiddleCenter or ExportAlignment.MiddleRight => y - height / 2f,
+            _ => y - height,
+        };
+
+        // Every handler ignores an override position that falls outside the frame, and a
+        // partly outside image would be cut off, so keep the whole bitmap on screen.
+        var maxLeft = Math.Max(0, ip.ScreenWidth - width);
+        var maxTop = Math.Max(0, ip.ScreenHeight - height);
+
+        ip.OverridePosition = new SKPointI(
+            (int)Math.Round(Math.Clamp(left, 0, maxLeft), MidpointRounding.AwayFromZero),
+            (int)Math.Round(Math.Clamp(top, 0, maxTop), MidpointRounding.AwayFromZero));
+    }
+
+    /// <summary>
+    /// PlayResX/PlayResY from an ASSA/SSA header, or (0,0) when the header has none - "\pos"
+    /// coordinates are relative to those.
+    /// </summary>
+    public static (int Width, int Height) GetScriptResolution(string? header)
+    {
+        if (string.IsNullOrEmpty(header))
+        {
+            return (0, 0);
+        }
+
+        var w = AdvancedSubStationAlpha.GetTagValueFromHeader("PlayResX", "[Script Info]", header);
+        var h = AdvancedSubStationAlpha.GetTagValueFromHeader("PlayResY", "[Script Info]", header);
+
+        if (int.TryParse(w, NumberStyles.Integer, CultureInfo.InvariantCulture, out var width) && width > 0 &&
+            int.TryParse(h, NumberStyles.Integer, CultureInfo.InvariantCulture, out var height) && height > 0)
+        {
+            return (width, height);
+        }
+
+        return (0, 0);
+    }
+
+    private static ExportAlignment FromDigit(char digit, ExportAlignment fallback)
+    {
+        return digit switch
+        {
+            '1' => ExportAlignment.BottomLeft,
+            '2' => ExportAlignment.BottomCenter,
+            '3' => ExportAlignment.BottomRight,
+            '4' => ExportAlignment.MiddleLeft,
+            '5' => ExportAlignment.MiddleCenter,
+            '6' => ExportAlignment.MiddleRight,
+            '7' => ExportAlignment.TopLeft,
+            '8' => ExportAlignment.TopCenter,
+            '9' => ExportAlignment.TopRight,
+            _ => fallback,
+        };
+    }
+}

--- a/src/seconv/Core/ImageOutputWriter.cs
+++ b/src/seconv/Core/ImageOutputWriter.cs
@@ -54,6 +54,9 @@ internal static class ImageOutputWriter
 
         var (screenWidth, screenHeight) = options.Resolution ?? (1920, 1080);
 
+        // "{\pos(x,y)}" is in the script's own resolution, the export canvas may be another one.
+        var (scriptWidth, scriptHeight) = ExportTextTags.GetScriptResolution(subtitle.Header);
+
         // Pre-render header with the first paragraph as a representative
         var firstParam = BuildParameter(subtitle.Paragraphs[0], 0, screenWidth, screenHeight, options);
         firstParam.Bitmap = ImageRenderer.GenerateBitmap(firstParam);
@@ -65,6 +68,8 @@ internal static class ImageOutputWriter
             var p = subtitle.Paragraphs[i];
             var ip = BuildParameter(p, i, screenWidth, screenHeight, options);
             ip.Bitmap = ImageRenderer.GenerateBitmap(ip);
+            // Needs the rendered size, so it cannot happen in BuildParameter.
+            ExportTextTags.ApplyPositionTag(ip, p.Text, scriptWidth, scriptHeight);
             handler.CreateParagraph(ip);
             handler.WriteParagraph(ip);
             ip.Bitmap?.Dispose();
@@ -161,13 +166,19 @@ internal static class ImageOutputWriter
     private static ImageParameter BuildParameter(Paragraph p, int index, int screenWidth, int screenHeight, ConversionOptions options)
     {
         var style = options.ImageStyle;
+
+        // "{\an8}" & co. position the single paragraph; --alignment is only the fallback for
+        // untagged lines. Without this the tag was rendered as literal text at the bottom of
+        // the frame (issue #13025) - as were "{\i1}", "{\b1}" and "{\c&H..&}", which
+        // ToRenderableText turns into the HTML tags the renderer understands.
+        var text = p.Text ?? string.Empty;
         return new ImageParameter
         {
             Index = index,
-            Text = p.Text ?? string.Empty,
+            Text = ExportTextTags.ToRenderableText(text),
             StartTime = p.StartTime.TimeSpan,
             EndTime = p.EndTime.TimeSpan,
-            Alignment = style.Alignment,
+            Alignment = ExportTextTags.GetAlignment(text, style.Alignment),
             ContentAlignment = style.ContentAlignment,
             FontName = style.FontName,
             FontSize = style.FontSize,

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
@@ -418,6 +418,8 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
 
                 var ip = imageParameters[i];
                 ip.Bitmap = GenerateBitmap(ip);
+                // "{\pos(x,y)}" anchors the rendered text, so it needs the bitmap size.
+                ExportTextTags.ApplyPositionTag(ip, Subtitles[i].Text);
                 _exportImageHandler.CreateParagraph(ip);
 
                 lock (_generateLock)
@@ -512,12 +514,12 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
         var subtitle = Subtitles[i];
         var imageParameter = new ImageParameter
         {
-            Alignment = GetContentAlignment(subtitle.Text, SelectedAlignment.Alignment),
+            Alignment = ExportTextTags.GetAlignment(subtitle.Text, SelectedAlignment.Alignment),
             ContentAlignment = SelectedContentAlignment.ContentAlignment,
             PaddingLeftRight = SelectedPaddingLeftRight,
             PaddingTopBottom = SelectedPaddingTopBottom,
             Index = i,
-            Text = HtmlUtil.RemoveAssAlignmentTags(subtitle.Text),
+            Text = ExportTextTags.ToRenderableText(subtitle.Text),
             StartTime = subtitle.StartTime,
             EndTime = subtitle.EndTime,
             FontColor = FontColor.ToSKColor(),
@@ -549,57 +551,6 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
         };
 
         return imageParameter;
-    }
-
-    private ExportAlignment GetContentAlignment(string text, ExportAlignment alignment)
-    {
-        var s = text.Trim();
-        if (s.StartsWith("{\\an1"))
-        {
-            return ExportAlignment.BottomLeft;
-        }
-
-        if (s.StartsWith("{\\an2"))
-        {
-            return ExportAlignment.BottomCenter;
-        }
-
-        if (s.StartsWith("{\\an3"))
-        {
-            return ExportAlignment.BottomRight;
-        }
-
-        if (s.StartsWith("{\\an4"))
-        {
-            return ExportAlignment.MiddleLeft;
-        }
-
-        if (s.StartsWith("{\\an5"))
-        {
-            return ExportAlignment.MiddleCenter;
-        }
-
-        if (s.StartsWith("{\\an6"))
-        {
-            return ExportAlignment.MiddleRight;
-        }
-
-        if (s.StartsWith("{\\an7"))
-        {
-            return ExportAlignment.TopLeft;
-        }
-
-        if (s.StartsWith("{\\an8"))
-        {
-            return ExportAlignment.TopCenter;
-        }
-
-        if (s.StartsWith("{\\an9"))
-        {
-            return ExportAlignment.TopRight;
-        }
-
-        return alignment;
     }
 
     [RelayCommand]
@@ -653,6 +604,8 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
             {
                 var ip = GetImageParameter(Subtitles.IndexOf(SelectedSubtitle));
                 var bitmap = GenerateBitmap(ip);
+                ip.Bitmap = bitmap;
+                ExportTextTags.ApplyPositionTag(ip, SelectedSubtitle.Text);
                 var position = CalculatePosition(ip, bitmap.Width, bitmap.Height);
                 vm.Initialize(bitmap, ip.ScreenWidth, ip.ScreenHeight, position.X, position.Y);
             });
@@ -724,13 +677,22 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
 
         var idx = Subtitles.IndexOf(selected);
         var ip = GetImageParameter(idx);
-        BitmapPreview = GenerateBitmap(ip).ToAvaloniaBitmap();
+        ip.Bitmap = GenerateBitmap(ip);
+        BitmapPreview = ip.Bitmap.ToAvaloniaBitmap();
+        ExportTextTags.ApplyPositionTag(ip, text);
         var position = CalculatePosition(ip, BitmapPreview.Size.Width, BitmapPreview.Size.Height);
         ImageInfo = $"{BitmapPreview.Size.Width}x{BitmapPreview.Size.Height} @ {position.X},{position.Y}";
     }
 
     private static SKPointI CalculatePosition(ImageParameter ip, double width, double height)
     {
+        // Set from a "{\pos(x,y)}" tag by ExportTextTags.ApplyPositionTag - the handlers use it
+        // instead of the alignment, so the preview must too.
+        if (ip.OverridePosition.HasValue)
+        {
+            return ip.OverridePosition.Value;
+        }
+
         var x = 0;
         var y = 0;
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -1588,18 +1588,22 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             return null;
         }
 
+        var (scriptWidth, scriptHeight) = ExportTextTags.GetScriptResolution(item.Subtitle.Header);
+
         var imageParameters = new List<ImageParameter>();
         for (var i = 0; i < item.Subtitle.Paragraphs.Count; i++)
         {
             Paragraph? subtitle = item.Subtitle.Paragraphs[i];
             var imageParameter = new ImageParameter
             {
-                Alignment = ExportAlignment.BottomCenter,
+                // "{\an8}" & co. were stripped from the text but not honored, so top-positioned
+                // lines silently ended up at the bottom (issue #13025).
+                Alignment = ExportTextTags.GetAlignment(subtitle.Text, ExportAlignment.BottomCenter),
                 ContentAlignment = ExportContentAlignment.Center,
                 PaddingLeftRight = profile.PaddingLeftRight,
                 PaddingTopBottom = profile.PaddingTopBottom,
                 Index = i,
-                Text = HtmlUtil.RemoveAssAlignmentTags(subtitle.Text),
+                Text = ExportTextTags.ToRenderableText(subtitle.Text),
                 StartTime = subtitle.StartTime.TimeSpan,
                 EndTime = subtitle.EndTime.TimeSpan,
                 FontColor = profile.FontColor.FromHexToColor().ToSKColor(),
@@ -1620,6 +1624,11 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             };
 
             imageParameter.Bitmap = ExportImageBasedViewModel.GenerateBitmap(imageParameter);
+
+            // "{\pos(x,y)}" anchors the rendered text, so it needs the bitmap size - and the
+            // coordinates are in the script's own resolution, not the export canvas.
+            ExportTextTags.ApplyPositionTag(imageParameter, subtitle.Text, scriptWidth, scriptHeight);
+
             imageParameters.Add(imageParameter);
         }
 

--- a/tests/libuilogic/Export/ExportTextTagsTests.cs
+++ b/tests/libuilogic/Export/ExportTextTagsTests.cs
@@ -1,0 +1,203 @@
+using Nikse.SubtitleEdit.UiLogic.Export;
+using SkiaSharp;
+
+namespace LibUiLogicTests.Export;
+
+public class ExportTextTagsTests
+{
+    private static ImageParameter MakeParameter(ExportAlignment alignment, int bitmapWidth = 200, int bitmapHeight = 50)
+    {
+        return new ImageParameter
+        {
+            Alignment = alignment,
+            ScreenWidth = 1920,
+            ScreenHeight = 1080,
+            Bitmap = new SKBitmap(bitmapWidth, bitmapHeight),
+        };
+    }
+
+    [Theory]
+    [InlineData("{\\an1}Hello", ExportAlignment.BottomLeft)]
+    [InlineData("{\\an2}Hello", ExportAlignment.BottomCenter)]
+    [InlineData("{\\an3}Hello", ExportAlignment.BottomRight)]
+    [InlineData("{\\an4}Hello", ExportAlignment.MiddleLeft)]
+    [InlineData("{\\an5}Hello", ExportAlignment.MiddleCenter)]
+    [InlineData("{\\an6}Hello", ExportAlignment.MiddleRight)]
+    [InlineData("{\\an7}Hello", ExportAlignment.TopLeft)]
+    [InlineData("{\\an8}Hello", ExportAlignment.TopCenter)]
+    [InlineData("{\\an9}Hello", ExportAlignment.TopRight)]
+    public void GetAlignment_AlignmentTag_MapsToExportAlignment(string text, ExportAlignment expected)
+    {
+        Assert.Equal(expected, ExportTextTags.GetAlignment(text, ExportAlignment.BottomCenter));
+    }
+
+    [Theory]
+    [InlineData("{\\an8\\i1}Hello")] // multi tag, alignment first
+    [InlineData("{\\i1\\an8}Hello")] // multi tag, alignment last
+    [InlineData("{\\pos(10,20)\\an8}Hello")]
+    [InlineData("{an8\\i1}Hello")] // malformed variant that RemoveAssAlignmentTags also strips
+    [InlineData("  {\\an8}Hello")]
+    public void GetAlignment_TagInsideBlock_IsFound(string text)
+    {
+        Assert.Equal(ExportAlignment.TopCenter, ExportTextTags.GetAlignment(text, ExportAlignment.BottomCenter));
+    }
+
+    [Theory]
+    [InlineData("Hello")]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("{\\i1}Hello")]
+    [InlineData("{\\an8Hello")] // no closing brace, not a tag
+    [InlineData("Hello {\\an8}")] // not leading, ignored like the export window always did
+    public void GetAlignment_NoLeadingAlignmentTag_UsesFallback(string? text)
+    {
+        Assert.Equal(ExportAlignment.MiddleRight, ExportTextTags.GetAlignment(text, ExportAlignment.MiddleRight));
+    }
+
+    [Theory]
+    [InlineData("{\\an8}Hello", "Hello")]
+    [InlineData("{\\an8\\an8}Hello", "Hello")]
+    [InlineData("Hello", "Hello")]
+    [InlineData(null, "")]
+    public void ToRenderableText_AlignmentTags_AreRemoved(string? text, string expected)
+    {
+        Assert.Equal(expected, ExportTextTags.ToRenderableText(text));
+    }
+
+    [Theory]
+    [InlineData("{\\i1}Hello{\\i0}", "<i>Hello</i>")]
+    [InlineData("{\\b1}Hello{\\b0}", "<b>Hello</b>")]
+    [InlineData("{\\an8\\i1}Hello{\\i0}", "<i>Hello</i>")]
+    [InlineData("{\\i1}Hello", "<i>Hello</i>")] // unclosed tag is closed for the renderer
+    public void ToRenderableText_AssaStyleTags_BecomeHtml(string text, string expected)
+    {
+        Assert.Equal(expected, ExportTextTags.ToRenderableText(text));
+    }
+
+    [Fact]
+    public void ToRenderableText_AssaColorTag_BecomesFontColor()
+    {
+        // ASSA colors are &HBBGGRR& - blue-red-green order flipped for HTML
+        Assert.Equal("<font color=\"#ff0000\">Red</font>", ExportTextTags.ToRenderableText("{\\c&H0000FF&}Red{\\c}"));
+    }
+
+    [Theory]
+    [InlineData("{\\pos(10,20)}Hello", "Hello")] // "too complex" for GetFormattedText, must not be drawn
+    [InlineData("{\\fad(200,200)}Hello", "Hello")]
+    [InlineData("{\\k50}Hello", "Hello")]
+    [InlineData("{\\an8\\pos(10,20)}Hello", "Hello")]
+    public void ToRenderableText_UntranslatableAssaTags_AreDroppedNotDrawn(string text, string expected)
+    {
+        Assert.Equal(expected, ExportTextTags.ToRenderableText(text));
+    }
+
+    [Theory]
+    [InlineData("<u>Hello</u>", "Hello")] // the renderer cannot underline
+    [InlineData("{\\u1}Hello{\\u0}", "Hello")]
+    public void ToRenderableText_UnderlineTags_AreRemoved(string text, string expected)
+    {
+        Assert.Equal(expected, ExportTextTags.ToRenderableText(text));
+    }
+
+    [Theory]
+    [InlineData("{\\pos(300,200)}Hello", 300f, 200f)]
+    [InlineData("{\\an8\\pos(300,200)}Hello", 300f, 200f)]
+    [InlineData("{\\pos( 300 , 200 )}Hello", 300f, 200f)]
+    [InlineData("{\\pos(300.5,200.25)}Hello", 300.5f, 200.25f)]
+    public void TryGetPosition_PosTag_IsRead(string text, float expectedX, float expectedY)
+    {
+        Assert.True(ExportTextTags.TryGetPosition(text, out var x, out var y));
+        Assert.Equal(expectedX, x);
+        Assert.Equal(expectedY, y);
+    }
+
+    [Theory]
+    [InlineData("Hello")]
+    [InlineData("{\\an8}Hello")]
+    [InlineData("{\\move(10,20,30,40)}Hello")]
+    [InlineData(null)]
+    public void TryGetPosition_NoPosTag_ReturnsFalse(string? text)
+    {
+        Assert.False(ExportTextTags.TryGetPosition(text, out _, out _));
+    }
+
+    [Theory]
+    // \pos gives the anchor point for the current alignment, the bitmap is 200x50
+    [InlineData(ExportAlignment.TopLeft, 300, 200)]
+    [InlineData(ExportAlignment.TopCenter, 200, 200)]
+    [InlineData(ExportAlignment.TopRight, 100, 200)]
+    [InlineData(ExportAlignment.MiddleLeft, 300, 175)]
+    [InlineData(ExportAlignment.MiddleCenter, 200, 175)]
+    [InlineData(ExportAlignment.BottomLeft, 300, 150)]
+    [InlineData(ExportAlignment.BottomCenter, 200, 150)]
+    [InlineData(ExportAlignment.BottomRight, 100, 150)]
+    public void ApplyPositionTag_AnchorsByAlignment(ExportAlignment alignment, int expectedLeft, int expectedTop)
+    {
+        var ip = MakeParameter(alignment);
+
+        ExportTextTags.ApplyPositionTag(ip, "{\\pos(300,200)}Hello");
+
+        Assert.NotNull(ip.OverridePosition);
+        Assert.Equal(expectedLeft, ip.OverridePosition!.Value.X);
+        Assert.Equal(expectedTop, ip.OverridePosition.Value.Y);
+    }
+
+    [Fact]
+    public void ApplyPositionTag_ScriptResolutionDiffers_ScalesToCanvas()
+    {
+        var ip = MakeParameter(ExportAlignment.TopLeft);
+
+        // 384x288 script on a 1920x1080 canvas: x*5, y*3.75
+        ExportTextTags.ApplyPositionTag(ip, "{\\pos(100,100)}Hello", 384, 288);
+
+        Assert.NotNull(ip.OverridePosition);
+        Assert.Equal(500, ip.OverridePosition!.Value.X);
+        Assert.Equal(375, ip.OverridePosition.Value.Y);
+    }
+
+    [Fact]
+    public void ApplyPositionTag_OutsideTheFrame_IsClampedInside()
+    {
+        var ip = MakeParameter(ExportAlignment.TopLeft);
+
+        ExportTextTags.ApplyPositionTag(ip, "{\\pos(-100,5000)}Hello");
+
+        Assert.NotNull(ip.OverridePosition);
+        Assert.Equal(0, ip.OverridePosition!.Value.X);
+        Assert.Equal(1080 - 50, ip.OverridePosition.Value.Y);
+    }
+
+    [Fact]
+    public void ApplyPositionTag_NoPosTag_LeavesOverridePositionUnset()
+    {
+        var ip = MakeParameter(ExportAlignment.BottomCenter);
+
+        ExportTextTags.ApplyPositionTag(ip, "{\\an8}Hello");
+
+        Assert.Null(ip.OverridePosition);
+    }
+
+    [Theory]
+    [InlineData("[Script Info]\r\nPlayResX: 384\r\nPlayResY: 288\r\n", 384, 288)]
+    [InlineData("[Script Info]\r\nPlayResX: 0\r\nPlayResY: 288\r\n", 0, 0)]
+    [InlineData("[Script Info]\r\nTitle: none\r\n", 0, 0)]
+    [InlineData(null, 0, 0)]
+    public void GetScriptResolution_ReadsPlayRes(string? header, int expectedWidth, int expectedHeight)
+    {
+        var (width, height) = ExportTextTags.GetScriptResolution(header);
+        Assert.Equal(expectedWidth, width);
+        Assert.Equal(expectedHeight, height);
+    }
+
+    [Theory]
+    [InlineData("<i>Hello</i>")]
+    [InlineData("<b>Hello</b>")]
+    [InlineData("<font color=\"#ff4040\">Hello</font>")]
+    [InlineData("Plain text")]
+    [InlineData("C:\\new folder")] // a lone backslash in plain text must survive
+    [InlineData("50% > 40%")]
+    public void ToRenderableText_TextWithoutAssaTags_IsUnchanged(string text)
+    {
+        Assert.Equal(text, ExportTextTags.ToRenderableText(text));
+    }
+}

--- a/tests/seconv/Core/ImageOutputAlignmentTest.cs
+++ b/tests/seconv/Core/ImageOutputAlignmentTest.cs
@@ -1,0 +1,127 @@
+using Nikse.SubtitleEdit.Core.BluRaySup;
+using SeConv.Core;
+using System.Text;
+using Xunit;
+
+namespace SeConvTests.Core;
+
+/// <summary>
+/// "{\an8}" &amp; co. must position the rendered paragraph in image based output, and must
+/// never end up as literal text in the bitmap (issue #13025).
+/// </summary>
+public class ImageOutputAlignmentTest : IDisposable
+{
+    private readonly string _tempRoot;
+
+    public ImageOutputAlignmentTest()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "ImgAlign_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+        {
+            Directory.Delete(_tempRoot, recursive: true);
+        }
+    }
+
+    private const string SrtContent = """
+        1
+        00:00:01,000 --> 00:00:02,000
+        {\an8}Top center
+
+        2
+        00:00:03,000 --> 00:00:04,000
+        {\an1}Bottom left
+
+        3
+        00:00:05,000 --> 00:00:06,000
+        Plain bottom center
+
+        """;
+
+    // PlayRes is half the export canvas below, so "\pos" has to be scaled x2 on the way out.
+    private const string AssContent = """
+        [Script Info]
+        ScriptType: v4.00+
+        PlayResX: 960
+        PlayResY: 540
+
+        [V4+ Styles]
+        Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+        Style: Default,Arial,24,&H00FFFFFF,&H0300FFFF,&H00000000,&H02000000,0,0,0,0,100,100,0,0,1,2,1,2,10,10,10,1
+
+        [Events]
+        Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+        Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,{\an7\pos(50,50)}Anchored top left
+        Dialogue: 0,0:00:03.00,0:00:04.00,Default,,0,0,0,,No position tag
+
+        """;
+
+    private async Task<string> ConvertToSup(string content = SrtContent, string extension = ".srt")
+    {
+        var input = Path.Combine(_tempRoot, "in" + extension);
+        await File.WriteAllTextAsync(input, content);
+        var outFolder = Path.Combine(_tempRoot, "sup");
+        Directory.CreateDirectory(outFolder);
+
+        var converter = new SubtitleConverter();
+        var result = await converter.ConvertAsync(new ConversionOptions
+        {
+            Patterns = [input],
+            Format = "bluraysup",
+            OutputFolder = outFolder,
+            Overwrite = true,
+            Resolution = (1920, 1080),
+            ImageStyle = new ImageExportStyle(),
+        });
+
+        Assert.True(result.Success, string.Join("; ", result.Errors));
+        return Assert.Single(Directory.GetFiles(outFolder, "*.sup"));
+    }
+
+    [Fact]
+    public async Task ConvertAsync_BluRaySup_AlignmentTagsPositionTheParagraph()
+    {
+        var supFile = await ConvertToSup();
+
+        var subtitles = BluRaySupParser.ParseBluRaySup(supFile, new StringBuilder());
+        Assert.Equal(3, subtitles.Count);
+
+        var top = subtitles[0].GetPosition();
+        var bottomLeft = subtitles[1].GetPosition();
+        var untagged = subtitles[2].GetPosition();
+
+        // {\an8} - top of the frame, horizontally centered
+        Assert.True(top.Top < 540, $"{{\\an8}} should be in the upper half, was y={top.Top}");
+
+        // {\an1} - bottom of the frame, flush left
+        Assert.True(bottomLeft.Top > 540, $"{{\\an1}} should be in the lower half, was y={bottomLeft.Top}");
+        Assert.True(bottomLeft.Left < untagged.Left, "{\\an1} should be further left than a centered line");
+
+        // No tag - unchanged default (bottom center)
+        Assert.True(untagged.Top > 540, $"untagged line should stay at the bottom, was y={untagged.Top}");
+        Assert.True(untagged.Left > 100, "untagged line should stay centered");
+    }
+
+    [Fact]
+    public async Task ConvertAsync_BluRaySup_PosTagPositionsTheParagraph()
+    {
+        var supFile = await ConvertToSup(AssContent, ".ass");
+
+        var subtitles = BluRaySupParser.ParseBluRaySup(supFile, new StringBuilder());
+        Assert.Equal(2, subtitles.Count);
+
+        // "{\an7\pos(50,50)}" in a 960x540 script, exported at 1920x1080: the top left corner
+        // of the text lands at 100,100
+        var positioned = subtitles[0].GetPosition();
+        Assert.Equal(100, positioned.Left);
+        Assert.Equal(100, positioned.Top);
+
+        // A line without "\pos" keeps the default bottom placement
+        var untagged = subtitles[1].GetPosition();
+        Assert.True(untagged.Top > 540, $"untagged line should stay at the bottom, was y={untagged.Top}");
+    }
+}


### PR DESCRIPTION
Fixes #13025

`seconv movie.ass "Blu-ray sup"` drew `{\an8}Hi` as literal text at the bottom of the frame: image based export fed the raw paragraph text to a renderer that only understands HTML tags, so ASSA override tags were neither applied nor removed.

New `ExportTextTags` in `libuilogic` reads the tags and prepares the text for the renderer:

- **Alignment** — `{\an1}`..`{\an9}` position the paragraph, also inside a multi tag block (`{\an8\i1}`, `{\pos(10,20)\an8}`). The export profile alignment is now only the fallback for untagged lines.
- **Style** — `{\i1}`, `{\b1}`, `{\c&H0000FF&}`, `{\fn}`, `{\fs}` become the HTML tags the renderer can draw (via `AdvancedSubStationAlpha.GetFormattedText`); whatever is left, including every tag on a line it considers too complex (`\pos`, `\fad`, `\k`, `\clip`, drawings), is dropped rather than drawn.
- **Position** — `{\pos(x,y)}` sets `OverridePosition`. The tag gives the *anchor point* for the current alignment, so it is applied after rendering when the bitmap size is known, scaled from the script's PlayResX/PlayResY to the export canvas, and clamped inside the frame.

Used by `seconv`, batch convert and the export images window. The window loses its private alignment parsing, and its preview follows the override position so it matches the exported file. Batch convert honored no alignment at all before — it stripped the tags and pinned every line to bottom center — so top positioned lines silently ended up at the bottom there.

Text without ASSA tags takes the same path as before: the conversion only runs when the text contains `{\`, so a plain `C:\new folder` in an SRT keeps its backslash.

### Verified

`seconv` end to end, reading the positions back out of the written files:

| input | result |
| --- | --- |
| `{\an8}Top center` | top of frame, centered |
| `{\an1}Bottom left` | bottom, flush left |
| `{\an7\pos(100,100)}` | `X="100" Y="100"` |
| `{\an5\pos(960,540)}`, 457x49 bitmap | `X="732" Y="516"` (centered on the point) |
| `\pos(20,20)`, PlayRes 384x288 on 1920x1080 | `X="100" Y="75"` (scaled) |
| `{\an8\i1}Top italic{\i0}` | italic, top, no tag drawn |
| `{\c&H0000FF&}Red text{\c}` | red |
| `{\pos(300,200)}Complex tag line` | clean text, tag dropped |

Tests: 64 cases in `ExportTextTagsTests`, plus `ImageOutputAlignmentTest` which converts to Blu-ray sup and asserts the positions parsed back with `BluRaySupParser`. Suites green: libuilogic 122/122, UI 1000/1000, seconv image/conversion 28/28.

### Known limits

- VobSub ignores `\pos` — its handler positions purely from `Alignment`; `{\anX}` works there. Needs a position threaded through `VobSubWriter`.
- `\move(...)` is dropped from the text but does not position the line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
