### PR TITLE
Fix ~25 bugs in the advanced ASSA effects

### DIFF
--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/AssaApplyAdvancedEffectViewModel.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/AssaApplyAdvancedEffectViewModel.cs
@@ -130,6 +130,12 @@ public partial class AssaApplyAdvancedEffectViewModel : ObservableObject
                 }
                 i--;
             }
+
+            if (SelectedOverrideTag == null || !OverrideTags.Contains(SelectedOverrideTag))
+            {
+                // The constructor's default selection may just have been removed
+                SelectedOverrideTag = OverrideTags.FirstOrDefault();
+            }
         }
 
         if (selectedParagraphs.Count > 1)
@@ -258,8 +264,12 @@ public partial class AssaApplyAdvancedEffectViewModel : ObservableObject
             result.Paragraphs.Add(line.ToParagraph(_assaFormat));
         }
 
-        result.Paragraphs.Sort((a, b) =>
-            a.StartTime.TotalMilliseconds.CompareTo(b.StartTime.TotalMilliseconds));
+        // OrderBy is a stable sort: several effects emit overlay + text events with the same
+        // start time and rely on their emit order for z-ordering (List.Sort is unstable and
+        // could swap them).
+        var sorted = result.Paragraphs.OrderBy(p => p.StartTime.TotalMilliseconds).ToList();
+        result.Paragraphs.Clear();
+        result.Paragraphs.AddRange(sorted);
 
         return result;
     }
@@ -281,9 +291,10 @@ public partial class AssaApplyAdvancedEffectViewModel : ObservableObject
     [RelayCommand]
     private async Task PlayAndBack()
     {
-        if (SelectedParagraphIndex <= 0)
+        if (SelectedParagraphIndex < 0)
         {
             await PlayAndBack(VideoPlayerControl, 3000);
+            return;
         }
 
         var selected = Paragraphs[SelectedParagraphIndex];
@@ -368,7 +379,7 @@ public partial class AssaApplyAdvancedEffectViewModel : ObservableObject
 
     internal void ComboBoxParagraphsChanged(object? sender, SelectionChangedEventArgs e)
     {
-        if (SelectedParagraphIndex <= 0)
+        if (SelectedParagraphIndex < 0)
         {
             return;
         }

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectAudioTextPulse.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectAudioTextPulse.cs
@@ -35,13 +35,12 @@ public class AdvancedEffectAudioTextPulse : IAdvancedEffectDisplay
         {
             var cleanText = Utilities.RemoveSsaTags(sub.Text)
                 .Replace("\r\n", "\\N").Replace("\r", "\\N").Replace("\n", "\\N").Trim();
-            if (string.IsNullOrEmpty(cleanText))
+            double durationMs = sub.Duration.TotalMilliseconds;
+            if (string.IsNullOrEmpty(cleanText) || durationMs <= 0)
             {
-                result.Add(sub);
+                result.Add(AdvancedEffectUtil.PassThrough(sub));
                 continue;
             }
-
-            double durationMs = sub.Duration.TotalMilliseconds;
 
             // Normalise against the loudest peak in the neighbourhood of this subtitle
             double localPeak = ComputeLocalPeak(wavePeaks,
@@ -92,7 +91,7 @@ public class AdvancedEffectAudioTextPulse : IAdvancedEffectDisplay
                 var frame = new SubtitleLineViewModel(sub, generateNewId: true);
                 frame.StartTime = sub.StartTime.Add(TimeSpan.FromMilliseconds(t));
                 frame.EndTime = sub.StartTime.Add(TimeSpan.FromMilliseconds(Math.Min(t + frameMs, durationMs)));
-                frame.Text = $"{{\\an2\\1c&HFFFFFF&\\3c{glowColor}\\bord{bord:F1}\\blur{blur:F1}\\shad0\\fscx{scale}\\fscy{scale}}}" + cleanText;
+                frame.Text = $"{{\\an2\\1c&HFFFFFF&\\3c{glowColor}\\bord{AdvancedEffectUtil.Tag(bord)}\\blur{AdvancedEffectUtil.Tag(blur)}\\shad0\\fscx{scale}\\fscy{scale}}}" + cleanText;
                 result.Add(frame);
             }
         }

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectBounceIn.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectBounceIn.cs
@@ -31,7 +31,7 @@ public class AdvancedEffectBounceIn : IAdvancedEffectDisplay
             var cleanText = Utilities.RemoveSsaTags(sub.Text);
             if (string.IsNullOrEmpty(cleanText))
             {
-                result.Add(sub);
+                result.Add(AdvancedEffectUtil.PassThrough(sub));
                 continue;
             }
 
@@ -43,6 +43,12 @@ public class AdvancedEffectBounceIn : IAdvancedEffectDisplay
                 ? (int)Math.Max(20, Math.Min(80, sub.Duration.TotalMilliseconds / 3.0 / nonSpaceCount))
                 : 50;
 
+            // The bounce animation itself runs 0-500 ms, so the last character must start
+            // no later than 500 ms before the subtitle ends or it never finishes (and a
+            // raw char index * stagger could even start after EndTime on long lines).
+            double maxStartOffsetMs = Math.Max(0, sub.Duration.TotalMilliseconds - 500);
+            int visibleIndex = 0;
+
             for (int i = 0; i < chars.Length; i++)
             {
                 if (chars[i] == ' ' || chars[i] == '\n')
@@ -51,8 +57,10 @@ public class AdvancedEffectBounceIn : IAdvancedEffectDisplay
                 }
 
                 var line = new SubtitleLineViewModel(sub, generateNewId: true);
-                line.StartTime = sub.StartTime.Add(TimeSpan.FromMilliseconds(i * staggerMs));
+                line.StartTime = sub.StartTime.Add(TimeSpan.FromMilliseconds(
+                    Math.Min(visibleIndex * staggerMs, maxStartOffsetMs)));
                 line.EndTime = sub.EndTime;
+                visibleIndex++;
 
                 sb.Clear();
                 for (int j = 0; j < chars.Length; j++)
@@ -74,8 +82,10 @@ public class AdvancedEffectBounceIn : IAdvancedEffectDisplay
                     }
                     else
                     {
-                        // Transparent placeholder — preserves spacing but invisible
-                        sb.Append("{\\alpha&HFF&}");
+                        // Transparent placeholder — preserves spacing but invisible.
+                        // The scale reset stops the bouncing char's \t animation from
+                        // carrying over and making the rest of the line pulse.
+                        sb.Append("{\\alpha&HFF&\\fscx100\\fscy100}");
                     }
 
                     sb.Append(chars[j]);

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectConfetti.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectConfetti.cs
@@ -197,7 +197,7 @@ public class AdvancedEffectConfetti : IAdvancedEffectDisplay
                 result.Add(piece);
             }
 
-            result.Add(sub);
+            result.Add(AdvancedEffectUtil.PassThrough(sub));
         }
 
         return result;

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFadeIn.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFadeIn.cs
@@ -26,7 +26,7 @@ public class AdvancedEffectFadeIn : IAdvancedEffectDisplay
         foreach (var sub in subtitles)
         {
             result.Add(CreateLineFadeIn(sub.StartTime, sub.Duration.TotalMilliseconds, w, h));
-            result.Add(sub);
+            result.Add(AdvancedEffectUtil.PassThrough(sub));
         }
 
         return result;
@@ -43,7 +43,7 @@ public class AdvancedEffectFadeIn : IAdvancedEffectDisplay
         string drawBox = $"m 0 0 l {w} 0 l {w} {h} l 0 {h}";
 
         // \fad(0, durationMs) makes the black box go from Opaque (0) to Transparent (durationMs)
-        fadeIn.Text = "{\\p1\\an7\\pos(0,0)\\bord0\\shad0\\1c&H000000&\\fad(0," + durationMs + ")}" + drawBox;
+        fadeIn.Text = "{\\p1\\an7\\pos(0,0)\\bord0\\shad0\\1c&H000000&\\fad(0," + (int)Math.Round(durationMs) + ")}" + drawBox;
 
         return fadeIn;
     }

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFadeInOut.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFadeInOut.cs
@@ -29,7 +29,7 @@ public class AdvancedEffectFadeInOut : IAdvancedEffectDisplay
         foreach (var sub in subtitles)
         {
             int durationMs = (int)sub.Duration.TotalMilliseconds;
-            int fadeMs = (int)Math.Min(500, durationMs / 3.0);
+            int fadeMs = Math.Max(0, (int)Math.Min(500, durationMs / 3.0));
 
             var fadeSub = new SubtitleLineViewModel(sub, generateNewId: true);
             fadeSub.Text = $"{{\\fad({fadeMs},{fadeMs})}}" + sub.Text;

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFadeOut.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFadeOut.cs
@@ -28,7 +28,7 @@ public class AdvancedEffectFadeOut : IAdvancedEffectDisplay
         foreach (var sub in subtitles)
         {
             result.Add(CreateBlackOverlay(sub.StartTime, sub.Duration.TotalMilliseconds, w, h));
-            result.Add(sub);
+            result.Add(AdvancedEffectUtil.PassThrough(sub));
         }
 
         return result;
@@ -40,10 +40,14 @@ public class AdvancedEffectFadeOut : IAdvancedEffectDisplay
         fadeOut.StartTime = lineStart;
         fadeOut.EndTime = lineStart.Add(TimeSpan.FromMilliseconds(durationMs));
 
+        // Layer is a Dialogue-line field, not an override tag - a "\layer10" tag would be
+        // silently ignored, so the above-the-text z-order is set on the event instead.
+        fadeOut.Layer = 10;
+
         // Vector rectangle covering the whole screen
         string drawBox = $"m 0 0 l {w} 0 l {w} {h} l 0 {h}";
 
-        fadeOut.Text = "{\\p1\\an7\\pos(0,0)\\bord0\\shad0\\1c&H000000&\\layer10\\fad(" + durationMs + ",0)}" + drawBox;
+        fadeOut.Text = "{\\p1\\an7\\pos(0,0)\\bord0\\shad0\\1c&H000000&\\fad(" + (int)Math.Round(durationMs) + ",0)}" + drawBox;
 
         return fadeOut;
     }

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFancyKaraoke.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFancyKaraoke.cs
@@ -5,6 +5,7 @@ using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -27,6 +28,10 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
 
     private static readonly Regex UnderlineTagRegex = new(@"\\u1", RegexOptions.Compiled);
     private static readonly Regex PrimaryColorTagRegex = new(@"\\1?c(&H[0-9A-Fa-f]{6}&)", RegexOptions.Compiled);
