### PR TITLE
Add "Go to first/last line" shortcuts with video sync (Ctrl+Home/End)

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -89,6 +89,7 @@ using Nikse.SubtitleEdit.Features.Shared.PickSubtitleFormat;
 using Nikse.SubtitleEdit.Features.Shared.PickTsTrack;
 using Nikse.SubtitleEdit.Features.Shared.PickVobSubLanguage;
 using Nikse.SubtitleEdit.Features.Shared.PromptFileSaved;
+using Nikse.SubtitleEdit.Features.Shared.PromptCheckBox;
 using Nikse.SubtitleEdit.Features.Shared.PromptTextBox;
 using Nikse.SubtitleEdit.Features.Shared.ShowImage;
 using Nikse.SubtitleEdit.Features.Shared.SourceView;
@@ -485,6 +486,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<ProfilesExportViewModel>();
         collection.AddTransient<ProfilesViewModel>();
         collection.AddTransient<PromptFileSavedViewModel>();
+        collection.AddTransient<PromptCheckBoxViewModel>();
         collection.AddTransient<PromptTextBoxViewModel>();
         collection.AddTransient<PromptUnknownWordViewModel>();
         collection.AddTransient<ReEncodeVideoViewModel>();

--- a/src/ui/Features/Edit/ShowHistory/ShowHistoryWindow.cs
+++ b/src/ui/Features/Edit/ShowHistory/ShowHistoryWindow.cs
@@ -54,6 +54,7 @@ public class ShowHistoryWindow : Window
             },
         };
         UiUtil.ApplyTableViewRowStyle(tableView);
+        TableViewExtras.AttachListNavigation(tableView);
         tableView.SelectionChanged += (sender, args) =>
         {
             vm.IsRollbackEnabled = tableView.SelectedItem != null;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12627,6 +12627,68 @@ public partial class MainViewModel :
         }
     }
 
+    // Ctrl+Home/Ctrl+End (#13194): jump to the first/last line and - unless turned off via the
+    // shortcut's Configure button - move the video to its start/end as well. SE 4 had the
+    // rewind half of this as the confusingly named "Stop" video shortcut.
+    [RelayCommand]
+    private void GoToFirstLine()
+    {
+        if (Subtitles.Count > 0)
+        {
+            SelectAndScrollToRow(0);
+        }
+
+        if (!Se.Settings.Tools.GoToFirstAndLastLineAlsoSetVideoPosition)
+        {
+            return;
+        }
+
+        var vp = GetVideoPlayerControl();
+        if (string.IsNullOrEmpty(_videoFileName) || vp == null)
+        {
+            return;
+        }
+
+        // Same behavior as the player's Stop button: pause, seek to 0 and pin the
+        // waveform cursor there right away instead of waiting for mpv to report back.
+        vp.VideoPlayer.Stop();
+        OnVideoPlayerStopRequested();
+
+        if (AudioVisualizer != null && AudioVisualizer.WavePeaks != null)
+        {
+            AudioVisualizerCenterOnPositionIfNeeded(0);
+        }
+    }
+
+    [RelayCommand]
+    private void GoToLastLine()
+    {
+        if (Subtitles.Count > 0)
+        {
+            SelectAndScrollToRow(Subtitles.Count - 1);
+        }
+
+        if (!Se.Settings.Tools.GoToFirstAndLastLineAlsoSetVideoPosition)
+        {
+            return;
+        }
+
+        var vp = GetVideoPlayerControl();
+        if (string.IsNullOrEmpty(_videoFileName) || vp == null || vp.Duration <= 0)
+        {
+            return;
+        }
+
+        PauseVideoAndFreezePlayhead(vp);
+        vp.Position = vp.Duration;
+        PinPlayheadTo(vp.Duration);
+
+        if (AudioVisualizer != null && AudioVisualizer.WavePeaks != null)
+        {
+            AudioVisualizerCenterOnPositionIfNeeded(vp.Duration);
+        }
+    }
+
     [RelayCommand]
     private void GoToNextLineFromVideoPosition()
     {
@@ -21683,6 +21745,16 @@ public partial class MainViewModel :
                     return;
                 }
 
