### PR TITLE
Cut allocations in the UI value converters

### DIFF
--- a/src/ui/Features/Shared/ColorPicker/ColorToBrushConverter.cs
+++ b/src/ui/Features/Shared/ColorPicker/ColorToBrushConverter.cs
@@ -1,18 +1,25 @@
 ﻿using Avalonia.Data.Converters;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using System;
 
 namespace Nikse.SubtitleEdit.Features.Shared.ColorPicker;
 
 internal class ColorToBrushConverter : IValueConverter
 {
+    // The colors are arbitrary (color pickers drag through the whole space), so there is nothing
+    // to cache - but an immutable brush is a plain object, while SolidColorBrush is an
+    // AvaloniaObject that drags a property store along for a value that never changes.
+    private static readonly ImmutableSolidColorBrush WhiteBrush = new(Colors.White);
+
     public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
     {
         if (value is Color color)
         {
-            return new SolidColorBrush(color);
+            return new ImmutableSolidColorBrush(color);
         }
-        return new SolidColorBrush(Colors.White);
+
+        return WhiteBrush;
     }
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)

--- a/src/ui/Logic/ValueConverters/BatchConvertStatusColorConverter.cs
+++ b/src/ui/Logic/ValueConverters/BatchConvertStatusColorConverter.cs
@@ -43,7 +43,7 @@ public class BatchConvertStatusColorConverter : IValueConverter
         }
 
         // "Error: {0}" - match on the part before the placeholder so translated texts work too.
-        var errorPrefix = string.Format(Se.Language.General.ErrorX, string.Empty).Trim();
+        var errorPrefix = GetErrorPrefix(Se.Language.General.ErrorX);
         if (status == Se.Language.General.NoSubtitlesFound ||
             status == Se.Language.Ocr.OllamaModelLikelyWrong ||
             (errorPrefix.Length > 0 && status.StartsWith(errorPrefix, StringComparison.OrdinalIgnoreCase)) ||
@@ -54,6 +54,22 @@ public class BatchConvertStatusColorConverter : IValueConverter
 
         // In-progress statuses (OCR percentages etc.) keep the default text color, no badge.
         return AvaloniaProperty.UnsetValue;
+    }
+
+    // Formatting + trimming "Error: {0}" per status cell showed up as the converter's only
+    // allocation; the language string changes at most once, when a translation is loaded.
+    private static string? _errorXFormat;
+    private static string _errorPrefix = string.Empty;
+
+    private static string GetErrorPrefix(string errorXFormat)
+    {
+        if (!ReferenceEquals(_errorXFormat, errorXFormat))
+        {
+            _errorXFormat = errorXFormat;
+            _errorPrefix = string.Format(errorXFormat, string.Empty).Trim();
+        }
+
+        return _errorPrefix;
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/src/ui/Logic/ValueConverters/BoolToFontStyleConverter.cs
+++ b/src/ui/Logic/ValueConverters/BoolToFontStyleConverter.cs
@@ -11,19 +11,19 @@ public class BoolToFontStyleConverter : IValueConverter
     {
         if (value is bool boolValue)
         {
-            return boolValue ? FontStyle.Italic : FontStyle.Normal;
+            return boolValue ? ConverterBoxes.FontStyleItalic : ConverterBoxes.FontStyleNormal;
         }
 
-        return FontStyle.Normal;
+        return ConverterBoxes.FontStyleNormal;
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is FontStyle fontStyle)
         {
-            return fontStyle == FontStyle.Italic;
+            return ConverterBoxes.Bool(fontStyle == FontStyle.Italic);
         }
 
-        return false;
+        return ConverterBoxes.False;
     }
 }

--- a/src/ui/Logic/ValueConverters/BooleanAndConverter.cs
+++ b/src/ui/Logic/ValueConverters/BooleanAndConverter.cs
@@ -2,7 +2,6 @@ using Avalonia.Data.Converters;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 
 namespace Nikse.SubtitleEdit.Logic.ValueConverters;
 
@@ -14,11 +13,20 @@ public class BooleanAndConverter : IMultiValueConverter
     {
         if (values == null || values.Count == 0)
         {
-            return false;
+            return ConverterBoxes.False;
         }
 
-        // Return true only if all values are boolean true
-        return values.All(v => v is bool b && b);
+        // Return true only if all values are boolean true - an indexed loop instead of
+        // values.All(), which allocates an enumerator per call through the IList interface.
+        for (var i = 0; i < values.Count; i++)
+        {
+            if (values[i] is not true)
+            {
+                return ConverterBoxes.False;
+            }
+        }
+
+        return ConverterBoxes.True;
     }
 
     public object[] ConvertBack(object? value, Type[] targetTypes, object? parameter, CultureInfo culture)

--- a/src/ui/Logic/ValueConverters/BooleanToGridLengthConverter.cs
+++ b/src/ui/Logic/ValueConverters/BooleanToGridLengthConverter.cs
@@ -1,5 +1,4 @@
-﻿using Avalonia.Controls;
-using Avalonia.Data.Converters;
+﻿using Avalonia.Data.Converters;
 using System;
 using System.Globalization;
 
