### PR TITLE
Fix pre-populated grids opening with no view-model selection

### DIFF
--- a/src/ui/Features/Shared/ErrorList/ErrorListViewModel.cs
+++ b/src/ui/Features/Shared/ErrorList/ErrorListViewModel.cs
@@ -56,13 +56,16 @@ public partial class ErrorListViewModel : ObservableObject
         {
             Subtitles.Add(item);
         }
-
-        HasErrors = SelectedSubtitle != null;
     }
 
-    internal void GridSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    /// <summary>
+    /// Follows the selection itself instead of the grid's SelectionChanged event: the row the
+    /// grid selects on its own (AlwaysSelected) never raises that event, which left Go to
+    /// disabled while row 0 looked selected.
+    /// </summary>
+    partial void OnSelectedSubtitleChanged(ErrorListItem? value)
     {
-        HasErrors = SelectedSubtitle != null;
+        HasErrors = value != null;
     }
 
     internal void OnBookmarksGridDoubleTapped(object? sender, TappedEventArgs e)

--- a/src/ui/Features/Shared/ErrorList/ErrorListWindow.cs
+++ b/src/ui/Features/Shared/ErrorList/ErrorListWindow.cs
@@ -95,12 +95,7 @@ public class ErrorListWindow : Window
             Width = new GridLength(1, GridUnitType.Star) // star sizing to take all available space
         });
 
-        dataGrid.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle))
-        {
-            Source = vm,
-            Mode = BindingMode.TwoWay
-        });
-        dataGrid.SelectionChanged += vm.GridSelectionChanged;
+        TableViewExtras.BindSelectedItem(dataGrid, vm, nameof(vm.SelectedSubtitle));
         dataGrid.DoubleTapped += (s, e) => vm.GoToCommand.Execute(null);    
         dataGrid.KeyDown += (s, e) => vm.GridKeyDown(e);
         dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>

--- a/src/ui/Features/SpellCheck/FindDoubleLines/FindDoubleLinesViewModel.cs
+++ b/src/ui/Features/SpellCheck/FindDoubleLines/FindDoubleLinesViewModel.cs
@@ -90,9 +90,14 @@ public partial class FindDoubleLinesViewModel : ObservableObject
         HasDoubleLines = Subtitles.Count > 0;
     }
 
-    internal void GridSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    /// <summary>
+    /// Follows the selection itself instead of the grid's SelectionChanged event: the row the
+    /// grid selects on its own (AlwaysSelected) never raises that event, which left Go to
+    /// disabled while row 0 looked selected.
+    /// </summary>
+    partial void OnSelectedSubtitleChanged(DoubleLineItem? value)
     {
-        HasDoubleLines = SelectedSubtitle != null;
+        HasDoubleLines = value != null;
     }
 
     internal void OnBookmarksGridDoubleTapped(object? sender, TappedEventArgs e)

--- a/src/ui/Features/SpellCheck/FindDoubleLines/FindDoubleLinesWindow.cs
+++ b/src/ui/Features/SpellCheck/FindDoubleLines/FindDoubleLinesWindow.cs
@@ -87,12 +87,7 @@ public class FindDoubleLinesWindow : Window
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
 
-        tableView.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle))
-        {
-            Source = vm,
-            Mode = BindingMode.TwoWay
-        });
-        tableView.SelectionChanged += vm.GridSelectionChanged;
+        TableViewExtras.BindSelectedItem(tableView, vm, nameof(vm.SelectedSubtitle));
         tableView.DoubleTapped += (s, e) => vm.GoToCommand.Execute(null);
         tableView.KeyDown += (s, e) => vm.GridKeyDown(e);
         tableView.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>

--- a/src/ui/Features/SpellCheck/FindDoubleWords/FindDoubleWordsViewModel.cs
+++ b/src/ui/Features/SpellCheck/FindDoubleWords/FindDoubleWordsViewModel.cs
@@ -65,8 +65,16 @@ public partial class FindDoubleWordsViewModel : ObservableObject
                 Subtitles.Add(new DoubleWordItem(subtitleLine, doubleWord));
             }
         }
+    }
 
