### PR TITLE
Fix #10209: keep exact WebVTT cue position settings on save

### DIFF
--- a/src/libse/SubtitleFormats/WebVTT.cs
+++ b/src/libse/SubtitleFormats/WebVTT.cs
@@ -143,41 +143,61 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         internal static string GetPositionInfoFromAssTag(Paragraph p)
         {
             string positionInfo;
+            string currentTag = null;
             if (p.Text.StartsWith("{\\an1", StringComparison.Ordinal))
             {
                 positionInfo = Configuration.Settings.SubtitleSettings.WebVttCueAn1;
+                currentTag = "{\\an1}";
             }
             else if (p.Text.StartsWith("{\\an3", StringComparison.Ordinal))
             {
                 positionInfo = Configuration.Settings.SubtitleSettings.WebVttCueAn3;
+                currentTag = "{\\an3}";
             }
             else if (p.Text.StartsWith("{\\an4", StringComparison.Ordinal))
             {
                 positionInfo = Configuration.Settings.SubtitleSettings.WebVttCueAn4;
+                currentTag = "{\\an4}";
             }
             else if (p.Text.StartsWith("{\\an5", StringComparison.Ordinal))
             {
                 positionInfo = Configuration.Settings.SubtitleSettings.WebVttCueAn5;
+                currentTag = "{\\an5}";
             }
             else if (p.Text.StartsWith("{\\an6", StringComparison.Ordinal))
             {
                 positionInfo = Configuration.Settings.SubtitleSettings.WebVttCueAn6;
+                currentTag = "{\\an6}";
             }
             else if (p.Text.StartsWith("{\\an7", StringComparison.Ordinal))
             {
                 positionInfo = Configuration.Settings.SubtitleSettings.WebVttCueAn7;
+                currentTag = "{\\an7}";
             }
             else if (p.Text.StartsWith("{\\an8", StringComparison.Ordinal))
             {
                 positionInfo = Configuration.Settings.SubtitleSettings.WebVttCueAn8;
+                currentTag = "{\\an8}";
             }
             else if (p.Text.StartsWith("{\\an9", StringComparison.Ordinal))
             {
                 positionInfo = Configuration.Settings.SubtitleSettings.WebVttCueAn9;
+                currentTag = "{\\an9}";
             }
             else
             {
                 positionInfo = Configuration.Settings.SubtitleSettings.WebVttCueAn2;
+            }
+
+            // The raw cue settings captured at load ("line:72.69% align:left position:44.90% size:10.21%")
+            // are exact, while the WebVttCueAnX settings are coarse 3x3-grid defaults. Re-emit the raw
+            // settings when they are still consistent with the current alignment tag (i.e. the user has
+            // not changed the alignment since load), so line%/position% are not lost or grid-locked (#10209).
+            if (!string.IsNullOrEmpty(p.Style) &&
+                !string.IsNullOrEmpty(GetPositionInfoRaw(p.Style)) &&
+                GetPositionInfo(p.Style) == (currentTag ?? string.Empty))
+            {
+                positionInfo = p.Style.Trim();
             }
 
             return (" " + positionInfo).TrimEnd();

--- a/tests/libse/SubtitleFormats/WebVttTest.cs
+++ b/tests/libse/SubtitleFormats/WebVttTest.cs
@@ -275,4 +275,20 @@ public class WebVttTest
         Assert.Equal(4, subtitle.Paragraphs.Count);
         Assert.Equal("One<00:00:02.000><c> two</c>", subtitle.Paragraphs[0].Text);
     }
+
+    // Cue settings with exact line%/position% values must survive a load/save round trip - before
+    // the fix the export re-mapped them to the coarse WebVttCueAnX grid defaults (#10209).
+    [Theory]
+    [InlineData("line:25% position:25%")]
+    [InlineData("line:72.69% align:left position:44.90% size:10.21%")]
+    [InlineData("line:90% position:50%")]
+    public void ToTextKeepsExactCuePositionSettings(string cueSettings)
+    {
+        var vtt = "WEBVTT\n\n00:00:01.000 --> 00:00:02.000 " + cueSettings + "\nHello";
+        var subtitle = LoadWebVttSubtitle(vtt);
+
+        var output = new WebVTT().ToText(subtitle, null);
+
+        Assert.Contains(cueSettings, output);
+    }
 }


### PR DESCRIPTION
## Problem
Fixes #10209 — WebVTT cue settings with exact percentages (`line:25% position:25%`) are lost on save: the export re-maps them to the coarse `WebVttCueAnX` grid defaults (`line:50%` etc.) and drops `position:`/`size:`/`align:` entirely. Reproduced on current main with the issue's exact repro (probe: `line:25% position:25%` → exported as `line:50%`, `position` gone).

## Fix
`src/libse/SubtitleFormats/WebVTT.cs` — `GetPositionInfoFromAssTag` now remembers which `{\anX}` tag was actually present and returns the user's stored cue settings (`p.Style` / `p.Extra`) verbatim when they match that tag's alignment, instead of always overwriting with the coarse grid default. Exact percentages survive the load/save round trip.

## Verification
- [x] `dotnet build src/ui/UI.csproj` — EXIT:0, 0 errors
- [x] New regression test `WebVttTest.ToTextKeepsExactCuePositionSettings` (3 Theory rows: `line:25% position:25%`, `line:72.69% align:left position:44.90% size:10.21%`, `line:90% position:50%`) — fails pre-fix (proven by probe on unmodified main), **3/3 PASS post-fix**
- [x] Manual verification path: open a VTT with `line:25% position:25%` → Source View / save → the cue settings are unchanged.

## Notes
- Deliberate non-change: when no `\an` tag is present or no custom settings are stored, the existing `WebVttCueAnX` defaults still apply.
- This PR was created with AI assistance (per repo AI contributor guidelines).