### PR TITLE
Clean up TODOs: 6 obsolete, 3 bugs, 11 small fixes

### DIFF
--- a/src/libse/Cea708/Cea708.cs
+++ b/src/libse/Cea708/Cea708.cs
@@ -570,16 +570,6 @@ namespace Nikse.SubtitleEdit.Core.Cea708
                     {
                         debugBuilder.Append($"{{SetText CL Group C0:Text={text.Content}}}");
                     }
-
-                    //TODO: ???
-                    //if (b >= 0x10 && b <= 0x17)
-                    //{
-                    //    i++;
-                    //}
-                    //else if (b >= 0x18 && b <= 0x1F)
-                    //{
-                    //    i+=2;
-                    //}
                 }
                 else if (b >= 0x20 && b <= 0x7F)
                 {

--- a/src/libse/ContainerFormats/TransportStream/TeletextHamming.cs
+++ b/src/libse/ContainerFormats/TransportStream/TeletextHamming.cs
@@ -68,12 +68,8 @@
             var r = Unham84[a];
             if (r == 0xff)
             {
+                // Unrecoverable data error - fall back to zero.
                 r = 0;
-                //TODO: Cast exception???
-                //if (config.Verbose)
-                //{
-                //    Console.WriteLine($"! Unrecoverable data error; UNHAM8/4({a:X2})");
-                //}
             }
             return (byte)(r & 0x0f);
         }

--- a/src/libse/SubtitleFormats/Ebu.cs
+++ b/src/libse/SubtitleFormats/Ebu.cs
@@ -518,48 +518,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     }
                 }
 
-                // convert text to bytes
-                var bytes = encoding.GetBytes(TextField);
-
-                // some fixes for bytes
-                if (bytes.Length == TextField.Length)
-                {
-                    for (var i = 0; i < bytes.Length; i++)
-                    {
-                        if (TextField[i] == '#')
-                        {
-                            bytes[i] = 0x23;
-                        }
-                        else if (TextField[i] == 'Đ')
-                        {
-                            bytes[i] = 0xe2;
-                        }
-                        else if (TextField[i] == '–') // em dash
-                        {
-                            bytes[i] = 0xd0;
-                        }
-                    }
-                }
-
-                // compare bytes with byte only implementation
-                if (bytes.Length == textBytes.Count)
-                {
-                    for (var idx = 0; idx < textBytes.Count; idx++)
-                    {
-                        if (bytes[idx] != textBytes[idx])
-                        {
-                            SeLogger.Error("EBU STL ENCODING DIFF: " + TextField);
-                            break;
-                        }
-                    }
-                }
-                else
-                {
-                    SeLogger.Error("EBU STL ENCODING DIFF LENGTH: " + TextField);
-                }
-
-                bytes = textBytes.ToArray(); //TODO: we use new byte list - remove old code
-
+                var bytes = textBytes.ToArray();
 
                 for (var i = 0; i < 112; i++)
                 {

--- a/src/libse/SubtitleFormats/Idx.cs
+++ b/src/libse/SubtitleFormats/Idx.cs
@@ -7,7 +7,6 @@ using System.Text.RegularExpressions;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
-    // TODO: Working on added edit capabilities for idx files...
     public class Idx : SubtitleFormat
     {
         // timestamp: 00:00:01:401, filepos: 000000000

--- a/src/ui/Features/Files/ExportCustomTextFormat/ExportCustomTextFormatViewModel.cs
+++ b/src/ui/Features/Files/ExportCustomTextFormat/ExportCustomTextFormatViewModel.cs
@@ -12,6 +12,7 @@ using Nikse.SubtitleEdit.UiLogic.Export;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Files.ExportCustomTextFormat;
@@ -47,6 +48,8 @@ public partial class ExportCustomTextFormatViewModel : ObservableObject
         _title = string.Empty;
         CustomFormats = new ObservableCollection<CustomFormatItem>();
         Encodings = new ObservableCollection<TextEncoding>(EncodingHelper.GetEncodings());
+        SelectedEncoding = Encodings.FirstOrDefault(p => p.DisplayName == Se.Settings.General.DefaultEncoding) ??
+                           Encodings[0];
         PreviewText = string.Empty;
         _subtitles = new List<SubtitleLineViewModel>();
     }
@@ -150,7 +153,7 @@ public partial class ExportCustomTextFormatViewModel : ObservableObject
             return;
         }
 
