### PR TITLE
fix: stop burn-in progress bar overlapping target file size box

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -45,8 +45,13 @@ public class BurnInWindow : Window
         var videoInfoView = MakeVideoInfoView(vm);
         var progressView = MakeProgressView(vm);
 
-        // Keep the left column (subtitle + video + target size) together and top-aligned so the
-        // extra vertical space goes to the preview instead of opening a gap between the boxes.
+        // The left column (subtitle + video settings + target size) is taller than the middle
+        // column's cut/preview/audio/video-info rows. Keeping all three boxes in one packed
+        // panel preserves the v5.1.0 look (no gaps), and the preview row's MinHeight below
+        // guarantees the panel fits in rows 0-3 - so it can never overflow into the
+        // progress-bar row (which used to draw the bar through the "File size in MB" field)
+        // - and the preview box never gets shorter than its label + player, so the player
+        // cannot spill over the audio settings box.
         var leftPanel = new StackPanel
         {
             Orientation = Orientation.Vertical,
@@ -100,9 +105,9 @@ public class BurnInWindow : Window
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // cut
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }, // preview + batch list
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star), MinHeight = 400 }, // preview + batch list (never smaller than the preview box needs)
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // audio
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // video info
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // video info + target file size
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // progress bar
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // buttons
             },
@@ -117,7 +122,7 @@ public class BurnInWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(leftPanel, 0, 0, 4, 1);
+        grid.Add(leftPanel, 0, 0, 4, 1);  // rows 0-3 (cut + preview + audio + video info)
         grid.Add(cutView, 0, 1);
         grid.Add(previewView, 1, 1);
         grid.Add(audioSettingsView, 2, 1);
@@ -168,6 +173,12 @@ public class BurnInWindow : Window
                 UpdateGrowAreas();
                 LockMinimumToContentSize(); // batch mode needs more width; re-fit and re-lock the minimum
             }
+            else if (e.PropertyName == nameof(vm.IsGenerating))
+            {
+                // The progress row only exists while generating; re-lock the minimum so the
+                // window (and the button row) always fit the content with the bar shown.
+                LockMinimumToContentSize(heightOnly: true);
+            }
         };
         UpdateGrowAreas();
 
@@ -188,7 +199,7 @@ public class BurnInWindow : Window
         };
     }
 
-    private void LockMinimumToContentSize()
+    private void LockMinimumToContentSize(bool heightOnly = false)
     {
         // Re-fit the window to the current mode's content (single mode is narrower; batch mode
         // needs more width for the file list), then lock that size in as the new minimum while
@@ -200,13 +211,32 @@ public class BurnInWindow : Window
         {
             var width = ClientSize.Width;
             var height = ClientSize.Height;
+            // Width/Height include the window chrome (title bar + borders); the minimum must
+            // cover the content plus the chrome, otherwise the window can be shrunk below the
+            // content and the bottom row (buttons) gets clipped.
+            var chromeWidth = Width - width;
+            var chromeHeight = Height - height;
             SizeToContent = SizeToContent.Manual;
             if (width > 0 && height > 0)
             {
-                MinWidth = width;
-                MinHeight = height;
-                Width = width;
-                Height = height;
+                if (heightOnly)
+                {
+                    // Used when generating starts/stops: the progress row only exists while
+                    // generating, so re-lock the minimum for that state. Only enlarge - never
+                    // shrink the window back down automatically.
+                    MinHeight = height + chromeHeight;
+                    if (Height < MinHeight)
+                    {
+                        Height = MinHeight;
+                    }
+                }
+                else
+                {
+                    MinWidth = width + chromeWidth;
+                    MinHeight = height + chromeHeight;
+                    Width = width + chromeWidth;
+                    Height = height + chromeHeight;
+                }
             }
         }, DispatcherPriority.Loaded);
     }

