### PR TITLE
Batch convert: "Embed fonts" ASSA function + font collector "Embed fonts in subtitle" button

### DIFF
--- a/src/ui/Features/Assa/AssaStylesViewModel.cs
+++ b/src/ui/Features/Assa/AssaStylesViewModel.cs
@@ -7,7 +7,6 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
-using Nikse.SubtitleEdit.Features.Assa.FontCollector;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Shared.PickFontName;
 using Nikse.SubtitleEdit.Features.Shared.PromptTextBox;
@@ -260,7 +259,7 @@ public partial class AssaStylesViewModel : ObservableObject, IClosingCleanup
         try
         {
             var bytes = File.ReadAllBytes(font.FilePath);
-            _subtitle.Footer = FontCollectorViewModel.AddFontToFooter(_subtitle.Footer, font.FilePath, bytes);
+            _subtitle.Footer = AssaFontEmbedder.AddFontToFooter(_subtitle.Footer, font.FilePath, bytes);
         }
         catch (Exception exception)
         {

--- a/src/ui/Features/Assa/FontCollector/FontCollectorViewModel.cs
+++ b/src/ui/Features/Assa/FontCollector/FontCollectorViewModel.cs
@@ -16,7 +16,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -39,8 +38,10 @@ public partial class FontCollectorViewModel : ObservableObject
 
     public Window? Window { get; set; }
 
-    private static readonly Regex FontNameTagRegex = new(@"\\fn(?<name>[^\\}]+)", RegexOptions.Compiled);
+    /// <summary>Set when "Embed fonts in subtitle" ran - the caller applies it to the real subtitle.</summary>
+    public string? UpdatedFooter { get; private set; }
 
+    private Subtitle _subtitle;
     private readonly IFolderHelper _folderHelper;
     private readonly IFileHelper _fileHelper;
     private readonly CancellationTokenSource _cancellationTokenSource = new();
@@ -53,10 +54,12 @@ public partial class FontCollectorViewModel : ObservableObject
         InstalledFontNames = new ObservableCollection<string>();
         CollectedFonts = new ObservableCollection<CollectedFont>();
         StatusText = string.Empty;
+        _subtitle = new Subtitle();
     }
 
     public void Initialize(Subtitle subtitle)
     {
+        _subtitle = subtitle;
         CollectFontNames(subtitle);
         MatchEmbeddedFonts(subtitle.Footer);
         IsScanning = true;
@@ -73,7 +76,7 @@ public partial class FontCollectorViewModel : ObservableObject
     /// </summary>
     internal void MatchEmbeddedFonts(string? footer)
     {
-        foreach (var (fileName, bytes) in GetEmbeddedFonts(footer))
+        foreach (var (fileName, bytes) in AssaFontEmbedder.GetEmbeddedFonts(footer))
         {
             try
             {
@@ -105,149 +108,6 @@ public partial class FontCollectorViewModel : ObservableObject
                 Se.LogError(exception, "Font collector could not read embedded font " + fileName);
             }
         }
-    }
-
-    /// <summary>Parses the [Fonts] attachment section of an ASSA footer into decoded font files.</summary>
-    internal static List<(string FileName, byte[] Bytes)> GetEmbeddedFonts(string? footer)
-    {
-        var result = new List<(string, byte[])>();
-        if (string.IsNullOrEmpty(footer))
-        {
-            return result;
-        }
-
-        var inFonts = false;
-        var fileName = string.Empty;
-        var content = new StringBuilder();
-
-        void Flush()
-        {
-            if (fileName.Length > 0 && content.Length > 0)
-            {
-                try
-                {
-                    result.Add((Path.GetFileName(fileName), UUEncoding.UUDecode(content.ToString().Trim())));
-                }
-                catch
-                {
-                    // a malformed attachment should not break the collector
-                }
-            }
-
-            content.Clear();
-            fileName = string.Empty;
-        }
-
-        foreach (var line in footer.SplitToLines())
-        {
-            var s = line.Trim();
-            if (s.Equals("[Fonts]", StringComparison.OrdinalIgnoreCase))
-            {
-                Flush();
-                inFonts = true;
-            }
-            else if (s == "[Script Info]" || s == "[V4+ Styles]" || s == "[V4 Styles]" || s == "[Events]" ||
-                     s.Equals("[Graphics]", StringComparison.OrdinalIgnoreCase))
-            {
-                // Only exact section headers end the fonts section - the UU-style encoding's
-                // alphabet ('!'..'`') contains '[', so encoded lines can start with it.
-                Flush();
-                inFonts = false;
-            }
-            else if (!inFonts)
-            {
-                // skip
-            }
-            else if (s.StartsWith("fontname:", StringComparison.OrdinalIgnoreCase) ||
-                     s.StartsWith("filename:", StringComparison.OrdinalIgnoreCase))
-            {
-                Flush();
-                fileName = s.Remove(0, 9).Trim();
-            }
-            else if (s.Length == 0)
-            {
-                Flush();
-            }
-            else
-            {
-                content.AppendLine(s);
-            }
-        }
-
-        Flush();
-        return result;
-    }
-
-    /// <summary>
-    /// Adds a font file to the [Fonts] attachment section of an ASSA footer, creating the
-    /// section if needed. A font whose file name is already attached is not added twice.
-    /// </summary>
-    internal static string AddFontToFooter(string? footer, string fontFilePath, byte[] fontBytes)
-    {
-        var fileName = Path.GetFileName(fontFilePath);
-        if (GetEmbeddedFonts(footer).Any(f => f.FileName.Equals(fileName, StringComparison.OrdinalIgnoreCase)))
-        {
-            return footer!;
-        }
-
-        var entryLines = new List<string> { "fontname: " + fileName };
-        entryLines.AddRange(UUEncoding.UUEncode(fontBytes).Trim().SplitToLines());
-
-        if (string.IsNullOrWhiteSpace(footer))
-        {
-            return "[Fonts]" + Environment.NewLine + string.Join(Environment.NewLine, entryLines) + Environment.NewLine;
-        }
-
-        var lines = footer.SplitToLines();
-        var result = new List<string>(lines.Count + entryLines.Count + 2);
-        var inFonts = false;
-        var inserted = false;
-
-        void InsertEntry()
-        {
-            while (result.Count > 0 && result[^1].Trim().Length == 0)
-            {
-                result.RemoveAt(result.Count - 1);
-            }
-
-            result.AddRange(entryLines);
-            inserted = true;
-        }
-
-        foreach (var line in lines)
-        {
-            var s = line.Trim();
-            if (s.Equals("[Fonts]", StringComparison.OrdinalIgnoreCase))
-            {
-                inFonts = true;
-            }
-            else if (inFonts && !inserted &&
-                     (s == "[Script Info]" || s == "[V4+ Styles]" || s == "[V4 Styles]" || s == "[Events]" ||
-                      s.Equals("[Graphics]", StringComparison.OrdinalIgnoreCase) ||
-                      s.Equals("[Aegisub Extradata]", StringComparison.OrdinalIgnoreCase)))
-            {
-                // Only exact section headers end the fonts section (see GetEmbeddedFonts).
-                InsertEntry();
-                result.Add(string.Empty);
-                inFonts = false;
-            }
-
-            result.Add(line);
-        }
-
-        if (inFonts && !inserted)
-        {
-            InsertEntry();
-        }
-
-        if (!inserted)
-        {
-            // No [Fonts] section - fonts go first, same order the attachments window writes.
-            return "[Fonts]" + Environment.NewLine + string.Join(Environment.NewLine, entryLines) +
-                   Environment.NewLine + Environment.NewLine + footer.TrimStart();
-        }
-
-        return string.Join(Environment.NewLine, result) + Environment.NewLine;
     }
 
     /// <summary>Fills the "Installed fonts" and "Collected fonts" tabs.</summary>
@@ -505,7 +365,7 @@ public partial class FontCollectorViewModel : ObservableObject
         {
             usedStyleNames.Add(string.IsNullOrEmpty(paragraph.Extra) ? "Default" : paragraph.Extra);
 
-            foreach (Match match in FontNameTagRegex.Matches(paragraph.Text))
+            foreach (Match match in AssaFontEmbedder.FontNameTagRegex.Matches(paragraph.Text))
             {
                 AddUsage(match.Groups["name"].Value, string.Format(Se.Language.Assa.FontCollectorInlineLineX, paragraph.Number));
             }
@@ -532,60 +392,30 @@ public partial class FontCollectorViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Scans the platform font directories and matches each font file's family/face names
-    /// against the collected font names. Skia has no file-path API, so files are read
-    /// directly; both the typographic family name and the Win32/GDI face name (what libass
-    /// matches) are checked.
+    /// Scans the font folders (via <see cref="FontHelper.FindFontFiles"/>) and posts a UI
+    /// update for every file whose family/face name matches a collected font name.
     /// </summary>
     private void ScanSystemFonts(List<FontCollectorItem> items, CancellationToken cancellationToken)
     {
         try
         {
+            // One name per item, and FindFontFiles reports each (name, file) match only
+            // once, so posted adds cannot double up on an item.
             var wanted = items.ToDictionary(i => i.FontName, i => i, StringComparer.OrdinalIgnoreCase);
-
-            // item.FoundFiles is only mutated in posted UI updates, so it cannot be used for
-            // duplicate checks on this thread - the family and face name of a regular font are
-            // usually identical, and both would queue an Add before either has run.
-            var found = items.ToDictionary(i => i, i => new HashSet<string>(StringComparer.OrdinalIgnoreCase));
-
-            foreach (var fontFile in EnumerateFontFiles())
+            FontHelper.FindFontFiles(wanted.Keys, cancellationToken, (name, file) =>
             {
-                if (cancellationToken.IsCancellationRequested)
+                var item = wanted[name];
+                Dispatcher.UIThread.Post(() =>
                 {
-                    return;
-                }
-
-                // A collection (.ttc/.otc) holds several faces; plain files have one at index 0.
-                for (var index = 0; index < 30; index++)
-                {
-                    using var typeface = SKTypeface.FromFile(fontFile, index);
-                    if (typeface == null)
+                    item.FoundFiles.Add(file);
+                    item.UpdateFileDisplay();
+                    item.Status = Se.Language.Assa.FontCollectorFound;
+                    if (item == SelectedFontItem)
                     {
-                        break;
+                        UpdateFontPreview(); // the selected row just became previewable
                     }
-
-                    var names = new[] { typeface.FamilyName, FontHelper.GetLibAssaFontName(typeface) };
-                    foreach (var name in names)
-                    {
-                        if (!string.IsNullOrEmpty(name) &&
-                            wanted.TryGetValue(name, out var item) &&
-                            found[item].Add(fontFile))
-                        {
-                            var file = fontFile;
-                            Dispatcher.UIThread.Post(() =>
-                            {
-                                item.FoundFiles.Add(file);
-                                item.UpdateFileDisplay();
-                                item.Status = Se.Language.Assa.FontCollectorFound;
-                                if (item == SelectedFontItem)
-                                {
-                                    UpdateFontPreview(); // the selected row just became previewable
-                                }
-                            });
-                        }
-                    }
-                }
-            }
+                });
+            });
         }
         catch (Exception exception)
         {
@@ -609,42 +439,6 @@ public partial class FontCollectorViewModel : ObservableObject
                 UpdateFontPreview(); // the selected row may only now have found files
             });
         }
