### PR TITLE
TTS: add output language to CosyVoice3 + Qwen3 (CrispASR) for cross-lingual cloning

### DIFF
--- a/src/ui/Features/Ocr/Download/DownloadTesseractModelWindow.cs
+++ b/src/ui/Features/Ocr/Download/DownloadTesseractModelWindow.cs
@@ -9,7 +9,6 @@ using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.ValueConverters;
-using Nikse.SubtitleEdit.Logic.Config;
 
 namespace Nikse.SubtitleEdit.Features.Ocr.Download;
 

--- a/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsViewModel.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -50,6 +52,19 @@ public partial class CosyVoice3CrispAsrSettingsViewModel : ObservableObject
         Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrSpeed = Math.Clamp(value, 0.25, 4.0);
     }
 
+    // Language spoken in imported reference WAVs, sent as the request's `source_lang` field so
+    // cross-lingual cloning engages even when the server cannot detect the reference language
+    // itself (its detection only answers for non-Latin scripts). "Auto" (empty code) sends no
+    // field. Applies to imported WAV clones only — baked presets carry their own bank language.
+    public ObservableCollection<TtsLanguage> SourceLanguages { get; } = new(CosyVoice3Languages.All);
+
+    [ObservableProperty] private TtsLanguage? _selectedSourceLanguage;
+
+    partial void OnSelectedSourceLanguageChanged(TtsLanguage? value)
+    {
+        Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrSourceLanguage = value?.Code ?? string.Empty;
+    }
+
     [ObservableProperty] private string _modelsFolder = string.Empty;
     [ObservableProperty] private string _voicesFolder = string.Empty;
     [ObservableProperty] private bool _isEngineInstalled;
@@ -68,6 +83,10 @@ public partial class CosyVoice3CrispAsrSettingsViewModel : ObservableObject
         ModelsFolder = CosyVoice3CrispAsr.GetSetModelsFolder();
         VoicesFolder = CosyVoice3CrispAsr.GetSetVoicesFolder();
         Speed = Math.Clamp(Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrSpeed, 0.25, 4.0);
+        var savedSourceLanguage = Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrSourceLanguage;
+        SelectedSourceLanguage =
+            SourceLanguages.FirstOrDefault(l => l.Code == savedSourceLanguage && !string.IsNullOrEmpty(l.Code))
+            ?? SourceLanguages.FirstOrDefault();
         PresetsLabel = $"{CosyVoice3CrispAsr.Presets.Length} baked presets (zero-shot + FLEURS en/de/zh/ja/fr/es/ko)";
         Refresh();
     }

--- a/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsWindow.cs
@@ -105,6 +105,7 @@ public class CosyVoice3CrispAsrSettingsWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnSpacing = 12,
             RowSpacing = 10,
@@ -146,7 +147,26 @@ public class CosyVoice3CrispAsrSettingsWindow : Window
         grid.Add(MakeLabel(Se.Language.General.Speed), 5, 0);
         grid.Add(MakeSpeedPanel(), 5, 1);
 
-        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 6, 0);
+        // Language spoken in imported reference WAVs — sent as `source_lang` so cross-lingual
+        // cloning engages when the target language differs (the server cannot detect the
+        // reference language itself for Latin scripts). Presets carry their own bank language.
+        grid.Add(MakeLabel("Reference language"), 6, 0);
+        var sourceLanguageCombo = UiUtil.MakeComboBox(vm.SourceLanguages, vm, nameof(vm.SelectedSourceLanguage));
+        var sourceLanguageHint = new TextBlock
+        {
+            Text = "Language spoken in imported reference WAVs (for cross-lingual cloning)",
+            FontSize = 12,
+            Opacity = 0.75,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(8, 0, 0, 0),
+        };
+        grid.Add(new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { sourceLanguageCombo, sourceLanguageHint },
+        }, 6, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 7, 0);
         var folderText = new TextBox
         {
             IsReadOnly = true,
@@ -158,7 +178,7 @@ public class CosyVoice3CrispAsrSettingsWindow : Window
             FontSize = 12,
             [!TextBox.TextProperty] = new Binding(nameof(vm.ModelsFolder)),
         };
