### PR TITLE
Fix #12288: batch auto-translate no longer hangs when translation fails

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -976,68 +976,79 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         ProgressMaxValue = itemsToConvert.Count;
         _ = Task.Run(async () =>
         {
-            var count = 1;
-            foreach (var batchItem in itemsToConvert)
+            // Nothing in this fire-and-forget task may throw its way out: an unobserved fault
+            // leaves IsConverting/IsProgressVisible/AreControlsEnabled set and the dialog frozen
+            // at "Converting 1/4..." forever with no error shown (#12288). The per-item catch
+            // below keeps one bad file from ending the batch; this try/finally guarantees the
+            // dialog is released even if anything outside the loop fails.
+            try
             {
-                var countDisplay = count;
-                ProgressText = string.Format(Se.Language.General.ConvertingXofYDotDoDot, countDisplay, itemsToConvert.Count);
-                ProgressValue = countDisplay / (double)itemsToConvert.Count;
-
-                try
+                var count = 1;
+                foreach (var batchItem in itemsToConvert)
                 {
-                    if (batchItem.Format!.StartsWith("Transport Stream", StringComparison.Ordinal))
+                    var countDisplay = count;
+                    ProgressText = string.Format(Se.Language.General.ConvertingXofYDotDoDot, countDisplay, itemsToConvert.Count);
+                    ProgressValue = countDisplay / (double)itemsToConvert.Count;
+
+                    try
                     {
-                        var tsResult = _batchConvertItemSplitter.LoadTransportStream(batchItem, _cancellationToken);
-                        foreach (var bi in tsResult)
+                        if (batchItem.Format!.StartsWith("Transport Stream", StringComparison.Ordinal))
                         {
-                            if (_cancellationToken.IsCancellationRequested)
+                            var tsResult = _batchConvertItemSplitter.LoadTransportStream(batchItem, _cancellationToken);
+                            foreach (var bi in tsResult)
                             {
-                                break;
+                                if (_cancellationToken.IsCancellationRequested)
+                                {
+                                    break;
+                                }
+                                await _batchConverter.Convert(bi, _cancellationToken);
                             }
-                            await _batchConverter.Convert(bi, _cancellationToken);
+                        }
+                        else
+                        {
+                            await _batchConverter.Convert(batchItem, _cancellationToken);
                         }
                     }
-                    else
+                    catch (Exception exception)
                     {
-                        await _batchConverter.Convert(batchItem, _cancellationToken);
+                        // A failed item (e.g. auto-translate engine not reachable/not configured) must
+                        // not stall the whole batch: mark it as failed and continue with the next file.
+                        if (!_cancellationToken.IsCancellationRequested)
+                        {
+                            SeLogger.Error(exception, "Batch convert failed for: " + batchItem.FileName);
+                            batchItem.Status = string.Format(Se.Language.General.ErrorX, exception.Message);
+                        }
                     }
-                }
-                catch (Exception exception)
-                {
-                    // A failed item (e.g. auto-translate engine not reachable/not configured) must
-                    // not stall the whole batch: mark it as failed and continue with the next file.
-                    // Without this the exception faults the fire-and-forget task below and the dialog
-                    // hangs at "Converting 1/4..." forever with no error shown (#12288).
-                    if (!_cancellationToken.IsCancellationRequested)
+
+                    count++;
+
+                    if (_cancellationToken.IsCancellationRequested)
                     {
-                        SeLogger.Error(exception, "Batch convert failed for: " + batchItem.FileName);
-                        batchItem.Status = string.Format(Se.Language.General.ErrorX, exception.Message);
+                        break;
                     }
                 }
 
-                count++;
-
+                var end = DateTime.UtcNow.Ticks;
+                var elapsed = new TimeSpan(end - start).TotalMilliseconds;
+                var message = string.Format(Se.Language.General.XFilesConvertedInY, itemsToConvert.Count, elapsed);
                 if (_cancellationToken.IsCancellationRequested)
                 {
-                    ProgressText = string.Empty;
-                    break;
+                    message += Environment.NewLine + Se.Language.General.ConversionCancelledByUser;
                 }
+
+                await ShowStatus(message);
             }
-
-            IsProgressVisible = false;
-            IsConverting = false;
-            AreControlsEnabled = true;
-            ProgressText = string.Empty;
-
-            var end = DateTime.UtcNow.Ticks;
-            var elapsed = new TimeSpan(end - start).TotalMilliseconds;
-            var message = string.Format(Se.Language.General.XFilesConvertedInY, itemsToConvert.Count, elapsed);
-            if (_cancellationToken.IsCancellationRequested)
+            catch (Exception exception)
             {
-                message += Environment.NewLine + Se.Language.General.ConversionCancelledByUser;
+                SeLogger.Error(exception, "Batch convert failed");
             }
-
-            await ShowStatus(message);
+            finally
+            {
+                IsProgressVisible = false;
+                IsConverting = false;
+                AreControlsEnabled = true;
+                ProgressText = string.Empty;
+            }
         }, _cancellationToken);
     }
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -983,21 +983,36 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
                 ProgressText = string.Format(Se.Language.General.ConvertingXofYDotDoDot, countDisplay, itemsToConvert.Count);
                 ProgressValue = countDisplay / (double)itemsToConvert.Count;
 
