### PR TITLE
Fix #9631: keep multi-word 'do not break' phrases together

### DIFF
--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -272,6 +272,27 @@ namespace Nikse.SubtitleEdit.Core.Common
                         return false;
                     }
                 }
+
+                // A multi-word entry (e.g. "SORT OF") means the whole phrase must stay together,
+                // so also forbid a break between its words - otherwise the line could still be
+                // split right before the last word of the phrase (issue #9631).
+                var nextSpaceIndex = s.IndexOf(' ', index + 1);
+                if (nextSpaceIndex < 0)
+                {
+                    nextSpaceIndex = s.Length;
+                }
+
+                if (nextSpaceIndex > index + 1)
+                {
+                    var s3 = s.Substring(0, nextSpaceIndex);
+                    foreach (NoBreakAfterItem ending in NoBreakAfterList(language))
+                    {
+                        if (ending.Regex == null && ending.Text != null && ending.Text.IndexOf(' ') >= 0 && ending.IsMatch(s3))
+                        {
+                            return false;
+                        }
+                    }
+                }
             }
             else
             {

--- a/tests/libse/Common/UtilitiesTest.cs
+++ b/tests/libse/Common/UtilitiesTest.cs
@@ -86,6 +86,54 @@ public class UtilitiesTest
         Assert.Equal(input, result);
     }
 
+    // A multi-word "do not break after" entry (e.g. "SORT OF") must keep the whole phrase
+    // together: the line may not be split between its words, even when a single word of the
+    // phrase ("OF") is in the list too (issue #9631).
+    [Theory]
+    [InlineData("HE WAS SORT OF WEIRD", 10, new[] { "SORT OF", "OF" })]
+    [InlineData("HE WAS SORT OF WEIRD", 10, new[] { "SORT OF" })]
+    [InlineData("I AT LEAST KNOW HIM", 8, new[] { "AT LEAST", "LEAST" })]
+    public void AutoBreakLine_NoBreakAfterMultiWordEntry_KeepsPhraseTogether(string input, int maxLength, string[] listItems)
+    {
+        var oldDataDirectory = Configuration.DataDirectory;
+        var oldUseNoLineBreakAfter = Configuration.Settings.Tools.UseNoLineBreakAfter;
+        var dictionaryFolder = Path.Combine(Path.GetTempPath(), "se9631_" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(dictionaryFolder, "Dictionaries"));
+            var xml = "<NoBreakAfterList>" + Environment.NewLine +
+                      string.Join(Environment.NewLine, listItems.Select(p => "  <Item>" + p + "</Item>")) +
+                      Environment.NewLine + "</NoBreakAfterList>";
+            File.WriteAllText(Path.Combine(dictionaryFolder, "Dictionaries", "zz_NoBreakAfterList.xml"), xml);
+            Configuration.DataDirectory = dictionaryFolder;
+            Configuration.Settings.Tools.UseNoLineBreakAfter = true;
+            Utilities.ResetNoBreakAfterList();
+
+            var result = Utilities.AutoBreakLinePrivate(input, maxLength, 0, "zz", false);
+
+            var lines = result.SplitToLines();
+            Assert.True(lines.Count == 2, "Expected two lines, got: " + result);
+            foreach (var item in listItems.Where(p => p.IndexOf(' ') >= 0))
+            {
+                Assert.True(lines[0].Contains(item) || lines[1].Contains(item),
+                    "Phrase \"" + item + "\" was split: " + result);
+            }
+        }
+        finally
+        {
+            Configuration.DataDirectory = oldDataDirectory;
+            Configuration.Settings.Tools.UseNoLineBreakAfter = oldUseNoLineBreakAfter;
+            Utilities.ResetNoBreakAfterList();
+            try
+            {
+                Directory.Delete(dictionaryFolder, true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
     // GetColorFromFontString measured colorStart relative to the extracted <font> tag
     // but indexed the full string, so a tag that wasn't at the start of the line read
     // the wrong region and returned the default color.


### PR DESCRIPTION
## Problem

Fixes #9631 — when the "do not break" list contains a multi-word phrase (e.g. `SORT OF`) and also one of its single words (`OF`), the auto line break still splits the phrase right before the single word (`HE WAS SORT` / `OF WEIRD`).

Root cause: `Utilities.CanBreak` (src/libse/Common/Utilities.cs:241) only checks the text *before* the candidate break point against the list (`head.EndsWith(entry)`). A multi-word entry like `SORT OF` therefore only ever matches at the break *after* the complete phrase — the break point *between* the words (`SORT|OF`) is never protected, so the balance-based splitter (TextSplit → `GetBestLengthSplit`) lands on it. Reproduced on current main with the list `[SORT OF, OF]`, and also with `[SORT OF]` or `[AT LEAST]` alone. The identical logic exists in SE4 (4.0.8 tag) — a long-standing flaw. The plain-text importer path (`PlainTextImporter.NextWordInDoNotBreakList`) already looks ahead and is not affected.

## Fix

In `Utilities.CanBreak`, after the existing head check, add a look-ahead: when the text up to the **next** space ends with a literal multi-word list entry (an entry containing a space), the break is also forbidden. This keeps the whole phrase together — including the issue's exact case where both `SORT OF` and `OF` are in the list.

- Single-word entries are completely untouched: an `OF`-only list still forbids the break after `of` exactly as before (verified).
- The change only *adds* prohibitions, never relaxes any: existing multi-word entries in the shipped dictionaries (e.g. `bg`/`mk` `на пр.`) keep their "no break after" behavior and additionally can no longer be split internally.

## Verification

- [x] `dotnet build src/ui/UI.csproj -v q -nologo` — EXIT:0, 0 warnings, 0 errors
- [x] New regression test: `AutoBreakLine_NoBreakAfterMultiWordEntry_KeepsPhraseTogether` (Theory, 3 rows) — **fails on pre-fix code** (3/3 failed with the fix stashed), passes post-fix (3/3)
- [x] Existing tests run: full `tests/libse` suite — 862 passed, 0 failed

## Notes

- Interpretation (per the issue's expected behavior): a multi-word entry means "keep the phrase together" — the line must not be split between the phrase's words. When both `SORT OF` and `OF` are present, the multi-word entry now protects the between-words break point, where the single word alone never applied.
- Known limitation (pre-existing, shared with the importer path): a phrase followed by punctuation (`SORT OF,`) is not protected by the look-ahead, since matching is word-boundary based. Deliberately not addressed to keep the change minimal.
- Deliberate non-change: `PlainTextImporter` already protects between-word breaks via `NextWordInDoNotBreakList` — no change needed there.
- This PR was created with AI assistance (per repo AI contributor guidelines).