### PR TITLE
Restore grid copy-to-clipboard menu items and plain text column paste

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -782,6 +782,23 @@ public static partial class InitListViewAndEditBox
         insertSubtitleFileAfterLineMenuItem.Command = vm.InsertSubtitleFileAfterThisLineCommand;
         flyout.Items.Add(insertSubtitleFileAfterLineMenuItem);
 
+        // SE4 had "Copy as text to clipboard" right here - without it the copy commands are only
+        // reachable via shortcuts, and the text-only ones have no default shortcut at all
+        var copyToClipboardMenuItem = new MenuItem { Header = Se.Language.General.CopyToClipboard, DataContext = vm };
+        copyToClipboardMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
+        copyToClipboardMenuItem.Command = vm.SubtitleGridCopyCommand;
+        flyout.Items.Add(copyToClipboardMenuItem);
+
+        var copyTextToClipboardMenuItem = new MenuItem { Header = Se.Language.General.CopyTextToClipboard, DataContext = vm };
+        copyTextToClipboardMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
+        copyTextToClipboardMenuItem.Command = vm.CopyTextToClipboardCommand;
+        flyout.Items.Add(copyTextToClipboardMenuItem);
+
+        var copyOriginalTextToClipboardMenuItem = new MenuItem { Header = Se.Language.Options.Shortcuts.CopyTextFromOriginalToClipboard, DataContext = vm };
+        copyOriginalTextToClipboardMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowColumnOriginalText)));
+        copyOriginalTextToClipboardMenuItem.Command = vm.CopyTextFromOriginalToClipboardCommand;
+        flyout.Items.Add(copyOriginalTextToClipboardMenuItem);
+
         var copyOriginal = new MenuItem { Header = Se.Language.Main.CopyTextFromOriginalToCurrent, Command = vm.ColumnCopyTextFromOriginalToCurrentCommand };
         copyOriginal.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowColumnOriginalText)));
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4342,7 +4342,23 @@ public partial class MainViewModel :
             }
         }
 
