### PR TITLE
Make "merge as dialog" respect the configured dialog style

### DIFF
--- a/src/ui/Logic/MergeManager.cs
+++ b/src/ui/Logic/MergeManager.cs
@@ -314,15 +314,20 @@ namespace Nikse.SubtitleEdit.Logic
             var subtitle = new Subtitle();
             subtitle.Paragraphs.AddRange(subtitles.Select(p=>new Paragraph(p.Text, p.StartTime.TotalMilliseconds, p.EndTime.TotalMilliseconds)));
             var language = LanguageAutoDetect.AutoDetectGoogleLanguage(subtitle);
-            var dialogHelper = new DialogSplitMerge { DialogStyle = Enum.Parse<DialogType>(Se.Settings.General.DialogStyle), TwoLetterLanguageCode = language };
-            var dialogText = dialogHelper.FixDashes("- " + currentText.TrimStart(' ', '-') + Environment.NewLine + "- " + nextText.TrimStart(' ', '-'));
+            var dialogHelper = new DialogSplitMerge
+            {
+                DialogStyle = Enum.Parse<DialogType>(Se.Settings.General.DialogStyle),
+                TwoLetterLanguageCode = language,
+                SkipLineEndingCheck = true, // user explicitly asked for a dialog merge
+            };
+            var dialogText = dialogHelper.FixDashesAndSpaces("- " + currentText.TrimStart(' ', '-') + Environment.NewLine + "- " + nextText.TrimStart(' ', '-'));
             currentParagraph.Text = dialogText;
 
             if (!string.IsNullOrWhiteSpace(currentOriginalText) || !string.IsNullOrWhiteSpace(nextOriginalText))
             {
-                var dialogOriginalText = dialogHelper.FixDashes("- " + currentOriginalText.TrimStart(' ', '-') 
-                                                                     + Environment.NewLine + "- " 
-                                                                     + nextOriginalText.TrimStart(' ', '-'));
+                var dialogOriginalText = dialogHelper.FixDashesAndSpaces("- " + currentOriginalText.TrimStart(' ', '-')
+                                                                              + Environment.NewLine + "- "
+                                                                              + nextOriginalText.TrimStart(' ', '-'));
                 currentParagraph.OriginalText = dialogOriginalText;
             }
 

--- a/tests/UI/Logic/MergeManagerTests.cs
+++ b/tests/UI/Logic/MergeManagerTests.cs
@@ -75,6 +75,49 @@ public class MergeManagerTests
         Assert.Contains("Hvordan gar det?", subtitles[0].OriginalText);
     }
 
+    // Issue #13307: the configured dialog style must decide dash placement and spacing,
+    // also when the first line has no sentence ending.
+    [Theory]
+    [InlineData("DashBothLinesWithSpace", "- Hi there", "- How are you?")]
+    [InlineData("DashBothLinesWithoutSpace", "-Hi there", "-How are you?")]
+    [InlineData("DashSecondLineWithSpace", "Hi there", "- How are you?")]
+    [InlineData("DashSecondLineWithoutSpace", "Hi there", "-How are you?")]
+    public void MergeSelectedLinesAsDialog_ShouldFollowDialogStyleSetting(string dialogStyle, string expectedLine1, string expectedLine2)
+    {
+        var originalDialogStyle = Se.Settings.General.DialogStyle;
+        try
+        {
+            Se.Settings.General.DialogStyle = dialogStyle;
+            var mergeManager = new MergeManager();
+            var subtitles = new ObservableCollection<SubtitleLineViewModel>
+            {
+                new()
+                {
+                    Number = 1,
+                    Text = "Hi there",
+                    StartTime = TimeSpan.FromSeconds(1),
+                    EndTime = TimeSpan.FromSeconds(2),
+                },
+                new()
+                {
+                    Number = 2,
+                    Text = "How are you?",
+                    StartTime = TimeSpan.FromSeconds(2),
+                    EndTime = TimeSpan.FromSeconds(3),
+                },
+            };
+
+            mergeManager.MergeSelectedLinesAsDialog(subtitles, [subtitles[0], subtitles[1]]);
+
+            Assert.Single(subtitles);
+            Assert.Equal(expectedLine1 + Environment.NewLine + expectedLine2, subtitles[0].Text);
+        }
+        finally
+        {
+            Se.Settings.General.DialogStyle = originalDialogStyle;
+        }
+    }
+
     [Fact]
     public void MergeSelectedLines_ShouldKeepOriginalTextEmpty_WhenBothOriginalTextsAreEmpty()
     {


### PR DESCRIPTION
Fixes item 2 of #13307 ("When merge lines as dialog is applied, dash is inserted with space although configured without space").

`MergeSelectedLinesAsDialog` built the merged text with a hard-coded `"- "` prefix on both lines and then only ran `FixDashes`, which adds dashes to lines that lack them but never removes the space after an existing dash — the space removal lives in `FixSpaces`. So with a "without space" dialog style configured, the result was still `- text`.

Two changes in `MergeManager`:
- Call `FixDashesAndSpaces` instead of `FixDashes`, so the spacing pass runs and the configured style decides dash spacing.
- Set `SkipLineEndingCheck = true` on the `DialogSplitMerge` helper: the user explicitly asked for a dialog merge, but without it, a first line lacking a sentence ending made `IsDialog` fail and bypassed the style entirely — leaving the hard-coded `"- "` prefixes even for the dash-on-second-line-only styles.

Adds a theory test covering all four dialog styles (using a first line without sentence ending, which exercises the `SkipLineEndingCheck` path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)