--- a/tests/UI/Features/Video/BurnInWindowTests.cs
+++ b/tests/UI/Features/Video/BurnInWindowTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using Nikse.SubtitleEdit.Features.Video.BurnIn;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace UITests.Features.Video;
+
+/// <summary>
+/// Construction + layout tests for the burn-in window. The layout is built entirely in code.
+/// The left settings column (subtitle + video + target size, packed in one panel spanning
+/// rows 0-3) is taller than the middle column's cut/preview/audio/video-info rows, so the
+/// preview row (row 1) carries a MinHeight: it keeps the packed panel inside rows 0-3 (so it
+/// can never overflow into the progress-bar row, which used to draw the bar through the
+/// "File size in MB" field) and keeps the preview box taller than its label + player (so the
+/// player can never spill over the audio settings box when the window is shrunk).
+/// </summary>
+public class BurnInWindowTests
+{
+    // WindowService only touches the provider when it creates a child window, which this
+    // construction test never does.
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static BurnInWindow BuildWindow()
+    {
+        var vm = new BurnInViewModel(
+            new FolderHelper(),
+            new FileHelper(),
+            new WindowService(new NullServiceProvider()));
+        return new BurnInWindow(vm);
+    }
+
+    /// <summary>Returns the window's root grid (the one holding the progress view).</summary>
+    private static Grid FindRootGrid(BurnInWindow window)
+    {
+        var progressBar = window.GetLogicalDescendants().OfType<ProgressBar>().FirstOrDefault();
+        Assert.NotNull(progressBar);
+        var progressView = progressBar.Parent as Grid;
+        Assert.NotNull(progressView);
+        var rootGrid = progressView.Parent as Grid;
+        Assert.NotNull(rootGrid);
+        return rootGrid;
+    }
+
+    [AvaloniaFact]
+    public void Window_Constructs()
+    {
+        var window = BuildWindow();
+
+        Assert.NotNull(window.Content);
+    }
+
+    [AvaloniaFact]
+    public void PreviewRow_HasMinimumHeight_KeepingPanelAboveProgressBar()
+    {
+        var window = BuildWindow();
+        var vm = window.DataContext as BurnInViewModel;
+        Assert.NotNull(vm);
+        vm.IsGenerating = true; // progress view is only visible while generating
+        window.Show();
+
+        var rootGrid = FindRootGrid(window);
+
+        // The preview row (row 1, star) must carry a MinHeight: without it the window can be
+        // shrunk (or restored) below the content height, the preview box gets shorter than its
+        // label + player and the player spills over the audio settings box below it.
+        var previewRow = rootGrid.RowDefinitions[1];
+        Assert.Equal(GridUnitType.Star, previewRow.Height.GridUnitType);
+        Assert.True(previewRow.MinHeight >= 350, $"Preview row MinHeight is only {previewRow.MinHeight:0.#}.");
+
+        // The left column is one panel spanning rows 0-3. With the row minimum in place it
+        // must fit entirely above the progress view - the regression this guards against drew
+        // the progress bar through the "File size in MB" field while generating.
+        var leftPanel = rootGrid.Children.OfType<StackPanel>().FirstOrDefault();
+        Assert.NotNull(leftPanel);
+        var progressView = rootGrid.Children.OfType<Grid>().FirstOrDefault(g => Grid.GetRow(g) == 4);
+        Assert.NotNull(progressView);
+
+        var panelBottom = leftPanel.TranslatePoint(new Point(0, leftPanel.Bounds.Height), window)?.Y;
+        var progressTop = progressView.TranslatePoint(new Point(0, 0), window)?.Y;
+        Assert.NotNull(panelBottom);
+        Assert.NotNull(progressTop);
+        Assert.True(
+            panelBottom.Value <= progressTop.Value + 1.5,
+            $"Left panel bottom ({panelBottom.Value:0.#}) is below the progress view top ({progressTop.Value:0.#}).");
+    }
+
+    [AvaloniaFact]
+    public void VideoPlayer_StaysAboveAudioSettingsBox_WhenWindowIsAtMinimumHeight()
+    {
+        var window = BuildWindow();
+        var vm = window.DataContext as BurnInViewModel;
+        Assert.NotNull(vm);
+        vm.IsGenerating = true; // progress view is only visible while generating
+        window.Show();
+
+        // Try to shrink the window far below the content minimum; the layout must clamp it so
+        // the preview box still fits its label + player.
+        window.Height = 400;
+        window.UpdateLayout();
+
+        var rootGrid = FindRootGrid(window);
+        var audioSettingsView = rootGrid.Children.OfType<Border>().FirstOrDefault(b => Grid.GetRow(b) == 2 && Grid.GetColumn(b) == 1);
+        Assert.NotNull(audioSettingsView);
+
+        // The player is the bottom-most element of the preview box; its bottom must never
+        // reach the audio settings box.
+        var player = vm.VideoPlayerControl;
+        Assert.NotNull(player);
+        var playerBottom = player.TranslatePoint(new Point(0, player.Bounds.Height), window)?.Y;
+        var audioTop = audioSettingsView.TranslatePoint(new Point(0, 0), window)?.Y;
+        Assert.NotNull(playerBottom);
+        Assert.NotNull(audioTop);
+        Assert.True(
+            playerBottom.Value <= audioTop.Value + 1.5,
+            $"Video player bottom ({playerBottom.Value:0.#}) overlaps the audio settings box top ({audioTop.Value:0.#}).");
+    }
+
+    [AvaloniaFact]
+    public void Window_EnlargesToFitProgressBar_WhenGeneratingStarts()
+    {
+        var window = BuildWindow();
+        var vm = window.DataContext as BurnInViewModel;
+        Assert.NotNull(vm);
+        window.Show();
+        window.UpdateLayout();
+        var before = window.ClientSize.Height;
+
+        // Starting a generation shows the progress row; the window minimum must grow so the
+        // button row is never clipped while the bar + status text are visible.
+        vm.IsGenerating = true;
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var rootGrid = FindRootGrid(window);
+        Assert.True(
+            rootGrid.Children.OfType<Grid>().Any(g => Grid.GetRow(g) == 4 && g.IsVisible),
+            "Progress view is not visible while generating.");
+
+        var buttonPanel = rootGrid.Children.OfType<StackPanel>().FirstOrDefault(s => Grid.GetRow(s) == 5);
+        Assert.NotNull(buttonPanel);
+        var buttonsBottom = buttonPanel.TranslatePoint(new Point(0, buttonPanel.Bounds.Height), window)?.Y;
+        Assert.NotNull(buttonsBottom);
+        Assert.True(
+            buttonsBottom.Value <= window.ClientSize.Height + 1.5,
+            $"Buttons bottom ({buttonsBottom.Value:0.#}) is clipped by the window height ({window.ClientSize.Height:0.#}).");
+        Assert.True(
+            window.ClientSize.Height >= before,
+            $"Window shrank when generating started ({before:0.#} -> {window.ClientSize.Height:0.#}).");
+    }
+}


