### PR TITLE
Fix #10211: IsNonStandardLineTerminationLanguage (CJK) check broken with Whisper?

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessor.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessor.cs
@@ -138,9 +138,9 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText
             return postProcessed;
         }
 
-        private static bool IsNonStandardLineTerminationLanguage(string language)
+        internal static bool IsNonStandardLineTerminationLanguage(string language)
         {
-            return language is "jp" or "ja" or "cn" or "yue";
+            return language is "jp" or "ja" or "zh" or "cn" or "yue";
         }
 
         public Subtitle Fix(Subtitle subtitle, bool usePostProcessing, bool addPeriods, bool mergeLines, bool fixCasing, bool fixShortDuration, bool splitLines, Engine engine)

--- a/tests/UI/Features/Video/SpeechToText/SpeechToTextPostProcessorTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/SpeechToTextPostProcessorTests.cs
@@ -1,0 +1,38 @@
+using Nikse.SubtitleEdit.Features.Video.SpeechToText;
+
+namespace UITests.Features.Video.SpeechToText;
+
+public class SpeechToTextPostProcessorTests
+{
+    [Fact]
+    public void IsNonStandardLineTerminationLanguage_WhisperJapanese_ReturnsTrue()
+    {
+        Assert.True(SpeechToTextPostProcessor.IsNonStandardLineTerminationLanguage("ja"));
+    }
+
+    [Fact]
+    public void IsNonStandardLineTerminationLanguage_WhisperChinese_ReturnsTrue()
+    {
+        Assert.True(SpeechToTextPostProcessor.IsNonStandardLineTerminationLanguage("zh"));
+    }
+
+    [Fact]
+    public void IsNonStandardLineTerminationLanguage_WhisperCantonese_ReturnsTrue()
+    {
+        Assert.True(SpeechToTextPostProcessor.IsNonStandardLineTerminationLanguage("yue"));
+    }
+
+    [Fact]
+    public void IsNonStandardLineTerminationLanguage_VoskCodes_ReturnsTrue()
+    {
+        Assert.True(SpeechToTextPostProcessor.IsNonStandardLineTerminationLanguage("jp"));
+        Assert.True(SpeechToTextPostProcessor.IsNonStandardLineTerminationLanguage("cn"));
+    }
+
+    [Fact]
+    public void IsNonStandardLineTerminationLanguage_OtherLanguages_ReturnsFalse()
+    {
+        Assert.False(SpeechToTextPostProcessor.IsNonStandardLineTerminationLanguage("en"));
+        Assert.False(SpeechToTextPostProcessor.IsNonStandardLineTerminationLanguage("da"));
+    }
+}


### PR DESCRIPTION
## Problem
Fixes #10211 — `IsNonStandardLineTerminationLanguage` never matches Whisper's Chinese language code, so CJK line-termination handling (skip period-adding, skip Latin line splitting) never triggers for Whisper Chinese output. Whisper returns `"zh"` (`src/libuilogic/AudioToText/WhisperLanguage.cs`), but the check only contained `"cn"` (Vosk's code) — the same mismatch the reporter observed for `"ja"` vs `"jp"` (`src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessor.cs`, `IsNonStandardLineTerminationLanguage`).

## Fix
Added `"zh"` to `IsNonStandardLineTerminationLanguage` so Whisper's Chinese code is recognized alongside the existing Vosk codes (`"jp"`, `"cn"`) and Whisper codes (`"ja"`, `"yue"`). The method was made `internal` (was `private`) so the regression test can assert it directly — `InternalsVisibleTo("UITests")` already exists in `UI.csproj`. Smallest change; the Japanese half (`"ja"`) was already handled on current main.

## Verification
- [x] `dotnet build src/ui/UI.csproj` — 0 errors, 0 warnings (EXIT:0)
- [x] New regression test(s): `IsNonStandardLineTerminationLanguage_WhisperChinese_ReturnsTrue` (plus Whisper `ja`/`yue`, Vosk `jp`/`cn`, and negative `en`/`da` cases) — on pre-fix code `IsNonStandardLineTerminationLanguage_WhisperChinese_ReturnsTrue` FAILS (1 failed / 4 passed); post-fix 5/5 pass
- [x] Existing tests run: `FullyQualifiedName~Features.Video.SpeechToText` — 107/107 pass

## Notes
- Interpretation: the issue is specifically about the `IsNonStandardLineTerminationLanguage` check; per guidelines the fix stays surgical.
- Related observation (NOT changed, same root-cause class): `MergeShortLines` (`SpeechToTextPostProcessor.cs` ~line 278) still keys CJK line-length limits off the Vosk codes `"jp"`/`"cn"`, so Whisper `"ja"`/`"zh"` also miss those branches. Left untouched as it is a separate behavior; flagging for the owner.
- This PR was created with AI assistance (per repo AI contributor guidelines).