-        if (detectedFormat == null)
+        var subtitle = new Subtitle();
+        detectedFormat?.LoadSubtitle(subtitle, lines, null);
+
+        // SE4 parity: plain text (e.g. a few lines copied from a text document) is not a subtitle
+        // format, but should still paste into the text column - one clipboard line per subtitle.
+        var textOnlySource = subtitle.Paragraphs.Count == 0;
+        if (textOnlySource)
+        {
+            // trailing blank lines are an artifact of the copy, not something to paste
+            var lastLineWithText = lines.FindLastIndex(p => !string.IsNullOrWhiteSpace(p));
+            for (var i = 0; i <= lastLineWithText; i++)
+            {
+                subtitle.Paragraphs.Add(new Paragraph(lines[i], 0, 0));
+            }
+        }
+
+        if (subtitle.Paragraphs.Count == 0)
         {
             await MessageBox.Show(Window, Se.Language.General.Error, Se.Language.General.UnknownSubtitleFormat,
                 MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -4350,14 +4366,23 @@ public partial class MainViewModel :
             return;
         }
 
-        var subtitle = new Subtitle();
-        detectedFormat.LoadSubtitle(subtitle, lines, null);
+        var result = await ShowDialogAsync<ColumnPasteWindow, ColumnPasteViewModel>(vm =>
+        {
+            if (textOnlySource)
+            {
+                vm.SetTextOnlySource();
+            }
+        });
 
-        var result = await ShowDialogAsync<ColumnPasteWindow, ColumnPasteViewModel>();
         if (!result.OkPressed)
         {
             return;
         }
+
+        // a plain text source has no time codes, so the text column is the only thing to paste
+        var columnsAll = result.ColumnsAll && !textOnlySource;
+        var columnsTimeCodesOnly = result.ColumnsTimeCodesOnly && !textOnlySource;
+        var columnsTextOnly = result.ColumnsTextOnly || textOnlySource;
 
         var count = 0;
         var overWrite = result.ModeOverwrite;
@@ -4367,17 +4392,17 @@ public partial class MainViewModel :
             {
                 for (int j = Subtitles.Count - 1; j > idx; j--)
                 {
-                    if (result.ColumnsAll)
+                    if (columnsAll)
                     {
                         Subtitles[j].SetStartTimeOnly(Subtitles[j - 1].StartTime);
                         Subtitles[j].EndTime = Subtitles[j - 1].EndTime;
                         Subtitles[j].Text = Subtitles[j - 1].Text;
                     }
-                    else if (result.ColumnsTextOnly)
+                    else if (columnsTextOnly)
                     {
                         Subtitles[j].Text = Subtitles[j - 1].Text;
                     }
-                    else if (result.ColumnsTimeCodesOnly)
+                    else if (columnsTimeCodesOnly)
                     {
                         Subtitles[j].SetStartTimeOnly(Subtitles[j - 1].StartTime);
                         Subtitles[j].EndTime = Subtitles[j - 1].EndTime;
@@ -4385,17 +4410,17 @@ public partial class MainViewModel :
                 }
             }
 
-            if (result.ColumnsAll)
+            if (columnsAll)
             {
                 Subtitles[idx].SetStartTimeOnly(subtitle.Paragraphs[i].StartTime.TimeSpan);
                 Subtitles[idx].EndTime = subtitle.Paragraphs[i].EndTime.TimeSpan;
                 Subtitles[idx].Text = subtitle.Paragraphs[i].Text;
             }
-            else if (result.ColumnsTextOnly)
+            else if (columnsTextOnly)
             {
                 Subtitles[idx].Text = subtitle.Paragraphs[i].Text;
             }
-            else if (result.ColumnsTimeCodesOnly)
+            else if (columnsTimeCodesOnly)
             {
                 Subtitles[idx].SetStartTimeOnly(subtitle.Paragraphs[i].StartTime.TimeSpan);
                 Subtitles[idx].EndTime = subtitle.Paragraphs[i].EndTime.TimeSpan;

--- a/src/ui/Features/Shared/ColumnPaste/ColumnPasteViewModel.cs
+++ b/src/ui/Features/Shared/ColumnPaste/ColumnPasteViewModel.cs
@@ -18,10 +18,28 @@ public partial class ColumnPasteViewModel : ObservableObject
     public Window? Window { get; internal set; }
     public bool OkPressed { get; private set; }
 
+    /// <summary>
+    /// True when the clipboard held plain text with no time codes, so only the text column can
+    /// be pasted. The window then disables the other column choices.
+    /// </summary>
+    public bool IsTextOnlySource { get; private set; }
+
     public ColumnPasteViewModel()
     {
         ColumnsAll = true;
         ModeOverwrite = true;
+    }
+
+    /// <summary>
+    /// Locks the column choice to "text only" - SE4 opened the dialog the same way when the
+    /// clipboard could not be parsed as a subtitle.
+    /// </summary>
+    internal void SetTextOnlySource()
+    {
+        IsTextOnlySource = true;
+        ColumnsAll = false;
+        ColumnsTimeCodesOnly = false;
+        ColumnsTextOnly = true;
     }
 
     [RelayCommand]

--- a/src/ui/Features/Shared/ColumnPaste/ColumnPasteWindow.cs
+++ b/src/ui/Features/Shared/ColumnPaste/ColumnPasteWindow.cs
@@ -38,19 +38,30 @@ public class ColumnPasteWindow : Window
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
         var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
 
-        grid.Add(MakeChooseColumnView(vm, out var radioButtonColumnsAll), 0);
+        grid.Add(MakeChooseColumnView(vm, out var radioButtonColumnsAll, out var radioButtonColumnsTextOnly), 0);
         grid.Add(MakeOverwriteView(vm), 0, 1);
         grid.Add(panelButtons, 1, 0, 1, 2);
 
         Content = grid;
 
-        Activated += delegate { radioButtonColumnsAll.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        // Plain text has no time codes, so the only enabled column choice is "text only"
+        var initialFocusControl = vm.IsTextOnlySource ? radioButtonColumnsTextOnly : radioButtonColumnsAll;
+        Activated += delegate { initialFocusControl.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.KeyDown;
     }
 
-    private static Border MakeChooseColumnView(ColumnPasteViewModel vm, out RadioButton radioButtonAll)
+    private static Border MakeChooseColumnView(ColumnPasteViewModel vm, out RadioButton radioButtonAll, out RadioButton radioButtonTextOnly)
     {
         radioButtonAll = UiUtil.MakeRadioButton(Se.Language.General.All, vm, nameof(vm.ColumnsAll), "column");
+        var radioButtonTimeCodesOnly = UiUtil.MakeRadioButton(Se.Language.Main.TimeCodesOnly, vm, nameof(vm.ColumnsTimeCodesOnly), "column");
+        radioButtonTextOnly = UiUtil.MakeRadioButton(Se.Language.Main.TextOnly, vm, nameof(vm.ColumnsTextOnly), "column");
+
+        if (vm.IsTextOnlySource)
+        {
+            // clipboard was plain text - there are no time codes to paste
+            radioButtonAll.IsEnabled = false;
+            radioButtonTimeCodesOnly.IsEnabled = false;
+        }
 
         var stackPanel = new StackPanel
         {
@@ -59,8 +70,8 @@ public class ColumnPasteWindow : Window
             {
                 UiUtil.MakeLabel(Se.Language.Main.ChooseColumn),
                 radioButtonAll,
-                UiUtil.MakeRadioButton(Se.Language.Main.TimeCodesOnly, vm, nameof(vm.ColumnsTimeCodesOnly), "column"),
-                UiUtil.MakeRadioButton(Se.Language.Main.TextOnly, vm, nameof(vm.ColumnsTextOnly), "column"),
+                radioButtonTimeCodesOnly,
+                radioButtonTextOnly,
             }
         };
 


### PR DESCRIPTION
Two SE4 features a user reported missing after moving from 4.0.16.

### 1. The subtitle grid context menu had no copy entry

SE4 showed **Copy as text to clipboard** between *Insert subtitle after this line...* and *Column*, so copying a few lines out to an external document was one click away.

In SE5 the commands exist but are shortcut-only, and the text-only variants (`CopyTextToClipboardCommand`, `CopyTextFromOriginalToClipboardCommand`) have no default shortcut at all, so they were unreachable unless the user assigned one by hand or imported SE4 shortcuts.

Three items are added in SE4's position, all using existing translated language keys:

| Header | Command | Visibility |
| --- | --- | --- |
| Copy to clipboard | `SubtitleGridCopyCommand` (number + time codes + text, current format - SE4 parity) | `IsSubtitleGridDataMenuVisible` |
| Copy text to clipboard | `CopyTextToClipboardCommand` | `IsSubtitleGridDataMenuVisible` |
| Copy text from original to clipboard | `CopyTextFromOriginalToClipboardCommand` | `ShowColumnOriginalText` |

### 2. Column -> "Paste from clipboard..." rejected plain text

SE5 looped the subtitle formats and, when none matched, showed *Unknown subtitle format* and gave up. SE4 (`ToolStripMenuItemPasteSpecialClick`) fell back to treating each clipboard line as paragraph text and opened the column paste dialog restricted to the text column - that is how recurring blocks (disclaimer, OST intro/outro) were pasted in from a text document.

The fallback is restored: each line becomes a `Paragraph(line, 0, 0)`, and the dialog opens locked to the text column ("All" and "Time codes only" disabled, initial focus on the enabled radio). The paste loop also guards on the plain-text source independently, so it can never write zeroed time codes. Trailing blank lines are dropped - a copy artifact that would otherwise blank a row (SE4 kept them). The error now only fires when there is genuinely nothing to paste.

Note that grid Ctrl+V already handles plain text and *creates* rows for it - more than SE4's Ctrl+V did, which ignored non-subtitle text entirely. Column paste fills existing rows, which is the SE4 behavior kept here.

### Testing

`UI.csproj` builds clean, full UI suite passes (1194 passed, 0 failed). Not eyeballed in a running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
