### PR TITLE
Always stamp the time code in set start/end time (#13066)

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -57,6 +57,7 @@ v5.2.0-beta1 (TBD)
 * Accessibility: accessible names for icon buttons, keep grid keyboard focus on Home/End jumps
 * Flatpak: bundle OpenBLAS so the CrispASR engines can start in the sandbox - thx DarkSwan86
 * Speech to text: report a missing shared library instead of silently returning an empty result
+* Fix "set start/end time" doing nothing when the video position was past the other time code - thx LabinSub
 * Update Italian translation - thx bovirus
 * Update Korean translation - thx 12si27
 * Update Polish translation - thx potplayer-fanpack

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -13675,12 +13675,11 @@ public partial class MainViewModel :
             return;
         }
 
+        // #13066: always stamp the start time, even when the playhead is past the line's
+        // current end (a fresh line sits right after the previous one, so that is the normal
+        // case when spotting forward). SetCueTimeHelper drags the end along when needed.
         var videoPositionSeconds = vp.Position;
-        var gap = Se.Settings.General.MinimumBetweenLines.GetMilliseconds() / 1000.0;
-        if (videoPositionSeconds >= s.EndTime.TotalSeconds - gap)
-        {
-            return;
-        }
+        var minimumDurationMs = Se.Settings.General.SubtitleMinimumDisplayMilliseconds;
 
         var isAssa = SelectedSubtitleFormat is AdvancedSubStationAlpha;
         if (isAssa)
@@ -13688,12 +13687,12 @@ public partial class MainViewModel :
             var selectedItems = SubtitleGridSelectedItems.Cast<SubtitleLineViewModel>().ToList();
             foreach (var item in selectedItems)
             {
-                item.SetStartTimeOnly(TimeSpan.FromSeconds(videoPositionSeconds));
+                SetCueTimeHelper.SetStart(item, TimeSpan.FromSeconds(videoPositionSeconds), minimumDurationMs);
             }
         }
         else
         {
-            s.SetStartTimeOnly(TimeSpan.FromSeconds(videoPositionSeconds));
+            SetCueTimeHelper.SetStart(s, TimeSpan.FromSeconds(videoPositionSeconds), minimumDurationMs);
         }
 
         _updateAudioVisualizer = true;
@@ -13719,12 +13718,9 @@ public partial class MainViewModel :
             return;
         }
 
+        // #13066: the start time is always stamped - see WaveformSetStart.
         var videoPositionSeconds = vp.Position;
-        var gap = Se.Settings.General.MinimumBetweenLines.GetMilliseconds() / 1000.0;
-        if (videoPositionSeconds >= s.EndTime.TotalSeconds - gap)
-        {
-            return;
-        }
+        var minimumDurationMs = Se.Settings.General.SubtitleMinimumDisplayMilliseconds;
 
         var isAssa = SelectedSubtitleFormat is AdvancedSubStationAlpha;
         if (isAssa)
@@ -13732,12 +13728,12 @@ public partial class MainViewModel :
             var selectedItems = SubtitleGridSelectedItems.Cast<SubtitleLineViewModel>().ToList();
             foreach (var item in selectedItems)
             {
-                item.SetStartTimeOnly(TimeSpan.FromSeconds(videoPositionSeconds));
+                SetCueTimeHelper.SetStart(item, TimeSpan.FromSeconds(videoPositionSeconds), minimumDurationMs);
             }
         }
         else
         {
-            s.SetStartTimeOnly(TimeSpan.FromSeconds(videoPositionSeconds));
+            SetCueTimeHelper.SetStart(s, TimeSpan.FromSeconds(videoPositionSeconds), minimumDurationMs);
         }
 
         SelectAndScrollToRow(idx + 1);
@@ -13786,12 +13782,10 @@ public partial class MainViewModel :
             return;
         }
 
+        // #13066: always stamp the end time, even when the playhead is before the line's
+        // current start - SetCueTimeHelper drags the start along when needed.
         var videoPositionSeconds = vp.Position;
-        var gap = Se.Settings.General.MinimumBetweenLines.GetMilliseconds() / 1000.0;
-        if (videoPositionSeconds < s.StartTime.TotalSeconds + gap)
-        {
-            return;
-        }
+        var minimumDurationMs = Se.Settings.General.SubtitleMinimumDisplayMilliseconds;
 
         var isAssa = SelectedSubtitleFormat is AdvancedSubStationAlpha;
         if (isAssa)
@@ -13799,12 +13793,12 @@ public partial class MainViewModel :
             var selectedItems = SubtitleGridSelectedItems.Cast<SubtitleLineViewModel>().ToList();
             foreach (var item in selectedItems)
             {
-                item.EndTime = TimeSpan.FromSeconds(videoPositionSeconds);
+                SetCueTimeHelper.SetEnd(item, TimeSpan.FromSeconds(videoPositionSeconds), minimumDurationMs);
             }
         }
         else
         {
-            s.EndTime = TimeSpan.FromSeconds(videoPositionSeconds);
+            SetCueTimeHelper.SetEnd(s, TimeSpan.FromSeconds(videoPositionSeconds), minimumDurationMs);
         }
 
         _updateAudioVisualizer = true;
