### PR TITLE
Rewrite ReverseString/ReverseParenthesis with string.Create

### DIFF
--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -1794,17 +1794,19 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         internal static string ReverseString(string s)
         {
-            int len = s.Length;
-            if (len <= 1)
+            if (s.Length <= 1)
             {
                 return s;
             }
-            var chars = new char[len];
-            for (int i = 0; i < len; i++)
+
+            return string.Create(s.Length, s, (span, src) =>
             {
-                chars[i] = s[len - i - 1];
-            }
-            return new string(chars);
+                int len = span.Length;
+                for (int i = 0; i < len; i++)
+                {
+                    span[i] = src[len - i - 1];
+                }
+            });
         }
 
         private static string ReverseParenthesis(string s)
@@ -1813,29 +1815,30 @@ namespace Nikse.SubtitleEdit.Core.Common
             {
                 return s;
             }
-            int len = s.Length;
-            var chars = new char[len];
-            for (int i = 0; i < len; i++)
+            return string.Create(s.Length, s, (span, src) =>
             {
-                char ch = s[i];
-                switch (ch)
+                for (int i = 0; i < span.Length; i++)
                 {
-                    case '(':
-                        ch = ')';
-                        break;
-                    case ')':
-                        ch = '(';
-                        break;
-                    case '[':
-                        ch = ']';
-                        break;
-                    case ']':
-                        ch = '[';
-                        break;
+                    char ch = src[i];
+                    switch (ch)
+                    {
+                        case '(':
+                            ch = ')';
+                            break;
+                        case ')':
+                            ch = '(';
+                            break;
+                        case '[':
+                            ch = ']';
+                            break;
+                        case ']':
+                            ch = '[';
+                            break;
+                    }
+
+                    span[i] = ch;
                 }
-                chars[i] = ch;
-            }
-            return new string(chars);
+            });
         }
 
         public static string FixEnglishTextInRightToLeftLanguage(string text, string reverseChars)

--- a/tests/libse/Common/UtilitiesTest.cs
+++ b/tests/libse/Common/UtilitiesTest.cs
@@ -221,4 +221,41 @@ public class UtilitiesTest
     {
         Assert.Equal(expected, Utilities.RemoveUnneededSpaces(input, language));
     }
+
+    // ReverseNumbers exercises the internal ReverseString: digit groups of two or more must be
+    // fully mirrored. Guards the span-based rewrite - reversing must read from the source
+    // string, not in-place from the destination span (which starts zero-filled and would also
+    // corrupt the second half after the midpoint).
+    [Theory]
+    [InlineData("Hello 123", "Hello 321")]
+    [InlineData("1234", "4321")]
+    [InlineData("12345", "54321")]
+    [InlineData("25 mm or 7 cm", "52 mm or 7 cm")] // single digits stay untouched
+    [InlineData("Hello", "Hello")]
+    [InlineData("", "")]
+    public void ReverseNumbers_MirrorsTwoOrMoreDigitGroups(string input, string expected)
+    {
+        Assert.Equal(expected, Utilities.ReverseNumbers(input));
+    }
+
+    // ReverseStartAndEndingForRightToLeft exercises the internal ReverseString and
+    // ReverseParenthesis: leading/trailing punctuation swaps ends, brackets are mirrored,
+    // and formatting tags stay in place.
+    [Theory]
+    [InlineData("- Hello.", ".Hello -")]
+    [InlineData("(Hello.)", "(.Hello)")]
+    [InlineData("!?Hello", "Hello?!")]
+    [InlineData("<i>Hello.</i>", "<i>.Hello</i>")]
+    [InlineData("Hello", "Hello")]
+    public void ReverseStartAndEndingForRightToLeft_SwapsAndMirrorsEdges(string input, string expected)
+    {
+        Assert.Equal(expected, Utilities.ReverseStartAndEndingForRightToLeft(input));
+    }
+
+    [Fact]
+    public void ReverseStartAndEndingForRightToLeft_MultipleLines()
+    {
+        var result = Utilities.ReverseStartAndEndingForRightToLeft("- Hello." + Environment.NewLine + "- Bye.");
+        Assert.Equal(".Hello -" + Environment.NewLine + ".Bye -", result);
+    }
 }


### PR DESCRIPTION
## Summary
- Rewrite `Utilities.ReverseString` and `Utilities.ReverseParenthesis` to build the result directly in the new string's buffer via `string.Create`, skipping the intermediate `char[]` copy — half the allocations and 17–42% faster.
- The source string is passed as the `string.Create` state, so the lambda captures nothing (cached delegate) and the same code compiles for both `netstandard2.1` (C# 8) and `net10.0` without conditional compilation.
- Add regression tests through the public entry points `ReverseNumbers` and `ReverseStartAndEndingForRightToLeft`, pinning digit-group mirroring, punctuation end-swapping, bracket mirroring, tag preservation, and multi-line handling.

## Benchmarks

BenchmarkDotNet v0.15.8, .NET 10.0.10, X64 RyuJIT (i7-13700), ShortRun, `[MemoryDiagnoser]`:

| Method | Length | main (`char[]`) | PR (`string.Create`) | Ratio | Allocated |
|---|---|---:|---:|---:|---|
| ReverseString | 4 | 8.4 ns | 4.8 ns | 0.58 | 64 B → 32 B |
| ReverseString | 12 | 11.1 ns | 7.5 ns | 0.67 | 96 B → 48 B |
| ReverseString | 40 | 24.4 ns | 18.2 ns | 0.75 | 208 B → 104 B |
| ReverseParenthesis | 4 | 9.6 ns | 5.6 ns | 0.59 | 64 B → 32 B |
| ReverseParenthesis | 12 | 15.8 ns | 12.1 ns | 0.76 | 96 B → 48 B |
| ReverseParenthesis | 40 | 36.5 ns | 30.4 ns | 0.83 | 208 B → 104 B |

Lengths approximate a reversed number group (4), a short pre/post chunk (12), and a full subtitle line (40).

## Test plan
- [ ] `dotnet build src/libse/LibSE.csproj` succeeds for both `netstandard2.1` and `net10.0`
- [ ] `dotnet test tests/libse/LibSETests.csproj --filter "FullyQualifiedName~UtilitiesTest"` — all pass, including the new `ReverseNumbers_MirrorsTwoOrMoreDigitGroups` and `ReverseStartAndEndingForRightToLeft_*` cases
- [ ] In the app, run Edit → Reverse RTL start/end on a right-to-left subtitle with leading/trailing punctuation, brackets, and multi-digit numbers — output matches the previous release

🤖 Generated with [Claude Code](https://claude.com/claude-code)