### PR TITLE
Fix #10193: harden SoftNI regression tests (review follow-up)

### DIFF
--- a/tests/libse/SubtitleFormats/SoftNiSubTest.cs
+++ b/tests/libse/SubtitleFormats/SoftNiSubTest.cs
@@ -28,6 +28,7 @@ public class SoftNiSubTest
             var lines = text.SplitToLines();
             var timingIndex = lines.FindIndex(line => line == "*TIMING*");
             Assert.True(timingIndex >= 0, "Missing *TIMING* section");
+            Assert.True(timingIndex + 1 < lines.Count, "Missing timing line after *TIMING* section");
             Assert.Equal(expectedTimingLine, lines[timingIndex + 1]);
         }
         finally
@@ -50,6 +51,7 @@ public class SoftNiSubTest
             var lines = text.SplitToLines();
             var timingIndex = lines.FindIndex(line => line == "*TIMING*");
             Assert.True(timingIndex >= 0, "Missing *TIMING* section");
+            Assert.True(timingIndex + 1 < lines.Count, "Missing timing line after *TIMING* section");
             Assert.Equal("1 24 0", lines[timingIndex + 1]);
         }
         finally


### PR DESCRIPTION
## Problem
Follow-up to merged PR #13241 (issue #10193, SoftNI sub export frame rate). Copilot review on #13241 noted that the regression tests index `lines[timingIndex + 1]` right after asserting the *TIMING* header exists, without checking that a following line actually exists — if the output is truncated or *TIMING* is the last line, the test would throw IndexOutOfRangeException instead of failing with a clear assertion message. The comment applies at two sites (line 31 and line 51 of tests/libse/SubtitleFormats/SoftNiSubTest.cs).

## Fix
Added a bounds assertion before indexing in both SoftNI tests:
`Assert.True(timingIndex + 1 < lines.Count, "Missing timing line after *TIMING* section");`

Test-only change; no production code touched.

## Verification
- [x] `dotnet build tests/libse/LibSETests.csproj` — EXIT:0, 0 errors
- [x] `dotnet test tests/libse/LibSETests.csproj --filter FullyQualifiedName~SoftNiSubTest` — Passed: 4, Failed: 0
- [x] Diff limited to 2 added assertion lines

## Notes
- Copilot review finding from PR #13241 addressed here as a follow-up PR since #13241 was already merged by the maintainer.
- This PR was created with AI assistance (per repo AI contributor guidelines).