### PR TITLE
Add a delay between requests to AI review

### DIFF
--- a/docs/features/ai-review.md
+++ b/docs/features/ai-review.md
@@ -28,7 +28,11 @@ If a local model is too slow on your machine, select the **OpenAI-compatible** e
 | OpenRouter | `https://openrouter.ai/api/v1/chat/completions` | `google/gemini-3.1-flash-lite` |
 | LM Studio (local) | `http://localhost:1234/v1/chat/completions` | *name shown in LM Studio* |
 
-The API key goes in the **API key** field - Subtitle Edit sends it as a bearer token. Note that the whole subtitle is sent in batches without a delay between them, so a rate limited free tier may start rejecting requests on a long file - press **Stop** to keep the suggestions found so far.
+The API key goes in the **API key** field - Subtitle Edit sends it as a bearer token.
+
+The subtitle is sent in batches, and free tiers usually limit how many requests you may send per minute. The timer field after the API key sets a **delay in seconds between requests** - raise it if the provider starts rejecting requests. It is off (0) by default, and the first request of a review never waits.
+
+Reviewing only part of a subtitle is also possible: select the lines in the subtitle grid, then right-click → **Selected lines** → **AI review...**.
 
 ## Reviewing
 

--- a/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
@@ -34,6 +34,7 @@ public partial class AiReviewViewModel : ObservableObject
     [ObservableProperty] private string _openAiCompatibleUrl;
     [ObservableProperty] private string _openAiCompatibleModel;
     [ObservableProperty] private string _openAiCompatibleApiKey;
+    [ObservableProperty] private int _requestDelaySeconds;
     [ObservableProperty] private ObservableCollection<LlamaCppModelDisplay> _llamaCppModels;
     [ObservableProperty] private LlamaCppModelDisplay? _selectedLlamaCppModel;
     [ObservableProperty] private string _languageDisplay;
@@ -73,6 +74,7 @@ public partial class AiReviewViewModel : ObservableObject
         OpenAiCompatibleUrl = Se.Settings.Tools.AiReview.OpenAiCompatibleUrl;
         OpenAiCompatibleModel = Se.Settings.Tools.AiReview.OpenAiCompatibleModel;
         OpenAiCompatibleApiKey = Se.Settings.Tools.AiReview.OpenAiCompatibleApiKey;
+        RequestDelaySeconds = Se.Settings.Tools.AiReview.RequestDelaySeconds;
         LlamaCppModels = new ObservableCollection<LlamaCppModelDisplay>();
         SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(
             LlamaCppModels,
@@ -242,6 +244,7 @@ public partial class AiReviewViewModel : ObservableObject
         settings.OpenAiCompatibleUrl = OpenAiCompatibleUrl.Trim();
         settings.OpenAiCompatibleModel = OpenAiCompatibleModel.Trim();
         settings.OpenAiCompatibleApiKey = OpenAiCompatibleApiKey.Trim();
+        settings.RequestDelaySeconds = RequestDelaySeconds;
         Se.SaveSettings();
     }
 
@@ -339,6 +342,29 @@ public partial class AiReviewViewModel : ObservableObject
         using var client = new AiReviewClient();
         var processedLines = 0;
         var consecutiveErrors = 0;
