### PR TITLE
Ask for the error verdict, not the error message

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9790,19 +9790,22 @@ public partial class MainViewModel :
             return;
         }
 
-        var list = new List<SubtitleLineViewModel>();
+        // The message is built only for the lines that actually have an error, and with the
+        // neighbours from the subtitle - not from the filtered list, where the previous error
+        // line is rarely the previous line and the gap/overlap wording came out wrong.
+        var list = new List<ErrorListItem>();
         for (int i = 0; i < Subtitles.Count; i++)
         {
             SubtitleLineViewModel? s = Subtitles[i];
             var prev = i > 0 ? Subtitles[i - 1] : null;
             var next = i < Subtitles.Count - 1 ? Subtitles[i + 1] : null;
-            if (!string.IsNullOrEmpty(s.GetErrors(prev, next)))
+            if (s.HasErrors(prev, next))
             {
-                list.Add(s);
+                list.Add(new ErrorListItem(s, prev, next));
             }
         }
 
-        var result = await ShowDialogAsync<ErrorListWindow, ErrorListViewModel>(vm => { vm.Initialize(list.ToList()); });
+        var result = await ShowDialogAsync<ErrorListWindow, ErrorListViewModel>(vm => { vm.Initialize(list); });
 
         if (result.GoToPressed && result.SelectedSubtitle != null)
         {
@@ -9836,7 +9839,7 @@ public partial class MainViewModel :
             var s = Subtitles[i];
             var prev = i > 0 ? Subtitles[i - 1] : null;
             var next = i < Subtitles.Count - 1 ? Subtitles[i + 1] : null;
-            if (!string.IsNullOrEmpty(s.GetErrors(prev, next)))
+            if (s.HasErrors(prev, next))
             {
                 SelectAndScrollToRow(i);
                 break;
@@ -9872,7 +9875,7 @@ public partial class MainViewModel :
             var s = Subtitles[i];
             var prev = i > 0 ? Subtitles[i - 1] : null;
             var next = i < Subtitles.Count - 1 ? Subtitles[i + 1] : null;
-            if (!string.IsNullOrEmpty(s.GetErrors(prev, next)))
+            if (s.HasErrors(prev, next))
             {
                 SelectAndScrollToRow(i);
                 break;

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -235,6 +235,24 @@ public partial class SubtitleLineViewModel : ObservableObject
         return p;
     }
 
+    // Read-time memo for the html-stripped, line-split text: the pixel width column, the text
+    // error verdict and GetErrors all need it, and each used to strip and split the text again -
+    // three times per line for a single error scan. Keyed on the text instance like the memos
+    // below. The returned list is shared, so callers must only read it.
+    private string? _strippedLinesCacheText;
+    private List<string>? _strippedLinesCacheValue;
+
+    private List<string> GetStrippedLines()
+    {
+        if (_strippedLinesCacheValue == null || !ReferenceEquals(_strippedLinesCacheText, Text))
+        {
+            _strippedLinesCacheValue = SubtitleTextInfoHelper.StripHtml(Text).SplitToLines();
+            _strippedLinesCacheText = Text;
+        }
+
+        return _strippedLinesCacheValue;
+    }
+
     // Read-time memo, see CharactersPerSecond below: the pixel-width column binding re-reads this
     // on every cell repaint and each read shapes every line with HarfBuzz.
     private string? _pixelWidthCacheText;
@@ -259,8 +277,7 @@ public partial class SubtitleLineViewModel : ObservableObject
                 return _pixelWidthCacheValue;
             }
 
-            var text = HtmlUtil.RemoveHtmlTags(Text, true);
-            var lines = text.SplitToLines();
+            var lines = GetStrippedLines();
             var maxWidth = 0;
             foreach (var line in lines)
             {
@@ -383,39 +400,38 @@ public partial class SubtitleLineViewModel : ObservableObject
         }
     }
 
