### PR TITLE
Five hot-path optimizations, BenchmarkDotNet-verified (round 3)

### DIFF
--- a/src/libuilogic/Ocr/BinaryOcrBitmap.cs
+++ b/src/libuilogic/Ocr/BinaryOcrBitmap.cs
@@ -25,7 +25,17 @@ public class BinaryOcrBitmap
     public int Y { get; set; }
     public int NumberOfColoredPixels { get; set; }
     public uint Hash { get; set; }
-    public byte[] Colors { get; set; } = [];
+
+    private byte[] _colors = [];
+    public byte[] Colors
+    {
+        get => _colors;
+        set
+        {
+            _colors = value;
+            InvalidateLineCaches();
+        }
+    }
     public bool Italic { get; set; }
     public int ExpandCount { get; set; }
     public bool LoadedOk { get; }
@@ -214,6 +224,67 @@ public class BinaryOcrBitmap
     public void SetPixel(int x, int y)
     {
         Colors[Width * y + x] = 1;
+        InvalidateLineCaches();
+    }
+
+    // Cached row/column occupancy used by the shape predicates below - several of
+    // them run on the same unmatched glyph during nOCR matching, so the scans are
+    // computed once and reused. Any pixel mutation must call InvalidateLineCaches.
+    private bool[]? _transparentHorLines;
+    private bool[]? _transparentVerLines;
+
+    private void InvalidateLineCaches()
+    {
+        _transparentHorLines = null;
+        _transparentVerLines = null;
+    }
+
+    private bool[] GetTransparentHorLines()
+    {
+        var lines = _transparentHorLines;
+        if (lines == null)
+        {
+            lines = new bool[Height];
+            for (int y = 0; y < Height; y++)
+            {
+                lines[y] = true;
+                for (int x = 0; x < Width; x++)
+                {
+                    if (GetPixel(x, y) != 0)
+                    {
+                        lines[y] = false;
+                        break;
+                    }
+                }
+            }
+            _transparentHorLines = lines;
+        }
+
+        return lines;
+    }
+
+    private bool[] GetTransparentVerLines()
+    {
+        var lines = _transparentVerLines;
+        if (lines == null)
+        {
+            lines = new bool[Width];
+            for (int x = 0; x < Width; x++)
+            {
+                lines[x] = true;
+                for (int y = 0; y < Height; y++)
+                {
+                    if (GetPixel(x, y) != 0)
+                    {
+                        lines[x] = false;
+                        break;
+                    }
+                }
+            }
+            _transparentVerLines = lines;
+        }
+
+        return lines;
     }
 
     public SKBitmap ToSKBitmap()
@@ -405,19 +476,7 @@ public class BinaryOcrBitmap
             }
         }
 
-        var transparentHorLines = new bool[Height];
-        for (int y = 0; y < Height; y++)
-        {
-            transparentHorLines[y] = true;
-            for (int x = 0; x < Width; x++)
-            {
-                if (GetPixel(x, y) != 0)
-                {
-                    transparentHorLines[y] = false;
-                    break;
-                }
-            }
-        }
+        var transparentHorLines = GetTransparentHorLines();
         if (transparentHorLines[0] || transparentHorLines[1])
         {
             return false;
@@ -453,19 +512,7 @@ public class BinaryOcrBitmap
             return false;
         }
 
-        var transparentHorLines = new bool[Height];
-        for (int y = 0; y < Height; y++)
-        {
-            transparentHorLines[y] = true;
-            for (int x = 0; x < Width; x++)
-            {
-                if (GetPixel(x, y) != 0)
-                {
-                    transparentHorLines[y] = false;
-                    break;
-                }
-            }
-        }
+        var transparentHorLines = GetTransparentHorLines();
 
         // top should be filled
         if (transparentHorLines[0] || transparentHorLines[1])
@@ -532,19 +579,7 @@ public class BinaryOcrBitmap
             return false;
         }
 
-        var transparentHorLines = new bool[Height];
-        for (int y = 0; y < Height; y++)
-        {
-            transparentHorLines[y] = true;
-            for (int x = 0; x < Width; x++)
-            {
-                if (GetPixel(x, y) != 0)
-                {
-                    transparentHorLines[y] = false;
-                    break;
-                }
-            }
-        }
+        var transparentHorLines = GetTransparentHorLines();
         if (transparentHorLines[0] || transparentHorLines[1] || transparentHorLines[2])
         {
             return false;
@@ -582,19 +617,7 @@ public class BinaryOcrBitmap
             return false;
         }
 
-        var transparentHorLines = new bool[Height];
-        for (int y = 0; y < Height; y++)
-        {
-            transparentHorLines[y] = true;
-            for (int x = 0; x < Width; x++)
-            {
-                if (GetPixel(x, y) != 0)
-                {
-                    transparentHorLines[y] = false;
-                    break;
-                }
-            }
-        }
+        var transparentHorLines = GetTransparentHorLines();
         for (int i = 0; i < transparentHorLines.Length; i++)
         {
             if (transparentHorLines[i])
@@ -603,19 +626,7 @@ public class BinaryOcrBitmap
             }
         }
 
-        var transparentVerLines = new bool[Width];
-        for (int x = 0; x < Width; x++)
-        {
-            transparentVerLines[x] = true;
-            for (int y = 0; y < Height; y++)
-            {
-                if (GetPixel(x, y) != 0)
-                {
-                    transparentVerLines[x] = false;
-                    break;
-                }
-            }
-        }
+        var transparentVerLines = GetTransparentVerLines();
         for (int i = 0; i < transparentVerLines.Length; i++)
         {
             if (transparentVerLines[i])
@@ -639,19 +650,7 @@ public class BinaryOcrBitmap
             return false;
         }
 
