### PR TITLE
Fix stuck .xdp- temp file names when saving via the Flatpak document portal

### DIFF
--- a/installer/flatpak/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/dk.nikse.subtitleedit.yaml
@@ -23,6 +23,14 @@ finish-args:
   - --device=dri
   # File access (subtitle files are typically in the home directory)
   - --filesystem=home
+  # Mounted drives and network shares (NAS/SMB is a common place for video files).
+  # Direct access avoids the document portal, whose single-file grants strand files
+  # saved with an auto-appended extension as hidden ".xdp-*" temp files (issue #13308)
+  # and add FUSE overhead to video playback.
+  - --filesystem=/mnt
+  - --filesystem=/media
+  - --filesystem=/run/media
+  - --filesystem=xdg-run/gvfs
   # Network (optional online services: translation, TTS, speech-to-text, etc.)
   - --share=network
   # Audio (video playback via mpv)

--- a/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
@@ -23,6 +23,14 @@ finish-args:
   - --device=dri
   # File access (subtitle files are typically in the home directory)
   - --filesystem=home
+  # Mounted drives and network shares (NAS/SMB is a common place for video files).
+  # Direct access avoids the document portal, whose single-file grants strand files
+  # saved with an auto-appended extension as hidden ".xdp-*" temp files (issue #13308)
+  # and add FUSE overhead to video playback.
+  - --filesystem=/mnt
+  - --filesystem=/media
+  - --filesystem=/run/media
+  - --filesystem=xdg-run/gvfs
   # Network (optional online services: translation, TTS, speech-to-text, etc.)
   - --share=network
   # Audio (video playback via mpv)

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -197,6 +197,8 @@ public partial class SpeechToTextViewModel : ObservableObject
 
     private readonly IWindowService _windowService;
     private readonly IFileHelper _fileHelper;
+    private readonly IFolderHelper _folderHelper;
+    private string? _batchOutputFolder;
     private bool _isUpdatingWhisperCppBackend;
     private bool _isUpdatingCrispAsrBackend;
     private static bool _crispAsrUpdatePromptShown;
@@ -211,10 +213,11 @@ public partial class SpeechToTextViewModel : ObservableObject
     /// </summary>
     public Action? RefreshEngineCombo { get; set; }
 
-    public SpeechToTextViewModel(IWindowService windowService, IFileHelper fileHelper)
+    public SpeechToTextViewModel(IWindowService windowService, IFileHelper fileHelper, IFolderHelper folderHelper)
     {
         _windowService = windowService;
         _fileHelper = fileHelper;
+        _folderHelper = folderHelper;
 
         Engines = [new WhisperCppEngine()];
         if (OperatingSystem.IsWindows())
@@ -1748,7 +1751,7 @@ public partial class SpeechToTextViewModel : ObservableObject
         {
             currentItem.Status = Se.Language.General.Converted;
             var languageCode = AddLanguageCodeToFileName ? GetFileNameLanguageCode(transcribedSubtitle) : null;
-            var subtitleFileName = GetSubtitleFileName(currentItem.InputVideoFileName, languageCode);
+            var subtitleFileName = GetSubtitleFileName(currentItem.InputVideoFileName, languageCode, _batchOutputFolder);
             var format = new SubRip();
             var text = format.ToText(transcribedSubtitle, string.Empty);
             File.WriteAllText(subtitleFileName, text);
@@ -1840,9 +1843,13 @@ public partial class SpeechToTextViewModel : ObservableObject
         });
     }
 
