### PR TITLE
Add "Beautify time codes" to Batch convert

### DIFF
--- a/docs/features/batch-convert.md
+++ b/docs/features/batch-convert.md
@@ -27,6 +27,7 @@ You can chain multiple conversion functions:
 - Offset time codes
 - Adjust duration
 - Change speed/frame rate
+- Beautify time codes — align cues to frames and apply the [Beautify time codes](beautify-time-codes.md) profile rules; frame rate and shot changes are read from a video file with the same name as the subtitle file, if one is found
 - Bridge gaps
 - Apply minimum gap
 - Merge lines with same text

--- a/src/seconv/Core/LibSEIntegration.cs
+++ b/src/seconv/Core/LibSEIntegration.cs
@@ -708,7 +708,17 @@ internal static class LibSEIntegration
                 break;
 
             case "beautifytimecodes":
-                // TODO: Beautify time codes
+                {
+                    // No video in headless mode, so no shot changes/exact time codes -
+                    // align cues to frames (honors --fps) and apply the profile's
+                    // gap/duration rules, like the UI's batch convert without a video.
+                    var beautifier = new Nikse.SubtitleEdit.Core.Forms.TimeCodesBeautifier(
+                        subtitle,
+                        Configuration.Settings.General.CurrentFrameRate,
+                        new List<double>(),
+                        new List<double>());
+                    beautifier.Beautify();
+                }
                 break;
 
             case "convertcolorstodialog":

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertConfig.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertConfig.cs
@@ -48,6 +48,7 @@ public class BatchConvertConfig
     public AutoBalanceLinesSettings AutoBalanceLines { get; set; }
     public SortBySettings SortBy { get; set; }
     public AdjustImageColorsSettings AdjustImageColors { get; set; }
+    public BeautifyTimeCodesSettings2 BeautifyTimeCodes { get; set; }
 
     public BatchConvertConfig()
     {
@@ -86,6 +87,7 @@ public class BatchConvertConfig
         AutoBalanceLines = new AutoBalanceLinesSettings();
         SortBy = new SortBySettings();
         AdjustImageColors = new AdjustImageColorsSettings();
+        BeautifyTimeCodes = new BeautifyTimeCodesSettings2();
     }
 
     public bool IsTargetFormatImageBased =>
@@ -369,6 +371,18 @@ public class BatchConvertConfig
         public SortBySettings()
         {
             SortBy = "Number";
+        }
+    }
+
+    // "2" suffix to avoid clashing with libse's BeautifyTimeCodesSettings (the profile store).
+    public class BeautifyTimeCodesSettings2
+    {
+        public bool IsActive { get; set; }
+        public bool SnapToShotChanges { get; set; }
+
+        public BeautifyTimeCodesSettings2()
+        {
+            SnapToShotChanges = true;
         }
     }
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertFunction.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertFunction.cs
@@ -47,6 +47,7 @@ public partial class BatchConvertFunction : ObservableObject
             MakeFunction(BatchConvertFunctionType.ChangeFrameRate, Se.Language.General.ChangeFrameRate, ViewChangeFrameRate.Make(vm), activeFunctions),
             MakeFunction(BatchConvertFunctionType.ChangeSpeed, Se.Language.General.ChangeSpeed, ViewChangeSpeed.Make(vm), activeFunctions),
             MakeFunction(BatchConvertFunctionType.ChangeCasing, Se.Language.General.ChangeCasing, ViewChangeCasing.Make(vm), activeFunctions),
+            MakeFunction(BatchConvertFunctionType.BeautifyTimeCodes, Se.Language.Tools.BeautifyTimeCodes.Title, ViewBeautifyTimeCodes.Make(vm), activeFunctions),
             MakeFunction(BatchConvertFunctionType.BridgeGaps, Se.Language.General.BridgeGaps, ViewBridgeGaps.Make(vm), activeFunctions),
             MakeFunction(BatchConvertFunctionType.ApplyMinGap, Se.Language.Tools.ApplyMinGaps.Title, ViewApplyMinGap.Make(vm), activeFunctions),
             MakeFunction(BatchConvertFunctionType.FixCommonErrors, Se.Language.General.FixCommonErrors, ViewFixCommonErrors.Make(vm), activeFunctions),

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertFunctionType.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertFunctionType.cs
@@ -29,4 +29,5 @@ public enum BatchConvertFunctionType
     AutoBalanceLines,
     SortBy,
     AdjustImageColors,
+    BeautifyTimeCodes,
 }

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -194,6 +194,9 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     [ObservableProperty] private bool _rtlRemoveUniCode;
     [ObservableProperty] private bool _rtlReverseStartEnd;
 
