### PR TITLE
OCR: auto-detect source language and make dictionary follow the language combo

### DIFF
--- a/src/libse/VobSub/Idx.cs
+++ b/src/libse/VobSub/Idx.cs
@@ -13,6 +13,11 @@ namespace Nikse.SubtitleEdit.Core.VobSub
         public readonly List<SKColor> Palette = new List<SKColor>();
         public readonly List<string> Languages = new List<string>();
 
+        /// <summary>
+        /// Two-letter ISO 639-1 codes from the idx "id:" lines, parallel to <see cref="Languages"/>.
+        /// </summary>
+        public readonly List<string> LanguageCodes = new List<string>();
+
         private static readonly Regex TimeCodeLinePattern = new Regex(@"^timestamp: \d+:\d+:\d+:\d+, filepos: [\dabcdefABCDEF]+$", RegexOptions.Compiled);
 
         public Idx(string fileName)
@@ -61,6 +66,7 @@ namespace Nikse.SubtitleEdit.Core.VobSub
                         }
                         // Use U+200E (LEFT-TO-RIGHT MARK) to support right-to-left scripts
                         Languages.Add(string.Format("{0} \x200E(0x{1:x})", languageName, languageIndex + 32));
+                        LanguageCodes.Add(twoLetterLanguageId);
                         languageIndex++;
                     }
                 }

--- a/src/libse/VobSub/VobSubParser.cs
+++ b/src/libse/VobSub/VobSubParser.cs
@@ -13,6 +13,11 @@ namespace Nikse.SubtitleEdit.Core.VobSub
         public List<SKColor> IdxPalette { get; private set; } = new List<SKColor>();
         public List<string> IdxLanguages { get; private set; } = new List<string>();
 
+        /// <summary>
+        /// Two-letter ISO 639-1 codes from the idx "id:" lines, parallel to <see cref="IdxLanguages"/>.
+        /// </summary>
+        public List<string> IdxLanguageCodes { get; private set; } = new List<string>();
+
         private const int PacketizedElementaryStreamMaximumLength = 2028;
 
         /// <summary>
@@ -228,6 +233,7 @@ namespace Nikse.SubtitleEdit.Core.VobSub
                 var idx = new Idx(idxFileName);
                 IdxPalette = idx.Palette;
                 IdxLanguages = idx.Languages;
+                IdxLanguageCodes = idx.LanguageCodes;
                 if (idx.IdxParagraphs.Count > 0)
                 {
                     var buffer = new byte[0x800]; // 2048

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17585,7 +17585,17 @@ public partial class MainViewModel :
             streamId = languageStreamIds.First();
         }
 
