### PR TITLE
Fix #13332: TTS generation folder - honor outputFolder, configurable, cleanup after merge

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/AdvancedTtsSettings/AdvancedTtsSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/AdvancedTtsSettings/AdvancedTtsSettingsViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
+using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.AdvancedTtsSettings;
 
@@ -23,12 +24,16 @@ public partial class AdvancedTtsSettingsViewModel : ObservableObject
     [ObservableProperty] private string _edgeTtsVolume;
     [ObservableProperty] private bool _isEdgeTtsEngine;
     [ObservableProperty] private string _rubberbandStatus;
+    [ObservableProperty] private string _outputFolder;
+
+    private readonly IFolderHelper _folderHelper;
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
 
-    public AdvancedTtsSettingsViewModel()
+    public AdvancedTtsSettingsViewModel(IFolderHelper folderHelper)
     {
+        _folderHelper = folderHelper;
         RubberbandStatus = FfmpegGenerator.IsRubberbandAvailable() ? "(installed)" : "(not found in FFmpeg)";
         var s = Se.Settings.Video.TextToSpeech;
         DoProAudioChain = s.ProAudioChainEnabled;
@@ -39,9 +44,20 @@ public partial class AdvancedTtsSettingsViewModel : ObservableObject
         DoHighQualityTimeStretch = s.HighQualityTimeStretchEnabled;
         SilencePaddingMs = s.SilencePaddingMs.ToString();
         OutputSampleRate = s.OutputSampleRate.ToString();
+        OutputFolder = s.OutputFolder;
         EdgeTtsRate = s.EdgeTtsRate;
         EdgeTtsPitch = s.EdgeTtsPitch;
         EdgeTtsVolume = s.EdgeTtsVolume;
+    }
+
+    [RelayCommand]
+    private async Task BrowseOutputFolder()
+    {
+        var folder = await _folderHelper.PickFolderAsync(Window!, Se.Language.General.SelectSaveFolder);
+        if (!string.IsNullOrEmpty(folder))
+        {
+            OutputFolder = folder;
+        }
     }
 
     [RelayCommand]
@@ -59,6 +75,7 @@ public partial class AdvancedTtsSettingsViewModel : ObservableObject
         s.EdgeTtsRate = EdgeTts.NormalizeProsodyValue(EdgeTtsRate, "%");
         s.EdgeTtsPitch = EdgeTts.NormalizeProsodyValue(EdgeTtsPitch, "Hz");
         s.EdgeTtsVolume = EdgeTts.NormalizeProsodyValue(EdgeTtsVolume, "%");
+        s.OutputFolder = OutputFolder?.Trim() ?? string.Empty;
         Se.SaveSettings();
 
         OkPressed = true;

--- a/src/ui/Features/Video/TextToSpeech/AdvancedTtsSettings/AdvancedTtsSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/AdvancedTtsSettings/AdvancedTtsSettingsWindow.cs
@@ -66,6 +66,32 @@ public class AdvancedTtsSettingsWindow : Window
                 MakeFieldRow(vm, Se.Language.Video.TextToSpeech.OutputSampleRate, nameof(vm.OutputSampleRate), 60,
                     Se.Language.Video.TextToSpeech.OutputSampleRateDescription),
 
+                new StackPanel
+                {
+                    Spacing = 2,
+                    Margin = new Thickness(0, 0, 0, 10),
+                    Children =
+                    {
+                        new StackPanel
+                        {
+                            Orientation = Orientation.Horizontal,
+                            Children =
+                            {
+                                new Label { Content = Se.Language.Video.TextToSpeech.OutputFolder, VerticalAlignment = VerticalAlignment.Center, FontWeight = FontWeight.SemiBold, Margin = new Thickness(0, 0, 5, 0) },
+                                UiUtil.MakeTextBox(260, vm, nameof(vm.OutputFolder)),
+                                UiUtil.MakeButton(Se.Language.Video.TextToSpeech.OutputFolderBrowse, vm.BrowseOutputFolderCommand),
+                            }
+                        },
+                        new TextBlock
+                        {
+                            Text = Se.Language.Video.TextToSpeech.OutputFolderHint,
+                            TextWrapping = TextWrapping.Wrap,
+                            Opacity = 0.7,
+                            Margin = new Thickness(26, 0, 0, 0),
+                        },
+                    }
+                },
+
                 MakeFieldRow(vm, Se.Language.Video.TextToSpeech.EdgeTtsRate, nameof(vm.EdgeTtsRate), 120,
                     Se.Language.Video.TextToSpeech.EdgeTtsRateDescription,
                     nameof(vm.IsEdgeTtsEngine)),

