### PR TITLE
Fix importing exported ASSA/SSA style files

### DIFF
--- a/src/ui/Features/Assa/AssaStylesViewModel.cs
+++ b/src/ui/Features/Assa/AssaStylesViewModel.cs
@@ -257,22 +257,7 @@ public partial class AssaStylesViewModel : ObservableObject, IClosingCleanup
 
     private static List<SsaStyle> LoadStylesFromImportFile(string fileName)
     {
-        if (fileName.EndsWith(".sty", StringComparison.OrdinalIgnoreCase))
-        {
-            var content = System.IO.File.ReadAllText(fileName);
-            var header = "[V4+ Styles]" + Environment.NewLine +
-                         SsaStyle.DefaultAssStyleFormat + Environment.NewLine +
-                         content;
-            return AdvancedSubStationAlpha.GetSsaStylesFromHeader(header);
-        }
-
-        var s = Subtitle.Parse(fileName, new AdvancedSubStationAlpha());
-        if (s == null || string.IsNullOrEmpty(s.Header))
-        {
-            return new List<SsaStyle>();
-        }
-
-        return AdvancedSubStationAlpha.GetSsaStylesFromHeader(s.Header);
+        return StyleFileImportHelper.LoadStyles(fileName, new AdvancedSubStationAlpha());
     }
 
     private static string MakeUniqueName(string name, ObservableCollection<StyleDisplay> styles)
@@ -531,6 +516,16 @@ public partial class AssaStylesViewModel : ObservableObject, IClosingCleanup
         }
 
         var ssaStyles = LoadStylesFromImportFile(fileName);
