### PR TITLE
Read stxt/sbtt text streams, tx3g style records and the MP4 VobSub palette

### DIFF
--- a/src/libse/ContainerFormats/Mp4/Boxes/Stbl.cs
+++ b/src/libse/ContainerFormats/Mp4/Boxes/Stbl.cs
@@ -2,6 +2,7 @@
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Core.VobSub;
+using SkiaSharp;
 using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
@@ -26,6 +27,12 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
         public List<Paragraph> Paragraphs;
         public List<Paragraph> GetParagraphs() => Paragraphs;
 
+        /// <summary>
+        /// Color lookup table for <see cref="SubPictures"/>, when the VobSub sample entry
+        /// carries one - null means the four default colors are used.
+        /// </summary>
+        public List<SKColor> VobSubPalette { get; private set; }
+
         private List<Cea608.CcData> _cea608CcData = new List<Cea608.CcData>();
         private Dictionary<uint, SampleToChunkMap> _stscLookup;
 
@@ -33,6 +40,9 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
         // 0xFFFFFFFF) must not expand into an OOM-sized list. Far above any real sample
         // count (5M samples is ~23 hours at 60 fps).
         private const int MaxRunLengthEntries = 5_000_000;
+
+        // Text subtitle samples are small; a larger declared size is malformed
+        private const uint MaxTextSampleSize = 10_000_000;
 
         public Stbl(Stream fs, ulong maximumLength, ulong timeScale, string handlerType, Mdia mdia)
         {
@@ -197,6 +207,11 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                 fs.Seek((long)Position, SeekOrigin.Begin);
             }
 
+            if (handlerType == "subp" && Stsd?.Name == "mp4s")
+            {
+                VobSubPalette = Mp4VobSubPalette.FromMp4sSampleEntry(Stsd.SampleEntryPayload);
+            }
+
             if (handlerType != "soun")
             {
                 Paragraphs = GetParagraphs(fs, handlerType);
@@ -359,13 +374,29 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                         }
                         else if (stsdCodec == "stpp") // TTML/IMSC1 in MP4 (ISO 14496-30)
                         {
-                            if (sampleSize <= 10_000_000)
+                            if (sampleSize <= MaxTextSampleSize)
                             {
                                 var sampleData = new byte[sampleSize];
                                 fs.Seek((long)sampleOffset, SeekOrigin.Begin);
                                 if (fs.Read(sampleData, 0, sampleData.Length) == sampleData.Length)
                                 {
                                     AddTtmlSample(sampleData, before * 1000.0, (totalTime - before) * 1000.0, paragraphs);
+                                }
+                            }
+                        }
+                        else if (Mp4TextSampleHelper.IsSimpleTextCodec(stsdCodec)) // text stream in MP4 (ISO 14496-30)
+                        {
+                            if (sampleSize <= MaxTextSampleSize)
+                            {
+                                var sampleData = new byte[sampleSize];
+                                fs.Seek((long)sampleOffset, SeekOrigin.Begin);
+                                if (fs.Read(sampleData, 0, sampleData.Length) == sampleData.Length)
+                                {
+                                    var text = Mp4TextSampleHelper.ReadSimpleTextSample(sampleData);
+                                    if (!string.IsNullOrEmpty(text))
+                                    {
+                                        paragraphs.Add(new Paragraph(text, before * 1000.0, totalTime * 1000.0));
+                                    }
                                 }
                             }
                         }
@@ -389,24 +420,33 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                                         buffer = new byte[textSize + 2];
                                         fs.Seek((long)sampleOffset, SeekOrigin.Begin);
                                         fs.ReadFully(buffer, 0, buffer.Length);
-                                        SubPictures.Add(new SubPicture(buffer)); // TODO: Where is palette?
+                                        SubPictures.Add(new SubPicture(buffer));
                                         paragraphs.Add(p);
                                     }
                                 }
-                                else
+                                else if (_mdia.IsClosedCaption)
                                 {
                                     buffer = new byte[textSize];
                                     fs.ReadFully(buffer, 0, buffer.Length);
-                                    p.Text = GetString(buffer, 0, (int)textSize).TrimEnd();
-
-                                    if (_mdia.IsClosedCaption)
-                                    {
-                                        p.Text = MakeScenaristText(buffer);
-                                    }
+                                    p.Text = MakeScenaristText(buffer);
 
                                     if (!string.IsNullOrEmpty(p.Text))
                                     {
                                         paragraphs.Add(p);
+                                    }
+                                }
+                                else if (sampleSize <= MaxTextSampleSize)
+                                {
+                                    // the whole sample, so the tx3g modifier boxes after the text can be read too
+                                    var sampleData = new byte[sampleSize];
+                                    fs.Seek((long)sampleOffset, SeekOrigin.Begin);
+                                    if (fs.Read(sampleData, 0, sampleData.Length) == sampleData.Length)
+                                    {
+                                        p.Text = Mp4TextSampleHelper.ReadTx3gSampleText(sampleData);
+                                        if (!string.IsNullOrEmpty(p.Text))
+                                        {
+                                            paragraphs.Add(p);
+                                        }
                                     }
                                 }
                             }

