### PR TITLE
Fix MP4 DASH subtitle extraction: namespaced TTML, shifted cues, truncation

### DIFF
--- a/src/libse/ContainerFormats/Mp4/Mp4Parser.cs
+++ b/src/libse/ContainerFormats/Mp4/Mp4Parser.cs
@@ -156,9 +156,25 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
             }
         }
 
+        /// <summary>
+        /// Upper bound on top-level boxes to walk. A DASH/CMAF file holds styp+moof+mdat per
+        /// segment, so a long subtitle representation legitimately has many thousands of them -
+        /// a flat cap silently truncated the extraction (a 2-second-segment file stopped after
+        /// ~33 minutes). Real segments are at least a few hundred bytes, so scale with the file
+        /// size and keep a ceiling so a malformed file still cannot spin for long.
+        /// </summary>
+        private static int GetMaxTopLevelBoxes(long fileLength)
+        {
+            const long minBoxes = 3000;
+            const long maxBoxes = 200_000;
+            var scaled = fileLength / 32;
+            return (int)(scaled < minBoxes ? minBoxes : scaled > maxBoxes ? maxBoxes : scaled);
+        }
+
         private void ParseMp4(Stream fs)
         {
             var count = 0;
+            var maxBoxes = GetMaxTopLevelBoxes(fs.Length);
             Position = 0;
             fs.Seek(0, SeekOrigin.Begin);
             var moreBytes = true;
@@ -187,7 +203,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
                 }
 
                 count++;
-                if (count > 3000)
+                if (count > maxBoxes)
                 {
                     break;
                 }
@@ -714,13 +730,16 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
                 }
 
                 var dts = traf.Tfdt.BaseMediaDecodeTime;
