### PR TITLE
Speed up merge, auto-break and image export (perf hunt on recent commits)

### DIFF
--- a/src/libse/BluRaySup/SkiaExt.cs
+++ b/src/libse/BluRaySup/SkiaExt.cs
@@ -158,38 +158,140 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             public int Bottom { get; set; }
         }
 
-        public static TrimResult TrimTransparentPixels(this SKBitmap bitmap)
+        /// <summary>
+        /// The smallest rectangle containing every pixel with a non-zero alpha, in absolute bitmap
+        /// coordinates, or <see cref="NonTransparentBounds.IsEmpty"/> when the bitmap draws nothing.
+        /// </summary>
+        public struct NonTransparentBounds
+        {
+            public int Top { get; set; }
+            public int Left { get; set; }
+            public int Right { get; set; }
+            public int Bottom { get; set; }
+            public bool IsEmpty => Top > Bottom || Left > Right;
+        }
+
+        // Little-endian view of two pixels: alpha is the 4th byte of each, so the high byte of each
+        // of the two packed uints.
+        private const ulong AlphaMask2Pixels = 0xFF000000FF000000UL;
+        private const uint AlphaMask1Pixel = 0xFF000000u;
+
+        /// <summary>
+        /// Index of the first pixel in [start, end) with a non-zero alpha, or -1 when there is none.
+        /// Image export rasterises into a 4000x2000 scratch canvas and nearly all of it is empty, so
+        /// the scan tests eight pixels per branch and stops at the first hit.
+        /// </summary>
+        private static unsafe int FirstNonTransparent(uint* row, int start, int end)
+        {
+            var x = start;
+            for (; x + 8 <= end; x += 8)
+            {
+                var block = (ulong*)(row + x);
+                if (((block[0] | block[1] | block[2] | block[3]) & AlphaMask2Pixels) != 0)
+                {
+                    break;
+                }
+            }
+
+            for (; x < end; x++)
+            {
+                if ((row[x] & AlphaMask1Pixel) != 0)
+                {
+                    return x;
+                }
+            }
+
+            return -1;
+        }
+
+        /// <summary>
+        /// Index of the last pixel in [start, end) with a non-zero alpha, or -1 when there is none.
+        /// </summary>
+        private static unsafe int LastNonTransparent(uint* row, int start, int end)
+        {
+            var x = end;
+            for (; x - 8 >= start; x -= 8)
+            {
+                var block = (ulong*)(row + x - 8);
+                if (((block[0] | block[1] | block[2] | block[3]) & AlphaMask2Pixels) != 0)
+                {
+                    break;
+                }
+            }
+
+            for (; x > start; x--)
+            {
+                if ((row[x - 1] & AlphaMask1Pixel) != 0)
+                {
+                    return x - 1;
+                }
+            }
+
+            return -1;
+        }
+
+        public static unsafe NonTransparentBounds GetNonTransparentBounds(this SKBitmap bitmap)
         {
             if (bitmap == null)
             {
                 throw new ArgumentNullException(nameof(bitmap));
             }
 
-            int width = bitmap.Width;
-            int height = bitmap.Height;
+            var width = bitmap.Width;
+            var height = bitmap.Height;
+            var top = height;
+            var left = width;
+            var right = -1;
+            var bottom = -1;
 
-            // Find the bounds of non-transparent pixels
-            int top = height;
-            int left = width;
-            int right = -1;
-            int bottom = -1;
+            var ptr = (byte*)bitmap.GetPixels().ToPointer();
+            var bytesPerPixel = bitmap.BytesPerPixel;
+            var rowBytes = bitmap.RowBytes;
 
-            unsafe
+            if (bytesPerPixel == 4 && BitConverter.IsLittleEndian)
             {
-                byte* ptr = (byte*)bitmap.GetPixels().ToPointer();
-                int bytesPerPixel = bitmap.BytesPerPixel;
-                int rowBytes = bitmap.RowBytes;
-
-                // Find top and bottom in one pass
-                for (int y = 0; y < height; y++)
+                for (var y = 0; y < height; y++)
                 {
-                    byte* row = ptr + (y * rowBytes);
+                    var row = (uint*)(ptr + y * rowBytes);
+                    var firstHit = FirstNonTransparent(row, 0, width);
+                    if (firstHit < 0)
+                    {
+                        continue;
+                    }
 
-                    for (int x = 0; x < width; x++)
+                    if (y < top)
+                    {
+                        top = y;
+                    }
+
+                    bottom = y;
+
+                    if (firstHit < left)
+                    {
+                        left = firstHit;
+                    }
+
+                    // Only the part of the row that could push the right edge out still needs
+                    // looking at, so later rows get cheaper as the bounds settle.
+                    if (right < width - 1)
+                    {
+                        var lastHit = LastNonTransparent(row, right + 1, width);
+                        if (lastHit > right)
+                        {
+                            right = lastHit;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                for (var y = 0; y < height; y++)
+                {
+                    var row = ptr + y * rowBytes;
+                    for (var x = 0; x < width; x++)
                     {
                         // Alpha is the 4th byte in RGBA/BGRA formats
-                        byte alpha = row[x * bytesPerPixel + 3];
-
+                        var alpha = row[x * bytesPerPixel + 3];
                         if (alpha > 0)
                         {
                             if (y < top) top = y;
@@ -201,8 +303,36 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
                 }
             }
 
+            return new NonTransparentBounds { Top = top, Left = left, Right = right, Bottom = bottom };
+        }
+
+        /// <summary>
+        /// Copies the given rectangle (inclusive bounds, absolute bitmap coordinates) into a new
+        /// bitmap. Parts of the rectangle outside the bitmap come out transparent.
+        /// </summary>
+        public static SKBitmap CropTo(this SKBitmap bitmap, int left, int top, int right, int bottom)
+        {
+            var newWidth = right - left + 1;
+            var newHeight = bottom - top + 1;
+            var cropped = new SKBitmap(newWidth, newHeight, bitmap.ColorType, bitmap.AlphaType);
+
+            using (var canvas = new SKCanvas(cropped))
+            {
+                canvas.Clear(SKColors.Transparent);
+                var sourceRect = new SKRect(left, top, right + 1, bottom + 1);
+                var destRect = new SKRect(0, 0, newWidth, newHeight);
+                canvas.DrawBitmap(bitmap, sourceRect, destRect);
+            }
+
+            return cropped;
+        }
+
+        public static TrimResult TrimTransparentPixels(this SKBitmap bitmap)
+        {
+            var bounds = bitmap.GetNonTransparentBounds();
+
             // If the entire bitmap is transparent, return the original
-            if (top > bottom || left > right)
+            if (bounds.IsEmpty)
             {
                 return new TrimResult
                 {
@@ -214,27 +344,13 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
                 };
             }
 
-            // Calculate the new dimensions
-            int newWidth = right - left + 1;
-            int newHeight = bottom - top + 1;
-
-            // Create the trimmed bitmap
-            SKBitmap trimmedBitmap = new SKBitmap(newWidth, newHeight, bitmap.ColorType, bitmap.AlphaType);
-
-            using (SKCanvas canvas = new SKCanvas(trimmedBitmap))
-            {
-                SKRect sourceRect = new SKRect(left, top, right + 1, bottom + 1);
-                SKRect destRect = new SKRect(0, 0, newWidth, newHeight);
-                canvas.DrawBitmap(bitmap, sourceRect, destRect);
-            }
-
             return new TrimResult
             {
-                TrimmedBitmap = trimmedBitmap,
-                Top = top,
-                Left = left,
-                Right = width - right - 1,
-                Bottom = height - bottom - 1
+                TrimmedBitmap = bitmap.CropTo(bounds.Left, bounds.Top, bounds.Right, bounds.Bottom),
+                Top = bounds.Top,
+                Left = bounds.Left,
+                Right = bitmap.Width - bounds.Right - 1,
+                Bottom = bitmap.Height - bounds.Bottom - 1
             };
         }
     }

--- a/src/libse/Common/NoBreakAfterItem.cs
+++ b/src/libse/Common/NoBreakAfterItem.cs
@@ -32,13 +32,38 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return Regex.IsMatch(line);
             }
 
-            if (line.EndsWith(Text, StringComparison.Ordinal))
+            return EndsWithWholeWord(line.AsSpan());
+        }
+
+        /// <summary>
+        /// Span overload so <see cref="Utilities.CanBreak"/> - which asks every list entry about
+        /// every candidate break point in the line - does not have to allocate the substring
+        /// before the break point. Only a regex entry still needs a string.
+        /// </summary>
+        public bool IsMatch(ReadOnlySpan<char> line)
+        {
+            if (line.IsEmpty || string.IsNullOrEmpty(Text))
             {
-                var indexBeforeText = line.Length - Text.Length - 1;
-                return indexBeforeText < 0 || line[indexBeforeText] == ' ';
+                return false;
             }
 
-            return false;
+            if (Regex != null)
+            {
+                return Regex.IsMatch(line.ToString());
+            }
+
+            return EndsWithWholeWord(line);
+        }
+
+        private bool EndsWithWholeWord(ReadOnlySpan<char> line)
+        {
+            if (!line.EndsWith(Text.AsSpan(), StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            var indexBeforeText = line.Length - Text.Length - 1;
+            return indexBeforeText < 0 || line[indexBeforeText] == ' ';
         }
 
         public override string ToString()

--- a/src/libse/Common/NoBreakAfterListInfo.cs
+++ b/src/libse/Common/NoBreakAfterListInfo.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+
+namespace Nikse.SubtitleEdit.Core.Common
+{
+    /// <summary>
+    /// A language's "no break after" list plus the two facts <see cref="Utilities.CanBreak"/> needs
+    /// about it. CanBreak runs once per candidate break point in the line, so deriving these per
+    /// call - as the multi-word phrase check for issue #9631 first did - means re-walking the whole
+    /// list (117 entries for Greek, the largest shipped list) for every space in the line.
+    /// </summary>
+    internal sealed class NoBreakAfterListInfo
+    {
+        /// <summary>
+        /// CanBreak asks for the list once per candidate break point, and AutoBreakLine(text)
+        /// passes no language at all, so the "no language" case must not allocate every time.
+        /// </summary>
+        public static readonly NoBreakAfterListInfo Empty = new NoBreakAfterListInfo(new List<NoBreakAfterItem>());
+
+        public NoBreakAfterListInfo(List<NoBreakAfterItem> items)
+        {
+            Items = items;
+            foreach (var item in items)
+            {
+                if (item.Regex != null)
+                {
+                    HasRegex = true;
+                }
+                else if (item.Text != null && item.Text.IndexOf(' ') >= 0)
+                {
+                    MultiWordItems = MultiWordItems ?? new List<NoBreakAfterItem>();
+                    MultiWordItems.Add(item);
+                }
+            }
+        }
+
+        public List<NoBreakAfterItem> Items { get; }
+
+        /// <summary>True when at least one entry matches with a regex, which needs a string.</summary>
+        public bool HasRegex { get; }
+
+        /// <summary>
+        /// The multi-word phrase entries, or null when the list has none - which is the case for
+        /// all but 2 of the 33 shipped lists.
+        /// </summary>
+        public List<NoBreakAfterItem> MultiWordItems { get; }
+    }
+}

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -264,10 +264,14 @@ namespace Nikse.SubtitleEdit.Core.Common
             var head = s.AsSpan(0, index);
             if (Configuration.Settings.Tools.UseNoLineBreakAfter)
             {
-                var s2 = s.Substring(0, index); // the list matches with Regex/EndsWith, which need a string
-                foreach (NoBreakAfterItem ending in NoBreakAfterList(language))
+                var noBreakAfter = GetNoBreakAfterListInfo(language);
+
+                // The list matches with EndsWith, which works on the span - only a regex entry
+                // needs the substring, and none of the shipped lists have one.
+                var s2 = noBreakAfter.HasRegex ? s.Substring(0, index) : null;
+                foreach (var ending in noBreakAfter.Items)
                 {
-                    if (ending.IsMatch(s2))
+                    if (s2 == null ? ending.IsMatch(head) : ending.IsMatch(s2))
                     {
                         return false;
                     }
@@ -275,21 +279,25 @@ namespace Nikse.SubtitleEdit.Core.Common
 
                 // A multi-word entry (e.g. "SORT OF") means the whole phrase must stay together,
                 // so also forbid a break between its words - otherwise the line could still be
-                // split right before the last word of the phrase (issue #9631).
-                var nextSpaceIndex = s.IndexOf(' ', index + 1);
-                if (nextSpaceIndex < 0)
+                // split right before the last word of the phrase (issue #9631). Only 2 of the 33
+                // shipped lists have such an entry, so the whole second pass is normally skipped.
+                if (noBreakAfter.MultiWordItems != null)
                 {
-                    nextSpaceIndex = s.Length;
-                }
-
-                if (nextSpaceIndex > index + 1)
-                {
-                    var s3 = s.Substring(0, nextSpaceIndex);
-                    foreach (NoBreakAfterItem ending in NoBreakAfterList(language))
+                    var nextSpaceIndex = s.IndexOf(' ', index + 1);
+                    if (nextSpaceIndex < 0)
                     {
-                        if (ending.Regex == null && ending.Text != null && ending.Text.IndexOf(' ') >= 0 && ending.IsMatch(s3))
+                        nextSpaceIndex = s.Length;
+                    }
+
+                    if (nextSpaceIndex > index + 1)
+                    {
+                        var s3 = s.AsSpan(0, nextSpaceIndex);
+                        foreach (var ending in noBreakAfter.MultiWordItems)
                         {
-                            return false;
+                            if (ending.IsMatch(s3))
+                            {
+                                return false;
+                            }
                         }
                     }
                 }
@@ -328,17 +336,18 @@ namespace Nikse.SubtitleEdit.Core.Common
         }
 
         private static string _lastNoBreakAfterListLanguage;
-        private static List<NoBreakAfterItem> _lastNoBreakAfterList = new List<NoBreakAfterItem>();
-
-        // CanBreak asks for this once per candidate break point, and AutoBreakLine(text) passes no
-        // language at all, so the "no language" case must not allocate a list every time.
-        private static readonly List<NoBreakAfterItem> EmptyNoBreakAfterList = new List<NoBreakAfterItem>();
+        private static NoBreakAfterListInfo _lastNoBreakAfterList = NoBreakAfterListInfo.Empty;
 
         internal static IEnumerable<NoBreakAfterItem> NoBreakAfterList(string languageName)
         {
+            return GetNoBreakAfterListInfo(languageName).Items;
+        }
+
+        internal static NoBreakAfterListInfo GetNoBreakAfterListInfo(string languageName)
+        {
             if (string.IsNullOrEmpty(languageName))
             {
-                return EmptyNoBreakAfterList;
+                return NoBreakAfterListInfo.Empty;
             }
 
             if (languageName == _lastNoBreakAfterListLanguage)
@@ -346,7 +355,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return _lastNoBreakAfterList;
             }
 
-            _lastNoBreakAfterList = new List<NoBreakAfterItem>();
+            var items = new List<NoBreakAfterItem>();
 
             //load words via xml
             string noBreakAfterFileName = DictionaryFolder + languageName + "_NoBreakAfterList.xml";
@@ -361,15 +370,17 @@ namespace Nikse.SubtitleEdit.Core.Common
                         if (node.Attributes?["RegEx"] != null && node.Attributes["RegEx"].InnerText.Equals("true", StringComparison.OrdinalIgnoreCase))
                         {
                             var r = new Regex(node.InnerText, RegexOptions.Compiled);
-                            _lastNoBreakAfterList.Add(new NoBreakAfterItem(r, node.InnerText));
+                            items.Add(new NoBreakAfterItem(r, node.InnerText));
                         }
                         else
                         {
-                            _lastNoBreakAfterList.Add(new NoBreakAfterItem(node.InnerText.TrimStart()));
+                            items.Add(new NoBreakAfterItem(node.InnerText.TrimStart()));
                         }
                     }
                 }
             }
+
+            _lastNoBreakAfterList = new NoBreakAfterListInfo(items);
             _lastNoBreakAfterListLanguage = languageName;
 
             return _lastNoBreakAfterList;

--- a/src/libuilogic/Export/ImageRenderer.cs
+++ b/src/libuilogic/Export/ImageRenderer.cs
@@ -139,8 +139,6 @@ public static class ImageRenderer
 
         //System.IO.File.WriteAllBytes(@"C:\temp\debug_raw.png", tempBitmap.ToPngArray());
 
-        var bitmapNoPadding = tempBitmap.TrimTransparentPixels();
-
         // The tight glyph-bound trim would make the bitmap height depend on the glyphs
         // present (ascenders/descenders), so bottom-anchored exports (PGS, VobSub,
         // BDN-XML) would place subtitles with and without descenders at different
@@ -148,25 +146,49 @@ public static class ImageRenderer
         // instead: top = first baseline - ascent, bottom = last baseline + descent,
         // plus room for outline and shadow. The height then depends only on the line
         // count, and the baselines land at fixed screen positions for every alignment.
-        // Note: TrimResult.Top/Left are absolute canvas coordinates, while Right/Bottom
-        // are distances from the canvas edges - convert before comparing.
+        //
+        // Measuring the drawn bounds and cropping to the union of them and the line box
+        // is one copy of the scratch canvas; trimming tight and re-padding afterwards
+        // was two.
+        var drawnBounds = tempBitmap.GetNonTransparentBounds();
+        if (drawnBounds.IsEmpty)
+        {
+            // Text that draws nothing despite not being whitespace (an unsupported codepoint,
+            // say). TrimTransparentPixels fell back to a copy of the whole scratch canvas here,
+            // so keep that shape rather than changing what those exports contain.
+            drawnBounds = new SkiaExt.NonTransparentBounds
+            {
+                Left = 0,
+                Top = 0,
+                Right = tempBitmap.Width - 1,
+                Bottom = tempBitmap.Height - 1,
+            };
+        }
+
         var firstBaseline = textStartY;
         var lastBaseline = textStartY + (lines.Count - 1) * (baseLineHeight + lineSpacing);
         // Floor/ceiling, not (int) truncation - truncation rounds toward zero, which
         // would wobble the padding by 0-1 px depending on the fractional font metrics.
         var lineBoxTop = (int)Math.Floor(firstBaseline - Math.Abs(fontMetrics.Ascent) - Math.Abs(outlineWidth));
         var lineBoxBottom = (int)Math.Ceiling(lastBaseline + Math.Abs(fontMetrics.Descent) + Math.Abs(outlineWidth) + Math.Abs(shadowWidth));
-        var tightTop = bitmapNoPadding.Top;
-        var tightBottom = tempBitmap.Height - 1 - bitmapNoPadding.Bottom;
-        var topPad = Math.Max(0, tightTop - lineBoxTop);
-        var bottomPad = Math.Max(0, lineBoxBottom - tightBottom);
-        var textBitmap = topPad > 0 || bottomPad > 0
-            ? bitmapNoPadding.TrimmedBitmap.AddTransparentMargins(0, topPad, 0, bottomPad)
-            : bitmapNoPadding.TrimmedBitmap;
+
+        // The line box can only fall outside the scratch canvas for text taller than the
+        // canvas, which is already clipped; keep the transparent rows for it anyway so the
+        // exported height stays a function of the line count alone.
+        var cropTop = Math.Max(0, Math.Min(drawnBounds.Top, lineBoxTop));
+        var cropBottom = Math.Min(tempBitmap.Height - 1, Math.Max(drawnBounds.Bottom, lineBoxBottom));
+        var overflowTop = cropTop - Math.Min(drawnBounds.Top, lineBoxTop);
+        var overflowBottom = Math.Max(drawnBounds.Bottom, lineBoxBottom) - cropBottom;
+
+        var textBitmap = tempBitmap.CropTo(drawnBounds.Left, cropTop, drawnBounds.Right, cropBottom);
+        if (overflowTop > 0 || overflowBottom > 0)
+        {
+            textBitmap = Replace(textBitmap, textBitmap.AddTransparentMargins(0, overflowTop, 0, overflowBottom));
+        }
 
         if (ip.BoxType != ExportBoxType.None)
         {
-            textBitmap = DrawBoxBehindText(textBitmap, lines, ip, regularFont, boldFont, italicFont, boldItalicFont, baseLineHeight, lineSpacing);
+            textBitmap = Replace(textBitmap, DrawBoxBehindText(textBitmap, lines, ip, regularFont, boldFont, italicFont, boldItalicFont, baseLineHeight, lineSpacing));
         }
 
         if (ip.PaddingTopBottom == 0 && ip.PaddingLeftRight == 0)
@@ -174,10 +196,26 @@ public static class ImageRenderer
             return textBitmap;
         }
 
-        var bitmapWithMargins = textBitmap.AddTransparentMargins(ip.PaddingLeftRight, ip.PaddingTopBottom, ip.PaddingLeftRight, ip.PaddingTopBottom);
+        var bitmapWithMargins = Replace(textBitmap,
+            textBitmap.AddTransparentMargins(ip.PaddingLeftRight, ip.PaddingTopBottom, ip.PaddingLeftRight, ip.PaddingTopBottom));
         //System.IO.File.WriteAllBytes(@"C:\temp\debug_with_margins.png", bitmapWithMargins.ToPngArray());
 
         return bitmapWithMargins;
+    }
+
+    /// <summary>
+    /// Each of the wrapping steps returns a new bitmap, and every SKBitmap holds a native pixel
+    /// buffer - a feature-length export runs this 2000+ times, so the intermediates have to go
+    /// back straight away instead of waiting for a finalizer.
+    /// </summary>
+    private static SKBitmap Replace(SKBitmap previous, SKBitmap replacement)
+    {
+        if (!ReferenceEquals(previous, replacement))
+        {
+            previous.Dispose();
+        }
+
+        return replacement;
     }
 
     // FontFaces.CreateTypeface may return null when the requested face is missing and Skia

