### PR TITLE
Fix 12 bugs found reviewing today's commits

### DIFF
--- a/docs/features/ocr.md
+++ b/docs/features/ocr.md
@@ -56,9 +56,10 @@ Local LLM-based OCR using a llama.cpp-compatible server.
 
 ### CrispEmbed
 Local OCR engine with multiple model backends (free/open source).
-- Backends: **PP-OCRv6**, **GLM-OCR**, **GOT-OCR2**, and **Qwen3-VL-2B**
+- Backends: **PP-OCRv6**, **GLM-OCR**, **GOT-OCR2**, **Qwen3-VL-2B**, and **DeepSeek-OCR-2**
 - **PP-OCRv6** is a text detector plus recognizer rather than a vision language model, so it needs only two small files (about 79 MB in total) and is the quickest way to get started
-- The other backends each offer a smaller `q4_k` and a higher-quality `q8_0` model (from about 445 MB for GOT-OCR2 q4_k up to about 2.3 GB for Qwen3-VL-2B q8_0)
+- **DeepSeek-OCR-2** is the most accurate backend on subtitle-style images; it ships a single `q4_k` model of about 2.31 GB
+- **GLM-OCR**, **GOT-OCR2** and **Qwen3-VL-2B** each offer a smaller `q4_k` and a higher-quality `q8_0` model (from about 445 MB for GOT-OCR2 q4_k up to about 2.29 GB for Qwen3-VL-2B q8_0)
 - The engine and models are downloaded from the OCR window on first use
 
 ### Mistral OCR

--- a/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
@@ -1603,8 +1603,13 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                 {
                     // skip empty and comment lines
                 }