@@ -13826,14 +13820,9 @@ public partial class MainViewModel :
             return;
         }
 
+        // #13066: the end time is always stamped - see WaveformSetEnd.
         var videoPositionSeconds = vp.Position;
-        var gap = Se.Settings.General.MinimumBetweenLines.GetMilliseconds() / 1000.0;
-        if (videoPositionSeconds < s.StartTime.TotalSeconds + gap)
-        {
-            return;
-        }
-
-        s.EndTime = TimeSpan.FromSeconds(videoPositionSeconds);
+        SetCueTimeHelper.SetEnd(s, TimeSpan.FromSeconds(videoPositionSeconds), Se.Settings.General.SubtitleMinimumDisplayMilliseconds);
 
         SelectAndScrollToRow(idx + 1);
 

--- a/src/ui/Logic/SetCueTimeHelper.cs
+++ b/src/ui/Logic/SetCueTimeHelper.cs
@@ -1,0 +1,59 @@
+﻿using Nikse.SubtitleEdit.Features.Main;
+using System;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Stamping the video position onto a line's start/end cue ("set start time" / "set end time").
+/// The commands used to bail out silently when the playhead was on the wrong side of the line's
+/// other cue (issue #13066) - the normal case when spotting forward, since a freshly inserted
+/// line sits right after the previous one, well behind the video position. SE4 always stamped
+/// the time and left a red negative duration; here the time is always stamped too, but the
+/// opposite cue moves along so the line stays valid.
+/// </summary>
+public static class SetCueTimeHelper
+{
+    /// <summary>
+    /// Sets the start time, keeping the end fixed. If the new start is at or after the end,
+    /// the end moves along so the line keeps its duration (or the minimum display duration
+    /// when the line had none).
+    /// </summary>
+    public static void SetStart(SubtitleLineViewModel line, TimeSpan start, int minimumDurationMs)
+    {
+        if (start < line.EndTime)
+        {
+            line.SetStartTimeOnly(start);
+            return;
+        }
+
+        line.SetTimes(start, start + GetDuration(line, minimumDurationMs));
+    }
+
+    /// <summary>
+    /// Sets the end time, keeping the start fixed. If the new end is at or before the start,
+    /// the start moves along so the line keeps its duration (or the minimum display duration
+    /// when the line had none), clamped at zero.
+    /// </summary>
+    public static void SetEnd(SubtitleLineViewModel line, TimeSpan end, int minimumDurationMs)
+    {
+        if (end > line.StartTime)
+        {
+            line.EndTime = end;
+            return;
+        }
+
+        var start = end - GetDuration(line, minimumDurationMs);
+        if (start < TimeSpan.Zero)
+        {
+            start = TimeSpan.Zero;
+        }
+
+        line.SetTimes(start, end);
+    }
+
+    private static TimeSpan GetDuration(SubtitleLineViewModel line, int minimumDurationMs)
+    {
+        var duration = line.EndTime - line.StartTime;
+        return duration > TimeSpan.Zero ? duration : TimeSpan.FromMilliseconds(minimumDurationMs);
+    }
+}

