### PR TITLE
Fix #12195: split line at cursor applies the continuation style (ellipses)

### DIFF
--- a/src/ui/Logic/ISplitManager.cs
+++ b/src/ui/Logic/ISplitManager.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
@@ -124,6 +125,23 @@ public class SplitManager : ISplitManager
             {
                 subtitle.Text = text;
                 newSubtitle.Text = string.Empty;
+            }
+        }
+
+        // SE 4 parity (#12195): "Split line at cursor" applies the configured continuation
+        // style (e.g. "Ellipses (trailing only)") to the halves - a trailing ellipsis on
+        // the first line, and a leading marker on the second for leading styles - instead
+        // of a clean cut.
+        if (!string.IsNullOrWhiteSpace(subtitle.Text)
+            && !string.IsNullOrWhiteSpace(newSubtitle.Text)
+            && Enum.TryParse<ContinuationStyle>(Se.Settings.General.ContinuationStyle, out var continuationStyle)
+            && continuationStyle != ContinuationStyle.None)
+        {
+            var continuationProfile = ContinuationUtilities.GetContinuationProfile(continuationStyle);
+            if (ContinuationUtilities.ShouldAddSuffix(subtitle.Text, continuationProfile))
+            {
+                subtitle.Text = ContinuationUtilities.AddSuffixIfNeeded(subtitle.Text, continuationProfile, false);
+                newSubtitle.Text = ContinuationUtilities.AddPrefixIfNeeded(newSubtitle.Text, continuationProfile, false);
             }
         }
 

--- a/tests/UI/Logic/SplitManagerTests.cs
+++ b/tests/UI/Logic/SplitManagerTests.cs
@@ -72,6 +72,52 @@ public class SplitManagerTests
     }
 
     [Fact]
+    public void Split_WithTextIndex_AppliesConfiguredContinuationStyle()
+    {
+        var originalContinuationStyle = Se.Settings.General.ContinuationStyle;
+        try
+        {
+            Se.Settings.General.MinimumBetweenLines.Milliseconds = 0;
+            Se.Settings.General.ContinuationStyle = nameof(ContinuationStyle.OnlyTrailingEllipsis);
+            var manager = new SplitManager();
+            var subtitle = MakeSubtitle("Hello world foo bar", 1, 3);
+            var subtitles = new ObservableCollection<SubtitleLineViewModel> { subtitle };
+
+            manager.Split(subtitles, subtitle, textIndex: 15, languageCode: "en");
+
+            Assert.Equal("Hello world foo…", subtitles[0].Text);
+            Assert.Equal("bar", subtitles[1].Text);
+        }
+        finally
+        {
+            Se.Settings.General.ContinuationStyle = originalContinuationStyle;
+        }
+    }
+
+    [Fact]
+    public void Split_WithoutSecondHalf_DoesNotAddContinuationMarker()
+    {
+        var originalContinuationStyle = Se.Settings.General.ContinuationStyle;
+        try
+        {
+            Se.Settings.General.MinimumBetweenLines.Milliseconds = 0;
+            Se.Settings.General.ContinuationStyle = nameof(ContinuationStyle.OnlyTrailingEllipsis);
+            var manager = new SplitManager();
+            var subtitle = MakeSubtitle("Hello", 1, 3);
+            var subtitles = new ObservableCollection<SubtitleLineViewModel> { subtitle };
+
+            manager.Split(subtitles, subtitle, textIndex: subtitle.Text.Length, languageCode: "en");
+
+            Assert.Equal("Hello", subtitles[0].Text);
+            Assert.Equal(string.Empty, subtitles[1].Text);
+        }
+        finally
+        {
+            Se.Settings.General.ContinuationStyle = originalContinuationStyle;
+        }
+    }
+
+    [Fact]
     public void Split_WithVideoPosition_UsesVideoPositionAsTimeSplitPoint()
     {
         // Arrange


### PR DESCRIPTION
## Problem
Fixes #12195 (point 1) — "Split line at cursor" does a clean cut in SE 5.1.0, while SE 4 appended the continuation marker per the configured continuation style (the reporter's "Ellipses (right only)" = `OnlyTrailingEllipsis`). The SplitManager never applied the continuation style.

## Fix
`src/ui/Logic/ISplitManager.cs` — after the text split, the configured `ContinuationStyle` is applied to the two halves via the existing `ContinuationUtilities` (same code path SE 4 used): a trailing ellipsis on the first line and a leading marker on the second for leading styles. Markers are applied only when both split halves contain text; `None` and an empty second half leave the clean cut unchanged.

## Verification
- [x] `dotnet build src/ui/UI.csproj` — EXIT:0, 0 errors
- [x] Permanent `Split_WithTextIndex_AppliesConfiguredContinuationStyle` regression test: `ContinuationStyle=OnlyTrailingEllipsis`, split "Hello world foo bar" at cursor → first half `Hello world foo…` (U+2026), second `bar`; proven RED on the parent commit and GREEN on this fix
- [x] Empty-second-half regression: RED before the guard (`Hello…`), GREEN after it (`Hello` + empty second half)
- [x] `SplitManagerTests`: 30/30 passed
- [x] Full local UI suite: 1453 passed, 1 skipped, 0 failed
- [x] Manual verification path: right-click → Split line at cursor with continuation style "Ellipsis (trailing only)" → first line ends with an ellipsis; with "None" → clean cut as before.

## Notes
- Deliberate non-change: the issue's point 2 (grid paste overwriting selected lines) is a separate behavior — not touched here.
- This PR was created with AI assistance (per repo AI contributor guidelines).