### PR TITLE
Fix #12687: Merge with next/previous trims subtitle even when Allow overlap is enabled

### DIFF
--- a/src/ui/Logic/MergeManager.cs
+++ b/src/ui/Logic/MergeManager.cs
@@ -113,7 +113,7 @@ namespace Nikse.SubtitleEdit.Logic
             currentParagraph.EndTime.TotalMilliseconds = endMilliseconds;
 
             var nextParagraph = subtitle.GetParagraphOrDefault(next);
-            if (nextParagraph != null && currentParagraph.EndTime.TotalMilliseconds > nextParagraph.StartTime.TotalMilliseconds && currentParagraph.StartTime.TotalMilliseconds < nextParagraph.StartTime.TotalMilliseconds)
+            if (!Se.Settings.Waveform.AllowOverlap && nextParagraph != null && currentParagraph.EndTime.TotalMilliseconds > nextParagraph.StartTime.TotalMilliseconds && currentParagraph.StartTime.TotalMilliseconds < nextParagraph.StartTime.TotalMilliseconds)
             {
                 currentParagraph.EndTime.TotalMilliseconds = nextParagraph.StartTime.TotalMilliseconds - 1;
             }
@@ -246,7 +246,7 @@ namespace Nikse.SubtitleEdit.Logic
             currentParagraph.EndTime = TimeSpan.FromMilliseconds(endMilliseconds);
 
             var nextParagraph = inputSubtitle.GetOrNull(next);
-            if (nextParagraph != null && currentParagraph.EndTime.TotalMilliseconds > nextParagraph.StartTime.TotalMilliseconds && currentParagraph.StartTime.TotalMilliseconds < nextParagraph.StartTime.TotalMilliseconds)
+            if (!Se.Settings.Waveform.AllowOverlap && nextParagraph != null && currentParagraph.EndTime.TotalMilliseconds > nextParagraph.StartTime.TotalMilliseconds && currentParagraph.StartTime.TotalMilliseconds < nextParagraph.StartTime.TotalMilliseconds)
             {
                 currentParagraph.EndTime = TimeSpan.FromMilliseconds(nextParagraph.StartTime.TotalMilliseconds - 1);
             }

--- a/tests/UI/Logic/MergeManagerTests.cs
+++ b/tests/UI/Logic/MergeManagerTests.cs
@@ -103,6 +103,91 @@ public class MergeManagerTests
         Assert.Single(subtitles);
         Assert.Equal(string.Empty, subtitles[0].OriginalText);
     }
+
+    [Fact]
+    public void MergeSelectedLines_ShouldKeepOriginalEndTime_WhenAllowOverlapEnabled()
+    {
+        // Arrange
+        Se.Settings.Waveform.AllowOverlap = true;
+        var mergeManager = new MergeManager();
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new()
+            {
+                Number = 1,
+                Text = "One",
+                OriginalText = "Original one",
+                StartTime = TimeSpan.FromMilliseconds(500),
+                EndTime = TimeSpan.FromMilliseconds(1500),
+            },
+            new()
+            {
+                Number = 2,
+                Text = "Two",
+                OriginalText = "Original two",
+                StartTime = TimeSpan.FromMilliseconds(1600),
+                EndTime = TimeSpan.FromMilliseconds(3500),
+            },
+            new()
+            {
+                Number = 3,
+                Text = "Three",
+                OriginalText = "Original three",
+                StartTime = TimeSpan.FromMilliseconds(3000),
+                EndTime = TimeSpan.FromMilliseconds(4000),
+            },
+        };
+
+        // Act — merge ① into ②, where ② overlaps the following subtitle ③
+        mergeManager.MergeSelectedLines(subtitles, [subtitles[0], subtitles[1]]);
+
+        // Assert — with "Allow overlap" enabled the merged line keeps ②'s original end time
+        Assert.Equal(2, subtitles.Count);
+        Assert.Equal(TimeSpan.FromMilliseconds(500), subtitles[0].StartTime);
+        Assert.Equal(TimeSpan.FromMilliseconds(3500), subtitles[0].EndTime);
+    }
+
+    [Fact]
+    public void MergeSelectedLines_ShouldTrimEndTimeToNextStart_WhenAllowOverlapDisabled()
+    {
+        // Arrange
+        Se.Settings.Waveform.AllowOverlap = false;
+        var mergeManager = new MergeManager();
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new()
+            {
+                Number = 1,
+                Text = "One",
+                OriginalText = "Original one",
+                StartTime = TimeSpan.FromMilliseconds(500),
+                EndTime = TimeSpan.FromMilliseconds(1500),
+            },
+            new()
+            {
+                Number = 2,
+                Text = "Two",
+                OriginalText = "Original two",
+                StartTime = TimeSpan.FromMilliseconds(1600),
+                EndTime = TimeSpan.FromMilliseconds(3500),
+            },
+            new()
+            {
+                Number = 3,
+                Text = "Three",
+                OriginalText = "Original three",
+                StartTime = TimeSpan.FromMilliseconds(3000),
+                EndTime = TimeSpan.FromMilliseconds(4000),
+            },
+        };
+
+        // Act — merge ① into ②, where ② overlaps the following subtitle ③
+        mergeManager.MergeSelectedLines(subtitles, [subtitles[0], subtitles[1]]);
+
+        // Assert — default behavior: the merged line is trimmed to end just before ③
+        Assert.Equal(2, subtitles.Count);
+        Assert.Equal(TimeSpan.FromMilliseconds(2999), subtitles[0].EndTime);
+    }
 }
 
 

