### PR TITLE
Fix seven bugs found in a review sweep of the beta-6 PRs

### DIFF
--- a/src/ui/Features/Ocr/Engines/MistralOcr.cs
+++ b/src/ui/Features/Ocr/Engines/MistralOcr.cs
@@ -106,8 +106,10 @@ public class MistralOcr
 
             return finalText.Trim();
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            // Only a real user cancel propagates; an HttpClient timeout also throws
+            // TaskCanceledException and must be recorded in Error below instead.
             throw;
         }
         catch (Exception ex)

--- a/src/ui/Features/Ocr/Engines/OllamaOcr.cs
+++ b/src/ui/Features/Ocr/Engines/OllamaOcr.cs
@@ -104,8 +104,11 @@ public class OllamaOcr
 
             return resultText.Trim();
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            // Only a real user cancel propagates; an HttpClient timeout also throws
+            // TaskCanceledException, and rethrowing that made a hung Ollama end the OCR
+            // run silently. The catch below records it in Error instead.
             throw;
         }
         catch (Exception ex)

--- a/src/ui/Features/Options/DoNotBreakAfterList/DoNotBreakAfterListViewModel.cs
+++ b/src/ui/Features/Options/DoNotBreakAfterList/DoNotBreakAfterListViewModel.cs
@@ -281,7 +281,9 @@ public partial class DoNotBreakAfterListViewModel : ObservableObject
         if (e.Key == Key.Enter)
         {
             e.Handled = true;
-            using var _ = AddItem();
+            // Fire-and-forget discard: "using var" would call Task.Dispose when this handler
+            // returns, which throws while the task is still awaiting a message box.
+            _ = AddItem();
         }
     }
 

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Data.Converters;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
@@ -651,7 +652,17 @@ public class SettingsPage : UserControl
             new SettingsItem(Se.Language.Options.Settings.AutoBreakPreferBottomPercent, () =>
             {
                 var nud = MakeNumericUpDownInt(nameof(_vm.AutoBreakPreferBottomPercent), 0, 50);
-                nud[!Control.IsEnabledProperty] = new Binding(nameof(_vm.AutoBreakUsePixelWidth)) { Source = _vm };
+                // The engine reads the percent only when both pixel width AND prefer-bottom-heavy
+                // are on (TextSplit), so enable it only when editing it can have an effect.
+                nud[!Control.IsEnabledProperty] = new MultiBinding
+                {
+                    Converter = BoolConverters.And,
+                    Bindings =
+                    {
+                        new Binding(nameof(_vm.AutoBreakUsePixelWidth)) { Source = _vm },
+                        new Binding(nameof(_vm.AutoBreakPreferBottomHeavy)) { Source = _vm },
+                    },
+                };
                 return nud;
             }),
             new SettingsItem(Se.Language.Options.Settings.UseDoNotBreakAfterList, () => new StackPanel

--- a/src/ui/Features/Options/WordLists/WordListsViewModel.cs
+++ b/src/ui/Features/Options/WordLists/WordListsViewModel.cs
@@ -453,7 +453,9 @@ public partial class WordListsViewModel : ObservableObject
         if (e.Key == Key.Enter)
         {
             e.Handled = true;
-            using var _ = AddName();
+            // Fire-and-forget discard: "using var" would call Task.Dispose when this handler
+            // returns, which throws while the task is still awaiting a message box.
+            _ = AddName();
         }
     }
 
@@ -462,8 +464,7 @@ public partial class WordListsViewModel : ObservableObject
         if (e.Key == Key.Enter)
         {
             e.Handled = true;
-            using var _ = AddWord();
-            using var _1 = AddName();
+            _ = AddWord();
         }
     }
 
@@ -472,7 +473,7 @@ public partial class WordListsViewModel : ObservableObject
         if (e.Key == Key.Enter)
         {
             e.Handled = true;
-            using var _ = AddOcrFix();
+            _ = AddOcrFix();
         }
     }
 }

--- a/src/ui/Features/Shared/MessageBox.cs
+++ b/src/ui/Features/Shared/MessageBox.cs
@@ -57,12 +57,58 @@ public class MessageBox : Window
     private readonly bool _hasOnlyOk;
     private readonly bool _hasNo;
     private readonly StackPanel _buttonPanel;
