### PR TITLE
Search the original text column in find and replace

### DIFF
--- a/docs/features/edit.md
+++ b/docs/features/edit.md
@@ -34,6 +34,8 @@ Options:
 
 > **Matching a line break with a regular expression:** use `\n` between the words on the two lines (for example `ear\ntwice`). `\r\n` and `\r` are accepted too and are treated the same as `\n`, so a rule works regardless of how it was written or which platform created it.
 
+> **Translator mode:** with an original subtitle loaded, both the text and the original text are searched. Within a line the text is searched first, then the original text, and the match is selected in the text box of the column it was found in.
+
 <!-- Screenshot: Find window -->
 ![Find](../screenshots/find.png)
 
@@ -43,6 +45,8 @@ Find and replace text in the subtitle.
 
 - **Menu:** Edit → Replace
 - **Shortcut:** `Ctrl+H`
+
+With an original subtitle loaded, replace works on both the text and the original text (same as Find).
 
 <!-- Screenshot: Replace window -->
 ![Replace](../screenshots/replace.png)

--- a/src/ui/Features/Edit/Find/FindViewModel.cs
+++ b/src/ui/Features/Edit/Find/FindViewModel.cs
@@ -32,6 +32,7 @@ public partial class FindViewModel : ObservableObject
 
     private IFindService? _findService;
     private List<string> _subs = new List<string>();
+    private List<string>? _originalSubs;
     private IFindResult? _findResult;
 
     public FindViewModel()
@@ -104,7 +105,7 @@ public partial class FindViewModel : ObservableObject
             return;
         }
 
-        var count = _findService.Count(SearchText, _subs, WholeWord, FindMode);
+        var count = _findService.Count(SearchText, _subs, WholeWord, FindMode, _originalSubs);
 
         if (count <= 0)
         {
@@ -153,10 +154,11 @@ public partial class FindViewModel : ObservableObject
         }
     }
 
-    internal void InitializeFindData(IFindService findService, List<string> subs, string selectedText, IFindResult findResult)
+    internal void InitializeFindData(IFindService findService, List<string> subs, string selectedText, IFindResult findResult, List<string>? originalSubs = null)
     {
         _findService = findService;
         _subs = subs;
+        _originalSubs = originalSubs;
         if (string.IsNullOrEmpty(SearchText))
         {
             SearchText = RegexUtils.EscapeNewLines(selectedText.Trim());

--- a/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
@@ -37,6 +37,7 @@ public partial class ReplaceViewModel : ObservableObject
 
     private IFindService? _findService;
     private List<string> _subs = new List<string>();
+    private List<string>? _originalSubs;
     private IFindResult? _findResult;
 
     public ReplaceViewModel()
@@ -111,7 +112,7 @@ public partial class ReplaceViewModel : ObservableObject
             return;
         }
 
-        var count = _findService.Count(SearchText, _subs, WholeWord, FindMode);
+        var count = _findService.Count(SearchText, _subs, WholeWord, FindMode, _originalSubs);
 
         if (count <= 0)
         {
@@ -157,15 +158,17 @@ public partial class ReplaceViewModel : ObservableObject
         }
     }
 
-    internal void RefreshSubtitles(List<string> subs)
+    internal void RefreshSubtitles(List<string> subs, List<string>? originalSubs = null)
     {
         _subs = subs;
+        _originalSubs = originalSubs;
     }
 
