### PR TITLE
Batch convert: frame rate source option for "Beautify time codes" + compact adjust image layout

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConvertConfig.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertConfig.cs
@@ -379,10 +379,13 @@ public class BatchConvertConfig
     {
         public bool IsActive { get; set; }
         public bool SnapToShotChanges { get; set; }
+        public bool UseFixedFrameRate { get; set; }
+        public double FixedFrameRate { get; set; }
 
         public BeautifyTimeCodesSettings2()
         {
             SnapToShotChanges = true;
+            FixedFrameRate = 23.976;
         }
     }
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -197,6 +197,10 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
 
     // Beautify time codes
     [ObservableProperty] private bool _beautifyTimeCodesSnapToShotChanges;
+    [ObservableProperty] private bool _beautifyTimeCodesUseVideoFrameRate;
+    [ObservableProperty] private bool _beautifyTimeCodesUseFixedFrameRate;
+    [ObservableProperty] private ObservableCollection<double> _beautifyTimeCodesFrameRates;
+    [ObservableProperty] private double _selectedBeautifyTimeCodesFrameRate;
 
     // Bride gaps
     [ObservableProperty] private int _bridgeGapsSmallerThanMs;
@@ -345,6 +349,21 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             60,
             120,
         };
+        BeautifyTimeCodesFrameRates = new ObservableCollection<double>
+        {
+            23.976,
+            24,
+            25,
+            29.97,
+            30,
+            48,
+            59.94,
+            60,
+            120,
+        };
+        SelectedBeautifyTimeCodesFrameRate = BeautifyTimeCodesFrameRates[0];
+        BeautifyTimeCodesUseVideoFrameRate = true;
+
         AdjustTypes = new ObservableCollection<AdjustDurationDisplay>(AdjustDurationDisplay.ListAll());
         SelectedAdjustType = AdjustTypes.First();
 
@@ -633,6 +652,8 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
 
         // Beautify time codes
         Se.Settings.Tools.BatchConvert.BeautifyTimeCodesSnapToShotChanges = BeautifyTimeCodesSnapToShotChanges;
+        Se.Settings.Tools.BatchConvert.BeautifyTimeCodesUseFixedFrameRate = BeautifyTimeCodesUseFixedFrameRate;
+        Se.Settings.Tools.BatchConvert.BeautifyTimeCodesFixedFrameRate = SelectedBeautifyTimeCodesFrameRate;
 
         // Adjust image brightness/alpha/color
         Se.Settings.Tools.BatchConvert.ImageAdjustBrightnessOn = ImageAdjustBrightnessOn;
@@ -762,6 +783,13 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         BridgeGapsPercentForLeft = Se.Settings.Tools.BridgeGaps.PercentForLeft;
 
         BeautifyTimeCodesSnapToShotChanges = Se.Settings.Tools.BatchConvert.BeautifyTimeCodesSnapToShotChanges;
+        BeautifyTimeCodesUseFixedFrameRate = Se.Settings.Tools.BatchConvert.BeautifyTimeCodesUseFixedFrameRate;
+        BeautifyTimeCodesUseVideoFrameRate = !BeautifyTimeCodesUseFixedFrameRate;
+        var beautifyRate = BeautifyTimeCodesFrameRates.FirstOrDefault(p => Math.Abs(p - Se.Settings.Tools.BatchConvert.BeautifyTimeCodesFixedFrameRate) < 0.001);
+        if (beautifyRate > 0)
+        {
+            SelectedBeautifyTimeCodesFrameRate = beautifyRate;
+        }
 
         SplitBreakSingleLineMaxLength = Se.Settings.General.SubtitleLineMaximumLength;
         SplitBreakMaxNumberOfLines = Se.Settings.General.MaxNumberOfLines;
@@ -2297,6 +2325,8 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             {
                 IsActive = activeFunctions.Contains(BatchConvertFunctionType.BeautifyTimeCodes),
                 SnapToShotChanges = BeautifyTimeCodesSnapToShotChanges,
+                UseFixedFrameRate = BeautifyTimeCodesUseFixedFrameRate,
+                FixedFrameRate = SelectedBeautifyTimeCodesFrameRate,
             },
 
             AdjustImageColors = new BatchConvertConfig.AdjustImageColorsSettings

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -2188,15 +2188,16 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             return subtitle;
         }
 
