### PR TITLE
Fix mpv dispose race and UI-thread core teardown hang

### DIFF
--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -733,6 +733,11 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
 
         internal async Task Open(string videoFileName)
         {
+            if (IsDisposed)
+            {
+                return;
+            }
+
             // Reset slider state before LoadFile. Otherwise, when the new file's
             // Duration arrives on the next timer tick, the slider's Maximum drops
             // and a stale Value (left over from the previous file) gets clamped to
@@ -741,6 +746,15 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             Duration = 0;
 
             await _videoPlayerInstance.LoadFile(videoFileName);
+
+            // The control may have been torn down while LoadFile was awaiting (fullscreen
+            // closed mid-open, a second layout rebuild). Starting the position timer then
+            // would poll the disposed player from the dispatcher for the rest of the session.
+            if (IsDisposed)
+            {
+                return;
+            }
+
             _videoPlayerInstance.Volume = Volume;
             _positionTimer?.Stop();
             _slowPollCounter = 4; // force Duration+icon update on the very first tick
@@ -799,6 +813,17 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
         }
 
         /// <summary>
+        /// Set once <see cref="CloseAndDisposePlayer"/> has started tearing this control down.
+        /// Every async open/restore sequence (Open, WaitForPlayersReadyAsync, the reopen
+        /// continuations in the layout rebuild, fullscreen and Reopen paths) must bail out when
+        /// this is set: a control is disposed from window Closed handlers and layout rebuilds
+        /// while such a sequence may still be awaiting, and without the check the continuation
+        /// keeps polling and seeking the dead player for seconds (issue #13083) - or worse,
+        /// restarts the 50 ms position timer on it, which then P/Invokes the freed core forever.
+        /// </summary>
+        internal bool IsDisposed { get; private set; }
+
+        /// <summary>
         /// Permanently tears this control down: stops the polling timers, unloads the file,
         /// detaches the native render host and destroys the underlying player.
         /// <para>
@@ -822,6 +847,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
         /// </summary>
         internal void CloseAndDisposePlayer()
         {
+            IsDisposed = true;
             Close();
 
             // Mark before the content goes. On the OpenGL host mpv's render context may only be
@@ -855,6 +881,13 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             var end = DateTime.UtcNow.AddMilliseconds(timeoutMs);
             while (DateTime.UtcNow < end)
             {
+                // A disposed player reports Duration 0 forever, so without this check the
+                // poll always runs to the full timeout against the dead core (issue #13083).
+                if (IsDisposed)
+                {
+                    return;
+                }
+
                 // Consider player ready when Duration is known (> 0)
                 var ready = VideoPlayer.Duration > 0.001;
 

--- a/src/ui/Features/Main/Layout/InitVideoPlayer.cs
+++ b/src/ui/Features/Main/Layout/InitVideoPlayer.cs
@@ -65,9 +65,17 @@ public static class InitVideoPlayer
             {
                 await control.Open(mediaFile);
                 await control.WaitForPlayersReadyAsync();
+
+                // A second rebuild within the ready wait (Options/OK, dock/undock) disposes
+                // this control's player via the block above - stop restoring into it (#13083).
                 for (var i = 0; i < 10; i++)
                 {
                     await System.Threading.Tasks.Task.Delay(10);
+                    if (control.IsDisposed)
+                    {
+                        return;
+                    }
+
                     control.Position = position;
                 }
             });

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12185,8 +12185,10 @@ public partial class MainViewModel :
                     // Wait until the player really has the file. Mpv initializes its
                     // core lazily on the first render pass, so while the rebuilt layout
                     // is still coming up the duration can take much longer to arrive
-                    // than the default ready wait allows.
-                    for (var i = 0; i < 200 && vp.VideoPlayer.Duration <= 0.001; i++)
+                    // than the default ready wait allows. A disposed player (another
+                    // rebuild got here first) reports Duration 0 forever - bail instead
+                    // of polling the dead core to the 10 s cap (#13083).
+                    for (var i = 0; i < 200 && !vp.IsDisposed && vp.VideoPlayer.Duration <= 0.001; i++)
                     {
                         await Task.Delay(50);
                     }
@@ -12197,7 +12199,7 @@ public partial class MainViewModel :
                     // clamped back to the start. Re-assert the seek until the player
                     // reports it, as the first ones are swallowed while the surface is
                     // still coming up.
-                    for (var i = 0; i < 40 && videoPosition > 0; i++)
+                    for (var i = 0; i < 40 && videoPosition > 0 && !vp.IsDisposed; i++)
                     {
                         vp.VideoPlayer.Position = videoPosition;
                         await Task.Delay(50);
@@ -12205,6 +12207,11 @@ public partial class MainViewModel :
                         {
                             break;
                         }
+                    }
+
+                    if (vp.IsDisposed)
+                    {
+                        return;
                     }
 
                     ReapplyPlaybackSpeed();

--- a/src/ui/Features/Shared/FullScreenVideoPlayer.cs
+++ b/src/ui/Features/Shared/FullScreenVideoPlayer.cs
@@ -221,6 +221,14 @@ public class FullScreenVideoWindow : Window
             // where nothing else re-seeks afterwards. Settle briefly and re-apply, the same pattern
             // used by the startup file-restore and Reopen paths.
             await Task.Delay(200);
+
+            // Closing the window while the open sequence above was still awaiting has already
+            // run the Closed handler and disposed the player - don't keep driving it (#13083).
+            if (videoPlayer.IsDisposed)
+            {
+                return;
+            }
+
             videoPlayer.VideoPlayer.Pause();
             videoPlayer.VideoPlayer.Position = position;
             videoPlayer.Position = position;
@@ -232,6 +240,11 @@ public class FullScreenVideoWindow : Window
 
             Dispatcher.UIThread.Post(() =>
             {
+                if (videoPlayer.IsDisposed)
+                {
+                    return;
+                }
+
                 videoPlayer.VideoPlayer.Position = position;
                 videoPlayer.Position = position;
             });

--- a/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
+++ b/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
@@ -187,6 +187,13 @@ public partial class VideoPlayerUndockedViewModel : ObservableObject
                 await videoPlayerControl.WaitForPlayersReadyAsync();
                 await Task.Delay(100);
 
+                // Re-docking while this restore was awaiting has already disposed the
+                // player this window built - don't keep driving it (#13083).
+                if (videoPlayerControl.IsDisposed)
+                {
+                    return;
+                }
+
                 videoPlayerControl.Volume = _originalVolume;
                 videoPlayerControl.Position = _originalPosition;
 

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -888,7 +888,16 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         }
 
         FreeRenderContext();
