### PR TITLE
Show WebVTT styles and voices in the subtitle grid

### DIFF
--- a/src/libse/Common/WebVttHelper.cs
+++ b/src/libse/Common/WebVttHelper.cs
@@ -23,6 +23,8 @@ namespace Nikse.SubtitleEdit.Core.Common
         private static readonly Regex PropertiesRegex = new Regex("{[ \\.\\p{L}\\d:#\\s,_;:\\-\\(\\)]+}", RegexOptions.Compiled);
 #endif
 
+        private static readonly Regex CueClassRegex = new Regex(@"<c\.[\.a-zA-Z\d#_-]+>", RegexOptions.Compiled);
+
         public static List<WebVttStyle> GetStyles(string header)
         {
             if (string.IsNullOrEmpty(header))
@@ -555,19 +557,30 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public static List<string> GetParagraphStyles(Paragraph paragraph)
         {
+            return paragraph == null ? new List<string>() : GetParagraphStyles(paragraph.Text);
+        }
+
+        /// <summary>
+        /// The cue class names used in a cue text ("&lt;c.loud.red&gt;" gives ".loud" and ".red"),
+        /// in the order they appear and without duplicates.
+        /// </summary>
+        public static List<string> GetParagraphStyles(string text)
+        {
             var list = new List<string>();
-            if (paragraph == null || string.IsNullOrEmpty(paragraph.Text))
+            if (string.IsNullOrEmpty(text))
             {
                 return list;
             }
 
-            var regex = new Regex(@"<c\.[\.a-zA-Z\d#_-]+>");
-            foreach (Match match in regex.Matches(paragraph.Text))
+            foreach (Match match in CueClassRegex.Matches(text))
             {
                 var styles = match.Value.Remove(0, 3).Trim('>', ' ').Split('.');
                 foreach (var styleName in styles)
                 {
-                    if (!string.IsNullOrEmpty(styleName) && !list.Contains(styleName))
+                    // The list holds the names with their leading dot, so the duplicate check
+                    // has to use the same spelling - without it a class used by two separate
+                    // "<c.x>" tags in one cue was listed twice.
+                    if (!string.IsNullOrEmpty(styleName) && !list.Contains("." + styleName))
                     {
                         list.Add("." + styleName);
                     }
@@ -585,12 +598,11 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
 
             var text = p.Text;
-            var regex = new Regex(@"<c\.[\.a-zA-Z\d#_-]+>");
-            var match = regex.Match(text);
+            var match = CueClassRegex.Match(text);
             while (match.Success)
             {
                 text = text.Remove(match.Index, match.Value.Length);
-                match = regex.Match(text);
+                match = CueClassRegex.Match(text);
             }
 
             text = text.Replace("</c>", string.Empty);

--- a/src/libse/SubtitleFormats/WebVTT.cs
+++ b/src/libse/SubtitleFormats/WebVTT.cs
@@ -1156,32 +1156,65 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 foreach (var p in subtitle.Paragraphs)
                 {
-                    var s = p.Text;
-                    var startIndex = s.IndexOf("<v ", StringComparison.Ordinal);
-                    while (startIndex >= 0)
+                    foreach (var voice in GetVoices(p.Text))
                     {
-                        var endIndex = s.IndexOf('>', startIndex);
-                        if (endIndex > startIndex)
+                        if (!list.Contains(voice))
                         {
-                            var voice = s.Substring(startIndex + 2, endIndex - startIndex - 2).Trim();
-                            if (!list.Contains(voice))
-                            {
-                                list.Add(voice);
-                            }
-                        }
-
-                        if (startIndex == s.Length - 1)
-                        {
-                            startIndex = -1;
-                        }
-                        else
-                        {
-                            startIndex = s.IndexOf("<v ", startIndex + 1, StringComparison.Ordinal);
+                            list.Add(voice);
                         }
                     }
                 }
             }
             return list;
+        }
+
+        /// <summary>
+        /// The names of the "&lt;v Name&gt;" voice tags in a single cue text, in the order they
+        /// appear and without duplicates.
+        /// </summary>
+        public static List<string> GetVoices(string text)
+        {
+            var list = new List<string>();
+            if (string.IsNullOrEmpty(text))
+            {
+                return list;
+            }
+
+            var startIndex = text.IndexOf("<v ", StringComparison.Ordinal);
+            while (startIndex >= 0)
+            {
+                var endIndex = text.IndexOf('>', startIndex);
+                if (endIndex > startIndex)
+                {
+                    var voice = text.Substring(startIndex + 2, endIndex - startIndex - 2).Trim();
+                    if (!list.Contains(voice))
+                    {
+                        list.Add(voice);
+                    }
+                }
+
+                if (startIndex == text.Length - 1)
+                {
+                    startIndex = -1;
+                }
+                else
+                {
+                    startIndex = text.IndexOf("<v ", startIndex + 1, StringComparison.Ordinal);
+                }
+            }
+
+            return list;
+        }
+
+        /// <summary>
+        /// The first "&lt;v Name&gt;" voice of a cue text, or an empty string when it has none.
+        /// This is WebVTT's counterpart of the actor of an ASSA line - it lives inside the cue
+        /// text instead of in a field of its own.
+        /// </summary>
+        public static string GetVoice(string text)
+        {
+            var voices = GetVoices(text);
+            return voices.Count > 0 ? voices[0] : string.Empty;
         }
 
         public static string RemoveTag(string tag, string text)

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1280,6 +1280,8 @@
     },
     "webVtt": {
       "setStylesForSelectedLinesTitle": "Set WebVTT styles for selected lines",
+      "voice": "Voice",
+      "showVoiceColumn": "Show \"Voice\" column",
       "voices": "Voices",
       "newVoiceDotDotDot": "New voice...",
       "removeVoices": "Remove voices",

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -417,12 +417,34 @@ public static partial class InitListViewAndEditBox
             Converter = booleanAndConverter,
             Bindings =
             {
-                new Binding(nameof(vm.HasFormatStyle)) { Source = vm, Mode = BindingMode.OneWay },
+                new Binding(nameof(vm.IsFormatAssaOrSsa)) { Source = vm, Mode = BindingMode.OneWay },
                 new Binding(nameof(vm.ShowColumnStyle)) { Source = vm, Mode = BindingMode.OneWay }
             }
         };
         styleColumn.Bind(SeTableViewColumn.IsVisibleProperty, styleColumnMultiBinding);
         columnManager.Add(styleColumn);
+
+        // WebVTT has styles too, but as cue classes inside the cue text instead of a field on
+        // the line - so it needs a column of its own, shown in place of the ASSA one.
+        var webVttStyleColumn = new SeTableViewColumn
+        {
+            Header = Se.Language.General.Style,
+            Tag = SubtitleGridColumnKeys.WebVttStyle,
+            Binding = new Binding(nameof(SubtitleLineViewModel.WebVttStyle)) { Mode = BindingMode.OneWay },
+            Width = new GridLength(120),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+        };
+        webVttStyleColumn.Bind(SeTableViewColumn.IsVisibleProperty, new MultiBinding
+        {
+            Converter = booleanAndConverter,
+            Bindings =
+            {
+                new Binding(nameof(vm.IsFormatWebVtt)) { Source = vm, Mode = BindingMode.OneWay },
+                new Binding(nameof(vm.ShowColumnStyle)) { Source = vm, Mode = BindingMode.OneWay }
+            }
+        });
+        columnManager.Add(webVttStyleColumn);
 
         var columnGap = new SeTableViewColumn
         {
@@ -467,10 +489,36 @@ public static partial class InitListViewAndEditBox
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         };
         columnManager.Add(actorColumn);
-        actorColumn.Bind(SeTableViewColumn.IsVisibleProperty, new Binding(nameof(vm.ShowColumnActor))
+        actorColumn.Bind(SeTableViewColumn.IsVisibleProperty, new MultiBinding
         {
-            Mode = BindingMode.OneWay,
-            Source = vm,
+            Converter = booleanAndConverter,
+            Bindings =
+            {
+                new Binding(nameof(vm.IsFormatWebVtt)) { Source = vm, Mode = BindingMode.OneWay, Converter = inverseBooleanConverter },
+                new Binding(nameof(vm.ShowColumnActor)) { Source = vm, Mode = BindingMode.OneWay },
+            }
+        });
+
+        // WebVTT's counterpart of the actor is the "<v Name>" voice inside the cue text; it
+        // replaces the Actor column while a WebVTT file is open, sharing its show/hide toggle.
+        var webVttVoiceColumn = new SeTableViewColumn
+        {
+            Header = Se.Language.File.WebVtt.Voice,
+            Tag = SubtitleGridColumnKeys.WebVttVoice,
+            Binding = new Binding(nameof(SubtitleLineViewModel.WebVttVoice)) { Mode = BindingMode.OneWay },
+            Width = new GridLength(120),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+        };
+        columnManager.Add(webVttVoiceColumn);
+        webVttVoiceColumn.Bind(SeTableViewColumn.IsVisibleProperty, new MultiBinding
+        {
+            Converter = booleanAndConverter,
+            Bindings =
+            {
+                new Binding(nameof(vm.IsFormatWebVtt)) { Source = vm, Mode = BindingMode.OneWay },
+                new Binding(nameof(vm.ShowColumnActor)) { Source = vm, Mode = BindingMode.OneWay },
+            }
         });
 
         var cpsColumn = new SeTableViewColumn
@@ -749,7 +797,8 @@ public static partial class InitListViewAndEditBox
 
         var showActorMenuItem = new MenuItem
         {
-            Header = Se.Language.General.ShowActorColumn,
+            // "Actor" for most formats, "Voice" for WebVTT - the two columns share this toggle.
+            [!MenuItem.HeaderProperty] = new Binding(nameof(vm.ShowActorColumnMenuHeader)),
             Command = vm.ToggleShowColumnActorCommand,
             DataContext = vm,
             Icon = new Icon
@@ -1815,8 +1864,10 @@ public static partial class InitListViewAndEditBox
         public const string Text = "Text";
         public const string OriginalText = "OriginalText";
         public const string Style = "Style";
+        public const string WebVttStyle = "WebVttStyle";
         public const string Gap = "Gap";
         public const string Actor = "Actor";
+        public const string WebVttVoice = "WebVttVoice";
         public const string Cps = "Cps";
         public const string Wpm = "Wpm";
         public const string PixelWidth = "PixelWidth";

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -254,8 +254,21 @@ public partial class MainViewModel :
     [ObservableProperty] private bool _areVideoControlsUndocked;
     [ObservableProperty] private bool _isFormatAssa;
     [ObservableProperty] private bool _isFormatSsa;
+    [ObservableProperty] private bool _isFormatAssaOrSsa;
+
+    /// <summary>
+    /// True for the formats that have a style per line - ASSA/SSA in <see cref="SubtitleLineViewModel.Style"/>,
+    /// WebVTT as cue classes inside the cue text (<see cref="SubtitleLineViewModel.WebVttStyle"/>).
+    /// Each has its own grid column; this gates the shared "Show style column" menu item.
+    /// </summary>
     [ObservableProperty] private bool _hasFormatStyle;
     [ObservableProperty] private bool _isFormatWebVtt;
+
+    /// <summary>
+    /// Header of the grid's actor/voice toggle in the column context menu - the column itself is
+    /// "Actor" for most formats and "Voice" for WebVTT, and the toggle shows the two columns.
+    /// </summary>
+    [ObservableProperty] private string _showActorColumnMenuHeader = Se.Language.General.ShowActorColumn;
     [ObservableProperty] private bool _areAssaContentMenuItemsVisible;
     [ObservableProperty] private bool _areWebVttContentMenuItemsVisible;
     [ObservableProperty] private bool _isWebVttBrowserPreviewVisible;
@@ -24663,8 +24676,12 @@ public partial class MainViewModel :
 
         IsFormatAssa = SelectedSubtitleFormat is AdvancedSubStationAlpha;
         IsFormatSsa = SelectedSubtitleFormat is SubStationAlpha;
+        IsFormatAssaOrSsa = SelectedSubtitleFormat is AdvancedSubStationAlpha or SubStationAlpha;
         IsFormatWebVtt = SelectedSubtitleFormat is WebVTT or WebVTTFileWithLineNumber;
-        HasFormatStyle = SelectedSubtitleFormat is AdvancedSubStationAlpha or SubStationAlpha;
+        HasFormatStyle = IsFormatAssaOrSsa || IsFormatWebVtt;
+        ShowActorColumnMenuHeader = IsFormatWebVtt
+            ? Se.Language.File.WebVtt.ShowVoiceColumn
+            : Se.Language.General.ShowActorColumn;
         ShowLayer = IsFormatAssa && Se.Settings.Appearance.ShowLayer;
         ShowLayerFilterIcon = IsFormatAssa && Se.Settings.Appearance.ShowLayer && _visibleLayers != null;
 

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -274,6 +274,53 @@ public partial class SubtitleLineViewModel : ObservableObject
         return _strippedLinesCacheValue!;
     }
 
+    // Read-time memos for the two WebVTT grid columns below, keyed on the text instance like
+    // the memos around them - both parse the text, and a cell binding re-reads its value on
+    // every repaint.
+    private string? _webVttStyleCacheText;
+    private string? _webVttStyleCacheValue;
+    private string? _webVttVoiceCacheText;
+    private string? _webVttVoiceCacheValue;
+
+    /// <summary>
+    /// The WebVTT cue classes of this line ("&lt;c.loud.red&gt;" shows as "loud, red"), for the
+    /// grid's Style column in WebVTT. WebVTT keeps them inside the cue text rather than in a
+    /// field of its own, so unlike the ASSA style this is derived from <see cref="Text"/>.
+    /// </summary>
+    public string WebVttStyle
+    {
+        get
+        {
+            if (!ReferenceEquals(_webVttStyleCacheText, Text) || _webVttStyleCacheValue == null)
+            {
+                var styles = WebVttHelper.GetParagraphStyles(Text);
+                _webVttStyleCacheValue = string.Join(", ", styles.Select(p => p.TrimStart('.')));
+                _webVttStyleCacheText = Text;
+            }
+
+            return _webVttStyleCacheValue;
+        }
+    }
+
+    /// <summary>
+    /// The WebVTT voice of this line (the "&lt;v Name&gt;" tag), for the grid's Voice column -
+    /// WebVTT's counterpart of the ASSA actor. Derived from <see cref="Text"/>, see
+    /// <see cref="WebVttStyle"/>.
+    /// </summary>
+    public string WebVttVoice
+    {
+        get
+        {
+            if (!ReferenceEquals(_webVttVoiceCacheText, Text) || _webVttVoiceCacheValue == null)
+            {
+                _webVttVoiceCacheValue = WebVTT.GetVoice(Text);
+                _webVttVoiceCacheText = Text;
+            }
+
+            return _webVttVoiceCacheValue;
+        }
+    }
+
     // Read-time memo, see CharactersPerSecond below: the pixel-width column binding re-reads this
     // on every cell repaint and each read shapes every line with HarfBuzz.
     private string? _pixelWidthCacheText;
@@ -813,6 +860,10 @@ public partial class SubtitleLineViewModel : ObservableObject
         OnPropertyChanged(nameof(WpmBackgroundBrush));
         OnPropertyChanged(nameof(PixelWidth));
         OnPropertyChanged(nameof(AccessibleErrorText));
+        // WebVTT keeps the cue classes and the voice inside the text, so those two columns
+        // change with it.
+        OnPropertyChanged(nameof(WebVttStyle));
+        OnPropertyChanged(nameof(WebVttVoice));
     }
 
     public void RefreshText()

--- a/src/ui/Logic/Config/Language/File/LanguageWebVtt.cs
+++ b/src/ui/Logic/Config/Language/File/LanguageWebVtt.cs
@@ -3,6 +3,8 @@ namespace Nikse.SubtitleEdit.Logic.Config.Language.File;
 public class LanguageWebVtt
 {
     public string SetStylesForSelectedLinesTitle { get; set; }
+    public string Voice { get; set; }
+    public string ShowVoiceColumn { get; set; }
     public string Voices { get; set; }
     public string NewVoiceDotDotDot { get; set; }
     public string RemoveVoices { get; set; }
@@ -17,6 +19,8 @@ public class LanguageWebVtt
     public LanguageWebVtt()
     {
         SetStylesForSelectedLinesTitle = "Set WebVTT styles for selected lines";
+        Voice = "Voice";
+        ShowVoiceColumn = "Show \"Voice\" column";
         Voices = "Voices";
         NewVoiceDotDotDot = "New voice...";
         RemoveVoices = "Remove voices";

--- a/tests/UI/Features/Main/SubtitleGridWebVttColumnTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridWebVttColumnTests.cs
@@ -1,0 +1,146 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Main.Layout;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// WebVTT has styles (cue classes) and voices, but keeps both inside the cue text instead of in
+/// the style/actor fields the ASSA columns read - so the grid showed an empty Style column (and
+/// none at all, since the column was ASSA-only) plus an "Actor" column that could never fill.
+/// These tests pin down that a WebVTT file gets its own Style and Voice columns instead.
+/// </summary>
+public class SubtitleGridWebVttColumnTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private (Window Window, MainViewModel Vm) ShowMainWindow()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+
+        var vm = (MainViewModel)view.DataContext!;
+        vm.ShowColumnStyle = true;
+        vm.ShowColumnActor = true;
+        vm.Subtitles.Add(new SubtitleLineViewModel(
+            new Paragraph("<v Joe><c.loud>Hello</c>", 0, 2000) { Actor = "Ann", Style = "Default" }, null!));
+
+        Settle(window);
+        return (window, vm);
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 5; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+
+    private static void SetFormat(Window window, MainViewModel vm, string formatName)
+    {
+        vm.SelectedSubtitleFormat = vm.SubtitleFormats.First(p => p.Name == formatName);
+        Settle(window);
+    }
+
+    private static string?[] VisibleColumnKeys(MainViewModel vm) =>
+        vm.SubtitleGrid.Columns.OfType<SeTableViewColumn>().Select(p => p.Tag as string).ToArray();
+
+    [AvaloniaFact]
+    public void WebVtt_ShowsTheWebVttStyleAndVoiceColumns()
+    {
+        var (window, vm) = ShowMainWindow();
+
+        SetFormat(window, vm, new WebVTT().Name);
+
+        var keys = VisibleColumnKeys(vm);
+        Assert.Contains(InitListViewAndEditBox.SubtitleGridColumnKeys.WebVttStyle, keys);
+        Assert.Contains(InitListViewAndEditBox.SubtitleGridColumnKeys.WebVttVoice, keys);
+        Assert.DoesNotContain(InitListViewAndEditBox.SubtitleGridColumnKeys.Style, keys);
+        Assert.DoesNotContain(InitListViewAndEditBox.SubtitleGridColumnKeys.Actor, keys);
+
+        // ... and they show what the cue text holds, not the (unused) style/actor fields.
+        Assert.Equal("loud", vm.Subtitles[0].WebVttStyle);
+        Assert.Equal("Joe", vm.Subtitles[0].WebVttVoice);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void Assa_KeepsTheStyleAndActorColumns()
+    {
+        var (window, vm) = ShowMainWindow();
+
+        SetFormat(window, vm, new AdvancedSubStationAlpha().Name);
+
+        var keys = VisibleColumnKeys(vm);
+        Assert.Contains(InitListViewAndEditBox.SubtitleGridColumnKeys.Style, keys);
+        Assert.Contains(InitListViewAndEditBox.SubtitleGridColumnKeys.Actor, keys);
+        Assert.DoesNotContain(InitListViewAndEditBox.SubtitleGridColumnKeys.WebVttStyle, keys);
+        Assert.DoesNotContain(InitListViewAndEditBox.SubtitleGridColumnKeys.WebVttVoice, keys);
+
+        window.Close();
+    }
+
+    /// <summary>
+    /// SubRip and friends have no styles at all - the Style column stays away, the Actor column
+    /// stays (it is what "Convert actors" and the ASSA import fill in).
+    /// </summary>
+    [AvaloniaFact]
+    public void SubRip_HasNoStyleColumnButKeepsActor()
+    {
+        var (window, vm) = ShowMainWindow();
+
+        SetFormat(window, vm, new SubRip().Name);
+
+        var keys = VisibleColumnKeys(vm);
+        Assert.DoesNotContain(InitListViewAndEditBox.SubtitleGridColumnKeys.Style, keys);
+        Assert.DoesNotContain(InitListViewAndEditBox.SubtitleGridColumnKeys.WebVttStyle, keys);
+        Assert.DoesNotContain(InitListViewAndEditBox.SubtitleGridColumnKeys.WebVttVoice, keys);
+        Assert.Contains(InitListViewAndEditBox.SubtitleGridColumnKeys.Actor, keys);
+
+        window.Close();
+    }
+
+    /// <summary>The one show/hide toggle serves both columns, so it has to be named for the one it shows.</summary>
+    [AvaloniaFact]
+    public void ShowActorColumnMenuHeader_SaysVoiceForWebVtt()
+    {
+        var (window, vm) = ShowMainWindow();
+
+        SetFormat(window, vm, new WebVTT().Name);
+        Assert.Equal(Se.Language.File.WebVtt.ShowVoiceColumn, vm.ShowActorColumnMenuHeader);
+
+        SetFormat(window, vm, new SubRip().Name);
+        Assert.Equal(Se.Language.General.ShowActorColumn, vm.ShowActorColumnMenuHeader);
+
+        window.Close();
+    }
+}

--- a/tests/UI/Features/Main/SubtitleLineViewModelWebVttTests.cs
+++ b/tests/UI/Features/Main/SubtitleLineViewModelWebVttTests.cs
@@ -1,0 +1,56 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Features.Main;
+using System;
+using System.Collections.Generic;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// The subtitle grid's WebVTT Style and Voice columns read their values off the cue text
+/// (WebVTT has no style/actor field of its own), and both values are memoized - so they must
+/// follow a text edit and raise a change notification for the cells to repaint.
+/// </summary>
+public class SubtitleLineViewModelWebVttTests
+{
+    [AvaloniaFact]
+    public void WebVttStyle_ListsTheCueClasses()
+    {
+        var vm = new SubtitleLineViewModel { Text = "<c.loud.red>Hello</c>" };
+
+        Assert.Equal("loud, red", vm.WebVttStyle);
+    }
+
+    [AvaloniaFact]
+    public void WebVttStyle_IsEmptyWithoutCueClasses()
+    {
+        var vm = new SubtitleLineViewModel { Text = "<i>Hello</i>" };
+
+        Assert.Equal(string.Empty, vm.WebVttStyle);
+    }
+
+    [AvaloniaFact]
+    public void WebVttVoice_ReadsTheVoiceTag()
+    {
+        var vm = new SubtitleLineViewModel { Text = "<v Joe Smith>Hello" };
+
+        Assert.Equal("Joe Smith", vm.WebVttVoice);
+    }
+
+    [AvaloniaFact]
+    public void WebVttStyleAndVoice_FollowATextChange()
+    {
+        var vm = new SubtitleLineViewModel { Text = "<v Joe><c.red>Hello</c>" };
+        Assert.Equal("red", vm.WebVttStyle);
+        Assert.Equal("Joe", vm.WebVttVoice);
+
+        var changed = new List<string?>();
+        vm.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        vm.Text = "<v Ann><c.loud>Hi</c>";
+
+        Assert.Equal("loud", vm.WebVttStyle);
+        Assert.Equal("Ann", vm.WebVttVoice);
+        Assert.Contains(nameof(SubtitleLineViewModel.WebVttStyle), changed);
+        Assert.Contains(nameof(SubtitleLineViewModel.WebVttVoice), changed);
+    }
+}

--- a/tests/libse/Core/WebVttHelperTest.cs
+++ b/tests/libse/Core/WebVttHelperTest.cs
@@ -217,4 +217,27 @@ public class WebVttHelperTest
         Assert.Equal(SKColors.Red, readBack.Color);
         Assert.Equal(SKColors.Blue, readBack.BackgroundColor);
     }
+
+    [Fact]
+    public void GetParagraphStylesReadsAllClassesOfATag()
+    {
+        var styles = WebVttHelper.GetParagraphStyles("<c.loud.red>Hello</c>");
+
+        Assert.Equal(new List<string> { ".loud", ".red" }, styles);
+    }
+
+    [Fact]
+    public void GetParagraphStylesListsAClassUsedTwiceOnlyOnce()
+    {
+        var styles = WebVttHelper.GetParagraphStyles("<c.red>Hello</c>" + Environment.NewLine + "<c.red>world</c>");
+
+        Assert.Equal(new List<string> { ".red" }, styles);
+    }
+
+    [Fact]
+    public void GetParagraphStylesOfTextWithoutClasses()
+    {
+        Assert.Empty(WebVttHelper.GetParagraphStyles("<i>Hello</i>"));
+        Assert.Empty(WebVttHelper.GetParagraphStyles(string.Empty));
+    }
 }

--- a/tests/libse/SubtitleFormats/WebVttTest.cs
+++ b/tests/libse/SubtitleFormats/WebVttTest.cs
@@ -326,4 +326,23 @@ public class WebVttTest
         Assert.Contains("position:44.90%", cueLine);
         Assert.Equal(1, cueLine.Split(new[] { "region:" }, StringSplitOptions.None).Length - 1);
     }