-    internal void InitializeFindData(IFindService findService, List<string> subs, string selectedText, MainViewModel mainViewModel)
+    internal void InitializeFindData(IFindService findService, List<string> subs, string selectedText, MainViewModel mainViewModel, List<string>? originalSubs = null)
     {
         _findService = findService;
         _subs = subs;
+        _originalSubs = originalSubs;
         _findResult = mainViewModel;
         if (!string.IsNullOrEmpty(selectedText))
         {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -11238,15 +11238,17 @@ public partial class MainViewModel :
 
         _findPreviousFocus = Window?.FocusManager?.GetFocusedElement() as Control;
         var subs = Subtitles.Select(p => p.Text).ToList();
+        var origs = GetOriginalTextsForFind();
         var result = _windowService.ShowWindow<FindWindow, FindViewModel>(Window!, (window, vm) =>
         {
             WindowService.KeepTopmostWhileOwnerActive(window, Window!);
             _findViewModel = vm;
 
             var selectedText = string.Empty;
-            if (EditTextBox != null && !string.IsNullOrEmpty(EditTextBox.SelectedText))
+            var textBox = GetFindTextBox(EditTextBoxOriginal.IsFocused);
+            if (textBox != null && !string.IsNullOrEmpty(textBox.SelectedText))
             {
-                selectedText = EditTextBox.SelectedText;
+                selectedText = textBox.SelectedText;
             }
 
             if ((string.IsNullOrEmpty(selectedText) || string.Equals(selectedText, _findService.CurrentTextFound, _findService.CurrentFindMode == FindMode.CaseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
@@ -11255,7 +11257,7 @@ public partial class MainViewModel :
                 selectedText = _findService.SearchText;
             }
 
-            vm.InitializeFindData(_findService, subs, selectedText, this);
+            vm.InitializeFindData(_findService, subs, selectedText, this, origs);
             window.AddHandler(InputElement.KeyDownEvent, _shortcutManager.OnKeyPressed, RoutingStrategies.Tunnel);
             window.AddHandler(InputElement.KeyUpEvent, _shortcutManager.OnKeyReleased, RoutingStrategies.Bubble);
             window.KeyDown += async (_, e) =>
@@ -11293,7 +11295,7 @@ public partial class MainViewModel :
 
                 if (vm.ResultFound)
                 {
-                    FocusEditTextBox();
+                    FocusEditTextBox(_findService.CurrentMatchInOriginal);
                 }
                 else
                 {
@@ -11313,15 +11315,16 @@ public partial class MainViewModel :
         }
 
         var subs = Subtitles.Select(p => p.Text).ToList();
+        var origs = GetOriginalTextsForFind();
 
         if (_findViewModel != null)
         {
-            _findViewModel.InitializeFindData(_findService, subs, _findService.SearchText, this);
+            _findViewModel.InitializeFindData(_findService, subs, _findService.SearchText, this, origs);
         }
 
         if (_replaceViewModel != null)
         {
-            _replaceViewModel.RefreshSubtitles(subs);
+            _replaceViewModel.RefreshSubtitles(subs, origs);
         }
     }
 
@@ -11339,16 +11342,19 @@ public partial class MainViewModel :
         {
             var currentLineIndex = Subtitles.IndexOf(selectedSubtitle);
             var subs = Subtitles.Select(p => p.Text).ToList();
-            _findService.Initialize(subs, SelectedSubtitleIndex ?? 0, result.WholeWord, result.FindMode);
+            var origs = GetOriginalTextsForFind();
+            var startInOriginal = IsFindPositionInOriginal();
+            var startTextBox = GetFindTextBox(startInOriginal);
+            _findService.Initialize(subs, SelectedSubtitleIndex ?? 0, result.WholeWord, result.FindMode, origs);
 
             var idx = -1;
             if (result.FindNextPressed)
             {
-                idx = _findService.FindNext(result.SearchText, subs, currentLineIndex, EditTextBox.SelectionEnd);
+                idx = _findService.FindNext(result.SearchText, subs, currentLineIndex, startTextBox.SelectionEnd, origs, startInOriginal);
             }
             else
             {
-                idx = _findService.FindPrevious(result.SearchText, subs, currentLineIndex, EditTextBox.SelectionStart - 1);
+                idx = _findService.FindPrevious(result.SearchText, subs, currentLineIndex, startTextBox.SelectionStart - 1, origs, startInOriginal);
             }
 
             if (idx < 0)
@@ -11364,8 +11370,8 @@ public partial class MainViewModel :
                     return;
                 }
                 idx = result.FindNextPressed
-                    ? _findService.FindNext(result.SearchText, subs, 0, 0)
-                    : _findService.FindPrevious(result.SearchText, subs, subs.Count, 0);
+                    ? _findService.FindNext(result.SearchText, subs, 0, 0, origs)
+                    : _findService.FindPrevious(result.SearchText, subs, subs.Count, 0, origs);
                 if (idx < 0)
                 {
                     ShowStatus(string.Format(Se.Language.General.XNotFound, _findService.SearchText));
@@ -11378,27 +11384,7 @@ public partial class MainViewModel :
                 _findViewModel.ResultFound = true;
             }
 
-            Dispatcher.UIThread.Post(() =>
-            {
-                var subtitle = Subtitles.GetOrNull(idx);
-                if (subtitle == null)
-                {
-                    return;
-                }
-
-                SubtitleGrid.SelectedIndex = idx;
-                SubtitleGrid.SelectedItem = subtitle;
-                SelectAndScrollToRow(idx);
-
-                ShowStatus(string.Format(Se.Language.General.FoundXInLineYZ, _findService.CurrentTextFound.Replace("\r\n", "·").Replace("\n", "·"), _findService.CurrentLineNumber + 1, _findService.CurrentTextIndex + 1));
-
-                if (EditTextBox.Text != subtitle.Text)
-                {
-                    EditTextBox.Text = subtitle.Text;
-                }
-
-                EditTextBox.Select(_findService.CurrentTextIndex, _findService.CurrentTextFound.Length);
-            });
+            ShowFindMatch(idx, _findService.CurrentTextFound, _findService.CurrentLineNumber, _findService.CurrentTextIndex, _findService.CurrentMatchInOriginal);
         }
     }
 
@@ -11418,9 +11404,11 @@ public partial class MainViewModel :
         }
 
         var subs = Subtitles.Select(p => p.Text).ToList();
+        var origs = GetOriginalTextsForFind();
+        var startInOriginal = IsFindPositionInOriginal();
         var currentLineIndex = Subtitles.IndexOf(selectedSubtitle);
-        var currentCharIndex = EditTextBox.SelectionEnd;
-        var idx = _findService.FindNext(_findService.SearchText, subs, currentLineIndex, currentCharIndex);
+        var currentCharIndex = GetFindTextBox(startInOriginal).SelectionEnd;
+        var idx = _findService.FindNext(_findService.SearchText, subs, currentLineIndex, currentCharIndex, origs, startInOriginal);
 
         if (idx < 0)
         {
@@ -11431,7 +11419,7 @@ public partial class MainViewModel :
                 _shortcutManager.ClearKeys();
                 return;
             }
-            idx = _findService.FindNext(_findService.SearchText, subs, 0, 0);
+            idx = _findService.FindNext(_findService.SearchText, subs, 0, 0, origs);
             if (idx < 0)
             {
                 ShowStatus(string.Format(Se.Language.General.XNotFound, _findService.SearchText));
@@ -11440,33 +11428,10 @@ public partial class MainViewModel :
             }
         }
 
-        var foundText = _findService.CurrentTextFound;
-        var foundLine = _findService.CurrentLineNumber;
-        var foundIndex = _findService.CurrentTextIndex;
+        var foundInOriginal = _findService.CurrentMatchInOriginal;
+        ShowFindMatch(idx, _findService.CurrentTextFound, _findService.CurrentLineNumber, _findService.CurrentTextIndex, foundInOriginal);
 
-        Dispatcher.UIThread.Post(() =>
-        {
-            var subtitle = Subtitles.GetOrNull(idx);
-            if (subtitle == null)
-            {
-                return;
-            }
-
-            SubtitleGrid.SelectedIndex = idx;
-            SubtitleGrid.SelectedItem = subtitle;
-            SelectAndScrollToRow(idx);
-
-            ShowStatus(string.Format(Se.Language.General.FoundXInLineYZ, foundText.Replace("\r\n", "·").Replace("\n", "·"), foundLine + 1, foundIndex + 1));
-
-            if (EditTextBox.Text != subtitle.Text)
-            {
-                EditTextBox.Text = subtitle.Text;
-            }
-
-            EditTextBox.Select(foundIndex, foundText.Length);
-        });
-
-        FocusEditTextBox();
+        FocusEditTextBox(foundInOriginal);
         _shortcutManager.ClearKeys();
     }
 
