### PR TITLE
Localize 'CUDA runtime' in llama.cpp download titles

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -121,6 +121,7 @@
     "couldNotOpenFileXErrorY": "Could not open file \"{0}\". Error: {1}",
     "count": "Count",
     "cps": "Chars/sec",
+    "cudaRuntime": "CUDA runtime",
     "currentVideoPosition": "Current video position",
     "custom": "Custom",
     "cut": "Cut",

--- a/src/ui/Features/Translate/DownloadLlamaCppViewModel.cs
+++ b/src/ui/Features/Translate/DownloadLlamaCppViewModel.cs
@@ -91,7 +91,7 @@ public partial class DownloadLlamaCppViewModel : ObservableObject
 
                 if (LlamaCppDownloadService.VariantNeedsCudaRuntime(Variant))
                 {
-                    TitleText = string.Format(Se.Language.General.DownloadingX, "CUDA runtime");
+                    TitleText = string.Format(Se.Language.General.DownloadingX, Se.Language.General.CudaRuntime);
                     using var cudartStream = new MemoryStream();
                     await _downloadService.DownloadCudaRuntime(cudartStream, Variant, MakeProgress(), token);
                     if (token.IsCancellationRequested)
@@ -100,7 +100,7 @@ public partial class DownloadLlamaCppViewModel : ObservableObject
                         return;
                     }
 
-                    TitleText = string.Format(Se.Language.General.UnpackingX, "CUDA runtime");
+                    TitleText = string.Format(Se.Language.General.UnpackingX, Se.Language.General.CudaRuntime);
                     cudartStream.Position = 0;
                     _zipUnpacker.UnpackZipStream(cudartStream, folder, string.Empty, true, new List<string>(), null);
                 }

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -121,6 +121,7 @@ public class LanguageGeneral
     public string CouldNotOpenFileXErrorY { get; set; }
     public string Count { get; set; }
     public string Cps { get; set; }
+    public string CudaRuntime { get; set; }
     public string CurrentVideoPosition { get; set; }
     public string Custom { get; set; }
     public string Cut { get; set; }
@@ -858,6 +859,7 @@ public class LanguageGeneral
         CouldNotOpenFileXErrorY = "Could not open file \"{0}\". Error: {1}";
         Count = "Count";
         Cps = "Chars/sec";
+        CudaRuntime = "CUDA runtime";
         CurrentVideoPosition = "Current video position";
         Custom = "Custom";
         Cut = "Cut";


### PR DESCRIPTION
## Problem

Follow-up to the Notes in #13152: the llama.cpp CUDA runtime download window shows `Downloading CUDA runtime` / `Unpacking CUDA runtime` where "CUDA runtime" is a hardcoded English argument to the localized `DownloadingX` / `UnpackingX` format strings (DownloadLlamaCppViewModel.cs:94,103) - so it stays English in every UI language.

## Fix

- New `LanguageGeneral.CudaRuntime` key ("CUDA runtime") + English.json entry, used as the format-string argument in both call sites, so translators can localize it (e.g. "CUDA-Laufzeitumgebung").

## Verification

- dotnet build src/ui/UI.csproj - 0 errors, 0 warnings
- English.json validated

## Notes

The other strings noted in #13152 were reviewed and left unchanged deliberately: dictionary language names are lookup data; "Dictionary download failed: {url}" is an internal exception message that never reaches the UI (the view model shows the localized generic "Download failed" instead); "Error downloading llama.cpp" is a log message; the SHA-256 integrity-check exception in LlamaCppDownloadService is diagnostic text, not UI.