+
+    [Theory]
+    [InlineData("<v Joe>Hello", "Joe")]
+    [InlineData("<v Joe Smith>Hello</v>", "Joe Smith")]
+    [InlineData("<v Joe>Hello\r\n<v Ann>Hi", "Joe")] // first voice wins - it is the line's speaker
+    [InlineData("Hello", "")]
+    [InlineData("", "")]
+    public void GetVoiceReadsTheFirstVoiceTag(string text, string expected)
+    {
+        Assert.Equal(expected, WebVTT.GetVoice(text));
+    }
+
+    [Fact]
+    public void GetVoicesOfOneTextListsEachVoiceOnce()
+    {
+        var voices = WebVTT.GetVoices("<v Joe>Hello</v> <v Ann>Hi</v> <v Joe>Bye</v>");
+
+        Assert.Equal(new List<string> { "Joe", "Ann" }, voices);
+    }
 }


### PR DESCRIPTION
Using WebVTT, the grid's **Style** column was not available even though the grid context menu offers *Styles* for WebVTT - and the **Actor** column, which WebVTT never fills, sat there empty where a *Voice* column belongs.

WebVTT keeps both values inside the cue text instead of in fields of their own: styles are cue classes (`<c.loud>`) and the counterpart of the actor is the voice tag (`<v Joe>`). The ASSA Style column reads `Paragraph.Style` and the Actor column reads `Paragraph.Actor`, so neither could ever show anything for WebVTT.