+    private static readonly Regex FirstTagBlockRegex = new(@"^\{([^}]*)\}", RegexOptions.Compiled);
+    private static readonly Regex AlignTagRegex = new(@"\\an\d", RegexOptions.Compiled);
+    private static readonly Regex PosTagRegex = new(@"\\pos\([^)]+\)", RegexOptions.Compiled);
+    private static readonly Regex MoveTagPatternRegex = new(@"\\move\([^)]+\)", RegexOptions.Compiled);
 
     /// <summary>
     /// When true, ignore explicit active-word markup and auto-sequence whole words
@@ -209,7 +214,10 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
             sb.Clear();
             if (!string.IsNullOrEmpty(posTags))
             {
-                sb.Append(posTags);
+                // \move times are relative to each event's start, so a \move copied verbatim
+                // into every word-line would restart the motion at every word boundary.
+                // Rewrite it per line so the movement continues seamlessly across words.
+                sb.Append(AdjustMoveForSegment(posTags, w * msPerWord, (end - start).TotalMilliseconds, totalMs));
             }
 
             // The active word for this step. In right-to-left mode advance from the last word
@@ -278,26 +286,84 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
         return result;
     }
 
+    private static readonly Regex MoveTagRegex = new(@"\\move\(([^)]*)\)", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Rewrites a \move inside <paramref name="posTags"/> for a sub-segment of the original
+    /// line, so that a line split into sequential word-events keeps one continuous motion.
+    /// The original motion runs from t1 to t2 (relative to the original line start, or the
+    /// whole line for the 4-argument form); each segment gets the interpolated start/end
+    /// coordinates and clamped times for its own time slice.
+    /// </summary>
+    private static string AdjustMoveForSegment(string posTags, double segmentOffsetMs, double segmentDurationMs, double lineDurationMs)
+    {
+        var match = MoveTagRegex.Match(posTags);
+        if (!match.Success)
+        {
+            return posTags;
+        }
+
+        var args = match.Groups[1].Value.Split(',');
+        if (args.Length != 4 && args.Length != 6)
+        {
+            return posTags;
+        }
+
+        var v = new double[args.Length];
+        for (var i = 0; i < args.Length; i++)
+        {
+            if (!double.TryParse(args[i].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out v[i]))
+            {
+                return posTags;
+            }
+        }
+
+        double x1 = v[0], y1 = v[1], x2 = v[2], y2 = v[3];
+        var t1 = args.Length == 6 ? v[4] : 0;
+        var t2 = args.Length == 6 ? v[5] : lineDurationMs;
+        if (t2 <= t1)
+        {
+            t1 = 0;
+            t2 = lineDurationMs;
+        }
+
+        double Lerp(double a, double b, double t) =>
+            t <= t1 ? a : t >= t2 ? b : a + (b - a) * (t - t1) / (t2 - t1);
+
+        var s1 = Math.Clamp(t1 - segmentOffsetMs, 0, segmentDurationMs);
+        var s2 = Math.Clamp(t2 - segmentOffsetMs, s1, segmentDurationMs);
+        var nx1 = (int)Math.Round(Lerp(x1, x2, segmentOffsetMs + s1));
+        var ny1 = (int)Math.Round(Lerp(y1, y2, segmentOffsetMs + s1));
+        var nx2 = (int)Math.Round(Lerp(x1, x2, segmentOffsetMs + s2));
+        var ny2 = (int)Math.Round(Lerp(y1, y2, segmentOffsetMs + s2));
+
+        var replacement = s2 <= s1 || (nx1 == nx2 && ny1 == ny2)
+            ? $"\\pos({nx2},{ny2})"
+            : $"\\move({nx1},{ny1},{nx2},{ny2},{(int)Math.Round(s1)},{(int)Math.Round(s2)})";
+
+        return posTags.Replace(match.Value, replacement);
+    }
+
     private static string ExtractPositionalTags(string text)
     {
-        var firstBlock = System.Text.RegularExpressions.Regex.Match(text, @"^\{([^}]*)\}");
+        var firstBlock = FirstTagBlockRegex.Match(text);
         if (!firstBlock.Success)
         {
             return string.Empty;
         }
         string inner = firstBlock.Groups[1].Value;
         var sb = new StringBuilder("{");
-        var anM = System.Text.RegularExpressions.Regex.Match(inner, @"\\an\d");
+        var anM = AlignTagRegex.Match(inner);
         if (anM.Success)
         {
             sb.Append(anM.Value);
         }
-        var posM = System.Text.RegularExpressions.Regex.Match(inner, @"\\pos\([^)]+\)");
+        var posM = PosTagRegex.Match(inner);
         if (posM.Success)
         {
             sb.Append(posM.Value);
         }
-        var moveM = System.Text.RegularExpressions.Regex.Match(inner, @"\\move\([^)]+\)");
+        var moveM = MoveTagPatternRegex.Match(inner);
         if (moveM.Success)
         {
             sb.Append(moveM.Value);
@@ -409,6 +475,12 @@ public class AdvancedEffectFancyKaraoke : IAdvancedEffectDisplay
             }
             int textStart = pos;
             while (pos < text.Length && text[pos] != '{') pos++;
+            if (pos == textStart && pos < text.Length)
+            {
+                // An unmatched '{' has no closing '}', so neither loop above advances -
+                // consume the rest as plain text to guarantee the scan terminates.
+                pos = text.Length;
+            }
             string plainText = text[textStart..pos];
             if (tags.Length > 0 || !string.IsNullOrEmpty(plainText))
             {

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFireflies.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectFireflies.cs
@@ -33,18 +33,19 @@ public class AdvancedEffectFireflies : IAdvancedEffectDisplay
 
         Random rng = new Random(subtitles[0].Text.GetHashCode());
 
-        int w = width > 0 ? width : 1280;
-        int h = height > 0 ? height : 720;
+        // The 40 px screen-edge margins below need at least ~80 px in each direction
+        int w = width > 80 ? width : 1280;
+        int h = height > 80 ? height : 720;
 
         var globalStart = subtitles.Min(s => s.StartTime);
         var globalEnd = subtitles.Max(s => s.EndTime);
         double totalVideoMs = (globalEnd - globalStart).TotalMilliseconds;
 
-        for (int i = 0; i < FireflyCount; i++)
+        for (int i = 0; i < FireflyCount && result.Count < AdvancedEffectUtil.MaxGeneratedEvents; i++)
         {
             double currentTimeMs = rng.Next(0, 3000) + (i * 30);
 
-            while (currentTimeMs < totalVideoMs)
+            while (currentTimeMs < totalVideoMs && result.Count < AdvancedEffectUtil.MaxGeneratedEvents)
             {
                 var fly = new SubtitleLineViewModel();
 
@@ -100,7 +101,7 @@ public class AdvancedEffectFireflies : IAdvancedEffectDisplay
                 int minBlur = (int)(glowBlur * 0.6);
 
                 string tags =
-                    $"\\an5\\bord{glowBorder:F1}\\shad0\\3c&H00FFFF&\\blur{(int)glowBlur}" +
+                    $"\\an5\\bord{AdvancedEffectUtil.Tag(glowBorder)}\\shad0\\3c&H00FFFF&\\blur{(int)glowBlur}" +
                     $"\\1c{color}\\alpha&H{hexAlpha}&\\fad({fadeDur},{fadeDur})" +
                     $"\\fscx{size}\\fscy{size}" +
                     $"\\move({startX},{startY},{endX},{endY})" +
@@ -114,7 +115,7 @@ public class AdvancedEffectFireflies : IAdvancedEffectDisplay
             }
         }
 
-        result.AddRange(subtitles);
+        result.AddRange(subtitles.Select(AdvancedEffectUtil.PassThrough));
         return result;
     }
 }

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectGlitch.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectGlitch.cs
@@ -38,9 +38,9 @@ public class AdvancedEffectGlitch : IAdvancedEffectDisplay
             double totalMs = sub.Duration.TotalMilliseconds;
             var rng = new Random(sub.Text.GetHashCode());
 
-            if (string.IsNullOrEmpty(cleanText))
+            if (string.IsNullOrEmpty(cleanText) || totalMs <= 0)
             {
-                result.Add(sub);
+                result.Add(AdvancedEffectUtil.PassThrough(sub));
                 continue;
             }
 
@@ -104,7 +104,7 @@ public class AdvancedEffectGlitch : IAdvancedEffectDisplay
                         break;
                     case 3: // Font shear (\fax) — digital skew distortion
                         double shear = rng.NextDouble() * 0.6 - 0.3;
-                        tags = $"\\fax{shear:F2}\\1c&HFFFFFF&\\alpha&H{alphaHex}&\\blur0.5\\shad0";
+                        tags = $"\\fax{AdvancedEffectUtil.Tag(shear)}\\1c&HFFFFFF&\\alpha&H{alphaHex}&\\blur0.5\\shad0";
                         break;
                     case 4: // Scale jitter + slight tilt
                         int glitchFrz = rng.Next(-6, 7);

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectHearts.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectHearts.cs
@@ -102,6 +102,11 @@ public class AdvancedEffectHearts : IAdvancedEffectDisplay
 
                 var heart = new SubtitleLineViewModel(sub, generateNewId: true);
                 heart.StartTime = sub.StartTime.Add(TimeSpan.FromMilliseconds(heartStartOffset));
+                if (heart.StartTime < TimeSpan.Zero)
+                {
+                    // The pre-roll must not produce a negative timestamp for subtitles near t=0
+                    heart.StartTime = TimeSpan.Zero;
+                }
                 heart.EndTime = sub.EndTime;
 
                 // Start above the screen, fall past the bottom
@@ -121,7 +126,7 @@ public class AdvancedEffectHearts : IAdvancedEffectDisplay
                 string color = HeartColors[rng.Next(HeartColors.Length)];
                 string shape = HeartShapes[rng.Next(HeartShapes.Length)];
                 string hexAlpha = alpha.ToString("X2");
-                string blurTag = blur > 0 ? $"\\blur{blur:F1}" : "";
+                string blurTag = blur > 0 ? $"\\blur{AdvancedEffectUtil.Tag(blur)}" : "";
 
                 string tags =
                     $"\\p1\\an5\\1c{color}\\bord0\\shad0{blurTag}\\alpha&H{hexAlpha}&" +
@@ -135,7 +140,7 @@ public class AdvancedEffectHearts : IAdvancedEffectDisplay
                 result.Add(heart);
             }
 
