### PR TITLE
Pin OmniVoice to omnivoice-2026-08-04 (CUDA build actually works now)

### DIFF
--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -1313,49 +1313,55 @@ public static class DownloadHashManager
             // otherwise users will be prompted to "update" to the same version they just got.
             [OmniVoice.WindowsCpu] = new[]
             {
-                "e4e301a9c03db62a3f0d8d15b34584c49407c43f3e59dd9eae4a90121ad7f012", // omnivoice-2026-08-03 (current download URL — upstream sync + ggml bump)
+                "8f7d78f72cfc69c904eb702497a27f9e760dcfff435d8e6acdee34cbf40a39aa", // omnivoice-2026-08-04 (current download URL — rebuild of the same sources as 2026-08-03)
+                "e4e301a9c03db62a3f0d8d15b34584c49407c43f3e59dd9eae4a90121ad7f012", // omnivoice-2026-08-03 (upstream sync + ggml bump)
                 "ba1606c39987ea541e55db53f8925ed3c4f8301447e4f590aca800ccd52cef52", // omnivoice-2026-06-18 (portable AVX2 baseline, GGML_NATIVE=OFF)
                 "4af38bcb264ef34d7d39a7c76af00993e32f731a17253b7e82a9b8a6140a736b", // omnivoice-2026-05-22
                 "ea1f0c6032f5a0333103ccffa7d7478c5ee00a35867776c277d717512587766c", // omnivoice-2026-05-17
             },
             [OmniVoice.WindowsVulkan] = new[]
             {
-                "f2123650b1f17a8b2cb9c8b8ff25b0cbc5a9064cb359294f1c0da6ac5246d4d3", // omnivoice-2026-08-03 (current download URL — upstream sync + ggml bump)
+                "a0172efa536e230c647ebfe7e0491a9f37be26622f792bcd1ff247310af9558b", // omnivoice-2026-08-04 (current download URL — rebuild of the same sources as 2026-08-03)
+                "f2123650b1f17a8b2cb9c8b8ff25b0cbc5a9064cb359294f1c0da6ac5246d4d3", // omnivoice-2026-08-03 (upstream sync + ggml bump)
                 "0f1e33fe67c78835991ccd787da68d265142f07e95f17b1c0b89e4d0c1fc6811", // omnivoice-2026-06-18 (portable AVX2 baseline, GGML_NATIVE=OFF)
                 "ff90f8eb8c36ea64d46bd1d245e109ef80cadf234417bdc2c78b7420ab8f9a43", // omnivoice-2026-05-22
                 "b461b8535892b3e6979aec79eff4d6a0109a31184008b778b6848d7d36ea9901", // omnivoice-2026-05-17
             },
             [OmniVoice.WindowsCuda] = new[]
             {
-                "7cc4ab9f4bec88468747e9e2f049ea6392a52d79da37e25504460de4b868c800", // omnivoice-2026-08-03 (current download URL — adds Pascal sm_61 + Volta sm_70 kernels; fixes #13061 no-kernel-image crash)
+                "02042cedf07e43915c24ddd14f4989648e334e0270cada8ff8074f39fa91209a", // omnivoice-2026-08-04 (current download URL — bundles the CUDA redistributables cudart64_12/cublas64_12/cublasLt64_12; fixes #13196)
+                "7cc4ab9f4bec88468747e9e2f049ea6392a52d79da37e25504460de4b868c800", // omnivoice-2026-08-03 (adds Pascal sm_61 + Volta sm_70 kernels; fixes #13061 no-kernel-image crash)
                 "1d3109d67e4a3e3e83bce83791fa4af5c825f2fd60806593fda0539091bf49e6", // omnivoice-2026-06-18 (portable AVX2 baseline, GGML_NATIVE=OFF; fixes #11677 illegal-instruction crash)
                 "735d5672507b3796138cecabcde6512e6a1e60bc9e6e86efd0fa6ce13a361fa1", // omnivoice-2026-05-22
                 "79308e79bb47df9f2bd2d31c6a60fe5672b74f43c3caf9b0a09566408894789e", // omnivoice-2026-05-17
             },
             [OmniVoice.MacOs] = new[]
             {
-                "54888cc0ab4c30be4a0393406ce0d6642d8dae6d8f1eed13ad9cf849a615c26d", // omnivoice-2026-08-03 (current download URL — upstream sync + ggml bump)
+                "d398d77684277824d5ff83e252fc9b7c518563b930a1dd717afc540f71100c00", // omnivoice-2026-08-04 (current download URL — rebuild of the same sources as 2026-08-03)
+                "54888cc0ab4c30be4a0393406ce0d6642d8dae6d8f1eed13ad9cf849a615c26d", // omnivoice-2026-08-03 (upstream sync + ggml bump)
                 "1063bf7f481bf1ecd296ba480a5655c68d12f392794504916fa542a2792da903", // omnivoice-2026-06-18
                 "d5ce6807adc50e6e1f1f92235828bad7c139c50042090a5361d0506e069ad1ba", // omnivoice-2026-05-22 (RPATH fix)
                 "bbe354cdf8995641074c46d02d7f8b9353fa4803452cb45a762de10e899aca8e", // omnivoice-2026-05-17
             },
             [OmniVoice.LinuxX64] = new[]
             {
-                "1d4898fab4d4cd8fef2331d1cc70ff98f5abce13cd1062e11ddf45e05ab7ba82", // omnivoice-2026-08-03 (current download URL — upstream sync + ggml bump)
+                "cc063f669a742a443866611b3f752528693e1426cf4dec0c023c1ccda86e5966", // omnivoice-2026-08-04 (current download URL — rebuild of the same sources as 2026-08-03)
+                "1d4898fab4d4cd8fef2331d1cc70ff98f5abce13cd1062e11ddf45e05ab7ba82", // omnivoice-2026-08-03 (upstream sync + ggml bump)
                 "698156714d03fadc503e4ebe01e47295b47c64df6d6496df48ed6c4128147214", // omnivoice-2026-06-18 (portable AVX2 baseline, GGML_NATIVE=OFF)
                 "c8eec5e66b362ddd3504658021a890a8acd4d2c092ba51a847fce1e80f4807e9", // omnivoice-2026-05-22 (RPATH fix)
                 "198046721ebcbe49ded959fd832ec4a091d899be49e2a26b549723e32b82daba", // omnivoice-2026-05-17
             },
             [OmniVoice.LinuxArm64] = new[]
             {
-                "95ea0aafb123ba6210ba29e6942eaa28c57924af9d63a3f218d65a7d3f4a28c4", // omnivoice-2026-08-03 (current download URL — upstream sync + ggml bump)
+                "ca193e791973bb0016703e3b1798d1dea049cafcdb2ad8abd05ee99c14285b02", // omnivoice-2026-08-04 (current download URL — rebuild of the same sources as 2026-08-03)
+                "95ea0aafb123ba6210ba29e6942eaa28c57924af9d63a3f218d65a7d3f4a28c4", // omnivoice-2026-08-03 (upstream sync + ggml bump)
                 "7ad6a7ca9484b14b4b1ec25fdec4e67b2750d7a27b86d5937676f143aa95eaeb", // omnivoice-2026-06-18
                 "a46029c360398fc8775d6a4d703df158fa6f3ee6576e6efd3be0b7be424e5276", // omnivoice-2026-05-22 (RPATH fix)
                 "3802d4136a6ffdc37cce72b286ab7c17422d55964fec13d4e3eb36f26e6ae1fe", // omnivoice-2026-05-17
             },
             [OmniVoice.Voices] = new[]
             {
-                "5d252eb78e8f4891279a36fa5127ea5ab80be35057eeaa5fadb49baeacd0c773", // omnivoice-2026-08-03 (current download URL — byte-identical since 2026-06-18; support-files/omnivoice-26-06 copy)
+                "5d252eb78e8f4891279a36fa5127ea5ab80be35057eeaa5fadb49baeacd0c773", // omnivoice-2026-08-04 (current download URL — byte-identical since 2026-06-18; support-files/omnivoice-26-06 copy)
             },
 
             // Qwen3 TTS — https://github.com/niksedk/qwen3-tts.cpp/releases

