### PR TITLE
Bring back "move up/down/to top/to bottom" for styles

### DIFF
--- a/docs/features/assa-styles.md
+++ b/docs/features/assa-styles.md
@@ -23,6 +23,7 @@ Manage Advanced SubStation Alpha (ASS/SSA) subtitle styles, including file style
 - View all styles defined in the current subtitle file.
 - Add, remove, copy, or rename styles.
 - Import styles from other subtitle files.
+- Reorder styles via the right-click menu — **Move up** (`Ctrl+Up`), **Move down** (`Ctrl+Down`), **Move to top**, and **Move to bottom**. Select several styles first to move them as a block. This is the order the styles are written to the file with, so it is also the order other tools will list them in.
 
 ### Storage Styles
 - Maintain a library of reusable styles separate from any subtitle file.

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -310,6 +310,8 @@
     "multiMode": "Multi mode",
     "moveDown": "Move down",
     "moveUp": "Move up",
+    "moveToTop": "Move to top",
+    "moveToBottom": "Move to bottom",
     "multipleReplace": "Multiple replace",
     "name": "Name",
     "new": "New",

--- a/src/ui/Features/Assa/AssaStylesViewModel.cs
+++ b/src/ui/Features/Assa/AssaStylesViewModel.cs
@@ -49,6 +49,7 @@ public partial class AssaStylesViewModel : ObservableObject, IClosingCleanup
     [ObservableProperty] private bool _isSetStyleAsDefaultVisible;
     [ObservableProperty] private bool _isCopyToFileStylesVisible;
     [ObservableProperty] private bool _isCategoryActionVisible;
+    [ObservableProperty] private bool _isMoveVisible;
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
@@ -321,6 +322,27 @@ public partial class AssaStylesViewModel : ObservableObject, IClosingCleanup
     private void FileRemoveAll()
     {
         FileStyles.Clear();
+    }
+
+    [RelayCommand]
+    private void FileMoveUp() => MoveFileStyles(ListMoveDirection.Up);
+
+    [RelayCommand]
+    private void FileMoveDown() => MoveFileStyles(ListMoveDirection.Down);
+
+    [RelayCommand]
+    private void FileMoveToTop() => MoveFileStyles(ListMoveDirection.Top);
+
+    [RelayCommand]
+    private void FileMoveToBottom() => MoveFileStyles(ListMoveDirection.Bottom);
+
+    /// <summary>
+    /// Reorders the selected file styles. The list order is not presentation-only - it is
+    /// the order the styles are written to the file header on OK (#13056).
+    /// </summary>
+    private void MoveFileStyles(ListMoveDirection direction)
+    {
+        TableViewExtras.MoveSelectedRows(FileStyleGrid, FileStyles, direction);
     }
 
     [RelayCommand]
@@ -1285,6 +1307,30 @@ public partial class AssaStylesViewModel : ObservableObject, IClosingCleanup
         }
     }
 
+    /// <summary>
+    /// Ctrl+Up/Ctrl+Down reorder the selected styles, as in SE 4. Tunneled, because the
+    /// ListBox underneath TableView handles Ctrl+Arrow itself (move focus without changing
+    /// the selection) and a bubbling handler would never see the key.
+    /// </summary>
+    internal void FileStylesMoveKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.KeyModifiers != KeyModifiers.Control || e.Source is TextBox)
+        {
+            return;
+        }
+
+        if (e.Key == Key.Up)
+        {
+            MoveFileStyles(ListMoveDirection.Up);
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Down)
+        {
+            MoveFileStyles(ListMoveDirection.Down);
+            e.Handled = true;
+        }
+    }
+
     private void DeleteFileStyle(StyleDisplay? selectedStyle)
     {
         if (selectedStyle == null)
@@ -1402,6 +1448,7 @@ public partial class AssaStylesViewModel : ObservableObject, IClosingCleanup
     {
         IsDeleteAllVisible = FileStyles.Count > 0;
         IsDeleteVisible = SelectedFileStyle != null;
+        IsMoveVisible = FileStyles.Count > 1 && FileStyleGrid.SelectedItems?.Count > 0;
     }
 
     internal void StoreContextMenuOpening(object? sender, EventArgs e)

--- a/src/ui/Features/Assa/AssaStylesWindow.cs
+++ b/src/ui/Features/Assa/AssaStylesWindow.cs
@@ -2,9 +2,11 @@
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using System.Collections;
+using System.Windows.Input;
 using Nikse.SubtitleEdit.Features.Shared.ColorPicker;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -155,6 +157,7 @@ public class AssaStylesWindow : Window
         dataGrid.SelectionChanged += vm.FileStylesChanged;
         dataGrid.GotFocus += vm.FileStylesGotFocus;
         dataGrid.KeyDown += vm.FileStylesKeyDown;
+        dataGrid.AddHandler(InputElement.KeyDownEvent, vm.FileStylesMoveKeyDown, RoutingStrategies.Tunnel);
         TableViewExtras.AttachHomeEndNavigation(dataGrid);
         vm.FileStyleGrid = dataGrid;
 
@@ -207,6 +210,8 @@ public class AssaStylesWindow : Window
         };
         menuItemReplaceWith.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsFileStyleSelected)) { Source = vm });
         flyout.Items.Add(menuItemReplaceWith);
