### PR TITLE
Update Netflix checks to the current Timed Text Style Guides

### DIFF
--- a/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsViewModel.cs
@@ -58,6 +58,8 @@ public partial class FixNetflixErrorsViewModel : ObservableObject
     [ObservableProperty] private FixNetflixErrorsItem? _selectedFix;
     [ObservableProperty] private string _fixText;
     [ObservableProperty] private bool _fixTextEnabled;
+    [ObservableProperty] private bool _isChildrenProgram;
+    [ObservableProperty] private bool _isSdh;
 
     // New: selectable list of Netflix checks
     [ObservableProperty] private ObservableCollection<NetflixCheckDisplayItem> _checks = new();
@@ -122,6 +124,8 @@ public partial class FixNetflixErrorsViewModel : ObservableObject
 
     private void LoadSettings()
     {
+        IsChildrenProgram = Se.Settings.Tools.FixNetflixErrors.IsChildrenProgram;
+        IsSdh = Se.Settings.Tools.FixNetflixErrors.IsSdh;
     }
 
     private void SaveSettings()
@@ -130,6 +134,8 @@ public partial class FixNetflixErrorsViewModel : ObservableObject
             .Where(c => c.IsSelected)
             .Select(c => c.Checker.GetType().Name)
             .ToList();
+        Se.Settings.Tools.FixNetflixErrors.IsChildrenProgram = IsChildrenProgram;
+        Se.Settings.Tools.FixNetflixErrors.IsSdh = IsSdh;
         Se.SaveSettings();
     }
 
@@ -258,6 +264,9 @@ public partial class FixNetflixErrorsViewModel : ObservableObject
         {
             Language = SelectedLanguage?.Code ?? "en",
             FrameRate = (double)(_mediaInfo?.FramesRate ?? (decimal)Configuration.Settings.General.CurrentFrameRate),
+            VideoFileName = _videoFileName,
+            IsChildrenProgram = IsChildrenProgram,
+            IsSDH = IsSdh,
         };
 
         controller.RunChecks(_subtitle, selectedChecks);
@@ -317,6 +326,16 @@ public partial class FixNetflixErrorsViewModel : ObservableObject
     }
 
     partial void OnSelectedLanguageChanged(LanguageItem? value)
+    {
+        SetDirty();
+    }
+
+    partial void OnIsChildrenProgramChanged(bool value)
+    {
+        SetDirty();
+    }
+
+    partial void OnIsSdhChanged(bool value)
     {
         SetDirty();
     }

--- a/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsWindow.cs
@@ -95,16 +95,31 @@ public class FixNetflixErrorsWindow : Window
     private Border MakeSettingsView(FixNetflixErrorsViewModel vm)
     {
         _comboBoxLanguage = UiUtil.MakeComboBox(vm.Languages, vm, nameof(vm.SelectedLanguage));
-        var panelTop = new StackPanel
+        var panelLanguage = new StackPanel
         {
             Orientation = Orientation.Horizontal,
             VerticalAlignment = VerticalAlignment.Center,
             HorizontalAlignment = HorizontalAlignment.Left,
-            Margin = new Thickness(8),
             Children =
             {
                 UiUtil.MakeTextBlock(Se.Language.General.Language).WithMarginRight(5),
                 _comboBoxLanguage
+            }
+        };
+
+        // Netflix allows higher reading speeds for SDH and requires lower ones for
+        // children's programs, so both change which limits the checks run against.
+        var panelTop = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Margin = new Thickness(8),
+            Spacing = 4,
+            Children =
+            {
+                panelLanguage,
+                UiUtil.MakeCheckBox(Se.Language.Tools.NetflixCheckAndFix.ChildrensProgram, vm, nameof(vm.IsChildrenProgram)),
+                UiUtil.MakeCheckBox(Se.Language.Tools.NetflixCheckAndFix.Sdh, vm, nameof(vm.IsSdh)),
             }
         };
 

