### PR TITLE
Two bug-hunt fixes: SSA storage style menu, TTS voice-seed UI freeze

### DIFF
--- a/src/ui/Features/Ssa/SsaStylesViewModel.cs
+++ b/src/ui/Features/Ssa/SsaStylesViewModel.cs
@@ -1094,7 +1094,10 @@ public partial class SsaStylesViewModel : ObservableObject, IClosingCleanup
 
     internal void StoreContextMenuOpening(object? sender, EventArgs e)
     {
-        IsDeleteAllVisible = FileStyles.Count > 0;
-        IsDeleteVisible = SelectedFileStyle != null;
+        // The storage menu's "Delete"/"Clear" must follow the storage list, not the file list -
+        // reading FileStyles here hid "Delete" whenever no file style happened to be selected,
+        // and offered "Clear" on an empty storage list.
+        IsDeleteAllVisible = StorageStyles.Count > 0;
+        IsDeleteVisible = SelectedStorageStyle != null;
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
@@ -301,30 +301,7 @@ public class CosyVoice3CrispAsr : ITtsEngine
             foreach (var src in Directory.GetFiles(sourceFolder, "*.wav"))
             {
                 var dest = Path.Combine(voicesFolder, Path.GetFileName(src));
-
-                if (!File.Exists(dest))
-                {
-                    try
-                    {
-                        var ffmpeg = FfmpegGenerator.ConvertToMono16kHzWav(src, dest);
-                        if (!ffmpeg.Start())
-                        {
-                            File.Copy(src, dest);
-                        }
-                        else
-                        {
-                            ffmpeg.WaitForExit();
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Se.LogError(ex, $"CosyVoice3 (CrispASR): resample seed '{src}' failed; falling back to plain copy");
-                        try { if (!File.Exists(dest))
-                        {
-                            File.Copy(src, dest);
-                        } } catch { }
-                    }
-                }
+                VoiceSeedHelper.CopyOrResample(src, dest, 16000, "CosyVoice3 (CrispASR)");
 
                 var sidecar = Path.ChangeExtension(src, ".txt");
                 if (File.Exists(sidecar))
@@ -404,7 +381,7 @@ public class CosyVoice3CrispAsr : ITtsEngine
         return true;
     }
 
-    public Task<Voice[]> GetVoices(string language)
+    public async Task<Voice[]> GetVoices(string language)
     {
         var result = new List<Voice>();
 
@@ -416,7 +393,9 @@ public class CosyVoice3CrispAsr : ITtsEngine
             result.Add(new Voice(new CosyVoice3Voice(display, preset)));
         }
 
-        var voicesFolder = GetSetVoicesFolder();
+        // Off the UI thread: GetSetVoicesFolder does one-time reference-WAV seeding through
+        // ffmpeg, and this is awaited from SelectedEngineChanged on the dispatcher.
+        var voicesFolder = await Task.Run(GetSetVoicesFolder);
         if (Directory.Exists(voicesFolder))
         {
             foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
@@ -427,7 +406,7 @@ public class CosyVoice3CrispAsr : ITtsEngine
             }
         }
 
-        return Task.FromResult(result.ToArray());
+        return result.ToArray();
     }
 
     private static string TryReadRefText(string wavPath)

