### PR TITLE
Add D-Cinema interop properties dialog

### DIFF
--- a/src/libse/Forms/DcPropertiesInterop.cs
+++ b/src/libse/Forms/DcPropertiesInterop.cs
@@ -1,0 +1,97 @@
+﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System.IO;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Core.Forms
+{
+    public class DcPropertiesInterop
+    {
+        public string GenerateIdAuto { get; set; }
+        public string ReelNumber { get; set; }
+        public string Language { get; set; }
+        public string FontId { get; set; }
+        public string FontUri { get; set; }
+        public string FontColor { get; set; }
+        public string Effect { get; set; }
+        public string EffectColor { get; set; }
+        public string FontSize { get; set; }
+        public string TopBottomMargin { get; set; }
+        public string FadeUpTime { get; set; }
+        public string FadeDownTime { get; set; }
+        public string ZPosition { get; set; }
+
+        public bool Save(string fileName)
+        {
+            if (string.IsNullOrEmpty(fileName))
+            {
+                return false;
+            }
+
+            try
+            {
+                File.WriteAllText(fileName, SerializeExportImageSub(), Encoding.UTF8);
+            }
+            catch
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private string SerializeExportImageSub()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("{");
+            sb.AppendLine("  \"generateIdAuto\": \"" + Json.EncodeJsonText(GenerateIdAuto) + "\",");
+            sb.AppendLine("  \"reelNumber\": \"" + Json.EncodeJsonText(ReelNumber) + "\",");
+            sb.AppendLine("  \"language\": \"" + Json.EncodeJsonText(Language) + "\",");
+            sb.AppendLine("  \"fontId\": \"" + Json.EncodeJsonText(FontId) + "\",");
+            sb.AppendLine("  \"fontUri\": \"" + Json.EncodeJsonText(FontUri) + "\",");
+            sb.AppendLine("  \"fontColor\": \"" + Json.EncodeJsonText(FontColor) + "\",");
+            sb.AppendLine("  \"effect\": \"" + Json.EncodeJsonText(Effect) + "\",");
+            sb.AppendLine("  \"effectColor\": \"" + Json.EncodeJsonText(EffectColor) + "\",");
+            sb.AppendLine("  \"fontSize\": \"" + Json.EncodeJsonText(FontSize) + "\",");
+            sb.AppendLine("  \"topBottomMargin\": \"" + Json.EncodeJsonText(TopBottomMargin) + "\",");
+            sb.AppendLine("  \"fadeUpTime\": \"" + Json.EncodeJsonText(FadeUpTime) + "\",");
+            sb.AppendLine("  \"fadeDownTime\": \"" + Json.EncodeJsonText(FadeDownTime) + "\",");
+            sb.AppendLine("  \"zPosition\": \"" + Json.EncodeJsonText(ZPosition) + "\"");
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+
+        public bool Load(string fileName)
+        {
+            if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
+            {
+                return false;
+            }
+
+            try
+            {
+                var json = File.ReadAllText(fileName, Encoding.UTF8);
+                var jp = new SeJsonParser();
+                GenerateIdAuto = jp.GetFirstObject(json, "generateIdAuto");
+                ReelNumber = jp.GetFirstObject(json, "reelNumber");
+                Language = jp.GetFirstObject(json, "language");
+                FontId = jp.GetFirstObject(json, "fontId");
+                FontUri = jp.GetFirstObject(json, "fontUri");
+                FontColor = jp.GetFirstObject(json, "fontColor");
+                Effect = jp.GetFirstObject(json, "effect");
+                EffectColor = jp.GetFirstObject(json, "effectColor");
+                FontSize = jp.GetFirstObject(json, "fontSize");
+                TopBottomMargin = jp.GetFirstObject(json, "topBottomMargin");
+                FadeUpTime = jp.GetFirstObject(json, "fadeUpTime");
+                FadeDownTime = jp.GetFirstObject(json, "fadeDownTime");
+                ZPosition = jp.GetFirstObject(json, "zPosition");
+            }
+            catch
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1275,6 +1275,8 @@
       "fadeUpTime": "Fade up time",
       "fadeDownTime": "Fade down time",
       "frames": "Frames",
+      "zPosition": "Z-position",
+      "zPositionHelp": "Positive numbers move text away, negative numbers move text closer, if z-position is zero then it's 2D",
       "export": "Export..."
     },
     "compare": "Compare",

--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -21,6 +21,7 @@ using Nikse.SubtitleEdit.Features.Files.ExportCustomTextFormat;
 using Nikse.SubtitleEdit.Features.Files.ExportImageBased;
 using Nikse.SubtitleEdit.Features.Files.ExportPac;
 using Nikse.SubtitleEdit.Features.Files.ExportPlainText;
+using Nikse.SubtitleEdit.Features.Files.FormatProperties.DCinemaInteropProperties;
 using Nikse.SubtitleEdit.Features.Files.FormatProperties.DCinemaSmpteProperties;
 using Nikse.SubtitleEdit.Features.Files.FormatProperties.ItunesTimedTextProperties;
 using Nikse.SubtitleEdit.Features.Files.FormatProperties.TimedText10Properties;
@@ -358,6 +359,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<CustomContinuationStyleViewModel>();
         collection.AddTransient<CutVideoViewModel>();
         collection.AddTransient<VideoOcrViewModel>();
+        collection.AddTransient<DCinemaInteropPropertiesViewModel>();
         collection.AddTransient<DCinemaSmptePropertiesViewModel>();
         collection.AddTransient<DownloadFfmpegViewModel>();
         collection.AddTransient<DownloadGoogleLensOcrViewModel>();

--- a/src/ui/Features/Files/FormatProperties/DcinemaInteropProperties/DCinemaInteropPropertiesViewModel.cs
+++ b/src/ui/Features/Files/FormatProperties/DcinemaInteropProperties/DCinemaInteropPropertiesViewModel.cs
@@ -1,0 +1,361 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Forms;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Shared.ColorPicker;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Files.FormatProperties.DCinemaInteropProperties;
+
+public partial class DCinemaInteropPropertiesViewModel : ObservableObject
+{
+    [ObservableProperty] private string _windowTitle = string.Empty;
+
+    [ObservableProperty] private ObservableCollection<string> _languages = null!;
+    [ObservableProperty] private ObservableCollection<string> _fontEffects = null!;
+
+    [ObservableProperty] private bool _generateIdAuto;
+    [ObservableProperty] private string _subtitleId = string.Empty;
+    [ObservableProperty] private string _movieTitle = string.Empty;
+    [ObservableProperty] private int _reelNumber;
+    [ObservableProperty] private string _selectedLanguage = string.Empty;
+
+    [ObservableProperty] private string _fontId = string.Empty;
+    [ObservableProperty] private string _fontUri = string.Empty;
+    [ObservableProperty] private Color _fontColor;
+    [ObservableProperty] private string _selectedFontEffect = string.Empty;
+    [ObservableProperty] private Color _fontEffectColor;
+    [ObservableProperty] private int _fontSize;
+    [ObservableProperty] private int _topBottomMargin;
+    [ObservableProperty] private decimal _zPosition;
+    [ObservableProperty] private int _fadeUpTime;
+    [ObservableProperty] private int _fadeDownTime;
+
+    public Window? Window { get; set; }
+
+    public Subtitle Subtitle { get; set; } = new();
+
+    public bool OkPressed { get; private set; }
+
+    private readonly IFileHelper _fileHelper;
+    private readonly IWindowService _windowService;
+
+    public DCinemaInteropPropertiesViewModel(IFileHelper fileHelper, IWindowService windowService)
+    {
+        _fileHelper = fileHelper;
+        _windowService = windowService;
+
+        // Interop's <Language> element holds the English culture name, not an ISO code
+        var languages = CultureInfo.GetCultures(CultureTypes.NeutralCultures)
+            .Select(x => x.EnglishName)
+            .OrderBy(l => l)
+            .ToList();
+        _languages = new ObservableCollection<string>(languages);
+
+        _fontEffects = new ObservableCollection<string> { "None", "Border", "Shadow" };
+    }
+
+    private void LoadSettings()
+    {
+        var ss = Se.Settings.File.DCinemaSmpte;
+
+        GenerateIdAuto = ss.DCinemaAutoGenerateSubtitleId;
+
+        SubtitleId = !string.IsNullOrEmpty(ss.CurrentDCinemaSubtitleId)
+            ? ss.CurrentDCinemaSubtitleId
+            : DCinemaInterop.GenerateId();
+
+        ReelNumber = int.TryParse(ss.CurrentDCinemaReelNumber, out int reelNumber) && reelNumber > 0
+            ? reelNumber
+            : 1;
+
+        MovieTitle = ss.CurrentDCinemaMovieTitle ?? string.Empty;
+        SelectedLanguage = !string.IsNullOrEmpty(ss.CurrentDCinemaLanguage)
+            ? ss.CurrentDCinemaLanguage
+            : "English";
+
+        FontId = !string.IsNullOrEmpty(ss.CurrentDCinemaFontId)
+            ? ss.CurrentDCinemaFontId
+            : "Font1";
+
+        FontUri = !string.IsNullOrEmpty(ss.CurrentDCinemaFontUri)
+            ? ss.CurrentDCinemaFontUri
+            : ss.DCinemaFontFile;
+
+        FontColor = ColorFromString(ss.CurrentDCinemaFontColor, Colors.White);
+
+        if (ss.CurrentDCinemaFontEffect?.Equals("border", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            SelectedFontEffect = "Border";
+        }
+        else if (ss.CurrentDCinemaFontEffect?.Equals("shadow", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            SelectedFontEffect = "Shadow";
+        }
+        else
+        {
+            SelectedFontEffect = "None";
+        }
+
+        FontEffectColor = ColorFromString(ss.CurrentDCinemaFontEffectColor, Colors.Black);
+
+        FontSize = ss.CurrentDCinemaFontSize > 0
+            ? ss.CurrentDCinemaFontSize
+            : ss.DCinemaFontSize > 0 ? ss.DCinemaFontSize : 42;
+
+        TopBottomMargin = ss.DCinemaBottomMargin > 0 ? ss.DCinemaBottomMargin : 8;
+        ZPosition = (decimal)ss.DCinemaZPosition is >= -10 and <= 10 ? (decimal)ss.DCinemaZPosition : 0;
+        FadeUpTime = ss.DCinemaFadeUpTime;
+        FadeDownTime = ss.DCinemaFadeDownTime;
+    }
+
+    private void SaveSettings()
+    {
+        var ss = Se.Settings.File.DCinemaSmpte;
+
+        ss.DCinemaAutoGenerateSubtitleId = GenerateIdAuto;
+
+        ss.CurrentDCinemaSubtitleId = SubtitleId;
+        ss.CurrentDCinemaMovieTitle = MovieTitle;
+        ss.CurrentDCinemaReelNumber = ReelNumber.ToString();
+        ss.CurrentDCinemaLanguage = SelectedLanguage;
+        ss.CurrentDCinemaFontId = FontId;
+        ss.CurrentDCinemaFontUri = FontUri;
+
+        ss.CurrentDCinemaFontColor = ColorToString(FontColor);
+
+        if (SelectedFontEffect?.Equals("Border", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            ss.CurrentDCinemaFontEffect = "border";
+        }
+        else if (SelectedFontEffect?.Equals("Shadow", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            ss.CurrentDCinemaFontEffect = "shadow";
+        }
+        else
+        {
+            ss.CurrentDCinemaFontEffect = string.Empty;
+        }
+
+        ss.CurrentDCinemaFontEffectColor = ColorToString(FontEffectColor);
+        ss.CurrentDCinemaFontSize = FontSize;
+
+        ss.DCinemaFontSize = FontSize;
+        ss.DCinemaBottomMargin = TopBottomMargin;
+        ss.DCinemaZPosition = (double)ZPosition;
+        ss.DCinemaFadeUpTime = FadeUpTime;
+        ss.DCinemaFadeDownTime = FadeDownTime;
+
+        Se.SaveSettings();
+    }
+
+    private static Color ColorFromString(string colorString, Color defaultColor)
+    {
+        if (string.IsNullOrEmpty(colorString))
+        {
+            return defaultColor;
+        }
+
+        try
+        {
+            return colorString.FromHexToColor();
+        }
+        catch
+        {
+            return defaultColor;
+        }
+    }
+
+    private string ColorToString(Color color)
+    {
+        return color.FromColorToHex();
+    }
+
+    [RelayCommand]
+    private void GenerateSubtitleId()
+    {
+        SubtitleId = DCinemaInterop.GenerateId();
+    }
+
+    [RelayCommand]
+    private async Task ChooseFontColor()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var vm = await _windowService.ShowDialogAsync<ColorPickerWindow, ColorPickerViewModel>(
+            Window, viewModel => { viewModel.SelectedColor = FontColor; });
+
+        if (vm.OkPressed)
+        {
+            FontColor = vm.SelectedColor;
+        }
+    }
+
+    [RelayCommand]
+    private async Task ChooseFontEffectColor()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var vm = await _windowService.ShowDialogAsync<ColorPickerWindow, ColorPickerViewModel>(
+            Window, viewModel => { viewModel.SelectedColor = FontEffectColor; });
+
+        if (vm.OkPressed)
+        {
+            FontEffectColor = vm.SelectedColor;
+        }
+    }
+
+    [RelayCommand]
+    private async Task Import()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var fileName = await _fileHelper.PickOpenFile(Window, "Import D-Cinema properties", "D-Cinema profile", ".DCinema-interop-profile");
+        if (fileName == null)
+        {
+            return;
+        }
+
+        try
+        {
+            var importer = new DcPropertiesInterop();
+            if (importer.Load(fileName))
+            {
+                GenerateIdAuto = Convert.ToBoolean(importer.GenerateIdAuto, CultureInfo.InvariantCulture);
+
+                if (int.TryParse(importer.ReelNumber, out var reelNumber))
+                {
+                    ReelNumber = reelNumber;
+                }
+
+                SelectedLanguage = importer.Language ?? "English";
+                FontId = importer.FontId ?? "Font1";
+                FontUri = importer.FontUri ?? string.Empty;
+                FontColor = ColorFromString(importer.FontColor, Colors.White);
+                SelectedFontEffect = importer.Effect ?? "None";
+                FontEffectColor = ColorFromString(importer.EffectColor, Colors.Black);
+
+                if (int.TryParse(importer.FontSize, out var fontSize))
+                {
+                    FontSize = fontSize;
+                }
+
+                if (int.TryParse(importer.TopBottomMargin, out var margin))
+                {
+                    TopBottomMargin = margin;
+                }
+
+                if (int.TryParse(importer.FadeUpTime, out var fadeUp))
+                {
+                    FadeUpTime = fadeUp;
+                }
+
+                if (int.TryParse(importer.FadeDownTime, out var fadeDown))
+                {
+                    FadeDownTime = fadeDown;
+                }
+
+                if (decimal.TryParse(importer.ZPosition, NumberStyles.Any, CultureInfo.InvariantCulture, out var zPosition) &&
+                    zPosition is >= -10 and <= 10)
+                {
+                    ZPosition = zPosition;
+                }
+            }
+        }
+        catch
+        {
+            // ignore import errors
+        }
+    }
+
+    [RelayCommand]
+    private async Task Export()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var fileName = await _fileHelper.PickSaveFile(Window, ".DCinema-interop-profile", "D-Cinema profile", "Export D-Cinema properties");
+        if (fileName == null)
+        {
+            return;
+        }
+
+        try
+        {
+            var exporter = new DcPropertiesInterop
+            {
+                GenerateIdAuto = GenerateIdAuto.ToString(CultureInfo.InvariantCulture),
+                ReelNumber = ReelNumber.ToString(CultureInfo.InvariantCulture),
+                Language = SelectedLanguage,
+                FontId = FontId,
+                FontUri = FontUri,
+                FontColor = ColorToString(FontColor),
+                Effect = SelectedFontEffect,
+                EffectColor = ColorToString(FontEffectColor),
+                FontSize = FontSize.ToString(CultureInfo.InvariantCulture),
+                TopBottomMargin = TopBottomMargin.ToString(CultureInfo.InvariantCulture),
+                FadeUpTime = FadeUpTime.ToString(CultureInfo.InvariantCulture),
+                FadeDownTime = FadeDownTime.ToString(CultureInfo.InvariantCulture),
+                ZPosition = ZPosition.ToString(CultureInfo.InvariantCulture),
+            };
+
+            exporter.Save(fileName);
+        }
+        catch
+        {
+            // ignore export errors
+        }
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        SaveSettings();
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+
+    public void Initialize(Subtitle subtitle, SubtitleFormat format)
+    {
+        Subtitle = subtitle;
+        WindowTitle = string.Format(Se.Language.File.XProperties, format.Name);
+        LoadSettings();
+    }
+}

--- a/src/ui/Features/Files/FormatProperties/DcinemaInteropProperties/DCinemaInteropPropertiesWindow.cs
+++ b/src/ui/Features/Files/FormatProperties/DcinemaInteropProperties/DCinemaInteropPropertiesWindow.cs
@@ -1,0 +1,267 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Data.Converters;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+
+namespace Nikse.SubtitleEdit.Features.Files.FormatProperties.DCinemaInteropProperties;
+
+public class DCinemaInteropPropertiesWindow : Window
+{
+    public DCinemaInteropPropertiesWindow(DCinemaInteropPropertiesViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Bind(Window.TitleProperty, new Binding(nameof(vm.WindowTitle))
+        {
+            Source = vm,
+            Mode = BindingMode.OneWay,
+        });
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        MinWidth = 550;
+        MinHeight = 500;
+        vm.Window = this;
+        DataContext = vm;
+
+        var labelWidth = 150;
+        var lang = Se.Language.File.PropertiesDCinema;
+
+        // General section
+        var checkBoxGenerateIdAuto = UiUtil.MakeCheckBox(lang.GenerateIdAuto, vm, nameof(vm.GenerateIdAuto));
+
+        var labelSubtitleId = UiUtil.MakeLabel(lang.SubtitleId).WithMinWidth(labelWidth);
+        var textBoxSubtitleId = UiUtil.MakeTextBox(280, vm, nameof(vm.SubtitleId));
+        var buttonGenerateId = UiUtil.MakeButton(lang.GenerateId, vm.GenerateSubtitleIdCommand);
+        var panelSubtitleId = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Spacing = 10,
+            Children = { labelSubtitleId, textBoxSubtitleId, buttonGenerateId }
+        };
+
+        var labelMovieTitle = UiUtil.MakeLabel(lang.MovieTitle).WithMinWidth(labelWidth);
+        var textBoxMovieTitle = UiUtil.MakeTextBox(300, vm, nameof(vm.MovieTitle));
+        var panelMovieTitle = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Spacing = 10,
+            Children = { labelMovieTitle, textBoxMovieTitle }
+        };
+
+        var labelReelNumber = UiUtil.MakeLabel(lang.ReelNumber).WithMinWidth(labelWidth);
+        var numericUpDownReelNumber = UiUtil.MakeNumericUpDownInt(1, 250, 1, 120, vm, nameof(vm.ReelNumber));
+        var labelLanguage = UiUtil.MakeLabel(Se.Language.General.Language).WithMinWidth(80);
+        var comboBoxLanguage = UiUtil.MakeComboBox(vm.Languages, vm, nameof(vm.SelectedLanguage)).WithMinWidth(150);
+        var panelReelNumber = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Spacing = 10,
+            Children = { labelReelNumber, numericUpDownReelNumber, labelLanguage, comboBoxLanguage }
+        };
+
+        // Font section
+        var labelFontId = UiUtil.MakeLabel(lang.FontId).WithMinWidth(labelWidth);
+        var textBoxFontId = UiUtil.MakeTextBox(200, vm, nameof(vm.FontId));
+        var panelFontId = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Spacing = 10,
+            Children = { labelFontId, textBoxFontId }
+        };
+
+        var labelFontUri = UiUtil.MakeLabel(lang.FontUri).WithMinWidth(labelWidth);
+        var textBoxFontUri = UiUtil.MakeTextBox(200, vm, nameof(vm.FontUri));
+        var panelFontUri = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Spacing = 10,
+            Children = { labelFontUri, textBoxFontUri }
+        };
+
+        var labelFontColor = UiUtil.MakeLabel(lang.FontColor).WithMinWidth(labelWidth);
+        var buttonFontColor = UiUtil.MakeButton(lang.ChooseColor, vm.ChooseFontColorCommand).WithMinWidth(100);
+        var panelFontColorPreview = new Border
+        {
+            Width = 30,
+            Height = 20,
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Colors.Black)
+        };
+        panelFontColorPreview.Bind(Border.BackgroundProperty, new Binding(nameof(vm.FontColor))
+        {
+            Source = vm,
+            Mode = BindingMode.OneWay,
+            Converter = new ColorToBrushConverter()
+        });
+
+        var panelFontColor = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Spacing = 10,
+            Children = { labelFontColor, buttonFontColor, panelFontColorPreview }
+        };
+
+        var labelFontEffect = UiUtil.MakeLabel(lang.FontEffect).WithMinWidth(labelWidth);
+        var comboBoxFontEffect = UiUtil.MakeComboBox<string>(vm.FontEffects, vm, nameof(vm.SelectedFontEffect)).WithMinWidth(100);
+        var panelFontEffect = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Spacing = 10,
+            Children = { labelFontEffect, comboBoxFontEffect }
+        };
+
+        var labelFontEffectColor = UiUtil.MakeLabel(lang.EffectColor).WithMinWidth(labelWidth);
+        var buttonFontEffectColor = UiUtil.MakeButton(lang.ChooseColor, vm.ChooseFontEffectColorCommand).WithMinWidth(100);
+        var panelFontEffectColorPreview = new Border
+        {
+            Width = 30,
+            Height = 20,
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Colors.Black)
+        };
+        panelFontEffectColorPreview.Bind(Border.BackgroundProperty, new Binding(nameof(vm.FontEffectColor))
+        {
+            Source = vm,
+            Mode = BindingMode.OneWay,
+            Converter = new ColorToBrushConverter()
+        });
+
+        var panelFontEffectColor = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Spacing = 10,
+            Children = { labelFontEffectColor, buttonFontEffectColor, panelFontEffectColorPreview }
+        };
+
+        var labelFontSize = UiUtil.MakeLabel(lang.FontSize).WithMinWidth(labelWidth);
+        var numericUpDownFontSize = UiUtil.MakeNumericUpDownInt(0, 250, 42, 120, vm, nameof(vm.FontSize));
+        var labelTopBottomMargin = UiUtil.MakeLabel(lang.TopBottomMargin).WithMinWidth(100);
+        var numericUpDownTopBottomMargin = UiUtil.MakeNumericUpDownInt(1, 50, 8, 120, vm, nameof(vm.TopBottomMargin));
+        var panelFontSize = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Spacing = 10,
+            Children = { labelFontSize, numericUpDownFontSize, labelTopBottomMargin, numericUpDownTopBottomMargin }
+        };
+
+        var labelZPosition = UiUtil.MakeLabel(lang.ZPosition).WithMinWidth(labelWidth);
+        var numericUpDownZPosition = UiUtil.MakeNumericUpDownTwoDecimals(-10, 10, 120, vm, nameof(vm.ZPosition));
+        var labelZPositionHelp = UiUtil.MakeLabel(string.Empty);
+        labelZPositionHelp.Opacity = 0.7;
+        labelZPositionHelp.Content = new TextBlock { Text = lang.ZPositionHelp, TextWrapping = TextWrapping.Wrap, MaxWidth = 280 };
+        var panelZPosition = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Spacing = 10,
+            Children = { labelZPosition, numericUpDownZPosition, labelZPositionHelp }
+        };
+
+        var labelFadeUpTime = UiUtil.MakeLabel(lang.FadeUpTime).WithMinWidth(labelWidth);
+        var numericUpDownFadeUpTime = UiUtil.MakeNumericUpDownInt(0, 50, 0, 120, vm, nameof(vm.FadeUpTime));
+        var labelFadeUpFrames = UiUtil.MakeLabel(lang.Frames);
+        var labelFadeDownTime = UiUtil.MakeLabel(lang.FadeDownTime).WithMinWidth(80);
+        var numericUpDownFadeDownTime = UiUtil.MakeNumericUpDownInt(0, 50, 0, 120, vm, nameof(vm.FadeDownTime));
+        var labelFadeDownFrames = UiUtil.MakeLabel(lang.Frames);
+        var panelFadeUpTime = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Spacing = 10,
+            Children = { labelFadeUpTime, numericUpDownFadeUpTime, labelFadeUpFrames, labelFadeDownTime, numericUpDownFadeDownTime, labelFadeDownFrames }
+        };
+
+        // Font GroupBox
+        var fontGroupBox = new Border
+        {
+            BorderBrush = new SolidColorBrush(Colors.Gray),
+            BorderThickness = new Thickness(1),
+            Padding = new Thickness(10),
+            Child = new StackPanel
+            {
+                Spacing = 10,
+                Children =
+                {
+                    new TextBlock { Text = lang.Font, FontWeight = FontWeight.Bold },
+                    panelFontId,
+                    panelFontUri,
+                    panelFontColor,
+                    panelFontEffect,
+                    panelFontEffectColor,
+                    panelFontSize,
+                    panelZPosition,
+                    panelFadeUpTime
+                }
+            }
+        };
+
+        var scrollViewer = new ScrollViewer
+        {
+            Content = new StackPanel
+            {
+                Spacing = 10,
+                Margin = UiUtil.MakeWindowMargin(),
+                Children =
+                {
+                    checkBoxGenerateIdAuto,
+                    panelSubtitleId,
+                    panelMovieTitle,
+                    panelReelNumber,
+                    fontGroupBox
+                }
+            }
+        };
+
+        var buttonImport = UiUtil.MakeButton(Se.Language.General.ImportDotDotDot, vm.ImportCommand);
+        var buttonExport = UiUtil.MakeButton(lang.Export, vm.ExportCommand);
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var buttonPanel = UiUtil.MakeButtonBar(buttonImport, buttonExport, buttonOk, buttonCancel);
+
+        var mainPanel = new DockPanel
+        {
+            LastChildFill = true,
+            Children = { buttonPanel, scrollViewer }
+        };
+        DockPanel.SetDock(buttonPanel, Dock.Bottom);
+
+        Content = mainPanel;
+
+        Activated += delegate { checkBoxGenerateIdAuto.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        KeyDown += (_, e) => vm.OnKeyDown(e);
+    }
+
+    private class ColorToBrushConverter : IValueConverter
+    {
+        public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value is Color color)
+            {
+                return new SolidColorBrush(color);
+            }
+            return new SolidColorBrush(Colors.White);
+        }
+
+        public object? ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value is SolidColorBrush brush)
+            {
+                return brush.Color;
+            }
+            return Colors.White;
+        }
+    }
+}

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -49,6 +49,7 @@ using Nikse.SubtitleEdit.Features.Files.ExportEbuStl;
 using Nikse.SubtitleEdit.Features.Files.ExportImageBased;
 using Nikse.SubtitleEdit.Features.Files.ExportPac;
 using Nikse.SubtitleEdit.Features.Files.ExportPlainText;
