### PR TITLE
Update OmniVoice TTS to omnivoice-2026-08-03 (Pascal/Volta CUDA support)

### DIFF
--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -1294,43 +1294,49 @@ public static class DownloadHashManager
             // otherwise users will be prompted to "update" to the same version they just got.
             [OmniVoice.WindowsCpu] = new[]
             {
-                "ba1606c39987ea541e55db53f8925ed3c4f8301447e4f590aca800ccd52cef52", // omnivoice-2026-06-18 (current download URL — portable AVX2 baseline, GGML_NATIVE=OFF)
+                "e4e301a9c03db62a3f0d8d15b34584c49407c43f3e59dd9eae4a90121ad7f012", // omnivoice-2026-08-03 (current download URL — upstream sync + ggml bump)
+                "ba1606c39987ea541e55db53f8925ed3c4f8301447e4f590aca800ccd52cef52", // omnivoice-2026-06-18 (portable AVX2 baseline, GGML_NATIVE=OFF)
                 "4af38bcb264ef34d7d39a7c76af00993e32f731a17253b7e82a9b8a6140a736b", // omnivoice-2026-05-22
                 "ea1f0c6032f5a0333103ccffa7d7478c5ee00a35867776c277d717512587766c", // omnivoice-2026-05-17
             },
             [OmniVoice.WindowsVulkan] = new[]
             {
-                "0f1e33fe67c78835991ccd787da68d265142f07e95f17b1c0b89e4d0c1fc6811", // omnivoice-2026-06-18 (current download URL — portable AVX2 baseline, GGML_NATIVE=OFF)
+                "f2123650b1f17a8b2cb9c8b8ff25b0cbc5a9064cb359294f1c0da6ac5246d4d3", // omnivoice-2026-08-03 (current download URL — upstream sync + ggml bump)
+                "0f1e33fe67c78835991ccd787da68d265142f07e95f17b1c0b89e4d0c1fc6811", // omnivoice-2026-06-18 (portable AVX2 baseline, GGML_NATIVE=OFF)
                 "ff90f8eb8c36ea64d46bd1d245e109ef80cadf234417bdc2c78b7420ab8f9a43", // omnivoice-2026-05-22
                 "b461b8535892b3e6979aec79eff4d6a0109a31184008b778b6848d7d36ea9901", // omnivoice-2026-05-17
             },
             [OmniVoice.WindowsCuda] = new[]
             {
-                "1d3109d67e4a3e3e83bce83791fa4af5c825f2fd60806593fda0539091bf49e6", // omnivoice-2026-06-18 (current download URL — portable AVX2 baseline, GGML_NATIVE=OFF; fixes #11677 illegal-instruction crash)
+                "7cc4ab9f4bec88468747e9e2f049ea6392a52d79da37e25504460de4b868c800", // omnivoice-2026-08-03 (current download URL — adds Pascal sm_61 + Volta sm_70 kernels; fixes #13061 no-kernel-image crash)
+                "1d3109d67e4a3e3e83bce83791fa4af5c825f2fd60806593fda0539091bf49e6", // omnivoice-2026-06-18 (portable AVX2 baseline, GGML_NATIVE=OFF; fixes #11677 illegal-instruction crash)
                 "735d5672507b3796138cecabcde6512e6a1e60bc9e6e86efd0fa6ce13a361fa1", // omnivoice-2026-05-22
                 "79308e79bb47df9f2bd2d31c6a60fe5672b74f43c3caf9b0a09566408894789e", // omnivoice-2026-05-17
             },
             [OmniVoice.MacOs] = new[]
             {
-                "1063bf7f481bf1ecd296ba480a5655c68d12f392794504916fa542a2792da903", // omnivoice-2026-06-18 (current download URL)
+                "54888cc0ab4c30be4a0393406ce0d6642d8dae6d8f1eed13ad9cf849a615c26d", // omnivoice-2026-08-03 (current download URL — upstream sync + ggml bump)
+                "1063bf7f481bf1ecd296ba480a5655c68d12f392794504916fa542a2792da903", // omnivoice-2026-06-18
                 "d5ce6807adc50e6e1f1f92235828bad7c139c50042090a5361d0506e069ad1ba", // omnivoice-2026-05-22 (RPATH fix)
                 "bbe354cdf8995641074c46d02d7f8b9353fa4803452cb45a762de10e899aca8e", // omnivoice-2026-05-17
             },
             [OmniVoice.LinuxX64] = new[]
             {
-                "698156714d03fadc503e4ebe01e47295b47c64df6d6496df48ed6c4128147214", // omnivoice-2026-06-18 (current download URL — portable AVX2 baseline, GGML_NATIVE=OFF)
+                "1d4898fab4d4cd8fef2331d1cc70ff98f5abce13cd1062e11ddf45e05ab7ba82", // omnivoice-2026-08-03 (current download URL — upstream sync + ggml bump)
+                "698156714d03fadc503e4ebe01e47295b47c64df6d6496df48ed6c4128147214", // omnivoice-2026-06-18 (portable AVX2 baseline, GGML_NATIVE=OFF)
                 "c8eec5e66b362ddd3504658021a890a8acd4d2c092ba51a847fce1e80f4807e9", // omnivoice-2026-05-22 (RPATH fix)
                 "198046721ebcbe49ded959fd832ec4a091d899be49e2a26b549723e32b82daba", // omnivoice-2026-05-17
             },
             [OmniVoice.LinuxArm64] = new[]
             {
-                "7ad6a7ca9484b14b4b1ec25fdec4e67b2750d7a27b86d5937676f143aa95eaeb", // omnivoice-2026-06-18 (current download URL)
+                "95ea0aafb123ba6210ba29e6942eaa28c57924af9d63a3f218d65a7d3f4a28c4", // omnivoice-2026-08-03 (current download URL — upstream sync + ggml bump)
+                "7ad6a7ca9484b14b4b1ec25fdec4e67b2750d7a27b86d5937676f143aa95eaeb", // omnivoice-2026-06-18
                 "a46029c360398fc8775d6a4d703df158fa6f3ee6576e6efd3be0b7be424e5276", // omnivoice-2026-05-22 (RPATH fix)
                 "3802d4136a6ffdc37cce72b286ab7c17422d55964fec13d4e3eb36f26e6ae1fe", // omnivoice-2026-05-17
             },
             [OmniVoice.Voices] = new[]
             {
-                "5d252eb78e8f4891279a36fa5127ea5ab80be35057eeaa5fadb49baeacd0c773", // omnivoice-2026-06-18 (current download URL — unchanged; identical to support-files/omnivoice-26-06 copy)
+                "5d252eb78e8f4891279a36fa5127ea5ab80be35057eeaa5fadb49baeacd0c773", // omnivoice-2026-08-03 (current download URL — byte-identical since 2026-06-18; support-files/omnivoice-26-06 copy)
             },
 
             // Qwen3 TTS — https://github.com/niksedk/qwen3-tts.cpp/releases

