### PR TITLE
Use string.Create for three allocate-then-copy string builds

### DIFF
--- a/src/libse/Common/FixCasing.cs
+++ b/src/libse/Common/FixCasing.cs
@@ -312,40 +312,34 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return text;
             }
 
-            var sb = new StringBuilder(text.Length);
-            var insideAngle = false;
-            var insideCurly = false;
-
-            foreach (char c in text)
+            return string.Create(text.Length, text, (span, src) =>
             {
-                if (c == '<')
-                {
-                    insideAngle = true;
-                }
-                else if (c == '>')
-                {
-                    insideAngle = false;
-                }
-                else if (c == '{')
-                {
-                    insideCurly = true;
-                }
-                else if (c == '}')
-                {
-                    insideCurly = false;
-                }
+                var insideAngle = false;
+                var insideCurly = false;
 
-                if (insideAngle || insideCurly)
+                for (var i = 0; i < span.Length; i++)
                 {
-                    sb.Append(c);
-                }
-                else
-                {
-                    sb.Append(char.ToUpper(c));
-                }
-            }
+                    var c = src[i];
+                    if (c == '<')
+                    {
+                        insideAngle = true;
+                    }
+                    else if (c == '>')
+                    {
+                        insideAngle = false;
+                    }
+                    else if (c == '{')
+                    {
+                        insideCurly = true;
+                    }
+                    else if (c == '}')
+                    {
+                        insideCurly = false;
+                    }
 
-            return sb.ToString();
+                    span[i] = insideAngle || insideCurly ? c : char.ToUpper(c);
+                }
+            });
         }
 
         private string MakeLowerCaseExceptTags(string text)
@@ -355,40 +349,34 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return text;
             }
 
-            var sb = new StringBuilder(text.Length);
-            var insideAngle = false;
-            var insideCurly = false;
-
-            foreach (char c in text)
+            return string.Create(text.Length, text, (span, src) =>
             {
-                if (c == '<')
-                {
-                    insideAngle = true;
-                }
-                else if (c == '>')
-                {
-                    insideAngle = false;
-                }
-                else if (c == '{')
-                {
-                    insideCurly = true;
-                }
-                else if (c == '}')
-                {
-                    insideCurly = false;
-                }
+                var insideAngle = false;
+                var insideCurly = false;
 
-                if (insideAngle || insideCurly)
+                for (var i = 0; i < span.Length; i++)
                 {
-                    sb.Append(c);
-                }
-                else
-                {
-                    sb.Append(char.ToLower(c));
-                }
-            }
+                    var c = src[i];
+                    if (c == '<')
+                    {
+                        insideAngle = true;
+                    }
+                    else if (c == '>')
+                    {
+                        insideAngle = false;
+                    }
+                    else if (c == '{')
+                    {
+                        insideCurly = true;
+                    }
+                    else if (c == '}')
+                    {
+                        insideCurly = false;
+                    }
 
-            return sb.ToString();
+                    span[i] = insideAngle || insideCurly ? c : char.ToLower(c);
+                }
+            });
         }
     }
 }

--- a/src/libse/ContainerFormats/TransportStream/Helper.cs
+++ b/src/libse/ContainerFormats/TransportStream/Helper.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Text;
 
 namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
 {
@@ -72,25 +71,25 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
                 return string.Empty;
             }
 
-            // Pre-calculate total length: 8 bits per byte
-            var sb = new StringBuilder(count * 8);
-            var span = buffer.AsSpan(index, count);
-            
-            for (var i = 0; i < count; i++)
+            // 8 bits per byte, written directly into the result string's buffer
+            return string.Create(count * 8, (buffer, index, count), (span, state) =>
             {
-                var b = span[i];
-                // Manual bit extraction is faster than Convert.ToString for single bytes
-                sb.Append((b & 0b10000000) != 0 ? '1' : '0');
-                sb.Append((b & 0b01000000) != 0 ? '1' : '0');
-                sb.Append((b & 0b00100000) != 0 ? '1' : '0');
-                sb.Append((b & 0b00010000) != 0 ? '1' : '0');
-                sb.Append((b & 0b00001000) != 0 ? '1' : '0');
-                sb.Append((b & 0b00000100) != 0 ? '1' : '0');
-                sb.Append((b & 0b00000010) != 0 ? '1' : '0');
-                sb.Append((b & 0b00000001) != 0 ? '1' : '0');
-            }
-
-            return sb.ToString();
+                var src = state.buffer.AsSpan(state.index, state.count);
+                var pos = 0;
+                for (var i = 0; i < src.Length; i++)
+                {
+                    var b = src[i];
+                    // Manual bit extraction is faster than Convert.ToString for single bytes
+                    span[pos++] = (b & 0b10000000) != 0 ? '1' : '0';
+                    span[pos++] = (b & 0b01000000) != 0 ? '1' : '0';
+                    span[pos++] = (b & 0b00100000) != 0 ? '1' : '0';
+                    span[pos++] = (b & 0b00010000) != 0 ? '1' : '0';
+                    span[pos++] = (b & 0b00001000) != 0 ? '1' : '0';
+                    span[pos++] = (b & 0b00000100) != 0 ? '1' : '0';
+                    span[pos++] = (b & 0b00000010) != 0 ? '1' : '0';
+                    span[pos++] = (b & 0b00000001) != 0 ? '1' : '0';
+                }
+            });
         }
     }
 }