--- a/src/ui/Features/Video/TextToSpeech/Engines/AllTalk.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/AllTalk.cs
@@ -175,7 +175,7 @@ public class AllTalk : ITtsEngine
             return new TtsResult { Text = text, FileName = string.Empty, Error = true, ErrorMessage = error };
         }
 
-        var outputFileName = Path.Combine(GetSetAllTalkFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetAllTalkFolder()), Guid.NewGuid() + ".wav");
         File.Move(allTalkFileNameOutputFileName, outputFileName);
 
         return new TtsResult { FileName = outputFileName, Text = text };

--- a/src/ui/Features/Video/TextToSpeech/Engines/AzureSpeech.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/AzureSpeech.cs
@@ -166,7 +166,7 @@ public class AzureSpeech : ITtsEngine
             return new TtsResult { Text = text, FileName = string.Empty, Error = true };
         }
 
-        var fileName = Path.Combine(GetSetAzureFolder(), Guid.NewGuid() + ".mp3");
+        var fileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetAzureFolder()), Guid.NewGuid() + ".mp3");
         await File.WriteAllBytesAsync(fileName, ms.ToArray(), cancellationToken);
         return new TtsResult { Text = text, FileName = fileName };
     }

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -304,7 +304,7 @@ public class ChatterboxTtsCpp : ITtsEngine
 
         await EnsureServerRunningAsync(ResolveModelKey(model), cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder()), Guid.NewGuid() + ".wav");
         var inputText = text;
 
         var payload = BuildSpeakPayload(inputText, chatterboxVoice.FilePath);

--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
@@ -499,7 +499,7 @@ public class CosyVoice3CrispAsr : ITtsEngine
         var modelKey = ResolveModelKey(model);
         await EnsureServerRunningAsync(modelKey, voiceArg, cosyVoice.RefText, cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder()), Guid.NewGuid() + ".wav");
 
         var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrSpeed, 0.25, 4.0);
         // Deliberately NO `voice` / `ref_text` field: for cloning, voiceArg is an absolute WAV

--- a/src/ui/Features/Video/TextToSpeech/Engines/EdgeTts.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/EdgeTts.cs
@@ -123,7 +123,7 @@ public class EdgeTts : ITtsEngine
         }
 
         var folder = GetSetEdgeTtsFolder();
-        var fileName = Path.Combine(folder, Guid.NewGuid() + ".mp3");
+        var fileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, folder), Guid.NewGuid() + ".mp3");
         var escapedText = EscapeQuotedArgValue(text);
         var escapedVoice = EscapeQuotedArgValue(edgeVoice.Name);
         var args =

--- a/src/ui/Features/Video/TextToSpeech/Engines/ElevenLabs.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ElevenLabs.cs
@@ -307,7 +307,7 @@ public class ElevenLabs : ITtsEngine
             return new TtsResult { Text = text, FileName = string.Empty, Error = true, ErrorMessage = error };
         }
 
-        var fileName = Path.Combine(GetSetElevenLabsFolder(), Guid.NewGuid() + ".mp3");
+        var fileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetElevenLabsFolder()), Guid.NewGuid() + ".mp3");
         await File.WriteAllBytesAsync(fileName, ms.ToArray(), cancellationToken);
         return new TtsResult { Text = text, FileName = fileName };
     }

--- a/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
@@ -376,7 +376,7 @@ public class F5TtsCrispAsr : ITtsEngine
         var modelKey = ResolveModelKey(model);
         await EnsureServerRunningAsync(modelKey, f5Voice.FilePath, refText, cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder()), Guid.NewGuid() + ".wav");
 
         var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.F5TtsCrispAsrSpeed, 0.25, 4.0);
         // Deliberately NO `voice` / `ref_text` field: the server rejects absolute paths outright

--- a/src/ui/Features/Video/TextToSpeech/Engines/GoogleSpeech.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/GoogleSpeech.cs
@@ -178,7 +178,7 @@ public class GoogleSpeech : ITtsEngine
             return new TtsResult { Text = text, FileName = string.Empty, Error = true };
         }
 
