### PR TITLE
Fix right-to-left text rendering in dialog subtitle grids

### DIFF
--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
@@ -121,6 +121,7 @@ public class ExportImageBasedWindow : Window
 
         var fullTimeConverter = new TimeSpanToDisplayFullConverter();
         var shortTimeConverter = new TimeSpanToDisplayShortConverter();
+        var textToFlowDirectionConverter = new TextToFlowDirectionConverter();
 
         // Columns
         vm.SubtitleGrid.Columns.Add(new SeTableViewColumn
@@ -194,7 +195,11 @@ public class ExportImageBasedWindow : Window
                 {
                     VerticalAlignment = VerticalAlignment.Center,
                     TextWrapping = TextWrapping.Wrap,
-                    [!TextBlock.TextProperty] = new Binding(nameof(SubtitleLineViewModel.Text))
+                    [!TextBlock.TextProperty] = new Binding(nameof(SubtitleLineViewModel.Text)),
+
+                    // Right-to-left text needs a right-to-left cell, or Avalonia splits the
+                    // line at every zero width non-joiner and reverses the word order (#13160).
+                    [!TextBlock.FlowDirectionProperty] = new Binding(nameof(SubtitleLineViewModel.Text)) { Converter = textToFlowDirectionConverter },
                 };
 
                 border.Child = textBlock;

--- a/src/ui/Features/Files/ImportCsvXlsxCustomColumns/ImportCsvXlsxCustomColumnsWindow.cs
+++ b/src/ui/Features/Files/ImportCsvXlsxCustomColumns/ImportCsvXlsxCustomColumnsWindow.cs
@@ -224,7 +224,7 @@ public class ImportCsvXlsxCustomColumnsWindow : Window
             Header = Se.Language.General.Text,
             CellTheme = UiUtil.TableViewCellTheme,
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-            Binding = new Binding(nameof(SubtitleLineViewModel.Text)),
+            CellTemplate = TableViewExtras.MakeTextCellTemplate(nameof(SubtitleLineViewModel.Text)),
             Width = new GridLength(1, GridUnitType.Star),
         });
     }

--- a/src/ui/Features/Files/ImportPlainText/ImportPlainTextWindow.cs
+++ b/src/ui/Features/Files/ImportPlainText/ImportPlainTextWindow.cs
@@ -343,7 +343,7 @@ public class ImportPlainTextWindow : Window
                 Header = Se.Language.General.Text,
                 CellTheme = UiUtil.TableViewCellTheme,
                 HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-                Binding = new Binding(nameof(SubtitleLineViewModel.Text)),
+                CellTemplate = TableViewExtras.MakeTextCellTemplate(nameof(SubtitleLineViewModel.Text)),
                 Width = new GridLength(1, GridUnitType.Star),
             },
         });

--- a/src/ui/Features/Shared/FindText/FindTextWindow.cs
+++ b/src/ui/Features/Shared/FindText/FindTextWindow.cs
@@ -111,7 +111,7 @@ public class FindTextWindow : Window
             Width = new GridLength(1, GridUnitType.Star),
             CellTheme = UiUtil.TableViewCellTheme,
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-            Binding = new Binding(nameof(SubtitleLineViewModel.Text)),
+            CellTemplate = TableViewExtras.MakeTextCellTemplate(nameof(SubtitleLineViewModel.Text)),
         });
 
         vm.SubtitleGrid.DataContext = vm.Subtitles;

--- a/src/ui/Features/Sync/PointSync/PointSyncWindow.cs
+++ b/src/ui/Features/Sync/PointSync/PointSyncWindow.cs
@@ -180,7 +180,7 @@ public class PointSyncWindow : Window
                 Header = Se.Language.General.Text,
                 CellTheme = UiUtil.TableViewCellTheme,
                 HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-                Binding = new Binding(nameof(SubtitleLineViewModel.Text)),
+                CellTemplate = TableViewExtras.MakeTextCellTemplate(nameof(SubtitleLineViewModel.Text)),
                 Width = new GridLength(1, GridUnitType.Star),
             },
         });

--- a/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherWindow.cs
+++ b/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherWindow.cs
@@ -205,7 +205,7 @@ public class PointSyncViaOtherWindow : Window
                 Header = Se.Language.General.Text,
                 CellTheme = UiUtil.TableViewCellTheme,
                 HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-                Binding = new Binding(nameof(SubtitleLineViewModel.Text)),
+                CellTemplate = TableViewExtras.MakeTextCellTemplate(nameof(SubtitleLineViewModel.Text)),
                 Width = new GridLength(1, GridUnitType.Star),
             },
         });
