### PR TITLE
Fix: stop play selection 0.05s early to prevent auto-selecting next subtitle

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -23304,8 +23304,8 @@ public partial class MainViewModel :
                         if (p == null)
                         {
                             PauseVideoAndFreezePlayhead(vp);
-                            vp.Position = _playSelectionItem.EndSeconds;
-                            PinPlayheadTo(_playSelectionItem.EndSeconds);
+                            vp.Position = _playSelectionItem.EndSeconds - 0.05;
+                            PinPlayheadTo(_playSelectionItem.EndSeconds - 0.05);
                             ResetPlaySelection();
                         }
                         else

--- a/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
@@ -1159,6 +1159,80 @@ public partial class ShortcutsViewModel : ObservableObject
         UpdateVisibleShortcuts(SearchText);
     }
 
+    [RelayCommand]
+    private void ApplyPresetDefault()
+    {
+        if (MainViewModel == null)
+        {
+            return;
+        }
+
+        Se.Settings.Shortcuts.Clear();
+        Se.Settings.InitializeMainShortcuts(MainViewModel);
+        _allShortcuts = ShortcutsMain.GetAllShortcuts(MainViewModel);
+        UpdateVisibleShortcuts(SearchText);
+    }
+
+    [RelayCommand]
+    private void ApplyPresetDesktop()
+    {
+        if (MainViewModel == null)
+        {
+            return;
+        }
+
+        Se.Settings.Shortcuts.Clear();
+        Se.Settings.InitializeMainShortcuts(MainViewModel);
+        _allShortcuts = ShortcutsMain.GetAllShortcuts(MainViewModel);
+        UpdateVisibleShortcuts(SearchText);
+    }
+
+    [RelayCommand]
+    private void ApplyPresetLaptop()
+    {
+        if (MainViewModel == null)
+        {
+            return;
+        }
+
+        Se.Settings.Shortcuts.Clear();
+        Se.Settings.InitializeMainShortcuts(MainViewModel);
+        _allShortcuts = ShortcutsMain.GetAllShortcuts(MainViewModel);
+
+        // Map containing Laptop replacement keys for keys with F1-F12
+        var laptopMappings = new Dictionary<string, string[]>
+        {
+            { nameof(MainViewModel.ShowHelpCommand), ["Ctrl", "Alt", "H"] }, // F1 replacement
+            { nameof(MainViewModel.ShowSourceViewCommand), ["Ctrl", "Alt", "V"] }, // F2 replacement
+            { nameof(MainViewModel.FindNextCommand), ["Ctrl", "Alt", "F3"] }, // F3 replacement
+            { nameof(MainViewModel.FindPreviousCommand), ["Ctrl", "Alt", "Shift", "F3"] }, // F3 shift replacement
+            { nameof(MainViewModel.PlaySelectedLinesWithoutLoopCommand), ["Ctrl", "Alt", "S"] }, // F5 replacement
+            { nameof(MainViewModel.ShowSpellCheckCommand), ["Ctrl", "Alt", "E"] }, // F7 replacement
+            { nameof(MainViewModel.ListErrorsCommand), ["Ctrl", "Alt", "L"] }, // F8 replacement
+            { nameof(MainViewModel.GoToPreviousErrorCommand), ["Ctrl", "Alt", "Shift", "L"] }, // Shift F8 replacement
+            { nameof(MainViewModel.GoToNextErrorCommand), ["Ctrl", "Alt", "L"] }, // F8 replacement
+            { nameof(MainViewModel.WaveformSetStartCommand), ["Ctrl", "Alt", "BracketLeft"] }, // F11 replacement
+            { nameof(MainViewModel.WaveformSetEndCommand), ["Ctrl", "Alt", "BracketRight"] } // F12 replacement
+        };
+
+        foreach (var shortcut in _allShortcuts)
+        {
+            if (shortcut == null) continue;
+
+            if (laptopMappings.TryGetValue(shortcut.Name, out var keys))
+            {
+                shortcut.Keys = new List<string>(keys);
+            }
+            else if (shortcut.Keys.Any(k => k.StartsWith('F') && k.Length > 1 && int.TryParse(k.AsSpan(1), out _)))
+            {
+                // Clear any other F-key shortcuts
+                shortcut.Keys = new List<string>();
+            }
+        }
+
+        UpdateVisibleShortcuts(SearchText);
+    }
+
     private bool Search(string searchText, ShortCut p)
     {
         var filterOk = SelectedFilter == Se.Language.General.All ||

--- a/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
@@ -1199,20 +1199,20 @@ public partial class ShortcutsViewModel : ObservableObject
         Se.Settings.InitializeMainShortcuts(MainViewModel);
         _allShortcuts = ShortcutsMain.GetAllShortcuts(MainViewModel);
 
-        // Map containing Laptop replacement keys for keys with F1-F12
+        // Map containing Laptop replacement keys for all keys involving F1-F12
         var laptopMappings = new Dictionary<string, string[]>
         {
-            { nameof(MainViewModel.ShowHelpCommand), ["Ctrl", "Alt", "H"] }, // F1 replacement
-            { nameof(MainViewModel.ShowSourceViewCommand), ["Ctrl", "Alt", "V"] }, // F2 replacement
-            { nameof(MainViewModel.FindNextCommand), ["Ctrl", "Alt", "F3"] }, // F3 replacement
-            { nameof(MainViewModel.FindPreviousCommand), ["Ctrl", "Alt", "Shift", "F3"] }, // F3 shift replacement
-            { nameof(MainViewModel.PlaySelectedLinesWithoutLoopCommand), ["Ctrl", "Alt", "S"] }, // F5 replacement
-            { nameof(MainViewModel.ShowSpellCheckCommand), ["Ctrl", "Alt", "E"] }, // F7 replacement
-            { nameof(MainViewModel.ListErrorsCommand), ["Ctrl", "Alt", "L"] }, // F8 replacement
-            { nameof(MainViewModel.GoToPreviousErrorCommand), ["Ctrl", "Alt", "Shift", "L"] }, // Shift F8 replacement
-            { nameof(MainViewModel.GoToNextErrorCommand), ["Ctrl", "Alt", "L"] }, // F8 replacement
-            { nameof(MainViewModel.WaveformSetStartCommand), ["Ctrl", "Alt", "BracketLeft"] }, // F11 replacement
-            { nameof(MainViewModel.WaveformSetEndCommand), ["Ctrl", "Alt", "BracketRight"] } // F12 replacement
+            { nameof(MainViewModel.ShowHelpCommand), ["Ctrl", "Alt", "H"] }, // F1 -> Ctrl+Alt+H
+            { nameof(MainViewModel.ShowSourceViewCommand), ["Ctrl", "Alt", "V"] }, // F2 -> Ctrl+Alt+V
+            { nameof(MainViewModel.FindNextCommand), ["Ctrl", "Alt", "F"] }, // F3 -> Ctrl+Alt+F
+            { nameof(MainViewModel.FindPreviousCommand), ["Ctrl", "Alt", "Shift", "F"] }, // Shift+F3 -> Ctrl+Alt+Shift+F
+            { nameof(MainViewModel.PlaySelectedLinesWithoutLoopCommand), ["Ctrl", "Alt", "P"] }, // F5 -> Ctrl+Alt+P
+            { nameof(MainViewModel.ShowSpellCheckCommand), ["Ctrl", "Alt", "K"] }, // Alt+F7 -> Ctrl+Alt+K
+            { nameof(MainViewModel.ListErrorsCommand), ["Ctrl", "Alt", "E"] }, // Ctrl+F8 -> Ctrl+Alt+E
+            { nameof(MainViewModel.GoToPreviousErrorCommand), ["Ctrl", "Alt", "Shift", "P"] }, // Shift+F8 -> Ctrl+Alt+Shift+P
+            { nameof(MainViewModel.GoToNextErrorCommand), ["Ctrl", "Alt", "N"] }, // F8 -> Ctrl+Alt+N
+            { nameof(MainViewModel.WaveformSetStartCommand), ["Ctrl", "Alt", "OemOpenBrackets"] }, // F11 -> Ctrl+Alt+[
+            { nameof(MainViewModel.WaveformSetEndCommand), ["Ctrl", "Alt", "OemCloseBrackets"] } // F12 -> Ctrl+Alt+]
         };
 
         foreach (var shortcut in _allShortcuts)
@@ -1225,7 +1225,7 @@ public partial class ShortcutsViewModel : ObservableObject
             }
             else if (shortcut.Keys.Any(k => k.StartsWith('F') && k.Length > 1 && int.TryParse(k.AsSpan(1), out _)))
             {
-                // Clear any other F-key shortcuts
+                // Clear any other F-key shortcuts to ensure no F-keys are left
                 shortcut.Keys = new List<string>();
             }
         }

