### PR TITLE
Fix flaky headless UI tests: wait for dispatcher state after key input

### DIFF
--- a/tests/UI/Controls/AssaTagRtlAvaloniaCanaryTests.cs
+++ b/tests/UI/Controls/AssaTagRtlAvaloniaCanaryTests.cs
@@ -26,8 +26,21 @@ namespace UITests.Controls;
 /// translation, or drop the workaround entirely if Avalonia now orders the tag
 /// characters correctly on its own.
 /// </summary>
-public class AssaTagRtlAvaloniaCanaryTests
+public class AssaTagRtlAvaloniaCanaryTests : IDisposable
 {
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
     // PR #12567's approach needs to translate hit-test/caret indices from the permuted
     // layout back to Text. A click goes TextBox -> TextPresenter.MoveCaretToPoint ->
     // TextLayout.HitTestPoint; the approach becomes viable as soon as any point on that
@@ -70,6 +83,7 @@ public class AssaTagRtlAvaloniaCanaryTests
             FontSize = 16,
         };
         var window = new Window { Content = textBox, Width = 400, Height = 120 };
+        _windows.Add(window);
         window.Styles.Add(styles);
         window.Show();
         textBox.ApplyTemplate();

--- a/tests/UI/Controls/SyntaxHighlightingTextBoxTests.cs
+++ b/tests/UI/Controls/SyntaxHighlightingTextBoxTests.cs
@@ -6,8 +6,21 @@ using Nikse.SubtitleEdit.Controls;
 
 namespace UITests.Controls;
 
