### PR TITLE
Update CrispEmbed to v0.17.0 and add PP-OCRv6 OCR backend

### DIFF
--- a/src/ui/Features/Ocr/Download/DownloadCrispEmbedViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadCrispEmbedViewModel.cs
@@ -46,6 +46,8 @@ public partial class DownloadCrispEmbedViewModel : ObservableObject, IClosingCle
     private CrispEmbedModel? _model;
     private string _modelTempFileName = string.Empty;
     private string _modelFileName = string.Empty;
+    private string _detectorTempFileName = string.Empty;
+    private string _detectorFileName = string.Empty;
 
     public DownloadCrispEmbedViewModel(ICrispEmbedDownloadService downloadService, IZipUnpacker zipUnpacker)
     {
@@ -87,6 +89,14 @@ public partial class DownloadCrispEmbedViewModel : ObservableObject, IClosingCle
         _model = model;
         _modelFileName = backend.GetModelPath(model);
         _modelTempFileName = _modelFileName + ".$tmp$";
+
+        // PP-OCRv6 needs its text detector as well - one dialog, two files.
+        if (model.HasDetector)
+        {
+            _detectorFileName = backend.GetDetectorPath(model);
+            _detectorTempFileName = _detectorFileName + ".$tmp$";
+        }
+
         TitleText = string.Format(Se.Language.General.DownloadingX, model.Name);
         StartDownload();
     }
@@ -193,21 +203,38 @@ public partial class DownloadCrispEmbedViewModel : ObservableObject, IClosingCle
 
     private void FinishModelDownload()
     {
-        if (!File.Exists(_modelTempFileName) || new FileInfo(_modelTempFileName).Length == 0)
+        if (!IsDownloaded(_modelTempFileName) ||
+            (_model is { HasDetector: true } && !IsDownloaded(_detectorTempFileName)))
         {
             ProgressText = Se.Language.General.DownloadFailed;
             Error = Se.Language.General.NoDataReceived;
+            DeleteTempModelFile();
             return;
         }
 
-        if (File.Exists(_modelFileName))
+        if (_model is { HasDetector: true })
         {
-            File.Delete(_modelFileName);
+            MoveIntoPlace(_detectorTempFileName, _detectorFileName);
         }
 
-        File.Move(_modelTempFileName, _modelFileName);
+        MoveIntoPlace(_modelTempFileName, _modelFileName);
         OkPressed = true;
         Close();
+    }
+
+    private static bool IsDownloaded(string fileName)
+    {
+        return File.Exists(fileName) && new FileInfo(fileName).Length > 0;
+    }
+
+    private static void MoveIntoPlace(string tempFileName, string fileName)
+    {
+        if (File.Exists(fileName))
+        {
+            File.Delete(fileName);
+        }
+
+        File.Move(tempFileName, fileName);
     }
 
     /// <summary>
@@ -265,7 +292,9 @@ public partial class DownloadCrispEmbedViewModel : ObservableObject, IClosingCle
 
         if (_isModelDownload && _model != null)
         {
-            _downloadTask = _downloadService.DownloadModel(_model.Url, _modelTempFileName, downloadProgress, _cancellationTokenSource.Token);
+            _downloadTask = _model.HasDetector
+                ? DownloadModelWithDetector(_model, downloadProgress)
+                : _downloadService.DownloadModel(_model.Url, _modelTempFileName, downloadProgress, _cancellationTokenSource.Token);
         }
         else if (OperatingSystem.IsWindows())
         {
@@ -288,6 +317,20 @@ public partial class DownloadCrispEmbedViewModel : ObservableObject, IClosingCle
         }
 
         _timer.Start();
+    }
+
+    /// <summary>
+    /// Downloads the detector and then the recognizer as one logical task, mapping each file onto
+    /// half of the progress bar. The detector is fetched first so a cancel mid-way never leaves a
+    /// complete recognizer next to a missing detector.
+    /// </summary>
+    private async System.Threading.Tasks.Task DownloadModelWithDetector(CrispEmbedModel model, IProgress<float> progress)
+    {
+        var detectorProgress = new Progress<float>(number => progress.Report(number * 0.5f));
+        await _downloadService.DownloadModel(model.DetectorUrl, _detectorTempFileName, detectorProgress, _cancellationTokenSource.Token);
+
+        var modelProgress = new Progress<float>(number => progress.Report(0.5f + number * 0.5f));
+        await _downloadService.DownloadModel(model.Url, _modelTempFileName, modelProgress, _cancellationTokenSource.Token);
     }
 
     private void Close()