--- a/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
@@ -245,31 +245,9 @@ public class F5TtsCrispAsr : ITtsEngine
             {
                 var dest = Path.Combine(voicesFolder, Path.GetFileName(src));
 
-                if (!File.Exists(dest))
-                {
-                    try
-                    {
-                        // qwen3-tts.cpp voice pack ships at 16 kHz; F5-TTS expects 24 kHz.
-                        // Resample on seed via ffmpeg so cloning sees 24 kHz directly.
-                        var ffmpeg = FfmpegGenerator.ConvertToMono24kHzWav(src, dest);
-                        if (!ffmpeg.Start())
-                        {
-                            File.Copy(src, dest);
-                        }
-                        else
-                        {
-                            ffmpeg.WaitForExit();
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Se.LogError(ex, $"F5-TTS (CrispASR): resample seed '{src}' failed; falling back to plain copy");
-                        try { if (!File.Exists(dest))
-                        {
-                            File.Copy(src, dest);
-                        } } catch { }
-                    }
-                }
+                // qwen3-tts.cpp voice pack ships at 16 kHz; F5-TTS expects 24 kHz.
+                // Resample on seed via ffmpeg so cloning sees 24 kHz directly.
+                VoiceSeedHelper.CopyOrResample(src, dest, 24000, "F5-TTS (CrispASR)");
 
                 var sidecar = Path.ChangeExtension(src, ".txt");
                 if (File.Exists(sidecar))
@@ -339,13 +317,15 @@ public class F5TtsCrispAsr : ITtsEngine
     public static bool AreModelsInstalled(string? modelKey = null) =>
         IsValidLocalModelFile(GetTalkerPath(modelKey), GetTalkerFileName(modelKey));
 
-    public Task<Voice[]> GetVoices(string language)
+    public async Task<Voice[]> GetVoices(string language)
     {
         var result = new List<Voice>();
 
         // Voice cloning only — no built-in default voice. The combo is empty until the user
         // imports a reference WAV (or the qwen3-tts.cpp voice seed runs above).
-        var voicesFolder = GetSetVoicesFolder();
+        // Off the UI thread: GetSetVoicesFolder does one-time reference-WAV seeding through
+        // ffmpeg, and this is awaited from SelectedEngineChanged on the dispatcher.
+        var voicesFolder = await Task.Run(GetSetVoicesFolder);
         if (Directory.Exists(voicesFolder))
         {
             foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
@@ -355,7 +335,7 @@ public class F5TtsCrispAsr : ITtsEngine
             }
         }
 
-        return Task.FromResult(result.ToArray());
+        return result.ToArray();
     }
 
     public bool IsVoiceInstalled(Voice voice) => true;

--- a/src/ui/Features/Video/TextToSpeech/Engines/IndexTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/IndexTtsCrispAsr.cs
@@ -242,30 +242,9 @@ public class IndexTtsCrispAsr : ITtsEngine
             foreach (var src in Directory.GetFiles(sourceFolder, "*.wav"))
             {
                 var dest = Path.Combine(voicesFolder, Path.GetFileName(src));
-                if (File.Exists(dest))
-                {
-                    continue;
-                }
 
-                try
-                {
-                    var ffmpeg = FfmpegGenerator.ConvertToMono24kHzWav(src, dest);
-                    if (!ffmpeg.Start())
-                    {
-                        // ffmpeg unavailable — better to seed at 16 kHz than skip the voice.
-                        File.Copy(src, dest);
-                        continue;
-                    }
-                    ffmpeg.WaitForExit();
-                }
-                catch (Exception ex)
-                {
-                    Se.LogError(ex, $"IndexTTS (CrispASR): resample seed '{src}' failed; falling back to plain copy");
-                    try { if (!File.Exists(dest))
-                    {
-                        File.Copy(src, dest);
-                    } } catch { }
-                }
+                // When ffmpeg cannot do it, seeding at 16 kHz beats skipping the voice.
+                VoiceSeedHelper.CopyOrResample(src, dest, 24000, "IndexTTS (CrispASR)");
             }
         }
         catch (Exception ex)
@@ -327,13 +306,15 @@ public class IndexTtsCrispAsr : ITtsEngine
         }
     }
 
-    public Task<Voice[]> GetVoices(string language)
+    public async Task<Voice[]> GetVoices(string language)
     {
         var result = new List<Voice>();
 
         // Voice cloning only — no built-in default voice. The combo is empty until the user
         // imports a reference WAV (or the qwen3-tts.cpp voice seed runs above).
-        var voicesFolder = GetSetVoicesFolder();
+        // Off the UI thread: GetSetVoicesFolder does one-time reference-WAV seeding through
+        // ffmpeg, and this is awaited from SelectedEngineChanged on the dispatcher.
+        var voicesFolder = await Task.Run(GetSetVoicesFolder);
         if (Directory.Exists(voicesFolder))
         {
             foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
@@ -343,7 +324,7 @@ public class IndexTtsCrispAsr : ITtsEngine
             }
         }
 
