### PR TITLE
Use the line's own style in the "Set position" preview

### DIFF
--- a/src/ui/Features/Assa/AssaSetPosition/AssaSetPositionViewModel.cs
+++ b/src/ui/Features/Assa/AssaSetPosition/AssaSetPositionViewModel.cs
@@ -149,12 +149,7 @@ public partial class AssaSetPositionViewModel : ObservableObject
             _isBottomAligned = style.Alignment == "1" || style.Alignment == "2" || style.Alignment == "3";
         }
 
-        var previewSubtitle = new Subtitle(subtitle);
-        previewSubtitle.Paragraphs.Clear();
-        var previewParagraph = line.ToParagraph();
-        previewParagraph.StartTime.TotalSeconds = 0;
-        previewParagraph.EndTime.TotalSeconds = 10;
-        previewSubtitle.Paragraphs.Add(previewParagraph);
+        var previewSubtitle = MakePreviewSubtitle(subtitle, line);
         var previewScreenshotFileName = FfmpegGenerator.GetScreenShotWithSubtitle(previewSubtitle, videoWidth ?? 1920, videoHeight ?? 1080);
         var skBitmap = SKBitmap.Decode(previewScreenshotFileName);
         var trimResult = skBitmap.TrimTransparentPixels();
@@ -230,6 +225,25 @@ public partial class AssaSetPositionViewModel : ObservableObject
         {
             Screenshot = BinaryAdjustAlphaViewModel.CreateCheckeredBackground(TargetWidth, TargetHeight);
         }
+    }
+
+    /// <summary>
+    /// Builds the one-line subtitle that ffmpeg renders into the draggable text overlay.
+    /// </summary>
+    internal static Subtitle MakePreviewSubtitle(Subtitle subtitle, SubtitleLineViewModel line)
+    {
+        var previewSubtitle = new Subtitle(subtitle);
+        previewSubtitle.Paragraphs.Clear();
+
+        // The ASSA writer takes the style name from Paragraph.Extra, which ToParagraph only fills
+        // in when it knows the format. Without it every preview fell back to the first style in the
+        // header, so lines using any other style were positioned against the wrong font/size (#13350).
+        var previewParagraph = line.ToParagraph(new AdvancedSubStationAlpha());
+        previewParagraph.StartTime.TotalSeconds = 0;
+        previewParagraph.EndTime.TotalSeconds = 10;
+        previewSubtitle.Paragraphs.Add(previewParagraph);
+
+        return previewSubtitle;
     }
 
     [RelayCommand]

