### PR TITLE
Localize native Mac export menu items

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2956,6 +2956,7 @@
     "newNOcrDatabase": "New nOCR database",
     "newBinaryImageCompareDatabase": "New/rename Binary Image Compare database",
     "renameNOcrDatabase": "Rename nOCR database",
+    "renameBinaryImageCompareDatabase": "Rename Binary Image Compare database",
     "nOcrDatabase": "nOCR database",
     "drawMode": "Draw mode:",
     "addNewCharcter": "Add new character",

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -238,14 +238,14 @@ public static class InitNativeMacMenu
         exportItems.Items.Add(Item(lExport.TitleExportDCinemaInteropPng, v => v.ExportDCinemaInteropPngCommand));
         exportItems.Items.Add(Item(lExport.TitleExportDCinemaSmpte2014Png, v => v.ExportDCinemaSmpte2014PngCommand));
         exportItems.Items.Add(Item(Ebu.NameOfFormat, v => v.ExportEbuStlCommand));
-        exportItems.Items.Add(Item("DOST/png", v => v.ExportDostPngCommand));
+        exportItems.Items.Add(Item(lExport.TitleExportDostPng, v => v.ExportDostPngCommand));
         exportItems.Items.Add(Item(lExport.TitleExportDvdSup, v => v.ExportDvdSupCommand));
-        exportItems.Items.Add(Item("Final Cut Pro + image", v => v.ExportFcpPngCommand));
+        exportItems.Items.Add(Item(lExport.TitleExportFcpImage, v => v.ExportFcpPngCommand));
         exportItems.Items.Add(Item(Se.Language.General.ImagesWithTimeCode, v => v.ExportImagesWithTimeCodeCommand));
         exportItems.Items.Add(Item(Pac.NameOfFormat, v => v.ExportPacCommand));
         exportItems.Items.Add(Item(new PacUnicode().Name, v => v.ExportPacUnicodeCommand));
         exportItems.Items.Add(Item(lExport.TitleExportVobSub, v => v.ExportVobSubCommand));
-        exportItems.Items.Add(Item("WebVTT png", v => v.ExportWebVttThumbnailsCommand));
+        exportItems.Items.Add(Item(lExport.TitleExportWebVttThumbnails, v => v.ExportWebVttThumbnailsCommand));
         exportItems.Items.Add(new NativeMenuItemSeparator());
         exportItems.Items.Add(Item(Clean(lExport.CustomTextFormatsDotDotDot), v => v.ShowExportCustomTextFormatCommand));
         exportItems.Items.Add(Item(Clean(lExport.PlainTextDotDotDot), v => v.ShowExportPlainTextCommand));

--- a/src/ui/Features/Ocr/Download/DownloadCrispEmbedViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadCrispEmbedViewModel.cs
@@ -153,7 +153,7 @@ public partial class DownloadCrispEmbedViewModel : ObservableObject, IClosingCle
         if (_downloadStream.Length == 0)
         {
             ProgressText = Se.Language.General.DownloadFailed;
-            Error = "No data received";
+            Error = Se.Language.General.NoDataReceived;
             return;
         }
 
@@ -196,7 +196,7 @@ public partial class DownloadCrispEmbedViewModel : ObservableObject, IClosingCle
         if (!File.Exists(_modelTempFileName) || new FileInfo(_modelTempFileName).Length == 0)
         {
             ProgressText = Se.Language.General.DownloadFailed;
-            Error = "No data received";
+            Error = Se.Language.General.NoDataReceived;
             return;
         }
 

--- a/src/ui/Features/Ocr/Download/DownloadGoogleLensOcrViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadGoogleLensOcrViewModel.cs
@@ -72,7 +72,7 @@ public partial class DownloadGoogleLensOcrViewModel : ObservableObject, IClosing
                 if (!File.Exists(_tempFileName))
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 
@@ -80,7 +80,7 @@ public partial class DownloadGoogleLensOcrViewModel : ObservableObject, IClosing
                 if (fileInfo.Length == 0)
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 

--- a/src/ui/Features/Ocr/Download/DownloadPaddleOcrViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadPaddleOcrViewModel.cs
@@ -114,7 +114,7 @@ public partial class DownloadPaddleOcrViewModel : ObservableObject, IClosingClea
                 if (!AllFileExists())
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 