-        return Task.FromResult(result.ToArray());
+        return result.ToArray();
     }
 
     public bool IsVoiceInstalled(Voice voice) => true;

--- a/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
@@ -297,31 +297,9 @@ public class MossTtsCrispAsr : ITtsEngine
             {
                 var dest = Path.Combine(voicesFolder, Path.GetFileName(src));
 
-                if (!File.Exists(dest))
-                {
-                    try
-                    {
-                        // qwen3-tts.cpp voice pack ships at 16 kHz; resample to MOSS-TTS's
-                        // native 24 kHz mono on seed.
-                        var ffmpeg = FfmpegGenerator.ConvertToMono24kHzWav(src, dest);
-                        if (!ffmpeg.Start())
-                        {
-                            File.Copy(src, dest);
-                        }
-                        else
-                        {
-                            ffmpeg.WaitForExit();
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Se.LogError(ex, $"MOSS-TTS (CrispASR): resample seed '{src}' failed; falling back to plain copy");
-                        try { if (!File.Exists(dest))
-                        {
-                            File.Copy(src, dest);
-                        } } catch { }
-                    }
-                }
+                // qwen3-tts.cpp voice pack ships at 16 kHz; resample to MOSS-TTS's
+                // native 24 kHz mono on seed.
+                VoiceSeedHelper.CopyOrResample(src, dest, 24000, "MOSS-TTS (CrispASR)");
 
                 var sidecar = Path.ChangeExtension(src, ".txt");
                 if (File.Exists(sidecar))
@@ -405,13 +383,15 @@ public class MossTtsCrispAsr : ITtsEngine
         return true;
     }
 
-    public Task<Voice[]> GetVoices(string language)
+    public async Task<Voice[]> GetVoices(string language)
     {
         var result = new List<Voice>();
 
         // Voice cloning only — no built-in default voice. The combo is empty until the user
         // imports a reference WAV (or the qwen3-tts.cpp voice seed runs above).
-        var voicesFolder = GetSetVoicesFolder();
+        // Off the UI thread: GetSetVoicesFolder does one-time reference-WAV seeding through
+        // ffmpeg, and this is awaited from SelectedEngineChanged on the dispatcher.
+        var voicesFolder = await Task.Run(GetSetVoicesFolder);
         if (Directory.Exists(voicesFolder))
         {
             foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
@@ -421,7 +401,7 @@ public class MossTtsCrispAsr : ITtsEngine
             }
         }
 
-        return Task.FromResult(result.ToArray());
+        return result.ToArray();
     }
 
     public bool IsVoiceInstalled(Voice voice) => true;

--- a/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceCrispAsr.cs
@@ -273,33 +273,7 @@ public class OmniVoiceCrispAsr : ITtsEngine
             foreach (var src in Directory.GetFiles(sourceFolder, "*.wav"))
             {
                 var dest = Path.Combine(voicesFolder, Path.GetFileName(src));
-                if (!File.Exists(dest))
-                {
-                    try
-                    {
-                        var ffmpeg = FfmpegGenerator.ConvertToMono24kHzWav(src, dest);
-                        if (!ffmpeg.Start())
-                        {
-                            File.Copy(src, dest);
-                        }
-                        else
-                        {
-                            ffmpeg.WaitForExit();
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Se.LogError(ex, $"OmniVoice (CrispASR): resample seed '{src}' failed; falling back to plain copy");
-                        try
-                        {
-                            if (!File.Exists(dest))
-                            {
-                                File.Copy(src, dest);
-                            }
-                        }
-                        catch { }
-                    }
-                }
+                VoiceSeedHelper.CopyOrResample(src, dest, 24000, "OmniVoice (CrispASR)");
 
                 var sidecar = Path.ChangeExtension(src, ".txt");
                 if (File.Exists(sidecar))
@@ -374,7 +348,7 @@ public class OmniVoiceCrispAsr : ITtsEngine
         return true;
     }
 
-    public Task<Voice[]> GetVoices(string language)
+    public async Task<Voice[]> GetVoices(string language)
     {
         // The backend has a usable built-in voice, so "Default" leads and cloning is opt-in.
         var result = new List<Voice>
@@ -382,7 +356,9 @@ public class OmniVoiceCrispAsr : ITtsEngine
             new Voice(new OmniVoiceCrispAsrVoice(DefaultVoiceName, string.Empty)),
         };
 
-        var voicesFolder = GetSetVoicesFolder();
+        // Off the UI thread: GetSetVoicesFolder does one-time reference-WAV seeding through
+        // ffmpeg, and this is awaited from SelectedEngineChanged on the dispatcher.
+        var voicesFolder = await Task.Run(GetSetVoicesFolder);
         if (Directory.Exists(voicesFolder))
         {
             foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
@@ -392,7 +368,7 @@ public class OmniVoiceCrispAsr : ITtsEngine
             }
         }
 