-        var result = await ShowDialogAsync<OcrWindow, OcrViewModel>(vm => { vm.Initialize(streamIdDictionary[streamId], palette, vobSubFileName); });
+        // Recover the picked stream's language code from the idx: Idx.cs formats language
+        // entries as "{LanguageName} ‎(0x{streamId:x})", parallel to IdxLanguageCodes.
+        string? languageCode = null;
+        var languageMarker = $"(0x{streamId:x})";
+        var languageIndex = vobSubParser.IdxLanguages.FindIndex(l => l.Contains(languageMarker, StringComparison.OrdinalIgnoreCase));
+        if (languageIndex >= 0 && languageIndex < vobSubParser.IdxLanguageCodes.Count)
+        {
+            languageCode = vobSubParser.IdxLanguageCodes[languageIndex];
+        }
+
+        var result = await ShowDialogAsync<OcrWindow, OcrViewModel>(vm => { vm.Initialize(streamIdDictionary[streamId], palette, vobSubFileName, languageCode); });
 
         if (result.OkPressed)
         {

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -174,6 +174,7 @@ public partial class OcrViewModel : ObservableObject
     private IOcrSubtitle? _ocrSubtitle;
     private List<OcrSubtitleItem> _allOcrSubtitleItems = new();
     private string _sourceFileName = string.Empty;
+    private Iso639Dash2LanguageCode? _sourceLanguageIso;
     private readonly INOcrCaseFixer _nOcrCaseFixer;
     private readonly IWindowService _windowService;
     private readonly IFileHelper _fileHelper;
@@ -416,6 +417,7 @@ public partial class OcrViewModel : ObservableObject
     partial void OnSelectedPaddleOcrLanguageChanged(OcrLanguage2? value) => AutoSelectDictionaryForOcrLanguage(value?.Code);
     partial void OnSelectedGoogleLensLanguageChanged(OcrLanguage2 value) => AutoSelectDictionaryForOcrLanguage(value?.Code);
     partial void OnSelectedGoogleVisionLanguageChanged(OcrLanguage? value) => AutoSelectDictionaryForOcrLanguage(value?.Code);
+    partial void OnSelectedOllamaLanguageChanged(string? value) => AutoSelectDictionaryForOcrLanguage(Iso639Dash2LanguageCode.GetTwoLetterCodeFromEnglishName(value ?? string.Empty));
 
     private void AutoSelectDictionaryForOcrLanguage(string? languageCode)
     {
@@ -447,6 +449,145 @@ public partial class OcrViewModel : ObservableObject
         {
             SelectedDictionary = match;
         }
+    }
+
+    /// <summary>
+    /// Pre-select the OCR language combo boxes (and via their change handlers, the spell-check
+    /// dictionary) from the source file's declared language: idx stream language, Matroska/mp4
+    /// track language, or a language tag in the file name (#13116). A detected language wins
+    /// over the last-used one; no-op when the source carries no language info.
+    /// </summary>
+    private void AutoDetectSourceLanguage(string? languageCode = null)
+    {
+        var iso = ResolveIsoLanguage(languageCode) ?? ResolveIsoLanguage(DetectLanguageCodeFromFileName(_sourceFileName));
+        if (iso == null)
+        {
+            return;
+        }
+
+        _sourceLanguageIso = iso;
+
+        var ollamaLanguage = OllamaLanguages.FirstOrDefault(p => p == iso.EnglishName);
+        if (ollamaLanguage != null)
+        {
+            SelectedOllamaLanguage = ollamaLanguage;
+        }
+
+        var paddleLanguage = PaddleOcrLanguages.FirstOrDefault(p => p.Code == iso.TwoLetterCode);
+        if (paddleLanguage != null)
+        {
+            SelectedPaddleOcrLanguage = paddleLanguage;
+        }
+
+        var lensLanguage = GoogleLensLanguages.FirstOrDefault(p => p.Code == iso.TwoLetterCode);
+        if (lensLanguage != null)
+        {
+            SelectedGoogleLensLanguage = lensLanguage;
+        }
+
+        var visionLanguage = GoogleVisionLanguages.FirstOrDefault(p => p.Code == iso.ThreeLetterCode || p.Code == iso.TwoLetterCode);
+        if (visionLanguage != null)
+        {
+            SelectedGoogleVisionLanguage = visionLanguage;
+        }
+
+        // The Tesseract list is only populated while the Tesseract engine is active;
+        // EngineSelectionChanged applies _sourceLanguageIso when it loads the list later.
+        var tesseractItem = TesseractDictionaryItems.FirstOrDefault(p => p.Code == iso.ThreeLetterCode);
+        if (tesseractItem != null)
+        {
+            SelectedTesseractDictionaryItem = tesseractItem;
+        }
+
+        // Also point the dictionary directly - the setters above only raise a change (and thereby
+        // auto-select the dictionary) when the combo value actually changes, e.g. not when the
+        // detected language equals the last-used one while the dictionary is something else.
+        AutoSelectDictionaryForOcrLanguage(iso.TwoLetterCode);
+    }
+
+    internal static Iso639Dash2LanguageCode? ResolveIsoLanguage(string? languageCode)
+    {
+        if (string.IsNullOrWhiteSpace(languageCode))
+        {
+            return null;
+        }
+
+        // Strip region subtags like "nl-NL" or "pt_BR".
+        var code = languageCode.Trim().ToLowerInvariant();
+        var separator = code.IndexOfAny(new[] { '-', '_' });
+        if (separator > 0)
+        {
+            code = code.Substring(0, separator);
+        }
+
+        if (code.Length == 2)
+        {
+            return Iso639Dash2LanguageCode.List.FirstOrDefault(p => p.TwoLetterCode == code);
+        }
+
+        if (code.Length == 3)
+        {
+            return Iso639Dash2LanguageCode.List.FirstOrDefault(p => p.ThreeLetterCode == code || p.BibliographicCode == code);
+        }
+
+        return null;
+    }
+
+    internal static string? DetectLanguageCodeFromFileName(string fileName)
+    {
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return null;
+        }
+
+        var name = Path.GetFileNameWithoutExtension(fileName);
+
+        // SE's own Matroska track export names files "..._track3_[dut]" - use the last
+        // bracketed token that is a valid ISO 639 code.
+        var bracketMatches = Regex.Matches(name, @"\[([a-zA-Z]{2,3})\]");
+        for (var i = bracketMatches.Count - 1; i >= 0; i--)
+        {
+            var code = bracketMatches[i].Groups[1].Value;
+            if (ResolveIsoLanguage(code) != null)
+            {
+                return code;
+            }
+        }
+
+        // Trailing dot-separated language tag like "movie.nl.sub" or "movie.dut.forced.sub"
+        // (the extension is already removed). Walk backwards past common non-language subtitle
+        // markers; "hi" is treated as hearing-impaired, not Hindi, as that reading is far more
+        // common in subtitle file names. Three-letter tokens must be lowercase so capitalized
+        // title words ("Big.Ben") are not mistaken for language codes; only the last two
+        // candidate tokens are considered so tokens deep inside the title cannot match.
+        var tokens = name.Split('.');
+        var checkedTokens = 0;
+        for (var i = tokens.Length - 1; i > 0 && checkedTokens < 2; i--)
+        {
+            var token = tokens[i].Trim();
+            if (token.Length == 0 || token.ToLowerInvariant() is "hi" or "sdh" or "cc" or "forced")
+            {
+                continue;
+            }
+
+            checkedTokens++;
+            if (token.Length is not (2 or 3) || !token.All(char.IsLetter))
+            {
+                continue;
+            }
+
+            if (token.Length == 3 && token != token.ToLowerInvariant())
+            {
+                continue;
+            }
+
+            if (ResolveIsoLanguage(token) != null)
+            {
+                return token;
+            }
+        }
+
+        return null;
     }
 
     private string? GetNOcrLanguageFileName()
