### PR TITLE
Add DeepSeek-OCR-2 backend to CrispEmbed OCR engine

### DIFF
--- a/src/ui/Features/Ocr/Engines/CrispEmbedEngine.cs
+++ b/src/ui/Features/Ocr/Engines/CrispEmbedEngine.cs
@@ -117,9 +117,9 @@ public static class CrispEmbedEngine
     }
 
     /// <summary>
-    /// The OCR backends offered in Subtitle Edit - the three CrispEmbed models best suited
-    /// for subtitle OCR. Model URLs/sizes match cstr's HuggingFace repos as referenced by
-    /// the CrispEmbed v0.14.0 model registry.
+    /// The OCR backends offered in Subtitle Edit - the CrispEmbed models best suited for
+    /// subtitle OCR. Model URLs/sizes match cstr's HuggingFace repos as referenced by the
+    /// CrispEmbed model registry.
     /// </summary>
     public static List<CrispEmbedBackend> GetBackends()
     {
@@ -204,6 +204,27 @@ public static class CrispEmbedEngine
                         Name = "qwen3-vl-2b-q8_0.gguf",
                         Size = "2.29 GB",
                         Url = "https://huggingface.co/cstr/qwen3-vl-2b-crispembed-gguf/resolve/main/qwen3-vl-2b-q8_0.gguf",
+                    },
+                },
+            },
+            // DeepSeek-OCR-2 (CrispEmbed v0.17.5): the most accurate backend here on
+            // subtitle-style images - the only one exact on a 9-image EN/DE/FR/ES/IT/ZH/JA/RU
+            // corpus where GLM-OCR scored 6/9 and GOT-OCR2 0/9 (verified 2026-08-05). ~2 s/image
+            // on Apple Silicon with the single-view mode CrispEmbedOcr requests via
+            // DS2_CROP_MODE=0. Only the q4_k "stacked" quant is offered: q8_0 measured slightly
+            // worse on the same corpus (8/9, drops an umlaut) while being 1.3 GB larger and no
+            // faster.
+            new()
+            {
+                Name = "DeepSeek-OCR-2",
+                Models = new List<CrispEmbedModel>
+                {
+                    new()
+                    {
+                        Name = "deepseek-ocr2-q4_k-stacked.gguf",
+                        Size = "2.31 GB",
+                        Url = "https://huggingface.co/cstr/deepseek-ocr2-crispembed-GGUF/resolve/main/deepseek-ocr2-q4_k-stacked.gguf",
+                        MinimumSizeBytes = 2_000_000_000,
                     },
                 },
             },

--- a/src/ui/Features/Ocr/Engines/CrispEmbedOcr.cs
+++ b/src/ui/Features/Ocr/Engines/CrispEmbedOcr.cs
@@ -117,6 +117,12 @@ public class CrispEmbedOcr : IDisposable
                 },
             };
 
+            // DeepSeek-OCR-2's dynamic crop mode (default since CrispEmbed v0.17.5) tiles the
+            // image into multiple views, which helps full-page documents but is 3-6x slower on
+            // subtitle-sized bitmaps with byte-identical output (measured 2026-08-05, EN/ZH/JA/RU
+            // plus a 1920px two-liner). Only the DeepSeek engine reads this variable.
+            _serverProcess.StartInfo.Environment["DS2_CROP_MODE"] = "0";
+
             _serverProcess.OutputDataReceived += (_, e) => CaptureServerOutput(e.Data);
             _serverProcess.ErrorDataReceived += (_, e) => CaptureServerOutput(e.Data);
             _serverProcess.Start();
@@ -211,7 +217,7 @@ public class CrispEmbedOcr : IDisposable
                     ? textElement.GetString() ?? string.Empty
                     : string.Empty;
 
-            return resultText.Replace("\r\n", "\n").Replace("\n", Environment.NewLine).Trim();
+            return NormalizeServerText(resultText);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -239,6 +245,22 @@ public class CrispEmbedOcr : IDisposable
                 // ignore
             }
         }
+    }
+
+    /// <summary>
+    /// Normalizes a VLM OCR result to platform newlines with per-line trimming. The document
+    /// models reproduce a centered second line's indentation as literal leading spaces, which
+    /// are never meaningful in a subtitle.
+    /// </summary>
+    internal static string NormalizeServerText(string text)
+    {
+        var lines = text.Replace("\r\n", "\n").Split('\n');
+        for (var i = 0; i < lines.Length; i++)
+        {
+            lines[i] = lines[i].Trim();
+        }
+
+        return string.Join(Environment.NewLine, lines).Trim();
     }
 
     /// <summary>

