### PR TITLE
Add missing auto-br settings: do-not-break-after list + bottom-heavy percent (#13310, part 1)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1962,7 +1962,7 @@ public partial class MainViewModel :
         _currentSpellCheckDictionary = null;
         _spellCheckSessionInProgress = false;
         _reDetectSpellCheckLanguage = true;
-        _autoTrimLanguageCode = null;
+        _detectedLanguageCode = null;
 
         if (format != null)
         {
@@ -8657,8 +8657,8 @@ public partial class MainViewModel :
             Subtitles[i].Text = result.Rows[i].TranslatedText;
         }
 
-        // The subtitle language just changed, so the cached auto-trim language is stale (issue #12144).
-        _autoTrimLanguageCode = null;
+        // The subtitle language just changed, so the cached detected language is stale (issue #12144).
+        _detectedLanguageCode = null;
 
         if (!wasOldTranslationChanged)
         {
@@ -8767,8 +8767,8 @@ public partial class MainViewModel :
             }
         }
 
-        // The translated lines changed language, so the cached auto-trim language is stale (issue #12144).
-        _autoTrimLanguageCode = null;
+        // The translated lines changed language, so the cached detected language is stale (issue #12144).
+        _detectedLanguageCode = null;
 
         _updateAudioVisualizer = true;
     }
@@ -8805,8 +8805,8 @@ public partial class MainViewModel :
             Subtitles[i].Text = result.Subtitles[i].Text;
         }
 
-        // The subtitle language just changed, so the cached auto-trim language is stale (issue #12144).
-        _autoTrimLanguageCode = null;
+        // The subtitle language just changed, so the cached detected language is stale (issue #12144).
+        _detectedLanguageCode = null;
 
         _subtitleFileNameOriginal = _subtitleFileName;
         _subtitleOriginal ??= new Subtitle();
@@ -13242,9 +13242,10 @@ public partial class MainViewModel :
             return;
         }
 
+        var language = GetDetectedLanguageCode();
         foreach (var s in selectedItems)
         {
-            s.Text = Utilities.AutoBreakLine(s.Text);
+            s.Text = Utilities.AutoBreakLine(s.Text, language);
         }
 
         _updateAudioVisualizer = true;
@@ -14693,12 +14694,12 @@ public partial class MainViewModel :
         _updateAudioVisualizer = true;
     }
 
-    private static List<string> NormalizeToTwoLines(string text)
+    private List<string> NormalizeToTwoLines(string text)
     {
         var lines = text.SplitToLines();
         if (lines.Count > 2)
         {
-            lines = Utilities.AutoBreakLine(Utilities.UnbreakLine(text)).SplitToLines();
+            lines = Utilities.AutoBreakLine(Utilities.UnbreakLine(text), GetDetectedLanguageCode()).SplitToLines();
         }
 
         if (lines.Count == 1)
@@ -14709,12 +14710,12 @@ public partial class MainViewModel :
         return lines;
     }
 
-    private static string JoinAndCapAtTwoLines(string s1, string s2)
+    private string JoinAndCapAtTwoLines(string s1, string s2)
     {
         var result = s1 + Environment.NewLine + s2;
         if (result.SplitToLines().Count > 2)
         {
-            result = Utilities.AutoBreakLine(Utilities.UnbreakLine(result));
+            result = Utilities.AutoBreakLine(Utilities.UnbreakLine(result), GetDetectedLanguageCode());
         }
 
         return result;
@@ -16911,11 +16912,18 @@ public partial class MainViewModel :
         return true;
     }
 
