### PR TITLE
Keep the source position when re-exporting image subtitles

### DIFF
--- a/src/seconv/Core/BitmapSubtitleLoader.cs
+++ b/src/seconv/Core/BitmapSubtitleLoader.cs
@@ -22,13 +22,19 @@ internal static class BitmapSubtitleLoader
     /// are the source-format's declared video frame dimensions when known — pass them
     /// to the output handler so e.g. Blu-Ray 1920x1080 stays at 1920x1080 rather than
     /// being squashed into the CLI's default <c>--resolution</c>. Null = caller picks.
+    /// <para>
+    /// <see cref="Position"/> is the bitmap's top-left corner in the source frame. Image
+    /// sources carry it per event (a top-positioned caption, a sign at the left edge), and
+    /// without it every re-export was re-centred at the bottom of the frame.
+    /// </para>
     /// </summary>
     public sealed record BitmapSubtitleItem(
         TimeCode StartTime,
         TimeCode EndTime,
         SKBitmap Bitmap,
         int? ScreenWidth = null,
-        int? ScreenHeight = null) : IDisposable
+        int? ScreenHeight = null,
+        SKPointI? Position = null) : IDisposable
     {
         public void Dispose() => Bitmap.Dispose();
     }
@@ -113,12 +119,16 @@ internal static class BitmapSubtitleLoader
             // 1115 zero-duration cues in the .sup export). MergeVobSubPacks has already
             // repaired EndTime for missing/negative/over-long delays — the same times the
             // GUI shows.
+            // GetPosition reads SubPicture.ImageDisplayArea, which is only filled in while
+            // decoding - so after GetBitmap above, never before.
+            var position = pack.GetPosition();
             items.Add(new BitmapSubtitleItem(
                 new TimeCode(pack.StartTime.TotalMilliseconds),
                 new TimeCode(pack.EndTime.TotalMilliseconds),
                 bmp,
                 screenWidth,
-                screenHeight));
+                screenHeight,
+                new SKPointI(position.Left, position.Top)));
         }
         WarnSkippedBitmaps(skipped, "VobSub");
         return items;
@@ -212,12 +222,14 @@ internal static class BitmapSubtitleLoader
             // are based on the SubPicture delay and only correct for .sub+.idx sources.
             // Screen size comes from the CodecPrivate "size:" line so an image output
             // (e.g. bluraysup) keeps the DVD frame instead of defaulting to 1920x1080.
+            var position = pack.GetPosition();
             items.Add(new BitmapSubtitleItem(
                 new TimeCode(pack.StartTime.TotalMilliseconds),
                 new TimeCode(pack.EndTime.TotalMilliseconds),
                 bmp,
                 screenWidth,
-                screenHeight));
+                screenHeight,
+                new SKPointI(position.Left, position.Top)));
         }
         WarnSkippedBitmaps(skipped, "MKV VobSub");
         if (items.Count == 0)
@@ -288,7 +300,10 @@ internal static class BitmapSubtitleLoader
             {
                 continue;
             }
-            items.Add(new BitmapSubtitleItem(paragraphs[i].StartTime, paragraphs[i].EndTime, bmp));
+            // ImageDisplayArea is filled in by GetBitmap above.
+            var displayArea = subPictures[i].ImageDisplayArea;
+            items.Add(new BitmapSubtitleItem(paragraphs[i].StartTime, paragraphs[i].EndTime, bmp,
+                Position: new SKPointI(displayArea.Left, displayArea.Top)));
         }
         if (items.Count == 0)
         {
@@ -329,10 +344,12 @@ internal static class BitmapSubtitleLoader
                 {
                     continue;
                 }
+                var position = dvb.GetPosition();
                 items.Add(new BitmapSubtitleItem(
                     new TimeCode(dvb.StartMilliseconds),
                     new TimeCode(dvb.EndMilliseconds),
-                    bmp));
+                    bmp,
+                    Position: new SKPointI(position.Left, position.Top)));
             }
             if (items.Count > 0)
             {
@@ -359,7 +376,9 @@ internal static class BitmapSubtitleLoader
             {
                 continue;
             }
-            items.Add(new BitmapSubtitleItem(pcs.StartTimeCode, pcs.EndTimeCode, bmp, screenWidth, screenHeight));
+            var position = pcs.GetPosition();
+            items.Add(new BitmapSubtitleItem(pcs.StartTimeCode, pcs.EndTimeCode, bmp, screenWidth, screenHeight,
+                new SKPointI(position.Left, position.Top)));
         }
         return items;
     }