-        // Frame rate and shot changes come from a video file matching the subtitle file
-        // name, when one exists. Shot changes are only available if they were previously
-        // generated/imported for that video (they are cached on disk per video file).
+        // Frame rate comes from either a fixed user-chosen rate or a video file matching
+        // the subtitle file name, when one exists. Shot changes are only available if they
+        // were previously generated/imported for that video (they are cached on disk per
+        // video file).
         //
-        // Without a matching video, fall back to the frame rate this batch is actually
-        // producing: the target of the "change frame rate" step when it runs (it runs before
-        // this one), otherwise the project frame rate. Configuration.Settings.General
-        // .DefaultFrameRate is not usable here - nothing in the UI ever assigns it, so it is
-        // always libse's built-in 23.976.
+        // Without a fixed rate or a matching video, fall back to the frame rate this batch
+        // is actually producing: the target of the "change frame rate" step when it runs
+        // (it runs before this one), otherwise the project frame rate. Configuration
+        // .Settings.General.DefaultFrameRate is not usable here - nothing in the UI ever
+        // assigns it, so it is always libse's built-in 23.976.
         var frameRate = _config.ChangeFrameRate.IsActive && _config.ChangeFrameRate.ToFrameRate > 0
             ? _config.ChangeFrameRate.ToFrameRate
             : Se.Settings.General.CurrentFrameRate;
@@ -2205,21 +2206,29 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             frameRate = Se.Settings.General.DefaultFrameRate;
         }
 
+        if (_config.BeautifyTimeCodes.UseFixedFrameRate && _config.BeautifyTimeCodes.FixedFrameRate > 0)
+        {
+            frameRate = _config.BeautifyTimeCodes.FixedFrameRate;
+        }
+
         var shotChanges = new List<double>();
 
         if (FindVideoFileName.TryFindVideoFileName(subtitleFileName, out var videoFileName))
         {
-            try
+            if (!_config.BeautifyTimeCodes.UseFixedFrameRate)
             {
-                var mediaInfo = FfmpegMediaInfo2.Parse(videoFileName);
-                if (mediaInfo.FramesRate > 0)
+                try
                 {
-                    frameRate = (double)mediaInfo.FramesRate;
+                    var mediaInfo = FfmpegMediaInfo2.Parse(videoFileName);
+                    if (mediaInfo.FramesRate > 0)
+                    {
+                        frameRate = (double)mediaInfo.FramesRate;
+                    }
                 }
-            }
-            catch
-            {
-                // no ffmpeg or unreadable video file - keep the fallback frame rate
+                catch
+                {
+                    // no ffmpeg or unreadable video file - keep the fallback frame rate
+                }
             }
 
             if (_config.BeautifyTimeCodes.SnapToShotChanges)

--- a/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAdjustImageColors.cs
+++ b/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAdjustImageColors.cs
@@ -26,81 +26,64 @@ public static class ViewAdjustImageColors
             Opacity = 0.7,
             FontStyle = FontStyle.Italic,
             TextWrapping = TextWrapping.Wrap,
-        };
-
-        var brightnessPanel = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            VerticalAlignment = VerticalAlignment.Center,
-            Spacing = 5,
-            Children =
-            {
-                MakeCheckBox(Se.Language.Tools.ImageBasedEdit.AdjustBrightness, vm, nameof(vm.ImageAdjustBrightnessOn)),
-                MakeLabel(Se.Language.Tools.ImageBasedEdit.Brightness),
-                MakeNumericUpDown(vm, nameof(vm.ImageAdjustBrightness), nameof(vm.ImageAdjustBrightnessOn), -100, 100, 1),
-                MakeLabel(Se.Language.Tools.ImageBasedEdit.Contrast),
-                MakeNumericUpDown(vm, nameof(vm.ImageAdjustContrast), nameof(vm.ImageAdjustBrightnessOn), -100, 100, 1),
-                MakeLabel(Se.Language.Tools.ImageBasedEdit.Gamma + " (%)"),
-                MakeNumericUpDown(vm, nameof(vm.ImageAdjustGamma), nameof(vm.ImageAdjustBrightnessOn), 20, 400, 5),
-            }
-        };
-
-        var alphaPanel = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            VerticalAlignment = VerticalAlignment.Center,
-            Spacing = 5,
-            Children =
-            {
-                MakeCheckBox(Se.Language.General.AdjustAlpha, vm, nameof(vm.ImageAdjustAlphaOn)),
-                MakeLabel(Se.Language.General.AlphaAdjustment),
-                MakeNumericUpDown(vm, nameof(vm.ImageAdjustAlpha), nameof(vm.ImageAdjustAlphaOn), -255, 255, 5),
-                MakeLabel(Se.Language.General.AlphaThreshold),
-                MakeNumericUpDown(vm, nameof(vm.ImageAdjustAlphaThreshold), nameof(vm.ImageAdjustAlphaOn), 0, 255, 5),
-            }
+            MaxWidth = 500,
+            HorizontalAlignment = HorizontalAlignment.Left,
         };
 
         var colorPicker = UiUtil.MakeColorPickerButton(vm, nameof(vm.ImageAdjustColorValue));
         colorPicker[!Control.IsEnabledProperty] = new Binding(nameof(vm.ImageAdjustColorOn)) { Source = vm };
