### PR TITLE
Add "Pl." (plaza) to Spanish abbreviation list

### DIFF
--- a/Dictionaries/es_abbreviations.xml
+++ b/Dictionaries/es_abbreviations.xml
@@ -25,6 +25,7 @@
   <Item>máx.</Item>
   <Item>mín.</Item>
   <Item>núm.</Item>
+  <Item>Pl.</Item>
   <Item>Prof.</Item>
   <Item>pág.</Item>
   <Item>ref.</Item>


### PR DESCRIPTION
Closes #13078.

Most of the abbreviations reported in #13078 were already covered by the fix for #13082 (`2698fd7a9` — don't uppercase after an abbreviation period, and `b9465b702` — shipped abbreviation lists, including `es_abbreviations.xml` with Ud./Uds./Vd./Vds./Sr./Sra./Srta./Dr./Dra./Prof./art./etc./aprox./máx./mín./pág./cap./Lic./Ing./Arq./av./núm.). Matching is case insensitive.

This adds the one remaining eligible entry from the report: `Pl.` (plaza).

Not added, by design:
- `EE. UU.`, `P.º`, `p. ej.` — inner-period forms are handled by a general rule (and `ej.` is already listed)
- `N°`, `N.º`, `C/` — no trailing period, so they can never trigger the uppercase-after-period fix

`ShippedAbbreviationListsTests` passes (32/32).

🤖 Generated with [Claude Code](https://claude.com/claude-code)