### PR TITLE
Update CrispASR to v0.8.25 and add GigaAM-v3 (STT) + OmniVoice TTS (CrispASR)

### DIFF
--- a/src/libuilogic/AudioToText/WhisperChoice.cs
+++ b/src/libuilogic/AudioToText/WhisperChoice.cs
@@ -19,6 +19,7 @@
         public const string CrispAsrCanary = "Crisp ASR Canary";
         public const string CrispAsrCohere = "Crisp ASR Cohere";
         public const string CrispAsrQwen3 = "Crisp ASR Qwen3";
+        public const string CrispAsrGigaAm = "Crisp ASR GigaAM";
         public const string CrispAsrGlm = "Crisp ASR GLM";
         public const string CrispAsrFireRed = "Crisp ASR Fire Red";
         public const string CrispAsrFunAsrNano = "Crisp ASR Fun-ASR Nano";

--- a/src/ui/Assets/SpeechToText/CrispASRGigaAM.txt
+++ b/src/ui/Assets/SpeechToText/CrispASRGigaAM.txt
@@ -1,0 +1,8 @@
+
+🇷🇺 GigaAM-v3
+
+Type: Rotary Conformer encoder with CTC or RNN-T head (ai-sage)
+Focus: 🗣️ Russian only — language detection is skipped
+Note: the "e2e" models write punctuation and capital letters by themselves;
+      the plain ctc/rnnt models return lowercase text without punctuation
+

--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Nikse.SubtitleEdit.Features.Assa;
 using Nikse.SubtitleEdit.Features.Assa.AssaApplyAdvancedEffect;
 using Nikse.SubtitleEdit.Features.Assa.AssaApplyCustomOverrideTags;
@@ -157,6 +157,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VibeVoiceCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.CosyVoice3CrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.F5TtsCrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VoxCPM2CrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.MossTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.EngineSettings;
@@ -268,6 +269,7 @@ public static class DependencyInjectionExtensions
         collection.AddHttpClient<IIndexTtsCrispAsrDownloadService, IndexTtsCrispAsrDownloadService>();
         collection.AddHttpClient<ICosyVoice3CrispAsrDownloadService, CosyVoice3CrispAsrDownloadService>();
         collection.AddHttpClient<IF5TtsCrispAsrDownloadService, F5TtsCrispAsrDownloadService>();
+        collection.AddHttpClient<IOmniVoiceCrispAsrDownloadService, OmniVoiceCrispAsrDownloadService>();
         collection.AddHttpClient<IVoxCPM2CrispAsrDownloadService, VoxCPM2CrispAsrDownloadService>();
         collection.AddHttpClient<IMossTtsCrispAsrDownloadService, MossTtsCrispAsrDownloadService>();
         collection.AddHttpClient<IZonosTtsCrispAsrDownloadService, ZonosTtsCrispAsrDownloadService>();
@@ -444,6 +446,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<IndexTtsCrispAsrSettingsViewModel>();
         collection.AddTransient<CosyVoice3CrispAsrSettingsViewModel>();
         collection.AddTransient<F5TtsCrispAsrSettingsViewModel>();
+        collection.AddTransient<OmniVoiceCrispAsrSettingsViewModel>();
         collection.AddTransient<VoxCPM2CrispAsrSettingsViewModel>();
         collection.AddTransient<MossTtsCrispAsrSettingsViewModel>();
         collection.AddTransient<KokoroTtsSettingsViewModel>();

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
@@ -26,6 +26,7 @@ public class CrispAsrEngine : CrispAsrEngineBase
             new CrispAsrFireRed(),
             new CrispAsrFunAsrNano(),
             //new CrispAsrFunAsrMltNano(), does not work well enough
+            new CrispAsrGigaAm(),
             new CrispAsrGlm(),
             new CrispAsrGranite(),
             new CrispAsrQwen3(),

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngineBase.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngineBase.cs
@@ -28,7 +28,7 @@ public abstract class CrispAsrEngineBase : ICrispAsrEngine
     /// CrispASR ships several builds per platform whose sizes differ by two orders of magnitude,
     /// and the variant is picked at download time rather than now — so Windows and Linux get a
     /// range rather than a single number that would either understate the GPU bundles or scare
-    /// users off the CPU one. Figures are the v0.8.24 release assets
+    /// users off the CPU one. Figures are the v0.8.25 release assets
     /// (<see cref="Nikse.SubtitleEdit.Logic.Download.CrispAsrDownloadService"/> holds the pin);
     /// they drift with every release, so treat them as indicative.
     /// </summary>