-        var colorPanel = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            VerticalAlignment = VerticalAlignment.Center,
-            Spacing = 5,
-            Children =
-            {
-                MakeCheckBox(Se.Language.Tools.ImageBasedEdit.AdjustColor, vm, nameof(vm.ImageAdjustColorOn)),
-                colorPicker,
-            }
-        };
 
         var grid = new Grid
         {
-            RowDefinitions =
-            {
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-            },
             ColumnDefinitions =
             {
                 new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnSpacing = 10,
-            RowSpacing = 10,
+            RowSpacing = 6,
             Width = double.NaN,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
+            HorizontalAlignment = HorizontalAlignment.Left,
         };
 
-        grid.Add(labelHeader, 0);
-        grid.Add(labelInfo, 1);
-        grid.Add(brightnessPanel, 2);
-        grid.Add(alphaPanel, 3);
-        grid.Add(colorPanel, 4);
+        var row = 0;
+        AddRow(grid, row++, labelHeader);
+        AddRow(grid, row++, labelInfo);
+
+        AddRow(grid, row++, MakeCheckBox(Se.Language.Tools.ImageBasedEdit.AdjustBrightness, vm, nameof(vm.ImageAdjustBrightnessOn)));
+        AddPair(grid, row++, Se.Language.Tools.ImageBasedEdit.Brightness, MakeNumericUpDown(vm, nameof(vm.ImageAdjustBrightness), nameof(vm.ImageAdjustBrightnessOn), -100, 100, 1));
+        AddPair(grid, row++, Se.Language.Tools.ImageBasedEdit.Contrast, MakeNumericUpDown(vm, nameof(vm.ImageAdjustContrast), nameof(vm.ImageAdjustBrightnessOn), -100, 100, 1));
+        AddPair(grid, row++, Se.Language.Tools.ImageBasedEdit.Gamma + " (%)", MakeNumericUpDown(vm, nameof(vm.ImageAdjustGamma), nameof(vm.ImageAdjustBrightnessOn), 20, 400, 5));
+
+        AddRow(grid, row++, MakeCheckBox(Se.Language.General.AdjustAlpha, vm, nameof(vm.ImageAdjustAlphaOn)));
+        AddPair(grid, row++, Se.Language.General.AlphaAdjustment, MakeNumericUpDown(vm, nameof(vm.ImageAdjustAlpha), nameof(vm.ImageAdjustAlphaOn), -255, 255, 5));
+        AddPair(grid, row++, Se.Language.General.AlphaThreshold, MakeNumericUpDown(vm, nameof(vm.ImageAdjustAlphaThreshold), nameof(vm.ImageAdjustAlphaOn), 0, 255, 5));
+
+        AddRow(grid, row++, MakeCheckBox(Se.Language.Tools.ImageBasedEdit.AdjustColor, vm, nameof(vm.ImageAdjustColorOn)));
+        grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) });
+        colorPicker.Margin = new Thickness(25, 0, 0, 0);
+        grid.Add(colorPicker, row, 0);
 
         return grid;
+    }
+
+    private static void AddRow(Grid grid, int row, Control control)
+    {
+        grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) });
+        grid.Add(control, row, 0, 1, 2);
+    }
+
+    private static void AddPair(Grid grid, int row, string labelText, Control control)
+    {
+        grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) });
+        var label = new Label
+        {
+            Content = labelText,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(25, 0, 0, 0),
+        };
+        grid.Add(label, row, 0);
+        grid.Add(control, row, 1);
     }
 
     private static CheckBox MakeCheckBox(string content, BatchConvertViewModel vm, string bindingProperty)