### PR DESCRIPTION
## Summary

In the "Generate video with burned-in subtitles" dialog, three related layout bugs:

1. While generating, the progress bar is drawn **through the "File size in MB" field** (the bar visibly overlaps the field's lower half).
2. The window can be shrunk so far that the **"Preview" label is covered by the video** and the video's **timestamp + file name overlap the "Audio encoding" section**.
3. The window can be shrunk (or restored) below the content height so the **button row (Generate / Help / Batch mode / OK / Cancel) is clipped in half** while generating.

### Root causes

1. The left settings column (subtitle + video encoding + target file size) is **taller than the middle column's rows** (cut / preview / audio / video info), because the preview row is a star row sized by the preview. The three left boxes were packed into one `StackPanel` spanning rows 0–3; a spanning child's height is not accounted for in the row layout, so on DPI-scaled displays the panel overflowed into row 4 — the progress-bar row — and the bar rendered through the bottom of the target-size box.
2. The saved window size (restored after the content minimum is locked) can be **smaller than the content minimum**; the preview row then shrinks below what its label + player need and the player spills over the audio settings box.
3. `LockMinimumToContentSize` used the **client size** as the window minimum, but `Width/MinHeight` cover the whole window including the title bar and borders (~30 px too small), and the minimum was measured **with the progress row hidden** (pre-generation) — so when generating started, the content grew and the window clipped the button row.

### Fix

- The left panel keeps the **v5.1.0 look** (three boxes packed, no gaps).
- The preview row (row 1) gets **`MinHeight = 400`** — two guarantees:
  - the packed panel always fits inside rows 0–3, so it can never overflow into the progress-bar row (the bar stays below every box, in single and batch mode);
  - the preview box is always taller than its label + player, so the player can never spill over the audio settings box.
- `LockMinimumToContentSize` now adds the **window chrome** (window size − client size) to the locked minimum, so the window can never be shrunk below its content.
- **Starting/stopping a generation re-locks the minimum** (height-only, enlarge-only), so the window always fits the content while the progress bar and status text are shown — the button row is never clipped. The saved window size is still respected as long as it is at least the content minimum.

### Tests

- `BurnInWindowTests.Window_Constructs` — construction smoke test (code-built layout, like `TextToSpeechWindowTests`).
- `BurnInWindowTests.PreviewRow_HasMinimumHeight_KeepingPanelAboveProgressBar` — asserts the star row carries `MinHeight >= 350` plus rendered geometry (left panel bottom above the progress view top); fails on both pre-fix layouts.
- `BurnInWindowTests.VideoPlayer_StaysAboveAudioSettingsBox_WhenWindowIsAtMinimumHeight` — renders the window at the clamped minimum and asserts the player's bottom stays above the audio settings box.
- `BurnInWindowTests.Window_EnlargesToFitProgressBar_WhenGeneratingStarts` — starts a generation and asserts the progress view is visible and the button row stays inside the window; fails without the re-lock.