@@ -11486,8 +11451,10 @@ public partial class MainViewModel :
         }
 
         var subs = Subtitles.Select(p => p.Text).ToList();
+        var origs = GetOriginalTextsForFind();
+        var startInOriginal = IsFindPositionInOriginal();
         var currentLineIndex = Subtitles.IndexOf(selectedSubtitle);
-        var idx = _findService.FindPrevious(_findService.SearchText, subs, currentLineIndex, EditTextBox.SelectionStart - 1);
+        var idx = _findService.FindPrevious(_findService.SearchText, subs, currentLineIndex, GetFindTextBox(startInOriginal).SelectionStart - 1, origs, startInOriginal);
 
         if (idx < 0)
         {
@@ -11498,7 +11465,7 @@ public partial class MainViewModel :
                 _shortcutManager.ClearKeys();
                 return;
             }
-            idx = _findService.FindPrevious(_findService.SearchText, subs, subs.Count, 0);
+            idx = _findService.FindPrevious(_findService.SearchText, subs, subs.Count, 0, origs);
             if (idx < 0)
             {
                 ShowStatus(string.Format(Se.Language.General.XNotFound, _findService.SearchText));
@@ -11507,10 +11474,55 @@ public partial class MainViewModel :
             }
         }
 
-        var foundText = _findService.CurrentTextFound;
-        var foundLine = _findService.CurrentLineNumber;
-        var foundIndex = _findService.CurrentTextIndex;
+        var foundInOriginal = _findService.CurrentMatchInOriginal;
+        ShowFindMatch(idx, _findService.CurrentTextFound, _findService.CurrentLineNumber, _findService.CurrentTextIndex, foundInOriginal);
 
+        FocusEditTextBox(foundInOriginal);
+        _shortcutManager.ClearKeys();
+    }
+
+    /// <summary>
+    /// Original texts to search alongside the main texts, or null when no original subtitle
+    /// is loaded. SE 4 searched both columns too (issue #13053).
+    /// </summary>
+    private List<string>? GetOriginalTextsForFind()
+    {
+        return ShowColumnOriginalText
+            ? Subtitles.Select(p => p.OriginalText ?? string.Empty).ToList()
+            : null;
+    }
+
+    /// <summary>
+    /// Which column a find should continue from: the focused text box if one has focus
+    /// (find/replace windows do not take focus from it), otherwise the column of the last match.
+    /// </summary>
+    private bool IsFindPositionInOriginal()
+    {
+        if (!ShowColumnOriginalText)
+        {
+            return false;
+        }
+
+        if (EditTextBoxOriginal.IsFocused)
+        {
+            return true;
+        }
+
+        if (EditTextBox.IsFocused)
+        {
+            return false;
+        }
+
+        return _findService.CurrentMatchInOriginal;
+    }
+
+    private ITextBoxWrapper GetFindTextBox(bool inOriginal)
+    {
+        return inOriginal ? EditTextBoxOriginal : EditTextBox;
+    }
+
+    private void ShowFindMatch(int idx, string foundText, int foundLine, int foundIndex, bool inOriginal)
+    {
         Dispatcher.UIThread.Post(() =>
         {
             var subtitle = Subtitles.GetOrNull(idx);
@@ -11525,16 +11537,17 @@ public partial class MainViewModel :
 
             ShowStatus(string.Format(Se.Language.General.FoundXInLineYZ, foundText.Replace("\r\n", "·").Replace("\n", "·"), foundLine + 1, foundIndex + 1));
 
-            if (EditTextBox.Text != subtitle.Text)
+            // The text-box binding may not have propagated yet by the time this dispatcher
+            // post runs; ensure it shows the target subtitle's text before selecting.
+            var textBox = GetFindTextBox(inOriginal);
+            var text = inOriginal ? subtitle.OriginalText : subtitle.Text;
+            if (textBox.Text != text)
             {
-                EditTextBox.Text = subtitle.Text;
+                textBox.Text = text;
             }
 
-            EditTextBox.Select(foundIndex, foundText.Length);
+            textBox.Select(foundIndex, foundText.Length);
         });
-
-        FocusEditTextBox();
-        _shortcutManager.ClearKeys();
     }
 
     private async Task<MessageBoxResult> ShowWrapAroundDialog(string message)
@@ -11583,15 +11596,17 @@ public partial class MainViewModel :
 
         _replacePreviousFocus = Window?.FocusManager?.GetFocusedElement() as Control;
         var subs = Subtitles.Select(p => p.Text).ToList();