-        grid.Add(folderText, 6, 1);
+        grid.Add(folderText, 7, 1);
 
         return new Border
         {

--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
@@ -56,7 +56,7 @@ public class CosyVoice3CrispAsr : ITtsEngine
 {
     public string Name => "CosyVoice3 (CrispASR)";
     public string Description => "Alibaba CosyVoice3 0.5B with 9 languages + 18 zh dialects, via CrispASR";
-    public bool HasLanguageParameter => false;
+    public bool HasLanguageParameter => true;
     public bool HasApiKey => false;
     public bool HasRegion => false;
     public bool HasModel => true;
@@ -437,7 +437,7 @@ public class CosyVoice3CrispAsr : ITtsEngine
 
     public Task<string[]> GetModels() => Task.FromResult(new[] { ModelKeyQ4K, ModelKeyF16 });
 
-    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(Array.Empty<TtsLanguage>());
+    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(CosyVoice3Languages.All);
 
     public Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken) =>
         GetVoices(language);
@@ -506,9 +506,26 @@ public class CosyVoice3CrispAsr : ITtsEngine
             CrispAsrTtsProvenance.AddSpeechAttestations(payload);
         }
 
+        // Target language for cross-lingual synthesis (#13110): the backend compares it to the
+        // reference voice's language and drops the reference transcript from the prompt when they
+        // differ, so the clone speaks the target language instead of imitating the reference's.
+        // Auto (empty) sends no field and keeps plain zero-shot. Baked presets carry their own
+        // bank language; for imported WAVs the reference language comes from the settings-window
+        // pick (source_lang) since the server's own detection is unreliable for Latin scripts.
+        var languageArg = CosyVoice3Languages.ResolveLanguageArg(language);
+        if (!string.IsNullOrEmpty(languageArg))
+        {
+            payload["language"] = languageArg;
+        }
+        var sourceLanguage = (Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrSourceLanguage ?? string.Empty).Trim();
+        if (isClone && !string.IsNullOrEmpty(sourceLanguage))
+        {
+            payload["source_lang"] = sourceLanguage;
+        }
+
         var body = JsonSerializer.Serialize(payload);
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
-        Se.WriteToolsLog($"CosyVoice3 (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (voice={cosyVoice}, clone={isClone}, refTextLen={cosyVoice.RefText.Length}, textLen={text.Length})");
+        Se.WriteToolsLog($"CosyVoice3 (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (voice={cosyVoice}, clone={isClone}, refTextLen={cosyVoice.RefText.Length}, textLen={text.Length}, language={(string.IsNullOrEmpty(languageArg) ? "(auto)" : languageArg)})");
 
         HttpResponseMessage response;
         try