@@ -4480,9 +4621,10 @@ public partial class OcrViewModel : ObservableObject
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleBluRay(subtitles);
         SetOcrSubtitleItems();
+        AutoDetectSourceLanguage();
     }
 
-    public void Initialize(List<VobSubMergedPack> vobSubMergedPackList, List<SKColor> palette, string vobSubFileName)
+    public void Initialize(List<VobSubMergedPack> vobSubMergedPackList, List<SKColor> palette, string vobSubFileName, string? languageCode = null)
     {
         _sourceFileName = vobSubFileName;
         Title = string.Format(Se.Language.Ocr.OcrX, vobSubFileName);
@@ -4490,6 +4632,7 @@ public partial class OcrViewModel : ObservableObject
         SetOcrSubtitleItems();
         IsVobSubVisible = true;
         ApplyStoredVobSubColors();
+        AutoDetectSourceLanguage(languageCode);
     }
 
     public void Initialize(Trak mp4SubtitleTrack, List<Paragraph> paragraphs, string fileName)
@@ -4498,6 +4641,7 @@ public partial class OcrViewModel : ObservableObject
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleMp4VobSub(mp4SubtitleTrack, paragraphs);
         SetOcrSubtitleItems();
+        AutoDetectSourceLanguage(mp4SubtitleTrack.Mdia?.Mdhd?.Iso639ThreeLetterCode);
     }
 
     public void Initialize(List<VobSubMergedPack> mergedVobSubPacks, List<SKColor> palette, MatroskaTrackInfo matroskaSubtitleInfo, string fileName)
@@ -4508,6 +4652,7 @@ public partial class OcrViewModel : ObservableObject
         SetOcrSubtitleItems();
         IsVobSubVisible = true;
         ApplyStoredVobSubColors();
+        AutoDetectSourceLanguage(matroskaSubtitleInfo.Language);
     }
 
     public void Initialize(MatroskaTrackInfo matroskaSubtitleInfo, Subtitle subtitle, List<DvbSubPes> subtitleImages, string fileName)
@@ -4516,6 +4661,7 @@ public partial class OcrViewModel : ObservableObject
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleMkvDvb(matroskaSubtitleInfo, subtitle, subtitleImages);
         SetOcrSubtitleItems();