-    }
-
-    private static IEnumerable<string> EnumerateFontFiles()
-    {
-        return GetFontFolders().SelectMany(FontHelper.EnumerateFontFiles);
-    }
-
-    private static List<string> GetFontFolders()
-    {
-        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-
-        // SE's own font collection is scanned first, so a collected font counts as
-        // found even when it is not installed on the system.
-        var folders = new List<string> { Se.FontsFolder };
-
-        if (OperatingSystem.IsWindows())
-        {
-            folders.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "Fonts"));
-            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            folders.Add(Path.Combine(localAppData, "Microsoft", "Windows", "Fonts"));
-        }
-        else if (OperatingSystem.IsMacOS())
-        {
-            folders.Add("/System/Library/Fonts");
-            folders.Add("/Library/Fonts");
-            folders.Add(Path.Combine(home, "Library", "Fonts"));
-        }
-        else
-        {
-            folders.Add("/usr/share/fonts");
-            folders.Add("/usr/local/share/fonts");
-            folders.Add(Path.Combine(home, ".fonts"));
-            folders.Add(Path.Combine(home, ".local", "share", "fonts"));
-        }
-
-        return folders;
     }
 
     /// <summary>
@@ -732,35 +526,97 @@ public partial class FontCollectorViewModel : ObservableObject
 
     private static List<string> FindSystemFontFiles(string fontName)
     {
-        var files = new List<string>();
-        foreach (var folder in GetFontFolders().Skip(1)) // index 0 is Se.FontsFolder - already collected
-        {
-            foreach (var fontFile in FontHelper.EnumerateFontFiles(folder))
-            {
-                for (var index = 0; index < 30; index++)
-                {
-                    using var typeface = SKTypeface.FromFile(fontFile, index);
-                    if (typeface == null)
-                    {
-                        break;
-                    }
-
-                    if ((fontName.Equals(typeface.FamilyName, StringComparison.OrdinalIgnoreCase) ||
-                         fontName.Equals(FontHelper.GetLibAssaFontName(typeface), StringComparison.OrdinalIgnoreCase)) &&
-                        !files.Contains(fontFile, StringComparer.OrdinalIgnoreCase))
-                    {
-                        files.Add(fontFile);
-                    }
-                }
-            }
-        }
-
-        return files;
+        // Skip(1): index 0 is Se.FontsFolder - already collected.
+        return FontHelper.FindFontFiles([fontName], CancellationToken.None,
+                folders: FontHelper.GetFontFolders().Skip(1))
+            .Values.SelectMany(f => f).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
     }
 
     private List<string> GetFoundFontFiles()
     {
         return FontItems.SelectMany(i => i.FoundFiles).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    /// <summary>
+    /// Embeds the needed fonts that were found on disk into the subtitle's [Fonts]
+    /// attachment section, after a confirmation showing count, file names and sizes.
+    /// The updated footer reaches the caller via <see cref="UpdatedFooter"/>.
+    /// </summary>
+    [RelayCommand]
+    private async Task EmbedFontsInSubtitle()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var embeddedFileNames = new HashSet<string>(
+            AssaFontEmbedder.GetEmbeddedFonts(_subtitle.Footer).Select(f => f.FileName),
+            StringComparer.OrdinalIgnoreCase);
+        var files = GetFoundFontFiles()
+            .Where(f => !embeddedFileNames.Contains(Path.GetFileName(f)))
+            .ToList();
+        if (files.Count == 0)
+        {
+            await MessageBox.Show(Window, Se.Language.Assa.FontCollectorTitle, Se.Language.Assa.FontCollectorNoFontsToEmbed, MessageBoxButtons.OK);
+            return;
+        }
+
+        long totalBytes = 0;
+        var fileLines = new List<string>();
+        foreach (var file in files)
+        {
+            var length = new FileInfo(file).Length;
+            totalBytes += length;
+            fileLines.Add($"{Path.GetFileName(file)} ({Utilities.FormatBytesToDisplayFileSize(length)})");
+        }
+
+        const int maxListedFiles = 12;
+        if (fileLines.Count > maxListedFiles)
+        {
+            var more = fileLines.Count - maxListedFiles;
+            fileLines = fileLines.Take(maxListedFiles).ToList();
+            fileLines.Add(string.Format(Se.Language.Assa.FontCollectorAndXMoreFonts, more));
+        }
+
+        var encodedBytes = (long)(totalBytes * 4.0 / 3.0); // the UU-style encoding stores 3 bytes as 4 characters
+        var message = string.Format(
+            Se.Language.Assa.FontCollectorEmbedXFontsSizeYZPrompt,
+            files.Count,
+            Utilities.FormatBytesToDisplayFileSize(totalBytes),
+            Utilities.FormatBytesToDisplayFileSize(encodedBytes),
+            string.Join(Environment.NewLine, fileLines));
+
+        var answer = await MessageBox.Show(Window, Se.Language.Assa.FontCollectorTitle, message, MessageBoxButtons.YesNo);
+        if (answer != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        var footer = _subtitle.Footer;
+        var count = 0;
+        foreach (var file in files)
+        {
+            try
+            {
+                footer = AssaFontEmbedder.AddFontToFooter(footer, file, await File.ReadAllBytesAsync(file));
+                count++;
+            }
+            catch (Exception exception)
+            {
+                Se.LogError(exception, "Font collector could not embed " + file);
+            }
+        }
+
+        _subtitle.Footer = footer;
+        UpdatedFooter = footer;
+        MatchEmbeddedFonts(footer); // the rows just became "Embedded"
+
+        await MessageBox.Show(
+            Window,
+            Se.Language.Assa.FontCollectorTitle,
+            string.Format(Se.Language.Assa.FontCollectorXFontFilesEmbedded, count),
+            MessageBoxButtons.OK);
     }
 
     private async Task CopyFontsTo(List<string> files, string folder, List<(string FileName, byte[] Bytes)>? embeddedFonts = null)

--- a/src/ui/Features/Assa/FontCollector/FontCollectorWindow.cs
+++ b/src/ui/Features/Assa/FontCollector/FontCollectorWindow.cs
@@ -139,9 +139,11 @@ public class FontCollectorWindow : Window
             [!TextBlock.TextProperty] = new Binding(nameof(vm.StatusText)),
         };
 
