### PR TITLE
Fix #13111/#13182/#13187 beta-5 follow-ups: menu-bar focus drops, Esc highlight, F10 underlines, submenu z-order

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -360,6 +360,7 @@ public partial class MainViewModel :
 
     VideoPlayerUndockedViewModel? _videoPlayerUndockedViewModel;
     AudioVisualizerUndockedViewModel? _audioVisualizerUndockedViewModel;
+    bool _suppressUndockedTopmost;
     FindViewModel? _findViewModel;
     Control? _findPreviousFocus;
     Control? _focusBeforeMainMenu;
@@ -2040,6 +2041,26 @@ public partial class MainViewModel :
         _formatChangedByUser = false;
         _undoRedoManager.Reset();
         _shortcutManager.ClearKeys();
+
+        // Clearing the rows also removed the focused row container, dropping keyboard focus to
+        // nothing at all - the next arrow key then walks focus from the window root into the first
+        // focusable control, which is the menu bar. After Ctrl+N the bar looked like it "activated
+        // itself" and kept eating keys (#13111). The grid stays focusable while empty exactly for
+        // this (see InitListViewAndEditBox), so put focus back on it. Deferred because the container
+        // only detaches once the collection change has been processed; guarded so a reset that runs
+        // while a dialog or any other control legitimately holds focus does not steal it. The second,
+        // Background-priority pass runs after the layout pass, catching a container that detached
+        // (and dropped focus) later than the first check.
+        void RestoreFocusIfDropped()
+        {
+            if (SubtitleGrid != null && Window?.FocusManager?.GetFocusedElement() == null)
+            {
+                TableViewExtras.FocusRow(SubtitleGrid);
+            }
+        }
+
+        Dispatcher.UIThread.Post(RestoreFocusIfDropped);
+        Dispatcher.UIThread.Post(RestoreFocusIfDropped, DispatcherPriority.Background);
     }
 
     [RelayCommand]
@@ -6253,7 +6274,7 @@ public partial class MainViewModel :
                 // SE loses focus to another app. Mirrors the Find/Replace helper from #11243.
                 // The two undocked windows are still independent in Alt+Tab — KeepTopmost… is
                 // just a Z-order knob, not an ownership change.
-                WindowService.KeepTopmostWhileOwnerActive(window, Window!);
+                WindowService.KeepTopmostWhileOwnerActive(window, Window!, () => _suppressUndockedTopmost);
             });
 
             _windowService.ShowIndependentWindow<AudioVisualizerUndockedWindow, AudioVisualizerUndockedViewModel>((window, vm) =>
@@ -6261,7 +6282,7 @@ public partial class MainViewModel :
                 _audioVisualizerUndockedViewModel = vm;
                 vm.Initialize(AudioVisualizer, this);
                 ReloadAudioVisualizer();
-                WindowService.KeepTopmostWhileOwnerActive(window, Window!);
+                WindowService.KeepTopmostWhileOwnerActive(window, Window!, () => _suppressUndockedTopmost);
             });
 
             InitLayout.MakeLayout12KeepVideo(MainView!, this);
@@ -6283,6 +6304,12 @@ public partial class MainViewModel :
     /// </summary>
     internal void SetUndockedWindowsTopmost(bool topmost)
     {
+        // Remembered (and consulted by the KeepTopmostWhileOwnerActive registrations) so the
+        // helper's activation handler cannot re-assert Topmost while a menu is still open:
+        // opening a cascaded submenu churns window activation, and the re-asserted Topmost put
+        // the tool windows back over the submenu popup (#13187 follow-up).
+        _suppressUndockedTopmost = !topmost;
+
         foreach (var undockedWindow in new[] { _videoPlayerUndockedViewModel?.Window, _audioVisualizerUndockedViewModel?.Window })
         {
             if (undockedWindow != null)
@@ -16044,6 +16071,16 @@ public partial class MainViewModel :
             return;
         }
 
+        // Same guard as SelectAndScrollToRow: a long scroll recycles the focused TableViewRow
+        // container, silently dropping keyboard focus out of the grid. This is the video-playhead
+        // sync path, so it fires on every seek step - once the focused row was recycled, the
+        // still-held seek key walked focus from the window root into the menu bar, which read as
+        // "the menu bar activates itself while skipping through the video" (#13182). Null focus is
+        // reclaimed too: a previous sync step may already have dropped it, and with nothing focused
+        // the very next key press walks into the menu. Focus anywhere else - the text box, the
+        // video player (docked or undocked), a dialog - is never touched.
+        var refocusGrid = IsSubtitleGridFocused() || Window?.FocusManager?.GetFocusedElement() == null;
+
         lock (_scrollLock)
         {
             _pendingScrollSubtitle = subtitle;
@@ -16074,6 +16111,11 @@ public partial class MainViewModel :
                     // Same follow-up as SelectAndScrollToRow: ScrollIntoView can leave the row
                     // a few pixels past the bottom edge on a variable-height grid.
                     EnsureRowFullyVisibleInSubtitleGrid(subtitleToScroll);
+                }
+
+                if (refocusGrid && (IsSubtitleGridFocused() || Window?.FocusManager?.GetFocusedElement() == null))
+                {
+                    Dispatcher.UIThread.Post(() => TableViewExtras.FocusRow(SubtitleGrid));
                 }
             }
         }, DispatcherPriority.Background);
