### PR TITLE
Fix #13278: avoid repeated paths in managed 7z extraction

### DIFF
--- a/src/ui/Logic/SevenZipExtractor/Unpacker.cs
+++ b/src/ui/Logic/SevenZipExtractor/Unpacker.cs
@@ -320,7 +320,6 @@ public static class Unpacker
 
         if (!Directory.Exists(skipPath))
         {
-            // If the skip path doesn't exist, just move everything
             skipPath = sourceDir;
         }
 
@@ -373,7 +372,7 @@ public static class Unpacker
         }
     }
 
-    public static void Extract7ZipSlow(string tempFileName, string dir, string skipFolderLevel, CancellationTokenSource cancellationTokenSource, Action<string> updateProgressText)
+    public static void Extract7ZipSlow(string tempFileName, string dir, string? skipFolderLevel, CancellationTokenSource cancellationTokenSource, Action<string> updateProgressText)
     {
         using Stream stream = File.OpenRead(tempFileName);
         using var archive = SevenZipArchive.OpenArchive(stream);
@@ -381,6 +380,7 @@ public static class Unpacker
         double unpackedSize = 0;
 
         var reader = archive.ExtractAllEntries();
+        var targetRoot = Path.GetFullPath(dir);
         while (reader.MoveToNextEntry())
         {
             if (cancellationTokenSource.IsCancellationRequested)
@@ -390,16 +390,46 @@ public static class Unpacker
 
             if (!string.IsNullOrEmpty(reader.Entry.Key))
             {
-                var entryFullName = reader.Entry.Key;
-                if (!string.IsNullOrEmpty(skipFolderLevel) && entryFullName.StartsWith(skipFolderLevel))
+                var entryFullName = reader.Entry.Key.Replace('\\', '/');
+                var normalizedSkipFolder = skipFolderLevel?.Replace('\\', '/').Trim('/') ?? string.Empty;
+                if (!string.IsNullOrEmpty(normalizedSkipFolder))
                 {
-                    entryFullName = entryFullName[skipFolderLevel.Length..];
+                    if (entryFullName.Equals(normalizedSkipFolder, StringComparison.Ordinal))
+                    {
+                        entryFullName = string.Empty;
+                    }
+                    else if (entryFullName.StartsWith(normalizedSkipFolder + "/", StringComparison.Ordinal))
+                    {
+                        entryFullName = entryFullName[(normalizedSkipFolder.Length + 1)..];
+                    }
                 }
 
                 entryFullName = entryFullName.Replace('/', Path.DirectorySeparatorChar);
-                entryFullName = entryFullName.TrimStart(Path.DirectorySeparatorChar);
+                if (Path.IsPathRooted(entryFullName))
+                {
+                    throw new InvalidDataException($"Archive entry is rooted outside the extraction folder: {reader.Entry.Key}");
+                }
 
-                var fullFileName = Path.Combine(dir, entryFullName);
+                entryFullName = entryFullName.TrimStart(Path.DirectorySeparatorChar);
+                if (string.IsNullOrEmpty(entryFullName))
+                {
+                    if (reader.Entry.IsDirectory)
+                    {
+                        Directory.CreateDirectory(dir);
+                        continue;
+                    }
+
+                    throw new InvalidDataException("Archive contains an empty file entry name.");
+                }
+
+                var fullFileName = Path.GetFullPath(Path.Combine(targetRoot, entryFullName));
+                var relativePath = Path.GetRelativePath(targetRoot, fullFileName);
+                if (relativePath.Equals("..", StringComparison.Ordinal) ||
+                    relativePath.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) ||
+                    Path.IsPathRooted(relativePath))
+                {
+                    throw new InvalidDataException($"Archive entry is outside the extraction folder: {reader.Entry.Key}");
+                }
 
                 if (reader.Entry.IsDirectory)
                 {
@@ -417,6 +447,8 @@ public static class Unpacker
                     continue;
                 }
 
+                Directory.CreateDirectory(fullPath);
+
                 var displayName = entryFullName;
                 if (displayName.Length > 30)
                 {
@@ -427,7 +459,10 @@ public static class Unpacker
                     updateProgressText(string.Format(Se.Language.General.UnpackingX, displayName));
                 });
 
-                reader.WriteEntryToDirectory(fullPath);
+                // WriteEntryToDirectory appends the entry's original full key again. Since
+                // fullPath already contains the stripped relative path, that produced the
+                // repeated .../numpy/core/Faster-Whisper-XXL/... nesting reported in #13278.
+                reader.WriteEntryToFile(fullFileName);
                 unpackedSize += reader.Entry.Size;
             }
         }