+
+        AddMoveMenuItems(flyout, vm);
 
         var buttonNew = UiUtil.MakeButton(vm.FileNewCommand, IconNames.Plus, Se.Language.General.New);
         var buttonRemove = UiUtil.MakeButton(vm.FileRemoveCommand, IconNames.Trash, Se.Language.General.Delete);
@@ -714,5 +719,38 @@ public class AssaStylesWindow : Window
         };
 
         return button;
+    }
+
+    /// <summary>
+    /// The "move up/down/to top/to bottom" block of the file styles context menu (#13056).
+    /// The styles are written to the file header in list order, so this is real reordering,
+    /// not a view sort.
+    /// </summary>
+    private static void AddMoveMenuItems(MenuFlyout flyout, AssaStylesViewModel vm)
+    {
+        var separator = new Separator();
+        separator.Bind(Separator.IsVisibleProperty, new Binding(nameof(vm.IsMoveVisible)) { Source = vm });
+        flyout.Items.Add(separator);
+
+        var items = new (string Header, ICommand Command, KeyGesture? Gesture)[]
+        {
+            (Se.Language.General.MoveUp, vm.FileMoveUpCommand, new KeyGesture(Key.Up, KeyModifiers.Control)),
+            (Se.Language.General.MoveDown, vm.FileMoveDownCommand, new KeyGesture(Key.Down, KeyModifiers.Control)),
+            (Se.Language.General.MoveToTop, vm.FileMoveToTopCommand, null),
+            (Se.Language.General.MoveToBottom, vm.FileMoveToBottomCommand, null),
+        };
+
+        foreach (var (header, command, gesture) in items)
+        {
+            var menuItem = new MenuItem
+            {
+                Header = header,
+                DataContext = vm,
+                Command = command,
+                InputGesture = gesture,
+            };
+            menuItem.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsMoveVisible)) { Source = vm });
+            flyout.Items.Add(menuItem);
+        }
     }
 }

--- a/src/ui/Features/Ssa/SsaStylesViewModel.cs
+++ b/src/ui/Features/Ssa/SsaStylesViewModel.cs
@@ -45,6 +45,7 @@ public partial class SsaStylesViewModel : ObservableObject, IClosingCleanup
     [ObservableProperty] private bool _isTakeUsagesFromVisible;
     [ObservableProperty] private bool _isSetStyleAsDefaultVisible;
     [ObservableProperty] private bool _isCopyToFileStylesVisible;
+    [ObservableProperty] private bool _isMoveVisible;
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
@@ -233,6 +234,27 @@ public partial class SsaStylesViewModel : ObservableObject, IClosingCleanup
     private void FileRemoveAll()
     {
         FileStyles.Clear();
+    }
+
+    [RelayCommand]
+    private void FileMoveUp() => MoveFileStyles(ListMoveDirection.Up);
+
+    [RelayCommand]
+    private void FileMoveDown() => MoveFileStyles(ListMoveDirection.Down);
+
+    [RelayCommand]
+    private void FileMoveToTop() => MoveFileStyles(ListMoveDirection.Top);
+
+    [RelayCommand]
+    private void FileMoveToBottom() => MoveFileStyles(ListMoveDirection.Bottom);
+
+    /// <summary>
+    /// Reorders the selected file styles. The list order is not presentation-only - it is
+    /// the order the styles are written to the file header on OK (#13056).
+    /// </summary>
+    private void MoveFileStyles(ListMoveDirection direction)
+    {
+        TableViewExtras.MoveSelectedRows(FileStyleGrid, FileStyles, direction);
     }
 
     [RelayCommand]
