### PR TITLE
Abbreviation lists for 30 more languages (#13082)

### DIFF
--- a/Dictionaries/bg_abbreviations.xml
+++ b/Dictionaries/bg_abbreviations.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Bulgarian abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>ап.</Item>
+  <Item>бул.</Item>
+  <Item>гр.</Item>
+  <Item>доц.</Item>
+  <Item>ет.</Item>
+  <Item>инж.</Item>
+  <Item>кв.</Item>
+  <Item>напр.</Item>
+  <Item>Проф.</Item>
+  <Item>Св.</Item>
+  <Item>стр.</Item>
+  <Item>ул.</Item>
+</Abbreviations>

--- a/Dictionaries/bs_abbreviations.xml
+++ b/Dictionaries/bs_abbreviations.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Bosnian abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>br.</Item>
+  <Item>Dr.</Item>
+  <Item>G.</Item>
+  <Item>Gdin.</Item>
+  <Item>Gđa.</Item>
+  <Item>Gđica.</Item>
+  <Item>itd.</Item>
+  <Item>npr.</Item>
+  <Item>str.</Item>
+  <Item>tzv.</Item>
+  <Item>ul.</Item>
+</Abbreviations>

--- a/Dictionaries/cs_abbreviations.xml
+++ b/Dictionaries/cs_abbreviations.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Czech abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>apod.</Item>
+  <Item>atd.</Item>
+  <Item>Dr.</Item>
+  <Item>hod.</Item>
+  <Item>max.</Item>
+  <Item>mil.</Item>
+  <Item>min.</Item>
+  <Item>mld.</Item>
+  <Item>např.</Item>
+  <Item>P.</Item>
+  <Item>popř.</Item>
+  <Item>resp.</Item>
+  <Item>Sl.</Item>
+  <Item>Sleč.</Item>
+  <Item>str.</Item>
+  <Item>tis.</Item>
+  <Item>tzn.</Item>
+  <Item>tzv.</Item>
+</Abbreviations>

--- a/Dictionaries/da_abbreviations.xml
+++ b/Dictionaries/da_abbreviations.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Danish abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>ang.</Item>
+  <Item>ca.</Item>
+  <Item>Dr.</Item>
+  <Item>dvs.</Item>
+  <Item>ekskl.</Item>
+  <Item>evt.</Item>
+  <Item>Fr.</Item>
+  <Item>Frk.</Item>
+  <Item>hhv.</Item>
+  <Item>Hr.</Item>
+  <Item>inkl.</Item>
+  <Item>jf.</Item>
+  <Item>kl.</Item>
+  <Item>mfl.</Item>
+  <Item>mv.</Item>
+  <Item>nr.</Item>
+  <Item>osv.</Item>
+  <Item>pga.</Item>
+  <Item>stk.</Item>
+  <Item>tlf.</Item>
+</Abbreviations>

--- a/Dictionaries/de_abbreviations.xml
+++ b/Dictionaries/de_abbreviations.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  German abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>Abb.</Item>
+  <Item>Abs.</Item>
+  <Item>Abt.</Item>
+  <Item>Anm.</Item>
+  <Item>Aufl.</Item>
+  <Item>bes.</Item>
+  <Item>bspw.</Item>
+  <Item>bzgl.</Item>
+  <Item>bzw.</Item>
+  <Item>ca.</Item>
+  <Item>Dr.</Item>
+  <Item>einschl.</Item>
+  <Item>etc.</Item>
+  <Item>evtl.</Item>
+  <Item>exkl.</Item>
+  <Item>Fr.</Item>
+  <Item>Frl.</Item>
+  <Item>geb.</Item>
+  <Item>gest.</Item>
+  <Item>ggf.</Item>
+  <Item>Hr.</Item>
+  <Item>Hrsg.</Item>
+  <Item>inkl.</Item>
+  <Item>insb.</Item>
+  <Item>Jh.</Item>
+  <Item>Kap.</Item>
+  <Item>Mio.</Item>
+  <Item>Mr.</Item>
+  <Item>Mrd.</Item>
+  <Item>Mrs.</Item>
+  <Item>Ms.</Item>
+  <Item>Nr.</Item>
+  <Item>sog.</Item>
+  <Item>Std.</Item>
+  <Item>Str.</Item>
+  <Item>Tel.</Item>
+  <Item>usf.</Item>
+  <Item>usw.</Item>
+  <Item>vgl.</Item>
+</Abbreviations>

--- a/Dictionaries/el_abbreviations.xml
+++ b/Dictionaries/el_abbreviations.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Greek abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>αρ.</Item>
+  <Item>δηλ.</Item>
+  <Item>Δρ.</Item>
+  <Item>καθ.</Item>
+  <Item>περ.</Item>
+  <Item>σελ.</Item>
+</Abbreviations>

--- a/Dictionaries/en_abbreviations.xml
+++ b/Dictionaries/en_abbreviations.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  English abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>approx.</Item>
+  <Item>Ave.</Item>
+  <Item>Blvd.</Item>
+  <Item>Capt.</Item>
+  <Item>Co.</Item>
+  <Item>Col.</Item>
+  <Item>dept.</Item>
+  <Item>Dr.</Item>
+  <Item>etc.</Item>
+  <Item>fig.</Item>
+  <Item>Gen.</Item>
+  <Item>Inc.</Item>
+  <Item>Lt.</Item>
+  <Item>Ltd.</Item>
+  <Item>Mr.</Item>
+  <Item>Mrs.</Item>
+  <Item>Ms.</Item>
+  <Item>pp.</Item>
+  <Item>Prof.</Item>
+  <Item>Rd.</Item>
+  <Item>Rev.</Item>
+  <Item>Sgt.</Item>
+  <Item>vol.</Item>
+  <Item>vs.</Item>
+</Abbreviations>

--- a/Dictionaries/es_abbreviations.xml
+++ b/Dictionaries/es_abbreviations.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Spanish abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>aprox.</Item>
+  <Item>Arq.</Item>
+  <Item>art.</Item>
+  <Item>av.</Item>
+  <Item>cap.</Item>
+  <Item>Cnel.</Item>
+  <Item>Dr.</Item>
+  <Item>Dra.</Item>
+  <Item>Dña.</Item>
+  <Item>ej.</Item>
+  <Item>etc.</Item>
+  <Item>Gral.</Item>
+  <Item>Ing.</Item>
+  <Item>Lic.</Item>
+  <Item>Mtra.</Item>
+  <Item>Mtro.</Item>
+  <Item>máx.</Item>
+  <Item>mín.</Item>
+  <Item>núm.</Item>
+  <Item>Prof.</Item>
+  <Item>pág.</Item>
+  <Item>ref.</Item>
+  <Item>Sr.</Item>
+  <Item>Sra.</Item>
+  <Item>Srta.</Item>
+  <Item>Sta.</Item>
+  <Item>Sto.</Item>
+  <Item>tel.</Item>
+  <Item>Tte.</Item>
+  <Item>Ud.</Item>
+  <Item>Uds.</Item>
+  <Item>Vd.</Item>
+  <Item>Vds.</Item>
+  <Item>vol.</Item>
+</Abbreviations>

--- a/Dictionaries/et_abbreviations.xml
+++ b/Dictionaries/et_abbreviations.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Estonian abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>Dr.</Item>
+  <Item>Hr.</Item>
+  <Item>jne.</Item>
+  <Item>jt.</Item>
+  <Item>lk.</Item>
+  <Item>nt.</Item>
+  <Item>Pr.</Item>
+  <Item>vt.</Item>
+</Abbreviations>

--- a/Dictionaries/fi_abbreviations.xml
+++ b/Dictionaries/fi_abbreviations.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Finnish abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>Dr.</Item>
+  <Item>esim.</Item>
+  <Item>Hra.</Item>
+  <Item>jne.</Item>
+  <Item>kpl.</Item>
+  <Item>krs.</Item>
+  <Item>milj.</Item>
+  <Item>mm.</Item>
+  <Item>mrd.</Item>
+  <Item>nro.</Item>
+  <Item>ns.</Item>
+  <Item>Nti.</Item>
+  <Item>os.</Item>
+  <Item>puh.</Item>
+  <Item>Rva.</Item>
+  <Item>tms.</Item>
+  <Item>ts.</Item>
+  <Item>yht.</Item>
+  <Item>ym.</Item>
+  <Item>yms.</Item>
+</Abbreviations>

--- a/Dictionaries/fr_abbreviations.xml
+++ b/Dictionaries/fr_abbreviations.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  French abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>apr.</Item>
+  <Item>art.</Item>
+  <Item>av.</Item>
+  <Item>cf.</Item>
+  <Item>ch.</Item>
+  <Item>chap.</Item>
+  <Item>Dr.</Item>
+  <Item>env.</Item>
+  <Item>etc.</Item>
+  <Item>ex.</Item>
+  <Item>fig.</Item>
+  <Item>M.</Item>
+  <Item>Mlle.</Item>
+  <Item>Mme.</Item>
+  <Item>qqch.</Item>
+  <Item>qqn.</Item>
+  <Item>réf.</Item>
+  <Item>St.</Item>
+  <Item>Ste.</Item>
+  <Item>tél.</Item>
+  <Item>vol.</Item>
+  <Item>éd.</Item>
+</Abbreviations>

--- a/Dictionaries/hr_abbreviations.xml
+++ b/Dictionaries/hr_abbreviations.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Croatian abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>bl.</Item>
+  <Item>br.</Item>
+  <Item>dipl.</Item>
+  <Item>dr.</Item>
+  <Item>g.</Item>
+  <Item>god.</Item>
+  <Item>gosp.</Item>
+  <Item>ing.</Item>
+  <Item>itd.</Item>
+  <Item>mr.</Item>
+  <Item>npr.</Item>
+  <Item>odn.</Item>
+  <Item>prof.</Item>
+  <Item>str.</Item>
+  <Item>sv.</Item>
+  <Item>tj.</Item>
+  <Item>tzv.</Item>
+  <Item>ul.</Item>
+  <Item>usp.</Item>
+  <Item>vlč.</Item>
+</Abbreviations>

--- a/Dictionaries/hu_abbreviations.xml
+++ b/Dictionaries/hu_abbreviations.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Hungarian abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>Dr.</Item>
+  <Item>Hgy.</Item>
+  <Item>ill.</Item>
+  <Item>kb.</Item>
+  <Item>Kis.</Item>
+  <Item>ld.</Item>
+  <Item>Mr.</Item>
+  <Item>pl.</Item>
+  <Item>stb.</Item>
+  <Item>vö.</Item>
+  <Item>ún.</Item>
+</Abbreviations>

--- a/Dictionaries/id_abbreviations.xml
+++ b/Dictionaries/id_abbreviations.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Indonesian abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>Bpk.</Item>
+  <Item>dll.</Item>
+  <Item>Dr.</Item>
+  <Item>dsb.</Item>
+  <Item>dst.</Item>
+  <Item>hlm.</Item>
+  <Item>Ibu.</Item>
+  <Item>Nn.</Item>
+  <Item>tsb.</Item>
+</Abbreviations>

--- a/Dictionaries/it_abbreviations.xml
+++ b/Dictionaries/it_abbreviations.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Italian abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>art.</Item>
+  <Item>Avv.</Item>
+  <Item>ca.</Item>
+  <Item>cap.</Item>
+  <Item>cfr.</Item>
+  <Item>Dott.</Item>
+  <Item>Dr.</Item>
+  <Item>ecc.</Item>
+  <Item>es.</Item>
+  <Item>Geom.</Item>
+  <Item>Ing.</Item>
+  <Item>num.</Item>
+  <Item>on.</Item>
+  <Item>pag.</Item>
+  <Item>Prof.</Item>
+  <Item>Rag.</Item>
+  <Item>Sig.</Item>
+  <Item>tel.</Item>
+  <Item>vol.</Item>
+</Abbreviations>

--- a/Dictionaries/lt_abbreviations.xml
+++ b/Dictionaries/lt_abbreviations.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Lithuanian abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>Dr.</Item>
+  <Item>nr.</Item>
+  <Item>P.</Item>
+  <Item>pan.</Item>
+  <Item>Pn.</Item>
+  <Item>psl.</Item>
+  <Item>pvz.</Item>
+</Abbreviations>

--- a/Dictionaries/lv_abbreviations.xml
+++ b/Dictionaries/lv_abbreviations.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Latvian abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>Dr.</Item>
+  <Item>K.</Item>
+  <Item>Kdz.</Item>
+  <Item>lpp.</Item>
+  <Item>nr.</Item>
+  <Item>piem.</Item>
+  <Item>utt.</Item>
+</Abbreviations>

--- a/Dictionaries/mk_abbreviations.xml
+++ b/Dictionaries/mk_abbreviations.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Macedonian abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>анг.</Item>
+  <Item>англ.</Item>
+  <Item>бр.</Item>
+  <Item>год.</Item>
+  <Item>напр.</Item>
+  <Item>проф.</Item>
+  <Item>стр.</Item>
+  <Item>ул.</Item>
+  <Item>чл.</Item>
+</Abbreviations>

--- a/Dictionaries/nb_abbreviations.xml
+++ b/Dictionaries/nb_abbreviations.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Norwegian abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>ang.</Item>
+  <Item>ca.</Item>
+  <Item>Dr.</Item>
+  <Item>dvs.</Item>
+  <Item>ekskl.</Item>
+  <Item>evt.</Item>
+  <Item>Fr.</Item>
+  <Item>Frk.</Item>
+  <Item>Fru.</Item>
+  <Item>hhv.</Item>
+  <Item>Hr.</Item>
+  <Item>inkl.</Item>
+  <Item>jf.</Item>
+  <Item>kl.</Item>
+  <Item>mfl.</Item>
+  <Item>mv.</Item>
+  <Item>nr.</Item>
+  <Item>osv.</Item>
+  <Item>pga.</Item>
+  <Item>tlf.</Item>
+</Abbreviations>

--- a/Dictionaries/pl_abbreviations.xml
+++ b/Dictionaries/pl_abbreviations.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Polish abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>al.</Item>
+  <Item>Dr.</Item>
+  <Item>gen.</Item>
+  <Item>godz.</Item>
+  <Item>inż.</Item>
+  <Item>itd.</Item>
+  <Item>itp.</Item>
+  <Item>mgr.</Item>
+  <Item>mld.</Item>
+  <Item>mln.</Item>
+  <Item>np.</Item>
+  <Item>nr.</Item>
+  <Item>ok.</Item>
+  <Item>P.</Item>
+  <Item>Pn.</Item>
+  <Item>prof.</Item>
+  <Item>płk.</Item>
+  <Item>str.</Item>
+  <Item>tys.</Item>
+  <Item>tzn.</Item>
+  <Item>tzw.</Item>
+  <Item>ul.</Item>
+  <Item>św.</Item>
+</Abbreviations>

--- a/Dictionaries/pt_abbreviations.xml
+++ b/Dictionaries/pt_abbreviations.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Portuguese abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>Art.</Item>
+  <Item>Arts.</Item>
+  <Item>Cap.</Item>
+  <Item>Caps.</Item>
+  <Item>Cf.</Item>
+  <Item>D.</Item>
+  <Item>decr.</Item>
+  <Item>Dr.</Item>
+  <Item>Dra.</Item>
+  <Item>Ed.</Item>
+  <Item>Eng.</Item>
+  <Item>etc.</Item>
+  <Item>Exma.</Item>
+  <Item>Exmo.</Item>
+  <Item>Fig.</Item>
+  <Item>Fr.</Item>
+  <Item>Gov.</Item>
+  <Item>gram.</Item>
+  <Item>Jr.</Item>
+  <Item>Mlle.</Item>
+  <Item>Mme.</Item>
+  <Item>Mna.</Item>
+  <Item>Mno.</Item>
+  <Item>Mr.</Item>
+  <Item>Mrs.</Item>
+  <Item>Ms.</Item>
+  <Item>P.</Item>
+  <Item>Pe.</Item>
+  <Item>Prof.</Item>
+  <Item>Pág.</Item>
+  <Item>Págs.</Item>
+  <Item>Ref.</Item>
+  <Item>Refs.</Item>
+  <Item>Sr.</Item>
+  <Item>Sra.</Item>
+  <Item>Srs.</Item>
+  <Item>Srta.</Item>
+  <Item>St.</Item>
+  <Item>Sta.</Item>
+  <Item>Sto.</Item>
+  <Item>Séc.</Item>
+  <Item>Sécs.</Item>
+  <Item>vol.</Item>
+  <Item>vols.</Item>
+  <Item>Vs.</Item>
+</Abbreviations>

--- a/Dictionaries/ro_abbreviations.xml
+++ b/Dictionaries/ro_abbreviations.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Romanian abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>aprox.</Item>
+  <Item>art.</Item>
+  <Item>cap.</Item>
+  <Item>Dl.</Item>
+  <Item>Dna.</Item>
+  <Item>Dr.</Item>
+  <Item>Dșo.</Item>
+  <Item>etc.</Item>
+  <Item>ex.</Item>
+  <Item>nr.</Item>
+  <Item>pag.</Item>
+  <Item>prof.</Item>
+  <Item>str.</Item>
+  <Item>vol.</Item>
+</Abbreviations>

--- a/Dictionaries/ru_abbreviations.xml
+++ b/Dictionaries/ru_abbreviations.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Russian abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>акад.</Item>
+  <Item>Г-жа.</Item>
+  <Item>Г-н.</Item>
+  <Item>г-ца.</Item>
+  <Item>гл.</Item>
+  <Item>Д-р.</Item>
+  <Item>др.</Item>
+  <Item>им.</Item>
+  <Item>млн.</Item>
+  <Item>млрд.</Item>
+  <Item>проф.</Item>
+  <Item>рис.</Item>
+  <Item>руб.</Item>
+  <Item>стр.</Item>
+  <Item>табл.</Item>
+  <Item>тыс.</Item>
+  <Item>ул.</Item>
+</Abbreviations>

--- a/Dictionaries/sk_abbreviations.xml
+++ b/Dictionaries/sk_abbreviations.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Slovak abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>apod.</Item>
+  <Item>atď.</Item>
+  <Item>Dr.</Item>
+  <Item>hod.</Item>
+  <Item>max.</Item>
+  <Item>mil.</Item>
+  <Item>min.</Item>
+  <Item>mld.</Item>
+  <Item>napr.</Item>
+  <Item>P.</Item>
+  <Item>resp.</Item>
+  <Item>Sl.</Item>
+  <Item>Sleč.</Item>
+  <Item>str.</Item>
+  <Item>tis.</Item>
+  <Item>tzn.</Item>
+  <Item>tzv.</Item>
+</Abbreviations>

--- a/Dictionaries/sl_abbreviations.xml
+++ b/Dictionaries/sl_abbreviations.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Slovenian abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>Dr.</Item>
+  <Item>G.</Item>
+  <Item>Ga.</Item>
+  <Item>Gdč.</Item>
+  <Item>itd.</Item>
+  <Item>npr.</Item>
+  <Item>oz.</Item>
+  <Item>prof.</Item>
+  <Item>str.</Item>
+  <Item>tj.</Item>
+  <Item>ul.</Item>
+</Abbreviations>

--- a/Dictionaries/sq_abbreviations.xml
+++ b/Dictionaries/sq_abbreviations.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Albanian abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>Dr.</Item>
+  <Item>etj.</Item>
+  <Item>Mr.</Item>
+  <Item>nr.</Item>
+  <Item>prof.</Item>
+  <Item>Z.</Item>
+  <Item>Znj.</Item>
+</Abbreviations>

--- a/Dictionaries/sr_abbreviations.xml
+++ b/Dictionaries/sr_abbreviations.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Serbian abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>bl.</Item>
+  <Item>br.</Item>
+  <Item>dipl.</Item>
+  <Item>dr.</Item>
+  <Item>g.</Item>
+  <Item>god.</Item>
+  <Item>gosp.</Item>
+  <Item>ing.</Item>
+  <Item>itd.</Item>
+  <Item>mr.</Item>
+  <Item>npr.</Item>
+  <Item>odn.</Item>
+  <Item>prof.</Item>
+  <Item>str.</Item>
+  <Item>sv.</Item>
+  <Item>tj.</Item>
+  <Item>tzv.</Item>
+  <Item>ul.</Item>
+  <Item>usp.</Item>
+  <Item>vlč.</Item>
+</Abbreviations>

--- a/Dictionaries/sv_abbreviations.xml
+++ b/Dictionaries/sv_abbreviations.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Swedish abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>ang.</Item>
+  <Item>avd.</Item>
+  <Item>ca.</Item>
+  <Item>Dr.</Item>
+  <Item>enl.</Item>
+  <Item>etc.</Item>
+  <Item>ev.</Item>
+  <Item>exkl.</Item>
+  <Item>Fr.</Item>
+  <Item>Frk.</Item>
+  <Item>Fru.</Item>
+  <Item>Hr.</Item>
+  <Item>inkl.</Item>
+  <Item>jfr.</Item>
+  <Item>kl.</Item>
+  <Item>nr.</Item>
+  <Item>osv.</Item>
+  <Item>resp.</Item>
+  <Item>tel.</Item>
+  <Item>tfn.</Item>
+</Abbreviations>

--- a/Dictionaries/tr_abbreviations.xml
+++ b/Dictionaries/tr_abbreviations.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Turkish abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>Alb.</Item>
+  <Item>Av.</Item>
+  <Item>B.</Item>
+  <Item>bkz.</Item>
+  <Item>By.</Item>
+  <Item>Doç.</Item>
+  <Item>Dr.</Item>
+  <Item>Gen.</Item>
+  <Item>Hn.</Item>
+  <Item>Müh.</Item>
+  <Item>Prof.</Item>
+  <Item>sf.</Item>
+  <Item>Sn.</Item>
+  <Item>vb.</Item>
+  <Item>vs.</Item>
+  <Item>yy.</Item>
+  <Item>örn.</Item>
+</Abbreviations>

--- a/Dictionaries/uk_abbreviations.xml
+++ b/Dictionaries/uk_abbreviations.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Ukrainian abbreviations - a period here ends an abbreviation, not a sentence, so "Fix common
+  errors" must not capitalize the following word (issue #13082). Matching is case insensitive,
+  so one entry per abbreviation is enough. Abbreviations with an inner period (e.g. "a.m.") are
+  already recognized by a general rule and need no entry here.
+-->
+<Abbreviations>
+  <Item>акад.</Item>
+  <Item>вул.</Item>
+  <Item>гл.</Item>
+  <Item>Д-р.</Item>
+  <Item>млн.</Item>
+  <Item>млрд.</Item>
+  <Item>П-ня.</Item>
+  <Item>п.</Item>
+  <Item>проф.</Item>
+  <Item>рис.</Item>
+  <Item>стор.</Item>
+  <Item>табл.</Item>
+  <Item>тис.</Item>
+  <Item>ін.</Item>
+</Abbreviations>

--- a/src/libse/Forms/FixCommonErrors/Helper.cs
+++ b/src/libse/Forms/FixCommonErrors/Helper.cs
@@ -26,7 +26,11 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 
             var word = string.Empty;
             var i = index - 1;
-            while (i >= 0 && char.IsLetter(text[i]))
+
+            // An inner hyphen is part of the word, so Russian/Ukrainian "д-р." and "г-жа." are
+            // found - but only between two letters, so a dialog dash ("- dhr.") is not swallowed.
+            while (i >= 0 && (char.IsLetter(text[i]) ||
+                              text[i] == '-' && i > 0 && char.IsLetter(text[i - 1]) && word.Length > 0))
             {
                 word = text[i--] + word;
             }

--- a/tests/libse/Dictionaries/ShippedAbbreviationListsTests.cs
+++ b/tests/libse/Dictionaries/ShippedAbbreviationListsTests.cs
@@ -1,0 +1,87 @@
+using System.Xml.Linq;
+using Nikse.SubtitleEdit.Core.Dictionaries;
+using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
+
+namespace LibSETests.Dictionaries;
+
+/// <summary>
+/// Guards the shipped <c>Dictionaries/&lt;lang&gt;_abbreviations.xml</c> files: a bad entry is
+/// silently ignored at runtime, so it would look like the abbreviation "just doesn't work".
+/// </summary>
+public class ShippedAbbreviationListsTests
+{
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "SubtitleEdit.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+
+    private static string DictionariesFolder() => Path.Combine(FindRepoRoot(), "Dictionaries");
+
+    public static TheoryData<string> AbbreviationFiles()
+    {
+        var data = new TheoryData<string>();
+        foreach (var file in Directory.GetFiles(DictionariesFolder(), "*_abbreviations.xml").OrderBy(f => f))
+        {
+            data.Add(Path.GetFileName(file));
+        }
+
+        return data;
+    }
+
+    [Fact]
+    public void ThereAreAbbreviationListsToCheck()
+    {
+        Assert.NotEmpty(Directory.GetFiles(DictionariesFolder(), "*_abbreviations.xml"));
+    }
+
+    [Theory]
+    [MemberData(nameof(AbbreviationFiles))]
+    public void FileIsWellFormedAndEveryEntryIsUsable(string fileName)
+    {
+        var path = Path.Combine(DictionariesFolder(), fileName);
+        var root = XDocument.Load(path).Root;
+
+        Assert.NotNull(root);
+        Assert.Equal("Abbreviations", root!.Name.LocalName);
+
+        var items = root.Elements("Item").Select(e => e.Value).ToList();
+        Assert.NotEmpty(items);
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var item in items)
+        {
+            Assert.Equal(item.Trim(), item);
+            Assert.True(item.Length > 1, $"{fileName}: '{item}' is too short");
+            Assert.EndsWith(".", item);
+            Assert.DoesNotContain(' ', item);
+
+            // An inner period is already matched by a general rule, so listing it is dead weight.
+            Assert.DoesNotContain('.', item.Substring(0, item.Length - 1));
+
+            Assert.True(seen.Add(item), $"{fileName}: '{item}' is listed twice");
+        }
+
+        // The language code in the file name is what the loader looks for.
+        var languageName = fileName.Substring(0, fileName.IndexOf("_abbreviations.xml", StringComparison.Ordinal));
+        var loaded = AbbreviationList.Load(DictionariesFolder(), languageName);
+        Assert.Equal(items.Count, loaded.Count);
+
+        // Every entry must be reachable by the lookup, which walks back over letters and inner
+        // hyphens only - an entry with any other character would never match anything.
+        var callbacks = new EmptyFixCallback { Abbreviations = loaded };
+        foreach (var item in items)
+        {
+            var text = "Xx yy " + item;
+            Assert.True(
+                Helper.IsAbbreviation(text, text.Length - 1, callbacks),
+                $"{fileName}: '{item}' can never be matched by the abbreviation lookup");
+        }
+    }
+}

