### PR TITLE
Fix menu bar keyboard navigation with no subtitle loaded (#13111)

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -64,6 +64,17 @@ public static partial class InitListViewAndEditBox
         // reader (issue #13015). Grid lines come from the TableView cell themes; sorting
         // was already disabled on the DataGrid and TableView has none.
         var subtitleGrid = TableViewExtras.MakeTableView();
+
+        // TableView itself is not focusable by default, and with no rows there is no focusable
+        // row container either - so an empty grid left the window without any focusable content.
+        // Keyboard focus then either stayed on the window root (Avalonia's AccessKeyHandler
+        // ignores all keys in that state, so Alt appeared dead and no access keys were
+        // underlined) or, once it reached the menu bar, could never leave it again because the
+        // menu deactivation had no focus target to restore to (#13111). The grid is both the
+        // startup focus target and that deactivation fallback, so it must be able to hold focus
+        // even with no rows - like an empty list view on Windows.
+        subtitleGrid.Focusable = true;
+
         subtitleGrid.Height = double.NaN;
         subtitleGrid.Margin = new Thickness(Se.Settings.Appearance.GridCompactMode ? 0 : 2);
         subtitleGrid.ItemsSource = vm.Subtitles;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -20943,11 +20943,19 @@ public partial class MainViewModel :
 
         _focusBeforeMainMenu = Window?.FocusManager?.GetFocusedElement() as Control;
 
-        // Defer focusing the menu bar: moving focus from inside the key handler is racy (Avalonia's
-        // access-key handling may still process the same key afterwards and reset focus). Let the
-        // current key event finish first, mirroring the deferred focus restore in DeactivateMainMenu
-        // (#11745).
-        Dispatcher.UIThread.Post(() => TryFocusMainMenu());
+        // Defer the activation: opening the menu from inside the key handler is racy (Avalonia's
+        // access-key handling may still process the same key afterwards and reset focus). Menu.Open
+        // is the same call Avalonia's bare-Alt handling makes: it selects and focuses the first
+        // top-level item, so the activation is visible ("File" highlights). Merely focusing the
+        // item, as this did before, gave no visual feedback at all - a top-level MenuItem has no
+        // keyboard-focus visual - which read as "F10 does nothing" (#13111).
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (Menu is { IsOpen: false })
+            {
+                Menu.Open();
+            }
+        });
         return true;
     }
 
@@ -20972,7 +20980,27 @@ public partial class MainViewModel :
                 return;
             }
 
-            SubtitleGrid?.Focus();
+            // Only pull focus somewhere else when it is actually still stuck in the menu:
+            // overlapping deactivations (e.g. Alt+Tab plus the synthetic Alt release, both running
+            // through here) would otherwise stomp the focus the first one just restored (#13111).
+            if (!IsMainMenuFocused())
+            {
+                return;
+            }
+
+            if (SubtitleGrid != null)
+            {
+                TableViewExtras.FocusRow(SubtitleGrid);
+            }
+
+            // Deactivation must never leave focus inside the menu: the bar would stay armed and
+            // every arrow key would keep navigating it even though it looks closed (#13111). If
+            // even the grid could not take focus (e.g. not part of the current layout), fall back
+            // to the edit text box as a last resort.
+            if (IsMainMenuFocused())
+            {
+                EditTextBox?.Focus();
+            }
         });
     }
 
