### PR TITLE
Spell check: detect the subtitle language again after open/import

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -446,6 +446,7 @@ public partial class MainViewModel :
     private static SolidColorBrush _errorBrush = new SolidColorBrush(_errorColor);
     private SpellCheckDictionaryDisplay? _currentSpellCheckDictionary;
     private bool _spellCheckSessionInProgress;
+    private bool _reDetectSpellCheckLanguage;
     private FfmpegMediaInfo2? _mediaInfo;
     string _dropDownFormatsSearchText = string.Empty;
     private System.Timers.Timer _dropDownFormatsSearchTimer = new System.Timers.Timer(1000);
@@ -1944,6 +1945,7 @@ public partial class MainViewModel :
         UpdateVideoOffsetStatus();
         _currentSpellCheckDictionary = null;
         _spellCheckSessionInProgress = false;
+        _reDetectSpellCheckLanguage = true;
         _autoTrimLanguageCode = null;
 
         if (format != null)
@@ -6310,20 +6312,14 @@ public partial class MainViewModel :
             return;
         }
 
-        // Fall back to the last dictionary used, so the spell check window opens with the same
-        // language as the previous session instead of re-detecting it.
-        var spellCheckDictionary = _currentSpellCheckDictionary;
-        if (spellCheckDictionary == null && !string.IsNullOrEmpty(Se.Settings.SpellCheck.LastLanguageDictionaryName))
-        {
-            spellCheckDictionary = new SpellCheckDictionaryDisplay
-            {
-                Name = Se.Settings.SpellCheck.LastLanguageDictionaryName,
-                DictionaryFileName = Se.Settings.SpellCheck.LastLanguageDictionaryFile ?? string.Empty,
-            };
-        }
+        // Only a dictionary the user picked explicitly for the subtitle currently loaded is passed
+        // on - it is cleared in ResetSubtitle, so open/import lets the window detect the language
+        // again (issue #13117). The dictionary of the previous session lives in
+        // Se.Settings.SpellCheck and is applied inside the window, where it can be weighed against
+        // the detected language instead of overriding it.
         var result = await ShowDialogAsync<SpellCheckWindow, SpellCheckViewModel>(vm =>
         {
-            vm.Initialize(Subtitles, SelectedSubtitleIndex, this, spellCheckDictionary, _spellCheckSessionInProgress);
+            vm.Initialize(Subtitles, SelectedSubtitleIndex, this, _currentSpellCheckDictionary, _spellCheckSessionInProgress);
         });
 
         // Only an unfinished spell check leaves something to continue from, and only then is the
@@ -16611,8 +16607,31 @@ public partial class MainViewModel :
         return null;
     }
 
+    /// <summary>
+    /// Re-detects the live spell check language after a reset filled the grid with new content -
+    /// an import that runs OCR, "import plain text", a join/merge and so on. Those paths call
+    /// ResetSubtitle, which drops the dictionary the user picked, but the spell check manager keeps
+    /// the dictionary of the previous file loaded, so the imported text would keep being underlined
+    /// against the language of the file before it (issue #13117). Auto detection costs ~15 ms on a
+    /// 900 line subtitle, so it is tied to a preceding reset instead of running on every grid fill:
+    /// operations that only rewrite the current subtitle (fix common errors, undo) do not reset and
+    /// keep their dictionary, including its "ignore all" list.
+    /// </summary>
+    private void ReDetectSpellCheckLanguageIfPending()
+    {
+        if (!_reDetectSpellCheckLanguage)
+        {
+            return;
+        }
+
+        _reDetectSpellCheckLanguage = false;
+        SetupLiveSpellCheck();
+    }
+
     private void SetupLiveSpellCheck()
     {
+        _reDetectSpellCheckLanguage = false;
+
         // A dictionary the user picked explicitly (live spell check context menu or the spell
         // check window) wins over auto detection - otherwise the next call here would silently
         // revert to the auto detected language. It is cleared in ResetSubtitle.
@@ -17705,6 +17724,8 @@ public partial class MainViewModel :
         {
             grid!.ItemsSource = Subtitles;
         }
+
+        ReDetectSpellCheckLanguageIfPending();
     }
 
     private void SetSubtitles(Subtitle subtitle, Subtitle? subtitleOriginal = null)