+        var origs = GetOriginalTextsForFind();
         var result = _windowService.ShowWindow<ReplaceWindow, ReplaceViewModel>(Window!, (window, vm) =>
         {
             WindowService.KeepTopmostWhileOwnerActive(window, Window!);
             _replaceViewModel = vm;
 
             var selectedText = string.Empty;
-            if (EditTextBox != null && !string.IsNullOrEmpty(EditTextBox.SelectedText))
+            var textBox = GetFindTextBox(EditTextBoxOriginal.IsFocused);
+            if (textBox != null && !string.IsNullOrEmpty(textBox.SelectedText))
             {
-                selectedText = EditTextBox.SelectedText;
+                selectedText = textBox.SelectedText;
             }
 
             if ((string.IsNullOrEmpty(selectedText) || string.Equals(selectedText, _findService.CurrentTextFound, _findService.CurrentFindMode == FindMode.CaseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
@@ -11600,7 +11615,7 @@ public partial class MainViewModel :
                 selectedText = _findService.SearchText;
             }
 
-            vm.InitializeFindData(_findService, subs, selectedText, this);
+            vm.InitializeFindData(_findService, subs, selectedText, this, origs);
             if (!string.IsNullOrEmpty(findSearchText))
             {
                 vm.SearchText = findSearchText;
@@ -11638,7 +11653,7 @@ public partial class MainViewModel :
 
                 if (vm.ResultFound)
                 {
-                    FocusEditTextBox();
+                    FocusEditTextBox(_findService.CurrentMatchInOriginal);
                 }
                 else
                 {
@@ -11733,6 +11748,7 @@ public partial class MainViewModel :
         {
             var currentLineIndex = Subtitles.IndexOf(selectedSubtitle);
             var subs = Subtitles.Select(p => p.Text).ToList();
+            var origs = GetOriginalTextsForFind();
 
             // Save the previous find result before Initialize wipes it. The
             // replace path uses these — not the EditTextBox selection — to
@@ -11742,13 +11758,17 @@ public partial class MainViewModel :
             var savedFoundLine = _findService.CurrentLineNumber;
             var savedFoundIndex = _findService.CurrentTextIndex;
             var savedFoundText = _findService.CurrentTextFound;
+            var savedFoundInOriginal = _findService.CurrentMatchInOriginal;
 
-            _findService.Initialize(subs, SelectedSubtitleIndex ?? 0, result.WholeWord, result.FindMode);
+            var startInOriginal = IsFindPositionInOriginal();
+            var startTextBox = GetFindTextBox(startInOriginal);
+
+            _findService.Initialize(subs, SelectedSubtitleIndex ?? 0, result.WholeWord, result.FindMode, origs);
 
             var idx = -1;
             if (result.FindNextPressed)
             {
-                idx = _findService.FindNext(result.SearchText, subs, currentLineIndex, EditTextBox.SelectionEnd);
+                idx = _findService.FindNext(result.SearchText, subs, currentLineIndex, startTextBox.SelectionEnd, origs, startInOriginal);
             }
             else if (result.ReplaceAllPressed)
             {
@@ -11764,37 +11784,62 @@ public partial class MainViewModel :
                     }
                 }
 
+                if (origs != null)
+                {
+                    for (var i = 0; i < Subtitles.Count && i < origs.Count; i++)
+                    {
+                        var s = Subtitles[i];
+                        var newText = origs[i];
+                        if (newText != s.OriginalText)
+                        {
+                            s.OriginalText = newText;
+                        }
+                    }
+                }
+
                 ShowStatus(string.Format(Se.Language.Main.ReplacedXWithYCountZ, result.SearchText, result.ReplaceText, replaceCount));
                 return;
             }
             else // replace requested
             {
-                var nextStartIndex = EditTextBox.SelectionEnd;
+                var nextStartIndex = startTextBox.SelectionEnd;
                 var nextStartLine = currentLineIndex;
+                var nextStartInOriginal = startInOriginal;
 
-                if (savedFoundLine >= 0
-                    && savedFoundLine < subs.Count
+                // The match to replace may sit in the original text column (translator mode).
+                var savedLines = savedFoundInOriginal ? origs : subs;
+                if (savedLines != null
+                    && savedFoundLine >= 0
+                    && savedFoundLine < savedLines.Count
                     && savedFoundIndex >= 0
                     && !string.IsNullOrEmpty(savedFoundText))
                 {
-                    var line = subs[savedFoundLine];
+                    var line = savedLines[savedFoundLine];
                     if (savedFoundIndex + savedFoundText.Length <= line.Length)
                     {
                         var replaced = TryBuildReplacement(line, savedFoundIndex, savedFoundText, result, out var newLine);
                         if (replaced.HasValue)
                         {
-                            subs[savedFoundLine] = newLine;
+                            savedLines[savedFoundLine] = newLine;
                             if (savedFoundLine < Subtitles.Count)
                             {
-                                Subtitles[savedFoundLine].Text = newLine;
+                                if (savedFoundInOriginal)
+                                {
+                                    Subtitles[savedFoundLine].OriginalText = newLine;
+                                }
+                                else
+                                {
+                                    Subtitles[savedFoundLine].Text = newLine;
+                                }
                             }
                             nextStartLine = savedFoundLine;
                             nextStartIndex = savedFoundIndex + replaced.Value;
+                            nextStartInOriginal = savedFoundInOriginal;
                         }
                     }
                 }
 
-                idx = _findService.FindNext(result.SearchText, subs, nextStartLine, nextStartIndex);
+                idx = _findService.FindNext(result.SearchText, subs, nextStartLine, nextStartIndex, origs, nextStartInOriginal);
             }
 
             if (idx < 0)
@@ -11806,7 +11851,7 @@ public partial class MainViewModel :
                     ShowStatus(string.Format(Se.Language.General.XNotFound, _findService.SearchText));
                     return;
                 }
-                idx = _findService.FindNext(result.SearchText, subs, 0, 0);
+                idx = _findService.FindNext(result.SearchText, subs, 0, 0, origs);
                 if (idx < 0)
                 {
                     ShowStatus(string.Format(Se.Language.General.XNotFound, _findService.SearchText));
@@ -11819,33 +11864,7 @@ public partial class MainViewModel :
                 _replaceViewModel.ResultFound = true;
             }
 
-            var foundText = _findService.CurrentTextFound;
-            var foundLine = _findService.CurrentLineNumber;
-            var foundIndex = _findService.CurrentTextIndex;
-
-            Dispatcher.UIThread.Post(() =>
-            {
-                var subtitle = Subtitles.GetOrNull(idx);
-                if (subtitle == null)
-                {
-                    return;
-                }
-
-                SubtitleGrid.SelectedIndex = idx;
-                SubtitleGrid.SelectedItem = subtitle;
-                SelectAndScrollToRow(idx);
-
-                // The text-box binding may not have propagated yet by the time this dispatcher
-                // post runs; ensure it shows the target subtitle's text before selecting.
-                if (EditTextBox.Text != subtitle.Text)
-                {
-                    EditTextBox.Text = subtitle.Text;
-                }
-
-                EditTextBox.Select(foundIndex, foundText.Length);
-
-                ShowStatus(string.Format(Se.Language.General.FoundXInLineYZ, foundText.Replace("\r\n", "·").Replace("\n", "·"), foundLine + 1, foundIndex + 1));
-            });
+            ShowFindMatch(idx, _findService.CurrentTextFound, _findService.CurrentLineNumber, _findService.CurrentTextIndex, _findService.CurrentMatchInOriginal);
         }
     }
 
@@ -13435,6 +13454,11 @@ public partial class MainViewModel :
 
     private void FocusEditTextBox()
     {
+        FocusEditTextBox(false);
+    }
+
+    private void FocusEditTextBox(bool original)
+    {
         Dispatcher.UIThread.Post(async () =>
         {
             if (AudioVisualizer != null && AudioVisualizer.IsFocused)
@@ -13442,10 +13466,11 @@ public partial class MainViewModel :
                 AudioVisualizer.SkipNextPointerEntered = true;
             }
 
+            var textBox = GetFindTextBox(original);
             ActivateWindow(Window);
-            EditTextBox.Focus();
+            textBox.Focus();
             await Task.Delay(10);
-            EditTextBox.Focus();
+            textBox.Focus();
         });
     }
 

--- a/src/ui/Logic/FindService.cs
+++ b/src/ui/Logic/FindService.cs
@@ -13,10 +13,12 @@ public partial class FindService : IFindService
     public int CurrentLineNumber { get; set; } = -1;
     public int CurrentTextIndex { get; set; } = -1;
     public string CurrentTextFound { get; set; } = string.Empty;
+    public bool CurrentMatchInOriginal { get; set; }
     public bool WholeWord { get; set; }
     public FindMode CurrentFindMode { get; set; } = FindMode.CaseInsensitive;
 
     private List<string> _textLines = new List<string>();
+    private List<string>? _originalTextLines;
     private readonly List<string> _searchHistory = new List<string>();
     private const int MaxSearchHistoryItems = 10;
 
@@ -46,16 +48,17 @@ public partial class FindService : IFindService
         }
     }
 