+                // Home/End (with or without Ctrl/Cmd/Shift) is likewise standard text editing -
+                // line/document start/end and selection. The "go to first/last line" shortcuts
+                // default to Ctrl+Home/End (#13194) but must stay out of text inputs.
+                if ((keyEventArgs.Key == Key.Home || keyEventArgs.Key == Key.End)
+                    && (keyEventArgs.KeyModifiers & ~(KeyModifiers.Control | KeyModifiers.Shift | KeyModifiers.Meta)) == KeyModifiers.None)
+                {
+                    _shortcutManager.ClearKeys();
+                    return;
+                }
+
                 if (_shortcutManager.TryGetSingleActiveKey(out var key))
                 {
                     if (EditTextBox.IsFocused && key == Key.Return &&
@@ -21766,12 +21838,14 @@ public partial class MainViewModel :
                     HandleShiftArrowSelection(Subtitles.Count); // clamps to Count - 1
                     return;
                 }
-                // Handle Ctrl+Home/End the same as plain Home/End: Ctrl is the habitual
-                // "go to top/bottom" chord, and routing it through SelectAndScrollToRow reuses the
-                // reliable scroll (EnsureRowFullyVisibleInSubtitleGrid) instead of falling through to
-                // Avalonia's default DataGrid navigation, which leaves the last row partially visible (#12173).
+                // Plain Home/End goes through SelectAndScrollToRow for the reliable scroll
+                // (EnsureRowFullyVisibleInSubtitleGrid) instead of falling through to Avalonia's
+                // default navigation, which leaves the last row partially visible (#12173).
+                // Ctrl+Home/End is deliberately NOT handled here anymore: it falls through to the
+                // shortcut dispatch below so the bindable "go to first/last line" actions run
+                // (#13194); if unbound, the grid's own AttachListNavigation handler picks it up.
                 else if (keyEventArgs.Key == Key.Home &&
-                         (keyEventArgs.KeyModifiers == KeyModifiers.None || keyEventArgs.KeyModifiers == KeyModifiers.Control) &&
+                         keyEventArgs.KeyModifiers == KeyModifiers.None &&
                          Subtitles.Count > 0)
                 {
                     keyEventArgs.Handled = true;
@@ -21779,7 +21853,7 @@ public partial class MainViewModel :
                     return;
                 }
                 else if (keyEventArgs.Key == Key.End &&
-                         (keyEventArgs.KeyModifiers == KeyModifiers.None || keyEventArgs.KeyModifiers == KeyModifiers.Control) &&
+                         keyEventArgs.KeyModifiers == KeyModifiers.None &&
                          Subtitles.Count > 0)
                 {
                     keyEventArgs.Handled = true;

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -574,6 +574,7 @@ public class OcrWindow : Window
         };
 
         UiUtil.ApplyTableViewRowStyle(dataGridSubtitle);
+        TableViewExtras.AttachListNavigation(dataGridSubtitle);
         dataGridSubtitle.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedOcrSubtitleItem)) { Source = vm });
         dataGridSubtitle.KeyDown += vm.SubtitleGridKeyDown;
         dataGridSubtitle.DoubleTapped += (s, e) => vm.SubtitleGridDoubleTapped();

--- a/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
+++ b/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
@@ -133,7 +133,9 @@ public static class Se4ShortcutsImporter
         ["MainVideoGoToNextSubtitle"] = nameof(MainViewModel.GoToNextLineAndSetVideoPositionCommand),
         ["MainVideoGoToPrevTimeCode"] = nameof(MainViewModel.VideoGoToPreviousTimeCodeCommand),
         ["MainVideoGoToNextTimeCode"] = nameof(MainViewModel.VideoGoToNextTimeCodeCommand),
-        ["MainVideoStop"] = nameof(MainViewModel.PauseCommand),
+        // SE4's "Stop" pauses and rewinds to 0 - GoToFirstLine does the same (plus selecting
+        // line 1); PauseCommand was a lossy stand-in that never rewound (#13194).
+        ["MainVideoStop"] = nameof(MainViewModel.GoToFirstLineCommand),
         ["MainVideoSelectNextSubtitle"] = nameof(MainViewModel.GoToNextLineCommand),
 
         // Synchronization

--- a/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
@@ -244,6 +244,8 @@ public partial class ShortcutsViewModel : ObservableObject
         _configurableCommands.Add(vm.SetActor8Command);
         _configurableCommands.Add(vm.SetActor9Command);
         _configurableCommands.Add(vm.SetActor10Command);