+using Nikse.SubtitleEdit.Features.Files.FormatProperties.DCinemaInteropProperties;
 using Nikse.SubtitleEdit.Features.Files.FormatProperties.DCinemaSmpteProperties;
 using Nikse.SubtitleEdit.Features.Files.FormatProperties.ItunesTimedTextProperties;
 using Nikse.SubtitleEdit.Features.Files.FormatProperties.RosettaProperties;
@@ -2432,42 +2433,57 @@ public partial class MainViewModel :
 
         if (format is DCinemaSmpte2007 or DCinemaSmpte2010 or DCinemaSmpte2014)
         {
-            Se.Settings.File.DCinemaSmpte.CurrentDCinemaSubtitleId = Configuration.Settings.SubtitleSettings.CurrentDCinemaSubtitleId;
-            Se.Settings.File.DCinemaSmpte.CurrentDCinemaMovieTitle = Configuration.Settings.SubtitleSettings.CurrentDCinemaMovieTitle;
-            Se.Settings.File.DCinemaSmpte.CurrentDCinemaReelNumber = Configuration.Settings.SubtitleSettings.CurrentDCinemaReelNumber;
-            Se.Settings.File.DCinemaSmpte.CurrentDCinemaIssueDate = Configuration.Settings.SubtitleSettings.CurrentDCinemaIssueDate;
-            Se.Settings.File.DCinemaSmpte.CurrentDCinemaLanguage = Configuration.Settings.SubtitleSettings.CurrentDCinemaLanguage;
-            Se.Settings.File.DCinemaSmpte.CurrentDCinemaEditRate = Configuration.Settings.SubtitleSettings.CurrentDCinemaEditRate;
-            Se.Settings.File.DCinemaSmpte.CurrentDCinemaTimeCodeRate = Configuration.Settings.SubtitleSettings.CurrentDCinemaTimeCodeRate;
-            Se.Settings.File.DCinemaSmpte.CurrentDCinemaStartTime = Configuration.Settings.SubtitleSettings.CurrentDCinemaStartTime;
-            Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontId = Configuration.Settings.SubtitleSettings.CurrentDCinemaFontId;
-            Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontUri = Configuration.Settings.SubtitleSettings.CurrentDCinemaFontUri;
-            Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontColor = Configuration.Settings.SubtitleSettings.CurrentDCinemaFontColor.ToHex();
-            Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontEffect = Configuration.Settings.SubtitleSettings.CurrentDCinemaFontEffect;
-            Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontEffectColor = Configuration.Settings.SubtitleSettings.CurrentDCinemaFontEffectColor.ToHex();
-            Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontSize = Configuration.Settings.SubtitleSettings.CurrentDCinemaFontSize;
-
+            CopyCurrentDCinemaSettingsToSe();
             var result = await ShowDialogAsync<DCinemaSmptePropertiesWindow, DCinemaSmptePropertiesViewModel>(vm => { vm.Initialize(GetUpdateSubtitle(), format); });
+            CopyCurrentDCinemaSettingsFromSe();
+            SetLibSeSettings();
+        }
 
