### PR TITLE
Shorten overly long lines in the v5.2.0-beta1 change log entries

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -5,7 +5,8 @@ Subtitle Edit Changelog
 
 v5.2.0-beta1 (TBD)
 
-* Auto-translate: new advanced local-LLM engines (llama.cpp and Ollama) with batch context, system prompt/parameter settings and schema-forced output - thx subof
+* Auto-translate: advanced llama.cpp and Ollama engines with batch context - thx subof
+* Auto-translate: system prompt, parameter settings and schema-forced output for these engines
 * Statistics: new dashboard view with tiles, meters, checks and a CPS histogram
 * Add "Remove/replace Unicode characters" tool (SE4 plugin port) - thx fraternl
 * Add ASSA font collector
@@ -13,25 +14,26 @@ v5.2.0-beta1 (TBD)
 * Import plain text: add "Align time codes via forced aligner" - thx subof/David
 * Cut video: option to also cut the subtitle
 * Batch convert: brightness, alpha and color adjustments for image output
-* Open video from URL: video/subtitle checkboxes and auto-generated subtitles, and show the yt-dlp update prompt as a message box
-* Clean up YouTube auto-generated captions on load - one cue per spoken line with plain text instead of roll-up duplicates with per-word time codes
+* Open video from URL: video/subtitle checkboxes and auto-generated subtitles
+* Open video from URL: show the yt-dlp update prompt as a message box
+* Clean up YouTube auto-generated captions on load into one plain-text cue per spoken line
 * Waveform: per-track audio picker with size estimates, live progress and cancel - thx shanytc
-* Waveform: copy the subtitle at the video position (Ctrl+C and context menu) and paste at the waveform position - thx shanytc
+* Waveform: copy the subtitle at the video position and paste at the waveform position - thx shanytc
 * Text to speech: custom voice models for Piper
 * Fix common errors: context menu with applied-rule details and a rule filter
 * Add default save location setting - thx gadkarisid
 * Add auto-break settings under Settings -> Tools - thx citizenhelene
 * Add more proxy settings: domain, system credentials and a bypass list
-* Add optional Auto-translate, Speech to text and "Point sync via another subtitle" toolbar icons - thx fraternl
+* Add optional Auto-translate, Speech to text and Point sync toolbar icons - thx fraternl
 * Add "Show selected lines earlier/later" to the subtitle grid context menu
-* Add "Go to video position..." to the Video menu and a shortcut to toggle subtitles on the video player
+* Add "Go to video position..." to the Video menu and a toggle-subtitles video player shortcut
 * Add export support for Audacity/Tenacity labels
 * Machine-readable ffmpeg progress for shot changes, burn-in, re-encode and transparent subtitles
 * Help: respect a custom help shortcut, wire F1 in more windows, and add five new help pages
 * Remove the MLX Whisper speech-to-text engine - thx ruonghieu
-* Performance: faster hot paths across the UI and core libraries, verified with BenchmarkDotNet - thx ivandrofly
+* Performance: faster hot paths across the UI and core libraries - thx ivandrofly
 * Build asset zips from source folders at build time and ship translations compressed
-* Move auto-translate, speech-to-text and OCR logic from libse to libuilogic, so the libse NuGet package stays a pure subtitle library
+* Move auto-translate, speech to text and OCR to libuilogic, keeping libse a pure subtitle library
 * Honor ASSA override tags (position, alignment, colors, ...) in image-based export - thx Maxia1
 * Honor {\pos(x,y)} in VobSub and DVD sup export
 * Fix red and blue being swapped in VobSub, SSA and TextST colors
@@ -49,9 +51,11 @@ v5.2.0-beta1 (TBD)
 * Apply "extend to line before/after" to all selected lines - thx NiggleHub
 * Skip an auto-backup tick while a save is still in flight - thx ivandrofly
 * Download 64-bit libVLC on Windows x64 - thx StandAloof
-* Screen readers: keyboard focus in the subtitle grid is exposed via UI Automation again - the main grid and all dialog grids now use TableView - thx Urs2026
-* Accessibility: announce rule violations in the grid row's accessible name, safer initial focus, accessible names for icon buttons, and keep keyboard focus in the grid on Home/End jumps
-* Flatpak: bundle OpenBLAS so the CrispASR speech-to-text engines can start in the sandbox - thx DarkSwan86
+* Screen readers: the subtitle grid exposes keyboard focus via UI Automation again - thx Urs2026
+* The main subtitle grid and all dialog grids now use TableView
+* Accessibility: announce rule violations in the grid row's accessible name, safer initial focus
+* Accessibility: accessible names for icon buttons, keep grid keyboard focus on Home/End jumps
+* Flatpak: bundle OpenBLAS so the CrispASR engines can start in the sandbox - thx DarkSwan86
 * Speech to text: report a missing shared library instead of silently returning an empty result
 * Update Italian translation - thx bovirus
 * Update Korean translation - thx 12si27


### PR DESCRIPTION
Split multi-topic v5.2.0-beta1 entries into separate bullets (Open video from URL, screen readers/accessibility) and trimmed the wordy ones, so every entry now fits within the separator width (~100 chars). No entries added or removed - wording only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)