-    private bool _seenSpaceKeyDown;
+    private readonly KeyPressTracker _enterTracker = new();
+    private readonly KeyPressTracker _spaceTracker = new();
+    private bool _initialFocusDone;
     private long _openedTimestamp;
 
     private bool IsInStartupGuardPeriod()
     {
         return _openedTimestamp == 0 || Stopwatch.GetElapsedTime(_openedTimestamp) < TimeSpan.FromMilliseconds(200);
+    }
+
+    // Decides whether a Space/Enter release may activate the focused button. OS key auto-repeat
+    // delivers ordinary KeyDowns, so a single event can't tell a key still held from before this
+    // window opened apart from a fresh press - but the pattern can: repeats of a pre-held key
+    // arrive at the repeat interval (~30-90 ms), while a fresh press that starts repeating waits
+    // the initial repeat delay (>= ~225 ms even at the fastest common OS setting) between its
+    // first and second KeyDown. A lone KeyDown released within 50 ms is a repeat-then-release
+    // slip, not a human tap. A swallowed release costs one extra key press; a leaked one answers
+    // a question the user never saw.
+    private sealed class KeyPressTracker
+    {
+        private int _keyDownCount;
+        private long _firstKeyDownTimestamp;
+        private bool _heldFromBeforeOpen;
+
+        public void OnKeyDown()
+        {
+            _keyDownCount++;
+            if (_keyDownCount == 1)
+            {
+                _firstKeyDownTimestamp = Stopwatch.GetTimestamp();
+            }
+            else if (_keyDownCount == 2 &&
+                     Stopwatch.GetElapsedTime(_firstKeyDownTimestamp) < TimeSpan.FromMilliseconds(225))
+            {
+                _heldFromBeforeOpen = true;
+            }
+        }
+
+        public bool IsFreshTapOnKeyUp()
+        {
+            var isFreshTap = _keyDownCount > 0 && !_heldFromBeforeOpen &&
+                             (_keyDownCount > 1 ||
+                              Stopwatch.GetElapsedTime(_firstKeyDownTimestamp) >= TimeSpan.FromMilliseconds(50));
+            Reset();
+            return isFreshTap;
+        }
+
+        public void Reset()
+        {
+            _keyDownCount = 0;
+            _heldFromBeforeOpen = false;
+        }
     }
 
     private MessageBox(string title, string message, MessageBoxButtons buttons, MessageBoxIcon icon, string? custom1 = null, string? custom2 = null, string? custom3 = null, string? custom4 = null)
@@ -250,10 +296,12 @@ public class MessageBox : Window
         // Focus the first button (the positive/default choice - Yes or OK), like classic Win32
         // message boxes: Space/Enter accepts, Escape cancels, arrow keys move focus. That makes
         // the key that opened this dialog a hazard: Avalonia's Button clicks on Space KeyUp
