### PR TITLE
Fix #13333: enable IME on Linux so dead-key accents work on ibus desktops

### DIFF
--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -165,7 +165,16 @@ namespace Nikse.SubtitleEdit
                 appBuilder = appBuilder
                     .With(new X11PlatformOptions
                     {
-                        RenderingMode = new[] { X11RenderingMode.Glx, X11RenderingMode.Egl }
+                        RenderingMode = new[] { X11RenderingMode.Glx, X11RenderingMode.Egl },
+
+                        // Avalonia only connects to the desktop's input method for CJK locales by
+                        // default; European locales fall back to libX11's local compose path, which
+                        // does not work on ibus desktops (GNOME/Fedora/Ubuntu) - dead keys type
+                        // nothing and swallow the next keystroke (issues #13333, #12334, #10618;
+                        // upstream AvaloniaUI/Avalonia#18596). Always enabling IME makes Avalonia
+                        // talk to ibus/fcitx over D-Bus like GTK apps do, so dead-key composition
+                        // (á, ê, õ, ...) works. Users can still opt out with AVALONIA_IM_MODULE=none.
+                        EnableIme = true,
                     })
                     .With(new AvaloniaNativePlatformOptions
                     {


### PR DESCRIPTION
Fixes #13333 (also the cause of #12334 and #10618).

### Problem

On Linux desktops that use **ibus** as the input framework (GNOME on Fedora, Ubuntu, elementaryOS…), dead keys don't work in Subtitle Edit: pressing e.g. `´` then `a` types nothing and swallows the keystroke, so accented characters (á, à, â, ã, é, ê, í, ó, ô, õ, ú…) can't be typed at all. Other apps (GTK/Qt/Chromium) work because they talk to ibus over D-Bus.

### Cause

Avalonia's X11 backend only connects to the desktop's input method when `LANG` is a CJK locale (or when the app opts in). For European locales it falls back to libX11's local compose path, which does not work on ibus desktops — reported upstream as AvaloniaUI/Avalonia#18596 (closed without a fix; ibus's XIM bridge has the same defect, ibus/ibus#546). SE has been affected on these setups across all 5.x releases.

### Fix

Set `X11PlatformOptions.EnableIme = true`. Avalonia then detects ibus/fcitx from the session environment (`XMODIFIERS`, `GTK_IM_MODULE`, …) and registers its native **D-Bus** input-method client — the same route GTK apps use, where dead-key composition works. On systems without any input framework the behavior is unchanged (same local fallback as today), and `AVALONIA_IM_MODULE=none` remains as a user-level opt-out.

### Testing

- Builds clean; no behavior change on Windows/macOS (the option is X11-only).
- Needs verification on a Linux/GNOME box with a dead-key layout (Portuguese, US-International…) — I could not exercise X11 dead keys from this machine. Suggest shipping in the next beta and asking the reporters of #13333/#12334 to confirm.
- Known risk: Avalonia's D-Bus IME clients have their own open bugs (e.g. Korean, AvaloniaUI/Avalonia#20257), but those affect setups that currently get no IME at all, so this should be a strict improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)