### PR TITLE
Complete a base-only auto-translate API url to the real endpoint

### DIFF
--- a/src/libuilogic/AutoTranslate/AnthropicTranslate.cs
+++ b/src/libuilogic/AutoTranslate/AnthropicTranslate.cs
@@ -38,6 +38,11 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             "claude-sonnet-4-6",
         };
 
+        /// <summary>
+        /// Endpoint used when the url in settings is only the service base - see <see cref="AutoTranslateUrl"/>.
+        /// </summary>
+        public const string DefaultUrl = "https://api.anthropic.com/v1/messages";
+
         public void Initialize()
         {
             _httpClient?.Dispose();
@@ -45,7 +50,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("anthropic-version", "2023-06-01");
-            _httpClient.BaseAddress = new Uri(Configuration.Settings.Tools.AnthropicApiUrl.TrimEnd('/'));
+            _httpClient.BaseAddress = new Uri(AutoTranslateUrl.Complete(Configuration.Settings.Tools.AnthropicApiUrl, DefaultUrl));
 
             if (!string.IsNullOrEmpty(Configuration.Settings.Tools.AnthropicApiKey))
             {

--- a/src/libuilogic/AutoTranslate/AutoTranslateUrl.cs
+++ b/src/libuilogic/AutoTranslate/AutoTranslateUrl.cs
@@ -1,0 +1,57 @@
+using System;
+
+namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
+{
+    /// <summary>
+    /// Completes an API url that only names the service base ("https://api.deepseek.com") to the
+    /// engine's real endpoint ("https://api.deepseek.com/chat/completions").
+    /// <para>
+    /// Vendors document the base url for OpenAI-SDK use, so that is what gets pasted into the url
+    /// box - and every request then hits the origin root, which answers 404 with nothing pointing
+    /// at the url as the culprit (#13044).
+    /// </para>
+    /// <para>
+    /// A url with a path of its own is left alone: only a bare origin, or a leading part of the
+    /// default endpoint path ("/v1", "/openai/v1"), is completed. That keeps custom endpoints
+    /// (llama.cpp's native "/completion", proxies with their own routes) working as typed.
+    /// </para>
+    /// </summary>
+    public static class AutoTranslateUrl
+    {
+        public static string Complete(string? url, string? defaultUrl)
+        {
+            var trimmed = (url ?? string.Empty).Trim();
+            if (trimmed.Length == 0)
+            {
+                return (defaultUrl ?? string.Empty).Trim().TrimEnd('/');
+            }
+
+            if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri) ||
+                !Uri.TryCreate((defaultUrl ?? string.Empty).Trim(), UriKind.Absolute, out var defaultUri))
+            {
+                return trimmed.TrimEnd('/');
+            }
+
+            if (uri.Query.Length > 0 || uri.Fragment.Length > 0)
+            {
+                return trimmed;
+            }
+
+            var path = uri.AbsolutePath.Trim('/');
+            var defaultPath = defaultUri.AbsolutePath.Trim('/');
+            if (defaultPath.Length == 0)
+            {
+                return trimmed.TrimEnd('/');
+            }
+
+            // Only complete an empty path or a proper prefix of the default path - anything else
+            // is a deliberate endpoint choice.
+            if (path.Length > 0 && !defaultPath.StartsWith(path + "/", StringComparison.OrdinalIgnoreCase))
+            {
+                return trimmed.TrimEnd('/');
+            }
+
+            return uri.GetLeftPart(UriPartial.Authority) + "/" + defaultPath;
+        }
+    }
+}

--- a/src/libuilogic/AutoTranslate/AvalAi.cs
+++ b/src/libuilogic/AutoTranslate/AvalAi.cs
@@ -71,13 +71,18 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             "qwen3.6-max"
         };
 
+        /// <summary>
+        /// Endpoint used when the url in settings is only the service base - see <see cref="AutoTranslateUrl"/>.
+        /// </summary>
+        public const string DefaultUrl = "https://api.avalai.ir/v1/chat/completions";
+
         public void Initialize()
         {
             _httpClient?.Dispose();
             _httpClient = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
-            _httpClient.BaseAddress = new Uri(Configuration.Settings.Tools.AvalAiUrl.TrimEnd('/'));
+            _httpClient.BaseAddress = new Uri(AutoTranslateUrl.Complete(Configuration.Settings.Tools.AvalAiUrl, DefaultUrl));
             _httpClient.Timeout = TimeSpan.FromMinutes(15);
 
             if (!string.IsNullOrEmpty(Configuration.Settings.Tools.AvalAiApiKey))

--- a/src/libuilogic/AutoTranslate/ChatGptTranslate.cs
+++ b/src/libuilogic/AutoTranslate/ChatGptTranslate.cs
@@ -73,13 +73,18 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             return translation;
         }
 
