### PR TITLE
WebVTT: style manager, voices and browser preview

### DIFF
--- a/docs/features/webvtt-styles.md
+++ b/docs/features/webvtt-styles.md
@@ -1,0 +1,79 @@
+# WebVTT Styles and Voices
+
+Manage the `STYLE` blocks of a WebVTT file — the cue classes referenced from the subtitle text as `<c.name>` — and the `<v Name>` voices used for speaker labelling.
+
+**Toolbar:** the styles button (shown when the current format is WebVTT)
+**Right-click a line:** `Styles`, `Voices`, `Browser preview`
+
+## WebVTT Styles
+
+A WebVTT style is CSS attached to a cue class:
+
+```
+WEBVTT
+
+STYLE
+::cue(.narrator) { color:rgb(255,255,0); font-style:italic }
+```
+
+A line then references it with `<c.narrator>Text</c>`, and several classes can be combined: `<c.narrator.small>Text</c>`.
+
+### How to Use
+
+1. Open or convert a subtitle to **WebVTT**.
+2. Click the styles button in the toolbar to open the style manager.
+3. Add, duplicate, remove, import or export styles in the left panel.
+4. Select a style to edit its properties on the right; the preview and the raw CSS update as you type.
+5. Click **OK** to write the styles back into the file header.
+
+### Style Properties
+
+Every CSS property is optional. Each colour has its own check box — an unchecked colour is left out of the style rather than written as a default, so a style that only sets `color` stays that way after a visit to the editor.
+
+- **Font:** name and size (`font-family`, `font-size`)
+- **Style:** bold, italic, underline, strikeout
+- **Color:** the text colour (`color`)
+- **Background:** the cue box colour (`background-color`)
+- **Shadow:** colour and width (`text-shadow`)
+
+Sizes are written in pixels. A style whose font size uses a relative unit (`em`, `%`) is left alone — Subtitle Edit has no pixel value to show for it, so the size field stays empty and the declaration is preserved only if you do not change it.
+
+### Reordering, Import and Export
+
+- Reorder styles from the right-click menu — **Move up** (`Ctrl+Up`), **Move down** (`Ctrl+Down`), **Move to top**, **Move to bottom**. This is the order the styles are written to the file with.
+- **Import** reads the `STYLE` blocks of another WebVTT file and lets you pick which ones to take. Imported names that clash with an existing style are given a numbered suffix.
+- **Export** writes the chosen styles to a small WebVTT file containing only a `STYLE` block, for reuse in other subtitles.
+
+Two styles with the same name are flagged in the editor: a cue class is keyed by name, so the second one would simply shadow the first when the file is read back.
+
+### Applying a Style to Lines
+
+Select one or more lines, right-click and choose **Styles**. The check marks start from the focused line. Checking styles wraps the selected lines in `<c...>`; clearing all of them removes the class tags again.
+
+## Voices
+
+WebVTT marks a speaker with a voice span: `<v Joe>Where are you?`
+
+Select one or more lines, right-click and choose **Voices**:
+
+- Pick one of the voices already used in the file.
+- **New voice...** prompts for a name and applies it.
+- **Remove voices** strips the `<v>` tags from the selected lines.
+
+Setting a voice replaces any voice already on the line rather than nesting a second tag.
+
+## Browser Preview
+
+With a video loaded in a browser-playable container (`.mp4`, `.m4v`, `.webm`, `.ogv`, `.mov`), right-click a line and choose **Browser preview**. Subtitle Edit writes a temporary HTML page that plays the video with the current subtitle attached as a WebVTT text track and opens it in your default browser, so you can check the cues in a real WebVTT renderer. The temporary page is deleted again shortly after it is opened.
+
+## Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| F1 | Show help |
+| Ctrl+Up / Ctrl+Down | Move the selected style up / down |
+| Escape | Close dialog |
+
+## See Also
+
+- [ASSA Styles](assa-styles.md) — the equivalent for ASS/SSA subtitles

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,6 +98,9 @@ Subtitle Edit is a free, open-source editor for video subtitles. This is the doc
 - [ASSA Apply Advanced Effects](features/assa-apply-advanced-effects.md) — Apply cinematic and creative animation effects
 - [ASSA Apply Custom Override Tags](features/assa-override-tags.md) — Apply custom tags
 
+### WebVTT
+- [WebVTT Styles and Voices](features/webvtt-styles.md) — Manage cue classes, voices and browser preview
+
 ### Options
 - [Settings](features/settings.md) — Application settings
 - [Shortcuts](features/shortcuts.md) — Keyboard shortcuts

--- a/src/libse/Common/WebVttHelper.cs
+++ b/src/libse/Common/WebVttHelper.cs
@@ -148,6 +148,10 @@ namespace Nikse.SubtitleEdit.Core.Common
             {
                 webVttStyle.FontName = value;
             }
+            else if (name == "font-size")
+            {
+                SetFontSize(webVttStyle, value);
+            }
             else if (name == "font-style")
             {
                 SetFontStyle(webVttStyle, value);
@@ -255,6 +259,26 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
         }
 
+        /// <summary>
+        /// Reads a <c>font-size</c> declaration. Only absolute pixel sizes are taken - a relative
+        /// size (em/rem/%/"larger") has no fixed pixel value, and <see cref="WebVttStyle.FontSize"/>
+        /// has nothing to express it with, so those are left unset rather than guessed at.
+        /// </summary>
+        private static void SetFontSize(WebVttStyle webVttStyle, string value)
+        {
+            var s = value.Trim();
+            if (s.EndsWith("px", StringComparison.OrdinalIgnoreCase))
+            {
+                s = s.Substring(0, s.Length - 2).Trim();
+            }
+
+            // Anything left with a unit on it ("1.5em", "120%") fails to parse and is skipped.
+            if (decimal.TryParse(s, NumberStyles.Number, CultureInfo.InvariantCulture, out var number) && number > 0)
+            {
+                webVttStyle.FontSize = number;
+            }
+        }
+
         private static void SetFontStyle(WebVttStyle webVttStyle, string value)
         {
             if (value == "italic" || value == "oblique")
@@ -295,7 +319,13 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return;
             }
 
-            if (int.TryParse(arr[1].Replace("px", string.Empty), out var number))
+            // CSS lengths may be fractional ("1.5px"), and the writer round-trips whatever the
+            // user picked, so parse invariant decimals rather than integers only.
+            if (decimal.TryParse(
+                    arr[1].Replace("px", string.Empty),
+                    NumberStyles.Number,
+                    CultureInfo.InvariantCulture,
+                    out var number))
             {
                 webVttStyle.ShadowColor = color;
                 webVttStyle.ShadowWidth = number;
@@ -407,9 +437,12 @@ namespace Nikse.SubtitleEdit.Core.Common
 
             if (style.ShadowColor.HasValue && style.ShadowWidth.HasValue && style.ShadowWidth > 0)
             {
+                // "#101010 3px" - one space, no space before "px", which is what SetTextShadow
+                // reads back. A missing $ used to emit the interpolation itself here, so the
+                // shadow was written as unparsable CSS and lost on the next read.
                 var colorString = Utilities.ColorToHexWithTransparency(style.ShadowColor.Value);
-                var widthString = "{style.ShadowWidth.Value.ToString(CultureInfo.InvariantCulture)} px";
-                sb.Append($"text-shadow: {colorString} {widthString}");
+                var widthString = style.ShadowWidth.Value.ToString(CultureInfo.InvariantCulture);
+                sb.Append($"text-shadow: {colorString} {widthString}px; ");
             }
 
             return sb.ToString().TrimEnd(' ', ';');

--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -27,6 +27,7 @@ using Nikse.SubtitleEdit.Features.Files.FormatProperties.ItunesTimedTextProperti
 using Nikse.SubtitleEdit.Features.Files.FormatProperties.TimedText10Properties;
 using Nikse.SubtitleEdit.Features.Files.FormatProperties.TimedTextImsc11Properties;
 using Nikse.SubtitleEdit.Features.Files.FormatProperties.WebVttProperties;
+using Nikse.SubtitleEdit.Features.WebVtt;
 using Nikse.SubtitleEdit.Features.Files.ImportImages;
 using Nikse.SubtitleEdit.Features.Files.ImportCsvXlsxCustomColumns;
 using Nikse.SubtitleEdit.Features.Files.ImportPlainText;
@@ -540,6 +541,8 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<WaveformThemesViewModel>();
         collection.AddTransient<WaveformToolbarItemsViewModel>();
         collection.AddTransient<WebVttPropertiesViewModel>();
+        collection.AddTransient<WebVttStylesViewModel>();
+        collection.AddTransient<WebVttStylePickerViewModel>();
         collection.AddTransient<SpeechToTextAdvancedViewModel>();
         collection.AddTransient<SpeechToTextPostProcessingViewModel>();
         collection.AddTransient<WordListsViewModel>();

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -630,6 +630,38 @@ public static partial class InitListViewAndEditBox
         sepAssa.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.AreAssaContentMenuItemsVisible)));
         flyout.Items.Add(sepAssa);
 
+        // WebVTT counterpart of the ASSA styles/actors block: cue classes and <v> voices.
+        var webVttStylesMenuItem = new MenuItem
+        {
+            Header = Se.Language.General.Styles,
+            DataContext = vm,
+            Command = vm.SetWebVttStylesForSelectedLinesCommand,
+        };
+        webVttStylesMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.AreWebVttContentMenuItemsVisible)) { Mode = BindingMode.TwoWay });
+        flyout.Items.Add(webVttStylesMenuItem);
+
+        var webVttVoicesMenuItem = new MenuItem
+        {
+            Header = Se.Language.File.WebVtt.Voices,
+            DataContext = vm,
+        };
+        webVttVoicesMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.AreWebVttContentMenuItemsVisible)) { Mode = BindingMode.TwoWay });
+        flyout.Items.Add(webVttVoicesMenuItem);
+        vm.MenuItemWebVttVoices = webVttVoicesMenuItem;
+
+        var webVttBrowserPreviewMenuItem = new MenuItem
+        {
+            Header = Se.Language.File.WebVtt.BrowserPreview,
+            DataContext = vm,
+            Command = vm.ShowWebVttBrowserPreviewCommand,
+        };
+        webVttBrowserPreviewMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsWebVttBrowserPreviewVisible)) { Mode = BindingMode.TwoWay });
+        flyout.Items.Add(webVttBrowserPreviewMenuItem);
+
+        var sepWebVtt = new Separator { DataContext = vm };
+        sepWebVtt.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.AreWebVttContentMenuItemsVisible)));
+        flyout.Items.Add(sepWebVtt);
+
         var showStartTimeMenuItem = new MenuItem
         {
             Header = Se.Language.General.ShowStartColumn,

--- a/src/ui/Features/Main/Layout/InitToolbar.cs
+++ b/src/ui/Features/Main/Layout/InitToolbar.cs
@@ -348,8 +348,26 @@ public static class InitToolbar
             ssaSeparator.DataContext = vm;
             ssaSeparator.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsFormatSsa)) { Mode = BindingMode.TwoWay });
 
+            var webVttSeparator = MakeSeparator();
+            stackPanelLeft.Children.Add(webVttSeparator);
+            webVttSeparator.DataContext = vm;
+            webVttSeparator.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsFormatWebVtt)) { Mode = BindingMode.TwoWay });
+
             isLastSeparator = true;
         }
