### PR TITLE
Localize Video OCR llama.cpp labels and download prompts

### DIFF
--- a/src/ui/Features/Ocr/Download/DownloadCrispEmbedViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadCrispEmbedViewModel.cs
@@ -153,7 +153,7 @@ public partial class DownloadCrispEmbedViewModel : ObservableObject, IClosingCle
         if (_downloadStream.Length == 0)
         {
             ProgressText = Se.Language.General.DownloadFailed;
-            Error = "No data received";
+            Error = Se.Language.General.NoDataReceived;
             return;
         }
 
@@ -196,7 +196,7 @@ public partial class DownloadCrispEmbedViewModel : ObservableObject, IClosingCle
         if (!File.Exists(_modelTempFileName) || new FileInfo(_modelTempFileName).Length == 0)
         {
             ProgressText = Se.Language.General.DownloadFailed;
-            Error = "No data received";
+            Error = Se.Language.General.NoDataReceived;
             return;
         }
 

--- a/src/ui/Features/Ocr/Download/DownloadGoogleLensOcrViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadGoogleLensOcrViewModel.cs
@@ -72,7 +72,7 @@ public partial class DownloadGoogleLensOcrViewModel : ObservableObject, IClosing
                 if (!File.Exists(_tempFileName))
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 
@@ -80,7 +80,7 @@ public partial class DownloadGoogleLensOcrViewModel : ObservableObject, IClosing
                 if (fileInfo.Length == 0)
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 

--- a/src/ui/Features/Ocr/Download/DownloadPaddleOcrViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadPaddleOcrViewModel.cs
@@ -114,7 +114,7 @@ public partial class DownloadPaddleOcrViewModel : ObservableObject, IClosingClea
                 if (!AllFileExists())
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 

