### PR TITLE
Fix #13113: add default frame rate setting to options

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -677,7 +677,15 @@ public partial class MainViewModel :
             "60",
             "120"
         };
-        SelectedFrameRate = FrameRates[0];
+        // Show the configured default frame rate in the toolbar combo (Options -> General ->
+        // "Default frame rate", #13113) instead of a hardcoded 23.976 when no video is loaded.
+        var defaultFrameRate = Se.Settings.General.CurrentFrameRate.ToString("0.###", CultureInfo.InvariantCulture);
+        if (!FrameRates.Contains(defaultFrameRate))
+        {
+            FrameRates.Insert(0, defaultFrameRate);
+        }
+
+        SelectedFrameRate = defaultFrameRate;
 
         StatusTextLeft = string.Empty;
         StatusTextRight = string.Empty;

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -267,6 +267,16 @@ public class SettingsPage : UserControl
             MakeNumericSettingInt(Se.Language.Options.Settings.TimeCodeUpDownStepMs, nameof(_vm.TimeCodeUpDownStepMs), 1, 5000),
             MakeCheckboxSetting(Se.Language.Options.Settings.PromptBeforeDelete, nameof(_vm.PromptBeforeDelete)),
             MakeCheckboxSetting(Se.Language.Options.Settings.UseFrameMode, nameof(_vm.UseFrameMode)),
+            new SettingsItem(Se.Language.Options.Settings.DefaultFrameRate, () => new ComboBox
+            {
+                MinWidth = 200,
+                DataContext = _vm,
+                [!ItemsControl.ItemsSourceProperty] = new Binding(nameof(_vm.FrameRates)),
+                [!SelectingItemsControl.SelectedItemProperty] = new Binding(nameof(_vm.SelectedDefaultFrameRate))
+                {
+                    Mode = BindingMode.TwoWay,
+                }
+            }),
             MakeCheckboxSetting(Se.Language.Options.Settings.TextBoxLimitNewLines, nameof(_vm.TextBoxLimitNewLines)),
             MakeCheckboxSetting(Se.Language.General.LockTimeCodes, nameof(_vm.LockTimeCodes)),
             MakeCheckboxSetting(Se.Language.Options.Settings.RememberPositionAndSize, nameof(_vm.RememberPositionAndSize)),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -121,6 +121,9 @@ public partial class SettingsViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(MinGapLabel))]
     private bool _useFrameMode;
 
+    [ObservableProperty] private ObservableCollection<string> _frameRates;
+    [ObservableProperty] private string _selectedDefaultFrameRate;
+
     public bool IsMsMode => !UseFrameMode;
     public string MinGapLabel => UseFrameMode
         ? Se.Language.Options.Settings.MinGapFrames
@@ -552,6 +555,20 @@ public partial class SettingsViewModel : ObservableObject
         Encodings = new ObservableCollection<TextEncoding>(EncodingHelper.GetEncodings());
         DefaultEncoding = Encodings.First();
 