@@ -38,17 +38,17 @@ public abstract class CrispAsrEngineBase : ICrispAsrEngine
         {
             if (OperatingSystem.IsWindows())
             {
-                // CPU ~7 MB, Vulkan ~33 MB, CUDA ~695 MB.
-                return "~7 MB – 695 MB";
+                // CPU ~7 MB, Vulkan ~32 MB, CUDA ~688 MB.
+                return "~7 MB – 688 MB";
             }
             if (OperatingSystem.IsLinux())
             {
-                // CPU ~24 MB (arm64 ~22 MB), Vulkan ~59 MB, ROCm ~89 MB, CUDA 13 ~205 MB, CUDA 12 ~271 MB.
-                return "~24 MB – 271 MB";
+                // CPU ~25 MB (arm64 ~23 MB), Vulkan ~55 MB, ROCm ~97 MB, CUDA 13 ~190 MB, CUDA 12 ~259 MB.
+                return "~25 MB – 259 MB";
             }
             if (OperatingSystem.IsMacOS())
             {
-                return "~14 MB";
+                return "~15 MB";
             }
             return string.Empty;
         }

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrGigaAm.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrGigaAm.cs
@@ -1,0 +1,249 @@
+using Nikse.SubtitleEdit.UiLogic.AudioToText;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+/// <summary>
+/// GigaAM-v3 (ai-sage) — a Russian-only ASR model, new as the <c>gigaam</c> backend in
+/// CrispASR v0.8.25. Rotary Conformer encoder with four published revisions: CTC and RNN-T
+/// heads, each in a character-level and an SPM ("e2e") variant.
+///
+/// The <c>e2e</c> heads emit punctuation and capitalisation natively, which is what subtitles
+/// want — the plain character-level heads return a bare lowercase transcript. Verified against
+/// the pinned v0.8.25 binary on Apple M4 / Metal with `say -v Milena` audio:
+///   e2e-rnnt-q8_0 → "Привет." / "Это тест распознавания" / "русской речи." (27x realtime)
+///   ctc-q4_k      → "привет это тест распознавания русской речи" (no case, no punctuation)
+/// so the e2e revisions are listed first and RNN-T is the registry default upstream picks.
+///
+/// The backend reports Russian as its only language and CrispASR skips language detection for
+/// it ("gigaam is ru-only — skipping language detection"). Passing <c>-l ru</c> is accepted;
+/// any other code is ignored with a warning, so the language list holds Russian alone.
+/// </summary>
+public class CrispAsrGigaAm : CrispAsrEngineBase
+{
+    public static string StaticName => "Crisp ASR GigaAM";
+    public override string Name => StaticName;
+    public override string Choice => WhisperChoice.CrispAsrGigaAm;
+    public override string Url => "https://github.com/CrispStrobe/CrispASR";
+    public override string BackendName => "gigaam";
+    public override string DefaultLanguage => "ru";
+    public override bool IncludeLanguage => true;
+    public override bool HasNativeTimestamps => true;
+
+    public override List<WhisperLanguage> Languages =>
+        new()
+        {
+            new WhisperLanguage("ru", "russian"),
+        };
+
+    public override List<WhisperModel> Models =>
+       new()
+       {
+            // e2e (SPM) revisions first: punctuation + capitalisation straight out of the
+            // model, so no separate punctuation-restoration pass is needed.
+            new WhisperModel
+            {
+                Name = "gigaam-v3-e2e-rnnt-q8_0.gguf",
+                Size = "249 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/gigaam-v3-GGUF/resolve/main/gigaam-v3-e2e-rnnt-q8_0.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "gigaam-v3-e2e-rnnt-q4_k.gguf",
+                Size = "154 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/gigaam-v3-GGUF/resolve/main/gigaam-v3-e2e-rnnt-q4_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "gigaam-v3-e2e-rnnt-f16.gguf",
+                Size = "452 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/gigaam-v3-GGUF/resolve/main/gigaam-v3-e2e-rnnt-f16.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "gigaam-v3-e2e-ctc-q8_0.gguf",
+                Size = "245 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/gigaam-v3-GGUF/resolve/main/gigaam-v3-e2e-ctc-q8_0.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "gigaam-v3-e2e-ctc-q4_k.gguf",
+                Size = "151 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/gigaam-v3-GGUF/resolve/main/gigaam-v3-e2e-ctc-q4_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "gigaam-v3-e2e-ctc-f16.gguf",
+                Size = "449 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/gigaam-v3-GGUF/resolve/main/gigaam-v3-e2e-ctc-f16.gguf",
+                ],
+            },
+
+            // Character-level heads: lowercase, unpunctuated output. Kept for users who feed
+            // the transcript through their own casing/punctuation step, or who want the raw
+            // character alignment rather than SPM pieces.
+            new WhisperModel
+            {
+                Name = "gigaam-v3-rnnt-q8_0.gguf",
+                Size = "247 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/gigaam-v3-GGUF/resolve/main/gigaam-v3-rnnt-q8_0.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "gigaam-v3-rnnt-q4_k.gguf",
+                Size = "153 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/gigaam-v3-GGUF/resolve/main/gigaam-v3-rnnt-q4_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "gigaam-v3-rnnt-f16.gguf",
+                Size = "451 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/gigaam-v3-GGUF/resolve/main/gigaam-v3-rnnt-f16.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "gigaam-v3-ctc-q8_0.gguf",
+                Size = "245 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/gigaam-v3-GGUF/resolve/main/gigaam-v3-ctc-q8_0.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "gigaam-v3-ctc-q4_k.gguf",
+                Size = "151 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/gigaam-v3-GGUF/resolve/main/gigaam-v3-ctc-q4_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "gigaam-v3-ctc-f16.gguf",
+                Size = "449 MB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/gigaam-v3-GGUF/resolve/main/gigaam-v3-ctc-f16.gguf",
+                ],
+            },
+       };
+
+    public override string Extension => string.Empty;
+    public override string UnpackSkipFolder => string.Empty;
+
+    public override bool IsEngineInstalled()
+    {
+        var executableFile = GetExecutable();
+        return File.Exists(executableFile);
+    }
+
+    public override string ToString()
+    {
+        return CrispAsrEngine.GetBackendDisplayName(this);
+    }
+
+    public override string GetAndCreateWhisperFolder()
+    {
+        var folder = Se.CrispAsrFolder;
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public override string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel)
+    {
+        var folder = GetAndCreateWhisperFolder();
+        var modelsFolder = Path.Combine(folder, "models");
+        if (!Directory.Exists(modelsFolder))
+        {
+            Directory.CreateDirectory(modelsFolder);
+        }
+
+        return modelsFolder;
+    }
+
+    public override string GetExecutable()
+    {
+        string fullPath = Path.Combine(GetAndCreateWhisperFolder(), GetExecutableFileName());
+        return fullPath;
+    }
+
+    public override bool IsModelInstalled(WhisperModel model)
+    {
+        var modelFile = GetModelForCmdLine(model.Name);
+        if (!File.Exists(modelFile))
+        {
+            return false;
+        }
+
+        return new FileInfo(modelFile).Length > 10_000_000;
+    }
+
+    public override string GetModelForCmdLine(string modelName)
+    {
+        var modelFileName = Path.Combine(GetAndCreateWhisperModelFolder(null), modelName);
+        return modelFileName;
+    }
+
+    public override string GetWhisperModelDownloadFileName(WhisperModel whisperModel, string url)
+    {
+        var folder = GetAndCreateWhisperModelFolder(whisperModel);
+        var fileNameOnly = Path.GetFileName(url);
+        var fileName = Path.Combine(folder, fileNameOnly);
+        return fileName;
+    }
+
+    internal static string GetExecutableFileName()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return "crispasr.exe";
+        }
+
+        return "crispasr";
+    }
+
+    public override bool CanBeDownloaded()
+    {
+        return true;
+    }
+
+    public override string CommandLineParameter
+    {
+        get => Se.Settings.Tools.AudioToText.CommandLineParameterCrispAsrGigaAm;
+        set => Se.Settings.Tools.AudioToText.CommandLineParameterCrispAsrGigaAm = value;
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -67,6 +67,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     private Task? _downloadTaskVoxCPM2CrispAsrVoices;
     private Task? _downloadTaskMossTtsCrispAsrModels;
     private Task? _downloadTaskMossTtsCrispAsrVoices;
+    private Task? _downloadTaskOmniVoiceCrispAsrModels;
     private Task? _downloadTaskZonosTtsCrispAsrModels;
     private Task? _downloadTaskZonosTtsCrispAsrVoices;
     private Task? _downloadTaskOmniVoice;
@@ -88,6 +89,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     private readonly IF5TtsCrispAsrDownloadService _f5TtsCrispAsrDownloadService;
     private readonly IVoxCPM2CrispAsrDownloadService _voxCPM2CrispAsrDownloadService;
     private readonly IMossTtsCrispAsrDownloadService _mossTtsCrispAsrDownloadService;
+    private readonly IOmniVoiceCrispAsrDownloadService _omniVoiceCrispAsrDownloadService;
     private readonly IZonosTtsCrispAsrDownloadService _zonosTtsCrispAsrDownloadService;
     private readonly IOmniVoiceDownloadService _omniVoiceDownloadService;
     private readonly CancellationTokenSource _cancellationTokenSource;
@@ -123,6 +125,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         IF5TtsCrispAsrDownloadService f5TtsCrispAsrDownloadService,
         IVoxCPM2CrispAsrDownloadService voxCPM2CrispAsrDownloadService,
         IMossTtsCrispAsrDownloadService mossTtsCrispAsrDownloadService,
+        IOmniVoiceCrispAsrDownloadService omniVoiceCrispAsrDownloadService,
         IZonosTtsCrispAsrDownloadService zonosTtsCrispAsrDownloadService,
         IOmniVoiceDownloadService omniVoiceDownloadService)
     {
@@ -137,6 +140,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         _f5TtsCrispAsrDownloadService = f5TtsCrispAsrDownloadService;
         _voxCPM2CrispAsrDownloadService = voxCPM2CrispAsrDownloadService;
         _mossTtsCrispAsrDownloadService = mossTtsCrispAsrDownloadService;
+        _omniVoiceCrispAsrDownloadService = omniVoiceCrispAsrDownloadService;
         _zonosTtsCrispAsrDownloadService = zonosTtsCrispAsrDownloadService;
         _omniVoiceDownloadService = omniVoiceDownloadService;
         _zipUnpacker = zipUnpacker;
@@ -943,6 +947,32 @@ public partial class DownloadTtsViewModel : ObservableObject
             // cloning from user-supplied 16 kHz WAVs. After the model bundle finishes, chain the
             // qwen3-tts.cpp voice pack ZIP so the user has the shared reference WAVs available
             // without a second manual download step. Baked presets work regardless of this step.
+            // OmniVoice (CrispASR) is model-only: the backend ships a usable built-in voice,
+            // so there is no voices ZIP to fetch afterwards the way CosyVoice3/VoxCPM2 need.
+            if (_downloadTaskOmniVoiceCrispAsrModels is { IsCompletedSuccessfully: true })
+            {
+                _timer.Stop();
+                _downloadTaskOmniVoiceCrispAsrModels = null;
+                OkPressed = true;
+                Close();
+                return;
+            }
+            else if (_downloadTaskOmniVoiceCrispAsrModels is { IsFaulted: true })
+            {
+                _timer.Stop();
+                var ex = _downloadTaskOmniVoiceCrispAsrModels.Exception?.InnerException ?? _downloadTaskOmniVoiceCrispAsrModels.Exception;
+                if (ex is OperationCanceledException)
+                {
+                    ProgressText = "Download canceled";
+                    Close();
+                }
+                else
+                {
+                    ProgressText = "Download failed";
+                    Error = ex?.Message ?? "Unknown error";
+                }
+            }
+
             if (_downloadTaskCosyVoice3CrispAsrModels is { IsCompletedSuccessfully: true })
             {
                 _timer.Stop();
@@ -1960,6 +1990,29 @@ public partial class DownloadTtsViewModel : ObservableObject
 
         _downloadTaskVoxCPM2CrispAsrModels =
             _voxCPM2CrispAsrDownloadService.DownloadModels(VoxCPM2CrispAsr.GetSetModelsFolder(), resolved, downloadProgress, titleProgress, _cancellationTokenSource.Token);
+    }
+
+    public void StartDownloadOmniVoiceCrispAsrModels(string? modelKey = null)
+    {
+        var resolved = OmniVoiceCrispAsr.ResolveModelKey(modelKey);
+        var modelFileName = OmniVoiceCrispAsr.GetModelFileName(resolved);
+        TitleText = $"Downloading OmniVoice (CrispASR) model ({resolved}): {modelFileName}";
+
+        var downloadProgress = new Progress<float>(number =>
+        {
+            var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+            var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+            ProgressValue = percentage;
+            ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+        });
+
+        var titleProgress = new Action<string>(title =>
+        {
+            Dispatcher.UIThread.Post(() => TitleText = title);
+        });
+
+        _downloadTaskOmniVoiceCrispAsrModels =
+            _omniVoiceCrispAsrDownloadService.DownloadModels(OmniVoiceCrispAsr.GetSetModelsFolder(), resolved, downloadProgress, titleProgress, _cancellationTokenSource.Token);
     }
 
     public void StartDownloadMossTtsCrispAsrModels(string? modelKey = null)

--- a/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceCrispAsr.cs
@@ -1,0 +1,901 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// OmniVoice run through the CrispASR runtime (the <c>omnivoice</c> backend) instead of the
+/// standalone <c>omnivoice-tts</c> CLI that <see cref="OmniVoiceTtsCpp"/> drives. Same model
+/// family, but it reuses the CrispASR runtime a user has already installed for speech-to-text
+/// and runs as a persistent server, so the model is loaded once instead of once per line.
+///
+/// Two GGUFs are needed and both live in SE's CrispASR/models folder:
+///   - Main model : omnivoice-{q4_k,q8_0,f16}.gguf     (the quant the user picks)
+///   - Tokenizer  : omnivoice-tokenizer-f16.gguf       (passed via --codec-model)
+///
+/// ⚠ The tokenizer must be the F16 build. cstr/omnivoice-GGUF also publishes
+/// <c>omnivoice-tokenizer-q8_0.gguf</c>, and it loads and synthesises fine — but its encoder
+/// tensors cannot be read back as f32 (crispasr logs <c>read_tensor_f32: unsupported type 8</c>
+/// per quantizer), so encoding a *reference* voice yields garbage codes and the clone comes out
+/// as noise. Worse, crispasr caches the encoded reference by audio content, so once a q8_0 run
+/// has poisoned the cache a later F16 run reuses the bad codes. SE therefore only ever ships
+/// and passes the F16 tokenizer. Verified against the pinned v0.8.25 binary on Apple M4 / Metal
+/// by median-F0 comparison of reference vs clone:
+///   female ref 191.5 Hz → clone 190.6 Hz, male ref 110.2 Hz → clone 111.8 Hz (both intelligible)
+///   same run with the q8_0 tokenizer → 481 Hz, transcribes to "I." (noise)
+///
+/// Unlike VoxCPM2/MOSS-TTS this backend has a usable built-in voice, so the combo offers
+/// "Default" (no reference) alongside any imported reference WAVs — matching what the
+/// standalone OmniVoice TTS engine offers.
+///
+/// Server usage:
+///   crispasr --server --backend omnivoice -m omnivoice-q4_k.gguf \
+///       --codec-model omnivoice-tokenizer-f16.gguf --host 127.0.0.1 --port N \
+///       [--voice reference.wav --ref-text "transcript"]
+/// then POST /v1/audio/speech with {"input": ..., "response_format": "wav", "speed": x}.
+/// Confirmed on crispasr 0.8.25: the reference comes from the startup <c>--voice</c> flag (the
+/// per-request log reports <c>voice='&lt;startup&gt;'</c>), so the server is torn down and
+/// restarted when the selected voice or ref-text changes — the same shape the other cloning
+/// CrispASR engines settled on after #12757.
+/// </summary>
+public class OmniVoiceCrispAsr : ITtsEngine
+{
+    public string Name => "OmniVoice TTS (CrispASR)";
+    public string Description => "646 languages, built-in voice + zero-shot cloning, via CrispASR";
+    public bool HasLanguageParameter => true;
+    public bool HasApiKey => false;
+    public bool HasRegion => false;
+    public bool HasModel => true;
+    public bool HasKeyFile => false;
+
+    // Three quants of the LLM half. The label total includes the F16 tokenizer companion
+    // (~403 MB), which every quant shares.
+    public const string ModelKeyQ4K = "Q4_K (~1 GB)";
+    public const string ModelKeyQ8_0 = "Q8_0 (~1.2 GB)";
+    public const string ModelKeyF16 = "F16 (~1.6 GB)";
+    public const string DefaultModelKey = ModelKeyQ4K;
+
+    public const string ModelQ4KFileName = "omnivoice-q4_k.gguf";
+    public const string ModelQ8_0FileName = "omnivoice-q8_0.gguf";
+    public const string ModelF16FileName = "omnivoice-f16.gguf";
+
+    /// <summary>
+    /// The F16 tokenizer/codec companion. Deliberately not user-selectable — see the class
+    /// remarks for why the q8_0 build silently breaks voice cloning.
+    /// </summary>
+    public const string TokenizerFileName = "omnivoice-tokenizer-f16.gguf";
+
+    public const string BackendName = "omnivoice";
+
+    /// <summary>
+    /// Name shown for the model's own voice, i.e. synthesis with no reference audio. Matches the
+    /// standalone OmniVoice TTS engine so the two behave the same in the voice combo.
+    /// </summary>
+    public const string DefaultVoiceName = "Default";
+
+    /// <summary>
+    /// All filenames that must sit in <see cref="GetSetModelsFolder"/> for the chosen quant:
+    /// the picked main model plus the shared F16 tokenizer. Main first so the download dialog
+    /// reports the big file before the small one.
+    /// </summary>
+    public static string[] GetRequiredFileNames(string? modelKey) => new[]
+    {
+        GetModelFileName(modelKey),
+        TokenizerFileName,
+    };
+
+    // Exact byte sizes from the HF tree API (cstr/omnivoice-GGUF). A truncated GGUF crashes the
+    // loader at server startup, so size is checked before the file is considered installed.
+    private static readonly Dictionary<string, long> ExpectedFileSizes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [ModelQ4KFileName] = 597547584L,
+        [ModelQ8_0FileName] = 817748544L,
+        [ModelF16FileName] = 1230625280L,
+        [TokenizerFileName] = 403183616L,
+    };
+
+    public static string ResolveModelKey(string? modelKey)
+    {
+        if (string.IsNullOrEmpty(modelKey))
+        {
+            var saved = Se.Settings.Video.TextToSpeech.OmniVoiceCrispAsrModel;
+            return string.IsNullOrEmpty(saved) ? DefaultModelKey : ResolveModelKey(saved);
+        }
+
+        return modelKey switch
+        {
+            ModelKeyF16 => ModelKeyF16,
+            ModelKeyQ8_0 => ModelKeyQ8_0,
+            _ => ModelKeyQ4K,
+        };
+    }
+
+    public static string GetModelFileName(string? modelKey) => ResolveModelKey(modelKey) switch
+    {
+        ModelKeyF16 => ModelF16FileName,
+        ModelKeyQ8_0 => ModelQ8_0FileName,
+        _ => ModelQ4KFileName,
+    };
+
+    public static bool IsValidLocalModelFile(string path, string fileName)
+    {
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
+        if (!ExpectedFileSizes.TryGetValue(fileName, out var expected))
+        {
+            return true;
+        }
+
+        try
+        {
+            return new FileInfo(path).Length == expected;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    // Measured RTF is ~1.2-1.8 on Apple M4 / Metal (the codec half runs on CPU), so a long
+    // subtitle line is seconds rather than minutes. 30 minutes still matches the other CrispASR
+    // TTS engines and leaves room for CPU-only machines; users can cancel from the
+    // GeneratingAudioWindow.
+    private static readonly HttpClient HttpClient = new()
+    {
+        Timeout = TimeSpan.FromMinutes(30),
+    };
+    private static readonly SemaphoreSlim ServerLock = new(1, 1);
+    private static Process? _serverProcess;
+    private static int _serverPort;
+    private static string? _serverLaunchCommand;
+    private static string? _serverModelKey;
+    // The reference is a startup flag, so changing the voice or its transcript means tear-down
+    // and restart.
+    private static string? _serverVoicePath;
+    private static string? _serverRefText;
+    private static bool _processExitHooked;
+    private static readonly StringBuilder _serverLog = new();
+
+    private static string ServerBaseUrl => $"http://127.0.0.1:{_serverPort}";
+
+    public Task<bool> IsInstalled(string? region)
+    {
+        return Task.FromResult(File.Exists(GetCrispAsrExecutable()));
+    }
+
+    public override string ToString() => Name;
+
+    public static string GetCrispAsrExecutable()
+    {
+        return new CrispAsrCohere().GetExecutable();
+    }
+
+    public static DownloadHashManager.UpdateStatus GetEngineUpdateStatus()
+    {
+        var exe = GetCrispAsrExecutable();
+        if (!File.Exists(exe))
+        {
+            return DownloadHashManager.UpdateStatus.Unknown;
+        }
+
+        var folder = Path.GetDirectoryName(exe);
+        return string.IsNullOrEmpty(folder)
+            ? DownloadHashManager.UpdateStatus.Unknown
+            : DownloadHashManager.GetSidecarStatus(folder);
+    }
+
+    public static string GetSetFolder()
+    {
+        if (!Directory.Exists(Se.TextToSpeechFolder))
+        {
+            Directory.CreateDirectory(Se.TextToSpeechFolder);
+        }
+
+        var folder = Path.Combine(Se.TextToSpeechFolder, "OmniVoiceCrispAsr");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public static string GetSetModelsFolder()
+    {
+        var modelsFolder = Path.Combine(Se.CrispAsrFolder, "models");
+        if (!Directory.Exists(modelsFolder))
+        {
+            Directory.CreateDirectory(modelsFolder);
+        }
+
+        return modelsFolder;
+    }
+
+    public static string GetSetVoicesFolder()
+    {
+        var voicesFolder = Path.Combine(GetSetFolder(), "voices");
+        if (!Directory.Exists(voicesFolder))
+        {
+            Directory.CreateDirectory(voicesFolder);
+        }
+
+        SeedVoicesFromOmniVoiceTtsCppIfEmpty(voicesFolder);
+        return voicesFolder;
+    }
+
+    private static bool _voiceSeedAttempted;
+
+    /// <summary>
+    /// One-time best-effort seed from the standalone OmniVoice TTS engine's voices folder, so a
+    /// user who already imported reference WAVs there does not have to import them again here.
+    /// Copies the WAV (resampled to 24 kHz mono, OmniVoice's native rate) and any .txt sidecar.
+    /// </summary>
+    private static void SeedVoicesFromOmniVoiceTtsCppIfEmpty(string voicesFolder)
+    {
+        if (_voiceSeedAttempted)
+        {
+            return;
+        }
+        _voiceSeedAttempted = true;
+
+        try
+        {
+            if (Directory.EnumerateFiles(voicesFolder, "*.wav").Any())
+            {
+                return;
+            }
+
+            var sourceFolder = OmniVoiceTtsCpp.GetSetVoicesFolder();
+            if (!Directory.Exists(sourceFolder) || !Directory.EnumerateFiles(sourceFolder, "*.wav").Any())
+            {
+                return;
+            }
+
+            foreach (var src in Directory.GetFiles(sourceFolder, "*.wav"))
+            {
+                var dest = Path.Combine(voicesFolder, Path.GetFileName(src));
+                if (!File.Exists(dest))
+                {
+                    try
+                    {
+                        var ffmpeg = FfmpegGenerator.ConvertToMono24kHzWav(src, dest);
+                        if (!ffmpeg.Start())
+                        {
+                            File.Copy(src, dest);
+                        }
+                        else
+                        {
+                            ffmpeg.WaitForExit();
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Se.LogError(ex, $"OmniVoice (CrispASR): resample seed '{src}' failed; falling back to plain copy");
+                        try
+                        {
+                            if (!File.Exists(dest))
+                            {
+                                File.Copy(src, dest);
+                            }
+                        }
+                        catch { }
+                    }
+                }
+
+                var sidecar = Path.ChangeExtension(src, ".txt");
+                if (File.Exists(sidecar))
+                {
+                    var sidecarDest = Path.ChangeExtension(dest, ".txt");
+                    if (!File.Exists(sidecarDest))
+                    {
+                        // These sidecars were written by OmniVoice TTS' own import, which stores
+                        // the spoken transcription, so they are usable as ref-text as-is.
+                        try { File.Copy(sidecar, sidecarDest); } catch { }
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "OmniVoice (CrispASR): voice seeding from OmniVoice TTS folder failed");
+        }
+    }
+
+    public static string GetModelPath(string? modelKey = null) =>
+        Path.Combine(GetSetModelsFolder(), GetModelFileName(modelKey));
+
+    public static string GetTokenizerPath() =>
+        Path.Combine(GetSetModelsFolder(), TokenizerFileName);
+
+    public static string GetCrispAsrCacheFolder() =>
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".cache", "crispasr");
+
+    public static bool TrySeedModelFromCrispAsrCache(string fileName, string destinationPath)
+    {
+        if (IsValidLocalModelFile(destinationPath, fileName))
+        {
+            return true;
+        }
+
+        try
+        {
+            if (File.Exists(destinationPath))
+            {
+                Se.LogError($"OmniVoice (CrispASR): removing wrong-sized local model file {destinationPath}");
+                File.Delete(destinationPath);
+            }
+
+            var cachePath = Path.Combine(GetCrispAsrCacheFolder(), fileName);
+            if (!IsValidLocalModelFile(cachePath, fileName))
+            {
+                return false;
+            }
+
+            File.Copy(cachePath, destinationPath);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"OmniVoice (CrispASR): cache seed copy failed for {fileName}");
+            return false;
+        }
+    }
+
+    public static bool AreModelsInstalled(string? modelKey = null)
+    {
+        var modelsFolder = GetSetModelsFolder();
+        foreach (var name in GetRequiredFileNames(modelKey))
+        {
+            if (!IsValidLocalModelFile(Path.Combine(modelsFolder, name), name))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public Task<Voice[]> GetVoices(string language)
+    {
+        // The backend has a usable built-in voice, so "Default" leads and cloning is opt-in.
+        var result = new List<Voice>
+        {
+            new Voice(new OmniVoiceCrispAsrVoice(DefaultVoiceName, string.Empty)),
+        };
+
+        var voicesFolder = GetSetVoicesFolder();
+        if (Directory.Exists(voicesFolder))
+        {
+            foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
+            {
+                var name = Path.GetFileNameWithoutExtension(file).Replace('_', ' ');
+                result.Add(new Voice(new OmniVoiceCrispAsrVoice(name, file)));
+            }
+        }
+
+        return Task.FromResult(result.ToArray());
+    }
+
+    public bool IsVoiceInstalled(Voice voice) => true;
+
+    public Task<string[]> GetRegions() => Task.FromResult(Array.Empty<string>());
+
+    public Task<string[]> GetModels() => Task.FromResult(new[] { ModelKeyQ4K, ModelKeyQ8_0, ModelKeyF16 });
+
+    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(OmniVoiceLanguages.All);
+
+    public Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken) =>
+        GetVoices(language);
+
+    public async Task<TtsResult> Speak(
+        string text,
+        string outputFolder,
+        Voice voice,
+        TtsLanguage? language,
+        string? region,
+        string? model,
+        CancellationToken cancellationToken)
+    {
+        if (voice.EngineVoice is not OmniVoiceCrispAsrVoice omniVoice)
+        {
+            throw new ArgumentException("Voice is not an OmniVoiceCrispAsrVoice");
+        }
+
+        var voicePath = omniVoice.FilePath ?? string.Empty;
+        var refText = string.IsNullOrEmpty(voicePath) ? string.Empty : TryReadRefText(voicePath);
+        var modelKey = ResolveModelKey(model);
+        await EnsureServerRunningAsync(modelKey, voicePath, refText, cancellationToken);
+
+        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+
+        var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.OmniVoiceCrispAsrSpeed, 0.25, 4.0);
+
+        // No `voice` field on purpose: like the other cloning CrispASR backends, omnivoice reads
+        // the reference from the startup --voice flag and treats a per-request `voice` as a file
+        // path, so sending a bare stem would drop us to the built-in voice without saying so
+        // (#12757). The server restarts on (voice, ref-text) change instead — see
+        // EnsureServerRunningAsync.
+        var payload = new Dictionary<string, object>
+        {
+            ["input"] = text,
+            ["response_format"] = "wav",
+            ["speed"] = speed,
+        };
+
+        // Only meaningful for cloned voices; the built-in voice impersonates no one.
+        if (!string.IsNullOrEmpty(voicePath))
+        {
+            CrispAsrTtsProvenance.AddSpeechAttestations(payload);
+        }
+
+        var body = JsonSerializer.Serialize(payload);
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        Se.WriteToolsLog($"OmniVoice (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (voice={omniVoice}, refTextLen={refText.Length}, textLen={text.Length})");
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await HttpClient.PostAsync($"{ServerBaseUrl}/v1/audio/speech", content, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            var serverLog = SnapshotServerLog();
+            var launchCommand = _serverLaunchCommand;
+            var died = _serverProcess?.HasExited == true;
+            if (died)
+            {
+                StopServerInternal();
+            }
+
+            var failMsg = $"OmniVoice (CrispASR) request failed — Voice: {omniVoice}, Text: {text}, "
+                + $"RequestJson: {body}, ServerExited: {died}, ServerLog: {serverLog}"
+                + LaunchCmdSuffix(launchCommand);
+            Se.LogError(ex, failMsg);
+            Se.WriteToolsLog(failMsg);
+
+            throw new InvalidOperationException(
+                (died
+                    ? "OmniVoice (CrispASR) — the crispasr server crashed during synthesis."
+                    : "OmniVoice (CrispASR) request failed — the connection to the crispasr server was dropped.")
+                + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}")
+                + LaunchCmdSuffix(launchCommand),
+                ex);
+        }
+
+        using (response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await SafeReadErrorAsync(response, cancellationToken);
+                var serverLog = SnapshotServerLog();
+                var launchCommand = _serverLaunchCommand;
+                var errMsg = $"OmniVoice (CrispASR) server error {(int)response.StatusCode} {response.StatusCode} — "
+                    + $"Voice: {omniVoice}, Text: {text}, RequestJson: {body}, "
+                    + $"ResponseBody: {errorBody}, ServerLog: {serverLog}"
+                    + LaunchCmdSuffix(launchCommand);
+                Se.LogError(errMsg);
+                Se.WriteToolsLog(errMsg);
+                throw new InvalidOperationException(
+                    $"OmniVoice (CrispASR) synthesis failed ({(int)response.StatusCode}): {errorBody}"
+                    + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}")
+                    + LaunchCmdSuffix(launchCommand));
+            }
+
+            await using var fileStream = File.Create(outputFileName);
+            await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            await contentStream.CopyToAsync(fileStream, cancellationToken);
+        }
+
+        return new TtsResult(outputFileName, text);
+    }
+
+    private static string TryReadRefText(string wavPath)
+    {
+        try
+        {
+            var sidecar = Path.ChangeExtension(wavPath, ".txt");
+            if (!File.Exists(sidecar))
+            {
+                return string.Empty;
+            }
+
+            var text = File.ReadAllText(sidecar).Trim();
+            return Qwen3TtsCrispAsr.LooksLikeUnusableTranscript(text) ? string.Empty : text;
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+
+    private static string FormatLaunchCommand(string exe, System.Collections.ObjectModel.Collection<string> args)
+    {
+        static string Quote(string s) =>
+            !string.IsNullOrEmpty(s) && s.IndexOfAny(new[] { ' ', '\t' }) >= 0
+                ? "\"" + s.Replace("\"", "\\\"") + "\""
+                : s;
+
+        var sb = new StringBuilder(Quote(exe));
+        foreach (var a in args)
+        {
+            sb.Append(' ').Append(Quote(a));
+        }
+        return sb.ToString();
+    }
+
+    private static string LaunchCmdSuffix(string? launchCommand) =>
+        string.IsNullOrEmpty(launchCommand)
+            ? string.Empty
+            : $"{Environment.NewLine}Launch command: {launchCommand}";
+
+    private static async Task<string> SafeReadErrorAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            return await response.Content.ReadAsStringAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            return $"<failed to read error body: {ex.Message}>";
+        }
+    }
+
+    private static async Task EnsureServerRunningAsync(string modelKey, string voicePath, string refText, CancellationToken ct)
+    {
+        bool MatchesCurrent() =>
+            _serverProcess is { HasExited: false } && _serverPort != 0
+            && string.Equals(_serverModelKey, modelKey, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(_serverVoicePath, voicePath, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(_serverRefText, refText, StringComparison.Ordinal);
+
+        if (MatchesCurrent())
+        {
+            return;
+        }
+
+        await ServerLock.WaitAsync(ct);
+        try
+        {
+            if (MatchesCurrent())
+            {
+                return;
+            }
+
+            if (_serverProcess != null)
+            {
+                StopServerInternal();
+            }
+
+            var exe = GetCrispAsrExecutable();
+            if (!File.Exists(exe))
+            {
+                throw new FileNotFoundException(
+                    "CrispASR executable not found. Install CrispASR via Video → Audio to text first.", exe);
+            }
+
+            var modelPath = GetModelPath(modelKey);
+            var hasLocalModel = AreModelsInstalled(modelKey);
+
+            var port = FindFreeLoopbackPort();
+            var psi = new ProcessStartInfo
+            {
+                WorkingDirectory = Path.GetDirectoryName(exe) ?? GetSetFolder(),
+                FileName = exe,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+            };
+            psi.ArgumentList.Add("--server");
+            psi.ArgumentList.Add("--backend");
+            psi.ArgumentList.Add(BackendName);
+            psi.ArgumentList.Add("-m");
+            psi.ArgumentList.Add(hasLocalModel ? modelPath : "auto");
+            if (hasLocalModel)
+            {
+                // Pin the F16 tokenizer explicitly. Left to sibling discovery, crispasr would be
+                // free to pick up a q8_0 tokenizer sitting in the same folder, which silently
+                // breaks cloning — see the class remarks.
+                psi.ArgumentList.Add("--codec-model");
+                psi.ArgumentList.Add(GetTokenizerPath());
+            }
+            else
+            {
+                psi.ArgumentList.Add("--auto-download");
+            }
+            psi.ArgumentList.Add("--host");
+            psi.ArgumentList.Add("127.0.0.1");
+            psi.ArgumentList.Add("--port");
+            psi.ArgumentList.Add(port.ToString());
+            psi.ArgumentList.Add("--voice-dir");
+            psi.ArgumentList.Add(GetSetVoicesFolder());
+            CrispAsrTtsProvenance.AddServerMarkingArgs(psi.ArgumentList, exe);
+
+            if (!string.IsNullOrEmpty(voicePath))
+            {
+                psi.ArgumentList.Add("--voice");
+                psi.ArgumentList.Add(voicePath);
+                if (!string.IsNullOrEmpty(refText))
+                {
+                    psi.ArgumentList.Add("--ref-text");
+                    psi.ArgumentList.Add(refText);
+                }
+            }
+
+            var process = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start crispasr (omnivoice)");
+
+            var launchCommand = FormatLaunchCommand(exe, psi.ArgumentList);
+            _serverLaunchCommand = launchCommand;
+            Se.WriteToolsLog("OmniVoice (CrispASR) server starting — "
+                + $"PID: {process.Id}, "
+                + $"Cmd: {launchCommand}");
+
+            lock (_serverLog) _serverLog.Clear();
+            process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
+            };
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
+            };
+            process.BeginErrorReadLine();
+            process.BeginOutputReadLine();
+
+            _serverProcess = process;
+            _serverPort = port;
+            _serverModelKey = modelKey;
+            _serverVoicePath = voicePath;
+            _serverRefText = refText;
+            HookProcessExitOnce();
+
+            // First-run auto-download pulls up to ~1.6 GB, so it gets a generous deadline.
+            var deadline = DateTime.UtcNow.AddMinutes(hasLocalModel ? 5 : 30);
+            while (DateTime.UtcNow < deadline)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (process.HasExited)
+                {
+                    var tail = SnapshotServerLog();
+                    var exitCode = process.ExitCode;
+                    var exitedLaunchCommand = _serverLaunchCommand;
+                    _serverProcess = null;
+                    _serverPort = 0;
+                    _serverLaunchCommand = null;
+                    _serverModelKey = null;
+                    _serverVoicePath = null;
+                    _serverRefText = null;
+                    throw new InvalidOperationException(
+                        $"crispasr (omnivoice) exited during startup (code {exitCode}). Output: {tail}"
+                        + LaunchCmdSuffix(exitedLaunchCommand));
+                }
+                if (await ProbeHealthAsync(port, TimeSpan.FromSeconds(2), ct))
+                {
+                    return;
+                }
+                await Task.Delay(TimeSpan.FromSeconds(1), ct);
+            }
+
+            var lastOutput = SnapshotServerLog();
+            var timeoutLaunchCommand = _serverLaunchCommand;
+            StopServerInternal();
+            throw new TimeoutException(
+                $"crispasr (omnivoice) did not report healthy within {(hasLocalModel ? 5 : 30)} minutes. Last output: {lastOutput}"
+                + LaunchCmdSuffix(timeoutLaunchCommand));
+        }
+        finally
+        {
+            ServerLock.Release();
+        }
+    }
+
+    private static string SnapshotServerLog()
+    {
+        lock (_serverLog)
+        {
+            var s = _serverLog.ToString().TrimEnd();
+            return s.Length > 2000 ? s[^2000..] : s;
+        }
+    }
+
+    private static async Task<bool> ProbeHealthAsync(int port, TimeSpan timeout, CancellationToken ct)
+    {
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(timeout);
+            using var resp = await HttpClient.GetAsync($"http://127.0.0.1:{port}/health", cts.Token);
+            return resp.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static int FindFreeLoopbackPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private static void HookProcessExitOnce()
+    {
+        if (_processExitHooked)
+        {
+            return;
+        }
+        _processExitHooked = true;
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
+    }
+
+    public static void StopServer() => StopServerInternal();
+
+    private static void StopServerInternal()
+    {
+        var p = _serverProcess;
+        _serverProcess = null;
+        _serverPort = 0;
+        _serverLaunchCommand = null;
+        _serverModelKey = null;
+        _serverVoicePath = null;
+        _serverRefText = null;
+        if (p == null)
+        {
+            return;
+        }
+        try
+        {
+            if (!p.HasExited)
+            {
+                p.Kill(entireProcessTree: true);
+                p.WaitForExit(2000);
+            }
+        }
+        catch
+        {
+            // best effort
+        }
+        finally
+        {
+            p.Dispose();
+        }
+    }
+
+    private static string GetUniqueDestinationFileName(string folder, string baseName)
+    {
+        var candidate = Path.Combine(folder, baseName + ".wav");
+        if (!File.Exists(candidate))
+        {
+            return candidate;
+        }
+
+        var number = 1;
+        do
+        {
+            candidate = Path.Combine(folder, $"{baseName}_{number}.wav");
+            number++;
+        } while (File.Exists(candidate));
+
+        return candidate;
+    }
+
+    public bool ImportVoice(string fileName) => ImportVoice(fileName, string.Empty);
+
+    /// <summary>
+    /// Imports <paramref name="fileName"/> as an OmniVoice reference voice. When
+    /// <paramref name="transcript"/> is non-empty it is written to the destination .txt sidecar
+    /// (passed as --ref-text and improves cloning quality); when empty, any .txt sidecar already
+    /// next to the source WAV is copied instead.
+    /// </summary>
+    public bool ImportVoice(string fileName, string transcript)
+    {
+        if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
+        {
+            return false;
+        }
+
+        var voicesFolder = GetSetVoicesFolder();
+        var baseName = Path.GetFileNameWithoutExtension(fileName);
+        var destinationFileName = GetUniqueDestinationFileName(voicesFolder, baseName);
+
+        // Resample to 24 kHz mono on import — OmniVoice's native rate, so crispasr does no
+        // further conversion of the reference.
+        try
+        {
+            var process = FfmpegGenerator.ConvertToMono24kHzWav(fileName, destinationFileName);
+            if (!process.Start())
+            {
+                return false;
+            }
+
+            process.WaitForExit();
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "OmniVoice (CrispASR) voice import failed (ffmpeg conversion).");
+            return false;
+        }
+
+        if (!File.Exists(destinationFileName))
+        {
+            return false;
+        }
+
+        try
+        {
+            var destSidecar = Path.ChangeExtension(destinationFileName, ".txt");
+            if (!string.IsNullOrWhiteSpace(transcript))
+            {
+                File.WriteAllText(destSidecar, transcript.Trim());
+            }
+            else
+            {
+                var sourceSidecar = Path.ChangeExtension(fileName, ".txt");
+                if (File.Exists(sourceSidecar) && !File.Exists(destSidecar))
+                {
+                    File.Copy(sourceSidecar, destSidecar);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "OmniVoice (CrispASR) voice import: failed to write .txt sidecar");
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Writes <paramref name="transcript"/> to <c>&lt;voice&gt;.txt</c> next to the supplied voice
+    /// WAV, so a transcription can be retro-fitted onto an imported or seeded voice without a
+    /// full re-import.
+    /// </summary>
+    public static bool TryWriteRefTextSidecar(string voiceWavPath, string transcript)
+    {
+        if (string.IsNullOrEmpty(voiceWavPath) || string.IsNullOrWhiteSpace(transcript))
+        {
+            return false;
+        }
+
+        try
+        {
+            var sidecar = Path.ChangeExtension(voiceWavPath, ".txt");
+            File.WriteAllText(sidecar, transcript.Trim());
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"OmniVoice (CrispASR): failed to write ref-text sidecar for '{voiceWavPath}'");
+            return false;
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/OmniVoiceCrispAsrSettings/OmniVoiceCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/OmniVoiceCrispAsrSettings/OmniVoiceCrispAsrSettingsViewModel.cs
@@ -1,0 +1,243 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceCrispAsrSettings;
+
+public partial class OmniVoiceCrispAsrSettingsViewModel : ObservableObject
+{
+    private static IBrush Green() => new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50));
+    private static IBrush Amber() => new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00));
+    private static IBrush Red() => new SolidColorBrush(Color.FromRgb(0xF4, 0x43, 0x36));
+    private static IBrush Grey() => new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E));
+
+    private readonly IWindowService _windowService;
+    private readonly IFolderHelper _folderHelper;
+
+    [ObservableProperty] private string _engineLabel = string.Empty;
+    [ObservableProperty] private IBrush _engineBrush = Grey();
+    [ObservableProperty] private string _engineDownloadButtonText = string.Empty;
+
+    [ObservableProperty] private string _modelQ4KLabel = string.Empty;
+    [ObservableProperty] private IBrush _modelQ4KBrush = Grey();
+
+    [ObservableProperty] private string _modelQ8_0Label = string.Empty;
+    [ObservableProperty] private IBrush _modelQ8_0Brush = Grey();
+
+    [ObservableProperty] private string _modelF16Label = string.Empty;
+    [ObservableProperty] private IBrush _modelF16Brush = Grey();
+
+    [ObservableProperty] private string _voicesLabel = string.Empty;
+
+    [ObservableProperty] private double _speed = 1.0;
+
+    public string SpeedLabel => $"Speed {Speed:0.00}x";
+
+    partial void OnSpeedChanged(double value)
+    {
+        OnPropertyChanged(nameof(SpeedLabel));
+        Se.Settings.Video.TextToSpeech.OmniVoiceCrispAsrSpeed = Math.Clamp(value, 0.25, 4.0);
+    }
+
+    [ObservableProperty] private string _modelsFolder = string.Empty;
+    [ObservableProperty] private string _voicesFolder = string.Empty;
+    [ObservableProperty] private bool _isEngineInstalled;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public OmniVoiceCrispAsrSettingsViewModel(IWindowService windowService, IFolderHelper folderHelper)
+    {
+        _windowService = windowService;
+        _folderHelper = folderHelper;
+    }
+
+    public void Initialize()
+    {
+        ModelsFolder = OmniVoiceCrispAsr.GetSetModelsFolder();
+        VoicesFolder = OmniVoiceCrispAsr.GetSetVoicesFolder();
+        Speed = Math.Clamp(Se.Settings.Video.TextToSpeech.OmniVoiceCrispAsrSpeed, 0.25, 4.0);
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        var exe = OmniVoiceCrispAsr.GetCrispAsrExecutable();
+        IsEngineInstalled = File.Exists(exe);
+
+        if (!IsEngineInstalled)
+        {
+            EngineLabel = "CrispASR not installed";
+            EngineBrush = Red();
+            EngineDownloadButtonText = "Download CrispASR";
+        }
+        else if (OmniVoiceCrispAsr.GetEngineUpdateStatus() == DownloadHashManager.UpdateStatus.UpdateAvailable)
+        {
+            EngineLabel = "CrispASR - update available";
+            EngineBrush = Amber();
+            EngineDownloadButtonText = "Update CrispASR";
+        }
+        else
+        {
+            EngineLabel = "CrispASR";
+            EngineBrush = Green();
+            EngineDownloadButtonText = "Re-download CrispASR";
+        }
+
+        if (IsEngineInstalled)
+        {
+            var baseLabel = EngineLabel;
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    var version = CrispAsrVersion.TryGet(exe);
+                    if (string.IsNullOrEmpty(version))
+                    {
+                        return;
+                    }
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        if (EngineLabel == baseLabel)
+                        {
+                            EngineLabel = baseLabel.Replace("CrispASR", $"CrispASR v{version}");
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Se.LogError(ex, "OmniVoiceCrispAsrSettings: CrispASR version probe failed");
+                }
+            });
+        }
+
+        ApplyModelStatus(
+            OmniVoiceCrispAsr.AreModelsInstalled(OmniVoiceCrispAsr.ModelKeyQ4K),
+            IsEngineInstalled,
+            label => ModelQ4KLabel = label,
+            brush => ModelQ4KBrush = brush);
+
+        ApplyModelStatus(
+            OmniVoiceCrispAsr.AreModelsInstalled(OmniVoiceCrispAsr.ModelKeyQ8_0),
+            IsEngineInstalled,
+            label => ModelQ8_0Label = label,
+            brush => ModelQ8_0Brush = brush);
+
+        ApplyModelStatus(
+            OmniVoiceCrispAsr.AreModelsInstalled(OmniVoiceCrispAsr.ModelKeyF16),
+            IsEngineInstalled,
+            label => ModelF16Label = label,
+            brush => ModelF16Brush = brush);
+
+        try
+        {
+            var wavCount = Directory.Exists(VoicesFolder)
+                ? Directory.GetFiles(VoicesFolder, "*.wav").Length
+                : 0;
+            VoicesLabel = wavCount == 0
+                ? "No voices imported (built-in voice only)"
+                : (wavCount == 1 ? "1 voice imported" : $"{wavCount} voices imported");
+        }
+        catch
+        {
+            VoicesLabel = string.Empty;
+        }
+    }
+
+    private static void ApplyModelStatus(bool fileInstalled, bool engineInstalled, Action<string> setLabel, Action<IBrush> setBrush)
+    {
+        if (fileInstalled)
+        {
+            setLabel("Installed");
+            setBrush(Green());
+            return;
+        }
+
+        if (!engineInstalled)
+        {
+            setLabel("CrispASR required");
+            setBrush(Grey());
+            return;
+        }
+
+        setLabel("Auto-download on first use");
+        setBrush(Grey());
+    }
+
+    [RelayCommand]
+    private async Task RedownloadEngine()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        await TtsVoiceInstaller.EnsureCrispAsrForOmniVoice(Window, _windowService, forceRedownload: true);
+        Refresh();
+    }
+
+    [RelayCommand]
+    private async Task OpenModelsFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(ModelsFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, ModelsFolder);
+        }
+        catch
+        {
+            // best-effort UX
+        }
+    }
+
+    [RelayCommand]
+    private async Task OpenVoicesFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(VoicesFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, VoicesFolder);
+        }
+        catch
+        {
+            // best-effort UX
+        }
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/OmniVoiceCrispAsrSettings/OmniVoiceCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/OmniVoiceCrispAsrSettings/OmniVoiceCrispAsrSettingsWindow.cs
@@ -1,0 +1,266 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceCrispAsrSettings;
+
+public class OmniVoiceCrispAsrSettingsWindow : Window
+{
+    private const int LabelWidth = 150;
+    private const int ValueWidth = 360;
+
+    private readonly OmniVoiceCrispAsrSettingsViewModel _vm;
+
+    public OmniVoiceCrispAsrSettingsWindow(OmniVoiceCrispAsrSettingsViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = "OmniVoice TTS (CrispASR) settings";
+        // Explicit width + height-only auto-sizing: SizeToContent.WidthAndHeight comes out far
+        // too wide on macOS.
+        Width = 620;
+        SizeToContent = SizeToContent.Height;
+        CanResize = false;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        Content = BuildContent(vm);
+
+        var ok = UiUtil.MakeButtonOk(vm.OkCommand);
+        Activated += delegate { ok.Focus(); };
+    }
+
+    private Border BuildContent(OmniVoiceCrispAsrSettingsViewModel vm)
+    {
+        var header = BuildHeader();
+        var details = BuildDetails(vm);
+        var actions = BuildActions(vm);
+
+        var stack = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 14,
+            Children = { header, details, actions },
+        };
+
+        var outerGrid = new Grid
+        {
+            Margin = UiUtil.MakeWindowMargin(),
+        };
+        outerGrid.Children.Add(stack);
+
+        return new Border
+        {
+            Child = outerGrid,
+            Padding = new Thickness(4),
+        };
+    }
+
+    private static StackPanel BuildHeader()
+    {
+        var title = new TextBlock
+        {
+            Text = "OmniVoice TTS (CrispASR)",
+            FontSize = 18,
+            FontWeight = FontWeight.SemiBold,
+        };
+
+        var subtitle = new TextBlock
+        {
+            Text = new OmniVoiceCrispAsr().Description,
+            FontSize = 12,
+            Opacity = 0.75,
+            Margin = new Thickness(0, 2, 0, 0),
+        };
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 0,
+            Children = { title, subtitle },
+        };
+    }
+
+    private static Border BuildDetails(OmniVoiceCrispAsrSettingsViewModel vm)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(LabelWidth, GridUnitType.Pixel) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnSpacing = 12,
+            RowSpacing = 10,
+        };
+
+        grid.Add(MakeLabel("Engine"), 0, 0);
+        var enginePanel = MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel));
+        var engineButton = UiUtil.MakeButton(string.Empty, vm.RedownloadEngineCommand)
+            .WithIconLeft(IconNames.Download)
+            .WithMarginLeft(12);
+        engineButton.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.EngineDownloadButtonText)));
+        enginePanel.Children.Add(engineButton);
+        grid.Add(enginePanel, 0, 1);
+
+        grid.Add(MakeLabel("Model " + OmniVoiceCrispAsr.ModelKeyQ4K), 1, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.ModelQ4KBrush), nameof(vm.ModelQ4KLabel)), 1, 1);
+
+        grid.Add(MakeLabel("Model " + OmniVoiceCrispAsr.ModelKeyQ8_0), 2, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.ModelQ8_0Brush), nameof(vm.ModelQ8_0Label)), 2, 1);
+
+        grid.Add(MakeLabel("Model " + OmniVoiceCrispAsr.ModelKeyF16), 3, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.ModelF16Brush), nameof(vm.ModelF16Label)), 3, 1);
+
+        grid.Add(MakeLabel("Voices"), 4, 0);
+        var voicesText = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.VoicesLabel)),
+        };
+        grid.Add(voicesText, 4, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.Speed), 5, 0);
+        grid.Add(MakeSpeedPanel(), 5, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 6, 0);
+        var folderText = new TextBox
+        {
+            IsReadOnly = true,
+            Width = ValueWidth,
+            BorderThickness = new Thickness(0),
+            Background = Brushes.Transparent,
+            Padding = new Thickness(0),
+            VerticalContentAlignment = VerticalAlignment.Center,
+            FontSize = 12,
+            [!TextBox.TextProperty] = new Binding(nameof(vm.ModelsFolder)),
+        };
+        grid.Add(folderText, 6, 1);
+
+        return new Border
+        {
+            Child = grid,
+            Padding = new Thickness(14),
+            CornerRadius = new CornerRadius(6),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
+        };
+    }
+
+    private static StackPanel MakeSpeedPanel()
+    {
+        var slider = new Slider
+        {
+            Minimum = 0.5,
+            Maximum = 2.0,
+            Width = 220,
+            TickFrequency = 0.05,
+            IsSnapToTickEnabled = true,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Slider.ValueProperty] = new Binding(nameof(OmniVoiceCrispAsrSettingsViewModel.Speed)),
+        };
+        var label = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            Width = 80,
+            [!TextBlock.TextProperty] = new Binding(nameof(OmniVoiceCrispAsrSettingsViewModel.SpeedLabel)),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { slider, label },
+        };
+    }
+
+    private static StackPanel MakeStatusPanel(string brushBindingPath, string labelBindingPath)
+    {
+        var dot = new Ellipse
+        {
+            Width = 10,
+            Height = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Ellipse.FillProperty] = new Binding(brushBindingPath),
+        };
+        var text = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(labelBindingPath),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { dot, text },
+        };
+    }
+
+    private static Grid BuildActions(OmniVoiceCrispAsrSettingsViewModel vm)
+    {
+        var openModelsFolder = UiUtil.MakeButton(Se.Language.General.OpenContainingFolder, vm.OpenModelsFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var openVoicesFolder = UiUtil.MakeButton("Voices folder", vm.OpenVoicesFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var close = UiUtil.MakeButton(Se.Language.General.Close, vm.OkCommand);
+
+        var leftPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Children = { openModelsFolder, openVoicesFolder },
+        };
+
+        var rightPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Spacing = 8,
+            Children = { close },
+        };
+
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+        };
+        grid.Add(leftPanel, 0, 0);
+        grid.Add(rightPanel, 0, 2);
+        return grid;
+    }
+
+    private static TextBlock MakeLabel(string text) => new()
+    {
+        Text = text,
+        Opacity = 0.7,
+        VerticalAlignment = VerticalAlignment.Center,
+    };
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
@@ -21,6 +21,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ElevenLabsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.EncodingSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.F5TtsCrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VoxCPM2CrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.MossTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTtsCrispAsrSettings;
@@ -245,6 +246,11 @@ public partial class TextToSpeechViewModel : ObservableObject
 
             new ZonosTtsCrispAsr(),
 
