### PR TITLE
Make the Source view selection visible in dark theme

### DIFF
--- a/src/ui/Features/Shared/SourceView/SourceViewWindow.cs
+++ b/src/ui/Features/Shared/SourceView/SourceViewWindow.cs
@@ -157,11 +157,17 @@ public class SourceViewWindow : Window
         var buttonReplaceAll = UiUtil.MakeButton(Se.Language.Edit.Find.ReplaceAll, vm.ReplaceAllCommand);
         buttonReplaceAll.Bind(IsVisibleProperty, new Binding(nameof(vm.IsReplaceVisible)));
 
+        // The options sit shoulder to shoulder after the buttons, so they need their own gap.
+        var optionMargin = new Thickness(10, 0, 0, 0);
         var checkBoxMatchCase = UiUtil.MakeCheckBox(Se.Language.General.CaseSensitive, vm, nameof(vm.MatchCase));
+        checkBoxMatchCase.Margin = optionMargin;
         var checkBoxWholeWord = UiUtil.MakeCheckBox(Se.Language.Edit.Find.WholeWord, vm, nameof(vm.WholeWord));
+        checkBoxWholeWord.Margin = optionMargin;
         var checkBoxRegex = UiUtil.MakeCheckBox(Se.Language.General.RegularExpression, vm, nameof(vm.UseRegularExpression));
+        checkBoxRegex.Margin = optionMargin;
 
         var labelStatus = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.FindStatus));
+        labelStatus.Margin = optionMargin;
 
         var buttonClose = UiUtil.MakeButton(vm.CloseFindBarCommand, IconNames.Close, Se.Language.SourceView.CloseSearch);
         buttonClose.HorizontalAlignment = HorizontalAlignment.Right;
@@ -170,6 +176,7 @@ public class SourceViewWindow : Window
         {
             Orientation = Orientation.Horizontal,
             VerticalAlignment = VerticalAlignment.Center,
+            LineSpacing = 6,
             Children =
             {
                 searchTextBox,

--- a/src/ui/Logic/UiTheme.cs
+++ b/src/ui/Logic/UiTheme.cs
@@ -625,6 +625,10 @@ public static class UiTheme
                 {
                     new Setter(SyntaxTextView.ForegroundProperty, new SolidColorBrush(foreColor)),
                     new Setter(SyntaxTextView.CaretBrushProperty, new SolidColorBrush(foreColor)),
+
+                    // The default translucent steel blue nearly disappears on a dark background -
+                    // a brighter blue still lets the syntax colors read through on top.
+                    new Setter(SyntaxTextView.SelectionBrushProperty, new SolidColorBrush(Color.FromArgb(0x99, 0x4C, 0x8D, 0xE0))),
                 }
             },
 


### PR DESCRIPTION
The syntax editor in "Source view" never got a `SelectionBrush`, so it fell back to its own default - steel blue at 40% alpha - which nearly disappears against the dark background. The dark theme now sets a brighter blue at ~60% alpha, so the selection band is clearly visible while the syntax colors still read through on top. Light and Classic themes keep the old default.

Also, in the find bar the three option check boxes and the status label had no margin at all, so they sat flush against the "Replace all" button and each other. They now get a small left margin, and the wrap panel gets line spacing so the rows do not touch when the bar wraps in a narrow window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)