### PR TITLE
Fix #10955: ASSA subtitle grid colors not working with fading colors

### DIFF
--- a/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
@@ -1056,7 +1056,11 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             return null; // Skip empty or excessively long color strings
         }
 
-        // ASSA colors are in format &HAABBGGRR& or &HBBGGRR& (BGR order, not RGB)
+        // ASSA colors are in format &HAABBGGRR& or &HBBGGRR& (BGR order, not RGB).
+        // A trailing ')' is left over when the color is the last tag inside a \t(...)
+        // fade transition ({\c&HFFFFFF&\t(20,1000,0.9,\c&H29F2FF&)}); for fading colors
+        // the grid shows the destination color, so drop the transition's closing paren.
+        colorStr = colorStr.TrimEnd(')');
         colorStr = colorStr.Trim("&Hh".AsSpan());
 
         if (colorStr.Length < 6 || colorStr.Length > 8)

--- a/tests/UI/Logic/ValueConverters/ValueConverterTests.cs
+++ b/tests/UI/Logic/ValueConverters/ValueConverterTests.cs
@@ -209,6 +209,21 @@ public class ValueConverterTests
         Assert.False(run.IsSet(TextElement.ForegroundProperty));
     }
 
+    [AvaloniaTheory]
+    [InlineData("{\\c&HFFFFFF&\\t(20,1000,0.9,\\c&H29F2FF&)}became clear.{\\c&HFFFFFF&}")]
+    [InlineData("{\\c&HFFFFFF&\\t(20,1000,0.9,\\1c&H29F2FF&)}x")]
+    public void ShowFormatting_UsesDestinationColorOfAssaFadeTransition(string text)
+    {
+        // Issue #10955: the destination color inside a \t(...) fade transition is the last
+        // tag before the transition's closing paren - the grid should show that color
+        // instead of losing the color entirely.
+        var run = SingleRun(Highlight(text, SubtitleGridFormattingTypes.ShowFormatting));
+
+        // &H29F2FF& is BGR: red = 0xFF, green = 0xF2, blue = 0x29
+        Assert.Equal(Color.FromArgb(255, 255, 242, 41),
+            Assert.IsAssignableFrom<ISolidColorBrush>(run.Foreground).Color);
+    }
+
     [AvaloniaFact]
     public void ShowFormatting_AppliesAssaFontNameAndSize()
     {


### PR DESCRIPTION
## Problem
Fixes #10955 — ASSA subtitle grid colors are not shown when the line uses fading colors: `{\c&HFFFFFF&\t(20,1000,0.9,\c&H29F2FF&)}became clear.{\c&HFFFFFF&}` renders uncolored in the grid.

Root cause: `TextWithSubtitleSyntaxHighlightingConverter.ParseAssaColor` (src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs:1052). Tag blocks are split on `\`, so the destination color inside a `\t(...)` fade transition becomes the segment `c&H29F2FF&)` — carrying the transition's closing paren. `ParseAssaColor` rejected the trailing `)` as a non-hex character and returned `null`, which reset the color state and left the following text with no foreground color at all.

## Fix
In `ParseAssaColor`, drop a trailing `)` from the color value before trimming the `&H` wrapper. A `)` can only appear there as the closing paren of a `\t(...)` transition, and the color inside the transition is the fade's destination color — the most logical one to display in the grid, as suggested in the issue. Behavior for all other tags is unchanged; malformed colors still fall back to no color.

## Verification
- [x] `dotnet build src/ui/UI.csproj` — 0 errors (EXIT:0)
- [x] New regression test(s): `ShowFormatting_UsesDestinationColorOfAssaFadeTransition` (2 theory rows: `\c` and `\1c` destination inside `\t()`) — fails on pre-fix code (Failed: 2, Passed: 0), passes post-fix (Failed: 0, Passed: 2)
- [x] Existing tests run: `ValueConverterTests` class — 57 passed; full `UITests` suite — all passed
- UI-only change; the failing/passing state is covered headlessly via the converter's rendered inline runs (no manual path needed)

## Notes
- Interpretation taken from the issue: when a `\t()` transition contains two colors, the grid displays the destination color (the one inside the transition). 
- Deliberate non-change: `\t()` timing/acceleration arguments are still ignored by the grid formatter, as before — only the color segment's parsing is fixed.
- This PR was created with AI assistance (per repo AI contributor guidelines).