### PR TITLE
Make point sync work without a video

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8857,6 +8857,12 @@ public partial class MainViewModel :
 
             SelectAndScrollToRow(0);
         }
+
+        // Point sync can open a video of its own - take it over here too (issue #13341).
+        if (string.IsNullOrEmpty(_videoFileName) && File.Exists(result.VideoFileName))
+        {
+            await VideoOpenFile(result.VideoFileName);
+        }
     }
 
     [RelayCommand]
@@ -8884,6 +8890,12 @@ public partial class MainViewModel :
             ReplaceSubtitles(result.SyncedSubtitles);
 
             SelectAndScrollToRow(0);
+        }
+
+        // "Set sync point via video" can open a video of its own - take it over here too (issue #13341).
+        if (string.IsNullOrEmpty(_videoFileName) && File.Exists(result.VideoFileName))
+        {
+            await VideoOpenFile(result.VideoFileName);
         }
     }
 

--- a/src/ui/Features/Sync/PointSync/PointSyncViewModel.cs
+++ b/src/ui/Features/Sync/PointSync/PointSyncViewModel.cs
@@ -33,6 +33,12 @@ public partial class PointSyncViewModel : ObservableObject
     public bool OkPressed { get; private set; }
     public string WindowTitle { get; private set; }
 
+    /// <summary>
+    /// The video in use when the window closed - the caller adopts it, so a video opened from
+    /// "Set sync point" also reaches the main window (issue #13341).
+    /// </summary>
+    public string VideoFileName => _videoFileName;
+
     private readonly IFileHelper _fileHelper;
     private readonly IWindowService _windowService;
 
@@ -89,6 +95,13 @@ public partial class PointSyncViewModel : ObservableObject
         {
             vm.Initialize(Subtitles.ToList(), SelectedSubtitle, _videoFileName, FileName, _audioVisualizer);
         });
+
+        // Keep a video opened (or found) in there, so the next sync point starts with it loaded -
+        // also when the dialog was cancelled.
+        if (!string.IsNullOrEmpty(result.VideoFileName))
+        {
+            _videoFileName = result.VideoFileName;
+        }
 
         if (!result.OkPressed)
         {

--- a/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
+++ b/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
@@ -28,6 +28,14 @@ public partial class SetSyncPointViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<SubtitleDisplayItem> _paragraphs;
     [ObservableProperty] private int _selectedParagraphIndex = -1;
     [ObservableProperty] private bool _isAudioVisualizerVisible;
+
+    /// <summary>
+    /// Whether the dialog shows its video half at all. With no video there is nothing to scrub, so
+    /// the player, the waveform and the playback buttons come off and the dialog is just the line
+    /// picker and the sync point time code (issue #13341).
+    /// </summary>
+    [ObservableProperty] private bool _isVideoVisible;
+
     [ObservableProperty] private string _title;
     [ObservableProperty] private string _videoInfo;
     [ObservableProperty] private TimeSpan _syncPointTimeCode;
@@ -103,6 +111,7 @@ public partial class SetSyncPointViewModel : ObservableObject
         }
 
         _videoFileName = videoFileName;
+        IsVideoVisible = HasVideo;
         SetVideoInFo(videoFileName);
 
         // Seed the sync point with the line's own start time - a video, when there is one, takes
@@ -366,6 +375,7 @@ public partial class SetSyncPointViewModel : ObservableObject
         // Only now does the player own the sync point - handing it over any earlier would let the
         // timer copy the still-zero position into the time code while the file is loading.
         _videoFileName = fileName;
+        IsVideoVisible = true;
         UpdateTimeCodeFromVideoPosition();
         CenterWaveform(VideoPlayerControl, AudioVisualizer);
         _updateAudioVisualizer = true;

--- a/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
+++ b/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
@@ -16,6 +16,7 @@ using Nikse.SubtitleEdit.Logic.VideoPlayers;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Nikse.SubtitleEdit.UiLogic.Media;
@@ -34,12 +35,21 @@ public partial class SetSyncPointViewModel : ObservableObject
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
     public double SyncPosition { get; private set; }
+
+    /// <summary>
+    /// The video in use when the dialog closed - either the one passed in, one found next to the
+    /// subtitle file, or one the user opened here. The caller adopts it so the next sync point
+    /// (and the main window) reuse it.
+    /// </summary>
+    public string VideoFileName { get; private set; }
+
     public VideoPlayerControl VideoPlayerControl { get; set; }
     public AudioVisualizer AudioVisualizer { get; set; }
     public ComboBox ComboBoxSubtitle { get; set; }
     public TimeCodeUpDown TimeCodeUpDownSyncPoint { get; set; }
 
     private readonly IWindowService _windowService;
+    private readonly IFileHelper _fileHelper;
 
     private string? _videoFileName;
     private DispatcherTimer _positionTimer = new DispatcherTimer();
@@ -48,12 +58,14 @@ public partial class SetSyncPointViewModel : ObservableObject
     private bool _updateTimeCodeFromVideo;
     private bool _timeCodeUpDownFocused;
 
