### PR TITLE
Fix #10533: PGS isn't zoomed with resized OCR window

### DIFF
--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -494,7 +494,7 @@ public class OcrWindow : Window
                 new TableViewColumn
                 {
                     Header = Se.Language.General.Image,
-                    Width = new GridLength(vm.ImageMaxWidth + cellChrome),
+                    Width = new GridLength(1, GridUnitType.Star),
                     CellTheme = UiUtil.TableViewNoPaddingCellTheme,
                     HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
                     CellTemplate = new FuncDataTemplate<OcrSubtitleItem>((item, _) =>
@@ -513,8 +513,21 @@ public class OcrWindow : Window
                                 Source = bitmap,
                                 Stretch = Avalonia.Media.Stretch.Uniform
                             };
-                            image.Bind(Image.MaxHeightProperty, new Binding(nameof(vm.ImageMaxHeight)) { Source = vm });
-                            image.Bind(Image.MaxWidthProperty, new Binding(nameof(vm.ImageMaxWidth)) { Source = vm });
+                            // Fill the cell (which grows with the window) instead of being capped
+                            // by a fixed max size; keep the same 2:1 box aspect the old 200x100
+                            // max produced, so rows stay compact.
+                            // Note: Layoutable.ActualWidth is a plain CLR property (not an
+                            // AvaloniaProperty), so it cannot be used in a binding - track the
+                            // cell's arranged width via Bounds instead.
+                            var imageHeightRatio = vm.ImageMaxHeight / vm.ImageMaxWidth;
+                            stackPanel.PropertyChanged += (_, e) =>
+                            {
+                                if (e.Property == Layoutable.BoundsProperty && stackPanel.Bounds.Width > 0)
+                                {
+                                    image.Width = stackPanel.Bounds.Width;
+                                    image.Height = stackPanel.Bounds.Width * imageHeightRatio;
+                                }
+                            };
 
                             // Subtitle bitmaps are usually light text on a transparent background, which
                             // is invisible on a light grid - give them a dark backdrop so they show.
@@ -562,14 +575,17 @@ public class OcrWindow : Window
                 },
         });
 
-        // The image thumbnails scale with Ctrl+plus/minus (Image.MaxWidth/MaxHeight are
-        // bound to the VM) - keep the pixel-sized image column in step with the zoom.
+        // The image column shares the window width (star), so the thumbnails scale when the
+        // window is resized. Ctrl+plus/minus zoom (ImageMaxWidth in the VM) changes the
+        // column's share of the width instead; the factor is squared because star widths
+        // distribute the free space, which keeps each zoom step near the old ~10% size change.
         var imageColumn = dataGridSubtitle.Columns[dataGridSubtitle.Columns.Count - 2];
         vm.PropertyChanged += (_, args) =>
         {
             if (args.PropertyName == nameof(vm.ImageMaxWidth))
             {
-                imageColumn.Width = new GridLength(vm.ImageMaxWidth + cellChrome);
+                var zoomFactor = vm.ImageMaxWidth / 200.0; // 200 = default ImageMaxWidth (OcrViewModel)
+                imageColumn.Width = new GridLength(zoomFactor * zoomFactor, GridUnitType.Star);
             }
         };
 

--- a/tests/UI/Features/Ocr/OcrTableViewTests.cs
+++ b/tests/UI/Features/Ocr/OcrTableViewTests.cs
@@ -90,15 +90,29 @@ public class OcrTableViewTests
         Assert.Equal(3, tableView.ItemsSource!.Cast<object>().Count());
 
         // TableView has no content-based sizing (Auto acts as 1*), so the narrow columns
-        // are pixel-sized from their widest content and only Text is star-sized.
-        Assert.All(tableView.Columns.Take(4), c => Assert.True(c.Width.IsAbsolute && c.Width.Value > 0));
-        Assert.True(tableView.Columns[^1].Width.IsStar);
+        // are pixel-sized from their widest content; Image and Text share the rest as stars.
+        Assert.All(tableView.Columns.Take(3), c => Assert.True(c.Width.IsAbsolute && c.Width.Value > 0));
+        Assert.True(tableView.Columns[3].Width.IsStar); // image column (issue #10533)
+        Assert.True(tableView.Columns[^1].Width.IsStar); // text column
 
