### PR TITLE
Fix ASSA/SSA style editor losing data on rename and style switch

### DIFF
--- a/src/ui/Features/Assa/AssaSingleStyleViewModel.cs
+++ b/src/ui/Features/Assa/AssaSingleStyleViewModel.cs
@@ -33,6 +33,20 @@ public partial class AssaSingleStyleViewModel : ObservableObject
         CurrentStyle = new StyleDisplay(style);
     }
 
+    /// <summary>
+    /// The font combo box binds SelectedItem to CurrentStyle.FontName; a font missing from
+    /// the item list would make Avalonia clear the selection and null out the style's font.
+    /// Make sure the font is listed before the style becomes current (#13101).
+    /// </summary>
+    partial void OnCurrentStyleChanging(StyleDisplay? value)
+    {
+        var fontName = value?.FontName;
+        if (!string.IsNullOrEmpty(fontName) && !Fonts.Contains(fontName))
+        {
+            Fonts.Insert(0, fontName);
+        }
+    }
+
     [RelayCommand]
     private void Ok()
     {

--- a/src/ui/Features/Assa/AssaStylesViewModel.cs
+++ b/src/ui/Features/Assa/AssaStylesViewModel.cs
@@ -74,6 +74,7 @@ public partial class AssaStylesViewModel : ObservableObject, IClosingCleanup
     private volatile bool _isClosing;
     private readonly System.Timers.Timer _timerUpdatePreview;
     private readonly List<string> _extraCategories = new();
+    private readonly FileStyleRenameTracker _renameTracker;
 
     public AssaStylesViewModel(IFileHelper fileHelper, IWindowService windowService)
     {
@@ -98,6 +99,8 @@ public partial class AssaStylesViewModel : ObservableObject, IClosingCleanup
 
         LoadSettings();
 
+        _renameTracker = new FileStyleRenameTracker(FileStyles, () => _subtitle, UpdateUsages);
+
         StorageStylesView = new ObservableCollection<StyleDisplay>();
         StorageStyles.CollectionChanged += (_, _) => RefreshStorageStylesView();
         RefreshStorageStylesView();
@@ -105,6 +108,20 @@ public partial class AssaStylesViewModel : ObservableObject, IClosingCleanup
 
         _timerUpdatePreview = new System.Timers.Timer(500);
         _timerUpdatePreview.Elapsed += TimerUpdatePreviewElapsed;
+    }
+
+    /// <summary>
+    /// The font combo box binds SelectedItem to CurrentStyle.FontName; a font missing from
+    /// the item list would make Avalonia clear the selection and null out the style's font.
+    /// Make sure the font is listed before the style becomes current (#13101).
+    /// </summary>
+    partial void OnCurrentStyleChanging(StyleDisplay? value)
+    {
+        var fontName = value?.FontName;
+        if (!string.IsNullOrEmpty(fontName) && !Fonts.Contains(fontName))
+        {
+            Fonts.Insert(0, fontName);
+        }
     }
 
     private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
@@ -1063,7 +1080,7 @@ public partial class AssaStylesViewModel : ObservableObject, IClosingCleanup
     {
         foreach (var style in FileStyles)
         {
-            style.UsageCount = _subtitle.Paragraphs.Count(p => p.Extra != null && p.Extra.TrimStart('*').Equals(style.Name.TrimStart('*')));
+            style.UsageCount = _subtitle.Paragraphs.Count(p => p.Extra != null && p.Extra.TrimStart('*').Equals(style.Name.TrimStart('*'), StringComparison.OrdinalIgnoreCase));
         }
     }
 

--- a/src/ui/Features/Assa/FileStyleRenameTracker.cs
+++ b/src/ui/Features/Assa/FileStyleRenameTracker.cs
@@ -1,0 +1,95 @@
+using Nikse.SubtitleEdit.Core.Common;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Assa;
+
+/// <summary>
+/// Keeps the subtitle's dialog lines pointing at the right style while file styles are
+/// renamed in the ASSA/SSA styles dialog (#13101). The name text box binds per keystroke,
+/// so each change re-points every line from the style's last known name to the new one -
+/// without this, renamed styles keep their old name in the lines, and OK silently resets
+/// those lines to the first style in the file.
+/// </summary>
+internal sealed class FileStyleRenameTracker
+{
+    private readonly ObservableCollection<StyleDisplay> _fileStyles;
+    private readonly Func<Subtitle> _getSubtitle;
+    private readonly Action _updateUsages;
+    private readonly List<StyleDisplay> _tracked = new();
+
+    public FileStyleRenameTracker(ObservableCollection<StyleDisplay> fileStyles, Func<Subtitle> getSubtitle, Action updateUsages)
+    {
+        _fileStyles = fileStyles;
+        _getSubtitle = getSubtitle;
+        _updateUsages = updateUsages;
+
+        fileStyles.CollectionChanged += (_, _) => Resync();
+        Resync();
+    }
+
+    private void Resync()
+    {
+        var previouslyTracked = new HashSet<StyleDisplay>(_tracked);
+        foreach (var style in _tracked)
+        {
+            style.PropertyChanged -= StylePropertyChanged;
+        }
+
+        _tracked.Clear();
+
+        foreach (var style in _fileStyles)
+        {
+            if (!previouslyTracked.Contains(style))
+            {
+                // The name a style enters the list with is the name its lines (if any) use -
+                // for loaded styles the name from the header, for new/imported/duplicated
+                // styles the freshly generated unique name.
+                style.LastKnownName = style.Name;
+            }
+
+            style.PropertyChanged += StylePropertyChanged;
+            _tracked.Add(style);
+        }
+    }
+
+    private void StylePropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(StyleDisplay.Name) || sender is not StyleDisplay style)
+        {
+            return;
+        }
+
+        var oldName = style.LastKnownName;
+        var newName = style.Name;
+        if (string.IsNullOrWhiteSpace(newName) || newName == oldName)
+        {
+            return; // blank is a transient editing state; keep the chain and wait for a real name
+        }
+
+        if (_fileStyles.Any(other => !ReferenceEquals(other, style) && other.Name.Equals(newName, StringComparison.OrdinalIgnoreCase)))
+        {
+            return; // duplicate name (possibly mid-typing); re-pointing now would merge two styles' lines
+        }
+
+        if (_fileStyles.Any(other => !ReferenceEquals(other, style) && other.Name.Equals(oldName, StringComparison.OrdinalIgnoreCase)))
+        {
+            style.LastKnownName = newName; // the old name belongs to another style; never steal its lines
+            return;
+        }
+
+        foreach (var paragraph in _getSubtitle().Paragraphs)
+        {
+            if (paragraph.Extra != null && paragraph.Extra.TrimStart('*').Equals(oldName, StringComparison.OrdinalIgnoreCase))
+            {
+                paragraph.Extra = newName;
+            }
+        }
+
+        style.LastKnownName = newName;
+        _updateUsages();
+    }
+}