+
+        stackPanelLeft.Children.Add(new Button
+        {
+            Content = MakeImage("AssaStyle"),
+            Command = vm.ShowWebVttStylesCommand,
+            Background = Brushes.Transparent,
+            [AutomationProperties.NameProperty] = languageHints.WebVttStylesHint,
+            [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.WebVttStylesHint, shortcuts, nameof(vm.ShowWebVttStylesCommand)),
+            [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsFormatWebVtt))
+            {
+                Source = vm,
+            },
+        });
 
         stackPanelLeft.Children.Add(new Button
         {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -153,6 +153,7 @@ using Nikse.SubtitleEdit.Features.Video.VideoOcr;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ReviewSpeech;
 using Nikse.SubtitleEdit.Features.Video.TransparentSubtitles;
+using Nikse.SubtitleEdit.Features.WebVtt;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using static Nikse.SubtitleEdit.Logic.FindService;
@@ -195,7 +196,8 @@ public partial class MainViewModel :
     IUndoRedoClient,
     IFindResult,
     IApplyAssaStyles,
-    IApplySsaStyles
+    IApplySsaStyles,
+    IApplyWebVttStyles
 {
     [ObservableProperty] private ObservableCollection<SubtitleLineViewModel> _subtitles;
     [ObservableProperty] private SubtitleLineViewModel? _selectedSubtitle;
@@ -253,7 +255,10 @@ public partial class MainViewModel :
     [ObservableProperty] private bool _isFormatAssa;
     [ObservableProperty] private bool _isFormatSsa;
     [ObservableProperty] private bool _hasFormatStyle;
+    [ObservableProperty] private bool _isFormatWebVtt;
     [ObservableProperty] private bool _areAssaContentMenuItemsVisible;
+    [ObservableProperty] private bool _areWebVttContentMenuItemsVisible;
+    [ObservableProperty] private bool _isWebVttBrowserPreviewVisible;
     [ObservableProperty] private bool _selectCurrentSubtitleWhilePlaying;
     [ObservableProperty] private bool _waveformCenter;
     [ObservableProperty] private bool _isRightToLeftEnabled;
@@ -535,6 +540,7 @@ public partial class MainViewModel :
     public StackPanel PanelSingleLineLengthsOriginal { get; set; }
     public MenuItem MenuItemStyles { get; set; }
     public MenuItem MenuItemActors { get; set; }
+    public MenuItem MenuItemWebVttVoices { get; set; }
     private Button _buttonWaveformPlay = null!;
 
     public Button ButtonWaveformPlay
@@ -641,6 +647,7 @@ public partial class MainViewModel :
         MenuItemAudioVisualizerCopyText = new MenuItem();
         MenuItemStyles = new MenuItem();
         MenuItemActors = new MenuItem();
+        MenuItemWebVttVoices = new MenuItem();
         AudioTraksMenuItem = new MenuItem();
         SubtitleDataGridSyntaxHighlighting = new TextWithSubtitleSyntaxHighlightingConverter();
         Toolbar = new Border();
@@ -1454,6 +1461,222 @@ public partial class MainViewModel :
             }
 
             RefreshSubtitlePreview();
+        }
+    }
+
+    [RelayCommand]
+    private async Task ShowWebVttStyles()
+    {
+        if (Window == null || !IsFormatWebVtt)
+        {
+            return;
+        }
+
+        var result = await ShowDialogAsync<WebVttStylesWindow, WebVttStylesViewModel>(vm =>
+        {
+            // GetUpdateSubtitle: the usage counts are read from the paragraph texts, so the
+            // dialog needs the grid's current text rather than a stale _subtitle.
+            vm.Initialize(GetUpdateSubtitle(), _subtitleFileName ?? string.Empty, GetFirstWebVttStyleOfSelectedLine(), this);
+        });
+
+        if (result.OkPressed)
+        {
+            ApplyWebVttStyles(result);
+        }
+    }
+
+    public void ApplyWebVttStyles(WebVttStylesViewModel result)
+    {
+        _subtitle.Header = result.Header;
+        RefreshSubtitlePreview();
+    }
+
+    private string GetFirstWebVttStyleOfSelectedLine()
+    {
+        var selected = SelectedSubtitle;
+        if (selected == null)
+        {
+            return string.Empty;
+        }
+
+        return WebVttHelper.GetParagraphStyles(selected.ToParagraph(SelectedSubtitleFormat)).FirstOrDefault() ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Fills the "voices" submenu of the subtitle grid context menu with the voices already used
+    /// in the file (<c>&lt;v Name&gt;</c>), plus entries for adding a new one and clearing them.
+    /// </summary>
+    private void FillWebVttVoicesMenu()
+    {
+        MenuItemWebVttVoices.Items.Clear();
+
+        foreach (var voice in WebVTT.GetVoices(GetUpdateSubtitle()).OrderBy(p => p, StringComparer.OrdinalIgnoreCase))
+        {
+            MenuItemWebVttVoices.Items.Add(new MenuItem
+            {
+                Header = voice,
+                Command = SetWebVttVoiceForSelectedLinesCommand,
+                CommandParameter = voice,
+            });
+        }
+
+        if (MenuItemWebVttVoices.Items.Count > 0)
+        {
+            MenuItemWebVttVoices.Items.Add(new Separator());
+        }
+
+        MenuItemWebVttVoices.Items.Add(new MenuItem
+        {
+            Header = Se.Language.File.WebVtt.NewVoiceDotDotDot,
+            Command = SetNewWebVttVoiceForSelectedLinesCommand,
+        });
+
+        MenuItemWebVttVoices.Items.Add(new MenuItem
+        {
+            Header = Se.Language.File.WebVtt.RemoveVoices,
+            Command = RemoveWebVttVoicesCommand,
+        });
+    }
+
+    [RelayCommand]
+    private void SetWebVttVoiceForSelectedLines(string? voice)
+    {
+        if (string.IsNullOrWhiteSpace(voice))
+        {
+            return;
+        }
+
+        var selectedItems = SubtitleGridSelectedItems.Cast<SubtitleLineViewModel>().ToList();
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            foreach (var p in selectedItems)
+            {
+                // Replace any existing voice rather than nesting a second <v> tag.
+                p.Text = "<v " + voice + ">" + WebVTT.RemoveTag("v", p.Text);
+            }
+
+            RefreshSubtitlePreview();
+        });
+    }
+
+    [RelayCommand]
+    private async Task SetNewWebVttVoiceForSelectedLines()
+    {
+        var result = await ShowDialogAsync<PromptTextBoxWindow, PromptTextBoxViewModel>(vm =>
+        {
+            vm.Initialize(Se.Language.File.WebVtt.VoiceName, string.Empty, 250, 20, true);
+        });
+
+        if (result.OkPressed && !string.IsNullOrWhiteSpace(result.Text))
+        {
+            SetWebVttVoiceForSelectedLines(result.Text.Trim());
+        }
+    }
+
+    [RelayCommand]
+    private void RemoveWebVttVoices()
+    {
+        var selectedItems = SubtitleGridSelectedItems.Cast<SubtitleLineViewModel>().ToList();
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            foreach (var p in selectedItems)
+            {
+                p.Text = WebVTT.RemoveTag("v", p.Text);
+            }
+
+            RefreshSubtitlePreview();
+        });
+    }
+
+    [RelayCommand]
+    private async Task SetWebVttStylesForSelectedLines()
+    {
+        if (Window == null || !IsFormatWebVtt)
+        {
+            return;
+        }
+
+        var styles = WebVttHelper.GetStyles(GetUpdateSubtitle().Header);
+        if (styles.Count == 0)
+        {
+            // Nothing to pick from - send the user to the style manager instead of an empty list.
+            await ShowWebVttStyles();
+            return;
+        }
+
+        var selectedItems = SubtitleGridSelectedItems.Cast<SubtitleLineViewModel>().ToList();
+        if (selectedItems.Count == 0)
+        {
+            return;
+        }
+
+        // The check marks start from the focused line, matching what the user sees selected.
+        var currentStyles = WebVttHelper.GetParagraphStyles(selectedItems[0].ToParagraph(SelectedSubtitleFormat));
+
+        var result = await ShowDialogAsync<WebVttStylePickerWindow, WebVttStylePickerViewModel>(vm =>
+        {
+            vm.Initialize(
+                Se.Language.File.WebVtt.SetStylesForSelectedLinesTitle,
+                Se.Language.General.Ok,
+                styles.Select(p => new WebVttStyleDisplay(p) { IsSelected = currentStyles.Contains(p.Name) }).ToList());
+        });
+
+        if (!result.OkPressed)
+        {
+            return;
+        }
+
+        var chosen = result.CheckedStyles.Select(p => p.ToWebVttStyle()).ToList();
+        foreach (var line in selectedItems)
+        {
+            var paragraph = line.ToParagraph(SelectedSubtitleFormat);
+            line.Text = WebVttHelper.SetParagraphStyles(paragraph, chosen);
+        }
+
+        RefreshSubtitlePreview();
+    }
+
+    /// <summary>
+    /// Writes the subtitle into a throw-away HTML page as a base64 <c>&lt;track&gt;</c> next to the
+    /// loaded video and opens it in the default browser, so the cues can be checked in a real
+    /// WebVTT renderer instead of Subtitle Edit's own.
+    /// </summary>
+    [RelayCommand]
+    private void ShowWebVttBrowserPreview()
+    {
+        if (!IsFormatWebVtt || string.IsNullOrEmpty(_videoFileName))
+        {
+            return;
+        }
+
+        try
+        {
+            var subtitleText = new WebVTT().ToText(GetUpdateSubtitle(), "preview");
+            var html = WebVttBrowserPreview.GenerateHtml(subtitleText, _videoFileName);
+            var htmlFileName = Path.Combine(Path.GetTempPath(), $"WebVttPreview_{Guid.NewGuid()}.html");
+            File.WriteAllText(htmlFileName, html, Encoding.UTF8);
+            UiUtil.OpenUrl(htmlFileName);
+
+            // The browser only needs the file while it loads it; clean up so the temp folder
+            // does not fill up with preview pages.
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(30));
+                try
+                {
+                    File.Delete(htmlFileName);
+                }
+                catch
+                {
+                    // Ignore
+                }
+            });
+        }
+        catch (Exception exception)
+        {
+            ShowStatus(exception.Message);
         }
     }
 
@@ -20624,6 +20847,8 @@ public partial class MainViewModel :
         MenuItemExtendToLineAfter.IsVisible = Subtitles.Count > 1 &&
             (selectedCount > 1 || (selectedCount == 1 && idx < count - 1));
         AreAssaContentMenuItemsVisible = false;
+        AreWebVttContentMenuItemsVisible = false;
+        IsWebVttBrowserPreviewVisible = false;
         ShowAutoTranslateSelectedLines = selectedCount > 0 && ShowColumnOriginalText;
         HasMultipleLinesSelected = selectedCount > 1;
         ShowColumnLayerFlyoutMenuItem = IsFormatAssa;
@@ -20734,6 +20959,12 @@ public partial class MainViewModel :
                     removeActorMenuItem.InputGesture = InitMenu.ToKeyGesture(removeActorShortcut);
                 }
                 MenuItemActors.Items.Add(removeActorMenuItem);
+            }
+            else if (IsFormatWebVtt && selectedCount > 0)
+            {
+                AreWebVttContentMenuItemsVisible = true;
+                IsWebVttBrowserPreviewVisible = WebVttBrowserPreview.IsSupportedVideoFile(_videoFileName);
+                FillWebVttVoicesMenu();
             }
         }
 
@@ -24326,6 +24557,7 @@ public partial class MainViewModel :
 
         IsFormatAssa = SelectedSubtitleFormat is AdvancedSubStationAlpha;
         IsFormatSsa = SelectedSubtitleFormat is SubStationAlpha;
+        IsFormatWebVtt = SelectedSubtitleFormat is WebVTT or WebVTTFileWithLineNumber;
         HasFormatStyle = SelectedSubtitleFormat is AdvancedSubStationAlpha or SubStationAlpha;
         ShowLayer = IsFormatAssa && Se.Settings.Appearance.ShowLayer;
         ShowLayerFilterIcon = IsFormatAssa && Se.Settings.Appearance.ShowLayer && _visibleLayers != null;

