### PR TITLE
Send the picked target language to OmniVoice (CrispASR)

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceCrispAsr.cs
@@ -48,11 +48,19 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 ///   crispasr --server --backend omnivoice -m omnivoice-q4_k.gguf \
 ///       --codec-model omnivoice-tokenizer-f16.gguf --host 127.0.0.1 --port N \
 ///       [--voice reference.wav --ref-text "transcript"]
-/// then POST /v1/audio/speech with {"input": ..., "response_format": "wav", "speed": x}.
+/// then POST /v1/audio/speech with {"input": ..., "response_format": "wav", "speed": x,
+/// "language": id}.
 /// Confirmed on crispasr 0.8.25: the reference comes from the startup <c>--voice</c> flag (the
 /// per-request log reports <c>voice='&lt;startup&gt;'</c>), so the server is torn down and
 /// restarted when the selected voice or ref-text changes — the same shape the other cloning
-/// CrispASR engines settled on after #12757.
+/// CrispASR engines settled on after #12757. The target language is the opposite case: a
+/// per-request field, applied without a restart.
+///
+/// ⚠ Honouring <c>language</c> per request needs a crispasr build newer than the pinned v0.8.25.
+/// On v0.8.25 the CLI adapter applies the language once at startup only, so the field is parsed
+/// and ignored and every line stays language-agnostic (#13273). Sending it is harmless there —
+/// the IDs SE offers are the model's own — and it starts working the moment
+/// <see cref="Logic.Download.CrispAsrDownloadService"/> is bumped past v0.8.25.
 /// </summary>
 public class OmniVoiceCrispAsr : ITtsEngine
 {
@@ -423,9 +431,19 @@ public class OmniVoiceCrispAsr : ITtsEngine
             CrispAsrTtsProvenance.AddSpeechAttestations(payload);
         }
 
+        // Target language (#13273). Unlike voice/ref-text this is a per-request field, so it needs
+        // no server restart — which is exactly why it has to travel on the payload: SE keeps one
+        // server for the whole session, so a startup flag could never follow a combo change after
+        // the first line. Auto (empty) sends no field and leaves the model language-agnostic.
+        var languageArg = OmniVoiceLanguages.ResolveLanguageArg(language);
+        if (!string.IsNullOrEmpty(languageArg))
+        {
+            payload["language"] = languageArg;
+        }
+
         var body = JsonSerializer.Serialize(payload);
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
-        Se.WriteToolsLog($"OmniVoice (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (voice={omniVoice}, refTextLen={refText.Length}, textLen={text.Length})");
+        Se.WriteToolsLog($"OmniVoice (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (voice={omniVoice}, refTextLen={refText.Length}, textLen={text.Length}, language={(string.IsNullOrEmpty(languageArg) ? "(auto)" : languageArg)})");
 
         HttpResponseMessage response;
         try

--- a/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceLanguages.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceLanguages.cs
@@ -1,12 +1,28 @@
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Linq;
+
 namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 
