### PR TITLE
Explain native engine exit codes instead of printing raw numbers

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/KokoroTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/KokoroTtsCpp.cs
@@ -1,5 +1,6 @@
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
 using System;
@@ -357,8 +358,13 @@ public class KokoroTtsCpp : ITtsEngine
                     var tail = SnapshotStderr(stderrBuffer);
                     _serverProcess = null;
                     _serverPort = 0;
+                    // An empty tail plus a 0xC00000xx code means the loader killed it before main -
+                    // NativeExitCodeHelper explains those instead of just printing the raw number.
+                    var hint = NativeExitCodeHelper.GetHint(process.ExitCode, "Kokoro TTS", GetSetFolder());
                     throw new InvalidOperationException(
-                        $"kokoro-tts-server exited during startup (code {process.ExitCode}). Output: {tail}");
+                        $"kokoro-tts-server exited during startup (code {NativeExitCodeHelper.Describe(process.ExitCode)})."
+                        + (hint == null ? string.Empty : " " + hint)
+                        + $" Output: {tail}");
                 }
                 if (await ProbeHealthAsync(port, TimeSpan.FromSeconds(1), ct))
                 {

--- a/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
@@ -1,5 +1,6 @@
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.Logic.Media;
@@ -22,7 +23,7 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 public class OmniVoiceTtsCpp : ITtsEngine
 {
     public string Name => "OmniVoice TTS";
-    public string Description => "646 languages, voice cloning, runs on CPU";
+    public string Description => "646 languages, voice cloning, CPU/Vulkan/CUDA";
     public bool HasLanguageParameter => true;
     public bool HasApiKey => false;
     public bool HasRegion => false;
@@ -335,14 +336,17 @@ public class OmniVoiceTtsCpp : ITtsEngine
 
             if (process.ExitCode != 0 || !File.Exists(outputFileName))
             {
-                var msg = $"OmniVoice TTS failed (exit code {process.ExitCode}) - "
+                // A process killed by the Windows loader (e.g. missing CUDA runtime, issue #13196)
+                // never reaches main, so stderr is empty and the bare exit code is all the user sees.
+                // NativeExitCodeHelper turns the known status codes into an actionable sentence.
+                var detail = NativeExitCodeHelper.Format(Name, process.ExitCode, GetSetFolder());
+                var msg = $"{detail} - "
                     + $"Voice: {omniVoice}, Text: {text}, "
                     + $"Args: {string.Join(' ', psi.ArgumentList)}, "
                     + $"StdErr: {stderr.Trim()}, StdOut: {stdout.Trim()}";
                 Se.LogError(msg);
                 Se.WriteToolsLog(msg);
-                throw new InvalidOperationException(
-                    $"OmniVoice TTS failed (exit code {process.ExitCode}). {stderr.Trim()}");
+                throw new InvalidOperationException($"{detail} {stderr.Trim()}".TrimEnd());
             }
 
             return new TtsResult(outputFileName, text);

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
@@ -1,5 +1,6 @@
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.Logic.Media;
@@ -415,8 +416,13 @@ public class Qwen3TtsCpp : ITtsEngine
                     _serverProcess = null;
                     _serverPort = 0;
                     _serverModelFileName = null;
+                    // An empty tail plus a 0xC00000xx code means the loader killed it before main -
+                    // NativeExitCodeHelper explains those instead of just printing the raw number.
+                    var hint = NativeExitCodeHelper.GetHint(process.ExitCode, "Qwen3 TTS", GetSetFolder());
                     throw new InvalidOperationException(
-                        $"qwen3-tts-server exited during startup (code {process.ExitCode}). Output: {tail}");
+                        $"qwen3-tts-server exited during startup (code {NativeExitCodeHelper.Describe(process.ExitCode)})."
+                        + (hint == null ? string.Empty : " " + hint)
+                        + $" Output: {tail}");
                 }
                 if (await ProbeHealthAsync(port, TimeSpan.FromSeconds(1), ct))
                 {

--- a/src/ui/Logic/NativeExitCodeHelper.cs
+++ b/src/ui/Logic/NativeExitCodeHelper.cs
@@ -1,0 +1,161 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Turns raw exit codes from bundled native helper processes (omnivoice-tts, qwen3-tts-server,
+/// kokoro-tts-server, ...) into something a user can act on.
+///
+/// A process that dies inside the Windows loader never gets to write a single line to stderr, so
+/// all the engine wrappers can report is a large negative number. 0xC0000135 (STATUS_DLL_NOT_FOUND)
+/// shows up as -1073741515, which tells the user nothing - see issue #13196, where the CUDA build of
+/// OmniVoice shipped without the CUDA redistributables and every run failed with exactly that.
+/// </summary>
+public static class NativeExitCodeHelper
+{
+    public const int StatusAccessViolation = unchecked((int)0xC0000005);
+    public const int StatusIllegalInstruction = unchecked((int)0xC000001D);
+    public const int StatusDllNotFound = unchecked((int)0xC0000135);
+    public const int StatusEntryPointNotFound = unchecked((int)0xC0000139);
+    public const int StatusDllInitFailed = unchecked((int)0xC0000142);
+    public const int StatusStackBufferOverrun = unchecked((int)0xC0000409);
+
+    // ggml names its GPU backends consistently across all the bundled *.cpp engines, so the same
+    // pair of probes works for every one of them.
+    private const string CudaBackendDll = "ggml-cuda.dll";
+    private const string VulkanBackendDll = "ggml-vulkan.dll";
+
+    // ggml-cuda.dll imports cudart64_*.dll and cublas64_*.dll; cuBLAS then pulls in cublasLt64_*.dll.
+    // Searched by glob rather than pinned to _12 so a CUDA 13 build - which renames them to _13 - is
+    // not reported as broken; the example name is only for the message, where a concrete file the
+    // user can look for beats a wildcard.
+    private static readonly (string Glob, string Example)[] CudaRuntimeDlls =
+    {
+        ("cudart64_*.dll", "cudart64_12.dll"),
+        ("cublas64_*.dll", "cublas64_12.dll"),
+        ("cublasLt64_*.dll", "cublasLt64_12.dll"),
+    };
+
+    /// <summary>
+    /// Formats an exit code for display, adding the hex form for values that look like a Windows
+    /// NTSTATUS (the 0xC00000xx range) since those are only recognisable in hex.
+    /// </summary>
+    public static string Describe(int exitCode)
+    {
+        return IsNtStatus(exitCode)
+            ? $"{exitCode} (0x{(uint)exitCode:X8})"
+            : exitCode.ToString();
+    }
+
+    /// <summary>
+    /// A sentence explaining what the exit code means and what to try, or null when the code carries
+    /// no useful meaning (a plain non-zero exit from the tool itself - stderr is better there).
+    /// </summary>
+    /// <param name="exitCode">Exit code of the native process.</param>
+    /// <param name="engineName">User-facing engine name, e.g. "OmniVoice TTS".</param>
+    /// <param name="installFolder">Engine install folder, probed to name the actual missing files.</param>
+    public static string? GetHint(int exitCode, string engineName, string? installFolder = null)
+    {
+        switch (exitCode)
+        {
+            case StatusDllNotFound:
+            case StatusEntryPointNotFound:
+            case StatusDllInitFailed:
+                return GetMissingDllHint(engineName, installFolder);
+
+            case StatusIllegalInstruction:
+                return $"{engineName} was stopped by an illegal instruction, which means this build "
+                       + "uses CPU instructions your processor does not support. Re-download the engine "
+                       + "and pick a different build.";
+
+            case StatusAccessViolation:
+            case StatusStackBufferOverrun:
+                return $"{engineName} crashed. If it is a GPU build, re-download the engine and try the "
+                       + "CPU build, which is slower but far less fragile.";
+
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>
+    /// "OmniVoice TTS failed (exit code -1073741515 (0xC0000135)). &lt;hint&gt;" - the hint is appended
+    /// only when the code is one we can explain.
+    /// </summary>
+    public static string Format(string engineName, int exitCode, string? installFolder = null)
+    {
+        var message = $"{engineName} failed (exit code {Describe(exitCode)}).";
+        var hint = GetHint(exitCode, engineName, installFolder);
+        return hint == null ? message : $"{message} {hint}";
+    }
+
+    private static string GetMissingDllHint(string engineName, string? installFolder)
+    {
+        var missing = FindMissingGpuRuntime(installFolder);
+        if (missing != null)
+        {
+            return $"{engineName} could not start because {missing}";
+        }
+
+        return $"{engineName} could not start: Windows could not load a DLL it needs. That is usually a "
+               + "missing GPU runtime (CUDA or Vulkan) or a missing Microsoft Visual C++ Redistributable. "
+               + "Re-download the engine and pick the CPU build, which has no such dependencies.";
+    }
+
+    /// <summary>
+    /// Best-effort look at what the install folder is missing, so the message can name real files
+    /// instead of guessing. Returns null when the folder looks fine or cannot be inspected - callers
+    /// then fall back to the generic wording.
+    /// </summary>
+    private static string? FindMissingGpuRuntime(string? installFolder)
+    {
+        if (string.IsNullOrEmpty(installFolder) || !Directory.Exists(installFolder))
+        {
+            return null;
+        }
+
+        try
+        {
+            if (File.Exists(Path.Combine(installFolder, CudaBackendDll)))
+            {
+                var missing = new List<string>();
+                foreach (var (glob, example) in CudaRuntimeDlls)
+                {
+                    if (Directory.GetFiles(installFolder, glob).Length == 0)
+                    {
+                        missing.Add(example);
+                    }
+                }
+
+                if (missing.Count > 0)
+                {
+                    return $"the CUDA runtime files are missing from {installFolder} ("
+                           + string.Join(", ", missing)
+                           + "). Re-download the engine and pick the Vulkan or CPU build, which need no "
+                           + "CUDA runtime, or copy the files from another CUDA install.";
+                }
+            }
+
+            if (File.Exists(Path.Combine(installFolder, VulkanBackendDll)) && !VulkanHelper.IsInstalled())
+            {
+                return "the Vulkan runtime (vulkan-1.dll) was not found. It normally ships with current "
+                       + "GPU drivers - update your driver, install the Vulkan runtime from "
+                       + "https://vulkan.lunarg.com/sdk/home, or re-download the engine and pick the CPU build.";
+            }
+        }
+        catch
+        {
+            // diagnostics only - never let the probe turn into a second failure
+        }
+
+        return null;
+    }
+
+    private static bool IsNtStatus(int exitCode)
+    {
+        // NTSTATUS failure codes are 0xC0000000-based. Ordinary tools exit with small values, and
+        // Unix signals surface as 128+n, so this range is unambiguous in practice.
+        return ((uint)exitCode & 0xFFFF0000) == 0xC0000000;
+    }
+}

--- a/tests/UI/Logic/NativeExitCodeHelperTests.cs
+++ b/tests/UI/Logic/NativeExitCodeHelperTests.cs
@@ -1,0 +1,194 @@
+using Nikse.SubtitleEdit.Logic;
+using System;
+using System.IO;
+
+namespace UITests.Logic;
+
+public class NativeExitCodeHelperTests
+{
+    private const string Engine = "OmniVoice TTS";
+
+    // Creates a temp folder standing in for an engine install, seeded with the given file names.
+    private static string MakeInstallFolder(params string[] fileNames)
+    {
+        var folder = Path.Combine(Path.GetTempPath(), "se-native-exit-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(folder);
+        foreach (var name in fileNames)
+        {
+            File.WriteAllText(Path.Combine(folder, name), string.Empty);
+        }
+
+        return folder;
+    }
+
+    [Fact]
+    public void Describe_AddsHexForNtStatusCodes()
+    {
+        // -1073741515 is what the user actually sees in the error dialog (issue #13196).
+        Assert.Equal("-1073741515 (0xC0000135)", NativeExitCodeHelper.Describe(NativeExitCodeHelper.StatusDllNotFound));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(139)]
+    public void Describe_LeavesOrdinaryExitCodesAlone(int exitCode)
+    {
+        Assert.Equal(exitCode.ToString(), NativeExitCodeHelper.Describe(exitCode));
+    }
+
+    [Fact]
+    public void GetHint_ReturnsNullForOrdinaryFailures()
+    {
+        // A tool that exits 1 has written a real error to stderr - do not bury it under a guess.
+        Assert.Null(NativeExitCodeHelper.GetHint(1, Engine));
+        Assert.Null(NativeExitCodeHelper.GetHint(0, Engine));
+    }
+
+    [Theory]
+    [InlineData(unchecked((int)0xC0000135))]
+    [InlineData(unchecked((int)0xC0000139))]
+    [InlineData(unchecked((int)0xC0000142))]
+    public void GetHint_ExplainsLoaderFailuresWithoutAnInstallFolder(int exitCode)
+    {
+        var hint = NativeExitCodeHelper.GetHint(exitCode, Engine);
+        Assert.NotNull(hint);
+        Assert.Contains("could not load a DLL", hint);
+        Assert.Contains(Engine, hint);
+    }
+
+    [Fact]
+    public void GetHint_NamesTheMissingCudaRuntimeFiles()
+    {
+        // Exactly the shipped omnivoice-win64-cuda.zip layout from issue #13196: the CUDA backend
+        // is present, the redistributables it imports are not.
+        var folder = MakeInstallFolder("omnivoice-tts.exe", "ggml.dll", "ggml-base.dll", "ggml-cpu.dll", "ggml-cuda.dll");
+        try
+        {
+            var hint = NativeExitCodeHelper.GetHint(NativeExitCodeHelper.StatusDllNotFound, Engine, folder);
+            Assert.NotNull(hint);
+            Assert.Contains("CUDA runtime files are missing", hint);
+            Assert.Contains("cudart64_12.dll", hint);
+            Assert.Contains("cublas64_12.dll", hint);
+            Assert.Contains("cublasLt64_12.dll", hint);
+            Assert.Contains(folder, hint);
+        }
+        finally
+        {
+            Directory.Delete(folder, true);
+        }
+    }
+
+    [Fact]
+    public void GetHint_FallsBackToGenericWhenTheCudaRuntimeIsPresent()
+    {
+        // Redistributables all there - whatever failed to load, it is not those, so do not claim it is.
+        var folder = MakeInstallFolder(
+            "ggml-cuda.dll", "cudart64_12.dll", "cublas64_12.dll", "cublasLt64_12.dll");
+        try
+        {
+            var hint = NativeExitCodeHelper.GetHint(NativeExitCodeHelper.StatusDllNotFound, Engine, folder);
+            Assert.NotNull(hint);
+            Assert.DoesNotContain("CUDA runtime files are missing", hint);
+            Assert.Contains("could not load a DLL", hint);
+        }
+        finally
+        {
+            Directory.Delete(folder, true);
+        }
+    }
+
+    [Fact]
+    public void GetHint_AcceptsCuda13FileNames()
+    {
+        // A CUDA 13 build renames the redistributables to _13; the glob must not read that as missing.
+        var folder = MakeInstallFolder(
+            "ggml-cuda.dll", "cudart64_13.dll", "cublas64_13.dll", "cublasLt64_13.dll");
+        try
+        {
+            var hint = NativeExitCodeHelper.GetHint(NativeExitCodeHelper.StatusDllNotFound, Engine, folder);
+            Assert.NotNull(hint);
+            Assert.DoesNotContain("CUDA runtime files are missing", hint);
+        }
+        finally
+        {
+            Directory.Delete(folder, true);
+        }
+    }
+
+    [Fact]
+    public void GetHint_ReportsPartiallyMissingCudaRuntime()
+    {
+        var folder = MakeInstallFolder("ggml-cuda.dll", "cudart64_12.dll");
+        try
+        {
+            var hint = NativeExitCodeHelper.GetHint(NativeExitCodeHelper.StatusDllNotFound, Engine, folder);
+            Assert.NotNull(hint);
+            Assert.Contains("cublas64_12.dll", hint);
+            Assert.Contains("cublasLt64_12.dll", hint);
+            Assert.DoesNotContain("cudart64_12.dll", hint);
+        }
+        finally
+        {
+            Directory.Delete(folder, true);
+        }
+    }
+
+    [Fact]
+    public void GetHint_IgnoresACpuInstallFolder()
+    {
+        // No GPU backend at all - the folder tells us nothing, so the generic wording stands.
+        var folder = MakeInstallFolder("omnivoice-tts.exe", "ggml.dll", "ggml-base.dll", "ggml-cpu.dll");
+        try
+        {
+            var hint = NativeExitCodeHelper.GetHint(NativeExitCodeHelper.StatusDllNotFound, Engine, folder);
+            Assert.NotNull(hint);
+            Assert.Contains("could not load a DLL", hint);
+        }
+        finally
+        {
+            Directory.Delete(folder, true);
+        }
+    }
+
+    [Fact]
+    public void GetHint_SurvivesAMissingInstallFolder()
+    {
+        var hint = NativeExitCodeHelper.GetHint(
+            NativeExitCodeHelper.StatusDllNotFound, Engine, Path.Combine(Path.GetTempPath(), "no-such-folder-" + Guid.NewGuid()));
+        Assert.NotNull(hint);
+        Assert.Contains("could not load a DLL", hint);
+    }
+
+    [Fact]
+    public void GetHint_ExplainsIllegalInstruction()
+    {
+        var hint = NativeExitCodeHelper.GetHint(NativeExitCodeHelper.StatusIllegalInstruction, Engine);
+        Assert.NotNull(hint);
+        Assert.Contains("CPU instructions your processor does not support", hint);
+    }
+
+    [Theory]
+    [InlineData(unchecked((int)0xC0000005))]
+    [InlineData(unchecked((int)0xC0000409))]
+    public void GetHint_ExplainsHardCrashes(int exitCode)
+    {
+        var hint = NativeExitCodeHelper.GetHint(exitCode, Engine);
+        Assert.NotNull(hint);
+        Assert.Contains("crashed", hint);
+    }
+
+    [Fact]
+    public void Format_AppendsTheHintWhenThereIsOne()
+    {
+        var message = NativeExitCodeHelper.Format(Engine, NativeExitCodeHelper.StatusDllNotFound);
+        Assert.StartsWith("OmniVoice TTS failed (exit code -1073741515 (0xC0000135)).", message);
+        Assert.Contains("could not load a DLL", message);
+    }
+
+    [Fact]
+    public void Format_StaysTerseForOrdinaryExitCodes()
+    {
+        Assert.Equal("OmniVoice TTS failed (exit code 3).", NativeExitCodeHelper.Format(Engine, 3));
+    }
+}


### PR DESCRIPTION
Diagnostics half of #13196. The packaging fix that actually unbreaks the OmniVoice CUDA build is niksedk/omnivoice.cpp#3; this PR makes the failure self-explanatory rather than a bare number, and covers the same class of failure in the other bundled native engines.

## Why

A native helper process killed by the Windows loader never reaches `main`, so stderr is empty and the exit code is all we have. In #13196 the user saw:

> OmniVoice TTS failed (exit code -1073741515).

`-1073741515` is `0xC0000135`, `STATUS_DLL_NOT_FOUND` — the CUDA build's `ggml-cuda.dll` imports `cudart64_12.dll` and `cublas64_12.dll`, and the published zip contains neither. Nothing in that message hints at a missing DLL, at CUDA, or at the fact that switching to the Vulkan build would have worked immediately.

## What

`NativeExitCodeHelper` (`src/ui/Logic/`):

- `Describe` adds the hex form for NTSTATUS-looking codes, since `0xC0000135` is recognisable where `-1073741515` is not.
- `GetHint` explains the codes we can actually identify — DLL not found / entry point not found / DLL init failed, illegal instruction, access violation, stack buffer overrun — and returns **null** for everything else. An ordinary `exit 1` means the tool wrote a real error to stderr, and a guess appended to that is worse than nothing.
- For loader failures it probes the install folder before wording the message. When `ggml-cuda.dll` is present but the redistributables are not, it names the missing files, names the folder, and points at the Vulkan or CPU build. When `ggml-vulkan.dll` is present and `vulkan-1.dll` is not installed, it says so instead. Otherwise it falls back to generic wording that mentions the usual causes (GPU runtime, VC++ Redistributable). The CUDA probe globs `cudart64_*.dll` rather than pinning `_12`, so a future CUDA 13 build is not misreported as broken.

The result for #13196:

> OmniVoice TTS failed (exit code -1073741515 (0xC0000135)). OmniVoice TTS could not start because the CUDA runtime files are missing from …\TextToSpeech\OmniVoice (cudart64_12.dll, cublas64_12.dll, cublasLt64_12.dll). Re-download the engine and pick the Vulkan or CPU build, which need no CUDA runtime, or copy the files from another CUDA install.

Wired into the three engines that launch bundled native binaries with GPU build variants: `OmniVoiceTtsCpp`, `Qwen3TtsCpp`, `KokoroTtsCpp`.

Also corrects the OmniVoice engine description, which still read `"646 languages, voice cloning, runs on CPU"` after the Vulkan and CUDA builds were added — visible in the reporter's screenshot, directly under a dialog reporting a CUDA backend.

## Testing

19 new tests in `tests/UI/Logic/NativeExitCodeHelperTests.cs`, including the exact shipped `omnivoice-win64-cuda.zip` layout from the issue, the CUDA-13 naming, a partially-populated folder, a CPU-only folder, and a nonexistent folder. Full UI suite: 1296 passed, 0 failed.

The Vulkan branch is deliberately not unit-tested — its outcome depends on whether the host has `vulkan-1.dll`, and a platform-dependent assertion is worse than none.

Closes #13196 once niksedk/omnivoice.cpp#3 ships in a release and the pin is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)