### PR TITLE
Add CrispEmbed OCR engine to batch convert

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -3057,7 +3057,9 @@
     "llamaCppReturnedNoText": "llama.cpp returned no text - check the server and model",
     "llamaCppDownloadEngineAndModelPrompt": "llama.cpp requires the llama-server engine and the selected OCR model to be downloaded. Download now?",
     "llamaCppDownloadEnginePrompt": "llama.cpp requires the llama-server engine to be downloaded. Download now?",
-    "llamaCppDownloadModelPrompt": "llama.cpp requires the selected OCR model to be downloaded. Download now?"
+    "llamaCppDownloadModelPrompt": "llama.cpp requires the selected OCR model to be downloaded. Download now?",
+    "crispEmbedNotDownloaded": "CrispEmbed engine/model not downloaded - download via batch convert settings",
+    "crispEmbedReturnedNoText": "CrispEmbed returned no text - check the model"
   },
   "assa": {
     "assaDraw": "ASSA Draw",

--- a/src/ui/Features/Ocr/Download/CrispEmbedDownloadHelper.cs
+++ b/src/ui/Features/Ocr/Download/CrispEmbedDownloadHelper.cs
@@ -1,0 +1,136 @@
+using Avalonia.Controls;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Ocr.Engines;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Logic;
+using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Ocr.Download;
+
+/// <summary>
+/// Shared download/availability flow for the CrispEmbed OCR engine - the OCR-side analog of
+/// <see cref="Translate.LlamaCppDownloadHelper"/>, used by both the OCR window and the batch
+/// convert settings.
+/// </summary>
+public static class CrispEmbedDownloadHelper
+{
+    /// <summary>
+    /// Makes sure the CrispEmbed engine binaries and the given model are on disk, offering
+    /// downloads for anything missing. The optional callbacks fire after the engine/model
+    /// download dialog closes (regardless of outcome) so callers can refresh install-status UI.
+    /// </summary>
+    public static async Task<bool> EnsureReadyAsync(
+        Window owner,
+        IWindowService windowService,
+        CrispEmbedBackend backend,
+        CrispEmbedModel model,
+        bool forceModelDownload = false,
+        Action? onEngineDownloadClosed = null,
+        Action? onModelDownloadClosed = null)
+    {
+        if (!CrispEmbedEngine.IsEngineInstalled())
+        {
+            string variant;
+            if (Configuration.IsRunningOnWindows)
+            {
+                var answer = await MessageBox.Show(
+                    owner,
+                    "Download CrispEmbed?",
+                    $"{Environment.NewLine}\"CrispEmbed\" requires downloading the CrispEmbed engine.{Environment.NewLine}{Environment.NewLine}Download and use CrispEmbed?",
+                    MessageBoxButtons.Cancel,
+                    MessageBoxIcon.Question,
+                    "CPU",
+                    "Vulkan",
+                    "CUDA");
+
+                if (answer == MessageBoxResult.Cancel)
+                {
+                    return false;
+                }
+
+                variant = answer switch
+                {
+                    MessageBoxResult.Custom1 => "cpu",
+                    MessageBoxResult.Custom3 => "cuda",
+                    _ => "vulkan",
+                };
+            }
+            else if (Configuration.IsRunningOnLinux && RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
+            {
+                var answer = await MessageBox.Show(
+                    owner,
+                    "Download CrispEmbed?",
+                    $"{Environment.NewLine}\"CrispEmbed\" requires downloading the CrispEmbed engine.{Environment.NewLine}{Environment.NewLine}Download and use CrispEmbed?",
+                    MessageBoxButtons.Cancel,
+                    MessageBoxIcon.Question,
+                    "CPU (~10 MB)",
+                    "GPU CUDA (~718 MB)");
+
+                if (answer == MessageBoxResult.Cancel)
+                {
+                    return false;
+                }
+
+                variant = answer == MessageBoxResult.Custom2 ? "cuda" : string.Empty;
+            }
+            else
+            {
+                var answer = await MessageBox.Show(
+                    owner,
+                    "Download CrispEmbed?",
+                    $"{Environment.NewLine}\"CrispEmbed\" requires downloading the CrispEmbed engine ({CrispEmbedEngine.DownloadSizeText}).{Environment.NewLine}{Environment.NewLine}Download and use CrispEmbed?",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (answer != MessageBoxResult.Yes)
+                {
+                    return false;
+                }
+
+                variant = string.Empty;
+            }
+
+            var engineResult = await windowService.ShowDialogAsync<DownloadCrispEmbedWindow, DownloadCrispEmbedViewModel>(owner,
+                vm => vm.InitializeEngine(variant));
+
+            onEngineDownloadClosed?.Invoke();
+
+            if (!engineResult.OkPressed)
+            {
+                return false;
+            }
+        }
+
+        if (forceModelDownload || !backend.IsModelInstalled(model))
+        {
+            if (!forceModelDownload)
+            {
+                var answer = await MessageBox.Show(
+                    owner,
+                    "Download model?",
+                    $"{Environment.NewLine}Download the model \"{model.Name}\" ({model.Size})?",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (answer != MessageBoxResult.Yes)
+                {
+                    return false;
+                }
+            }
+
+            var modelResult = await windowService.ShowDialogAsync<DownloadCrispEmbedWindow, DownloadCrispEmbedViewModel>(owner,
+                vm => vm.InitializeModel(backend, model));
+
+            onModelDownloadClosed?.Invoke();
+
+            if (!modelResult.OkPressed)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -1289,110 +1289,18 @@ public partial class OcrViewModel : ObservableObject
             return false;
         }
 
-        if (!CrispEmbedEngine.IsEngineInstalled())
-        {
-            string variant;
-            if (Configuration.IsRunningOnWindows)
+        return await CrispEmbedDownloadHelper.EnsureReadyAsync(
+            Window, _windowService, backend, model.Model, forceModelDownload,
+            onEngineDownloadClosed: () =>
             {
-                var answer = await MessageBox.Show(
-                    Window,
-                    "Download CrispEmbed?",
-                    $"{Environment.NewLine}\"CrispEmbed\" requires downloading the CrispEmbed engine.{Environment.NewLine}{Environment.NewLine}Download and use CrispEmbed?",
-                    MessageBoxButtons.Cancel,
-                    MessageBoxIcon.Question,
-                    "CPU",
-                    "Vulkan",
-                    "CUDA");
-
-                if (answer == MessageBoxResult.Cancel)
-                {
-                    return false;
-                }
-
-                variant = answer switch
-                {
-                    MessageBoxResult.Custom1 => "cpu",
-                    MessageBoxResult.Custom3 => "cuda",
-                    _ => "vulkan",
-                };
-            }
-            else if (Configuration.IsRunningOnLinux && RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
+                _isCtrlDown = false;
+                RefreshEngineCombo?.Invoke();
+            },
+            onModelDownloadClosed: () =>
             {
-                var answer = await MessageBox.Show(
-                    Window,
-                    "Download CrispEmbed?",
-                    $"{Environment.NewLine}\"CrispEmbed\" requires downloading the CrispEmbed engine.{Environment.NewLine}{Environment.NewLine}Download and use CrispEmbed?",
-                    MessageBoxButtons.Cancel,
-                    MessageBoxIcon.Question,
-                    "CPU (~10 MB)",
-                    "GPU CUDA (~718 MB)");
-
-                if (answer == MessageBoxResult.Cancel)
-                {
-                    return false;
-                }
-
-                variant = answer == MessageBoxResult.Custom2 ? "cuda" : string.Empty;
-            }
-            else
-            {
-                var answer = await MessageBox.Show(
-                    Window,
-                    "Download CrispEmbed?",
-                    $"{Environment.NewLine}\"CrispEmbed\" requires downloading the CrispEmbed engine ({CrispEmbedEngine.DownloadSizeText}).{Environment.NewLine}{Environment.NewLine}Download and use CrispEmbed?",
-                    MessageBoxButtons.YesNoCancel,
-                    MessageBoxIcon.Question);
-
-                if (answer != MessageBoxResult.Yes)
-                {
-                    return false;
-                }
-
-                variant = string.Empty;
-            }
-
-            var engineResult = await _windowService.ShowDialogAsync<DownloadCrispEmbedWindow, DownloadCrispEmbedViewModel>(Window,
-                vm => vm.InitializeEngine(variant));
-
-            _isCtrlDown = false;
-            RefreshEngineCombo?.Invoke();
-
-            if (!engineResult.OkPressed)
-            {
-                return false;
-            }
-        }
-
-        if (forceModelDownload || !backend.IsModelInstalled(model.Model))
-        {
-            if (!forceModelDownload)
-            {
-                var answer = await MessageBox.Show(
-                    Window,
-                    "Download model?",
-                    $"{Environment.NewLine}Download the model \"{model.Model.Name}\" ({model.Model.Size})?",
-                    MessageBoxButtons.YesNoCancel,
-                    MessageBoxIcon.Question);
-
-                if (answer != MessageBoxResult.Yes)
-                {
-                    return false;
-                }
-            }
-
-            var modelResult = await _windowService.ShowDialogAsync<DownloadCrispEmbedWindow, DownloadCrispEmbedViewModel>(Window,
-                vm => vm.InitializeModel(backend, model.Model));
-
-            _isCtrlDown = false;
-            RefreshCrispEmbedModelCombo?.Invoke();
-
-            if (!modelResult.OkPressed)
-            {
-                return false;
-            }
-        }
-
-        return true;
+                _isCtrlDown = false;
+                RefreshCrispEmbedModelCombo?.Invoke();
+            });
     }
 
     [RelayCommand]

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
@@ -4,6 +4,8 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Ocr;
+using Nikse.SubtitleEdit.Features.Ocr.Download;
+using Nikse.SubtitleEdit.Features.Ocr.Engines;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Translate;
 using Nikse.SubtitleEdit.Logic;
@@ -63,6 +65,11 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<LlamaCppModelDisplay> _llamaCppOcrModels;
     [ObservableProperty] private LlamaCppModelDisplay? _selectedLlamaCppOcrModel;
 
+    [ObservableProperty] private ObservableCollection<CrispEmbedBackend> _crispEmbedBackends;
+    [ObservableProperty] private CrispEmbedBackend? _selectedCrispEmbedBackend;
+    [ObservableProperty] private ObservableCollection<CrispEmbedModelDisplay> _crispEmbedModels;
+    [ObservableProperty] private CrispEmbedModelDisplay? _selectedCrispEmbedModel;
+
     [ObservableProperty] bool _isOcrLanguageVisible;
     [ObservableProperty] bool _isTesseractOcrVisible;
     [ObservableProperty] bool _isPaddleOCrVisible;
@@ -70,8 +77,10 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
     [ObservableProperty] bool _isNOcrVisible;
     [ObservableProperty] bool _isOllamaVisible;
     [ObservableProperty] bool _isLlamaCppVisible;
+    [ObservableProperty] bool _isCrispEmbedVisible;
 
     public Window? Window { get; set; }
+    public Action? RefreshCrispEmbedModelCombo { get; set; }
 
     public bool OkPressed { get; private set; }
 
@@ -85,6 +94,11 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         TargetEncodings = new ObservableCollection<string>(encodings);
 
         OcrEngines = new ObservableCollection<string> { "nOcr", "BinaryOcr", "Tesseract", "Ollama", "llama.cpp" };
+        if (CrispEmbedEngine.CanBeDownloaded())
+        {
+            OcrEngines.Add(CrispEmbedEngine.StaticName);
+        }
+
         if (!OperatingSystem.IsMacOS())
         {
             OcrEngines.Add("PaddleOCR");
@@ -127,6 +141,11 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         LlamaCppOcrModels = new ObservableCollection<LlamaCppModelDisplay>();
         SelectedLlamaCppOcrModel = LlamaCppDownloadHelper.PopulateModels(
             LlamaCppOcrModels, LlamaCppServerManager.OcrModels, Se.Settings.Ocr.LlamaCppOcrModel);
+
+        CrispEmbedBackends = new ObservableCollection<CrispEmbedBackend>(CrispEmbedEngine.GetBackends());
+        CrispEmbedModels = new ObservableCollection<CrispEmbedModelDisplay>();
+        SelectedCrispEmbedBackend = CrispEmbedBackends.FirstOrDefault(p => p.Name == Se.Settings.Ocr.CrispEmbedBackend)
+                                    ?? CrispEmbedBackends.FirstOrDefault();
 
         _folderHelper = folderHelper;
         _windowService = windowService;
@@ -241,7 +260,32 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
             Se.Settings.Ocr.LlamaCppOcrModel = SelectedLlamaCppOcrModel.Model.FileName;
         }
 
+        if (ocrEngine == CrispEmbedEngine.StaticName)
+        {
+            Se.Settings.Ocr.CrispEmbedBackend = SelectedCrispEmbedBackend?.Name ?? Se.Settings.Ocr.CrispEmbedBackend;
+            Se.Settings.Ocr.CrispEmbedModel = SelectedCrispEmbedModel?.Model.Name ?? Se.Settings.Ocr.CrispEmbedModel;
+        }
+
         Se.SaveSettings();
+    }
+
+    partial void OnSelectedCrispEmbedBackendChanged(CrispEmbedBackend? value)
+    {
+        CrispEmbedModels.Clear();
+        if (value == null)
+        {
+            SelectedCrispEmbedModel = null;
+            return;
+        }
+
+        foreach (var model in value.Models)
+        {
+            CrispEmbedModels.Add(new CrispEmbedModelDisplay { Backend = value, Model = model });
+        }
+
+        SelectedCrispEmbedModel = CrispEmbedModels.FirstOrDefault(p => p.Model.Name == Se.Settings.Ocr.CrispEmbedModel)
+                                  ?? CrispEmbedModels.FirstOrDefault(p => value.IsModelInstalled(p.Model))
+                                  ?? CrispEmbedModels.FirstOrDefault();
     }
 
     partial void OnSelectedNOcrDatabaseChanged(string? value)
@@ -308,6 +352,22 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
             }
         }
 
+        // Same for CrispEmbed: engine binaries plus the selected backend's model.
+        if (SelectedOcrEngine == CrispEmbedEngine.StaticName)
+        {
+            if (SelectedCrispEmbedBackend is not { } backend || SelectedCrispEmbedModel is not { } model)
+            {
+                return;
+            }
+
+            var ready = await CrispEmbedDownloadHelper.EnsureReadyAsync(Window!, _windowService, backend, model.Model,
+                onModelDownloadClosed: () => RefreshCrispEmbedModelCombo?.Invoke());
+            if (!ready)
+            {
+                return;
+            }
+        }
+
         SaveSettings();
         OkPressed = true;
         Window?.Close();
@@ -351,13 +411,14 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
             return;
         }
 