--- a/src/ui/Features/Ocr/Download/DownloadTesseractModelViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadTesseractModelViewModel.cs
@@ -75,7 +75,7 @@ public partial class DownloadTesseractModelViewModel : ObservableObject, IClosin
                 if (_downloadStream.Length == 0)
                 {
                     StatusText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 

--- a/src/ui/Features/Ocr/Download/DownloadTesseractViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadTesseractViewModel.cs
@@ -76,7 +76,7 @@ public partial class DownloadTesseractViewModel : ObservableObject, IClosingClea
                 if (_downloadStream.Length == 0)
                 {
                     StatusText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -221,7 +221,7 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
                 if (_downloadStream.Length == 0)
                 {
                     ProgressText = "Download failed";
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -197,7 +197,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 if (_downloadStream.Length == 0)
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 
@@ -261,7 +261,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 if (_downloadStreamModel.Length == 0)
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 
@@ -272,7 +272,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 if (_downloadStreamConfig.Length == 0)
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 
@@ -321,7 +321,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 if (_downloadStreamQwen3TtsCpp.Length == 0)
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 
@@ -476,7 +476,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 if (_downloadStreamKokoroTtsCpp.Length == 0)
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 
@@ -1322,7 +1322,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 if (_downloadStreamOmniVoice.Length == 0)
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 

--- a/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media.Imaging;
 using Avalonia.Threading;
@@ -110,7 +110,7 @@ public partial class VideoOcrViewModel : ObservableObject
         GlmLanguage = string.Empty;
         LlamaCppModels = new ObservableCollection<LlamaCppModelDisplay>();
         LlamaCppLanguage = string.Empty;
-        LlamaCppServerButtonText = "Start server";
+        LlamaCppServerButtonText = Se.Language.General.StartServer;
         ProgressText = string.Empty;
         PreviewPositionText = string.Empty;
         ScanAreaText = string.Empty;
@@ -224,7 +224,7 @@ public partial class VideoOcrViewModel : ObservableObject
 
     private void UpdateLlamaCppServerButtonText()
     {
-        LlamaCppServerButtonText = LlamaCppServerManager.IsServerRunning ? "Stop server" : "Start server";
+        LlamaCppServerButtonText = LlamaCppServerManager.IsServerRunning ? Se.Language.General.StopServer : Se.Language.General.StartServer;
     }
 
     [RelayCommand]
@@ -302,15 +302,15 @@ public partial class VideoOcrViewModel : ObservableObject
             string message;
             if (!engineInstalled && !modelInstalled)
             {
-                message = "llama.cpp requires the llama-server engine and the selected OCR model to be downloaded. Download now?";
+                message = Se.Language.Ocr.LlamaCppDownloadEngineAndModelPrompt;
             }
             else if (!engineInstalled)
             {
-                message = "llama.cpp requires the llama-server engine to be downloaded. Download now?";
+                message = Se.Language.Ocr.LlamaCppDownloadEnginePrompt;
             }
             else
             {
-                message = "llama.cpp requires the selected OCR model to be downloaded. Download now?";
+                message = Se.Language.Ocr.LlamaCppDownloadModelPrompt;
             }
 
             var answer = await MessageBox.Show(

--- a/src/ui/Logic/ValueConverters/DoubleToOneDecimalHideMaxConverter.cs
+++ b/src/ui/Logic/ValueConverters/DoubleToOneDecimalHideMaxConverter.cs
@@ -12,7 +12,7 @@ public class DoubleToOneDecimalHideMaxConverter : IValueConverter
     {
         if (value is double d)
         {
-            if (d == double.MaxValue || d == double.NaN)
+            if (d == double.MaxValue || double.IsNaN(d))
             {
                 return string.Empty;
             }

--- a/src/ui/Logic/ValueConverters/FileSizeConverter.cs
+++ b/src/ui/Logic/ValueConverters/FileSizeConverter.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 namespace Nikse.SubtitleEdit.Logic.ValueConverters;
 internal class FileSizeConverter : IValueConverter
 {
-    private static readonly string[] SizeSuffixes = { Se.Language.General.Bytes, "KB", "MB", "GB", "TB", "PB" };
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
@@ -42,10 +41,11 @@ internal class FileSizeConverter : IValueConverter
         }
 
         int magnitude = 0;
+        var sizeSuffixes = new[] { Se.Language.General.Bytes, "KB", "MB", "GB", "TB", "PB" };
         double adjustedSize = bytes;
 
         // Keep dividing by 1024 until we get a manageable number
-        while (adjustedSize >= 1024 && magnitude < SizeSuffixes.Length - 1)
+        while (adjustedSize >= 1024 && magnitude < sizeSuffixes.Length - 1)
         {
             magnitude++;
             adjustedSize /= 1024;
@@ -54,7 +54,7 @@ internal class FileSizeConverter : IValueConverter
         // Format with appropriate decimal places
         string format = adjustedSize >= 100 ? "0" : (adjustedSize >= 10 ? "0.0" : "0.##");
 
-        var result = $"{adjustedSize.ToString(format, culture)} {SizeSuffixes[magnitude]}";
+        var result = $"{adjustedSize.ToString(format, culture)} {sizeSuffixes[magnitude]}";
         return result;
     }
 


### PR DESCRIPTION
## Problem

Follow-up to #13135 (Copilot review comments). VideoOcrViewModel still showed hardcoded English "Start server"/"Stop server" button labels and the three llama.cpp OCR download prompt messages, while AutoTranslate/Ocr view models and LanguageGeneral/LanguageOcr already have the keys.

## Fix

- "Start server"/"Stop server" -> Se.Language.General.StartServer / StopServer
- The three "llama.cpp requires ... Download now?" prompts -> Se.Language.Ocr.LlamaCppDownloadEngineAndModelPrompt / LlamaCppDownloadEnginePrompt / LlamaCppDownloadModelPrompt

## Verification

- dotnet build src/ui/UI.csproj - 0 errors, 0 warnings