### PR TITLE
Add MP4 DASH/CMAF subtitle support (wvtt, stpp, tx3g in fragmented MP4)

### DIFF
--- a/src/libse/ContainerFormats/Mp4/Boxes/Mdia.cs
+++ b/src/libse/ContainerFormats/Mp4/Boxes/Mdia.cs
@@ -13,7 +13,8 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
         public readonly string HandlerType;
         public readonly string HandlerName = string.Empty;
 
-        public bool IsTextSubtitle => HandlerType == "sbtl" || HandlerType == "text";
+        // "subt" is the handler for stpp (TTML/IMSC1) tracks, ISO/IEC 14496-30
+        public bool IsTextSubtitle => HandlerType == "sbtl" || HandlerType == "text" || HandlerType == "subt";
 
         public bool IsVobSubSubtitle => HandlerType == "subp";
 

--- a/src/libse/ContainerFormats/Mp4/Boxes/Moof.cs
+++ b/src/libse/ContainerFormats/Mp4/Boxes/Moof.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 
 namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
 {
@@ -7,7 +8,16 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
     /// </summary>
     public class Moof : Box
     {
-        public Traf Traf { get; set; }
+        /// <summary>
+        /// All track fragments in this movie fragment. A muxed fMP4/DASH segment has one
+        /// traf per track (video + audio + subtitles), so keeping only one loses data.
+        /// </summary>
+        public List<Traf> Trafs { get; } = new List<Traf>();
+
+        /// <summary>
+        /// First track fragment (for callers that only handle single-track fragments).
+        /// </summary>
+        public Traf Traf => Trafs.Count > 0 ? Trafs[0] : null;
 
         public Moof(Stream fs, ulong maximumLength)
         {
@@ -21,7 +31,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
 
                 if (Name == "traf")
                 {
-                    Traf = new Traf(fs, Position);
+                    Trafs.Add(new Traf(fs, Position));
                 }
 
                 fs.Seek((long)Position, SeekOrigin.Begin);

--- a/src/libse/ContainerFormats/Mp4/Boxes/Moov.cs
+++ b/src/libse/ContainerFormats/Mp4/Boxes/Moov.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
@@ -10,6 +10,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
     {
         public Mvhd Mvhd;
         public List<Trak> Tracks;
+        public List<Trex> Trexs = new List<Trex>();
 
         public Moov(Stream fs, ulong maximumLength)
         {
@@ -29,6 +30,26 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                 else if (Name == "mvhd")
                 {
                     Mvhd = new Mvhd(fs);
+                }
+                else if (Name == "mvex") // Movie Extends Box - fragment defaults
+                {
+                    var mvexEnd = Position;
+                    while (fs.Position < (long)mvexEnd)
+                    {
+                        if (!InitializeSizeAndName(fs))
+                        {
+                            return;
+                        }
+
+                        if (Name == "trex")
+                        {
+                            Trexs.Add(new Trex(fs, Size));
+                        }
+
+                        fs.Seek((long)Position, SeekOrigin.Begin);
+                    }
+
+                    Position = mvexEnd;
                 }
 
                 fs.Seek((long)Position, SeekOrigin.Begin);

--- a/src/libse/ContainerFormats/Mp4/Boxes/Stbl.cs
+++ b/src/libse/ContainerFormats/Mp4/Boxes/Stbl.cs
@@ -357,6 +357,18 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                                 paragraphs.Add(new Paragraph(wvttText.ToString(), before * 1000.0, totalTime * 1000.0));
                             }
                         }
+                        else if (stsdCodec == "stpp") // TTML/IMSC1 in MP4 (ISO 14496-30)
+                        {
+                            if (sampleSize <= 10_000_000)
+                            {
+                                var sampleData = new byte[sampleSize];
+                                fs.Seek((long)sampleOffset, SeekOrigin.Begin);
+                                if (fs.Read(sampleData, 0, sampleData.Length) == sampleData.Length)
+                                {
+                                    AddTtmlSample(sampleData, before * 1000.0, (totalTime - before) * 1000.0, paragraphs);
+                                }
+                            }
+                        }
                         else
                         {
                             fs.Seek((long)sampleOffset, SeekOrigin.Begin);
@@ -426,6 +438,44 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
             }
 
             return paragraphs;
+        }
+
+        private readonly HashSet<string> _addedTtmlCues = new HashSet<string>();
+
+        /// <summary>
+        /// An stpp sample is a complete TTML document covering the sample's time window;
+        /// cue times inside the document are media times (or sample-relative for Smooth
+        /// Streaming style documents), and cues spanning several samples are repeated in
+        /// each document, so duplicates are dropped.
+        /// </summary>
+        private void AddTtmlSample(byte[] sampleData, double sampleStartMs, double sampleDurationMs, List<Paragraph> paragraphs)
+        {
+            var xml = Encoding.UTF8.GetString(sampleData);
+            foreach (var doc in Mp4TtmlHelper.SplitTtmlDocuments(xml))
+            {
+                var docParagraphs = Mp4TtmlHelper.ParseTtmlDocument(doc);
+                if (docParagraphs.Count == 0)
+                {
+                    continue;
+                }
+
+                if (Mp4TtmlHelper.AreTimesSampleRelative(docParagraphs, sampleStartMs, sampleDurationMs))
+                {
+                    foreach (var p in docParagraphs)
+                    {
+                        p.StartTime.TotalMilliseconds += sampleStartMs;
+                        p.EndTime.TotalMilliseconds += sampleStartMs;
+                    }
+                }
+
+                foreach (var p in docParagraphs)
+                {
+                    if (_addedTtmlCues.Add($"{p.StartTime.TotalMilliseconds:0}|{p.EndTime.TotalMilliseconds:0}|{p.Text}"))
+                    {
+                        paragraphs.Add(p);
+                    }
+                }
+            }
         }
 
         private static string GetC608Text(SerializedRow[] screen)

--- a/src/libse/ContainerFormats/Mp4/Boxes/Traf.cs
+++ b/src/libse/ContainerFormats/Mp4/Boxes/Traf.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 
 namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
 {
@@ -7,8 +8,17 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
     /// </summary>
     public class Traf : Box
     {
+        /// <summary>
+        /// All track fragment runs, in file order. ISO/IEC 14496-12 allows several trun
+        /// boxes per traf; keeping only the last one dropped all earlier sample runs.
+        /// </summary>
+        public List<Trun> Truns { get; } = new List<Trun>();
 
-        public Trun Trun { get; set; }
+        /// <summary>
+        /// First track fragment run (for callers that only handle a single run).
+        /// </summary>
+        public Trun Trun => Truns.Count > 0 ? Truns[0] : null;
+
         public Tfdt Tfdt { get; set; }
         public Tfhd Tfhd { get; set; }
 
@@ -24,7 +34,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
 
                 if (Name == "trun")
                 {
-                    Trun = new Trun(fs, Position);
+                    Truns.Add(new Trun(fs, Position));
                 }
                 else if (Name == "tfhd")
                 {
@@ -38,31 +48,34 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                 fs.Seek((long)Position, SeekOrigin.Begin);
             }
 
-            if (Trun?.Samples == null)
+            foreach (var trun in Truns)
             {
-                return;
-            }
-
-            foreach (var timeSegment in Trun.Samples)
-            {
-                if (Tfdt != null)
-                {
-                    timeSegment.BaseMediaDecodeTime = Tfdt.BaseMediaDecodeTime;
-                }
-
-                if (Tfhd == null)
+                if (trun.Samples == null)
                 {
                     continue;
                 }
 
-                if (timeSegment.Duration == null && Tfhd.DefaultSampleDuration != null)
+                foreach (var timeSegment in trun.Samples)
                 {
-                    timeSegment.Duration = Tfhd.DefaultSampleDuration;
-                }
+                    if (Tfdt != null)
+                    {
+                        timeSegment.BaseMediaDecodeTime = Tfdt.BaseMediaDecodeTime;
+                    }
 
-                if (timeSegment.Size == null && Tfhd.DefaultSampleSize != null)
-                {
-                    timeSegment.Size = Tfhd.DefaultSampleSize;
+                    if (Tfhd == null)
+                    {
+                        continue;
+                    }
+
+                    if (timeSegment.Duration == null && Tfhd.DefaultSampleDuration != null)
+                    {
+                        timeSegment.Duration = Tfhd.DefaultSampleDuration;
+                    }
+
+                    if (timeSegment.Size == null && Tfhd.DefaultSampleSize != null)
+                    {
+                        timeSegment.Size = Tfhd.DefaultSampleSize;
+                    }
                 }
             }
         }

--- a/src/libse/ContainerFormats/Mp4/Boxes/Trex.cs
+++ b/src/libse/ContainerFormats/Mp4/Boxes/Trex.cs
@@ -1,0 +1,40 @@
+﻿using System.IO;
+
+namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
+{
+    /// <summary>
+    /// Track Extends Box (moov/mvex/trex) - per-track defaults for movie fragments.
+    /// A fragment sample without a duration/size in trun or tfhd uses these.
+    /// </summary>
+    public class Trex : Box
+    {
+        public readonly uint TrackId;
+        public readonly uint DefaultSampleDescriptionIndex;
+        public readonly uint DefaultSampleDuration;
+        public readonly uint DefaultSampleSize;
+        public readonly uint DefaultSampleFlags;
+
+        public Trex(Stream fs, ulong size)
+        {
+            var bufferSize = (long)size - 8;
+            if (bufferSize < 24)
+            {
+                return;
+            }
+
+            Buffer = new byte[24];
+            var bytesRead = fs.Read(Buffer, 0, Buffer.Length);
+            if (bytesRead < Buffer.Length)
+            {
+                return;
+            }
+
+            // version + flags at 0
+            TrackId = GetUInt(4);
+            DefaultSampleDescriptionIndex = GetUInt(8);
+            DefaultSampleDuration = GetUInt(12);
+            DefaultSampleSize = GetUInt(16);
+            DefaultSampleFlags = GetUInt(20);
+        }
+    }
+}

--- a/src/libse/ContainerFormats/Mp4/CmafParser.cs
+++ b/src/libse/ContainerFormats/Mp4/CmafParser.cs
@@ -88,14 +88,17 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
 
             ulong timePeriodStart = 0; // ???
             ulong timeScale = 0;
-            if (Moov?.Tracks[0].Mdia.Mdhd.TimeScale > 0)
-            {
-                timeScale = Moov.Tracks[0].Mdia.Mdhd.TimeScale;
-            }
 
+            // Fragment ticks are media-track times, so the track's mdhd timescale is the
+            // right clock; the movie (mvhd) timescale is only a fallback.
             if (Moov?.Mvhd?.TimeScale > 0)
             {
                 timeScale = Moov.Mvhd.TimeScale;
+            }
+
+            if (Moov?.Tracks?.Count > 0 && Moov.Tracks[0].Mdia?.Mdhd?.TimeScale > 0)
+            {
+                timeScale = Moov.Tracks[0].Mdia.Mdhd.TimeScale;
             }
 
             if (timeScale == 0)
@@ -121,7 +124,10 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
                     // payloads.
                     if (payload != null)
                     {
-                        Subtitle.Paragraphs.Add(new Paragraph(payload, timePeriodStart + startTime / timeScale, timePeriodStart + currentTime / timeScale));
+                        // Paragraph takes milliseconds; integer tick division truncated to whole seconds
+                        var startMs = (timePeriodStart + startTime) / (double)timeScale * 1000.0;
+                        var endMs = (timePeriodStart + currentTime) / (double)timeScale * 1000.0;
+                        Subtitle.Paragraphs.Add(new Paragraph(payload, startMs, endMs));
                     }
                 }
             }

--- a/src/libse/ContainerFormats/Mp4/Mp4Parser.cs
+++ b/src/libse/ContainerFormats/Mp4/Mp4Parser.cs
@@ -22,6 +22,11 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
         public Subtitle VttcSubtitle { get; private set; }
         public string VttcLanguage { get; private set; }
 
+        /// <summary>
+        /// Sample codec of <see cref="VttcSubtitle"/>: "wvtt", "stpp" or "tx3g".
+        /// </summary>
+        public string VttcCodec { get; private set; }
+
         public Subtitle TrunCea608Subtitle { get; private set; }
         public Subtitle TrunCea708Subtitle { get; private set; }
         private List<Cea608.CcData> _trunCea608CcData = new List<Cea608.CcData>();
@@ -151,7 +156,6 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
             Position = 0;
             fs.Seek(0, SeekOrigin.Begin);
             var moreBytes = true;
-            var timeTotalMs = 0d;
             while (moreBytes)
             {
                 moreBytes = InitializeSizeAndName(fs);
@@ -167,67 +171,12 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
                 else if (Name == "moof")
                 {
                     Moof = new Moof(fs, Position);
-
-                    if (Moof.Traf?.Trun?.DataOffset != null && Moof.Traf.Tfdt != null)
-                    {
-                        var dts = Moof.Traf.Tfdt.BaseMediaDecodeTime;
-                        var startPosition = (uint)(Moof.StartPosition + Moof.Traf.Trun.DataOffset.Value);
-                        for (var index = 0; index < Moof.Traf.Trun.Samples.Count; index++)
-                        {
-                            var sample = Moof.Traf.Trun.Samples[index];
-                            if (sample.Size.HasValue)
-                            {
-                                var ccData = GetCcDataHelper.GetCcData(fs, startPosition, sample.Size.Value);
-                                if (ccData.Count > 0)
-                                {
-                                    if (sample.TimeOffset.HasValue)
-                                    {
-                                        ccData[0].Time = (ulong)((long)dts + sample.TimeOffset.Value);
-                                    }
-
-                                    _trunCea608CcData.Add(ccData[0]); //TODO: can there be more than one?
-                                }
-
-                                startPosition += sample.Size.Value;
-                            }
-
-                            if (sample.Duration.HasValue)
-                            {
-                                dts += sample.Duration.Value;
-                            }
-                        }
-                    }
+                    ApplyTrexDefaults();
+                    ReadFragmentedCcSamples(fs);
                 }
-                else if (Name == "mdat" && Moof != null && Moof?.Traf?.Trun?.Samples?.Count > 0)
+                else if (Name == "mdat" && Moof != null)
                 {
-                    var mdat = new Mdat(fs, Position);
-                    if (Moof.Traf?.Trun?.Samples.Count > 0)
-                    {
-                        if (VttcSubtitle == null)
-                        {
-                            VttcSubtitle = new Subtitle();
-
-                            if (Moov?.Tracks.FirstOrDefault()?.Mdia?.Mdhd != null)
-                            {
-                                var track = Moov.Tracks.FirstOrDefault();
-                                VttcLanguage = track.Mdia.Mdhd.Iso639ThreeLetterCode;
-                                if (string.IsNullOrEmpty(VttcLanguage))
-                                {
-                                    VttcLanguage = track.Mdia.Mdhd.LanguageString;
-                                }
-                            }
-                        }
-
-                        if (Moof.Traf.Trun.Samples.All(p => p.Size != null))
-                        {
-                            ReadVttWithSize(mdat, Moof.Traf.Trun.Samples, ref timeTotalMs);
-                        }
-                        else
-                        {
-                            ReadVttWithoutSize(mdat.Vtts, Moof.Traf.Trun.Samples, ref timeTotalMs);
-                        }
-                    }
-
+                    ReadFragmentedTextSamples(fs, (ulong)fs.Position, Position);
                     Moof = null;
                 }
 
@@ -246,6 +195,19 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
             }
 
             fs.Close();
+
+            // Surface the first fragmented text track that produced cues (DASH/CMAF
+            // subtitle representations, or the subtitle track of a muxed fMP4).
+            var bestFragmentedTrack = _fragmentedTextTracks.FirstOrDefault(p => p.Subtitle.Paragraphs.Count > 0);
+            if (bestFragmentedTrack != null)
+            {
+                var sorted = bestFragmentedTrack.Subtitle.Paragraphs.OrderBy(p => p.StartTime.TotalMilliseconds).ToList();
+                bestFragmentedTrack.Subtitle.Paragraphs.Clear();
+                bestFragmentedTrack.Subtitle.Paragraphs.AddRange(sorted);
+                VttcSubtitle = bestFragmentedTrack.Subtitle;
+                VttcLanguage = bestFragmentedTrack.Language;
+                VttcCodec = bestFragmentedTrack.Codec;
+            }
 
             if (VttcSubtitle != null)
             {
@@ -575,7 +537,15 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
 
         private void DisplayScreen(DataOutput data)
         {
+            // Fragment ticks are media-track times, so prefer the video track's mdhd
+            // timescale; the movie (mvhd) timescale is only a fallback.
             var timeScale = Moov?.Mvhd?.TimeScale ?? 1000.0;
+            var videoTrack = GetVideoTracks().FirstOrDefault();
+            if (videoTrack?.Mdia?.Mdhd?.TimeScale > 0)
+            {
+                timeScale = videoTrack.Mdia.Mdhd.TimeScale;
+            }
+
             var startMs = data.Start / timeScale * 1000.0;
             var endMs = data.End / timeScale * 1000.0;
             var p = new Paragraph(GetText(data.Screen), startMs, endMs);
@@ -598,16 +568,516 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
             return sb.ToString().Trim();
         }
 
-        private void ReadVttWithSize(Mdat mdat, List<TimeSegment> trunSamples, ref double timeTotalMs)
+        private sealed class FragmentedTextTrack
+        {
+            public uint? TrackId { get; set; }
+            public Subtitle Subtitle { get; } = new Subtitle();
+            public string Language { get; set; }
+            public string Codec { get; set; } // "wvtt", "stpp" or "tx3g"
+            public double LegacyTimeTotalMs; // running clock for fragments without data offsets
+            public long NextTicks; // running decode time for fragments without tfdt
+            public HashSet<string> AddedTtmlCues { get; } = new HashSet<string>();
+        }
+
+        private readonly List<FragmentedTextTrack> _fragmentedTextTracks = new List<FragmentedTextTrack>();
+
+        private Trak FindTrack(uint? trackId)
+        {
+            if (trackId == null || Moov?.Tracks == null)
+            {
+                return null;
+            }
+
+            foreach (var trak in Moov.Tracks)
+            {
+                if (trak.Tkhd?.TrackId == trackId.Value)
+                {
+                    return trak;
+                }
+            }
+
+            return Moov.Tracks.Count == 1 ? Moov.Tracks[0] : null;
+        }
+
+        /// <summary>
+        /// Timescale for a fragment's ticks (tfdt/sample durations). Those are media-track
+        /// times, so the track's mdhd timescale applies - the movie (mvhd) timescale is a
+        /// different clock and using it skewed all DASH/CMAF cue times by their ratio.
+        /// </summary>
+        private double GetTrackTimeScale(Trak trak)
+        {
+            if (trak?.Mdia?.Mdhd?.TimeScale > 0)
+            {
+                return trak.Mdia.Mdhd.TimeScale;
+            }
+
+            if (Moov?.Tracks?.Count == 1 && Moov.Tracks[0].Mdia?.Mdhd?.TimeScale > 0)
+            {
+                return Moov.Tracks[0].Mdia.Mdhd.TimeScale;
+            }
+
+            if (Moov?.Mvhd?.TimeScale > 0)
+            {
+                return Moov.Mvhd.TimeScale;
+            }
+
+            return 1000.0;
+        }
+
+        /// <summary>
+        /// Fills fragment samples that carry no duration/size in trun or tfhd with the
+        /// per-track defaults from moov/mvex/trex (common for the last DASH segment,
+        /// whose tfhd often omits default-sample-duration).
+        /// </summary>
+        private void ApplyTrexDefaults()
+        {
+            if (Moov == null || Moov.Trexs.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var traf in Moof.Trafs)
+            {
+                var trackId = traf.Tfhd?.TrackId;
+                Trex trex = null;
+                foreach (var t in Moov.Trexs)
+                {
+                    if (trackId == null || t.TrackId == trackId.Value)
+                    {
+                        trex = t;
+                        break;
+                    }
+                }
+
+                if (trex == null)
+                {
+                    continue;
+                }
+
+                foreach (var trun in traf.Truns)
+                {
+                    foreach (var sample in trun.Samples)
+                    {
+                        if (sample.Duration == null && trex.DefaultSampleDuration > 0)
+                        {
+                            sample.Duration = trex.DefaultSampleDuration;
+                        }
+
+                        if (sample.Size == null && trex.DefaultSampleSize > 0)
+                        {
+                            sample.Size = trex.DefaultSampleSize;
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// CEA-608/708 byte pairs from the pending moof's sample runs (H.264 SEI in
+        /// fragmented video). Only video/clcp tracks can carry them; text and audio
+        /// track fragments are skipped.
+        /// </summary>
+        private void ReadFragmentedCcSamples(Stream fs)
+        {
+            foreach (var traf in Moof.Trafs)
+            {
+                var trak = FindTrack(traf.Tfhd?.TrackId);
+                if (trak?.Mdia != null && !trak.Mdia.IsVideo && !trak.Mdia.IsClosedCaption)
+                {
+                    continue;
+                }
+
+                if (traf.Tfdt == null)
+                {
+                    continue;
+                }
+
+                var dts = traf.Tfdt.BaseMediaDecodeTime;
+                var haveStartPosition = false;
+                ulong startPosition = 0;
+                foreach (var trun in traf.Truns)
+                {
+                    if (trun.DataOffset != null)
+                    {
+                        startPosition = (ulong)((long)Moof.StartPosition + trun.DataOffset.Value);
+                        haveStartPosition = true;
+                    }
+
+                    if (!haveStartPosition)
+                    {
+                        break;
+                    }
+
+                    for (var index = 0; index < trun.Samples.Count; index++)
+                    {
+                        var sample = trun.Samples[index];
+                        if (sample.Size.HasValue)
+                        {
+                            var ccData = GetCcDataHelper.GetCcData(fs, startPosition, sample.Size.Value);
+                            if (ccData.Count > 0)
+                            {
+                                if (sample.TimeOffset.HasValue)
+                                {
+                                    ccData[0].Time = (ulong)((long)dts + sample.TimeOffset.Value);
+                                }
+
+                                _trunCea608CcData.Add(ccData[0]); //TODO: can there be more than one?
+                            }
+
+                            startPosition += sample.Size.Value;
+                        }
+
+                        if (sample.Duration.HasValue)
+                        {
+                            dts += sample.Duration.Value;
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Text subtitle samples (wvtt/stpp/tx3g) from the pending moof's track fragments.
+        /// Slices exact sample byte ranges via trun data offsets and sizes, so it also works
+        /// for muxed fMP4 where the mdat interleaves video/audio/subtitle data. Falls back
+        /// to scanning the mdat for WebVTT cue boxes when no offsets are available.
+        /// </summary>
+        private void ReadFragmentedTextSamples(Stream fs, ulong mdatDataStart, ulong mdatEnd)
+        {
+            foreach (var traf in Moof.Trafs)
+            {
+                var trackId = traf.Tfhd?.TrackId;
+                var trak = FindTrack(trackId);
+                if (trak?.Mdia != null && !trak.Mdia.IsTextSubtitle)
+                {
+                    continue; // audio/video/vobsub; CEA captions are handled at moof time
+                }
+
+                var samples = new List<TimeSegment>();
+                foreach (var trun in traf.Truns)
+                {
+                    samples.AddRange(trun.Samples);
+                }
+
+                if (samples.Count == 0)
+                {
+                    continue;
+                }
+
+                var stsdCodec = trak?.Mdia?.Minf?.Stbl?.Stsd?.Name;
+                var timeScale = GetTrackTimeScale(trak);
+                var track = GetFragmentedTextTrack(trackId, trak);
+
+                var haveOffsets = traf.Tfhd?.BaseDataOffset != null || traf.Truns[0].DataOffset != null;
+                var haveSizes = samples.All(p => p.Size != null);
+                if (haveOffsets && haveSizes)
+                {
+                    ReadFragmentedTextSamplesPrecise(fs, traf, stsdCodec, timeScale, track);
+                }
+                else
+                {
+                    fs.Seek((long)mdatDataStart, SeekOrigin.Begin);
+                    var mdat = new Mdat(fs, mdatEnd);
+                    if (track.Codec == null && mdat.Vtts.Count > 0)
+                    {
+                        track.Codec = "wvtt";
+                    }
+
+                    if (haveSizes)
+                    {
+                        ReadVttWithSize(track, mdat, samples, timeScale);
+                    }
+                    else
+                    {
+                        ReadVttWithoutSize(track, mdat.Vtts, samples, timeScale);
+                    }
+                }
+            }
+        }
+
+        private FragmentedTextTrack GetFragmentedTextTrack(uint? trackId, Trak trak)
+        {
+            foreach (var existing in _fragmentedTextTracks)
+            {
+                if (existing.TrackId == trackId)
+                {
+                    return existing;
+                }
+            }
+
+            var track = new FragmentedTextTrack { TrackId = trackId };
+            var mdhd = trak?.Mdia?.Mdhd ?? Moov?.Tracks?.FirstOrDefault()?.Mdia?.Mdhd;
+            if (mdhd != null)
+            {
+                track.Language = mdhd.Iso639ThreeLetterCode;
+                if (string.IsNullOrEmpty(track.Language))
+                {
+                    track.Language = mdhd.LanguageString;
+                }
+            }
+
+            _fragmentedTextTracks.Add(track);
+            return track;
+        }
+
+        private void ReadFragmentedTextSamplesPrecise(Stream fs, Traf traf, string stsdCodec, double timeScale, FragmentedTextTrack track)
+        {
+            const uint maxSampleSize = 10_000_000; // subtitle samples are small; guard against malformed sizes
+
+            // without a tfdt, fragment times continue from the previous fragment of this track
+            var ticks = traf.Tfdt != null ? (long)traf.Tfdt.BaseMediaDecodeTime : track.NextTicks;
+            var baseOffset = traf.Tfhd?.BaseDataOffset ?? Moof.StartPosition;
+            var samplePosition = baseOffset;
+            foreach (var trun in traf.Truns)
+            {
+                if (trun.DataOffset != null)
+                {
+                    samplePosition = (ulong)((long)baseOffset + trun.DataOffset.Value);
+                }
+
+                foreach (var sample in trun.Samples)
+                {
+                    var size = sample.Size ?? 0;
+                    var startTicks = ticks + (sample.TimeOffset ?? 0);
+                    var durationTicks = sample.Duration ?? 0;
+                    if (sample.Duration.HasValue)
+                    {
+                        ticks += sample.Duration.Value;
+                    }
+
+                    var startMs = startTicks / timeScale * 1000.0;
+                    var durationMs = durationTicks / timeScale * 1000.0;
+
+                    if (size > 2 && size <= maxSampleSize && samplePosition + size <= (ulong)fs.Length)
+                    {
+                        var buffer = new byte[size];
+                        fs.Seek((long)samplePosition, SeekOrigin.Begin);
+                        if (fs.Read(buffer, 0, buffer.Length) == buffer.Length)
+                        {
+                            AddFragmentedTextSample(buffer, stsdCodec, startMs, durationMs, track);
+                        }
+                    }
+
+                    samplePosition += size;
+                }
+            }
+
+            track.NextTicks = ticks;
+        }
+
+        private static void AddFragmentedTextSample(byte[] sample, string stsdCodec, double startMs, double durationMs, FragmentedTextTrack track)
+        {
+            var kind = stsdCodec ?? SniffTextSampleKind(sample);
+            if (track.Codec == null && kind != null)
+            {
+                track.Codec = kind;
+            }
+
+            if (kind == "wvtt")
+            {
+                ReadWvttSample(sample, startMs, durationMs, track);
+            }
+            else if (kind == "stpp")
+            {
+                ReadStppSample(sample, startMs, durationMs, track);
+            }
+            else if (kind != null)
+            {
+                ReadTx3gSample(sample, startMs, durationMs, track); // tx3g / generic MPEG-4 timed text
+            }
+        }
+
+        /// <summary>
+        /// Codec guess for a subtitle sample when no moov is available (a lone DASH .m4s
+        /// segment without its init file): wvtt samples are ISO-BMFF boxes, stpp samples
+        /// are TTML XML documents, tx3g samples are a 16-bit length + UTF-8 text.
+        /// </summary>
+        private static string SniffTextSampleKind(byte[] sample)
+        {
+            if (sample.Length >= 8)
+            {
+                var boxSize = System.Buffers.Binary.BinaryPrimitives.ReadUInt32BigEndian(sample.AsSpan(0, 4));
+                if (boxSize >= 8 && boxSize <= (uint)sample.Length)
+                {
+                    var boxName = Encoding.ASCII.GetString(sample, 4, 4);
+                    if (boxName == "vttc" || boxName == "vtte" || boxName == "vtta")
+                    {
+                        return "wvtt";
+                    }
+                }
+            }
+
+            var i = 0;
+            if (sample.Length >= 3 && sample[0] == 0xEF && sample[1] == 0xBB && sample[2] == 0xBF)
+            {
+                i = 3; // skip UTF-8 BOM
+            }
+
+            while (i < sample.Length && (sample[i] == (byte)' ' || sample[i] == (byte)'\t' || sample[i] == (byte)'\r' || sample[i] == (byte)'\n'))
+            {
+                i++;
+            }
+
+            if (i < sample.Length && sample[i] == (byte)'<')
+            {
+                return "stpp";
+            }
+
+            if (sample.Length >= 2)
+            {
+                int textSize = System.Buffers.Binary.BinaryPrimitives.ReadUInt16BigEndian(sample.AsSpan(0, 2));
+                if (textSize == sample.Length - 2)
+                {
+                    return "tx3g";
+                }
+
+                // text followed by tx3g modifier boxes (styl/hlit/hclr/...)
+                if (textSize > 0 && textSize < sample.Length - 2 - 8)
+                {
+                    var boxStart = 2 + textSize;
+                    var boxSize = System.Buffers.Binary.BinaryPrimitives.ReadUInt32BigEndian(sample.AsSpan(boxStart, 4));
+                    var boxName = Encoding.ASCII.GetString(sample, boxStart + 4, 4);
+                    if (boxSize >= 8 && boxStart + (long)boxSize <= sample.Length &&
+                        (boxName == "styl" || boxName == "hlit" || boxName == "hclr" || boxName == "krok" || boxName == "dlay" || boxName == "href" || boxName == "tbox" || boxName == "blnk" || boxName == "twrp"))
+                    {
+                        return "tx3g";
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static void ReadWvttSample(byte[] sample, double startMs, double durationMs, FragmentedTextTrack track)
+        {
+            if (durationMs <= 0)
+            {
+                return;
+            }
+
+            string payloadText = null;
+            string style = null;
+            var pos = 0;
+            while (pos + 8 <= sample.Length)
+            {
+                var boxSize = (int)System.Buffers.Binary.BinaryPrimitives.ReadUInt32BigEndian(sample.AsSpan(pos, 4));
+                if (boxSize < 8 || pos + boxSize > sample.Length)
+                {
+                    break;
+                }
+
+                var boxName = Encoding.ASCII.GetString(sample, pos + 4, 4);
+                if (boxName == "vttc")
+                {
+                    var inner = pos + 8;
+                    var end = pos + boxSize;
+                    while (inner + 8 <= end)
+                    {
+                        var innerSize = (int)System.Buffers.Binary.BinaryPrimitives.ReadUInt32BigEndian(sample.AsSpan(inner, 4));
+                        if (innerSize < 8 || inner + innerSize > end)
+                        {
+                            break;
+                        }
+
+                        var innerName = Encoding.ASCII.GetString(sample, inner + 4, 4);
+                        var contentLength = innerSize - 8;
+                        if (innerName == "payl" && contentLength > 0 && contentLength < 5000)
+                        {
+                            var s = GetString(sample, inner + 8, contentLength).Trim();
+                            payloadText = payloadText == null ? s : payloadText + Environment.NewLine + s;
+                        }
+                        else if (innerName == "sttg" && contentLength > 0 && contentLength < 5000)
+                        {
+                            style = GetString(sample, inner + 8, contentLength).Trim();
+                        }
+
+                        inner += innerSize;
+                    }
+                }
+                // vtte = empty cue (gap marker), vtta = additional text - skip both
+
+                pos += boxSize;
+            }
+
+            if (string.IsNullOrEmpty(payloadText))
+            {
+                return;
+            }
+
+            var p = new Paragraph(payloadText, startMs, startMs + durationMs);
+            var positionInfo = WebVTT.GetPositionInfo(style);
+            if (!string.IsNullOrEmpty(positionInfo))
+            {
+                p.Text = positionInfo + p.Text;
+                p.Extra = style;
+                track.Subtitle.Header = "WEBVTT";
+            }
+
+            track.Subtitle.Paragraphs.Add(p);
+        }
+
+        private static void ReadStppSample(byte[] sample, double startMs, double durationMs, FragmentedTextTrack track)
+        {
+            var xml = Encoding.UTF8.GetString(sample);
+            foreach (var doc in Mp4TtmlHelper.SplitTtmlDocuments(xml))
+            {
+                var docParagraphs = Mp4TtmlHelper.ParseTtmlDocument(doc);
+                if (docParagraphs.Count == 0)
+                {
+                    continue;
+                }
+
+                if (Mp4TtmlHelper.AreTimesSampleRelative(docParagraphs, startMs, durationMs))
+                {
+                    foreach (var p in docParagraphs)
+                    {
+                        p.StartTime.TotalMilliseconds += startMs;
+                        p.EndTime.TotalMilliseconds += startMs;
+                    }
+                }
+
+                foreach (var p in docParagraphs)
+                {
+                    // documents repeat cues that span segment boundaries - add each cue once
+                    if (track.AddedTtmlCues.Add($"{p.StartTime.TotalMilliseconds:0}|{p.EndTime.TotalMilliseconds:0}|{p.Text}"))
+                    {
+                        track.Subtitle.Paragraphs.Add(p);
+                    }
+                }
+            }
+        }
+
+        private static void ReadTx3gSample(byte[] sample, double startMs, double durationMs, FragmentedTextTrack track)
+        {
+            if (sample.Length < 2 || durationMs <= 0)
+            {
+                return;
+            }
+
+            int textSize = System.Buffers.Binary.BinaryPrimitives.ReadUInt16BigEndian(sample.AsSpan(0, 2));
+            if (textSize == 0 || textSize > sample.Length - 2)
+            {
+                return;
+            }
+
+            var text = GetString(sample, 2, textSize).TrimEnd();
+            if (string.IsNullOrEmpty(text))
+            {
+                return;
+            }
+
+            track.Subtitle.Paragraphs.Add(new Paragraph(text, startMs, startMs + durationMs));
+        }
+
+        private void ReadVttWithSize(FragmentedTextTrack track, Mdat mdat, List<TimeSegment> trunSamples, double timeScale)
         {
             var payloadIndex = 0;
-            var timeScale = Moov?.Mvhd?.TimeScale ?? 1000.0;
             foreach (var timeSegment in trunSamples)
             {
-                var before = timeTotalMs;
+                var before = track.LegacyTimeTotalMs;
                 if (timeSegment.Duration.HasValue)
                 {
-                    timeTotalMs += timeSegment.Duration.Value / timeScale * 1000.0;
+                    track.LegacyTimeTotalMs += timeSegment.Duration.Value / timeScale * 1000.0;
                 }
 
                 var timeSegmentSize = timeSegment.Size;
@@ -619,7 +1089,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
 
                     if (timeSegment.Duration.HasValue && payload != null)
                     {
-                        AddVttParagraph(timeTotalMs, payload, before, style);
+                        AddVttParagraph(track, track.LegacyTimeTotalMs, payload, before, style);
                     }
 
                     while (payloadIndex + 1 < mdat.Vtts.Count && timeSegmentSize >= payloadSize + mdat.Vtts[payloadIndex + 1].PayloadSize)
@@ -630,7 +1100,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
 
                         if (timeSegment.Duration.HasValue && payload != null)
                         {
-                            AddVttParagraph(timeTotalMs, payload, before, style);
+                            AddVttParagraph(track, track.LegacyTimeTotalMs, payload, before, style);
                         }
 
                         payloadSize += mdat.Vtts[payloadIndex].PayloadSize; // add 8
@@ -641,7 +1111,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
             }
         }
 
-        private void AddVttParagraph(double timeTotalMs, string payload, double before, string style)
+        private static void AddVttParagraph(FragmentedTextTrack track, double timeTotalMs, string payload, double before, string style)
         {
             var p = new Paragraph(payload, before, timeTotalMs);
             var positionInfo = WebVTT.GetPositionInfo(style);
@@ -649,31 +1119,31 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
             {
                 p.Text = positionInfo + p.Text;
                 p.Extra = style;
-                VttcSubtitle.Header = "WEBVTT";
+                track.Subtitle.Header = "WEBVTT";
             }
-            VttcSubtitle.Paragraphs.Add(p);
+
+            track.Subtitle.Paragraphs.Add(p);
         }
 
-        private void ReadVttWithoutSize(List<Vttc.VttData> vtts, List<TimeSegment> trunSamples, ref double timeTotalMs)
+        private static void ReadVttWithoutSize(FragmentedTextTrack track, List<Vttc.VttData> vtts, List<TimeSegment> trunSamples, double timeScale)
         {
             if (vtts == null || trunSamples.Count <= 0 || trunSamples.Count < vtts.Count)
             {
                 return;
             }
 
-            var timeScale = Moov?.Mvhd?.TimeScale ?? 1000.0;
             var sampleIdx = 0;
             foreach (var vtt in vtts)
             {
-                var presentation = Moof.Traf.Trun.Samples[sampleIdx];
+                var presentation = trunSamples[sampleIdx];
                 if (presentation.Duration.HasValue)
                 {
-                    var before = timeTotalMs;
-                    timeTotalMs += presentation.Duration.Value / timeScale * 1000.0;
+                    var before = track.LegacyTimeTotalMs;
+                    track.LegacyTimeTotalMs += presentation.Duration.Value / timeScale * 1000.0;
                     sampleIdx++;
                     if (vtt.Payload != null)
                     {
-                        VttcSubtitle.Paragraphs.Add(new Paragraph(vtt.Payload, before, timeTotalMs));
+                        track.Subtitle.Paragraphs.Add(new Paragraph(vtt.Payload, before, track.LegacyTimeTotalMs));
                     }
                 }
             }

--- a/src/libse/ContainerFormats/Mp4/Mp4TtmlHelper.cs
+++ b/src/libse/ContainerFormats/Mp4/Mp4TtmlHelper.cs
@@ -1,0 +1,171 @@
+﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System;
+using System.Collections.Generic;
+
+namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
+{
+    /// <summary>
+    /// Helpers for TTML/IMSC1 ("stpp") subtitle samples in MP4 (ISO/IEC 14496-30).
+    /// </summary>
+    public static class Mp4TtmlHelper
+    {
+        /// <summary>
+        /// Splits concatenated TTML documents. An stpp mdat (or a single large read of one)
+        /// often holds several complete TTML sample documents back to back — one per sample —
+        /// and feeding the concatenation to an XML parser fails on the second document.
+        /// </summary>
+        public static List<string> SplitTtmlDocuments(string text)
+        {
+            var result = new List<string>();
+            if (string.IsNullOrEmpty(text))
+            {
+                return result;
+            }
+
+            var pos = 0;
+            while (pos < text.Length)
+            {
+                var start = FindRootTag(text, pos);
+                if (start < 0)
+                {
+                    break;
+                }
+
+                var close = FindCloseTag(text, start);
+                if (close < 0)
+                {
+                    result.Add(text.Substring(start));
+                    break;
+                }
+
+                result.Add(text.Substring(start, close - start));
+                pos = close;
+            }
+
+            if (result.Count == 0)
+            {
+                result.Add(text);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Index of the next TTML root tag ("&lt;tt&gt;", "&lt;tt ...&gt;" or a namespaced
+        /// "&lt;ns:tt ...&gt;" like "&lt;tt:tt&gt;") at or after <paramref name="startIndex"/>,
+        /// or -1. Plain "&lt;tt" prefix matching is not enough: it would also hit
+        /// "&lt;ttm:title&gt;" inside the document head.
+        /// </summary>
+        private static int FindRootTag(string text, int startIndex)
+        {
+            var pos = startIndex;
+            while (pos < text.Length)
+            {
+                var idx = text.IndexOf("<tt", pos, StringComparison.Ordinal);
+                if (idx < 0)
+                {
+                    return -1;
+                }
+
+                var after = idx + 3;
+                if (after >= text.Length)
+                {
+                    return -1;
+                }
+
+                var c = text[after];
+                if (c == '>' || c == ' ' || c == '\t' || c == '\r' || c == '\n')
+                {
+                    return idx;
+                }
+
+                if (c == ':' && after + 2 < text.Length && text[after + 1] == 't' && text[after + 2] == 't')
+                {
+                    return idx;
+                }
+
+                pos = idx + 1;
+            }
+
+            return -1;
+        }
+
+        /// <summary>
+        /// Index just past the root close tag ("&lt;/tt&gt;" or "&lt;/tt:tt&gt;") that ends the
+        /// document whose root starts at <paramref name="rootIndex"/>, or -1.
+        /// </summary>
+        private static int FindCloseTag(string text, int rootIndex)
+        {
+            var pos = rootIndex;
+            while (pos < text.Length)
+            {
+                var idx = text.IndexOf("</tt", pos, StringComparison.Ordinal);
+                if (idx < 0)
+                {
+                    return -1;
+                }
+
+                var after = idx + 4;
+                if (after < text.Length && (text[after] == '>' || text[after] == ':'))
+                {
+                    var end = text.IndexOf('>', after);
+                    return end < 0 ? -1 : end + 1;
+                }
+
+                pos = idx + 1;
+            }
+
+            return -1;
+        }
+
+        /// <summary>
+        /// Parses a single TTML document into paragraphs. Returns an empty list if the
+        /// document is not valid TTML (e.g. an empty gap-filler document).
+        /// </summary>
+        public static List<Paragraph> ParseTtmlDocument(string xml)
+        {
+            try
+            {
+                var lines = xml.SplitToLines(100_000);
+                var format = new TimedText10();
+                if (!format.IsMine(lines, null))
+                {
+                    return new List<Paragraph>();
+                }
+
+                var subtitle = new Subtitle();
+                format.LoadSubtitle(subtitle, lines, null);
+                return subtitle.Paragraphs;
+            }
+            catch
+            {
+                return new List<Paragraph>();
+            }
+        }
+
+        /// <summary>
+        /// Whether the cue times in a TTML sample document are relative to the sample start
+        /// (Smooth Streaming style zero-based documents) rather than absolute media times.
+        /// If all cues end within the sample's duration while the sample itself starts later,
+        /// the times are segment-relative and must be shifted by the sample start.
+        /// </summary>
+        public static bool AreTimesSampleRelative(List<Paragraph> docParagraphs, double sampleStartMs, double sampleDurationMs)
+        {
+            if (docParagraphs.Count == 0 || sampleStartMs <= 0 || sampleDurationMs <= 0)
+            {
+                return false;
+            }
+
+            foreach (var p in docParagraphs)
+            {
+                if (p.EndTime.TotalMilliseconds > sampleDurationMs)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/libse/SubtitleFormats/IsmtDfxp.cs
+++ b/src/libse/SubtitleFormats/IsmtDfxp.cs
@@ -3,6 +3,7 @@ using Nikse.SubtitleEdit.Core.ContainerFormats.Mp4;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
@@ -52,11 +53,25 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             _errorCount = 0;
             subtitle.Paragraphs.Clear();
             var mp4Parser = new MP4Parser(fileName);
+
+            // Box-aware fragmented parsing (trun sample offsets/sizes) beats the mdat
+            // text-sniffing below - it also works when TTML samples share an mdat with
+            // video/audio data. Use it whenever it found TTML cues.
+            if (mp4Parser.VttcCodec == "stpp" && mp4Parser.VttcSubtitle?.Paragraphs.Count > 0)
+            {
+                subtitle.Paragraphs.AddRange(mp4Parser.VttcSubtitle.Paragraphs);
+                subtitle.Renumber();
+                return;
+            }
+
             var dfxpStrings = mp4Parser.GetMdatsAsStrings();
             SubtitleFormat format = new TimedText10();
             SubtitleFormat format2 = new TimedTextBase64Image();
             SubtitleFormat format3 = new TimedTextImage();
-            foreach (var xmlAsString in dfxpStrings)
+            // An mdat may hold several complete TTML sample documents back to back (one
+            // per sample, e.g. DASH segments with gap-filler documents) - parse each
+            // document separately, as the concatenation is not valid XML.
+            foreach (var xmlAsString in dfxpStrings.SelectMany(Mp4TtmlHelper.SplitTtmlDocuments))
             {
                 try
                 {

--- a/src/seconv/Core/ContainerSubtitleLoader.cs
+++ b/src/seconv/Core/ContainerSubtitleLoader.cs
@@ -37,12 +37,27 @@ internal static class ContainerSubtitleLoader
 
         if (ext is ".mp4" or ".m4v" or ".m4s" or ".3gp")
         {
-            // Old converter applied a 10 KB minimum. Below that, fall through to text loader.
             try
             {
-                if (new FileInfo(filePath).Length > 10_000)
+                var fileLength = new FileInfo(filePath).Length;
+                if (fileLength > 10_000)
                 {
                     return LoadMp4(filePath, options);
+                }
+
+                // Subtitle-only DASH/CMAF files (an init segment plus a few m4s fragments)
+                // are typically just a few KB. Try the MP4 parser, but on failure fall
+                // through to the text loader as the old 10 KB minimum did.
+                if (fileLength > 100)
+                {
+                    try
+                    {
+                        return LoadMp4(filePath, options);
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        // No tracks found; let the text loader try.
+                    }
                 }
             }
             catch

--- a/tests/libse/Core/ContainerFormats/Mp4/Mp4DashSubtitleTest.cs
+++ b/tests/libse/Core/ContainerFormats/Mp4/Mp4DashSubtitleTest.cs
@@ -1,0 +1,445 @@
+using System.Linq;
+using System.Text;
+using Nikse.SubtitleEdit.Core.ContainerFormats.Mp4;
+
+namespace LibSETests.Core.ContainerFormats.Mp4;
+
+/// <summary>
+/// Fragmented MP4 (DASH/CMAF) subtitle extraction: wvtt, stpp and tx3g samples
+/// addressed via moof/traf/trun, with moov only providing track metadata.
+/// </summary>
+public class Mp4DashSubtitleTest
+{
+    // Fragment ticks (tfdt, sample durations) are media-track times, so the track's
+    // mdhd timescale applies. Using the movie (mvhd) timescale skewed all cue times
+    // by mvhd/mdhd - the classic GPAC layout is mvhd=600 vs track=1000, i.e. 5/3 off.
+    [Fact]
+    public void FragmentedWvtt_UsesTrackTimescale_NotMovieTimescale()
+    {
+        var init = BuildInit("text", "wvtt", trackId: 1, mdhdTimeScale: 1000, mvhdTimeScale: 600);
+        var sample = WvttCueSample("Hello DASH");
+        var segment = BuildSegment(trackId: 1, tfdtTicks: 1000, durations: new uint[] { 3000 }, samples: new[] { sample });
+
+        var subtitle = ParseVttc(Concat(init, segment));
+
+        Assert.NotNull(subtitle);
+        var p = Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("Hello DASH", p.Text);
+        Assert.Equal(1000, p.StartTime.TotalMilliseconds, 1);
+        Assert.Equal(4000, p.EndTime.TotalMilliseconds, 1);
+    }
+
+    // A lone DASH media segment (no init) still yields the cue text, timed from tfdt
+    // with the 1000 default timescale.
+    [Fact]
+    public void FragmentedWvtt_LoneSegmentWithoutInit_StillExtractsCue()
+    {
+        var sample = WvttCueSample("Lone segment");
+        var segment = BuildSegment(trackId: 1, tfdtTicks: 4000, durations: new uint[] { 2000 }, samples: new[] { sample });
+
+        var subtitle = ParseVttc(segment);
+
+        Assert.NotNull(subtitle);
+        var p = Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("Lone segment", p.Text);
+        Assert.Equal(4000, p.StartTime.TotalMilliseconds, 1);
+        Assert.Equal(6000, p.EndTime.TotalMilliseconds, 1);
+    }
+
+    // Muxed fMP4: one moof with a traf per track. Keeping only one traf (the old
+    // behaviour) lost the subtitle track whenever audio/video fragments were present;
+    // per-traf data offsets must be honoured so the right mdat bytes are sliced.
+    [Fact]
+    public void FragmentedMuxed_MultipleTrafs_ExtractsSubtitleTraf()
+    {
+        var init = BuildInit("text", "wvtt", trackId: 2, mdhdTimeScale: 1000, mvhdTimeScale: 600,
+            extraTrack: BuildTrak("soun", null, trackId: 1, mdhdTimeScale: 48000));
+
+        var audioJunk = new byte[] { 0xde, 0xad, 0xbe, 0xef, 0x01, 0x02, 0x03, 0x04 };
+        var subtitleSample = WvttCueSample("Muxed cue");
+        var segment = BuildMuxedSegment(
+            (trackId: 1u, tfdtTicks: 0u, durations: new uint[] { 1024 }, samples: new[] { audioJunk }),
+            (trackId: 2u, tfdtTicks: 2000u, durations: new uint[] { 1500 }, samples: new[] { subtitleSample }));
+
+        var subtitle = ParseVttc(Concat(init, segment));
+
+        Assert.NotNull(subtitle);
+        var p = Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("Muxed cue", p.Text);
+        Assert.Equal(2000, p.StartTime.TotalMilliseconds, 1);
+        Assert.Equal(3500, p.EndTime.TotalMilliseconds, 1);
+    }
+
+    // stpp samples are complete TTML documents; cues spanning several samples are
+    // repeated in each document and must be emitted once, at their document times.
+    [Fact]
+    public void FragmentedStpp_TtmlSamples_UseDocumentTimes_AndDeduplicate()
+    {
+        var doc1 = TtmlDoc("<p begin=\"00:00:01.000\" end=\"00:00:06.000\">Long cue</p>");
+        var doc2 = TtmlDoc("<p begin=\"00:00:01.000\" end=\"00:00:06.000\">Long cue</p><p begin=\"00:00:05.000\" end=\"00:00:07.000\">Second</p>");
+        var init = BuildInit("subt", "stpp", trackId: 1, mdhdTimeScale: 1000, mvhdTimeScale: 600);
+        var seg1 = BuildSegment(1, 0, new uint[] { 4000 }, new[] { Encoding.UTF8.GetBytes(doc1) });
+        var seg2 = BuildSegment(1, 4000, new uint[] { 4000 }, new[] { Encoding.UTF8.GetBytes(doc2) });
+
+        var subtitle = ParseVttc(Concat(init, seg1, seg2));
+
+        Assert.NotNull(subtitle);
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+        Assert.Equal("Long cue", subtitle.Paragraphs[0].Text);
+        Assert.Equal(1000, subtitle.Paragraphs[0].StartTime.TotalMilliseconds, 1);
+        Assert.Equal(6000, subtitle.Paragraphs[0].EndTime.TotalMilliseconds, 1);
+        Assert.Equal("Second", subtitle.Paragraphs[1].Text);
+    }
+
+    // Smooth Streaming style documents restart at zero in every fragment; such cues
+    // must be shifted by the sample start (tfdt) to land on the media timeline.
+    [Fact]
+    public void FragmentedStpp_ZeroBasedDocumentTimes_ShiftedBySampleStart()
+    {
+        var doc = TtmlDoc("<p begin=\"00:00:01.000\" end=\"00:00:03.000\">Relative</p>");
+        var init = BuildInit("subt", "stpp", trackId: 1, mdhdTimeScale: 1000, mvhdTimeScale: 600);
+        var segment = BuildSegment(1, 10_000, new uint[] { 4000 }, new[] { Encoding.UTF8.GetBytes(doc) });
+
+        var subtitle = ParseVttc(Concat(init, segment));
+
+        Assert.NotNull(subtitle);
+        var p = Assert.Single(subtitle.Paragraphs);
+        Assert.Equal(11_000, p.StartTime.TotalMilliseconds, 1);
+        Assert.Equal(13_000, p.EndTime.TotalMilliseconds, 1);
+    }
+
+    // A progressive (non-fragmented) TTML track uses handler "subt", which was not
+    // recognized as a text subtitle at all.
+    [Fact]
+    public void ProgressiveStpp_SubtHandler_TrackIsVisible()
+    {
+        var doc = Encoding.UTF8.GetBytes(TtmlDoc("<p begin=\"00:00:02.000\" end=\"00:00:05.000\">Progressive TTML</p>"));
+        var file = BuildProgressive("subt", "stpp", new[] { doc }, sampleDurationTicks: 6000, timeScale: 1000);
+
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(tempFile, file);
+            var parser = new MP4Parser(tempFile);
+            var tracks = parser.GetSubtitleTracks();
+            var track = Assert.Single(tracks);
+            var paragraphs = track.Mdia.Minf.Stbl.GetParagraphs();
+            var p = Assert.Single(paragraphs);
+            Assert.Equal("Progressive TTML", p.Text);
+            Assert.Equal(2000, p.StartTime.TotalMilliseconds, 1);
+            Assert.Equal(5000, p.EndTime.TotalMilliseconds, 1);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    // The last DASH segment often has no sample duration in trun or tfhd; the
+    // per-track default lives in moov/mvex/trex.
+    [Fact]
+    public void TrexDefaultDuration_FillsSamplesWithoutDuration()
+    {
+        var init = BuildInit("text", "wvtt", trackId: 1, mdhdTimeScale: 1000, mvhdTimeScale: 600, trexDefaultDuration: 2500);
+        var sample = WvttCueSample("Trex default");
+        var segment = BuildSegment(trackId: 1, tfdtTicks: 8000, durations: null, samples: new[] { sample });
+
+        var subtitle = ParseVttc(Concat(init, segment));
+
+        Assert.NotNull(subtitle);
+        var p = Assert.Single(subtitle.Paragraphs);
+        Assert.Equal(8000, p.StartTime.TotalMilliseconds, 1);
+        Assert.Equal(10_500, p.EndTime.TotalMilliseconds, 1);
+    }
+
+    [Fact]
+    public void SplitTtmlDocuments_ConcatenatedDocuments_SplitsEach()
+    {
+        var doc1 = TtmlDoc("<p begin=\"00:00:01.000\" end=\"00:00:02.000\">One</p>");
+        var doc2 = TtmlDoc("<p begin=\"00:00:03.000\" end=\"00:00:04.000\">Two</p>");
+
+        var docs = Mp4TtmlHelper.SplitTtmlDocuments(doc1 + doc2);
+
+        Assert.Equal(2, docs.Count);
+        Assert.Contains("One", docs[0]);
+        Assert.DoesNotContain("Two", docs[0]);
+        Assert.Contains("Two", docs[1]);
+    }
+
+    // "<tt" prefix matching alone would also hit "<ttm:title>" in the head and
+    // "</ttm:title>" as a bogus close tag.
+    [Fact]
+    public void SplitTtmlDocuments_TtmMetadataInHead_DoesNotSplitInsideDocument()
+    {
+        var doc = "<?xml version=\"1.0\"?><tt xmlns=\"http://www.w3.org/ns/ttml\" xmlns:ttm=\"http://www.w3.org/ns/ttml#metadata\"><head><metadata><ttm:title>My title</ttm:title></metadata></head><body><div><p begin=\"00:00:01.000\" end=\"00:00:02.000\">One</p></div></body></tt>";
+
+        var docs = Mp4TtmlHelper.SplitTtmlDocuments(doc + doc);
+
+        Assert.Equal(2, docs.Count);
+        Assert.Contains("My title", docs[0]);
+        Assert.Contains("</tt>", docs[0]);
+    }
+
+    [Fact]
+    public void SplitTtmlDocuments_NamespacedRoot_IsRecognized()
+    {
+        var doc = "<tt:tt xmlns:tt=\"http://www.w3.org/ns/ttml\"><tt:body><tt:div><tt:p begin=\"00:00:01.000\" end=\"00:00:02.000\">One</tt:p></tt:div></tt:body></tt:tt>";
+
+        var docs = Mp4TtmlHelper.SplitTtmlDocuments(doc + doc);
+
+        Assert.Equal(2, docs.Count);
+    }
+
+    private static Nikse.SubtitleEdit.Core.Common.Subtitle ParseVttc(byte[] fileBytes)
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(tempFile, fileBytes);
+            return new MP4Parser(tempFile).VttcSubtitle;
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    private static string TtmlDoc(string paragraphs) =>
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?><tt xmlns=\"http://www.w3.org/ns/ttml\" xml:lang=\"en\"><body><div>" + paragraphs + "</div></body></tt>";
+
+    private static byte[] WvttCueSample(string text) =>
+        Box("vttc", Box("payl", Encoding.UTF8.GetBytes(text)));
+
+    /// <summary>Init segment: ftyp + moov with one (or two) tracks and optional mvex/trex.</summary>
+    private static byte[] BuildInit(string handlerType, string stsdCodec, uint trackId, uint mdhdTimeScale, uint mvhdTimeScale, byte[]? extraTrack = null, uint trexDefaultDuration = 0)
+    {
+        var ftyp = Box("ftyp", Ascii("iso6"), UInt32Be(512), Ascii("iso6"), Ascii("dash"));
+
+        var mvhd = BuildMvhd(mvhdTimeScale);
+        var trak = BuildTrak(handlerType, stsdCodec, trackId, mdhdTimeScale);
+
+        var moovParts = new System.Collections.Generic.List<byte[]> { mvhd };
+        if (extraTrack != null)
+        {
+            moovParts.Add(extraTrack);
+        }
+
+        moovParts.Add(trak);
+
+        if (trexDefaultDuration > 0)
+        {
+            var trex = Box("trex",
+                new byte[4],                     // version + flags
+                UInt32Be(trackId),
+                UInt32Be(1),                     // default_sample_description_index
+                UInt32Be(trexDefaultDuration),
+                UInt32Be(0),                     // default_sample_size
+                UInt32Be(0));                    // default_sample_flags
+            moovParts.Add(Box("mvex", trex));
+        }
+
+        var moov = Box("moov", moovParts.ToArray());
+        return Concat(ftyp, moov);
+    }
+
+    private static byte[] BuildMvhd(uint timeScale)
+    {
+        // v0 mvhd content is 100 bytes; the parser reads timescale at offset 12.
+        var content = new byte[100];
+        WriteUInt32Be(content, 12, timeScale);
+        WriteUInt32Be(content, 16, timeScale * 30); // duration
+        return Box("mvhd", content);
+    }
+
+    private static byte[] BuildTrak(string handlerType, string? stsdCodec, uint trackId, uint mdhdTimeScale)
+    {
+        // v0 tkhd content is 84 bytes; track id at offset 12.
+        var tkhdContent = new byte[84];
+        WriteUInt32Be(tkhdContent, 12, trackId);
+        var tkhd = Box("tkhd", tkhdContent);
+
+        var hdlr = Box("hdlr",
+            new byte[4],
+            new byte[4],
+            Ascii(handlerType),
+            new byte[12],
+            new byte[] { 0 });
+
+        var mdhd = Box("mdhd",
+            new byte[4],
+            new byte[4],
+            new byte[4],
+            UInt32Be(mdhdTimeScale),
+            UInt32Be(mdhdTimeScale * 30),
+            UInt16Be(0x55C4),                    // language = "und"
+            UInt16Be(0));
+
+        if (stsdCodec != null)
+        {
+            var stsd = Box("stsd", new byte[4], UInt32Be(1), Box(stsdCodec));
+            var stbl = Box("stbl", stsd,
+                Box("stts", new byte[4], UInt32Be(0)),
+                Box("stsc", new byte[4], UInt32Be(0)),
+                Box("stsz", new byte[4], UInt32Be(0), UInt32Be(0)),
+                Box("stco", new byte[4], UInt32Be(0)));
+            var minf = Box("minf", stbl);
+            return Box("trak", tkhd, Box("mdia", hdlr, mdhd, minf));
+        }
+
+        return Box("trak", tkhd, Box("mdia", hdlr, mdhd));
+    }
+
+    /// <summary>Media segment: styp + moof (single traf) + mdat.</summary>
+    private static byte[] BuildSegment(uint trackId, uint tfdtTicks, uint[]? durations, byte[][] samples)
+    {
+        return BuildMuxedSegment((trackId, tfdtTicks, durations, samples));
+    }
+
+    /// <summary>
+    /// Media segment with one traf per track; all sample data shares one mdat and each
+    /// traf's trun uses a moof-relative data offset to its own byte range.
+    /// </summary>
+    private static byte[] BuildMuxedSegment(params (uint trackId, uint tfdtTicks, uint[]? durations, byte[][] samples)[] tracks)
+    {
+        var styp = Box("styp", Ascii("msdh"), UInt32Be(0), Ascii("msdh"), Ascii("dash"));
+
+        // two passes: trun data offsets depend on the finished moof size
+        var moof = BuildMoof(tracks, new int[tracks.Length]);
+        var dataOffsets = new int[tracks.Length];
+        var runningOffset = moof.Length + 8; // + mdat header
+        for (var i = 0; i < tracks.Length; i++)
+        {
+            dataOffsets[i] = runningOffset;
+            runningOffset += tracks[i].samples.Sum(s => s.Length);
+        }
+
+        moof = BuildMoof(tracks, dataOffsets);
+        var mdat = Box("mdat", tracks.SelectMany(t => t.samples).ToArray());
+        return Concat(styp, moof, mdat);
+    }
+
+    private static byte[] BuildMoof((uint trackId, uint tfdtTicks, uint[]? durations, byte[][] samples)[] tracks, int[] dataOffsets)
+    {
+        var mfhd = Box("mfhd", new byte[4], UInt32Be(1));
+        var trafs = new byte[tracks.Length][];
+        for (var i = 0; i < tracks.Length; i++)
+        {
+            var (trackId, tfdtTicks, durations, samples) = tracks[i];
+
+            var tfhd = Box("tfhd",
+                UInt32Be(0x020000),              // default-base-is-moof, no optional fields
+                UInt32Be(trackId));
+
+            var tfdt = Box("tfdt", new byte[4], UInt32Be(tfdtTicks));
+
+            var trunFlags = 0x000201u;           // data-offset + sample-size
+            if (durations != null)
+            {
+                trunFlags |= 0x000100;           // + sample-duration
+            }
+
+            var trunParts = new System.Collections.Generic.List<byte[]>
+            {
+                UInt32Be(trunFlags),
+                UInt32Be((uint)samples.Length),
+                UInt32Be((uint)dataOffsets[i]),
+            };
+            for (var s = 0; s < samples.Length; s++)
+            {
+                if (durations != null)
+                {
+                    trunParts.Add(UInt32Be(durations[s]));
+                }
+
+                trunParts.Add(UInt32Be((uint)samples[s].Length));
+            }
+
+            var trun = Box("trun", trunParts.ToArray());
+            trafs[i] = Box("traf", tfhd, tfdt, trun);
+        }
+
+        return Box("moof", new[] { mfhd }.Concat(trafs).ToArray());
+    }
+
+    /// <summary>Progressive MP4 with a single subtitle track (classic stbl sample tables).</summary>
+    private static byte[] BuildProgressive(string handlerType, string stsdCodec, byte[][] samples, uint sampleDurationTicks, uint timeScale)
+    {
+        var ftyp = Box("ftyp", Ascii("isom"), UInt32Be(512), Ascii("isom"), Ascii("iso2"));
+        var mdat = Box("mdat", samples);
+        var sampleDataOffset = (uint)(ftyp.Length + 8);
+
+        var stsd = Box("stsd", new byte[4], UInt32Be(1), Box(stsdCodec));
+        var stts = Box("stts", new byte[4], UInt32Be(1), UInt32Be((uint)samples.Length), UInt32Be(sampleDurationTicks));
+        var stsc = Box("stsc", new byte[4], UInt32Be(1), UInt32Be(1), UInt32Be((uint)samples.Length), UInt32Be(1));
+        var stsz = Box("stsz", new byte[4], UInt32Be(0), UInt32Be((uint)samples.Length),
+            Concat(samples.Select(s => UInt32Be((uint)s.Length)).ToArray()));
+        var stco = Box("stco", new byte[4], UInt32Be(1), UInt32Be(sampleDataOffset));
+        var stbl = Box("stbl", stsd, stts, stsc, stsz, stco);
+        var minf = Box("minf", stbl);
+
+        var hdlr = Box("hdlr", new byte[4], new byte[4], Ascii(handlerType), new byte[12], new byte[] { 0 });
+        var mdhd = Box("mdhd", new byte[4], new byte[4], new byte[4],
+            UInt32Be(timeScale), UInt32Be(sampleDurationTicks * (uint)samples.Length), UInt16Be(0x55C4), UInt16Be(0));
+
+        var tkhdContent = new byte[84];
+        WriteUInt32Be(tkhdContent, 12, 1);
+        var trak = Box("trak", Box("tkhd", tkhdContent), Box("mdia", hdlr, mdhd, minf));
+        var moov = Box("moov", trak);
+
+        return Concat(ftyp, mdat, moov);
+    }
+
+    private static byte[] Box(string name, params byte[][] parts)
+    {
+        var total = 8;
+        foreach (var p in parts)
+        {
+            total += p.Length;
+        }
+
+        var box = new byte[total];
+        WriteUInt32Be(box, 0, (uint)total);
+        Encoding.ASCII.GetBytes(name, 0, 4, box, 4);
+        var off = 8;
+        foreach (var p in parts)
+        {
+            System.Buffer.BlockCopy(p, 0, box, off, p.Length);
+            off += p.Length;
+        }
+
+        return box;
+    }
+
+    private static byte[] Concat(params byte[][] parts)
+    {
+        var total = 0;
+        foreach (var p in parts)
+        {
+            total += p.Length;
+        }
+
+        var result = new byte[total];
+        var off = 0;
+        foreach (var p in parts)
+        {
+            System.Buffer.BlockCopy(p, 0, result, off, p.Length);
+            off += p.Length;
+        }
+
+        return result;
+    }
+
+    private static byte[] Ascii(string s) => Encoding.ASCII.GetBytes(s);
+
+    private static byte[] UInt32Be(uint v) => new[] { (byte)(v >> 24), (byte)(v >> 16), (byte)(v >> 8), (byte)v };
+
+    private static byte[] UInt16Be(ushort v) => new[] { (byte)(v >> 8), (byte)v };
+
+    private static void WriteUInt32Be(byte[] dst, int off, uint v)
+    {
+        dst[off] = (byte)(v >> 24);
+        dst[off + 1] = (byte)(v >> 16);
+        dst[off + 2] = (byte)(v >> 8);
+        dst[off + 3] = (byte)v;
+    }
+}


### PR DESCRIPTION
## Summary

Subtitles in MP4 DASH/CMAF files (fragmented MP4) mostly failed to load. This PR makes all common DASH subtitle shapes work — WebVTT (`wvtt`), TTML/IMSC1 (`stpp`) and MPEG-4 timed text (`tx3g`) — whether the file is a subtitle-only DASH representation (init + `.m4s` segments, concatenated or onDemand single-file), a muxed fragmented MP4 with video/audio, a lone `.m4s` segment without its init, or a progressive MP4.

## What was broken

| Problem | Effect |
|---|---|
| Fragmented WebVTT used the movie (`mvhd`) timescale instead of the track's `mdhd` timescale | All DASH-WebVTT cue times skewed (5/3 too late with GPAC's 600/1000 layout) |
| `subt` handler + `stpp` samples unsupported | TTML-in-MP4 tracks completely invisible, progressive and fragmented |
| `Moof` kept one `traf`, `Traf` one `trun`, `tfhd` track ids unused | Muxed fMP4 yielded no subtitles at all |
| `IsmtDfxp` parsed each mdat as a single XML document | mdats holding several TTML sample docs were silently dropped (partial extraction) |
| `moov/mvex/trex` defaults not parsed | Last DASH segment's cue truncated/dropped when `trun`/`tfhd` omit sample durations |
| seconv 10 KB minimum for MP4 | Subtitle-only DASH files (a few KB) never reached the MP4 parser |
| `CmafParser` divided ticks with integer math and preferred `mvhd` | `.cmft` cue times truncated to whole seconds, and in seconds instead of ms |

## What this PR does

- **`Mp4Parser`**: fragmented samples are now sliced precisely per track — all `traf`/`trun` boxes are kept, each fragment resolves its track via `tfhd` track id, sample byte ranges come from data offsets + sizes, and timing comes from `tfdt` + sample durations in the **track** timescale (with per-track continuation when `tfdt` is absent, as in `MP4Box -frag` output). Missing durations/sizes fall back to `mvex/trex` defaults.
- **Sample decoders**: `wvtt` cue boxes (`vttc`/`payl`/`sttg`, incl. position info), `stpp` TTML documents (deduplicating cues repeated across segment documents; zero-based Smooth-Streaming-style docs are shifted by the sample start), and `tx3g` length-prefixed text. Lone `.m4s` segments without an init are sniffed by content.
- **Progressive TTML**: `subt` handler recognized; `stpp` sample parsing added to `Stbl`, so TTML tracks appear as normal subtitle tracks (incl. the track picker).
- **`IsmtDfxp`**: delegates to the box-aware parser when it finds TTML cues; otherwise splits concatenated TTML documents before XML parsing.
- **seconv**: small MP4 files (> 100 bytes) are tried against the MP4 parser, falling back to the text loader as before.
- **`CmafParser`**: correct timescale preference and millisecond math.

## Testing

- 10 new unit tests build minimal init/media segments programmatically: track-vs-movie timescale, lone segment, muxed multi-traf, TTML document times + dedup + zero-based shift, progressive `subt`/`stpp`, `trex` defaults, and TTML document splitting (incl. `ttm:` metadata red herrings and namespaced roots).
- Verified end-to-end against GPAC (MP4Box) DASH packages — live profile (init + 8 `.m4s`), onDemand profile, `-frag` muxed files, and progressive muxes, for all three codecs: every variant now extracts all 6 test cues with timings identical to the progressive reference (previously: wrong times, 3/6 cues, or nothing).
- All existing suites pass: libse 831, seconv 290, libuilogic 140, UI 1270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)