-        // without checking it also saw the KeyDown, and a held Enter key-repeats straight into
-        // the new window - either would answer Yes/OK by accident. Guard: swallow Space/Enter
-        // for the first 200 ms after opening, and Space KeyUps whose KeyDown this window never
-        // saw (a Space can be held down well past any fixed time window before releasing).
+        // without checking it also saw the KeyDown, and a key still held from the previous
+        // dialog starts OS auto-repeating into this window after the initial repeat delay -
+        // either would answer Yes/OK by accident. Guard three ways: swallow Space/Enter for the
+        // first 200 ms after opening, click Enter on KeyUp ourselves (instead of Avalonia's
+        // KeyDown click, which an auto-repeat would fire directly), and only accept a release
+        // whose press pattern looks like a fresh tap made inside this window (KeyPressTracker).
         Opened += (_, _) => _openedTimestamp = Stopwatch.GetTimestamp();
         AddHandler(KeyDownEvent, (_, e) =>
         {
@@ -261,9 +309,14 @@ public class MessageBox : Window
             {
                 e.Handled = true;
             }
+            else if (e.Key == Key.Enter)
+            {
+                _enterTracker.OnKeyDown();
+                e.Handled = true; // no KeyDown click - the KeyUp handler below clicks instead
+            }
             else if (e.Key == Key.Space)
             {
-                _seenSpaceKeyDown = true;
+                _spaceTracker.OnKeyDown();
             }
         }, RoutingStrategies.Tunnel);
         AddHandler(KeyUpEvent, (_, e) =>
@@ -271,13 +324,41 @@ public class MessageBox : Window
             if (e.Key is Key.Space or Key.Enter && IsInStartupGuardPeriod())
             {
                 e.Handled = true;
+                _enterTracker.Reset();
+                _spaceTracker.Reset();
             }
-            else if (e.Key == Key.Space && !_seenSpaceKeyDown)
+            else if (e.Key == Key.Enter)
             {
                 e.Handled = true;
+                if (_enterTracker.IsFreshTapOnKeyUp() && FocusManager?.GetFocusedElement() is Button focusedButton)
+                {
+                    focusedButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                }
+            }
+            else if (e.Key == Key.Space && !_spaceTracker.IsFreshTapOnKeyUp())
+            {
+                e.Handled = true; // Button clicks Space on KeyUp; block releases that fail the gate
             }
         }, RoutingStrategies.Tunnel);
-        Activated += delegate { buttonPanel.Children[0].Focus(); };
+        Activated += delegate
+        {
+            // Re-arm the guard on every activation (alt-tabbing back can bring a held key's
+            // auto-repeat along), but move focus only the first time so arrow-key navigation
+            // survives a focus round-trip to another window.
+            _openedTimestamp = Stopwatch.GetTimestamp();
+            if (!_initialFocusDone)
+            {
+                _initialFocusDone = true;
+                buttonPanel.Children[0].Focus();
+            }
+        };
+        Deactivated += delegate
+        {
+            // Key releases go to the newly focused window, so presses counted here would
+            // otherwise linger and mis-classify the next press after refocus.
+            _enterTracker.Reset();
+            _spaceTracker.Reset();
+        };
 
         UiTheme.ApplyScaleToWindow(this);
     }

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -321,15 +321,27 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             }
             else if (Se.Settings.Tools.BatchConvert.OcrEngine.Equals("Ollama", StringComparison.OrdinalIgnoreCase))
             {
-                await RunOllamaOcr(imageSubtitle, item, cancellationToken);
+                // A false return means the runner already set a terminal status (engine not
+                // downloaded, startup failure, cancelled, every line blank) - stop here so the
+                // save path below cannot overwrite it with "Converted" or a generic error.
+                if (!await RunOllamaOcr(imageSubtitle, item, cancellationToken))
+                {
+                    return;
+                }
             }
             else if (Se.Settings.Tools.BatchConvert.OcrEngine.Equals("llama.cpp", StringComparison.OrdinalIgnoreCase))
             {
-                await RunLlamaCppOcr(imageSubtitle, item, cancellationToken);
+                if (!await RunLlamaCppOcr(imageSubtitle, item, cancellationToken))
+                {
+                    return;
+                }
             }
             else if (Se.Settings.Tools.BatchConvert.OcrEngine.Equals(CrispEmbedEngine.StaticName, StringComparison.OrdinalIgnoreCase))
             {
-                await RunCrispEmbedOcr(imageSubtitle, item, cancellationToken);
+                if (!await RunCrispEmbedOcr(imageSubtitle, item, cancellationToken))
+                {
+                    return;
+                }
             }
             else
             {
@@ -1276,7 +1288,12 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         }
     }
     
-    private async Task RunOllamaOcr(IOcrSubtitle imageSubtitles, BatchConvertItem item, CancellationToken cancellationToken)
+    /// <returns>
+    /// True when the item should continue through convert functions and save; false when the
+    /// runner already set a terminal status (not downloaded, startup failure, cancelled, every
+    /// line blank) that the save path must not overwrite.
+    /// </returns>
+    private async Task<bool> RunOllamaOcr(IOcrSubtitle imageSubtitles, BatchConvertItem item, CancellationToken cancellationToken)
     {
         var ollamaOcr = new OllamaOcr();
         var url = Se.Settings.Ocr.OllamaUrl;
@@ -1309,10 +1326,14 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             item.Subtitle.Paragraphs.All(p => string.IsNullOrWhiteSpace(p.Text)))
         {
             item.Status = Se.Language.Ocr.OllamaModelLikelyWrong;
+            return false;
         }
