### PR TITLE
Fix #12286: load names list in seconv FixCommonErrors (no period before names)

### DIFF
--- a/src/libse/Forms/FixCommonErrors/EmptyFixCallback.cs
+++ b/src/libse/Forms/FixCommonErrors/EmptyFixCallback.cs
@@ -53,9 +53,17 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 
         public string Language { get; set; } = "en";
 
+        /// <summary>
+        /// Names from the <c>Dictionaries/&lt;lang&gt;_names.xml</c> lists, or empty when the
+        /// caller does not load them. Backs <see cref="IsName"/> so rules like "Add missing
+        /// period" do not treat always-uppercase names (e.g. "Roemenië") as sentence starts
+        /// (#12286; case-sensitive, like the GUI names list).
+        /// </summary>
+        public HashSet<string> Names { get; set; } = new HashSet<string>(StringComparer.Ordinal);
+
         public bool IsName(string candidate)
         {
-            return false;
+            return Names.Contains(candidate);
         }
 
         public Encoding Encoding { get; set; } = Encoding.UTF8;

--- a/src/seconv/Core/FixCommonErrorsRunner.cs
+++ b/src/seconv/Core/FixCommonErrorsRunner.cs
@@ -5,6 +5,7 @@ using Nikse.SubtitleEdit.Core.Interfaces;
 using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
 using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 using SkiaSharp;
+using System.Collections.Concurrent;
 using System.Globalization;
 
 namespace SeConv.Core;
@@ -31,6 +32,9 @@ internal static class FixCommonErrorsRunner
     internal const string OcrFixRuleId = "FixCommonOcrErrors";
 
     private static readonly IReadOnlyList<(string Id, Func<IFixCommonError> Factory)> Rules = BuildRules();
+    // Dictionary paths are case-sensitive on Linux. Prefer an occasional duplicate cache entry
+    // on Windows over returning another directory's names list on a case-sensitive file system.
+    private static readonly ConcurrentDictionary<string, HashSet<string>> NamesByFolderAndLanguage = new(StringComparer.Ordinal);
 
     public static IReadOnlyList<string> AvailableRuleIds { get; } =
         Rules.Select(r => r.Id).Append(OcrFixRuleId).ToArray();
@@ -149,6 +153,11 @@ internal static class FixCommonErrorsRunner
             // Without this the uppercase-after-period rules treat every abbreviation period as a
             // sentence ending, e.g. Dutch "dhr. de vries" -> "dhr. De vries" (#13082).
             Abbreviations = AbbreviationList.Load(SpellCheckConfig.DictionariesFolder(), language),
+
+            // Same names-list backing as the GUI dialog (which loads it since #13085): without it
+            // IsName() always returns false, so "Add missing period" adds a period before
+            // always-uppercase names like "Roemenië" on the next line (#12286).
+            Names = LoadNames(language),
         };
 
         // Fix Common Errors is not idempotent in a single pass: one rule can create a
@@ -177,6 +186,16 @@ internal static class FixCommonErrorsRunner
         {
             RunOcrFix(subtitle, language);
         }
+    }
+
+    private static HashSet<string> LoadNames(string language)
+    {
+        var folder = SpellCheckConfig.DictionariesFolder();
+        var normalizedFolder = string.IsNullOrEmpty(folder) ? string.Empty : Path.GetFullPath(folder);
+        var key = normalizedFolder + "\0" + language;
+        return NamesByFolderAndLanguage.GetOrAdd(
+            key,
+            _ => new NameList(folder, language, false, string.Empty).GetNames());
     }
 
     /// <summary>

--- a/tests/seconv/Core/FixCommonErrorsRunnerTest.cs
+++ b/tests/seconv/Core/FixCommonErrorsRunnerTest.cs
@@ -1,4 +1,6 @@
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 using SeConv.Core;
 using Xunit;
 
