### PR TITLE
Fix two flaky UI tests

### DIFF
--- a/tests/UI/Features/Files/ImportPlainText/ForcedAlignerTests.cs
+++ b/tests/UI/Features/Files/ImportPlainText/ForcedAlignerTests.cs
@@ -17,6 +17,40 @@ public class ForcedAlignerTests
     }
 
     /// <summary>
+    /// Records progress reports on the reporting thread, synchronously.
+    /// <para>
+    /// <see cref="Progress{T}"/> posts to the captured synchronization context instead, so the
+    /// reports land some unknown time after the run finishes - the test used to sleep 200 ms and
+    /// hope, which failed under load, and appended to a plain List from a pool thread while the
+    /// assertions read it. Reporting inline removes both problems: nothing here needs the
+    /// callbacks marshalled anywhere.
+    /// </para>
+    /// </summary>
+    private sealed class CollectingProgress : IProgress<ForcedAligner.Progress>
+    {
+        private readonly List<ForcedAligner.Progress> _reports = new();
+
+        public IReadOnlyList<ForcedAligner.Progress> Reports
+        {
+            get
+            {
+                lock (_reports)
+                {
+                    return _reports.ToList();
+                }
+            }
+        }
+
+        public void Report(ForcedAligner.Progress value)
+        {
+            lock (_reports)
+            {
+                _reports.Add(value);
+            }
+        }
+    }
+
+    /// <summary>
     /// Stands in for ffmpeg: reports a duration and hands out window file names without
     /// touching the disk for audio.
     /// </summary>
@@ -216,14 +250,12 @@ public class ForcedAlignerTests
         try
         {
             var audio = new FakeAudio(1200, folder);
-            var reports = new List<ForcedAligner.Progress>();
-            var progress = new Progress<ForcedAligner.Progress>(p => reports.Add(p));
+            var progress = new CollectingProgress();
 
             await new ForcedAligner(new FakeRunner(240), audio)
                 .AlignAsync(Script(300), progress, TestContext.Current.CancellationToken);
 
-            // Progress<T> marshals asynchronously; give the posted callbacks a moment.
-            await Task.Delay(200, TestContext.Current.CancellationToken);
+            var reports = progress.Reports;
 
             Assert.NotEmpty(reports);
             Assert.All(reports, r => Assert.Equal(300, r.LinesTotal));

--- a/tests/UI/Features/Main/SubtitleGridScrollPerformanceTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridScrollPerformanceTests.cs
@@ -95,6 +95,17 @@ public class SubtitleGridScrollPerformanceTests
 
         int Press(PhysicalKey key)
         {
+            // Re-anchor focus on the grid before every press. KeyPressQwerty routes through the
+            // application-wide focused element, and that leaks between headless tests: closing a
+            // window does not clear it, so a detached row container from an earlier test can
+            // still be "focused". The panel recycling this grid's focused row during a jump then
+            // hands focus back to that stale row, and every later press lands there instead -
+            // the test failed with realized=0 and an unchanged SelectedIndex, at a different
+            // round each run. What this test measures is how many rows a jump realizes, not how
+            // Avalonia routes keys, so pin the focus rather than depend on it.
+            TableViewExtras.FocusRow(grid);
+            Dispatcher.UIThread.RunJobs();
+
             prepared = 0;
             window.KeyPressQwerty(key, RawInputModifiers.None);
             Settle(window);


### PR DESCRIPTION
Between them these two failed roughly 3 full-suite runs in 10 locally. 15 consecutive runs pass with the fixes.

### `SubtitleGridScrollPerformanceTests.HomeAndEnd_RealizeOnlyAViewportOfRows`

Failed with `realized=0` and an unchanged `SelectedIndex`, at a different round each run — the key press reached nothing at all.

Instrumenting the focused element showed why: it was a `TableViewRow` belonging to a `TableView` with 5000 items that is **not in this window** — a detached row container from an earlier test's `MainView`. Closing a window does not clear the application-wide focused element, so that stale row survives into the next test. When the panel recycles this grid's focused row during a jump, focus falls back to the stale one, and every later press lands there instead.

`KeyPressQwerty` routes through that application-wide focused element, so the test was hostage to it. Since what the test measures is how many rows a jump realizes — not how Avalonia routes keys — it now re-anchors focus on the grid before each press.

Not a product bug: the stale target only exists because a second `MainView` was built in the same process. In the app the existing `Post(() => FocusRow(...))` in `AttachListNavigation` still covers the recycled-row case.

I first tried clearing focus in a test teardown instead; that made it *worse* (7 failures in 12), so it was reverted.

### `ForcedAlignerTests.ProgressIsReportedPerWindow`

Used `Progress<T>`, which posts to the captured synchronization context, then slept 200 ms and hoped the callbacks had arrived — and appended to a plain `List<T>` from a pool thread while the assertions read it. Now reports inline through a small `IProgress<T>`: nothing to wait for, no `List` shared across threads, and the delay is gone.

### Verification

`dotnet build` — 0 errors, 0 warnings. 15 consecutive full `dotnet test tests/UI` runs, 1179/1179 each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)