-    public SetSyncPointViewModel(IWindowService windowService)
+    public SetSyncPointViewModel(IWindowService windowService, IFileHelper fileHelper)
     {
         _windowService = windowService;
+        _fileHelper = fileHelper;
 
         Title = string.Empty;
         VideoInfo = string.Empty;
+        VideoFileName = string.Empty;
         _videoFileName = string.Empty;
         VideoPlayerControl = new VideoPlayerControl(new EmptyVideoPlayer());
         AudioVisualizer = new AudioVisualizer();
@@ -72,19 +84,49 @@ public partial class SetSyncPointViewModel : ObservableObject
         string? subtitleFileName,
         AudioVisualizer? audioVisualizer)
     {
-        SetVideoInFo(videoFileName);
         Paragraphs = new ObservableCollection<SubtitleDisplayItem>(paragraphs.Select(p => new SubtitleDisplayItem(p)));
-        _videoFileName = videoFileName;
         _subtitleLines = paragraphs;
+
+        // Only a video the caller already had, or one the user picks here, is reported back - a
+        // video merely found on disk must not travel up and open in the main window, which would
+        // walk over the "auto open video file" setting.
+        VideoFileName = videoFileName ?? string.Empty;
+
+        // No video handed down from the main window - look for one next to the subtitle file, the
+        // way the old "Set sync point" did. Failing that the dialog still works: the time code can
+        // be typed, and "Open video file..." is there to pick one.
+        if (string.IsNullOrEmpty(videoFileName) &&
+            !string.IsNullOrEmpty(subtitleFileName) &&
+            FindVideoFileName.TryFindVideoFileName(subtitleFileName, out var foundVideoFileName))
+        {
+            videoFileName = foundVideoFileName;
+        }
+
+        _videoFileName = videoFileName;
+        SetVideoInFo(videoFileName);
+
+        // Seed the sync point with the line's own start time - a video, when there is one, takes
+        // over from here (OnLoaded). Without this the box would sit at 00:00:00.000 with no video,
+        // which reads as a broken dialog (issue #13341).
+        if (selectedSubtitle != null)
+        {
+            SyncPointTimeCode = selectedSubtitle.StartTime;
+        }
+        else if (paragraphs.Count > 0)
+        {
+            SyncPointTimeCode = paragraphs[0].StartTime;
+        }
 
         Dispatcher.UIThread.Post(() =>
         {
-            if (!string.IsNullOrEmpty(videoFileName))
+            if (!string.IsNullOrEmpty(_videoFileName))
             {
-                _ = VideoPlayerControl.Open(videoFileName);
+                _ = VideoPlayerControl.Open(_videoFileName);
             }
 
-            if (audioVisualizer != null)
+            // An audio visualizer without peaks is just an empty box - only show it when the main
+            // window actually has a waveform to lend us.
+            if (audioVisualizer?.WavePeaks != null)
             {
                 AudioVisualizer.WavePeaks = audioVisualizer.WavePeaks;
                 IsAudioVisualizerVisible = true;
@@ -139,8 +181,10 @@ public partial class SetSyncPointViewModel : ObservableObject
 
             // Follow the video position - but leave the time code alone while the user is typing
             // in it (a running video moves on its own, so then the box should still follow).
+            // With no video there is nothing to follow and the box is the only input, so the
+            // player must not be allowed to reset it to zero (issue #13341).
             var isEditingTimeCode = TimeCodeUpDownSyncPoint.IsKeyboardFocusWithin && !VideoPlayerControl.IsPlaying;
-            if (!isEditingTimeCode)
+            if (!isEditingTimeCode && HasVideo)
             {
                 UpdateTimeCodeFromVideoPosition();
             }
@@ -194,13 +238,31 @@ public partial class SetSyncPointViewModel : ObservableObject
         }
     }
 
+    private bool HasVideo => !string.IsNullOrEmpty(_videoFileName);
+
+    /// <summary>
+    /// Where the sync point currently sits. The video owns this while one is loaded; otherwise
+    /// the time code box does, so the nudge buttons keep working without a video.
+    /// </summary>
+    private double CurrentPositionSeconds => HasVideo
+        ? VideoPlayerControl.Position
+        : SyncPointTimeCode.TotalSeconds;
+
     /// <summary>
     /// Single entry point for moving the video - keeps the sync point time code box in sync
     /// with the video position, also while the box has focus (where the timer leaves it alone).
+    /// With no video the box is authoritative, so it is set directly instead.
     /// </summary>
     private void SetVideoPosition(double seconds)
     {
-        VideoPlayerControl.Position = Math.Max(0, seconds);
+        seconds = Math.Max(0, seconds);
+        if (!HasVideo)
+        {
+            SyncPointTimeCode = TimeSpan.FromSeconds(seconds);
+            return;
+        }
+
+        VideoPlayerControl.Position = seconds;
         UpdateTimeCodeFromVideoPosition();
         _updateAudioVisualizer = true;
     }
@@ -220,7 +282,7 @@ public partial class SetSyncPointViewModel : ObservableObject
 
     partial void OnSyncPointTimeCodeChanged(TimeSpan value)
     {
-        if (_updateTimeCodeFromVideo)
+        if (_updateTimeCodeFromVideo || !HasVideo)
         {
             return;
         }
@@ -233,30 +295,35 @@ public partial class SetSyncPointViewModel : ObservableObject
     [RelayCommand]
     private void LeftOneSecondBack()
     {
-        SetVideoPosition(VideoPlayerControl.Position - 1);
+        SetVideoPosition(CurrentPositionSeconds - 1);
     }
 
     [RelayCommand]
     private void LeftOneSecondForward()
     {
-        SetVideoPosition(VideoPlayerControl.Position + 1);
+        SetVideoPosition(CurrentPositionSeconds + 1);
     }
 
     [RelayCommand]
     private void LeftHalfSecondBack()
     {
-        SetVideoPosition(VideoPlayerControl.Position - 0.5);
+        SetVideoPosition(CurrentPositionSeconds - 0.5);
     }
 
     [RelayCommand]
     private void LeftHalfSecondForward()
     {
-        SetVideoPosition(VideoPlayerControl.Position + 0.5);
+        SetVideoPosition(CurrentPositionSeconds + 0.5);
     }
 
     [RelayCommand]
     private async Task PlayTwoSecondsAndBackLeft()
     {
+        if (!HasVideo)
+        {
+            return;
+        }
+
         await PlayAndBack(VideoPlayerControl, 2000);
         UpdateTimeCodeFromVideoPosition();
         _updateAudioVisualizer = true;
@@ -265,6 +332,43 @@ public partial class SetSyncPointViewModel : ObservableObject
     private void CenterWaveform(VideoPlayerControl videoPlayerControl, AudioVisualizer audioVisualizer)
     {
         audioVisualizer.StartPositionSeconds = Math.Max(0, videoPlayerControl.Position - 0.5);
+    }
+
+    /// <summary>
+    /// Opens a video from inside the dialog, so entering point sync without one is not a dead end
+    /// (issue #13341). The caller adopts <see cref="VideoFileName"/> when the dialog closes.
+    /// </summary>
+    [RelayCommand]
+    private async Task OpenVideoFile()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var fileName = await _fileHelper.PickOpenVideoFile(Window, Se.Language.General.OpenVideoFileTitle);
+        if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
+        {
+            return;
+        }
+
+        var syncPoint = SyncPointTimeCode;
+        VideoFileName = fileName;
+        SetVideoInFo(fileName);
+
+        // Open at the time code the user already had, rather than snapping the sync point back to
+        // the start of the newly opened file. It has to be passed to Open: the position slider is
+        // clamped to Duration, which is only polled once the player is running, so seeking right
+        // after the open would land at zero.
+        await VideoPlayerControl.Open(fileName, Math.Max(0, syncPoint.TotalSeconds));
+        await VideoPlayerControl.WaitForPlayersReadyAsync();
+
+        // Only now does the player own the sync point - handing it over any earlier would let the
+        // timer copy the still-zero position into the time code while the file is loading.
+        _videoFileName = fileName;
+        UpdateTimeCodeFromVideoPosition();
+        CenterWaveform(VideoPlayerControl, AudioVisualizer);
+        _updateAudioVisualizer = true;
     }
 
     [RelayCommand]
@@ -294,7 +398,9 @@ public partial class SetSyncPointViewModel : ObservableObject
     [RelayCommand]
     private void Ok()
     {
-        SyncPosition = VideoPlayerControl.Position;
+        // The time code box is the result, not the player - the player is only one of the ways to
+        // drive it, and there may not be one at all (issue #13341).
+        SyncPosition = Math.Max(0, SyncPointTimeCode.TotalSeconds);
         OkPressed = true;
         Window?.Close();
     }
@@ -352,12 +458,12 @@ public partial class SetSyncPointViewModel : ObservableObject
     {
         UiUtil.RestoreWindowPosition(Window);
 
-        if (string.IsNullOrEmpty(_videoFileName))
+        // Only the video needs waiting for - the sync point still has to be seeded from the
+        // selected line when there is none, or it would stay at zero (issue #13341).
+        if (HasVideo)
         {
-            return;
+            await VideoPlayerControl.WaitForPlayersReadyAsync();
         }
-
-        await VideoPlayerControl.WaitForPlayersReadyAsync();
 
         Dispatcher.UIThread.Post(() =>
         {
@@ -386,27 +492,30 @@ public partial class SetSyncPointViewModel : ObservableObject
         if (e.Key == Key.Space || (e.Key == Key.P && e.KeyModifiers.HasFlag(KeyModifiers.Control)))
         {
             e.Handled = true;
-            VideoPlayerControl.TogglePlayPause();
+            if (HasVideo)
+            {
+                VideoPlayerControl.TogglePlayPause();
+            }
         }
         else if (e.Key == Key.Left && e.KeyModifiers.HasFlag(KeyModifiers.Control))
         {
             e.Handled = true;
-            SetVideoPosition(VideoPlayerControl.Position - 1);
+            SetVideoPosition(CurrentPositionSeconds - 1);
         }
         else if (e.Key == Key.Right && e.KeyModifiers.HasFlag(KeyModifiers.Control))
         {
             e.Handled = true;
-            SetVideoPosition(VideoPlayerControl.Position + 1);
+            SetVideoPosition(CurrentPositionSeconds + 1);
         }
         else if (e.Key == Key.Left && e.KeyModifiers.HasFlag(KeyModifiers.Alt))
         {
             e.Handled = true;
-            SetVideoPosition(VideoPlayerControl.Position - 0.5);
+            SetVideoPosition(CurrentPositionSeconds - 0.5);
         }
         else if (e.Key == Key.Right && e.KeyModifiers.HasFlag(KeyModifiers.Alt))
         {
             e.Handled = true;
-            SetVideoPosition(VideoPlayerControl.Position + 0.5);
+            SetVideoPosition(CurrentPositionSeconds + 0.5);
         }
     }
 

--- a/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointWindow.cs
+++ b/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointWindow.cs
@@ -8,6 +8,7 @@ using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
 using Nikse.SubtitleEdit.Features.Main.Layout;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 
 namespace Nikse.SubtitleEdit.Features.Sync.PointSync.SetSyncPoint;
 
@@ -32,6 +33,13 @@ public class SetSyncPointWindow : Window
         MinWidth = 800;
         Height = vm.IsVideoVisible ? 800 : VideolessHeight;
         MinHeight = vm.IsVideoVisible ? 650 : VideolessMinHeight;
+        if (!vm.IsVideoVisible)
+        {
+            // Both modes save under the same window name, so RestoreWindowPosition would bring
+            // back the with-video height and leave the videoless dialog mostly blank. The content
+            // is fixed-height in this mode - cap the window instead of special-casing the restore.
+            MaxHeight = VideolessHeight;
+        }
 
         var labelVideoInfo = UiUtil.MakeLabel(string.Empty).WithBindText(vm, nameof(vm.VideoInfo));
 
@@ -193,11 +201,9 @@ public class SetSyncPointWindow : Window
             }
 
             rowVideoPlayer.Height = new GridLength(1, GridUnitType.Star);
-            if (Height < 650)
-            {
-                MinHeight = 650;
-                Height = 800;
-            }
+            MaxHeight = double.PositiveInfinity;
+            MinHeight = 650;
+            Height = Math.Max(Height, 800);
         };
 
         // Focus the time code box, not a button, so the window receives key events without arming

--- a/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointWindow.cs
+++ b/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointWindow.cs
@@ -26,12 +26,20 @@ public class SetSyncPointWindow : Window
         DataContext = vm;
 
         var labelVideoInfo = UiUtil.MakeLabel(string.Empty).WithBindText(vm, nameof(vm.VideoInfo));
+
+        // Entering point sync without a video used to be a dead end - the sync point can be typed,
+        // but there was no way to load a video from here (issue #13341).
+        var buttonOpenVideo = UiUtil.MakeButton(Se.Language.General.OpenVideoFile, vm.OpenVideoFileCommand);
+
         var panelVideo = new StackPanel
         {
             Orientation = Orientation.Horizontal,
+            Spacing = 10,
+            VerticalAlignment = VerticalAlignment.Center,
             Children =
             {
-                labelVideoInfo
+                buttonOpenVideo,
+                labelVideoInfo,
             }
         };
 

--- a/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointWindow.cs
+++ b/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointWindow.cs
@@ -13,17 +13,25 @@ namespace Nikse.SubtitleEdit.Features.Sync.PointSync.SetSyncPoint;
 
 public class SetSyncPointWindow : Window
 {
+    /// <summary>Room for the line picker, the time code and the two button rows - nothing else.</summary>
+    private const double VideolessHeight = 340;
+    private const double VideolessMinHeight = 340;
+
     public SetSyncPointWindow(SetSyncPointViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
         Title = Se.Language.Sync.SetSyncPoint;
         CanResize = true;
-        Width = 1000;
-        Height = 800;
-        MinWidth = 800;
-        MinHeight = 650;
         vm.Window = this;
         DataContext = vm;
+
+        // The view model is initialized before this constructor runs, so the dialog knows here
+        // whether it has a video - and without one there is no player or waveform to make room
+        // for, just the line picker and the sync point time code (issue #13341).
+        Width = 1000;
+        MinWidth = 800;
+        Height = vm.IsVideoVisible ? 800 : VideolessHeight;
+        MinHeight = vm.IsVideoVisible ? 650 : VideolessMinHeight;
 
         var labelVideoInfo = UiUtil.MakeLabel(string.Empty).WithBindText(vm, nameof(vm.VideoInfo));
 
@@ -59,6 +67,10 @@ public class SetSyncPointWindow : Window
         vm.AudioVisualizer.OnVideoPositionChanged += vm.AudioVisualizerLeftPositionChanged;
         vm.AudioVisualizer.OnPrimarySingleClicked += vm.AudioVisualizerOnPrimarySingleClicked;
 
+        // IsAudioVisualizerVisible was set but never bound, so the waveform box was drawn as a
+        // grey slab whether or not the main window had any peaks to lend it.
+        vm.AudioVisualizer.WithBindIsVisible(nameof(vm.IsAudioVisualizerVisible));
+
         var comboBoxLeft = UiUtil.MakeComboBoxBindText(vm.Paragraphs, vm, nameof(SubtitleDisplayItem.Text), nameof(vm.SelectedParagraphIndex));
         comboBoxLeft.Width = double.NaN;
         comboBoxLeft.MinHeight = 50;
@@ -73,7 +85,9 @@ public class SetSyncPointWindow : Window
                 Mode = BindingMode.TwoWay,
             },
         };
-        AutomationProperties.SetName(vm.TimeCodeUpDownSyncPoint, Se.Language.General.VideoPosition);
+        // Not "Video position": this box is the sync point itself, and it is the only input when
+        // the dialog has no video at all (issue #13341). SE4 labelled it the same way.
+        AutomationProperties.SetName(vm.TimeCodeUpDownSyncPoint, Se.Language.Sync.SyncPointTimeCode);
 
         var panelTimeCode = new StackPanel
         {
@@ -81,10 +95,16 @@ public class SetSyncPointWindow : Window
             Spacing = 10,
             Children =
             {
-                UiUtil.MakeLabel(Se.Language.General.VideoPosition),
+                UiUtil.MakeLabel(Se.Language.Sync.SyncPointTimeCode),
                 vm.TimeCodeUpDownSyncPoint,
             }
         };
+
+        // Playback is the one thing with no meaning when there is no video - the nudge buttons and
+        // "Go to sub pos" still move the sync point time code, so they stay.
+        var buttonPlayTwoSecondsAndBack = UiUtil
+            .MakeButton(Se.Language.Sync.PlayTwoSecondsAndBack, vm.PlayTwoSecondsAndBackLeftCommand)
+            .WithBindIsVisible(nameof(vm.IsVideoVisible));
 
         var panelLeftButtons = new StackPanel
         {
@@ -92,7 +112,7 @@ public class SetSyncPointWindow : Window
             Children =
             {
                 UiUtil.MakeButton(vm.LeftOneSecondBackCommand, IconNames.ArrowLeftThick, Se.Language.General.OneSecondBack),
-                UiUtil.MakeButton(Se.Language.Sync.PlayTwoSecondsAndBack, vm.PlayTwoSecondsAndBackLeftCommand),
+                buttonPlayTwoSecondsAndBack,
                 UiUtil.MakeButton(vm.LeftOneSecondForwardCommand, IconNames.ArrowRightThick, Se.Language.General.OneSecondForward),
                 UiUtil.MakeButton(Se.Language.Sync.GoToSubPos, vm.GoToLeftSubtitleCommand),
                 UiUtil.MakeButton(Se.Language.Sync.FindText, vm.FindTextLeftCommand),
@@ -103,11 +123,20 @@ public class SetSyncPointWindow : Window
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
         var buttonPanel = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
 
+        // A Star row keeps its share of the height even when its child is hidden, so the row itself
+        // has to collapse - otherwise the videoless dialog is mostly empty space.
+        var rowVideoPlayer = new RowDefinition
+        {
+            Height = vm.IsVideoVisible ? new GridLength(1, GridUnitType.Star) : new GridLength(0),
+        };
+
+        vm.VideoPlayerControl.WithBindIsVisible(nameof(vm.IsVideoVisible));
+
         var gridLeft = new Grid
         {
             RowDefinitions =
             {
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }, // video player
+                rowVideoPlayer,                                                       // video player
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // audio visualizer
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // combo box
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // sync point time code
@@ -153,6 +182,23 @@ public class SetSyncPointWindow : Window
         grid.Add(buttonPanel, 2, 0, 1, 2);
 
         Content = grid;
+
+        // "Open video file..." can bring a video in after the videoless dialog is already up: give
+        // the player its row back and grow the window, which is otherwise too short to show it.
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName != nameof(vm.IsVideoVisible) || !vm.IsVideoVisible)
+            {
+                return;
+            }
+
+            rowVideoPlayer.Height = new GridLength(1, GridUnitType.Star);
+            if (Height < 650)
+            {
+                MinHeight = 650;
+                Height = 800;
+            }
+        };
 
         // Focus the time code box, not a button, so the window receives key events without arming
         // any button: a focused button fires OnClick on bare Space, and "Set sync point" used to be

--- a/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherViewModel.cs
+++ b/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherViewModel.cs
@@ -8,6 +8,7 @@ using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Shared.FindText;
+using Nikse.SubtitleEdit.Features.Sync.PointSync.SetSyncPoint;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
@@ -36,6 +37,12 @@ public partial class PointSyncViaOtherViewModel : ObservableObject
     public List<SubtitleLineViewModel> SyncedSubtitles { get; private set; }
     public bool OkPressed { get; private set; }
     public string WindowTitle { get; private set; }
+
+    /// <summary>
+    /// The video in use when the window closed - the caller adopts it, so a video opened from
+    /// "Set sync point via video" also reaches the main window (issue #13341).
+    /// </summary>
+    public string VideoFileName => _videoFileName;
 
     /// <summary>Set by the window; scrolls the "other subtitle" grid to a line without selecting it.</summary>
     public Action<SubtitleLineViewModel>? ScrollOtherToLine { get; set; }
@@ -200,12 +207,63 @@ public partial class PointSyncViaOtherViewModel : ObservableObject
         // the original line - the grid line may already show previewed times after "Apply",
         // which would bake the previous offset into the new point (#12942).
         var leftIndex = Subtitles.IndexOf(left);
-        var syncPoint = new SyncPoint(
+        AddSyncPoint(new SyncPoint(
             _originalSubtitles[leftIndex], leftIndex,
-            right, Othersubtitles.IndexOf(right));
+            right, Othersubtitles.IndexOf(right)));
+    }
 
-        // A line has at most one sync point (setting it again re-points it), and the list
-        // stays in chronological order (#12529).
+    /// <summary>
+    /// Sets a sync point from the video instead of from the other subtitle - for lines the other
+    /// file has no counterpart for, and for when there is no other file at all yet (issue #13341).
+    /// </summary>
+    [RelayCommand]
+    private async Task SetSyncPointViaVideo()
+    {
+        var left = SelectedSubtitle;
+        if (left == null || Window == null)
+        {
+            return;
+        }
+
+        var result = await _windowService.ShowDialogAsync<SetSyncPointWindow, SetSyncPointViewModel>(Window, vm =>
+        {
+            vm.Initialize(Subtitles.ToList(), left, _videoFileName, FileName, null);
+        });
+
+        // Keep a video opened (or found) in there - also when the dialog was cancelled.
+        if (!string.IsNullOrEmpty(result.VideoFileName))
+        {
+            _videoFileName = result.VideoFileName;
+        }
+
+        if (!result.OkPressed)
+        {
+            return;
+        }
+
+        // As in SetSyncPoint: the left time has to come from the original line, since the grid may
+        // already show previewed times after "Apply" (#12942). The right side is the video
+        // position, carried on a copy of the line - there is no other-subtitle line for it.
+        var leftIndex = Subtitles.IndexOf(left);
+        if (leftIndex < 0 || leftIndex >= _originalSubtitles.Count)
+        {
+            return;
+        }
+
+        var right = new SubtitleLineViewModel(_originalSubtitles[leftIndex])
+        {
+            StartTime = TimeSpan.FromSeconds(result.SyncPosition),
+        };
+
+        AddSyncPoint(new SyncPoint(_originalSubtitles[leftIndex], leftIndex, right, leftIndex));
+    }
+
+    /// <summary>
+    /// A line has at most one sync point (setting it again re-points it), and the list stays in
+    /// chronological order (#12529).
+    /// </summary>
+    private void AddSyncPoint(SyncPoint syncPoint)
+    {
         var existing = SyncPoints.FirstOrDefault(p => p.LeftIndex == syncPoint.LeftIndex);
         if (existing != null)
         {

--- a/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherWindow.cs
+++ b/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherWindow.cs
@@ -78,7 +78,7 @@ public class PointSyncViaOtherWindow : Window
         {
             RowDefinitions =
             {
-                new RowDefinition { Height = new GridLength(50, GridUnitType.Pixel) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
             },
             ColumnDefinitions =
@@ -88,6 +88,7 @@ public class PointSyncViaOtherWindow : Window
             Width = double.NaN,
             HorizontalAlignment = HorizontalAlignment.Stretch,
             Margin = new Thickness(0, 60, 0, 0),
+            RowSpacing = 10,
         };
 
         // The DataGrid this replaces hid its header (HeadersVisibility.None); TableView
@@ -134,7 +135,23 @@ public class PointSyncViaOtherWindow : Window
         var buttonSetSyncPoint = UiUtil.MakeButton(Se.Language.Sync.SetSyncPoint, vm.SetSyncPointCommand)
             .WithIconLeft(IconNames.ArrowLeftRightBold);
 
-        grid.Add(buttonSetSyncPoint, 0);
+        // The other subtitle is the usual source for a sync point here, but a line it does not
+        // cover still has to be pinnable - so allow picking the time off the video (issue #13341).
+        var buttonSetSyncPointViaVideo = UiUtil.MakeButton(Se.Language.Sync.SetSyncPointViaVideo, vm.SetSyncPointViaVideoCommand)
+            .WithIconLeft(IconNames.MovieOpenOutline);
+
+        var panelSetSyncPoint = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 5,
+            Children =
+            {
+                buttonSetSyncPoint,
+                buttonSetSyncPointViaVideo,
+            }
+        };
+
+        grid.Add(panelSetSyncPoint, 0);
         grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGrid), 1);
 
         return grid;

--- a/src/ui/Logic/Config/Language/Sync/LanguageSync.cs
+++ b/src/ui/Logic/Config/Language/Sync/LanguageSync.cs
@@ -25,6 +25,7 @@ public class LanguageSync
     public string ShowLater { get; set; }
     public string SetSyncPoint { get; set; }
     public string SetSyncPointViaVideo { get; set; }
+    public string SyncPointTimeCode { get; set; }
     public string SyncPoints { get; set; }
     public string PointSync { get; set; }
     public string PointSyncViaOther { get; set; }
@@ -57,6 +58,7 @@ public class LanguageSync
         ShowLater = "Show later";
         SetSyncPoint = "Set sync point";
         SetSyncPointViaVideo = "Set sync point via video...";
+        SyncPointTimeCode = "Sync point time code";
         SyncPoints = "Sync points";
         PointSync = "Point sync";
         PointSyncViaOther = "Point sync via other subtitle";

--- a/src/ui/Logic/Config/Language/Sync/LanguageSync.cs
+++ b/src/ui/Logic/Config/Language/Sync/LanguageSync.cs
@@ -24,6 +24,7 @@ public class LanguageSync
     public string ShowEarlier { get; set; }
     public string ShowLater { get; set; }
     public string SetSyncPoint { get; set; }
+    public string SetSyncPointViaVideo { get; set; }
     public string SyncPoints { get; set; }
     public string PointSync { get; set; }
     public string PointSyncViaOther { get; set; }
@@ -55,6 +56,7 @@ public class LanguageSync
         ShowEarlier = "Show earlier";
         ShowLater = "Show later";
         SetSyncPoint = "Set sync point";
+        SetSyncPointViaVideo = "Set sync point via video...";
         SyncPoints = "Sync points";
         PointSync = "Point sync";
         PointSyncViaOther = "Point sync via other subtitle";

--- a/tests/UI/Features/Sync/PointSync/PointSyncWindowTests.cs
+++ b/tests/UI/Features/Sync/PointSync/PointSyncWindowTests.cs
@@ -127,6 +127,39 @@ public class PointSyncWindowTests : IDisposable
     }
 
     [AvaloniaFact]
+    public void SetSyncPointWindow_WithoutVideo_IgnoresASavedWithVideoHeight()
+    {
+        // Both modes save their size under the same window name, so without the MaxHeight cap the
+        // videoless dialog restores the with-video height and opens as a mostly blank window.
+        var rememberBefore = Se.Settings.General.RememberPositionAndSize;
+        var positionsBefore = Se.Settings.General.WindowPositions.ToList();
+        try
+        {
+            Se.Settings.General.RememberPositionAndSize = true;
+            Se.Settings.General.WindowPositions.Add(
+                new SeWindowPosition(nameof(SetSyncPointWindow), false, false, 50, 50, 1100, 900));
+
+            var vm = new SetSyncPointViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+            var lines = TwoLines();
+            vm.Initialize(lines, lines[0], videoFileName: null, subtitleFileName: null, audioVisualizer: null);
+
+            var window = Track(new SetSyncPointWindow(vm));
+            window.Show();
+            Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+            Assert.True(window.Bounds.Height <= window.MaxHeight,
+                $"height was {window.Bounds.Height}, cap {window.MaxHeight}");
+            Assert.True(window.MaxHeight < 400, $"cap was {window.MaxHeight}");
+        }
+        finally
+        {
+            Se.Settings.General.RememberPositionAndSize = rememberBefore;
+            Se.Settings.General.WindowPositions.Clear();
+            Se.Settings.General.WindowPositions.AddRange(positionsBefore);
+        }
+    }
+
+    [AvaloniaFact]
     public void PointSyncViaOtherWindow_HasBothSetSyncPointButtons()
     {
         // The other subtitle stays the usual source, and the video is the fallback for lines it

--- a/tests/UI/Features/Sync/PointSync/PointSyncWindowTests.cs
+++ b/tests/UI/Features/Sync/PointSync/PointSyncWindowTests.cs
@@ -1,0 +1,92 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Sync.PointSync;
+using Nikse.SubtitleEdit.Features.Sync.PointSync.SetSyncPoint;
+using Nikse.SubtitleEdit.Features.Sync.PointSyncViaOther;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UITests.Features.Sync.PointSync;
+
+/// <summary>
+/// Construction tests for the three point sync windows. Their layouts are built in code, so a bad
+/// panel or a missing command only shows up when the window is actually constructed - which is
+/// what these do. Both point sync windows gained a video-related button (issue #13341).
+/// </summary>
+public class PointSyncWindowTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static List<SubtitleLineViewModel> TwoLines()
+        => new()
+        {
+            new() { StartTime = TimeSpan.FromSeconds(1), EndTime = TimeSpan.FromSeconds(3) },
+            new() { StartTime = TimeSpan.FromSeconds(5), EndTime = TimeSpan.FromSeconds(7) },
+        };
+
+    private T Track<T>(T window) where T : Window
+    {
+        _windows.Add(window);
+        return window;
+    }
+
+    /// <summary>
+    /// Button labels. WithIconLeft repacks the content into an icon + text panel, so the caption
+    /// is on a TextBlock inside the button rather than on Button.Content.
+    /// </summary>
+    private static IEnumerable<string> ButtonTexts(Window window)
+        => window.GetLogicalDescendants()
+            .OfType<Button>()
+            .SelectMany(b => b.GetLogicalDescendants().OfType<TextBlock>().Select(t => t.Text)
+                .Append(b.Content as string))
+            .Where(t => !string.IsNullOrEmpty(t))
+            .Select(t => t!);
+
+    [AvaloniaFact]
+    public void PointSyncWindow_Constructs()
+    {
+        var vm = new PointSyncViewModel(new FileHelper(), new WindowService(new NullServiceProvider()));
+        var lines = TwoLines();
+        vm.Initialize(lines, new List<SubtitleLineViewModel>(), string.Empty, string.Empty, null);
+
+        var window = Track(new PointSyncWindow(vm));
+
+        Assert.NotNull(window.Content);
+    }
+
+    [AvaloniaFact]
+    public void PointSyncViaOtherWindow_HasBothSetSyncPointButtons()
+    {
+        // The other subtitle stays the usual source, and the video is the fallback for lines it
+        // does not cover - so both buttons have to be there.
+        var vm = new PointSyncViaOtherViewModel(new FileHelper(), new WindowService(new NullServiceProvider()));
+        vm.Initialize(TwoLines(), string.Empty, string.Empty);
+
+        var window = Track(new PointSyncViaOtherWindow(vm));
+
+        var texts = ButtonTexts(window).ToList();
+        Assert.Contains(Se.Language.Sync.SetSyncPoint, texts);
+        Assert.Contains(Se.Language.Sync.SetSyncPointViaVideo, texts);
+    }
+}

--- a/tests/UI/Features/Sync/PointSync/PointSyncWindowTests.cs
+++ b/tests/UI/Features/Sync/PointSync/PointSyncWindowTests.cs
@@ -52,16 +52,29 @@ public class PointSyncWindowTests : IDisposable
     }
 
     /// <summary>
-    /// Button labels. WithIconLeft repacks the content into an icon + text panel, so the caption
-    /// is on a TextBlock inside the button rather than on Button.Content.
+    /// Captions of every button in the window, visible or not. WithIconLeft repacks the content
+    /// into an icon + text panel, so the caption is on a TextBlock inside the button rather than
+    /// on Button.Content.
     /// </summary>
     private static IEnumerable<string> ButtonTexts(Window window)
         => window.GetLogicalDescendants()
             .OfType<Button>()
-            .SelectMany(b => b.GetLogicalDescendants().OfType<TextBlock>().Select(t => t.Text)
-                .Append(b.Content as string))
+            .SelectMany(CaptionsOf)
             .Where(t => !string.IsNullOrEmpty(t))
             .Select(t => t!);
+
+    private static IEnumerable<string?> CaptionsOf(Button button)
+        => button.GetLogicalDescendants().OfType<TextBlock>().Select(t => t.Text)
+            .Append(button.Content as string);
+
+    /// <summary>
+    /// A hidden button is still in the logical tree, so presence says nothing about whether the
+    /// user can see it - this is what the visibility assertions have to go through.
+    /// </summary>
+    private static Button ButtonWithText(Window window, string text)
+        => window.GetLogicalDescendants()
+            .OfType<Button>()
+            .First(b => CaptionsOf(b).Contains(text));
 
     [AvaloniaFact]
     public void PointSyncWindow_Constructs()
@@ -73,6 +86,44 @@ public class PointSyncWindowTests : IDisposable
         var window = Track(new PointSyncWindow(vm));
 
         Assert.NotNull(window.Content);
+    }
+
+    [AvaloniaFact]
+    public void SetSyncPointWindow_WithoutVideo_HidesThePlayerAndPlaybackButton()
+    {
+        // The videoless dialog is just the line picker and the sync point time code - the player,
+        // the waveform and "Play 2 secs & back" have nothing to show or do (issue #13341).
+        var vm = new SetSyncPointViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        var lines = TwoLines();
+        vm.Initialize(lines, lines[0], videoFileName: null, subtitleFileName: null, audioVisualizer: null);
+
+        var window = Track(new SetSyncPointWindow(vm));
+
+        Assert.False(vm.IsVideoVisible);
+        Assert.False(vm.VideoPlayerControl.IsVisible);
+        Assert.False(vm.AudioVisualizer.IsVisible);
+        Assert.False(ButtonWithText(window, Se.Language.Sync.PlayTwoSecondsAndBack).IsVisible);
+
+        // Everything that still means something without a video stays.
+        Assert.True(ButtonWithText(window, Se.Language.Sync.GoToSubPos).IsVisible);
+        Assert.True(ButtonWithText(window, Se.Language.General.OpenVideoFile).IsVisible);
+    }
+
+    [AvaloniaFact]
+    public void SetSyncPointWindow_WithVideo_KeepsThePlayerAndPlaybackButton()
+    {
+        var vm = new SetSyncPointViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        var lines = TwoLines();
+
+        // A path is enough for the layout decision; nothing opens it here (the open is posted to
+        // the dispatcher and this test never pumps it).
+        vm.Initialize(lines, lines[0], videoFileName: "/does/not/exist.mp4", subtitleFileName: null, audioVisualizer: null);
+
+        var window = Track(new SetSyncPointWindow(vm));
+
+        Assert.True(vm.IsVideoVisible);
+        Assert.True(vm.VideoPlayerControl.IsVisible);
+        Assert.True(ButtonWithText(window, Se.Language.Sync.PlayTwoSecondsAndBack).IsVisible);
     }
 
     [AvaloniaFact]

