### PR TITLE
Stop waveform drags and typing paying per-tick undo/preview costs (#13234)

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -387,6 +387,22 @@ public class AudioVisualizer : Control
     private const double ClickDragSlopPixels = 3.0;
     public bool IsScrolling => (Environment.TickCount64 - _audioVisualizerLastScroll) < 100;
 
+    // Wall clock of the last pointer-driven time code edit (drag move/resize/new selection).
+    private long _lastPointerEditMs;
+
+    /// <summary>
+    /// True while the user is dragging time codes in the waveform - the pointer twin of
+    /// <c>MainViewModel.IsUserEditing</c>'s keyboard check, with the same 500 ms grace.
+    /// A drag rewrites the paragraph times on every undo change-detection tick, and each
+    /// tick that sees a change deep-copies the whole subtitle, so the drag has to suppress
+    /// detection the way typing does; the settled state is captured once the grace expires
+    /// (issue #13234). Deliberately a timestamp rather than "_interactionMode != None": a
+    /// drag that loses pointer capture without a PointerReleased must not be able to leave
+    /// change detection switched off for the rest of the session.
+    /// </summary>
+    public bool IsEditingWithPointer =>
+        _lastPointerEditMs != 0 && Environment.TickCount64 - _lastPointerEditMs < 500;
+
     public class PositionEventArgs : EventArgs
     {
         public double PositionInSeconds { get; set; }
@@ -1188,6 +1204,7 @@ public class AudioVisualizer : Control
                 newP.EndTime = TimeSpan.FromSeconds(_newSelectionSeconds);
             }
 
+            _lastPointerEditMs = Environment.TickCount64;
             InvalidateVisual();
             return;
         }
@@ -1460,6 +1477,10 @@ public class AudioVisualizer : Control
 
                 break;
         }
+
+        // Past the early returns above, every remaining interaction mode has just rewritten
+        // the active paragraph's times - see IsEditingWithPointer.
+        _lastPointerEditMs = Environment.TickCount64;
 
         // SE 4 parity: scrub the video to the edge being dragged so the user sees the
         // exact frame at the new start/end while resizing (whole-paragraph moves are excluded).
@@ -2855,6 +2876,56 @@ public class AudioVisualizer : Control
         return formatted;
     }
 
