### PR TITLE
Prepare v5.2.0-beta3

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,40 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.2.0-beta3 (4th of August 2026)
+
+* Extract ARIB STD-B24 captions from transport streams (Japanese ISDB, Brazilian SBTVD)
+* Add D-Cinema interop properties dialog - thx igitlin
+* ASSA: embed fonts from the font collector, in the style editor and in batch convert
+* OCR: auto-detect source language and let the dictionary follow the language combo - thx fraternl
+* Text to speech: output language for CosyVoice3/Qwen3 cross-lingual cloning - thx subof
+* Text to speech: OmniVoice now works on Pascal/Volta CUDA cards - thx subof
+* Fix common errors: draggable splitter between the fixes and the preview - thx perkesfurmah-collab
+* Accessibility: announce grid time codes and name the Shortcuts list items - thx Shaima-Almarzooqi
+* Fix video playback on Windows ARM64 (an x64 mpv was downloaded) - thx Shaima-Almarzooqi
+* Fix crash on macOS with AV1 video by updating the bundled dav1d - thx almog6500
+* Fix "Copy text only" pasting lines out of order for a reverse selection - thx hisui3393
+* Fix keyboard navigation of the menu bar with no subtitle loaded - thx GrampaWildWilly
+* Auto-translate via copy-paste: overwrite re-translated lines instead of appending them - thx revov
+* Fix window cleanup running twice when closing - thx ivandrofly
+* Fix "Remove formatting - font name" doing nothing - thx Ironship
+* Fix Enter not working in the "Replace with" box - thx Ironship
+* Fix Escape not closing the "Generating audio" window - thx Ironship
+* Fix double key handling in the Media info window - thx Ironship
+* Fix the indeterminate progress bar not resetting on stop - thx Ironship
+* Fix the output folder field staying disabled in Batch convert settings - thx Ironship
+* Fix Binary OCR database windows showing nOCR titles - thx Ironship
+* Fix the burn-in window layout: progress bar overlapping the file size box - thx Ironship
+* Fix the file size converter keeping the suffix of the previously loaded language - thx Ironship
+* Use the dark theme background in the syntax text editor - thx pdjdev
+* Add "Pl." (plaza) to the Spanish abbreviation list - thx fraternl
+* Localize many remaining hardcoded strings (downloads, export menus, engines) - thx Ironship
+* Update Polish translation - thx potplayer-fanpack
+* Update Turkish translation - thx bilimiyorum
+* Update Portuguese (Brazil) translation - thx igorruckert
+
+-----------------------------------------------------------------------------------------------------
+
 v5.2.0-beta2 (3rd of August 2026)
 
 * Add type-to-search to all combo boxes - thx 9jfcc

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -18,7 +18,7 @@ public class Se
     internal const int CurrentMacOsFontMigrationVersion = 1;
     internal const int CurrentShortcutsMigrationVersion = 1;
 
-    public static string Version { get; set; } = "v5.2.0-beta2";
+    public static string Version { get; set; } = "v5.2.0-beta3";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Change log section for **v5.2.0-beta3** plus the version bump in `src/ui/Logic/Config/Se.cs`.

Entry set compiled by ancestor-checking every merged PR's merge commit against the `v5.2.0-beta2` tag (`cc8f0f5ba`), so it covers everything that landed after the beta2 build — including #13109/#13112/#13115, which merged shortly *after* the tag was cut and therefore never shipped in beta2.

Highlights:

- ARIB STD-B24 caption extraction from transport streams (#13171)
- D-Cinema interop properties dialog (#13170)
- ASSA font embedding in the style editor and batch convert (#13166, #13167)
- Windows ARM64 playback fix (#13169) and the macOS AV1/dav1d crash fix (#13174)
- The large localization batch from @Ironship, condensed into one line

Skipped as internal-only: test-leak fixes (#13154), the Copilot-review follow-ups (#13153, #13143) and the converter type/NaN fixes that had no visible effect (#13122, #13144).

One note: #13108 (Portuguese (Brazil)) *was* in the beta2 build but was missing from the beta2 change log, so it is credited here instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)