+    // Beautify time codes
+    [ObservableProperty] private bool _beautifyTimeCodesSnapToShotChanges;
+
     // Bride gaps
     [ObservableProperty] private int _bridgeGapsSmallerThanMs;
     [ObservableProperty] private int _bridgeGapsMinGapMs;
@@ -627,6 +630,9 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         Se.Settings.Tools.BatchConvert.SortBy = SelectedSortByOption?.Key ?? "Number";
         Se.Settings.Tools.BatchConvert.SortByDescending = SortByDescending;
 
+        // Beautify time codes
+        Se.Settings.Tools.BatchConvert.BeautifyTimeCodesSnapToShotChanges = BeautifyTimeCodesSnapToShotChanges;
+
         // Adjust image brightness/alpha/color
         Se.Settings.Tools.BatchConvert.ImageAdjustBrightnessOn = ImageAdjustBrightnessOn;
         Se.Settings.Tools.BatchConvert.ImageAdjustBrightness = ImageAdjustBrightness;
@@ -753,6 +759,8 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         BridgeGapsSmallerThanMs = Se.Settings.Tools.BridgeGaps.BridgeGapsSmallerThanMs;
         BridgeGapsMinGapMs = Se.Settings.Tools.BridgeGaps.MinGapMs;
         BridgeGapsPercentForLeft = Se.Settings.Tools.BridgeGaps.PercentForLeft;
+
+        BeautifyTimeCodesSnapToShotChanges = Se.Settings.Tools.BatchConvert.BeautifyTimeCodesSnapToShotChanges;
 
         SplitBreakSingleLineMaxLength = Se.Settings.General.SubtitleLineMaximumLength;
         SplitBreakMaxNumberOfLines = Se.Settings.General.MaxNumberOfLines;
@@ -1269,6 +1277,18 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         {
             FixCommonErrorsProfile = result.SelectedProfile;
         }
+    }
+
+    [RelayCommand]
+    private async Task ShowBeautifyTimeCodesProfile()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        await _windowService.ShowDialogAsync<BeautifyTimeCodes.Profile.BeautifyTimeCodesProfileWindow, BeautifyTimeCodes.Profile.BeautifyTimeCodesProfileViewModel>(Window!,
+            vm => { vm.Initialize(); });
     }
 
     [RelayCommand]
@@ -2203,6 +2223,12 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
                 IsActive = activeFunctions.Contains(BatchConvertFunctionType.SortBy),
                 SortBy = SelectedSortByOption?.Key ?? "Number",
                 Descending = SortByDescending,
+            },
+
+            BeautifyTimeCodes = new BatchConvertConfig.BeautifyTimeCodesSettings2
+            {
+                IsActive = activeFunctions.Contains(BatchConvertFunctionType.BeautifyTimeCodes),
+                SnapToShotChanges = BeautifyTimeCodesSnapToShotChanges,
             },
 
             AdjustImageColors = new BatchConvertConfig.AdjustImageColorsSettings

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -25,6 +25,7 @@ using Nikse.SubtitleEdit.Features.Tools.SplitBreakLongLines;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Dictionaries;
+using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using Nikse.SubtitleEdit.UiLogic.Ocr;
 using SkiaSharp;
@@ -1672,6 +1673,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             s = ChangeSpeed(s);
             s = BridgeGaps(s);
             s = ApplyMinGap(s);
+            s = BeautifyTimeCodes(s, item.FileName);
         }
         else
         {
@@ -1699,6 +1701,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             s = FixRightToLeft(s);
             s = AssaChangeResolution(s);
             s = AssaChangeStyle(s);
+            s = BeautifyTimeCodes(s, item.FileName);
             s = SortBy(s);
         }
 
@@ -2089,6 +2092,44 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             }
         }
 
+        return subtitle;
+    }
+
+    private Subtitle BeautifyTimeCodes(Subtitle subtitle, string subtitleFileName)
+    {
+        if (!_config.BeautifyTimeCodes.IsActive)
+        {
+            return subtitle;
+        }
+
+        // Frame rate and shot changes come from a video file matching the subtitle file
+        // name, when one exists. Shot changes are only available if they were previously
+        // generated/imported for that video (they are cached on disk per video file).
+        var frameRate = Configuration.Settings.General.DefaultFrameRate;
+        var shotChanges = new List<double>();
+
+        if (FindVideoFileName.TryFindVideoFileName(subtitleFileName, out var videoFileName))
+        {
+            try
+            {
+                var mediaInfo = FfmpegMediaInfo2.Parse(videoFileName);
+                if (mediaInfo.FramesRate > 0)
+                {
+                    frameRate = (double)mediaInfo.FramesRate;
+                }
+            }
+            catch
+            {
+                // no ffmpeg or unreadable video file - keep the default frame rate
+            }
+
+            if (_config.BeautifyTimeCodes.SnapToShotChanges)
+            {
+                shotChanges = ShotChangesHelper.FromDisk(videoFileName);
+            }
+        }
+
+        new Core.Forms.TimeCodesBeautifier(subtitle, frameRate, new List<double>(), shotChanges).Beautify();
         return subtitle;
     }
 

