### PR TITLE
Fix burn-in minimum width and redundant selection ordering

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -296,8 +296,17 @@ public partial class MainViewModel :
     /// picked. The control's own SelectedItems follows selection order, so shift-clicking upwards
     /// leaves the anchor row in front and ctrl-clicking around scrambles the list entirely - and
     /// everything downstream (copy, merge, export, ...) then works on the rows out of order.
+    ///
+    /// Building this walks the whole subtitle list, so read it into a local instead of touching it
+    /// repeatedly, and use <see cref="SubtitleGridSelectedCount"/> when only the count is needed.
     /// </summary>
     public List<SubtitleLineViewModel> SubtitleGridSelectedItems => GetSelectedSubtitlesInOrder();
+
+    /// <summary>
+    /// Number of selected rows. Ordering the rows costs a pass over every subtitle, which callers
+    /// that only ask how many are selected (menu visibility and the like) must not pay for.
+    /// </summary>
+    public int SubtitleGridSelectedCount => SubtitleGrid.SelectedItems?.Count ?? 0;
 
     private List<SubtitleLineViewModel> GetSelectedSubtitlesInOrder()
     {
@@ -5514,20 +5523,16 @@ public partial class MainViewModel :
     private List<int> GetSelectedSubtitleIndices()
     {
         var selectedIndices = new List<int>();
-        if (SubtitleGridSelectedItems != null)
+        foreach (var item in SubtitleGridSelectedItems)
         {
-            foreach (var item in SubtitleGridSelectedItems.Cast<SubtitleLineViewModel>())
+            var index = Subtitles.IndexOf(item);
+            if (index >= 0)
             {
-                var index = Subtitles.IndexOf(item);
-                if (index >= 0)
-                {
-                    selectedIndices.Add(index);
-                }
+                selectedIndices.Add(index);
             }
-
-            selectedIndices.Sort();
         }
 
+        selectedIndices.Sort();
         return selectedIndices;
     }
 
@@ -8371,7 +8376,7 @@ public partial class MainViewModel :
         var result = _windowService.ShowWindow<AdjustAllTimesWindow, AdjustAllTimesViewModel>(Window, (window, vm) =>
         {
             _adjustAllTimesViewModel = vm;
-            var selectedCount = SubtitleGridSelectedItems.Count;
+            var selectedCount = SubtitleGridSelectedCount;
             vm.Initialize(this, selectedCount, forceSelectedLines); // uses call from IAdjustCallback: Adjust
         });
     }
@@ -10865,7 +10870,7 @@ public partial class MainViewModel :
             return;
         }
 