-        var transparentHorLines = new bool[Height];
-        for (int y = 0; y < Height; y++)
-        {
-            transparentHorLines[y] = true;
-            for (int x = 0; x < Width; x++)
-            {
-                if (GetPixel(x, y) != 0)
-                {
-                    transparentHorLines[y] = false;
-                    break;
-                }
-            }
-        }
+        var transparentHorLines = GetTransparentHorLines();
         if (transparentHorLines[Height - 1] || transparentHorLines[Height - 2])
         {
             return false;
@@ -683,19 +682,7 @@ public class BinaryOcrBitmap
             return false;
         }
 
-        var transparentHorLines = new bool[Height];
-        for (int y = 0; y < Height; y++)
-        {
-            transparentHorLines[y] = true;
-            for (int x = 0; x < Width; x++)
-            {
-                if (GetPixel(x, y) != 0)
-                {
-                    transparentHorLines[y] = false;
-                    break;
-                }
-            }
-        }
+        var transparentHorLines = GetTransparentHorLines();
         for (int i = 0; i < transparentHorLines.Length; i++)
         {
             if (transparentHorLines[i])
@@ -734,19 +721,7 @@ public class BinaryOcrBitmap
             return false;
         }
 
-        var transparentHorLines = new bool[Height];
-        for (int y = 0; y < Height; y++)
-        {
-            transparentHorLines[y] = true;
-            for (int x = 0; x < Width; x++)
-            {
-                if (GetPixel(x, y) != 0)
-                {
-                    transparentHorLines[y] = false;
-                    break;
-                }
-            }
-        }
+        var transparentHorLines = GetTransparentHorLines();
         for (int i = 0; i < transparentHorLines.Length; i++)
         {
             if (transparentHorLines[i])
@@ -755,19 +730,7 @@ public class BinaryOcrBitmap
             }
         }
 
-        var transparentVerLines = new bool[Width];
-        for (int x = 0; x < Width; x++)
-        {
-            transparentVerLines[x] = true;
-            for (int y = 0; y < Height; y++)
-            {
-                if (GetPixel(x, y) != 0)
-                {
-                    transparentVerLines[x] = false;
-                    break;
-                }
-            }
-        }
+        var transparentVerLines = GetTransparentVerLines();
         for (int i = 0; i < transparentVerLines.Length; i++)
         {
             if (transparentVerLines[i])
@@ -817,19 +780,7 @@ public class BinaryOcrBitmap
             return false;
         }
 
-        var transparentHorLines = new bool[Height];
-        for (int y = 0; y < Height; y++)
-        {
-            transparentHorLines[y] = true;
-            for (int x = 0; x < Width; x++)
-            {
-                if (GetPixel(x, y) != 0)
-                {
-                    transparentHorLines[y] = false;
-                    break;
-                }
-            }
-        }
+        var transparentHorLines = GetTransparentHorLines();
         for (int i = 0; i < transparentHorLines.Length; i++)
         {
             if (transparentHorLines[i])
@@ -838,19 +789,7 @@ public class BinaryOcrBitmap
             }
         }
 
-        var transparentVerLines = new bool[Width];
-        for (int x = 0; x < Width; x++)
-        {
-            transparentVerLines[x] = true;
-            for (int y = 0; y < Height; y++)
-            {
-                if (GetPixel(x, y) != 0)
-                {
-                    transparentVerLines[x] = false;
-                    break;
-                }
-            }
-        }
+        var transparentVerLines = GetTransparentVerLines();
         for (int i = 0; i < transparentVerLines.Length; i++)
         {
             if (transparentVerLines[i])

--- a/src/libuilogic/Translate/MergeAndSplitHelper.cs
+++ b/src/libuilogic/Translate/MergeAndSplitHelper.cs
@@ -446,6 +446,12 @@ public static partial class MergeAndSplitHelper
         public TranslateRow PreviousRow { get; set; }
         public int StartIndex { get; }
 
+        // Memo for ExceedsMaxSize: result.Text gets a new string identity whenever a row is
+        // merged in, so its URL-encoded length is recomputed only then - not per visited row,
+        // which re-encoded the whole accumulated text every iteration (O(N^2) over a run).
+        public string? EncodedLengthTextRef { get; set; }
+        public int EncodedLengthValue { get; set; }
+
         public MergeContext(TranslateRow[] sourceSubtitle, int index)
         {
             StartIndex = index;
@@ -482,10 +488,43 @@ public static partial class MergeAndSplitHelper
         }
     }
 
+    // Same count as Utilities.CountTagInText(builder.ToString(), c) without materializing the
+    // whole accumulated text into a fresh string per merged row.
+    private static int CountChar(StringBuilder builder, char c)
+    {
+        var count = 0;
+        foreach (var chunk in builder.GetChunks())
+        {
+            foreach (var ch in chunk.Span)
+            {
+                if (ch == c)
+                {
+                    count++;
+                }
+            }
+        }
+
+        return count;
+    }
+
+    private static readonly int NewLineUrlEncodeLength = Utilities.UrlEncodeLength(Environment.NewLine);
+
     private static bool ExceedsMaxSize(MergeResult result, MergeContext context, TranslateRow currentRow, int maxTextSize)
     {
-        return context.CurrentItem != null &&
-               Utilities.UrlEncodeLength(result.Text + Environment.NewLine + currentRow.Text) > maxTextSize;
+        if (context.CurrentItem == null)
+        {
+            return false;
+        }
+
+        // UrlEncodeLength is a per-char sum, so summing the parts equals encoding the
+        // concatenation without building the throwaway "accumulated + row" string.
+        if (!ReferenceEquals(context.EncodedLengthTextRef, result.Text))
+        {
+            context.EncodedLengthTextRef = result.Text;
+            context.EncodedLengthValue = Utilities.UrlEncodeLength(result.Text);
+        }
+
+        return context.EncodedLengthValue + NewLineUrlEncodeLength + Utilities.UrlEncodeLength(currentRow.Text) > maxTextSize;
     }
 
     private static bool ProcessRow(MergeResult result, MergeContext context, TranslateRow currentRow, int rowIndex, bool noSentenceEndingSource)
