### PR TITLE
Update CrispEmbed to v0.17.2

### DIFF
--- a/docs/features/ocr.md
+++ b/docs/features/ocr.md
@@ -56,8 +56,9 @@ Local LLM-based OCR using a llama.cpp-compatible server.
 
 ### CrispEmbed
 Local OCR engine with multiple model backends (free/open source).
-- Backends: **GLM-OCR**, **GOT-OCR2**, and **Qwen3-VL-2B**
-- Each backend offers a smaller `q4_k` and a higher-quality `q8_0` model (from about 445 MB for GOT-OCR2 q4_k up to about 2.3 GB for Qwen3-VL-2B q8_0)
+- Backends: **PP-OCRv6**, **GLM-OCR**, **GOT-OCR2**, and **Qwen3-VL-2B**
+- **PP-OCRv6** is a text detector plus recognizer rather than a vision language model, so it needs only two small files (about 79 MB in total) and is the quickest way to get started
+- The other backends each offer a smaller `q4_k` and a higher-quality `q8_0` model (from about 445 MB for GOT-OCR2 q4_k up to about 2.3 GB for Qwen3-VL-2B q8_0)
 - The engine and models are downloaded from the OCR window on first use
 
 ### Mistral OCR

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -1324,8 +1324,8 @@ public partial class OcrViewModel : ObservableObject
                     $"{Environment.NewLine}\"CrispEmbed\" requires downloading the CrispEmbed engine.{Environment.NewLine}{Environment.NewLine}Download and use CrispEmbed?",
                     MessageBoxButtons.Cancel,
                     MessageBoxIcon.Question,
