### PR TITLE
Fix all build warnings and modernize libuilogic for .NET 10

### DIFF
--- a/src/libuilogic/AudioToText/ResultText.cs
+++ b/src/libuilogic/AudioToText/ResultText.cs
@@ -2,7 +2,7 @@
 {
     public class ResultText
     {
-        public string Text { get; set; }
+        public string Text { get; set; } = string.Empty;
 
         /// <summary>
         /// Start seconds

--- a/src/libuilogic/AudioToText/WhisperCTranslate2Model.cs
+++ b/src/libuilogic/AudioToText/WhisperCTranslate2Model.cs
@@ -6,9 +6,9 @@ namespace Nikse.SubtitleEdit.UiLogic.AudioToText
 {
     public class WhisperCTranslate2Model : IWhisperModel
     {
-        public string[] Urls { get; set; }
-        public string Size { get; set; }
-        public string Name { get; set; }
+        public string[] Urls { get; set; } = Array.Empty<string>();
+        public string Size { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
         public bool AlreadyDownloaded { get; set; }
         public long Bytes { get; set; }
 

--- a/src/libuilogic/AudioToText/WhisperHelper.cs
+++ b/src/libuilogic/AudioToText/WhisperHelper.cs
@@ -99,12 +99,12 @@ namespace Nikse.SubtitleEdit.UiLogic.AudioToText
             return !string.IsNullOrEmpty(GetWhisperFolder());
         }
 
-        public static string GetWhisperFolder()
+        public static string? GetWhisperFolder()
         {
             return GetWhisperFolder(Configuration.Settings.Tools.WhisperChoice);
         }
 
-        public static string GetWhisperFolder(string whisperChoice)
+        public static string? GetWhisperFolder(string whisperChoice)
         {
             if (Configuration.IsRunningOnLinux && whisperChoice == WhisperChoice.Cpp)
             {
@@ -402,7 +402,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AudioToText
             return "whisper";
         }
 
-        public static string GetWhisperPathAndFileName()
+        public static string? GetWhisperPathAndFileName()
         {
             return GetWhisperPathAndFileName(Configuration.Settings.Tools.WhisperChoice);
         }
@@ -410,7 +410,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AudioToText
         /// <summary>
         /// Get installed path
         /// </summary>
-        public static string GetWhisperPathAndFileName(string whisperChoice)
+        public static string? GetWhisperPathAndFileName(string whisperChoice)
         {
             var fileNameOnly = GetExecutableFileName(whisperChoice);
             var whisperFolder = GetWhisperFolder(whisperChoice);

--- a/src/libuilogic/AudioToText/WhisperModel.cs
+++ b/src/libuilogic/AudioToText/WhisperModel.cs
@@ -5,11 +5,11 @@ namespace Nikse.SubtitleEdit.UiLogic.AudioToText
 {
     public class WhisperModel : IWhisperModel
     {
-        public string[] Urls { get; set; }
-        public string Size { get; set; }
-        public string Name { get; set; }
+        public string[] Urls { get; set; } = Array.Empty<string>();
+        public string Size { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
         public bool Rename { get; set; }
-        public string Folder { get; set; }
+        public string Folder { get; set; } = string.Empty;
         public bool AlreadyDownloaded { get; set; }
         public long Bytes { get; set; }
         public bool Dynamic { get; set; }

--- a/src/libuilogic/AudioToText/WhisperPurfviewFasterWhisperModel.cs
+++ b/src/libuilogic/AudioToText/WhisperPurfviewFasterWhisperModel.cs
@@ -8,9 +8,9 @@ namespace Nikse.SubtitleEdit.UiLogic.AudioToText
 {
     public class WhisperPurfviewFasterWhisperModel : IWhisperModel
     {
-        public string[] Urls { get; set; }
-        public string Size { get; set; }
-        public string Name { get; set; }
+        public string[] Urls { get; set; } = Array.Empty<string>();
+        public string Size { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
         public bool AlreadyDownloaded { get; set; }
         public long Bytes { get; set; }
 

--- a/src/libuilogic/AutoTranslate/AnthropicTranslate.cs
+++ b/src/libuilogic/AutoTranslate/AnthropicTranslate.cs
@@ -15,14 +15,14 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 {
     public class AnthropicTranslate : IAutoTranslator, IDisposable
     {
-        private HttpClient _httpClient;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "Anthropic Claude";
         public override string ToString() => StaticName;
 
         public string Name => StaticName;
         public string Url => "https://www.anthropic.com/";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 900;
 
         /// <summary>
@@ -80,14 +80,14 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             var input = "{ \"model\": \"" + model + "\", \"max_tokens\": 1024, \"messages\": [{ \"role\": \"user\", \"content\": \"" + prompt + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
 
             int[] retryDelays = { 2555, 5007, 9013 };
-            HttpResponseMessage result = null;
+            HttpResponseMessage result = null!;
             var json = string.Empty;
             for (var attempt = 0; attempt <= retryDelays.Length; attempt++)
             {
                 var content = new StringContent(input, Encoding.UTF8);
                 content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
                 result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-                var bytes = await result.Content.ReadAsByteArrayAsync();
+                var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
                 json = Encoding.UTF8.GetString(bytes).Trim();
 
                 if (!DeepLTranslate.ShouldRetry(result, json) || attempt == retryDelays.Length)

--- a/src/libuilogic/AutoTranslate/AvalAi.cs
+++ b/src/libuilogic/AutoTranslate/AvalAi.cs
@@ -15,13 +15,13 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 {
     public class AvalAi : IAutoTranslator, IDisposable
     {
-        private HttpClient _httpClient;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "AvalAI";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://avalai.ir";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1500;
 
         /// <summary>
@@ -133,7 +133,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
             var json = Encoding.UTF8.GetString(bytes).Trim();
             if (!result.IsSuccessStatusCode)
             {

--- a/src/libuilogic/AutoTranslate/BaiduTranslate.cs
+++ b/src/libuilogic/AutoTranslate/BaiduTranslate.cs
@@ -18,15 +18,15 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
     /// </summary>
     public class BaiduTranslate : IAutoTranslator, IDisposable
     {
-        private HttpClient _httpClient;
-        private string _appId;
-        private string _secretKey;
+        private HttpClient _httpClient = null!;
+        private string _appId = string.Empty;
+        private string _secretKey = string.Empty;
 
         public static string StaticName { get; set; } = "Baidu Translate";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://fanyi.baidu.com";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1500;
 
         public void Initialize()
@@ -89,7 +89,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             var url = $"/api/trans/vip/translate?q={Uri.EscapeDataString(text)}&from={fromLang}&to={toLang}&appid={_appId}&salt={salt}&sign={sign}";
 
             var result = await _httpClient.GetAsync(url, cancellationToken);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
             var json = Encoding.UTF8.GetString(bytes).Trim();
 
             if (!result.IsSuccessStatusCode)

--- a/src/libuilogic/AutoTranslate/ChatGptTranslate.cs
+++ b/src/libuilogic/AutoTranslate/ChatGptTranslate.cs
@@ -18,13 +18,13 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
     {
         private static readonly Regex UnicodeRegex = new Regex(@"\\u([0-9a-fA-F]{4})", RegexOptions.Compiled);
 
-        private HttpClient _httpClient;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "ChatGPT";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://chat.openai.com/";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1500;
         /// <summary>
         /// Default when no model is configured. A mini model: cheap, broadly available on every
@@ -115,14 +115,14 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             var input = "{\"model\": \"" + Json.EncodeJsonText(model) + "\",\"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
 
             int[] retryDelays = { 2555, 5007, 9013 };
-            HttpResponseMessage result = null;
+            HttpResponseMessage result = null!;
             var json = string.Empty;
             for (var attempt = 0; attempt <= retryDelays.Length; attempt++)
             {
                 var content = new StringContent(input, Encoding.UTF8);
                 content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
                 result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-                var bytes = await result.Content.ReadAsByteArrayAsync();
+                var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
                 json = Encoding.UTF8.GetString(bytes).Trim();
 
                 if (!DeepLTranslate.ShouldRetry(result, json) || attempt == retryDelays.Length)

--- a/src/libuilogic/AutoTranslate/CrispAsrMadladTranslate.cs
+++ b/src/libuilogic/AutoTranslate/CrispAsrMadladTranslate.cs
@@ -20,11 +20,11 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://github.com/CrispStrobe/CrispASR";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1000;
 
-        private string _executablePath;
-        private string _modelPath;
+        private string _executablePath = string.Empty;
+        private string _modelPath = string.Empty;
 
         public void Initialize()
         {

--- a/src/libuilogic/AutoTranslate/DeepLTranslate.cs
+++ b/src/libuilogic/AutoTranslate/DeepLTranslate.cs
@@ -15,16 +15,16 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
     /// </summary>
     public class DeepLTranslate : IAutoTranslator, IDisposable
     {
-        private string _apiKey;
-        private string _apiUrl;
-        private string _formality;
-        private HttpClient _httpClient;
+        private string _apiKey = string.Empty;
+        private string _apiUrl = string.Empty;
+        private string _formality = string.Empty;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "DeepL V2 translate";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://www.deepl.com";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1500;
 
         public void Initialize()
@@ -158,13 +158,13 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
         public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
         {
             int[] retryDelays = { 555, 3007, 7013 };
-            HttpResponseMessage result = null;
-            string resultContent = null;
+            HttpResponseMessage result = null!;
+            var resultContent = string.Empty;
             for (var attempt = 0; attempt <= retryDelays.Length; attempt++)
             {
                 var postContent = MakeContent(text, sourceLanguageCode, targetLanguageCode);
                 result = await _httpClient.PostAsync("/v2/translate", postContent, cancellationToken);
-                resultContent = await result.Content.ReadAsStringAsync();
+                resultContent = await result.Content.ReadAsStringAsync(cancellationToken);
 
                 if (!ShouldRetry(result, resultContent) || attempt == retryDelays.Length)
                 {
@@ -204,8 +204,8 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
                                 {
                                     if (transItem == "text")
                                     {
-                                        var s = innerDic[transItem].ToString();
-                                        resultList.Add(s);
+                                        var s = innerDic[transItem]?.ToString();
+                                        resultList.Add(s ?? string.Empty);
                                     }
                                 }
                             }

--- a/src/libuilogic/AutoTranslate/DeepLXTranslate.cs
+++ b/src/libuilogic/AutoTranslate/DeepLXTranslate.cs
@@ -16,14 +16,14 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
     /// </summary>
     public class DeepLXTranslate : IAutoTranslator, IDisposable
     {
-        private string _apiUrl;
-        private HttpClient _httpClient;
+        private string _apiUrl = string.Empty;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "DeepLX translate";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://github.com/OwO-Network/DeepLX";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1500;
 
         public void Initialize()
@@ -51,13 +51,13 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
         public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
         {
             int[] retryDelays = { 555, 3007, 7013 };
-            HttpResponseMessage result = null;
-            string resultContent = null;
+            HttpResponseMessage result = null!;
+            var resultContent = string.Empty;
             for (var attempt = 0; attempt <= retryDelays.Length; attempt++)
             {
                 var postContent = MakeContent(text, sourceLanguageCode, targetLanguageCode);
                 result = await _httpClient.PostAsync("/translate", postContent, cancellationToken);
-                resultContent = await result.Content.ReadAsStringAsync();
+                resultContent = await result.Content.ReadAsStringAsync(cancellationToken);
 
                 if (!DeepLTranslate.ShouldRetry(result, resultContent) || attempt == retryDelays.Length)
                 {

--- a/src/libuilogic/AutoTranslate/DeepSeekTranslate.cs
+++ b/src/libuilogic/AutoTranslate/DeepSeekTranslate.cs
@@ -15,13 +15,13 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 {
     public class DeepSeekTranslate : IAutoTranslator, IDisposable
     {
-        private HttpClient _httpClient;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "DeepSeek";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://api.deepseek.com";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1500;
 
         /// <summary>
@@ -86,14 +86,14 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             var input = "{\"model\": \"" + model + "\",\"thinking\": {\"type\": \"disabled\"},\"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
 
             int[] retryDelays = { 2555, 5007, 9013 };
-            HttpResponseMessage result = null;
-            string resultContent = null;
+            HttpResponseMessage result = null!;
+            var resultContent = string.Empty;
             for (var attempt = 0; attempt <= retryDelays.Length; attempt++)
             {
                 var content = new StringContent(input, Encoding.UTF8);
                 content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
                 result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-                resultContent = await result.Content.ReadAsStringAsync();
+                resultContent = await result.Content.ReadAsStringAsync(cancellationToken);
 
                 if (!DeepLTranslate.ShouldRetry(result, resultContent) || attempt == retryDelays.Length)
                 {

--- a/src/libuilogic/AutoTranslate/FileNameHelper.cs
+++ b/src/libuilogic/AutoTranslate/FileNameHelper.cs
@@ -7,7 +7,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 {
     public static class FileNameHelper
     {
-        public static string GetFileNameWithTargetLanguage(string oldFileName, string videoFileName, Subtitle oldSubtitle, SubtitleFormat subtitleFormat, string sourceIsoCode, string targetIsoCode)
+        public static string? GetFileNameWithTargetLanguage(string oldFileName, string videoFileName, Subtitle? oldSubtitle, SubtitleFormat subtitleFormat, string sourceIsoCode, string targetIsoCode)
         {
             if (string.IsNullOrEmpty(targetIsoCode))
             {

--- a/src/libuilogic/AutoTranslate/GeminiTranslate.cs
+++ b/src/libuilogic/AutoTranslate/GeminiTranslate.cs
@@ -19,11 +19,11 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://deepmind.google/technologies/gemini/";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1500;
 
-        private HttpClient _httpClient;
-        private string _baseUrl;
+        private HttpClient _httpClient = null!;
+        private string _baseUrl = string.Empty;
 
 
         /// <summary>
@@ -88,8 +88,8 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
         public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
         {
             int[] retryDelays = { 555, 3007, 7013 };
-            HttpResponseMessage result = null;
-            string resultContent = null;
+            HttpResponseMessage result = null!;
+            var resultContent = string.Empty;
             var switchedBaseUrl = false;
             for (var attempt = 0; attempt <= retryDelays.Length; attempt++)
             {
@@ -112,7 +112,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
                     continue;
                 }
 
-                resultContent = await result.Content.ReadAsStringAsync();
+                resultContent = await result.Content.ReadAsStringAsync(cancellationToken);
 
                 if (!DeepLTranslate.ShouldRetry(result, resultContent) || attempt == retryDelays.Length)
                 {

--- a/src/libuilogic/AutoTranslate/GoogleTranslateV1.cs
+++ b/src/libuilogic/AutoTranslate/GoogleTranslateV1.cs
@@ -18,13 +18,13 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
     /// </summary>
     public class GoogleTranslateV1 : IAutoTranslator, IDisposable
     {
-        private HttpClient _httpClient;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "Google Translate V1 API";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://translate.google.com/";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1500;
 
         public void Initialize()
@@ -56,7 +56,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
                 var url = $"translate_a/single?client=gtx&sl={sourceLanguageCode}&tl={targetLanguageCode}&dt=t&q={Utilities.UrlEncode(text)}";
 
                 var result = await _httpClient.GetAsync(url, cancellationToken);
-                var bytes = await result.Content.ReadAsByteArrayAsync();
+                var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
                 jsonResultString = Encoding.UTF8.GetString(bytes).Trim();
 
                 if (!result.IsSuccessStatusCode)

--- a/src/libuilogic/AutoTranslate/GoogleTranslateV2.cs
+++ b/src/libuilogic/AutoTranslate/GoogleTranslateV2.cs
@@ -18,14 +18,14 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
     /// </summary>
     public class GoogleTranslateV2 : IAutoTranslator, IDisposable
     {
-        private string _apiKey;
-        private HttpClient _httpClient;
+        private string _apiKey = string.Empty;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "Google Translate V2 API";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://translate.google.com/";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1500;
 
         public void Initialize()
@@ -61,7 +61,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
                 {
                     try
                     {
-                        Error = await result.Content.ReadAsStringAsync();
+                        Error = await result.Content.ReadAsStringAsync(cancellationToken);
                         SeLogger.Error($"Error in {StaticName}.Translate: " + Error);
                     }
                     catch
@@ -85,7 +85,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
                     throw new Exception($"An error occurred calling GT translate - status code: {result.StatusCode}");
                 }
 
-                content = await result.Content.ReadAsStringAsync();
+                content = await result.Content.ReadAsStringAsync(cancellationToken);
             }
             catch (WebException webException)
             {

--- a/src/libuilogic/AutoTranslate/GroqTranslate.cs
+++ b/src/libuilogic/AutoTranslate/GroqTranslate.cs
@@ -15,13 +15,13 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 {
     public class GroqTranslate : IAutoTranslator, IDisposable
     {
-        private HttpClient _httpClient;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "Groq";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://groq.com/";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1500;
 
         /// <summary>
@@ -93,14 +93,14 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             var input = "{\"model\": \"" + model + "\",\"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
 
             int[] retryDelays = { 2555, 5007, 9013 };
-            HttpResponseMessage result = null;
+            HttpResponseMessage result = null!;
             var json = string.Empty;
             for (var attempt = 0; attempt <= retryDelays.Length; attempt++)
             {
                 var content = new StringContent(input, Encoding.UTF8);
                 content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
                 result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-                var bytes = await result.Content.ReadAsByteArrayAsync();
+                var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
                 json = Encoding.UTF8.GetString(bytes).Trim();
 
                 if (!DeepLTranslate.ShouldRetry(result, json) || attempt == retryDelays.Length)

--- a/src/libuilogic/AutoTranslate/KoboldCppTranslate.cs
+++ b/src/libuilogic/AutoTranslate/KoboldCppTranslate.cs
@@ -15,13 +15,13 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 {
     public class KoboldCppTranslate : IAutoTranslator, IDisposable
     {
-        private HttpClient _httpClient;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "KoboldCpp (local LLM)";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://github.com/LostRuins/koboldcpp/releases";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1000;
 
         public void Initialize()
@@ -69,7 +69,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken).ConfigureAwait(false);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
             var json = Encoding.UTF8.GetString(bytes).Trim();
             if (!result.IsSuccessStatusCode)
             {

--- a/src/libuilogic/AutoTranslate/LaraTranslate.cs
+++ b/src/libuilogic/AutoTranslate/LaraTranslate.cs
@@ -15,18 +15,18 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 {
     public class LaraTranslate : IAutoTranslator, IDisposable
     {
-        private HttpClient _httpClient;
+        private HttpClient _httpClient = null!;
 
         public const string SdkVersion = "1.1.0";
         public static string StaticName { get; set; } = "Lara";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://laratranslate.com";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1500;
 
-        private string _accessKeyId;
-        private byte[] _signingKey;
+        private string _accessKeyId = string.Empty;
+        private byte[] _signingKey = Array.Empty<byte>();
 
         public void Initialize()
         {
@@ -82,12 +82,9 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             var signature = Sign(method, "/translate", contentMd5 ?? "", actualContentType, dateHeader);
             request.Headers.TryAddWithoutValidation("Authorization", $"Lara {_accessKeyId}:{signature}");
 
-            // netstandard2.1: ReadAsByteArrayAsync has no CancellationToken
-            // overload; the token is flowed through SendAsync, which is where
-            // the long blocking happens.
             using var response = await _httpClient.SendAsync(request, cancellationToken);
 
-            var bytes = await response.Content.ReadAsByteArrayAsync();
+            var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
             var json = Encoding.UTF8.GetString(bytes).Trim();
             if (!response.IsSuccessStatusCode)
             {
@@ -95,7 +92,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
                 SeLogger.Error("Lara Translate failed calling API: Status code=" + response.StatusCode + Environment.NewLine +
                     json + Environment.NewLine +
                     "input: " + requestBody + Environment.NewLine +
-                    "url: " + new Uri(_httpClient.BaseAddress, "/translate"));
+                    "url: " + new Uri(_httpClient.BaseAddress!, "/translate"));
             }
 
             response.EnsureSuccessStatusCode();

--- a/src/libuilogic/AutoTranslate/LibreTranslate.cs
+++ b/src/libuilogic/AutoTranslate/LibreTranslate.cs
@@ -15,13 +15,13 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 {
     public class LibreTranslate : IAutoTranslator, IDisposable
     {
-        private HttpClient _httpClient;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "LibreTranslate";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://github.com/LibreTranslate/LibreTranslate";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 220;
 
         public void Initialize()
@@ -66,7 +66,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             var result = await _httpClient.PostAsync("translate", content, cancellationToken);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
             var json = Encoding.UTF8.GetString(bytes).Trim();
             if (!result.IsSuccessStatusCode)
             {

--- a/src/libuilogic/AutoTranslate/LlamaCppTranslate.cs
+++ b/src/libuilogic/AutoTranslate/LlamaCppTranslate.cs
@@ -15,13 +15,13 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 {
     public class LlamaCppTranslate : IAutoTranslator, IDisposable
     {
-        private HttpClient _httpClient;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "llama.cpp (local LLM)";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://github.com/ggml-org/llama.cpp";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1000;
 
         public void Initialize()
@@ -71,7 +71,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
             var json = Encoding.UTF8.GetString(bytes).Trim();
             if (!result.IsSuccessStatusCode)
             {

--- a/src/libuilogic/AutoTranslate/LmStudioTranslate.cs
+++ b/src/libuilogic/AutoTranslate/LmStudioTranslate.cs
@@ -15,13 +15,13 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 {
     public class LmStudioTranslate : IAutoTranslator, IDisposable
     {
-        private HttpClient _httpClient;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "LM Studio (local LLM)";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://lmstudio.ai/";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1000;
 
         public void Initialize()
@@ -63,7 +63,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
             var json = Encoding.UTF8.GetString(bytes).Trim();
             if (!result.IsSuccessStatusCode)
             {

--- a/src/libuilogic/AutoTranslate/MicrosoftTranslator.cs
+++ b/src/libuilogic/AutoTranslate/MicrosoftTranslator.cs
@@ -26,19 +26,19 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
         // Azure issues tokens valid for 10 minutes; refresh with a margin so
         // long translation runs do not start failing with 401 mid-run.
         private static readonly TimeSpan AccessTokenLifetime = TimeSpan.FromMinutes(8);
-        private static List<TranslationPair> _translationPairs;
-        private string _accessToken;
+        private static List<TranslationPair>? _translationPairs;
+        private string _accessToken = string.Empty;
         private DateTime _accessTokenFetchedUtc;
-        private string _apiKey;
-        private string _tokenEndpoint;
-        private string _category;
-        private IDownloader _httpClient;
+        private string _apiKey = string.Empty;
+        private string _tokenEndpoint = string.Empty;
+        private string _category = string.Empty;
+        private IDownloader _httpClient = null!;
 
         public static string StaticName { get; set; } = "Bing Microsoft Translator";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://www.bing.com/translator";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1500;
 
         public void Initialize()
@@ -88,7 +88,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             var result = await httpClient.PostAsync(url, content, cancellationToken);
             var parser = new JsonParser();
-            var jsonResult = await result.Content.ReadAsStringAsync();
+            var jsonResult = await result.Content.ReadAsStringAsync(cancellationToken);
 
             if (!result.IsSuccessStatusCode)
             {
@@ -195,7 +195,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
                     {
                         if (v[innerKey] is Dictionary<string, object> l)
                         {
-                            list.Add(new TranslationPair(l["name"].ToString(), innerKey, innerKey));
+                            list.Add(new TranslationPair(l["name"]?.ToString() ?? string.Empty, innerKey, innerKey));
                         }
                     }
                 }

--- a/src/libuilogic/AutoTranslate/MistralTranslate.cs
+++ b/src/libuilogic/AutoTranslate/MistralTranslate.cs
@@ -18,15 +18,15 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
     /// </summary>
     public class MistralTranslate : IAutoTranslator, IDisposable
     {
-        private string _apiKey;
-        private string _apiUrl;
-        private HttpClient _httpClient;
+        private string _apiKey = string.Empty;
+        private string _apiUrl = string.Empty;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "Mistral AI Translate";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://mistral.ai";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1500;
 
         /// <summary>
@@ -82,14 +82,14 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             var input = "{\"model\": \"" + model + "\",\"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
 
             int[] retryDelays = { 2555, 5007, 9013 };
-            HttpResponseMessage result = null;
+            HttpResponseMessage result = null!;
             var json = string.Empty;
             for (var attempt = 0; attempt <= retryDelays.Length; attempt++)
             {
                 var content = new StringContent(input, Encoding.UTF8);
                 content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
                 result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-                var bytes = await result.Content.ReadAsByteArrayAsync();
+                var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
                 json = Encoding.UTF8.GetString(bytes).Trim();
 
                 if (!DeepLTranslate.ShouldRetry(result, json) || attempt == retryDelays.Length)

--- a/src/libuilogic/AutoTranslate/MyMemoryApi.cs
+++ b/src/libuilogic/AutoTranslate/MyMemoryApi.cs
@@ -13,14 +13,14 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 {
     public class MyMemoryApi : IAutoTranslator, IDisposable
     {
-        private HttpClient _httpClient;
+        private HttpClient _httpClient = null!;
         private readonly SeJsonParser _jsonParser = new SeJsonParser();
 
         public static string StaticName { get; set; } = "MyMemory Translate";
         public string Name => StaticName;
         public override string ToString() => StaticName;
         public string Url => "https://mymemory.translated.net/";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1500;
 
         public void Initialize()
@@ -222,13 +222,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
         public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
         {
             var url = MakeUrl(text, sourceLanguageCode, targetLanguageCode, Configuration.Settings.Tools.AutoTranslateMyMemoryApiKey);
-            // netstandard2.1 has no GetStringAsync(string, CancellationToken)
-            // overload, so we go via SendAsync to flow the token into the
-            // connection/send phase (cancel propagates there).
-            using var request = new HttpRequestMessage(HttpMethod.Get, url);
-            using var response = await _httpClient.SendAsync(request, cancellationToken);
-            response.EnsureSuccessStatusCode();
-            var jsonResultString = await response.Content.ReadAsStringAsync();
+            var jsonResultString = await _httpClient.GetStringAsync(url, cancellationToken);
             var textResult = _jsonParser.GetFirstObject(jsonResultString, "translatedText");
             var result = Json.DecodeJsonText(textResult);
 

--- a/src/libuilogic/AutoTranslate/NoLanguageLeftBehindApi.cs
+++ b/src/libuilogic/AutoTranslate/NoLanguageLeftBehindApi.cs
@@ -13,13 +13,13 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 {
     public class NoLanguageLeftBehindApi : IAutoTranslator, IDisposable
     {
-        private HttpClient _httpClient;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "winstxnhdw-nllb-api";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://github.com/winstxnhdw/nllb-api";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 250;
 
         public void Initialize()
@@ -53,13 +53,10 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
         public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
         {
             var content = new StringContent("{ \"text\": \"" + Json.EncodeJsonText(text) + "\",  \"source\": \"" + sourceLanguageCode + "\", \"target\": \"" + targetLanguageCode + "\" }", Encoding.UTF8, "application/json");
-            // netstandard2.1: ReadAsStringAsync has no CancellationToken
-            // overload; the token is flowed through PostAsync, which is where
-            // the long blocking happens.
             using var result = await _httpClient.PostAsync("translator", content, cancellationToken);
             result.EnsureSuccessStatusCode();
 
-            var responseString = await result.Content.ReadAsStringAsync();
+            var responseString = await result.Content.ReadAsStringAsync(cancellationToken);
 
             var parser = new SeJsonParser();
             var resultText = parser.GetFirstObject(responseString, "result");

--- a/src/libuilogic/AutoTranslate/NoLanguageLeftBehindServe.cs
+++ b/src/libuilogic/AutoTranslate/NoLanguageLeftBehindServe.cs
@@ -13,13 +13,13 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 {
     public class NoLanguageLeftBehindServe : IAutoTranslator, IDisposable
     {
-        private HttpClient _httpClient;
+        private HttpClient _httpClient = null!;
         
         public static string StaticName { get; set; } = "thammegowda-nllb-serve";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://github.com/thammegowda/nllb-serve";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 250;
 
         public void Initialize()
@@ -66,7 +66,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 
             var result = await _httpClient.PostAsync("translate", content, cancellationToken);
             result.EnsureSuccessStatusCode();
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
             var json = Encoding.UTF8.GetString(bytes).Trim();
 
             var parser = new SeJsonParser();

--- a/src/libuilogic/AutoTranslate/NvidiaTranslate.cs
+++ b/src/libuilogic/AutoTranslate/NvidiaTranslate.cs
@@ -15,13 +15,13 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 {
     public class NvidiaTranslate : IAutoTranslator, IDisposable
     {
-        private HttpClient _httpClient;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "NVIDIA";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://build.nvidia.com/models";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1500;
 
         /// <summary>
@@ -124,14 +124,14 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             var input = "{\"model\": \"" + model + "\",\"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
 
             int[] retryDelays = { 2555, 5007, 9013 };
-            HttpResponseMessage result = null;
-            string resultContent = null;
+            HttpResponseMessage result = null!;
+            var resultContent = string.Empty;
             for (var attempt = 0; attempt <= retryDelays.Length; attempt++)
             {
                 var content = new StringContent(input, Encoding.UTF8);
                 content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
                 result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-                resultContent = await result.Content.ReadAsStringAsync();
+                resultContent = await result.Content.ReadAsStringAsync(cancellationToken);
 
                 if (!DeepLTranslate.ShouldRetry(result, resultContent) || attempt == retryDelays.Length)
                 {

--- a/src/libuilogic/AutoTranslate/OllamaTranslate.cs
+++ b/src/libuilogic/AutoTranslate/OllamaTranslate.cs
@@ -14,13 +14,13 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 {
     public class OllamaTranslate : IAutoTranslator, IDisposable
     {
-        private HttpClient _httpClient;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "Ollama (local LLM)";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://github.com/ollama/ollama";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1000;
 
         public void Initialize()
@@ -66,7 +66,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken).ConfigureAwait(false);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
             var json = Encoding.UTF8.GetString(bytes).Trim();
             if (!result.IsSuccessStatusCode)
             {

--- a/src/libuilogic/AutoTranslate/OpenAiCompatibleTranslate.cs
+++ b/src/libuilogic/AutoTranslate/OpenAiCompatibleTranslate.cs
@@ -20,13 +20,13 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
     /// </summary>
     public class OpenAiCompatibleTranslate : IAutoTranslator, IDisposable
     {
-        private HttpClient _httpClient;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "OpenAI Compatible API";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://platform.openai.com/docs/api-reference/chat";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1500;
 
         public void Initialize()
@@ -74,7 +74,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
             var json = Encoding.UTF8.GetString(bytes).Trim();
             if (!result.IsSuccessStatusCode)
             {

--- a/src/libuilogic/AutoTranslate/OpenRouterTranslate.cs
+++ b/src/libuilogic/AutoTranslate/OpenRouterTranslate.cs
@@ -15,13 +15,13 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 {
     public class OpenRouterTranslate : IAutoTranslator, IDisposable
     {
-        private HttpClient _httpClient;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "OpenRouter";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://openrouter.ai/";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1500;
 
         /// <summary>
@@ -100,14 +100,14 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             var input = "{\"model\": \"" + model + "\",\"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
 
             int[] retryDelays = { 2555, 5007, 9013 };
-            HttpResponseMessage result = null;
+            HttpResponseMessage result = null!;
             var json = string.Empty;
             for (var attempt = 0; attempt <= retryDelays.Length; attempt++)
             {
                 var content = new StringContent(input, Encoding.UTF8);
                 content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
                 result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
-                var bytes = await result.Content.ReadAsByteArrayAsync();
+                var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
                 json = Encoding.UTF8.GetString(bytes).Trim();
 
                 if (!DeepLTranslate.ShouldRetry(result, json) || attempt == retryDelays.Length)

--- a/src/libuilogic/AutoTranslate/PapagoTranslate.cs
+++ b/src/libuilogic/AutoTranslate/PapagoTranslate.cs
@@ -14,7 +14,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 {
     public class PapagoTranslate : IAutoTranslator, IDisposable
     {
-        private HttpClient _httpClient;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "Papago Translate";
 
@@ -24,7 +24,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 
         public string Url => "https://papago.naver.com/";
 
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
 
         public int MaxCharacters => 5000;
 
@@ -64,7 +64,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             var content = new FormUrlEncodedContent(formData);
 
             var result = await _httpClient.PostAsync("n2mt", content, cancellationToken);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
             var json = Encoding.UTF8.GetString(bytes).Trim();
 
             if (!result.IsSuccessStatusCode)

--- a/src/libuilogic/AutoTranslate/PerplexityTranslate.cs
+++ b/src/libuilogic/AutoTranslate/PerplexityTranslate.cs
@@ -14,13 +14,13 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 {
     public class PerplexityTranslate : IAutoTranslator, IDisposable
     {
-        private HttpClient _httpClient;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "Perplexity";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://www.perplexity.ai/";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1500;
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 
             var content = new StringContent(requestBody, Encoding.UTF8, "application/json");
             var result = await _httpClient.PostAsync("/v1/responses", content, cancellationToken);
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
             var json = Encoding.UTF8.GetString(bytes).Trim();
             if (!result.IsSuccessStatusCode)
             {

--- a/src/libuilogic/AutoTranslate/SeamlessM4TTranslate.cs
+++ b/src/libuilogic/AutoTranslate/SeamlessM4TTranslate.cs
@@ -15,13 +15,13 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 {
     public class SeamlessM4TTranslate : IAutoTranslator, IDisposable
     {
-        private HttpClient _httpClient;
+        private HttpClient _httpClient = null!;
 
         public static string StaticName { get; set; } = "SeamlessM4T";
         public override string ToString() => StaticName;
         public string Name => StaticName;
         public string Url => "https://replicate.com/cjwbw/seamless_communication/api";
-        public string Error { get; set; }
+        public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 250;
 
         public void Initialize()
@@ -68,7 +68,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             var result = await _httpClient.PostAsync("predictions", content, cancellationToken);
             result.EnsureSuccessStatusCode();
-            var bytes = await result.Content.ReadAsByteArrayAsync();
+            var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
             var json = Encoding.UTF8.GetString(bytes).Trim();
 
             var parser = new SeJsonParser();

--- a/src/libuilogic/Common/BookmarkPersistence.cs
+++ b/src/libuilogic/Common/BookmarkPersistence.cs
@@ -10,9 +10,9 @@ namespace Nikse.SubtitleEdit.UiLogic.Common
     public class BookmarkPersistence
     {
         private readonly Subtitle _subtitle;
-        private readonly string _fileName;
+        private readonly string? _fileName;
 
-        public BookmarkPersistence(Subtitle subtitle, string fileName)
+        public BookmarkPersistence(Subtitle subtitle, string? fileName)
         {
             _subtitle = subtitle;
             _fileName = fileName;
@@ -52,7 +52,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Common
             }
         }
 
-        private string SerializeBookmarks()
+        private string? SerializeBookmarks()
         {
             int count = 0;
             var sb = new StringBuilder();

--- a/src/libuilogic/Common/LanguageFavorites.cs
+++ b/src/libuilogic/Common/LanguageFavorites.cs
@@ -46,7 +46,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Common
             IEnumerable<T> items,
             Func<T, string> codeSelector,
             IList<string> favoriteCodes,
-            Func<T, bool> pinTop = null)
+            Func<T, bool>? pinTop = null)
         {
             var list = items.ToList();
             var favorites = (favoriteCodes ?? new List<string>())

--- a/src/libuilogic/Http/BypassingWebProxy.cs
+++ b/src/libuilogic/Http/BypassingWebProxy.cs
@@ -41,13 +41,13 @@ namespace Nikse.SubtitleEdit.UiLogic.Http
                 .ToArray();
         }
 
-        public ICredentials Credentials
+        public ICredentials? Credentials
         {
             get => _inner.Credentials;
             set => _inner.Credentials = value;
         }
 
-        public Uri GetProxy(Uri destination) => IsBypassed(destination) ? null : _inner.GetProxy(destination);
+        public Uri? GetProxy(Uri destination) => IsBypassed(destination) ? null : _inner.GetProxy(destination);
 
         public bool IsBypassed(Uri host)
         {

--- a/src/libuilogic/Http/HttpClientDownloader.cs
+++ b/src/libuilogic/Http/HttpClientDownloader.cs
@@ -15,7 +15,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Http
 
         public HttpClientDownloader(HttpClient httpClient) => _httpClient = httpClient;
 
-        public Uri BaseAddress
+        public Uri? BaseAddress
         {
             get => _httpClient.BaseAddress;
             set => _httpClient.BaseAddress = value;
@@ -34,7 +34,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Http
             return Encoding.UTF8.GetString(response, 0, response.Length);
         }
 
-        public async Task DownloadAsync(string requestUri, Stream destination, IProgress<float> progress = null, CancellationToken cancellationToken = default)
+        public async Task DownloadAsync(string requestUri, Stream destination, IProgress<float>? progress = null, CancellationToken cancellationToken = default)
         {
             try
             {
@@ -42,7 +42,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Http
                 using (var response = await _httpClient.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken))
                 {
                     var contentLength = response.Content.Headers.ContentLength;
-                    using (var downloadStream = await response.Content.ReadAsStreamAsync())
+                    using (var downloadStream = await response.Content.ReadAsStreamAsync(cancellationToken))
                     {
                         if (progress == null || !contentLength.HasValue)
                         {
@@ -71,7 +71,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Http
             }
         }
 
-        public static async Task CopyToAsync(Stream source, Stream destination, int bufferSize, IProgress<long> progress = null, CancellationToken cancellationToken = default)
+        public static async Task CopyToAsync(Stream source, Stream destination, int bufferSize, IProgress<long>? progress = null, CancellationToken cancellationToken = default)
         {
             if (source == null)
             {

--- a/src/libuilogic/Http/HttpClientFactoryWithProxy.cs
+++ b/src/libuilogic/Http/HttpClientFactoryWithProxy.cs
@@ -13,11 +13,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Http
             var proxyAddress = proxySettings.ProxyAddress;
             if (string.IsNullOrEmpty(proxyAddress))
             {
-#if NETSTANDARD
-                var systemProxy = WebRequest.DefaultWebProxy;
-#else
                 var systemProxy = HttpClient.DefaultProxy;
-#endif
                 if (systemProxy == null)
                 {
                     return new HttpClient();

--- a/src/libuilogic/Http/IDownloader.cs
+++ b/src/libuilogic/Http/IDownloader.cs
@@ -9,8 +9,8 @@ namespace Nikse.SubtitleEdit.UiLogic.Http
 {
     public interface IDownloader : IDisposable
     {
-        Task DownloadAsync(string requestUri, Stream destination, IProgress<float> progress = null, CancellationToken cancellationToken = default);
-        Uri BaseAddress { get; set; }
+        Task DownloadAsync(string requestUri, Stream destination, IProgress<float>? progress = null, CancellationToken cancellationToken = default);
+        Uri? BaseAddress { get; set; }
         HttpRequestHeaders DefaultRequestHeaders { get; }
         Task<HttpResponseMessage> PostAsync(string uri, StringContent stringContent, CancellationToken cancellationToken = default);
         Task<string> GetStringAsync(string url);

--- a/src/libuilogic/Http/LegacyDownloader.cs
+++ b/src/libuilogic/Http/LegacyDownloader.cs
@@ -13,7 +13,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Http
 {
     public class LegacyDownloader : IDownloader
     {
-        public Task DownloadAsync(string requestUri, Stream destination, IProgress<float> progress = null, CancellationToken cancellationToken = default)
+        public Task DownloadAsync(string requestUri, Stream destination, IProgress<float>? progress = null, CancellationToken cancellationToken = default)
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
 
@@ -74,7 +74,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Http
             _httpClient = httpClient;
         }
 
-        public Uri BaseAddress
+        public Uri? BaseAddress
         {
             get => _httpClient.BaseAddress;
             set => _httpClient.BaseAddress = value;
@@ -144,7 +144,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Http
             }
         }
 
-        public static IWebProxy GetProxy()
+        public static IWebProxy? GetProxy()
         {
             var proxySettings = Configuration.Settings.Proxy;
             if (string.IsNullOrEmpty(proxySettings.ProxyAddress))

--- a/src/libuilogic/Media/FfmpegMediaInfo.cs
+++ b/src/libuilogic/Media/FfmpegMediaInfo.cs
@@ -19,7 +19,6 @@ namespace Nikse.SubtitleEdit.UiLogic.Media
         public TimeCode Duration { get; set; }
         public decimal FramesRate { get; set; } 
 
-#if NET7_0_OR_GREATER
         [GeneratedRegex(@"\d\d+x\d\d+")]
         private static partial Regex ResolutionRegexGen();
         private static readonly Regex ResolutionRegex = ResolutionRegexGen();
@@ -35,16 +34,11 @@ namespace Nikse.SubtitleEdit.UiLogic.Media
         [GeneratedRegex(@" \d+ fps")]
         private static partial Regex Fps2RegexGen();
         private static readonly Regex Fps2Regex = Fps2RegexGen();
-#else
-        private static readonly Regex ResolutionRegex = new Regex(@"\d\d+x\d\d+", RegexOptions.Compiled);
-        private static readonly Regex DurationRegex = new Regex(@"Duration: \d+[:\.,]\d+[:\.,]\d+[:\.,]\d+", RegexOptions.Compiled);
-        private static readonly Regex Fps1Regex = new Regex(@" \d+\.\d+ fps", RegexOptions.Compiled);
-        private static readonly Regex Fps2Regex = new Regex(@" \d+ fps", RegexOptions.Compiled);
-#endif
 
         private FfmpegMediaInfo()
         {
             Tracks = new List<FfmpegTrackInfo>();
+            Duration = new TimeCode();
         }
 
         public static FfmpegMediaInfo Parse(string videoFileName)

--- a/src/libuilogic/Media/FfmpegTrackInfo.cs
+++ b/src/libuilogic/Media/FfmpegTrackInfo.cs
@@ -7,7 +7,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Media
     public class FfmpegTrackInfo
     {
         public FfmpegTrackType TrackType { get; set; }
-        public string TrackInfo { get; set; }
+        public string TrackInfo { get; set; } = string.Empty;
         // ISO 639-2/T language tag (e.g. "eng") captured from the ffmpeg
         // "Stream #0:N(LANG): TYPE:" prefix. Empty when ffmpeg did not report one.
         public string Language { get; set; } = string.Empty;

--- a/src/libuilogic/Ocr/Service/GoogleCloudVisionApi.cs
+++ b/src/libuilogic/Ocr/Service/GoogleCloudVisionApi.cs
@@ -241,7 +241,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.Service
                 if (annotations.Count > 0)
                 {
                     var lines = new List<List<Annotation>>();
-                    Annotation last = null;
+                    Annotation? last = null;
                     var lineThreshold = Math.Max(9, annotations.Average(p => p.Height) / 4.0);
                     var lineIndex = 0;
 
@@ -420,9 +420,9 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.Service
 
         public class Annotation
         {
-            public string Text { get; set; }
-            public List<SKPointI> Vertices { get; set; }
-            public string DetectedBreak { get; set; }
+            public string Text { get; set; } = string.Empty;
+            public List<SKPointI> Vertices { get; set; } = new();
+            public string DetectedBreak { get; set; } = string.Empty;
 
             public int Width
             {

--- a/src/libuilogic/Ocr/Service/OcrLanguage.cs
+++ b/src/libuilogic/Ocr/Service/OcrLanguage.cs
@@ -5,7 +5,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.Service
 {
     public class OcrLanguage
     {
-        public string Code { get; set; }
+        public string Code { get; set; } = string.Empty;
 
         public override string ToString()
         {

--- a/src/libuilogic/Ocr/TesseractDictionary.cs
+++ b/src/libuilogic/Ocr/TesseractDictionary.cs
@@ -143,9 +143,9 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr
             "yor"
         };
 
-        public string Code { get; set; }
-        public string Name { get; set; }
-        public string Url { get; set; }
+        public string Code { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Url { get; set; } = string.Empty;
 
         public static List<TesseractDictionary> List()
         {

--- a/src/libuilogic/Translate/CopyPasteBlock.cs
+++ b/src/libuilogic/Translate/CopyPasteBlock.cs
@@ -5,8 +5,8 @@ namespace Nikse.SubtitleEdit.UiLogic.Translate
 {
     public class CopyPasteBlock
     {
-        public string TargetText { get; set; }
-        public List<Paragraph> Paragraphs { get; set; }
-        public List<Formatting> Formattings { get; set; }
+        public string TargetText { get; set; } = string.Empty;
+        public List<Paragraph> Paragraphs { get; set; } = new();
+        public List<Formatting> Formattings { get; set; } = new();
     }
 }

--- a/src/libuilogic/Translate/Formatting.cs
+++ b/src/libuilogic/Translate/Formatting.cs
@@ -34,9 +34,9 @@ namespace Nikse.SubtitleEdit.UiLogic.Translate
         };
 
         private bool Italic { get; set; }
-        private string Font { get; set; }
+        private string Font { get; set; } = string.Empty;
         private bool ItalicTwoLines { get; set; }
-        private string StartTags { get; set; }
+        private string StartTags { get; set; } = string.Empty;
         private bool AutoBreak { get; set; }
         private bool SquareBrackets { get; set; }
         private bool SquareBracketsUppercase { get; set; }
@@ -46,7 +46,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Translate
         private bool BreakSplitAtLineEnding { get; set; }
         private bool BreakIsDialog { get; set; }
         private bool HasReset { get; set; }
-        private string ReplaceAllText { get; set; }
+        private string? ReplaceAllText { get; set; }
 
         public string SetTagsAndReturnTrimmed(string input, string sourceLanguage)
         {

--- a/src/libuilogic/Translate/TranslationPair.cs
+++ b/src/libuilogic/Translate/TranslationPair.cs
@@ -35,7 +35,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Translate
 
         public override string ToString() => Name.ToLowerInvariant().Replace('_', ' ').CapitalizeFirstLetter();
 
-        public bool Equals(TranslationPair other) => other != null && Code.Equals(other.Code);
+        public bool Equals(TranslationPair? other) => other != null && Code.Equals(other.Code);
 
         public override int GetHashCode() => Code != null ? Code.GetHashCode() : 0;
     }

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -4380,7 +4380,7 @@ public partial class OcrViewModel : ObservableObject
         }
         else if (e.Key == Key.V && e.KeyModifiers.HasFlag(KeyModifiers.Control) && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
         {
-            if (SubtitleGrid != null && SubtitleGrid.SelectedItems.Count > 1)
+            if (SubtitleGrid?.SelectedItems?.Count > 1)
             {
                 e.Handled = true;
                 Dispatcher.UIThread.Post(async void () => { await FillSelectedLinesWithClipboard(); });
@@ -4780,7 +4780,7 @@ public partial class OcrViewModel : ObservableObject
     internal void SubtitleGridContextOpening(object? sender, EventArgs e)
     {
         ShowContextMenu = OcrSubtitleItems.Count > 0;
-        HasMultipleLinesSelected = SubtitleGrid != null && SubtitleGrid.SelectedItems.Count > 1;
+        HasMultipleLinesSelected = SubtitleGrid?.SelectedItems?.Count > 1;
     }
 
     internal void SubtitleGridSelectionChanged(object? sender, SelectionChangedEventArgs e)
@@ -4809,7 +4809,7 @@ public partial class OcrViewModel : ObservableObject
             return;
         }
 
-        var selectedItems = SubtitleGrid.SelectedItems.Cast<OcrSubtitleItem>().ToList();
+        var selectedItems = SubtitleGrid.SelectedItems?.Cast<OcrSubtitleItem>().ToList() ?? new List<OcrSubtitleItem>();
         if (selectedItems.Count < 2)
         {
             return;

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -968,7 +968,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         if (model != null && LlamaCppServerManager.IsModelInstalled(model.FileName))
         {
             var answer = await MessageBox.Show(
-                Window,
+                Window!,
                 Se.Language.General.Download,
                 string.Format(Se.Language.Translate.XIsAlreadyDownloadedReDownload, model.DisplayName),
                 MessageBoxButtons.YesNo,
@@ -1011,7 +1011,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         var installedKey = GetLlamaCppEngineUpdate()?.key ?? string.Empty;
 
         await _windowService.ShowDialogAsync<LlamaCppEngineSettingsWindow, LlamaCppEngineSettingsViewModel>(
-            Window,
+            Window!,
             vm => vm.Initialize(() => UpdateLlamaCppEngineAsync(installedKey)));
 
         RefreshDownloadDots?.Invoke();
@@ -1031,7 +1031,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         }
 
         await _windowService.ShowDialogAsync<LlamaCppAdvancedSettingsWindow, LlamaCppAdvancedSettingsViewModel>(
-            Window,
+            Window!,
             vm => vm.Initialize());
     }
 
@@ -1112,7 +1112,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         catch (Exception ex)
         {
             await MessageBox.Show(
-                Window,
+                Window!,
                 Se.Language.General.Error,
                 ex.Message,
                 MessageBoxButtons.OK,
@@ -1144,7 +1144,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         _llamaCppUpdatePromptShown = true;
 
         var answer = await MessageBox.Show(
-            Window,
+            Window!,
             string.Format(Se.Language.Video.AudioToText.UpdateXTitle, "llama.cpp"),
             string.Format(Se.Language.Video.AudioToText.UpdateXMessage, "llama.cpp", Environment.NewLine),
             MessageBoxButtons.YesNoCancel,
@@ -1277,7 +1277,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         {
             // show message about selecting target language
             await MessageBox.Show(
-                Window,
+                Window!,
                 Se.Language.General.Error,
                 Se.Language.Translate.PleaseSelectATargetLanguage,
                 MessageBoxButtons.OK,
@@ -1316,7 +1316,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         {
             IsProgressEnabled = false;
             await MessageBox.Show(
-                Window,
+                Window!,
                 Se.Language.General.Error,
                 string.Format(Se.Language.General.XRequiresAnApiKey, translator.Name),
                 MessageBoxButtons.OK,
@@ -1329,7 +1329,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         {
             IsProgressEnabled = false;
             await MessageBox.Show(
-                Window,
+                Window!,
                 Se.Language.General.Error,
                 string.Format(Se.Language.General.XRequiresAnApiKey, translator.Name),
                 MessageBoxButtons.OK,
@@ -1345,7 +1345,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         {
             IsProgressEnabled = false;
             await MessageBox.Show(
-                Window,
+                Window!,
                 Se.Language.General.Error,
                 string.Format(Se.Language.General.XRequiresAValidUrl, translator.Name),
                 MessageBoxButtons.OK,
@@ -1397,7 +1397,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             IsProgressEnabled = false;
             StatusText = Se.Language.Translate.ReadyToTranslate;
             await MessageBox.Show(
-                Window,
+                Window!,
                 Se.Language.General.Error,
                 string.Format(Se.Language.General.ErrorX, exception.Message),
                 MessageBoxButtons.OK,

--- a/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsWindow.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsWindow.cs
@@ -87,12 +87,12 @@ public class LlamaCppAdvancedSettingsWindow : Window
         AddRow(grid, 0, Se.Language.Translate.Synopsis, synopsisBox);
 
         var glossaryBox = MakeMultilineTextBox(vm, nameof(vm.Glossary), 76);
-        glossaryBox.Watermark = Se.Language.Translate.GlossaryHint;
+        glossaryBox.PlaceholderText = Se.Language.Translate.GlossaryHint;
         SetHint(glossaryBox, Se.Language.Translate.GlossaryHint);
         AddRow(grid, 1, Se.Language.Translate.Glossary, glossaryBox);
 
         var promptBox = MakeMultilineTextBox(vm, nameof(vm.Prompt), 56);
-        promptBox.Watermark = LlamaCppAdvancedProtocol.DefaultPrompt;
+        promptBox.PlaceholderText = LlamaCppAdvancedProtocol.DefaultPrompt;
         SetHint(promptBox, Se.Language.Translate.CustomPromptHint);
         AddRow(grid, 2, Se.Language.Translate.PromptText, promptBox);
 

--- a/src/ui/Features/Video/SpeechToText/Engines/DashScopeQwen3SttEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/DashScopeQwen3SttEngine.cs
@@ -54,7 +54,7 @@ public class DashScopeQwen3SttEngine : IOnlineSttEngine
     public long UploadThresholdBytes => long.MaxValue;
     public long ChunkSizeBytes => long.MaxValue;
 
-    public string GetAndCreateWhisperFolder() => WhisperHelper.GetWhisperFolder(WhisperChoice.DashScopeQwen3);
+    public string GetAndCreateWhisperFolder() => WhisperHelper.GetWhisperFolder(WhisperChoice.DashScopeQwen3) ?? string.Empty;
     public string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel) => new WhisperModel().ModelFolder;
     public string GetExecutable() => string.Empty;
     public bool IsModelInstalled(WhisperModel model) => true;

--- a/src/ui/Features/Video/SpeechToText/Engines/OpenRouterSttEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/OpenRouterSttEngine.cs
@@ -58,7 +58,7 @@ public class OpenRouterSttEngine : IOnlineSttEngine
     public long UploadThresholdBytes => UploadThreshold;
     public long ChunkSizeBytes => ChunkSize;
 
-    public string GetAndCreateWhisperFolder() => WhisperHelper.GetWhisperFolder(WhisperChoice.OpenRouter);
+    public string GetAndCreateWhisperFolder() => WhisperHelper.GetWhisperFolder(WhisperChoice.OpenRouter) ?? string.Empty;
     public string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel) => new WhisperModel().ModelFolder;
     public string GetExecutable() => string.Empty;
     public bool IsModelInstalled(WhisperModel model) => true;

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineOpenAi.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineOpenAi.cs
@@ -43,7 +43,7 @@ public class WhisperEngineOpenAi : ISpeechToTextEngine
     public string GetAndCreateWhisperFolder()
     {
         var folder = WhisperHelper.GetWhisperFolder(WhisperChoice.OpenAi);
-        return folder;
+        return folder ?? string.Empty;
     }
 
     public string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel)

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineOpenAiCompatible.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineOpenAiCompatible.cs
@@ -67,7 +67,7 @@ public class OpenAiCompatibleSttEngine : IOnlineSttEngine
 
     public string GetAndCreateWhisperFolder()
     {
-        return WhisperHelper.GetWhisperFolder(WhisperChoice.OpenAiCompatible);
+        return WhisperHelper.GetWhisperFolder(WhisperChoice.OpenAiCompatible) ?? string.Empty;
     }
 
     public string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel)

--- a/tests/UI/Features/Files/ImportPlainText/ForcedAlignerIntegrationTests.cs
+++ b/tests/UI/Features/Files/ImportPlainText/ForcedAlignerIntegrationTests.cs
@@ -47,7 +47,7 @@ public class ForcedAlignerIntegrationTests
             using var audio = new FfmpegWindowAudioSource("ffmpeg", Audio!, totalSeconds, folder);
             var runner = new CrispAsrAlignOnlyRunner(Executable!, Model!);
 
-            var result = await new ForcedAligner(runner, audio).AlignAsync(lines);
+            var result = await new ForcedAligner(runner, audio).AlignAsync(lines, null, TestContext.Current.CancellationToken);
 
             Assert.True(result.AlignedLines > lines.Count * 0.95,
                 $"only {result.AlignedLines} of {lines.Count} lines aligned");

--- a/tests/UI/Features/Files/ImportPlainText/ForcedAlignerTests.cs
+++ b/tests/UI/Features/Files/ImportPlainText/ForcedAlignerTests.cs
@@ -125,7 +125,7 @@ public class ForcedAlignerTests
             var runner = new FakeRunner(240);
             var lines = Script(1800);
 
-            var result = await new ForcedAligner(runner, audio).AlignAsync(lines);
+            var result = await new ForcedAligner(runner, audio).AlignAsync(lines, null, TestContext.Current.CancellationToken);
 
             Assert.True(audio.Windows.Count >= 20, $"expected many windows, got {audio.Windows.Count}");
             Assert.All(audio.Windows, w => Assert.InRange(w.Duration, 1, 300));
@@ -172,7 +172,7 @@ public class ForcedAlignerTests
             var audio = new FakeAudio(60, folder);
             var lines = Script(12);
 
-            var result = await new ForcedAligner(new FakeRunner(60), audio).AlignAsync(lines);
+            var result = await new ForcedAligner(new FakeRunner(60), audio).AlignAsync(lines, null, TestContext.Current.CancellationToken);
 
             // Chunks are small by design, so even short audio may take more than one pass -
             // what matters is that every line comes out timed and in order.
@@ -198,7 +198,7 @@ public class ForcedAlignerTests
             var audio = new FakeAudio(1200, folder);
             var lines = Script(300);
 
-            var result = await new ForcedAligner(new FakeRunner(240), audio).AlignAsync(lines);
+            var result = await new ForcedAligner(new FakeRunner(240), audio).AlignAsync(lines, null, TestContext.Current.CancellationToken);
 
             // Losing a line at a window seam is the failure mode that matters here.
             Assert.Equal(300, result.AlignedLines);
@@ -220,10 +220,10 @@ public class ForcedAlignerTests
             var progress = new Progress<ForcedAligner.Progress>(p => reports.Add(p));
 
             await new ForcedAligner(new FakeRunner(240), audio)
-                .AlignAsync(Script(300), progress);
+                .AlignAsync(Script(300), progress, TestContext.Current.CancellationToken);
 
             // Progress<T> marshals asynchronously; give the posted callbacks a moment.
-            await Task.Delay(200);
+            await Task.Delay(200, TestContext.Current.CancellationToken);
 
             Assert.NotEmpty(reports);
             Assert.All(reports, r => Assert.Equal(300, r.LinesTotal));
@@ -298,7 +298,7 @@ public class ForcedAlignerTests
         {
             var lines = Script(20);
 
-            await new ForcedAligner(new StretchingRunner(), new FakeAudio(300, folder)).AlignAsync(lines);
+            await new ForcedAligner(new StretchingRunner(), new FakeAudio(300, folder)).AlignAsync(lines, null, TestContext.Current.CancellationToken);
 
             var maxDurationMs = Se.Settings.General.SubtitleMaximumDisplayMilliseconds;
             var timed = lines.Where(l => l.EndTime > TimeSpan.Zero).ToList();
@@ -339,7 +339,7 @@ public class ForcedAlignerTests
 
             var spoken = lines.Where(l => !string.IsNullOrWhiteSpace(l.Text)).ToList();
 
-            await new ForcedAligner(new FakeRunner(240), new FakeAudio(240, folder)).AlignAsync(lines);
+            await new ForcedAligner(new FakeRunner(240), new FakeAudio(240, folder)).AlignAsync(lines, null, TestContext.Current.CancellationToken);
 
             // Each spoken line must land where the fake actually speaks it: 10 chars/sec
             // over the spoken lines only, blanks contributing nothing.
@@ -365,7 +365,7 @@ public class ForcedAlignerTests
         try
         {
             var result = await new ForcedAligner(new FakeRunner(240), new FakeAudio(600, folder))
-                .AlignAsync(new List<SubtitleLineViewModel>());
+                .AlignAsync(new List<SubtitleLineViewModel>(), null, TestContext.Current.CancellationToken);
 
             Assert.Equal(0, result.TotalLines);
             Assert.Equal(0, result.AlignedLines);

--- a/tests/UI/Logic/EmbeddedAssetsTests.cs
+++ b/tests/UI/Logic/EmbeddedAssetsTests.cs
@@ -87,7 +87,7 @@ public class EmbeddedAssetsTests
     {
         var onDisk = Directory
             .GetFiles(Path.Combine(GetAssetsFolder(), ZippedFolder), "*.json")
-            .Select(Path.GetFileName)
+            .Select(f => Path.GetFileName(f)!)
             .OrderBy(f => f, StringComparer.Ordinal)
             .ToList();
 


### PR DESCRIPTION
The solution built with **196 warnings** — almost all nullable-reference warnings in `libuilogic`, plus a handful in `ui` and the test projects. It now builds clean: **0 warnings, 0 errors**, and all 2152 tests pass.

## Nullability

- **Translation engines** — `Error` defaults to empty, and `_httpClient` plus the settings-backed string fields are marked as assigned in `Initialize()` (the `= null!` idiom already used elsewhere in the repo). No runtime behaviour change.
- **Shared retry-loop locals** (`result`, `resultContent`) no longer start as untyped `null`.
- **APIs that genuinely return null are annotated as such** instead of lying about it: `WhisperHelper.GetWhisperFolder`/`GetWhisperPathAndFileName`, `BookmarkPersistence`'s file name (which the class already null-checks), `LegacyDownloader.GetProxy`, `BypassingWebProxy.Credentials`/`GetProxy`, `IDownloader.BaseAddress` and its optional `IProgress` parameters, `Formatting.ReplaceAllText`.
- **DTOs** (whisper models, OCR annotations, ffmpeg track info) initialize their collections and strings rather than handing out nulls.
- `OcrViewModel` guards Avalonia's nullable `SelectedItems`.
- `TextBox.Watermark` → `PlaceholderText` (obsolete since Avalonia 11).
- Tests pass `TestContext.Current.CancellationToken` (xUnit1051).

## .NET 10 clean-up

`libuilogic` is no longer multi-targeted at netstandard2.1, so:

- **The cancellation token now flows into `ReadAsStringAsync` / `ReadAsByteArrayAsync` / `ReadAsStreamAsync`.** A cancelled translation or download now stops during the response-body read instead of after it. Three comments explaining the missing netstandard overloads are gone with it.
- `MyMemoryApi` uses `GetStringAsync(url, cancellationToken)` directly instead of the manual `HttpRequestMessage` + `SendAsync` + `EnsureSuccessStatusCode` dance.
- Dropped the dead `NETSTANDARD` and `!NET7_0_OR_GREATER` branches in `HttpClientFactoryWithProxy` and `FfmpegMediaInfo`.

## Note

One fix was caught by the test suite and worth flagging: `Formatting.ReplaceAllText` is checked with `!= null` to decide whether a line is replaced wholesale, so defaulting it to `string.Empty` silently blanked every translated line. It is annotated `string?` instead. The other defaults were each checked against their consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)