--- a/src/seconv/Core/ImageOutputWriter.cs
+++ b/src/seconv/Core/ImageOutputWriter.cs
@@ -125,6 +125,16 @@ internal static class ImageOutputWriter
         var screenWidth = item.ScreenWidth ?? defaultWidth;
         var screenHeight = item.ScreenHeight ?? defaultHeight;
 
+        // The source's own position, in the frame the bitmap came from - kept as-is because
+        // the item's screen size travels with it. Handlers ignore a position outside the
+        // frame and fall back to the alignment below, so an unusable one costs nothing.
+        var position = item.Position;
+        if (position is { } p &&
+            (p.X < 0 || p.X >= screenWidth || p.Y < 0 || p.Y >= screenHeight))
+        {
+            position = null;
+        }
+
         var style = options.ImageStyle;
         return new ImageParameter
         {
@@ -134,6 +144,7 @@ internal static class ImageOutputWriter
             StartTime = item.StartTime.TimeSpan,
             EndTime = item.EndTime.TimeSpan,
             Alignment = style.Alignment,
+            OverridePosition = position,
             ContentAlignment = style.ContentAlignment,
             // Font/colour fields are still required by the ImageParameter contract even
             // though no rendering happens — handlers read them for metadata in some

--- a/tests/seconv/Core/ImageToImageTest.cs
+++ b/tests/seconv/Core/ImageToImageTest.cs
@@ -1,4 +1,7 @@
+using Nikse.SubtitleEdit.Core.BluRaySup;
 using SeConv.Core;
+using System.Text;
+using System.Text.RegularExpressions;
 using Xunit;
 
 namespace SeConvTests.Core;
@@ -75,6 +78,80 @@ public class ImageToImageTest : IDisposable
         Assert.Contains("<BDN", index);
         Assert.DoesNotContain("400 300", index); // would indicate the --resolution leaked through
         Assert.DoesNotContain("VideoFormat=\"400x300\"", index);
+    }
+
+    // Three lines the export places in three different spots, so a re-export that drops the
+    // source position (and re-centres everything at the bottom) cannot pass by accident.
+    private const string PositionedAssContent = """
+        [Script Info]
+        ScriptType: v4.00+
+        PlayResX: 1920
+        PlayResY: 1080
+
+        [V4+ Styles]
+        Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+        Style: Default,Arial,48,&H00FFFFFF,&H0300FFFF,&H00000000,&H02000000,0,0,0,0,100,100,0,0,1,2,1,2,10,10,10,1
+
+        [Events]
+        Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+        Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,{\an7\pos(100,100)}Top left corner
+        Dialogue: 0,0:00:03.00,0:00:04.00,Default,,0,0,0,,{\an5\pos(960,540)}Middle of the frame
+        Dialogue: 0,0:00:05.00,0:00:06.00,Default,,0,0,0,,{\an8}Top center
+
+        """;
+
+    [Fact]
+    public async Task ConvertAsync_BluRaySupToBdnXml_PreservesSourcePositions()
+    {
+        var input = Path.Combine(_tempRoot, "positioned.ass");
+        await File.WriteAllTextAsync(input, PositionedAssContent, TestContext.Current.CancellationToken);
+
+        var supFolder = Path.Combine(_tempRoot, "sup");
+        Directory.CreateDirectory(supFolder);
+        var converter = new SubtitleConverter();
+        var supResult = await converter.ConvertAsync(new ConversionOptions
+        {
+            Patterns = [input],
+            Format = "bluraysup",
+            OutputFolder = supFolder,
+            Overwrite = true,
+            Resolution = (1920, 1080),
+            ImageStyle = new ImageExportStyle(),
+        });
+        Assert.True(supResult.Success, string.Join("; ", supResult.Errors));
+        var supFile = Assert.Single(Directory.GetFiles(supFolder, "*.sup"));
+
+        var expected = BluRaySupParser.ParseBluRaySup(supFile, new StringBuilder())
+            .Select(p => p.GetPosition())
+            .ToList();
+        Assert.Equal(3, expected.Count);
+        // The three lines really are in three different places in the source
+        Assert.Equal(3, expected.Select(p => p.Top).Distinct().Count());
+
+        // Re-export the .sup as BDN-XML, which records each bitmap's X/Y
+        var bdnFolder = Path.Combine(_tempRoot, "bdn2");
+        Directory.CreateDirectory(bdnFolder);
+        var bdnResult = await converter.ConvertAsync(new ConversionOptions
+        {
+            Patterns = [supFile],
+            Format = "bdnxml",
+            OutputFolder = bdnFolder,
+            Overwrite = true,
+        });
+        Assert.True(bdnResult.Success, string.Join("; ", bdnResult.Errors));
+
+        var indexFile = Assert.Single(Directory.GetFiles(bdnFolder, "index.xml", SearchOption.AllDirectories));
+        var index = await File.ReadAllTextAsync(indexFile, TestContext.Current.CancellationToken);
+        var written = Regex.Matches(index, @"<Graphic[^>]*\sX=""(\d+)""\s+Y=""(\d+)""")
+            .Select(m => (X: int.Parse(m.Groups[1].Value), Y: int.Parse(m.Groups[2].Value)))
+            .ToList();
+
+        Assert.Equal(expected.Count, written.Count);
+        for (var i = 0; i < expected.Count; i++)
+        {
+            Assert.Equal(expected[i].Left, written[i].X);
+            Assert.Equal(expected[i].Top, written[i].Y);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
`seconv in.sup bdnxml` re-centred a whole file at the bottom of the frame: the image-to-image path (sup → BDN-XML, VobSub → sup, MKV PGS → sup, DVB → sup, ...) handed the output handler bitmaps with no position, so every event was placed by the export alignment alone. Top captions and signs lost their place.

`BitmapSubtitleItem` now carries the source position and every loader fills it in:

| source | position from |
| --- | --- |
| Blu-ray .sup / MKV PGS | `PcsData.GetPosition()` (PCS object origin) |
| VobSub .sub+.idx / MKV VobSub | `VobSubMergedPack.GetPosition()` (subpicture display area) |
| MP4 VobSub | `SubPicture.ImageDisplayArea` |
| DVB-sub (TS) | `TransportStreamSubtitle.GetPosition()` |

`BuildPreservedParameter` passes it on as `OverridePosition`. Coordinates need no scaling - the item's own screen size travels with the bitmap and becomes the export canvas. A position outside that frame is dropped so the handler falls back to the alignment, which is what it does with an unusable override anyway.

The GUI batch converter already did this (`BatchConverter.WriteToImageBasedFormat`); only seconv was missing it.

### Verified

`.ass` with `{\an7\pos(100,100)}`, `{\an5\pos(960,540)}` and `{\an8}` → Blu-ray sup → BDN-XML now reproduces the source positions exactly (`X="100" Y="100"`, `X="732" Y="516"`, `X="782" Y="974"`), identical to exporting the `.ass` straight to BDN-XML. Before, all three came out at `Y="974"`.

New regression test `ConvertAsync_BluRaySupToBdnXml_PreservesSourcePositions` compares the BDN-XML X/Y against the positions parsed out of the source .sup, and asserts the three lines really are in three distinct spots so a re-centred export cannot pass by accident. Confirmed it fails without the fix (expected 100, got 799).

seconv suite 282/283 - the one failure, `VobSubPaletteTest.LoadVobSub_AppliesIdxPalette_ToDecodedBitmaps`, is pre-existing on main and unrelated (confirmed by stashing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