--- a/src/ui/Logic/Config/Language/Tools/LanguageNetflixCheckAndFix.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageNetflixCheckAndFix.cs
@@ -23,6 +23,8 @@ public class LanguageNetflixCheckAndFix
     public string TextforHiUseBrackets { get; set; }
     public string TwoFrameGrap { get; set; }
     public string WhiteSpace { get; set; }
+    public string ChildrensProgram { get; set; }
+    public string Sdh { get; set; }
 
     // Checker comment strings
     public string GlyphCheckReport { get; set; }
@@ -83,6 +85,8 @@ public class LanguageNetflixCheckAndFix
         TextforHiUseBrackets = "Text for HI, use brackets";
         TwoFrameGrap = "Two frame gap";
         WhiteSpace = "White space";
+        ChildrensProgram = "Children's program";
+        Sdh = "SDH (deaf/hard of hearing)";
 
         // Checker comment strings
         GlyphCheckReport = "Invalid character {0} found at column {1}";

--- a/src/ui/Logic/Config/SeFixNetflixErrors.cs
+++ b/src/ui/Logic/Config/SeFixNetflixErrors.cs
@@ -5,4 +5,6 @@ namespace Nikse.SubtitleEdit.Logic.Config;
 public class SeFixNetflixErrors
 {
     public List<string> SelectedRules { get; set; } = new();
+    public bool IsChildrenProgram { get; set; }
+    public bool IsSdh { get; set; }
 }

--- a/src/ui/Logic/NetflixQualityCheck/NetflixCheckMaxCps.cs
+++ b/src/ui/Logic/NetflixQualityCheck/NetflixCheckMaxCps.cs
@@ -40,13 +40,12 @@ public class NetflixCheckMaxCps : INetflixQualityChecker
             var charactersPerSeconds = jp.GetCharactersPerSecond(calc);
             if (charactersPerSeconds > charactersPerSecond && !p.StartTime.IsMaxTime)
             {
+                // Count with the same calculator used for the check above, so the new duration
+                // actually lands on the Netflix limit for this language.
+                var numberOfCharacters = (double)calc.CountCharacters(jp.Text, true);
+                var maxDurationMilliseconds = numberOfCharacters / charactersPerSecond * 1000.0;
                 var fixedParagraph = new Paragraph(p, false);
-                if (fixedParagraph.GetCharactersPerSecond() > charactersPerSecond)
-                {
-                    var numberOfCharacters = (double)p.Text.CountCharacters(true);
-                    var maxDurationMilliseconds = numberOfCharacters / Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds * 1000.0;
-                    fixedParagraph.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + maxDurationMilliseconds;
-                }
+                fixedParagraph.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + maxDurationMilliseconds;
 
                 controller.AddRecord(p, fixedParagraph, comment, FormattableString.Invariant($"CPS={charactersPerSeconds:0.##}"), true);
             }

--- a/src/ui/Logic/NetflixQualityCheck/NetflixCheckNumbersOneToTenSpellOut.cs
+++ b/src/ui/Logic/NetflixQualityCheck/NetflixCheckNumbersOneToTenSpellOut.cs
@@ -80,7 +80,7 @@ public class NetflixCheckNumbersOneToTenSpellOut : INetflixQualityChecker
 
                 if (ok)
                 {
-                    newText = newText.Remove(m.Index, 2).Insert(m.Index, "ten");
+                    newText = newText.Remove(m.Index, 2).Insert(m.Index, NetflixHelper.ConvertNumberToString(m.Value, false, controller.Language));
                 }
 
                 m = NumberTen.Match(newText, m.Index + 1);

