### PR TITLE
Bind backup count directly to Files.Count in restore auto backup

### DIFF
--- a/src/ui/Features/Files/RestoreAutoBackup/RestoreAutoBackupViewModel.cs
+++ b/src/ui/Features/Files/RestoreAutoBackup/RestoreAutoBackupViewModel.cs
@@ -21,7 +21,6 @@ public partial class RestoreAutoBackupViewModel : ObservableObject
     [ObservableProperty] private DisplayFile? _selectedFile;
     [ObservableProperty] private ObservableCollection<DisplayFile> _files;
     [ObservableProperty] private bool _isEmptyFilesVisible;
-    [ObservableProperty] private string _filesSummaryText = string.Empty;
 
     public Window? Window { get; set; }
     public string? RestoreFileName { get; set; }
@@ -69,8 +68,6 @@ public partial class RestoreAutoBackupViewModel : ObservableObject
             SelectedFile = Files[0];
             IsEmptyFilesVisible = true;
         }
-
-        FilesSummaryText = string.Format(Se.Language.File.RestoreAutoBackup.XBackups, Files.Count);
     }
 
     [RelayCommand]

--- a/src/ui/Features/Files/RestoreAutoBackup/RestoreAutoBackupWindow.cs
+++ b/src/ui/Features/Files/RestoreAutoBackup/RestoreAutoBackupWindow.cs
@@ -105,8 +105,11 @@ public class RestoreAutoBackupWindow : Window
             VerticalAlignment = VerticalAlignment.Center,
             Opacity = 0.8,
             Margin = new Thickness(10, 0, 0, 0),
+            [!TextBlock.TextProperty] = new Binding($"{nameof(vm.Files)}.{nameof(vm.Files.Count)}")
+            {
+                StringFormat = Se.Language.File.RestoreAutoBackup.XBackups
+            }
         };
-        summaryText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.FilesSummaryText)));
 
         var buttonDeleteAllSubtitles = UiUtil.MakeButton(Se.Language.File.RestoreAutoBackup.DeleteAll, vm.DeleteAllFilesCommand)
             .WithBindIsVisible(nameof(vm.IsEmptyFilesVisible))


### PR DESCRIPTION
## Summary
- Remove the manually maintained `FilesSummaryText` property from `RestoreAutoBackupViewModel`
- Bind the summary `TextBlock` directly to `Files.Count` with the `XBackups` language string as `StringFormat`, so the label updates automatically whenever the collection changes (e.g. after Delete all)

## Test plan
- [x] Open File → Restore auto-backup with existing backups and verify the label shows "N backups" matching the list
- [x] Click "Delete all" and confirm the label updates to "0 backups" after the list clears
- [x] Verify the label is localized (format string comes from `Se.Language.File.RestoreAutoBackup.XBackups`)

## Image

<img width="812" height="672" alt="image" src="https://github.com/user-attachments/assets/489203b5-266d-48d3-856d-5253c2dd882c" />

Backup count wasn't being updated after you click "Delete all"

🤖 Generated with [Claude Code](https://claude.com/claude-code)