-// Auto-generated from omnivoice.cpp/src/lang-map.h (646 entries).
-// omnivoice-tts accepts either the ISO ID (the second column) or the
-// English language name (case-insensitive). We send the ISO ID so the
-// command-line stays compact and locale-independent.
+/// <summary>
+/// The 646 languages OmniVoice knows, plus an "Auto" entry that leaves the choice to the model.
+///
+/// Both OmniVoice engines take the ISO ID (the <see cref="Catalog"/> second column) rather than
+/// the English name — the model accepts either, but the ID keeps the command line compact and
+/// locale-independent. <see cref="OmniVoiceTtsCpp"/> passes it as <c>--lang</c>;
+/// <see cref="OmniVoiceCrispAsr"/> sends it as the per-request <c>language</c> field of
+/// <c>/v1/audio/speech</c>.
+///
+/// The IDs are ISO 639-3 *individual* languages, so a few familiar macrolanguage codes are absent
+/// by design and not gaps in the list: there is no <c>ar</c>, for instance — Arabic is <c>arb</c>
+/// (Standard), <c>arz</c> (Egyptian), <c>ary</c> (Moroccan) and some twenty more.
+/// </summary>
 internal static class OmniVoiceLanguages
 {
-    public static readonly TtsLanguage[] All = new TtsLanguage[]
+    // Auto-generated from omnivoice.cpp/src/lang-map.h (646 entries).
+    // Kept private and verbatim so it can be regenerated wholesale; the "Auto" entry that leads
+    // the user-facing list is added by All below rather than edited into this block.
+    private static readonly TtsLanguage[] Catalog = new TtsLanguage[]
     {
         new("Abadi", "kbt"),
         new("Abkhazian", "ab"),
@@ -655,5 +671,85 @@ internal static class OmniVoiceLanguages
         new("Zulu", "zu"),
         new("Ömie", "aom"),
     };
+
+    /// <summary>
+    /// Code for the "Auto" entry — an empty code means no language is sent and the model picks
+    /// for itself (language-agnostic synthesis), which is what both engines did before the
+    /// language selection was wired up.
+    /// </summary>
+    public const string AutoCode = "";
+
+    public static readonly TtsLanguage Auto = new("Auto", AutoCode);
+
+    /// <summary>
+    /// "Auto" first, then the 646 generated entries in their existing order. Auto leads so a
+    /// combo that falls back to its first entry preserves the old no-language behaviour instead
+    /// of conditioning every line on "Abadi", the first entry alphabetically.
+    ///
+    /// Declared after <see cref="Catalog"/> on purpose: static field initializers run in textual
+    /// order, so moving this above the catalog would copy a null array.
+    /// </summary>
+    public static readonly TtsLanguage[] All = BuildAll();
+
+    private static TtsLanguage[] BuildAll()
+    {
+        var result = new TtsLanguage[Catalog.Length + 1];
+        result[0] = Auto;
+        Array.Copy(Catalog, 0, result, 1, Catalog.Length);
+        return result;
+    }
+
+    /// <summary>
+    /// The value to send as the OmniVoice (CrispASR) request's <c>language</c> field for
+    /// <paramref name="language"/>, or an empty string when no field should be sent (Auto, an
+    /// unknown entry, or nothing selected).
+    /// </summary>
+    public static string ResolveLanguageArg(TtsLanguage? language)
+    {
+        // A null language means the CALLER had none to hand over, which is not the same as the
+        // user picking "Auto". The cast dialog's voice-test button and every cross-engine cast
+        // row pass null on purpose ("engines fall back to their own saved defaults"), so without
+        // this fallback those paths would silently ignore the language the user did pick — the
+        // same hole CosyVoice3 had in #13272.
+        if (language == null)
+        {
+            return ResolveSavedLanguageArg();
+        }
+
+        var code = language.Code;
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            return string.Empty;
+        }
+
+        // Guard against a language object left over from another engine (the view model can hold
+        // one while switching engines): only IDs this engine actually advertises are passed on.
+        // Unknown values are not fatal server-side — crispasr logs "language 'de-DE' is not one of
+        // the model's 646 language IDs" and falls back to language-agnostic — but dropping them
+        // here keeps the request honest.
+        return IsSupported(code) ? code : string.Empty;
+    }
+
+    /// <summary>
+    /// The language ID behind the pick saved by the main TTS window for the CrispASR engine, or
+    /// an empty string when nothing is saved / the saved entry is "Auto". The setting stores the
+    /// DISPLAY NAME, which is how <c>TextToSpeechViewModel</c> writes and restores it.
+    /// </summary>
+    public static string ResolveSavedLanguageArg()
+    {
+        var savedName = Se.Settings.Video.TextToSpeech.OmniVoiceCrispAsrLanguage;
+        if (string.IsNullOrWhiteSpace(savedName))
+        {
+            return string.Empty;
+        }
+
+        return All.FirstOrDefault(l => string.Equals(l.Name, savedName, StringComparison.OrdinalIgnoreCase))?.Code
+               ?? string.Empty;
+    }
+
+    /// <summary>True when <paramref name="code"/> is one of the model's 646 language IDs.</summary>
+    public static bool IsSupported(string? code) =>
+        !string.IsNullOrWhiteSpace(code)
+        && Catalog.Any(l => string.Equals(l.Code, code, StringComparison.OrdinalIgnoreCase));
 }
 

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -1527,6 +1527,8 @@ public partial class ReviewSpeechViewModel : ObservableObject
     {
         MossTtsCrispAsr => Languages.FirstOrDefault(p => p.Name == Se.Settings.Video.TextToSpeech.MossTtsCrispAsrLanguage)
                            ?? Languages.FirstOrDefault(),
+        OmniVoiceCrispAsr => Languages.FirstOrDefault(p => p.Name == Se.Settings.Video.TextToSpeech.OmniVoiceCrispAsrLanguage)
+                             ?? Languages.FirstOrDefault(),
         CosyVoice3CrispAsr => Languages.FirstOrDefault(p => p.Name == Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrLanguage)
                               ?? Languages.FirstOrDefault(),
         Qwen3TtsCrispAsr => Languages.FirstOrDefault(p => p.Name == Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrLanguage)

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -422,6 +422,7 @@ public partial class TextToSpeechViewModel : ObservableObject
         else if (SelectedEngine is OmniVoiceCrispAsr)
         {
             Se.Settings.Video.TextToSpeech.OmniVoiceCrispAsrModel = SelectedModel ?? OmniVoiceCrispAsr.DefaultModelKey;
+            Se.Settings.Video.TextToSpeech.OmniVoiceCrispAsrLanguage = SelectedLanguage?.Name ?? string.Empty;
         }
         else if (SelectedEngine is MossTtsCrispAsr)
         {
@@ -3333,14 +3334,17 @@ public partial class TextToSpeechViewModel : ObservableObject
                     Languages.Add(language);
                 }
 
-                // OmniVoice has 646 alphabetically-sorted languages; the first entry ("Abadi") is
-                // a useless default. Default to English so the engine is usable out of the box.
+                // OmniVoice has 646 alphabetically-sorted languages behind its "Auto" entry;
+                // falling through to the first *language* ("Abadi") would be a useless default,
+                // so omnivoice-tts asks for English explicitly and stays usable out of the box.
                 // The CrispASR cloning engines restore the saved pick (their lists lead with
                 // "Auto", which is also the right fallback - it reproduces the
                 // pre-language-selection behaviour).
                 SelectedLanguage = engine switch
                 {
                     OmniVoiceTtsCpp => Languages.FirstOrDefault(l => l.Code == "en") ?? Languages.FirstOrDefault(),
+                    OmniVoiceCrispAsr => Languages.FirstOrDefault(l => l.Name == Se.Settings.Video.TextToSpeech.OmniVoiceCrispAsrLanguage)
+                                         ?? Languages.FirstOrDefault(),
                     MossTtsCrispAsr => Languages.FirstOrDefault(l => l.Name == Se.Settings.Video.TextToSpeech.MossTtsCrispAsrLanguage)
                                        ?? Languages.FirstOrDefault(),
                     CosyVoice3CrispAsr => Languages.FirstOrDefault(l => l.Name == Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrLanguage)

--- a/src/ui/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/ui/Logic/Config/SeVideoTextToSpeech.cs
@@ -49,6 +49,8 @@ public class SeVideoTextToSpeech
     public double F5TtsCrispAsrSpeed { get; set; }
     public string OmniVoiceCrispAsrModel { get; set; }
     public double OmniVoiceCrispAsrSpeed { get; set; }
+    // Display name of the picked OmniVoice target language ("Auto" = let the model decide).
+    public string OmniVoiceCrispAsrLanguage { get; set; }
     public string VoxCPM2CrispAsrModel { get; set; }
     public double VoxCPM2CrispAsrSpeed { get; set; }
     public string MossTtsCrispAsrModel { get; set; }
@@ -145,6 +147,7 @@ public class SeVideoTextToSpeech
         F5TtsCrispAsrSpeed = 1.0;
         OmniVoiceCrispAsrModel = "Q4_K (~1 GB)";
         OmniVoiceCrispAsrSpeed = 1.0;
+        OmniVoiceCrispAsrLanguage = string.Empty;
         VoxCPM2CrispAsrModel = "Q4_K (~1.7 GB)";
         VoxCPM2CrispAsrSpeed = 1.0;
         MossTtsCrispAsrModel = "Q4_K (~10.5 GB incl. codec)";

--- a/tests/UI/Features/Video/TextToSpeech/Engines/CrispAsrTtsLanguagesTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/CrispAsrTtsLanguagesTests.cs
@@ -39,6 +39,84 @@ public class CrispAsrTtsLanguagesTests
         Assert.Equal(11, all.Length);
     }
 
+    /// <summary>
+    /// #13273: the OmniVoice (CrispASR) combo listed all 646 languages and changed nothing —
+    /// Speak() took the pick and never put it on the request. Wiring it up needed "Auto" in front
+    /// of the catalog too: the view model falls back to the first entry, and without Auto that is
+    /// "Abadi", a real ISO 639-3 id the model would happily condition on.
+    /// </summary>
+    [Fact]
+    public void OmniVoiceLanguages_LeadWithAutoThenTheWholeCatalog()
+    {
+        var all = OmniVoiceLanguages.All;
+
+        Assert.Equal("Auto", all[0].Name);
+        Assert.Equal(string.Empty, all[0].Code);
+        Assert.Equal(647, all.Length);
+
+        // The entry that made a bare first-entry fallback dangerous.
+        Assert.Equal("Abadi", all[1].Name);
+    }
+
+    [Theory]
+    [InlineData("German", "de")]
+    [InlineData("Standard Arabic", "arb")]
+    [InlineData("Egyptian Arabic", "arz")]
+    public void OmniVoiceLanguages_SendTheModelsOwnIds(string displayName, string expectedCode)
+    {
+        var language = OmniVoiceLanguages.All.Single(l => l.Name == displayName);
+
+        Assert.Equal(expectedCode, language.Code);
+        Assert.Equal(expectedCode, OmniVoiceLanguages.ResolveLanguageArg(language));
+    }
+
+    /// <summary>
+    /// The ids are ISO 639-3 *individual* languages, so the macrolanguage code "ar" is absent by
+    /// design — Arabic is arb/arz/ary and friends. Asserted so a future "missing Arabic" report
+    /// does not get 'fixed' by inventing an id the model has never seen.
+    /// </summary>
+    [Fact]
+    public void OmniVoiceLanguages_HaveNoMacrolanguageArabic()
+    {
+        Assert.False(OmniVoiceLanguages.IsSupported("ar"));
+        Assert.True(OmniVoiceLanguages.IsSupported("arb"));
+        Assert.True(OmniVoiceLanguages.IsSupported("ary"));
+    }
+
+    [Fact]
+    public void OmniVoiceLanguages_ResolveLanguageArg_AutoAndUnknownSendNoField()
+    {
+        using var _ = new SavedTtsLanguageScope("German", "German", "German", "German");
+
+        // An explicit "Auto" pick must win over whatever is saved - unlike a null argument.
+        Assert.Equal(string.Empty, OmniVoiceLanguages.ResolveLanguageArg(OmniVoiceLanguages.Auto));
+
+        // A language object left over from another engine, and a locale-shaped code the model
+        // has no token for. crispasr falls back to language-agnostic on both, but the request
+        // should not carry them in the first place.
+        Assert.Equal(string.Empty, OmniVoiceLanguages.ResolveLanguageArg(new TtsLanguage("German", "de-DE")));
+        Assert.Equal(string.Empty, OmniVoiceLanguages.ResolveLanguageArg(new TtsLanguage("Klingon", "tlh")));
+    }
+
+    [Fact]
+    public void OmniVoiceLanguages_ResolveLanguageArg_Null_FallsBackToTheSavedPick()
+    {
+        using (new SavedTtsLanguageScope("German", "German", "German", "German"))
+        {
+            Assert.Equal("de", OmniVoiceLanguages.ResolveLanguageArg(null));
+        }
+
+        using (new SavedTtsLanguageScope(string.Empty, string.Empty, string.Empty, string.Empty))
+        {
+            Assert.Equal(string.Empty, OmniVoiceLanguages.ResolveLanguageArg(null));
+        }
+
+        using (new SavedTtsLanguageScope("Auto", "Auto", "Auto", "Auto"))
+        {
+            Assert.Equal(string.Empty, OmniVoiceLanguages.ResolveLanguageArg(null));
+        }
+    }
+
     [Theory]
     [InlineData("Chinese", "zh")]
     [InlineData("German", "de")]
@@ -195,17 +273,20 @@ internal sealed class SavedTtsLanguageScope : IDisposable
     private readonly string _cosyVoice3;
     private readonly string _qwen3;
     private readonly string _moss;
+    private readonly string _omniVoice;
 
-    public SavedTtsLanguageScope(string cosyVoice3, string qwen3, string moss)
+    public SavedTtsLanguageScope(string cosyVoice3, string qwen3, string moss, string omniVoice = "")
     {
         var settings = Se.Settings.Video.TextToSpeech;
         _cosyVoice3 = settings.CosyVoice3CrispAsrLanguage;
         _qwen3 = settings.Qwen3TtsCrispAsrLanguage;
         _moss = settings.MossTtsCrispAsrLanguage;
+        _omniVoice = settings.OmniVoiceCrispAsrLanguage;
 
         settings.CosyVoice3CrispAsrLanguage = cosyVoice3;
         settings.Qwen3TtsCrispAsrLanguage = qwen3;
         settings.MossTtsCrispAsrLanguage = moss;
+        settings.OmniVoiceCrispAsrLanguage = omniVoice;
     }
 
     public void Dispose()
@@ -214,6 +295,7 @@ internal sealed class SavedTtsLanguageScope : IDisposable
         settings.CosyVoice3CrispAsrLanguage = _cosyVoice3;
         settings.Qwen3TtsCrispAsrLanguage = _qwen3;
         settings.MossTtsCrispAsrLanguage = _moss;
+        settings.OmniVoiceCrispAsrLanguage = _omniVoice;
     }
 }
 