-    public static string GetSubtitleFileName(string videoFileName, string? languageCode)
+    public static string GetSubtitleFileName(string videoFileName, string? languageCode, string? outputFolder = null)
     {
-        var path = Path.GetDirectoryName(videoFileName);
+        // For document portal video paths the output goes to the folder picked in
+        // Transcribe() - only the granted video file name itself can exist in such a folder.
+        var path = !string.IsNullOrEmpty(outputFolder) && DocumentPortal.IsPortalPath(videoFileName)
+            ? outputFolder
+            : Path.GetDirectoryName(videoFileName);
         var fileName = Path.GetFileNameWithoutExtension(videoFileName);
         // "video.en.srt" style - the language token must stay right before the
         // extension for media players to pick it up, so the collision counter
@@ -3062,6 +3069,21 @@ public partial class SpeechToTextViewModel : ObservableObject
         if (IsBatchMode && BatchItems.Count > 0)
         {
             _videoFileName = BatchItems[0].InputVideoFileName;
+
+            if (string.IsNullOrEmpty(_batchOutputFolder) &&
+                BatchItems.Any(b => DocumentPortal.IsPortalPath(b.InputVideoFileName)))
+            {
+                // Videos opened through the Flatpak document portal live in a single-file
+                // grant where a sibling .srt can never materialize as a real file (issue
+                // #13308), so ask for a real output folder before transcribing.
+                var folder = await _folderHelper.PickFolderAsync(Window!, Se.Language.General.PickOutputFolder);
+                if (string.IsNullOrEmpty(folder))
+                {
+                    return;
+                }
+
+                _batchOutputFolder = folder;
+            }
         }
 
         if (string.IsNullOrEmpty(_videoFileName))

--- a/src/ui/Logic/DocumentPortal.cs
+++ b/src/ui/Logic/DocumentPortal.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Detection for the xdg document portal used by sandboxed (Flatpak) builds on Linux.
+/// When a file dialog targets a folder the sandbox cannot access directly (e.g. an SMB
+/// share with only --filesystem=home granted), the portal grants access to exactly one
+/// file name - the name confirmed in the dialog - exposed through a FUSE mount under
+/// $XDG_RUNTIME_DIR/doc/. Writing any other name into that granted folder leaves a
+/// hidden ".xdp-&lt;name&gt;-&lt;random&gt;" temp file on the real file system, so a file
+/// extension appended after the dialog has closed can never materialize (issue #13308).
+/// </summary>
+public static class DocumentPortal
+{
+    /// <summary>
+    /// True when running inside a Flatpak sandbox, where file dialogs may hand out
+    /// document portal paths.
+    /// </summary>
+    public static bool IsSandboxed { get; } = OperatingSystem.IsLinux() && File.Exists("/.flatpak-info");
+
+    /// <summary>
+    /// True when the path goes through the document portal FUSE mount, i.e. writes are
+    /// restricted to the single file name granted by the portal dialog.
+    /// </summary>
+    public static bool IsPortalPath(string? path)
+    {
+        if (!IsSandboxed || string.IsNullOrEmpty(path))
+        {
+            return false;
+        }
+
+        return IsPortalPath(path, Environment.GetEnvironmentVariable("XDG_RUNTIME_DIR"));
+    }
+
+    internal static bool IsPortalPath(string path, string? runtimeDir)
+    {
+        if (!string.IsNullOrEmpty(runtimeDir) &&
+            path.StartsWith(runtimeDir.TrimEnd('/') + "/doc/", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        // XDG_RUNTIME_DIR is practically always /run/user/<uid>, so pattern-match that
+        // layout as a fallback for when the environment variable is not set.
+        var parts = path.Split('/');
+        return parts.Length > 5 && parts[0].Length == 0 && parts[1] == "run" && parts[2] == "user" && parts[4] == "doc";
+    }
+}

--- a/src/ui/Logic/Media/FileHelper.cs
+++ b/src/ui/Logic/Media/FileHelper.cs
@@ -260,23 +260,30 @@ namespace Nikse.SubtitleEdit.Logic.Media
             var options = new FilePickerSaveOptions
             {
                 Title = title,
-                SuggestedFileName = Path.GetFileName(suggestedFileName),
+                SuggestedFileName = MakePortalSafeSuggestedFileName(suggestedFileName, currentFormat.Extension),
                 FileTypeChoices = MakeSaveFilePickerFileTypes(currentFormat),
                 DefaultExtension = currentFormat.Extension.TrimStart('.')
             };
 
             await SetSuggestedStartLocation(topLevel, options, suggestedFileName);
 
-            var file = await NativePickers.SaveFilePickerAsync(topLevel, options);
-
-            if (file != null)
+            for (var attempt = 0; ; attempt++)
             {
-                return file.Path.LocalPath;
-            }
+                var file = await NativePickers.SaveFilePickerAsync(topLevel, options);
+                if (file == null)
+                {
+                    return string.Empty;
+                }
 
-            return string.Empty;
+                var fileName = file.Path.LocalPath;
+                if (attempt >= MaxPortalNameRetries ||
+                    !NeedsPortalGrantedName(fileName, options, AddDefaultExtension(Path.GetFileName(fileName), currentFormat.Extension)))
+                {
+                    return fileName;
+                }
+            }
         }
-        
+
         public async Task<FileHelperSubtitleSavePickerResult?> PickSaveSubtitleFileAs(
             Visual sender,
             SubtitleFormat currentFormat,
@@ -290,29 +297,105 @@ namespace Nikse.SubtitleEdit.Logic.Media
             var options = new FilePickerSaveOptions
             {
                 Title = title,
-                SuggestedFileName = Path.GetFileName(suggestedFileName),
+                // Pre-fill with the same extension rule the result goes through below
+                // (AddMissingExtension), so under the document portal the granted name is
+                // final-safe when the user keeps the suggestion (see NeedsPortalGrantedName).
+                SuggestedFileName = DocumentPortal.IsSandboxed
+                    ? AddMissingExtension(Path.GetFileName(suggestedFileName), currentFormat.Extension)
+                    : Path.GetFileName(suggestedFileName),
                 FileTypeChoices = filePickerFileTypes,
                 SuggestedFileType = defaultChoice,
             };
 
             await SetSuggestedStartLocation(topLevel, options, suggestedFileName);
 
-            // Use SaveFilePickerWithResultAsync instead of SaveFilePickerAsync
-            var result = await topLevel.StorageProvider.SaveFilePickerWithResultAsync(options);
-
-            if (result.File == null)
+            for (var attempt = 0; ; attempt++)
             {
-                return null;
+                // Use SaveFilePickerWithResultAsync instead of SaveFilePickerAsync
+                var result = await topLevel.StorageProvider.SaveFilePickerWithResultAsync(options);
+
+                if (result.File == null)
+                {
+                    return null;
+                }
+
+                var subtitleFormat = SubtitleFormat.AllSubtitleFormats
+                    .FirstOrDefault(f => result.SelectedFileType?.Name == f.Name) ?? currentFormat;
+
+                var fileName = AddMissingExtension(result.File.Path.LocalPath, subtitleFormat.Extension);
+                if (attempt < MaxPortalNameRetries &&
+                    NeedsPortalGrantedName(result.File.Path.LocalPath, options, Path.GetFileName(fileName)))
+                {
+                    if (result.SelectedFileType != null)
+                    {
+                        options.SuggestedFileType = result.SelectedFileType;
+                    }
+
+                    continue;
+                }
+
+                return new FileHelperSubtitleSavePickerResult
+                {
+                    FileName = fileName,
+                    SubtitleFormat = subtitleFormat,
+                };
+            }
+        }
+
+        private const int MaxPortalNameRetries = 2;
+
+        /// <summary>
+        /// Under the Flatpak document portal only the exact file name granted in the save
+        /// dialog can be written - a different name in the granted folder is stranded as a
+        /// hidden ".xdp-&lt;name&gt;-&lt;random&gt;" temp file, so an extension appended after the
+        /// dialog has closed never materializes (issue #13308). When the picked name differs
+        /// from the dialog's pre-filled name (meaning the granted name may lack the extension
+        /// that was appended afterwards), put the fully-extensioned name into
+        /// <paramref name="options"/> and return true so the caller re-opens the dialog and
+        /// the portal grants the final name.
+        /// </summary>
+        private static bool NeedsPortalGrantedName(string pickedFileName, FilePickerSaveOptions options, string wantedFileName)
+        {
+            if (!DocumentPortal.IsPortalPath(pickedFileName))
+            {
+                return false;
             }
 
-            var subtitleFormat = SubtitleFormat.AllSubtitleFormats
-                .FirstOrDefault(f => result.SelectedFileType?.Name == f.Name) ?? currentFormat;
-            
-            return new FileHelperSubtitleSavePickerResult
+            var pickedName = Path.GetFileName(pickedFileName);
+            if (pickedName == wantedFileName && pickedName == options.SuggestedFileName)
             {
-                FileName = AddMissingExtension(result.File.Path.LocalPath, subtitleFormat.Extension),
-                SubtitleFormat = subtitleFormat,
-            };
+                // No extension is pending and the user kept the pre-filled name, so the
+                // granted name is already the final one.
+                return false;
+            }
+
+            options.SuggestedFileName = wantedFileName;
+            return true;
+        }
+
+        /// <summary>
+        /// The portal save dialog grants exactly the file name shown in its name box, so under
+        /// Flatpak the suggestion must already carry the extension (see NeedsPortalGrantedName).
+        /// Elsewhere the suggestion is passed through unchanged.
+        /// </summary>
+        private static string MakePortalSafeSuggestedFileName(string suggestedFileName, string extension)
+        {
+            var name = Path.GetFileName(suggestedFileName);
+            return DocumentPortal.IsSandboxed ? AddDefaultExtension(name, extension) : name;
+        }
+
+        /// <summary>
+        /// Mirrors Avalonia's post-dialog DefaultExtension handling: the extension is only
+        /// added when the file name has none at all.
+        /// </summary>
+        private static string AddDefaultExtension(string fileName, string extension)
+        {
+            if (string.IsNullOrEmpty(fileName) || string.IsNullOrEmpty(extension) || Path.HasExtension(fileName))
+            {
+                return fileName;
+            }
+
+            return fileName + (extension.StartsWith('.') ? extension : "." + extension);
         }
 
         /// <summary>