--- a/tests/UI/Features/Ocr/Engines/CrispEmbedEngineTests.cs
+++ b/tests/UI/Features/Ocr/Engines/CrispEmbedEngineTests.cs
@@ -10,7 +10,7 @@ public class CrispEmbedEngineTests
     {
         var backends = CrispEmbedEngine.GetBackends();
 
-        Assert.Equal(new[] { "PP-OCRv6", "GLM-OCR", "GOT-OCR2", "Qwen3-VL-2B" }, backends.Select(p => p.Name));
+        Assert.Equal(new[] { "PP-OCRv6", "GLM-OCR", "GOT-OCR2", "Qwen3-VL-2B", "DeepSeek-OCR-2" }, backends.Select(p => p.Name));
     }
 
     [Fact]
@@ -99,6 +99,16 @@ public class CrispEmbedEngineTests
     public void GetExitCodeHint_IsEmptyForCodesWithNothingToAdd(int exitCode)
     {
         Assert.Equal(string.Empty, CrispEmbedOcr.GetExitCodeHint(exitCode));
+    }
+
+    [Theory]
+    [InlineData("Line one\n    Line two indented", "Line one\nLine two indented")]
+    [InlineData("  padded  ", "padded")]
+    [InlineData("One\r\nTwo", "One\nTwo")]
+    [InlineData("", "")]
+    public void NormalizeServerText_TrimsEachLine(string input, string expected)
+    {
+        Assert.Equal(expected.Replace("\n", Environment.NewLine), CrispEmbedOcr.NormalizeServerText(input));
     }
 
     [Fact]


### PR DESCRIPTION
Adds **DeepSeek-OCR-2** as a new CrispEmbed OCR backend, per the inclusion bar that a new engine must be at least as good as the existing ones — it measured as the best backend on subtitle-style images.

## Verification (headless, against the pinned CrispEmbed v0.17.5 release)

9-image subtitle-style corpus rendered with ffmpeg drawtext, ground truth known exactly: EN dialog two-liner, EN with numbers/currency/punctuation (1920px), DE (umlauts, ß, €), FR (accents), ES (inverted punctuation), IT (italic font), ZH, JA, RU. Run exactly the way SE runs it (`crispembed-server --ocr … ` + `POST /ocr/model`), scored by exact match and character error rate:

| backend | exact | CER | avg ms/image (M-series Mac) |
|---|---|---|---|
| **DeepSeek-OCR-2 q4_k-stacked** | **9/9** | **0.000** | 2,203 |
| PP-OCRv6 medium | 7/9 | 0.072 | ~600 |
| GLM-OCR q4_k | 6/9 | 0.038 | 840 |
| Qwen3-VL-2B q4_k | 2/9 | 8.47 | 11,789 |
| GOT-OCR2 q4_k | 0/9 | 0.281 | 1,649 |

Notable failures it avoids: GLM-OCR drops the line break in two-liners and "corrected" Russian «Помоги» to «Помогите»; PP-OCRv6 returned only punctuation for Russian; Qwen3-VL fell into a repetition loop on one image.

## Decisions

- **Only the q4_k "stacked" quant is offered** (2.31 GB). q8_0 was downloaded and verified too: 8/9 (drops the umlaut in "Größenwahn"), 1.3 GB larger, no faster — no reason to ship it.
- **`DS2_CROP_MODE=0`** is set when starting crispembed-server: DeepSeek's dynamic crop mode (default since v0.17.5) tiles the image into multiple views, which helps full-page documents but is 3–6× slower on subtitle-sized bitmaps with byte-identical output (verified including a 1920px two-liner). The variable is only read by the DeepSeek engine.
- **Per-line trimming** of VLM server results (`NormalizeServerText`): DeepSeek reproduces a centered second line's indentation as literal leading spaces, which are never meaningful in a subtitle.

No download-dialog changes needed — it is generic over `CrispEmbedModel`.

## Tests

- `GetBackends_HasExpectedBackends` updated for the new backend
- New `NormalizeServerText_TrimsEachLine` theory
- All 19 CrispEmbed tests pass; UI project builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)