+    // The two footer labels are cached by value, not just by the composed string: building the
+    // key was the cost. "#N  duration" meant a TimeCode plus ToShortDisplayString plus two
+    // interpolations, and the CPS label another format - per visible paragraph per frame, only
+    // to look up an already-shaped FormattedText. Keyed on the values so a hit allocates nothing;
+    // the frame-mode flag is part of the key because ToShortDisplayString switches on it.
+    private readonly Dictionary<(int Number, long DurationMs, bool FrameMode), string> _footerNumberDurationCache = new(512);
+    private readonly Dictionary<double, string> _footerCpsCache = new(256);
+
+    private string GetCachedNumberAndDurationLabel(SubtitleLineViewModel paragraph)
+    {
+        var key = (paragraph.Number, (long)paragraph.Duration.TotalMilliseconds, Se.Settings.General.UseFrameMode);
+        if (!_footerNumberDurationCache.TryGetValue(key, out var label))
+        {
+            // Same cap as the other per-frame text caches - the key includes the duration, so at
+            // high zoom a long drag would otherwise grow this without bound.
+            if (_footerNumberDurationCache.Count > 8000)
+            {
+                _footerNumberDurationCache.Clear();
+            }
+
+            // ToShortDisplayString consults the libse UseTimeFormatHHMMSSFF flag, which SE 5
+            // mirrors from Se.Settings.General.UseFrameMode (Se.cs:409). So flipping frame
+            // mode on automatically switches this label between the time form ("2,500") and
+            // the frame form ("00:00:02:12") without an explicit branch here.
+            label = $"#{paragraph.Number}  {new TimeCode(paragraph.Duration.TotalMilliseconds).ToShortDisplayString()}";
+            _footerNumberDurationCache[key] = label;
+        }
+
+        return label;
+    }
+
+    private string GetCachedCpsLabel(double charactersPerSecond)
+    {
+        // Keyed on the exact value, not a rounded bucket: CharactersPerSecond is itself memoized
+        // per (text, start, end), so an unchanged paragraph yields a bit-identical key every
+        // frame, and no two distinct values can share an entry and print each other's label.
+        if (!_footerCpsCache.TryGetValue(charactersPerSecond, out var label))
+        {
+            if (_footerCpsCache.Count > 8000)
+            {
+                _footerCpsCache.Clear();
+            }
+
+            label = charactersPerSecond.ToString("0.00", CultureInfo.CurrentCulture);
+            _footerCpsCache[charactersPerSecond] = label;
+        }
+
+        return label;
+    }
+
     private (List<string> Lines, string Unwrapped) GetPreparedParagraphText(string rawText)
     {
         if (!_paragraphTextCache.TryGetValue(rawText, out var prepared))
@@ -2969,8 +3040,7 @@ public class AudioVisualizer : Control
                 // mirrors from Se.Settings.General.UseFrameMode (Se.cs:409). So flipping frame
                 // mode on automatically switches this label between the time form ("2,500") and
                 // the frame form ("00:00:02:12") without an explicit branch here.
-                var durationText = new TimeCode(paragraph.Duration.TotalMilliseconds).ToShortDisplayString();
-                var withDuration = $"#{paragraph.Number}  {durationText}";
+                var withDuration = GetCachedNumberAndDurationLabel(paragraph);
                 var probe = GetCachedParagraphText(withDuration);
 
                 baseLine = probe.Width >= availableWidth
@@ -2982,7 +3052,7 @@ public class AudioVisualizer : Control
         string? cpsLine = null;
         if (n > 99 && Se.Settings.Waveform.WaveformShowCps && paragraph.Duration.TotalMilliseconds > 0)
         {
-            cpsLine = $"{paragraph.CharactersPerSecond:0.00}";
+            cpsLine = GetCachedCpsLabel(paragraph.CharactersPerSecond);
         }
 
         if (baseLine == null && cpsLine == null)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -410,6 +410,11 @@ public partial class MainViewModel :
     private string? _liveSpellCheckDictionaryFileName;
     private HashSet<int>? _visibleLayers;
     private readonly List<SubtitleLineViewModel> _waveformSubtitleBuffer = new();
+    // Dirty tracking for _waveformSubtitleBuffer - see the rebuild block in the position
+    // timer tick. Starts dirty so the first tick after startup always builds the buffer.
+    private bool _waveformSubtitleBufferDirty = true;
+    private bool _waveformBufferNoLayers;
+    private HashSet<int>? _waveformBufferVisibleLayers;
     private DispatcherTimer _positionTimer = new();
     private DispatcherTimer _slowTimer = new();
     private DispatcherTimer _cursorTimer = new(); // ~60 fps; drives only the waveform/video playhead cursor
@@ -19812,21 +19817,23 @@ public partial class MainViewModel :
         }
     }
 
-    public bool IsTyping()
+    /// <summary>
+    /// True while the user is in the middle of a continuous edit, so undo change detection
+    /// can skip the tick instead of snapshotting a half-finished state (and paying a full
+    /// subtitle deep copy several times a second).
+    /// </summary>
+    public bool IsUserEditing()
     {
-        if (_lastKeyPressedMs == 0)
-        {
-            return false;
-        }
-
-        var ms = Environment.TickCount64;
-        var diff = ms - _lastKeyPressedMs;
-        if (diff < 500)
+        if (_lastKeyPressedMs != 0 && Environment.TickCount64 - _lastKeyPressedMs < 500)
         {
             return true;
         }
 
-        return false;
+        // Dragging time codes in the waveform is the pointer equivalent of typing: it rewrites
+        // the times on every change-detection tick, but presses no key, so the keyboard check
+        // above never covered it and every tick of a drag deep-copied the whole subtitle and
+        // pushed an intermediate state onto the undo stack (issue #13234).
+        return AudioVisualizer?.IsEditingWithPointer == true;
     }
 
     // Hash used by undo change detection. Undo snapshots capture and restore OriginalText,
@@ -19843,9 +19850,42 @@ public partial class MainViewModel :
             return Dispatcher.UIThread.Invoke(GetUndoRedoHash);
         }
 