-            Configuration.Settings.SubtitleSettings.CurrentDCinemaSubtitleId = Se.Settings.File.DCinemaSmpte.CurrentDCinemaSubtitleId;
-            Configuration.Settings.SubtitleSettings.CurrentDCinemaMovieTitle = Se.Settings.File.DCinemaSmpte.CurrentDCinemaMovieTitle;
-            Configuration.Settings.SubtitleSettings.CurrentDCinemaReelNumber = Se.Settings.File.DCinemaSmpte.CurrentDCinemaReelNumber;
-            Configuration.Settings.SubtitleSettings.CurrentDCinemaIssueDate = Se.Settings.File.DCinemaSmpte.CurrentDCinemaIssueDate;
-            Configuration.Settings.SubtitleSettings.CurrentDCinemaLanguage = Se.Settings.File.DCinemaSmpte.CurrentDCinemaLanguage;
-            Configuration.Settings.SubtitleSettings.CurrentDCinemaEditRate = Se.Settings.File.DCinemaSmpte.CurrentDCinemaEditRate;
-            Configuration.Settings.SubtitleSettings.CurrentDCinemaTimeCodeRate = Se.Settings.File.DCinemaSmpte.CurrentDCinemaTimeCodeRate;
-            Configuration.Settings.SubtitleSettings.CurrentDCinemaStartTime = Se.Settings.File.DCinemaSmpte.CurrentDCinemaStartTime;
-            Configuration.Settings.SubtitleSettings.CurrentDCinemaFontId = Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontId;
-            Configuration.Settings.SubtitleSettings.CurrentDCinemaFontUri = Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontUri;
-            Configuration.Settings.SubtitleSettings.CurrentDCinemaFontColor = Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontColor.FromHexToColor().ToSkColor();
-            Configuration.Settings.SubtitleSettings.CurrentDCinemaFontEffect = Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontEffect;
-            Configuration.Settings.SubtitleSettings.CurrentDCinemaFontEffectColor = Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontEffectColor.FromHexToColor().ToSkColor();
-            Configuration.Settings.SubtitleSettings.CurrentDCinemaFontSize = Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontSize;
-
+        if (format is DCinemaInterop)
+        {
+            CopyCurrentDCinemaSettingsToSe();
+            var result = await ShowDialogAsync<DCinemaInteropPropertiesWindow, DCinemaInteropPropertiesViewModel>(vm => { vm.Initialize(GetUpdateSubtitle(), format); });
+            CopyCurrentDCinemaSettingsFromSe();
             SetLibSeSettings();
         }
 
         _shortcutManager.ClearKeys();
