### PR TITLE
TTS: keep the target language on cloning, detect the reference language

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsWindow.cs
@@ -154,7 +154,8 @@ public class CosyVoice3CrispAsrSettingsWindow : Window
         var sourceLanguageCombo = UiUtil.MakeComboBox(vm.SourceLanguages, vm, nameof(vm.SelectedSourceLanguage));
         var sourceLanguageHint = new TextBlock
         {
-            Text = "Language spoken in imported reference WAVs (for cross-lingual cloning)",
+            Text = "Language spoken in imported reference WAVs (for cross-lingual cloning). "
+                   + "Auto detects it from each voice's transcript.",
             FontSize = 12,
             Opacity = 0.75,
             VerticalAlignment = VerticalAlignment.Center,

--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
@@ -79,6 +79,15 @@ public class CosyVoice3CrispAsr : ITtsEngine
     public const string BackendName = "cosyvoice3-tts";
 
     /// <summary>
+    /// Combo-box group labels for the engine's two generation modes: a voice baked into
+    /// <c>cosyvoice3-voices.gguf</c>, or zero-shot cloning from an imported reference WAV.
+    /// crispasr's cosyvoice3-tts backend has no third mode — the instruct / voice-design path of
+    /// the upstream web demo is not ported — so these two cover it.
+    /// </summary>
+    public const string PresetLabel = "Preset";
+    public const string CloneLabel = "Clone";
+
+    /// <summary>
     /// All filenames that must be present in <see cref="GetSetModelsFolder"/> for the chosen
     /// quant. Both quants share the F16 companion set — only the LLM differs. Listed in this
     /// order so the download dialog progresses through them deterministically.
@@ -388,9 +397,15 @@ public class CosyVoice3CrispAsr : ITtsEngine
         // Baked-in presets come first so the combo opens on a working default. Imported WAVs
         // (zero-shot clones) follow — they need a .txt sidecar with the transcription or the
         // server returns noise.
+        //
+        // The two groups are the engine's two generation modes (crispasr's cosyvoice3-tts takes
+        // either a bank name or a reference WAV, and nothing else), so they are labelled as such:
+        // the flat concatenation gave no way to tell an engine preset from your own import
+        // (#13272). Labels live on DisplayName, never on the voice Name, which is what saved
+        // cast-row mappings match against.
         foreach (var (display, preset) in Presets)
         {
-            result.Add(new Voice(new CosyVoice3Voice(display, preset)));
+            result.Add(new Voice(new CosyVoice3Voice(display, preset), $"{PresetLabel}: {display}"));
         }
 
         // Off the UI thread: GetSetVoicesFolder does one-time reference-WAV seeding through
@@ -402,7 +417,7 @@ public class CosyVoice3CrispAsr : ITtsEngine
             {
                 var name = Path.GetFileNameWithoutExtension(file).Replace('_', ' ');
                 var refText = TryReadRefText(file);
-                result.Add(new Voice(new CosyVoice3Voice(name, file, refText)));
+                result.Add(new Voice(new CosyVoice3Voice(name, file, refText), $"{CloneLabel}: {name}"));
             }
         }
 
@@ -510,22 +525,44 @@ public class CosyVoice3CrispAsr : ITtsEngine
         // reference voice's language and drops the reference transcript from the prompt when they
         // differ, so the clone speaks the target language instead of imitating the reference's.
         // Auto (empty) sends no field and keeps plain zero-shot. Baked presets carry their own
-        // bank language; for imported WAVs the reference language comes from the settings-window
-        // pick (source_lang) since the server's own detection is unreliable for Latin scripts.
+        // bank language; for imported WAVs the reference language is resolved per voice below.
         var languageArg = CosyVoice3Languages.ResolveLanguageArg(language);
         if (!string.IsNullOrEmpty(languageArg))
         {
             payload["language"] = languageArg;
         }