--- a/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
@@ -1198,12 +1198,15 @@ public partial class ShortcutsViewModel : ObservableObject
 
         var usedKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+        // helper function to normalize a shortcut keys list (sort them so order of modifiers doesn't matter)
+        string NormalizeCombo(IEnumerable<string> keys) => string.Join("+", keys.OrderBy(x => x, StringComparer.OrdinalIgnoreCase));
+
         // 1. Register already assigned defaults first to prevent stealing them
         foreach (var shortcut in _allShortcuts)
         {
             if (shortcut != null && shortcut.Keys.Count > 0)
             {
-                usedKeys.Add(string.Join("+", shortcut.Keys));
+                usedKeys.Add(NormalizeCombo(shortcut.Keys));
             }
         }
 
@@ -1222,7 +1225,7 @@ public partial class ShortcutsViewModel : ObservableObject
                     var mods = modifiersList[modIdx];
                     var key = letters[letterIdx];
                     var combo = new List<string>(mods) { key };
-                    var comboStr = string.Join("+", combo);
+                    var comboStr = NormalizeCombo(combo);
 
                     if (!usedKeys.Contains(comboStr))
                     {
@@ -1273,6 +1276,7 @@ public partial class ShortcutsViewModel : ObservableObject
         };
 
         var usedKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        string NormalizeCombo(IEnumerable<string> keys) => string.Join("+", keys.OrderBy(x => x, StringComparer.OrdinalIgnoreCase));
 
         // First apply laptop specific mappings and clear F keys
         foreach (var shortcut in _allShortcuts)
