### PR TITLE
Docs: state which unknown-word choices are remembered

### DIFF
--- a/docs/features/ocr.md
+++ b/docs/features/ocr.md
@@ -148,6 +148,25 @@ When the OCR engine encounters uncertain characters, you can:
 - Type the correct text
 - Add to the OCR fix dictionary for automatic correction
 
+### What is remembered
+
+Some of the choices in the unknown-word prompt are saved to disk and reused on later
+OCR runs; others only last as long as the OCR window is open.
+
+| Choice | Remembered? | Stored in |
+|---|---|---|
+| **Change all** | Yes | `{language}_OCRFixReplaceList.xml` |
+| **Add to names list** | Yes | `{language}_names.xml` |
+| **Add to user dictionary** | Yes | `{language}_user.xml` |
+| **Skip once** | No | — |
+| **Skip all** | No — current OCR session only | — |
+
+**"Skip all" is deliberately temporary.** It silences a word for the rest of the current
+OCR session and is forgotten when the OCR window closes, so a mis-click never has lasting
+consequences. If you want a word to be accepted permanently, use **Add to user
+dictionary** (or **Add to names list** for proper nouns) instead, and use **Change all**
+for a correction that should be applied automatically from now on.
+
 ## OCR Fix Replacement Lists
 
 Subtitle Edit uses language-specific XML files to automatically correct common OCR errors. These files are named `{language}_OCRFixReplaceList.xml` (e.g., `eng_OCRFixReplaceList.xml` for English) and are located in the `Dictionaries` folder.

--- a/docs/features/spell-check.md
+++ b/docs/features/spell-check.md
@@ -15,13 +15,18 @@ Check spelling of subtitle text and correct misspelled words.
 3. The spell checker will highlight the first unknown word
 4. Choose an action for each flagged word:
    - **Change** — Replace with the text in the word field (once)
-   - **Change all** — Replace all occurrences
+   - **Change all** — Replace all occurrences, and remember the correction for future runs
    - **Skip once** — Ignore this occurrence
-   - **Skip all** — Ignore all occurrences of this word
+   - **Skip all** — Ignore all occurrences of this word, for the current session only
    - **Add to names list (case sensitive)** — Add the word to the names/proper nouns list (matches the exact casing)
    - **Add to user dictionary** — Add the word to your personal dictionary
 5. The spell checker advances to the next unknown word automatically
 6. When all words have been checked, the window closes
+
+**Skip all is not saved.** It lasts until the window closes and is not carried over to the
+next run, so a mis-click never has lasting consequences. To accept a word permanently use
+**Add to user dictionary** (or **Add to names list** for proper nouns); to have a
+correction applied automatically from now on use **Change all**.
 
 ## Suggestions
 


### PR DESCRIPTION
## Problem

Neither the OCR page nor the spell-check page said which of the unknown-word choices are remembered and which are not. Both list "Change all" and "Skip all" side by side with no hint that one is written to disk and the other disappears when the window closes.

That gap is what made #13284 ("Skip all choices are now remembered") look like a bug fix rather than a behaviour change: #10166 reads as a defect precisely because the documented behaviour never existed to contradict it.

## Change

Documentation only — no code.

**`docs/features/ocr.md`** — a "What is remembered" table under *Unknown Words*:

| Choice | Remembered? | Stored in |
|---|---|---|
| Change all | Yes | `{language}_OCRFixReplaceList.xml` |
| Add to names list | Yes | `{language}_names.xml` |
| Add to user dictionary | Yes | `{language}_user.xml` |
| Skip once | No | — |
| Skip all | No — current OCR session only | — |

…plus a short paragraph on why "Skip all" is deliberately temporary (a mis-click should not have lasting consequences) and which choice to use instead when you do want something permanent.

**`docs/features/spell-check.md`** — the same distinction inline in the existing option list, with a shorter note.

## Verified

- `Change all` → `OcrFixEngine.ChangeAll` → `OcrFixReplaceList2.AddWordOrPartial` → `SaveWordToWordList`, which writes `<lang>_OCRFixReplaceList.xml`. Persisted.
- `Skip all` → `OcrFixEngine.SkipAll` adds to the in-memory `_wordSkipList` only; it is created per engine instance and cleared by `Unload()`. Nothing reads or writes disk. Session-only.
- F1 targets land on these pages: the OCR window calls `ShowHelp("features/ocr")` (`OcrViewModel.cs:4521`) and the spell-check window calls `ShowHelp("features/spell-check")` (`SpellCheckViewModel.cs:931`).
- Swept all 70 `ShowHelp(...)` targets in `src/ui` against `docs/<target>.md` — every one resolves, none missing.

## Related

- Closes the documentation half of #10166. The remaining half is that 5.x lost the `Tools.CheckOneLetterWords` setting that 4.0.14 had (`OcrFixEngine`: `correct = !Configuration.Settings.Tools.CheckOneLetterWords`, defaulted to `true` in `ToolsSettings.cs:541`). It does not exist anywhere in `src` today, and there is no single-character branch in `src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs` — so the supported way to stop single-letter prompts is gone. That is the likelier root fix for the reporter and is worth its own issue.
- #13284 was closed in favour of keeping "Skip all" session-only.