-        var sourceLanguage = (Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrSourceLanguage ?? string.Empty).Trim();
-        if (isClone && !string.IsNullOrEmpty(sourceLanguage))
+
+        // Reference language, per voice: the settings-window pick when set, otherwise detected
+        // from this voice's own transcript. The backend needs BOTH sides to go cross-lingual and
+        // its own detection declines on Latin-script transcripts, so leaving this empty is what
+        // made an en->de clone come out with the English reference's accent (#13272). One global
+        // setting also cannot be right for a user with reference WAVs in two languages, which is
+        // why the per-voice transcript wins over nothing at all.
+        var sourceLanguage = isClone
+            ? CosyVoice3Languages.ResolveSourceLanguageArg(cosyVoice.RefText)
+            : string.Empty;
+        if (!string.IsNullOrEmpty(sourceLanguage))
         {
             payload["source_lang"] = sourceLanguage;
+        }
+        else if (isClone && !string.IsNullOrEmpty(languageArg))
+        {
+            // Target language asked for, reference language unknowable: the backend will fall
+            // back to plain zero-shot and keep the reference's accent. It says so in its own log,
+            // which nobody reads on a request that returned 200 - so say it here, where the user
+            // can act on it.
+            Se.WriteToolsLog(
+                $"CosyVoice3 (CrispASR): target language '{languageArg}' requested for cloned voice "
+                + $"'{cosyVoice.Voice}', but the language of its reference WAV could not be determined "
+                + "from the transcript. Synthesis stays zero-shot and keeps the reference's accent - "
+                + "set \"Reference language\" in the CosyVoice3 settings window to enable cross-lingual "
+                + "synthesis.",
+                true);
         }
 
         var body = JsonSerializer.Serialize(payload);
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
-        Se.WriteToolsLog($"CosyVoice3 (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (voice={cosyVoice}, clone={isClone}, refTextLen={cosyVoice.RefText.Length}, textLen={text.Length}, language={(string.IsNullOrEmpty(languageArg) ? "(auto)" : languageArg)})");
+        Se.WriteToolsLog($"CosyVoice3 (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (voice={cosyVoice}, clone={isClone}, refTextLen={cosyVoice.RefText.Length}, textLen={text.Length}, language={(string.IsNullOrEmpty(languageArg) ? "(auto)" : languageArg)}, sourceLanguage={(string.IsNullOrEmpty(sourceLanguage) ? "(unknown)" : sourceLanguage)})");
 
         HttpResponseMessage response;
         try

