### PR TITLE
Source view: discard prompt, find/replace, live parse check, go to line

### DIFF
--- a/docs/features/source-view.md
+++ b/docs/features/source-view.md
@@ -1,0 +1,64 @@
+# Source View
+
+Edit the subtitle as raw text in the current subtitle format — time codes, tags, headers and all. Useful for fixing something the grid cannot express, for pasting a whole file in at once, or just for seeing exactly what will be written to disk.
+
+- **Menu:** Edit → Source view
+- **Shortcut:** F2
+
+The editor is virtualizing: only the lines on screen are colored and laid out, so even a very large file opens and scrolls instantly.
+
+## Status Line
+
+Along the bottom, next to the OK/Cancel buttons:
+
+- **Line X, column Y** — where the caret is
+- **Selected: N characters in M line(s)** — only while something is selected
+- **Parse result** — the source is re-parsed shortly after you stop typing and the result is shown as `<lines> lines, <subtitles> subtitles`. If the format reports bad blocks, the error count is appended; if nothing can be parsed at all, the line turns red and reads `Could not parse as <format>`
+
+That last one is the point of the status line: a broken edit shows up while you are making it, instead of when you press OK.
+
+Above about 4 MB of source text the parse is skipped — re-parsing a file that size on every pause would cost more than the editing does — and only the line count is shown.
+
+## Unsaved Changes
+
+**OK** parses the source and replaces the subtitle with the result. If the source cannot be parsed at all, Subtitle Edit says so and leaves the window open.
+
+If you have edited the text, **Cancel**, **Escape** and the window's close button all ask before throwing the changes away.
+
+## Find and Replace
+
+Press **Ctrl+F** (find) or **Ctrl+H** (replace) to open the search bar below the editor. It searches the source text — including time codes and tags — not the subtitle lines.
+
+- **Case sensitive**, **Whole word** and **Regular expression** can be combined
+- Searching wraps around at the end (and at the top, going backwards)
+- With **Regular expression** on, the replacement supports group references (`$1`, `$2`, …). Without it, `$` is literal
+- **Replace all** is a single undo step: one **Ctrl+Z** takes the whole batch back
+- **Escape** closes the search bar; a second **Escape** closes the window
+
+Selecting a word before pressing Ctrl+F searches for that word.
+
+## Go to Line
+
+**Ctrl+G** opens the go-to-line dialog and selects the line you pick. Line numbers are source lines, not subtitle numbers.
+
+## Editing
+
+Beyond the usual typing, selection and clipboard keys, the editor supports:
+
+| Shortcut | Action |
+|----------|--------|
+| Alt+Up / Alt+Down | Move the current line (or the selected block) up / down |
+| Ctrl+D | Duplicate the current line or selected block |
+| Ctrl+Shift+K | Delete the current line |
+| Ctrl+Backspace | Delete the word before the caret |
+| Ctrl+Delete | Delete the word after the caret |
+| Ctrl+Z / Ctrl+Y | Undo / redo |
+
+On macOS, use Cmd where Ctrl is shown, and Option+Backspace / Option+Delete for the word deletes. Alt+Up / Alt+Down are the same on every platform.
+
+The same commands — plus find, replace and go to line — are in the editor's right-click menu.
+
+## See also
+
+- [Edit Menu](edit.md) — find and replace across subtitle lines rather than raw source
+- [Keyboard Shortcuts](../reference/keyboard-shortcuts.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ Subtitle Edit is a free, open-source editor for video subtitles. This is the doc
 
 ### Editing
 - [Edit Menu](features/edit.md) — Find, Replace, Multiple Replace, History
+- [Source View](features/source-view.md) — Edit the raw subtitle source: syntax coloring, live parse check, find/replace, line commands
 - [Modify Selection](features/modify-selection.md) — Select lines by rules: text, hearing-impaired text, duration, CPS, gaps, styles, actors
 - [Subtitle Grid](features/subtitle-grid.md) — Working with the subtitle list/grid
 - [Text Editor](features/text-editor.md) — Editing subtitle text

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -59,6 +59,25 @@ See also: [Shortcuts Settings](../features/shortcuts.md)
 | F8 / Shift+F8 | Go to next / previous error |
 | Alt+F7 | Spell check |
 
+## Source View
+
+Inside the [source view](../features/source-view.md) window (F2), which edits the raw subtitle text. These are fixed, not configurable in Options → Shortcuts.
+
+| Shortcut | Action |
+|----------|--------|
+| Ctrl+F | Find in the source |
+| Ctrl+H | Replace in the source (Cmd+Alt+F also works on macOS) |
+| F3 / Shift+F3 | Find next / previous |
+| Ctrl+G | Go to line number |
+| Alt+Up / Alt+Down | Move the current line or selected block up / down |
+| Ctrl+D | Duplicate the current line or selected block |
+| Ctrl+Shift+K | Delete the current line |
+| Ctrl+Backspace | Delete the word before the caret |
+| Ctrl+Delete | Delete the word after the caret |
+| Escape | Close the search bar, then the window |
+
+> **Note:** On macOS the word deletes use Option+Backspace / Option+Delete, matching the platform. Alt+Up / Alt+Down are the same everywhere.
+
 ## Video Playback
 
 | Shortcut | Action |

--- a/src/ui/Controls/SyntaxTextEditorControl/SyntaxTextEditor.cs
+++ b/src/ui/Controls/SyntaxTextEditorControl/SyntaxTextEditor.cs
@@ -213,6 +213,24 @@ public class SyntaxTextEditor : Decorator
 
     public void BringCaretIntoView() => _view.BringCaretIntoView();
 
+    /// <summary>Moves the lines the selection touches one line up (-1) or down (+1).</summary>
+    public void MoveSelectedLines(int lineDelta) => _view.MoveSelectedLines(lineDelta);
+
+    public void DuplicateSelectedLines() => _view.DuplicateSelectedLines();
+
+    public void DeleteSelectedLines() => _view.DeleteSelectedLines();
+
+    public void DeleteWordLeft() => _view.DeleteWordLeft();
+
+    public void DeleteWordRight() => _view.DeleteWordRight();
+
+    /// <summary>Replaces the whole text as one undoable edit - see the note on the view.</summary>
+    public void ReplaceAllText(string newText) => _view.ReplaceAllText(newText);
+
+    public bool CanUndo => _view.CanUndo;
+
+    public bool CanRedo => _view.CanRedo;
+
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         base.OnPropertyChanged(change);

--- a/src/ui/Controls/SyntaxTextEditorControl/SyntaxTextView.cs
+++ b/src/ui/Controls/SyntaxTextEditorControl/SyntaxTextView.cs
@@ -1129,10 +1129,39 @@ public class SyntaxTextView : Control
             ? (e.KeyModifiers & KeyModifiers.Alt) != 0
             : (e.KeyModifiers & KeyModifiers.Control) != 0;
 
+        // Alt+Up/Down moves lines everywhere, including macOS - the same binding VS Code uses. The
+        // guarded cases must come before the plain ones below or the compiler calls them subsumed.
+        var altModifier = (e.KeyModifiers & KeyModifiers.Alt) != 0;
+
         var isNavigation = true;
 
         switch (e.Key)
         {
+            case Key.Up when altModifier && !shift:
+                isNavigation = false;
+                MoveSelectedLines(-1);
+                break;
+            case Key.Down when altModifier && !shift:
+                isNavigation = false;
+                MoveSelectedLines(1);
+                break;
+            case Key.D when commandModifier && !shift:
+                isNavigation = false;
+                DuplicateSelectedLines();
+                break;
+            case Key.K when commandModifier && shift:
+                isNavigation = false;
+                DeleteSelectedLines();
+                break;
+            case Key.Back when wordModifier:
+                isNavigation = false;
+                DeleteWordLeft();
+                break;
+            case Key.Delete when wordModifier:
+                isNavigation = false;
+                DeleteWordRight();
+                break;
+
             case Key.Left:
                 SetCaret(wordModifier ? GetWordLeftOffset(_caretOffset) : GetPreviousCaretStop(_caretOffset), shift);
                 break;
@@ -1591,6 +1620,200 @@ public class SyntaxTextView : Control
 
         _allowUndoMerge = false;
         ApplyEdit(_caretOffset, end - _caretOffset, string.Empty);
+    }
+
+    /// <summary>Deletes from the caret back to the start of the word (Ctrl/Option+Backspace).</summary>
+    public void DeleteWordLeft()
+    {
+        if (IsReadOnly)
+        {
+            return;
+        }
+
+        if (SelectionLength > 0)
+        {
+            DeleteSelection();
+            return;
+        }
+
+        var start = GetWordLeftOffset(_caretOffset);
+        if (start == _caretOffset)
+        {
+            return;
+        }
+
+        _allowUndoMerge = false;
+        ApplyEdit(start, _caretOffset - start, string.Empty);
+    }
+
+    /// <summary>Deletes from the caret forward to the end of the word (Ctrl/Option+Delete).</summary>
+    public void DeleteWordRight()
+    {
+        if (IsReadOnly)
+        {
+            return;
+        }
+
+        if (SelectionLength > 0)
+        {
+            DeleteSelection();
+            return;
+        }
+
+        var end = GetWordRightOffset(_caretOffset);
+        if (end == _caretOffset)
+        {
+            return;
+        }
+
+        _allowUndoMerge = false;
+        ApplyEdit(_caretOffset, end - _caretOffset, string.Empty);
+    }
+
+    /// <summary>
+    /// The first and last line the selection touches. The line commands work on whole lines, so a
+    /// caret anywhere in a line is enough to include it.
+    /// </summary>
+    private (int First, int Last) GetSelectedLineRange()
+    {
+        var first = _document.GetPosition(SelectionStart).Line;
+        var endPosition = _document.GetPosition(SelectionEnd);
+        var last = endPosition.Line;
+
+        // A selection that stops exactly at the start of a line does not really reach into it.
+        if (last > first && endPosition.Column == 0)
+        {
+            last--;
+        }
+
+        return (first, last);
+    }
+
+    private string GetLinesText(int firstLine, int lastLine)
+    {
+        var start = _document.GetLineStartOffset(firstLine);
+        return _document.GetText(start, _document.GetLineEndOffset(lastLine) - start);
+    }
+
+    /// <summary>
+    /// Puts the caret and the selection back on text that moved <paramref name="lineDelta"/> lines,
+    /// so the block stays selected and the command can be repeated.
+    /// </summary>
+    private void RestoreSelectionShiftedByLines(
+        SyntaxTextPosition caretBefore,
+        SyntaxTextPosition anchorBefore,
+        int lineDelta)
+    {
+        _selectionAnchor = _document.GetOffset(anchorBefore.Line + lineDelta, anchorBefore.Column);
+        SetCaret(_document.GetOffset(caretBefore.Line + lineDelta, caretBefore.Column), extendSelection: true);
+        InvalidateVisual();
+        BringCaretIntoView();
+    }
+
+    /// <summary>Moves the lines the selection touches one line up (-1) or down (+1).</summary>
+    public void MoveSelectedLines(int lineDelta)
+    {
+        if (IsReadOnly || lineDelta == 0)
+        {
+            return;
+        }
+
+        var (first, last) = GetSelectedLineRange();
+        if ((lineDelta < 0 && first == 0) || (lineDelta > 0 && last >= _document.LineCount - 1))
+        {
+            return;
+        }
+
+        var block = GetLinesText(first, last);
+        var neighborLine = lineDelta < 0 ? first - 1 : last + 1;
+        var neighbor = _document.GetLine(neighborLine);
+
+        // Rewrite the block and the line it swaps with in one edit: one undo step, and the lines
+        // below it never move, so the view keeps its cached layouts.
+        var replacement = lineDelta < 0
+            ? block + _document.NewLine + neighbor
+            : neighbor + _document.NewLine + block;
+
+        var caretBefore = _document.GetPosition(_caretOffset);
+        var anchorBefore = _document.GetPosition(_selectionAnchor);
+
+        var regionStart = _document.GetLineStartOffset(Math.Min(first, neighborLine));
+        var regionEnd = _document.GetLineEndOffset(Math.Max(last, neighborLine));
+
+        _allowUndoMerge = false;
+        ApplyEdit(regionStart, regionEnd - regionStart, replacement);
+        _allowUndoMerge = false;
+
+        RestoreSelectionShiftedByLines(caretBefore, anchorBefore, lineDelta);
+    }
+
+    /// <summary>Inserts a copy of the lines the selection touches below them.</summary>
+    public void DuplicateSelectedLines()
+    {
+        if (IsReadOnly)
+        {
+            return;
+        }
+
+        var (first, last) = GetSelectedLineRange();
+        var block = GetLinesText(first, last);
+
+        var caretBefore = _document.GetPosition(_caretOffset);
+        var anchorBefore = _document.GetPosition(_selectionAnchor);
+
+        _allowUndoMerge = false;
+        ApplyEdit(_document.GetLineEndOffset(last), 0, _document.NewLine + block);
+        _allowUndoMerge = false;
+
+        // Land on the copy, so pressing it again duplicates the copy rather than the original.
+        RestoreSelectionShiftedByLines(caretBefore, anchorBefore, last - first + 1);
+    }
+
+    /// <summary>Removes the lines the selection touches, line break and all.</summary>
+    public void DeleteSelectedLines()
+    {
+        if (IsReadOnly)
+        {
+            return;
+        }
+
+        var (first, last) = GetSelectedLineRange();
+        var start = _document.GetLineStartOffset(first);
+        int end;
+
+        if (last < _document.LineCount - 1)
+        {
+            end = _document.GetLineStartOffset(last + 1); // take the line break below with it
+        }
+        else if (first > 0)
+        {
+            start = _document.GetLineEndOffset(first - 1); // last line: take the break above instead
+            end = _document.GetLineEndOffset(last);
+        }
+        else
+        {
+            end = _document.GetLineEndOffset(last); // nothing above to take a break from: empty it
+        }
+
+        _allowUndoMerge = false;
+        ApplyEdit(start, end - start, string.Empty);
+        _allowUndoMerge = false;
+    }
+
+    /// <summary>
+    /// Replaces the whole text as one undoable edit. Assigning <see cref="Text"/> would go behind
+    /// the undo stack's back, so replace-all uses this.
+    /// </summary>
+    public void ReplaceAllText(string newText)
+    {
+        if (IsReadOnly)
+        {
+            return;
+        }
+
+        _allowUndoMerge = false;
+        ApplyEdit(0, _document.TextLength, newText ?? string.Empty);
+        _allowUndoMerge = false;
     }
 
     /// <summary>The offset one character (or one whole line break) before <paramref name="offset"/>.</summary>

--- a/src/ui/Features/Shared/SourceView/SourceViewViewModel.cs
+++ b/src/ui/Features/Shared/SourceView/SourceViewViewModel.cs
@@ -1,6 +1,5 @@
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
@@ -10,10 +9,12 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Controls.SyntaxTextEditorControl;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Shared.GoToLineNumber;
 using Nikse.SubtitleEdit.Features.Shared.TextBoxUtils;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Shared.SourceView;
@@ -23,8 +24,22 @@ public partial class SourceViewViewModel : ObservableObject, IClosingCleanup
     [ObservableProperty] private string _title;
     [ObservableProperty] private string _text;
     [ObservableProperty] private string _lineAndColumnInfo;
+    [ObservableProperty] private string _selectionInfo;
+    [ObservableProperty] private string _validationInfo;
+    [ObservableProperty] private bool _isValidationError;
+
+    [ObservableProperty] private bool _isFindBarVisible;
+    [ObservableProperty] private bool _isReplaceVisible;
+    [ObservableProperty] private string _searchText;
+    [ObservableProperty] private string _replaceText;
+    [ObservableProperty] private bool _matchCase;
+    [ObservableProperty] private bool _wholeWord;
+    [ObservableProperty] private bool _useRegularExpression;
+    [ObservableProperty] private string _findStatus;
 
     public Window? Window { get; set; }
+    public TextBox? SearchTextBox { get; set; }
+    public TextBox? ReplaceTextBox { get; set; }
 
     public bool OkPressed { get; private set; }
     public Subtitle Subtitle { get; private set; }
@@ -34,74 +49,67 @@ public partial class SourceViewViewModel : ObservableObject, IClosingCleanup
     public IRelayCommand CutCommand { get; }
     public IRelayCommand CopyCommand { get; }
     public IRelayCommand PasteCommand { get; }
+    public IRelayCommand SelectAllCommand { get; }
+    public IRelayCommand UndoCommand { get; }
+    public IRelayCommand RedoCommand { get; }
+    public IRelayCommand MoveLineUpCommand { get; }
+    public IRelayCommand MoveLineDownCommand { get; }
+    public IRelayCommand DuplicateLineCommand { get; }
+    public IRelayCommand DeleteLineCommand { get; }
 
-    private readonly System.Timers.Timer _cursorTimer;
+    // Parsing a multi-megabyte source on every idle tick would cost more than the editing does, so
+    // above this the status line only reports the size.
+    private const int MaxValidationTextLength = 4 * 1024 * 1024;
+
+    private readonly IWindowService _windowService;
+    private readonly DispatcherTimer _validationTimer;
+
+    private SyntaxTextEditor? _editor;
     private int _initialCaretIndex;
+    private bool _isDirty;
 
-    public SourceViewViewModel()
+    /// <summary>Set once the user confirmed the discard, so the second Close() goes through.</summary>
+    private bool _discardConfirmed;
+
+    public SourceViewViewModel(IWindowService windowService)
     {
+        _windowService = windowService;
         SourceViewTextBox = new TextBoxWrapper(new TextBox());
         Title = string.Empty;
         Text = string.Empty;
         LineAndColumnInfo = string.Empty;
+        SelectionInfo = string.Empty;
+        ValidationInfo = string.Empty;
+        SearchText = string.Empty;
+        ReplaceText = string.Empty;
+        FindStatus = string.Empty;
         Subtitle = new Subtitle();
         _subtitleFormat = new SubRip();
         CutCommand = new RelayCommand(() => SourceViewTextBox.Cut());
         CopyCommand = new RelayCommand(() => SourceViewTextBox.Copy());
         PasteCommand = new RelayCommand(() => SourceViewTextBox.Paste());
+        SelectAllCommand = new RelayCommand(() => SourceViewTextBox.SelectAll());
+        UndoCommand = new RelayCommand(() => _editor?.Undo());
+        RedoCommand = new RelayCommand(() => _editor?.Redo());
+        MoveLineUpCommand = new RelayCommand(() => _editor?.MoveSelectedLines(-1));
+        MoveLineDownCommand = new RelayCommand(() => _editor?.MoveSelectedLines(1));
+        DuplicateLineCommand = new RelayCommand(() => _editor?.DuplicateSelectedLines());
+        DeleteLineCommand = new RelayCommand(() => _editor?.DeleteSelectedLines());
 
-        _cursorTimer = new System.Timers.Timer(200);
-        _cursorTimer.Elapsed += CursorTimerElapsed;
-    }
-
-    private void CursorTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
-    {
-        if (SourceViewTextBox == null)
-        {
-            return;
-        }
-
-        Dispatcher.UIThread.Post(() =>
-        {
-            var caretIndex = SourceViewTextBox.CaretIndex;
-            int lineNumber;
-            int columnNumber;
-
-            if (SourceViewTextBox.TextControl is SyntaxTextView view)
-            {
-                // The editor already indexes the lines - asking it beats walking the whole source
-                // four times a second (which on a large file costs more than the editing does).
-                var position = view.Document.GetPosition(caretIndex);
-                lineNumber = position.Line + 1;
-                columnNumber = position.Column + 1;
-            }
-            else
-            {
-                var text = SourceViewTextBox.Text ?? string.Empty;
-                lineNumber = 1;
-                columnNumber = 1;
-
-                for (var i = 0; i < Math.Min(caretIndex, text.Length); i++)
-                {
-                    if (text[i] == '\n')
-                    {
-                        lineNumber++;
-                        columnNumber = 1;
-                    }
-                    else if (text[i] != '\r') // Skip carriage return
-                    {
-                        columnNumber++;
-                    }
-                }
-            }
-
-            LineAndColumnInfo = string.Format(Se.Language.General.LineXColumnY, lineNumber, columnNumber);
-        });
+        _validationTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(400) };
+        _validationTimer.Tick += ValidationTimerTick;
     }
 
     public void OnClosingCleanup()
     {
-        _cursorTimer.StopAndDispose(CursorTimerElapsed);
+        _validationTimer.Stop();
+        _validationTimer.Tick -= ValidationTimerTick;
+
+        if (_editor != null)
+        {
+            _editor.CaretChanged -= EditorCaretChanged;
+            _editor.TextChanged -= EditorTextChanged;
+        }
     }
 
     internal void Initialize(
@@ -114,12 +122,14 @@ public partial class SourceViewViewModel : ObservableObject, IClosingCleanup
         Title = title;
         Text = text;
         _subtitleFormat = subtitleFormat;
-        _cursorTimer.Start();
         _initialCaretIndex = FindSelectedParagraphCaretIndex(text, subtitle, subtitleFormat, selectedParagraphIndex);
 
         // The editor only lays out the lines it shows, so even a very large source opens fast -
         // no need for the plain-text-box fallback this used to need above 2 MB.
         SourceViewTextBox = CreateAdvancedTextBoxWrapper(text, subtitleFormat);
+
+        UpdateCaretInfo();
+        Validate();
     }
 
     internal void FocusEditor()