+            // OmniVoice (CrispASR) — the same model family as the standalone OmniVoice TTS
+            // above, but on the shared CrispASR runtime and as a persistent server, so the
+            // model loads once instead of once per line.
+            new OmniVoiceCrispAsr(),
+
             new ChatterboxTtsCpp(),
         ];
 
@@ -414,6 +420,10 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             Se.Settings.Video.TextToSpeech.VoxCPM2CrispAsrModel = SelectedModel ?? VoxCPM2CrispAsr.DefaultModelKey;
         }
+        else if (SelectedEngine is OmniVoiceCrispAsr)
+        {
+            Se.Settings.Video.TextToSpeech.OmniVoiceCrispAsrModel = SelectedModel ?? OmniVoiceCrispAsr.DefaultModelKey;
+        }
         else if (SelectedEngine is MossTtsCrispAsr)
         {
             Se.Settings.Video.TextToSpeech.MossTtsCrispAsrModel = SelectedModel ?? MossTtsCrispAsr.DefaultModelKey;
@@ -582,6 +592,7 @@ public partial class TextToSpeechViewModel : ObservableObject
         string? wavPath = null;
         bool isCosyVoice3 = false;
         bool isVoxCPM2 = false;
+        bool isOmniVoiceCrispAsr = false;
         bool isMossTts = false;
         bool isQwen3Clone = false;
         if (voice.EngineVoice is CosyVoice3Voice cosy && !string.IsNullOrEmpty(cosy.FilePath) && string.IsNullOrEmpty(cosy.RefText))
@@ -604,6 +615,16 @@ public partial class TextToSpeechViewModel : ObservableObject
             {
                 wavPath = vox.FilePath;
                 isVoxCPM2 = true;
+            }
+        }
+        else if (voice.EngineVoice is OmniVoiceCrispAsrVoice omniCrisp && !string.IsNullOrEmpty(omniCrisp.FilePath))
+        {
+            // Empty FilePath means the built-in voice, which clones nothing and needs no ref-text.
+            var existing = TryReadRefTextSibling(omniCrisp.FilePath);
+            if (string.IsNullOrEmpty(existing))
+            {
+                wavPath = omniCrisp.FilePath;
+                isOmniVoiceCrispAsr = true;
             }
         }
         else if (voice.EngineVoice is MossTtsVoice moss && !string.IsNullOrEmpty(moss.FilePath))