-                else if (trimmedLine.StartsWith("dialog:", StringComparison.OrdinalIgnoreCase) || trimmedLine.StartsWith("dialogue:", StringComparison.OrdinalIgnoreCase))
+                else if (trimmedLine.StartsWith("dialog:", StringComparison.OrdinalIgnoreCase) ||
+                         trimmedLine.StartsWith("dialogue:", StringComparison.OrdinalIgnoreCase) ||
+                         trimmedLine.StartsWith("comment:", StringComparison.OrdinalIgnoreCase))
                 {
+                    // "Comment:" also starts the event section: a header-less payload (the
+                    // clipboard carries bare event lines) can begin with a commented event,
+                    // and without this those lines never reach the event parser (#10476).
                     eventsStarted = true;
                     fontsStarted = false;
                     graphicsStarted = false;

--- a/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
@@ -1592,13 +1592,6 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                 lineNumber++;
                 var trimmedLine = line.Trim();
 
-                if (!eventsStarted && !fontsStarted && !graphicsStarted &&
-                    !trimmedLine.Equals("[fonts]", StringComparison.InvariantCultureIgnoreCase) &&
-                    !trimmedLine.Equals("[graphics]", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    header.AppendLine(line);
-                }
-
                 if (string.IsNullOrWhiteSpace(line) || trimmedLine.StartsWith(';'))
                 {
                     // skip empty and comment lines
@@ -1610,9 +1603,20 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                     // "Comment:" also starts the event section: a header-less payload (the
                     // clipboard carries bare event lines) can begin with a commented event,
                     // and without this those lines never reach the event parser (#10476).
+                    //
+                    // Runs before the header append below so an event line is never captured
+                    // as header content - in a normal file the [Events] section header has
+                    // already set eventsStarted, so nothing changes there.
                     eventsStarted = true;
                     fontsStarted = false;
                     graphicsStarted = false;
+                }
+
+                if (!eventsStarted && !fontsStarted && !graphicsStarted &&
+                    !trimmedLine.Equals("[fonts]", StringComparison.InvariantCultureIgnoreCase) &&
+                    !trimmedLine.Equals("[graphics]", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    header.AppendLine(line);
                 }
 
                 if (trimmedLine.Equals("[events]", StringComparison.OrdinalIgnoreCase))

--- a/src/libse/SubtitleFormats/SubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/SubStationAlpha.cs
@@ -413,6 +413,19 @@ Format: Marked, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
                     header.AppendLine(line);
                 }
 
+                // An event line also starts the event section, so a header-less payload (the
+                // clipboard carries bare event lines) still parses. Set before the section
+                // chain below so this same line is then parsed as an event (#10476).
+                if (!eventsStarted && !string.IsNullOrEmpty(line) &&
+                    (line.TrimStart().StartsWith("dialogue:", StringComparison.OrdinalIgnoreCase) ||
+                     line.TrimStart().StartsWith("dialog:", StringComparison.OrdinalIgnoreCase) ||
+                     line.TrimStart().StartsWith("comment:", StringComparison.OrdinalIgnoreCase)))
+                {
+                    eventsStarted = true;
+                    fontsStarted = false;
+                    graphicsStarted = false;
+                }
+
                 if (!string.IsNullOrEmpty(line) && line.TrimStart().StartsWith(';'))
                 {
                     // skip comment lines

--- a/src/libse/SubtitleFormats/SubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/SubStationAlpha.cs
@@ -408,14 +408,11 @@ Format: Marked, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
             {
                 var line = lines[i1];
                 lineNumber++;
-                if (!eventsStarted)
-                {
-                    header.AppendLine(line);
-                }
-
                 // An event line also starts the event section, so a header-less payload (the
-                // clipboard carries bare event lines) still parses. Set before the section
-                // chain below so this same line is then parsed as an event (#10476).
+                // clipboard carries bare event lines) still parses. Runs before the header
+                // append below so the event line is parsed as an event rather than captured
+                // as header content; in a normal file [Events] has already set eventsStarted,
+                // so nothing changes there (#10476).
                 if (!eventsStarted && !string.IsNullOrEmpty(line) &&
                     (line.TrimStart().StartsWith("dialogue:", StringComparison.OrdinalIgnoreCase) ||
                      line.TrimStart().StartsWith("dialog:", StringComparison.OrdinalIgnoreCase) ||
@@ -424,6 +421,11 @@ Format: Marked, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
                     eventsStarted = true;
                     fontsStarted = false;
                     graphicsStarted = false;
+                }
+
+                if (!eventsStarted)
+                {
+                    header.AppendLine(line);
                 }
 
                 if (!string.IsNullOrEmpty(line) && line.TrimStart().StartsWith(';'))

--- a/src/libse/SubtitleFormats/WebVTT.cs
+++ b/src/libse/SubtitleFormats/WebVTT.cs
@@ -197,7 +197,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 !string.IsNullOrEmpty(GetPositionInfoRaw(p.Style)) &&
                 GetPositionInfo(p.Style) == (currentTag ?? string.Empty))
             {
-                positionInfo = p.Style.Trim();
+                // "region:" is written separately by the caller, so drop it here - otherwise a
+                // cue that listed it after the other settings ("line:10% region:r1") is saved
+                // with the region twice.
+                positionInfo = RemoveCueSetting(p.Style, "region:").Trim();
             }
 
             return (" " + positionInfo).TrimEnd();
@@ -693,6 +696,28 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             var region = GetTag(s, "region:");
             return region;
+        }
+
+        /// <summary>
+        /// Removes a "name:value" cue setting (and its trailing space) from a raw cue settings
+        /// string, leaving the other settings untouched.
+        /// </summary>
+        internal static string RemoveCueSetting(string s, string tag)
+        {
+            if (string.IsNullOrEmpty(s))
+            {
+                return s;
+            }
+
+            var pos = s.IndexOf(tag, StringComparison.Ordinal);
+            if (pos < 0)
+            {
+                return s;
+            }
+
+            var end = s.IndexOf(' ', pos);
+            var result = end < 0 ? s.Remove(pos) : s.Remove(pos, end - pos + 1);
+            return result.Trim();
         }
 
         private static string GetTag(string s, string tag)

--- a/src/libuilogic/Media/FfmpegMediaInfo.cs
+++ b/src/libuilogic/Media/FfmpegMediaInfo.cs
@@ -35,6 +35,10 @@ namespace Nikse.SubtitleEdit.UiLogic.Media
         private static partial Regex Fps2RegexGen();
         private static readonly Regex Fps2Regex = Fps2RegexGen();
 
+        [GeneratedRegex(@"^Stream #\d+:(\d+)")]
+        private static partial Regex StreamIndexRegexGen();
+        private static readonly Regex StreamIndexRegex = StreamIndexRegexGen();
+
         private FfmpegMediaInfo()
         {
             Tracks = new List<FfmpegTrackInfo>();
@@ -61,20 +65,29 @@ namespace Nikse.SubtitleEdit.UiLogic.Media
             return (long)((double)FramesRate * Duration.TotalMilliseconds / TimeCode.BaseUnit);
         }
 
-        public bool HasFrontCenterAudio(int trackNumber)
+        /// <summary>
+        /// True when the given audio track is 5.1/7.1/9.1 and therefore has a front-center
+        /// channel. <paramref name="streamIndex"/> is the global ffmpeg stream index (the N in
+        /// "Stream #0:N" / "-map 0:N"), which is what every caller has; a negative value means
+        /// "no specific track" and falls back to the first audio track.
+        /// </summary>
+        public bool HasFrontCenterAudio(int streamIndex)
         {
-            if (trackNumber < 0)
-            {
-                trackNumber = 0;
-            }
-
             var audioTracks = Tracks.Where(track => track.TrackType == FfmpegTrackType.Audio).ToList();
-            if (trackNumber >= audioTracks.Count)
+            if (audioTracks.Count == 0)
             {
                 return false;
             }
 
-            var info = audioTracks[trackNumber].TrackInfo;
+            var track = streamIndex < 0
+                ? audioTracks[0]
+                : audioTracks.FirstOrDefault(t => t.StreamIndex == streamIndex);
+            if (track == null)
+            {
+                return false;
+            }
+
+            var info = track.TrackInfo;
             return info.Contains("5.1", StringComparison.Ordinal) ||
                    info.Contains("7.1", StringComparison.Ordinal) ||
                    info.Contains("9.1", StringComparison.Ordinal);
@@ -121,21 +134,27 @@ namespace Nikse.SubtitleEdit.UiLogic.Media
                     {
                         var trackType = arr[1].Trim();
                         var trackInfo = arr[2].Trim();
+                        var streamIndexMatch = StreamIndexRegex.Match(s);
+                        var streamIndex = streamIndexMatch.Success &&
+                                          int.TryParse(streamIndexMatch.Groups[1].Value, out var si)
+                            ? si
+                            : -1;
+
                         if (trackType == FfmpegTrackType.Audio.ToString())
                         {
-                            info.Tracks.Add(new FfmpegTrackInfo { TrackType = FfmpegTrackType.Audio, TrackInfo = trackInfo });
+                            info.Tracks.Add(new FfmpegTrackInfo { TrackType = FfmpegTrackType.Audio, TrackInfo = trackInfo, StreamIndex = streamIndex });
                         }
                         else if (trackType == FfmpegTrackType.Video.ToString())
                         {
-                            info.Tracks.Add(new FfmpegTrackInfo { TrackType = FfmpegTrackType.Video, TrackInfo = trackInfo });
+                            info.Tracks.Add(new FfmpegTrackInfo { TrackType = FfmpegTrackType.Video, TrackInfo = trackInfo, StreamIndex = streamIndex });
                         }
                         else if (trackType == FfmpegTrackType.Subtitle.ToString())
                         {
-                            info.Tracks.Add(new FfmpegTrackInfo { TrackType = FfmpegTrackType.Subtitle, TrackInfo = trackInfo });
+                            info.Tracks.Add(new FfmpegTrackInfo { TrackType = FfmpegTrackType.Subtitle, TrackInfo = trackInfo, StreamIndex = streamIndex });
                         }
                         else
                         {
-                            info.Tracks.Add(new FfmpegTrackInfo { TrackType = FfmpegTrackType.Other, TrackInfo = trackInfo });
+                            info.Tracks.Add(new FfmpegTrackInfo { TrackType = FfmpegTrackType.Other, TrackInfo = trackInfo, StreamIndex = streamIndex });
                         }
                     }
                 }

--- a/src/libuilogic/Media/FfmpegTrackInfo.cs
+++ b/src/libuilogic/Media/FfmpegTrackInfo.cs
@@ -12,6 +12,10 @@ namespace Nikse.SubtitleEdit.UiLogic.Media
         // "Stream #0:N(LANG): TYPE:" prefix. Empty when ffmpeg did not report one.
         public string Language { get; set; } = string.Empty;
 
+        // The global ffmpeg stream index N from "Stream #0:N" - the same number used in
+        // "-map 0:N". -1 when ffmpeg did not report one.
+        public int StreamIndex { get; set; } = -1;
+
         public int BitRate
         {
             get

--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -2881,12 +2881,19 @@ public class AudioVisualizer : Control
     // interpolations, and the CPS label another format - per visible paragraph per frame, only
     // to look up an already-shaped FormattedText. Keyed on the values so a hit allocates nothing;
     // the frame-mode flag is part of the key because ToShortDisplayString switches on it.
-    private readonly Dictionary<(int Number, long DurationMs, bool FrameMode), string> _footerNumberDurationCache = new(512);
+    private readonly Dictionary<(int Number, long DurationMs, bool FrameMode, double FrameRate), string> _footerNumberDurationCache = new(512);
     private readonly Dictionary<double, string> _footerCpsCache = new(256);
 
     private string GetCachedNumberAndDurationLabel(SubtitleLineViewModel paragraph)
     {
-        var key = (paragraph.Number, (long)paragraph.Duration.TotalMilliseconds, Se.Settings.General.UseFrameMode);
+        // The frame rate is part of the key: in frame mode ToShortDisplayString renders frames
+        // via Configuration.Settings.General.CurrentFrameRate, so the same duration maps to a
+        // different label after the user changes the project frame rate.
+        var frameMode = Se.Settings.General.UseFrameMode;
+        var key = (paragraph.Number,
+                   (long)paragraph.Duration.TotalMilliseconds,
+                   frameMode,
+                   frameMode ? Configuration.Settings.General.CurrentFrameRate : 0);
         if (!_footerNumberDurationCache.TryGetValue(key, out var label))
         {
             // Same cap as the other per-frame text caches - the key includes the duration, so at
@@ -3879,6 +3886,8 @@ public class AudioVisualizer : Control
         _timeLineTextCache.Clear();
         _paragraphFormattedTextCache.Clear();
         _paragraphTextCache.Clear();
+        _footerNumberDurationCache.Clear();
+        _footerCpsCache.Clear();
         _waveformCacheValid = false;
         _gridLinesGeometry = null;
         _timeLineCacheValid = false;

--- a/src/ui/Features/Files/ExportCustomTextFormat/ExportCustomTextFormatViewModel.cs
+++ b/src/ui/Features/Files/ExportCustomTextFormat/ExportCustomTextFormatViewModel.cs
@@ -153,7 +153,11 @@ public partial class ExportCustomTextFormatViewModel : ObservableObject
             return;
         }
 
-        await System.IO.File.WriteAllTextAsync(fileName, PreviewText, SelectedEncoding?.Encoding ?? Encoding.UTF8);
+        // Resolve via the display name, not TextEncoding.Encoding: that property is plain
+        // Encoding.UTF8 (which emits a BOM) for both "UTF-8 with BOM" and "UTF-8 without BOM",
+        // so writing it directly would always add a BOM.
+        var encoding = EncodingHelper.ResolveEncoding(SelectedEncoding?.DisplayName, null);
+        await System.IO.File.WriteAllTextAsync(fileName, PreviewText, encoding);
     }
 
     [RelayCommand]

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -16130,7 +16130,7 @@ public partial class MainViewModel :
 
             if (FileUtil.IsMatroskaFileFast(fileName) && FileUtil.IsMatroskaFile(fileName))
             {
-                if (await ImportSubtitleFromMatroskaFile(fileName, videoFileName))
+                if (await ImportSubtitleFromMatroskaFile(fileName, videoFileName, skipLoadVideo))
                 {
                     return;
                 }
@@ -16205,7 +16205,7 @@ public partial class MainViewModel :
             {
                 if (!new IsmtDfxp().IsMine(null, fileName))
                 {
-                    var ok = await ImportSubtitleFromMp4(fileName);
+                    var ok = await ImportSubtitleFromMp4(fileName, skipLoadVideo);
                     if (ok)
                     {
                         return;
@@ -16215,7 +16215,7 @@ public partial class MainViewModel :
 
             if ((ext == ".ts" || ext == ".tsv" || ext == ".tts" || ext == ".rec" || ext == ".mpeg" || ext == ".mpg") && fileSize > 10000 && FileUtil.IsTransportStream(fileName))
             {
-                await ImportSubtitleFromTransportStream(fileName);
+                await ImportSubtitleFromTransportStream(fileName, skipLoadVideo);
                 return;
             }
 
@@ -16232,14 +16232,14 @@ public partial class MainViewModel :
 
                 if (!isTextSt)
                 {
-                    await ImportSubtitleFromTransportStream(fileName);
+                    await ImportSubtitleFromTransportStream(fileName, skipLoadVideo);
                     return;
                 }
             }
 
             if (FileUtil.IsVobSub(fileName) && ext == ".sub")
             {
-                var ok = await ImportSubtitleFromVobSubFile(fileName, videoFileName);
+                var ok = await ImportSubtitleFromVobSubFile(fileName, videoFileName, skipLoadVideo);
                 if (ok)
                 {
                     SelectAndScrollToRow(0);
@@ -16253,7 +16253,7 @@ public partial class MainViewModel :
                 var subFile = Path.ChangeExtension(fileName, ".sub");
                 if (File.Exists(subFile) && FileUtil.IsVobSub(subFile))
                 {
-                    var ok = await ImportSubtitleFromVobSubFile(subFile, videoFileName);
+                    var ok = await ImportSubtitleFromVobSubFile(subFile, videoFileName, skipLoadVideo);
                     if (ok)
                     {
                         SelectAndScrollToRow(0);
@@ -16272,13 +16272,13 @@ public partial class MainViewModel :
 
                     if (_subtitle.OriginalFormat?.Name == new TimedTextBase64Image().Name)
                     {
-                        ImportAndInlineBase64(_subtitle, fileName);
+                        ImportAndInlineBase64(_subtitle, fileName, skipLoadVideo);
                         return;
                     }
 
                     if (_subtitle.OriginalFormat?.Name == new TimedTextImage().Name)
                     {
-                        ImportAndOcrDost(fileName, _subtitle);
+                        ImportAndOcrDost(fileName, _subtitle, skipLoadVideo);
                         return;
                     }
 
@@ -16318,7 +16318,7 @@ public partial class MainViewModel :
 
             if (ext == ".divx" || ext == ".avi")
             {
-                if (ImportSubtitleFromDivX(fileName))
+                if (ImportSubtitleFromDivX(fileName, skipLoadVideo))
                 {
                     return;
                 }
@@ -16373,7 +16373,7 @@ public partial class MainViewModel :
                 {
                     subtitle = new Subtitle();
                     format.LoadSubtitle(subtitle, lines, fileName);
-                    ImportAndOcrWebVttImages(fileName, subtitle);
+                    ImportAndOcrWebVttImages(fileName, subtitle, skipLoadVideo);
                     return;
                 }
             }
@@ -16382,7 +16382,7 @@ public partial class MainViewModel :
             {
                 if (FileUtil.IsSpDvdSup(fileName))
                 {
-                    ImportAndOcrSpDvdSup(fileName);
+                    ImportAndOcrSpDvdSup(fileName, skipLoadVideo);
                     return;
                 }
 
@@ -16831,7 +16831,7 @@ public partial class MainViewModel :
         }
     }
 
-    private bool ImportSubtitleFromDivX(string fileName)
+    private bool ImportSubtitleFromDivX(string fileName, bool skipLoadVideo = false)
     {
         var list = DivXSubParser.ImportSubtitleFromDivX(fileName);
         if (list.Count == 0)
@@ -16845,7 +16845,7 @@ public partial class MainViewModel :
 
             if (result.OkPressed)
             {
-                await FinishOcrImportAsync(fileName, result.OcredSubtitle);
+                await FinishOcrImportAsync(fileName, result.OcredSubtitle, skipLoadVideo: skipLoadVideo);
             }
         });
 
@@ -16882,7 +16882,7 @@ public partial class MainViewModel :
         }
     }
 
-    private void ImportAndOcrDost(string fileName, Subtitle subtitle)
+    private void ImportAndOcrDost(string fileName, Subtitle subtitle, bool skipLoadVideo = false)
     {
         Dispatcher.UIThread.Post(async () =>
         {
@@ -16890,12 +16890,12 @@ public partial class MainViewModel :
 
             if (result.OkPressed)
             {
-                await FinishOcrImportAsync(fileName, result.OcredSubtitle);
+                await FinishOcrImportAsync(fileName, result.OcredSubtitle, skipLoadVideo: skipLoadVideo);
             }
         });
     }
 
-    private void ImportAndOcrWebVttImages(string fileName, Subtitle subtitle)
+    private void ImportAndOcrWebVttImages(string fileName, Subtitle subtitle, bool skipLoadVideo = false)
     {
         Dispatcher.UIThread.Post(async () =>
         {
@@ -16903,12 +16903,12 @@ public partial class MainViewModel :
 
             if (result.OkPressed)
             {
-                await FinishOcrImportAsync(fileName, result.OcredSubtitle);
+                await FinishOcrImportAsync(fileName, result.OcredSubtitle, skipLoadVideo: skipLoadVideo);
             }
         });
     }
 
-    private void ImportAndOcrSpDvdSup(string fileName)
+    private void ImportAndOcrSpDvdSup(string fileName, bool skipLoadVideo = false)
     {
         Dispatcher.UIThread.Post(async () =>
         {
@@ -16916,12 +16916,12 @@ public partial class MainViewModel :
 
             if (result.OkPressed)
             {
-                await FinishOcrImportAsync(fileName, result.OcredSubtitle);
+                await FinishOcrImportAsync(fileName, result.OcredSubtitle, skipLoadVideo: skipLoadVideo);
             }
         });
     }
 
-    private void ImportAndInlineBase64(Subtitle subtitle, string fileName)
+    private void ImportAndInlineBase64(Subtitle subtitle, string fileName, bool skipLoadVideo = false)
     {
         IList<IBinaryParagraphWithPosition> list = [];
         foreach (var p in subtitle.Paragraphs)
@@ -16962,7 +16962,7 @@ public partial class MainViewModel :
 
             if (result.OkPressed)
             {
-                await FinishOcrImportAsync(fileName, result.OcredSubtitle);
+                await FinishOcrImportAsync(fileName, result.OcredSubtitle, skipLoadVideo: skipLoadVideo);
             }
         });
     }
@@ -16987,7 +16987,7 @@ public partial class MainViewModel :
         }
     }
 
-    private async Task ImportSubtitleFromTransportStream(string fileName)
+    private async Task ImportSubtitleFromTransportStream(string fileName, bool skipLoadVideo = false)
     {
         ShowStatus(string.Format(Se.Language.General.ParsingXDotDotDot, fileName));
         var tsParser = new TransportStreamParser();
@@ -17072,7 +17072,7 @@ public partial class MainViewModel :
             {
                 // The transport stream itself is the video - the teletext branch above already
                 // opens it, the DVB one used to leave the player empty.
-                await FinishOcrImportAsync(fileName, result.OcredSubtitle, sourceIsVideo: true);
+                await FinishOcrImportAsync(fileName, result.OcredSubtitle, sourceIsVideo: true, skipLoadVideo: skipLoadVideo);
             }
         });
 
@@ -17093,7 +17093,7 @@ public partial class MainViewModel :
         _lastProgressPercent = percent;
     }
 
-    private async Task<bool> ImportSubtitleFromMp4(string fileName)
+    private async Task<bool> ImportSubtitleFromMp4(string fileName, bool skipLoadVideo = false)
     {
         var mp4Parser = new MP4Parser(fileName);
         var mp4SubtitleTracks = mp4Parser.GetSubtitleTracks();
@@ -17158,7 +17158,7 @@ public partial class MainViewModel :
         {
             var hasVideoTrack = mp4Parser.GetVideoTracks().Count > 0;
             var track = mp4SubtitleTracks[0];
-            LoadMp4Subtitle(fileName, track, hasVideoTrack);
+            LoadMp4Subtitle(fileName, track, hasVideoTrack, skipLoadVideo);
 
             // An image track opens the video itself once OCR is done - opening it here too would
             // only get it closed again by the VideoCloseFile() at the start of the OCR import.
@@ -17177,7 +17177,7 @@ public partial class MainViewModel :
             if (result.OkPressed && result.SelectedTrack != null && result.SelectedTrack.Track != null)
             {
                 var hasVideoTrack = mp4Parser.GetVideoTracks().Count > 0;
-                LoadMp4Subtitle(fileName, result.SelectedTrack.Track, hasVideoTrack);
+                LoadMp4Subtitle(fileName, result.SelectedTrack.Track, hasVideoTrack, skipLoadVideo);
 
                 // Picking a track from a multi-track .mp4 left the player empty, unlike the
                 // single-track path right above.
@@ -17228,7 +17228,7 @@ public partial class MainViewModel :
     /// image-track branch uses it - that one finishes asynchronously after OCR and so has to open the
     /// video itself; for text tracks the caller does it.
     /// </param>
-    private void LoadMp4Subtitle(string fileName, Trak mp4SubtitleTrack, bool hasVideoTrack)
+    private void LoadMp4Subtitle(string fileName, Trak mp4SubtitleTrack, bool hasVideoTrack, bool skipLoadVideo = false)
     {
         if (mp4SubtitleTrack.Mdia.IsVobSubSubtitle)
         {
@@ -17239,7 +17239,7 @@ public partial class MainViewModel :
 
                 if (result.OkPressed)
                 {
-                    await FinishOcrImportAsync(fileName, result.OcredSubtitle, sourceIsVideo: hasVideoTrack);
+                    await FinishOcrImportAsync(fileName, result.OcredSubtitle, sourceIsVideo: hasVideoTrack, skipLoadVideo: skipLoadVideo);
                 }
             });
         }
@@ -17264,7 +17264,7 @@ public partial class MainViewModel :
     /// same path .mp4 files take. It used to dead-end here on a "does not seem to contain any
     /// subtitles" error, so a subtitle-less .mkv could never be opened as a video (#12171).
     /// </summary>
-    private async Task<bool> ImportSubtitleFromMatroskaFile(string fileName, string? videoFileName)
+    private async Task<bool> ImportSubtitleFromMatroskaFile(string fileName, string? videoFileName, bool skipLoadVideo = false)
     {
         var matroska = new MatroskaFile(fileName);
         var subtitleList = matroska.GetTracks(true);
@@ -17282,7 +17282,7 @@ public partial class MainViewModel :
                     await ShowDialogAsync<PickMatroskaTrackWindow, PickMatroskaTrackViewModel>(vm => { vm.Initialize(matroska, subtitleList, fileName); });
                 if (result.OkPressed && result.SelectedMatroskaTrack != null)
                 {
-                    if (await LoadMatroskaSubtitle(result.SelectedMatroskaTrack, matroska, fileName))
+                    if (await LoadMatroskaSubtitle(result.SelectedMatroskaTrack, matroska, fileName, skipLoadVideo))
                     {
                         if (!IsImageSubtitleTrack(result.SelectedMatroskaTrack))
                         {
@@ -17312,7 +17312,7 @@ public partial class MainViewModel :
         else
         {
             var ext = Path.GetExtension(matroska.Path).ToLowerInvariant();
-            if (await LoadMatroskaSubtitle(subtitleList[0], matroska, fileName))
+            if (await LoadMatroskaSubtitle(subtitleList[0], matroska, fileName, skipLoadVideo))
             {
                 if (Se.Settings.Video.AutoOpen && !IsImageSubtitleTrack(subtitleList[0]))
                 {
@@ -17380,7 +17380,8 @@ public partial class MainViewModel :
     private async Task<bool> LoadMatroskaSubtitle(
         MatroskaTrackInfo matroskaSubtitleInfo,
         MatroskaFile matroska,
-        string fileName)
+        string fileName,
+        bool skipLoadVideo = false)
     {
         if (matroskaSubtitleInfo.CodecId.Equals("S_HDMV/PGS", StringComparison.OrdinalIgnoreCase))
         {
@@ -17409,7 +17410,7 @@ public partial class MainViewModel :
 
                 if (result.OkPressed)
                 {
-                    await FinishOcrImportAsync(fileName, result.OcredSubtitle, sourceIsVideo: IsMatroskaVideoFileName(fileName));
+                    await FinishOcrImportAsync(fileName, result.OcredSubtitle, sourceIsVideo: IsMatroskaVideoFileName(fileName), skipLoadVideo: skipLoadVideo);
                 }
             });
 
@@ -17423,12 +17424,12 @@ public partial class MainViewModel :
 
         if (matroskaSubtitleInfo.CodecId.Equals("S_DVBSUB", StringComparison.OrdinalIgnoreCase))
         {
-            return await LoadDvbFromMatroska(matroskaSubtitleInfo, matroska, fileName);
+            return await LoadDvbFromMatroska(matroskaSubtitleInfo, matroska, fileName, skipLoadVideo);
         }
 
         if (matroskaSubtitleInfo.CodecId.Equals("S_VOBSUB", StringComparison.OrdinalIgnoreCase))
         {
-            return await LoadVobSubFromMatroska(matroskaSubtitleInfo, matroska, fileName);
+            return await LoadVobSubFromMatroska(matroskaSubtitleInfo, matroska, fileName, skipLoadVideo);
         }
 
         var sub = await ExtractMatroskaSubtitleAsync(matroska, matroskaSubtitleInfo.TrackNumber);
@@ -17454,7 +17455,8 @@ public partial class MainViewModel :
         track.CodecId.Equals("S_DVBSUB", StringComparison.OrdinalIgnoreCase) ||
         track.CodecId.Equals("S_VOBSUB", StringComparison.OrdinalIgnoreCase);
 
-    private async Task<bool> LoadDvbFromMatroska(MatroskaTrackInfo matroskaSubtitleInfo, MatroskaFile matroska, string fileName)
+    private async Task<bool> LoadDvbFromMatroska(MatroskaTrackInfo matroskaSubtitleInfo, MatroskaFile matroska, string fileName,
+        bool skipLoadVideo = false)
     {
         ShowStatus(Se.Language.Main.ParsingMatroskaFile);
         var sub = await ExtractMatroskaSubtitleAsync(matroska, matroskaSubtitleInfo.TrackNumber);
@@ -17547,7 +17549,7 @@ public partial class MainViewModel :
 
             if (result.OkPressed)
             {
-                await FinishOcrImportAsync(fileName, result.OcredSubtitle, sourceIsVideo: IsMatroskaVideoFileName(fileName));
+                await FinishOcrImportAsync(fileName, result.OcredSubtitle, sourceIsVideo: IsMatroskaVideoFileName(fileName), skipLoadVideo: skipLoadVideo);
             }
         });
 
@@ -17555,7 +17557,7 @@ public partial class MainViewModel :
     }
 
     private async Task<bool> LoadVobSubFromMatroska(MatroskaTrackInfo matroskaSubtitleInfo, MatroskaFile matroska,
-        string fileName)
+        string fileName, bool skipLoadVideo = false)
     {
         if (matroskaSubtitleInfo.ContentEncodingType == 1)
         {
@@ -17609,7 +17611,7 @@ public partial class MainViewModel :
 
             if (result.OkPressed)
             {
-                await FinishOcrImportAsync(fileName, result.OcredSubtitle, sourceIsVideo: IsMatroskaVideoFileName(fileName));
+                await FinishOcrImportAsync(fileName, result.OcredSubtitle, sourceIsVideo: IsMatroskaVideoFileName(fileName), skipLoadVideo: skipLoadVideo);
             }
         });
 
@@ -17692,7 +17694,7 @@ public partial class MainViewModel :
         return true;
     }
 
-    private async Task<bool> ImportSubtitleFromVobSubFile(string vobSubFileName, string? videoFileName)
+    private async Task<bool> ImportSubtitleFromVobSubFile(string vobSubFileName, string? videoFileName, bool skipLoadVideo = false)
     {
         var vobSubParser = new VobSubParser(true);
         string idxFileName = Path.ChangeExtension(vobSubFileName, ".idx");
@@ -17756,7 +17758,7 @@ public partial class MainViewModel :
 
         if (result.OkPressed)
         {
-            await FinishOcrImportAsync(vobSubFileName, result.OcredSubtitle, videoFileName: videoFileName);
+            await FinishOcrImportAsync(vobSubFileName, result.OcredSubtitle, videoFileName: videoFileName, skipLoadVideo: skipLoadVideo);
             return true;
         }
 

--- a/src/ui/Features/Ocr/Engines/CrispEmbedOcr.cs
+++ b/src/ui/Features/Ocr/Engines/CrispEmbedOcr.cs
@@ -486,8 +486,10 @@ public class CrispEmbedOcr : IDisposable
 
     /// <summary>
     /// Plain-language help for the exit codes the dynamic loader and the shell use on Unix, which
-    /// a user cannot be expected to decode. 127 is the common one: the CrispEmbed CPU builds for
-    /// Linux link against OpenBLAS but do not ship it (see SubtitleEdit issue #13205).
+    /// a user cannot be expected to decode. 127 means a shared library could not be loaded.
+    /// The original cause (issue #13205) was an unshipped OpenBLAS dependency, fixed upstream in
+    /// CrispEmbed v0.17.5; what remains is typically a glibc too old for the pinned build, so the
+    /// hint no longer names a specific package to install.
     /// </summary>
     internal static string GetExitCodeHint(int exitCode)
     {
@@ -500,9 +502,11 @@ public class CrispEmbedOcr : IDisposable
         {
             127 => "Exit code 127 means a shared library the CrispEmbed binaries depend on could not be loaded." +
                    Environment.NewLine +
-                   "The Linux CrispEmbed builds need OpenBLAS, which they do not ship: try installing it" +
+                   "This is usually a system C library (glibc) older than the one the CrispEmbed build needs;" +
                    Environment.NewLine +
-                   "(\"sudo apt install libopenblas0\", \"sudo pacman -S openblas\", or your distro's equivalent).",
+                   "the CUDA builds in particular require a newer glibc than the CPU builds." +
+                   Environment.NewLine +
+                   "Run \"ldd\" on the CrispEmbed binary to see which library is missing.",
             126 => "Exit code 126 means the CrispEmbed binary could not be executed - it may be missing the" +
                    Environment.NewLine +
                    "executable permission, or be blocked by the system.",

--- a/src/ui/Features/Shared/DownloadLibVlcViewModel.cs
+++ b/src/ui/Features/Shared/DownloadLibVlcViewModel.cs
@@ -187,6 +187,15 @@ public partial class DownloadLibVlcViewModel : ObservableObject, IClosingCleanup
 
             Dispatcher.UIThread.Post(() =>
             {
+                // The user can cancel while the probe is still running (it walks the VLC
+                // install directory and can take seconds). Close() is itself posted, so this
+                // continuation can be queued behind it - bail out rather than reporting
+                // success or kicking off a download on a dialog that is already gone.
+                if (_done || _cancellationTokenSource == null || _cancellationTokenSource.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 // Only skip the download on a clean, positive probe - a faulted probe (broken
                 // libVLC install) must fall through to the download, not leave the dialog
                 // stuck with an unobserved exception (review follow-up).

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -2105,7 +2105,20 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         // Frame rate and shot changes come from a video file matching the subtitle file
         // name, when one exists. Shot changes are only available if they were previously
         // generated/imported for that video (they are cached on disk per video file).
-        var frameRate = Configuration.Settings.General.DefaultFrameRate;
+        //
+        // Without a matching video, fall back to the frame rate this batch is actually
+        // producing: the target of the "change frame rate" step when it runs (it runs before
+        // this one), otherwise the project frame rate. Configuration.Settings.General
+        // .DefaultFrameRate is not usable here - nothing in the UI ever assigns it, so it is
+        // always libse's built-in 23.976.
+        var frameRate = _config.ChangeFrameRate.IsActive && _config.ChangeFrameRate.ToFrameRate > 0
+            ? _config.ChangeFrameRate.ToFrameRate
+            : Se.Settings.General.CurrentFrameRate;
+        if (frameRate <= 0)
+        {
+            frameRate = Se.Settings.General.DefaultFrameRate;
+        }
+
         var shotChanges = new List<double>();
 
         if (FindVideoFileName.TryFindVideoFileName(subtitleFileName, out var videoFileName))
@@ -2120,12 +2133,21 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             }
             catch
             {
-                // no ffmpeg or unreadable video file - keep the default frame rate
+                // no ffmpeg or unreadable video file - keep the fallback frame rate
             }
 
             if (_config.BeautifyTimeCodes.SnapToShotChanges)
             {
-                shotChanges = ShotChangesHelper.FromDisk(videoFileName);
+                try
+                {
+                    shotChanges = ShotChangesHelper.FromDisk(videoFileName);
+                }
+                catch
+                {
+                    // unreadable/corrupt shot-changes cache - beautify without them rather
+                    // than aborting the rest of the batch
+                    shotChanges = new List<double>();
+                }
             }
         }
 

--- a/src/ui/Logic/MergeManager.cs
+++ b/src/ui/Logic/MergeManager.cs
@@ -96,7 +96,10 @@ namespace Nikse.SubtitleEdit.Logic
                     sb.AppendLine(addText);
                 }
 
-                endMilliseconds = subtitle.Paragraphs[index].EndTime.TotalMilliseconds;
+                // Max, not last: with "keep end time" the merged line must span every merged
+                // line, and selected lines are not necessarily ordered by end time (e.g. an
+                // ASSA sign event that outlives the dialog line merged into it).
+                endMilliseconds = Math.Max(endMilliseconds, subtitle.Paragraphs[index].EndTime.TotalMilliseconds);
             }
 
             var currentParagraph = subtitle.Paragraphs[firstIndex];
@@ -206,7 +209,10 @@ namespace Nikse.SubtitleEdit.Logic
                     sbOriginal.AppendLine(inputSubtitle[index].OriginalText);
                 }
 
-                endMilliseconds = inputSubtitle[index].EndTime.TotalMilliseconds;
+                // Max, not last: with "keep end time" the merged line must span every merged
+                // line, and selected lines are not necessarily ordered by end time (e.g. an
+                // ASSA sign event that outlives the dialog line merged into it).
+                endMilliseconds = Math.Max(endMilliseconds, inputSubtitle[index].EndTime.TotalMilliseconds);
             }
 
             var currentParagraph = inputSubtitle[firstIndex];

--- a/src/ui/Logic/SubtitleGridCopyPasteHelper.cs
+++ b/src/ui/Logic/SubtitleGridCopyPasteHelper.cs
@@ -71,7 +71,21 @@ internal static class SubtitleGridCopyPasteHelper
 
             if (firstEventIndex > 0)
             {
-                var eventLines = lines.GetRange(firstEventIndex, lines.Count - firstEventIndex);
+                // Stop at the first section that follows the events: ToText appends the
+                // subtitle footer ([Fonts] / [Graphics] / [Aegisub Extradata], including the
+                // embedded font payload) after the event lines, and that would be pasted as
+                // fake subtitle lines just like the header was (#10476).
+                var endIndex = lines.Count;
+                for (var i = firstEventIndex; i < lines.Count; i++)
+                {
+                    if (lines[i].TrimStart().StartsWith('['))
+                    {
+                        endIndex = i;
+                        break;
+                    }
+                }
+
+                var eventLines = lines.GetRange(firstEventIndex, endIndex - firstEventIndex);
                 while (eventLines.Count > 0 && string.IsNullOrWhiteSpace(eventLines[eventLines.Count - 1]))
                 {
                     eventLines.RemoveAt(eventLines.Count - 1);

--- a/src/ui/Logic/UiTheme.cs
+++ b/src/ui/Logic/UiTheme.cs
@@ -996,6 +996,38 @@ public static class UiTheme
         return Se.Settings.Appearance.DarkModeBackgroundColor.FromHexToColor();
     }
 
+    /// <summary>
+    /// The window/grid background of the active theme. Used where something has to be drawn
+    /// legibly against it (e.g. picking a readable ASSA color for the subtitle grid), so the
+    /// light themes must not all be assumed to be white.
+    /// </summary>
+    public static Color GetThemeBackgroundColor()
+    {
+        try
+        {
+            if (IsDarkThemeEnabled())
+            {
+                return GetDarkThemeBackgroundColor();
+            }
+        }
+        catch
+        {
+            // malformed DarkModeBackgroundColor in the settings file
+            return Color.FromRgb(0x21, 0x21, 0x21);
+        }
+
+        var themeSetting = Se.Settings.Appearance.Theme;
+        if (themeSetting == ThemeNameClassic)
+        {
+            return ClassicBackgroundColor;
+        }
+
+        return themeSetting == ThemeNamePastel ? PastelBackgroundColor : Colors.White;
+    }
+
+    private static readonly Color ClassicBackgroundColor = Color.FromRgb(236, 233, 216);
+    private static readonly Color PastelBackgroundColor = Color.FromRgb(240, 235, 255);
+
     public static Color GetDarkThemeForegroundColor()
     {
         return Se.Settings.Appearance.DarkModeForegroundColor.FromHexToColor();

--- a/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
@@ -941,6 +941,11 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
         var colorCandidateCount = 0;
         var sawColorTag = false;
 
+        // Set by a \t(...) animation in this block. Only then can two primary colors both be
+        // "current" (the static one and the transition's destination); without a transition,
+        // consecutive color tags are plain overrides and the last one wins.
+        var sawTransitionTag = false;
+
         // Limit number of tags to prevent excessive processing
         const int maxTags = 50;
         var handled = 0;
@@ -974,6 +979,15 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                 state.Reset();
                 colorCandidateCount = 0;
                 sawColorTag = false;
+                sawTransitionTag = false;
+                continue;
+            }
+
+            // Animation: \t(...) - the tags splitter cuts on '\', so the transition's own
+            // color arrives as a later segment; just note that a transition is in play.
+            if (firstChar == 't' && tagLen > 1 && trimmedTag[1] == '(')
+            {
+                sawTransitionTag = true;
                 continue;
             }
 
@@ -1070,16 +1084,20 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             }
         }
 
-        if (colorCandidateCount == 1)
+        if (colorCandidateCount > 1 && sawTransitionTag)
         {
-            state.Color = colorCandidates[0];
-        }
-        else if (colorCandidateCount > 1)
-        {
-            // Two or more colors (static + fade destination): the grid can only show one, so
-            // show the one with the best contrast against the grid background - or none when
-            // even the best would be near-invisible (#10955).
+            // Static color plus a \t(...) fade destination: the grid can only show one, so show
+            // the one with the best contrast against the grid background - or none when even
+            // the best would be near-invisible (#10955).
             state.Color = PickMostVisibleColor(colorCandidates.Slice(0, colorCandidateCount));
+        }
+        else if (colorCandidateCount > 0)
+        {
+            // No transition involved, so ASSA's last-wins rule applies: consecutive static
+            // color tags resolve to the last one, matching libass and the video preview. The
+            // visibility guard deliberately does not apply here - a single explicit color is
+            // shown as authored even when it has little contrast.
+            state.Color = colorCandidates[colorCandidateCount - 1];
         }
         else if (sawColorTag)
         {
@@ -1109,9 +1127,11 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             return backgroundOverride();
         }
 
-        return UiTheme.IsDarkThemeEnabled()
-            ? Se.Settings.Appearance.DarkModeBackgroundColor.FromHexToColor()
-            : Colors.White;
+        // Not just white for "not dark": SE also ships the Classic (gray) and Pastel
+        // (lavender) light themes, and contrast has to be measured against the real
+        // background. Also swallows a malformed DarkModeBackgroundColor rather than
+        // letting it throw out of IValueConverter.Convert.
+        return UiTheme.GetThemeBackgroundColor();
     }
 
     private static Color? PickMostVisibleColor(ReadOnlySpan<Color> candidates)

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -115,6 +115,16 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
     private MpvGetPropertyDouble? _mpvGetPropertyDouble;
 
+    /// <summary>
+    /// MPV_FORMAT_FLAG makes mpv write a 4-byte int, so it must not be read through the
+    /// "ref double" overload: the value would land in the low half of the 8-byte double and a
+    /// flag of 1 would read back as the subnormal 5E-324 rather than 1.0.
+    /// </summary>
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate int MpvGetPropertyFlag(IntPtr mpvHandle, byte[] name, int format, ref int data);
+
+    private MpvGetPropertyFlag? _mpvGetPropertyFlag;
+
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     private delegate int MpvSetProperty(IntPtr mpvHandle, byte[] name, int format, ref byte[] data);
 
@@ -291,6 +301,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         _mpvSetOptionString = (MpvSetOptionString)GetDllType(typeof(MpvSetOptionString), "mpv_set_option_string");
         _mpvGetPropertyString = (MpvGetPropertyString)GetDllType(typeof(MpvGetPropertyString), "mpv_get_property");
         _mpvGetPropertyDouble = (MpvGetPropertyDouble)GetDllType(typeof(MpvGetPropertyDouble), "mpv_get_property");
+        _mpvGetPropertyFlag = (MpvGetPropertyFlag)GetDllType(typeof(MpvGetPropertyFlag), "mpv_get_property");
         _mpvSetProperty = (MpvSetProperty)GetDllType(typeof(MpvSetProperty), "mpv_set_property");
         _mpvFree = (MpvFree)GetDllType(typeof(MpvFree), "mpv_free");
         _mpvClientApiVersion = (MpvClientApiVersion)GetDllType(typeof(MpvClientApiVersion), "mpv_client_api_version");
@@ -1130,16 +1141,16 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         get
         {
             EnsureNotDisposed();
-            if (_mpv == IntPtr.Zero || _mpvGetPropertyDouble == null)
+            if (_mpv == IntPtr.Zero || _mpvGetPropertyFlag == null)
             {
                 return false;
             }
 
             try
             {
-                double pauseValue = 0;
+                var pauseValue = 0;
                 var nameBytes = PropertyNamePause;
-                var err = _mpvGetPropertyDouble(_mpv, nameBytes, MPV_FORMAT_FLAG, ref pauseValue);
+                var err = _mpvGetPropertyFlag(_mpv, nameBytes, MPV_FORMAT_FLAG, ref pauseValue);
 
                 if (err < 0)
                 {
@@ -1160,16 +1171,16 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         get
         {
             EnsureNotDisposed();
-            if (_mpv == IntPtr.Zero || _mpvGetPropertyDouble == null)
+            if (_mpv == IntPtr.Zero || _mpvGetPropertyFlag == null)
             {
                 return false;
             }
 
             try
             {
-                double pauseValue = 0;
+                var pauseValue = 0;
                 var nameBytes = PropertyNamePause;
-                var err = _mpvGetPropertyDouble(_mpv, nameBytes, MPV_FORMAT_FLAG, ref pauseValue);
+                var err = _mpvGetPropertyFlag(_mpv, nameBytes, MPV_FORMAT_FLAG, ref pauseValue);
 
                 if (err < 0)
                 {
@@ -1207,16 +1218,16 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
     private bool IsEofReached()
     {
-        if (_mpv == IntPtr.Zero || _mpvGetPropertyDouble == null)
+        if (_mpv == IntPtr.Zero || _mpvGetPropertyFlag == null)
         {
             return false;
         }
 
         try
         {
-            double eofValue = 0;
+            var eofValue = 0;
             var nameBytes = PropertyNameEofReached;
-            var err = _mpvGetPropertyDouble(_mpv, nameBytes, MPV_FORMAT_FLAG, ref eofValue);
+            var err = _mpvGetPropertyFlag(_mpv, nameBytes, MPV_FORMAT_FLAG, ref eofValue);
             if (err < 0)
             {
                 return false;
@@ -1552,7 +1563,8 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         var audioTracks = new List<AudioTrackInfo>();
 
         EnsureNotDisposed();
-        if (_mpv == IntPtr.Zero || _mpvGetPropertyDouble == null || _mpvGetPropertyString == null || _mpvFree == null)
+        if (_mpv == IntPtr.Zero || _mpvGetPropertyDouble == null || _mpvGetPropertyFlag == null ||
+            _mpvGetPropertyString == null || _mpvFree == null)
         {
             return audioTracks;
         }
@@ -1659,18 +1671,18 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
                 }
 
                 // Get track selected status
-                double selectedValue = 0;
+                var selectedValue = 0;
                 var selectedBytes = GetUtf8Bytes($"track-list/{i}/selected");
-                err = _mpvGetPropertyDouble(_mpv, selectedBytes, MPV_FORMAT_FLAG, ref selectedValue);
+                err = _mpvGetPropertyFlag(_mpv, selectedBytes, MPV_FORMAT_FLAG, ref selectedValue);
 
-                trackInfo.IsSelected = err >= 0 && selectedValue == 1;
+                trackInfo.IsSelected = err >= 0 && selectedValue != 0;
 
                 // Get track default flag
-                double defaultValue = 0;
+                var defaultValue = 0;
                 var defaultBytes = GetUtf8Bytes($"track-list/{i}/default");
-                err = _mpvGetPropertyDouble(_mpv, defaultBytes, MPV_FORMAT_FLAG, ref defaultValue);
+                err = _mpvGetPropertyFlag(_mpv, defaultBytes, MPV_FORMAT_FLAG, ref defaultValue);
 
-                trackInfo.IsDefault = err >= 0 && defaultValue == 1;
+                trackInfo.IsDefault = err >= 0 && defaultValue != 0;
 
                 audioTracks.Add(trackInfo);
             }

--- a/tests/UI/Features/Ocr/Engines/CrispEmbedEngineTests.cs
+++ b/tests/UI/Features/Ocr/Engines/CrispEmbedEngineTests.cs
@@ -86,9 +86,14 @@ public class CrispEmbedEngineTests
             return;
         }
 
-        // The cause of SubtitleEdit issue #13205: the Linux builds link against OpenBLAS but do
-        // not ship it, so the loader aborts before the server can say anything itself.
-        Assert.Contains("OpenBLAS", CrispEmbedOcr.GetExitCodeHint(127));
+        // 127 = the loader could not resolve a dependency before the server could report
+        // anything itself. The OpenBLAS cause behind #13205 was fixed upstream in v0.17.5, so
+        // the hint must not send users off to install it; glibc is the remaining cause.
+        var hint127 = CrispEmbedOcr.GetExitCodeHint(127);
+        Assert.Contains("shared library", hint127);
+        Assert.Contains("glibc", hint127);
+        Assert.DoesNotContain("OpenBLAS", hint127);
+        Assert.DoesNotContain("libopenblas", hint127);
         Assert.Contains("executed", CrispEmbedOcr.GetExitCodeHint(126));
     }
 

--- a/tests/UI/Logic/MergeManagerTests.cs
+++ b/tests/UI/Logic/MergeManagerTests.cs
@@ -159,6 +159,39 @@ public class MergeManagerTests
         Assert.Equal(TimeSpan.FromMilliseconds(3500), subtitles[0].EndTime);
     }
 
+    // The merged line must span every merged line, so the end time is the latest of them - not
+    // the last one in selection order. An ASSA sign event that outlives a dialog line merged
+    // into it is exactly the case the ASSA-only default targets, and taking "last" silently
+    // truncated it.
+    [Fact]
+    public void MergeSelectedLines_ShouldKeepLatestEndTime_NotLastLineEndTime()
+    {
+        var mergeManager = new MergeManager();
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new()
+            {
+                Number = 1,
+                Text = "Sign that stays up",
+                StartTime = TimeSpan.Zero,
+                EndTime = TimeSpan.FromSeconds(10),
+            },
+            new()
+            {
+                Number = 2,
+                Text = "Short dialog",
+                StartTime = TimeSpan.FromSeconds(2),
+                EndTime = TimeSpan.FromSeconds(4),
+            },
+        };
+
+        mergeManager.MergeSelectedLines(subtitles, [subtitles[0], subtitles[1]], keepEndTime: true);
+
+        Assert.Single(subtitles);
+        Assert.Equal(TimeSpan.Zero, subtitles[0].StartTime);
+        Assert.Equal(TimeSpan.FromSeconds(10), subtitles[0].EndTime);
+    }
+
     [Theory]
     [InlineData(false, true, true, false)] // setting off => never keep, even for ASSA
     [InlineData(false, false, false, false)]

--- a/tests/UI/Logic/SubtitleGridCopyPasteHelperTests.cs
+++ b/tests/UI/Logic/SubtitleGridCopyPasteHelperTests.cs
@@ -55,4 +55,65 @@ public class SubtitleGridCopyPasteHelperTests
         Assert.Equal("Line one", pasted.Paragraphs[0].Text);
         Assert.Equal("Line two", pasted.Paragraphs[1].Text);
     }
+
+    // The event section used to start only at "Dialogue:", so a payload whose first event was
+    // a "Comment:" lost that line (or, when every line was commented, failed to parse at all
+    // and got pasted as raw text).
+    [Theory]
+    [InlineData("ass")]
+    [InlineData("ssa")]
+    public void CopyPayload_LeadingCommentLine_RoundTrips(string extension)
+    {
+        var format = extension == "ass" ? (SubtitleFormat)new AdvancedSubStationAlpha() : new SubStationAlpha();
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("Commented first", 1000, 2000) { IsComment = true });
+        sub.Paragraphs.Add(new Paragraph("Normal second", 3000, 4000));
+
+        var lines = SubtitleGridCopyPasteHelper.GetClipboardText(format, sub).SplitToLines();
+        var pasted = Subtitle.Parse(lines, extension);
+
+        Assert.NotNull(pasted);
+        Assert.Equal(2, pasted.Paragraphs.Count);
+        Assert.Equal("Commented first", pasted.Paragraphs[0].Text);
+        Assert.Equal("Normal second", pasted.Paragraphs[1].Text);
+    }
+
+    [Theory]
+    [InlineData("ass")]
+    [InlineData("ssa")]
+    public void CopyPayload_AllCommentLines_RoundTrips(string extension)
+    {
+        var format = extension == "ass" ? (SubtitleFormat)new AdvancedSubStationAlpha() : new SubStationAlpha();
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("Only comment", 1000, 2000) { IsComment = true });
+
+        var lines = SubtitleGridCopyPasteHelper.GetClipboardText(format, sub).SplitToLines();
+        var pasted = Subtitle.Parse(lines, extension);
+
+        Assert.NotNull(pasted);
+        Assert.Single(pasted.Paragraphs);
+        Assert.Equal("Only comment", pasted.Paragraphs[0].Text);
+    }
+
+    // ToText appends the subtitle footer after the event lines, so stripping only the header
+    // still left [Fonts]/[Graphics] (including embedded font payloads) on the clipboard - the
+    // same fake-subtitle-lines problem #10476 is about, just from the other end of the file.
+    [Theory]
+    [InlineData("ass")]
+    [InlineData("ssa")]
+    public void CopyPayload_DoesNotIncludeFooterSections(string extension)
+    {
+        var format = extension == "ass" ? (SubtitleFormat)new AdvancedSubStationAlpha() : new SubStationAlpha();
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("Line one", 1000, 2000));
+        sub.Footer = "[Fonts]" + Environment.NewLine + "fontname: Arial_0.ttf" + Environment.NewLine + "!!0000";
+
+        var payload = SubtitleGridCopyPasteHelper.GetClipboardText(format, sub);
+
+        Assert.DoesNotContain("[Fonts]", payload, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("fontname:", payload, StringComparison.OrdinalIgnoreCase);
+        Assert.All(payload.SplitToLines(), l => Assert.True(
+            l.TrimStart().StartsWith("Dialogue:", StringComparison.OrdinalIgnoreCase) ||
+            l.TrimStart().StartsWith("Comment:", StringComparison.OrdinalIgnoreCase)));
+    }
 }

--- a/tests/UI/Logic/ValueConverters/ValueConverterTests.cs
+++ b/tests/UI/Logic/ValueConverters/ValueConverterTests.cs
@@ -274,6 +274,53 @@ public class ValueConverterTests
         }
     }
 