--- a/tests/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterPeriodInsideParagraphTest.cs
+++ b/tests/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterPeriodInsideParagraphTest.cs
@@ -77,6 +77,22 @@ public class FixStartWithUppercaseLetterAfterPeriodInsideParagraphTest
         Assert.Equal(input, Fix(input, "en", "Dr."));
     }
 
+    // An inner hyphen is part of the word, so Russian/Ukrainian "д-р." and "г-жа." are found.
+    [Theory]
+    [InlineData("Я видел д-р. иванова вчера.")]
+    [InlineData("Я видел г-жа. иванова вчера.")]
+    public void HyphenatedAbbreviationIsRecognized(string input)
+    {
+        Assert.Equal(input, Fix(input, "ru", "д-р.", "г-жа."));
+    }
+
+    // A dialog dash must not become part of the word.
+    [Fact]
+    public void DialogDashIsNotPartOfTheWord()
+    {
+        Assert.Equal("Ja. - Nee. Tot morgen.", Fix("Ja. - Nee. tot morgen.", "nl", "dhr."));
+    }
+
     // A period that is not an abbreviation must still be fixed.
     [Fact]
     public void CapitalizesAfterNonAbbreviation()


### PR DESCRIPTION
Follow-up to #13085, which added the `<lang>_abbreviations.xml` mechanism but shipped data for Dutch only. This fills in the other languages.