+        _configurableCommands.Add(vm.GoToFirstLineCommand);
+        _configurableCommands.Add(vm.GoToLastLineCommand);
     }
 
     private void BuildGroupTiles()
@@ -602,6 +604,24 @@ public partial class ShortcutsViewModel : ObservableObject
         if (actorSlotIndex >= 0)
         {
             await ConfigureActorSlot(node, actorSlotIndex);
+            return;
+        }
+
+        // "Go to first/last line" share one option: whether the video position follows (#13194).
+        if (node.ShortCut.Action == MainViewModel.GoToFirstLineCommand ||
+            node.ShortCut.Action == MainViewModel.GoToLastLineCommand)
+        {
+            var result = await _windowService.ShowDialogAsync<Nikse.SubtitleEdit.Features.Shared.PromptCheckBox.PromptCheckBoxWindow,
+                Nikse.SubtitleEdit.Features.Shared.PromptCheckBox.PromptCheckBoxViewModel>(Window, vm =>
+            {
+                vm.Initialize(node.Title, Se.Language.Options.Shortcuts.AlsoSetVideoPosition,
+                    Se.Settings.Tools.GoToFirstAndLastLineAlsoSetVideoPosition);
+            });
+            if (result.OkPressed)
+            {
+                Se.Settings.Tools.GoToFirstAndLastLineAlsoSetVideoPosition = result.IsChecked;
+            }
+
             return;
         }
 

--- a/src/ui/Features/Shared/PromptCheckBox/PromptCheckBoxViewModel.cs
+++ b/src/ui/Features/Shared/PromptCheckBox/PromptCheckBoxViewModel.cs
@@ -1,0 +1,57 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Nikse.SubtitleEdit.Features.Shared.PromptCheckBox;
+
+public partial class PromptCheckBoxViewModel : ObservableObject
+{
+    [ObservableProperty] private string _title;
+    [ObservableProperty] private string _checkBoxText;
+    [ObservableProperty] private bool _isChecked;
+
+    public Window? Window { get; set; }
+
+    public bool OkPressed { get; private set; }
+
+    public PromptCheckBoxViewModel()
+    {
+        Title = string.Empty;
+        CheckBoxText = string.Empty;
+    }
+
+    internal void Initialize(string title, string checkBoxText, bool isChecked)
+    {
+        Title = title;
+        CheckBoxText = checkBoxText;
+        IsChecked = isChecked;
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+        else if (e.Key == Key.Enter)
+        {
+            e.Handled = true;
+            Ok();
+        }
+    }
+}