-                    "CPU",
-                    "GPU CUDA");
+                    "CPU (~10 MB)",
+                    "GPU CUDA (~705 MB)");
 
                 if (answer == MessageBoxResult.Cancel)
                 {

--- a/src/ui/Logic/Download/CrispEmbedDownloadService.cs
+++ b/src/ui/Logic/Download/CrispEmbedDownloadService.cs
@@ -21,13 +21,16 @@ public class CrispEmbedDownloadService : ICrispEmbedDownloadService
 {
     private readonly HttpClient _httpClient;
 
-    private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.0/crispembed-windows-x86_64-cuda.zip";
-    private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.0/crispembed-windows-x86_64-vulkan.zip";
-    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.0/crispembed-windows-x86_64.zip";
-    private const string MacUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.0/crispembed-macos-arm64.tar.gz";
-    private const string LinuxUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.0/crispembed-linux-x86_64.tar.gz";
-    private const string LinuxCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.0/crispembed-linux-x86_64-cuda.tar.gz";
-    private const string LinuxArmUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.0/crispembed-linux-arm64.tar.gz";
+    private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.2/crispembed-windows-x86_64-cuda.zip";
+    private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.2/crispembed-windows-x86_64-vulkan.zip";
+    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.2/crispembed-windows-x86_64.zip";
+    private const string MacUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.2/crispembed-macos-arm64.tar.gz";
+    private const string LinuxUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.2/crispembed-linux-x86_64.tar.gz";
+    // The plain "-cuda" archive expects a CUDA 12.x *toolkit* on the host (libcudart/libcublas),
+    // not just a driver, and fails in the dynamic loader with exit code 127 when it is missing.
+    // The "-bundled" variant ships those two libraries, so it runs with only an NVIDIA driver.
+    private const string LinuxCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.2/crispembed-linux-x86_64-cuda-bundled.tar.gz";
+    private const string LinuxArmUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.2/crispembed-linux-arm64.tar.gz";
 
     public CrispEmbedDownloadService(HttpClient httpClient)
     {

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -747,49 +747,56 @@ public static class DownloadHashManager
             // otherwise users will be prompted to "update" to the same version they just got.
             [CrispEmbed.WindowsCuda] = new[]
             {
-                "957cd0292caa2962927b78a64d897cf6a86404212e37e7907233f9c675a30ef1", // v0.17.0 (current download URL)
+                "62c67b9ee210ae39f46fc416faa7125a2db82b8766b2518924e1c1c2ee166466", // v0.17.2 (current download URL)
+                "957cd0292caa2962927b78a64d897cf6a86404212e37e7907233f9c675a30ef1", // v0.17.0
                 "8c546e2f10dc70873f1ed904634f8642d4f76b36132aad8c70d96548e99e98a9", // v0.16.1
                 "98423ef22da5b60420ca74f3b3ef41d152d1181659b06b6f873c369eea8dcdf7", // v0.15.0
                 "faf376578103b37d7b1d5a385072ff8c66f35cbb7f20a801a6ab0d4e85802cda", // v0.14.0
             },
             [CrispEmbed.WindowsVulkan] = new[]
             {
-                "4c25232b037291c8ff1ce6999de7cd669fe7a4d6ebed84735173dd458edb0250", // v0.17.0 (current download URL)
+                "aad639f14bfb4202ade4140cd6d1505abd97b69cd0e00639158ac5ef7fe211bd", // v0.17.2 (current download URL)
+                "4c25232b037291c8ff1ce6999de7cd669fe7a4d6ebed84735173dd458edb0250", // v0.17.0
                 "91b6ea29a2f9ab9dae387dee90f2195c19d44bdb6baae35b008870abef80af94", // v0.16.1
                 "bae16ce2d475a48d9fb4573a5ed156b2c9ecff6c1565c509461ce5d70f11c6d9", // v0.15.0
                 "d1722ae897a0909de877e6d1defeb5cf56041ced923cb058770fc76f9dcc8a37", // v0.14.0
             },
             [CrispEmbed.WindowsCpu] = new[]
             {
-                "601f722b8fd01896ea4943f87099b5bc1f32177c6163cabfbd327e5a9866c0a0", // v0.17.0 (current download URL)
+                "4e06b89a315a75f5aa495a88278039d4e89800f56b15f1ada4a99998da3020a3", // v0.17.2 (current download URL)
+                "601f722b8fd01896ea4943f87099b5bc1f32177c6163cabfbd327e5a9866c0a0", // v0.17.0
                 "2337b553090d48dfdd24f11f23e126ed1cea521d77fa01800ca14b261b1834ad", // v0.16.1
                 "90cbe585e202d55c917ce4d14a5b92ca0db459f927ea396203822d94aa149e60", // v0.15.0
                 "49ba9a172f918c82648d69a4758841a45e29bb8e2700ffa64e4c94f325d0fec3", // v0.14.0
             },
             [CrispEmbed.MacOs] = new[]
             {
-                "4146cf85ab13bad1ebab0a9903022e8098dc5eafec4f844e2eeaa65a6ae069dc", // v0.17.0 (current download URL)
+                "6b5f44da74da4a99bce41aaaa2ddb1f8905e60ec455d45780ba32d9d05f4d0f2", // v0.17.2 (current download URL)
+                "4146cf85ab13bad1ebab0a9903022e8098dc5eafec4f844e2eeaa65a6ae069dc", // v0.17.0
                 "22d41f046fda10b02b3908fac28d62247788f311d792b80c07f9b97aefc9d52d", // v0.16.1
                 "369605d468c0433eb3bd6c356d2220eaa49467f7a5970423e6373771cadece9c", // v0.15.0
                 "2a47142eea71f0120fbf86eda21a0d972618e01c2bf5d67e54204d8e5644411e", // v0.14.0
             },
             [CrispEmbed.Linux] = new[]
             {
-                "61b4a47c471743665d6629e38babc3e7eb32ccffb79f35e99ce76da192c3d61e", // v0.17.0 (current download URL)
+                "149e3c3db4a2b5e8efad0396cf9382902f529e40be0ebca894ea1eeb92f8fb92", // v0.17.2 (current download URL)
+                "61b4a47c471743665d6629e38babc3e7eb32ccffb79f35e99ce76da192c3d61e", // v0.17.0
                 "3fbe97c86444eaf3b164bdc69684a571a0a31497fa91ca5321bd33d961ecbdc2", // v0.16.1
                 "8863cb689d892a7aaa7555306a019b99c863c3669571205db49032c4f8b34450", // v0.15.0
                 "e255a59c615fcdf869794c7fabc2f7a4da7babddce5a7ef4771e4fc4a51ff65c", // v0.14.0
             },
             [CrispEmbed.LinuxCuda] = new[]
             {
-                "2d8b9c242c3c50fd8092ccde954d8540feefbcfc800f763b8a4a227b226c59d7", // v0.17.0 (current download URL)
+                "82be9b2546c741d236c96ee244f7264303f743dd62421f0a0391796aafd5237d", // v0.17.2 (bundled CUDA runtime) (current download URL)
+                "2d8b9c242c3c50fd8092ccde954d8540feefbcfc800f763b8a4a227b226c59d7", // v0.17.0
                 "1bd9e322617c5c63490d1054140e8109ff7b8b471a26381d5cea12bf7a8c6e62", // v0.16.1
                 "5ce79deb4845c2b04757ee398b5f7ac0ff65bd5435a70da1f18491f3ff8c7c30", // v0.15.0
                 "48e2c0e8536c7db717155adb418330e29bb5f7b1c8eda8686fe7513ae6ea58d9", // v0.14.0
             },
             [CrispEmbed.LinuxArm] = new[]
             {
-                "77309c2ab93a01e255a806ba8d54be2854ee160b3e6bb0a85b11cd68e22093a9", // v0.17.0 (current download URL)
+                "088874ae9f79a8aec1bd1f16699bad18beb130693d69465fadccfe7751d6ca99", // v0.17.2 (current download URL)
+                "77309c2ab93a01e255a806ba8d54be2854ee160b3e6bb0a85b11cd68e22093a9", // v0.17.0
                 "b89d26ee3e0b2091bbbdb1b6f337add44faae5b4914c0d54c4cb50a25bd2bcf6", // v0.16.1
                 "3a5056e831ddd5af26cc9d623a2c2de7d51d2297bcac67045feb1dac117dece8", // v0.15.0
                 "3d08ea2cb15da4f1d71dfc3ae030f855d7a5d32a662952b6ea43ff17d3b37788", // v0.14.0


### PR DESCRIPTION
Bumps the CrispEmbed engine from v0.17.0 to [v0.17.2](https://github.com/CrispStrobe/CrispEmbed/releases/tag/v0.17.2).

Two upstream releases are picked up:

- **v0.17.1** dropped the OpenBLAS link-time dependency that made *every* Linux tarball exit with code 127 in the dynamic loader before reaching `main()` — the cause of #13205. Verified by extracting the v0.17.2 Linux x86_64 and arm64 archives: `libggml-blas` is gone, and no binary has a `libopenblas` `DT_NEEDED` entry any more.
- **v0.17.2** fixes two embedding-quality bugs (Qwen-family tokenizer newline handling, a missing GTE v1.5 per-layer bias) and adds a Linux CUDA archive that bundles the CUDA runtime. The OCR engines are untouched by both fixes.

### Linux CUDA now uses the self-contained archive

The plain `crispembed-linux-x86_64-cuda.tar.gz` requires a CUDA 12.x **toolkit** on the host (`libcudart.so.12` / `libcublas.so.12`), not just a driver, and fails with the same silent exit 127 when it is missing — Subtitle Edit has no way to detect that beforehand. `crispembed-linux-x86_64-cuda-bundled.tar.gz` ships those libraries and needs only the NVIDIA driver, so that is what the CUDA option downloads now. It is ~705 MB instead of ~138 MB, so the Linux download prompt spells out both sizes: "CPU (~10 MB)" / "GPU CUDA (~705 MB)".

### Verification

- All seven pinned URLs cross-checked against the live release digests; every `DownloadHashManager` index 0 matches the archive its URL resolves to.
- macOS smoke test: `crispembed-server --ocr` from v0.17.2 returns byte-identical text and confidences to the installed v0.16.1 for the same image and model (GOT-OCR2 q4_k).
- Build clean, CrispEmbed and download-hash tests pass.

Also documents the PP-OCRv6 backend added in #13210, which never made it into the OCR help page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)