### PR TITLE
Fix the dominant headless UI test flake: share one Avalonia app per assembly

### DIFF
--- a/src/ui/Logic/UiTheme.cs
+++ b/src/ui/Logic/UiTheme.cs
@@ -7,6 +7,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Styling;
 using Avalonia.Themes.Fluent;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Nikse.SubtitleEdit.Controls.SyntaxTextEditorControl;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -46,7 +47,9 @@ public static class UiTheme
             if (themeSetting == ThemeNameSystem)
             {
                 // No Application in unit tests or at design time - fall back to dark.
-                if (Application.Current == null)
+                // ActualThemeVariant is UI-thread-affine, so an off-thread read (plain
+                // xunit facts, worker threads) must fall back too instead of throwing.
+                if (Application.Current == null || !Dispatcher.UIThread.CheckAccess())
                 {
                     return ThemeNameDark;
                 }

--- a/tests/UI/Logic/Accessibility/EditBoxAccessibilityNameTests.cs
+++ b/tests/UI/Logic/Accessibility/EditBoxAccessibilityNameTests.cs
@@ -13,6 +13,15 @@ using UITests.Logic.Accessibility;
 
 [assembly: AvaloniaTestApplication(typeof(TestAppBuilder))]
 
+// Avalonia 12 defaults to PerTest isolation, which resets the dispatcher and rebuilds the
+// whole application - including a Compositor on a timer-driven render loop - for every
+// test. That re-initialization races under CI load: DefaultRenderLoop.Add throws
+// "The calling thread cannot access this object" from AvaloniaHeadlessPlatform.Initialize
+// during a random test's cleanup (~2 in 5 runs on GitHub Actions). One shared application
+// per assembly initializes once and closes the race window. The suite is safe to share:
+// tests close their windows and restore any Application-level state they touch.
+[assembly: AvaloniaTestIsolation(AvaloniaTestIsolationLevel.PerAssembly)]
+
 namespace UITests.Logic.Accessibility;
 
 public class TestApp : Application


### PR DESCRIPTION
## Problem

After #13271 removed the timing flakes, one flake class remained — and a 5-run stress test on `main` showed it hits ~2 in 5 runs: a random test (often one that never opens a window, like `ValueConverterTests`) fails at 1 ms during cleanup with

```
InvalidOperationException: The calling thread cannot access this object because a different thread owns it.
   at Avalonia.Rendering.DefaultRenderLoop.Add(IRenderLoopTask i)
   ...
   at Avalonia.Headless.AvaloniaHeadlessPlatform.Initialize(AvaloniaHeadlessPlatformOptions opts)
   at Avalonia.Headless.HeadlessUnitTestSession.EnsureIsolatedApplication()
```

It even beat the retry safety net from #13294 once (both attempts flaked → red run [31085114308](https://github.com/SubtitleEdit/subtitleedit/actions/runs/31085114308)).

## Root cause

Avalonia 12's headless test framework defaults to **PerTest isolation**: for every one of the 1475 tests it resets the dispatcher and rebuilds the whole application — including a `Compositor` on a timer-driven render loop (we use real Skia compositing for the RTL canary tests). Each of those 1475 re-initializations is a race window under CI load.

## Fix

`[assembly: AvaloniaTestIsolation(AvaloniaTestIsolationLevel.PerAssembly)]` — one shared application for the whole run, initialized exactly once. The suite is compatible: tests close their windows (#13271/#13154) and restore any `Application`-level state they touch (`SubtitleSyntaxThemeColorTests`).

One genuine incompatibility surfaced and is fixed here: with a shared application alive, `UiTheme.ThemeName`'s read of `Application.Current.ActualThemeVariant` became reachable from non-UI threads (plain xunit facts calling `SubtitleSyntaxTokenizer.Tokenize`), where Avalonia throws. The existing "no application → dark" fallback now also covers off-thread reads — which also hardens production, where such a read would previously have crashed.

## Verification

- 3 consecutive full local suite runs: 1475/1475 green each.
- Suite wall time drops ~35% (1475 app rebuilds gone).
- Will stress-test with 5 dispatched CI runs on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)