### PR TITLE
Localize 'Start server' button labels

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -379,6 +379,8 @@
     "llamaCppUseRemoteServer": "Use external server (URL)",
     "llamaCppEngineSettings": "llama.cpp engine settings",
     "llamaCppEngineSettingsSubtitle": "Local llama.cpp server build",
+    "startServer": "Start server",
+    "stopServer": "Stop server",
     "pickOutputFolder": "Pick output folder",
     "pickResolutionFromCurrentVideo": "Pick resolution from current video",
     "pickResolutionFromVideoDotDotDot": "Pick resolution from video...",
@@ -2991,7 +2993,10 @@
     "showAllOllamaModels": "Show all models (not just vision-capable)",
     "ollamaModelLikelyWrong": "Ollama returned no text - the selected model may not support OCR / vision",
     "llamaCppNotDownloaded": "llama.cpp engine/model not downloaded - download via batch convert settings",
-    "llamaCppReturnedNoText": "llama.cpp returned no text - check the server and model"
+    "llamaCppReturnedNoText": "llama.cpp returned no text - check the server and model",
+    "llamaCppDownloadEngineAndModelPrompt": "llama.cpp requires the llama-server engine and the selected OCR model to be downloaded. Download now?",
+    "llamaCppDownloadEnginePrompt": "llama.cpp requires the llama-server engine to be downloaded. Download now?",
+    "llamaCppDownloadModelPrompt": "llama.cpp requires the selected OCR model to be downloaded. Download now?"
   },
   "assa": {
     "assaDraw": "ASSA Draw",

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -239,7 +239,7 @@ public partial class OcrViewModel : ObservableObject
         OllamaUrl = string.Empty;
         LlamaCppUrl = string.Empty;
         LlamaCppOcrModels = new ObservableCollection<LlamaCppModelDisplay>();
-        LlamaCppOcrServerButtonText = "Start server";
+        LlamaCppOcrServerButtonText = Se.Language.General.StartServer;
         CrispEmbedBackends = new ObservableCollection<CrispEmbedBackend>(CrispEmbedEngine.GetBackends());
         CrispEmbedModels = new ObservableCollection<CrispEmbedModelDisplay>();
         TesseractDictionaryItems = new ObservableCollection<TesseractDictionary>();
@@ -1271,7 +1271,7 @@ public partial class OcrViewModel : ObservableObject
 
     private void UpdateLlamaCppOcrServerButtonText()
     {
-        LlamaCppOcrServerButtonText = LlamaCppServerManager.IsServerRunning ? "Stop server" : "Start server";
+        LlamaCppOcrServerButtonText = LlamaCppServerManager.IsServerRunning ? Se.Language.General.StopServer : Se.Language.General.StartServer;
     }
 
     [RelayCommand]
@@ -1348,15 +1348,15 @@ public partial class OcrViewModel : ObservableObject
             string message;
             if (!engineInstalled && !modelInstalled)
             {
-                message = "llama.cpp requires the llama-server engine and the selected OCR model to be downloaded. Download now?";
+                message = Se.Language.Ocr.LlamaCppDownloadEngineAndModelPrompt;
             }
             else if (!engineInstalled)
             {
-                message = "llama.cpp requires the llama-server engine to be downloaded. Download now?";
+                message = Se.Language.Ocr.LlamaCppDownloadEnginePrompt;
             }
             else
             {
-                message = "llama.cpp requires the selected OCR model to be downloaded. Download now?";
+                message = Se.Language.Ocr.LlamaCppDownloadModelPrompt;
             }
 
             var answer = await MessageBox.Show(

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -104,7 +104,7 @@ public partial class AutoTranslateViewModel : ObservableObject
     [ObservableProperty] private bool _llamaCppAdvancedButtonIsVisible;
     [ObservableProperty] private bool _llamaCppRemoteToggleIsVisible;
     [ObservableProperty] private bool _llamaCppUseRemoteServer;
-    [ObservableProperty] private string _llamaCppServerButtonText = "Start server";
+    [ObservableProperty] private string _llamaCppServerButtonText = Se.Language.General.StartServer;
     [ObservableProperty] private string _llamaCppDownloadButtonText = string.Empty;
     [ObservableProperty] private string _crispAsrDownloadButtonText = string.Empty;
 
@@ -952,7 +952,7 @@ public partial class AutoTranslateViewModel : ObservableObject
 
     private void UpdateLlamaCppServerButtonText()
     {
-        LlamaCppServerButtonText = LlamaCppServerManager.IsServerRunning ? "Stop server" : "Start server";
+        LlamaCppServerButtonText = LlamaCppServerManager.IsServerRunning ? Se.Language.General.StopServer : Se.Language.General.StartServer;
     }
 
     [RelayCommand]

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -379,6 +379,8 @@ public class LanguageGeneral
     public string LlamaCppUseRemoteServer { get; set; }
     public string LlamaCppEngineSettings { get; set; }
     public string LlamaCppEngineSettingsSubtitle { get; set; }
+    public string StartServer { get; set; }
+    public string StopServer { get; set; }
     public string PickOutputFolder { get; set; }
     public string PickResolutionFromCurrentVideo { get; set; }
     public string PickResolutionFromVideoDotDotDot { get; set; }
@@ -1101,6 +1103,8 @@ public class LanguageGeneral
         LlamaCppUseRemoteServer = "Use external server (URL)";
         LlamaCppEngineSettings = "llama.cpp engine settings";
         LlamaCppEngineSettingsSubtitle = "Local llama.cpp server build";
+        StartServer = "Start server";
+        StopServer = "Stop server";
         PickOutputFolder = "Pick output folder";
         PickResolutionFromCurrentVideo = "Pick resolution from current video";
         PickResolutionFromVideoDotDotDot = "Pick resolution from video...";

--- a/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
+++ b/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
@@ -113,6 +113,9 @@ public class LanguageOcr
     public string OllamaModelLikelyWrong { get; set; }
     public string LlamaCppNotDownloaded { get; set; }
     public string LlamaCppReturnedNoText { get; set; }
+    public string LlamaCppDownloadEngineAndModelPrompt { get; set; }
+    public string LlamaCppDownloadEnginePrompt { get; set; }
+    public string LlamaCppDownloadModelPrompt { get; set; }
 
     public LanguageOcr()
     {
@@ -228,5 +231,8 @@ public class LanguageOcr
         OllamaModelLikelyWrong = "Ollama returned no text - the selected model may not support OCR / vision";
         LlamaCppNotDownloaded = "llama.cpp engine/model not downloaded - download via batch convert settings";
         LlamaCppReturnedNoText = "llama.cpp returned no text - check the server and model";
+        LlamaCppDownloadEngineAndModelPrompt = "llama.cpp requires the llama-server engine and the selected OCR model to be downloaded. Download now?";
+        LlamaCppDownloadEnginePrompt = "llama.cpp requires the llama-server engine to be downloaded. Download now?";
+        LlamaCppDownloadModelPrompt = "llama.cpp requires the selected OCR model to be downloaded. Download now?";
     }
 }


### PR DESCRIPTION
**Problem:** The llama.cpp "Start server"/"Stop server" button labels and the llama.cpp download-prompt messages are hardcoded English strings.

- `src/ui/Features/Translate/AutoTranslateViewModel.cs:107` (`_llamaCppServerButtonText = "Start server"`), `:955` (ternary `"Stop server" : "Start server"`)
- `src/ui/Features/Ocr/OcrViewModel.cs:242`, `:1274` (same ternary)
- `src/ui/Features/Ocr/OcrViewModel.cs:1351-1359`: three user-visible `MessageBox` prompts ("llama.cpp requires ... Download now?")

**Fix:** Added `General.StartServer` / `General.StopServer` keys (used by both Translate and OCR view models) and `Ocr.LlamaCppDownloadEngineAndModelPrompt` / `LlamaCppDownloadEnginePrompt` / `LlamaCppDownloadModelPrompt` keys, plus the matching English.json entries. All occurrences replaced with `Se.Language.*`.

**Verification:** `dotnet build src/ui/UI.csproj -c Debug` — 0 errors, 0 warnings. English.json validated (utf-8-sig). No `"Start server"`/`"Stop server"` literals remain in either view model.

**Notes:** The "llama.cpp" engine name inside the already-localized update prompt (`AutoTranslateViewModel.cs:1148-1149`, `string.Format(Se.Language.Video.AudioToText.UpdateXTitle, "llama.cpp")`) was left as-is — it is a proper-noun engine name used as a format argument.