@@ -21404,7 +21432,7 @@ public partial class MainViewModel :
             // F10 here really is the user's own choice (#13083).
             if (k == Key.F10 && keyEventArgs.KeyModifiers == KeyModifiers.None && !_shortcutManager.HasSingleKeyShortcut("F10"))
             {
-                if (IsMainMenuFocused())
+                if (IsMainMenuFocused() || Menu is { IsOpen: true })
                 {
                     DeactivateMainMenu();
                     keyEventArgs.Handled = true;
@@ -21727,6 +21755,18 @@ public partial class MainViewModel :
                 _focusBeforeMainMenu = focusToRestore;
             }
 
+            DeactivateMainMenu();
+        }
+        else if (e.Key is Key.LeftAlt or Key.RightAlt && Menu is { IsOpen: false } && IsMainMenuFocused())
+        {
+            // Alt on an open menu bar: Avalonia's AccessKeyHandler closes the bar on the Alt press,
+            // but it only restores focus for bars it opened itself via bare Alt - after an F10
+            // activation (Menu.Open) it has no saved focus element, so the close leaves keyboard
+            // focus stranded on the menu item and the bar keeps swallowing every key (#13111). By
+            // the time the release arrives the press has settled, so "focused but not open" is
+            // exactly that stranded state - deactivate fully, restoring the focus saved at
+            // activation. (When Avalonia opens the bar on this very release, IsOpen is already
+            // true here and this branch stays out of the way.)
             DeactivateMainMenu();
         }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -2372,7 +2372,7 @@ public partial class BinaryEditViewModel : ObservableObject
         // menu toggle (#12504) - the menu stays reachable via Alt.
         if (e.Key == Key.F10 && e.KeyModifiers == KeyModifiers.None && !_shortcutManager.HasSingleKeyShortcut("F10"))
         {
-            if (IsMenuFocused())
+            if (IsMenuFocused() || Menu is { IsOpen: true })
             {
                 DeactivateMenu();
                 e.Handled = true;
@@ -2512,23 +2512,20 @@ public partial class BinaryEditViewModel : ObservableObject
 
             DeactivateMenu();
         }
-
-        _shortcutManager.OnKeyReleased(this, e);
-    }
-
-    /// <summary>
-    /// Moves keyboard focus to the first top-level menu item so the menu can be opened and
-    /// navigated with the keyboard / a screen reader (F10, #11745). No-op when the menu is hidden
-    /// (macOS uses the native menu).
-    /// </summary>
-    private bool TryFocusMenu()
-    {
-        if (Menu == null || !Menu.IsVisible || Menu.Items.Count == 0)
+        else if (e.Key is Key.LeftAlt or Key.RightAlt && Menu is { IsOpen: false, IsVisible: true } && IsMenuFocused())
         {
-            return false;
+            // Alt on an open menu bar: Avalonia's AccessKeyHandler closes the bar on the Alt press,
+            // but it only restores focus for bars it opened itself via bare Alt - after an F10
+            // activation (Menu.Open) it has no saved focus element, so the close leaves keyboard
+            // focus stranded on the menu item, where the bar keeps swallowing every key (#13111).
+            // By the time the release arrives the press has settled, so "focused but not open" is
+            // exactly that stranded state - deactivate fully, restoring the focus saved at
+            // activation. (When Avalonia opens the bar on this very release, IsOpen is already
+            // true here and this branch stays out of the way.)
+            DeactivateMenu();
         }
 
-        return Menu.Items[0] is MenuItem firstItem && firstItem.Focus(NavigationMethod.Tab);
+        _shortcutManager.OnKeyReleased(this, e);
     }
 
     /// <summary>
@@ -2545,7 +2542,20 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         _focusBeforeMenu = Window?.FocusManager?.GetFocusedElement() as Control;
-        return TryFocusMenu();
+
+        // Defer the activation: opening the menu from inside the key handler is racy, so let the
+        // current event finish first. Menu.Open is the same call Avalonia's bare-Alt handling
+        // makes: it selects and focuses the first top-level item, so the activation is visible
+        // ("File" highlights). Merely focusing the item, as this did before, gave no visual
+        // feedback at all - a top-level MenuItem has no keyboard-focus visual (#13111).
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (Menu is { IsOpen: false })
+            {
+                Menu.Open();
+            }
+        });
+        return true;
     }
 
     /// <summary>
@@ -2569,7 +2579,12 @@ public partial class BinaryEditViewModel : ObservableObject
                 return;
             }
 
-            if (SubtitleGrid != null)
+            // Only pull focus somewhere else when it is actually still stuck in the menu:
+            // overlapping deactivations (e.g. a task switch plus the synthetic Alt release, both
+            // running through here) would otherwise stomp the focus the first one just restored.
+            // Deactivation must never leave focus inside the menu - the bar would stay armed and
+            // every arrow key would keep navigating it even though it looks closed (#13111).
+            if (IsMenuFocused() && SubtitleGrid != null)
             {
                 TableViewExtras.FocusRow(SubtitleGrid);
             }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -427,6 +427,13 @@ public class BinaryEditWindow : Window
 
         // Grid for subtitle lines (grid lines come from the TableView cell themes)
         var dataGrid = TableViewExtras.MakeTableView();
+
+        // TableView itself is not focusable by default, and without rows there are no focusable
+        // row containers either - the grid must be able to hold keyboard focus even when empty,
+        // both as the menu-deactivation fallback and so the window never ends up without any
+        // focusable content (same fix as the main subtitle grid, #13111).
+        dataGrid.Focusable = true;
+
         dataGrid.Height = double.NaN;
         dataGrid.FontSize = Se.Settings.Appearance.SubtitleGridFontSize;
 

