### PR TITLE
Fix AI Review delay input width

### DIFF
--- a/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
@@ -61,7 +61,7 @@ public class AiReviewWindow : Window
         // Free cloud tiers rate limit hard, so the delay between requests lives next to the API key
         // rather than in a settings dialog. The label would not fit the toolbar - a timer icon plus
         // tooltip carries the meaning, and the accessible name keeps it readable for screen readers.
-        var numericDelay = UiUtil.MakeNumericUpDownInt(0, 600, 0, 70, vm, nameof(vm.RequestDelaySeconds))
+        var numericDelay = UiUtil.MakeNumericUpDownInt(0, 600, 0, double.NaN, vm, nameof(vm.RequestDelaySeconds))
             .WithAccessibleName(Se.Language.Translate.DelayInSecondsBetweenRequests);
         ToolTip.SetTip(numericDelay, Se.Language.Translate.DelayInSecondsBetweenRequests);
         var iconDelay = new Optris.Icons.Avalonia.Icon


### PR DESCRIPTION
## Problem

The AI Review request-delay `NumericUpDown` had no visible input area because its fixed width was too narrow for the spinner buttons.

## Fix

Use automatic sizing for the delay input (`double.NaN`) so the text field and spinner buttons both remain visible.

## Screenshots
|Before|After|
|-|-|
|<img width="551" height="276" src="https://github.com/user-attachments/assets/a83083a0-db3a-48a3-93a8-47ea8e23cac8" />|<img width="551" height="276" src="https://github.com/user-attachments/assets/12a56fe7-cf4b-4207-ab5d-0efbb1802c68" />|


## Testing

- Confirmed the delay input displays correctly in AI Review.
- Tested on Fedora 44 (x64, local build).