@@ -167,6 +177,11 @@ public partial class SourceViewViewModel : ObservableObject, IClosingCleanup
             Text = text,
         };
 
+        // Subscribed after the text is set, so loading the source does not count as an edit.
+        editor.CaretChanged += EditorCaretChanged;
+        editor.TextChanged += EditorTextChanged;
+        _editor = editor;
+
         // The view model's Text is not kept in sync while typing on purpose: materializing the
         // whole source on every keystroke is what made a large file crawl. Ok reads the editor.
         var textBoxBorder = new Border
@@ -180,6 +195,383 @@ public partial class SourceViewViewModel : ObservableObject, IClosingCleanup
 
         return new SyntaxTextEditorWrapper(editor, textBoxBorder);
     }
+
+    // ----------------------------------------------------------------------------------------
+    // Status line
+    // ----------------------------------------------------------------------------------------
+
+    private void EditorCaretChanged(object? sender, EventArgs e) => UpdateCaretInfo();
+
+    private void EditorTextChanged(object? sender, EventArgs e)
+    {
+        _isDirty = true;
+
+        // Restart the idle window: validating while the user is still typing would only flicker.
+        _validationTimer.Stop();
+        _validationTimer.Start();
+    }
+
+    private void UpdateCaretInfo()
+    {
+        if (_editor == null)
+        {
+            return;
+        }
+
+        var document = _editor.Document;
+        var position = document.GetPosition(_editor.CaretOffset);
+        LineAndColumnInfo = string.Format(Se.Language.General.LineXColumnY, position.Line + 1, position.Column + 1);
+
+        var selectionLength = _editor.SelectionLength;
+        if (selectionLength == 0)
+        {
+            SelectionInfo = string.Empty;
+            return;
+        }
+
+        var firstLine = document.GetPosition(_editor.SelectionStart).Line;
+        var lastLine = document.GetPosition(_editor.SelectionStart + selectionLength).Line;
+        SelectionInfo = string.Format(
+            Se.Language.SourceView.SelectedXCharactersYLines,
+            selectionLength,
+            lastLine - firstLine + 1);
+    }
+
+    private void ValidationTimerTick(object? sender, EventArgs e)
+    {
+        _validationTimer.Stop();
+        Validate();
+    }
+
+    /// <summary>
+    /// Parses the source the way <see cref="Ok"/> will and reports the result, so a broken edit
+    /// shows up while it is being made instead of when the dialog is closed.
+    /// </summary>
+    internal void Validate()
+    {
+        if (_editor == null)
+        {
+            return;
+        }
+
+        var source = _editor.Text ?? string.Empty;
+        var lineCount = _editor.Document.LineCount;
+
+        if (source.Length > MaxValidationTextLength)
+        {
+            IsValidationError = false;
+            ValidationInfo = string.Format(Se.Language.SourceView.XLinesYSubtitles, lineCount, "?");
+            return;
+        }
+
+        var subtitle = new Subtitle();
+
+        // A few formats pick the frame rate up from the source header. Validation runs on every
+        // idle tick, so it must not leave that behind in the global settings.
+        var oldFrameRate = Configuration.Settings.General.CurrentFrameRate;
+        try
+        {
+            _subtitleFormat.LoadSubtitle(subtitle, source.SplitToLines(), string.Empty);
+        }
+        catch
+        {
+            // A format that throws on malformed input is just an unparsable source here.
+            subtitle.Paragraphs.Clear();
+        }
+        finally
+        {
+            Configuration.Settings.General.CurrentFrameRate = oldFrameRate;
+        }
+
+        if (subtitle.Paragraphs.Count == 0)
+        {
+            IsValidationError = true;
+            ValidationInfo = string.Format(Se.Language.SourceView.CouldNotParseAsX, _subtitleFormat.Name);
+            return;
+        }
+
+        var errorCount = _subtitleFormat.ErrorCount;
+        IsValidationError = errorCount > 0;
+        ValidationInfo = errorCount > 0
+            ? string.Format(Se.Language.SourceView.XLinesYSubtitlesZErrors, lineCount, subtitle.Paragraphs.Count, errorCount)
+            : string.Format(Se.Language.SourceView.XLinesYSubtitles, lineCount, subtitle.Paragraphs.Count);
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Find and replace
+    // ----------------------------------------------------------------------------------------
+
+    [RelayCommand]
+    private void ShowFind()
+    {
+        IsReplaceVisible = false;
+        OpenFindBar();
+    }
+
+    [RelayCommand]
+    private void ShowReplace()
+    {
+        IsReplaceVisible = true;
+        OpenFindBar();
+    }
+
+    private void OpenFindBar()
+    {
+        // Selecting a word and pressing Ctrl+F should search for that word, like everywhere else.
+        var selected = _editor?.SelectedText ?? string.Empty;
+        if (selected.Length > 0 && selected.IndexOfAny(['\r', '\n']) < 0)
+        {
+            SearchText = selected;
+        }
+
+        FindStatus = string.Empty;
+        IsFindBarVisible = true;
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            SearchTextBox?.Focus();
+            SearchTextBox?.SelectAll();
+        });
+    }
+
+    [RelayCommand]
+    private void CloseFindBar()
+    {
+        IsFindBarVisible = false;
+        FindStatus = string.Empty;
+        SourceViewTextBox.Focus();
+    }
+
+    /// <summary>
+    /// One regex for every mode - plain text is the escaped pattern - so whole word and wrap-around
+    /// behave the same whichever mode the user is in. Null means the pattern is unusable.
+    /// </summary>
+    private Regex? BuildSearchRegex()
+    {
+        if (string.IsNullOrEmpty(SearchText))
+        {
+            return null;
+        }
+
+        var pattern = UseRegularExpression ? SearchText : Regex.Escape(SearchText);
+        if (WholeWord)
+        {
+            pattern = @"\b(?:" + pattern + @")\b";
+        }
+
+        var options = MatchCase ? RegexOptions.None : RegexOptions.IgnoreCase;
+        try
+        {
+            return new Regex(pattern, options);
+        }
+        catch (ArgumentException)
+        {
+            FindStatus = Se.Language.SourceView.InvalidRegularExpression;
+            return null;
+        }
+    }
+
+    [RelayCommand]
+    private void FindNext() => Find(forward: true, fromSelectionStart: false);
+
+    [RelayCommand]
+    private void FindPrevious() => Find(forward: false, fromSelectionStart: false);
+
+    /// <summary>Re-runs the search from where the caret is while the search text is being typed.</summary>
+    internal void SearchTextChanged(object? sender, TextChangedEventArgs e)
+    {
+        if (!IsFindBarVisible || string.IsNullOrEmpty(SearchText))
+        {
+            FindStatus = string.Empty;
+            return;
+        }
+
+        Find(forward: true, fromSelectionStart: true);
+    }
+
+    private bool Find(bool forward, bool fromSelectionStart)
+    {
+        if (_editor == null)
+        {
+            return false;
+        }
+
+        var regex = BuildSearchRegex();
+        if (regex == null)
+        {
+            return false;
+        }
+
+        var text = _editor.Text ?? string.Empty;
+
+        // Step past the match that is selected right now, but do not skip one that starts exactly
+        // under a bare caret.
+        var searchFrom = _editor.SelectionStart;
+        if (!fromSelectionStart && _editor.SelectionLength > 0)
+        {
+            searchFrom++;
+        }
+
+        var match = forward
+            ? FindForward(regex, text, searchFrom)
+            : FindBackward(regex, text, _editor.SelectionStart);
+
+        if (match == null)
+        {
+            FindStatus = string.Format(Se.Language.General.XNotFound, SearchText);
+            return false;
+        }
+
+        FindStatus = string.Empty;
+        _editor.Select(match.Index, match.Length);
+        _editor.BringCaretIntoView();
+        return true;
+    }
+
+    private static Match? FindForward(Regex regex, string text, int startAt)
+    {
+        if (startAt <= text.Length)
+        {
+            var match = regex.Match(text, Math.Max(0, startAt));
+            if (match.Success)
+            {
+                return match;
+            }
+        }
+
+        // Wrap around to the top, the way find in the main window does.
+        var fromTop = regex.Match(text);
+        return fromTop.Success ? fromTop : null;
+    }
+
+    private static Match? FindBackward(Regex regex, string text, int before)
+    {
+        Match? best = null;
+        Match? last = null;
+
+        for (var match = regex.Match(text); match.Success; match = match.NextMatch())
+        {
+            if (match.Index < before)
+            {
+                best = match;
+            }
+
+            last = match;
+
+            // A zero-length match would loop forever otherwise.
+            if (match.Length == 0 && match.Index >= text.Length)
+            {
+                break;
+            }
+        }
+
+        return best ?? last; // nothing above the caret: wrap around to the last match
+    }
+
+    [RelayCommand]
+    private void Replace()
+    {
+        if (_editor == null)
+        {
+            return;
+        }
+
+        var regex = BuildSearchRegex();
+        if (regex == null)
+        {
+            return;
+        }
+
+        // Only replace when the current selection really is the match - otherwise just go find one.
+        if (_editor.SelectionLength > 0)
+        {
+            var selected = _editor.SelectedText;
+            var match = regex.Match(selected);
+            if (match.Success && match.Index == 0 && match.Length == selected.Length)
+            {
+                var replacement = UseRegularExpression
+                    ? match.Result(ReplaceText ?? string.Empty)
+                    : ReplaceText ?? string.Empty;
+
+                _editor.InsertText(replacement);
+                _editor.Select(_editor.CaretOffset, 0);
+            }
+        }
+
+        Find(forward: true, fromSelectionStart: true);
+    }
+
+    [RelayCommand]
+    private void ReplaceAll()
+    {
+        if (_editor == null)
+        {
+            return;
+        }
+
+        var regex = BuildSearchRegex();
+        if (regex == null)
+        {
+            return;
+        }
+
+        var text = _editor.Text ?? string.Empty;
+        var count = regex.Count(text);
+        if (count == 0)
+        {
+            FindStatus = string.Format(Se.Language.General.XNotFound, SearchText);
+            return;
+        }
+
+        var replacement = UseRegularExpression
+            ? ReplaceText ?? string.Empty
+            : (ReplaceText ?? string.Empty).Replace("$", "$$"); // a literal replacement stays literal
+
+        var caretBefore = _editor.CaretOffset;
+
+        // One edit for the whole document: one undo step, and the text never goes around the undo
+        // stack the way assigning Text would.
+        _editor.ReplaceAllText(regex.Replace(text, replacement));
+
+        _editor.Select(Math.Min(caretBefore, _editor.Document.TextLength), 0);
+        _editor.BringCaretIntoView();
+        FindStatus = string.Format(Se.Language.SourceView.ReplacedXOccurrences, count);
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Go to line
+    // ----------------------------------------------------------------------------------------
+
+    [RelayCommand]
+    private async Task GoToLine()
+    {
+        if (_editor == null || Window == null)
+        {
+            return;
+        }
+
+        var document = _editor.Document;
+        var currentLine = document.GetPosition(_editor.CaretOffset).Line + 1;
+
+        var result = await _windowService.ShowDialogAsync<GoToLineNumberWindow, GoToLineNumberViewModel>(
+            Window,
+            vm => vm.Initialize(currentLine, document.LineCount));
+
+        if (result is not { OkPressed: true, LineNumber: > 0 })
+        {
+            return;
+        }
+
+        var line = Math.Min((int)result.LineNumber.Value, document.LineCount) - 1;
+        var start = document.GetLineStartOffset(line);
+        _editor.Select(start, document.GetLineEndOffset(line) - start);
+        _editor.BringCaretIntoView();
+        SourceViewTextBox.Focus();
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Closing
+    // ----------------------------------------------------------------------------------------
 
     [RelayCommand]
     private async Task Ok()
@@ -196,6 +588,7 @@ public partial class SourceViewViewModel : ObservableObject, IClosingCleanup
         if (string.IsNullOrEmpty(text))
         {
             OkPressed = false;
+            _discardConfirmed = true; // an empty source is not a change worth asking about
             Window?.Close();
             return;
         }
@@ -268,12 +661,92 @@ public partial class SourceViewViewModel : ObservableObject, IClosingCleanup
         Window?.Close();
     }
 
+    /// <summary>
+    /// True while closing would throw away edits. The window turns this into a prompt - hand-editing
+    /// a few hundred lines and losing them to a stray Escape is not a fair trade.
+    /// </summary>
+    public bool NeedsDiscardConfirmation => _isDirty && !OkPressed && !_discardConfirmed;
+
+    public async Task<bool> ConfirmDiscardAsync()
+    {
+        if (Window == null)
+        {
+            return true;
+        }
+
+        var result = await MessageBox.Show(
+            Window,
+            Se.Language.SourceView.DiscardChangesTitle,
+            Se.Language.SourceView.DiscardChanges,
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Question);
+
+        _discardConfirmed = result == MessageBoxResult.Yes;
+        return _discardConfirmed;
+    }
+
     internal void OnKeyDown(object? sender, KeyEventArgs e)
     {
-        if (e.Key == Key.Escape)
+        var commandModifier = OperatingSystem.IsMacOS()
+            ? (e.KeyModifiers & KeyModifiers.Meta) != 0
+            : (e.KeyModifiers & KeyModifiers.Control) != 0;
+        var shift = (e.KeyModifiers & KeyModifiers.Shift) != 0;
+
+        switch (e.Key)
         {
-            e.Handled = true;
-            Window?.Close();
+            case Key.Escape:
+                e.Handled = true;
+                if (IsFindBarVisible)
+                {
+                    CloseFindBar(); // first Escape leaves the search bar, the next one leaves the window
+                }
+                else
+                {
+                    Window?.Close();
+                }
+
+                break;
+
+            // Cmd+H hides the application on macOS, so replace answers to Cmd+Alt+F there as well.
+            // This case has to come first or Cmd+Alt+F would be swallowed by plain Ctrl+F below.
+            case Key.H when commandModifier:
+            case Key.F when commandModifier && (e.KeyModifiers & KeyModifiers.Alt) != 0:
+                e.Handled = true;
+                ShowReplace();
+                break;
+
+            case Key.F when commandModifier && !shift:
+                e.Handled = true;
+                ShowFind();
+                break;
+
+            case Key.G when commandModifier:
+                e.Handled = true;
+                _ = GoToLine();
+                break;
+
+            case Key.F3:
+                e.Handled = true;
+                if (string.IsNullOrEmpty(SearchText))
+                {
+                    ShowFind();
+                }
+                else
+                {
+                    Find(forward: !shift, fromSelectionStart: false);
+                }
+
+                break;
+
+            case Key.Enter when IsFindBarVisible && IsSearchInputFocused():
+                e.Handled = true;
+                Find(forward: !shift, fromSelectionStart: false);
+                break;
         }
+    }
+
+    private bool IsSearchInputFocused()
+    {
+        return SearchTextBox?.IsFocused == true || ReplaceTextBox?.IsFocused == true;
     }
 }