+    // Without a \t(...) transition, two primary color tags are plain overrides and ASSA's
+    // last-wins rule applies - the contrast pick must not second-guess libass here, or the
+    // grid disagrees with the video preview.
+    [AvaloniaFact]
+    public void ShowFormatting_ConsecutiveStaticAssaColors_LastOneWins()
+    {
+        TextWithSubtitleSyntaxHighlightingConverter.GridBackgroundOverride = () => Color.FromRgb(33, 33, 33);
+        try
+        {
+            // White first, then blue (&HFF0000& is BGR => #0000FF). White has by far the better
+            // contrast on #212121, so a contrast pick would choose it - but blue is written
+            // last, and last wins.
+            var run = SingleRun(Highlight("{\\1c&HFFFFFF&\\1c&HFF0000&}x",
+                SubtitleGridFormattingTypes.ShowFormatting));
+
+            Assert.Equal(Color.FromArgb(255, 0, 0, 255),
+                Assert.IsAssignableFrom<ISolidColorBrush>(run.Foreground).Color);
+        }
+        finally
+        {
+            TextWithSubtitleSyntaxHighlightingConverter.GridBackgroundOverride = null;
+        }
+    }
+
+    // The same two colors, but now the second one is a \t(...) destination, so the contrast
+    // pick applies and the more visible of the two is shown.
+    [AvaloniaFact]
+    public void ShowFormatting_StaticPlusTransitionColor_MostVisibleWins()
+    {
+        TextWithSubtitleSyntaxHighlightingConverter.GridBackgroundOverride = () => Color.FromRgb(33, 33, 33);
+        try
+        {
+            var run = SingleRun(Highlight("{\\1c&HFFFFFF&\\t(20,1000,0.9,\\1c&HFF0000&)}x",
+                SubtitleGridFormattingTypes.ShowFormatting));
+
+            // Same two colors as the last-wins test above, but the second one is now a
+            // transition destination: blue #0000FF has very low contrast on #212121, so the
+            // white static color is shown instead of the textually last one.
+            Assert.Equal(Colors.White,
+                Assert.IsAssignableFrom<ISolidColorBrush>(run.Foreground).Color);
+        }
+        finally
+        {
+            TextWithSubtitleSyntaxHighlightingConverter.GridBackgroundOverride = null;
+        }
+    }
+
     // A color tag whose value does not parse still resets the color, exactly as it did before
     // candidate collection was introduced.
     [AvaloniaFact]

