### PR TITLE
Restore the four missing SE4 subtitle grid double-click actions

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7029,6 +7029,19 @@ public partial class MainViewModel :
         }
     }
 
+    /// <summary>
+    /// Plays a single line from its start and stops at its end - the SE4
+    /// "go to video position, play current, and pause" behavior.
+    /// </summary>
+    private void PlayLineAndPauseAtEnd(VideoPlayerControl vp, SubtitleLineViewModel item)
+    {
+        vp.VideoPlayer.Pause();
+        vp.Position = item.StartTime.TotalSeconds;
+        PinPlayheadTo(item.StartTime.TotalSeconds);
+        _playSelectionItem = new PlaySelectionItem([item], item.EndTime, false);
+        vp.VideoPlayer.Play();
+    }
+
     private bool PlayerSelectedLines(bool loop)
     {
         var selectedItems = SubtitleGridSelectedItems.Cast<SubtitleLineViewModel>().OrderBy(p => p.StartTime).ToList();
@@ -24010,6 +24023,40 @@ public partial class MainViewModel :
                 vp.VideoPlayer.Play();
                 AudioVisualizerCenterOnPositionIfNeeded(selectedItem, seconds);
                 FocusEditTextBox();
+                return;
+            }
+
+            if (Se.Settings.General.SubtitleDoubleClickAction == SubtitleDoubleClickActionType.GoToSubtitleAndPlayCurrentAndPause.ToString())
+            {
+                PlayLineAndPauseAtEnd(vp, selectedItem);
+                AudioVisualizerCenterOnPositionIfNeeded(selectedItem, seconds);
+                return;
+            }
+
+            if (Se.Settings.General.SubtitleDoubleClickAction == SubtitleDoubleClickActionType.GoToSubtitleMinus1SecAndPause.ToString())
+            {
+                seconds = Math.Max(0, seconds - 1.0);
+                PauseVideoAndFreezePlayhead(vp);
+                vp.Position = seconds;
+                AudioVisualizerCenterOnPositionIfNeeded(selectedItem, seconds);
+                return;
+            }
+
+            if (Se.Settings.General.SubtitleDoubleClickAction == SubtitleDoubleClickActionType.GoToSubtitleMinusHalfSecAndPause.ToString())
+            {
+                seconds = Math.Max(0, seconds - 0.5);
+                PauseVideoAndFreezePlayhead(vp);
+                vp.Position = seconds;
+                AudioVisualizerCenterOnPositionIfNeeded(selectedItem, seconds);
+                return;
+            }
+
+            if (Se.Settings.General.SubtitleDoubleClickAction == SubtitleDoubleClickActionType.GoToSubtitleMinus1SecAndPlay.ToString())
+            {
+                seconds = Math.Max(0, seconds - 1.0);
+                vp.Position = seconds;
+                vp.VideoPlayer.Play();
+                AudioVisualizerCenterOnPositionIfNeeded(selectedItem, seconds);
                 return;
             }
 

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -581,7 +581,11 @@ public partial class SettingsViewModel : ObservableObject
             Se.Language.Options.Settings.GridGoToSubtitleAndPlay,
             Se.Language.Options.Settings.GridGoToSubtitleAndSetVideoPosition,
             Se.Language.Options.Settings.GridGoToSubtitleAndPauseAndFocusTextBox,
-            Se.Language.Options.Settings.GridGoToSubtitleAndPlayAndFocusTextBox
+            Se.Language.Options.Settings.GridGoToSubtitleAndPlayAndFocusTextBox,
+            Se.Language.Options.Settings.SubtitleListActionVideoGoToPositionAndPlayCurrentAndPause,
+            Se.Language.Options.Settings.SubtitleListActionVideoGoToPositionMinus1SecAndPause,
+            Se.Language.Options.Settings.SubtitleListActionVideoGoToPositionMinusHalfSecAndPause,
+            Se.Language.Options.Settings.SubtitleListActionVideoGoToPositionMinus1SecAndPlay
         ];
         SelectedSubtitleDoubleClickActionType = SubtitleDoubleClickActionTypes[0];
 
@@ -1478,6 +1482,10 @@ public partial class SettingsViewModel : ObservableObject
         { SubtitleDoubleClickActionType.GoToSubtitleOnly.ToString(), Se.Language.Options.Settings.GridGoToSubtitleAndSetVideoPosition },
         { SubtitleDoubleClickActionType.GoToSubtitleAndPauseAndFocusTextBox.ToString(), Se.Language.Options.Settings.GridGoToSubtitleAndPauseAndFocusTextBox },
         { SubtitleDoubleClickActionType.GoToSubtitleAndPlayAndFocusTextBox.ToString(), Se.Language.Options.Settings.GridGoToSubtitleAndPlayAndFocusTextBox },
