### PR TITLE
Fix DoubleToOneDecimalHideMaxConverter.Instance being the wrong type

### DIFF
--- a/src/ui/Logic/ValueConverters/DoubleToOneDecimalHideMaxConverter.cs
+++ b/src/ui/Logic/ValueConverters/DoubleToOneDecimalHideMaxConverter.cs
@@ -6,7 +6,7 @@ namespace Nikse.SubtitleEdit.Logic.ValueConverters;
 
 public class DoubleToOneDecimalHideMaxConverter : IValueConverter
 {
-    public static readonly DoubleToOneDecimalConverter Instance = new();
+    public static readonly DoubleToOneDecimalHideMaxConverter Instance = new();
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {


### PR DESCRIPTION
**Problem:** `src/ui/Logic/ValueConverters/DoubleToOneDecimalHideMaxConverter.cs:9` declares `Instance` as `DoubleToOneDecimalConverter`, so the HideMax semantics - returning an empty string for `double.MaxValue`/`NaN` (lines 15-17) - are never applied when the converter is used through `Instance`.

**Fix:** Change the static field type to `DoubleToOneDecimalHideMaxConverter` so `Instance` actually hides max/NaN values.

**Verification:** `dotnet build src/ui/UI.csproj -c Debug` - 0 errors, 0 warnings.

**Notes:** One-line type fix; no other behavior changes.