-    public void Initialize(List<string> textLines, int currentLineNumber, bool wholeWord, FindMode findMode)
+    public void Initialize(List<string> textLines, int currentLineNumber, bool wholeWord, FindMode findMode, List<string>? originalTextLines = null)
     {
         _textLines = textLines;
+        _originalTextLines = originalTextLines;
         CurrentLineNumber = Math.Max(-1, Math.Min(currentLineNumber, textLines.Count - 1));
         WholeWord = wholeWord;
         CurrentFindMode = findMode;
         ResetSearchState();
     }
 
-    public int FindNext(string searchText, List<string> textLines, int startLineIndex, int startTextIndex)
+    public int FindNext(string searchText, List<string> textLines, int startLineIndex, int startTextIndex, List<string>? originalTextLines = null, bool startInOriginal = false)
     {
         if (string.IsNullOrEmpty(searchText) || _textLines.Count == 0)
         {
@@ -65,12 +68,14 @@ public partial class FindService : IFindService
 
         SearchText = RegexUtils.EscapeNewLines(searchText);
         _textLines = textLines;
+        _originalTextLines = originalTextLines;
         AddToSearchHistory(searchText);
 
         if (startLineIndex < 0)
         {
             startLineIndex = 0;
             startTextIndex = 0;
+            startInOriginal = false;
         }
         else
         {
@@ -79,10 +84,20 @@ public partial class FindService : IFindService
                 return NotFound();
             }
 
-            // If we've reached the end of current line, move to next line
-            if (startTextIndex >= _textLines[startLineIndex].Length)
+            // If we've reached the end of the current text, move on to the next column
+            // (original text of the same line) or to the next line.
+            if (startTextIndex >= GetLine(startLineIndex, startInOriginal).Length)
             {
-                startLineIndex++;
+                if (!startInOriginal && GetOriginalLine(startLineIndex) != null)
+                {
+                    startInOriginal = true;
+                }
+                else
+                {
+                    startLineIndex++;
+                    startInOriginal = false;
+                }
+
                 startTextIndex = 0;
             }
 
@@ -92,12 +107,40 @@ public partial class FindService : IFindService
             }
         }
 
-        var result = FindInList(searchText, startLineIndex, startTextIndex);
+        var result = FindInList(searchText, startLineIndex, startTextIndex, startInOriginal);
         CurrentLineNumber = result.lineIndex;
         CurrentTextIndex = result.textIndex;
         CurrentTextFound = result.foundText;