@@ -926,6 +948,30 @@ public partial class SsaStylesViewModel : ObservableObject, IClosingCleanup
         }
     }
 
+    /// <summary>
+    /// Ctrl+Up/Ctrl+Down reorder the selected styles, as in SE 4. Tunneled, because the
+    /// ListBox underneath TableView handles Ctrl+Arrow itself (move focus without changing
+    /// the selection) and a bubbling handler would never see the key.
+    /// </summary>
+    internal void FileStylesMoveKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.KeyModifiers != KeyModifiers.Control || e.Source is TextBox)
+        {
+            return;
+        }
+
+        if (e.Key == Key.Up)
+        {
+            MoveFileStyles(ListMoveDirection.Up);
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Down)
+        {
+            MoveFileStyles(ListMoveDirection.Down);
+            e.Handled = true;
+        }
+    }
+
     private void DeleteFileStyle(StyleDisplay? selectedStyle)
     {
         if (selectedStyle == null)
@@ -1043,6 +1089,7 @@ public partial class SsaStylesViewModel : ObservableObject, IClosingCleanup
     {
         IsDeleteAllVisible = FileStyles.Count > 0;
         IsDeleteVisible = SelectedFileStyle != null;
+        IsMoveVisible = FileStyles.Count > 1 && FileStyleGrid.SelectedItems?.Count > 0;
     }
 
     internal void StoreContextMenuOpening(object? sender, EventArgs e)

--- a/src/ui/Features/Ssa/SsaStylesWindow.cs
+++ b/src/ui/Features/Ssa/SsaStylesWindow.cs
@@ -2,9 +2,11 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using System.Collections;
+using System.Windows.Input;
 using Nikse.SubtitleEdit.Features.Assa;
 using Nikse.SubtitleEdit.Features.Shared.ColorPicker;
 using Nikse.SubtitleEdit.Logic;
@@ -156,6 +158,7 @@ public class SsaStylesWindow : Window
         dataGrid.SelectionChanged += vm.FileStylesChanged;
         dataGrid.GotFocus += vm.FileStylesGotFocus;
         dataGrid.KeyDown += vm.FileStylesKeyDown;
+        dataGrid.AddHandler(InputElement.KeyDownEvent, vm.FileStylesMoveKeyDown, RoutingStrategies.Tunnel);
         TableViewExtras.AttachHomeEndNavigation(dataGrid);
         vm.FileStyleGrid = dataGrid;
 
@@ -199,6 +202,8 @@ public class SsaStylesWindow : Window
         };
         menuItemTakeUsagesFrom.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsTakeUsagesFromVisible)) { Source = vm });
         flyout.Items.Add(menuItemTakeUsagesFrom);
+
+        AddMoveMenuItems(flyout, vm);
 
         var buttonNew = UiUtil.MakeButton(vm.FileNewCommand, IconNames.Plus, Se.Language.General.New);
         var buttonRemove = UiUtil.MakeButton(vm.FileRemoveCommand, IconNames.Trash, Se.Language.General.Delete);
@@ -678,5 +683,38 @@ public class SsaStylesWindow : Window
         };
 
         return button;
+    }
+
+    /// <summary>
+    /// The "move up/down/to top/to bottom" block of the file styles context menu (#13056).
+    /// The styles are written to the file header in list order, so this is real reordering,
+    /// not a view sort.
+    /// </summary>
+    private static void AddMoveMenuItems(MenuFlyout flyout, SsaStylesViewModel vm)
+    {
+        var separator = new Separator();
+        separator.Bind(Separator.IsVisibleProperty, new Binding(nameof(vm.IsMoveVisible)) { Source = vm });
+        flyout.Items.Add(separator);
+
+        var items = new (string Header, ICommand Command, KeyGesture? Gesture)[]
+        {
+            (Se.Language.General.MoveUp, vm.FileMoveUpCommand, new KeyGesture(Key.Up, KeyModifiers.Control)),
+            (Se.Language.General.MoveDown, vm.FileMoveDownCommand, new KeyGesture(Key.Down, KeyModifiers.Control)),
+            (Se.Language.General.MoveToTop, vm.FileMoveToTopCommand, null),
+            (Se.Language.General.MoveToBottom, vm.FileMoveToBottomCommand, null),
+        };
+
+        foreach (var (header, command, gesture) in items)
+        {
+            var menuItem = new MenuItem
+            {
+                Header = header,
+                DataContext = vm,
+                Command = command,
+                InputGesture = gesture,
+            };
+            menuItem.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsMoveVisible)) { Source = vm });
+            flyout.Items.Add(menuItem);
+        }
     }
 }

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -310,6 +310,8 @@ public class LanguageGeneral
     public string MultiMode { get; set; }
     public string MoveDown { get; set; }
     public string MoveUp { get; set; }
