### PR TITLE
Fix #13303: delete dead on first row of the first file opened after startup

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -15973,9 +15973,17 @@ public partial class MainViewModel :
                 // shows the first row highlighted while SelectedSubtitle is still null -
                 // empty edit box and go to next/previous line dead until the selection is
                 // moved away and back (#13190). Assigning the same item above raises no
-                // event either, so sync the view model explicitly.
-                if (!ReferenceEquals(SelectedSubtitle, itemToScroll))
+                // event either, so sync the view model explicitly. SelectedSubtitle alone
+                // is no proof the pipeline ran: the TwoWay SelectedItem binding writes it
+                // directly when the grid picks row 0 on its own, while _selectedSubtitles -
+                // what delete/copy/italic read - stays empty, leaving those commands dead
+                // on the first row of the first file opened after startup (#13303).
+                var selectionCacheStale = _selectedSubtitles == null
+                                          || _selectedSubtitles.Count != 1
+                                          || !ReferenceEquals(_selectedSubtitles[0], itemToScroll);
+                if (!ReferenceEquals(SelectedSubtitle, itemToScroll) || selectionCacheStale)
                 {
+                    TableViewExtras.SyncSelectedItemsWithSelection(SubtitleGrid);
                     SubtitleGridSelectionChanged();
                 }
 

--- a/tests/UI/Features/Main/SubtitleOpenFirstRowDeleteTests.cs
+++ b/tests/UI/Features/Main/SubtitleOpenFirstRowDeleteTests.cs
@@ -1,0 +1,115 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// Opening the first file after startup leaves the commands that read the selection dead on
+/// row 0 (issue #13303): the grid picks row 0 on its own (AlwaysSelected) without raising
+/// SelectionChanged, and the TwoWay SelectedItem binding writes SelectedSubtitle directly -
+/// so the repair in SelectAndScrollToRow, which used SelectedSubtitle as proof that the
+/// selection-changed pipeline ran, was skipped and the view model's selection cache stayed
+/// empty. Delete (key or context menu) then silently did nothing until the selection was
+/// moved to another row.
+/// </summary>
+public class SubtitleOpenFirstRowDeleteTests : IDisposable
+{
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+    private readonly string _tempDirectory;
+
+    public SubtitleOpenFirstRowDeleteTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "SubtitleEdit.UITests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+
+    private (Window Window, MainViewModel Vm) ShowEmptyMainWindow()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        return (window, vm);
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 5; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+
+    private string WriteSrt(string name)
+    {
+        var fileName = Path.Combine(_tempDirectory, name);
+        File.WriteAllText(fileName,
+            "1" + Environment.NewLine +
+            "00:00:01,000 --> 00:00:02,000" + Environment.NewLine +
+            "Line one" + Environment.NewLine +
+            Environment.NewLine +
+            "2" + Environment.NewLine +
+            "00:00:03,000 --> 00:00:04,000" + Environment.NewLine +
+            "Line two" + Environment.NewLine +
+            Environment.NewLine +
+            "3" + Environment.NewLine +
+            "00:00:05,000 --> 00:00:06,000" + Environment.NewLine +
+            "Line three" + Environment.NewLine);
+        return fileName;
+    }
+
+    [AvaloniaFact]
+    public async Task DeleteRemovesTheFirstRowOfTheFirstOpenedFile()
+    {
+        var (window, vm) = ShowEmptyMainWindow();
+        Se.Settings.General.PromptBeforeDelete = false;
+
+        await vm.SubtitleOpen(WriteSrt("first.srt"), skipLoadVideo: true);
+        Settle(window);
+
+        Assert.Equal(3, vm.Subtitles.Count);
+        Assert.Same(vm.Subtitles[0], vm.SelectedSubtitle);
+
+        // The user's very first action: delete the first row. Without the repair this
+        // silently did nothing because the selection cache was never populated.
+        await vm.DeleteSelectedLinesCommand.ExecuteAsync(null);
+        Settle(window);
+
+        Assert.Equal(2, vm.Subtitles.Count);
+        Assert.Equal("Line two", vm.Subtitles[0].Text);
+    }
+}


### PR DESCRIPTION
Fixes #13303.

### Symptom
After a fresh application launch, Delete (key or context menu) silently does nothing on the first row of the first subtitle file opened - no confirmation dialog. Moving the selection to another row once fixes it for the rest of the session, and a second file opened in the same session is unaffected.

### Root cause
This is a residual case of #13230. On the first file open:

1. `SetSubtitles` reattaches ItemsSource, and the grid picks row 0 on its own (`SelectionMode.AlwaysSelected`) **without raising SelectionChanged**.
2. The TwoWay `SelectedItem` binding writes `SelectedSubtitle` directly, bypassing `SubtitleGridSelectionChanged`.
3. The repair in `SelectAndScrollToRow` (added for #13190) used `!ReferenceEquals(SelectedSubtitle, itemToScroll)` as proof that the selection pipeline had run - so with `SelectedSubtitle` already correct via the binding, it skipped the repair.
4. `_selectedSubtitles` - the cache every selection command reads (delete, copy, italic, ...) - stayed `null`, so those commands hit their `selectedItems.Count == 0` early return.

The edit box and time codes looked fine the whole time (they follow `SelectedSubtitle`), which is what made only the commands appear dead.

### Fix
In `SelectAndScrollToRow`, run the repair whenever the `_selectedSubtitles` cache does not match the single row being selected, not only when `SelectedSubtitle` diverges. Before re-reading the selection, sync the grid's `SelectedItems` from its selection model (`SyncSelectedItemsWithSelection`, idempotent) so the re-read can never blank the selection the way #13230 did.

### Test
New headless test drives the real user scenario - fresh main window, `SubtitleOpen` on a temp .srt, then the delete command - and failed before the fix (3 rows remained) / passes after. Full UI suite: 1486/1486 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)