### PR TITLE
Open videos paused and at the right position

### DIFF
--- a/src/ui/Controls/VideoPlayer/EmptyVideoPlayer.cs
+++ b/src/ui/Controls/VideoPlayer/EmptyVideoPlayer.cs
@@ -51,7 +51,7 @@ public class EmptyVideoPlayer : IVideoPlayer
         _fileName = string.Empty;
     }
 
-    public Task LoadFile(string fileName)
+    public Task LoadFile(string fileName, double startPositionSeconds = 0)
     {
         _fileName = fileName;
         return Task.CompletedTask;

--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -731,7 +731,12 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             Dispatcher.UIThread.Invoke(() => { _iconVolume.Value = isMuted ? "fa-solid fa-volume-xmark" : "fa-solid fa-volume-up"; });
         }
 
-        internal async Task Open(string videoFileName)
+        /// <param name="startPositionSeconds">
+        /// Where the video should already be when it comes up. Callers that restore a position
+        /// (session restore, fullscreen, undock) pass it here instead of seeking afterwards:
+        /// a later seek leaves the player showing 0:00 for a moment and then jumping (#13329).
+        /// </param>
+        internal async Task Open(string videoFileName, double startPositionSeconds = 0)
         {
             if (IsDisposed)
             {
@@ -745,7 +750,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             SetPositionDisplayOnly(0);
             Duration = 0;
 
-            await _videoPlayerInstance.LoadFile(videoFileName);
+            await _videoPlayerInstance.LoadFile(videoFileName, startPositionSeconds);
 
             // The control may have been torn down while LoadFile was awaiting (fullscreen
             // closed mid-open, a second layout rebuild). Starting the position timer then

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -16887,20 +16887,25 @@ public partial class MainViewModel :
 
             if (Se.Settings.Video.AutoOpen && skipLoadVideo == false)
             {
+                // Open the video at the restored line right away. SeekVideoToSelectedLineAsync
+                // below still runs as a safety net, but on its own it means the video comes up at
+                // 0:00, stays there for a few hundred milliseconds and then jumps (issue #13329).
+                var videoStartPositionSeconds = GetRestoredVideoStartPositionSeconds(selectedSubtitleIndex);
+
                 if (!string.IsNullOrEmpty(videoFileName) && File.Exists(videoFileName))
                 {
-                    await VideoOpenFile(videoFileName, desiredAudioTrackId);
+                    await VideoOpenFile(videoFileName, desiredAudioTrackId, videoStartPositionSeconds);
                 }
                 else if (TryGetRecentVideoFileName(fileName, out var recentVideoFileName))
                 {
                     // Honor the media this subtitle was last opened with - e.g. an audio-only
                     // project keeps its .wav instead of grabbing a later burned-in .mp4 of the
                     // same name that FindVideoFileName would otherwise prefer (issue #11612).
-                    await VideoOpenFile(recentVideoFileName, desiredAudioTrackId);
+                    await VideoOpenFile(recentVideoFileName, desiredAudioTrackId, videoStartPositionSeconds);
                 }
                 else if (FindVideoFileName.TryFindVideoFileName(fileName, out videoFileName))
                 {
-                    await VideoOpenFile(videoFileName, desiredAudioTrackId);
+                    await VideoOpenFile(videoFileName, desiredAudioTrackId, videoStartPositionSeconds);
                 }
             }
 
@@ -16924,6 +16929,19 @@ public partial class MainViewModel :
         {
             await SeekVideoToSelectedLineAsync();
         }
+    }
+
+    // Where the video should be opened when a session is restored: the start time of the line the
+    // user was last on. Mirrors the "index 0 is not a restored position" rule in
+    // SeekVideoToSelectedLineAsync, so a freshly opened file still comes up at 0:00.
+    private double GetRestoredVideoStartPositionSeconds(int? selectedSubtitleIndex)
+    {
+        if (selectedSubtitleIndex is not > 0 || selectedSubtitleIndex.Value >= Subtitles.Count)
+        {
+            return 0;
+        }
+
+        return Subtitles[selectedSubtitleIndex.Value].StartTime.TotalSeconds;
     }
 
     // Seek the video to the selected line's start after (re)opening a file, like SE 4 did.
@@ -19305,7 +19323,10 @@ public partial class MainViewModel :
                && (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);
     }
 
