### PR TITLE
Fix #13309: option to add language code to batch speech-to-text file names

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -57,6 +57,7 @@ public partial class SpeechToTextViewModel : ObservableObject
     [ObservableProperty] private bool _doTranslateToEnglish;
     [ObservableProperty] private bool _doAdjustTimings;
     [ObservableProperty] private bool _doPostProcessing;
+    [ObservableProperty] private bool _addLanguageCodeToFileName;
 
     [ObservableProperty] private string _parameters;
 
@@ -311,6 +312,7 @@ public partial class SpeechToTextViewModel : ObservableObject
         DoTranslateToEnglish = false;
         DoAdjustTimings = Se.Settings.Tools.AudioToText.WhisperAutoAdjustTimings;
         DoPostProcessing = Se.Settings.Tools.AudioToText.PostProcessing;
+        AddLanguageCodeToFileName = Se.Settings.Tools.AudioToText.WhisperAddLanguageCodeToFileName;
 
         OpenAiCompatibleSttUrl = Se.Settings.Tools.OpenAiCompatibleSttUrl;
         OpenAiCompatibleSttApiKey = Se.Settings.Tools.OpenAiCompatibleSttApiKey;
@@ -368,6 +370,7 @@ public partial class SpeechToTextViewModel : ObservableObject
     {
         Se.Settings.Tools.AudioToText.WhisperAutoAdjustTimings = DoAdjustTimings;
         Se.Settings.Tools.AudioToText.PostProcessing = DoPostProcessing;
+        Se.Settings.Tools.AudioToText.WhisperAddLanguageCodeToFileName = AddLanguageCodeToFileName;
         var engine = GetEffectiveSelectedEngine();
         engine.CommandLineParameter = Parameters;
         Se.Settings.Tools.AudioToText.WhisperChoice = engine.Choice;
@@ -1744,7 +1747,8 @@ public partial class SpeechToTextViewModel : ObservableObject
         if (transcribedSubtitle != null && transcribedSubtitle.Paragraphs.Count > 0)
         {
             currentItem.Status = Se.Language.General.Converted;
-            var subtitleFileName = GetSubtitleFileName(currentItem.InputVideoFileName);
+            var languageCode = AddLanguageCodeToFileName ? GetFileNameLanguageCode(transcribedSubtitle) : null;
+            var subtitleFileName = GetSubtitleFileName(currentItem.InputVideoFileName, languageCode);
             var format = new SubRip();
             var text = format.ToText(transcribedSubtitle, string.Empty);
             File.WriteAllText(subtitleFileName, text);
@@ -1836,20 +1840,56 @@ public partial class SpeechToTextViewModel : ObservableObject
         });
     }
 
-    private static string GetSubtitleFileName(string videoFileName)
+    public static string GetSubtitleFileName(string videoFileName, string? languageCode)
     {
         var path = Path.GetDirectoryName(videoFileName);
         var fileName = Path.GetFileNameWithoutExtension(videoFileName);
+        // "video.en.srt" style - the language token must stay right before the
+        // extension for media players to pick it up, so the collision counter
+        // goes on the base name: "video_2.en.srt".
+        var languagePart = string.IsNullOrWhiteSpace(languageCode) ? string.Empty : "." + languageCode;
         var extension = ".srt";
-        var subtitleFileName = Path.Combine(path!, fileName + extension);
+        var subtitleFileName = Path.Combine(path!, fileName + languagePart + extension);
         int count = 2;
         while (File.Exists(subtitleFileName))
         {
-            subtitleFileName = Path.Combine(path!, fileName + "_" + count + extension);
+            subtitleFileName = Path.Combine(path!, fileName + "_" + count + languagePart + extension);
             count++;
         }
 
         return subtitleFileName;
+    }
+
+    /// <summary>
+    /// The language code to embed in a generated subtitle file name ("video.en.srt"),
+    /// or null when no usable code can be determined. Resolution mirrors PostProcess:
+    /// selected language, then the online engine's configured hint, then auto-detection
+    /// on the transcript itself - but "auto" is never usable as a file name token.
+    /// </summary>
+    private string? GetFileNameLanguageCode(Subtitle? transcript)
+    {
+        if (DoTranslateToEnglish)
+        {
+            return "en";
+        }
+
+        var languageCode = SelectedLanguage?.Code;
+        if (string.IsNullOrWhiteSpace(languageCode) || languageCode.Equals("auto", StringComparison.OrdinalIgnoreCase))
+        {
+            languageCode = GetOnlineEngineLanguageHint();
+        }
+
+        if (string.IsNullOrWhiteSpace(languageCode) && transcript != null)
+        {
+            languageCode = LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(transcript);
+        }
+
+        if (string.IsNullOrWhiteSpace(languageCode) || languageCode.Equals("auto", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return languageCode;
     }
 
     private Subtitle PostProcess(Subtitle transcript)

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -562,6 +562,14 @@ public class SpeechToTextWindow : Window
         var buttonRemove = UiUtil.MakeButton(Se.Language.General.Remove, vm.RemoveCommand).BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled));
         var buttonClear = UiUtil.MakeButton(Se.Language.General.Clear, vm.ClearCommand).BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled));
 
+        var checkAddLanguageCode = UiUtil.MakeCheckBox(Se.Language.Video.AudioToText.AddLanguageCodeToFileName, vm, nameof(vm.AddLanguageCodeToFileName))
+            .BindIsEnabled(vm, nameof(vm.IsTranscribeEnabled));
+        checkAddLanguageCode.Margin = new Thickness(10, 0, 0, 0);
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            ToolTip.SetTip(checkAddLanguageCode, Se.Language.Video.AudioToText.AddLanguageCodeToFileNameHint);
+        }
+
         var panelFileControls = new StackPanel
         {
             Orientation = Orientation.Horizontal,
@@ -572,6 +580,7 @@ public class SpeechToTextWindow : Window
                 buttonAdd,
                 buttonRemove,
                 buttonClear,
+                checkAddLanguageCode,
             }
         };
 

