### PR TITLE
Update auto-translate model lists for August 2026 provider changes

### DIFF
--- a/src/libse/Settings/ToolsSettings.cs
+++ b/src/libse/Settings/ToolsSettings.cs
@@ -157,7 +157,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
             OpenAiCompatibleTranslateModel = string.Empty;
             GroqUrl = "https://api.groq.com/openai/v1/chat/completions";
             GroqPrompt = "Translate from {0} to {1}, keep punctuation as input, keep line breaks exactly the same, do not censor the translation, give only the output without comments:";
-            GroqModel = "llama-3.3-70b-versatile"; // GroqTranslate.Models[0] in LibUiLogic
+            GroqModel = "openai/gpt-oss-120b"; // GroqTranslate.Models[0] in LibUiLogic
             DeepSeekUrl = "https://api.deepseek.com/chat/completions";
             DeepSeekPrompt = "Translate from {0} to {1}, keep punctuation as input, keep line breaks exactly the same, do not censor the translation, give only the output without comments:";
             DeepSeekModel = "deepseek-v4-flash"; // DeepSeekTranslate.Models[0] in LibUiLogic
@@ -185,7 +185,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
             KoboldCppTemperature = 0.4m;
             AnthropicApiUrl = "https://api.anthropic.com/v1/messages";
             AnthropicPrompt = "Translate from {0} to {1}, keep sentences in {1} as they are, do not censor the translation, give only the output without comments:";
-            AnthropicApiModel = "claude-opus-4-8"; // AnthropicTranslate.Models[0] in LibUiLogic
+            AnthropicApiModel = "claude-opus-5"; // AnthropicTranslate.Models[0] in LibUiLogic
             BaiduUrl = "https://fanyi-api.baidu.com";
             GeminiModel = "gemini-flash-latest"; // GeminiTranslate.Models[0] in LibUiLogic
             GeminiPrompt = "Please translate the following text from {0} to {1}, keep line breaks exactly the same, do not censor the translation, only write the result:";