--- a/src/ui/Logic/Download/OmniVoiceDownloadService.cs
+++ b/src/ui/Logic/Download/OmniVoiceDownloadService.cs
@@ -33,7 +33,7 @@ public class OmniVoiceDownloadService : IOmniVoiceDownloadService
 
     // omnivoice.cpp release pin. Bump in lockstep with the hashes in DownloadHashManager.OmniVoice
     // (each new release: prepend the new SHA-256 at index 0, keep the previous one for "update available").
-    public const string ReleaseTag = "omnivoice-2026-06-18";
+    public const string ReleaseTag = "omnivoice-2026-08-03";
     private const string ReleaseUrlBase = "https://github.com/niksedk/omnivoice.cpp/releases/download/" + ReleaseTag + "/";
 
     private const string WindowsCpuUrl = ReleaseUrlBase + "omnivoice-win64-cpu.zip";


### PR DESCRIPTION
## Problem

#13061: the standalone OmniVoice TTS CUDA build crashed on a Quadro P5000 (Pascal, compute capability 6.1) with `CUDA error: no kernel image is available for execution on the device` at the first IM2COL op. Root cause: the omnivoice.cpp release binaries were built with `CMAKE_CUDA_ARCHITECTURES` starting at `75-virtual`, so pre-Turing cards had no compatible cubin and no JIT-able PTX.

## Fix (upstream, niksedk/omnivoice.cpp)

- [`9888d4c`](https://github.com/niksedk/omnivoice.cpp/commit/9888d4c13fffc76b50d586cb6a74f56f6d49588c) adds `61-real;70-real` (Pascal + Volta) to the distributed arch list, gated on CUDA < 13 which removed those archs. ggml still fully guards Pascal (`GGML_CUDA_CC_PASCAL`/`DP4A` paths), so no source changes were needed.
- [`08e7d9b`](https://github.com/niksedk/omnivoice.cpp/commit/08e7d9bb2d5cdc8f52d35ed01b8a0610d0717358) fixes the Windows Vulkan CI build: the ggml bump merged from upstream now requires SPIRV-Headers' CMake config, which the stripped Vulkan SDK install lacks.
- Released as [omnivoice-2026-08-03](https://github.com/niksedk/omnivoice.cpp/releases/tag/omnivoice-2026-08-03) — all 6 platform builds green. Verified from the CUDA build log: `CMAKE_CUDA_ARCHITECTURES=61-real;70-real;75-virtual;80-virtual;86-real;89-real;120a-real;121a-real`, 141 nvcc invocations targeting `sm_61`. The release also picks up the upstream sync + ggml bump for all platforms.

## This PR

- Bumps `ReleaseTag` in `OmniVoiceDownloadService.cs` to `omnivoice-2026-08-03`.
- Prepends the six new archive SHA-256s (computed from freshly downloaded release assets; sizes match the release API) in `DownloadHashManager`, keeping previous entries so existing installs are offered the update. `OmniVoices.zip` is byte-identical to the previous release, so its single hash entry stands.

## Testing

- `dotnet build src/ui/UI.csproj`: clean, 0 warnings.
- `dotnet test tests/UI --filter "FullyQualifiedName~OmniVoice|FullyQualifiedName~Download"`: 58 passed, 0 failed.

Note: `change-log.txt` deliberately untouched.

Fixes the standalone-engine half of #13061 (the CrispASR-route half shipped in #13063).

🤖 Generated with [Claude Code](https://claude.com/claude-code)