--- a/tests/UI/Logic/MergeManagerTests.cs
+++ b/tests/UI/Logic/MergeManagerTests.cs
@@ -108,85 +108,101 @@ public class MergeManagerTests
     public void MergeSelectedLines_ShouldKeepOriginalEndTime_WhenAllowOverlapEnabled()
     {
         // Arrange
-        Se.Settings.Waveform.AllowOverlap = true;
-        var mergeManager = new MergeManager();
-        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        var originalAllowOverlap = Se.Settings.Waveform.AllowOverlap;
+        try
         {
-            new()
+            Se.Settings.Waveform.AllowOverlap = true;
+            var mergeManager = new MergeManager();
+            var subtitles = new ObservableCollection<SubtitleLineViewModel>
             {
-                Number = 1,
-                Text = "One",
-                OriginalText = "Original one",
-                StartTime = TimeSpan.FromMilliseconds(500),
-                EndTime = TimeSpan.FromMilliseconds(1500),
-            },
-            new()
-            {
-                Number = 2,
-                Text = "Two",
-                OriginalText = "Original two",
-                StartTime = TimeSpan.FromMilliseconds(1600),
-                EndTime = TimeSpan.FromMilliseconds(3500),
-            },
-            new()
-            {
-                Number = 3,
-                Text = "Three",
-                OriginalText = "Original three",
-                StartTime = TimeSpan.FromMilliseconds(3000),
-                EndTime = TimeSpan.FromMilliseconds(4000),
-            },
-        };
+                new()
+                {
+                    Number = 1,
+                    Text = "One",
+                    OriginalText = "Original one",
+                    StartTime = TimeSpan.FromMilliseconds(500),
+                    EndTime = TimeSpan.FromMilliseconds(1500),
+                },
+                new()
+                {
+                    Number = 2,
+                    Text = "Two",
+                    OriginalText = "Original two",
+                    StartTime = TimeSpan.FromMilliseconds(1600),
+                    EndTime = TimeSpan.FromMilliseconds(3500),
+                },
+                new()
+                {
+                    Number = 3,
+                    Text = "Three",
+                    OriginalText = "Original three",
+                    StartTime = TimeSpan.FromMilliseconds(3000),
+                    EndTime = TimeSpan.FromMilliseconds(4000),
+                },
+            };
 
-        // Act — merge ① into ②, where ② overlaps the following subtitle ③
-        mergeManager.MergeSelectedLines(subtitles, [subtitles[0], subtitles[1]]);
+            // Act — merge ① into ②, where ② overlaps the following subtitle ③
+            mergeManager.MergeSelectedLines(subtitles, [subtitles[0], subtitles[1]]);
 