-    private async Task VideoOpenFile(string videoFileName, int desiredAudioTrackId = -1) // OpenVideoFile
+    // startPositionSeconds: where the video should already be when it comes up, for callers that
+    // restore a session. Handing it to the player beats seeking afterwards - the video then never
+    // shows 0:00 first and never visibly jumps (issue #13329).
+    private async Task VideoOpenFile(string videoFileName, int desiredAudioTrackId = -1, double startPositionSeconds = 0) // OpenVideoFile
     {
         var vp = GetVideoPlayerControl();
         if (vp == null)
@@ -19315,7 +19336,7 @@ public partial class MainViewModel :
 
         _videoOpenTokenSource?.Cancel();
         _audioTrack = null;
-        await vp.Open(videoFileName);
+        await vp.Open(videoFileName, startPositionSeconds);
         _videoFileName = videoFileName;
         RefreshSubtitlePreview();
 

--- a/src/ui/Features/Shared/FullScreenVideoPlayer.cs
+++ b/src/ui/Features/Shared/FullScreenVideoPlayer.cs
@@ -219,7 +219,9 @@ public class FullScreenVideoWindow : Window
             // Start polling for cursor movement
             _mouseMoveDetectionTimer?.Start();
 
-            await videoPlayer.Open(videoFileName);
+            // Open where the user was rather than at 0:00 - going fullscreen otherwise shows the
+            // start of the video for a moment and then jumps back (issue #13329).
+            await videoPlayer.Open(videoFileName, position);
             await videoPlayer.WaitForPlayersReadyAsync();
 
             // The freshly opened player starts at 0:00; seek back to where the user was. The seek

--- a/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
+++ b/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
@@ -182,7 +182,9 @@ public partial class VideoPlayerUndockedViewModel : ObservableObject
             Dispatcher.UIThread.Post(async () =>
             {
                 await Task.Delay(100);
-                await videoPlayerControl.Open(_originalVideoFileName);
+                // Open where the docked player was - seeking only afterwards shows the start of
+                // the video for a moment and then jumps (issue #13329).
+                await videoPlayerControl.Open(_originalVideoFileName, _originalPosition);
                 await Task.Delay(100);
                 await videoPlayerControl.WaitForPlayersReadyAsync();
                 await Task.Delay(100);

--- a/src/ui/Logic/VideoPlayers/IVideoPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/IVideoPlayer.cs
@@ -9,7 +9,17 @@ public interface IVideoPlayer
     string FileName { get; }
 
     bool CanLoad();
-    Task LoadFile(string fileName);
+
+    /// <summary>
+    /// Loads a media file. Playback never starts by itself - the player comes up paused and
+    /// only <see cref="Play"/> / <see cref="PlayOrPause"/> start it (issue #13329).
+    /// </summary>
+    /// <param name="startPositionSeconds">
+    /// Where the first presented frame should be. Seeking after the file is up leaves the player
+    /// showing 0:00 for a few hundred milliseconds and then visibly jumping, so callers that
+    /// already know the wanted position (session restore, fullscreen, undock) pass it here.
+    /// </param>
+    Task LoadFile(string fileName, double startPositionSeconds = 0);
     void CloseFile();
 
     void Play();

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -514,6 +514,29 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         return string.Join(Path.PathSeparator, usable);
     }
 
+    /// <summary>
+    /// Brings the core up paused.
+    /// <para>
+    /// mpv's own default is <c>pause=no</c>, so a file starts playing the moment the demuxer has
+    /// something - Subtitle Edit never wants that: opening a video is an editing action, not a
+    /// "watch it" one, and every caller that does want playback (visual sync, the ASSA previews,
+    /// cut video) asks for it explicitly. Pausing from managed code once the load has been issued
+    /// is too late: that call sits behind an await continuation on the UI thread, which at
+    /// start-up - restoring the last session, building the grid, laying out the waveform - can
+    /// take a few hundred milliseconds, and the user gets a burst of the video at mpv's default
+    /// volume before it lands (issue #13329).
+    /// </para>
+    /// <para>Must be called before mpv_initialize.</para>
+    /// </summary>
+    private void SetStartPausedOption()
+    {
+        var err = SetOptionString("pause", "yes");
+        if (err < 0)
+        {
+            Se.LogError(new InvalidOperationException(GetErrorString(err)), "LibMpvDynamicPlayer could not set pause=yes");
+        }
+    }
+
     private int _brightness;
 
     public int ToggleBrightness()
@@ -585,6 +608,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         // Set mpv to use OpenGL render API for all platforms
         SetOptionString("vo", "libmpv");
         SetOptionString("gpu-api", "opengl");
+        SetStartPausedOption();
 
         // On Linux, do NOT force gpu-context.  Avalonia (11.x) has no native
         // Wayland backend — it always provides an X11/XWayland OpenGL context,
@@ -688,6 +712,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         // Tell mpv to use the external (libmpv) renderer.
         SetOptionString("vo", "libmpv");
         SetOptionString("gpu-api", "metal");
+        SetStartPausedOption();
 
         SetYtDlpPathOption();
 
@@ -990,7 +1015,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         }
     }
 