-            result.Add(sub);
+            result.Add(AdvancedEffectUtil.PassThrough(sub));
         }
 
         return result;

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectKaraoke.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectKaraoke.cs
@@ -39,7 +39,7 @@ public class AdvancedEffectKaraoke : IAdvancedEffectDisplay
             var cleanText = Utilities.RemoveSsaTags(subtitle.Text);
             if (string.IsNullOrEmpty(cleanText))
             {
-                result.Add(subtitle);
+                result.Add(AdvancedEffectUtil.PassThrough(subtitle));
                 continue;
             }
 

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectMatrix.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectMatrix.cs
@@ -56,7 +56,7 @@ public class AdvancedEffectMatrix : IAdvancedEffectDisplay
             int colX = col * colW + colW / 2;
             double streamStart = rng.Next(0, (int)(totalVideoMs * 0.25)) + col * 25;
 
-            while (streamStart < totalVideoMs)
+            while (streamStart < totalVideoMs && result.Count < AdvancedEffectUtil.MaxGeneratedEvents)
             {
                 int streamLen = rng.Next(8, 18);
                 int fallDur = rng.Next(1200, 3500);
@@ -93,7 +93,7 @@ public class AdvancedEffectMatrix : IAdvancedEffectDisplay
                         float pos = (float)j / (streamLen - 1); // 0 = head … 1 = tail
                         color = pos < 0.35f ? BrightGreen : pos < 0.65f ? MidGreen : DarkGreen;
                         float trailBlur = Math.Max(1.0f, 3.0f - pos * 2.0f);
-                        extra = $"\\blur{trailBlur:F1}\\bord0";
+                        extra = $"\\blur{AdvancedEffectUtil.Tag(trailBlur)}\\bord0";
                         alpha = Math.Min(0xD0, (int)(pos * 200));
                     }
 
@@ -126,7 +126,7 @@ public class AdvancedEffectMatrix : IAdvancedEffectDisplay
                 .Replace("\r\n", " ").Replace("\r", " ").Replace("\n", " ").Trim();
             if (string.IsNullOrEmpty(cleanText))
             {
-                result.Add(sub);
+                result.Add(AdvancedEffectUtil.PassThrough(sub));
                 continue;
             }
 
@@ -171,9 +171,17 @@ public class AdvancedEffectMatrix : IAdvancedEffectDisplay
                 var falling = new SubtitleLineViewModel(sub, generateNewId: true);
                 falling.StartTime = sub.StartTime.Add(TimeSpan.FromMilliseconds(-preRollMs));
                 falling.EndTime = sub.StartTime.Add(TimeSpan.FromMilliseconds(charRevealMs - preRollMs));
+                if (falling.StartTime < TimeSpan.Zero)
+                {
+                    // The pre-roll must not produce negative timestamps for subtitles near t=0
+                    falling.StartTime = TimeSpan.Zero;
+                }
                 falling.Text = $"{{\\an5\\1c{BrightGreen}\\blur3\\bord0\\shad0\\fs{fs}" +
                                $"\\move({charX},-20,{charX},{revealY})}}" + scrambled[i];
-                result.Add(falling);
+                if (falling.EndTime > falling.StartTime)
+                {
+                    result.Add(falling);
+                }
 
                 // Part 2: actual char falls from revealY down to restY (with flash on reveal)
                 int restY = (int)(h * 0.88); // resting line — near bottom, subtitle-style
@@ -185,20 +193,28 @@ public class AdvancedEffectMatrix : IAdvancedEffectDisplay
                     var revealed = new SubtitleLineViewModel(sub, generateNewId: true);
                     revealed.StartTime = sub.StartTime.Add(TimeSpan.FromMilliseconds(charRevealMs - preRollMs));
                     revealed.EndTime = sub.StartTime; // arrives at restY exactly at subtitle start time
+                    if (revealed.StartTime < TimeSpan.Zero)
+                    {
+                        revealed.StartTime = TimeSpan.Zero;
+                    }
                     int flashDur = Math.Min(300, (int)fallToRestMs);
                     revealed.Text = $"{{\\an5\\1c{HeadColor}\\blur3\\bord1\\shad0\\fs{fs}" +
                                     $"\\t(0,{flashDur},\\1c&HFFFFFF&\\blur1)" +
                                     $"\\move({charX},{revealY},{charX},{restY})}}" + chars[i];
-                    result.Add(revealed);
+                    if (revealed.EndTime > revealed.StartTime)
+                    {
+                        result.Add(revealed);
+                    }
                 }
 
                 // Part 3: char rests at restY until subtitle ends so the text is readable
-                if (restStartMs < fallDuration)
+                // (capped at the next subtitle's start so overlapping text never doubles up)
+                double restMs = Math.Min(fallDuration, nextSubOffsetMs);
+                if (restStartMs < fallDuration && restMs > 0)
                 {
                     var resting = new SubtitleLineViewModel(sub, generateNewId: true);
                     resting.StartTime = sub.StartTime; // all chars land at restY at subtitle start time
-                    resting.EndTime = sub.StartTime.Add(TimeSpan.FromMilliseconds(
-                        Math.Min(2000, nextSubOffsetMs)));
+                    resting.EndTime = sub.StartTime.Add(TimeSpan.FromMilliseconds(restMs));
                     resting.Text = $"{{\\an5\\pos({charX},{restY})\\1c&HFFFFFF&\\blur0.5\\bord1\\shad0\\fs{fs}}}" + chars[i];
                     result.Add(resting);
                 }

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectNeonBurst.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectNeonBurst.cs
@@ -32,26 +32,27 @@ public class AdvancedEffectNeonBurst : IAdvancedEffectDisplay
             string[] neonColors = { "&H00FF00&", "&HFFFF00&", "&HFF00FF&", "&H00FFFF&" };
             string chosenColor = neonColors[rng.Next(neonColors.Length)];
 
+            // The two events overlap in time at the same (style-derived) position, so they
+            // must sit on different ASSA layers: same-layer unpositioned events trigger
+            // libass collision avoidance, which would stack them vertically instead of
+            // rendering the glow behind the core. Cloning from the source line keeps its
+            // style, actor and margins.
+            var cleanText = HtmlUtil.RemoveHtmlTags(sub.Text, true);
+
             // 2. CREATE THE GLOW LAYER (The 'Bloom')
-            // We create a duplicate line that sits behind the text with a heavy blur
-            var glowLayer = new SubtitleLineViewModel()
-            {
-                StartTime = sub.StartTime,
-                EndTime = sub.EndTime,
-                // Deep neon glow: High blur, matching color, slightly transparent
-                Text = "{\\bord5\\blur8\\shad0\\1c" + chosenColor + "\\3c" + chosenColor + "\\alpha&H60&" +
-                       GetPopTags(0, 150) + "}" + HtmlUtil.RemoveHtmlTags(sub.Text, true) // CleanText removes existing tags
-            };
+            // A duplicate line that sits behind the text with a heavy blur
+            var glowLayer = new SubtitleLineViewModel(sub, generateNewId: true);
+            glowLayer.Layer = sub.Layer;
+            // Deep neon glow: High blur, matching color, slightly transparent
+            glowLayer.Text = "{\\bord5\\blur8\\shad0\\1c" + chosenColor + "\\3c" + chosenColor + "\\alpha&H60&" +
+                             GetPopTags(0, 150) + "}" + cleanText;
 
             // 3. CREATE THE SHARP TOP LAYER (The 'Core')
-            var coreLayer = new SubtitleLineViewModel()
-            {
-                StartTime = sub.StartTime,
-                EndTime = sub.EndTime,
-                // Sharp white core with a thin neon border
-                Text = "{\\bord2\\blur0.5\\shad0\\1c&HFFFFFF&\\3c" + chosenColor +
-                       GetPopTags(0, 150) + "}" + HtmlUtil.RemoveHtmlTags(sub.Text, true)
-            };
+            var coreLayer = new SubtitleLineViewModel(sub, generateNewId: true);
+            coreLayer.Layer = sub.Layer + 1;
+            // Sharp white core with a thin neon border
+            coreLayer.Text = "{\\bord2\\blur0.5\\shad0\\1c&HFFFFFF&\\3c" + chosenColor +
+                             GetPopTags(0, 150) + "}" + cleanText;
 
             result.Add(glowLayer);
             result.Add(coreLayer);

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectOldMovie.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectOldMovie.cs
@@ -34,10 +34,10 @@ public class AdvancedEffectOldMovie : IAdvancedEffectDisplay
 
         // --- 1. HEAVY FILM NOISE (GRAIN) ---
         // High particle count (40) with very short lifespans (33ms = 30fps)
