### PR TITLE
Write generated speech to the caller's output folder

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/AllTalk.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/AllTalk.cs
@@ -175,7 +175,7 @@ public class AllTalk : ITtsEngine
             return new TtsResult { Text = text, FileName = string.Empty, Error = true, ErrorMessage = error };
         }
 
-        var outputFileName = Path.Combine(GetSetAllTalkFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetAllTalkFolder), Guid.NewGuid() + ".wav");
         File.Move(allTalkFileNameOutputFileName, outputFileName);
 
         return new TtsResult { FileName = outputFileName, Text = text };

--- a/src/ui/Features/Video/TextToSpeech/Engines/AzureSpeech.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/AzureSpeech.cs
@@ -166,7 +166,7 @@ public class AzureSpeech : ITtsEngine
             return new TtsResult { Text = text, FileName = string.Empty, Error = true };
         }
 
-        var fileName = Path.Combine(GetSetAzureFolder(), Guid.NewGuid() + ".mp3");
+        var fileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetAzureFolder), Guid.NewGuid() + ".mp3");
         await File.WriteAllBytesAsync(fileName, ms.ToArray(), cancellationToken);
         return new TtsResult { Text = text, FileName = fileName };
     }

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -304,7 +304,7 @@ public class ChatterboxTtsCpp : ITtsEngine
 
         await EnsureServerRunningAsync(ResolveModelKey(model), cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
         var inputText = text;
 
         var payload = BuildSpeakPayload(inputText, chatterboxVoice.FilePath);

--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
@@ -499,7 +499,7 @@ public class CosyVoice3CrispAsr : ITtsEngine
         var modelKey = ResolveModelKey(model);
         await EnsureServerRunningAsync(modelKey, voiceArg, cosyVoice.RefText, cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
 
         var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrSpeed, 0.25, 4.0);
         // Deliberately NO `voice` / `ref_text` field: for cloning, voiceArg is an absolute WAV

--- a/src/ui/Features/Video/TextToSpeech/Engines/EdgeTts.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/EdgeTts.cs
@@ -122,7 +122,7 @@ public class EdgeTts : ITtsEngine
             throw new ArgumentException("Voice is not an EdgeTtsVoice");
         }
 
-        var folder = GetSetEdgeTtsFolder();
+        var folder = TtsOutputFolder.Resolve(outputFolder, GetSetEdgeTtsFolder);
         var fileName = Path.Combine(folder, Guid.NewGuid() + ".mp3");
         var escapedText = EscapeQuotedArgValue(text);
         var escapedVoice = EscapeQuotedArgValue(edgeVoice.Name);

--- a/src/ui/Features/Video/TextToSpeech/Engines/ElevenLabs.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ElevenLabs.cs
@@ -307,7 +307,7 @@ public class ElevenLabs : ITtsEngine
             return new TtsResult { Text = text, FileName = string.Empty, Error = true, ErrorMessage = error };
         }
 
-        var fileName = Path.Combine(GetSetElevenLabsFolder(), Guid.NewGuid() + ".mp3");
+        var fileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetElevenLabsFolder), Guid.NewGuid() + ".mp3");
         await File.WriteAllBytesAsync(fileName, ms.ToArray(), cancellationToken);
         return new TtsResult { Text = text, FileName = fileName };
     }

--- a/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
@@ -376,7 +376,7 @@ public class F5TtsCrispAsr : ITtsEngine
         var modelKey = ResolveModelKey(model);
         await EnsureServerRunningAsync(modelKey, f5Voice.FilePath, refText, cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
 
         var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.F5TtsCrispAsrSpeed, 0.25, 4.0);
         // Deliberately NO `voice` / `ref_text` field: the server rejects absolute paths outright

--- a/src/ui/Features/Video/TextToSpeech/Engines/GoogleSpeech.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/GoogleSpeech.cs
@@ -178,7 +178,7 @@ public class GoogleSpeech : ITtsEngine
             return new TtsResult { Text = text, FileName = string.Empty, Error = true };
         }
 