@@ -109,17 +92,7 @@ public static class ViewAdjustImageColors
         {
             Content = content,
             VerticalAlignment = VerticalAlignment.Center,
-            Margin = new Thickness(0, 0, 10, 0),
             [!ToggleButton.IsCheckedProperty] = new Binding(bindingProperty) { Source = vm, Mode = BindingMode.TwoWay },
-        };
-    }
-
-    private static Label MakeLabel(string content)
-    {
-        return new Label
-        {
-            Content = content,
-            VerticalAlignment = VerticalAlignment.Center,
         };
     }
 

--- a/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewBeautifyTimeCodes.cs
+++ b/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewBeautifyTimeCodes.cs
@@ -19,6 +19,30 @@ public static class ViewBeautifyTimeCodes
 
         var checkBoxSnapToShotChanges = UiUtil.MakeCheckBox(Se.Language.Tools.BeautifyTimeCodes.BatchSnapToShotChanges, vm, nameof(vm.BeautifyTimeCodesSnapToShotChanges));
 
+        var radioFrameRateFromVideo = UiUtil.MakeRadioButton(Se.Language.Tools.BeautifyTimeCodes.BatchFrameRateFromVideo, vm, nameof(vm.BeautifyTimeCodesUseVideoFrameRate), "BeautifyTimeCodesFrameRateSource");
+        var radioFrameRateFixed = UiUtil.MakeRadioButton(Se.Language.Tools.BeautifyTimeCodes.BatchFrameRateFixed, vm, nameof(vm.BeautifyTimeCodesUseFixedFrameRate), "BeautifyTimeCodesFrameRateSource");
+
+        var comboFrameRate = new ComboBox
+        {
+            ItemsSource = vm.BeautifyTimeCodesFrameRates,
+            SelectedValue = vm.SelectedBeautifyTimeCodesFrameRate,
+            VerticalAlignment = VerticalAlignment.Center,
+            MinWidth = 90,
+        }.WithBindSelected(nameof(vm.SelectedBeautifyTimeCodesFrameRate))
+         .WithBindEnabled(nameof(vm.BeautifyTimeCodesUseFixedFrameRate));
+
+        var panelFrameRateFixed = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            VerticalAlignment = VerticalAlignment.Center,
+            Spacing = 5,
+            Children =
+            {
+                radioFrameRateFixed,
+                comboFrameRate,
+            }
+        };
+
         var buttonEditProfile = UiUtil.MakeButton(vm.ShowBeautifyTimeCodesProfileCommand, IconNames.Settings, Se.Language.Tools.BeautifyTimeCodes.EditProfile);
 
         var labelInfo = new TextBlock
@@ -27,6 +51,8 @@ public static class ViewBeautifyTimeCodes
             Opacity = 0.7,
             FontStyle = FontStyle.Italic,
             TextWrapping = TextWrapping.Wrap,
+            MaxWidth = 500,
+            HorizontalAlignment = HorizontalAlignment.Left,
         };
 
         return new StackPanel
@@ -38,6 +64,8 @@ public static class ViewBeautifyTimeCodes
             {
                 labelHeader,
                 checkBoxSnapToShotChanges,
+                radioFrameRateFromVideo,
+                panelFrameRateFixed,
                 buttonEditProfile,
                 labelInfo,
             }

--- a/src/ui/Logic/Config/Language/Tools/LanguageBeautifyTimeCodes.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageBeautifyTimeCodes.cs
@@ -22,6 +22,8 @@ public class LanguageBeautifyTimeCodes
     public string NextChange { get; set; }
     public string EditProfile { get; set; }
     public string BatchSnapToShotChanges { get; set; }
+    public string BatchFrameRateFromVideo { get; set; }
+    public string BatchFrameRateFixed { get; set; }
     public string BatchInfo { get; set; }
 
     public LanguageBeautifyTimeCodes()
@@ -46,6 +48,8 @@ public class LanguageBeautifyTimeCodes
         NextChange = "Next change";
         EditProfile = "Edit profile...";
         BatchSnapToShotChanges = "Snap cues to shot changes (if available)";
-        BatchInfo = "Frame rate and shot changes are read from a video file with the same name as the subtitle file, if one is found.";
+        BatchFrameRateFromVideo = "Use frame rate from video file with same name as subtitle file";
+        BatchFrameRateFixed = "Use fixed frame rate";
+        BatchInfo = "Shot changes are read from a video file with the same name as the subtitle file, if one is found.";
     }
 }

