### PR TITLE
Fix slow Home / long jumps in the subtitle grid

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -15602,6 +15602,11 @@ public partial class MainViewModel :
             if (indexToScroll >= 0 && indexToScroll < Subtitles.Count)
             {
                 var itemToScroll = Subtitles[indexToScroll];
+
+                // Get the offset next to the target first - left to itself the virtualizing panel
+                // walks there row by row on long jumps, which is what made Home (and Find/Go to
+                // line hits near the top) crawl on large files (see PrePositionScroll).
+                TableViewExtras.PrePositionScroll(SubtitleGrid, indexToScroll);
                 SubtitleGrid.SelectedItem = itemToScroll;
                 SubtitleGrid.ScrollIntoView(itemToScroll);
 
@@ -15702,12 +15707,19 @@ public partial class MainViewModel :
             // Only execute if this is the latest scroll request
             if (subtitleToScroll != null && Subtitles.Contains(subtitleToScroll))
             {
+                TableViewExtras.PrePositionScroll(SubtitleGrid, Subtitles.IndexOf(subtitleToScroll));
                 SubtitleGrid.SelectedItem = subtitleToScroll;
                 SubtitleGrid.ScrollIntoView(subtitleToScroll);
 
                 if (Se.Settings.General.SubtitleGridCenterSelectedRow)
                 {
                     CenterSelectedRowInSubtitleGrid(subtitleToScroll);
+                }
+                else
+                {
+                    // Same follow-up as SelectAndScrollToRow: ScrollIntoView can leave the row
+                    // a few pixels past the bottom edge on a variable-height grid.
+                    EnsureRowFullyVisibleInSubtitleGrid(subtitleToScroll);
                 }
             }
         }, DispatcherPriority.Background);

--- a/src/ui/Logic/TableViewExtras.cs
+++ b/src/ui/Logic/TableViewExtras.cs
@@ -338,6 +338,7 @@ public static class TableViewExtras
                 return;
             }
 
+            PrePositionScroll(tableView, e.Key == Key.Home ? 0 : items.Count - 1);
             tableView.SelectedItem = target;
             tableView.ScrollIntoView(target);
 
@@ -443,6 +444,92 @@ public static class TableViewExtras
             .OfType<TableViewRow>()
             .Count(r => r.IsVisible && r.Bounds.Height > 0);
         return Math.Max(1, visibleRowCount - 1);
