### PR TITLE
Fix #12734: Return shortcut does not work when focusing the subtitle grid

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -21931,10 +21931,16 @@ public partial class MainViewModel :
                     return;
                 }
                 else if (keyEventArgs.Key == Key.Enter && keyEventArgs.KeyModifiers == KeyModifiers.None &&
-                         !_shortcutManager.HasSingleKeyShortcut(ShortcutManager.GetShortcutKeyName(keyEventArgs)))
+                         _shortcutManager.CheckShortcuts(keyEventArgs, CategorySubtitleGrid) == null &&
+                         _shortcutManager.CheckShortcuts(keyEventArgs, CategorySubtitleGridAndTextBox) == null &&
+                         _shortcutManager.CheckShortcuts(keyEventArgs, CategoryGeneralLower) == null)
                 {
                     // A user-assigned bare Return shortcut wins over the built-in "go to subtitle and set
                     // video position" Enter handling, so the shortcut reaches dispatch below (#12734).
+                    // Probed with the same CheckShortcuts calls the dispatch itself uses - grid
+                    // categories right below, General at the end of the handler - so a Return
+                    // bound only in the waveform or text-box context does not disable the
+                    // built-in Enter behavior here.
                     if (Se.Settings.General.SubtitleEnterKeyAction == SubtitleEnterKeyActionType.GoToSubtitleAndSetVideoPosition.ToString())
                     {
                         keyEventArgs.Handled = true;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -21930,8 +21930,11 @@ public partial class MainViewModel :
                     SelectAndScrollToRow(Subtitles.Count - 1);
                     return;
                 }
-                else if (keyEventArgs.Key == Key.Enter && keyEventArgs.KeyModifiers == KeyModifiers.None)
+                else if (keyEventArgs.Key == Key.Enter && keyEventArgs.KeyModifiers == KeyModifiers.None &&
+                         !_shortcutManager.HasSingleKeyShortcut(ShortcutManager.GetShortcutKeyName(keyEventArgs)))
                 {
+                    // A user-assigned bare Return shortcut wins over the built-in "go to subtitle and set
+                    // video position" Enter handling, so the shortcut reaches dispatch below (#12734).
                     if (Se.Settings.General.SubtitleEnterKeyAction == SubtitleEnterKeyActionType.GoToSubtitleAndSetVideoPosition.ToString())
                     {
                         keyEventArgs.Handled = true;

--- a/tests/UI/Features/Main/SubtitleGridEnterShortcutTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridEnterShortcutTests.cs
@@ -1,0 +1,110 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// A user-assigned bare Return shortcut must fire while the subtitle grid is focused (#12734).
+/// The built-in "go to subtitle and set video position" Enter handling used to swallow the key
+/// unconditionally, so shortcut dispatch (e.g. "Play next (and stop)") was never reached for
+/// bare Return; Shift+Return already worked because it never matched that branch.
+/// </summary>
+public class SubtitleGridEnterShortcutTests
+{
+    private static (Window Window, MainViewModel Vm, TableView Grid) ShowMainWindowWithLines(int lineCount = 3)
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        for (var i = 0; i < lineCount; i++)
+        {
+            vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph($"Line {i + 1}", i * 2000, i * 2000 + 1500), null!)
+            {
+                Number = i + 1,
+            });
+        }
+
+        Settle(window);
+        return (window, vm, vm.SubtitleGrid);
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 5; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+
+    private static void ClickRow(Window window, TableView grid, int index)
+    {
+        var container = (Visual?)grid.ContainerFromItem(((IList<SubtitleLineViewModel>)grid.ItemsSource!)[index]);
+        Assert.NotNull(container);
+        var bounds = container!.Bounds;
+        var point = container.TranslatePoint(new Point(bounds.Width / 2, bounds.Height / 2), window)!.Value;
+
+        window.MouseDown(point, MouseButton.Left, RawInputModifiers.None);
+        window.MouseUp(point, MouseButton.Left, RawInputModifiers.None);
+        Settle(window);
+    }
+
+    [AvaloniaFact]
+    public void Enter_RunsUserAssignedReturnShortcut_WhenGridIsFocused()
+    {
+        // The user assigned bare Return to "go to next line" (any grid/general action works;
+        // the real-world report used "Play next (and stop)", which needs a video player and is
+        // not observable headless - this proxy action is).
+        // The settings singleton is shared across tests in the run, so make sure the action has
+        // exactly ONE binding - the user's - or GetUsedShortcuts' GroupBy(First()) would prefer
+        // the pre-existing default binding (Alt+Down) over it.
+        var originalGoToNextLine = Se.Settings.Shortcuts.FirstOrDefault(s => s.ActionName == nameof(MainViewModel.GoToNextLineCommand));
+        Se.Settings.Shortcuts.RemoveAll(s => s.ActionName == nameof(MainViewModel.GoToNextLineCommand));
+        Se.Settings.Shortcuts.Add(new SeShortCut(nameof(MainViewModel.GoToNextLineCommand), ["Return"]));
+        try
+        {
+            var (window, vm, grid) = ShowMainWindowWithLines();
+
+            ClickRow(window, grid, 0);
+            Assert.Equal(0, vm.SelectedSubtitleIndex);
+
+            window.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+            Settle(window);
+
+            // The user-assigned bare Return shortcut ran "go to next line" instead of being
+            // swallowed by the built-in Enter handling.
+            Assert.Equal(1, vm.SelectedSubtitleIndex);
+
+            window.Close();
+        }
+        finally
+        {
+            Se.Settings.Shortcuts.RemoveAll(s => s.ActionName == nameof(MainViewModel.GoToNextLineCommand));
+            if (originalGoToNextLine != null)
+            {
+                Se.Settings.Shortcuts.Add(originalGoToNextLine);
+            }
+        }
+    }
+}

--- a/tests/UI/Features/Main/SubtitleGridEnterShortcutTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridEnterShortcutTests.cs
@@ -78,7 +78,7 @@ public class SubtitleGridEnterShortcutTests
         // The settings singleton is shared across tests in the run, so make sure the action has
         // exactly ONE binding - the user's - or GetUsedShortcuts' GroupBy(First()) would prefer
         // the pre-existing default binding (Alt+Down) over it.
-        var originalGoToNextLine = Se.Settings.Shortcuts.FirstOrDefault(s => s.ActionName == nameof(MainViewModel.GoToNextLineCommand));
+        var originalGoToNextLine = Se.Settings.Shortcuts.Where(s => s.ActionName == nameof(MainViewModel.GoToNextLineCommand)).ToList();
         Se.Settings.Shortcuts.RemoveAll(s => s.ActionName == nameof(MainViewModel.GoToNextLineCommand));
         Se.Settings.Shortcuts.Add(new SeShortCut(nameof(MainViewModel.GoToNextLineCommand), ["Return"]));
         try
@@ -101,10 +101,7 @@ public class SubtitleGridEnterShortcutTests
         finally
         {
             Se.Settings.Shortcuts.RemoveAll(s => s.ActionName == nameof(MainViewModel.GoToNextLineCommand));
-            if (originalGoToNextLine != null)
-            {
-                Se.Settings.Shortcuts.Add(originalGoToNextLine);
-            }
+            Se.Settings.Shortcuts.AddRange(originalGoToNextLine);
         }
     }
 }