--- a/src/ui/Features/Assa/StyleDisplay.cs
+++ b/src/ui/Features/Assa/StyleDisplay.cs
@@ -12,7 +12,6 @@ namespace Nikse.SubtitleEdit.Features.Assa;
 public partial class StyleDisplay : ObservableObject
 {
     [ObservableProperty] private string _name = string.Empty;
-    [ObservableProperty] private string _fontName = string.Empty;
     [ObservableProperty] private decimal _fontSize;
     [ObservableProperty] private int _usageCount;
     [ObservableProperty] private Color _colorPrimary;
@@ -29,15 +28,6 @@ public partial class StyleDisplay : ObservableObject
     [ObservableProperty] private decimal _scaleY;
     [ObservableProperty] private decimal _spacing;
     [ObservableProperty] private decimal _angle;
-    [ObservableProperty] private bool _alignmentAn1;
-    [ObservableProperty] private bool _alignmentAn2;
-    [ObservableProperty] private bool _alignmentAn3;
-    [ObservableProperty] private bool _alignmentAn4;
-    [ObservableProperty] private bool _alignmentAn5;
-    [ObservableProperty] private bool _alignmentAn6;
-    [ObservableProperty] private bool _alignmentAn7;
-    [ObservableProperty] private bool _alignmentAn8;
-    [ObservableProperty] private bool _alignmentAn9;
     [ObservableProperty] private int _marginLeft;
     [ObservableProperty] private int _marginRight;
     [ObservableProperty] private int _marginVertical;
@@ -46,29 +36,96 @@ public partial class StyleDisplay : ObservableObject
     [ObservableProperty] private bool _isDefault;
     [ObservableProperty] private string _category = string.Empty;
 
-    public string OriginalName { get; set; } = string.Empty;
+    private string _fontName = string.Empty;
+
+    /// <summary>
+    /// The font combo box binds SelectedItem two-way to this. When the style editor switches
+    /// to a style whose font is not in the combo's item list, Avalonia clears SelectedItem and
+    /// the binding writes null back - which must not erase the style's font (#13101).
+    /// </summary>
+    public string FontName
+    {
+        get => _fontName;
+        set
+        {
+            if (value is null)
+            {
+                return;
+            }
+
+            SetProperty(ref _fontName, value);
+        }
+    }
+
+    /// <summary>
+    /// The name this style is currently known by in the subtitle's dialog lines. The styles
+    /// dialog re-points lines on rename and then advances this to the new name (#13101).
+    /// </summary>
+    public string LastKnownName { get; set; } = string.Empty;
+
+    // The nine alignment flags back one shared radio-button group, bound two-way through
+    // "CurrentStyle.AlignmentAnX". When the current style changes, the group unchecks the
+    // old radio while its binding still points at the previously shown style, which would
+    // erase that style's alignment (#13101). Radio semantics only ever need "set true":
+    // checking one clears the others, and false writes are ignored.
+    private bool _alignmentAn1;
+    private bool _alignmentAn2;
+    private bool _alignmentAn3;
+    private bool _alignmentAn4;
+    private bool _alignmentAn5;
+    private bool _alignmentAn6;
+    private bool _alignmentAn7;
+    private bool _alignmentAn8;
+    private bool _alignmentAn9;
+
+    public bool AlignmentAn1 { get => _alignmentAn1; set { if (value) { SetCheckedAlignment(1); } } }
+    public bool AlignmentAn2 { get => _alignmentAn2; set { if (value) { SetCheckedAlignment(2); } } }
+    public bool AlignmentAn3 { get => _alignmentAn3; set { if (value) { SetCheckedAlignment(3); } } }
+    public bool AlignmentAn4 { get => _alignmentAn4; set { if (value) { SetCheckedAlignment(4); } } }
+    public bool AlignmentAn5 { get => _alignmentAn5; set { if (value) { SetCheckedAlignment(5); } } }
+    public bool AlignmentAn6 { get => _alignmentAn6; set { if (value) { SetCheckedAlignment(6); } } }
+    public bool AlignmentAn7 { get => _alignmentAn7; set { if (value) { SetCheckedAlignment(7); } } }
+    public bool AlignmentAn8 { get => _alignmentAn8; set { if (value) { SetCheckedAlignment(8); } } }
+    public bool AlignmentAn9 { get => _alignmentAn9; set { if (value) { SetCheckedAlignment(9); } } }
+
+    private void SetCheckedAlignment(int alignment)
+    {
+        SetAlignmentFlag(ref _alignmentAn1, alignment == 1, nameof(AlignmentAn1));
+        SetAlignmentFlag(ref _alignmentAn2, alignment == 2, nameof(AlignmentAn2));
+        SetAlignmentFlag(ref _alignmentAn3, alignment == 3, nameof(AlignmentAn3));
+        SetAlignmentFlag(ref _alignmentAn4, alignment == 4, nameof(AlignmentAn4));
+        SetAlignmentFlag(ref _alignmentAn5, alignment == 5, nameof(AlignmentAn5));
+        SetAlignmentFlag(ref _alignmentAn6, alignment == 6, nameof(AlignmentAn6));
+        SetAlignmentFlag(ref _alignmentAn7, alignment == 7, nameof(AlignmentAn7));
+        SetAlignmentFlag(ref _alignmentAn8, alignment == 8, nameof(AlignmentAn8));
+        SetAlignmentFlag(ref _alignmentAn9, alignment == 9, nameof(AlignmentAn9));
+    }
+
+    private void SetAlignmentFlag(ref bool field, bool value, string propertyName)
+    {
+        if (field == value)
+        {
+            return;
+        }
+
+        field = value;
+        OnPropertyChanged(propertyName);
+    }
 
     public StyleDisplay()
     {
         _name = string.Empty;
-        OriginalName = string.Empty;
         AlignmentAn2 = true;
         BorderStyle = BorderStyleItem.List().First();
     }
 
     public void SetAlignment(string alignment)
     {
-        AlignmentAn1 = alignment.EndsWith("1");
-        AlignmentAn2 = alignment.EndsWith("2");
-        AlignmentAn3 = alignment.EndsWith("3");
-        AlignmentAn4 = alignment.EndsWith("4");
-        AlignmentAn5 = alignment.EndsWith("5");
-        AlignmentAn6 = alignment.EndsWith("6");
-        AlignmentAn7 = alignment.EndsWith("7");
-        AlignmentAn8 = alignment.EndsWith("8");
-        AlignmentAn9 = alignment.EndsWith("9");
+        var number = alignment.Length > 0 && alignment[^1] >= '1' && alignment[^1] <= '9'
+            ? alignment[^1] - '0'
+            : 2; // bottom center
 
-        UpdateAlignment();
+        SetCheckedAlignment(number);
     }
 
     public string GetAlignment()
@@ -76,16 +133,6 @@ public partial class StyleDisplay : ObservableObject
         if (AlignmentAn1)
         {
             return "1";
-        }
-
-        if (AlignmentAn2)
-        {
-            return "2";
-        }
-
-        if (AlignmentAn3)
-        {
-            return "3";
         }
 
         if (AlignmentAn3)
@@ -129,7 +176,7 @@ public partial class StyleDisplay : ObservableObject
     public StyleDisplay(SsaStyle style)
     {
         Name = style.Name;
-        OriginalName = style.Name;
+        LastKnownName = style.Name;
         FontName = style.FontName;
         FontSize = style.FontSize;
         ColorPrimary = style.Primary.ToAvaloniaColor();
@@ -146,15 +193,7 @@ public partial class StyleDisplay : ObservableObject
         ScaleY = style.ScaleY;
         Spacing = style.Spacing;
         Angle = style.Angle;
-        AlignmentAn1 = style.Alignment.EndsWith("1");
-        AlignmentAn2 = style.Alignment.EndsWith("2");
-        AlignmentAn3 = style.Alignment.EndsWith("3");
-        AlignmentAn4 = style.Alignment.EndsWith("4");
-        AlignmentAn5 = style.Alignment.EndsWith("5");
-        AlignmentAn6 = style.Alignment.EndsWith("6");
-        AlignmentAn7 = style.Alignment.EndsWith("7");
-        AlignmentAn8 = style.Alignment.EndsWith("8");
-        AlignmentAn9 = style.Alignment.EndsWith("9");
+        SetAlignment(style.Alignment);
         MarginLeft = style.MarginLeft;
         MarginRight = style.MarginRight;
         MarginVertical = style.MarginVertical;
@@ -171,14 +210,12 @@ public partial class StyleDisplay : ObservableObject
         {
             BorderStyle = BorderStyleItem.List().First(p => p.Style == Assa.BorderStyleType.Outline);
         }
-
-        UpdateAlignment();
     }
 
     public StyleDisplay(SeAssaStyle style)
     {
         Name = style.Name;
-        OriginalName = style.Name;
+        LastKnownName = style.Name;
         FontName = style.FontName;
         FontSize = style.FontSize;
         ColorPrimary = style.ColorPrimary.FromHexToColor();
@@ -215,21 +252,6 @@ public partial class StyleDisplay : ObservableObject
         }
 
         SetAlignment(style.Alignment);
-    }
-
-    private void UpdateAlignment()
-    {
-        if (!AlignmentAn1 &&
-            !AlignmentAn3 &&
-            !AlignmentAn4 &&
-            !AlignmentAn5 &&
-            !AlignmentAn6 &&
-            !AlignmentAn7 &&
-            !AlignmentAn8 &&
-            !AlignmentAn9)
-        {
-            AlignmentAn2 = true; // bottom center
-        }
     }
 
     internal SsaStyle ToSsaStyle()

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1313,7 +1313,10 @@ public partial class MainViewModel :
 
         var result = await ShowDialogAsync<AssaStylesWindow, AssaStylesViewModel>(vm =>
         {
-            vm.Initialize(_subtitle, SelectedSubtitleFormat, _subtitleFileName ?? string.Empty,
+            // GetUpdateSubtitle: the dialog needs paragraphs with Extra set to the grid rows'
+            // current styles - a stale _subtitle breaks usage counts and the positional
+            // re-apply of styles on OK (#13101).
+            vm.Initialize(GetUpdateSubtitle(), SelectedSubtitleFormat, _subtitleFileName ?? string.Empty,
                 SelectedSubtitle?.Style ?? string.Empty, this);
         });
 
@@ -1373,7 +1376,8 @@ public partial class MainViewModel :
 
         var result = await ShowDialogAsync<SsaStylesWindow, SsaStylesViewModel>(vm =>
         {
-            vm.Initialize(_subtitle, SelectedSubtitleFormat, _subtitleFileName ?? string.Empty,
+            // GetUpdateSubtitle: see ShowAssaStyles (#13101).
+            vm.Initialize(GetUpdateSubtitle(), SelectedSubtitleFormat, _subtitleFileName ?? string.Empty,
                 SelectedSubtitle?.Style ?? string.Empty, this);
         });
 

--- a/src/ui/Features/Ssa/SsaStylesViewModel.cs
+++ b/src/ui/Features/Ssa/SsaStylesViewModel.cs
@@ -57,6 +57,7 @@ public partial class SsaStylesViewModel : ObservableObject, IClosingCleanup
     private readonly IFileHelper _fileHelper;
     private readonly IWindowService _windowService;
     private IApplySsaStyles? _applySsaStyles;
+    private readonly FileStyleRenameTracker _renameTracker;
     private Subtitle _subtitle;
     private string _subtitleFileName;
     private volatile bool _isClosing;
@@ -83,8 +84,24 @@ public partial class SsaStylesViewModel : ObservableObject, IClosingCleanup
 
         LoadSettings();
 
+        _renameTracker = new FileStyleRenameTracker(FileStyles, () => _subtitle, UpdateUsages);
+
         _timerUpdatePreview = new System.Timers.Timer(500);
         _timerUpdatePreview.Elapsed += TimerUpdatePreviewElapsed;
+    }
+
+    /// <summary>
+    /// The font combo box binds SelectedItem to CurrentStyle.FontName; a font missing from
+    /// the item list would make Avalonia clear the selection and null out the style's font.
+    /// Make sure the font is listed before the style becomes current (#13101).
+    /// </summary>
+    partial void OnCurrentStyleChanging(StyleDisplay? value)
+    {
+        var fontName = value?.FontName;
+        if (!string.IsNullOrEmpty(fontName) && !Fonts.Contains(fontName))
+        {
+            Fonts.Insert(0, fontName);
+        }
     }
 
     private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
@@ -687,7 +704,7 @@ public partial class SsaStylesViewModel : ObservableObject, IClosingCleanup
     {
         foreach (var style in FileStyles)
         {
-            style.UsageCount = _subtitle.Paragraphs.Count(p => p.Extra != null && p.Extra.TrimStart('*').Equals(style.Name.TrimStart('*')));
+            style.UsageCount = _subtitle.Paragraphs.Count(p => p.Extra != null && p.Extra.TrimStart('*').Equals(style.Name.TrimStart('*'), StringComparison.OrdinalIgnoreCase));
         }
     }
 

--- a/tests/UI/Features/Assa/AssaStyleEditorDataLossTests.cs
+++ b/tests/UI/Features/Assa/AssaStyleEditorDataLossTests.cs
@@ -1,0 +1,144 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Assa;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Features.Assa;
+
+/// <summary>
+/// Regression tests for issue #13101: the ASSA style editor lost information when switching
+/// between styles. The editor panel binds two-way through "CurrentStyle.X", and two of those
+/// bindings destroyed data on the previously (or newly) shown style:
+/// - the nine alignment radios share one group, and the group-uncheck of the old radio wrote
+///   false into a style that still had that alignment set;
+/// - the font combo cleared SelectedItem (and thereby the style's FontName) when the new
+///   current style's font was not in the combo's item list.
+/// These tests drive the real controls headless, built exactly like the production windows.
+/// </summary>
+public class AssaStyleEditorDataLossTests
+{
+    private static AssaStylesViewModel MakeVm()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<AssaStylesViewModel>();
+    }
+
+    private static StackPanel MakeAlignmentRadios(AssaStylesViewModel vm)
+    {
+        // Same construction as AssaStylesWindow/SsaStylesWindow/AssaSingleStyleWindow.
+        var panel = new StackPanel();
+        panel.Children.Add(UiUtil.MakeRadioButton(string.Empty, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.AlignmentAn7), "align"));
+        panel.Children.Add(UiUtil.MakeRadioButton(string.Empty, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.AlignmentAn8), "align"));
+        panel.Children.Add(UiUtil.MakeRadioButton(string.Empty, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.AlignmentAn9), "align"));
+        panel.Children.Add(UiUtil.MakeRadioButton(string.Empty, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.AlignmentAn4), "align"));
+        panel.Children.Add(UiUtil.MakeRadioButton(string.Empty, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.AlignmentAn5), "align"));
+        panel.Children.Add(UiUtil.MakeRadioButton(string.Empty, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.AlignmentAn6), "align"));
+        panel.Children.Add(UiUtil.MakeRadioButton(string.Empty, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.AlignmentAn1), "align"));
+        panel.Children.Add(UiUtil.MakeRadioButton(string.Empty, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.AlignmentAn2), "align"));
+        panel.Children.Add(UiUtil.MakeRadioButton(string.Empty, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.AlignmentAn3), "align"));
+        return panel;
+    }
+
+    [AvaloniaFact]
+    public void SwitchBetweenStylesWithDifferentAlignment_DoesNotLoseAlignment()
+    {
+        var vm = MakeVm();
+        var a = new StyleDisplay(new SsaStyle { Name = "A", Alignment = "2" });
+        var b = new StyleDisplay(new SsaStyle { Name = "B", Alignment = "5" });
+
+        var window = new Window { Content = MakeAlignmentRadios(vm) };
+        window.Show();
+
+        vm.CurrentStyle = a;
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        vm.CurrentStyle = b;
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        Assert.True(b.AlignmentAn5, "style B lost An5 after direct switch");
+        Assert.True(a.AlignmentAn2, "style A lost An2 after direct switch");
+
+        vm.CurrentStyle = a;
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        Assert.True(a.AlignmentAn2, "style A lost An2 after switching back");
+        Assert.True(b.AlignmentAn5, "style B lost An5 after switching back");
+    }
+
+    [AvaloniaFact]
+    public void SwitchBetweenStylesWithSameAlignment_ThroughNull_DoesNotLoseAlignment()
+    {
+        var vm = MakeVm();
+        var fileStyle = new StyleDisplay(new SsaStyle { Name = "FileDefault", Alignment = "2" });
+        var storageStyle = new StyleDisplay(new SsaStyle { Name = "StorageDefault", Alignment = "2" });
+
+        var window = new Window { Content = MakeAlignmentRadios(vm) };
+        window.Show();
+
+        vm.CurrentStyle = fileStyle;
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        // The file and storage grids both switch the current style on GotFocus and on
+        // SelectionChanged, so a grid-to-grid click briefly passes through a stale selection.
+        vm.CurrentStyle = null;
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        vm.CurrentStyle = storageStyle;
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        Assert.True(storageStyle.AlignmentAn2, "storage style lost An2 after switching through null");
+        Assert.True(fileStyle.AlignmentAn2, "file style lost An2 after switching through null");
+    }
+
+    [AvaloniaFact]
+    public void CheckingAnotherAlignmentRadio_MovesTheAlignment()
+    {
+        var vm = MakeVm();
+        var style = new StyleDisplay(new SsaStyle { Name = "A", Alignment = "2" });
+
+        var panel = MakeAlignmentRadios(vm);
+        var window = new Window { Content = panel };
+        window.Show();
+
+        vm.CurrentStyle = style;
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        // Check the An8 radio (top center) like a user click would.
+        var an8Radio = (RadioButton)panel.Children[1];
+        an8Radio.IsChecked = true;
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        Assert.True(style.AlignmentAn8);
+        Assert.False(style.AlignmentAn2);
+        Assert.Equal("8", style.GetAlignment());
+    }
+
+    [AvaloniaFact]
+    public void SwitchToStyleWithFontNotInFontsList_DoesNotLoseFontName()
+    {
+        var vm = MakeVm();
+        vm.Fonts.Clear();
+        vm.Fonts.Add("Arial");
+
+        var a = new StyleDisplay(new SsaStyle { Name = "A", FontName = "Arial" });
+        var b = new StyleDisplay(new SsaStyle { Name = "B", FontName = "SomeUninstalledFont" });
+
+        var combo = UiUtil.MakeComboBox(vm.Fonts, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.FontName));
+        var window = new Window { Content = combo };
+        window.Show();
+
+        vm.CurrentStyle = a;
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        vm.CurrentStyle = b;
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("SomeUninstalledFont", b.FontName);
+        Assert.Equal("Arial", a.FontName);
+    }
+}

