### PR TITLE
Bind more count labels directly to collection Count

### DIFF
--- a/src/ui/Features/Files/ImportCsvXlsxCustomColumns/ImportCsvXlsxCustomColumnsViewModel.cs
+++ b/src/ui/Features/Files/ImportCsvXlsxCustomColumns/ImportCsvXlsxCustomColumnsViewModel.cs
@@ -23,7 +23,6 @@ public partial class ImportCsvXlsxCustomColumnsViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<CsvColumnDefinition> _columns;
     [ObservableProperty] private ObservableCollection<CsvRowItem> _rows;
     [ObservableProperty] private ObservableCollection<SubtitleLineViewModel> _previewSubtitles;
-    [ObservableProperty] private string _previewCount;
     [ObservableProperty] private bool _isOkEnabled;
 
     public Window? Window { get; set; }
@@ -71,7 +70,6 @@ public partial class ImportCsvXlsxCustomColumnsViewModel : ObservableObject
         Columns = new ObservableCollection<CsvColumnDefinition>();
         Rows = new ObservableCollection<CsvRowItem>();
         PreviewSubtitles = new ObservableCollection<SubtitleLineViewModel>();
-        PreviewCount = string.Empty;
     }
 
     [RelayCommand]
@@ -254,7 +252,6 @@ public partial class ImportCsvXlsxCustomColumnsViewModel : ObservableObject
         IsOkEnabled = textCol != null && Rows.Count > 0;
         if (textCol == null)
         {
-            PreviewCount = string.Empty;
             return;
         }
 
@@ -301,8 +298,6 @@ public partial class ImportCsvXlsxCustomColumnsViewModel : ObservableObject
             };
             PreviewSubtitles.Add(line);
         }
-
-        PreviewCount = string.Format(Se.Language.File.Import.NumberOfSubtitlesX, PreviewSubtitles.Count);
     }
 
     private static double ParseTimeCell(string? cell, bool isFrames, bool isMilliseconds)
@@ -529,7 +524,6 @@ public partial class ImportCsvXlsxCustomColumnsViewModel : ObservableObject
         Columns.Clear();
         Rows.Clear();
         PreviewSubtitles.Clear();
-        PreviewCount = string.Empty;
         SeparatorDisplay = string.Empty;
         IsOkEnabled = false;
         ColumnsRebuilt?.Invoke(this, EventArgs.Empty);

--- a/src/ui/Features/Files/ImportCsvXlsxCustomColumns/ImportCsvXlsxCustomColumnsWindow.cs
+++ b/src/ui/Features/Files/ImportCsvXlsxCustomColumns/ImportCsvXlsxCustomColumnsWindow.cs
@@ -53,7 +53,10 @@ public class ImportCsvXlsxCustomColumnsWindow : Window
         _previewGrid.ItemsSource = vm.PreviewSubtitles;
         BuildPreviewColumns(_previewGrid);
 
-        var labelPreview = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.PreviewCount)).WithAlignmentTop();
+        var labelPreview = UiUtil.MakeLabel().WithBindText(vm, new Binding($"{nameof(vm.PreviewSubtitles)}.{nameof(vm.PreviewSubtitles.Count)}")
+        {
+            StringFormat = Se.Language.File.Import.NumberOfSubtitlesX,
+        }).WithAlignmentTop();
 
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
         buttonOk.Bind(Button.IsEnabledProperty, new Binding(nameof(vm.IsOkEnabled)) { Source = vm });

--- a/src/ui/Features/Files/ImportPlainText/ImportPlainTextViewModel.cs
+++ b/src/ui/Features/Files/ImportPlainText/ImportPlainTextViewModel.cs
@@ -36,7 +36,6 @@ public partial class ImportPlainTextViewModel : ObservableObject, IClosingCleanu
     [ObservableProperty] private bool _useFixedDuration;
     [ObservableProperty] private int _fixedDurationMs;
     [ObservableProperty] private string _plainText;
-    [ObservableProperty] private string _numberOfSubtitles;
     [ObservableProperty] private bool _isAligning;
     [ObservableProperty] private string _alignProgress;
     [ObservableProperty] private double _alignPercent;
@@ -70,7 +69,6 @@ public partial class ImportPlainTextViewModel : ObservableObject, IClosingCleanu
         SelectedSplitAtOption = SplitAtOptions[0];
         PlainText = string.Empty;
         MinGapMs = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
-        NumberOfSubtitles = string.Empty;
         AlignProgress = string.Empty;
         FixedDurationMs = (int)Math.Round(Se.Settings.Tools.AdjustDurations.AdjustDurationFixed * 1000.0, MidpointRounding.AwayFromZero);
 
@@ -145,15 +143,6 @@ public partial class ImportPlainTextViewModel : ObservableObject, IClosingCleanu
                     var subtitle = subtitles[i];
                     subtitle.Number = i + 1;
                     Subtitles.Add(subtitle);
-                }
-
-                if (Subtitles.Count > 0)
-                {
-                    NumberOfSubtitles = string.Format(Se.Language.File.Import.NumberOfSubtitlesX, Subtitles.Count);
-                }
-                else
-                {
-                    NumberOfSubtitles = string.Empty;
                 }
 
                 TaskCompletionSource? toSignal;

--- a/src/ui/Features/Files/ImportPlainText/ImportPlainTextWindow.cs
+++ b/src/ui/Features/Files/ImportPlainText/ImportPlainTextWindow.cs
@@ -67,7 +67,10 @@ public class ImportPlainTextWindow : Window
         };
 
         // Shares its cell with the alignment progress, so it steps aside while that runs.
