### PR TITLE
Join subtitles: let the files be rearranged again

### DIFF
--- a/src/ui/Features/Tools/JoinSubtitles/JoinSubtitlesViewModel.cs
+++ b/src/ui/Features/Tools/JoinSubtitles/JoinSubtitlesViewModel.cs
@@ -14,6 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Tools.JoinSubtitles;
@@ -26,20 +27,26 @@ public partial class JoinSubtitlesViewModel : ObservableObject
     [ObservableProperty] private bool _appendTimeCodes;
     [ObservableProperty] private bool _isJoinEnabled;
     [ObservableProperty] private bool _isDeleteVisible;
+    [ObservableProperty] private bool _isMoveVisible;
     [ObservableProperty] private int _appendTimeCodesAddMilliseconds;
 
     public Window? Window { get; set; }
+    public TableView JoinItemsGrid { get; set; }
 
     public bool OkPressed { get; private set; }
     public SubtitleFormat JoinedFormat { get; private set; }
     public Subtitle JoinedSubtitle { get; private set; }
 
+    private static readonly Regex NumberRegex = new(@"\d+", RegexOptions.Compiled);
+
     private readonly IFileHelper _fileHelper;
+    private bool _loadFailed;
 
     public JoinSubtitlesViewModel(IFileHelper fileHelper)
     {
         _fileHelper = fileHelper;
         JoinItems = new ObservableCollection<JoinDisplayItem>();
+        JoinItemsGrid = new TableView();
         JoinedFormat = new SubRip();
         JoinedSubtitle = new Subtitle();
         LoadSettings();
@@ -50,6 +57,23 @@ public partial class JoinSubtitlesViewModel : ObservableObject
         KeepTimeCodes = Se.Settings.Tools.JoinKeepTimeCodes;
         AppendTimeCodes = !KeepTimeCodes;
         AppendTimeCodesAddMilliseconds = Se.Settings.Tools.JoinAppendMilliseconds;
+    }
+
+    /// <summary>
+    /// Switching time-code mode changes the joined result and, for "Keep time codes", the
+    /// list order too (SortAndLoad sorts by start time there) - so rebuild, as SE 4 does.
+    /// Posted, because the radio group sets <see cref="KeepTimeCodes"/> and
+    /// <see cref="AppendTimeCodes"/> one after the other and SortAndLoad must not run
+    /// between the two.
+    /// </summary>
+    partial void OnKeepTimeCodesChanged(bool value)
+    {
+        if (JoinItems.Count == 0)
+        {
+            return;
+        }
+
+        Dispatcher.UIThread.Post(async void () => await SortAndLoad());
     }
 
     private void SaveSettings()
@@ -74,20 +98,28 @@ public partial class JoinSubtitlesViewModel : ObservableObject
             return;
         }
 
-        foreach (var fileName in fileNames)
+        await AddFiles(fileNames);
+    }
+
+    /// <summary>
+    /// Appends the files to the end of the list, in natural file name order (so "part2"
+    /// lands before "part10"), as in SE 4. The list must not be re-sorted by start time
+    /// here: in "Append time codes" mode the order is the user's to decide, and re-sorting
+    /// on every add made it impossible to arrange the files at all (issue #13092).
+    /// </summary>
+    private async Task AddFiles(IEnumerable<string> fileNames)
+    {
+        var newFileNames = fileNames.ToList();
+        newFileNames.Sort(NaturalCompare);
+
+        foreach (var fileName in newFileNames)
         {
-            bool flowControl = await AddFile(fileName);
-            if (!flowControl)
+            if (JoinItems.Any(p => p.FullFileName.Equals(fileName, StringComparison.OrdinalIgnoreCase)))
             {
                 continue;
             }
-        }
 
-        var items = JoinItems.ToList();
-        JoinItems.Clear();
-        foreach (var item in items.OrderBy(p=>p.StartTime))
-        {
-            JoinItems.Add(item);
+            await AddFile(fileName);
         }
 
         await SortAndLoad();
@@ -95,11 +127,22 @@ public partial class JoinSubtitlesViewModel : ObservableObject
         IsJoinEnabled = JoinItems.Count > 1;
     }
 