--- a/src/ui/Features/Shared/SourceView/SourceViewWindow.cs
+++ b/src/ui/Features/Shared/SourceView/SourceViewWindow.cs
@@ -1,15 +1,21 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
+using Avalonia.Media;
 using Nikse.SubtitleEdit.Controls.SyntaxTextEditorControl;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.ValueConverters;
 
 namespace Nikse.SubtitleEdit.Features.Shared.SourceView;
 
 public class SourceViewWindow : Window
 {
+    /// <summary>Set once the discard prompt was answered, so the second Close() is not questioned.</summary>
+    private bool _allowClose;
+
     public SourceViewWindow(SourceViewViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
@@ -33,6 +39,22 @@ public class SourceViewWindow : Window
                     new MenuItem { Header = Se.Language.General.Cut, Command = vm.CutCommand },
                     new MenuItem { Header = Se.Language.General.Copy, Command = vm.CopyCommand },
                     new MenuItem { Header = Se.Language.General.Paste, Command = vm.PasteCommand },
+                    new MenuItem { Header = Se.Language.General.SelectAll, Command = vm.SelectAllCommand },
+                    new Separator(),
+                    new MenuItem { Header = Se.Language.General.Undo, Command = vm.UndoCommand },
+                    new MenuItem { Header = Se.Language.General.Redo, Command = vm.RedoCommand },
+                    new Separator(),
+
+                    // The line commands live in the editor's key handling; the menu is what makes
+                    // them findable at all.
+                    new MenuItem { Header = Se.Language.SourceView.MoveLineUp, Command = vm.MoveLineUpCommand },
+                    new MenuItem { Header = Se.Language.SourceView.MoveLineDown, Command = vm.MoveLineDownCommand },
+                    new MenuItem { Header = Se.Language.SourceView.DuplicateLine, Command = vm.DuplicateLineCommand },
+                    new MenuItem { Header = Se.Language.SourceView.DeleteLine, Command = vm.DeleteLineCommand },
+                    new Separator(),
+                    new MenuItem { Header = Se.Language.General.Find, Command = vm.ShowFindCommand },
+                    new MenuItem { Header = Se.Language.General.Replace, Command = vm.ShowReplaceCommand },
+                    new MenuItem { Header = Se.Language.General.GoToLineNumber, Command = vm.GoToLineCommand },
                 },
             };
             textEditor.ContextFlyout = textBoxContextFlyout;
