### PR TITLE
Localize spell-check dictionary and llama.cpp download statuses

### DIFF
--- a/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs
+++ b/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs
@@ -119,7 +119,7 @@ public partial class GetDictionariesViewModel : ObservableObject, IClosingCleanu
             {
                 _timer.Stop();
                 _done = true;
-                StatusText = "Download canceled";
+                StatusText = Se.Language.General.DownloadCanceled;
                 Close();
             }
             else if (_downloadTask is { IsFaulted: true })
@@ -152,7 +152,7 @@ public partial class GetDictionariesViewModel : ObservableObject, IClosingCleanu
         _downloadTask = null;
         Dispatcher.UIThread.Post(() =>
         {
-            StatusText = "Download failed";
+            StatusText = Se.Language.General.DownloadFailed;
             Progress = 0;
             ProgressOpacity = 0;
             IsProgressVisible = false;

--- a/src/ui/Features/Translate/DownloadLlamaCppViewModel.cs
+++ b/src/ui/Features/Translate/DownloadLlamaCppViewModel.cs
@@ -160,7 +160,7 @@ public partial class DownloadLlamaCppViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            ProgressText = "Download failed";
+            ProgressText = Se.Language.General.DownloadFailed;
             Error = ex.Message;
             Se.LogError(ex, "Error downloading llama.cpp");
         }


### PR DESCRIPTION
### Problem
Hardcoded English download status strings are shown to users instead of localized text, even though `Se.Language.General.DownloadFailed` / `Se.Language.General.DownloadCanceled` keys already exist:

- `src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs:122` — `StatusText = "Download canceled";`
- `src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs:155` — `StatusText = "Download failed";`
- `src/ui/Features/Translate/DownloadLlamaCppViewModel.cs:163` — `ProgressText = "Download failed";`

### Fix
Replaced the hardcoded literals with the existing localization keys:

- `GetDictionariesViewModel.cs:122` — `"Download canceled"` → `Se.Language.General.DownloadCanceled`
- `GetDictionariesViewModel.cs:155` — `"Download failed"` → `Se.Language.General.DownloadFailed`
- `DownloadLlamaCppViewModel.cs:163` — `"Download failed"` → `Se.Language.General.DownloadFailed`

Both files already had `using Nikse.SubtitleEdit.Logic.Config;`, so no using changes were needed. No new language keys or JSON edits were added.

### Verification
- `dotnet build src/ui/UI.csproj -c Debug --nologo -v q` → Build succeeded, **0 errors** (1 pre-existing warning in an unrelated file: `DownloadTesseractModelWindow.cs` duplicate using).
- `git diff` contains only the 3 changed string lines.

### Notes
- Remaining hardcoded strings in these files were reviewed and intentionally left unchanged: dictionary language names (e.g. "Finnish", "Polish" — data keys in a lookup dictionary, not UI status text), "CUDA runtime" (proper noun used inside localized `DownloadingX`/`UnpackingX` format strings; no localization key exists), and an exception/log message (`"Dictionary download failed: {url}"`, `"Error downloading llama.cpp"`).