-        var fileName = Path.Combine(GetSetGoogleFolder(), Guid.NewGuid() + ".mp3");
+        var fileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetGoogleFolder()), Guid.NewGuid() + ".mp3");
         await File.WriteAllBytesAsync(fileName, ms.ToArray(), cancellationToken);
         return new TtsResult { Text = text, FileName = fileName };
     }

--- a/src/ui/Features/Video/TextToSpeech/Engines/IndexTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/IndexTtsCrispAsr.cs
@@ -363,7 +363,7 @@ public class IndexTtsCrispAsr : ITtsEngine
         var modelKey = ResolveModelKey(model);
         await EnsureServerRunningAsync(modelKey, indexVoice.FilePath, cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder()), Guid.NewGuid() + ".wav");
         var inputText = text;
 
         // OpenAI-compatible /v1/audio/speech payload. CrispASR's indextts backend uses:

--- a/src/ui/Features/Video/TextToSpeech/Engines/KokoroTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/KokoroTtsCpp.cs
@@ -235,7 +235,7 @@ public class KokoroTtsCpp : ITtsEngine
 
         await EnsureServerRunningAsync(cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder()), Guid.NewGuid() + ".wav");
         var inputText = text;
         var voiceName = string.IsNullOrEmpty(kokoroVoice.Voice) ? DefaultVoice : kokoroVoice.Voice;
 

--- a/src/ui/Features/Video/TextToSpeech/Engines/MistralSpeech.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/MistralSpeech.cs
@@ -154,7 +154,7 @@ public class MistralSpeech : ITtsEngine
             return new TtsResult { Text = text, FileName = string.Empty, Error = true };
         }
 
-        var fileName = Path.Combine(GetSetMistralFolder(), Guid.NewGuid() + ".mp3");
+        var fileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetMistralFolder()), Guid.NewGuid() + ".mp3");
         await File.WriteAllBytesAsync(fileName, ms.ToArray(), cancellationToken);
         return new TtsResult { Text = text, FileName = fileName };
     }

--- a/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
@@ -443,7 +443,7 @@ public class MossTtsCrispAsr : ITtsEngine
         var languageArg = MossTtsLanguages.ResolveLanguageArg(language);
         await EnsureServerRunningAsync(modelKey, mossVoice.FilePath, refText, languageArg, cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder()), Guid.NewGuid() + ".wav");
 
         var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.MossTtsCrispAsrSpeed, 0.25, 4.0);
         var payload = BuildSpeakPayload(text, speed);

--- a/src/ui/Features/Video/TextToSpeech/Engines/Murf.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Murf.cs
@@ -175,7 +175,7 @@ public class Murf : ITtsEngine
             return new TtsResult { Text = text, FileName = string.Empty, Error = true };
         }
 
-        var fileName = Path.Combine(GetSetMurfFolder(), Guid.NewGuid() + ".mp3");
+        var fileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetMurfFolder()), Guid.NewGuid() + ".mp3");
         await File.WriteAllBytesAsync(fileName, ms.ToArray(), cancellationToken);
         return new TtsResult { Text = text, FileName = fileName };
     }

--- a/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceCrispAsr.cs
@@ -401,7 +401,7 @@ public class OmniVoiceCrispAsr : ITtsEngine
         var modelKey = ResolveModelKey(model);
         await EnsureServerRunningAsync(modelKey, voicePath, refText, cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder()), Guid.NewGuid() + ".wav");
 
         var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.OmniVoiceCrispAsrSpeed, 0.25, 4.0);
 

--- a/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
@@ -235,7 +235,7 @@ public class OmniVoiceTtsCpp : ITtsEngine
                 $"OmniVoice TTS models not found in {GetSetModelsFolder()}. Download them via the TTS download dialog.");
         }
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder()), Guid.NewGuid() + ".wav");
         var inputText = text;
 
         var psi = new ProcessStartInfo

--- a/src/ui/Features/Video/TextToSpeech/Engines/Piper.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Piper.cs
@@ -237,8 +237,9 @@ public class Piper : ITtsEngine
             throw new ArgumentException("Voice is not a PiperVoice");
         }
 