--- a/src/ui/Logic/Download/OmniVoiceDownloadService.cs
+++ b/src/ui/Logic/Download/OmniVoiceDownloadService.cs
@@ -33,7 +33,7 @@ public class OmniVoiceDownloadService : IOmniVoiceDownloadService
 
     // omnivoice.cpp release pin. Bump in lockstep with the hashes in DownloadHashManager.OmniVoice
     // (each new release: prepend the new SHA-256 at index 0, keep the previous one for "update available").
-    public const string ReleaseTag = "omnivoice-2026-08-03";
+    public const string ReleaseTag = "omnivoice-2026-08-04";
     private const string ReleaseUrlBase = "https://github.com/niksedk/omnivoice.cpp/releases/download/" + ReleaseTag + "/";
 
     private const string WindowsCpuUrl = ReleaseUrlBase + "omnivoice-win64-cpu.zip";


### PR DESCRIPTION
Closes #13196.

The Windows CUDA zip has never shipped the CUDA redistributables that `ggml-cuda.dll` imports, so `omnivoice-tts.exe` died inside the Windows loader with `STATUS_DLL_NOT_FOUND` on every machine without a CUDA toolkit installed — reported as `OmniVoice TTS failed (exit code -1073741515)`. Fixed in the engine's packaging (niksedk/omnivoice.cpp#3) and released as [`omnivoice-2026-08-04`](https://github.com/niksedk/omnivoice.cpp/releases/tag/omnivoice-2026-08-04).