@@ -6,6 +8,37 @@ namespace SeConvTests.Core;
 
 public class FixCommonErrorsRunnerTest
 {
+    [Fact]
+    public void Run_MissingPeriod_DoesNotAddPeriodBeforeLoadedName()
+    {
+        var originalFolder = SpellCheckConfig.DictionariesFolder;
+        var folder = Path.Combine(Path.GetTempPath(), "SeConvNamesTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(folder);
+        File.WriteAllText(
+            Path.Combine(folder, "nl_names.xml"),
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?><names><name>Roemenië</name></names>");
+
+        try
+        {
+            SpellCheckConfig.DictionariesFolder = () => folder;
+            var subtitle = new Subtitle();
+            subtitle.Paragraphs.Add(new Paragraph("Dit komt omdat", 0, 1000));
+            subtitle.Paragraphs.Add(new Paragraph("Roemenië een bondgenoot is", 2000, 3000));
+
+            FixCommonErrorsRunner.Run(
+                subtitle,
+                new[] { nameof(FixMissingPeriodsAtEndOfLine) },
+                languageOverride: "nl");
+
+            Assert.Equal("Dit komt omdat", subtitle.Paragraphs[0].Text);
+        }
+        finally
+        {
+            SpellCheckConfig.DictionariesFolder = originalFolder;
+            Directory.Delete(folder, true);
+        }
+    }
+
     [Fact]
     public void RunAll_OnEmptySubtitle_NoThrow()
     {


### PR DESCRIPTION
## Problem

Fixes #12286 (remaining part) — "add a point to a sentence because the next line starts with uppercase. But Roemenië is always uppercase."

The reported dialog behavior was fixed on main (the GUI now loads the names list since #13085 / commit 2698fd7a9: "Also load the names list in FixCommonErrorsViewModel - it was injected but never loaded, so IsName() and GetAbbreviations() were always empty in the dialog"). But the same bug is still live in the **seconv CLI**: `FixCommonErrorsRunner` builds an `EmptyFixCallback` whose `IsName()` hardcodes `return false`, so "Add missing period at end of line" adds a period before always-uppercase names in batch conversion too:

- pre-fix, real file, real seconv run: `maakt haar positie erg moeilijk, omdat.` (period added before "Roemenië" on the next line)
- post-fix, same input: `maakt haar positie erg moeilijk, omdat` (unchanged)

## Fix

- `src/libse/Forms/FixCommonErrors/EmptyFixCallback.cs`: added a `Names` set (empty by default — behavior unchanged for callers that do not load names) and `IsName()` now consults it instead of always returning false.
- `src/seconv/Core/FixCommonErrorsRunner.cs`: load the names list for the effective language and hand it to the callback. The parsed set is cached by normalized dictionary-folder path plus language, so a multi-file batch does not re-parse the three names XML files for every subtitle. `useOnlineNameList: false` is intentional because seconv is an offline deterministic CLI.

## Verification

- `dotnet build src/seconv/SeConv.csproj --no-incremental` — EXIT:0.
- Permanent integration regression test `Run_MissingPeriod_DoesNotAddPeriodBeforeLoadedName` creates a real temporary `nl_names.xml`, calls `FixCommonErrorsRunner.Run(...)` with the real `FixMissingPeriodsAtEndOfLine` rule and `languageOverride: "nl"`, and proves that no period is inserted before `Roemenië`.
- Full `SeConvTests`: 291/291 PASS.
- The issue's real sample was also checked end to end: pre-fix output added `omdat.` before `Roemenië`; post-fix keeps `omdat` unchanged.

## Notes

- The names check is case-sensitive (ordinal), exactly like the GUI names list (`SeNamesList.IsName`), and `NameList` skips missing dictionary files, so languages without names lists behave as before (empty set → rule unchanged).
- This PR complements #13085 (GUI dialog); the issue's remaining surface is the CLI batch path.
- This PR was created with AI assistance (per repo AI contributor guidelines).