-        return Task.FromResult(result.ToArray());
+        return result.ToArray();
     }
 
     public bool IsVoiceInstalled(Voice voice) => true;

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -304,24 +304,11 @@ public class Qwen3TtsCrispAsr : ITtsEngine
             foreach (var src in Directory.GetFiles(sourceFolder, "*.wav"))
             {
                 var dest = Path.Combine(voicesFolder, Path.GetFileName(src));
-                if (File.Exists(dest))
-                {
-                    continue;
-                }
 
-                try
-                {
-                    // Resample to 24 kHz mono — the Base backend rejects any other rate.
-                    var process = FfmpegGenerator.ConvertToMono24kHzWav(src, dest);
-                    if (process.Start())
-                    {
-                        process.WaitForExit();
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Se.LogError(ex, $"Qwen3 TTS (CrispASR): failed to resample seeded voice {Path.GetFileName(src)}");
-                }
+                // Resample to 24 kHz mono — the Base backend rejects any other rate, so a voice
+                // that cannot be resampled is skipped rather than copied at its original rate.
+                VoiceSeedHelper.CopyOrResample(
+                    src, dest, 24000, "Qwen3 TTS (CrispASR)", copyOnFailure: false);
             }
         }
         catch (Exception ex)
@@ -681,7 +668,7 @@ public class Qwen3TtsCrispAsr : ITtsEngine
         }
     }
 
-    public Task<Voice[]> GetVoices(string language)
+    public async Task<Voice[]> GetVoices(string language)
     {
         var result = new List<Voice>();
         var modelKey = ResolveModelKey(Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrModel);
@@ -691,7 +678,7 @@ public class Qwen3TtsCrispAsr : ITtsEngine
             // VoiceDesign has no speaker encoder — the instruction string drives the voice, so
             // a single "Default" entry is all the combo needs.
             result.Add(new Voice(new Qwen3TtsVoice("Default", string.Empty)));
-            return Task.FromResult(result.ToArray());
+            return result.ToArray();
         }
 
         if (modelKey == ModelKeyCustomVoice)
@@ -704,13 +691,15 @@ public class Qwen3TtsCrispAsr : ITtsEngine
             {
                 result.Add(new Voice(new Qwen3TtsVoice(speaker, string.Empty)));
             }
-            return Task.FromResult(result.ToArray());
+            return result.ToArray();
         }
 
         // Voice clone (Base): list the imported reference WAVs. Voice cloning refuses requests
         // without a reference, so there is no "Default" entry — the user must import a voice
         // (with its transcript) first.
-        var voicesFolder = GetSetVoicesFolder();
+        // Off the UI thread: GetSetVoicesFolder does one-time reference-WAV seeding through
+        // ffmpeg, and this is awaited from SelectedEngineChanged on the dispatcher.
+        var voicesFolder = await Task.Run(GetSetVoicesFolder);
         if (Directory.Exists(voicesFolder))
         {
             foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
@@ -720,7 +709,7 @@ public class Qwen3TtsCrispAsr : ITtsEngine
             }
         }
 
-        return Task.FromResult(result.ToArray());
+        return result.ToArray();
     }
 
     public bool IsVoiceInstalled(Voice voice) => true;

