### PR TITLE
ASSA styles: embed collected font in [Fonts] when picked from the font collector

### DIFF
--- a/src/ui/Features/Assa/AssaStylesViewModel.cs
+++ b/src/ui/Features/Assa/AssaStylesViewModel.cs
@@ -7,6 +7,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Assa.FontCollector;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Shared.PickFontName;
 using Nikse.SubtitleEdit.Features.Shared.PromptTextBox;
@@ -18,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -240,6 +242,29 @@ public partial class AssaStylesViewModel : ObservableObject, IClosingCleanup
             }
 
             CurrentStyle.FontName = result.SelectedFontName;
+
+            if (result.SelectedCollectedFont != null)
+            {
+                EmbedCollectedFont(result.SelectedCollectedFont);
+            }
+        }
+    }
+
+    /// <summary>
+    /// A font picked from the "Collected fonts" tab need not be installed on the machine
+    /// that plays the subtitle, so its file is embedded in the [Fonts] attachment section.
+    /// Reaches the main subtitle only on OK, like the rest of this dialog's changes.
+    /// </summary>
+    private void EmbedCollectedFont(CollectedFont font)
+    {
+        try
+        {
+            var bytes = File.ReadAllBytes(font.FilePath);
+            _subtitle.Footer = FontCollectorViewModel.AddFontToFooter(_subtitle.Footer, font.FilePath, bytes);
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, "Could not embed collected font " + font.FilePath);
         }
     }
 

--- a/src/ui/Features/Assa/FontCollector/FontCollectorViewModel.cs
+++ b/src/ui/Features/Assa/FontCollector/FontCollectorViewModel.cs
@@ -178,6 +178,78 @@ public partial class FontCollectorViewModel : ObservableObject
         return result;
     }
 