+        /// <summary>
+        /// Endpoint used when the url in settings is only the service base - see <see cref="AutoTranslateUrl"/>.
+        /// </summary>
+        public const string DefaultUrl = "https://api.openai.com/v1/chat/completions";
+
         public void Initialize()
         {
             _httpClient?.Dispose();
             _httpClient = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
-            _httpClient.BaseAddress = new Uri(Configuration.Settings.Tools.ChatGptUrl.TrimEnd('/'));
+            _httpClient.BaseAddress = new Uri(AutoTranslateUrl.Complete(Configuration.Settings.Tools.ChatGptUrl, DefaultUrl));
             _httpClient.Timeout = TimeSpan.FromMinutes(15);
 
             if (!string.IsNullOrEmpty(Configuration.Settings.Tools.ChatGptApiKey))

--- a/src/libuilogic/AutoTranslate/DeepSeekTranslate.cs
+++ b/src/libuilogic/AutoTranslate/DeepSeekTranslate.cs
@@ -33,13 +33,18 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             "deepseek-v4-pro",
         };
 
+        /// <summary>
+        /// Endpoint used when the url in settings is only the service base - see <see cref="AutoTranslateUrl"/>.
+        /// </summary>
+        public const string DefaultUrl = "https://api.deepseek.com/chat/completions";
+
         public void Initialize()
         {
             _httpClient?.Dispose();
             _httpClient = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
-            _httpClient.BaseAddress = new Uri(Configuration.Settings.Tools.DeepSeekUrl.TrimEnd('/'));
+            _httpClient.BaseAddress = new Uri(AutoTranslateUrl.Complete(Configuration.Settings.Tools.DeepSeekUrl, DefaultUrl));
             _httpClient.Timeout = TimeSpan.FromMinutes(15);
 
             if (!string.IsNullOrEmpty(Configuration.Settings.Tools.DeepSeekApiKey))

--- a/src/libuilogic/AutoTranslate/GroqTranslate.cs
+++ b/src/libuilogic/AutoTranslate/GroqTranslate.cs
@@ -46,13 +46,18 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             "groq/compound-mini",                           // Smaller compound system
         };
 