-    // RemoveUnneededSpaces has language-specific rules - e.g. Dutch keeps the space in
-    // "ze 's avonds" - so auto-trim must not run with an empty language code (issue #12144).
-    // Detection is too slow for the per-selection trim in SubtitleGrid_SelectionChanged,
-    // so the code is cached here; this method re-detects on every file load and auto-save.
-    private string? _autoTrimLanguageCode;
+    // Cached detected language of the loaded subtitle (empty = undetected, null = not yet
+    // detected). Shared by auto-trim and auto-break: RemoveUnneededSpaces has language-specific
+    // rules - e.g. Dutch keeps the space in "ze 's avonds" - so auto-trim must not run with an
+    // empty language code (issue #12144), and auto-break needs the language to pick the
+    // do-not-break-after list. Detection is too slow to run per line or per selection change,
+    // so the code is cached here and reset on file load/new and after translation.
+    private string? _detectedLanguageCode;
+
+    private string GetDetectedLanguageCode()
+    {
+        return _detectedLanguageCode ??= Subtitles.AutoDetectGoogleLanguageOrNull() ?? string.Empty;
+    }
 
     private void AutoTrimWhiteSpaces()
     {
@@ -16923,10 +16931,10 @@ public partial class MainViewModel :
         {
             // OrNull + empty fallback: undetected text must not get the English-only rules
             // (e.g. the " 's " merge corrupting Dutch, #12144).
-            _autoTrimLanguageCode = Subtitles.AutoDetectGoogleLanguageOrNull() ?? string.Empty;
+            _detectedLanguageCode = Subtitles.AutoDetectGoogleLanguageOrNull() ?? string.Empty;
             foreach (var item in Subtitles)
             {
-                item.Text = Utilities.RemoveUnneededSpaces(item.Text, _autoTrimLanguageCode).Trim();
+                item.Text = Utilities.RemoveUnneededSpaces(item.Text, _detectedLanguageCode).Trim();
             }
         }
     }