@@ -10,10 +9,10 @@ public class BooleanToGridLengthConverter : IValueConverter
     {
         if (value is bool boolValue)
         {
-            return boolValue ? new GridLength(1, GridUnitType.Star) : new GridLength(0);
+            return boolValue ? ConverterBoxes.StarGridLength : ConverterBoxes.ZeroGridLength;
         }
 
-        return new GridLength(1, GridUnitType.Star);
+        return ConverterBoxes.StarGridLength;
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/src/ui/Logic/ValueConverters/ConverterBoxes.cs
+++ b/src/ui/Logic/ValueConverters/ConverterBoxes.cs
@@ -1,0 +1,30 @@
+using Avalonia.Controls;
+using Avalonia.Media;
+
+namespace Nikse.SubtitleEdit.Logic.ValueConverters;
+
+/// <summary>
+/// Pre-boxed results for the converters that only ever return one of a handful of values.
+/// A converter returns <see cref="object"/>, so every <c>return true</c> / <c>return 1.0</c> /
+/// <c>return FlowDirection.RightToLeft</c> otherwise boxes - one small allocation per bound
+/// property per row, on every grid repaint.
+/// </summary>
+internal static class ConverterBoxes
+{
+    internal static readonly object True = true;
+    internal static readonly object False = false;
+
+    internal static readonly object ZeroDouble = 0.0;
+    internal static readonly object OneDouble = 1.0;
+
+    internal static readonly object StarGridLength = new GridLength(1, GridUnitType.Star);
+    internal static readonly object ZeroGridLength = new GridLength(0);
+
+    internal static readonly object FontStyleNormal = FontStyle.Normal;
+    internal static readonly object FontStyleItalic = FontStyle.Italic;
+
+    internal static readonly object FlowDirectionLeftToRight = FlowDirection.LeftToRight;
+    internal static readonly object FlowDirectionRightToLeft = FlowDirection.RightToLeft;
+
+    internal static object Bool(bool value) => value ? True : False;
+}

--- a/src/ui/Logic/ValueConverters/DoubleToDisplayShortConverter.cs
+++ b/src/ui/Logic/ValueConverters/DoubleToDisplayShortConverter.cs
@@ -10,8 +10,14 @@ public class DoubleToDisplayShortConverter : IValueConverter
 {
     public static readonly DoubleToDisplayShortConverter Instance = new();
 
+    // Reused to avoid per-call TimeCode allocations (expected to be used from the UI thread only).
+    private readonly TimeCode _formattingTimeCode = new();
+    private const string ZeroFrameMode = "00.00";
+    private const string ZeroTime = "00,000";
+
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
+        var useFrameMode = Se.Settings.General.UseFrameMode;
         if (value is double ms)
         {
             if (ms == double.MaxValue || double.IsNaN(ms))
@@ -21,20 +27,13 @@ public class DoubleToDisplayShortConverter : IValueConverter
                 return string.Empty;
             }
 
-            if (Se.Settings.General.UseFrameMode)
-            {
-                return new TimeCode(ms).ToShortStringHHMMSSFF();
-            }
-
-            return new TimeCode(ms).ToShortString();
+            _formattingTimeCode.TotalMilliseconds = ms;
+            return useFrameMode
+                ? _formattingTimeCode.ToShortStringHHMMSSFF()
+                : _formattingTimeCode.ToShortString();
         }
 
-        if (Se.Settings.General.UseFrameMode)
-        {
-            return "00.00";
-        }
-
-        return "00,000";
+        return useFrameMode ? ZeroFrameMode : ZeroTime;
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/src/ui/Logic/ValueConverters/DoubleToNoDecimalHideMaxConverter.cs
+++ b/src/ui/Logic/ValueConverters/DoubleToNoDecimalHideMaxConverter.cs
@@ -12,7 +12,8 @@ public class DoubleToNoDecimalHideMaxConverter : IValueConverter
     {
         if (value is double d)
         {
-            if (d == double.MaxValue || d == double.NaN)
+            // NaN never equals anything, itself included - "d == double.NaN" was always false.
+            if (d == double.MaxValue || double.IsNaN(d))
             {
                 return string.Empty;
             }

--- a/src/ui/Logic/ValueConverters/DurationToBackgroundConverter.cs
+++ b/src/ui/Logic/ValueConverters/DurationToBackgroundConverter.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia.Data.Converters;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Globalization;
@@ -10,23 +11,42 @@ internal class DurationToBackgroundConverter : IValueConverter
 {
     public static readonly DurationToBackgroundConverter Instance = new();
 
+    private static readonly ImmutableSolidColorBrush TransparentBrush = new(Colors.Transparent);
+
+    // The error color is a hex string in the settings, so the whole cost of this converter used
+    // to be parsing it and building an AvaloniaObject brush per cell. Cache the brush and
+    // re-derive it only when the setting's value actually changes.
+    private static string? _cachedErrorColorHex;
+    private static ImmutableSolidColorBrush? _cachedErrorBrush;
+
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is TimeSpan ts)
         {
             var general = Se.Settings.General;
-            if (general.ColorDurationTooShort && ts.TotalMilliseconds < general.SubtitleMinimumDisplayMilliseconds)
+            var totalMilliseconds = ts.TotalMilliseconds;
+            if ((general.ColorDurationTooShort && totalMilliseconds < general.SubtitleMinimumDisplayMilliseconds) ||
+                (general.ColorDurationTooLong && totalMilliseconds > general.SubtitleMaximumDisplayMilliseconds))
             {
-                return new SolidColorBrush(general.ErrorColor.FromHexToColor());
-            }
-            else if (general.ColorDurationTooLong && ts.TotalMilliseconds > general.SubtitleMaximumDisplayMilliseconds)
-            {
-                return new SolidColorBrush(general.ErrorColor.FromHexToColor());
+                return GetErrorBrush(general.ErrorColor);
             }
         }
 
         // Default background
-        return new SolidColorBrush(Colors.Transparent);
+        return TransparentBrush;
+    }
+
+    private static ImmutableSolidColorBrush GetErrorBrush(string errorColorHex)
+    {
+        // "is null" rather than "== null": ImmutableSolidColorBrush overloads == with
+        // non-nullable operands, which a null check would go through.
+        if (_cachedErrorBrush is null || !string.Equals(_cachedErrorColorHex, errorColorHex, StringComparison.Ordinal))
+        {
+            _cachedErrorColorHex = errorColorHex;
+            _cachedErrorBrush = new ImmutableSolidColorBrush(errorColorHex.FromHexToColor());
+        }
+
+        return _cachedErrorBrush;
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/src/ui/Logic/ValueConverters/InverseBooleanConverter.cs
+++ b/src/ui/Logic/ValueConverters/InverseBooleanConverter.cs
@@ -10,19 +10,19 @@ public class InverseBooleanConverter : IValueConverter
     {
         if (value is bool boolValue)
         {
-            return !boolValue;
+            return ConverterBoxes.Bool(!boolValue);
         }
 
-        return false;
+        return ConverterBoxes.False;
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is bool boolValue)
         {
-            return !boolValue;
+            return ConverterBoxes.Bool(!boolValue);
         }
 
-        return false;
+        return ConverterBoxes.False;
     }
 }

--- a/src/ui/Logic/ValueConverters/MiddleEllipsisConverter.cs
+++ b/src/ui/Logic/ValueConverters/MiddleEllipsisConverter.cs
@@ -39,7 +39,10 @@ public class MiddleEllipsisConverter : IValueConverter
         var keep = maxLength - Ellipsis.Length;
         var front = (keep + 1) / 2;
         var back = keep - front;
-        return s[..front] + Ellipsis + s[^back..];
+
+        // Concat the three spans in one go - "s[..front] + Ellipsis + s[^back..]" cut two
+        // intermediate strings first and then threw them away.
+        return string.Concat(s.AsSpan(0, front), Ellipsis, s.AsSpan(s.Length - back));
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/src/ui/Logic/ValueConverters/NotNullConverter.cs
+++ b/src/ui/Logic/ValueConverters/NotNullConverter.cs
@@ -8,7 +8,7 @@ public class NotNullConverter : IValueConverter
 {
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        return value != null;
+        return ConverterBoxes.Bool(value != null);
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/src/ui/Logic/ValueConverters/NullToOpacityConverter.cs
+++ b/src/ui/Logic/ValueConverters/NullToOpacityConverter.cs
@@ -8,7 +8,7 @@ public class NullToOpacityConverter : IValueConverter
 {
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        return value != null ? 1.0 : 0.0;
+        return value != null ? ConverterBoxes.OneDouble : ConverterBoxes.ZeroDouble;
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/src/ui/Logic/ValueConverters/TextOneLineShortConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextOneLineShortConverter.cs
@@ -30,13 +30,10 @@ public class TextOneLineShortConverter : IValueConverter
 
         // Try to cut at the last space before maxLength
         var lastSpace = str.LastIndexOf(' ', maxLength);
-        if (lastSpace > 0)
-        {
-            return str[..lastSpace] + "...";
-        }
+        var cut = lastSpace > 0 ? lastSpace : maxLength;
 
-        // Fallback: hard cut
-        return str[..maxLength] + "...";
+        // One allocation instead of a substring that is immediately concatenated away
+        return string.Concat(str.AsSpan(0, cut), "...");
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/src/ui/Logic/ValueConverters/TextToFlowDirectionConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextToFlowDirectionConverter.cs
@@ -1,5 +1,4 @@
 using Avalonia.Data.Converters;
-using Avalonia.Media;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
@@ -18,19 +17,20 @@ public class TextToFlowDirectionConverter : IValueConverter
 {
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        var rightToLeftMode = Se.Settings.Appearance.RightToLeft;
         if (value is string text && !string.IsNullOrWhiteSpace(text))
         {
             return LanguageAutoDetect.ContainsRightToLeftLetter(text)
-                ? FlowDirection.RightToLeft
-                : FlowDirection.LeftToRight;
+                ? ConverterBoxes.FlowDirectionRightToLeft
+                : ConverterBoxes.FlowDirectionLeftToRight;
         }
 
         // Always produce an explicit direction: a binding that yields UnsetValue
         // does not fall back to the inherited direction but to the property
         // default (left to right), which left right to left cells misaligned in
         // right to left mode.
-        return rightToLeftMode ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
+        return Se.Settings.Appearance.RightToLeft
+            ? ConverterBoxes.FlowDirectionRightToLeft
+            : ConverterBoxes.FlowDirectionLeftToRight;
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/src/ui/Logic/ValueConverters/TextToSingleLineConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextToSingleLineConverter.cs
@@ -33,13 +33,10 @@ public class TextToSingleLineConverter : IValueConverter
 
         // Try to cut at the last space before maxLength
         var lastSpace = str.LastIndexOf(' ', maxLength);
-        if (lastSpace > 0)
-        {
-            return str[..lastSpace] + "...";
-        }
+        var cut = lastSpace > 0 ? lastSpace : maxLength;
 
-        // Fallback: hard cut
-        return str[..maxLength] + "...";
+        // One allocation instead of a substring that is immediately concatenated away
+        return string.Concat(str.AsSpan(0, cut), "...");
     }
     
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
@@ -59,6 +60,35 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
 
     private static readonly TextDecorationCollection MisspelledDecorations = new() { MisspelledDecoration };
 
+    // Colors parsed out of the subtitle itself (ASSA \c tags, <font color=...>) are arbitrary, so
+    // there is nothing worth caching - but an immutable brush is a plain object where
+    // SolidColorBrush is an AvaloniaObject that drags a property store along for a fixed color.
+    private static ImmutableSolidColorBrush CreateBrush(Color color) => new(color);
+
+    // <font face="..."> and \fnName repeat the same handful of names down a whole file, and
+    // constructing a FontFamily parses the name every time.
+    private static readonly Dictionary<string, FontFamily> FontFamilyCache = new(StringComparer.Ordinal);
+    private const int FontFamilyCacheLimit = 64;
+
+    private static FontFamily GetFontFamily(string name)
+    {
+        if (FontFamilyCache.TryGetValue(name, out var fontFamily))
+        {
+            return fontFamily;
+        }
+
+        fontFamily = new FontFamily(name);
+        if (FontFamilyCache.Count < FontFamilyCacheLimit)
+        {
+            FontFamilyCache[name] = fontFamily;
+        }
+
+        return fontFamily;
+    }
+
+    // The characters that end an HTML tag name - a literal array here would be allocated per tag.
+    private static readonly char[] TagNameDelimiters = { ' ', '\t', '\r', '\n' };
+
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is not string str || string.IsNullOrEmpty(str))
@@ -72,35 +102,48 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             str = str.Substring(0, 197).TrimEnd() + "...";
         }
 
-        if (Se.Settings.Appearance.SubtitleGridFormattingType == (int)SubtitleGridFormattingTypes.ShowFormatting)
+        var formattingType = Se.Settings.Appearance.SubtitleGridFormattingType;
+        if (formattingType == (int)SubtitleGridFormattingTypes.ShowFormatting)
         {
             var lines = MakeShowFormatting(str);
             return SpellCheckLines(lines);
         }
 
-        if (Se.Settings.Appearance.SubtitleGridFormattingType == (int)SubtitleGridFormattingTypes.ShowTags)
+        if (formattingType == (int)SubtitleGridFormattingTypes.ShowTags)
         {
             var lines = MakeShowTags(str);
             return SpellCheckLines(lines);
         }
 
-        // No formatting (default)
+        // No formatting (default) - walk the line breaks directly instead of SplitToLines(),
+        // which builds a List plus one string per line only to hand each one to a Run.
         var inlines = new InlineCollection();
-        var firstLine = true;
-        foreach (var line in str.SplitToLines())
+        var lineStart = 0;
+        var i = 0;
+        while (i < str.Length)
         {
-            if (!firstLine)
+            var c = str[i];
+            if (c != '\r' && c != '\n' && c != '\u2028')
             {
-                AppendLineSeparator(inlines);
+                i++;
+                continue;
             }
 
-            if (line.Length > 0)
+            if (i > lineStart)
             {
-                inlines.Add(new Run(line));
+                inlines.Add(new Run(str.Substring(lineStart, i - lineStart)));
             }
 
-            firstLine = false;
+            i += c == '\r' && i + 1 < str.Length && str[i + 1] == '\n' ? 2 : 1;
+            lineStart = i;
+            AppendLineSeparator(inlines);
         }
+
+        if (lineStart < str.Length)
+        {
+            inlines.Add(new Run(lineStart == 0 ? str : str.Substring(lineStart)));
+        }
+
         return SpellCheckLines(inlines);
     }
 
@@ -359,9 +402,85 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
         return false;
     }
 
+    /// <summary>
+    /// Collects markup into as few <see cref="Run"/>s as possible. Neighbouring characters that
+    /// share a foreground render identically whether they sit in one run or in ten, and a Run is
+    /// an AvaloniaObject - the number of runs, not the string work, is what a cell repaint costs.
+    /// Text is appended straight out of the source string, so the per-token substrings are gone
+    /// as well.
+    /// </summary>
+    private sealed class InlineBuilder
+    {
+        private readonly InlineCollection _inlines = new();
+        private readonly StringBuilder _pending = new(64);
+        private IBrush? _pendingBrush;
+
+        public void Append(char c, IBrush? brush)
+        {
+            StartSegment(brush);
+            _pending.Append(c);
+        }
+
+        public void Append(string text, IBrush? brush)
+        {
+            StartSegment(brush);
+            _pending.Append(text);
+        }
+
+        public void Append(string source, int start, int length, IBrush? brush)
+        {
+            if (length <= 0)
+            {
+                return;
+            }
+
+            StartSegment(brush);
+            _pending.Append(source, start, length);
+        }
+
+        public void AddLineBreak()
+        {
+            Flush();
+            _inlines.Add(new LineBreak());
+        }
+
+        public InlineCollection Build()
+        {
+            Flush();
+            return _inlines;
+        }
+
+        private void StartSegment(IBrush? brush)
+        {
+            if (_pending.Length > 0 && !ReferenceEquals(brush, _pendingBrush))
+            {
+                Flush();
+            }
+
+            _pendingBrush = brush;
+        }
+
+        private void Flush()
+        {
+            if (_pending.Length == 0)
+            {
+                return;
+            }
+
+            var run = new Run(_pending.ToString());
+            if (_pendingBrush != null)
+            {
+                run.Foreground = _pendingBrush;
+            }
+
+            _inlines.Add(run);
+            _pending.Clear();
+        }
+    }
+
     private static InlineCollection MakeShowTags(string str)
     {
-        var inlines = new InlineCollection();
+        var builder = new InlineBuilder();
         var i = 0;
         while (i < str.Length)
         {
@@ -375,7 +494,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                 if (tagEnd != -1)
                 {
                     // Add opening brace
-                    inlines.Add(new Run("{") { Foreground = CharsBrush });
+                    builder.Append('{', CharsBrush);
 
                     // Process all tags within the braces (separated by backslashes)
                     var currentPos = i + 1;
@@ -388,7 +507,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                         }
 
                         // Add the backslash
-                        inlines.Add(new Run("\\") { Foreground = CharsBrush });
+                        builder.Append('\\', CharsBrush);
 
                         // Find where this tag ends (next backslash or closing brace)
                         var nextBackslash = str.IndexOf('\\', currentPos + 1);
@@ -398,44 +517,34 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                         var tagNameEnd = SubtitleSyntaxTokenizer.GetAssTagNameEnd(str, tagNameStart, thisTagEnd);
 
                         // Add tag name
-                        if (tagNameEnd > tagNameStart)
-                        {
-                            inlines.Add(new Run(str.Substring(tagNameStart, tagNameEnd - tagNameStart))
-                            {
-                                Foreground = ElementBrush
-                            });
-                        }
+                        builder.Append(str, tagNameStart, tagNameEnd - tagNameStart, ElementBrush);
 
                         // Add tag value/parameters (e.g., "1", "Arial", "&HFFFFFF&")
                         if (tagNameEnd < thisTagEnd)
                         {
-                            var tagName = str.Substring(tagNameStart, tagNameEnd - tagNameStart);
-                            var tagValue = str.Substring(tagNameEnd, thisTagEnd - tagNameEnd);
-
                             Color? assColor = null;
-                            if (SubtitleSyntaxTokenizer.IsAssColorTag(tagName))
+                            if (SubtitleSyntaxTokenizer.IsAssColorTag(str.AsSpan(tagNameStart, tagNameEnd - tagNameStart)))
                             {
-                                assColor = SubtitleSyntaxTokenizer.TryParseAssColor(tagValue);
+                                // Only the color tags need the value as a string
+                                assColor = SubtitleSyntaxTokenizer.TryParseAssColor(str.Substring(tagNameEnd, thisTagEnd - tagNameEnd));
                             }
 
-                            inlines.Add(new Run(tagValue)
-                            {
-                                Foreground = assColor.HasValue ? new SolidColorBrush(assColor.Value) : ValuesBrush
-                            });
+                            builder.Append(str, tagNameEnd, thisTagEnd - tagNameEnd,
+                                assColor.HasValue ? CreateBrush(assColor.Value) : ValuesBrush);
                         }
 
                         currentPos = thisTagEnd;
                     }
 
                     // Add closing brace
-                    inlines.Add(new Run("}") { Foreground = CharsBrush });
+                    builder.Append('}', CharsBrush);
                     i = tagEnd + 1;
                     continue;
                 }
                 else
                 {
                     // Malformed ASS/SSA tag - treat as regular text
-                    inlines.Add(new Run(c.ToString()));
+                    builder.Append(c, null);
                     i++;
                     continue;
                 }
