### PR TITLE
Fix #12227: 'Start with uppercase letter after paragraph' sees single-letter lines as paragraph ends

### DIFF
--- a/src/libse/Forms/FixCommonErrors/Helper.cs
+++ b/src/libse/Forms/FixCommonErrors/Helper.cs
@@ -321,7 +321,11 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             if (string.IsNullOrEmpty(prevText) || prevText.Length < 3)
             {
-                return true;
+                // Short lines are usually paragraph markers (dash, music note, etc.) that end a
+                // paragraph - but a short line of actual text (e.g. "u") continues the same
+                // sentence and must not trigger capitalization of the next line (#12227).
+                var trimmed = prevText.TrimEnd();
+                return string.IsNullOrEmpty(trimmed) || !char.IsLetterOrDigit(trimmed[trimmed.Length - 1]);
             }
 
             prevText = prevText.Replace("♪", string.Empty).Replace("♫", string.Empty).Trim();

--- a/src/libse/Forms/FixCommonErrors/Helper.cs
+++ b/src/libse/Forms/FixCommonErrors/Helper.cs
@@ -324,8 +324,13 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                 // Short lines are usually paragraph markers (dash, music note, etc.) that end a
                 // paragraph - but a short line of actual text (e.g. "u") continues the same
                 // sentence and must not trigger capitalization of the next line (#12227).
-                var trimmed = prevText.TrimEnd();
-                return string.IsNullOrEmpty(trimmed) || !char.IsLetterOrDigit(trimmed[trimmed.Length - 1]);
+                var trimmed = prevText?.TrimEnd();
+                if (string.IsNullOrEmpty(trimmed))
+                {
+                    return true;
+                }
+
+                return !char.IsLetterOrDigit(trimmed[trimmed.Length - 1]);
             }
 
             prevText = prevText.Replace("♪", string.Empty).Replace("♫", string.Empty).Trim();

--- a/src/libse/Forms/FixCommonErrors/Helper.cs
+++ b/src/libse/Forms/FixCommonErrors/Helper.cs
@@ -321,9 +321,11 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             if (string.IsNullOrEmpty(prevText) || prevText.Length < 3)
             {
-                // Short lines are usually paragraph markers (dash, music note, etc.) that end a
-                // paragraph - but a short line of actual text (e.g. "u") continues the same
-                // sentence and must not trigger capitalization of the next line (#12227).
+                // One- and two-character lines that are paragraph markers (dash, music note,
+                // "--") or end in punctuation still end a paragraph - but a short line ending
+                // in a letter or digit ("u", "Ja") continues the same sentence, matching what
+                // the full check below decides for longer lines, and must not trigger
+                // capitalization of the next line (#12227).
                 var trimmed = prevText?.TrimEnd();
                 if (string.IsNullOrEmpty(trimmed))
                 {

--- a/tests/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterParagraphTest.cs
+++ b/tests/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterParagraphTest.cs
@@ -46,6 +46,30 @@ public class FixStartWithUppercaseLetterAfterParagraphTest
         Assert.Equal("he is asleep.", Fix("It is 5 a.m.", "he is asleep.", "en"));
     }
 
+    // A line ending with a quotation mark is not a paragraph end - the quote is not
+    // preceded by sentence-ending punctuation, so the next line continues the sentence (#12227).
+    [Fact]
+    public void KeepsLowercaseWhenPreviousParagraphEndsWithQuote()
+    {
+        Assert.Equal("me ontmoeten.", Fix("\"u\"", "me ontmoeten.", "nl"));
+    }
+
+    // The previous subtitle is a one-letter fragment ("u") - not a paragraph end, so the
+    // next line must not be capitalized (#12227).
+    [Fact]
+    public void KeepsLowercaseWhenPreviousParagraphIsSingleLetter()
+    {
+        Assert.Equal("me ontmoeten.", Fix("u", "me ontmoeten.", "nl"));
+    }
+
+    // Same, but the one-letter fragment is line one of a two-line subtitle.
+    [Fact]
+    public void KeepsLowercaseWhenFirstLineIsSingleLetter()
+    {
+        var text = "u" + Environment.NewLine + "me ontmoeten.";
+        Assert.Equal(text, Fix("- Wilt", text, "nl"));
+    }
+
     // A real sentence ending must still be fixed.
     [Fact]
     public void CapitalizesAfterSentenceEnding()

--- a/tests/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterParagraphTest.cs
+++ b/tests/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterParagraphTest.cs
@@ -47,11 +47,35 @@ public class FixStartWithUppercaseLetterAfterParagraphTest
     }
 
     // A line ending with a quotation mark is not a paragraph end - the quote is not
