### PR TITLE
Guard IClosingCleanup so cleanup runs at most once per window (#13100)

### DIFF
--- a/src/ui/Logic/IClosingCleanup.cs
+++ b/src/ui/Logic/IClosingCleanup.cs
@@ -7,7 +7,8 @@ namespace Nikse.SubtitleEdit.Logic;
 /// timers are stopped and disposed on every close path - OK/Cancel buttons, Escape, the title-bar
 /// close and Alt+F4 alike - without each view model having to hook them individually.
 ///
-/// Implementations must be idempotent: the method may run after the view model has already torn its
+/// The central hook guarantees at most one invocation per window (#13100), but implementations
+/// must still be idempotent: the method may run after the view model has already torn its
 /// timers down through some other path.
 /// </summary>
 public interface IClosingCleanup

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -3109,10 +3109,14 @@ public static class UiUtil
         // System.Timers.Timer keeps its (captured) view model - and the whole closed window - alive
         // and ticking. Wired here, in the one place every window funnels through, so individual
         // dialogs don't each have to remember to do it. (#12739)
+        // Guarded so the cleanup runs at most once per window even if Closed were ever raised
+        // again, keeping non-idempotent cleanups safe by construction. (#13100)
+        var cleanedUp = false;
         window.Closed += (_, _) =>
         {
-            if (window.DataContext is IClosingCleanup cleanup)
+            if (!cleanedUp && window.DataContext is IClosingCleanup cleanup)
             {
+                cleanedUp = true;
                 cleanup.OnClosingCleanup();
             }
         };


### PR DESCRIPTION
Adds the central once-per-window guard suggested in #13100: `UiUtil.InitializeWindow` now latches a `cleanedUp` flag before invoking `IClosingCleanup.OnClosingCleanup()`, so the cleanup hook can never run twice on the same view model even if `Window.Closed` were ever raised more than once.

Notes:
- In Avalonia 12.1.1 I could not reproduce a double `Closed` raise on any desktop backend (details in the issue), so this is belt-and-braces rather than the fix for the reported `ObjectDisposedException` — non-idempotent cleanups still need to handle teardown happening through another path first, and the `IClosingCleanup` doc keeps saying so (now also mentioning the central guard).
- No behavior change for existing implementations; all current ones are timer-based and idempotent.

Closes #13100

🤖 Generated with [Claude Code](https://claude.com/claude-code)