### PR TITLE
Widen plugin manager window, remember position/size, fix title

### DIFF
--- a/src/ui/Features/Options/Plugins/PluginManagerWindow.cs
+++ b/src/ui/Features/Options/Plugins/PluginManagerWindow.cs
@@ -18,11 +18,11 @@ public class PluginManagerWindow : Window
     {
         _vm = vm;
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Plugins.Title;
+        Title = Se.Language.Plugins.Title.Replace("_", string.Empty); // the language string doubles as a menu header, where "_" marks the access key
         CanResize = true;
-        Width = 650;
+        Width = 850;
         Height = 450;
-        MinWidth = 500;
+        MinWidth = 600;
         MinHeight = 300;
         vm.Window = this;
         DataContext = vm;
@@ -143,6 +143,9 @@ public class PluginManagerWindow : Window
 
         Activated += delegate { buttonClose.Focus(); };
         KeyDown += (_, e) => vm.OnKeyDown(e);
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
     }
 
     protected override void OnClosing(WindowClosingEventArgs e)


### PR DESCRIPTION
Three small fixes to the "Manage plugins" window.

## What changed

- **Wider**: `Width` 650 → 850, `MinWidth` 500 → 600. The side button column is 180px wide, so the plugin list had very little room for name + version + author + description.
- **Remembers position and size**: added the usual `UiUtil.SaveWindowPosition` / `UiUtil.RestoreWindowPosition` pair on `Closing`/`Loaded`, like the Word lists window and the other resizable dialogs. `UiUtil.InitializeWindow` already sets `Window.Name`, so it keys off `PluginManagerWindow` and honours the "remember position and size" setting.
- **Title showed `_Plugins`**: `Se.Language.Plugins.Title` is also the main menu header (`InitMenu.cs`), where `_` marks the Alt access key. The window title now strips it, the same way `InitNativeMacMenu.Clean()` and other call sites do. The language string is unchanged, so the Alt+P menu accelerator still works.

## Notes for reviewers

Only `PluginManagerWindow.cs` is touched — no language file changes, so no translation churn. Build is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)