+
+        return !cancelled;
     }
 
-    private async Task RunLlamaCppOcr(IOcrSubtitle imageSubtitles, BatchConvertItem item, CancellationToken cancellationToken)
+    /// <inheritdoc cref="RunOllamaOcr"/>
+    private async Task<bool> RunLlamaCppOcr(IOcrSubtitle imageSubtitles, BatchConvertItem item, CancellationToken cancellationToken)
     {
         // Curated OCR model from settings (picked in batch convert settings / the OCR window).
         // The batch run never downloads - the settings dialog prompts for that on OK.
@@ -1321,7 +1342,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         if (model == null || !LlamaCppServerManager.IsEngineInstalled() || !LlamaCppServerManager.IsModelInstalled(model))
         {
             item.Status = Se.Language.Ocr.LlamaCppNotDownloaded;
-            return;
+            return false;
         }
 
         try
@@ -1332,7 +1353,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         catch (Exception ex)
         {
             item.Status = string.Format(Se.Language.General.ErrorX, ex.Message);
-            return;
+            return false;
         }
 
         var engine = new LlamaCppOcr(Se.Settings.Ocr.LlamaCppOcrTimeoutMinutes);
@@ -1366,10 +1387,14 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             item.Subtitle.Paragraphs.All(p => string.IsNullOrWhiteSpace(p.Text)))
         {
             item.Status = Se.Language.Ocr.LlamaCppReturnedNoText;
+            return false;
         }
+
+        return !cancelled;
     }
 
-    private async Task RunCrispEmbedOcr(IOcrSubtitle imageSubtitles, BatchConvertItem item, CancellationToken cancellationToken)
+    /// <inheritdoc cref="RunOllamaOcr"/>
+    private async Task<bool> RunCrispEmbedOcr(IOcrSubtitle imageSubtitles, BatchConvertItem item, CancellationToken cancellationToken)
     {
         // Backend/model picked in batch convert settings (shared with the OCR window). The batch
         // run never downloads - the settings dialog prompts for that on OK.
@@ -1379,7 +1404,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         if (backend == null || model == null || !CrispEmbedEngine.IsEngineInstalled() || !backend.IsModelInstalled(model))
         {
             item.Status = Se.Language.Ocr.CrispEmbedNotDownloaded;
-            return;
+            return false;
         }
 
         using var engine = new CrispEmbedOcr(Se.Settings.Ocr.CrispEmbedOcrTimeoutMinutes);
@@ -1403,13 +1428,13 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         catch (OperationCanceledException)
         {
             item.Status = Se.Language.General.Cancelled;
-            return;
+            return false;
         }
 
         if (!started)
         {
             item.Status = string.Format(Se.Language.General.ErrorX, engine.Error);
-            return;
+            return false;
         }
 
         item.Subtitle = new Subtitle();
@@ -1428,7 +1453,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             catch (OperationCanceledException)
             {
                 item.Status = Se.Language.General.Cancelled;
-                return;
+                return false;
             }
 
             var p = new Paragraph(text, imageSubtitles.GetStartTime(i).TotalMilliseconds, imageSubtitles.GetEndTime(i).TotalMilliseconds);
@@ -1448,7 +1473,10 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             item.Subtitle.Paragraphs.All(p => string.IsNullOrWhiteSpace(p.Text)))
         {
             item.Status = Se.Language.Ocr.CrispEmbedReturnedNoText;
+            return false;
         }