-        HasDoubleWords = SelectedSubtitle != null;
+    /// <summary>
+    /// Follows the selection itself instead of the grid's SelectionChanged event: the row the
+    /// grid selects on its own (AlwaysSelected) never raises that event, which left Go to
+    /// disabled while row 0 looked selected.
+    /// </summary>
+    partial void OnSelectedSubtitleChanged(DoubleWordItem? value)
+    {
+        HasDoubleWords = value != null;
     }
 
     private string GetDoubleWordMatch(string input)
@@ -130,11 +138,6 @@ public partial class FindDoubleWordsViewModel : ObservableObject
         }
 
         return true;
-    }
-
-    internal void GridSelectionChanged(object? sender, SelectionChangedEventArgs e)
-    {
-        HasDoubleWords = SelectedSubtitle != null;
     }
 
     internal void OnBookmarksGridDoubleTapped(object? sender, TappedEventArgs e)

--- a/src/ui/Features/SpellCheck/FindDoubleWords/FindDoubleWordsWindow.cs
+++ b/src/ui/Features/SpellCheck/FindDoubleWords/FindDoubleWordsWindow.cs
@@ -95,12 +95,7 @@ public class FindDoubleWordsWindow : Window
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
 
-        tableView.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle))
-        {
-            Source = vm,
-            Mode = BindingMode.TwoWay
-        });
-        tableView.SelectionChanged += vm.GridSelectionChanged;
+        TableViewExtras.BindSelectedItem(tableView, vm, nameof(vm.SelectedSubtitle));
         tableView.DoubleTapped += (s, e) => vm.GoToCommand.Execute(null);
         tableView.KeyDown += (s, e) => vm.GridKeyDown(e);
         tableView.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -2643,6 +2643,13 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     {
         UiUtil.RestoreWindowPosition(Window);
         ComboBoxSubtitleFormatChanged();
+
+        // Show the settings of the function the grid starts on. The functions list is built in
+        // the constructor, so the grid selects row 0 before its selection binding exists and no
+        // SelectionChanged is ever raised - the settings panel stayed blank until a function was
+        // clicked. Done here rather than at bind time because FunctionContainer is only replaced
+        // with the real ScrollViewer later in the window's layout.
+        SelectedFunctionChanged();
     }
 
     internal void OnClosing(object? sender, WindowClosingEventArgs e)

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
@@ -507,7 +507,7 @@ public class BatchConvertWindow : Window
                 Width = new GridLength(1, GridUnitType.Star),
             },
         });
-        dataGrid.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedBatchFunction)) { Source = vm });
+        TableViewExtras.BindSelectedItem(dataGrid, vm, nameof(vm.SelectedBatchFunction));
         // The DataGrid-era CheckboxMultiSelect helper is replaced by native selection,
         // AddSpaceToggle (Space toggles the checkbox) and a SelectionChanged hook that
         // shows the selected function's settings view (was onFocusedItemChanged).

--- a/src/ui/Features/Video/ShotChanges/ShotChangeListViewModel.cs
+++ b/src/ui/Features/Video/ShotChanges/ShotChangeListViewModel.cs
@@ -106,13 +106,16 @@ public partial class ShotChangeListViewModel : ObservableObject
         {
             ShotChanges.Add(new ShotChangeItem(ShotChanges.Count, time));
         }
-
-        HasShotChanges = SelectedShotChange != null;
     }
 
-    internal void GridSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    /// <summary>
+    /// Follows the selection itself instead of the grid's SelectionChanged event: the row the
+    /// grid selects on its own (AlwaysSelected) never raises that event, which left Go to and
+    /// Clear disabled while row 0 looked selected.
+    /// </summary>
+    partial void OnSelectedShotChangeChanged(ShotChangeItem? value)
     {
-        HasShotChanges = SelectedShotChange != null;
+        HasShotChanges = value != null;
     }
 
     internal void OnShotChangeGridDoubleTapped(object? sender, TappedEventArgs e)

--- a/src/ui/Features/Video/ShotChanges/ShotChangeListWindow.cs
+++ b/src/ui/Features/Video/ShotChanges/ShotChangeListWindow.cs
@@ -86,12 +86,7 @@ public class ShotChangeListWindow : Window
             CellTheme = UiUtil.TableViewCellTheme,
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
-        tableView.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedShotChange))
-        {
-            Source = vm,
-            Mode = BindingMode.TwoWay
-        });
-        tableView.SelectionChanged += vm.GridSelectionChanged;
+        TableViewExtras.BindSelectedItem(tableView, vm, nameof(vm.SelectedShotChange));
         tableView.DoubleTapped += (s, e) => vm.GoToCommand.Execute(null);
         tableView.KeyDown += (s, e) => vm.GridKeyDown(e);
         tableView.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>