@@ -298,7 +298,7 @@ public class PointSyncViaOtherWindow : Window
                 Header = Se.Language.General.Text,
                 CellTheme = UiUtil.TableViewCellTheme,
                 HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-                Binding = new Binding(nameof(SubtitleLineViewModel.Text)),
+                CellTemplate = TableViewExtras.MakeTextCellTemplate(nameof(SubtitleLineViewModel.Text)),
                 Width = new GridLength(1, GridUnitType.Star),
             },
         });

--- a/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsWindow.cs
+++ b/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsWindow.cs
@@ -257,7 +257,7 @@ public class ApplyDurationLimitsWindow : Window
             new SeTableViewColumn
             {
                 Header = Se.Language.General.Text,
-                Binding = new Binding(nameof(SubtitleLineViewModel.Text)),
+                CellTemplate = TableViewExtras.MakeTextCellTemplate(nameof(SubtitleLineViewModel.Text)),
                 Width = new GridLength(1, GridUnitType.Star),
                 CellTheme = UiUtil.TableViewCellTheme,
                 HeaderTheme = UiUtil.TableViewColumnHeaderTheme,

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -617,6 +617,7 @@ public class FixCommonErrorsWindow : Window
         var fullTimeConverter = new TimeSpanToDisplayFullConverter();
         var shortTimeConverter = new TimeSpanToDisplayShortConverter();
         var syntaxHighlightingConverter = new TextWithSubtitleSyntaxHighlightingConverter();
+        var textToFlowDirectionConverter = new TextToFlowDirectionConverter();
         var dataGridSubtitles = TableViewExtras.MakeTableView(multiSelect: false);
         dataGridSubtitles.DataContext = _vm;
         dataGridSubtitles.ItemsSource = _vm.Paragraphs;
@@ -704,6 +705,10 @@ public class FixCommonErrorsWindow : Window
                     VerticalAlignment = VerticalAlignment.Center,
                     TextWrapping = TextWrapping.NoWrap,
                     [!TextBlock.InlinesProperty] = new Binding(nameof(SubtitleLineViewModel.Text)) { Converter = syntaxHighlightingConverter },
+
+                    // Right-to-left text needs a right-to-left cell, or Avalonia splits the
+                    // line at every zero width non-joiner and reverses the word order (#13160).
+                    [!TextBlock.FlowDirectionProperty] = new Binding(nameof(SubtitleLineViewModel.Text)) { Converter = textToFlowDirectionConverter },
                 };
                 if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
                 {

--- a/src/ui/Features/Tools/MergeSubtitlesWithSameText/MergeSameTextWindow.cs
+++ b/src/ui/Features/Tools/MergeSubtitlesWithSameText/MergeSameTextWindow.cs
@@ -195,7 +195,7 @@ public class MergeSameTextWindow : Window
                     Header = Se.Language.General.Text,
                     CellTheme = UiUtil.TableViewCellTheme,
                     HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-                    Binding = new Binding(nameof(SubtitleLineViewModel.Text)),
+                    CellTemplate = TableViewExtras.MakeTextCellTemplate(nameof(SubtitleLineViewModel.Text)),
                     Width = new GridLength(1, GridUnitType.Star),
                 },
                 new SeTableViewColumn

--- a/src/ui/Features/Tools/MergeSubtitlesWithSameTimeCodes/MergeSameTimeCodesWindow.cs
+++ b/src/ui/Features/Tools/MergeSubtitlesWithSameTimeCodes/MergeSameTimeCodesWindow.cs
@@ -203,7 +203,7 @@ public class MergeSameTimeCodesWindow : Window
                     Header = Se.Language.General.Text,
                     CellTheme = UiUtil.TableViewCellTheme,
                     HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-                    Binding = new Binding(nameof(SubtitleLineViewModel.Text)),
+                    CellTemplate = TableViewExtras.MakeTextCellTemplate(nameof(SubtitleLineViewModel.Text)),
                     Width = new GridLength(1, GridUnitType.Star),
                 },
                 new SeTableViewColumn