--- a/tests/UI/Features/Sync/PointSync/SetSyncPointViewModelTests.cs
+++ b/tests/UI/Features/Sync/PointSync/SetSyncPointViewModelTests.cs
@@ -1,0 +1,117 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Sync.PointSync.SetSyncPoint;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+
+namespace UITests.Features.Sync.PointSync;
+
+/// <summary>
+/// "Set sync point" without a video (issue #13341). The video is only one of the ways to drive the
+/// sync point - the time code box is the result - so the dialog has to work with no video at all:
+/// the box starts at the selected line's time, the nudge buttons move it, and OK returns it.
+/// </summary>
+public class SetSyncPointViewModelTests
+{
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static SetSyncPointViewModel MakeViewModel()
+        => new(new WindowService(new NullServiceProvider()), new FileHelper());
+
+    private static List<SubtitleLineViewModel> ThreeLines()
+        => new()
+        {
+            new() { StartTime = TimeSpan.FromSeconds(10), EndTime = TimeSpan.FromSeconds(12) },
+            new() { StartTime = TimeSpan.FromSeconds(30), EndTime = TimeSpan.FromSeconds(32) },
+            new() { StartTime = TimeSpan.FromSeconds(50), EndTime = TimeSpan.FromSeconds(52) },
+        };
+
+    [AvaloniaFact]
+    public void Initialize_WithoutVideo_SeedsSyncPointFromSelectedLine()
+    {
+        var lines = ThreeLines();
+        var vm = MakeViewModel();
+
+        vm.Initialize(lines, lines[1], videoFileName: null, subtitleFileName: null, audioVisualizer: null);
+
+        Assert.Equal(TimeSpan.FromSeconds(30), vm.SyncPointTimeCode);
+    }
+
+    [AvaloniaFact]
+    public void Initialize_WithoutVideoOrSelection_SeedsSyncPointFromFirstLine()
+    {
+        var lines = ThreeLines();
+        var vm = MakeViewModel();
+
+        vm.Initialize(lines, null, videoFileName: null, subtitleFileName: null, audioVisualizer: null);
+
+        Assert.Equal(TimeSpan.FromSeconds(10), vm.SyncPointTimeCode);
+    }
+
+    [AvaloniaFact]
+    public void Ok_WithoutVideo_ReturnsTheTypedTimeCode()
+    {
+        // The value a user types is the whole point of the dialog when there is no video to scrub -
+        // taking the result off the (empty) player instead gave a sync point of zero.
+        var lines = ThreeLines();
+        var vm = MakeViewModel();
+        vm.Initialize(lines, lines[1], videoFileName: null, subtitleFileName: null, audioVisualizer: null);
+
+        vm.SyncPointTimeCode = TimeSpan.FromSeconds(42.5);
+        vm.OkCommand.Execute(null);
+
+        Assert.True(vm.OkPressed);
+        Assert.Equal(42.5, vm.SyncPosition, 3);
+    }
+
+    [AvaloniaFact]
+    public void NudgeButtons_WithoutVideo_MoveTheTimeCode()
+    {
+        var lines = ThreeLines();
+        var vm = MakeViewModel();
+        vm.Initialize(lines, lines[1], videoFileName: null, subtitleFileName: null, audioVisualizer: null);
+
+        vm.LeftOneSecondForwardCommand.Execute(null);
+        vm.LeftHalfSecondForwardCommand.Execute(null);
+
+        Assert.Equal(TimeSpan.FromSeconds(31.5), vm.SyncPointTimeCode);
+
+        vm.LeftOneSecondBackCommand.Execute(null);
+        vm.LeftHalfSecondBackCommand.Execute(null);
+
+        Assert.Equal(TimeSpan.FromSeconds(30), vm.SyncPointTimeCode);
+    }
+
+    [AvaloniaFact]
+    public void NudgeBack_WithoutVideo_StopsAtZero()
+    {
+        var lines = ThreeLines();
+        var vm = MakeViewModel();
+        vm.Initialize(lines, lines[0], videoFileName: null, subtitleFileName: null, audioVisualizer: null);
+
+        for (var i = 0; i < 20; i++)
+        {
+            vm.LeftOneSecondBackCommand.Execute(null);
+        }
+
+        Assert.Equal(TimeSpan.Zero, vm.SyncPointTimeCode);
+    }
+
+    [AvaloniaFact]
+    public void GoToSubtitle_WithoutVideo_MovesTheTimeCodeToThatLine()
+    {
+        var lines = ThreeLines();
+        var vm = MakeViewModel();
+        vm.Initialize(lines, lines[0], videoFileName: null, subtitleFileName: null, audioVisualizer: null);
+
+        vm.SelectedParagraphIndex = 2;
+        vm.GoToLeftSubtitleCommand.Execute(null);
+
+        Assert.Equal(TimeSpan.FromSeconds(50), vm.SyncPointTimeCode);
+    }
+}