+    /// <summary>
+    /// Adds a font file to the [Fonts] attachment section of an ASSA footer, creating the
+    /// section if needed. A font whose file name is already attached is not added twice.
+    /// </summary>
+    internal static string AddFontToFooter(string? footer, string fontFilePath, byte[] fontBytes)
+    {
+        var fileName = Path.GetFileName(fontFilePath);
+        if (GetEmbeddedFonts(footer).Any(f => f.FileName.Equals(fileName, StringComparison.OrdinalIgnoreCase)))
+        {
+            return footer!;
+        }
+
+        var entryLines = new List<string> { "fontname: " + fileName };
+        entryLines.AddRange(UUEncoding.UUEncode(fontBytes).Trim().SplitToLines());
+
+        if (string.IsNullOrWhiteSpace(footer))
+        {
+            return "[Fonts]" + Environment.NewLine + string.Join(Environment.NewLine, entryLines) + Environment.NewLine;
+        }
+
+        var lines = footer.SplitToLines();
+        var result = new List<string>(lines.Count + entryLines.Count + 2);
+        var inFonts = false;
+        var inserted = false;
+
+        void InsertEntry()
+        {
+            while (result.Count > 0 && result[^1].Trim().Length == 0)
+            {
+                result.RemoveAt(result.Count - 1);
+            }
+
+            result.AddRange(entryLines);
+            inserted = true;
+        }
+
+        foreach (var line in lines)
+        {
+            var s = line.Trim();
+            if (s.Equals("[Fonts]", StringComparison.OrdinalIgnoreCase))
+            {
+                inFonts = true;
+            }
+            else if (inFonts && !inserted &&
+                     (s == "[Script Info]" || s == "[V4+ Styles]" || s == "[V4 Styles]" || s == "[Events]" ||
+                      s.Equals("[Graphics]", StringComparison.OrdinalIgnoreCase) ||
+                      s.Equals("[Aegisub Extradata]", StringComparison.OrdinalIgnoreCase)))
+            {
+                // Only exact section headers end the fonts section (see GetEmbeddedFonts).
+                InsertEntry();
+                result.Add(string.Empty);
+                inFonts = false;
+            }
+
+            result.Add(line);
+        }
+
+        if (inFonts && !inserted)
+        {
+            InsertEntry();
+        }
+
+        if (!inserted)
+        {
+            // No [Fonts] section - fonts go first, same order the attachments window writes.
+            return "[Fonts]" + Environment.NewLine + string.Join(Environment.NewLine, entryLines) +
+                   Environment.NewLine + Environment.NewLine + footer.TrimStart();
+        }
+
+        return string.Join(Environment.NewLine, result) + Environment.NewLine;
+    }
+
     /// <summary>Fills the "Installed fonts" and "Collected fonts" tabs.</summary>
     private void LoadFontLists()
     {

--- a/src/ui/Features/Shared/PickFontName/PickFontNameViewModel.cs
+++ b/src/ui/Features/Shared/PickFontName/PickFontNameViewModel.cs
@@ -32,6 +32,9 @@ public partial class PickFontNameViewModel : ObservableObject, IClosingCleanup
 
     public bool OkPressed { get; private set; }
 
+    /// <summary>Set when the pick came from the "Collected fonts" tab - such a font has a file callers can embed.</summary>
+    public CollectedFont? SelectedCollectedFont { get; private set; }
+
     private List<string> _allFontNames;
     private readonly List<CollectedFont> _allCollectedFonts;
     private readonly System.Timers.Timer _timerUpdate;
@@ -224,6 +227,11 @@ public partial class PickFontNameViewModel : ObservableObject, IClosingCleanup
         if (!string.IsNullOrEmpty(fontName))
         {
             SelectedFontName = fontName;
+
+            if (SelectedTabIndex == 1)
+            {
+                SelectedCollectedFont = _allCollectedFonts.Find(f => f.Name.Equals(fontName, StringComparison.OrdinalIgnoreCase));
+            }
         }
 
         OkPressed = true;

--- a/tests/UI/Features/Assa/FontCollectorAddFontToFooterTests.cs
+++ b/tests/UI/Features/Assa/FontCollectorAddFontToFooterTests.cs
@@ -1,0 +1,103 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Assa.FontCollector;
+
+namespace UITests.Features.Assa;
+
+/// <summary>
+/// Tests the [Fonts] footer writing used when a collected font is picked in the
+/// ASSA styles dialog. The payload need not be a real font - only splitting and
+/// UU-encoding are exercised (3-divisible sizes round-trip exactly).
+/// </summary>
+public class FontCollectorAddFontToFooterTests
+{
+    private static byte[] MakeBytes(int count, byte seed)
+    {
+        var bytes = new byte[count];
+        for (var i = 0; i < count; i++)
+        {
+            bytes[i] = (byte)(seed + i);
+        }
+
+        return bytes;
+    }
+
+    [Fact]
+    public void EmptyFooter_CreatesFontsSection()
+    {
+        var bytes = MakeBytes(300, 7);
+
+        var footer = FontCollectorViewModel.AddFontToFooter(null, "/some/folder/MyFont.ttf", bytes);
+
+        var fonts = FontCollectorViewModel.GetEmbeddedFonts(footer);
+        Assert.Single(fonts);
+        Assert.Equal("MyFont.ttf", fonts[0].FileName);
+        Assert.Equal(bytes, fonts[0].Bytes);
+        Assert.Contains("[Fonts]" + Environment.NewLine, footer); // the save gate in AdvancedSubStationAlpha.ToText
+    }
+
+    [Fact]
+    public void ExistingFontsSection_AppendsAndKeepsExistingFont()
+    {
+        var bytes1 = MakeBytes(99, 3);
+        var bytes2 = MakeBytes(81, 90);
+        var footer = "[Fonts]\r\nfontname: one.ttf\r\n" + UUEncoding.UUEncode(bytes1);
+
+        footer = FontCollectorViewModel.AddFontToFooter(footer, "two.otf", bytes2);
+
+        var fonts = FontCollectorViewModel.GetEmbeddedFonts(footer);
+        Assert.Equal(2, fonts.Count);
+        Assert.Equal("one.ttf", fonts[0].FileName);
+        Assert.Equal(bytes1, fonts[0].Bytes);
+        Assert.Equal("two.otf", fonts[1].FileName);
+        Assert.Equal(bytes2, fonts[1].Bytes);
+    }
+
+    [Fact]
+    public void FontsSectionFollowedByGraphics_InsertsBeforeGraphics()
+    {
+        var bytes1 = MakeBytes(99, 3);
+        var bytes2 = MakeBytes(81, 90);
+        var footer =
+            "[Fonts]\r\n" +
+            "fontname: one.ttf\r\n" + UUEncoding.UUEncode(bytes1) + "\r\n" +
+            "\r\n" +
+            "[Graphics]\r\n" +
+            "filename: img.png\r\nAAAA\r\n";
+
+        footer = FontCollectorViewModel.AddFontToFooter(footer, "two.otf", bytes2);
+
+        var fonts = FontCollectorViewModel.GetEmbeddedFonts(footer);
+        Assert.Equal(2, fonts.Count);
+        Assert.Equal("one.ttf", fonts[0].FileName);
+        Assert.Equal("two.otf", fonts[1].FileName);
+        Assert.True(footer.IndexOf("two.otf", StringComparison.Ordinal) < footer.IndexOf("[Graphics]", StringComparison.Ordinal));
+        Assert.Contains("filename: img.png", footer);
+    }
+
+    [Fact]
+    public void GraphicsOnlyFooter_AddsFontsSectionFirst()
+    {
+        var bytes = MakeBytes(300, 7);
+        var footer = "[Graphics]\r\nfilename: img.png\r\nAAAA\r\n";
+
+        footer = FontCollectorViewModel.AddFontToFooter(footer, "MyFont.ttf", bytes);
+
+        var fonts = FontCollectorViewModel.GetEmbeddedFonts(footer);
+        Assert.Single(fonts);
+        Assert.Equal("MyFont.ttf", fonts[0].FileName);
+        Assert.True(footer.IndexOf("[Fonts]", StringComparison.Ordinal) < footer.IndexOf("[Graphics]", StringComparison.Ordinal));
+        Assert.Contains("filename: img.png", footer);
+    }
+
+    [Fact]
+    public void SameFileName_IsNotAttachedTwice()
+    {
+        var bytes = MakeBytes(300, 7);
+        var footer = FontCollectorViewModel.AddFontToFooter(null, "MyFont.ttf", bytes);
+
+        var unchanged = FontCollectorViewModel.AddFontToFooter(footer, "/other/path/MyFont.ttf", MakeBytes(60, 1));
+
+        Assert.Equal(footer, unchanged);
+        Assert.Single(FontCollectorViewModel.GetEmbeddedFonts(unchanged));
+    }
+}


### PR DESCRIPTION
### What

When a font is picked from the **Collected fonts** tab in the ASSA styles font picker, its font file is now embedded in the subtitle's `[Fonts]` attachment section. A collected font need not be installed on the machine that plays the subtitle, so embedding it makes the file self-contained. Picks from the **Installed fonts** tab are unchanged (nothing is embedded).

### How

- `PickFontNameViewModel` exposes a `SelectedCollectedFont` result property, set on OK only when the pick came from the collected-fonts tab.
- New static helper `FontCollectorViewModel.AddFontToFooter` UU-encodes the font file into the footer's `[Fonts]` section:
  - creates the section if missing, placing it before `[Graphics]` (same order the attachments window writes);
  - appends at the end of an existing `[Fonts]` section otherwise;
  - never attaches the same file name twice, so repeated picks don't duplicate the attachment.
- `AssaStylesViewModel.PickFontName` wires the two together. The dialog works on a subtitle copy and the footer is only copied back on OK, so cancelling the styles dialog discards the embedding - consistent with the dialog's other changes.

### Tests

5 new tests in `FontCollectorAddFontToFooterTests` cover round-tripping through the existing `GetEmbeddedFonts` parser, insertion before `[Graphics]`, graphics-only footers, the duplicate-file-name guard, and that the output matches the `"[Fonts]" + Environment.NewLine` gate `AdvancedSubStationAlpha.ToText` uses when deciding to write the footer. Full UI suite: 1259 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)