### PR TITLE
Fix flaky UI tests: serialize Avalonia headless test classes

### DIFF
--- a/tests/UI/AssemblyInfo.cs
+++ b/tests/UI/AssemblyInfo.cs
@@ -1,0 +1,12 @@
+using Xunit;
+
+// The Avalonia headless UI tests share static application state and the global
+// Se.Settings instance. xUnit runs test classes in parallel by default, so two classes
+// can run at the same time while one mutates a setting the other one is reading
+// (e.g. SubtitleLineMaximumLength, MinimumBetweenLines), and timing-sensitive
+// keyboard/input tests starve on slow 2-core CI runners. That produced random CI
+// failures - a different victim test on every run, all green in isolation and green on
+// re-run. Running the UI test classes one at a time removes the concurrency that both
+// failure modes depend on. Measured locally: no runtime cost (full suite ~28 s either
+// way). Pure-logic test assemblies (LibSE tests) are unaffected and stay parallel.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
## Problem
The UI test suite (`Tests / test` workflow) fails randomly: **a different test on every run**, 1–5 failures per run, all green in isolation and green on re-run of the same binary. Victims so far: `SyntaxTextEditorTests` (4 different tests), `MainMenuKeyboardActivationTests`, `TextBoxTagTogglerTests`, `SyntaxHighlightingTextPresenterCanaryTests`, `SplitManagerTests` (5 in one run), `HistoryButton_MouseClick_OpensFlyoutWithItems`.

Root cause — two failure modes, both depend on xUnit's default **parallel test-class execution**:
1. **Shared static state**: the headless UI tests share the global `Se.Settings` instance; many test classes mutate it (e.g. `SubtitleLineMaximumLength`, `MinimumBetweenLines`) without restoring. A class running in parallel with another can change a setting the other is reading → wrong behavior → assertion failure. Proven: in one audit run, a probe test leaked settings and 5 `SplitManagerTests` failed; those tests pass 28/28 in isolation.
2. **CPU contention on timing-sensitive tests**: keyboard/input-simulation tests (SyntaxTextEditor, menu-keyboard activation) assert timing-sensitive behavior and starve on the 2-core CI runner while other classes run concurrently.

## Fix
`tests/UI/AssemblyInfo.cs` — `[assembly: CollectionBehavior(DisableTestParallelization = true)]` for the UI test assembly. Test classes now run one at a time, which removes the concurrency both failure modes depend on. Pure-logic assemblies (libse tests) are untouched and stay parallel.

Measured locally on this machine: **no runtime cost** — full suite 27–32 s both ways (1442/1442, 3 consecutive green runs with the fix; the suite is CPU-bound, not throughput-bound).

## Verification
- [x] `dotnet build src/ui/UI.csproj` — EXIT:0, 0 errors
- [x] `dotnet test tests/UI/UITests.csproj` with the fix: **3 consecutive runs, 1442/1442 green each** (27–32 s)
- [x] Control: suite green on the same machine without the fix (flakes reproduced in CI on 4 PRs today — evidence in comments on #13251/#13262/#13264/#13266)
- [x] SplitManagerTests 28/28 in isolation (the flake-victim class from the audit incident)

## Notes
- This PR was created with AI assistance (per repo AI contributor guidelines).