### PR TITLE
Move focus between message box buttons with arrow keys

### DIFF
--- a/src/ui/Features/Shared/MessageBox.cs
+++ b/src/ui/Features/Shared/MessageBox.cs
@@ -1,12 +1,15 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -54,6 +57,13 @@ public class MessageBox : Window
     private readonly bool _hasOnlyOk;
     private readonly bool _hasNo;
     private readonly StackPanel _buttonPanel;
+    private bool _seenSpaceKeyDown;
+    private long _openedTimestamp;
+
+    private bool IsInStartupGuardPeriod()
+    {
+        return _openedTimestamp == 0 || Stopwatch.GetElapsedTime(_openedTimestamp) < TimeSpan.FromMilliseconds(200);
+    }
 
     private MessageBox(string title, string message, MessageBoxButtons buttons, MessageBoxIcon icon, string? custom1 = null, string? custom2 = null, string? custom3 = null, string? custom4 = null)
     {
@@ -237,10 +247,37 @@ public class MessageBox : Window
         grid.ContextFlyout = contextMenu;
         UiUtil.AttachMacContextFlyoutHandler(this, grid);
 
-        // Focus the last button (buttons are added positive-first, so the last one is the
-        // negative/cancel choice) - a focused button clicks on bare Space, and focusing e.g.
-        // "Yes" in a Yes/No box would make Space answer Yes by accident.
-        Activated += delegate { buttonPanel.Children[buttonPanel.Children.Count - 1].Focus(); };
+        // Focus the first button (the positive/default choice - Yes or OK), like classic Win32
+        // message boxes: Space/Enter accepts, Escape cancels, arrow keys move focus. That makes
+        // the key that opened this dialog a hazard: Avalonia's Button clicks on Space KeyUp
+        // without checking it also saw the KeyDown, and a held Enter key-repeats straight into
+        // the new window - either would answer Yes/OK by accident. Guard: swallow Space/Enter
+        // for the first 200 ms after opening, and Space KeyUps whose KeyDown this window never
+        // saw (a Space can be held down well past any fixed time window before releasing).
+        Opened += (_, _) => _openedTimestamp = Stopwatch.GetTimestamp();
+        AddHandler(KeyDownEvent, (_, e) =>
+        {
+            if (e.Key is Key.Space or Key.Enter && IsInStartupGuardPeriod())
+            {
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Space)
+            {
+                _seenSpaceKeyDown = true;
+            }
+        }, RoutingStrategies.Tunnel);
+        AddHandler(KeyUpEvent, (_, e) =>
+        {
+            if (e.Key is Key.Space or Key.Enter && IsInStartupGuardPeriod())
+            {
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Space && !_seenSpaceKeyDown)
+            {
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
+        Activated += delegate { buttonPanel.Children[0].Focus(); };
 
         UiTheme.ApplyScaleToWindow(this);
     }

--- a/src/ui/Features/Shared/MessageBox.cs
+++ b/src/ui/Features/Shared/MessageBox.cs
@@ -53,6 +53,7 @@ public class MessageBox : Window
     private readonly bool _hasCancel;
     private readonly bool _hasOnlyOk;
     private readonly bool _hasNo;
+    private readonly StackPanel _buttonPanel;
 
     private MessageBox(string title, string message, MessageBoxButtons buttons, MessageBoxIcon icon, string? custom1 = null, string? custom2 = null, string? custom3 = null, string? custom4 = null)
     {
@@ -149,6 +150,7 @@ public class MessageBox : Window
             HorizontalAlignment = HorizontalAlignment.Right,
             Margin = new Thickness(10)
         };
+        _buttonPanel = buttonPanel;
 
         void AddButton(string text, MessageBoxResult result)
         {
@@ -286,5 +288,37 @@ public class MessageBox : Window
             Close(_result);
             e.Handled = true;
         }
+        else if (e.Key is Key.Left or Key.Up or Key.Right or Key.Down)
+        {
+            MoveButtonFocus(e.Key is Key.Right or Key.Down ? 1 : -1);
+            e.Handled = true;
+        }
+    }
+
+    private void MoveButtonFocus(int direction)
+    {
+        var buttons = _buttonPanel.Children;
+        if (buttons.Count == 0)
+        {
+            return;
+        }
+
+        var focused = FocusManager?.GetFocusedElement();
+        var index = -1;
+        for (var i = 0; i < buttons.Count; i++)
+        {
+            if (ReferenceEquals(buttons[i], focused))
+            {
+                index = i;
+                break;
+            }
+        }
+
+        index = index < 0
+            ? (direction > 0 ? 0 : buttons.Count - 1)
+            : (index + direction + buttons.Count) % buttons.Count;
+
+        // NavigationMethod.Directional makes the focus adorner visible, like tabbing does
+        buttons[index].Focus(NavigationMethod.Directional);
     }
 }


### PR DESCRIPTION
### What

Keyboard behavior of the shared `MessageBox` window now matches classic Win32 message boxes:

- **Arrow keys move focus between buttons** - Right/Down focuses the next button, Left/Up the previous one, wrapping around at either end. Focus is set with `NavigationMethod.Directional` so the focus adorner is shown, same as tabbing.
- **The first (positive) button - Yes or OK - gets default focus** instead of the last (negative) one, so Space/Enter accepts and Escape cancels.

### Guarding against accidental activation

Focusing Yes/OK makes the key that opened the dialog a hazard: Avalonia's `Button` clicks on Space KeyUp without checking it also saw the KeyDown, and a held Enter key-repeats straight into the new window - either would answer the dialog by accident. Two complementary guards:

- Space/Enter are ignored for the first 200 ms after the window opens (covers Enter key-repeat and quick Space releases).
- Space KeyUps whose KeyDown this window never saw are swallowed (covers a Space held down past any fixed time window before releasing).

Escape handling is unchanged (still maps to Cancel/No/OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)