### PR TITLE
Fix Enter key not working in the Replace with box

### DIFF
--- a/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
@@ -190,4 +190,13 @@ public partial class ReplaceViewModel : ObservableObject
             await FindNextCommand.ExecuteAsync(null);
         }
     }
+
+    internal async void ReplaceTextBoxKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter)
+        {
+            e.Handled = true;
+            await ReplaceCommand.ExecuteAsync(null);
+        }
+    }
 }

--- a/src/ui/Features/Edit/Replace/ReplaceWindow.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceWindow.cs
@@ -70,6 +70,7 @@ public class ReplaceWindow : Window
             PlaceholderText = Se.Language.Edit.Find.ReplaceTextWatermark,
             [!TextBox.TextProperty] = new Binding(nameof(vm.ReplaceText)) { Mode = BindingMode.TwoWay }
         };
+        textBoxReplace.KeyDown += vm.ReplaceTextBoxKeyDown;
 
         var panelReplace = new StackPanel
         {


### PR DESCRIPTION
**Problem:** In the Replace window (src/ui/Features/Edit/Replace/ReplaceWindow.cs), Enter only worked in the \"Find\" box (`textBoxFind.KeyDown += vm.FindTextBoxKeyDown`); pressing Enter in the \"Replace with\" box did nothing.

**Fix:** Added an analogous `ReplaceTextBoxKeyDown` handler to `ReplaceViewModel` (following the `FindTextBoxKeyDown` pattern): Enter executes `ReplaceCommand` (Replace + find next, the default button action for this field). The handler is wired to `textBoxReplace`, which is a plain single-line TextBox (no AcceptsReturn). Escape is already handled at window level via the tunneled `KeyDown` handler, so nothing else was needed.

**Verification:** `dotnet build src/ui/UI.csproj -c Debug` passes with 0 errors / 0 warnings.

**Notes:** No new language keys.