### PR TITLE
Fix red and blue swapping in VobSub, SSA and TextST colours

### DIFF
--- a/src/libse/Common/ColorUtils.cs
+++ b/src/libse/Common/ColorUtils.cs
@@ -75,12 +75,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         internal static SKColor FromArgb(int alpha, SKColor c)
         {
-            return new SKColor(c.Red, c.Green, c.Blue, (byte)alpha);    
-        }
-
-        internal static SKColor FromArgb(int alpha, byte blue, byte green, byte red)
-        {
-            return new SKColor(red, green, blue, (byte)alpha);
+            return new SKColor(c.Red, c.Green, c.Blue, (byte)alpha);
         }
     }
 }

--- a/src/libse/Common/RegexUtils.cs
+++ b/src/libse/Common/RegexUtils.cs
@@ -223,7 +223,8 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// Normalizes the new-line escapes a user typed in a regular expression (<c>\r\n</c>, <c>\n</c>
         /// or <c>\r</c>) to a single line-feed, so a rule matches regardless of which escape was typed
         /// and regardless of the platform line-ending. Subtitle text is matched line-feed normalized too
-        /// (see <see cref="ReplaceNewLineSafe"/>), keeping the pattern and the text in sync. The previous
+        /// (see <see cref="ReplaceNewLineSafe(Regex, string, string)"/>), keeping the pattern and the text
+        /// in sync. The previous
         /// behavior expanded these to Environment.NewLine (CRLF on Windows), which no longer matched the
         /// line-feed text used in v5, so cross-line regex rules silently stopped working (#11956).
         /// </summary>

--- a/src/seconv/Core/AutoTranslateRunner.cs
+++ b/src/seconv/Core/AutoTranslateRunner.cs
@@ -2,7 +2,6 @@ using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.UiLogic.Translate;
 using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
-using Nikse.SubtitleEdit.UiLogic.Translate;
 
 namespace SeConv.Core;
 

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -31,7 +31,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
-using Nikse.SubtitleEdit.UiLogic.Translate;
 using Nikse.SubtitleEdit.UiLogic.Common;
 
 namespace Nikse.SubtitleEdit.Features.Translate;

--- a/src/ui/Features/Translate/CopyPasteTranslateViewModel.cs
+++ b/src/ui/Features/Translate/CopyPasteTranslateViewModel.cs
@@ -12,7 +12,6 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Nikse.SubtitleEdit.UiLogic.Translate;
 
 namespace Nikse.SubtitleEdit.Features.Translate;
 

--- a/tests/libse/Common/ColorUtilsTest.cs
+++ b/tests/libse/Common/ColorUtilsTest.cs
@@ -1,0 +1,72 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using SkiaSharp;
+using Xunit;
+
+namespace LibSETests.Common;
+
+/// <summary>
+/// ColorUtils.FromArgb used to have an extra overload taking (int alpha, byte blue, byte
+/// green, byte red) - reversed. Byte arguments bound to it in preference to the (int alpha,
+/// int red, int green, int blue) overload, so four call sites silently swapped red and blue:
+/// VobSub subpicture decoding, .idx palettes written with alpha, SSA numeric colours and
+/// TextST palettes. These tests pin the ARGB order down.
+/// </summary>
+public class ColorUtilsTest
+{
+    [Fact]
+    public void FromArgb_ByteArguments_KeepArgbOrder()
+    {
+        // Explicit bytes - the argument types that used to pick the reversed overload
+        byte r = 255;
+        byte g = 128;
+        byte b = 0;
+
+        var color = ColorUtils.FromArgb(200, r, g, b);
+
+        Assert.Equal(200, color.Alpha);
+        Assert.Equal(255, color.Red);
+        Assert.Equal(128, color.Green);
+        Assert.Equal(0, color.Blue);
+    }
+
+    [Fact]
+    public void GetSsaColor_DecimalNumber_IsBgrNotRgb()
+    {
+        // SSA numeric colours are decimal &HBBGGRR: 255 is red, 16711680 is blue
+        var red = AdvancedSubStationAlpha.GetSsaColor("255", SKColors.Yellow);
+        Assert.Equal(255, red.Red);
+        Assert.Equal(0, red.Green);
+        Assert.Equal(0, red.Blue);
+
+        var blue = AdvancedSubStationAlpha.GetSsaColor("16711680", SKColors.Yellow);
+        Assert.Equal(0, blue.Red);
+        Assert.Equal(0, blue.Green);
+        Assert.Equal(255, blue.Blue);
+    }
+
+    [Fact]
+    public void TextStPalette_YCbCr_MapsToRgbNotBgr()
+    {
+        // Y=81, Cb=90, Cr=240 is red in studio-range BT.709
+        var palette = new TextST.Palette { Y = 81, Cb = 90, Cr = 240, T = 255 };
+
+        var color = palette.Color;
+
+        Assert.True(color.Red > 200, $"expected a red-dominant colour, got {color}");
+        Assert.True(color.Blue < 60, $"expected little blue, got {color}");
+    }
+
+    [Fact]
+    public void IdxPalette_EightDigitHex_KeepsChannelOrder()
+    {
+        // "aarrggbb" - the .idx palette variant that carries alpha
+        var idx = new Nikse.SubtitleEdit.Core.VobSub.Idx(new List<string> { "palette: 80ff8000, 000000" });
+
+        Assert.Equal(2, idx.Palette.Count);
+        Assert.Equal(0x80, idx.Palette[0].Alpha);
+        Assert.Equal(255, idx.Palette[0].Red);
+        Assert.Equal(0x80, idx.Palette[0].Green);
+        Assert.Equal(0, idx.Palette[0].Blue);
+    }
+}