@@ -17733,6 +17754,8 @@ public partial class MainViewModel :
         SubtitleGrid.ItemsSource = Subtitles;
 
         _updateAudioVisualizer = true;
+
+        ReDetectSpellCheckLanguageIfPending();
     }
 
     private void SetSubtitles(List<SubtitleLineViewModel> subtitles)
@@ -17750,6 +17773,8 @@ public partial class MainViewModel :
 
         SubtitleGrid.ItemsSource = Subtitles;
         _updateAudioVisualizer = true;
+
+        ReDetectSpellCheckLanguageIfPending();
     }
 
     public bool HasChanges()

--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -606,77 +606,54 @@ public partial class SpellCheckViewModel : ObservableObject, IClosingCleanup
             subtitle.Paragraphs.Add(p);
         }
 
-        var languageCode = LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(subtitle);
-        if (languageCode == null)
-        {
-            languageCode = "en";
-        }
+        var detectedLanguageCode = LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(subtitle);
+        var languageCode = detectedLanguageCode ?? "en";
+
+        // Hunspell entries are identified by dictionary file; MS Word entries have no file and are
+        // identified by name only. A dictionary the user picked explicitly wins over detection - it
+        // is only kept for the subtitle currently loaded, so it cannot carry a language over from an
+        // earlier file. When it matches nothing (file deleted since last session, name stored under
+        // another OS locale) the detected language is used instead.
+        var pickedDictionary = spellCheckDictionary == null
+            ? null
+            : (!string.IsNullOrEmpty(spellCheckDictionary.DictionaryFileName)
+                   ? Dictionaries.FirstOrDefault(l => l.DictionaryFileName.Equals(spellCheckDictionary.DictionaryFileName, StringComparison.OrdinalIgnoreCase))
+                   : null)
+              ?? Dictionaries.FirstOrDefault(l => l.Name.Equals(spellCheckDictionary.Name, StringComparison.OrdinalIgnoreCase));
 
         if (_spellCheckManager.WordSpellChecker != null)
         {
-            try
-            {
-                var languages = _spellCheckManager.WordSpellChecker.GetInstalledLanguages();
-                var culture = new CultureInfo(languageCode);
-                var text = culture.NativeName; // "Português (Portugal)"
-                var startIndex = text.IndexOf('(') + 1;
-                var endIndex = text.IndexOf(')', startIndex);
-                if (startIndex > 0 && endIndex > startIndex)
-                {
-                    var languageName = text.AsMemory(startIndex, endIndex - startIndex);
-                    if (!string.IsNullOrWhiteSpace(Se.Settings.SpellCheck.LastLanguageDictionaryName) && Se.Settings.SpellCheck.LastLanguageDictionaryName.Contains(languageName.Span, StringComparison.OrdinalIgnoreCase))
-                    {
-                        var selectedLan = languages.FirstOrDefault(l => l.Name.Contains(Se.Settings.SpellCheck.LastLanguageDictionaryName, StringComparison.OrdinalIgnoreCase));
-                        if (selectedLan != null)
-                        {
-                            _spellCheckManager.WordSpellChecker.CurrentLanguage = selectedLan;
-                            SelectedDictionary = Dictionaries.FirstOrDefault(l => l.Name.Equals(selectedLan.Name, StringComparison.OrdinalIgnoreCase));
-                            return;
-                        }
-                    }
-
-                    var selectedLanguage = languages.FirstOrDefault(l => l.Name.Contains(languageName.Span, StringComparison.OrdinalIgnoreCase));
-                    if (selectedLanguage != null)
-                    {
-                        _spellCheckManager.WordSpellChecker.CurrentLanguage = selectedLanguage;
-                        SelectedDictionary = Dictionaries.FirstOrDefault(l => l.Name.Equals(selectedLanguage.Name, StringComparison.OrdinalIgnoreCase));
-                    }
-                }
-            }
-            catch
-            {
-                // ignore
-            }
+            SetWordLanguage(detectedLanguageCode, pickedDictionary);
             return;
         }
 
         var threeLetterCode = Iso639Dash2LanguageCode.GetThreeLetterCodeFromTwoLetterCode(languageCode);
