### PR TITLE
Fix indeterminate progress bar not resetting on Stop

### DIFF
--- a/src/ui/Features/Shared/IndeterminateProgressHelper.cs
+++ b/src/ui/Features/Shared/IndeterminateProgressHelper.cs
@@ -84,8 +84,9 @@ public class IndeterminateProgressHelper : IDisposable
             }
         }
 
-        // Restore opacity
+        // Restore opacity and reset progress
         _setProgressOpacity(1.0);
+        _setProgressValue(0);
     }
 
     private static double EaseInOutCubic(double x)


### PR DESCRIPTION
**Problem:** `IndeterminateProgressHelper.Stop()` (src/ui/Features/Shared/IndeterminateProgressHelper.cs:68) only restores the progress bar opacity to 1.0. The `ProgressBar.Value` stays wherever the marquee animation stopped (e.g. 63%), so after stopping, the bar shows a partial fill instead of being empty.

**Fix:** Also reset the progress value to 0 in `Stop()`, mirroring `Start()` which already sets both opacity and value on the same delegates.

**Verification:** `dotnet build src/ui/UI.csproj -c Debug` - 0 errors, 0 warnings.

**Notes:** Stop() may be called from the timer callback or externally; `_setProgressValue` is the same UI-thread-safe delegate used by `Start()`.