-        IsOcrLanguageVisible = ocrEngine != "nOcr" && ocrEngine != "BinaryOcr" && ocrEngine != "Ollama" && ocrEngine != "llama.cpp";
+        IsOcrLanguageVisible = ocrEngine != "nOcr" && ocrEngine != "BinaryOcr" && ocrEngine != "Ollama" && ocrEngine != "llama.cpp" && ocrEngine != CrispEmbedEngine.StaticName;
         IsTesseractOcrVisible = ocrEngine == "Tesseract";
         IsPaddleOCrVisible = ocrEngine == "PaddleOCR";
         IsBinaryOcrVisible = ocrEngine == "BinaryOcr";
         IsNOcrVisible = ocrEngine == "nOcr";
         IsOllamaVisible = ocrEngine == "Ollama";
         IsLlamaCppVisible = ocrEngine == "llama.cpp";
+        IsCrispEmbedVisible = ocrEngine == CrispEmbedEngine.StaticName;
 
         if (ocrEngine == "Tesseract")
         {

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
@@ -1,6 +1,8 @@
 using Avalonia.Controls;
+using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Layout;
+using Nikse.SubtitleEdit.Features.Ocr.Engines;
 using Nikse.SubtitleEdit.Features.Translate;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -107,11 +109,19 @@ public class BatchConvertSettingsWindow : Window
             model => model.Model.DisplayName,
             model => model.Model.Size,
             model => model.IsInstalled ? DownloadDotStatus.UpToDate : DownloadDotStatus.NotInstalled);