@@ -395,21 +478,28 @@ namespace Nikse.SubtitleEdit.Logic.Media
             var options = new FilePickerSaveOptions
             {
                 Title = title,
-                SuggestedFileName = Path.GetFileName(suggestedFileName),
+                SuggestedFileName = MakePortalSafeSuggestedFileName(suggestedFileName, extension),
                 FileTypeChoices = MakeSaveFilePickerFileTypes(extension, extension),
                 DefaultExtension = extension.TrimStart('.')
             };
 
             await SetSuggestedStartLocation(topLevel, options, suggestedFileName);
 
-            var file = await NativePickers.SaveFilePickerAsync(topLevel, options);
-
-            if (file != null)
+            for (var attempt = 0; ; attempt++)
             {
-                return file.Path.LocalPath;
-            }
+                var file = await NativePickers.SaveFilePickerAsync(topLevel, options);
+                if (file == null)
+                {
+                    return string.Empty;
+                }
 
-            return string.Empty;
+                var fileName = file.Path.LocalPath;
+                if (attempt >= MaxPortalNameRetries ||
+                    !NeedsPortalGrantedName(fileName, options, AddDefaultExtension(Path.GetFileName(fileName), extension)))
+                {
+                    return fileName;
+                }
+            }
         }
 
         public Task<string> PickSaveFile(
@@ -432,21 +522,28 @@ namespace Nikse.SubtitleEdit.Logic.Media
             var options = new FilePickerSaveOptions
             {
                 Title = title,
-                SuggestedFileName = Path.GetFileName(suggestedFileName),
+                SuggestedFileName = MakePortalSafeSuggestedFileName(suggestedFileName, defaultExtension),
                 FileTypeChoices = MakeSaveFilePickerFileTypes(fileTypes),
                 DefaultExtension = defaultExtension.TrimStart('.'),
             };
 
             await SetSuggestedStartLocation(topLevel, options, suggestedFileName);
 
-            var file = await NativePickers.SaveFilePickerAsync(topLevel, options);
-
-            if (file != null)
+            for (var attempt = 0; ; attempt++)
             {
-                return file.Path.LocalPath;
-            }
+                var file = await NativePickers.SaveFilePickerAsync(topLevel, options);
+                if (file == null)
+                {
+                    return string.Empty;
+                }
 
-            return string.Empty;
+                var fileName = file.Path.LocalPath;
+                if (attempt >= MaxPortalNameRetries ||
+                    !NeedsPortalGrantedName(fileName, options, AddDefaultExtension(Path.GetFileName(fileName), defaultExtension)))
+                {
+                    return fileName;
+                }
+            }
         }
 
         private static List<FilePickerFileType> MakeSaveFilePickerFileTypes(IReadOnlyList<(string Name, string Extension)> fileTypes)