### PR DESCRIPTION
Fixes the SE half of #13273.

The engine advertised `HasLanguageParameter` and offered all 646 of the model's languages, but `Speak()` took the `TtsLanguage` and never put it on the request — the payload was only `{input, response_format, speed}`. As reported, the menu was decoration.

It has to be a payload field rather than a startup flag: SE keeps one crispasr server for the whole session, so a launch argument could never follow a combo change after the first line. The other cloning CrispASR engines already send it this way.

### The default had to be fixed first

Adding the field alone would have made things worse. The view model had no arm for this engine, so it fell through to the first entry of an alphabetical list — **"Abadi" (`kbt`)**, a real ISO 639-3 id the model would happily condition on — and the pick was never persisted.

So `OmniVoiceLanguages.All` now leads with **"Auto"** (empty code → no field → language-agnostic, i.e. the pre-existing behaviour), with the 646 generated entries kept in a private `Catalog` so they can still be regenerated wholesale. Both the main TTS window and the review window restore the saved pick — they had drifted apart, review already defaulting to English while the main window defaulted to Abadi — and a new `OmniVoiceCrispAsrLanguage` setting stores it.

### Two things beyond the report

- `ResolveLanguageArg(null)` falls back to the saved pick. The cast dialog's voice-test button and every cross-engine cast row pass `null` on purpose ("engines fall back to their own saved defaults") — the same hole CosyVoice3 had in #13272.
- Values that are not the model's own ids are dropped rather than sent. crispasr falls back to language-agnostic on those anyway, but a locale code like `de-DE` or a leftover language object from another engine has no business on the wire.

