### PR TITLE
Surface Ollama OCR failures instead of silently producing blank lines

### DIFF
--- a/src/ui/Features/Ocr/Engines/OllamaOcr.cs
+++ b/src/ui/Features/Ocr/Engines/OllamaOcr.cs
@@ -36,6 +36,8 @@ public class OllamaOcr
 
     public async Task<string> Ocr(SKBitmap bitmap, string url, string model, string language, CancellationToken cancellationToken)
     {
+        Error = string.Empty;
+
         try
         {
             // Pad to square to improve OCR accuracy
@@ -108,6 +110,13 @@ public class OllamaOcr
         }
         catch (Exception ex)
         {
+            // E.g. connection refused (Ollama not running) or timeout — record it so the caller
+            // can tell a real failure apart from a textless image. A non-success HTTP status has
+            // already stored the (more informative) response body in Error.
+            if (string.IsNullOrEmpty(Error))
+            {
+                Error = ex.Message;
+            }
             SeLogger.Error(ex, "Error calling Ollama for OCR");
             return string.Empty;
         }

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -3969,9 +3969,13 @@ public partial class OcrViewModel : ObservableObject
     private void RunOllamaOcr(List<int> selectedIndices, CancellationToken cancellationToken)
     {
         var ollamaOcr = new OllamaOcr(Se.Settings.Ocr.OllamaOcrTimeoutMinutes);
+        var url = OllamaUrl;
+        var model = OllamaModel;
 
         _ = Task.Run(async () =>
         {
+            var processedCount = 0;
+            var producedAnyText = false;
             try
             {
                 for (var processedIndex = 0; processedIndex < selectedIndices.Count; processedIndex++)
@@ -3989,20 +3993,65 @@ public partial class OcrViewModel : ObservableObject
 
                     SelectAndScrollToRow(i);
 
-                    var text = await ollamaOcr.Ocr(bitmap, OllamaUrl, OllamaModel, SelectedOllamaLanguage ?? "English", cancellationToken);
+                    var text = await ollamaOcr.Ocr(bitmap, url, model, SelectedOllamaLanguage ?? "English", cancellationToken);
+
+                    // Surface a real failure (Ollama not running, model not pulled, out of memory)
+                    // instead of silently filling the grid with blank lines.
+                    if (string.IsNullOrEmpty(text) && !string.IsNullOrEmpty(ollamaOcr.Error))
+                    {
+                        await ShowOllamaErrorAsync(ollamaOcr.Error, url, model);
+                        return;
+                    }
+
+                    processedCount++;
+                    if (!string.IsNullOrWhiteSpace(text))
+                    {
+                        producedAnyText = true;
+                    }
+
                     item.Text = text;
 
                     OcrFixLineAndSetText(i, item);
                 }
+
+                if (processedCount >= 1 && !producedAnyText && !cancellationToken.IsCancellationRequested)
+                {
+                    await ShowOllamaErrorAsync(
+                        "Ollama returned no text for " +
+                        (processedCount == 1 ? "the line." : "any of the " + processedCount + " lines.") + Environment.NewLine +
+                        "The model may not suit subtitle images, or the selected language may be wrong.",
+                        url, model);
+                }
             }
             catch (OperationCanceledException)
             {
+            }
+            catch (Exception ex)
+            {
+                SeLogger.Error(ex, "Error running Ollama OCR");
+                await ShowOllamaErrorAsync(ollamaOcr.Error is { Length: > 0 } e ? e : ex.Message, url, model);
             }
             finally
             {
                 PauseOcr();
             }
         });
+    }
+
+    private async Task ShowOllamaErrorAsync(string error, string url, string model)
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        await Dispatcher.UIThread.InvokeAsync(async () =>
+            await MessageBox.Show(
+                Window!,
+                Se.Language.General.Error,
+                "Ollama OCR failed (model \"" + model + "\" at " + url + "):" + Environment.NewLine + Environment.NewLine + error,
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error));
     }
 
     private void RunLlamaCppOcr(List<int> selectedIndices, CancellationToken cancellationToken)


### PR DESCRIPTION
Follow-up to the [OCR engine comparison feedback](https://github.com/SubtitleEdit/subtitleedit/pull/13238#issuecomment-5206357374): "glm-ocr (Ollama): ~6 s for 109 subtitle images — finished almost instantly but returned empty subtitles."

### Root cause

Reproduced locally: any fast-failing Ollama request — server not running (connection refused), model not pulled (404), or Ollama refusing to load the model into available RAM (500, likely on the reporter's 4 GB machine, since glm-ocr F16 is 2.2 GB) — fails in **~55–70 ms per image**, which matches the reported 6 s / 109 images almost exactly. `OllamaOcr.Ocr` swallowed the exception and returned an empty string, and `RunOllamaOcr` never read `ollamaOcr.Error`, so the loop blanked every line and reported success.

The happy path is fine: with Ollama 0.32.6 + glm-ocr, SE's exact request returns correct text (verified headlessly with a console harness against `OllamaOcr` — `"Hello world"` in ~4 s, fence garbage stripped by `CleanOcrText`). Current Ollama also accepts `"think": false` for models without the thinking capability, so that field is not the problem.

### Changes

- `OllamaOcr`: record exceptions (connection refused, timeout) in `Error`, clear `Error` per call, and keep the HTTP response body when it is the more informative message (it was previously overwritten by the generic `EnsureSuccessStatusCode` exception text).
- `OcrViewModel.RunOllamaOcr`: adopt the existing Tesseract pattern — stop and show an error dialog on the first image that fails, and warn when a run completes without producing any text at all.
- Side effect: Video OCR's existing first-image fail-fast for Ollama now actually fires on connection errors (it checked `Error`, which stayed empty for exceptions).

### Verification

- Console harness against local Ollama: happy path returns text with empty `Error`; wrong port → `Error="Connection refused (localhost:11435)"` in 70 ms; missing model → `Error` carries the Ollama JSON body in 55 ms.
- `dotnet test --filter FullyQualifiedName~OllamaOcr`: 6/6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)