@@ -446,10 +555,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             {
                 var commentEnd = str.IndexOf("-->", i + 4, StringComparison.Ordinal);
                 var commentLength = commentEnd != -1 ? commentEnd + 3 - i : str.Length - i;
-                inlines.Add(new Run(str.Substring(i, commentLength))
-                {
-                    Foreground = CommentBrush
-                });
+                builder.Append(str, i, commentLength, CommentBrush);
                 i += commentLength;
                 continue;
             }
@@ -460,22 +566,21 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                 var tagEnd = str.IndexOf('>', i + 1);
                 if (tagEnd != -1)
                 {
-                    var tagContent = str.Substring(i, tagEnd - i + 1);
-                    ParseHtmlTag(inlines, tagContent);
+                    ParseHtmlTag(builder, str, i, tagEnd);
                     i = tagEnd + 1;
                     continue;
                 }
                 else
                 {
                     // Malformed HTML tag - treat as regular text
-                    inlines.Add(new Run(c.ToString()));
+                    builder.Append(c, null);
                     i++;
                     continue;
                 }
             }
 
             // Handle line breaks
-            if (AppendLineBreak(inlines, c, c2, ref i))
+            if (AppendLineBreak(builder, c, c2, ref i))
             {
                 continue;
             }
@@ -489,17 +594,17 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
 
             if (i > textStart)
             {
-                inlines.Add(new Run(str.Substring(textStart, i - textStart)));
+                builder.Append(str, textStart, i - textStart, null);
             }
             else
             {
                 // Safety: if we didn't match any condition and haven't advanced, treat as regular character
-                inlines.Add(new Run(str[i].ToString()));
+                builder.Append(str[i], null);
                 i++;
             }
         }
 
-        return inlines;
+        return builder.Build();
     }
 
     private static InlineCollection MakeShowFormatting(string str)
@@ -525,8 +630,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                 var tagEnd = str.IndexOf('}', i + 2);
                 if (tagEnd != -1 && tagEnd - i < 500) // Limit tag length to prevent malicious input
                 {
-                    var tagContent = str.Substring(i + 1, tagEnd - i - 1); // Content between { and }
-                    ParseAssaTags(tagContent, state);
+                    ParseAssaTags(str, i + 1, tagEnd, state); // Content between { and }
                     i = tagEnd + 1;
                     continue;
                 }
@@ -557,8 +661,13 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                 var tagEnd = str.IndexOf('>', i + 1);
                 if (tagEnd != -1 && tagEnd - i < 500) // Limit tag length
                 {
-                    var tagContent = str.Substring(i + 1, tagEnd - i - 1).Trim();
-                    if (string.IsNullOrEmpty(tagContent))
+                    // Tracked as indexes into str: the tag name is only compared, so it never
+                    // needs to be cut out and lower-cased, and only <font> needs its content
+                    // as a string.
+                    var contentStart = i + 1;
+                    var contentEnd = tagEnd;
+                    TrimRange(str, ref contentStart, ref contentEnd);
+                    if (contentEnd <= contentStart)
                     {
                         // Empty tag - treat as regular text
                         var run = CreateFormattedRun(c.ToString(), state);
@@ -567,53 +676,60 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                         continue;
                     }
 
-                    var isClosingTag = tagContent.StartsWith('/');
+                    var isClosingTag = str[contentStart] == '/';
                     if (isClosingTag)
                     {
-                        tagContent = tagContent.Substring(1).Trim();
+                        contentStart++;
+                        TrimRange(str, ref contentStart, ref contentEnd);
                     }
 
-                    var tagNameEnd = tagContent.IndexOfAny(new[] { ' ', '\t', '\r', '\n' });
-                    var tagName = (tagNameEnd > 0 ? tagContent.Substring(0, tagNameEnd) : tagContent).ToLowerInvariant();
+                    var tagNameEnd = contentEnd > contentStart
+                        ? str.IndexOfAny(TagNameDelimiters, contentStart, contentEnd - contentStart)
+                        : -1;
+                    var tagName = str.AsSpan(
+                        contentStart,
+                        (tagNameEnd > contentStart ? tagNameEnd : contentEnd) - contentStart);
 
                     if (isClosingTag)
                     {
                         // Handle closing tags
-                        switch (tagName)
+                        if (tagName.Equals("i", StringComparison.OrdinalIgnoreCase))
                         {
-                            case "i":
-                                state.Italic = false;
-                                break;
-                            case "b":
-                                state.Bold = false;
-                                break;
-                            case "u":
-                                state.Underline = false;
-                                break;
-                            case "font":
-                                state.Color = null;
-                                state.FontName = null;
-                                state.FontSize = null;
-                                break;
+                            state.Italic = false;
+                        }
+                        else if (tagName.Equals("b", StringComparison.OrdinalIgnoreCase))
+                        {
+                            state.Bold = false;
+                        }
+                        else if (tagName.Equals("u", StringComparison.OrdinalIgnoreCase))
+                        {
+                            state.Underline = false;
+                        }
+                        else if (tagName.Equals("font", StringComparison.OrdinalIgnoreCase))
+                        {
+                            state.Color = null;
+                            state.FontName = null;
+                            state.FontSize = null;
                         }
                     }
                     else
                     {
                         // Handle opening tags
-                        switch (tagName)
+                        if (tagName.Equals("i", StringComparison.OrdinalIgnoreCase))
                         {
-                            case "i":
-                                state.Italic = true;
-                                break;
-                            case "b":
-                                state.Bold = true;
-                                break;
-                            case "u":
-                                state.Underline = true;
-                                break;
-                            case "font":
-                                ParseFontTag(tagContent, state);
-                                break;
+                            state.Italic = true;
+                        }
+                        else if (tagName.Equals("b", StringComparison.OrdinalIgnoreCase))
+                        {
+                            state.Bold = true;
+                        }
+                        else if (tagName.Equals("u", StringComparison.OrdinalIgnoreCase))
+                        {
+                            state.Underline = true;
+                        }
+                        else if (tagName.Equals("font", StringComparison.OrdinalIgnoreCase))
+                        {
+                            ParseFontTag(str.Substring(contentStart, contentEnd - contentStart), state);
                         }
                     }
                     i = tagEnd + 1;
@@ -676,6 +792,22 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
         return inlines;
     }
 