+        /// <summary>
+        /// Endpoint used when the url in settings is only the service base - see <see cref="AutoTranslateUrl"/>.
+        /// </summary>
+        public const string DefaultUrl = "https://api.groq.com/openai/v1/chat/completions";
+
         public void Initialize()
         {
             _httpClient?.Dispose();
             _httpClient = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
-            _httpClient.BaseAddress = new Uri(Configuration.Settings.Tools.GroqUrl.TrimEnd('/'));
+            _httpClient.BaseAddress = new Uri(AutoTranslateUrl.Complete(Configuration.Settings.Tools.GroqUrl, DefaultUrl));
             _httpClient.Timeout = TimeSpan.FromMinutes(15);
 
             if (!string.IsNullOrEmpty(Configuration.Settings.Tools.GroqApiKey))

--- a/src/libuilogic/AutoTranslate/KoboldCppTranslate.cs
+++ b/src/libuilogic/AutoTranslate/KoboldCppTranslate.cs
@@ -24,13 +24,18 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
         public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1000;
 
+        /// <summary>
+        /// Endpoint used when the url in settings is only the service base - see <see cref="AutoTranslateUrl"/>.
+        /// </summary>
+        public const string DefaultUrl = "http://localhost:5001/api/generate/";
+
         public void Initialize()
         {
             _httpClient?.Dispose();
             _httpClient = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
-            _httpClient.BaseAddress = new Uri(Configuration.Settings.Tools.KoboldCppUrl.TrimEnd('/'));
+            _httpClient.BaseAddress = new Uri(AutoTranslateUrl.Complete(Configuration.Settings.Tools.KoboldCppUrl, DefaultUrl));
             _httpClient.Timeout = TimeSpan.FromMinutes(25);
         }
 

--- a/src/libuilogic/AutoTranslate/LlamaCppTranslate.cs
+++ b/src/libuilogic/AutoTranslate/LlamaCppTranslate.cs
@@ -24,13 +24,18 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
         public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1000;
 
+        /// <summary>
+        /// Endpoint used when the url in settings is only the service base - see <see cref="AutoTranslateUrl"/>.
+        /// </summary>
+        public const string DefaultUrl = "http://localhost:8080/v1/chat/completions";
+
         public void Initialize()
         {
             _httpClient?.Dispose();
             _httpClient = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
-            _httpClient.BaseAddress = new Uri(Configuration.Settings.Tools.LlamaCppApiUrl.TrimEnd('/'));
+            _httpClient.BaseAddress = new Uri(AutoTranslateUrl.Complete(Configuration.Settings.Tools.LlamaCppApiUrl, DefaultUrl));
             _httpClient.Timeout = TimeSpan.FromMinutes(15);
         }
 

--- a/src/libuilogic/AutoTranslate/LmStudioTranslate.cs
+++ b/src/libuilogic/AutoTranslate/LmStudioTranslate.cs
@@ -24,13 +24,18 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
         public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1000;
 
+        /// <summary>
+        /// Endpoint used when the url in settings is only the service base - see <see cref="AutoTranslateUrl"/>.
+        /// </summary>
+        public const string DefaultUrl = "http://localhost:1234/v1/chat/completions/";
+
         public void Initialize()
         {
             _httpClient?.Dispose();
             _httpClient = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
-            _httpClient.BaseAddress = new Uri(Configuration.Settings.Tools.LmStudioApiUrl.TrimEnd('/'));
+            _httpClient.BaseAddress = new Uri(AutoTranslateUrl.Complete(Configuration.Settings.Tools.LmStudioApiUrl, DefaultUrl));
             _httpClient.Timeout = TimeSpan.FromMinutes(15);
         }
 

--- a/src/libuilogic/AutoTranslate/MistralTranslate.cs
+++ b/src/libuilogic/AutoTranslate/MistralTranslate.cs
@@ -40,6 +40,11 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             "ministral-8b-latest",      // Ministral 3 8B — lightweight, fast
         };
 
+        /// <summary>
+        /// Endpoint used when the url in settings is only the service base - see <see cref="AutoTranslateUrl"/>.
+        /// </summary>
+        public const string DefaultUrl = "https://api.mistral.ai/v1/chat/completions";
+
         public void Initialize()
         {
             _apiKey = Configuration.Settings.Tools.AutoTranslateMistralApiKey;
@@ -51,7 +56,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             }
 
             _httpClient = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
-            _httpClient.BaseAddress = new Uri(_apiUrl.Trim().TrimEnd('/'));
+            _httpClient.BaseAddress = new Uri(AutoTranslateUrl.Complete(_apiUrl, DefaultUrl));
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", "Bearer " + _apiKey.Trim());
         }
 

--- a/src/libuilogic/AutoTranslate/NvidiaTranslate.cs
+++ b/src/libuilogic/AutoTranslate/NvidiaTranslate.cs
@@ -82,13 +82,18 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             "microsoft/phi-3.5-moe-instruct",
         };
 