@@ -672,6 +693,10 @@ public partial class TextToSpeechViewModel : ObservableObject
             else if (isVoxCPM2)
             {
                 written = VoxCPM2CrispAsr.TryWriteRefTextSidecar(wavPath, result.Text);
+            }
+            else if (isOmniVoiceCrispAsr)
+            {
+                written = OmniVoiceCrispAsr.TryWriteRefTextSidecar(wavPath, result.Text);
             }
             else if (isMossTts)
             {
@@ -1132,6 +1157,10 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             VoxCPM2CrispAsr.StopServer();
         }
+        if (keepAlive is not OmniVoiceCrispAsr)
+        {
+            OmniVoiceCrispAsr.StopServer();
+        }
         if (keepAlive is not MossTtsCrispAsr)
         {
             MossTtsCrispAsr.StopServer();
@@ -1339,6 +1368,10 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             await _windowService.ShowDialogAsync<F5TtsCrispAsrSettingsWindow, F5TtsCrispAsrSettingsViewModel>(Window!, vm => vm.Initialize());
         }
+        else if (SelectedEngine is OmniVoiceCrispAsr)
+        {
+            await _windowService.ShowDialogAsync<OmniVoiceCrispAsrSettingsWindow, OmniVoiceCrispAsrSettingsViewModel>(Window!, vm => vm.Initialize());
+        }
         else if (SelectedEngine is VoxCPM2CrispAsr)
         {
             await _windowService.ShowDialogAsync<VoxCPM2CrispAsrSettingsWindow, VoxCPM2CrispAsrSettingsViewModel>(Window!, vm => vm.Initialize());
@@ -1439,6 +1472,9 @@ public partial class TextToSpeechViewModel : ObservableObject
             case VoxCPM2CrispAsr:
                 await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadVoxCPM2CrispAsrModels(VoxCPM2CrispAsr.ResolveModelKey(SelectedModel)));
                 break;