-        System.IO.File.WriteAllText(fileName, PreviewText); // TODO: use default encoding
+        await System.IO.File.WriteAllTextAsync(fileName, PreviewText, SelectedEncoding?.Encoding ?? Encoding.UTF8);
     }
 
     [RelayCommand]

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7866,6 +7866,10 @@ public partial class MainViewModel :
             return;
         }
 
+        var maxStartDistance = Se.Settings.Waveform.SnapToShotChangeStartMaxSeconds;
+        var maxEndDistance = Se.Settings.Waveform.SnapToShotChangeEndMaxSeconds;
+        var maxSameShotEndDistance = Se.Settings.Waveform.SnapToShotChangeSameShotEndMaxSeconds;
+
         foreach (var line in selectedLines)
         {
             var idx = Subtitles.IndexOf(line);
@@ -7874,11 +7878,11 @@ public partial class MainViewModel :
 
             var nearestStartShotChange = AudioVisualizer.ShotChanges
                 .OrderBy(s => Math.Abs(s - line.StartTime.TotalSeconds))
-                .FirstOrDefault(s => Math.Abs(s - line.StartTime.TotalSeconds) < 1.0); //TODO: customizable
+                .FirstOrDefault(s => Math.Abs(s - line.StartTime.TotalSeconds) < maxStartDistance);
 
             var nearestEndShotChange = AudioVisualizer.ShotChanges
                 .OrderBy(s => Math.Abs(s - line.EndTime.TotalSeconds))
-                .FirstOrDefault(s => Math.Abs(s - line.EndTime.TotalSeconds) < 1.5); //TODO: customizable
+                .FirstOrDefault(s => Math.Abs(s - line.EndTime.TotalSeconds) < maxEndDistance);
 
             if (nearestStartShotChange == 0 && nearestEndShotChange == 0)
             {
@@ -7913,7 +7917,7 @@ public partial class MainViewModel :
             {
                 nearestEndShotChange = AudioVisualizer.ShotChanges
                     .OrderBy(s => Math.Abs(s - line.EndTime.TotalSeconds))
-                    .FirstOrDefault(s => Math.Abs(s - line.EndTime.TotalSeconds) < 0.5); //TODO: customizable
+                    .FirstOrDefault(s => Math.Abs(s - line.EndTime.TotalSeconds) < maxSameShotEndDistance);
 
                 if (nearestEndShotChange > 0 && nearestEndShotChange > line.StartTime.TotalSeconds)
                 {

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrSettingsViewModel.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrSettingsViewModel.cs
@@ -60,7 +60,9 @@ public partial class BinaryOcrSettingsViewModel : ObservableObject
     private async Task Delete()
     {
         var name = Path.GetFileNameWithoutExtension(BinaryOcrDatabaseName);
-        var totalItemsCount = 1; // TODO: fix to get actual count from database
+        var totalItemsCount = _binaryOcrDb == null
+            ? 0
+            : _binaryOcrDb.CompareImages.Count + _binaryOcrDb.CompareImagesExpanded.Count;
         var answer = await MessageBox.Show(
            Window!,
            "Delete Binary Image Compare database?",

--- a/src/ui/Features/Shared/BinaryEdit/BinaryApplyDurationLimits/BinaryApplyDurationLimitsWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryApplyDurationLimits/BinaryApplyDurationLimitsWindow.cs
@@ -41,7 +41,7 @@ public class BinaryApplyDurationLimitsWindow : Window
         // Minimum duration
         var minimumLabel = new Label
         {
-            Content = "Minimum duration (milliseconds):", // TODO: Add to language resources
+            Content = Se.Language.Tools.ApplyDurationLimits.MinimumDurationMilliseconds,
             VerticalAlignment = VerticalAlignment.Center,
         };
         grid.Add(minimumLabel, 0, 0);
@@ -63,7 +63,7 @@ public class BinaryApplyDurationLimitsWindow : Window
         // Maximum duration
         var maximumLabel = new Label
         {
-            Content = "Maximum duration (milliseconds):", // TODO: Add to language resources
+            Content = Se.Language.Tools.ApplyDurationLimits.MaximumDurationMilliseconds,
             VerticalAlignment = VerticalAlignment.Center,
         };
         grid.Add(maximumLabel, 0, 1);

--- a/src/ui/Features/Shared/DownloadLibMpvViewModel.cs
+++ b/src/ui/Features/Shared/DownloadLibMpvViewModel.cs
@@ -85,7 +85,7 @@ public partial class DownloadLibMpvViewModel : ObservableObject, IClosingCleanup
                 {
                     try
                     {
-                        File.Delete(fileName); //TODO: might be in use... save to temp file instead
+                        File.Delete(fileName);
                     }
                     catch
                     {

--- a/src/ui/Features/Shared/GetAudioClips/GetAudioClipsViewModel.cs
+++ b/src/ui/Features/Shared/GetAudioClips/GetAudioClipsViewModel.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.UiLogic.Media;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -27,6 +28,7 @@ public partial class GetAudioClipsViewModel : ObservableObject
 
     private string _videoFileName;
     private int _audioTrackFfIndex;
+    private bool _useCenterChannelOnly;
     private readonly CancellationTokenSource _cancellationTokenSource;
     private List<SubtitleLineViewModel> _lines;
 
@@ -51,6 +53,10 @@ public partial class GetAudioClipsViewModel : ObservableObject
 
     private void ExtractLines()
     {
+        // Probed once per run - FfmpegMediaInfo.Parse spawns ffmpeg, so it must not run per line.
+        _useCenterChannelOnly = Se.Settings.General.FfmpegUseCenterChannelOnly &&
+                                FfmpegMediaInfo.Parse(_videoFileName).HasFrontCenterAudio(_audioTrackFfIndex);
+
         var count = 0;
         foreach (var line in _lines)
         {
@@ -107,13 +113,11 @@ public partial class GetAudioClipsViewModel : ObservableObject
 
     private Process GetExtractProcess(string videoFileName, SubtitleLineViewModel line, string outputFileName)
     {
-        var useCenterChannelOnly = false; //TODO: Se.Settings.Waveform.cen;
-
         var arguments = FfmpegGenerator.ExtractAudioClipFromVideoParameters(
             videoFileName,
             line.StartTime.TotalSeconds,
             line.Duration.TotalSeconds,
-            useCenterChannelOnly,
+            _useCenterChannelOnly,
             outputFileName,
             _audioTrackFfIndex);
 

--- a/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsViewModel.cs
+++ b/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsViewModel.cs
@@ -7,6 +7,7 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic.Config;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Threading;
 using Nikse.SubtitleEdit.Core.Common;
@@ -122,55 +123,43 @@ public partial class ApplyDurationLimitsViewModel : ObservableObject, IClosingCl
 
                 var next = _allSubtitles.GetOrNull(index + 1);
 
-                if (next == null)
+                if (item.Duration.TotalMilliseconds > maxMs && FixMaxDurationMs)
                 {
-                    if (item.Duration.TotalMilliseconds > maxMs && FixMaxDurationMs)
-                    {
-                        var newEndTime = TimeSpan.FromMilliseconds(item.StartTime.TotalMilliseconds + maxMs);
-                        Update(item, newEndTime);
-                        fixCount++;
-                    }
-
-                    if (item.Duration.TotalMilliseconds < minMs && FixMinDurationMs)
-                    {
-                        var newEndTime = TimeSpan.FromMilliseconds(item.StartTime.TotalMilliseconds + minMs);
-                        Update(item, newEndTime);
-                        fixCount++;
-                    }
+                    // Shortening never runs into the next line or a shot change.
+                    var newEndTime = TimeSpan.FromMilliseconds(item.StartTime.TotalMilliseconds + maxMs);
+                    Update(item, newEndTime);
+                    fixCount++;
                 }
-                else
+
+                if (item.Duration.TotalMilliseconds < minMs && FixMinDurationMs)
                 {
-                    if (item.Duration.TotalMilliseconds > maxMs && FixMaxDurationMs)
+                    var wantedEndTime = TimeSpan.FromMilliseconds(item.StartTime.TotalMilliseconds + minMs);
+                    var allowedEndTime = wantedEndTime;
+
+                    // Never overlap the next line.
+                    if (next != null && wantedEndTime > next.StartTime)
                     {
-                        var newEndTime = TimeSpan.FromMilliseconds(item.StartTime.TotalMilliseconds + maxMs);
-                        Update(item, newEndTime);
-                        fixCount++;
+                        allowedEndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
                     }
 
-                    if (item.Duration.TotalMilliseconds < minMs && FixMinDurationMs)
+                    allowedEndTime = CapAtShotChange(item, allowedEndTime);
+
+                    if (allowedEndTime >= wantedEndTime)
                     {
-                        var newEndTime = TimeSpan.FromMilliseconds(item.StartTime.TotalMilliseconds + minMs);
-                        if (newEndTime > next.StartTime)
-                        {
-                            var cappedEndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
-                            if (cappedEndTime > item.EndTime)
-                            {
-                                // improved, but not fixed
-                                Update(item, cappedEndTime,  Se.Language.Tools.ApplyDurationLimits.OnlyPartialFixed);
-                                improveCount++;
-                            }
-                            else
-                            {
-                                // unfixable
-                                Subtitles.Add(item);
-                                skipCount++;
-                            }
-                        }
-                        else
-                        {
-                            Update(item, newEndTime);
-                            fixCount++;
-                        }
+                        Update(item, wantedEndTime);
+                        fixCount++;
+                    }
+                    else if (allowedEndTime > item.EndTime)
+                    {
+                        // improved, but not fixed
+                        Update(item, allowedEndTime, Se.Language.Tools.ApplyDurationLimits.OnlyPartialFixed);
+                        improveCount++;
+                    }
+                    else
+                    {
+                        // unfixable
+                        Subtitles.Add(item);
+                        skipCount++;
                     }
                 }
             }
@@ -194,6 +183,43 @@ public partial class ApplyDurationLimitsViewModel : ObservableObject, IClosingCl
 
             FixesSkippedInfo = skipCount > 0 ? string.Format(Se.Language.Tools.ApplyDurationLimits.UnfixableX, skipCount) : string.Empty;
         });
+    }
+
+    /// <summary>
+    /// Caps an extended end time at the first shot change that falls inside the extension, so a line
+    /// is never stretched across a cut. Returns <paramref name="newEndTime"/> unchanged when the
+    /// option is off, when there are no shot changes, or when nothing is in the way.
+    /// </summary>
+    private TimeSpan CapAtShotChange(SubtitleLineViewModel item, TimeSpan newEndTime)
+    {
+        if (!DoNotGoPastShotChange || _shotChanges.Count == 0)
+        {
+            return newEndTime;
+        }
+
+        var currentEndMs = item.EndTime.TotalMilliseconds;
+        var newEndMs = newEndTime.TotalMilliseconds;
+        if (newEndMs <= currentEndMs)
+        {
+            return newEndTime;
+        }
+
+        // _shotChanges is sorted in Initialize, so the first hit is the earliest one.
+        foreach (var shotChangeSeconds in _shotChanges)
+        {
+            var shotChangeMs = shotChangeSeconds * 1000.0;
+            if (shotChangeMs >= newEndMs)
+            {
+                break;
+            }
+
+            if (shotChangeMs > currentEndMs)
+            {
+                return TimeSpan.FromMilliseconds(shotChangeMs);
+            }
+        }
+
+        return newEndTime;
     }
 
     private void Update(SubtitleLineViewModel item, TimeSpan newEndTime, string? comment = null)
@@ -273,9 +299,8 @@ public partial class ApplyDurationLimitsViewModel : ObservableObject, IClosingCl
     public void Initialize(List<SubtitleLineViewModel> toList, List<double> shotChanges)
     {
         _allSubtitles = toList;
-        _shotChanges =  shotChanges;
-        IsDoNotGoPastShotChangeVisible = shotChanges.Count > 0;
-        IsDoNotGoPastShotChangeVisible = false; //TODO: not implemented
+        _shotChanges = shotChanges.OrderBy(p => p).ToList();
+        IsDoNotGoPastShotChangeVisible = _shotChanges.Count > 0;
         _previewTimer.Start();
         _isDirty = true;
     }

--- a/src/ui/Features/Translate/TranslateSettingsViewModel.cs
+++ b/src/ui/Features/Translate/TranslateSettingsViewModel.cs
@@ -20,7 +20,7 @@ public partial class TranslateSettingsViewModel : ObservableObject
     [ObservableProperty] private string _selectedMergeOptions;
 
     [ObservableProperty] private decimal? _serverDelaySeconds;
-    [ObservableProperty] private decimal? _maxBytesRequest;
+    [ObservableProperty] private int? _maxBytesRequest;
 
     [ObservableProperty] private string _promptText;
     [ObservableProperty] private bool _promptIsVisible;
@@ -196,7 +196,7 @@ public partial class TranslateSettingsViewModel : ObservableObject
             : MergeOptions[0];
 
         ServerDelaySeconds = Se.Settings.AutoTranslate.RequestDelaySeconds;
-        MaxBytesRequest = Se.Settings.AutoTranslate.RequestMaxBytes;
+        MaxBytesRequest = (int)Se.Settings.AutoTranslate.RequestMaxBytes;
         PromptText = string.Empty;
         PromptIsVisible = true;
 

--- a/src/ui/Features/Translate/TranslateSettingsWindow.cs
+++ b/src/ui/Features/Translate/TranslateSettingsWindow.cs
@@ -54,23 +54,9 @@ public class TranslateSettingsWindow : Window
         });
 
         var labelMaxBytes = UiUtil.MakeTextBlock(Se.Language.Translate.MaxBytesPerRequest);
-        var maxBytesNumericUpDown = new NumericUpDown //TODO: UiUtil.MakeNumericUpDown
-        {
-            Minimum = 0,
-            Maximum = 100_000,
-            Value = 1000,
-            Width = 150,
-            VerticalAlignment = VerticalAlignment.Center,
-            HorizontalAlignment = HorizontalAlignment.Left,
-            Increment = 100,
-            FormatString = "#,###,##0",
-        };
-        maxBytesNumericUpDown.Bind(NumericUpDown.ValueProperty, new Binding
-        {
-            Path = nameof(vm.MaxBytesRequest),
-            Mode = BindingMode.TwoWay,
-            Source = vm,
-        });
+        var maxBytesNumericUpDown = UiUtil.MakeNumericUpDownInt(0, 100_000, 1000, 150, vm, nameof(vm.MaxBytesRequest));
+        maxBytesNumericUpDown.Increment = 100;
+        maxBytesNumericUpDown.FormatString = "#,###,##0";
 
         var labelPrompt = UiUtil.MakeTextBlock(Se.Language.Translate.PromptText, vm, null, nameof(vm.PromptIsVisible));
         var promptTextBox = new TextBox

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewRow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewRow.cs
@@ -1,4 +1,3 @@
-using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Nikse.SubtitleEdit.Features.Main;
 using System.Collections.Generic;
@@ -12,7 +11,6 @@ public partial class ReviewRow : ObservableObject
     [ObservableProperty] private string _voice;
     [ObservableProperty] private string _cps;
     [ObservableProperty] private string _speed;
-    [ObservableProperty] private Color _speedBackgroundColor;
     [ObservableProperty] private string _text;
     [ObservableProperty] private bool _hasHistory;
     [ObservableProperty] private bool _isPlaying;
@@ -39,7 +37,6 @@ public partial class ReviewRow : ObservableObject
         Voice = string.Empty;
         Cps = string.Empty;
         Speed = string.Empty;
-        SpeedBackgroundColor = Colors.AliceBlue; //TODO: (Color)Application.Current!.Resources[ThemeNames.BackgroundColor];
         Text = string.Empty;
         StepResult = new TtsStepResult();
         HistoryItems = new List<ReviewHistoryRow>();

--- a/src/ui/Logic/Config/Language/Tools/LanguageApplyDurationLimits.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageApplyDurationLimits.cs
@@ -8,6 +8,8 @@ public class LanguageApplyDurationLimits
     public string FixMinDurationMs { get; set; }
     public string DoNotGoPastShotChange { get; set; }
     public string FixMaxDurationMs { get; set; }
+    public string MinimumDurationMilliseconds { get; set; }
+    public string MaximumDurationMilliseconds { get; set; }
     public string MaxDurationShouldBeHigherThanMinDuration { get; set; }
     public string ChangedDurationFromXToYCommentZ { get; set; }
     public string OnlyPartialFixed { get; set; }
@@ -22,6 +24,8 @@ public class LanguageApplyDurationLimits
         FixMinDurationMs = "Fix minimum duration (ms)";
         DoNotGoPastShotChange = "Do not go past shot change";
         FixMaxDurationMs = "Fix maximum duration (ms)";
+        MinimumDurationMilliseconds = "Minimum duration (milliseconds):";
+        MaximumDurationMilliseconds = "Maximum duration (milliseconds):";
         MaxDurationShouldBeHigherThanMinDuration = "Maximum duration should be higher than minimum duration";
         ChangedDurationFromXToYCommentZ =  "Changed duration from {0} to {1} {2}";
         OnlyPartialFixed = "(only partial fix)";

--- a/src/ui/Logic/Config/SeAudioToText.cs
+++ b/src/ui/Logic/Config/SeAudioToText.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia.Media;
+using WhisperChoices = Nikse.SubtitleEdit.UiLogic.AudioToText.WhisperChoice;
 
 namespace Nikse.SubtitleEdit.Logic.Config;
 
@@ -6,7 +7,9 @@ public class SeAudioToText
 {
     public bool PostProcessing { get; set; } = true;
 
-    public string WhisperChoice { get; set; } = "WhisperCPP"; //TODO: WhisperEngineCpp.StaticName;
+    // Must be one of the WhisperChoice constants - the engine lookup in SpeechToTextViewModel
+    // matches on ISpeechToTextEngine.Choice/Name, so an unknown value selects no engine at all.
+    public string WhisperChoice { get; set; } = WhisperChoices.Cpp;
 
     public bool WhisperIgnoreVersion { get; set; } = false;
 

--- a/src/ui/Logic/Config/SeWaveform.cs
+++ b/src/ui/Logic/Config/SeWaveform.cs
@@ -54,6 +54,14 @@ public class SeWaveform
     public bool SnapToFrames { get; set; }
     public bool ShotChangesAutoGenerate { get; set; }
     public int SnapToShotChangesPixels { get; set; }
+
+    // Search radius (in seconds) used by "Snap selected lines to nearest shot change". A shot change
+    // further away than this from the cue is left alone. The end cue gets a wider radius than the
+    // start cue; when both cues resolve to the same shot change the end cue is retried with the
+    // narrower "same shot" radius.
+    public double SnapToShotChangeStartMaxSeconds { get; set; }
+    public double SnapToShotChangeEndMaxSeconds { get; set; }
+    public double SnapToShotChangeSameShotEndMaxSeconds { get; set; }
     public bool FocusOnMouseOver { get; set; }
     public bool GuessTimeCodeStartFromBeginning { get; set; }
     public int GuessTimeCodeScanBlockSize { get; set; }
@@ -122,6 +130,9 @@ public class SeWaveform
         SnapToShotChanges = true;
         SnapToFrames = false;
         ShotChangesAutoGenerate = false;
+        SnapToShotChangeStartMaxSeconds = 1.0;
+        SnapToShotChangeEndMaxSeconds = 1.5;
+        SnapToShotChangeSameShotEndMaxSeconds = 0.5;
 
         SpectrogramStyle = nameof(SeSpectrogramStyle.Classic);
         LastDisplayMode = nameof(WaveformDisplayMode.OnlyWaveform);

--- a/src/ui/Logic/Download/TesseractDownloadService.cs
+++ b/src/ui/Logic/Download/TesseractDownloadService.cs
@@ -17,7 +17,6 @@ public class TesseractDownloadService : ITesseractDownloadService
 {
     private readonly HttpClient _httpClient;
     private const string WindowsUrl = "https://github.com/SubtitleEdit/support-files/releases/download/tesseract550/Tesseract550.zip";
-    private const string MacUrl = "https://github.com/SubtitleEdit/support-files/releases/download/tesseract550/Tesseract550.zip"; //TODO:
     private readonly IZipUnpacker _zipUnpacker;
 
     public TesseractDownloadService(HttpClient httpClient, IZipUnpacker zipUnpacker)
@@ -33,11 +32,8 @@ public class TesseractDownloadService : ITesseractDownloadService
             return WindowsUrl;
         }
 
-        if (OperatingSystem.IsMacOS())
-        {
-            return MacUrl;
-        }
-
+        // macOS/Linux use a package-manager install ("brew install tesseract" /
+        // "apt install tesseract-ocr") - see OcrViewModel.CheckAndDownloadTesseract.
         throw new PlatformNotSupportedException();
     }
 

--- a/src/ui/Logic/WindowsService.cs
+++ b/src/ui/Logic/WindowsService.cs
@@ -118,7 +118,7 @@ namespace Nikse.SubtitleEdit.Logic
             var window = (T)w;
             configureViewModel?.Invoke(window, viewModel);
 
-            window.WindowStartupLocation = WindowStartupLocation.CenterOwner; //TODO: does this work on mac?
+            window.WindowStartupLocation = WindowStartupLocation.CenterOwner;
 
             // Must run before Show() - see the note in ShowWindow<T>. (#12665)
             ApplyRightToLeftSettings(window);
@@ -195,7 +195,7 @@ namespace Nikse.SubtitleEdit.Logic
 
             var window = (TWindow)w;
 
-            window.WindowStartupLocation = WindowStartupLocation.CenterOwner; //TODO: does this work on mac?
+            window.WindowStartupLocation = WindowStartupLocation.CenterOwner;
             configureWindow?.Invoke(window);
 
             ApplyRightToLeftSettings(window);


### PR DESCRIPTION
Triage of the 57 `TODO`/`FIXME` comments in the tree: removes the ones that no longer apply, fixes three that were hiding real defects, and closes out the small mechanical ones. The remaining ~28 are libse format/spec unknowns that need samples or specs, plus unported SE4 features — left alone.

## Bugs

- **`SeAudioToText.WhisperChoice`** defaulted to `"WhisperCPP"`, which matches no engine (`WhisperChoice.Cpp` is `"CPP"`, `WhisperEngineCpp.Name` is `"Whisper CPP"`). `TrySelectBackendChoice` matches on `Choice`/`Name`, so the saved-choice lookup in `SpeechToTextViewModel` fell through every branch and no engine was selected on first run. Note the original TODO's suggested value (`WhisperEngineCpp.StaticName`) would not have matched either.
- **`TesseractDownloadService.MacUrl`** pointed at the Windows zip. It turned out to be unreachable — `CheckAndDownloadTesseract` only opens the download dialog on Windows and routes macOS to `brew install tesseract` — so the constant is deleted and `GetTesseractUrl` is now Windows-only, with a comment pointing at the real path.
- **Apply duration limits: "do not go past shot change"** was force-hidden by a line that deliberately overwrote the one above it. The checkbox, binding, visibility and `SetChanged()` wiring already existed; only view-model logic was missing. Added `CapAtShotChange` and merged the two near-duplicate min-duration branches into a single path that caps against both the next line and the next shot change — so a shot-capped extension now reports as a partial fix rather than a full one. Shot changes are sorted on `Initialize`.

## Obsolete comments and dead code removed

`WindowsService` (CenterOwner-on-mac question, ×2), `Idx` (stale "working on edit capabilities" note), `TeletextHamming` and `Cea708` (commented-out blocks from the original ports), `DownloadLibMpvViewModel` (the `catch` below already handles the case).

## Small fixes

- Binary apply-duration-limits labels moved out of hardcoded English into `LanguageApplyDurationLimits`
- `TranslateSettings` uses `UiUtil.MakeNumericUpDownInt` (gains mouse-wheel + automation-name handling). `MaxBytesRequest` changed `decimal?` → `int?`, because the helper's `NullableIntConverter` would otherwise reset the field to the default on every load
- Snap-to-shot-change thresholds (1.0s / 1.5s / 0.5s) are now `SeWaveform` settings
- Binary OCR delete prompt shows the real database item count instead of a hardcoded `1`
- Get audio clips honours `General.FfmpegUseCenterChannelOnly`, mirroring `WaveFileExtractor`'s `HasFrontCenterAudio` guard and probed once per run rather than per line
- Export custom text format writes with the selected encoding, initialised from `General.DefaultEncoding`
- `ReviewRow`: removed the unread `SpeedBackgroundColor` property — it had no readers and the `ThemeNames` type its TODO referenced does not exist anywhere

## Note on the EBU change

Only the provably dead part is removed: the parallel `encoding.GetBytes` computation, its byte fixups, and the `SeLogger.Error` diff logging. Its result was already overwritten by `textBytes.ToArray()` on the very next line, and `TextField` is not read after `GetBytes` (the extra-block path reads only `extra`). Emitted bytes are unchanged; the only behaviour change is that the encoding-diff logging no longer fires, which is what the TODO asked for. The string-side path above it is likely dead too but needs the Chinese-language branch traced, so the two remaining "use bytes directly" TODOs still mark it.

## Not included

`InitListViewAndEditBox.cs:1313` — the `Margin(0, 18, 0, 0)` top-align hack. It needs visual verification in the running app; a blind change risks misaligning the edit box.

## Testing

Build clean (0 warnings). `LibSETests` 865/865, `UITests` 1452/1452.

Heads-up unrelated to this PR: the UI suite fails exactly one test per full run, a different one each time (`FindWindowHistoryTests`, `MainMenuKeyboardActivationTests`, a `ValueConverterTests` cleanup failure, `SubtitleGridScrollPerformanceTests`), and does so on an unmodified `main` worktree as well. Each passes in isolation and a second full run here was fully green. Looks like pre-existing order-dependent shared state in the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)