@@ -48,17 +70,15 @@ public class SourceViewWindow : Window
             Child = vm.SourceViewTextBox.ContentControl,
         };
 
-        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
-        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
-        var buttonPanel = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
-
-        var labelCursorPosition = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.LineAndColumnInfo)).WithAlignmentTop();
+        var findBar = MakeFindBar(vm);
+        var bottomPanel = MakeBottomPanel(vm);
 
         var grid = new Grid
         {
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
@@ -73,15 +93,165 @@ public class SourceViewWindow : Window
         };
 
         grid.Add(contentBorder, 0);
-        grid.Add(labelCursorPosition, 1);
-        grid.Add(buttonPanel, 1);
+        grid.Add(findBar, 1);
+        grid.Add(bottomPanel, 2);
 
         Content = grid;
 
         Opened += delegate { Avalonia.Threading.Dispatcher.UIThread.Post(vm.FocusEditor); };
         AddHandler(KeyDownEvent, vm.OnKeyDown, RoutingStrategies.Tunnel);
 
-        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Closing += async (_, e) =>
+        {
+            if (!_allowClose && vm.NeedsDiscardConfirmation)
+            {
+                // Cancel first, synchronously - the close cannot be stopped after the await.
+                e.Cancel = true;
+                if (await vm.ConfirmDiscardAsync())
+                {
+                    _allowClose = true;
+                    Close();
+                }
+
+                return;
+            }
+
+            UiUtil.SaveWindowPosition(this);
+        };
+
         Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