+            case OmniVoiceCrispAsr:
+                await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadOmniVoiceCrispAsrModels(OmniVoiceCrispAsr.ResolveModelKey(SelectedModel)));
+                break;
             case MossTtsCrispAsr:
                 await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadMossTtsCrispAsrModels(MossTtsCrispAsr.ResolveModelKey(SelectedModel)));
                 break;
@@ -1504,6 +1540,9 @@ public partial class TextToSpeechViewModel : ObservableObject
                 ? DownloadDotStatus.UpToDate
                 : DownloadDotStatus.NotInstalled,
             VoxCPM2CrispAsr => VoxCPM2CrispAsr.AreModelsInstalled(modelKey)
+                ? DownloadDotStatus.UpToDate
+                : DownloadDotStatus.NotInstalled,
+            OmniVoiceCrispAsr => OmniVoiceCrispAsr.AreModelsInstalled(modelKey)
                 ? DownloadDotStatus.UpToDate
                 : DownloadDotStatus.NotInstalled,
             MossTtsCrispAsr => MossTtsCrispAsr.AreModelsInstalled(modelKey)
@@ -3404,6 +3443,16 @@ public partial class TextToSpeechViewModel : ObservableObject
             else if (SelectedEngine is VoxCPM2CrispAsr)
             {
                 SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.VoxCPM2CrispAsrModel);