--- a/tests/UI/Features/Assa/AssaSetPositionPreviewStyleTests.cs
+++ b/tests/UI/Features/Assa/AssaSetPositionPreviewStyleTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Linq;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Assa.AssaSetPosition;
+using Nikse.SubtitleEdit.Features.Main;
+
+namespace UITests.Features.Assa;
+
+/// <summary>
+/// Regression tests for discussion #13350: the "Set position" preview rendered the line with the
+/// first style in the header instead of the style the line actually uses.
+/// </summary>
+public class AssaSetPositionPreviewStyleTests
+{
+    private const string HeaderWithTwoStyles = @"[Script Info]
+; This is an Advanced Sub Station Alpha v4+ script.
+Title:
+ScriptType: v4.00+
+PlayResX: 1920
+PlayResY: 1080
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Default,Arial,20,&H00FFFFFF,&H0300FFFF,&H00000000,&H02000000,0,0,0,0,100,100,0,0,1,2,1,2,10,10,10,1
+Style: Big,Verdana,72,&H0000FFFF,&H0300FFFF,&H00000000,&H02000000,-1,0,0,0,100,100,0,0,1,3,2,8,10,10,10,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text";
+
+    private static Subtitle MakeAssaSubtitle(string style)
+    {
+        var subtitle = new Subtitle { Header = HeaderWithTwoStyles };
+        subtitle.Paragraphs.Add(new Paragraph("Hello world", 1000, 3000) { Extra = style });
+        return subtitle;
+    }
+
+    private static SubtitleLineViewModel MakeLine(Subtitle subtitle)
+    {
+        return new SubtitleLineViewModel(subtitle.Paragraphs[0], new AdvancedSubStationAlpha());
+    }
+
+    private static string GetDialogueStyle(Subtitle subtitle)
+    {
+        var text = new AdvancedSubStationAlpha().ToText(subtitle, string.Empty);
+        var dialogue = text.SplitToLines().First(l => l.StartsWith("Dialogue:", StringComparison.Ordinal));
+
+        // Layer, Start, End, Style, ...
+        return dialogue.Substring("Dialogue:".Length).Split(',')[3].Trim();
+    }
+
+    [Fact]
+    public void PreviewSubtitle_KeepsTheStyleOfTheLine()
+    {
+        var subtitle = MakeAssaSubtitle("Big");
+
+        var preview = AssaSetPositionViewModel.MakePreviewSubtitle(subtitle, MakeLine(subtitle));
+
+        Assert.Equal("Big", GetDialogueStyle(preview));
+    }
+
+    [Fact]
+    public void PreviewSubtitle_KeepsTheHeaderStyles()
+    {
+        var subtitle = MakeAssaSubtitle("Big");
+
+        var preview = AssaSetPositionViewModel.MakePreviewSubtitle(subtitle, MakeLine(subtitle));
+
+        var styles = AdvancedSubStationAlpha.GetStylesFromHeader(preview.Header);
+        Assert.Equal(new[] { "Default", "Big" }, styles);
+    }
+
+    [Fact]
+    public void PreviewSubtitle_HasASingleParagraphStartingAtZero()
+    {
+        var subtitle = MakeAssaSubtitle("Default");
+        subtitle.Paragraphs.Add(new Paragraph("Second line", 4000, 6000) { Extra = "Big" });
+
+        var preview = AssaSetPositionViewModel.MakePreviewSubtitle(subtitle, MakeLine(subtitle));
+
+        var p = Assert.Single(preview.Paragraphs);
+        Assert.Equal("Hello world", p.Text);
+        Assert.Equal(0, p.StartTime.TotalSeconds);
+        Assert.Equal(10, p.EndTime.TotalSeconds);
+    }
+
+    [Fact]
+    public void PreviewSubtitle_DoesNotTouchTheSourceSubtitle()
+    {
+        var subtitle = MakeAssaSubtitle("Big");
+
+        _ = AssaSetPositionViewModel.MakePreviewSubtitle(subtitle, MakeLine(subtitle));
+
+        var p = Assert.Single(subtitle.Paragraphs);
+        Assert.Equal(1000, p.StartTime.TotalMilliseconds);
+        Assert.Equal(3000, p.EndTime.TotalMilliseconds);
+    }
+}


### PR DESCRIPTION
Fixes the regression reported in discussion #13350: the "Set position" window rendered the preview text with the first style in the ASSA header instead of the style the selected line actually uses, so styled lines could not be positioned against their real look (SE 4 did this correctly).

### Cause

The preview paragraph was built with `line.ToParagraph()` — the no-format overload. Only the format-aware overload copies the style name into `Paragraph.Extra`, and the ASSA writer takes the Style column from `Extra`; with `Extra` empty it falls back to the first style in the header. The ffmpeg/libass overlay therefore always drew in that fallback style (wrong font, size, outline, alignment).

Verified against the reporter's screenshot: rendering their scenario through the exact `FfmpegGenerator` command with the fallback style yields a trimmed overlay at left edge X=829 — the same `X: 829` shown in their window.

### Fix

- Extract preview construction into `MakePreviewSubtitle` and build the paragraph with `line.ToParagraph(new AdvancedSubStationAlpha())`.
- Regression tests: style column preserved, header styles intact, single 0–10 s paragraph, source subtitle untouched. The style test fails on the old code (`Expected: "Big", Actual: "Default"`).

Tested on macOS: preview now renders with the line's own style (libass fontselect picks the styled face instead of the default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)