--- a/src/ui/Logic/NetflixQualityCheck/NetflixCheckShotChange.cs
+++ b/src/ui/Logic/NetflixQualityCheck/NetflixCheckShotChange.cs
@@ -45,9 +45,6 @@ public class NetflixCheckShotChange : INetflixQualityChecker
 
         foreach (Paragraph p in subtitle.Paragraphs)
         {
-            var fixedParagraph = new Paragraph(p, false);
-            string comment = string.Empty;
-
             // These frame values are invariant across all shot changes - compute once per paragraph
             // instead of recomputing inside every Where/FirstOrDefault predicate.
             var startFrame = SubtitleFormat.MillisecondsToFrames(p.StartTime.TotalMilliseconds);
@@ -65,8 +62,9 @@ public class NetflixCheckShotChange : INetflixQualityChecker
                 var gapToShotChange = SubtitleFormat.MillisecondsToFrames(p.StartTime.TotalMilliseconds - nearestStartPrevShotChange * 1000);
                 if (gapToShotChange != 0 && gapToShotChange < halfSecGapInFrames)
                 {
+                    var fixedParagraph = new Paragraph(p, false);
                     fixedParagraph.StartTime.TotalMilliseconds = nearestStartPrevShotChange * 1000;
-                    comment = string.Format(Se.Language.Tools.NetflixCheckAndFix.ShotChangeInCueWithinXFramesAfterSnap, halfSecGapInFrames);
+                    var comment = string.Format(Se.Language.Tools.NetflixCheckAndFix.ShotChangeInCueWithinXFramesAfterSnap, halfSecGapInFrames);
                     controller.AddRecord(p, fixedParagraph, comment, string.Empty, true);
                 }
             }
@@ -78,7 +76,9 @@ public class NetflixCheckShotChange : INetflixQualityChecker
                 var threshold = (int)Math.Round(halfSecGapInFrames * 0.75, MidpointRounding.AwayFromZero);
                 if (gapToShotChange != 0 && gapToShotChange < halfSecGapInFrames)
                 {
-                    var canBeFixed = false;  
+                    var fixedParagraph = new Paragraph(p, false);
+                    string comment;
+                    var canBeFixed = false;
                     if (gapToShotChange < threshold)
                     {
                         fixedParagraph.StartTime.TotalMilliseconds = nearestStartNextShotChange * 1000;
@@ -100,8 +100,9 @@ public class NetflixCheckShotChange : INetflixQualityChecker
                 double nearestEndPrevShotChange = previousEndShotChanges.Aggregate((x, y) => Math.Abs(x - p.EndTime.TotalSeconds) < Math.Abs(y - p.EndTime.TotalSeconds) ? x : y);
                 if (SubtitleFormat.MillisecondsToFrames(p.EndTime.TotalMilliseconds - nearestEndPrevShotChange * 1000) < halfSecGapInFrames)
                 {
+                    var fixedParagraph = new Paragraph(p, false);
                     fixedParagraph.EndTime.TotalMilliseconds = nearestEndPrevShotChange * 1000 - twoFramesGap;
-                    comment = string.Format(Se.Language.Tools.NetflixCheckAndFix.ShotChangeOutCueWithinXFramesAfterChange, halfSecGapInFrames);
+                    var comment = string.Format(Se.Language.Tools.NetflixCheckAndFix.ShotChangeOutCueWithinXFramesAfterChange, halfSecGapInFrames);
                     controller.AddRecord(p, fixedParagraph, comment, string.Empty, true);
                 }
             }
@@ -109,19 +110,25 @@ public class NetflixCheckShotChange : INetflixQualityChecker
             if (nextEndShotChanges.Count > 0)
             {
                 double nearestEndNextShotChange = nextEndShotChanges.Aggregate((x, y) => Math.Abs(x - p.EndTime.TotalSeconds) < Math.Abs(y - p.EndTime.TotalSeconds) ? x : y);
-                if (SubtitleFormat.MillisecondsToFrames(nearestEndNextShotChange * 1000 - p.EndTime.TotalMilliseconds) < halfSecGapInFrames &&
-                    SubtitleFormat.MillisecondsToFrames(nearestEndNextShotChange * 1000 - p.EndTime.TotalMilliseconds) < 2)
+                // "If an out-time is within half a second of the last frame before the shot change,
+                // extend the out-time to the shot change, respecting the two-frame gap from the shot
+                // change." An out-cue already sitting on the two-frame gap is what we would move it
+                // to, so it is not an issue.
+                var framesToShotChange = SubtitleFormat.MillisecondsToFrames(nearestEndNextShotChange * 1000 - p.EndTime.TotalMilliseconds);
+                if (framesToShotChange < halfSecGapInFrames && framesToShotChange != 2)
                 {
+                    var fixedParagraph = new Paragraph(p, false);
                     fixedParagraph.EndTime.TotalMilliseconds = nearestEndNextShotChange * 1000 - twoFramesGap;
-                    comment = string.Format(Se.Language.Tools.NetflixCheckAndFix.ShotChangeOutCueWithinXFramesOfChange, halfSecGapInFrames);
+                    var comment = string.Format(Se.Language.Tools.NetflixCheckAndFix.ShotChangeOutCueWithinXFramesOfChange, halfSecGapInFrames);
                     controller.AddRecord(p, fixedParagraph, comment, string.Empty, true);
                 }
             }
 
             if (onShotChange > 0)
             {
+                var fixedParagraph = new Paragraph(p, false);
                 fixedParagraph.EndTime.TotalMilliseconds = onShotChange * 1000 - twoFramesGap;
-                comment = Se.Language.Tools.NetflixCheckAndFix.ShotChangeOutCueOnShotChange;
+                var comment = Se.Language.Tools.NetflixCheckAndFix.ShotChangeOutCueOnShotChange;
                 controller.AddRecord(p, fixedParagraph, comment, string.Empty, true);
             }
         }