--- a/src/ui/Features/Shared/PromptCheckBox/PromptCheckBoxWindow.cs
+++ b/src/ui/Features/Shared/PromptCheckBox/PromptCheckBoxWindow.cs
@@ -1,0 +1,57 @@
+using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Nikse.SubtitleEdit.Logic;
+
+namespace Nikse.SubtitleEdit.Features.Shared.PromptCheckBox;
+
+public class PromptCheckBoxWindow : Window
+{
+    public PromptCheckBoxWindow(PromptCheckBoxViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Bind(TitleProperty, new Binding(nameof(vm.Title)));
+        SizeToContent = SizeToContent.WidthAndHeight;
+        MinWidth = 300;
+        CanResize = false;
+        vm.Window = this;
+        DataContext = vm;
+
+        var checkBox = new CheckBox
+        {
+            Margin = new Thickness(0, 0, 10, 0),
+            [!ToggleButton.IsCheckedProperty] = new Binding(nameof(vm.IsChecked)) { Mode = BindingMode.TwoWay },
+            [!ContentControl.ContentProperty] = new Binding(nameof(vm.CheckBoxText)),
+        };
+        AutomationProperties.SetName(checkBox, vm.CheckBoxText);
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var buttonPanel = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            RowSpacing = 10,
+        };
+
+        grid.Add(checkBox, 0);
+        grid.Add(buttonPanel, 1);
+
+        Content = grid;
+
+        Activated += delegate { checkBox.Focus(); }; // hack to make OnKeyDown work
+        KeyDown += (_, e) => vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -26,6 +26,9 @@ public class LanguageSettingsShortcuts
     public string GeneralGoToNextSubtitle { get; set; }
     public string GeneralGoToNextSubtitleCursorAtEnd { get; set; }
     public string GeneralGoToPrevSubtitle { get; set; }
+    public string GeneralGoToFirstLine { get; set; }
+    public string GeneralGoToLastLine { get; set; }
+    public string AlsoSetVideoPosition { get; set; }
     public string GeneralGoToVideoPosition { get; set; }
     public string GeneralToggleItalic { get; set; }
     public string GeneralToggleBold { get; set; }
@@ -274,6 +277,9 @@ public class LanguageSettingsShortcuts
         GeneralGoToNextSubtitle = "Go to next subtitle";
         GeneralGoToNextSubtitleCursorAtEnd = "Go to next subtitle and set cursor at end";
         GeneralGoToPrevSubtitle = "Go to previous subtitle";
+        GeneralGoToFirstLine = "Go to first line";
+        GeneralGoToLastLine = "Go to last line";
+        AlsoSetVideoPosition = "Also set video position";
         GeneralGoToVideoPosition = "Go to video position";
         GeneralToggleItalic = "Toggle italic";
         GeneralToggleBold = "Toggle bold";

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -62,6 +62,7 @@ public class SeTools
     public string? SplitSubtitleEncoding { get; set; }
     public string SplitOddLinesAction { get; set; }
     public bool GoToLineNumberAlsoSetVideoPosition { get; set; }
+    public bool GoToFirstAndLastLineAlsoSetVideoPosition { get; set; }
     public bool SplitRebalanceLongLinesSplit { get; set; }
     public bool SplitRebalanceLongLinesRebalance { get; set; }
     public string UnicodeSymbolsToInsert { get; set; }
@@ -188,6 +189,7 @@ public class SeTools
         SplitOutputFolder = string.Empty;
         SplitSubtitleFormat = new SubRip().Name;
         GoToLineNumberAlsoSetVideoPosition = true;
+        GoToFirstAndLastLineAlsoSetVideoPosition = true;
         SplitRebalanceLongLinesSplit = true;
         SplitRebalanceLongLinesRebalance = true;
         SplitOddLinesAction = nameof(SplitOddLinesActionType.Smart);

--- a/src/ui/Logic/ShortcutManager.cs
+++ b/src/ui/Logic/ShortcutManager.cs
@@ -448,6 +448,31 @@ public class ShortcutManager : IShortcutManager
             }
         }
 
+        // 3. Numpad navigation fallback: with NumLock off the numpad emits Home/End/
+        // PageUp/... with a "NumPad" prefix so they can be bound independently (#10934).
+        // When no numpad-specific binding matched above, retry with the main-keyboard
+        // token so a plain "Ctrl+Home" binding fires from the numpad Home key too (#13194).
+        List<string>? collapsedKeys = null;
+        var lookupKeys = normalizedKeys ?? currentInputKeys;
+        for (var keyIndex = 0; keyIndex < lookupKeys.Count; keyIndex++)
+        {
+            var collapsed = CollapseNumPadNavigationToken(lookupKeys[keyIndex]);
+            if (!ReferenceEquals(collapsed, lookupKeys[keyIndex]))
+            {
+                collapsedKeys ??= new List<string>(lookupKeys);
+                collapsedKeys[keyIndex] = collapsed;
+            }
+        }
+
+        if (collapsedKeys != null)
+        {
+            var collapsedHash = ShortCut.CalculateHash(collapsedKeys, activeControl);
+            if (collapsedHash != inputHash && _lookupTable!.TryGetValue(collapsedHash, out shortcut))
+            {
+                return shortcut.Action;
+            }
+        }
+
         return null;
     }
 
@@ -464,6 +489,36 @@ public class ShortcutManager : IShortcutManager
             "LeftShift" or "RightShift" => "Shift",
             "LeftAlt" or "RightAlt" => "Alt",
             "LWin" or "RWin" => "Win",