@@ -21198,26 +21240,6 @@ public partial class MainViewModel :
     };
 
     /// <summary>
-    /// Moves keyboard focus to the first top-level item of the main menu bar, so the menu can be
-    /// opened and navigated with the keyboard / a screen reader (F10, #11745). No-op on platforms
-    /// that use the native menu (macOS), where <see cref="Menu"/> has no items.
-    /// </summary>
-    private bool TryFocusMainMenu()
-    {
-        if (Menu == null || Menu.Items.Count == 0)
-        {
-            return false;
-        }
-
-        if (Menu.Items[0] is MenuItem firstItem)
-        {
-            return firstItem.Focus(NavigationMethod.Tab);
-        }
-
-        return false;
-    }
-
-    /// <summary>
     /// Activates the main menu bar for keyboard navigation (Windows standard F10; bare Alt is handled
     /// by Avalonia's built-in AccessKeyHandler), remembering the control that had focus so it can be
     /// restored on deactivation. Returns false on platforms with a native menu (macOS), where the
@@ -21243,6 +21265,13 @@ public partial class MainViewModel :
             if (Menu is { IsOpen: false })
             {
                 Menu.Open();
+
+                // Alt activation also underlines the access keys (Avalonia's AccessKeyHandler sets
+                // this inherited property on the window); Menu.Open alone does not, which made F10
+                // open a menu whose access keys work but are invisible (#13111 beta-4 feedback).
+                // F10 and Alt are synonyms on Windows, so show the underlines here too - the
+                // built-in handler clears the property again on every close path (MainMenuClosed).
+                Window?.SetValue(AccessText.ShowAccessKeyProperty, true);
             }
         });
         return true;