-    public async Task LoadFile(string path)
+    public async Task LoadFile(string path, double startPositionSeconds = 0)
     {
         EnsureNotDisposed();
 
@@ -1007,7 +1032,27 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         _audioEndBound = null;
         _lastRawTimePos = -1;
 
+        // Open at the wanted position instead of at 0:00 - a seek issued once the file is up
+        // shows the start of the video for a moment and then jumps (issue #13329). "start" is
+        // sticky, so it has to be cleared ("none", its own default) for opens that want the
+        // beginning - a silent failure here would strand every later open at a stale position.
+        var startErr = SetOptionString("start", startPositionSeconds > 0
+            ? startPositionSeconds.ToString(CultureInfo.InvariantCulture)
+            : "none");
+        if (startErr < 0)
+        {
+            Se.LogError(new InvalidOperationException(GetErrorString(startErr)), "LibMpvDynamicPlayer LoadFile start");
+        }
+
         await WaitForCoreInitializedAsync();
+
+        // mpv's own default is pause=no, so it starts playing the instant it has decoded
+        // something. The core is created paused (see the Initialize* methods) and every caller
+        // that wants playback asks for it explicitly, but pause it here too: it is a user
+        // property, so anything the user did to the previous file - or a play that ran while
+        // this one was being picked - would otherwise carry over into this load.
+        DoMpvCommand("set", "pause", "yes");
+        _pausedValue = null;
 
         var err = await Task.Run(() => DoMpvCommand("loadfile", path));
         if (_disposed)
@@ -1076,6 +1121,10 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
         await WaitForCoreInitializedAsync();
 
+        // Unlike LoadFile this one is meant to start playing: it backs the "play this clip"
+        // buttons in the text-to-speech windows, which load a file and expect to hear it.
+        // Those windows build their own core via Initialize(), which - unlike the three
+        // rendering Initialize* methods - deliberately leaves mpv's pause default alone.
         var err = await Task.Run(() => DoMpvCommand("loadfile", path));
         if (_disposed)
         {
@@ -1717,6 +1766,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
         // Set mpv to use software rendering
         SetOptionString("vo", "libmpv");
+        SetStartPausedOption();
 
         if (_mpvInitialize == null || _mpvRenderContextCreate == null || _mpvRenderContextSetUpdateCallback == null)
         {

--- a/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicPlayer.cs
@@ -103,6 +103,10 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayer
     private libvlc_audio_set_volume? _libvlc_audio_set_volume;
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate void libvlc_audio_set_mute(IntPtr mediaPlayer, int status);
+    private libvlc_audio_set_mute? _libvlc_audio_set_mute;
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     private delegate int libvlc_audio_get_track_count(IntPtr mediaPlayer);
     private libvlc_audio_get_track_count? _libvlc_audio_get_track_count;
 
@@ -340,6 +344,7 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayer
         _libvlc_audio_get_delay = (libvlc_audio_get_delay)GetDllType(typeof(libvlc_audio_get_delay), "libvlc_audio_get_delay");
         _libvlc_audio_get_volume = (libvlc_audio_get_volume)GetDllType(typeof(libvlc_audio_get_volume), "libvlc_audio_get_volume");
         _libvlc_audio_set_volume = (libvlc_audio_set_volume)GetDllType(typeof(libvlc_audio_set_volume), "libvlc_audio_set_volume");
+        _libvlc_audio_set_mute = (libvlc_audio_set_mute)GetDllType(typeof(libvlc_audio_set_mute), "libvlc_audio_set_mute");
 
         _libvlc_track_description_release = (libvlc_track_description_release)GetDllType(typeof(libvlc_track_description_release), "libvlc_track_description_release");
         if (_libvlc_track_description_release == null)
@@ -634,7 +639,7 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayer
 
     public string FileName => _fileName;
 
-    public async Task LoadFile(string path)
+    public async Task LoadFile(string path, double startPositionSeconds = 0)
     {
         EnsureNotDisposed();
 
@@ -695,6 +700,15 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayer
                 // Ignore
             }
 
+            // The duration only becomes available once playback has begun, so this has to play
+            // the file - but the user asked to open a video, not to hear the first tenth of a
+            // second of it (issue #13329). Silence it for as long as the probe runs. Both mute
+            // and volume are set: libvlc applies whichever it can, depending on when the audio
+            // output gets created.
+            var volumeBeforeProbe = _libvlc_audio_get_volume?.Invoke(_mediaPlayer) ?? -1;
+            _libvlc_audio_set_mute?.Invoke(_mediaPlayer, 1);
+            _libvlc_audio_set_volume?.Invoke(_mediaPlayer, 0);
+
             // Start playing to parse media and get duration
             _libvlc_media_player_play?.Invoke(_mediaPlayer);
 
@@ -715,9 +729,20 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayer
                 }
             }
 
-            // Pause immediately after getting duration and seek to start
+            // Pause immediately after getting duration and go to where the caller wants to be -
+            // seeking only once the player is up shows the start of the video first and then
+            // jumps (issue #13329).
             _libvlc_media_player_set_pause?.Invoke(_mediaPlayer, 1);
-            _libvlc_media_player_set_time?.Invoke(_mediaPlayer, 0);
+            _libvlc_media_player_set_time?.Invoke(_mediaPlayer, startPositionSeconds > 0 ? (long)(startPositionSeconds * 1000.0) : 0);
+
+            // Hand the audio back. VideoPlayerControl.Open re-applies the user's volume right
+            // after this, but LoadFile is also reached from the sub-reload path, which doesn't -
+            // so restore what this player had rather than leaving it silent.
+            _libvlc_audio_set_mute?.Invoke(_mediaPlayer, 0);
+            if (volumeBeforeProbe >= 0)
+            {
+                _libvlc_audio_set_volume?.Invoke(_mediaPlayer, volumeBeforeProbe);
+            }
 
             _fileName = path;
         });

