### PR TITLE
Bind count labels directly to collection Count

### DIFF
--- a/src/ui/Features/Shared/Bookmarks/BookmarksListViewModel.cs
+++ b/src/ui/Features/Shared/Bookmarks/BookmarksListViewModel.cs
@@ -18,7 +18,6 @@ public partial class BookmarksListViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<SubtitleLineViewModel> _subtitles;
     [ObservableProperty] private SubtitleLineViewModel? _selectedSubtitle;
     [ObservableProperty] private bool _hasBookmarks;
-    [ObservableProperty] private string _countText = string.Empty;
 
     public Window? Window { get; set; }
 
@@ -27,11 +26,7 @@ public partial class BookmarksListViewModel : ObservableObject
     public BookmarksListViewModel()
     {
         Subtitles = new ObservableCollection<SubtitleLineViewModel>();
-        Subtitles.CollectionChanged += (_, _) => UpdateCountText();
     }
-
-    private void UpdateCountText() =>
-        CountText = $"{Se.Language.General.Count}: {Subtitles.Count}";
 
     [RelayCommand]
     private async Task Clear()
@@ -129,7 +124,6 @@ public partial class BookmarksListViewModel : ObservableObject
         }
 
         HasBookmarks = SelectedSubtitle != null;
-        UpdateCountText();
     }
 
     internal void GridSelectionChanged(object? sender, SelectionChangedEventArgs e)

--- a/src/ui/Features/Shared/Bookmarks/BookmarksListWindow.cs
+++ b/src/ui/Features/Shared/Bookmarks/BookmarksListWindow.cs
@@ -40,6 +40,7 @@ public class BookmarksListWindow : Window
         labelCount.Bind(TextBlock.TextProperty, new Binding($"{nameof(vm.Subtitles)}.{nameof(vm.Subtitles.Count)}")
         {
             Source = vm,
+            Mode = BindingMode.OneWay,
             StringFormat = Se.Language.General.Count + ": {0}",
         });
 

--- a/src/ui/Features/Shared/Bookmarks/BookmarksListWindow.cs
+++ b/src/ui/Features/Shared/Bookmarks/BookmarksListWindow.cs
@@ -37,7 +37,11 @@ public class BookmarksListWindow : Window
             VerticalAlignment = VerticalAlignment.Bottom,
             Margin = new Thickness(0, 0, 0, 10),
         };
-        labelCount.Bind(TextBlock.TextProperty, new Binding(nameof(vm.CountText)) { Source = vm });
+        labelCount.Bind(TextBlock.TextProperty, new Binding($"{nameof(vm.Subtitles)}.{nameof(vm.Subtitles.Count)}")
+        {
+            Source = vm,
+            StringFormat = Se.Language.General.Count + ": {0}",
+        });
 
         var grid = new Grid
         {

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModel.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModel.cs
@@ -72,7 +72,6 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsSettingsMode))]
     private bool _isApplyVisible;
-    [ObservableProperty] private string _linesFoundText;
 
     public Window? Window { get; set; }
 
@@ -97,7 +96,6 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
         Languages = new ObservableCollection<LanguageItem>(LanguageItem.GetAll());
         Fixes = new ObservableCollection<RemoveItem>();
         FixText = string.Empty;
-        LinesFoundText = string.Format(Se.Language.Tools.RemoveTextForHearingImpaired.LinesFoundX, 0);
         _timer = new Timer(500);
         _timer.Elapsed += TimerElapsed;
         _subtitle = new Subtitle();
@@ -297,8 +295,6 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
                 newFixes.Add(new RemoveItem(apply, index, p.Text, newText, p));
             }
         }