+        AutoDetectSourceLanguage(matroskaSubtitleInfo.Language);
     }
 
     public void Initialize(MatroskaTrackInfo matroskaSubtitleInfo, List<BluRaySupParser.PcsData> pcsDataList, string fileName)
@@ -4524,6 +4670,7 @@ public partial class OcrViewModel : ObservableObject
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleMkvBluRay(matroskaSubtitleInfo, pcsDataList);
         SetOcrSubtitleItems();
+        AutoDetectSourceLanguage(matroskaSubtitleInfo.Language);
     }
 
     public void Initialize(IList<IBinaryParagraphWithPosition> list, string fileName)
@@ -4532,6 +4679,7 @@ public partial class OcrViewModel : ObservableObject
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleIBinaryParagraph(list);
         SetOcrSubtitleItems();
+        AutoDetectSourceLanguage();
     }
 
     public void InitializeBdn(Subtitle subtitle, string fileName, bool isSon)
@@ -4540,6 +4688,7 @@ public partial class OcrViewModel : ObservableObject
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleBdn(subtitle, fileName, isSon);
         SetOcrSubtitleItems();
+        AutoDetectSourceLanguage();
     }
 
     public void InitializeWebVtt(Subtitle subtitle, string fileName)
@@ -4548,6 +4697,7 @@ public partial class OcrViewModel : ObservableObject
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleWebVttImages(subtitle, fileName);
         SetOcrSubtitleItems();
+        AutoDetectSourceLanguage();
     }
 
     public void InitializeSpDvdSup(string fileName)
@@ -4556,6 +4706,7 @@ public partial class OcrViewModel : ObservableObject
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleSpDvdSupImages(fileName);
         SetOcrSubtitleItems();
+        AutoDetectSourceLanguage();
     }
 
     internal void Initialize(TransportStreamParser tsParser, List<TransportStreamSubtitle> subtitles, string fileName)
@@ -4564,6 +4715,7 @@ public partial class OcrViewModel : ObservableObject
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
         _ocrSubtitle = new OcrSubtitleTransportStream(tsParser, subtitles, fileName);
         SetOcrSubtitleItems();
+        AutoDetectSourceLanguage();
     }
 
     internal void Initialize(List<ImportImageItem> images)
@@ -4580,6 +4732,7 @@ public partial class OcrViewModel : ObservableObject
         Title = string.Format(Se.Language.Ocr.OcrX, "DivX");
         _ocrSubtitle = new OcrSubtitleDivX(list, fileName);
         SetOcrSubtitleItems();
+        AutoDetectSourceLanguage();
     }
 
     internal void EngineSelectionChanged(object? sender, SelectionChangedEventArgs e)
@@ -4633,7 +4786,8 @@ public partial class OcrViewModel : ObservableObject
             LoadActiveTesseractDictionaries();
             if (SelectedTesseractDictionaryItem == null)
             {
-                SelectedTesseractDictionaryItem = TesseractDictionaryItems.FirstOrDefault(p => p.Code == Se.Settings.Ocr.TesseractLastLanguage) ??
+                SelectedTesseractDictionaryItem = TesseractDictionaryItems.FirstOrDefault(p => _sourceLanguageIso != null && p.Code == _sourceLanguageIso.ThreeLetterCode) ??
+                                                  TesseractDictionaryItems.FirstOrDefault(p => p.Code == Se.Settings.Ocr.TesseractLastLanguage) ??
                                                   TesseractDictionaryItems.FirstOrDefault(p => p.Code == "eng") ??
                                                   TesseractDictionaryItems.FirstOrDefault();
             }