--- a/src/ui/Features/Tools/SortBy/SortByWindow.cs
+++ b/src/ui/Features/Tools/SortBy/SortByWindow.cs
@@ -208,7 +208,7 @@ public class SortByWindow : Window
             Header = Se.Language.General.Text,
             CellTheme = UiUtil.TableViewCellTheme,
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-            Binding = new Binding(nameof(SubtitleLineViewModel.Text)),
+            CellTemplate = TableViewExtras.MakeTextCellTemplate(nameof(SubtitleLineViewModel.Text)),
             Width = new GridLength(1, GridUnitType.Star),
         });
         dataGridSubtitle.Columns.Add(new SeTableViewColumn

--- a/src/ui/Features/Translate/CopyPasteTranslateWindow.cs
+++ b/src/ui/Features/Translate/CopyPasteTranslateWindow.cs
@@ -141,7 +141,7 @@ public class CopyPasteTranslateWindow : Window
         vm.SubtitleGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Text,
-            Binding = new Binding(nameof(SubtitleLineViewModel.OriginalText)),
+            CellTemplate = TableViewExtras.MakeTextCellTemplate(nameof(SubtitleLineViewModel.OriginalText)),
             Width = new GridLength(1, GridUnitType.Star),
             CellTheme = UiUtil.TableViewCellTheme,
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
@@ -149,7 +149,7 @@ public class CopyPasteTranslateWindow : Window
         vm.SubtitleGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Translation,
-            Binding = new Binding(nameof(SubtitleLineViewModel.Text)),
+            CellTemplate = TableViewExtras.MakeTextCellTemplate(nameof(SubtitleLineViewModel.Text)),
             Width = new GridLength(1, GridUnitType.Star),
             CellTheme = UiUtil.TableViewCellTheme,
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,

--- a/src/ui/Logic/TableViewExtras.cs
+++ b/src/ui/Logic/TableViewExtras.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Layout;
@@ -8,6 +9,7 @@ using Avalonia.Media;
 using Avalonia.Styling;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Logic.ValueConverters;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -240,6 +242,8 @@ public sealed class TableViewColumnManager
 /// </summary>
 public static class TableViewExtras
 {
+    private static readonly TextToFlowDirectionConverter TextToFlowDirection = new();
+
     /// <summary>
     /// Creates a TableView with SE's standard look and behavior (multi-select by
     /// default, resizable columns, tight row style).
@@ -269,6 +273,30 @@ public static class TableViewExtras
 
         UiUtil.ApplyTableViewRowStyle(tableView);
         return tableView;
+    }
+
+    /// <summary>
+    /// A read-only text cell whose flow direction follows its own content, the way the
+    /// main subtitle grid's text cells do. Use it for every column showing subtitle text
+    /// instead of the column's plain <c>Binding</c>.
+    /// <para>
+    /// A plain binding leaves the cell with the window's left-to-right direction, and
+    /// Avalonia then lays a right-to-left line out under a left-to-right base direction:
+    /// the line is cut at every zero width non-joiner (U+200C, bidi class BN, which
+    /// Avalonia leaves at the paragraph level instead of giving it the surrounding
+    /// right-to-left level) and the resulting runs are placed left to right. Persian and
+    /// Arabic words written with a ZWNJ are torn in half and the word order is reversed
+    /// (issue #13160).
+    /// </para>
+    /// </summary>
+    public static IDataTemplate MakeTextCellTemplate(string propertyPath)
+    {
+        return new FuncDataTemplate<object>((_, _) => new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            [!TextBlock.TextProperty] = new Binding(propertyPath) { Mode = BindingMode.OneWay },
+            [!TextBlock.FlowDirectionProperty] = new Binding(propertyPath) { Converter = TextToFlowDirection, Mode = BindingMode.OneWay },
+        });
     }
 
     /// <summary>

