### PR TITLE
Fix CrispASR failing to start in the Flatpak (missing libopenblas)

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -51,6 +51,8 @@ v5.2.0-beta1 (TBD)
 * Download 64-bit libVLC on Windows x64 - thx StandAloof
 * Screen readers: keyboard focus in the subtitle grid is exposed via UI Automation again - the main grid and all dialog grids now use TableView - thx Urs2026
 * Accessibility: announce rule violations in the grid row's accessible name, safer initial focus, accessible names for icon buttons, and keep keyboard focus in the grid on Home/End jumps
+* Flatpak: bundle OpenBLAS so the CrispASR speech-to-text engines can start in the sandbox - thx DarkSwan86
+* Speech to text: report a missing shared library instead of silently returning an empty result
 * Update Italian translation - thx bovirus
 * Update Korean translation - thx 12si27
 * Update Polish translation - thx potplayer-fanpack

--- a/installer/flatpak/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/dk.nikse.subtitleedit.yaml
@@ -361,6 +361,35 @@ modules:
         sha256: ed087f83ee789c1ea5f39c464c55a5c9d4008deb0efe900814f2df262b82c36e
         strip-components: 0
 
+  # --- OpenBLAS (needed by the downloaded CrispASR engines; see issue #12970) ---
+  #
+  # The CrispASR Linux binaries (x86_64 CPU/Vulkan and arm64) are linked against
+  # libopenblas.so.0 but ship only crispasr, crispasr-quantize and libc2pa_c.so.
+  # org.freedesktop.Platform has no OpenBLAS, and the sandbox hides the host /usr,
+  # so speech-to-text died instantly with
+  #   "crispasr: error while loading shared libraries: libopenblas.so.0"
+  # no matter what the user installed on the host. Building it into /app/lib puts it
+  # on the sandbox library path, which the crispasr child process inherits.
+  #
+  # DYNAMIC_ARCH=1 so one build works on every CPU (the runtime baseline is generic);
+  # USE_OPENMP=1 matches the libgomp the engine already links against. crispasr imports
+  # exactly two symbols from this library - cblas_sgemm and openblas_set_num_threads - so
+  # LAPACK/LAPACKE are switched off: they roughly halve the build time and would otherwise
+  # need a Fortran compiler.
+  - name: openblas
+    buildsystem: simple
+    build-commands:
+      - make DYNAMIC_ARCH=1 USE_OPENMP=1 NUM_THREADS=64 NO_STATIC=1 NO_LAPACK=1 NO_LAPACKE=1 -j $FLATPAK_BUILDER_N_JOBS
+      - make PREFIX=/app NO_STATIC=1 NO_LAPACK=1 NO_LAPACKE=1 install
+    cleanup:
+      - /include
+      - /lib/cmake
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.34/OpenBLAS-0.3.34.tar.gz
+        sha256: cd7e129868320cc2d033afa920e31202dfe0b8066a5b66661900ccc0f197dfed
+
   # --- SubtitleEdit application ---
 
   - name: subtitleedit

--- a/src/ui/Features/Video/SpeechToText/MissingSharedLibrary.cs
+++ b/src/ui/Features/Video/SpeechToText/MissingSharedLibrary.cs
@@ -1,0 +1,53 @@
+﻿using System;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText;
+
+/// <summary>
+/// Detects the Linux/macOS dynamic loader error that fires when a downloaded speech-to-text
+/// engine cannot start because one of the shared libraries it was linked against is missing.
+///
+/// The CrispASR Linux builds link against libopenblas.so.0 but do not ship it, so the engine
+/// exits immediately with this message. Without detection the run just produced an empty
+/// subtitle and only the console log hinted at why (issue #12970).
+/// </summary>
+public static class MissingSharedLibrary
+{
+    // glibc:  <exe>: error while loading shared libraries: libopenblas.so.0: cannot open shared object file: ...
+    // macOS:  dyld: Library not loaded: @rpath/libfoo.dylib
+    private const string GlibcMarker = "error while loading shared libraries: ";
+    private const string DyldMarker = "Library not loaded: ";
+
+    /// <summary>
+    /// Returns the name of the missing library, or null if the line is not a loader error.
+    /// </summary>
+    public static string? GetName(string? line)
+    {
+        if (string.IsNullOrEmpty(line))
+        {
+            return null;
+        }
+
+        var name = GetAfterMarker(line, GlibcMarker) ?? GetAfterMarker(line, DyldMarker);
+        if (name == null)
+        {
+            return null;
+        }
+
+        // glibc appends ": cannot open shared object file: ..." after the library name
+        var colon = name.IndexOf(':');
+        if (colon > 0)
+        {
+            name = name.Substring(0, colon);
+        }
+
+        name = name.Trim();
+
+        return name.Length == 0 ? null : name;
+    }
+
+    private static string? GetAfterMarker(string line, string marker)
+    {
+        var index = line.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        return index < 0 ? null : line.Substring(index + marker.Length);
+    }
+}

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -143,6 +143,7 @@ public partial class SpeechToTextViewModel : ObservableObject
     private bool _unknownArgument;
     private bool _cudaOutOfMemory;
     private bool _incompleteModel;
