### PR TITLE
Add do-not-break-after list editor dialog (#13310, part 2)

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -45,6 +45,7 @@ using Nikse.SubtitleEdit.Features.Ocr.Download;
 using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
 using Nikse.SubtitleEdit.Features.Ocr.NOcr;
 using Nikse.SubtitleEdit.Features.Ocr.VobSubColorChooser;
+using Nikse.SubtitleEdit.Features.Options.DoNotBreakAfterList;
 using Nikse.SubtitleEdit.Features.Options.Language;
 using Nikse.SubtitleEdit.Features.Options.Plugins;
 using Nikse.SubtitleEdit.Features.Options.Settings;
@@ -472,6 +473,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<PickOllamaModelViewModel>();
         collection.AddTransient<PickRuleProfileViewModel>();
         collection.AddTransient<PickLanguageViewModel>();
+        collection.AddTransient<DoNotBreakAfterListViewModel>();
         collection.AddTransient<PickSpellCheckDictionaryViewModel>();
         collection.AddTransient<PickSubtitleFormatViewModel>();
         collection.AddTransient<PickTsTrackViewModel>();

--- a/src/ui/Features/Options/DoNotBreakAfterList/DoNotBreakAfterListViewModel.cs
+++ b/src/ui/Features/Options/DoNotBreakAfterList/DoNotBreakAfterListViewModel.cs
@@ -1,0 +1,296 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Shared.PickLanguage;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace Nikse.SubtitleEdit.Features.Options.DoNotBreakAfterList;
+
+public partial class DoNotBreakAfterListViewModel : ObservableObject
+{
+    [ObservableProperty] private ObservableCollection<DoNotBreakLanguageItem> _languages;
+    [ObservableProperty] private DoNotBreakLanguageItem? _selectedLanguage;
+    [ObservableProperty] private ObservableCollection<NoBreakAfterListItem> _items;
+    [ObservableProperty] private NoBreakAfterListItem? _selectedItem;
+    [ObservableProperty] private string _newItemText;
+    [ObservableProperty] private bool _isTextItem;
+    [ObservableProperty] private bool _isRegexItem;
+
+    public Window? Window { get; set; }
+
+    private readonly IWindowService _windowService;
+
+    public DoNotBreakAfterListViewModel(IWindowService windowService)
+    {
+        _windowService = windowService;
+
+        Languages = new ObservableCollection<DoNotBreakLanguageItem>();
+        Items = new ObservableCollection<NoBreakAfterListItem>();
+        NewItemText = string.Empty;
+        IsTextItem = true;
+
+        InitLanguages(null);
+    }
+
+    private void InitLanguages(string? selectTwoLetterCode)
+    {
+        var languages = new List<DoNotBreakLanguageItem>();
+        if (Directory.Exists(Se.DictionariesFolder))
+        {
+            var cultures = CultureInfo.GetCultures(CultureTypes.NeutralCultures);
+            foreach (var fileName in Directory.GetFiles(Se.DictionariesFolder, "*_NoBreakAfterList.xml"))
+            {
+                try
+                {
+                    var name = Path.GetFileName(fileName);
+                    var languageId = name.Substring(0, name.IndexOf('_'));
+                    var ci = cultures.FirstOrDefault(p => p.TwoLetterISOLanguageName == languageId)
+                             ?? CultureInfo.GetCultureInfoByIetfLanguageTag(languageId);
+                    var displayName = ci.EnglishName + " (" + ci.NativeName.CapitalizeFirstLetter() + ")";
+                    languages.Add(new DoNotBreakLanguageItem(displayName, ci.TwoLetterISOLanguageName, fileName));
+                }
+                catch
+                {
+                    // a file name that does not map to a culture is not editable by language - skip it
+                }
+            }
+        }
+
+        Languages.Clear();
+        Languages.AddRange(languages.OrderBy(p => p.DisplayName, StringComparer.OrdinalIgnoreCase));
+
+        SelectedLanguage =
+            Languages.FirstOrDefault(p => p.TwoLetterCode == selectTwoLetterCode) ??
+            Languages.FirstOrDefault(p => p.TwoLetterCode == "en") ??
+            Languages.FirstOrDefault();
+    }
+
+    internal void SelectedLanguageChanged()
+    {
+        Items.Clear();
+        SelectedItem = null;
+
+        var language = SelectedLanguage;
+        if (language == null)
+        {
+            return;
+        }
+
+        Items.AddRange(LoadItems(language.FileName));
+    }
+
+    private static List<NoBreakAfterListItem> LoadItems(string fileName)
+    {
+        var items = new List<NoBreakAfterListItem>();
+        try
+        {
+            var doc = new XmlDocument();
+            doc.Load(fileName);
+            foreach (XmlNode node in doc.DocumentElement!.SelectNodes("Item")!)
+            {
+                if (!string.IsNullOrEmpty(node.InnerText))
+                {
+                    var isRegex = node.Attributes?["RegEx"] != null &&
+                                  node.Attributes["RegEx"]!.InnerText.Equals("true", StringComparison.OrdinalIgnoreCase);
+                    items.Add(new NoBreakAfterListItem(node.InnerText, isRegex));
+                }
+            }
+        }
+        catch
+        {
+            // an unreadable list shows as empty; saving a new item will rewrite the file
+        }
+
+        return items.OrderBy(p => p.Text, StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    private bool SaveItems(string fileName, IEnumerable<NoBreakAfterListItem> items)
+    {
+        try
+        {
+            var doc = new XmlDocument();
+            doc.LoadXml("<NoBreakAfterList />");
+            foreach (var item in items)
+            {
+                XmlNode node = doc.CreateElement("Item");
+                node.InnerText = item.Text;
+                if (item.IsRegex)
+                {
+                    var attribute = doc.CreateAttribute("RegEx");
+                    attribute.InnerText = true.ToString();
+                    node.Attributes!.Append(attribute);
+                }
+
+                doc.DocumentElement!.AppendChild(node);
+            }
+
+            doc.Save(fileName);
+            Utilities.ResetNoBreakAfterList(); // the break engine caches the active list per language
+            return true;
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, $"Failed to save no-break-after list to '{fileName}'");
+            return false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task AddItem()
+    {
+        var text = NewItemText.Trim();
+        var language = SelectedLanguage;
+        if (string.IsNullOrEmpty(text) || language == null || Window == null)
+        {
+            return;
+        }
+
+        if (IsRegexItem && !RegexUtils.IsValidRegex(text))
+        {
+            await MessageBox.Show(Window, Se.Language.General.Error, Se.Language.SourceView.InvalidRegularExpression, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return;
+        }
+
+        var existing = Items.FirstOrDefault(p => p.Text == text && p.IsRegex == IsRegexItem);
+        if (existing != null)
+        {
+            SelectedItem = existing;
+            return;
+        }
+
+        var item = new NoBreakAfterListItem(text, IsRegexItem);
+        if (!SaveItems(language.FileName, Items.Append(item)))
+        {
+            await MessageBox.Show(Window, Se.Language.General.Error, Se.Language.Options.WordLists.UnableToAddItem, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return;
+        }
+
+        var insertIndex = 0;
+        while (insertIndex < Items.Count && string.Compare(Items[insertIndex].Text, item.Text, StringComparison.OrdinalIgnoreCase) < 0)
+        {
+            insertIndex++;
+        }
+
+        Items.Insert(insertIndex, item);
+        SelectedItem = item;
+        NewItemText = string.Empty;
+    }
+
+    [RelayCommand]
+    private async Task RemoveItem()
+    {
+        var selected = SelectedItem;
+        var language = SelectedLanguage;
+        if (selected == null || language == null || Window == null)
+        {
+            return;
+        }
+
+        if (!SaveItems(language.FileName, Items.Where(p => p != selected)))
+        {
+            await MessageBox.Show(Window, Se.Language.General.Error, Se.Language.Options.WordLists.UnableToRemoveItem, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return;
+        }
+
+        var idx = Items.IndexOf(selected);
+        Items.Remove(selected);
+
+        if (Items.Count == 0)
+        {
+            SelectedItem = null;
+        }
+        else if (idx >= Items.Count)
+        {
+            SelectedItem = Items[Items.Count - 1];
+        }
+        else
+        {
+            SelectedItem = Items[idx];
+        }
+    }
+
+    [RelayCommand]
+    private async Task NewLanguage()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var existingCodes = Languages.Select(p => p.TwoLetterCode).ToList();
+        var viewModel = await _windowService.ShowDialogAsync<PickLanguageWindow, PickLanguageViewModel>(
+            Window, vm =>
+            {
+                vm.Title = Se.Language.Options.Settings.UseDoNotBreakAfterList;
+                vm.Initialize(existingCodes);
+            });
+
+        if (!viewModel.OkPressed || viewModel.SelectedLanguage == null)
+        {
+            return;
+        }
+
+        var twoLetterCode = viewModel.SelectedLanguage.Code;
+        var fileName = Path.Combine(Se.DictionariesFolder, twoLetterCode + "_NoBreakAfterList.xml");
+        if (!File.Exists(fileName))
+        {
+            var seedItems = new[] { "Dr", "Dr.", "Mr.", "Mrs.", "Ms." }
+                .Select(p => new NoBreakAfterListItem(p, false));
+            if (!SaveItems(fileName, seedItems))
+            {
+                await MessageBox.Show(Window, Se.Language.General.Error, Se.Language.Options.WordLists.UnableToAddItem, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+        }
+
+        InitLanguages(twoLetterCode);
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        Window?.Close();
+    }
+
+    partial void OnSelectedItemChanged(NoBreakAfterListItem? value)
+    {
+        if (value == null)
+        {
+            return;
+        }
+
+        NewItemText = value.Text;
+        IsRegexItem = value.IsRegex;
+        IsTextItem = !value.IsRegex;
+    }
+
+    internal void ItemTextBoxKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter)
+        {
+            e.Handled = true;
+            using var _ = AddItem();
+        }
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Options/DoNotBreakAfterList/DoNotBreakAfterListWindow.cs
+++ b/src/ui/Features/Options/DoNotBreakAfterList/DoNotBreakAfterListWindow.cs
@@ -1,0 +1,112 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Styling;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Options.DoNotBreakAfterList;
+
+public class DoNotBreakAfterListWindow : Window
+{
+    private readonly DoNotBreakAfterListViewModel _vm;
+
+    public DoNotBreakAfterListWindow(DoNotBreakAfterListViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.Options.Settings.UseDoNotBreakAfterList;
+        CanResize = true;
+        Width = 500;
+        Height = 600;
+        MinWidth = 400;
+        MinHeight = 400;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        var labelLanguage = UiUtil.MakeLabel(Se.Language.General.Language);
+        var comboLanguages = UiUtil.MakeComboBox(vm.Languages, vm, nameof(vm.SelectedLanguage));
+        comboLanguages.SelectionChanged += (_, _) => vm.SelectedLanguageChanged();
+        var buttonNewLanguage = UiUtil.MakeButton(Se.Language.General.New, vm.NewLanguageCommand);
+        var panelLanguage = UiUtil.MakeHorizontalPanel(labelLanguage, comboLanguages, buttonNewLanguage);
+
+        var listBoxItems = new ListBox
+        {
+            [!ListBox.ItemsSourceProperty] = new Binding(nameof(vm.Items)) { Mode = BindingMode.OneWay },
+            [!ListBox.SelectedItemProperty] = new Binding(nameof(vm.SelectedItem)) { Mode = BindingMode.TwoWay },
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+        };
+        listBoxItems.Styles.Add(new Style(x => x.OfType<ListBoxItem>())
+        {
+            Setters =
+            {
+                new Setter(ListBoxItem.PaddingProperty, new Thickness(8, 2)),
+                new Setter(ListBoxItem.MarginProperty, new Thickness(1)),
+            }
+        });
+        var listBoxBorder = UiUtil.MakeBorderForControl(listBoxItems);
+
+        var textBoxItem = UiUtil.MakeTextBox(150, vm, nameof(vm.NewItemText));
+        textBoxItem.KeyDown += (_, e) => vm.ItemTextBoxKeyDown(e);
+        var radioText = new RadioButton
+        {
+            Content = Se.Language.General.Text,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!ToggleButton.IsCheckedProperty] = new Binding(nameof(vm.IsTextItem)) { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged },
+        };
+        var radioRegex = new RadioButton
+        {
+            Content = Se.Language.General.RegularExpression,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!ToggleButton.IsCheckedProperty] = new Binding(nameof(vm.IsRegexItem)) { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged },
+        };
+        var buttonAdd = UiUtil.MakeButton(vm.AddItemCommand, IconNames.Plus, Se.Language.General.New);
+        var buttonRemove = UiUtil.MakeButton(vm.RemoveItemCommand, IconNames.Trash, Se.Language.General.Remove);
+        var panelEdit = UiUtil.MakeButtonBar(textBoxItem, radioText, radioRegex, buttonAdd, buttonRemove).WithAlignmentLeft().WithSpacing(4);
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var panelButtons = UiUtil.MakeButtonBar(buttonOk);
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // language
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }, // list
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // add/remove
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // buttons
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            RowSpacing = 10,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        grid.Add(panelLanguage, 0);
+        grid.Add(listBoxBorder, 1);
+        grid.Add(panelEdit, 2);
+        grid.Add(panelButtons, 3);
+
+        Content = grid;
+
+        Activated += delegate { comboLanguages.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        Loaded += (_, _) => vm.SelectedLanguageChanged();
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Options/DoNotBreakAfterList/DoNotBreakLanguageItem.cs
+++ b/src/ui/Features/Options/DoNotBreakAfterList/DoNotBreakLanguageItem.cs
@@ -1,0 +1,20 @@
+namespace Nikse.SubtitleEdit.Features.Options.DoNotBreakAfterList;
+
+public class DoNotBreakLanguageItem
+{
+    public string DisplayName { get; }
+    public string TwoLetterCode { get; }
+    public string FileName { get; }
+
+    public DoNotBreakLanguageItem(string displayName, string twoLetterCode, string fileName)
+    {
+        DisplayName = displayName;
+        TwoLetterCode = twoLetterCode;
+        FileName = fileName;
+    }
+
+    public override string ToString()
+    {
+        return DisplayName;
+    }
+}

--- a/src/ui/Features/Options/DoNotBreakAfterList/NoBreakAfterListItem.cs
+++ b/src/ui/Features/Options/DoNotBreakAfterList/NoBreakAfterListItem.cs
@@ -1,0 +1,18 @@
+namespace Nikse.SubtitleEdit.Features.Options.DoNotBreakAfterList;
+
+public class NoBreakAfterListItem
+{
+    public string Text { get; }
+    public bool IsRegex { get; }
+
+    public NoBreakAfterListItem(string text, bool isRegex)
+    {
+        Text = text;
+        IsRegex = isRegex;
+    }
+
+    public override string ToString()
+    {
+        return Text;
+    }
+}

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -654,7 +654,20 @@ public class SettingsPage : UserControl
                 nud[!Control.IsEnabledProperty] = new Binding(nameof(_vm.AutoBreakUsePixelWidth)) { Source = _vm };
                 return nud;
             }),
-            MakeCheckboxSetting(Se.Language.Options.Settings.UseDoNotBreakAfterList, nameof(_vm.UseNoLineBreakAfter)),
+            new SettingsItem(Se.Language.Options.Settings.UseDoNotBreakAfterList, () => new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing = 10,
+                Children =
+                {
+                    new CheckBox
+                    {
+                        VerticalAlignment = VerticalAlignment.Center,
+                        [!ToggleButton.IsCheckedProperty] = new Binding(nameof(_vm.UseNoLineBreakAfter)) { Source = _vm, Mode = BindingMode.TwoWay },
+                    },
+                    UiUtil.MakeButton(Se.Language.General.Edit, _vm.EditDoNotBreakAfterListCommand),
+                }
+            }),
             new SettingsItem(Se.Language.Options.Settings.SplitOddLinesAction, () => new ComboBox
             {
                 MinWidth = 200,

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -15,6 +15,7 @@ using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Assa;
 using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Options.DoNotBreakAfterList;
 using Nikse.SubtitleEdit.Features.Options.Settings.SyntaxColorTooWideSettings;
 using Nikse.SubtitleEdit.Features.Tools.BeautifyTimeCodes.Profile;
 using Nikse.SubtitleEdit.Features.Options.Settings.WaveformThemes;
@@ -2099,6 +2100,17 @@ public partial class SettingsViewModel : ObservableObject
             ColorTextTooWideFontName = viewModel.SelectedFont;
             ColorTextTooWideFontSize = viewModel.FontSize;
         }
+    }
+
+    [RelayCommand]
+    private async Task EditDoNotBreakAfterList()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        await _windowService.ShowDialogAsync<DoNotBreakAfterListWindow, DoNotBreakAfterListViewModel>(Window);
     }
 
     [RelayCommand]

--- a/src/ui/Features/Shared/PickLanguage/PickLanguageViewModel.cs
+++ b/src/ui/Features/Shared/PickLanguage/PickLanguageViewModel.cs
@@ -21,6 +21,12 @@ public partial class PickLanguageViewModel : ObservableObject
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
 
+    /// <summary>
+    /// Optional window title; the window falls back to the favorite-languages title when unset.
+    /// Set it in the ShowDialogAsync configure action - that runs before the window constructor.
+    /// </summary>
+    public string? Title { get; set; }
+
     private readonly List<PickLanguageDisplay> _all;
 
     public PickLanguageViewModel()

--- a/src/ui/Features/Shared/PickLanguage/PickLanguageWindow.cs
+++ b/src/ui/Features/Shared/PickLanguage/PickLanguageWindow.cs
@@ -13,7 +13,7 @@ public class PickLanguageWindow : Window
     public PickLanguageWindow(PickLanguageViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Options.Settings.FavoriteLanguages;
+        Title = vm.Title ?? Se.Language.Options.Settings.FavoriteLanguages;
         CanResize = true;
         Width = 500;
         Height = 600;

--- a/tests/UI/Features/Options/DoNotBreakAfterListEditTests.cs
+++ b/tests/UI/Features/Options/DoNotBreakAfterListEditTests.cs
@@ -1,0 +1,167 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Features.Options.DoNotBreakAfterList;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml;
+
+namespace UITests.Features.Options;
+
+/// <summary>
+/// Tests for the do-not-break-after list editor (settings, auto-br). The view model reads and
+/// writes the per-language *_NoBreakAfterList.xml files in Se.DictionariesFolder, which is
+/// redirected to a temp folder here.
+/// </summary>
+public class DoNotBreakAfterListEditTests : IDisposable
+{
+    private readonly string _savedDictionariesFolder;
+    private readonly string _tempFolder;
+    private readonly List<Window> _windows = new();
+
+    public DoNotBreakAfterListEditTests()
+    {
+        _savedDictionariesFolder = Se.DictionariesFolder;
+        _tempFolder = Path.Combine(Path.GetTempPath(), "SeTestNoBreak_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempFolder);
+        Se.DictionariesFolder = _tempFolder;
+
+        File.WriteAllText(Path.Combine(_tempFolder, "en_NoBreakAfterList.xml"),
+            "<NoBreakAfterList><Item>Mrs.</Item><Item>Dr.</Item><Item RegEx=\"True\">^\\d+$</Item></NoBreakAfterList>");
+    }
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+            window.Close();
+        }
+
+        _windows.Clear();
+
+        Se.DictionariesFolder = _savedDictionariesFolder;
+        try
+        {
+            Directory.Delete(_tempFolder, true);
+        }
+        catch
+        {
+            // temp cleanup only
+        }
+    }
+
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private DoNotBreakAfterListViewModel BuildViewModel()
+    {
+        return new DoNotBreakAfterListViewModel(new WindowService(new NullServiceProvider()));
+    }
+
+    private DoNotBreakAfterListWindow BuildWindow(DoNotBreakAfterListViewModel vm)
+    {
+        var window = new DoNotBreakAfterListWindow(vm);
+        _windows.Add(window);
+        return window;
+    }
+
+    private string[] ReadSavedItems()
+    {
+        var doc = new XmlDocument();
+        doc.Load(Path.Combine(_tempFolder, "en_NoBreakAfterList.xml"));
+        return doc.DocumentElement!.SelectNodes("Item")!.Cast<XmlNode>().Select(n => n.InnerText).ToArray();
+    }
+
+    [AvaloniaFact]
+    public void LoadsLanguagesAndItems_SortedWithRegexFlag()
+    {
+        var vm = BuildViewModel();
+        vm.SelectedLanguageChanged();
+
+        var language = Assert.Single(vm.Languages);
+        Assert.Equal("en", language.TwoLetterCode);
+        Assert.StartsWith("English", language.DisplayName);
+        Assert.Same(language, vm.SelectedLanguage);
+
+        Assert.Equal(new[] { "Dr.", "Mrs.", "^\\d+$" }, vm.Items.Select(p => p.Text));
+        Assert.True(vm.Items[2].IsRegex);
+        Assert.False(vm.Items[0].IsRegex);
+    }
+
+    [AvaloniaFact]
+    public void AddItem_InsertsSortedAndSavesFile()
+    {
+        var vm = BuildViewModel();
+        BuildWindow(vm); // sets vm.Window, required by the add/remove commands
+        vm.SelectedLanguageChanged();
+
+        vm.NewItemText = "Prof.";
+        vm.AddItemCommand.Execute(null);
+
+        Assert.Equal(new[] { "Dr.", "Mrs.", "Prof.", "^\\d+$" }, vm.Items.Select(p => p.Text));
+        Assert.Equal("Prof.", vm.SelectedItem?.Text);
+        Assert.Contains("Prof.", ReadSavedItems());
+
+        // A fresh view model sees the saved item, including the kept regex flag.
+        var vm2 = BuildViewModel();
+        vm2.SelectedLanguageChanged();
+        Assert.Contains(vm2.Items, p => p.Text == "Prof." && !p.IsRegex);
+        Assert.Contains(vm2.Items, p => p.Text == "^\\d+$" && p.IsRegex);
+    }
+
+    [AvaloniaFact]
+    public void AddItem_DuplicateIsNotAddedTwice()
+    {
+        var vm = BuildViewModel();
+        BuildWindow(vm);
+        vm.SelectedLanguageChanged();
+
+        vm.NewItemText = "Dr.";
+        vm.AddItemCommand.Execute(null);
+
+        Assert.Single(vm.Items, p => p.Text == "Dr.");
+        Assert.Equal("Dr.", vm.SelectedItem?.Text);
+    }
+
+    [AvaloniaFact]
+    public void RemoveItem_RemovesAndSavesFile()
+    {
+        var vm = BuildViewModel();
+        BuildWindow(vm);
+        vm.SelectedLanguageChanged();
+
+        vm.SelectedItem = vm.Items.First(p => p.Text == "Dr.");
+        vm.RemoveItemCommand.Execute(null);
+
+        Assert.DoesNotContain(vm.Items, p => p.Text == "Dr.");
+        Assert.DoesNotContain("Dr.", ReadSavedItems());
+        Assert.NotNull(vm.SelectedItem); // selection moves to a neighbor
+    }
+
+    [AvaloniaFact]
+    public void SelectingItem_ShowsTextAndKind()
+    {
+        var vm = BuildViewModel();
+        vm.SelectedLanguageChanged();
+
+        vm.SelectedItem = vm.Items.First(p => p.IsRegex);
+
+        Assert.Equal("^\\d+$", vm.NewItemText);
+        Assert.True(vm.IsRegexItem);
+        Assert.False(vm.IsTextItem);
+    }
+
+    [AvaloniaFact]
+    public void Window_Constructs()
+    {
+        var vm = BuildViewModel();
+        var window = BuildWindow(vm);
+
+        Assert.NotNull(window.Content);
+    }
+}


### PR DESCRIPTION
Part 2 of 2 for #13310, stacked on #13312 (merge that first — this PR's base is its branch, and GitHub will retarget to main when it merges).

Ports SE4's `DoNotBreakAfterListEdit` to SE5:

### The dialog

Opened from Settings → Tools via an **Edit** button next to the "Use do-not-break-after list" checkbox (added in part 1):

- Language combo built from the `*_NoBreakAfterList.xml` files in the dictionaries folder, shown as "EnglishName (NativeName)" like SE4.
- Item list plus add/remove with a text-vs-regular-expression radio choice; selecting an item shows its text and kind.
- **New** creates a seeded list (`Dr`, `Dr.`, `Mr.`, `Mrs.`, `Ms.` — SE4's seed) for a language chosen in the existing `PickLanguageWindow`, which gained an optional title override for reuse outside the favorite-languages context.

### Behavior notes

- Add/remove **saves immediately** (like the SE5 word lists editor) rather than SE4's save-on-OK — this also avoids SE4's disabled-combo-after-edit quirk. Each save calls `Utilities.ResetNoBreakAfterList()` so the break engine's per-language cache picks the edit up right away.
- Invalid regex and save failures show a message box; adding a duplicate just selects the existing item.

### Tests

Six headless tests (`DoNotBreakAfterListEditTests`) redirect `Se.DictionariesFolder` to a temp folder and cover language/item loading with regex-flag parsing, sorted insert with file round-trip, duplicate handling, remove, selection sync, and window construction.

### Known limitation (pre-existing, worth a follow-up)

`DictionaryInitializer` re-extracts Dictionaries.zip on every version upgrade, so user edits to *shipped* lists (e.g. `en_NoBreakAfterList.xml`) are overwritten on upgrade; lists created for languages the zip doesn't ship survive until the zip ships one. SE4 had no such re-extraction. Possible fixes (user overlay file, or skipping user-modified files during extraction) affect more than this dialog, so they're left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)