--- a/src/ui/Controls/SyntaxTextEditorControl/SyntaxTextDocument.cs
+++ b/src/ui/Controls/SyntaxTextEditorControl/SyntaxTextDocument.cs
@@ -67,18 +67,23 @@ public sealed class SyntaxTextDocument
             return _lines[0];
         }
 
-        var sb = new StringBuilder(TextLength);
-        for (var i = 0; i < _lines.Count; i++)
+        // TextLength counts every line plus a NewLine between each, so the result can be
+        // written straight into the string's buffer.
+        return string.Create(TextLength, this, static (span, doc) =>
         {
-            if (i > 0)
+            var pos = 0;
+            for (var i = 0; i < doc._lines.Count; i++)
             {
-                sb.Append(NewLine);
+                if (i > 0)
+                {
+                    doc.NewLine.AsSpan().CopyTo(span[pos..]);
+                    pos += doc.NewLine.Length;
+                }
+
+                doc._lines[i].AsSpan().CopyTo(span[pos..]);
+                pos += doc._lines[i].Length;
             }
-
-            sb.Append(_lines[i]);
-        }
-
-        return sb.ToString();
+        });
     }
 
     private void SetText(string? text)


### PR DESCRIPTION
## Summary
- Replace StringBuilder with `string.Create` at three sites where the final length is known exactly upfront, writing the result directly into the new string's buffer:
  - `FixCasing.MakeUpperCaseExceptTags` / `MakeLowerCaseExceptTags` — runs per line during fix-casing; the tag-state loop is unchanged, only retargeted from `Append` to span writes.
  - `TransportStream/Helper.GetBinaryString` — runs per PES packet when parsing `.ts` files.
  - `SyntaxTextDocument.BuildText` — the syntax editor rebuilds the cached document text on every edit; the buffer is sized by the already-exact `TextLength`.
- The libse lambdas receive the source via the `string.Create` state parameter, so they capture nothing and compile as C# 8 for the `netstandard2.1` target.
- Removed the `using System.Text;` left unused in `Helper.cs`.

## Benchmarks

BenchmarkDotNet v0.15.8, .NET 10.0.10, X64 RyuJIT (i7-13700), ShortRun, `[MemoryDiagnoser]`. Old and new outputs verified identical on empty, tagged, mixed, and boundary inputs before measuring.

| Site | Case | main (StringBuilder) | PR (string.Create) | Ratio | Allocated |
|---|---|---:|---:|---:|---|
| SyntaxTextDocument.BuildText | 2 lines | 24.4 ns | 11.9 ns | 0.49 | 432 B → 192 B |
| | 10 lines | 92.5 ns | 47.9 ns | 0.52 | 1,808 B → 880 B |
| | 50 lines | 396.7 ns | 239.0 ns | 0.60 | 8,688 B → 4,320 B |
| Helper.GetBinaryString | 5 bytes (PTS field) | 33.9 ns | 22.4 ns | 0.66 | 256 B → 104 B |
| | 32 bytes | 173.9 ns | 136.1 ns | 0.78 | 1,120 B → 536 B |
| FixCasing upper-except-tags | plain line | 98.5 ns | 86.2 ns | 0.88 | 256 B → 104 B |
| | tagged line | ~119 ns | 81.1 ns | 0.69 | 272 B → 112 B |

At 50 lines, BuildText also stops spilling into Gen1 (0.0091 → 0 collects per 1k ops).

## Test plan
- [ ] `dotnet build src/libse/LibSE.csproj` succeeds for both `netstandard2.1` and `net10.0`
- [ ] `dotnet test tests/libse/LibSETests.csproj` — all pass, including `FixCasingTest` and `StrippableTextFixCasingTest` which cover both converted casing methods
- [ ] `dotnet test tests/UI/UITests.csproj --filter "FullyQualifiedName~SyntaxTextDocument"` — all 15 pass
- [ ] In the app: Fix common errors → make uppercase/lowercase on lines with `<i>`/`{\an8}` tags keeps tags untouched; open a `.ts` file with subtitles and verify time codes still parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)