### PR TITLE
Only show video controls when the mouse is over the video window

### DIFF
--- a/src/ui/Features/Shared/FullScreenVideoPlayer.cs
+++ b/src/ui/Features/Shared/FullScreenVideoPlayer.cs
@@ -103,7 +103,14 @@ public class FullScreenVideoWindow : Window
                         Math.Abs(cursorPos.Value.Y - _lastCursorPosition.Y) > mouseMovementMinPixels)
                     {
                         _lastCursorPosition = cursorPos.Value;
-                        videoPlayer.NotifyUserActivity();
+
+                        // Only movement over this window counts - the poll is desktop-wide,
+                        // so mouse movement in another app or on another monitor must not
+                        // bring the controls back up (issue #13207).
+                        if (CursorPositionHelper.IsCursorOverWindow(this, cursorPos.Value))
+                        {
+                            videoPlayer.NotifyUserActivity();
+                        }
                     }
                 }
             }

--- a/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
+++ b/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
@@ -219,7 +219,14 @@ public partial class VideoPlayerUndockedViewModel : ObservableObject
                         Math.Abs(cursorPos.Value.Y - _lastCursorPosition.Y) > mouseMovementMinPixels)
                     {
                         _lastCursorPosition = cursorPos.Value;
-                        VideoPlayerControl.NotifyUserActivity();
+
+                        // Only movement over this window counts - the poll is desktop-wide,
+                        // so mouse movement in another app or on another monitor must not
+                        // bring the controls back up (issue #13207).
+                        if (CursorPositionHelper.IsCursorOverWindow(Window, cursorPos.Value))
+                        {
+                            VideoPlayerControl.NotifyUserActivity();
+                        }
                     }
                 }
             }

--- a/src/ui/Logic/CursorPositionHelper.cs
+++ b/src/ui/Logic/CursorPositionHelper.cs
@@ -1,4 +1,6 @@
-﻿using Nikse.SubtitleEdit.Logic.Config;
+﻿using Avalonia;
+using Avalonia.Controls;
+using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Runtime.InteropServices;
 
@@ -101,5 +103,34 @@ public static  class CursorPositionHelper
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// True when a desktop cursor position from <see cref="GetCursorPosition"/> is inside the
+    /// client area of <paramref name="window"/>.
+    /// The video windows poll the cursor because the mpv "wid" player renders into a native child
+    /// window that swallows Avalonia pointer events - but that poll sees the whole desktop, so
+    /// without this test any mouse movement in any app on any monitor counted as user activity
+    /// and popped the video controls back up (issue #13207).
+    /// </summary>
+    public static bool IsCursorOverWindow(Window? window, (int X, int Y) cursorPosition)
+    {
+        if (window == null || !window.IsVisible || window.WindowState == WindowState.Minimized)
+        {
+            return false;
+        }
+
+        try
+        {
+            var point = window.PointToClient(new PixelPoint(cursorPosition.X, cursorPosition.Y));
+            var size = window.ClientSize;
+            return point.X >= 0 && point.Y >= 0 && point.X < size.Width && point.Y < size.Height;
+        }
+        catch
+        {
+            // Window not (yet) attached to a platform implementation - no logging, this runs
+            // on a 100 ms timer and would spam the log.
+            return false;
+        }
     }
 }

--- a/tests/UI/Logic/CursorPositionOverWindowTests.cs
+++ b/tests/UI/Logic/CursorPositionOverWindowTests.cs
@@ -1,0 +1,65 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// The video windows poll the desktop cursor position (the mpv native child window swallows
+/// Avalonia pointer events), so activity must be hit-tested against the window - otherwise
+/// mouse movement in any other app or on another monitor shows the video controls (issue #13207).
+/// </summary>
+public class CursorPositionOverWindowTests
+{
+    private static Window ShowWindow()
+    {
+        var window = new Window { Width = 400, Height = 300 };
+        window.Show();
+        return window;
+    }
+
+    [AvaloniaFact]
+    public void CursorInsideWindowCounts()
+    {
+        var window = ShowWindow();
+
+        var inside = window.PointToScreen(new Point(window.ClientSize.Width / 2, window.ClientSize.Height / 2));
+
+        Assert.True(CursorPositionHelper.IsCursorOverWindow(window, (inside.X, inside.Y)));
+    }
+
+    [AvaloniaTheory]
+    [InlineData(-50, 0.5)] // left of the window
+    [InlineData(0.5, -50)] // above the window
+    [InlineData(50, 0.5)] // right of the window
+    [InlineData(0.5, 50)] // below the window
+    public void CursorOutsideWindowDoesNotCount(double x, double y)
+    {
+        var window = ShowWindow();
+
+        // Fractions are a point inside that axis, whole numbers an offset outside the client area.
+        var clientX = x < 1 && x > 0 ? window.ClientSize.Width * x : x < 0 ? x : window.ClientSize.Width + x;
+        var clientY = y < 1 && y > 0 ? window.ClientSize.Height * y : y < 0 ? y : window.ClientSize.Height + y;
+        var outside = window.PointToScreen(new Point(clientX, clientY));
+
+        Assert.False(CursorPositionHelper.IsCursorOverWindow(window, (outside.X, outside.Y)));
+    }
+
+    [AvaloniaFact]
+    public void MinimizedWindowNeverCounts()
+    {
+        var window = ShowWindow();
+        var inside = window.PointToScreen(new Point(window.ClientSize.Width / 2, window.ClientSize.Height / 2));
+
+        window.WindowState = WindowState.Minimized;
+
+        Assert.False(CursorPositionHelper.IsCursorOverWindow(window, (inside.X, inside.Y)));
+    }
+
+    [AvaloniaFact]
+    public void NoWindowNeverCounts()
+    {
+        Assert.False(CursorPositionHelper.IsCursorOverWindow(null, (0, 0)));
+    }
+}


### PR DESCRIPTION
Fixes #13207.

The undocked video player window and the fullscreen video window poll the desktop cursor position on a 100 ms timer — the mpv "wid" player renders into a native child window that swallows Avalonia pointer events, so `PointerMoved` alone can't drive the auto-hide.

That poll sees the whole desktop, and any movement over the 20 px threshold counted as user activity. So the auto-hidden controls popped back up whenever the mouse moved in *any* app on *any* monitor, with Subtitle Edit not even in the foreground.

## Changes

- New `CursorPositionHelper.IsCursorOverWindow(window, cursorPosition)`: converts the polled desktop position with `PointToClient` (Avalonia handles per-monitor DPI) and checks it against `ClientSize`; false for a null, hidden, or minimized window.
- Both pollers gate on it before calling `NotifyUserActivity()` — `VideoPlayerUndockedViewModel` (the case in the issue) and `FullScreenVideoWindow`, which had the same copy-pasted block.

`_lastCursorPosition` is still updated on every move, so moving the mouse in from another monitor registers as activity the moment it crosses into the window — no click or focus needed, which is what the issue asks for.

## Tests

7 new headless tests in `tests/UI/Logic/CursorPositionOverWindowTests.cs` (inside, off each of the four edges, minimized, null). Full UI suite green: 1318 passed.

## Notes

- The coordinate spaces of `GetCursorPos` / CoreGraphics / `XQueryPointer` and Avalonia's `PixelPoint` line up by platform convention; Windows (the reported case) is the straightforward one, but a quick check on a Retina Mac and on X11 is worthwhile.
- This is pure geometry — if another window sits on top of the player, movement over that window still counts. Fixing that needs per-platform "window under cursor" calls; left out for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)