-        for (int i = 0; i < 40; i++)
+        for (int i = 0; i < 40 && result.Count < AdvancedEffectUtil.MaxGeneratedEvents; i++)
         {
             double currentTimeMs = rng.Next(0, 1000);
-            while (currentTimeMs < totalMs)
+            while (currentTimeMs < totalMs && result.Count < AdvancedEffectUtil.MaxGeneratedEvents)
             {
                 var grain = new SubtitleLineViewModel(); // Using requested constructor
                 int life = 33;
@@ -57,10 +57,10 @@ public class AdvancedEffectOldMovie : IAdvancedEffectDisplay
         }
 
         // --- 2. IMPERFECT/BROKEN SCRATCHES ---
-        for (int i = 0; i < 6; i++)
+        for (int i = 0; i < 6 && result.Count < AdvancedEffectUtil.MaxGeneratedEvents; i++)
         {
             double currentTimeMs = rng.Next(0, 5000);
-            while (currentTimeMs < totalMs)
+            while (currentTimeMs < totalMs && result.Count < AdvancedEffectUtil.MaxGeneratedEvents)
             {
                 var scratch = new SubtitleLineViewModel();
                 int life = rng.Next(50, 150);
@@ -69,7 +69,6 @@ public class AdvancedEffectOldMovie : IAdvancedEffectDisplay
 
                 int x = rng.Next(50, w - 50);
                 int startY = rng.Next(-100, h / 2);
-                int endY = startY + rng.Next(h / 2, h + 200);
 
                 // Slightly crooked vertical line
                 string sDraw = $"m 0 0 l 1 0 l {rng.Next(0, 3)} {h} l {rng.Next(-2, 1)} {h}";
@@ -82,7 +81,7 @@ public class AdvancedEffectOldMovie : IAdvancedEffectDisplay
 
         // --- 3. SLOW GATE FLICKER ---
         double flickerTime = 0;
-        while (flickerTime < totalMs)
+        while (flickerTime < totalMs && result.Count < AdvancedEffectUtil.MaxGeneratedEvents)
         {
             var flicker = new SubtitleLineViewModel();
             int life = rng.Next(180, 400);
@@ -97,12 +96,17 @@ public class AdvancedEffectOldMovie : IAdvancedEffectDisplay
         }
 
         // --- 4. VIGNETTE ---
+        // The inner rectangle must be wound opposite to the outer one (counter-clockwise)
+        // so the nonzero fill rule cuts it out as a hole; wound the same way, the drawing
+        // would fill the whole screen and dim the entire video.
         var vignette = new SubtitleLineViewModel() { StartTime = globalStart, EndTime = globalEnd };
-        string vDraw = $"m 0 0 l {w} 0 l {w} {h} l 0 {h} l 0 0 m 180 180 l {w - 180} 180 l {w - 180} {h - 180} l 180 {h - 180} l 180 180";
+        int inset = Math.Min(180, Math.Min(w, h) / 4);
+        string vDraw = $"m 0 0 l {w} 0 l {w} {h} l 0 {h} " +
+                       $"m {inset} {inset} l {inset} {h - inset} l {w - inset} {h - inset} l {w - inset} {inset}";
         vignette.Text = "{\\p1\\an7\\pos(0,0)\\bord0\\shad0\\1c&H000000&\\alpha&HA0&\\be90}" + vDraw;
         result.Add(vignette);
 
-        result.AddRange(subtitles);
+        result.AddRange(subtitles.Select(AdvancedEffectUtil.PassThrough));
         return result;
     }
 }

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectRain.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectRain.cs
@@ -34,10 +34,10 @@ public class AdvancedEffectRain : IAdvancedEffectDisplay
 
         int dropCount = 350;
 
-        for (int i = 0; i < dropCount; i++)
+        for (int i = 0; i < dropCount && result.Count < AdvancedEffectUtil.MaxGeneratedEvents; i++)
         {
             double currentTimeMs = 0;
-            while (currentTimeMs < totalVideoMs)
+            while (currentTimeMs < totalVideoMs && result.Count < AdvancedEffectUtil.MaxGeneratedEvents)
             {
                 var drop = new SubtitleLineViewModel();
 
@@ -88,18 +88,20 @@ public class AdvancedEffectRain : IAdvancedEffectDisplay
 
                 // --- TAG CONSTRUCTION ---
                 string hexAlpha = alpha.ToString("X2");
-                string tags = $@"\\an5\\bord0\\shad0\\blur{blur:F1}\\1c{color}\\alpha&H{hexAlpha}&\\fad(150,150)" +
-                              $@"\\fscx{dropWidth}\\fscy{dropLength}" +
-                              $@"\\move({startX}, -100, {endX}, {screenHeight + 100})";
+                string tags = $@"\an5\bord0\shad0\blur{AdvancedEffectUtil.Tag(blur)}\1c{color}\alpha&H{hexAlpha}&\fad(150,150)" +
+                              $@"\fscx{dropWidth}\fscy{dropLength}" +
+                              $@"\move({startX},-100,{endX},{screenHeight + 100})";
 
                 drop.Text = "{" + tags + "}·";
                 result.Add(drop);
 
-                currentTimeMs += (fallDuration * rng.NextDouble());
+                // The floor keeps the advance from degenerating towards zero (an unbounded
+                // number of events) when NextDouble() lands close to 0
+                currentTimeMs += fallDuration * (0.35 + 0.65 * rng.NextDouble());
             }
         }
 
-        result.AddRange(subtitles);
+        result.AddRange(subtitles.Select(AdvancedEffectUtil.PassThrough));
         return result;
     }
 }

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectRainbowPulse.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectRainbowPulse.cs
@@ -11,6 +11,9 @@ public class AdvancedEffectRainbowPulse : IAdvancedEffectDisplay
     public string Description => Se.Language.Assa.AdvancedEffectRainbowPulseDescription;
     public bool UsesAudio => false;
 
+    private static readonly System.Text.RegularExpressions.Regex TagOrTextRegex =
+        new(@"(\{.*?\})|([^{]+)", System.Text.RegularExpressions.RegexOptions.Compiled);
+
     public override string ToString() => Name;
 
     public List<SubtitleLineViewModel> ApplyEffect(string header, List<SubtitleLineViewModel> subtitles, int width, int height, WavePeakData2? wavePeaks)
@@ -22,7 +25,7 @@ public class AdvancedEffectRainbowPulse : IAdvancedEffectDisplay
         {
             // 1. Split the text into parts (Tags vs Text)
             // This regex finds everything inside { } and everything outside.
-            var matches = System.Text.RegularExpressions.Regex.Matches(sub.Text, @"(\{.*?\})|([^{]+)");
+            var matches = TagOrTextRegex.Matches(sub.Text);
 
             var fullParts = new List<(string Content, bool IsTag)>();
             foreach (System.Text.RegularExpressions.Match m in matches)
@@ -54,6 +57,8 @@ public class AdvancedEffectRainbowPulse : IAdvancedEffectDisplay
             int stepMs = 200;
 
             // 3. Create a line for each visible character
+            int generated = 0;
+            var colorCycle = new System.Text.StringBuilder();
             for (int i = 0; i < visibleChars.Count; i++)
             {
                 var target = visibleChars[i];
@@ -64,13 +69,19 @@ public class AdvancedEffectRainbowPulse : IAdvancedEffectDisplay
 
                 var charLine = new SubtitleLineViewModel(sub, generateNewId: true);
 
+                // All the per-character lines overlap in time at the same position, so each
+                // needs its own ASSA layer: same-layer unpositioned events trigger libass
+                // collision avoidance, which would stack them vertically instead of
+                // rendering them on top of each other.
+                charLine.Layer = sub.Layer + generated;
+
                 // Rainbow logic
                 int startColorIndex = i % rainbowColors.Length;
-                string colorCycle = "";
+                colorCycle.Clear();
                 for (int currentTime = 0, step = 1; currentTime < totalMs; currentTime += stepMs, step++)
                 {
                     int nextIndex = (startColorIndex + step) % rainbowColors.Length;
-                    colorCycle += $@"\t({currentTime},{currentTime + stepMs},\1c{rainbowColors[nextIndex]})";
+                    colorCycle.Append($@"\t({currentTime},{currentTime + stepMs},\1c{rainbowColors[nextIndex]})");
                 }
 
                 // Construct the string by rebuilding the parts
@@ -88,20 +99,27 @@ public class AdvancedEffectRainbowPulse : IAdvancedEffectDisplay
                         string left = partText.Substring(0, target.CharIndex);
                         string right = partText.Substring(target.CharIndex + 1);
 
-                        finalString.Append(@"{ \alpha&HFF& }").Append(left)
-                                   .Append(@"{ \alpha&H00&\1c").Append(rainbowColors[startColorIndex]).Append(colorCycle).Append(" }")
+                        finalString.Append(@"{\alpha&HFF&}").Append(left)
+                                   .Append(@"{\alpha&H00&\1c").Append(rainbowColors[startColorIndex]).Append(colorCycle).Append('}')
                                    .Append(target.Character)
-                                   .Append(@"{ \alpha&HFF& }").Append(right);
+                                   .Append(@"{\alpha&HFF&}").Append(right);
                     }
                     else
                     {
                         // This part is text but doesn't have our active letter, hide it
-                        finalString.Append(@"{ \alpha&HFF& }").Append(fullParts[p].Content);
+                        finalString.Append(@"{\alpha&HFF&}").Append(fullParts[p].Content);
                     }
                 }
 
                 charLine.Text = finalString.ToString();
                 result.Add(charLine);
+                generated++;
+            }
+
+            if (generated == 0)
+            {
+                // Nothing to animate (empty/whitespace-only line) - keep the line as-is
+                result.Add(AdvancedEffectUtil.PassThrough(sub));
             }
         }
         return result;

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectScrambleReveal.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectScrambleReveal.cs
@@ -32,7 +32,7 @@ public class AdvancedEffectScrambleReveal : IAdvancedEffectDisplay
             var cleanText = Utilities.RemoveSsaTags(subtitle.Text);
             if (string.IsNullOrEmpty(cleanText))
             {
-                result.Add(subtitle);
+                result.Add(AdvancedEffectUtil.PassThrough(subtitle));
                 continue;
             }
 

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectSlideInLeft.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectSlideInLeft.cs
@@ -26,33 +26,39 @@ public class AdvancedEffectSlideInLeft : IAdvancedEffectDisplay
             return result;
         }
 