+        var labelCrispEmbedBackend = UiUtil.MakeLabel(Se.Language.General.Backend).WithBindVisible(vm, nameof(vm.IsCrispEmbedVisible)).WithMarginLeft(10);
+        var comboBoxCrispEmbedBackends = UiUtil.MakeComboBox(vm.CrispEmbedBackends, vm, nameof(vm.SelectedCrispEmbedBackend))
+            .WithBindVisible(nameof(vm.IsCrispEmbedVisible));
+        var labelCrispEmbedModel = UiUtil.MakeLabel(Se.Language.General.Model).WithBindVisible(vm, nameof(vm.IsCrispEmbedVisible)).WithMarginLeft(10);
+        var comboBoxCrispEmbedModels = UiUtil.MakeComboBox(vm.CrispEmbedModels, vm, nameof(vm.SelectedCrispEmbedModel))
+            .WithBindVisible(nameof(vm.IsCrispEmbedVisible));
+        comboBoxCrispEmbedModels.ItemTemplate = MakeCrispEmbedModelItemTemplate();
+        vm.RefreshCrispEmbedModelCombo = () => comboBoxCrispEmbedModels.ItemTemplate = MakeCrispEmbedModelItemTemplate();
         var panelOcrEngine = new StackPanel
         {
             Orientation = Orientation.Horizontal,
             Margin = new Avalonia.Thickness(0, 30, 0, 0),
-            Children = { labelOcrEngine, comboBoxOcrEngine, labelOcLanguage, comboBoxTesseractLanguages, labelTesseractEngineMode, comboBoxTesseractEngineMode, comboBoxPaddleLanguages, labelBinaryOcrDatabase, comboBoxBinaryOcrDatabases, labelBinaryOcrFallback, comboBoxBinaryOcrFallback, labelNOcrDatabase, comboBoxNOcrDatabases, labelNOcrFallback, comboBoxNOcrFallback, labelOllamaModel, comboBoxOllamaModels, buttonOllamaModelBrowse, labelLlamaCppModel, comboBoxLlamaCppModels }
+            Children = { labelOcrEngine, comboBoxOcrEngine, labelOcLanguage, comboBoxTesseractLanguages, labelTesseractEngineMode, comboBoxTesseractEngineMode, comboBoxPaddleLanguages, labelBinaryOcrDatabase, comboBoxBinaryOcrDatabases, labelBinaryOcrFallback, comboBoxBinaryOcrFallback, labelNOcrDatabase, comboBoxNOcrDatabases, labelNOcrFallback, comboBoxNOcrFallback, labelOllamaModel, comboBoxOllamaModels, buttonOllamaModelBrowse, labelLlamaCppModel, comboBoxLlamaCppModels, labelCrispEmbedBackend, comboBoxCrispEmbedBackends, labelCrispEmbedModel, comboBoxCrispEmbedModels }
         };
         comboBoxOcrEngine.SelectionChanged += (s, e) => vm.OnOcrEngineChanged();
 
