### PR TITLE
i18n follow-up: reuse existing export title strings, fix cancelled spelling

### DIFF
--- a/src/ui/Features/Files/ExportEbuStl/ExportEbuStlWindow.cs
+++ b/src/ui/Features/Files/ExportEbuStl/ExportEbuStlWindow.cs
@@ -13,7 +13,7 @@ public class ExportEbuStlWindow : Window
     public ExportEbuStlWindow(ExportEbuStlViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.File.Export.TitleExportEbuStl;
+        Title = Se.Language.Options.Shortcuts.FileExportEbuStl;
         SizeToContent = SizeToContent.WidthAndHeight;
         CanResize = false;
         vm.Window = this;

--- a/src/ui/Features/Files/ExportPac/ExportPacWindow.cs
+++ b/src/ui/Features/Files/ExportPac/ExportPacWindow.cs
@@ -10,7 +10,7 @@ public class ExportPacWindow : Window
     public ExportPacWindow(ExportPacViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.File.Export.TitleExportPac;
+        Title = Se.Language.Options.Shortcuts.FileExportPac;
         SizeToContent = SizeToContent.WidthAndHeight;
         CanResize = false;
         vm.Window = this;

--- a/src/ui/Logic/Config/Language/File/LanguageExport.cs
+++ b/src/ui/Logic/Config/Language/File/LanguageExport.cs
@@ -16,8 +16,6 @@ public class LanguageExport
     public string TitleExportFcpImage { get; set; }
     public string TitleExportWebVttThumbnails { get; set; }
     public string TitleExportCavena890 { get; set; }
-    public string TitleExportEbuStl { get; set; }
-    public string TitleExportPac { get; set; }
     public string ExportCavenaTranslatedTitle { get; set; }
     public string ExportCavenaOriginalTitle { get; set; }
     public string ExportCavenaTranslator { get; set; }
@@ -60,8 +58,6 @@ public class LanguageExport
         TitleExportFcpImage = "Final Cut Pro + image";
         TitleExportWebVttThumbnails = "WebVTT png";
         TitleExportCavena890 = "Export Cavena 890";
-        TitleExportEbuStl = "Export EBU STL";
-        TitleExportPac = "Export Pac";
         ExportCavenaTranslatedTitle = "Translated title";
         ExportCavenaOriginalTitle = "Original title";
         ExportCavenaTranslator = "Translator";

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -885,7 +885,7 @@ public class LanguageGeneral
         DownloadingX = "Downloading {0}";
         DownloadingXPercent = "Downloading {0}%";
         DownloadFailed = "Download failed";
-        DownloadCanceled = "Download canceled";
+        DownloadCanceled = "Download cancelled";
         UnpackFailed = "Unpack failed: {0}";
         UnpackingFailed = "Unpacking failed";
         NoDataReceived = "No data received";


### PR DESCRIPTION
Follow-up cleanup after merging the Ironship i18n batch (#13127–#13140):

- `File.Export.TitleExportEbuStl` / `TitleExportPac` duplicated the existing `Options.Shortcuts.FileExportEbuStl` / `FileExportPac` values. The export windows now reuse the shortcut strings (same pattern the batch itself used for the "Choose layout" title), and the duplicate keys are removed from `LanguageExport`.
- `General.DownloadCanceled` said "canceled" while every other entry uses the British "cancelled" (`Cancelled`, `ConversionCancelledByUser`, `TranslationCancelled`); aligned it.

English.json is intentionally untouched — regenerate it from the language classes via the in-app export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)