-        int cx = width / 2;
-        int cy = height - 60;
+        int w = width > 0 ? width : 1280;
+        int h = height > 0 ? height : 720;
+        int cx = w / 2;
+        int cy = h - 60;
 
         foreach (var sub in subtitles)
         {
             int durationMs = (int)sub.Duration.TotalMilliseconds;
-            int slideMs = (int)Math.Min(400, durationMs / 3.0);
+            int slideMs = Math.Max(0, (int)Math.Min(400, durationMs / 3.0));
+
+            // Existing \pos/\move/\an in the source line would conflict with the generated
+            // positioning (\pos and \move are mutually exclusive, the last \an wins)
+            var text = AdvancedEffectUtil.RemovePositionTags(sub.Text);
 
             // Slide in from left
             var inSub = new SubtitleLineViewModel(sub, generateNewId: true);
             inSub.StartTime = sub.StartTime;
             inSub.EndTime = sub.StartTime + TimeSpan.FromMilliseconds(slideMs);
-            inSub.Text = $"{{\\an2\\move(-{width},{cy},{cx},{cy},0,{slideMs})}}" + sub.Text;
+            inSub.Text = $"{{\\an2\\move(-{w},{cy},{cx},{cy},0,{slideMs})}}" + text;
             result.Add(inSub);
 
             // Hold at centre
             var holdSub = new SubtitleLineViewModel(sub, generateNewId: true);
             holdSub.StartTime = sub.StartTime + TimeSpan.FromMilliseconds(slideMs);
             holdSub.EndTime = sub.EndTime - TimeSpan.FromMilliseconds(slideMs);
-            holdSub.Text = $"{{\\an2\\pos({cx},{cy})}}" + sub.Text;
+            holdSub.Text = $"{{\\an2\\pos({cx},{cy})}}" + text;
             result.Add(holdSub);
 
             // Slide out to left
             var outSub = new SubtitleLineViewModel(sub, generateNewId: true);
             outSub.StartTime = sub.EndTime - TimeSpan.FromMilliseconds(slideMs);
             outSub.EndTime = sub.EndTime;
-            outSub.Text = $"{{\\an2\\move({cx},{cy},-{width},{cy},0,{slideMs})}}" + sub.Text;
+            outSub.Text = $"{{\\an2\\move({cx},{cy},-{w},{cy},0,{slideMs})}}" + text;
             result.Add(outSub);
         }
 

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectSlideInRight.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectSlideInRight.cs
@@ -26,34 +26,40 @@ public class AdvancedEffectSlideInRight : IAdvancedEffectDisplay
             return result;
         }
 
-        int cx = width / 2;
-        int cy = height - 60;
-        int offscreenX = width * 2;
+        int w = width > 0 ? width : 1280;
+        int h = height > 0 ? height : 720;
+        int cx = w / 2;
+        int cy = h - 60;
+        int offscreenX = w * 2;
 
         foreach (var sub in subtitles)
         {
             int durationMs = (int)sub.Duration.TotalMilliseconds;
-            int slideMs = (int)Math.Min(400, durationMs / 3.0);
+            int slideMs = Math.Max(0, (int)Math.Min(400, durationMs / 3.0));
+
+            // Existing \pos/\move/\an in the source line would conflict with the generated
+            // positioning (\pos and \move are mutually exclusive, the last \an wins)
+            var text = AdvancedEffectUtil.RemovePositionTags(sub.Text);
 
             // Slide in from right
             var inSub = new SubtitleLineViewModel(sub, generateNewId: true);
             inSub.StartTime = sub.StartTime;
             inSub.EndTime = sub.StartTime + TimeSpan.FromMilliseconds(slideMs);
-            inSub.Text = $"{{\\an2\\move({offscreenX},{cy},{cx},{cy},0,{slideMs})}}" + sub.Text;
+            inSub.Text = $"{{\\an2\\move({offscreenX},{cy},{cx},{cy},0,{slideMs})}}" + text;
             result.Add(inSub);
 
             // Hold at centre
             var holdSub = new SubtitleLineViewModel(sub, generateNewId: true);
             holdSub.StartTime = sub.StartTime + TimeSpan.FromMilliseconds(slideMs);
             holdSub.EndTime = sub.EndTime - TimeSpan.FromMilliseconds(slideMs);
-            holdSub.Text = $"{{\\an2\\pos({cx},{cy})}}" + sub.Text;
+            holdSub.Text = $"{{\\an2\\pos({cx},{cy})}}" + text;
             result.Add(holdSub);
 
             // Slide out to right
             var outSub = new SubtitleLineViewModel(sub, generateNewId: true);
             outSub.StartTime = sub.EndTime - TimeSpan.FromMilliseconds(slideMs);
             outSub.EndTime = sub.EndTime;
-            outSub.Text = $"{{\\an2\\move({cx},{cy},{offscreenX},{cy},0,{slideMs})}}" + sub.Text;
+            outSub.Text = $"{{\\an2\\move({cx},{cy},{offscreenX},{cy},0,{slideMs})}}" + text;
             result.Add(outSub);
         }
 

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectSlowZoomIn.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectSlowZoomIn.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace Nikse.SubtitleEdit.Features.Assa.AssaApplyAdvancedEffect.Effects;
 
 /// <summary>
-/// Slow zoom-in: each subtitle starts at 100% scale and smoothly grows to 102%
+/// Slow zoom-in: each subtitle starts at 100% scale and smoothly grows to 110%
 /// over the full subtitle duration — a barely-noticeable creeping zoom.
 /// </summary>
 public class AdvancedEffectSlowZoomIn : IAdvancedEffectDisplay

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectSlowZoomOut.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectSlowZoomOut.cs
@@ -6,8 +6,8 @@ using System.Collections.Generic;
 namespace Nikse.SubtitleEdit.Features.Assa.AssaApplyAdvancedEffect.Effects;
 
 /// <summary>
-/// Slow zoom-out: each subtitle starts at a large scale (derived from the style font size)
-/// and smoothly eases down to 100% over the full subtitle duration.
+/// Slow zoom-out: each subtitle starts at 110% scale and smoothly eases down to 100%
+/// over the full subtitle duration.
 /// </summary>
 public class AdvancedEffectSlowZoomOut : IAdvancedEffectDisplay
 {

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectSnow.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectSnow.cs
@@ -33,13 +33,13 @@ public class AdvancedEffectSnow : IAdvancedEffectDisplay
         var globalEnd = subtitles.Max(s => s.EndTime);
         double totalVideoMs = (globalEnd - globalStart).TotalMilliseconds;
 
-        for (int i = 0; i < FlakeCount; i++)
+        for (int i = 0; i < FlakeCount && result.Count < AdvancedEffectUtil.MaxGeneratedEvents; i++)
         {
             // INITIAL DELAY: This creates the "start slow" effect.
             // Higher index flakes start much later in the video.
             double currentTimeMs = rng.Next(0, 5000) + (i * 20);
 
-            while (currentTimeMs < totalVideoMs)
+            while (currentTimeMs < totalVideoMs && result.Count < AdvancedEffectUtil.MaxGeneratedEvents)
             {
                 var flake = new SubtitleLineViewModel();
 
@@ -92,9 +92,9 @@ public class AdvancedEffectSnow : IAdvancedEffectDisplay
 
                 // GLOW: white border (\bord + \3c) blurred outward creates a soft luminous halo
                 string hexAlpha = alpha.ToString("X2");
-                string tags = $@"\\an5\\bord{glowBorder:F1}\\shad0\\3c&HFFFFFF&\\blur{glowBlur:F1}\\1c&HFFFFFF&\\alpha&H{hexAlpha}&\\fad(1200,1200)" +
-                              $@"\\fscx{size}\\fscy{size}\\frz{startRotation}\\t(0,{fallDuration},\\frz{endRotation})" +
-                              $@"\\move({startX},-50,{endX},{screenHeight + 50})";
+                string tags = $@"\an5\bord{AdvancedEffectUtil.Tag(glowBorder)}\shad0\3c&HFFFFFF&\blur{AdvancedEffectUtil.Tag(glowBlur)}\1c&HFFFFFF&\alpha&H{hexAlpha}&\fad(1200,1200)" +
+                              $@"\fscx{size}\fscy{size}\frz{startRotation}\t(0,{fallDuration},\frz{endRotation})" +
+                              $@"\move({startX},-50,{endX},{screenHeight + 50})";
 
                 flake.Text = "{" + tags + "}•";
                 result.Add(flake);
@@ -103,7 +103,7 @@ public class AdvancedEffectSnow : IAdvancedEffectDisplay
             }
         }
 
-        result.AddRange(subtitles);
+        result.AddRange(subtitles.Select(AdvancedEffectUtil.PassThrough));
         return result;
     }
 }

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectStarWarsScroll.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectStarWarsScroll.cs
@@ -64,11 +64,13 @@ public class AdvancedEffectStarWarsScroll : IAdvancedEffectDisplay
                 int yOffset = i * internalLineSpacing;
 
                 // THE TAGS
+                // 105 = 140 x 0.75: the 3-D squash folded into the start scale, since a
+                // second \fscy in the same block would simply override the first
                 string tags =
                     $@"\an5\b1\bord2\blur0.6\1c{swYellow}" +
-                    $@"\frx52\fscy75" +
+                    $@"\frx52" +
                     $@"\fad(1200,0)" +
