### PR TITLE
Casing: make selection casing discoverable + add sentence case (#13093)

### DIFF
--- a/docs/features/change-casing.md
+++ b/docs/features/change-casing.md
@@ -16,6 +16,18 @@ Fix the casing (capitalization) of subtitle text.
 - **All uppercase** — Convert all text to uppercase
 - **All lowercase** — Convert all text to lowercase
 
+## Casing of the selected text
+
+The text box context menu has a **Casing** submenu that works on the text you have selected in the
+subtitle text box (or, for **Toggle casing**, on the selected lines when the subtitle list has focus):
+
+- **Toggle casing** — Cycles the selection: ALL CAPS → all lowercase → Title Case (`Ctrl+Shift+F3`)
+- **Selection to UPPERCASE** (`Ctrl+Shift+U`)
+- **Selection to lowercase** (`Ctrl+U`)
+- **Selection to Sentence case** — Same as **Normal casing** above, but only for the selection
+
+All four can be given your own shortcut in Options → Settings → Shortcuts → Text box.
+
 ## Fix Names
 
 When **Fix names** (or **Fix names only**) is selected, a follow-up window lists the proposed name fixes so you can include or exclude individual items before applying.

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1502,6 +1502,38 @@ public static partial class InitListViewAndEditBox
 
         flyoutTextBox.Items.Add(new Separator());
 
+        // Casing was shortcut-only, which made people think it had been removed (#13093).
+        var menuItemTextBoxCasing = new MenuItem { Header = Se.Language.General.Casing };
+        menuItemTextBoxCasing.Items.Add(new MenuItem
+        {
+            Header = Se.Language.General.ToggleCasing,
+            Command = vm.ToggleCasingCommand,
+        });
+        menuItemTextBoxCasing.Items.Add(new MenuItem
+        {
+            Header = Se.Language.General.SelectionToUppercase,
+            Command = vm.SelectionToUpperCommand,
+        });
+        menuItemTextBoxCasing.Items.Add(new MenuItem
+        {
+            Header = Se.Language.General.SelectionToLowercase,
+            Command = vm.SelectionToLowerCommand,
+        });
+        menuItemTextBoxCasing.Items.Add(new MenuItem
+        {
+            Header = Se.Language.General.SelectionToSentenceCase,
+            Command = vm.SelectionToSentenceCaseCommand,
+        });
+        menuItemTextBoxCasing.Items.Add(new Separator());
+        menuItemTextBoxCasing.Items.Add(new MenuItem
+        {
+            Header = Se.Language.Main.Menu.ChangeCasing,
+            Command = vm.ChangeCasingSelectedLinesCommand,
+        });
+        flyoutTextBox.Items.Add(menuItemTextBoxCasing);
+
+        flyoutTextBox.Items.Add(new Separator());
+
         var unicodeSymbols = Se.Settings.Tools.UnicodeSymbolsToInsert.Split(';', System.StringSplitOptions.RemoveEmptyEntries);
         if (unicodeSymbols.Length > 0)
         {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -10654,43 +10654,83 @@ public partial class MainViewModel :
                 return;
             }
 
+            // SE4 parity: the first selected line decides the next state for the whole selection,
+            // otherwise lines in different states drift apart on every press.
+            var first = selectedItems[0].Text;
             foreach (var item in selectedItems)
             {
-                item.Text = _casingToggler.ToggleCasing(item.Text, SelectedSubtitleFormat);
+                item.Text = _casingToggler.ToggleCasing(item.Text, SelectedSubtitleFormat, first);
             }
 
             _updateAudioVisualizer = true;
             return;
         }
 
-        if (EditTextBox.SelectedText.Length <= 0)
+        var tb = GetFocusedTextBoxWrapper() ?? EditTextBox;
+        if (tb.SelectedText.Length <= 0)
         {
+            ShowStatus(Se.Language.General.NothingSelected);
             return;
         }
 