+    }
+
+    /// <summary>Refinement steps <see cref="PrePositionScroll"/> is allowed to take.</summary>
+    private const int PrePositionScrollPasses = 3;
+
+    /// <summary>
+    /// Moves the scroll offset next to <paramref name="index"/> before a
+    /// <see cref="ItemsControl.ScrollIntoView(int)"/>, so the panel never has to travel there
+    /// row by row.
+    /// TableView's VirtualizingStackPanel locates an unrealized row by estimating its offset
+    /// from the average row height, and with variable-height rows that estimate drifts. When it
+    /// drifts far enough the panel falls back to walking - realizing every single row between
+    /// where it is and where it is going. Measured on a 5000-line file: Home realized 78, 139,
+    /// 184, ... 513 containers on successive Home/End round trips (~1 s per keypress, getting
+    /// worse), and a jump to line 100 realized 4935 containers - the entire file - in every
+    /// second attempt, taking >10 seconds. Lines 400 and 700 hit the same walk less often. End
+    /// never did: the drift only bites when travelling towards the top.
+    /// Setting the offset skips rows instead of realizing them, so this walks the estimate in
+    /// instead: measure where the realized rows actually sit, jump, remeasure, at most three
+    /// times. Each pass realizes one viewport, and ScrollIntoView then has less than half a
+    /// viewport left to cover. Measured after: 16-77 containers for any target, no walks.
+    /// </summary>
+    public static void PrePositionScroll(TableView tableView, int index)
+    {
+        var scrollViewer = tableView.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
+        if (scrollViewer == null || scrollViewer.Viewport.Height <= 0)
+        {
+            return;
+        }
+
+        // The top is the one position that needs no estimate at all.
+        if (index == 0)
+        {
+            if (scrollViewer.Offset.Y > 0.5)
+            {
+                scrollViewer.Offset = new Vector(scrollViewer.Offset.X, 0);
+            }
+
+            return;
+        }
+
+        for (var pass = 0; pass < PrePositionScrollPasses; pass++)
+        {
+            var rows = tableView.GetRealizedContainers()
+                .OfType<TableViewRow>()
+                .Where(r => r.Bounds.Height > 0)
+                .Select(r => (Index: tableView.IndexFromContainer(r), Row: r))
+                .Where(x => x.Index >= 0)
+                .OrderBy(x => x.Index)
+                .ToList();
+
+            // Nothing to measure from, or the target is realized already - ScrollIntoView is
+            // cheap from here.
+            if (rows.Count == 0 || rows.Any(x => x.Index == index))
+            {
+                return;
+            }
+
+            var first = rows[0];
+            var firstTop = ((Visual)first.Row).TranslatePoint(new Point(0, 0), scrollViewer)?.Y;
+            if (firstTop == null)
+            {
+                return;
+            }
+
+            // Where the target should be, from the heights actually on screen rather than from
+            // the panel's own (drifting) average.
+            var averageRowHeight = rows.Average(x => x.Row.Bounds.Height);
+            var delta = ((index - first.Index) * averageRowHeight) - firstTop.Value;
+            if (Math.Abs(delta) < scrollViewer.Viewport.Height / 2)
+            {
+                return;
+            }
+
+            var newY = Math.Max(0, Math.Min(scrollViewer.Offset.Y + delta, scrollViewer.Extent.Height - scrollViewer.Viewport.Height));
+            if (Math.Abs(newY - scrollViewer.Offset.Y) < 1)
+            {
+                return;
+            }
+
+            scrollViewer.Offset = new Vector(scrollViewer.Offset.X, newY);
+
+            // Realize the rows at the new offset so the next pass has something to measure
+            // (and so the caller's ScrollIntoView starts from the corrected position).
+            tableView.UpdateLayout();
+        }
     }
 
     /// <summary>

--- a/tests/UI/Features/Main/SubtitleGridScrollPerformanceTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridScrollPerformanceTests.cs
@@ -137,11 +137,15 @@ public class SubtitleGridScrollPerformanceTests
         var prepared = 0;
         grid.ContainerPrepared += (_, _) => prepared++;
 
+        var elapsed = TimeSpan.Zero;
+
         int JumpTo(int index)
         {
             prepared = 0;
+            var sw = System.Diagnostics.Stopwatch.StartNew();
             vm.SelectAndScrollToSubtitle(vm.Subtitles[index]);
             Settle(window);
+            elapsed = sw.Elapsed;
             return prepared;
         }
 