@@ -177,5 +187,17 @@ public class BatchConvertSettingsWindow : Window
 
         Activated += delegate { comboBoxTargetEncoding.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (s, e) => vm.OnKeyDown(e);
+    }
+
+    // Model combo item template: a dot (green = downloaded, grey = not downloaded yet) plus the
+    // model's download size - same treatment as the OCR window's CrispEmbed model combo.
+    private static FuncDataTemplate<CrispEmbedModelDisplay> MakeCrispEmbedModelItemTemplate()
+    {
+        return StatusDots.ComboItemTemplate<CrispEmbedModelDisplay>(
+            model => model.Model.Name,
+            model => string.IsNullOrEmpty(model.Model.Size) ? null : model.Model.Size,
+            model => model.Backend.IsModelInstalled(model.Model)
+                ? DownloadDotStatus.UpToDate
+                : DownloadDotStatus.NotInstalled);
     }
 }

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -21,6 +21,7 @@ using Nikse.SubtitleEdit.Features.Files.ExportImageBased;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Ocr;
 using Nikse.SubtitleEdit.Features.Ocr.Download;
+using Nikse.SubtitleEdit.Features.Ocr.Engines;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Shared.ErrorList;
 using Nikse.SubtitleEdit.Features.Shared.PickSubtitleFormat;
