### PR TITLE
Fix #10271: Subtitle textbox (or gridbox) section is not resizable

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -23,6 +23,8 @@ namespace Nikse.SubtitleEdit.Features.Main.Layout;
 
 public static partial class InitListViewAndEditBox
 {
+    private const double EditGridMinimumHeight = 92;
+    private const double EditGridMargin = 10;
 
     public static Grid MakeLayoutListViewAndEditBox(MainView mainPage, MainViewModel vm)
     {
@@ -54,7 +56,13 @@ public static partial class InitListViewAndEditBox
 
         var mainGrid = new Grid
         {
-            RowDefinitions = new RowDefinitions("*,Auto"),
+            RowDefinitions =
+            {
+                new RowDefinition(GridLength.Star),
+                // GridSplitter constrains the row definition, so include editGrid's outer
+                // margin to preserve the text box's 92 px minimum at the drag limit.
+                new RowDefinition(GridLength.Auto) { MinHeight = EditGridMinimumHeight + EditGridMargin * 2 },
+            },
         };
 
         // TableView (Avalonia 12.1) pilot #3, after Show history (#12704) and the OCR grid
@@ -1159,9 +1167,13 @@ public static partial class InitListViewAndEditBox
         // Edit area - restructured with time controls on left, multiline text on right
         var editGrid = new Grid
         {
-            Margin = new Thickness(10),
+            Margin = new Thickness(EditGridMargin),
+            MinHeight = EditGridMinimumHeight,
             ColumnDefinitions = new ColumnDefinitions("Auto, *"), // Two columns: left for time controls, right for text
-            RowDefinitions = new RowDefinitions("Auto")
+            // Star so the section grows when the user drags the splitter above it (#10271):
+            // with Auto, the extra pixel height from the splitter only added dead space below
+            // the fixed-height text box.
+            RowDefinitions = new RowDefinitions("*")
         };
 
         // Left panel for time controls
@@ -1720,6 +1732,23 @@ public static partial class InitListViewAndEditBox
         Grid.SetRow(editGrid, 1);
         mainGrid.Children.Add(editGrid);
 
+        // GridSplitter overlaying the boundary between the subtitle grid (row 0) and the
+        // edit box (row 1) so the text box section can be resized vertically, like SE4
+        // (#10271). The splitter lives in the edit box's own row (no extra row - an extra
+        // row would shrink the grid viewport and break the grid scroll perf tests); with
+        // VerticalAlignment.Top it resizes the row above (grid, Star) and its own row
+        // (edit box, Auto -> becomes Pixel once the user drags). The negative top margin
+        // centers the 4 px strip on the boundary.
+        var editBoxSplitter = new GridSplitter
+        {
+            Height = UiUtil.SplitterWidthOrHeight,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Top,
+            Margin = new Thickness(0, -UiUtil.SplitterWidthOrHeight / 2.0, 0, 0)
+        };
+        Grid.SetRow(editBoxSplitter, 1);
+        mainGrid.Children.Add(editBoxSplitter);
+
 
         textEditGrid.ColumnDefinitions[1].Bind(ColumnDefinition.WidthProperty, new Binding(nameof(vm.ShowColumnOriginalText))
         {
@@ -1832,8 +1861,9 @@ public static partial class InitListViewAndEditBox
 
         textBox.AcceptsReturn = true;
         textBox.TextWrapping = TextWrapping.Wrap;
+        // MinHeight keeps the default layout; no fixed Height so the text box grows with the
+        // resizable edit section (#10271).
         textBox.MinHeight = 92;
-        textBox.Height = 92;
         textBox.FontSize = appearance.SubtitleTextBoxFontSize;
         textBox.FontWeight = appearance.SubtitleTextBoxFontBold ? FontWeight.Bold : FontWeight.Normal;
         textBox.IsUndoEnabled = false;

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -23,8 +23,18 @@ namespace Nikse.SubtitleEdit.Features.Main.Layout;
 
 public static partial class InitListViewAndEditBox
 {
-    private const double EditGridMinimumHeight = 92;
+    // The text box's own floor - unchanged, so the default layout looks exactly as before.
+    private const double SubtitleTextBoxMinimumHeight = 92;
+    // Starting floor for the edit section, replaced by a measured value on first layout (see
+    // TrackEditSectionMinimumHeight). textEditGrid is "Auto,*,Auto": the "Text" header and the
+    // "Line length / Total chars" panel sit above and below the box, and the floor has to cover
+    // all three - sized to the box alone, the box (which cannot shrink past its own MinHeight)
+    // overflows its row and draws over the labels underneath (#10271).
+    private const double EditGridMinimumHeight = SubtitleTextBoxMinimumHeight;
     private const double EditGridMargin = 10;
+    // The subtitle grid row is Star, so without a floor the splitter can drag it away to
+    // nothing and there is no handle left to drag back (#10271).
+    private const double SubtitleGridMinimumHeight = 45;
 
     public static Grid MakeLayoutListViewAndEditBox(MainView mainPage, MainViewModel vm)
     {
@@ -58,7 +68,7 @@ public static partial class InitListViewAndEditBox
         {
             RowDefinitions =
             {
-                new RowDefinition(GridLength.Star),
+                new RowDefinition(GridLength.Star) { MinHeight = SubtitleGridMinimumHeight },
                 // GridSplitter constrains the row definition, so include editGrid's outer
                 // margin to preserve the text box's 92 px minimum at the drag limit.
                 new RowDefinition(GridLength.Auto) { MinHeight = EditGridMinimumHeight + EditGridMargin * 2 },
@@ -1749,6 +1759,8 @@ public static partial class InitListViewAndEditBox
         Grid.SetRow(editBoxSplitter, 1);
         mainGrid.Children.Add(editBoxSplitter);
 
+        TrackEditSectionMinimumHeight(mainGrid, textEditGrid);
+
 
         textEditGrid.ColumnDefinitions[1].Bind(ColumnDefinition.WidthProperty, new Binding(nameof(vm.ShowColumnOriginalText))
         {
@@ -1851,6 +1863,44 @@ public static partial class InitListViewAndEditBox
     /// Makes the subtitle edit text box - a <see cref="SyntaxHighlightingTextBox"/> when
     /// "Color tags" is on, else a normal TextBox.
     /// </summary>
+
+    /// <summary>
+    /// Keeps the edit section's drag floor equal to what the section actually needs: the text
+    /// box's own minimum plus the "Text" header and the "Line length / Total chars" panel that
+    /// sit above and below it. Those two rows are Auto, so their height follows the UI font -
+    /// a hard-coded allowance goes stale as soon as the font size changes, and if it is too
+    /// small the text box (which cannot shrink past its MinHeight) overflows its row and draws
+    /// over the labels (#10271). Measured rather than stored: this is a derived layout fact,
+    /// not something a user should configure.
+    /// </summary>
+    private static void TrackEditSectionMinimumHeight(Grid mainGrid, Grid textEditGrid)
+    {
+        textEditGrid.LayoutUpdated += (_, _) =>
+        {
+            if (textEditGrid.RowDefinitions.Count < 3)
+            {
+                return;
+            }
+
+            var labelRows = textEditGrid.RowDefinitions[0].ActualHeight +
+                            textEditGrid.RowDefinitions[2].ActualHeight;
+            if (labelRows <= 0)
+            {
+                return;
+            }
+
+            var needed = SubtitleTextBoxMinimumHeight + labelRows + EditGridMargin * 2;
+            var row = mainGrid.RowDefinitions[1];
+
+            // Only react to a real change - assigning MinHeight re-triggers layout, so an
+            // unconditional write here would spin.
+            if (Math.Abs(row.MinHeight - needed) > 0.5)
+            {
+                row.MinHeight = needed;
+            }
+        };
+    }
+
     private static TextBox MakeSubtitleTextBox()
     {
         var appearance = Se.Settings.Appearance;
@@ -1863,7 +1913,7 @@ public static partial class InitListViewAndEditBox
         textBox.TextWrapping = TextWrapping.Wrap;
         // MinHeight keeps the default layout; no fixed Height so the text box grows with the
         // resizable edit section (#10271).
-        textBox.MinHeight = 92;
+        textBox.MinHeight = SubtitleTextBoxMinimumHeight;
         textBox.FontSize = appearance.SubtitleTextBoxFontSize;
         textBox.FontWeight = appearance.SubtitleTextBoxFontBold ? FontWeight.Bold : FontWeight.Normal;
         textBox.IsUndoEnabled = false;

--- a/tests/UI/Features/Main/SubtitleGridScrollPerformanceTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridScrollPerformanceTests.cs
@@ -1,5 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
@@ -53,7 +54,8 @@ public class SubtitleGridScrollPerformanceTests : IDisposable
         _output = output;
     }
 
-    private (Window Window, MainViewModel Vm, TableView Grid, ScrollViewer ScrollViewer) ShowMainWindowWithLines()
+    private (Window Window, MainViewModel Vm, TableView Grid, ScrollViewer ScrollViewer) ShowMainWindowWithLines(
+        int lineCount = LineCount)
     {
         var services = new ServiceCollection();
         services.AddSubtitleEditServices();
@@ -69,7 +71,7 @@ public class SubtitleGridScrollPerformanceTests : IDisposable
         window.UpdateLayout();
 
         var vm = (MainViewModel)view.DataContext!;
-        for (var i = 0; i < LineCount; i++)
+        for (var i = 0; i < lineCount; i++)
         {
             // Every third line is two lines tall - variable row heights are what makes the
             // panel's average-height estimate drift in the first place.
@@ -93,6 +95,67 @@ public class SubtitleGridScrollPerformanceTests : IDisposable
         {
             Dispatcher.UIThread.RunJobs();
             window.UpdateLayout();
+        }
+    }
+
+    private static void Drag(GridSplitter splitter, double verticalChange)
+    {
+        splitter.RaiseEvent(new VectorEventArgs
+        {
+            RoutedEvent = Thumb.DragStartedEvent,
+            Vector = default,
+        });
+        splitter.RaiseEvent(new VectorEventArgs
+        {
+            RoutedEvent = Thumb.DragDeltaEvent,
+            Vector = new Vector(0, verticalChange),
+        });
+        splitter.RaiseEvent(new VectorEventArgs
+        {
+            RoutedEvent = Thumb.DragCompletedEvent,
+            Vector = new Vector(0, verticalChange),
+        });
+    }
+
+    [AvaloniaFact]
+    public void EditBoxSplitter_DragResizesEditSectionAndPreservesMinimumHeight()
+    {
+        var (window, _, _, _) = ShowMainWindowWithLines(0);
+
+        try
+        {
+            var splitter = Assert.Single(window.GetVisualDescendants().OfType<GridSplitter>(), s =>
+                Grid.GetRow(s) == 1 &&
+                s.VerticalAlignment == Avalonia.Layout.VerticalAlignment.Top &&
+                s.Parent is Grid { RowDefinitions.Count: 2 });
+            var mainGrid = Assert.IsType<Grid>(splitter.Parent);
+            var editGrid = Assert.Single(mainGrid.Children.OfType<Grid>(), g => Grid.GetRow(g) == 1);
+            var initialHeight = editGrid.Bounds.Height;
+
+            Drag(splitter, -120);
+            Settle(window);
+            var grownHeight = editGrid.Bounds.Height;
+
+            Assert.True(grownHeight > initialHeight,
+                $"Dragging up should grow editGrid (initial={initialHeight:F1}, grown={grownHeight:F1})");
+
+            Drag(splitter, window.Bounds.Height);
+            Settle(window);
+            var minimumHeight = editGrid.Bounds.Height;
+
+            Assert.True(minimumHeight < grownHeight,
+                $"Dragging down should shrink editGrid (grown={grownHeight:F1}, shrunk={minimumHeight:F1})");
+
+            var textBoxMinimum = editGrid.GetVisualDescendants()
+                .OfType<TextBox>()
+                .Max(p => p.MinHeight);
+            Assert.True(minimumHeight >= textBoxMinimum,
+                $"Dragging must not make editGrid smaller than its text boxes " +
+                $"(grid={minimumHeight:F1}, text box minimum={textBoxMinimum:F1})");
+        }
+        finally
+        {
+            window.Close();
         }
     }
 

--- a/tests/UI/Features/Main/SubtitleGridScrollPerformanceTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridScrollPerformanceTests.cs
@@ -160,6 +160,43 @@ public class SubtitleGridScrollPerformanceTests : IDisposable
     }
 
     [AvaloniaFact]
+    public void EditBoxSplitter_AtMinimum_TextBoxDoesNotOverflowTheLabelRow()
+    {
+        // The edit section is "Auto,*,Auto": the "Text" header and the "Line length /
+        // Total chars" panel sit above and below the box. The section floor has to cover all
+        // three - sized to the box alone, the box (which cannot shrink past its own MinHeight)
+        // overflows its row and draws over the labels underneath (#10271).
+        var (window, _, _, _) = ShowMainWindowWithLines(0);
+
+        try
+        {
+            var splitter = Assert.Single(window.GetVisualDescendants().OfType<GridSplitter>(), s =>
+                Grid.GetRow(s) == 1 &&
+                s.VerticalAlignment == Avalonia.Layout.VerticalAlignment.Top &&
+                s.Parent is Grid { RowDefinitions.Count: 2 });
+            var textEditGrid = window.GetVisualDescendants().OfType<Grid>()
+                .First(g => g.Name == "SubtitleTextEditGrid");
+
+            Drag(splitter, window.Bounds.Height);
+            Settle(window);
+
+            var textBox = textEditGrid.GetVisualDescendants().OfType<TextBox>().First();
+            var textBoxRowBottom = textEditGrid.RowDefinitions[0].ActualHeight +
+                                   textEditGrid.RowDefinitions[1].ActualHeight;
+
+            Assert.True(textBox.Bounds.Bottom <= textBoxRowBottom + 0.5,
+                $"Text box overflows its row and covers the length labels " +
+                $"(box bottom={textBox.Bounds.Bottom:F1}, row bottom={textBoxRowBottom:F1})");
+            Assert.True(textEditGrid.RowDefinitions[2].ActualHeight > 0,
+                "The length-label row collapsed to zero at the minimum section height");
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void HomeAndEnd_RealizeOnlyAViewportOfRows()
     {
         var (window, _, grid, scrollViewer) = ShowMainWindowWithLines();


### PR DESCRIPTION
## Problem

Fixes #10271 — the boundary between the subtitle grid and the subtitle text box cannot be dragged, so the text box section cannot be resized vertically (and the grid cannot be shrunk to give it room).

Issue quote (verbatim):

> I don't know if it's by design, but it's not possible to increase the textbox size vertically (up and down).
> Or you could look at it from gridbox perspective, that you can't decrease it's size vertically.

> Second that. It's possible to change the size of textbix in SE4 why not on SE5? — m0ck69

**Root cause:** the SE5 code-built main window layout (`src/ui/Features/Main/Layout/InitListViewAndEditBox.cs`) puts the subtitle grid and the edit box into a `Grid` with row definitions `"*,Auto"` (grid = Star row 0, edit box = Auto row 1) and never adds a `GridSplitter` between them. SE4 had a draggable splitter between the list view and the text box; the SE5 port omitted it, so the edit box row is fixed at its content height and there is nothing to drag. (`MakeLayoutListViewAndEditBox` feeds all 12 main layouts, so every layout is affected.) On top of that, the text box itself had a hardcoded `Height = 92`, so even growing the section would not grow the box.

## Fix

`src/ui/Features/Main/Layout/InitListViewAndEditBox.cs`:

- A horizontal `GridSplitter` overlays the boundary between the subtitle grid (row 0) and the edit box (row 1). It lives in the edit box's own row — the row count stays at two, so no dedicated splitter row steals height from the subtitle-grid viewport. `VerticalAlignment.Top` gives Avalonia's `PreviousAndCurrent` behavior: dragging resizes the Star grid row and the Auto edit-box row (which becomes pixel-sized).
- `editGrid` uses a Star row so dragged height reaches the text area instead of becoming dead space.
- The fixed text-box `Height = 92` is removed while `MinHeight = 92` keeps the default appearance.
- The splitter clamp preserves the text box's 92 px minimum (112 px including `editGrid`'s 10 px top/bottom margins), so the edit section cannot be dragged below its content minimum.

Behavior: the edit section starts at its normal content height. Dragging the splitter up grows the text box; dragging down shrinks it while retaining the text box's 92 px minimum. The subtitle-grid Star row fills the remaining space, like SE4.

## Permanent regression test

`tests/UI/Features/Main/SubtitleGridScrollPerformanceTests.cs` now contains a durable headless test against the real `MainView`:

- starts a headless 1400×900 window through the existing application/service bootstrap;
- locates the actual overlay `GridSplitter` and its sibling `editGrid` in the visual tree;
- raises the real `Thumb.DragStartedEvent`, `DragDeltaEvent`, and `DragCompletedEvent` routed events;
- verifies that dragging up grows `editGrid`, dragging down shrinks it, and `editGrid` never becomes smaller than the real minimum height of its text boxes;
- closes the window in `finally` to avoid leaking headless state.

The test was verified RED against the pre-fix layout (`Assert.Single`: no matching splitter) and GREEN with this change.

## Verification

- [x] `dotnet build src/ui/UI.csproj -v q -nologo --no-incremental` — **EXIT 0**, 0 warnings, 0 errors.
- [x] Current rebased head: `SubtitleGridScrollPerformanceTests` **8/8 PASS**.
- [x] Current rebased head: full UI suite — **1475 passed, 0 failed, 1 skipped** (1476 total).
- [ ] Manual: drag the splitter between the subtitle grid and text box in several main-window layouts; confirm both sections resize and the edit area cannot collapse completely.

## Notes

- The dragged height remains session-local to the current layout. Follow-up #13293 tracks preserving it across layout switches (and potentially restarts) so that concern is not lost.
- This PR was created with AI assistance (per repo AI contributor guidelines).
