### PR TITLE
Fix #13202: anchor rendered subtitle bitmap to the font line box

### DIFF
--- a/src/libuilogic/Export/ImageRenderer.cs
+++ b/src/libuilogic/Export/ImageRenderer.cs
@@ -140,7 +140,27 @@ public static class ImageRenderer
         //System.IO.File.WriteAllBytes(@"C:\temp\debug_raw.png", tempBitmap.ToPngArray());
 
         var bitmapNoPadding = tempBitmap.TrimTransparentPixels();
-        var textBitmap = bitmapNoPadding.TrimmedBitmap;
+
+        // The tight glyph-bound trim would make the bitmap height depend on the glyphs
+        // present (ascenders/descenders), so bottom-anchored exports (PGS, VobSub,
+        // BDN-XML) would place subtitles with and without descenders at different
+        // vertical positions (issue #13202). Anchor the bitmap to the font's line box
+        // instead: top = first baseline - ascent, bottom = last baseline + descent,
+        // plus room for outline and shadow. The height then depends only on the line
+        // count, and the baselines land at fixed screen positions for every alignment.
+        // Note: TrimResult.Top/Left are absolute canvas coordinates, while Right/Bottom
+        // are distances from the canvas edges - convert before comparing.
+        var firstBaseline = textStartY;
+        var lastBaseline = textStartY + (lines.Count - 1) * (baseLineHeight + lineSpacing);
+        var lineBoxTop = (int)(firstBaseline - Math.Abs(fontMetrics.Ascent) - Math.Abs(outlineWidth));
+        var lineBoxBottom = (int)(lastBaseline + Math.Abs(fontMetrics.Descent) + Math.Abs(outlineWidth) + Math.Abs(shadowWidth));
+        var tightTop = bitmapNoPadding.Top;
+        var tightBottom = tempBitmap.Height - 1 - bitmapNoPadding.Bottom;
+        var topPad = Math.Max(0, tightTop - lineBoxTop);
+        var bottomPad = Math.Max(0, lineBoxBottom - tightBottom);
+        var textBitmap = topPad > 0 || bottomPad > 0
+            ? bitmapNoPadding.TrimmedBitmap.AddTransparentMargins(0, topPad, 0, bottomPad)
+            : bitmapNoPadding.TrimmedBitmap;
 
         if (ip.BoxType != ExportBoxType.None)
         {

--- a/src/libuilogic/Export/ImageRenderer.cs
+++ b/src/libuilogic/Export/ImageRenderer.cs
@@ -152,9 +152,8 @@ public static class ImageRenderer
         // are distances from the canvas edges - convert before comparing.
         var firstBaseline = textStartY;
         var lastBaseline = textStartY + (lines.Count - 1) * (baseLineHeight + lineSpacing);
-        // Floor/ceiling (not (int) truncation, which rounds toward zero and would wobble the
-        // padding by 0-1 px on negative fractional metrics) so the anchoring is stable
-        // (review follow-up, #13202).
+        // Floor/ceiling, not (int) truncation - truncation rounds toward zero, which
+        // would wobble the padding by 0-1 px depending on the fractional font metrics.
         var lineBoxTop = (int)Math.Floor(firstBaseline - Math.Abs(fontMetrics.Ascent) - Math.Abs(outlineWidth));
         var lineBoxBottom = (int)Math.Ceiling(lastBaseline + Math.Abs(fontMetrics.Descent) + Math.Abs(outlineWidth) + Math.Abs(shadowWidth));
         var tightTop = bitmapNoPadding.Top;

--- a/src/libuilogic/Export/ImageRenderer.cs
+++ b/src/libuilogic/Export/ImageRenderer.cs
@@ -152,8 +152,11 @@ public static class ImageRenderer
         // are distances from the canvas edges - convert before comparing.
         var firstBaseline = textStartY;
         var lastBaseline = textStartY + (lines.Count - 1) * (baseLineHeight + lineSpacing);
-        var lineBoxTop = (int)(firstBaseline - Math.Abs(fontMetrics.Ascent) - Math.Abs(outlineWidth));
-        var lineBoxBottom = (int)(lastBaseline + Math.Abs(fontMetrics.Descent) + Math.Abs(outlineWidth) + Math.Abs(shadowWidth));
+        // Floor/ceiling (not (int) truncation, which rounds toward zero and would wobble the
+        // padding by 0-1 px on negative fractional metrics) so the anchoring is stable
+        // (review follow-up, #13202).
+        var lineBoxTop = (int)Math.Floor(firstBaseline - Math.Abs(fontMetrics.Ascent) - Math.Abs(outlineWidth));
+        var lineBoxBottom = (int)Math.Ceiling(lastBaseline + Math.Abs(fontMetrics.Descent) + Math.Abs(outlineWidth) + Math.Abs(shadowWidth));
         var tightTop = bitmapNoPadding.Top;
         var tightBottom = tempBitmap.Height - 1 - bitmapNoPadding.Bottom;
         var topPad = Math.Max(0, tightTop - lineBoxTop);


### PR DESCRIPTION
## Problem
Fixes #13202 — exporting subtitles to PGS/Blu-ray SUP, BDN-XML or VobSub positions the image bottom-anchored as `y = ScreenHeight − Bitmap.Height − margin`; the bitmap was trimmed to the tight glyph bounding box, so its height depended on the glyph content (descenders etc.). Two subtitles with the same number of lines and the same alignment landed at different vertical positions (measured ~13 px; the issue reports ~21 px).

## Fix
`src/libuilogic/Export/ImageRenderer.cs` — `GenerateBitmap` now anchors the trimmed bitmap to the **font line box** (top = first baseline − ascent, bottom = last baseline + descent, plus outline/shadow room) via `AddTransparentMargins` on the tight trim. The bitmap height now depends only on the line count, so baselines land at fixed screen positions for every alignment.

## Verification
- [x] `dotnet build src/ui/UI.csproj` — EXIT:0, 0 errors
- [x] End-to-end export check (throwaway probe, deleted): BDN-XML + VobSub exports of the issue's two test subtitles (same style, with vs. without descenders) were `Y=905/H=121` vs `Y=918/H=108` pre-fix → **identical `Y=887/H=139` post-fix**
- [x] Manual verification path: export two-line subtitles with and without descenders to BDN-XML/VobSub → identical vertical position.

## Notes
- Deliberate non-change: the box-per-line path and the VobSub/BluRaySup writers are untouched; only the shared bitmap height computation changed, so all bottom-anchored export handlers benefit.
- This PR was created with AI assistance (per repo AI contributor guidelines).