-    private async Task<bool> AddFile(string fileName)
+    /// <summary>
+    /// SE 4's natural file name order: digit runs are zero-padded before an ordinal
+    /// compare, so "CD2" sorts before "CD10".
+    /// </summary>
+    private static int NaturalCompare(string x, string y)
+    {
+        var a = NumberRegex.Replace(x, m => m.Value.PadLeft(10, '0')).Replace(" ", string.Empty);
+        var b = NumberRegex.Replace(y, m => m.Value.PadLeft(10, '0')).Replace(" ", string.Empty);
+        return string.Compare(a, b, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task AddFile(string fileName)
     {
         if (Window == null)
         {
-            return false;
+            return;
         }
 
         var subtitle = Subtitle.Parse(fileName);
@@ -122,7 +165,7 @@ public partial class JoinSubtitlesViewModel : ObservableObject
         if (subtitle == null || subtitle.Paragraphs.Count == 0)
         {
             await MessageBox.Show(Window, Se.Language.General.Error, "Unable to read subtitle from file: " + fileName);
-            return false;
+            return;
         }
 
         var item = new JoinDisplayItem
@@ -134,11 +177,10 @@ public partial class JoinSubtitlesViewModel : ObservableObject
             Lines = subtitle.Paragraphs.Count,
         };
         JoinItems.Add(item);
-        return true;
     }
 
     [RelayCommand]
-    private void Remove()
+    private async Task Remove()
     {
         var selected = SelectedJoinItem;
         if (selected == null)
@@ -159,18 +201,62 @@ public partial class JoinSubtitlesViewModel : ObservableObject
         }
 
         IsJoinEnabled = JoinItems.Count > 1;
+
+        await SortAndLoad();
     }
 
     [RelayCommand]
     private void Clear()
     {
         JoinItems.Clear();
+        JoinedSubtitle = new Subtitle();
         IsJoinEnabled = false;
     }
 
     [RelayCommand]
-    private void Ok()
+    private Task MoveUp() => Move(ListMoveDirection.Up);
+
+    [RelayCommand]
+    private Task MoveDown() => Move(ListMoveDirection.Down);
+
+    [RelayCommand]
+    private Task MoveToTop() => Move(ListMoveDirection.Top);
+
+    [RelayCommand]
+    private Task MoveToBottom() => Move(ListMoveDirection.Bottom);
+
+    /// <summary>
+    /// Reorders the files to join. Only meaningful in "Append time codes" mode - "Keep time
+    /// codes" sorts everything by start time anyway, which is why the menu items are hidden
+    /// there, as in SE 4.
+    /// </summary>
+    private async Task Move(ListMoveDirection direction)
     {
+        if (!AppendTimeCodes || JoinItems.Count < 2)
+        {
+            return;
+        }
+
+        TableViewExtras.MoveSelectedRows(JoinItemsGrid, JoinItems, direction);
+
+        await SortAndLoad();
+    }
+
+    [RelayCommand]
+    private async Task Ok()
+    {
+        // The joined subtitle is built by SortAndLoad, and the time-code mode and the added
+        // milliseconds can both have changed since the last one ran - rebuild before handing
+        // it over, so the result always matches what the dialog shows.
+        await SortAndLoad();
+
+        // A file that has become unreadable since it was added drops out of the list here,
+        // so stay open with the shortened list rather than joining the remains silently.
+        if (_loadFailed)
+        {
+            return;
+        }
+
         SaveSettings();
         OkPressed = true;
         Window?.Close();
@@ -184,6 +270,7 @@ public partial class JoinSubtitlesViewModel : ObservableObject
 
     private async Task SortAndLoad()
     {
+        _loadFailed = false;
         JoinedFormat = new SubRip(); // default subtitle format
         string? header = null;
         SubtitleFormat? lastFormat = null;
@@ -406,6 +493,8 @@ public partial class JoinSubtitlesViewModel : ObservableObject
 
     private async Task Revert(int idx, string message)
     {
+        _loadFailed = true;
+
         if (Window == null)
         {
             return;
@@ -424,13 +513,38 @@ public partial class JoinSubtitlesViewModel : ObservableObject
         if (e.Key == Key.Delete && SelectedJoinItem != null)
         {
             e.Handled = true;
-            Remove();
+            RemoveCommand.Execute(null);
+        }
+    }
+
+    /// <summary>
+    /// Ctrl+Up/Ctrl+Down reorder the selected file. Tunneled, because the ListBox underneath
+    /// TableView handles Ctrl+Arrow itself (move focus without changing the selection) and a
+    /// bubbling handler would never see the key.
+    /// </summary>
+    internal void GridMoveKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.KeyModifiers != KeyModifiers.Control)
+        {
+            return;
+        }
+
+        if (e.Key == Key.Up)
+        {
+            e.Handled = true;
+            MoveUpCommand.Execute(null);
+        }
+        else if (e.Key == Key.Down)
+        {
+            e.Handled = true;
+            MoveDownCommand.Execute(null);
         }
     }
 
     internal void ItemsContextMenuOpening(object? sender, EventArgs e)
     {
         IsDeleteVisible = SelectedJoinItem != null;
+        IsMoveVisible = AppendTimeCodes && JoinItems.Count > 1 && JoinItemsGrid.SelectedItems?.Count > 0;
     }
 
     internal void KeyDown(object? sender, KeyEventArgs e)
@@ -469,34 +583,22 @@ public partial class JoinSubtitlesViewModel : ObservableObject
         }
 
         var files = e.DataTransfer.TryGetFiles();
