### PR TITLE
Localize ASSA image color picker and batch convert labels

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1629,6 +1629,7 @@
     },
     "batchConvert": {
       "title": "Batch convert",
+      "assaSource": "ASSA source",
       "oneActionsSelected": "One action selected",
       "xActionsSelected": "{0} actions selected",
       "outputFolderSource": " Output folder: Source folder",
@@ -3030,6 +3031,8 @@
     "llamaCppDownloadModelPrompt": "llama.cpp requires the selected OCR model to be downloaded. Download now?"
   },
   "assa": {
+    "mouseOverColor": "Mouse-over color",
+    "clickedColor": "Clicked color",
     "assaDraw": "ASSA Draw",
     "drawSelectTool": "Select (move points)",
     "drawLineTool": "Line Tool (F4)",

--- a/src/ui/Features/Assa/AssaImageColorPicker/AssaImageColorPickerWindow.cs
+++ b/src/ui/Features/Assa/AssaImageColorPicker/AssaImageColorPickerWindow.cs
@@ -103,7 +103,7 @@ public class AssaImageColorPickerWindow : Window
             BorderBrush = new SolidColorBrush(Colors.Gray),
             [!Border.BackgroundProperty] = new Binding(nameof(vm.CurrentMouseColor)),
         };
-        ToolTip.SetTip(mouseColorBox, "Mouse-over color");
+        ToolTip.SetTip(mouseColorBox, Se.Language.Assa.MouseOverColor);
 
         var mouseColorInfo = new StackPanel
         {
@@ -112,7 +112,7 @@ public class AssaImageColorPickerWindow : Window
             HorizontalAlignment = HorizontalAlignment.Left,
             Children =
             {
-                UiUtil.MakeLabel("Mouse-over color"),
+                UiUtil.MakeLabel(Se.Language.Assa.MouseOverColor),
                 new TextBlock
                 {
                     [!TextBlock.TextProperty] = new Binding(nameof(vm.CurrentMouseColorHex)),
@@ -130,7 +130,7 @@ public class AssaImageColorPickerWindow : Window
             [!Border.BackgroundProperty] = new Binding(nameof(vm.ClickedColor)),
             Margin = new Thickness(40, 0, 0, 0),
         };
-        ToolTip.SetTip(clickedColorBox, "Clicked color");
+        ToolTip.SetTip(clickedColorBox, Se.Language.Assa.ClickedColor);
 
         var copyButton = new Button
         {
@@ -147,7 +147,7 @@ public class AssaImageColorPickerWindow : Window
             HorizontalAlignment = HorizontalAlignment.Left,
             Children =
             {
-                UiUtil.MakeLabel("Clicked color"),
+                UiUtil.MakeLabel(Se.Language.Assa.ClickedColor),
                 new TextBlock
                 {
                     [!TextBlock.TextProperty] = new Binding(nameof(vm.ClickedColorHex)),

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertAssaWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertAssaWindow.cs
@@ -87,7 +87,7 @@ public class BatchConvertAssaWindow : Window
             RowSpacing = 5,
         };
         
-        var labelAssaSource = UiUtil.MakeLabel("ASSA source").WithBold();
+        var labelAssaSource = UiUtil.MakeLabel(Se.Language.Tools.BatchConvert.AssaSource).WithBold();
         var contentBorder = new Border
         {
             VerticalAlignment = VerticalAlignment.Stretch,

--- a/src/ui/Logic/Config/Language/Assa/LanguageAssa.cs
+++ b/src/ui/Logic/Config/Language/Assa/LanguageAssa.cs
@@ -28,6 +28,8 @@ public class LanguageAssa
     // Progress Bar Generator
     public string ProgressBarTitle { get; set; }
     public string ProgressBarSettings { get; set; }
+    public string MouseOverColor { get; set; }
+    public string ClickedColor { get; set; }
     public string ProgressBarForeColor { get; set; }
     public string ProgressBarSquareCorners { get; set; }
     public string ProgressBarRoundedCorners { get; set; }
@@ -432,5 +434,7 @@ public class LanguageAssa
         AdvancedEffectSlideInRightDescription = "Text slides in from off-screen right, holds, then exits back to the right";
         AdvancedEffectFadeInOutDescription = "Text fades in at the start and fades out at the end of each subtitle";
         OverrideTagsHistory = "Override tags history";
+        MouseOverColor = "Mouse-over color";
+        ClickedColor = "Clicked color";
     }
 }

--- a/src/ui/Logic/Config/Language/Tools/LanguageBatchConvert.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageBatchConvert.cs
@@ -15,6 +15,7 @@ public class LanguageBatchConvert
     public string FileNameContainsDotDotDot { get; set; }
     public string TrackLanguageContainsDotDotDot { get; set; }
     public string BatchConvertSettings { get; set; }
+    public string AssaSource { get; set; }
     public string AddFormatting { get; set; }
     public string AddItalic { get; set; }
     public string AddBold { get; set; }
@@ -82,5 +83,6 @@ public class LanguageBatchConvert
         AssaChangeStyleToStyle = "to";
         AssaChangeStyleImportStyle = "Import style...";
         AssaChangeStyleTrimUnusedStyles = "Trim unused styles";
+        AssaSource = "ASSA source";
     }
 }


### PR DESCRIPTION
## Problem

Hardcoded English labels: "Mouse-over color" / "Clicked color" (labels and tooltips) in the ASSA image color picker (AssaImageColorPickerWindow.cs:106-115,133,150) and "ASSA source" section header in batch convert (BatchConvertAssaWindow.cs:90).

## Fix

- Added MouseOverColor / ClickedColor keys to LanguageAssa and AssaSource to LanguageBatchConvert (+ English.json base).
- Replaced all literals in labels and tooltips.

## Verification

- dotnet build src/ui/UI.csproj - 0 errors, 0 warnings
- English.json validated