-        var result = await ShowDialogAsync<PickAlignmentWindow, PickAlignmentViewModel>(vm => { vm.Initialize(selected, SubtitleGridSelectedItems.Count); });
+        var result = await ShowDialogAsync<PickAlignmentWindow, PickAlignmentViewModel>(vm => { vm.Initialize(selected, SubtitleGridSelectedCount); });
 
         if (result.OkPressed)
         {
@@ -15779,14 +15784,13 @@ public partial class MainViewModel :
 
     private void InverseRowSelection()
     {
-        if (SubtitleGridSelectedItems == null || Subtitles.Count == 0)
+        if (Subtitles.Count == 0)
         {
             return;
         }
 
         // Store currently selected items
-        var selectedItems =
-            new HashSet<SubtitleLineViewModel>(SubtitleGridSelectedItems.Cast<SubtitleLineViewModel>());
+        var selectedItems = new HashSet<SubtitleLineViewModel>(SubtitleGridSelectedItems);
 
         // Inverting a small selection on a large file selects almost every row, so
         // apply via the detach/reattach helper to avoid the per-row hang (#11529).
@@ -20397,17 +20401,18 @@ public partial class MainViewModel :
     {
         var idx = SubtitleGrid.SelectedIndex;
         var count = Subtitles.Count;
-        MenuItemMergeAsDialog.IsVisible = SubtitleGridSelectedItems.Count == 2;
-        MenuItemMerge.IsVisible = SubtitleGridSelectedItems.Count > 1;
+        var selectedCount = SubtitleGridSelectedCount;
+        MenuItemMergeAsDialog.IsVisible = selectedCount == 2;
+        MenuItemMerge.IsVisible = selectedCount > 1;
         // With 2+ lines selected at least one of them has a neighbor on either side,
         // so the focused-index boundary check only applies to single selection (#12981)
         MenuItemExtendToLineBefore.IsVisible = Subtitles.Count > 1 &&
-            (SubtitleGridSelectedItems.Count > 1 || (SubtitleGridSelectedItems.Count == 1 && idx > 0));
+            (selectedCount > 1 || (selectedCount == 1 && idx > 0));
         MenuItemExtendToLineAfter.IsVisible = Subtitles.Count > 1 &&
-            (SubtitleGridSelectedItems.Count > 1 || (SubtitleGridSelectedItems.Count == 1 && idx < count - 1));
+            (selectedCount > 1 || (selectedCount == 1 && idx < count - 1));
         AreAssaContentMenuItemsVisible = false;
-        ShowAutoTranslateSelectedLines = SubtitleGridSelectedItems.Count > 0 && ShowColumnOriginalText;
-        HasMultipleLinesSelected = SubtitleGridSelectedItems.Count > 1;
+        ShowAutoTranslateSelectedLines = selectedCount > 0 && ShowColumnOriginalText;
+        HasMultipleLinesSelected = selectedCount > 1;
         ShowColumnLayerFlyoutMenuItem = IsFormatAssa;
 
         if (IsSubtitleGridFlyoutHeaderVisible)
@@ -20429,11 +20434,11 @@ public partial class MainViewModel :
         else
         {
             IsSubtitleGridDataMenuVisible = true;
-            IsMergeWithNextOrPreviousVisible = SubtitleGridSelectedItems.Count == 1;
+            IsMergeWithNextOrPreviousVisible = selectedCount == 1;
             IsInsertLineNoSelectionVisible = false;
             // Any single selected line, not only the last - a pre-timed file keeps its own time
             // codes, so inserting midway is a normal workflow (discussion #11744).
-            IsInsertSubtitleFileAfterLineVisible = SubtitleGridSelectedItems.Count == 1;
+            IsInsertSubtitleFileAfterLineVisible = selectedCount == 1;
 
             if (IsFormatAssa || IsFormatSsa)
             {
@@ -20552,7 +20557,7 @@ public partial class MainViewModel :
         // lines selected the per-word suggestions/"ignore all" would be ambiguous (they act on the
         // one clicked cell, not the selection).
         if (IsSubtitleGridFlyoutHeaderVisible ||
-            SubtitleGridSelectedItems.Count != 1 ||
+            SubtitleGridSelectedCount != 1 ||
             (!Se.Settings.Appearance.SubtitleGridLiveSpellCheck && !Se.Settings.Appearance.SubtitleTextBoxLiveSpellCheck))
         {
             return;
@@ -22039,8 +22044,9 @@ public partial class MainViewModel :
 
         if (_shiftSelectAnchorIndex < 0)
         {
-            var anchor = SelectedSubtitleIndex ?? (SubtitleGridSelectedItems.Count > 0
-                ? Subtitles.IndexOf((SubtitleLineViewModel)SubtitleGridSelectedItems[0]!)
+            var selectedInOrder = SubtitleGridSelectedItems;
+            var anchor = SelectedSubtitleIndex ?? (selectedInOrder.Count > 0
+                ? Subtitles.IndexOf(selectedInOrder[0])
                 : -1);
             if (anchor < 0)
             {
@@ -22161,7 +22167,9 @@ public partial class MainViewModel :
             }
         }
 
-        SubtitleGridSelectionChanged();
+        // Hand the ordered selection on rather than letting SubtitleGridSelectionChanged read the
+        // property again: building it walks every subtitle, and this runs on every arrow key.
+        SubtitleGridSelectionChanged(selectedItems);
     }
 
     /// <summary>
@@ -22181,15 +22189,15 @@ public partial class MainViewModel :
         return Subtitles.IndexOf(item);
     }
 
-    private void SubtitleGridSelectionChanged()
+    private void SubtitleGridSelectionChanged(List<SubtitleLineViewModel>? alreadyOrderedSelection = null)
     {
-        var selectedItems = SubtitleGridSelectedItems;
+        var selectedItems = alreadyOrderedSelection ?? SubtitleGridSelectedItems;
         EditTextBox.ClearSelection();
         EditTextBoxOriginal.ClearSelection();
         ResetPlaySelection();
         _updateAudioVisualizer = true;
 
-        if (selectedItems == null || selectedItems.Count == 0)
+        if (selectedItems.Count == 0)
         {
             SelectedSubtitle = null;
             SelectedSubtitleIndex = null;

--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -204,18 +204,39 @@ public class BurnInWindow : Window
         // Re-fit the window to the current mode's content (single mode is narrower; batch mode
         // needs more width for the file list), then lock that size in as the new minimum while
         // still allowing the user to enlarge the window further.
-        MinWidth = 0;
+        //
+        // heightOnly re-fits only the height: the width (and the minimum locked for it) is the
+        // user's, and clearing MinWidth here would leave it at zero - the callback below never
+        // restores it - so the window could be dragged narrower than its content, which is the
+        // clipping this whole method exists to prevent.
+        if (!heightOnly)
+        {
+            MinWidth = 0;
+        }
+
         MinHeight = 0;
-        SizeToContent = SizeToContent.WidthAndHeight;
+        SizeToContent = heightOnly ? SizeToContent.Height : SizeToContent.WidthAndHeight;
         Dispatcher.UIThread.Post(() =>
         {
             var width = ClientSize.Width;
             var height = ClientSize.Height;
-            // Width/Height include the window chrome (title bar + borders); the minimum must
-            // cover the content plus the chrome, otherwise the window can be shrunk below the
-            // content and the bottom row (buttons) gets clipped.
+            // Any difference between the window size and the client size (title bar, borders) has
+            // to be added on top of the content, or the minimum sits below it and the bottom row
+            // (buttons) gets clipped. Avalonia measures windows by client area, so this is
+            // normally zero; Width/Height are also NaN until something assigns them, hence the
+            // guard - NaN here would wipe out the minimum entirely.
             var chromeWidth = Width - width;
             var chromeHeight = Height - height;
+            if (double.IsNaN(chromeWidth) || chromeWidth < 0)
+            {
+                chromeWidth = 0;
+            }
+
+            if (double.IsNaN(chromeHeight) || chromeHeight < 0)
+            {
+                chromeHeight = 0;
+            }
+
             SizeToContent = SizeToContent.Manual;
             if (width > 0 && height > 0)
             {

--- a/tests/UI/Features/Video/BurnInWindowTests.cs
+++ b/tests/UI/Features/Video/BurnInWindowTests.cs
@@ -156,4 +156,27 @@ public class BurnInWindowTests
             window.ClientSize.Height >= before,
             $"Window shrank when generating started ({before:0.#} -> {window.ClientSize.Height:0.#}).");
     }
+
+    // Re-locking the minimum for the progress row is height-only, but it used to clear MinWidth
+    // along the way and never put it back - so starting (or finishing) a burn-in left the window
+    // freely shrinkable sideways, clipping the very content the minimum protects.
+    [AvaloniaFact]
+    public void Window_KeepsMinimumWidth_WhenGeneratingStartsAndStops()
+    {
+        var window = BuildWindow();
+        var vm = window.DataContext as BurnInViewModel;
+        Assert.NotNull(vm);
+        window.Show();
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        var lockedMinWidth = window.MinWidth;
+        Assert.True(lockedMinWidth > 0, "The window never locked a minimum width to begin with.");
+
+        vm.IsGenerating = true;
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        Assert.Equal(lockedMinWidth, window.MinWidth);
+
+        vm.IsGenerating = false;
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        Assert.Equal(lockedMinWidth, window.MinWidth);
+    }
 }


### PR DESCRIPTION
Two follow-ups from a bug hunt over the last few merges.

## Burn-in window loses its minimum width (#13157)

`LockMinimumToContentSize` clears both minimums before re-fitting, but the new `heightOnly` path only restores `MinHeight` — `MinWidth` is left at zero. `heightOnly` runs whenever `IsGenerating` flips, so starting (or finishing) a burn-in leaves the window freely shrinkable sideways, clipping the very content the minimum exists to protect.

Measured on the real window:

```
                     before              after
after Opened:        MinWidth=1048       MinWidth=1048
after IsGenerating:  MinWidth=0     →    MinWidth=1048
after done:          MinWidth=0     →    MinWidth=1048
```

`heightOnly` now leaves `MinWidth` alone and re-fits with `SizeToContent.Height` instead of `WidthAndHeight`, so the user's width and its locked minimum both survive.

The chrome delta is also guarded against `NaN`. It is normally zero — Avalonia measures windows by client area — but `Width`/`Height` read `NaN` until something assigns them, and in that state the arithmetic would have wiped the minimum out rather than raising it.

## Redundant selection ordering on the keystroke path (#13175)

`SubtitleGridSelectedItems` went from returning the grid's live list to building an ordered snapshot, which walks every subtitle on each read. It is read twice per selection change — so on every arrow key — and nine times when the subtitle context menu opens.

No caching here: `Subtitles` is a reassignable `[ObservableProperty]` collection and an invalidation hook would race the window's own `SelectionChanged` handler, so a stale selection list — operating on the wrong rows — would be a worse problem than the cost. The redundant work is removed instead:

- New `SubtitleGridSelectedCount` (O(1), reads the control's count directly) for the call sites that only ask *how many* rows are selected. Ordering is irrelevant to that question, and this restores the exact pre-#13175 semantics for those sites, since the old `.Count` was the control's count.
- `SubtitleGrid_SelectionChanged` hands its already-built list to `SubtitleGridSelectionChanged` instead of both reading the property.
- Two null checks left over from the old `IList` (a `List<T>` is never null) each triggered a full rebuild; removed, along with the now-pointless `Cast<SubtitleLineViewModel>()` calls.

Net: the keystroke path goes from two full walks per selection change to one, and context-menu opening from nine to zero.

## Tests

New `Window_KeepsMinimumWidth_WhenGeneratingStartsAndStops`. UI suite passing, including the four existing burn-in layout tests and the four `SubtitleGridSelectionOrderTests` that guard #13175's actual fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)