+    public string MoveToTop { get; set; }
+    public string MoveToBottom { get; set; }
     public string MultipleReplace { get; set; }
     public string Name { get; set; }
     public string New { get; set; }
@@ -1025,6 +1027,8 @@ public class LanguageGeneral
         MultiMode = "Multi mode";
         MoveDown = "Move down";
         MoveUp = "Move up";
+        MoveToTop = "Move to top";
+        MoveToBottom = "Move to bottom";
         MultipleReplace = "Multiple replace";
         Name = "Name";
         New = "New";

--- a/src/ui/Logic/ListReorder.cs
+++ b/src/ui/Logic/ListReorder.cs
@@ -1,0 +1,118 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+public enum ListMoveDirection
+{
+    Up,
+    Down,
+    Top,
+    Bottom,
+}
+
+/// <summary>
+/// Multi-selection aware "move up/down/to top/to bottom" over an
+/// <see cref="ObservableCollection{T}"/>, for lists where the order is data rather than
+/// presentation (ASSA/SSA styles are written to the file header in list order).
+///
+/// A selection keeps its internal order and its gaps: moving {0, 2, 3} up gives
+/// {0, 1, 2} - row 0 is already at the top and pins the ones below it - so repeated
+/// moves collapse a scattered selection against the edge instead of scrambling it.
+/// </summary>
+public static class ListReorder
+{
+    /// <summary>
+    /// Moves the items at <paramref name="selectedIndices"/> one step in
+    /// <paramref name="direction"/>, or all the way to the top/bottom. Indices outside
+    /// the collection are ignored; the order they are given in does not matter.
+    /// </summary>
+    public static void Move<T>(ObservableCollection<T> items, IEnumerable<int> selectedIndices, ListMoveDirection direction)
+    {
+        var indices = selectedIndices
+            .Where(i => i >= 0 && i < items.Count)
+            .Distinct()
+            .OrderBy(i => i)
+            .ToList();
+
+        if (indices.Count == 0 || items.Count < 2)
+        {
+            return;
+        }
+
+        switch (direction)
+        {
+            case ListMoveDirection.Up:
+                MoveUp(items, indices);
+                break;
+            case ListMoveDirection.Down:
+                MoveDown(items, indices);
+                break;
+            case ListMoveDirection.Top:
+                MoveToTop(items, indices);
+                break;
+            case ListMoveDirection.Bottom:
+                MoveToBottom(items, indices);
+                break;
+        }
+    }
+
+    private static void MoveUp<T>(ObservableCollection<T> items, List<int> indices)
+    {
+        // Rows already stacked at the very top cannot move and pin the boundary the rest
+        // move against. Walking top-down means a swap only ever touches the row above the
+        // one being moved, so the indices still to come stay valid.
+        var boundary = 0;
+        foreach (var index in indices)
+        {
+            if (index == boundary)
+            {
+                boundary++;
+                continue;
+            }
+
+            items.Move(index, index - 1);
+        }
+    }
+
+    private static void MoveDown<T>(ObservableCollection<T> items, List<int> indices)
+    {
+        var boundary = items.Count - 1;
+        for (var i = indices.Count - 1; i >= 0; i--)
+        {
+            var index = indices[i];
+            if (index == boundary)
+            {
+                boundary--;
+                continue;
+            }
+
+            items.Move(index, index + 1);
+        }
+    }
+
+    private static void MoveToTop<T>(ObservableCollection<T> items, List<int> indices)
+    {
+        // Snapshot the items before moving anything - the indices go stale on the first Move.
+        // Filling the target slots front-to-back keeps every not-yet-moved item at or after
+        // its target, so each Move only shifts rows that are still to the right of it.
+        var selected = indices.Select(i => items[i]).ToList();
+        for (var i = 0; i < selected.Count; i++)
+        {
+            items.Move(items.IndexOf(selected[i]), i);
+        }
+    }
+
+    private static void MoveToBottom<T>(ObservableCollection<T> items, List<int> indices)
+    {
+        // Mirror of MoveToTop: fill the target slots back-to-front. Going front-to-back here
+        // would drag each already-placed row one slot back towards the middle as the next one
+        // is removed from in front of it, reversing the selection's order.
+        var selected = indices.Select(i => items[i]).ToList();
+        for (var i = selected.Count - 1; i >= 0; i--)
+        {
+            items.Move(items.IndexOf(selected[i]), items.Count - (selected.Count - i));
+        }
+    }
+}

