### PR TITLE
Fix #10166: OCR skip-all choices are now remembered

### DIFF
--- a/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
@@ -13,13 +13,14 @@ public interface IOcrFixEngine
     bool IsLoaded();
     List<string> GetSpellCheckSuggestions(string word);
     void ChangeAll(string from, string to);
-    void SkipAll(string word);
+    void SkipAll(IEnumerable<string> words);
     void AddName(string name);
     List<string> ReloadNames();
 }
 
 public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
 {
+    private static readonly object SkipListFileLock = new();
     private bool _isLoaded;
     private OcrFixReplaceList2 _ocrFixReplaceList;
     private string _fiveLetterName;
@@ -68,6 +69,7 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
         var names = ReloadNames();
         _wordSplitList = StringWithoutSpaceSplitToWords.LoadWordSplitList(SpellCheckConfig.DictionariesFolder(), _threeLetterIsoLanguageName, names);
         _ocrFixReplaceList = OcrFixReplaceList2.FromLanguageId(_threeLetterIsoLanguageName);
+        LoadSkipList();
     }
 
     public OcrFixLineResult FixOcrErrors(int index, string text, bool doTryToGuessUnknownWords)
@@ -539,11 +541,107 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
         _ocrFixReplaceList.AddWordOrPartial(from, to);
     }
 