-        TerminateCore();
+
+        // Only the render-context free needs the graphics context - the core does not, and
+        // mpv_terminate_destroy blocks until every mpv worker has exited. The deinit callback
+        // runs on the UI thread, so terminating here would freeze the UI for as long as a
+        // stuck load takes to unwind (the "Not Responding" kill in issue #13083) - the very
+        // thing the worker-thread dispose in VideoPlayerControl.CloseAndDisposePlayer was
+        // meant to prevent (issue #11176) but couldn't, because on this path the Dispose it
+        // runs is reduced to setting a flag. TerminateCore is idempotent (interlocked handle
+        // claim), so racing the owner's background Dispose is safe.
+        Task.Run(TerminateCore);
     }
 
     private void FreeRenderContext()


### PR DESCRIPTION
Addresses the error log and "Not Responding" hang reported in https://github.com/SubtitleEdit/subtitleedit/issues/13083#issuecomment-5162094186.

The attached log showed two ~3-second bursts of `LibMpvDynamicPlayer method called after disposal` (~21 entries each at ~10/s), followed by a hang that had to be killed from the taskbar. The burst signature matches `WaitForPlayersReadyAsync` polling `Duration` every 100 ms for its full 2.5 s timeout against a disposed player (a disposed player reports Duration 0 forever, so "ready" never arrives), plus the trailing pause/seek/volume calls — i.e. an async open/restore sequence racing a `CloseAndDisposePlayer()`.

### Fix 1: open/restore continuations bail out once the player is disposed

`VideoPlayerControl` now has an `IsDisposed` flag set when `CloseAndDisposePlayer()` starts, and every async sequence that can still be awaiting when a dispose lands checks it:

- `Open()` — the critical one: resuming after a dispose used to restart the 50 ms position timer on the dead player, which then P/Invoked the freed core from the dispatcher for the rest of the session
- `WaitForPlayersReadyAsync()` — returns immediately instead of polling the dead core to the timeout (this alone covers all ~20 call sites)
- the fullscreen window's `Loaded` restore (window `Closed` disposes the player while the open is still in flight)
- the layout-rebuild reopen in `InitVideoPlayer` (a second rebuild within the ready wait — Options/OK, dock/undock — disposes the control the first posted task still drives)
- the undocked video window's restore (re-dock during the restore)
- the Reopen position-restore loops in `MainViewModel` (200×50 ms duration poll + 40×50 ms seek loop)

### Fix 2: `mpv_terminate_destroy` off the UI thread

`CloseAndDisposePlayer` documents that the core teardown "runs on a worker thread rather than freezing the UI" (issue #11176) — but on the OpenGL host that wasn't what happened. There, `Dispose()` only records intent, and the real teardown runs in the GL deinit callback (`FreeRenderContextIfDisposePending`) **on the UI thread**. `mpv_terminate_destroy` blocks until every mpv worker has exited — many seconds when a load is stuck, which is exactly the mid-open dispose scenario the log demonstrates. That is the most plausible cause of the reported "Not Responding" state.

The deinit callback now frees only the render context (which genuinely must happen with the GL context current) and hands the core to a worker thread for termination. `TerminateCore` claims the handle with an interlocked exchange, so racing the owner's background `Dispose` remains safe and double-free is impossible.

### Testing

- `dotnet build src/ui` clean, all 1209 UI tests pass
- The disposal log entries (`EnsureNotDisposed`) are intentionally left in place — they are the diagnostic that caught this

Note: this does not touch the Alt/F10 menu-bar behavior that issue #13083 is primarily about — the error log turned out to describe a separate bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)