### PR TITLE
Destroy the video player when its control is discarded (#13048)

### DIFF
--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -823,6 +823,13 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
         internal void CloseAndDisposePlayer()
         {
             Close();
+
+            // Mark before the content goes. On the OpenGL host mpv's render context may only be
+            // freed from the GL deinit callback (the GL context has to be current), and dropping
+            // the content is what fires that callback - so it has to already know the player is
+            // being discarded, or it hands back to a Dispose that can no longer free the context.
+            (_videoPlayerInstance as LibMpvDynamicPlayer)?.MarkForDispose();
+
             Content = null;
 
             if (_videoPlayerInstance is not IDisposable disposablePlayer)

--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -798,6 +798,51 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             Duration = 0;
         }
 
+        /// <summary>
+        /// Permanently tears this control down: stops the polling timers, unloads the file,
+        /// detaches the native render host and destroys the underlying player.
+        /// <para>
+        /// Call this - not just <c>VideoPlayer.CloseFile()</c> - whenever a control is thrown
+        /// away (layout rebuild, leaving fullscreen, closing the undocked window). Skipping it
+        /// leaks two things that survive until the app exits: the 50 ms <see cref="_positionTimer"/>,
+        /// which a running <see cref="DispatcherTimer"/> keeps rooted in the dispatcher (so it goes
+        /// on P/Invoking the dead player from the UI thread forever), and the native player core
+        /// itself, whose worker threads and GPU context are only released by its Dispose. Since
+        /// Options/OK rebuilds the layout on any setting change, that used to leak one mpv core
+        /// plus one UI-thread poller per OK, which is what made the waveform playhead stutter
+        /// until restart (issue #13048).
+        /// </para>
+        /// <para>
+        /// Order matters: stop and unload first so the player is idle, then drop the content
+        /// (which destroys the embedded window), and only then destroy the core. mpv's
+        /// <c>mpv_terminate_destroy</c> blocks until every worker has exited - milliseconds when
+        /// idle, but many seconds if a load is stuck on a slow path - so it runs on a worker
+        /// thread rather than freezing the UI (same reasoning as issue #11176).
+        /// </para>
+        /// </summary>
+        internal void CloseAndDisposePlayer()
+        {
+            Close();
+            Content = null;
+
+            if (_videoPlayerInstance is not IDisposable disposablePlayer)
+            {
+                return;
+            }
+
+            Task.Run(() =>
+            {
+                try
+                {
+                    disposablePlayer.Dispose();
+                }
+                catch (Exception exception)
+                {
+                    Se.LogError(exception, "VideoPlayerControl background player dispose");
+                }
+            });
+        }
+
         internal async Task WaitForPlayersReadyAsync(int timeoutMs = 2500)
         {
             var end = DateTime.UtcNow.AddMilliseconds(timeoutMs);

--- a/src/ui/Features/Main/Layout/InitVideoPlayer.cs
+++ b/src/ui/Features/Main/Layout/InitVideoPlayer.cs
@@ -32,8 +32,13 @@ public static class InitVideoPlayer
         {
             mediaFile = vm.VideoPlayerControl.VideoPlayer.FileName;
             position = vm.VideoPlayerControl.VideoPlayer.Position;
-            vm.VideoPlayerControl.VideoPlayer.CloseFile();
-            vm.VideoPlayerControl.Content = null;
+
+            // The old control is replaced by the one built below and never used again, so tear
+            // it down completely. Closing the file alone left its 50 ms position timer running
+            // (which keeps the whole control alive in the dispatcher, polling a dead player from
+            // the UI thread) and left the native player core undestroyed - one leaked mpv per
+            // layout rebuild, and Options/OK rebuilds the layout on any setting change (#13048).
+            vm.VideoPlayerControl.CloseAndDisposePlayer();
             vm.VideoPlayerControl = null;
         }
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -6120,7 +6120,11 @@ public partial class MainViewModel :
             var position = vp.Position;
             var volume = vp.Volume;
             var videoFileName = vp.VideoPlayer.FileName;
-            VideoPlayerControl?.Close();
+
+            // The undocked window below builds its own player, so this one is finished. Close()
+            // alone stopped its timers but left the native player core alive for the rest of the
+            // session (issue #13048).
+            VideoPlayerControl?.CloseAndDisposePlayer();
             VideoPlayerControl = null;
 
             if (_videoPlayerUndockedViewModel != null)

--- a/src/ui/Features/Shared/FullScreenVideoPlayer.cs
+++ b/src/ui/Features/Shared/FullScreenVideoPlayer.cs
@@ -195,6 +195,14 @@ public class FullScreenVideoWindow : Window
             videoPlayer.VideoPlayer.CloseFile();
         };
 
+        // A fresh player is built for every fullscreen session and this one is never used again,
+        // so destroy it instead of only unloading the file - otherwise each enter/leave fullscreen
+        // leaked a live player core plus its 50 ms position timer (same root cause as issue #13048).
+        // Done from Closed, not Closing: it drops the embedded render host, which is better left
+        // until the window is actually gone. onClose above has already copied position and volume
+        // back to the docked player.
+        Closed += (_, _) => videoPlayer.CloseAndDisposePlayer();
+
         Activated += delegate { Focus(); }; // hack to make OnKeyDown work
         Loaded += async(_, _) =>
         {

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicOpenGlControl.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicOpenGlControl.cs
@@ -131,12 +131,13 @@ public class LibMpvDynamicOpenGlControl : OpenGlControlBase
 
     protected override void OnOpenGlDeinit(GlInterface gl)
     {
-        //if (_mpvPlayer != null)
-        //{
-        //    _mpvPlayer.RequestRender -= OnMpvRequestRender;
-        //    _mpvPlayer.Dispose();
-        //    _mpvPlayer = null;
-        //}
+        // This is the only place mpv's OpenGL render context may be freed: it runs on the render
+        // thread with the GL context current, and mpv_render_context_free deletes the GPU objects
+        // mpv allocated in it. But a deinit is not the same as being discarded - Avalonia also
+        // deinits on a plain reparent, and layout 12 reparents the live control on purpose to keep
+        // playback going - so this only completes a teardown the owner already asked for. Without
+        // a pending dispose nothing happens here, exactly as before (issue #13048).
+        _mpvPlayer?.FreeRenderContextIfDisposePending();
 
         base.OnOpenGlDeinit(gl);
     }

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -24,6 +24,11 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     private IntPtr _library = IntPtr.Zero;
     private IntPtr _mpv = IntPtr.Zero;
     private IntPtr _renderContext = IntPtr.Zero;
+
+    // True once the render context was created against a graphics API whose context is
+    // thread-affine (OpenGL, Metal), which decides who is allowed to free it - see Dispose.
+    private volatile bool _renderContextNeedsGraphicsContext;
+    private volatile bool _disposePendingRenderContextFree;
     private volatile bool _disposed;
     private volatile bool _coreInitialized;
     private string _fileName = string.Empty;
@@ -530,6 +535,9 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
                 Se.LogError(new InvalidOperationException(GetErrorString(err)), "LibMpvDynamicPlayer InitializeWithOpenGL mpv_render_context_create");
             }
 
+            // Only the GL thread may free this again - see Dispose / FreeRenderContext.
+            _renderContextNeedsGraphicsContext = true;
+
             // Set update callback
             _renderUpdateCallback = OnRenderUpdate;
             var callbackPtr = Marshal.GetFunctionPointerForDelegate(_renderUpdateCallback);
@@ -619,6 +627,9 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
             {
                 Se.LogError(new InvalidOperationException(GetErrorString(err)), "LibMpvDynamicPlayer InitializeWithMetal mpv_render_context_create");
             }
+
+            // Only the render thread may free this again - see Dispose / FreeRenderContext.
+            _renderContextNeedsGraphicsContext = true;
 
             // Register the render-update callback so mpv can trigger redraws.
             _renderUpdateCallback = OnRenderUpdate;
@@ -743,22 +754,82 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     }
 
     /// <summary>