+        var buttonEmbedFonts = UiUtil.MakeButton(Se.Language.Assa.FontCollectorEmbedFontsDotDotDot, vm.EmbedFontsInSubtitleCommand)
+            .WithIconLeft(IconNames.Paperclip);
         var buttonCopyToSeFolder = UiUtil.MakeButton(Se.Language.Assa.FontCollectorCopyFontsToSeFontsFolder, vm.CopyFontsToSeFontsFolderCommand)
             .WithIconLeft(IconNames.FormatFont);
-        var buttonBar = UiUtil.MakeButtonBar(buttonCopyToSeFolder);
+        var buttonBar = UiUtil.MakeButtonBar(buttonEmbedFonts, buttonCopyToSeFolder);
 
         var grid = new Grid
         {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1435,10 +1435,16 @@ public partial class MainViewModel :
             return;
         }
 
-        await ShowDialogAsync<Features.Assa.FontCollector.FontCollectorWindow, Features.Assa.FontCollector.FontCollectorViewModel>(vm =>
+        var result = await ShowDialogAsync<Features.Assa.FontCollector.FontCollectorWindow, Features.Assa.FontCollector.FontCollectorViewModel>(vm =>
         {
             vm.Initialize(GetUpdateSubtitle());
         });
+
+        if (result.UpdatedFooter != null)
+        {
+            // "Embed fonts in subtitle" was used (and already confirmed in the dialog).
+            _subtitle.Footer = result.UpdatedFooter;
+        }
     }
 
     [RelayCommand]

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertConfig.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertConfig.cs
@@ -42,6 +42,7 @@ public class BatchConvertConfig
     public SplitBreakLongLinesSettings SplitBreakLongLines { get; set; }
     public AssaChangeResolutionSettings AssaChangeResolution { get; set; }
     public AssaChangeStyleSettings AssaChangeStyle { get; set; }
+    public AssaEmbedFontsSettings AssaEmbedFonts { get; set; }
     public MergeShortLinesSettings MergeShortLines { get; set; }
     public ApplyDurationLimitsSettings ApplyDurationLimits { get; set; }
     public AutoBalanceLinesSettings AutoBalanceLines { get; set; }
@@ -79,6 +80,7 @@ public class BatchConvertConfig
         SplitBreakLongLines = new SplitBreakLongLinesSettings();
         AssaChangeResolution = new AssaChangeResolutionSettings();
         AssaChangeStyle = new AssaChangeStyleSettings();
+        AssaEmbedFonts = new AssaEmbedFontsSettings();
         MergeShortLines = new MergeShortLinesSettings();
         ApplyDurationLimits = new ApplyDurationLimitsSettings();
         AutoBalanceLines = new AutoBalanceLinesSettings();
@@ -314,6 +316,11 @@ public class BatchConvertConfig
             ToStyle = string.Empty;
             ImportedStyleHeader = string.Empty;
         }
