### PR TITLE
CI: retry the test run once on failure to contain headless UI flakes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,11 +41,27 @@ jobs:
         run: dotnet build SubtitleEdit.sln --no-restore
 
       - name: Test
+        id: test
+        continue-on-error: true
         run: dotnet test SubtitleEdit.sln --no-build --logger "trx;LogFileName=tests.trx"
 
-      # Uploaded on failure so a red check can be diagnosed without re-running locally.
+      # The headless UI suite has a contamination failure mode no in-test fix can cover:
+      # when a test crashes the shared Avalonia dispatcher thread, every later test that
+      # needs the headless session fails instantly in cleanup ("calling thread cannot
+      # access this object" from AvaloniaHeadlessPlatform.Initialize). A fresh process is
+      # the only recovery, so a failed run gets exactly one retry. A real regression fails
+      # both runs and still blocks the merge; a pass-on-retry stays visible as a warning
+      # annotation plus the first run's trx artifact.
+      - name: Retry tests once on failure
+        if: steps.test.outcome == 'failure'
+        run: |
+          echo "::warning title=Flaky test run::First test run failed; retrying once in a fresh process. Check the test-results artifact for the failure."
+          dotnet test SubtitleEdit.sln --no-build --logger "trx;LogFileName=tests-retry.trx"
+
+      # Uploaded whenever the first run failed - also on a green retry, so flakes can be
+      # diagnosed without re-running locally.
       - name: Upload test results
-        if: failure()
+        if: steps.test.outcome == 'failure'
         uses: actions/upload-artifact@v5
         with:
           name: test-results


### PR DESCRIPTION
## What

When the `Test` step fails, CI now reruns `dotnet test` once in a fresh process. A real regression fails both runs and still blocks the merge. A pass-on-retry stays visible: a warning annotation on the run, plus the first run's trx uploaded in the `test-results` artifact (upload now triggers on first-run failure, not only overall job failure).

## Why

Recent red runs on unrelated PRs (e.g. 31078216706, 31074898860, 31069939432) show two flake classes:

1. **Timing flakes** in the headless UI tests (menu activation, syntax editor key input) — addressed at the test level by #13271.
2. **A contamination cascade** no in-test fix can cover: once a test crashes the shared Avalonia dispatcher thread, every later test that needs the headless session fails instantly during cleanup with `InvalidOperationException: The calling thread cannot access this object` thrown from `AvaloniaHeadlessPlatform.Initialize` (re-initializing the platform from the wrong thread). That is why random unrelated tests fail at 1 ms. The only recovery is a fresh process, which is exactly what this retry provides.

Over 2026-08-05/06, 6 of 8 red PRs went green on a plain rerun — this automates that manual step while keeping the flake signal (annotation + artifact) so the underlying tests can still be hunted down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)