### PR TITLE
Respect container default audio track on video open

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -19032,24 +19032,18 @@ public partial class MainViewModel :
                     ? tracks.FirstOrDefault(t => t.Id == desiredAudioTrackId)
                     : null;
 
-                // On a fresh open (no explicitly requested/restored track) with more than one audio
-                // track, default to the track that is fastest to extract a waveform from - e.g. a
-                // compressed AC3/AAC track over lossless TrueHD - so the waveform appears in seconds
-                // instead of minutes. A track requested via desiredAudioTrackId (e.g. restored from
-                // recent files) always wins.
-                if (chosen == null && desiredAudioTrackId < 0 && tracks.Count > 1)
-                {
-                    chosen = tracks
-                        .OrderByDescending(t => WaveformExtractionEstimate.GetDecodeSpeedFactor(t.Codec))
-                        .ThenBy(t => t.Id)
-                        .First();
-                }
+                // On a fresh open (no explicitly requested/restored track), follow mpv's own
+                // selection, which honors the container's default-track flag - picking any other
+                // track (e.g. the fastest to decode) can land on a commentary or audio-description
+                // track (#13233). The waveform audio-track picker still shows per-track extraction
+                // estimates for users who want a faster track.
+                chosen ??= tracks.FirstOrDefault(t => t.IsSelected)
+                    ?? tracks.FirstOrDefault(t => t.IsDefault)
+                    ?? tracks[0];
 
-                chosen ??= tracks.FirstOrDefault(t => t.IsSelected) ?? tracks[0];
-
-                // Switch mpv to the chosen track when it isn't already the selected one (fastest
-                // default or a restored track) so playback, the track menu and the waveform picker
-                // all agree on the same track.
+                // Switch mpv to the chosen track when it isn't already the selected one (e.g. a
+                // track restored from recent files) so playback, the track menu and the waveform
+                // picker all agree on the same track.
                 if (chosen.Id != -1 && !chosen.IsSelected)
                 {
                     mpv.SetAudioTrack(chosen.Id);

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/AudioTrackInfo.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/AudioTrackInfo.cs
@@ -8,6 +8,9 @@ public class AudioTrackInfo
     public string? Language { get; set; }
     public string? Title { get; set; }
     public bool IsSelected { get; set; }
+
+    /// <summary>True when the container marks this track as the default track.</summary>
+    public bool IsDefault { get; set; }
     public int? FfIndex { get; set; }
 
     /// <summary>Codec name as reported by mpv (e.g. "truehd", "ac3", "aac"), or null if unknown.</summary>

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -1665,6 +1665,13 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
                 trackInfo.IsSelected = err >= 0 && selectedValue == 1;
 
+                // Get track default flag
+                double defaultValue = 0;
+                var defaultBytes = GetUtf8Bytes($"track-list/{i}/default");
+                err = _mpvGetPropertyDouble(_mpv, defaultBytes, MPV_FORMAT_FLAG, ref defaultValue);
+
+                trackInfo.IsDefault = err >= 0 && defaultValue == 1;
+
                 audioTracks.Add(trackInfo);
             }
 


### PR DESCRIPTION
Fixes #13233

On a fresh video open with multiple audio tracks, the fastest-to-decode codec heuristic (added in b001f282c for quicker waveform extraction) could select a commentary or audio-description track over the main mix, because those tracks are typically compressed AC3/AAC while the main mix is DTS/TrueHD. In the reported file, the "Commentary by …" track was auto-selected over the two DTS main tracks.

Changes:
- `VideoOpenFile` no longer overrides the track selection with the fastest-decoding codec; on a fresh open it follows mpv's own selection, which honors the container's default-track flag (fallback: default-flagged track, then first track). A track restored from recent files still wins, as before.
- `AudioTrackInfo` gains an `IsDefault` property, read from mpv's `track-list/N/default`, used as the fallback when no track is reported as selected.

The waveform audio-track picker still shows per-track extraction time estimates, so choosing a faster track for waveform generation remains a one-click, now-deliberate action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)