+        CurrentMatchInOriginal = result.inOriginal;
 
         return CurrentLineNumber;
+    }
+
+    /// <summary>
+    /// Text of a line in the requested column - the main text, or the original text when
+    /// an original subtitle is loaded (translator mode).
+    /// </summary>
+    private string GetLine(int lineIndex, bool original)
+    {
+        if (original)
+        {
+            return GetOriginalLine(lineIndex) ?? string.Empty;
+        }
+
+        return lineIndex >= 0 && lineIndex < _textLines.Count ? _textLines[lineIndex] : string.Empty;
+    }
+
+    /// <summary>
+    /// Original text of a line, or null when no original subtitle is loaded.
+    /// </summary>
+    private string? GetOriginalLine(int lineIndex)
+    {
+        if (_originalTextLines == null || lineIndex < 0 || lineIndex >= _originalTextLines.Count)
+        {
+            return null;
+        }
+
+        return _originalTextLines[lineIndex];
     }
 
     private int NotFound()
@@ -106,7 +149,7 @@ public partial class FindService : IFindService
         return -1;
     }
 
-    public int FindPrevious(string searchText, List<string> textLines, int startLineIndex, int startTextIndex)
+    public int FindPrevious(string searchText, List<string> textLines, int startLineIndex, int startTextIndex, List<string>? originalTextLines = null, bool startInOriginal = false)
     {
         if (string.IsNullOrEmpty(searchText) || _textLines.Count == 0)
         {
@@ -116,6 +159,7 @@ public partial class FindService : IFindService
 
         SearchText = RegexUtils.EscapeNewLines(searchText);
         _textLines = textLines;
+        _originalTextLines = originalTextLines;
         AddToSearchHistory(searchText);
 
         if (startLineIndex < 0)
@@ -127,16 +171,27 @@ public partial class FindService : IFindService
             if (startLineIndex >= _textLines.Count)
             {
                 startLineIndex = _textLines.Count - 1;
-                startTextIndex = _textLines[startLineIndex].Length - 1;
+                startInOriginal = GetOriginalLine(startLineIndex) != null;
+                startTextIndex = GetLine(startLineIndex, startInOriginal).Length - 1;
             }
 
-            // If we've reached the beginning of current line, move to previous line
+            // If we've reached the beginning of the current text, move back to the previous
+            // column (main text of the same line) or to the previous line.
             if (startTextIndex < 0)
             {
-                startLineIndex--;
+                if (startInOriginal)
+                {
+                    startInOriginal = false;
+                }
+                else
+                {
+                    startLineIndex--;
+                    startInOriginal = startLineIndex >= 0 && GetOriginalLine(startLineIndex) != null;
+                }
+
                 if (startLineIndex >= 0)
                 {
-                    startTextIndex = _textLines[startLineIndex].Length - 1;
+                    startTextIndex = GetLine(startLineIndex, startInOriginal).Length - 1;
                 }
             }
 
@@ -146,15 +201,16 @@ public partial class FindService : IFindService
             }
         }
 
-        var result = FindInListReverse(searchText, startLineIndex, startTextIndex);
+        var result = FindInListReverse(searchText, startLineIndex, startTextIndex, startInOriginal);
         CurrentLineNumber = result.lineIndex;
         CurrentTextIndex = result.textIndex;
         CurrentTextFound = result.foundText;
+        CurrentMatchInOriginal = result.inOriginal;
 
         return CurrentLineNumber;
     }
 
-    public int Count(string searchText, IReadOnlyList<string> textLines, bool wholeWord, FindMode findMode)
+    public int Count(string searchText, IReadOnlyList<string> textLines, bool wholeWord, FindMode findMode, IReadOnlyList<string>? originalTextLines = null)
     {
         if (string.IsNullOrEmpty(searchText) || textLines == null || textLines.Count == 0)
         {
@@ -165,6 +221,14 @@ public partial class FindService : IFindService
         foreach (var line in textLines)
         {
             total += CountMatchesInLine(line, searchText, wholeWord, findMode);
+        }
+
+        if (originalTextLines != null)
+        {
+            foreach (var line in originalTextLines)
+            {
+                total += CountMatchesInLine(line, searchText, wholeWord, findMode);
+            }
         }
 
         return total;
@@ -210,6 +274,19 @@ public partial class FindService : IFindService
             }
         }
 
+        if (_originalTextLines != null)
+        {
+            for (int lineIndex = 0; lineIndex < _originalTextLines.Count; lineIndex++)
+            {
+                var replacedText = ReplaceInLine(_originalTextLines[lineIndex], searchText, replaceText);
+                if (replacedText.replaced)
+                {
+                    _originalTextLines[lineIndex] = replacedText.newText;
+                    totalReplacements += replacedText.replacementCount;
+                }
+            }
+        }
+
         if (totalReplacements > 0)
         {
             AddToSearchHistory(searchText);
@@ -234,6 +311,7 @@ public partial class FindService : IFindService
         CurrentLineNumber = -1;
         CurrentTextIndex = -1;
         CurrentTextFound = string.Empty;
+        CurrentMatchInOriginal = false;
     }
 
     private void AddToSearchHistory(string searchText)
@@ -260,23 +338,42 @@ public partial class FindService : IFindService
         Se.Settings.Tools.FindHistory = _searchHistory;
     }
 