--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3Languages.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3Languages.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// The nine languages CosyVoice3 0.5B is trained on (Chinese, English, Japanese, Korean, German,
+/// Spanish, French, Italian, Russian — the model card's "9 languages"; its 18 Mandarin dialects
+/// are voice-level variants, not output languages), plus an "Auto" entry that leaves the choice
+/// to the model.
+///
+/// The pick is sent as the per-request <c>language</c> field of <c>/v1/audio/speech</c> —
+/// crispasr's cosyvoice3-tts backend compares it to the reference voice's language
+/// (src/core/tts_lang.h) and mirrors upstream <c>frontend_cross_lingual</c> when they differ:
+/// the reference transcript is dropped from the LM prompt so the clone speaks the target
+/// language instead of imitating the reference's (CrispASR #329, SE #13110). Same language (or
+/// Auto) keeps plain zero-shot cloning — the pre-existing behaviour. Requires a CrispASR build
+/// with the #329 fix for Latin-script reference voices; older builds ignore the field for those
+/// (their reference-language detection only answered for Hangul/Kana/Han/Cyrillic).
+///
+/// ISO-639-1 codes are sent as-is: the backend normalizes them via core_tts_lang::norm, which
+/// covers all nine. Display names are taken from <see cref="OmniVoiceLanguages"/> so sibling
+/// engines label the same language identically in the UI.
+/// </summary>
+internal static class CosyVoice3Languages
+{
+    /// <summary>
+    /// Code for the "Auto" entry — an empty code means no <c>language</c> field is sent and the
+    /// clone stays zero-shot in the reference's language (the pre-existing behaviour).
+    /// </summary>
+    public const string AutoCode = "";
+
+    public static readonly TtsLanguage Auto = new("Auto", AutoCode);
+
+    private static readonly string[] IsoCodes = { "zh", "en", "ja", "ko", "de", "es", "fr", "it", "ru" };
+
+    /// <summary>
+    /// "Auto" first, then the nine supported languages sorted by display name. Auto stays first
+    /// so the combo's default selection preserves the old no-language behaviour.
+    /// </summary>
+    public static readonly TtsLanguage[] All = Build();
+
+    private static TtsLanguage[] Build()
+    {
+        var omniNames = OmniVoiceLanguages.All.ToDictionary(l => l.Code, l => l.Name, StringComparer.OrdinalIgnoreCase);
+
+        var languages = IsoCodes
+            .Select(iso => new TtsLanguage(omniNames.TryGetValue(iso, out var name) ? name : iso, iso))
+            .OrderBy(l => l.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        languages.Insert(0, Auto);
+        return languages.ToArray();
+    }
+
+    /// <summary>
+    /// The value to send as the request's <c>language</c> field for <paramref name="language"/>,
+    /// or an empty string when no field should be sent (Auto, an unknown entry, or nothing
+    /// selected).
+    /// </summary>
+    public static string ResolveLanguageArg(TtsLanguage? language)
+    {
+        var code = language?.Code;
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            return string.Empty;
+        }
+
+        // Guard against a language object left over from another engine (the view model can hold
+        // one while switching engines): only values this engine actually advertises are passed on.
+        return All.Any(l => string.Equals(l.Code, code, StringComparison.OrdinalIgnoreCase))
+            ? code
+            : string.Empty;
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -42,7 +42,7 @@ public class Qwen3TtsCrispAsr : ITtsEngine
 {
     public string Name => "Qwen3 TTS (CrispASR)";
     public string Description => "via CrispASR (VoiceDesign or CustomVoice 1.7B)";
-    public bool HasLanguageParameter => false;
+    public bool HasLanguageParameter => true;
     public bool HasApiKey => false;
     public bool HasRegion => false;
     public bool HasModel => true;
@@ -718,7 +718,7 @@ public class Qwen3TtsCrispAsr : ITtsEngine
 
     public Task<string[]> GetModels() => Task.FromResult(new[] { ModelKeyVoiceDesign, ModelKeyCustomVoice, ModelKeyClone });
 
-    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(Array.Empty<TtsLanguage>());
+    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(Qwen3TtsCrispAsrLanguages.All);
 
     public Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken) =>
         GetVoices(language);
@@ -808,9 +808,19 @@ public class Qwen3TtsCrispAsr : ITtsEngine
             payload["instructions"] = "a calm female voice";
         }
 
+        // Output language (#13110): the backend maps the ISO code to the talker's explicit
+        // codec_language_id — applies to VoiceDesign, CustomVoice and cloned voices alike.
+        // Auto (empty) sends no field and lets the model infer the language from the text,
+        // which for a cloned reference in another language surfaces as a strong accent.
+        var languageArg = Qwen3TtsCrispAsrLanguages.ResolveLanguageArg(language);
+        if (!string.IsNullOrEmpty(languageArg))
+        {
+            payload["language"] = languageArg;
+        }
+
         var body = JsonSerializer.Serialize(payload);
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
-        Se.WriteToolsLog($"Qwen3 TTS (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (voice={qwen3Voice}, model={modelKey}, textLen={text.Length}, instructionLen={instruction.Length})");
+        Se.WriteToolsLog($"Qwen3 TTS (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (voice={qwen3Voice}, model={modelKey}, textLen={text.Length}, instructionLen={instruction.Length}, language={(string.IsNullOrEmpty(languageArg) ? "(auto)" : languageArg)})");
 
         HttpResponseMessage response;
         try

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsrLanguages.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsrLanguages.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// The ten output languages in the Qwen3-TTS 1.7B talker's <c>codec_language_id</c> table
+/// (Chinese, English, German, Italian, Portuguese, Spanish, Japanese, Korean, French, Russian —
+/// from the HF config; emitted into the GGUF as <c>qwen3tts.codec_language_names</c>), plus an
+/// "Auto" entry that leaves the choice to the model.
+///
+/// The pick is sent as the per-request <c>language</c> field of <c>/v1/audio/speech</c>.
+/// crispasr's qwen3-tts backend maps the ISO code to the English name the table is keyed by
+/// (core_lang::iso_to_english covers all ten) and sets the talker's explicit
+/// <c>codec_language_id</c> in the codec prefill — applies to VoiceDesign, CustomVoice and
+/// cloned voices alike (CrispASR #329, SE #13110). Without it the prefill takes the "nothink"
+/// path and the model infers the language from the text, which for a cloned reference in
+/// another language surfaces as a strong accent. Auto (no field) keeps that pre-existing
+/// behaviour; a code the loaded GGUF doesn't know logs a server-side warning and falls back to
+/// auto.
+///
+/// Display names are taken from <see cref="OmniVoiceLanguages"/> so sibling engines label the
+/// same language identically in the UI.
+/// </summary>
+internal static class Qwen3TtsCrispAsrLanguages
+{
+    /// <summary>
+    /// Code for the "Auto" entry — an empty code means no <c>language</c> field is sent and the
+    /// model infers the language from the text itself (the pre-existing behaviour).
+    /// </summary>
+    public const string AutoCode = "";
+
+    public static readonly TtsLanguage Auto = new("Auto", AutoCode);
+
+    private static readonly string[] IsoCodes = { "zh", "en", "de", "it", "pt", "es", "ja", "ko", "fr", "ru" };
+
+    /// <summary>
+    /// "Auto" first, then the ten supported languages sorted by display name. Auto stays first
+    /// so the combo's default selection preserves the old no-language behaviour.
+    /// </summary>
+    public static readonly TtsLanguage[] All = Build();
+
+    private static TtsLanguage[] Build()
+    {
+        var omniNames = OmniVoiceLanguages.All.ToDictionary(l => l.Code, l => l.Name, StringComparer.OrdinalIgnoreCase);
+
+        var languages = IsoCodes
+            .Select(iso => new TtsLanguage(omniNames.TryGetValue(iso, out var name) ? name : iso, iso))
+            .OrderBy(l => l.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        languages.Insert(0, Auto);
+        return languages.ToArray();
+    }
+
+    /// <summary>
+    /// The value to send as the request's <c>language</c> field for <paramref name="language"/>,
+    /// or an empty string when no field should be sent (Auto, an unknown entry, or nothing
+    /// selected).
+    /// </summary>
+    public static string ResolveLanguageArg(TtsLanguage? language)
+    {
+        var code = language?.Code;
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            return string.Empty;
+        }
+
+        // Guard against a language object left over from another engine (the view model can hold
+        // one while switching engines): only values this engine actually advertises are passed on.
+        return All.Any(l => string.Equals(l.Code, code, StringComparison.OrdinalIgnoreCase))
+            ? code
+            : string.Empty;
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -1512,11 +1512,29 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
             // Same preference order as SelectedModelChanged: the saved language, then English,
             // then whatever comes first.
-            SelectedLanguage = Languages.FirstOrDefault(p => p.Name == Se.Settings.Video.TextToSpeech.ElevenLabsLanguage)
-                               ?? Languages.FirstOrDefault(p => p.Code == "en")
-                               ?? Languages.FirstOrDefault();
+            SelectedLanguage = ResolveSavedLanguage(engine);
         }
     }
+
+    /// <summary>
+    /// The language to preselect for <paramref name="engine"/> from the current
+    /// <see cref="Languages"/> list. The CrispASR cloning engines lead with "Auto" and persist
+    /// per-engine picks — restore those, and fall back to Auto (first entry) rather than English
+    /// so an untouched language combo keeps the engine's pre-language-selection behaviour.
+    /// Everything else keeps the saved-ElevenLabs → English → first order.
+    /// </summary>
+    private TtsLanguage? ResolveSavedLanguage(ITtsEngine engine) => engine switch
+    {
+        MossTtsCrispAsr => Languages.FirstOrDefault(p => p.Name == Se.Settings.Video.TextToSpeech.MossTtsCrispAsrLanguage)
+                           ?? Languages.FirstOrDefault(),
+        CosyVoice3CrispAsr => Languages.FirstOrDefault(p => p.Name == Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrLanguage)
+                              ?? Languages.FirstOrDefault(),
+        Qwen3TtsCrispAsr => Languages.FirstOrDefault(p => p.Name == Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrLanguage)
+                            ?? Languages.FirstOrDefault(),
+        _ => Languages.FirstOrDefault(p => p.Name == Se.Settings.Video.TextToSpeech.ElevenLabsLanguage)
+             ?? Languages.FirstOrDefault(p => p.Code == "en")
+             ?? Languages.FirstOrDefault(),
+    };
 
     internal void SelectedLanguageChanged(object? sender, SelectionChangedEventArgs e)
     {
@@ -1574,11 +1592,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
                     Languages.Add(language);
                 }
 
-                SelectedLanguage = Languages.FirstOrDefault(p => p.Name == Se.Settings.Video.TextToSpeech.ElevenLabsLanguage);
-                if (SelectedLanguage == null)
-                {
-                    SelectedLanguage = Languages.FirstOrDefault(p => p.Code == "en");
-                }
+                SelectedLanguage = ResolveSavedLanguage(engine);
             }
         });
     }

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -396,6 +396,7 @@ public partial class TextToSpeechViewModel : ObservableObject
             // Shared instruction text with the qwen3-tts.cpp engine so the same voice
             // description applies whichever Qwen3 backend the user picks.
             Se.Settings.Video.TextToSpeech.Qwen3TtsCppInstruction = (Instruction ?? string.Empty).Trim();