--- a/src/ui/Logic/TableViewExtras.cs
+++ b/src/ui/Logic/TableViewExtras.cs
@@ -10,6 +10,7 @@ using Avalonia.Threading;
 using Avalonia.VisualTree;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 
 namespace Nikse.SubtitleEdit.Logic;
@@ -639,6 +640,65 @@ public static class TableViewExtras
 
             scrollViewer.Offset = new Vector(offset.X, newY);
         }, DispatcherPriority.Loaded);
+    }
+
+    /// <summary>
+    /// Moves the selected rows within <paramref name="items"/> (see <see cref="ListReorder"/>)
+    /// and leaves the same rows selected at their new positions, with the moved block
+    /// scrolled into view.
+    /// </summary>
+    public static void MoveSelectedRows<TItem>(TableView tableView, ObservableCollection<TItem> items, ListMoveDirection direction)
+        where TItem : class
+    {
+        var selected = tableView.SelectedItems?.OfType<TItem>().ToList();
+        if (selected == null || selected.Count == 0)
+        {
+            return;
+        }
+
+        // The row the control treats as the selection anchor - restored first below so it
+        // stays SelectedItem (view models bind their "current row" to that, not to SelectedItems).
+        var anchor = tableView.SelectedItem as TItem;
+
+        ListReorder.Move(items, selected.Select(items.IndexOf), direction);
+
+        var remaining = new HashSet<TItem>(selected);
+        var newIndices = new List<int>(selected.Count);
+        for (var i = 0; i < items.Count && remaining.Count > 0; i++)
+        {
+            if (remaining.Remove(items[i]))
+            {
+                newIndices.Add(i);
+            }
+        }
+
+        if (newIndices.Count == 0)
+        {
+            return;
+        }
+
+        // ObservableCollection.Move raises one CollectionChanged per row, and the selection
+        // model's index bookkeeping does not survive a run of them intact - restore the
+        // whole selection explicitly. The batch defers SelectionChanged to the end, so
+        // SelectionMode.AlwaysSelected never sees the momentarily empty selection and
+        // cannot force row 0 back in.
+        tableView.Selection.BeginBatchUpdate();
+        tableView.Selection.Clear();
+        var anchorIndex = anchor != null ? items.IndexOf(anchor) : -1;
+        if (anchorIndex >= 0)
+        {
+            tableView.Selection.Select(anchorIndex); // first Select after Clear sets SelectedIndex
+        }
+
+        foreach (var index in newIndices)
+        {
+            tableView.Selection.Select(index);
+        }
+
+        tableView.Selection.EndBatchUpdate();
+
+        var edgeIndex = direction is ListMoveDirection.Up or ListMoveDirection.Top ? newIndices[0] : newIndices[^1];
+        tableView.ScrollIntoView(items[edgeIndex]);
     }
 }
 

