### PR TITLE
Remove font collector button from ASSA styles window

### DIFF
--- a/src/ui/Features/Assa/AssaStylesViewModel.cs
+++ b/src/ui/Features/Assa/AssaStylesViewModel.cs
@@ -192,29 +192,6 @@ public partial class AssaStylesViewModel : ObservableObject, IClosingCleanup
         UpdateUsages();
     }
 
-    [RelayCommand]
-    private async Task ShowFontCollector()
-    {
-        if (Window == null)
-        {
-            return;
-        }
-
-        // Give the collector the styles as currently edited, not the ones the file was
-        // opened with - SaveFileStylesToHeader only touches the pending Header, which is
-        // what Ok/Apply would write anyway.
-        SaveFileStylesToHeader();
-        var subtitle = new Subtitle(_subtitle) { Header = Header };
-
-        await _windowService.ShowDialogAsync<FontCollector.FontCollectorWindow, FontCollector.FontCollectorViewModel>(Window, vm =>
-        {
-            vm.Initialize(subtitle);
-        });
-
-        // Fonts may have been copied into SE's Fonts folder - re-offer them in the combo.
-        Task.Run(() => LoadFonts());
-    }
-
     /// <summary>
     /// Opens the font picker (installed fonts + fonts collected in SE's Fonts folder)
     /// and assigns the picked font to the current style.

--- a/src/ui/Features/Assa/AssaStylesWindow.cs
+++ b/src/ui/Features/Assa/AssaStylesWindow.cs
@@ -446,11 +446,10 @@ public class AssaStylesWindow : Window
         var comboBoxFontName = UiUtil.MakeComboBox(vm.Fonts, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.FontName)).WithMinWidth(150);
         var buttonFontBrowse = UiUtil.MakeButtonBrowse(vm.PickFontNameCommand, null, Se.Language.Tools.PickFontNameTitle);
         var buttonFontAttachments = UiUtil.MakeButton(vm.BrowseFontNameCommand, IconNames.Paperclip, Se.Language.Assa.Attachments);
-        var buttonFontCollector = UiUtil.MakeButton(vm.ShowFontCollectorCommand, IconNames.FormatFont, Se.Language.Assa.FontCollectorTitle);
         var labelFontSize = UiUtil.MakeLabel(Se.Language.General.FontSize);
         var numericUpDownFontSize = UiUtil.MakeNumericUpDownOneDecimal(1, 1000, 130, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.FontSize));
         numericUpDownFontSize.Increment = 1;
-        var panelFont = UiUtil.MakeHorizontalPanel(labelFontName, comboBoxFontName, buttonFontBrowse, buttonFontAttachments, buttonFontCollector, labelFontSize, numericUpDownFontSize);
+        var panelFont = UiUtil.MakeHorizontalPanel(labelFontName, comboBoxFontName, buttonFontBrowse, buttonFontAttachments, labelFontSize, numericUpDownFontSize);
 
         var checkBoxBold = UiUtil.MakeCheckBox(Se.Language.General.Bold, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.Bold));
         var checkBoxItalic = UiUtil.MakeCheckBox(Se.Language.General.Italic, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.Italic));


### PR DESCRIPTION
Removes the font collector icon button from the "ASSA styles" window's font row, along with the now-unused `ShowFontCollector` relay command in `AssaStylesViewModel`.

The font collector is still reachable from the main menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)