+    /// <summary>
+    /// Narrows [start, end) to the same range String.Trim() would keep.
+    /// </summary>
+    private static void TrimRange(string source, ref int start, ref int end)
+    {
+        while (start < end && char.IsWhiteSpace(source[start]))
+        {
+            start++;
+        }
+
+        while (end > start && char.IsWhiteSpace(source[end - 1]))
+        {
+            end--;
+        }
+    }
+
     private static Run CreateFormattedRun(string text, FormattingState state)
     {
         var run = new Run(text);
@@ -701,13 +833,13 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
         // Apply color
         if (state.Color.HasValue)
         {
-            run.Foreground = new SolidColorBrush(state.Color.Value);
+            run.Foreground = CreateBrush(state.Color.Value);
         }
 
         // Apply font name
         if (!string.IsNullOrEmpty(state.FontName))
         {
-            run.FontFamily = new FontFamily(state.FontName);
+            run.FontFamily = GetFontFamily(state.FontName);
         }
 
         // Apply font size
@@ -731,8 +863,12 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
 
         try
         {
+            // Every Match allocates, and a <font> tag almost never carries all three attributes -
+            // a plain substring probe first tells us whether the pattern can match at all.
             // Parse color attribute
-            var colorMatch = FontColorRegex.Match(tagContent);
+            var colorMatch = tagContent.Contains("color", StringComparison.OrdinalIgnoreCase)
+                ? FontColorRegex.Match(tagContent)
+                : Match.Empty;
             if (colorMatch.Success)
             {
                 var colorValue = colorMatch.Groups[1].Value;
@@ -751,7 +887,9 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             }
 
             // Parse face (font name) attribute
-            var faceMatch = FontFaceRegex.Match(tagContent);
+            var faceMatch = tagContent.Contains("face", StringComparison.OrdinalIgnoreCase)
+                ? FontFaceRegex.Match(tagContent)
+                : Match.Empty;
             if (faceMatch.Success)
             {
                 var fontName = faceMatch.Groups[1].Value.Trim();
@@ -762,7 +900,9 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             }
 
             // Parse size attribute
-            var sizeMatch = FontSizeRegex.Match(tagContent);
+            var sizeMatch = tagContent.Contains("size", StringComparison.OrdinalIgnoreCase)
+                ? FontSizeRegex.Match(tagContent)
+                : Match.Empty;
             if (sizeMatch.Success && double.TryParse(sizeMatch.Groups[1].Value, out var size))
             {
                 state.FontSize = size;
@@ -778,24 +918,41 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
         }
     }
 
-    private static void ParseAssaTags(string tagContent, FormattingState state)
+    /// <summary>
+    /// Applies the ASSA override tags in source[start..end) to <paramref name="state"/>. Indexes
+    /// plus spans instead of Split + Trim + Substring: this runs for every ASSA tag block of
+    /// every visible row on every repaint, and only a font name ends up as a string.
+    /// </summary>
+    private static void ParseAssaTags(string source, int start, int end, FormattingState state)
     {
-        if (string.IsNullOrEmpty(tagContent) || tagContent.Length > 500)
+        var length = end - start;
+        if (length <= 0 || length > 500)
         {
             return; // Skip empty or excessively long tag content
         }
 
-        // Split by backslash to get individual tags
-        var tags = tagContent.Split('\\', StringSplitOptions.RemoveEmptyEntries);
+        var content = source.AsSpan(start, length);
 
         // Limit number of tags to prevent excessive processing
-        var maxTags = Math.Min(tags.Length, 50);
+        const int maxTags = 50;
+        var handled = 0;
+        var pos = 0;
 
-        for (var i = 0; i < maxTags; i++)
+        while (pos < content.Length && handled < maxTags)
         {
-            var tag = tags[i];
-            var trimmedTag = tag.Trim();
-            if (string.IsNullOrEmpty(trimmedTag) || trimmedTag.Length > 100)
+            var next = content.Slice(pos).IndexOf('\\');
+            var segment = next < 0 ? content.Slice(pos) : content.Slice(pos, next);
+            pos = next < 0 ? content.Length : pos + next + 1;
+
+            if (segment.Length == 0)
+            {
+                continue; // Split(RemoveEmptyEntries) dropped these before they were counted
+            }
+
+            handled++;
+
+            var trimmedTag = segment.Trim();
+            if (trimmedTag.Length == 0 || trimmedTag.Length > 100)
             {
                 continue; // Skip empty or excessively long individual tags
             }
@@ -820,12 +977,12 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             // Bold: \b1 or \b0 (can also be \b700 for weight)
             if (firstChar == 'b' && tagLen >= 2 && char.IsDigit(trimmedTag[1]))
             {
-                var value = trimmedTag.Substring(1);
-                if (value == "0")
+                var value = trimmedTag.Slice(1);
+                if (value.Length == 1 && value[0] == '0')
                 {
                     state.Bold = false;
                 }
-                else if (value == "1")
+                else if (value.Length == 1 && value[0] == '1')
                 {
                     state.Bold = true;
                 }
@@ -846,10 +1003,10 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             // Font name: \fnFontName
             if (tagLen > 2 && firstChar == 'f' && trimmedTag[1] == 'n')
             {
-                var fontName = trimmedTag.Substring(2).Trim();
+                var fontName = trimmedTag.Slice(2).Trim();
                 if (fontName.Length > 0 && fontName.Length <= 100)
                 {
-                    state.FontName = fontName;
+                    state.FontName = fontName.ToString();
                 }
                 continue;
             }
@@ -857,7 +1014,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             // Font size: \fs20
             if (tagLen > 2 && firstChar == 'f' && trimmedTag[1] == 's')
             {
-                var sizeStr = trimmedTag.Substring(2);
+                var sizeStr = trimmedTag.Slice(2);
                 if (sizeStr.Length <= 4 && double.TryParse(sizeStr, NumberStyles.Any, CultureInfo.InvariantCulture, out var size))
                 {
                     state.FontSize = size;
@@ -875,8 +1032,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                 }
                 else
                 {
-                    var colorStr = trimmedTag.Substring(1);
-                    state.Color = ParseAssaColor(colorStr);
+                    state.Color = ParseAssaColor(trimmedTag.Slice(1));
                 }
                 continue;
             }
@@ -887,56 +1043,71 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                 // For numbered color tags, we only handle primary (1c) for text color
                 if (firstChar == '1')
                 {
-                    var colorStr = trimmedTag.Substring(2);
-                    state.Color = ParseAssaColor(colorStr);
+                    state.Color = ParseAssaColor(trimmedTag.Slice(2));
                 }
             }
         }
     }
 
-    private static Color? ParseAssaColor(string colorStr)
+    private static Color? ParseAssaColor(ReadOnlySpan<char> colorStr)
     {
-        if (string.IsNullOrEmpty(colorStr) || colorStr.Length > 20)
+        if (colorStr.Length == 0 || colorStr.Length > 20)
         {
             return null; // Skip empty or excessively long color strings
         }
 
+        // ASSA colors are in format &HAABBGGRR& or &HBBGGRR& (BGR order, not RGB)
+        colorStr = colorStr.Trim("&Hh".AsSpan());
+
+        if (colorStr.Length < 6 || colorStr.Length > 8)
+        {
+            return null; // Invalid length
+        }
+
+        // ASSA format: [AA]BBGGRR - the color bytes are always the last six characters, and a
+        // six-character value is the same as one padded with an alpha of 00 (= fully opaque).
+        var rgb = colorStr.Slice(colorStr.Length - 6);
+        if (!TryParseHexByte(rgb.Slice(0, 2), out var blue) ||
+            !TryParseHexByte(rgb.Slice(2, 2), out var green) ||
+            !TryParseHexByte(rgb.Slice(4, 2), out var red))
+        {
+            return null;
+        }
+
+        byte alpha = 255;
+        if (colorStr.Length >= 8)
+        {
+            if (!TryParseHexByte(colorStr.Slice(0, 2), out var alphaValue))
+            {
+                return null;
+            }
+
+            alpha = (byte)(255 - alphaValue); // ASSA alpha is inverted (0 = opaque, 255 = transparent)
+        }
+
+        return Color.FromArgb(alpha, red, green, blue);
+    }
+
+    private static bool TryParseHexByte(ReadOnlySpan<char> hex, out byte value)
+    {
+        if (byte.TryParse(hex, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out value))
+        {
+            return true;
+        }
+
+        // Convert.ToByte(s, 16) - what this used to be - also accepts shapes byte.TryParse
+        // rejects, e.g. a leading sign ("+1") or an "0x" prefix. Malformed color values are rare
+        // enough that reproducing them through the old, allocating path costs nothing in practice.
         try
         {
-            // ASSA colors are in format &HAABBGGRR& or &HBBGGRR& (BGR order, not RGB)
-            colorStr = colorStr.Trim('&', 'H', 'h');
-
-            if (string.IsNullOrEmpty(colorStr) || colorStr.Length < 6 || colorStr.Length > 8)
-            {
-                return null; // Invalid length
-            }
-
-            // Pad to 8 characters if needed (add alpha)
-            if (colorStr.Length == 6)
-            {
-                colorStr = "00" + colorStr; // Add alpha = 0 (fully opaque in ASSA)
-            }
-
-            // ASSA format: AABBGGRR
-            var blue = System.Convert.ToByte(colorStr.Substring(colorStr.Length - 6, 2), 16);
-            var green = System.Convert.ToByte(colorStr.Substring(colorStr.Length - 4, 2), 16);
-            var red = System.Convert.ToByte(colorStr.Substring(colorStr.Length - 2, 2), 16);
-            byte alpha = 255;
-
-            if (colorStr.Length >= 8)
-            {
-                var alphaValue = System.Convert.ToByte(colorStr.Substring(0, 2), 16);
-                alpha = (byte)(255 - alphaValue); // ASSA alpha is inverted (0 = opaque, 255 = transparent)
-            }
-
-            return Color.FromArgb(alpha, red, green, blue);
+            value = System.Convert.ToByte(hex.ToString(), 16);
+            return true;
         }
         catch
         {
-            // Ignore parsing errors
+            value = 0;
+            return false;
         }
-
-        return null;
     }
 
     private class FormattingState
@@ -959,155 +1130,181 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
         }
     }
 
-    private static void ParseHtmlTag(InlineCollection inlines, string tagContent)
+    /// <summary>
+    /// Renders the tag between <paramref name="start"/> (the '&lt;') and <paramref name="end"/>
+    /// (the '&gt;'). Works on indexes into the source string so nothing between them has to be
+    /// copied out first.
+    /// </summary>
+    private static void ParseHtmlTag(InlineBuilder builder, string source, int start, int end)
     {
         // Add opening <
-        inlines.Add(new Run("<") { Foreground = CharsBrush });
+        builder.Append('<', CharsBrush);
 
-        var content = tagContent.Substring(1, tagContent.Length - 2); // Remove < and >
-        var isClosingTag = content.StartsWith('/');
-        if (isClosingTag)
+        var contentStart = start + 1; // just after <
+        var contentEnd = end;         // exclusive, i.e. just before >
+
+        if (contentStart < contentEnd && source[contentStart] == '/')
         {
-            inlines.Add(new Run("/") { Foreground = CharsBrush });
-            content = content.Substring(1);
+            builder.Append('/', CharsBrush);
+            contentStart++;
         }
 
-        var isSelfClosing = content.EndsWith('/');
+        var isSelfClosing = contentEnd > contentStart && source[contentEnd - 1] == '/';
         if (isSelfClosing)
         {
-            content = content.Substring(0, content.Length - 1).TrimEnd();
+            contentEnd--;
+            while (contentEnd > contentStart && char.IsWhiteSpace(source[contentEnd - 1]))
+            {
+                contentEnd--;
+            }
         }
 
         // Find element name
-        var spaceIndex = content.IndexOf(' ');
-        var elementName = spaceIndex > 0 ? content.Substring(0, spaceIndex) : content;
+        var spaceIndex = contentEnd > contentStart
+            ? source.IndexOf(' ', contentStart, contentEnd - contentStart)
+            : -1;
+        var elementNameEnd = spaceIndex > contentStart ? spaceIndex : contentEnd;
 
         // Add element name
-        inlines.Add(new Run(elementName) { Foreground = ElementBrush });
+        builder.Append(source, contentStart, elementNameEnd - contentStart, ElementBrush);
 
         // Parse attributes if any
-        if (spaceIndex > 0)
+        if (spaceIndex > contentStart)
         {
-            var attributesPart = content.Substring(spaceIndex);
-            ParseHtmlAttributes(inlines, attributesPart);
+            ParseHtmlAttributes(builder, source, spaceIndex, contentEnd);
         }
 
         // Add self-closing /
         if (isSelfClosing)
         {
-            inlines.Add(new Run(" /") { Foreground = CharsBrush });
+            builder.Append(" /", CharsBrush);
         }
 
         // Add closing >
-        inlines.Add(new Run(">") { Foreground = CharsBrush });
+        builder.Append('>', CharsBrush);
     }
 
-    private static void ParseHtmlAttributes(InlineCollection inlines, string attributesPart)
+    private static void ParseHtmlAttributes(InlineBuilder builder, string source, int start, int end)
     {
-        int i = 0;
-        while (i < attributesPart.Length)
+        var i = start;
+        while (i < end)
         {
-            // Skip whitespace
-            while (i < attributesPart.Length && char.IsWhiteSpace(attributesPart[i]))
-            {
-                inlines.Add(new Run(attributesPart[i].ToString()));
-                i++;
-            }
-
-            if (i >= attributesPart.Length)
+            // Skip whitespace - one segment for the whole stretch instead of one per space
+            i = AppendWhitespace(builder, source, i, end);
+            if (i >= end)
             {
                 break;
             }
 
             // Read attribute name
             var attrStart = i;
-            while (i < attributesPart.Length && (char.IsLetterOrDigit(attributesPart[i]) || attributesPart[i] == '-' || attributesPart[i] == '_'))
+            while (i < end && (char.IsLetterOrDigit(source[i]) || source[i] == '-' || source[i] == '_'))
             {
                 i++;
             }
 
-            var attributeName = string.Empty;
-            if (i > attrStart)
+            var attributeNameLength = i - attrStart;
+            if (attributeNameLength > 0)
             {
-                attributeName = attributesPart.Substring(attrStart, i - attrStart);
-                inlines.Add(new Run(attributeName)
-                {
-                    Foreground = AttributeBrush
-                });
+                builder.Append(source, attrStart, attributeNameLength, AttributeBrush);
             }
-            else if (i < attributesPart.Length)
+            else if (i < end)
             {
                 // Unexpected character - add it and move on to prevent infinite loop
-                inlines.Add(new Run(attributesPart[i].ToString()));
+                builder.Append(source[i], null);
                 i++;
             }
 
             // Skip whitespace
-            while (i < attributesPart.Length && char.IsWhiteSpace(attributesPart[i]))
-            {
-                inlines.Add(new Run(attributesPart[i].ToString()));
-                i++;
-            }
+            i = AppendWhitespace(builder, source, i, end);
 
             // Check for =
-            if (i < attributesPart.Length && attributesPart[i] == '=')
+            if (i >= end || source[i] != '=')
             {
-                inlines.Add(new Run("=") { Foreground = CharsBrush });
+                continue;
+            }
+
+            builder.Append('=', CharsBrush);
+            i++;
+
+            // Skip whitespace
+            i = AppendWhitespace(builder, source, i, end);
+
+            // Read attribute value (quoted)
+            if (i >= end || (source[i] != '"' && source[i] != '\''))
+            {
+                continue;
+            }
+
+            var quote = source[i];
+            builder.Append(quote, CharsBrush);
+            i++;
+
+            var valueStart = i;
+            while (i < end && source[i] != quote)
+            {
                 i++;
+            }
 
-                // Skip whitespace
-                while (i < attributesPart.Length && char.IsWhiteSpace(attributesPart[i]))
+            if (i > valueStart)
+            {
+                // Check if this is a color attribute and try to parse the actual color
+                IBrush valueBrush;
+                if (source.AsSpan(attrStart, attributeNameLength).Equals("color", StringComparison.OrdinalIgnoreCase))
                 {
-                    inlines.Add(new Run(attributesPart[i].ToString()));
-                    i++;
+                    var parsedColor = SubtitleSyntaxTokenizer.TryParseColor(source.Substring(valueStart, i - valueStart));
+                    valueBrush = parsedColor.HasValue
+                        ? CreateBrush(parsedColor.Value)
+                        : ValuesBrush;
+                }
+                else
+                {
+                    var hasColon = source.AsSpan(valueStart, i - valueStart).IndexOf(':') >= 0;
+                    valueBrush = hasColon ? StyleBrush : ValuesBrush;
                 }
 
-                // Read attribute value (quoted)
-                if (i < attributesPart.Length && (attributesPart[i] == '"' || attributesPart[i] == '\''))
-                {
-                    var quote = attributesPart[i];
-                    inlines.Add(new Run(quote.ToString()) { Foreground = CharsBrush });
-                    i++;
+                builder.Append(source, valueStart, i - valueStart, valueBrush);
+            }
 
-                    var valueStart = i;
-                    while (i < attributesPart.Length && attributesPart[i] != quote)
-                    {
-                        i++;
-                    }
-
-                    if (i > valueStart)
-                    {
-                        var value = attributesPart.Substring(valueStart, i - valueStart);
-
-                        // Check if this is a color attribute and try to parse the actual color
-                        IBrush valueBrush;
-                        if (attributeName.Equals("color", StringComparison.OrdinalIgnoreCase))
-                        {
-                            var parsedColor = SubtitleSyntaxTokenizer.TryParseColor(value);
-                            valueBrush = parsedColor.HasValue
-                                ? new SolidColorBrush(parsedColor.Value)
-                                : ValuesBrush;
-                        }
-                        else
-                        {
-                            var hasColon = value.Contains(':');
-                            valueBrush = hasColon ? StyleBrush : ValuesBrush;
-                        }
-
-                        inlines.Add(new Run(value)
-                        {
-                            Foreground = valueBrush
-                        });
-                    }
-
-                    if (i < attributesPart.Length)
-                    {
-                        inlines.Add(new Run(quote.ToString()) { Foreground = CharsBrush });
-                        i++;
-                    }
-                }
+            if (i < end)
+            {
+                builder.Append(quote, CharsBrush);
+                i++;
             }
         }
+    }
+
+    private static int AppendWhitespace(InlineBuilder builder, string source, int i, int end)
+    {
+        var whitespaceStart = i;
+        while (i < end && char.IsWhiteSpace(source[i]))
+        {
+            i++;
+        }
+
+        builder.Append(source, whitespaceStart, i - whitespaceStart, null);
+        return i;
+    }
+
+    private static bool AppendLineBreak(InlineBuilder builder, char c, char c2, ref int i)
+    {
+        if (c != '\n' && c != '\r' && c != '\u2028')
+        {
+            return false;
+        }
+
+        var separator = GetLineSeparator();
+        if (separator == null)
+        {
+            builder.AddLineBreak();
+        }
+        else
+        {
+            builder.Append(separator, AttributeBrush);
+        }
+
+        i += c == '\r' && c2 == '\n' ? 2 : 1;
+        return true;
     }
 
     private static bool AppendLineBreak(InlineCollection inlines, char c, char c2, ref int i)