@@ -314,11 +357,17 @@ public partial class DownloadCrispEmbedViewModel : ObservableObject, IClosingCle
 
     private void DeleteTempModelFile()
     {
+        DeleteQuietly(_modelTempFileName);
+        DeleteQuietly(_detectorTempFileName);
+    }
+
+    private static void DeleteQuietly(string fileName)
+    {
         try
         {
-            if (!string.IsNullOrEmpty(_modelTempFileName) && File.Exists(_modelTempFileName))
+            if (!string.IsNullOrEmpty(fileName) && File.Exists(fileName))
             {
-                File.Delete(_modelTempFileName);
+                File.Delete(fileName);
             }
         }
         catch

--- a/src/ui/Features/Ocr/Engines/CrispEmbedBackend.cs
+++ b/src/ui/Features/Ocr/Engines/CrispEmbedBackend.cs
@@ -4,28 +4,46 @@ using System.IO;
 namespace Nikse.SubtitleEdit.Features.Ocr.Engines;
 
 /// <summary>
-/// One OCR backend (model family) for the CrispEmbed engine, e.g. GLM-OCR. All backends run
-/// through the same crispembed-server executable; only the GGUF model differs.
+/// One OCR backend (model family) for the CrispEmbed engine, e.g. GLM-OCR. The VLM backends run
+/// through crispembed-server (model loaded once per OCR session); PP-OCRv6 is a detector plus
+/// recognizer pair and runs through the crispembed CLI instead - see <see cref="CrispEmbedOcr"/>.
 /// </summary>
 public class CrispEmbedBackend
 {
     public string Name { get; set; } = string.Empty;
     public List<CrispEmbedModel> Models { get; set; } = new();
 
+    /// <summary>
+    /// True when this backend's models need a companion text detector, which also selects the
+    /// CLI pipeline execution path instead of the crispembed-server one.
+    /// </summary>
+    public bool UsesTextDetector => Models.Count > 0 && Models[0].HasDetector;
+
     public string GetModelPath(CrispEmbedModel model)
     {
         return Path.Combine(CrispEmbedEngine.GetAndCreateModelFolder(), model.Name);
     }
 
+    public string GetDetectorPath(CrispEmbedModel model)
+    {
+        return model.HasDetector
+            ? Path.Combine(CrispEmbedEngine.GetAndCreateModelFolder(), model.DetectorName)
+            : string.Empty;
+    }
+
     public bool IsModelInstalled(CrispEmbedModel model)
     {
-        var modelFile = GetModelPath(model);
-        if (!File.Exists(modelFile))
+        if (!IsFilePresent(GetModelPath(model), model.MinimumSizeBytes))
         {
             return false;
         }
 
-        return new FileInfo(modelFile).Length > 10_000_000;
+        return !model.HasDetector || IsFilePresent(GetDetectorPath(model), model.MinimumDetectorSizeBytes);
+    }
+
+    private static bool IsFilePresent(string fileName, long minimumSizeBytes)
+    {
+        return File.Exists(fileName) && new FileInfo(fileName).Length >= minimumSizeBytes;
     }
 
     public override string ToString()

--- a/src/ui/Features/Ocr/Engines/CrispEmbedEngine.cs
+++ b/src/ui/Features/Ocr/Engines/CrispEmbedEngine.cs
@@ -30,8 +30,8 @@ public static class CrispEmbedEngine
     }
 
     /// <summary>
-    /// Like CrispASR, the Windows variants differ wildly in size (CPU ~5 MB, Vulkan ~24 MB,
-    /// CUDA ~691 MB) and the variant is picked at download time, so show a range.
+    /// Like CrispASR, the Windows variants differ wildly in size (CPU ~6 MB, Vulkan ~25 MB,
+    /// CUDA ~684 MB) and the variant is picked at download time, so show a range.
     /// </summary>
     public static string DownloadSizeText
     {
@@ -39,17 +39,17 @@ public static class CrispEmbedEngine
         {
             if (OperatingSystem.IsWindows())
             {
-                return "~5 MB – 691 MB";
+                return "~6 MB – 684 MB";
             }
 
             if (OperatingSystem.IsLinux())
             {
-                return "~8 MB";
+                return "~10 MB";
             }
 
             if (OperatingSystem.IsMacOS())
             {
-                return "~6 MB";
+                return "~8 MB";
             }
 
             return string.Empty;
@@ -95,6 +95,22 @@ public static class CrispEmbedEngine
         return Path.Combine(GetAndCreateFolder(), GetServerExecutableFileName());
     }
 
+    public static string GetCliExecutableFileName()
+    {
+        return OperatingSystem.IsWindows() ? "crispembed.exe" : "crispembed";
+    }
+
+    /// <summary>
+    /// The single-shot CLI from the same archive. PP-OCRv6 runs through it because
+    /// crispembed-server only exposes the detector+recognizer orchestrator when it is also given
+    /// a primary embedding model (-m), which Subtitle Edit has no use for - see
+    /// <see cref="CrispEmbedOcr"/>.
+    /// </summary>
+    public static string GetCliExecutable()
+    {
+        return Path.Combine(GetAndCreateFolder(), GetCliExecutableFileName());
+    }
+
     public static bool IsEngineInstalled()
     {
         return File.Exists(GetServerExecutable());
@@ -109,6 +125,28 @@ public static class CrispEmbedEngine
     {
         return new List<CrispEmbedBackend>
         {
+            // PP-OCRv6 (CrispEmbed v0.17.0) is a detector + recognizer pair rather than a VLM:
+            // two small GGUFs instead of one ~1 GB model, and it keeps punctuation and per-line
+            // breaks on subtitle bitmaps. Only the "medium" tier is offered - "tiny" returns
+            // garbage on subtitle-sized text and "small", while as accurate here, saves too
+            // little to be worth a second entry (verified 2026-08-04).
+            new()
+            {
+                Name = "PP-OCRv6",
+                Models = new List<CrispEmbedModel>
+                {
+                    new()
+                    {
+                        Name = "PP-OCRv6_medium_rec-f16.gguf",
+                        Size = "79 MB",
+                        Url = "https://huggingface.co/cstr/PP-OCRv6-medium-rec-GGUF/resolve/main/PP-OCRv6_medium_rec-f16.gguf",
+                        DetectorName = "PP-OCRv6_medium_det-f16.gguf",
+                        DetectorUrl = "https://huggingface.co/cstr/PP-OCRv6-medium-det-GGUF/resolve/main/PP-OCRv6_medium_det-f16.gguf",
+                        MinimumSizeBytes = 30_000_000,
+                        MinimumDetectorSizeBytes = 30_000_000,
+                    },
+                },
+            },
             new()
             {
                 Name = "GLM-OCR",

--- a/src/ui/Features/Ocr/Engines/CrispEmbedModel.cs
+++ b/src/ui/Features/Ocr/Engines/CrispEmbedModel.cs
@@ -2,12 +2,32 @@ namespace Nikse.SubtitleEdit.Features.Ocr.Engines;
 
 /// <summary>
 /// A downloadable GGUF model (one quantization) for a CrispEmbed OCR backend.
+/// Detector-based backends (PP-OCRv6) need a second GGUF - the text detector - which is
+/// downloaded alongside the recognizer and passed to the CLI as --ocr-det.
 /// </summary>
 public class CrispEmbedModel
 {
     public string Name { get; set; } = string.Empty;
     public string Size { get; set; } = string.Empty;
     public string Url { get; set; } = string.Empty;
+
+    /// <summary>File name of the companion text-detection GGUF, or empty for single-model backends.</summary>
+    public string DetectorName { get; set; } = string.Empty;
+
+    /// <summary>Download URL of the companion text-detection GGUF, or empty for single-model backends.</summary>
+    public string DetectorUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Smallest plausible size of the downloaded recognizer, used to spot a truncated download.
+    /// The VLM backends are hundreds of MB; the PP-OCRv6 pair is only a few MB, so the floor
+    /// cannot be a single constant.
+    /// </summary>
+    public long MinimumSizeBytes { get; set; } = 10_000_000;
+
+    /// <summary>Same truncation floor as <see cref="MinimumSizeBytes"/>, for the detector GGUF.</summary>
+    public long MinimumDetectorSizeBytes { get; set; } = 10_000_000;
+
+    public bool HasDetector => !string.IsNullOrEmpty(DetectorName);
 
     public override string ToString()
     {

--- a/src/ui/Features/Ocr/Engines/CrispEmbedOcr.cs
+++ b/src/ui/Features/Ocr/Engines/CrispEmbedOcr.cs
@@ -24,16 +24,59 @@ namespace Nikse.SubtitleEdit.Features.Ocr.Engines;
 public class CrispEmbedOcr : IDisposable
 {
     private readonly HttpClient _httpClient;
+    private readonly int _timeoutMinutes;
     private Process? _serverProcess;
     private int _port;
+
+    private string _cliExecutable = string.Empty;
+    private string _cliRecognizerModel = string.Empty;
+    private string _cliDetectorModel = string.Empty;
+    private bool _isCliPipeline;
 
     public string Error { get; set; }
 
     public CrispEmbedOcr(int timeoutMinutes = 5)
     {
         Error = string.Empty;
+        _timeoutMinutes = Math.Max(1, timeoutMinutes);
         _httpClient = new HttpClient();
-        _httpClient.Timeout = TimeSpan.FromMinutes(Math.Max(1, timeoutMinutes));
+        _httpClient.Timeout = TimeSpan.FromMinutes(_timeoutMinutes);
+    }
+
+    /// <summary>
+    /// Prepares the PP-OCRv6 detector+recognizer pipeline, which runs as one crispembed CLI
+    /// invocation per image instead of through crispembed-server. The server only enables its
+    /// OCR orchestrator when it is also given a primary embedding model via -m, and dies on
+    /// startup if that model is not a real embedding GGUF - so there is no server-side route to
+    /// the pipeline without downloading an unrelated model. The CLI reloads the pair per image,
+    /// which costs little: the two GGUFs are a few MB and a full invocation is well under a
+    /// second, i.e. no slower than one already-loaded VLM request.
+    /// </summary>
+    public bool StartCliPipeline(string cliExecutable, string recognizerFileName, string detectorFileName)
+    {
+        if (!File.Exists(cliExecutable))
+        {
+            Error = $"CrispEmbed CLI not found: {cliExecutable}";
+            return false;
+        }
+
+        if (!File.Exists(recognizerFileName))
+        {
+            Error = $"CrispEmbed model not found: {recognizerFileName}";
+            return false;
+        }
+
+        if (!File.Exists(detectorFileName))
+        {
+            Error = $"CrispEmbed text detector not found: {detectorFileName}";
+            return false;
+        }
+
+        _cliExecutable = cliExecutable;
+        _cliRecognizerModel = recognizerFileName;
+        _cliDetectorModel = detectorFileName;
+        _isCliPipeline = true;
+        return true;
     }
 
     public async Task<bool> StartServerAsync(string serverExecutable, string modelFileName, CancellationToken cancellationToken)
@@ -133,6 +176,11 @@ public class CrispEmbedOcr : IDisposable
                 await File.WriteAllBytesAsync(tempFileName, flattened.ToPngArray(), cancellationToken);
             }
 
+            if (_isCliPipeline)
+            {
+                return await OcrViaCliPipeline(tempFileName, cancellationToken);
+            }
+
             // The server reads the image from disk, so only the path goes over the wire. The
             // server's request parser does not un-escape JSON strings, so send forward slashes
             // (fine with Windows file APIs) to keep the serialized path escape-free.
@@ -185,6 +233,128 @@ public class CrispEmbedOcr : IDisposable
             {
                 // ignore
             }
+        }
+    }
+
+    /// <summary>
+    /// Runs one crispembed CLI invocation for the PP-OCRv6 pipeline and returns the recognized
+    /// text. --json keeps the result on a single line ("full_text" with "\n" between detected
+    /// regions), which is unambiguous next to the progress lines the CLI writes to stdout.
+    /// </summary>
+    private async Task<string> OcrViaCliPipeline(string imageFileName, CancellationToken cancellationToken)
+    {
+        var arguments = $"--ocr-pipeline \"{imageFileName}\" --ocr-engine ppocrv6 " +
+                        $"--ocr-det \"{_cliDetectorModel}\" --ocr-rec \"{_cliRecognizerModel}\" --json";
+
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo(_cliExecutable, arguments)
+            {
+                WindowStyle = ProcessWindowStyle.Hidden,
+                CreateNoWindow = true,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                WorkingDirectory = Path.GetDirectoryName(_cliExecutable),
+            },
+        };
+
+        process.Start();
+
+        var stdOutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stdErrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(TimeSpan.FromMinutes(_timeoutMinutes));
+
+        try
+        {
+            await process.WaitForExitAsync(timeout.Token);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            KillQuietly(process);
+            Error = "CrispEmbed OCR timed out";
+            SeLogger.Error("CrispEmbed CLI pipeline timed out: " + arguments);
+            return string.Empty;
+        }
+        catch (OperationCanceledException)
+        {
+            KillQuietly(process);
+            throw;
+        }
+
+        var output = await stdOutTask;
+        var errorOutput = await stdErrTask;
+        if (!string.IsNullOrWhiteSpace(errorOutput))
+        {
+            LogServerOutput("crispembed: " + errorOutput.Trim());
+        }
+
+        if (process.ExitCode != 0)
+        {
+            Error = string.IsNullOrWhiteSpace(errorOutput)
+                ? $"CrispEmbed exited with code {process.ExitCode}"
+                : errorOutput.Trim();
+            SeLogger.Error("CrispEmbed CLI pipeline failed: " + Error);
+            return string.Empty;
+        }
+
+        return ParseCliPipelineOutput(output);
+    }
+
+    /// <summary>
+    /// Picks the JSON object out of the CLI's stdout - the detector prints progress lines such as
+    /// "ppocrv6-det: persistent GGML detector graph ready" before it - and returns "full_text"
+    /// with the platform's newlines.
+    /// </summary>
+    internal static string ParseCliPipelineOutput(string? output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+        {
+            return string.Empty;
+        }
+
+        foreach (var line in output.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (!trimmed.StartsWith('{'))
+            {
+                continue;
+            }
+
+            try
+            {
+                using var document = JsonDocument.Parse(trimmed);
+                if (document.RootElement.TryGetProperty("full_text", out var fullText))
+                {
+                    return (fullText.GetString() ?? string.Empty)
+                        .Replace("\r\n", "\n")
+                        .Replace("\n", Environment.NewLine)
+                        .Trim();
+                }
+            }
+            catch (JsonException)
+            {
+                // not the result object - keep looking
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private static void KillQuietly(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch
+        {
+            // ignore
         }
     }
 

--- a/src/ui/Features/Ocr/Engines/CrispEmbedOcr.cs
+++ b/src/ui/Features/Ocr/Engines/CrispEmbedOcr.cs
@@ -3,6 +3,7 @@ using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using SkiaSharp;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
@@ -32,6 +33,10 @@ public class CrispEmbedOcr : IDisposable
     private string _cliRecognizerModel = string.Empty;
     private string _cliDetectorModel = string.Empty;
     private bool _isCliPipeline;
+
+    private const int MaxCapturedOutputLines = 12;
+    private readonly Queue<string> _lastOutputLines = new();
+    private readonly Lock _outputLock = new();
 
     public string Error { get; set; }
 
@@ -112,8 +117,8 @@ public class CrispEmbedOcr : IDisposable
                 },
             };
 
-            _serverProcess.OutputDataReceived += (_, e) => LogServerOutput(e.Data);
-            _serverProcess.ErrorDataReceived += (_, e) => LogServerOutput(e.Data);
+            _serverProcess.OutputDataReceived += (_, e) => CaptureServerOutput(e.Data);
+            _serverProcess.ErrorDataReceived += (_, e) => CaptureServerOutput(e.Data);
             _serverProcess.Start();
             _serverProcess.BeginOutputReadLine();
             _serverProcess.BeginErrorReadLine();
@@ -137,7 +142,7 @@ public class CrispEmbedOcr : IDisposable
 
             if (_serverProcess.HasExited)
             {
-                Error = $"CrispEmbed server exited with code {_serverProcess.ExitCode}";
+                Error = await BuildStartupFailureMessage(_serverProcess);
                 SeLogger.Error("CrispEmbed server exited during startup: " + Error);
                 return false;
             }
@@ -387,6 +392,100 @@ public class CrispEmbedOcr : IDisposable
         {
             Se.WriteToolsLog("crispembed-server: " + line);
         }
+    }
+
+    /// <summary>
+    /// Mirrors the server's output to the tools log and keeps the last few lines in memory, so a
+    /// process that dies during startup can report what it actually said instead of only an exit
+    /// code. Raised on threadpool threads by the async readers, hence the lock.
+    /// </summary>
+    private void CaptureServerOutput(string? line)
+    {
+        LogServerOutput(line);
+
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return;
+        }
+
+        lock (_outputLock)
+        {
+            _lastOutputLines.Enqueue(line.Trim());
+            while (_lastOutputLines.Count > MaxCapturedOutputLines)
+            {
+                _lastOutputLines.Dequeue();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds the message shown when the server exits before it starts listening. The useful part
+    /// is almost always on the process's own stderr - a missing shared library, an unreadable
+    /// model - so wait for the async readers to drain and append what they saw. Without this the
+    /// user only ever sees "exited with code N" while the real cause sits in the tools log.
+    /// </summary>
+    private async Task<string> BuildStartupFailureMessage(Process process)
+    {
+        var exitCode = process.ExitCode;
+
+        // The process has already exited; this only lets the redirected streams finish. It is
+        // capped because a surviving grandchild can hold the pipe open indefinitely.
+        try
+        {
+            using var drain = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            await process.WaitForExitAsync(drain.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            // report whatever was captured before the deadline
+        }
+
+        var message = $"CrispEmbed server exited with code {exitCode}";
+
+        var hint = GetExitCodeHint(exitCode);
+        if (!string.IsNullOrEmpty(hint))
+        {
+            message += Environment.NewLine + Environment.NewLine + hint;
+        }
+
+        string output;
+        lock (_outputLock)
+        {
+            output = string.Join(Environment.NewLine, _lastOutputLines);
+        }
+
+        if (!string.IsNullOrWhiteSpace(output))
+        {
+            message += Environment.NewLine + Environment.NewLine + output;
+        }
+
+        return message;
+    }
+
+    /// <summary>
+    /// Plain-language help for the exit codes the dynamic loader and the shell use on Unix, which
+    /// a user cannot be expected to decode. 127 is the common one: the CrispEmbed CPU builds for
+    /// Linux link against OpenBLAS but do not ship it (see SubtitleEdit issue #13205).
+    /// </summary>
+    internal static string GetExitCodeHint(int exitCode)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return string.Empty;
+        }
+
+        return exitCode switch
+        {
+            127 => "Exit code 127 means a shared library the CrispEmbed binaries depend on could not be loaded." +
+                   Environment.NewLine +
+                   "The Linux CrispEmbed builds need OpenBLAS, which they do not ship: try installing it" +
+                   Environment.NewLine +
+                   "(\"sudo apt install libopenblas0\", \"sudo pacman -S openblas\", or your distro's equivalent).",
+            126 => "Exit code 126 means the CrispEmbed binary could not be executed - it may be missing the" +
+                   Environment.NewLine +
+                   "executable permission, or be blocked by the system.",
+            _ => string.Empty,
+        };
     }
 
     private static int GetFreePort()

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -4173,21 +4173,29 @@ public partial class OcrViewModel : ObservableObject
             try
             {
                 ProgressText = "Loading CrispEmbed model...";
-                var started = await engine.StartServerAsync(
-                    CrispEmbedEngine.GetServerExecutable(),
-                    backend.GetModelPath(model.Model),
-                    cancellationToken);
+
+                // PP-OCRv6 is a detector+recognizer pair driven through the CLI; the VLM backends
+                // load once into crispembed-server.
+                var started = backend.UsesTextDetector
+                    ? engine.StartCliPipeline(
+                        CrispEmbedEngine.GetCliExecutable(),
+                        backend.GetModelPath(model.Model),
+                        backend.GetDetectorPath(model.Model))
+                    : await engine.StartServerAsync(
+                        CrispEmbedEngine.GetServerExecutable(),
+                        backend.GetModelPath(model.Model),
+                        cancellationToken);
 
                 if (!started)
                 {
                     var error = engine.Error;
-                    SeLogger.Error("CrispEmbed server failed to start: " + error);
+                    SeLogger.Error("CrispEmbed failed to start: " + error);
                     await Dispatcher.UIThread.InvokeAsync(async () =>
                     {
                         await MessageBox.Show(
                             Window!,
                             "CrispEmbed error",
-                            $"The CrispEmbed server could not be started:{Environment.NewLine}{Environment.NewLine}{error}",
+                            $"CrispEmbed could not be started:{Environment.NewLine}{Environment.NewLine}{error}",
                             MessageBoxButtons.OK,
                             MessageBoxIcon.Error);
                     });

--- a/src/ui/Logic/Download/CrispEmbedDownloadService.cs
+++ b/src/ui/Logic/Download/CrispEmbedDownloadService.cs
@@ -21,13 +21,13 @@ public class CrispEmbedDownloadService : ICrispEmbedDownloadService
 {
     private readonly HttpClient _httpClient;
 
-    private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.16.1/crispembed-windows-x86_64-cuda.zip";
-    private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.16.1/crispembed-windows-x86_64-vulkan.zip";
-    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.16.1/crispembed-windows-x86_64.zip";
-    private const string MacUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.16.1/crispembed-macos-arm64.tar.gz";
-    private const string LinuxUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.16.1/crispembed-linux-x86_64.tar.gz";
-    private const string LinuxCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.16.1/crispembed-linux-x86_64-cuda.tar.gz";
-    private const string LinuxArmUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.16.1/crispembed-linux-arm64.tar.gz";
+    private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.0/crispembed-windows-x86_64-cuda.zip";
+    private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.0/crispembed-windows-x86_64-vulkan.zip";
+    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.0/crispembed-windows-x86_64.zip";
+    private const string MacUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.0/crispembed-macos-arm64.tar.gz";
+    private const string LinuxUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.0/crispembed-linux-x86_64.tar.gz";
+    private const string LinuxCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.0/crispembed-linux-x86_64-cuda.tar.gz";
+    private const string LinuxArmUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.0/crispembed-linux-arm64.tar.gz";
 
     public CrispEmbedDownloadService(HttpClient httpClient)
     {

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -747,43 +747,50 @@ public static class DownloadHashManager
             // otherwise users will be prompted to "update" to the same version they just got.
             [CrispEmbed.WindowsCuda] = new[]
             {
-                "8c546e2f10dc70873f1ed904634f8642d4f76b36132aad8c70d96548e99e98a9", // v0.16.1 (current download URL)
+                "957cd0292caa2962927b78a64d897cf6a86404212e37e7907233f9c675a30ef1", // v0.17.0 (current download URL)
+                "8c546e2f10dc70873f1ed904634f8642d4f76b36132aad8c70d96548e99e98a9", // v0.16.1
                 "98423ef22da5b60420ca74f3b3ef41d152d1181659b06b6f873c369eea8dcdf7", // v0.15.0
                 "faf376578103b37d7b1d5a385072ff8c66f35cbb7f20a801a6ab0d4e85802cda", // v0.14.0
             },
             [CrispEmbed.WindowsVulkan] = new[]
             {
-                "91b6ea29a2f9ab9dae387dee90f2195c19d44bdb6baae35b008870abef80af94", // v0.16.1 (current download URL)
+                "4c25232b037291c8ff1ce6999de7cd669fe7a4d6ebed84735173dd458edb0250", // v0.17.0 (current download URL)
+                "91b6ea29a2f9ab9dae387dee90f2195c19d44bdb6baae35b008870abef80af94", // v0.16.1
                 "bae16ce2d475a48d9fb4573a5ed156b2c9ecff6c1565c509461ce5d70f11c6d9", // v0.15.0
                 "d1722ae897a0909de877e6d1defeb5cf56041ced923cb058770fc76f9dcc8a37", // v0.14.0
             },
             [CrispEmbed.WindowsCpu] = new[]
             {
-                "2337b553090d48dfdd24f11f23e126ed1cea521d77fa01800ca14b261b1834ad", // v0.16.1 (current download URL)
+                "601f722b8fd01896ea4943f87099b5bc1f32177c6163cabfbd327e5a9866c0a0", // v0.17.0 (current download URL)
+                "2337b553090d48dfdd24f11f23e126ed1cea521d77fa01800ca14b261b1834ad", // v0.16.1
                 "90cbe585e202d55c917ce4d14a5b92ca0db459f927ea396203822d94aa149e60", // v0.15.0
                 "49ba9a172f918c82648d69a4758841a45e29bb8e2700ffa64e4c94f325d0fec3", // v0.14.0
             },
             [CrispEmbed.MacOs] = new[]
             {
-                "22d41f046fda10b02b3908fac28d62247788f311d792b80c07f9b97aefc9d52d", // v0.16.1 (current download URL)
+                "4146cf85ab13bad1ebab0a9903022e8098dc5eafec4f844e2eeaa65a6ae069dc", // v0.17.0 (current download URL)
+                "22d41f046fda10b02b3908fac28d62247788f311d792b80c07f9b97aefc9d52d", // v0.16.1
                 "369605d468c0433eb3bd6c356d2220eaa49467f7a5970423e6373771cadece9c", // v0.15.0
                 "2a47142eea71f0120fbf86eda21a0d972618e01c2bf5d67e54204d8e5644411e", // v0.14.0
             },
             [CrispEmbed.Linux] = new[]
             {
-                "3fbe97c86444eaf3b164bdc69684a571a0a31497fa91ca5321bd33d961ecbdc2", // v0.16.1 (current download URL)
+                "61b4a47c471743665d6629e38babc3e7eb32ccffb79f35e99ce76da192c3d61e", // v0.17.0 (current download URL)
+                "3fbe97c86444eaf3b164bdc69684a571a0a31497fa91ca5321bd33d961ecbdc2", // v0.16.1
                 "8863cb689d892a7aaa7555306a019b99c863c3669571205db49032c4f8b34450", // v0.15.0
                 "e255a59c615fcdf869794c7fabc2f7a4da7babddce5a7ef4771e4fc4a51ff65c", // v0.14.0
             },
             [CrispEmbed.LinuxCuda] = new[]
             {
-                "1bd9e322617c5c63490d1054140e8109ff7b8b471a26381d5cea12bf7a8c6e62", // v0.16.1 (current download URL)
+                "2d8b9c242c3c50fd8092ccde954d8540feefbcfc800f763b8a4a227b226c59d7", // v0.17.0 (current download URL)
+                "1bd9e322617c5c63490d1054140e8109ff7b8b471a26381d5cea12bf7a8c6e62", // v0.16.1
                 "5ce79deb4845c2b04757ee398b5f7ac0ff65bd5435a70da1f18491f3ff8c7c30", // v0.15.0
                 "48e2c0e8536c7db717155adb418330e29bb5f7b1c8eda8686fe7513ae6ea58d9", // v0.14.0
             },
             [CrispEmbed.LinuxArm] = new[]
             {
-                "b89d26ee3e0b2091bbbdb1b6f337add44faae5b4914c0d54c4cb50a25bd2bcf6", // v0.16.1 (current download URL)
+                "77309c2ab93a01e255a806ba8d54be2854ee160b3e6bb0a85b11cd68e22093a9", // v0.17.0 (current download URL)
+                "b89d26ee3e0b2091bbbdb1b6f337add44faae5b4914c0d54c4cb50a25bd2bcf6", // v0.16.1
                 "3a5056e831ddd5af26cc9d623a2c2de7d51d2297bcac67045feb1dac117dece8", // v0.15.0
                 "3d08ea2cb15da4f1d71dfc3ae030f855d7a5d32a662952b6ea43ff17d3b37788", // v0.14.0
             },

--- a/tests/UI/Features/Ocr/Engines/CrispEmbedEngineTests.cs
+++ b/tests/UI/Features/Ocr/Engines/CrispEmbedEngineTests.cs
@@ -77,6 +77,31 @@ public class CrispEmbedEngineTests
     }
 
     [Fact]
+    public void GetExitCodeHint_ExplainsLoaderFailures()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            // 126/127 are Unix loader/shell conventions - no hint to give on Windows.
+            Assert.Equal(string.Empty, CrispEmbedOcr.GetExitCodeHint(127));
+            return;
+        }
+
+        // The cause of SubtitleEdit issue #13205: the Linux builds link against OpenBLAS but do
+        // not ship it, so the loader aborts before the server can say anything itself.
+        Assert.Contains("OpenBLAS", CrispEmbedOcr.GetExitCodeHint(127));
+        Assert.Contains("executed", CrispEmbedOcr.GetExitCodeHint(126));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(139)]
+    public void GetExitCodeHint_IsEmptyForCodesWithNothingToAdd(int exitCode)
+    {
+        Assert.Equal(string.Empty, CrispEmbedOcr.GetExitCodeHint(exitCode));
+    }
+
+    [Fact]
     public void ParseCliPipelineOutput_SkipsNonResultJson()
     {
         const string output = "{\"warning\":\"some other object\"}\n{\"full_text\":\"the real result\"}\n";

--- a/tests/UI/Features/Ocr/Engines/CrispEmbedEngineTests.cs
+++ b/tests/UI/Features/Ocr/Engines/CrispEmbedEngineTests.cs
@@ -10,7 +10,78 @@ public class CrispEmbedEngineTests
     {
         var backends = CrispEmbedEngine.GetBackends();
 
-        Assert.Equal(new[] { "GLM-OCR", "GOT-OCR2", "Qwen3-VL-2B" }, backends.Select(p => p.Name));
+        Assert.Equal(new[] { "PP-OCRv6", "GLM-OCR", "GOT-OCR2", "Qwen3-VL-2B" }, backends.Select(p => p.Name));
+    }
+
+    [Fact]
+    public void GetBackends_OnlyPpOcrV6UsesTextDetector()
+    {
+        foreach (var backend in CrispEmbedEngine.GetBackends())
+        {
+            Assert.Equal(backend.Name == "PP-OCRv6", backend.UsesTextDetector);
+
+            // A backend is all-or-nothing: the run path is picked from the backend, not per model.
+            Assert.All(backend.Models, model => Assert.Equal(backend.UsesTextDetector, model.HasDetector));
+        }
+    }
+
+    [Fact]
+    public void GetBackends_DetectorModelsAreWellFormed()
+    {
+        var models = CrispEmbedEngine.GetBackends()
+            .Where(p => p.UsesTextDetector)
+            .SelectMany(p => p.Models)
+            .ToList();
+
+        Assert.NotEmpty(models);
+
+        foreach (var model in models)
+        {
+            Assert.EndsWith(".gguf", model.DetectorName);
+            Assert.StartsWith("https://huggingface.co/", model.DetectorUrl);
+            Assert.EndsWith("/" + model.DetectorName, model.DetectorUrl);
+
+            // The detector lands in the same models folder as the recognizer.
+            Assert.NotEqual(model.Name, model.DetectorName);
+
+            // Truncation floors must stay below the real file sizes or a good download reads
+            // as "not installed" forever.
+            Assert.InRange(model.MinimumSizeBytes, 1, 40_000_000);
+            Assert.InRange(model.MinimumDetectorSizeBytes, 1, 40_000_000);
+        }
+    }
+
+    [Fact]
+    public void GetBackends_ModelFileNamesAreUniqueAcrossBackends()
+    {
+        var names = CrispEmbedEngine.GetBackends()
+            .SelectMany(p => p.Models)
+            .SelectMany(m => m.HasDetector ? new[] { m.Name, m.DetectorName } : new[] { m.Name })
+            .ToList();
+
+        Assert.Equal(names.Count, names.Distinct().Count());
+    }
+
+    [Theory]
+    [InlineData(
+        "ppocrv6-det: persistent GGML detector graph ready (CPU, 736x96)\n{\"n_regions\":2,\"mean_confidence\":0.92,\"full_text\":\"Line one\\nLine two\"}\n",
+        "Line one\nLine two")]
+    [InlineData("{\"n_regions\":0,\"mean_confidence\":0.0,\"full_text\":\"\"}", "")]
+    [InlineData("ppocrv6-det: nothing but progress noise\n", "")]
+    [InlineData("", "")]
+    public void ParseCliPipelineOutput_ReturnsFullText(string output, string expected)
+    {
+        var actual = CrispEmbedOcr.ParseCliPipelineOutput(output);
+
+        Assert.Equal(expected.Replace("\n", Environment.NewLine), actual);
+    }
+
+    [Fact]
+    public void ParseCliPipelineOutput_SkipsNonResultJson()
+    {
+        const string output = "{\"warning\":\"some other object\"}\n{\"full_text\":\"the real result\"}\n";
+
+        Assert.Equal("the real result", CrispEmbedOcr.ParseCliPipelineOutput(output));
     }
 
     [Fact]


### PR DESCRIPTION
Bumps the pinned CrispEmbed release to [v0.17.0](https://github.com/CrispStrobe/CrispEmbed/releases/tag/v0.17.0) and adds **PP-OCRv6** as a CrispEmbed OCR backend.

## CrispEmbed v0.17.0

All seven variant URLs bumped, with SHA-256s computed from the published archives (each archive integrity-checked after download) and the download-size hints corrected. Smoke-tested the macOS build against `glm-ocr-q4_k`: correct text, response key unchanged.

## PP-OCRv6

A detector + recognizer GGUF pair rather than a VLM, which needed two departures from the existing shape.

**It runs through the `crispembed` CLI, not `crispembed-server.`** The server only enables its OCR orchestrator when it is *also* given a primary embedding model via `-m`, and dies on startup if that model is not a real embedding GGUF (`missing token_embd.weight`) — so there is no server route to the pipeline without downloading an unrelated model. (`/health` also reports `"ocr_pipeline": true` when `--ocr-det`/`--ocr-rec` are passed without `--ocr-pipeline`, but `POST /ocr/pipeline` then answers "OCR orchestrator not loaded".) One CLI invocation per image costs ~0.6 s including model load — no slower than a single already-loaded VLM request.

**The download fetches two files in one dialog**, detector first, so a cancel can never leave a recognizer without its detector.

Measured on a rendered subtitle fixture (italic, apostrophes, `6:45`, umlaut), Apple M4:

| backend | output | time/image | size |
|---|---|--:|--:|
| PP-OCRv6 tiny | garbage — not offered | 0.14 s | 3 MB |
| PP-OCRv6 small | byte-perfect — not offered | 0.61 s | 16 MB |
| **PP-OCRv6 medium** | **byte-perfect** | 2.90 s | 83 MB |
| GLM-OCR q4_k (existing) | dropped a leading `- ` | 0.76 s | 889 MB |

Only the medium tier is offered: tiny is unusable on subtitle-sized text, and small — while as accurate here — saves too little to justify a second entry.

The old flat "installed" check (`> 10 MB`) could not express a 5 MB detector, so the truncation floor moved onto `CrispEmbedModel` as a per-model value.

PP-OCRv6 is listed first in the backend combo, but the default in `SeOcr.cs` is still GLM-OCR q8_0 — happy to flip that in a follow-up.

## Testing

11 CrispEmbed unit tests pass (4 new, covering the detector-pair model shape, cross-backend file-name uniqueness, and CLI output parsing). The end-to-end pipeline was verified against the real v0.17.0 binary using the exact argument string this code builds.

## Note

This does **not** fix #13205. The v0.17.0 Linux tarballs still carry the `libggml.so.0 → libggml-blas.so.0 → libopenblas.so.0` chain with `libopenblas` unbundled, and still require GLIBC_2.38 / GLIBCXX_3.4.32. That is tracked upstream at CrispStrobe/CrispEmbed#42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
