### PR TITLE
Prepare v5.2.0-beta4

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,39 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.2.0-beta4 (5th of August 2026)
+
+* Read subtitles from fragmented MP4 (DASH/CMAF): WebVTT, TTML/IMSC1 and tx3g
+* Offer the MP4 track picker for fragmented files with several subtitle tracks
+* Read stxt/sbtt text streams, tx3g styles and the VobSub palette from MP4
+* Source view: find/replace, go to line, live format check and a prompt before discarding edits
+* Add "Go to first line"/"Go to last line" shortcuts with video sync (Ctrl+Home/End) - thx GrampaWildWilly
+* OCR: add the PP-OCRv6 backend (CrispEmbed v0.17.2)
+* AI review/assistant: add Gemma 4 E2B, EuroLLM 9B/22B and Granite 4.1 8B
+* Update ffmpeg downloads - Windows 9.0, macOS ARM 8.1, macOS Intel 8.0
+* Update llama.cpp to b10256
+* Accessibility: announce combo box and spinner value changes, and let Alt close an open drop-down - thx Shaima-Almarzooqi
+* Spell check: detect the subtitle language again after opening/importing a file - thx fraternl
+* Fix right-to-left text rendering in dialog subtitle grids - thx AliNet1974
+* Fix the Settings dialog not opening with focus - thx GrampaWildWilly
+* Fix the subtitle grid getting stuck on the first caption after opening a file - thx GrampaWildWilly
+* Fix the initial video position not being 0:00 - thx GrampaWildWilly
+* Fix menus hidden behind the undocked audio visualizer - thx GrampaWildWilly
+* Fix undocked video controls popping up on mouse movement in other apps - thx GrampaWildWilly
+* Fix OmniVoice text to speech failing to start with the CUDA engine - thx subof
+* Explain native engine exit codes instead of showing a raw number - thx subof
+* Fix the CrispEmbed server exiting with code 127 on Linux - thx perkesfurmah-collab
+* Fix speech to text failing to start in the Flathub package (missing OpenBLAS) - thx DarkSwan86
+* Fix Statistics and batch convert crashing with the Bulgarian UI (bad format strings)
+* Fix the burn-in window losing its minimum width while generating
+* Faster subtitle grid selection handling and time code display - thx ivandrofly
+* Update Polish translation - thx potplayer-fanpack
+* Update French translation - thx Need74
+* Update Korean translation - thx 12si27
+* Update Japanese translation - thx hisui3393
+
+-----------------------------------------------------------------------------------------------------
+
 v5.2.0-beta3 (4th of August 2026)
 
 * Extract ARIB STD-B24 captions from transport streams (Japanese ISDB, Brazilian SBTVD)

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -18,7 +18,7 @@ public class Se
     internal const int CurrentMacOsFontMigrationVersion = 1;
     internal const int CurrentShortcutsMigrationVersion = 1;
 
-    public static string Version { get; set; } = "v5.2.0-beta3";
+    public static string Version { get; set; } = "v5.2.0-beta4";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Opens the **v5.2.0-beta4** change log section and bumps `Se.Version`.

## Coverage

28 PRs merged since the `v5.2.0-beta3` tag, enumerated by ancestor-checking every merged PR's merge commit against the tag (`git merge-base --is-ancestor <sha> v5.2.0-beta3`) rather than reading `git log`, plus one direct commit to main (the Japanese translation, 45b2f85b4). Every merge commit in `v5.2.0-beta3..main` maps to a PR in the list, so nothing was squash-merged past the sweep.

| | |
|---|---|
| Features | #13178 #13179 #13184 #13215 (MP4/DASH), #13211 (source view), #13198 (go to first/last line), #13210 #13218 (PP-OCRv6), #13186 (AI models) |
| Fixes | #13177 #13188 #13192 #13193 #13197 #13199 #13201 #13209 #13212 #13213 |
| Updates | #13189 #13216 #13217 #13219 |
| Perf | #13221 |
| Translations | #13180 #13214 #13220 #13223 + 45b2f85b4 |

Credits come from each PR's linked issue author: fraternl (#13117), AliNet1974 (#13160), GrampaWildWilly (#13185, #13190, #13191, #13187, #13194, #13207), subof (#13196), perkesfurmah-collab (#13205), DarkSwan86 (#12970), Shaima-Almarzooqi (#12087), plus the translation PR authors.

Not listed, per the usual convention: internal-only work (#13176 was beta3's own prep; the English.json regeneration in 17f5c087a; the `LanguageFileFormatStringTests` regression guard).

## Not touched

`English.json`, `Polish.json` and `Korean.json` still carry `"version": "v5.2.0-beta3"` in their header. That stamp comes from the English regeneration pass, and the beta1/beta2/beta3 prep commits left it alone too - flagging it in case you want the regeneration run before tagging.

## Verification

`dotnet build src/ui/UI.csproj -c Release` succeeds (1 pre-existing nullable warning in `PickMp4TrackViewModel.cs`).

The change log date reads **5th of August 2026** - adjust if the tag slips to another day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