--- a/tests/libse/SubtitleFormats/SubStationAlphaTest.cs
+++ b/tests/libse/SubtitleFormats/SubStationAlphaTest.cs
@@ -29,4 +29,39 @@ Dialogue: Marked=0,0:20:24.01,0:20:26.44,*Default,NTP,0000,0000,0000,,Du wirst s
         Assert.Equal(2, subtitle.Paragraphs.Count);
         Assert.All(subtitle.Paragraphs, p => Assert.Equal("Default", p.Extra));
     }
+
+    // A header-less payload (bare event lines, as the clipboard carries) must parse its events
+    // without any of them ending up in Header, which consumers treat as pre-[Events] content.
+    [Theory]
+    [InlineData("ssa", "Dialogue: Marked=0,0:00:01.00,0:00:02.00,*Default,NTP,0000,0000,0000,,Hello")]
+    [InlineData("ssa", "Comment: Marked=0,0:00:01.00,0:00:02.00,*Default,NTP,0000,0000,0000,,Hello")]
+    [InlineData("ass", "Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,Hello")]
+    [InlineData("ass", "Comment: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,Hello")]
+    public void HeaderLessEventPayload_DoesNotPutEventLinesInHeader(string extension, string eventLine)
+    {
+        var subtitle = new Subtitle();
+        SubtitleFormat format = extension == "ass" ? new AdvancedSubStationAlpha() : new SubStationAlpha();
+
+        format.LoadSubtitle(subtitle, new List<string> { eventLine }, "test." + extension);
+
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("Hello", subtitle.Paragraphs[0].Text);
+
+        var header = subtitle.Header ?? string.Empty;
+        Assert.DoesNotContain("Dialogue:", header, System.StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Comment:", header, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    // The normal case must be untouched: a full file still captures every pre-[Events] section.
+    [Fact]
+    public void FullFile_StillCapturesHeaderSections()
+    {
+        var subtitle = new Subtitle();
+
+        new SubStationAlpha().LoadSubtitle(subtitle, new List<string>(SsaWithMarkedDefault.SplitToLines()), "test.ssa");
+
+        Assert.Contains("[Script Info]", subtitle.Header);
+        Assert.Contains("[V4 Styles]", subtitle.Header);
+        Assert.DoesNotContain("Dialogue:", subtitle.Header, System.StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/tests/libse/SubtitleFormats/WebVttTest.cs
+++ b/tests/libse/SubtitleFormats/WebVttTest.cs
@@ -3,6 +3,7 @@ using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace LibSETests.SubtitleFormats;
@@ -290,5 +291,39 @@ public class WebVttTest
         var output = new WebVTT().ToText(subtitle, null);
 
         Assert.Contains(cueSettings, output);
+    }
+
+    // "region:" is written separately from the raw cue settings, so re-emitting the raw string
+    // verbatim wrote it twice whenever the source listed it after the other settings.
+    [Theory]
+    [InlineData("region:r1 line:10%")]
+    [InlineData("line:10% region:r1")]
+    [InlineData("line:10% region:r1 align:left")]
+    [InlineData("region:r1")]
+    public void ToTextWritesRegionOnlyOnce(string cueSettings)
+    {
+        var vtt = "WEBVTT\n\nREGION\nid:r1\n\n00:00:01.000 --> 00:00:02.000 " + cueSettings + "\nHello";
+        var subtitle = LoadWebVttSubtitle(vtt);
+
+        var output = new WebVTT().ToText(subtitle, null);
+        var cueLine = output.SplitToLines().First(l => l.Contains("-->"));
+
+        Assert.Equal(1, cueLine.Split(new[] { "region:" }, StringSplitOptions.None).Length - 1);
+        Assert.Contains("region:r1", cueLine);
+    }
+
+    // The other settings must still survive alongside the region.
+    [Fact]
+    public void ToTextKeepsPositionSettingsNextToRegion()
+    {
+        var vtt = "WEBVTT\n\nREGION\nid:r1\n\n00:00:01.000 --> 00:00:02.000 line:72.69% region:r1 position:44.90%\nHello";
+        var subtitle = LoadWebVttSubtitle(vtt);
+
+        var output = new WebVTT().ToText(subtitle, null);
+        var cueLine = output.SplitToLines().First(l => l.Contains("-->"));
+
+        Assert.Contains("line:72.69%", cueLine);
+        Assert.Contains("position:44.90%", cueLine);
+        Assert.Equal(1, cueLine.Split(new[] { "region:" }, StringSplitOptions.None).Length - 1);
     }
 }

--- a/tests/libuilogic/Common/FfmpegMediaInfoTrackTests.cs
+++ b/tests/libuilogic/Common/FfmpegMediaInfoTrackTests.cs
@@ -1,0 +1,78 @@
+using Nikse.SubtitleEdit.UiLogic.Media;
+using System.Linq;
+using Xunit;
+
+namespace LibUiLogicTests.Common;
+
+public class FfmpegMediaInfoTrackTests
+{
+    // Real "ffmpeg -i" shape: the video is stream 0, so the first audio track is stream 1.
+    // Callers hold these global stream indexes (they pass them to "-map 0:N"), which is why
+    // the track lookup has to match on them rather than on the position in the audio list.
+    private const string LogVideoPlusTwoAudio = @"
+Input #0, matroska,webm, from 'movie.mkv':
+  Duration: 00:01:00.00, start: 0.000000, bitrate: 1234 kb/s
+    Stream #0:0(eng): Video: h264 (High), yuv420p, 1920x1080, 23.98 fps, 23.98 tbr
+    Stream #0:1(eng): Audio: aac (LC), 48000 Hz, stereo, fltp, 128 kb/s
+    Stream #0:2(eng): Audio: dts (DTS-HD MA), 48000 Hz, 5.1(side), s32p, 1536 kb/s
+";
+
+    [Fact]
+    public void ParseLog_CapturesGlobalStreamIndex()
+    {
+        var info = FfmpegMediaInfo.ParseLog(LogVideoPlusTwoAudio);
+
+        var audio = info.Tracks.Where(t => t.TrackType == FfmpegTrackType.Audio).ToList();
+        Assert.Equal(2, audio.Count);
+        Assert.Equal(1, audio[0].StreamIndex);
+        Assert.Equal(2, audio[1].StreamIndex);
+        Assert.Equal(0, info.Tracks.First(t => t.TrackType == FfmpegTrackType.Video).StreamIndex);
+    }
+
+    // The 5.1 track is stream 2 - the second audio track but the third stream. Indexing the
+    // audio-only list with the global index missed it entirely (2 >= 2 audio tracks => false),
+    // silently disabling "use center channel only".
+    [Fact]
+    public void HasFrontCenterAudio_MatchesOnGlobalStreamIndex()
+    {
+        var info = FfmpegMediaInfo.ParseLog(LogVideoPlusTwoAudio);
+
+        Assert.True(info.HasFrontCenterAudio(2));   // the 5.1 track
+        Assert.False(info.HasFrontCenterAudio(1));  // the stereo track
+    }
+
+    [Fact]
+    public void HasFrontCenterAudio_NegativeIndexUsesFirstAudioTrack()
+    {
+        var info = FfmpegMediaInfo.ParseLog(LogVideoPlusTwoAudio);
+
+        // First audio track is stereo.
+        Assert.False(info.HasFrontCenterAudio(-1));
+
+        var surroundFirst = FfmpegMediaInfo.ParseLog(@"
+Input #0, matroska,webm, from 'movie.mkv':
+    Stream #0:0(eng): Video: h264 (High), yuv420p, 1920x1080, 23.98 fps, 23.98 tbr
+    Stream #0:1(eng): Audio: dts (DTS-HD MA), 48000 Hz, 7.1, s32p, 1536 kb/s
+");
+        Assert.True(surroundFirst.HasFrontCenterAudio(-1));
+    }
+
+    [Fact]
+    public void HasFrontCenterAudio_UnknownStreamIndexIsFalse()
+    {
+        var info = FfmpegMediaInfo.ParseLog(LogVideoPlusTwoAudio);
+
+        Assert.False(info.HasFrontCenterAudio(99));
+    }
+
+    [Fact]
+    public void HasFrontCenterAudio_NoAudioTracksIsFalse()
+    {
+        var info = FfmpegMediaInfo.ParseLog(@"
+Input #0, matroska,webm, from 'movie.mkv':
+    Stream #0:0(eng): Video: h264 (High), yuv420p, 1920x1080, 23.98 fps, 23.98 tbr
+");
+        Assert.False(info.HasFrontCenterAudio(0));
+        Assert.False(info.HasFrontCenterAudio(-1));
+    }
+}


### PR DESCRIPTION
Bug hunt over the 51 non-merge commits from 2026-08-05. Every finding below was reproduced before being fixed, and each fix that could be pinned has a regression test — the whole set was invisible to the existing suite.

**2775 tests pass** (879 libse, 145 libuilogic, 290 seconv, 1461 UI), 19 of them new.

## Data loss / corrupt output

**ASSA/SSA clipboard drops commented lines** (13ffe420d, 8752a3523)
The event section started only at `Dialogue:`, never `Comment:`. Reproduced through libse: copying `[Comment, Dialogue]` and pasting gave **1 paragraph instead of 2**, and an all-comment payload failed to parse entirely, so `Paste` fell through to the plain-text branch and inserted the literal `Comment: 0,0:00:01.00,...` as subtitle text. Both loaders now also start the event section on an event line.

**#10476 was only half fixed** (13ffe420d)
`ToText` appends the subtitle footer *after* the events, so stripping the header still left `[Fonts]`/`[Graphics]` — embedded font payloads included — on the clipboard. Verified payload from copying one line:

```
Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,Line one

[Fonts]
fontname: Arial_0.ttf
!!0000
```

The payload now stops at the first section following the events.

**WebVTT writes `region:` twice** (f2679a0a1)
The raw cue-setting re-emit includes a trailing `region:` that is also prepended separately. Verified round trip:

```
in : 00:00:01.000 --> 00:00:02.000 line:10% region:r1
out: 00:00:01.000 --> 00:00:02.000 region:r1 line:10% region:r1
```

Only when the source listed `region:` after the other settings; region-first and region-only round-trip cleanly.

**"Open subtitle (keep video)" discards the video** (51997067d)
`FinishOcrImportAsync` honors `skipLoadVideo`, but only 2 of its 13 call sites passed it — the two `.sup` branches. The VobSub, transport-stream, Matroska and MP4 importers took no such parameter, so the command closed the video and opened a name-matched one instead. The flag is threaded through every importer; this also stops the CLI path loading a video twice.

## Fixes that did not do what they claimed

**The default-audio-track fix was inert, and made selection worse** (db3da41c4)
`MPV_FORMAT_FLAG` makes mpv write a 4-byte int, but the flag properties were read through the `ref double` overload, so a flag of 1 landed in the low half of the double and read back as the subnormal `5E-324`. `IsDefault` and `IsSelected` were therefore permanently false: the chain always fell through to `tracks[0]`, and `!chosen.IsSelected` was always true, so SE called `SetAudioTrack(tracks[0].Id)` on *every* open — actively overriding the container-default track mpv had already picked, then persisting it to recent files.

Verified against real libmpv with an ffmpeg-generated MKV whose default is the *second* audio track:

```
track type    title       OLD ref double            NEW ref int
1     audio   Commentary  0,000E+000 (==1? False)   0 (==1? False)
2     audio   Main Mix    4,941E-324 (==1? False)   1 (==1? True)
```

Added a `ref int` delegate for flags and used it for every `MPV_FORMAT_FLAG` read. The pre-existing `IsPaused`/`IsEofReached` getters shared the flaw but survived by comparing against zero; they are now correct by construction rather than by luck.

**Merge "keep end time" truncates its own headline case** (abd5dc439)
`endMilliseconds` was overwritten each iteration instead of maxed, so the merged line took the *last* end rather than the *latest*. Merging an ASSA sign event `0:00:00.00 → 0:00:10.00` with a dialog line `0:00:02.00 → 0:00:04.00` produced `0:00:00.00 → 0:00:04.00` — six seconds discarded, in exactly the overlapping-events workflow the ASSA-only default targets.

**Batch convert "beautify time codes" always used 23.976 fps** (11fa17187)
It fell back to `Configuration.Settings.General.DefaultFrameRate`, a libse field nothing in the UI ever assigns — its only writer in the tree is seconv's settings loader. It now falls back to the "change frame rate" target when that step is active (it runs immediately before), otherwise the project frame rate. Reading the shot-changes cache is also guarded: it sat outside the existing `try`, so one truncated or locked file aborted the remaining files and left the dialog stuck with `IsConverting` never reset.

**Export custom text format wrote a BOM unconditionally** (e18d70a6a)
The old `File.WriteAllText` used BOM-less UTF-8; the new overload passed `Encoding.UTF8`, which emits a preamble. The dialog has no encoding picker, and `TextEncoding.Encoding` is `Encoding.UTF8` for *both* the "with BOM" and "without BOM" entries, so honoring the setting required resolving by display name. Now goes through `EncodingHelper.ResolveEncoding`, like the main save path.

## Narrower

- **ASSA grid color ignored last-wins** (6c5f60f86) — the contrast pick fired for any two primary colors, so consecutive *static* colors stopped following ASSA's last-wins rule and the grid disagreed with the video preview. Scoped to blocks carrying a `\t(...)` transition.
- **Contrast scored against the wrong background** (6c5f60f86) — white was assumed for every non-dark theme, though SE ships Classic (gray) and Pastel. Added `UiTheme.GetThemeBackgroundColor`, which also swallows a malformed `DarkModeBackgroundColor` rather than throwing out of an `IValueConverter.Convert`.
- **"Use center channel only" silently did nothing** (e18d70a6a) — a global ffmpeg stream index was passed to `HasFrontCenterAudio`, which indexed the audio-only track list. `FfmpegTrackInfo` now carries the real stream index and the lookup matches on it.
- **Waveform footer labels went stale** (cfb19f3a2) — the cache key omitted the frame rate, which `ToShortDisplayString` reads in frame mode, and neither new cache was cleared by `ResetCache`.
- **libVLC probe ignored cancellation** (92f1bd8b0) — cancelling during the probe still started a download on a closed dialog, and `OkPressed` could be set after the cancel.
- **Stale user-facing text** (035b8f7a0, 0145bd3de) — the exit-127 hint still told Linux users to install OpenBLAS, a dependency removed upstream in v0.17.5; `docs/features/ocr.md` omitted DeepSeek-OCR-2 and stated a quant rule and size ceiling it breaks.

## Deliberately not changed

- **Auto-trim language narrowing** (`!= "nl"` → `== "en"`) is a real over-narrowing — the ` 's ` merge is now off for every other language and for format readers passing `null`, and the `""` fallback also disables the en-gated ordinal fixes. But it is the product of three follow-up commits, and reverting it risks re-breaking #12144. Flagging rather than changing intent.
- **Multi-word "do not break" phrases** (93f04afc4) — trailing punctuation defeats the ordinal `EndsWith`, and 3+ word phrases are protected only at their last gap. The 33 shipped lists contain exactly three multi-word entries (bg `Н. Св.`, mk `на пр.`, `На пр.`), all two-word, so this affects custom lists almost exclusively.

## Known loose end

`FfmpegMediaInfo2` carries an identical copy of the center-channel bug, currently with no callers. Left alone rather than duplicating the stream-index plumbing into a second class, but it is a trap for the next caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