-    public IBrush TextBackgroundBrush
+    public IBrush TextBackgroundBrush => HasTextRuleError() ? _errorBrush : _transparentBrush;
+
+    /// <summary>
+    /// The memoized "text too long / too wide / too many lines" verdict behind
+    /// <see cref="TextBackgroundBrush"/>. Also read by <see cref="AccessibleErrorText"/> and
+    /// <see cref="HasErrors"/>, so scanning the file for errors twice (list errors, go to
+    /// next error) never re-strips or re-shapes a line whose text is unchanged.
+    /// </summary>
+    private bool HasTextRuleError()
     {
-        get
+        if (string.IsNullOrEmpty(Text))
         {
-            if (string.IsNullOrEmpty(Text))
-            {
-                return _transparentBrush;
-            }
-
-            var settings = TextErrorSettings.Current();
-            if (!ReferenceEquals(_textErrorCacheText, Text) || !_textErrorCacheSettings.Equals(settings))
-            {
-                _textErrorCacheText = Text;
-                _textErrorCacheSettings = settings;
-                _textErrorCacheValue = HasTextError(Text, settings);
-            }
-
-            return _textErrorCacheValue ? _errorBrush : _transparentBrush;
+            return false;
         }
+
+        var settings = TextErrorSettings.Current();
+        if (!ReferenceEquals(_textErrorCacheText, Text) || !_textErrorCacheSettings.Equals(settings))
+        {
+            _textErrorCacheText = Text;
+            _textErrorCacheSettings = settings;
+            _textErrorCacheValue = HasTextError(settings);
+        }
+
+        return _textErrorCacheValue;
     }
 