-    /// Destroys the mpv core. Safe to call more than once and from more than one thread at
-    /// a time: a control can dispose its player when it is detached from the visual tree
-    /// while the owner disposes the same instance on a worker thread, and handing the same
-    /// handle to <c>mpv_terminate_destroy</c> twice is a double free. Each handle is claimed
-    /// with an interlocked exchange so exactly one caller ever gets a non-zero pointer.
+    /// Records that this player is being thrown away. Call it before detaching the render host:
+    /// dropping the host fires the graphics deinit callback, and that callback only completes a
+    /// teardown it can already see (see <see cref="FreeRenderContextIfDisposePending"/>). Marking
+    /// afterwards would race the callback and leave the core alive - the leak from issue #13048.
+    /// Cheap and non-blocking, unlike <see cref="Dispose"/>.
     /// </summary>
-    public void Dispose()
+    public void MarkForDispose()
     {
-        _disposed = true;
+        if (_renderContextNeedsGraphicsContext)
+        {
+            _disposePendingRenderContextFree = true;
+        }
+    }
 
+    /// <summary>
+    /// Completes a <see cref="Dispose"/> that had to wait for the graphics thread, and does
+    /// nothing at all if no dispose is pending.
+    /// <para>
+    /// Call this from the render control's deinit callback, where the graphics context is
+    /// current: <c>mpv_render_context_free</c> deletes the GPU objects mpv allocated in that
+    /// context, so for OpenGL and Metal no other thread may free it. Deinit alone is not a
+    /// reason to tear anything down - Avalonia deinits on a plain reparent too - which is why
+    /// this is a no-op unless the owner already asked for the player to go away.
+    /// </para>
+    /// </summary>
+    public void FreeRenderContextIfDisposePending()
+    {
+        if (!_disposePendingRenderContextFree)
+        {
+            return;
+        }
+
+        FreeRenderContext();
+        TerminateCore();
+    }
+
+    private void FreeRenderContext()
+    {
         var renderContext = Interlocked.Exchange(ref _renderContext, IntPtr.Zero);
         if (renderContext != IntPtr.Zero && _mpvRenderContextFree != null)
         {
             _mpvRenderContextFree(renderContext);
         }
+    }
 
