### PR TITLE
Fix Escape not closing the Generating audio window

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/GeneratingAudioWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/GeneratingAudioWindow.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Layout;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -56,6 +57,15 @@ public class GeneratingAudioWindow : Window
         Loaded += delegate
         {
             buttonCancel.Focus();
+        };
+
+        KeyDown += (_, e) =>
+        {
+            if (e.Key == Key.Escape)
+            {
+                vm.CancelCommand?.Execute(null);
+                e.Handled = true;
+            }
         };
     }
 }


### PR DESCRIPTION
**Problem:** The \"Generating audio\" window (src/ui/Features/Video/TextToSpeech/ReviewSpeech/GeneratingAudioWindow.cs) was the only window in the app with a Cancel button but no keyboard handler — Escape/Enter did nothing, and Cancel could only be clicked with the mouse.

**Fix:** Added a `KeyDown` handler in the window constructor: Escape executes `vm.CancelCommand` (which cancels the `CancellationTokenSource` and closes the window via `Window?.Close()`). The window has no OK/Done button, so no Enter handling is needed.

**Verification:** `dotnet build src/ui/UI.csproj -c Debug` passes with 0 errors / 0 warnings.

**Notes:** No new language keys.