### PR TITLE
Read the frame size from a standalone VobSub .idx

### DIFF
--- a/src/seconv/Core/BitmapSubtitleLoader.cs
+++ b/src/seconv/Core/BitmapSubtitleLoader.cs
@@ -67,10 +67,11 @@ internal static class BitmapSubtitleLoader
     /// VobSub <c>.sub</c> (+ optional <c>.idx</c>) → bitmap events. Uses
     /// <see cref="VobSubParser.OpenSubIdx"/>, which uses the .idx for timing + palette when
     /// present and otherwise parses the .sub's MPEG-PS stream directly (stream PTS timing +
-    /// a default palette). The VobSub spec doesn't store a screen size in the index file, so
-    /// we bake in the DVD-standard frame sizes (720x576 PAL, 720x480 NTSC) — otherwise the
-    /// output writer would fall back to <c>--resolution</c> / 1920x1080, which is wrong
-    /// metadata for DVD sources.
+    /// a default palette). The frame size comes from the .idx's <c>size:</c> line when it has
+    /// one — VobSub is not always DVD-sized (Subtitle Edit's own export writes whatever the
+    /// source was, e.g. <c>size: 1920x1080</c>) and squeezing a 1920x1080 stream into a DVD
+    /// frame moves every subpicture. Without that line, fall back to the DVD standards
+    /// (720x576 PAL, 720x480 NTSC) rather than <c>--resolution</c> / 1920x1080.
     /// </summary>
     public static IReadOnlyList<BitmapSubtitleItem> LoadVobSub(string subPath, string idxPath, bool isPal)
     {
@@ -84,8 +85,8 @@ internal static class BitmapSubtitleLoader
             throw new InvalidOperationException($"No VobSub subtitle packs in: {subPath}");
         }
 
-        var screenWidth = 720;
-        var screenHeight = isPal ? 576 : 480;
+        var (screenWidth, screenHeight) = TryGetVobSubIdxScreenSize(ReadIdxText(idxPath))
+                                          ?? (720, isPal ? 576 : 480);
 
         var items = new List<BitmapSubtitleItem>(packs.Count);
         var skipped = 0;
