### PR TITLE
Fix Remove formatting: font name doing nothing

### DIFF
--- a/src/ui/Logic/FontNameService.cs
+++ b/src/ui/Logic/FontNameService.cs
@@ -95,6 +95,11 @@ public class FontNameService : IFontNameService
 
     public void RemoveFontNames(SubtitleLineViewModel p, bool isAssa)
     {
+        if (p == null || string.IsNullOrEmpty(p.Text))
+        {
+            return;
+        }
 
+        p.Text = HtmlUtil.RemoveFontName(p.Text);
     }
 }


### PR DESCRIPTION
**Problem:** `FontNameService.RemoveFontNames(SubtitleLineViewModel p, bool isAssa)` (src/ui/Logic/FontNameService.cs:96) had an empty body, so the \"Remove formatting: font name\" menu command (MainViewModel.cs:11257) silently did nothing.

**Fix:** Implemented the method using the existing `HtmlUtil.RemoveFontName` helper (src/libse/Common/HtmlUtil.cs:1616), which handles both ASSA (\fn tags) and HTML (<font face=...>) markup, with a null/empty-text guard. No new regexes introduced.

**Verification:** `dotnet build src/ui/UI.csproj -c Debug` passes with 0 errors / 0 warnings.

**Notes:** No new language keys.