--- a/tests/UI/Features/Main/MainMenuKeyboardActivationTests.cs
+++ b/tests/UI/Features/Main/MainMenuKeyboardActivationTests.cs
@@ -1,0 +1,170 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// Keyboard activation of the main menu bar with an empty subtitle grid (#13111). Before a
+/// subtitle is loaded the grid has no rows, and TableView itself is not focusable by default -
+/// so the window had no focusable content at all. Keyboard focus either stayed on the window
+/// root, where Avalonia's AccessKeyHandler ignores every key (bare Alt looked dead, no access
+/// keys underlined), or it reached the menu bar and could never leave again because menu
+/// deactivation had no focus target to restore to: Escape, F10 and Alt+Tab all appeared to
+/// close the bar while arrow keys proved it was still armed. F10 activation was also invisible
+/// (focus only, no "File" highlight); it now goes through Menu.Open like Avalonia's own
+/// bare-Alt handling.
+/// </summary>
+public class MainMenuKeyboardActivationTests
+{
+    private static (Window Window, MainViewModel Vm) ShowMainWindowWithEmptyGrid()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+
+        // On macOS the in-window menu is hidden in favor of the native menu bar; these tests
+        // exercise the in-window menu (the Windows/Linux path), so show it regardless of the
+        // host platform.
+        vm.Menu.IsVisible = true;
+
+        Settle(window);
+        return (window, vm);
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 5; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+
+    /// <summary>
+    /// True when keyboard focus is on a menu item - the state in which the window key handler
+    /// hands every key to the menu instead of running shortcuts.
+    /// </summary>
+    private static bool IsFocusOnMenuItem(Window window) =>
+        window.FocusManager?.GetFocusedElement() is MenuItem;
+
+    private static void PressAndRelease(Window window, PhysicalKey key, RawInputModifiers modifiers)
+    {
+        window.KeyPressQwerty(key, modifiers);
+        Dispatcher.UIThread.RunJobs();
+        window.KeyReleaseQwerty(key, modifiers);
+        Settle(window);
+    }
+
+    [AvaloniaFact]
+    public void EmptyGrid_IsFocusable_AndHoldsStartupFocus()
+    {
+        var (window, vm) = ShowMainWindowWithEmptyGrid();
+
+        // The startup focus is what keeps Avalonia's AccessKeyHandler alive: it ignores all
+        // keyboard events (including bare Alt) while nothing inside the window has focus.
+        Assert.True(vm.SubtitleGrid.Focusable);
+
+        TableViewExtras.FocusRow(vm.SubtitleGrid);
+        Settle(window);
+        Assert.Same(vm.SubtitleGrid, window.FocusManager?.GetFocusedElement());
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void F10_OpensTheMenuBarVisibly()
+    {
+        var (window, vm) = ShowMainWindowWithEmptyGrid();
+        TableViewExtras.FocusRow(vm.SubtitleGrid);
+        Settle(window);
+
+        PressAndRelease(window, PhysicalKey.F10, RawInputModifiers.None);
+
+        // Menu.Open (the same path as Avalonia's bare-Alt activation) selects the first
+        // top-level item, so "File" is highlighted - focus alone gave no visual feedback.
+        Assert.True(vm.Menu.IsOpen);
+        Assert.True(IsFocusOnMenuItem(window));
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void F10_TogglesTheMenuBarOffAgain_WithEmptyGrid()
+    {
+        var (window, vm) = ShowMainWindowWithEmptyGrid();
+        TableViewExtras.FocusRow(vm.SubtitleGrid);
+        Settle(window);
+
+        PressAndRelease(window, PhysicalKey.F10, RawInputModifiers.None);
+        Assert.True(vm.Menu.IsOpen);
+
+        PressAndRelease(window, PhysicalKey.F10, RawInputModifiers.None);
+
+        Assert.False(vm.Menu.IsOpen);
+        Assert.False(IsFocusOnMenuItem(window));
+        Assert.Same(vm.SubtitleGrid, window.FocusManager?.GetFocusedElement());
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void Escape_DeactivatesTheMenuBar_WithEmptyGrid()
+    {
+        var (window, vm) = ShowMainWindowWithEmptyGrid();
+        TableViewExtras.FocusRow(vm.SubtitleGrid);
+        Settle(window);
+
+        PressAndRelease(window, PhysicalKey.F10, RawInputModifiers.None);
+        Assert.True(vm.Menu.IsOpen);
+
+        PressAndRelease(window, PhysicalKey.Escape, RawInputModifiers.None);
+
+        Assert.False(vm.Menu.IsOpen);
+        Assert.False(IsFocusOnMenuItem(window));
+        Assert.Same(vm.SubtitleGrid, window.FocusManager?.GetFocusedElement());
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void BareAlt_DeactivatesAnF10OpenedMenuBar()
+    {
+        var (window, vm) = ShowMainWindowWithEmptyGrid();
+        TableViewExtras.FocusRow(vm.SubtitleGrid);
+        Settle(window);
+
+        PressAndRelease(window, PhysicalKey.F10, RawInputModifiers.None);
+        Assert.True(vm.Menu.IsOpen);
+
+        // Avalonia's AccessKeyHandler closes the bar on the Alt press but only restores focus
+        // for bars it opened itself - after an F10 activation the close would strand focus on
+        // the menu item, where the bar keeps swallowing every key.
+        window.KeyPressQwerty(PhysicalKey.AltLeft, RawInputModifiers.Alt);
+        Dispatcher.UIThread.RunJobs();
+        window.KeyReleaseQwerty(PhysicalKey.AltLeft, RawInputModifiers.None);
+        Settle(window);
+
+        Assert.False(vm.Menu.IsOpen);
+        Assert.False(IsFocusOnMenuItem(window));
+        Assert.Same(vm.SubtitleGrid, window.FocusManager?.GetFocusedElement());
+
+        window.Close();
+    }
+}


### PR DESCRIPTION
Addresses the core of #13111 (continuation of #13083).

## Root cause

With no subtitle loaded the grid has no rows, and `TableView` is not focusable by default — so the main window contained **no focusable content at all**. Keyboard focus then either:

- stayed on the window root, where Avalonia's `AccessKeyHandler` ignores every keyboard event (its `IsFocusWithinOwner` check requires focus on a descendant) — so bare Alt looked dead and no access keys were underlined, or
- reached the menu bar and could never leave again: `DeactivateMainMenu`'s focus restore fell back to `SubtitleGrid.Focus()`, which silently returned `false`, leaving focus stranded on the menu item. Escape, a second F10 and Alt+Tab all *appeared* to close the bar while any arrow key proved it was still armed.

This is exactly the reported "two states": broken before ever loading a subtitle, fine afterwards (rows exist, and `OpenLastFileOnStart` keeps it that way across sessions).

## Changes

1. **Empty grid can hold focus** — the main subtitle `TableView` is now `Focusable`, like an empty list view on Windows. It is both the startup focus target and the menu-deactivation fallback.
2. **Deactivation guarantees focus leaves the menu** — falls back through selected row → grid → edit text box, and only moves focus when it is actually still stuck in the menu, so overlapping deactivations (Alt+Tab + the synthetic Alt release) don't stomp an already-restored focus.
3. **F10 activates the menu bar visibly** — via `Menu.Open()`, the same path as Avalonia's built-in bare-Alt activation, so "File" gets its highlight. Previously SE only focused the first `MenuItem`, which has no keyboard-focus visual — F10 worked but looked like it did nothing.
4. **Alt closes an F10-opened bar cleanly** — Avalonia's `AccessKeyHandler` closes an open bar on Alt-down but only restores focus for bars it opened itself via bare Alt; after an F10 activation it stranded focus on the menu item. The key-up handler now detects the settled "focused but not open" state and deactivates fully.

## Tests

New headless tests in `MainMenuKeyboardActivationTests` (all against the real `MainView`/`MainViewModel` with an **empty** grid — the #13111 fresh-start state): startup focus, visible F10 activation, F10 toggle, Escape deactivation, Alt closing an F10-opened bar. All five fail without the fix; full UI suite passes (1214 tests).

The same four changes are also ported to `BinaryEditViewModel`/`BinaryEditWindow`, which carry a parallel copy of the menu activation logic (its now-unused `TryFocusMenu` is removed). No dedicated headless tests there — spinning up that window needs a real binary subtitle file, and the ported logic is identical to the main-window code the new tests cover.

## Not in this PR

- Menus obscured by the undocked audio visualizer (`Topmost` vs. popup z-order) — separate bug, separate fix.
- Needs a quick manual sanity check on Windows with a fresh portable install (fresh `Settings.json`, no recent files) to confirm the first-run flavor is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