--- a/tests/UI/Controls/VideoPlayerControlOpenPositionTests.cs
+++ b/tests/UI/Controls/VideoPlayerControlOpenPositionTests.cs
@@ -1,0 +1,98 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Controls.VideoPlayer;
+using Nikse.SubtitleEdit.Logic.VideoPlayers;
+using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace UITests.Controls;
+
+/// <summary>
+/// Covers the "video plays for a moment and then jumps" behaviour behind issue #13329.
+/// Restoring a session used to open the video at 0:00 and seek only once the player reported
+/// ready, which showed the start of the file for a few hundred milliseconds before jumping to
+/// where the user actually was. The wanted position now travels with the open request, so the
+/// very first frame the player presents is the right one.
+/// </summary>
+public class VideoPlayerControlOpenPositionTests
+{
+    private sealed class RecordingVideoPlayer : IVideoPlayer
+    {
+        public double LastStartPositionSeconds { get; private set; } = -1;
+        public int LoadFileCount { get; private set; }
+        public int PauseCount { get; private set; }
+
+        public string Name => "recording";
+        public string FileName { get; private set; } = string.Empty;
+
+        public bool CanLoad() => true;
+
+        public Task LoadFile(string fileName, double startPositionSeconds = 0)
+        {
+            FileName = fileName;
+            LastStartPositionSeconds = startPositionSeconds;
+            LoadFileCount++;
+            return Task.CompletedTask;
+        }
+
+        public void CloseFile() => FileName = string.Empty;
+
+        public void Play()
+        {
+        }
+
+        public void PlayOrPause()
+        {
+        }
+
+        public void Pause() => PauseCount++;
+
+        public void Stop()
+        {
+        }
+
+        public AudioTrackInfo? ToggleAudioTrack() => null;
+
+        public bool IsPlaying => false;
+        public bool IsPaused => true;
+        public double Position { get; set; }
+        public double Duration => 600;
+        public int VolumeMaximum => 100;
+        public double Volume { get; set; } = 50;
+        public double Speed { get; set; } = 1.0;
+    }
+
+    [AvaloniaFact]
+    public async Task OpenForwardsTheStartPositionToThePlayer()
+    {
+        var player = new RecordingVideoPlayer();
+        var control = new VideoPlayerControl(player);
+
+        await control.Open("fake.mkv", 123.5);
+
+        Assert.Equal(123.5, player.LastStartPositionSeconds);
+    }
+
+    [AvaloniaFact]
+    public async Task OpenWithoutAStartPositionLoadsFromTheBeginning()
+    {
+        var player = new RecordingVideoPlayer();
+        var control = new VideoPlayerControl(player);
+
+        await control.Open("fake.mkv");
+
+        Assert.Equal(0, player.LastStartPositionSeconds);
+    }
+
+    [AvaloniaFact]
+    public async Task OpenPausesThePlayer()
+    {
+        var player = new RecordingVideoPlayer();
+        var control = new VideoPlayerControl(player);
+
+        await control.Open("fake.mkv");
+
+        // Opening a video is an editing action - it must never leave playback running.
+        Assert.True(player.PauseCount > 0);
+    }
+}