@@ -21256,6 +21285,15 @@ public partial class MainViewModel :
     private void DeactivateMainMenu()
     {
         Menu?.Close();
+
+        // Menu.Close() early-returns when the bar is already closed - but a top-level item can
+        // still be selected in that state (an Escape that closed the drop-down leaves the item
+        // highlighted so the bar stays visibly active), and skipping the reset left that
+        // highlight behind after deactivation (#13111 beta-4 feedback).
+        if (Menu != null)
+        {
+            Menu.SelectedIndex = -1;
+        }
 
         var restore = _focusBeforeMainMenu;
         _focusBeforeMainMenu = null;
@@ -21777,10 +21815,17 @@ public partial class MainViewModel :
             // bar (#11745 beta-2 feedback).
             if (k == Key.Escape && keyEventArgs.KeyModifiers == KeyModifiers.None && (IsMainMenuFocused() || Menu.IsOpen))
             {
-                if (Menu.Items.OfType<MenuItem>().Any(mi => mi.IsSubMenuOpen))
+                if (Menu.Items.OfType<MenuItem>().FirstOrDefault(mi => mi.IsSubMenuOpen) is { } openItem)
                 {
-                    Menu.Close();
-                    TryFocusMainMenu(); // keep the bar focused so the next Escape deactivates it
+                    // Close only the drop-down and keep the bar active with the same item
+                    // highlighted and focused, so the next Escape deactivates it (Windows
+                    // standard). Closing the whole bar and refocusing the first item made the
+                    // highlight jump to "File" no matter which menu was open, and left
+                    // Menu.IsOpen false so the final deactivation skipped its selection reset
+                    // (#13111 beta-4 feedback).
+                    openItem.Close();
+                    Menu.SelectedItem = openItem;
+                    openItem.Focus(NavigationMethod.Tab);
                 }
                 else
                 {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1,5 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
@@ -2591,6 +2592,12 @@ public partial class BinaryEditViewModel : ObservableObject
             if (Menu is { IsOpen: false })
             {
                 Menu.Open();
+
+                // Alt activation also underlines the access keys (Avalonia's AccessKeyHandler sets
+                // this inherited property on the window); Menu.Open alone does not, which made F10
+                // open a menu whose access keys work but are invisible (#13111 beta-4 feedback).
+                // The built-in handler clears the property again on every close path.
+                Window?.SetValue(AccessText.ShowAccessKeyProperty, true);
             }
         });
         return true;
@@ -2604,6 +2611,14 @@ public partial class BinaryEditViewModel : ObservableObject
     private void DeactivateMenu()
     {
         Menu?.Close();
+
+        // Menu.Close() early-returns when the bar is already closed - but a top-level item can
+        // still be selected in that state, and skipping the reset would leave its highlight
+        // behind after deactivation (#13111 beta-4 feedback).
+        if (Menu != null)
+        {
+            Menu.SelectedIndex = -1;
+        }
 
         var restore = _focusBeforeMenu;
         _focusBeforeMenu = null;

--- a/src/ui/Logic/WindowsService.cs
+++ b/src/ui/Logic/WindowsService.cs
@@ -228,8 +228,14 @@ namespace Nikse.SubtitleEdit.Logic
         /// non-modal tool windows (Find, Replace, etc.) so they don't float above other
         /// applications on macOS, where Avalonia maps Topmost to NSWindowLevel.Floating
         /// process-wide.
+        /// <paramref name="suppress"/> (optional) is consulted on every re-assertion: while it
+        /// returns true the child stays non-topmost no matter what the activation state says. The
+        /// main menu uses this for the undocked tool windows - dropping their Topmost once when
+        /// the menu opened was not enough, because opening a cascaded submenu churns window
+        /// activation and the handler below re-asserted Topmost right over the submenu popup
+        /// (#13187 follow-up).
         /// </summary>
-        public static void KeepTopmostWhileOwnerActive(Window child, Window owner)
+        public static void KeepTopmostWhileOwnerActive(Window child, Window owner, Func<bool>? suppress = null)
         {
             void OnFocusChanged(object? sender, EventArgs e)
             {
@@ -242,7 +248,7 @@ namespace Nikse.SubtitleEdit.Logic
                         return;
                     }
 
-                    child.Topmost = owner.IsActive || child.IsActive;
+                    child.Topmost = suppress?.Invoke() != true && (owner.IsActive || child.IsActive);
                 });
             }
 
@@ -258,7 +264,7 @@ namespace Nikse.SubtitleEdit.Logic
                 child.Deactivated -= OnFocusChanged;
             };
 
-            child.Topmost = owner.IsActive || child.IsActive;
+            child.Topmost = suppress?.Invoke() != true && (owner.IsActive || child.IsActive);
         }
 
         /// <summary>

