### PR TITLE
Address Copilot review comments from the i18n PR batch

### DIFF
--- a/src/ui/Features/Ocr/Download/DownloadCrispEmbedViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadCrispEmbedViewModel.cs
@@ -142,7 +142,7 @@ public partial class DownloadCrispEmbedViewModel : ObservableObject, IClosingCle
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
         }

--- a/src/ui/Features/Ocr/Download/DownloadGoogleLensOcrViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadGoogleLensOcrViewModel.cs
@@ -114,7 +114,7 @@ public partial class DownloadGoogleLensOcrViewModel : ObservableObject, IClosing
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
         }

--- a/src/ui/Features/Ocr/Download/DownloadPaddleOcrViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadPaddleOcrViewModel.cs
@@ -193,7 +193,7 @@ public partial class DownloadPaddleOcrViewModel : ObservableObject, IClosingClea
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
         }

--- a/src/ui/Features/Ocr/Download/DownloadTesseractModelViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadTesseractModelViewModel.cs
@@ -97,7 +97,7 @@ public partial class DownloadTesseractModelViewModel : ObservableObject, IClosin
                 else
                 {
                     StatusText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
         }

--- a/src/ui/Features/Ocr/Download/DownloadTesseractViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadTesseractViewModel.cs
@@ -97,7 +97,7 @@ public partial class DownloadTesseractViewModel : ObservableObject, IClosingClea
                 else
                 {
                     StatusText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
         }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -208,17 +208,17 @@ public class BinaryEditWindow : Window
                         },
                         new MenuItem
                         {
-                            Header = "IMSC 1.1 image profile",
+                            Header = Se.Language.File.Export.TitleExportImscImage,
                             Command = vm.ExportImscImageCommand,
                         },
                         new MenuItem
                         {
-                            Header = "DOST/png",
+                            Header = Se.Language.File.Export.TitleExportDostPng,
                             Command = vm.ExportDostPngCommand,
                         },
                         new MenuItem
                         {
-                            Header = "Final Cut Pro + image",
+                            Header = Se.Language.File.Export.TitleExportFcpImage,
                             Command = vm.ExportFcpPngCommand,
                         },
                         new MenuItem
@@ -238,7 +238,7 @@ public class BinaryEditWindow : Window
                         },
                         new MenuItem
                         {
-                            Header = "WebVTT png",
+                            Header = Se.Language.File.Export.TitleExportWebVttThumbnails,
                             Command = vm.ExportWebVttThumbnailCommand,
                         },
                     }

--- a/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
+++ b/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
@@ -18,13 +18,13 @@ public static class InitNativeMacMenuBinaryEdit
         var exportMenu = new NativeMenu();
         Add(exportMenu, Se.Language.General.BluRaySup, vm.ExportBluRaySupCommand);
         Add(exportMenu, Se.Language.General.BdnXml, vm.ExportBdnXmlCommand);
-        Add(exportMenu, "IMSC 1.1 image profile", vm.ExportImscImageCommand);
-        Add(exportMenu, "DOST/png", vm.ExportDostPngCommand);
-        Add(exportMenu, "Final Cut Pro + image", vm.ExportFcpPngCommand);
+        Add(exportMenu, Se.Language.File.Export.TitleExportImscImage, vm.ExportImscImageCommand);
+        Add(exportMenu, Se.Language.File.Export.TitleExportDostPng, vm.ExportDostPngCommand);
+        Add(exportMenu, Se.Language.File.Export.TitleExportFcpImage, vm.ExportFcpPngCommand);
         Add(exportMenu, Se.Language.General.ImagesWithHtmlIndex, vm.ExportHtmlIndexCommand);
         Add(exportMenu, Se.Language.General.ImagesWithTimeCode, vm.ExportImagesWithTimeCodeCommand);
         Add(exportMenu, Se.Language.File.Export.TitleExportVobSub, vm.ExportVobSubCommand);
-        Add(exportMenu, "WebVTT png", vm.ExportWebVttThumbnailCommand);
+        Add(exportMenu, Se.Language.File.Export.TitleExportWebVttThumbnails, vm.ExportWebVttThumbnailCommand);
         fileMenu.Items.Add(new NativeMenuItem(Clean(l.Export)) { Menu = exportMenu });
         fileMenu.Items.Add(new NativeMenuItemSeparator());
         Add(fileMenu, Se.Language.Tools.ImageBasedEdit.ImportTimeCodes, vm.ImportTimeCodesCommand);

--- a/src/ui/Features/Shared/BinaryEdit/SetText/SetTextWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/SetText/SetTextWindow.cs
@@ -135,14 +135,14 @@ public class SetTextWindow : Window
         var numericUpDownShadowWidth = UiUtil.MakeNumericUpDownOneDecimal(0, 50, 120, vm, nameof(vm.ShadowWidth));
         numericUpDownShadowWidth.Margin = new Thickness(5);
 