--- a/src/ui/Logic/Config/SeBatchConvert.cs
+++ b/src/ui/Logic/Config/SeBatchConvert.cs
@@ -106,6 +106,8 @@ public class SeBatchConvert
     public bool SortByDescending { get; set; }
 
     public bool BeautifyTimeCodesSnapToShotChanges { get; set; }
+    public bool BeautifyTimeCodesUseFixedFrameRate { get; set; }
+    public double BeautifyTimeCodesFixedFrameRate { get; set; }
 
     public bool ImageAdjustBrightnessOn { get; set; }
     public double ImageAdjustBrightness { get; set; }
@@ -177,5 +179,6 @@ public class SeBatchConvert
         SortByDescending = false;
 
         BeautifyTimeCodesSnapToShotChanges = true;
+        BeautifyTimeCodesFixedFrameRate = 23.976;
     }
 }

--- a/tests/UI/Features/Tools/BatchConvert/BatchConverterBeautifyTimeCodesTests.cs
+++ b/tests/UI/Features/Tools/BatchConvert/BatchConverterBeautifyTimeCodesTests.cs
@@ -24,7 +24,7 @@ Second line.
 Third line.
 ";
 
-    private static async Task<Subtitle> RunConvertAsync(bool beautifyActive)
+    private static async Task<Subtitle> RunConvertAsync(bool beautifyActive, Action<BatchConvertConfig>? configure = null)
     {
         var dir = Directory.CreateTempSubdirectory("se-beautify-test");
         try
@@ -46,6 +46,7 @@ Third line.
                 TargetFormatName = SubRip.NameOfFormat,
             };
             config.BeautifyTimeCodes.IsActive = beautifyActive;
+            configure?.Invoke(config);
 
             var converter = new BatchConverter(null!, null!, null!);
             converter.Initialize(config);
@@ -85,6 +86,30 @@ Third line.
         {
             var gap = result.Paragraphs[i + 1].StartTime.TotalMilliseconds - result.Paragraphs[i].EndTime.TotalMilliseconds;
             Assert.True(gap >= minGapMs, $"gap between cue {i + 1} and {i + 2} is {gap} ms, expected at least {minGapMs} ms");
+        }
+    }
+
+    [Fact]
+    public async Task Convert_BeautifyTimeCodesFixedFrameRate_AlignsCuesToFixedFrameRate()
+    {
+        // 25 fps => frames are 40 ms apart, which no fallback rate (23.976/24/30/...)
+        // would produce, so alignment proves the fixed rate was used.
+        var result = await RunConvertAsync(beautifyActive: true, config =>
+        {
+            config.BeautifyTimeCodes.UseFixedFrameRate = true;
+            config.BeautifyTimeCodes.FixedFrameRate = 25;
+        });
+
+        Assert.Equal(3, result.Paragraphs.Count);
+
+        foreach (var p in result.Paragraphs)
+        {
+            foreach (var ms in new[] { p.StartTime.TotalMilliseconds, p.EndTime.TotalMilliseconds })
+            {
+                var frames = ms * 25.0 / 1000.0;
+                Assert.True(Math.Abs(frames - Math.Round(frames)) < 0.1,
+                    $"time code {ms} ms is not aligned to a 25 fps frame");
+            }
         }
     }
 


### PR DESCRIPTION
## Beautify time codes: explicit frame rate source

The batch convert "Beautify time codes" function now lets the user choose where the frame rate comes from:

- **Use frame rate from video file with same name as subtitle file** — default, the previous behavior (falls back to the change-frame-rate target / project frame rate when no video is found)
- **Use fixed frame rate** — a frame rate picked from a combo box (23.976 … 120)

With a fixed rate selected, a matching video file is still used for shot changes when "Snap cues to shot changes" is enabled — it just no longer overrides the frame rate. Both the choice and the rate persist in settings, and the info text now only mentions shot changes since frame rate sourcing is explicit in the UI.

## Adjust image brightness/alpha/color: compact layout

The function view packed each section (checkbox + up to three label/numeric pairs) into a single horizontal row, and the italic info text could not wrap inside the auto-sized grid, which made the panel very wide. The view is now a two-column layout: each section checkbox on its own row with indented label/numeric rows beneath it, and the info text capped at 500 px so it wraps (same cap applied to the beautify info text).

## Testing

- New test: beautify with a fixed 25 fps aligns cues to 40 ms frames — a rate no fallback path would produce, so it proves the fixed rate is used
- Existing beautify batch tests and the language JSON tests pass (36 total)
- UI project builds with 0 warnings/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)