### PR TITLE
Keep subtitle grid selections in subtitle order

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -291,9 +291,49 @@ public partial class MainViewModel :
 
     public TableView SubtitleGrid { get; set; }
 
-    // ListBox.SelectedItems is nullable (IList?) where DataGrid's was not; the grid
-    // always provides one, so this non-null view keeps the many call sites tidy.
-    public System.Collections.IList SubtitleGridSelectedItems => SubtitleGrid.SelectedItems!;
+    /// <summary>
+    /// The selected rows, always in subtitle order (topmost row first) no matter how they were
+    /// picked. The control's own SelectedItems follows selection order, so shift-clicking upwards
+    /// leaves the anchor row in front and ctrl-clicking around scrambles the list entirely - and
+    /// everything downstream (copy, merge, export, ...) then works on the rows out of order.
+    /// </summary>
+    public List<SubtitleLineViewModel> SubtitleGridSelectedItems => GetSelectedSubtitlesInOrder();
+
+    private List<SubtitleLineViewModel> GetSelectedSubtitlesInOrder()
+    {
+        var selected = SubtitleGrid.SelectedItems;
+        var count = selected?.Count ?? 0;
+        if (count == 0)
+        {
+            return new List<SubtitleLineViewModel>();
+        }
+
+        if (count == 1)
+        {
+            // Single selection is the common case (every arrow key lands here) - no ordering needed.
+            return new List<SubtitleLineViewModel>(1) { (SubtitleLineViewModel)selected![0]! };
+        }
+
+        // One pass over the subtitles rather than IndexOf per selected row, which would be
+        // O(selected * subtitles) and this runs on every selection change.
+        var wanted = new HashSet<SubtitleLineViewModel>(count);
+        for (var i = 0; i < count; i++)
+        {
+            wanted.Add((SubtitleLineViewModel)selected![i]!);
+        }
+
+        var ordered = new List<SubtitleLineViewModel>(count);
+        for (var i = 0; i < Subtitles.Count && ordered.Count < wanted.Count; i++)
+        {
+            if (wanted.Contains(Subtitles[i]))
+            {
+                ordered.Add(Subtitles[i]);
+            }
+        }
+
+        return ordered;
+    }
+
     public TableViewColumnManager? SubtitleGridColumnManager { get; set; }
     public TableViewDragSelect? SubtitleGridDragSelect { get; set; }
     public Border? SubtitleGridDropHost { get; set; }
@@ -13100,10 +13140,7 @@ public partial class MainViewModel :
         // Distributes the duration spanning the first..last selected paragraphs
         // proportionally to each paragraph's CPS character count, packing them
         // back-to-back with the configured minimum gap between them.