-public class SyntaxHighlightingTextBoxTests
+public class SyntaxHighlightingTextBoxTests : IDisposable
 {
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
     // Ligatures merge letter sequences like "ffi" into one glyph cluster, making the caret
     // and mouse selection treat them as a single character (#12585) - the edit box must
     // disable standard/contextual ligatures ("liga"/"clig") while keeping script-critical
@@ -32,6 +45,7 @@ public class SyntaxHighlightingTextBoxTests
     {
         var textBox = new SyntaxHighlightingTextBox();
         var window = new Window { Content = textBox, Width = 320, Height = 120 };
+        _windows.Add(window);
         window.Show();
         textBox.ApplyTemplate();
 

--- a/tests/UI/Controls/SyntaxHighlightingTextPresenterCanaryTests.cs
+++ b/tests/UI/Controls/SyntaxHighlightingTextPresenterCanaryTests.cs
@@ -18,9 +18,23 @@ namespace UITests.Controls;
 /// first layout through the real template, so the breakage surfaces as a red test at upgrade
 /// time instead.
 /// </summary>
-public class SyntaxHighlightingTextPresenterCanaryTests
+public class SyntaxHighlightingTextPresenterCanaryTests : IDisposable
 {
-    private static (Window window, SyntaxHighlightingTextBox textBox) ShowTextBox(string text, ISourceSyntaxHighlighter? highlighter = null)
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private (Window window, SyntaxHighlightingTextBox textBox) ShowTextBox(string text, ISourceSyntaxHighlighter? highlighter = null)
     {
         var styles = (Styles)AvaloniaXamlLoader.Load(new Uri("avares://SubtitleEdit/Styles.axaml"));
         var textBox = new SyntaxHighlightingTextBox
@@ -30,6 +44,7 @@ public class SyntaxHighlightingTextPresenterCanaryTests
             FontSize = 16,
         };
         var window = new Window { Content = textBox, Width = 400, Height = 120 };
+        _windows.Add(window);
         window.Styles.Add(styles);
         window.Show();
         textBox.ApplyTemplate();

--- a/tests/UI/Controls/SyntaxTextEditorTests.cs
+++ b/tests/UI/Controls/SyntaxTextEditorTests.cs
@@ -4,6 +4,7 @@ using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using Avalonia.Media;
+using Avalonia.Threading;
 using Nikse.SubtitleEdit.Controls.SyntaxTextEditorControl;
 using Nikse.SubtitleEdit.Logic;
 
@@ -47,7 +48,7 @@ public class SyntaxTextEditorTests : IDisposable
         return sb.ToString();
     }
 
-    private (Window Window, SyntaxTextEditor Editor) Show(string text, bool readOnly = false)
+    private async Task<(Window Window, SyntaxTextEditor Editor)> Show(string text, bool readOnly = false)
     {
         var editor = new SyntaxTextEditor
         {
@@ -63,18 +64,64 @@ public class SyntaxTextEditorTests : IDisposable
         window.Show();
         window.UpdateLayout();
         editor.View.Focus();
+
+        // The key presses only reach the editor once the view holds focus; under CPU load the
+        // Focus() call can lag a few frames (CI flake: Shift+Right selection missing). Wait for
+        // it - the test's own state waits surface a real focus failure.
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        while (!ReferenceEquals(window.FocusManager?.GetFocusedElement(), editor.View))
+        {
+            if (stopwatch.ElapsedMilliseconds > 1000)
+            {
+                Assert.Fail("The editor did not get keyboard focus within 1 second — keys would land nowhere and the test result would be meaningless.");
+            }
+
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(10);
+        }
+
         return (window, editor);
     }
 
     private static void Press(Window window, Key key, RawInputModifiers modifiers = RawInputModifiers.None)
     {
         window.KeyPress(key, modifiers, PhysicalKey.None, string.Empty);
+
+        // Process the dispatcher queue synchronously so the editor digests the caret/text state
+        // the test set directly before the key handler ran (under load that digestion can lag a
+        // frame, and the command would then act on stale state - CI flake).
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+    }
+
+    /// <summary>
+    /// Waits for a state that a key press is expected to produce. The headless KeyPress dispatch
+    /// rides the dispatcher queue, so under CPU load the editor state can lag a few frames behind
+    /// the synchronous call; asserting instantly then fails nondeterministically (CI flake with a
+    /// different victim test every run). Polling with a delay pumps the headless dispatcher until
+    /// the expected state appears, or fails with a descriptive message on timeout.
+    /// </summary>
+    private static async Task WaitUntil(Func<bool> condition, string failureMessage, int timeoutMs = 500)
+    {
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        while (!condition())
+        {
+            if (stopwatch.ElapsedMilliseconds > timeoutMs)
+            {
+                Assert.Fail(failureMessage);
+            }
+
+            // RunJobs pumps any queued dispatcher work the condition may depend on; Task.Delay
+            // additionally yields the thread so the headless session can process input.
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(10);
+        }
     }
 
     [AvaloniaFact]
-    public void OnlyTheVisibleLinesAreLaidOut()
+    public async Task OnlyTheVisibleLinesAreLaidOut()
     {
-        var (_, editor) = Show(MakeSrt(20_000)); // 4 lines per paragraph plus a trailing blank
+        var (_, editor) = await Show(MakeSrt(20_000)); // 4 lines per paragraph plus a trailing blank
         var view = editor.View;
 
         view.EnsureVisibleLayouts();
@@ -92,9 +139,9 @@ public class SyntaxTextEditorTests : IDisposable
     }
 
     [AvaloniaFact]
-    public void ScrollingBuildsOnlyTheNewlyVisibleLines()
+    public async Task ScrollingBuildsOnlyTheNewlyVisibleLines()
     {
-        var (_, editor) = Show(MakeSrt(20_000));
+        var (_, editor) = await Show(MakeSrt(20_000));
         var view = editor.View;
 
         view.EnsureVisibleLayouts();
@@ -118,9 +165,9 @@ public class SyntaxTextEditorTests : IDisposable
     }
 
     [AvaloniaFact]
-    public void ScrollOffsetIsClampedToTheExtent()
+    public async Task ScrollOffsetIsClampedToTheExtent()
     {
-        var (_, editor) = Show(MakeSrt(10));
+        var (_, editor) = await Show(MakeSrt(10));
         var view = editor.View;
 
         view.ScrollOffset = new Vector(-500, -500);
@@ -131,9 +178,9 @@ public class SyntaxTextEditorTests : IDisposable
     }
 
     [AvaloniaFact]
-    public void GutterCountsAndFollowsTheView()
+    public async Task GutterCountsAndFollowsTheView()
     {
-        var (_, editor) = Show(MakeSrt(100));
+        var (_, editor) = await Show(MakeSrt(100));
 
         var gutter = Assert.IsType<LineNumberGutter>(
             ((Grid)((Decorator)editor).Child!).Children[0]);
@@ -149,9 +196,9 @@ public class SyntaxTextEditorTests : IDisposable
     }
 
     [AvaloniaFact]
-    public void ShowLineNumbersHidesTheGutter()
+    public async Task ShowLineNumbersHidesTheGutter()
     {
-        var (_, editor) = Show(MakeSrt(10));
+        var (_, editor) = await Show(MakeSrt(10));
         var gutter = ((Grid)((Decorator)editor).Child!).Children[0];
 
         editor.ShowLineNumbers = false;
@@ -159,35 +206,34 @@ public class SyntaxTextEditorTests : IDisposable
     }
 
     [AvaloniaFact]
-    public void CaretMovesByCharacterAndLine()
+    public async Task CaretMovesByCharacterAndLine()
     {
-        var (window, editor) = Show("one\r\ntwo\r\nthree");
+        var (window, editor) = await Show("one\r\ntwo\r\nthree");
         var view = editor.View;
 
         view.CaretOffset = 0;
         Press(window, Key.Right);
-        Assert.Equal(1, view.CaretOffset);
+        await WaitUntil(() => view.CaretOffset == 1, "Right should move the caret to offset 1");
 
         Press(window, Key.End);
-        Assert.Equal(3, view.CaretOffset);
+        await WaitUntil(() => view.CaretOffset == 3, "End should move the caret to the end of line 1");
 
         // Past the end of a line the caret lands on the next line's start, not inside the break.
         Press(window, Key.Right);
-        Assert.Equal(5, view.CaretOffset);
+        await WaitUntil(() => view.CaretOffset == 5, "Right past the line end should land on line 2 start");
 
         Press(window, Key.Down);
-        Assert.Equal(2, view.CaretLine);
+        await WaitUntil(() => view.CaretLine == 2, "Down should move the caret to line 2");
 
         // Left from the start of a line steps back over the whole break, onto the end of line 1.
         Press(window, Key.Left);
-        Assert.Equal(1, view.CaretLine);
-        Assert.Equal(8, view.CaretOffset);
+        await WaitUntil(() => view.CaretLine == 1 && view.CaretOffset == 8, "Left should step back over the break");
     }
 
     [AvaloniaFact]
-    public void ShiftArrowSelectsAndTypingReplacesTheSelection()
+    public async Task ShiftArrowSelectsAndTypingReplacesTheSelection()
     {
-        var (window, editor) = Show("hello world");
+        var (window, editor) = await Show("hello world");
         var view = editor.View;
 
         view.CaretOffset = 0;
@@ -196,35 +242,33 @@ public class SyntaxTextEditorTests : IDisposable
             Press(window, Key.Right, RawInputModifiers.Shift);
         }
 
-        Assert.Equal("hello", view.SelectedText);
+        await WaitUntil(() => view.SelectedText == "hello", "Shift+Right x5 should select \"hello\"");
 
         view.InsertText("bye");
-        Assert.Equal("bye world", editor.Text);
-        Assert.Equal(3, view.CaretOffset);
+        await WaitUntil(() => editor.Text == "bye world", "typing over the selection should replace it");
+        await WaitUntil(() => view.CaretOffset == 3, "caret should sit at the end of the inserted text");
     }
 
     [AvaloniaFact]
-    public void EnterSplitsTheLineAndBackspaceJoinsItBack()
+    public async Task EnterSplitsTheLineAndBackspaceJoinsItBack()
     {
-        var (window, editor) = Show("onetwo");
+        var (window, editor) = await Show("onetwo");
         var view = editor.View;
 
         view.CaretOffset = 3;
         Press(window, Key.Enter);
-
-        Assert.Equal(2, view.Document.LineCount);
-        Assert.Equal("one" + view.Document.NewLine + "two", editor.Text);
+        await WaitUntil(() => view.Document.LineCount == 2, "Enter should split the line");
+        await WaitUntil(() => editor.Text == "one" + view.Document.NewLine + "two", "Enter should split at the caret");
 
         Press(window, Key.Back);
-        Assert.Equal(1, view.Document.LineCount);
-        Assert.Equal("onetwo", editor.Text);
-        Assert.Equal(3, view.CaretOffset);
+        await WaitUntil(() => view.Document.LineCount == 1, "Backspace should join the lines");
+        await WaitUntil(() => editor.Text == "onetwo" && view.CaretOffset == 3, "Backspace should restore the text and caret");
     }
 
     [AvaloniaFact]
-    public void TypedCharactersUndoAsOneStep()
+    public async Task TypedCharactersUndoAsOneStep()
     {
-        var (_, editor) = Show("start");
+        var (_, editor) = await Show("start");
         var view = editor.View;
 
         view.CaretOffset = 5;
@@ -242,9 +286,9 @@ public class SyntaxTextEditorTests : IDisposable
     }
 
     [AvaloniaFact]
-    public void UndoRestoresDeletedTextAndTheCaret()
+    public async Task UndoRestoresDeletedTextAndTheCaret()
     {
-        var (_, editor) = Show("one two three");
+        var (_, editor) = await Show("one two three");
         var view = editor.View;
 
         view.Select(4, 3);
@@ -258,9 +302,9 @@ public class SyntaxTextEditorTests : IDisposable
     }
 
     [AvaloniaFact]
-    public void ReadOnlyRefusesEveryEdit()
+    public async Task ReadOnlyRefusesEveryEdit()
     {
-        var (window, editor) = Show("keep me", readOnly: true);
+        var (window, editor) = await Show("keep me", readOnly: true);
         var view = editor.View;
 
         view.CaretOffset = 0;
@@ -269,15 +313,17 @@ public class SyntaxTextEditorTests : IDisposable
         view.SelectAll();
         Press(window, Key.Back);
 
+        // These are no-transition assertions: waiting would pass before a delayed key was handled.
+        // Press settles the dispatcher, so assert the unchanged state synchronously afterwards.
         Assert.Equal("keep me", editor.Text);
         Assert.False(view.CanUndo);
     }
 
     [AvaloniaFact]
-    public void SelectAllCoversTheWholeDocument()
+    public async Task SelectAllCoversTheWholeDocument()
     {
         var text = MakeSrt(5);
-        var (_, editor) = Show(text);
+        var (_, editor) = await Show(text);
 
         editor.SelectAll();
 
@@ -287,9 +333,9 @@ public class SyntaxTextEditorTests : IDisposable
     }
 
     [AvaloniaFact]
-    public void SettingTextKeepsTheDocumentAndCaretConsistent()
+    public async Task SettingTextKeepsTheDocumentAndCaretConsistent()
     {
-        var (_, editor) = Show("first");
+        var (_, editor) = await Show("first");
 
         editor.Text = "a\r\nb\r\nc";
 
@@ -299,9 +345,9 @@ public class SyntaxTextEditorTests : IDisposable
     }
 
     [AvaloniaFact]
-    public void BringCaretIntoViewScrollsToTheCaret()
+    public async Task BringCaretIntoViewScrollsToTheCaret()
     {
-        var (_, editor) = Show(MakeSrt(2_000));
+        var (_, editor) = await Show(MakeSrt(2_000));
         var view = editor.View;
 
         view.CaretOffset = view.Document.GetLineStartOffset(5_000);
@@ -318,36 +364,36 @@ public class SyntaxTextEditorTests : IDisposable
     private static string Lines(params string[] lines) => string.Join("\r\n", lines);
 
     [AvaloniaFact]
-    public void AltUpMovesTheCaretLineUpAndKeepsTheColumn()
+    public async Task AltUpMovesTheCaretLineUpAndKeepsTheColumn()
     {
-        var (window, editor) = Show(Lines("one", "two", "three"));
+        var (window, editor) = await Show(Lines("one", "two", "three"));
         var view = editor.View;
 
         view.CaretOffset = view.Document.GetOffset(1, 2); // inside "two"
         Press(window, Key.Up, RawInputModifiers.Alt);
 
-        Assert.Equal(Lines("two", "one", "three"), editor.Text);
-        Assert.Equal(new SyntaxTextPosition(0, 2), view.Document.GetPosition(view.CaretOffset));
+        await WaitUntil(() => editor.Text == Lines("two", "one", "three"), "Alt+Up should move the caret line up");
+        await WaitUntil(() => view.Document.GetPosition(view.CaretOffset) == new SyntaxTextPosition(0, 2), "the caret should keep its column");
     }
 
     [AvaloniaFact]
-    public void AltDownMovesTheWholeSelectedBlock()
+    public async Task AltDownMovesTheWholeSelectedBlock()
     {
-        var (window, editor) = Show(Lines("a", "b", "c", "d"));
+        var (window, editor) = await Show(Lines("a", "b", "c", "d"));
         var view = editor.View;
 
         // Select from inside line 0 to inside line 1 - both lines count as touched.
         view.Select(view.Document.GetOffset(0, 0), view.Document.GetOffset(1, 1));
         Press(window, Key.Down, RawInputModifiers.Alt);
 
-        Assert.Equal(Lines("c", "a", "b", "d"), editor.Text);
-        Assert.Equal("a\r\nb", view.SelectedText);
+        await WaitUntil(() => editor.Text == Lines("c", "a", "b", "d"), "Alt+Down should move the selected block");
+        await WaitUntil(() => view.SelectedText == "a\r\nb", "the selection should move with the block");
     }
 
     [AvaloniaFact]
-    public void MovingLinesStaysInsideTheDocument()
+    public async Task MovingLinesStaysInsideTheDocument()
     {
-        var (window, editor) = Show(Lines("first", "last"));
+        var (window, editor) = await Show(Lines("first", "last"));
         var view = editor.View;
 
         view.CaretOffset = 0;
@@ -361,95 +407,95 @@ public class SyntaxTextEditorTests : IDisposable
     }
 
     [AvaloniaFact]
-    public void MoveLineUndoesAsOneStep()
+    public async Task MoveLineUndoesAsOneStep()
     {
-        var (window, editor) = Show(Lines("one", "two", "three"));
+        var (window, editor) = await Show(Lines("one", "two", "three"));
         var view = editor.View;
 
         view.CaretOffset = view.Document.GetLineStartOffset(2);
         Press(window, Key.Up, RawInputModifiers.Alt);
-        Assert.Equal(Lines("one", "three", "two"), editor.Text);
+        await WaitUntil(() => editor.Text == Lines("one", "three", "two"), "Alt+Up should move line 3 above line 2");
 
         view.Undo();
-        Assert.Equal(Lines("one", "two", "three"), editor.Text);
-        Assert.False(view.CanUndo);
+        await WaitUntil(() => editor.Text == Lines("one", "two", "three"), "Undo should restore the original order");
+        await WaitUntil(() => !view.CanUndo, "the move must undo as one step");
     }
 
     [AvaloniaFact]
-    public void DuplicateLineInsertsTheCopyBelowAndLandsOnIt()
+    public async Task DuplicateLineInsertsTheCopyBelowAndLandsOnIt()
     {
-        var (window, editor) = Show(Lines("one", "two"));
+        var (window, editor) = await Show(Lines("one", "two"));
         var view = editor.View;
 
         view.CaretOffset = view.Document.GetOffset(0, 1);
         Press(window, Key.D, ControlOrMeta);
 
-        Assert.Equal(Lines("one", "one", "two"), editor.Text);
-        Assert.Equal(new SyntaxTextPosition(1, 1), view.Document.GetPosition(view.CaretOffset));
+        await WaitUntil(() => editor.Text == Lines("one", "one", "two"), "Ctrl+D should duplicate the line below");
+        await WaitUntil(() => view.Document.GetPosition(view.CaretOffset) == new SyntaxTextPosition(1, 1), "the caret should land on the copy");
 
         // Repeating it duplicates the copy, not the original.
         Press(window, Key.D, ControlOrMeta);
-        Assert.Equal(Lines("one", "one", "one", "two"), editor.Text);
+        await WaitUntil(() => editor.Text == Lines("one", "one", "one", "two"), "repeating Ctrl+D should duplicate the copy");
     }
 
     [AvaloniaFact]
-    public void DeleteLineTakesTheLineBreakWithIt()
+    public async Task DeleteLineTakesTheLineBreakWithIt()
     {
-        var (window, editor) = Show(Lines("one", "two", "three"));
+        var (window, editor) = await Show(Lines("one", "two", "three"));
         var view = editor.View;
 
         view.CaretOffset = view.Document.GetLineStartOffset(1);
         Press(window, Key.K, ControlOrMeta | RawInputModifiers.Shift);
 
-        Assert.Equal(Lines("one", "three"), editor.Text);
-        Assert.Equal(2, view.Document.LineCount);
+        await WaitUntil(() => editor.Text == Lines("one", "three"), "Ctrl+Shift+K should delete the whole line");
+        await WaitUntil(() => view.Document.LineCount == 2, "the line break must go with the line");
     }
 
     [AvaloniaFact]
-    public void DeletingTheLastLineTakesTheBreakAboveIt()
+    public async Task DeletingTheLastLineTakesTheBreakAboveIt()
     {
-        var (window, editor) = Show(Lines("one", "two"));
+        var (window, editor) = await Show(Lines("one", "two"));
         var view = editor.View;
 
         view.CaretOffset = view.Document.GetLineStartOffset(1);
         Press(window, Key.K, ControlOrMeta | RawInputModifiers.Shift);
 
-        Assert.Equal("one", editor.Text);
-        Assert.Equal(1, view.Document.LineCount);
+        await WaitUntil(() => editor.Text == "one", "deleting the last line must keep the first");
+        await WaitUntil(() => view.Document.LineCount == 1, "the break above the deleted line must go too");
     }
 
     [AvaloniaFact]
-    public void DeleteLineOnTheOnlyLineJustEmptiesIt()
+    public async Task DeleteLineOnTheOnlyLineJustEmptiesIt()
     {
-        var (window, editor) = Show("only");
+        var (window, editor) = await Show("only");
         var view = editor.View;
 
         Press(window, Key.K, ControlOrMeta | RawInputModifiers.Shift);
 
-        Assert.Equal(string.Empty, editor.Text);
-        Assert.Equal(1, view.Document.LineCount);
+        await WaitUntil(() => editor.Text == string.Empty, "deleting the only line must empty the document");
+        await WaitUntil(() => view.Document.LineCount == 1, "the only line must stay, just empty");
     }
 
     [AvaloniaFact]
-    public void DeleteWordLeftAndRightRemoveOneWord()
+    public async Task DeleteWordLeftAndRightRemoveOneWord()
     {
-        var (window, editor) = Show("one two three");
+        var (window, editor) = await Show("one two three");
         var view = editor.View;
 
         view.CaretOffset = 7; // right after "two"
         Press(window, Key.Back, WordModifier);
-        Assert.Equal("one  three", editor.Text);
+        await WaitUntil(() => editor.Text == "one  three", "Ctrl+Backspace should remove the word to the left");
 
         view.CaretOffset = 4;
         Press(window, Key.Delete, WordModifier);
-        Assert.Equal("one ", editor.Text);
+        await WaitUntil(() => editor.Text == "one ", "Ctrl+Delete should remove the word to the right");
     }
 
     [AvaloniaFact]
-    public void ReadOnlyRefusesTheLineCommands()
+    public async Task ReadOnlyRefusesTheLineCommands()
     {
         var text = Lines("one", "two", "three");
-        var (window, editor) = Show(text, readOnly: true);
+        var (window, editor) = await Show(text, readOnly: true);
 
         editor.View.CaretOffset = editor.Document.GetLineStartOffset(1);
         Press(window, Key.Up, RawInputModifiers.Alt);
@@ -457,14 +503,16 @@ public class SyntaxTextEditorTests : IDisposable
         Press(window, Key.K, ControlOrMeta | RawInputModifiers.Shift);
         Press(window, Key.Back, WordModifier);
 
+        // Each Press settles the dispatcher. Polling unchanged state would return before a delayed
+        // command and could hide a regression, so check the no-op contract directly.
         Assert.Equal(text, editor.Text);
         Assert.False(editor.View.CanUndo);
     }
 
     [AvaloniaFact]
-    public void ReplaceAllTextIsOneUndoStep()
+    public async Task ReplaceAllTextIsOneUndoStep()
     {
-        var (_, editor) = Show(Lines("one", "two"));
+        var (_, editor) = await Show(Lines("one", "two"));
 
         editor.ReplaceAllText(Lines("1", "2"));
         Assert.Equal(Lines("1", "2"), editor.Text);

--- a/tests/UI/Features/Assa/AssaStyleEditorDataLossTests.cs
+++ b/tests/UI/Features/Assa/AssaStyleEditorDataLossTests.cs
@@ -18,8 +18,21 @@ namespace UITests.Features.Assa;
 ///   current style's font was not in the combo's item list.
 /// These tests drive the real controls headless, built exactly like the production windows.
 /// </summary>
-public class AssaStyleEditorDataLossTests
+public class AssaStyleEditorDataLossTests : IDisposable
 {
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
     private static AssaStylesViewModel MakeVm()
     {
         var services = new ServiceCollection();
@@ -52,6 +65,7 @@ public class AssaStyleEditorDataLossTests
         var b = new StyleDisplay(new SsaStyle { Name = "B", Alignment = "5" });
 
         var window = new Window { Content = MakeAlignmentRadios(vm) };
+        _windows.Add(window);
         window.Show();
 
         vm.CurrentStyle = a;
@@ -78,6 +92,7 @@ public class AssaStyleEditorDataLossTests
         var storageStyle = new StyleDisplay(new SsaStyle { Name = "StorageDefault", Alignment = "2" });
 
         var window = new Window { Content = MakeAlignmentRadios(vm) };
+        _windows.Add(window);
         window.Show();
 
         vm.CurrentStyle = fileStyle;
@@ -103,6 +118,7 @@ public class AssaStyleEditorDataLossTests
 
         var panel = MakeAlignmentRadios(vm);
         var window = new Window { Content = panel };
+        _windows.Add(window);
         window.Show();
 
         vm.CurrentStyle = style;
@@ -130,6 +146,7 @@ public class AssaStyleEditorDataLossTests
 
         var combo = UiUtil.MakeComboBox(vm.Fonts, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.FontName));
         var window = new Window { Content = combo };
+        _windows.Add(window);
         window.Show();
 
         vm.CurrentStyle = a;

--- a/tests/UI/Features/LlamaCppEngineSettingsButtonTests.cs
+++ b/tests/UI/Features/LlamaCppEngineSettingsButtonTests.cs
@@ -21,8 +21,21 @@ namespace UITests.Features;
 /// is invisible until the window is actually constructed. These tests assert the button reaches the
 /// logical tree and is effectively visible, which a build alone cannot prove.
 /// </summary>
-public class LlamaCppEngineSettingsButtonTests
+public class LlamaCppEngineSettingsButtonTests : IDisposable
 {
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
     private sealed class NullServiceProvider : IServiceProvider
     {
         public object? GetService(Type serviceType) => null;
@@ -44,6 +57,7 @@ public class LlamaCppEngineSettingsButtonTests
     {
         var vm = new AiReviewViewModel(new WindowService(new NullServiceProvider()));
         var window = new AiReviewWindow(vm);
+        _windows.Add(window);
         try
         {
             var button = FindEngineSettingsButton(window);
@@ -63,6 +77,7 @@ public class LlamaCppEngineSettingsButtonTests
     {
         var vm = new AiAssistantViewModel(new WindowService(new NullServiceProvider()));
         var window = new AiAssistantWindow(vm);
+        _windows.Add(window);
         try
         {
             var button = FindEngineSettingsButton(window);
@@ -101,6 +116,7 @@ public class LlamaCppEngineSettingsButtonTests
     {
         var vm = new AiReviewViewModel(new WindowService(new NullServiceProvider()));
         var window = new AiReviewWindow(vm);
+        _windows.Add(window);
         try
         {
             var engineCombo = window.GetLogicalDescendants().OfType<ComboBox>()
@@ -119,6 +135,7 @@ public class LlamaCppEngineSettingsButtonTests
     {
         var vm = new AiAssistantViewModel(new WindowService(new NullServiceProvider()));
         var window = new AiAssistantWindow(vm);
+        _windows.Add(window);
         try
         {
             var engineCombo = window.GetLogicalDescendants().OfType<ComboBox>()
@@ -142,6 +159,7 @@ public class LlamaCppEngineSettingsButtonTests
     {
         var vm = new AutoTranslateViewModel(new WindowService(new NullServiceProvider()), new FolderHelper());
         var window = new AutoTranslateWindow(vm);
+        _windows.Add(window);
         try
         {
             Assert.NotNull(FindEngineSettingsButton(window));
@@ -161,6 +179,7 @@ public class LlamaCppEngineSettingsButtonTests
     {
         var vm = new AiReviewViewModel(new WindowService(new NullServiceProvider()));
         var window = new AiReviewWindow(vm);
+        _windows.Add(window);
         try
         {
             vm.SelectedEngine = SeAiReview.EngineOllama;

--- a/tests/UI/Features/Main/MainMenuKeyboardActivationTests.cs
+++ b/tests/UI/Features/Main/MainMenuKeyboardActivationTests.cs
@@ -22,15 +22,31 @@ namespace UITests.Features.Main;
 /// (focus only, no "File" highlight); it now goes through Menu.Open like Avalonia's own
 /// bare-Alt handling.
 /// </summary>
-public class MainMenuKeyboardActivationTests
+public class MainMenuKeyboardActivationTests : IDisposable
 {
-    private static (Window Window, MainViewModel Vm) ShowMainWindowWithEmptyGrid()
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown
+    // ("Test Case Cleanup Failure" - different thread owns the window).
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private (Window Window, MainViewModel Vm) ShowMainWindowWithEmptyGrid()
     {
         var services = new ServiceCollection();
         services.AddSubtitleEditServices();
         Locator.Services = services.BuildServiceProvider();
 
         var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
         MainView.NextHostWindow = window;
         var view = new MainView();
         window.Content = view;
@@ -65,12 +81,47 @@ public class MainMenuKeyboardActivationTests
     private static bool IsFocusOnMenuItem(Window window) =>
         window.FocusManager?.GetFocusedElement() is MenuItem;
 
+    /// <summary>
+    /// The key cycles below only reach the window handlers once the grid actually holds focus;
+    /// FocusRow + Settle can still leave the focus a frame behind on a loaded runner, and a key
+    /// pressed before that lands nowhere (menu never opens - CI flake).
+    /// </summary>
+    private static async Task WaitForGridFocus(Window window, MainViewModel vm)
+    {
+        await WaitUntil(
+            () => ReferenceEquals(vm.SubtitleGrid, window.FocusManager?.GetFocusedElement()),
+            "the grid should hold keyboard focus before the key cycle");
+    }
+
     private static void PressAndRelease(Window window, PhysicalKey key, RawInputModifiers modifiers)
     {
         window.KeyPressQwerty(key, modifiers);
         Dispatcher.UIThread.RunJobs();
         window.KeyReleaseQwerty(key, modifiers);
         Settle(window);
+    }
+
+    /// <summary>
+    /// Waits for a state a key cycle is expected to produce. Even with the RunJobs/Settle calls in
+    /// PressAndRelease, the access-key handling can still be a few dispatcher frames behind under
+    /// CPU load (CI flake: a different menu test failed on every run); polling with a delay pumps
+    /// the headless dispatcher until the expected state appears, or fails on timeout.
+    /// </summary>
+    private static async Task WaitUntil(Func<bool> condition, string failureMessage, int timeoutMs = 500)
+    {
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        while (!condition())
+        {
+            if (stopwatch.ElapsedMilliseconds > timeoutMs)
+            {
+                Assert.Fail(failureMessage);
+            }
+
+            // RunJobs pumps any queued dispatcher work the condition may depend on; Task.Delay
+            // additionally yields the thread so the headless session can process input.
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(10);
+        }
     }
 
     [AvaloniaFact]
@@ -90,112 +141,118 @@ public class MainMenuKeyboardActivationTests
     }
 
     [AvaloniaFact]
-    public void F10_OpensTheMenuBarVisibly()
+    public async Task F10_OpensTheMenuBarVisibly()
     {
         var (window, vm) = ShowMainWindowWithEmptyGrid();
         TableViewExtras.FocusRow(vm.SubtitleGrid);
         Settle(window);
+        await WaitForGridFocus(window, vm);
 
         PressAndRelease(window, PhysicalKey.F10, RawInputModifiers.None);
 
         // Menu.Open (the same path as Avalonia's bare-Alt activation) selects the first
         // top-level item, so "File" is highlighted - focus alone gave no visual feedback.
-        Assert.True(vm.Menu.IsOpen);
-        Assert.True(IsFocusOnMenuItem(window));
+        await WaitUntil(() => vm.Menu.IsOpen, "F10 should open the menu bar");
+        await WaitUntil(() => IsFocusOnMenuItem(window), "F10 should focus the first menu item");
 
         window.Close();
     }
 
     [AvaloniaFact]
-    public void F10_TogglesTheMenuBarOffAgain_WithEmptyGrid()
+    public async Task F10_TogglesTheMenuBarOffAgain_WithEmptyGrid()
     {
         var (window, vm) = ShowMainWindowWithEmptyGrid();
         TableViewExtras.FocusRow(vm.SubtitleGrid);
         Settle(window);
+        await WaitForGridFocus(window, vm);
 
         PressAndRelease(window, PhysicalKey.F10, RawInputModifiers.None);
-        Assert.True(vm.Menu.IsOpen);
+        await WaitUntil(() => vm.Menu.IsOpen, "F10 should open the menu bar");
 
         PressAndRelease(window, PhysicalKey.F10, RawInputModifiers.None);
 
-        Assert.False(vm.Menu.IsOpen);
-        Assert.False(IsFocusOnMenuItem(window));
-        Assert.Same(vm.SubtitleGrid, window.FocusManager?.GetFocusedElement());
+        await WaitUntil(() => !vm.Menu.IsOpen, "the second F10 should close the menu bar");
+        await WaitUntil(() => !IsFocusOnMenuItem(window), "the menu item should lose focus");
+        await WaitUntil(() => ReferenceEquals(vm.SubtitleGrid, window.FocusManager?.GetFocusedElement()), "focus should return to the grid");
 
         window.Close();
     }
 
     [AvaloniaFact]
-    public void Escape_DeactivatesTheMenuBar_WithEmptyGrid()
+    public async Task Escape_DeactivatesTheMenuBar_WithEmptyGrid()
     {
         var (window, vm) = ShowMainWindowWithEmptyGrid();
         TableViewExtras.FocusRow(vm.SubtitleGrid);
         Settle(window);
+        await WaitForGridFocus(window, vm);
 
         PressAndRelease(window, PhysicalKey.F10, RawInputModifiers.None);
-        Assert.True(vm.Menu.IsOpen);
+        await WaitUntil(() => vm.Menu.IsOpen, "F10 should open the menu bar");
 
         PressAndRelease(window, PhysicalKey.Escape, RawInputModifiers.None);
 
-        Assert.False(vm.Menu.IsOpen);
-        Assert.False(IsFocusOnMenuItem(window));
-        Assert.Same(vm.SubtitleGrid, window.FocusManager?.GetFocusedElement());
+        await WaitUntil(() => !vm.Menu.IsOpen, "Escape should close the menu bar");
+        await WaitUntil(() => !IsFocusOnMenuItem(window), "Escape should release the menu item focus");
+        await WaitUntil(() => ReferenceEquals(vm.SubtitleGrid, window.FocusManager?.GetFocusedElement()), "Escape should restore focus to the grid");
 
         window.Close();
     }
 
     [AvaloniaFact]
-    public void BareAlt_ClosesTheMenu_WhileFocusIsInsideAnOpenDropDown()
+    public async Task BareAlt_ClosesTheMenu_WhileFocusIsInsideAnOpenDropDown()
     {
         var (window, vm) = ShowMainWindowWithEmptyGrid();
         TableViewExtras.FocusRow(vm.SubtitleGrid);
         Settle(window);
+        await WaitForGridFocus(window, vm);
 
         // Bare Alt activates the bar (Avalonia's AccessKeyHandler opens it on the release).
         PressAndRelease(window, PhysicalKey.AltLeft, RawInputModifiers.Alt);
-        Assert.True(vm.Menu.IsOpen);
+        await WaitUntil(() => vm.Menu.IsOpen, "bare Alt should open the menu bar");
 
         // Down opens the File drop-down and focuses its first item. (The headless platform hosts
         // drop-downs in the window's overlay layer, so this cannot reproduce the desktop bug
         // where they live in a separate popup top-level - the test below covers that part.)
         PressAndRelease(window, PhysicalKey.ArrowDown, RawInputModifiers.None);
-        Assert.True(IsFocusOnMenuItem(window));
+        await WaitUntil(() => IsFocusOnMenuItem(window), "Down should focus the first drop-down item");
 
         PressAndRelease(window, PhysicalKey.AltLeft, RawInputModifiers.Alt);
 
-        Assert.False(vm.Menu.IsOpen);
-        Assert.False(IsFocusOnMenuItem(window));
-        Assert.Same(vm.SubtitleGrid, window.FocusManager?.GetFocusedElement());
+        await WaitUntil(() => !vm.Menu.IsOpen, "bare Alt with a drop-down item focused should close the bar");
+        await WaitUntil(() => !IsFocusOnMenuItem(window), "the drop-down item should lose focus");
+        await WaitUntil(() => ReferenceEquals(vm.SubtitleGrid, window.FocusManager?.GetFocusedElement()), "focus should return to the grid");
 
         window.Close();
     }
 
     [AvaloniaFact]
-    public void BareAlt_ClosesTheMenu_WhenTheFocusedMenuItemLivesInAnotherTopLevel()
+    public async Task BareAlt_ClosesTheMenu_WhenTheFocusedMenuItemLivesInAnotherTopLevel()
     {
         var (window, vm) = ShowMainWindowWithEmptyGrid();
         TableViewExtras.FocusRow(vm.SubtitleGrid);
         Settle(window);
+        await WaitForGridFocus(window, vm);
 
         PressAndRelease(window, PhysicalKey.F10, RawInputModifiers.None);
-        Assert.True(vm.Menu.IsOpen);
+        await WaitUntil(() => vm.Menu.IsOpen, "F10 should open the menu bar");
 
         // On desktop an open drop-down hosts its items in a PopupRoot - a separate top-level,
         // where Avalonia's AccessKeyHandler ignores every key, so its bare-Alt toggle never saw
         // the second Alt (#12087). The headless platform has no popup top-levels, so model the
         // same focus topology with a second window hosting the focused menu item.
         var popupStandIn = new Window { Content = new Menu { Items = { new MenuItem { Header = "Item" } } } };
+        _windows.Add(popupStandIn);
         popupStandIn.Show();
         Dispatcher.UIThread.RunJobs();
         var popupItem = (MenuItem)((Menu)popupStandIn.Content!).Items[0]!;
         popupItem.Focusable = true;
         Assert.True(popupItem.Focus());
         Settle(window);
-        Assert.NotSame(window, TopLevel.GetTopLevel(window.FocusManager?.GetFocusedElement() as Visual));
+        await WaitUntil(() => !ReferenceEquals(window, TopLevel.GetTopLevel(window.FocusManager?.GetFocusedElement() as Visual)), "focus should move to the second top-level");
 
         // Guard against a false pass: if showing the second window had already closed the menu
         // (e.g. via a deactivation handler), the Alt cycle below would have nothing to do.
-        Assert.True(vm.Menu.IsOpen);
+        Assert.True(vm.Menu.IsOpen, "the menu must still be open before the Alt cycle");
 
         // The key events reach the main window's handlers through the popup's event route; the
         // headless KeyPress helpers only target one window, so raise them the way the route would.
@@ -217,22 +274,23 @@ public class MainMenuKeyboardActivationTests
         });
         Settle(window);
 
-        Assert.False(vm.Menu.IsOpen);
-        Assert.Same(vm.SubtitleGrid, window.FocusManager?.GetFocusedElement());
+        await WaitUntil(() => !vm.Menu.IsOpen, "bare Alt should close the menu when focus is in another top-level");
+        await WaitUntil(() => ReferenceEquals(vm.SubtitleGrid, window.FocusManager?.GetFocusedElement()), "focus should return to the grid");
 
         popupStandIn.Close();
         window.Close();
     }
 
     [AvaloniaFact]
-    public void BareAlt_DeactivatesAnF10OpenedMenuBar()
+    public async Task BareAlt_DeactivatesAnF10OpenedMenuBar()
     {
         var (window, vm) = ShowMainWindowWithEmptyGrid();
         TableViewExtras.FocusRow(vm.SubtitleGrid);
         Settle(window);
+        await WaitForGridFocus(window, vm);
 
         PressAndRelease(window, PhysicalKey.F10, RawInputModifiers.None);
-        Assert.True(vm.Menu.IsOpen);
+        await WaitUntil(() => vm.Menu.IsOpen, "F10 should open the menu bar");
 
         // Avalonia's AccessKeyHandler closes the bar on the Alt press but only restores focus
         // for bars it opened itself - after an F10 activation the close would strand focus on
@@ -242,9 +300,9 @@ public class MainMenuKeyboardActivationTests
         window.KeyReleaseQwerty(PhysicalKey.AltLeft, RawInputModifiers.None);
         Settle(window);
 
-        Assert.False(vm.Menu.IsOpen);
-        Assert.False(IsFocusOnMenuItem(window));
-        Assert.Same(vm.SubtitleGrid, window.FocusManager?.GetFocusedElement());
+        await WaitUntil(() => !vm.Menu.IsOpen, "bare Alt should close an F10-opened bar");
+        await WaitUntil(() => !IsFocusOnMenuItem(window), "the menu item should lose focus");
+        await WaitUntil(() => ReferenceEquals(vm.SubtitleGrid, window.FocusManager?.GetFocusedElement()), "focus should return to the grid");
 
         window.Close();
     }

--- a/tests/UI/Features/Main/SubtitleGridScrollPerformanceTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridScrollPerformanceTests.cs
@@ -22,9 +22,23 @@ namespace UITests.Features.Main;
 /// successive Home/End round trips (~1 s per keypress, getting worse) while End stayed at 17,
 /// and a jump to line 100 realized all 4935 remaining rows in every second attempt.
 /// </summary>
-public class SubtitleGridScrollPerformanceTests
+public class SubtitleGridScrollPerformanceTests : IDisposable
 {
     private const int LineCount = 5000;
+
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
 
     /// <summary>
     /// A viewport holds ~17 rows. Three passes of pre-positioning plus the ScrollIntoView that
@@ -39,13 +53,14 @@ public class SubtitleGridScrollPerformanceTests
         _output = output;
     }
 
-    private static (Window Window, MainViewModel Vm, TableView Grid, ScrollViewer ScrollViewer) ShowMainWindowWithLines()
+    private (Window Window, MainViewModel Vm, TableView Grid, ScrollViewer ScrollViewer) ShowMainWindowWithLines()
     {
         var services = new ServiceCollection();
         services.AddSubtitleEditServices();
         Locator.Services = services.BuildServiceProvider();
 
         var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
         MainView.NextHostWindow = window;
         var view = new MainView();
         window.Content = view;

--- a/tests/UI/Features/Main/SubtitleGridSelectionOrderTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridSelectionOrderTests.cs
@@ -21,17 +21,32 @@ namespace UITests.Features.Main;
 /// where subtitle order gets restored - see issue #13173, where "Copy (text only)" put the lines
 /// on the clipboard out of order after a reverse selection.
 /// </summary>
-public class SubtitleGridSelectionOrderTests
+public class SubtitleGridSelectionOrderTests : IDisposable
 {
     private const int LineCount = 20;
 
-    private static (Window Window, MainViewModel Vm, TableView Grid) ShowMainWindowWithLines()
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private (Window Window, MainViewModel Vm, TableView Grid) ShowMainWindowWithLines()
     {
         var services = new ServiceCollection();
         services.AddSubtitleEditServices();
         Locator.Services = services.BuildServiceProvider();
 
         var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
         MainView.NextHostWindow = window;
         var view = new MainView();
         window.Content = view;

--- a/tests/UI/Features/SourceViewEditorTests.cs
+++ b/tests/UI/Features/SourceViewEditorTests.cs
@@ -14,8 +14,22 @@ namespace UITests.Features;
 /// not mirrored into the view model while typing (that cost grows with the file), so the test that
 /// matters most here is that Ok still picks up what was actually typed.
 /// </summary>
-public class SourceViewEditorTests
+public class SourceViewEditorTests : IDisposable
 {
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
     /// <summary>Only Go to line opens a window, and none of these tests take that path.</summary>
     private sealed class NoWindowService : IWindowService
     {
@@ -87,6 +101,7 @@ public class SourceViewEditorTests
     {
         var (vm, subtitle, _) = MakeSourceView();
         var window = new Window { Content = new Border { Child = vm.SourceViewTextBox.ContentControl } };
+        _windows.Add(window);
         vm.Window = window;
         window.Show();
         window.UpdateLayout();
@@ -135,6 +150,7 @@ public class SourceViewEditorTests
     {
         var (vm, _, _) = MakeSourceView();
         var window = new Window { Content = new Border { Child = vm.SourceViewTextBox.ContentControl } };
+        _windows.Add(window);
         vm.Window = window;
         window.Show();
         window.UpdateLayout();

--- a/tests/UI/Features/Video/BurnInWindowTests.cs
+++ b/tests/UI/Features/Video/BurnInWindowTests.cs
@@ -20,8 +20,26 @@ namespace UITests.Features.Video;
 /// "File size in MB" field) and keeps the preview box taller than its label + player (so the
 /// player can never spill over the audio settings box when the window is shrunk).
 /// </summary>
-public class BurnInWindowTests
+public class BurnInWindowTests : IDisposable
 {
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            // The burn-in window posts its re-fit callback from Opened; flush it while the
+            // window is still alive so it does not run against the disposed platform
+            // implementation during session teardown.
+            Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
     // WindowService only touches the provider when it creates a child window, which this
     // construction test never does.
     private sealed class NullServiceProvider : IServiceProvider
@@ -29,13 +47,15 @@ public class BurnInWindowTests
         public object? GetService(Type serviceType) => null;
     }
 
-    private static BurnInWindow BuildWindow()
+    private BurnInWindow BuildWindow()
     {
         var vm = new BurnInViewModel(
             new FolderHelper(),
             new FileHelper(),
             new WindowService(new NullServiceProvider()));
-        return new BurnInWindow(vm);
+        var window = new BurnInWindow(vm);
+        _windows.Add(window);
+        return window;
     }
 
     /// <summary>Returns the window's root grid (the one holding the progress view).</summary>

--- a/tests/UI/Features/Video/TextToSpeechWindowTests.cs
+++ b/tests/UI/Features/Video/TextToSpeechWindowTests.cs
@@ -17,8 +17,22 @@ namespace UITests.Features.Video;
 /// so a bad grid index or binding only surfaces when the window is instantiated - which no other
 /// test (and no plain app-start smoke run) does.
 /// </summary>
-public class TextToSpeechWindowTests
+public class TextToSpeechWindowTests : IDisposable
 {
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
     // WindowService only touches the provider when it creates a child window, which this
     // construction test never does.
     private sealed class NullServiceProvider : IServiceProvider
@@ -26,14 +40,16 @@ public class TextToSpeechWindowTests
         public object? GetService(Type serviceType) => null;
     }
 
-    private static TextToSpeechWindow BuildWindow()
+    private TextToSpeechWindow BuildWindow()
     {
         var vm = new TextToSpeechViewModel(
             new TtsDownloadService(new HttpClient()),
             new WindowService(new NullServiceProvider()),
             new FileHelper(),
             new FolderHelper());
-        return new TextToSpeechWindow(vm);
+        var window = new TextToSpeechWindow(vm);
+        _windows.Add(window);
+        return window;
     }
 
     private static IEnumerable<Button> AllButtons(TextToSpeechWindow window)

--- a/tests/UI/Logic/Accessibility/EditBoxAccessibilityNameTests.cs
+++ b/tests/UI/Logic/Accessibility/EditBoxAccessibilityNameTests.cs
@@ -62,13 +62,28 @@ public static class TestAppBuilder
 /// The custom controls receive keyboard focus on an inner PART_TextBox, so the name
 /// set on the outer control must be forwarded to that text box (issue #11553).
 /// </summary>
-public class EditBoxAccessibilityNameTests
+public class EditBoxAccessibilityNameTests : IDisposable
 {
-    private static TextBox GetInnerTextBox(Control control)
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private TextBox GetInnerTextBox(Control control)
     {
         // Force the control's template to apply so PART_TextBox exists and the
         // name-forwarding in OnApplyTemplate runs.
         var window = new Window { Content = control, Width = 320, Height = 120 };
+        _windows.Add(window);
         window.Show();
         control.ApplyTemplate();
 

--- a/tests/UI/Logic/Accessibility/ScreenReaderAnnouncementsTests.cs
+++ b/tests/UI/Logic/Accessibility/ScreenReaderAnnouncementsTests.cs
@@ -16,8 +16,22 @@ namespace UITests.Logic.Accessibility;
 /// NVDA silent while Up/Down stepped through combo box values. SE patches the map via reflection
 /// at startup and raises the missing Value change itself.
 /// </summary>
-public class ScreenReaderAnnouncementsTests
+public class ScreenReaderAnnouncementsTests : IDisposable
 {
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
     /// <summary>
     /// Also the upgrade canary: the startup patch is deliberately fail-soft, so this test is what
     /// actually breaks the build when an Avalonia upgrade renames AutomationNode.s_propertyMap or
@@ -46,6 +60,7 @@ public class ScreenReaderAnnouncementsTests
 
         var comboBox = new ComboBox { ItemsSource = new[] { "First", "Second" }, SelectedIndex = 0 };
         var window = new Window { Content = comboBox };
+        _windows.Add(window);
         window.Show();
         Dispatcher.UIThread.RunJobs();
 
@@ -77,6 +92,7 @@ public class ScreenReaderAnnouncementsTests
         var comboBox = new ComboBox { ItemsSource = new[] { "First", "Second" }, SelectedIndex = 0 };
         var textBox = new TextBox();
         var window = new Window { Content = new StackPanel { Children = { comboBox, textBox } } };
+        _windows.Add(window);
         window.Show();
         Dispatcher.UIThread.RunJobs();
 

--- a/tests/UI/Logic/AltMenuAccessKeyResetTests.cs
+++ b/tests/UI/Logic/AltMenuAccessKeyResetTests.cs
@@ -16,9 +16,23 @@ namespace UITests.Logic;
 /// <see cref="UiUtil.RaiseSyntheticAltKeyUp"/> to complete the cycle; these tests pin both the
 /// broken Avalonia behavior (a canary for upstream fixes) and the recovery.
 /// </summary>
-public class AltMenuAccessKeyResetTests
+public class AltMenuAccessKeyResetTests : IDisposable
 {
-    private static Window MakeWindowWithMenu(out Menu menu)
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private Window MakeWindowWithMenu(out Menu menu)
     {
         menu = new Menu { Items = { new MenuItem { Header = "_File" } } };
         var editor = new TextBox();
@@ -26,6 +40,7 @@ public class AltMenuAccessKeyResetTests
         {
             Content = new StackPanel { Children = { menu, editor } },
         };
+        _windows.Add(window);
 
         window.Show();
         Dispatcher.UIThread.RunJobs();

--- a/tests/UI/Logic/ComboBoxDropDownScaleTests.cs
+++ b/tests/UI/Logic/ComboBoxDropDownScaleTests.cs
@@ -12,14 +12,29 @@ namespace UITests.Logic;
 /// style now bakes in the scaled font size. At 100% no style is added at all, so windows
 /// that locally restyle their combos (e.g. the burn-in window's compact 12.5) keep their look.
 /// </summary>
-public class ComboBoxDropDownScaleTests
+public class ComboBoxDropDownScaleTests : IDisposable
 {
-    private static ComboBoxItem FirstDropDownItem(double scaleFactor)
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private ComboBoxItem FirstDropDownItem(double scaleFactor)
     {
         UiTheme.SetLayoutScale(scaleFactor);
 
         var comboBox = new ComboBox { ItemsSource = new[] { "One", "Two" } };
         var window = new Window { Content = comboBox, Width = 300, Height = 200 };
+        _windows.Add(window);
         window.Show();
         window.UpdateLayout();
 

--- a/tests/UI/Logic/CursorPositionOverWindowTests.cs
+++ b/tests/UI/Logic/CursorPositionOverWindowTests.cs
@@ -10,11 +10,26 @@ namespace UITests.Logic;
 /// Avalonia pointer events), so activity must be hit-tested against the window - otherwise
 /// mouse movement in any other app or on another monitor shows the video controls (issue #13207).
 /// </summary>
-public class CursorPositionOverWindowTests
+public class CursorPositionOverWindowTests : IDisposable
 {
-    private static Window ShowWindow()
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private Window ShowWindow()
     {
         var window = new Window { Width = 400, Height = 300 };
+        _windows.Add(window);
         window.Show();
         return window;
     }

--- a/tests/UI/Logic/MoveSelectedRowsTests.cs
+++ b/tests/UI/Logic/MoveSelectedRowsTests.cs
@@ -14,8 +14,22 @@ namespace UITests.Logic;
 /// TableView really ends up selecting the moved rows, and that SelectedItem - which the
 /// view models bind their "current style" to - still points at the anchor row afterwards.
 /// </summary>
-public class MoveSelectedRowsTests
+public class MoveSelectedRowsTests : IDisposable
 {
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
     private sealed class Row
     {
         public Row(string name) => Name = name;
@@ -25,7 +39,7 @@ public class MoveSelectedRowsTests
         public override string ToString() => Name;
     }
 
-    private static (TableView Grid, ObservableCollection<Row> Items) MakeGrid()
+    private (TableView Grid, ObservableCollection<Row> Items) MakeGrid()
     {
         var items = new ObservableCollection<Row>(
             new[] { "a", "b", "c", "d", "e" }.Select(n => new Row(n)));
@@ -35,6 +49,7 @@ public class MoveSelectedRowsTests
         grid.ItemsSource = items;
 
         var window = new Window { Content = grid, Width = 400, Height = 300 };
+        _windows.Add(window);
         window.Show();
         window.UpdateLayout();
         Dispatcher.UIThread.RunJobs();

--- a/tests/UI/Logic/TableViewBindSelectedItemTests.cs
+++ b/tests/UI/Logic/TableViewBindSelectedItemTests.cs
@@ -19,8 +19,22 @@ public partial class ProbeViewModel : ObservableObject
     [ObservableProperty] private string? _selected;
 }
 
-public class TableViewBindSelectedItemTests
+public class TableViewBindSelectedItemTests : IDisposable
 {
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
     private static TableView MakeGrid(params string[] items)
     {
         var grid = TableViewExtras.MakeTableView(multiSelect: false);
@@ -29,9 +43,10 @@ public class TableViewBindSelectedItemTests
         return grid;
     }
 
-    private static void Show(TableView grid)
+    private void Show(TableView grid)
     {
         var window = new Window { Content = grid };
+        _windows.Add(window);
         window.Show();
         Dispatcher.UIThread.RunJobs();
         window.UpdateLayout();

--- a/tests/UI/Logic/TableViewPageNavigationTests.cs
+++ b/tests/UI/Logic/TableViewPageNavigationTests.cs
@@ -13,15 +13,30 @@ namespace UITests.Logic;
 /// are actually on screen - these tests pin the edge-first behavior and that the target row
 /// is always visible, which is what makes it survive variable row heights.
 /// </summary>
-public class TableViewPageNavigationTests
+public class TableViewPageNavigationTests : IDisposable
 {
-    private static TableView Show(IList<string> items, double windowHeight = 300)
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private TableView Show(IList<string> items, double windowHeight = 300)
     {
         var grid = TableViewExtras.MakeTableView(multiSelect: false);
         grid.Columns.Add(new SeTableViewColumn { Binding = new Binding(".") });
         grid.ItemsSource = items;
 
         var window = new Window { Content = grid, Width = 400, Height = windowHeight };
+        _windows.Add(window);
         window.Show();
         Dispatcher.UIThread.RunJobs();
         window.UpdateLayout();

--- a/tests/UI/Logic/TableViewSelectionSyncTests.cs
+++ b/tests/UI/Logic/TableViewSelectionSyncTests.cs
@@ -14,8 +14,22 @@ namespace UITests.Logic;
 /// and time codes went blank and a selection starting at row 1 left row 1 out (issue #13230).
 /// <see cref="TableViewExtras.MakeTableView"/> repairs the collection on every ItemsSource change.
 /// </summary>
-public class TableViewSelectionSyncTests
+public class TableViewSelectionSyncTests : IDisposable
 {
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
     private sealed class Row
     {
         public string Text { get; set; } = string.Empty;
@@ -53,7 +67,7 @@ public class TableViewSelectionSyncTests
     /// The main subtitle grid: multi-select, always selected, with the view model's current row and
     /// index bound two-way - and filled the way SetSubtitles fills it (detach, fill, re-attach).
     /// </summary>
-    private static (TableView Grid, Vm Vm, ObservableCollection<Row> Items) MakeGridWithRows(int rowCount)
+    private (TableView Grid, Vm Vm, ObservableCollection<Row> Items) MakeGridWithRows(int rowCount)
     {
         var items = new ObservableCollection<Row>();
         var vm = new Vm();
@@ -64,7 +78,9 @@ public class TableViewSelectionSyncTests
         grid[!TableView.SelectedItemProperty] = new Binding(nameof(vm.Selected)) { Mode = BindingMode.TwoWay, Source = vm };
         grid[!TableView.SelectedIndexProperty] = new Binding(nameof(vm.SelectedIndex)) { Mode = BindingMode.TwoWay, Source = vm };
 
-        new Window { Width = 400, Height = 300, Content = grid }.Show();
+        var window = new Window { Width = 400, Height = 300, Content = grid };
+        _windows.Add(window);
+        window.Show();
 
         grid.ItemsSource = null;
         for (var i = 1; i <= rowCount; i++)

--- a/tests/UI/Logic/TableViewTextCellFlowDirectionTests.cs
+++ b/tests/UI/Logic/TableViewTextCellFlowDirectionTests.cs
@@ -18,8 +18,22 @@ namespace UITests.Logic;
 /// pieces left to right - Persian words are torn in half and the word order is reversed
 /// (issue #13160, reported for "Point sync via other subtitle").
 /// </summary>
-public class TableViewTextCellFlowDirectionTests
+public class TableViewTextCellFlowDirectionTests : IDisposable
 {
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
     /// <summary>"دیگه نمی‌خوام ببینمت." - one Persian sentence with a ZWNJ inside نمی‌خوام.</summary>
     private const string PersianWithZwnj = "دیگه نمی‌خوام ببینمت.";
 
@@ -65,7 +79,7 @@ public class TableViewTextCellFlowDirectionTests
     /// Builds a one-column grid with the shared text-cell template, shows it, and returns
     /// the realized cell's text block.
     /// </summary>
-    private static TextBlock RealizeTextCell(string text)
+    private TextBlock RealizeTextCell(string text)
     {
         var tableView = TableViewExtras.MakeTableView(multiSelect: false);
         tableView.Columns.Add(new SeTableViewColumn
@@ -82,6 +96,7 @@ public class TableViewTextCellFlowDirectionTests
         };
 
         var window = new Window { Width = 400, Height = 200, Content = tableView };
+        _windows.Add(window);
         window.Show();
         Dispatcher.UIThread.RunJobs();
         window.UpdateLayout();


### PR DESCRIPTION
## Problem
The `Tests / test` workflow fails intermittently: the victim test varies between runs, the tests pass in isolation, and reruns are usually green. The failures cluster around keyboard-driven Avalonia headless tests and around test-session teardown.

The relevant mechanisms are:
1. Keyboard assertions can observe state before queued UI work has settled.
2. Tests set caret/selection state directly before pressing a key, so the control can process the key against stale state.
3. A key sent before focus is established lands on the wrong element or nowhere.
4. Windows that outlive a failed test can race with headless-session teardown.

## Fix
- Track every window created by the affected test classes and close it from `Dispose`, so assertion failures cannot leak a window into the next headless session.
- Wait only for **actual state transitions** after keyboard input, while pumping queued dispatcher work.
- Keep no-op/read-only checks as direct assertions after the synchronous dispatcher/layout settle; these checks must not poll a condition that is already true before the key is handled.
- Require the intended control/grid to own keyboard focus before a key cycle begins, and fail clearly if focus is not acquired.
- Settle the dispatcher and layout after each headless key press so direct caret/selection changes are current before the next step.
- Send every key exactly once. There are no retry loops that could hide an input-routing or focus defect.
- Use a 500 ms transition timeout (1 s for initial editor focus) instead of a 5 s default.

## Verification
- [x] `dotnet build tests/UI/UITests.csproj --nologo -v minimal` — succeeded, 0 warnings, 0 errors
- [x] Targeted `SyntaxTextEditorTests|MainMenuKeyboardActivationTests` filter — 10/10 consecutive runs green, 32/32 tests per run
- [x] Full `tests/UI/UITests.csproj` suite — 3/3 consecutive runs green, 1451 passed / 1 skipped per run
- [x] Window-tracking audit — all 33 window creation sites are tracked (the audit script's two reported mismatches were manually verified false positives: a differently named `popupStandIn` and a multiline `new Window` construction)
- [x] Final diff check is clean; branch contains one commit authored by Ironship

## Known residual (pre-existing, out of scope)
A rare Avalonia headless session teardown race can still report `Test Case Cleanup Failure` / dispatcher thread-affinity errors after the test itself passes. This PR removes leaked test windows as one contributor, but it does not claim to fix that framework-level residual.

## Notes
- Test-only change; no production code and no xUnit configuration changed.
- No tests are disabled or weakened.
- This PR was created with AI assistance, following the repository's AI contributor guidelines.
