### PR TITLE
Remove hardcoded 'Line lengths' placeholder

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1658,7 +1658,7 @@ public static partial class InitListViewAndEditBox
         // add label to panelSingleLineLengthsOriginal
         var singleLineLengthLabel = new TextBlock
         {
-            Text = "Line lengths: x/x",
+            Text = Se.Language.Main.SingleLineLength,
             FontWeight = FontWeight.Bold,
             Margin = new Thickness(0, 0, 5, 0)
         };


### PR DESCRIPTION
**Problem:** `InitListViewAndEditBox.cs:1661` sets the initial text of the single-line-lengths label in the "original text" column panel to the hardcoded English placeholder "Line lengths: x/x". The localized label `Se.Language.Main.SingleLineLength` ("Line length: ") only replaces it when a subtitle line gets selected (SubtitleTextInfoHelper.FillLineLengthPanel), so the hardcoded string is visible at startup and in non-English UI languages.

**Fix:** Initialize the label with the existing localized key `Se.Language.Main.SingleLineLength` instead of the hardcoded literal.

**Verification:** `dotnet build src/ui/UI.csproj -c Debug` - 0 errors, 0 warnings.

**Notes:** The TextBlock itself must stay - `FillLineLengthPanel` reuses it as the first child of the panel; removing it would change the label styling (bold + margin) once a selection is made.