--- a/src/ui/Logic/NetflixQualityCheck/NetflixCheckTextForHiUseBrackets.cs
+++ b/src/ui/Logic/NetflixQualityCheck/NetflixCheckTextForHiUseBrackets.cs
@@ -18,7 +18,7 @@ public class NetflixCheckTextForHiUseBrackets : INetflixQualityChecker
 
     public void Check(Subtitle subtitle, NetflixQualityController controller)
     {
-        if (controller.Language == "jp")
+        if (controller.Language == "ja")
         {
             return;
         }

--- a/src/ui/Logic/NetflixQualityCheck/NetflixQualityController.cs
+++ b/src/ui/Logic/NetflixQualityCheck/NetflixQualityController.cs
@@ -117,8 +117,6 @@ public class NetflixQualityController
                 case "ko": // Korean
                 case "zh": // Chinese
                     return 16;
-                case "ru": // Russian
-                    return 39;
                 default:
                     return 42;
             }
@@ -140,7 +138,7 @@ public class NetflixQualityController
                     return DialogType.DashBothLinesWithSpace;
                 case "hu": // Hungarian
                     return DialogType.DashBothLinesWithSpace;
-                case "in": // Indonesian
+                case "id": // Indonesian
                     return DialogType.DashBothLinesWithSpace;
                 case "it": // Italian
                     return DialogType.DashBothLinesWithSpace;
@@ -182,23 +180,18 @@ public class NetflixQualityController
     {
         get
         {
-            if (!string.IsNullOrEmpty(Language))
+            switch (Language)
             {
-                if (Language == "ar") // Arabic
-                {
+                case "ar": // Arabic
+                case "he": // Hebrew
+                case "hi": // Hindi
+                case "ko": // Korean
+                case "th": // Thai
+                case "zh": // Chinese
                     return false;
-                }
-                else if (Language == "ko") // Korean
-                {
-                    return false;
-                }
-                else if (Language == "zh") // Chinese
-                {
-                    return false;
-                }
+                default:
+                    return true;
             }
-
-            return true;
         }
     }
 