--- a/tests/UI/Logic/SetCueTimeHelperTests.cs
+++ b/tests/UI/Logic/SetCueTimeHelperTests.cs
@@ -1,0 +1,110 @@
+﻿using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+public class SetCueTimeHelperTests
+{
+    private const int MinimumDurationMs = 1000;
+
+    private static SubtitleLineViewModel NewLine(double startMs, double endMs) => new()
+    {
+        Text = "Hello",
+        StartTime = TimeSpan.FromMilliseconds(startMs),
+        EndTime = TimeSpan.FromMilliseconds(endMs),
+    };
+
+    [Fact]
+    public void SetStart_BeforeEnd_KeepsEndFixed()
+    {
+        var line = NewLine(1000, 3000);
+
+        SetCueTimeHelper.SetStart(line, TimeSpan.FromMilliseconds(1500), MinimumDurationMs);
+
+        Assert.Equal(1500, line.StartTime.TotalMilliseconds, 3);
+        Assert.Equal(3000, line.EndTime.TotalMilliseconds, 3);
+        Assert.Equal(1500, line.Duration.TotalMilliseconds, 3);
+    }
+
+    [Fact]
+    public void SetStart_PastEnd_StampsStartAndKeepsDuration()
+    {
+        // #13066: the playhead is past the line's end (the normal case for a freshly
+        // inserted line) - the start must still be set instead of the command doing nothing.
+        var line = NewLine(1000, 3000);
+
+        SetCueTimeHelper.SetStart(line, TimeSpan.FromMilliseconds(10000), MinimumDurationMs);
+
+        Assert.Equal(10000, line.StartTime.TotalMilliseconds, 3);
+        Assert.Equal(12000, line.EndTime.TotalMilliseconds, 3);
+        Assert.Equal(2000, line.Duration.TotalMilliseconds, 3);
+    }
+
+    [Fact]
+    public void SetStart_AtEnd_StampsStartAndKeepsDuration()
+    {
+        var line = NewLine(1000, 3000);
+
+        SetCueTimeHelper.SetStart(line, TimeSpan.FromMilliseconds(3000), MinimumDurationMs);
+
+        Assert.Equal(3000, line.StartTime.TotalMilliseconds, 3);
+        Assert.Equal(5000, line.EndTime.TotalMilliseconds, 3);
+    }
+
+    [Fact]
+    public void SetStart_PastEndOfZeroDurationLine_UsesMinimumDuration()
+    {
+        var line = NewLine(0, 0);
+
+        SetCueTimeHelper.SetStart(line, TimeSpan.FromMilliseconds(5000), MinimumDurationMs);
+
+        Assert.Equal(5000, line.StartTime.TotalMilliseconds, 3);
+        Assert.Equal(6000, line.EndTime.TotalMilliseconds, 3);
+    }
+
+    [Fact]
+    public void SetEnd_AfterStart_KeepsStartFixed()
+    {
+        var line = NewLine(1000, 3000);
+
+        SetCueTimeHelper.SetEnd(line, TimeSpan.FromMilliseconds(4000), MinimumDurationMs);
+
+        Assert.Equal(1000, line.StartTime.TotalMilliseconds, 3);
+        Assert.Equal(4000, line.EndTime.TotalMilliseconds, 3);
+        Assert.Equal(3000, line.Duration.TotalMilliseconds, 3);
+    }
+
+    [Fact]
+    public void SetEnd_BeforeStart_StampsEndAndKeepsDuration()
+    {
+        var line = NewLine(10000, 12000);
+
+        SetCueTimeHelper.SetEnd(line, TimeSpan.FromMilliseconds(5000), MinimumDurationMs);
+
+        Assert.Equal(3000, line.StartTime.TotalMilliseconds, 3);
+        Assert.Equal(5000, line.EndTime.TotalMilliseconds, 3);
+        Assert.Equal(2000, line.Duration.TotalMilliseconds, 3);
+    }
+
+    [Fact]
+    public void SetEnd_BeforeStart_ClampsStartAtZero()
+    {
+        var line = NewLine(10000, 12000);
+
+        SetCueTimeHelper.SetEnd(line, TimeSpan.FromMilliseconds(500), MinimumDurationMs);
+
+        Assert.Equal(0, line.StartTime.TotalMilliseconds, 3);
+        Assert.Equal(500, line.EndTime.TotalMilliseconds, 3);
+    }
+
+    [Fact]
+    public void SetEnd_BeforeStartOfZeroDurationLine_UsesMinimumDuration()
+    {
+        var line = NewLine(10000, 10000);
+
+        SetCueTimeHelper.SetEnd(line, TimeSpan.FromMilliseconds(5000), MinimumDurationMs);
+
+        Assert.Equal(4000, line.StartTime.TotalMilliseconds, 3);
+        Assert.Equal(5000, line.EndTime.TotalMilliseconds, 3);
+    }
+}


### PR DESCRIPTION
Fixes #13066.

### Problem

`WaveformSetStart` (F11) returned silently when the video position was at or past the selected line's **current** end time:

```csharp
if (videoPositionSeconds >= s.EndTime.TotalSeconds - gap)
{
    return;
}
```

`WaveformSetEnd` (F12) had the mirror-image guard against the start time.

`InsertService.InsertAfter` anchors a new line to the *previous* line (`start = prev.End + gap`, `end = start + NewEmptyDefaultMs`), not to the playhead. So in the ordinary spotting workflow — video playing ahead of where the subtitle list currently ends — the new line's end time is already behind the playhead and F11 was a dead key, with no status message either. Pressing F12 first moved the end ahead, after which F11 worked. That is exactly what the reporter described.

Repro: line `00:00:01,000 --> 00:00:03,000` selected, seek to `00:00:10`, press F11 → nothing happens.

SE4 never bailed: `SetStartTime`/`SetEndTime` always wrote the time code, leaving a red negative duration that the following keypress fixed.

### Fix

The four affected commands — `WaveformSetStart`, `WaveformSetStartAndGoToNext`, `WaveformSetEnd`, `WaveformSetEndAndGoToNext` — now always stamp the playhead position. New `SetCueTimeHelper` keeps the line valid instead of leaving a negative duration: when the new start lands at/after the end (or the new end at/before the start), the opposite cue moves along, preserving the line's duration, or the minimum display duration if the line had none. The start is clamped at zero.

ASSA multi-selection behaviour is unchanged — the fixup is applied per selected line, so each keeps its own duration.

### Tests

New `tests/UI/Logic/SetCueTimeHelperTests.cs` (8 cases: normal side, wrong side, exactly-on-the-other-cue, zero-duration line, zero clamp). Full UI suite: 1136 passed, 1 skipped, 0 failed.

### Note (not addressed here)

SE4 subtracts `SetStartEndHumanDelay` from the position when the player is not paused, for both set-start and set-end. SE5 has no such setting anywhere, so time codes stamped while playing are consistently late by the reaction-time offset SE4 compensated for. Worth a separate issue if you want parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)