### PR TITLE
Add type-to-search to all combo boxes

### DIFF
--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -30,6 +30,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Nikse.SubtitleEdit.Logic;
 
@@ -761,6 +762,86 @@ public static class UiUtil
         }
 
         return comboBox;
+    }
+
+    private sealed class ComboBoxTypeSearchState
+    {
+        public string Prefix = string.Empty;
+        public long LastTypedTicks;
+    }
+
+    private static readonly ConditionalWeakTable<ComboBox, ComboBoxTypeSearchState> ComboBoxTypeSearchStates = new();
+
+    /// <summary>
+    /// App-wide: lets the user jump to a drop-down item by typing its first letters
+    /// (e.g. "Ar" selects "Arial"), like a classic WinForms combo box. Repeating the
+    /// same letter cycles through items starting with it; the typed prefix resets
+    /// after a short pause. Call once at startup.
+    /// </summary>
+    public static void EnableComboBoxTypeSearch()
+    {
+        InputElement.TextInputEvent.AddClassHandler<ComboBox>(ComboBoxTypeSearchTextInput, RoutingStrategies.Tunnel);
+    }
+
+    private static void ComboBoxTypeSearchTextInput(ComboBox comboBox, TextInputEventArgs e)
+    {
+        if (comboBox.IsEditable)
+        {
+            return; // typing must edit the text, not jump the selection
+        }
+
+        var text = e.Text;
+        if (string.IsNullOrEmpty(text) || char.IsControl(text[0]))
+        {
+            return;
+        }
+
+        var state = ComboBoxTypeSearchStates.GetOrCreateValue(comboBox);
+        var nowTicks = Environment.TickCount64;
+        if (nowTicks - state.LastTypedTicks > 1200)
+        {
+            state.Prefix = string.Empty;
+        }
+        state.LastTypedTicks = nowTicks;
+        state.Prefix += text;
+
+        var items = comboBox.Items;
+        if (items.Count == 0)
+        {
+            return;
+        }
+
+        var index = FindItemStartingWith(items, state.Prefix, startIndex: 0);
+        if (index < 0 && state.Prefix.Length > 1 && state.Prefix.All(c => char.ToLowerInvariant(c) == char.ToLowerInvariant(state.Prefix[0])))
+        {
+            // Same letter repeated: cycle through items starting with that letter.
+            state.Prefix = state.Prefix[..1];
+            index = FindItemStartingWith(items, state.Prefix, startIndex: comboBox.SelectedIndex + 1);
+            if (index < 0)
+            {
+                index = FindItemStartingWith(items, state.Prefix, startIndex: 0);
+            }
+        }
+
+        if (index >= 0)
+        {
+            comboBox.SelectedIndex = index;
+            e.Handled = true;
+        }
+    }
+
+    private static int FindItemStartingWith(IList items, string prefix, int startIndex)
+    {
+        for (var i = Math.Max(0, startIndex); i < items.Count; i++)
+        {
+            var display = items[i]?.ToString();
+            if (display != null && display.StartsWith(prefix, StringComparison.CurrentCultureIgnoreCase))
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     internal static ComboBox MakeComboBoxBindText<T>(ObservableCollection<T> sourceItems, object vm, string textPath,

--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -185,6 +185,9 @@ namespace Nikse.SubtitleEdit
                 // Set current theme
                 UiTheme.SetCurrentTheme();
 
+                // Type-to-search in all drop-downs (e.g. typing "Ar" selects "Arial")
+                UiUtil.EnableComboBoxTypeSearch();
+
                 // Setup main window (Batch Convert standalone if requested via CLI)
                 if (HasBatchConvertUiArg(args))
                 {


### PR DESCRIPTION
Typing in any drop-down now jumps to the first item starting with the typed letters - e.g. typing "Ar" in a font selector selects "Arial", like the classic WinForms combo box in SE 4.

- Repeating the same letter cycles through items starting with it
- The typed prefix resets after a 1.2 s pause
- Works with the dropdown closed or open
- Matches on the display string, so enum/object-based combos work too
- Registered once at startup as a global `TextInput` class handler on `ComboBox`, so every current and future drop-down gets it automatically; editable combos are skipped so typing still edits their text

Requested in discussion #13080.

🤖 Generated with [Claude Code](https://claude.com/claude-code)