--- a/src/ui/Logic/MergeManager.cs
+++ b/src/ui/Logic/MergeManager.cs
@@ -50,6 +50,14 @@ namespace Nikse.SubtitleEdit.Logic
             var firstIndex = 0;
             double endMilliseconds = 0;
             var next = 0;
+
+            // Auto-detection reads the whole file (two subtitle copies, then ~30 word-count passes
+            // over the joined text), so it must run once per merge - not once per merged line.
+            // Merging the lines only edits trailing continuation marks, which cannot change a
+            // whole-file language verdict.
+            string? language = null;
+            string DetectLanguage() => language ?? (language = LanguageAutoDetect.AutoDetectGoogleLanguage(subtitle));
+
             foreach (var index in selectedIndices)
             {
                 if (first)
@@ -75,7 +83,7 @@ namespace Nikse.SubtitleEdit.Logic
                     var continuationProfile = ContinuationUtilities.GetContinuationProfile(continuationStyle);
                     if (next < firstIndex + selectedIndices.Length)
                     {
-                        var mergeResult = ContinuationUtilities.MergeHelper(subtitle.Paragraphs[index].Text, subtitle.Paragraphs[index + 1].Text, continuationProfile, LanguageAutoDetect.AutoDetectGoogleLanguage(subtitle));
+                        var mergeResult = ContinuationUtilities.MergeHelper(subtitle.Paragraphs[index].Text, subtitle.Paragraphs[index + 1].Text, continuationProfile, DetectLanguage());
                         subtitle.Paragraphs[index].Text = mergeResult.Item1;
                         subtitle.Paragraphs[index + 1].Text = mergeResult.Item2;
                     }
@@ -119,7 +127,7 @@ namespace Nikse.SubtitleEdit.Logic
             }
             else
             {
-                text = Utilities.AutoBreakLine(text, LanguageAutoDetect.AutoDetectGoogleLanguage(subtitle));
+                text = Utilities.AutoBreakLine(text, DetectLanguage());
             }
 
             currentParagraph.Text = text;
