### PR TITLE
Fix #12705 (point 3): persist original subtitle when closing with Yes

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -18004,7 +18004,8 @@ public partial class MainViewModel :
     }
 
     // Saves the current subtitle, prompting for a file name first when it is still untitled.
-    // Returns false if the save (or the "save as" file picker) was cancelled.
+    // Returns false if the save (or the "save as" file picker) was cancelled or failed, so
+    // close flows abort instead of losing data on a failed write (review follow-up, #12705).
     private async Task<bool> SaveCurrentSubtitle()
     {
         if (string.IsNullOrEmpty(_subtitleFileName))
@@ -18012,8 +18013,7 @@ public partial class MainViewModel :
             return await SaveSubtitleAs();
         }
 
-        await SaveSubtitle();
-        return true;
+        return await SaveSubtitle();
     }
 
     // As SaveCurrentSubtitle, but for the original (translation source) subtitle.
@@ -18024,8 +18024,7 @@ public partial class MainViewModel :
             return await SaveSubtitleOriginalAs();
         }
 
-        await SaveSubtitleOriginal();
-        return true;
+        return await SaveSubtitleOriginal();
     }
 
     private async Task<bool> SaveSubtitle(bool isAutoSave = false)
@@ -18676,8 +18675,9 @@ public partial class MainViewModel :
             // always progresses.
             try
             {
-                if (!await PromptSaveChanges(Se.Language.General.SaveChangesMessage,
-                        () => SaveSubtitle()))
+                // Prompt only for files that actually changed. This also persists the original
+                // subtitle of a translation pair without rewriting an untouched main file.
+                if (!await HasChangesContinue())
                 {
                     // Stay cancelled - window won't close
                     return;
@@ -24104,25 +24104,6 @@ public partial class MainViewModel :
             ApplyLiveSpellCheck(result.SelectedDictionary);
             ShowStatus(string.Format(Se.Language.Main.LiveSpellCheckLanguageXLoaded, result.SelectedDictionary.Name));
         });
-    }
-
-    private async void OnWindowClosing(object? sender, WindowClosingEventArgs e)
-    {
-        if (Window == null || !HasChanges())
-        {
-            return;
-        }
-
-        e.Cancel = true;
-
-        if (!await PromptSaveChanges(Se.Language.General.SaveChangesMessage,
-                () => SaveSubtitle()))
-        {
-            return;
-        }
-
-        Window.Closing -= OnWindowClosing;
-        Window.Close();
     }
 
     public void AudioVisualizerFlyoutMenuOpening(object sender, AudioVisualizer.ContextEventArgs e)

--- a/tests/UI/Features/Main/MainWindowClosingTranslationTests.cs
+++ b/tests/UI/Features/Main/MainWindowClosingTranslationTests.cs
@@ -1,0 +1,91 @@
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Main;
+
+public class MainWindowClosingTranslationTests
+{
+    [AvaloniaFact]
+    public void OnlyOriginalChanged_FirstClosePromptIsForOriginal()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1200, Height = 800 };
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var vm = (MainViewModel)view.DataContext!;
+        var line = new SubtitleLineViewModel(new Paragraph("Main text", 0, 2000), null!)
+        {
+            OriginalText = "Original text",
+        };
+        vm.Subtitles.Add(line);
+        vm.ShowColumnOriginalText = true;
+        var mainHash = vm.GetFastHash();
+        SetPrivateField(vm, "_changeSubtitleHash", mainHash);
+        SetPrivateField(vm, "_changeSubtitleHashOriginal", vm.GetFastHashOriginal());
+        line.OriginalText = "Changed original text";
+
+        Assert.True(vm.HasChanges());
+        Assert.Equal(mainHash, vm.GetFastHash());
+
+        try
+        {
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+
+            var messageBox = Assert.Single(
+                window.OwnedWindows.OfType<MessageBox>(),
+                p => p.Title == Se.Language.General.SaveChangesTitle);
+            var messages = messageBox.GetVisualDescendants()
+                .OfType<TextBlock>()
+                .Select(p => p.Text)
+                .Where(p => !string.IsNullOrEmpty(p))
+                .ToList();
+            var expected = string.Format(
+                Se.Language.General.SaveChangesToXOriginal,
+                Se.Language.General.Untitled);
+
+            Assert.Contains(expected, messages);
+        }
+        finally
+        {
+            foreach (var ownedWindow in window.OwnedWindows.ToArray())
+            {
+                ownedWindow.Close();
+            }
+
+            window.Closing -= vm.OnClosing;
+            if (window.IsVisible)
+            {
+                window.Close();
+            }
+        }
+    }
+
+    private static void SetPrivateField(MainViewModel vm, string name, object value)
+    {
+        GetField(name).SetValue(vm, value);
+    }
+
+    private static FieldInfo GetField(string name)
+    {
+        return typeof(MainViewModel).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
+               ?? throw new InvalidOperationException($"Field not found: {name}");
+    }
+}


### PR DESCRIPTION
## Problem

Fixes point 3 of #12705 — edits made to the ORIGINAL subtitle of a translation pair are silently discarded when the user closes the window via the X button and answers "Yes" to save, while clicking the toolbar Save button persists them.

Root cause: `MainViewModel.OnClosing` checked the combined dirty state but prompted and saved only the main subtitle. Adding the original prompt exposed a second problem: when only the original changed, the close path first prompted for and rewrote the untouched main file, then prompted for the original.

## Fix

Use the existing `HasChangesContinue()` flow from `OnClosing`. It already:

- prompts for the main file only when the main subtitle changed;
- then calls `ContinueNewOrExitOriginal()` and prompts only when the original changed;
- propagates Save/Save As failure or cancellation so closing remains cancelled.

This gives one prompt per genuinely changed file and avoids running auto-trim/serialization on an untouched main subtitle.

Also removed the dead `OnWindowClosing` duplicate. `MainView` wires only `OnClosing`; keeping an unwired divergent copy of the same save logic was misleading.

Behavior after the fix:

- Edit main + original → X → each changed file gets its own prompt.
- Edit only original → X → the first and only save prompt is for the original; the main file is not rewritten.
- Cancel or a failed save keeps the window open.
- No discards that file and continues to the next genuinely changed file.

## Verification

- [x] RED: real headless `MainView` test reproduced the regression — the first close prompt was for the current/main subtitle when only `OriginalText` was dirty.
- [x] GREEN: `MainWindowClosingTranslationTests` 1/1 PASS — the first close prompt is now for the original subtitle and the main hash remains unchanged.
- [x] `dotnet build src/ui/UI.csproj --no-restore --no-incremental` — EXIT:0.
- [x] Full UITests retry: 1452 passed, 0 failed, 1 skipped.
- [x] The first full run had two unrelated `SyntaxTextEditorTests` focus/timing failures; both passed 10/10 in isolation on the same SHA before the clean full retry.

## Notes

- Points 1 and 2 of #12705 were already resolved (PR #12708 and a settings misunderstanding, confirmed by the reporter).
- This follow-up implements niksedk's review request to reuse `HasChangesContinue()`, delete the dead close handler, and add a durable regression test.
- This PR was created with AI assistance (per repo AI contributor guidelines).