--- a/src/libuilogic/AutoTranslate/AnthropicTranslate.cs
+++ b/src/libuilogic/AutoTranslate/AnthropicTranslate.cs
@@ -30,6 +30,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
         /// </summary>
         public static string[] Models => new[]
         {
+            "claude-opus-5",
             "claude-opus-4-8",
             "claude-sonnet-5",
             "claude-haiku-4-5",

--- a/src/libuilogic/AutoTranslate/AvalAi.cs
+++ b/src/libuilogic/AutoTranslate/AvalAi.cs
@@ -45,6 +45,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             "gpt-oss-20b",
 
             // Google / Gemini
+            "gemini-3.6-flash",
             "gemini-3.5-flash",
             "gemini-3.1-pro-preview",
             "gemini-3.1-flash-lite",
@@ -53,6 +54,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             "gemini-2.5-flash-lite",
 
             // Anthropic Claude
+            "claude-opus-5",
             "claude-opus-4.8",
             "claude-sonnet-5",
             "claude-haiku-4.5",

--- a/src/libuilogic/AutoTranslate/ChatGptTranslate.cs
+++ b/src/libuilogic/AutoTranslate/ChatGptTranslate.cs
@@ -40,7 +40,6 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",
             "gpt-5.5",
             "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano",
-            "gpt-5.3-chat",
             "gpt-5.2",
             "gpt-5.1",
             "gpt-5", "gpt-5-mini", "gpt-5-nano",

--- a/src/libuilogic/AutoTranslate/GeminiTranslate.cs
+++ b/src/libuilogic/AutoTranslate/GeminiTranslate.cs
@@ -35,7 +35,9 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             "gemini-flash-latest",
 
             // Gemini 3.x - Latest Generation
+            "gemini-3.6-flash",
             "gemini-3.5-flash",
+            "gemini-3.5-flash-lite",
             "gemini-3.1-pro-preview",
             "gemini-3.1-flash-lite",
             "gemini-3-flash-preview",

--- a/src/libuilogic/AutoTranslate/GroqTranslate.cs
+++ b/src/libuilogic/AutoTranslate/GroqTranslate.cs
@@ -30,16 +30,11 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
         public static string[] Models => new[]
         {
             // High-Performance / Frontier Multilingual
-            "llama-3.3-70b-versatile",                      // Proven high-reliability translator (Production)
             "openai/gpt-oss-120b",                          // Extreme reasoning & nuance (Production)
 
             // Medium / Efficient Multilingual
             "openai/gpt-oss-20b",                           // High-speed reasoning model (Production)
-            "qwen/qwen3-32b",                               // Exceptional for Asian & European languages (Preview)
-            "meta-llama/llama-4-scout-17b-16e-instruct",    // Massive context for long documents (Preview)
-
-            // Lightweight / Fast Translation
-            "llama-3.1-8b-instant",                         // Lowest latency for short strings (Production)
+            "qwen/qwen3.6-27b",                             // Strong multilingual mid-size model (Preview)
 
             // Agentic systems
             "groq/compound",                                // Groq compound system

--- a/src/libuilogic/AutoTranslate/OpenRouterTranslate.cs
+++ b/src/libuilogic/AutoTranslate/OpenRouterTranslate.cs
@@ -32,6 +32,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             // High-Reasoning & Multilingual (The Leaders)
             "openai/gpt-5.6-sol",                       // OpenAI flagship for complex professional work
             "openai/gpt-5.5",                           // Previous-gen flagship general-purpose translator
+            "anthropic/claude-opus-5",                  // Current Anthropic flagship for nuanced translation
             "anthropic/claude-opus-4.8",                // Exceptional nuance and formal tone preservation
             "anthropic/claude-sonnet-5",                // Strong balance of quality and cost
             "google/gemini-3.1-pro-preview",            // Massive context for translating whole books
@@ -42,7 +43,8 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             // Efficient / Fast Translation
             "openai/gpt-5.6-terra",                     // Balanced intelligence and cost
             "openai/gpt-5.6-luna",                      // Cost-optimized, high-volume
-            "google/gemini-3.5-flash",                  // Google's most intelligent flash model
+            "google/gemini-3.6-flash",                  // Google's newest flash model, cheaper and smarter
+            "google/gemini-3.5-flash",                  // Strong previous-gen flash model
             "google/gemini-3.1-flash-lite",             // Speed-optimized multimodal
             "anthropic/claude-haiku-4.5",               // Fast Anthropic option
             "deepseek/deepseek-v4-flash",               // Low-latency DeepSeek

--- a/src/libuilogic/AutoTranslate/PerplexityTranslate.cs
+++ b/src/libuilogic/AutoTranslate/PerplexityTranslate.cs
@@ -32,14 +32,17 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             "openai/gpt-5.6-sol",
             "openai/gpt-5.6-terra",
             "openai/gpt-5.6-luna",
+            "anthropic/claude-opus-5",
             "anthropic/claude-opus-4-8",
             "anthropic/claude-sonnet-5",
             "anthropic/claude-haiku-4-5",
+            "google/gemini-3.6-flash",
             "google/gemini-3.5-flash",
             "google/gemini-3.1-pro-preview",
             "google/gemini-3.1-flash-lite",
             "xai/grok-4.5",
             "perplexity/glm-5.2",
+            "perplexity/kimi-k3",
             "perplexity/kimi-k2.7-code",
         };
 


### PR DESCRIPTION
Review of all auto-translate engine model lists against live provider catalogs (2026-08-07).

## Urgent removals
- **Groq**: `llama-3.3-70b-versatile`, `llama-3.1-8b-instant`, `qwen/qwen3-32b`, and `meta-llama/llama-4-scout-17b-16e-instruct` all [shut down 2026-08-16](https://console.groq.com/docs/deprecations). Added the recommended replacement `qwen/qwen3.6-27b`; the settings default `GroqModel` moves to `openai/gpt-oss-120b`.
- **OpenAI**: `gpt-5.3-chat` [retires 2026-08-10](https://developers.openai.com/api/docs/deprecations) (→ gpt-5.6-sol). Note `gpt-5`/`-mini`/`-nano` are deprecated with a 2026-12-11 shutdown — left in for now.

## Additions
- **Anthropic**: `claude-opus-5` — current Opus, drop-in at Opus 4.8 pricing; new list head and settings default.
- **Gemini**: `gemini-3.6-flash` (GA, cheaper and better than 3.5-flash) and `gemini-3.5-flash-lite` (GA).
- **Perplexity** (verified against the [Agent API catalog](https://docs.perplexity.ai/docs/agent-api/models.md)): `anthropic/claude-opus-5`, `google/gemini-3.6-flash`, `perplexity/kimi-k3`.
- **OpenRouter / AvalAi**: mirrored `claude-opus-5` and `gemini-3.6-flash`.

## Verified current, unchanged
DeepSeek (v4-flash/pro), Mistral (`-latest` aliases), Nvidia NIM list.

LibUiLogic builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)