### PR TITLE
Honor {\pos(x,y)} in VobSub and DVD sup export

### DIFF
--- a/src/libuilogic/Export/ExportHandlerDvdSup.cs
+++ b/src/libuilogic/Export/ExportHandlerDvdSup.cs
@@ -30,7 +30,9 @@ public class ExportHandlerDvdSup : IExportHandler
         }
 
         var p = new Paragraph(param.Text, param.StartTime.TotalMilliseconds, param.EndTime.TotalMilliseconds);
-        _dvdSupWriter.WriteParagraph(p, param.Bitmap, MapAlignment(param));
+        // "{\pos(x,y)}" (ExportTextTags.ApplyPositionTag) wins over the alignment, as in the
+        // other image based handlers.
+        _dvdSupWriter.WriteParagraph(p, param.Bitmap, MapAlignment(param), param.OverridePositionPoint);
     }
 
     private static BluRayContentAlignment MapAlignment(ImageParameter param)

--- a/src/libuilogic/Export/ExportHandlerVobSub.cs
+++ b/src/libuilogic/Export/ExportHandlerVobSub.cs
@@ -36,7 +36,9 @@ public class ExportHandlerVobSub : IExportHandler
         var p = new Paragraph(param.Text, param.StartTime.TotalMilliseconds, param.EndTime.TotalMilliseconds);
         var alignment = MapAlignment(param);
 
-        _vobSubWriter.WriteParagraph(p, param.Bitmap, alignment);
+        // "{\pos(x,y)}" (ExportTextTags.ApplyPositionTag) wins over the alignment, as in the
+        // other image based handlers.
+        _vobSubWriter.WriteParagraph(p, param.Bitmap, alignment, param.OverridePositionPoint);
     }
 
     private static BluRayContentAlignment MapAlignment(ImageParameter param)

--- a/src/libuilogic/Export/ImageParameter.cs
+++ b/src/libuilogic/Export/ImageParameter.cs
@@ -51,6 +51,14 @@ public class ImageParameter
         Error = string.Empty;
     }
 
+    /// <summary>
+    /// <see cref="OverridePosition"/> - the bitmap's top left corner - in the shape the VobSub
+    /// and DVD sup writers take it. They range check it themselves and fall back to
+    /// <see cref="Alignment"/> when it falls outside the frame.
+    /// </summary>
+    public SKPoint? OverridePositionPoint =>
+        OverridePosition.HasValue ? new SKPoint(OverridePosition.Value.X, OverridePosition.Value.Y) : null;
+
     public BluRayContentAlignment BluRayContentAlignment => Alignment switch
     {
         ExportAlignment.TopLeft => BluRayContentAlignment.TopLeft,

--- a/tests/seconv/Core/ImageOutputAlignmentTest.cs
+++ b/tests/seconv/Core/ImageOutputAlignmentTest.cs
@@ -1,4 +1,5 @@
 using Nikse.SubtitleEdit.Core.BluRaySup;
+using Nikse.SubtitleEdit.Core.VobSub;
 using SeConv.Core;
 using System.Text;
 using Xunit;
@@ -62,24 +63,29 @@ public class ImageOutputAlignmentTest : IDisposable
 
     private async Task<string> ConvertToSup(string content = SrtContent, string extension = ".srt")
     {
+        return await Convert(content, extension, "bluraysup", "*.sup", (1920, 1080));
+    }
+
+    private async Task<string> Convert(string content, string extension, string format, string outputPattern, (int, int) resolution)
+    {
         var input = Path.Combine(_tempRoot, "in" + extension);
         await File.WriteAllTextAsync(input, content);
-        var outFolder = Path.Combine(_tempRoot, "sup");
+        var outFolder = Path.Combine(_tempRoot, format);
         Directory.CreateDirectory(outFolder);
 
         var converter = new SubtitleConverter();
         var result = await converter.ConvertAsync(new ConversionOptions
         {
             Patterns = [input],
-            Format = "bluraysup",
+            Format = format,
             OutputFolder = outFolder,
             Overwrite = true,
-            Resolution = (1920, 1080),
+            Resolution = resolution,
             ImageStyle = new ImageExportStyle(),
         });
 
         Assert.True(result.Success, string.Join("; ", result.Errors));
-        return Assert.Single(Directory.GetFiles(outFolder, "*.sup"));
+        return Assert.Single(Directory.GetFiles(outFolder, outputPattern));
     }
 
     [Fact]
@@ -123,5 +129,31 @@ public class ImageOutputAlignmentTest : IDisposable
         // A line without "\pos" keeps the default bottom placement
         var untagged = subtitles[1].GetPosition();
         Assert.True(untagged.Top > 540, $"untagged line should stay at the bottom, was y={untagged.Top}");
+    }
+
+    [Fact]
+    public async Task ConvertAsync_VobSub_PosTagPositionsTheParagraph()
+    {
+        // VobSub is 720x576 (PAL), so the 960x540 script's "\pos(50,50)" scales to
+        // 50*720/960 = 37.5 -> 38 and 50*576/540 = 53.3 -> 53
+        var subFile = await Convert(AssContent, ".ass", "vobsub", "*.sub", (720, 576));
+
+        var parser = new VobSubParser(true);
+        parser.OpenSubIdx(subFile, Path.ChangeExtension(subFile, ".idx"));
+        var packs = parser.MergeVobSubPacks();
+        Assert.Equal(2, packs.Count);
+
+        // Decoding fills in ImageDisplayArea from the subpicture's display control commands
+        foreach (var pack in packs)
+        {
+            pack.GetBitmap();
+        }
+
+        var positioned = packs[0].SubPicture.ImageDisplayArea;
+        Assert.Equal(38, positioned.Left);
+        Assert.Equal(53, positioned.Top);
+
+        var untagged = packs[1].SubPicture.ImageDisplayArea;
+        Assert.True(untagged.Top > 288, $"untagged line should stay at the bottom, was y={untagged.Top}");
     }
 }


### PR DESCRIPTION
Follow-up to #13026 (issue #13025).

`{\pos(x,y)}` now positions the paragraph in Blu-ray sup, BDN-XML, DOST and IMSC image export, but VobSub and DVD sup still fell back to plain alignment.

Turns out `VobSubWriter.WriteParagraph` and `DvdSupWriter.WriteParagraph` have taken an optional `overridePosition` all along - `WriteDisplayArea` even range checks it and falls back to the alignment when it lands outside the frame. The two handlers just never passed one.

- `ImageParameter.OverridePositionPoint` exposes the position as the `SKPoint?` those writers take, next to the existing `BluRayContentAlignment` property.
- `ExportHandlerVobSub` and `ExportHandlerDvdSup` pass it through.

DVD sup shares `VobSubWriter.GetSubImageBuffer`, so one code path covers both.

### Verified

New end to end test: a 960x540 script with `{\an7\pos(50,50)}` exported to VobSub at 720x576, parsed back with `VobSubParser` - `ImageDisplayArea` sits at 38,53 (`50*720/960 = 37.5` and `50*576/540 = 53.3`). A line without `\pos` keeps its bottom placement.

libuilogic 122/122. seconv image/VobSub 36/37 - the one failure, `VobSubPaletteTest.LoadVobSub_AppliesIdxPalette_ToDecodedBitmaps`, is pre-existing on main and unrelated (confirmed by stashing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
