### PR TITLE
Polish.json: fix trailing commas + add CI check for translation JSON

### DIFF
--- a/.github/workflows/validate-language-files.yml
+++ b/.github/workflows/validate-language-files.yml
@@ -1,0 +1,46 @@
+name: Validate language files
+
+# Translation files under src/ui/Assets/Languages are frequently updated by direct
+# commits rather than pull requests, and a malformed one is silent at build time:
+# Se.LoadLanguage just falls back to English at start-up. Polish.json shipped on main
+# with two trailing commas (System.Text.Json rejects those) before this gate existed.
+#
+# This runs the two test classes that cover the translation files:
+#   LanguageJsonFilesTests    - every *.json parses as strict JSON
+#   SeLanguageJsonContextTests - the source-generated context reads the same graph as
+#                                the reflection serializer, so a section that fails to
+#                                map cannot silently deserialize as null
+#
+# Deliberately not filtered on `paths`: the source-gen test also depends on the
+# SeLanguage model classes, and a paths list that drifts would make this check quietly
+# stop running. The job is a plain .NET build, so running it on every push is cheap and
+# it stays safe to mark as a required status check.
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  validate-language-files:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore tests/UI/UITests.csproj
+
+      - name: Build
+        run: dotnet build tests/UI/UITests.csproj --no-restore
+
+      - name: Validate translation JSON
+        run: >
+          dotnet test tests/UI/UITests.csproj --no-build
+          --filter "FullyQualifiedName~LanguageJsonFilesTests|FullyQualifiedName~SeLanguageJsonContextTests"

--- a/src/ui/Assets/Languages/Polish.json
+++ b/src/ui/Assets/Languages/Polish.json
@@ -1137,7 +1137,7 @@
       "addLineBetweenSubtitles": "Dodaj linię między napisami",
       "titleExportDCinemaInteropPng": "D-Cinema interop/png",
       "titleExportDCinemaSmpte2014Png": "D-Cinema SMPTE 2014/png",
-      "imageBasedSubtitleSaved": "Zapisano napisy oparte na obrazach",
+      "imageBasedSubtitleSaved": "Zapisano napisy oparte na obrazach"
     },
     "statistics": {
       "title": "Statystyki",
@@ -1685,7 +1685,7 @@
       "outputFormatAssa": "Advanced Sub Station Alpha (.ass)",
       "style1": "Styl 1",
       "style2": "Styl 2",
-      "merge": "_Połącz",
+      "merge": "_Połącz"
     },
     "splitSubtitle": {
       "title": "Podziel napisy",


### PR DESCRIPTION
### The bug

Two objects in `src/ui/Assets/Languages/Polish.json` ended with a trailing comma (lines 1140 and 1688), which `System.Text.Json` rejects. Polish translations failed to load entirely — `Se.LoadLanguage` falls back to English rather than reporting an error — and two unit tests failed:

- `UITests.Logic.LanguageJsonFilesTests.LanguageFile_IsValidJson(Polish.json)`
- `UITests.Logic.Config.SeLanguageJsonContextTests.SourceGeneratedContext_MatchesReflectionSerializer(Polish.json)`

### The CI gate

The tests that catch this already existed, but nothing ran them on push or pull request: every workflow in `.github/workflows` is `workflow_dispatch` only, and the `dotnet test` steps in `build-ui.yml` and `build-seconv.yml` are commented out. AppVeyor does run the suite, but the broken file reached `main` regardless.

`validate-language-files.yml` runs both language test classes on `ubuntu-latest` for `pull_request` and pushes to `main`. It is deliberately not filtered on `paths` — the source-gen test also depends on the `SeLanguage` model classes, and a drifting paths list would make the check quietly stop running.

Verified the gate actually bites: injecting a trailing comma into `Danish.json` fails both tests; reverting it passes.

### Result

Full suite: 2431 passed, 0 failed, 1 skipped. Solution builds with 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