--- a/tests/UI/Logic/ListReorderTests.cs
+++ b/tests/UI/Logic/ListReorderTests.cs
@@ -1,0 +1,143 @@
+using Nikse.SubtitleEdit.Logic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace UITests.Logic;
+
+public class ListReorderTests
+{
+    private static ObservableCollection<string> MakeList() =>
+        new(new[] { "a", "b", "c", "d", "e" });
+
+    private static int[] IndicesOf(ObservableCollection<string> list, params string[] items) =>
+        items.Select(list.IndexOf).ToArray();
+
+    [Fact]
+    public void Up_MovesSingleRowOneStep()
+    {
+        var list = MakeList();
+        ListReorder.Move(list, IndicesOf(list, "c"), ListMoveDirection.Up);
+        Assert.Equal(new[] { "a", "c", "b", "d", "e" }, list);
+    }
+
+    [Fact]
+    public void Up_KeepsTopRowInPlace()
+    {
+        var list = MakeList();
+        ListReorder.Move(list, IndicesOf(list, "a"), ListMoveDirection.Up);
+        Assert.Equal(new[] { "a", "b", "c", "d", "e" }, list);
+    }
+
+    [Fact]
+    public void Up_MovesContiguousBlockAsOne()
+    {
+        var list = MakeList();
+        ListReorder.Move(list, IndicesOf(list, "c", "d"), ListMoveDirection.Up);
+        Assert.Equal(new[] { "a", "c", "d", "b", "e" }, list);
+    }
+
+    [Fact]
+    public void Up_PinnedTopRowsHoldTheRestBack()
+    {
+        // {a, c, d} selected: 'a' is already at the top, so 'c' and 'd' collapse against it.
+        var list = MakeList();
+        ListReorder.Move(list, IndicesOf(list, "a", "c", "d"), ListMoveDirection.Up);
+        Assert.Equal(new[] { "a", "c", "d", "b", "e" }, list);
+    }
+
+    [Fact]
+    public void Up_IsIdempotentOnceTheSelectionIsStackedAtTheTop()
+    {
+        var list = MakeList();
+        ListReorder.Move(list, IndicesOf(list, "a", "b"), ListMoveDirection.Up);
+        Assert.Equal(new[] { "a", "b", "c", "d", "e" }, list);
+    }
+
+    [Fact]
+    public void Down_MovesSingleRowOneStep()
+    {
+        var list = MakeList();
+        ListReorder.Move(list, IndicesOf(list, "c"), ListMoveDirection.Down);
+        Assert.Equal(new[] { "a", "b", "d", "c", "e" }, list);
+    }
+
+    [Fact]
+    public void Down_KeepsBottomRowInPlace()
+    {
+        var list = MakeList();
+        ListReorder.Move(list, IndicesOf(list, "e"), ListMoveDirection.Down);
+        Assert.Equal(new[] { "a", "b", "c", "d", "e" }, list);
+    }
+
+    [Fact]
+    public void Down_PinnedBottomRowsHoldTheRestBack()
+    {
+        var list = MakeList();
+        ListReorder.Move(list, IndicesOf(list, "b", "c", "e"), ListMoveDirection.Down);
+        Assert.Equal(new[] { "a", "d", "b", "c", "e" }, list);
+    }
+
+    [Fact]
+    public void Top_MovesScatteredSelectionKeepingItsOrder()
+    {
+        var list = MakeList();
+        ListReorder.Move(list, IndicesOf(list, "b", "d"), ListMoveDirection.Top);
+        Assert.Equal(new[] { "b", "d", "a", "c", "e" }, list);
+    }
+
+    [Fact]
+    public void Bottom_MovesScatteredSelectionKeepingItsOrder()
+    {
+        var list = MakeList();
+        ListReorder.Move(list, IndicesOf(list, "b", "d"), ListMoveDirection.Bottom);
+        Assert.Equal(new[] { "a", "c", "e", "b", "d" }, list);
+    }
+
+    [Fact]
+    public void Top_SelectionOrderFollowsListOrderNotSelectionOrder()
+    {
+        var list = MakeList();
+        ListReorder.Move(list, new[] { 3, 1 }, ListMoveDirection.Top);
+        Assert.Equal(new[] { "b", "d", "a", "c", "e" }, list);
+    }
+
+    [Fact]
+    public void Move_IgnoresOutOfRangeAndDuplicateIndices()
+    {
+        var list = MakeList();
+        ListReorder.Move(list, new[] { 2, 2, -1, 99 }, ListMoveDirection.Up);
+        Assert.Equal(new[] { "a", "c", "b", "d", "e" }, list);
+    }
+
+    [Fact]
+    public void Move_NoOpOnEmptySelection()
+    {
+        var list = MakeList();
+        ListReorder.Move(list, new int[0], ListMoveDirection.Down);
+        Assert.Equal(new[] { "a", "b", "c", "d", "e" }, list);
+    }
+
+    [Fact]
+    public void Move_NoOpOnSingleItemList()
+    {
+        var list = new ObservableCollection<string> { "a" };
+        ListReorder.Move(list, new[] { 0 }, ListMoveDirection.Bottom);
+        Assert.Equal(new[] { "a" }, list);
+    }
+
+    [Fact]
+    public void Move_WholeSelectionIsAlwaysANoOp()
+    {
+        var list = MakeList();
+        var all = Enumerable.Range(0, list.Count).ToArray();
+        foreach (var direction in new[]
+                 {
+                     ListMoveDirection.Up, ListMoveDirection.Down,
+                     ListMoveDirection.Top, ListMoveDirection.Bottom,
+                 })
+        {
+            ListReorder.Move(list, all, direction);
+            Assert.Equal(new[] { "a", "b", "c", "d", "e" }, list);
+        }
+    }
+}