+    }
+
+    private static void CopyCurrentDCinemaSettingsToSe()
+    {
+        Se.Settings.File.DCinemaSmpte.CurrentDCinemaSubtitleId = Configuration.Settings.SubtitleSettings.CurrentDCinemaSubtitleId;
+        Se.Settings.File.DCinemaSmpte.CurrentDCinemaMovieTitle = Configuration.Settings.SubtitleSettings.CurrentDCinemaMovieTitle;
+        Se.Settings.File.DCinemaSmpte.CurrentDCinemaReelNumber = Configuration.Settings.SubtitleSettings.CurrentDCinemaReelNumber;
+        Se.Settings.File.DCinemaSmpte.CurrentDCinemaIssueDate = Configuration.Settings.SubtitleSettings.CurrentDCinemaIssueDate;
+        Se.Settings.File.DCinemaSmpte.CurrentDCinemaLanguage = Configuration.Settings.SubtitleSettings.CurrentDCinemaLanguage;
+        Se.Settings.File.DCinemaSmpte.CurrentDCinemaEditRate = Configuration.Settings.SubtitleSettings.CurrentDCinemaEditRate;
+        Se.Settings.File.DCinemaSmpte.CurrentDCinemaTimeCodeRate = Configuration.Settings.SubtitleSettings.CurrentDCinemaTimeCodeRate;
+        Se.Settings.File.DCinemaSmpte.CurrentDCinemaStartTime = Configuration.Settings.SubtitleSettings.CurrentDCinemaStartTime;
+        Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontId = Configuration.Settings.SubtitleSettings.CurrentDCinemaFontId;
+        Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontUri = Configuration.Settings.SubtitleSettings.CurrentDCinemaFontUri;
+        Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontColor = Configuration.Settings.SubtitleSettings.CurrentDCinemaFontColor.ToHex();
+        Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontEffect = Configuration.Settings.SubtitleSettings.CurrentDCinemaFontEffect;
+        Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontEffectColor = Configuration.Settings.SubtitleSettings.CurrentDCinemaFontEffectColor.ToHex();
+        Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontSize = Configuration.Settings.SubtitleSettings.CurrentDCinemaFontSize;
+    }
+
+    private static void CopyCurrentDCinemaSettingsFromSe()
+    {
+        Configuration.Settings.SubtitleSettings.CurrentDCinemaSubtitleId = Se.Settings.File.DCinemaSmpte.CurrentDCinemaSubtitleId;
+        Configuration.Settings.SubtitleSettings.CurrentDCinemaMovieTitle = Se.Settings.File.DCinemaSmpte.CurrentDCinemaMovieTitle;
+        Configuration.Settings.SubtitleSettings.CurrentDCinemaReelNumber = Se.Settings.File.DCinemaSmpte.CurrentDCinemaReelNumber;
+        Configuration.Settings.SubtitleSettings.CurrentDCinemaIssueDate = Se.Settings.File.DCinemaSmpte.CurrentDCinemaIssueDate;
+        Configuration.Settings.SubtitleSettings.CurrentDCinemaLanguage = Se.Settings.File.DCinemaSmpte.CurrentDCinemaLanguage;
+        Configuration.Settings.SubtitleSettings.CurrentDCinemaEditRate = Se.Settings.File.DCinemaSmpte.CurrentDCinemaEditRate;
+        Configuration.Settings.SubtitleSettings.CurrentDCinemaTimeCodeRate = Se.Settings.File.DCinemaSmpte.CurrentDCinemaTimeCodeRate;
+        Configuration.Settings.SubtitleSettings.CurrentDCinemaStartTime = Se.Settings.File.DCinemaSmpte.CurrentDCinemaStartTime;
+        Configuration.Settings.SubtitleSettings.CurrentDCinemaFontId = Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontId;
+        Configuration.Settings.SubtitleSettings.CurrentDCinemaFontUri = Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontUri;
+        Configuration.Settings.SubtitleSettings.CurrentDCinemaFontColor = Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontColor.FromHexToColor().ToSkColor();
+        Configuration.Settings.SubtitleSettings.CurrentDCinemaFontEffect = Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontEffect;
+        Configuration.Settings.SubtitleSettings.CurrentDCinemaFontEffectColor = Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontEffectColor.FromHexToColor().ToSkColor();
+        Configuration.Settings.SubtitleSettings.CurrentDCinemaFontSize = Se.Settings.File.DCinemaSmpte.CurrentDCinemaFontSize;
     }
 
     [RelayCommand]