--- a/tests/UI/Features/Assa/AssaStylesViewModelTests.cs
+++ b/tests/UI/Features/Assa/AssaStylesViewModelTests.cs
@@ -47,6 +47,107 @@ public class AssaStylesViewModelTests
         Assert.Contains(Se.Language.General.Default, viewModel.StorageCategories);
     }
 
+    private static AssaStylesViewModel MakeInitializedVm(out Subtitle subtitle)
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        var provider = services.BuildServiceProvider();
+        var vm = provider.GetRequiredService<AssaStylesViewModel>();
+
+        var styles = new List<SsaStyle>
+        {
+            new() { Name = "Default" },
+            new() { Name = "Top", Alignment = "8" },
+        };
+        subtitle = new Subtitle
+        {
+            Header = Nikse.SubtitleEdit.Core.SubtitleFormats.AdvancedSubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(
+                Nikse.SubtitleEdit.Core.SubtitleFormats.AdvancedSubStationAlpha.DefaultHeader, styles),
+        };
+        subtitle.Paragraphs.Add(new Paragraph("one", 0, 1000) { Extra = "Default" });
+        subtitle.Paragraphs.Add(new Paragraph("two", 1000, 2000) { Extra = "Default" });
+        subtitle.Paragraphs.Add(new Paragraph("three", 2000, 3000) { Extra = "Top" });
+
+        vm.Initialize(subtitle, new Nikse.SubtitleEdit.Core.SubtitleFormats.AdvancedSubStationAlpha(), "test.ass", "Default", null);
+        return vm;
+    }
+
+    /// <summary>
+    /// Renaming a style must re-point the lines that use it, keeping usage counts and the
+    /// styles applied on OK correct (#13101). The name text box binds per keystroke, so the
+    /// re-pointing must also survive intermediate states while typing.
+    /// </summary>
+    [AvaloniaFact]
+    public void RenamingFileStyle_RepointsSubtitleLines()
+    {
+        var vm = MakeInitializedVm(out _);
+        try
+        {
+            var defaultStyle = vm.FileStyles.First(s => s.Name == "Default");
+            Assert.Equal(2, defaultStyle.UsageCount);
+
+            defaultStyle.Name = "Narrator";
+
+            Assert.Equal("Narrator", vm.ResultSubtitle.Paragraphs[0].Extra);
+            Assert.Equal("Narrator", vm.ResultSubtitle.Paragraphs[1].Extra);
+            Assert.Equal("Top", vm.ResultSubtitle.Paragraphs[2].Extra);
+            Assert.Equal(2, defaultStyle.UsageCount);
+        }
+        finally
+        {
+            vm.OnClosingCleanup();
+        }
+    }
+
+    [AvaloniaFact]
+    public void RenamingFileStyle_ThroughBlankName_StillRepointsSubtitleLines()
+    {
+        var vm = MakeInitializedVm(out _);
+        try
+        {
+            var defaultStyle = vm.FileStyles.First(s => s.Name == "Default");
+
+            // Select-all + delete, then type a new name: the blank state must not break the chain.
+            defaultStyle.Name = string.Empty;
+            defaultStyle.Name = "N";
+            defaultStyle.Name = "Na";
+            defaultStyle.Name = "Narrator";
+
+            Assert.Equal("Narrator", vm.ResultSubtitle.Paragraphs[0].Extra);
+            Assert.Equal("Narrator", vm.ResultSubtitle.Paragraphs[1].Extra);
+            Assert.Equal("Top", vm.ResultSubtitle.Paragraphs[2].Extra);
+        }
+        finally
+        {
+            vm.OnClosingCleanup();
+        }
+    }
+
+    [AvaloniaFact]
+    public void RenamingFileStyle_ToAnotherStylesName_DoesNotStealItsLines()
+    {
+        var vm = MakeInitializedVm(out _);
+        try
+        {
+            var topStyle = vm.FileStyles.First(s => s.Name == "Top");
+
+            // "Top" -> "Default" collides with the other style; nothing may be re-pointed.
+            topStyle.Name = "Default";
+            Assert.Equal("Default", vm.ResultSubtitle.Paragraphs[0].Extra);
+            Assert.Equal("Top", vm.ResultSubtitle.Paragraphs[2].Extra);
+
+            // Typing on to a unique name must still move only the lines that used "Top".
+            topStyle.Name = "Default2";
+            Assert.Equal("Default", vm.ResultSubtitle.Paragraphs[0].Extra);
+            Assert.Equal("Default", vm.ResultSubtitle.Paragraphs[1].Extra);
+            Assert.Equal("Default2", vm.ResultSubtitle.Paragraphs[2].Extra);
+        }
+        finally
+        {
+            vm.OnClosingCleanup();
+        }
+    }
+
     /// <summary>
     /// A stored style with a category must surface that category in the combo list and the style
     /// must be filtered into its category when selected.