--- a/tests/UI/Features/Ocr/OcrSourceLanguageDetectionTests.cs
+++ b/tests/UI/Features/Ocr/OcrSourceLanguageDetectionTests.cs
@@ -1,0 +1,72 @@
+using Nikse.SubtitleEdit.Core.VobSub;
+using Nikse.SubtitleEdit.Features.Ocr;
+
+namespace UITests.Features.Ocr;
+
+public class OcrSourceLanguageDetectionTests
+{
+    [Theory]
+    [InlineData(@"C:\Video\kongekabale.2004_track5_[dut].sub", "dut")] // SE's own mkv track export naming (#13116)
+    [InlineData("/home/user/movie_track3_[fre].sup", "fre")]
+    [InlineData("movie_[xx]_track2_[nld].sub", "nld")] // last valid bracketed token wins
+    [InlineData("movie.nl.sub", "nl")]
+    [InlineData("movie.NL.sub", "NL")] // two-letter tags may be upper case
+    [InlineData("movie.dut.forced.sub", "dut")] // skips the "forced" marker
+    [InlineData("movie.en.hi.sub", "en")] // "hi" is hearing-impaired, not Hindi
+    [InlineData("movie.deu.sup", "deu")]
+    public void DetectLanguageCodeFromFileName_FindsLanguage(string fileName, string expected)
+    {
+        Assert.Equal(expected, OcrViewModel.DetectLanguageCodeFromFileName(fileName));
+    }
+
+    [Theory]
+    [InlineData("movie.sub")]
+    [InlineData("")]
+    [InlineData("movie_[cd1].sub")] // bracketed token that is not a language
+    [InlineData("Big.Ben.sub")] // capitalized three-letter title word is not a language tag
+    [InlineData("movie.hi.sub")] // lone "hi" reads as hearing-impaired, so no detection
+    [InlineData("The.Movie.2004.sub")]
+    public void DetectLanguageCodeFromFileName_NoLanguage(string fileName)
+    {
+        Assert.Null(OcrViewModel.DetectLanguageCodeFromFileName(fileName));
+    }
+
+    [Theory]
+    [InlineData("nl", "Dutch")]
+    [InlineData("nld", "Dutch")]
+    [InlineData("dut", "Dutch")] // ISO 639-2/B (bibliographic) form, as used by Matroska
+    [InlineData("nl-NL", "Dutch")] // region subtag is stripped
+    [InlineData("pt_BR", "Portuguese")]
+    [InlineData("GER", "German")]
+    public void ResolveIsoLanguage_Resolves(string code, string expectedEnglishName)
+    {
+        var iso = OcrViewModel.ResolveIsoLanguage(code);
+        Assert.NotNull(iso);
+        Assert.Equal(expectedEnglishName, iso!.EnglishName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("und")]
+    [InlineData("xxxx")]
+    public void ResolveIsoLanguage_Unknown(string? code)
+    {
+        Assert.Null(OcrViewModel.ResolveIsoLanguage(code));
+    }
+
+    [Fact]
+    public void Idx_ParsesLanguageCodes_ParallelToLanguages()
+    {
+        var idx = new Idx(new List<string>
+        {
+            "id: en, index: 0",
+            "id: nl, index: 1",
+        });
+
+        Assert.Equal(2, idx.Languages.Count);
+        Assert.Equal(new List<string> { "en", "nl" }, idx.LanguageCodes);
+        Assert.Contains("(0x20)", idx.Languages[0]);
+        Assert.Contains("(0x21)", idx.Languages[1]);
+    }
+}


### PR DESCRIPTION
Fixes #13116.

Two changes to the OCR window's language handling:

**Dictionary follows the language combo (all engines).** The Ollama/llama.cpp `Language` combo was the only OCR-language selector without a change handler, so picking Dutch left the spell-check dictionary on the last-used one. It now auto-selects the matching installed dictionary like the Tesseract, Paddle and Google Lens/Vision combos already do (SE4 parity, #11907). As before, this is a no-op when no matching dictionary is installed, so the user's choice is kept.

**The source file's language pre-selects the OCR language.** When the window opens, the language combos (and via the handlers above, the dictionary) are pre-selected from the source's declared language, overriding the last-used language:

- VobSub sub/idx: the picked stream's language from the idx `id:` lines (`Idx`/`VobSubParser` now expose the two-letter codes alongside the existing display names),
- Matroska tracks: `MatroskaTrackInfo.Language` (handles ISO 639-2/B codes like `dut`),
- mp4 VobSub tracks: the mdhd language,
- everything else: a language tag in the file name — SE's own track-export naming `..._track5_[dut]` (the reporter's case) or a trailing `movie.nl`-style tag. The file-name heuristic skips `forced`/`sdh`/`cc`/`hi` markers, requires three-letter tokens to be lowercase so capitalized title words don't match, and treats `hi` as hearing-impaired rather than Hindi.

When the source carries no language info, everything behaves as before (last-used language). Includes unit tests for the file-name/code resolution and the idx code parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)