### PR TITLE
Move shot changes progress percentage below the progress bar

### DIFF
--- a/src/ui/Features/Video/ShotChanges/ShotChangesWindow.cs
+++ b/src/ui/Features/Video/ShotChanges/ShotChangesWindow.cs
@@ -167,11 +167,12 @@ public class ShotChangesWindow : Window
         var progressBar = UiUtil.MakeProgressBar();
         progressBar.MinWidth = 400;
         progressBar[!ProgressBar.ValueProperty] = new Binding(nameof(vm.ProgressValue)) { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged };
-        var progressText = UiUtil.MakeLabel().WithBindText(vm, nameof(ShotChangesViewModel.ProgressText)).WithAlignmentCenter().WithMarginTop(14); 
+        var progressText = UiUtil.MakeLabel().WithBindText(vm, nameof(ShotChangesViewModel.ProgressText)).WithAlignmentCenter();
         var gridProgress = new Grid
         {
             Width = double.NaN,
             HorizontalAlignment = HorizontalAlignment.Stretch,
+            RowSpacing = 5,
             ColumnDefinitions =
             {
                 new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
@@ -179,10 +180,11 @@ public class ShotChangesWindow : Window
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
         };
         gridProgress.Add(progressBar, 0);
-        gridProgress.Add(progressText, 0);
+        gridProgress.Add(progressText, 1);
 
         grid.Add(UiUtil.MakeBorderForControlNoPadding(tableView), 0);
         grid.Add(panelSensitivity, 1);


### PR DESCRIPTION
In the *Generate shot changes* tab, the percentage label was drawn on top of the progress bar.

The bar and the label shared row 0 of the same grid. The bar has a fixed `Height = 10` while the row grew to fit the label's `MarginTop(14)` plus text, so the bar was centered vertically in the taller row and ended up behind the label.

The label now gets its own grid row below the bar, and the top-margin hack is replaced by `RowSpacing = 5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)