-                    $@"\fscx140\fscy140" +
+                    $@"\fscx140\fscy105" +
                     $@"\move({centerX},{yStartBase + yOffset},{centerX},{yEndBase + yOffset},0,{(int)travelDurationMs})" +
 
                     // SCALE

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectStarfield.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectStarfield.cs
@@ -36,11 +36,15 @@ public class AdvancedEffectStarfield : IAdvancedEffectDisplay
         var globalEnd = subtitles.Max(s => s.EndTime);
         double totalMs = (globalEnd - globalStart).TotalMilliseconds;
 
+        // The UI binding can hand over a transient 0 (cleared spinner) or an out-of-range
+        // value while the preview timer is running - clamp before dividing
+        double speedMultiplier = Math.Clamp((double)SpeedMultiplier, 0.1, 10.0);
+
         for (int i = 0; i < StarCount; i++)
         {
             double startMs = rng.NextDouble() * totalMs;
             // INCREASED LIFESPAN: Ensures they stay on screen longer
-            int life = (int)(rng.Next(5000, 19000) / (double)SpeedMultiplier);
+            int life = (int)(rng.Next(5000, 19000) / speedMultiplier);
 
             var star = new SubtitleLineViewModel();
             star.StartTime = globalStart.Add(TimeSpan.FromMilliseconds(startMs));
@@ -68,26 +72,27 @@ public class AdvancedEffectStarfield : IAdvancedEffectDisplay
             int fadeOutStart = (int)(life * 0.8); // Start fading out at 80% of life
 
             // \fad(fadeIn, fadeOut) is the most reliable way to prevent "popping"
-            string tags = $@"\\p1\\an5\\bord0\\shad0\\blur1.8\\1c{color}\\move({startX},{startY},{endX},{endY})\\fad(800,800)";
+            string tags = $@"\p1\an5\bord0\shad0\blur1.8\1c{color}\move({startX},{startY},{endX},{endY})\fad(800,800)";
 
             // Initial setup
-            tags += $@"\\fscx{baseSize / 2}\\fscy{baseSize / 2}";
+            tags += $@"\fscx{baseSize / 2}\fscy{baseSize / 2}";
 
             // Growth over full life
-            tags += $@"\\t(0,{life},\\fscx{baseSize * 2.5}\\fscy{baseSize * 2.5})";
+            int grownSize = (int)Math.Round(baseSize * 2.5);
+            tags += $@"\t(0,{life},\fscx{grownSize}\fscy{grownSize})";
 
             // Twinkle (1 in 8)
             if (rng.Next(0, 8) == 0)
             {
                 int tStep = life / 5;
-                tags += $@"\\t({tStep},{tStep * 2},\\alpha&H66&)\\t({tStep * 2},{tStep * 3},\\alpha&H00&)";
+                tags += $@"\t({tStep},{tStep * 2},\alpha&H66&)\t({tStep * 2},{tStep * 3},\alpha&H00&)";
             }
 
             star.Text = "{" + tags + "}" + shape;
             result.Add(star);
         }
 
-        result.AddRange(subtitles);
+        result.AddRange(subtitles.Select(AdvancedEffectUtil.PassThrough));
         return result;
     }
 }

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectTvClose.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectTvClose.cs
@@ -44,7 +44,7 @@ public class AdvancedEffectTvClose : IAdvancedEffectDisplay
             result.Add(CreateBar(sub.StartTime, durationMs, halfMs, w, h,
                 startY: h, endY: halfH));
 