+        // GetFastHash and GetFastHashOriginal walk Subtitles hashing the same seven per-line
+        // fields; only the text field differs (Text vs OriginalText). Composing them meant two
+        // full passes, and this runs on every change-detection tick (issue #13234) - fold both
+        // texts into one pass instead. The value differs from the old composition, which is
+        // fine: undo hashes are only ever compared with other values from this method, within
+        // this process. Save-tracking keeps using GetFastHash/GetFastHashOriginal separately.
         unchecked
         {
-            return GetFastHash() * 31 + GetFastHashOriginal();
+            var hash = 17;
+            hash = hash * 23 + (_subtitleFileName?.GetHashCode() ?? 0);
+            hash = hash * 23 + (_subtitleFileNameOriginal?.GetHashCode() ?? 0);
+            hash = hash * 23 + (SelectedEncoding.DisplayName?.GetHashCode() ?? 0);
+            hash = hash * 23 + (_subtitle.Header is { } header ? string.GetHashCode(header.AsSpan().Trim()) : 0);
+            hash = hash * 23 + (_subtitle.Footer is { } footer ? string.GetHashCode(footer.AsSpan().Trim()) : 0);
+
+            _subtitleOriginal ??= new Subtitle();
+            hash = hash * 23 + (_subtitleOriginal.Header is { } headerOrg ? string.GetHashCode(headerOrg.AsSpan().Trim()) : 0);
+            hash = hash * 23 + (_subtitleOriginal.Footer is { } footerOrg ? string.GetHashCode(footerOrg.AsSpan().Trim()) : 0);
+
+            var count = Subtitles.Count;
+            for (var i = 0; i < count; i++)
+            {
+                var p = Subtitles[i];
+
+                hash = hash * 23 + p.Number;
+                hash = hash * 23 + p.StartTime.TotalMilliseconds.GetHashCode();
+                hash = hash * 23 + p.EndTime.TotalMilliseconds.GetHashCode();
+                hash = hash * 23 + (p.Text?.GetHashCode() ?? 0);
+                hash = hash * 23 + (p.OriginalText?.GetHashCode() ?? 0);
+                hash = hash * 23 + (p.Style?.GetHashCode() ?? 0);
+                hash = hash * 23 + (p.Extra?.GetHashCode() ?? 0);
+                hash = hash * 23 + (p.Actor?.GetHashCode() ?? 0);
+                hash = hash * 23 + p.Layer;
+            }
+
+            return hash;
         }
     }
 
@@ -19860,7 +19900,7 @@ public partial class MainViewModel :
             return Dispatcher.UIThread.Invoke(GetFastHash);
         }
 
-        // Runs every 250 ms (undo change detection) plus every 400 ms (title/auto-save),
+        // Runs every 333 ms (undo change detection) plus every 400 ms (title/auto-save),
         // so it must not allocate: the old version concatenated fileName+encoding and
         // called Trim() on Header/Footer - the editor normalises subtitles to ASSA, so
         // Header is a multi-KB styles block ending in a newline and Trim() copied all of
@@ -22493,6 +22533,7 @@ public partial class MainViewModel :
     private void OnSubtitlesCollectionChangedForMpv(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
     {
         _mpvPreviewDirty = true;
+        _waveformSubtitleBufferDirty = true;
         if (e.NewItems != null)
             foreach (SubtitleLineViewModel item in e.NewItems)
                 item.PropertyChanged += OnSubtitleItemChangedForMpv;
@@ -22508,6 +22549,13 @@ public partial class MainViewModel :
             or nameof(SubtitleLineViewModel.EndTime))
         {
             _mpvPreviewDirty = true;
+            // A start-time change can reorder the buffer, so it must be rebuilt and re-sorted.
+            _waveformSubtitleBufferDirty = true;
+        }
+        else if (e.PropertyName is nameof(SubtitleLineViewModel.Layer))
+        {
+            // The waveform buffer filters on Layer when layers are hidden from the waveform.
+            _waveformSubtitleBufferDirty = true;
         }
     }
 
@@ -22804,35 +22852,52 @@ public partial class MainViewModel :
                     }
                 }
 