--- a/src/ui/Logic/TableViewExtras.cs
+++ b/src/ui/Logic/TableViewExtras.cs
@@ -386,6 +386,41 @@ public static class TableViewExtras
     }
 
     /// <summary>
+    /// Two-way binds the TableView's selection to <paramref name="propertyName"/> on
+    /// <paramref name="viewModel"/>, and pushes the row the control has already selected into
+    /// that property when it is still null.
+    ///
+    /// <see cref="MakeTableView"/> keeps <see cref="SelectionMode.AlwaysSelected"/>, so the
+    /// control selects row 0 the moment ItemsSource is assigned - before this binding exists -
+    /// and a binding's first push goes source to target. For a list that was already populated
+    /// (the dialog pattern, where the view model is initialized before the window is built) the
+    /// grid therefore shows row 0 highlighted while the view model still sees null: previews
+    /// stay empty, OK picks nothing and "is anything selected" flags stay false, until the user
+    /// clicks another row and back again. Prefer this over binding SelectedItem by hand.
+    /// </summary>
+    public static void BindSelectedItem(TableView tableView, object viewModel, string propertyName)
+    {
+        tableView.Bind(TableView.SelectedItemProperty, new Binding(propertyName)
+        {
+            Source = viewModel,
+            Mode = BindingMode.TwoWay,
+        });
+
+        if (tableView.SelectedItem is not { } selected)
+        {
+            return;
+        }
+
+        var property = viewModel.GetType().GetProperty(propertyName);
+        if (property is { CanWrite: true } &&
+            property.GetValue(viewModel) == null &&
+            property.PropertyType.IsInstanceOfType(selected))
+        {
+            property.SetValue(viewModel, selected);
+        }
+    }
+
+    /// <summary>
     /// Moves keyboard focus to the selected row's container when it is realized, falling
     /// back to the TableView itself. Focusing the row (not the list control) is what makes
     /// the current line visible to screen readers via UI Automation (issue #13015).