@@ -233,23 +234,58 @@ internal static class BitmapSubtitleLoader
     /// </summary>
     internal static (int Width, int Height) GetVobSubIdxScreenSize(string? codecPrivate)
     {
-        if (!string.IsNullOrWhiteSpace(codecPrivate))
+        return TryGetVobSubIdxScreenSize(codecPrivate) ?? (720, 576);
+    }
+
+    /// <summary>
+    /// Frame size from .idx text ("size: 720x576"), or null when it carries no usable
+    /// <c>size:</c> line — the caller then picks its own default (DVD PAL vs NTSC differ,
+    /// so there is no single right fallback here).
+    /// </summary>
+    internal static (int Width, int Height)? TryGetVobSubIdxScreenSize(string? idxText)
+    {
+        if (string.IsNullOrWhiteSpace(idxText))
         {
-            foreach (var line in codecPrivate.SplitToLines())
+            return null;
+        }
+
+        foreach (var line in idxText.SplitToLines())
+        {
+            if (line.StartsWith("size:", StringComparison.OrdinalIgnoreCase))
             {
-                if (line.StartsWith("size:", StringComparison.OrdinalIgnoreCase))
+                var parts = line.Substring(5).Trim().Split('x');
+                if (parts.Length == 2 &&
+                    int.TryParse(parts[0].Trim(), out var w) && w > 0 &&
+                    int.TryParse(parts[1].Trim(), out var h) && h > 0)
                 {
-                    var parts = line.Substring(5).Trim().Split('x');
-                    if (parts.Length == 2 &&
-                        int.TryParse(parts[0].Trim(), out var w) && w > 0 &&
-                        int.TryParse(parts[1].Trim(), out var h) && h > 0)
-                    {
-                        return (w, h);
-                    }
+                    return (w, h);
                 }
             }
         }
-        return (720, 576);
+
+        return null;
+    }
+
+    /// <summary>
+    /// Text of a standalone <c>.idx</c>, or null when there is none to read — an absent or
+    /// unreadable companion is normal (<see cref="VobSubParser.OpenSubIdx"/> copes), so it
+    /// must not fail the conversion.
+    /// </summary>
+    private static string? ReadIdxText(string? idxPath)
+    {
+        if (string.IsNullOrEmpty(idxPath) || !File.Exists(idxPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            return File.ReadAllText(idxPath);
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     /// <summary>

--- a/tests/seconv/Core/ImageToImageTest.cs
+++ b/tests/seconv/Core/ImageToImageTest.cs
@@ -106,4 +106,77 @@ public class ImageToImageTest : IDisposable
         Assert.False(result.Success);
         Assert.Contains("Tesseract not found on PATH", result.Errors[0]);
     }
+
+    private const string SrtContent = """
+        1
+        00:00:01,000 --> 00:00:02,000
+        Hello
+
+        2
+        00:00:03,000 --> 00:00:04,000
+        World
+
+        """;
+
+    [Fact]
+    public async Task ConvertAsync_VobSubToBdnXml_KeepsTheIdxFrameSize_NotDvdPal()
+    {
+        // A 1920x1080 VobSub - Subtitle Edit writes "size: 1920x1080" into the .idx - used to
+        // come back as DVD PAL 720x576, which moves every subpicture inside a smaller frame.
+        var input = Path.Combine(_tempRoot, "in.srt");
+        await File.WriteAllTextAsync(input, SrtContent, TestContext.Current.CancellationToken);
+
+        var vobFolder = Path.Combine(_tempRoot, "vob");
+        Directory.CreateDirectory(vobFolder);
+        var converter = new SubtitleConverter();
+        var vobResult = await converter.ConvertAsync(new ConversionOptions
+        {
+            Patterns = [input],
+            Format = "vobsub",
+            OutputFolder = vobFolder,
+            Overwrite = true,
+            Resolution = (1920, 1080),
+            ImageStyle = new ImageExportStyle(),
+        });
+        Assert.True(vobResult.Success, string.Join("; ", vobResult.Errors));
+
+        var subFile = Assert.Single(Directory.GetFiles(vobFolder, "*.sub"));
+        var idxFile = Path.ChangeExtension(subFile, ".idx");
+        Assert.Contains("size: 1920x1080",
+            await File.ReadAllTextAsync(idxFile, TestContext.Current.CancellationToken));
+
+        var bdnFolder = Path.Combine(_tempRoot, "bdn3");
+        Directory.CreateDirectory(bdnFolder);
+        var bdnResult = await converter.ConvertAsync(new ConversionOptions
+        {
+            Patterns = [subFile],
+            Format = "bdnxml",
+            OutputFolder = bdnFolder,
+            Overwrite = true,
+        });
+        Assert.True(bdnResult.Success, string.Join("; ", bdnResult.Errors));
+
+        var indexFile = Assert.Single(Directory.GetFiles(bdnFolder, "index.xml", SearchOption.AllDirectories));
+        var index = await File.ReadAllTextAsync(indexFile, TestContext.Current.CancellationToken);
+        Assert.Contains("VideoFormat=\"1080p\"", index);
+    }
+
+    [Theory]
+    [InlineData("size: 720x480\npalette: 000000", 720, 480)]
+    [InlineData("SIZE: 1920x1080", 1920, 1080)]
+    public void TryGetVobSubIdxScreenSize_SizeLine_IsParsed(string idxText, int width, int height)
+    {
+        Assert.Equal((width, height), BitmapSubtitleLoader.TryGetVobSubIdxScreenSize(idxText));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("palette: 000000")]
+    [InlineData("size: banana")]
+    public void TryGetVobSubIdxScreenSize_NoUsableSizeLine_ReturnsNull(string? idxText)
+    {
+        // null, not a guess - the caller knows whether PAL or NTSC is the right default
+        Assert.Null(BitmapSubtitleLoader.TryGetVobSubIdxScreenSize(idxText));
+    }
 }


### PR DESCRIPTION
Found while verifying #13028.

The VobSub loader assumed every `.sub`+`.idx` was DVD sized (720x576 PAL, 720x480 NTSC):

```
var screenWidth = 720;
var screenHeight = isPal ? 576 : 480;
```

But VobSub is not always DVD sized - Subtitle Edit's own VobSub export writes `size: 1920x1080` into the `.idx` for a 1080p source. Re-exporting such a file (`seconv in.sub bdnxml`) squeezed it into a 720x576 frame, which moves every subpicture inside it and records the wrong `VideoFormat`. The MKV VobSub path has read that same `size:` line out of CodecPrivate all along.

- `TryGetVobSubIdxScreenSize` returns null rather than guessing when the line is missing or malformed, so the caller keeps its own PAL/NTSC default - there is no single right fallback at that level.
- `GetVobSubIdxScreenSize` (MKV) is now a thin wrapper over it, unchanged behaviour, existing tests untouched.
- A missing or unreadable `.idx` is normal (`VobSubParser.OpenSubIdx` copes), so reading it never fails the conversion.

### Verified

`.ass` → VobSub at 1920x1080 → BDN-XML: the index now says `VideoFormat="1080p"`; before it came out as a 720x576 frame.

New tests: an end to end `ConvertAsync_VobSubToBdnXml_KeepsTheIdxFrameSize_NotDvdPal` (confirmed failing without the fix) plus parse/null cases for the helper. seconv suite 288/289 - the one failure, `VobSubPaletteTest.LoadVobSub_AppliesIdxPalette_ToDecodedBitmaps` ("the CLUT was not applied"), is pre-existing on main and unrelated to frame size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
