### PR TITLE
Bump the Flatpak ffmpeg from 7.1.2 to 9.0

### DIFF
--- a/installer/flatpak/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/dk.nikse.subtitleedit.yaml
@@ -196,8 +196,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/FFmpeg/FFmpeg.git
-        tag: n7.1.2
-        commit: 7003a8c4544b780eb0ab5c02ac4ad89d2132f2a2
+        tag: n9.0
+        commit: 5b9252abfe2fda0ccb71ed45cd7a954cc45d2b6f
 
   - name: libXpresent
     buildsystem: autotools

--- a/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
@@ -196,8 +196,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/FFmpeg/FFmpeg.git
-        tag: n7.1.2
-        commit: 7003a8c4544b780eb0ab5c02ac4ad89d2132f2a2
+        tag: n9.0
+        commit: 5b9252abfe2fda0ccb71ed45cd7a954cc45d2b6f
 
   - name: libXpresent
     buildsystem: autotools


### PR DESCRIPTION
The Flatpak manifest still built ffmpeg `n7.1.2` while every other platform had moved on. FFmpeg 9.0 "Lei" was released 2026-08-04.

Both manifests (`installer/flatpak/` and `installer/flatpak/flathub/`) are bumped together.

**Why this needed checking:** libmpv is built against this ffmpeg, so a major-version API break would surface only at build time.

- Of the **83 public symbols that disappear between `n7.1.2` and `n9.0`**, mpv v0.41.0 references **none** (diffed every header in libavcodec/libavutil/libavformat/libavfilter/libavdevice/libswscale/libswresample across both tags, then grepped the mpv tree).
- Every `--enable-*` option the manifest passes still exists in 9.0's `configure`.
- mpv's `meson.build` sets only *lower* bounds on the libav\* versions, so nothing blocks at configure time.
- A static check can't catch struct-field or signature changes, so this is being verified by an actual **Build Flatpak** run on this branch: https://github.com/SubtitleEdit/subtitleedit/actions/runs/30938398928

**One subtlety:** the `commit:` field here is the annotated **tag object** SHA (what `git rev-parse n9.0` returns), which is the convention the existing pin used — `7003a8c…` is not a commit in FFmpeg/FFmpeg, it's the `n7.1.2` tag object. Using the commit the tag points at would fail flatpak-builder's check.

Companion to #13216 (Windows/macOS ffmpeg downloads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)