+    private string? _missingSharedLibrary;
     private bool _loadedFromStdOut;
     private string? _videoFileName;
     private string _audioFileName = string.Empty;
@@ -752,7 +753,13 @@ public partial class SpeechToTextViewModel : ObservableObject
                 ProgressValue = 100;
 
                 var hasError = false;
-                if (_incompleteModel)
+                if (_missingSharedLibrary != null)
+                {
+                    await MessageBox.Show(Window!, "Speech to text engine could not start",
+                        GetMissingSharedLibraryMessage(_missingSharedLibrary));
+                    hasError = true;
+                }
+                else if (_incompleteModel)
                 {
                     await MessageBox.Show(Window!, "Incomplete model",
                         "The model is incomplete. Please download the full model.");
@@ -915,6 +922,28 @@ public partial class SpeechToTextViewModel : ObservableObject
         _timerWhisper.Start();
     }
 
+    /// <summary>
+    /// Builds the message shown when the engine binary could not be started because a shared
+    /// library it links against is missing (issue #12970).
+    /// </summary>
+    private static string GetMissingSharedLibraryMessage(string libraryName)
+    {
+        var message =
+            $"The speech to text engine could not start - the shared library \"{libraryName}\" is missing.{Environment.NewLine}{Environment.NewLine}" +
+            "Install it with your package manager and try again.";
+
+        if (libraryName.StartsWith("libopenblas", StringComparison.OrdinalIgnoreCase))
+        {
+            message +=
+                $"{Environment.NewLine}{Environment.NewLine}" +
+                $"Debian/Ubuntu: sudo apt install libopenblas0{Environment.NewLine}" +
+                $"Fedora: sudo dnf install openblas{Environment.NewLine}" +
+                "Arch: sudo pacman -S openblas";
+        }
+
+        return message;
+    }
+
     private void ProcessQwen3AsrCppTranscription(SeAudioToText settings)
     {
         var jsonPath = _qwen3AsrOutputJsonPath;
@@ -944,6 +973,15 @@ public partial class SpeechToTextViewModel : ObservableObject
             Dispatcher.UIThread.Invoke<Task>(async () =>
             {
                 LogToConsole($"Speech to text ({settings.WhisperChoice}) done in {_sw.Elapsed}{Environment.NewLine}");
+                if (_missingSharedLibrary != null)
+                {
+                    await MessageBox.Show(Window!, "Speech to text engine could not start",
+                        GetMissingSharedLibraryMessage(_missingSharedLibrary));
+                    ProgressValue = 100;
+                    IsTranscribeEnabled = true;
+                    return;
+                }
+
                 if (_unknownArgument && !string.IsNullOrEmpty(settings.WhisperCustomCommandLineArguments))
                 {
                     await MessageBox.Show(Window!, $"Unknown argument: {settings.WhisperCustomCommandLineArguments}",
@@ -3008,6 +3046,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             _unknownArgument = false;
             _cudaOutOfMemory = false;
             _incompleteModel = false;
+            _missingSharedLibrary = null;
             _loadedFromStdOut = false;
 
             Se.Settings.Tools.AudioToText.WhisperChoice = engine.Choice;
@@ -4057,6 +4096,13 @@ public partial class SpeechToTextViewModel : ObservableObject
         if (string.IsNullOrWhiteSpace(outLine.Data))
         {
             return;
+        }
+
+        // Check before the language guard below - the dynamic loader fails before the engine
+        // prints anything else, and this must be reported even if no language is selected.
+        if (_missingSharedLibrary == null)
+        {
+            _missingSharedLibrary = MissingSharedLibrary.GetName(outLine.Data);
         }
 
         if (SelectedLanguage is not WhisperLanguage language)

--- a/tests/UI/Features/Video/SpeechToText/MissingSharedLibraryTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/MissingSharedLibraryTests.cs
@@ -1,0 +1,35 @@
+﻿using Nikse.SubtitleEdit.Features.Video.SpeechToText;
+
+namespace UITests.Features.Video.SpeechToText;
+
+public class MissingSharedLibraryTests
+{
+    [Fact]
+    public void GetName_GlibcLoaderError_ReturnsLibraryName()
+    {
+        // The exact line from issue #12970 (Flatpak, CrispASR Qwen3)
+        const string line = "/home/user/.var/app/dk.nikse.subtitleedit/config/Subtitle Edit/CrispASR/crispasr: " +
+                            "error while loading shared libraries: libopenblas.so.0: " +
+                            "cannot open shared object file: No such file or directory";
+
+        Assert.Equal("libopenblas.so.0", MissingSharedLibrary.GetName(line));
+    }
+
+    [Fact]
+    public void GetName_DyldLoaderError_ReturnsLibraryName()
+    {
+        const string line = "dyld: Library not loaded: @rpath/libc2pa_c.dylib";
+
+        Assert.Equal("@rpath/libc2pa_c.dylib", MissingSharedLibrary.GetName(line));
+    }
+
+    [Theory]
+    [InlineData("whisper_init_from_file_with_params_no_state: loading model from 'ggml-base.bin'")]
+    [InlineData("error: unknown argument: --nonsense")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void GetName_UnrelatedOutput_ReturnsNull(string? line)
+    {
+        Assert.Null(MissingSharedLibrary.GetName(line));
+    }
+}


### PR DESCRIPTION
Fixes #12970.

## Root cause

The CrispASR Linux release tarballs (v0.8.24) contain only three files:

```
crispasr-linux-x86_64/{crispasr, crispasr-quantize, libc2pa_c.so}
```

but the `crispasr` binary's `DT_NEEDED` list — identical for x86_64 CPU, x86_64 Vulkan and arm64 — is:

```
libc.so.6  libc2pa_c.so  libgcc_s.so.1  libgomp.so.1  libm.so.6  libopenblas.so.0  libstdc++.so.6
DT_RUNPATH: $ORIGIN:/home/runner/work/CrispASR/CrispASR/third_party/c2pa/lib
```

`libopenblas.so.0` is neither shipped nor resolvable. `org.freedesktop.Platform` 24.08 has no OpenBLAS and the sandbox hides the host `/usr`, so in the Flatpak speech-to-text died instantly with

```
crispasr: error while loading shared libraries: libopenblas.so.0: cannot open shared object file
```

no matter what the user installed on the host — which is why the reporter's `dnf install openblas-devel` changed nothing. Portable Linux builds work only when the distro happens to have OpenBLAS installed.

## Changes

**1. Bundle OpenBLAS in the Flatpak** — new `openblas` module installing into `/app/lib`, which Flatpak puts on the sandbox library path and the `crispasr` child process inherits. Same approach as the bundled Tesseract (#11646). LAPACK/LAPACKE are switched off: the `crispasr` dynamic symbol table imports exactly two symbols from the library, `cblas_sgemm` and `openblas_set_num_threads`, so skipping LAPACK roughly halves the build time and avoids needing a Fortran compiler.

**2. Report the failure instead of swallowing it** — previously the loader error was logged and the run then fell through to `Loading result from STDOUT`, producing an empty subtitle with no dialog. A new `MissingSharedLibrary` parser recognises glibc's `error while loading shared libraries: <lib>: …` and dyld's `Library not loaded: …`; both completion paths (generic and the Qwen3 no-output-JSON path) now show a message box naming the library, with apt/dnf/pacman hints when it is OpenBLAS. The check runs before the `SelectedLanguage` guard in `OutputHandler`, since the dynamic loader fails before the engine prints anything else.

## Testing

- 6 new unit tests in `MissingSharedLibraryTests.cs`, including the verbatim log line from the issue.
- UI project builds clean; all 96 SpeechToText tests pass.
- The Flatpak module itself is verified by inspection and YAML parse only — it needs a `flatpak-builder` run on Linux to confirm, so the build-flatpak workflow should run on this branch before merging.

## Still open

Non-Flatpak Linux users remain broken by default; they now just get a clear message and install instructions. The complete fix belongs upstream at CrispStrobe/CrispASR — ship `libopenblas.so.0` next to the binary (the existing `$ORIGIN` runpath would pick it up, needing no SE change at all) or build with `GGML_BLAS=OFF`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