-        var selectedItems = SubtitleGridSelectedItems
-            .Cast<SubtitleLineViewModel>()
-            .OrderBy(p => Subtitles.IndexOf(p))
-            .ToList();
+        var selectedItems = SubtitleGridSelectedItems;
 
         if (selectedItems.Count < 2)
         {
@@ -19858,8 +19895,8 @@ public partial class MainViewModel :
             .OrderBy(i => i)
             .ToList();
 
-        // Anchor on the lowest selected index, not selectedItems.First() (which is the
-        // first-clicked row and can differ from row order on an out-of-order selection).
+        // Anchor on the lowest selected index - rows that are no longer in Subtitles drop out
+        // of the mapping above, so this is not simply Subtitles.IndexOf(selectedItems[0]).
         var idx = sortedIndices.FirstOrDefault();
 
         var firstLine = Subtitles.GetOrNull(sortedIndices.FirstOrDefault());
@@ -23514,10 +23551,12 @@ public partial class MainViewModel :
                 Math.Abs(p.StartTime.TotalMilliseconds - e.Paragraph.StartTime.TotalMilliseconds) < 0.01);
             if (p != null)
             {
-                var selectedItems = SubtitleGridSelectedItems;
+                // Toggling has to go through the control's own (selection-ordered) list -
+                // SubtitleGridSelectedItems is an ordered snapshot, mutating it does nothing.
+                var selectedItems = SubtitleGrid.SelectedItems!;
                 if (selectedItems.Contains(p))
                 {
-                    if (selectedItems.Count != 1 || selectedItems[0] != p)
+                    if (selectedItems.Count != 1 || !ReferenceEquals(selectedItems[0], p))
                     {
                         selectedItems.Remove(p);
                     }

--- a/tests/UI/Features/Main/SubtitleGridSelectionOrderTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridSelectionOrderTests.cs
@@ -1,0 +1,132 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// The grid's own SelectedItems follows the order rows were picked, not the order they appear in:
+/// shift-clicking upwards leaves the row that was already selected in front, and ctrl-clicking
+/// around scrambles the list entirely. Everything downstream (copy, copy text only, merge, export
+/// selected lines, ...) reads <see cref="MainViewModel.SubtitleGridSelectedItems"/>, so that is
+/// where subtitle order gets restored - see issue #13173, where "Copy (text only)" put the lines
+/// on the clipboard out of order after a reverse selection.
+/// </summary>
+public class SubtitleGridSelectionOrderTests
+{
+    private const int LineCount = 20;
+
+    private static (Window Window, MainViewModel Vm, TableView Grid) ShowMainWindowWithLines()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        for (var i = 0; i < LineCount; i++)
+        {
+            vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph($"Line {i + 1}", i * 2000, i * 2000 + 1500), null!)
+            {
+                Number = i + 1,
+            });
+        }
+
+        Settle(window);
+        return (window, vm, vm.SubtitleGrid);
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 5; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+
+    private static void Click(Window window, TableView grid, int index, RawInputModifiers modifiers)
+    {
+        var container = (Visual?)grid.ContainerFromItem(((IList<SubtitleLineViewModel>)grid.ItemsSource!)[index]);
+        Assert.NotNull(container);
+        var bounds = container!.Bounds;
+        var point = container.TranslatePoint(new Point(bounds.Width / 2, bounds.Height / 2), window)!.Value;
+
+        window.MouseDown(point, MouseButton.Left, modifiers);
+        window.MouseUp(point, MouseButton.Left, modifiers);
+        Settle(window);
+    }
+
+    private static int[] SelectedNumbers(MainViewModel vm) =>
+        vm.SubtitleGridSelectedItems.Select(p => p.Number).ToArray();
+
+    [AvaloniaTheory]
+    [InlineData(2, 6)] // downwards
+    [InlineData(6, 2)] // upwards - the reverse selection from issue #13173
+    public void ShiftClick_SelectsInSubtitleOrder_InBothDirections(int first, int second)
+    {
+        var (window, vm, grid) = ShowMainWindowWithLines();
+
+        Click(window, grid, first, RawInputModifiers.None);
+        Click(window, grid, second, RawInputModifiers.Shift);
+
+        var lo = Math.Min(first, second);
+        var hi = Math.Max(first, second);
+        Assert.Equal(Enumerable.Range(lo + 1, hi - lo + 1).ToArray(), SelectedNumbers(vm));
+
+        window.Close();
+    }
+
+    /// <summary>
+    /// Adding a row above the current one puts it last in the control's own SelectedItems; the
+    /// view model still hands out the pair top row first. (Only one added row: in the headless
+    /// harness the multi-select modifier is Ctrl, and the grid's context flyout - which Ctrl+click
+    /// opens on macOS - then swallows every ctrl-click after the first.)
+    /// </summary>
+    [AvaloniaFact]
+    public void CtrlClick_OnARowAbove_StillSelectsInSubtitleOrder()
+    {
+        var (window, vm, grid) = ShowMainWindowWithLines();
+
+        Click(window, grid, 7, RawInputModifiers.None);
+        Click(window, grid, 1, RawInputModifiers.Control);
+
+        Assert.Equal(new[] { 2, 8 }, SelectedNumbers(vm));
+
+        window.Close();
+    }
+
+    /// <summary>
+    /// The anchor row - the one the edit box and waveform follow - is still the row that was
+    /// clicked last, even though it is no longer first in the selection.
+    /// </summary>
+    [AvaloniaFact]
+    public void ReverseShiftClick_KeepsTheClickedRowAsTheCurrentRow()
+    {
+        var (window, vm, grid) = ShowMainWindowWithLines();
+
+        Click(window, grid, 6, RawInputModifiers.None);
+        Click(window, grid, 2, RawInputModifiers.Shift);
+
+        Assert.Same(vm.Subtitles[2], grid.SelectedItem);
+        Assert.Equal(new[] { 3, 4, 5, 6, 7 }, SelectedNumbers(vm));
+
+        window.Close();
+    }
+}


### PR DESCRIPTION
Fixes #13173.

### The bug

The subtitle grid's own `SelectedItems` follows the order rows were **picked**, not the order they appear in. Reproduced headlessly against the real main window:

| how the rows were selected | control's `SelectedItems` |
| --- | --- |
| click row 8, ctrl+click row 2 | `8, 2` |
| click row 7, shift+click row 3 (upwards) | `7, 3, 4, 5, 6` |

Every caller goes through `MainViewModel.SubtitleGridSelectedItems`, which handed that list straight out — so *Copy (text only)* pasted the lines out of order after a reverse selection, and so did copy, merge, delete, export selected lines, and the rest.

### The fix

`SubtitleGridSelectedItems` now returns the rows sorted by their position in `Subtitles`, so the order is the subtitle's regardless of how the user selected. One pass over the list rather than `IndexOf` per row, and the single-selection case (every arrow key) short-circuits before any of it.

Two follow-ons:

- `AudioVisualizerOnToggleSelection` toggled a row by mutating the list it got from the property; that now has to go through `SubtitleGrid.SelectedItems` directly, since the property is a snapshot.
- Two spots that already worked around the old order (an `OrderBy(IndexOf)` in the duration-distribution command and a comment in delete) no longer need to.

The `OrderBy(p => p.StartTime)` in the playback and shot-change commands is deliberate and left alone — those are about time, not row order.

### Tests

New `SubtitleGridSelectionOrderTests` drives real mouse clicks against a headless main window and asserts subtitle order after shift-click in both directions, after ctrl-click on a row above, and that the clicked row is still the current row after a reverse shift-click. Full UI suite: 1270 passed.