### PR TITLE
Fix #11663: Persian (Farsi) texts are rendered in reverse order after translation

### DIFF
--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -428,7 +428,7 @@ public class AutoTranslateWindow : Window
         tableView.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Text,
-            Binding = new Binding(nameof(TranslateRow.Text)),
+            CellTemplate = TableViewExtras.MakeTextCellTemplate(nameof(TranslateRow.Text)),
             Width = new GridLength(1, GridUnitType.Star),
             CellTheme = UiUtil.TableViewCellTheme,
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
@@ -436,7 +436,7 @@ public class AutoTranslateWindow : Window
         tableView.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Translation,
-            Binding = new Binding(nameof(TranslateRow.TranslatedText)),
+            CellTemplate = TableViewExtras.MakeTextCellTemplate(nameof(TranslateRow.TranslatedText)),
             Width = new GridLength(1, GridUnitType.Star),
             CellTheme = UiUtil.TableViewCellTheme,
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,


### PR DESCRIPTION
## Problem

Fixes #11663 — Persian (Farsi) texts are rendered in reverse order in the Auto-translate window's live table after translation, making it impossible to assess translation quality in real time.

> We have identified a minor issue within the AI translation feature where Persian (Farsi) texts are rendered in reverse order after translation. This effectively makes it impossible to assess the translation quality in real time. Consequently, for large files, we are forced to wait several hours for the entire process to complete before we can review the output—a workflow that I find far from ideal. If possible, we kindly request that this issue be addressed prior to the final release of version 5. Thank you for your consideration.

### Root cause

The stored translation is correct — `MainViewModel.ShowAutoTranslate` copies `TranslateRow.TranslatedText` verbatim into the subtitle (src/ui/Features/Main/MainViewModel.cs:8630), and no code path in the translate pipeline reverses the string. The bug is display-only: the Auto-translate window's table (`BuildRowGridCard` in src/ui/Features/Translate/AutoTranslateWindow.cs:428-443) defines its "Text" and "Translation" columns with a plain `Binding`. A plain binding leaves the cell with the window's left-to-right flow direction; Avalonia then lays a right-to-left line out under an LTR base direction, cuts it at zero-width non-joiners (U+200C, bidi class BN — common in Persian), and places the resulting runs left to right, so the word order renders reversed. This is the same failure mode fixed for other TableView windows in #13160 via `TableViewExtras.MakeTextCellTemplate` (src/ui/Logic/TableViewExtras.cs:334-356), which binds the cell's `FlowDirection` to its own text content through `TextToFlowDirectionConverter`. The Auto-translate window was the last TableView window of the #13160-converted set still using a plain binding for subtitle text columns.

## Fix

Use the established `TableViewExtras.MakeTextCellTemplate` for the Auto-translate window's "Text" and "Translation" columns (src/ui/Features/Translate/AutoTranslateWindow.cs), exactly as the sibling Copy-paste translate window (src/ui/Features/Translate/CopyPasteTranslateWindow.cs:141-156) and 9 other TableView windows already do. The cell template binds `TextBlock.FlowDirection` to the cell's content, so Persian/Arabic text flows right-to-left and renders in correct word order.

## Verification

- [x] `dotnet build src/ui/UI.csproj -v q -nologo` — EXIT:0, 0 warnings, 0 errors
- [x] New regression test(s): none — UI-only change; per repo policy headless UI tests are reserved for keyboard-dispatch regressions
- Manual verification path: open Auto-translate (Tools > Auto-translate), pick any engine, translate an English subtitle to Persian (fa); the Translation column now shows the Persian text in correct right-to-left word order while translation runs, instead of reversed. Compare against the Copy-paste translate window which already renders correctly.
- `git diff --stat`: 1 file, 2 insertions, 2 deletions (no reformatting, no other files touched)

## Notes

- Interpretation: issue reports the real-time preview in the Auto-translate window; the final applied subtitle is verified correct by the reporter after the run completes, consistent with a display-only cause.
- The main window's edit box RTL issues (#12167, #10212) are separate — they concern the main subtitle text box/RTL mode and are NOT changed here.
- Deliberate non-change: other windows' plain-binding columns for non-text data (numbers, times) intentionally keep `Binding`.
- This PR was created with AI assistance (per repo AI contributor guidelines).

## Notes

- Follow-up opportunity (out of scope here): an audit found ~11 other TableView windows that still use plain bindings for subtitle text and share this RTL display bug — a future pass could convert them to `MakeTextCellTemplate` the same way.