--- a/src/ui/Features/WebVtt/WebVttBrowserPreview.cs
+++ b/src/ui/Features/WebVtt/WebVttBrowserPreview.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Features.WebVtt;
+
+/// <summary>
+/// Builds a stand-alone HTML page that plays the loaded video with the subtitle attached as a
+/// WebVTT text track, so the cues can be checked in a browser's own WebVTT renderer.
+/// </summary>
+public static class WebVttBrowserPreview
+{
+    /// <summary>Video containers a browser can be expected to play from a local file.</summary>
+    public static bool IsSupportedVideoFile(string? videoFileName)
+    {
+        if (string.IsNullOrEmpty(videoFileName))
+        {
+            return false;
+        }
+
+        var extension = Path.GetExtension(videoFileName).ToLowerInvariant();
+        return extension is ".mp4" or ".m4v" or ".webm" or ".ogv" or ".ogg" or ".mov";
+    }
+
+    public static string GenerateHtml(string webVttText, string videoFileName)
+    {
+        // The subtitle goes in as a data URI: a browser will not load a file:// track from a
+        // file:// page (cross-origin), and base64 also side-steps escaping the cue text.
+        var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(webVttText));
+        var extension = Path.GetExtension(videoFileName).TrimStart('.').ToLowerInvariant();
+        var mimeType = extension switch
+        {
+            "webm" => "webm",
+            "ogv" or "ogg" => "ogg",
+            _ => "mp4",
+        };
+
+        return $@"<!doctype html>
+<html lang=""en"">
+<head>
+  <meta charset=""utf-8"">
+  <title>WebVTT preview</title>
+  <style>
+    body {{ background: #202020; color: #eee; font-family: sans-serif; margin: 0; padding: 1em; }}
+    video {{ max-width: 100%; }}
+  </style>
+</head>
+<body>
+  <video controls preload=""metadata"">
+    <source src=""{ToFileUri(videoFileName)}"" type=""video/{mimeType}"" />
+    <track label=""Preview"" kind=""subtitles"" srclang=""en"" src=""data:text/vtt;base64,{base64}"" default>
+  </video>
+</body>
+</html>";
+    }
+
+    private static string ToFileUri(string fileName)
+    {
+        try
+        {
+            return new Uri(Path.GetFullPath(fileName)).AbsoluteUri;
+        }
+        catch
+        {
+            return "file://" + fileName;
+        }
+    }
+}

--- a/src/ui/Features/WebVtt/WebVttStyleDisplay.cs
+++ b/src/ui/Features/WebVtt/WebVttStyleDisplay.cs
@@ -1,0 +1,171 @@
+using Avalonia.Media;
+using Avalonia.Skia;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Globalization;
+
+namespace Nikse.SubtitleEdit.Features.WebVtt;
+
+/// <summary>
+/// Editable view of a <see cref="WebVttStyle"/>.
+/// <para>
+/// A WebVTT cue style is CSS, so every property is optional - a style that only sets
+/// <c>color</c> must not gain a <c>font-family</c> just by being opened in the editor.
+/// The nullable values of <see cref="WebVttStyle"/> are therefore split into a value plus
+/// a "use it" flag, and only the enabled ones are written back in <see cref="ToWebVttStyle"/>.
+/// </para>
+/// <para>
+/// <see cref="Name"/> is held without the leading dot that the cue selector uses
+/// (<c>::cue(.red)</c>); the dot is added back when converting to a <see cref="WebVttStyle"/>.
+/// </para>
+/// </summary>
+public partial class WebVttStyleDisplay : ObservableObject
+{
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Css))]
+    private string _name;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Css))]
+    [NotifyPropertyChangedFor(nameof(FontNameDisplay))]
+    private string _fontName;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Css))]
+    [NotifyPropertyChangedFor(nameof(FontSizeDisplay))]
+    private decimal _fontSize;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Css))]
+    private bool _bold;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Css))]
+    [NotifyPropertyChangedFor(nameof(ItalicDisplay))]
+    private bool _italic;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Css))]
+    private bool _underline;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Css))]
+    private bool _strikeout;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Css))]
+    private bool _useColor;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Css))]
+    private Color _color;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Css))]
+    private bool _useBackgroundColor;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Css))]
+    private Color _backgroundColor;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Css))]
+    private bool _useShadow;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Css))]
+    private Color _shadowColor;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Css))]
+    private decimal _shadowWidth;
+
+    [ObservableProperty] private int _usageCount;
+    [ObservableProperty] private bool _isSelected;
+
+    public WebVttStyleDisplay()
+    {
+        _name = string.Empty;
+        _fontName = string.Empty;
+        _color = Colors.White;
+        _backgroundColor = Colors.Black;
+        _shadowColor = Colors.Black;
+    }
+
+    public WebVttStyleDisplay(WebVttStyle style) : this()
+    {
+        _name = (style.Name ?? string.Empty).TrimStart('.');
+        _fontName = style.FontName ?? string.Empty;
+        _fontSize = style.FontSize ?? 0;
+        _bold = style.Bold == true;
+        _italic = style.Italic == true;
+        _underline = style.Underline == true;
+        _strikeout = style.StrikeThrough == true;
+
+        if (style.Color.HasValue)
+        {
+            _useColor = true;
+            _color = style.Color.Value.ToAvaloniaColor();
+        }
+
+        if (style.BackgroundColor.HasValue)
+        {
+            _useBackgroundColor = true;
+            _backgroundColor = style.BackgroundColor.Value.ToAvaloniaColor();
+        }
+
+        if (style.ShadowColor.HasValue)
+        {
+            _useShadow = true;
+            _shadowColor = style.ShadowColor.Value.ToAvaloniaColor();
+            _shadowWidth = style.ShadowWidth ?? 0;
+        }
+    }
+
+    public WebVttStyleDisplay(WebVttStyleDisplay style) : this()
+    {
+        _name = style.Name;
+        _fontName = style.FontName;
+        _fontSize = style.FontSize;
+        _bold = style.Bold;
+        _italic = style.Italic;
+        _underline = style.Underline;
+        _strikeout = style.Strikeout;
+        _useColor = style.UseColor;
+        _color = style.Color;
+        _useBackgroundColor = style.UseBackgroundColor;
+        _backgroundColor = style.BackgroundColor;
+        _useShadow = style.UseShadow;
+        _shadowColor = style.ShadowColor;
+        _shadowWidth = style.ShadowWidth;
+    }
+
+    public WebVttStyle ToWebVttStyle()
+    {
+        return new WebVttStyle
+        {
+            Name = "." + Name.TrimStart('.'),
+            FontName = string.IsNullOrWhiteSpace(FontName) ? null : FontName,
+            FontSize = FontSize > 0 ? FontSize : null,
+            Bold = Bold ? true : null,
+            Italic = Italic ? true : null,
+            Underline = Underline ? true : null,
+            StrikeThrough = Strikeout ? true : null,
+            Color = UseColor ? Color.ToSKColor() : null,
+            BackgroundColor = UseBackgroundColor ? BackgroundColor.ToSKColor() : null,
+            ShadowColor = UseShadow ? ShadowColor.ToSKColor() : null,
+            ShadowWidth = UseShadow ? ShadowWidth : null,
+        };
+    }
+
+    /// <summary>The CSS this style is written as, shown in the editor so the raw result stays visible.</summary>
+    public string Css => WebVttHelper.GetCssProperties(ToWebVttStyle());
+
+    public string FontNameDisplay => string.IsNullOrWhiteSpace(FontName) ? "-" : FontName;
+
+    public string FontSizeDisplay => FontSize > 0 ? FontSize.ToString(CultureInfo.CurrentCulture) : "-";
+
+    public string ItalicDisplay => Italic ? Se.Language.General.Yes : "-";
+}

--- a/src/ui/Features/WebVtt/WebVttStylePickerViewModel.cs
+++ b/src/ui/Features/WebVtt/WebVttStylePickerViewModel.cs
@@ -1,0 +1,106 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.WebVtt;
+
+/// <summary>
+/// Check-list of WebVTT styles. Used for the three places a subset of styles is chosen:
+/// setting styles on the selected lines, picking which styles to import, and picking which
+/// styles to export.
+/// </summary>
+public partial class WebVttStylePickerViewModel : ObservableObject
+{
+    [ObservableProperty] private string _title;
+    [ObservableProperty] private string _buttonAcceptText;
+    [ObservableProperty] private ObservableCollection<WebVttStyleDisplay> _styles;
+    [ObservableProperty] private WebVttStyleDisplay? _selectedStyle;
+    [ObservableProperty] private string _selectedStyleCss;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public List<WebVttStyleDisplay> CheckedStyles => Styles.Where(p => p.IsSelected).ToList();
+
+    public WebVttStylePickerViewModel()
+    {
+        _title = string.Empty;
+        _buttonAcceptText = string.Empty;
+        _selectedStyleCss = string.Empty;
+        _styles = new ObservableCollection<WebVttStyleDisplay>();
+    }
+
+    public void Initialize(string title, string buttonAcceptText, List<WebVttStyleDisplay> styles)
+    {
+        Title = title;
+        ButtonAcceptText = buttonAcceptText;
+        Styles.Clear();
+        Styles.AddRange(styles);
+
+        if (Styles.Count > 0)
+        {
+            SelectedStyle = Styles[0];
+        }
+    }
+
+    partial void OnSelectedStyleChanged(WebVttStyleDisplay? value)
+    {
+        SelectedStyleCss = value == null ? string.Empty : value.Css.Replace("; ", ";" + System.Environment.NewLine);
+    }
+
+    [RelayCommand]
+    private void SelectAll()
+    {
+        foreach (var style in Styles)
+        {
+            style.IsSelected = true;
+        }
+    }
+
+    [RelayCommand]
+    private void InvertSelection()
+    {
+        foreach (var style in Styles)
+        {
+            style.IsSelected = !style.IsSelected;
+        }
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Close();
+    }
+
+    private void Close()
+    {
+        Dispatcher.UIThread.Post(() => Window?.Close());
+    }
+
+    internal void KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/webvtt-styles");
+        }
+    }
+}

--- a/src/ui/Features/WebVtt/WebVttStylePickerWindow.cs
+++ b/src/ui/Features/WebVtt/WebVttStylePickerWindow.cs
@@ -1,0 +1,146 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.WebVtt;
+
+public class WebVttStylePickerWindow : Window
+{
+    public WebVttStylePickerWindow(WebVttStylePickerViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Bind(TitleProperty, new Binding(nameof(vm.Title))
+        {
+            Source = vm,
+            Mode = BindingMode.TwoWay,
+        });
+        CanResize = true;
+        Width = 600;
+        Height = 500;
+        MinWidth = 400;
+        MinHeight = 300;
+
+        vm.Window = this;
+        DataContext = vm;
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            ColumnSpacing = 5,
+            RowSpacing = 5,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        var labelStyles = UiUtil.MakeLabel(Se.Language.General.Styles).WithBold();
+
+        var labelCss = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.SelectedStyleCss));
+        labelCss.MinHeight = 60;
+        labelCss.VerticalContentAlignment = VerticalAlignment.Top;
+
+        var buttonOk = UiUtil.MakeButton(string.Empty, vm.OkCommand).WithBindContent(nameof(vm.ButtonAcceptText));
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        grid.Add(labelStyles, 0);
+        grid.Add(MakeStylesView(vm, out var stylesGrid), 1);
+        grid.Add(UiUtil.MakeBorderForControl(labelCss), 2);
+        grid.Add(panelButtons, 3);
+
+        Content = grid;
+
+        // initial focus on an input, not an action button - a focused button clicks on bare Space
+        Activated += delegate { TableViewExtras.FocusRow(stylesGrid); };
+        KeyDown += vm.KeyDown;
+    }
+
+    private static Border MakeStylesView(WebVttStylePickerViewModel vm, out TableView tableView)
+    {
+        // No header sorting: checked styles are applied/written in list order.
+        var dataGrid = TableViewExtras.MakeTableView(multiSelect: false);
+        tableView = dataGrid;
+        dataGrid.DataContext = vm;
+        dataGrid.ItemsSource = vm.Styles;
+
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Enabled,
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            CellTemplate = new FuncDataTemplate<WebVttStyleDisplay>((_, _) =>
+                new Border
+                {
+                    Background = Brushes.Transparent, // Prevents highlighting
+                    Padding = new Thickness(4),
+                    Child = new CheckBox
+                    {
+                        [!ToggleButton.IsCheckedProperty] = new Binding(nameof(WebVttStyleDisplay.IsSelected)),
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                    },
+                }),
+            Width = new GridLength(80),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Name,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(WebVttStyleDisplay.Name)),
+            Width = new GridLength(1, GridUnitType.Star),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.FontName,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(WebVttStyleDisplay.FontNameDisplay)),
+            Width = new GridLength(160),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.FontSize,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(WebVttStyleDisplay.FontSizeDisplay)),
+            Width = new GridLength(90),
+        });
+
+        dataGrid.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedStyle)) { Source = vm });
+        TableViewExtras.AttachListNavigation(dataGrid);
+
+        var flyout = new MenuFlyout();
+        flyout.Items.Add(new MenuItem
+        {
+            Header = Se.Language.General.SelectAll,
+            DataContext = vm,
+            Command = vm.SelectAllCommand,
+        });
+        flyout.Items.Add(new MenuItem
+        {
+            Header = Se.Language.General.InvertSelection,
+            DataContext = vm,
+            Command = vm.InvertSelectionCommand,
+        });
+        dataGrid.ContextFlyout = flyout;
+        UiUtil.AttachMacContextFlyoutHandler(dataGrid);
+
+        return UiUtil.MakeBorderForControl(dataGrid);
+    }
+}

