### PR TITLE
Grid paste: overlap-only shifting and insert-in-order re-timing (SE4 parity)

### DIFF
--- a/src/ui/Logic/SubtitleGridCopyPasteHelper.cs
+++ b/src/ui/Logic/SubtitleGridCopyPasteHelper.cs
@@ -101,30 +101,36 @@ internal static class SubtitleGridCopyPasteHelper
     internal static async Task Paste(Window window, ObservableCollection<SubtitleLineViewModel> subtitles, int index, SubtitleFormat subtitleFormat)
     {
         var text = await ClipboardHelper.GetTextAsync(window);
+        Paste(subtitles, index, subtitleFormat, text);
+    }
+
+    internal static void Paste(ObservableCollection<SubtitleLineViewModel> subtitles, int index, SubtitleFormat subtitleFormat, string? text)
+    {
         if (string.IsNullOrEmpty(text))
         {
             return;
         }
 
-        var addTimeMilliseconds = (double)0;
-        if (subtitles.Count > 0 && index >= 0 && index < subtitles.Count)
-        {
-            addTimeMilliseconds = subtitles[index].EndTime.TotalMilliseconds + Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
-            index++;
-        }
-        else if (subtitles.Count > 0)
-        {
-             // If index is invalid (e.g. -1), append to end
-             addTimeMilliseconds = subtitles[subtitles.Count - 1].EndTime.TotalMilliseconds + Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
-             index = subtitles.Count;
-        }
-
-
         var lines = text.SplitToLines();
         var subtitle = Subtitle.Parse(lines, subtitleFormat.Extension);
+
+        var beforeIndex = -1;
+        if (subtitles.Count > 0 && index >= 0 && index < subtitles.Count)
+        {
+            beforeIndex = index;
+            index++;
+        }
+        else
+        {
+            // If index is invalid (e.g. -1), append to end. This also clamps an empty
+            // subtitle's insertion index to zero.
+            beforeIndex = subtitles.Count - 1;
+            index = subtitles.Count;
+        }
+
         if (subtitle?.Paragraphs.Count > 0)
         {
-            LoadParagraphs(subtitles, index, subtitleFormat, subtitle);
+            LoadParagraphs(subtitles, index, subtitleFormat, subtitle, GetOverlapShift(subtitles, beforeIndex, subtitle));
             return;
         }
 
@@ -133,12 +139,15 @@ internal static class SubtitleGridCopyPasteHelper
             if (item.IsMine(lines, string.Empty) && subtitle != null)
             {
                 item.LoadSubtitle(subtitle, lines, string.Empty);
-                LoadParagraphs(subtitles, index, subtitleFormat, subtitle);
+                LoadParagraphs(subtitles, index, subtitleFormat, subtitle, GetOverlapShift(subtitles, beforeIndex, subtitle));
                 return;
             }
         }
 
         // fallback - plain text
+        var addTimeMilliseconds = beforeIndex >= 0
+            ? subtitles[beforeIndex].EndTime.TotalMilliseconds + Se.Settings.General.MinimumBetweenLines.GetMilliseconds()
+            : 0;
         foreach (var line in lines)
         {
             if (!string.IsNullOrWhiteSpace(line))
@@ -156,10 +165,32 @@ internal static class SubtitleGridCopyPasteHelper
         }
     }
 