-        if (files != null)
+        if (files == null)
         {
-            Dispatcher.UIThread.Post(async () =>
-            {
-                foreach (var file in files)
-                {
-                    var path = file.Path?.LocalPath;
-                    if (path != null && System.IO.File.Exists(path))
-                    {
-                        bool flowControl = await AddFile(path);
-                        if (!flowControl)
-                        {
-                            continue;
-                        }
-                    }
-                }
-
-                var items = JoinItems.ToList();
-                JoinItems.Clear();
-                foreach (var item in items.OrderBy(p => p.StartTime))
-                {
-                    JoinItems.Add(item);
-                }
-
-                await SortAndLoad();
-
-                IsJoinEnabled = JoinItems.Count > 1;
-            });
+            return;
         }
+
+        var fileNames = files
+            .Select(p => p.Path?.LocalPath)
+            .Where(p => p != null && System.IO.File.Exists(p))
+            .Select(p => p!)
+            .ToList();
+
+        if (fileNames.Count == 0)
+        {
+            return;
+        }
+
+        Dispatcher.UIThread.Post(async void () => await AddFiles(fileNames));
     }
 }

--- a/src/ui/Features/Tools/JoinSubtitles/JoinSubtitlesWindow.cs
+++ b/src/ui/Features/Tools/JoinSubtitles/JoinSubtitlesWindow.cs
@@ -5,6 +5,7 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using System.Collections;
+using System.Windows.Input;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.ValueConverters;
@@ -82,7 +83,8 @@ public class JoinSubtitlesWindow : Window
 
         // Sorting dropped in the DataGrid -> TableView conversion: the join is produced
         // by iterating this list in order (the VM sorts it by start time itself), so the
-        // list must not be reordered by clicking a header.
+        // list must not be reordered by clicking a header. Reordering is done explicitly
+        // instead, through the move items in the context menu.
         var dataGrid = TableViewExtras.MakeTableView(multiSelect: false);
         _tableViewFiles = dataGrid;
         dataGrid.Width = double.NaN;
@@ -137,6 +139,8 @@ public class JoinSubtitlesWindow : Window
                 e.Handled = true;
             }
         }, RoutingStrategies.Tunnel);
+        dataGrid.AddHandler(InputElement.KeyDownEvent, vm.GridMoveKeyDown, RoutingStrategies.Tunnel);
+        vm.JoinItemsGrid = dataGrid;
 
         var flyout = new MenuFlyout();
         flyout.Opening += vm.ItemsContextMenuOpening;
@@ -151,6 +155,8 @@ public class JoinSubtitlesWindow : Window
         };
         menuItemDelete.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteVisible)) { Source = vm });
         flyout.Items.Add(menuItemDelete);