+                // trun data offsets are relative to tfhd's base-data-offset when present
+                // (PIFF/Smooth Streaming sets it), and to the moof start otherwise.
+                var baseOffset = traf.Tfhd?.BaseDataOffset ?? Moof.StartPosition;
                 var haveStartPosition = false;
                 ulong startPosition = 0;
                 foreach (var trun in traf.Truns)
                 {
                     if (trun.DataOffset != null)
                     {
-                        startPosition = (ulong)((long)Moof.StartPosition + trun.DataOffset.Value);
+                        startPosition = (ulong)((long)baseOffset + trun.DataOffset.Value);
                         haveStartPosition = true;
                     }
 

--- a/src/libse/ContainerFormats/Mp4/Mp4TtmlHelper.cs
+++ b/src/libse/ContainerFormats/Mp4/Mp4TtmlHelper.cs
@@ -26,13 +26,13 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
             var pos = 0;
             while (pos < text.Length)
             {
-                var start = FindRootTag(text, pos);
+                var start = FindRootTag(text, pos, out var rootTagName);
                 if (start < 0)
                 {
                     break;
                 }
 
-                var close = FindCloseTag(text, start);
+                var close = FindCloseTag(text, start, rootTagName);
                 if (close < 0)
                 {
                     result.Add(text.Substring(start));
@@ -54,63 +54,86 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
         /// <summary>
         /// Index of the next TTML root tag ("&lt;tt&gt;", "&lt;tt ...&gt;" or a namespaced
         /// "&lt;ns:tt ...&gt;" like "&lt;tt:tt&gt;") at or after <paramref name="startIndex"/>,
-        /// or -1. Plain "&lt;tt" prefix matching is not enough: it would also hit
-        /// "&lt;ttm:title&gt;" inside the document head.
+        /// or -1. <paramref name="rootTagName"/> receives the qualified name as written, so the
+        /// matching close tag can be found by exact name. Plain "&lt;tt" prefix matching is not
+        /// enough: it would also hit "&lt;ttm:title&gt;" inside the document head.
         /// </summary>
-        private static int FindRootTag(string text, int startIndex)
+        private static int FindRootTag(string text, int startIndex, out string rootTagName)
         {
+            rootTagName = null;
             var pos = startIndex;
             while (pos < text.Length)
             {
-                var idx = text.IndexOf("<tt", pos, StringComparison.Ordinal);
-                if (idx < 0)
+                var i = text.IndexOf('<', pos);
+                if (i < 0)
                 {
                     return -1;
                 }
 
-                var after = idx + 3;
-                if (after >= text.Length)
+                pos = i + 1;
+                var nameStart = i + 1;
+                var nameEnd = nameStart;
+                while (nameEnd < text.Length && IsNameChar(text[nameEnd]))
                 {
-                    return -1;
+                    nameEnd++;
                 }
 
-                var c = text[after];
-                if (c == '>' || c == ' ' || c == '\t' || c == '\r' || c == '\n')
+                if (nameEnd == nameStart || nameEnd >= text.Length)
                 {
-                    return idx;
+                    continue; // "</...", "<?xml ...", "<!--" or a truncated tag
                 }
 
-                if (c == ':' && after + 2 < text.Length && text[after + 1] == 't' && text[after + 2] == 't')
+                var afterName = text[nameEnd];
+                if (afterName != '>' && afterName != '/' && afterName != ' ' && afterName != '\t' && afterName != '\r' && afterName != '\n')
                 {
-                    return idx;
+                    continue;
                 }
 
-                pos = idx + 1;
+                var qualifiedName = text.Substring(nameStart, nameEnd - nameStart);
+                var colon = qualifiedName.LastIndexOf(':');
+                var localName = colon < 0 ? qualifiedName : qualifiedName.Substring(colon + 1);
+                if (localName == "tt")
+                {
+                    rootTagName = qualifiedName;
+                    return i;
+                }
             }
 
             return -1;
         }
 
-        /// <summary>
-        /// Index just past the root close tag ("&lt;/tt&gt;" or "&lt;/tt:tt&gt;") that ends the
-        /// document whose root starts at <paramref name="rootIndex"/>, or -1.
-        /// </summary>
-        private static int FindCloseTag(string text, int rootIndex)
+        private static bool IsNameChar(char c)
         {
+            return char.IsLetterOrDigit(c) || c == ':' || c == '_' || c == '-' || c == '.';
+        }
+
+        /// <summary>
+        /// Index just past the close tag that ends the document whose root starts at
+        /// <paramref name="rootIndex"/>, or -1. The close tag must carry the root's own
+        /// qualified name: matching "&lt;/tt" loosely also hits "&lt;/tt:p&gt;", which cut
+        /// namespaced documents off after their first cue.
+        /// </summary>
+        private static int FindCloseTag(string text, int rootIndex, string rootTagName)
+        {
+            var closeTag = "</" + rootTagName;
             var pos = rootIndex;
             while (pos < text.Length)
             {
-                var idx = text.IndexOf("</tt", pos, StringComparison.Ordinal);
+                var idx = text.IndexOf(closeTag, pos, StringComparison.Ordinal);
                 if (idx < 0)
                 {
                     return -1;
                 }
 
-                var after = idx + 4;
-                if (after < text.Length && (text[after] == '>' || text[after] == ':'))
+                var after = idx + closeTag.Length;
+                while (after < text.Length && (text[after] == ' ' || text[after] == '\t' || text[after] == '\r' || text[after] == '\n'))
                 {
-                    var end = text.IndexOf('>', after);
-                    return end < 0 ? -1 : end + 1;
+                    after++;
+                }
+
+                if (after < text.Length && text[after] == '>')
+                {
+                    return after + 1;
                 }
 
                 pos = idx + 1;
@@ -147,8 +170,8 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
         /// <summary>
         /// Whether the cue times in a TTML sample document are relative to the sample start
         /// (Smooth Streaming style zero-based documents) rather than absolute media times.
-        /// If all cues end within the sample's duration while the sample itself starts later,
-        /// the times are segment-relative and must be shifted by the sample start.
+        /// If all cues start before the sample does and end within the sample's duration, the
+        /// times are segment-relative and must be shifted by the sample start.
         /// </summary>
         public static bool AreTimesSampleRelative(List<Paragraph> docParagraphs, double sampleStartMs, double sampleDurationMs)
         {
@@ -159,6 +182,15 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
 
             foreach (var p in docParagraphs)
             {
+                // A cue with absolute media times cannot start before the sample carrying it.
+                // Without this the check misfired on any absolute cue that happened to end
+                // inside the sample duration (long segments, or a track with a start offset),
+                // shifting it a whole sample start too late.
+                if (p.StartTime.TotalMilliseconds >= sampleStartMs)
+                {
+                    return false;
+                }
+
                 if (p.EndTime.TotalMilliseconds > sampleDurationMs)
                 {
                     return false;

--- a/src/ui/Features/Shared/PickMp4Track/Mp4TrackInfoDisplay.cs
+++ b/src/ui/Features/Shared/PickMp4Track/Mp4TrackInfoDisplay.cs
@@ -1,6 +1,7 @@
 ﻿using Nikse.SubtitleEdit.Core.ContainerFormats.Matroska;
 using Nikse.SubtitleEdit.Core.ContainerFormats.Mp4;
 using Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes;
+using System;
 
 namespace Nikse.SubtitleEdit.Features.Shared.PickMp4Track;
 
@@ -17,7 +18,13 @@ public class Mp4TrackInfoDisplay
     public string Name { get; internal set; }
     public ulong StartPosition { get; internal set; }
     public bool IsVobSubSubtitle { get; internal set; }
-    public ulong Duration { get; internal set; }
+
+    /// <summary>
+    /// End of the track's last cue. Taken from the cues themselves for both track kinds -
+    /// tkhd.Duration is in movie-timescale ticks, which does not compare with the fragmented
+    /// tracks' millisecond times in the same column.
+    /// </summary>
+    public TimeSpan Duration { get; internal set; }
 
     public Mp4TrackInfoDisplay()
     {

--- a/src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs
+++ b/src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs
@@ -67,7 +67,7 @@ public partial class PickMp4TrackViewModel : ObservableObject
                 Name = track.Mdia.Name,
                 StartPosition = track.Mdia.StartPosition,
                 IsVobSubSubtitle = track.Mdia.IsVobSubSubtitle,
-                Duration = track.Tkhd.Duration,
+                Duration = LastCueEnd(track.Mdia?.Minf?.Stbl?.GetParagraphs()),
                 Track = track,
             };
             Tracks.Add(display);
@@ -84,8 +84,6 @@ public partial class PickMp4TrackViewModel : ObservableObject
         WindowTitle = $"Pick MP4 track - {fileName}";
         foreach (var track in fragmentedTracks)
         {
-            var paragraphs = track.Subtitle.Paragraphs;
-            var lastCue = paragraphs.Count > 0 ? paragraphs[paragraphs.Count - 1] : null;
             Tracks.Add(new Mp4TrackInfoDisplay
             {
                 HandlerType = track.Codec ?? string.Empty,
@@ -94,10 +92,17 @@ public partial class PickMp4TrackViewModel : ObservableObject
                     : track.Language ?? string.Empty,
                 StartPosition = 0,
                 IsVobSubSubtitle = false,
-                Duration = lastCue != null ? (ulong)lastCue.EndTime.TotalMilliseconds : 0,
+                Duration = LastCueEnd(track.Subtitle.Paragraphs),
                 FragmentedTrack = track,
             });
         }
+    }
+
+    private static TimeSpan LastCueEnd(List<Paragraph>? paragraphs)
+    {
+        return paragraphs == null || paragraphs.Count == 0
+            ? TimeSpan.Zero
+            : paragraphs[paragraphs.Count - 1].EndTime.TimeSpan;
     }
 
     private static List<Paragraph> GetTrackParagraphs(Mp4TrackInfoDisplay display)

--- a/src/ui/Features/Shared/PickMp4Track/PickMp4TrackWindow.cs
+++ b/src/ui/Features/Shared/PickMp4Track/PickMp4TrackWindow.cs
@@ -8,6 +8,7 @@ using Avalonia.Layout;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.ValueConverters;
+using System;
 
 namespace Nikse.SubtitleEdit.Features.Shared.PickMp4Track;
 
@@ -109,7 +110,7 @@ public class PickMp4TrackWindow : Window
             Header = "Duration",
             CellTheme = UiUtil.TableViewCellTheme,
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-            Binding = new Binding(nameof(Mp4TrackInfoDisplay.Duration)),
+            Binding = new Binding(nameof(Mp4TrackInfoDisplay.Duration)) { Converter = new TimeSpanToDisplayFullConverter() },
             Width = new GridLength(100),
         };
         var vobSubColumn = new SeTableViewColumn
@@ -144,7 +145,7 @@ public class PickMp4TrackWindow : Window
         new TableViewHeaderSorter(dataGridTracks)
             .AddSortable<Mp4TrackInfoDisplay, string>(handlerColumn, x => x.HandlerType)
             .AddSortable<Mp4TrackInfoDisplay, string>(nameColumn, x => x.Name)
-            .AddSortable<Mp4TrackInfoDisplay, ulong>(durationColumn, x => x.Duration)
+            .AddSortable<Mp4TrackInfoDisplay, TimeSpan>(durationColumn, x => x.Duration)
             .AddSortable<Mp4TrackInfoDisplay, bool>(vobSubColumn, x => x.IsVobSubSubtitle)
             .AddSortable<Mp4TrackInfoDisplay, ulong>(startPositionColumn, x => x.StartPosition);
 

--- a/tests/libse/Core/ContainerFormats/Mp4/Mp4DashSubtitleTest.cs
+++ b/tests/libse/Core/ContainerFormats/Mp4/Mp4DashSubtitleTest.cs
@@ -220,14 +220,119 @@ public class Mp4DashSubtitleTest
         Assert.Contains("</tt>", docs[0]);
     }
 
-    [Fact]
-    public void SplitTtmlDocuments_NamespacedRoot_IsRecognized()
+    // Matching "</tt" loosely also hit "</tt:p>", so a namespaced document was cut off after
+    // its first cue and the truncated fragment no longer parsed as XML at all.
+    [Theory]
+    [InlineData("tt")]
+    [InlineData("ttml")]
+    public void SplitTtmlDocuments_NamespacedRoot_KeepsWholeDocument(string prefix)
     {
-        var doc = "<tt:tt xmlns:tt=\"http://www.w3.org/ns/ttml\"><tt:body><tt:div><tt:p begin=\"00:00:01.000\" end=\"00:00:02.000\">One</tt:p></tt:div></tt:body></tt:tt>";
+        var doc = $"<{prefix}:tt xmlns:{prefix}=\"http://www.w3.org/ns/ttml\"><{prefix}:body><{prefix}:div>" +
+                  $"<{prefix}:p begin=\"00:00:01.000\" end=\"00:00:02.000\">One</{prefix}:p>" +
+                  $"<{prefix}:p begin=\"00:00:03.000\" end=\"00:00:04.000\">Two</{prefix}:p>" +
+                  $"</{prefix}:div></{prefix}:body></{prefix}:tt>";
 
         var docs = Mp4TtmlHelper.SplitTtmlDocuments(doc + doc);
 
         Assert.Equal(2, docs.Count);
+        Assert.All(docs, d =>
+        {
+            Assert.EndsWith($"</{prefix}:tt>", d);
+            var paragraphs = Mp4TtmlHelper.ParseTtmlDocument(d);
+            Assert.Equal(2, paragraphs.Count);
+            Assert.Equal("One", paragraphs[0].Text);
+            Assert.Equal("Two", paragraphs[1].Text);
+        });
+    }
+
+    [Fact]
+    public void FragmentedStpp_NamespacedTtml_ExtractsAllCues()
+    {
+        var doc = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><tt:tt xmlns:tt=\"http://www.w3.org/ns/ttml\"><tt:body><tt:div>" +
+                  "<tt:p begin=\"00:00:01.000\" end=\"00:00:02.000\">One</tt:p>" +
+                  "<tt:p begin=\"00:00:02.500\" end=\"00:00:03.500\">Two</tt:p></tt:div></tt:body></tt:tt>";
+        var init = BuildInit("subt", "stpp", trackId: 1, mdhdTimeScale: 1000, mvhdTimeScale: 600);
+        var segment = BuildSegment(1, 0, new uint[] { 4000 }, new[] { Encoding.UTF8.GetBytes(doc) });
+
+        var subtitle = ParseVttc(Concat(init, segment));
+
+        Assert.NotNull(subtitle);
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+        Assert.Equal("One", subtitle.Paragraphs[0].Text);
+        Assert.Equal(1000, subtitle.Paragraphs[0].StartTime.TotalMilliseconds, 1);
+        Assert.Equal("Two", subtitle.Paragraphs[1].Text);
+        Assert.Equal(2500, subtitle.Paragraphs[1].StartTime.TotalMilliseconds, 1);
+    }
+
+    // The zero-based-times heuristic used to look only at cue ends versus the sample duration,
+    // so an absolute cue that happened to end inside a long sample was shifted by tfdt.
+    [Fact]
+    public void FragmentedStpp_AbsoluteDocumentTimes_AreNotShifted()
+    {
+        var doc = TtmlDoc("<p begin=\"00:00:02.500\" end=\"00:00:05.000\">Absolute</p>");
+        var init = BuildInit("subt", "stpp", trackId: 1, mdhdTimeScale: 1000, mvhdTimeScale: 600);
+        var segment = BuildSegment(1, 2000, new uint[] { 10_000 }, new[] { Encoding.UTF8.GetBytes(doc) });
+
+        var subtitle = ParseVttc(Concat(init, segment));
+
+        Assert.NotNull(subtitle);
+        var p = Assert.Single(subtitle.Paragraphs);
+        Assert.Equal(2500, p.StartTime.TotalMilliseconds, 1);
+        Assert.Equal(5000, p.EndTime.TotalMilliseconds, 1);
+    }
+
+    // A DASH file is styp+moof+mdat per segment, so a flat 3000-box scan limit stopped the
+    // parse after ~1000 segments and silently dropped the rest of the subtitle.
+    [Fact]
+    public void ManySegments_AreNotTruncatedByTheBoxScanLimit()
+    {
+        const int segmentCount = 1100; // > 3000 top-level boxes
+        var parts = new System.Collections.Generic.List<byte[]> { BuildInit("text", "wvtt", 1, 1000, 600) };
+        for (var i = 0; i < segmentCount; i++)
+        {
+            parts.Add(BuildSegment(1, (uint)(i * 2000), new uint[] { 2000 }, new[] { WvttCueSample($"Cue {i}") }));
+        }
+
+        var subtitle = ParseVttc(Concat(parts.ToArray()));
+
+        Assert.NotNull(subtitle);
+        Assert.Equal(segmentCount, subtitle.Paragraphs.Count);
+        Assert.Equal($"Cue {segmentCount - 1}", subtitle.Paragraphs[segmentCount - 1].Text);
+    }
+
+    // IsmtDfxp splits each mdat into TTML documents before parsing; a namespaced document must
+    // survive that split intact, as the whole mdat used to go straight to TimedText10.
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void IsmtDfxp_TtmlInMdat_LoadsAllCues(bool namespaced)
+    {
+        var xml = namespaced
+            ? "<?xml version=\"1.0\" encoding=\"UTF-8\"?><tt:tt xmlns:tt=\"http://www.w3.org/ns/ttml\"><tt:body><tt:div>" +
+              "<tt:p begin=\"00:00:01.000\" end=\"00:00:02.000\">One</tt:p>" +
+              "<tt:p begin=\"00:00:03.000\" end=\"00:00:04.000\">Two</tt:p></tt:div></tt:body></tt:tt>"
+            : TtmlDoc("<p begin=\"00:00:01.000\" end=\"00:00:02.000\">One</p><p begin=\"00:00:03.000\" end=\"00:00:04.000\">Two</p>");
+
+        var file = Concat(
+            Box("ftyp", Ascii("isml"), UInt32Be(1), Ascii("piff"), Ascii("iso2")),
+            Box("moov", BuildTrak("sbtl", "dfxp", trackId: 1, mdhdTimeScale: 10_000_000)),
+            Box("mdat", Encoding.UTF8.GetBytes(xml)));
+
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(tempFile, file);
+            var subtitle = new Nikse.SubtitleEdit.Core.Common.Subtitle();
+            new Nikse.SubtitleEdit.Core.SubtitleFormats.IsmtDfxp().LoadSubtitle(subtitle, new System.Collections.Generic.List<string>(), tempFile);
+
+            Assert.Equal(2, subtitle.Paragraphs.Count);
+            Assert.Equal("One", subtitle.Paragraphs[0].Text);
+            Assert.Equal("Two", subtitle.Paragraphs[1].Text);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
     }
 
     private static Nikse.SubtitleEdit.Core.Common.Subtitle ParseVttc(byte[] fileBytes)


### PR DESCRIPTION
Follow-up bug hunt on the DASH/CMAF support in #13179. Five defects, each reproduced against a synthetic MP4 before and after the fix.

### Namespaced TTML lost every cue

`SplitTtmlDocuments` matched `</tt` loosely, so `</tt:p>` terminated the document: a `<tt:tt>` (or `<ttml:tt>`) sample was cut off after its first cue, and the truncated fragment no longer parsed as XML at all.

```
<tt:tt …><tt:body><tt:div><tt:p>One</tt:p><tt:p>Two</tt:p>…</tt:tt>
  intact                       → 2 cues
  after SplitTtmlDocuments     → "<tt:tt …><tt:body><tt:div><tt:p …>One</tt:p>" → 0 cues
```

`FindRootTag` now captures the root's qualified name (any prefix) and the close tag must carry that exact name.

This also regressed `IsmtDfxp`, which since #13179 runs every mdat through the splitter — namespaced `.ismt` files stopped loading entirely, and since `IsMine` delegates to `LoadSubtitle`, they were no longer even detected as ISMT.

### TTML with absolute times was shifted a whole sample start too late

`AreTimesSampleRelative` only compared cue ends against the sample duration, so any absolute cue that happened to end inside a long sample looked like a zero-based Smooth Streaming document:

```
stpp, tfdt=2000, sample duration=10000, cue begin=2.5s end=5.0s
  → extracted as 00:00:04,500 → 00:00:07,000   (2s late)
```

A cue with absolute media times cannot start before the sample carrying it, so require that as well. Genuine zero-based documents still shift.

### Long DASH files were silently truncated

A DASH file is `styp + moof + mdat` per segment, so the flat 3000 top-level box scan limit stopped the parse after ~1000 segments — 33 minutes at 2-second segments — with no error:

```
1500 segments (2s each) → 999 cues, last "Cue 998" at 00:33:16
```

The limit now scales with the file size and keeps a ceiling, so malformed files still cannot spin.

### Fragmented CEA-608 ignored tfhd base-data-offset

`ReadFragmentedCcSamples` always measured trun data offsets from the moof start, reading the wrong bytes on PIFF/Smooth Streaming files that set base-data-offset. The text path already handled this; the caption path now agrees.

### Track picker Duration column mixed units

Movie-timescale ticks for moov tracks, milliseconds for fragmented ones, rendered as a raw number. Both now use the last cue's end, displayed as a time.

## Tests

The old `SplitTtmlDocuments` namespace test only counted chunks, so it passed on the broken output — it now asserts each chunk ends at the real root close and re-parses to all its cues. New coverage for namespaced stpp extraction, absolute times, the segment count limit, and `IsmtDfxp` round-trips.

libse 838, seconv 290, UI 1271 — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)