### PR TITLE
Port the OpenBLAS module to the Flathub manifest

### DIFF
--- a/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
@@ -361,6 +361,35 @@ modules:
         sha256: ed087f83ee789c1ea5f39c464c55a5c9d4008deb0efe900814f2df262b82c36e
         strip-components: 0
 
+  # --- OpenBLAS (needed by the downloaded CrispASR engines; see issue #12970) ---
+  #
+  # The CrispASR Linux binaries (x86_64 CPU/Vulkan and arm64) are linked against
+  # libopenblas.so.0 but ship only crispasr, crispasr-quantize and libc2pa_c.so.
+  # org.freedesktop.Platform has no OpenBLAS, and the sandbox hides the host /usr,
+  # so speech-to-text died instantly with
+  #   "crispasr: error while loading shared libraries: libopenblas.so.0"
+  # no matter what the user installed on the host. Building it into /app/lib puts it
+  # on the sandbox library path, which the crispasr child process inherits.
+  #
+  # DYNAMIC_ARCH=1 so one build works on every CPU (the runtime baseline is generic);
+  # USE_OPENMP=1 matches the libgomp the engine already links against. crispasr imports
+  # exactly two symbols from this library - cblas_sgemm and openblas_set_num_threads - so
+  # LAPACK/LAPACKE are switched off: they roughly halve the build time and would otherwise
+  # need a Fortran compiler.
+  - name: openblas
+    buildsystem: simple
+    build-commands:
+      - make DYNAMIC_ARCH=1 USE_OPENMP=1 NUM_THREADS=64 NO_STATIC=1 NO_LAPACK=1 NO_LAPACKE=1 -j $FLATPAK_BUILDER_N_JOBS
+      - make PREFIX=/app NO_STATIC=1 NO_LAPACK=1 NO_LAPACKE=1 install
+    cleanup:
+      - /include
+      - /lib/cmake
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.34/OpenBLAS-0.3.34.tar.gz
+        sha256: cd7e129868320cc2d033afa920e31202dfe0b8066a5b66661900ccc0f197dfed
+
   # --- SubtitleEdit application ---
 
   - name: subtitleedit


### PR DESCRIPTION
`88cc95e94` added OpenBLAS to [installer/flatpak/dk.nikse.subtitleedit.yaml](installer/flatpak/dk.nikse.subtitleedit.yaml) to fix CrispASR failing to start (#12970), but [the Flathub copy](installer/flatpak/flathub/dk.nikse.subtitleedit.yaml) was last touched on 2026-07-23 — eight days before that fix — and never received it.

The **Build Flatpak** workflow only builds the first manifest (`manifest-path: installer/flatpak/dk.nikse.subtitleedit.yaml`), so CI stayed green while the published Flathub package shipped without libopenblas. Speech-to-text there should still be dying at launch with `crispasr: error while loading shared libraries: libopenblas.so.0`.

**Verified still required**, against the CrispASR version SE pins today (v0.8.25) rather than the version current when the original fix landed — all three Linux archives list it as a hard `DT_NEEDED` and bundle no BLAS of their own:

| archive | `libopenblas.so.0` |
|---|---|
| `crispasr-linux-x86_64` | NEEDED |
| `crispasr-linux-x86_64-vulkan` | NEEDED |
| `crispasr-linux-arm64` | NEEDED |

The comment's build-flag reasoning also still holds: the only undefined OpenBLAS symbols in the binary are `cblas_sgemm` and `openblas_set_num_threads`, so `NO_LAPACK=1 NO_LAPACKE=1` remain correct.

(CrispEmbed no longer needs it — v0.17.2 ships no BLAS backend at all — so CrispASR is now the sole consumer, but one consumer is enough.)

The block is copied verbatim and placed at the same position, so the two manifests now differ **only** in the `subtitleedit` source stanza (local `type: dir` vs tagged `type: git`), as intended. Both parse and their module lists are identical.

Not separately CI-verified, because the workflow does not build this manifest — but this exact module built successfully as part of the other manifest in [run 30938398928](https://github.com/SubtitleEdit/subtitleedit/actions/runs/30938398928) (`Building module openblas`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)