+    }
+
+    public class AssaEmbedFontsSettings
+    {
+        public bool IsActive { get; set; }
     }
 
     public class MergeShortLinesSettings

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertFunction.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertFunction.cs
@@ -57,6 +57,7 @@ public partial class BatchConvertFunction : ObservableObject
             MakeFunction(BatchConvertFunctionType.AutoTranslate, Se.Language.General.AutoTranslate, ViewAutoTranslate.Make(vm), activeFunctions),
             MakeFunction(BatchConvertFunctionType.AssaChangeResolution, Se.Language.Assa.ResolutionResamplerTitle, ViewAssaChangeResolution.Make(vm), activeFunctions),
             MakeFunction(BatchConvertFunctionType.AssaChangeStyle, Se.Language.Tools.BatchConvert.AssaChangeStyleTitle, ViewAssaChangeStyle.Make(vm), activeFunctions),
+            MakeFunction(BatchConvertFunctionType.AssaEmbedFonts, Se.Language.Tools.BatchConvert.AssaEmbedFontsTitle, ViewAssaEmbedFonts.Make(vm), activeFunctions),
             MakeFunction(BatchConvertFunctionType.MergeShortLines, Se.Language.Tools.MergeShortLines.Title, ViewMergeShortLines.Make(vm), activeFunctions),
             MakeFunction(BatchConvertFunctionType.ApplyDurationLimits, Se.Language.Tools.ApplyDurationLimits.Title, ViewApplyDurationLimits.Make(vm), activeFunctions),
             MakeFunction(BatchConvertFunctionType.AutoBalanceLines, Se.Language.General.AutoBalanceLines, ViewAutoBalanceLines.Make(vm), activeFunctions),

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertFunctionType.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertFunctionType.cs
@@ -23,6 +23,7 @@ public enum BatchConvertFunctionType
     RemoveLineBreaks,
     AssaChangeResolution,
     AssaChangeStyle,
+    AssaEmbedFonts,
     MergeShortLines,
     ApplyDurationLimits,
     AutoBalanceLines,

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -2171,6 +2171,11 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
                 TrimUnusedStyles = AssaChangeStyleTrimUnusedStyles,
             },
 
+            AssaEmbedFonts = new BatchConvertConfig.AssaEmbedFontsSettings
+            {
+                IsActive = activeFunctions.Contains(BatchConvertFunctionType.AssaEmbedFonts),
+            },
+
             MergeShortLines = new BatchConvertConfig.MergeShortLinesSettings
             {
                 IsActive = activeFunctions.Contains(BatchConvertFunctionType.MergeShortLines),

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -64,6 +64,10 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
     private BatchConvertConfig _config;
     private List<SubtitleFormat> _subtitleFormats;
 
+    // Font-name -> found font files, shared across the items of one batch run so the
+    // "Embed fonts" function does not rescan the font folders for every file.
+    private readonly Dictionary<string, List<string>> _fontFilesCache = new(StringComparer.OrdinalIgnoreCase);
+
     public SubtitleFormat Format { get; set; } = new SubRip();
 
     public Encoding Encoding { get; set; } = Encoding.UTF8;
@@ -92,6 +96,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
     {
         _config = config;
         _subtitleFormats = SubtitleFormatHelper.GetSubtitleFormatsWithFavoritesAtTop();
+        _fontFilesCache.Clear();
     }
 
     /// <summary>
@@ -1535,6 +1540,13 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                         s.Header = _config.AssaHeader;
                         s.Footer = _config.AssaFooter;
                     }
+                }
+
+                // After the header/footer template above, so fonts are collected from the
+                // styles that are actually written and the embedding is not overwritten.
+                if (_config.AssaEmbedFonts.IsActive)
+                {
+                    AssaFontEmbedder.EmbedUsedFonts(s, cancellationToken, _fontFilesCache);
                 }
             }
 

--- a/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAssaEmbedFonts.cs
+++ b/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAssaEmbedFonts.cs
@@ -1,0 +1,39 @@
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Tools.BatchConvert.FunctionViews;
+
+public static class ViewAssaEmbedFonts
+{
+    public static Control Make(BatchConvertViewModel vm)
+    {
+        var labelHeader = new Label
+        {
+            Content = Se.Language.Tools.BatchConvert.AssaEmbedFontsTitle,
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.Bold,
+        };
+
+        var labelInfo = new TextBlock
+        {
+            Text = Se.Language.Tools.BatchConvert.AssaEmbedFontsInfo,
+            Opacity = 0.7,
+            FontStyle = FontStyle.Italic,
+            TextWrapping = TextWrapping.Wrap,
+        };
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Margin = new Avalonia.Thickness(10),
+            Spacing = 10,
+            Children =
+            {
+                labelHeader,
+                labelInfo,
+            }
+        };
+    }
+}