-        var fileNameOnly = Guid.NewGuid() + ".wav";
-        var process = StartPiperProcess(piperVoice, text, fileNameOnly);
+        var outputFolderResolved = TtsOutputFolder.Resolve(outputFolder, GetSetPiperFolder());
+        var fileName = Path.Combine(outputFolderResolved, Guid.NewGuid() + ".wav");
+        var process = StartPiperProcess(piperVoice, text, fileName);
         Se.WriteToolsLog($"Piper: {process.StartInfo.FileName} {process.StartInfo.Arguments} (voice={piperVoice}, textLen={text.Length})");
         var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
         await process.WaitForExitAsync(cancellationToken);
@@ -257,7 +258,6 @@ public class Piper : ITtsEngine
             return new TtsResult { Text = text, FileName = string.Empty, Error = true };
         }
 
-        var fileName = Path.Combine(GetSetPiperFolder(), fileNameOnly);
         if (!File.Exists(fileName) || new FileInfo(fileName).Length == 0)
         {
             var msg = $"Piper exited successfully but produced no audio - Parameters: "
@@ -281,7 +281,7 @@ public class Piper : ITtsEngine
             {
                 WorkingDirectory = GetSetPiperFolder(),
                 FileName = GetPiperExecutableFileName(),
-                Arguments = $"-m \"{voice.ModelShort}\" -c \"{voice.ConfigShort}\" -f {outputFileName}",
+                Arguments = $"-m \"{voice.ModelShort}\" -c \"{voice.ConfigShort}\" -f \"{outputFileName}\"",
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 RedirectStandardInput = true,

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
@@ -231,7 +231,7 @@ public class Qwen3TtsCpp : ITtsEngine
         var modelFileName = GetModelFileName(ResolveModelKey(model));
         await EnsureServerRunningAsync(modelFileName, cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder()), Guid.NewGuid() + ".wav");
         var inputText = text;
 
         // Voice instruction only does anything on the instruction-tuned VoiceDesign model;

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -763,7 +763,7 @@ public class Qwen3TtsCrispAsr : ITtsEngine
 
         await EnsureServerRunningAsync(modelKey, cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder()), Guid.NewGuid() + ".wav");
         var inputText = text;
         // Share the qwen3-tts.cpp instruction setting so users get the same voice description
         // regardless of which Qwen3 engine they're testing with.

--- a/src/ui/Features/Video/TextToSpeech/Engines/VibeVoiceCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VibeVoiceCrispAsr.cs
@@ -351,7 +351,7 @@ public class VibeVoiceCrispAsr : ITtsEngine
         var modelKey = ResolveModelKey(model);
         await EnsureServerRunningAsync(modelKey, cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder()), Guid.NewGuid() + ".wav");
         var inputText = text;
 
         // OpenAI-compatible /v1/audio/speech payload. CrispASR's vibevoice backends look at:

--- a/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
@@ -415,7 +415,7 @@ public class VoxCPM2CrispAsr : ITtsEngine
         var modelKey = ResolveModelKey(model);
         await EnsureServerRunningAsync(modelKey, voxVoice.FilePath, refText, cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder()), Guid.NewGuid() + ".wav");
 
         var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.VoxCPM2CrispAsrSpeed, 0.25, 4.0);
         // Deliberately NO `voice` / `ref_text` field: the voxcpm2 backend treats a per-request

--- a/src/ui/Features/Video/TextToSpeech/Engines/ZonosTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ZonosTtsCrispAsr.cs
@@ -342,7 +342,7 @@ public class ZonosTtsCrispAsr : ITtsEngine
 
         await EnsureServerRunningAsync(zonosVoice.FilePath, cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder()), Guid.NewGuid() + ".wav");
         var inputText = text;
 
         // OpenAI-compatible /v1/audio/speech payload. Zonos transcribes the reference internally

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -144,6 +144,20 @@ public partial class TextToSpeechViewModel : ObservableObject
     private readonly IFileHelper _fileHelper;
     private readonly IFolderHelper _folderHelper;
     private string _waveFolder;
