### PR TITLE
Text box: put cursor at line start when navigating lines

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12421,6 +12421,38 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private void GoToNextLineCursorAtEnd()
+    {
+        var idx = (SelectedSubtitleIndex ?? -1) + 1;
+        if (idx <= 0 || idx >= Subtitles.Count)
+        {
+            return;
+        }
+
+        GoToNextLine();
+
+        // SelectAndScrollToRow places the caret at the start in a dispatcher post;
+        // queue the caret-at-end placement after it. The text-box binding may not
+        // have propagated yet by then (same situation as ShowFindMatch), so make
+        // sure the box shows the target line's text before measuring its length.
+        Dispatcher.UIThread.Post(() =>
+        {
+            var subtitle = Subtitles.GetOrNull(idx);
+            if (subtitle == null || !ReferenceEquals(SubtitleGrid.SelectedItem, subtitle))
+            {
+                return;
+            }
+
+            if (EditTextBox.Text != subtitle.Text)
+            {
+                EditTextBox.Text = subtitle.Text;
+            }
+
+            EditTextBox.CaretIndex = EditTextBox.Text.Length;
+        });
+    }
+
+    [RelayCommand]
     private void GoToPreviousLine()
     {
         var idx = SelectedSubtitleIndex ?? -1;
@@ -15729,6 +15761,7 @@ public partial class MainViewModel :
             if (indexToScroll >= 0 && indexToScroll < Subtitles.Count)
             {
                 var itemToScroll = Subtitles[indexToScroll];
+                var rowChanged = !ReferenceEquals(SubtitleGrid.SelectedItem, itemToScroll);
 
                 // Get the offset next to the target first - left to itself the virtualizing panel
                 // walks there row by row on long jumps, which is what made Home (and Find/Go to
@@ -15736,6 +15769,18 @@ public partial class MainViewModel :
                 TableViewExtras.PrePositionScroll(SubtitleGrid, indexToScroll);
                 SubtitleGrid.SelectedItem = itemToScroll;
                 SubtitleGrid.ScrollIntoView(itemToScroll);
+
+                // Avalonia keeps the caret index when the bound text changes, so navigating
+                // to another line left the caret at the previous line's (clamped) position -
+                // seemingly random (issue #12707). SE4 always lands at the start (WinForms
+                // resets the caret when Text is assigned); do the same. Callers that place
+                // the caret themselves (e.g. find match highlight) set the selected row
+                // before calling, so rowChanged is false and they are not clobbered here.
+                if (rowChanged)
+                {
+                    EditTextBox.CaretIndex = 0;
+                    EditTextBoxOriginal.CaretIndex = 0;
+                }
 
                 if (Se.Settings.General.SubtitleGridCenterSelectedRow)
                 {

--- a/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
+++ b/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
@@ -315,6 +315,7 @@ public static class Se4ShortcutsImporter
         // General
         ["GeneralGoToFirstSelectedLine"] = nameof(MainViewModel.FocusSelectedLineCommand),
         ["GeneralGoToNextSubtitle"] = nameof(MainViewModel.GoToNextLineCommand),
+        ["GeneralGoToNextSubtitleCursorAtEnd"] = nameof(MainViewModel.GoToNextLineCursorAtEndCommand),
         ["GeneralGoToPrevSubtitle"] = nameof(MainViewModel.GoToPreviousLineCommand),
         ["GeneralGoToNextBookmark"] = nameof(MainViewModel.GoToNextBookmarkCommand),
         ["GeneralGoToPreviousBookmark"] = nameof(MainViewModel.GoToPreviousBookmarkCommand),

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -24,6 +24,7 @@ public class LanguageSettingsShortcuts
     public string GeneralToggleTranslationMode { get; set; }
     public string GeneralChooseLayout { get; set; }
     public string GeneralGoToNextSubtitle { get; set; }
+    public string GeneralGoToNextSubtitleCursorAtEnd { get; set; }
     public string GeneralGoToPrevSubtitle { get; set; }
     public string GeneralGoToVideoPosition { get; set; }
     public string GeneralToggleItalic { get; set; }
@@ -271,6 +272,7 @@ public class LanguageSettingsShortcuts
         GeneralToggleTranslationMode = "Toggle translation mode";
         GeneralChooseLayout = "Choose layout";
         GeneralGoToNextSubtitle = "Go to next subtitle";
+        GeneralGoToNextSubtitleCursorAtEnd = "Go to next subtitle and set cursor at end";
         GeneralGoToPrevSubtitle = "Go to previous subtitle";
         GeneralGoToVideoPosition = "Go to video position";
         GeneralToggleItalic = "Toggle italic";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -229,6 +229,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.CommandShowLayoutCommand), Se.Language.Options.Shortcuts.GeneralChooseLayout },
 
         { nameof(MainViewModel.GoToNextLineCommand), Se.Language.Options.Shortcuts.GeneralGoToNextSubtitle },
+        { nameof(MainViewModel.GoToNextLineCursorAtEndCommand), Se.Language.Options.Shortcuts.GeneralGoToNextSubtitleCursorAtEnd },
         { nameof(MainViewModel.GoToPreviousLineCommand), Se.Language.Options.Shortcuts.GeneralGoToPrevSubtitle },
         { nameof(MainViewModel.GoToNextLineAndSetVideoPositionCommand), Se.Language.Options.Shortcuts.GoToNextLineAndSetVideoPosition },
         { nameof(MainViewModel.GoToPreviousLineAndSetVideoPositionCommand), Se.Language.Options.Shortcuts.GoToPreviousLineAndSetVideoPosition },
@@ -579,6 +580,7 @@ public static class ShortcutsMain
 
         AddShortcut(shortcuts, vm.GoToPreviousLineCommand, nameof(vm.GoToPreviousLineCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToNextLineCommand, nameof(vm.GoToNextLineCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.GoToNextLineCursorAtEndCommand, nameof(vm.GoToNextLineCursorAtEndCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToPreviousLineAndSetVideoPositionCommand, nameof(vm.GoToPreviousLineAndSetVideoPositionCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToNextLineAndSetVideoPositionCommand, nameof(vm.GoToNextLineAndSetVideoPositionCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToPreviousLineFromVideoPositionCommand, nameof(vm.GoToPreviousLineFromVideoPositionCommand), ShortcutCategory.General);


### PR DESCRIPTION
Fixes #12707

### Problem

With "Go to next line" / "Go to next line and set video position", the caret in the edit text box landed several characters into the new line, seemingly at random. Avalonia's `TextBox` keeps the caret index (clamped to the new text length) when the bound text changes, so the caret simply stayed wherever it was in the *previous* line.

### Fix

SE4 always lands at the start of the text box: WinForms resets the caret to 0 whenever `Text` is assigned, and every row navigation goes through that assignment. This PR restores that invariant centrally in `SelectAndScrollToRow` - when the selected row actually changes, the caret in both edit text boxes is reset to 0. Flows that place the caret themselves (find/replace match highlighting) set the selected row *before* calling `SelectAndScrollToRow`, so the row-changed guard leaves them untouched.

### SE4 shortcut port

SE4 also had a dedicated "Go to next line and set cursor at end" shortcut (`GeneralGoToNextSubtitleCursorAtEnd`) whose SE5 counterpart was missing. Ported it:

- New `GoToNextLineCursorAtEnd` command (navigates like "Go to next line", then places the caret at the end once the binding has propagated)
- Registered in the shortcuts window under General, unbound by default (as in SE4)
- Mapped in the SE4 shortcuts importer so imported SE4 bindings carry over

### Testing

- `dotnet build src/ui/UI.csproj` - clean
- `dotnet test tests/UI/UITests.csproj --filter Se4ShortcutsImporterMap` - passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)