--- a/src/ui/Logic/AssaFontEmbedder.cs
+++ b/src/ui/Logic/AssaFontEmbedder.cs
@@ -1,0 +1,322 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Logic.Config;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Headless helpers for the [Fonts] attachment section of ASSA files: parsing embedded
+/// fonts, embedding font files, and finding/embedding the fonts a subtitle actually uses.
+/// Shared by the font collector, the ASSA styles dialog and batch convert.
+/// </summary>
+public static class AssaFontEmbedder
+{
+    /// <summary>Matches inline <c>\fn</c> font-name override tags.</summary>
+    public static readonly Regex FontNameTagRegex = new(@"\\fn(?<name>[^\\}]+)", RegexOptions.Compiled);
+
+    /// <summary>Parses the [Fonts] attachment section of an ASSA footer into decoded font files.</summary>
+    public static List<(string FileName, byte[] Bytes)> GetEmbeddedFonts(string? footer)
+    {
+        var result = new List<(string, byte[])>();
+        if (string.IsNullOrEmpty(footer))
+        {
+            return result;
+        }
+
+        var inFonts = false;
+        var fileName = string.Empty;
+        var content = new StringBuilder();
+
+        void Flush()
+        {
+            if (fileName.Length > 0 && content.Length > 0)
+            {
+                try
+                {
+                    result.Add((Path.GetFileName(fileName), UUEncoding.UUDecode(content.ToString().Trim())));
+                }
+                catch
+                {
+                    // a malformed attachment should not break the caller
+                }
+            }
+
+            content.Clear();
+            fileName = string.Empty;
+        }
+
+        foreach (var line in footer.SplitToLines())
+        {
+            var s = line.Trim();
+            if (s.Equals("[Fonts]", StringComparison.OrdinalIgnoreCase))
+            {
+                Flush();
+                inFonts = true;
+            }
+            else if (s == "[Script Info]" || s == "[V4+ Styles]" || s == "[V4 Styles]" || s == "[Events]" ||
+                     s.Equals("[Graphics]", StringComparison.OrdinalIgnoreCase))
+            {
+                // Only exact section headers end the fonts section - the UU-style encoding's
+                // alphabet ('!'..'`') contains '[', so encoded lines can start with it.
+                Flush();
+                inFonts = false;
+            }
+            else if (!inFonts)
+            {
+                // skip
+            }
+            else if (s.StartsWith("fontname:", StringComparison.OrdinalIgnoreCase) ||
+                     s.StartsWith("filename:", StringComparison.OrdinalIgnoreCase))
+            {
+                Flush();
+                fileName = s.Remove(0, 9).Trim();
+            }
+            else if (s.Length == 0)
+            {
+                Flush();
+            }
+            else
+            {
+                content.AppendLine(s);
+            }
+        }
+
+        Flush();
+        return result;
+    }
+
+    /// <summary>
+    /// Adds a font file to the [Fonts] attachment section of an ASSA footer, creating the
+    /// section if needed. A font whose file name is already attached is not added twice.
+    /// </summary>
+    public static string AddFontToFooter(string? footer, string fontFilePath, byte[] fontBytes)
+    {
+        var fileName = Path.GetFileName(fontFilePath);
+        if (GetEmbeddedFonts(footer).Any(f => f.FileName.Equals(fileName, StringComparison.OrdinalIgnoreCase)))
+        {
+            return footer!;
+        }
+
+        var entryLines = new List<string> { "fontname: " + fileName };
+        entryLines.AddRange(UUEncoding.UUEncode(fontBytes).Trim().SplitToLines());
+
+        if (string.IsNullOrWhiteSpace(footer))
+        {
+            return "[Fonts]" + Environment.NewLine + string.Join(Environment.NewLine, entryLines) + Environment.NewLine;
+        }
+
+        var lines = footer.SplitToLines();
+        var result = new List<string>(lines.Count + entryLines.Count + 2);
+        var inFonts = false;
+        var inserted = false;
+
+        void InsertEntry()
+        {
+            while (result.Count > 0 && result[^1].Trim().Length == 0)
+            {
+                result.RemoveAt(result.Count - 1);
+            }
+
+            result.AddRange(entryLines);
+            inserted = true;
+        }
+
+        foreach (var line in lines)
+        {
+            var s = line.Trim();
+            if (s.Equals("[Fonts]", StringComparison.OrdinalIgnoreCase))
+            {
+                inFonts = true;
+            }
+            else if (inFonts && !inserted &&
+                     (s == "[Script Info]" || s == "[V4+ Styles]" || s == "[V4 Styles]" || s == "[Events]" ||
+                      s.Equals("[Graphics]", StringComparison.OrdinalIgnoreCase) ||
+                      s.Equals("[Aegisub Extradata]", StringComparison.OrdinalIgnoreCase)))
+            {
+                // Only exact section headers end the fonts section (see GetEmbeddedFonts).
+                InsertEntry();
+                result.Add(string.Empty);
+                inFonts = false;
+            }
+
+            result.Add(line);
+        }
+
+        if (inFonts && !inserted)
+        {
+            InsertEntry();
+        }
+
+        if (!inserted)
+        {
+            // No [Fonts] section - fonts go first, same order the attachments window writes.
+            return "[Fonts]" + Environment.NewLine + string.Join(Environment.NewLine, entryLines) +
+                   Environment.NewLine + Environment.NewLine + footer.TrimStart();
+        }
+
+        return string.Join(Environment.NewLine, result) + Environment.NewLine;
+    }
+
+    /// <summary>
+    /// Collects the font names an ASSA renderer would need: fonts of styles that are
+    /// actually used by lines, plus inline <c>\fn</c> overrides.
+    /// </summary>
+    public static List<string> GetUsedFontNames(Subtitle subtitle)
+    {
+        var result = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        void Add(string fontName)
+        {
+            fontName = fontName.Trim().TrimStart('@'); // "@" prefix = vertical variant of the same font
+            if (fontName.Length > 0 && seen.Add(fontName))
+            {
+                result.Add(fontName);
+            }
+        }
+
+        var header = subtitle.Header ?? string.Empty;
+        var usedStyleNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var paragraph in subtitle.Paragraphs)
+        {
+            usedStyleNames.Add(string.IsNullOrEmpty(paragraph.Extra) ? "Default" : paragraph.Extra.TrimStart('*'));
+
+            foreach (Match match in FontNameTagRegex.Matches(paragraph.Text))
+            {
+                Add(match.Groups["name"].Value);
+            }
+        }
+
+        if (header.Contains("[V4", StringComparison.Ordinal))
+        {
+            foreach (var styleName in AdvancedSubStationAlpha.GetStylesFromHeader(header))
+            {
+                if (usedStyleNames.Contains(styleName))
+                {
+                    Add(AdvancedSubStationAlpha.GetSsaStyle(styleName, header).FontName);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Embeds the font files the subtitle uses (styles + inline <c>\fn</c> tags) into its
+    /// [Fonts] attachment section. Fonts already embedded are skipped; the rest are searched
+    /// in SE's Fonts folder and the system font folders. Returns the number of files embedded.
+    /// An optional cache (font name -> found files) lets batch runs skip repeated disk scans.
+    /// </summary>
+    public static int EmbedUsedFonts(Subtitle subtitle, CancellationToken cancellationToken, IDictionary<string, List<string>>? fontFileCache = null)
+    {
+        var usedNames = GetUsedFontNames(subtitle);
+        if (usedNames.Count == 0)
+        {
+            return 0;
+        }
+
+        var embeddedNames = GetEmbeddedFontNames(subtitle.Footer);
+        var missingNames = usedNames.Where(n => !embeddedNames.Contains(n)).ToList();
+        if (missingNames.Count == 0)
+        {
+            return 0;
+        }
+
+        var found = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        var namesToScan = new List<string>();
+        foreach (var name in missingNames)
+        {
+            if (fontFileCache != null && fontFileCache.TryGetValue(name, out var cached))
+            {
+                found[name] = cached;
+            }
+            else
+            {
+                namesToScan.Add(name);
+            }
+        }
+
+        if (namesToScan.Count > 0)
+        {
+            foreach (var kvp in FontHelper.FindFontFiles(namesToScan, cancellationToken))
+            {
+                found[kvp.Key] = kvp.Value;
+                if (fontFileCache != null)
+                {
+                    fontFileCache[kvp.Key] = kvp.Value;
+                }
+            }
+        }
+
+        var embeddedFileNames = new HashSet<string>(
+            GetEmbeddedFonts(subtitle.Footer).Select(f => f.FileName), StringComparer.OrdinalIgnoreCase);
+        var footer = subtitle.Footer;
+        var count = 0;
+        foreach (var file in found.Values.SelectMany(f => f).Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            if (!embeddedFileNames.Add(Path.GetFileName(file)))
+            {
+                continue;
+            }
+
+            try
+            {
+                footer = AddFontToFooter(footer, file, File.ReadAllBytes(file));
+                count++;
+            }
+            catch (Exception exception)
+            {
+                Se.LogError(exception, "Could not embed font " + file);
+            }
+        }
+
+        subtitle.Footer = footer;
+        return count;
+    }
+
+    /// <summary>
+    /// The family and libass face names of the fonts a footer already carries as
+    /// [Fonts] attachments - those need not be embedded again.
+    /// </summary>
+    private static HashSet<string> GetEmbeddedFontNames(string? footer)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (fileName, bytes) in GetEmbeddedFonts(footer))
+        {
+            try
+            {
+                using var data = SKData.CreateCopy(bytes);
+                for (var index = 0; index < 30; index++)
+                {
+                    using var typeface = SKTypeface.FromData(data, index);
+                    if (typeface == null)
+                    {
+                        break;
+                    }
+
+                    names.Add(typeface.FamilyName);
+                    names.Add(FontHelper.GetLibAssaFontName(typeface));
+                }
+            }
+            catch (Exception exception)
+            {
+                Se.LogError(exception, "Could not read embedded font " + fileName);
+            }
+        }
+
+        return names;
+    }
+}

--- a/src/ui/Logic/Config/Language/Assa/LanguageAssa.cs
+++ b/src/ui/Logic/Config/Language/Assa/LanguageAssa.cs
@@ -59,6 +59,11 @@ public class LanguageAssa
     public string Attachments { get; set; }
     public string FontCollectorNoFontsToCopy { get; set; }
     public string FontCollectorXFontFilesCopiedToY { get; set; }
+    public string FontCollectorEmbedFontsDotDotDot { get; set; }
+    public string FontCollectorEmbedXFontsSizeYZPrompt { get; set; }
+    public string FontCollectorAndXMoreFonts { get; set; }
+    public string FontCollectorNoFontsToEmbed { get; set; }
+    public string FontCollectorXFontFilesEmbedded { get; set; }
 
     // Resolution Resampler
     public string ResolutionResamplerTitle { get; set; }
@@ -276,6 +281,11 @@ public class LanguageAssa
         Attachments = "Attachments";
         FontCollectorNoFontsToCopy = "No font files found to copy.";
         FontCollectorXFontFilesCopiedToY = "{0} font file(s) copied to {1}";
+        FontCollectorEmbedFontsDotDotDot = "Embed fonts in subtitle...";
+        FontCollectorEmbedXFontsSizeYZPrompt = "Embed {0} font file(s) in the subtitle?\n\nTotal font size: {1} - about {2} as text in the ASSA file.\n\n{3}";
+        FontCollectorAndXMoreFonts = "...and {0} more";
+        FontCollectorNoFontsToEmbed = "No new fonts to embed - the needed fonts are already embedded or were not found.";
+        FontCollectorXFontFilesEmbedded = "{0} font file(s) embedded in the subtitle.";
         ResolutionResamplerTitle = "Change resolution";
         ResolutionResamplerSourceRes = "Source resolution";
         ResolutionResamplerTargetRes = "Target resolution";

--- a/src/ui/Logic/Config/Language/Tools/LanguageBatchConvert.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageBatchConvert.cs
@@ -37,6 +37,8 @@ public class LanguageBatchConvert
     public string FontSizeBounceIn { get; set; }
     public string AssaChangeResolutionOnlyAppliesToAssa { get; set; }
     public string AssaChangeStyleTitle { get; set; }
+    public string AssaEmbedFontsTitle { get; set; }
+    public string AssaEmbedFontsInfo { get; set; }
     public string AdjustImageColorsTitle { get; set; }
     public string AdjustImageColorsInfo { get; set; }
     public string AssaChangeStyleFromStyle { get; set; }
@@ -77,6 +79,8 @@ public class LanguageBatchConvert
         FontSizeBounceIn = "Font size bounce in";
         AssaChangeResolutionOnlyAppliesToAssa = "Only applies to Advanced Sub Station Alpha (ASSA) subtitles";
         AssaChangeStyleTitle = "Change style";
+        AssaEmbedFontsTitle = "Embed fonts";
+        AssaEmbedFontsInfo = "Embeds the font files the subtitle uses (styles and inline font tags) in the [Fonts] section of the output file. Fonts are searched in the Subtitle Edit fonts folder and the system font folders; fonts already embedded are kept. Only applies when the target format is Advanced Sub Station Alpha.";
         AdjustImageColorsTitle = "Adjust image brightness/alpha/color";
         AdjustImageColorsInfo = "Only applies when converting image-based subtitles to an image-based format (e.g. Blu-ray sup to Blu-ray sup).";
         AssaChangeStyleFromStyle = "Change style from";

--- a/src/ui/Logic/FontHelper.cs
+++ b/src/ui/Logic/FontHelper.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 
 namespace Nikse.SubtitleEdit.Logic;
 
@@ -84,6 +85,106 @@ public static class FontHelper
 
     /// <summary>Family names of the fonts collected in SE's own Fonts folder, sorted.</summary>
     public static List<string> GetFontsFolderFontNames() => GetFontsFolderFonts().Select(f => f.Name).ToList();
+
+    /// <summary>
+    /// The folders font files are searched in: SE's own Fonts folder first, so a collected
+    /// font counts as found even when it is not installed, then the platform font folders.
+    /// </summary>
+    public static List<string> GetFontFolders()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        var folders = new List<string> { Se.FontsFolder };
+
+        if (OperatingSystem.IsWindows())
+        {
+            folders.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "Fonts"));
+            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            folders.Add(Path.Combine(localAppData, "Microsoft", "Windows", "Fonts"));
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            folders.Add("/System/Library/Fonts");
+            folders.Add("/Library/Fonts");
+            folders.Add(Path.Combine(home, "Library", "Fonts"));
+        }
+        else
+        {
+            folders.Add("/usr/share/fonts");
+            folders.Add("/usr/local/share/fonts");
+            folders.Add(Path.Combine(home, ".fonts"));
+            folders.Add(Path.Combine(home, ".local", "share", "fonts"));
+        }
+
+        return folders;
+    }
+
+    /// <summary>
+    /// Scans font folders and matches each font file's family/face names against
+    /// <paramref name="fontNames"/>. Skia has no file-path API, so files are read directly;
+    /// both the typographic family name and the Win32/GDI face name (what libass matches)
+    /// are checked. Returns a map from font name to the matching files; on a completed scan
+    /// every requested name has an entry (empty when not found), on cancellation only the
+    /// names matched so far do. <paramref name="onFound"/> fires once per (name, file) match,
+    /// on the scanning thread. <paramref name="folders"/> defaults to <see cref="GetFontFolders"/>.
+    /// </summary>
+    public static Dictionary<string, List<string>> FindFontFiles(
+        ICollection<string> fontNames,
+        CancellationToken cancellationToken,
+        Action<string, string>? onFound = null,
+        IEnumerable<string>? folders = null)
+    {
+        var wanted = new HashSet<string>(fontNames, StringComparer.OrdinalIgnoreCase);
+        var result = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var fontFile in (folders ?? GetFontFolders()).SelectMany(EnumerateFontFiles))
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return result; // incomplete - no negative entries for names not scanned to the end
+            }
+
+            // A collection (.ttc/.otc) holds several faces; plain files have one at index 0.
+            for (var index = 0; index < 30; index++)
+            {
+                using var typeface = SKTypeface.FromFile(fontFile, index);
+                if (typeface == null)
+                {
+                    break;
+                }
+
+                foreach (var name in new[] { typeface.FamilyName, GetLibAssaFontName(typeface) })
+                {
+                    if (string.IsNullOrEmpty(name) || !wanted.Contains(name))
+                    {
+                        continue;
+                    }
+
+                    if (!result.TryGetValue(name, out var files))
+                    {
+                        files = new List<string>();
+                        result[name] = files;
+                    }
+
+                    if (!files.Contains(fontFile, StringComparer.OrdinalIgnoreCase))
+                    {
+                        files.Add(fontFile);
+                        onFound?.Invoke(name, fontFile);
+                    }
+                }
+            }
+        }
+
+        foreach (var name in wanted)
+        {
+            if (!result.ContainsKey(name))
+            {
+                result[name] = new List<string>();
+            }
+        }
+
+        return result;
+    }
 
     public static List<string> GetSystemFonts()
     {

--- a/tests/UI/Features/Assa/FontCollectorAddFontToFooterTests.cs
+++ b/tests/UI/Features/Assa/FontCollectorAddFontToFooterTests.cs
@@ -1,5 +1,5 @@
 using Nikse.SubtitleEdit.Core.Common;
-using Nikse.SubtitleEdit.Features.Assa.FontCollector;
+using Nikse.SubtitleEdit.Logic;
 
 namespace UITests.Features.Assa;
 
@@ -26,9 +26,9 @@ public class FontCollectorAddFontToFooterTests
     {
         var bytes = MakeBytes(300, 7);
 
-        var footer = FontCollectorViewModel.AddFontToFooter(null, "/some/folder/MyFont.ttf", bytes);
+        var footer = AssaFontEmbedder.AddFontToFooter(null, "/some/folder/MyFont.ttf", bytes);
 
-        var fonts = FontCollectorViewModel.GetEmbeddedFonts(footer);
+        var fonts = AssaFontEmbedder.GetEmbeddedFonts(footer);
         Assert.Single(fonts);
         Assert.Equal("MyFont.ttf", fonts[0].FileName);
         Assert.Equal(bytes, fonts[0].Bytes);
@@ -42,9 +42,9 @@ public class FontCollectorAddFontToFooterTests
         var bytes2 = MakeBytes(81, 90);
         var footer = "[Fonts]\r\nfontname: one.ttf\r\n" + UUEncoding.UUEncode(bytes1);
 
-        footer = FontCollectorViewModel.AddFontToFooter(footer, "two.otf", bytes2);
+        footer = AssaFontEmbedder.AddFontToFooter(footer, "two.otf", bytes2);
 
-        var fonts = FontCollectorViewModel.GetEmbeddedFonts(footer);
+        var fonts = AssaFontEmbedder.GetEmbeddedFonts(footer);
         Assert.Equal(2, fonts.Count);
         Assert.Equal("one.ttf", fonts[0].FileName);
         Assert.Equal(bytes1, fonts[0].Bytes);
@@ -64,9 +64,9 @@ public class FontCollectorAddFontToFooterTests
             "[Graphics]\r\n" +
             "filename: img.png\r\nAAAA\r\n";
 
-        footer = FontCollectorViewModel.AddFontToFooter(footer, "two.otf", bytes2);
+        footer = AssaFontEmbedder.AddFontToFooter(footer, "two.otf", bytes2);
 
-        var fonts = FontCollectorViewModel.GetEmbeddedFonts(footer);
+        var fonts = AssaFontEmbedder.GetEmbeddedFonts(footer);
         Assert.Equal(2, fonts.Count);
         Assert.Equal("one.ttf", fonts[0].FileName);
         Assert.Equal("two.otf", fonts[1].FileName);
@@ -80,9 +80,9 @@ public class FontCollectorAddFontToFooterTests
         var bytes = MakeBytes(300, 7);
         var footer = "[Graphics]\r\nfilename: img.png\r\nAAAA\r\n";
 
-        footer = FontCollectorViewModel.AddFontToFooter(footer, "MyFont.ttf", bytes);
+        footer = AssaFontEmbedder.AddFontToFooter(footer, "MyFont.ttf", bytes);
 
-        var fonts = FontCollectorViewModel.GetEmbeddedFonts(footer);
+        var fonts = AssaFontEmbedder.GetEmbeddedFonts(footer);
         Assert.Single(fonts);
         Assert.Equal("MyFont.ttf", fonts[0].FileName);
         Assert.True(footer.IndexOf("[Fonts]", StringComparison.Ordinal) < footer.IndexOf("[Graphics]", StringComparison.Ordinal));
@@ -93,11 +93,11 @@ public class FontCollectorAddFontToFooterTests
     public void SameFileName_IsNotAttachedTwice()
     {
         var bytes = MakeBytes(300, 7);
-        var footer = FontCollectorViewModel.AddFontToFooter(null, "MyFont.ttf", bytes);
+        var footer = AssaFontEmbedder.AddFontToFooter(null, "MyFont.ttf", bytes);
 
-        var unchanged = FontCollectorViewModel.AddFontToFooter(footer, "/other/path/MyFont.ttf", MakeBytes(60, 1));
+        var unchanged = AssaFontEmbedder.AddFontToFooter(footer, "/other/path/MyFont.ttf", MakeBytes(60, 1));
 
         Assert.Equal(footer, unchanged);
-        Assert.Single(FontCollectorViewModel.GetEmbeddedFonts(unchanged));
+        Assert.Single(AssaFontEmbedder.GetEmbeddedFonts(unchanged));
     }
 }

--- a/tests/UI/Features/Assa/FontCollectorEmbeddedFontsTests.cs
+++ b/tests/UI/Features/Assa/FontCollectorEmbeddedFontsTests.cs
@@ -1,5 +1,5 @@
 using Nikse.SubtitleEdit.Core.Common;
-using Nikse.SubtitleEdit.Features.Assa.FontCollector;
+using Nikse.SubtitleEdit.Logic;
 
 namespace UITests.Features.Assa;
 
@@ -26,7 +26,7 @@ public class FontCollectorEmbeddedFontsTests
         var bytes = MakeBytes(300, 7);
         var footer = "[Fonts]\r\nfontname: MyFont_0.ttf\r\n" + UUEncoding.UUEncode(bytes);
 
-        var fonts = FontCollectorViewModel.GetEmbeddedFonts(footer);
+        var fonts = AssaFontEmbedder.GetEmbeddedFonts(footer);
 
         Assert.Single(fonts);
         Assert.Equal("MyFont_0.ttf", fonts[0].FileName);
@@ -47,7 +47,7 @@ public class FontCollectorEmbeddedFontsTests
             "[Graphics]\r\n" +
             "filename: not-a-font.png\r\nAAAA\r\n";
 
-        var fonts = FontCollectorViewModel.GetEmbeddedFonts(footer);
+        var fonts = AssaFontEmbedder.GetEmbeddedFonts(footer);
 
         Assert.Equal(2, fonts.Count);
         Assert.Equal("one.ttf", fonts[0].FileName);
@@ -59,8 +59,8 @@ public class FontCollectorEmbeddedFontsTests
     [Fact]
     public void GetEmbeddedFonts_EmptyOrFontlessFooter_ReturnsNothing()
     {
-        Assert.Empty(FontCollectorViewModel.GetEmbeddedFonts(null));
-        Assert.Empty(FontCollectorViewModel.GetEmbeddedFonts(string.Empty));
-        Assert.Empty(FontCollectorViewModel.GetEmbeddedFonts("[Graphics]\r\nfilename: img.png\r\nAAAA\r\n"));
+        Assert.Empty(AssaFontEmbedder.GetEmbeddedFonts(null));
+        Assert.Empty(AssaFontEmbedder.GetEmbeddedFonts(string.Empty));
+        Assert.Empty(AssaFontEmbedder.GetEmbeddedFonts("[Graphics]\r\nfilename: img.png\r\nAAAA\r\n"));
     }
 }