--- a/tests/UI/Logic/SevenZipExtractor/UnpackerTests.cs
+++ b/tests/UI/Logic/SevenZipExtractor/UnpackerTests.cs
@@ -1,0 +1,61 @@
+using Nikse.SubtitleEdit.Logic.SevenZipExtractor;
+
+namespace UITests.Logic.SevenZipExtractor;
+
+public class UnpackerTests : IDisposable
+{
+    private const string ArchiveBase64 = "N3q8ryccAASRme6J7wAAAAAAAAAWAAAAAAAAANtGIGABABZlbmdpbmVleGVjdXRhYmxlbGljZW5zZQDgAlUAzF0AAIEzB64Pz7XvEA/Ual595dfdm+avUngQmcP0+WCm1/B0sii/q/CHmny4m6aKmeaETC1j6oYCbmCvutV7/FCFvtanCgHlX/zjPbLzpoLXTRu5YlZGWdBR+YNjTU+jaIr+BgzCBmucvUyzM93+Zf2XK7H3EeosnQ88EhVRM096o8AbJeFkMSXMddJen437oUr4YA7ZtjnpAZxnmMuFuDTcR0hzuZ2JwNeddfoONNW9EvkwlskRI/+0AJxZRToJCGFpXlUTmVVoSecnAAAAABcGGwEJgNQABwsBAAEhIQEYDIJWAAA=";
+    private const string AbsolutePathArchiveBase64 = "N3q8ryccAASLHia9CwAAAAAAAACCAAAAAAAAACgymrgBAAZvdXRzaWRlAAEEBgABCQsABwsBAAEhIQEADAcACAoBpv3qtQAABQEZDAAAAAAAAAAAAAAAABE7AC8AdABtAHAALwBzAGUAMQAzADIAOAA4AGUAdgBpAGwALwBvAHUAdABzAGkAZABlAC4AdAB4AHQAAAAZABQKAQB8salAgSXdARUGAQAggKSBAAA=";
+
+    private readonly string _tempFolder;
+
+    public UnpackerTests()
+    {
+        _tempFolder = Path.Combine(Path.GetTempPath(), "SeUnpackerTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempFolder);
+    }
+
+    [Fact]
+    public void Extract7ZipSlow_StripsWrapperWithoutRepeatingOriginalEntryPath()
+    {
+        var archiveFileName = Path.Combine(_tempFolder, "fixture.7z");
+        var outputFolder = Path.Combine(_tempFolder, "output");
+        File.WriteAllBytes(archiveFileName, Convert.FromBase64String(ArchiveBase64));
+
+        Unpacker.Extract7ZipSlow(
+            archiveFileName,
+            outputFolder,
+            "Faster-Whisper-XXL",
+            new CancellationTokenSource(),
+            _ => { });
+
+        Assert.Equal("engine", File.ReadAllText(Path.Combine(outputFolder, "_xxl_data", "numpy", "core", "engine.bin")));
+        Assert.Equal("executable", File.ReadAllText(Path.Combine(outputFolder, "whisper-faster")));
+        Assert.Equal("license", File.ReadAllText(Path.Combine(outputFolder, "license.txt")));
+        Assert.False(Directory.Exists(Path.Combine(outputFolder, "_xxl_data", "numpy", "core", "Faster-Whisper-XXL")));
+        Assert.Equal(3, Directory.GetFiles(outputFolder, "*", SearchOption.AllDirectories).Length);
+    }
+
+    [Fact]
+    public void Extract7ZipSlow_RejectsAbsoluteEntryPath()
+    {
+        var archiveFileName = Path.Combine(_tempFolder, "absolute-path.7z");
+        var outputFolder = Path.Combine(_tempFolder, "absolute-output");
+        File.WriteAllBytes(archiveFileName, Convert.FromBase64String(AbsolutePathArchiveBase64));
+
+        var exception = Assert.Throws<InvalidDataException>(() => Unpacker.Extract7ZipSlow(
+            archiveFileName,
+            outputFolder,
+            string.Empty,
+            new CancellationTokenSource(),
+            _ => { }));
+
+        Assert.Contains("outside the extraction folder", exception.Message);
+        Assert.Empty(Directory.GetFiles(_tempFolder, "outside.txt", SearchOption.AllDirectories));
+    }
+
+    public void Dispose()
+    {
+        Directory.Delete(_tempFolder, true);
+    }
+}


### PR DESCRIPTION
## Problem

Fixes #13278 — on Linux, Purfview Faster Whisper XXL can be extracted into repeatedly nested paths, so the executable is not at `<install dir>/faster-whisper-xxl`.

Issue quote (verbatim):

> Using Ubuntu 26.04 and SE 5.1.0 (and 5.2.0-beta4), a series of problems occur when trying to install this speech-to-text engine.
> [1] The binary faster-whisper-xxl is installed in an unexpected location: <img ...>
> It is in fact installed in a further subdirectory name "Faster-Whisper-XXL"; moving it up one directory level fixed the execution issue.

**Root cause:** when the external 7-Zip paths are unavailable/fail, `Extract7ZipSlow` uses SharpCompress. It first computes the correct destination after stripping `Faster-Whisper-XXL/`, but then calls `reader.WriteEntryToDirectory(fullPath)`. That API appends the entry's original full archive key again. For an entry such as `Faster-Whisper-XXL/_xxl_data/numpy/core/file`, the resulting path becomes:

`<install>/_xxl_data/numpy/core/Faster-Whisper-XXL/_xxl_data/numpy/core/file`

This is the repeated path visible in the issue screenshot.

The current real Linux archive was downloaded and inspected byte-for-byte. Its wrapper is exactly `Faster-Whisper-XXL` (same case and Unicode code points), plus a root `license.txt`; therefore the previous theory about a differently named wrapper was incorrect and that fallback has been removed.

## Fix

- Normalize the archive entry and strip only an exact wrapper directory boundary.
- Canonicalize the extraction root and each destination, reject rooted/absolute entries and any normalized `..` path that escapes the root, then call `WriteEntryToFile(fullFileName)`. This restores the path-containment property that `WriteEntryToDirectory` previously provided while avoiding its duplicate-key behavior.
- Preserve the old fallback when the requested wrapper genuinely does not exist; no speculative single-directory unwrap remains.

## Verification

- [x] `dotnet build src/ui/UI.csproj --no-incremental -v q -nologo` — EXIT:0.
- [x] Permanent `UnpackerTests.Extract7ZipSlow_StripsWrapperWithoutRepeatingOriginalEntryPath` uses a real embedded 7z fixture with the same wrapper, nested `_xxl_data/numpy/core` path and loose root `license.txt`.
- [x] RED/GREEN proven: the layout test fails 0/1 on the old code and passes on the fix. A second real `7z -spf` fixture proves an absolute archive entry is rejected instead of being written outside the target; `UnpackerTests` 2/2 PASS.
- [x] Full real asset `Faster-Whisper-XXL_r245.4_linux.7z` (1,657,634,355 bytes compressed; 4,393 files and 634 folders) was extracted through `Extract7ZipSlow`: PASS in 4m19s. `faster-whisper-xxl`, `license.txt` and `_xxl_data` were at the install root, with zero nested `Faster-Whisper-XXL` directories.

## Notes

- The issue's later execution-environment points are outside this extraction-layout fix and are not claimed as resolved here.
- This PR was created with AI assistance (per repo AI contributor guidelines).