+        FrameRates =
+        [
+            "23.976",
+            "24",
+            "25",
+            "29.97",
+            "30",
+            "50",
+            "59.94",
+            "60",
+            "120"
+        ];
+        SelectedDefaultFrameRate = FrameRates[0];
+
         SubtitleEnterKeyActionTypes =
         [
             Se.Language.Options.Settings.GridGoToSubtitleAndSetVideoPosition,
@@ -723,6 +740,11 @@ public partial class SettingsViewModel : ObservableObject
         CpsLineLengthStrategy = CpsLineLengthStrategies.FirstOrDefault(p => p.Code == general.CpsLineLengthStrategy) ?? CpsLineLengthStrategies.First();
 
         UseFrameMode = general.UseFrameMode;
+        SelectedDefaultFrameRate = general.DefaultFrameRate.ToString("0.###", CultureInfo.InvariantCulture);
+        if (!FrameRates.Contains(SelectedDefaultFrameRate))
+        {
+            FrameRates.Insert(0, SelectedDefaultFrameRate);
+        }
         TextBoxLimitNewLines = general.SubtitleTextBoxLimitNewLines;
         NewEmptyDefaultMs = general.NewEmptyDefaultMs;
         TimeCodeUpDownStepMs = general.TimeCodeUpDownStepMs;
@@ -1566,6 +1588,18 @@ public partial class SettingsViewModel : ObservableObject
         general.CpsLineLengthStrategy = CpsLineLengthStrategy.Code;
 
         general.UseFrameMode = UseFrameMode;
+        if (double.TryParse(SelectedDefaultFrameRate, NumberStyles.Any, CultureInfo.InvariantCulture, out var defaultFrameRate))
+        {
+            general.DefaultFrameRate = defaultFrameRate;
+            if (_mainViewModel is { IsVideoLoaded: false })
+            {
+                // Apply the new default immediately when there is no video-derived rate to keep.
+                // Video open and toolbar selection update both settings stores themselves.
+                general.CurrentFrameRate = defaultFrameRate;
+                Configuration.Settings.General.CurrentFrameRate = defaultFrameRate;
+                _mainViewModel.SelectedFrameRate = defaultFrameRate.ToString("0.###", CultureInfo.InvariantCulture);
+            }
+        }
         general.SubtitleTextBoxLimitNewLines = TextBoxLimitNewLines;
         general.NewEmptyDefaultMs = NewEmptyDefaultMs ?? general.NewEmptyDefaultMs;
         general.TimeCodeUpDownStepMs = TimeCodeUpDownStepMs ?? general.TimeCodeUpDownStepMs;

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -2195,9 +2195,8 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         //
         // Without a fixed rate or a matching video, fall back to the frame rate this batch
         // is actually producing: the target of the "change frame rate" step when it runs
-        // (it runs before this one), otherwise the project frame rate. Configuration
-        // .Settings.General.DefaultFrameRate is not usable here - nothing in the UI ever
-        // assigns it, so it is always libse's built-in 23.976.
+        // (it runs before this one), otherwise the project frame rate. If that is not valid
+        // either, use the user's "Default frame rate" setting from Options (#13113).
         var frameRate = _config.ChangeFrameRate.IsActive && _config.ChangeFrameRate.ToFrameRate > 0
             ? _config.ChangeFrameRate.ToFrameRate
             : Se.Settings.General.CurrentFrameRate;

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -222,6 +222,7 @@ public class LanguageSettings
     public string ResetWaveform { get; set; }
     public string ResetRules { get; set; }
     public string UseFrameMode { get; set; }
+    public string DefaultFrameRate { get; set; }
     public string TextBoxLimitNewLines { get; set; }
     public string MpvOpenGl { get; set; }
     public string MpvSoftwareRendering { get; set; }
@@ -524,6 +525,7 @@ public class LanguageSettings
         ResetWaveform = "Reset waveform";
         ResetRules = "Reset rules";
         UseFrameMode = "Use frame mode (hh.mm.ss.ff)";
+        DefaultFrameRate = "Default frame rate";
         TextBoxLimitNewLines = "Limit number of lines in subtitle text box";
         MpvOpenGl = "libmpv - OpenGL";
         MpvWidRendering = "libmpv - Native Window ID rendering";

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -381,9 +381,20 @@ public class Se
 
         SetDefaultValues();
 
+        // The persisted CurrentFrameRate may predate the "Default frame rate" option (it had no
+        // UI until #13113), so it can silently keep 23.976 even after the user changes the
+        // default. The explicit default now wins at startup; the toolbar frame-rate combo still
+        // overrides it for the session/video.
+        Settings.General.CurrentFrameRate = Settings.General.DefaultFrameRate;
+
         MigrateMacOsFontSettings(Settings.Appearance, OperatingSystem.IsMacOS(), true);
 
         UpdateLibSeSettings();
+
+        // Seed libse's live frame rate once at startup. Do not put this in
+        // UpdateLibSeSettings(): SaveSettings also calls that method, and a later save must not
+        // overwrite a frame rate supplied by the parser after a video has been opened.
+        Configuration.Settings.General.CurrentFrameRate = Settings.General.CurrentFrameRate;
     }
 
     internal static void MigrateMacOsFontSettings(SeAppearance appearance, bool isMacOs, bool isLegacySettings)