-        EditTextBox.SelectedText = _casingToggler.ToggleCasing(EditTextBox.SelectedText, SelectedSubtitleFormat);
+        ReplaceSelectedText(tb, _casingToggler.ToggleCasing(tb.SelectedText, SelectedSubtitleFormat));
     }
 
     [RelayCommand]
     private void SelectionToLower()
     {
-        if (EditTextBox.SelectedText.Length <= 0)
+        var tb = GetFocusedTextBoxWrapper() ?? EditTextBox;
+        if (tb.SelectedText.Length <= 0)
         {
+            ShowStatus(Se.Language.General.NothingSelected);
             return;
         }
 
-        EditTextBox.SelectedText = EditTextBox.SelectedText.ToLower(CultureInfo.CurrentCulture);
+        ReplaceSelectedText(tb, tb.SelectedText.ToLower(CultureInfo.CurrentCulture));
     }
 
     [RelayCommand]
     private void SelectionToUpper()
     {
-        if (EditTextBox.SelectedText.Length <= 0)
+        var tb = GetFocusedTextBoxWrapper() ?? EditTextBox;
+        if (tb.SelectedText.Length <= 0)
         {
+            ShowStatus(Se.Language.General.NothingSelected);
             return;
         }
 
-        EditTextBox.SelectedText = EditTextBox.SelectedText.ToUpper(CultureInfo.CurrentCulture);
+        ReplaceSelectedText(tb, tb.SelectedText.ToUpper(CultureInfo.CurrentCulture));
+    }
+
+    [RelayCommand]
+    private void SelectionToSentenceCase()
+    {
+        var tb = GetFocusedTextBoxWrapper() ?? EditTextBox;
+        if (tb.SelectedText.Length <= 0)
+        {
+            ShowStatus(Se.Language.General.NothingSelected);
+            return;
+        }
+
+        var text = tb.Text ?? string.Empty;
+        var selectionStart = Math.Min(tb.SelectionStart, tb.SelectionEnd);
+        var textBefore = selectionStart > 0 && selectionStart <= text.Length
+            ? text.Substring(0, selectionStart)
+            : string.Empty;
+
+        var language = Subtitles.AutoDetectGoogleLanguage() ?? "en";
+        ReplaceSelectedText(tb, SentenceCaser.SentenceCase(textBefore, tb.SelectedText, language));
+    }
+
+    /// <summary>
+    /// Replaces the selected text and re-selects the result, so casing commands can be
+    /// pressed repeatedly on the same selection (SE4 parity).
+    /// </summary>
+    private static void ReplaceSelectedText(ITextBoxWrapper tb, string newText)
+    {
+        var selectionStart = Math.Min(tb.SelectionStart, tb.SelectionEnd);
+        tb.SelectedText = newText;
+        tb.Select(selectionStart, newText.Length);
     }
 
     [RelayCommand]

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -76,6 +76,7 @@ public class LanguageGeneral
     public string Cancelled { get; set; }
     public string CaseInsensitive { get; set; }
     public string CaseSensitive { get; set; }
+    public string Casing { get; set; }
     public string Category { get; set; }
     public string Center { get; set; }
     public string CenterHorizontally { get; set; }
@@ -331,6 +332,7 @@ public class LanguageGeneral
     public string NormalCasing { get; set; }
     public string NotAvailable { get; set; }
     public string NotInstalled { get; set; }
+    public string NothingSelected { get; set; }
     public string Number { get; set; }
     public string NumberSymbol { get; set; }
     public string OcrDotDotDot { get; set; }
@@ -475,6 +477,9 @@ public class LanguageGeneral
     public string SelectSaveFolder { get; set; }
     public string SelectSubtitle { get; set; }
     public string SelectedAFolderToSaveTo { get; set; }
+    public string SelectionToLowercase { get; set; }
+    public string SelectionToSentenceCase { get; set; }
+    public string SelectionToUppercase { get; set; }
     public string SelectedLines { get; set; }
     public string SelectedlinesX { get; set; }
     public string Sensitivity { get; set; }
@@ -793,6 +798,7 @@ public class LanguageGeneral
         Cancelled = "Cancelled";
         CaseInsensitive = "Case insensitive";
         CaseSensitive = "Case sensitive";
+        Casing = "Casing";
         Category = "Category";
         Center = "Center";
         CenterHorizontally = "Center horizontally";
@@ -1048,6 +1054,7 @@ public class LanguageGeneral
         NormalCasing = "Normal casing";
         NotAvailable = "N/A";
         NotInstalled = "Not installed";