@@ -551,7 +590,7 @@ public static partial class MergeAndSplitHelper
             context.CurrentItem.TextIndexStart = result.Text.Length;
             context.CurrentItem.TextIndexEnd = result.Text.Length;
             context.CurrentItem.EndChar = endChar;
-            context.CurrentItem.EndCharOccurrences = Utilities.CountTagInText(context.TextBuilder.ToString(), endChar);
+            context.CurrentItem.EndCharOccurrences = CountChar(context.TextBuilder, endChar);
             result.MergeResultItems.Add(context.CurrentItem);
         }
 
@@ -582,7 +621,7 @@ public static partial class MergeAndSplitHelper
             {
                 var endChar = result.Text[^1];
                 context.CurrentItem.EndChar = endChar;
-                context.CurrentItem.EndCharOccurrences = Utilities.CountTagInText(context.TextBuilder.ToString(), endChar);
+                context.CurrentItem.EndCharOccurrences = CountChar(context.TextBuilder, endChar);
                 context.CurrentItem.TextIndexEnd = result.Text.Length;
             }
 
@@ -642,7 +681,7 @@ public static partial class MergeAndSplitHelper
             {
                 var endChar = result.Text[^1];
                 context.CurrentItem.EndChar = endChar;
-                context.CurrentItem.EndCharOccurrences = Utilities.CountTagInText(context.TextBuilder.ToString(), endChar);
+                context.CurrentItem.EndCharOccurrences = CountChar(context.TextBuilder, endChar);
             }
         }
 

--- a/src/ui/Features/Files/Compare/TextDiffHighlighter.cs
+++ b/src/ui/Features/Files/Compare/TextDiffHighlighter.cs
@@ -307,44 +307,19 @@ public static class TextDiffHighlighter
         var used1 = new bool[s1.Length];
         var used2 = new bool[s2.Length];
 
+        // Both selection routines pick the exact same cell (longest unused run; ties keep the
+        // smallest (i, j) in row-major order, like the original scan did). The per-cell walk
+        // has the lower constant on short texts but re-walks whole runs, which goes cubic on
+        // long repetitive text (a freeze in the Compare window / Multiple Replace preview);
+        // the anti-diagonal scan is O(n*m) per round, so it takes over above the threshold.
+        var useDiagonalScan = (long)s1.Length * s2.Length >= 10_000;
+
         // Find multiple common substrings
         while (true)
         {
-            int maxLen = 0;
-            int maxPos1 = 0;
-            int maxPos2 = 0;
-
-            // Build LCS table for unused parts
-            for (int i = 0; i < s1.Length; i++)
-            {
-                if (used1[i])
-                {
-                    continue;
-                }
-
-                for (int j = 0; j < s2.Length; j++)
-                {
-                    if (used2[j])
-                    {
-                        continue;
-                    }
-
-                    int len = 0;
-                    while (i + len < s1.Length && j + len < s2.Length &&
-                           !used1[i + len] && !used2[j + len] &&
-                           s1[i + len] == s2[j + len])
-                    {
-                        len++;
-                    }
-
-                    if (len > maxLen)
-                    {
-                        maxLen = len;
-                        maxPos1 = i;
-                        maxPos2 = j;
-                    }
-                }
-            }
+            var (maxLen, maxPos1, maxPos2) = useDiagonalScan
+                ? FindLongestUnusedRunByDiagonals(s1, s2, used1, used2)
+                : FindLongestUnusedRunByWalk(s1, s2, used1, used2);
 
             // If no common substring found or too short, stop
             if (maxLen < minLength)
@@ -366,5 +341,88 @@ public static class TextDiffHighlighter
         result.Sort((a, b) => a.pos1.CompareTo(b.pos1));
 
         return result;
+    }
+
+    private static (int maxLen, int maxPos1, int maxPos2) FindLongestUnusedRunByWalk(string s1, string s2, bool[] used1, bool[] used2)
+    {
+        int maxLen = 0;
+        int maxPos1 = 0;
+        int maxPos2 = 0;
+
+        for (int i = 0; i < s1.Length; i++)
+        {
+            if (used1[i])
+            {
+                continue;
+            }
+
+            for (int j = 0; j < s2.Length; j++)
+            {
+                if (used2[j])
+                {
+                    continue;
+                }
+
+                int len = 0;
+                while (i + len < s1.Length && j + len < s2.Length &&
+                       !used1[i + len] && !used2[j + len] &&
+                       s1[i + len] == s2[j + len])
+                {
+                    len++;
+                }
+
+                if (len > maxLen)
+                {
+                    maxLen = len;
+                    maxPos1 = i;
+                    maxPos2 = j;
+                }
+            }
+        }
+
+        return (maxLen, maxPos1, maxPos2);
+    }
+
+    private static (int maxLen, int maxPos1, int maxPos2) FindLongestUnusedRunByDiagonals(string s1, string s2, bool[] used1, bool[] used2)
+    {
+        int maxLen = 0;
+        int maxPos1 = 0;
+        int maxPos2 = 0;
+
+        // Walking each anti-diagonal backward, the run length starting at (i, j) is just the
+        // run below-right plus one - no per-cell re-walk, no table. The explicit tie-break
+        // compensates for the diagonal visiting order.
+        void WalkDiagonal(int startI, int startJ)
+        {
+            var steps = Math.Min(s1.Length - startI, s2.Length - startJ);
+            var below = 0; // run length starting at (i + 1, j + 1)
+            for (var t = steps - 1; t >= 0; t--)
+            {
+                int i = startI + t;
+                int j = startJ + t;
+                var run = !used1[i] && !used2[j] && s1[i] == s2[j] ? below + 1 : 0;
+                below = run;
+
+                if (run > maxLen ||
+                    (run == maxLen && run > 0 && (i < maxPos1 || (i == maxPos1 && j < maxPos2))))
+                {
+                    maxLen = run;
+                    maxPos1 = i;
+                    maxPos2 = j;
+                }
+            }
+        }
+
+        for (int startI = 0; startI < s1.Length; startI++)
+        {
+            WalkDiagonal(startI, 0);
+        }
+
+        for (int startJ = 1; startJ < s2.Length; startJ++)
+        {
+            WalkDiagonal(0, startJ);
+        }
+
+        return (maxLen, maxPos1, maxPos2);
     }
 }

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -73,6 +73,10 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
     private List<FixRuleDisplayItem> _allFixRules = new();
     private readonly LanguageFixCommonErrors _language;
     private bool _previewMode = true;