@@ -952,6 +953,11 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             return;
         }
 
+        if (!await EnsureCrispEmbedAvailable(config))
+        {
+            return;
+        }
+
         if (!await EnsureCrispAsrAvailable(config))
         {
             return;
@@ -1133,6 +1139,42 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         }
 
         return true;
+    }
+
+    // Pre-run gate for the CrispEmbed OCR engine: when the run will actually OCR image-based
+    // inputs, make sure the engine binaries and the configured backend's model are on disk
+    // (prompting for downloads if not) - the batch converter itself never prompts.
+    private async Task<bool> EnsureCrispEmbedAvailable(BatchConvertConfig config)
+    {
+        if (Window == null)
+        {
+            return true;
+        }
+
+        if (config.IsTargetFormatImageBased)
+        {
+            return true;
+        }
+
+        if (!Se.Settings.Tools.BatchConvert.OcrEngine.Equals(CrispEmbedEngine.StaticName, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (!BatchItems.Any(IsImageBasedInput))
+        {
+            return true;
+        }
+
+        var backend = CrispEmbedEngine.GetBackends().FirstOrDefault(b => b.Name == Se.Settings.Ocr.CrispEmbedBackend);
+        var model = backend?.Models.FirstOrDefault(m => m.Name == Se.Settings.Ocr.CrispEmbedModel)
+                    ?? backend?.Models.FirstOrDefault(m => backend.IsModelInstalled(m));
+        if (backend == null || model == null)
+        {
+            return true; // no matching backend in settings - the converter reports the status per item
+        }
+
+        return await CrispEmbedDownloadHelper.EnsureReadyAsync(Window, _windowService, backend, model);
     }
 
     private async Task<bool> EnsureCrispAsrAvailable(BatchConvertConfig config)

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -327,6 +327,10 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             {
                 await RunLlamaCppOcr(imageSubtitle, item, cancellationToken);
             }
+            else if (Se.Settings.Tools.BatchConvert.OcrEngine.Equals(CrispEmbedEngine.StaticName, StringComparison.OrdinalIgnoreCase))
+            {
+                await RunCrispEmbedOcr(imageSubtitle, item, cancellationToken);
+            }
             else
             {
                 await RunOcrTesseract(imageSubtitle, item, cancellationToken);
@@ -1362,6 +1366,88 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             item.Subtitle.Paragraphs.All(p => string.IsNullOrWhiteSpace(p.Text)))
         {
             item.Status = Se.Language.Ocr.LlamaCppReturnedNoText;
+        }
+    }
+
+    private async Task RunCrispEmbedOcr(IOcrSubtitle imageSubtitles, BatchConvertItem item, CancellationToken cancellationToken)
+    {
+        // Backend/model picked in batch convert settings (shared with the OCR window). The batch
+        // run never downloads - the settings dialog prompts for that on OK.
+        var backend = CrispEmbedEngine.GetBackends().FirstOrDefault(b => b.Name == Se.Settings.Ocr.CrispEmbedBackend);
+        var model = backend?.Models.FirstOrDefault(m => m.Name == Se.Settings.Ocr.CrispEmbedModel)
+                    ?? backend?.Models.FirstOrDefault(m => backend.IsModelInstalled(m));
+        if (backend == null || model == null || !CrispEmbedEngine.IsEngineInstalled() || !backend.IsModelInstalled(model))
+        {
+            item.Status = Se.Language.Ocr.CrispEmbedNotDownloaded;
+            return;
+        }
+
+        using var engine = new CrispEmbedOcr(Se.Settings.Ocr.CrispEmbedOcrTimeoutMinutes);
+
+        // PP-OCRv6 is a detector+recognizer pair driven through the CLI; the VLM backends load
+        // once into crispembed-server per file - see CrispEmbedOcr.
+        item.Status = Se.Language.General.OcrDotDotDot;
+        bool started;
+        try
+        {
+            started = backend.UsesTextDetector
+                ? engine.StartCliPipeline(
+                    CrispEmbedEngine.GetCliExecutable(),
+                    backend.GetModelPath(model),
+                    backend.GetDetectorPath(model))
+                : await engine.StartServerAsync(
+                    CrispEmbedEngine.GetServerExecutable(),
+                    backend.GetModelPath(model),
+                    cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            item.Status = Se.Language.General.Cancelled;
+            return;
+        }
+
+        if (!started)
+        {
+            item.Status = string.Format(Se.Language.General.ErrorX, engine.Error);
+            return;
+        }
+
+        item.Subtitle = new Subtitle();
+        var cancelled = false;
+        for (var i = 0; i < imageSubtitles.Count; i++)
+        {
+            var pct = (i + 1) * 100 / imageSubtitles.Count;
+            item.Status = string.Format(Se.Language.General.OcrPercentX, pct);
+            var bitmap = imageSubtitles.GetBitmap(i);
+
+            string text;
+            try
+            {
+                text = await engine.Ocr(bitmap, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                item.Status = Se.Language.General.Cancelled;
+                return;
+            }
+
+            var p = new Paragraph(text, imageSubtitles.GetStartTime(i).TotalMilliseconds, imageSubtitles.GetEndTime(i).TotalMilliseconds);
+            item.Subtitle.Paragraphs.Add(p);
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                item.Status = Se.Language.General.Cancelled;
+                cancelled = true;
+                break;
+            }
+        }
+
+        // Every line blank means the engine/model setup is broken - flag the file so the user
+        // notices instead of ending up with a silently-empty subtitle.
+        if (!cancelled && item.Subtitle.Paragraphs.Count > 0 &&
+            item.Subtitle.Paragraphs.All(p => string.IsNullOrWhiteSpace(p.Text)))
+        {
+            item.Status = Se.Language.Ocr.CrispEmbedReturnedNoText;
         }
     }
 

--- a/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
+++ b/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
@@ -122,6 +122,8 @@ public class LanguageOcr
     public string LlamaCppDownloadEngineAndModelPrompt { get; set; }
     public string LlamaCppDownloadEnginePrompt { get; set; }
     public string LlamaCppDownloadModelPrompt { get; set; }
+    public string CrispEmbedNotDownloaded { get; set; }
+    public string CrispEmbedReturnedNoText { get; set; }
 
     public LanguageOcr()
     {
@@ -246,5 +248,7 @@ public class LanguageOcr
         LlamaCppDownloadEngineAndModelPrompt = "llama.cpp requires the llama-server engine and the selected OCR model to be downloaded. Download now?";
         LlamaCppDownloadEnginePrompt = "llama.cpp requires the llama-server engine to be downloaded. Download now?";
         LlamaCppDownloadModelPrompt = "llama.cpp requires the selected OCR model to be downloaded. Download now?";
+        CrispEmbedNotDownloaded = "CrispEmbed engine/model not downloaded - download via batch convert settings";
+        CrispEmbedReturnedNoText = "CrispEmbed returned no text - check the model";
     }
 }

--- a/src/ui/Logic/ValueConverters/BatchConvertStatusColorConverter.cs
+++ b/src/ui/Logic/ValueConverters/BatchConvertStatusColorConverter.cs
@@ -46,6 +46,10 @@ public class BatchConvertStatusColorConverter : IValueConverter
         var errorPrefix = GetErrorPrefix(Se.Language.General.ErrorX);
         if (status == Se.Language.General.NoSubtitlesFound ||
             status == Se.Language.Ocr.OllamaModelLikelyWrong ||
+            status == Se.Language.Ocr.LlamaCppNotDownloaded ||
+            status == Se.Language.Ocr.LlamaCppReturnedNoText ||
+            status == Se.Language.Ocr.CrispEmbedNotDownloaded ||
+            status == Se.Language.Ocr.CrispEmbedReturnedNoText ||
             (errorPrefix.Length > 0 && status.StartsWith(errorPrefix, StringComparison.OrdinalIgnoreCase)) ||
             status.StartsWith("BinaryOcr database not found", StringComparison.Ordinal))
         {

--- a/tests/UI/Features/Tools/BatchConvert/BatchConvertSettingsViewModelCrispEmbedTests.cs
+++ b/tests/UI/Features/Tools/BatchConvert/BatchConvertSettingsViewModelCrispEmbedTests.cs
@@ -1,0 +1,79 @@
+using Avalonia.Headless.XUnit;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Features.Ocr.Engines;
+using Nikse.SubtitleEdit.Features.Tools.BatchConvert;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Tools.BatchConvert;
+
+/// <summary>
+/// Tests for the CrispEmbed OCR engine option in the batch convert settings - the engine list,
+/// the backend/model combos, and how they follow the OCR settings shared with the OCR window.
+/// </summary>
+public class BatchConvertSettingsViewModelCrispEmbedTests
+{
+    [AvaloniaFact]
+    public void OcrEngines_ContainCrispEmbed_WhenAvailableOnPlatform()
+    {
+        var viewModel = MakeViewModel();
+
+        Assert.Equal(CrispEmbedEngine.CanBeDownloaded(),
+            viewModel.OcrEngines.Contains(CrispEmbedEngine.StaticName));
+    }
+
+    [AvaloniaFact]
+    public void SelectingCrispEmbed_ShowsBackendAndModel_AndHidesLanguage()
+    {
+        if (!CrispEmbedEngine.CanBeDownloaded())
+        {
+            return;
+        }
+
+        var viewModel = MakeViewModel();
+
+        viewModel.SelectedOcrEngine = CrispEmbedEngine.StaticName;
+        viewModel.OnOcrEngineChanged();
+
+        Assert.True(viewModel.IsCrispEmbedVisible);
+        Assert.False(viewModel.IsOcrLanguageVisible);
+        Assert.NotNull(viewModel.SelectedCrispEmbedBackend);
+        Assert.NotNull(viewModel.SelectedCrispEmbedModel);
+    }
+
+    [AvaloniaFact]
+    public void BackendCombo_FollowsOcrSettings_AndSwitchRepopulatesModels()
+    {
+        var savedBackend = Se.Settings.Ocr.CrispEmbedBackend;
+        var savedModel = Se.Settings.Ocr.CrispEmbedModel;
+        try
+        {
+            Se.Settings.Ocr.CrispEmbedBackend = "GLM-OCR";
+            Se.Settings.Ocr.CrispEmbedModel = "glm-ocr-q4_k.gguf";
+
+            var viewModel = MakeViewModel();
+
+            Assert.Equal("GLM-OCR", viewModel.SelectedCrispEmbedBackend?.Name);
+            Assert.Equal("glm-ocr-q4_k.gguf", viewModel.SelectedCrispEmbedModel?.Model.Name);
+
+            var otherBackend = viewModel.CrispEmbedBackends.First(p => p.Name == "GOT-OCR2");
+            viewModel.SelectedCrispEmbedBackend = otherBackend;
+
+            Assert.All(viewModel.CrispEmbedModels, m => Assert.Equal(otherBackend, m.Backend));
+            Assert.NotNull(viewModel.SelectedCrispEmbedModel);
+        }
+        finally
+        {
+            Se.Settings.Ocr.CrispEmbedBackend = savedBackend;
+            Se.Settings.Ocr.CrispEmbedModel = savedModel;
+        }
+    }
+
+    private static BatchConvertSettingsViewModel MakeViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        using var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<BatchConvertSettingsViewModel>();
+    }
+}


### PR DESCRIPTION
The OCR window has the CrispEmbed engine (the CrispASR-family local OCR engine with multiple model backends - PP-OCRv6, GLM-OCR, GOT-OCR2, Qwen3-VL-2B, DeepSeek-OCR-2), but batch convert could not use it.

## What's in here

- **Batch convert settings**: "CrispEmbed" appears in the OCR engine list (on platforms where the engine can be downloaded), with **Backend** and **Model** combos that share the OCR window's settings keys (`Se.Settings.Ocr.CrispEmbedBackend`/`CrispEmbedModel`) and show the same green/grey install-status dots.
- **Download flow**: OK in the settings dialog and a pre-run check in batch convert both ensure the engine binaries and the selected model are on disk (offering the download dialogs), so the batch run itself never prompts - same contract as the llama.cpp OCR engine.
- **Converter**: new `RunCrispEmbedOcr` runs the VLM backends through `crispembed-server` (model loaded once per file) and PP-OCRv6 through the CLI detector+recognizer pipeline, mirroring the OCR window. Missing engine/model or an all-blank result is flagged per item.
- **Shared helper**: the engine/model ensure-downloaded flow is extracted from `OcrViewModel` into `CrispEmbedDownloadHelper` (analog of `LlamaCppDownloadHelper`), used by both windows - no behavior change in the OCR window.
- The new failure statuses (plus the existing llama.cpp ones, which were missed) now color as errors in the batch grid.

## Tests

- 3 new headless tests for the settings view model (engine list availability, visibility toggling, backend/model population from settings).
- Full UI suite passes: 1475/1475.

🤖 Generated with [Claude Code](https://claude.com/claude-code)