+                if (string.IsNullOrEmpty(SelectedModel))
+                {
+                    SelectedModel = Models.FirstOrDefault();
+                }
+                IsEngineSettingsVisible = true;
+                IsModelDownloadVisible = true;
+            }
+            else if (SelectedEngine is OmniVoiceCrispAsr)
+            {
+                SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.OmniVoiceCrispAsrModel);
                 if (string.IsNullOrEmpty(SelectedModel))
                 {
                     SelectedModel = Models.FirstOrDefault();

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
@@ -189,6 +189,8 @@ public class TextToSpeechWindow : Window
                 return StatusDots.From(engine.IsInstalled(null).Result, F5TtsCrispAsr.GetEngineUpdateStatus());
             case VoxCPM2CrispAsr:
                 return StatusDots.From(engine.IsInstalled(null).Result, VoxCPM2CrispAsr.GetEngineUpdateStatus());
+            case OmniVoiceCrispAsr:
+                return StatusDots.From(engine.IsInstalled(null).Result, OmniVoiceCrispAsr.GetEngineUpdateStatus());
             case MossTtsCrispAsr:
                 return StatusDots.From(engine.IsInstalled(null).Result, MossTtsCrispAsr.GetEngineUpdateStatus());
             case ZonosTtsCrispAsr:

--- a/src/ui/Features/Video/TextToSpeech/TtsEngineInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsEngineInstaller.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Threading;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Shared;
@@ -400,6 +400,44 @@ public static class TtsEngineInstaller
 
                 var dlResult = await windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(window, vm => vm.StartDownloadVoxCPM2CrispAsrModels(voxModelKey));
                 if (!dlResult.OkPressed || !VoxCPM2CrispAsr.AreModelsInstalled(voxModelKey))
+                {
+                    return false;
+                }
+
+                await Dispatcher.UIThread.InvokeAsync(async () =>
+                {
+                    await refreshVoices();
+                });
+                return true;
+            }
+
+            return true;
+        }
+
+        if (engine is OmniVoiceCrispAsr)
+        {
+            if (!await TtsVoiceInstaller.EnsureCrispAsrForOmniVoice(window, windowService, forceRedownload: false))
+            {
+                return false;
+            }
+
+            var omniCrispModelKey = OmniVoiceCrispAsr.ResolveModelKey(model);
+            if (!OmniVoiceCrispAsr.AreModelsInstalled(omniCrispModelKey))
+            {
+                var answer = await MessageBox.Show(
+                    window,
+                    "Download OmniVoice (CrispASR) model?",
+                    $"{Environment.NewLine}\"OmniVoice TTS (CrispASR)\" ({omniCrispModelKey}) requires a model.{Environment.NewLine}{Environment.NewLine}Download model?",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (answer != MessageBoxResult.Yes)
+                {
+                    return false;
+                }
+
+                var dlResult = await windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(window, vm => vm.StartDownloadOmniVoiceCrispAsrModels(omniCrispModelKey));
+                if (!dlResult.OkPressed || !OmniVoiceCrispAsr.AreModelsInstalled(omniCrispModelKey))
                 {
                     return false;
                 }

--- a/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
@@ -142,7 +142,7 @@ public static class TtsVoiceInstaller
 
     /// <summary>
     /// Ensures the CrispASR runtime that MOSS-TTS (CrispASR) runs on is installed.
-    /// The moss-tts backend ships in CrispASR v0.8.13 and newer (SE pins v0.8.24).
+    /// The moss-tts backend ships in CrispASR v0.8.13 and newer (SE pins v0.8.25).
     /// </summary>
     public static Task<bool> EnsureCrispAsrForMossTts(Window? window, IWindowService windowService, bool forceRedownload)
         => EnsureCrispAsrAsync(window, windowService, forceRedownload,

--- a/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
@@ -141,6 +141,17 @@ public static class TtsVoiceInstaller
             minVersionNote: "v0.7.0 or newer");
 
     /// <summary>
+    /// Ensures the CrispASR runtime that OmniVoice TTS (CrispASR) runs on is installed.
+    /// The omnivoice backend has shipped since well before the pinned build, so the note only
+    /// names the version SE itself pins.
+    /// </summary>
+    public static Task<bool> EnsureCrispAsrForOmniVoice(Window? window, IWindowService windowService, bool forceRedownload)
+        => EnsureCrispAsrAsync(window, windowService, forceRedownload,
+            engineDisplayName: "OmniVoice TTS (CrispASR)",
+            extraCapabilityCheck: null,
+            minVersionNote: "v0.8.25 or newer");
+
+    /// <summary>
     /// Ensures the CrispASR runtime that MOSS-TTS (CrispASR) runs on is installed.
     /// The moss-tts backend ships in CrispASR v0.8.13 and newer (SE pins v0.8.25).
     /// </summary>

--- a/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -224,6 +224,28 @@ public partial class VoiceSettingsViewModel : ObservableObject
                 ? voxEngine.ImportVoice(fileName, (result.Text ?? string.Empty).Trim())
                 : voxEngine.ImportVoice(fileName);
         }
+        else if (_engine is OmniVoiceCrispAsr omniCrispEngine)
+        {
+            // OmniVoice clones zero-shot from audio alone; a transcription (ref-text) is optional
+            // but improves quality, so prompt like VoxCPM2 while allowing an empty answer.
+            var transcript = TryReadSiblingTranscript(fileName) ?? string.Empty;
+            var audioFileName = fileName;
+            var result = await _windowService.ShowDialogAsync<PromptTextBoxWindow, PromptTextBoxViewModel>(Window!, vm =>
+            {
+                vm.Initialize(
+                    Se.Language.Video.TextToSpeech.VoiceCloneTranscriptTitle,
+                    transcript,
+                    500,
+                    150);
+                vm.ConfigureExtraButton(
+                    Se.Language.Video.TextToSpeech.UseSpeechToTextDotDotDot,
+                    () => RunSpeechToTextAsync(audioFileName));
+            });
+
+            ok = result.OkPressed
+                ? omniCrispEngine.ImportVoice(fileName, (result.Text ?? string.Empty).Trim())
+                : omniCrispEngine.ImportVoice(fileName);
+        }
         else if (_engine is MossTtsCrispAsr mossEngine)
         {
             // MOSS-TTS clones zero-shot from audio alone; a transcription (ref-text) is optional
@@ -426,6 +448,7 @@ public partial class VoiceSettingsViewModel : ObservableObject
                                || engine.GetType() == typeof(CosyVoice3CrispAsr)
                                || engine.GetType() == typeof(F5TtsCrispAsr)
                                || engine.GetType() == typeof(VoxCPM2CrispAsr)
+                               || engine.GetType() == typeof(OmniVoiceCrispAsr)
                                || engine.GetType() == typeof(MossTtsCrispAsr)
                                || engine.GetType() == typeof(ZonosTtsCrispAsr)
                                || engine.GetType() == typeof(ChatterboxTtsCpp)

--- a/src/ui/Features/Video/TextToSpeech/Voices/OmniVoiceCrispAsrVoice.cs
+++ b/src/ui/Features/Video/TextToSpeech/Voices/OmniVoiceCrispAsrVoice.cs
@@ -1,0 +1,30 @@
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+
+/// <summary>
+/// A voice for the OmniVoice (CrispASR) engine. An empty <see cref="FilePath"/> means the
+/// model's own built-in voice (no reference audio); a path means zero-shot cloning from that
+/// reference WAV. Kept separate from <see cref="OmniVoice"/> so the two OmniVoice engines can
+/// never be handed each other's voices by the shared voice combo.
+/// </summary>
+public class OmniVoiceCrispAsrVoice
+{
+    public string Voice { get; set; }
+    public string FilePath { get; set; }
+
+    public override string ToString()
+    {
+        return Voice;
+    }
+
+    public OmniVoiceCrispAsrVoice()
+    {
+        Voice = string.Empty;
+        FilePath = string.Empty;
+    }
+
+    public OmniVoiceCrispAsrVoice(string voice, string filePath)
+    {
+        Voice = voice;
+        FilePath = filePath;
+    }
+}

--- a/src/ui/Logic/Config/SeAudioToText.cs
+++ b/src/ui/Logic/Config/SeAudioToText.cs
@@ -49,6 +49,7 @@ public class SeAudioToText
     // CJK-friendlier max line length (each char is roughly a whole word/syllable).
     public string CommandLineParameterCrispAsrFunAsrNano { get; set; } = "--max-len 20 --split-on-punct";
     public string CommandLineParameterCrispAsrFunAsrMltNano { get; set; } = "--max-len 50 --split-on-punct";
+    public string CommandLineParameterCrispAsrGigaAm { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrGlm { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrGranite { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrParakeet { get; set; } = "--max-len 50 --split-on-punct";

--- a/src/ui/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/ui/Logic/Config/SeVideoTextToSpeech.cs
@@ -40,6 +40,8 @@ public class SeVideoTextToSpeech
     public double CosyVoice3CrispAsrSpeed { get; set; }
     public string F5TtsCrispAsrModel { get; set; }
     public double F5TtsCrispAsrSpeed { get; set; }
+    public string OmniVoiceCrispAsrModel { get; set; }
+    public double OmniVoiceCrispAsrSpeed { get; set; }
     public string VoxCPM2CrispAsrModel { get; set; }
     public double VoxCPM2CrispAsrSpeed { get; set; }
     public string MossTtsCrispAsrModel { get; set; }
@@ -131,6 +133,8 @@ public class SeVideoTextToSpeech
         CosyVoice3CrispAsrSpeed = 1.0;
         F5TtsCrispAsrModel = "F16 (~953 MB)";
         F5TtsCrispAsrSpeed = 1.0;
+        OmniVoiceCrispAsrModel = "Q4_K (~1 GB)";
+        OmniVoiceCrispAsrSpeed = 1.0;
         VoxCPM2CrispAsrModel = "Q4_K (~1.7 GB)";
         VoxCPM2CrispAsrSpeed = 1.0;
         MossTtsCrispAsrModel = "Q4_K (~10.5 GB incl. codec)";

--- a/src/ui/Logic/Download/CrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/CrispAsrDownloadService.cs
@@ -24,17 +24,17 @@ public class CrispAsrDownloadService : ICrispAsrDownloadService
 {
     private readonly HttpClient _httpClient;
 
-    private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.24/crispasr-windows-x86_64-cuda.zip";
-    private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.24/crispasr-windows-x86_64-vulkan.zip";
-    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.24/crispasr-windows-x86_64-cpu.zip";
-    private const string WindowsCpuLegacyUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.24/crispasr-windows-x86_64-cpu-legacy.zip";
-    private const string MacUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.24/crispasr-macos.tar.gz";
-    private const string LinuxUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.24/crispasr-linux-x86_64.tar.gz";
-    private const string LinuxCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.24/crispasr-linux-x86_64-cuda.tar.gz";
-    private const string LinuxCuda13Url = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.24/crispasr-linux-x86_64-cuda13.tar.gz";
-    private const string LinuxVulkanUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.24/crispasr-linux-x86_64-vulkan.tar.gz";
-    private const string LinuxHipUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.24/crispasr-linux-x86_64-hip.tar.gz";
-    private const string LinuxArmUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.24/crispasr-linux-arm64.tar.gz";
+    private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.25/crispasr-windows-x86_64-cuda.zip";
+    private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.25/crispasr-windows-x86_64-vulkan.zip";
+    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.25/crispasr-windows-x86_64-cpu.zip";
+    private const string WindowsCpuLegacyUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.25/crispasr-windows-x86_64-cpu-legacy.zip";
+    private const string MacUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.25/crispasr-macos.tar.gz";
+    private const string LinuxUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.25/crispasr-linux-x86_64.tar.gz";
+    private const string LinuxCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.25/crispasr-linux-x86_64-cuda.tar.gz";
+    private const string LinuxCuda13Url = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.25/crispasr-linux-x86_64-cuda13.tar.gz";
+    private const string LinuxVulkanUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.25/crispasr-linux-x86_64-vulkan.tar.gz";
+    private const string LinuxHipUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.25/crispasr-linux-x86_64-hip.tar.gz";
+    private const string LinuxArmUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.25/crispasr-linux-arm64.tar.gz";
 
     public CrispAsrDownloadService(HttpClient httpClient)
     {

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -288,7 +288,8 @@ public static class DownloadHashManager
             // otherwise users will be prompted to "update" to the same version they just got.
             [CrispAsr.WindowsCuda] = new[]
             {
-                "832af6218508ac52fc71ac5653c433786bdfae81f775e2c77bfefd05df6f255b", // v0.8.24 (current download URL)
+                "3a19127a8f082e5ef4f9eaa0505cd2d9bf93f7ec45dff174a51990ef675f055e", // v0.8.25 (current download URL)
+                "832af6218508ac52fc71ac5653c433786bdfae81f775e2c77bfefd05df6f255b", // v0.8.24
                 "e5786bd9622735349977dd5da52c294d4ebafb58ba85316383178d6062fe036e", // v0.8.23
                 "8f59bc6d124397db38d0ff4d6a53a99c5a502ccdfd5ca563064d0d53138bda20", // v0.8.20
                 "478a74780a514ede1d5cc2d66074252e94855c90628f3feafee0caa378ed2e4b", // v0.8.15
@@ -326,7 +327,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.WindowsVulkan] = new[]
             {
-                "70956638045042b49f61f9f04ee9ceae9fc8b450f6f56a10fc98c2088207628a", // v0.8.24 (current download URL)
+                "938f30ee33c673934b0869945cf04750e8a89e3318863c516b54c3a9949fe3df", // v0.8.25 (current download URL)
+                "70956638045042b49f61f9f04ee9ceae9fc8b450f6f56a10fc98c2088207628a", // v0.8.24
                 "17b5a4cca2186a58d0cedc1ac58ddd0636c0f856c7094ec9bbaecada360ec52e", // v0.8.23
                 "676952e1459cd75de2d70450f5417eb7076d1cdb58299085599d3e19dd3b523f", // v0.8.20
                 "a13e9714e8b8a6318c32b56442b914338d39aeafd088b7fd49262daccfd74d5b", // v0.8.15
@@ -364,7 +366,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.WindowsCpu] = new[]
             {
-                "a05456c9adac276289060ae83bd77ed7b4d87ccfd447aed804e497d76e73f8f8", // v0.8.24 (current download URL)
+                "07c668ecfa2942f6d6d4bfc82429a84d35824a7419a796d03fae6f15a3ce8d45", // v0.8.25 (current download URL)
+                "a05456c9adac276289060ae83bd77ed7b4d87ccfd447aed804e497d76e73f8f8", // v0.8.24
                 "43451e16c7ba3617beb41747bd857bebd0c4ed6c2af918da98c8280daf167d8e", // v0.8.23
                 "463df25f8b201566dc3cea9b1bb94ae45e85fd887e068bf4875e99de01c8aae7", // v0.8.20
                 "652bd964381ef716e0fd06bb975a7a4775855111d47bd29e0abb56c8e3515885", // v0.8.15
@@ -395,7 +398,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.WindowsCpuLegacy] = new[]
             {
-                "589846e35e760f4cfa090ffea363cbd2648cf4bb41d7bf5cc0a8df7b91e6d7eb", // v0.8.24 (current download URL)
+                "964890a77147365f92ad41e358889026db8b31fbc839c039a13a97f271c8b861", // v0.8.25 (current download URL)
+                "589846e35e760f4cfa090ffea363cbd2648cf4bb41d7bf5cc0a8df7b91e6d7eb", // v0.8.24
                 "126965dc4daa644c014d1a3f0e1d9be57e568ffe55f02f89b57bf56573d48122", // v0.8.23
                 "11cd2dd552bbb22b8f8df5cb3b6a9c2191e3b0417df6a112a83678bbecc07995", // v0.8.20
                 "d1673ae438eb6a87e5b9f8392686a2b6b31a82ce2fe3c5b9164ed685274815e5", // v0.8.15
@@ -432,7 +436,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.MacOs] = new[]
             {
-                "78397afd5aef2dbd6fa73f8d60800dd4d5725589fb4b04800efd2fb3ff88930c", // v0.8.24 (current download URL)
+                "0aa78b9a5e1e0e930e4d7a79706b486306c36c0a358ec432ea6729727a767891", // v0.8.25 (current download URL)
+                "78397afd5aef2dbd6fa73f8d60800dd4d5725589fb4b04800efd2fb3ff88930c", // v0.8.24
                 "e605c7cbfbd61da708b61f5faff8657f276b6d30797f20fcf49dece2cf2d3eb1", // v0.8.23
                 "ce7c4837314ba378007da4b3a4019cc5e80678a900e8b442a60026140942a285", // v0.8.20
                 "80c0a4fdbc1c44de08c4a92cf04d9301192e65b96d84f4e26d1a9f57e1703f14", // v0.8.15
@@ -470,7 +475,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.Linux] = new[]
             {
-                "9b909ae765774e7e73e3a5b06e8e23df388ed62c9451141abbbc08b685e2e34b", // v0.8.24 (current download URL)
+                "050be2dd783d9c5c213b2455c45d00844c7cbbbb06afe3166fc010108a6a5a08", // v0.8.25 (current download URL)
+                "9b909ae765774e7e73e3a5b06e8e23df388ed62c9451141abbbc08b685e2e34b", // v0.8.24
                 "3f911304a0a013d5ec7409011ca0899e16a60a931fa714b9a85c4d35e1653c59", // v0.8.23
                 "4a0a772ea1903d4d65682506c42c36356fe3806189d08b9f9f09af590e29babf", // v0.8.20
                 "ecae0527284423c3908a0dbb6bac8046a2206298dc7849e6eb0390cd4a711a30", // v0.8.15
@@ -508,7 +514,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.LinuxCuda] = new[]
             {
-                "36cd1877438efa03adcf2a40c3c169e8b9a421d63b9ab786bc08fae0576bb775", // v0.8.24 (current download URL)
+                "bc504fff3d9c02d92e348b1c624169fd4a37de7b87eccb1276fe34fa1c2ebe1f", // v0.8.25 (current download URL)
+                "36cd1877438efa03adcf2a40c3c169e8b9a421d63b9ab786bc08fae0576bb775", // v0.8.24
                 "6eda215837da0ffbbd5f362945b0197ea81d9e29b7fd5e9889dc237e222539ac", // v0.8.23
                 "620dc66a75e4774cb645b6ee642c6dff61123e9939d762ba1d89ff8cffe6f81a", // v0.8.20
                 "e89f460523ac8ef9018a1e7d120b974d51c252b98b7c8be02f5e6e593f296dc4", // v0.8.15
@@ -537,25 +544,29 @@ public static class DownloadHashManager
             },
             [CrispAsr.LinuxCuda13] = new[]
             {
-                "5e753a2850d779ade96d3d9578728686363934f92024a45e9ca4db9e69a6165c", // v0.8.24 (current download URL)
+                "176dab15daded7e7b7fcc9a1685ff2b9a63047d4365d4ba5fa8dc4e97c069771", // v0.8.25 (current download URL)
+                "5e753a2850d779ade96d3d9578728686363934f92024a45e9ca4db9e69a6165c", // v0.8.24
                 "e8278bdcddfbc24b162391353490158318eb9a6c85504453348ca22d61f4bbd0", // v0.8.23
                 "2bb3d45a3623fd6422624b4912c1b1f903f59a6563c7e6acfdea9e5fb96f6743", // v0.8.20 (first SE-tracked build)
             },
             [CrispAsr.LinuxVulkan] = new[]
             {
-                "0a9c872347c259d3d55e8baac83687afc7ce9a3e185441a934fd4f17e103dacb", // v0.8.24 (current download URL)
+                "d8bd2d0dbbf3bb721dd185f40b35974b47322bf010fde05d2052d6f04e48ef33", // v0.8.25 (current download URL)
+                "0a9c872347c259d3d55e8baac83687afc7ce9a3e185441a934fd4f17e103dacb", // v0.8.24
                 "22bcca4c87325e9af4560fd6db5528074b17f6ef5855a8130b6e9b23d55d9cfb", // v0.8.23
                 "0dd956a1a7f7beb0c715cdd2f0d028d6de64a23427a923be7f7f5c57cfabc903", // v0.8.20 (first SE-tracked build)
             },
             [CrispAsr.LinuxHip] = new[]
             {
-                "3b3c4ec77f4d977e7dad5969a5938321f61694819cba03b5d7b3738d35ade8e4", // v0.8.24 (current download URL)
+                "f6469c530113a8336018e1d769c2f0383889f6691f93d858a7106655dfea643d", // v0.8.25 (current download URL)
+                "3b3c4ec77f4d977e7dad5969a5938321f61694819cba03b5d7b3738d35ade8e4", // v0.8.24
                 "5a355826f717375e75dca6bdf6ea3fc987678975aa95c0f18863877bad7b9af5", // v0.8.23
                 "427dc48c311fba3aa05436185bfefa879ddf20510e1b72d4da2b0f43a4a49c63", // v0.8.20 (first SE-tracked build)
             },
             [CrispAsr.LinuxArm] = new[]
             {
-                "1268db9d415c1aff727f67e8612301445db4073b754a0fd8f020625c8b139065", // v0.8.24 (current download URL)
+                "19d6031178a3a9a223f4a7cc47c97d87ae1bd11270fd26a68f3accb2397e5183", // v0.8.25 (current download URL)
+                "1268db9d415c1aff727f67e8612301445db4073b754a0fd8f020625c8b139065", // v0.8.24
                 "5fe8e5bef06c15515dd3418818795e7e9287ea3eee5a18a7d3aea8add9de0e6c", // v0.8.23
                 "61604a17ffe17f8683d79fe41cf482886d9ed4215557b6fdf7f78dff74ec088a", // v0.8.20
                 "7d9a0740631fab57289b36e5970a792853c45da7a386d729be875212709de034", // v0.8.15
@@ -769,7 +780,8 @@ public static class DownloadHashManager
             // SHA-256 of crispasr.exe / crispasr extracted from each archive above.
             [CrispAsr.WindowsCudaExecutable] = new[]
             {
-                "a6aa443d82a0fac7429172c8c707e668cd5ebf2f45411266cb6f8acd36283f0d", // v0.8.24 (current download URL)
+                "75d770cb6d876d87b457c7aee7e498a62e18f1a54930afc31c72fec2471103b7", // v0.8.25 (current download URL)
+                "a6aa443d82a0fac7429172c8c707e668cd5ebf2f45411266cb6f8acd36283f0d", // v0.8.24
                 "a9e77b8522ba8959b5bf0bd631df0c0a0e46a95437fb1e7fd0a22e510b9f0e45", // v0.8.23
                 "a82f91533889968c8d6f3db75938629ed52722664decf962f703e675d6c59816", // v0.8.20
                 "281df85cca3920b6a1c6aa5b51c94285677efd4cdcf17e837a2b5754db6ae2c5", // v0.8.15
@@ -792,7 +804,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.WindowsVulkanExecutable] = new[]
             {
-                "7ca199ae00a05b27313d08ab2220b8a1c47911c22b2257a2795bd28acb47bf58", // v0.8.24 (current download URL)
+                "4d5f35ee9deef8d698ec7d056422ae8e858dc088db434932f8032e8c6766ce7a", // v0.8.25 (current download URL)
+                "7ca199ae00a05b27313d08ab2220b8a1c47911c22b2257a2795bd28acb47bf58", // v0.8.24
                 "c938fc051f6c8f5c190a874b7e38d4ae369f974cc1056d693d0c758ece9652ab", // v0.8.23
                 "55b76d3939d0c57fb89de23241527f4e5b8356f3a10afc51bc1a526fce148606", // v0.8.20
                 "a8d8674b3a0c382cfda8970f097206473ad474577d30cbf3e8710ca21a187017", // v0.8.15
@@ -830,7 +843,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.WindowsCpuExecutable] = new[]
             {
-                "5a2ccf43197211d90690e96f121252287fbf28abd6d0f8a276fe2269ba3d6314", // v0.8.24 (current download URL)
+                "775ce2a860bac8ba988cc0016d6224f0f8a453684244bd4fd7ab73e559df1df1", // v0.8.25 (current download URL)
+                "5a2ccf43197211d90690e96f121252287fbf28abd6d0f8a276fe2269ba3d6314", // v0.8.24
                 "7276a38caab4d8440263d4e808b2adcc785596ffb2a5998cef9e28ec22fb389e", // v0.8.23
                 "da33481ffc04bd418cca05a017a3fe6990eefc0438b0c1059fa3910468f32ac5", // v0.8.20
                 "eaa950290b928f336db843482c8900543f92055b2137a2870b42ee07d70f2750", // v0.8.15
@@ -861,7 +875,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.WindowsCpuLegacyExecutable] = new[]
             {
-                "11971927a6933e2e500a58f03bca22a07cc2d7c00c4b72bd71b4ed3e4c8df487", // v0.8.24 (current download URL)
+                "58569b7845a6de2f359ae8125460aebe7cb46081571b24c5293728eb48909c63", // v0.8.25 (current download URL)
+                "11971927a6933e2e500a58f03bca22a07cc2d7c00c4b72bd71b4ed3e4c8df487", // v0.8.24
                 "ee196ff0f596803531427bbece3e8480a91fdd67237158c69dfaedf977f82056", // v0.8.23
                 "4be44ebb28222e7303c241d43129eebfe2a4aa6219f4c8dbdec54adeb4d99112", // v0.8.20
                 "753922b46caf301ccbc76775ce12192245843b307104c3a8e638ac8b9d5e0bd0", // v0.8.15
@@ -898,7 +913,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.LinuxExecutable] = new[]
             {
-                "e6b57f41d02d63bbbd7f558d66c53ae8197216309c1154efddfd910927990791", // v0.8.24 (current download URL)
+                "497e8d5c4a57cac2517d0c4a5b1f25004af5b2c95052a07e0cf04b4d12435d91", // v0.8.25 (current download URL)
+                "e6b57f41d02d63bbbd7f558d66c53ae8197216309c1154efddfd910927990791", // v0.8.24
                 "1373b0be0e499d8cac71b20ebf4d49b544fc8e9c70fb004e020afcf89c066671", // v0.8.23
                 "0d37ad0b75a878ae42b5e88c379124340ff36b08515a8ccce7d6419e24916e84", // v0.8.20
                 "04153e5ba883e68ecbe7a83465ed4381d3546615b7661db96fbe987a8918f166", // v0.8.15
@@ -936,7 +952,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.MacOsExecutable] = new[]
             {
-                "4adb49598710f728220501b60b278187d174f51784e7ac553b2879ea41729a26", // v0.8.24 (current download URL)
+                "bcac974bd9a7dfddc4f4194d86dc1b6d42dc622ca161855fe5a498fd73a31701", // v0.8.25 (current download URL)
+                "4adb49598710f728220501b60b278187d174f51784e7ac553b2879ea41729a26", // v0.8.24
                 "4b896543778678ed2f3997b2c0276b0f1cad182dd9de5b4a7e619beca35fc8a6", // v0.8.23
                 "26cf44c6293a5d0281bc6a918b1e087b4021e7f4afd2890c4f67eee8ac329a0f", // v0.8.20
                 "10ff8bc07c6c9f2151278f093350d3bab4b9659440c968024ec1588c90da9bec", // v0.8.15
@@ -974,7 +991,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.LinuxCudaExecutable] = new[]
             {
-                "4438849bdf545df69ac272a73bdef19d11f04f4ca02b9350e49fe3d39dfcf8b6", // v0.8.24 (current download URL)
+                "403804c5d2a438d43f2da984a8f351eb36600aa164214b4737691e0ea5950b4b", // v0.8.25 (current download URL)
+                "4438849bdf545df69ac272a73bdef19d11f04f4ca02b9350e49fe3d39dfcf8b6", // v0.8.24
                 "a06560cea1fd11cac3e8253d2288c11908984be01641309a4e51ade6cee8978f", // v0.8.23
                 "5ab1ad8a37fca03d963c3fc1f3b6b7ace541c078df3e3f371a46737ebdfc6b45", // v0.8.20
                 "f526b0c2cdd7bfc8205f658aee976ced1a2afe70a4a31aa25b1ef6cb48175496", // v0.8.15
@@ -1003,25 +1021,29 @@ public static class DownloadHashManager
             },
             [CrispAsr.LinuxCuda13Executable] = new[]
             {
-                "5c6707ac3e8e1b565bf3fb7df50e72add250a0b8f41bfe9b439de7da1d1ef03d", // v0.8.24 (current download URL)
+                "a1ece1aeb9896c5550a45f4af7c9502c0a76b78a0de9ff00078b5730a28ec7c5", // v0.8.25 (current download URL)
+                "5c6707ac3e8e1b565bf3fb7df50e72add250a0b8f41bfe9b439de7da1d1ef03d", // v0.8.24
                 "06276e933645e3504ed3c522231993c658cbee60a2624ca762c339cc5e70a948", // v0.8.23
                 "d82fd05883f37fbf75878c14629b8d3d388f1586d64b52cbe2eeda3472f736c3", // v0.8.20 (first SE-tracked build)
             },
             [CrispAsr.LinuxVulkanExecutable] = new[]
             {
-                "16a11dff29deb05974bfd4a5ba8ec304163b577eb8ec941e9e599e78f034f695", // v0.8.24 (current download URL)
+                "204b9becbb783ca70f64d72652911ed360369a6201b3e16982a5535391c9f372", // v0.8.25 (current download URL)
+                "16a11dff29deb05974bfd4a5ba8ec304163b577eb8ec941e9e599e78f034f695", // v0.8.24
                 "bda8c75712f57f4020e5d3db348d9f114042f77d75ecab3a34b503f699ff34b6", // v0.8.23
                 "ac97955896cb5bdad91a109e771cc7dee351b4d8aea57eedfed76896836fc914", // v0.8.20 (first SE-tracked build)
             },
             [CrispAsr.LinuxHipExecutable] = new[]
             {
-                "d4ceff3e5096fa566f4fff21a664969efd484ccc0463df3789536dc91dc82d77", // v0.8.24 (current download URL)
+                "2a5504fb5ed295a6ca9689b5f8657af0346425ffa1263f137659dfba24082b9a", // v0.8.25 (current download URL)
+                "d4ceff3e5096fa566f4fff21a664969efd484ccc0463df3789536dc91dc82d77", // v0.8.24
                 "d976c5705241ede03b1d1b9e20d4a79caa669cc51eeda1061472a6eed5c0df08", // v0.8.23
                 "7075f1581bdf1542ba25b9fa9119a1ebe58fda8f5423aeb68344c6b587ac9101", // v0.8.20 (first SE-tracked build)
             },
             [CrispAsr.LinuxArmExecutable] = new[]
             {
-                "3e237d35e89517ea0070ecba1e09d8e872dd5f329bbdef04a9f00c7d147d39b3", // v0.8.24 (current download URL)
+                "29b0aa5ab51fc12f29ea9b705f2fedfd2d5d640a333404f8a64e62eeabf4f943", // v0.8.25 (current download URL)
+                "3e237d35e89517ea0070ecba1e09d8e872dd5f329bbdef04a9f00c7d147d39b3", // v0.8.24
                 "b7f1b4181257949e849989b908ac5bff3c57b16298ef0e4dac69f06db1305100", // v0.8.23
                 "f7cf43213ebbb298d373f67573a9e38a6445924804afa36d724cedf74251f9c7", // v0.8.20
                 "8af30ea0fb610ea5b7a7bcd767070469f6daa74f3b86be45f53dd9e3cb3c5176", // v0.8.15

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -225,6 +225,17 @@ public static class DownloadHashManager
         public const string Ref = "VoxCPM2CrispAsr.Ref";
     }
 
+    public static class OmniVoiceCrispAsr
+    {
+        // SHA-256 of each GGUF the omnivoice backend needs: the three main quants and the F16
+        // tokenizer companion. The q8_0 tokenizer is deliberately absent — it breaks reference
+        // encoding, so SE never downloads it. Hashes are the HF LFS oid from the tree API.
+        public const string ModelQ4K = "OmniVoiceCrispAsr.ModelQ4K";
+        public const string ModelQ8_0 = "OmniVoiceCrispAsr.ModelQ8_0";
+        public const string ModelF16 = "OmniVoiceCrispAsr.ModelF16";
+        public const string TokenizerF16 = "OmniVoiceCrispAsr.TokenizerF16";
+    }
+
     public static class MossTtsCrispAsr
     {
         // SHA-256 of each GGUF the moss-tts backend needs: the four backbone quants and the
@@ -1484,6 +1495,26 @@ public static class DownloadHashManager
             [VoxCPM2CrispAsr.Ref] = new[]
             {
                 "9b024ef9a109075aa8ac7219c097a1b1b1bed23d3230b33a902e162c2c10c5f8", // voxcpm2-ref.gguf
+            },
+
+            // OmniVoice (CrispASR) — cstr/omnivoice-GGUF on HuggingFace. Only the F16 tokenizer
+            // is listed: omnivoice-tokenizer-q8_0.gguf loads, but its encoder tensors cannot be
+            // read back as f32, so cloning a reference voice yields noise (see OmniVoiceCrispAsr).
+            [OmniVoiceCrispAsr.ModelQ4K] = new[]
+            {
+                "a1a9c6fcf0253143581ecaa2ab3dd7084abf1378bec7986da3523e358273dda3", // omnivoice-q4_k.gguf
+            },
+            [OmniVoiceCrispAsr.ModelQ8_0] = new[]
+            {
+                "9d8835c80d50cce6ba66bed60c31e94836a7f990c40d2e22496c0b6710c98bb5", // omnivoice-q8_0.gguf
+            },
+            [OmniVoiceCrispAsr.ModelF16] = new[]
+            {
+                "670592a520713f036c1f10fdaa2839d3fb473144c06a772d7e715f7fb813d666", // omnivoice-f16.gguf
+            },
+            [OmniVoiceCrispAsr.TokenizerF16] = new[]
+            {
+                "710ef610e1f2845c6b7333d5432376b24f2d20d2c54a8cec9bc118d183ecea63", // omnivoice-tokenizer-f16.gguf
             },
 
             // MOSS-TTS (CrispASR) — cstr/moss-tts-v1.5-GGUF on HuggingFace.

--- a/src/ui/Logic/Download/OmniVoiceCrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/OmniVoiceCrispAsrDownloadService.cs
@@ -1,0 +1,169 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Nikse.SubtitleEdit.UiLogic;
+
+namespace Nikse.SubtitleEdit.Logic.Download;
+
+public interface IOmniVoiceCrispAsrDownloadService
+{
+    Task DownloadModels(string modelsFolder, string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Downloads the GGUFs the omnivoice backend needs — the picked main quant plus the shared F16
+/// tokenizer — into SE's CrispASR/models folder, so the user gets one SE progress dialog instead
+/// of crispasr's silent --auto-download. Same .part + size-check + SHA-256 verify pattern as
+/// VoxCPM2/CosyVoice3.
+///
+/// Only the F16 tokenizer is ever fetched: the q8_0 build in the same repo cannot be read back
+/// as f32 when encoding a reference voice, so it silently turns voice cloning into noise. See
+/// <see cref="OmniVoiceCrispAsr"/> for the measurements.
+/// </summary>
+public class OmniVoiceCrispAsrDownloadService : IOmniVoiceCrispAsrDownloadService
+{
+    private const string RepoBase = "https://huggingface.co/cstr/omnivoice-GGUF/resolve/main/";
+
+    private readonly HttpClient _httpClient;
+
+    private static readonly Dictionary<string, string> ModelUrls = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [OmniVoiceCrispAsr.ModelQ4KFileName] = RepoBase + OmniVoiceCrispAsr.ModelQ4KFileName,
+        [OmniVoiceCrispAsr.ModelQ8_0FileName] = RepoBase + OmniVoiceCrispAsr.ModelQ8_0FileName,
+        [OmniVoiceCrispAsr.ModelF16FileName] = RepoBase + OmniVoiceCrispAsr.ModelF16FileName,
+        [OmniVoiceCrispAsr.TokenizerFileName] = RepoBase + OmniVoiceCrispAsr.TokenizerFileName,
+    };
+
+    public OmniVoiceCrispAsrDownloadService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task DownloadModels(string modelsFolder, string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken)
+    {
+        // Destinations come from the engine so cache-seed adoption and SE-managed downloads
+        // converge on the same canonical folder.
+        modelsFolder = OmniVoiceCrispAsr.GetSetModelsFolder();
+
+        var required = OmniVoiceCrispAsr.GetRequiredFileNames(modelKey);
+
+        await Task.Run(() =>
+        {
+            foreach (var fileName in required)
+            {
+                var dest = Path.Combine(modelsFolder, fileName);
+                OmniVoiceCrispAsr.TrySeedModelFromCrispAsrCache(fileName, dest);
+                EnsureRemovedIfInvalid(dest, fileName);
+            }
+        }, cancellationToken);
+
+        var missing = new List<string>();
+        foreach (var fileName in required)
+        {
+            var dest = Path.Combine(modelsFolder, fileName);
+            if (!OmniVoiceCrispAsr.IsValidLocalModelFile(dest, fileName))
+            {
+                missing.Add(fileName);
+            }
+        }
+
+        var step = 0;
+        foreach (var fileName in missing)
+        {
+            step++;
+            titleProgress?.Invoke($"Downloading OmniVoice (CrispASR) models ({step}/{missing.Count}): {fileName}");
+            var dest = Path.Combine(modelsFolder, fileName);
+            await DownloadAndVerify(dest, fileName, progress, cancellationToken);
+        }
+    }
+
+    private async Task DownloadAndVerify(string finalPath, string fileName, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        var partPath = finalPath + ".part";
+        try
+        {
+            await DownloadHelper.DownloadFileAsync(_httpClient, GetUrl(fileName), partPath, progress, cancellationToken);
+            await VerifyFile(partPath, GetHashKey(fileName), fileName, cancellationToken);
+            File.Move(partPath, finalPath);
+        }
+        catch
+        {
+            TryDelete(partPath);
+            throw;
+        }
+    }
+
+    private static string? GetHashKey(string fileName)
+    {
+        if (string.Equals(fileName, OmniVoiceCrispAsr.ModelQ4KFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.OmniVoiceCrispAsr.ModelQ4K;
+        }
+        if (string.Equals(fileName, OmniVoiceCrispAsr.ModelQ8_0FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.OmniVoiceCrispAsr.ModelQ8_0;
+        }
+        if (string.Equals(fileName, OmniVoiceCrispAsr.ModelF16FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.OmniVoiceCrispAsr.ModelF16;
+        }
+        if (string.Equals(fileName, OmniVoiceCrispAsr.TokenizerFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.OmniVoiceCrispAsr.TokenizerF16;
+        }
+        return null;
+    }
+
+    private static async Task VerifyFile(string filePath, string? key, string fileName, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            return;
+        }
+
+        var expected = DownloadHashManager.GetLatestKnownHash(key);
+        if (string.IsNullOrEmpty(expected))
+        {
+            return;
+        }
+
+        string actual;
+        await using (var stream = File.OpenRead(filePath))
+        {
+            actual = await Sha256Util.ComputeSha256Async(stream, cancellationToken);
+        }
+
+        if (!string.Equals(expected, actual, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new IOException(
+                $"OmniVoice (CrispASR) model {fileName} failed integrity check (expected SHA-256 {expected}, got {actual}).");
+        }
+    }
+
+    private static string GetUrl(string fileName)
+    {
+        if (!ModelUrls.TryGetValue(fileName, out var url))
+        {
+            throw new ArgumentException($"Unknown OmniVoice (CrispASR) model: {fileName}", nameof(fileName));
+        }
+        return url;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try { File.Delete(path); } catch { /* best-effort cleanup */ }
+    }
+
+    private static void EnsureRemovedIfInvalid(string path, string fileName)
+    {
+        if (!File.Exists(path) || OmniVoiceCrispAsr.IsValidLocalModelFile(path, fileName))
+        {
+            return;
+        }
+        TryDelete(path);
+    }
+}

--- a/tests/UI/Features/Video/SpeechToText/Engines/CrispAsrEngineTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/Engines/CrispAsrEngineTests.cs
@@ -12,6 +12,7 @@ public class CrispAsrEngineTests
     [InlineData(WhisperChoice.CrispAsrKyutai, typeof(CrispAsrKyutai), "kyutai-stt")]
     [InlineData(WhisperChoice.CrispAsrMega, typeof(CrispAsrMega), "mega-asr")]
     [InlineData(WhisperChoice.CrispAsrFunAsrNano, typeof(CrispAsrFunAsrNano), "funasr")]
+    [InlineData(WhisperChoice.CrispAsrGigaAm, typeof(CrispAsrGigaAm), "gigaam")]
     public void TrySelectBackendChoice_SelectsPersistedCrispBackendChoice(string choice, Type backendType, string backendName)
     {
         var engine = new CrispAsrEngine();

--- a/tests/UI/Features/Video/SpeechToText/Engines/CrispAsrGigaAmTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/Engines/CrispAsrGigaAmTests.cs
@@ -1,0 +1,73 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.UiLogic.AudioToText;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+namespace UITests.Features.Video.SpeechToText.Engines;
+
+/// <summary>
+/// GigaAM-v3 is Russian-only and its "e2e" revisions are the ones that write punctuation and
+/// capital letters. Both facts are encoded in the model list and language list rather than in
+/// runtime logic, so they are what these tests pin.
+/// </summary>
+public class CrispAsrGigaAmTests
+{
+    [Fact]
+    public void Languages_AreRussianOnly()
+    {
+        var engine = new CrispAsrGigaAm();
+
+        // crispasr prints "'en' ignored — GigaAM-v3 is a Russian-only model" for anything else,
+        // so offering a second language in the combo would only produce a silent no-op.
+        var language = Assert.Single(engine.Languages);
+        Assert.Equal("ru", language.Code);
+        Assert.Equal("ru", engine.DefaultLanguage);
+    }
+
+    [Fact]
+    public void Models_ListPunctuatingRevisionsFirst()
+    {
+        var engine = new CrispAsrGigaAm();
+
+        // The first entry is what the model combo lands on by default; the plain ctc/rnnt heads
+        // return lowercase text with no punctuation, which is the wrong default for subtitles.
+        Assert.StartsWith("gigaam-v3-e2e-", engine.Models[0].Name);
+        Assert.All(engine.Models.Take(6), m => Assert.StartsWith("gigaam-v3-e2e-", m.Name));
+        Assert.All(engine.Models.Skip(6), m => Assert.DoesNotContain("-e2e-", m.Name));
+    }
+
+    [Fact]
+    public void Models_AllPointAtTheGigaAmV3Repo()
+    {
+        var engine = new CrispAsrGigaAm();
+
+        Assert.Equal(12, engine.Models.Count);
+        foreach (var model in engine.Models)
+        {
+            var url = Assert.Single(model.Urls);
+            Assert.Equal($"https://huggingface.co/cstr/gigaam-v3-GGUF/resolve/main/{model.Name}", url);
+        }
+    }
+
+    [Fact]
+    public void Backend_IsRegisteredWithTheCrispAsrEngine()
+    {
+        var engine = new CrispAsrEngine();
+
+        Assert.True(engine.TrySelectBackendChoice(WhisperChoice.CrispAsrGigaAm));
+        Assert.Equal("gigaam", engine.BackendName);
+    }
+
+    /// <summary>
+    /// The help asset name is derived from <c>Name</c> with spaces removed, so a rename that
+    /// isn't mirrored in Assets/SpeechToText silently drops the backend header.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task GetHelpText_IncludesTheGigaAmHeader()
+    {
+        var engine = new CrispAsrGigaAm();
+
+        var helpText = await engine.GetHelpText();
+
+        Assert.Contains("GigaAM-v3", helpText);
+    }
+}

--- a/tests/UI/Features/Video/TextToSpeech/Engines/OmniVoiceCrispAsrTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/OmniVoiceCrispAsrTests.cs
@@ -1,0 +1,126 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic.Download;
+
+namespace UITests.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// The rules this engine has to get right are all data rules, and each one has a matching
+/// failure mode observed against crispasr 0.8.25:
+///  - ship the F16 tokenizer, never the q8_0 one (q8_0 turns voice cloning into noise),
+///  - keep the built-in "Default" voice first (this backend, unlike VoxCPM2, has one),
+///  - keep the byte sizes exact (a truncated GGUF only fails at server startup).
+/// </summary>
+public class OmniVoiceCrispAsrTests
+{
+    [Fact]
+    public void RequiredFiles_AlwaysPairTheQuantWithTheF16Tokenizer()
+    {
+        foreach (var key in new[] { OmniVoiceCrispAsr.ModelKeyQ4K, OmniVoiceCrispAsr.ModelKeyQ8_0, OmniVoiceCrispAsr.ModelKeyF16 })
+        {
+            var required = OmniVoiceCrispAsr.GetRequiredFileNames(key);
+
+            Assert.Equal(2, required.Length);
+            Assert.Equal(OmniVoiceCrispAsr.GetModelFileName(key), required[0]);
+            Assert.Equal("omnivoice-tokenizer-f16.gguf", required[1]);
+        }
+    }
+
+    /// <summary>
+    /// omnivoice-tokenizer-q8_0.gguf loads and synthesises, but its encoder tensors cannot be
+    /// read back as f32, so an encoded reference voice comes out as noise — and crispasr caches
+    /// that bad encoding by audio content. It must never appear anywhere in the engine.
+    /// </summary>
+    [Fact]
+    public void TheQ8TokenizerIsNeverReferenced()
+    {
+        Assert.Equal("omnivoice-tokenizer-f16.gguf", OmniVoiceCrispAsr.TokenizerFileName);
+        Assert.DoesNotContain("tokenizer-q8", OmniVoiceCrispAsr.TokenizerFileName);
+
+        var hash = DownloadHashManager.GetLatestKnownHash(DownloadHashManager.OmniVoiceCrispAsr.TokenizerF16);
+        Assert.Equal("710ef610e1f2845c6b7333d5432376b24f2d20d2c54a8cec9bc118d183ecea63", hash);
+    }
+
+    [Theory]
+    [InlineData(null, "omnivoice-q4_k.gguf")]
+    [InlineData("", "omnivoice-q4_k.gguf")]
+    [InlineData("nonsense", "omnivoice-q4_k.gguf")]
+    [InlineData(OmniVoiceCrispAsr.ModelKeyQ8_0, "omnivoice-q8_0.gguf")]
+    [InlineData(OmniVoiceCrispAsr.ModelKeyF16, "omnivoice-f16.gguf")]
+    public void GetModelFileName_FallsBackToTheLightestQuant(string? modelKey, string expected)
+    {
+        // A saved setting from an older/newer build must not resolve to a file that isn't there;
+        // anything unrecognised lands on Q4_K rather than throwing mid-synthesis.
+        Assert.Equal(expected, OmniVoiceCrispAsr.GetModelFileName(modelKey));
+    }
+
+    [Fact]
+    public void IsValidLocalModelFile_RejectsATruncatedDownload()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        try
+        {
+            File.WriteAllBytes(path, new byte[16]);
+
+            // Size is the cheap stand-in for "this GGUF is complete" — the loader would otherwise
+            // only fail once the server is already starting.
+            Assert.False(OmniVoiceCrispAsr.IsValidLocalModelFile(path, "omnivoice-q4_k.gguf"));
+
+            // A filename with no recorded size is accepted on existence alone.
+            Assert.True(OmniVoiceCrispAsr.IsValidLocalModelFile(path, "something-else.gguf"));
+        }
+        finally
+        {
+            try { File.Delete(path); } catch { }
+        }
+    }
+
+    [Fact]
+    public async Task Voices_LeadWithTheBuiltInVoice()
+    {
+        var engine = new OmniVoiceCrispAsr();
+
+        var voices = await engine.GetVoices(string.Empty);
+
+        // Unlike VoxCPM2/MOSS-TTS, this backend synthesises fine with no reference audio, so the
+        // combo must offer that as the first entry rather than starting out empty.
+        Assert.NotEmpty(voices);
+        var first = Assert.IsType<OmniVoiceCrispAsrVoice>(voices[0].EngineVoice);
+        Assert.Equal("Default", first.Voice);
+        Assert.Equal(string.Empty, first.FilePath);
+    }
+
+    [Fact]
+    public async Task Engine_UsesTheOmnivoiceBackendAndItsOwnVoiceType()
+    {
+        var engine = new OmniVoiceCrispAsr();
+
+        Assert.Equal("omnivoice", OmniVoiceCrispAsr.BackendName);
+        Assert.Equal("OmniVoice TTS (CrispASR)", engine.Name);
+        Assert.True(engine.HasModel);
+        Assert.True(engine.HasLanguageParameter);
+
+        // Speaking with the standalone engine's voice type must fail loudly rather than get
+        // silently reinterpreted — the two engines share the voice combo.
+        var wrongVoice = new Voice(new OmniVoice("Default", string.Empty));
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            engine.Speak("hello", string.Empty, wrongVoice, null, null, null, CancellationToken.None));
+    }
+
+    [Fact]
+    public void ModelHashes_AreRegisteredForEveryQuant()
+    {
+        foreach (var key in new[]
+                 {
+                     DownloadHashManager.OmniVoiceCrispAsr.ModelQ4K,
+                     DownloadHashManager.OmniVoiceCrispAsr.ModelQ8_0,
+                     DownloadHashManager.OmniVoiceCrispAsr.ModelF16,
+                     DownloadHashManager.OmniVoiceCrispAsr.TokenizerF16,
+                 })
+        {
+            var hash = DownloadHashManager.GetLatestKnownHash(key);
+            Assert.False(string.IsNullOrEmpty(hash), $"no hash registered for {key}");
+            Assert.Equal(64, hash!.Length);
+        }
+    }
+}


### PR DESCRIPTION
Three commits: the runtime bump, then the two new engines it makes available.

## Update CrispASR to v0.8.25

Bumps the pinned runtime across all 11 platform download URLs and adds the new archive + executable SHA-256 hashes, all computed from freshly downloaded release assets (sizes match the release API exactly).

Verification:
- macOS binary probe-tested: reports `0.8.25`, git sha `6e5bf7ff`, backends `cpu,metal,blas`, and transcribes correctly via the sensevoice backend on Metal.
- Diffed the full `--help` flag set against the installed v0.8.24 binary: **identical**, so nothing SE passes was removed or renamed. Upstream confirms it is drop-in.
- Download-size figures refreshed from the v0.8.25 assets.

Notable upstream fixes for SE users: the pyannote powerset decode table had two entries transposed, so every frame with a third speaker talking alone was credited to the wrong two (15 DER points on VoxConverse dev); `--diarize-max-speakers` was picking the speaker count instead of bounding it (15.74% → 7.81% DER with TitaNet); pyannote segmentation is now chunked and parallel (~50s → ~18s on a 2888s file at `-t 8`); sherpa diarization no longer hangs indefinitely on Windows (#328); whisper vocabularies with half-serialized special tokens now fail loudly instead of producing wrong ids (#322).

## Add GigaAM-v3 speech-to-text

`ai-sage/GigaAM-v3`, new as the `gigaam` backend in v0.8.25 — the only backend added this release. Russian-only, Rotary Conformer encoder, 12 GGUFs from `cstr/gigaam-v3-GGUF` (CTC and RNN-T heads, each character-level or SPM "e2e", three quants each).

The e2e revisions are listed first because they emit punctuation and capitalisation natively. Verified on Russian test audio at 27× realtime:

| model | output |
|---|---|
| `e2e-rnnt-q8_0` | `"Привет." / "Это тест распознавания" / "русской речи."` |
| `ctc-q4_k` | `"привет это тест распознавания русской речи"` |

Both produce valid timestamped SRT under SE's default `--max-len 50 --split-on-punct`. The language list holds Russian alone — `-l ru` is accepted, anything else is ignored with a warning.

## Add OmniVoice TTS (CrispASR)

Runs OmniVoice through the `omnivoice` backend, alongside the existing standalone `omnivoice-tts` engine — the same split SE already has between `Qwen3TtsCpp` and `Qwen3TtsCrispAsr`. It reuses the CrispASR runtime a user may already have for speech-to-text and runs as a persistent server, so the model loads once instead of once per line.

Three quants from `cstr/omnivoice-GGUF` plus the tokenizer companion, staged with size + SHA-256 verification (all four hashes match the HF LFS oids). Unlike VoxCPM2/MOSS-TTS this backend has a usable built-in voice, so the combo offers "Default" first and cloning is opt-in; reference WAVs are seeded from the standalone engine's voices folder.

### ⚠ The tokenizer is pinned to the F16 build

`omnivoice-tokenizer-q8_0.gguf` loads and synthesises fine, but its encoder tensors cannot be read back as f32 (`read_tensor_f32: unsupported type 8` per quantizer), so encoding a *reference* voice yields garbage codes and the clone comes out as noise. Worse, crispasr caches the encoded reference by audio content, so a single q8_0 run poisons later F16 runs. Measured by median F0 of reference vs clone:

| run | reference | clone |
|---|---|---|
| female ref, F16 tokenizer | 191.5 Hz | **190.6 Hz** — intelligible, correct text |
| male ref, F16 tokenizer | 110.2 Hz | **111.8 Hz** — intelligible, correct text |
| same, q8_0 tokenizer | 110.2 Hz | 481 Hz — transcribes to `"I."` (noise) |

SE therefore only ever downloads the F16 tokenizer and pins it explicitly via `--codec-model` rather than leaving it to sibling discovery. A test pins that.

The exact server command line SE builds — server mode, `--voice-dir`, provenance flags, cloning reference — was run end to end, and its output round-trips back through sensevoice as the right words in the right voice (187.2 Hz against a 191.5 Hz reference).

## Testing

`dotnet test tests/UI` on the merge of this branch with current `main`: **1127 passed, 2 failed**. Both failures (`SubtitleGridScrollPerformanceTests.HomeAndEnd_RealizeOnlyAViewportOfRows` and `SyntaxTextDocumentTests.InsertWithLineBreaksSplitsTheLine`) reproduce identically on plain `origin/main` and are unrelated to these changes. This branch adds 17 tests, all passing.

Note: `change-log.txt` is deliberately untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)