--- a/tests/UI/Logic/NetflixQualityCheck/NetflixCheckMaxCpsTests.cs
+++ b/tests/UI/Logic/NetflixQualityCheck/NetflixCheckMaxCpsTests.cs
@@ -1,0 +1,66 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.NetflixQualityCheck;
+using Xunit;
+
+namespace UITests.Logic.NetflixQualityCheck;
+
+public class NetflixCheckMaxCpsTests
+{
+    private static NetflixQualityController RunCheck(string text, string language, int durationMs)
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(text, 0, durationMs));
+        var controller = new NetflixQualityController { Language = language };
+
+        new NetflixCheckMaxCps("test").Check(subtitle, controller);
+
+        return controller;
+    }
+
+    // 40 characters in one second is 40 CPS, well over the English limit of 20.
+    private const string FortyCharacters = "Forty characters of plain dialogue here.";
+
+    [Fact]
+    public void ReportsSubtitlesOverTheReadingSpeedLimit()
+    {
+        var controller = RunCheck(FortyCharacters, "en", 1000);
+
+        Assert.Single(controller.Records);
+    }
+
+    // The proposed duration used to be derived from the user's own profile setting, so it
+    // could leave the subtitle still over the Netflix limit.
+    [Fact]
+    public void ProposedDurationMeetsTheNetflixLimit()
+    {
+        var controller = RunCheck(FortyCharacters, "en", 1000);
+        var fixedParagraph = controller.Records[0].FixedParagraph;
+
+        Assert.NotNull(fixedParagraph);
+        Assert.True(fixedParagraph!.GetCharactersPerSecond() <= 20.001,
+            $"Expected at most 20 CPS, got {fixedParagraph.GetCharactersPerSecond():0.##}");
+    }
+
+    [Fact]
+    public void ProposedDurationUsesTheChildrensLimitWhenSet()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(FortyCharacters, 0, 1000));
+        var controller = new NetflixQualityController { Language = "en", IsChildrenProgram = true };
+
+        new NetflixCheckMaxCps("test").Check(subtitle, controller);
+
+        var fixedParagraph = controller.Records[0].FixedParagraph;
+        Assert.NotNull(fixedParagraph);
+        Assert.True(fixedParagraph!.GetCharactersPerSecond() <= 17.001,
+            $"Expected at most 17 CPS, got {fixedParagraph.GetCharactersPerSecond():0.##}");
+    }
+
+    [Fact]
+    public void DoesNotReportSubtitlesWithinTheLimit()
+    {
+        var controller = RunCheck(FortyCharacters, "en", 4000);
+
+        Assert.Empty(controller.Records);
+    }
+}

--- a/tests/UI/Logic/NetflixQualityCheck/NetflixCheckNumbersOneToTenSpellOutTests.cs
+++ b/tests/UI/Logic/NetflixQualityCheck/NetflixCheckNumbersOneToTenSpellOutTests.cs
@@ -1,0 +1,51 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.NetflixQualityCheck;
+using Xunit;
+
+namespace UITests.Logic.NetflixQualityCheck;
+
+public class NetflixCheckNumbersOneToTenSpellOutTests
+{
+    private static string RunFix(string text, string language)
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(text, 0, 3000));
+        var controller = new NetflixQualityController { Language = language };
+
+        new NetflixCheckNumbersOneToTenSpellOut("test").Check(subtitle, controller);
+
+        return controller.Records.Count > 0 && controller.Records[0].FixedParagraph != null
+            ? controller.Records[0].FixedParagraph!.Text
+            : text;
+    }
+
+    [Theory]
+    [InlineData("en", "There were 3 of them.", "There were three of them.")]
+    [InlineData("es", "Había 3 perros.", "Había tres perros.")]
+    [InlineData("de", "Es waren 3 Hunde.", "Es waren drei Hunde.")]
+    public void SpellsOutSingleDigitsInTheSubtitleLanguage(string language, string input, string expected)
+    {
+        Assert.Equal(expected, RunFix(input, language));
+    }
+
+    // "10" used to be replaced with the English "ten" no matter the subtitle language.
+    [Theory]
+    [InlineData("en", "There were 10 of them.", "There were ten of them.")]
+    [InlineData("es", "Había 10 perros.", "Había diez perros.")]
+    [InlineData("it", "C'erano 10 cani.", "C'erano dieci cani.")]
+    [InlineData("fr", "Il y avait 10 chiens.", "Il y avait dix chiens.")]
+    public void SpellsOutTenInTheSubtitleLanguage(string language, string input, string expected)
+    {
+        Assert.Equal(expected, RunFix(input, language));
+    }
+
+    // No spell-out list for these languages, so the digits must be left alone rather
+    // than replaced with English words.
+    [Theory]
+    [InlineData("sv", "Det var 10 stycken.")]
+    [InlineData("nl", "Er waren 10 honden.")]
+    public void LeavesNumbersAloneWithoutASpellOutList(string language, string input)
+    {
+        Assert.Equal(input, RunFix(input, language));
+    }
+}

