### PR TITLE
Localize Speech-to-text labels

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2173,6 +2173,8 @@
     "pickOnlineSubtitleTitle": "Pick subtitle to download",
     "pickOnlineSubtitleFetching": "Downloading subtitles...",
     "pickOnlineSubtitleNoneFound": "No subtitles found for this URL.",
+    "forcedAligner": "Forced aligner",
+    "postProcessing": "Post-processing...",
     "toggleCurrentSubtitleWhilePlaying": "Toggle current subtitle while playing",
     "toggleSubtitlesOnVideoPlayer": "Toggle subtitles on video player",
     "subtitlesOnVideoPlayerOn": "Subtitles on video player: on",

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -1880,7 +1880,7 @@ public partial class SpeechToTextViewModel : ObservableObject
 
         if (DoAdjustTimings || DoPostProcessing)
         {
-            ProgressText = "Post-processing...";
+            ProgressText = Se.Language.Video.PostProcessing;
         }
 
         var postProcessor = new SpeechToTextPostProcessor(DoTranslateToEnglish ? "en" : languageCode)

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -114,7 +114,7 @@ public class SpeechToTextWindow : Window
             .BindIsVisible(vm, nameof(vm.IsCrispAsrSelected))
             .WithLabeledBy(labelBackend);
 
-        var labelForcedAligner = UiUtil.MakeTextBlock("Forced aligner").WithMarginTop(10)
+        var labelForcedAligner = UiUtil.MakeTextBlock(Se.Language.Video.ForcedAligner).WithMarginTop(10)
             .BindIsVisible(vm, nameof(vm.IsForcedAlignerVisible));
         var comboForcedAligner = UiUtil.MakeComboBox(vm.ForcedAligners, vm, nameof(vm.SelectedForcedAligner))
             .WithMinWidth(220)

--- a/src/ui/Logic/Config/Language/Video/LanguageVideo.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageVideo.cs
@@ -61,6 +61,8 @@ public class LanguageVideo
     public string PickOnlineSubtitleTitle { get; set; }
     public string PickOnlineSubtitleFetching { get; set; }
     public string PickOnlineSubtitleNoneFound { get; set; }
+    public string ForcedAligner { get; set; }
+    public string PostProcessing { get; set; }
     public string ToggleCurrentSubtitleWhilePlaying { get; set; }
     public string ToggleSubtitlesOnVideoPlayer { get; set; }
     public string SubtitlesOnVideoPlayerOn { get; set; }
@@ -128,6 +130,8 @@ public class LanguageVideo
         PickOnlineSubtitleTitle = "Pick subtitle to download";
         PickOnlineSubtitleFetching = "Downloading subtitles...";
         PickOnlineSubtitleNoneFound = "No subtitles found for this URL.";
+        ForcedAligner = "Forced aligner";
+        PostProcessing = "Post-processing...";
         ToggleCurrentSubtitleWhilePlaying = "Toggle current subtitle while playing";
         ToggleSubtitlesOnVideoPlayer = "Toggle subtitles on video player";
         SubtitlesOnVideoPlayerOn = "Subtitles on video player: on";


### PR DESCRIPTION
**Problem:** Hardcoded English strings in the Speech-to-text window:
- `src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs:117` — `UiUtil.MakeTextBlock("Forced aligner")` label
- `src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs:1883` — `ProgressText = "Post-processing..."` status

**Fix:** Added `Video.ForcedAligner` ("Forced aligner") and `Video.PostProcessing` ("Post-processing...") keys to `LanguageVideo` + English.json (video section). Both occurrences replaced with `Se.Language.Video.*`.

**Verification:** `dotnet build src/ui/UI.csproj -c Debug` — 0 errors, 0 warnings. English.json validated (utf-8-sig). No `"Forced aligner"` / `"Post-processing..."` literals remain in the SpeechToText files.

**Notes:** `General.PostProcessing` exists with the value "Post processing" (no hyphen/ellipsis) — a new Video key was added instead to preserve the exact visible text.