+            _ => key
+        };
+    }
+
+    /// <summary>
+    /// Maps the NumLock-off numpad navigation tokens ("NumPadHome", ...) onto their
+    /// main-keyboard counterparts. Used ONLY as the last lookup stage in
+    /// <see cref="CheckShortcuts"/> - never in binding hashes - so a numpad-specific
+    /// binding keeps its distinct identity and always wins (#10934), while a plain
+    /// "Ctrl+Home" binding also fires from the numpad Home key (#13194). Both alias
+    /// spellings of the page keys are listed because Key.ToString() picks an
+    /// unspecified alias for enum members sharing a value (PageUp/Prior, PageDown/Next).
+    /// </summary>
+    public static string CollapseNumPadNavigationToken(string key)
+    {
+        return key switch
+        {
+            "NumPadHome" => "Home",
+            "NumPadEnd" => "End",
+            "NumPadPageUp" => "PageUp",
+            "NumPadPrior" => "Prior",
+            "NumPadPageDown" => "PageDown",
+            "NumPadNext" => "Next",
+            "NumPadUp" => "Up",
+            "NumPadDown" => "Down",
+            "NumPadLeft" => "Left",
+            "NumPadRight" => "Right",
+            "NumPadInsert" => "Insert",
+            "NumPadDelete" => "Delete",
+            "NumPadClear" => "Clear",
             _ => key
         };
     }

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -231,6 +231,8 @@ public static class ShortcutsMain
         { nameof(MainViewModel.GoToNextLineCommand), Se.Language.Options.Shortcuts.GeneralGoToNextSubtitle },
         { nameof(MainViewModel.GoToNextLineCursorAtEndCommand), Se.Language.Options.Shortcuts.GeneralGoToNextSubtitleCursorAtEnd },
         { nameof(MainViewModel.GoToPreviousLineCommand), Se.Language.Options.Shortcuts.GeneralGoToPrevSubtitle },
+        { nameof(MainViewModel.GoToFirstLineCommand), Se.Language.Options.Shortcuts.GeneralGoToFirstLine },
+        { nameof(MainViewModel.GoToLastLineCommand), Se.Language.Options.Shortcuts.GeneralGoToLastLine },
         { nameof(MainViewModel.GoToNextLineAndSetVideoPositionCommand), Se.Language.Options.Shortcuts.GoToNextLineAndSetVideoPosition },
         { nameof(MainViewModel.GoToPreviousLineAndSetVideoPositionCommand), Se.Language.Options.Shortcuts.GoToPreviousLineAndSetVideoPosition },
         { nameof(MainViewModel.GoToPreviousLineFromVideoPositionCommand), Se.Language.Options.Shortcuts.GoToPreviousLineFromVideoPosition },