## What this does

- WebVTT gets its own **Style** column, listing the cue classes of the line (`<c.loud.red>` shows as `loud, red`).
- WebVTT gets a **Voice** column in place of Actor, showing the `<v Name>` voice.
- Both are shown only for WebVTT, in place of the ASSA Style / the Actor column, and share the existing show/hide toggles in the column header context menu. That toggle is named *Show "Voice" column* while a WebVTT file is open.
- The "Show style column" menu item is now offered for WebVTT as well (it was ASSA/SSA only).
- Both values are derived from the cue text and memoized on the text instance like the other per-row values the grid re-reads on every repaint, and they follow text edits - including the ones the *Styles* and *Voices* context menu items make.

## Drive-by fix

`WebVttHelper.GetParagraphStyles` listed a class twice when two separate `<c.x>` tags in one cue used it: the duplicate check compared the name without the leading dot the list stores it with. It also compiled its regex on every call, and now shares one static regex with `SetParagraphStyles`.

## Tests

New tests for the two derived row values (and their change notification), for the column swap per format (WebVTT / ASSA / SubRip) through the real main window, for the renamed toggle, and for the libse helpers `WebVttHelper.GetParagraphStyles(string)` / `WebVTT.GetVoice`. Full suites pass: libse 927, UI 1600, libuilogic 149, seconv 291.

Not included: sorting by style/actor still uses the ASSA fields, so "sort by actor" does nothing for WebVTT - happy to follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)