-        var labelBoxType = UiUtil.MakeLabel(Se.Language.Edit.BoxType);
+        var labelBoxType = UiUtil.MakeLabel(Se.Language.Video.BurnIn.BoxType + ":");
         labelBoxType.Margin = new Thickness(5);
         
         var comboBoxBoxType = UiUtil.MakeComboBox(vm.BoxTypes, vm, nameof(vm.SelectedBoxType))
             .WithMinWidth(150);
         comboBoxBoxType.Margin = new Thickness(5);
 
-        var labelBackgroundColor = UiUtil.MakeLabel(Se.Language.Edit.BackgroundColor);
+        var labelBackgroundColor = UiUtil.MakeLabel(Se.Language.General.BackgroundColor + ":");
         labelBackgroundColor.Margin = new Thickness(5);
         
         var colorPickerBackgroundColor = UiUtil.MakeColorPickerButton(vm, nameof(vm.BackgroundColor));

--- a/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs
+++ b/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs
@@ -119,8 +119,11 @@ public partial class GetDictionariesViewModel : ObservableObject, IClosingCleanu
             {
                 _timer.Stop();
                 _done = true;
-                StatusText = Se.Language.General.DownloadCanceled;
-                Close();
+                Dispatcher.UIThread.Post(() =>
+                {
+                    StatusText = Se.Language.General.DownloadCanceled;
+                    Close();
+                });
             }
             else if (_downloadTask is { IsFaulted: true })
             {
@@ -136,8 +139,11 @@ public partial class GetDictionariesViewModel : ObservableObject, IClosingCleanu
                 {
                     _timer.Stop();
                     _done = true;
-                    OkPressed = true;
-                    Close();
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        OkPressed = true;
+                        Close();
+                    });
                 }
             }
         }

--- a/src/ui/Features/Translate/LlamaCppDownloadHelper.cs
+++ b/src/ui/Features/Translate/LlamaCppDownloadHelper.cs
@@ -261,15 +261,15 @@ public static class LlamaCppDownloadHelper
         string message;
         if (!engineInstalled && !modelInstalled)
         {
-            message = "llama.cpp requires the llama-server engine and a translation model to be downloaded. Download now?";
+            message = Se.Language.Translate.LlamaCppDownloadEngineAndModelPrompt;
         }
         else if (!engineInstalled)
         {
-            message = "llama.cpp requires the llama-server engine to be downloaded. Download now?";
+            message = Se.Language.Translate.LlamaCppDownloadEnginePrompt;
         }
         else
         {
-            message = "llama.cpp requires the selected translation model to be downloaded. Download now?";
+            message = Se.Language.Translate.LlamaCppDownloadModelPrompt;
         }
 
         var answer = await MessageBox.Show(

--- a/src/ui/Features/Video/OpenFromUrl/DownloadVideoFromUrlViewModel.cs
+++ b/src/ui/Features/Video/OpenFromUrl/DownloadVideoFromUrlViewModel.cs
@@ -310,14 +310,14 @@ public partial class DownloadVideoFromUrlViewModel : ObservableObject, IClosingC
                 var ex = _downloadTask.Exception?.InnerException ?? _downloadTask.Exception;
                 if (ex is OperationCanceledException)
                 {
-                    StatusText = "Download canceled";
+                    StatusText = Se.Language.General.DownloadCanceled;
                     TryDeletePartial();
                     Close();
                 }
                 else
                 {
-                    StatusText = "Download failed";
-                    Error = ex?.Message ?? "Unknown error";
+                    StatusText = Se.Language.General.DownloadFailed;
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                     TryDeletePartial();
                     Se.LogError(ex ?? new Exception("Unknown download error"), "yt-dlp video download failed");
                 }

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -220,7 +220,7 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
             {
                 if (_downloadStream.Length == 0)
                 {
-                    ProgressText = "Download failed";
+                    ProgressText = Se.Language.General.DownloadFailed;
                     Error = Se.Language.General.NoDataReceived;
                     return;
                 }
@@ -287,13 +287,13 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
             var ex = _downloadTask.Exception?.InnerException ?? _downloadTask.Exception;
             if (ex is OperationCanceledException)
             {
-                ProgressText = "Download canceled";
+                ProgressText = Se.Language.General.DownloadCanceled;
                 Close();
             }
             else
             {
-                ProgressText = "Download failed";
-                Error = ex?.Message ?? "Unknown error";
+                ProgressText = Se.Language.General.DownloadFailed;
+                Error = ex?.Message ?? Se.Language.General.UnknownError;
             }
 
             return;

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
@@ -127,7 +127,7 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject, ICl
                 var ex = _downloadTask.Exception?.InnerException ?? _downloadTask.Exception;
                 if (ex is OperationCanceledException)
                 {
-                    ProgressText = "Download canceled";
+                    ProgressText = Se.Language.General.DownloadCanceled;
                     Cancel();
 
                     return;
@@ -145,8 +145,8 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject, ICl
                     return;
                 }
 
-                ProgressText = "Download failed";
-                Error = ex?.Message ?? "Unknown error";
+                ProgressText = Se.Language.General.DownloadFailed;
+                Error = ex?.Message ?? Se.Language.General.UnknownError;
 
                 return;
             }
@@ -457,7 +457,7 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject, ICl
             // path failure) would land in the dispatcher unhandled and crash the app,
             // with the caller unable to observe it.
             Se.LogError(exception, "Speech-to-text model download failed to start");
-            ProgressText = "Download failed";
+            ProgressText = Se.Language.General.DownloadFailed;
             Error = exception.Message;
         }
     }

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -2448,7 +2448,7 @@ public partial class SpeechToTextViewModel : ObservableObject
 
         if (string.IsNullOrEmpty(error))
         {
-            await MessageBox.Show(Window!, "Unknown error", $"Unable to start {engine.Name}!");
+            await MessageBox.Show(Window!, Se.Language.General.UnknownError, $"Unable to start {engine.Name}!");
         }
         else
         {

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -250,7 +250,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
 
@@ -294,7 +294,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
 
@@ -310,7 +310,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
 
@@ -399,7 +399,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
 
@@ -465,7 +465,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
 
@@ -528,7 +528,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
 
@@ -550,7 +550,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
 
@@ -572,7 +572,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
 
@@ -625,7 +625,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
 
@@ -727,7 +727,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
 
@@ -815,7 +815,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
 
@@ -899,7 +899,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
 
@@ -969,7 +969,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
 
@@ -1014,7 +1014,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
 
@@ -1100,7 +1100,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
 
@@ -1186,7 +1186,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
 
@@ -1272,7 +1272,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
 
@@ -1411,7 +1411,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
 
@@ -1477,7 +1477,7 @@ public partial class DownloadTtsViewModel : ObservableObject
                 else
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
-                    Error = ex?.Message ?? "Unknown error";
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
             }
         }