Bumps `ReleaseTag` and prepends the six new archive SHA-256s at index 0 in `DownloadHashManager.OmniVoice`.

## Verification

Checked the published archive rather than trusting the green CI run — the bug being fixed was a packaging step that succeeded while producing an incomplete zip:

```
   102,518,272  cublas64_12.dll      <- new
   668,669,952  cublasLt64_12.dll    <- new
       583,680  cudart64_12.dll      <- new
       648,704  ggml-base.dll
       803,840  ggml-cpu.dll
   145,993,728  ggml-cuda.dll
        67,072  ggml.dll
       435,200  omnivoice-tts.exe
       182,784  omnivoice-codec.exe
        22,528  quantize.exe
```

`omnivoice-win64-cpu.zip` is unchanged in content (the copy step is gated on the CUDA matrix entry), and I confirmed GitHub's reported asset digest matches a locally computed SHA-256 before trusting the other five.

## The size, which is worth a conscious decision

The CUDA download goes **133 MB → 680 MB**, almost entirely `cublasLt64_12.dll`. That is simply what carrying cuBLAS costs, and it is in line with everything comparable: `qwen3-tts.cpp`'s CUDA zip is 754 MB, and llama.cpp's `cudart-llama-bin-win-cuda-12.4-x64.zip` — which Subtitle Edit already downloads for the llama.cpp CUDA backend — is 391 MB on its own.

Still, if 680 MB is too much for a TTS engine, the alternatives are worth weighing separately: `nvprune` the redistributables down to the architectures actually built, or ship them as a shared sidecar so a user with both llama.cpp CUDA and OmniVoice CUDA does not download cuBLAS twice. Neither belongs in this PR — the current state is a working engine, where before it was a broken one.

## Related

- niksedk/omnivoice.cpp#3 — the packaging fix (merged, released)
- #13199 — makes this class of failure explain itself instead of printing a bare exit code

## Testing

Full UI suite: 1277 passed, 0 failed. The engine itself cannot be exercised from macOS; the CUDA path needs a Windows/NVIDIA machine, ideally the reporter's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)