### PR TITLE
Fix #12972: last line of changelog covered by horizontal scrollbar

### DIFF
--- a/src/ui/Features/Help/CheckForUpdates/CheckForUpdatesWindow.cs
+++ b/src/ui/Features/Help/CheckForUpdates/CheckForUpdatesWindow.cs
@@ -46,6 +46,10 @@ public class CheckForUpdatesWindow : Window
             VerticalAlignment = Avalonia.Layout.VerticalAlignment.Stretch,
             DataContext = vm,
         };
+        // With auto-hiding scrollbars (e.g. macOS "When Scrolling") the horizontal scrollbar
+        // overlays the last line of the changelog; reserve its space like the subtitle grid does,
+        // so the final line is always fully visible when scrolled to the bottom (#12972).
+        ScrollViewer.SetAllowAutoHide(changeLogBox, false);
         changeLogBox.Bind(TextBox.TextProperty, new Binding(nameof(vm.ChangeLogText)));
 
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);


### PR DESCRIPTION
## Problem
Fixes #12972 — in the "Check for updates" / "What's new" window, scrolling the changelog all the way down leaves the last line covered by the horizontal scrollbar. The changelog is a read-only `TextBox` (`TextWrapping=NoWrap`); its internal `ScrollViewer` auto-hides scrollbars (default, or macOS "When Scrolling" preference), so the horizontal scrollbar overlays the bottom of the text area and the final line cannot be scrolled fully into view. (The screenshot in the issue is this dialog, not the subtitle grid — the grid already reserves scrollbar space.)

## Fix
`src/ui/Features/Help/CheckForUpdates/CheckForUpdatesWindow.cs` — `ScrollViewer.SetAllowAutoHide(changeLogBox, false)` on the changelog TextBox. Avalonia's TextBox template binds the internal ScrollViewer's `AllowAutoHide` to the attached property on the TextBox (Avalonia 12.1.1 TextBox.xaml line 146), so the scrollbar now reserves its space and the last line scrolls fully above it. Same pattern the subtitle grid already uses (`InitListViewAndEditBox.cs:88`). A local value also wins over the global scrollbar style, so this holds on every OS regardless of the auto-hide preference.

## Verification
- [x] `dotnet build src/ui/UI.csproj` — EXIT:0, 0 errors
- [x] Mechanism verified against Avalonia 12.1.1 source (TextBox.xaml `AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"`)
- [x] Manual verification path (UI-only fix, no automated test per campaign/AI-guideline policy): open Help → Check for updates (or the What's new window), resize the window narrow so the horizontal scrollbar appears, scroll to the bottom — the last line must be fully visible above the scrollbar.

## Notes
- Deliberate non-change: the subtitle grid and other scroll areas keep their current behavior; only this read-only changelog box reserves scrollbar space.
- The commenter's note ("This behavior is probably similar in other locations") is acknowledged — other read-only changelog boxes (e.g. the main window's What's-new panel) could get the same one-liner later; kept out of this PR to stay surgical.
- This PR was created with AI assistance (per repo AI contributor guidelines).