@@ -1124,23 +1321,33 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
 
     private static void AppendLineSeparator(InlineCollection inlines)
     {
-        if (Se.Settings.Appearance.SubtitleGridTextSingleLine)
+        var separator = GetLineSeparator();
+        if (separator == null)
         {
-            var separator = Se.Settings.Appearance.SubtitleGridTextSingleLineSeparator;
-            if (string.IsNullOrEmpty(separator))
-            {
-                separator = " ";
-            }
-
-            // Add the separator as literal text so markup-like separators (e.g. "<br />")
-            // are shown verbatim instead of being parsed away by the formatter. Render it in the
-            // soft blue accent (AttributeBrush) - a mid-tone that reads on both light and dark
-            // themes - so the separator stands out clearly from the actual subtitle text.
-            inlines.Add(new Run(separator) { Foreground = AttributeBrush });
+            inlines.Add(new LineBreak());
             return;
         }
 
-        inlines.Add(new LineBreak());
+        inlines.Add(new Run(separator) { Foreground = AttributeBrush });
+    }
+
+    /// <summary>
+    /// The text a line break renders as in single-line mode, or null for a real line break.
+    /// The separator is added as literal text so markup-like separators (e.g. "&lt;br /&gt;") are
+    /// shown verbatim instead of being parsed away by the formatter. It is rendered in the soft
+    /// blue accent (AttributeBrush) - a mid-tone that reads on both light and dark themes - so it
+    /// stands out clearly from the actual subtitle text.
+    /// </summary>
+    private static string? GetLineSeparator()
+    {
+        var appearance = Se.Settings.Appearance;
+        if (!appearance.SubtitleGridTextSingleLine)
+        {
+            return null;
+        }
+
+        var separator = appearance.SubtitleGridTextSingleLineSeparator;
+        return string.IsNullOrEmpty(separator) ? " " : separator;
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/src/ui/Logic/ValueConverters/TimeSpanToDisplayShortConverter.cs
+++ b/src/ui/Logic/ValueConverters/TimeSpanToDisplayShortConverter.cs
@@ -11,25 +11,23 @@ public class TimeSpanToDisplayShortConverter : IValueConverter
 {
     public static readonly TimeSpanToDisplayShortConverter Instance = new();
 
+    // Reused to avoid per-call TimeCode allocations (expected to be used from the UI thread only).
+    private readonly TimeCode _formattingTimeCode = new();
+    private const string ZeroFrameMode = "00.00";
+    private const string ZeroTime = "00,000";
+
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
+        var useFrameMode = Se.Settings.General.UseFrameMode;
         if (value is TimeSpan ts)
         {
-            if (Se.Settings.General.UseFrameMode)
-            {
-                return new TimeCode(ts).ToShortStringHHMMSSFF();
-            }
-
-            var result = new TimeCode(ts).ToShortString();
-            return result;
-        }
-        
-        if (Se.Settings.General.UseFrameMode)
-        {
-            return "00.00";
+            _formattingTimeCode.TimeSpan = ts;
+            return useFrameMode
+                ? _formattingTimeCode.ToShortStringHHMMSSFF()
+                : _formattingTimeCode.ToShortString();
         }
 
-        return "00,000";
+        return useFrameMode ? ZeroFrameMode : ZeroTime;
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/tests/UI/Logic/ValueConverters/ValueConverterTests.cs
+++ b/tests/UI/Logic/ValueConverters/ValueConverterTests.cs
@@ -1,0 +1,432 @@
+using Avalonia.Controls.Documents;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.ValueConverters;
+using System.Globalization;
+
+namespace UITests.Logic.ValueConverters;
+
+/// <summary>
+/// Covers the behaviour the grid-cell converters have to keep: which characters end up in which
+/// color, which formatting a run carries, and the sentinel/edge cases. The converters run per
+/// visible row on every repaint, so they get rewritten for speed now and then - these tests are
+/// what says the output did not move.
+/// </summary>
+public class ValueConverterTests
+{
+    private static readonly CultureInfo Culture = CultureInfo.InvariantCulture;
+
+    private static InlineCollection Highlight(string text, SubtitleGridFormattingTypes mode, bool singleLine = false)
+    {
+        var previousMode = Se.Settings.Appearance.SubtitleGridFormattingType;
+        var previousSingleLine = Se.Settings.Appearance.SubtitleGridTextSingleLine;
+        var previousSpellCheck = Se.Settings.Appearance.SubtitleGridLiveSpellCheck;
+        try
+        {
+            Se.Settings.Appearance.SubtitleGridFormattingType = (int)mode;
+            Se.Settings.Appearance.SubtitleGridTextSingleLine = singleLine;
+            Se.Settings.Appearance.SubtitleGridLiveSpellCheck = false;
+            var converter = new TextWithSubtitleSyntaxHighlightingConverter();
+            return (InlineCollection)converter.Convert(text, typeof(InlineCollection), null, Culture)!;
+        }
+        finally
+        {
+            Se.Settings.Appearance.SubtitleGridFormattingType = previousMode;
+            Se.Settings.Appearance.SubtitleGridTextSingleLine = previousSingleLine;
+            Se.Settings.Appearance.SubtitleGridLiveSpellCheck = previousSpellCheck;
+        }
+    }
+
+    /// <summary>All rendered characters, with a line break rendering as "\n".</summary>
+    private static string FlatText(InlineCollection inlines)
+    {
+        var text = string.Empty;
+        foreach (var inline in inlines)
+        {
+            text += inline switch
+            {
+                LineBreak => "\n",
+                Run run => run.Text ?? string.Empty,
+                _ => string.Empty,
+            };
+        }
+
+        return text;
+    }
+
+    /// <summary>The characters that carry <paramref name="color"/> as their foreground.</summary>
+    private static string TextWithColor(InlineCollection inlines, Color color)
+    {
+        var text = string.Empty;
+        foreach (var inline in inlines)
+        {
+            if (inline is Run run && run.Foreground is ISolidColorBrush brush && brush.Color == color)
+            {
+                text += run.Text;
+            }
+        }
+
+        return text;
+    }
+
+    private static Run SingleRun(InlineCollection inlines)
+    {
+        var run = Assert.IsType<Run>(Assert.Single(inlines));
+        return run;
+    }
+
+    [AvaloniaFact]
+    public void NoFormatting_KeepsMarkupVerbatimAndBreaksLines()
+    {
+        var inlines = Highlight("<i>one</i>\r\ntwo", SubtitleGridFormattingTypes.NoFormatting);
+
+        Assert.Equal("<i>one</i>\ntwo", FlatText(inlines));
+        Assert.Contains(inlines, i => i is LineBreak);
+    }
+
+    [AvaloniaFact]
+    public void NoFormatting_SingleLineModeUsesTheSeparatorInsteadOfALineBreak()
+    {
+        var previous = Se.Settings.Appearance.SubtitleGridTextSingleLineSeparator;
+        try
+        {
+            Se.Settings.Appearance.SubtitleGridTextSingleLineSeparator = " | ";
+            var inlines = Highlight("one\r\ntwo", SubtitleGridFormattingTypes.NoFormatting, singleLine: true);
+
+            Assert.Equal("one | two", FlatText(inlines));
+            Assert.DoesNotContain(inlines, i => i is LineBreak);
+        }
+        finally
+        {
+            Se.Settings.Appearance.SubtitleGridTextSingleLineSeparator = previous;
+        }
+    }
+
+    [AvaloniaTheory]
+    [InlineData("")]
+    [InlineData("one")]
+    [InlineData("one\r\ntwo")]
+    [InlineData("one\ntwo")]
+    [InlineData("one\rtwo")]
+    [InlineData("one\r\n\r\ntwo")]
+    [InlineData("\r\none")]
+    [InlineData("one\r\n")]
+    public void NoFormatting_RendersEveryLineOfPlainText(string text)
+    {
+        var expected = text.Replace("\r\n", "\n").Replace('\r', '\n');
+
+        Assert.Equal(expected, FlatText(Highlight(text, SubtitleGridFormattingTypes.NoFormatting)));
+    }
+
+    [AvaloniaFact]
+    public void ShowFormatting_HidesTheMarkupAndAppliesIt()
+    {
+        var inlines = Highlight("<i><b><u>styled</u></b></i>", SubtitleGridFormattingTypes.ShowFormatting);
+
+        var run = SingleRun(inlines);
+        Assert.Equal("styled", run.Text);
+        Assert.Equal(FontStyle.Italic, run.FontStyle);
+        Assert.Equal(FontWeight.Bold, run.FontWeight);
+        Assert.NotNull(run.TextDecorations);
+        Assert.NotEmpty(run.TextDecorations!);
+    }
+
+    [AvaloniaFact]
+    public void ShowFormatting_AppliesFontTagAttributes()
+    {
+        var inlines = Highlight("<font color=\"#ff8800\" face=\"Arial\" size=\"20\">x</font>",
+            SubtitleGridFormattingTypes.ShowFormatting);
+
+        var run = SingleRun(inlines);
+        Assert.Equal("x", run.Text);
+        Assert.Equal(Color.FromArgb(255, 0xff, 0x88, 0x00), Assert.IsAssignableFrom<ISolidColorBrush>(run.Foreground).Color);
+        Assert.Equal("Arial", run.FontFamily.Name);
+        Assert.Equal(16, run.FontSize); // 20 * 0.8, clamped to 8..24
+    }
+
+    [AvaloniaFact]
+    public void ShowFormatting_ClosingFontTagResetsColorFaceAndSize()
+    {
+        var inlines = Highlight("<font color=\"#ff8800\" face=\"Arial\" size=\"20\">a</font>b",
+            SubtitleGridFormattingTypes.ShowFormatting);
+
+        var last = Assert.IsType<Run>(inlines[^1]);
+        Assert.Equal("b", last.Text);
+        Assert.False(last.IsSet(TextElement.ForegroundProperty));
+        Assert.False(last.IsSet(TextElement.FontFamilyProperty));
+        Assert.False(last.IsSet(TextElement.FontSizeProperty));
+    }
+
+    [AvaloniaTheory]
+    [InlineData("{\\i1}x", true)]
+    [InlineData("{\\i0}x", false)]
+    [InlineData("{\\i1\\r}x", false)]
+    public void ShowFormatting_AppliesAssaItalic(string text, bool italic)
+    {
+        var run = SingleRun(Highlight(text, SubtitleGridFormattingTypes.ShowFormatting));
+
+        Assert.Equal(italic ? FontStyle.Italic : FontStyle.Normal, run.FontStyle);
+    }
+
+    [AvaloniaTheory]
+    [InlineData("{\\b1}x", true)]
+    [InlineData("{\\b0}x", false)]
+    [InlineData("{\\b700}x", true)]
+    [InlineData("{\\b400}x", false)]
+    public void ShowFormatting_AppliesAssaBoldAndWeights(string text, bool bold)
+    {
+        var run = SingleRun(Highlight(text, SubtitleGridFormattingTypes.ShowFormatting));
+
+        Assert.Equal(bold ? FontWeight.Bold : FontWeight.Normal, run.FontWeight);
+    }
+
+    [AvaloniaTheory]
+    // ASSA colors are BGR with an inverted alpha: &HBBGGRR& and &HAABBGGRR&.
+    [InlineData("{\\c&H00FF00&}x", 255, 0, 255, 0)]
+    [InlineData("{\\c&HFF0000&}x", 255, 0, 0, 255)]
+    [InlineData("{\\1c&H0000FF&}x", 255, 255, 0, 0)]
+    [InlineData("{\\c&H8000FF00&}x", 127, 0, 255, 0)]
+    public void ShowFormatting_ParsesAssaColors(string text, int a, int r, int g, int b)
+    {
+        var run = SingleRun(Highlight(text, SubtitleGridFormattingTypes.ShowFormatting));
+
+        Assert.Equal(Color.FromArgb((byte)a, (byte)r, (byte)g, (byte)b),
+            Assert.IsAssignableFrom<ISolidColorBrush>(run.Foreground).Color);
+    }
+
+    [AvaloniaTheory]
+    [InlineData("{\\c}x")]              // reset
+    [InlineData("{\\c&HFFF&}x")]        // too short
+    [InlineData("{\\c&HZZZZZZ&}x")]     // not hex
+    [InlineData("{\\c&H0011223344&}x")] // too long
+    [InlineData("{\\2c&H00FF00&}x")]    // secondary color is not the text color
+    public void ShowFormatting_LeavesForegroundUnsetForUnusableAssaColors(string text)
+    {
+        var run = SingleRun(Highlight(text, SubtitleGridFormattingTypes.ShowFormatting));
+
+        Assert.False(run.IsSet(TextElement.ForegroundProperty));
+    }
+
+    [AvaloniaFact]
+    public void ShowFormatting_AppliesAssaFontNameAndSize()
+    {
+        var run = SingleRun(Highlight("{\\fnArial\\fs20}x", SubtitleGridFormattingTypes.ShowFormatting));
+
+        Assert.Equal("Arial", run.FontFamily.Name);
+        Assert.Equal(16, run.FontSize);
+    }
+
+    [AvaloniaFact]
+    public void ShowTags_ShowsTheMarkupItself()
+    {
+        var text = "<font color=\"#00ff00\">hi</font>";
+
+        Assert.Equal(text, FlatText(Highlight(text, SubtitleGridFormattingTypes.ShowTags)));
+    }
+
+    [AvaloniaFact]
+    public void ShowTags_ColorsElementNamesAndAttributeNames()
+    {
+        var inlines = Highlight("<font color=\"#00ff00\">hi</font>", SubtitleGridFormattingTypes.ShowTags);
+
+        Assert.Equal("fontfont", TextWithColor(inlines, SubtitleSyntaxTokenizer.ElementColor));
+        Assert.Equal("color", TextWithColor(inlines, SubtitleSyntaxTokenizer.AttributeColor));
+    }
+
+    [AvaloniaFact]
+    public void ShowTags_ShowsAColorAttributeValueInItsOwnColor()
+    {
+        var inlines = Highlight("<font color=\"#00ff00\">hi</font>", SubtitleGridFormattingTypes.ShowTags);
+
+        Assert.Equal("#00ff00", TextWithColor(inlines, Color.FromRgb(0, 0xff, 0)));
+    }
+
+    [AvaloniaFact]
+    public void ShowTags_ShowsAnAssaColorValueInItsOwnColor()
+    {
+        var inlines = Highlight("{\\c&H00FF00&}hi", SubtitleGridFormattingTypes.ShowTags);
+
+        Assert.Equal("{\\c&H00FF00&}hi", FlatText(inlines));
+        Assert.Equal("&H00FF00&", TextWithColor(inlines, Color.FromRgb(0, 0xff, 0)));
+        Assert.Equal("c", TextWithColor(inlines, SubtitleSyntaxTokenizer.ElementColor));
+    }
+
+    [AvaloniaFact]
+    public void ShowTags_ColorsAStyleAttributeValueDifferently()
+    {
+        var inlines = Highlight("<span style=\"font-weight:bold\">hi</span>", SubtitleGridFormattingTypes.ShowTags);
+
+        Assert.Equal("font-weight:bold", TextWithColor(inlines, SubtitleSyntaxTokenizer.StyleColor));
+    }
+
+    [AvaloniaFact]
+    public void ShowTags_ColorsHtmlComments()
+    {
+        var inlines = Highlight("<!-- note -->x", SubtitleGridFormattingTypes.ShowTags);
+
+        Assert.Equal("<!-- note -->", TextWithColor(inlines, SubtitleSyntaxTokenizer.CommentColor));
+    }
+
+    [AvaloniaTheory]
+    [InlineData("<b/>x")]
+    [InlineData("<b />x")]
+    public void ShowTags_NormalizesSelfClosingTags(string text)
+    {
+        Assert.Equal("<b />x", FlatText(Highlight(text, SubtitleGridFormattingTypes.ShowTags)));
+    }
+
+    [AvaloniaTheory]
+    [InlineData("a < b")]
+    [InlineData("unclosed <tag")]
+    [InlineData("{\\unclosed")]
+    [InlineData("{ not a tag }")]
+    [InlineData("<>")]
+    public void ShowTags_LeavesMalformedMarkupIntact(string text)
+    {
+        Assert.Equal(text, FlatText(Highlight(text, SubtitleGridFormattingTypes.ShowTags)));
+    }
+
+    [AvaloniaFact]
+    public void Highlight_TruncatesVeryLongText()
+    {
+        var inlines = Highlight(new string('a', 400), SubtitleGridFormattingTypes.NoFormatting);
+
+        Assert.Equal(new string('a', 197) + "...", FlatText(inlines));
+    }
+
+    [AvaloniaFact]
+    public void Highlight_EmptyTextGivesAnEmptyCollection()
+    {
+        Assert.Empty(Highlight(string.Empty, SubtitleGridFormattingTypes.ShowFormatting));
+    }
+
+    [Fact]
+    public void MiddleEllipsis_KeepsTheStartAndTheEnd()
+    {
+        var converter = new MiddleEllipsisConverter();
+
+        Assert.Equal("0123...6789", converter.Convert("0123456789ABCDEF6789", typeof(string), "11", Culture));
+    }
+
+    [Fact]
+    public void MiddleEllipsis_LeavesShortValuesAlone()
+    {
+        var converter = new MiddleEllipsisConverter();
+
+        Assert.Equal("short", converter.Convert("short", typeof(string), "50", Culture));
+    }
+
+    [Fact]
+    public void TextOneLineShort_FlattensLineBreaks()
+    {
+        var converter = new TextOneLineShortConverter();
+
+        // Each of \r and \n becomes a space, so a CRLF leaves two.
+        Assert.Equal("one  two", converter.Convert("one\r\ntwo", typeof(string), "30", Culture));
+        Assert.Equal("one two", converter.Convert("one\ntwo", typeof(string), "30", Culture));
+    }
+
+    [Fact]
+    public void TextOneLineShort_TruncatesAtAWordBoundary()
+    {
+        var converter = new TextOneLineShortConverter();
+
+        Assert.Equal("one two...", converter.Convert("one two three four", typeof(string), "10", Culture));
+    }
+
+    [Fact]
+    public void TextOneLineShort_HardCutsWhenThereIsNoSpaceToCutAt()
+    {
+        var converter = new TextOneLineShortConverter();
+
+        Assert.Equal("0123456789...", converter.Convert("0123456789ABCDEF", typeof(string), "10", Culture));
+    }
+
+    [Fact]
+    public void DoubleToNoDecimalHideMax_HidesTheSentinelsIncludingNaN()
+    {
+        var converter = new DoubleToNoDecimalHideMaxConverter();
+
+        Assert.Equal(string.Empty, converter.Convert(double.MaxValue, typeof(string), null, Culture));
+        Assert.Equal(string.Empty, converter.Convert(double.NaN, typeof(string), null, Culture));
+        Assert.Equal("42", converter.Convert(41.6, typeof(string), null, Culture));
+    }
+
+    [Fact]
+    public void BooleanAnd_IsTrueOnlyWhenEveryValueIsTrue()
+    {
+        var converter = BooleanAndConverter.Instance;
+
+        Assert.Equal(true, converter.Convert(new object?[] { true, true }, typeof(bool), null, Culture));
+        Assert.Equal(false, converter.Convert(new object?[] { true, false }, typeof(bool), null, Culture));
+        Assert.Equal(false, converter.Convert(new object?[] { true, null }, typeof(bool), null, Culture));
+        Assert.Equal(false, converter.Convert(new object?[] { true, "yes" }, typeof(bool), null, Culture));
+        Assert.Equal(false, converter.Convert(Array.Empty<object?>(), typeof(bool), null, Culture));
+    }
+
+    [Fact]
+    public void SmallConverters_ReturnSharedBoxesSoBindingDoesNotAllocatePerRow()
+    {
+        var inverse = new InverseBooleanConverter();
+        var notNull = new NotNullConverter();
+
+        Assert.Same(
+            inverse.Convert(false, typeof(bool), null, Culture),
+            notNull.Convert("anything", typeof(bool), null, Culture));
+        Assert.Same(
+            inverse.Convert(true, typeof(bool), null, Culture),
+            notNull.Convert(null, typeof(bool), null, Culture));
+    }
+
+    [AvaloniaFact]
+    public void DurationToBackground_ReusesTheSameBrushInstances()
+    {
+        var converter = DurationToBackgroundConverter.Instance;
+        var previousShort = Se.Settings.General.ColorDurationTooShort;
+        var previousMinimum = Se.Settings.General.SubtitleMinimumDisplayMilliseconds;
+        try
+        {
+            Se.Settings.General.ColorDurationTooShort = true;
+            Se.Settings.General.SubtitleMinimumDisplayMilliseconds = 1000;
+
+            var tooShortA = converter.Convert(TimeSpan.FromMilliseconds(100), typeof(object), null, Culture);
+            var tooShortB = converter.Convert(TimeSpan.FromMilliseconds(200), typeof(object), null, Culture);
+            var okA = converter.Convert(TimeSpan.FromMilliseconds(5000), typeof(object), null, Culture);
+            var okB = converter.Convert(TimeSpan.FromMilliseconds(6000), typeof(object), null, Culture);
+
+            Assert.Same(tooShortA, tooShortB);
+            Assert.Same(okA, okB);
+            Assert.NotSame(tooShortA, okA);
+            Assert.Equal(Colors.Transparent, Assert.IsAssignableFrom<ISolidColorBrush>(okA).Color);
+        }
+        finally
+        {
+            Se.Settings.General.ColorDurationTooShort = previousShort;
+            Se.Settings.General.SubtitleMinimumDisplayMilliseconds = previousMinimum;
+        }
+    }
+
+    [AvaloniaFact]
+    public void BatchConvertStatusColor_StillFollowsTheErrorTextAfterItChanges()
+    {
+        var converter = new BatchConvertStatusColorConverter();
+        var previous = Se.Language.General.ErrorX;
+        try
+        {
+            Se.Language.General.ErrorX = "Error: {0}";
+            var first = converter.Convert("Error: nope", typeof(object), null, Culture);
+            Assert.NotNull(first);
+
+            // A loaded translation swaps the string - the cached prefix has to follow.
+            Se.Language.General.ErrorX = "Fejl: {0}";
+            Assert.Null(converter.Convert("Error: nope", typeof(object), null, Culture) as ISolidColorBrush);
+            Assert.NotNull(converter.Convert("Fejl: nix", typeof(object), null, Culture) as ISolidColorBrush);
+        }
+        finally
+        {
+            Se.Language.General.ErrorX = previous;
+        }
+    }
+}

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -33,6 +33,10 @@ Reports land in `tests/benchmarks/BenchmarkDotNet.Artifacts/results/` (gitignore
 | `SubtitleImageAdjusterBenchmarks` | The full-frame pixel adjustments the binary-edit dialogs run on every debounced slider tick (brightness/contrast/gamma, alpha, colorize). |
 | `FixCommonErrorsAllowFixBenchmarks` | One apply pass worth of `AllowFix` probes - what every libse fix rule asks once per paragraph during "Apply selected fixes". |
 | `ModifySelectionRuleBenchmarks` | One 250 ms preview-timer tick of the modify-selection window: the selected rule evaluated against every line (regex, line-count and style rules). |
+| `GridCellConverterBenchmarks` | One repaint of a 200-row viewport through the time-code, gap, CPS/WPM, flow-direction and duration-background value converters. |
+| `SyntaxHighlightingConverterBenchmarks` | The same repaint through the syntax highlighting converter - the most expensive per-row work in the grid - in all three formatting modes. |
+| `SmallConverterBenchmarks` | The handful of small converters a row goes through (boolean/null bindings, color swatches, ellipsis, batch convert status). |
+| `BrushCreationBenchmarks` | Why the converters hand out `ImmutableSolidColorBrush`: a `SolidColorBrush` is an AvaloniaObject with a property store, for a color that never changes. |
 
 Benchmarks that model a collection the app gets from Avalonia (e.g. `DataGrid.SelectedItems`)
 reproduce its interface surface rather than substituting a `List<T>` - `SelectedItems` only

--- a/tests/benchmarks/ValueConverterBenchmarks.cs
+++ b/tests/benchmarks/ValueConverterBenchmarks.cs
@@ -1,0 +1,466 @@
+using Avalonia;
+using Avalonia.Controls.Documents;
+using Avalonia.Headless;
+using Avalonia.Media;
+using Avalonia.Media.Immutable;
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Features.Shared.ColorPicker;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.ValueConverters;
+using System.Globalization;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// The value converters the subtitle grid runs per visible row on every repaint.
+/// One iteration = one repaint of a 200-row viewport (the grid virtualizes, but a fast
+/// scroll re-converts every recycled row, and the whole set is re-converted on sort,
+/// selection paint, theme change and settings change).
+/// </summary>
+[MemoryDiagnoser]
+public class GridCellConverterBenchmarks
+{
+    private const int Rows = 200;
+
+    private static bool _avaloniaInitialized;
+
+    private readonly CultureInfo _culture = CultureInfo.InvariantCulture;
+
+    private TimeSpanToDisplayFullConverter _fullTime = null!;
+    private TimeSpanToDisplayShortConverter _shortTime = null!;
+    private DoubleToDisplayShortConverter _gap = null!;
+    private DoubleToOneDecimalHideMaxConverter _cpsWpm = null!;
+    private TextToFlowDirectionConverter _flowDirection = null!;
+    private DurationToBackgroundConverter _durationBackground = null!;
+
+    private TimeSpan[] _startTimes = null!;
+    private TimeSpan[] _durations = null!;
+    private double[] _gaps = null!;
+    private double[] _cps = null!;
+    private string[] _texts = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        EnsureAvalonia();
+
+        _fullTime = new TimeSpanToDisplayFullConverter();
+        _shortTime = new TimeSpanToDisplayShortConverter();
+        _gap = new DoubleToDisplayShortConverter();
+        _cpsWpm = new DoubleToOneDecimalHideMaxConverter();
+        _flowDirection = new TextToFlowDirectionConverter();
+        _durationBackground = new DurationToBackgroundConverter();
+
+        _startTimes = new TimeSpan[Rows];
+        _durations = new TimeSpan[Rows];
+        _gaps = new double[Rows];
+        _cps = new double[Rows];
+        _texts = new string[Rows];
+
+        var sentences = ConverterBenchmarkData.GridTexts;
+        for (var i = 0; i < Rows; i++)
+        {
+            _startTimes[i] = TimeSpan.FromMilliseconds(i * 2400 + 137);
+            _durations[i] = TimeSpan.FromMilliseconds(1500 + i % 900);
+            // Every 10th row has the "no gap" sentinel the last-line cell uses.
+            _gaps[i] = i % 10 == 0 ? double.MaxValue : 200 + i % 700;
+            _cps[i] = i % 13 == 0 ? double.MaxValue : 8.5 + i % 11;
+            _texts[i] = sentences[i % sentences.Length];
+        }
+    }
+
+    internal static void EnsureAvalonia()
+    {
+        if (_avaloniaInitialized)
+        {
+            return;
+        }
+
+        _avaloniaInitialized = true;
+        AppBuilder.Configure<Application>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false })
+            .UseSkia()
+            .WithInterFont()
+            .SetupWithoutStarting();
+    }
+
+    /// <summary>Start and end time cells - two full time-code conversions per row.</summary>
+    [Benchmark]
+    public object FullTimeCells()
+    {
+        object last = null!;
+        for (var i = 0; i < Rows; i++)
+        {
+            last = _fullTime.Convert(_startTimes[i], typeof(string), null, _culture);
+            last = _fullTime.Convert(_startTimes[i] + _durations[i], typeof(string), null, _culture);
+        }
+
+        return last;
+    }
+
+    /// <summary>Duration cell.</summary>
+    [Benchmark]
+    public object ShortTimeCells()
+    {
+        object last = null!;
+        for (var i = 0; i < Rows; i++)
+        {
+            last = _shortTime.Convert(_durations[i], typeof(string), null, _culture);
+        }
+
+        return last;
+    }
+
+    /// <summary>Gap column (double milliseconds, MaxValue = no gap).</summary>
+    [Benchmark]
+    public object GapCells()
+    {
+        object last = null!;
+        for (var i = 0; i < Rows; i++)
+        {
+            last = _gap.Convert(_gaps[i], typeof(string), null, _culture);
+        }
+
+        return last;
+    }
+
+    /// <summary>CPS and WPM columns.</summary>
+    [Benchmark]
+    public object CpsWpmCells()
+    {
+        object last = null!;
+        for (var i = 0; i < Rows; i++)
+        {
+            last = _cpsWpm.Convert(_cps[i], typeof(string), null, _culture);
+            last = _cpsWpm.Convert(_cps[i] * 7, typeof(string), null, _culture);
+        }
+
+        return last;
+    }
+
+    /// <summary>Text and original-text flow direction.</summary>
+    [Benchmark]
+    public object FlowDirectionCells()
+    {
+        object last = null!;
+        for (var i = 0; i < Rows; i++)
+        {
+            last = _flowDirection.Convert(_texts[i], typeof(object), null, _culture);
+        }
+
+        return last;
+    }
+
+    /// <summary>Duration cell background brush.</summary>
+    [Benchmark]
+    public object DurationBackgroundCells()
+    {
+        object last = null!;
+        for (var i = 0; i < Rows; i++)
+        {
+            last = _durationBackground.Convert(_durations[i], typeof(object), null, _culture);
+        }
+
+        return last;
+    }
+}
+
+/// <summary>
+/// The syntax highlighting converter: the most expensive per-row work in the grid, run for
+/// the text cell and (when shown) the original-text cell of every visible row.
+/// </summary>
+[MemoryDiagnoser]
+public class SyntaxHighlightingConverterBenchmarks
+{
+    private const int Rows = 200;
+
+    private readonly CultureInfo _culture = CultureInfo.InvariantCulture;
+
+    private TextWithSubtitleSyntaxHighlightingConverter _converter = null!;
+    private string[] _texts = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        GridCellConverterBenchmarks.EnsureAvalonia();
+        _converter = new TextWithSubtitleSyntaxHighlightingConverter();
+
+        var sentences = ConverterBenchmarkData.GridTexts;
+        _texts = new string[Rows];
+        for (var i = 0; i < Rows; i++)
+        {
+            _texts[i] = sentences[i % sentences.Length];
+        }
+    }
+
+    private object RunAll()
+    {
+        object last = null!;
+        for (var i = 0; i < Rows; i++)
+        {
+            last = _converter.Convert(_texts[i], typeof(InlineCollection), null, _culture);
+        }
+
+        return last;
+    }
+
+    [Benchmark]
+    public object NoFormatting()
+    {
+        Se.Settings.Appearance.SubtitleGridFormattingType = (int)SubtitleGridFormattingTypes.NoFormatting;
+        return RunAll();
+    }
+
+    [Benchmark(Baseline = true)]
+    public object ShowFormatting()
+    {
+        Se.Settings.Appearance.SubtitleGridFormattingType = (int)SubtitleGridFormattingTypes.ShowFormatting;
+        return RunAll();
+    }
+
+    [Benchmark]
+    public object ShowTags()
+    {
+        Se.Settings.Appearance.SubtitleGridFormattingType = (int)SubtitleGridFormattingTypes.ShowTags;
+        return RunAll();
+    }
+}
+
+/// <summary>
+/// The small converters. Each is trivial on its own, but the grid runs a handful per row and
+/// every one of them boxes its result for the binding system.
+/// </summary>
+[MemoryDiagnoser]
+public class SmallConverterBenchmarks
+{
+    private const int Rows = 200;
+
+    private readonly CultureInfo _culture = CultureInfo.InvariantCulture;
+
+    private InverseBooleanConverter _inverseBoolean = null!;
+    private NotNullConverter _notNull = null!;
+    private NullToOpacityConverter _nullToOpacity = null!;
+    private BooleanToGridLengthConverter _booleanToGridLength = null!;
+    private BoolToFontStyleConverter _boolToFontStyle = null!;
+    private BooleanToCheckMarkConverter _booleanToCheckMark = null!;
+    private BooleanAndConverter _booleanAnd = null!;
+    private ColorToBrushConverter _colorToBrush = null!;
+    private MiddleEllipsisConverter _middleEllipsis = null!;
+    private TextOneLineShortConverter _textOneLineShort = null!;
+    private BatchConvertStatusColorConverter _statusColor = null!;
+
+    private object?[] _bookmarks = null!;
+    private object?[] _booleans = null!;
+    private object?[] _booleanPairs = null!;
+    private string[] _paths = null!;
+    private string[] _statuses = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        GridCellConverterBenchmarks.EnsureAvalonia();
+
+        _inverseBoolean = new InverseBooleanConverter();
+        _notNull = new NotNullConverter();
+        _nullToOpacity = new NullToOpacityConverter();
+        _booleanToGridLength = new BooleanToGridLengthConverter();
+        _boolToFontStyle = new BoolToFontStyleConverter();
+        _booleanToCheckMark = new BooleanToCheckMarkConverter();
+        _booleanAnd = BooleanAndConverter.Instance;
+        _colorToBrush = new ColorToBrushConverter();
+        _middleEllipsis = new MiddleEllipsisConverter();
+        _textOneLineShort = new TextOneLineShortConverter();
+        _statusColor = new BatchConvertStatusColorConverter();
+
+        _bookmarks = new object?[Rows];
+        _booleans = new object?[Rows];
+        _paths = new string[Rows];
+        _statuses = new string[Rows];
+        for (var i = 0; i < Rows; i++)
+        {
+            _bookmarks[i] = i % 7 == 0 ? "A bookmark comment" : null;
+            _booleans[i] = i % 3 != 0;
+            _paths[i] = $"/Users/someone/Movies/season 3/episode {i:D2}/the.long.file.name.S03E{i:D2}.1080p.WEB-DL.mkv";
+            _statuses[i] = ConverterBenchmarkData.BatchStatuses[i % ConverterBenchmarkData.BatchStatuses.Length];
+        }
+
+        _booleanPairs = new object?[] { true, true, false };
+    }
+
+    /// <summary>The row's IsHidden / Bookmark / column-visibility bindings.</summary>
+    [Benchmark]
+    public object BooleanAndNullConverters()
+    {
+        object last = null!;
+        for (var i = 0; i < Rows; i++)
+        {
+            last = _inverseBoolean.Convert(_booleans[i], typeof(bool), null, _culture);
+            last = _notNull.Convert(_bookmarks[i], typeof(bool), null, _culture);
+            last = _nullToOpacity.Convert(_bookmarks[i], typeof(double), null, _culture);
+            last = _booleanToGridLength.Convert(_booleans[i], typeof(object), null, _culture);
+            last = _boolToFontStyle.Convert(_booleans[i], typeof(object), null, _culture);
+            last = _booleanToCheckMark.Convert(_booleans[i], typeof(string), null, _culture);
+        }
+
+        return last;
+    }
+
+    [Benchmark]
+    public object? BooleanAnd()
+    {
+        object? last = null;
+        for (var i = 0; i < Rows; i++)
+        {
+            last = _booleanAnd.Convert(_booleanPairs, typeof(bool), null, _culture);
+        }
+
+        return last;
+    }
+
+    [Benchmark]
+    public object? ColorToBrush()
+    {
+        object? last = null;
+        for (var i = 0; i < Rows; i++)
+        {
+            last = _colorToBrush.Convert(ConverterBenchmarkData.Colors[i % ConverterBenchmarkData.Colors.Length], typeof(object), null, _culture);
+        }
+
+        return last;
+    }
+
+    [Benchmark]
+    public object MiddleEllipsis()
+    {
+        object last = null!;
+        for (var i = 0; i < Rows; i++)
+        {
+            last = _middleEllipsis.Convert(_paths[i], typeof(string), "60", _culture);
+        }
+
+        return last;
+    }
+
+    [Benchmark]
+    public object TextOneLineShort()
+    {
+        object last = null!;
+        for (var i = 0; i < Rows; i++)
+        {
+            last = _textOneLineShort.Convert(ConverterBenchmarkData.GridTexts[i % ConverterBenchmarkData.GridTexts.Length], typeof(string), null, _culture);
+        }
+
+        return last;
+    }
+
+    /// <summary>Batch convert's status column - foreground and background per row.</summary>
+    [Benchmark]
+    public object? BatchConvertStatusColor()
+    {
+        object? last = null;
+        for (var i = 0; i < Rows; i++)
+        {
+            last = _statusColor.Convert(_statuses[i], typeof(object), "background", _culture);
+            last = _statusColor.Convert(_statuses[i], typeof(object), null, _culture);
+        }
+
+        return last;
+    }
+}
+
+/// <summary>
+/// Why the converters stopped handing out <see cref="SolidColorBrush"/>: it is an AvaloniaObject
+/// with a property store behind it, for a value that never changes after construction.
+/// </summary>
+[MemoryDiagnoser]
+public class BrushCreationBenchmarks
+{
+    private const int Count = 200;
+
+    private static readonly Dictionary<Color, SolidColorBrush> Cache = new();
+
+    [GlobalSetup]
+    public void Setup() => GridCellConverterBenchmarks.EnsureAvalonia();
+
+    [Benchmark(Baseline = true)]
+    public object SolidColorBrushPerCall()
+    {
+        object last = null!;
+        for (var i = 0; i < Count; i++)
+        {
+            last = new SolidColorBrush(ConverterBenchmarkData.Colors[i % ConverterBenchmarkData.Colors.Length]);
+        }
+
+        return last;
+    }
+
+    [Benchmark]
+    public object ImmutableSolidColorBrushPerCall()
+    {
+        object last = null!;
+        for (var i = 0; i < Count; i++)
+        {
+            last = new ImmutableSolidColorBrush(ConverterBenchmarkData.Colors[i % ConverterBenchmarkData.Colors.Length]);
+        }
+
+        return last;
+    }
+
+    [Benchmark]
+    public object CachedSolidColorBrush()
+    {
+        object last = null!;
+        for (var i = 0; i < Count; i++)
+        {
+            var color = ConverterBenchmarkData.Colors[i % ConverterBenchmarkData.Colors.Length];
+            if (!Cache.TryGetValue(color, out var brush))
+            {
+                brush = new SolidColorBrush(color);
+                Cache[color] = brush;
+            }
+
+            last = brush;
+        }
+
+        return last;
+    }
+}
+
+internal static class ConverterBenchmarkData
+{
+    /// <summary>
+    /// Subtitle lines with the mix a real file has: plain text, two-liners, italics,
+    /// font tags, ASSA override tags and one right-to-left line.
+    /// </summary>
+    internal static readonly string[] GridTexts =
+    {
+        "It was the best of times, it was the worst of times.",
+        "Are you coming with us?",
+        "- No." + "\r\n" + "- Then stay here and wait.",
+        "<i>I told you already, this is not going to work out</i>" + "\r\n" + "<i>the way you think it will.</i>",
+        "Hello.",
+        "<font color=\"#ff8800\" face=\"Arial\" size=\"20\">Somewhere in Denmark</font>",
+        "{\\an8}Chapter one",
+        "{\\i1\\c&H00FF00&\\fnArial\\fs28}Do you have any idea{\\i0}" + "\r\n" + "what you have done?",
+        "مرحبا بالعالم",
+        "He said: <b>\"Never again.\"</b>" + "\r\n" + "And he meant it.",
+    };
+
+    internal static readonly string[] BatchStatuses =
+    {
+        "-",
+        "Converted",
+        "Error: file not found",
+        "OCR 42%",
+        "Cancelled",
+        "-",
+    };
+
+    internal static readonly Avalonia.Media.Color[] Colors =
+    {
+        Avalonia.Media.Color.FromRgb(255, 255, 255),
+        Avalonia.Media.Color.FromRgb(255, 200, 0),
+        Avalonia.Media.Color.FromRgb(0, 128, 255),
+        Avalonia.Media.Color.FromRgb(255, 255, 255),
+    };
+}