--- a/tests/UI/Logic/DocumentPortalTests.cs
+++ b/tests/UI/Logic/DocumentPortalTests.cs
@@ -1,0 +1,27 @@
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+public class DocumentPortalTests
+{
+    [Theory]
+    [InlineData("/run/user/1000/doc/a1b2c3/FOO", "/run/user/1000", true)]
+    [InlineData("/run/user/1000/doc/a1b2c3/FOO.srt", "/run/user/1000", true)]
+    [InlineData("/run/user/1000/doc/a1b2c3/FOO", "/run/user/1000/", true)] // trailing slash in XDG_RUNTIME_DIR
+    [InlineData("/home/user/Videos/FOO.srt", "/run/user/1000", false)]
+    [InlineData("/run/user/1000/gvfs/smb-share/FOO.srt", "/run/user/1000", false)]
+    [InlineData("/run/user/1000/doc", "/run/user/1000", false)] // the mount root itself is not a granted file
+    public void IsPortalPath_WithRuntimeDir(string path, string runtimeDir, bool expected)
+    {
+        Assert.Equal(expected, DocumentPortal.IsPortalPath(path, runtimeDir));
+    }
+
+    [Theory]
+    [InlineData("/run/user/1000/doc/a1b2c3/FOO.srt", true)]
+    [InlineData("/home/user/Videos/FOO.srt", false)]
+    [InlineData("/run/user/1000/gvfs/smb-share/FOO.srt", false)]
+    public void IsPortalPath_WithoutRuntimeDir_FallsBackToPatternMatch(string path, bool expected)
+    {
+        Assert.Equal(expected, DocumentPortal.IsPortalPath(path, null));
+    }
+}