+                // Rebuild + re-sort the buffer only when its inputs changed since the last tick;
+                // an idle tick used to copy and order-check every line 20x a second (#13234).
+                // Membership/order inputs: the collection and each line's times/layer (both flip
+                // _waveformSubtitleBufferDirty via the ForMpv hooks), plus the layer-visibility
+                // state checked here - _visibleLayers is only ever swapped wholesale, so a
+                // reference comparison covers it. The buffer holds live references, so paragraph
+                // content read later this tick is always current either way.
                 var noLayers = _visibleLayers == null || !Se.Settings.Assa.HideLayersFromWaveform || _visibleLayers.Count == 0;
                 var subtitle = _waveformSubtitleBuffer;
-                subtitle.Clear();
-                if (subtitle.Capacity < Subtitles.Count)
+                if (_waveformSubtitleBufferDirty ||
+                    noLayers != _waveformBufferNoLayers ||
+                    !ReferenceEquals(_visibleLayers, _waveformBufferVisibleLayers))
                 {
-                    subtitle.Capacity = Subtitles.Count;
-                }
-                if (noLayers)
-                {
-                    for (var i = 0; i < Subtitles.Count; i++)
+                    _waveformSubtitleBufferDirty = false;
+                    _waveformBufferNoLayers = noLayers;
+                    _waveformBufferVisibleLayers = _visibleLayers;
+
+                    subtitle.Clear();
+                    if (subtitle.Capacity < Subtitles.Count)
                     {
-                        subtitle.Add(Subtitles[i]);
+                        subtitle.Capacity = Subtitles.Count;
                     }
-                }
-                else
-                {
-                    var layerSet = _visibleLayers!;
-                    for (var i = 0; i < Subtitles.Count; i++)
+                    if (noLayers)
                     {
-                        var p = Subtitles[i];
-                        if (layerSet.Contains(p.Layer))
+                        for (var i = 0; i < Subtitles.Count; i++)
                         {
-                            subtitle.Add(p);
+                            subtitle.Add(Subtitles[i]);
                         }
                     }
+                    else
+                    {
+                        var layerSet = _visibleLayers!;
+                        for (var i = 0; i < Subtitles.Count; i++)
+                        {
+                            var p = Subtitles[i];
+                            if (layerSet.Contains(p.Layer))
+                            {
+                                subtitle.Add(p);
+                            }
+                        }
+                    }
+
+                    // The buffer is nearly always already in start-time order, so skip the
+                    // O(n log n) sort after a cheap early-exit ordered check.
+                    ListSortUtil.SortIfNeeded(subtitle, static (a, b) => a.StartTime.Ticks.CompareTo(b.StartTime.Ticks));
                 }
-                // Runs every 50 ms tick and the buffer is nearly always already in start-time
-                // order, so skip the O(n log n) sort after a cheap early-exit ordered check.
-                ListSortUtil.SortIfNeeded(subtitle, static (a, b) => a.StartTime.Ticks.CompareTo(b.StartTime.Ticks));
 
                 // The playhead cursor is interpolated and applied by the dedicated high-frequency
                 // _cursorTimer (see UpdatePlayheadEstimate) so it moves at ~60 fps instead of this
@@ -23021,7 +23086,12 @@ public partial class MainViewModel :
             AutoSaveTick(mainHash, originalHash);
 
             var vp = GetVideoPlayerControl();