### PR DESCRIPTION
The value converters run per bound property per visible row on every grid repaint. Every one of them returns `object`, so returning a `bool`, a `double` or an enum boxed a fresh value each time, and several built a new `SolidColorBrush` — an `AvaloniaObject` with a full property store — for a color that never changes.

## What changed

- **Boxing** — added `ConverterBoxes` with pre-boxed constants, used by the inverse-bool, not-null, opacity, grid-length, font-style and flow-direction converters.
- **Brushes** — `ColorToBrushConverter` and `DurationToBackgroundConverter` now hand out `ImmutableSolidColorBrush`; the latter also caches instead of re-parsing its hex error color per cell.
- **Syntax highlighter** — a run-coalescing builder (adjacent same-foreground text becomes one `Run`, appended straight out of the source string), span-based ASSA tag/color parsing instead of `Split`+`Trim`+`Substring`, span tag-name comparison instead of `Substring`+`ToLowerInvariant`, a `static readonly` delimiter array (was allocated per HTML tag), substring probes before the three `<font>` regexes, and a `FontFamily` cache.
- **Smaller ones** — reused `TimeCode` instances, `string.Concat` over spans instead of substring-then-concat, and a cached formatted `"Error:"` prefix in the batch convert status column.
- **Bug fix** — `d == double.NaN` is always false; `DoubleToNoDecimalHideMaxConverter` now uses `double.IsNaN(d)`, so a NaN CPS/WPM hides like `double.MaxValue` already did.

