### PR TITLE
Fix #10193: SoftNI sub export writes project frame rate instead of hardcoded 25 fps

### DIFF
--- a/src/libse/SubtitleFormats/SoftNiColonSub.cs
+++ b/src/libse/SubtitleFormats/SoftNiColonSub.cs
@@ -116,7 +116,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             sb.AppendLine(@"*READ*");
             sb.AppendLine(@"0,300 15,000 130,000 100,000 25,000");
             sb.AppendLine(@"*TIMING*");
-            sb.AppendLine(@"1 25 0");
+            sb.AppendLine($"1 {(int)Math.Round(Configuration.Settings.General.CurrentFrameRate)} 0");
             sb.AppendLine(@"*TIMED BACKUP NAME*");
             sb.AppendLine(@"C:\");
             sb.AppendLine(@"*FORMAT SAMPLE ÅåÉéÌìÕõÛûÿ*");

--- a/src/libse/SubtitleFormats/SoftNiSub.cs
+++ b/src/libse/SubtitleFormats/SoftNiSub.cs
@@ -117,7 +117,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             sb.AppendLine(@"*READ*");
             sb.AppendLine(@"0,300 15,000 130,000 100,000 25,000");
             sb.AppendLine(@"*TIMING*");
-            sb.AppendLine(@"1 25 0");
+            sb.AppendLine($"1 {(int)Math.Round(Configuration.Settings.General.CurrentFrameRate)} 0");
             sb.AppendLine(@"*TIMED BACKUP NAME*");
             sb.AppendLine(@"C:\");
             sb.AppendLine(@"*FORMAT SAMPLE ÅåÉéÌìÕõÛûÿ*");

--- a/tests/libse/SubtitleFormats/SoftNiSubTest.cs
+++ b/tests/libse/SubtitleFormats/SoftNiSubTest.cs
@@ -1,0 +1,60 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Xunit;
+
+namespace LibSETests.SubtitleFormats;
+
+public class SoftNiSubTest
+{
+    // Regression for issue #10193: the *TIMING* line of exported SoftNi files
+    // used to hardcode "1 25 0" regardless of the project frame rate, which
+    // made players interpret the hh:mm:ss.ff time codes at the wrong speed for
+    // non-25 fps projects. The second token must be the project frame rate
+    // (rounded to the nearest integer, matching other SoftNi writers).
+    [Theory]
+    [InlineData(23.976, "1 24 0")]
+    [InlineData(25.0, "1 25 0")]
+    [InlineData(29.97, "1 30 0")]
+    public void SoftNiSubToText_WritesProjectFrameRateInTimingLine(double frameRate, string expectedTimingLine)
+    {
+        var originalFrameRate = Configuration.Settings.General.CurrentFrameRate;
+        try
+        {
+            Configuration.Settings.General.CurrentFrameRate = frameRate;
+            var subtitle = new Subtitle();
+            subtitle.Paragraphs.Add(new Paragraph("Hello", 0, 1000));
+
+            var text = new SoftNiSub().ToText(subtitle, "Test");
+            var lines = text.SplitToLines();
+            var timingIndex = lines.FindIndex(line => line == "*TIMING*");
+            Assert.True(timingIndex >= 0, "Missing *TIMING* section");
+            Assert.Equal(expectedTimingLine, lines[timingIndex + 1]);
+        }
+        finally
+        {
+            Configuration.Settings.General.CurrentFrameRate = originalFrameRate;
+        }
+    }
+
+    [Fact]
+    public void SoftNiColonSubToText_WritesProjectFrameRateInTimingLine()
+    {
+        var originalFrameRate = Configuration.Settings.General.CurrentFrameRate;
+        try
+        {
+            Configuration.Settings.General.CurrentFrameRate = 23.976;
+            var subtitle = new Subtitle();
+            subtitle.Paragraphs.Add(new Paragraph("Hello", 0, 1000));
+
+            var text = new SoftNicolonSub().ToText(subtitle, "Test");
+            var lines = text.SplitToLines();
+            var timingIndex = lines.FindIndex(line => line == "*TIMING*");
+            Assert.True(timingIndex >= 0, "Missing *TIMING* section");
+            Assert.Equal("1 24 0", lines[timingIndex + 1]);
+        }
+        finally
+        {
+            Configuration.Settings.General.CurrentFrameRate = originalFrameRate;
+        }
+    }
+}


### PR DESCRIPTION
## Problem
Fixes #10193 — exporting to SoftNI sub (`*.sub`) always writes the `*TIMING*` line as `1 25 0`, no matter the project frame rate. Players use that value to interpret the `hh:mm:ss.ff` frame digits (which SE already writes using the project frame rate), so projects at 23.976 / 24 / 29.97 / 30 fps get wrong timing. Root cause: hardcoded `sb.AppendLine(@"1 25 0");` in `src/libse/SubtitleFormats/SoftNiSub.cs:120` (and the identical line in the colon-variant `src/libse/SubtitleFormats/SoftNiColonSub.cs:119`).

## Fix
The `*TIMING*` line now uses the current project frame rate (`Configuration.Settings.General.CurrentFrameRate`, the same source other formats use), rounded to the nearest integer — e.g. `1 24 0` at 23.976 fps, `1 30 0` at 29.97 fps, `1 25 0` at 25 fps. The trailing token (`0`) and the rest of the file layout are unchanged, so 25 fps output is byte-identical to before.

Why integer rounding: the SoftNI timing field is an integer frame rate in every reference found — the issue commenter's tested fix (`fps.ToString("##")`) and the independent TeroSubtitler implementation (`Format('1 %d 1 1 1', [Round(FPS)])`, whose loader also reads the second token as the fps). Sub-second precision lives in the frame digits, which are still generated at the exact project rate, so the rounding error is at most ~1 ms per second.

## Verification
- [x] `dotnet build src/ui/UI.csproj` — EXIT:0, 0 errors, 0 warnings
- [x] New regression test(s): `SoftNiSubToText_WritesProjectFrameRateInTimingLine` (Theory: 23.976→`1 24 0`, 25→`1 25 0`, 29.97→`1 30 0`) and `SoftNiColonSubToText_WritesProjectFrameRateInTimingLine` — on pre-fix code 3 of 4 fail, post-fix all 4 pass
- [x] Existing tests run: `MicroDVDTest` (frame-rate-writing sibling family) — 2/2 pass

## Notes
- Interpretation: the issue asks that the exported SoftNI file carry the project frame rate; the second token of the timing line is the frame rate field (confirmed by TeroSubtitler's SoftNI loader and the issue commenter).
- The identical hardcoded line in `SoftNiColonSub.cs` (the colon-timecode variant of the same SoftNI format) is fixed too — same bug, same format family.
- Deliberate non-change: kept the trailing `0` token (existing output shape for 25 fps is preserved); the DF/NDF information needed to write drop-frame markers is not available in SE, matching the issue commenter's note.
- This PR was created with AI assistance (per repo AI contributor guidelines).