--- a/src/ui/Logic/Config/Language/Video/LanguageAudioToText.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageAudioToText.cs
@@ -36,6 +36,8 @@ public class LanguageAudioToText
     public string EngineSettings { get; set; }
     public string EngineSettingsSubtitle { get; set; }
     public string BackendAndUpdateStatus { get; set; }
+    public string AddLanguageCodeToFileName { get; set; }
+    public string AddLanguageCodeToFileNameHint { get; set; }
 
     public LanguageAudioToText()
     {
@@ -73,5 +75,7 @@ public class LanguageAudioToText
         EngineSettings = "Speech-to-text engine settings";
         EngineSettingsSubtitle = "Speech-to-text engine";
         BackendAndUpdateStatus = "Backend and update status";
+        AddLanguageCodeToFileName = "Add language code to file name";
+        AddLanguageCodeToFileNameHint = "Name generated subtitles like \"video.en.srt\" instead of \"video.srt\"";
     }
 }

--- a/src/ui/Logic/Config/SeAudioToText.cs
+++ b/src/ui/Logic/Config/SeAudioToText.cs
@@ -15,6 +15,8 @@ public class SeAudioToText
 
     public bool WhisperDeleteTempFiles { get; set; } = true;
 
+    public bool WhisperAddLanguageCodeToFileName { get; set; }
+
     public string? WhisperModel { get; set; } = string.Empty;
 
     public string WhisperLanguageCode { get; set; } = string.Empty;

--- a/tests/UI/Features/Video/SpeechToText/SpeechToTextSubtitleFileNameTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/SpeechToTextSubtitleFileNameTests.cs
@@ -1,0 +1,68 @@
+using Nikse.SubtitleEdit.Features.Video.SpeechToText;
+
+namespace UITests.Features.Video.SpeechToText;
+
+public class SpeechToTextSubtitleFileNameTests : IDisposable
+{
+    private readonly string _folder;
+
+    public SpeechToTextSubtitleFileNameTests()
+    {
+        _folder = Path.Combine(Path.GetTempPath(), "se-stt-name-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_folder);
+    }
+
+    public void Dispose()
+    {
+        Directory.Delete(_folder, true);
+    }
+
+    private string Video(string name) => Path.Combine(_folder, name);
+
+    [Fact]
+    public void NoLanguageCode_UsesVideoName()
+    {
+        var result = SpeechToTextViewModel.GetSubtitleFileName(Video("My Video.mkv"), null);
+
+        Assert.Equal(Video("My Video.srt"), result);
+    }
+
+    [Fact]
+    public void LanguageCode_IsInsertedBeforeExtension()
+    {
+        var result = SpeechToTextViewModel.GetSubtitleFileName(Video("My Video.mkv"), "fr");
+
+        Assert.Equal(Video("My Video.fr.srt"), result);
+    }
+
+    [Fact]
+    public void EmptyLanguageCode_UsesVideoName()
+    {
+        var result = SpeechToTextViewModel.GetSubtitleFileName(Video("My Video.mkv"), string.Empty);
+
+        Assert.Equal(Video("My Video.srt"), result);
+    }
+
+    [Fact]
+    public void ExistingFile_GetsCounter()
+    {
+        File.WriteAllText(Video("My Video.srt"), string.Empty);
+
+        var result = SpeechToTextViewModel.GetSubtitleFileName(Video("My Video.mkv"), null);
+
+        Assert.Equal(Video("My Video_2.srt"), result);
+    }
+
+    [Fact]
+    public void ExistingFileWithLanguageCode_CounterKeepsLanguageTokenBeforeExtension()
+    {
+        // "My Video.fr_2.srt" would break media player language detection - the
+        // counter must go on the base name: "My Video_2.fr.srt".
+        File.WriteAllText(Video("My Video.fr.srt"), string.Empty);
+        File.WriteAllText(Video("My Video_2.fr.srt"), string.Empty);
+
+        var result = SpeechToTextViewModel.GetSubtitleFileName(Video("My Video.mkv"), "fr");
+
+        Assert.Equal(Video("My Video_3.fr.srt"), result);
+    }
+}


### PR DESCRIPTION
Fixes #13309.

Adds an opt-in **"Add language code to file name"** checkbox to the speech-to-text batch panel (next to Add/Remove/Clear). When enabled, batch-generated subtitles are named `video.en.srt` instead of `video.srt` — the `name.lang.ext` convention media players (Plex/Jellyfin/Kodi/VLC) use for language detection, and handy for keeping batch output apart per language.

### How the code is resolved
Mirrors the existing `PostProcess` fallback chain:
1. Selected input language (skipped when it is "Auto detect")
2. The online engine's configured language hint
3. `LanguageAutoDetect.AutoDetectGoogleLanguageOrNull` on the transcript

"Translate to English" always yields `en`, and `auto` is never used as a filename token — if nothing usable resolves, the name falls back to today's suffix-free form.

### Details
- Setting persisted as `SeAudioToText.WhisperAddLanguageCodeToFileName` (default off, so existing batch workflows are unchanged)
- Collision counter goes on the base name (`video_2.en.srt`) so the language token stays right before the extension
- Tooltip guarded by ShowHints; strings added to `LanguageAudioToText` (English.json left for the normal regeneration flow)
- 5 new unit tests for the filename builder (`SpeechToTextSubtitleFileNameTests`), all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)