-            if (!_mpvPreviewDirty || vp == null || _mpvPreviewRefreshBusy)
+            // IsUserEditing: refreshing the preview mid-edit means paying GetUpdateSubtitle +
+            // two Subtitle copies + ToText + a temp-file write on the UI thread every 400 ms
+            // while the user types or drags in the waveform (issue #13234). The dirty flag
+            // stays set, so the settled state is pushed on the first quiet tick - and the
+            // preview reads better settling once than flickering mid-word anyway.
+            if (!_mpvPreviewDirty || vp == null || _mpvPreviewRefreshBusy || IsUserEditing())
             {
                 return;
             }

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -113,17 +113,25 @@ public partial class SubtitleLineViewModel : ObservableObject
 
     public SubtitleLineViewModel(SubtitleLineViewModel p, bool generateNewId = false)
     {
-        Text = p.Text;
-        OriginalText = p.OriginalText;
-        StartTime = p.StartTime;
-        EndTime = p.EndTime;
-        UpdateDuration();
+        // The observable properties are written as backing fields, not through their setters.
+        // Nothing can be subscribed to an object still inside its own constructor, so every
+        // notification the setters raise is discarded - but ObservableObject allocates a
+        // PropertyChanging/PropertyChangedEventArgs for each one anyway, and the Text and
+        // StartTime/EndTime setters fan out to a dozen more raises via their partial hooks.
+        // That was ~40 dead allocations per line, and undo snapshots this whole collection
+        // (issue #13234). The hooks are notification-only apart from UpdateDuration, which is
+        // what _duration is set to below.
+        _text = p.Text;
+        _originalText = p.OriginalText;
+        _startTime = p.StartTime;
+        _endTime = p.EndTime;
+        _duration = p.EndTime - p.StartTime;
+        _style = p.Style;
+        _actor = p.Actor;
+        _layer = p.Layer;
+        _number = p.Number;
         Language = p.Language;
         Region = p.Region;
-        Style = p.Style;
-        Actor = p.Actor;
-        Layer = p.Layer;
-        Number = p.Number;
         Extra = p.Extra;
         Effect = p.Effect;
         IsComment = p.IsComment;
@@ -132,7 +140,7 @@ public partial class SubtitleLineViewModel : ObservableObject
         MarginV = p.MarginV;
         NewSection = p.NewSection;
         Forced = p.Forced;
-        Bookmark = p.Bookmark;
+        _bookmark = p.Bookmark;
 
         Id = generateNewId ? Guid.NewGuid() : p.Id;
 

--- a/src/ui/Logic/UndoRedo/IUndoRedoClient.cs
+++ b/src/ui/Logic/UndoRedo/IUndoRedoClient.cs
@@ -4,5 +4,9 @@ public interface IUndoRedoClient
 {
     int GetFastHash();
     UndoRedoItem MakeUndoRedoObject(string description);
-    bool IsTyping();
+    /// <summary>
+    /// True while a continuous edit is in progress (typing, dragging time codes in the
+    /// waveform). Change detection skips those ticks and captures the settled state instead.
+    /// </summary>
+    bool IsUserEditing();
 }

--- a/src/ui/Logic/UndoRedo/UndoRedoManager.cs
+++ b/src/ui/Logic/UndoRedo/UndoRedoManager.cs
@@ -27,18 +27,20 @@ public sealed class UndoRedoManager : IUndoRedoManager
     // threads (plain int reads aren't guaranteed visible on weak memory
     // architectures).
     private int _disposed;
-    // Reentrancy gate for CheckForChanges. The timer fires every 250ms on the thread
+    // Reentrancy gate for CheckForChanges. The timer fires every 333ms on the thread
     // pool regardless of whether the previous tick finished; when the UI thread is
     // busy for a long stretch (e.g. parsing a large file), each tick would otherwise
     // pile up blocked in the client's dispatcher marshaling and force the pool to
     // inject hundreds of threads — issue #12683. Interlocked so overlapping ticks
     // return immediately instead of queueing.
     private int _checkForChangesInProgress;
-    // Narrowed from 1s → 250ms to reduce the window in which two distinct user
-    // actions (e.g. text edit + waveform drag) get bundled into a single undo
-    // entry — issue #11280. CheckForChanges is gated by IsTyping() and
-    // IsAlreadyTracked() so most ticks are nearly free when nothing has changed.
-    private TimeSpan _detectionInterval = TimeSpan.FromMilliseconds(250);
+    // Narrowed from 1s to reduce the window in which two distinct user actions
+    // (e.g. text edit + waveform drag) get bundled into a single undo entry —
+    // issue #11280. CheckForChanges is gated by IsUserEditing() and IsAlreadyTracked()
+    // so most ticks are nearly free when nothing has changed; a tick that does see a
+    // change deep-copies the whole subtitle, so 333ms rather than 250ms keeps #11280
+    // fixed while paying that cost less often — issue #13234.
+    private TimeSpan _detectionInterval = TimeSpan.FromMilliseconds(333);
 
     private const int MaxUndoItems = 100;
     private const int MaxPreviewLength = 50;
@@ -103,7 +105,7 @@ public sealed class UndoRedoManager : IUndoRedoManager
         lock (_lock)
         {
             _undoRedoClient = client;
-            // Keep the field-initializer default (250ms) when caller passes null
+            // Keep the field-initializer default (333ms) when caller passes null
             // — see the comment on _detectionInterval for the rationale.
             _detectionInterval = interval ?? _detectionInterval;
 
@@ -260,7 +262,7 @@ public sealed class UndoRedoManager : IUndoRedoManager
             return;
         }
 
-        if (client.IsTyping())
+        if (client.IsUserEditing())
         {
             return;
         }

--- a/tests/UI/Logic/UndoRedo/UndoRedoManagerTests.cs
+++ b/tests/UI/Logic/UndoRedo/UndoRedoManagerTests.cs
@@ -13,12 +13,12 @@ public class UndoRedoManagerTests
     private sealed class FakeClient : IUndoRedoClient
     {
         public int Hash { get; set; }
-        public bool Typing { get; set; }
+        public bool Editing { get; set; }
         public SubtitleLineViewModel[] Subtitles { get; set; } = [];
         public string? FileNameOriginal { get; set; }
 
         public int GetFastHash() => Hash;
-        public bool IsTyping() => Typing;
+        public bool IsUserEditing() => Editing;
         public UndoRedoItem MakeUndoRedoObject(string description)
         {
             var item = MakeItem(description, Hash, Subtitles);
@@ -41,7 +41,7 @@ public class UndoRedoManagerTests
             return 1;
         }
 
-        public bool IsTyping() => false;
+        public bool IsUserEditing() => false;
         public UndoRedoItem MakeUndoRedoObject(string description) => MakeItem(description, 1);
     }
 
@@ -558,9 +558,9 @@ public class UndoRedoManagerTests
     }
 
     [Fact]