### Where the data comes from

**Seed:** every `<Item>` ending in a period in the curated in-repo `Dictionaries/<lang>_NoBreakAfterList.xml` — `Sr. Sra. Srta. Prof. Lic. Arq. Ing. Gral.` for Spanish, 78 entries for Portuguese, `Dr. Fr. Frl. Hr. Nr.` for German, and so on. Nothing invented.

**Extras:** conservative per-language additions for the abbreviations subtitles actually hit mid-sentence — `usw. bzw. ca. evtl. ggf. inkl.` (de), `osv. tlf. ekskl. pga.` (da/nb), `itd. itp. ok. godz.` (pl), `vb. vs. bkz. örn.` (tr), `esim. jne. mm.` (fi), `акад. млн. стр. ул.` (ru), etc.

Entries were picked to avoid colliding with a common standalone word in that language. Deliberate exclusions worth knowing about:

- **`No.` for English** — "The answer is no." would stop being capitalized after.
- **`min.` for Danish and Norwegian** — `min` means "my".
- **`Max.`/`min.` for German** — `Max` is a common first name.
- **`г.` for Bulgarian** — it already has dedicated handling in the fix.

Case variants collapse to one entry (matching is case insensitive), and abbreviations with an inner period are left out — a general rule already handles those. Arabic and Vietnamese get no file; there is nothing to seed from and no confident extras.