### Note on the ids

They are ISO 639-3 *individual* languages, so there is no `ar` — Arabic is `arb` (Standard), `arz` (Egyptian), `ary` (Moroccan) and ~20 more. That is the model's vocabulary, not a gap in the list; asserted in tests so it does not get "fixed" later by inventing an id the model has never seen.

### Requires a CrispASR bump to take effect

On the pinned **v0.8.25** the CLI adapter applies the language only at startup, so the field is parsed and ignored on every request. The fixes — per-request apply, the session C-ABI arm, and running `_resolve_language()` on the id — are on CrispASR `main` and in no release yet.

Sending it on v0.8.25 is harmless (SE only ever puts the model's own ids on the wire) and it goes live the moment `CrispAsrDownloadService` is bumped past v0.8.25 — the same bump CosyVoice3 cross-lingual (#13272) is waiting on. Flagged in the class docs so nobody debugs it as broken in the meantime.

### Not fixed here

The other half of #13273 — the reference accent — is a separate, structural problem. OmniVoice has no cross-lingual mode: the reference transcript sits before the reference audio in a single token stream, so it cannot be dropped the way CosyVoice3 does. Cloning an English speaker onto German text may still sound English however the tag is set. Thanks to @CrispStrobe for the detailed backend analysis and for not overclaiming that part.

### Testing

Full UI suite: 1599 passed, 0 failed. New coverage for the Auto-leads invariant, the null/Auto/unknown resolution paths, and the absent-`ar` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)