## Measurements

BenchmarkDotNet, one repaint of a 200-row viewport. Separate before/after runs were not comparable on this machine (an *unchanged* control benchmark drifted 20%), so the old code is compiled alongside the new and BDN interleaves them in a single process.

| | Time old → new | Allocated old → new |
|---|---|---|
| Boolean/null row bindings | 4122 → 416 ns | 25.6 KB → **0 B** |
| Batch convert status color | 10016 → 667 ns | 20.8 KB → **0 B** |
| Boolean AND | 1671 → 510 ns | 4.8 KB → **0 B** |
| Color swatch → brush | 22445 → 1913 ns | 123.2 → 17.6 KB |
| Duration cell background | 22.2 → 1.2 μs | 125 → 4.8 KB |
| Middle ellipsis | 5771 → 4169 ns | 60.8 → 28.8 KB |
| Syntax: ShowFormatting | 144.9 → 120.7 μs | 551.6 → 480.9 KB |
| Syntax: ShowTags | 420.7 → 394.4 μs | 1695.2 → 1526.6 KB |
| Syntax: NoFormatting | 78.3 → 74.6 μs | 399.2 → 382.0 KB |

The syntax-highlighter *timings* carry wide error bars (±15%) even interleaved — the allocation column is the reliable signal there. The small converters' gains are far above noise.