+        if (ssaStyles.Count == 0)
+        {
+            await MessageBox.Show(
+                Window,
+                Se.Language.General.Error,
+                "Nothing to import",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return;
+        }
 
         var result = await _windowService.ShowDialogAsync<AssaStylePickerWindow, AssaStylePickerViewModel>(Window, vm =>
         {

--- a/src/ui/Features/Assa/StyleFileImportHelper.cs
+++ b/src/ui/Features/Assa/StyleFileImportHelper.cs
@@ -1,0 +1,77 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Nikse.SubtitleEdit.Features.Assa;
+
+public static class StyleFileImportHelper
+{
+    /// <summary>
+    /// Reads ASSA/SSA styles from a file picked for style import.
+    /// Handles Aegisub ".sty" files, normal subtitle files, and style-only files (like the ones
+    /// made by "Export..." in the styles window) - the latter have no dialogue lines and are
+    /// therefore not recognized as subtitles at all.
+    /// </summary>
+    public static List<SsaStyle> LoadStyles(string fileName, SubtitleFormat format)
+    {
+        if (fileName.EndsWith(".sty", StringComparison.OrdinalIgnoreCase))
+        {
+            var content = ReadAllText(fileName);
+            if (content == null)
+            {
+                return new List<SsaStyle>();
+            }
+
+            var styHeader = "[V4+ Styles]" + Environment.NewLine +
+                            SsaStyle.DefaultAssStyleFormat + Environment.NewLine +
+                            content;
+            return AdvancedSubStationAlpha.GetSsaStylesFromHeader(styHeader);
+        }
+
+        var subtitle = Subtitle.Parse(fileName, format);
+        if (subtitle != null && !string.IsNullOrEmpty(subtitle.Header))
+        {
+            return AdvancedSubStationAlpha.GetSsaStylesFromHeader(subtitle.Header);
+        }
+
+        return GetStylesFromStyleOnlyFile(ReadAllText(fileName));
+    }
+
+    /// <summary>
+    /// Reads styles from a file with a "[V4+ Styles]"/"[V4 Styles]" section but no dialogue lines.
+    /// Everything from "[Events]" and down is cut away, as the events "Format:" line would
+    /// otherwise be read as a style format line.
+    /// </summary>
+    private static List<SsaStyle> GetStylesFromStyleOnlyFile(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return new List<SsaStyle>();
+        }
+
+        var eventsIndex = text.IndexOf("[Events]", StringComparison.OrdinalIgnoreCase);
+        var header = eventsIndex >= 0 ? text.Substring(0, eventsIndex) : text;
+
+        if (!header.Contains("[V4+ Styles]", StringComparison.OrdinalIgnoreCase) &&
+            !header.Contains("[V4 Styles]", StringComparison.OrdinalIgnoreCase))
+        {
+            return new List<SsaStyle>();
+        }
+
+        return AdvancedSubStationAlpha.GetSsaStylesFromHeader(header);
+    }
+
+    private static string? ReadAllText(string fileName)
+    {
+        try
+        {
+            return File.ReadAllText(fileName);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/ui/Features/Ssa/SsaStylesViewModel.cs
+++ b/src/ui/Features/Ssa/SsaStylesViewModel.cs
@@ -144,8 +144,8 @@ public partial class SsaStylesViewModel : ObservableObject, IClosingCleanup
             return;
         }
 
-        var s = Subtitle.Parse(fileName, format);
-        if (s == null || string.IsNullOrEmpty(s.Header))
+        var ssaStyles = StyleFileImportHelper.LoadStyles(fileName, format);
+        if (ssaStyles.Count == 0)
         {
             await MessageBox.Show(
                 Window,
@@ -155,8 +155,6 @@ public partial class SsaStylesViewModel : ObservableObject, IClosingCleanup
                 MessageBoxIcon.Error);
             return;
         }
-
-        var ssaStyles = AdvancedSubStationAlpha.GetSsaStylesFromHeader(s.Header);
 
         var result = await _windowService.ShowDialogAsync<AssaStylePickerWindow, AssaStylePickerViewModel>(Window, vm =>
         {
@@ -365,8 +363,8 @@ public partial class SsaStylesViewModel : ObservableObject, IClosingCleanup
             return;
         }
 
-        var s = Subtitle.Parse(fileName, format);
-        if (s == null || string.IsNullOrEmpty(s.Header))
+        var ssaStyles = StyleFileImportHelper.LoadStyles(fileName, format);
+        if (ssaStyles.Count == 0)
         {
             await MessageBox.Show(
                 Window,
@@ -376,8 +374,6 @@ public partial class SsaStylesViewModel : ObservableObject, IClosingCleanup
                 MessageBoxIcon.Error);
             return;
         }
-
-        var ssaStyles = AdvancedSubStationAlpha.GetSsaStylesFromHeader(s.Header);
 
         var result = await _windowService.ShowDialogAsync<AssaStylePickerWindow, AssaStylePickerViewModel>(Window, vm =>
         {

--- a/tests/UI/Features/Assa/StyleFileImportHelperTests.cs
+++ b/tests/UI/Features/Assa/StyleFileImportHelperTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Assa;
+
+namespace UITests.Features.Assa;
+
+/// <summary>
+/// Style files made by "Export..." in the ASSA/SSA styles window contain styles but no dialogue
+/// lines, so they are not recognized as subtitle files - importing them used to fail with
+/// "Nothing to import".
+/// </summary>
+public class StyleFileImportHelperTests : IDisposable
+{
+    private readonly List<string> _tempFiles = new();
+
+    private string WriteTempFile(string extension, string content)
+    {
+        var fileName = Path.Combine(Path.GetTempPath(), "se-style-import-test-" + Guid.NewGuid().ToString("N") + extension);
+        File.WriteAllText(fileName, content);
+        _tempFiles.Add(fileName);
+        return fileName;
+    }
+
+    private static List<SsaStyle> MakeStyles()
+    {
+        return new List<SsaStyle>
+        {
+            new SsaStyle { Name = "Default", FontName = "Arial", FontSize = 20 },
+            new SsaStyle { Name = "Narrator", FontName = "Verdana", FontSize = 24, Italic = true },
+        };
+    }
+
+    /// <summary>
+    /// Same as AssaStylesViewModel.FileExport/StorageExport.
+    /// </summary>
+    private static string ExportAssStyles(List<SsaStyle> styles)
+    {
+        var subtitle = new Subtitle
+        {
+            Header = AdvancedSubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(AdvancedSubStationAlpha.DefaultHeader, styles)
+        };
+        return subtitle.ToText(new AdvancedSubStationAlpha());
+    }
+
+    /// <summary>
+    /// Same as SsaStylesViewModel.FileExport/StorageExport.
+    /// </summary>
+    private static string ExportSsaStyles(List<SsaStyle> styles)
+    {
+        var subtitle = new Subtitle
+        {
+            Header = SubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(
+                AdvancedSubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(AdvancedSubStationAlpha.DefaultHeader, styles),
+                string.Empty)
+        };
+        return subtitle.ToText(new SubStationAlpha());
+    }
+
+    [Fact]
+    public void LoadStyles_ImportsExportedAssStyleFile()
+    {
+        var fileName = WriteTempFile(".ass", ExportAssStyles(MakeStyles()));
+
+        var styles = StyleFileImportHelper.LoadStyles(fileName, new AdvancedSubStationAlpha());
+
+        Assert.Equal(new[] { "Default", "Narrator" }, styles.Select(p => p.Name).ToArray());
+        Assert.Equal("Verdana", styles[1].FontName);
+        Assert.Equal(24, styles[1].FontSize);
+        Assert.True(styles[1].Italic);
+    }
+
+    [Fact]
+    public void LoadStyles_ImportsExportedSsaStyleFile()
+    {
+        var fileName = WriteTempFile(".ssa", ExportSsaStyles(MakeStyles()));
+
+        var styles = StyleFileImportHelper.LoadStyles(fileName, new SubStationAlpha());
+
+        Assert.Equal(new[] { "Default", "Narrator" }, styles.Select(p => p.Name).ToArray());
+        Assert.Equal("Verdana", styles[1].FontName);
+        Assert.True(styles[1].Italic);
+    }
+
+    [Fact]
+    public void LoadStyles_ImportsFromNormalSubtitleFile()
+    {
+        var subtitle = new Subtitle
+        {
+            Header = AdvancedSubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(AdvancedSubStationAlpha.DefaultHeader, MakeStyles())
+        };
+        subtitle.Paragraphs.Add(new Paragraph("Hello", 1000, 2000) { Extra = "Narrator" });
+        var fileName = WriteTempFile(".ass", subtitle.ToText(new AdvancedSubStationAlpha()));
+
+        var styles = StyleFileImportHelper.LoadStyles(fileName, new AdvancedSubStationAlpha());
+
+        Assert.Equal(new[] { "Default", "Narrator" }, styles.Select(p => p.Name).ToArray());
+    }
+
+    [Fact]
+    public void LoadStyles_ImportsAegisubStyFile()
+    {
+        var fileName = WriteTempFile(".sty",
+            "Style: FromSty,Tahoma,30,&H00FFFFFF,&H0000FFFF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,1,1,2,10,10,10,1" + Environment.NewLine);
+
+        var styles = StyleFileImportHelper.LoadStyles(fileName, new AdvancedSubStationAlpha());
+
+        var style = Assert.Single(styles);
+        Assert.Equal("FromSty", style.Name);
+        Assert.Equal("Tahoma", style.FontName);
+    }
+
+    [Fact]
+    public void LoadStyles_ReturnsEmptyForFileWithoutStyles()
+    {
+        var fileName = WriteTempFile(".ass", "hello world" + Environment.NewLine);
+
+        var styles = StyleFileImportHelper.LoadStyles(fileName, new AdvancedSubStationAlpha());
+
+        Assert.Empty(styles);
+    }
+
+    [Fact]
+    public void LoadStyles_ReturnsEmptyForMissingFile()
+    {
+        var fileName = Path.Combine(Path.GetTempPath(), "se-style-import-test-does-not-exist.ass");
+
+        var styles = StyleFileImportHelper.LoadStyles(fileName, new AdvancedSubStationAlpha());
+
+        Assert.Empty(styles);
+    }
+
+    public void Dispose()
+    {
+        foreach (var fileName in _tempFiles)
+        {
+            try
+            {
+                File.Delete(fileName);
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+    }
+}


### PR DESCRIPTION
Reported by email: ASSA style export works, but importing the exported file fails with **"Nothing to import"**.

## Cause

"Export..." in the ASSA/SSA styles window writes a file with styles but no dialogue lines:

```
[V4+ Styles]
Format: Name, Fontname, ...
Style: Default,Arial,20,...

[Events]
Format: Layer, Start, End, ...
```

Import went through `Subtitle.Parse(fileName, format)`, and `SubtitleFormat.IsMine` only accepts a file when `subtitle.Paragraphs.Count > _errorCount`. With zero dialogue lines the file is not recognized as a subtitle at all, `Parse` returns `null`, and the import ends with "Nothing to import".

The `.ssa` export in the SSA styles window was broken the same way.

## Fix

New `StyleFileImportHelper` shared by all four import paths (ASSA/SSA, file styles + storage styles). It keeps the existing behaviour for Aegisub `.sty` files and normal subtitle files, and adds a fallback that reads `Style:` lines straight from the file when it has a `[V4+ Styles]`/`[V4 Styles]` section but is not a parseable subtitle.

Everything from `[Events]` and down is cut away before parsing, since the events `Format:` line would otherwise be read as a style format line and shift the style column indices.

ASSA storage import also got the missing empty check - it previously opened an empty style picker instead of reporting anything.

## Tests

`StyleFileImportHelperTests` covers the `.ass` and `.ssa` export/import round-trip, a normal subtitle file, an Aegisub `.sty` file, a file without styles, and a missing file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)