### PR TITLE
Make the WebVTT preview file URI test platform-agnostic

### DIFF
--- a/tests/UI/Features/WebVtt/WebVttBrowserPreviewTests.cs
+++ b/tests/UI/Features/WebVtt/WebVttBrowserPreviewTests.cs
@@ -48,7 +48,11 @@ public class WebVttBrowserPreviewTests
         var html = WebVttBrowserPreview.GenerateHtml("WEBVTT", "/videos/my movie.mp4");
 
         // A raw path with a space would break the src attribute; it has to be percent-encoded.
-        Assert.Contains("file:///videos/my%20movie.mp4", html);
-        Assert.DoesNotContain("src=\"/videos/my movie.mp4\"", html);
+        // Only the tail of the URI is portable: Path.GetFullPath() anchors a rooted path to the
+        // current drive on Windows, so the preview yields file:///C:/videos/... there and
+        // file:///videos/... on Linux and macOS.
+        Assert.Contains("src=\"file:///", html);
+        Assert.Contains("/videos/my%20movie.mp4", html);
+        Assert.DoesNotContain("my movie.mp4", html);
     }
 }


### PR DESCRIPTION
`WebVttBrowserPreviewTests.VideoIsReferencedAsAFileUri` fails on Windows on `main`. It passes on Linux and macOS, which is why CI is green.

The test passes `/videos/my movie.mp4` and expects the generated HTML to contain `file:///videos/my%20movie.mp4`. But [WebVttBrowserPreview.cs:61](https://github.com/SubtitleEdit/subtitleedit/blob/main/src/ui/Features/WebVtt/WebVttBrowserPreview.cs#L61) builds the URI with `new Uri(Path.GetFullPath(fileName)).AbsoluteUri`, and on Windows `Path.GetFullPath` anchors a rooted-but-driveless path to the *current drive*:

```
[System.Uri]::new([System.IO.Path]::GetFullPath("/videos/my movie.mp4")).AbsoluteUri
file:///C:/videos/my%20movie.mp4
```

So the expectation only holds where `/videos/...` is already absolute.

The behaviour the test actually cares about — percent-encoding a space so it cannot break the `src` attribute — was never broken. This asserts on the portable part instead: the `src` is a file URI, the space is encoded, and the raw file name appears nowhere in the output. No production code changed.

Introduced in 64930a8e3e "Bring back WebVTT styles, voices and browser preview from SE4".

Full UI suite on Windows: 1629 passed, 0 failed (was 1628 passed, 1 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)