### PR TITLE
Guard the missing mdia box in the MP4 track picker

### DIFF
--- a/src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs
+++ b/src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs
@@ -61,13 +61,22 @@ public partial class PickMp4TrackViewModel : ObservableObject
         WindowTitle = $"Pick MP4 track - {fileName}";
         foreach (var track in _mp4Tracks)
         {
+            // A trak box without an mdia child carries no media information at all;
+            // Mp4Parser.GetSubtitleTracks() already drops those, but the callers are
+            // free to hand us any track list.
+            var mdia = track.Mdia;
+            if (mdia == null)
+            {
+                continue;
+            }
+
             var display = new Mp4TrackInfoDisplay
             {
-                HandlerType = track.Mdia.HandlerType,
-                Name = track.Mdia.Name,
-                StartPosition = track.Mdia.StartPosition,
-                IsVobSubSubtitle = track.Mdia.IsVobSubSubtitle,
-                Duration = LastCueEnd(track.Mdia?.Minf?.Stbl?.GetParagraphs()),
+                HandlerType = mdia.HandlerType,
+                Name = mdia.Name,
+                StartPosition = mdia.StartPosition,
+                IsVobSubSubtitle = mdia.IsVobSubSubtitle,
+                Duration = LastCueEnd(mdia.Minf?.Stbl?.GetParagraphs()),
                 Track = track,
             };
             Tracks.Add(display);


### PR DESCRIPTION
Clears the one warning left in the UI project, noticed while building #13226.

```
PickMp4TrackViewModel.cs(66,31): warning CS8602: Dereference of a possibly null reference.
```

## Why it warned

`Initialize(List<Trak>, string)` builds each display row from five `track.Mdia` members - four dereferenced unconditionally, and `Duration` guarded with `track.Mdia?.Minf?...`. That `?.` puts `track.Mdia` into maybe-null state, and the state is carried back over the `foreach` edge, so the *first* access in the next iteration (line 66) is the one that warns. `libse` is nullable-oblivious, so nothing outside this loop contributes.

## Is it reachable

Not today. Every call site goes through `Mp4Parser.GetSubtitleTracks()`, which already filters on `trak.Mdia != null && trak.Mdia.Minf?.Stbl != null`:

- [MainViewModel.cs:17137](src/ui/Features/Main/MainViewModel.cs#L17137) and [:17209](src/ui/Features/Main/MainViewModel.cs#L17209)
- the fragmented/DASH overload takes `Mp4FragmentedSubtitleTrack` and never touches `Mdia`

But `Initialize` is public and accepts any `List<Trak>` - `Moov.Tracks` unfiltered would NRE - and the mixed style left it ambiguous which way the method meant to lean. So this guards rather than suppresses.

## Change

The track's `mdia` is read once into a local and the row is skipped when it is absent; the remaining `Minf?.Stbl?` chain stays, since those really can be missing on a track that has an `mdia`.

## Left alone

`Export()` has the same unguarded chain - `track.Mdia.IsVobSubSubtitle` at line 141, then `track.Mdia.Minf.Stbl` three times at 149-151. It does not warn (no `?.` on `Mdia` in that method to seed the state) and it is equally unreachable, but it is the same latent NRE. Out of scope here - happy to fold it in if you want the file consistent.

## Verification

- `dotnet build src/ui/UI.csproj -c Release` - **0 warnings, 0 errors** (was 1 warning)
- `dotnet test tests/UI/UITests.csproj -c Release` - **1360 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