@@ -23984,7 +24000,7 @@ public partial class MainViewModel :
         if (e.AddedItems.Count == 1)
         {
             var format = e.AddedItems[0] as SubtitleFormat;
-            if (format is TimedTextImsc11 or ItunesTimedText or TimedText10 or TimedTextImscRosetta or TmpegEncXml or DCinemaSmpte2007 or DCinemaSmpte2010 or DCinemaSmpte2014)
+            if (format is TimedTextImsc11 or ItunesTimedText or TimedText10 or TimedTextImscRosetta or TmpegEncXml or DCinemaSmpte2007 or DCinemaSmpte2010 or DCinemaSmpte2014 or DCinemaInterop)
             {
                 IsFilePropertiesVisible = true;
                 FilePropertiesText = string.Format(Se.Language.Main.XPropertiesDotDotDot, format.Name);

--- a/src/ui/Logic/Config/Language/File/LanguageFilePropertiesDCinema.cs
+++ b/src/ui/Logic/Config/Language/File/LanguageFilePropertiesDCinema.cs
@@ -26,6 +26,8 @@ public class LanguageFilePropertiesDCinema
     public string FadeUpTime { get; internal set; }
     public string FadeDownTime { get; internal set; }
     public string Frames { get; internal set; }
+    public string ZPosition { get; internal set; }
+    public string ZPositionHelp { get; internal set; }
     public string Export { get; internal set; }
 
     public LanguageFilePropertiesDCinema()
@@ -54,6 +56,8 @@ public class LanguageFilePropertiesDCinema
         FadeUpTime = "Fade up time";
         FadeDownTime = "Fade down time";
         Frames = "Frames";
+        ZPosition = "Z-position";
+        ZPositionHelp = "Positive numbers move text away, negative numbers move text closer, if z-position is zero then it's 2D";
         Export = "Export...";
     }
 

--- a/tests/UI/Features/Files/DCinemaInteropPropertiesTests.cs
+++ b/tests/UI/Features/Files/DCinemaInteropPropertiesTests.cs
@@ -1,0 +1,115 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Files.FormatProperties.DCinemaInteropProperties;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Files;
+
+public class DCinemaInteropPropertiesTests
+{
+    private static DCinemaInteropPropertiesViewModel MakeViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<DCinemaInteropPropertiesViewModel>();
+    }
+
+    [AvaloniaFact]
+    public void Window_OpensWithDefaults()
+    {
+        Se.Settings.File.DCinemaSmpte = new SeDCinemaSmpte();
+
+        var vm = MakeViewModel();
+        vm.Initialize(new Subtitle(), new DCinemaInterop());
+        var window = new DCinemaInteropPropertiesWindow(vm);
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.False(string.IsNullOrEmpty(vm.SubtitleId));
+            Assert.Equal(1, vm.ReelNumber);
+            Assert.Equal("English", vm.SelectedLanguage);
+            Assert.Equal("Font1", vm.FontId);
+            Assert.Equal("Arial.ttf", vm.FontUri);
+            Assert.Equal(42, vm.FontSize);
+            Assert.Equal(8, vm.TopBottomMargin);
+            Assert.Equal(0, vm.ZPosition);
+            Assert.Equal("None", vm.SelectedFontEffect);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Ok_SavesSettingsIncludingZPosition()
+    {
+        Se.Settings.File.DCinemaSmpte = new SeDCinemaSmpte();
+
+        var vm = MakeViewModel();
+        vm.Initialize(new Subtitle(), new DCinemaInterop());
+        var window = new DCinemaInteropPropertiesWindow(vm);
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            vm.MovieTitle = "Test Movie";
+            vm.ReelNumber = 3;
+            vm.SelectedFontEffect = "Border";
+            vm.FontSize = 48;
+            vm.TopBottomMargin = 10;
+            vm.ZPosition = -1.25m;
+            vm.FadeUpTime = 2;
+            vm.FadeDownTime = 4;
+
+            vm.OkCommand.Execute(null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(vm.OkPressed);
+            var ss = Se.Settings.File.DCinemaSmpte;
+            Assert.Equal("Test Movie", ss.CurrentDCinemaMovieTitle);
+            Assert.Equal("3", ss.CurrentDCinemaReelNumber);
+            Assert.Equal("border", ss.CurrentDCinemaFontEffect);
+            Assert.Equal(48, ss.CurrentDCinemaFontSize);
+            Assert.Equal(10, ss.DCinemaBottomMargin);
+            Assert.Equal(-1.25, ss.DCinemaZPosition);
+            Assert.Equal(2, ss.DCinemaFadeUpTime);
+            Assert.Equal(4, ss.DCinemaFadeDownTime);
+        }
+        finally
+        {
+            if (!vm.OkPressed)
+            {
+                window.Close();
+            }
+        }
+    }
+
+    [AvaloniaFact]
+    public void Cancel_DoesNotSaveSettings()
+    {
+        Se.Settings.File.DCinemaSmpte = new SeDCinemaSmpte();
+
+        var vm = MakeViewModel();
+        vm.Initialize(new Subtitle(), new DCinemaInterop());
+        var window = new DCinemaInteropPropertiesWindow(vm);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        vm.MovieTitle = "Discarded";
+        vm.CancelCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(vm.OkPressed);
+        Assert.Equal(string.Empty, Se.Settings.File.DCinemaSmpte.CurrentDCinemaMovieTitle);
+    }
+}

--- a/tests/libse/Forms/DcPropertiesInteropTest.cs
+++ b/tests/libse/Forms/DcPropertiesInteropTest.cs
@@ -1,0 +1,64 @@
+using Nikse.SubtitleEdit.Core.Forms;
+
+namespace LibSETests.Forms;
+
+public class DcPropertiesInteropTest
+{
+    [Fact]
+    public void SaveAndLoad_RoundTripsAllProperties()
+    {
+        var fileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".DCinema-interop-profile");
+        try
+        {
+            var exporter = new DcPropertiesInterop
+            {
+                GenerateIdAuto = "True",
+                ReelNumber = "3",
+                Language = "English",
+                FontId = "Font1",
+                FontUri = "Arial.ttf",
+                FontColor = "#FFFFFFFF",
+                Effect = "Border",
+                EffectColor = "#FF000000",
+                FontSize = "42",
+                TopBottomMargin = "8",
+                FadeUpTime = "2",
+                FadeDownTime = "4",
+                ZPosition = "-1.25",
+            };
+
+            Assert.True(exporter.Save(fileName));
+
+            var importer = new DcPropertiesInterop();
+            Assert.True(importer.Load(fileName));
+
+            Assert.Equal("True", importer.GenerateIdAuto);
+            Assert.Equal("3", importer.ReelNumber);
+            Assert.Equal("English", importer.Language);
+            Assert.Equal("Font1", importer.FontId);
+            Assert.Equal("Arial.ttf", importer.FontUri);
+            Assert.Equal("#FFFFFFFF", importer.FontColor);
+            Assert.Equal("Border", importer.Effect);
+            Assert.Equal("#FF000000", importer.EffectColor);
+            Assert.Equal("42", importer.FontSize);
+            Assert.Equal("8", importer.TopBottomMargin);
+            Assert.Equal("2", importer.FadeUpTime);
+            Assert.Equal("4", importer.FadeDownTime);
+            Assert.Equal("-1.25", importer.ZPosition);
+        }
+        finally
+        {
+            if (File.Exists(fileName))
+            {
+                File.Delete(fileName);
+            }
+        }
+    }
+
+    [Fact]
+    public void Load_MissingFile_ReturnsFalse()
+    {
+        var importer = new DcPropertiesInterop();
+        Assert.False(importer.Load(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"))));
+    }
+}


### PR DESCRIPTION
Fixes #13168

SE 5 had a properties dialog for the D-Cinema SMPTE formats, but the interop format was selectable with no UI to set font, size, colors, margins, fades, or z-position. This ports the SE 4 interop dialog to SE 5.

## Changes

- New `DCinemaInteropPropertiesWindow`/`ViewModel`, modeled on the SMPTE pair: subtitle ID (+ generate / auto-generate on save), movie title, reel number, language, font ID/URI/color/effect/effect color/size, top/bottom margin, fade up/down, and the interop-only z-position (with the SE 4 help text).
- The **File → "D-Cinema interop properties..."** menu item now appears when the current format is D-Cinema interop (same mechanism as the SMPTE formats).
- Profile import/export via the SE 4-compatible `.DCinema-interop-profile` JSON format (`DcPropertiesInterop` ported to libse).
- Language keys `zPosition`/`zPositionHelp` added to the language class and English.json.
- The interop `<Language>` element holds English culture names ("English"), not ISO codes, so the language list differs from the SMPTE dialog accordingly.
- Refactor: the duplicated D-Cinema settings sync in `FilePropertiesShow` is extracted into `CopyCurrentDCinemaSettingsToSe`/`FromSe` helpers, shared by both branches; removed a stray empty `DCinemaSmpteProperties ViewModel.cs` file.

## Tests

- Headless UI tests: window opens with sensible defaults, OK persists all fields including z-position, Cancel discards.
- libse test: profile export/import round-trips all properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)