### PR DESCRIPTION
Fixes #13308.

### Root cause

The `.xdp-FOO.srt-ZFWrex` names come from the xdg **document portal**, not from the filesystem type. The Flatpak only has `--filesystem=home`, so saving anywhere outside home (SMB share, tmpfs, `/mnt`, ...) goes through the portal, which grants access to **exactly one file name** — the name confirmed in the save dialog — exposed via a FUSE mount under `$XDG_RUNTIME_DIR/doc/`. Writing any *other* name into that granted folder is stored on the real filesystem as a hidden `.xdp-<name>-<random>` temp file that only materializes if renamed onto the granted name.

SE (and Avalonia's own `DefaultExtension` handling, which works the same way) append the file extension **after** the dialog closes. So when the user typed `FOO`, the portal granted `FOO`, SE wrote `FOO.srt` — a name that can never materialize. Inside the sandbox the FUSE view shows `FOO.srt`, so the app can't even see the problem. This exactly matches the report: typing the extension yourself avoids the bug.

### Fix (three parts)

1. **Save pickers** (`FileHelper`): the suggestion is pre-filled with the final extension, and when a picked document-portal name still differs from a final-safe name (an extension append is pending, or the pre-filled suggestion was edited), the dialog is re-opened once with the fully-extensioned name pre-filled so the portal grants the actual final name. Non-portal paths (all other OSes, and flatpak saves inside granted folders) behave exactly as before.
2. **Batch speech-to-text**: videos opened through the portal live in single-file grants where a sibling `.srt` can never materialize, so batch mode now asks for an output folder (folder grants are full directory mirrors and support new files) before transcribing.
3. **Flatpak manifests**: grant `/mnt`, `/media`, `/run/media` and `xdg-run/gvfs` so mounted drives and network shares bypass the document portal entirely — this alone covers the reporter's SMB setup, and also removes document-portal FUSE overhead from mpv playback and transcription of videos on shares.

New `DocumentPortal` helper contains the sandbox/path detection, with unit tests for the path matching.

### Testing

- `dotnet build` clean, new `DocumentPortalTests` (9 cases) plus existing STT tests pass.
- The portal code path is Linux-flatpak-only and guarded by `/.flatpak-info` + `$XDG_RUNTIME_DIR/doc/` checks; on other platforms the pickers are byte-for-byte the old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)