+    /// <summary>
+    /// Destroys the mpv core. Safe to call more than once and from more than one thread at
+    /// a time: a control can dispose its player when it is detached from the visual tree
+    /// while the owner disposes the same instance on a worker thread, and handing the same
+    /// handle to <c>mpv_terminate_destroy</c> twice is a double free. Each handle is claimed
+    /// with an interlocked exchange so exactly one caller ever gets a non-zero pointer.
+    /// <para>
+    /// When rendering goes through a graphics API the render context belongs to a thread this
+    /// one is not - freeing an OpenGL render context without that context current is undefined -
+    /// so there this only records the intent and returns. The render control's deinit callback
+    /// then calls <see cref="FreeRenderContextIfDisposePending"/>, which frees the context and
+    /// destroys the core. If that callback never arrives the core outlives us, which is exactly
+    /// what happened before this handshake existed - so asking is never worse than not asking.
+    /// </para>
+    /// </summary>
+    public void Dispose()
+    {
+        _disposed = true;
+
+        if (_renderContextNeedsGraphicsContext && _renderContext != IntPtr.Zero)
+        {
+            _disposePendingRenderContextFree = true;
+            return;
+        }
+
+        FreeRenderContext();
+        TerminateCore();
+    }
+
+    private void TerminateCore()
+    {
         var mpv = Interlocked.Exchange(ref _mpv, IntPtr.Zero);
         if (mpv != IntPtr.Zero && _mpvTerminateDestroy != null)
         {

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
@@ -741,25 +742,27 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         }
     }
 
+    /// <summary>
+    /// Destroys the mpv core. Safe to call more than once and from more than one thread at
+    /// a time: a control can dispose its player when it is detached from the visual tree
+    /// while the owner disposes the same instance on a worker thread, and handing the same
+    /// handle to <c>mpv_terminate_destroy</c> twice is a double free. Each handle is claimed
+    /// with an interlocked exchange so exactly one caller ever gets a non-zero pointer.
+    /// </summary>
     public void Dispose()
     {
-        if (_disposed)
-        {
-            return;
-        }
-
         _disposed = true;
 
-        if (_renderContext != IntPtr.Zero && _mpvRenderContextFree != null)
+        var renderContext = Interlocked.Exchange(ref _renderContext, IntPtr.Zero);
+        if (renderContext != IntPtr.Zero && _mpvRenderContextFree != null)
         {
-            _mpvRenderContextFree(_renderContext);
-            _renderContext = IntPtr.Zero;
+            _mpvRenderContextFree(renderContext);
         }
 
-        if (_mpv != IntPtr.Zero && _mpvTerminateDestroy != null)
+        var mpv = Interlocked.Exchange(ref _mpv, IntPtr.Zero);
+        if (mpv != IntPtr.Zero && _mpvTerminateDestroy != null)
         {
-            _mpvTerminateDestroy.Invoke(_mpv);
-            _mpv = IntPtr.Zero;
+            _mpvTerminateDestroy.Invoke(mpv);
         }
     }
 