-                if (batchItem.Format!.StartsWith("Transport Stream", StringComparison.Ordinal))
+                try
                 {
-                    var tsResult = _batchConvertItemSplitter.LoadTransportStream(batchItem, _cancellationToken);
-                    foreach (var bi in tsResult)
+                    if (batchItem.Format!.StartsWith("Transport Stream", StringComparison.Ordinal))
                     {
-                        if (_cancellationToken.IsCancellationRequested)
+                        var tsResult = _batchConvertItemSplitter.LoadTransportStream(batchItem, _cancellationToken);
+                        foreach (var bi in tsResult)
                         {
-                            break;
+                            if (_cancellationToken.IsCancellationRequested)
+                            {
+                                break;
+                            }
+                            await _batchConverter.Convert(bi, _cancellationToken);
                         }
-                        await _batchConverter.Convert(bi, _cancellationToken);
+                    }
+                    else
+                    {
+                        await _batchConverter.Convert(batchItem, _cancellationToken);
                     }
                 }
-                else
+                catch (Exception exception)
                 {
-                    await _batchConverter.Convert(batchItem, _cancellationToken);
+                    // A failed item (e.g. auto-translate engine not reachable/not configured) must
+                    // not stall the whole batch: mark it as failed and continue with the next file.
+                    // Without this the exception faults the fire-and-forget task below and the dialog
+                    // hangs at "Converting 1/4..." forever with no error shown (#12288).
+                    if (!_cancellationToken.IsCancellationRequested)
+                    {
+                        SeLogger.Error(exception, "Batch convert failed for: " + batchItem.FileName);
+                        batchItem.Status = string.Format(Se.Language.General.ErrorX, exception.Message);
+                    }
                 }
 
                 count++;


### PR DESCRIPTION
## Problem
Fixes #12288 — Batch convert with only "Auto-translate" selected hangs forever at "Converting 1/4..." with no progress and no error when the translation engine cannot actually translate (e.g. no Ollama server / API key / model reachable).

Root cause: `BatchConvertViewModel.Convert()` runs the per-file batch loop inside a fire-and-forget `Task.Run` (src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs:977) with no try/catch. Any exception from the auto-translate path — `DoAutoTranslate.DoTranslate` rethrows after logging (src/libuilogic/Translate/DoAutoTranslate.cs:123), `BatchConverter.Convert` has no catch around `RunConvertFunctions`/`AutoTranslate` — faults the task unobserved. `IsConverting`, `IsProgressVisible` and `AreControlsEnabled` are then never reset, so the dialog freezes at "Converting 1/4..." forever with no visible error. The interactive Translate window handles the same exceptions by showing an error dialog; the batch path did not.

## Issue (verbatim)
> Linux flatpak on Ubuntu 24.04 (I never tried this batch auto-translate before, so I don't know how long this problem has been around).
>
> Steps to repro:
>
> 1. Tools > Batch convert
> 2. Add multiple VTT files
> 3. Select only Auto-translate
> 4. Target format WebVTT with numbers
> 5. Click convert
> 6. Wait forever with nothing happening.
>
> The message at the bottom of the batch pop-up continues to say "Converting 1/4..."
>
> Other batch conversion selections (spot-checked) complete very fast. The VTT input files are in French and I'm trying to convert them to English.

## Fix
Wrap the per-item conversion in the batch loop in a try/catch (src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs): on failure the item is logged via `SeLogger.Error` and its status is set to `Error; <message>` in the grid, and the batch continues with the next file instead of stalling forever. Cancellation is still honored (no error status is set when the cancellation token fired). This matches the existing per-item error pattern already used for OCR failures in `BatchConverter`.

## Verification
- [x] `dotnet build src/ui/UI.csproj -v q -nologo` — EXIT:0, 0 warnings, 0 errors
- No new unit tests: UI ViewModel fix, headless UI tests are impractical per repo guidelines; manual verification path below.
- Manual verification path (not run here — Linux flatpak scenario from the report):
  1. Tools > Batch convert, add multiple VTT files, select only Auto-translate, target format WebVTT with numbers, click convert, with no translation engine reachable (default OllamaTranslate on localhost:11434 not running / no API key configured).
     - Before fix: hangs at "Converting 1/4..." forever, no error.
     - After fix: each file quickly shows an "Error; ..." status in the list and the batch finishes with the summary message; `error-log.txt` contains the exception.
  2. Repeat with a working engine (e.g. Ollama started): files convert normally.

## Notes
- Interpretation: the report is treated as "any translation failure must be surfaced per file instead of hanging the whole batch"; the most common trigger is the default Ollama engine being unreachable on a fresh install.
- Deliberate non-change: `DoAutoTranslate`/`BatchConverter` keep throwing — the seconv CLI path and interactive Translate window rely on exceptions; only the batch ViewModel loop now contains them.
- Deliberate non-change: per-item status text uses the existing `Error; {0}` resource; the final "X files converted in Y" summary wording is untouched.
- This PR was created with AI assistance (per repo AI contributor guidelines).