### PR TITLE
Five small typing/mpv-preview optimizations (#13234 follow-up)

### DIFF
--- a/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
@@ -128,7 +128,12 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
         public override string ToText(Subtitle subtitle, string title)
         {
             var fromTtml = false;
-            var header = $@"[Script Info]
+
+            // Built on demand: DefaultStyle allocates and serializes a fresh SsaStyle on every
+            // get, and subtitles that already carry a valid ASSA header (every save of an .ass
+            // file and every mpv preview refresh) never use this fallback template.
+            string headerTemplate = null;
+            string HeaderTemplate() => headerTemplate ??= $@"[Script Info]
 ; This is an Advanced Sub Station Alpha v4+ script.
 Title: {{0}}
 ScriptType: v4.00+" +
@@ -143,7 +148,10 @@ $@"
 [Events]
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text";
 
-            var sb = new StringBuilder();
+            // Pre-size: header + roughly one "Dialogue:" prefix, timecodes, style/margins and
+            // text per paragraph. Growing from the 16-char default instead re-copies the whole
+            // multi-hundred-KB buffer on every doubling.
+            var sb = new StringBuilder((subtitle.Header?.Length ?? 1024) + subtitle.Paragraphs.Count * 100);
             var isValidAssHeader = !string.IsNullOrEmpty(subtitle.Header) && subtitle.Header.Contains("[V4+ Styles]");
             var styles = new List<string>();
             if (isValidAssHeader)
@@ -154,7 +162,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
             }
             else if (!string.IsNullOrEmpty(subtitle.Header) && subtitle.Header.Contains("[V4 Styles]"))
             {
-                LoadStylesFromSubstationAlpha(subtitle, title, header, HeaderNoStyles, sb);
+                LoadStylesFromSubstationAlpha(subtitle, title, HeaderTemplate(), HeaderNoStyles, sb);
                 isValidAssHeader = !string.IsNullOrEmpty(subtitle.Header) && subtitle.Header.Contains("[V4+ Styles]");
                 if (isValidAssHeader)
                 {
@@ -163,7 +171,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
             }
             else if (subtitle.Header != null && subtitle.Header.Contains("http://www.w3.org/ns/ttml"))
             {
-                LoadStylesFromTimedText10(subtitle, title, header, HeaderNoStyles, sb);
+                LoadStylesFromTimedText10(subtitle, title, HeaderTemplate(), HeaderNoStyles, sb);
                 fromTtml = true;
                 isValidAssHeader = !string.IsNullOrEmpty(subtitle.Header) && subtitle.Header.Contains("[V4+ Styles]");
                 if (isValidAssHeader)
@@ -173,7 +181,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
             }
             else if (subtitle.Header != null && subtitle.Header.Contains("http://www.w3.org/2006/10/ttaf1"))
             {
-                LoadStylesFromTimedTextTimedDraft2006Oct(subtitle, title, header, HeaderNoStyles, sb);
+                LoadStylesFromTimedTextTimedDraft2006Oct(subtitle, title, HeaderTemplate(), HeaderNoStyles, sb);
                 fromTtml = true;
                 isValidAssHeader = !string.IsNullOrEmpty(subtitle.Header) && subtitle.Header.Contains("[V4+ Styles]");
                 if (isValidAssHeader)
@@ -185,13 +193,13 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
             {
                 subtitle = WebVttToAssa.Convert(subtitle, new SsaStyle(), 0, 0);
                 isValidAssHeader = !string.IsNullOrEmpty(subtitle.Header) && subtitle.Header.Contains("[V4+ Styles]");
+                var webVttHeader = isValidAssHeader ? subtitle.Header : HeaderTemplate();
                 if (isValidAssHeader)
                 {
                     styles = GetStylesFromHeader(subtitle.Header);
-                    header = subtitle.Header;
                 }
 
-                sb.AppendFormat(header, title).AppendLine();
+                sb.AppendFormat(webVttHeader, title).AppendLine();
 
                 if (!sb.ToString().Contains("Format: Layer"))
                 {
@@ -200,8 +208,8 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
             }
             else
             {
-                sb.AppendFormat(header, title).AppendLine();
-                styles = GetStylesFromHeader(header);
+                sb.AppendFormat(HeaderTemplate(), title).AppendLine();
+                styles = GetStylesFromHeader(HeaderTemplate());
             }
 
             // List.Contains is a linear scan and runs up to three times per paragraph below;
@@ -992,14 +1000,41 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
             return styles;
         }
 
+        // Single-entry memo for GetStylesFromHeader, keyed on the header string instance (the
+        // same immutable header is passed repeatedly: every save and every video preview
+        // refresh re-parses it otherwise). Immutable holder swapped by reference, so the
+        // lookup is thread-safe without locking - same pattern as CalcFactory.
+        private sealed class StylesFromHeaderCache
+        {
+            public readonly string Header;
+            public readonly List<string> Styles;
+
+            public StylesFromHeaderCache(string header, List<string> styles)
+            {
+                Header = header;
+                Styles = styles;
+            }
+        }
+
+        private static volatile StylesFromHeaderCache _stylesFromHeaderCache;
+
         public static List<string> GetStylesFromHeader(string headerLines)
         {
-            var list = new List<string>();
-
             if (headerLines == null)
             {
                 headerLines = DefaultStyle;
             }
+
+            // Key on the caller's instance (before the TTML rewrite below). Callers may mutate
+            // the returned list, so the cached list stays private and every hit returns a copy.
+            var key = headerLines;
+            var cached = _stylesFromHeaderCache;
+            if (cached != null && ReferenceEquals(cached.Header, key))
+            {
+                return new List<string>(cached.Styles);
+            }
+
+            var list = new List<string>();
 
             if (headerLines.Contains("http://www.w3.org/ns/ttml"))
             {
@@ -1020,6 +1055,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                 }
             }
 
+            _stylesFromHeaderCache = new StylesFromHeaderCache(key, new List<string>(list));
             return list;
         }
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -22612,13 +22612,20 @@ public partial class MainViewModel :
 
     private void OnSubtitleItemChangedForMpv(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
-        if (e.PropertyName is nameof(SubtitleLineViewModel.Text)
-            or nameof(SubtitleLineViewModel.StartTime)
-            or nameof(SubtitleLineViewModel.EndTime))
+        if (e.PropertyName is nameof(SubtitleLineViewModel.StartTime))
         {
             _mpvPreviewDirty = true;
             // A start-time change can reorder the buffer, so it must be rebuilt and re-sorted.
             _waveformSubtitleBufferDirty = true;
+        }
+        else if (e.PropertyName is nameof(SubtitleLineViewModel.Text)
+            or nameof(SubtitleLineViewModel.EndTime))
+        {
+            // Preview only: the buffer holds live references sorted by start time, so text
+            // and end-time edits change neither membership nor order. Marking it dirty here
+            // used to refill + order-check every line 20x a second while the user typed in
+            // the edit box or dragged an end time in the waveform.
+            _mpvPreviewDirty = true;
         }
         else if (e.PropertyName is nameof(SubtitleLineViewModel.Layer))
         {
@@ -22922,8 +22929,8 @@ public partial class MainViewModel :
 
                 // Rebuild + re-sort the buffer only when its inputs changed since the last tick;
                 // an idle tick used to copy and order-check every line 20x a second (#13234).
-                // Membership/order inputs: the collection and each line's times/layer (both flip
-                // _waveformSubtitleBufferDirty via the ForMpv hooks), plus the layer-visibility
+                // Membership/order inputs: the collection and each line's start time/layer (both
+                // flip _waveformSubtitleBufferDirty via the ForMpv hooks), plus the layer-visibility
                 // state checked here - _visibleLayers is only ever swapped wholesale, so a
                 // reference comparison covers it. The buffer holds live references, so paragraph
                 // content read later this tick is always current either way.

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -244,21 +244,34 @@ public partial class SubtitleLineViewModel : ObservableObject
     }
 
     // Read-time memo for the html-stripped, line-split text: the pixel width column, the text
-    // error verdict and GetErrors all need it, and each used to strip and split the text again -
-    // three times per line for a single error scan. Keyed on the text instance like the memos
-    // below. The returned list is shared, so callers must only read it.
+    // error verdict, GetErrors and the edit box's line-length panel all need it, and each used
+    // to strip and split the text again - three times per line for a single error scan. Keyed
+    // on the text instance like the memos below. The returned string/list are shared, so
+    // callers must only read them.
     private string? _strippedLinesCacheText;
+    private string? _strippedTextCacheValue;
     private List<string>? _strippedLinesCacheValue;
 
-    private List<string> GetStrippedLines()
+    private void EnsureStrippedCache()
     {
         if (_strippedLinesCacheValue == null || !ReferenceEquals(_strippedLinesCacheText, Text))
         {
-            _strippedLinesCacheValue = SubtitleTextInfoHelper.StripHtml(Text).SplitToLines();
+            _strippedTextCacheValue = SubtitleTextInfoHelper.StripHtml(Text);
+            _strippedLinesCacheValue = _strippedTextCacheValue.SplitToLines();
             _strippedLinesCacheText = Text;
         }
+    }
 
-        return _strippedLinesCacheValue;
+    internal string GetStrippedText()
+    {
+        EnsureStrippedCache();
+        return _strippedTextCacheValue!;
+    }
+
+    internal List<string> GetStrippedLines()
+    {
+        EnsureStrippedCache();
+        return _strippedLinesCacheValue!;
     }
 
     // Read-time memo, see CharactersPerSecond below: the pixel-width column binding re-reads this

--- a/src/ui/Logic/Media/MpvReloader.cs
+++ b/src/ui/Logic/Media/MpvReloader.cs
@@ -73,7 +73,8 @@ public class MpvReloader : IMpvReloader
             {
                 var defaultStyle = GetMpvPreviewStyle(Se.Settings.Video);
                 defaultStyle.BorderStyle = "3";
-                subtitle = new Subtitle(subtitle);
+                // No extra copy here: "subtitle" is already this method's private copy, and
+                // Convert deep-copies its input again internally without mutating it.
                 subtitle = WebVttToAssa.Convert(subtitle, defaultStyle, VideoWidth, VideoHeight);
                 AddSecondarySubtitle(subtitle, subtitleSecondary);
                 text = subtitle.ToText(_assFormat);
@@ -92,8 +93,12 @@ public class MpvReloader : IMpvReloader
                         subtitle.Header = AdvancedSubStationAlpha.GetHeaderAndStylesFromSubStationAlpha(subtitle.Header);
                     }
 
-                    var oldSub = subtitle;
-                    subtitle = new Subtitle(subtitle);
+                    // "subtitle" is already this method's private copy (see the top of the try
+                    // block), so mutating it in place is safe - the second full deep copy that
+                    // used to live here cost one Paragraph + two TimeCode allocations per line
+                    // on the UI thread for every preview refresh. Only the pre-preview-style
+                    // header is needed for the STL checks below.
+                    var oldHeader = subtitle.Header;
                     if (Se.Settings.Appearance.RightToLeft)
                     {
                         for (var index = 0; index < subtitle.Paragraphs.Count; index++)
@@ -111,7 +116,7 @@ public class MpvReloader : IMpvReloader
                         subtitle.Header = MpvPreviewStyleHeader;
                     }
 
-                    if (oldSub.Header != null && oldSub.Header.Length > 20 && oldSub.Header.AsSpan(3, 3).SequenceEqual("STL"))
+                    if (oldHeader != null && oldHeader.Length > 20 && oldHeader.AsSpan(3, 3).SequenceEqual("STL"))
                     {
                         var previewFontName = Configuration.IsRunningOnLinux ? Configuration.DefaultLinuxFontName : "Tahoma";
                         var boxStyle = $"Style: Box,{previewFontName},12,&H00FFFFFF,&H0300FFFF,&H00000000,&H02000000,-1,0,0,0,100,100,0,0,3,2,0,2,10,10,10,1{Environment.NewLine}Style: Default,";
@@ -122,8 +127,8 @@ public class MpvReloader : IMpvReloader
                         {
                             try
                             {
-                                var encoding = Ebu.GetEncoding(oldSub.Header[..3]);
-                                var buffer = encoding.GetBytes(oldSub.Header);
+                                var encoding = Ebu.GetEncoding(oldHeader[..3]);
+                                var buffer = encoding.GetBytes(oldHeader);
                                 var header = Ebu.ReadHeader(buffer);
                                 if (header.DisplayStandardCode != "0")
                                 {

--- a/src/ui/Logic/SubtitleTextInfoHelper.cs
+++ b/src/ui/Logic/SubtitleTextInfoHelper.cs
@@ -37,7 +37,20 @@ internal static class SubtitleTextInfoHelper
         out string totalText,
         out IBrush totalBackground)
     {
-        var info = PopulateLineLengthsAndTotal(text, panel);
+        // This runs on every keystroke in the edit box, right after the row view model's own
+        // bindings (text error tint, pixel width) already stripped and split the same text.
+        // Reuse that memo instead of stripping/splitting a second time; the guard keeps the
+        // fallback for callers passing a different string than the row's current text.
+        TextTotalInfo info;
+        if (ReferenceEquals(text, item.Text))
+        {
+            info = PopulateLineLengthsAndTotalCore(item.GetStrippedText(), item.GetStrippedLines(), panel);
+        }
+        else
+        {
+            info = PopulateLineLengthsAndTotal(text, panel);
+        }
+
         var maxCps = Se.Settings.General.SubtitleMaximumCharactersPerSeconds;
 
         var cps = GetCharactersPerSecond(text, item.StartTime, item.EndTime);
@@ -49,12 +62,16 @@ internal static class SubtitleTextInfoHelper
 
     internal static TextTotalInfo PopulateLineLengthsAndTotal(string text, StackPanel panel)
     {
+        var cleanText = StripHtml(text);
+        return PopulateLineLengthsAndTotalCore(cleanText, cleanText.SplitToLines(), panel);
+    }
+
+    private static TextTotalInfo PopulateLineLengthsAndTotalCore(string cleanText, List<string> lines, StackPanel panel)
+    {
         var colorTextTooLong = Se.Settings.General.ColorTextTooLong;
         var maxLineLength = Se.Settings.General.SubtitleLineMaximumLength;
 
-        var cleanText = StripHtml(text);
         var totalLength = GetTotalLength(cleanText);
-        var lines = cleanText.SplitToLines();
         var lineCount = lines.Count;
 
         FillLineLengthPanel(panel, lines, colorTextTooLong, maxLineLength);

--- a/tests/benchmarks/TypingAndPreviewBenchmarks.cs
+++ b/tests/benchmarks/TypingAndPreviewBenchmarks.cs
@@ -1,0 +1,131 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// Models the video preview refresh snapshot in MpvReloader.RefreshMpv for a non-ASSA UI
+/// format (SubRip - the default): the old shape deep-copied the already-private snapshot a
+/// second time before swapping in the preview style header; the new shape mutates the
+/// private copy in place and only keeps the original header string for the STL checks.
+/// Both shapes are modeled here so the win is visible in a single run.
+/// </summary>
+[MemoryDiagnoser]
+public class PreviewSnapshotBenchmarks
+{
+    private Subtitle _subtitle = new();
+    private string _previewHeader = string.Empty;
+
+    [Params(1000, 5000)]
+    public int Lines { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var texts = new[]
+        {
+            "It was the best of times, it was the worst of times.",
+            "<i>Are you coming with us?</i>",
+            "- No." + Environment.NewLine + "- Then stay here and wait.",
+            "1999 was a very long time ago.",
+            "Hello.",
+        };
+
+        _subtitle = new Subtitle();
+        var startMs = 1000.0;
+        for (var i = 0; i < Lines; i++)
+        {
+            _subtitle.Paragraphs.Add(new Paragraph(texts[i % texts.Length], startMs, startMs + 2000));
+            startMs += 2100;
+        }
+
+        _previewHeader = string.Format(
+            Nikse.SubtitleEdit.Core.SubtitleFormats.AdvancedSubStationAlpha.HeaderNoStyles,
+            "MPV preview file",
+            new SsaStyle().ToRawAss(SsaStyle.DefaultAssStyleFormat));
+    }
+
+    [Benchmark(Baseline = true)]
+    public int SecondDeepCopy()
+    {
+        // Old RefreshMpv shape: private snapshot copy + a second full deep copy.
+        var snapshot = new Subtitle(_subtitle, false);
+        var oldSub = snapshot;
+        var working = new Subtitle(snapshot);
+        working.Header = _previewHeader;
+        return working.Paragraphs.Count + (oldSub.Header?.Length ?? 0);
+    }
+
+    [Benchmark]
+    public int MutateSnapshotInPlace()
+    {
+        // New RefreshMpv shape: keep the original header string, mutate the private copy.
+        var snapshot = new Subtitle(_subtitle, false);
+        var oldHeader = snapshot.Header;
+        snapshot.Header = _previewHeader;
+        return snapshot.Paragraphs.Count + (oldHeader?.Length ?? 0);
+    }
+}
+
+/// <summary>
+/// Models the per-keystroke text-info work in the edit box: the row view model's bindings
+/// (text error tint) strip + split the text once via their memo, and the old
+/// SubtitleTextInfoHelper.Populate stripped + split the very same text a second time for the
+/// line-length panel. The new Populate reuses the memo, so only one strip + split remains.
+/// </summary>
+[MemoryDiagnoser]
+public class KeystrokeStripSplitBenchmarks
+{
+    private string[] _texts = [];
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Rotating texts model successive keystroke states; ASSA override tags and italics
+        // make the strip do real work, like the issue reporter's ASSA project.
+        _texts =
+        [
+            @"{\an8}It was the best of times,",
+            @"{\an8}It was the best of times, it",
+            @"{\an8}It was the best of times, it was",
+            "<i>Are you coming\r\nwith us?</i>",
+            "<i>Are you coming\r\nwith us now?</i>",
+            @"{\i1}- No.{\i0}" + "\r\n" + "- Then stay here.",
+        ];
+    }
+
+    [Benchmark(Baseline = true)]
+    public int StripAndSplitTwice()
+    {
+        var total = 0;
+        foreach (var text in _texts)
+        {
+            // Row view model memo build (tint/pixel-width bindings).
+            var stripped1 = HtmlUtil.RemoveHtmlTags(text, true);
+            total += stripped1.SplitToLines().Count;
+
+            // Old Populate: same strip + split again for the line-length panel.
+            var stripped2 = HtmlUtil.RemoveHtmlTags(text, true);
+            total += stripped2.SplitToLines().Count;
+        }
+
+        return total;
+    }
+
+    [Benchmark]
+    public int StripAndSplitOnce()
+    {
+        var total = 0;
+        foreach (var text in _texts)
+        {
+            // New Populate reuses the row view model's memo, so each keystroke pays one
+            // strip + split; the second consumer just reads the cached values.
+            var stripped = HtmlUtil.RemoveHtmlTags(text, true);
+            var lines = stripped.SplitToLines();
+            total += lines.Count;
+            total += lines.Count;
+        }
+
+        return total;
+    }
+}


### PR DESCRIPTION
Follow-up to #13234 ("text editing and preview refresh are still slightly less responsive"): five small optimizations on the per-keystroke path and the mpv preview refresh path, each verified with BenchmarkDotNet on Apple M4 (default job, MemoryDiagnoser).

## Typing path

**1. Text/end-time edits no longer rebuild the waveform buffer** (`MainViewModel.OnSubtitleItemChangedForMpv`)
The buffer holds live `SubtitleLineViewModel` references sorted by start time, so text and end-time edits change neither membership nor order — but they marked the buffer dirty, so every keystroke (and every end-time drag tick) paid a full refill + order-check on the next 50 ms tick. Cost eliminated per tick (`WaveformBufferBenchmarks.RefillAndSortCheck`):

| Lines | Per-tick cost removed |
|---|---:|
| 1,000 | 24.4 μs |
| 5,000 | 125.3 μs |
| 20,000 | 1,030 μs |

**2. Edit-box info panel reuses the row's stripped-text memo** (`SubtitleTextInfoHelper.Populate` + `SubtitleLineViewModel`)
Per keystroke, the row VM's bindings (error tint / pixel width) already strip + split the text into the memo; `Populate` then stripped + split the same text again for the line-length panel. It now reuses the memo (`KeystrokeStripSplitBenchmarks`):

| Method | Mean | Allocated |
|---|---:|---:|
| StripAndSplitTwice (old) | 4.70 μs | 2.5 KB |
| StripAndSplitOnce (new) | 2.35 μs | 1.25 KB |

## mpv preview refresh path

**3. `MpvReloader.RefreshMpv` drops its redundant second deep copy** (non-ASSA and WebVTT paths)
`subtitle` is already the method's private copy; the second `new Subtitle(subtitle)` also generated a fresh `Guid` per paragraph. The WebVTT path's extra copy was redundant too (`WebVttToAssa.Convert` deep-copies internally and never mutates its input). Only the pre-preview-style header string is kept for the STL checks. Modeled snapshot prep (`PreviewSnapshotBenchmarks`):

| Lines | Old | New | Allocated |
|---|---:|---:|---:|
| 1,000 | 1,239.5 μs | 140.7 μs | 406 KB → 203 KB |
| 5,000 | 6,510.0 μs | 776.7 μs | 2,031 KB → 1,016 KB |

**4. ASSA `ToText`: lazy fallback header template + pre-sized StringBuilder**
The interpolated fallback header (which serializes a fresh `SsaStyle` via `DefaultStyle` on every get) was built on every call, even though subtitles with a valid ASSA header — every .ass save and every preview refresh — never use it. The output builder is also pre-sized instead of doubling up from 16 chars.

**5. `GetStylesFromHeader`: single-entry reference memo**
The same immutable header string is re-parsed on every save and preview refresh. Hits return a defensive copy so caller mutation cannot poison the cache (same lock-free pattern as `CalcFactory`).

Real before/after for 4+5 (`ToTextBenchmarks.AssaToText`, 100-style header):

| Paragraphs | Before | After |
|---|---:|---:|
| 1,000 | 1,041.5 μs | 1,045.9 μs (neutral) |
| 10,000 | 9,274.9 μs | 7,003.8 μs (−24%) |

`SubRipToText` (untouched code path) served as control: allocations byte-identical, time within noise.

## Verification

- All 897 libse tests pass; related UI tests (MpvReloader/TextInfo/SubtitleLineViewModel/Waveform) pass.
- Byte-identity dump harness over an edge-case battery (null/empty/valid-ASSA/V4-SSA/WebVTT headers × 0/1/7/40 paragraphs, comments, actors, margins, ASSA tags) for `ToText` + `GetStylesFromHeader` — output byte-identical before vs. after, including a probe that mutates the returned styles list to prove the memo cannot be poisoned.
- New `tests/benchmarks/TypingAndPreviewBenchmarks.cs` models the old/new shapes of 2 and 3 so the wins stay measurable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)