### PR TITLE
Fix empty preview in the track pickers on open

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1259,6 +1259,7 @@
     "loadXFromFile": "Load \"{0}\" from file",
     "saveCompareHtmlTitle": "Save compare HTML file",
     "pickMatroskaTrackX": "Pick Matroska track - {0}",
+    "pickTransportStreamTrackX": "Pick transport stream track - {0}",
     "rosettaProperties": "Timed Text Rosetta IMSC properties",
     "rosettaFontSize": "Font size (row height)",
     "xProperties": "{0} properties"

--- a/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackViewModel.cs
+++ b/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackViewModel.cs
@@ -414,6 +414,12 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
 
         Dispatcher.UIThread.Post(() =>
         {
+            // Select via the view model, not just the grid index: the tracks TableView is created
+            // with SelectionMode.AlwaysSelected, so it auto-selects row 0 while its SelectedItem
+            // binding is still being set up. Assigning the same index back is then a no-op that
+            // raises no SelectionChanged, so SelectedTrack stayed null - the preview pane opened
+            // empty (and OK picked nothing) until another track was clicked and back again.
+            SelectedTrack = Tracks[index];
             TracksGrid.SelectedIndex = index;
             if (TracksGrid.SelectedItem is { } selectedItem)
             {

--- a/src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs
+++ b/src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs
@@ -250,6 +250,10 @@ public partial class PickMp4TrackViewModel : ObservableObject
 
         Dispatcher.UIThread.Post(() =>
         {
+            // Select via the view model, not just the grid index - see the same fix in
+            // PickMatroskaTrackViewModel: AlwaysSelected has already put the grid on row 0, so
+            // re-assigning the index raises no SelectionChanged and SelectedTrack stayed null.
+            SelectedTrack = Tracks[index];
             TracksGrid.SelectedIndex = index;
             if (TracksGrid.SelectedItem is { } selectedItem)
             {

--- a/src/ui/Features/Shared/PickTsTrack/PickTsTrackViewModel.cs
+++ b/src/ui/Features/Shared/PickTsTrack/PickTsTrackViewModel.cs
@@ -43,6 +43,8 @@ public partial class PickTsTrackViewModel : ObservableObject
     internal void Initialize(TransportStreamParser tsParser, string fileName)
     {
         _tsParser = tsParser;
+        _fileName = fileName;
+        WindowTitle = string.Format(Se.Language.File.PickTransportStreamTrackX, fileName);
 
         var programMapTableParser = new ProgramMapTableParser();
         programMapTableParser.Parse(fileName); // get languages
@@ -161,7 +163,15 @@ public partial class PickTsTrackViewModel : ObservableObject
             return true;
         }
 
+        // GetDvbSubtitles returns null for a packet id it decoded no images for - a subtitle PID
+        // announced by the stream is not a guarantee that anything came out of it.
         var subtitles = _tsParser.GetDvbSubtitles(selectedTrack.TrackNumber);
+        if (subtitles == null)
+        {
+            SubtitleCountText = string.Empty;
+            return false;
+        }
+
         SubtitleCountText = string.Format(Se.Language.File.Import.NumberOfSubtitlesX, subtitles.Count);
         for (var i = 0; i < 20 && i < subtitles.Count; i++)
         {
@@ -189,6 +199,11 @@ public partial class PickTsTrackViewModel : ObservableObject
 
         Dispatcher.UIThread.Post(() =>
         {
+            // Select via the view model, not just the grid index - see the same fix in
+            // PickMatroskaTrackViewModel: AlwaysSelected has already put the grid on row 0, so
+            // re-assigning the index raises no SelectionChanged and SelectedTrack stayed null,
+            // which left the preview empty and made OK return no track at all.
+            SelectedTrack = Tracks[index];
             TracksGrid.SelectedIndex = index;
             if (TracksGrid.SelectedItem is { } selectedItem)
             {

--- a/src/ui/Features/Shared/PickVobSubLanguage/PickVobSubLanguageViewModel.cs
+++ b/src/ui/Features/Shared/PickVobSubLanguage/PickVobSubLanguageViewModel.cs
@@ -151,6 +151,11 @@ public partial class PickVobSubLanguageViewModel : ObservableObject
 
         Dispatcher.UIThread.Post(() =>
         {
+            // Select via the view model, not just the grid index - see the same fix in
+            // PickMatroskaTrackViewModel: AlwaysSelected has already put the grid on row 0, so
+            // re-assigning the index raises no SelectionChanged and SelectedLanguage stayed null,
+            // which left the preview empty and made OK do nothing.
+            SelectedLanguage = Languages[index];
             LanguagesGrid.SelectedIndex = index;
             if (LanguagesGrid.SelectedItem is { } selectedItem)
             {

--- a/src/ui/Logic/Config/Language/File/LanguageFile.cs
+++ b/src/ui/Logic/Config/Language/File/LanguageFile.cs
@@ -28,6 +28,7 @@ public class LanguageFile
     public string LoadXFromFile { get; set; }
     public string SaveCompareHtmlTitle { get; set; }
     public string PickMatroskaTrackX { get; set; }
+    public string PickTransportStreamTrackX { get; set; }
     public string RosettaProperties { get; set; }
     public string RosettaFontSize { get; set; }
     public string XProperties { get; set; }
@@ -51,6 +52,7 @@ public class LanguageFile
         LoadXFromFile = "Load \"{0}\" from file";
         SaveCompareHtmlTitle = "Save compare HTML file";
         PickMatroskaTrackX = "Pick Matroska track - {0}";
+        PickTransportStreamTrackX = "Pick transport stream track - {0}";
         RosettaProperties = "Timed Text Rosetta IMSC properties";
         RosettaFontSize = "Font size (row height)";
         XProperties = "{0} properties";

--- a/tests/UI/Features/Shared/PickTrackWindowSelectionTests.cs
+++ b/tests/UI/Features/Shared/PickTrackWindowSelectionTests.cs
@@ -1,0 +1,235 @@
+﻿using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.ContainerFormats.Matroska;
+using Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream;
+using Nikse.SubtitleEdit.Core.VobSub;
+using Nikse.SubtitleEdit.Features.Shared.PickMatroskaTrack;
+using Nikse.SubtitleEdit.Features.Shared.PickMp4Track;
+using Nikse.SubtitleEdit.Features.Shared.PickTsTrack;
+using Nikse.SubtitleEdit.Features.Shared.PickVobSubLanguage;
+using SkiaSharp;
+
+namespace UITests.Features.Shared;
+
+/// <summary>
+/// The track/language pickers only open when a file holds more than one track, so the initial
+/// selection has to reach the view model on its own. The tracks grid is created with
+/// SelectionMode.AlwaysSelected, which puts it on row 0 before the SelectedItem binding is wired
+/// up - so re-assigning index 0 afterwards raised no SelectionChanged and the view model's
+/// selection stayed null: the preview pane opened empty and OK picked nothing, until the user
+/// clicked another row and back again.
+/// </summary>
+public class PickTrackWindowSelectionTests
+{
+    private static PickMatroskaTrackViewModel MakeMatroskaViewModel(int trackCount)
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        var provider = services.BuildServiceProvider();
+        var vm = provider.GetRequiredService<PickMatroskaTrackViewModel>();
+
+        var tracks = new List<MatroskaTrackInfo>();
+        for (var i = 0; i < trackCount; i++)
+        {
+            tracks.Add(new MatroskaTrackInfo
+            {
+                TrackNumber = i + 1,
+                IsSubtitle = true,
+                CodecId = "S_TEXT/UTF8",
+                Language = "eng",
+                Name = $"Track {i + 1}",
+            });
+        }
+
+        // No MatroskaFile: the preview build bails out early, which keeps the test off the disk
+        // while still exercising the selection plumbing.
+        vm.Initialize(null!, tracks, "test.mkv");
+        return vm;
+    }
+
+    [AvaloniaFact]
+    public void PickMatroskaTrackWindow_SelectsFirstTrackInViewModelOnOpen()
+    {
+        var vm = MakeMatroskaViewModel(2);
+        var window = new PickMatroskaTrackWindow(vm);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Same(vm.Tracks[0], vm.SelectedTrack);
+        Assert.Equal(0, vm.TracksGrid.SelectedIndex);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void PickMatroskaTrackWindow_OkUsesTheInitiallySelectedTrackWithoutAClick()
+    {
+        var vm = MakeMatroskaViewModel(2);
+        var window = new PickMatroskaTrackWindow(vm);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        vm.OkCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(vm.OkPressed);
+        Assert.NotNull(vm.SelectedMatroskaTrack);
+        Assert.Equal(1, vm.SelectedMatroskaTrack!.TrackNumber);
+    }
+
+    private static PickMp4TrackViewModel MakeMp4ViewModel(int trackCount)
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        var provider = services.BuildServiceProvider();
+        var vm = provider.GetRequiredService<PickMp4TrackViewModel>();
+
+        for (var i = 0; i < trackCount; i++)
+        {
+            // No Trak: the preview build bails out early, which keeps the test off the disk while
+            // still exercising the selection plumbing.
+            vm.Tracks.Add(new Mp4TrackInfoDisplay { HandlerType = "sbtl", Track = null });
+        }
+
+        return vm;
+    }
+
+    [AvaloniaFact]
+    public void PickMp4TrackWindow_SelectsFirstTrackInViewModelOnOpen()
+    {
+        var vm = MakeMp4ViewModel(2);
+        var window = new PickMp4TrackWindow(vm);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Same(vm.Tracks[0], vm.SelectedTrack);
+        Assert.Equal(0, vm.TracksGrid.SelectedIndex);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void PickMp4TrackWindow_OkUsesTheInitiallySelectedTrackWithoutAClick()
+    {
+        var vm = MakeMp4ViewModel(2);
+        var window = new PickMp4TrackWindow(vm);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        vm.OkCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(vm.OkPressed);
+        Assert.Same(vm.Tracks[0], vm.SelectedMatroskaTrack);
+    }
+
+    private static PickTsTrackViewModel MakeTsViewModel(int trackCount)
+    {
+        // A stream with no sync bytes parses to zero tracks, which is all Initialize needs here -
+        // it is called for the window title, and the tracks are added the way it would add them.
+        var tsParser = new TransportStreamParser();
+        tsParser.Parse(new MemoryStream(new byte[4096]), null!);
+
+        var vm = new PickTsTrackViewModel();
+        vm.Initialize(tsParser, @"C:\video\movie.ts");
+
+        for (var i = 0; i < trackCount; i++)
+        {
+            vm.Tracks.Add(new TsTrackInfoDisplay
+            {
+                TrackNumber = 4096 + i,
+                Language = "eng",
+                Codec = "DVB",
+            });
+        }
+
+        return vm;
+    }
+
+    [AvaloniaFact]
+    public void PickTsTrackWindow_SelectsFirstTrackInViewModelOnOpen()
+    {
+        var vm = MakeTsViewModel(2);
+        var window = new PickTsTrackWindow(vm);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Same(vm.Tracks[0], vm.SelectedTrack);
+        Assert.Equal(0, vm.TracksGrid.SelectedIndex);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void PickTsTrackWindow_HasATitle()
+    {
+        var vm = MakeTsViewModel(2);
+        var window = new PickTsTrackWindow(vm);
+
+        // The view model left WindowTitle empty, so the window opened with no title at all.
+        Assert.Contains("movie.ts", window.Title);
+    }
+
+    private static PickVobSubLanguageViewModel MakeVobSubViewModel(int languageCount)
+    {
+        var streamIdDictionary = new Dictionary<int, List<VobSubMergedPack>>();
+        var idxLanguages = new List<string>();
+        for (var i = 0; i < languageCount; i++)
+        {
+            var streamId = 0x20 + i;
+
+            // No packs: the preview stays empty, which keeps the test off image decoding.
+            streamIdDictionary.Add(streamId, new List<VobSubMergedPack>());
+            idxLanguages.Add($"English (0x{streamId:x})");
+        }
+
+        var vm = new PickVobSubLanguageViewModel();
+        vm.Initialize(streamIdDictionary, new List<SKColor>(), idxLanguages, @"C:\video\movie.idx");
+        return vm;
+    }
+
+    [AvaloniaFact]
+    public void PickVobSubLanguageWindow_SelectsFirstLanguageInViewModelOnOpen()
+    {
+        var vm = MakeVobSubViewModel(2);
+        var window = new PickVobSubLanguageWindow(vm);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Same(vm.Languages[0], vm.SelectedLanguage);
+        Assert.Equal(0, vm.LanguagesGrid.SelectedIndex);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void PickVobSubLanguageWindow_OkUsesTheInitiallySelectedLanguageWithoutAClick()
+    {
+        var vm = MakeVobSubViewModel(2);
+        var window = new PickVobSubLanguageWindow(vm);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        vm.OkCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(vm.OkPressed);
+        Assert.Equal(0x20, vm.SelectedStreamId);
+    }
+}


### PR DESCRIPTION
When opening a file with more than one subtitle track, the pick-track window opened with an empty preview pane - it only filled in after clicking another track and back again. Pressing OK straight away picked no track at all.

## Cause

The tracks grid is created with `SelectionMode.AlwaysSelected`, so it auto-selects row 0 the moment `ItemsSource` is assigned - before its `SelectedItem` binding and `SelectionChanged` handler are attached. The `Loaded` handler then called `SelectAndScrollToRow(0)`, which only assigned the same index back: no `SelectionChanged`, so nothing was ever pushed into the view model and its selection stayed `null`. Clicking another track was a real selection change, which is why it started working from then on.

## Fix

Select through the view-model property, which is the source of truth for both the preview and OK. Applied to all four pickers with this shape:

- `PickMatroskaTrackViewModel` (.mkv - reported)
- `PickMp4TrackViewModel` (.mp4)
- `PickTsTrackViewModel` (.ts)
- `PickVobSubLanguageViewModel` (VobSub language pick - its OK returned early on a null selection, so it did nothing at all)

Two extra fixes in the transport stream picker:

- `Initialize` never set `WindowTitle`, so the window opened untitled. It now uses a new `pickTransportStreamTrackX` language string, matching the Matroska picker.
- `TransportStreamParser.GetDvbSubtitles` returns `null` for a packet id it decoded no images for - a subtitle PID announced by the stream is no guarantee that anything came out of it - and the preview dereferenced it straight away. Guarded.

## Tests

New `PickTrackWindowSelectionTests` (headless Avalonia) covers all four pickers: the first track is selected in the view model on open, and OK returns that track without a click, plus the transport stream window title. All 8 fail before the change and pass after; full UI suite green (1033 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)