### PR TITLE
Fix red/blue swap in VobSub and DVB decoding on macOS/Linux

### DIFF
--- a/src/libse/Common/FastBitmap.cs
+++ b/src/libse/Common/FastBitmap.cs
@@ -51,6 +51,15 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return;
             }
 
+            if (_workingBitmap.ColorType != SKColorType.Bgra8888)
+            {
+                // PixelData writes raw B,G,R,A bytes; on any other layout (e.g. the
+                // Rgba8888 platform default on macOS/Linux) red and blue would silently
+                // swap. Callers must create their bitmaps as Bgra8888.
+                throw new InvalidOperationException(
+                    $"FastBitmap requires a Bgra8888 bitmap, got {_workingBitmap.ColorType}.");
+            }
+
             _width = _workingBitmap.Width * sizeof(PixelData);
             if (_width % 4 != 0)
             {

--- a/src/libse/ContainerFormats/TransportStream/ObjectDataSegment.cs
+++ b/src/libse/ContainerFormats/TransportStream/ObjectDataSegment.cs
@@ -87,7 +87,9 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
                     y = 500;
                 }
 
-                Image = new SKBitmap(Math.Max(1, width), y + 1);
+                // Bgra8888 explicitly: FastBitmap writes raw B,G,R,A bytes, and the platform
+                // default color type is Rgba8888 on macOS/Linux, which would swap red/blue.
+                Image = new SKBitmap(Math.Max(1, width), y + 1, SKColorType.Bgra8888, SKAlphaType.Premul);
                 Image.Erase(SKColors.Transparent);
                 _fastImage = new FastBitmap(Image);
                 _fastImage.LockImage();

--- a/src/libse/VobSub/SubPicture.cs
+++ b/src/libse/VobSub/SubPicture.cs
@@ -237,7 +237,9 @@ namespace Nikse.SubtitleEdit.Core.VobSub
                 return new SKBitmap(1, 1);
             }
 
-            var bmp = new SKBitmap(imageDisplayArea.Width + 1, imageDisplayArea.Height + 1);
+            // Bgra8888 explicitly: FastBitmap writes raw B,G,R,A bytes, and the platform
+            // default color type is Rgba8888 on macOS/Linux, which would swap red/blue.
+            var bmp = new SKBitmap(imageDisplayArea.Width + 1, imageDisplayArea.Height + 1, SKColorType.Bgra8888, SKAlphaType.Premul);
             if (fourColors[0] != SKColors.Transparent)
             {
                 using (var canvas = new SKCanvas(bmp))

--- a/tests/UI/Controls/SyntaxTextDocumentTests.cs
+++ b/tests/UI/Controls/SyntaxTextDocumentTests.cs
@@ -80,8 +80,11 @@ public class SyntaxTextDocumentTests
         var document = Document("onetwo");
         document.Insert(3, "\r\nX\r\n");
 
+        // The seed text has no line break, so the document falls back to
+        // Environment.NewLine and normalizes the inserted breaks to it.
+        var nl = Environment.NewLine;
         Assert.Equal(3, document.LineCount);
-        Assert.Equal("one\r\nX\r\ntwo", document.Text);
+        Assert.Equal($"one{nl}X{nl}two", document.Text);
         Assert.Equal("X", document.GetLine(1));
     }
 


### PR DESCRIPTION
## Summary

Both of the suite's failing tests on macOS are addressed - one was a real code bug, one a platform-dependent test.

**The code bug:** `FastBitmap` writes raw `B,G,R,A` bytes, but its two users (`SubPicture` for VobSub and the DVB `ObjectDataSegment`) created their bitmaps with `new SKBitmap(w, h)`, which uses the *platform default* color type - Bgra8888 on Windows but **Rgba8888 on macOS/Linux**. There, every decoded VobSub/DVB subpicture came out with red and blue swapped. This is what `LoadVobSub_AppliesIdxPalette_ToDecodedBitmaps` was still failing on after cc4832c75 (the `ColorUtils` overload fix), which only made it pass on Windows.

- Pin both creation sites to `Bgra8888` + `Premul` (identical to what the default ctor produced on Windows, so no behavior change there)
- `FastBitmap.LockImage` now throws on any other color type, so future misuse fails loudly instead of silently swapping channels (`NikseBitmap` already guards this way)

**The test bug:** `SyntaxTextDocumentTests.InsertWithLineBreaksSplitsTheLine` seeds a document without a line break, so inserted breaks normalize to `Environment.NewLine` - the expectation can't hardcode CRLF. It now builds the expected text from `Environment.NewLine`.

## Test plan

- [x] Full suite on macOS: 2,302 tests, 0 failures (was 2 failures)
- [x] Full rebuild with 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)