-    private (int lineIndex, int textIndex, string foundText) FindInList(string searchText, int startLineIndex, int startTextIndex = 0)
+    // Within a line the main text is searched before the original text, so a search resuming
+    // from a match in the original column skips the main text of that line - SE 4 did the same
+    // via its "match in original" flag (issue #13053).
+    private (int lineIndex, int textIndex, string foundText, bool inOriginal) FindInList(string searchText, int startLineIndex, int startTextIndex, bool startInOriginal)
     {
         for (var i = startLineIndex; i < _textLines.Count; i++)
         {
-            var textIndex = i == startLineIndex ? startTextIndex : 0;
-            var match = FindInLine(_textLines[i], searchText, textIndex);
+            var first = i == startLineIndex;
+            var textIndex = first ? startTextIndex : 0;
 
-            if (match.found)
+            if (!(first && startInOriginal))
             {
-                return (i, match.index, match.foundText);
+                var match = FindInLine(_textLines[i], searchText, textIndex);
+                if (match.found)
+                {
+                    return (i, match.index, match.foundText, false);
+                }
+
+                textIndex = 0;
+            }
+
+            var original = GetOriginalLine(i);
+            if (original != null)
+            {
+                var match = FindInLine(original, searchText, textIndex);
+                if (match.found)
+                {
+                    return (i, match.index, match.foundText, true);
+                }
             }
         }
 
-        return (-1, -1, string.Empty);
+        return (-1, -1, string.Empty, false);
     }
 
-    private (int lineIndex, int textIndex, string foundText) FindInListReverse(string searchText, int startLineIndex, int startTextIndex)
+    private (int lineIndex, int textIndex, string foundText, bool inOriginal) FindInListReverse(string searchText, int startLineIndex, int startTextIndex, bool startInOriginal)
     {
         for (var i = startLineIndex; i >= 0; i--)
         {
@@ -285,16 +382,29 @@ public partial class FindService : IFindService
                 continue;
             }
 
-            var textIndex = i == startLineIndex ? startTextIndex : _textLines[i].Length - 1;
-            var match = FindInLineReverse(_textLines[i], searchText, textIndex);
+            var first = i == startLineIndex;
+            var original = GetOriginalLine(i);
 
-            if (match.found)
+            // Reverse of the forward order: original text first, then the main text.
+            if (original != null && (!first || startInOriginal))
             {
-                return (i, match.index, match.foundText);
+                var textIndex = first ? startTextIndex : original.Length - 1;
+                var match = FindInLineReverse(original, searchText, textIndex);
+                if (match.found)
+                {
+                    return (i, match.index, match.foundText, true);
+                }
+            }
+
+            var mainTextIndex = first && !startInOriginal ? startTextIndex : _textLines[i].Length - 1;
+            var mainMatch = FindInLineReverse(_textLines[i], searchText, mainTextIndex);
+            if (mainMatch.found)
+            {
+                return (i, mainMatch.index, mainMatch.foundText, false);
             }
         }
 
-        return (-1, -1, string.Empty);
+        return (-1, -1, string.Empty, false);
     }
 
     private (bool found, int index, string foundText) FindInLine(string line, string searchText, int startIndex = 0)

--- a/src/ui/Logic/IFindService.cs
+++ b/src/ui/Logic/IFindService.cs
@@ -9,15 +9,21 @@ public interface IFindService
     int CurrentLineNumber { get; set; }
     int CurrentTextIndex { get; set; }
     string CurrentTextFound { get; set; }
+
+    /// <summary>
+    /// True when the last match was found in the original text column (translator mode).
+    /// </summary>
+    bool CurrentMatchInOriginal { get; set; }
+
     bool WholeWord { get; set; }
     FindMode CurrentFindMode { get; set; }
     IReadOnlyList<string> SearchHistory { get; }
 
-    void Initialize(List<string> textLines, int currentLineIndex, bool wholeWord, FindMode findMode);
-    int FindNext(string searchText, List<string> textLines, int currentLineIndex, int startTextIndex);
-    int FindPrevious(string searchText, List<string> textLines, int currentLineIndex, int startTextIndex);
+    void Initialize(List<string> textLines, int currentLineIndex, bool wholeWord, FindMode findMode, List<string>? originalTextLines = null);
+    int FindNext(string searchText, List<string> textLines, int currentLineIndex, int startTextIndex, List<string>? originalTextLines = null, bool startInOriginal = false);
+    int FindPrevious(string searchText, List<string> textLines, int currentLineIndex, int startTextIndex, List<string>? originalTextLines = null, bool startInOriginal = false);
     int ReplaceAll(string searchText, string replaceText);
-    int Count(string searchText, IReadOnlyList<string> textLines, bool wholeWord, FindMode findMode);
+    int Count(string searchText, IReadOnlyList<string> textLines, bool wholeWord, FindMode findMode, IReadOnlyList<string>? originalTextLines = null);
     List<(int LineIndex, int TextIndex, string FoundText)> FindAll(string searchText);
     void Reset();
     void RemoveFromSearchHistory(string searchText);

--- a/tests/UI/Logic/FindServiceTests.cs
+++ b/tests/UI/Logic/FindServiceTests.cs
@@ -159,4 +159,116 @@ public class FindServiceTests
         Assert.Equal("single line", lines[0]);
         Assert.Equal("top bottom", lines[1]);
     }