-    public void SkipAll(string word)
+    public void SkipAll(IEnumerable<string> words)
     {
-        if (!_wordSkipList.Contains(word) && !string.IsNullOrWhiteSpace(word))
+        var changed = false;
+        foreach (var word in words.Where(p => !string.IsNullOrWhiteSpace(p)))
         {
-            _wordSkipList.Add(word);
+            changed |= _wordSkipList.Add(word);
+        }
+
+        if (changed)
+        {
+            SaveSkipList();
+        }
+    }
+
+    // "Skip all" choices are persisted per language so the same correct word is not flagged
+    // again on the next OCR run (#10166). The file follows the <language>_WordSplitList.txt
+    // pattern: one word per line in the dictionaries folder. Memory is cleared on Unload;
+    // the file stays.
+    private string GetSkipListFileName() =>
+        Path.Combine(SpellCheckConfig.DictionariesFolder(), _threeLetterIsoLanguageName + "_OcrSkipAllList.txt");
+
+    private void LoadSkipList()
+    {
+        // Initialize can be called again on the same engine after the user changes dictionary.
+        // Never merge one language's remembered words into the next language's file.
+        _wordSkipList.Clear();
+
+        try
+        {
+            if (string.IsNullOrEmpty(_threeLetterIsoLanguageName))
+            {
+                return;
+            }
+
+            var fileName = GetSkipListFileName();
+            if (!File.Exists(fileName))
+            {
+                return;
+            }
+
+            foreach (var word in File.ReadAllLines(fileName).Select(p => p.Trim()).Where(p => p.Length > 0))
+            {
+                _wordSkipList.Add(word);
+            }
+        }
+        catch (Exception exception)
+        {
+            SpellCheckConfig.LogError("Error loading OCR skip-all list: " + exception.Message);
+        }
+    }
+
+    private void SaveSkipList()
+    {
+        string? tempFileName = null;
+        try
+        {
+            if (string.IsNullOrEmpty(_threeLetterIsoLanguageName))
+            {
+                return;
+            }
+
+            // SkipListFileLock is process-local: it serialises OCR windows inside one
+            // SubtitleEdit instance, but two instances can still write the same language
+            // file. The merge-before-write below keeps that from corrupting the file -
+            // worst case one instance's word is lost.
+            lock (SkipListFileLock)
+            {
+                var fileName = GetSkipListFileName();
+                if (File.Exists(fileName))
+                {
+                    // Two OCR windows can add words to the same language. Merge the current
+                    // on-disk list while holding the process lock so neither window loses words.
+                    foreach (var word in File.ReadAllLines(fileName).Select(p => p.Trim()).Where(p => p.Length > 0))
+                    {
+                        _wordSkipList.Add(word);
+                    }
+                }
+
+                tempFileName = fileName + "." + Guid.NewGuid().ToString("N") + ".tmp";
+                File.WriteAllLines(tempFileName, _wordSkipList.OrderBy(p => p, StringComparer.Ordinal));
+                File.Move(tempFileName, fileName, true);
+                tempFileName = null;
+            }
+        }
+        catch (Exception exception)
+        {
+            SpellCheckConfig.LogError("Error saving OCR skip-all list: " + exception.Message);
+        }
+        finally
+        {
+            if (tempFileName != null)
+            {
+                try
+                {
+                    File.Delete(tempFileName);
+                }
+                catch
+                {
+                    // Best-effort cleanup after a failed atomic replace.
+                }
+            }
         }
     }
 

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -3685,11 +3685,13 @@ public partial class OcrViewModel : ObservableObject
 
                     if (result.SkipAllPressed)
                     {
-                        foreach (var word in GetUnknownWordSkipForms(unknownWord))
+                        var skipForms = GetUnknownWordSkipForms(unknownWord).ToList();
+                        foreach (var word in skipForms)
                         {
                             skipAllWords.Add(word);
-                            _ocrFixEngine.SkipAll(word);
                         }
+
+                        _ocrFixEngine.SkipAll(skipForms);
 
                         continue;
                     }

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixEngineSkipAllPersistenceTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixEngineSkipAllPersistenceTests.cs
@@ -1,0 +1,67 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Interfaces;
+using Nikse.SubtitleEdit.Logic.Dictionaries;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+public class OcrFixEngineSkipAllPersistenceTests : IDisposable
+{
+    private readonly Func<string> _originalDictionariesFolder;
+    private readonly string _tempFolder;
+
+    public OcrFixEngineSkipAllPersistenceTests()
+    {
+        _originalDictionariesFolder = SpellCheckConfig.DictionariesFolder;
+        _tempFolder = Path.Combine(Path.GetTempPath(), "SeOcrSkipAllTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempFolder);
+        SpellCheckConfig.DictionariesFolder = () => _tempFolder;
+    }
+
+    [Fact]
+    public void SkipAll_PersistsOncePerLanguageWithoutCrossLanguageContamination()
+    {
+        var engine = new OcrFixEngine(new FakeSpellChecker());
+        var dictionary = new SpellCheckDictionaryDisplay { DictionaryFileName = "test.dic" };
+        var subtitle = new Subtitle();
+
+        ((IOcrFixEngine)engine).Initialize(subtitle, "eng", dictionary);
+        engine.SkipAll(new[] { "foo", "foo", "FOO" });
+
+        var englishFile = Path.Combine(_tempFolder, "eng_OcrSkipAllList.txt");
+        Assert.Equal(new[] { "FOO", "foo" }, File.ReadAllLines(englishFile));
+
+        // Re-use the same engine, as OcrViewModel does when the dictionary changes.
+        ((IOcrFixEngine)engine).Initialize(subtitle, "nld", dictionary);
+        engine.SkipAll(new[] { "bar", "baz" });
+
+        var dutchFile = Path.Combine(_tempFolder, "nld_OcrSkipAllList.txt");
+        Assert.Equal(new[] { "bar", "baz" }, File.ReadAllLines(dutchFile));
+        Assert.DoesNotContain("foo", File.ReadAllLines(dutchFile));
+        Assert.Equal(new[] { "FOO", "foo" }, File.ReadAllLines(englishFile));
+        Assert.Empty(Directory.GetFiles(_tempFolder, "*.tmp"));
+
+        var reloadedEngine = new OcrFixEngine(new FakeSpellChecker());
+        var verificationSubtitle = new Subtitle();
+        verificationSubtitle.Paragraphs.Add(new Paragraph("foo control", 0, 1000));
+        ((IOcrFixEngine)reloadedEngine).Initialize(verificationSubtitle, "eng", dictionary);
+
+        var result = reloadedEngine.FixOcrErrors(0, "foo control", doTryToGuessUnknownWords: false);
+        Assert.True(result.Words.Single(p => p.Word == "foo").IsSpellCheckedOk);
+        Assert.False(result.Words.Single(p => p.Word == "control").IsSpellCheckedOk);
+    }
+
+    public void Dispose()
+    {
+        SpellCheckConfig.DictionariesFolder = _originalDictionariesFolder;
+        Directory.Delete(_tempFolder, true);
+    }
+
+    private sealed class FakeSpellChecker : ISpellChecker
+    {
+        public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => true;
+        public bool IsWordCorrect(string word) => false;
+        public List<string> GetSuggestions(string word) => new();
+    }
+}

--- a/tests/UI/Features/Tools/FixCommonErrors/FixCommonOcrErrorsTests.cs
+++ b/tests/UI/Features/Tools/FixCommonErrors/FixCommonOcrErrorsTests.cs
@@ -59,7 +59,7 @@ public class FixCommonOcrErrorsTests : IDisposable
         public bool IsLoaded() => true;
         public List<string> GetSpellCheckSuggestions(string word) => new();
         public void ChangeAll(string from, string to) { }
-        public void SkipAll(string word) { }
+        public void SkipAll(IEnumerable<string> words) { }
         public void AddName(string name) { }
         public List<string> ReloadNames() => new();
     }