-        var fileName = Path.Combine(GetSetGoogleFolder(), Guid.NewGuid() + ".mp3");
+        var fileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetGoogleFolder), Guid.NewGuid() + ".mp3");
         await File.WriteAllBytesAsync(fileName, ms.ToArray(), cancellationToken);
         return new TtsResult { Text = text, FileName = fileName };
     }

--- a/src/ui/Features/Video/TextToSpeech/Engines/IndexTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/IndexTtsCrispAsr.cs
@@ -363,7 +363,7 @@ public class IndexTtsCrispAsr : ITtsEngine
         var modelKey = ResolveModelKey(model);
         await EnsureServerRunningAsync(modelKey, indexVoice.FilePath, cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
         var inputText = text;
 
         // OpenAI-compatible /v1/audio/speech payload. CrispASR's indextts backend uses:

--- a/src/ui/Features/Video/TextToSpeech/Engines/KokoroTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/KokoroTtsCpp.cs
@@ -235,7 +235,7 @@ public class KokoroTtsCpp : ITtsEngine
 
         await EnsureServerRunningAsync(cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
         var inputText = text;
         var voiceName = string.IsNullOrEmpty(kokoroVoice.Voice) ? DefaultVoice : kokoroVoice.Voice;
 

--- a/src/ui/Features/Video/TextToSpeech/Engines/MistralSpeech.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/MistralSpeech.cs
@@ -154,7 +154,7 @@ public class MistralSpeech : ITtsEngine
             return new TtsResult { Text = text, FileName = string.Empty, Error = true };
         }
 
-        var fileName = Path.Combine(GetSetMistralFolder(), Guid.NewGuid() + ".mp3");
+        var fileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetMistralFolder), Guid.NewGuid() + ".mp3");
         await File.WriteAllBytesAsync(fileName, ms.ToArray(), cancellationToken);
         return new TtsResult { Text = text, FileName = fileName };
     }

--- a/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
@@ -443,7 +443,7 @@ public class MossTtsCrispAsr : ITtsEngine
         var languageArg = MossTtsLanguages.ResolveLanguageArg(language);
         await EnsureServerRunningAsync(modelKey, mossVoice.FilePath, refText, languageArg, cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
 
         var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.MossTtsCrispAsrSpeed, 0.25, 4.0);
         var payload = BuildSpeakPayload(text, speed);

--- a/src/ui/Features/Video/TextToSpeech/Engines/Murf.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Murf.cs
@@ -175,7 +175,7 @@ public class Murf : ITtsEngine
             return new TtsResult { Text = text, FileName = string.Empty, Error = true };
         }
 
-        var fileName = Path.Combine(GetSetMurfFolder(), Guid.NewGuid() + ".mp3");
+        var fileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetMurfFolder), Guid.NewGuid() + ".mp3");
         await File.WriteAllBytesAsync(fileName, ms.ToArray(), cancellationToken);
         return new TtsResult { Text = text, FileName = fileName };
     }

--- a/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceCrispAsr.cs
@@ -401,7 +401,7 @@ public class OmniVoiceCrispAsr : ITtsEngine
         var modelKey = ResolveModelKey(model);
         await EnsureServerRunningAsync(modelKey, voicePath, refText, cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
 
         var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.OmniVoiceCrispAsrSpeed, 0.25, 4.0);
 

--- a/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
@@ -235,7 +235,7 @@ public class OmniVoiceTtsCpp : ITtsEngine
                 $"OmniVoice TTS models not found in {GetSetModelsFolder()}. Download them via the TTS download dialog.");
         }
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
         var inputText = text;
 
         var psi = new ProcessStartInfo

--- a/src/ui/Features/Video/TextToSpeech/Engines/Piper.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Piper.cs
@@ -237,8 +237,8 @@ public class Piper : ITtsEngine
             throw new ArgumentException("Voice is not a PiperVoice");
         }
 