-    private static bool HasTextError(string text, TextErrorSettings settings)
+    private bool HasTextError(TextErrorSettings settings)
     {
-        // Strip HTML and split into lines once and reuse across all settings-enabled branches.
-        string? stripped = null;
-        List<string>? strippedLines = null;
-
+        // The stripped lines are memoized (GetStrippedLines), so the enabled branches share them.
         if (settings.ColorTextTooLong)
         {
-            stripped = SubtitleTextInfoHelper.StripHtml(text);
-            strippedLines = stripped.SplitToLines();
-
-            foreach (var line in strippedLines)
+            foreach (var line in GetStrippedLines())
             {
                 if (SubtitleTextInfoHelper.GetLineLength(line) > settings.MaxLineLength)
                 {
@@ -426,9 +442,7 @@ public partial class SubtitleLineViewModel : ObservableObject
 
         if (settings.ColorTextTooWide)
         {
-            stripped ??= SubtitleTextInfoHelper.StripHtml(text);
-            strippedLines ??= stripped.SplitToLines();
-            foreach (var line in strippedLines)
+            foreach (var line in GetStrippedLines())
             {
                 if (CalculatePixelWidth(line) > settings.MaxPixelWidth)
                 {
@@ -439,9 +453,7 @@ public partial class SubtitleLineViewModel : ObservableObject
 
         if (settings.ColorTextTooManyLines)
         {
-            stripped ??= SubtitleTextInfoHelper.StripHtml(text);
-            strippedLines ??= stripped.SplitToLines();
-            if (strippedLines.Count > settings.MaxNumberOfLines)
+            if (GetStrippedLines().Count > settings.MaxNumberOfLines)
             {
                 return true;
             }
@@ -629,8 +641,8 @@ public partial class SubtitleLineViewModel : ObservableObject
                 Add("WPM " + Math.Round(WordsPerMinute));
             }
 
-            // TextBackgroundBrush caches the expensive HarfBuzz width check by (Text, settings).
-            if (!ReferenceEquals(TextBackgroundBrush, _transparentBrush))
+            // Memoized by (Text, settings) - the same verdict the Text cell tint uses.
+            if (HasTextRuleError())
             {
                 Add("text too long or wide");
             }
@@ -926,18 +938,66 @@ public partial class SubtitleLineViewModel : ObservableObject
         return SubtitleTextInfoHelper.GetCharactersPerSecond(Text, StartTime, EndTime);
     }
 
+    /// <summary>
+    /// Whether <see cref="GetErrors"/> would report anything, without building the message.
+    /// Same rules, but allocation-free and short-circuiting, and the text rules go through the
+    /// memoized verdict - the error scans (list errors, go to next/previous error) only need
+    /// the yes/no answer, and they ask it for every line of the file.
+    /// </summary>
+    public bool HasErrors(SubtitleLineViewModel? prev, SubtitleLineViewModel? next)
+    {
+        var general = Se.Settings.General;
+
+        if (general.ColorCharactersPerSecond &&
+            Math.Round(CharactersPerSecond, 2, MidpointRounding.AwayFromZero) > general.SubtitleMaximumCharactersPerSeconds)
+        {
+            return true;
+        }
+
+        var durMsRounded = Math.Round(Duration.TotalMilliseconds, 3, MidpointRounding.AwayFromZero);
+        if (general.ColorDurationTooShort && durMsRounded < general.SubtitleMinimumDisplayMilliseconds)
+        {
+            return true;
+        }
+
+        if (general.ColorDurationTooLong && durMsRounded > general.SubtitleMaximumDisplayMilliseconds)
+        {
+            return true;
+        }
+
+        if (prev != null && HasGapError(general, (StartTime - prev.EndTime).TotalMilliseconds))
+        {
+            return true;
+        }
+
+        if (next != null && HasGapError(general, (next.StartTime - EndTime).TotalMilliseconds))
+        {
+            return true;
+        }
+
+        // Last, because these are the only rules that touch the text (and, with
+        // "text too wide" on, shape every line with HarfBuzz).
+        return HasTextRuleError();
+    }
+
+    private static bool HasGapError(SeGeneral general, double gapMs)
+        => gapMs < 0
+            ? general.ColorTimeCodeOverlap
+            : general.ColorGapTooShort && gapMs < general.MinimumBetweenLines.GetMilliseconds();
+
     public string GetErrors(SubtitleLineViewModel? prev, SubtitleLineViewModel? next)
     {
         var errors = new StringBuilder();
 
         var general = Se.Settings.General;
-        var strippedText = SubtitleTextInfoHelper.StripHtml(Text);
-        var lines = strippedText.SplitToLines();
-        var lineCount = lines.Count;
 
-        if (lineCount > general.MaxNumberOfLines && Se.Settings.General.ColorTextTooManyLines)
+        if (Se.Settings.General.ColorTextTooManyLines)
         {
-            errors.AppendLine("Max #lines: " + lineCount + " >" + general.MaxNumberOfLines);
+            var lineCount = GetStrippedLines().Count;
+            if (lineCount > general.MaxNumberOfLines)
+            {
+                errors.AppendLine("Max #lines: " + lineCount + " >" + general.MaxNumberOfLines);
+            }
         }
 
         var cpsRounded = Math.Round(CharactersPerSecond, 2, MidpointRounding.AwayFromZero);
@@ -964,7 +1024,7 @@ public partial class SubtitleLineViewModel : ObservableObject
 
         if (Se.Settings.General.ColorTextTooLong)
         {
-            foreach (var line in lines)
+            foreach (var line in GetStrippedLines())
             {
                 var lineLength = SubtitleTextInfoHelper.GetLineLength(line);
                 if (lineLength > general.SubtitleLineMaximumLength)
@@ -976,7 +1036,7 @@ public partial class SubtitleLineViewModel : ObservableObject
 
         if (Se.Settings.General.ColorTextTooWide)
         {
-            foreach (var line in lines)
+            foreach (var line in GetStrippedLines())
             {
                 var pixelWidth = CalculatePixelWidth(line);
                 if (pixelWidth > general.ColorTextTooWidePixels)

--- a/src/ui/Features/Shared/ErrorList/ErrorListViewModel.cs
+++ b/src/ui/Features/Shared/ErrorList/ErrorListViewModel.cs
@@ -46,16 +46,17 @@ public partial class ErrorListViewModel : ObservableObject
         }
     }
 
-    internal void Initialize(List<SubtitleLineViewModel> subtitleLineViewModels)
+    /// <summary>
+    /// The items come ready-made from the caller: it is the only place that still knows each
+    /// line's real neighbours, which the gap/overlap wording needs.
+    /// </summary>
+    internal void Initialize(List<ErrorListItem> errorListItems)
     {
-        for (int i = 0; i < subtitleLineViewModels.Count; i++)
+        foreach (var item in errorListItems)
         {
-            SubtitleLineViewModel? subtitleLine = subtitleLineViewModels[i];
-            var prev = i > 0 ? subtitleLineViewModels[i - 1] : null;
-            var next = i < subtitleLineViewModels.Count - 1 ? subtitleLineViewModels[i + 1] : null;
-            Subtitles.Add(new ErrorListItem(subtitleLine, prev, next));
+            Subtitles.Add(item);
         }
-        
+
         HasErrors = SelectedSubtitle != null;
     }
 

--- a/src/ui/Features/Tools/BatchConvert/BatchErrorList/BatchErrorListItem.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchErrorList/BatchErrorListItem.cs
@@ -1,6 +1,4 @@
-﻿using Nikse.SubtitleEdit.Core.Common;
-using Nikse.SubtitleEdit.Core.SubtitleFormats;
-using Nikse.SubtitleEdit.Features.Main;
+﻿using Nikse.SubtitleEdit.Features.Main;
 
 namespace Nikse.SubtitleEdit.Features.Tools.BatchConvert.BatchErrorList;
 
@@ -12,15 +10,12 @@ public class BatchErrorListItem
     public string Error { get; set; }
     public SubtitleLineViewModel Subtitle { get; set; }
 
-    public BatchErrorListItem(string fileName, SubtitleLineViewModel subtitle, Paragraph? prev, Paragraph? next)
+    public BatchErrorListItem(string fileName, SubtitleLineViewModel subtitle, SubtitleLineViewModel? prev, SubtitleLineViewModel? next)
     {
         FileName = fileName;
         Subtitle = subtitle;
         Text = subtitle.Text;
         Number = subtitle.Number;
-        var format = new SubRip();
-        var previousSubtitleLineViewModel = prev != null ? new SubtitleLineViewModel(prev, format) : null;
-        var nextSubtitleLineViewModel = next != null ? new SubtitleLineViewModel(next, format) : null;
-        Error = subtitle.GetErrors(previousSubtitleLineViewModel, nextSubtitleLineViewModel);
+        Error = subtitle.GetErrors(prev, next);
     }
 }

--- a/src/ui/Features/Tools/BatchConvert/BatchErrorList/BatchErrorListViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchErrorList/BatchErrorListViewModel.cs
@@ -99,16 +99,24 @@ public partial class BatchErrorListViewModel : ObservableObject
                 continue;
             }
 
-            for (int i = 0; i < batchItem.Subtitle.Paragraphs.Count; i++)
+            // One view model per paragraph, reused as its neighbours' prev/next: the previous
+            // version built three of them (plus a format) for every paragraph of every file and
+            // threw away all but the ones with an error.
+            var format = batchItem.Subtitle.OriginalFormat ?? new SubRip();
+            var lines = new List<SubtitleLineViewModel>(batchItem.Subtitle.Paragraphs.Count);
+            foreach (var p in batchItem.Subtitle.Paragraphs)
             {
-                Core.Common.Paragraph? p = batchItem.Subtitle.Paragraphs[i];
-                var prev = i > 0 ? batchItem.Subtitle.Paragraphs[i - 1] : null;
-                var next = i < batchItem.Subtitle.Paragraphs.Count - 1 ? batchItem.Subtitle.Paragraphs[i + 1] : null;
-                var format = batchItem.Subtitle.OriginalFormat ?? new SubRip();
-                var errorItem = new BatchErrorListItem(batchItem.FileName, new SubtitleLineViewModel(p, format), prev, next);
-                if (!string.IsNullOrEmpty(errorItem.Error))
+                lines.Add(new SubtitleLineViewModel(p, format));
+            }
+
+            for (var i = 0; i < lines.Count; i++)
+            {
+                var line = lines[i];
+                var prev = i > 0 ? lines[i - 1] : null;
+                var next = i < lines.Count - 1 ? lines[i + 1] : null;
+                if (line.HasErrors(prev, next))
                 {
-                    Subtitles.Add(errorItem);
+                    Subtitles.Add(new BatchErrorListItem(batchItem.FileName, line, prev, next));
                 }
             }
         }

--- a/tests/UI/Features/Main/SubtitleLineViewModelHasErrorsTests.cs
+++ b/tests/UI/Features/Main/SubtitleLineViewModelHasErrorsTests.cs
@@ -1,0 +1,200 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// The error scans (list errors, go to next/previous error, batch convert's error list) ask
+/// <see cref="SubtitleLineViewModel.HasErrors"/> instead of building the message with
+/// <see cref="SubtitleLineViewModel.GetErrors"/>, so the two must agree on every line.
+/// </summary>
+public class SubtitleLineViewModelHasErrorsTests
+{
+    private static SubtitleLineViewModel Line(string text, double startMs, double endMs)
+        => new()
+        {
+            Text = text,
+            StartTime = TimeSpan.FromMilliseconds(startMs),
+            EndTime = TimeSpan.FromMilliseconds(endMs),
+        };
+
+    private static List<SubtitleLineViewModel> MakeLines()
+        => new()
+        {
+            Line("Hello there.", 1000, 3000),                                   // clean
+            Line("Hi.", 3100, 3200),                                            // duration too short
+            Line("A very long single line that is well past forty-three characters.", 4000, 12000), // too long + too long duration
+            Line("Way too much text to read in this little time, honestly.", 12100, 12900), // cps/wpm
+            Line("Line one" + Environment.NewLine + "Line two" + Environment.NewLine + "Line three", 13000, 16000), // too many lines
+            Line("<i>Overlapping.</i>", 15500, 17000),                          // overlaps the previous line
+            Line("Barely a gap.", 17005, 19000),                                // gap too short
+            Line(string.Empty, 20000, 22000),                                   // empty text
+            Line("{\\an8}Somewhere in Denmark", 22100, 24000),                  // clean, ssa tag
+        };
+
+    /// <summary>Returns how many lines have errors, so a test can prove it is not vacuous.</summary>
+    private static int AssertAgrees(List<SubtitleLineViewModel> lines)
+    {
+        var withErrors = 0;
+        for (var i = 0; i < lines.Count; i++)
+        {
+            var prev = i > 0 ? lines[i - 1] : null;
+            var next = i < lines.Count - 1 ? lines[i + 1] : null;
+            var expected = !string.IsNullOrEmpty(lines[i].GetErrors(prev, next));
+
+            Assert.True(
+                expected == lines[i].HasErrors(prev, next),
+                $"line {i} ('{lines[i].Text}'): GetErrors says {expected}, HasErrors says {!expected}");
+
+            if (expected)
+            {
+                withErrors++;
+            }
+        }
+
+        return withErrors;
+    }
+
+    [AvaloniaFact]
+    public void HasErrors_MatchesGetErrors_WithAllRulesOn()
+    {
+        var originalSettings = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            var general = Se.Settings.General;
+            general.ColorDurationTooShort = true;
+            general.ColorDurationTooLong = true;
+            general.ColorTextTooLong = true;
+            general.ColorTextTooManyLines = true;
+            general.ColorCharactersPerSecond = true;
+            general.ColorWordsPerMinute = true;
+            general.ColorTimeCodeOverlap = true;
+            general.ColorGapTooShort = true;
+            general.ColorTextTooWide = false; // font dependent, covered separately below
+
+            var withErrors = AssertAgrees(MakeLines());
+            Assert.True(withErrors >= 5, $"expected the battery to trip several rules, got {withErrors}");
+        }
+        finally
+        {
+            Se.Settings = originalSettings;
+        }
+    }
+
+    [AvaloniaFact]
+    public void HasErrors_MatchesGetErrors_WithTextTooWideOn()
+    {
+        var originalSettings = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            var general = Se.Settings.General;
+            general.ColorTextTooWide = true;
+            general.ColorTextTooWidePixels = 200; // narrow enough that longer lines trip it
+            general.ColorTextTooWideFontName = "Arial";
+            general.ColorTextTooWideFontSize = 40;
+
+            var withErrors = AssertAgrees(MakeLines());
+            Assert.True(withErrors >= 1, "expected at least one line to be too wide");
+        }
+        finally
+        {
+            Se.Settings = originalSettings;
+        }
+    }
+
+    [AvaloniaFact]
+    public void HasErrors_MatchesGetErrors_WithAllRulesOff()
+    {
+        var originalSettings = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            var general = Se.Settings.General;
+            general.ColorDurationTooShort = false;
+            general.ColorDurationTooLong = false;
+            general.ColorTextTooLong = false;
+            general.ColorTextTooWide = false;
+            general.ColorTextTooManyLines = false;
+            general.ColorCharactersPerSecond = false;
+            general.ColorWordsPerMinute = false;
+            general.ColorTimeCodeOverlap = false;
+            general.ColorGapTooShort = false;
+
+            var lines = MakeLines();
+            Assert.Equal(0, AssertAgrees(lines));
+
+            for (var i = 0; i < lines.Count; i++)
+            {
+                Assert.False(lines[i].HasErrors(i > 0 ? lines[i - 1] : null, i < lines.Count - 1 ? lines[i + 1] : null));
+            }
+        }
+        finally
+        {
+            Se.Settings = originalSettings;
+        }
+    }
+
+    /// <summary>
+    /// GetErrors, the pixel width column and the text error verdict share one memo of the
+    /// html-stripped lines, so an edited line must not keep answering for the old text.
+    /// </summary>
+    [AvaloniaFact]
+    public void HasErrors_FollowsTextChange()
+    {
+        var originalSettings = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.General.ColorTextTooLong = true;
+            Se.Settings.General.SubtitleLineMaximumLength = 10;
+            Se.Settings.General.ColorCharactersPerSecond = false;
+            Se.Settings.General.ColorWordsPerMinute = false;
+            Se.Settings.General.ColorDurationTooShort = false;
+            Se.Settings.General.ColorDurationTooLong = false;
+
+            var line = Line("Short", 1000, 3000);
+            Assert.False(line.HasErrors(null, null));
+
+            line.Text = "A line that is clearly longer than ten characters.";
+            Assert.True(line.HasErrors(null, null));
+
+            line.Text = "Short";
+            Assert.False(line.HasErrors(null, null));
+        }
+        finally
+        {
+            Se.Settings = originalSettings;
+        }
+    }
+
+    /// <summary>The pixel width column reads the same memo, so it must follow the text too.</summary>
+    [AvaloniaFact]
+    public void PixelWidth_FollowsTextChange()
+    {
+        var originalSettings = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.General.ShowColumnPixelWidth = true;
+            Se.Settings.General.ColorTextTooWideFontName = "Arial";
+            Se.Settings.General.ColorTextTooWideFontSize = 40;
+
+            var line = Line("Hi", 1000, 3000);
+            var narrow = line.PixelWidth;
+
+            line.Text = "A considerably wider line of text than the first one.";
+            var wide = line.PixelWidth;
+
+            Assert.True(wide > narrow, $"expected the wider text to measure wider, got {wide} <= {narrow}");
+        }
+        finally
+        {
+            Se.Settings = originalSettings;
+        }
+    }
+}

--- a/tests/benchmarks/SubtitleErrorPathBenchmarks.cs
+++ b/tests/benchmarks/SubtitleErrorPathBenchmarks.cs
@@ -1,0 +1,259 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Shared.ErrorList;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// The "find errors" paths: list errors (whole file), go to next/previous error (scan
+/// until a hit) and the per-row accessible error text the grid reads on every repaint.
+/// </summary>
+[MemoryDiagnoser]
+public class SubtitleErrorPathBenchmarks
+{
+    private List<SubtitleLineViewModel> _lines = new();
+    private List<Paragraph> _paragraphs = new();
+
+    /// <summary>Lines in a typical feature-length subtitle.</summary>
+    [Params(1000)]
+    public int LineCount { get; set; }
+
+    /// <summary>Off by default; on it shapes every line with HarfBuzz.</summary>
+    [Params(false, true)]
+    public bool ColorTextTooWide { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var general = Se.Settings.General;
+        general.ColorDurationTooShort = true;
+        general.ColorDurationTooLong = true;
+        general.ColorTextTooLong = true;
+        general.ColorTextTooManyLines = true;
+        general.ColorCharactersPerSecond = true;
+        general.ColorWordsPerMinute = true;
+        general.ColorTimeCodeOverlap = true;
+        general.ColorGapTooShort = true;
+        general.ColorTextTooWide = ColorTextTooWide;
+        general.SubtitleLineMaximumLength = 43;
+        general.MaxNumberOfLines = 2;
+        general.SubtitleMinimumDisplayMilliseconds = 1000;
+        general.SubtitleMaximumDisplayMilliseconds = 8000;
+        general.SubtitleMaximumCharactersPerSeconds = 25.0;
+        general.SubtitleMaximumWordsPerMinute = 400;
+        general.ColorTextTooWidePixels = 1200;
+        general.MinimumBetweenLines.Milliseconds = 24;
+
+        _lines = SubtitleFactory.Make(LineCount);
+
+        // Realistic error density (~15%): every 7th line runs too fast, every 11th overlaps.
+        for (var i = 0; i < _lines.Count; i++)
+        {
+            if (i % 7 == 3)
+            {
+                _lines[i].SetTimes(_lines[i].StartTime, _lines[i].StartTime + TimeSpan.FromMilliseconds(400));
+            }
+
+            if (i % 11 == 5 && i > 0)
+            {
+                _lines[i].SetTimes(_lines[i - 1].EndTime - TimeSpan.FromMilliseconds(200), _lines[i].EndTime);
+            }
+        }
+
+        SubtitleTextInfoHelper.UpdateGaps(_lines);
+        _paragraphs = _lines.Select(l => l.ToParagraph()).ToList();
+    }
+
+    /// <summary>Main menu "List errors" - and the same scan behind go to next/previous error.</summary>
+    [Benchmark]
+    public int ListErrorsScan()
+    {
+        var count = 0;
+        for (var i = 0; i < _lines.Count; i++)
+        {
+            var s = _lines[i];
+            var prev = i > 0 ? _lines[i - 1] : null;
+            var next = i < _lines.Count - 1 ? _lines[i + 1] : null;
+            if (!string.IsNullOrEmpty(s.GetErrors(prev, next)))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    /// The same scan right after a file is loaded, i.e. with every per-line memo cold.
+    /// The iteration setup hands each line a fresh string instance, which is what the
+    /// ReferenceEquals-keyed memos in the view model key on.
+    /// </summary>
+    [IterationSetup(Target = nameof(ListErrorsScanCold))]
+    public void InvalidateMemos()
+    {
+        foreach (var line in _lines)
+        {
+            line.Text = new string(line.Text.AsSpan());
+        }
+    }
+
+    [Benchmark]
+    public int ListErrorsScanCold()
+    {
+        var count = 0;
+        for (var i = 0; i < _lines.Count; i++)
+        {
+            var s = _lines[i];
+            var prev = i > 0 ? _lines[i - 1] : null;
+            var next = i < _lines.Count - 1 ? _lines[i + 1] : null;
+            if (!string.IsNullOrEmpty(s.GetErrors(prev, next)))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>The scan as the commands do it now: ask for the verdict, not the message.</summary>
+    [Benchmark]
+    public int HasErrorsScan()
+    {
+        var count = 0;
+        for (var i = 0; i < _lines.Count; i++)
+        {
+            var s = _lines[i];
+            var prev = i > 0 ? _lines[i - 1] : null;
+            var next = i < _lines.Count - 1 ? _lines[i + 1] : null;
+            if (s.HasErrors(prev, next))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    [IterationSetup(Target = nameof(HasErrorsScanCold))]
+    public void InvalidateMemosForHasErrors() => InvalidateMemos();
+
+    [Benchmark]
+    public int HasErrorsScanCold() => HasErrorsScan();
+
+    /// <summary>"List errors" now: filter with the verdict, build the message only for hits.</summary>
+    [Benchmark]
+    public int ListErrorsFullNew()
+    {
+        var items = new List<ErrorListItem>();
+        for (var i = 0; i < _lines.Count; i++)
+        {
+            var s = _lines[i];
+            var prev = i > 0 ? _lines[i - 1] : null;
+            var next = i < _lines.Count - 1 ? _lines[i + 1] : null;
+            if (s.HasErrors(prev, next))
+            {
+                items.Add(new ErrorListItem(s, prev, next));
+            }
+        }
+
+        return items.Count;
+    }
+
+    /// <summary>Batch convert's error list now: one view model per paragraph, reused as neighbour.</summary>
+    [Benchmark]
+    public int BatchErrorListInitializeNew()
+    {
+        var count = 0;
+        var format = new SubRip();
+        var lines = new List<SubtitleLineViewModel>(_paragraphs.Count);
+        foreach (var p in _paragraphs)
+        {
+            lines.Add(new SubtitleLineViewModel(p, format));
+        }
+
+        for (var i = 0; i < lines.Count; i++)
+        {
+            var prev = i > 0 ? lines[i - 1] : null;
+            var next = i < lines.Count - 1 ? lines[i + 1] : null;
+            if (lines[i].HasErrors(prev, next))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>The full "List errors" command: scan, then build the dialog's item list.</summary>
+    [Benchmark]
+    public int ListErrorsFull()
+    {
+        var list = new List<SubtitleLineViewModel>();
+        for (var i = 0; i < _lines.Count; i++)
+        {
+            var s = _lines[i];
+            var prev = i > 0 ? _lines[i - 1] : null;
+            var next = i < _lines.Count - 1 ? _lines[i + 1] : null;
+            if (!string.IsNullOrEmpty(s.GetErrors(prev, next)))
+            {
+                list.Add(s);
+            }
+        }
+
+        var items = new List<ErrorListItem>(list.Count);
+        for (var i = 0; i < list.Count; i++)
+        {
+            var prev = i > 0 ? list[i - 1] : null;
+            var next = i < list.Count - 1 ? list[i + 1] : null;
+            items.Add(new ErrorListItem(list[i], prev, next));
+        }
+
+        return items.Count;
+    }
+
+    /// <summary>
+    /// Batch convert's error list, as BatchErrorListViewModel.Initialize + the
+    /// BatchErrorListItem constructor do it: a view model for the line and one for each
+    /// neighbour, then the full error message, for every paragraph of every file.
+    /// </summary>
+    [Benchmark]
+    public int BatchErrorListInitialize()
+    {
+        var count = 0;
+        var format = new SubRip();
+        for (var i = 0; i < _paragraphs.Count; i++)
+        {
+            var p = _paragraphs[i];
+            var prev = i > 0 ? _paragraphs[i - 1] : null;
+            var next = i < _paragraphs.Count - 1 ? _paragraphs[i + 1] : null;
+
+            var line = new SubtitleLineViewModel(p, format);
+            var itemFormat = new SubRip();
+            var prevLine = prev != null ? new SubtitleLineViewModel(prev, itemFormat) : null;
+            var nextLine = next != null ? new SubtitleLineViewModel(next, itemFormat) : null;
+            if (!string.IsNullOrEmpty(line.GetErrors(prevLine, nextLine)))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>Row accessible name: read for every realized row on every invalidation.</summary>
+    [Benchmark]
+    public int AccessibleErrorTextVisibleRows()
+    {
+        var length = 0;
+        for (var i = 0; i < 30; i++)
+        {
+            length += _lines[i].AccessibleErrorText.Length;
+        }
+
+        return length;
+    }
+}


### PR DESCRIPTION
Follow-up to #13023, on the path that finds the rule violations that PR announces.

The error scans — **List errors**, **go to next/previous error**, and batch convert's error list — built the full error *message* for every line of the file just to test it for emptiness. Building it strips the html, splits the text, counts every line and, with *text too wide* on, shapes every line with HarfBuzz.

- New `SubtitleLineViewModel.HasErrors(prev, next)`: the same rules, short-circuiting and without allocating, with the text rules going through the verdict `TextBackgroundBrush` already memoizes by `(Text, settings)`. The scans call it instead of `GetErrors`.
- One memo of the html-stripped, line-split text per line, shared by the pixel width column, the text error verdict and `GetErrors` — each of the three used to strip and split the text again.
- **List errors** builds the message only for the lines that have an error, and with the neighbours from the subtitle. It used to pass the neighbours from the *filtered* list, where the previous error line is rarely the previous line — so the gap/overlap wording in the dialog was computed against the wrong lines (a bug, not just a cost).
- Batch convert's error list builds one view model per paragraph and reuses it as its neighbours' prev/next; it used to build three of them (plus a `SubRip` format) for every paragraph of every file and throw away all but the ones with an error.

## Numbers

BenchmarkDotNet (`tests/benchmarks/SubtitleErrorPathBenchmarks.cs`, added here), 1000 lines with ~15% of them violating a rule, net10.0, Apple silicon, default job, `MemoryDiagnoser`:

| path | before | after |
|---|---|---|
| error scan | 212 µs, 490 KB | **15.0 µs, 0 B** |
| error scan, cold memos (right after load) | 1015 µs, 490 KB | **159 µs, 0 B** |
| List errors, whole command | 429 µs, 917 KB | **135 µs, 361 KB** |
| batch convert error list | 811 µs, 3.2 MB | **321 µs, 0.97 MB** |
| error scan, *text too wide* on | 3157 µs, 2.7 MB | **15.5 µs, 0 B** |
| List errors, *text too wide* on | 5576 µs, 4.7 MB | **2274 µs, 2.0 MB** |

`GetErrors` itself keeps roughly its old timing (196 µs vs 212 µs for a full-file pass, within the error bars) but allocates ~25% less; it is now only called for lines that actually have an error.

`AccessibleErrorText` from #13023 was measured too (2.5 µs / 7.2 KB for 30 rows) and is unchanged — its local function was already allocation-free, so it only picked up the shared memoized verdict.

## Behavior

`HasErrors` has to agree with `GetErrors` line for line, so new tests assert exactly that over a battery of violations (too short/long duration, cps/wpm, too many lines, too long/wide text, overlap, short gap, empty text, ssa tags) with the rules on, with them all off, and with *text too wide* on — plus that the shared stripped-text memo follows an edited line. Full UI suite green (1019 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)