-            result.Add(sub);
+            result.Add(AdvancedEffectUtil.PassThrough(sub));
         }
 
         return result;

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectTypewriter.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectTypewriter.cs
@@ -27,7 +27,7 @@ public class AdvancedEffectTypewriter : IAdvancedEffectDisplay
             var cleanText = Utilities.RemoveSsaTags(subtitle.Text);
             if (string.IsNullOrEmpty(cleanText))
             {
-                result.Add(subtitle);
+                result.Add(AdvancedEffectUtil.PassThrough(subtitle));
                 continue;
             }
 

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectTypewriterWithHighlight.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectTypewriterWithHighlight.cs
@@ -24,7 +24,7 @@ public class AdvancedEffectTypewriterWithHighlight : IAdvancedEffectDisplay
             var cleanText = Utilities.RemoveSsaTags(subtitle.Text);
             if (string.IsNullOrEmpty(cleanText))
             {
-                result.Add(subtitle);
+                result.Add(AdvancedEffectUtil.PassThrough(subtitle));
                 continue;
             }
 

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectUtil.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectUtil.cs
@@ -1,0 +1,50 @@
+using Nikse.SubtitleEdit.Features.Main;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Nikse.SubtitleEdit.Features.Assa.AssaApplyAdvancedEffect.Effects;
+
+/// <summary>
+/// Shared helpers for the advanced effect generators.
+/// </summary>
+internal static class AdvancedEffectUtil
+{
+    /// <summary>
+    /// Safety cap for particle generators whose event count scales with the covered time
+    /// span (rain, snow, grain, ...). Keeps the 750 ms preview rebuild and the temp-file
+    /// serialization bounded when the effect is applied across a long subtitle file.
+    /// </summary>
+    public const int MaxGeneratedEvents = 20_000;
+
+    /// <summary>
+    /// Formats a fractional override tag value with an invariant decimal point. Tag
+    /// arguments must never use the current culture: a decimal comma both corrupts the
+    /// number and acts as an argument separator inside \t, \fad, \move, ...
+    /// </summary>
+    public static string Tag(double value) => value.ToString("0.##", CultureInfo.InvariantCulture);
+
+    /// <inheritdoc cref="Tag(double)"/>
+    public static string Tag(decimal value) => value.ToString("0.##", CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Clones a line that an effect passes through unchanged, so the returned list never
+    /// aliases the dialog's working set.
+    /// </summary>
+    public static SubtitleLineViewModel PassThrough(SubtitleLineViewModel sub) => new(sub, generateNewId: true);
+
+    private static readonly Regex PositionTagRegex = new(@"\\(?:pos|move)\([^)]*\)|\\an\d|\\a\d+", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Strips positioning override tags (\pos, \move, \an, \a) from a line's text so an
+    /// effect can apply its own positioning without emitting conflicting tags.
+    /// </summary>
+    public static string RemovePositionTags(string text)
+    {
+        if (string.IsNullOrEmpty(text) || !text.Contains('\\'))
+        {
+            return text;
+        }
+
+        return PositionTagRegex.Replace(text, string.Empty).Replace("{}", string.Empty);
+    }
+}

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectWave.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectWave.cs
@@ -12,6 +12,9 @@ public class AdvancedEffectWave : IAdvancedEffectDisplay
     public string Description => Se.Language.Assa.AdvancedEffectWaveDescription;
     public bool UsesAudio => false;
 
+    private static readonly System.Text.RegularExpressions.Regex TagOrTextRegex =
+        new(@"(\{.*?\})|([^{]+)", System.Text.RegularExpressions.RegexOptions.Compiled);
+
     public override string ToString() => Name;
 
     public List<SubtitleLineViewModel> ApplyEffect(string header, List<SubtitleLineViewModel> subtitles, int width, int height, WavePeakData2? wavePeaks)
@@ -20,7 +23,7 @@ public class AdvancedEffectWave : IAdvancedEffectDisplay
 
         foreach (var sub in subtitles)
         {
-            var matches = System.Text.RegularExpressions.Regex.Matches(sub.Text, @"(\{.*?\})|([^{]+)");
+            var matches = TagOrTextRegex.Matches(sub.Text);
             var fullParts = new List<(string Content, bool IsTag)>();
             foreach (System.Text.RegularExpressions.Match m in matches)
                 fullParts.Add((m.Value, m.Value.StartsWith("{")));
@@ -29,7 +32,17 @@ public class AdvancedEffectWave : IAdvancedEffectDisplay
             for (int p = 0; p < fullParts.Count; p++)
                 if (!fullParts[p].IsTag)
                     for (int c = 0; c < fullParts[p].Content.Length; c++)
-                        visibleChars.Add((fullParts[p].Content[c], p, c));
+                    {
+                        var content = fullParts[p].Content;
+                        if (content[c] == '\\' && c + 1 < content.Length && content[c + 1] is 'N' or 'n' or 'h')
+                        {
+                            // Inline \N/\n/\h stays intact in the rebuilt text but must never
+                            // be animated as if it were two visible glyphs
+                            c++;
+                            continue;
+                        }
+                        visibleChars.Add((content[c], p, c));
+                    }
 
             double totalMs = sub.Duration.TotalMilliseconds;
 
@@ -37,6 +50,8 @@ public class AdvancedEffectWave : IAdvancedEffectDisplay
             int waveSpeed = 200; // Time per "step" in the wave
             double waveFrequency = 0.4; // How many letters are "up" at once
 
+            int generated = 0;
+            var waveTransforms = new System.Text.StringBuilder();
             for (int i = 0; i < visibleChars.Count; i++)
             {
                 var target = visibleChars[i];
@@ -47,7 +62,7 @@ public class AdvancedEffectWave : IAdvancedEffectDisplay
 
                 var charLine = new SubtitleLineViewModel(sub, generateNewId: true);
 
-                string waveTransforms = "";
+                waveTransforms.Clear();
                 // We create a rolling loop for the duration of the line
                 for (int time = 0; time < totalMs; time += waveSpeed)
                 {
@@ -59,7 +74,7 @@ public class AdvancedEffectWave : IAdvancedEffectDisplay
                     // Map that to scale: 100% (flat) to 160% (peak)
                     int currentScale = 100 + (int)((heightFactor + 1) * 30);
 
-                    waveTransforms += $@" \t({time},{time + waveSpeed},\fscy{currentScale})";
+                    waveTransforms.Append($@"\t({time},{time + waveSpeed},\fscy{currentScale})");
                 }
 
                 var finalString = new System.Text.StringBuilder();
@@ -74,7 +89,7 @@ public class AdvancedEffectWave : IAdvancedEffectDisplay
                         string partText = fullParts[p].Content;
                         // Force \an2 (bottom center) so the letters grow UPWARDS from the ground
                         finalString.Append(@"{\alpha&HFF&}").Append(partText.Substring(0, target.CharIndex))
-                                   .Append(@"{\alpha&H00&" + waveTransforms + "}").Append(target.Character)
+                                   .Append(@"{\alpha&H00&").Append(waveTransforms).Append('}').Append(target.Character)
                                    .Append(@"{\alpha&HFF&}").Append(partText.Substring(target.CharIndex + 1));
                     }
                     else
@@ -85,6 +100,13 @@ public class AdvancedEffectWave : IAdvancedEffectDisplay
 
                 charLine.Text = finalString.ToString();
                 result.Add(charLine);
+                generated++;
+            }
+
+            if (generated == 0)
+            {
+                // Nothing to animate (empty/whitespace-only line) - keep the line as-is
+                result.Add(AdvancedEffectUtil.PassThrough(sub));
             }
         }
         return result;

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectWaveBlue.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectWaveBlue.cs
@@ -12,6 +12,9 @@ public class AdvancedEffectWaveBlue : IAdvancedEffectDisplay
     public string Description => Se.Language.Assa.AdvancedEffectWaveBlueDescription;
     public bool UsesAudio => false;
 
+    private static readonly System.Text.RegularExpressions.Regex TagOrTextRegex =
+        new(@"(\{.*?\})|([^{]+)", System.Text.RegularExpressions.RegexOptions.Compiled);
+
     public override string ToString() => Name;
 
     public List<SubtitleLineViewModel> ApplyEffect(string header, List<SubtitleLineViewModel> subtitles, int width, int height, WavePeakData2? wavePeaks)
@@ -20,7 +23,7 @@ public class AdvancedEffectWaveBlue : IAdvancedEffectDisplay
 
         foreach (var sub in subtitles)
         {
-            var matches = System.Text.RegularExpressions.Regex.Matches(sub.Text, @"(\{.*?\})|([^{]+)");
+            var matches = TagOrTextRegex.Matches(sub.Text);
             var fullParts = new List<(string Content, bool IsTag)>();
             foreach (System.Text.RegularExpressions.Match m in matches)
                 fullParts.Add((m.Value, m.Value.StartsWith("{")));
@@ -29,12 +32,24 @@ public class AdvancedEffectWaveBlue : IAdvancedEffectDisplay
             for (int p = 0; p < fullParts.Count; p++)
                 if (!fullParts[p].IsTag)
                     for (int c = 0; c < fullParts[p].Content.Length; c++)
-                        visibleChars.Add((fullParts[p].Content[c], p, c));
+                    {
+                        var content = fullParts[p].Content;
+                        if (content[c] == '\\' && c + 1 < content.Length && content[c + 1] is 'N' or 'n' or 'h')
+                        {
+                            // Inline \N/\n/\h stays intact in the rebuilt text but must never
+                            // be animated as if it were two visible glyphs
+                            c++;
+                            continue;
+                        }
+                        visibleChars.Add((content[c], p, c));
+                    }
 
             double totalMs = sub.Duration.TotalMilliseconds;
             int waveSpeed = 150; // Faster updates = smoother motion
             double waveFrequency = 0.5; // Distance between peaks
 
+            int generated = 0;
+            var oceanTransforms = new System.Text.StringBuilder();
             for (int i = 0; i < visibleChars.Count; i++)
             {
                 var target = visibleChars[i];
@@ -44,7 +59,7 @@ public class AdvancedEffectWaveBlue : IAdvancedEffectDisplay
                 }
 
                 var charLine = new SubtitleLineViewModel(sub, generateNewId: true);
-                string oceanTransforms = "";
+                oceanTransforms.Clear();
 
                 for (int time = 0; time < totalMs; time += waveSpeed)
                 {
@@ -63,7 +78,7 @@ public class AdvancedEffectWaveBlue : IAdvancedEffectDisplay
                     // 3. BLUR: Add a "glow" only at the peaks
                     int blurValue = (sineValue > 0.7) ? 4 : 1;
 
-                    oceanTransforms += $@" \t({time},{time + waveSpeed},\fscy{heightScale}\1c{currentColor}\blur{blurValue})";
+                    oceanTransforms.Append($@"\t({time},{time + waveSpeed},\fscy{heightScale}\1c{currentColor}\blur{blurValue})");
                 }
 
                 var finalString = new System.Text.StringBuilder();
@@ -78,7 +93,7 @@ public class AdvancedEffectWaveBlue : IAdvancedEffectDisplay
                         string partText = fullParts[p].Content;
                         // Initial State: Deep Blue, Bottom-Anchored
                         finalString.Append(@"{\alpha&HFF&}").Append(partText.Substring(0, target.CharIndex))
-                                   .Append(@"{\alpha&H00&\1c&HFF8800&" + oceanTransforms + "}").Append(target.Character)
+                                   .Append(@"{\alpha&H00&\1c&HFF8800&").Append(oceanTransforms).Append('}').Append(target.Character)
                                    .Append(@"{\alpha&HFF&}").Append(partText.Substring(target.CharIndex + 1));
                     }
                     else
@@ -89,6 +104,13 @@ public class AdvancedEffectWaveBlue : IAdvancedEffectDisplay
 
                 charLine.Text = finalString.ToString();
                 result.Add(charLine);
+                generated++;
+            }
+
+            if (generated == 0)
+            {
+                // Nothing to animate (empty/whitespace-only line) - keep the line as-is
+                result.Add(AdvancedEffectUtil.PassThrough(sub));
             }
         }
         return result;

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectWordByWord.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectWordByWord.cs
@@ -30,14 +30,14 @@ public class AdvancedEffectWordByWord : IAdvancedEffectDisplay
 
             if (string.IsNullOrWhiteSpace(cleanText))
             {
-                result.Add(subtitle);
+                result.Add(AdvancedEffectUtil.PassThrough(subtitle));
                 continue;
             }
 
             var words = cleanText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
             if (words.Length <= 1)
             {
-                result.Add(subtitle);
+                result.Add(AdvancedEffectUtil.PassThrough(subtitle));
                 continue;
             }
 

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectWordSpacing.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/Effects/AdvancedEffectWordSpacing.cs
@@ -60,7 +60,7 @@ public class AdvancedEffectWordSpacing : IAdvancedEffectDisplay
             else if (c == ' ' && !insideTags)
             {
                 // Replace space with tagged space using \fsp
-                result.Append($"{{\\fsp{SpacingPixels}}} {{\\fsp0}}");
+                result.Append($"{{\\fsp{AdvancedEffectUtil.Tag(SpacingPixels)}}} {{\\fsp0}}");
             }
             else
             {

--- a/tests/UI/Features/Assa/AdvancedEffectTests.cs
+++ b/tests/UI/Features/Assa/AdvancedEffectTests.cs
@@ -1,0 +1,216 @@
+using Nikse.SubtitleEdit.Features.Assa.AssaApplyAdvancedEffect.Effects;
+using Nikse.SubtitleEdit.Features.Main;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace UITests.Features.Assa;
+
+/// <summary>
+/// Regression tests for the advanced ASSA effect generators.
+/// </summary>
+public class AdvancedEffectTests
+{
+    private static SubtitleLineViewModel MakeLine(string text, double startMs = 0, double durationMs = 2000)
+    {
+        return new SubtitleLineViewModel
+        {
+            Text = text,
+            StartTime = TimeSpan.FromMilliseconds(startMs),
+            EndTime = TimeSpan.FromMilliseconds(startMs + durationMs),
+        };
+    }
+
+    /// <summary>
+    /// An unmatched '{' used to stall BuildSegments forever (neither the tag loop nor the
+    /// plain-text scan advanced), hanging the preview's background rebuild and OK.
+    /// </summary>
+    [Fact]
+    public void FancyKaraoke_UnmatchedBrace_Terminates()
+    {
+        var effect = new AdvancedEffectFancyKaraoke { AutoDetectActiveWord = false };
+        var result = effect.ApplyEffect(string.Empty, [MakeLine("Hello {world")], 1280, 720, null);
+
+        Assert.Single(result);
+        Assert.Contains("Hello", result[0].Text);
+    }
+
+    /// <summary>
+    /// A \move copied verbatim into each auto-sequenced word-line restarts the motion at
+    /// every word boundary; it must be rewritten to one continuous motion instead.
+    /// </summary>
+    [Fact]
+    public void FancyKaraoke_AutoSequence_RewritesMovePerWordLine()
+    {
+        var effect = new AdvancedEffectFancyKaraoke { AutoDetectActiveWord = true };
+        var result = effect.ApplyEffect(string.Empty, [MakeLine(@"{\move(0,0,100,100)}a b")], 1280, 720, null);
+
+        Assert.Equal(2, result.Count);
+        Assert.Contains(@"\move(0,0,50,50,0,1000)", result[0].Text);
+        Assert.Contains(@"\move(50,50,100,100,0,1000)", result[1].Text);
+    }
+
+    /// <summary>
+    /// Override tag arguments must be culture-invariant: under a comma-decimal locale a
+    /// fractional value interpolated with the current culture corrupts the tag.
+    /// </summary>
+    [Fact]
+    public void WordSpacing_FractionalSpacing_IsCultureInvariant()
+    {
+        var previous = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("da-DK");
+            var effect = new AdvancedEffectWordSpacing { SpacingPixels = 12.5m };
+            var result = effect.ApplyEffect(string.Empty, [MakeLine("a b")], 1280, 720, null);
+
+            Assert.Contains(@"{\fsp12.5}", result[0].Text);
+            Assert.DoesNotContain("12,5", result[0].Text);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+    }
+
+    /// <inheritdoc cref="WordSpacing_FractionalSpacing_IsCultureInvariant"/>
+    [Fact]
+    public void AudioTextPulse_FractionalBorder_IsCultureInvariant()
+    {
+        var previous = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("da-DK");
+            var effect = new AdvancedEffectAudioTextPulse();
+            var result = effect.ApplyEffect(string.Empty, [MakeLine("Hello", durationMs: 100)], 1280, 720, null);
+
+            // With no wave data the amplitude is 0, so every frame gets the resting border 1.5
+            Assert.NotEmpty(result);
+            Assert.All(result, line => Assert.Contains(@"\bord1.5", line.Text));
+            Assert.All(result, line => Assert.DoesNotContain("1,5", line.Text));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+    }
+
+    /// <summary>
+    /// The fade duration is emitted as a rounded integer - a fractional line duration must
+    /// not leak a decimal point (or comma) into \fad.
+    /// </summary>
+    [Fact]
+    public void FadeIn_FractionalDuration_EmitsIntegerFad()
+    {
+        var effect = new AdvancedEffectFadeIn();
+        var result = effect.ApplyEffect(string.Empty, [MakeLine("Hello", durationMs: 1500.5)], 1280, 720, null);
+
+        var overlay = result[0];
+        Assert.Contains(@"\fad(0,1500)", overlay.Text);
+    }
+
+    /// <summary>
+    /// Character stagger used to be computed from the raw char index (including spaces), so
+    /// long lines produced events starting after the subtitle already ended.
+    /// </summary>
+    [Fact]
+    public void BounceIn_LongLine_NeverStartsAfterLineEnd()
+    {
+        var text = string.Join(" ", Enumerable.Repeat("word", 25)); // 124 chars, 100 visible
+        var effect = new AdvancedEffectBounceIn();
+        var result = effect.ApplyEffect(string.Empty, [MakeLine(text, durationMs: 1000)], 1280, 720, null);
+
+        Assert.All(result, line => Assert.True(line.StartTime < line.EndTime));
+    }
+
+    /// <summary>
+    /// Effects must never put the caller's live view-model instances into the returned
+    /// list - pass-through lines have to be clones.
+    /// </summary>
+    [Fact]
+    public void Karaoke_EmptyLine_PassesThroughAsClone()
+    {
+        var source = MakeLine(string.Empty);
+        var effect = new AdvancedEffectKaraoke();
+        var result = effect.ApplyEffect(string.Empty, [source], 1280, 720, null);
+
+        Assert.Single(result);
+        Assert.NotSame(source, result[0]);
+        Assert.NotEqual(source.Id, result[0].Id);
+    }
+
+    /// <summary>
+    /// The per-drop advance has a floor now; a long span must terminate and respect the
+    /// generator's global event cap.
+    /// </summary>
+    [Fact]
+    public void Rain_LongSpan_IsCappedAndTerminates()
+    {
+        var lines = new List<SubtitleLineViewModel>
+        {
+            MakeLine("a", startMs: 0),
+            MakeLine("b", startMs: 3_600_000 - 2000),
+        };
+        var effect = new AdvancedEffectRain();
+        var result = effect.ApplyEffect(string.Empty, lines, 1280, 720, null);
+
+        Assert.True(result.Count <= AdvancedEffectUtil.MaxGeneratedEvents + lines.Count);
+    }
+
+    /// <summary>
+    /// The vignette's inner rectangle must be wound opposite to the outer one so the fill
+    /// rule cuts a hole; same-direction winding filled (and dimmed) the entire screen.
+    /// </summary>
+    [Fact]
+    public void OldMovie_VignetteInnerContour_IsReverseWound()
+    {
+        var effect = new AdvancedEffectOldMovie();
+        var result = effect.ApplyEffect(string.Empty, [MakeLine("Hello")], 1280, 720, null);
+
+        var vignette = result.First(l => l.Text.Contains(@"\be90"));
+        // Inner contour runs top-left -> bottom-left (counter-clockwise), unlike the outer
+        Assert.Contains("m 180 180 l 180 540", vignette.Text);
+    }
+
+    /// <summary>
+    /// The two neon layers overlap in time at the same position; they must sit on distinct
+    /// ASSA layers or libass collision avoidance stacks them vertically.
+    /// </summary>
+    [Fact]
+    public void NeonBurst_GlowAndCore_GetDistinctLayers()
+    {
+        var effect = new AdvancedEffectNeonBurst();
+        var result = effect.ApplyEffect(string.Empty, [MakeLine("Hello")], 1280, 720, null);
+
+        Assert.Equal(2, result.Count);
+        Assert.NotEqual(result[0].Layer, result[1].Layer);
+    }
+
+    /// <summary>
+    /// A literal \N must survive the wave effect intact - it used to be split into a stray
+    /// animated backslash glyph plus a plain 'N', destroying the line break.
+    /// </summary>
+    [Fact]
+    public void Wave_InlineLineBreak_IsPreserved()
+    {
+        var effect = new AdvancedEffectWave();
+        var result = effect.ApplyEffect(string.Empty, [MakeLine(@"ab\Ncd")], 1280, 720, null);
+
+        Assert.Equal(4, result.Count); // one line per visible char; \N is not a char
+        Assert.All(result, line => Assert.Contains(@"\N", line.Text));
+    }
+
+    /// <summary>
+    /// Hearts pre-roll starts before the subtitle; near t=0 that must clamp to zero instead
+    /// of emitting negative timestamps.
+    /// </summary>
+    [Fact]
+    public void Hearts_NearZeroStart_HasNoNegativeTimestamps()
+    {
+        var effect = new AdvancedEffectHearts();
+        var result = effect.ApplyEffect(string.Empty, [MakeLine("Hello", startMs: 300, durationMs: 4000)], 1280, 720, null);
+
+        Assert.All(result, line => Assert.True(line.StartTime >= TimeSpan.Zero));
+    }
+}


### PR DESCRIPTION
Bug-hunt sweep over the "Apply advanced effects" dialog and all 32 effect generators, followed by a cleanup/perf pass. Build is green with 0 warnings; 12 new regression tests pass.

## Crashes / hangs
- **FancyKaraoke infinite loop**: text with an unmatched `{` (e.g. `Hello {world`) stalled `BuildSegments` forever — the 750 ms preview rebuild pegged a core and OK hung the UI thread.
- **"Play current" crash**: with no paragraph selected the `<= 0` branch was missing a `return` and fell through to `Paragraphs[-1]`; index 0 also double-played.
- **Fireflies** threw `ArgumentOutOfRangeException` on videos smaller than ~80 px.
- **Unbounded generation**: Rain's random time step could round to ~0 ms (millions of events), and the Rain/Snow/Fireflies/OldMovie/Matrix particle loops scaled unbounded with the covered span (movie-length selections → 1–2M events rebuilt every 750 ms). All particle generators now share a 20k event cap and Rain's step has a floor.

## Locale corruption
The app never forces invariant culture, so every fractional tag value formatted with `:F1`/interpolation broke under comma-decimal locales (`\bord2,3`, `\fad(0,2000,5)`, `\fax0,25`, `\fsp12,5`, …) — the comma both corrupts the number and acts as an argument separator. Fixed in AudioTextPulse, Fireflies, Glitch, Hearts, Matrix, Rain, Snow, Starfield, WordSpacing, FadeIn and FadeOut via a new shared `AdvancedEffectUtil.Tag()`.

## Wrong ASSA semantics
- **FadeOut** emitted `\layer10`, which is not an override tag (Layer is a Dialogue-line field) — the intended above-the-text z-order silently did nothing; now set on the event.
- **NeonBurst / RainbowPulse collision stacking**: overlapping unpositioned events on the same layer trigger libass collision avoidance, so the glow rendered *beside* the core and RainbowPulse stacked one row per character. Overlays now get distinct `Layer` values. NeonBurst also kept losing the line's style/actor/margins (bare view models).
- **OldMovie vignette**: both drawing contours were wound clockwise, so the fill rule never cut the hole and the whole frame was dimmed for the entire duration.
- **Snow/Starfield/Rain**: verbatim strings with `\\` emitted literal double backslashes in every override tag.
- **StarWarsScroll**: the 3-D squash `\fscy75` was immediately overridden by `\fscy140`; folded into `\fscx140\fscy105`.
- **FancyKaraoke**: a source `\move` copied verbatim into every auto-sequenced word line restarted the motion at each word boundary; it is now rewritten per segment (interpolated endpoints, clamped times) so the motion continues seamlessly.

## Timing
- **BounceIn** staggered by raw char index (spaces included), so long lines emitted events starting after the subtitle ended; placeholders also inherited the bounce scale animation, making the whole line pulse.
- **Hearts / Matrix** pre-roll produced negative timestamps for subtitles near t=0.
- **Matrix** resting text vanished after a stray 2 s cap (contradicting its own comment) and produced inverted times on overlapping lines.
- **Wave/WaveBlue** split a literal `\N` into a stray animated backslash glyph plus `N`, destroying the line break.
- Zero-duration or empty lines silently disappeared from AudioTextPulse/Glitch/RainbowPulse/Wave output; all pass through now.

## Dialog
- Stable sort in `BuildPreviewSubtitle` (`List.Sort` is unstable; same-start overlay/text pairs — which TvClose explicitly relies on — could swap z-order).
- Selecting the first line in the combo now seeks the video; removing audio effects no longer leaves a dangling selection; effects never return the caller's live view models (pass-throughs are clones); slide effects strip conflicting `\pos`/`\move`/`\an` and got dimension fallbacks.

## Cleanup / perf
Shared `AdvancedEffectUtil` (invariant formatting, pass-through clone, event cap, position-tag strip), hot-path regexes hoisted to compiled statics, `StringBuilder` reuse instead of O(n²) string concat in per-character transform loops, stale doc comments fixed.

## Open question
Karaoke/FancyKaraoke `RightToLeft` (added for #12271) may run the highlight temporally backwards for real RTL text — libass applies bidi to logical order, so the default reveal already progresses visually right-to-left. Left unchanged; worth checking with a Hebrew/Arabic sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)