### PR TITLE
Fix UI tests leaking windows across headless sessions

### DIFF
--- a/tests/UI/Features/Edit/Find/FindWindowHistoryTests.cs
+++ b/tests/UI/Features/Edit/Find/FindWindowHistoryTests.cs
@@ -56,16 +56,16 @@ public class FindWindowHistoryTests
         var window = new FindWindow(vm);
         try
         {
-                    window.Show();
-                    Dispatcher.UIThread.RunJobs();
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
 
-                    var historyButton = window.GetLogicalDescendants().OfType<Button>().First(b => b.Flyout != null);
+            var historyButton = window.GetLogicalDescendants().OfType<Button>().First(b => b.Flyout != null);
 
-                    Assert.False(historyButton.IsVisible);
+            Assert.False(historyButton.IsVisible);
 
-                    // First search lands in history -> button appears.
-                    vm.SearchHistory.Add("foo");
-                    Assert.True(historyButton.IsVisible);
+            // First search lands in history -> button appears.
+            vm.SearchHistory.Add("foo");
+            Assert.True(historyButton.IsVisible);
         }
         finally
         {

--- a/tests/UI/Features/Edit/Find/FindWindowHistoryTests.cs
+++ b/tests/UI/Features/Edit/Find/FindWindowHistoryTests.cs
@@ -5,6 +5,7 @@ using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using Avalonia.LogicalTree;
+using Avalonia.Threading;
 using Nikse.SubtitleEdit.Features.Edit.Find;
 
 namespace UITests.Features.Edit.Find;
@@ -24,6 +25,10 @@ public class FindWindowHistoryTests
 
         var window = new FindWindow(vm);
         window.Show();
+        // Settle the window's Opened callbacks (UiUtil posts a working-area clamp at
+        // Background priority) while the window is alive, so closing it afterwards
+        // cannot hit the disposed platform implementation during session teardown.
+        Dispatcher.UIThread.RunJobs();
 
         var historyButton = window.GetLogicalDescendants().OfType<Button>().First(b => b.Flyout != null);
         return (window, historyButton);
@@ -32,9 +37,11 @@ public class FindWindowHistoryTests
     [AvaloniaFact]
     public void HistoryButton_IsVisible_WhenHistoryExists()
     {
-        var (_, historyButton) = BuildShownWindow();
+        var (window, historyButton) = BuildShownWindow();
 
         Assert.True(historyButton.IsVisible);
+
+        window.Close();
     }
 
     [AvaloniaFact]
@@ -43,6 +50,7 @@ public class FindWindowHistoryTests
         var vm = new FindViewModel();
         var window = new FindWindow(vm);
         window.Show();
+        Dispatcher.UIThread.RunJobs();
 
         var historyButton = window.GetLogicalDescendants().OfType<Button>().First(b => b.Flyout != null);
 
@@ -51,12 +59,14 @@ public class FindWindowHistoryTests
         // First search lands in history -> button appears.
         vm.SearchHistory.Add("foo");
         Assert.True(historyButton.IsVisible);
+
+        window.Close();
     }
 
     [AvaloniaFact]
     public void HistoryFlyout_HasItemsBeforeOpening_AndFollowsHistoryChanges()
     {
-        var (_, historyButton) = BuildShownWindow();
+        var (window, historyButton) = BuildShownWindow();
 
         var flyout = Assert.IsType<MenuFlyout>(historyButton.Flyout);
         Assert.Equal(2, flyout.Items.Count);
@@ -66,6 +76,8 @@ public class FindWindowHistoryTests
         vm.SearchHistory.Add("baz");
 
         Assert.Equal(3, flyout.Items.Count);
+
+        window.Close();
     }
 
     [AvaloniaFact]
@@ -84,5 +96,7 @@ public class FindWindowHistoryTests
         var flyout = Assert.IsType<MenuFlyout>(historyButton.Flyout);
         Assert.True(flyout.IsOpen, "history flyout should open on click");
         Assert.Equal(2, flyout.Items.Count);
+
+        window.Close();
     }
 }