--- a/src/ui/Features/Ocr/Download/DownloadTesseractModelViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadTesseractModelViewModel.cs
@@ -75,7 +75,7 @@ public partial class DownloadTesseractModelViewModel : ObservableObject, IClosin
                 if (_downloadStream.Length == 0)
                 {
                     StatusText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 

--- a/src/ui/Features/Ocr/Download/DownloadTesseractViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadTesseractViewModel.cs
@@ -76,7 +76,7 @@ public partial class DownloadTesseractViewModel : ObservableObject, IClosingClea
                 if (_downloadStream.Length == 0)
                 {
                     StatusText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -1586,7 +1586,7 @@ public partial class OcrViewModel : ObservableObject
         if (result.NewPressed)
         {
             var newResult = await _windowService.ShowDialogAsync<BinaryOcrDbNewWindow, BinaryOcrDbNewViewModel>(Window!,
-                vm => { vm.Initialize(Se.Language.Ocr.NewNOcrDatabase, string.Empty); });
+                vm => { vm.Initialize(Se.Language.Ocr.NewBinaryImageCompareDatabase, string.Empty); });
             if (newResult.OkPressed)
             {
                 if (!Directory.Exists(Se.OcrFolder))
@@ -1623,7 +1623,7 @@ public partial class OcrViewModel : ObservableObject
             var newResult = await _windowService.ShowDialogAsync<BinaryOcrDbNewWindow, BinaryOcrDbNewViewModel>(Window!,
             vm =>
             {
-                vm.Initialize(Se.Language.Ocr.RenameNOcrDatabase, result.BinaryOcrDatabaseName);
+                vm.Initialize(Se.Language.Ocr.RenameBinaryImageCompareDatabase, result.BinaryOcrDatabaseName);
             });
 
             _isCtrlDown = false;

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -221,7 +221,7 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
                 if (_downloadStream.Length == 0)
                 {
                     ProgressText = "Download failed";
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -197,7 +197,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 if (_downloadStream.Length == 0)
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 
@@ -261,7 +261,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 if (_downloadStreamModel.Length == 0)
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 
@@ -272,7 +272,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 if (_downloadStreamConfig.Length == 0)
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 
@@ -321,7 +321,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 if (_downloadStreamQwen3TtsCpp.Length == 0)
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 
@@ -476,7 +476,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 if (_downloadStreamKokoroTtsCpp.Length == 0)
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 
@@ -1322,7 +1322,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 if (_downloadStreamOmniVoice.Length == 0)
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = "No data received";
+                    Error = Se.Language.General.NoDataReceived;
                     return;
                 }
 

--- a/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media.Imaging;
 using Avalonia.Threading;
@@ -110,7 +110,7 @@ public partial class VideoOcrViewModel : ObservableObject
         GlmLanguage = string.Empty;
         LlamaCppModels = new ObservableCollection<LlamaCppModelDisplay>();
         LlamaCppLanguage = string.Empty;
-        LlamaCppServerButtonText = "Start server";
+        LlamaCppServerButtonText = Se.Language.General.StartServer;
         ProgressText = string.Empty;
         PreviewPositionText = string.Empty;
         ScanAreaText = string.Empty;
@@ -224,7 +224,7 @@ public partial class VideoOcrViewModel : ObservableObject
 
     private void UpdateLlamaCppServerButtonText()
     {
-        LlamaCppServerButtonText = LlamaCppServerManager.IsServerRunning ? "Stop server" : "Start server";
+        LlamaCppServerButtonText = LlamaCppServerManager.IsServerRunning ? Se.Language.General.StopServer : Se.Language.General.StartServer;
     }
 
     [RelayCommand]
@@ -302,15 +302,15 @@ public partial class VideoOcrViewModel : ObservableObject
             string message;
             if (!engineInstalled && !modelInstalled)
             {
-                message = "llama.cpp requires the llama-server engine and the selected OCR model to be downloaded. Download now?";
+                message = Se.Language.Ocr.LlamaCppDownloadEngineAndModelPrompt;
             }
             else if (!engineInstalled)
             {
-                message = "llama.cpp requires the llama-server engine to be downloaded. Download now?";
+                message = Se.Language.Ocr.LlamaCppDownloadEnginePrompt;
             }
             else
             {
-                message = "llama.cpp requires the selected OCR model to be downloaded. Download now?";
+                message = Se.Language.Ocr.LlamaCppDownloadModelPrompt;
             }
 
             var answer = await MessageBox.Show(

--- a/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
+++ b/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
@@ -32,6 +32,7 @@ public class LanguageOcr
     public string NewNOcrDatabase { get; set; }
     public string NewBinaryImageCompareDatabase { get; set; }
     public string RenameNOcrDatabase { get; set; }
+    public string RenameBinaryImageCompareDatabase { get; set; }
     public string NOcrDatabase { get; set; }
     public string DrawMode { get; set; }
     public string AddNewCharcter { get; set; }
@@ -152,6 +153,7 @@ public class LanguageOcr
         NewNOcrDatabase = "New nOCR database";
         NewBinaryImageCompareDatabase = "New/rename Binary Image Compare database";
         RenameNOcrDatabase = "Rename nOCR database";
+        RenameBinaryImageCompareDatabase = "Rename Binary Image Compare database";
         NOcrDatabase = "nOCR database";
         DrawMode = "Draw mode:";
         AddNewCharcter = "Add new character";


### PR DESCRIPTION
## Problem

Follow-up to #13131 (Copilot review comment). The native macOS menu (InitNativeMacMenu.cs) still hardcoded the English export captions "DOST/png", "Final Cut Pro + image" and "WebVTT png", while the main menu and the new LanguageExport keys (TitleExportDostPng, TitleExportFcpImage, TitleExportWebVttThumbnails) are localized.

## Fix

- The three native menu items now use the LanguageExport keys (lExport is already in scope).

## Verification

- dotnet build src/ui/UI.csproj - 0 errors, 0 warnings