--- a/tests/UI/Logic/MoveSelectedRowsTests.cs
+++ b/tests/UI/Logic/MoveSelectedRowsTests.cs
@@ -1,0 +1,139 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Logic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// The context-menu reordering in the ASSA/SSA styles dialogs (#13056) moves rows one
+/// <see cref="ObservableCollection{T}.Move"/> at a time and then puts the selection back
+/// on the same rows. These cover the part <see cref="ListReorderTests"/> cannot: that the
+/// TableView really ends up selecting the moved rows, and that SelectedItem - which the
+/// view models bind their "current style" to - still points at the anchor row afterwards.
+/// </summary>
+public class MoveSelectedRowsTests
+{
+    private sealed class Row
+    {
+        public Row(string name) => Name = name;
+
+        public string Name { get; }
+
+        public override string ToString() => Name;
+    }
+
+    private static (TableView Grid, ObservableCollection<Row> Items) MakeGrid()
+    {
+        var items = new ObservableCollection<Row>(
+            new[] { "a", "b", "c", "d", "e" }.Select(n => new Row(n)));
+
+        var grid = TableViewExtras.MakeTableView();
+        grid.Columns.Add(new SeTableViewColumn { Header = "Name" });
+        grid.ItemsSource = items;
+
+        var window = new Window { Content = grid, Width = 400, Height = 300 };
+        window.Show();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        return (grid, items);
+    }
+
+    /// <summary>
+    /// Batched, because <see cref="TableViewExtras.MakeTableView"/> keeps
+    /// SelectionMode.AlwaysSelected: a bare Clear() lets the control put row 0 back before
+    /// the intended rows are selected, which silently widens the selection.
+    /// </summary>
+    private static void Select(TableView grid, params int[] indices)
+    {
+        grid.Selection.BeginBatchUpdate();
+        grid.Selection.Clear();
+        foreach (var index in indices)
+        {
+            grid.Selection.Select(index);
+        }
+
+        grid.Selection.EndBatchUpdate();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(indices.Length, grid.SelectedItems!.Count);
+    }
+
+    private static string Order(ObservableCollection<Row> items) =>
+        string.Concat(items.Select(i => i.Name));
+
+    private static string SelectedNames(TableView grid) =>
+        string.Concat(grid.SelectedItems!.OfType<Row>().OrderBy(r => r.Name).Select(r => r.Name));
+
+    [AvaloniaFact]
+    public void Up_MovesTheRowAndKeepsItSelected()
+    {
+        var (grid, items) = MakeGrid();
+        Select(grid, 2); // "c"
+
+        TableViewExtras.MoveSelectedRows(grid, items, ListMoveDirection.Up);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("acbde", Order(items));
+        Assert.Equal("c", SelectedNames(grid));
+        Assert.Equal("c", ((Row)grid.SelectedItem!).Name);
+        Assert.Equal(1, grid.SelectedIndex);
+    }
+
+    [AvaloniaFact]
+    public void Down_KeepsAMultiRowSelectionIntact()
+    {
+        var (grid, items) = MakeGrid();
+        Select(grid, 1, 2); // "b", "c"
+
+        TableViewExtras.MoveSelectedRows(grid, items, ListMoveDirection.Down);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("adbce", Order(items));
+        Assert.Equal("bc", SelectedNames(grid));
+        Assert.Equal(2, grid.SelectedItems!.Count);
+    }
+
+    [AvaloniaFact]
+    public void Bottom_KeepsScatteredSelectionAndItsAnchor()
+    {
+        var (grid, items) = MakeGrid();
+        Select(grid, 1, 3); // "b", "d" - "b" is the anchor (selected first)
+
+        TableViewExtras.MoveSelectedRows(grid, items, ListMoveDirection.Bottom);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("acebd", Order(items));
+        Assert.Equal("bd", SelectedNames(grid));
+        Assert.Equal("b", ((Row)grid.SelectedItem!).Name);
+    }
+
+    [AvaloniaFact]
+    public void Top_MovesEverySelectedRowToTheFront()
+    {
+        var (grid, items) = MakeGrid();
+        Select(grid, 1, 3);
+
+        TableViewExtras.MoveSelectedRows(grid, items, ListMoveDirection.Top);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("bdace", Order(items));
+        Assert.Equal("bd", SelectedNames(grid));
+    }
+
+    [AvaloniaFact]
+    public void Up_AtTheTopChangesNothingAndKeepsTheSelection()
+    {
+        var (grid, items) = MakeGrid();
+        Select(grid, 0);
+
+        TableViewExtras.MoveSelectedRows(grid, items, ListMoveDirection.Up);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("abcde", Order(items));
+        Assert.Equal("a", SelectedNames(grid));
+    }
+}