-    // preceded by sentence-ending punctuation, so the next line continues the sentence (#12227).
+    // preceded by sentence-ending punctuation, so the next line continues the sentence.
+    // ("\"u\"" is three characters, so this is the pre-existing long-line path - kept as a
+    // regression guard around the short-line change for #12227.)
     [Fact]
     public void KeepsLowercaseWhenPreviousParagraphEndsWithQuote()
     {
         Assert.Equal("me ontmoeten.", Fix("\"u\"", "me ontmoeten.", "nl"));
+    }
+
+    // Two-character lines follow the same rule as longer ones: no sentence-ending
+    // punctuation means no paragraph end (#12227).
+    [Fact]
+    public void KeepsLowercaseWhenPreviousParagraphIsTwoLetterWord()
+    {
+        Assert.Equal("we vertrekken.", Fix("Ja", "we vertrekken.", "nl"));
+    }
+
+    // ...while a short line that ends in sentence punctuation still ends the paragraph.
+    [Fact]
+    public void CapitalizesAfterShortLineEndingWithPeriod()
+    {
+        Assert.Equal("We vertrekken.", Fix("Ja.", "we vertrekken.", "nl"));
+    }
+
+    // A lone dash line is a paragraph marker, not text - it still ends the paragraph.
+    [Fact]
+    public void CapitalizesAfterLoneDashLine()
+    {
+        Assert.Equal("We vertrekken.", Fix("-", "we vertrekken.", "nl"));
     }
 
     // The previous subtitle is a one-letter fragment ("u") - not a paragraph end, so the


### PR DESCRIPTION
## Problem
Fixes #12227 — "Start with uppercase letter after paragraph" in Fix common errors wrongly treats a short line of text as a paragraph end. With a previous subtitle consisting of a single letter (e.g. `u` — the issue reporter's `"u"` is phrasing; the actual line is one letter), `Helper.IsPreviousTextEndOfParagraph` returned `true` for ANY previous text shorter than 3 characters, so the next line (`me ontmoeten.`) got capitalized (`Me ontmoeten.`) and the following "Add missing period" pass then appended a period.

## Fix
`src/libse/Forms/FixCommonErrors/Helper.cs` — `IsPreviousTextEndOfParagraph`: short lines (< 3 chars) now end a paragraph only if the trimmed last character is not a letter/digit. Short punctuation/empty lines (`-`, `♪`, `""`) keep ending the paragraph; a short text fragment (`u`) continues the sentence. Existing behavior for everything else is unchanged. (The literal `"u"`-with-quotes case was already handled on current main — covered by a regression test.)

## Verification
- [x] `dotnet build src/ui/UI.csproj` — EXIT:0, 0 errors
- [x] New regression tests in `FixStartWithUppercaseLetterAfterParagraphTest`: `KeepsLowercaseWhenPreviousParagraphEndsWithQuote`, `KeepsLowercaseWhenPreviousParagraphIsSingleLetter`, `KeepsLowercaseWhenFirstLineIsSingleLetter` — failed pre-fix (2 fails), all 8 tests in the class pass post-fix
- [x] `dotnet test tests/libse/LibSETests.csproj --filter FullyQualifiedName~FixStartWithUppercaseLetterAfterParagraphTest` — Passed: 8, Failed: 0

## Notes
- Interpretation: the quotation marks in the issue title are the author's phrasing; the failing input is a single-letter text line. The literal-quote case is already fixed on main (verified by a passing test) and kept covered.
- Deliberate non-change: capitalization after real sentence endings and after short punctuation lines (dash, music notes) is preserved.
- This PR was created with AI assistance (per repo AI contributor guidelines).