@@ -157,6 +165,14 @@ namespace Nikse.SubtitleEdit.Logic
             var firstIndex = 0;
             double endMilliseconds = 0;
             var next = 0;
+
+            // Auto-detection copies the whole grid into a Subtitle and runs ~30 word-count passes
+            // over the joined text, so it must run once per merge - not once per merged line (and
+            // not three more times for the auto-break calls below). Merging only edits trailing
+            // continuation marks, which cannot change a whole-file language verdict.
+            string? language = null;
+            string DetectLanguage() => language ?? (language = inputSubtitle.AutoDetectGoogleLanguage());
+
             foreach (var selectedItem in selectedItems)
             {
                 var index = inputSubtitle.IndexOf(selectedItem);
@@ -183,7 +199,7 @@ namespace Nikse.SubtitleEdit.Logic
                     var continuationProfile = ContinuationUtilities.GetContinuationProfile(continuationStyle);
                     if (next < firstIndex + selectedItems.Count)
                     {
-                        var mergeResult = ContinuationUtilities.MergeHelper(inputSubtitle[index].Text, inputSubtitle[index + 1].Text, continuationProfile, inputSubtitle.AutoDetectGoogleLanguage());
+                        var mergeResult = ContinuationUtilities.MergeHelper(inputSubtitle[index].Text, inputSubtitle[index + 1].Text, continuationProfile, DetectLanguage());
                         inputSubtitle[index].Text = mergeResult.Item1;
                         inputSubtitle[index + 1].Text = mergeResult.Item2;
                     }
@@ -229,7 +245,7 @@ namespace Nikse.SubtitleEdit.Logic
             }
             else if (breakMode != BreakMode.KeepBreaks)
             {
-                text = Utilities.AutoBreakLine(text, inputSubtitle.AutoDetectGoogleLanguage());
+                text = Utilities.AutoBreakLine(text, DetectLanguage());
             }
 
             currentParagraph.Text = text;