--- a/tests/UI/Features/Assa/FontCollectorEmbeddedMatchTests.cs
+++ b/tests/UI/Features/Assa/FontCollectorEmbeddedMatchTests.cs
@@ -82,7 +82,7 @@ public class FontCollectorEmbeddedMatchTests
         var (familyName, bytes) = font.Value;
         var footer = "[Fonts]\r\nfontname: embedded_0.ttf\r\n" + UUEncoding.UUEncode(bytes) + "\r\n";
 
-        var embedded = FontCollectorViewModel.GetEmbeddedFonts(footer);
+        var embedded = Nikse.SubtitleEdit.Logic.AssaFontEmbedder.GetEmbeddedFonts(footer);
 
         Assert.Single(embedded);
         Assert.True(embedded[0].Bytes.Length >= bytes.Length, $"decoded {embedded[0].Bytes.Length} < original {bytes.Length}");

--- a/tests/UI/Logic/AssaFontEmbedderTests.cs
+++ b/tests/UI/Logic/AssaFontEmbedderTests.cs
@@ -1,0 +1,82 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// Tests the headless used-font collection behind the batch convert "Embed fonts"
+/// function (and shared with the font collector).
+/// </summary>
+public class AssaFontEmbedderTests
+{
+    private static Subtitle LoadAssa()
+    {
+        var text =
+            "[Script Info]\r\n" +
+            "ScriptType: v4.00+\r\n" +
+            "\r\n" +
+            "[V4+ Styles]\r\n" +
+            "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding\r\n" +
+            "Style: Default,Arial,20,&H00FFFFFF,&H0000FFFF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1\r\n" +
+            "Style: Fancy,My Fancy Font,20,&H00FFFFFF,&H0000FFFF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1\r\n" +
+            "Style: Unused,Unused Font,20,&H00FFFFFF,&H0000FFFF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1\r\n" +
+            "\r\n" +
+            "[Events]\r\n" +
+            "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\r\n" +
+            "Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,Hello\r\n" +
+            "Dialogue: 0,0:00:04.00,0:00:06.00,Fancy,,0,0,0,,World\r\n" +
+            "Dialogue: 0,0:00:07.00,0:00:09.00,Default,,0,0,0,,{\\fn@Inline Font}tagged\r\n";
+
+        var subtitle = new Subtitle();
+        new AdvancedSubStationAlpha().LoadSubtitle(subtitle, text.SplitToLines(), string.Empty);
+        return subtitle;
+    }
+
+    [Fact]
+    public void GetUsedFontNames_ReturnsUsedStyleAndInlineFonts()
+    {
+        var names = AssaFontEmbedder.GetUsedFontNames(LoadAssa());
+
+        Assert.Contains("Arial", names);
+        Assert.Contains("My Fancy Font", names);
+        Assert.Contains("Inline Font", names); // "@" (vertical variant) prefix is trimmed
+    }
+
+    [Fact]
+    public void GetUsedFontNames_SkipsFontsOfUnusedStyles()
+    {
+        var names = AssaFontEmbedder.GetUsedFontNames(LoadAssa());
+
+        Assert.DoesNotContain("Unused Font", names);
+    }
+
+    [Fact]
+    public void GetUsedFontNames_NoHeader_ReturnsOnlyInlineFonts()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("{\\fnSome Font}Hi", 0, 1000));
+
+        var names = AssaFontEmbedder.GetUsedFontNames(subtitle);
+
+        Assert.Equal(new[] { "Some Font" }, names);
+    }
+
+    [Fact]
+    public void FindFontFiles_CompletedScan_HasNegativeEntryForUnknownFont()
+    {
+        var folder = Directory.CreateTempSubdirectory();
+        try
+        {
+            var result = FontHelper.FindFontFiles(
+                ["No Such Font"], CancellationToken.None, folders: [folder.FullName]);
+
+            Assert.Single(result);
+            Assert.Empty(result["No Such Font"]);
+        }
+        finally
+        {
+            folder.Delete(recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Builds on #13166's `AddFontToFooter`.

### Batch convert: "Embed fonts" function

New function in the ASSA group: when the target format is Advanced Sub Station Alpha, the font files the subtitle uses (style fonts of lines actually present, plus inline `\fn` tags) are embedded in the `[Fonts]` section of the output file.

- Runs at save time, **after** the ASSA header/footer template override, so fonts are collected from the styles that are actually written and the template footer cannot clobber the embedding. This also makes it work for e.g. SRT → ASSA conversions with a style template.
- Fonts already embedded in the source are detected (family + libass face names of the attachments) and kept, and the same file name is never attached twice.
- Fonts are searched in SE's Fonts folder (the font collector's collection) first, then the system font folders. A per-run name→files cache means the folders are scanned once per batch, not once per file.

### Font collector: "Embed fonts in subtitle..." button

On the current-subtitle tab next to "Copy to font collector". It gathers the needed fonts that were found on disk (skipping ones already attached) and shows a confirmation dialog with the metadata: file count, per-file names and sizes (up to 12 listed), total size on disk, and the ~4/3-larger UU-encoded size the ASSA file will grow by. On Yes the fonts are embedded, the rows flip to "Embedded", and the main window applies the updated footer when the collector closes.

### Shared, reusable embed logic

To make this possible headlessly (and reusable for future work like MKV font attaching or "collect to zip"), the pure logic moved out of the view models:

- New `Logic/AssaFontEmbedder`: `GetEmbeddedFonts` / `AddFontToFooter` (moved from `FontCollectorViewModel`), plus new `GetUsedFontNames` and `EmbedUsedFonts`.
- `FontHelper` gains `GetFontFolders` (moved from the collector) and `FindFontFiles` (name → matching font files, checking both the typographic family name and the Win32/GDI face name libass matches). The collector's background scan and its installed-font copy now run on this shared scan, with the same incremental UI updates as before.

### Tests

4 new tests (used-font-name collection incl. `@`-prefix trimming and unused-style skipping; `FindFontFiles` negative-entry contract) plus the existing footer tests repointed at `AssaFontEmbedder`. Full UI suite: 1263 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)