-
-        LinesFoundText = string.Format(Se.Language.Tools.RemoveTextForHearingImpaired.LinesFoundX, newFixes.Count);
 
         if (newFixes.Count == Fixes.Count)
         {

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
@@ -366,7 +366,10 @@ public class RemoveTextForHearingImpairedWindow : Window
         TableViewExtras.AddSpaceToggle<RemoveItem>(dataGrid,
             item => item.Apply, (item, v) => item.Apply = v);
 
-        var labelLinesFound = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.LinesFoundText));
+        var labelLinesFound = UiUtil.MakeLabel().WithBindText(vm, new Binding($"{nameof(vm.Fixes)}.{nameof(vm.Fixes.Count)}")
+        {
+            StringFormat = Se.Language.Tools.RemoveTextForHearingImpaired.LinesFoundX,
+        });
 
         var grid = new Grid
         {

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
@@ -368,6 +368,7 @@ public class RemoveTextForHearingImpairedWindow : Window
 
         var labelLinesFound = UiUtil.MakeLabel().WithBindText(vm, new Binding($"{nameof(vm.Fixes)}.{nameof(vm.Fixes.Count)}")
         {
+            Mode = BindingMode.OneWay,
             StringFormat = Se.Language.Tools.RemoveTextForHearingImpaired.LinesFoundX,
         });
 

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -75,8 +75,6 @@ public partial class TextToSpeechViewModel : ObservableObject
     [ObservableProperty] private bool _hasRegion;
     [ObservableProperty] private string _region;
     [ObservableProperty] private bool _hasModel;
-    [ObservableProperty] private int _voiceCount;
-    [ObservableProperty] private string _voiceCountInfo;
     [ObservableProperty] private bool _isVoiceCountVisible;
     [ObservableProperty] private string _linesInfo = string.Empty;
     [ObservableProperty] private bool _hasVideoFile;
@@ -170,7 +168,6 @@ public partial class TextToSpeechViewModel : ObservableObject
         Languages = new ObservableCollection<TtsLanguage>();
         ApiKey = string.Empty;
         Region = string.Empty;
-        VoiceCountInfo = string.Empty;
         ProgressText = string.Empty;
         IsVoiceTestEnabled = true;
         IsVoiceComboEnabled = true;
@@ -1683,8 +1680,6 @@ public partial class TextToSpeechViewModel : ObservableObject
         SelectedVoice = Voices.FirstOrDefault(v => v.Name == currentVoiceName)
                         ?? Voices.FirstOrDefault(v => v.Name == Se.Settings.Video.TextToSpeech.Voice)
                         ?? Voices.FirstOrDefault();
-        VoiceCount = Voices.Count;
-        VoiceCountInfo = string.Format(Se.Language.Video.TextToSpeech.XVoices, Voices.Count);
         IsVoiceCountVisible = Voices.Count > 0;
     }
 
@@ -3251,10 +3246,6 @@ public partial class TextToSpeechViewModel : ObservableObject
             {
                 Voices.Add(vo);
             }
-            VoiceCount = Voices.Count;
-            // The label binds VoiceCountInfo; only VoiceCount was ever written, so the voice
-            // count next to the combo stayed permanently blank.
-            VoiceCountInfo = string.Format(Se.Language.Video.TextToSpeech.XVoices, Voices.Count);
             IsVoiceCountVisible = Voices.Count > 0;
 
             var lastVoice = Voices.FirstOrDefault(v => v.Name == Se.Settings.Video.TextToSpeech.Voice);

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -350,7 +350,11 @@ public class TextToSpeechWindow : Window
                     {
                         FontSize = 11.5,
                         Opacity = 0.8,
-                        [!TextBlock.TextProperty] = new Binding(nameof(vm.VoiceCountInfo)) { Mode = BindingMode.OneWay },
+                        [!TextBlock.TextProperty] = new Binding($"{nameof(vm.Voices)}.{nameof(vm.Voices.Count)}")
+                        {
+                            Mode = BindingMode.OneWay,
+                            StringFormat = Se.Language.Video.TextToSpeech.XVoices,
+                        },
                     },
                     [!Border.IsVisibleProperty] = new Binding(nameof(vm.IsVoiceCountVisible)) { Mode = BindingMode.OneWay },
                 },


### PR DESCRIPTION
## Summary
Same refactor as #13057, applied to the three remaining places where a manually maintained string property only mirrored an `ObservableCollection`'s `Count`:

- **Bookmarks list**: remove `CountText`, the `UpdateCountText()` helper, and the `CollectionChanged` subscription that existed only to refresh it; the label binds `Subtitles.Count` with a `StringFormat`
- **Text to speech**: remove `VoiceCountInfo` and the dead write-only `VoiceCount` property; the voice-count badge binds `Voices.Count` (this label previously shipped a bug where it stayed permanently blank because the wrong property was written)
- **Remove text for hearing impaired**: remove `LinesFoundText`; the label binds `Fixes.Count` (the removed assignment used a local list whose count always equals `Fixes.Count` — the early-return path is guarded by count equality)

## Test plan
- [ ] Bookmarks list: open a subtitle with bookmarks, verify the count label; delete a bookmarked line with Del and verify the count decreases
- [ ] Text to speech: pick an engine, verify the "x voices" badge next to the voice combo shows the correct number and updates when switching engines
- [ ] Remove text for hearing impaired: open with a subtitle containing HI text, verify "Lines found: N" matches the grid and updates when toggling rule checkboxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)