### PR TITLE
Fix double key-down handling in MediaInfo window

### DIFF
--- a/src/ui/Features/Shared/MediaInfoView/MediaInfoViewWindow.cs
+++ b/src/ui/Features/Shared/MediaInfoView/MediaInfoViewWindow.cs
@@ -57,7 +57,5 @@ public class MediaInfoViewWindow : Window
         Content = grid;
 
         AddHandler(KeyDownEvent, vm.OnKeyDownHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: false);
-
-        KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }


### PR DESCRIPTION
**Problem:** `MediaInfoViewWindow` (src/ui/Features/Shared/MediaInfoView/MediaInfoViewWindow.cs:59-61) registers the same key event twice: `AddHandler(KeyDownEvent, vm.OnKeyDownHandler, ...)` and `KeyDown += (_, e) => vm.OnKeyDown(e)`. Since `OnKeyDownHandler` only delegates to `OnKeyDown` (MediaInfoViewViewModel.cs:230-233), every key press is handled twice - e.g. Escape would close the window through both paths.

**Fix:** Remove the redundant `KeyDown +=` subscription and keep the `AddHandler` variant, matching the pattern used by other windows (e.g. PickVobSubLanguageWindow.cs:58).

**Verification:** `dotnet build src/ui/UI.csproj -c Debug` - 0 errors, 0 warnings.

**Notes:** Escape now closes the window exactly once.