--- a/tests/UI/Features/Edit/Find/FindWindowHistoryTests.cs
+++ b/tests/UI/Features/Edit/Find/FindWindowHistoryTests.cs
@@ -39,9 +39,14 @@ public class FindWindowHistoryTests
     {
         var (window, historyButton) = BuildShownWindow();
 
-        Assert.True(historyButton.IsVisible);
-
-        window.Close();
+        try
+        {
+            Assert.True(historyButton.IsVisible);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     [AvaloniaFact]
@@ -49,18 +54,23 @@ public class FindWindowHistoryTests
     {
         var vm = new FindViewModel();
         var window = new FindWindow(vm);
-        window.Show();
-        Dispatcher.UIThread.RunJobs();
+        try
+        {
+                    window.Show();
+                    Dispatcher.UIThread.RunJobs();
 
-        var historyButton = window.GetLogicalDescendants().OfType<Button>().First(b => b.Flyout != null);
+                    var historyButton = window.GetLogicalDescendants().OfType<Button>().First(b => b.Flyout != null);
 
-        Assert.False(historyButton.IsVisible);
+                    Assert.False(historyButton.IsVisible);
 
-        // First search lands in history -> button appears.
-        vm.SearchHistory.Add("foo");
-        Assert.True(historyButton.IsVisible);
-
-        window.Close();
+                    // First search lands in history -> button appears.
+                    vm.SearchHistory.Add("foo");
+                    Assert.True(historyButton.IsVisible);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     [AvaloniaFact]
@@ -68,16 +78,21 @@ public class FindWindowHistoryTests
     {
         var (window, historyButton) = BuildShownWindow();
 
-        var flyout = Assert.IsType<MenuFlyout>(historyButton.Flyout);
-        Assert.Equal(2, flyout.Items.Count);
+        try
+        {
+            var flyout = Assert.IsType<MenuFlyout>(historyButton.Flyout);
+            Assert.Equal(2, flyout.Items.Count);
 
-        // Simulate InitializeFindData refreshing the history after window construction.
-        var vm = (FindViewModel)historyButton.DataContext!;
-        vm.SearchHistory.Add("baz");
+            // Simulate InitializeFindData refreshing the history after window construction.
+            var vm = (FindViewModel)historyButton.DataContext!;
+            vm.SearchHistory.Add("baz");
 
-        Assert.Equal(3, flyout.Items.Count);
-
-        window.Close();
+            Assert.Equal(3, flyout.Items.Count);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     [AvaloniaFact]
@@ -88,15 +103,20 @@ public class FindWindowHistoryTests
         AvaloniaHeadlessPlatform.ForceRenderTimerTick();
         Avalonia.Threading.Dispatcher.UIThread.RunJobs();
 
-        var center = historyButton.TranslatePoint(
-            new Point(historyButton.Bounds.Width / 2, historyButton.Bounds.Height / 2), window)!.Value;
-        window.MouseDown(center, MouseButton.Left);
-        window.MouseUp(center, MouseButton.Left);
+        try
+        {
+            var center = historyButton.TranslatePoint(
+                new Point(historyButton.Bounds.Width / 2, historyButton.Bounds.Height / 2), window)!.Value;
+            window.MouseDown(center, MouseButton.Left);
+            window.MouseUp(center, MouseButton.Left);
 
-        var flyout = Assert.IsType<MenuFlyout>(historyButton.Flyout);
-        Assert.True(flyout.IsOpen, "history flyout should open on click");
-        Assert.Equal(2, flyout.Items.Count);
-
-        window.Close();
+            var flyout = Assert.IsType<MenuFlyout>(historyButton.Flyout);
+            Assert.True(flyout.IsOpen, "history flyout should open on click");
+            Assert.Equal(2, flyout.Items.Count);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 }

--- a/tests/UI/Features/Edit/ShowHistoryTableViewTests.cs
+++ b/tests/UI/Features/Edit/ShowHistoryTableViewTests.cs
@@ -122,13 +122,12 @@ public class ShowHistoryTableViewTests
         var window = ShowWindow(vm);
         try
         {
+            var tableView = GetTableView(window);
 
-                    var tableView = GetTableView(window);
-
-                    Assert.Equal(2, tableView.Columns.Count);
-                    Assert.Equal(GridUnitType.Auto, tableView.Columns[0].Width.GridUnitType);
-                    Assert.Equal(GridUnitType.Star, tableView.Columns[1].Width.GridUnitType);
-                    Assert.Equal(vm.HistoryItems, tableView.ItemsSource);
+            Assert.Equal(2, tableView.Columns.Count);
+            Assert.Equal(GridUnitType.Auto, tableView.Columns[0].Width.GridUnitType);
+            Assert.Equal(GridUnitType.Star, tableView.Columns[1].Width.GridUnitType);
+            Assert.Equal(vm.HistoryItems, tableView.ItemsSource);
         }
         finally
         {
@@ -143,15 +142,14 @@ public class ShowHistoryTableViewTests
         var window = ShowWindow(vm);
         try
         {
+            var tableView = GetTableView(window);
+            var rows = tableView.GetVisualDescendants().OfType<TableViewRow>().ToList();
+            Assert.Equal(3, rows.Count);
 
-                    var tableView = GetTableView(window);
-                    var rows = tableView.GetVisualDescendants().OfType<TableViewRow>().ToList();
-                    Assert.Equal(3, rows.Count);
-
-                    // Cell content must actually resolve through TableViewColumn.Binding.
-                    var texts = rows[0].GetVisualDescendants().OfType<TextBlock>().Select(t => t.Text).ToList();
-                    Assert.Contains("2026-07-21 10:00:00", texts);
-                    Assert.Contains("Change 0", texts);
+            // Cell content must actually resolve through TableViewColumn.Binding.
+            var texts = rows[0].GetVisualDescendants().OfType<TextBlock>().Select(t => t.Text).ToList();
+            Assert.Contains("2026-07-21 10:00:00", texts);
+            Assert.Contains("Change 0", texts);
         }
         finally
         {
@@ -166,14 +164,13 @@ public class ShowHistoryTableViewTests
         var window = ShowWindow(vm);
         try
         {
+            var tableView = GetTableView(window);
+            Assert.False(vm.IsRollbackEnabled);
 
-                    var tableView = GetTableView(window);
-                    Assert.False(vm.IsRollbackEnabled);
+            tableView.SelectedIndex = 1;
 
-                    tableView.SelectedIndex = 1;
-
-                    Assert.Same(vm.HistoryItems[1], vm.SelectedHistoryItem);
-                    Assert.True(vm.IsRollbackEnabled);
+            Assert.Same(vm.HistoryItems[1], vm.SelectedHistoryItem);
+            Assert.True(vm.IsRollbackEnabled);
         }
         finally
         {
@@ -299,11 +296,10 @@ public class ShowHistoryTableViewTests
         var window = ShowWindow(vm);
         try
         {
+            var tableView = GetTableView(window);
+            var realized = tableView.GetVisualDescendants().OfType<TableViewRow>().Count();
 
-                    var tableView = GetTableView(window);
-                    var realized = tableView.GetVisualDescendants().OfType<TableViewRow>().Count();
-
-                    Assert.InRange(realized, 1, 200);
+            Assert.InRange(realized, 1, 200);
         }
         finally
         {

--- a/tests/UI/Features/Edit/ShowHistoryTableViewTests.cs
+++ b/tests/UI/Features/Edit/ShowHistoryTableViewTests.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Controls.Presenters;
@@ -120,15 +120,20 @@ public class ShowHistoryTableViewTests
     {
         var vm = MakeViewModel(3);
         var window = ShowWindow(vm);
+        try
+        {
 
-        var tableView = GetTableView(window);
+                    var tableView = GetTableView(window);
 
-        Assert.Equal(2, tableView.Columns.Count);
-        Assert.Equal(GridUnitType.Auto, tableView.Columns[0].Width.GridUnitType);
-        Assert.Equal(GridUnitType.Star, tableView.Columns[1].Width.GridUnitType);
-        Assert.Equal(vm.HistoryItems, tableView.ItemsSource);
-
-        window.Close();
+                    Assert.Equal(2, tableView.Columns.Count);
+                    Assert.Equal(GridUnitType.Auto, tableView.Columns[0].Width.GridUnitType);
+                    Assert.Equal(GridUnitType.Star, tableView.Columns[1].Width.GridUnitType);
+                    Assert.Equal(vm.HistoryItems, tableView.ItemsSource);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     [AvaloniaFact]
@@ -136,17 +141,22 @@ public class ShowHistoryTableViewTests
     {
         var vm = MakeViewModel(3);
         var window = ShowWindow(vm);
+        try
+        {
 
-        var tableView = GetTableView(window);
-        var rows = tableView.GetVisualDescendants().OfType<TableViewRow>().ToList();
-        Assert.Equal(3, rows.Count);
+                    var tableView = GetTableView(window);
+                    var rows = tableView.GetVisualDescendants().OfType<TableViewRow>().ToList();
+                    Assert.Equal(3, rows.Count);
 
-        // Cell content must actually resolve through TableViewColumn.Binding.
-        var texts = rows[0].GetVisualDescendants().OfType<TextBlock>().Select(t => t.Text).ToList();
-        Assert.Contains("2026-07-21 10:00:00", texts);
-        Assert.Contains("Change 0", texts);
-
-        window.Close();
+                    // Cell content must actually resolve through TableViewColumn.Binding.
+                    var texts = rows[0].GetVisualDescendants().OfType<TextBlock>().Select(t => t.Text).ToList();
+                    Assert.Contains("2026-07-21 10:00:00", texts);
+                    Assert.Contains("Change 0", texts);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     [AvaloniaFact]
@@ -154,16 +164,21 @@ public class ShowHistoryTableViewTests
     {
         var vm = MakeViewModel(3);
         var window = ShowWindow(vm);
+        try
+        {
 
-        var tableView = GetTableView(window);
-        Assert.False(vm.IsRollbackEnabled);
+                    var tableView = GetTableView(window);
+                    Assert.False(vm.IsRollbackEnabled);
 
-        tableView.SelectedIndex = 1;
+                    tableView.SelectedIndex = 1;
 
-        Assert.Same(vm.HistoryItems[1], vm.SelectedHistoryItem);
-        Assert.True(vm.IsRollbackEnabled);
-
-        window.Close();
+                    Assert.Same(vm.HistoryItems[1], vm.SelectedHistoryItem);
+                    Assert.True(vm.IsRollbackEnabled);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     [AvaloniaTheory]
@@ -282,12 +297,17 @@ public class ShowHistoryTableViewTests
         // otherwise a long undo history would realize thousands of rows.
         var vm = MakeViewModel(2000);
         var window = ShowWindow(vm);
+        try
+        {
 
-        var tableView = GetTableView(window);
-        var realized = tableView.GetVisualDescendants().OfType<TableViewRow>().Count();
+                    var tableView = GetTableView(window);
+                    var realized = tableView.GetVisualDescendants().OfType<TableViewRow>().Count();
 
-        Assert.InRange(realized, 1, 200);
-
-        window.Close();
+                    Assert.InRange(realized, 1, 200);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 }

--- a/tests/UI/Features/Edit/ShowHistoryTableViewTests.cs
+++ b/tests/UI/Features/Edit/ShowHistoryTableViewTests.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Controls.Presenters;
@@ -59,11 +59,12 @@ public class ShowHistoryTableViewTests
         // dividers below it - and in a different colour, because the built-in header draws its
         // separator as a semi-transparent rectangle inside the resize thumb.
         var previous = Se.Settings.Appearance.GridLinesAppearance;
+        ShowHistoryWindow? window = null;
         try
         {
             Se.Settings.Appearance.GridLinesAppearance = "All";
 
-            var window = ShowWindow(MakeViewModel(3));
+            window = ShowWindow(MakeViewModel(3));
             var tableView = GetTableView(window);
 
             var headers = tableView.GetVisualDescendants().OfType<TableViewColumnHeader>().ToList();
@@ -83,6 +84,7 @@ public class ShowHistoryTableViewTests
         finally
         {
             Se.Settings.Appearance.GridLinesAppearance = previous;
+            window?.Close();
         }
     }
 
@@ -92,11 +94,12 @@ public class ShowHistoryTableViewTests
         // The cells only draw bottom borders, so without a header bottom line the first row had no
         // line above it - and the line has to sit exactly on the row's top edge, not float above it.
         var previous = Se.Settings.Appearance.GridLinesAppearance;
+        ShowHistoryWindow? window = null;
         try
         {
             Se.Settings.Appearance.GridLinesAppearance = "All";
 
-            var window = ShowWindow(MakeViewModel(3));
+            window = ShowWindow(MakeViewModel(3));
             var tableView = GetTableView(window);
 
             var header = tableView.GetVisualDescendants().OfType<TableViewColumnHeader>().First();
@@ -108,6 +111,7 @@ public class ShowHistoryTableViewTests
         finally
         {
             Se.Settings.Appearance.GridLinesAppearance = previous;
+            window?.Close();
         }
     }
 
@@ -123,6 +127,8 @@ public class ShowHistoryTableViewTests
         Assert.Equal(GridUnitType.Auto, tableView.Columns[0].Width.GridUnitType);
         Assert.Equal(GridUnitType.Star, tableView.Columns[1].Width.GridUnitType);
         Assert.Equal(vm.HistoryItems, tableView.ItemsSource);
+
+        window.Close();
     }
 
     [AvaloniaFact]
@@ -139,6 +145,8 @@ public class ShowHistoryTableViewTests
         var texts = rows[0].GetVisualDescendants().OfType<TextBlock>().Select(t => t.Text).ToList();
         Assert.Contains("2026-07-21 10:00:00", texts);
         Assert.Contains("Change 0", texts);
+
+        window.Close();
     }
 
     [AvaloniaFact]
@@ -154,6 +162,8 @@ public class ShowHistoryTableViewTests
 
         Assert.Same(vm.HistoryItems[1], vm.SelectedHistoryItem);
         Assert.True(vm.IsRollbackEnabled);
+
+        window.Close();
     }
 
     [AvaloniaTheory]
@@ -164,11 +174,12 @@ public class ShowHistoryTableViewTests
     public void ShowHistoryWindow_CellBordersFollowGridLinesSetting(string setting, double right, double bottom)
     {
         var previous = Se.Settings.Appearance.GridLinesAppearance;
+        ShowHistoryWindow? window = null;
         try
         {
             Se.Settings.Appearance.GridLinesAppearance = setting;
 
-            var window = ShowWindow(MakeViewModel(3));
+            window = ShowWindow(MakeViewModel(3));
 
             var cells = GetTableView(window).GetVisualDescendants().OfType<TableViewCell>().ToList();
             Assert.NotEmpty(cells);
@@ -183,6 +194,7 @@ public class ShowHistoryTableViewTests
         finally
         {
             Se.Settings.Appearance.GridLinesAppearance = previous;
+            window?.Close();
         }
     }
 
@@ -194,11 +206,12 @@ public class ShowHistoryTableViewTests
         // the border properties to the ContentPresenter (which paints the border in Avalonia).
         // Without that, grid lines are silently missing.
         var previous = Se.Settings.Appearance.GridLinesAppearance;
+        ShowHistoryWindow? window = null;
         try
         {
             Se.Settings.Appearance.GridLinesAppearance = "All";
 
-            var window = ShowWindow(MakeViewModel(3));
+            window = ShowWindow(MakeViewModel(3));
 
             var cell = GetTableView(window).GetVisualDescendants().OfType<TableViewCell>().First();
             var presenter = cell.GetVisualDescendants().OfType<ContentPresenter>().First();
@@ -210,6 +223,7 @@ public class ShowHistoryTableViewTests
         finally
         {
             Se.Settings.Appearance.GridLinesAppearance = previous;
+            window?.Close();
         }
     }
 
@@ -220,11 +234,12 @@ public class ShowHistoryTableViewTests
         // cells were 18px inside 39px rows, so the horizontal line floated above the row edge and
         // the vertical line was drawn as one short segment per row instead of a continuous column.
         var previous = Se.Settings.Appearance.GridLinesAppearance;
+        ShowHistoryWindow? window = null;
         try
         {
             Se.Settings.Appearance.GridLinesAppearance = "All";
 
-            var window = ShowWindow(MakeViewModel(4));
+            window = ShowWindow(MakeViewModel(4));
 
             var tableView = GetTableView(window);
             var rows = tableView.GetVisualDescendants().OfType<TableViewRow>().ToList();
@@ -256,6 +271,7 @@ public class ShowHistoryTableViewTests
         finally
         {
             Se.Settings.Appearance.GridLinesAppearance = previous;
+            window?.Close();
         }
     }
 
@@ -271,5 +287,7 @@ public class ShowHistoryTableViewTests
         var realized = tableView.GetVisualDescendants().OfType<TableViewRow>().Count();
 
         Assert.InRange(realized, 1, 200);
+
+        window.Close();
     }
 }

--- a/tests/UI/Features/LlamaCppEngineSettingsButtonTests.cs
+++ b/tests/UI/Features/LlamaCppEngineSettingsButtonTests.cs
@@ -50,6 +50,8 @@ public class LlamaCppEngineSettingsButtonTests
         Assert.NotNull(button);
         Assert.True(vm.IsLlamaCppVisible, "llama.cpp is the default engine, so its controls must be visible.");
         Assert.True(button!.IsVisible);
+
+        window.Close();
     }
 
     [AvaloniaFact]
@@ -63,6 +65,8 @@ public class LlamaCppEngineSettingsButtonTests
         Assert.NotNull(button);
         Assert.True(vm.IsLlamaCppVisible, "llama.cpp is the default engine, so its controls must be visible.");
         Assert.True(button!.IsVisible);
+
+        window.Close();
     }
 
     /// <summary>
@@ -94,6 +98,8 @@ public class LlamaCppEngineSettingsButtonTests
             .First(c => AutomationProperties.GetName(c) == Se.Language.General.Engine);
 
         Assert.NotNull(engineCombo.ItemTemplate);
+
+        window.Close();
     }
 
     [AvaloniaFact]
@@ -106,6 +112,8 @@ public class LlamaCppEngineSettingsButtonTests
             .First(c => AutomationProperties.GetName(c) == Se.Language.General.Engine);
 
         Assert.NotNull(engineCombo.ItemTemplate);
+
+        window.Close();
     }
 
     /// <summary>
@@ -120,6 +128,8 @@ public class LlamaCppEngineSettingsButtonTests
         var window = new AutoTranslateWindow(vm);
 
         Assert.NotNull(FindEngineSettingsButton(window));
+
+        window.Close();
     }
 
     /// <summary>
@@ -138,5 +148,7 @@ public class LlamaCppEngineSettingsButtonTests
         var button = FindEngineSettingsButton(window);
         Assert.NotNull(button);
         Assert.False(button!.IsEffectivelyVisible);
+
+        window.Close();
     }
 }

--- a/tests/UI/Features/LlamaCppEngineSettingsButtonTests.cs
+++ b/tests/UI/Features/LlamaCppEngineSettingsButtonTests.cs
@@ -44,14 +44,19 @@ public class LlamaCppEngineSettingsButtonTests
     {
         var vm = new AiReviewViewModel(new WindowService(new NullServiceProvider()));
         var window = new AiReviewWindow(vm);
+        try
+        {
 
-        var button = FindEngineSettingsButton(window);
+                    var button = FindEngineSettingsButton(window);
 
-        Assert.NotNull(button);
-        Assert.True(vm.IsLlamaCppVisible, "llama.cpp is the default engine, so its controls must be visible.");
-        Assert.True(button!.IsVisible);
-
-        window.Close();
+                    Assert.NotNull(button);
+                    Assert.True(vm.IsLlamaCppVisible, "llama.cpp is the default engine, so its controls must be visible.");
+                    Assert.True(button!.IsVisible);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     [AvaloniaFact]
@@ -59,14 +64,19 @@ public class LlamaCppEngineSettingsButtonTests
     {
         var vm = new AiAssistantViewModel(new WindowService(new NullServiceProvider()));
         var window = new AiAssistantWindow(vm);
+        try
+        {
 
-        var button = FindEngineSettingsButton(window);
+                    var button = FindEngineSettingsButton(window);
 
-        Assert.NotNull(button);
-        Assert.True(vm.IsLlamaCppVisible, "llama.cpp is the default engine, so its controls must be visible.");
-        Assert.True(button!.IsVisible);
-
-        window.Close();
+                    Assert.NotNull(button);
+                    Assert.True(vm.IsLlamaCppVisible, "llama.cpp is the default engine, so its controls must be visible.");
+                    Assert.True(button!.IsVisible);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     /// <summary>
@@ -93,13 +103,18 @@ public class LlamaCppEngineSettingsButtonTests
     {
         var vm = new AiReviewViewModel(new WindowService(new NullServiceProvider()));
         var window = new AiReviewWindow(vm);
+        try
+        {
 
-        var engineCombo = window.GetLogicalDescendants().OfType<ComboBox>()
-            .First(c => AutomationProperties.GetName(c) == Se.Language.General.Engine);
+                    var engineCombo = window.GetLogicalDescendants().OfType<ComboBox>()
+                        .First(c => AutomationProperties.GetName(c) == Se.Language.General.Engine);
 
-        Assert.NotNull(engineCombo.ItemTemplate);
-
-        window.Close();
+                    Assert.NotNull(engineCombo.ItemTemplate);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     [AvaloniaFact]
@@ -107,13 +122,18 @@ public class LlamaCppEngineSettingsButtonTests
     {
         var vm = new AiAssistantViewModel(new WindowService(new NullServiceProvider()));
         var window = new AiAssistantWindow(vm);
+        try
+        {
 
-        var engineCombo = window.GetLogicalDescendants().OfType<ComboBox>()
-            .First(c => AutomationProperties.GetName(c) == Se.Language.General.Engine);
+                    var engineCombo = window.GetLogicalDescendants().OfType<ComboBox>()
+                        .First(c => AutomationProperties.GetName(c) == Se.Language.General.Engine);
 
-        Assert.NotNull(engineCombo.ItemTemplate);
-
-        window.Close();
+                    Assert.NotNull(engineCombo.ItemTemplate);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     /// <summary>
@@ -126,10 +146,15 @@ public class LlamaCppEngineSettingsButtonTests
     {
         var vm = new AutoTranslateViewModel(new WindowService(new NullServiceProvider()), new FolderHelper());
         var window = new AutoTranslateWindow(vm);
+        try
+        {
 
-        Assert.NotNull(FindEngineSettingsButton(window));
-
-        window.Close();
+                    Assert.NotNull(FindEngineSettingsButton(window));
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     /// <summary>
@@ -141,14 +166,19 @@ public class LlamaCppEngineSettingsButtonTests
     {
         var vm = new AiReviewViewModel(new WindowService(new NullServiceProvider()));
         var window = new AiReviewWindow(vm);
+        try
+        {
 
-        vm.SelectedEngine = SeAiReview.EngineOllama;
+                    vm.SelectedEngine = SeAiReview.EngineOllama;
 
-        Assert.False(vm.IsLlamaCppVisible);
-        var button = FindEngineSettingsButton(window);
-        Assert.NotNull(button);
-        Assert.False(button!.IsEffectivelyVisible);
-
-        window.Close();
+                    Assert.False(vm.IsLlamaCppVisible);
+                    var button = FindEngineSettingsButton(window);
+                    Assert.NotNull(button);
+                    Assert.False(button!.IsEffectivelyVisible);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 }

--- a/tests/UI/Features/LlamaCppEngineSettingsButtonTests.cs
+++ b/tests/UI/Features/LlamaCppEngineSettingsButtonTests.cs
@@ -46,12 +46,11 @@ public class LlamaCppEngineSettingsButtonTests
         var window = new AiReviewWindow(vm);
         try
         {
+            var button = FindEngineSettingsButton(window);
 
-                    var button = FindEngineSettingsButton(window);
-
-                    Assert.NotNull(button);
-                    Assert.True(vm.IsLlamaCppVisible, "llama.cpp is the default engine, so its controls must be visible.");
-                    Assert.True(button!.IsVisible);
+            Assert.NotNull(button);
+            Assert.True(vm.IsLlamaCppVisible, "llama.cpp is the default engine, so its controls must be visible.");
+            Assert.True(button!.IsVisible);
         }
         finally
         {
@@ -66,12 +65,11 @@ public class LlamaCppEngineSettingsButtonTests
         var window = new AiAssistantWindow(vm);
         try
         {
+            var button = FindEngineSettingsButton(window);
 
-                    var button = FindEngineSettingsButton(window);
-
-                    Assert.NotNull(button);
-                    Assert.True(vm.IsLlamaCppVisible, "llama.cpp is the default engine, so its controls must be visible.");
-                    Assert.True(button!.IsVisible);
+            Assert.NotNull(button);
+            Assert.True(vm.IsLlamaCppVisible, "llama.cpp is the default engine, so its controls must be visible.");
+            Assert.True(button!.IsVisible);
         }
         finally
         {
@@ -105,11 +103,10 @@ public class LlamaCppEngineSettingsButtonTests
         var window = new AiReviewWindow(vm);
         try
         {
+            var engineCombo = window.GetLogicalDescendants().OfType<ComboBox>()
+                .First(c => AutomationProperties.GetName(c) == Se.Language.General.Engine);
 
-                    var engineCombo = window.GetLogicalDescendants().OfType<ComboBox>()
-                        .First(c => AutomationProperties.GetName(c) == Se.Language.General.Engine);
-
-                    Assert.NotNull(engineCombo.ItemTemplate);
+            Assert.NotNull(engineCombo.ItemTemplate);
         }
         finally
         {
@@ -124,11 +121,10 @@ public class LlamaCppEngineSettingsButtonTests
         var window = new AiAssistantWindow(vm);
         try
         {
+            var engineCombo = window.GetLogicalDescendants().OfType<ComboBox>()
+                .First(c => AutomationProperties.GetName(c) == Se.Language.General.Engine);
 
-                    var engineCombo = window.GetLogicalDescendants().OfType<ComboBox>()
-                        .First(c => AutomationProperties.GetName(c) == Se.Language.General.Engine);
-
-                    Assert.NotNull(engineCombo.ItemTemplate);
+            Assert.NotNull(engineCombo.ItemTemplate);
         }
         finally
         {
@@ -148,8 +144,7 @@ public class LlamaCppEngineSettingsButtonTests
         var window = new AutoTranslateWindow(vm);
         try
         {
-
-                    Assert.NotNull(FindEngineSettingsButton(window));
+            Assert.NotNull(FindEngineSettingsButton(window));
         }
         finally
         {
@@ -168,13 +163,12 @@ public class LlamaCppEngineSettingsButtonTests
         var window = new AiReviewWindow(vm);
         try
         {
+            vm.SelectedEngine = SeAiReview.EngineOllama;
 
-                    vm.SelectedEngine = SeAiReview.EngineOllama;
-
-                    Assert.False(vm.IsLlamaCppVisible);
-                    var button = FindEngineSettingsButton(window);
-                    Assert.NotNull(button);
-                    Assert.False(button!.IsEffectivelyVisible);
+            Assert.False(vm.IsLlamaCppVisible);
+            var button = FindEngineSettingsButton(window);
+            Assert.NotNull(button);
+            Assert.False(button!.IsEffectivelyVisible);
         }
         finally
         {

--- a/tests/UI/Features/Shared/PickTrackWindowSelectionTests.cs
+++ b/tests/UI/Features/Shared/PickTrackWindowSelectionTests.cs
@@ -54,15 +54,20 @@ public class PickTrackWindowSelectionTests
     {
         var vm = MakeMatroskaViewModel(2);
         var window = new PickMatroskaTrackWindow(vm);
-        window.Show();
-        Dispatcher.UIThread.RunJobs();
-        window.UpdateLayout();
-        Dispatcher.UIThread.RunJobs();
+        try
+        {
+                    window.Show();
+                    Dispatcher.UIThread.RunJobs();
+                    window.UpdateLayout();
+                    Dispatcher.UIThread.RunJobs();
 
-        Assert.Same(vm.Tracks[0], vm.SelectedTrack);
-        Assert.Equal(0, vm.TracksGrid.SelectedIndex);
-
-        window.Close();
+                    Assert.Same(vm.Tracks[0], vm.SelectedTrack);
+                    Assert.Equal(0, vm.TracksGrid.SelectedIndex);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     [AvaloniaFact]
@@ -70,19 +75,24 @@ public class PickTrackWindowSelectionTests
     {
         var vm = MakeMatroskaViewModel(2);
         var window = new PickMatroskaTrackWindow(vm);
-        window.Show();
-        Dispatcher.UIThread.RunJobs();
-        window.UpdateLayout();
-        Dispatcher.UIThread.RunJobs();
+        try
+        {
+                    window.Show();
+                    Dispatcher.UIThread.RunJobs();
+                    window.UpdateLayout();
+                    Dispatcher.UIThread.RunJobs();
 
-        vm.OkCommand.Execute(null);
-        Dispatcher.UIThread.RunJobs();
+                    vm.OkCommand.Execute(null);
+                    Dispatcher.UIThread.RunJobs();
 
-        Assert.True(vm.OkPressed);
-        Assert.NotNull(vm.SelectedMatroskaTrack);
-        Assert.Equal(1, vm.SelectedMatroskaTrack!.TrackNumber);
-
-        window.Close();
+                    Assert.True(vm.OkPressed);
+                    Assert.NotNull(vm.SelectedMatroskaTrack);
+                    Assert.Equal(1, vm.SelectedMatroskaTrack!.TrackNumber);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     private static PickMp4TrackViewModel MakeMp4ViewModel(int trackCount)
@@ -107,15 +117,20 @@ public class PickTrackWindowSelectionTests
     {
         var vm = MakeMp4ViewModel(2);
         var window = new PickMp4TrackWindow(vm);
-        window.Show();
-        Dispatcher.UIThread.RunJobs();
-        window.UpdateLayout();
-        Dispatcher.UIThread.RunJobs();
+        try
+        {
+                    window.Show();
+                    Dispatcher.UIThread.RunJobs();
+                    window.UpdateLayout();
+                    Dispatcher.UIThread.RunJobs();
 
-        Assert.Same(vm.Tracks[0], vm.SelectedTrack);
-        Assert.Equal(0, vm.TracksGrid.SelectedIndex);
-
-        window.Close();
+                    Assert.Same(vm.Tracks[0], vm.SelectedTrack);
+                    Assert.Equal(0, vm.TracksGrid.SelectedIndex);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     [AvaloniaFact]
@@ -123,18 +138,23 @@ public class PickTrackWindowSelectionTests
     {
         var vm = MakeMp4ViewModel(2);
         var window = new PickMp4TrackWindow(vm);
-        window.Show();
-        Dispatcher.UIThread.RunJobs();
-        window.UpdateLayout();
-        Dispatcher.UIThread.RunJobs();
+        try
+        {
+                    window.Show();
+                    Dispatcher.UIThread.RunJobs();
+                    window.UpdateLayout();
+                    Dispatcher.UIThread.RunJobs();
 
-        vm.OkCommand.Execute(null);
-        Dispatcher.UIThread.RunJobs();
+                    vm.OkCommand.Execute(null);
+                    Dispatcher.UIThread.RunJobs();
 
-        Assert.True(vm.OkPressed);
-        Assert.Same(vm.Tracks[0], vm.SelectedMatroskaTrack);
-
-        window.Close();
+                    Assert.True(vm.OkPressed);
+                    Assert.Same(vm.Tracks[0], vm.SelectedMatroskaTrack);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     private static PickTsTrackViewModel MakeTsViewModel(int trackCount)
@@ -165,15 +185,20 @@ public class PickTrackWindowSelectionTests
     {
         var vm = MakeTsViewModel(2);
         var window = new PickTsTrackWindow(vm);
-        window.Show();
-        Dispatcher.UIThread.RunJobs();
-        window.UpdateLayout();
-        Dispatcher.UIThread.RunJobs();
+        try
+        {
+                    window.Show();
+                    Dispatcher.UIThread.RunJobs();
+                    window.UpdateLayout();
+                    Dispatcher.UIThread.RunJobs();
 
-        Assert.Same(vm.Tracks[0], vm.SelectedTrack);
-        Assert.Equal(0, vm.TracksGrid.SelectedIndex);
-
-        window.Close();
+                    Assert.Same(vm.Tracks[0], vm.SelectedTrack);
+                    Assert.Equal(0, vm.TracksGrid.SelectedIndex);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     [AvaloniaFact]
@@ -181,11 +206,16 @@ public class PickTrackWindowSelectionTests
     {
         var vm = MakeTsViewModel(2);
         var window = new PickTsTrackWindow(vm);
+        try
+        {
 
-        // The view model left WindowTitle empty, so the window opened with no title at all.
-        Assert.Contains("movie.ts", window.Title);
-
-        window.Close();
+                    // The view model left WindowTitle empty, so the window opened with no title at all.
+                    Assert.Contains("movie.ts", window.Title);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     private static PickVobSubLanguageViewModel MakeVobSubViewModel(int languageCount)
@@ -211,15 +241,20 @@ public class PickTrackWindowSelectionTests
     {
         var vm = MakeVobSubViewModel(2);
         var window = new PickVobSubLanguageWindow(vm);
-        window.Show();
-        Dispatcher.UIThread.RunJobs();
-        window.UpdateLayout();
-        Dispatcher.UIThread.RunJobs();
+        try
+        {
+                    window.Show();
+                    Dispatcher.UIThread.RunJobs();
+                    window.UpdateLayout();
+                    Dispatcher.UIThread.RunJobs();
 
-        Assert.Same(vm.Languages[0], vm.SelectedLanguage);
-        Assert.Equal(0, vm.LanguagesGrid.SelectedIndex);
-
-        window.Close();
+                    Assert.Same(vm.Languages[0], vm.SelectedLanguage);
+                    Assert.Equal(0, vm.LanguagesGrid.SelectedIndex);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     [AvaloniaFact]
@@ -227,17 +262,22 @@ public class PickTrackWindowSelectionTests
     {
         var vm = MakeVobSubViewModel(2);
         var window = new PickVobSubLanguageWindow(vm);
-        window.Show();
-        Dispatcher.UIThread.RunJobs();
-        window.UpdateLayout();
-        Dispatcher.UIThread.RunJobs();
+        try
+        {
+                    window.Show();
+                    Dispatcher.UIThread.RunJobs();
+                    window.UpdateLayout();
+                    Dispatcher.UIThread.RunJobs();
 
-        vm.OkCommand.Execute(null);
-        Dispatcher.UIThread.RunJobs();
+                    vm.OkCommand.Execute(null);
+                    Dispatcher.UIThread.RunJobs();
 
-        Assert.True(vm.OkPressed);
-        Assert.Equal(0x20, vm.SelectedStreamId);
-
-        window.Close();
+                    Assert.True(vm.OkPressed);
+                    Assert.Equal(0x20, vm.SelectedStreamId);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 }

--- a/tests/UI/Features/Shared/PickTrackWindowSelectionTests.cs
+++ b/tests/UI/Features/Shared/PickTrackWindowSelectionTests.cs
@@ -81,6 +81,8 @@ public class PickTrackWindowSelectionTests
         Assert.True(vm.OkPressed);
         Assert.NotNull(vm.SelectedMatroskaTrack);
         Assert.Equal(1, vm.SelectedMatroskaTrack!.TrackNumber);
+
+        window.Close();
     }
 
     private static PickMp4TrackViewModel MakeMp4ViewModel(int trackCount)

--- a/tests/UI/Features/Shared/PickTrackWindowSelectionTests.cs
+++ b/tests/UI/Features/Shared/PickTrackWindowSelectionTests.cs
@@ -131,6 +131,8 @@ public class PickTrackWindowSelectionTests
 
         Assert.True(vm.OkPressed);
         Assert.Same(vm.Tracks[0], vm.SelectedMatroskaTrack);
+
+        window.Close();
     }
 
     private static PickTsTrackViewModel MakeTsViewModel(int trackCount)
@@ -180,6 +182,8 @@ public class PickTrackWindowSelectionTests
 
         // The view model left WindowTitle empty, so the window opened with no title at all.
         Assert.Contains("movie.ts", window.Title);
+
+        window.Close();
     }
 
     private static PickVobSubLanguageViewModel MakeVobSubViewModel(int languageCount)
@@ -231,5 +235,7 @@ public class PickTrackWindowSelectionTests
 
         Assert.True(vm.OkPressed);
         Assert.Equal(0x20, vm.SelectedStreamId);
+
+        window.Close();
     }
 }

--- a/tests/UI/Features/Shared/PickTrackWindowSelectionTests.cs
+++ b/tests/UI/Features/Shared/PickTrackWindowSelectionTests.cs
@@ -56,13 +56,13 @@ public class PickTrackWindowSelectionTests
         var window = new PickMatroskaTrackWindow(vm);
         try
         {
-                    window.Show();
-                    Dispatcher.UIThread.RunJobs();
-                    window.UpdateLayout();
-                    Dispatcher.UIThread.RunJobs();
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
 
-                    Assert.Same(vm.Tracks[0], vm.SelectedTrack);
-                    Assert.Equal(0, vm.TracksGrid.SelectedIndex);
+            Assert.Same(vm.Tracks[0], vm.SelectedTrack);
+            Assert.Equal(0, vm.TracksGrid.SelectedIndex);
         }
         finally
         {
@@ -77,17 +77,17 @@ public class PickTrackWindowSelectionTests
         var window = new PickMatroskaTrackWindow(vm);
         try
         {
-                    window.Show();
-                    Dispatcher.UIThread.RunJobs();
-                    window.UpdateLayout();
-                    Dispatcher.UIThread.RunJobs();
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
 
-                    vm.OkCommand.Execute(null);
-                    Dispatcher.UIThread.RunJobs();
+            vm.OkCommand.Execute(null);
+            Dispatcher.UIThread.RunJobs();
 
-                    Assert.True(vm.OkPressed);
-                    Assert.NotNull(vm.SelectedMatroskaTrack);
-                    Assert.Equal(1, vm.SelectedMatroskaTrack!.TrackNumber);
+            Assert.True(vm.OkPressed);
+            Assert.NotNull(vm.SelectedMatroskaTrack);
+            Assert.Equal(1, vm.SelectedMatroskaTrack!.TrackNumber);
         }
         finally
         {
@@ -119,13 +119,13 @@ public class PickTrackWindowSelectionTests
         var window = new PickMp4TrackWindow(vm);
         try
         {
-                    window.Show();
-                    Dispatcher.UIThread.RunJobs();
-                    window.UpdateLayout();
-                    Dispatcher.UIThread.RunJobs();
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
 
-                    Assert.Same(vm.Tracks[0], vm.SelectedTrack);
-                    Assert.Equal(0, vm.TracksGrid.SelectedIndex);
+            Assert.Same(vm.Tracks[0], vm.SelectedTrack);
+            Assert.Equal(0, vm.TracksGrid.SelectedIndex);
         }
         finally
         {
@@ -140,16 +140,16 @@ public class PickTrackWindowSelectionTests
         var window = new PickMp4TrackWindow(vm);
         try
         {
-                    window.Show();
-                    Dispatcher.UIThread.RunJobs();
-                    window.UpdateLayout();
-                    Dispatcher.UIThread.RunJobs();
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
 
-                    vm.OkCommand.Execute(null);
-                    Dispatcher.UIThread.RunJobs();
+            vm.OkCommand.Execute(null);
+            Dispatcher.UIThread.RunJobs();
 
-                    Assert.True(vm.OkPressed);
-                    Assert.Same(vm.Tracks[0], vm.SelectedMatroskaTrack);
+            Assert.True(vm.OkPressed);
+            Assert.Same(vm.Tracks[0], vm.SelectedMatroskaTrack);
         }
         finally
         {
@@ -187,13 +187,13 @@ public class PickTrackWindowSelectionTests
         var window = new PickTsTrackWindow(vm);
         try
         {
-                    window.Show();
-                    Dispatcher.UIThread.RunJobs();
-                    window.UpdateLayout();
-                    Dispatcher.UIThread.RunJobs();
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
 
-                    Assert.Same(vm.Tracks[0], vm.SelectedTrack);
-                    Assert.Equal(0, vm.TracksGrid.SelectedIndex);
+            Assert.Same(vm.Tracks[0], vm.SelectedTrack);
+            Assert.Equal(0, vm.TracksGrid.SelectedIndex);
         }
         finally
         {
@@ -208,9 +208,8 @@ public class PickTrackWindowSelectionTests
         var window = new PickTsTrackWindow(vm);
         try
         {
-
-                    // The view model left WindowTitle empty, so the window opened with no title at all.
-                    Assert.Contains("movie.ts", window.Title);
+            // The view model left WindowTitle empty, so the window opened with no title at all.
+            Assert.Contains("movie.ts", window.Title);
         }
         finally
         {
@@ -243,13 +242,13 @@ public class PickTrackWindowSelectionTests
         var window = new PickVobSubLanguageWindow(vm);
         try
         {
-                    window.Show();
-                    Dispatcher.UIThread.RunJobs();
-                    window.UpdateLayout();
-                    Dispatcher.UIThread.RunJobs();
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
 
-                    Assert.Same(vm.Languages[0], vm.SelectedLanguage);
-                    Assert.Equal(0, vm.LanguagesGrid.SelectedIndex);
+            Assert.Same(vm.Languages[0], vm.SelectedLanguage);
+            Assert.Equal(0, vm.LanguagesGrid.SelectedIndex);
         }
         finally
         {
@@ -264,16 +263,16 @@ public class PickTrackWindowSelectionTests
         var window = new PickVobSubLanguageWindow(vm);
         try
         {
-                    window.Show();
-                    Dispatcher.UIThread.RunJobs();
-                    window.UpdateLayout();
-                    Dispatcher.UIThread.RunJobs();
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
 
-                    vm.OkCommand.Execute(null);
-                    Dispatcher.UIThread.RunJobs();
+            vm.OkCommand.Execute(null);
+            Dispatcher.UIThread.RunJobs();
 
-                    Assert.True(vm.OkPressed);
-                    Assert.Equal(0x20, vm.SelectedStreamId);
+            Assert.True(vm.OkPressed);
+            Assert.Equal(0x20, vm.SelectedStreamId);
         }
         finally
         {


### PR DESCRIPTION
## Problem

The UITests suite intermittently fails with `[Test Case Cleanup Failure] System.InvalidOperationException: The calling thread cannot access this object because a different thread owns it` at `ServerCompositor..ctor` <- `AvaloniaHeadlessPlatform.Initialize` <- `HeadlessUnitTestSession.EnsureIsolatedApplication` (a different test is hit on every run). 

Root cause: several tests create `Window` objects (some of them even `Show()` them) and never close them. The leaked windows keep the per-test isolated headless application alive, so the next test's session cannot cleanly reset the static `Dispatcher`/compositor state and its compositor initialization collides with the previous session's thread.

A second, related mechanism: `UiUtil.InitializeWindow` posts a `ClampToWorkingArea` callback at Background priority from the window's `Opened` event. Tests that `Show()` a window and close it without `Dispatcher.UIThread.RunJobs()` in between leave that posted callback to run during session teardown - on the already-disposed window platform implementation (`ObjectDisposedException: Window platform implementation was already disposed`, reproduced deterministically after adding `Close()` to the Find window tests).

## Fix

- Every test that constructs a window now closes it: FindWindowHistoryTests (4), ShowHistoryTableViewTests (9), LlamaCppEngineSettingsButtonTests (6), PickTrackWindowSelectionTests (3).
- Tests that show a window now run `Dispatcher.UIThread.RunJobs()` after `Show()` so the posted working-area clamp executes while the window is alive.
- `ShowHistoryTableViewTests`: window is now declared before the try/finally and closed in the finally (`window?.Close()`), so windows are released even when an assertion fails.

## Verification

- `dotnet build tests/UI/UITests.csproj` - 0 errors.
- Full UITests suite run 10x locally on the rebased branch: 8x clean (1238 passed / 0 failed); the 2 remaining failures were unrelated flakes (one timing-sensitive `SubtitleGridScrollPerformanceTests` assertion - a known upstream flake, last commit on that file is "Fix two flaky UI tests" - passes in isolation; one uncharacterized run). Before the fix, the window-leak cleanup failures reproduced regularly (observed on multiple PRs in CI).
- The `ObjectDisposedException` mechanism was reproduced deterministically mid-fix and is gone after the `RunJobs` change.

## Notes

The remaining `SubtitleGridScrollPerformanceTests` timing flake is out of scope for this PR (pre-existing, unrelated to window leaks).