Two things measured and **rejected**: switching `"0.0"`/`"0.000"` format strings to `"F1"`/`"F3"` (0.84× ±0.18 at one decimal, dead even at three — not worth the change), and a `foreach` form of `BooleanAndConverter` (allocates an enumerator through `IList<object?>`; the indexed loop is 3× faster than the original and allocation-free).

## Behaviour

Beyond the tests, a run-length-encoded dump of the highlighter's per-character formatting — so splitting or merging `Run`s is provably invisible — over 132 edge-case inputs × 3 formatting modes × 2 line-separator settings is byte-identical before and after.

That caught one real difference: `Convert.ToByte(s, 16)` accepts a sign where `byte.TryParse` with `AllowHexSpecifier` does not. The new ASSA color parser falls back to the old path on failure, so malformed colors such as `&H+10000&` still render exactly as before.

Adds 55 unit tests (`tests/UI/Logic/ValueConverters/ValueConverterTests.cs`) and a benchmark class per converter group.

## Noticed, not changed

- Four converters have no references anywhere in `src` or `tests`: `TextToSingleLineConverter`, `TimeSpanToSecondsConverter`, `TimeSpanFormatter`, `TimeSpanFormatterShort`. `DurationToBackgroundConverter` is referenced only from its own file. Optimized rather than deleted — removal is a separate call.
- `DCinemaInteropPropertiesWindow` and `DCinemaSmptePropertiesWindow` each carry a private duplicate of `ColorToBrushConverter`, so they did not get the immutable-brush fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)