--- a/tests/UI/Features/Shared/PrePopulatedGridSelectionTests.cs
+++ b/tests/UI/Features/Shared/PrePopulatedGridSelectionTests.cs
@@ -1,0 +1,127 @@
+﻿using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Shared.ErrorList;
+using Nikse.SubtitleEdit.Features.SpellCheck.FindDoubleLines;
+using Nikse.SubtitleEdit.Features.SpellCheck.FindDoubleWords;
+using Nikse.SubtitleEdit.Features.Tools.BatchConvert;
+using Nikse.SubtitleEdit.Features.Video.ShotChanges;
+
+namespace UITests.Features.Shared;
+
+/// <summary>
+/// Windows whose list is filled before the window is built used to open with row 0 highlighted
+/// but the view model's selection still null - so the buttons gated on "is anything selected"
+/// stayed disabled, and detail panes stayed blank, until the user clicked another row and back.
+/// </summary>
+public class PrePopulatedGridSelectionTests
+{
+    private static List<SubtitleLineViewModel> MakeLines(params string[] texts)
+    {
+        var lines = new List<SubtitleLineViewModel>();
+        for (var i = 0; i < texts.Length; i++)
+        {
+            lines.Add(new SubtitleLineViewModel(new Paragraph(texts[i], i * 2000, i * 2000 + 1500), null!)
+            {
+                Number = i + 1,
+            });
+        }
+
+        return lines;
+    }
+
+    private static void Show(Avalonia.Controls.Window window)
+    {
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    [AvaloniaFact]
+    public void ShotChangeListWindow_HasASelectionAndEnabledButtonsOnOpen()
+    {
+        var vm = new ShotChangeListViewModel();
+        vm.Initialize(new List<double> { 1.0, 2.5 });
+        var window = new ShotChangeListWindow(vm);
+
+        Show(window);
+
+        Assert.Same(vm.ShotChanges[0], vm.SelectedShotChange);
+        Assert.True(vm.HasShotChanges, "Go to / Clear are bound to HasShotChanges");
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void ErrorListWindow_HasASelectionAndAnEnabledGoToOnOpen()
+    {
+        var lines = MakeLines("First line", "Second line");
+        var vm = new ErrorListViewModel();
+        vm.Initialize(new List<ErrorListItem>
+        {
+            new(lines[0], null, lines[1]),
+            new(lines[1], lines[0], null),
+        });
+        var window = new ErrorListWindow(vm);
+
+        Show(window);
+
+        Assert.Same(vm.Subtitles[0], vm.SelectedSubtitle);
+        Assert.True(vm.HasErrors, "Go to is bound to HasErrors");
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void FindDoubleWordsWindow_HasASelectionAndAnEnabledGoToOnOpen()
+    {
+        var vm = new FindDoubleWordsViewModel();
+        vm.Initialize(MakeLines("This is is a test", "And and another one"));
+        var window = new FindDoubleWordsWindow(vm);
+
+        Show(window);
+
+        Assert.NotEmpty(vm.Subtitles);
+        Assert.Same(vm.Subtitles[0], vm.SelectedSubtitle);
+        Assert.True(vm.HasDoubleWords, "Go to is bound to HasDoubleWords");
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void FindDoubleLinesWindow_HasASelectionAndAnEnabledGoToOnOpen()
+    {
+        var vm = new FindDoubleLinesViewModel();
+        vm.Initialize(MakeLines("Same line", "Same line"));
+        var window = new FindDoubleLinesWindow(vm);
+
+        Show(window);
+
+        Assert.NotEmpty(vm.Subtitles);
+        Assert.Same(vm.Subtitles[0], vm.SelectedSubtitle);
+        Assert.True(vm.HasDoubleLines, "Go to is bound to HasDoubleLines");
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void BatchConvertWindow_ShowsTheFirstFunctionsSettingsOnOpen()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        var provider = services.BuildServiceProvider();
+        var vm = provider.GetRequiredService<BatchConvertViewModel>();
+        var window = new BatchConvertWindow(vm);
+
+        Show(window);
+
+        Assert.NotNull(vm.SelectedBatchFunction);
+        Assert.NotNull(vm.FunctionContainer.Content);
+
+        window.Close();
+    }
+}

--- a/tests/UI/Logic/TableViewBindSelectedItemTests.cs
+++ b/tests/UI/Logic/TableViewBindSelectedItemTests.cs
@@ -1,0 +1,107 @@
+﻿using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// TableViews from <see cref="TableViewExtras.MakeTableView"/> keep SelectionMode.AlwaysSelected,
+/// so the control selects row 0 as soon as ItemsSource is assigned - before any SelectedItem
+/// binding exists. A binding's first push goes source to target, so for a list that was already
+/// populated the grid ends up showing row 0 while the view model still sees null.
+/// <see cref="TableViewExtras.BindSelectedItem"/> is the fix; these tests pin both halves.
+/// </summary>
+public partial class ProbeViewModel : ObservableObject
+{
+    [ObservableProperty] private string? _selected;
+}
+
+public class TableViewBindSelectedItemTests
+{
+    private static TableView MakeGrid(params string[] items)
+    {
+        var grid = TableViewExtras.MakeTableView(multiSelect: false);
+        grid.Columns.Add(new SeTableViewColumn { Binding = new Binding(".") });
+        grid.ItemsSource = items.ToList();
+        return grid;
+    }
+
+    private static void Show(TableView grid)
+    {
+        var window = new Window { Content = grid };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    [AvaloniaFact]
+    public void PlainBind_LeavesTheViewModelOutOfSync()
+    {
+        // Documents the trap the helper exists for: the grid is on row 0, the view model is not.
+        var vm = new ProbeViewModel();
+        var grid = MakeGrid("a", "b");
+
+        grid.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.Selected)) { Source = vm });
+        Show(grid);
+
+        Assert.Equal(0, grid.SelectedIndex);
+        Assert.Null(vm.Selected);
+    }
+
+    [AvaloniaFact]
+    public void BindSelectedItem_PushesTheGridsInitialSelectionIntoTheViewModel()
+    {
+        var vm = new ProbeViewModel();
+        var grid = MakeGrid("a", "b");
+
+        TableViewExtras.BindSelectedItem(grid, vm, nameof(vm.Selected));
+        Show(grid);
+
+        Assert.Equal(0, grid.SelectedIndex);
+        Assert.Equal("a", vm.Selected);
+    }
+
+    [AvaloniaFact]
+    public void BindSelectedItem_KeepsAViewModelSelectionThatIsAlreadySet()
+    {
+        var vm = new ProbeViewModel { Selected = "b" };
+        var grid = MakeGrid("a", "b");
+
+        TableViewExtras.BindSelectedItem(grid, vm, nameof(vm.Selected));
+        Show(grid);
+
+        Assert.Equal("b", vm.Selected);
+        Assert.Equal(1, grid.SelectedIndex);
+    }
+
+    [AvaloniaFact]
+    public void BindSelectedItem_StillRoundTripsLaterSelectionChanges()
+    {
+        var vm = new ProbeViewModel();
+        var grid = MakeGrid("a", "b");
+
+        TableViewExtras.BindSelectedItem(grid, vm, nameof(vm.Selected));
+        Show(grid);
+
+        grid.SelectedIndex = 1;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("b", vm.Selected);
+    }
+
+    [AvaloniaFact]
+    public void BindSelectedItem_OnAnEmptyGridSelectsNothing()
+    {
+        var vm = new ProbeViewModel();
+        var grid = MakeGrid();
+
+        TableViewExtras.BindSelectedItem(grid, vm, nameof(vm.Selected));
+        Show(grid);
+
+        Assert.Null(vm.Selected);
+    }
+}


### PR DESCRIPTION
Follow-up to #13047. That PR fixed the four track pickers one by one; this one fixes the mechanism behind them and the remaining windows that hit it.

## The mechanism

`MakeTableView` keeps `SelectionMode.AlwaysSelected`, so a `TableView` selects row 0 the moment `ItemsSource` is assigned - which happens before the window attaches its `SelectedItem` binding. A binding''s first push goes source → target, so when the list was already populated (the dialog pattern, where the view model is initialized before the window is built) the grid ends up showing row 0 highlighted while the view model still sees `null`. Verified with a headless probe:

```
afterItemsSource=0  afterBind=0  afterShow=0  vm.Selected=<null>
```

Nothing looks wrong - the window just doesn''t work until the user clicks another row and back. Lists that are filled *after* the window is up (async loads, user adds files) were never affected: that selection change is a real one and the binding writes it through.

## The fix

`TableViewExtras.BindSelectedItem(tableView, viewModel, propertyName)` binds two-way and then pushes the row the control already selected into the view model when it is still null. Prefer it over binding `SelectedItem` by hand.

Applied to the windows where the null selection was actually visible:

| Window | Was |
|---|---|
| Shot changes list | **Go to** and **Clear** disabled until a row was clicked |
| List errors | **Go to** disabled |
| Find double words | **Go to** disabled |
| Find double lines | **Go to** disabled |
| Batch convert | the function settings panel stayed blank until a function was clicked |

The three "is anything selected" flags (`HasShotChanges`, `HasErrors`, `HasDoubleWords`, `HasDoubleLines`) now follow the selection property via `OnSelectedXChanged` instead of the grid''s `SelectionChanged` event, which the control''s own initial selection never raises. Batch convert refreshes its function panel in `Onloaded`, because `FunctionContainer` is only replaced with the real `ScrollViewer` later in the window layout.

## Also audited, no change needed

74 `SelectedItemProperty` bind sites: 34 never assign their view-model property, 18 of those also read it, and the rest of those turned out to be safe - lists filled after the window opens (EmbeddedSubtitlesEdit, BurnIn, SpeechToText, TransparentSubtitles, FixCommonErrors), lists that start empty (SortBy), view models that already set their own selection (PickRuleProfile, PickFontName, PickSpellCheckDictionary, ManualChosenEncoding, RestoreAutoBackup, PickOnlineSubtitle, OCR, ReviewSpeech), a flag gated on `Count` rather than selection (BatchErrorList), and one property nothing reads (PickLayerFilter).

## Tests

- `TableViewBindSelectedItemTests` - pins the helper: pushes the initial selection, does not overwrite a selection the view model already has, still round-trips later changes, no-ops on an empty grid. One test documents the plain-`Bind` trap so the difference stays visible.
- `PrePopulatedGridSelectionTests` - one test per fixed window. All 5 fail on `main` and pass here (verified by stashing the source changes).

Full UI suite: 1043 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)