### PR TITLE
Restore F10/Alt keyboard activation of the menu bar

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,13 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.2.0-beta2 (unreleased)
+
+* Fix F10 no longer activating the menu bar: remove the default F10 "set end and go to next" binding (a one-time migration clears the stale persisted copy; re-assign F10 to get the SE4 behavior back) - thx GrampaWildWilly
+* Fix Alt no longer activating the menu bar after a dialog opened while Alt was held - thx GrampaWildWilly
+
+-----------------------------------------------------------------------------------------------------
+
 v5.2.0-beta1 (2nd of August 2026)
 
 * Auto-translate: advanced llama.cpp and Ollama engines with batch context - thx subof

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -79,7 +79,11 @@ See also: [Shortcuts Settings](../features/shortcuts.md)
 |----------|--------|
 | F11 | Set start time |
 | F12 | Set end time |
-| F10 | Set end time and go to next line |
+
+"Set end time and go to next line" has no default shortcut: bare F10 activates the
+main menu bar (the Windows standard). Assign F10 to the action in Options →
+Shortcuts if you prefer the Subtitle Edit 4 behavior — a user-assigned shortcut
+wins over the menu activation.
 
 ## Waveform
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -20860,6 +20860,13 @@ public partial class MainViewModel :
     /// </summary>
     internal void OnWindowDeactivated(object? sender, EventArgs e)
     {
+        // Avalonia's AccessKeyHandler must not be left mid-Alt-gesture either: a modal opened
+        // while Alt was held (Alt, O, ... reaching the Shortcuts window) eats the physical Alt
+        // release, and the stranded "ignore the next Alt up" state makes the next bare Alt press
+        // fail to open the menu bar (#13083). Complete the cycle with a synthetic release first;
+        // if that release opens the menu, the deactivation cleanup below closes it again.
+        UiUtil.RaiseSyntheticAltKeyUp(Window);
+
         // Drop any held-key state when focus leaves the window. A modal dialog (e.g. the
         // "Save changes?" prompt that Ctrl+O raises on a changed file) steals focus, so the KeyUp
         // for the held keys never reaches the main window and they stay "stuck down". That left
@@ -21271,7 +21278,9 @@ public partial class MainViewModel :
             // into the menu bar, a second press deactivates it and restores the previous focus. This
             // also lets the menu be reached and read with a screen reader without a mouse (#11745).
             // A user-assigned F10 shortcut wins over the menu toggle (#12504) - the menu stays
-            // reachable via Alt.
+            // reachable via Alt. The shipped defaults deliberately bind no bare F10 (and
+            // Se.MigrateShortcuts clears the old persisted F10 default), so a registered single-key
+            // F10 here really is the user's own choice (#13083).
             if (k == Key.F10 && keyEventArgs.KeyModifiers == KeyModifiers.None && !_shortcutManager.HasSingleKeyShortcut("F10"))
             {
                 if (IsMainMenuFocused())

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -2581,6 +2581,11 @@ public partial class BinaryEditViewModel : ObservableObject
     /// </summary>
     internal void OnWindowDeactivated(object? sender, EventArgs e)
     {
+        // Complete Avalonia's bare-Alt cycle when a modal steals focus while Alt is held, so the
+        // stranded AccessKeyHandler state cannot leave the next bare Alt press unable to open the
+        // menu bar (#13083). If the synthetic release opens the menu, the cleanup below closes it.
+        UiUtil.RaiseSyntheticAltKeyUp(Window);
+
         // A task switch (Alt+Tab) must drop any active menu-bar state, otherwise Avalonia leaves
         // the access-key underlines / selection armed and they reappear when the window is re-activated
         // (#11745 beta-2 feedback).

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -16,11 +16,13 @@ namespace Nikse.SubtitleEdit.Logic.Config;
 public class Se
 {
     internal const int CurrentMacOsFontMigrationVersion = 1;
+    internal const int CurrentShortcutsMigrationVersion = 1;
 
     public static string Version { get; set; } = "v5.2.0-beta1";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();
+    public int? ShortcutsMigrationVersion { get; set; }
     public string Color1 { get; set; } = "#ffff00ff";
     public string Color2 { get; set; } = "#ff0000ff";
     public string Color3 { get; set; } = "#00ff00ff";
@@ -256,6 +258,8 @@ public class Se
 
     public void InitializeMainShortcuts(MainViewModel vm)
     {
+        MigrateShortcuts();
+
         var defaults = ShortcutsMain.GetDefaultShortcuts(vm);
 
         if (Shortcuts.Count == 0)
@@ -270,6 +274,37 @@ public class Se
             if (!existing.Contains(def.ActionName))
             {
                 Shortcuts.Add(def);
+            }
+        }
+    }
+
+    /// <summary>
+    /// One-time shortcut migrations, versioned like <see cref="MigrateMacOsFontSettings"/> so a
+    /// binding the user re-assigns afterwards is never touched again.
+    ///
+    /// Version 1: v5.0.0 - v5.2.0-beta1 shipped F10 as the default for "set end and go to next",
+    /// and any visit to the Shortcuts window persisted that default to Settings.json. Once the
+    /// F10-suppression check from #12504 landed, the persisted default permanently disabled the
+    /// standard F10 menu-bar activation (#13083). The default is gone now, and the stale persisted
+    /// copy - indistinguishable from a user assignment - is cleared here once; users who really
+    /// want F10 on the action can assign it again and it will stick.
+    /// </summary>
+    internal void MigrateShortcuts()
+    {
+        if (ShortcutsMigrationVersion.GetValueOrDefault() >= CurrentShortcutsMigrationVersion)
+        {
+            return;
+        }
+
+        ShortcutsMigrationVersion = CurrentShortcutsMigrationVersion;
+
+        foreach (var shortcut in Shortcuts)
+        {
+            if (shortcut.ActionName == nameof(MainViewModel.WaveformSetEndAndGoToNextCommand) &&
+                shortcut.Keys.Count == 1 &&
+                shortcut.Keys[0].Equals(nameof(Avalonia.Input.Key.F10), StringComparison.OrdinalIgnoreCase))
+            {
+                shortcut.Keys.Clear();
             }
         }
     }

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -943,9 +943,14 @@ public static class ShortcutsMain
             new(nameof(vm.RightToLeftToggleCommand), [cmd, "Shift", "Alt", nameof(Avalonia.Input.Key.R)], ShortcutCategory.General),
 
             // Timing / creation (V4 defaults)
+            // Note: WaveformSetEndAndGoToNext deliberately ships without its V4 default (F10).
+            // Bare F10 activates the main menu bar (Windows standard, #11745), and a registered
+            // single-key F10 shortcut suppresses that (#12504) - so a shipped F10 default would
+            // permanently kill F10 menu activation for everyone (#13083). Users who want the V4
+            // behavior can still assign F10 to the action themselves; that user-defined shortcut
+            // then wins over the menu toggle. Se.MigrateShortcuts clears the old persisted default.
             new(nameof(vm.WaveformSetStartCommand), [nameof(Avalonia.Input.Key.F11)], ShortcutCategory.General),
             new(nameof(vm.WaveformSetEndCommand), [nameof(Avalonia.Input.Key.F12)], ShortcutCategory.General),
-            new(nameof(vm.WaveformSetEndAndGoToNextCommand), [nameof(Avalonia.Input.Key.F10)], ShortcutCategory.General),
             new(nameof(vm.InsertLineAfterCommand), ["Alt", nameof(Avalonia.Input.Key.Insert)], ShortcutCategory.General),
             new(nameof(vm.InsertLineBeforeCommand), [cmd, "Shift", nameof(Avalonia.Input.Key.Insert)], ShortcutCategory.General),
             new(nameof(vm.AutoBreakCommand), [cmd, "Alt", nameof(Avalonia.Input.Key.B)], ShortcutCategory.General),

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -3400,6 +3400,28 @@ public static class UiUtil
         return false;
     }
 
+    /// <summary>
+    /// Completes Avalonia's bare-Alt menu cycle when the window loses activation while Alt is held.
+    /// AccessKeyHandler tracks the Alt press privately and only settles on the Alt <em>release</em>;
+    /// when a modal window steals focus mid-gesture (e.g. Alt, O, ... opening the Shortcuts window),
+    /// the release never reaches this window and the handler is stranded with "Alt is down / ignore
+    /// the next Alt up" state - the next bare Alt press then fails to open the menu bar (#13083).
+    /// Raising a synthetic Alt KeyUp lets the handler finish its cycle. When Alt was down with no
+    /// other key pressed, that release legitimately opens the menu - callers run their
+    /// menu-deactivation cleanup afterwards to close it again.
+    /// </summary>
+    internal static void RaiseSyntheticAltKeyUp(Window? window)
+    {
+        window?.RaiseEvent(new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyUpEvent,
+            Source = window,
+            Key = Key.LeftAlt,
+            PhysicalKey = PhysicalKey.AltLeft,
+            KeyModifiers = KeyModifiers.None,
+        });
+    }
+
     private static bool _windowsSystemMenuClassHandlerRegistered;
 
     /// <summary>

--- a/tests/UI/Logic/AltMenuAccessKeyResetTests.cs
+++ b/tests/UI/Logic/AltMenuAccessKeyResetTests.cs
@@ -1,0 +1,97 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// Avalonia's AccessKeyHandler owns bare-Alt menu-bar activation and only settles its private
+/// state on the Alt *release*. When a modal window steals focus mid-gesture (e.g. Alt, O, ...
+/// opening the Shortcuts window), the release never reaches the window and the handler is left
+/// with "ignore the next Alt up" armed - so the next bare Alt press fails to open the menu
+/// (#13083). OnWindowDeactivated raises a synthetic Alt KeyUp via
+/// <see cref="UiUtil.RaiseSyntheticAltKeyUp"/> to complete the cycle; these tests pin both the
+/// broken Avalonia behavior (a canary for upstream fixes) and the recovery.
+/// </summary>
+public class AltMenuAccessKeyResetTests
+{
+    private static Window MakeWindowWithMenu(out Menu menu)
+    {
+        menu = new Menu { Items = { new MenuItem { Header = "_File" } } };
+        var editor = new TextBox();
+        var window = new Window
+        {
+            Content = new StackPanel { Children = { menu, editor } },
+        };
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        editor.Focus();
+        Dispatcher.UIThread.RunJobs();
+        return window;
+    }
+
+    /// <summary>Alt goes down, another key is pressed (menu navigation / accelerator), and the
+    /// Alt release is lost to a modal window stealing focus.</summary>
+    private static void SimulateMissedAltRelease(Window window)
+    {
+        window.KeyPress(Key.LeftAlt, RawInputModifiers.Alt, PhysicalKey.AltLeft, null);
+        window.KeyPress(Key.Q, RawInputModifiers.Alt, PhysicalKey.Q, "q");
+        window.KeyRelease(Key.Q, RawInputModifiers.Alt, PhysicalKey.Q, "q");
+    }
+
+    private static void PressAndReleaseBareAlt(Window window)
+    {
+        window.KeyPress(Key.LeftAlt, RawInputModifiers.Alt, PhysicalKey.AltLeft, null);
+        window.KeyRelease(Key.LeftAlt, RawInputModifiers.None, PhysicalKey.AltLeft, null);
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    [AvaloniaFact]
+    public void BareAltOpensMenu()
+    {
+        var window = MakeWindowWithMenu(out var menu);
+
+        PressAndReleaseBareAlt(window);
+
+        Assert.True(menu.IsOpen);
+        window.Close();
+    }
+
+    // Canary for the Avalonia behavior the synthetic release works around: if this starts
+    // failing (menu opens), Avalonia recovers from a missed Alt KeyUp on its own and
+    // UiUtil.RaiseSyntheticAltKeyUp can likely be removed.
+    [AvaloniaFact]
+    public void MissedAltReleaseLeavesNextBareAltDeadWithoutReset()
+    {
+        var window = MakeWindowWithMenu(out var menu);
+
+        SimulateMissedAltRelease(window);
+        PressAndReleaseBareAlt(window);
+
+        Assert.False(menu.IsOpen);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void SyntheticAltKeyUpRestoresBareAltAfterMissedRelease()
+    {
+        var window = MakeWindowWithMenu(out var menu);
+
+        SimulateMissedAltRelease(window);
+
+        // What OnWindowDeactivated does when the modal steals focus: complete the Alt cycle,
+        // then close the menu in case the synthetic release opened it.
+        UiUtil.RaiseSyntheticAltKeyUp(window);
+        menu.Close();
+        Dispatcher.UIThread.RunJobs();
+
+        PressAndReleaseBareAlt(window);
+
+        Assert.True(menu.IsOpen);
+        window.Close();
+    }
+}

--- a/tests/UI/Logic/ShortcutsF10MenuTests.cs
+++ b/tests/UI/Logic/ShortcutsF10MenuTests.cs
@@ -1,0 +1,81 @@
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// Bare F10 must activate the main menu bar (Windows standard, #11745) unless the user
+/// themselves assigned F10 to an action (#12504). v5.0.0 - v5.2.0-beta1 shipped F10 as the
+/// default for "set end and go to next", and visiting the Shortcuts window persisted that
+/// default to Settings.json - permanently disabling F10 menu activation (#13083). The default
+/// is gone and a one-time migration clears the stale persisted copy.
+/// </summary>
+public class ShortcutsF10MenuTests
+{
+    private const string WaveformSetEndAndGoToNext = nameof(MainViewModel.WaveformSetEndAndGoToNextCommand);
+
+    [Fact]
+    public void DefaultShortcutsDoNotBindBareF10()
+    {
+        // GetDefaultShortcuts only uses the vm parameter for nameof() - never dereferenced.
+        var defaults = ShortcutsMain.GetDefaultShortcuts(null!);
+
+        Assert.DoesNotContain(defaults, s => s.Keys.Count == 1 &&
+            s.Keys[0].Equals("F10", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void MigrationClearsStaleDefaultF10Binding()
+    {
+        var settings = new Se();
+        settings.Shortcuts.Add(new SeShortCut(WaveformSetEndAndGoToNext, ["F10"]));
+
+        settings.MigrateShortcuts();
+
+        Assert.Empty(settings.Shortcuts.Single(s => s.ActionName == WaveformSetEndAndGoToNext).Keys);
+        Assert.Equal(Se.CurrentShortcutsMigrationVersion, settings.ShortcutsMigrationVersion);
+    }
+
+    [Fact]
+    public void MigrationKeepsF10AssignedAfterMigrationRan()
+    {
+        // The user re-assigned F10 to the action after the one-time migration - it must stick.
+        var settings = new Se
+        {
+            ShortcutsMigrationVersion = Se.CurrentShortcutsMigrationVersion,
+        };
+        settings.Shortcuts.Add(new SeShortCut(WaveformSetEndAndGoToNext, ["F10"]));
+
+        settings.MigrateShortcuts();
+
+        Assert.Equal(new[] { "F10" }, settings.Shortcuts.Single(s => s.ActionName == WaveformSetEndAndGoToNext).Keys);
+    }
+
+    [Fact]
+    public void MigrationLeavesOtherBindingsAlone()
+    {
+        // F10 on any other action is a real user assignment; a modified binding on the
+        // waveform action is too. Neither may be touched.
+        var settings = new Se();
+        settings.Shortcuts.Add(new SeShortCut(nameof(MainViewModel.TogglePlayPauseCommand), ["F10"]));
+        settings.Shortcuts.Add(new SeShortCut(WaveformSetEndAndGoToNext, ["Control", "F10"]));
+
+        settings.MigrateShortcuts();
+
+        Assert.Equal(new[] { "F10" }, settings.Shortcuts[0].Keys);
+        Assert.Equal(new[] { "Control", "F10" }, settings.Shortcuts[1].Keys);
+    }
+
+    [Fact]
+    public void MigrationRunsOnlyOnce()
+    {
+        var settings = new Se();
+
+        settings.MigrateShortcuts();
+        settings.Shortcuts.Add(new SeShortCut(WaveformSetEndAndGoToNext, ["F10"]));
+        settings.MigrateShortcuts();
+
+        Assert.Equal(new[] { "F10" }, settings.Shortcuts.Single(s => s.ActionName == WaveformSetEndAndGoToNext).Keys);
+    }
+}


### PR DESCRIPTION
Fixes #13083 — after visiting the Shortcuts window, F10 and Alt no longer activated the main menu bar, and the F10 loss survived restarts.

## F10 (the persistent part)

The F10-suppression check from #12504 lets a user-assigned F10 shortcut win over the menu toggle, but it cannot tell a user assignment from the shipped `F10 → set end and go to next` default (shipped since v5.0.0) — and OK in the Shortcuts window persists the whole seeded shortcut list to Settings.json, which made the suppression permanent ("a one-time switch", as the reporter put it).

- Shipped defaults now bind no bare F10, keeping the Windows-standard menu key free.
- A one-time versioned migration (`Se.MigrateShortcuts`, same pattern as the macOS font migration) clears the stale persisted F10 copy from existing Settings.json files. It runs once, so re-assigning F10 afterwards sticks; F10 on other actions and modified bindings are never touched.
- User shortcuts are still checked first: assigning F10 to any action (including "set end and go to next", for the SE4 behavior) wins over the menu toggle.

## Alt (per-session, re-triggered each session)

Avalonia's `AccessKeyHandler` settles bare-Alt state only on the Alt **KeyUp**; a modal stealing focus mid-gesture (Alt, O, … opening the Shortcuts window) eats the release and strands the handler with "ignore the next Alt up" armed — verified against the Avalonia 12.1.1 source and reproduced in a headless test. `OnWindowDeactivated` now raises a synthetic Alt KeyUp to complete the cycle (main window + binary edit window); if the synthetic release opens the menu, the existing deactivation cleanup closes it again.

## Tests

- `ShortcutsF10MenuTests` — defaults never bind bare F10; the migration clears the stale binding, runs only once, and preserves user assignments.
- `AltMenuAccessKeyResetTests` — headless keyboard tests: bare Alt opens the menu; a missed Alt release kills the next Alt press (a canary that flags when Avalonia fixes this upstream, so the workaround can be dropped); the synthetic KeyUp restores it.

Full UI suite: 1191 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)