### PR TITLE
Apply dark theme background for SyntaxTextEditor

### DIFF
--- a/src/ui/Logic/UiTheme.cs
+++ b/src/ui/Logic/UiTheme.cs
@@ -637,6 +637,16 @@ public static class UiTheme
                 }
             },
 
+            // The source editor owns its text surface, so unlike a TextBox it does not inherit
+            // the dark input background from Fluent.
+            new Style(x => x.OfType<SyntaxTextEditor>())
+            {
+                Setters =
+                {
+                    new Setter(SyntaxTextEditor.BackgroundProperty, new SolidColorBrush(bgColor)),
+                }
+            },
+
             // MenuItem
             new Style(x => x.OfType<Avalonia.Controls.MenuItem>())
             {


### PR DESCRIPTION
## Problem

`SyntaxTextEditor` kept its default white background in dark mode, making the dark-theme foreground and syntax colors difficult to read.

## Cause & Fix

The virtualizing editor owns its text surface instead of using Avalonia's `TextBox` template. Its background therefore does not inherit the dark input background applied to `TextBox`.

This change adds a dark-theme style for `SyntaxTextEditor` using the configured dark background color. The same style also covers the source view, format preview, and ASSA batch-convert editor.

## Screenshots
|Before|After|
|-|-|
|<img width="1740" height="1606" alt="image" src="https://github.com/user-attachments/assets/2ecd5349-90a7-4cd7-a36c-ffbc7e936412" />|<img width="1744" height="1606" alt="image" src="https://github.com/user-attachments/assets/da139a1a-6ae5-491f-b9a6-e60c9e44789b" />|

## Testing

- Confirmed correct display in Light, Dark, Classic and Pastel themes.
- Tested on Fedora 44 (x64, local build).