-    public void CheckForChanges_DoesNotAddEntry_WhenIsTyping()
+    public void CheckForChanges_DoesNotAddEntry_WhenUserIsEditing()
     {
-        var client = new FakeClient { Hash = 42, Typing = true };
+        var client = new FakeClient { Hash = 42, Editing = true };
         var manager = new UndoRedoManager();
         manager.SetupChangeDetection(client, TimeSpan.FromHours(1));
         manager.StartChangeDetection();

--- a/tests/benchmarks/UndoSnapshotBenchmarks.cs
+++ b/tests/benchmarks/UndoSnapshotBenchmarks.cs
@@ -1,0 +1,75 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Features.Main;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// Undo change detection snapshots the whole subtitle collection (MainViewModel.MakeUndoRedoObject),
+/// and before issue #13234 it did so several times a second during a waveform drag. The copy
+/// constructor is the whole cost of that snapshot.
+///
+/// <see cref="CopyViaProperties"/> is the pre-#13234 shape kept here on purpose: it copies through
+/// the public observable setters, so the A/B runs in one build instead of across a git stash.
+/// </summary>
+[MemoryDiagnoser]
+public class UndoSnapshotBenchmarks
+{
+    private List<SubtitleLineViewModel> _lines = new();
+
+    [Params(500, 3000)]
+    public int Lines { get; set; }
+
+    [GlobalSetup]
+    public void Setup() => _lines = SubtitleFactory.Make(Lines);
+
+    /// <summary>What MakeUndoRedoObject does today.</summary>
+    [Benchmark(Baseline = true)]
+    public SubtitleLineViewModel[] CopyViaFields()
+    {
+        var result = new SubtitleLineViewModel[_lines.Count];
+        for (var i = 0; i < _lines.Count; i++)
+        {
+            result[i] = new SubtitleLineViewModel(_lines[i]);
+        }
+
+        return result;
+    }
+
+    /// <summary>The old copy constructor, reproduced through the public setters.</summary>
+    [Benchmark]
+    public SubtitleLineViewModel[] CopyViaProperties()
+    {
+        var result = new SubtitleLineViewModel[_lines.Count];
+        for (var i = 0; i < _lines.Count; i++)
+        {
+            var p = _lines[i];
+            var copy = new SubtitleLineViewModel
+            {
+                Text = p.Text,
+                OriginalText = p.OriginalText,
+                StartTime = p.StartTime,
+                EndTime = p.EndTime,
+                Style = p.Style,
+                Actor = p.Actor,
+                Layer = p.Layer,
+                Number = p.Number,
+                Language = p.Language,
+                Region = p.Region,
+                Extra = p.Extra,
+                Effect = p.Effect,
+                IsComment = p.IsComment,
+                MarginL = p.MarginL,
+                MarginR = p.MarginR,
+                MarginV = p.MarginV,
+                NewSection = p.NewSection,
+                Forced = p.Forced,
+                Bookmark = p.Bookmark,
+                Id = p.Id,
+            };
+            copy.UpdateDuration();
+            result[i] = copy;
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
UI responsiveness work for #13234 ("Waveform adjustment and text editing feel less responsive than before"). The common thread behind both symptoms: continuous edits paid full-subtitle work several times a second on the UI thread.

## Undo change detection

- **`IsTyping()` → `IsUserEditing()`, now covering waveform pointer drags.** A drag rewrites time codes on every change-detection tick but presses no key, so the keyboard-only guard never suppressed it — every tick of a drag deep-copied the whole subtitle and pushed an intermediate state onto the undo stack. `AudioVisualizer.IsEditingWithPointer` is timestamp-based with the same 500 ms grace as the keyboard check (deliberately not `_interactionMode != None`, so a lost pointer capture can never leave detection switched off). A drag now takes one snapshot when it settles, and Ctrl+Z after a drag lands on the pre-drag state instead of somewhere mid-drag.
- **Detection interval 250 ms → 333 ms.** A tick that sees a change deep-copies the whole subtitle; this keeps the #11280 fix while paying that cost less often.
- **Snapshot cost cut ~12×.** The `SubtitleLineViewModel` copy ctor went through the public observable setters, paying ~40 discarded notification allocations + partial-hook fan-out per line — nothing can be subscribed to an object mid-construction. It now writes backing fields. Measured with the new `UndoSnapshotBenchmarks` (old shape kept as an in-build baseline, no cross-build noise):

  | Lines | Old (setters) | New (fields) | Alloc |
  |---|---|---|---|
  | 500 | 299 µs / 531 KB | 28 µs / 180 KB | 2.96× less |
  | 3000 | 2 038 µs / 3 188 KB | 174 µs / 1 078 KB | 2.96× less |

- **`GetUndoRedoHash` walks the subtitle once, not twice** — one fused pass hashing `Text` and `OriginalText` per line instead of composing `GetFastHash() * 31 + GetFastHashOriginal()`. Undo hashes are only ever compared among themselves in-process; save-tracking keeps the separate hashes untouched.

## Timers

- **The 400 ms mpv preview refresh defers while the user is editing.** It ran `GetUpdateSubtitle()` + two `Subtitle` copies + `ToText()` + a temp-file write on the UI thread every tick while typing. The dirty flag stays set, so the settled state is pushed on the first quiet tick (≤ 900 ms after the last input) — and the preview settles once instead of flickering mid-word.
- **The 50 ms position timer rebuilds the waveform subtitle buffer only when dirty.** It used to copy every line and order-check the buffer 20×/second, always (~60k list-adds + 60k comparisons per second at idle on a 3000-line file). The dirty flag is set by the existing `ForMpv` hooks (collection changes; per-line `Text`/`StartTime`/`EndTime`, plus `Layer` since the buffer filters on it) and by comparing the layer-visibility inputs, which are only ever swapped wholesale. The buffer holds live references and time changes mark dirty synchronously on the UI thread, so no tick can see a stale ordering.

## Waveform render

- **Paragraph footer labels cached by value.** `DrawParagraphFooter` built a `TimeCode` + `ToShortDisplayString()` + string interpolations per visible paragraph per frame just to key the `FormattedText` cache (~1800 allocations/second at 60 fps × 10 visible lines). Now keyed on `(Number, DurationMs, frame-mode)` and on the exact CPS double (safe because `CharactersPerSecond` is itself memoized); a hit allocates nothing. Same 8000-entry cap as the sibling caches.

## Verification

- All 1424 UI tests pass after rebasing onto main.
- Benchmark run per the repo benchmark workflow (single build, A/B baseline inside the benchmark, no src edits mid-run).
- The remaining #13234 candidates (accessible-name MultiBinding gating, spectrogram per-frame rebuild) are deliberately left out pending the reporter's answers on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)