--- a/src/ui/Features/WebVtt/WebVttStylesViewModel.cs
+++ b/src/ui/Features/WebVtt/WebVttStylesViewModel.cs
@@ -1,0 +1,654 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media.Imaging;
+using Avalonia.Skia;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.WebVtt;
+
+/// <summary>
+/// Editor for the <c>STYLE</c> blocks of a WebVTT file - the cue classes referenced from the
+/// text as <c>&lt;c.name&gt;</c>. The whole <c>STYLE</c> section of the header is rewritten from
+/// <see cref="Styles"/> on OK/Apply, so the list order is the file order, not a view sort.
+/// </summary>
+public partial class WebVttStylesViewModel : ObservableObject, IClosingCleanup
+{
+    [ObservableProperty] private string _title;
+    [ObservableProperty] private ObservableCollection<WebVttStyleDisplay> _styles;
+    [ObservableProperty] private ObservableCollection<string> _fonts;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsStyleSelected))]
+    private WebVttStyleDisplay? _selectedStyle;
+
+    [ObservableProperty] private Bitmap? _imagePreview;
+    [ObservableProperty] private string _cssBefore;
+    [ObservableProperty] private string _cssAfter;
+    [ObservableProperty] private string _duplicateStyleNames;
+    [ObservableProperty] private bool _hasDuplicateStyleNames;
+    [ObservableProperty] private bool _isApplyVisible;
+    [ObservableProperty] private bool _isNameInvalid;
+
+    public bool IsStyleSelected => SelectedStyle != null;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    /// <summary>The rewritten WebVTT header, valid after OK or Apply.</summary>
+    public string Header { get; private set; }
+
+    public TableView StyleGrid { get; set; }
+
+    private readonly IFileHelper _fileHelper;
+    private readonly IWindowService _windowService;
+    private readonly System.Timers.Timer _timerUpdatePreview;
+    private List<WebVttStyle> _originalStyles;
+    private Subtitle _subtitle;
+    private IApplyWebVttStyles? _applyWebVttStyles;
+    private volatile bool _isClosing;
+
+    public WebVttStylesViewModel(IFileHelper fileHelper, IWindowService windowService)
+    {
+        _fileHelper = fileHelper;
+        _windowService = windowService;
+
+        _title = string.Empty;
+        _styles = new ObservableCollection<WebVttStyleDisplay>();
+        _fonts = new ObservableCollection<string>();
+        _cssBefore = string.Empty;
+        _cssAfter = string.Empty;
+        _duplicateStyleNames = string.Empty;
+        _originalStyles = new List<WebVttStyle>();
+        _subtitle = new Subtitle();
+
+        Header = string.Empty;
+        StyleGrid = new TableView();
+
+        _timerUpdatePreview = new System.Timers.Timer(300);
+        _timerUpdatePreview.Elapsed += TimerUpdatePreviewElapsed;
+    }
+
+    public void Initialize(Subtitle subtitle, string fileName, string? selectedStyleName, IApplyWebVttStyles? applyWebVttStyles)
+    {
+        Title = string.Format(Se.Language.Assa.StylesTitleX, fileName);
+        _subtitle = subtitle;
+        _applyWebVttStyles = applyWebVttStyles;
+        IsApplyVisible = applyWebVttStyles != null;
+        Header = subtitle.Header ?? string.Empty;
+        _originalStyles = WebVttHelper.GetStyles(Header);
+
+        Styles.Clear();
+        foreach (var style in WebVttHelper.GetStyles(Header))
+        {
+            var display = new WebVttStyleDisplay(style);
+            display.PropertyChanged += StyleChanged;
+            Styles.Add(display);
+
+            if (!string.IsNullOrEmpty(display.FontName) && !Fonts.Contains(display.FontName))
+            {
+                Fonts.Insert(0, display.FontName);
+            }
+        }
+
+        UpdateUsages();
+        CheckDuplicateStyleNames();
+
+        if (Styles.Count > 0)
+        {
+            SelectedStyle = Styles.FirstOrDefault(p =>
+                                p.Name.Equals((selectedStyleName ?? string.Empty).TrimStart('.'), StringComparison.OrdinalIgnoreCase))
+                            ?? Styles[0];
+        }
+
+        Task.Run(LoadFonts);
+
+        _timerUpdatePreview.Start();
+    }
+
+    /// <summary>
+    /// The font combo box binds to the selected style's font name; a font missing from the item
+    /// list would make Avalonia clear the selection and null out the style's font (see #13101).
+    /// </summary>
+    partial void OnSelectedStyleChanging(WebVttStyleDisplay? value)
+    {
+        var fontName = value?.FontName;
+        if (!string.IsNullOrEmpty(fontName) && !Fonts.Contains(fontName))
+        {
+            Fonts.Insert(0, fontName);
+        }
+    }
+
+    partial void OnSelectedStyleChanged(WebVttStyleDisplay? value)
+    {
+        UpdateCssLabels();
+        ValidateName();
+    }
+
+    private void LoadFonts()
+    {
+        var fonts = FontHelper.GetLibAssaFonts();
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            foreach (var font in fonts)
+            {
+                if (!Fonts.Contains(font))
+                {
+                    Fonts.Add(font);
+                }
+            }
+        });
+    }
+
+    private void StyleChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(WebVttStyleDisplay.UsageCount) ||
+            e.PropertyName == nameof(WebVttStyleDisplay.IsSelected))
+        {
+            return;
+        }
+
+        if (e.PropertyName == nameof(WebVttStyleDisplay.Name))
+        {
+            CheckDuplicateStyleNames();
+            ValidateName();
+        }
+
+        UpdateCssLabels();
+    }
+
+    private void UpdateCssLabels()
+    {
+        var style = SelectedStyle;
+        if (style == null)
+        {
+            CssBefore = string.Empty;
+            CssAfter = string.Empty;
+            return;
+        }
+
+        var before = _originalStyles.FirstOrDefault(p => (p.Name ?? string.Empty).TrimStart('.') == style.Name);
+        CssBefore = before == null ? string.Empty : Wrap(WebVttHelper.GetCssProperties(before));
+        CssAfter = Wrap(style.Css);
+    }
+
+    private static string Wrap(string css) => css.Replace("; ", ";" + Environment.NewLine);
+
+    /// <summary>
+    /// A style name that is empty or already taken would silently overwrite another style when
+    /// the header is rewritten, so it is flagged in the editor instead.
+    /// </summary>
+    private void ValidateName()
+    {
+        var style = SelectedStyle;
+        IsNameInvalid = style != null &&
+                        (string.IsNullOrWhiteSpace(style.Name) ||
+                         Styles.Count(p => p.Name.Equals(style.Name, StringComparison.OrdinalIgnoreCase)) > 1);
+    }
+
+    private void CheckDuplicateStyleNames()
+    {
+        var duplicates = Styles
+            .GroupBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToList();
+
+        HasDuplicateStyleNames = duplicates.Count > 0;
+        DuplicateStyleNames = duplicates.Count > 0
+            ? string.Format(Se.Language.File.WebVtt.DuplicateStyleNamesX, string.Join(", ", duplicates))
+            : string.Empty;
+    }
+
+    private void UpdateUsages()
+    {
+        foreach (var style in Styles)
+        {
+            style.UsageCount = CountUsages(_subtitle, style.Name);
+        }
+    }
+
+    /// <summary>
+    /// Counts the lines using a cue class. A class is referenced as <c>&lt;c.name&gt;</c> and
+    /// several classes can be combined (<c>&lt;c.name.other&gt;</c>), so the name is matched
+    /// followed by either the next class separator or the closing bracket.
+    /// </summary>
+    private static int CountUsages(Subtitle subtitle, string styleName)
+    {
+        if (string.IsNullOrEmpty(styleName))
+        {
+            return 0;
+        }
+
+        var count = 0;
+        foreach (var p in subtitle.Paragraphs)
+        {
+            if (string.IsNullOrEmpty(p.Text))
+            {
+                continue;
+            }
+
+            if (p.Text.Contains("." + styleName + ".", StringComparison.Ordinal) ||
+                p.Text.Contains("." + styleName + ">", StringComparison.Ordinal))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    [RelayCommand]
+    private void New()
+    {
+        var style = new WebVttStyleDisplay { Name = MakeUniqueName("new") };
+        style.PropertyChanged += StyleChanged;
+        Styles.Add(style);
+        SelectedStyle = style;
+        CheckDuplicateStyleNames();
+        TableViewExtras.EnsureRowFullyVisible(StyleGrid, style);
+    }
+
+    [RelayCommand]
+    private void Duplicate()
+    {
+        if (SelectedStyle == null)
+        {
+            return;
+        }
+
+        var style = new WebVttStyleDisplay(SelectedStyle) { Name = MakeUniqueName(SelectedStyle.Name) };
+        style.PropertyChanged += StyleChanged;
+        Styles.Add(style);
+        SelectedStyle = style;
+        CheckDuplicateStyleNames();
+        TableViewExtras.EnsureRowFullyVisible(StyleGrid, style);
+    }
+
+    private string MakeUniqueName(string baseName)
+    {
+        // The name ends up in a cue class selector, where a space would split it into two classes.
+        var name = string.IsNullOrWhiteSpace(baseName) ? "new" : baseName.Trim().Replace(" ", "-");
+        var candidate = name;
+        var count = 2;
+        while (Styles.Any(p => p.Name.Equals(candidate, StringComparison.OrdinalIgnoreCase)))
+        {
+            candidate = name + "-" + count;
+            count++;
+        }
+
+        return candidate;
+    }
+
+    [RelayCommand]
+    private void Remove()
+    {
+        if (SelectedStyle == null)
+        {
+            return;
+        }
+
+        var idx = Styles.IndexOf(SelectedStyle);
+        SelectedStyle.PropertyChanged -= StyleChanged;
+        Styles.RemoveAt(idx);
+        SelectedStyle = Styles.Count == 0 ? null : Styles[Math.Min(idx, Styles.Count - 1)];
+        CheckDuplicateStyleNames();
+    }
+
+    [RelayCommand]
+    private void RemoveAll()
+    {
+        foreach (var style in Styles)
+        {
+            style.PropertyChanged -= StyleChanged;
+        }
+
+        Styles.Clear();
+        SelectedStyle = null;
+        CheckDuplicateStyleNames();
+    }
+
+    [RelayCommand]
+    private async Task Import()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var format = new WebVTT();
+        var fileName = await _fileHelper.PickOpenFile(
+            Window,
+            Se.Language.File.WebVtt.OpenStyleFileTitle,
+            format.Name,
+            "*" + format.Extension,
+            format.Name,
+            "*.webvtt");
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return;
+        }
+
+        List<WebVttStyle> importStyles;
+        try
+        {
+            importStyles = WebVttHelper.GetStyles(FileUtil.ReadAllTextShared(fileName, Encoding.UTF8));
+        }
+        catch (Exception exception)
+        {
+            await MessageBox.Show(Window, Se.Language.General.Error, exception.Message, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return;
+        }
+
+        if (importStyles.Count == 0)
+        {
+            await MessageBox.Show(
+                Window,
+                Se.Language.General.Error,
+                Se.Language.File.WebVtt.NoStylesToImport,
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return;
+        }
+
+        var pickerResult = await _windowService.ShowDialogAsync<WebVttStylePickerWindow, WebVttStylePickerViewModel>(Window, vm =>
+        {
+            vm.Initialize(
+                Se.Language.File.WebVtt.ImportStylesTitle,
+                Se.Language.General.Import,
+                importStyles.Select(p => new WebVttStyleDisplay(p) { IsSelected = true }).ToList());
+        });
+
+        if (!pickerResult.OkPressed)
+        {
+            return;
+        }
+
+        WebVttStyleDisplay? last = null;
+        foreach (var style in pickerResult.CheckedStyles)
+        {
+            style.Name = MakeUniqueName(style.Name);
+            style.IsSelected = false;
+            style.PropertyChanged += StyleChanged;
+            Styles.Add(style);
+            last = style;
+
+            if (!string.IsNullOrEmpty(style.FontName) && !Fonts.Contains(style.FontName))
+            {
+                Fonts.Insert(0, style.FontName);
+            }
+        }
+
+        if (last != null)
+        {
+            SelectedStyle = last;
+        }
+
+        UpdateUsages();
+        CheckDuplicateStyleNames();
+    }
+
+    [RelayCommand]
+    private async Task Export()
+    {
+        if (Window == null || Styles.Count == 0)
+        {
+            return;
+        }
+
+        var pickerResult = await _windowService.ShowDialogAsync<WebVttStylePickerWindow, WebVttStylePickerViewModel>(Window, vm =>
+        {
+            vm.Initialize(
+                Se.Language.File.WebVtt.ExportStylesTitle,
+                Se.Language.General.Export,
+                Styles.Select(p => new WebVttStyleDisplay(p) { IsSelected = true }).ToList());
+        });
+
+        var selected = pickerResult.CheckedStyles;
+        if (!pickerResult.OkPressed || selected.Count == 0)
+        {
+            return;
+        }
+
+        // A cue selector is keyed by name, so two styles with the same name cannot both be
+        // exported - the second would simply shadow the first when the file is read back.
+        var duplicates = selected
+            .GroupBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToList();
+        if (duplicates.Count > 0)
+        {
+            await MessageBox.Show(
+                Window,
+                Se.Language.General.Error,
+                string.Format(Se.Language.File.WebVtt.DuplicateStyleNamesX, string.Join(", ", duplicates)),
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return;
+        }
+
+        var fileName = await _fileHelper.PickSaveFile(
+            Window,
+            ".vtt",
+            "my_styles.vtt",
+            Se.Language.File.WebVtt.ExportStylesTitle);
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return;
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine("WEBVTT");
+        sb.AppendLine();
+        sb.AppendLine("STYLE");
+        foreach (var style in selected)
+        {
+            sb.AppendLine(ToRawStyle(style));
+        }
+
+        try
+        {
+            await System.IO.File.WriteAllTextAsync(fileName, sb.ToString().TrimEnd() + Environment.NewLine, Encoding.UTF8);
+        }
+        catch (Exception exception)
+        {
+            await MessageBox.Show(Window, Se.Language.General.Error, exception.Message, MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private static string ToRawStyle(WebVttStyleDisplay style)
+    {
+        return "::cue(." + style.Name.TrimStart('.') + ") { " + style.Css + " }";
+    }
+
+    [RelayCommand]
+    private void MoveUp() => TableViewExtras.MoveSelectedRows(StyleGrid, Styles, ListMoveDirection.Up);
+
+    [RelayCommand]
+    private void MoveDown() => TableViewExtras.MoveSelectedRows(StyleGrid, Styles, ListMoveDirection.Down);
+
+    [RelayCommand]
+    private void MoveToTop() => TableViewExtras.MoveSelectedRows(StyleGrid, Styles, ListMoveDirection.Top);
+
+    [RelayCommand]
+    private void MoveToBottom() => TableViewExtras.MoveSelectedRows(StyleGrid, Styles, ListMoveDirection.Bottom);
+
+    /// <summary>
+    /// Rewrites the <c>STYLE</c> section of the header from <see cref="Styles"/>, keeping every
+    /// other header line (the <c>WEBVTT</c> line, <c>NOTE</c> blocks, ...) as it was.
+    /// </summary>
+    private void SetHeader()
+    {
+        var header = _subtitle.Header ?? string.Empty;
+        if (!header.StartsWith("WEBVTT", StringComparison.Ordinal))
+        {
+            header = "WEBVTT";
+        }
+
+        var styleOn = false;
+        var sb = new StringBuilder();
+        foreach (var line in header.SplitToLines())
+        {
+            if (line.Trim().Equals("STYLE", StringComparison.OrdinalIgnoreCase))
+            {
+                styleOn = true;
+            }
+            else if (line.Trim().Length == 0 && styleOn)
+            {
+                styleOn = false;
+            }
+            else if (!styleOn)
+            {
+                sb.AppendLine(line);
+            }
+        }
+
+        var result = new StringBuilder(sb.ToString().Trim());
+        if (Styles.Count > 0)
+        {
+            result.AppendLine();
+            result.AppendLine();
+            result.AppendLine("STYLE");
+            foreach (var style in Styles)
+            {
+                result.AppendLine(ToRawStyle(style));
+            }
+        }
+
+        Header = result.ToString().TrimEnd() + Environment.NewLine;
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        SetHeader();
+        Close();
+    }
+
+    [RelayCommand]
+    private void Apply()
+    {
+        OkPressed = true;
+        SetHeader();
+        _applyWebVttStyles?.ApplyWebVttStyles(this);
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Close();
+    }
+
+    private void Close()
+    {
+        Dispatcher.UIThread.Post(() => Window?.Close());
+    }
+
+    private void TimerUpdatePreviewElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        if (_isClosing)
+        {
+            return;
+        }
+
+        _timerUpdatePreview.Stop();
+        UpdatePreview();
+
+        // OnClosingCleanup may have disposed the timer while this handler ran, and Start() on a
+        // disposed timer throws from a thread-pool thread, taking the app down (#12739).
+        if (!_isClosing)
+        {
+            _timerUpdatePreview.Start();
+        }
+    }
+
+    private void UpdatePreview()
+    {
+        var style = SelectedStyle;
+        if (style == null)
+        {
+            ImagePreview = new SKBitmap(1, 1, true).ToAvaloniaBitmap();
+            return;
+        }
+
+        var fontSize = style.FontSize > 0 ? (float)style.FontSize * 2.5f : 60f;
+        var fontName = string.IsNullOrWhiteSpace(style.FontName)
+            ? SKTypeface.Default.FamilyName
+            : FontHelper.GetSkiaFontNameFromLibAssaFontName(style.FontName);
+
+        // WebVTT has no outline; the background color is the cue box behind the whole cue.
+        var bitmap = TextToImageGenerator.GenerateImageWithPadding(
+            "This is a test",
+            fontName,
+            fontSize,
+            style.Bold,
+            style.UseColor ? style.Color.ToSKColor() : SKColors.White,
+            SKColors.Transparent,
+            style.UseShadow ? style.ShadowColor.ToSKColor() : SKColors.Transparent,
+            style.UseBackgroundColor ? style.BackgroundColor.ToSKColor() : SKColors.Transparent,
+            0,
+            style.UseShadow ? (float)style.ShadowWidth : 0,
+            isItalic: style.Italic,
+            isUnderline: style.Underline,
+            isStrikeout: style.Strikeout);
+
+        var frame = TextToImageGenerator.ComposeOnPreviewFrame(bitmap, 2, 0, 0, 20);
+        ImagePreview = frame.ToAvaloniaBitmap();
+    }
+
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
+    }
+
+    internal void KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/webvtt-styles");
+        }
+    }
+
+    internal void StylesMoveKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.KeyModifiers != KeyModifiers.Control)
+        {
+            return;
+        }
+
+        if (e.Key == Key.Up)
+        {
+            e.Handled = true;
+            MoveUp();
+        }
+        else if (e.Key == Key.Down)
+        {
+            e.Handled = true;
+            MoveDown();
+        }
+    }
+}