-        // The image column tracks the Ctrl+plus/minus zoom via ImageMaxWidth.
-        var imageWidthBefore = tableView.Columns[3].Width.Value;
+        // The image column and its thumbnails grow with the window (issue #10533: the
+        // column used to be pixel-fixed, so resizing the OCR window did not zoom the PGS).
+        var imageColumn = tableView.Columns[3];
+        var firstRowImage = tableView.GetVisualDescendants().OfType<TableViewRow>().First()
+            .GetVisualDescendants().OfType<Image>().First();
+        var columnWidthBefore = imageColumn.ActualWidth;
+        var imageWidthBefore = firstRowImage.Width;
+        window.Width = 1600;
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Assert.True(imageColumn.ActualWidth > columnWidthBefore, $"column {imageColumn.ActualWidth} not > {columnWidthBefore}");
+        Assert.True(firstRowImage.Width > imageWidthBefore, $"image {firstRowImage.Width} not > {imageWidthBefore}");
+
+        // The image column still tracks the Ctrl+plus/minus zoom via ImageMaxWidth.
+        var zoomWeightBefore = imageColumn.Width.Value;
         vm.ImageMaxWidth *= 1.1;
         Dispatcher.UIThread.RunJobs();
-        Assert.True(tableView.Columns[3].Width.Value > imageWidthBefore);
+        Assert.True(imageColumn.Width.Value > zoomWeightBefore);
 
         window.Close();
     }


### PR DESCRIPTION
## Problem

Fixes #10533 — when resizing the OCR window, the displayed PGS stays the same size; on a 4k monitor the red recognition box is really small and barely visible.

Issue quote (verbatim):

> When resizing the OCR window, the showed PGS stays of the same size:
> <img width="2797" height="1934" alt="Image" src="https://github.com/user-attachments/assets/8d78e9d7-ef91-42b2-ae37-5d1ab7dc42dd" />
> On a 4k monitor, the red line around the letter to be recognized is really small and barely visible.

**Root cause:** the OCR window's subtitle table shows each PGS as a per-row `Image` (Stretch=Uniform) inside a **pixel-fixed** column: `Width = new GridLength(vm.ImageMaxWidth + cellChrome)` (OcrWindow.cs:497, ~216 px). Resizing the window only grows the star-sized Text column, so the thumbnails never scale. The only zoom path was Ctrl+plus/minus (#10330), which edits `vm.ImageMaxWidth`/`ImageMaxHeight` (defaults 200/100) — the window itself never affects the picture size.

## Fix

`src/ui/Features/Ocr/OcrWindow.cs` — smallest change, zoom feature untouched:

- Image column: fixed pixel width → Star (`GridLength(1, GridUnitType.Star)`) — it now shares the window's extra width (same mechanism the Text column uses; star widths are recomputed on every measure).
- Per-row `Image`: no longer capped by fixed `MaxWidth`/`MaxHeight`. Instead the image fills the cell — its `Width` follows the cell's arranged width and `Height` keeps the same 2:1 box aspect the old 200×100 max produced, so rows stay compact. (Avalonia note: `Layoutable.ActualWidth` is a plain CLR property, not an AvaloniaProperty, so it cannot be used in a binding — the cell width is tracked via the `Bounds` property change instead.)
- Ctrl+plus/minus zoom still works: it multiplies `ImageMaxWidth`/`ImageMaxHeight`, and the zoom handler now maps that to the star column weight instead of a pixel width, so the zoom steps keep their previous ~10 % behavior.

## Verification

- [x] `dotnet build src/ui/UI.csproj -v q -nologo` — EXIT:0, 0 warnings, 0 errors (real command output).
- [x] `tests/UI/Features/Ocr/OcrTableViewTests.cs` — updated with the resize behavior: asserts the Image column is Star, resizes the window 1200 → 1600 and asserts the image column width and the first row's image width grow, and asserts the zoom still bumps the column weight. **5/5 PASS** (the image-width assertion failed before this fix — the binding never delivered — and passes now).
- [ ] Manual: open the OCR window with a PGS, resize the window wider → the thumbnails scale up; Ctrl+plus still zooms; the red recognition box is visible at 4k.

## Notes

- The 2:1 aspect ratio of the thumbnails matches the old 200×100 default, so row heights stay compact at any window size.
- This PR was created with AI assistance (per repo AI contributor guidelines).