+
+        AddMoveMenuItems(flyout, vm);
 
         var buttonAdd = UiUtil.MakeButton(vm.AddCommand, IconNames.Plus, Se.Language.General.New);
         var buttonRemove = UiUtil.MakeButton(vm.RemoveCommand, IconNames.Trash, Se.Language.General.Remove);
@@ -171,6 +177,40 @@ public class JoinSubtitlesWindow : Window
         grid.Add(panelButtons, 1);
 
         return UiUtil.MakeBorderForControlNoPadding(grid);
+    }
+
+    /// <summary>
+    /// The "move up/down/to top/to bottom" block of the file list context menu (#13092).
+    /// The files are joined in list order, so this is real reordering, not a view sort.
+    /// Hidden in "Keep time codes" mode, where the order does not matter - the paragraphs
+    /// are sorted by start time regardless - exactly as in SE 4.
+    /// </summary>
+    private static void AddMoveMenuItems(MenuFlyout flyout, JoinSubtitlesViewModel vm)
+    {
+        var separator = new Separator();
+        separator.Bind(Separator.IsVisibleProperty, new Binding(nameof(vm.IsMoveVisible)) { Source = vm });
+        flyout.Items.Add(separator);
+
+        var items = new (string Header, ICommand Command, KeyGesture? Gesture)[]
+        {
+            (Se.Language.General.MoveUp, vm.MoveUpCommand, new KeyGesture(Key.Up, KeyModifiers.Control)),
+            (Se.Language.General.MoveDown, vm.MoveDownCommand, new KeyGesture(Key.Down, KeyModifiers.Control)),
+            (Se.Language.General.MoveToTop, vm.MoveToTopCommand, null),
+            (Se.Language.General.MoveToBottom, vm.MoveToBottomCommand, null),
+        };
+
+        foreach (var (header, command, gesture) in items)
+        {
+            var menuItem = new MenuItem
+            {
+                Header = header,
+                DataContext = vm,
+                Command = command,
+                InputGesture = gesture,
+            };
+            menuItem.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsMoveVisible)) { Source = vm });
+            flyout.Items.Add(menuItem);
+        }
     }
 
     private static StackPanel MakeControlsView(JoinSubtitlesViewModel vm)


### PR DESCRIPTION
Fixes #13092

## The problem

In "Join subtitles" the file list was re-sorted by start time after **every** add — from the file picker and from drag & drop alike:

```csharp
foreach (var item in items.OrderBy(p => p.StartTime))
```

So the file with the lowest start time always ended up first, and there was no way to arrange the parts: not by dragging, not from the context menu (it only had *Delete*), not with the keyboard, and not by adding the files one at a time in the wanted order. SE 4 can rearrange them.

Sorting by start time is only right for **Keep time codes**, where `SortAndLoad` sorts the joined paragraphs by start time anyway. For **Append time codes** the order is the user's to decide.

## The fix

- **Add and drop append to the end of the list**, in natural file name order (`CD2` before `CD10`, as SE 4's `ListViewSorter.NaturalComparer` does), and skip files already in the list. The blanket `OrderBy` on start time is gone; the per-mode bubble sort inside `SortAndLoad` is untouched.
- **Move up / down / to top / to bottom are back** on the file list context menu, plus `Ctrl+Up` / `Ctrl+Down`. They reuse the existing `TableViewExtras.MoveSelectedRows` helper, and are hidden in "Keep time codes" mode — exactly as SE 4 cancels its context menu there.

## Also fixed along the way

The joined subtitle is now rebuilt whenever it can go stale — after a remove, after a reorder, when the time-code mode changes, and once more on Join. Previously `SortAndLoad` ran only when a file was added, so:

- removing a file still left it in the join,
- switching the radio button after adding the files produced a join built with the *old* mode,
- changing "add milliseconds" after adding the files had no effect.

If a file has become unreadable since it was added, the rebuild on Join drops it from the list and the dialog stays open, rather than silently joining what is left.

## Testing

Release build clean. Verified against the reporter's case (two overlapping SRTs, "Append time codes"): the list now keeps the add order, the move items appear, and `Ctrl+Up`/`Ctrl+Down` reorder the selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)