--- a/src/ui/Features/WebVtt/WebVttStylesWindow.cs
+++ b/src/ui/Features/WebVtt/WebVttStylesWindow.cs
@@ -1,0 +1,459 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data.Converters;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Shared.ColorPicker;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Windows.Input;
+
+namespace Nikse.SubtitleEdit.Features.WebVtt;
+
+public class WebVttStylesWindow : Window
+{
+    public WebVttStylesWindow(WebVttStylesViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Bind(TitleProperty, new Binding(nameof(vm.Title))
+        {
+            Source = vm,
+            Mode = BindingMode.TwoWay,
+        });
+        CanResize = true;
+        Width = 1150;
+        Height = 750;
+        MinWidth = 900;
+        MinHeight = 560;
+
+        vm.Window = this;
+        DataContext = vm;
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            ColumnSpacing = 5,
+            RowSpacing = 5,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        var buttonApply = UiUtil.MakeButton(Se.Language.General.Apply, vm.ApplyCommand)
+            .WithBindIsVisible(nameof(vm.IsApplyVisible));
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var panelButtons = UiUtil.MakeButtonBar(buttonApply, buttonOk, buttonCancel);
+
+        grid.Add(MakeStylesView(vm), 0, 0);
+        grid.Add(MakeRightView(vm), 0, 1);
+        grid.Add(panelButtons, 1, 0, 1, 2);
+
+        Content = grid;
+
+        // initial focus on an input, not an action button - a focused button clicks on bare Space
+        Activated += delegate { TableViewExtras.FocusRow(vm.StyleGrid); };
+        KeyDown += vm.KeyDown;
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
+    }
+
+    private static Border MakeStylesView(WebVttStylesViewModel vm)
+    {
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // label
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }, // styles
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // duplicate names warning
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // buttons
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            RowSpacing = 5,
+        };
+
+        var label = UiUtil.MakeLabel(Se.Language.General.Styles).WithBold();
+
+        // No header sorting: the styles are written to the file header in list order on
+        // OK/Apply, so the collection order is not presentation-only.
+        var dataGrid = TableViewExtras.MakeTableView();
+        dataGrid.DataContext = vm;
+        dataGrid.ItemsSource = vm.Styles;
+
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Name,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(WebVttStyleDisplay.Name)),
+            Width = new GridLength(1, GridUnitType.Star),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.FontName,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(WebVttStyleDisplay.FontNameDisplay)),
+            Width = new GridLength(150),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.FontSize,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(WebVttStyleDisplay.FontSizeDisplay)),
+            Width = new GridLength(80),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Italic,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(WebVttStyleDisplay.ItalicDisplay)),
+            Width = new GridLength(70),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Usages,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(WebVttStyleDisplay.UsageCount)),
+            Width = new GridLength(80),
+        });
+
+        dataGrid.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedStyle)) { Source = vm });
+        dataGrid.AddHandler(InputElement.KeyDownEvent, vm.StylesMoveKeyDown, RoutingStrategies.Tunnel);
+        TableViewExtras.AttachListNavigation(dataGrid);
+        vm.StyleGrid = dataGrid;
+
+        var flyout = new MenuFlyout();
+        flyout.Items.Add(new MenuItem
+        {
+            Header = Se.Language.General.Delete,
+            DataContext = vm,
+            Command = vm.RemoveCommand,
+        });
+        flyout.Items.Add(new MenuItem
+        {
+            Header = Se.Language.General.Clear,
+            DataContext = vm,
+            Command = vm.RemoveAllCommand,
+        });
+        AddMoveMenuItems(flyout, vm);
+        dataGrid.ContextFlyout = flyout;
+        UiUtil.AttachMacContextFlyoutHandler(dataGrid);
+
+        var labelDuplicates = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.DuplicateStyleNames));
+        labelDuplicates.Foreground = Brushes.OrangeRed;
+        labelDuplicates.Bind(IsVisibleProperty, new Binding(nameof(vm.HasDuplicateStyleNames)) { Source = vm });
+
+        var buttonNew = UiUtil.MakeButton(vm.NewCommand, IconNames.Plus, Se.Language.General.New);
+        var buttonDuplicate = UiUtil.MakeButton(vm.DuplicateCommand, IconNames.Duplicate, Se.Language.General.Duplicate);
+        var buttonRemove = UiUtil.MakeButton(vm.RemoveCommand, IconNames.Trash, Se.Language.General.Delete);
+        var buttonImport = UiUtil.MakeButton(vm.ImportCommand, IconNames.Import, Se.Language.General.Import);
+        var buttonExport = UiUtil.MakeButton(vm.ExportCommand, IconNames.Export, Se.Language.General.Export);
+        var panelButtons = UiUtil.MakeButtonBar(
+            buttonNew,
+            buttonDuplicate,
+            buttonRemove,
+            buttonImport,
+            buttonExport
+        ).WithAlignmentLeft();
+
+        grid.Add(label, 0, 0);
+        grid.Add(dataGrid, 1, 0);
+        grid.Add(labelDuplicates, 2, 0);
+        grid.Add(panelButtons, 3, 0);
+
+        return UiUtil.MakeBorderForControl(grid);
+    }
+
+    private static Grid MakeRightView(WebVttStylesViewModel vm)
+    {
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            RowSpacing = 5,
+        };
+
+        grid.Add(MakeSelectedStyleView(vm), 0);
+        grid.Add(MakePreviewView(vm), 1);
+        grid.Add(MakeRawStyleView(vm), 2);
+
+        return grid;
+    }
+
+    private static Border MakeSelectedStyleView(WebVttStylesViewModel vm)
+    {
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            ColumnSpacing = 5,
+            RowSpacing = 5,
+        };
+
+        var label = UiUtil.MakeLabel(Se.Language.General.Style).WithBold();
+
+        var labelName = UiUtil.MakeLabel(Se.Language.General.Name).WithMinWidth(70);
+        var textBoxName = UiUtil.MakeTextBox(220, vm, nameof(vm.SelectedStyle) + "." + nameof(WebVttStyleDisplay.Name));
+        // A blank or already-used name would silently overwrite another style on save.
+        textBoxName.Bind(TemplatedControl.BorderBrushProperty, new Binding(nameof(vm.IsNameInvalid))
+        {
+            Source = vm,
+            Converter = new FuncValueConverter<bool, IBrush?>(invalid => invalid ? Brushes.OrangeRed : null),
+        });
+        var panelName = UiUtil.MakeHorizontalPanel(labelName, textBoxName);
+
+        var labelFontName = UiUtil.MakeLabel(Se.Language.General.FontName).WithMinWidth(70);
+        var comboBoxFontName = UiUtil.MakeComboBox(vm.Fonts, vm, nameof(vm.SelectedStyle) + "." + nameof(WebVttStyleDisplay.FontName)).WithMinWidth(160);
+        var labelFontSize = UiUtil.MakeLabel(Se.Language.General.FontSize);
+        var numericUpDownFontSize = UiUtil.MakeNumericUpDownOneDecimal(0, 500, 110, vm, nameof(vm.SelectedStyle) + "." + nameof(WebVttStyleDisplay.FontSize));
+        numericUpDownFontSize.Increment = 1;
+        var panelFont = UiUtil.MakeHorizontalPanel(labelFontName, comboBoxFontName, labelFontSize, numericUpDownFontSize);
+
+        var checkBoxBold = UiUtil.MakeCheckBox(Se.Language.General.Bold, vm, nameof(vm.SelectedStyle) + "." + nameof(WebVttStyleDisplay.Bold));
+        var checkBoxItalic = UiUtil.MakeCheckBox(Se.Language.General.Italic, vm, nameof(vm.SelectedStyle) + "." + nameof(WebVttStyleDisplay.Italic));
+        var checkBoxUnderline = UiUtil.MakeCheckBox(Se.Language.General.Underline, vm, nameof(vm.SelectedStyle) + "." + nameof(WebVttStyleDisplay.Underline));
+        var checkBoxStrikeout = UiUtil.MakeCheckBox(Se.Language.General.Strikeout, vm, nameof(vm.SelectedStyle) + "." + nameof(WebVttStyleDisplay.Strikeout));
+        var panelFontStyle = UiUtil.MakeHorizontalPanel(checkBoxBold, checkBoxItalic, checkBoxUnderline, checkBoxStrikeout);
+
+        // Every CSS property is optional, so each color has its own "use it" check box - an
+        // unchecked color is left out of the style instead of being written as a default.
+        var panelColor = MakeColorRow(
+            vm,
+            Se.Language.General.Color,
+            nameof(WebVttStyleDisplay.UseColor),
+            nameof(WebVttStyleDisplay.Color));
+        var panelBackgroundColor = MakeColorRow(
+            vm,
+            Se.Language.General.Background,
+            nameof(WebVttStyleDisplay.UseBackgroundColor),
+            nameof(WebVttStyleDisplay.BackgroundColor));
+
+        var panelShadow = MakeColorRow(
+            vm,
+            Se.Language.General.Shadow,
+            nameof(WebVttStyleDisplay.UseShadow),
+            nameof(WebVttStyleDisplay.ShadowColor));
+        var labelShadowWidth = UiUtil.MakeLabel(Se.Language.General.ShadowWidth);
+        var numericUpDownShadowWidth = UiUtil.MakeNumericUpDownOneDecimal(0, 100, 110, vm, nameof(vm.SelectedStyle) + "." + nameof(WebVttStyleDisplay.ShadowWidth));
+        numericUpDownShadowWidth.Increment = 1;
+        panelShadow.Children.Add(labelShadowWidth);
+        panelShadow.Children.Add(numericUpDownShadowWidth);
+
+        grid.Add(label, 0, 0);
+        grid.Add(panelName, 1, 0);
+        grid.Add(panelFont, 2, 0);
+        grid.Add(panelFontStyle, 3, 0);
+        grid.Add(UiUtil.MakeHorizontalPanel(panelColor, panelBackgroundColor), 4, 0);
+        grid.Add(panelShadow, 5, 0);
+
+        return UiUtil.MakeBorderForControl(grid);
+    }
+
+    private static StackPanel MakeColorRow(WebVttStylesViewModel vm, string text, string useProperty, string colorProperty)
+    {
+        var checkBox = UiUtil.MakeCheckBox(text, vm, nameof(vm.SelectedStyle) + "." + useProperty);
+        var button = MakeStyleColorPickerButton(vm, colorProperty);
+        return UiUtil.MakeHorizontalPanel(checkBox, button);
+    }
+
+    private static Border MakePreviewView(WebVttStylesViewModel vm)
+    {
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        var label = UiUtil.MakeLabel(Se.Language.General.Preview).WithBold();
+
+        var image = new Image
+        {
+            [!Image.SourceProperty] = new Binding(nameof(vm.ImagePreview)),
+            DataContext = vm,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Top,
+            Stretch = Stretch.Uniform, // Scale the preview frame to fit while keeping aspect ratio
+            MinHeight = 140,
+            MaxHeight = 220,
+        };
+
+        grid.Add(label, 0);
+        grid.Add(image, 1);
+
+        return UiUtil.MakeBorderForControl(grid);
+    }
+
+    /// <summary>
+    /// The CSS the style was loaded from next to the CSS it will be saved as, so an edit to a
+    /// hand-written style shows exactly what it changes.
+    /// </summary>
+    private static Border MakeRawStyleView(WebVttStylesViewModel vm)
+    {
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            ColumnSpacing = 5,
+        };
+
+        var labelBeforeTitle = UiUtil.MakeLabel(Se.Language.General.Before).WithBold();
+        var labelAfterTitle = UiUtil.MakeLabel(Se.Language.General.After).WithBold();
+
+        var labelBefore = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.CssBefore));
+        labelBefore.MinHeight = 70;
+        labelBefore.VerticalContentAlignment = VerticalAlignment.Top;
+
+        var labelAfter = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.CssAfter));
+        labelAfter.MinHeight = 70;
+        labelAfter.VerticalContentAlignment = VerticalAlignment.Top;
+
+        grid.Add(labelBeforeTitle, 0, 0);
+        grid.Add(labelAfterTitle, 0, 1);
+        grid.Add(labelBefore, 1, 0);
+        grid.Add(labelAfter, 1, 1);
+
+        return UiUtil.MakeBorderForControl(grid);
+    }
+
+    private static Button MakeStyleColorPickerButton(WebVttStylesViewModel vm, string colorPropertyName)
+    {
+        var swatch = new Border
+        {
+            Width = 30,
+            Height = 20,
+            CornerRadius = new CornerRadius(3),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Colors.Gray),
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        swatch.Bind(Border.BackgroundProperty, new Binding(nameof(vm.SelectedStyle) + "." + colorPropertyName)
+        {
+            Source = vm,
+            Converter = new ColorToBrushConverter(),
+        });
+
+        var button = new Button
+        {
+            Content = swatch,
+            Padding = new Thickness(4, 2),
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+
+        button.Click += async (_, _) =>
+        {
+            if (TopLevel.GetTopLevel(button) is not Window window || vm.SelectedStyle is null)
+            {
+                return;
+            }
+
+            var propInfo = typeof(WebVttStyleDisplay).GetProperty(colorPropertyName);
+            var currentColor = propInfo?.GetValue(vm.SelectedStyle) is Color c ? c : Colors.White;
+
+            var pickerVm = new ColorPickerViewModel();
+            pickerVm.Initialize(currentColor);
+            var pickerWindow = new ColorPickerWindow(pickerVm);
+            await pickerWindow.ShowDialog(window);
+
+            if (pickerVm.OkPressed)
+            {
+                propInfo?.SetValue(vm.SelectedStyle, pickerVm.SelectedColor);
+            }
+        };
+
+        return button;
+    }
+
+    /// <summary>
+    /// The "move up/down/to top/to bottom" block of the styles context menu. The styles are
+    /// written to the file header in list order, so this is real reordering, not a view sort.
+    /// </summary>
+    private static void AddMoveMenuItems(MenuFlyout flyout, WebVttStylesViewModel vm)
+    {
+        flyout.Items.Add(new Separator());
+
+        var items = new (string Header, ICommand Command, KeyGesture? Gesture)[]
+        {
+            (Se.Language.General.MoveUp, vm.MoveUpCommand, new KeyGesture(Key.Up, KeyModifiers.Control)),
+            (Se.Language.General.MoveDown, vm.MoveDownCommand, new KeyGesture(Key.Down, KeyModifiers.Control)),
+            (Se.Language.General.MoveToTop, vm.MoveToTopCommand, null),
+            (Se.Language.General.MoveToBottom, vm.MoveToBottomCommand, null),
+        };
+
+        foreach (var (header, command, gesture) in items)
+        {
+            flyout.Items.Add(new MenuItem
+            {
+                Header = header,
+                DataContext = vm,
+                Command = command,
+                InputGesture = gesture,
+            });
+        }
+    }
+}