--- a/tests/libuilogic/Common/LanguageFavoritesTest.cs
+++ b/tests/libuilogic/Common/LanguageFavoritesTest.cs
@@ -25,7 +25,7 @@ public class LanguageFavoritesTest
     [Fact]
     public void ParseCodes_EmptyReturnsEmpty()
     {
-        Assert.Empty(LanguageFavorites.ParseCodes(null));
+        Assert.Empty(LanguageFavorites.ParseCodes(null!));
         Assert.Empty(LanguageFavorites.ParseCodes(" "));
     }
 


### PR DESCRIPTION
Fixes the long-failing `VobSubPaletteTest.LoadVobSub_AppliesIdxPalette_ToDecodedBitmaps` - and three more colour bugs with the same root cause.

`ColorUtils` had two four-argument overloads sitting next to each other:

```csharp
public   static SKColor FromArgb(int alpha, int red,   int green, int blue)
internal static SKColor FromArgb(int alpha, byte blue, byte green, byte red)   // reversed
```

Byte arguments bind to the reversed one in preference (exact type match beats three implicit conversions), so any call site passing `byte` channels silently swapped red and blue - no cast, no warning, nothing to notice at the call site. Four sites were affected:

| call site | effect |
| --- | --- |
| `SubPicture.SetTransparency` | every VobSub subpicture decoded with a CLUT had red and blue swapped - yellow DVD subtitles rendered cyan |
| `Idx.HexToColor` | `.idx` palette entries in `aarrggbb` form |
| `AdvancedSubStationAlpha.GetSsaColor` | SSA decimal colours, where the swap is deliberate (`&HBBGGRR`) - the overload undid it, so `"255"` returned blue instead of red |
| `TextST.Palette.Color` | palette entries straight out of `YCbCr2Rgb` |

Deleting the overload fixes all four at once: the byte arguments now bind to the ARGB overload, which is what every one of those sites was written against. No call site needed editing.

The failing test was diagnosed by dumping the decode: the `.idx` said `palette: 000000, ff0000, ...`, the parsed CLUT entry was `#ffff0000` (red), and the decoded pixel came out `#ff0000ff` (blue). So the CLUT was being applied all along - its message ("the CLUT was not applied") pointed at the wrong culprit. The test has never passed; it fails at the commit that introduced it.

### Tests

New `ColorUtilsTest` pins the channel order at each affected layer: `FromArgb` itself, SSA decimal colours (`255` → red, `16711680` → blue), TextST YCbCr → RGB, and 8-digit `.idx` palette entries. The three behavioural ones fail without the fix; all pass with it.

Suites: libse 740/740, seconv 290/290 (the palette test included - seconv is now fully green), libuilogic 122/122, UI 1000/1000.

### Warnings

Also cleared the build warnings in the projects this touches: an ambiguous `cref` in `RegexUtils` (libse is now warning-free), duplicate `using` directives in `AutoTranslateRunner` and two UI view models, and a null literal in a libuilogic test.

Not touched: 340 nullable warnings in libuilogic and 32 in UI (mostly CS8618/CS8604). Those are a separate sweep - fixing them properly means annotating nullability, not silencing, and does not belong in a colour-decode fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