+        NothingSelected = "Nothing selected";
         Number = "Number";
         NumberSymbol = "#";
         OcrDotDotDot = "OCR...";
@@ -1192,6 +1199,9 @@ public class LanguageGeneral
         SelectSaveFolder = "Select a folder to save to";
         SelectSubtitle = "Select subtitle";
         SelectedAFolderToSaveTo = "Selected a folder to save to";
+        SelectionToLowercase = "Selection to lowercase";
+        SelectionToSentenceCase = "Selection to Sentence case";
+        SelectionToUppercase = "Selection to UPPERCASE";
         SelectedLines = "Selected lines";
         SelectedlinesX = "Selected lines: {0}";
         Sensitivity = "Sensitivity";

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -232,6 +232,8 @@ public class LanguageSettingsShortcuts
     public string GoToPreviousBookmark { get; set; }
     public string SelectionToLower { get; set; }
     public string SelectionToUpper { get; set; }
+    public string SelectionToSentenceCase { get; set; }
+    public string SelectionToggleCasing { get; set; }
     public string GoogleIt { get; set; }
     public string SetActorXY { get; set; }
     public string SetNewActor { get; set; }
@@ -482,6 +484,8 @@ public class LanguageSettingsShortcuts
         GoToPreviousBookmark = "Go to previous bookmark";
         SelectionToLower = "Text box: Selection to lowercase";
         SelectionToUpper = "Text box: Selection to uppercase";
+        SelectionToSentenceCase = "Text box: Selection to Sentence case";
+        SelectionToggleCasing = "Text box: Toggle casing (UPPER -> lower -> Title Case)";
         GoogleIt = "Google it (selected text)";
         SetActorXY = "Set actor {0}: {1}";
         SetNewActor = "Set new actor...";

--- a/src/ui/Logic/SentenceCaser.cs
+++ b/src/ui/Logic/SentenceCaser.cs
@@ -1,0 +1,76 @@
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace Nikse.SubtitleEdit.Logic
+{
+    /// <summary>
+    /// Sentence-cases a piece of text - the "Normal casing" fix from the "Change casing" dialog,
+    /// but applied to the current text box selection instead of whole lines (#13093).
+    /// </summary>
+    public static class SentenceCaser
+    {
+        private static string? _cachedLanguage;
+        private static FixCasing? _cachedFixCasing;
+
+        /// <summary>
+        /// Sentence-cases <paramref name="selectedText"/>, keeping any leading/trailing white space.
+        /// </summary>
+        /// <param name="textBefore">
+        /// The text preceding the selection. It decides whether the selection starts a new sentence,
+        /// so selecting the middle of a sentence does not capitalize the first word.
+        /// </param>
+        /// <param name="selectedText">The text to sentence-case.</param>
+        /// <param name="language">Two letter language code, used for the name list and culture.</param>
+        public static string SentenceCase(string textBefore, string selectedText, string language)
+        {
+            if (string.IsNullOrWhiteSpace(selectedText))
+            {
+                return selectedText;
+            }
+
+            // "Normal casing" trims the text it fixes, which would eat the white space around the
+            // selection - keep it and only run the fixer on the core.
+            var start = 0;
+            while (start < selectedText.Length && char.IsWhiteSpace(selectedText[start]))
+            {
+                start++;
+            }
+
+            var end = selectedText.Length;
+            while (end > start && char.IsWhiteSpace(selectedText[end - 1]))
+            {
+                end--;
+            }
+
+            var prefix = selectedText.Substring(0, start);
+            var core = selectedText.Substring(start, end - start);
+            var suffix = selectedText.Substring(end);
+
+            var subtitle = new Subtitle();
+            var hasTextBefore = !string.IsNullOrWhiteSpace(textBefore);
+            if (hasTextBefore)
+            {
+                // Same start/end times means no gap, so the fixer treats the selection as a
+                // continuation of the text before it.
+                subtitle.Paragraphs.Add(new Paragraph(textBefore, 0, 1000));
+            }
+
+            subtitle.Paragraphs.Add(new Paragraph(core, 1000, 2000));
+
+            GetFixCasing(language).Fix(subtitle);
+
+            return prefix + subtitle.Paragraphs[hasTextBefore ? 1 : 0].Text + suffix;
+        }
+
+        // Loading the name list hits the disk, so keep the last one around - this runs on a keystroke.
+        private static FixCasing GetFixCasing(string language)
+        {
+            if (_cachedFixCasing == null || _cachedLanguage != language)
+            {
+                _cachedFixCasing = new FixCasing(language) { FixNormal = true };
+                _cachedLanguage = language;
+            }
+
+            return _cachedFixCasing;
+        }
+    }
+}

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -431,9 +431,10 @@ public static class ShortcutsMain
         { nameof(MainViewModel.PlaySelectedLinesWithLoopCommand), Se.Language.General.PlaySelectedLinesWithLoop },
         { nameof(MainViewModel.PlaySelectedLinesAndFocusWaveformCommand), Se.Language.General.PlaySelectedLinesAndFocusWaveform },
         { nameof(MainViewModel.PlaySelectedLinesWithLoopAndFocusWaveformCommand), Se.Language.General.PlaySelectedLinesWithLoopAndFocusWaveform },
