### PR TITLE
Don't uppercase the word after an abbreviation period (#13082)

### DIFF
--- a/Dictionaries/nl_abbreviations.xml
+++ b/Dictionaries/nl_abbreviations.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Dutch abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (o.a., i.p.v.,
+  d.w.z., m.b.t.) are already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>afb.</Item>
+  <Item>afd.</Item>
+  <Item>art.</Item>
+  <Item>bijv.</Item>
+  <Item>bijz.</Item>
+  <Item>blz.</Item>
+  <Item>bv.</Item>
+  <Item>ca.</Item>
+  <Item>dhr.</Item>
+  <Item>div.</Item>
+  <Item>dl.</Item>
+  <Item>dr.</Item>
+  <Item>drs.</Item>
+  <Item>ds.</Item>
+  <Item>enz.</Item>
+  <Item>etc.</Item>
+  <Item>evt.</Item>
+  <Item>excl.</Item>
+  <Item>fam.</Item>
+  <Item>geb.</Item>
+  <Item>gem.</Item>
+  <Item>hfdst.</Item>
+  <Item>incl.</Item>
+  <Item>ing.</Item>
+  <Item>ir.</Item>
+  <Item>jl.</Item>
+  <Item>jr.</Item>
+  <Item>max.</Item>
+  <Item>mej.</Item>
+  <Item>mevr.</Item>
+  <Item>min.</Item>
+  <Item>mld.</Item>
+  <Item>mln.</Item>
+  <Item>mr.</Item>
+  <Item>mw.</Item>
+  <Item>nl.</Item>
+  <Item>nr.</Item>
+  <Item>ong.</Item>
+  <Item>opm.</Item>
+  <Item>pag.</Item>
+  <Item>prof.</Item>
+  <Item>resp.</Item>
+  <Item>tel.</Item>
+  <Item>vgl.</Item>
+  <Item>vnl.</Item>
+  <Item>zgn.</Item>
+  <Item>zn.</Item>
+</Abbreviations>

--- a/src/libse/Dictionaries/AbbreviationList.cs
+++ b/src/libse/Dictionaries/AbbreviationList.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml;
+
+namespace Nikse.SubtitleEdit.Core.Dictionaries
+{
+    /// <summary>
+    /// Language specific abbreviations like "dhr." or "enz.", used to tell an abbreviation period
+    /// apart from a sentence ending so the following word is not capitalized (issue #13082).
+    ///
+    /// Read from "&lt;two-letter-iso&gt;_abbreviations.xml" in the dictionary folder, e.g.
+    /// "nl_abbreviations.xml", plus an optional region specific file like
+    /// "pt_BR_abbreviations.xml". Names ending with a period (e.g. "Dr." in names.xml) are a
+    /// second source and are added by the names list itself.
+    /// </summary>
+    public static class AbbreviationList
+    {
+        /// <summary>
+        /// Returns a case insensitive set of abbreviations (each including the trailing period)
+        /// for the given language. Never null; an empty set when there is no list for it.
+        /// </summary>
+        public static HashSet<string> Load(string dictionaryFolder, string languageName)
+        {
+            // Case insensitive: subtitles use both "Dr." and "dr.", and it is an abbreviation
+            // either way - so a single entry per abbreviation is enough in the xml files.
+            var abbreviations = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrEmpty(dictionaryFolder) || string.IsNullOrEmpty(languageName))
+            {
+                return abbreviations;
+            }
+
+            // Converts e.g. nl_NL => nl (neutral culture).
+            var twoLetterIsoLanguageName = languageName.Length > 2 ? languageName.Substring(0, 2) : languageName;
+            AddFromFile(abbreviations, Path.Combine(dictionaryFolder, twoLetterIsoLanguageName + "_abbreviations.xml"));
+            if (languageName.Length > 2)
+            {
+                AddFromFile(abbreviations, Path.Combine(dictionaryFolder, languageName + "_abbreviations.xml"));
+            }
+
+            return abbreviations;
+        }
+
+        private static void AddFromFile(HashSet<string> abbreviations, string fileName)
+        {
+            if (!File.Exists(fileName))
+            {
+                return;
+            }
+
+            try
+            {
+                var doc = new XmlDocument { XmlResolver = null };
+                doc.Load(fileName);
+                var nodes = doc.DocumentElement?.SelectNodes("Item");
+                if (nodes == null)
+                {
+                    return;
+                }
+
+                foreach (XmlNode node in nodes)
+                {
+                    var abbreviation = node.InnerText.Trim();
+                    if (abbreviation.Length > 1 && abbreviation.EndsWith('.'))
+                    {
+                        abbreviations.Add(abbreviation);
+                    }
+                }
+            }
+            catch (Exception exception)
+            {
+                System.Diagnostics.Debug.WriteLine("AbbreviationList: Unable to read " + fileName + ": " + exception.Message);
+            }
+        }
+    }
+}

