### PR TITLE
Use DispatcherTimer for auto-backup instead of Timers.Timer

### DIFF
--- a/src/ui/Logic/AutoBackupService.cs
+++ b/src/ui/Logic/AutoBackupService.cs
@@ -24,7 +24,7 @@ public interface IAutoBackupService
 public partial class AutoBackupService : IAutoBackupService
 {
     private MainViewModel? _mainViewModel;
-    private System.Timers.Timer? _timerAutoBackup;
+    private DispatcherTimer? _timerAutoBackup;
     private int _backupInFlight;
     // Source-generated rather than RegexOptions.Compiled: this type is constructed from the
     // MainViewModel ctor, and Compiled emits IL at construction time on the start-up path
@@ -48,41 +48,40 @@ public partial class AutoBackupService : IAutoBackupService
             minutes = 1;
         }
 
-        _timerAutoBackup = new System.Timers.Timer(TimeSpan.FromMinutes(minutes));
-        _timerAutoBackup.Elapsed += (_, _) =>
+        // DispatcherTimer ticks on the UI thread, which HasChanges/GetUpdateSubtitle
+        // require (they mutate the shared subtitle and enumerate the UI-bound
+        // collection) - take the snapshot here, then write the file off-thread from
+        // a copy. It also makes Stop() synchronous: no straggler tick can run after
+        // StopAutobackup(), unlike Timers.Timer whose queued Elapsed could.
+        _timerAutoBackup = new DispatcherTimer(DispatcherPriority.Background) { Interval = TimeSpan.FromMinutes(minutes) };
+        _timerAutoBackup.Tick += (_, _) =>
         {
-            // Timer.Elapsed fires on a ThreadPool thread, but HasChanges/GetUpdateSubtitle
-            // mutate the shared subtitle and enumerate the UI-bound collection - take the
-            // snapshot on the UI thread, then write the file off-thread from a copy.
-            Dispatcher.UIThread.Post(() =>
+            if (_mainViewModel is not { } vm || !vm.HasChanges())
             {
-                if (_mainViewModel is not { } vm || !vm.HasChanges())
-                {
-                    return;
-                }
+                return;
+            }
 
-                // A save on a very large subtitle can outlive the timer interval; skip this
-                // tick rather than write concurrently (two saves in the same wall-clock
-                // second would also collide on the same timestamped filename). The next
-                // tick picks up newer state anyway.
-                if (Interlocked.CompareExchange(ref _backupInFlight, 1, 0) != 0)
-                {
-                    return;
-                }
+            // A save on a very large subtitle can outlive the timer interval; skip this
+            // tick rather than write concurrently (two saves in the same wall-clock
+            // second would also collide on the same timestamped filename). The next
+            // tick picks up newer state anyway.
+            if (Interlocked.CompareExchange(ref _backupInFlight, 1, 0) != 0)
+            {
+                return;
+            }
 
-                var saveFormat = vm.SelectedSubtitleFormat;
-                var subtitle = new Subtitle(vm.GetUpdateSubtitle(), false);
-                Task.Run(() =>
+            var saveFormat = vm.SelectedSubtitleFormat;
+            var subtitle = new Subtitle(vm.GetUpdateSubtitle(), false);
+            Task.Run(() =>
+            {
+                try
                 {
-                    try
-                    {
-                        SaveAutoBackup(subtitle, saveFormat);
-                    }
-                    finally
-                    {
-                        Interlocked.Exchange(ref _backupInFlight, 0);
-                    }
-                });
+                    SaveAutoBackup(subtitle, saveFormat);
+                }
+                finally
+                {
+                    Interlocked.Exchange(ref _backupInFlight, 0);
+                }
             });
         };
         _timerAutoBackup.Start();
@@ -91,7 +90,6 @@ public partial class AutoBackupService : IAutoBackupService
     public void StopAutobackup()
     {
         _timerAutoBackup?.Stop();
-        _timerAutoBackup?.Dispose();
         _timerAutoBackup = null;
     }
 


### PR DESCRIPTION
## Summary
- Replace `System.Timers.Timer` with Avalonia `DispatcherTimer` (explicit `DispatcherPriority.Background`) in `AutoBackupService`
- The old `Elapsed` handler fired on a ThreadPool thread whose only job was to `Dispatcher.UIThread.Post` back to the UI thread, where the snapshot work (`HasChanges`/`GetUpdateSubtitle`) already ran — `Tick` now runs there directly, removing the hop and one level of nesting
- Closes a shutdown race: a queued `Elapsed` or already-posted callback could run after `StopAutobackup()` and still write a backup; `DispatcherTimer.Stop()` on the UI thread is synchronous
- The `_backupInFlight` guard is kept — the file write still runs off-thread via `Task.Run` and resets the flag from a background thread
- Dropped the `Dispose()` call (`DispatcherTimer` is not `IDisposable`; `Stop()` suffices)

## Test plan
- [x] Enable auto-backup in Options with a 1-minute interval, edit a subtitle, and verify a timestamped backup file appears in the auto-backup folder after the interval
- [x] Verify no backup is written when there are no unsaved changes
- [x] Change the auto-backup interval in Options (restarts the timer) and verify backups follow the new interval
- [ ] Verify UI stays responsive while backups are written for a very large subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)