### PR DESCRIPTION
Fixes #13341.

"Set sync point" opened at 00:00:00.000 with no video loaded and returned the (empty) player's position on OK, so point sync looked broken unless a video was open. SE4 never required one: the time code box was seeded from the selected line, the box - not the player - was the result, and the dialog could open a video itself. This restores that behavior and extends it to "Point sync via other subtitle".

### Set sync point
- Seed the sync point time code from the selected line, video or not (the seeding used to hang off the video-ready path, which returned early with no video).
- OK returns the time code box instead of the player position; the position timer, nudge buttons and Space stay off the box when there is no video to drive it.
- New "Open video file..." button, plus SE4's probe for a video next to the subtitle file, so entering point sync without a video is no longer a dead end.
- Videoless layout: with no video the player row collapses, the waveform and "Play 2 secs & back" come off, and the dialog opens at 340px instead of 800px. Opening a video restores the full layout live. A MaxHeight cap keeps a stale saved with-video size from inflating the videoless dialog (both modes save under the same window name).
- The time code is labelled "Sync point time code" (as in SE4) instead of "Video position".
- The audio visualizer is now actually bound to IsAudioVisualizerVisible - it used to render as an empty grey slab even with no peaks to show.

### Point sync / via other
- A video opened (or found) inside "Set sync point" is carried back so the next sync point starts with it loaded, and adopted by the main window when it had none. A merely auto-found video stays local to the dialog, so it cannot override the "auto open video file" setting.
- "Point sync via other subtitle" gains "Set sync point via video...", for lines the other file has no counterpart for - and it is the only typed-time-code path there before an other subtitle is loaded.

New strings `Sync.SetSyncPointViaVideo` and `Sync.SyncPointTimeCode` exist in LanguageSync.cs only; English.json needs the usual regeneration pass.

Tests: 9 view-model/window tests for the no-video path (seeding, OK result, nudges, clamp at zero, hidden player/playback button, stale-saved-height cap). Full UI suite passes (1618).

🤖 Generated with [Claude Code](https://claude.com/claude-code)