-        var labelNumberOfSubtitles = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.NumberOfSubtitles)).WithAlignmentTop();
+        var labelNumberOfSubtitles = UiUtil.MakeLabel().WithBindText(vm, new Binding($"{nameof(vm.Subtitles)}.{nameof(vm.Subtitles.Count)}")
+        {
+            StringFormat = Se.Language.File.Import.NumberOfSubtitlesX,
+        }).WithAlignmentTop();
         labelNumberOfSubtitles.Bind(IsVisibleProperty, new Binding(nameof(vm.IsAligning))
         {
             Source = vm,

--- a/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
+++ b/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
@@ -21,8 +21,6 @@ public partial class FixNamesViewModel : ObservableObject, IClosingCleanup
 {
     [ObservableProperty] private ObservableCollection<FixNameItem> _names;
     [ObservableProperty] private ObservableCollection<FixNameHitItem> _hits;
-    [ObservableProperty] private string _namesCount;
-    [ObservableProperty] private string _hitCount;
     [ObservableProperty] private string _extraNames;
 
     public Window? Window { get; set; }
@@ -50,8 +48,6 @@ public partial class FixNamesViewModel : ObservableObject, IClosingCleanup
         Hits = new ObservableCollection<FixNameHitItem>();
 
         _loading = true;
-        NamesCount = string.Empty;
-        HitCount = string.Empty;
         _nameListInclMulti = new List<string>();
         _language = "en_US";
         _subtitleBefore = new Subtitle();
@@ -156,7 +152,6 @@ public partial class FixNamesViewModel : ObservableObject, IClosingCleanup
 
         Names.Clear();
         Names.AddRange(names);
-        NamesCount = $"Names: {Names.Count:#,##0}";
     }
 
     private static bool IsWordBoundary(string text, int startIndex, string name)
@@ -209,7 +204,6 @@ public partial class FixNamesViewModel : ObservableObject, IClosingCleanup
         {
             Hits.Clear();
             Hits.AddRange(hits);
-            HitCount = $"Hits: {Hits.Count:#,##0}";
         });
     }
 

--- a/src/ui/Features/Tools/ChangeCasing/FixNamesWindow.cs
+++ b/src/ui/Features/Tools/ChangeCasing/FixNamesWindow.cs
@@ -60,7 +60,11 @@ public class FixNamesWindow : Window
 
         row++;
         var labelNamesCount = new Label();
-        labelNamesCount.Bind(Label.ContentProperty, new Binding(nameof(vm.NamesCount)) { Mode = BindingMode.OneWay });
+        labelNamesCount.Bind(Label.ContentProperty, new Binding($"{nameof(vm.Names)}.{nameof(vm.Names.Count)}")
+        {
+            Mode = BindingMode.OneWay,
+            StringFormat = lang.NamesX,
+        });
         grid.Add(labelNamesCount, row, 0);
 
         row++;
@@ -87,7 +91,10 @@ public class FixNamesWindow : Window
         grid.Add(stackExtraNames, row, 0);
 
         row++;
-        var labelHits = UiUtil.MakeLabel(new Binding(nameof(vm.HitCount)));
+        var labelHits = UiUtil.MakeLabel(new Binding($"{nameof(vm.Hits)}.{nameof(vm.Hits.Count)}")
+        {
+            StringFormat = lang.HitsX,
+        });
         grid.Add(labelHits, row, 0);
 
         row++;

--- a/src/ui/Logic/Config/Language/Tools/LanguageChangeCasing.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageChangeCasing.cs
@@ -3,6 +3,8 @@
 public class LanguageChangeCasing
 {
     public string FixNames { get; set; }
+    public string NamesX { get; set; }
+    public string HitsX { get; set; }
     public string ExtraNames { get; set; }
     public string EnterExtraNamesHint { get; set; }
     public string OnlyFixUppercaseLines { get; set; }
@@ -13,6 +15,8 @@ public class LanguageChangeCasing
     public LanguageChangeCasing()
     {
         FixNames = "Fix names";
+        NamesX = "Names: {0:#,##0}";
+        HitsX = "Hits: {0:#,##0}";
         ExtraNames = "Extra names";
         EnterExtraNamesHint = "Enter extra names to fix, separated by comma";
         OnlyFixUppercaseLines = "Only fix uppercase lines";


### PR DESCRIPTION
## Summary
Follow-up to #13058, converting the remaining three manually maintained count-text properties. Unlike #13058 this has a small visible change: the labels now show a formatted "0" (e.g. "Number of subtitles: 0") in states where they were previously blank.

- **Import CSV/XLSX with custom columns**: remove `PreviewCount` (four assignment sites); the preview label binds `PreviewSubtitles.Count`
- **Import plain text**: remove `NumberOfSubtitles` and its blank-when-zero branch; the label binds `Subtitles.Count` (it is still hidden while alignment runs, via the existing `IsAligning` binding)
- **Fix names (change casing)**: remove `NamesCount` and `HitCount`; the labels bind `Names.Count` / `Hits.Count` with `StringFormat = "Names: {0:#,##0}"` / `"Hits: {0:#,##0}"`, preserving the numeric formatting (previously hardcoded English, now routed through the new `NamesX`/`HitsX` language strings so they can be translated)

## Test plan
- [ ] CSV import: open a CSV, verify "Number of subtitles: N" matches the preview grid; set no column to Text and verify it shows 0; change column roles and verify it updates
- [ ] Plain text import: paste text and verify the count updates as the preview regenerates; clear the text and verify it shows 0
- [ ] Fix names: open with a subtitle containing names, verify "Names: N" and "Hits: N" match the grids and update when toggling name checkboxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)