+    }
+
+    /// <summary>
+    /// The search bar sits between the editor and the buttons and is hidden until Ctrl+F / Ctrl+H.
+    /// A dialog on top of a dialog would be in the way of the text it is searching.
+    /// </summary>
+    private static Border MakeFindBar(SourceViewViewModel vm)
+    {
+        var searchTextBox = new TextBox
+        {
+            Width = 260,
+            PlaceholderText = Se.Language.Edit.Find.SearchTextWatermark,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!TextBox.TextProperty] = new Binding(nameof(vm.SearchText)) { Mode = BindingMode.TwoWay },
+        };
+        searchTextBox.TextChanged += vm.SearchTextChanged;
+        vm.SearchTextBox = searchTextBox;
+
+        var replaceTextBox = new TextBox
+        {
+            Width = 260,
+            PlaceholderText = Se.Language.Edit.Find.ReplaceTextWatermark,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!TextBox.TextProperty] = new Binding(nameof(vm.ReplaceText)) { Mode = BindingMode.TwoWay },
+            [!IsVisibleProperty] = new Binding(nameof(vm.IsReplaceVisible)),
+        };
+        vm.ReplaceTextBox = replaceTextBox;
+
+        var buttonFindPrevious = UiUtil.MakeButton(Se.Language.Edit.Find.FindPrevious, vm.FindPreviousCommand);
+        var buttonFindNext = UiUtil.MakeButton(Se.Language.Edit.Find.FindNext, vm.FindNextCommand);
+
+        var buttonReplace = UiUtil.MakeButton(Se.Language.General.Replace, vm.ReplaceCommand);
+        buttonReplace.Bind(IsVisibleProperty, new Binding(nameof(vm.IsReplaceVisible)));
+
+        var buttonReplaceAll = UiUtil.MakeButton(Se.Language.Edit.Find.ReplaceAll, vm.ReplaceAllCommand);
+        buttonReplaceAll.Bind(IsVisibleProperty, new Binding(nameof(vm.IsReplaceVisible)));
+
+        var checkBoxMatchCase = UiUtil.MakeCheckBox(Se.Language.General.CaseSensitive, vm, nameof(vm.MatchCase));
+        var checkBoxWholeWord = UiUtil.MakeCheckBox(Se.Language.Edit.Find.WholeWord, vm, nameof(vm.WholeWord));
+        var checkBoxRegex = UiUtil.MakeCheckBox(Se.Language.General.RegularExpression, vm, nameof(vm.UseRegularExpression));
+
+        var labelStatus = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.FindStatus));
+
+        var buttonClose = UiUtil.MakeButton(vm.CloseFindBarCommand, IconNames.Close, Se.Language.SourceView.CloseSearch);
+        buttonClose.HorizontalAlignment = HorizontalAlignment.Right;
+
+        var panel = new WrapPanel
+        {
+            Orientation = Orientation.Horizontal,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children =
+            {
+                searchTextBox,
+                buttonFindPrevious,
+                buttonFindNext,
+                replaceTextBox,
+                buttonReplace,
+                buttonReplaceAll,
+                checkBoxMatchCase,
+                checkBoxWholeWord,
+                checkBoxRegex,
+                labelStatus,
+            },
+        };
+
+        var innerGrid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+            RowDefinitions = { new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) } },
+        };
+        innerGrid.Add(panel, 0, 0);
+        innerGrid.Add(buttonClose, 0, 1);
+
+        var border = new Border
+        {
+            Child = innerGrid,
+            Margin = new Thickness(0, 6, 10, 0),
+            Padding = new Thickness(6, 4),
+            BorderThickness = new Thickness(1),
+            BorderBrush = UiUtil.GetTextColor(0.3d),
+            CornerRadius = new CornerRadius(UiUtil.CornerRadius),
+            [!IsVisibleProperty] = new Binding(nameof(vm.IsFindBarVisible)),
+        };
+
+        return border;
+    }
+
+    private static Grid MakeBottomPanel(SourceViewViewModel vm)
+    {
+        var labelCursorPosition = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.LineAndColumnInfo));
+        var labelSelection = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.SelectionInfo));
+
+        // Red only when the source does not parse - the count is ordinary information otherwise.
+        var labelValidation = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.ValidationInfo));
+        labelValidation.Bind(ForegroundProperty, new Binding(nameof(vm.IsValidationError))
+        {
+            Converter = new BooleanToBrushConverter
+            {
+                TrueBrush = new SolidColorBrush(Color.FromRgb(0xD3, 0x2F, 0x2F)),
+                FalseBrush = UiUtil.GetTextColor(0.7d),
+            },
+        });
+
+        var statusPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            VerticalAlignment = VerticalAlignment.Center,
+            Spacing = 15,
+            Children = { labelCursorPosition, labelSelection, labelValidation },
+        };
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var buttonPanel = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+            RowDefinitions = { new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) } },
+        };
+
+        grid.Add(statusPanel, 0, 0);
+        grid.Add(buttonPanel, 0, 1);
+
+        return grid;
     }
 }