### PR DESCRIPTION
Fixes #13056

SE 4's styles dialog let you reorder the styles in the file from the right-click menu — **Move up**, **Move down**, **Move to top**, **Move to bottom**. SE 5 shipped without them, so there was no way to change the order at all. The order is not cosmetic: it is the order the styles are written to the file header on OK, which is also the order other tools list them in.

## What this adds

The four commands on the **file styles** list in both the ASSA and the SSA dialog, in the right-click menu below a separator, plus `Ctrl+Up` / `Ctrl+Down`.

Unlike SE 4 — which bailed out unless exactly one row was selected, the tediousness the reporter called out — a multi-row selection moves as a block and keeps its internal order. Rows already stacked against the edge pin the rest: `{a, c, d}` moved up gives `a, c, d, b, e`.

The reorder itself lives in `ListReorder` so it can be unit tested away from the UI. `TableViewExtras.MoveSelectedRows` adds the TableView side: a run of `ObservableCollection.Move` does not leave the grid's selection intact, so the selection is restored explicitly, with the anchor row re-selected first so it stays `SelectedItem` (the view models bind their "current style" to that).

## Notes for review

- The clear-and-reselect runs inside a `BeginBatchUpdate`. `SelectionMode.AlwaysSelected` puts row 0 back on a bare `Selection.Clear()`; batching defers `SelectionChanged` so the control never sees the empty selection. An early draft of the *test* helper hit exactly that and silently widened every selection by one row.
- `Ctrl+Up`/`Ctrl+Down` is a **tunnel** handler — the ListBox under TableView handles `Ctrl+Arrow` itself (move focus without changing selection), so a bubbling handler never sees the key. Worth a click-through. macOS binds `Ctrl+Up/Down` to Mission Control, so it may not arrive there; the menu items always work.
- **`Ctrl+Home`/`Ctrl+End` deliberately left out.** SE 4 used them for top/bottom, but `AttachHomeEndNavigation` consumes Home/End as a tunnel handler regardless of modifiers and is shared by 11 grids — making it modifier-aware would change behavior in all of them for one feature. Happy to do that as a follow-up if wanted.
- **Storage styles list untouched** — SE 4 had no move there either, and SE 5's storage list is filtered by category, which makes "move to top" ambiguous.
- `change-log.txt` not touched.

## Tests

20 new tests: 15 covering the pure reorder cases (edge pinning, scattered selections, order preservation, out-of-range/duplicate indices), 5 headless Avalonia ones asserting the grid really ends up with the moved rows selected and the anchor intact. Full UI suite green at 1162.

One real bug the tests caught: move-to-bottom filling target slots front-to-back drags each already-placed row back toward the middle as the next is removed in front of it, reversing the selection's order. It fills back-to-front now.

## Still worth doing separately

The same SE 4 move menus are also missing from **Attachments**, **Export custom text format**, and **Join subtitles** — order matters most in the last one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)