-    private static void LoadParagraphs(ObservableCollection<SubtitleLineViewModel> subtitles, int index, SubtitleFormat subtitleFormat, Subtitle subtitle)
+    private static double GetOverlapShift(ObservableCollection<SubtitleLineViewModel> subtitles, int beforeIndex, Subtitle subtitle)
+    {
+        if (subtitle.Paragraphs.Count == 0 || beforeIndex < 0 || beforeIndex >= subtitles.Count)
+        {
+            return 0;
+        }
+
+        var lastEnd = subtitles[beforeIndex].EndTime.TotalMilliseconds;
+        var firstPastedStart = subtitle.Paragraphs[0].StartTime.TotalMilliseconds;
+        var startsAfterNextLine = beforeIndex + 1 < subtitles.Count &&
+                                  subtitles[beforeIndex + 1].StartTime.TotalMilliseconds < firstPastedStart;
+        return lastEnd > firstPastedStart || startsAfterNextLine
+            ? lastEnd + Se.Settings.General.MinimumBetweenLines.GetMilliseconds() - firstPastedStart
+            : 0;
+    }
+
+    private static void LoadParagraphs(ObservableCollection<SubtitleLineViewModel> subtitles, int index, SubtitleFormat subtitleFormat, Subtitle subtitle, double addTimeMilliseconds)
     {
         foreach (var p in subtitle.Paragraphs)
         {
+            if (addTimeMilliseconds != 0)
+            {
+                p.StartTime.TotalMilliseconds += addTimeMilliseconds;
+                p.EndTime.TotalMilliseconds += addTimeMilliseconds;
+            }
+
             subtitles.Insert(index, new SubtitleLineViewModel(p, subtitleFormat));
             index++;
         }

--- a/tests/UI/Logic/SubtitleGridCopyPasteHelperTests.cs
+++ b/tests/UI/Logic/SubtitleGridCopyPasteHelperTests.cs
@@ -1,7 +1,10 @@
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
 using System;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Xunit;
 
@@ -115,5 +118,116 @@ public class SubtitleGridCopyPasteHelperTests
         Assert.All(payload.SplitToLines(), l => Assert.True(
             l.TrimStart().StartsWith("Dialogue:", StringComparison.OrdinalIgnoreCase) ||
             l.TrimStart().StartsWith("Comment:", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [Fact]
+    public void PasteTimedNonOverlappingAfterSelectionPreservesTimes()
+    {
+        var subtitles = MakeSubtitlesWithLastEnd(5_000);
+        var clipboardText = MakeSrt((10_000, 12_000, "First"), (13_000, 15_000, "Second"));
+
+        SubtitleGridCopyPasteHelper.Paste(subtitles, 0, new SubRip(), clipboardText);
+
+        Assert.Equal(3, subtitles.Count);
+        Assert.Equal(10_000, subtitles[1].StartTime.TotalMilliseconds);
+        Assert.Equal(12_000, subtitles[1].EndTime.TotalMilliseconds);
+        Assert.Equal(13_000, subtitles[2].StartTime.TotalMilliseconds);
+        Assert.Equal(15_000, subtitles[2].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void PasteTimedOverlappingAfterSelectionShiftsByDelta()
+    {
+        var subtitles = MakeSubtitlesWithLastEnd(5_000);
+        var clipboardText = MakeSrt((4_000, 6_000, "First"), (7_000, 9_000, "Second"));
+        var expectedStart = 5_000 + Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
+
+        SubtitleGridCopyPasteHelper.Paste(subtitles, 0, new SubRip(), clipboardText);
+
+        Assert.Equal(3, subtitles.Count);
+        Assert.Equal(expectedStart, subtitles[1].StartTime.TotalMilliseconds);
+        Assert.Equal(expectedStart + 2_000, subtitles[1].EndTime.TotalMilliseconds);
+        Assert.Equal(expectedStart + 3_000, subtitles[2].StartTime.TotalMilliseconds);
+        Assert.Equal(expectedStart + 5_000, subtitles[2].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void PasteTimedAfterNextLineShiftsBackBetweenTheExistingLines()
+    {
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new()
+            {
+                StartTime = TimeSpan.Zero,
+                EndTime = TimeSpan.FromMilliseconds(5_000),
+                Text = "Before",
+            },
+            new()
+            {
+                StartTime = TimeSpan.FromMilliseconds(8_000),
+                EndTime = TimeSpan.FromMilliseconds(9_000),
+                Text = "After",
+            },
+        };
+        var clipboardText = MakeSrt((10_000, 11_000, "Inserted"));
+        var expectedStart = 5_000 + Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
+
+        SubtitleGridCopyPasteHelper.Paste(subtitles, 0, new SubRip(), clipboardText);
+
+        Assert.Equal(3, subtitles.Count);
+        Assert.Equal("Inserted", subtitles[1].Text);
+        Assert.Equal(expectedStart, subtitles[1].StartTime.TotalMilliseconds);
+        Assert.Equal(expectedStart + 1_000, subtitles[1].EndTime.TotalMilliseconds);
+        Assert.Equal(8_000, subtitles[2].StartTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void PasteTimedWithNoSelectionPreservesTimesWhenAppending()
+    {
+        var subtitles = MakeSubtitlesWithLastEnd(5_000);
+        var clipboardText = MakeSrt((10_000, 12_000, "Appended"));
+
+        SubtitleGridCopyPasteHelper.Paste(subtitles, -1, new SubRip(), clipboardText);
+
+        Assert.Equal(2, subtitles.Count);
+        Assert.Equal(10_000, subtitles[1].StartTime.TotalMilliseconds);
+        Assert.Equal(12_000, subtitles[1].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void PasteTimedIntoEmptySubtitleWithNoSelectionInsertsAtStart()
+    {
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>();
+        var clipboardText = MakeSrt((10_000, 12_000, "Only line"));
+
+        SubtitleGridCopyPasteHelper.Paste(subtitles, -1, new SubRip(), clipboardText);
+
+        var pasted = Assert.Single(subtitles);
+        Assert.Equal(10_000, pasted.StartTime.TotalMilliseconds);
+        Assert.Equal(12_000, pasted.EndTime.TotalMilliseconds);
+    }
+
+    private static ObservableCollection<SubtitleLineViewModel> MakeSubtitlesWithLastEnd(double endMilliseconds)
+    {
+        return
+        [
+            new SubtitleLineViewModel
+            {
+                StartTime = TimeSpan.Zero,
+                EndTime = TimeSpan.FromMilliseconds(endMilliseconds),
+                Text = "Existing",
+            },
+        ];
+    }
+
+    private static string MakeSrt(params (double start, double end, string text)[] entries)
+    {
+        var subtitle = new Subtitle();
+        foreach (var (start, end, text) in entries)
+        {
+            subtitle.Paragraphs.Add(new Paragraph(text, start, end));
+        }
+
+        return new SubRip().ToText(subtitle, string.Empty);
     }
 }


### PR DESCRIPTION
## Problem
On `main`, timed grid pastes keep the clipboard timestamps even when the pasted block overlaps the line before the insertion point. Subtitle Edit 4 instead moved a timed paste only when that overlap existed, while preserving non-overlapping timestamps.

## Fix
`SubtitleGridCopyPasteHelper.Paste` now:
- parses timed clipboard content before choosing an offset;
- uses one overlap-shift calculation for both the direct parse and format-detection paths;
- preserves timestamps when there is no overlap;
- shifts timed lines by the delta needed to clear the preceding line plus `MinimumBetweenLines`; this includes the SE4 insert-between-lines case where the clipboard block starts after the existing next line and must move backward;
- applies the same logic when there is no selection and the paste appends to the end;
- clamps the insertion index to `0` for an empty subtitle instead of calling `Insert(-1, ...)`;
- keeps the existing plain-text behavior of continuing after the preceding line.

A synchronous text overload keeps the timestamp logic directly unit-testable while the window overload remains responsible only for reading the clipboard.

## Verification
- [x] `dotnet test tests/UI/UITests.csproj --filter "FullyQualifiedName~SubtitleGridCopyPasteHelperTests" --no-restore` — 13 passed, 0 failed
- [x] `dotnet test tests/UI/UITests.csproj --no-build --no-restore` — 1479 passed, 1 skipped, 0 failed
- [x] `dotnet build src/ui/UI.csproj --no-restore` — 0 warnings, 0 errors
- [x] GitHub Actions `test` — passed in 2m36s
- [x] Regression coverage: selected/non-overlapping, selected/overlapping, insert-before-next with a negative delta, no-selection append, and empty-subtitle insertion

The first full-suite run had one unrelated headless menu-keyboard flake (`BareAlt_ClosesTheMenu_WhileFocusIsInsideAnOpenDropDown`); the immediate unchanged rerun was fully green as reported above.

## Scope
This is a standalone grid-paste timing parity improvement. It does not claim to fix #12195, and it does not change paste-overwrite/selection semantics. The branch was rebased after #13264 merged, preserving its no-selection routing change.

This PR was created with AI assistance, per the repository's AI contributor guidelines.