-        var fileNameOnly = Guid.NewGuid() + ".wav";
-        var process = StartPiperProcess(piperVoice, text, fileNameOnly);
+        var fileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetPiperFolder), Guid.NewGuid() + ".wav");
+        var process = StartPiperProcess(piperVoice, text, fileName);
         Se.WriteToolsLog($"Piper: {process.StartInfo.FileName} {process.StartInfo.Arguments} (voice={piperVoice}, textLen={text.Length})");
         var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
         await process.WaitForExitAsync(cancellationToken);
@@ -257,7 +257,6 @@ public class Piper : ITtsEngine
             return new TtsResult { Text = text, FileName = string.Empty, Error = true };
         }
 
-        var fileName = Path.Combine(GetSetPiperFolder(), fileNameOnly);
         if (!File.Exists(fileName) || new FileInfo(fileName).Length == 0)
         {
             var msg = $"Piper exited successfully but produced no audio - Parameters: "
@@ -281,7 +280,9 @@ public class Piper : ITtsEngine
             {
                 WorkingDirectory = GetSetPiperFolder(),
                 FileName = GetPiperExecutableFileName(),
-                Arguments = $"-m \"{voice.ModelShort}\" -c \"{voice.ConfigShort}\" -f {outputFileName}",
+                // -f is quoted: the output file now lives in the caller's run folder (an absolute
+                // path that can contain spaces), not a bare GUID name in the piper folder.
+                Arguments = $"-m \"{voice.ModelShort}\" -c \"{voice.ConfigShort}\" -f \"{outputFileName}\"",
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 RedirectStandardInput = true,

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
@@ -231,7 +231,7 @@ public class Qwen3TtsCpp : ITtsEngine
         var modelFileName = GetModelFileName(ResolveModelKey(model));
         await EnsureServerRunningAsync(modelFileName, cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
         var inputText = text;
 
         // Voice instruction only does anything on the instruction-tuned VoiceDesign model;

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -763,7 +763,7 @@ public class Qwen3TtsCrispAsr : ITtsEngine
 
         await EnsureServerRunningAsync(modelKey, cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
         var inputText = text;
         // Share the qwen3-tts.cpp instruction setting so users get the same voice description
         // regardless of which Qwen3 engine they're testing with.

--- a/src/ui/Features/Video/TextToSpeech/Engines/TtsOutputFolder.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/TtsOutputFolder.cs
@@ -1,0 +1,43 @@
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.IO;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// Resolves the folder an engine writes its generated audio into.
+/// <para>
+/// Callers hand <see cref="ITtsEngine.Speak"/> a per-run output folder (the temp wave folder),
+/// but every engine used to ignore it and write into its own <c>TextToSpeech/&lt;Engine&gt;/</c>
+/// folder instead. Nothing ever cleaned those up, so a few generation runs left hundreds of
+/// stray clips sitting next to the engine's voices (#13332).
+/// </para>
+/// <para>
+/// Falls back to the engine's own folder when the caller passes nothing usable, so synthesis
+/// still works for callers that don't have a run folder (and for the engine unit tests).
+/// </para>
+/// </summary>
+public static class TtsOutputFolder
+{
+    public static string Resolve(string? outputFolder, Func<string> engineFolder)
+    {
+        if (!string.IsNullOrWhiteSpace(outputFolder))
+        {
+            try
+            {
+                if (!Directory.Exists(outputFolder))
+                {
+                    Directory.CreateDirectory(outputFolder);
+                }
+
+                return outputFolder;
+            }
+            catch (Exception ex)
+            {
+                Se.LogError(ex, $"TextToSpeech: cannot write to output folder \"{outputFolder}\" - using the engine folder instead");
+            }
+        }
+
+        return engineFolder();
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/Engines/VibeVoiceCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VibeVoiceCrispAsr.cs
@@ -351,7 +351,7 @@ public class VibeVoiceCrispAsr : ITtsEngine
         var modelKey = ResolveModelKey(model);
         await EnsureServerRunningAsync(modelKey, cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
         var inputText = text;
 
         // OpenAI-compatible /v1/audio/speech payload. CrispASR's vibevoice backends look at:

--- a/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
@@ -415,7 +415,7 @@ public class VoxCPM2CrispAsr : ITtsEngine
         var modelKey = ResolveModelKey(model);
         await EnsureServerRunningAsync(modelKey, voxVoice.FilePath, refText, cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
 
         var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.VoxCPM2CrispAsrSpeed, 0.25, 4.0);
         // Deliberately NO `voice` / `ref_text` field: the voxcpm2 backend treats a per-request

--- a/src/ui/Features/Video/TextToSpeech/Engines/ZonosTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ZonosTtsCrispAsr.cs
@@ -342,7 +342,7 @@ public class ZonosTtsCrispAsr : ITtsEngine
 
         await EnsureServerRunningAsync(zonosVoice.FilePath, cancellationToken);
 
-        var outputFileName = Path.Combine(GetSetFolder(), Guid.NewGuid() + ".wav");
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
         var inputText = text;
 
         // OpenAI-compatible /v1/audio/speech payload. Zonos transcribes the reference internally

--- a/tests/UI/Features/Video/TextToSpeech/Engines/TtsOutputFolderTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/TtsOutputFolderTests.cs
@@ -1,0 +1,127 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+namespace UITests.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// Every engine used to ignore the output folder its caller passed to
+/// <see cref="ITtsEngine.Speak"/> and write into its own <c>TextToSpeech/&lt;Engine&gt;/</c>
+/// folder instead, where nothing ever deleted the clips again (#13332). The last test here is
+/// the guard against that coming back with the next engine.
+/// </summary>
+public class TtsOutputFolderTests
+{
+    [Fact]
+    public void UsesTheCallersFolderWhenItExists()
+    {
+        var callerFolder = CreateTempFolder();
+        try
+        {
+            Assert.Equal(callerFolder, TtsOutputFolder.Resolve(callerFolder, () => "engine-folder"));
+        }
+        finally
+        {
+            Directory.Delete(callerFolder, true);
+        }
+    }
+
+    [Fact]
+    public void CreatesTheCallersFolderWhenItIsMissing()
+    {
+        var callerFolder = Path.Combine(Path.GetTempPath(), "SeTtsOutputFolderTests_" + Guid.NewGuid());
+        try
+        {
+            Assert.Equal(callerFolder, TtsOutputFolder.Resolve(callerFolder, () => "engine-folder"));
+            Assert.True(Directory.Exists(callerFolder));
+        }
+        finally
+        {
+            if (Directory.Exists(callerFolder))
+            {
+                Directory.Delete(callerFolder, true);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void FallsBackToTheEngineFolderWhenNothingUsableIsPassed(string? outputFolder)
+    {
+        Assert.Equal("engine-folder", TtsOutputFolder.Resolve(outputFolder, () => "engine-folder"));
+    }
+
+    /// <summary>
+    /// A bad path must not fail the whole generation run - synthesis falls back to the engine's
+    /// own folder, which is exactly where it went before.
+    /// </summary>
+    [Fact]
+    public void FallsBackToTheEngineFolderWhenTheFolderCannotBeCreated()
+    {
+        var blockingFile = Path.Combine(Path.GetTempPath(), "SeTtsOutputFolderTests_" + Guid.NewGuid() + ".tmp");
+        File.WriteAllText(blockingFile, "not a folder");
+        try
+        {
+            var impossibleFolder = Path.Combine(blockingFile, "output");
+            Assert.Equal("engine-folder", TtsOutputFolder.Resolve(impossibleFolder, () => "engine-folder"));
+        }
+        finally
+        {
+            File.Delete(blockingFile);
+        }
+    }
+
+    /// <summary>
+    /// Reflection finds the engines, the source scan finds the idiom: a new engine that writes to
+    /// its own folder instead of the caller's fails here rather than in a bug report six months on.
+    /// </summary>
+    [Fact]
+    public void EveryEngineRoutesItsOutputThroughResolve()
+    {
+        var enginesFolder = GetEnginesSourceFolder();
+        var engineTypes = typeof(ITtsEngine).Assembly
+            .GetTypes()
+            .Where(t => t is { IsClass: true, IsAbstract: false } && typeof(ITtsEngine).IsAssignableFrom(t))
+            .OrderBy(t => t.Name)
+            .ToList();
+
+        Assert.NotEmpty(engineTypes);
+
+        foreach (var engineType in engineTypes)
+        {
+            var sourceFile = Path.Combine(enginesFolder, engineType.Name + ".cs");
+            Assert.True(File.Exists(sourceFile), $"No source file found for TTS engine '{engineType.Name}' at '{sourceFile}'.");
+
+            var source = File.ReadAllText(sourceFile);
+            Assert.True(
+                source.Contains("TtsOutputFolder.Resolve(outputFolder", StringComparison.Ordinal),
+                $"{engineType.Name}.Speak must write into the caller's output folder - "
+                + "use TtsOutputFolder.Resolve(outputFolder, <engine folder getter>) instead of the engine folder.");
+        }
+    }
+
+    private static string CreateTempFolder()
+    {
+        var folder = Path.Combine(Path.GetTempPath(), "SeTtsOutputFolderTests_" + Guid.NewGuid());
+        Directory.CreateDirectory(folder);
+        return folder;
+    }
+
+    private static string GetEnginesSourceFolder()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "src", "ui", "Features", "Video", "TextToSpeech", "Engines");
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            $"Could not locate the TTS engines source folder walking up from '{AppContext.BaseDirectory}'.");
+    }
+}


### PR DESCRIPTION
Fixes the file-pileup half of #13332.

## The bug

Every TTS engine takes an `outputFolder` argument in `ITtsEngine.Speak(...)` and **ignores it**. All 21 engines wrote their generated clip into their own `TextToSpeech/<Engine>/` folder instead — the same folder that holds the engine's reference voices — and nothing ever deleted them. The caller's run folder only ever received the post-processed copies, so after a few generation runs the engine folder held hundreds of stray WAVs/MP3s (what the reporter saw next to `VoxCPM2CrispAsr`).

## The fix

New `TtsOutputFolder.Resolve(outputFolder, engineFolder)`:

- uses the folder the caller passed, creating it when missing;
- falls back to the engine's own folder when the caller passes nothing usable, or the folder can't be created — a bad path degrades to the old behaviour instead of failing the whole generation run.

All 21 engines now resolve their target through it: the 10 CrispASR-backed ones, Chatterbox / Kokoro / Qwen3TtsCpp / OmniVoiceTtsCpp / Piper / AllTalk, and the cloud engines (Azure, ElevenLabs, EdgeTts, Google, Mistral, Murf).

Piper needed more than a one-liner: it passed a bare GUID filename as `-f` and relied on the process working directory. It now receives the absolute path, **quoted**, since the run folder can contain spaces.

Side effect worth knowing: `TextToSpeechViewModel` creates its intermediate WAV next to the engine's file, so that litter moves out of the engine folder too.

## Tests

`TtsOutputFolderTests` covers the four `Resolve` behaviours plus a guard test that reflects over every `ITtsEngine` implementation and asserts its source routes through `TtsOutputFolder.Resolve(outputFolder, …)` — a future engine that writes into its own folder fails there instead of in a bug report.

7 new tests pass, the 119 existing TextToSpeech tests pass, `UI.csproj` builds clean.

## Not in scope here

- The caller passes `Path.GetTempPath()` itself, so clips land in the temp root alongside the pipeline's existing `silence.wav`/ffmpeg output. A per-run subfolder with cleanup would be tidier.
- The issue's request for a user-selectable output folder is a feature; the plumbing for it now exists (pick a folder in the UI, pass it as `waveFolder`).
- The issue's other question — CrispASR being duplicated per engine — is not happening: the runtime and its models live only in `<data>/CrispASR` (+ `models/`), one download service, one pin (v0.8.25), and every TTS engine resolves the executable via `new CrispAsrCohere().GetExecutable()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)