--- a/tests/UI/Logic/TableViewTextCellFlowDirectionTests.cs
+++ b/tests/UI/Logic/TableViewTextCellFlowDirectionTests.cs
@@ -1,0 +1,91 @@
+using System.Collections.ObjectModel;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Avalonia.Media.TextFormatting;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// Text cells in a <see cref="TableView"/> must take their flow direction from their own
+/// content, the way the main subtitle grid's cells do. A cell left at the window's
+/// left-to-right direction lays a right-to-left line out under a left-to-right base
+/// direction, which cuts the line at every zero width non-joiner (U+200C) and places the
+/// pieces left to right - Persian words are torn in half and the word order is reversed
+/// (issue #13160, reported for "Point sync via other subtitle").
+/// </summary>
+public class TableViewTextCellFlowDirectionTests
+{
+    /// <summary>"دیگه نمی‌خوام ببینمت." - one Persian sentence with a ZWNJ inside نمی‌خوام.</summary>
+    private const string PersianWithZwnj = "دیگه نمی‌خوام ببینمت.";
+
+    [AvaloniaFact]
+    public void TextCellFlowsRightToLeftForRightToLeftText()
+    {
+        var textBlock = RealizeTextCell(PersianWithZwnj);
+
+        Assert.Equal(FlowDirection.RightToLeft, textBlock.FlowDirection);
+    }
+
+    [AvaloniaFact]
+    public void TextCellFlowsLeftToRightForLeftToRightText()
+    {
+        var textBlock = RealizeTextCell("Hello world.");
+
+        Assert.Equal(FlowDirection.LeftToRight, textBlock.FlowDirection);
+    }
+
+    /// <summary>
+    /// The user-visible symptom: Avalonia gives the ZWNJ the paragraph embedding level
+    /// instead of the level of the letters around it, so the sentence is laid out as
+    /// several runs. Under a left-to-right base direction those runs are then placed left
+    /// to right, which puts the first word of the sentence on the left - reversed word
+    /// order, with نمی‌خوام torn in half. With the cell following its content the runs are
+    /// ordered right to left again, so the first word is the rightmost thing on the line.
+    /// </summary>
+    [AvaloniaFact]
+    public void RightToLeftTextKeepsItsFirstWordRightmost()
+    {
+        var textBlock = RealizeTextCell(PersianWithZwnj);
+        var line = Assert.Single(textBlock.TextLayout.TextLines);
+
+        // TextRuns are in visual order (left to right), so the last one is the rightmost.
+        var rightmost = line.TextRuns
+            .OfType<ShapedTextRun>()
+            .Last(r => !string.IsNullOrWhiteSpace(r.Text.Span.ToString().Trim('‌')));
+
+        Assert.StartsWith("دیگه", rightmost.Text.Span.ToString());
+    }
+
+    /// <summary>
+    /// Builds a one-column grid with the shared text-cell template, shows it, and returns
+    /// the realized cell's text block.
+    /// </summary>
+    private static TextBlock RealizeTextCell(string text)
+    {
+        var tableView = TableViewExtras.MakeTableView(multiSelect: false);
+        tableView.Columns.Add(new SeTableViewColumn
+        {
+            Header = "Text",
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            CellTemplate = TableViewExtras.MakeTextCellTemplate(nameof(SubtitleLineViewModel.Text)),
+            Width = new GridLength(1, GridUnitType.Star),
+        });
+        tableView.ItemsSource = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new() { Text = text },
+        };
+
+        var window = new Window { Width = 400, Height = 200, Content = tableView };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        return Assert.Single(tableView.GetVisualDescendants().OfType<TextBlock>(), t => t.Text == text);
+    }
+}


### PR DESCRIPTION
Fixes #13160.

Persian/Arabic lines were rendered with the words in the wrong order in "Point sync via other subtitle" (and every other dialog that lists subtitle text), while the main subtitle grid showed the same lines correctly.

### Root cause

Only the main grid binds each text cell's flow direction to its own content (`TextToFlowDirectionConverter`). The dialog grids bound the text as a plain string column, so the cell kept the window's left-to-right direction — and Avalonia lays a right-to-left line out under a left-to-right base direction like this:

```
--- LeftToRight ---            (base direction of the dialog cell)
run len=8  level=1  [دیگه نمی]
run len=1  level=0  [U+200C]      <-- ZWNJ dropped to the paragraph level
run len=11 level=1  [خوام ببینمت]
run len=1  level=0  [.]

--- RightToLeft ---            (base direction of the main grid cell)
run len=20 level=1  [دیگه نمی‌خوام ببینمت]
```

The zero width non-joiner (U+200C) is bidi class BN, and Avalonia gives it the paragraph embedding level instead of the level of the letters around it (UAX#9 X9 says it should take the preceding character's level). Under a left-to-right base direction the line is therefore split into two right-to-left runs which are then placed left to right: the word order reverses and words spelled with a ZWNJ (نمی‌خوام) are torn in half. Under a right-to-left base direction the runs are ordered correctly, so giving the cell the direction of its content is enough — the upstream bidi bug is worth reporting to Avalonia separately, but it cannot bite once the base direction matches the text.

### Change

- New shared `TableViewExtras.MakeTextCellTemplate(propertyPath)`: a text cell that binds both `Text` and `FlowDirection` to the same property, exactly as the main subtitle grid does.
- Used for the text columns of: point sync via other subtitle (both grids), point sync, find text, sort by, apply duration limits, merge with same text, merge with same time codes, copy/paste translate (original and translation), import plain text, import CSV/XLSX custom columns.
- Fix common errors and export image based already had hand-written cell templates, so those get the one `FlowDirection` binding added instead — their background tints and syntax highlighting are untouched.

### Tests

New `TableViewTextCellFlowDirectionTests` realizes a real `TableView` cell with the reported line `دیگه نمی‌خوام ببینمت.` and asserts:

- right-to-left content gives the cell a right-to-left flow direction, Latin content a left-to-right one;
- the rightmost shaped run on the line starts with the sentence's first word, i.e. the word order is no longer reversed.

Verified the tests fail with the flow-direction binding removed (only the Latin control passes). Full UI suite: 1280 passed, 0 failed.

Note: the second request in #13160 — the gap between the time columns and right-aligned RTL text in the main list — is not addressed here. Edit → Right-to-left mode already gives that compact layout without changing the UI language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)