### PR TITLE
Fix macOS AV1 crash by bumping bundled dav1d via IINA 1.4.4

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -34,8 +34,8 @@ env:
   #   2. Download https://github.com/iina/iina/releases/download/<ver>/IINA.<ver>.dmg
   #   3. Run `shasum -a 256` on it and update IINA_SHA256.
   #   4. Verify the new release still ships a universal Contents/Frameworks/ payload.
-  IINA_VERSION: v1.4.2
-  IINA_SHA256: 2e0fd89fbba1c92a6c115171e5b51904883bb497fbe513a6961d080fbab08ff6
+  IINA_VERSION: v1.4.4
+  IINA_SHA256: dd0fc0bd4b37fb57a1c8d30d6e3201b3a64bafd29959fe56953964613237beb1
 
 
 jobs:


### PR DESCRIPTION
Fixes the macOS crash reported in [discussion #12929](https://github.com/SubtitleEdit/subtitleedit/discussions/12929#discussioncomment-17887694) (MacBook Air M5, app crashes on startup / when double-clicking a subtitle line with an AV1 video loaded).

## Root cause

The attached crash log shows a SIGSEGV on a `dav1d-worker` thread in `prep_8tap_neon_i8mm` inside SE's bundled `libdav1d.7.dylib`, reading 1 byte outside a 3 MB malloc region during AV1 software decode.

This is an upstream dav1d bug: the 6-tap 2D/HV subpel filter in `mc_dotprod.S` used the wrong register as a source pointer (macro arg `\xmy` instead of `\lsrc`), striding through unrelated memory on CPUs with the i8mm extension (Apple M4/M5). Fixed upstream in dav1d 1.5.0 by [videolan/dav1d@287e90a3](https://github.com/videolan/dav1d/commit/287e90a3a60c3f6f6866938c4d2973558505d1c0) ("AArch64: Fix typo in SBD 6-tap 2D/HV subpel filter"). The crash is layout-dependent, hence intermittent — it fires when a decode read lands exactly on an unmapped page.

## Fix

SE harvests its macOS libmpv stack from IINA. IINA v1.4.2 bundles dav1d **1.4.3** (buggy); IINA v1.4.4 bundles dav1d **1.5.1** (fixed). This PR bumps the pin per the checklist in the workflow:

- `IINA_VERSION`: v1.4.2 → v1.4.4
- `IINA_SHA256`: sha256 of `IINA.v1.4.4.dmg` (verified locally against the downloaded release asset)

## Verification

- Downloaded `IINA.v1.4.4.dmg` (104 MB), hash matches the value in this PR.
- Mounted it and confirmed the bundle still ships a universal `Contents/Frameworks/` payload: 72 dylibs, `libmpv.2.dylib` and `libdav1d.7.dylib` both `x86_64 arm64`.
- Confirmed the bundled dav1d version string is 1.5.1, and that upstream commit 287e90a3 is an ancestor of the dav1d 1.5.0 tag but not of 1.4.3.

(IINA 1.4.3/1.4.4 themselves only contain `iina://` URL-scheme security fixes in the IINA app, which SE doesn't ship — the dylib payload is what matters here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)