### PR TITLE
Fix the Windows installer build failing on libonigwrap.dll

### DIFF
--- a/installer/WindowsInno/Subtitle_Edit_Installer.iss
+++ b/installer/WindowsInno/Subtitle_Edit_Installer.iss
@@ -135,7 +135,6 @@ Name: reset_settings;     Description: {cm:tsk_ResetSettings};  GroupDescription
 Source: {#bindir}\SubtitleEdit.exe;      DestDir: {app}; Flags: ignoreversion
 Source: {#bindir}\av_libglesv2.dll;      DestDir: {app}; Flags: ignoreversion
 Source: {#bindir}\libHarfBuzzSharp.dll;  DestDir: {app}; Flags: ignoreversion
-Source: {#bindir}\libonigwrap.dll;       DestDir: {app}; Flags: ignoreversion
 Source: {#bindir}\libSkiaSharp.dll;      DestDir: {app}; Flags: ignoreversion
 Source: ..\..\change-log.txt;            DestDir: {app}; Flags: ignoreversion
 Source: ..\LICENSE.rtf;                  DestDir: {app}; Flags: ignoreversion


### PR DESCRIPTION
The v5.2.0-beta1 release build failed in `build-windows` at the **Build Inno Setup installer** step ([run 30736405156](https://github.com/SubtitleEdit/subtitleedit/actions/runs/30736405156/job/91465861418)).

[ca2bfa49cd](https://github.com/SubtitleEdit/subtitleedit/commit/ca2bfa49cd) replaced AvaloniaEdit with the virtualizing syntax editor and dropped the `AvaloniaEdit.TextMate` package. That package was what pulled in TextMateSharp and its native `libonigwrap.dll`, so the publish output no longer contains the file - but `Subtitle_Edit_Installer.iss` still listed it under `[Files]`, and ISCC fails hard on a missing source.

Nothing in the tree references TextMate or onigwrap any more, so the line is simply removed. The other three native DLLs in the list (`av_libglesv2`, `libHarfBuzzSharp`, `libSkiaSharp`) still come from Avalonia/SkiaSharp and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