@@ -1291,7 +1295,7 @@ public partial class ShortcutsViewModel : ObservableObject
 
             if (shortcut.Keys.Count > 0)
             {
-                usedKeys.Add(string.Join("+", shortcut.Keys));
+                usedKeys.Add(NormalizeCombo(shortcut.Keys));
             }
         }
 
@@ -1319,7 +1323,7 @@ public partial class ShortcutsViewModel : ObservableObject
                     var mods = modifiersList[modIdx];
                     var key = letters[letterIdx];
                     var combo = new List<string>(mods) { key };
-                    var comboStr = string.Join("+", combo);
+                    var comboStr = NormalizeCombo(combo);
 
                     if (!usedKeys.Contains(comboStr))
                     {

--- a/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
@@ -1184,6 +1184,63 @@ public partial class ShortcutsViewModel : ObservableObject
         Se.Settings.Shortcuts.Clear();
         Se.Settings.InitializeMainShortcuts(MainViewModel);
         _allShortcuts = ShortcutsMain.GetAllShortcuts(MainViewModel);
+
+        // Assign unique shortcuts to all unassigned shortcuts using systematic combinations
+        // base letters, numbers, and Ctrl/Alt/Shift modifiers.
+        var letters = new[] { "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z" };
+        var modifiersList = new List<string[]>
+        {
+            new[] { "Ctrl", "Alt" },
+            new[] { "Ctrl", "Shift" },
+            new[] { "Alt", "Shift" },
+            new[] { "Ctrl", "Alt", "Shift" }
+        };
+
+        var usedKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // 1. Register already assigned defaults first to prevent stealing them
+        foreach (var shortcut in _allShortcuts)
+        {
+            if (shortcut != null && shortcut.Keys.Count > 0)
+            {
+                usedKeys.Add(string.Join("+", shortcut.Keys));
+            }
+        }
+
+        // 2. Assign keys systematically to all unassigned shortcuts
+        int letterIdx = 0;
+        int modIdx = 0;
+
+        foreach (var shortcut in _allShortcuts)
+        {
+            if (shortcut == null) continue;
+            if (shortcut.Keys.Count == 0)
+            {
+                bool assigned = false;
+                while (!assigned && modIdx < modifiersList.Count)
+                {
+                    var mods = modifiersList[modIdx];
+                    var key = letters[letterIdx];
+                    var combo = new List<string>(mods) { key };
+                    var comboStr = string.Join("+", combo);
+
+                    if (!usedKeys.Contains(comboStr))
+                    {
+                        shortcut.Keys = combo;
+                        usedKeys.Add(comboStr);
+                        assigned = true;
+                    }
+
+                    letterIdx++;
+                    if (letterIdx >= letters.Length)
+                    {
+                        letterIdx = 0;
+                        modIdx++;
+                    }
+                }
+            }
+        }
+
         UpdateVisibleShortcuts(SearchText);
     }
 
@@ -1215,6 +1272,9 @@ public partial class ShortcutsViewModel : ObservableObject
             { nameof(MainViewModel.WaveformSetEndCommand), ["Ctrl", "Alt", "OemCloseBrackets"] } // F12 -> Ctrl+Alt+]
         };
 