--- a/src/ui/Features/Video/TextToSpeech/Engines/VibeVoiceCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VibeVoiceCrispAsr.cs
@@ -234,30 +234,9 @@ public class VibeVoiceCrispAsr : ITtsEngine
             foreach (var src in Directory.GetFiles(sourceFolder, "*.wav"))
             {
                 var dest = Path.Combine(voicesFolder, Path.GetFileName(src));
-                if (File.Exists(dest))
-                {
-                    continue;
-                }
 
-                try
-                {
-                    var ffmpeg = FfmpegGenerator.ConvertToMono24kHzWav(src, dest);
-                    if (!ffmpeg.Start())
-                    {
-                        // ffmpeg unavailable — better to seed at 16 kHz than skip the voice.
-                        File.Copy(src, dest);
-                        continue;
-                    }
-                    ffmpeg.WaitForExit();
-                }
-                catch (Exception ex)
-                {
-                    Se.LogError(ex, $"VibeVoice (CrispASR): resample seed '{src}' failed; falling back to plain copy");
-                    try { if (!File.Exists(dest))
-                    {
-                        File.Copy(src, dest);
-                    } } catch { }
-                }
+                // When ffmpeg cannot do it, seeding at 16 kHz beats skipping the voice.
+                VoiceSeedHelper.CopyOrResample(src, dest, 24000, "VibeVoice (CrispASR)");
             }
         }
         catch (Exception ex)
@@ -315,13 +294,15 @@ public class VibeVoiceCrispAsr : ITtsEngine
     public static bool AreModelsInstalled(string? modelKey = null) =>
         IsValidLocalModelFile(GetTalkerPath(modelKey), GetTalkerFileName(modelKey));
 
-    public Task<Voice[]> GetVoices(string language)
+    public async Task<Voice[]> GetVoices(string language)
     {
         var result = new List<Voice>();
 
         // Voice cloning only — no built-in default voice. The combo is empty until the user
         // imports a reference WAV (or the qwen3-tts.cpp voice seed runs above).
-        var voicesFolder = GetSetVoicesFolder();
+        // Off the UI thread: GetSetVoicesFolder does one-time reference-WAV seeding through
+        // ffmpeg, and this is awaited from SelectedEngineChanged on the dispatcher.
+        var voicesFolder = await Task.Run(GetSetVoicesFolder);
         if (Directory.Exists(voicesFolder))
         {
             foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
@@ -331,7 +312,7 @@ public class VibeVoiceCrispAsr : ITtsEngine
             }
         }
 
-        return Task.FromResult(result.ToArray());
+        return result.ToArray();
     }
 
     public bool IsVoiceInstalled(Voice voice) => true;