+    private string _generationOutputFolder = string.Empty;
+
+    // Snapshot of the output-folder decision made at Initialize: when the user configured a
+    // custom folder, session files are kept there by design and cleanup is disabled; with the
+    // default scratch folder (system temp) per-line files are intermediates and get deleted
+    // after the merge / on close (#13332). Snapshotting (not re-reading the setting) keeps the
+    // decision stable even if the setting changes mid-session.
+    private bool _keepSessionGeneratedFiles;
+
+    // Per-line files produced by this window's Speak calls (scratch). Deleted after the merge
+    // so the temporary folder doesn't fill with GUID-named wavs; kept when the user configured
+    // a custom output folder (#13332).
+    private readonly object _sessionAudioFilesLock = new();
+    private readonly List<string> _sessionGeneratedAudioFiles = new();
     private CancellationTokenSource _cancellationTokenSource;
     private CancellationToken _cancellationToken;
     private WavePeakData2? _wavePeakData;
@@ -972,6 +986,31 @@ public partial class TextToSpeechViewModel : ObservableObject
         ProgressValue = 0.0;
         _waveFolder = waveFolder;
 
+        // Per-line generated files: user-configured folder when set, otherwise the scratch
+        // folder (system temp). Engines used to ignore the folder they were given and wrote
+        // into their own data folders, piling up GUID-named files that were never cleaned
+        // (#13332) — see TtsOutputFolder.
+        var outputFolderSetting = Se.Settings.Video.TextToSpeech.OutputFolder;
+        _keepSessionGeneratedFiles = !string.IsNullOrWhiteSpace(outputFolderSetting);
+        _generationOutputFolder = _keepSessionGeneratedFiles ? outputFolderSetting : _waveFolder;
+        if (_keepSessionGeneratedFiles)
+        {
+            try
+            {
+                Directory.CreateDirectory(_generationOutputFolder);
+            }
+            catch (Exception ex)
+            {
+                // The setting is a free-text field: an unusable path (invalid chars, a file,
+                // no permission) must not prevent the TTS window from opening - fall back to
+                // the scratch folder and log instead.
+                Se.LogError(ex, "TTS: configured output folder is unusable - falling back to the temporary folder");
+                Se.WriteToolsLog($"TTS: configured output folder \"{outputFolderSetting}\" is unusable - falling back to the temporary folder");
+                _generationOutputFolder = _waveFolder;
+                _keepSessionGeneratedFiles = false;
+            }
+        }
+
         _castKind = ActorVoiceDetector.Detect(subtitle, format);
         // Only surface the cast button when there's actually more than one actor/voice to assign
         // — a single-speaker subtitle uses the global engine/voice and the button would be a no-op.
@@ -1046,7 +1085,7 @@ public partial class TextToSpeechViewModel : ObservableObject
         var usableEngines = ActorVoiceDetector.FilterUsableEngines(Engines).ToList();
         var result = await _windowService.ShowDialogAsync<ActorVoiceMappingWindow, ActorVoiceMappingViewModel>(Window!, vm =>
         {
-            vm.Initialize(actorNames, usableEngines, _actorVoiceMappings, SelectedEngine, SelectedVoice, _castKind, _waveFolder);
+            vm.Initialize(actorNames, usableEngines, _actorVoiceMappings, SelectedEngine, SelectedVoice, _castKind, _generationOutputFolder);
         });
 
         if (result.OkPressed)
@@ -1608,7 +1647,11 @@ public partial class TextToSpeechViewModel : ObservableObject
             // await, so awaiting it directly kept the dispatcher busy and left the "please wait"
             // popup above unpainted for the whole spawn (#12878).
             var result = await Task.Run(() =>
-                engine.Speak(text, _waveFolder, voice, SelectedLanguage, SelectedRegion, SelectedModel, testVoiceToken));
+                engine.Speak(text, _generationOutputFolder, voice, SelectedLanguage, SelectedRegion, SelectedModel, testVoiceToken));
+            if (!result.Error && !string.IsNullOrEmpty(result.FileName))
+            {
+                TrackSessionGeneratedFile(result.FileName);
+            }
             if (!testVoiceToken.IsCancellationRequested)
             {
                 if (result.Error || string.IsNullOrEmpty(result.FileName) || !File.Exists(result.FileName))
@@ -2197,6 +2240,7 @@ public partial class TextToSpeechViewModel : ObservableObject
         var audioFileName = await _fileHelper.PickSaveFile(Window!, ".wav", GetSuggestedMergedAudioFileName(), Se.Language.General.SaveFileAsTitle);
         if (string.IsNullOrEmpty(audioFileName))
         {
+            DeleteSessionGeneratedAudioFiles();
             ResetGeneratingUiState();
             return;
         }
@@ -2207,6 +2251,9 @@ public partial class TextToSpeechViewModel : ObservableObject
 
         await HandleAddToVideo(audioFileName, outputFolder, _cancellationToken);
 
+        // The merged track (saved above) is the deliverable - the per-line scratch wavs this
+        // session generated are no longer needed anywhere (#13332).
+        DeleteSessionGeneratedAudioFiles();
         ResetGeneratingUiState();
     }
 
