### PR TITLE
Fix FileSizeConverter caching language-dependent suffix at type init

### DIFF
--- a/src/ui/Logic/ValueConverters/DoubleToOneDecimalHideMaxConverter.cs
+++ b/src/ui/Logic/ValueConverters/DoubleToOneDecimalHideMaxConverter.cs
@@ -12,7 +12,7 @@ public class DoubleToOneDecimalHideMaxConverter : IValueConverter
     {
         if (value is double d)
         {
-            if (d == double.MaxValue || d == double.NaN)
+            if (d == double.MaxValue || double.IsNaN(d))
             {
                 return string.Empty;
             }

--- a/src/ui/Logic/ValueConverters/FileSizeConverter.cs
+++ b/src/ui/Logic/ValueConverters/FileSizeConverter.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 namespace Nikse.SubtitleEdit.Logic.ValueConverters;
 internal class FileSizeConverter : IValueConverter
 {
-    private static readonly string[] SizeSuffixes = { Se.Language.General.Bytes, "KB", "MB", "GB", "TB", "PB" };
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
@@ -42,10 +41,11 @@ internal class FileSizeConverter : IValueConverter
         }
 
         int magnitude = 0;
+        var sizeSuffixes = new[] { Se.Language.General.Bytes, "KB", "MB", "GB", "TB", "PB" };
         double adjustedSize = bytes;
 
         // Keep dividing by 1024 until we get a manageable number
-        while (adjustedSize >= 1024 && magnitude < SizeSuffixes.Length - 1)
+        while (adjustedSize >= 1024 && magnitude < sizeSuffixes.Length - 1)
         {
             magnitude++;
             adjustedSize /= 1024;
@@ -54,7 +54,7 @@ internal class FileSizeConverter : IValueConverter
         // Format with appropriate decimal places
         string format = adjustedSize >= 100 ? "0" : (adjustedSize >= 10 ? "0.0" : "0.##");
 
-        var result = $"{adjustedSize.ToString(format, culture)} {SizeSuffixes[magnitude]}";
+        var result = $"{adjustedSize.ToString(format, culture)} {sizeSuffixes[magnitude]}";
         return result;
     }
 


### PR DESCRIPTION
## Problem

Follow-up to #13127 (Copilot review comment). `SizeSuffixes` was a `static readonly` array initialized with `Se.Language.General.Bytes` at type initialization - if the language is loaded/changed after the converter is first used (e.g. a runtime language switch), the "bytes" suffix stays in the old language.

## Fix

- The suffix array is now built per call inside `Convert`, so it always reads the current `Se.Language.General.Bytes`.

## Verification

- dotnet build src/ui/UI.csproj - 0 errors, 0 warnings