### PR DESCRIPTION
Fixes #13101.

The style editor had three separate data-loss defects, all confirmed with headless Avalonia repro tests before fixing:

### Renames never reached the subtitle lines
Nothing re-pointed lines when a style was renamed, so on OK the renamed style's lines were silently reset to the first style in the file. A new `FileStyleRenameTracker` re-points `Paragraph.Extra` on every name change (the name box binds per keystroke), with guards so a name that is momentarily blank or colliding with another style never merges or steals another style's lines. Usage counts follow the rename live.

### Switching styles erased the previous style's alignment
The nine alignment radios share one group, bound two-way through `CurrentStyle.AlignmentAnX`. When the current style changed, the group unchecked the old radio while its binding still pointed at the previously shown style — writing `false` into that style's alignment (visible in the issue's GIF as the cleared radio group). Radio semantics only ever need "set true", so the alignment setters now ignore `false` writes and clear their siblings on `true`. This also covers the SSA styles window and the single-style editor, which build the same radio group.

### Switching styles could erase the font name
When the newly shown style's font was not in the font combo's item list (e.g. a storage style using an uninstalled font), Avalonia cleared `SelectedItem` and the two-way binding nulled the style's `FontName`. The font is now inserted into the list before the style becomes current, and `FontName` ignores null writes.

### Stale subtitle handed to the dialog
`ShowAssaStyles`/`ShowSsaStyles` passed the raw `_subtitle`, whose paragraphs don't track the grid (other dialogs use `GetUpdateSubtitle()`). That's why the "Usages" column showed 0 in the issue's GIF, and it could misalign the positional re-apply of styles on OK.

Also in passing: usage counting is now case-insensitive like the rest of the style-name handling, and a duplicated dead `AlignmentAn3` branch in `GetAlignment` is removed.

**Tests:** `AssaStyleEditorDataLossTests` drives the real radio group and font combo headless (these fail on main), and three new `AssaStylesViewModelTests` cover rename propagation including blank/duplicate intermediate states. Full UI suite: 1200 passed; the 2 pre-existing `Polish.json` JSON-validity failures on main are unrelated (trailing comma from the recent Polish translation update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)