### PR TITLE
Localize BinaryEdit dialogs

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1286,6 +1286,10 @@
     "xProperties": "{0} properties"
   },
   "edit": {
+    "noSubtitleSelected": "No subtitle selected",
+    "pleaseSelectExactlyOneSubtitle": "Please select exactly one subtitle.",
+    "boxType": "Box type:",
+    "backgroundColor": "Background color:",
     "modifySelection": {
       "title": "Modify selection",
       "contains": "Contains",

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -2243,7 +2243,7 @@ public partial class BinaryEditViewModel : ObservableObject
         // Only allow if exactly one subtitle is selected
         if (SelectedSubtitle == null)
         {
-            await MessageBox.Show(Window, "No subtitle selected", "Please select exactly one subtitle.",
+            await MessageBox.Show(Window, Se.Language.Edit.NoSubtitleSelected, Se.Language.Edit.PleaseSelectExactlyOneSubtitle,
                 MessageBoxButtons.OK, MessageBoxIcon.Information);
             return;
         }

--- a/src/ui/Features/Shared/BinaryEdit/SetText/SetTextWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/SetText/SetTextWindow.cs
@@ -135,14 +135,14 @@ public class SetTextWindow : Window
         var numericUpDownShadowWidth = UiUtil.MakeNumericUpDownOneDecimal(0, 50, 120, vm, nameof(vm.ShadowWidth));
         numericUpDownShadowWidth.Margin = new Thickness(5);
 
-        var labelBoxType = UiUtil.MakeLabel("Box type:");
+        var labelBoxType = UiUtil.MakeLabel(Se.Language.Edit.BoxType);
         labelBoxType.Margin = new Thickness(5);
         
         var comboBoxBoxType = UiUtil.MakeComboBox(vm.BoxTypes, vm, nameof(vm.SelectedBoxType))
             .WithMinWidth(150);
         comboBoxBoxType.Margin = new Thickness(5);
 
-        var labelBackgroundColor = UiUtil.MakeLabel("Background color:");
+        var labelBackgroundColor = UiUtil.MakeLabel(Se.Language.Edit.BackgroundColor);
         labelBackgroundColor.Margin = new Thickness(5);
         
         var colorPickerBackgroundColor = UiUtil.MakeColorPickerButton(vm, nameof(vm.BackgroundColor));

--- a/src/ui/Logic/Config/Language/Edit/LanguageEdit.cs
+++ b/src/ui/Logic/Config/Language/Edit/LanguageEdit.cs
@@ -8,10 +8,18 @@ public class LanguageEdit
     public LanguageRegularExpressionContextMenu RegularExpressionContextMenu { get; set; } = new();
     public string ShowHistory { get; set; }
     public string RestoreSelected { get; set; }
+    public string NoSubtitleSelected { get; set; }
+    public string PleaseSelectExactlyOneSubtitle { get; set; }
+    public string BoxType { get; set; }
+    public string BackgroundColor { get; set; }
 
     public LanguageEdit()
     {
         ShowHistory = "History for undo";
         RestoreSelected = "Restore selected";
+        NoSubtitleSelected = "No subtitle selected";
+        PleaseSelectExactlyOneSubtitle = "Please select exactly one subtitle.";
+        BoxType = "Box type:";
+        BackgroundColor = "Background color:";
     }
 }


### PR DESCRIPTION
## Problem

BinaryEdit shows hardcoded English strings: the "No subtitle selected" MessageBox (src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs:2246) and the "Box type:" / "Background color:" labels in the Set Text window (SetTextWindow.cs:138,145).

## Fix

- Added 4 keys to LanguageEdit (+ English.json base): NoSubtitleSelected, PleaseSelectExactlyOneSubtitle, BoxType, BackgroundColor.
- Replaced all literals with Se.Language.Edit.*.

## Verification

- dotnet build src/ui/UI.csproj - 0 errors, 0 warnings
- English.json validated