+        { SubtitleDoubleClickActionType.GoToSubtitleAndPlayCurrentAndPause.ToString(), Se.Language.Options.Settings.SubtitleListActionVideoGoToPositionAndPlayCurrentAndPause },
+        { SubtitleDoubleClickActionType.GoToSubtitleMinus1SecAndPause.ToString(), Se.Language.Options.Settings.SubtitleListActionVideoGoToPositionMinus1SecAndPause },
+        { SubtitleDoubleClickActionType.GoToSubtitleMinusHalfSecAndPause.ToString(), Se.Language.Options.Settings.SubtitleListActionVideoGoToPositionMinusHalfSecAndPause },
+        { SubtitleDoubleClickActionType.GoToSubtitleMinus1SecAndPlay.ToString(), Se.Language.Options.Settings.SubtitleListActionVideoGoToPositionMinus1SecAndPlay },
     };
 
     // Rebuilds the static language-dependent maps in place so callers keep their reference.

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -259,6 +259,10 @@ public class LanguageSettings
     public string GridGoToSubtitleAndPlay { get; set; }
     public string GridGoToSubtitleAndPauseAndFocusTextBox { get; set; }
     public string GridGoToSubtitleAndPlayAndFocusTextBox { get; set; }
+    public string SubtitleListActionVideoGoToPositionAndPlayCurrentAndPause { get; set; }
+    public string SubtitleListActionVideoGoToPositionMinus1SecAndPause { get; set; }
+    public string SubtitleListActionVideoGoToPositionMinusHalfSecAndPause { get; set; }
+    public string SubtitleListActionVideoGoToPositionMinus1SecAndPlay { get; set; }
     public string SubtitleGridFormattingNone { get; set; }
     public string SubtitleGridFormattingShowFormatting { get; set; }
     public string SubtitleGridFormattingShowTags { get; set; }
@@ -563,6 +567,10 @@ public class LanguageSettings
         GridGoToSubtitleAndPlay = "Go to subtitle and play";
         GridGoToSubtitleAndPauseAndFocusTextBox = "Go to subtitle and pause and focus text box";
         GridGoToSubtitleAndPlayAndFocusTextBox = "Go to subtitle and play and focus text box";
+        SubtitleListActionVideoGoToPositionAndPlayCurrentAndPause = "Go to video position, play current, and pause";
+        SubtitleListActionVideoGoToPositionMinus1SecAndPause = "Go to video position - 1 s and pause";
+        SubtitleListActionVideoGoToPositionMinusHalfSecAndPause = "Go to video position - 0.5 s and pause";
+        SubtitleListActionVideoGoToPositionMinus1SecAndPlay = "Go to video position - 1 s and play";
         SubtitleGridFormattingNone = "No formatting";
         SubtitleGridFormattingShowFormatting = "Show formatting";
         SubtitleGridFormattingShowTags = "Show tags";

--- a/src/ui/Logic/Config/SubtitleDoubleClickActionType.cs
+++ b/src/ui/Logic/Config/SubtitleDoubleClickActionType.cs
@@ -8,4 +8,8 @@ public enum SubtitleDoubleClickActionType
     GoToSubtitleOnly,
     GoToSubtitleAndPauseAndFocusTextBox,
     GoToSubtitleAndPlayAndFocusTextBox,
+    GoToSubtitleAndPlayCurrentAndPause,
+    GoToSubtitleMinus1SecAndPause,
+    GoToSubtitleMinusHalfSecAndPause,
+    GoToSubtitleMinus1SecAndPlay,
 }