@@ -251,7 +267,7 @@ namespace Nikse.SubtitleEdit.Logic
                 }
                 else if (breakMode != BreakMode.KeepBreaks)
                 {
-                    originalText = Utilities.AutoBreakLine(originalText, inputSubtitle.AutoDetectGoogleLanguage());
+                    originalText = Utilities.AutoBreakLine(originalText, DetectLanguage());
                 }
 
                 currentParagraph.OriginalText = originalText;

--- a/tests/benchmarks/ImageRendererBenchmarks.cs
+++ b/tests/benchmarks/ImageRendererBenchmarks.cs
@@ -1,0 +1,79 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.BluRaySup;
+using Nikse.SubtitleEdit.UiLogic.Export;
+using SkiaSharp;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// Image-based export (Blu-ray SUP, VobSub, BDN-XML, "export as images") calls
+/// <see cref="ImageRenderer.GenerateBitmap"/> once per subtitle line, so a feature-length file runs
+/// it 1500-2500 times. Each call rasterises into an oversized 4000x2000 scratch canvas and then has
+/// to find the drawn pixels in it.
+/// </summary>
+[MemoryDiagnoser]
+public class ImageRendererBenchmarks
+{
+    private ImageParameter _parameter = new();
+    private SKBitmap _scratch = new(1, 1);
+
+    /// <summary>Extra transparent margin around the exported bitmap (an export setting).</summary>
+    [Params(0, 10)]
+    public int Padding { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _parameter = new ImageParameter
+        {
+            Text = "It was the best of times," + Environment.NewLine + "it was the worst of times.",
+            FontName = "Arial",
+            FontSize = 60,
+            FontColor = SKColors.White,
+            OutlineColor = SKColors.Black,
+            OutlineWidth = 3,
+            ShadowColor = SKColors.Black,
+            ShadowWidth = 2,
+            ScreenWidth = 1920,
+            ScreenHeight = 1080,
+            BottomTopMargin = 20,
+            LeftRightMargin = 20,
+            LineSpacingPercent = 100,
+            PaddingLeftRight = Padding,
+            PaddingTopBottom = Padding,
+            Alignment = ExportAlignment.BottomCenter,
+        };
+
+        // The scratch canvas GenerateBitmap allocates internally, with a realistic amount of drawn
+        // content in it, so the trim scan can be measured on its own.
+        _scratch = new SKBitmap(4000, 2000);
+        using (var canvas = new SKCanvas(_scratch))
+        {
+            canvas.Clear(SKColors.Transparent);
+            using var paint = new SKPaint { Color = SKColors.White, IsAntialias = true };
+            using var font = new SKFont(SKTypeface.Default, 60);
+            canvas.DrawText("It was the best of times,", 40, 120, SKTextAlign.Left, font, paint);
+            canvas.DrawText("it was the worst of times.", 40, 200, SKTextAlign.Left, font, paint);
+        }
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _scratch.Dispose();
+
+    [Benchmark]
+    public int GenerateBitmap()
+    {
+        using var bitmap = ImageRenderer.GenerateBitmap(_parameter);
+        return bitmap.Height;
+    }
+
+    [Benchmark]
+    public int TrimTransparentPixels()
+    {
+        var result = _scratch.TrimTransparentPixels();
+        using (result.TrimmedBitmap)
+        {
+            return result.Top;
+        }
+    }
+}

--- a/tests/benchmarks/MergeManagerBenchmarks.cs
+++ b/tests/benchmarks/MergeManagerBenchmarks.cs
@@ -1,0 +1,49 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using System.Collections.ObjectModel;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// "Merge selected lines" is a single user gesture, but it used to auto-detect the language of the
+/// whole file once per merged line - and every detection deep-copied the entire subtitle twice
+/// before running ~30 word-count passes over the joined text. Merging a handful of lines in a
+/// feature-length file therefore cost seconds.
+/// </summary>
+[MemoryDiagnoser]
+public class MergeManagerBenchmarks
+{
+    private ObservableCollection<SubtitleLineViewModel> _lines = new();
+    private List<SubtitleLineViewModel> _selected = new();
+
+    /// <summary>Lines in the loaded file - a feature-length subtitle is 1500-2500 lines.</summary>
+    [Params(2000)]
+    public int Lines { get; set; }
+
+    /// <summary>Lines the user selected and merged in one gesture.</summary>
+    [Params(2, 20)]
+    public int Selected { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Configuration.Settings.General.ContinuationStyle = ContinuationStyle.OnlyTrailingDots;
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        _lines = new ObservableCollection<SubtitleLineViewModel>(SubtitleFactory.Make(Lines));
+        _selected = _lines.Skip(10).Take(Selected).ToList();
+    }
+
+    [Benchmark]
+    public int MergeSelectedLines()
+    {
+        new MergeManager().MergeSelectedLines(_lines, _selected);
+        return _lines.Count;
+    }
+}

--- a/tests/benchmarks/NoBreakAfterBenchmarks.cs
+++ b/tests/benchmarks/NoBreakAfterBenchmarks.cs
@@ -1,0 +1,79 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// With "no line break after" enabled, <see cref="Utilities.AutoBreakLine(string, string)"/> asks
+/// <c>CanBreak</c> about every space in the line, and CanBreak walks the whole per-language list.
+/// The multi-word phrase check (issue #9631) added a second walk plus a substring per candidate,
+/// even though only 2 of the 33 shipped lists contain a multi-word entry at all.
+///
+/// The list sizes mirror the shipped files: 19 items for English, 117 for Greek (the largest).
+/// </summary>
+[MemoryDiagnoser]
+public class NoBreakAfterBenchmarks
+{
+    private const string Long = "It was the best of times, it was the worst of times, it was the age of wisdom, " +
+                                "it was the age of foolishness, it was the epoch of belief.";
+
+    private string _dictionaryFolder = string.Empty;
+    private string _oldDataDirectory = string.Empty;
+    private bool _oldUseNoLineBreakAfter;
+
+    /// <summary>Entries in the language's NoBreakAfterList.</summary>
+    [Params(19, 117)]
+    public int ListItems { get; set; }
+
+    /// <summary>Whether the list contains a multi-word phrase (only bg and mk do).</summary>
+    [Params(false, true)]
+    public bool MultiWord { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _oldDataDirectory = Configuration.DataDirectory;
+        _oldUseNoLineBreakAfter = Configuration.Settings.Tools.UseNoLineBreakAfter;
+        _dictionaryFolder = Path.Combine(Path.GetTempPath(), "seNoBreakAfterBench_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(_dictionaryFolder, "Dictionaries"));
+
+        var items = new List<string>();
+        for (var i = 0; i < ListItems; i++)
+        {
+            items.Add("wrd" + i + ".");
+        }
+
+        if (MultiWord)
+        {
+            items[items.Count - 1] = "SORT OF";
+        }
+
+        var xml = "<NoBreakAfterList>" + Environment.NewLine +
+                  string.Join(Environment.NewLine, items.Select(p => "  <Item>" + p + "</Item>")) +
+                  Environment.NewLine + "</NoBreakAfterList>";
+        File.WriteAllText(Path.Combine(_dictionaryFolder, "Dictionaries", "zz_NoBreakAfterList.xml"), xml);
+
+        Configuration.DataDirectory = _dictionaryFolder;
+        Configuration.Settings.Tools.UseNoLineBreakAfter = true;
+        Utilities.ResetNoBreakAfterList();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        Configuration.DataDirectory = _oldDataDirectory;
+        Configuration.Settings.Tools.UseNoLineBreakAfter = _oldUseNoLineBreakAfter;
+        Utilities.ResetNoBreakAfterList();
+        try
+        {
+            Directory.Delete(_dictionaryFolder, true);
+        }
+        catch
+        {
+            // best effort
+        }
+    }
+
+    [Benchmark]
+    public string AutoBreakLine() => Utilities.AutoBreakLinePrivate(Long, 43, 0, "zz", false);
+}

--- a/tests/libse/BluRaySup/SkiaExtTrimTest.cs
+++ b/tests/libse/BluRaySup/SkiaExtTrimTest.cs
@@ -1,0 +1,135 @@
+using Nikse.SubtitleEdit.Core.BluRaySup;
+using SkiaSharp;
+
+namespace LibSETests.BluRaySup;
+
+/// <summary>
+/// <see cref="SkiaExt.GetNonTransparentBounds"/> tests eight pixels per branch and stops at the
+/// first hit in a row, so the interesting cases are the ones near the block boundary: widths that
+/// are not a multiple of eight, content in the first and last pixel of a row, and rows that only
+/// have content between bounds already found by an earlier row.
+/// </summary>
+public class SkiaExtTrimTest
+{
+    private static SKBitmap MakeBitmap(int width, int height, params (int X, int Y, byte Alpha)[] spots)
+    {
+        var bitmap = new SKBitmap(width, height);
+        bitmap.Erase(SKColors.Transparent);
+        foreach (var spot in spots)
+        {
+            bitmap.SetPixel(spot.X, spot.Y, new SKColor(200, 100, 50, spot.Alpha));
+        }
+
+        return bitmap;
+    }
+
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(7, 3)]   // shorter than one block
+    [InlineData(8, 8)]   // exactly one block
+    [InlineData(9, 5)]   // one block plus a remainder
+    [InlineData(17, 17)]
+    [InlineData(64, 33)]
+    public void GetNonTransparentBounds_FindsSinglePixelAnywhere(int width, int height)
+    {
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                using var bitmap = MakeBitmap(width, height, (x, y, 255));
+
+                var bounds = bitmap.GetNonTransparentBounds();
+
+                Assert.False(bounds.IsEmpty);
+                Assert.Equal(x, bounds.Left);
+                Assert.Equal(x, bounds.Right);
+                Assert.Equal(y, bounds.Top);
+                Assert.Equal(y, bounds.Bottom);
+            }
+        }
+    }
+
+    [Fact]
+    public void GetNonTransparentBounds_AlphaOfOneCounts()
+    {
+        using var bitmap = MakeBitmap(20, 4, (13, 2, 1));
+
+        var bounds = bitmap.GetNonTransparentBounds();
+
+        Assert.Equal(13, bounds.Left);
+        Assert.Equal(13, bounds.Right);
+        Assert.Equal(2, bounds.Top);
+        Assert.Equal(2, bounds.Bottom);
+    }
+
+    [Fact]
+    public void GetNonTransparentBounds_FullyTransparentIsEmpty()
+    {
+        using var bitmap = MakeBitmap(33, 9);
+
+        Assert.True(bitmap.GetNonTransparentBounds().IsEmpty);
+    }
+
+    // The right edge is only searched beyond the widest hit so far, so a later row whose content
+    // sits inside the bounds found earlier must not narrow them.
+    [Fact]
+    public void GetNonTransparentBounds_LaterInnerRowDoesNotNarrowTheBounds()
+    {
+        using var bitmap = MakeBitmap(40, 6, (0, 1, 255), (39, 1, 255), (20, 4, 255));
+
+        var bounds = bitmap.GetNonTransparentBounds();
+
+        Assert.Equal(0, bounds.Left);
+        Assert.Equal(39, bounds.Right);
+        Assert.Equal(1, bounds.Top);
+        Assert.Equal(4, bounds.Bottom);
+    }
+
+    [Fact]
+    public void TrimTransparentPixels_CropsToTheDrawnPixels()
+    {
+        using var bitmap = MakeBitmap(30, 20, (5, 4, 255), (11, 9, 255));
+
+        var result = bitmap.TrimTransparentPixels();
+
+        using (result.TrimmedBitmap)
+        {
+            Assert.Equal(7, result.TrimmedBitmap.Width);
+            Assert.Equal(6, result.TrimmedBitmap.Height);
+            Assert.Equal(5, result.Left);
+            Assert.Equal(4, result.Top);
+            Assert.Equal(30 - 11 - 1, result.Right);   // distance from the right edge
+            Assert.Equal(20 - 9 - 1, result.Bottom);   // distance from the bottom edge
+            Assert.Equal(255, result.TrimmedBitmap.GetPixel(0, 0).Alpha);
+            Assert.Equal(255, result.TrimmedBitmap.GetPixel(6, 5).Alpha);
+            Assert.Equal(0, result.TrimmedBitmap.GetPixel(3, 3).Alpha);
+        }
+    }
+
+    [Fact]
+    public void TrimTransparentPixels_FullyTransparentKeepsTheOriginalSize()
+    {
+        using var bitmap = MakeBitmap(12, 7);
+
+        var result = bitmap.TrimTransparentPixels();
+
+        using (result.TrimmedBitmap)
+        {
+            Assert.Equal(12, result.TrimmedBitmap.Width);
+            Assert.Equal(7, result.TrimmedBitmap.Height);
+        }
+    }
+
+    [Fact]
+    public void CropTo_KeepsTheRequestedRectangleAndPadsOutsideItTransparently()
+    {
+        using var bitmap = MakeBitmap(20, 10, (4, 3, 255));
+
+        using var cropped = bitmap.CropTo(2, 1, 6, 5);
+
+        Assert.Equal(5, cropped.Width);
+        Assert.Equal(5, cropped.Height);
+        Assert.Equal(255, cropped.GetPixel(2, 2).Alpha);
+        Assert.Equal(0, cropped.GetPixel(0, 0).Alpha);
+    }
+}