@@ -581,6 +583,8 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.GoToPreviousLineCommand, nameof(vm.GoToPreviousLineCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToNextLineCommand, nameof(vm.GoToNextLineCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToNextLineCursorAtEndCommand, nameof(vm.GoToNextLineCursorAtEndCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.GoToFirstLineCommand, nameof(vm.GoToFirstLineCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.GoToLastLineCommand, nameof(vm.GoToLastLineCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToPreviousLineAndSetVideoPositionCommand, nameof(vm.GoToPreviousLineAndSetVideoPositionCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToNextLineAndSetVideoPositionCommand, nameof(vm.GoToNextLineAndSetVideoPositionCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToPreviousLineFromVideoPositionCommand, nameof(vm.GoToPreviousLineFromVideoPositionCommand), ShortcutCategory.General);
@@ -896,6 +900,9 @@ public static class ShortcutsMain
             new(nameof(vm.AddOrEditBookmarkCommand), [cmd, "Shift", "B"]),
             new(nameof(vm.GoToPreviousLineCommand), ["Alt", "Up"]),
             new(nameof(vm.GoToNextLineCommand), ["Alt", "Down"]),
+            // Go to first/last line (also sets the video position by default, #13194).
+            new(nameof(vm.GoToFirstLineCommand), [cmd, nameof(Avalonia.Input.Key.Home)], ShortcutCategory.General),
+            new(nameof(vm.GoToLastLineCommand), [cmd, nameof(Avalonia.Input.Key.End)], ShortcutCategory.General),
             new(nameof(vm.SelectAllLinesCommand), [cmd, "A"], ShortcutCategory.SubtitleGrid),
             new(nameof(vm.InverseSelectionCommand), [cmd, "Shift", "I"], ShortcutCategory.SubtitleGrid),
             new(nameof(vm.ToggleLinesItalicOrSelectedTextCommand), [cmd, "I"], ShortcutCategory.SubtitleGrid),

--- a/src/ui/Logic/TableViewExtras.cs
+++ b/src/ui/Logic/TableViewExtras.cs
@@ -268,6 +268,12 @@ public static class TableViewExtras
         };
 
         UiUtil.ApplyTableViewRowStyle(tableView);
+
+        // Home/End/PageUp/PageDown (and Ctrl+Home/End) list navigation in every grid (#13194).
+        // Handlers attached earlier in the routing path (window-level tunnel handlers, shortcut
+        // dispatch) still win; this is the fallback when nothing else handled the key.
+        AttachListNavigation(tableView);
+
         return tableView;
     }
 

--- a/tests/UI/Logic/ShortcutsGoToFirstLastLineTests.cs
+++ b/tests/UI/Logic/ShortcutsGoToFirstLastLineTests.cs
@@ -1,0 +1,106 @@
+using Avalonia.Input;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Options.Shortcuts;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// Ctrl+Home / Ctrl+End default to "go to first/last line", which also move the video
+/// position unless turned off (#13194). The reporter uses the numpad Home key, so a plain
+/// "Ctrl+Home" binding must fire from the NumLock-off numpad Home too - via the last-resort
+/// collapse stage in CheckShortcuts - while a numpad-specific binding keeps winning (#10934).
+/// </summary>
+public class ShortcutsGoToFirstLastLineTests
+{
+    private static KeyEventArgs KeyEvent(Key key, PhysicalKey physicalKey, KeyModifiers modifiers)
+    {
+        return new KeyEventArgs
+        {
+            Key = key,
+            PhysicalKey = physicalKey,
+            KeyModifiers = modifiers,
+        };
+    }
+
+    [Fact]
+    public void DefaultsBindCtrlHomeAndCtrlEndToGoToFirstAndLastLine()
+    {
+        // GetDefaultShortcuts only uses the vm parameter for nameof() - never dereferenced.
+        var defaults = ShortcutsMain.GetDefaultShortcuts(null!);
+
+        var first = defaults.Single(s => s.ActionName == nameof(MainViewModel.GoToFirstLineCommand));
+        var last = defaults.Single(s => s.ActionName == nameof(MainViewModel.GoToLastLineCommand));
+
+        Assert.Contains("Home", first.Keys);
+        Assert.Contains("End", last.Keys);
+        Assert.Equal(2, first.Keys.Count); // modifier (Ctrl/Cmd) + Home
+        Assert.Equal(2, last.Keys.Count);
+    }
+
+    [Fact]
+    public void PlainCtrlHomeBindingFiresFromNumpadHome()
+    {
+        var manager = new ShortcutManager();
+        var category = ShortcutCategory.General;
+        var command = new RelayCommand(() => { });
+        manager.RegisterShortcut(new ShortCut("Go to first line", ["Ctrl", "Home"], category, command));
+
+        var numpadHome = KeyEvent(Key.Home, PhysicalKey.NumPad7, KeyModifiers.Control);
+        manager.OnKeyPressed(null, numpadHome);
+
+        Assert.Same(command, manager.CheckShortcuts(numpadHome, category.ToString()));
+    }
+
+    [Fact]
+    public void NumpadSpecificBindingStillWinsOverPlainBinding()
+    {
+        var manager = new ShortcutManager();
+        var category = ShortcutCategory.General;
+        var plainCommand = new RelayCommand(() => { });
+        var numpadCommand = new RelayCommand(() => { });
+        manager.RegisterShortcut(new ShortCut("Plain", ["Ctrl", "Home"], category, plainCommand));
+        manager.RegisterShortcut(new ShortCut("Numpad", ["Ctrl", "NumPadHome"], category, numpadCommand));
+
+        var numpadHome = KeyEvent(Key.Home, PhysicalKey.NumPad7, KeyModifiers.Control);
+        manager.OnKeyPressed(null, numpadHome);
+        Assert.Same(numpadCommand, manager.CheckShortcuts(numpadHome, category.ToString()));
+
+        manager.ClearKeys();
+        var mainHome = KeyEvent(Key.Home, PhysicalKey.Home, KeyModifiers.Control);
+        manager.OnKeyPressed(null, mainHome);
+        Assert.Same(plainCommand, manager.CheckShortcuts(mainHome, category.ToString()));
+    }
+
+    [Fact]
+    public void MainHomeDoesNotFireNumpadOnlyBinding()
+    {
+        // The reverse direction stays independent (#10934): a binding placed
+        // specifically on the numpad key must not react to the main-keyboard key.
+        var manager = new ShortcutManager();
+        var category = ShortcutCategory.General;
+        var command = new RelayCommand(() => { });
+        manager.RegisterShortcut(new ShortCut("Numpad only", ["Ctrl", "NumPadHome"], category, command));
+
+        var mainHome = KeyEvent(Key.Home, PhysicalKey.Home, KeyModifiers.Control);
+        manager.OnKeyPressed(null, mainHome);
+
+        Assert.Null(manager.CheckShortcuts(mainHome, category.ToString()));
+    }
+
+    [Theory]
+    [InlineData("NumPadHome", "Home")]
+    [InlineData("NumPadEnd", "End")]
+    [InlineData("NumPadDelete", "Delete")]
+    [InlineData("NumPadInsert", "Insert")]
+    // Digits, Decimal and Enter stay fully distinct across NumLock states.
+    [InlineData("NumPad7", "NumPad7")]
+    [InlineData("NumPadDecimal", "NumPadDecimal")]
+    [InlineData("NumPadReturn", "NumPadReturn")]
+    [InlineData("Home", "Home")]
+    public void CollapseNumPadNavigationTokenMapsOnlyNavigationKeys(string token, string expected)
+    {
+        Assert.Equal(expected, ShortcutManager.CollapseNumPadNavigationToken(token));
+    }
+}


### PR DESCRIPTION
Fixes #13194.

Adds the shortcut GrampaWildWilly asked for: jump to the first line and rewind the video to 0:00 (SE 4 had the rewind half as the confusingly named "Stop"), plus the symmetric go-to-last-line-and-end-of-video.

## What's included

- **Two new bindable actions** - "Go to first line" and "Go to last line" - defaulting to **Ctrl+Home / Ctrl+End** (Cmd on macOS). They select the first/last row and, by default, also pause and move the video to its start/end (same code path as the player's Stop button, so the waveform cursor pins immediately).
- **Configurable video sync**: selecting either shortcut in the Shortcuts window shows the existing Configure button, which opens a new small checkbox dialog ("Also set video position", one shared setting, default on). Backed by a new reusable `PromptCheckBoxWindow`.
- **Active everywhere except text inputs**: works from the subtitle grid, waveform, video player area, and the undocked video/waveform windows (they already forward keys to the main handler). In text boxes Ctrl+Home/End stays native caret navigation, guarded the same way as Ctrl+Left/Right (#11357).
- **SE 4 import fix**: `MainVideoStop` was mapped to Pause, which never rewound - it now maps to the new rewind action, so the reporter's SE 4 Ctrl+Home workflow imports faithfully.
- **Numpad Home/End works too**: the reporter always uses the numpad Home key. Numpad keys keep their distinct tokens (deliberate, #10934 - same reporter), but `CheckShortcuts` gains a last-resort lookup stage that collapses the NumLock-off numpad navigation tokens onto their main-keyboard names. A plain Ctrl+Home binding now fires from the numpad key, while numpad-specific bindings keep absolute priority and main-keyboard presses never trigger numpad-only bindings. Covered by new unit tests.
- **Home/End/PageUp/PageDown in all TableViews**: `MakeTableView` now attaches the existing `AttachListNavigation` fallback (window-level handlers and shortcuts still win), plus explicit calls for the two hand-rolled grids (OCR, Show history). The subtitle grid's hard-coded Ctrl+Home/End branch yields to the new shortcuts; plain Home/End keeps the #12173 reliable scroll.

## Notes

- Existing users get the new default bindings via the defaults merge; a pre-existing user assignment of Ctrl+Home to something else wins (lookup is first-registered, dedupe-tolerant).
- Ctrl+End seeks to the literal end of the video per the issue request; changing it to the last line's start time would be a one-line change in `GoToLastLine`.
- The full-screen video window keeps its own local shortcut set (per #12504 design) and is not wired up here.

Tests: 1288 UI tests pass (one unrelated flaky theme-zip cleanup failure under parallel run, passes in isolation), including the pre-existing #10934 numpad-distinctness tests and a new `ShortcutsGoToFirstLastLineTests` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)