+
+    // #13053: in translator mode the original text column must be searched too - SE 4 searched
+    // both columns, SE 5 only looked at the main text.
+    [Fact]
+    public void FindNext_FindsMatchInOriginalTextOnly()
+    {
+        var lines = new List<string> { "Paráda.", "- No tak, no tak." };
+        var originals = new List<string> { "Great.", "- Come on, come on." };
+        var service = new FindService();
+        service.Initialize(lines, 0, false, FindService.FindMode.CaseInsensitive, originals);
+
+        var idx = service.FindNext("come", lines, 0, 0, originals);
+
+        Assert.Equal(1, idx);
+        Assert.True(service.CurrentMatchInOriginal);
+        Assert.Equal(2, service.CurrentTextIndex);
+    }
+
+    // Within a line the main text is searched before the original text.
+    [Fact]
+    public void FindNext_SearchesMainTextBeforeOriginalText()
+    {
+        var lines = new List<string> { "hello there" };
+        var originals = new List<string> { "hello again" };
+        var service = new FindService();
+        service.Initialize(lines, 0, false, FindService.FindMode.CaseInsensitive, originals);
+
+        var idx = service.FindNext("hello", lines, 0, 0, originals);
+        Assert.Equal(0, idx);
+        Assert.False(service.CurrentMatchInOriginal);
+
+        // Continue from the match in the main text - the next hit is in the original text
+        // of the same line.
+        idx = service.FindNext("hello", lines, 0, service.CurrentTextIndex + 5, originals, false);
+        Assert.Equal(0, idx);
+        Assert.True(service.CurrentMatchInOriginal);
+        Assert.Equal(0, service.CurrentTextIndex);
+    }
+
+    // Resuming from a match in the original column must not find the same line's main text again.
+    [Fact]
+    public void FindNext_ResumingFromOriginal_SkipsMainTextOfSameLine()
+    {
+        var lines = new List<string> { "hello there", "nothing here" };
+        var originals = new List<string> { "hello again", "hello once more" };
+        var service = new FindService();
+        service.Initialize(lines, 0, false, FindService.FindMode.CaseInsensitive, originals);
+
+        var idx = service.FindNext("hello", lines, 0, 1, originals, true);
+
+        Assert.Equal(1, idx);
+        Assert.True(service.CurrentMatchInOriginal);
+    }
+
+    // Backwards the columns are visited in reverse order: original text first, then main text.
+    [Fact]
+    public void FindPrevious_SearchesOriginalTextBeforeMainText()
+    {
+        var lines = new List<string> { "hello there", "no match here" };
+        var originals = new List<string> { "hello again", "no match either" };
+        var service = new FindService();
+        service.Initialize(lines, 0, false, FindService.FindMode.CaseInsensitive, originals);
+
+        var idx = service.FindPrevious("hello", lines, 1, lines[1].Length - 1, originals);
+        Assert.Equal(0, idx);
+        Assert.True(service.CurrentMatchInOriginal);
+
+        idx = service.FindPrevious("hello", lines, 0, service.CurrentTextIndex - 1, originals, true);
+        Assert.Equal(0, idx);
+        Assert.False(service.CurrentMatchInOriginal);
+    }
+
+    [Fact]
+    public void Count_IncludesOriginalTexts()
+    {
+        var lines = new List<string> { "hello world", "nothing" };
+        var originals = new List<string> { "hello again", "hello once more" };
+        var service = new FindService();
+
+        var count = service.Count("hello", lines, false, FindService.FindMode.CaseInsensitive, originals);
+
+        Assert.Equal(3, count);
+    }
+
+    [Fact]
+    public void ReplaceAll_ReplacesInOriginalTexts()
+    {
+        var lines = new List<string> { "hello world" };
+        var originals = new List<string> { "hello again" };
+        var service = new FindService();
+        service.Initialize(lines, 0, false, FindService.FindMode.CaseInsensitive, originals);
+
+        var count = service.ReplaceAll("hello", "hi");
+
+        Assert.Equal(2, count);
+        Assert.Equal("hi world", lines[0]);
+        Assert.Equal("hi again", originals[0]);
+    }
+
+    // No original subtitle loaded - nothing changes for the plain single-column case.
+    [Fact]
+    public void FindNext_WithoutOriginals_NeverReportsMatchInOriginal()
+    {
+        var lines = new List<string> { "hello world" };
+        var service = new FindService();
+        service.Initialize(lines, 0, false, FindService.FindMode.CaseInsensitive);
+
+        var idx = service.FindNext("world", lines, 0, 0);
+
+        Assert.Equal(0, idx);
+        Assert.False(service.CurrentMatchInOriginal);
+    }
 }


### PR DESCRIPTION
Fixes #13053

Find and replace only searched the main text, so in translator mode a word visible in the **Original text** column was reported as not found (see the screenshot in the issue: "come" is in line 31's original text). SE 4 searched both columns and selected the match in the text box of the column it was found in.

## Changes

**`FindService` / `IFindService`** — optional parallel list of original texts:
- `Initialize`, `FindNext`, `FindPrevious` and `Count` take an optional `originalTextLines`; the find methods also take `startInOriginal` so a search resumes from the column of the last match.
- New `CurrentMatchInOriginal` (SE 4 called it `MatchInOriginal`) reports which column matched.
- Within a line the main text is searched before the original text; backwards the order is reversed. Resuming from a match in the original column skips that line's main text, so "find next" cannot loop on the same match.
- `Count` counts both columns, `ReplaceAll` replaces in both.

**`MainViewModel`** — passes the original texts whenever the original column is shown (null otherwise, so nothing changes without a loaded original), and acts on the match column: selection, focus and the initial "selected text" for the dialog follow the original text box when that is where the match is. Replace patches `OriginalText` when the replaced match was in the original column, and Replace All copies both lists back. Four near-identical result blocks were folded into one `ShowFindMatch` helper.

Not included: SE 4's Replace-only "find/replace in: translation and original / translation only / original only" combo — its default was "both", which is what this does.

## Tests

7 new cases in `FindServiceTests` (match in original only, column order forwards/backwards, resume-from-original, count, replace-all, and the no-original case). Full UI suite passes apart from `SubtitleGridScrollPerformanceTests.HomeAndEnd_RealizeOnlyAViewportOfRows`, which already fails on `main` (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)