--- a/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media.Imaging;
 using Avalonia.Threading;

--- a/src/ui/Logic/Config/Language/Edit/LanguageEdit.cs
+++ b/src/ui/Logic/Config/Language/Edit/LanguageEdit.cs
@@ -10,8 +10,6 @@ public class LanguageEdit
     public string RestoreSelected { get; set; }
     public string NoSubtitleSelected { get; set; }
     public string PleaseSelectExactlyOneSubtitle { get; set; }
-    public string BoxType { get; set; }
-    public string BackgroundColor { get; set; }
 
     public LanguageEdit()
     {
@@ -19,7 +17,5 @@ public class LanguageEdit
         RestoreSelected = "Restore selected";
         NoSubtitleSelected = "No subtitle selected";
         PleaseSelectExactlyOneSubtitle = "Please select exactly one subtitle.";
-        BoxType = "Box type:";
-        BackgroundColor = "Background color:";
     }
 }

--- a/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
+++ b/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
@@ -151,7 +151,7 @@ public class LanguageOcr
         ExpandInfoX = "Expand count: {0}";
         EditNOcrDatabaseXWithYItems = "Edit nOCR database {0} with {1:#,###,##0} items";
         NewNOcrDatabase = "New nOCR database";
-        NewBinaryImageCompareDatabase = "New/rename Binary Image Compare database";
+        NewBinaryImageCompareDatabase = "New Binary Image Compare database";
         RenameNOcrDatabase = "Rename nOCR database";
         RenameBinaryImageCompareDatabase = "Rename Binary Image Compare database";
         NOcrDatabase = "nOCR database";

--- a/src/ui/Logic/Config/Language/Translate/LanguageTranslate.cs
+++ b/src/ui/Logic/Config/Language/Translate/LanguageTranslate.cs
@@ -49,6 +49,9 @@ public class LanguageTranslate
     public string MaxTokensPerReply { get; set; }
     public string ServerContextSizeTokens { get; set; }
     public string CustomPromptHint { get; set; }
+    public string LlamaCppDownloadEngineAndModelPrompt { get; set; }
+    public string LlamaCppDownloadEnginePrompt { get; set; }
+    public string LlamaCppDownloadModelPrompt { get; set; }
 
     public LanguageTranslate()
     {
@@ -99,5 +102,8 @@ public class LanguageTranslate
         MaxTokensPerReply = "Max tokens per reply";
         ServerContextSizeTokens = "Server context size (tokens)";
         CustomPromptHint = "Custom instructions ({0} = source language, {1} = target language); empty = built-in prompt";
+        LlamaCppDownloadEngineAndModelPrompt = "llama.cpp requires the llama-server engine and a translation model to be downloaded. Download now?";
+        LlamaCppDownloadEnginePrompt = "llama.cpp requires the llama-server engine to be downloaded. Download now?";
+        LlamaCppDownloadModelPrompt = "llama.cpp requires the selected translation model to be downloaded. Download now?";
     }
 }

