### PR TITLE
Fix video playback on Windows ARM64 (native ARM64 libmpv)

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -324,6 +324,8 @@ jobs:
         run: |
           Invoke-WebRequest -Uri "https://github.com/SubtitleEdit/support-files/releases/download/libmpv-2026-04-21/libmpv2-win64.zip" -OutFile "libmpv2-64.zip"
           Expand-Archive -Path "libmpv2-64.zip" -DestinationPath "libmpv-temp"
+          Invoke-WebRequest -Uri "https://github.com/SubtitleEdit/support-files/releases/download/libmpv-2026-04-21/libmpv2-win-arm64.zip" -OutFile "libmpv2-arm64.zip"
+          Expand-Archive -Path "libmpv2-arm64.zip" -DestinationPath "libmpv-arm64-temp"
 
       - name: Publish Windows x64 app
         run: |
@@ -350,6 +352,8 @@ jobs:
             -p:FileVersion=$env:APP_VER_FULL `
             -p:InformationalVersion=$env:APP_VER_DISPLAY `
             -o ./publish/windows-arm64
+          # Must be the native ARM64 libmpv build — an ARM64 process cannot load the x64 DLL (issue #12087).
+          Copy-Item "libmpv-arm64-temp/libmpv-2.dll" "./publish/windows-arm64/"
           Get-ChildItem -Path "./publish/windows-arm64" -Filter "*.pdb" -Recurse -File | Remove-Item -Force
 
       # - name: Setup WiX

--- a/src/ui/Logic/Download/LibMpvDownloadService .cs
+++ b/src/ui/Logic/Download/LibMpvDownloadService .cs
@@ -18,6 +18,7 @@ public class LibMpvDownloadService : ILibMpvDownloadService
 {
     private readonly HttpClient _httpClient;
     private const string WindowsUrl = "https://github.com/SubtitleEdit/support-files/releases/download/libmpv-2026-04-21/libmpv2-win64.zip";
+    private const string WindowsUrlArm = "https://github.com/SubtitleEdit/support-files/releases/download/libmpv-2026-04-21/libmpv2-win-arm64.zip";
     private const string MacUrl = "";
     private const string MacUrlArm = "";
 
@@ -30,7 +31,11 @@ public class LibMpvDownloadService : ILibMpvDownloadService
     {
         if (OperatingSystem.IsWindows())
         {
-            return WindowsUrl;
+            // A native ARM64 process cannot load an x64 DLL, so the download
+            // must match the process architecture (issue #12087).
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? WindowsUrlArm
+                : WindowsUrl;
         }
 
         throw new PlatformNotSupportedException("Unsupported platform for libmpv download." + Environment.NewLine +


### PR DESCRIPTION
Fixes the Windows ARM64 playback problem reported in https://github.com/SubtitleEdit/subtitleedit/issues/12087#issuecomment-5168001725.

## Root cause

The Windows ARM64 zip shipped without `libmpv-2.dll`, so on first run the app prompted to download mpv — but `LibMpvDownloadService` always fetched `libmpv2-win64.zip`, an **x64** DLL. A native ARM64 process cannot load an x64 DLL, so the download "succeeded" but playback never worked. The x64 build works on the same machine because the whole process runs under x64 emulation (and never prompts, since its zip bundles the DLL).

## Changes

- **build-ui.yml**: download `libmpv2-win-arm64.zip` and bundle the native ARM64 `libmpv-2.dll` in the Windows ARM64 zip, matching the x64 package — so ARM64 users get working playback out of the box with no download prompt.
- **LibMpvDownloadService**: pick the Windows download URL by `RuntimeInformation.ProcessArchitecture`, so the in-app mpv download also works on ARM64 (dev builds, or if the bundled DLL is deleted).

The new `libmpv2-win-arm64.zip` asset has been uploaded to the `libmpv-2026-04-21` release in SubtitleEdit/support-files. It is repackaged from `mpv-dev-aarch64-20260421-git-5921fe5.7z` from shinchiro/mpv-winbuild-cmake — the **same upstream tag (20260421)** the existing x64 zip was built from, so both architectures ship the same mpv version. The DLL was verified as `PE32+ executable (DLL) (GUI) Aarch64` before packaging. SHA-256 of the zip: `f479f61b0ad09df3597ce919c2f661c6f6a4f37d8d84a22acc2c18354b5066d9`.

## Testing

- UI project builds with the service change.
- Not verified on real Windows ARM64 hardware (none available) — verification via the next beta with the reporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)