--- a/tests/UI/Logic/NetflixQualityCheck/NetflixQualityControllerTests.cs
+++ b/tests/UI/Logic/NetflixQualityCheck/NetflixQualityControllerTests.cs
@@ -1,0 +1,86 @@
+using Nikse.SubtitleEdit.Core.Enums;
+using Nikse.SubtitleEdit.Logic.NetflixQualityCheck;
+using Xunit;
+
+namespace UITests.Logic.NetflixQualityCheck;
+
+/// <summary>
+/// The per-language limits are transcribed from the Netflix Timed Text Style Guides at
+/// https://partnerhelp.netflixstudios.com - these tests pin the ones that have drifted.
+/// </summary>
+public class NetflixQualityControllerTests
+{
+    // Netflix raised the Russian limit from 39 to 42 CPR in the December 2025 TTSG update.
+    [Theory]
+    [InlineData("ru", 42)]
+    [InlineData("en", 42)]
+    [InlineData("th", 35)]
+    [InlineData("ko", 16)]
+    [InlineData("zh", 16)]
+    public void SingleLineMaxLengthMatchesStyleGuide(string language, int expected)
+    {
+        Assert.Equal(expected, new NetflixQualityController { Language = language }.SingleLineMaxLength);
+    }
+
+    // Indonesian is "id" in ISO 639-1; the old "in" case never matched, so Indonesian
+    // silently fell through to the no-space default.
+    [Theory]
+    [InlineData("id", DialogType.DashBothLinesWithSpace)]
+    [InlineData("ko", DialogType.DashBothLinesWithSpace)]
+    [InlineData("th", DialogType.DashBothLinesWithSpace)]
+    [InlineData("bg", DialogType.DashSecondLineWithSpace)]
+    [InlineData("nl", DialogType.DashSecondLineWithoutSpace)]
+    [InlineData("fi", DialogType.DashSecondLineWithoutSpace)]
+    [InlineData("de", DialogType.DashBothLinesWithoutSpace)]
+    [InlineData("en", DialogType.DashBothLinesWithoutSpace)]
+    public void SpeakerStyleMatchesStyleGuide(string language, DialogType expected)
+    {
+        Assert.Equal(expected, new NetflixQualityController { Language = language }.SpeakerStyle);
+    }
+
+    // "Do not use italics" appears verbatim in these guides.
+    [Theory]
+    [InlineData("ar")]
+    [InlineData("he")]
+    [InlineData("hi")]
+    [InlineData("ko")]
+    [InlineData("th")]
+    [InlineData("zh")]
+    public void ItalicsAreNotAllowed(string language)
+    {
+        Assert.False(new NetflixQualityController { Language = language }.AllowItalics);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ru")]
+    [InlineData("ja")]
+    [InlineData("tr")]
+    public void ItalicsAreAllowed(string language)
+    {
+        Assert.True(new NetflixQualityController { Language = language }.AllowItalics);
+    }
+
+    [Theory]
+    [InlineData("en", false, false, 20)]
+    [InlineData("en", true, false, 17)]
+    [InlineData("en", false, true, 20)]
+    [InlineData("hi", false, false, 22)]
+    [InlineData("hi", false, true, 25)]
+    [InlineData("hi", true, true, 20)]
+    [InlineData("ko", false, false, 12)]
+    [InlineData("ko", false, true, 14)]
+    [InlineData("th", false, false, 17)]
+    [InlineData("th", false, true, 20)]
+    public void ReadingSpeedMatchesStyleGuide(string language, bool isChildrenProgram, bool isSdh, int expected)
+    {
+        var controller = new NetflixQualityController
+        {
+            Language = language,
+            IsChildrenProgram = isChildrenProgram,
+            IsSDH = isSdh,
+        };
+
+        Assert.Equal(expected, controller.CharactersPerSecond);
+    }
+}


### PR DESCRIPTION
I re-checked every value in `NetflixQualityController` against the live Netflix Timed Text Style Guides on partnerhelp.netflixstudios.com.

Most of it is still correct — the reading speeds (English 20/17, Arabic 20/17 + SDH 23/20, Hindi 22/18 + SDH 25/20, Japanese 4 + SDH 7, Korean 12/9 + SDH 14/11, Chinese 9/7 + SDH 11/9, and the 17/13 default), the 833 ms / 7 s durations, the two-frame gap, closing 3–11 frame gaps, the two-line maximum, and the dialogue-dash table for all the other languages it encodes. These are the parts that had drifted.

## Rule fixes

**Russian line length was 39, should be 42.** Netflix [raised it to 42 CPR in the December 2025 TTSG update](https://partnerhelp.netflixstudios.com/hc/en-us/articles/47550553159187-TTSG-Updates-December-2025); the [Russian guide](https://partnerhelp.netflixstudios.com/hc/en-us/articles/215346638-Russian-Timed-Text-Style-Guide) now says 42 under Character Limitation, and 39 survives only in its Font Information section. Russian subtitles were being flagged for lines Netflix accepts.

**Indonesian dash style never applied.** The case was `"in"`, but both `Iso639Dash2LanguageCode` and `LanguageAutoDetect` produce `"id"`, so Indonesian fell through to the no-space default instead of the "hyphen followed by a space" its [guide](https://partnerhelp.netflixstudios.com/hc/en-us/articles/215350268-Indonesian-Timed-Text-Style-Guide) requires.

**Italics were only blocked for Arabic, Korean and Chinese.** The [Hebrew](https://partnerhelp.netflixstudios.com/hc/en-us/articles/220636427-Hebrew-Timed-Text-Style-Guide), [Hindi](https://partnerhelp.netflixstudios.com/hc/en-us/articles/115003196707-Hindi-Timed-Text-Style-Guide) and [Thai](https://partnerhelp.netflixstudios.com/hc/en-us/articles/220448308-Thai-Timed-Text-Style-Guide) guides carry the same "Do not use italics" wording.

**"10" was always spelled out as the English "ten".** Spanish got "ten" instead of "diez", and languages with no spell-out list had English words injected into their subtitles.

**The reading-speed fix targeted the wrong limit.** It derived the new duration from `Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds` — the user's own profile setting — rather than the Netflix per-language limit, so applying the suggestion could leave the subtitle still in violation.

## Two checks were dead

**Shot changes never ran.** `NetflixCheckShotChange` returns early unless `controller.VideoFileName` is set, and the dialog never set it — despite the check appearing in the list users tick and the docs promising it uses the loaded video. It now gets the video file name.

**Children's and SDH limits were unreachable.** `IsChildrenProgram` and `IsSDH` were declared and read but never assigned anywhere, leaving roughly sixty lines of correct CPS values dead. Both are now checkboxes in the dialog, remembered between sessions.

Enabling the shot-change check surfaced two problems in it: the out-cue window had `< halfSecGapInFrames && < 2`, collapsing the guide's half-second rule to two frames; and all five branches mutated one shared `Paragraph`, so a later fix overwrote what an earlier record had already proposed. Both are fixed.

Also: the hearing-impaired bracket check guarded on `"jp"`. Japanese is `"ja"`, and its SDH guide uses full-width parentheses rather than square brackets, so the intended skip now happens.

## Tests

56 tests pass, including 3 new files covering the per-language tables, the spell-out fix and the reading-speed fix.

One unrelated test fails on `main` on Windows: `WebVttBrowserPreviewTests.VideoIsReferencedAsAFileUri` expects `file:///videos/my%20movie.mp4`, but `Path.GetFullPath("/videos/my movie.mp4")` prepends the current drive on Windows, giving `file:///C:/videos/my%20movie.mp4`. The production code is fine — the test hardcodes a POSIX-absolute path. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)