--- a/src/libse/ContainerFormats/Mp4/Boxes/Stsd.cs
+++ b/src/libse/ContainerFormats/Mp4/Boxes/Stsd.cs
@@ -5,7 +5,17 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
 {
     public class Stsd : Box
     {
+        // Sample entries are small (codec configuration only) - a larger one is malformed
+        private const int MaxSampleEntryPayload = 64 * 1024;
+
         public uint NumberOfEntries { get; set; }
+
+        /// <summary>
+        /// The sample entry that <see cref="Box.Name"/> describes, without its 8-byte box
+        /// header, e.g. for reading the VobSub palette out of an "mp4s" entry.
+        /// </summary>
+        public byte[] SampleEntryPayload { get; private set; }
+
         public Stsd(Stream fs, ulong maximumLength)
         {
             Position = (ulong)fs.Position;
@@ -19,6 +29,14 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                 if (!InitializeSizeAndName(fs))
                 {
                     return;
+                }
+
+                SampleEntryPayload = null;
+                if (Size > 8 && Size <= MaxSampleEntryPayload && (ulong)fs.Position + Size - 8 <= (ulong)fs.Length)
+                {
+                    var payload = new byte[Size - 8];
+                    fs.ReadFully(payload, 0, payload.Length);
+                    SampleEntryPayload = payload;
                 }
 
                 fs.Seek((long)Position, SeekOrigin.Begin);

--- a/src/libse/ContainerFormats/Mp4/Mp4FragmentedSubtitleTrack.cs
+++ b/src/libse/ContainerFormats/Mp4/Mp4FragmentedSubtitleTrack.cs
@@ -13,7 +13,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
 
         public string Language { get; set; }
 
-        /// <summary>Sample codec: "wvtt", "stpp" or "tx3g".</summary>
+        /// <summary>Sample codec: "wvtt", "stpp", "tx3g", "stxt" or "sbtt".</summary>
         public string Codec { get; set; }
 
         public Subtitle Subtitle { get; set; } = new Subtitle();

--- a/src/libse/ContainerFormats/Mp4/Mp4Parser.cs
+++ b/src/libse/ContainerFormats/Mp4/Mp4Parser.cs
@@ -23,7 +23,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
         public string VttcLanguage { get; private set; }
 
         /// <summary>
-        /// Sample codec of <see cref="VttcSubtitle"/>: "wvtt", "stpp" or "tx3g".
+        /// Sample codec of <see cref="VttcSubtitle"/>: "wvtt", "stpp", "tx3g", "stxt" or "sbtt".
         /// </summary>
         public string VttcCodec { get; private set; }
 
@@ -610,7 +610,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
             public uint? TrackId { get; set; }
             public Subtitle Subtitle { get; } = new Subtitle();
             public string Language { get; set; }
-            public string Codec { get; set; } // "wvtt", "stpp" or "tx3g"
+            public string Codec { get; set; } // "wvtt", "stpp", "tx3g", "stxt" or "sbtt"
             public double LegacyTimeTotalMs; // running clock for fragments without data offsets
             public long NextTicks; // running decode time for fragments without tfdt
             public HashSet<string> AddedTtmlCues { get; } = new HashSet<string>();
@@ -777,7 +777,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
         }
 
         /// <summary>
-        /// Text subtitle samples (wvtt/stpp/tx3g) from the pending moof's track fragments.
+        /// Text subtitle samples (wvtt/stpp/tx3g/stxt/sbtt) from the pending moof's track fragments.
         /// Slices exact sample byte ranges via trun data offsets and sizes, so it also works
         /// for muxed fMP4 where the mdat interleaves video/audio/subtitle data. Falls back
         /// to scanning the mdat for WebVTT cue boxes when no offsets are available.
@@ -921,6 +921,10 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
             {
                 ReadStppSample(sample, startMs, durationMs, track);
             }
+            else if (Mp4TextSampleHelper.IsSimpleTextCodec(kind))
+            {
+                ReadSimpleTextSample(sample, startMs, durationMs, track);
+            }
             else if (kind != null)
             {
                 ReadTx3gSample(sample, startMs, durationMs, track); // tx3g / generic MPEG-4 timed text
@@ -930,7 +934,8 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
         /// <summary>
         /// Codec guess for a subtitle sample when no moov is available (a lone DASH .m4s
         /// segment without its init file): wvtt samples are ISO-BMFF boxes, stpp samples
-        /// are TTML XML documents, tx3g samples are a 16-bit length + UTF-8 text.
+        /// are TTML XML documents, tx3g samples are a 16-bit length + UTF-8 text, and
+        /// anything left that is readable text is treated as an stxt/sbtt text stream.
         /// </summary>
         private static string SniffTextSampleKind(byte[] sample)
         {
@@ -985,7 +990,46 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
                 }
             }
 
-            return null;
+            return IsPlainText(sample) ? "stxt" : null;
+        }
+
+        /// <summary>
+        /// Whether the whole sample is readable text, i.e. valid UTF-8 without control
+        /// characters. Last resort of <see cref="SniffTextSampleKind"/>, so it must not
+        /// accept the binary samples of the codecs checked before it.
+        /// </summary>
+        private static bool IsPlainText(byte[] sample)
+        {
+            if (sample.Length == 0)
+            {
+                return false;
+            }
+
+            string text;
+            try
+            {
+                text = new UTF8Encoding(false, true).GetString(sample);
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+
+            var letters = 0;
+            foreach (var ch in text)
+            {
+                if (char.IsControl(ch) && ch != '\r' && ch != '\n' && ch != '\t')
+                {
+                    return false;
+                }
+
+                if (!char.IsWhiteSpace(ch))
+                {
+                    letters++;
+                }
+            }
+
+            return letters > 0;
         }
 
         private static void ReadWvttSample(byte[] sample, double startMs, double durationMs, FragmentedTextTrack track)
@@ -1089,18 +1133,32 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
 
         private static void ReadTx3gSample(byte[] sample, double startMs, double durationMs, FragmentedTextTrack track)
         {
-            if (sample.Length < 2 || durationMs <= 0)
+            if (durationMs <= 0)
             {
                 return;
             }
 
-            int textSize = System.Buffers.Binary.BinaryPrimitives.ReadUInt16BigEndian(sample.AsSpan(0, 2));
-            if (textSize == 0 || textSize > sample.Length - 2)
+            var text = Mp4TextSampleHelper.ReadTx3gSampleText(sample);
+            if (string.IsNullOrEmpty(text))
             {
                 return;
             }
 
-            var text = GetString(sample, 2, textSize).TrimEnd();
+            track.Subtitle.Paragraphs.Add(new Paragraph(text, startMs, startMs + durationMs));
+        }
+
+        /// <summary>
+        /// "stxt"/"sbtt" text stream samples (ISO/IEC 14496-30) - the sample is the text
+        /// itself, with no 16-bit length in front of it like tx3g has.
+        /// </summary>
+        private static void ReadSimpleTextSample(byte[] sample, double startMs, double durationMs, FragmentedTextTrack track)
+        {
+            if (durationMs <= 0)
+            {
+                return;
+            }
+
+            var text = Mp4TextSampleHelper.ReadSimpleTextSample(sample);
             if (string.IsNullOrEmpty(text))
             {
                 return;

--- a/src/libse/ContainerFormats/Mp4/Mp4TextSampleHelper.cs
+++ b/src/libse/ContainerFormats/Mp4/Mp4TextSampleHelper.cs
@@ -1,0 +1,312 @@
+using Nikse.SubtitleEdit.Core.Common;
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
+{
+    /// <summary>
+    /// Readers for the plain-text subtitle sample formats in MP4, shared by the progressive
+    /// (stbl) and the fragmented (moof) parsers: 3GPP timed text ("tx3g") and the ISO/IEC
+    /// 14496-30 text streams ("stxt" and "sbtt").
+    /// </summary>
+    public static class Mp4TextSampleHelper
+    {
+        private static readonly char[] LineBreakChars = { '\r', '\n' };
+
+        /// <summary>
+        /// True for the ISO/IEC 14496-30 text stream sample entries, where the sample is the
+        /// text itself - unlike tx3g there is no 16-bit length in front of it. MP4Box writes
+        /// these for <c>:sopt:stxtmod=stxt</c> ("stxt", markup stripped) and
+        /// <c>:sopt:stxtmod=sbtt</c> ("sbtt", markup kept).
+        /// </summary>
+        public static bool IsSimpleTextCodec(string stsdCodec)
+        {
+            return stsdCodec == "stxt" || stsdCodec == "sbtt";
+        }
+
+        /// <summary>
+        /// An "stxt"/"sbtt" sample is the whole text of one cue, UTF-8 or UTF-16 with BOM.
+        /// </summary>
+        public static string ReadSimpleTextSample(byte[] sample)
+        {
+            if (sample == null || sample.Length == 0)
+            {
+                return null;
+            }
+
+            var length = sample.Length;
+            while (length > 0 && sample[length - 1] == 0) // some writers pad the sample with NULs
+            {
+                length--;
+            }
+
+            if (length == 0)
+            {
+                return null;
+            }
+
+            return NormalizeLineBreaks(DecodeText(sample, 0, length))?.TrimEnd();
+        }
+
+        /// <summary>
+        /// A tx3g sample is a 16-bit text length, the text itself, then optional modifier
+        /// boxes (styl/hlit/hclr/...). Style records are turned into the markup tags used
+        /// by the rest of Subtitle Edit.
+        /// </summary>
+        public static string ReadTx3gSampleText(byte[] sample)
+        {
+            if (sample == null || sample.Length < 2)
+            {
+                return null;
+            }
+
+            int textSize = BinaryPrimitives.ReadUInt16BigEndian(sample.AsSpan(0, 2));
+            if (textSize == 0 || textSize > sample.Length - 2)
+            {
+                return null;
+            }
+
+            // styl offsets index the raw text, so styling must be applied before the line
+            // breaks are normalized (that can change the character count)
+            var text = DecodeText(sample, 2, textSize);
+            if (string.IsNullOrEmpty(text))
+            {
+                return null;
+            }
+
+            text = ApplyStyleRecords(text, sample, 2 + textSize);
+            return NormalizeLineBreaks(text)?.TrimEnd();
+        }
+
+        private static string DecodeText(byte[] data, int index, int count)
+        {
+            if (count <= 0)
+            {
+                return string.Empty;
+            }
+
+            // 3GPP TS 26.245 allows UTF-16 text, which is then prefixed with a BOM
+            if (count >= 2 && data[index] == 0xFE && data[index + 1] == 0xFF)
+            {
+                return Encoding.BigEndianUnicode.GetString(data, index + 2, count - 2);
+            }
+
+            if (count >= 2 && data[index] == 0xFF && data[index + 1] == 0xFE)
+            {
+                return Encoding.Unicode.GetString(data, index + 2, count - 2);
+            }
+
+            if (count >= 3 && data[index] == 0xEF && data[index + 1] == 0xBB && data[index + 2] == 0xBF)
+            {
+                index += 3;
+                count -= 3;
+            }
+
+            return Encoding.UTF8.GetString(data, index, count);
+        }
+
+        private static string NormalizeLineBreaks(string text)
+        {
+            if (text == null || text.IndexOfAny(LineBreakChars) < 0)
+            {
+                return text;
+            }
+
+            return string.Join(Environment.NewLine, text.SplitToLines());
+        }
+
+        /// <summary>
+        /// Wraps the parts of the text covered by "styl" records in italic/bold/underline
+        /// and font color tags. Records may overlap, so the style is resolved per character
+        /// and tags are opened and closed where it changes.
+        /// </summary>
+        private static string ApplyStyleRecords(string text, byte[] sample, int index)
+        {
+            var records = ReadStyleRecords(sample, index);
+            if (records == null)
+            {
+                return text;
+            }
+
+            var styles = new StyleRecord[text.Length];
+            var styled = false;
+            foreach (var record in records)
+            {
+                if (!record.HasStyle)
+                {
+                    continue;
+                }
+
+                var start = Math.Max(0, record.StartChar);
+                var end = Math.Min(text.Length, record.EndChar);
+                for (var i = start; i < end; i++)
+                {
+                    styles[i] = styles[i].Merge(record);
+                    styled = true;
+                }
+            }
+
+            if (!styled)
+            {
+                return text;
+            }
+
+            var sb = new StringBuilder(text.Length + 16);
+            var current = new StyleRecord();
+            for (var i = 0; i < text.Length; i++)
+            {
+                var next = styles[i];
+                if (!next.Equals(current))
+                {
+                    AppendCloseTags(sb, current);
+                    AppendOpenTags(sb, next);
+                    current = next;
+                }
+
+                sb.Append(text[i]);
+            }
+
+            AppendCloseTags(sb, current);
+            return sb.ToString();
+        }
+
+        private static void AppendOpenTags(StringBuilder sb, StyleRecord style)
+        {
+            if (style.Color != null)
+            {
+                sb.Append("<font color=\"").Append(style.Color).Append("\">");
+            }
+
+            if (style.Bold)
+            {
+                sb.Append("<b>");
+            }
+
+            if (style.Italic)
+            {
+                sb.Append("<i>");
+            }
+
+            if (style.Underline)
+            {
+                sb.Append("<u>");
+            }
+        }
+
+        private static void AppendCloseTags(StringBuilder sb, StyleRecord style)
+        {
+            if (style.Underline)
+            {
+                sb.Append("</u>");
+            }
+
+            if (style.Italic)
+            {
+                sb.Append("</i>");
+            }
+
+            if (style.Bold)
+            {
+                sb.Append("</b>");
+            }
+
+            if (style.Color != null)
+            {
+                sb.Append("</font>");
+            }
+        }
+
+        /// <summary>
+        /// The "styl" box among the tx3g modifier boxes: a 16-bit record count followed by
+        /// 12-byte records. QuickTime text tracks use the same box name with 14-byte records,
+        /// so the record count must account for the whole box or the box is left alone.
+        /// </summary>
+        private static List<StyleRecord> ReadStyleRecords(byte[] sample, int index)
+        {
+            const int recordSize = 12;
+            List<StyleRecord> records = null;
+            while (index + 8 <= sample.Length)
+            {
+                var boxSize = (long)BinaryPrimitives.ReadUInt32BigEndian(sample.AsSpan(index, 4));
+                if (boxSize < 8 || index + boxSize > sample.Length)
+                {
+                    break;
+                }
+
+                if (Encoding.ASCII.GetString(sample, index + 4, 4) == "styl" && boxSize >= 10)
+                {
+                    int count = BinaryPrimitives.ReadUInt16BigEndian(sample.AsSpan(index + 8, 2));
+                    if (10 + count * recordSize == boxSize)
+                    {
+                        records = records ?? new List<StyleRecord>(count);
+                        for (var i = 0; i < count; i++)
+                        {
+                            var entry = index + 10 + i * recordSize;
+                            records.Add(new StyleRecord
+                            {
+                                StartChar = BinaryPrimitives.ReadUInt16BigEndian(sample.AsSpan(entry, 2)),
+                                EndChar = BinaryPrimitives.ReadUInt16BigEndian(sample.AsSpan(entry + 2, 2)),
+                                Bold = (sample[entry + 6] & 1) != 0,
+                                Italic = (sample[entry + 6] & 2) != 0,
+                                Underline = (sample[entry + 6] & 4) != 0,
+                                Color = GetColor(sample, entry + 8),
+                            });
+                        }
+                    }
+                }
+
+                index += (int)boxSize;
+            }
+
+            return records;
+        }
+
+        /// <summary>
+        /// Text color as RGBA. White and fully transparent colors are the tx3g default and
+        /// are left out, so an ordinary subtitle does not get a font tag on every line.
+        /// </summary>
+        private static string GetColor(byte[] sample, int index)
+        {
+            var r = sample[index];
+            var g = sample[index + 1];
+            var b = sample[index + 2];
+            var a = sample[index + 3];
+            if (a == 0 || (r == 0xFF && g == 0xFF && b == 0xFF))
+            {
+                return null;
+            }
+
+            return $"#{r:x2}{g:x2}{b:x2}";
+        }
+
+        private struct StyleRecord
+        {
+            public int StartChar;
+            public int EndChar;
+            public bool Bold;
+            public bool Italic;
+            public bool Underline;
+            public string Color;
+
+            public bool HasStyle => Bold || Italic || Underline || Color != null;
+
+            public StyleRecord Merge(StyleRecord other)
+            {
+                return new StyleRecord
+                {
+                    Bold = Bold || other.Bold,
+                    Italic = Italic || other.Italic,
+                    Underline = Underline || other.Underline,
+                    Color = Color ?? other.Color,
+                };
+            }
+
+            public bool Equals(StyleRecord other)
+            {
+                return Bold == other.Bold && Italic == other.Italic && Underline == other.Underline && Color == other.Color;
+            }
+        }
+    }
+}

--- a/src/libse/ContainerFormats/Mp4/Mp4VobSubPalette.cs
+++ b/src/libse/ContainerFormats/Mp4/Mp4VobSubPalette.cs
@@ -1,0 +1,142 @@
+using Nikse.SubtitleEdit.Core.BluRaySup;
+using SkiaSharp;
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
+{
+    /// <summary>
+    /// The DVD color lookup table of a VobSub track in an MP4 (handler "subp"). MP4Box puts
+    /// the 16 palette entries of the source idx file in the decoder specific info of the
+    /// "mp4s" sample entry, as the DVD stores them: 4 bytes per entry, (0, Y, Cr, Cb).
+    /// </summary>
+    public static class Mp4VobSubPalette
+    {
+        private const int PaletteEntries = 16;
+
+        /// <summary>
+        /// Palette from an "mp4s" sample entry payload (everything after the 8-byte box
+        /// header), or null when the entry carries no usable palette.
+        /// </summary>
+        public static List<SKColor> FromMp4sSampleEntry(byte[] payload)
+        {
+            if (payload == null)
+            {
+                return null;
+            }
+
+            var index = 8; // 6 reserved bytes + 2 bytes data reference index
+            while (index + 8 <= payload.Length)
+            {
+                var boxSize = (long)BinaryPrimitives.ReadUInt32BigEndian(payload.AsSpan(index, 4));
+                if (boxSize < 8 || index + boxSize > payload.Length)
+                {
+                    return null;
+                }
+
+                if (Encoding.ASCII.GetString(payload, index + 4, 4) == "esds" && boxSize > 12 &&
+                    TryFindDecoderSpecificInfo(payload, index + 12, index + (int)boxSize, out var offset, out var length))
+                {
+                    return FromDecoderSpecificInfo(payload, offset, length);
+                }
+
+                index += (int)boxSize;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Walks the MPEG-4 descriptors of an esds box down to the DecoderSpecificInfo (tag 5).
+        /// </summary>
+        private static bool TryFindDecoderSpecificInfo(byte[] data, int index, int end, out int dsiOffset, out int dsiLength)
+        {
+            dsiOffset = 0;
+            dsiLength = 0;
+            while (index < end)
+            {
+                var tag = data[index];
+                index++;
+
+                var length = 0;
+                var sizeByte = 0x80;
+                for (var i = 0; i < 4 && (sizeByte & 0x80) != 0 && index < end; i++)
+                {
+                    sizeByte = data[index];
+                    index++;
+                    length = (length << 7) | (sizeByte & 0x7F);
+                }
+
+                if (length < 0 || index + length > end)
+                {
+                    return false;
+                }
+
+                switch (tag)
+                {
+                    case 0x03: // ES_Descriptor - descend past ES_ID and the optional fields its flags announce
+                        if (index + 3 > end)
+                        {
+                            return false;
+                        }
+
+                        var flags = data[index + 2];
+                        index += 3;
+                        if ((flags & 0x80) != 0)
+                        {
+                            index += 2; // dependsOn_ES_ID
+                        }
+
+                        if ((flags & 0x40) != 0)
+                        {
+                            if (index >= end)
+                            {
+                                return false;
+                            }
+
+                            index += 1 + data[index]; // URL
+                        }
+
+                        if ((flags & 0x20) != 0)
+                        {
+                            index += 2; // OCR_ES_ID
+                        }
+
+                        break;
+                    case 0x04: // DecoderConfigDescriptor - descend past the fixed 13 byte header
+                        index += 13;
+                        break;
+                    case 0x05: // DecoderSpecificInfo
+                        dsiOffset = index;
+                        dsiLength = length;
+                        return true;
+                    default:
+                        index += length;
+                        break;
+                }
+            }
+
+            return false;
+        }
+
+        private static List<SKColor> FromDecoderSpecificInfo(byte[] data, int offset, int length)
+        {
+            if (length < PaletteEntries * 4)
+            {
+                return null;
+            }
+
+            var palette = new List<SKColor>(PaletteEntries);
+            for (var i = 0; i < PaletteEntries; i++)
+            {
+                var entry = offset + i * 4;
+                var rgb = BluRaySupPalette.YCbCr2Rgb(data[entry + 1], data[entry + 3], data[entry + 2], true);
+                palette.Add(new SKColor((byte)rgb[0], (byte)rgb[1], (byte)rgb[2]));
+            }
+
+            return palette;
+        }
+    }
+}

--- a/src/seconv/Core/BitmapSubtitleLoader.cs
+++ b/src/seconv/Core/BitmapSubtitleLoader.cs
@@ -319,19 +319,21 @@ internal static class BitmapSubtitleLoader
     /// VobSub track inside an MP4 (handler type <c>subp</c>, e.g. produced by MP4Box) →
     /// bitmap events. The decoded subpictures and their timing are parsed by libse's
     /// <see cref="Stbl"/>; index <c>i</c> of <c>SubPictures</c> lines up with paragraph
-    /// <c>i</c>. Mirrors the desktop <c>OcrSubtitleMp4VobSub</c> (palette left to default).
+    /// <c>i</c>. Mirrors the desktop <c>OcrSubtitleMp4VobSub</c>, including the CLUT from
+    /// the sample entry when the track has one.
     /// </summary>
     public static IReadOnlyList<BitmapSubtitleItem> LoadMp4VobSub(Trak track)
     {
         var paragraphs = track.Mdia.Minf.Stbl.GetParagraphs();
         var subPictures = track.Mdia.Minf.Stbl.SubPictures;
+        var palette = track.Mdia.Minf.Stbl.VobSubPalette;
         var count = Math.Min(paragraphs.Count, subPictures.Count);
 
         var items = new List<BitmapSubtitleItem>(count);
         for (var i = 0; i < count; i++)
         {
             var bmp = subPictures[i].GetBitmap(
-                null, SKColors.Transparent, SKColors.Black, SKColors.White, SKColors.Black, false);
+                palette, SKColors.Transparent, SKColors.Black, SKColors.White, SKColors.Black, false);
             if (bmp is null)
             {
                 continue;

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleMp4VobSub.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleMp4VobSub.cs
@@ -22,7 +22,8 @@ public class OcrSubtitleMp4VobSub : IOcrSubtitle
 
     public SKBitmap GetBitmap(int index)
     {
-        return _mp4SubtitleTrack.Mdia.Minf.Stbl.SubPictures[index].GetBitmap(null, SKColors.Transparent, SKColors.Black, SKColors.White, SKColors.Black, false);
+        var stbl = _mp4SubtitleTrack.Mdia.Minf.Stbl;
+        return stbl.SubPictures[index].GetBitmap(stbl.VobSubPalette, SKColors.Transparent, SKColors.Black, SKColors.White, SKColors.Black, false);
     }
 
     public TimeSpan GetStartTime(int index)

--- a/src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs
+++ b/src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs
@@ -148,6 +148,7 @@ public partial class PickMp4TrackViewModel : ObservableObject
 
             var paragraphs = track.Mdia.Minf.Stbl.GetParagraphs();
             var subPictures = track.Mdia.Minf.Stbl.SubPictures;
+            var palette = track.Mdia.Minf.Stbl.VobSubPalette;
             var count = Math.Min(paragraphs.Count, subPictures.Count);
             if (count == 0)
             {
@@ -176,7 +177,7 @@ public partial class PickMp4TrackViewModel : ObservableObject
                 var paragraph = paragraphs[i];
                 exportHandler.WriteParagraph(new ImageParameter
                 {
-                    Bitmap = subPicture.GetBitmap(null, SKColors.Transparent, SKColors.Black, SKColors.White, SKColors.Black, false),
+                    Bitmap = subPicture.GetBitmap(palette, SKColors.Transparent, SKColors.Black, SKColors.White, SKColors.Black, false),
                     StartTime = TimeSpan.FromMilliseconds(paragraph.StartTime.TotalMilliseconds),
                     EndTime = TimeSpan.FromMilliseconds(paragraph.EndTime.TotalMilliseconds),
                     ScreenWidth = screenWidth,
@@ -268,7 +269,7 @@ public partial class PickMp4TrackViewModel : ObservableObject
 
             if (selectedTrack.IsVobSubSubtitle && selectedTrack.Track is { } trackinfo)
             {
-                cue.Image = new Image { Source = trackinfo.Mdia.Minf.Stbl.SubPictures[i - 1].GetBitmap(null, SKColors.Transparent, SKColors.Black, SKColors.White, SKColors.Black, false).ToAvaloniaBitmap() };
+                cue.Image = new Image { Source = trackinfo.Mdia.Minf.Stbl.SubPictures[i - 1].GetBitmap(trackinfo.Mdia.Minf.Stbl.VobSubPalette, SKColors.Transparent, SKColors.Black, SKColors.White, SKColors.Black, false).ToAvaloniaBitmap() };
             }
             else
             {

--- a/tests/libse/ContainerFormats/Mp4TextSampleTest.cs
+++ b/tests/libse/ContainerFormats/Mp4TextSampleTest.cs
@@ -1,0 +1,202 @@
+using Nikse.SubtitleEdit.Core.ContainerFormats.Mp4;
+using Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes;
+using System.Text;
+
+namespace LibSETests.ContainerFormats;
+
+public class Mp4TextSampleTest
+{
+    private static byte[] MakeBox(string name, params byte[][] content)
+    {
+        var payload = content.SelectMany(b => b).ToArray();
+        var size = 8 + payload.Length;
+        var bytes = new List<byte>
+        {
+            (byte)(size >> 24), (byte)(size >> 16), (byte)(size >> 8), (byte)size,
+        };
+        bytes.AddRange(Encoding.ASCII.GetBytes(name));
+        bytes.AddRange(payload);
+        return bytes.ToArray();
+    }
+
+    private static byte[] UInt32(uint value) => new[] { (byte)(value >> 24), (byte)(value >> 16), (byte)(value >> 8), (byte)value };
+
+    private static byte[] UInt16(int value) => new[] { (byte)(value >> 8), (byte)value };
+
+    /// <summary>
+    /// tx3g sample: 16-bit text length, the UTF-8 text, then the modifier boxes.
+    /// </summary>
+    private static byte[] Tx3gSample(string text, params byte[][] modifierBoxes)
+    {
+        var textBytes = Encoding.UTF8.GetBytes(text);
+        return UInt16(textBytes.Length).Concat(textBytes).Concat(modifierBoxes.SelectMany(b => b)).ToArray();
+    }
+
+    private static byte[] StylBox(params byte[][] records) => MakeBox("styl", UInt16(records.Length), records.SelectMany(r => r).ToArray());
+
+    private static byte[] StylRecord(int startChar, int endChar, byte faceStyle, uint rgba = 0xFFFFFFFF)
+    {
+        return UInt16(startChar).Concat(UInt16(endChar))
+            .Concat(UInt16(1))                     // font id
+            .Concat(new[] { faceStyle, (byte)18 }) // face style flags + font size
+            .Concat(UInt32(rgba)).ToArray();
+    }
+
+    // An "stxt"/"sbtt" sample is the text itself. Reading it as a tx3g sample ate the first
+    // two characters as a length and then ran past the end of the sample.
+    [Fact]
+    public void SimpleTextSampleIsTheWholeSample()
+    {
+        var sample = Encoding.UTF8.GetBytes("Hello world");
+
+        Assert.Equal("Hello world", Mp4TextSampleHelper.ReadSimpleTextSample(sample));
+    }
+
+    [Fact]
+    public void SimpleTextSampleKeepsMarkupAndSkipsPadding()
+    {
+        var sample = Encoding.UTF8.GetBytes("Hello <i>world</i>").Concat(new byte[] { 0, 0 }).ToArray();
+
+        Assert.Equal("Hello <i>world</i>", Mp4TextSampleHelper.ReadSimpleTextSample(sample));
+    }
+
+    [Theory]
+    [InlineData("stxt", true)]
+    [InlineData("sbtt", true)]
+    [InlineData("tx3g", false)]
+    [InlineData("wvtt", false)]
+    [InlineData(null, false)]
+    public void SimpleTextCodecsAreRecognized(string? codec, bool expected)
+    {
+        Assert.Equal(expected, Mp4TextSampleHelper.IsSimpleTextCodec(codec));
+    }
+
+    [Fact]
+    public void Tx3gSampleWithoutStyleIsPlainText()
+    {
+        Assert.Equal("Hello world", Mp4TextSampleHelper.ReadTx3gSampleText(Tx3gSample("Hello world")));
+    }
+
+    [Fact]
+    public void Tx3gSampleLongerThanTheTextIsRejected()
+    {
+        var sample = new byte[] { 0xFF, 0xFF, (byte)'a', (byte)'b' }; // declares 65535 bytes of text
+
+        Assert.Null(Mp4TextSampleHelper.ReadTx3gSampleText(sample));
+    }
+
+    // styl offsets count characters, not bytes, so non-ASCII text must not shift them.
+    [Fact]
+    public void Tx3gStyleRecordMakesItalic()
+    {
+        var sample = Tx3gSample("Héllö wörld end", StylBox(StylRecord(6, 11, 2)));
+
+        Assert.Equal("Héllö <i>wörld</i> end", Mp4TextSampleHelper.ReadTx3gSampleText(sample));
+    }
+
+    [Fact]
+    public void Tx3gStyleRecordsCombine()
+    {
+        var sample = Tx3gSample("bold and italic", StylBox(StylRecord(0, 4, 1), StylRecord(9, 15, 2 | 4)));
+
+        Assert.Equal("<b>bold</b> and <i><u>italic</u></i>", Mp4TextSampleHelper.ReadTx3gSampleText(sample));
+    }
+
+    [Fact]
+    public void Tx3gStyleRecordWithColor()
+    {
+        var sample = Tx3gSample("red text", StylBox(StylRecord(0, 3, 0, 0xFF0000FF)));
+
+        Assert.Equal("<font color=\"#ff0000\">red</font> text", Mp4TextSampleHelper.ReadTx3gSampleText(sample));
+    }
+
+    // White is the tx3g default color - tagging every cue with it would be noise.
+    [Fact]
+    public void Tx3gDefaultWhiteStyleRecordAddsNoTags()
+    {
+        var sample = Tx3gSample("plain text", StylBox(StylRecord(0, 5, 0)));
+
+        Assert.Equal("plain text", Mp4TextSampleHelper.ReadTx3gSampleText(sample));
+    }
+
+    // QuickTime text tracks use "styl" too, but with 14-byte records - misreading those as
+    // tx3g records would style arbitrary parts of the text.
+    [Fact]
+    public void QuickTimeStyleRecordsAreIgnored()
+    {
+        var quickTimeRecord = UInt16(0).Concat(UInt16(4)).Concat(UInt16(1))
+            .Concat(new byte[] { 2, 18 })
+            .Concat(new byte[] { 0, 0, 0, 0, 0, 0 }) // QuickTime uses a 6 byte color
+            .ToArray();
+        var sample = Tx3gSample("Hello world", MakeBox("styl", UInt16(1), quickTimeRecord));
+
+        Assert.Equal("Hello world", Mp4TextSampleHelper.ReadTx3gSampleText(sample));
+    }
+
+    // The full stbl path: an "stxt" track with one sample, its text stored after the boxes.
+    [Fact]
+    public void StblReadsSimpleTextTrack()
+    {
+        var text = Encoding.UTF8.GetBytes("Hello world");
+        var boxes = new[]
+        {
+            MakeBox("stsd", UInt32(0), UInt32(1), MakeBox("stxt", new byte[6], UInt16(1), new byte[] { 0, 0 })),
+            MakeBox("stts", UInt32(0), UInt32(1), UInt32(1), UInt32(1000)),
+            MakeBox("stsc", UInt32(0), UInt32(1), UInt32(1), UInt32(1), UInt32(1)),
+            MakeBox("stsz", UInt32(0), UInt32(0), UInt32(1), UInt32((uint)text.Length)),
+        }.SelectMany(b => b).ToList();
+        const int stcoBoxSize = 8 + 4 + 4 + 4; // the text starts right after the stco box
+        boxes.AddRange(MakeBox("stco", UInt32(0), UInt32(1), UInt32((uint)(boxes.Count + stcoBoxSize))));
+
+        using var ms = new MemoryStream(boxes.Concat(text).ToArray());
+        var stbl = new Stbl(ms, (ulong)boxes.Count, 1000, "text", null);
+
+        var paragraphs = stbl.GetParagraphs();
+        Assert.Single(paragraphs);
+        Assert.Equal("Hello world", paragraphs[0].Text);
+        Assert.Equal(0, paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(1000, paragraphs[0].EndTime.TotalMilliseconds);
+    }
+
+    // MP4Box stores the idx palette in the esds of the "mp4s" sample entry, as the DVD
+    // stores it: 4 bytes per entry, (0, Y, Cr, Cb).
+    [Fact]
+    public void VobSubPaletteIsReadFromSampleEntry()
+    {
+        var dsi = new List<byte>();
+        dsi.AddRange(new byte[] { 0x00, 0x10, 0x80, 0x80 }); // black
+        dsi.AddRange(new byte[] { 0x00, 0xde, 0x80, 0x80 }); // near white
+        while (dsi.Count < 64)
+        {
+            dsi.Add(0);
+        }
+
+        var esds = MakeBox("esds",
+            UInt32(0),                                         // version + flags
+            new byte[] { 0x03, (byte)(3 + 2 + 15 + 64) },      // ES_Descriptor
+            new byte[] { 0x00, 0x00, 0x00 },                   // ES_ID + flags
+            new byte[] { 0x04, (byte)(13 + 2 + 64) },          // DecoderConfigDescriptor
+            new byte[13],                                      // object type, stream type, buffer size, bitrates
+            new byte[] { 0x05, 64 },                           // DecoderSpecificInfo
+            dsi.ToArray());
+        var sampleEntryPayload = new byte[6].Concat(UInt16(1)).Concat(esds).ToArray();
+
+        var palette = Mp4VobSubPalette.FromMp4sSampleEntry(sampleEntryPayload);
+
+        Assert.NotNull(palette);
+        Assert.Equal(16, palette!.Count);
+        Assert.Equal(0x00, palette[0].Red);
+        Assert.Equal(0x00, palette[0].Green);
+        Assert.Equal(0x00, palette[0].Blue);
+        Assert.InRange(palette[1].Red, 0xee, 0xf2);
+        Assert.InRange(palette[1].Green, 0xee, 0xf2);
+        Assert.InRange(palette[1].Blue, 0xee, 0xf2);
+    }
+
+    [Fact]
+    public void VobSubPaletteIsNullWithoutEsds()
+    {
+        Assert.Null(Mp4VobSubPalette.FromMp4sSampleEntry(new byte[6].Concat(UInt16(1)).ToArray()));
+        Assert.Null(Mp4VobSubPalette.FromMp4sSampleEntry(null));
+    }
+}


### PR DESCRIPTION
Testing which subtitle types MP4Box (GPAC 26.02) can put in an MP4, and running each through `MP4Parser`, turned up one real gap and two smaller ones.

## stxt / sbtt were read as tx3g

`stxt` (simple text) and `sbtt` (subtitle text) samples are the text itself — ISO/IEC 14496-30 has no 16-bit length in front of them like tx3g does. Both fell into the generic tx3g branch, so the first two characters were consumed as a length and the reader ran past the end of the sample. `MP4Box -add sub.srt:sopt:stxtmod=stxt` came out as:

```
[1,000 -> 3,000] llo world....A..E.,/...........-tB.........
[4,000 -> 6,500] cond line | with two rows....A..E.,/........
```

Worse than no support: the track was listed as valid and the user got truncated text plus binary junk. The fragmented/DASH variants had the same blind spot but failed silently (no track at all).

The new `Mp4TextSampleHelper` reads both sample layouts for the progressive (stbl) and fragmented (moof) parsers, and the codec sniffer used for a lone `.m4s` segment without its init file now falls back to a text stream when the sample is readable text.

## tx3g style records are applied

`Hello <i>world</i>` imported as tx3g came back as plain `Hello world` — gpac moves the italic into a `styl` box that was skipped, so the same SRT round-tripped differently depending on the import mode. The records now become `<i>`, `<b>`, `<u>` and `<font color>`.

Two things checked rather than assumed:
- The record offsets count **characters**, not bytes — verified with `Héllö <i>wörld</i> end`, where gpac writes `start=6 end=11`. Styling is applied before line-break normalization so the indices stay valid.
- QuickTime text tracks use the same box name with **14-byte** records. Those are rejected by an exact `10 + count * 12 == boxSize` check, so a QT track can't get randomly styled text.

White is the tx3g default color and produces no font tag, so ordinary cues stay clean.

## VobSub palette

MP4Box does store the idx palette — in the esds of the `mp4s` sample entry, as the DVD stores it: 16 entries of `(0, Y, Cr, Cb)`. It is now read into `Stbl.VobSubPalette` and passed to `SubPicture.GetBitmap` at all four places the subpictures are rendered (OCR, track picker preview, export to sup, seconv).

This matters beyond colors: without a CLUT, `GetBitmap` skips both the SetColor and SetContrast display commands, so normally-transparent outline planes render opaque and fuse into the glyphs — the same cause as the garbled VobSub OCR in #12772.

```
palette=000000,f0f0f0,cccccc,999999,3333f9,1111b9   (source idx: 000000, f0f0f0, cccccc, 999999, 3333fa, 1111bb)
centerPixel=#ffcccccc   with CLUT
centerPixel=#ff000000   without (previous behavior)
```

## Support matrix after this change

| MP4Box import | sample entry | progressive | fragmented (`-dash`) |
|---|---|---|---|
| `-add x.srt` (default), `.ssa`, `.sub`, `.ttxt`, `.texml`, `.mov` output | `tx3g` | ✅ + styles | ✅ |
| `-add x.vtt`, `-add x.srt:sopt:stxtmod=vtt` | `wvtt` | ✅ | ✅ |
| `-add x.ttml` | `stpp` | ✅ | ✅ |
| `-add x.srt:sopt:stxtmod=stxt` | `stxt` | ✅ *(was garbage)* | ✅ *(was missing)* |
| `-add x.srt:sopt:stxtmod=sbtt` | `sbtt` | ✅ *(was garbage)* | ✅ *(was missing)* |
| `-add x.idx` (VobSub) | `mp4s` / `subp` | ✅ + palette | n/a |
| `-add x.scc` | `GMCW` | ⛔ rejected | n/a |

`GMCW` is gpac's own wrapper, not a conformant `c608` track — there is nothing standard to decode. It used to be listed with binary text; requiring a tx3g text length to fit inside its sample now rejects it.

## Testing

- 17 new tests in `tests/libse/ContainerFormats/Mp4TextSampleTest.cs`, including a full `stbl`-level parse of an stxt track and the esds palette walk.
- Full suites pass: libse 855, seconv 290, libuilogic 140.
- Every paragraph of the existing fixtures (`sample_MP4.mp4` — 808 cues, `sample_MP4_SRT.mp4`, `container_text.mp4`) plus stpp/wvtt/microdvd/ssa samples diffed against a build of `main`: identical except the two intended italic restorations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)