--- a/src/libse/Forms/FixCommonErrors/EmptyFixCallback.cs
+++ b/src/libse/Forms/FixCommonErrors/EmptyFixCallback.cs
@@ -60,9 +60,15 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 
         public Encoding Encoding { get; set; } = Encoding.UTF8;
 
+        /// <summary>
+        /// Abbreviations like "dhr." or "U.S." - empty unless the caller fills it in, e.g. from
+        /// <see cref="Dictionaries.AbbreviationList"/> and the names list.
+        /// </summary>
+        public HashSet<string> Abbreviations { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         public HashSet<string> GetAbbreviations()
         {
-            return new HashSet<string>();
+            return Abbreviations;
         }
 
         public bool DoSpell(string word)

--- a/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterParagraph.cs
+++ b/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterParagraph.cs
@@ -1,7 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
-using System.Text;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 {
@@ -22,7 +21,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                 Paragraph prev = subtitle.GetParagraphOrDefault(i - 1);
 
                 string oldText = p.Text;
-                string fixedText = DoFix(new Paragraph(p), prev, callbacks.Encoding, callbacks.Language);
+                string fixedText = DoFix(new Paragraph(p), prev, callbacks);
 
                 if (oldText != fixedText && callbacks.AllowFix(p, fixAction))
                 {
@@ -34,8 +33,11 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             callbacks.UpdateFixStatus(fixedStartWithUppercaseLetterAfterParagraphTicked, fixAction);
         }
 
-        private static string DoFix(Paragraph p, Paragraph prev, Encoding encoding, string language)
+        private static string DoFix(Paragraph p, Paragraph prev, IFixCallbacks callbacks)
         {
+            var encoding = callbacks.Encoding;
+            var language = callbacks.Language;
+
             if (p.Text != null && p.Text.Length > 1)
             {
                 string text = p.Text;
@@ -101,10 +103,9 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                 if (!isUrl && !char.IsDigit(firstLetter) && isPrevEndOfLine &&
                     (char.IsLower(firstLetter) || Helper.IsTurkishLittleI(firstLetter, encoding, language) || DutchCasing.IsDutch(language)))
                 {
-                    bool isMatchInKnowAbbreviations = language == "en" &&
-                        (prevText.EndsWith(" o.r.", StringComparison.Ordinal) ||
-                         prevText.EndsWith(" a.m.", StringComparison.Ordinal) ||
-                         prevText.EndsWith(" p.m.", StringComparison.Ordinal));
+                    // The previous subtitle can end in an abbreviation ("Ik sprak met dhr.") and
+                    // then this one continues the same sentence - do not capitalize it (#13082).
+                    bool isMatchInKnowAbbreviations = Helper.EndsWithAbbreviation(prevText, callbacks);
 
                     if (!isMatchInKnowAbbreviations)
                     {
@@ -186,10 +187,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                         isPrevEndOfLine &&
                         (char.IsLower(firstLetter) || Helper.IsTurkishLittleI(firstLetter, encoding, language) || DutchCasing.IsDutch(language)))
                     {
-                        bool isMatchInKnowAbbreviations = language == "en" &&
-                            (prevText.EndsWith(" o.r.", StringComparison.Ordinal) ||
-                             prevText.EndsWith(" a.m.", StringComparison.Ordinal) ||
-                             prevText.EndsWith(" p.m.", StringComparison.Ordinal));
+                        // Same as above, but for line one ending in an abbreviation.
+                        bool isMatchInKnowAbbreviations = Helper.EndsWithAbbreviation(prevText, callbacks);
 
                         if (!isMatchInKnowAbbreviations)
                         {

--- a/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterPeriodInsideParagraph.cs
+++ b/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterPeriodInsideParagraph.cs
@@ -13,28 +13,6 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 
         private static readonly char[] ExpectedChars = { '.', '!', '?' };
 
-        private bool IsAbbreviation(string text, int index, IFixCallbacks callbacks)
-        {
-            if (text[index] != '.')
-            {
-                return false;
-            }
-
-            if (index - 3 > 0 && char.IsLetterOrDigit(text[index - 1]) && text[index - 2] == '.') // e.g: O.R.
-            {
-                return true;
-            }
-
-            var word = string.Empty;
-            int i = index - 1;
-            while (i >= 0 && char.IsLetter(text[i]))
-            {
-                word = text[i--] + word;
-            }
-
-            return callbacks.GetAbbreviations().Contains(word + ".");
-        }
-
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {
             string fixAction = Language.StartWithUppercaseLetterAfterPeriodInsideParagraph;
@@ -69,7 +47,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                             }
                         }
 
-                        if (start + 3 < text.Length && (text[start + 1] == ' ') && !IsAbbreviation(text, start, callbacks))
+                        if (start + 3 < text.Length && (text[start + 1] == ' ') && !Helper.IsAbbreviation(text, start, callbacks))
                         {
                             var textBefore = text.Substring(0, start + 1);
                             var afterText = text.Substring(start + 2);

--- a/src/libse/Forms/FixCommonErrors/Helper.cs
+++ b/src/libse/Forms/FixCommonErrors/Helper.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 using System.Linq;
 using System.Text;
@@ -7,6 +8,41 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 {
     public static class Helper
     {
+        /// <summary>
+        /// True if the period at <paramref name="index"/> ends an abbreviation ("dhr.", "O.R.")
+        /// rather than a sentence, so the next word must not be capitalized.
+        /// </summary>
+        public static bool IsAbbreviation(string text, int index, IFixCallbacks callbacks)
+        {
+            if (string.IsNullOrEmpty(text) || index < 0 || index >= text.Length || text[index] != '.')
+            {
+                return false;
+            }
+
+            if (index - 3 > 0 && char.IsLetterOrDigit(text[index - 1]) && text[index - 2] == '.') // e.g: O.R.
+            {
+                return true;
+            }
+
+            var word = string.Empty;
+            var i = index - 1;
+            while (i >= 0 && char.IsLetter(text[i]))
+            {
+                word = text[i--] + word;
+            }
+
+            return callbacks.GetAbbreviations().Contains(word + ".");
+        }
+
+        /// <summary>
+        /// True if <paramref name="text"/> ends with an abbreviation, e.g. a subtitle line ending
+        /// in "Ik sprak met dhr." where the next line continues the same sentence.
+        /// </summary>
+        public static bool EndsWithAbbreviation(string text, IFixCallbacks callbacks)
+        {
+            return !string.IsNullOrEmpty(text) && IsAbbreviation(text, text.Length - 1, callbacks);
+        }
+
         public static bool IsTurkishLittleI(char firstLetter, Encoding encoding, string language)
         {
             if (language != "tr")

--- a/src/seconv/Core/FixCommonErrorsRunner.cs
+++ b/src/seconv/Core/FixCommonErrorsRunner.cs
@@ -1,4 +1,5 @@
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Dictionaries;
 using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
@@ -144,6 +145,10 @@ internal static class FixCommonErrorsRunner
         var callbacks = new EmptyFixCallback
         {
             Language = language,
+
+            // Without this the uppercase-after-period rules treat every abbreviation period as a
+            // sentence ending, e.g. Dutch "dhr. de vries" -> "dhr. De vries" (#13082).
+            Abbreviations = AbbreviationList.Load(SpellCheckConfig.DictionariesFolder(), language),
         };
 
         // Fix Common Errors is not idempotent in a single pass: one rule can create a

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -84,6 +84,8 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
     private int _totalFixes;
     private SubtitleFormat _subtitleFormat;
     private readonly INamesList _namesList;
+    private string? _namesListFolder;
+    private string? _namesListLanguage;
     private readonly IWindowService _windowService;
     private readonly IOcrFixEngine _ocrFixEngine;
 
@@ -595,6 +597,8 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
             return;
         }
 
+        LoadNamesListIfNeeded();
+
         _totalErrors = 0;
         _allowedFixLookup = null; // fix selection may have changed since the last pass
 
@@ -1016,6 +1020,26 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
             _totalFixes += fixes;
             //            LogStatus(message, string.Format(LanguageSettings.Current.FixCommonErrors.XFixesApplied, fixes));
         }
+    }
+
+    /// <summary>
+    /// The names list backs <see cref="IsName"/> and <see cref="GetAbbreviations"/>, so without
+    /// this the rules saw no names and no abbreviations at all - e.g. Dutch "dhr. de vries" was
+    /// capitalized to "dhr. De vries" (#13082). Reloaded only when the language changes, like
+    /// the batch converter does.
+    /// </summary>
+    private void LoadNamesListIfNeeded()
+    {
+        var dictionaryFolder = Se.DictionariesFolder;
+        if (string.Equals(_namesListFolder, dictionaryFolder, StringComparison.Ordinal) &&
+            string.Equals(_namesListLanguage, Language, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _namesList.Load(dictionaryFolder, Language);
+        _namesListFolder = dictionaryFolder;
+        _namesListLanguage = Language;
     }
 
     public bool IsName(string candidate)

--- a/src/ui/Logic/Dictionaries/SeNamesList.cs
+++ b/src/ui/Logic/Dictionaries/SeNamesList.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Xml;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Dictionaries;
 
 namespace Nikse.SubtitleEdit.Logic.Dictionaries;
 
@@ -13,7 +14,10 @@ public class SeNamesList : INamesList
     private HashSet<string> _namesMultiList = new();
     private HashSet<string> _namesMultiListUppercase = new();
     private HashSet<string> _blackList = new();
-    private readonly HashSet<string> _abbreviationList = new();
+
+    // Case insensitive: "dr." is as much an abbreviation as "Dr.", and the name lists only
+    // carry the capitalized form.
+    private readonly HashSet<string> _abbreviationList = new(StringComparer.OrdinalIgnoreCase);
     public string LanguageName { get; private set; } = "en";
 
     public void Load(string dictionaryFolder, string languageCode)
@@ -56,6 +60,12 @@ public class SeNamesList : INamesList
             {
                 _abbreviationList.Add(name);
             }
+        }
+
+        // e.g. nl_abbreviations.xml - abbreviations that are not names ("enz.", "ca.", "nr.").
+        foreach (var abbreviation in AbbreviationList.Load(_dictionaryFolder, languageCode))
+        {
+            _abbreviationList.Add(abbreviation);
         }
     }
 

--- a/tests/UI/Logic/Dictionaries/SeNamesListAbbreviationsTests.cs
+++ b/tests/UI/Logic/Dictionaries/SeNamesListAbbreviationsTests.cs
@@ -1,0 +1,84 @@
+using Nikse.SubtitleEdit.Logic.Dictionaries;
+
+namespace UITests.Logic.Dictionaries;
+
+public class SeNamesListAbbreviationsTests : IDisposable
+{
+    private readonly string _folder = Path.Combine(Path.GetTempPath(), "se-nameslist-" + Guid.NewGuid().ToString("N"));
+
+    public SeNamesListAbbreviationsTests()
+    {
+        Directory.CreateDirectory(_folder);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_folder, true);
+        }
+        catch
+        {
+            // temp folder cleanup is best effort
+        }
+    }
+
+    private void WriteNames(string fileName, params string[] names)
+    {
+        var xml = "<names>" + string.Concat(names.Select(n => "<name>" + n + "</name>")) + "</names>";
+        File.WriteAllText(Path.Combine(_folder, fileName), xml);
+    }
+
+    private void WriteAbbreviations(string fileName, params string[] items)
+    {
+        var xml = "<Abbreviations>" + string.Concat(items.Select(i => "<Item>" + i + "</Item>")) + "</Abbreviations>";
+        File.WriteAllText(Path.Combine(_folder, fileName), xml);
+    }
+
+    // Names ending with a period stay a source of abbreviations, but "Dr." must also match "dr.".
+    [Fact]
+    public void NameAbbreviationsMatchCaseInsensitively()
+    {
+        WriteNames("names.xml", "Dr.", "Mr.", "Robert");
+
+        var namesList = new SeNamesList();
+        namesList.Load(_folder, "nl");
+
+        var abbreviations = namesList.GetAbbreviations();
+        Assert.Contains("dr.", abbreviations);
+        Assert.Contains("Dr.", abbreviations);
+        Assert.DoesNotContain("Robert", abbreviations);
+    }
+
+    // Abbreviations that are not names come from <lang>_abbreviations.xml (#13082).
+    [Fact]
+    public void LoadsLanguageAbbreviationFile()
+    {
+        WriteNames("names.xml", "Dr.");
+        WriteAbbreviations("nl_abbreviations.xml", "dhr.", "enz.");
+
+        var namesList = new SeNamesList();
+        namesList.Load(_folder, "nl");
+
+        var abbreviations = namesList.GetAbbreviations();
+        Assert.Contains("dhr.", abbreviations);
+        Assert.Contains("Enz.", abbreviations);
+        Assert.Contains("Dr.", abbreviations);
+    }
+
+    // A second Load must not keep the previous language's abbreviations.
+    [Fact]
+    public void ReloadReplacesPreviousLanguageAbbreviations()
+    {
+        WriteAbbreviations("nl_abbreviations.xml", "dhr.");
+        WriteAbbreviations("es_abbreviations.xml", "sr.");
+
+        var namesList = new SeNamesList();
+        namesList.Load(_folder, "nl");
+        namesList.Load(_folder, "es");
+
+        var abbreviations = namesList.GetAbbreviations();
+        Assert.Contains("sr.", abbreviations);
+        Assert.DoesNotContain("dhr.", abbreviations);
+    }
+}

--- a/tests/libse/Dictionaries/AbbreviationListTest.cs
+++ b/tests/libse/Dictionaries/AbbreviationListTest.cs
@@ -1,0 +1,102 @@
+using Nikse.SubtitleEdit.Core.Dictionaries;
+
+namespace LibSETests.Dictionaries;
+
+public class AbbreviationListTest : IDisposable
+{
+    private readonly string _folder = Path.Combine(Path.GetTempPath(), "se-abbr-" + Guid.NewGuid().ToString("N"));
+
+    public AbbreviationListTest()
+    {
+        Directory.CreateDirectory(_folder);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_folder, true);
+        }
+        catch
+        {
+            // temp folder cleanup is best effort
+        }
+    }
+
+    private void WriteList(string fileName, params string[] items)
+    {
+        var xml = "<Abbreviations>" + string.Concat(items.Select(i => "<Item>" + i + "</Item>")) + "</Abbreviations>";
+        File.WriteAllText(Path.Combine(_folder, fileName), xml);
+    }
+
+    [Fact]
+    public void LoadsTwoLetterLanguageFile()
+    {
+        WriteList("nl_abbreviations.xml", "dhr.", "enz.");
+
+        var list = AbbreviationList.Load(_folder, "nl");
+
+        Assert.Equal(2, list.Count);
+        Assert.Contains("dhr.", list);
+        Assert.Contains("enz.", list);
+    }
+
+    [Fact]
+    public void MatchesCaseInsensitively()
+    {
+        WriteList("nl_abbreviations.xml", "dhr.");
+
+        var list = AbbreviationList.Load(_folder, "nl");
+
+        Assert.Contains("Dhr.", list);
+        Assert.Contains("DHR.", list);
+    }
+
+    // A region specific language name loads both the neutral and the region file, like the names list.
+    [Fact]
+    public void LoadsNeutralAndRegionFile()
+    {
+        WriteList("pt_abbreviations.xml", "sr.");
+        WriteList("pt_BR_abbreviations.xml", "vosmecê.");
+
+        var list = AbbreviationList.Load(_folder, "pt_BR");
+
+        Assert.Contains("sr.", list);
+        Assert.Contains("vosmecê.", list);
+    }
+
+    // Entries without a trailing period would never match and are dropped.
+    [Fact]
+    public void IgnoresEntriesWithoutTrailingPeriod()
+    {
+        WriteList("nl_abbreviations.xml", "dhr.", "dhr", ".", "");
+
+        var list = AbbreviationList.Load(_folder, "nl");
+
+        Assert.Equal(new[] { "dhr." }, list.ToArray());
+    }
+
+    [Theory]
+    [InlineData("xx")] // no file for this language
+    [InlineData("")]
+    [InlineData(null)]
+    public void ReturnsEmptySetWhenThereIsNoList(string? languageName)
+    {
+        Assert.Empty(AbbreviationList.Load(_folder, languageName!));
+    }
+
+    [Fact]
+    public void ReturnsEmptySetForMissingFolder()
+    {
+        Assert.Empty(AbbreviationList.Load(Path.Combine(_folder, "does-not-exist"), "nl"));
+    }
+
+    // A broken file must not take down "Fix common errors".
+    [Fact]
+    public void ReturnsEmptySetForInvalidXml()
+    {
+        File.WriteAllText(Path.Combine(_folder, "nl_abbreviations.xml"), "<Abbreviations><Item>dhr.");
+
+        Assert.Empty(AbbreviationList.Load(_folder, "nl"));
+    }
+}

--- a/tests/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterParagraphTest.cs
+++ b/tests/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterParagraphTest.cs
@@ -1,0 +1,64 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
+
+namespace LibSETests.Forms.FixCommonErrors;
+
+public class FixStartWithUppercaseLetterAfterParagraphTest
+{
+    /// <summary>
+    /// Fixes <paramref name="text"/> with <paramref name="previous"/> as the preceding subtitle
+    /// and returns the fixed text.
+    /// </summary>
+    private static string Fix(string previous, string text, string language, params string[] abbreviations)
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(previous, 0, 2000));
+        subtitle.Paragraphs.Add(new Paragraph(text, 2100, 4000));
+        subtitle.Renumber();
+        var callbacks = new EmptyFixCallback
+        {
+            Language = language,
+            Abbreviations = new HashSet<string>(abbreviations, StringComparer.OrdinalIgnoreCase),
+        };
+        new FixStartWithUppercaseLetterAfterParagraph().Fix(subtitle, callbacks);
+        return subtitle.Paragraphs[1].Text;
+    }
+
+    // The previous subtitle ends in an abbreviation, so this one continues the same sentence (#13082).
+    [Fact]
+    public void KeepsLowercaseWhenPreviousParagraphEndsWithAbbreviation()
+    {
+        Assert.Equal("de vries gisteren.", Fix("Ik sprak met dhr.", "de vries gisteren.", "nl", "dhr."));
+    }
+
+    // Same, but the abbreviation ends line one of a two-line subtitle.
+    [Fact]
+    public void KeepsLowercaseWhenFirstLineEndsWithAbbreviation()
+    {
+        var text = "Ik sprak met dhr." + Environment.NewLine + "de vries gisteren.";
+        Assert.Equal(text, Fix("Vorige regel.", text, "nl", "dhr."));
+    }
+
+    // Multi-dot abbreviations are recognized without being listed.
+    [Fact]
+    public void KeepsLowercaseAfterMultiDotAbbreviation()
+    {
+        Assert.Equal("he is asleep.", Fix("It is 5 a.m.", "he is asleep.", "en"));
+    }
+
+    // A real sentence ending must still be fixed.
+    [Fact]
+    public void CapitalizesAfterSentenceEnding()
+    {
+        Assert.Equal("And this starts.", Fix("This ends here.", "and this starts.", "en", "dr."));
+    }
+
+    // ...also on line two of a two-line subtitle.
+    [Fact]
+    public void CapitalizesSecondLineAfterSentenceEnding()
+    {
+        var expected = "Dit is een zin." + Environment.NewLine + "En dit ook.";
+        var input = "Dit is een zin." + Environment.NewLine + "en dit ook.";
+        Assert.Equal(expected, Fix("Vorige regel.", input, "nl", "dhr."));
+    }
+}

--- a/tests/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterPeriodInsideParagraphTest.cs
+++ b/tests/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterPeriodInsideParagraphTest.cs
@@ -5,12 +5,17 @@ namespace LibSETests.Forms.FixCommonErrors;
 
 public class FixStartWithUppercaseLetterAfterPeriodInsideParagraphTest
 {
-    private static string Fix(string input, string language)
+    private static string Fix(string input, string language, params string[] abbreviations)
     {
         var subtitle = new Subtitle();
         subtitle.Paragraphs.Add(new Paragraph(input, 0, 2000));
         subtitle.Renumber();
-        new FixStartWithUppercaseLetterAfterPeriodInsideParagraph().Fix(subtitle, new EmptyFixCallback { Language = language });
+        var callbacks = new EmptyFixCallback
+        {
+            Language = language,
+            Abbreviations = new HashSet<string>(abbreviations, StringComparer.OrdinalIgnoreCase),
+        };
+        new FixStartWithUppercaseLetterAfterPeriodInsideParagraph().Fix(subtitle, callbacks);
         return subtitle.Paragraphs[0].Text;
     }
 
@@ -36,5 +41,46 @@ public class FixStartWithUppercaseLetterAfterPeriodInsideParagraphTest
     public void Dutch_LeavesContractionAfterEllipsis()
     {
         Assert.Equal("Het regelt... 's morgens werkt hij.", Fix("Het regelt... 's morgens werkt hij.", "nl"));
+    }
+
+    // An abbreviation period is not a sentence ending, so the next word stays as it is (#13082).
+    [Theory]
+    [InlineData("Ik sprak dhr. de vries gisteren.")]
+    [InlineData("Volgens mevr. jansen is alles geregeld.")]
+    [InlineData("Dat bevestigde dr. de boer vanochtend.")]
+    [InlineData("Ook prof. van den berg was aanwezig.")]
+    [InlineData("Ga naar nr. twaalf aan het einde.")]
+    [InlineData("We wachten ca. vijf minuten.")]
+    [InlineData("Neem kleding, eten, drinken, enz. mee.")]
+    public void Dutch_KeepsLowercaseAfterAbbreviation(string input)
+    {
+        Assert.Equal(input, Fix(input, "nl", "dhr.", "mevr.", "dr.", "prof.", "nr.", "ca.", "enz."));
+    }
+
+    // Abbreviations with an inner period are recognized without being listed.
+    [Theory]
+    [InlineData("Er waren o.a. fietsen en brommers.")]
+    [InlineData("Neem de trein i.p.v. de bus.")]
+    [InlineData("Dat betekent, d.w.z. dat we vertrekken.")]
+    public void Dutch_KeepsLowercaseAfterMultiDotAbbreviation(string input)
+    {
+        Assert.Equal(input, Fix(input, "nl"));
+    }
+
+    // The abbreviation list is matched case insensitively - subtitles use both "Dr." and "dr.".
+    [Theory]
+    [InlineData("I met dr. smith today.")]
+    [InlineData("I met Dr. smith today.")]
+    [InlineData("I met DR. smith today.")]
+    public void AbbreviationMatchIsCaseInsensitive(string input)
+    {
+        Assert.Equal(input, Fix(input, "en", "Dr."));
+    }
+
+    // A period that is not an abbreviation must still be fixed.
+    [Fact]
+    public void CapitalizesAfterNonAbbreviation()
+    {
+        Assert.Equal("Ik ga weg. Tot morgen.", Fix("Ik ga weg. tot morgen.", "nl", "dhr.", "enz."));
     }
 }


### PR DESCRIPTION
Fixes #13082.

### The report

In Dutch, `dhr. mevr. dr. prof. nr. ca. enz.` are followed by a lowercase continuation, but "Fix common errors" capitalized it. Reproduced with the attached file (`abbreviations.nl.srt.txt`) — 7 of the 11 lines were wrongly changed:

| before | after (old behaviour) |
|---|---|
| `Ik sprak dhr. de vries gisteren.` | `dhr. **De** vries` |
| `Volgens mevr. jansen is alles geregeld.` | `mevr. **J**ansen` |
| `Dat bevestigde dr. de boer vanochtend.` | `dr. **De** boer` |
| `Ook prof. van den berg was aanwezig.` | `prof. **V**an den berg` |
| `Ga naar nr. twaalf aan het einde.` | `nr. **T**waalf` |
| `We wachten ca. vijf minuten.` | `ca. **V**ijf` |
| `Neem kleding, eten, drinken, enz. mee.` | `enz. **M**ee` |

`o.a.`, `i.p.v.`, `d.w.z.` and `M.b.t.` were already fine — the inner period is caught by a general rule.

### Causes

1. **Dutch had no abbreviation data.** The abbreviation set is derived from names-list entries ending in `.`; `nl_names.xml` has none, so only the global `names.xml` (`Dr.`, `Mr.`, `St.`, …) contributed.
2. **Lookup was case sensitive.** `Dr. smith` was left alone but `dr. smith` became `dr. Smith` — in every language, English included.
3. **`FixStartWithUppercaseLetterAfterParagraph` never consulted the abbreviation list.** It only had a hardcoded English ` o.r.`/` a.m.`/` p.m.` check, so a subtitle (or line one of a two-liner) ending in `dhr.` still capitalized the continuation.

### Changes

- New `Dictionaries/nl_abbreviations.xml` (47 entries) and `AbbreviationList`, a loader for `<lang>_abbreviations.xml` (plus an optional region file like `pt_BR_abbreviations.xml`). Merged with the names-derived abbreviations. Matching is case insensitive, so one entry per abbreviation is enough.
- `Helper.IsAbbreviation` / `Helper.EndsWithAbbreviation`, shared by both uppercase-after-period rules; the hardcoded English trio is gone (it was already redundant with `IsPreviousTextEndOfParagraph`).
- `FixCommonErrorsViewModel` now loads the names list. It was injected but never loaded, so `IsName()` and `GetAbbreviations()` were always empty in the dialog — the batch converter already did this. Also makes the name guards in `FixUppercaseIInsideWords` and `FixMissingPeriodsAtEndOfLine` work there.
- `seconv` passes the abbreviations to its `EmptyFixCallback` so the CLI behaves the same.

### Trade-off

An abbreviation that genuinely ends a sentence (`…drinken, enz. Daarna gingen we.`) will no longer be offered as a fix. That false negative is the safer side for a checkbox-based fix list, and matches how the Bulgarian `г.` case is already handled.

### Verified

- All 11 lines of the reported file unchanged, through both the fix rules and the `seconv` CLI end-to-end.
- Normal capitalization still applies (`Ik ga weg. tot morgen.` → `Ik ga weg. Tot morgen.`).
- New tests: `AbbreviationListTest`, `FixStartWithUppercaseLetterAfterParagraphTest`, `SeNamesListAbbreviationsTests`, plus cases in `FixStartWithUppercaseLetterAfterPeriodInsideParagraphTest`.
- Full suites green: libse 771, UI 1187, seconv 290, libuilogic 140.

### Follow-up (not in this PR)

Other languages still have no `_abbreviations.xml`. `<lang>_NoBreakAfterList.xml` already carries curated abbreviations for 30 languages (`es`: `Sr. Sra. Srta. Prof. Lic. …`, `pt`: 78 entries) and would be a good seed. The case-insensitive fix alone already improves them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)