--- a/src/ui/Logic/Config/Language/File/LanguageFile.cs
+++ b/src/ui/Logic/Config/Language/File/LanguageFile.cs
@@ -11,6 +11,7 @@ public class LanguageFile
     public LanguageManualChosenEncoding ManualChosenEncoding { get; set; } = new();
     public LanguageRestoreAutoBackup RestoreAutoBackup { get; set; } = new();
     public LanguageFilePropertiesDCinema PropertiesDCinema { get; set; } = new();
+    public LanguageWebVtt WebVtt { get; set; } = new();
     public string Compare { get; set; }
     public string PreviousDifference { get; set; }
     public string NextDifference { get; set; }

--- a/src/ui/Logic/Config/Language/File/LanguageWebVtt.cs
+++ b/src/ui/Logic/Config/Language/File/LanguageWebVtt.cs
@@ -1,0 +1,31 @@
+namespace Nikse.SubtitleEdit.Logic.Config.Language.File;
+
+public class LanguageWebVtt
+{
+    public string SetStylesForSelectedLinesTitle { get; set; }
+    public string Voices { get; set; }
+    public string NewVoiceDotDotDot { get; set; }
+    public string RemoveVoices { get; set; }
+    public string VoiceName { get; set; }
+    public string BrowserPreview { get; set; }
+    public string ImportStylesTitle { get; set; }
+    public string ExportStylesTitle { get; set; }
+    public string OpenStyleFileTitle { get; set; }
+    public string NoStylesToImport { get; set; }
+    public string DuplicateStyleNamesX { get; set; }
+
+    public LanguageWebVtt()
+    {
+        SetStylesForSelectedLinesTitle = "Set WebVTT styles for selected lines";
+        Voices = "Voices";
+        NewVoiceDotDotDot = "New voice...";
+        RemoveVoices = "Remove voices";
+        VoiceName = "Voice name";
+        BrowserPreview = "Browser preview";
+        ImportStylesTitle = "Import WebVTT styles";
+        ExportStylesTitle = "Export WebVTT styles";
+        OpenStyleFileTitle = "Open WebVTT file to import styles from";
+        NoStylesToImport = "No styles found in the chosen file";
+        DuplicateStyleNamesX = "Duplicate style names: {0}";
+    }
+}

--- a/src/ui/Logic/Config/Language/Main/LanguageMainToolbar.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMainToolbar.cs
@@ -28,6 +28,7 @@ public class LanguageMainToolbar
     public string AssaAttachmentsHint { get; set; }
     public string AssaDrawHint { get; set; }
     public string SsaStylesHint { get; set; }
+    public string WebVttStylesHint { get; set; }
     public string SsaPropertiesHint { get; set; }
     public string SsaAttachmentsHint { get; set; }
 
@@ -60,6 +61,7 @@ public class LanguageMainToolbar
         AssaAttachmentsHint = "Advanced Sub Station Alpha attachments";
         AssaDrawHint = "Advanced Sub Station Alpha draw shapes";
         SsaStylesHint = "Sub Station Alpha styles";
+        WebVttStylesHint = "WebVTT style manager";
         SsaPropertiesHint = "Sub Station Alpha properties";
         SsaAttachmentsHint = "Sub Station Alpha attachments";
     }

--- a/src/ui/Logic/IApplyWebVttStyles.cs
+++ b/src/ui/Logic/IApplyWebVttStyles.cs
@@ -1,0 +1,8 @@
+using Nikse.SubtitleEdit.Features.WebVtt;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+public interface IApplyWebVttStyles
+{
+    void ApplyWebVttStyles(WebVttStylesViewModel result);
+}