--- a/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicPlayer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
@@ -1088,34 +1089,34 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayer
         }
     }
 
+    /// <summary>
+    /// Releases the VLC instance. Safe to call more than once and from more than one thread
+    /// at a time - releasing the same native pointer twice is a double free - so each handle
+    /// is claimed with an interlocked exchange and only the caller that wins releases it.
+    /// </summary>
     public void Dispose()
     {
-        if (_disposed)
-        {
-            return;
-        }
-
         _disposed = true;
 
         try
         {
-            if (_mediaPlayer != IntPtr.Zero)
+            var mediaPlayer = Interlocked.Exchange(ref _mediaPlayer, IntPtr.Zero);
+            if (mediaPlayer != IntPtr.Zero)
             {
-                _libvlc_media_player_stop?.Invoke(_mediaPlayer);
-                _libvlc_media_player_release?.Invoke(_mediaPlayer);
-                _mediaPlayer = IntPtr.Zero;
+                _libvlc_media_player_stop?.Invoke(mediaPlayer);
+                _libvlc_media_player_release?.Invoke(mediaPlayer);
             }
 
-            if (_libVlc != IntPtr.Zero && _libvlc_release != null)
+            var libVlc = Interlocked.Exchange(ref _libVlc, IntPtr.Zero);
+            if (libVlc != IntPtr.Zero && _libvlc_release != null)
             {
-                _libvlc_release(_libVlc);
-                _libVlc = IntPtr.Zero;
+                _libvlc_release(libVlc);
             }
 
-            if (_library != IntPtr.Zero)
+            var library = Interlocked.Exchange(ref _library, IntPtr.Zero);
+            if (library != IntPtr.Zero)
             {
-                NativeMethods.CrossFreeLibrary(_library);
-                _library = IntPtr.Zero;
+                NativeMethods.CrossFreeLibrary(library);
             }
         }
         catch

--- a/tests/UI/Controls/VideoPlayerControlTeardownTests.cs
+++ b/tests/UI/Controls/VideoPlayerControlTeardownTests.cs
@@ -1,0 +1,175 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Controls.VideoPlayer;
+using Nikse.SubtitleEdit.Logic.VideoPlayers;
+using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace UITests.Controls;
+
+/// <summary>
+/// Covers the teardown leak behind issue #13048: Options/OK rebuilds the layout on any
+/// setting change, and the discarded <see cref="VideoPlayerControl"/> used to keep its
+/// 50 ms position timer running (rooted in the dispatcher, so it polled a dead player
+/// from the UI thread forever) and never destroyed the native player core. One leaked
+/// player and poller per OK is what made the waveform playhead stutter until restart.
+/// </summary>
+public class VideoPlayerControlTeardownTests
+{
+    private sealed class FakeVideoPlayer : IVideoPlayer, IDisposable
+    {
+        public int DisposeCount;
+        public int CloseFileCount;
+
+        public string Name => "fake";
+        public string FileName { get; private set; } = string.Empty;
+
+        public bool CanLoad() => true;
+
+        public Task LoadFile(string fileName)
+        {
+            FileName = fileName;
+            return Task.CompletedTask;
+        }
+
+        public void CloseFile()
+        {
+            CloseFileCount++;
+            FileName = string.Empty;
+        }
+
+        public void Play()
+        {
+        }
+
+        public void PlayOrPause()
+        {
+        }
+
+        public void Pause()
+        {
+        }
+
+        public void Stop()
+        {
+        }
+
+        public AudioTrackInfo? ToggleAudioTrack() => null;
+
+        public bool IsPlaying => false;
+        public bool IsPaused => true;
+        public double Position { get; set; }
+        public double Duration => 60;
+        public int VolumeMaximum => 100;
+        public double Volume { get; set; } = 50;
+        public double Speed { get; set; } = 1.0;
+
+        public void Dispose() => DisposeCount++;
+    }
+
+    private static DispatcherTimer? GetPositionTimer(VideoPlayerControl control) =>
+        (DispatcherTimer?)typeof(VideoPlayerControl)
+            .GetField("_positionTimer", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(control);
+
+    private static async Task<VideoPlayerControl> MakeOpenedControlAsync(FakeVideoPlayer player)
+    {
+        var control = new VideoPlayerControl(player);
+        await control.Open("fake.mkv");
+        return control;
+    }
+
+    [AvaloniaFact]
+    public async Task OpenStartsThePositionTimer()
+    {
+        var control = await MakeOpenedControlAsync(new FakeVideoPlayer());
+
+        Assert.True(GetPositionTimer(control)?.IsEnabled);
+    }
+
+    [AvaloniaFact]
+    public async Task CloseAndDisposePlayerStopsThePositionTimer()
+    {
+        var control = await MakeOpenedControlAsync(new FakeVideoPlayer());
+
+        control.CloseAndDisposePlayer();
+
+        // A running DispatcherTimer keeps the control (and through it the player) alive for
+        // the rest of the session, so leaving it enabled is the leak, not just wasted work.
+        Assert.False(GetPositionTimer(control)?.IsEnabled);
+    }
+
+    [AvaloniaFact]
+    public async Task CloseAndDisposePlayerDetachesTheRenderHost()
+    {
+        var control = await MakeOpenedControlAsync(new FakeVideoPlayer());
+
+        control.CloseAndDisposePlayer();
+
+        // Dropping the content is what destroys the embedded native window; it has to happen
+        // before the core is destroyed, while the player is already stopped.
+        Assert.Null(control.Content);
+    }
+
+    [AvaloniaFact]
+    public async Task CloseAndDisposePlayerDisposesThePlayer()
+    {
+        var player = new FakeVideoPlayer();
+        var control = await MakeOpenedControlAsync(player);
+
+        control.CloseAndDisposePlayer();
+
+        // The dispose runs on a worker thread on purpose (mpv_terminate_destroy blocks until
+        // every worker has exited - see issue #11176), so give it a moment to land.
+        await WaitForAsync(() => player.DisposeCount > 0);
+        Assert.Equal(1, player.DisposeCount);
+        Assert.True(player.CloseFileCount > 0);
+    }
+
+    [AvaloniaFact]
+    public async Task CloseAndDisposePlayerIsSafeToRepeat()
+    {
+        var player = new FakeVideoPlayer();
+        var control = await MakeOpenedControlAsync(player);
+
+        control.CloseAndDisposePlayer();
+        await WaitForAsync(() => player.DisposeCount > 0);
+
+        // Some paths (a control detaching itself, then its owner tearing it down) can reach
+        // this twice; the player's own Dispose is the guard, this must not throw.
+        control.CloseAndDisposePlayer();
+
+        Assert.Null(control.Content);
+        Assert.False(GetPositionTimer(control)?.IsEnabled);
+    }
+
+    [AvaloniaFact]
+    public async Task CloseLeavesThePlayerUsable()
+    {
+        var player = new FakeVideoPlayer();
+        var control = await MakeOpenedControlAsync(player);
+
+        // Close() is the "closed the video file, control stays" path (Video > Close video),
+        // so it must keep the player alive for the next Open.
+        control.Close();
+
+        Assert.Equal(0, player.DisposeCount);
+        Assert.NotNull(control.Content);
+
+        await control.Open("other.mkv");
+        Assert.Equal("other.mkv", player.FileName);
+        Assert.True(GetPositionTimer(control)?.IsEnabled);
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition, int timeoutMs = 5000)
+    {
+        var waited = 0;
+        while (!condition() && waited < timeoutMs)
+        {
+            await Task.Delay(10);
+            waited += 10;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #13048.

## The report

Play a video, watch the waveform playhead glide. Open Options, change *any* setting, press OK. From then on the playhead skips, until Subtitle Edit is restarted. Reporter is on Windows with the default video player, `libmpv - Native Window ID rendering`.

## What was happening

Options/OK compares a settings snapshot from before and after, and if anything at all differs it runs `ApplySettings`, which unconditionally rebuilds the layout — so "any setting" really does mean any. The rebuild replaces the video player control, and the old one was only asked to close its file:

```csharp
vm.VideoPlayerControl.VideoPlayer.CloseFile();
vm.VideoPlayerControl.Content = null;
vm.VideoPlayerControl = null;
```

That left two things alive for the rest of the session:

- **The control's 50 ms position timer kept running.** A running `DispatcherTimer` is rooted in the dispatcher, so the whole control stayed reachable and went on P/Invoking the dead player from the UI thread. `Close()`, which stops it, was never called.
- **The native player core was never destroyed.** `LibMpvDynamicPlayer.Dispose` (`mpv_terminate_destroy`) had no call site anywhere outside the software renderer, so the mpv workers and GPU context stayed up with their `wid` window already destroyed.

`InitLayout.CleanupControl` could not catch either one — it only disposes controls implementing `IDisposable`, and `VideoPlayerControl` is a plain `UserControl`.

So every Options/OK left behind one live player core plus one UI-thread poller, and they accumulated. The 16 ms cursor timer that glides the playhead is the highest-frequency work on that thread, so it is where the added contention showed up first.

The tell-tale asymmetry: the **software** render host does dispose its player on detach, deliberately, on a worker thread (#11176). The **wid** host never got the same treatment and the **OpenGL** host had its disposal commented out — and those two are the platform defaults (`MpvWid` on Windows, `MpvOpenGl` elsewhere).

## The fix

`VideoPlayerControl.CloseAndDisposePlayer()`: stop the timers, unload the file, drop the content (which destroys the embedded window), then destroy the core on a worker thread — `mpv_terminate_destroy` blocks until every mpv worker has exited, which is the freeze from #11176.

Called from the three places that knowingly throw a control away:

- the layout rebuild in `InitVideoPlayer.MakeLayoutVideoPlayer`
- leaving fullscreen, from `FullScreenVideoWindow`'s `Closed`
- undocking the video, in `MainViewModel`

`Video > Close video` deliberately still uses plain `Close()`, since that control is reused for the next file.

### Why teardown stays explicit

The obvious-looking fix is to dispose from the render hosts' detach/destroy hooks. That would be wrong: `InitLayout.MakeLayout12` reparents the **live** control (`RemoveControlFromParent`, then re-add) specifically to keep playback going, so detaching is not the same thing as discarding. That is also why the OpenGL host's disposal was commented out. Teardown is therefore driven by the owner, at the point where a control is genuinely abandoned.

### Freeing the render context

The mpv `wid` host has no render context at all, so destroying it from a worker is fine. The OpenGL host does have one, and `mpv_render_context_free` deletes the GPU objects mpv allocated in it — it may only run where that context is current, i.e. Avalonia's render thread inside `OnOpenGlDeinit`, never on a pool thread.

So the two halves are split. `Dispose` destroys the core directly when nothing graphics-bound is in the way; otherwise it records the intent and returns, and `OnOpenGlDeinit` calls `FreeRenderContextIfDisposePending`, which frees the context on the right thread and then destroys the core. The intent is recorded *before* the content is dropped, because dropping the content is what fires the deinit callback — marking afterwards would let the callback run first, see nothing pending, and hand back to a `Dispose` that can no longer free the context safely.

A deinit with no pending dispose stays a no-op, so a plain reparent behaves exactly as before. If the callback never arrives the core outlives the app, which is what happened before this handshake existed, so asking is never worse than not asking.

### Interlocked handles

Both players' `Dispose` now claim each native handle with `Interlocked.Exchange`. This is a consequence of the fix rather than a cleanup: the software render host already disposes on detach, so the same instance can now be disposed from two threads, and handing the same pointer to `mpv_terminate_destroy` or `libvlc_release` twice is a double free. The old `if (_disposed) return;` guard is not atomic.

## Testing

`tests/UI/Controls/VideoPlayerControlTeardownTests.cs` — 6 tests over a fake player: timer stopped, content detached, player disposed exactly once, repeat-safe, and `Close()` still leaving the player usable for the next `Open`. Full UI suite: 1040 passed, 0 failed.

Manually exercised on macOS (so the OpenGL host, not the reported `wid` one): repeated Options/OK with a video playing, fullscreen in and out, layout switches including the no-video layout and back, undock and redock, and close-then-open-another-video.

**Not verified end to end**: the original symptom needs Windows with mpv-wid. The leak itself is proven from the code and now closed, but that it is *the* stutter mechanism is still inference. Worth confirming by repeating Options/OK and watching Subtitle Edit's thread count — before this it should climb by about one player's worth per OK, after it should stay flat.

## Left out

A dozen modal dialogs (BurnIn, VisualSync, CutVideo, the ASSA windows) create their own player via `MakeVideoPlayer()` and never destroy it — same leak class, and it hits the default render host on every platform. Out of scope here; worth a follow-up, along with `LibMpvDynamicSoftwareControl` disposing on *any* detach, which likely leaves a dead player after a layout-12 reparent for software-renderer users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)