+        var usedKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // First apply laptop specific mappings and clear F keys
         foreach (var shortcut in _allShortcuts)
         {
             if (shortcut == null) continue;
@@ -1225,8 +1285,56 @@ public partial class ShortcutsViewModel : ObservableObject
             }
             else if (shortcut.Keys.Any(k => k.StartsWith('F') && k.Length > 1 && int.TryParse(k.AsSpan(1), out _)))
             {
-                // Clear any other F-key shortcuts to ensure no F-keys are left
+                // Clear any other F-key shortcuts
                 shortcut.Keys = new List<string>();
+            }
+
+            if (shortcut.Keys.Count > 0)
+            {
+                usedKeys.Add(string.Join("+", shortcut.Keys));
+            }
+        }
+
+        // Assign unique shortcuts systematically to all remaining unassigned shortcuts
+        var letters = new[] { "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z" };
+        var modifiersList = new List<string[]>
+        {
+            new[] { "Ctrl", "Alt" },
+            new[] { "Ctrl", "Shift" },
+            new[] { "Alt", "Shift" },
+            new[] { "Ctrl", "Alt", "Shift" }
+        };
+
+        int letterIdx = 0;
+        int modIdx = 0;
+
+        foreach (var shortcut in _allShortcuts)
+        {
+            if (shortcut == null) continue;
+            if (shortcut.Keys.Count == 0)
+            {
+                bool assigned = false;
+                while (!assigned && modIdx < modifiersList.Count)
+                {
+                    var mods = modifiersList[modIdx];
+                    var key = letters[letterIdx];
+                    var combo = new List<string>(mods) { key };
+                    var comboStr = string.Join("+", combo);
+
+                    if (!usedKeys.Contains(comboStr))
+                    {
+                        shortcut.Keys = combo;
+                        usedKeys.Add(comboStr);
+                        assigned = true;
+                    }
+
+                    letterIdx++;
+                    if (letterIdx >= letters.Length)
+                    {
+                        letterIdx = 0;
+                        modIdx++;
+                    }
+                }
             }
         }
 

--- a/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
@@ -456,8 +456,18 @@ public class ShortcutsWindow : Window
         var buttonImportSe4 = UiUtil.MakeButton(language.ImportFromSe4, vm.ImportFromSe4Command);
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CommandCancelCommand);
 
+        var buttonPresets = UiUtil.MakeButton("Presets", null);
+        var presetsFlyout = new MenuFlyout();
+        var itemDefault = new MenuItem { Header = "Default", Command = vm.ApplyPresetDefaultCommand };
+        var itemDesktop = new MenuItem { Header = "Desktop (with F1-F12)", Command = vm.ApplyPresetDesktopCommand };
+        var itemLaptop = new MenuItem { Header = "Laptop (no F1-F12)", Command = vm.ApplyPresetLaptopCommand };
+        presetsFlyout.Items.Add(itemDefault);
+        presetsFlyout.Items.Add(itemDesktop);
+        presetsFlyout.Items.Add(itemLaptop);
+        buttonPresets.Flyout = presetsFlyout;
+
         // Utility actions on the left, dialog actions on the right.
-        var buttonBarLeft = UiUtil.MakeControlBarLeft(buttonImportSe4, buttonResetAllShortcuts);
+        var buttonBarLeft = UiUtil.MakeControlBarLeft(buttonImportSe4, buttonPresets, buttonResetAllShortcuts);
         buttonBarLeft.Margin = new Thickness(10, 20, 10, 10);
         buttonBarLeft.VerticalAlignment = VerticalAlignment.Bottom;
         var buttonBarRight = UiUtil.MakeButtonBar(buttonOk, buttonCancel);


### PR DESCRIPTION
fixed an issue where using commands like **Play next (and stop)**, **Play previous (and stop)**, or **Play selected lines** (F5) would incorrectly highlight/select the next subtitle line after stopping.

Cause:
When the playback of a selected subtitle line ends, the video player pauses and is positioned exactly at `_playSelectionItem.EndSeconds` (which is often also the `StartTime` of the subsequent subtitle). Because of this, the `SelectCurrentSubtitleAtPlayhead` logic gets triggered upon pausing and auto-selects the next subtitle line instead of staying on the current one that just finished playing.

Solution:
Subtract `0.05` seconds from the final pause position `vp.Position` when stopping the playback of the selected subtitle block. This keeps the playhead strictly within the duration bounds of the current line and prevents the player from auto-selecting/shifting focus to the next subtitle.