--- a/tests/UI/Features/WebVtt/WebVttBrowserPreviewTests.cs
+++ b/tests/UI/Features/WebVtt/WebVttBrowserPreviewTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Text;
+using Nikse.SubtitleEdit.Features.WebVtt;
+
+namespace UITests.Features.WebVtt;
+
+public class WebVttBrowserPreviewTests
+{
+    [Theory]
+    [InlineData("movie.mp4", true)]
+    [InlineData("movie.MP4", true)]
+    [InlineData("movie.webm", true)]
+    [InlineData("movie.mkv", false)]
+    [InlineData("movie.avi", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void OnlyBrowserPlayableContainersAreOffered(string? videoFileName, bool expected)
+    {
+        Assert.Equal(expected, WebVttBrowserPreview.IsSupportedVideoFile(videoFileName));
+    }
+
+    [Fact]
+    public void SubtitleIsEmbeddedAsBase64Track()
+    {
+        var vtt = "WEBVTT" + Environment.NewLine + Environment.NewLine +
+                  "00:00:01.000 --> 00:00:02.000" + Environment.NewLine + "Hello";
+
+        var html = WebVttBrowserPreview.GenerateHtml(vtt, "/videos/movie.mp4");
+
+        var expectedBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(vtt));
+        Assert.Contains("data:text/vtt;base64," + expectedBase64, html);
+    }
+
+    [Theory]
+    [InlineData("/videos/movie.mp4", "video/mp4")]
+    [InlineData("/videos/movie.webm", "video/webm")]
+    [InlineData("/videos/movie.ogv", "video/ogg")]
+    public void MimeTypeFollowsTheContainer(string videoFileName, string expectedType)
+    {
+        var html = WebVttBrowserPreview.GenerateHtml("WEBVTT", videoFileName);
+
+        Assert.Contains(expectedType, html);
+    }
+
+    [Fact]
+    public void VideoIsReferencedAsAFileUri()
+    {
+        var html = WebVttBrowserPreview.GenerateHtml("WEBVTT", "/videos/my movie.mp4");
+
+        // A raw path with a space would break the src attribute; it has to be percent-encoded.
+        Assert.Contains("file:///videos/my%20movie.mp4", html);
+        Assert.DoesNotContain("src=\"/videos/my movie.mp4\"", html);
+    }
+}

--- a/tests/UI/Features/WebVtt/WebVttStyleDisplayTests.cs
+++ b/tests/UI/Features/WebVtt/WebVttStyleDisplayTests.cs
@@ -1,0 +1,153 @@
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.WebVtt;
+using SkiaSharp;
+
+namespace UITests.Features.WebVtt;
+
+/// <summary>
+/// A WebVTT cue style is CSS, where every property is optional. These tests pin down that the
+/// editor's value+flag model does not invent properties a style never had, and that a style
+/// survives a trip through the editor unchanged.
+/// </summary>
+public class WebVttStyleDisplayTests
+{
+    [Fact]
+    public void EmptyStyleWritesNoProperties()
+    {
+        var display = new WebVttStyleDisplay { Name = "plain" };
+
+        var style = display.ToWebVttStyle();
+
+        Assert.Equal(".plain", style.Name);
+        Assert.Null(style.FontName);
+        Assert.Null(style.FontSize);
+        Assert.Null(style.Bold);
+        Assert.Null(style.Italic);
+        Assert.Null(style.Underline);
+        Assert.Null(style.StrikeThrough);
+        Assert.Null(style.Color);
+        Assert.Null(style.BackgroundColor);
+        Assert.Null(style.ShadowColor);
+        Assert.Equal(string.Empty, WebVttHelper.GetCssProperties(style));
+    }
+
+    [Fact]
+    public void UncheckedColorIsNotWritten()
+    {
+        // The color value is still there (so re-checking the box restores it), but an
+        // unchecked color must not end up in the CSS.
+        var display = new WebVttStyleDisplay
+        {
+            Name = "x",
+            Color = Colors.Red,
+            UseColor = false,
+        };
+
+        Assert.Null(display.ToWebVttStyle().Color);
+    }
+
+    [Fact]
+    public void CheckedColorIsWritten()
+    {
+        var display = new WebVttStyleDisplay
+        {
+            Name = "x",
+            Color = Colors.Red,
+            UseColor = true,
+        };
+
+        Assert.Equal(SKColors.Red, display.ToWebVttStyle().Color);
+    }
+
+    [Fact]
+    public void ZeroFontSizeMeansNotSet()
+    {
+        var display = new WebVttStyleDisplay { Name = "x", FontSize = 0 };
+
+        Assert.Null(display.ToWebVttStyle().FontSize);
+        Assert.Equal("-", display.FontSizeDisplay);
+    }
+
+    [Fact]
+    public void NameIsHeldWithoutTheCueSelectorDot()
+    {
+        var display = new WebVttStyleDisplay(new WebVttStyle { Name = ".red" });
+
+        Assert.Equal("red", display.Name);
+        Assert.Equal(".red", display.ToWebVttStyle().Name);
+    }
+
+    [Fact]
+    public void RoundTripsAFullStyle()
+    {
+        var original = new WebVttStyle
+        {
+            Name = ".fancy",
+            FontName = "Arial",
+            FontSize = 22,
+            Bold = true,
+            Italic = true,
+            Underline = true,
+            StrikeThrough = true,
+            Color = SKColors.Red,
+            BackgroundColor = SKColors.Blue,
+            ShadowColor = SKColors.Black,
+            ShadowWidth = 2,
+        };
+
+        var result = new WebVttStyleDisplay(original).ToWebVttStyle();
+
+        Assert.Equal(original.Name, result.Name);
+        Assert.Equal(original.FontName, result.FontName);
+        Assert.Equal(original.FontSize, result.FontSize);
+        Assert.Equal(original.Bold, result.Bold);
+        Assert.Equal(original.Italic, result.Italic);
+        Assert.Equal(original.Underline, result.Underline);
+        Assert.Equal(original.StrikeThrough, result.StrikeThrough);
+        Assert.Equal(original.Color, result.Color);
+        Assert.Equal(original.BackgroundColor, result.BackgroundColor);
+        Assert.Equal(original.ShadowColor, result.ShadowColor);
+        Assert.Equal(original.ShadowWidth, result.ShadowWidth);
+    }
+
+    [Fact]
+    public void CopyConstructorCopiesEverything()
+    {
+        var source = new WebVttStyleDisplay
+        {
+            Name = "src",
+            FontName = "Arial",
+            FontSize = 12,
+            Bold = true,
+            UseColor = true,
+            Color = Colors.Green,
+            UseShadow = true,
+            ShadowColor = Colors.Black,
+            ShadowWidth = 3,
+        };
+
+        var copy = new WebVttStyleDisplay(source);
+
+        Assert.Equal(source.Css, copy.Css);
+    }
+
+    [Fact]
+    public void CssUpdatesWhenAPropertyChanges()
+    {
+        var display = new WebVttStyleDisplay { Name = "x" };
+        var raised = false;
+        display.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(WebVttStyleDisplay.Css))
+            {
+                raised = true;
+            }
+        };
+
+        display.Italic = true;
+
+        Assert.True(raised);
+        Assert.Contains("font-style:italic", display.Css);
+    }
+}

--- a/tests/UI/Features/WebVtt/WebVttStylePickerViewModelTests.cs
+++ b/tests/UI/Features/WebVtt/WebVttStylePickerViewModelTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.WebVtt;
+
+namespace UITests.Features.WebVtt;
+
+public class WebVttStylePickerViewModelTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private WebVttStylePickerViewModel ShowWindow(List<WebVttStyleDisplay> styles)
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        var vm = services.BuildServiceProvider().GetRequiredService<WebVttStylePickerViewModel>();
+
+        var window = new WebVttStylePickerWindow(vm);
+        _windows.Add(window);
+        window.Show();
+        vm.Initialize("Pick styles", "OK", styles);
+        Dispatcher.UIThread.RunJobs();
+        return vm;
+    }
+
+    private static List<WebVttStyleDisplay> MakeStyles() => new()
+    {
+        new WebVttStyleDisplay(new WebVttStyle { Name = ".red" }),
+        new WebVttStyleDisplay(new WebVttStyle { Name = ".big", FontSize = 30 }),
+    };
+
+    [AvaloniaFact]
+    public void OnlyCheckedStylesAreReturned()
+    {
+        var vm = ShowWindow(MakeStyles());
+
+        vm.Styles[1].IsSelected = true;
+        vm.OkCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(vm.OkPressed);
+        Assert.Equal(new[] { "big" }, vm.CheckedStyles.Select(p => p.Name).ToArray());
+    }
+
+    [AvaloniaFact]
+    public void SelectAllChecksEverything()
+    {
+        var vm = ShowWindow(MakeStyles());
+
+        vm.SelectAllCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(2, vm.CheckedStyles.Count);
+    }
+
+    [AvaloniaFact]
+    public void InvertSelectionFlipsEveryCheck()
+    {
+        var styles = MakeStyles();
+        styles[0].IsSelected = true;
+        var vm = ShowWindow(styles);
+
+        vm.InvertSelectionCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(new[] { "big" }, vm.CheckedStyles.Select(p => p.Name).ToArray());
+    }
+
+    [AvaloniaFact]
+    public void SelectingAStyleShowsItsCss()
+    {
+        var vm = ShowWindow(MakeStyles());
+
+        vm.SelectedStyle = vm.Styles[1];
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Contains("font-size:30px", vm.SelectedStyleCss);
+    }
+
+    [AvaloniaFact]
+    public void CheckedStylesApplyAsCueClassesOnTheLine()
+    {
+        // What the main window does with the picker result.
+        var vm = ShowWindow(MakeStyles());
+        vm.SelectAllCommand.Execute(null);
+        vm.OkCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        var paragraph = new Paragraph("Hello", 0, 1000);
+        var text = WebVttHelper.SetParagraphStyles(paragraph, vm.CheckedStyles.Select(p => p.ToWebVttStyle()).ToList());
+
+        Assert.Equal("<c.red.big>Hello</c>", text);
+    }
+
+    [AvaloniaFact]
+    public void ClearingEveryCheckRemovesTheCueClasses()
+    {
+        var vm = ShowWindow(MakeStyles());
+        vm.OkCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        var paragraph = new Paragraph("<c.red.big>Hello</c>", 0, 1000);
+        var text = WebVttHelper.SetParagraphStyles(paragraph, vm.CheckedStyles.Select(p => p.ToWebVttStyle()).ToList());
+
+        Assert.Equal("Hello", text);
+    }
+}

