### PR TITLE
Fix #13225: Show subtitle language names in MP4 track picker

### DIFF
--- a/src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs
+++ b/src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs
@@ -70,16 +70,22 @@ public partial class PickMp4TrackViewModel : ObservableObject
                 continue;
             }
 
+            // mdia.Name is the Box.Name of the last parsed child box (typically "minf"),
+            // so it must not be shown as the track name - the track language from the
+            // media header (mdhd) is what identifies the track. LanguageString maps an
+            // unknown/unset code to the literal "Any", so that cannot drive the fallback:
+            // an unlabeled track (the common ffmpeg/MP4Box output) shows the handler name
+            // from hdlr, or the handler type when that is blank (review follow-up, #13225).
+            var language = mdia.Mdhd?.LanguageString;
+            if (string.IsNullOrEmpty(language) || language == "Any")
+            {
+                language = string.IsNullOrEmpty(mdia.HandlerName) ? mdia.HandlerType : mdia.HandlerName;
+            }
+
             var display = new Mp4TrackInfoDisplay
             {
                 HandlerType = mdia.HandlerType,
-                // mdia.Name is the Box.Name of the last parsed child box (typically "minf"),
-                // so it must not be shown as the track name - the track language from the
-                // media header (mdhd) is what identifies the track; fall back to the
-                // handler name from hdlr, and to the handler type when that is blank
-                // (review follow-up, #13225).
-                Name = mdia.Mdhd?.LanguageString ??
-                       (string.IsNullOrEmpty(mdia.HandlerName) ? mdia.HandlerType : mdia.HandlerName),
+                Name = language,
                 StartPosition = mdia.StartPosition,
                 IsVobSubSubtitle = mdia.IsVobSubSubtitle,
                 Duration = LastCueEnd(mdia.Minf?.Stbl?.GetParagraphs()),

--- a/src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs
+++ b/src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs
@@ -73,7 +73,11 @@ public partial class PickMp4TrackViewModel : ObservableObject
             var display = new Mp4TrackInfoDisplay
             {
                 HandlerType = mdia.HandlerType,
-                Name = mdia.Name,
+                // mdia.Name is the Box.Name of the last parsed child box (typically "minf"),
+                // so it must not be shown as the track name - the track language from the
+                // media header (mdhd) is what identifies the track; fall back to the
+                // handler name from hdlr when no media header is present.
+                Name = mdia.Mdhd?.LanguageString ?? mdia.HandlerName,
                 StartPosition = mdia.StartPosition,
                 IsVobSubSubtitle = mdia.IsVobSubSubtitle,
                 Duration = LastCueEnd(mdia.Minf?.Stbl?.GetParagraphs()),

--- a/src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs
+++ b/src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs
@@ -76,8 +76,10 @@ public partial class PickMp4TrackViewModel : ObservableObject
                 // mdia.Name is the Box.Name of the last parsed child box (typically "minf"),
                 // so it must not be shown as the track name - the track language from the
                 // media header (mdhd) is what identifies the track; fall back to the
-                // handler name from hdlr when no media header is present.
-                Name = mdia.Mdhd?.LanguageString ?? mdia.HandlerName,
+                // handler name from hdlr, and to the handler type when that is blank
+                // (review follow-up, #13225).
+                Name = mdia.Mdhd?.LanguageString ??
+                       (string.IsNullOrEmpty(mdia.HandlerName) ? mdia.HandlerType : mdia.HandlerName),
                 StartPosition = mdia.StartPosition,
                 IsVobSubSubtitle = mdia.IsVobSubSubtitle,
                 Duration = LastCueEnd(mdia.Minf?.Stbl?.GetParagraphs()),


### PR DESCRIPTION
## Problem
Fixes #13225 — in the "Pick MP4 track" dialog (shown when importing embedded subtitles from an MP4), every track's Name column shows the same unreadable value ("minf"), so the user cannot tell which subtitle track is which language.

Root cause: `PickMp4TrackViewModel.Initialize(List<Trak>…)` populated the Name column with `mdia.Name` (src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs:76). `Mdia` inherits `Name` from `Box`, which holds the box type of the *last child box parsed inside mdia* — typically `minf` — and was never a track name. The actual track language lives in the media header: `Mdia.Mdhd` (ISO 639-2/T code, mapped to an English name by `Mdhd.LanguageString`).

## Fix
Show the track's language from mdhd as the Name (`mdia.Mdhd?.LanguageString`), falling back to the hdlr handler name (`mdia.HandlerName`) when no media header is present. This mirrors:
- the fragmented-track branch of the same dialog, which already shows the mdhd-derived language (`track.Language`), and
- the SE 4.x precedent (`GenerateVideoWithSoftSubs`: Name from HandlerName, Language from `Mdhd.Iso639ThreeLetterCode`).

Files changed: `src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs` (5 insertions, 1 deletion).

## Verification
- [x] `dotnet build src/ui/UI.csproj -v q -nologo` — Build succeeded, 0 warnings, 0 errors (exit code 0)
- [ ] No new regression tests: UI-only display fix (the value shown in a dialog column); per repo AI guidelines §4, the manual verification path is documented below.
- Manual verification path: open an MP4 containing embedded subtitle tracks with languages set in mdhd (e.g. muxed with ffmpeg or HandBrake) → "Import subtitle from MP4" (or open the file and import the embedded subtitle) → the "Pick MP4 track" dialog now shows the language of each track (e.g. "English", "Chinese") in the Name column instead of "minf" for every row. Fragmented (DASH/CMAF) files with multiple text tracks are unaffected (separate code path).

## Notes
- Interpretation: the Name column is meant to identify the track for the user; the mdhd language is the reliable identifier. When the mdhd language code is not in the ISO 639-2 list (e.g. "und"), `LanguageString` yields "Any" — the existing SE convention for unknown languages.
- Deliberate non-change: `EmbeddedSubtitlesEditViewModel.cs:699` also reads `track.Mdia.Name` (used there as a Format label) — same Box.Name confusion, but a different dialog/column not covered by this issue; left for the owner to decide.
- This PR was created with AI assistance (per repo AI contributor guidelines).