### PR TITLE
Fix beta 3 focus, first-caption selection, initial video position, and undocked menu z-order

### DIFF
--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -38,6 +38,11 @@ public static class InitMenu
         menu.Items.Clear();
         menu.Opened += (s, e) => DisplayShortcuts(menu, vm);
 
+        // In undocked mode the tool windows are topmost while SE is active (#11971), which
+        // covers the menu popups - drop their topmost while a menu is open (#13187/#12899).
+        menu.Opened += (s, e) => vm.SetUndockedWindowsTopmost(false);
+        menu.Closed += (s, e) => vm.SetUndockedWindowsTopmost(true);
+
         // Drop the menu's font one notch below the theme default and tighten
         // each item's vertical padding — a denser menu reads better when there
         // are this many entries. The style targets nested MenuItems so submenu

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -6269,6 +6269,23 @@ public partial class MainViewModel :
         });
     }
 
+    /// <summary>
+    /// Suppress (or restore) the undocked tool windows' topmost state. They float above the
+    /// main window while SE is active (KeepTopmostWhileOwnerActive, #11971), which also puts
+    /// them above the main menu's popups - so the menu drops their topmost while it is open
+    /// (#13187/#12899). Restoring re-applies the helper's rule instead of a blanket true.
+    /// </summary>
+    internal void SetUndockedWindowsTopmost(bool topmost)
+    {
+        foreach (var undockedWindow in new[] { _videoPlayerUndockedViewModel?.Window, _audioVisualizerUndockedViewModel?.Window })
+        {
+            if (undockedWindow != null)
+            {
+                undockedWindow.Topmost = topmost && (Window?.IsActive == true || undockedWindow.IsActive);
+            }
+        }
+    }
+
     [RelayCommand]
     private void VideoRedockControls()
     {
@@ -15840,6 +15857,17 @@ public partial class MainViewModel :
                 SubtitleGrid.SelectedItem = itemToScroll;
                 SubtitleGrid.ScrollIntoView(itemToScroll);
 
+                // TableView can initialize row 0 as selected when ItemsSource is assigned
+                // without raising SelectionChanged, so after a fresh file open the grid
+                // shows the first row highlighted while SelectedSubtitle is still null -
+                // empty edit box and go to next/previous line dead until the selection is
+                // moved away and back (#13190). Assigning the same item above raises no
+                // event either, so sync the view model explicitly.
+                if (!ReferenceEquals(SelectedSubtitle, itemToScroll))
+                {
+                    SubtitleGridSelectionChanged();
+                }
+
                 // Avalonia keeps the caret index when the bound text changes, so navigating
                 // to another line left the caret at the previous line's (clamped) position -
                 // seemingly random (issue #12707). SE4 always lands at the start (WinForms
@@ -16548,6 +16576,14 @@ public partial class MainViewModel :
     {
         var vp = GetVideoPlayerControl();
         if (string.IsNullOrEmpty(_videoFileName) || SelectedSubtitle == null || vp == null)
+        {
+            return;
+        }
+
+        // A remembered first-line selection is not a previously established position - it is
+        // just where the grid always lands on open. Leave the video at 0:00 instead of jumping
+        // to the first caption's start time (#13191 / #12898); only a mid-file line restores.
+        if ((SelectedSubtitleIndex ?? 0) == 0)
         {
             return;
         }

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -128,6 +128,11 @@ public class SettingsPage : UserControl
         _searchBox.TextChanged += (_, e) => UpdateVisibleSections(_searchBox.Text ?? string.Empty);
     }
 
+    public void FocusSearchBox()
+    {
+        _searchBox.Focus();
+    }
+
     private static Button MakeMenuItem(SettingsSection section, IRelayCommand command)
     {
         var label = new Label

--- a/src/ui/Features/Options/Settings/SettingsWindow.cs
+++ b/src/ui/Features/Options/Settings/SettingsWindow.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Threading;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -21,7 +22,17 @@ public class SettingsWindow : Window
         CanResize = true;
 
         vm.Window = this;
-        Content = new SettingsPage(vm);
+        var page = new SettingsPage(vm);
+        Content = page;
+
+        // Without an explicit Activate/Focus the dialog can open with keyboard focus left in the
+        // main window (reproducible in undocked mode with floating topmost tool windows, #13185).
+        Opened += (_, _) =>
+        {
+            Activate();
+            Dispatcher.UIThread.Post(() => page.FocusSearchBox(), DispatcherPriority.Input);
+        };
+
         Loaded += vm.Onloaded;
         Closing += vm.OnClosing;
     }


### PR DESCRIPTION
Fixes four issues reported against 5.2.0 beta 3:

- **#13185 – Settings dialog does not open with focus**: `SettingsWindow` never focused anything on open, unlike `ShortcutsWindow` (which explicitly activates and focuses its search box — that was the earlier fix the reporter half-remembered). The dialog now activates and focuses the settings search box on `Opened`. Reproducible in undocked mode with the floating topmost tool windows.

- **#13190 – Stuck on first caption**: TableView can initialize row 0 as selected when `ItemsSource` is assigned without raising `SelectionChanged`, so after a fresh file open the grid showed the first row highlighted while `SelectedSubtitle` was still `null` — empty edit box, and go to next/previous line (Alt+Down/Alt+Up) dead because `GoToNextLine` bails on a null `SelectedSubtitleIndex`. `SelectAndScrollToRow` now syncs the view model explicitly when the assignment raises no event.

- **#13191 / #12898 – Initial video position is not time index 0**: `SeekVideoToSelectedLineAsync` (startup restore + Reopen) now treats a remembered *first-line* selection as "no previously established position" and leaves the video at 0:00; only a mid-file line restores the position (the #12222 behavior is unchanged for that case). Note the #13190 fix would otherwise have made the first-caption jump deterministic, since `SelectedSubtitle` is now reliably set after open.

- **#13187 / #12899 – Menus obscured behind the undocked audio visualizer**: the undocked tool windows are topmost while SE is active (#11971), which also covered the main menu's popups. Their topmost is now suppressed while a main-window menu is open and restored (via the same owner-active rule) when it closes.

All 1276 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)