### PR TITLE
Fix #10627: Auto-translate via copy-paste loses all but the first ASSA tag group

### DIFF
--- a/src/libuilogic/Translate/Formatting.cs
+++ b/src/libuilogic/Translate/Formatting.cs
@@ -59,14 +59,16 @@ namespace Nikse.SubtitleEdit.UiLogic.Translate
             var text = input.Trim();
 
             // SSA/ASS tags
-            if (text.StartsWith("{\\", StringComparison.Ordinal))
+            while (text.StartsWith("{\\", StringComparison.Ordinal))
             {
                 var endIndex = text.IndexOf('}');
-                if (endIndex > 0)
+                if (endIndex <= 0)
                 {
-                    StartTags = text.Substring(0, endIndex + 1);
-                    text = text.Remove(0, endIndex + 1).Trim();
+                    break;
                 }
+
+                StartTags += text.Substring(0, endIndex + 1);
+                text = text.Remove(0, endIndex + 1).Trim();
             }
 
             // ASSA reset tag

--- a/tests/libuilogic/Translate/CopyPasteTranslatorTests.cs
+++ b/tests/libuilogic/Translate/CopyPasteTranslatorTests.cs
@@ -49,6 +49,29 @@ public class CopyPasteTranslatorTests
     }
 
     [Fact]
+    public void GetTranslationResult_KeepsAllConsecutiveAssaTagGroups()
+    {
+        // Reporter's ASSA lines carry several adjacent {\...} groups (e.g.
+        // {\pos(960,480)}{\fs-1.5}{\fs75}{\fscx120}{\fsc110}{\fad(0,0)}{\bord0});
+        // SetTagsAndReturnTrimmed must strip ALL of them into the formatting
+        // (not only the first), so the clipboard text is clean and the
+        // re-applied translation keeps every group (#10627).
+        var paragraphs = MakeParagraphs(
+            "{\\pos(960,480)}{\\fs75}{\\bord0}The World Of Sword And Magic",
+            "This is the second line.");
+        var translator = new CopyPasteTranslator(paragraphs, Separator);
+
+        var blocks = translator.BuildBlocks(60, string.Empty, 0);
+        Assert.Single(blocks);
+        Assert.DoesNotContain("{", blocks[0].TargetText);
+
+        var result = translator.GetTranslationResult(string.Empty, blocks[0].TargetText, blocks[0]);
+        Assert.Equal(2, result.Count);
+        Assert.StartsWith("{\\pos(960,480)}{\\fs75}{\\bord0}", result[0]);
+        Assert.Equal("This is the second line.", result[1]);
+    }
+
+    [Fact]
     public void GetTranslationResult_SecondBlock_IsNotReplacedByFirstBlocksMusicNotes()
     {
         var paragraphs = MakeParagraphs(


### PR DESCRIPTION
## Problem

Fixes #10627 — "Auto-translate via copy-paste" does not carry the subtitle formatting over to the translated text correctly: formatting is dropped, changed, or invented where none existed.

Issue quote (verbatim, key parts):

> Basically, the “_Auto-translate via copy-paste_” feature doesn't work properly in the sense that when I paste the translated text, the formatting “arguments” aren't always carried over correctly.
> ...
> The problem is that in some cases, copy-pasting fails to preserve the original subtitle formatting ...
> **Actual result:** ... in the translated text, the formatting sometimes does not carry over correctly, with many random issues such as:
> - the formatting does not carry over at all;
> - it changes the formatting;
> - it creates **A LOT OF** new formatting where NONE existed in the original text;
> - a lot of “confusion” caused by the program.

(The reporter uses ASSA files; the affected lines carry several adjacent tag groups, e.g. `{\pos(960,480)}{\fs-1.5}{\fs75}{\fscx120}{\fsc110}{\fad(0,0)}{\bord0}`.)

**Root cause:** in `Formatting.SetTagsAndReturnTrimmed` (src/libuilogic/Translate/Formatting.cs), only the **first** `{\...}` group of a line was captured into `StartTags`; any further leading groups were **left in the clipboard text** that is sent to the translator. Consequences (matching the report): the leftover groups get "translated"/mangled into new formatting, the re-applied line keeps only the first group while the rest becomes garbage text, and the per-line tag handling drifts.

## Fix

`src/libuilogic/Translate/Formatting.cs` — the single `if` becomes a `while` that captures **all** consecutive leading `{\...}` groups into `StartTags` and strips them from the clipboard text. A malformed-tag guard (`endIndex <= 0` → break) preserves the previous behavior for broken input (a `{\...` without a closing `}` stays in the text).

Behavior for single-group, `<i>`/`<font>`, `[...]`, `\reset`, and malformed inputs is unchanged (verified with a simulation before applying).

## Verification

- [x] `dotnet build src/ui/UI.csproj -v q -nologo` — EXIT:0, 0 warnings, 0 errors (real command output).
- [x] New regression test `GetTranslationResult_KeepsAllConsecutiveAssaTagGroups` in tests/libuilogic/Translate/CopyPasteTranslatorTests.cs: an ASSA line with three adjacent groups round-trips through the copy-paste translator — the clipboard text contains no `{`, and the result re-applies all three groups. CopyPasteTranslator tests: **3/3 PASS**.
- [ ] Manual: Tools → Translate → Auto-translate via copy-paste with an ASSA file; lines with several adjacent tag groups keep all groups after pasting the translation.

## Notes

- The fix covers the leading-tag case from the report; tags in the middle/end of a line (karaoke) are out of scope for this change.
- This PR was created with AI assistance (per repo AI contributor guidelines).