--- a/src/ui/Logic/Config/Language/LanguageSourceView.cs
+++ b/src/ui/Logic/Config/Language/LanguageSourceView.cs
@@ -1,0 +1,35 @@
+namespace Nikse.SubtitleEdit.Logic.Config.Language;
+
+public class LanguageSourceView
+{
+    public string DiscardChangesTitle { get; set; }
+    public string DiscardChanges { get; set; }
+    public string XLinesYSubtitles { get; set; }
+    public string XLinesYSubtitlesZErrors { get; set; }
+    public string CouldNotParseAsX { get; set; }
+    public string SelectedXCharactersYLines { get; set; }
+    public string ReplacedXOccurrences { get; set; }
+    public string InvalidRegularExpression { get; set; }
+    public string MoveLineUp { get; set; }
+    public string MoveLineDown { get; set; }
+    public string DuplicateLine { get; set; }
+    public string DeleteLine { get; set; }
+    public string CloseSearch { get; set; }
+
+    public LanguageSourceView()
+    {
+        DiscardChangesTitle = "Discard changes?";
+        DiscardChanges = "The source text has been changed." + System.Environment.NewLine + "Discard the changes?";
+        XLinesYSubtitles = "{0} lines, {1} subtitles";
+        XLinesYSubtitlesZErrors = "{0} lines, {1} subtitles, {2} error(s)";
+        CouldNotParseAsX = "Could not parse as {0}";
+        SelectedXCharactersYLines = "Selected: {0} characters in {1} line(s)";
+        ReplacedXOccurrences = "Replaced {0} occurrence(s)";
+        InvalidRegularExpression = "Invalid regular expression";
+        MoveLineUp = "Move line up";
+        MoveLineDown = "Move line down";
+        DuplicateLine = "Duplicate line";
+        DeleteLine = "Delete line";
+        CloseSearch = "Close search";
+    }
+}

--- a/src/ui/Logic/Config/Language/SeLanguage.cs
+++ b/src/ui/Logic/Config/Language/SeLanguage.cs
@@ -21,6 +21,7 @@ public class SeLanguage
     public LanguageMain Main { get; set; } = new();
     public LanguageFile File { get; set; } = new();
     public LanguageEdit Edit { get; set; } = new();
+    public LanguageSourceView SourceView { get; set; } = new();
     public LanguageTools Tools { get; set; } = new();
     public LanguageSpellCheck SpellCheck { get; set; } = new();
     public LanguageVideo Video { get; set; } = new();

--- a/tests/UI/Controls/SyntaxTextEditorTests.cs
+++ b/tests/UI/Controls/SyntaxTextEditorTests.cs
@@ -310,4 +310,175 @@ public class SyntaxTextEditorTests : IDisposable
         var visible = view.GetVisibleLineRange();
         Assert.InRange(5_000, visible.First, visible.Last);
     }
+
+    // ----------------------------------------------------------------------------------------
+    // Line commands
+    // ----------------------------------------------------------------------------------------
+
+    private static string Lines(params string[] lines) => string.Join("\r\n", lines);
+
+    [AvaloniaFact]
+    public void AltUpMovesTheCaretLineUpAndKeepsTheColumn()
+    {
+        var (window, editor) = Show(Lines("one", "two", "three"));
+        var view = editor.View;
+
+        view.CaretOffset = view.Document.GetOffset(1, 2); // inside "two"
+        Press(window, Key.Up, RawInputModifiers.Alt);
+
+        Assert.Equal(Lines("two", "one", "three"), editor.Text);
+        Assert.Equal(new SyntaxTextPosition(0, 2), view.Document.GetPosition(view.CaretOffset));
+    }
+
+    [AvaloniaFact]
+    public void AltDownMovesTheWholeSelectedBlock()
+    {
+        var (window, editor) = Show(Lines("a", "b", "c", "d"));
+        var view = editor.View;
+
+        // Select from inside line 0 to inside line 1 - both lines count as touched.
+        view.Select(view.Document.GetOffset(0, 0), view.Document.GetOffset(1, 1));
+        Press(window, Key.Down, RawInputModifiers.Alt);
+
+        Assert.Equal(Lines("c", "a", "b", "d"), editor.Text);
+        Assert.Equal("a\r\nb", view.SelectedText);
+    }
+
+    [AvaloniaFact]
+    public void MovingLinesStaysInsideTheDocument()
+    {
+        var (window, editor) = Show(Lines("first", "last"));
+        var view = editor.View;
+
+        view.CaretOffset = 0;
+        Press(window, Key.Up, RawInputModifiers.Alt);
+        Assert.Equal(Lines("first", "last"), editor.Text);
+
+        view.CaretOffset = view.Document.GetLineStartOffset(1);
+        Press(window, Key.Down, RawInputModifiers.Alt);
+        Assert.Equal(Lines("first", "last"), editor.Text);
+        Assert.False(view.CanUndo);
+    }
+
+    [AvaloniaFact]
+    public void MoveLineUndoesAsOneStep()
+    {
+        var (window, editor) = Show(Lines("one", "two", "three"));
+        var view = editor.View;
+
+        view.CaretOffset = view.Document.GetLineStartOffset(2);
+        Press(window, Key.Up, RawInputModifiers.Alt);
+        Assert.Equal(Lines("one", "three", "two"), editor.Text);
+
+        view.Undo();
+        Assert.Equal(Lines("one", "two", "three"), editor.Text);
+        Assert.False(view.CanUndo);
+    }
+
+    [AvaloniaFact]
+    public void DuplicateLineInsertsTheCopyBelowAndLandsOnIt()
+    {
+        var (window, editor) = Show(Lines("one", "two"));
+        var view = editor.View;
+
+        view.CaretOffset = view.Document.GetOffset(0, 1);
+        Press(window, Key.D, ControlOrMeta);
+
+        Assert.Equal(Lines("one", "one", "two"), editor.Text);
+        Assert.Equal(new SyntaxTextPosition(1, 1), view.Document.GetPosition(view.CaretOffset));
+
+        // Repeating it duplicates the copy, not the original.
+        Press(window, Key.D, ControlOrMeta);
+        Assert.Equal(Lines("one", "one", "one", "two"), editor.Text);
+    }
+
+    [AvaloniaFact]
+    public void DeleteLineTakesTheLineBreakWithIt()
+    {
+        var (window, editor) = Show(Lines("one", "two", "three"));
+        var view = editor.View;
+
+        view.CaretOffset = view.Document.GetLineStartOffset(1);
+        Press(window, Key.K, ControlOrMeta | RawInputModifiers.Shift);
+
+        Assert.Equal(Lines("one", "three"), editor.Text);
+        Assert.Equal(2, view.Document.LineCount);
+    }
+
+    [AvaloniaFact]
+    public void DeletingTheLastLineTakesTheBreakAboveIt()
+    {
+        var (window, editor) = Show(Lines("one", "two"));
+        var view = editor.View;
+
+        view.CaretOffset = view.Document.GetLineStartOffset(1);
+        Press(window, Key.K, ControlOrMeta | RawInputModifiers.Shift);
+
+        Assert.Equal("one", editor.Text);
+        Assert.Equal(1, view.Document.LineCount);
+    }
+
+    [AvaloniaFact]
+    public void DeleteLineOnTheOnlyLineJustEmptiesIt()
+    {
+        var (window, editor) = Show("only");
+        var view = editor.View;
+
+        Press(window, Key.K, ControlOrMeta | RawInputModifiers.Shift);
+
+        Assert.Equal(string.Empty, editor.Text);
+        Assert.Equal(1, view.Document.LineCount);
+    }
+
+    [AvaloniaFact]
+    public void DeleteWordLeftAndRightRemoveOneWord()
+    {
+        var (window, editor) = Show("one two three");
+        var view = editor.View;
+
+        view.CaretOffset = 7; // right after "two"
+        Press(window, Key.Back, WordModifier);
+        Assert.Equal("one  three", editor.Text);
+
+        view.CaretOffset = 4;
+        Press(window, Key.Delete, WordModifier);
+        Assert.Equal("one ", editor.Text);
+    }
+
+    [AvaloniaFact]
+    public void ReadOnlyRefusesTheLineCommands()
+    {
+        var text = Lines("one", "two", "three");
+        var (window, editor) = Show(text, readOnly: true);
+
+        editor.View.CaretOffset = editor.Document.GetLineStartOffset(1);
+        Press(window, Key.Up, RawInputModifiers.Alt);
+        Press(window, Key.D, ControlOrMeta);
+        Press(window, Key.K, ControlOrMeta | RawInputModifiers.Shift);
+        Press(window, Key.Back, WordModifier);
+
+        Assert.Equal(text, editor.Text);
+        Assert.False(editor.View.CanUndo);
+    }
+
+    [AvaloniaFact]
+    public void ReplaceAllTextIsOneUndoStep()
+    {
+        var (_, editor) = Show(Lines("one", "two"));
+
+        editor.ReplaceAllText(Lines("1", "2"));
+        Assert.Equal(Lines("1", "2"), editor.Text);
+
+        editor.Undo();
+        Assert.Equal(Lines("one", "two"), editor.Text);
+        Assert.False(editor.View.CanUndo);
+    }
+
+    // The editor follows the platform: Cmd on macOS, Ctrl elsewhere - and word steps use Option on
+    // macOS, where Ctrl is not a text-editing modifier at all.
+    private static RawInputModifiers ControlOrMeta =>
+        OperatingSystem.IsMacOS() ? RawInputModifiers.Meta : RawInputModifiers.Control;
+
+    private static RawInputModifiers WordModifier =>
+        OperatingSystem.IsMacOS() ? RawInputModifiers.Alt : RawInputModifiers.Control;
 }