+        /// <summary>
+        /// Endpoint used when the url in settings is only the service base - see <see cref="AutoTranslateUrl"/>.
+        /// </summary>
+        public const string DefaultUrl = "https://integrate.api.nvidia.com/v1/chat/completions";
+
         public void Initialize()
         {
             _httpClient?.Dispose();
             _httpClient = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
-            _httpClient.BaseAddress = new Uri(Configuration.Settings.Tools.NvidiaUrl.TrimEnd('/'));
+            _httpClient.BaseAddress = new Uri(AutoTranslateUrl.Complete(Configuration.Settings.Tools.NvidiaUrl, DefaultUrl));
             _httpClient.Timeout = TimeSpan.FromMinutes(15);
 
             if (!string.IsNullOrEmpty(Configuration.Settings.Tools.NvidiaApiKey))

--- a/src/libuilogic/AutoTranslate/OllamaTranslate.cs
+++ b/src/libuilogic/AutoTranslate/OllamaTranslate.cs
@@ -23,13 +23,18 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
         public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1000;
 
+        /// <summary>
+        /// Endpoint used when the url in settings is only the service base - see <see cref="AutoTranslateUrl"/>.
+        /// </summary>
+        public const string DefaultUrl = "http://localhost:11434/api/generate";
+
         public void Initialize()
         {
             _httpClient?.Dispose();
             _httpClient = new HttpClient();
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
-            _httpClient.BaseAddress = new Uri(Configuration.Settings.Tools.OllamaApiUrl.TrimEnd('/'));
+            _httpClient.BaseAddress = new Uri(AutoTranslateUrl.Complete(Configuration.Settings.Tools.OllamaApiUrl, DefaultUrl));
             _httpClient.Timeout = TimeSpan.FromMinutes(25);
         }
 

--- a/src/libuilogic/AutoTranslate/OpenAiCompatibleTranslate.cs
+++ b/src/libuilogic/AutoTranslate/OpenAiCompatibleTranslate.cs
@@ -29,13 +29,18 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
         public string Error { get; set; } = string.Empty;
         public int MaxCharacters => 1500;
 
+        /// <summary>
+        /// Endpoint used when the url in settings is only the service base - see <see cref="AutoTranslateUrl"/>.
+        /// </summary>
+        public const string DefaultUrl = "http://localhost:8000/v1/chat/completions";
+
         public void Initialize()
         {
             _httpClient?.Dispose();
             _httpClient = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
-            _httpClient.BaseAddress = new Uri(Configuration.Settings.Tools.OpenAiCompatibleTranslateUrl.TrimEnd('/'));
+            _httpClient.BaseAddress = new Uri(AutoTranslateUrl.Complete(Configuration.Settings.Tools.OpenAiCompatibleTranslateUrl, DefaultUrl));
             _httpClient.Timeout = TimeSpan.FromMinutes(15);
 
             if (!string.IsNullOrEmpty(Configuration.Settings.Tools.OpenAiCompatibleTranslateApiKey))

--- a/src/libuilogic/AutoTranslate/OpenRouterTranslate.cs
+++ b/src/libuilogic/AutoTranslate/OpenRouterTranslate.cs
@@ -58,13 +58,18 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             "qwen/qwen3-next-80b-a3b-instruct:free",    // Free-tier MoE alternative
         };
 
+        /// <summary>
+        /// Endpoint used when the url in settings is only the service base - see <see cref="AutoTranslateUrl"/>.
+        /// </summary>
+        public const string DefaultUrl = "https://openrouter.ai/api/v1/chat/completions";
+
         public void Initialize()
         {
             _httpClient?.Dispose();
             _httpClient = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
-            _httpClient.BaseAddress = new Uri(Configuration.Settings.Tools.OpenRouterUrl.TrimEnd('/'));
+            _httpClient.BaseAddress = new Uri(AutoTranslateUrl.Complete(Configuration.Settings.Tools.OpenRouterUrl, DefaultUrl));
             _httpClient.Timeout = TimeSpan.FromMinutes(15);
 
             if (!string.IsNullOrEmpty(Configuration.Settings.Tools.OpenRouterApiKey))

--- a/src/libuilogic/AutoTranslate/PerplexityTranslate.cs
+++ b/src/libuilogic/AutoTranslate/PerplexityTranslate.cs
@@ -43,13 +43,18 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             "perplexity/kimi-k2.7-code",
         };
 
+        /// <summary>
+        /// Endpoint used when the url in settings is only the service base - see <see cref="AutoTranslateUrl"/>.
+        /// </summary>
+        public const string DefaultUrl = "https://api.perplexity.ai/v1/responses";
+
         public void Initialize()
         {
             _httpClient?.Dispose();
             _httpClient = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
-            _httpClient.BaseAddress = new Uri(Configuration.Settings.Tools.PerplexityUrl.TrimEnd('/'));
+            _httpClient.BaseAddress = new Uri(AutoTranslateUrl.Complete(Configuration.Settings.Tools.PerplexityUrl, DefaultUrl));
             _httpClient.Timeout = TimeSpan.FromMinutes(15);
 
             if (!string.IsNullOrEmpty(Configuration.Settings.Tools.PerplexityApiKey))

--- a/src/seconv/Core/AutoTranslateRunner.cs
+++ b/src/seconv/Core/AutoTranslateRunner.cs
@@ -171,21 +171,11 @@ internal sealed class AutoTranslateRunner
     /// <summary>
     /// Completes a user-supplied --translate-url to the full chat/completions endpoint.
     /// Accepts a bare <c>host:port</c>, an OpenAI-style <c>.../v1</c> base (with or without
-    /// trailing slash), or an already-complete <c>.../chat/completions</c> URL — the old
-    /// <c>Contains("/v1/")</c> check missed the no-trailing-slash base form and produced
-    /// <c>.../v1/v1/chat/completions</c>.
+    /// trailing slash), or an already-complete <c>.../chat/completions</c> URL.
     /// </summary>
     internal static string CompleteChatCompletionsUrl(string url)
     {
-        var trimmed = url.TrimEnd('/');
-        if (trimmed.EndsWith("/chat/completions", StringComparison.OrdinalIgnoreCase))
-        {
-            return trimmed;
-        }
-
-        return trimmed.EndsWith("/v1", StringComparison.OrdinalIgnoreCase)
-            ? trimmed + "/chat/completions"
-            : trimmed + "/v1/chat/completions";
+        return AutoTranslateUrl.Complete(url, LlamaCppTranslate.DefaultUrl);
     }
 
     internal static TranslationPair ResolveLanguage(List<TranslationPair> languages, string requested, string kind)

--- a/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedTranslate.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedTranslate.cs
@@ -1,4 +1,5 @@
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
 
 namespace Nikse.SubtitleEdit.Features.Translate.LlamaCppAdvanced;
 
@@ -17,6 +18,6 @@ public class LlamaCppAdvancedTranslate : AdvancedTranslatorBase
 
     protected override string GetApiUrl()
     {
-        return Configuration.Settings.Tools.LlamaCppApiUrl;
+        return AutoTranslateUrl.Complete(Configuration.Settings.Tools.LlamaCppApiUrl, LlamaCppTranslate.DefaultUrl);
     }
 }

--- a/src/ui/Features/Translate/LlamaCppAdvanced/OllamaAdvancedTranslate.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/OllamaAdvancedTranslate.cs
@@ -1,4 +1,5 @@
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
 
 namespace Nikse.SubtitleEdit.Features.Translate.LlamaCppAdvanced;
 
@@ -16,9 +17,14 @@ public class OllamaAdvancedTranslate : AdvancedTranslatorBase
     public override string Name => StaticName;
     public override string Url => "https://ollama.com";
 
+    /// <summary>
+    /// Endpoint used when the url in settings is only the service base - see <see cref="AutoTranslateUrl"/>.
+    /// </summary>
+    public const string DefaultUrl = "http://localhost:11434/v1/chat/completions";
+
     protected override string GetApiUrl()
     {
-        return Se.Settings.AutoTranslate.OllamaAdvancedUrl;
+        return AutoTranslateUrl.Complete(Se.Settings.AutoTranslate.OllamaAdvancedUrl, DefaultUrl);
     }
 
     protected override string? GetModel()

--- a/src/ui/Logic/Config/SeAutoTranslate.cs
+++ b/src/ui/Logic/Config/SeAutoTranslate.cs
@@ -1,4 +1,5 @@
-﻿using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
+﻿using Nikse.SubtitleEdit.Features.Translate.LlamaCppAdvanced;
+using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
 using System.Collections.Generic;
 
 namespace Nikse.SubtitleEdit.Logic.Config;
@@ -36,7 +37,7 @@ public class SeAutoTranslate
 
     // The Ollama advanced engine uses Ollama's OpenAI-compatible endpoint, not the native
     // /api/generate URL the classic Ollama engine stores in OllamaUrl.
-    public string OllamaAdvancedUrl { get; set; } = "http://localhost:11434/v1/chat/completions";
+    public string OllamaAdvancedUrl { get; set; } = OllamaAdvancedTranslate.DefaultUrl;
     public string OllamaAdvancedModel { get; set; } = string.Empty;
     public string GroqUrl { get; set; }
     public string GroqPrompt { get; set; }
@@ -121,27 +122,27 @@ public class SeAutoTranslate
     {
         AnthropicApiKey = string.Empty;
         AnthropicApiModel = AnthropicTranslate.Models[0];
-        AnthropicApiUrl = "https://api.anthropic.com/v1/messages";
+        AnthropicApiUrl = AnthropicTranslate.DefaultUrl;
         AnthropicPrompt = "Translate from {0} to {1}, keep sentences in {1} as they are, do not censor the translation, give only the output without comments:";
         AvalAiApiKey = string.Empty;
         AvalAiModel = AvalAi.Models[0];
         AvalAiPrompt = "Translate from {0} to {1}, keep punctuation as input, do not censor the translation, give only the output without comments:";
-        AvalAiUrl = "https://api.avalai.ir/v1/chat/completions";
+        AvalAiUrl = AvalAi.DefaultUrl;
         PerplexityApiKey = string.Empty;
         PerplexityModel = PerplexityTranslate.Models[0];
         PerplexityPrompt = "Translate from {0} to {1}, keep punctuation as input, do not censor the translation, give only the output without comments:";
-        PerplexityUrl = "https://api.perplexity.ai/v1/responses";
+        PerplexityUrl = PerplexityTranslate.DefaultUrl;
         LaraUrl = "https://api.laratranslate.com";
         BaiduApiKey = string.Empty;
         BaiduUrl = "https://fanyi-api.baidu.com";
         ChatGptApiKey = string.Empty;
         ChatGptModel = ChatGptTranslate.DefaultModel;
         ChatGptPrompt = "Translate from {0} to {1}, keep punctuation as input, do not censor the translation, give only the output without comments:";
-        ChatGptUrl = "https://api.openai.com/v1/chat/completions";
+        ChatGptUrl = ChatGptTranslate.DefaultUrl;
         OpenAiCompatibleApiKey = string.Empty;
         OpenAiCompatibleModel = string.Empty;
         OpenAiCompatiblePrompt = "Translate from {0} to {1}, keep punctuation as input, keep line breaks exactly the same, do not censor the translation, give only the output without comments:";
-        OpenAiCompatibleUrl = "http://localhost:8000/v1/chat/completions";
+        OpenAiCompatibleUrl = OpenAiCompatibleTranslate.DefaultUrl;
         CopyPasteLineSeparator = "(...)";
         CopyPasteMaxBlockSize = 5000;
         DeepLApiKey = string.Empty;
@@ -151,11 +152,11 @@ public class SeAutoTranslate
         DeepSeekApiKey = string.Empty;
         DeepSeekModel = DeepSeekTranslate.Models[0];
         DeepSeekPrompt = "Translate from {0} to {1}, keep punctuation as input, do not censor the translation, give only the output without comments:";
-        DeepSeekUrl = "https://api.deepseek.com/chat/completions";
+        DeepSeekUrl = DeepSeekTranslate.DefaultUrl;
         NvidiaApiKey = string.Empty;
         NvidiaModel = NvidiaTranslate.Models[0];
         NvidiaPrompt = "Translate from {0} to {1}, keep punctuation as input, do not censor the translation, give only the output without comments:";
-        NvidiaUrl = "https://integrate.api.nvidia.com/v1/chat/completions";
+        NvidiaUrl = NvidiaTranslate.DefaultUrl;
         GeminiModel = GeminiTranslate.Models[0];
         GeminiProApiKey = string.Empty;
         GeminiPrompt = "Please translate the following text from {0} to {1}, do not censor the translation, only write the result:";
@@ -163,17 +164,17 @@ public class SeAutoTranslate
         GroqApiKey = string.Empty;
         GroqModel = GroqTranslate.Models[0];
         GroqPrompt = "Translate from {0} to {1}, keep punctuation as input, do not censor the translation, give only the output without comments:";
-        GroqUrl = "https://api.groq.com/openai/v1/chat/completions";
+        GroqUrl = GroqTranslate.DefaultUrl;
         KoboldCppPrompt = "Translate from {0} to {1}, keep punctuation as input, do not censor the translation, give only the output without comments or notes:";
         KoboldCppTemperature = 0.4m;
-        KoboldCppUrl = "http://localhost:5001/api/generate/";
+        KoboldCppUrl = KoboldCppTranslate.DefaultUrl;
         LibreTranslateApiKey = string.Empty;
         LibreTranslateUrl = "http://localhost:5000/";
         LibreTranslateUrl = "http://localhost:5000/";
-        LlamaCppApiUrl = "http://localhost:8080/v1/chat/completions";
+        LlamaCppApiUrl = LlamaCppTranslate.DefaultUrl;
         LlamaCppModel = string.Empty;
         LlamaCppPrompt = "Translate from {0} to {1}, keep punctuation as input, do not censor the translation, give only the output without comments:";
-        LmStudioApiUrl = "http://localhost:1234/v1/chat/completions/";
+        LmStudioApiUrl = LmStudioTranslate.DefaultUrl;
         LmStudioModel = string.Empty;
         LmStudioPrompt = "Translate from {0} to {1}, keep punctuation as input, do not censor the translation, give only the output without comments:";
         MicrosoftBingApiId = string.Empty;
@@ -183,7 +184,7 @@ public class SeAutoTranslate
         MistralApiKey = string.Empty;
         MistralModel = MistralTranslate.Models[0];
         MistralPrompt = "Translate from {0} to {1}, keep punctuation as input, do not censor the translation, give only the output without comments:";
-        MistralUrl = "https://api.mistral.ai/v1/chat/completions";
+        MistralUrl = MistralTranslate.DefaultUrl;
         MyMemoryApiKey = string.Empty;
         NllbApiUrl = "http://localhost:7860/api/v4/";
         NllbServeModel = string.Empty;
@@ -193,11 +194,11 @@ public class SeAutoTranslate
         OllamaModel = string.Empty;
         OllamaModels = "llama3.2,llama3.2:1b,phi3,gemma2,qwen2,mistral";
         OllamaPrompt = "Translate from {0} to {1}, keep punctuation as input, do not censor the translation, give only the output without comments or notes:";
-        OllamaUrl = "http://localhost:11434/api/generate";
+        OllamaUrl = OllamaTranslate.DefaultUrl;
         OpenRouterApiKey = string.Empty;
         OpenRouterModel = OpenRouterTranslate.Models[0];
         OpenRouterPrompt = "Translate from {0} to {1}, keep punctuation as input, do not censor the translation, give only the output without comments:";
-        OpenRouterUrl = "https://openrouter.ai/api/v1/chat/completions";
+        OpenRouterUrl = OpenRouterTranslate.DefaultUrl;
         PapagoApiKey = string.Empty;
         PapagoApiKeyId = string.Empty;
         RequestMaxBytes = 1000;

--- a/tests/libuilogic/AutoTranslate/AutoTranslateUrlTests.cs
+++ b/tests/libuilogic/AutoTranslate/AutoTranslateUrlTests.cs
@@ -1,0 +1,78 @@
+using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
+
+namespace LibUiLogicTests.AutoTranslate;
+
+public class AutoTranslateUrlTests
+{
+    [Theory]
+    // The #13044 case: DeepSeek documents "https://api.deepseek.com" as the base url for the
+    // OpenAI SDK, so that is what users paste - and posting to the origin root gives 404.
+    [InlineData("https://api.deepseek.com", "https://api.deepseek.com/chat/completions")]
+    [InlineData("https://api.deepseek.com/", "https://api.deepseek.com/chat/completions")]
+    [InlineData("https://api.openai.com", "https://api.openai.com/v1/chat/completions")]
+    // A leading part of the endpoint path is completed too, without doubling it.
+    [InlineData("https://api.openai.com/v1", "https://api.openai.com/v1/chat/completions")]
+    [InlineData("https://api.openai.com/v1/", "https://api.openai.com/v1/chat/completions")]
+    public void Complete_AddsMissingEndpointPath(string url, string expected)
+    {
+        var defaultUrl = url.Contains("deepseek")
+            ? DeepSeekTranslate.DefaultUrl
+            : ChatGptTranslate.DefaultUrl;
+
+        Assert.Equal(expected, AutoTranslateUrl.Complete(url, defaultUrl));
+    }
+
+    [Theory]
+    [InlineData("https://api.groq.com", "https://api.groq.com/openai/v1/chat/completions")]
+    [InlineData("https://api.groq.com/openai", "https://api.groq.com/openai/v1/chat/completions")]
+    [InlineData("https://api.groq.com/openai/v1", "https://api.groq.com/openai/v1/chat/completions")]
+    public void Complete_HandlesMultiSegmentEndpointPaths(string url, string expected)
+    {
+        Assert.Equal(expected, AutoTranslateUrl.Complete(url, GroqTranslate.DefaultUrl));
+    }
+
+    [Theory]
+    // Already complete - only the trailing slash goes.
+    [InlineData("http://localhost:8080/v1/chat/completions")]
+    [InlineData("http://localhost:8080/v1/chat/completions/")]
+    // A deliberate endpoint that is not part of the default path must survive untouched, e.g.
+    // llama.cpp's native completion route or a proxy with its own routing.
+    [InlineData("http://localhost:8080/completion")]
+    [InlineData("https://my-proxy.example.com/openai/deployments/gpt/chat/completions")]
+    public void Complete_LeavesAnExplicitPathAlone(string url)
+    {
+        Assert.Equal(url.TrimEnd('/'), AutoTranslateUrl.Complete(url, LlamaCppTranslate.DefaultUrl));
+    }
+
+    [Fact]
+    public void Complete_KeepsQueryStringUrlsVerbatim()
+    {
+        const string url = "https://my-proxy.example.com?route=chat";
+
+        Assert.Equal(url, AutoTranslateUrl.Complete(url, ChatGptTranslate.DefaultUrl));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void Complete_FallsBackToTheDefaultWhenEmpty(string? url)
+    {
+        Assert.Equal(ChatGptTranslate.DefaultUrl, AutoTranslateUrl.Complete(url, ChatGptTranslate.DefaultUrl));
+    }
+
+    [Fact]
+    public void Complete_LeavesNonUrlTextAlone()
+    {
+        Assert.Equal("not a url", AutoTranslateUrl.Complete("not a url", ChatGptTranslate.DefaultUrl));
+    }
+
+    [Fact]
+    public void Complete_CompletesNativeEndpointsToo()
+    {
+        // Ollama and KoboldCpp are not chat/completions services - the default path decides.
+        Assert.Equal("http://localhost:11434/api/generate", AutoTranslateUrl.Complete("http://localhost:11434", OllamaTranslate.DefaultUrl));
+        Assert.Equal("http://localhost:5001/api/generate", AutoTranslateUrl.Complete("http://localhost:5001", KoboldCppTranslate.DefaultUrl));
+        Assert.Equal("https://api.anthropic.com/v1/messages", AutoTranslateUrl.Complete("https://api.anthropic.com", AnthropicTranslate.DefaultUrl));
+    }
+}


### PR DESCRIPTION
Fixes #13044.

DeepSeek (and most other providers) document the *service base* — `https://api.deepseek.com` — because that is what the OpenAI SDK wants. Paste that into Subtitle Edit's API url box and every request goes to the origin root, which answers **404 Not Found** with nothing hinting that the url is the problem. The default SE ships (`https://api.deepseek.com/chat/completions`) is correct; the trap is only hit once a user edits the field.

### What this does

New `AutoTranslateUrl.Complete(url, defaultUrl)` in libuilogic:

- a url that is **only an origin** (`https://api.deepseek.com`) gets the engine's default endpoint path appended
- a url that is a **leading part** of the default path (`/v1`, `https://api.groq.com/openai/v1`) is completed without doubling anything
- a url with **a path of its own** is left exactly as typed — llama.cpp's native `/completion`, Azure-style deployment routes, or any proxy with its own routing keep working
- urls with a query string, non-urls, and already-complete urls are untouched

Because the *engine's own default path* decides what gets appended, this is not chat/completions-specific: Ollama completes to `/api/generate`, KoboldCpp to `/api/generate`, Anthropic to `/v1/messages`, Perplexity to `/v1/responses`.

Applied to every engine that posts to `BaseAddress` root: ChatGPT, OpenAI-compatible, DeepSeek, Groq, Mistral, Nvidia, OpenRouter, AvalAI, Perplexity, Anthropic, Ollama, KoboldCpp, LM Studio, llama.cpp, plus the two advanced engines.

Each engine now owns its endpoint as a `DefaultUrl` const, and `SeAutoTranslate` seeds its defaults from those consts instead of repeating the literals. `seconv`'s `CompleteChatCompletionsUrl` delegates to the shared helper (its existing tests pass unchanged, and it no longer mangles `.../completion` into `.../completion/v1/chat/completions`).

### Testing

New `AutoTranslateUrlTests` (13 cases) covering completion, non-doubling, explicit paths, query strings, empty/invalid input, and the native-endpoint engines. `LibUiLogicTests` 140/140, `SeConvTests` and `UITests` pass except two failures that also fail on `main` (`VobSubPaletteTest`, `SubtitleGridScrollPerformanceTests`) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)