+        var delay = TimeSpan.FromSeconds(Math.Max(0, RequestDelaySeconds));
+        var lastRequestCompletedUtc = DateTime.MinValue;
+
+        // Cloud engines enforce strict requests-per-minute limits and answer with 429 when they are
+        // exceeded, so wait until the delay has passed since the previous request finished - the same
+        // rule auto-translate uses. The first request of a run never waits.
+        async Task<string> ChatWithDelayAsync(string content)
+        {
+            var remaining = delay - (DateTime.UtcNow - lastRequestCompletedUtc);
+            if (remaining > TimeSpan.Zero)
+            {
+                await Task.Delay(remaining, ct);
+            }
+
+            try
+            {
+                return await client.ChatAsync(url, model, systemPrompt, content, ct, apiKey);
+            }
+            finally
+            {
+                lastRequestCompletedUtc = DateTime.UtcNow;
+            }
+        }
 
         try
         {
@@ -353,12 +379,12 @@ public partial class AiReviewViewModel : ObservableObject
                 List<AiReviewChange>? changes = null;
                 try
                 {
-                    var reply = await client.ChatAsync(url, model, systemPrompt, userContent, ct, apiKey);
+                    var reply = await ChatWithDelayAsync(userContent);
                     changes = AiReviewProtocol.ParseChanges(reply, editableNumbers);
                     if (changes.Count == 0 && AiReviewProtocol.ExtractJsonObject(reply) == null)
                     {
                         // invalid reply - one retry for this chunk
-                        reply = await client.ChatAsync(url, model, systemPrompt, userContent, ct, apiKey);
+                        reply = await ChatWithDelayAsync(userContent);
                         changes = AiReviewProtocol.ParseChanges(reply, editableNumbers);
                     }
 

--- a/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
@@ -57,12 +57,27 @@ public class AiReviewWindow : Window
             .WithAccessibleName(Se.Language.General.ApiKey);
         textBoxOpenAiApiKey.PlaceholderText = Se.Language.General.ApiKey;
         textBoxOpenAiApiKey.PasswordChar = '\u25cf';
+
+        // Free cloud tiers rate limit hard, so the delay between requests lives next to the API key
+        // rather than in a settings dialog. The label would not fit the toolbar - a timer icon plus
+        // tooltip carries the meaning, and the accessible name keeps it readable for screen readers.
+        var numericDelay = UiUtil.MakeNumericUpDownInt(0, 600, 0, 70, vm, nameof(vm.RequestDelaySeconds))
+            .WithAccessibleName(Se.Language.Translate.DelayInSecondsBetweenRequests);
+        ToolTip.SetTip(numericDelay, Se.Language.Translate.DelayInSecondsBetweenRequests);
+        var iconDelay = new Optris.Icons.Avalonia.Icon
+        {
+            Value = "mdi-timer-outline",
+            FontSize = 16,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        ToolTip.SetTip(iconDelay, Se.Language.Translate.DelayInSecondsBetweenRequests);
+
         var panelOpenAiCompatible = new StackPanel
         {
             Orientation = Orientation.Horizontal,
             Spacing = 5,
             VerticalAlignment = VerticalAlignment.Center,
-            Children = { textBoxOpenAiUrl, textBoxOpenAiModel, textBoxOpenAiApiKey },
+            Children = { textBoxOpenAiUrl, textBoxOpenAiModel, textBoxOpenAiApiKey, iconDelay, numericDelay },
         };
         panelOpenAiCompatible.Bind(IsVisibleProperty, new Binding(nameof(vm.IsOpenAiCompatibleVisible)));
 

--- a/src/ui/Logic/Config/SeAiReview.cs
+++ b/src/ui/Logic/Config/SeAiReview.cs
@@ -11,6 +11,7 @@ public class SeAiReview
     public string OpenAiCompatibleApiKey { get; set; }
     public string Prompt { get; set; }
     public int MaxLinesPerBatch { get; set; }
+    public int RequestDelaySeconds { get; set; }
 
     public const string EngineOllama = "Ollama";
     public const string EngineLlamaCpp = "llama.cpp";
@@ -32,5 +33,6 @@ public class SeAiReview
         OpenAiCompatibleApiKey = string.Empty;
         Prompt = DefaultPrompt;
         MaxLinesPerBatch = 15;
+        RequestDelaySeconds = 0;
     }
 }


### PR DESCRIPTION
Follow-up to the [5.1.0 feedback in #12929](https://github.com/SubtitleEdit/subtitleedit/discussions/12929#discussioncomment-17864407), where a user wanted to run AI review against Gemini instead of a local model.

AI review sends the subtitle in batches with no pause between them. Free cloud tiers limit requests per minute and answer with 429, and after three consecutive failures the review stops - so a long subtitle could not be reviewed against a free key at all.

## Changes

- New **delay in seconds between requests** field in the OpenAI-compatible engine panel, next to the API key. A timer icon plus tooltip carries the label, which does not fit the toolbar; the accessible name is the full string.
- Stored as `SeAiReview.RequestDelaySeconds`, **0 (off) by default**, so local engines are unaffected.
- The wait uses the same rule as auto-translate ([`MergeAndSplitHelper`](https://github.com/SubtitleEdit/subtitleedit/blob/main/src/libuilogic/Translate/MergeAndSplitHelper.cs#L70)): wait until the delay has passed *since the previous request finished*, so the first request of a run never waits and a slow engine costs no extra time. The invalid-reply retry is throttled too.
- Reuses the existing `Translate.DelayInSecondsBetweenRequests` string, so no new translations are needed.
- Docs: the new field and the selected-lines entry point are documented in `docs/features/ai-review.md`.

## Testing

- `dotnet build src/ui/UI.csproj` - clean.
- `dotnet test tests/UI/UITests.csproj --filter AiReview` - 15/15 pass.
- The delay itself is a local function inside `Review()`, matching how auto-translate keeps its equivalent private and untested; no unit test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