@@ -613,6 +624,11 @@ public class Se
     {
         Configuration.Settings.General.FFmpegLocation = Settings.General.FfmpegPath;
         Configuration.Settings.General.UseTimeFormatHHMMSSFF = Settings.General.UseFrameMode;
+        Configuration.Settings.General.DefaultFrameRate = Settings.General.DefaultFrameRate;
+        // Note: the CURRENT frame rate is intentionally NOT pushed here - the video-open path
+        // and the toolbar frame-rate combo write both sides directly (MainViewModel), and an
+        // unconditional push would overwrite the parser's rate with a stale UI value whenever
+        // settings are applied after a video was opened (#13113).
 
         Configuration.Settings.Proxy.ProxyAddress = Settings.General.ProxyAddress ?? string.Empty;
         Configuration.Settings.Proxy.UserName = Settings.General.ProxyUserName ?? string.Empty;

--- a/tests/UI/Logic/Config/FrameRateSettingsTests.cs
+++ b/tests/UI/Logic/Config/FrameRateSettingsTests.cs
@@ -1,0 +1,68 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Logic.Config;
+
+public class FrameRateSettingsTests
+{
+    [Fact]
+    public void LoadSettings_SeedsCurrentFrameRateFromDefault()
+    {
+        var savedSettings = Se.Settings;
+        var savedLibSeRate = Configuration.Settings.General.CurrentFrameRate;
+        var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "se_framerate_load_" + System.Guid.NewGuid().ToString("N") + ".json");
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.General.DefaultFrameRate = 25.0;
+            Se.Settings.General.CurrentFrameRate = 23.976; // stale persisted value from before #13113
+            Se.SaveSettings(path);
+
+            Se.Settings = new Se();
+            Se.LoadSettings(path);
+
+            // The explicit default wins at startup in both the UI settings store and libse.
+            Assert.Equal(25.0, Se.Settings.General.CurrentFrameRate);
+            Assert.Equal(25.0, Configuration.Settings.General.CurrentFrameRate);
+        }
+        finally
+        {
+            Se.Settings = savedSettings;
+            Configuration.Settings.General.CurrentFrameRate = savedLibSeRate;
+            if (System.IO.File.Exists(path))
+            {
+                System.IO.File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void SaveSettings_DoesNotOverwriteVideoDerivedFrameRate()
+    {
+        var savedSettings = Se.Settings;
+        var savedLibSeRate = Configuration.Settings.General.CurrentFrameRate;
+        var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "se_framerate_save_" + System.Guid.NewGuid().ToString("N") + ".json");
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.General.DefaultFrameRate = 25.0;
+            Se.Settings.General.CurrentFrameRate = 25.0;
+            Configuration.Settings.General.CurrentFrameRate = 29.97; // video-derived rate, e.g. from the parser
+
+            Se.SaveSettings(path);
+
+            // SaveSettings must not push a stale UI value over the parser's rate (the
+            // CurrentFrameRate bridge was removed from UpdateLibSeSettings for this reason).
+            Assert.Equal(29.97, Configuration.Settings.General.CurrentFrameRate);
+        }
+        finally
+        {
+            Se.Settings = savedSettings;
+            Configuration.Settings.General.CurrentFrameRate = savedLibSeRate;
+            if (System.IO.File.Exists(path))
+            {
+                System.IO.File.Delete(path);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Fixes #13113 — on macOS (and other platforms) SubtitleEdit 5.x always opens files at the default 23.976 fps and there is no way to change the default frame rate in the UI.

> SE (5.2 beta 2, macOS x64) defaults to opening files in 23.976 fps, and I cannot find a way to change this. It would be great if there was a setting to change the default frame rate, or if SE always remembered the last set frame rate between startups.

The setting value exists (`Se.Settings.General.DefaultFrameRate`, `src/ui/Logic/Config/SeGeneral.cs:40`, default 23.976) but no UI control reads or writes it in SE 5.x — a comment in `src/ui/Features/Tools/BatchConvert/BatchConverter.cs:2112` confirms: "nothing in the UI ever assigns it". SE 4.0.16 had a "Default frame rate" combo box in Options (`src/ui/Forms/Options/Settings.Designer.cs` in tag 4.0.16, saving `gs.DefaultFrameRate = outFrameRate`); the control was lost in the 5.x rewrite.

## Fix

Restore the missing UI control: add a "Default frame rate" combo box to Options → General (next to "Use frame mode"), wired to `Se.Settings.General.DefaultFrameRate`:

- `src/ui/Features/Options/Settings/SettingsPage.cs` — new `SettingsItem` with a `ComboBox` bound to `FrameRates` / `SelectedDefaultFrameRate` (same pattern as the existing DefaultEncoding combo).
- `src/ui/Features/Options/Settings/SettingsViewModel.cs` — `FrameRates` list (23.976/24/25/29.97/30/50/59.94/60/120), load of the current value (inserted into the list when it is not one of the presets), and save back to `general.DefaultFrameRate`.
- `src/ui/Logic/Config/Se.cs` — `LoadSettings()` re-derives the UI-side `CurrentFrameRate = DefaultFrameRate`, bridges the default into libse, and then seeds libse's live `CurrentFrameRate` once at startup. `SaveSettings()` deliberately does not copy the UI-side current rate, so later settings saves cannot overwrite a frame rate supplied by a video parser.
- `src/ui/Logic/Config/Language/Options/LanguageSettings.cs` — "Default frame rate" resource string (the generated `English.json` file is not hand-edited).

`CurrentFrameRate` semantics: at startup it now comes from the configurable default; opening a video still overrides it with the video's actual frame rate (`MainViewModel.cs:19224`), and the toolbar combo still overrides it for the session.

## Verification

- [x] `dotnet build src/ui/UI.csproj -v q -nologo` — EXIT:0, 0 warnings, 0 errors (build.log attached in run)
- [x] Permanent regression tests (committed, `tests/UI/Logic/Config/FrameRateSettingsTests.cs`):
  - `LoadSettings_SeedsCurrentFrameRateFromDefault` — a persisted stale 23.976 current rate is replaced by the configured default (25) on load, in both the UI settings store and libse;
  - `SaveSettings_DoesNotOverwriteVideoDerivedFrameRate` — a parser-provided 29.97 in libse survives a later `SaveSettings(temp)`.
  - 2/2 PASS, plus the neighboring ContinuationStyle round-trip tests 4/4 PASS.
- [ ] Manual verification path:
  1. Start SE 5.x, open Options → General.
  2. "Default frame rate" combo is present next to "Use frame mode" and shows 23.976.
  3. Change it to 25 and close Options — with no video loaded, the toolbar and live frame-rate setting update to 25 immediately.
  4. Restart SE and open an SRT file without loading a video — the frame rate remains 25 (not 23.976), e.g. visible in the status bar / when inserting time codes in frame mode.
  5. Open a video file — the video's actual frame rate still takes over as before.

## Notes

- Interpretation: the issue asks for a way to change the default frame rate; implementing the explicit setting (the first option the reporter suggests) is the smallest change. Remembering the last-used frame rate across startups would change `CurrentFrameRate` semantics, which is deliberately NOT done.
- The combo is intentionally not editable: a rate that is not one of the presets (e.g. 23.98) can only appear if it is already present in `Settings.json`; `FrameRates.Insert(0, …)` displays such a value but there is no way to type a custom one. Deliberate, matching the same pattern as the other frame-rate combos in the app.
- Deliberate non-change: the hard-coded 23.976 fallback in `GetMediaInformation` (`MainViewModel.cs:19224`) is only hit when a video is loaded but its frame rate cannot be read; left untouched to keep `CurrentFrameRate` semantics stable.
- This PR was created with AI assistance (per repo AI contributor guidelines).


## Follow-up (audit-driven, commit deb99c6)

Independent audit found the setting was persisted but never applied at startup: `Settings.json` stores `currentFrameRate`, and it was restored over the constructor's `CurrentFrameRate = DefaultFrameRate` on every load. Fixed:

- `Se.cs` — after settings load, `CurrentFrameRate` is re-seeded from `DefaultFrameRate` (the explicit setting now wins at startup; opening a video still overrides it with the video's real frame rate, and the toolbar combo still overrides it for the session).
- `MainViewModel.cs` — the toolbar frame-rate combo now shows the configured default instead of a hardcoded 23.976 when no video is loaded (custom values are added to the combo list, same pattern as the Options combo).
- `BatchConverter.cs` — comment updated (it claimed no UI ever assigns `DefaultFrameRate`; that is no longer true).

Deliberate behavior change: the last-used frame rate is no longer restored across restarts; the "Default frame rate" setting is authoritative at startup (the issue asked for exactly this).


## Follow-up 2 + maintainer review (final commit 887a210)

The final deep audit found that copying `CurrentFrameRate` inside `UpdateLibSeSettings()` made every `Se.SaveSettings()` overwrite a parser-provided rate (for example 29.97) with stale UI session state (for example 24). The first follow-up removed that copy, but maintainer review correctly found that libse then stayed at its constructor default (23.976) at startup.

Final split of responsibilities:
- `LoadSettings()` seeds both the UI-side and libse live current rate from the user's configured default exactly once at startup.
- `UpdateLibSeSettings()` bridges `DefaultFrameRate`, but does not overwrite the live current rate during later settings saves.
- Saving Options with no video loaded applies the new default immediately to both stores and refreshes the toolbar value. If a video is loaded, its parser-derived rate is preserved.
- The hand-edited generated `English.json` hunk was removed; `LanguageSettings.cs` remains the source of truth.

Verification on 887a210 (real runs):
- clean `dotnet build src/ui/UI.csproj --no-incremental` — EXIT:0;
- focused startup/save probe — 2/2 PASS: startup 25 reaches UI + libse; parser 29.97 survives a later `SaveSettings(temp)`.