-        SelectedDictionary = Dictionaries.FirstOrDefault(p => p.GetThreeLetterCode().Equals(threeLetterCode, StringComparison.OrdinalIgnoreCase));
+        var detectedDictionary = Dictionaries.FirstOrDefault(p => p.GetThreeLetterCode().Equals(threeLetterCode, StringComparison.OrdinalIgnoreCase));
 
-        if (spellCheckDictionary is not null)
-        {
-            // Hunspell entries are identified by dictionary file; MS Word entries have no file
-            // and are identified by name only. When the passed dictionary matches nothing (file
-            // deleted since last session, name stored under another OS locale), keep the
-            // auto-detected dictionary instead of clearing it.
-            SelectedDictionary = (!string.IsNullOrEmpty(spellCheckDictionary.DictionaryFileName)
-                    ? Dictionaries.FirstOrDefault(l => l.DictionaryFileName.Equals(spellCheckDictionary.DictionaryFileName, StringComparison.OrdinalIgnoreCase))
-                    : null)
-                ?? Dictionaries.FirstOrDefault(l => l.Name.Equals(spellCheckDictionary.Name, StringComparison.OrdinalIgnoreCase))
-                ?? SelectedDictionary;
-        }
-
-        if (SelectedDictionary == null)
+        if (detectedDictionary == null)
         {
             // Match on the file name ("de_DE.dic" starts with "de") — the display name is
             // localized ("German"/"Deutsch") and does not reliably start with the ISO code.
-            SelectedDictionary = Dictionaries.FirstOrDefault(l =>
+            detectedDictionary = Dictionaries.FirstOrDefault(l =>
                 Path.GetFileName(l.DictionaryFileName).StartsWith(languageCode, StringComparison.OrdinalIgnoreCase));
         }
 
+        SelectedDictionary = pickedDictionary;
+
         if (SelectedDictionary == null)
         {
-            SelectedDictionary = FindLastUsedDictionary(Dictionaries);
+            // The dictionary of the previous session is only a dialect refinement within the
+            // detected language - it keeps "en_GB" over "en_US" for an English subtitle, but it
+            // must not force English onto a Dutch one just because English was spell checked
+            // last (issue #13117). It does stay the best guess when nothing was detected or when
+            // the detected language has no dictionary installed.
+            var lastUsedDictionary = FindLastUsedDictionary(Dictionaries);
+            var keepLastUsed = lastUsedDictionary != null &&
+                               (detectedLanguageCode == null ||
+                                detectedDictionary == null ||
+                                lastUsedDictionary.GetThreeLetterCode().Equals(detectedDictionary.GetThreeLetterCode(), StringComparison.OrdinalIgnoreCase));
+
+            SelectedDictionary = keepLastUsed ? lastUsedDictionary : detectedDictionary;
         }
 
         if (SelectedDictionary == null && Dictionaries.Count > 0)
@@ -688,6 +665,78 @@ public partial class SpellCheckViewModel : ObservableObject, IClosingCleanup
         {
             _spellCheckManager.Initialize(SelectedDictionary.DictionaryFileName, SpellCheckDictionaryDisplay.GetTwoLetterLanguageCode(SelectedDictionary));
         }
+    }
+
+    /// <summary>
+    /// Selects the MS Word language matching the subtitle. Word has no dictionary files - its
+    /// languages are matched by name, and the selection is applied to the Word instance too.
+    /// Leaves the selection made in <see cref="LoadDictionaries"/> (the language of the previous
+    /// session) untouched when nothing matches.
+    /// </summary>
+    private void SetWordLanguage(string? detectedLanguageCode, SpellCheckDictionaryDisplay? pickedDictionary)
+    {
+        var wordSpellChecker = _spellCheckManager.WordSpellChecker;
+        if (wordSpellChecker == null)
+        {
+            return;
+        }
+
+        try
+        {
+            var languages = wordSpellChecker.GetInstalledLanguages();
+
+            if (pickedDictionary != null && SelectWordLanguage(languages, l => l.Name.Equals(pickedDictionary.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                return;
+            }
+
+            if (detectedLanguageCode == null)
+            {
+                return;
+            }
+
+            // Word reports its languages by local name - "Dutch (Netherlands)" on an English Word,
+            // "Nederlands (Nederland)" on a Dutch one - so the detected language is matched by both
+            // its English and its native name. A two letter code gives a neutral culture, whose
+            // name carries no region in parentheses to match on.
+            var culture = new CultureInfo(detectedLanguageCode);
+            var detectedNames = new[] { culture.EnglishName, culture.NativeName }
+                .Where(n => !string.IsNullOrWhiteSpace(n))
+                .ToArray();
+
+            // The language of the previous session is only a dialect refinement within the detected
+            // language ("English (United Kingdom)" over "English (United States)"); it must not
+            // force English onto a Dutch subtitle just because English was checked last (#13117).
+            var lastUsedName = Se.Settings.SpellCheck.LastLanguageDictionaryName;
+            if (!string.IsNullOrWhiteSpace(lastUsedName) &&
+                detectedNames.Any(n => lastUsedName.Contains(n, StringComparison.OrdinalIgnoreCase)) &&
+                SelectWordLanguage(languages, l => l.Name.Contains(lastUsedName, StringComparison.OrdinalIgnoreCase)))
+            {
+                return;
+            }
+
+            SelectWordLanguage(languages, l => detectedNames.Any(n => l.Name.Contains(n, StringComparison.OrdinalIgnoreCase)));
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+
+    private bool SelectWordLanguage(List<WordSpellCheckLanguage> languages, Func<WordSpellCheckLanguage, bool> predicate)
+    {
+        var language = languages.FirstOrDefault(predicate);
+        var dictionary = language == null
+            ? null
+            : Dictionaries.FirstOrDefault(l => l.Name.Equals(language.Name, StringComparison.OrdinalIgnoreCase));
+        if (language == null || dictionary == null)
+        {
+            return false;
+        }
+
+        _spellCheckManager.WordSpellChecker!.CurrentLanguage = language;
+        SelectedDictionary = dictionary;
+        return true;
     }
 
     [RelayCommand]

--- a/tests/UI/Features/SpellCheck/SpellCheckLanguageSelectionTests.cs
+++ b/tests/UI/Features/SpellCheck/SpellCheckLanguageSelectionTests.cs
@@ -1,0 +1,193 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.Logic.Ocr;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+
+namespace UITests.Features.SpellCheck;
+
+/// <summary>
+/// The spell check window has to open on the language of the subtitle in front of the user. It used
+/// to open on the dictionary of the previous spell check instead, so a Dutch subtitle was checked
+/// against English when English was checked last - every word flagged (issue #13117).
+/// </summary>
+public class SpellCheckLanguageSelectionTests : IDisposable
+{
+    private readonly string _originalDictionariesFolder;
+    private readonly Func<string> _originalSpellCheckDictionariesFolder;
+    private readonly string? _originalLastLanguageDictionaryFile;
+    private readonly string? _originalLastLanguageDictionaryName;
+    private readonly string _tempDictionariesFolder;
+
+    private static readonly string[] DutchLines =
+    {
+        "Ik heb het niet gezien, maar dat is niet erg.",
+        "Wat doe je hier zo laat op de avond?",
+        "Hij zei dat ze morgen zouden komen.",
+        "Dat is een goed idee, maar we hebben geen tijd.",
+        "Kun je mij even helpen met deze koffer?",
+        "Ze wonen al jaren in dat kleine huis.",
+        "Ik weet niet waar hij naartoe is gegaan.",
+        "We moeten nu echt gaan, anders komen we te laat.",
+    };
+
+    private static readonly string[] EnglishLines =
+    {
+        "I have not seen it, but that is not a problem.",
+        "What are you doing here so late in the evening?",
+        "He said that they would come tomorrow.",
+        "That is a good idea, but we do not have the time.",
+        "Can you help me with this suitcase for a moment?",
+        "They have lived in that small house for years.",
+        "I do not know where he has gone.",
+        "We really have to go now, or we will be late.",
+    };
+
+    public SpellCheckLanguageSelectionTests()
+    {
+        _originalDictionariesFolder = Se.DictionariesFolder;
+        _originalSpellCheckDictionariesFolder = SpellCheckConfig.DictionariesFolder;
+        _originalLastLanguageDictionaryFile = Se.Settings.SpellCheck.LastLanguageDictionaryFile;
+        _originalLastLanguageDictionaryName = Se.Settings.SpellCheck.LastLanguageDictionaryName;
+
+        _tempDictionariesFolder = Path.Combine(Path.GetTempPath(), "SeSpellCheckLanguage_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDictionariesFolder);
+
+        // Three dictionaries: two English dialects (so "keep the dialect of the previous session"
+        // is an actual choice) and the Dutch one the subtitle should land on.
+        WriteDictionary("en_US", "color", "neighbor");
+        WriteDictionary("en_GB", "colour", "neighbour");
+        WriteDictionary("nl_NL", "kleur", "buurman");
+
+        Se.DictionariesFolder = _tempDictionariesFolder;
+        SpellCheckConfig.DictionariesFolder = () => _tempDictionariesFolder;
+    }
+
+    private void WriteDictionary(string name, params string[] words)
+    {
+        File.WriteAllText(Path.Combine(_tempDictionariesFolder, name + ".aff"), "SET UTF-8\n");
+        File.WriteAllText(Path.Combine(_tempDictionariesFolder, name + ".dic"), words.Length + "\n" + string.Join("\n", words) + "\n");
+    }
+
+    private string DictionaryPath(string name)
+    {
+        return Path.Combine(_tempDictionariesFolder, name + ".dic");
+    }
+
+    private void SetLastUsedDictionary(string name)
+    {
+        Se.Settings.SpellCheck.LastLanguageDictionaryFile = DictionaryPath(name);
+        Se.Settings.SpellCheck.LastLanguageDictionaryName = name;
+    }
+
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private sealed class NullFocusSubtitleLine : IFocusSubtitleLine
+    {
+        public void GoToAndFocusLine(SubtitleLineViewModel p)
+        {
+        }
+    }
+
+    private static ObservableCollection<SubtitleLineViewModel> MakeSubtitles(string[] lines)
+    {
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>();
+        foreach (var line in lines)
+        {
+            subtitles.Add(new SubtitleLineViewModel { Text = line });
+        }
+
+        return subtitles;
+    }
+
+    private static SpellCheckViewModel MakeViewModel()
+    {
+        return new SpellCheckViewModel(
+            new SpellCheckManager(),
+            new WindowService(new NullServiceProvider()),
+            new FileHelper(),
+            new BluRayHelper(),
+            new OcrImageSourceHolder());
+    }
+
+    private static string SelectedDictionaryName(SpellCheckViewModel vm)
+    {
+        return Path.GetFileNameWithoutExtension(vm.SelectedDictionary!.DictionaryFileName);
+    }
+
+    [AvaloniaFact]
+    public void DutchSubtitle_AfterEnglishSpellCheck_UsesDutch()
+    {
+        SetLastUsedDictionary("en_US");
+        var vm = MakeViewModel();
+
+        vm.Initialize(MakeSubtitles(DutchLines), 0, new NullFocusSubtitleLine(), null);
+
+        Assert.Equal("nl_NL", SelectedDictionaryName(vm));
+    }
+
+    [AvaloniaFact]
+    public void EnglishSubtitle_KeepsTheDialectOfThePreviousSpellCheck()
+    {
+        // en_GB was used last; detection only knows "en", so the remembered dialect has to survive
+        // instead of falling back to whichever English dictionary happens to be listed first.
+        SetLastUsedDictionary("en_GB");
+        var vm = MakeViewModel();
+
+        vm.Initialize(MakeSubtitles(EnglishLines), 0, new NullFocusSubtitleLine(), null);
+
+        Assert.Equal("en_GB", SelectedDictionaryName(vm));
+    }
+
+    [AvaloniaFact]
+    public void DictionaryPickedForThisSubtitle_WinsOverDetection()
+    {
+        SetLastUsedDictionary("nl_NL");
+        var vm = MakeViewModel();
+
+        // What the main window passes after the user picked a dictionary for the subtitle it has
+        // loaded - a deliberate choice that detection must not undo.
+        var picked = new SpellCheckDictionaryDisplay { Name = "en_US", DictionaryFileName = DictionaryPath("en_US") };
+
+        vm.Initialize(MakeSubtitles(DutchLines), 0, new NullFocusSubtitleLine(), picked);
+
+        Assert.Equal("en_US", SelectedDictionaryName(vm));
+    }
+
+    [AvaloniaFact]
+    public void SubtitleWithoutDetectableLanguage_KeepsTheDictionaryOfThePreviousSpellCheck()
+    {
+        SetLastUsedDictionary("en_GB");
+        var vm = MakeViewModel();
+
+        vm.Initialize(MakeSubtitles(new[] { "123", "- ...", "?!" }), 0, new NullFocusSubtitleLine(), null);
+
+        Assert.Equal("en_GB", SelectedDictionaryName(vm));
+    }
+
+    public void Dispose()
+    {
+        Se.DictionariesFolder = _originalDictionariesFolder;
+        SpellCheckConfig.DictionariesFolder = _originalSpellCheckDictionariesFolder;
+        Se.Settings.SpellCheck.LastLanguageDictionaryFile = _originalLastLanguageDictionaryFile;
+        Se.Settings.SpellCheck.LastLanguageDictionaryName = _originalLastLanguageDictionaryName;
+
+        try
+        {
+            Directory.Delete(_tempDictionariesFolder, true);
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+}


### PR DESCRIPTION
Fixes #13117.

Reported as "after a Dutch subtitle is OCR'd the spell check is not prepared" — the window opens on the language of the *previous* spell check, so every Dutch word is flagged. The reporter also noted that "fix OCR errors" gets the language right, which is the useful clue: this is not a detection failure.

Auto detection is fine — on the attached `koning.nl.srt` (900 lines) `LanguageAutoDetect.AutoDetectGoogleLanguageOrNull` returns `nl`. The detected dictionary was simply overwritten afterwards.

### What went wrong

`SetLanguage` detects the language and selects the matching dictionary, then unconditionally replaces it with the dictionary passed in by the caller. `ShowSpellCheck` always passed one: `_currentSpellCheckDictionary` is cleared in `ResetSubtitle`, but it then rebuilt a stand-in from `Se.Settings.SpellCheck.LastLanguageDictionary*`, which survives across files and sessions.

### Changes

**Spell check window language.** `ShowSpellCheck` passes only a dictionary the user picked for the subtitle currently loaded. Since that is cleared on reset, open/import detects again. The remembered dictionary is applied inside `SetLanguage` as a *dialect refinement within the detected language*, so `en_GB` still wins over `en_US` for an English subtitle but cannot claim a Dutch one. It remains the fallback when nothing is detected, or when the detected language has no dictionary installed.

**MS Word provider.** Its branch matched the detected language against the region in parentheses of the culture's native name, but the detected code is two letters, i.e. a neutral culture with no region — `nl` gives `Nederlands`, not `Nederlands (Nederland)`. The block could never run, so the Word provider did no detection at all and always kept the previous session's language. It now matches Word's language names against both the English and the native name of the detected language, with the same dialect-only role for the remembered one.

**Live spell check after imports.** The 12 import paths that run OCR call `ResetSubtitle` and fill the grid without re-arming live spell check, so imported text kept being underlined against the language of the file before it. Only `SubtitleOpen`, transcription and video OCR did it. A reset now marks the language for re-detection and the grid fill acts on it, covering every import path in one place. Detection costs ~15 ms on a 900-line subtitle, so it is tied to a preceding reset: operations that only rewrite the current subtitle (fix common errors, undo) keep their dictionary — and with it their session-only "ignore all" list.

### Tests

New `SpellCheckLanguageSelectionTests` (headless, temp dictionary folder with `en_US`, `en_GB`, `nl_NL`):

- Dutch subtitle after an English spell check → Dutch
- English subtitle keeps the `en_GB` dialect remembered from last time
- a dictionary picked for this subtitle still overrides detection
- a subtitle with no detectable language keeps the previous dictionary

Full UI suite: 1274 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)