+
+        return !cancelled;
     }
 
     /// <summary>

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -1883,7 +1883,9 @@ public partial class SpeechToTextViewModel : ObservableObject
         var languageCode = SelectedLanguage?.Code;
         if (string.IsNullOrWhiteSpace(languageCode) || languageCode.Equals("auto", StringComparison.OrdinalIgnoreCase))
         {
-            languageCode = GetOnlineEngineLanguageHint();
+            // Normalized here (not just at the end) so a hint that can't be mapped to a
+            // code falls through to auto-detection instead of being dropped outright.
+            languageCode = NormalizeFileNameLanguageCode(GetOnlineEngineLanguageHint());
         }
 
         if (string.IsNullOrWhiteSpace(languageCode) && transcript != null)
@@ -1896,7 +1898,39 @@ public partial class SpeechToTextViewModel : ObservableObject
             return null;
         }
 
-        return languageCode;
+        return NormalizeFileNameLanguageCode(languageCode);
+    }
+
+    /// <summary>
+    /// Maps a language token to a code usable as a file name part, or null when it can't be.
+    /// The token may come from the online engines' free-text "language hint" setting, so it
+    /// can be a full name ("English" - the APIs accept those) or any arbitrary text; a full
+    /// name is mapped to its whisper code and anything not code-shaped is dropped rather than
+    /// embedded in the file name (path separators and the like would make the save throw).
+    /// </summary>
+    internal static string? NormalizeFileNameLanguageCode(string? languageCode)
+    {
+        if (string.IsNullOrWhiteSpace(languageCode))
+        {
+            return null;
+        }
+
+        var token = languageCode.Trim();
+        var match = WhisperLanguage.Languages.FirstOrDefault(p =>
+            p.Code.Equals(token, StringComparison.OrdinalIgnoreCase) ||
+            p.Name.Equals(token, StringComparison.OrdinalIgnoreCase));
+        if (match != null)
+        {
+            return match.Code;
+        }
+
+        // Unknown but code-shaped ("pt-BR", "yue") - keep as typed, lowercased.
+        if (token.Length <= 6 && token.All(c => char.IsAsciiLetter(c) || c == '-'))
+        {
+            return token.ToLowerInvariant();
+        }
+
+        return null;
     }
 
     private Subtitle PostProcess(Subtitle transcript)