-        { nameof(MainViewModel.ToggleCasingCommand), Se.Language.General.ToggleCasing },
+        { nameof(MainViewModel.ToggleCasingCommand), Se.Language.Options.Shortcuts.SelectionToggleCasing },
         { nameof(MainViewModel.SelectionToLowerCommand), Se.Language.Options.Shortcuts.SelectionToLower },
         { nameof(MainViewModel.SelectionToUpperCommand), Se.Language.Options.Shortcuts.SelectionToUpper },
+        { nameof(MainViewModel.SelectionToSentenceCaseCommand), Se.Language.Options.Shortcuts.SelectionToSentenceCase },
         { nameof(MainViewModel.GoogleItCommand), Se.Language.Options.Shortcuts.GoogleIt },
         { nameof(MainViewModel.ImportImageSubtitleForEditCommand), Se.Language.Options.Shortcuts.ImportImageSubtitleForEdit },
         { nameof(MainViewModel.ShowMediaInformationCommand), Se.Language.Options.Shortcuts.ShowMediaInformation },
@@ -826,9 +827,12 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.PlaySelectedLinesWithLoopCommand, nameof(vm.PlaySelectedLinesWithLoopCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.PlaySelectedLinesAndFocusWaveformCommand, nameof(vm.PlaySelectedLinesAndFocusWaveformCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.PlaySelectedLinesWithLoopAndFocusWaveformCommand, nameof(vm.PlaySelectedLinesWithLoopAndFocusWaveformCommand), ShortcutCategory.General, ShortcutGroup.Video);
-        AddShortcut(shortcuts, vm.ToggleCasingCommand, nameof(vm.ToggleCasingCommand), ShortcutCategory.SubtitleGridAndTextBox);
+        // "Toggle casing" also works on selected lines in the grid, but it belongs next to the two
+        // other casing actions when browsing shortcuts - the group is display-only (#13093).
+        AddShortcut(shortcuts, vm.ToggleCasingCommand, nameof(vm.ToggleCasingCommand), ShortcutCategory.SubtitleGridAndTextBox, ShortcutGroup.TextBox);
         AddShortcut(shortcuts, vm.SelectionToLowerCommand, nameof(vm.SelectionToLowerCommand), ShortcutCategory.TextBox);
         AddShortcut(shortcuts, vm.SelectionToUpperCommand, nameof(vm.SelectionToUpperCommand), ShortcutCategory.TextBox);
+        AddShortcut(shortcuts, vm.SelectionToSentenceCaseCommand, nameof(vm.SelectionToSentenceCaseCommand), ShortcutCategory.TextBox);
         AddShortcut(shortcuts, vm.GoogleItCommand, nameof(vm.GoogleItCommand), ShortcutCategory.TextBox, ShortcutGroup.Search);
         AddShortcut(shortcuts, vm.ImportImageSubtitleForEditCommand, nameof(vm.ImportImageSubtitleForEditCommand), ShortcutCategory.General, ShortcutGroup.File);
         AddShortcut(shortcuts, vm.ShowMediaInformationCommand, nameof(vm.ShowMediaInformationCommand), ShortcutCategory.General, ShortcutGroup.Video);

--- a/tests/UI/Logic/SentenceCaserTests.cs
+++ b/tests/UI/Logic/SentenceCaserTests.cs
@@ -1,0 +1,59 @@
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// "Selection to Sentence case" (#13093) - the "Normal casing" fix applied to a text box
+/// selection instead of whole lines.
+/// </summary>
+public class SentenceCaserTests
+{
+    [Fact]
+    public void SentenceCaseUppercaseSelection()
+    {
+        var res = SentenceCaser.SentenceCase(string.Empty, "HOW ARE YOU?", "en");
+        Assert.Equal("How are you?", res);
+    }
+
+    [Fact]
+    public void SentenceCaseKeepsSentenceStartsInsideSelection()
+    {
+        var res = SentenceCaser.SentenceCase(string.Empty, "HOW ARE YOU? I AM FINE.", "en");
+        Assert.Equal("How are you? I am fine.", res);
+    }
+
+    [Fact]
+    public void SentenceCaseDoesNotCapitalizeMidSentenceSelection()
+    {
+        var res = SentenceCaser.SentenceCase("How ", "ARE YOU?", "en");
+        Assert.Equal("are you?", res);
+    }
+
+    [Fact]
+    public void SentenceCaseCapitalizesAfterSentenceEnd()
+    {
+        var res = SentenceCaser.SentenceCase("I am fine. ", "HOW ARE YOU?", "en");
+        Assert.Equal("How are you?", res);
+    }
+
+    [Fact]
+    public void SentenceCaseKeepsSurroundingWhiteSpace()
+    {
+        var res = SentenceCaser.SentenceCase(string.Empty, " HOW ARE YOU? ", "en");
+        Assert.Equal(" How are you? ", res);
+    }
+
+    [Fact]
+    public void SentenceCaseKeepsTags()
+    {
+        var res = SentenceCaser.SentenceCase(string.Empty, "<i>HOW ARE YOU?</i>", "en");
+        Assert.Equal("<i>How are you?</i>", res);
+    }
+
+    [Fact]
+    public void SentenceCaseWhiteSpaceOnlySelectionIsUnchanged()
+    {
+        var res = SentenceCaser.SentenceCase(string.Empty, "   ", "en");
+        Assert.Equal("   ", res);
+    }
+}


### PR DESCRIPTION
Fixes #13093

"Toggle casing" (`Ctrl+Shift+F3`, the SE4 default) was never removed - it is just shortcut-only, and in the Shortcuts window it sits under "Subtitle list view & text box" while the other two casing actions are under "Text box". Browsing the Text box group therefore shows only lowercase/uppercase, which reads as "the sentence casing option is gone".

### Changes

- **Text box context menu** — new **Casing** submenu: Toggle casing, Selection to UPPERCASE, Selection to lowercase, Selection to Sentence case, and Change casing...
- **Shortcuts window** — "Toggle casing" is now labeled `Text box: Toggle casing (UPPER -> lower -> Title Case)` and listed in the **Text box** group. The dispatch category is unchanged (`SubtitleGridAndTextBox`), so it still works on selected lines when the grid has focus; only the display group moved.
- **New action: `Text box: Selection to Sentence case`** — the "Normal casing" fix from the Change casing dialog, applied to the text box selection. The text before the selection decides whether the first word is capitalized, so selecting the middle of a sentence does not capitalize it. Leading/trailing white space and tags are kept. Ships unassigned; assignable in Options - Shortcuts.

### Bugs fixed along the way

- Toggle casing / to lowercase / to UPPERCASE always operated on the main text box, but the key handler dispatches them when **either** edit box has focus - pressing them in the original/translation box changed the main box. They now use the focused text box.
- The selection is restored after the change, so the commands can be pressed repeatedly on the same selection (SE4 parity).
- With nothing selected they did nothing silently; they now show "Nothing selected" in the status bar, like SE4.
- Toggle casing on multiple grid lines cycled each line on its own state, so a mixed selection drifted apart. It now uses the first selected line as the reference, like SE4's `ToggleCasingListView`.

### Tests

`tests/UI/Logic/SentenceCaserTests.cs` (7 new tests) - full UI suite passes locally: 1202 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)