--- a/tests/UI/Features/Options/SubtitleDoubleClickActionMapTests.cs
+++ b/tests/UI/Features/Options/SubtitleDoubleClickActionMapTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Nikse.SubtitleEdit.Features.Options.Settings;
+using Nikse.SubtitleEdit.Logic.Config;
+using Xunit;
+
+namespace UITests.Features.Options;
+
+/// <summary>
+/// Guards the subtitle-grid double-click action list in Options. The combo box shows translated
+/// texts and the setting stores enum names, so an action can only be picked when it has a text in
+/// the action-to-text map. A value missing from the map is invisible in Options and any stored
+/// setting for it silently falls back to "go to subtitle and pause" - which is how the SE 4
+/// actions went missing in SE 5 (#13324).
+/// </summary>
+public class SubtitleDoubleClickActionMapTests
+{
+    private static readonly Dictionary<SubtitleDoubleClickActionType, Func<string>> ExpectedTexts = new()
+    {
+        [SubtitleDoubleClickActionType.None] = () => Se.Language.General.None,
+        [SubtitleDoubleClickActionType.GoToSubtitleAndPause] = () => Se.Language.Options.Settings.GridGoToSubtitleAndPause,
+        [SubtitleDoubleClickActionType.GoToSubtitleAndPlay] = () => Se.Language.Options.Settings.GridGoToSubtitleAndPlay,
+        [SubtitleDoubleClickActionType.GoToSubtitleOnly] = () => Se.Language.Options.Settings.GridGoToSubtitleAndSetVideoPosition,
+        [SubtitleDoubleClickActionType.GoToSubtitleAndPauseAndFocusTextBox] = () => Se.Language.Options.Settings.GridGoToSubtitleAndPauseAndFocusTextBox,
+        [SubtitleDoubleClickActionType.GoToSubtitleAndPlayAndFocusTextBox] = () => Se.Language.Options.Settings.GridGoToSubtitleAndPlayAndFocusTextBox,
+        [SubtitleDoubleClickActionType.GoToSubtitleAndPlayCurrentAndPause] = () => Se.Language.Options.Settings.SubtitleListActionVideoGoToPositionAndPlayCurrentAndPause,
+        [SubtitleDoubleClickActionType.GoToSubtitleMinus1SecAndPause] = () => Se.Language.Options.Settings.SubtitleListActionVideoGoToPositionMinus1SecAndPause,
+        [SubtitleDoubleClickActionType.GoToSubtitleMinusHalfSecAndPause] = () => Se.Language.Options.Settings.SubtitleListActionVideoGoToPositionMinusHalfSecAndPause,
+        [SubtitleDoubleClickActionType.GoToSubtitleMinus1SecAndPlay] = () => Se.Language.Options.Settings.SubtitleListActionVideoGoToPositionMinus1SecAndPlay,
+    };
+
+    [Fact]
+    public void EveryActionHasAnExpectedText()
+    {
+        var missing = Enum.GetValues<SubtitleDoubleClickActionType>()
+            .Where(a => !ExpectedTexts.ContainsKey(a))
+            .ToList();
+
+        Assert.True(missing.Count == 0,
+            "These double-click actions have no entry in this test - add them here, to the map in " +
+            "SettingsViewModel and to the Options combo box list: " + string.Join(", ", missing));
+    }
+
+    [Theory]
+    [MemberData(nameof(AllActions))]
+    public void ActionTextMapsBackToTheAction(SubtitleDoubleClickActionType action)
+    {
+        var text = ExpectedTexts[action]();
+
+        Assert.False(string.IsNullOrEmpty(text), $"{action} has no text in the English language file");
+        Assert.Equal(action.ToString(), SettingsViewModel.MapToSelectedSubtitleDoubleClickAction(text));
+    }
+
+    public static TheoryData<SubtitleDoubleClickActionType> AllActions()
+    {
+        var data = new TheoryData<SubtitleDoubleClickActionType>();
+        foreach (var action in Enum.GetValues<SubtitleDoubleClickActionType>())
+        {
+            data.Add(action);
+        }
+
+        return data;
+    }
+}


### PR DESCRIPTION
Fixes #13324.

SE 5 shipped six of SE 4's nine **subtitle grid double-click** actions. Four never made it across — the one the issue asks for, plus three siblings:

| Restored action | Behavior |
| --- | --- |
| Go to video position, play current, and pause | Plays the double-clicked line from its start, stops at its end |
| Go to video position - 1 s and pause | Seeks to start − 1 s, pauses |
| Go to video position - 0.5 s and pause | Seeks to start − 0.5 s, pauses |
| Go to video position - 1 s and play | Seeks to start − 1 s, plays on |

### Notes

- **Play current and pause** reuses the existing play-selection machinery (`PlaySelectionItem`) via a new `PlayLineAndPauseAtEnd` helper, so it stops at the end of the line exactly like the F5 *play selected lines* command — and unlike `PlayerSelectedLines`, it plays the line that was double-clicked rather than the first line of a multi-row selection.
- The minus-*x*-seconds actions clamp at 0, so double-clicking a line near the start of the video cannot seek negative.
- **The translations come for free.** The new language properties are named after the SE 4 keys, which are still sitting in 23 of the 32 shipped translation files as leftovers from the SE 4 import (`subtitleListActionVideoGoToPosition*` under `options.settings`). Verified by deserializing `Danish.json` — all four bind and come out translated. Only the 9 files without those leftovers fall back to English.
- The stored setting is an enum *name*, not an SE 4-style index, so appending the four values cannot disturb anyone's existing setting.
- `English.json` is deliberately left untouched — English runs off the class defaults, and the committed JSON is regenerated separately.

### Tests

New `SubtitleDoubleClickActionMapTests` guards the failure mode behind this issue: an action with no entry in the action-to-text map is invisible in Options, and a stored setting for it silently falls back to *go to subtitle and pause*. The test fails if a future enum value is added without wiring up its text.

Full UI suite green locally: 1579 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)