--- a/tests/UI/Features/SourceViewEditorTests.cs
+++ b/tests/UI/Features/SourceViewEditorTests.cs
@@ -5,6 +5,7 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Shared.SourceView;
 using Nikse.SubtitleEdit.Features.Shared.TextBoxUtils;
+using Nikse.SubtitleEdit.Logic;
 
 namespace UITests.Features;
 
@@ -15,6 +16,31 @@ namespace UITests.Features;
 /// </summary>
 public class SourceViewEditorTests
 {
+    /// <summary>Only Go to line opens a window, and none of these tests take that path.</summary>
+    private sealed class NoWindowService : IWindowService
+    {
+        public T ShowWindow<T>(Window owner, Action<T>? configure = null) where T : Window
+            => throw new NotSupportedException();
+
+        public TViewModel ShowWindow<T, TViewModel>(Window owner, Action<T, TViewModel>? configure = null)
+            where T : Window where TViewModel : class
+            => throw new NotSupportedException();
+
+        public TViewModel ShowIndependentWindow<T, TViewModel>(Action<T, TViewModel>? configure = null)
+            where T : Window where TViewModel : class
+            => throw new NotSupportedException();
+
+        public Task<T> ShowDialogAsync<T>(Window owner, Action<T>? configure = null) where T : Window
+            => throw new NotSupportedException();
+
+        public Task<TViewModel> ShowDialogAsync<TWindow, TViewModel>(
+            Window owner,
+            Action<TViewModel>? configureViewModel = null,
+            Action<TWindow>? configureWindow = null)
+            where TWindow : Window where TViewModel : class
+            => throw new NotSupportedException();
+    }
+
     private static (SourceViewViewModel Vm, Subtitle Subtitle, string Text) MakeSourceView()
     {
         var subtitle = new Subtitle();
@@ -24,10 +50,12 @@ public class SourceViewEditorTests
         var format = new SubRip();
         var text = subtitle.ToText(format);
 
-        var vm = new SourceViewViewModel();
+        var vm = new SourceViewViewModel(new NoWindowService());
         vm.Initialize("Source view", text, format, subtitle, 1);
         return (vm, subtitle, text);
     }
+
+    private static SyntaxTextView ViewOf(SourceViewViewModel vm) => (SyntaxTextView)vm.SourceViewTextBox.TextControl;
 
     [AvaloniaFact]
     public void SourceIsShownInTheVirtualizingEditor()
@@ -45,7 +73,7 @@ public class SourceViewEditorTests
         var (vm, _, text) = MakeSourceView();
         vm.FocusEditor();
 
-        var view = (SyntaxTextView)vm.SourceViewTextBox.TextControl;
+        var view = ViewOf(vm);
         var caretLine = view.Document.GetPosition(view.CaretOffset).Line;
 
         // The caret lands on the text of the selected paragraph - line 6 here: number, time code,
@@ -63,7 +91,7 @@ public class SourceViewEditorTests
         window.Show();
         window.UpdateLayout();
 
-        var view = (SyntaxTextView)vm.SourceViewTextBox.TextControl;
+        var view = ViewOf(vm);
         var offset = view.Document.Text.IndexOf("Second line", StringComparison.Ordinal);
         view.Select(offset, "Second line".Length);
         view.InsertText("Edited line");
@@ -75,5 +103,242 @@ public class SourceViewEditorTests
         Assert.Equal(2, subtitle.Paragraphs.Count);
 
         window.Close();
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Unsaved changes
+    // ----------------------------------------------------------------------------------------
+
+    [AvaloniaFact]
+    public void AnUntouchedSourceClosesWithoutAsking()
+    {
+        var (vm, _, _) = MakeSourceView();
+
+        // Loading the source is not an edit, and neither is only moving the caret.
+        ViewOf(vm).CaretOffset = 3;
+
+        Assert.False(vm.NeedsDiscardConfirmation);
+    }
+
+    [AvaloniaFact]
+    public void EditingTheSourceAsksBeforeThrowingTheChangesAway()
+    {
+        var (vm, _, _) = MakeSourceView();
+
+        ViewOf(vm).InsertText("x");
+
+        Assert.True(vm.NeedsDiscardConfirmation);
+    }
+
+    [AvaloniaFact]
+    public void OkNeverAsksAboutDiscarding()
+    {
+        var (vm, _, _) = MakeSourceView();
+        var window = new Window { Content = new Border { Child = vm.SourceViewTextBox.ContentControl } };
+        vm.Window = window;
+        window.Show();
+        window.UpdateLayout();
+
+        var view = ViewOf(vm);
+        view.CaretOffset = view.Document.TextLength;
+        view.InsertText("x");
+        vm.OkCommand.Execute(null);
+
+        Assert.True(vm.OkPressed);
+        Assert.False(vm.NeedsDiscardConfirmation);
+
+        window.Close();
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Live validation
+    // ----------------------------------------------------------------------------------------
+
+    [AvaloniaFact]
+    public void ValidationReportsTheLineAndSubtitleCount()
+    {
+        var (vm, _, _) = MakeSourceView();
+
+        Assert.False(vm.IsValidationError);
+        Assert.Contains("2 subtitles", vm.ValidationInfo);
+    }
+
+    [AvaloniaFact]
+    public void ValidationFlagsASourceThatNoLongerParses()
+    {
+        var (vm, _, _) = MakeSourceView();
+
+        ViewOf(vm).ReplaceAllText("this is not a subtitle at all");
+        vm.Validate();
+
+        Assert.True(vm.IsValidationError);
+        Assert.Contains("SubRip", vm.ValidationInfo);
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Find and replace
+    // ----------------------------------------------------------------------------------------
+
+    [AvaloniaFact]
+    public void FindNextSelectsTheMatchAndWrapsAround()
+    {
+        var (vm, _, _) = MakeSourceView();
+        var view = ViewOf(vm);
+
+        vm.SearchText = "line";
+        view.CaretOffset = 0;
+        view.ClearSelection();
+
+        vm.FindNextCommand.Execute(null);
+        var first = view.SelectionStart;
+        Assert.Equal("line", view.SelectedText);
+
+        vm.FindNextCommand.Execute(null);
+        var second = view.SelectionStart;
+        Assert.True(second > first);
+
+        // Only two matches, so the third search comes back around to the first one.
+        vm.FindNextCommand.Execute(null);
+        Assert.Equal(first, view.SelectionStart);
+    }
+
+    [AvaloniaFact]
+    public void FindIsCaseInsensitiveUntilMatchCaseIsTurnedOn()
+    {
+        var (vm, _, _) = MakeSourceView();
+        var view = ViewOf(vm);
+
+        vm.SearchText = "FIRST";
+        view.CaretOffset = 0;
+        view.ClearSelection();
+
+        vm.FindNextCommand.Execute(null);
+        Assert.Equal("First", view.SelectedText);
+
+        vm.MatchCase = true;
+        view.CaretOffset = 0;
+        view.ClearSelection();
+        vm.FindNextCommand.Execute(null);
+
+        Assert.Equal(0, view.SelectionLength);
+        Assert.Contains("FIRST", vm.FindStatus);
+    }
+
+    [AvaloniaFact]
+    public void WholeWordDoesNotMatchInsideAWord()
+    {
+        var (vm, _, _) = MakeSourceView();
+        var view = ViewOf(vm);
+        view.ReplaceAllText("1\r\n00:00:01,000 --> 00:00:03,000\r\nsub subtitle\r\n");
+
+        vm.SearchText = "sub";
+        vm.WholeWord = true;
+        view.CaretOffset = 0;
+        view.ClearSelection();
+
+        vm.FindNextCommand.Execute(null);
+        Assert.Equal("sub", view.SelectedText);
+
+        // "subtitle" must not count, so the next search wraps back to the same "sub".
+        var firstMatch = view.SelectionStart;
+        vm.FindNextCommand.Execute(null);
+        Assert.Equal(firstMatch, view.SelectionStart);
+    }
+
+    [AvaloniaFact]
+    public void FindPreviousWalksBackwards()
+    {
+        var (vm, _, _) = MakeSourceView();
+        var view = ViewOf(vm);
+
+        vm.SearchText = "line";
+        view.CaretOffset = view.Document.TextLength;
+        view.ClearSelection();
+
+        vm.FindPreviousCommand.Execute(null);
+        var last = view.SelectionStart;
+
+        vm.FindPreviousCommand.Execute(null);
+        Assert.True(view.SelectionStart < last);
+        Assert.Equal("line", view.SelectedText);
+    }
+
+    [AvaloniaFact]
+    public void ReplaceAllReplacesEveryMatchAsOneUndoStep()
+    {
+        var (vm, _, text) = MakeSourceView();
+        var view = ViewOf(vm);
+
+        vm.SearchText = "line";
+        vm.ReplaceText = "row";
+        vm.ReplaceAllCommand.Execute(null);
+
+        Assert.Contains("First row", view.Text);
+        Assert.Contains("Second row", view.Text);
+        Assert.Contains("2", vm.FindStatus);
+
+        view.Undo();
+        Assert.Equal(text, view.Text);
+    }
+
+    [AvaloniaFact]
+    public void ReplaceAllKeepsADollarSignLiteralOutsideRegexMode()
+    {
+        var (vm, _, _) = MakeSourceView();
+        var view = ViewOf(vm);
+
+        vm.SearchText = "First";
+        vm.ReplaceText = "$0 costs";
+        vm.ReplaceAllCommand.Execute(null);
+
+        Assert.Contains("$0 costs line", view.Text);
+    }
+
+    [AvaloniaFact]
+    public void RegexModeSubstitutesGroups()
+    {
+        var (vm, _, _) = MakeSourceView();
+        var view = ViewOf(vm);
+
+        vm.UseRegularExpression = true;
+        vm.SearchText = @"(\w+) line";
+        vm.ReplaceText = "line $1";
+        vm.ReplaceAllCommand.Execute(null);
+
+        Assert.Contains("line First", view.Text);
+        Assert.Contains("line Second", view.Text);
+    }
+
+    [AvaloniaFact]
+    public void AnInvalidRegexIsReportedInsteadOfThrowing()
+    {
+        var (vm, _, text) = MakeSourceView();
+
+        vm.UseRegularExpression = true;
+        vm.SearchText = "([unclosed";
+        vm.FindNextCommand.Execute(null);
+        vm.ReplaceAllCommand.Execute(null);
+
+        Assert.Equal(text, ViewOf(vm).Text);
+        Assert.False(string.IsNullOrEmpty(vm.FindStatus));
+    }
+
+    [AvaloniaFact]
+    public void ReplaceSwapsTheCurrentMatchAndMovesToTheNext()
+    {
+        var (vm, _, _) = MakeSourceView();
+        var view = ViewOf(vm);
+
+        vm.SearchText = "line";
+        vm.ReplaceText = "row";
+        view.CaretOffset = 0;
+        view.ClearSelection();
+
+        vm.FindNextCommand.Execute(null); // select the first "line"
+        vm.ReplaceCommand.Execute(null);
+
+        Assert.Contains("First row", view.Text);
+        Assert.Contains("Second line", view.Text);
+        Assert.Equal("line", view.SelectedText); // sitting on the next match
     }
 }


### PR DESCRIPTION
The source view was a syntax-colored text box with OK/Cancel. This gives it the things it was missing.

### Escape no longer eats your edits

`Cancel`, `Escape` and the window's close button now ask before discarding a modified source. OK never asks. The dirty flag comes off the editor's `TextChanged`, so loading the source and moving the caret don't count as edits.

### Find / replace

An inline bar below the editor rather than a dialog — a dialog on top of a dialog sits in front of the text it is searching.

- `Ctrl+F` find, `Ctrl+H` replace (`Cmd+Alt+F` on macOS, since `Cmd+H` hides the app), `F3` / `Shift+F3`, `Escape` closes the bar before the window
- Case sensitive / whole word / regular expression, freely combined; wrap-around in both directions
- Regex mode substitutes groups (`$1`, `$2`); outside it a `$` stays literal
- Selecting a word before `Ctrl+F` searches for that word

**Replace all is one undo step.** It goes through a new `SyntaxTextView.ReplaceAllText`, because assigning `Text` replaces the document behind the undo stack's back.

This does not use `IFindService` — that one is line-list-oriented over paragraphs, which is the wrong shape for a flat source buffer.

### Live parse check

The source is re-parsed shortly after you stop typing and the result goes in the status line: `142 lines, 87 subtitles`, with the format's error count appended, or a red `Could not parse as SubRip`. Previously you found out the source was broken only when you pressed OK, and got "No subtitles found!" with no hint where.

Skipped above 4 MB, where re-parsing on every pause would cost more than the editing does. Validation saves and restores `CurrentFrameRate` — a few formats read it from the header, and a background check must not leave that in the global settings.

### Go to line

`Ctrl+G`, reusing the existing `GoToLineNumberWindow`.

### Status line without the polling timer

The 200 ms `System.Timers.Timer` that recomputed line/column is gone; `SyntaxTextEditor.CaretChanged` already fires. Added selection info (`Selected: 214 characters in 6 line(s)`).

### Editor line commands

In `SyntaxTextView`, so every consumer of the control gets them:

| Shortcut | Action |
|----------|--------|
| Alt+Up / Alt+Down | Move the line or selected block |
| Ctrl+D | Duplicate |
| Ctrl+Shift+K | Delete line |
| Ctrl+Backspace / Ctrl+Delete | Delete word left / right (Option on macOS) |

Each is a single edit over the affected region: one undo step, and the lines below never move, so the view keeps its cached layouts. They're in the right-click menu too, which also gained select all, undo/redo, find, replace and go to line.

### Strings

New `LanguageSourceView` class; the find bar reuses `Se.Language.Edit.Find.*`, which were defined but unused until now. `English.json` untouched — it regenerates from the classes.

### Docs

New `docs/features/source-view.md`, linked from the index, plus a **Source View** section in the keyboard shortcuts reference.

### Testing

24 new tests (line commands incl. read-only and document-edge cases, undo grouping; dirty tracking, validation, find/replace/regex/whole-word/wrap). Full UI suite green: 1343 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