+            Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrLanguage = SelectedLanguage?.Name ?? string.Empty;
         }
         else if (SelectedEngine is VibeVoiceCrispAsr)
         {
@@ -408,6 +409,7 @@ public partial class TextToSpeechViewModel : ObservableObject
         else if (SelectedEngine is CosyVoice3CrispAsr)
         {
             Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrModel = SelectedModel ?? CosyVoice3CrispAsr.DefaultModelKey;
+            Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrLanguage = SelectedLanguage?.Name ?? string.Empty;
         }
         else if (SelectedEngine is F5TtsCrispAsr)
         {
@@ -3311,13 +3313,18 @@ public partial class TextToSpeechViewModel : ObservableObject
 
                 // OmniVoice has 646 alphabetically-sorted languages; the first entry ("Abadi") is
                 // a useless default. Default to English so the engine is usable out of the box.
-                // MOSS-TTS restores the saved pick (its list leads with "Auto", which is also the
-                // right fallback - it reproduces the pre-language-selection behaviour).
+                // The CrispASR cloning engines restore the saved pick (their lists lead with
+                // "Auto", which is also the right fallback - it reproduces the
+                // pre-language-selection behaviour).
                 SelectedLanguage = engine switch
                 {
                     OmniVoiceTtsCpp => Languages.FirstOrDefault(l => l.Code == "en") ?? Languages.FirstOrDefault(),
                     MossTtsCrispAsr => Languages.FirstOrDefault(l => l.Name == Se.Settings.Video.TextToSpeech.MossTtsCrispAsrLanguage)
                                        ?? Languages.FirstOrDefault(),
+                    CosyVoice3CrispAsr => Languages.FirstOrDefault(l => l.Name == Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrLanguage)
+                                          ?? Languages.FirstOrDefault(),
+                    Qwen3TtsCrispAsr => Languages.FirstOrDefault(l => l.Name == Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrLanguage)
+                                        ?? Languages.FirstOrDefault(),
                     _ => Languages.FirstOrDefault(),
                 };
             }

--- a/src/ui/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/ui/Logic/Config/SeVideoTextToSpeech.cs
@@ -32,12 +32,19 @@ public class SeVideoTextToSpeech
     public string Qwen3TtsCppVulkanPath { get; set; }
     public string Qwen3TtsCppInstruction { get; set; }
     public string Qwen3TtsCrispAsrModel { get; set; }
+    // Display name of the picked Qwen3-TTS output language ("Auto" = let the model infer it).
+    public string Qwen3TtsCrispAsrLanguage { get; set; }
     public string VibeVoiceCrispAsrModel { get; set; }
     public double VibeVoiceCrispAsrSpeed { get; set; }
     public string IndexTtsCrispAsrModel { get; set; }
     public double IndexTtsCrispAsrSpeed { get; set; }
     public string CosyVoice3CrispAsrModel { get; set; }
     public double CosyVoice3CrispAsrSpeed { get; set; }
+    // Display name of the picked CosyVoice3 target language ("Auto" = plain zero-shot cloning).
+    public string CosyVoice3CrispAsrLanguage { get; set; }
+    // ISO code of the language spoken in imported reference WAVs (empty = let the server detect).
+    // Sent as `source_lang` so cross-lingual cloning engages for Latin-script references too.
+    public string CosyVoice3CrispAsrSourceLanguage { get; set; }
     public string F5TtsCrispAsrModel { get; set; }
     public double F5TtsCrispAsrSpeed { get; set; }
     public string OmniVoiceCrispAsrModel { get; set; }
@@ -125,12 +132,15 @@ public class SeVideoTextToSpeech
         Qwen3TtsCppVulkanPath = string.Empty;
         Qwen3TtsCppInstruction = string.Empty;
         Qwen3TtsCrispAsrModel = "1.7B VoiceDesign";
+        Qwen3TtsCrispAsrLanguage = string.Empty;
         VibeVoiceCrispAsrModel = "Q8_0 (~2.8 GB)";
         VibeVoiceCrispAsrSpeed = 1.1;
         IndexTtsCrispAsrModel = "Q8_0 (~870 MB)";
         IndexTtsCrispAsrSpeed = 1.0;
         CosyVoice3CrispAsrModel = "Q4_K (~1.6 GB total)";
         CosyVoice3CrispAsrSpeed = 1.0;
+        CosyVoice3CrispAsrLanguage = string.Empty;
+        CosyVoice3CrispAsrSourceLanguage = string.Empty;
         F5TtsCrispAsrModel = "F16 (~953 MB)";
         F5TtsCrispAsrSpeed = 1.0;
         OmniVoiceCrispAsrModel = "Q4_K (~1 GB)";

--- a/tests/UI/Features/Video/TextToSpeech/Engines/CrispAsrTtsLanguagesTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/CrispAsrTtsLanguagesTests.cs
@@ -1,0 +1,99 @@
+﻿using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+namespace UITests.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// The CosyVoice3 / Qwen3-TTS (CrispASR) target-language lists added for #13110. Both are sent
+/// as the per-request "language" field of /v1/audio/speech; CosyVoice3 additionally engages
+/// cross-lingual cloning when it differs from the reference voice's language.
+/// </summary>
+public class CrispAsrTtsLanguagesTests
+{
+    [Fact]
+    public void CosyVoice3Languages_LeadWithAutoThenTheNineSupportedLanguages()
+    {
+        // "Auto" must stay first: the view model falls back to the first entry, and Auto is the
+        // pre-existing behaviour (no language field, plain zero-shot cloning).
+        var all = CosyVoice3Languages.All;
+
+        Assert.Equal("Auto", all[0].Name);
+        Assert.Equal(string.Empty, all[0].Code);
+        Assert.Equal(10, all.Length);
+    }
+
+    [Fact]
+    public void Qwen3TtsCrispAsrLanguages_LeadWithAutoThenTheTenSupportedLanguages()
+    {
+        // The ten entries mirror the talker's codec_language_id table (HF config); Auto keeps
+        // the "nothink" prefill path where the model infers the language from the text.
+        var all = Qwen3TtsCrispAsrLanguages.All;
+
+        Assert.Equal("Auto", all[0].Name);
+        Assert.Equal(string.Empty, all[0].Code);
+        Assert.Equal(11, all.Length);
+    }
+
+    [Theory]
+    [InlineData("Chinese", "zh")]
+    [InlineData("German", "de")]
+    [InlineData("Russian", "ru")]
+    public void CosyVoice3Languages_SendIsoCodes(string displayName, string expectedCode)
+    {
+        // The backend normalizes ISO-639-1 codes itself (core_tts_lang::norm), so the code is
+        // sent as-is; display names come from the shared OmniVoice table.
+        var language = CosyVoice3Languages.All.Single(l => l.Name == displayName);
+
+        Assert.Equal(expectedCode, language.Code);
+    }
+
+    [Theory]
+    [InlineData("Portuguese", "pt")]
+    [InlineData("Japanese", "ja")]
+    public void Qwen3TtsCrispAsrLanguages_SendIsoCodes(string displayName, string expectedCode)
+    {
+        // crispasr's qwen3-tts adapter maps the ISO code to the English name the model's
+        // codec_language_names table is keyed by (core_lang::iso_to_english covers all ten).
+        var language = Qwen3TtsCrispAsrLanguages.All.Single(l => l.Name == displayName);
+
+        Assert.Equal(expectedCode, language.Code);
+    }
+
+    [Fact]
+    public void ResolveLanguageArg_AutoOrNull_SendsNoField()
+    {
+        Assert.Equal(string.Empty, CosyVoice3Languages.ResolveLanguageArg(null));
+        Assert.Equal(string.Empty, CosyVoice3Languages.ResolveLanguageArg(CosyVoice3Languages.Auto));
+        Assert.Equal(string.Empty, Qwen3TtsCrispAsrLanguages.ResolveLanguageArg(null));
+        Assert.Equal(string.Empty, Qwen3TtsCrispAsrLanguages.ResolveLanguageArg(Qwen3TtsCrispAsrLanguages.Auto));
+    }
+
+    [Fact]
+    public void ResolveLanguageArg_ForeignLanguage_SendsNoField()
+    {
+        // Switching engines can leave a language from another engine's list selected (OmniVoice
+        // has 646 of them); only codes the engine actually supports may reach the server.
+        Assert.Equal(string.Empty, CosyVoice3Languages.ResolveLanguageArg(new TtsLanguage("Abadi", "kbt")));
+        Assert.Equal(string.Empty, Qwen3TtsCrispAsrLanguages.ResolveLanguageArg(new TtsLanguage("Abadi", "kbt")));
+    }
+
+    [Fact]
+    public void ResolveLanguageArg_SupportedLanguage_PassesItThrough()
+    {
+        Assert.Equal("de", CosyVoice3Languages.ResolveLanguageArg(
+            CosyVoice3Languages.All.Single(l => l.Name == "German")));
+        Assert.Equal("pt", Qwen3TtsCrispAsrLanguages.ResolveLanguageArg(
+            Qwen3TtsCrispAsrLanguages.All.Single(l => l.Name == "Portuguese")));
+    }
+
+    [Fact]
+    public void CosyVoice3Languages_HasNoPortuguese_Qwen3HasNoKoreanGap()
+    {
+        // Guard the per-model capability split: CosyVoice3's nine languages include Korean but
+        // not Portuguese; Qwen3-TTS's ten include Portuguese. A refactor that merges the two
+        // lists would silently offer languages a model cannot speak.
+        Assert.DoesNotContain(CosyVoice3Languages.All, l => l.Code == "pt");
+        Assert.Contains(CosyVoice3Languages.All, l => l.Code == "ko");
+        Assert.Contains(Qwen3TtsCrispAsrLanguages.All, l => l.Code == "pt");
+    }
+}


### PR DESCRIPTION
Adds the target-language parameter requested in #13110.

## What

- **CosyVoice3 (CrispASR)** and **Qwen3 TTS (CrispASR)** now show the standard language combo ("Auto" + the languages each model actually supports: CosyVoice3's 9, Qwen3-TTS's 10 from the talker's `codec_language_id` table). The pick is sent as the per-request `language` field of `/v1/audio/speech`.
- **CosyVoice3** also gets a "Reference language" pick in its settings window, sent as `source_lang` for imported WAV clones. CrispASR's own reference-language detection only answers for non-Latin scripts, so en→de style cloning pairs need the explicit tag ([CrispASR #329](https://github.com/CrispStrobe/CrispASR/issues/329)).
- Language picks persist per engine and are restored in both the main TTS window and the review window (the review window previously preselected English instead of the saved/Auto pick for the CrispASR cloning engines).
- **Chatterbox** is unchanged: SE ships the English-only Base/Turbo models; the language token requires the multilingual v3 weights, which aren't wired up.

## Why

Without a target language these engines clone in same-language zero-shot mode, so asking an English reference voice to speak German produces German with a strong English accent. With `language` (+ `source_lang` for Latin-script references) the cosyvoice3 backend switches to cross-lingual synthesis and drops the reference transcript from the prompt; qwen3-tts sets the talker's explicit `codec_language_id`.

## Compatibility

Auto (default) sends no fields — behaviour is unchanged. With a language picked, the currently pinned CrispASR v0.8.25 ignores/partially honors the fields (unknown JSON fields are ignored server-side); the release after v0.8.25 carries the cross-lingual fixes (commit 14be8056) and makes this fully effective. No CrispASR version bump needed in this PR.

## Tests

- 11 new tests covering the two language lists (Auto-first ordering, ISO codes, foreign-language guard, per-model capability split)
- All 101 TextToSpeech tests pass; full UI build clean with 0 warnings (also fixes a pre-existing duplicate-using warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)