@@ -2408,6 +2455,62 @@ public partial class TextToSpeechViewModel : ObservableObject
         }
     }
 
+    /// <summary>
+    /// Deletes the per-line audio files (and audio intermediates) this window generated. With
+    /// the default scratch folder (system temp) the files are pure intermediates — the merged
+    /// track the user saves is the deliverable — so they are removed after the merge and on
+    /// window close, instead of piling up GUID-named wavs forever (#13332). When the user
+    /// configured a custom output folder the files are intentionally kept there.
+    /// </summary>
+    private void DeleteSessionGeneratedAudioFiles()
+    {
+        if (_keepSessionGeneratedFiles)
+        {
+            return;
+        }
+
+        List<string> toDelete;
+        lock (_sessionAudioFilesLock)
+        {
+            toDelete = new List<string>(_sessionGeneratedAudioFiles);
+            _sessionGeneratedAudioFiles.Clear();
+        }
+
+        foreach (var file in toDelete)
+        {
+            try
+            {
+                if (File.Exists(file))
+                {
+                    File.Delete(file);
+                }
+            }
+            catch
+            {
+                // ignored - best-effort cleanup of scratch files
+            }
+        }
+    }
+
+    /// <summary>
+    /// Registers a generated audio file (or intermediate) for the session-end cleanup. All
+    /// files are tracked regardless of folder; <see cref="DeleteSessionGeneratedAudioFiles"/>
+    /// decides whether to delete them. Called from background threads (Speak runs off the UI
+    /// thread), hence the lock.
+    /// </summary>
+    private void TrackSessionGeneratedFile(string? filePath)
+    {
+        if (string.IsNullOrEmpty(filePath))
+        {
+            return;
+        }
+
+        lock (_sessionAudioFilesLock)
+        {
+            _sessionGeneratedAudioFiles.Add(filePath);
+        }
+    }
+
     private async Task<string> GenerateSilenceWaveFile(TtsStepResult[] stepResults, CancellationToken cancellationToken)
     {
         ProgressText = Se.Language.Video.TextToSpeech.PreparingMergeDotDotDot;
@@ -2513,8 +2616,12 @@ public partial class TextToSpeechViewModel : ObservableObject
                 var speakResult = await TtsInstructionSwap.RunAsync(
                     resolution.Engine,
                     resolution.Instruction,
-                    () => resolution.Engine.Speak(resolution.Text, _waveFolder, resolution.Voice,
+                    () => resolution.Engine.Speak(resolution.Text, _generationOutputFolder, resolution.Voice,
                         language, region, model, cancellationToken));
+                if (!speakResult.Error && !string.IsNullOrEmpty(speakResult.FileName))
+                {
+                    TrackSessionGeneratedFile(speakResult.FileName);
+                }
                 if (speakResult.Error && !string.IsNullOrEmpty(speakResult.ErrorMessage) && !errorMessages.Contains(speakResult.ErrorMessage))
                 {
                     errorMessages.Add(speakResult.ErrorMessage);
@@ -2820,6 +2927,7 @@ public partial class TextToSpeechViewModel : ObservableObject
                 {
                     // Step 1: Trim silence from start and end
                     var outputFileName1 = Path.Combine(Path.GetDirectoryName(item.CurrentFileName)!, Guid.NewGuid() + ".wav");
+                    TrackSessionGeneratedFile(outputFileName1);
                     var trimProcess = FfmpegGenerator.TrimSilenceStartAndEnd(item.CurrentFileName, outputFileName1);
                     await trimProcess.StartAndWaitAsync(cancellationToken, segmentOperationTimeout);
 
@@ -2831,6 +2939,7 @@ public partial class TextToSpeechViewModel : ObservableObject
                     if (doVad)
                     {
                         var vadOutput = Path.Combine(Path.GetDirectoryName(item.CurrentFileName)!, $"vad_{Guid.NewGuid()}.wav");
+                        TrackSessionGeneratedFile(vadOutput);
                         var vadProcess = FfmpegGenerator.CompressInternalSilence(currentFile, vadOutput, vadMaxSilence);
                         await vadProcess.StartAndWaitAsync(cancellationToken, segmentOperationTimeout);
 
@@ -2913,6 +3022,7 @@ public partial class TextToSpeechViewModel : ObservableObject
                     var ext = ".wav";
                     var factor = (decimal)mediaInfo.Duration.TotalMilliseconds / divisor;
                     var outputFileName2 = Path.Combine(_waveFolder, $"{index}_{Guid.NewGuid()}{ext}");
+                    TrackSessionGeneratedFile(outputFileName2);
                     var overrideFileName = string.Empty;
                     if (!string.IsNullOrEmpty(overrideFileName) && File.Exists(Path.Combine(_waveFolder, overrideFileName)))
                     {
@@ -3066,6 +3176,10 @@ public partial class TextToSpeechViewModel : ObservableObject
                 try
                 {
                     processedFile = await TtsPostProcessor.ApplyPostProcessing(item.CurrentFileName, Path.GetDirectoryName(item.CurrentFileName)!, cancellationToken);
+                    if (!string.Equals(processedFile, item.CurrentFileName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        TrackSessionGeneratedFile(processedFile);
+                    }
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
@@ -3643,6 +3757,11 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             SeLogger.Error(ex, "TTS window close: saving the window position failed");
         }
+
+        // Scratch per-line wavs from a session that never reached the merge (or whose merge
+        // cancelled) are junk once the window is gone (#13332). No-op with a custom output
+        // folder configured - those files are kept by design.
+        DeleteSessionGeneratedAudioFiles();
 
         Se.WriteToolsLog("TTS window: close cleanup done");
     }

--- a/src/ui/Features/Video/TextToSpeech/TtsOutputFolder.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsOutputFolder.cs
@@ -1,0 +1,38 @@
+using System.IO;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech;
+
+/// <summary>
+/// Resolves the folder per-line generated audio files are written to.
+/// </summary>
+/// <remarks>
+/// Every engine's <c>Speak</c> used to ignore its <c>outputFolder</c> parameter and dumped
+/// GUID-named wavs into its own data folder (<c>.../TextToSpeech/&lt;Engine&gt;/</c>) — files
+/// that were never cleaned up, so the folders filled with hundreds of files (#13332). The
+/// caller now passes the session's generation folder (system temp by default, or the
+/// user-configured folder from TTS advanced settings); <see cref="Resolve"/> falls back to the
+/// engine's own folder only as a defensive default for direct callers that pass an empty
+/// folder. The resolved folder is created (best-effort) so engines can write to it directly.
+/// </remarks>
+public static class TtsOutputFolder
+{
+    public static string Resolve(string requestedFolder, string engineDefaultFolder)
+    {
+        if (string.IsNullOrWhiteSpace(requestedFolder))
+        {
+            return engineDefaultFolder;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(requestedFolder);
+        }
+        catch
+        {
+            // Best-effort: if the folder can't be created, the engine's write below fails with
+            // a descriptive error anyway. Never throw from resolution.
+        }
+
+        return requestedFolder;
+    }
+}

--- a/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
@@ -107,6 +107,11 @@ public class LanguageTextToSpeech
     public string SubtitleMergedLinesAppliedSingular { get; set; }
     public string SubtitleMergedLinesAppliedPlural { get; set; }
 
+    // Output folder for generated audio files (advanced TTS settings)
+    public string OutputFolder { get; set; }
+    public string OutputFolderHint { get; set; }
+    public string OutputFolderBrowse { get; set; }
+
     public LanguageTextToSpeech()
     {
         Title = "Text to speech";
@@ -120,6 +125,9 @@ public class LanguageTextToSpeech
         AddAudioToVideoFile = "Add audio to video file";
         EngineAndVoice = "Engine & voice";
         Output = "Output";
+        OutputFolder = "Output folder";
+        OutputFolderHint = "Folder for the generated audio files. Empty = system temporary folder (per-line files are cleaned up after the merge; the final audio is saved via the save dialog).";
+        OutputFolderBrowse = "Browse...";
         XLinesFromY = "{0} lines from {1}";
         XLines = "{0} lines";
         XVoices = "{0} voices";

--- a/src/ui/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/ui/Logic/Config/SeVideoTextToSpeech.cs
@@ -98,6 +98,11 @@ public class SeVideoTextToSpeech
     // Output sample rate (0 = default)
     public int OutputSampleRate { get; set; }
 
+    // Folder for per-line generated audio files. Empty = system temp (scratch; files are
+    // intermediates and get cleaned up after the merge). When set, generated files are
+    // written to this folder and kept (#13332).
+    public string OutputFolder { get; set; }
+
     // Remembered actor/voice mappings. Pre-fills the cast dialog so users don't have to
     // re-assign the same character voices every time they open a new subtitle. Keyed by actor
     // name; matches happen case-insensitively.
@@ -169,6 +174,7 @@ public class SeVideoTextToSpeech
         HighQualityTimeStretchEnabled = false;
         SilencePaddingMs = 0;
         OutputSampleRate = 0;
+        OutputFolder = string.Empty;
         LastActorVoiceMappings = new List<ActorVoiceMapping>();
     }
 }


### PR DESCRIPTION
Fixes points 1+2 of #13332 (confused output paths, no way to choose the generation folder, hundreds of files piling up in the engine folders). Point 3 of the issue (per-engine CrispASR copies) is not reproducible in the current code - the CrispASR runtime has been a single shared install since these engines were added; see my comment on the issue.

## Problem
Every TTS engine's `Speak(text, outputFolder, ...)` **ignored** the `outputFolder` parameter and wrote GUID-named audio files into its own data folder (`.../TextToSpeech/<Engine>/`). The folders were never cleaned, so they filled with hundreds of files, and generated audio landed in places the user didn't expect (MOSS-TTS files in the folder tree next to `VoxCPM2CrispAsr`, etc.).

## Changes
1. **Engines honor `outputFolder`** — all 21 local engines (CrispASR family, Chatterbox, Piper, EdgeTts, ElevenLabs, Azure, Google, Mistral, Murf, AllTalk, Kokoro, OmniVoice/Qwen3 cpp) now write to the folder they are given via a shared `TtsOutputFolder.Resolve(requested, engineDefault)` helper (creates the folder best-effort). Fallback to the engine folder only for direct callers that pass an empty folder. Piper additionally gets the full resolved path quoted in the `-f` argument (it used to receive only a relative name and wrote into its own folder regardless).
2. **New setting `Video.TextToSpeech.OutputFolder`** (TTS → Advanced settings, "Output folder" + Browse): empty = system temporary folder (scratch); set = per-line files are written there and kept. An unusable path falls back to the scratch folder with a log instead of blocking the TTS window.
3. **Scratch cleanup** — per-line files and audio intermediates (trim/VAD/stretch/post-process) generated this session are deleted after the merge (and on window close for sessions that never merged), so the temp folder doesn't fill with GUID wavs. Files in a user-configured folder are intentionally kept (decision snapshotted at window open).

## Behavior after this PR
- Default: per-line files go to the system temp folder (same scratch area as all other merge intermediates), the engine data folders stop accumulating, and the final audio is still saved via the existing save dialog.
- User picks a folder in advanced settings: files land there and stay.
- Imported sessions are unaffected (their files are the user's exported copies and are never touched).

## Verification
- `dotnet build src/ui/UI.csproj` — clean (0 errors, 0 warnings) on the current head.
- TTS test suite (`--filter TextToSpeech`): 111 passed, 0 failed.
- 3 parallel read-only audits (engines / ViewModel lifecycle / settings+DI+metadata): findings fixed on this head — Piper output path (HIGH), folder-creation contract, `CreateDirectory` guard, intermediate tracking, setting snapshot, cast-dialog folder consistency.
- All 4 `Speak` call sites audited; review-regenerate and cast-dialog voice test use the same session folder.
- Throwaway probe tests for `TtsOutputFolder.Resolve` + the setting default passed (3/3), removed before commit per the project's minimal-test convention.