@@ -149,7 +153,7 @@ public class SubtitleGridScrollPerformanceTests
         {
             JumpTo(LineCount - 1);
             var realized = JumpTo(target);
-            _output.WriteLine($"round {round}: jump to {target} realized={realized} " +
+            _output.WriteLine($"round {round}: jump to {target} realized={realized} in {elapsed.TotalMilliseconds:F0}ms " +
                               $"offset={scrollViewer.Offset.Y:F0} extent={scrollViewer.Extent.Height:F0}");
             Assert.True(realized <= MaxRealizedPerJump, $"Jump to {target} realized {realized} rows in round {round}");
 

--- a/tests/UI/Features/Main/SubtitleGridScrollPerformanceTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridScrollPerformanceTests.cs
@@ -1,0 +1,165 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// Jumping around the subtitle grid must cost a viewport of rows, not the distance travelled.
+/// TableView's virtualizing panel locates an unrealized row by estimating its offset from the
+/// average row height, and with variable-height rows that estimate drifts until the panel gives
+/// up and walks - realizing every row on the way. Measured on 5000 lines before
+/// <see cref="TableViewExtras.PrePositionScroll"/>: Home realized 78, 139, 184, ... 513 rows on
+/// successive Home/End round trips (~1 s per keypress, getting worse) while End stayed at 17,
+/// and a jump to line 100 realized all 4935 remaining rows in every second attempt.
+/// </summary>
+public class SubtitleGridScrollPerformanceTests
+{
+    private const int LineCount = 5000;
+
+    /// <summary>
+    /// A viewport holds ~17 rows. Three passes of pre-positioning plus the ScrollIntoView that
+    /// follows can realize a few viewports; anything beyond this is the panel walking again.
+    /// </summary>
+    private const int MaxRealizedPerJump = 120;
+
+    private readonly ITestOutputHelper _output;
+
+    public SubtitleGridScrollPerformanceTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    private static (Window Window, MainViewModel Vm, TableView Grid, ScrollViewer ScrollViewer) ShowMainWindowWithLines()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        for (var i = 0; i < LineCount; i++)
+        {
+            // Every third line is two lines tall - variable row heights are what makes the
+            // panel's average-height estimate drift in the first place.
+            var text = $"Line {i} of the test subtitle" + (i % 3 == 0 ? Environment.NewLine + "second line here" : string.Empty);
+            vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph(text, i * 2000, i * 2000 + 1500), null!) { Number = i + 1 });
+        }
+
+        for (var pump = 0; pump < 10; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+
+        var grid = vm.SubtitleGrid;
+        return (window, vm, grid, grid.GetVisualDescendants().OfType<ScrollViewer>().First());
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 3; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+
+    [AvaloniaFact]
+    public void HomeAndEnd_RealizeOnlyAViewportOfRows()
+    {
+        var (window, _, grid, scrollViewer) = ShowMainWindowWithLines();
+        grid.SelectedIndex = 0;
+        Dispatcher.UIThread.RunJobs();
+        TableViewExtras.FocusRow(grid);
+        Dispatcher.UIThread.RunJobs();
+
+        var prepared = 0;
+        grid.ContainerPrepared += (_, _) => prepared++;
+
+        int Press(PhysicalKey key)
+        {
+            prepared = 0;
+            window.KeyPressQwerty(key, RawInputModifiers.None);
+            Settle(window);
+            return prepared;
+        }
+
+        for (var round = 0; round < 8; round++)
+        {
+            var end = Press(PhysicalKey.End);
+            _output.WriteLine($"round {round}: End realized={end} idx={grid.SelectedIndex} " +
+                              $"offset={scrollViewer.Offset.Y:F0} extent={scrollViewer.Extent.Height:F0}");
+            Assert.Equal(LineCount - 1, grid.SelectedIndex);
+            Assert.True(end <= MaxRealizedPerJump, $"End realized {end} rows in round {round}");
+
+            var home = Press(PhysicalKey.Home);
+            _output.WriteLine($"round {round}: Home realized={home} idx={grid.SelectedIndex} " +
+                              $"offset={scrollViewer.Offset.Y:F0} extent={scrollViewer.Extent.Height:F0}");
+            Assert.Equal(0, grid.SelectedIndex);
+            Assert.True(home <= MaxRealizedPerJump, $"Home realized {home} rows in round {round}");
+        }
+
+        window.Close();
+    }
+
+    /// <summary>
+    /// The same walk hit any long jump, not just Home: Find, Go to line number and bookmarks all
+    /// land here through SelectAndScrollTo. Lines near the top were the worst, but 400 and 700
+    /// hit it too, so the whole range is covered.
+    /// </summary>
+    [AvaloniaTheory]
+    [InlineData(0)]
+    [InlineData(20)]
+    [InlineData(100)]
+    [InlineData(400)]
+    [InlineData(700)]
+    [InlineData(2500)]
+    public void JumpToRow_FromTheBottom_RealizesOnlyAFewViewports(int target)
+    {
+        var (window, vm, grid, scrollViewer) = ShowMainWindowWithLines();
+        var prepared = 0;
+        grid.ContainerPrepared += (_, _) => prepared++;
+
+        int JumpTo(int index)
+        {
+            prepared = 0;
+            vm.SelectAndScrollToSubtitle(vm.Subtitles[index]);
+            Settle(window);
+            return prepared;
+        }
+
+        for (var round = 0; round < 5; round++)
+        {
+            JumpTo(LineCount - 1);
+            var realized = JumpTo(target);
+            _output.WriteLine($"round {round}: jump to {target} realized={realized} " +
+                              $"offset={scrollViewer.Offset.Y:F0} extent={scrollViewer.Extent.Height:F0}");
+            Assert.True(realized <= MaxRealizedPerJump, $"Jump to {target} realized {realized} rows in round {round}");
+
+            // ... and the row is actually on screen when it is over.
+            var row = grid.ContainerFromItem(vm.Subtitles[target]);
+            Assert.NotNull(row);
+            var top = ((Visual)row!).TranslatePoint(new Point(0, 0), scrollViewer)!.Value.Y;
+            Assert.InRange(top, -1, scrollViewer.Viewport.Height);
+        }
+
+        window.Close();
+    }
+}


### PR DESCRIPTION
Home in the subtitle grid was noticeably slow on large files while End stayed instant.

## Cause

TableView's virtualizing panel locates an unrealized row by estimating its offset from the average row height. With variable-height rows (two-line subtitles) that estimate drifts, and once it drifts far enough the panel stops jumping and *walks* — realizing every row between where it is and where it is going.

Measured headless on a 5000-line file, row containers realized per keypress:

| round | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
|---|---|---|---|---|---|---|---|---|
| End | 17 | 17 | 17 | 17 | 17 | 17 | 17 | 17 |
| Home | 17 | 17 | 18 | 78 | 139 | 184 | 233 | 289 |

Home went from ~90 ms to ~1 s over eight Home/End round trips, and the panel's extent estimate decayed along with it (140000 → 132373).

It was not only Home. Any long jump could hit the same walk — Find, Go to line number, bookmarks and the video-follow all scroll through the same code:

- jump to line 100: `17, 4935, 17, 4935, 17, 4935` containers — 4935 is the whole file, >10 s
- jump to line 400: full walk in 1 of 6 attempts
- jump to line 700: full walk in 1 of 6 attempts

End never walked; the fallback only bites travelling towards the top.

## Fix

`TableViewExtras.PrePositionScroll` moves the scroll offset next to the target before `ScrollIntoView`, so the panel skips those rows instead of realizing them. It measures where the realized rows actually sit, jumps, and remeasures — at most three passes, each realizing one viewport — leaving ScrollIntoView less than half a viewport to cover. Row 0 is special-cased to offset 0, the one scroll position that needs no estimate.

After: 16–77 containers for any target, flat across rounds, and the extent estimate stops drifting.

Two approaches were measured and rejected on the way:

- snapping to the bottom edge for End — the bottom is only known through the *estimated* extent, so the jump teleports the panel past the real content and inflates the estimate further
- blanket snap-to-top for near-top targets — costs roughly `index` realizations (line 200 → 202 containers), so it is worse than plain ScrollIntoView except very close to the top

`SelectAndScrollToSubtitle` now also nudges the row fully into view when the center-selected-row option is off, the same way `SelectAndScrollToRow` already did — ScrollIntoView could leave the row a few pixels past the bottom edge.

## Tests

`SubtitleGridScrollPerformanceTests` drives the real main window headless with 5000 lines and asserts both real key presses (Home/End, 8 round trips) and jumps to lines 0/20/100/400/700/2500 stay within a few viewports of realizations, and that the target row ends up on screen. Both assertions fail on `main`.

Full UI suite: 1020 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