--- a/src/ui/Features/Video/TextToSpeech/Engines/VoiceSeedHelper.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VoiceSeedHelper.cs
@@ -1,0 +1,145 @@
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.IO;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// The one step every CrispASR TTS engine's voice seeding shares: put a reference WAV into the
+/// engine's voices folder at the sample rate that engine clones from, falling back to a plain
+/// copy when ffmpeg cannot do it.
+///
+/// The engines differ in source folder, target rate and sidecar handling, so only this inner
+/// step is shared - but it is the part with the traps: an ffmpeg that never exits used to hang
+/// the seed forever, and a failed run left a truncated WAV behind that the "already seeded"
+/// check then treated as a good voice for the rest of the install's life.
+/// </summary>
+public static class VoiceSeedHelper
+{
+    /// <summary>
+    /// Reference WAVs are a few seconds each, so a resample is a second or two; past this
+    /// something is wrong with the child process and the plain copy is the better answer.
+    /// </summary>
+    private static readonly TimeSpan ConvertTimeout = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// Writes <paramref name="src"/> to <paramref name="dest"/> resampled to mono at
+    /// <paramref name="sampleRateHz"/>, or copies it verbatim when ffmpeg cannot be run or does
+    /// not produce a usable file. Does nothing when <paramref name="dest"/> already exists.
+    /// Never throws: seeding is best-effort and must not take the voice list down with it.
+    /// </summary>
+    /// <param name="sampleRateHz">24000 for most backends, 16000 for CosyVoice3's s3tok.</param>
+    /// <param name="enginePrefix">Engine name used in log lines, e.g. "OmniVoice (CrispASR)".</param>
+    /// <param name="copyOnFailure">
+    /// False for backends that reject a reference at any other sample rate (Qwen3 Base), where a
+    /// verbatim copy would seed a voice the server refuses. Those skip the voice instead.
+    /// </param>
+    public static void CopyOrResample(
+        string src,
+        string dest,
+        int sampleRateHz,
+        string enginePrefix,
+        bool copyOnFailure = true)
+    {
+        if (File.Exists(dest))
+        {
+            return;
+        }
+
+        try
+        {
+            if (TryConvert(src, dest, sampleRateHz, enginePrefix))
+            {
+                return;
+            }
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"{enginePrefix}: resample seed '{src}' failed; falling back to plain copy");
+        }
+
+        // The conversion failed, so whatever it wrote is not a voice - and a truncated WAV is
+        // still non-empty, so "does the file exist / is it non-empty" cannot be the test here.
+        // Drop it unconditionally, or the copy below is skipped and the engine keeps a broken
+        // voice for the rest of the install's life.
+        TryDelete(dest);
+
+        if (!copyOnFailure)
+        {
+            return;
+        }
+
+        try
+        {
+            if (!File.Exists(dest))
+            {
+                File.Copy(src, dest);
+            }
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"{enginePrefix}: seeding '{src}' failed");
+        }
+    }
+
+    private static bool TryConvert(string src, string dest, int sampleRateHz, string enginePrefix)
+    {
+        using var ffmpeg = sampleRateHz == 16000
+            ? FfmpegGenerator.ConvertToMono16kHzWav(src, dest)
+            : FfmpegGenerator.ConvertToMono24kHzWav(src, dest);
+        if (!ffmpeg.Start())
+        {
+            // ffmpeg unavailable - the caller's plain copy seeds the voice at its original rate.
+            return false;
+        }
+
+        if (!ffmpeg.WaitForExit((int)ConvertTimeout.TotalMilliseconds))
+        {
+            Se.LogError($"{enginePrefix}: resample seed '{src}' timed out after {ConvertTimeout.TotalSeconds:0} seconds; falling back to plain copy");
+            try
+            {
+                ffmpeg.Kill(entireProcessTree: true);
+            }
+            catch
+            {
+                // Already gone, or not ours to kill - either way the fallback copy still applies.
+            }
+
+            return false;
+        }
+
+        if (ffmpeg.ExitCode != 0)
+        {
+            Se.LogError($"{enginePrefix}: resample seed '{src}' exited with code {ffmpeg.ExitCode}; falling back to plain copy");
+            return false;
+        }
+
+        return IsUsable(dest);
+    }
+
+    private static bool IsUsable(string path)
+    {
+        try
+        {
+            return File.Exists(path) && new FileInfo(path).Length > 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch
+        {
+            // Best-effort. If it cannot be removed the fallback copy is skipped, but the
+            // failure that got us here is already logged above.
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
@@ -273,31 +273,9 @@ public class VoxCPM2CrispAsr : ITtsEngine
             {
                 var dest = Path.Combine(voicesFolder, Path.GetFileName(src));
 
-                if (!File.Exists(dest))
-                {
-                    try
-                    {
-                        // qwen3-tts.cpp voice pack ships at 16 kHz; resample to 24 kHz mono on
-                        // seed (crispasr upsamples to VoxCPM2's 48 kHz internally).
-                        var ffmpeg = FfmpegGenerator.ConvertToMono24kHzWav(src, dest);
-                        if (!ffmpeg.Start())
-                        {
-                            File.Copy(src, dest);
-                        }
-                        else
-                        {
-                            ffmpeg.WaitForExit();
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Se.LogError(ex, $"VoxCPM2 (CrispASR): resample seed '{src}' failed; falling back to plain copy");
-                        try { if (!File.Exists(dest))
-                        {
-                            File.Copy(src, dest);
-                        } } catch { }
-                    }
-                }
+                // qwen3-tts.cpp voice pack ships at 16 kHz; resample to 24 kHz mono on
+                // seed (crispasr upsamples to VoxCPM2's 48 kHz internally).
+                VoiceSeedHelper.CopyOrResample(src, dest, 24000, "VoxCPM2 (CrispASR)");
 
                 var sidecar = Path.ChangeExtension(src, ".txt");
                 if (File.Exists(sidecar))
@@ -378,13 +356,15 @@ public class VoxCPM2CrispAsr : ITtsEngine
         return true;
     }
 
-    public Task<Voice[]> GetVoices(string language)
+    public async Task<Voice[]> GetVoices(string language)
     {
         var result = new List<Voice>();
 
         // Voice cloning only — no built-in default voice. The combo is empty until the user
         // imports a reference WAV (or the qwen3-tts.cpp voice seed runs above).
-        var voicesFolder = GetSetVoicesFolder();
+        // Off the UI thread: GetSetVoicesFolder does one-time reference-WAV seeding through
+        // ffmpeg, and this is awaited from SelectedEngineChanged on the dispatcher.
+        var voicesFolder = await Task.Run(GetSetVoicesFolder);
         if (Directory.Exists(voicesFolder))
         {
             foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
@@ -394,7 +374,7 @@ public class VoxCPM2CrispAsr : ITtsEngine
             }
         }
 
-        return Task.FromResult(result.ToArray());
+        return result.ToArray();
     }
 
     public bool IsVoiceInstalled(Voice voice) => true;

--- a/tests/UI/Features/Video/TextToSpeech/Engines/VoiceSeedHelperTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/VoiceSeedHelperTests.cs
@@ -1,0 +1,123 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+namespace UITests.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// Voice seeding is best-effort and runs once per install, which is exactly why its failure
+/// modes are expensive: whatever it leaves in the voices folder is what the engine clones from
+/// for the rest of that install's life, and nothing retries it.
+///
+/// These tests do not need ffmpeg to be present - a source ffmpeg cannot decode and a missing
+/// ffmpeg both land on the same failure path, which is the one being pinned.
+/// </summary>
+public class VoiceSeedHelperTests : IDisposable
+{
+    private readonly string _folder = Path.Combine(
+        Path.GetTempPath(), "se-voice-seed-tests-" + Guid.NewGuid().ToString("N"));
+
+    public VoiceSeedHelperTests() => Directory.CreateDirectory(_folder);
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_folder, true);
+        }
+        catch
+        {
+            // Temp folder cleanup is not what these tests are about.
+        }
+    }
+
+    private string Path_(string name) => Path.Combine(_folder, name);
+
+    [Fact]
+    public void ExistingDestination_IsLeftAlone()
+    {
+        var src = Path_("src.wav");
+        var dest = Path_("dest.wav");
+        File.WriteAllText(src, "new");
+        File.WriteAllText(dest, "already seeded");
+
+        VoiceSeedHelper.CopyOrResample(src, dest, 24000, "Test");
+
+        Assert.Equal("already seeded", File.ReadAllText(dest));
+    }
+
+    /// <summary>
+    /// A failed conversion must still leave a usable voice behind. This is where the old code
+    /// went wrong: it guarded the fallback with "if the destination does not exist", so a
+    /// conversion that failed *after* opening its output (a kill, a timeout, a partial write)
+    /// left the truncated file in place and the copy never ran.
+    /// </summary>
+    [Fact]
+    public void FailedConversion_FallsBackToAVerbatimCopy()
+    {
+        var src = Path_("src.wav");
+        var dest = Path_("dest.wav");
+        File.WriteAllText(src, "not actually a wav, so ffmpeg cannot convert it");
+
+        VoiceSeedHelper.CopyOrResample(src, dest, 24000, "Test");
+
+        Assert.True(File.Exists(dest));
+        Assert.Equal(File.ReadAllBytes(src), File.ReadAllBytes(dest));
+    }
+
+    /// <summary>
+    /// Qwen3's Base backend rejects a reference at any rate but 24 kHz, so for it a failed
+    /// resample means "skip this voice" - and skipping must not leave the failed output behind
+    /// either, or the engine seeds a voice the server refuses.
+    /// </summary>
+    [Fact]
+    public void FailedConversion_WithoutCopyFallback_LeavesNothingBehind()
+    {
+        var src = Path_("src.wav");
+        var dest = Path_("dest.wav");
+        File.WriteAllText(src, "not actually a wav, so ffmpeg cannot convert it");
+
+        VoiceSeedHelper.CopyOrResample(src, dest, 24000, "Test", copyOnFailure: false);
+
+        Assert.False(File.Exists(dest));
+    }
+
+    [Fact]
+    public void RealWav_IsSeeded()
+    {
+        var src = Path_("src.wav");
+        var dest = Path_("dest.wav");
+        File.WriteAllBytes(src, MakeSilentWav(sampleRate: 8000, milliseconds: 50));
+
+        VoiceSeedHelper.CopyOrResample(src, dest, 24000, "Test");
+
+        // Resampled when ffmpeg is on the box, plain-copied when it is not - either way the
+        // voice has to end up in the folder as a non-empty file.
+        Assert.True(File.Exists(dest));
+        Assert.True(new FileInfo(dest).Length > 0);
+    }
+
+    private static byte[] MakeSilentWav(int sampleRate, int milliseconds)
+    {
+        var samples = sampleRate * milliseconds / 1000;
+        var dataBytes = samples * 2; // mono, 16-bit
+
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream);
+        writer.Write("RIFF"u8.ToArray());
+        writer.Write(36 + dataBytes);
+        writer.Write("WAVE"u8.ToArray());
+        writer.Write("fmt "u8.ToArray());
+        writer.Write(16);              // PCM header size
+        writer.Write((short)1);        // PCM
+        writer.Write((short)1);        // mono
+        writer.Write(sampleRate);
+        writer.Write(sampleRate * 2);  // byte rate
+        writer.Write((short)2);        // block align
+        writer.Write((short)16);       // bits per sample
+        writer.Write("data"u8.ToArray());
+        writer.Write(dataBytes);
+        writer.Write(new byte[dataBytes]);
+        writer.Flush();
+
+        return stream.ToArray();
+    }
+}