### PR DESCRIPTION
## Problem

Fixes #10166 — "Skip all" choices in the OCR unknown-word prompt are never remembered: the same correct word is flagged again on every OCR run.

Issue (verbatim):
> When I run OCR, individual characters are flagged as errors even when they are correct. Even if I skip or resolve the problem, this choice is never stored, and the same error or false positive is prompted every time.
> **EDIT: As a workaround, I added all single-character words and corrections manually inside custom lists.**

Root cause: `OcrFixEngine._wordSkipList` (src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs:32) is a strictly in-memory `HashSet<string>`. The engine is created fresh per OCR run (`AddTransient`), `Unload()` clears the set, and nothing ever loads or saves it — so every Skip/Skip-all choice is lost the moment the OCR window closes. The other choices in the same dialog do persist (ChangeAll → `<lang>_OCRFixReplaceList.xml`, add-to-dictionary → `<lang>_user.xml`), which is why the reporter's manual custom-list workaround works while Skip does not.

## Fix

Persist the skip-all list per language as `<language>_OcrSkipAllList.txt` (one word per line in the dictionaries folder):

- `Initialize()` clears the in-memory set before loading the selected language, so changing dictionary cannot copy English words into Dutch (or another language).
- `SkipAll(IEnumerable<string>)` accepts all word forms from one user click and writes the file once, instead of rewriting it once per form.
- Saving merges additions from another OCR window under a process lock, writes a unique temporary file, and atomically replaces the final file.
- `Unload()` still clears memory only; the per-language file persists.
- Missing language/file and IO failures are handled through the existing `SpellCheckConfig.LogError` path.

Deliberate non-change: single-character words may still be flagged on the first run. This matches current 5.x behavior; after the user chooses Skip all, that choice is remembered. A UI editor/toggle for permanent choices is a separate design decision for the maintainer.

## Verification

- [x] `dotnet build src/ui/UI.csproj --no-incremental -v q -nologo` — EXIT:0
- [x] New focused regression test: `OcrFixEngineSkipAllPersistenceTests` — reuses one engine across English → Dutch, verifies no cross-language contamination, dedupe/order, one file per language, no leftover temp file, then creates a fresh engine and proves the persisted word is accepted while an unknown control word is still flagged.
- [x] `FullyQualifiedName~FixEngine` + new test — 58/58 PASS.
- Manual path: Skip all for a word, restart/re-run OCR with the same dictionary, and confirm the word is no longer prompted. Change dictionary and confirm the skipped word does not leak into the other language.

## Notes

- This PR was created with AI assistance (per repo AI contributor guidelines).