--- a/tests/UI/Controls/VideoPlayerControlTeardownTests.cs
+++ b/tests/UI/Controls/VideoPlayerControlTeardownTests.cs
@@ -28,7 +28,7 @@ public class VideoPlayerControlTeardownTests
 
         public bool CanLoad() => true;
 
-        public Task LoadFile(string fileName)
+        public Task LoadFile(string fileName, double startPositionSeconds = 0)
         {
             FileName = fileName;
             return Task.CompletedTask;

--- a/tests/UI/Features/Main/RestoredVideoStartPositionTests.cs
+++ b/tests/UI/Features/Main/RestoredVideoStartPositionTests.cs
@@ -1,0 +1,127 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using System.Reflection;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// Restoring a session hands the remembered line's start time to the video player so the file
+/// opens where the user was, instead of opening at 0:00 and seeking a few hundred milliseconds
+/// later - which showed the start of the video and then a visible jump (issue #13329).
+/// A remembered row 0 is not a restored position though, it is just where the grid always lands
+/// on open, so that case must still open at the beginning (issues #13191 / #12898).
+/// </summary>
+public class RestoredVideoStartPositionTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+    private readonly string _tempDirectory;
+
+    public RestoredVideoStartPositionTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "SubtitleEdit.UITests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+
+    private (Window Window, MainViewModel Vm) ShowEmptyMainWindow()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        return (window, vm);
+    }
+
+    private string WriteSrt(string name)
+    {
+        var fileName = Path.Combine(_tempDirectory, name);
+        File.WriteAllText(fileName,
+            "1" + Environment.NewLine +
+            "00:00:01,000 --> 00:00:02,000" + Environment.NewLine +
+            "Line one" + Environment.NewLine +
+            Environment.NewLine +
+            "2" + Environment.NewLine +
+            "00:01:30,500 --> 00:01:32,000" + Environment.NewLine +
+            "Line two" + Environment.NewLine +
+            Environment.NewLine +
+            "3" + Environment.NewLine +
+            "00:02:05,000 --> 00:02:06,000" + Environment.NewLine +
+            "Line three" + Environment.NewLine);
+        return fileName;
+    }
+
+    private static double GetStartPosition(MainViewModel vm, int? selectedSubtitleIndex) =>
+        (double)typeof(MainViewModel)
+            .GetMethod("GetRestoredVideoStartPositionSeconds", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(vm, new object?[] { selectedSubtitleIndex })!;
+
+    private async Task<MainViewModel> OpenThreeLineFileAsync()
+    {
+        var (window, vm) = ShowEmptyMainWindow();
+        await vm.SubtitleOpen(WriteSrt("restore.srt"), skipLoadVideo: true);
+        for (var pump = 0; pump < 5; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+
+        Assert.Equal(3, vm.Subtitles.Count);
+        return vm;
+    }
+
+    [AvaloniaFact]
+    public async Task RestoredLineOpensTheVideoAtThatLinesStartTime()
+    {
+        var vm = await OpenThreeLineFileAsync();
+
+        Assert.Equal(90.5, GetStartPosition(vm, 1));
+        Assert.Equal(125, GetStartPosition(vm, 2));
+    }
+
+    [AvaloniaFact]
+    public async Task FirstRowAndNoRememberedLineOpenTheVideoAtTheBeginning()
+    {
+        var vm = await OpenThreeLineFileAsync();
+
+        Assert.Equal(0, GetStartPosition(vm, 0));
+        Assert.Equal(0, GetStartPosition(vm, null));
+    }
+
+    [AvaloniaFact]
+    public async Task StaleRememberedLineOpensTheVideoAtTheBeginning()
+    {
+        var vm = await OpenThreeLineFileAsync();
+
+        // The file shrank since the line was remembered - no position to restore.
+        Assert.Equal(0, GetStartPosition(vm, 9));
+    }
+}


### PR DESCRIPTION
Fixes #13329.

Starting SE with *open last file on start* played the restored video for a moment, then jumped to the line the user was last on and stopped.

### Why

Nothing ever told mpv to start paused. Its default is `pause=no`, so the file starts playing as soon as the demuxer has something; the only thing stopping it was `VideoPlayerControl.Open` calling `Pause()` **after** the load, one await continuation away on a UI thread that is at its busiest during start-up. The user's volume is applied after the load too, so the burst came out at mpv's default 100. Audio-only files were worse - `LoadFile` can spend up to 2.5 s polling for the duration before it returns and lets the pause happen.

The second half of the report - the jump - is the restore seeking only once the player reports ready: the video came up at 0:00, sat there ~400 ms and then moved.

### What changed

- The mpv core is created paused: all three rendering `Initialize*` methods set `pause=yes` before `mpv_initialize`, and `LoadFile` pauses again right before `loadfile`. Playback can now only start when something asks for it - and every caller that wants it (visual sync, set sync point, the ASSA previews, cut video) already calls `Play()` explicitly.
- `LoadAudio` is deliberately left alone: it backs the "play this clip" buttons in the text-to-speech windows, which rely on the load starting playback. Those windows build their own core via `Initialize()`, which does not set the option.
- The wanted position travels with the open request instead of being seeked afterwards - mpv's `start` option, `set_time` for VLC. Session restore, entering fullscreen and undocking the video all pass it, so the first frame presented is the right one. `SeekVideoToSelectedLineAsync` still runs as the safety net, and the "row 0 is not a restored position" rule (#13191 / #12898) is mirrored, so a freshly opened file still comes up at 0:00.
- libvlc had the same symptom from a different cause: it deliberately plays the file to make the duration appear, sleeping in 50 ms steps, so every open was audible regardless. It is muted (and volume 0) for as long as that probe runs, then restored.

### Testing

`dotnet test tests/UI` - 1585 passed. New tests cover the open plumbing (start position forwarded to the player, open always pauses) and the restore rule (mid-file line -> its start time, row 0 / no remembered line / stale index -> 0).

Not covered by tests: the native mpv and VLC behaviour itself - worth a manual check that the video comes up silent and already at the restored line, and that visual sync / ASSA preview / cut video still start playing.