--- a/tests/libse/Common/UtilitiesTest.cs
+++ b/tests/libse/Common/UtilitiesTest.cs
@@ -134,6 +134,47 @@ public class UtilitiesTest
         }
     }
 
+    // A regex entry matches against the text before the break point. CanBreak matches the list
+    // against a span and only materialises that text as a string when the list has a regex in it,
+    // so a list with one still has to work - none of the shipped lists has one.
+    [Fact]
+    public void AutoBreakLine_NoBreakAfterRegexEntry_IsHonored()
+    {
+        var oldDataDirectory = Configuration.DataDirectory;
+        var oldUseNoLineBreakAfter = Configuration.Settings.Tools.UseNoLineBreakAfter;
+        var dictionaryFolder = Path.Combine(Path.GetTempPath(), "seRegexNoBreak_" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(dictionaryFolder, "Dictionaries"));
+            File.WriteAllText(Path.Combine(dictionaryFolder, "Dictionaries", "zz_NoBreakAfterList.xml"),
+                "<NoBreakAfterList>" + Environment.NewLine +
+                "  <Item RegEx=\"true\">\\bnumber$</Item>" + Environment.NewLine +
+                "</NoBreakAfterList>");
+            Configuration.DataDirectory = dictionaryFolder;
+            Configuration.Settings.Tools.UseNoLineBreakAfter = true;
+            Utilities.ResetNoBreakAfterList();
+
+            var result = Utilities.AutoBreakLinePrivate("Call the number seven now", 14, 0, "zz", false);
+
+            var lines = result.SplitToLines();
+            Assert.True(lines.Count == 2, "Expected two lines, got: " + result);
+            Assert.False(lines[0].TrimEnd().EndsWith("number"), "Broke after the regex entry: " + result);
+        }
+        finally
+        {
+            Configuration.DataDirectory = oldDataDirectory;
+            Configuration.Settings.Tools.UseNoLineBreakAfter = oldUseNoLineBreakAfter;
+            Utilities.ResetNoBreakAfterList();
+            try
+            {
+                Directory.Delete(dictionaryFolder, true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
     // GetColorFromFontString measured colorStart relative to the extracted <font> tag
     // but indexed the full string, so a tag that wasn't at the start of the line read
     // the wrong region and returned the default color.


### PR DESCRIPTION
Performance hunt over this week's commits. Three hot paths that recent fixes either made slower or left slow while touching them. Every change is measured with BenchmarkDotNet (new benchmark classes included) and produces byte-identical output.

## Merge selected lines — 18.6× faster

`MergeManager` (touched by the "keep end time when merging" commit) ran whole-file language auto-detection **once per merged line**. Each run deep-copies the subtitle twice and then does ~30 word-count passes over the joined text, so merging N lines in a P-line file cost N × O(P). It now detects once per merge, lazily, so a merge that needs neither continuation handling nor auto-break does not pay for it at all. Merging only edits trailing continuation marks, which cannot change a whole-file language verdict.

| 2000-line file | before | after | |
|---|---|---|---|
| merge 20 lines | 290.2 ms / 34.85 MB | **15.6 ms / 2.01 MB** | 18.6× / 17.3× |
| merge 2 lines | 29.0 ms / 3.46 MB | **15.0 ms / 1.73 MB** | 1.9× / 2.0× |

The three Gen0/Gen1/Gen2 collections per merge are gone, and the cost is now flat in the selection size instead of linear.

## Auto break line — 2.0× faster

The multi-word phrase check added for #9631 walked the whole per-language list a second time and allocated a substring for every candidate break point — even though only 2 of the 33 shipped lists contain a multi-word entry at all. The list's derived facts (has a regex entry; which entries are phrases) are now computed once when the list is loaded, and `NoBreakAfterItem` gained a span overload so matching no longer needs the text before the break point as a string. Only a regex entry still does, and no shipped list has one.

Measured with "no line break after" enabled:

| list size | before | after | |
|---|---|---|---|
| 117 entries (Greek, largest shipped) | 22.7 µs | **11.2 µs** | 2.0× |
| 19 entries (English) | 6.6 µs | **3.9 µs** | 1.7× |
| allocation, all cases | 31.24 KB | **20.34 KB** | 1.5× |

## Image export — 1.6× faster end to end

`ImageRenderer.GenerateBitmap` runs once per subtitle line for PGS, VobSub, BDN-XML and "export as images", so a feature-length file runs it 2000+ times.

- **Finding the drawn pixels** in the 4000×2000 scratch canvas was a scalar per-pixel loop with no early exit — 8M branchy iterations per line, 60% of the whole render. It now tests eight pixels per branch, stops at the first hit in a row, and only searches the part of a row that could still widen the bounds.
- **The line-box anchoring** added for #13202 made a second full copy of the bitmap to re-pad what the trim had just cropped away. Measuring the bounds first and cropping once to the union of them and the line box does it in one copy.
- **The intermediate bitmaps were never disposed**, so their native pixel buffers waited for a finalizer — 2000+ times per exported file.

| | before | after | |
|---|---|---|---|
| trim scan | 2.92 ms | **1.16 ms** | 2.5× |
| whole `GenerateBitmap` | 4.86 ms | **2.95 ms** | 1.6× |

That is roughly 3.7 s off a 2000-line image-based export.

## Verification

- **2780 tests pass**: libse 887, libuilogic 140, seconv 290, UI 1463. New tests cover the rewritten pixel scan (single pixel at every position for widths on either side of the 8-pixel block boundary, alpha == 1, fully transparent, inner rows not narrowing the bounds) and a regex "no break after" entry, which no shipped list exercises.
- **Byte-identity proof beyond the tests**: a harness dumped 360 rendered bitmap hashes (10 texts × padding × box type × outline/shadow × font size), 88 trim results and 2244 auto-break results (every shipped `NoBreakAfterList`, setting on and off, three line lengths) before and after. The output is byte-identical.
- Benchmarks were run as before/after pairs around `git stash` in the same session, default job, on an idle machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
