### PR TITLE
Fix NaN comparison in DoubleToOneDecimalHideMaxConverter

### DIFF
--- a/src/ui/Logic/ValueConverters/DoubleToOneDecimalHideMaxConverter.cs
+++ b/src/ui/Logic/ValueConverters/DoubleToOneDecimalHideMaxConverter.cs
@@ -12,7 +12,7 @@ public class DoubleToOneDecimalHideMaxConverter : IValueConverter
     {
         if (value is double d)
         {
-            if (d == double.MaxValue || d == double.NaN)
+            if (d == double.MaxValue || double.IsNaN(d))
             {
                 return string.Empty;
             }


### PR DESCRIPTION
## Problem

Follow-up to #13122 (Copilot review comment). The HideMax converter checks `d == double.NaN`, which is always false in IEEE 754 (NaN != NaN), so NaN values were formatted instead of hidden even with the correctly-typed Instance.

## Fix

- `d == double.NaN` -> `double.IsNaN(d)`.

## Verification

- dotnet build src/ui/UI.csproj - 0 errors, 0 warnings