--- a/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewBeautifyTimeCodes.cs
+++ b/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewBeautifyTimeCodes.cs
@@ -1,0 +1,46 @@
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Tools.BatchConvert.FunctionViews;
+
+public static class ViewBeautifyTimeCodes
+{
+    public static Control Make(BatchConvertViewModel vm)
+    {
+        var labelHeader = new Label
+        {
+            Content = Se.Language.Tools.BeautifyTimeCodes.Title,
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.Bold,
+        };
+
+        var checkBoxSnapToShotChanges = UiUtil.MakeCheckBox(Se.Language.Tools.BeautifyTimeCodes.BatchSnapToShotChanges, vm, nameof(vm.BeautifyTimeCodesSnapToShotChanges));
+
+        var buttonEditProfile = UiUtil.MakeButton(vm.ShowBeautifyTimeCodesProfileCommand, IconNames.Settings, Se.Language.Tools.BeautifyTimeCodes.EditProfile);
+
+        var labelInfo = new TextBlock
+        {
+            Text = Se.Language.Tools.BeautifyTimeCodes.BatchInfo,
+            Opacity = 0.7,
+            FontStyle = FontStyle.Italic,
+            TextWrapping = TextWrapping.Wrap,
+        };
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Margin = new Avalonia.Thickness(10),
+            Spacing = 10,
+            Children =
+            {
+                labelHeader,
+                checkBoxSnapToShotChanges,
+                buttonEditProfile,
+                labelInfo,
+            }
+        };
+    }
+}

--- a/src/ui/Logic/Config/Language/Tools/LanguageBeautifyTimeCodes.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageBeautifyTimeCodes.cs
@@ -21,6 +21,8 @@ public class LanguageBeautifyTimeCodes
     public string PreviousChange { get; set; }
     public string NextChange { get; set; }
     public string EditProfile { get; set; }
+    public string BatchSnapToShotChanges { get; set; }
+    public string BatchInfo { get; set; }
 
     public LanguageBeautifyTimeCodes()
     {
@@ -43,5 +45,7 @@ public class LanguageBeautifyTimeCodes
         PreviousChange = "Previous change";
         NextChange = "Next change";
         EditProfile = "Edit profile...";
+        BatchSnapToShotChanges = "Snap cues to shot changes (if available)";
+        BatchInfo = "Frame rate and shot changes are read from a video file with the same name as the subtitle file, if one is found.";
     }
 }

--- a/src/ui/Logic/Config/SeBatchConvert.cs
+++ b/src/ui/Logic/Config/SeBatchConvert.cs
@@ -105,6 +105,8 @@ public class SeBatchConvert
     public string SortBy { get; set; }
     public bool SortByDescending { get; set; }
 
+    public bool BeautifyTimeCodesSnapToShotChanges { get; set; }
+
     public bool ImageAdjustBrightnessOn { get; set; }
     public double ImageAdjustBrightness { get; set; }
     public double ImageAdjustContrast { get; set; }
@@ -173,5 +175,7 @@ public class SeBatchConvert
 
         SortBy = "Number";
         SortByDescending = false;
+
+        BeautifyTimeCodesSnapToShotChanges = true;
     }
 }