--- a/src/ui/Logic/Config/Language/Video/LanguageVideo.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageVideo.cs
@@ -162,7 +162,9 @@ public class LanguageVideo
         ReEncodeGeneratingDone = "Generating done";
         ReEncodeGeneratedFilesX = "Generated files ({0}):";
         ReEncodeFfmpegParameters = "ffmpeg parameters";
-        AssaStyleWillBeUsed = "Current ASSA style will be used\n\nChange subtitle format if\nyou want to set styles here";
+        AssaStyleWillBeUsed = "Current ASSA style will be used" + Environment.NewLine + Environment.NewLine +
+                              "Change subtitle format if" + Environment.NewLine +
+                              "you want to set styles here";
         Voices = "Voices";
         Presets = "Presets";
         TalkerX = "Talker {0}";

--- a/src/ui/Logic/ValueConverters/FileSizeConverter.cs
+++ b/src/ui/Logic/ValueConverters/FileSizeConverter.cs
@@ -41,11 +41,10 @@ internal class FileSizeConverter : IValueConverter
         }
 
         int magnitude = 0;
-        var sizeSuffixes = new[] { Se.Language.General.Bytes, "KB", "MB", "GB", "TB", "PB" };
         double adjustedSize = bytes;
 
         // Keep dividing by 1024 until we get a manageable number
-        while (adjustedSize >= 1024 && magnitude < sizeSuffixes.Length - 1)
+        while (adjustedSize >= 1024 && magnitude < 5)
         {
             magnitude++;
             adjustedSize /= 1024;
@@ -54,7 +53,16 @@ internal class FileSizeConverter : IValueConverter
         // Format with appropriate decimal places
         string format = adjustedSize >= 100 ? "0" : (adjustedSize >= 10 ? "0.0" : "0.##");
 
-        var result = $"{adjustedSize.ToString(format, culture)} {sizeSuffixes[magnitude]}";
+        var suffix = magnitude switch
+        {
+            0 => Se.Language.General.Bytes,
+            1 => "KB",
+            2 => "MB",
+            3 => "GB",
+            4 => "TB",
+            _ => "PB",
+        };
+        var result = $"{adjustedSize.ToString(format, culture)} {suffix}";
         return result;
     }
 


### PR DESCRIPTION
Follow-up addressing the valid Copilot review comments left on the merged Ironship i18n batch (#13119–#13152):

**Localization gaps Copilot caught that were still on main**
- BinaryEditWindow + native Mac BinaryEdit export menus still had hardcoded "IMSC 1.1 image profile" / "DOST/png" / "Final Cut Pro + image" / "WebVTT png" (from the #13131 comment) — now reuse `File.Export.TitleExport*`.
- Translate's llama.cpp download prompts in `LlamaCppDownloadHelper` (from the #13135 comment) — three new `LanguageTranslate` keys.
- Remaining `"Download failed"` / `"Download canceled"` / `"No data received"` / `"Unknown error"` literals in the STT engine/model, TTS, OpenFromUrl and OCR download view models — now `General.*`.

**Duplication / value fixes**
- #13141's `Edit.BoxType` / `Edit.BackgroundColor` duplicated `Video.BurnIn.BoxType` and `General.BackgroundColor`; SetTextWindow now reuses those (colon appended in code) and the duplicate keys are removed.
- `NewBinaryImageCompareDatabase` no longer says "New/rename …" now that rename has its own key.

**Code-quality comments**
- `FileSizeConverter` picks the suffix via `switch` — no per-call array allocation, bytes label still read per conversion (also resolves the #13127 static-init comment).
- `GetDictionariesViewModel` timer callback now marshals `StatusText`/`Close()`/`OkPressed` through `Dispatcher.UIThread.Post` (the success branch had the same cross-thread issue Copilot flagged on the cancel branch).
- Removed the accidental UTF-8 BOM #13148 introduced in `VideoOcrViewModel.cs`.
- `AssaStyleWillBeUsed` uses `Environment.NewLine` like the class's other multi-line defaults.

English.json intentionally untouched — regenerate from the language classes.

Not addressed (judgment calls): moving `ForcedAligner`/`PostProcessing` under `video.audioToText` and relocating the color-picker keys in `LanguageAssa` (organizational churn); the #13123 `Key.Return` comment is moot (Avalonia aliases `Enter`/`Return` to the same value); the #13119 `isAssa` comment is a theoretical edge case (literal `\fn` in non-ASSA text) left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)