### PR DESCRIPTION
Two unrelated bugs found while reviewing the recent commits.

### SSA storage style menu read the file style list

`StoreContextMenuOpening` computed `IsDeleteVisible` / `IsDeleteAllVisible` from `FileStyles` and `SelectedFileStyle`, but those two flags drive **Delete** and **Clear** in the *storage* styles context menu. So the storage menu hid "Delete" whenever no file style happened to be selected, and offered "Clear" on an empty storage list as long as the file list was non-empty. The ASSA twin already reads `StorageStyles` / `SelectedStorageStyle`.

### TTS voice seeding froze the UI on ffmpeg

Selecting a CrispASR TTS engine calls `GetVoices` → `GetSetVoicesFolder` → the one-time reference-WAV seed, which runs ffmpeg per WAV with a `WaitForExit` that has no timeout. `GetVoices` was synchronous (`Task.FromResult`) and is awaited from `SelectedEngineChanged` on the dispatcher, so a user who had imported reference WAVs got a frozen window for the duration — and forever if a conversion hung.

`GetVoices` is now `async` and resolves the folder through `Task.Run` in all eight engines. For Qwen3 that also covers its extra in-place `NormalizeVoiceSampleRates` pass.

The per-WAV step was copy-pasted across all eight engines with the same two traps, so it moves into `VoiceSeedHelper` and is hardened there:

- the conversion gets a 60s timeout and the child is killed rather than left hanging
- a non-zero exit or an empty output counts as failure
- **the failed output is deleted before the fallback copy** — the old guard was `if (!File.Exists(dest))`, so a conversion that died after opening its output left a truncated WAV that every later run then accepted as a good voice, for the life of the install

Qwen3 keeps its own semantics via `copyOnFailure: false`: its Base backend rejects a reference at any rate but 24 kHz, so an unconvertible voice must be skipped, not copied at the wrong rate.

Four new tests in `VoiceSeedHelperTests` pin the contract; they don't require ffmpeg to be installed.

### Verification

`dotnet build src/ui/UI.csproj` — 0 errors, 0 warnings. `dotnet test tests/UI` — 1179/1179 pass.

Unrelated note: `SubtitleGridScrollPerformanceTests.HomeAndEnd_RealizeOnlyAViewportOfRows` is flaky on `main` independently of this branch (3 of 4 full-suite runs failed it on an unmodified tree locally). Worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)