@@ -17915,7 +17923,7 @@ public partial class MainViewModel :
     /// </summary>
     private void ReplaceSubtitles(IEnumerable<SubtitleLineViewModel> items)
     {
-        _autoTrimLanguageCode = null;
+        _detectedLanguageCode = null;
 
         // Materialize first: callers may pass a lazy query over Subtitles itself.
         var list = items as IReadOnlyList<SubtitleLineViewModel> ?? items.ToList();
@@ -22424,7 +22432,7 @@ public partial class MainViewModel :
 
         if (Se.Settings.General.AutoTrimWhiteSpace && e.RemovedItems.Count < 10)
         {
-            var languageCode = _autoTrimLanguageCode ??= Subtitles.AutoDetectGoogleLanguageOrNull() ?? string.Empty;
+            var languageCode = GetDetectedLanguageCode();
             foreach (SubtitleLineViewModel? item in e.RemovedItems)
             {
                 if (item != null)

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -3682,6 +3682,29 @@ public partial class OcrViewModel : ObservableObject
         public OcrFixLineResult OcrFixLineResult { get; set; } = new OcrFixLineResult();
     }
 
+    // The auto-break language comes from the selected spell check dictionary (used for the
+    // do-not-break-after list). Mapping dictionary name to a two-letter code involves culture
+    // lookups, so memoize it - OcrFixLine runs once per OCR'ed line.
+    private SpellCheckDictionaryDisplay? _autoBreakLanguageSource;
+    private string _autoBreakLanguage = string.Empty;
+
+    private string GetAutoBreakLanguage()
+    {
+        var dictionary = SelectedDictionary;
+        if (dictionary == null || dictionary.Name == GetDictionaryNameNone())
+        {
+            return string.Empty;
+        }
+
+        if (!ReferenceEquals(dictionary, _autoBreakLanguageSource))
+        {
+            _autoBreakLanguageSource = dictionary;
+            _autoBreakLanguage = SpellCheckDictionaryDisplay.GetTwoLetterLanguageCode(dictionary);
+        }
+
+        return _autoBreakLanguage;
+    }
+
     private OcrFixLineResultTemp OcrFixLine(int i, OcrSubtitleItem item)
     {
         var result = new OcrFixLineResultTemp();
@@ -3689,7 +3712,7 @@ public partial class OcrViewModel : ObservableObject
         // The checkbox promises "auto-break if more than X lines", so leave shorter results alone.
         if (DoAutoBreak && Utilities.GetNumberOfLines(item.Text) > Se.Settings.General.MaxNumberOfLines)
         {
-            item.Text = Utilities.AutoBreakLine(item.Text);
+            item.Text = Utilities.AutoBreakLine(item.Text, GetAutoBreakLanguage());
         }
 
         if (SelectedDictionary != null &&
@@ -3781,7 +3804,7 @@ public partial class OcrViewModel : ObservableObject
         // The checkbox promises "auto-break if more than X lines", so leave shorter results alone.
         if (DoAutoBreak && Utilities.GetNumberOfLines(item.Text) > Se.Settings.General.MaxNumberOfLines)
         {
-            item.Text = Utilities.AutoBreakLine(item.Text);
+            item.Text = Utilities.AutoBreakLine(item.Text, GetAutoBreakLanguage());
         }
 
         var unknownWords = new List<UnknownWordItem>();

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -646,7 +646,15 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.AutoBreakCommaBreakEarly, nameof(_vm.AutoBreakCommaBreakEarly)),
             MakeCheckboxSetting(Se.Language.Options.Settings.AutoBreakDashEarly, nameof(_vm.AutoBreakDashEarly)),
             MakeCheckboxSetting(Se.Language.Options.Settings.AutoBreakUsePixelWidth, nameof(_vm.AutoBreakUsePixelWidth)),
-            MakeCheckboxSetting(Se.Language.Options.Settings.AutoBreakPreferBottomHeavy, nameof(_vm.AutoBreakPreferBottomHeavy)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.AutoBreakPreferBottomHeavy, nameof(_vm.AutoBreakPreferBottomHeavy),
+                new Binding(nameof(_vm.AutoBreakUsePixelWidth)) { Source = _vm }),
+            new SettingsItem(Se.Language.Options.Settings.AutoBreakPreferBottomPercent, () =>
+            {
+                var nud = MakeNumericUpDownInt(nameof(_vm.AutoBreakPreferBottomPercent), 0, 50);
+                nud[!Control.IsEnabledProperty] = new Binding(nameof(_vm.AutoBreakUsePixelWidth)) { Source = _vm };
+                return nud;
+            }),
+            MakeCheckboxSetting(Se.Language.Options.Settings.UseDoNotBreakAfterList, nameof(_vm.UseNoLineBreakAfter)),
             new SettingsItem(Se.Language.Options.Settings.SplitOddLinesAction, () => new ComboBox
             {
                 MinWidth = 200,

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -80,6 +80,8 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _autoBreakDashEarly;
     [ObservableProperty] private bool _autoBreakUsePixelWidth;
     [ObservableProperty] private bool _autoBreakPreferBottomHeavy;
+    [ObservableProperty] private int _autoBreakPreferBottomPercent;
+    [ObservableProperty] private bool _useNoLineBreakAfter;
 
     // "Color text if more than N lines" must track the live "Max number of lines"
     // value instead of a hardcoded "2" (#12028), including while typing (nullable/
@@ -717,6 +719,8 @@ public partial class SettingsViewModel : ObservableObject
         AutoBreakDashEarly = Se.Settings.Tools.AutoBreakDashEarly;
         AutoBreakUsePixelWidth = Se.Settings.Tools.AutoBreakUsePixelWidth;
         AutoBreakPreferBottomHeavy = Se.Settings.Tools.AutoBreakPreferBottomHeavy;
+        AutoBreakPreferBottomPercent = (int)Math.Round(Se.Settings.Tools.AutoBreakPreferBottomPercent, MidpointRounding.AwayFromZero);
+        UseNoLineBreakAfter = Se.Settings.Tools.UseNoLineBreakAfter;
         DialogStyle = DialogStyles.FirstOrDefault(p => p.Code == general.DialogStyle) ?? DialogStyles.First();
         ContinuationStyle = ContinuationStyles.FirstOrDefault(p => p.Code == general.ContinuationStyle) ?? ContinuationStyles.First();
         IsEditCustomContinuationStyleVisible = ContinuationStyle?.Code == nameof(Core.Enums.ContinuationStyle.Custom);
@@ -1561,6 +1565,8 @@ public partial class SettingsViewModel : ObservableObject
         Se.Settings.Tools.AutoBreakDashEarly = AutoBreakDashEarly;
         Se.Settings.Tools.AutoBreakUsePixelWidth = AutoBreakUsePixelWidth;
         Se.Settings.Tools.AutoBreakPreferBottomHeavy = AutoBreakPreferBottomHeavy;
+        Se.Settings.Tools.AutoBreakPreferBottomPercent = AutoBreakPreferBottomPercent;
+        Se.Settings.Tools.UseNoLineBreakAfter = UseNoLineBreakAfter;
         general.DialogStyle = DialogStyle.Code;
         general.ContinuationStyle = ContinuationStyle.Code;
         general.CpsLineLengthStrategy = CpsLineLengthStrategy.Code;

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -87,6 +87,8 @@ public class LanguageSettings
     public string AutoBreakDashEarly { get; set; }
     public string AutoBreakUsePixelWidth { get; set; }
     public string AutoBreakPreferBottomHeavy { get; set; }
+    public string AutoBreakPreferBottomPercent { get; set; }
+    public string UseDoNotBreakAfterList { get; set; }
     public string NewEmptyDefaultMs { get; set; }
     public string TimeCodeUpDownStepMs { get; set; }
     public string PromptBeforeDelete { get; set; }
@@ -390,6 +392,8 @@ public class LanguageSettings
         AutoBreakDashEarly = "Auto-break early for dash (dialogs)";
         AutoBreakUsePixelWidth = "Auto-break by pixel width";
         AutoBreakPreferBottomHeavy = "Auto-break prefer bottom heavy";
+        AutoBreakPreferBottomPercent = "Auto-break bottom heavy percentage";
+        UseDoNotBreakAfterList = "Use do-not-break-after list";
         NewEmptyDefaultMs = "Default new subtitle duration (ms)";
         TimeCodeUpDownStepMs = "Time up/down increment (ms)";
         PromptBeforeDelete = "Prompt before delete";

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -609,7 +609,7 @@ public class Se
         }
     }
 
-    private static void UpdateLibSeSettings()
+    internal static void UpdateLibSeSettings()
     {
         Configuration.Settings.General.FFmpegLocation = Settings.General.FfmpegPath;
         Configuration.Settings.General.UseTimeFormatHHMMSSFF = Settings.General.UseFrameMode;
@@ -633,6 +633,8 @@ public class Se
         Configuration.Settings.Tools.AutoBreakDashEarly = Settings.Tools.AutoBreakDashEarly;
         Configuration.Settings.Tools.AutoBreakUsePixelWidth = Settings.Tools.AutoBreakUsePixelWidth;
         Configuration.Settings.Tools.AutoBreakPreferBottomHeavy = Settings.Tools.AutoBreakPreferBottomHeavy;
+        Configuration.Settings.Tools.AutoBreakPreferBottomPercent = Settings.Tools.AutoBreakPreferBottomPercent;
+        Configuration.Settings.Tools.UseNoLineBreakAfter = Settings.Tools.UseNoLineBreakAfter;
 
         var stt = Settings.Tools.AudioToText;
         Configuration.Settings.Tools.WhisperChoice = stt.WhisperChoice;

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -156,6 +156,8 @@ public class SeTools
     public bool AutoBreakDashEarly { get; set; } = true;
     public bool AutoBreakUsePixelWidth { get; set; } = true;
     public bool AutoBreakPreferBottomHeavy { get; set; } = true;
+    public double AutoBreakPreferBottomPercent { get; set; } = 5;
+    public bool UseNoLineBreakAfter { get; set; } = false;
     public bool SpellCheckEnglishTreatInApostropheAsIng { get; set; } = true;
     public bool WriteToolsLog { get; set; } = false;
 

--- a/tests/UI/Logic/Config/AutoBreakSettingsTests.cs
+++ b/tests/UI/Logic/Config/AutoBreakSettingsTests.cs
@@ -1,0 +1,57 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Settings;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Logic.Config;
+
+public class AutoBreakSettingsTests
+{
+    [Fact]
+    public void SeToolsAutoBreakDefaults_MatchLibSeToolsSettings()
+    {
+        var seTools = new SeTools();
+        var libSeTools = new ToolsSettings();
+
+        Assert.Equal(libSeTools.AutoBreakLineEndingEarly, seTools.AutoBreakLineEndingEarly);
+        Assert.Equal(libSeTools.AutoBreakCommaBreakEarly, seTools.AutoBreakCommaBreakEarly);
+        Assert.Equal(libSeTools.AutoBreakDashEarly, seTools.AutoBreakDashEarly);
+        Assert.Equal(libSeTools.AutoBreakUsePixelWidth, seTools.AutoBreakUsePixelWidth);
+        Assert.Equal(libSeTools.AutoBreakPreferBottomHeavy, seTools.AutoBreakPreferBottomHeavy);
+        Assert.Equal(libSeTools.AutoBreakPreferBottomPercent, seTools.AutoBreakPreferBottomPercent);
+        Assert.Equal(libSeTools.UseNoLineBreakAfter, seTools.UseNoLineBreakAfter);
+    }
+
+    [Fact]
+    public void UpdateLibSeSettings_CopiesAutoBreakSettings()
+    {
+        var savedSettings = Se.Settings;
+        var savedTools = Configuration.Settings.Tools;
+        try
+        {
+            Configuration.Settings.Tools = new ToolsSettings();
+            Se.Settings = new Se();
+            Se.Settings.Tools.AutoBreakLineEndingEarly = true;
+            Se.Settings.Tools.AutoBreakCommaBreakEarly = true;
+            Se.Settings.Tools.AutoBreakDashEarly = false;
+            Se.Settings.Tools.AutoBreakUsePixelWidth = false;
+            Se.Settings.Tools.AutoBreakPreferBottomHeavy = false;
+            Se.Settings.Tools.AutoBreakPreferBottomPercent = 12;
+            Se.Settings.Tools.UseNoLineBreakAfter = true;
+
+            Se.UpdateLibSeSettings();
+
+            Assert.True(Configuration.Settings.Tools.AutoBreakLineEndingEarly);
+            Assert.True(Configuration.Settings.Tools.AutoBreakCommaBreakEarly);
+            Assert.False(Configuration.Settings.Tools.AutoBreakDashEarly);
+            Assert.False(Configuration.Settings.Tools.AutoBreakUsePixelWidth);
+            Assert.False(Configuration.Settings.Tools.AutoBreakPreferBottomHeavy);
+            Assert.Equal(12, Configuration.Settings.Tools.AutoBreakPreferBottomPercent);
+            Assert.True(Configuration.Settings.Tools.UseNoLineBreakAfter);
+        }
+        finally
+        {
+            Se.Settings = savedSettings;
+            Configuration.Settings.Tools = savedTools;
+        }
+    }
+}


### PR DESCRIPTION
Part 1 of 2 for #13310 (remaining SE4 auto-br configuration, follow-up to #12934). Part 2 (the do-not-break-after list editor dialog) will follow stacked on this branch.

### What's added

- **"Use do-not-break-after list" checkbox** in Settings → Tools, wired to libse's existing `UseNoLineBreakAfter`. The engine support (and the 33 `*_NoBreakAfterList.xml` dictionaries shipped in Dictionaries.zip) were already in place — but the setting was never synced from SE5's config, so the feature was permanently off.
- **Bottom-heavy percentage** (0–50, default 5) next to the existing "prefer bottom heavy" checkbox, wired to libse's `AutoBreakPreferBottomPercent`, which was previously locked to its default.
- Both bottom-heavy controls are now **enabled only when "break by pixel width" is on**, matching SE4 and the engine gate in `TextSplit` (bottom-heavy is only applied in pixel-width mode).

### Language wire-up

The no-break list is selected per language (`en` → `en_NoBreakAfterList.xml`), but several SE5 call sites used the language-less `AutoBreakLine` overload, which would make the new checkbox a silent no-op there:

- The main **auto-break command** and the two-line normalize/join helpers (move word up/down) now use a cached detected language — the existing `_autoTrimLanguageCode` cache generalized to `_detectedLanguageCode` (same invalidation points: file load/new, translation).
- **OCR auto-break** derives the language from the selected spell check dictionary (memoized, since it runs once per OCR'ed line).

Detection stays out of per-line loops per the known `AutoDetectGoogleLanguage` perf constraint.

### Tests

`AutoBreakSettingsTests`: defaults parity between `SeTools` and libse `ToolsSettings` for all seven auto-br fields, and the `UpdateLibSeSettings` sync (made internal for the test, like `MigrateMacOsFontSettings`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)