-        // Assert — with "Allow overlap" enabled the merged line keeps ②'s original end time
-        Assert.Equal(2, subtitles.Count);
-        Assert.Equal(TimeSpan.FromMilliseconds(500), subtitles[0].StartTime);
-        Assert.Equal(TimeSpan.FromMilliseconds(3500), subtitles[0].EndTime);
+            // Assert — with "Allow overlap" enabled the merged line keeps ②'s original end time
+            Assert.Equal(2, subtitles.Count);
+            Assert.Equal(TimeSpan.FromMilliseconds(500), subtitles[0].StartTime);
+            Assert.Equal(TimeSpan.FromMilliseconds(3500), subtitles[0].EndTime);
+        }
+        finally
+        {
+            Se.Settings.Waveform.AllowOverlap = originalAllowOverlap;
+        }
     }
 
     [Fact]
     public void MergeSelectedLines_ShouldTrimEndTimeToNextStart_WhenAllowOverlapDisabled()
     {
         // Arrange
-        Se.Settings.Waveform.AllowOverlap = false;
-        var mergeManager = new MergeManager();
-        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        var originalAllowOverlap = Se.Settings.Waveform.AllowOverlap;
+        try
         {
-            new()
+            Se.Settings.Waveform.AllowOverlap = false;
+            var mergeManager = new MergeManager();
+            var subtitles = new ObservableCollection<SubtitleLineViewModel>
             {
-                Number = 1,
-                Text = "One",
-                OriginalText = "Original one",
-                StartTime = TimeSpan.FromMilliseconds(500),
-                EndTime = TimeSpan.FromMilliseconds(1500),
-            },
-            new()
-            {
-                Number = 2,
-                Text = "Two",
-                OriginalText = "Original two",
-                StartTime = TimeSpan.FromMilliseconds(1600),
-                EndTime = TimeSpan.FromMilliseconds(3500),
-            },
-            new()
-            {
-                Number = 3,
-                Text = "Three",
-                OriginalText = "Original three",
-                StartTime = TimeSpan.FromMilliseconds(3000),
-                EndTime = TimeSpan.FromMilliseconds(4000),
-            },
-        };
+                new()
+                {
+                    Number = 1,
+                    Text = "One",
+                    OriginalText = "Original one",
+                    StartTime = TimeSpan.FromMilliseconds(500),
+                    EndTime = TimeSpan.FromMilliseconds(1500),
+                },
+                new()
+                {
+                    Number = 2,
+                    Text = "Two",
+                    OriginalText = "Original two",
+                    StartTime = TimeSpan.FromMilliseconds(1600),
+                    EndTime = TimeSpan.FromMilliseconds(3500),
+                },
+                new()
+                {
+                    Number = 3,
+                    Text = "Three",
+                    OriginalText = "Original three",
+                    StartTime = TimeSpan.FromMilliseconds(3000),
+                    EndTime = TimeSpan.FromMilliseconds(4000),
+                },
+            };
 
-        // Act — merge ① into ②, where ② overlaps the following subtitle ③
-        mergeManager.MergeSelectedLines(subtitles, [subtitles[0], subtitles[1]]);
+            // Act — merge ① into ②, where ② overlaps the following subtitle ③
+            mergeManager.MergeSelectedLines(subtitles, [subtitles[0], subtitles[1]]);
 
-        // Assert — default behavior: the merged line is trimmed to end just before ③
-        Assert.Equal(2, subtitles.Count);
-        Assert.Equal(TimeSpan.FromMilliseconds(2999), subtitles[0].EndTime);
+            // Assert — default behavior: the merged line is trimmed to end just before ③
+            Assert.Equal(2, subtitles.Count);
+            Assert.Equal(TimeSpan.FromMilliseconds(2999), subtitles[0].EndTime);
+        }
+        finally
+        {
+            Se.Settings.Waveform.AllowOverlap = originalAllowOverlap;
+        }
     }
 }
 


### PR DESCRIPTION
## Problem
Fixes #12687 — with "Allow overlap" enabled, "Merge with next"/"Merge with previous" still trimmed the merged subtitle's end time to one millisecond before the following subtitle's start, discarding the original end time of the merged-away line.

Root cause: `MergeManager.MergeSelectedLines` (both overloads) unconditionally clamps the merged end time to `nextParagraph.StartTime - 1` (src/ui/Logic/MergeManager.cs:116 and :249), regardless of the "Allow overlap" setting (`Se.Settings.Waveform.AllowOverlap`) that the waveform move/resize path already respects.

## Fix
Gate the overlap-prevention clamp on `Se.Settings.Waveform.AllowOverlap` in both `MergeSelectedLines` overloads: when overlap is allowed, the merged subtitle keeps the original end time of the second merged line; when it is disabled, the previous trimming behavior is unchanged (regression test covers both).

## Verification
- [x] `dotnet build src/ui/UI.csproj` — EXIT:0, 0 errors, 0 warnings
- [x] New regression tests:
  - `MergeSelectedLines_ShouldKeepOriginalEndTime_WhenAllowOverlapEnabled` — fails on pre-fix code (Actual 00:00:02.9990000 vs Expected 00:00:03.5000000), passes post-fix
  - `MergeSelectedLines_ShouldTrimEndTimeToNextStart_WhenAllowOverlapDisabled` — confirms existing default behavior is preserved
  - Stash proof: fix stashed → `Failed: 1, Passed: 4`; fix restored → `Passed: 5` (tests/UI/Logic/MergeManagerTests.cs)
- [x] Existing tests run: `FullyQualifiedName~MergeManagerTests` (all 5, incl. 3 pre-existing) and `FullyQualifiedName~UITests.Logic` — pass

## Notes
- Interpretation: the existing "Allow overlap" setting (Options → Waveform, used by the waveform move/resize clamping) is the intended gate; the issue asks merge to respect it rather than introducing a new setting.
- Both `MergeSelectedLines` overloads were updated for consistency; the `Subtitle`/`int[]` overload currently has no callers in the repo, but carries the identical clamp logic.
- No unrelated changes; dead code found during investigation (the `int[]` overload) left untouched apart from the same one-line gate.
- This PR was created with AI assistance (per repo AI contributor guidelines).