### PR DESCRIPTION
## Problem
Fixes #12734 — with the subtitle grid focused, a user-assigned bare Return shortcut ("Play next (and stop)" in the report) never fires: the grid branch of `OnKeyDownHandler` handled `Enter` (the "go to subtitle and set video position" action) and unconditionally `return`ed, so shortcut dispatch was never reached. Shift+Return already worked because it doesn't match `KeyModifiers.None`. (In the text box, Return inserting a newline is intentional editing behavior — not changed.)

## Fix
`src/ui/Features/Main/MainViewModel.cs` — the grid Enter branch is now skipped when the user has assigned bare Return to a shortcut, using the same `_shortcutManager.HasSingleKeyShortcut(...)` pattern already used for user-assigned F10 (#12504) and bare digits (type-ahead line navigation). Without a user assignment the built-in Enter behavior is unchanged.

## Verification
- [x] `dotnet build src/ui/UI.csproj` — EXIT:0, 0 errors
- [x] New regression test `SubtitleGridEnterShortcutTests.Enter_RunsUserAssignedReturnShortcut_WhenGridIsFocused` (headless Avalonia): registers bare Return on an observable grid/general command, focuses the grid, presses Enter, asserts the action ran — **fails on pre-fix code (1/1 FAIL), passes post-fix (1/1 PASS)**; also passes when run after other keyboard tests (shared-settings state handled, cleanup in finally)
- [x] Related suites green: MainMenuKeyboardActivationTests + ShortcutsF10MenuTests + SubtitleGridSelectionOrderTests + new test — 17/17

## Notes
- Scope: grid only. The text box keeps inserting a newline on Return (intentional editing behavior; a dedicated setting gates single-key shortcuts in text input).
- Test uses a proxy action (GoToNextLine) because "Play next (and stop)" needs a video player and is not observable headless.
- Deliberate non-change: `SubtitleEnterKeyAction` built-in handling is preserved for users without a bare-Return assignment.
- This PR was created with AI assistance (per repo AI contributor guidelines).