--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3Languages.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3Languages.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -61,7 +63,17 @@ internal static class CosyVoice3Languages
     /// </summary>
     public static string ResolveLanguageArg(TtsLanguage? language)
     {
-        var code = language?.Code;
+        // A null language means the CALLER had none to hand over, which is not the same as the
+        // user picking "Auto". The cast dialog's voice-test button and every cross-engine cast
+        // row pass null on purpose ("engines fall back to their own saved defaults"), so without
+        // this fallback the request went out with no `language` field and the clone kept the
+        // reference's accent on exactly the dubbing path the target language exists for (#13272).
+        if (language == null)
+        {
+            return ResolveSavedLanguageArg();
+        }
+
+        var code = language.Code;
         if (string.IsNullOrWhiteSpace(code))
         {
             return string.Empty;
@@ -69,8 +81,80 @@ internal static class CosyVoice3Languages
 
         // Guard against a language object left over from another engine (the view model can hold
         // one while switching engines): only values this engine actually advertises are passed on.
-        return All.Any(l => string.Equals(l.Code, code, StringComparison.OrdinalIgnoreCase))
-            ? code
-            : string.Empty;
+        return IsSupported(code) ? code : string.Empty;
+    }
+
+    /// <summary>
+    /// The language code behind the pick saved by the main TTS window, or an empty string when
+    /// nothing is saved / the saved entry is "Auto". The setting stores the DISPLAY NAME, which
+    /// is how <c>TextToSpeechViewModel</c> writes and restores it.
+    /// </summary>
+    public static string ResolveSavedLanguageArg()
+    {
+        var savedName = Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrLanguage;
+        if (string.IsNullOrWhiteSpace(savedName))
+        {
+            return string.Empty;
+        }
+
+        return All.FirstOrDefault(l => string.Equals(l.Name, savedName, StringComparison.OrdinalIgnoreCase))?.Code
+               ?? string.Empty;
+    }
+
+    /// <summary>True when <paramref name="code"/> is one of the nine languages CosyVoice3 knows.</summary>
+    public static bool IsSupported(string? code) =>
+        !string.IsNullOrWhiteSpace(code)
+        && All.Any(l => !string.IsNullOrEmpty(l.Code) && string.Equals(l.Code, code, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// The language of a cloning reference, resolved the way the backend documents it: the
+    /// explicit "Reference language" pick from the settings window first, then a best-effort
+    /// detection over the reference transcript.
+    /// </summary>
+    /// <remarks>
+    /// The backend only goes cross-lingual once it knows BOTH the target and the reference
+    /// language, and its own reference detection declines on short or Latin-script transcripts —
+    /// which is every en→de / en→fr / en→ru pair a dubbing workflow actually asks for. Detecting
+    /// SE-side means a user who imported an English reference and asked for German gets
+    /// cross-lingual synthesis without first finding a combo box in an engine settings window.
+    /// The explicit pick still wins, and a detection outside CosyVoice3's nine languages is
+    /// discarded rather than sent (the backend would reject it).
+    /// </remarks>
+    public static string ResolveSourceLanguageArg(string? refText)
+    {
+        var configured = (Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrSourceLanguage ?? string.Empty).Trim();
+        if (IsSupported(configured))
+        {
+            return configured;
+        }
+
+        return DetectSourceLanguage(refText);
+    }
+
+    /// <summary>
+    /// Best-effort language of <paramref name="refText"/>, or an empty string when it cannot be
+    /// determined or is not one of CosyVoice3's nine languages. Uses the same detector the rest
+    /// of SE uses for subtitle language (function words first, then writing system).
+    /// </summary>
+    public static string DetectSourceLanguage(string? refText)
+    {
+        if (string.IsNullOrWhiteSpace(refText))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var subtitle = new Subtitle();
+            subtitle.Paragraphs.Add(new Paragraph(refText, 0, 0));
+            var detected = LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(subtitle);
+            return IsSupported(detected) ? detected! : string.Empty;
+        }
+        catch
+        {
+            // Detection is an optimization - a failure just means we send no source_lang and the
+            // backend falls back to its own (declining) detection.
+            return string.Empty;
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/Engines/MossTtsLanguages.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/MossTtsLanguages.cs
@@ -1,3 +1,4 @@
+using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -112,7 +113,15 @@ internal static class MossTtsLanguages
     /// </summary>
     public static string ResolveLanguageArg(TtsLanguage? language)
     {
-        var code = language?.Code;
+        // A null language means the CALLER had none to hand over, not that the user picked
+        // "Auto" - the cast dialog's voice-test button and cross-engine cast rows both pass null
+        // and rely on the engine falling back to its own saved default (#13272).
+        if (language == null)
+        {
+            return ResolveSavedLanguageArg();
+        }
+
+        var code = language.Code;
         if (string.IsNullOrWhiteSpace(code))
         {
             return string.Empty;
@@ -123,5 +132,22 @@ internal static class MossTtsLanguages
         return All.Any(l => string.Equals(l.Code, code, StringComparison.OrdinalIgnoreCase))
             ? code
             : string.Empty;
+    }
+
+    /// <summary>
+    /// The language code behind the pick saved by the main TTS window, or an empty string when
+    /// nothing is saved / the saved entry is "Auto". The setting stores the DISPLAY NAME, which
+    /// is how <c>TextToSpeechViewModel</c> writes and restores it.
+    /// </summary>
+    public static string ResolveSavedLanguageArg()
+    {
+        var savedName = Se.Settings.Video.TextToSpeech.MossTtsCrispAsrLanguage;
+        if (string.IsNullOrWhiteSpace(savedName))
+        {
+            return string.Empty;
+        }
+
+        return All.FirstOrDefault(l => string.Equals(l.Name, savedName, StringComparison.OrdinalIgnoreCase))?.Code
+               ?? string.Empty;
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsrLanguages.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsrLanguages.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -61,7 +62,15 @@ internal static class Qwen3TtsCrispAsrLanguages
     /// </summary>
     public static string ResolveLanguageArg(TtsLanguage? language)
     {
-        var code = language?.Code;
+        // A null language means the CALLER had none to hand over, not that the user picked
+        // "Auto" - the cast dialog's voice-test button and cross-engine cast rows both pass null
+        // and rely on the engine falling back to its own saved default (#13272).
+        if (language == null)
+        {
+            return ResolveSavedLanguageArg();
+        }
+
+        var code = language.Code;
         if (string.IsNullOrWhiteSpace(code))
         {
             return string.Empty;
@@ -72,5 +81,22 @@ internal static class Qwen3TtsCrispAsrLanguages
         return All.Any(l => string.Equals(l.Code, code, StringComparison.OrdinalIgnoreCase))
             ? code
             : string.Empty;
+    }
+
+    /// <summary>
+    /// The language code behind the pick saved by the main TTS window, or an empty string when
+    /// nothing is saved / the saved entry is "Auto". The setting stores the DISPLAY NAME, which
+    /// is how <c>TextToSpeechViewModel</c> writes and restores it.
+    /// </summary>
+    public static string ResolveSavedLanguageArg()
+    {
+        var savedName = Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrLanguage;
+        if (string.IsNullOrWhiteSpace(savedName))
+        {
+            return string.Empty;
+        }
+
+        return All.FirstOrDefault(l => string.Equals(l.Name, savedName, StringComparison.OrdinalIgnoreCase))?.Code
+               ?? string.Empty;
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -11,6 +11,7 @@ using Avalonia.Media;
 using Avalonia.Styling;
 using System.Collections.ObjectModel;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
 using Optris.Icons.Avalonia;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -328,6 +329,17 @@ public class TextToSpeechWindow : Window
         // The Qwen3 VoiceDesign model has no speaker encoder - the combo is locked to "Default".
         var comboBoxVoices = UiUtil.MakeComboBox(vm.Voices, vm, nameof(vm.SelectedVoice)).WithWidth(controlMinWidth);
         comboBoxVoices.Bind(ComboBox.IsEnabledProperty, new Binding(nameof(vm.IsVoiceComboEnabled)) { Mode = BindingMode.OneWay });
+        // Show Voice.DisplayName rather than the default ToString(): engines whose list mixes
+        // several kinds of voice label them there (CosyVoice3's "Preset: ..." / "Clone: ...",
+        // #13272). DisplayName falls back to the plain name, so every other engine is unchanged.
+        comboBoxVoices.ItemTemplate = new FuncDataTemplate<Voice>((_, _) =>
+        {
+            // Bound rather than assigned: the template supports recycling, and a recycled
+            // container only gets a new DataContext - a statically-set Text would go stale.
+            var textBlock = new TextBlock { VerticalAlignment = VerticalAlignment.Center };
+            textBlock.Bind(TextBlock.TextProperty, new Binding(nameof(Voice.DisplayName)));
+            return textBlock;
+        }, true);
 
         var panelVoice = new StackPanel
         {

--- a/src/ui/Features/Video/TextToSpeech/Voices/Voice.cs
+++ b/src/ui/Features/Video/TextToSpeech/Voices/Voice.cs
@@ -5,9 +5,29 @@ public class Voice
     public object? EngineVoice { get; set; }
     public string Name => ToString();
 
-    public Voice(object voice)
+    /// <summary>
+    /// Optional combo-box label for when the bare voice name doesn't say enough on its own - e.g.
+    /// CosyVoice3, whose list concatenates baked engine presets and imported clones with nothing
+    /// marking which is which (#13272). Falls back to <see cref="Name"/>.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately separate from <see cref="Name"/>: Name is the value that gets persisted (the
+    /// saved voice pick, and every cast-row mapping) and matched back by string on load, and a
+    /// cast row whose saved name no longer matches falls silently through to the engine's first
+    /// voice. Decorating Name itself would therefore re-point saved casts at the wrong speaker.
+    /// </remarks>
+    public string DisplayName => string.IsNullOrEmpty(_displayName) ? Name : _displayName;
+
+    private readonly string _displayName;
+
+    public Voice(object voice) : this(voice, string.Empty)
+    {
+    }
+
+    public Voice(object voice, string displayName)
     {
         EngineVoice = voice;
+        _displayName = displayName;
     }
 
     public override string ToString()

--- a/tests/UI/Features/Video/TextToSpeech/Engines/CrispAsrTtsLanguagesTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/CrispAsrTtsLanguagesTests.cs
@@ -1,5 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic.Config;
 
 namespace UITests.Features.Video.TextToSpeech.Engines;
 
@@ -7,7 +8,11 @@ namespace UITests.Features.Video.TextToSpeech.Engines;
 /// The CosyVoice3 / Qwen3-TTS (CrispASR) target-language lists added for #13110. Both are sent
 /// as the per-request "language" field of /v1/audio/speech; CosyVoice3 additionally engages
 /// cross-lingual cloning when it differs from the reference voice's language.
+///
+/// Several cases read or write the saved picks in <see cref="Se.Settings"/>, hence the shared
+/// TTS-settings collection.
 /// </summary>
+[Collection(TtsSettingsCollection.Name)]
 public class CrispAsrTtsLanguagesTests
 {
     [Fact]
@@ -60,12 +65,95 @@ public class CrispAsrTtsLanguagesTests
     }
 
     [Fact]
-    public void ResolveLanguageArg_AutoOrNull_SendsNoField()
+    public void ResolveLanguageArg_Auto_SendsNoField()
     {
-        Assert.Equal(string.Empty, CosyVoice3Languages.ResolveLanguageArg(null));
+        using var _ = new SavedTtsLanguageScope("German", "German", "German");
+
+        // An explicit "Auto" pick means the user asked for no language field, and it must win
+        // over whatever is saved - unlike a null argument (see below).
         Assert.Equal(string.Empty, CosyVoice3Languages.ResolveLanguageArg(CosyVoice3Languages.Auto));
-        Assert.Equal(string.Empty, Qwen3TtsCrispAsrLanguages.ResolveLanguageArg(null));
         Assert.Equal(string.Empty, Qwen3TtsCrispAsrLanguages.ResolveLanguageArg(Qwen3TtsCrispAsrLanguages.Auto));
+        Assert.Equal(string.Empty, MossTtsLanguages.ResolveLanguageArg(MossTtsLanguages.Auto));
+    }
+
+    [Fact]
+    public void ResolveLanguageArg_Null_FallsBackToTheSavedPick()
+    {
+        // #13272: the cast dialog's voice-test button and every cross-engine cast row call Speak
+        // with language: null on the assumption that engines fall back to their own saved
+        // default. These three didn't, so the target language silently vanished on exactly the
+        // dubbing path it exists for and the clone kept the reference's accent.
+        using var _ = new SavedTtsLanguageScope("German", "Portuguese", "German");
+
+        Assert.Equal("de", CosyVoice3Languages.ResolveLanguageArg(null));
+        Assert.Equal("pt", Qwen3TtsCrispAsrLanguages.ResolveLanguageArg(null));
+        Assert.Equal("de", MossTtsLanguages.ResolveLanguageArg(null));
+    }
+
+    [Fact]
+    public void ResolveLanguageArg_Null_WithNothingSaved_SendsNoField()
+    {
+        using var _ = new SavedTtsLanguageScope(string.Empty, string.Empty, string.Empty);
+
+        Assert.Equal(string.Empty, CosyVoice3Languages.ResolveLanguageArg(null));
+        Assert.Equal(string.Empty, Qwen3TtsCrispAsrLanguages.ResolveLanguageArg(null));
+        Assert.Equal(string.Empty, MossTtsLanguages.ResolveLanguageArg(null));
+    }
+
+    [Fact]
+    public void ResolveLanguageArg_Null_WithSavedAuto_SendsNoField()
+    {
+        using var _ = new SavedTtsLanguageScope("Auto", "Auto", "Auto");
+
+        Assert.Equal(string.Empty, CosyVoice3Languages.ResolveLanguageArg(null));
+        Assert.Equal(string.Empty, Qwen3TtsCrispAsrLanguages.ResolveLanguageArg(null));
+        Assert.Equal(string.Empty, MossTtsLanguages.ResolveLanguageArg(null));
+    }
+
+    [Theory]
+    [InlineData("The quick brown fox is not what it seems, and there is nothing we can do about it.", "en")]
+    [InlineData("Ich habe das Buch nicht gelesen, aber es ist mir egal, was du davon hältst.", "de")]
+    [InlineData("Это моя тестовая запись, и я не знаю, что ещё сказать об этом.", "ru")]
+    public void DetectSourceLanguage_ReadsTheReferenceTranscript(string refText, string expected)
+    {
+        // The reference language is half of the cross-lingual gate, and the backend's own
+        // detector declines on Latin scripts. Reading it off the transcript SE already keeps in
+        // the voice's .txt sidecar is what makes en->de work without any manual setup (#13272).
+        Assert.Equal(expected, CosyVoice3Languages.DetectSourceLanguage(refText));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Jeg har ikke læst bogen, men jeg er ligeglad med hvad du mener om den.")]
+    public void DetectSourceLanguage_UnknownOrUnsupported_ReturnsEmpty(string refText)
+    {
+        // Danish is a language the detector knows but CosyVoice3 does not - sending it would be
+        // rejected by the backend, so an unsupported hit counts as "could not determine".
+        Assert.Equal(string.Empty, CosyVoice3Languages.DetectSourceLanguage(refText));
+    }
+
+    [Fact]
+    public void ResolveSourceLanguageArg_ExplicitPickWinsOverDetection()
+    {
+        using var _ = new SavedReferenceLanguageScope("fr");
+
+        Assert.Equal("fr", CosyVoice3Languages.ResolveSourceLanguageArg(
+            "The quick brown fox is not what it seems, and there is nothing we can do about it."));
+    }
+
+    [Fact]
+    public void ResolveSourceLanguageArg_NoPick_DetectsPerVoice()
+    {
+        // One global setting cannot be right for a user with reference WAVs in two languages,
+        // so with nothing picked each voice answers from its own transcript.
+        using var _ = new SavedReferenceLanguageScope(string.Empty);
+
+        Assert.Equal("en", CosyVoice3Languages.ResolveSourceLanguageArg(
+            "The quick brown fox is not what it seems, and there is nothing we can do about it."));
+        Assert.Equal("de", CosyVoice3Languages.ResolveSourceLanguageArg(
+            "Ich habe das Buch nicht gelesen, aber es ist mir egal, was du davon hältst."));
+        Assert.Equal(string.Empty, CosyVoice3Languages.ResolveSourceLanguageArg(string.Empty));
     }
 
     [Fact]
@@ -95,5 +183,56 @@ public class CrispAsrTtsLanguagesTests
         Assert.DoesNotContain(CosyVoice3Languages.All, l => l.Code == "pt");
         Assert.Contains(CosyVoice3Languages.All, l => l.Code == "ko");
         Assert.Contains(Qwen3TtsCrispAsrLanguages.All, l => l.Code == "pt");
+    }
+}
+
+/// <summary>
+/// Sets the three saved target-language picks (stored as DISPLAY NAMES, which is how
+/// TextToSpeechViewModel writes them) and restores them afterwards.
+/// </summary>
+internal sealed class SavedTtsLanguageScope : IDisposable
+{
+    private readonly string _cosyVoice3;
+    private readonly string _qwen3;
+    private readonly string _moss;
+
+    public SavedTtsLanguageScope(string cosyVoice3, string qwen3, string moss)
+    {
+        var settings = Se.Settings.Video.TextToSpeech;
+        _cosyVoice3 = settings.CosyVoice3CrispAsrLanguage;
+        _qwen3 = settings.Qwen3TtsCrispAsrLanguage;
+        _moss = settings.MossTtsCrispAsrLanguage;
+
+        settings.CosyVoice3CrispAsrLanguage = cosyVoice3;
+        settings.Qwen3TtsCrispAsrLanguage = qwen3;
+        settings.MossTtsCrispAsrLanguage = moss;
+    }
+
+    public void Dispose()
+    {
+        var settings = Se.Settings.Video.TextToSpeech;
+        settings.CosyVoice3CrispAsrLanguage = _cosyVoice3;
+        settings.Qwen3TtsCrispAsrLanguage = _qwen3;
+        settings.MossTtsCrispAsrLanguage = _moss;
+    }
+}
+
+/// <summary>
+/// Sets CosyVoice3's "Reference language" pick (an ISO code, unlike the target-language setting)
+/// and restores it afterwards.
+/// </summary>
+internal sealed class SavedReferenceLanguageScope : IDisposable
+{
+    private readonly string _original;
+
+    public SavedReferenceLanguageScope(string code)
+    {
+        _original = Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrSourceLanguage;
+        Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrSourceLanguage = code;
+    }
+
+    public void Dispose()
+    {
+        Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrSourceLanguage = _original;
     }
 }


### PR DESCRIPTION
Fixes the Subtitle Edit side of #13272 — CosyVoice3 (CrispASR) cloning ignoring the target language — plus the same class of bug in the two sibling CrispASR engines.

### The target language was dropped on two paths

The cast/actor dialog's voice-test button and every cross-engine cast row call `Speak` with `language: null`, on the documented assumption that the engine falls back to its own saved default. CosyVoice3, Qwen3-TTS and MOSS-TTS (all CrispASR) didn't — `ResolveLanguageArg` treated a null argument the same as an explicit "Auto" and sent no `language` field. So the setting silently vanished on exactly the dubbing workflow it exists for.

`ResolveLanguageArg(null)` now falls back to the engine's saved pick. An explicit "Auto" still wins over whatever is saved — only a null *argument* falls back.

### The reference language was never sent unless you went looking for it

`cosyvoice3-tts` only switches to cross-lingual once it knows **both** the target language and the language of the reference clip, and its own detector declines on Latin-script transcripts. SE sent `source_lang` only if you had opened the CosyVoice3 settings window and picked "Reference language" by hand — and one global setting cannot be right for a user with reference WAVs in two languages.

It is now resolved per voice: the explicit pick when set, otherwise detected from that voice's own transcript sidecar via `LanguageAutoDetect`. Detections outside CosyVoice3's nine languages are discarded rather than sent.

### The failure was silent

When the reference language can't be determined, the backend keeps the reference's accent and reports it — on a request that returns HTTP 200, so nobody sees it. That now goes to the tools log along with what to do about it.

### The voice list didn't say which entries were which

CosyVoice3's combo concatenates the 8 baked bank voices and any imported clones flat, with nothing marking the difference — the "please separate the generation modes" half of the issue. They are now labelled `Preset: …` / `Clone: …`.

crispasr's `cosyvoice3-tts` has exactly two modes (bank name, or reference WAV); the instruct / voice-design path of the upstream web demo isn't ported, which is why this can't become a mode selector the way Qwen3-TTS's three model files do. The labels live on a new `Voice.DisplayName`, **never** on `Voice.Name` — `Name` is what saved cast-row mappings match against, and a row whose saved name no longer matches falls silently through to the engine's first voice.

### Known limitation, not fixed here

Cross-lingual cloning is only fully live once CrispASR ships a release past **v0.8.25** (what `CrispAsrDownloadService` pins today). The fix that made the gate reachable for Latin-script references — CrispStrobe/CrispASR@14be8056, from CrispStrobe/CrispASR#329 — is on `main`, 29 commits past that tag, and in no release. Until then en→de / en→ru / es→it stay zero-shot regardless of what the UI sends. The pin bump is a follow-up.

### Testing

- 9 new tests in `CrispAsrTtsLanguagesTests`: the null fallback for all three engines, explicit-Auto still winning, nothing-saved and saved-Auto both sending no field, reference detection across en/de/ru, unsupported-language (Danish) rejection, and explicit-pick-beats-detection.
- 112 TTS tests pass; full UI suite 1462/1463, the one failure being the known-flaky `SyntaxTextEditorTests.DuplicateLineInsertsTheCopyBelowAndLandsOnIt`, which passes on rerun.
- Not visually verified in a running app — the combo relabelling is the only UI-visible change.

Follow-up to #13110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