31 lists total, from 6 entries (Greek) to 45 (Portuguese).

### Code change

`Helper.IsAbbreviation` now treats an inner hyphen as part of the word, so the Russian/Ukrainian `д-р.` and `г-жа.` forms in the seed are actually found — before this they were dead entries, since the lookup stopped at the hyphen. A hyphen only counts between two letters, so a dialog dash is still not swallowed.

### Tests

`ShippedAbbreviationListsTests` validates every shipped list: well-formed XML, entries trimmed and ending in a period, no spaces, no duplicates, no inner periods, loader round-trip, and — the one that matters — every entry is actually reachable by the abbreviation lookup. A bad entry is silently ignored at runtime, so without this it would just look like the abbreviation doesn't work.

### Verified

Spot-checked end-to-end per language, both directions:

```
[de] kept    Wir warten ca. fünf Minuten und so usw. weiter.
[fr] kept    Prends le train env. dix minutes etc. après.
[es] kept    Esperamos aprox. cinco minutos, art. tres.
[it] kept    Aspettiamo ca. cinque minuti, ecc. eccetera.
[da] kept    Vi venter ca. fem minutter osv. videre.
[pl] kept    Czekamy ok. pięć minut itd. dalej.
[ru] kept    Я видел д-р. иванова, гл. пятая.
[tr] kept    Yaklaşık vb. beş dakika bkz. sayfa.
[pt] kept    Esperamos cf. cinco minutos, etc. mais.

[de] CHANGED Es ist spät. morgen komme ich.  =>  Es ist spät. Morgen komme ich.
[es] CHANGED Es tarde. mañana vengo.          =>  Es tarde. Mañana vengo.
[ru] CHANGED Уже поздно. завтра приду.        =>  Уже поздно. Завтра приду.
```

Full suites green: libse 806, UI 1187, seconv 290, libuilogic 140.

### Review note

The seed half is existing repo data. The extras are my own per-language judgement and are the part worth a native speaker's eye — the files are plain lists, so translators can trim or extend them without touching code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)