+
+    // Set while a bulk loop is flipping IsSelected on many fix items, so the per-item
+    // PropertyChanged handler skips its summary recount; the loop runs one recount at the end.
+    private bool _suppressFixesSummaryUpdate;
     public List<int> DeleteIndices = new();
     private List<FixDisplayItem> _oldFixes = new();
     private HashSet<(Guid? id, string action)>? _allowedFixLookup;
@@ -319,9 +323,21 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
     public void FixesSelectAll()
     {
         var selectAll = VisibleFixes.Any(f => !f.IsSelected);
-        foreach (var fix in VisibleFixes)
+
+        // Each IsSelected set raises PropertyChanged, whose handler re-runs the full
+        // summary/chip recount - O(visible x fixes) for one click. Suppress the per-item
+        // recounts during the loop and do a single one at the end.
+        _suppressFixesSummaryUpdate = true;
+        try
         {
-            fix.IsSelected = selectAll;
+            foreach (var fix in VisibleFixes)
+            {
+                fix.IsSelected = selectAll;
+            }
+        }
+        finally
+        {
+            _suppressFixesSummaryUpdate = false;
         }
 
         UpdateFixesSummary();
@@ -369,7 +385,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
     {
         item.PropertyChanged += (_, e) =>
         {
-            if (e.PropertyName == nameof(FixDisplayItem.IsSelected))
+            if (e.PropertyName == nameof(FixDisplayItem.IsSelected) && !_suppressFixesSummaryUpdate)
             {
                 UpdateFixesSummary();
             }

--- a/src/ui/Logic/FindService.cs
+++ b/src/ui/Logic/FindService.cs
@@ -25,14 +25,16 @@ public partial class FindService : IFindService
     // ReplaceAll/Count/FindAll call into regex mode once per line; caching the last-built Regex
     // avoids recompiling the same pattern for every line in the subtitle.
     private string? _cachedRegexPattern;
+    private RegexOptions _cachedRegexOptions;
     private Regex? _cachedRegex;
 
-    private Regex GetCachedRegex(string pattern)
+    private Regex GetCachedRegex(string pattern, RegexOptions options = RegexOptions.None)
     {
-        if (_cachedRegex == null || _cachedRegexPattern != pattern)
+        if (_cachedRegex == null || _cachedRegexPattern != pattern || _cachedRegexOptions != options)
         {
-            _cachedRegex = new Regex(pattern);
+            _cachedRegex = new Regex(pattern, options);
             _cachedRegexPattern = pattern;
+            _cachedRegexOptions = options;
         }
 
         return _cachedRegex;
@@ -567,7 +569,7 @@ public partial class FindService : IFindService
 
         try
         {
-            var regex = new Regex(pattern, options);
+            var regex = GetCachedRegex(pattern, options);
 
             if (startIndex > 0 && maxReplacements == 1)
             {
@@ -613,7 +615,7 @@ public partial class FindService : IFindService
 
             try
             {
-                var match = Regex.Match(searchLine, pattern, options);
+                var match = GetCachedRegex(pattern, options).Match(searchLine);
                 if (match.Success)
                 {
                     return (true, startIndex + match.Index, match.Value);
@@ -647,7 +649,7 @@ public partial class FindService : IFindService
 
             try
             {
-                var matches = Regex.Matches(searchLine, pattern, options);
+                var matches = GetCachedRegex(pattern, options).Matches(searchLine);
                 if (matches.Count > 0)
                 {
                     var lastMatch = matches[matches.Count - 1];
@@ -678,7 +680,7 @@ public partial class FindService : IFindService
             var searchLine = startIndex > 0 ? line.Substring(startIndex) : line;
             var originalLength = searchLine.Length;
             searchLine = NormalizeLineEndingsForRegex(searchLine, out var indexMap);
-            var match = Regex.Match(searchLine, RegexUtils.FixNewLine(searchText));
+            var match = GetCachedRegex(RegexUtils.FixNewLine(searchText)).Match(searchLine);
 
             if (match.Success)
             {
@@ -703,7 +705,7 @@ public partial class FindService : IFindService
 
             // Advance by 1 after each match so overlapping matches are found
             // (e.g. two long lines sharing the \n between them).
-            var regex = new Regex(RegexUtils.FixNewLine(searchText));
+            var regex = GetCachedRegex(RegexUtils.FixNewLine(searchText));
             Match? lastMatch = null;
             var pos = 0;
             while (pos < searchLine.Length)
@@ -740,7 +742,7 @@ public partial class FindService : IFindService
                 try
                 {
                     var searchLine = NormalizeLineEndingsForRegex(line);
-                    return Regex.Matches(searchLine, RegexUtils.FixNewLine(searchText)).Count;
+                    return GetCachedRegex(RegexUtils.FixNewLine(searchText)).Matches(searchLine).Count;
                 }
                 catch (ArgumentException)
                 {
@@ -768,7 +770,7 @@ public partial class FindService : IFindService
                 try
                 {
                     var searchLine = NormalizeLineEndingsForRegex(line, out var indexMap);
-                    var regexMatches = Regex.Matches(searchLine, RegexUtils.FixNewLine(searchText));
+                    var regexMatches = GetCachedRegex(RegexUtils.FixNewLine(searchText)).Matches(searchLine);
                     foreach (Match match in regexMatches)
                     {
                         matches.Add(new FindMatch(MapNormalizedIndex(indexMap, match.Index, line.Length), match.Value));
@@ -792,7 +794,7 @@ public partial class FindService : IFindService
 
                     try
                     {
-                        var regexMatches = Regex.Matches(line, pattern, options);
+                        var regexMatches = GetCachedRegex(pattern, options).Matches(line);
                         foreach (Match match in regexMatches)
                         {
                             matches.Add(new FindMatch(match.Index, match.Value));
@@ -824,8 +826,14 @@ public partial class FindService : IFindService
         return matches;
     }
 
-    private static int MapNormalizedIndex(List<int> indexMap, int normalizedIndex, int originalLength)
+    // A null indexMap means the line had no '\r', i.e. normalization was the identity mapping.
+    private static int MapNormalizedIndex(List<int>? indexMap, int normalizedIndex, int originalLength)
     {
+        if (indexMap == null)
+        {
+            return normalizedIndex < originalLength ? normalizedIndex : originalLength;
+        }
+
         return normalizedIndex < indexMap.Count ? indexMap[normalizedIndex] : originalLength;
     }
 
@@ -856,19 +864,17 @@ public partial class FindService : IFindService
         return normalized.ToString();
     }
 
-    private static string NormalizeLineEndingsForRegex(string line, out List<int> indexMap)
+    private static string NormalizeLineEndingsForRegex(string line, out List<int>? indexMap)
     {
-        indexMap = new List<int>(line.Length);
-
         if (!line.Contains('\r'))
         {
-            for (var i = 0; i < line.Length; i++)
-            {
-                indexMap.Add(i);
-            }
-
+            // The common case: nothing to normalize, so the mapping is the identity - a null
+            // map signals that to MapNormalizedIndex without allocating a per-line List.
+            indexMap = null;
             return line;
         }
+
+        indexMap = new List<int>(line.Length);
 
         var normalized = new StringBuilder(line.Length);
         for (var i = 0; i < line.Length; i++)

--- a/tests/UI/Features/Tools/FixCommonErrors/FixCommonErrorsSelectAllTests.cs
+++ b/tests/UI/Features/Tools/FixCommonErrors/FixCommonErrorsSelectAllTests.cs
@@ -1,0 +1,80 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
+
+namespace UITests.Features.Tools.FixCommonErrors;
+
+// Toggling "Select all" sets IsSelected on every visible fix item; each set raises
+// PropertyChanged, and the per-item handler used to re-run the full summary/chip recount,
+// making one click O(visible x fixes). The bulk loop must suppress the per-item recounts
+// and run exactly one at the end - with the same end state as per-item toggling.
+public class FixCommonErrorsSelectAllTests
+{
+    private static FixCommonErrorsViewModel BuildViewModelWithFixes(int count, bool isSelected)
+    {
+        var vm = new FixCommonErrorsViewModel(null!, null!, null!);
+        for (var i = 0; i < count; i++)
+        {
+            // Public IFixCallbacks entry point; _previewMode starts true, so this populates
+            // Fixes and (with no filter chips yet) VisibleFixes.
+            vm.AddFixToListView(new Paragraph($"line {i}", i * 1000, i * 1000 + 900), "Fix commas", "before", "after", isSelected);
+        }
+
+        return vm;
+    }
+
+    [AvaloniaFact]
+    public void FixesSelectAll_RunsSummaryRecountOnce_NotOncePerItem()
+    {
+        var vm = BuildViewModelWithFixes(5, isSelected: false);
+
+        // ApplySelectedFixesText is rewritten with the global selected count on every summary
+        // recount, so per-item recounts would step it "(1)", "(2)", ... - one event per item.
+        var applyTextChanges = 0;
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(vm.ApplySelectedFixesText))
+            {
+                applyTextChanges++;
+            }
+        };
+
+        vm.FixesSelectAll();
+
+        Assert.Equal(1, applyTextChanges);
+    }
+
+    [AvaloniaFact]
+    public void FixesSelectAll_EndStateMatchesPerItemToggling()
+    {
+        var vm = BuildViewModelWithFixes(5, isSelected: false);
+
+        vm.FixesSelectAll();
+
+        Assert.All(vm.Fixes, f => Assert.True(f.IsSelected));
+        Assert.EndsWith("(5)", vm.ApplySelectedFixesText);
+        Assert.Equal(Nikse.SubtitleEdit.Logic.Config.Se.Language.General.SelectNone, vm.FixesSelectAllText);
+    }
+
+    [AvaloniaFact]
+    public void FixesSelectAll_DeselectsAll_WhenEverythingIsSelected()
+    {
+        var vm = BuildViewModelWithFixes(3, isSelected: true);
+
+        vm.FixesSelectAll();
+
+        Assert.All(vm.Fixes, f => Assert.False(f.IsSelected));
+        Assert.EndsWith("(0)", vm.ApplySelectedFixesText);
+        Assert.Equal(Nikse.SubtitleEdit.Logic.Config.Se.Language.General.SelectAll, vm.FixesSelectAllText);
+    }
+
+    [AvaloniaFact]
+    public void SingleItemToggle_StillUpdatesSummary()
+    {
+        var vm = BuildViewModelWithFixes(2, isSelected: false);
+
+        vm.Fixes[0].IsSelected = true;
+
+        Assert.EndsWith("(1)", vm.ApplySelectedFixesText);
+    }
+}

--- a/tests/benchmarks/HotPathRound3Benchmarks.cs
+++ b/tests/benchmarks/HotPathRound3Benchmarks.cs
@@ -1,0 +1,313 @@
+using Avalonia;
+using Avalonia.Headless;
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+using Nikse.SubtitleEdit.UiLogic.Translate;
+using System.Reflection;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// Find/Count/ReplaceAll walk every line of the subtitle. Regex mode built an identity
+/// List&lt;int&gt; index map per line (only needed when the line contains '\r'), and the
+/// whole-word paths compiled a new Regex per line.
+/// </summary>
+[MemoryDiagnoser]
+public class FindServiceRound3Benchmarks
+{
+    private FindService _service = null!;
+    private List<string> _lines = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var sentences = new[]
+        {
+            "It was the best of times, it was the worst of times.",
+            "Are you coming with us?",
+            "- No.\n- Then stay here and wait for the others.",
+            "I told you already, this is not going to work out the way you think it will.",
+            "Hello there.",
+            "Somewhere in Denmark,\r\na quiet evening begins.",
+        };
+
+        _lines = new List<string>(2000);
+        for (var i = 0; i < 2000; i++)
+        {
+            _lines.Add(sentences[i % sentences.Length]);
+        }
+
+        _service = new FindService();
+    }
+
+    [Benchmark]
+    public int CountRegex()
+    {
+        return _service.Count(@"t[he]+\b", _lines, false, FindService.FindMode.RegularExpression);
+    }
+
+    [Benchmark]
+    public int FindAllRegex()
+    {
+        _service.Initialize(_lines, 0, false, FindService.FindMode.RegularExpression);
+        return _service.FindAll(@"\bth\w+").Count;
+    }
+
+    [Benchmark]
+    public int FindAllWholeWord()
+    {
+        _service.Initialize(_lines, 0, true, FindService.FindMode.CaseInsensitive);
+        return _service.FindAll("the").Count;
+    }
+
+    [Benchmark]
+    public int ReplaceAllWholeWord()
+    {
+        // Replacing "the" with itself keeps the run idempotent across iterations while
+        // still exercising the full per-line whole-word replace path.
+        _service.Initialize(_lines, 0, true, FindService.FindMode.CaseInsensitive);
+        return _service.ReplaceAll("the", "the");
+    }
+}
+
+/// <summary>
+/// The Compare window diffs every changed line pair with a repeated longest-common-substring
+/// walk that went near-cubic on repetitive text; same greedy result now comes from an
+/// O(n*m)-per-round suffix-run table.
+/// </summary>
+[MemoryDiagnoser]
+public class TextDiffRound3Benchmarks
+{
+    private Func<string, string, int, List<(int pos1, int pos2, int length)>> _findCommonSubstrings = null!;
+    private (string a, string b)[] _pairs = null!;
+    private string _longA = null!;
+    private string _longB = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var type = typeof(FindService).Assembly.GetType("Nikse.SubtitleEdit.Features.Files.Compare.TextDiffHighlighter")!;
+        var method = type.GetMethod("FindLongestCommonSubstrings", BindingFlags.NonPublic | BindingFlags.Static)!;
+        _findCommonSubstrings = method.CreateDelegate<Func<string, string, int, List<(int, int, int)>>>();
+
+        _pairs = new[]
+        {
+            ("It was the best of times, it was the worst of times.",
+             "It was the best of days, it was the worst of days."),
+            ("I told you already, this is not going to work out.",
+             "I told you before, this is never going to work out."),
+            ("- No.\n- Then stay here and wait for the others.",
+             "- No!\n- Then wait here and stay with the others."),
+            // Repetitive text is the old walk's worst case (every position matches every position).
+            ("la la la la la la la la la la la la la la la la la la",
+             "la la la la la la la la la la la la la la la la laa la"),
+            ("Somewhere in Denmark, a quiet evening begins to fall.",
+             "Somewhere in Sweden, a quiet morning begins to dawn."),
+        };
+
+        _longA = string.Concat(Enumerable.Repeat("ha ha ha he he ", 30));
+        _longB = _longA.Remove(200, 3).Insert(320, "hi hi ");
+    }
+
+    [Benchmark]
+    public int DiffLinePairs()
+    {
+        var total = 0;
+        foreach (var (a, b) in _pairs)
+        {
+            total += _findCommonSubstrings(a, b, 3).Count;
+        }
+
+        return total;
+    }
+
+    [Benchmark]
+    public int DiffRepetitiveLongPair()
+    {
+        // Long repetitive text: every position matches every position and the common runs
+        // are long, the shape that sent the naive walk cubic (a UI freeze in the Compare
+        // window / Multiple Replace preview).
+        return _findCommonSubstrings(_longA, _longB, 3).Count;
+    }
+}
+
+/// <summary>
+/// Auto-translate merges rows until the URL-encoded batch limit; the size check re-encoded
+/// the whole accumulated text (plus a throwaway concat) for every visited row, and the
+/// sentence-end bookkeeping materialized the accumulated StringBuilder per merged row.
+/// </summary>
+[MemoryDiagnoser]
+public class MergeSplitRound3Benchmarks
+{
+    private TranslateRow[] _rows = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var sentences = new[]
+        {
+            "and then we walked along the shore for a while",
+            "because nobody had told them what happened that night",
+            "which was exactly what she had been afraid of",
+            "so the others kept going without looking back",
+            "until the lights of the harbour finally came into view.",
+        };
+
+        _rows = new TranslateRow[400];
+        for (var i = 0; i < _rows.Length; i++)
+        {
+            _rows[i] = new TranslateRow
+            {
+                Number = i + 1,
+                Show = TimeSpan.FromMilliseconds(i * 2500),
+                Hide = TimeSpan.FromMilliseconds(i * 2500 + 2200),
+                Text = sentences[i % sentences.Length],
+            };
+        }
+    }
+
+    [Benchmark]
+    public int MergeMultipleLines()
+    {
+        var result = MergeAndSplitHelper.MergeMultipleLines(_rows, 0, 10000, false, false);
+        return result.Text.Length;
+    }
+}
+
+/// <summary>
+/// nOCR runs several shape predicates per unmatched glyph; each one re-scanned the whole
+/// bitmap for empty rows into a fresh bool[Height]. Bitmap construction happens inside the
+/// benchmark so per-instance caching is measured from cold, like real matching.
+/// </summary>
+[MemoryDiagnoser]
+public class BinaryOcrPredicateRound3Benchmarks
+{
+    private (int width, int height, List<(int x, int y)> pixels)[] _shapes = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var random = new Random(42);
+        _shapes = new (int, int, List<(int, int)>)[60];
+        for (var i = 0; i < _shapes.Length; i++)
+        {
+            var width = random.Next(6, 40);
+            var height = random.Next(12, 60);
+            var pixels = new List<(int, int)>();
+            for (var y = 0; y < height; y++)
+            {
+                for (var x = 0; x < width; x++)
+                {
+                    if (random.Next(4) == 0)
+                    {
+                        pixels.Add((x, y));
+                    }
+                }
+            }
+
+            _shapes[i] = (width, height, pixels);
+        }
+    }
+
+    [Benchmark]
+    public int AllPredicates()
+    {
+        var hits = 0;
+        foreach (var (width, height, pixels) in _shapes)
+        {
+            var bitmap = new BinaryOcrBitmap(width, height);
+            foreach (var (x, y) in pixels)
+            {
+                bitmap.SetPixel(x, y);
+            }
+
+            if (bitmap.IsPeriod()) hits++;
+            if (bitmap.IsPeriodAtTop(20)) hits++;
+            if (bitmap.IsComma()) hits++;
+            if (bitmap.IsApostrophe()) hits++;
+            if (bitmap.IsLowercaseI(out _)) hits++;
+            if (bitmap.IsLowercaseJ()) hits++;
+            if (bitmap.IsColon()) hits++;
+            if (bitmap.IsDash()) hits++;
+            if (bitmap.IsExclamationMark()) hits++;
+            if (bitmap.IsLowercaseL()) hits++;
+            if (bitmap.IsC()) hits++;
+            if (bitmap.IsO()) hits++;
+        }
+
+        return hits;
+    }
+}
+
+/// <summary>
+/// Fix common errors: select-all toggled IsSelected per visible item, and every set re-ran
+/// the full summary/chip recount - O(visible x fixes x chips) per click.
+/// </summary>
+[MemoryDiagnoser]
+public class FixesSelectAllRound3Benchmarks
+{
+    private static bool _avaloniaInitialized;
+    private FixCommonErrorsViewModel _viewModel = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        if (!_avaloniaInitialized)
+        {
+            _avaloniaInitialized = true;
+            AppBuilder.Configure<Application>()
+                .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false })
+                .UseSkia()
+                .WithInterFont()
+                .SetupWithoutStarting();
+        }
+
+        var actions = new[]
+        {
+            "Fix empty lines", "Fix overlapping display times", "Fix short display times",
+            "Fix long display times", "Fix invalid italic tags", "Fix unneeded spaces",
+        };
+
+        _viewModel = new FixCommonErrorsViewModel(null!, null!, null!);
+        for (var i = 0; i < 1500; i++)
+        {
+            var p = new Paragraph($"Line {i} text goes here.", i * 2000, i * 2000 + 1500) { Number = i + 1 };
+            // Goes through the same path the scan uses, so the per-item PropertyChanged
+            // subscription that drives the summary recount is attached.
+            _viewModel.AddFixToListView(p, actions[i % actions.Length], "before", "after", i % 3 != 0);
+        }
+    }
+
+    [Benchmark]
+    public int SelectAllToggle()
+    {
+        // Alternates select-all/deselect-all; each call is one full bulk pass.
+        _viewModel.FixesSelectAll();
+        return _viewModel.Fixes.Count;
+    }
+}
+
+/// <summary>
+/// Unchanged code path used as the run-to-run noise yardstick - if this one moves, the
+/// difference is machine noise, not the optimizations.
+/// </summary>
+[MemoryDiagnoser]
+public class NoiseYardstickRound3Benchmarks
+{
+    private string _text = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _text = string.Concat(Enumerable.Repeat("It was the best of times, æøå 1234. ", 200));
+    }
+
+    [Benchmark]
+    public int UrlEncodeLengthYardstick()
+    {
+        return Utilities.UrlEncodeLength(_text);
+    }
+}

--- a/tests/libuilogic/Ocr/BinaryOcrBitmapTests.cs
+++ b/tests/libuilogic/Ocr/BinaryOcrBitmapTests.cs
@@ -1,0 +1,70 @@
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+
+namespace LibUiLogicTests.Ocr;
+
+public class BinaryOcrBitmapTests
+{
+    private static BinaryOcrBitmap MakeFilled(int width, int height, int y, int skipRow = -1)
+    {
+        var bmp = new BinaryOcrBitmap(width, height) { Y = y };
+        var colored = 0;
+        for (var yy = 0; yy < height; yy++)
+        {
+            if (yy == skipRow)
+            {
+                continue;
+            }
+
+            for (var xx = 0; xx < width; xx++)
+            {
+                bmp.SetPixel(xx, yy);
+                colored++;
+            }
+        }
+
+        bmp.NumberOfColoredPixels = colored;
+        return bmp;
+    }
+
+    /// <summary>
+    /// The shape predicates cache row/column occupancy scans; SetPixel after a
+    /// predicate call must invalidate that cache so results stay correct.
+    /// </summary>
+    [Fact]
+    public void IsLowercaseL_SetPixelAfterPredicate_InvalidatesCache()
+    {
+        // 5x25 with one transparent row fails IsLowercaseL.
+        var bmp = MakeFilled(5, 25, 10, skipRow: 12);
+        Assert.False(bmp.IsLowercaseL()); // warm the cache
+
+        // Fill the transparent row; the predicate must see the new pixels.
+        for (var x = 0; x < bmp.Width; x++)
+        {
+            bmp.SetPixel(x, 12);
+        }
+
+        bmp.NumberOfColoredPixels = 5 * 25;
+        Assert.True(bmp.IsLowercaseL());
+    }
+
+    [Fact]
+    public void IsLowercaseL_ColorsReplacedAfterPredicate_InvalidatesCache()
+    {
+        var bmp = MakeFilled(5, 25, 10);
+        Assert.True(bmp.IsLowercaseL()); // warm the cache
+
+        // Replace pixel data with an all-transparent buffer; cached rows must not survive.
+        bmp.Colors = new byte[5 * 25];
+        bmp.NumberOfColoredPixels = 0;
+        Assert.False(bmp.IsLowercaseL());
+    }
+
+    [Fact]
+    public void IsDash_WarmCache_ReturnsSameResult()
+    {
+        // 12x5 fully filled at Y=15 satisfies IsDash on both cold and warm cache paths.
+        var bmp = MakeFilled(12, 5, 15);
+        Assert.True(bmp.IsDash());
+        Assert.True(bmp.IsDash());
+    }
+}


### PR DESCRIPTION
Third perf pass, same methodology as #12959/#12985: new benchmark classes in `tests/benchmarks/HotPathRound3Benchmarks.cs` (including an unchanged noise yardstick), baseline measured via `git stash` of the src changes with the identical benchmark binary, and semantic equivalence proven by fuzzing the new code against verbatim copies of the old implementations before any measurement.

## Numbers (Apple M4, ShortRun, MemoryDiagnoser)

| Benchmark | Before | After | Win |
|---|---|---|---|
| Fix common errors: select-all click (1500 fixes) | 29,755 µs / 234 KB | 41.9 µs / 236 B | **710×** |
| Find/replace: whole-word ReplaceAll (2000 lines) | 6,173 µs / 6.3 MB | 981 µs / 0.6 MB | **6.3×, −90% alloc** |
| Find/replace: FindAll regex (2000 lines) | 1,618 µs / 1.77 MB | 1,239 µs / 1.39 MB | 1.3× |
| Auto-translate: MergeMultipleLines (400 rows) | 1,171 µs / 2.25 MB | 898 µs / 1.15 MB | 1.3×, −49% alloc |
| nOCR: 12 shape predicates × 60 glyphs | 104.6 µs / 60 KB | 95.4 µs / 58 KB | 1.1× |
| Compare diff: repetitive 450-char pair | 4,648 µs | 2,470 µs | **1.9×** (growing with length) |
| Compare diff: five typical line pairs | 123.9 µs / 1.5 KB | 130.4 µs / 1.5 KB | unchanged (within noise) |
| Noise yardstick (unchanged code) | 11.88 µs | 12.20 µs | ±3% = machine noise |

## The five changes

1. **Fix common errors select-all** (`FixCommonErrorsViewModel`): every per-item `IsSelected` write re-ran the full summary/chip recount — O(visible × fixes × chips) per click. A suppression flag lets the bulk loop run one final recount. New regression test asserts exactly one recount and identical end state; the test fails with the guard removed (negative-control verified).
2. **FindService** (`src/ui/Logic/FindService.cs`): regex-mode paths allocated and filled an identity `List<int>` index map for every line (only lines containing `\r` need a map — `null` now means identity), and the whole-word find/replace paths compiled a `new Regex` per line (the existing single-entry cache now keys on pattern + `RegexOptions` and is used by all per-line paths).
3. **Auto-translate merge** (`MergeAndSplitHelper`): `ExceedsMaxSize` URL-encoded `result.Text + newline + row` from scratch for every visited row — O(N²) over a merge run. `UrlEncodeLength` is a strict per-char sum, so the parts are summed instead, with the accumulated text's encoded length memoized by string identity (any content change produces a new string instance). The sentence-end bookkeeping also materialized `TextBuilder.ToString()` per merged row just to count one char — now counted over the builder's chunks.
4. **nOCR shape predicates** (`BinaryOcrBitmap`): 8 predicates re-scanned the whole bitmap into a fresh `bool[Height]` (3 more into `bool[Width]`) on every call, and several run back-to-back per unmatched glyph. Row/column occupancy is now computed once per instance, lazily, and invalidated by `SetPixel`/`Colors` writes (mutability audit: no call site mutates after predicates run today; invalidation added regardless). With cache-invalidation tests.
5. **Compare-window diff** (`TextDiffHighlighter`): the repeated longest-common-substring selection walked the full common run from every (i,j), which goes cubic on long repetitive text (a real freeze shape for the Compare window / Multiple Replace preview). Hybrid: the original walk below a 10k char-product threshold — typical pairs keep their exact old speed — and an anti-diagonal O(n·m) scan above it. Both routines provably select the identical cell (the tie-break reproduces the original row-major first-maximum rule).

## Equivalence verification (before benchmarking)

- FindService: fuzzed against a verbatim origin/main copy of the whole class — 14,400 operation comparisons (Count/FindAll/FindNext/FindPrevious/ReplaceAll × 3 modes × whole-word on/off, lines with `\n`, `\r\n`, lone `\r`, unicode, empties) — all identical, including replaced line contents.
- LCS: 3,200 pairs against the verbatim old algorithm, biased to tiny alphabets (dense ties) and including 200 long pairs that cross the hybrid threshold — all identical.
- OCR predicates: 1,472 bitmaps / 38,272 predicate comparisons against the old implementations, including post-mutation re-checks — all identical.
- Merge: `UrlEncodeLength` additivity (5,000 checks) + chunk-counter equivalence (3,000 checks) — all identical.
- Full suites: 1,518 UI tests + 149 LibUiLogic tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)