--- a/tests/UI/Features/Main/FileNewMenuFocusTests.cs
+++ b/tests/UI/Features/Main/FileNewMenuFocusTests.cs
@@ -1,0 +1,137 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using System.Reflection;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// File > New (Ctrl+N) clears the subtitle grid, and clearing the rows removes the focused row
+/// container with them - keyboard focus dropped to nothing at all. The next arrow key then walked
+/// focus from the window root into the first focusable control, the menu bar, which read as "the
+/// menu bar activated itself after Ctrl+N" and took two Alt presses to leave (#13111 beta-4/5
+/// feedback). ResetSubtitle now puts focus back on the (empty-but-focusable) grid.
+/// </summary>
+public class FileNewMenuFocusTests : IDisposable
+{
+    // Close every window in Dispose so a failed test cannot leave one racing the headless
+    // session teardown (same pattern as MainMenuKeyboardActivationTests).
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private (Window Window, MainViewModel Vm) ShowMainWindowWithLines(int lineCount = 3)
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        vm.Menu.IsVisible = true;
+
+        for (var i = 0; i < lineCount; i++)
+        {
+            vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph($"Line {i + 1}", i * 2000, i * 2000 + 1500), null!)
+            {
+                Number = i + 1,
+            });
+        }
+
+        Settle(window);
+        return (window, vm);
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 5; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+
+    /// <summary>
+    /// Marks the current content as saved so File > New skips the "save changes?" prompt -
+    /// a modal would block the headless run.
+    /// </summary>
+    private static void MarkUnchanged(MainViewModel vm)
+    {
+        typeof(MainViewModel).GetField("_changeSubtitleHash", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(vm, vm.GetFastHash());
+    }
+
+    /// <summary>
+    /// Polls for a state the focus machinery is expected to reach: even with Settle, focus
+    /// changes can be a few dispatcher frames behind on a loaded runner (same pattern as
+    /// MainMenuKeyboardActivationTests.WaitUntil).
+    /// </summary>
+    private static async Task WaitUntil(Func<bool> condition, string failureMessage, int timeoutMs = 500)
+    {
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        while (!condition())
+        {
+            if (stopwatch.ElapsedMilliseconds > timeoutMs)
+            {
+                Assert.Fail(failureMessage);
+            }
+
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(10);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task FileNew_KeepsFocusOutOfTheMenuBar()
+    {
+        var (window, vm) = ShowMainWindowWithLines();
+
+        TableViewExtras.FocusRow(vm.SubtitleGrid);
+        Settle(window);
+        await WaitUntil(() => vm.SubtitleGrid.IsKeyboardFocusWithin,
+            "the grid should hold keyboard focus before File > New");
+
+        MarkUnchanged(vm);
+        vm.CommandFileNewCommand.Execute(null);
+        Settle(window);
+
+        // Focus must not be dropped: with nothing focused, the next arrow key walks focus
+        // into the menu bar. (Generous timeout: the restore runs in a Background-priority
+        // dispatcher pass after layout, which can lag on a loaded runner.)
+        await WaitUntil(() => ReferenceEquals(vm.SubtitleGrid, window.FocusManager?.GetFocusedElement()),
+            "File > New should leave keyboard focus on the (now empty) grid", timeoutMs: 2000);
+
+        window.KeyPressQwerty(PhysicalKey.ArrowDown, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+        window.KeyReleaseQwerty(PhysicalKey.ArrowDown, RawInputModifiers.None);
+        Settle(window);
+
+        Assert.False(window.FocusManager?.GetFocusedElement() is MenuItem);
+        Assert.False(vm.Menu.IsOpen);
+
+        window.Close();
+    }
+}

--- a/tests/UI/Features/Main/MainMenuKeyboardActivationTests.cs
+++ b/tests/UI/Features/Main/MainMenuKeyboardActivationTests.cs
@@ -1,5 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
@@ -278,6 +279,70 @@ public class MainMenuKeyboardActivationTests : IDisposable
         await WaitUntil(() => ReferenceEquals(vm.SubtitleGrid, window.FocusManager?.GetFocusedElement()), "focus should return to the grid");
 
         popupStandIn.Close();
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public async Task F10_ShowsAccessKeyUnderlines_LikeAlt()
+    {
+        var (window, vm) = ShowMainWindowWithEmptyGrid();
+        TableViewExtras.FocusRow(vm.SubtitleGrid);
+        Settle(window);
+        await WaitForGridFocus(window, vm);
+
+        PressAndRelease(window, PhysicalKey.F10, RawInputModifiers.None);
+        await WaitUntil(() => vm.Menu.IsOpen, "F10 should open the menu bar");
+
+        // Alt activation shows the access-key underlines via this inherited window property;
+        // F10 is its synonym and must do the same - the underlines still *worked* after F10,
+        // they were just invisible (#13111 beta-4/5 feedback).
+        await WaitUntil(() => window.GetValue(AccessText.ShowAccessKeyProperty), "F10 should show the access-key underlines");
+
+        PressAndRelease(window, PhysicalKey.F10, RawInputModifiers.None);
+
+        await WaitUntil(() => !vm.Menu.IsOpen, "the second F10 should close the menu bar");
+        await WaitUntil(() => !window.GetValue(AccessText.ShowAccessKeyProperty), "closing should clear the access-key underlines");
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public async Task Escape_ClosesDropDownKeepingItemHighlighted_ThenDeactivates()
+    {
+        var (window, vm) = ShowMainWindowWithEmptyGrid();
+        TableViewExtras.FocusRow(vm.SubtitleGrid);
+        Settle(window);
+        await WaitForGridFocus(window, vm);
+
+        // Open the bar and move to the second top-level item, then drop its menu down - the
+        // regression showed on any non-first menu: the first Escape yanked the highlight back
+        // to "File" (#13111 beta-4 feedback).
+        PressAndRelease(window, PhysicalKey.F10, RawInputModifiers.None);
+        await WaitUntil(() => vm.Menu.IsOpen, "F10 should open the menu bar");
+        PressAndRelease(window, PhysicalKey.ArrowRight, RawInputModifiers.None);
+        PressAndRelease(window, PhysicalKey.ArrowDown, RawInputModifiers.None);
+        await WaitUntil(() => vm.Menu.Items.OfType<MenuItem>().Any(mi => mi.IsSubMenuOpen), "Down should open the second item's drop-down");
+
+        var openItem = vm.Menu.Items.OfType<MenuItem>().First(mi => mi.IsSubMenuOpen);
+        Assert.NotSame(vm.Menu.Items[0], openItem);
+
+        // First Escape: only the drop-down closes; the bar stays active with the same item
+        // highlighted (Windows standard).
+        PressAndRelease(window, PhysicalKey.Escape, RawInputModifiers.None);
+
+        await WaitUntil(() => !openItem.IsSubMenuOpen, "Escape should close the drop-down");
+        Assert.True(vm.Menu.IsOpen, "the bar must stay active after the first Escape");
+        Assert.Same(openItem, vm.Menu.SelectedItem);
+
+        // Second Escape: the bar deactivates completely - no leftover highlight, focus back in
+        // the editing area.
+        PressAndRelease(window, PhysicalKey.Escape, RawInputModifiers.None);
+
+        await WaitUntil(() => !vm.Menu.IsOpen, "the second Escape should close the menu bar");
+        await WaitUntil(() => vm.Menu.SelectedIndex == -1, "deactivation should clear the top-level highlight");
+        await WaitUntil(() => !IsFocusOnMenuItem(window), "the menu item should lose focus");
+        await WaitUntil(() => ReferenceEquals(vm.SubtitleGrid, window.FocusManager?.GetFocusedElement()), "focus should return to the grid");
+
         window.Close();
     }
 

--- a/tests/UI/Features/Main/PlayheadSyncFocusTests.cs
+++ b/tests/UI/Features/Main/PlayheadSyncFocusTests.cs
@@ -1,0 +1,126 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// The video-playhead sync (SelectAndScrollToSubtitle) scrolls the grid as the user seeks through
+/// the video. A long scroll recycles the focused TableViewRow container, silently dropping
+/// keyboard focus out of the grid - and with nothing focused, the still-held seek key walked focus
+/// from the window root into the menu bar, which read as "the menu bar activates itself roughly
+/// every 10 captions while skipping through the video" (#13182). The sync path now puts focus back
+/// on the newly selected row, but only when the grid had focus (or focus was already dropped) - it
+/// must never steal focus from the text box or the docked/undocked video player.
+/// </summary>
+public class PlayheadSyncFocusTests : IDisposable
+{
+    // Close every window in Dispose so a failed test cannot leave one racing the headless
+    // session teardown (same pattern as MainMenuKeyboardActivationTests).
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private (Window Window, MainViewModel Vm) ShowMainWindowWithLines(int lineCount)
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        vm.Menu.IsVisible = true;
+
+        for (var i = 0; i < lineCount; i++)
+        {
+            vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph($"Line {i + 1}", i * 2000, i * 2000 + 1500), null!)
+            {
+                Number = i + 1,
+            });
+        }
+
+        Settle(window);
+        return (window, vm);
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 8; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+
+    /// <summary>
+    /// Polls for a state the focus machinery is expected to reach: even with Settle, focus
+    /// changes can be a few dispatcher frames behind on a loaded runner (same pattern as
+    /// MainMenuKeyboardActivationTests.WaitUntil).
+    /// </summary>
+    private static async Task WaitUntil(Func<bool> condition, string failureMessage, int timeoutMs = 500)
+    {
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        while (!condition())
+        {
+            if (stopwatch.ElapsedMilliseconds > timeoutMs)
+            {
+                Assert.Fail(failureMessage);
+            }
+
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(10);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task LongPlayheadScroll_KeepsKeyboardFocusInTheGrid()
+    {
+        var (window, vm) = ShowMainWindowWithLines(300);
+
+        TableViewExtras.FocusRow(vm.SubtitleGrid);
+        Settle(window);
+        await WaitUntil(() => vm.SubtitleGrid.IsKeyboardFocusWithin,
+            "the grid should hold keyboard focus before the scroll");
+
+        // Jump far enough that the focused row container is recycled out of the realized range -
+        // the same thing a 5-second seek does every few captions.
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[250]);
+        Settle(window);
+
+        await WaitUntil(
+            () => window.FocusManager?.GetFocusedElement() != null &&
+                  (vm.SubtitleGrid.IsKeyboardFocusWithin ||
+                   ReferenceEquals(window.FocusManager?.GetFocusedElement(), vm.SubtitleGrid)),
+            "keyboard focus should stay in the grid after a long playhead scroll");
+
+        window.Close();
+    }
+
+    // Note: a companion "does not steal focus from the text box" test is deliberately absent.
+    // The refocus guard in SelectAndScrollToSubtitle is inert while the text box holds focus
+    // (verified by instrumentation), but the headless session has a pre-existing quirk where a
+    // playhead scroll moves focus onto a grid row anyway once an earlier test's window existed
+    // in the same session - asserting on it would only flake CI on behavior this change does
+    // not touch.
+}


### PR DESCRIPTION
Fixes the remaining beta-5 items from GrampaWildWilly's reports in #13111, #13182 and #13187.

### Menu bar "activates itself" after Ctrl+N (#13111, latest comment)
`ResetSubtitle` clears the grid rows, and the focused row container is removed with them - keyboard focus dropped to nothing at all. The next arrow key then walked focus from the window root into the first focusable control, the menu bar. That read as "the menu bar activated itself after Ctrl+N" and took multiple Alt presses to leave. `ResetSubtitle` now restores focus to the (empty-but-focusable, see #13111/PR #13112) grid when the clear left focus dropped - guarded so a reset under a dialog or with focus elsewhere steals nothing. A second Background-priority pass catches containers that detach after the first check.

### Menu bar activates ~every 10 captions while seeking (#13182)
The video-playhead sync path (`SelectAndScrollToSubtitle`) recycles the focused row container on long scrolls - same focus drop, so a held seek key (e.g. RightArrow bound to "skip 5 seconds") periodically walked into the menu bar. The "random ~10 caption interval" is just how long a focused container survives in the realized range. The sync now restores grid focus the same way `SelectAndScrollToRow` already did, and also reclaims focus when it was already dropped by an earlier sync step. It never touches focus held by the text box, a dialog, or the docked/undocked video player (the guard requires focus inside the grid or no focus at all; `FocusManager.GetFocusedElement` is app-global, so focus in the undocked windows is never null).

### Esc behavior on the menu bar (#13111 beta-4 nits)
Escape on an open drop-down now closes only the drop-down and keeps the bar active with the *same* top-level item highlighted and focused (Windows standard) - previously the whole bar was closed and the first item re-focused, which yanked the highlight to "File". The second Escape's deactivation also clears the selection explicitly: `Menu.Close()` early-returns when the bar is already closed, which is what used to leave the highlight behind.

### F10 shows no access-key underlines (#13111 beta-4 nits)
F10 activation now sets the same inherited `ShowAccessKey` property Avalonia's AccessKeyHandler sets on bare Alt, so F10 and Alt are visually identical; the built-in handler clears it on every close path. Ported to the BinaryEdit window too.

### Cascaded submenus behind the undocked audio visualizer (#13187 follow-up)
PR #13193 drops the undocked tool windows' topmost while a menu is open, but `KeepTopmostWhileOwnerActive` re-asserts `Topmost` on every window activation event - and opening a cascaded submenu churns activation, putting the tool windows back over the submenu popup (the screenshot in #13187). The menu's suppression is now consulted on every re-assertion, so it holds for as long as the menu is open, docked or undocked.

### Tests
New headless regression tests: Ctrl+N keeps focus out of the menu bar (fails without the fix), long playhead scroll keeps focus in the grid (fails without the fix), Esc closes drop-down keeping the item highlighted then deactivates cleanly, F10 shows/clears underlines. Written in the flake-hardened style from 804ef9a4a (WaitUntil polling, windows closed in Dispose). Full `UITests.Features.Main` suite run repeatedly: only the known pre-existing infra flakes (e.g. `BareAlt_ClosesTheMenu_WhileFocusIsInsideAnOpenDropDown`, thread-affinity cleanup failures) appear, and those reproduce on clean main as well.

One pre-existing quirk was found but deliberately not addressed here: a playhead scroll can move focus from the edit text box onto a grid row when another main window existed earlier in the process (instrumentation confirms none of the SE refocus paths fire) - left out to keep this change surgical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)