### PR TITLE
Fix a couple of timecode inconsistencies in SMPTE mode (SE4)

### DIFF
--- a/src/ui/Controls/VideoPlayerContainer.cs
+++ b/src/ui/Controls/VideoPlayerContainer.cs
@@ -1908,12 +1908,12 @@ namespace Nikse.SubtitleEdit.Controls
             {
                 if (showDuration || Configuration.Settings.General.CurrentVideoOffsetInMs != 0)
                 {
-                    var span = TimeCode.FromSeconds(positionInSeconds + 0.017 + Configuration.Settings.General.CurrentVideoOffsetInMs / TimeCode.BaseUnit);
+                    var span = TimeCode.FromSeconds(positionInSeconds + Configuration.Settings.General.CurrentVideoOffsetInMs / TimeCode.BaseUnit);
                     displayTimeCode = $"{span.ToDisplayString()} / {dur.ToDisplayString()} SMPTE";
                 }
                 else
                 {
-                    var pos = positionInSeconds + 0.017 + Configuration.Settings.General.CurrentVideoOffsetInMs / TimeCode.BaseUnit;
+                    var pos = positionInSeconds + Configuration.Settings.General.CurrentVideoOffsetInMs / TimeCode.BaseUnit;
                     var seconds = (pos - dur.TotalSeconds) * -1;
                     if (seconds < 0)
                     {
@@ -2124,15 +2124,15 @@ namespace Nikse.SubtitleEdit.Controls
                 {
                     var v = value;
 
-                    if (SmpteMode)
-                    {
-                        v *= 1.001;
-                    }
-
                     if (Configuration.Settings.General.UseTimeFormatHHMMSSFF)
                     {
                         var tc = TimeCode.FromSeconds(v);
                         v = tc.AlignToFrame().TotalSeconds;
+                    }
+
+                    if (SmpteMode)
+                    {
+                        v *= 1.001;
                     }
 
                     VideoPlayer.CurrentPosition = v;


### PR DESCRIPTION
Adding 0.017 to the video timecode in SMPTE mode used to make it not aligned with the actual time in the video, and used to add a frame in frame mode.

And `AlignToFrame` should run before the 1.001 scaling, not after.