--- a/tests/UI/Features/Tools/BatchConvert/BatchConverterBeautifyTimeCodesTests.cs
+++ b/tests/UI/Features/Tools/BatchConvert/BatchConverterBeautifyTimeCodesTests.cs
@@ -1,0 +1,104 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Tools.BatchConvert;
+using Nikse.SubtitleEdit.UiLogic.BatchConvert;
+
+namespace UITests.Features.Tools.BatchConvert;
+
+public class BatchConverterBeautifyTimeCodesTests
+{
+    // Issue #13224: "Beautify time codes" as a batch convert function. Without a matching
+    // video file the converter falls back to the default frame rate, so the observable
+    // effect is frame alignment plus the profile's minimum gap between cues.
+
+    private const string InputSrt = @"1
+00:00:01,013 --> 00:00:03,987
+Hello there.
+
+2
+00:00:04,001 --> 00:00:06,499
+Second line.
+
+3
+00:00:06,530 --> 00:00:09,123
+Third line.
+";
+
+    private static async Task<Subtitle> RunConvertAsync(bool beautifyActive)
+    {
+        var dir = Directory.CreateTempSubdirectory("se-beautify-test");
+        try
+        {
+            var inputFile = Path.Combine(dir.FullName, "input.srt");
+            await File.WriteAllTextAsync(inputFile, InputSrt);
+
+            var outputFolder = Path.Combine(dir.FullName, "out");
+            Directory.CreateDirectory(outputFolder);
+
+            var subtitle = Subtitle.Parse(inputFile);
+            var item = new BatchConvertItem(inputFile, new FileInfo(inputFile).Length, new SubRip().Name, subtitle);
+
+            var config = new BatchConvertConfig
+            {
+                SaveInSourceFolder = false,
+                OutputFolder = outputFolder,
+                Overwrite = true,
+                TargetFormatName = SubRip.NameOfFormat,
+            };
+            config.BeautifyTimeCodes.IsActive = beautifyActive;
+
+            var converter = new BatchConverter(null!, null!, null!);
+            converter.Initialize(config);
+            await converter.Convert(item, CancellationToken.None);
+
+            var outputFile = Path.Combine(outputFolder, "input.srt");
+            Assert.True(File.Exists(outputFile), "converted file was not written");
+            return Subtitle.Parse(outputFile);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Convert_BeautifyTimeCodesActive_AlignsCuesToFramesAndEnforcesMinGap()
+    {
+        var result = await RunConvertAsync(beautifyActive: true);
+
+        Assert.Equal(3, result.Paragraphs.Count);
+
+        var frameRate = Configuration.Settings.General.DefaultFrameRate;
+        foreach (var p in result.Paragraphs)
+        {
+            foreach (var ms in new[] { p.StartTime.TotalMilliseconds, p.EndTime.TotalMilliseconds })
+            {
+                var frames = ms * frameRate / 1000.0;
+                Assert.True(Math.Abs(frames - Math.Round(frames)) < 0.1,
+                    $"time code {ms} ms is not aligned to a {frameRate} fps frame");
+            }
+        }
+
+        // Default profile enforces a minimum gap (in frames) between consecutive cues.
+        var minGapMs = Configuration.Settings.BeautifyTimeCodes.Profile.Gap * 1000.0 / frameRate - 0.5;
+        for (var i = 0; i < result.Paragraphs.Count - 1; i++)
+        {
+            var gap = result.Paragraphs[i + 1].StartTime.TotalMilliseconds - result.Paragraphs[i].EndTime.TotalMilliseconds;
+            Assert.True(gap >= minGapMs, $"gap between cue {i + 1} and {i + 2} is {gap} ms, expected at least {minGapMs} ms");
+        }
+    }
+
+    [Fact]
+    public async Task Convert_BeautifyTimeCodesInactive_LeavesTimeCodesUnchanged()
+    {
+        var result = await RunConvertAsync(beautifyActive: false);
+
+        Assert.Equal(3, result.Paragraphs.Count);
+        Assert.Equal(1013, result.Paragraphs[0].StartTime.TotalMilliseconds, 3);
+        Assert.Equal(3987, result.Paragraphs[0].EndTime.TotalMilliseconds, 3);
+        Assert.Equal(4001, result.Paragraphs[1].StartTime.TotalMilliseconds, 3);
+        Assert.Equal(6499, result.Paragraphs[1].EndTime.TotalMilliseconds, 3);
+        Assert.Equal(6530, result.Paragraphs[2].StartTime.TotalMilliseconds, 3);
+        Assert.Equal(9123, result.Paragraphs[2].EndTime.TotalMilliseconds, 3);
+    }
+}


### PR DESCRIPTION
Adds "Beautify time codes" as a batch convert function, as requested in #13224.

## What it does

- New function in the batch convert function list: runs the libse `TimeCodesBeautifier` on each converted file (same engine as Tools → Beautify time codes), aligning cues to frames and applying the shared beautify profile's gap/duration/chaining rules.
- Like SE 4's batch convert, frame rate and previously generated shot changes are picked up from a video file matching the subtitle file name, when one is found; otherwise the default frame rate is used with no shot changes.
- The function panel has a "Snap cues to shot changes (if available)" toggle (persisted in settings, default on) and a settings button that opens the shared beautify profile editor.
- Runs for both text and image-based conversions, after the other timing fixes (matching SE 4's order).
- Bonus: implements the previously stubbed `--beautify-time-codes` operation in seconv (frame alignment honoring `--fps`; no video lookup in headless mode).

## Verification

- Headless end-to-end run through `BatchConverter.Convert`: off-frame cues get frame-aligned at the default frame rate, and the profile's 3-frame minimum gap is enforced.
- With a matching 25 fps video and cached shot changes: frame rate is read from the video (cues align to 40 ms frames) and out/in cues snap exactly to the shot changes.
- `seconv input.srt srt --beautify-time-codes --fps 25` produces frame-aligned output.
- New unit tests (`BatchConverterBeautifyTimeCodesTests`) cover active and inactive paths; full UI suite (1443) and seconv suite (290) pass.

Fixes #13224 (the batch convert part; the issue's separate "fix beautify time codes" remark has no details to act on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)