--- a/tests/UI/Features/WebVtt/WebVttStylesViewModelTests.cs
+++ b/tests/UI/Features/WebVtt/WebVttStylesViewModelTests.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.WebVtt;
+
+namespace UITests.Features.WebVtt;
+
+/// <summary>
+/// Drives the real WebVTT style manager window headless, built exactly like in production, so
+/// the bindings and the header rewrite are exercised and not just the view model in isolation.
+/// </summary>
+public class WebVttStylesViewModelTests : IDisposable
+{
+    private const string Header =
+        "WEBVTT\r\n" +
+        "\r\n" +
+        "NOTE this comment must survive\r\n" +
+        "\r\n" +
+        "STYLE\r\n" +
+        "::cue(.red) { color:rgb(255,0,0) }\r\n" +
+        "::cue(.big) { font-size:30px; font-weight:bold }\r\n";
+
+    // Every window opened by a test is closed again in Dispose: an unclosed window would
+    // outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private static WebVttStylesViewModel MakeVm()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<WebVttStylesViewModel>();
+    }
+
+    private WebVttStylesViewModel ShowWindow(Subtitle subtitle)
+    {
+        var vm = MakeVm();
+        var window = new WebVttStylesWindow(vm);
+        _windows.Add(window);
+        window.Show();
+        vm.Initialize(subtitle, "test.vtt", null, null);
+        Dispatcher.UIThread.RunJobs();
+        return vm;
+    }
+
+    private static Subtitle MakeSubtitle()
+    {
+        var subtitle = new Subtitle { Header = Header };
+        subtitle.Paragraphs.Add(new Paragraph("<c.red>Red line</c>", 0, 1000));
+        subtitle.Paragraphs.Add(new Paragraph("<c.red.big>Both</c>", 1000, 2000));
+        subtitle.Paragraphs.Add(new Paragraph("Plain", 2000, 3000));
+        return subtitle;
+    }
+
+    [AvaloniaFact]
+    public void LoadsStylesFromHeader()
+    {
+        var vm = ShowWindow(MakeSubtitle());
+
+        Assert.Equal(new[] { "red", "big" }, vm.Styles.Select(p => p.Name).ToArray());
+        Assert.True(vm.Styles[0].UseColor);
+        Assert.Equal(Colors.Red, vm.Styles[0].Color);
+        Assert.Equal(30, vm.Styles[1].FontSize);
+        Assert.True(vm.Styles[1].Bold);
+    }
+
+    [AvaloniaFact]
+    public void CountsUsagesPerStyle()
+    {
+        var vm = ShowWindow(MakeSubtitle());
+
+        Assert.Equal(2, vm.Styles.Single(p => p.Name == "red").UsageCount);
+        Assert.Equal(1, vm.Styles.Single(p => p.Name == "big").UsageCount);
+    }
+
+    [AvaloniaFact]
+    public void OkRewritesTheStyleBlockAndKeepsTheRestOfTheHeader()
+    {
+        var vm = ShowWindow(MakeSubtitle());
+
+        vm.Styles[0].Italic = true;
+        vm.OkCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(vm.OkPressed);
+        Assert.Contains("NOTE this comment must survive", vm.Header);
+        Assert.Contains("font-style:italic", vm.Header);
+
+        // Exactly one STYLE block - the old one is replaced, not appended to.
+        Assert.Equal(1, vm.Header.Split('\n').Count(line => line.Trim() == "STYLE"));
+
+        var readBack = WebVttHelper.GetStyles(vm.Header);
+        Assert.Equal(new[] { ".red", ".big" }, readBack.Select(p => p.Name).ToArray());
+        Assert.True(readBack[0].Italic);
+    }
+
+    [AvaloniaFact]
+    public void RemovingEveryStyleLeavesNoStyleBlock()
+    {
+        var vm = ShowWindow(MakeSubtitle());
+
+        vm.RemoveAllCommand.Execute(null);
+        vm.OkCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Empty(WebVttHelper.GetStyles(vm.Header));
+        Assert.DoesNotContain("::cue(", vm.Header);
+        Assert.StartsWith("WEBVTT", vm.Header);
+    }
+
+    [AvaloniaFact]
+    public void NewStyleGetsAUniqueName()
+    {
+        var vm = ShowWindow(MakeSubtitle());
+
+        vm.NewCommand.Execute(null);
+        vm.NewCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(4, vm.Styles.Count);
+        Assert.Equal(vm.Styles.Count, vm.Styles.Select(p => p.Name).Distinct().Count());
+    }
+
+    [AvaloniaFact]
+    public void DuplicateKeepsThePropertiesButNotTheName()
+    {
+        var vm = ShowWindow(MakeSubtitle());
+
+        vm.SelectedStyle = vm.Styles[0];
+        vm.DuplicateCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        var copy = vm.Styles.Last();
+        Assert.NotEqual("red", copy.Name);
+        Assert.True(copy.UseColor);
+        Assert.Equal(Colors.Red, copy.Color);
+    }
+
+    [AvaloniaFact]
+    public void DuplicateNamesAreFlagged()
+    {
+        var vm = ShowWindow(MakeSubtitle());
+
+        Assert.False(vm.HasDuplicateStyleNames);
+
+        vm.Styles[1].Name = "red";
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(vm.HasDuplicateStyleNames);
+        Assert.Contains("red", vm.DuplicateStyleNames);
+    }
+
+    [AvaloniaFact]
+    public void EmptyNameIsFlagged()
+    {
+        var vm = ShowWindow(MakeSubtitle());
+
+        vm.SelectedStyle = vm.Styles[0];
+        Dispatcher.UIThread.RunJobs();
+        Assert.False(vm.IsNameInvalid);
+
+        vm.Styles[0].Name = string.Empty;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(vm.IsNameInvalid);
+    }
+
+    [AvaloniaFact]
+    public void MoveDownReordersTheHeader()
+    {
+        var vm = ShowWindow(MakeSubtitle());
+
+        vm.StyleGrid.SelectedItem = vm.Styles[0];
+        Dispatcher.UIThread.RunJobs();
+        vm.MoveDownCommand.Execute(null);
+        vm.OkCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(new[] { ".big", ".red" }, WebVttHelper.GetStyles(vm.Header).Select(p => p.Name).ToArray());
+    }
+
+    [AvaloniaFact]
+    public void CancelLeavesTheHeaderAlone()
+    {
+        var subtitle = MakeSubtitle();
+        var vm = ShowWindow(subtitle);
+
+        vm.Styles[0].Italic = true;
+        vm.CancelCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(vm.OkPressed);
+        Assert.Equal(Header, subtitle.Header);
+    }
+
+    [AvaloniaFact]
+    public void HandlesASubtitleWithoutAnyStyleBlock()
+    {
+        var subtitle = new Subtitle { Header = "WEBVTT" };
+        subtitle.Paragraphs.Add(new Paragraph("Hello", 0, 1000));
+
+        var vm = ShowWindow(subtitle);
+        Assert.Empty(vm.Styles);
+
+        vm.NewCommand.Execute(null);
+        vm.OkCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Single(WebVttHelper.GetStyles(vm.Header));
+    }
+}

--- a/tests/libse/Core/WebVttHelperTest.cs
+++ b/tests/libse/Core/WebVttHelperTest.cs
@@ -111,4 +111,110 @@ public class WebVttHelperTest
 
         Assert.Equal("france.tv access", result);
     }
+
+    [Fact]
+    public void GetCssPropertiesWritesParsableTextShadow()
+    {
+        var style = new WebVttStyle
+        {
+            Name = ".shadow",
+            ShadowColor = new SKColor(0x10, 0x10, 0x10),
+            ShadowWidth = 3,
+        };
+
+        var css = WebVttHelper.GetCssProperties(style);
+
+        Assert.Contains("text-shadow: #101010ff 3px", css);
+    }
+
+    [Fact]
+    public void TextShadowRoundTrips()
+    {
+        var style = new WebVttStyle
+        {
+            Name = ".shadow",
+            Color = SKColors.White,
+            ShadowColor = new SKColor(0x10, 0x20, 0x30),
+            ShadowWidth = 3,
+        };
+
+        var header = WebVttHelper.AddStyleToHeader(null, style);
+        var readBack = WebVttHelper.GetStyles(header).Single();
+
+        Assert.Equal(new SKColor(0x10, 0x20, 0x30), readBack.ShadowColor);
+        Assert.Equal(3, readBack.ShadowWidth);
+    }
+
+    [Fact]
+    public void TextShadowRoundTripsFractionalWidth()
+    {
+        var style = new WebVttStyle
+        {
+            Name = ".shadow",
+            ShadowColor = SKColors.Black,
+            ShadowWidth = 1.5m,
+        };
+
+        var header = WebVttHelper.AddStyleToHeader(null, style);
+        var readBack = WebVttHelper.GetStyles(header).Single();
+
+        Assert.Equal(1.5m, readBack.ShadowWidth);
+    }
+
+    [Theory]
+    [InlineData("20px", 20)]
+    [InlineData("20", 20)]
+    [InlineData(" 18.5px ", 18.5)]
+    public void FontSizeIsRead(string cssValue, decimal expected)
+    {
+        var header = "WEBVTT" + Environment.NewLine + Environment.NewLine +
+                     "STYLE" + Environment.NewLine +
+                     "::cue(.big) { font-size:" + cssValue + " }";
+
+        var style = WebVttHelper.GetStyles(header).Single();
+
+        Assert.Equal(expected, style.FontSize);
+    }
+
+    [Theory]
+    [InlineData("1.5em")]
+    [InlineData("larger")]
+    public void RelativeFontSizeIsNotRead(string cssValue)
+    {
+        var header = "WEBVTT" + Environment.NewLine + Environment.NewLine +
+                     "STYLE" + Environment.NewLine +
+                     "::cue(.big) { font-size:" + cssValue + " }";
+
+        var style = WebVttHelper.GetStyles(header).Single();
+
+        Assert.Null(style.FontSize);
+    }
+
+    [Fact]
+    public void FontAndDecorationsRoundTrip()
+    {
+        var style = new WebVttStyle
+        {
+            Name = ".fancy",
+            FontName = "Arial",
+            FontSize = 20,
+            Bold = true,
+            Italic = true,
+            Underline = true,
+            Color = SKColors.Red,
+            BackgroundColor = SKColors.Blue,
+        };
+
+        var header = WebVttHelper.AddStyleToHeader(null, style);
+        var readBack = WebVttHelper.GetStyles(header).Single();
+
+        Assert.Equal(".fancy", readBack.Name);
+        Assert.Equal("Arial", readBack.FontName);
+        Assert.Equal(20, readBack.FontSize);
+        Assert.True(readBack.Bold);
+        Assert.True(readBack.Italic);
+        Assert.True(readBack.Underline);
+        Assert.Equal(SKColors.Red, readBack.Color);
+        Assert.Equal(SKColors.Blue, readBack.BackgroundColor);
+    }
 }


### PR DESCRIPTION
SE5 could open and save WebVTT but had no way to edit the `STYLE` blocks, set a speaker voice, or preview the cues in a browser — all of which SE4 had. This ports that set to Avalonia, and fixes two libse parser bugs it uncovered along the way.

Found while scanning `se4-legacy` for features missing from SE5.

## Style manager

Reached from the toolbar styles button, shown when the current format is WebVTT (same slot as the ASSA/SSA styles buttons).

- Style list with font / size / italic / usage columns, reorderable with `Ctrl+Up`/`Ctrl+Down` and the context menu — the list order is the order the styles are written to the header, so this is real reordering, not a view sort.
- New / duplicate / remove / clear, plus import and export of styles from and to other WebVTT files through a shared check-list picker.
- Editor for name, font, size, bold/italic/underline/strikeout and the text, background and shadow colours, with a live preview.
- A WebVTT cue style is CSS, where **every property is optional**, so each colour has its own "use it" check box. An unchecked colour is left out of the style rather than written as a default — a style that only sets `color` stays that way after a visit to the editor.
- The raw CSS the style was loaded from is shown next to the CSS it will be saved as. Duplicate and empty names are flagged: a cue selector is keyed by name, so a duplicate would silently shadow another style.
- Only the `STYLE` section of the header is rewritten; `NOTE` blocks and everything else are kept.

## Grid context menu (WebVTT only)

- **Styles...** applies cue classes (`<c.name>`) to the selected lines, pre-checked from the focused line.
- **Voices** lists the voices already used in the file, plus **New voice...** and **Remove voices**. Setting a voice replaces any existing `<v>` rather than nesting a second one.
- **Browser preview** writes a temporary HTML page that plays the loaded video with the subtitle attached as a base64 `<track>`, so the cues can be checked in a real WebVTT renderer. Offered only for browser-playable containers, and the temp page is cleaned up afterwards.

## libse fixes found while porting

Both are in code the style manager exercises directly:

- `GetCssProperties` emitted the *literal text* of an interpolation for `text-shadow` (a missing `$`), so a shadow was written as unparsable CSS and lost on the next read.
- `font-size` was written but never parsed back. `GetOnlyColorStyle` and `WebVttToAssa` already expected `WebVttStyle.FontSize` to be populated, so a style carrying a font size was wrongly treated as colour-only, and the size was dropped when converting to ASSA.
- Both now accept fractional CSS lengths; relative font sizes (`em`, `%`) are left unset rather than guessed at.

## Notes

`English.json` is deliberately untouched — English uses the class defaults (`LoadLanguage` returns early for English) and the file is regenerated from the language classes.

## Tests

45 new tests, all suites green (libse 918, UI 1555, libuilogic 149, seconv 291):

- libse round-trip tests for the shadow and font-size fixes.
- `WebVttStyleDisplay` tests pinning that the editor never invents CSS properties a style did not have.
- Headless tests that build the **real** style manager and picker windows and drive them: loading, usage counts, header rewrite (including that `NOTE` survives and only one `STYLE` block results), remove-all, unique naming, duplicate/empty-name flagging, reordering, cancel, and a file with no `STYLE` block at all.
- Browser-preview tests for container filtering, base64 embedding, MIME type and file-URI escaping.

Docs: new `docs/features/webvtt-styles.md`, linked from the index and wired to F1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)