@@ -3070,8 +3104,11 @@ public partial class SpeechToTextViewModel : ObservableObject
         {
             _videoFileName = BatchItems[0].InputVideoFileName;
 
-            if (string.IsNullOrEmpty(_batchOutputFolder) &&
-                BatchItems.Any(b => DocumentPortal.IsPortalPath(b.InputVideoFileName)))
+            // Every run picks its output folder anew - a folder chosen for an earlier batch
+            // in this dialog session must not silently receive a later batch's output.
+            _batchOutputFolder = null;
+
+            if (BatchItems.Any(b => DocumentPortal.IsPortalPath(b.InputVideoFileName)))
             {
                 // Videos opened through the Flatpak document portal live in a single-file
                 // grant where a sibling .srt can never materialize as a real file (issue

--- a/tests/UI/Features/Video/SpeechToText/SpeechToTextFileNameLanguageCodeTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/SpeechToTextFileNameLanguageCodeTests.cs
@@ -1,0 +1,33 @@
+using Nikse.SubtitleEdit.Features.Video.SpeechToText;
+
+namespace UITests.Features.Video.SpeechToText;
+
+// The token can come from the online engines' free-text "language hint" setting, so it may be
+// a full language name (the APIs accept those) or arbitrary text with path-hostile characters.
+public class SpeechToTextFileNameLanguageCodeTests
+{
+    [Theory]
+    [InlineData("en", "en")] // code passes through
+    [InlineData("EN", "en")] // case-insensitive
+    [InlineData("English", "en")] // full name maps to whisper code
+    [InlineData("danish", "da")]
+    [InlineData("pt-BR", "pt-br")] // unknown but code-shaped is kept as typed
+    [InlineData("yue", "yue")]
+    public void MapsCodesAndFullNames(string token, string expected)
+    {
+        Assert.Equal(expected, SpeechToTextViewModel.NormalizeFileNameLanguageCode(token));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("pt/BR")] // path separator must never reach a file name
+    [InlineData("en:us")]
+    [InlineData("Portuguese (Brazil)")] // unmappable free text is dropped, not embedded
+    [InlineData("simplified chinese")]
+    public void DropsUnmappableTokens(string? token)
+    {
+        Assert.Null(SpeechToTextViewModel.NormalizeFileNameLanguageCode(token));
+    }
+}


### PR DESCRIPTION
A systematic review of the PRs merged since beta 5 (#13290–#13316) surfaced these bugs; each was verified against the code before fixing, and everything here is covered by the existing suite (1527 UI tests pass) plus new tests for the file-name language codes.

## MessageBox: held keys could answer the new dialog (#13305 follow-up)
OS key auto-repeat delivers ordinary KeyDowns, so a key held ~0.5 s from the previous dialog outlives the 200 ms guard: the first Enter repeat clicked the focused **positive** button directly (Avalonia clicks Enter on KeyDown), and a Space repeat re-armed the seen-KeyDown gate so the eventual release clicked. Fix: Enter clicks on KeyUp instead, and a release only counts when its press pattern looks like a fresh tap made inside the window — repeats of a pre-held key arrive at the repeat interval (~30–90 ms), while a fresh press that starts repeating waits the initial repeat delay (≥ ~225 ms) between first and second KeyDown. Also fixed: alt-tabbing away and back no longer snaps focus back to Yes/OK (discarding arrow-key navigation), and the guard re-arms on every activation.

## Enter in list editors could crash instead of showing the error (#13314 follow-up)
`using var _ = AddItem();` disposes the returned `Task` when the handler returns, and `Task.Dispose()` throws unless the task has completed — which it hasn't on the paths that await a message box. Typing an invalid regex like `(` and pressing Enter crashed inside Avalonia's key dispatch. Same pattern fixed in the word-lists editor (names / user words / OCR fixes), which also had a stray `AddName()` call in the user-word Enter handler.

## Ollama/Mistral OCR: timeouts ended the run silently (#13304 follow-up)
An `HttpClient` timeout throws `TaskCanceledException` (an `OperationCanceledException`), which the engine rethrew and the caller swallowed as a user cancel — a hung server stopped OCR mid-run with no dialog, the exact silent-failure class #13304 set out to fix. Both engines now rethrow only when the token was actually cancelled (`when (cancellationToken.IsCancellationRequested)`, the pattern CrispEmbedOcr/LlamaCppOcr/GlmOcr already use), so timeouts land in `Error` and reach the existing error dialog.

## Batch convert: OCR failure statuses were clobbered (#13290 follow-up)
The statuses the OCR runners set were dead on arrival:
- "returned no text": the all-blank subtitle is non-null, so it flowed into `SaveSubtitleFormat`, which stamped **Converted** — a green row and an empty output file.
- "not downloaded" / server-startup errors: `item.Subtitle` stays null, so control fell through to the image-export path and overwrote the informative status with a generic *Error: Error* (after wasting a full image-adjustment pass).
- mid-run cancels were similarly overwritten.

The Ollama/llama.cpp/CrispEmbed runners now return whether the item should continue to the save path; a terminal status stops there and stays visible. (This also fixes the same pre-existing clobbering for the llama.cpp and Ollama statuses.)

## Batch speech to text: language hint went verbatim into file names (#13313 follow-up)
The online engines' free-text "language hint" was embedded unsanitized: a user who typed "English" (which the APIs accept) got `video.English.srt`, defeating the media-player naming convention, and path-hostile characters (`pt/BR`, `en:us`) made the save throw mid-batch. Hints now map full names to their whisper code, keep unknown code-shaped tokens (`pt-BR`), and fall back to transcript auto-detection for anything unmappable. With tests.

## Batch speech to text: output folder pinned for the whole session (#13315 follow-up)
`_batchOutputFolder` was never cleared, so after one portal batch, a second batch in the same dialog silently reused the first run's folder — and a run cancelled right after the folder prompt still pinned it. Each batch run now prompts anew.

## Settings: bottom-heavy percent spinner enabled when it does nothing (#13312 follow-up)
The engine reads the percent only when *both* pixel-width and prefer-bottom-heavy are on (`TextSplit`); the spinner was enabled on pixel-width alone. Now bound to both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)