### PR TITLE
Fix "Apply custom override tags" preview styles and OK without video

### DIFF
--- a/src/ui/Features/Assa/AssaApplyCustomOverrideTags/AssaApplyCustomOverrideTagsViewModel.cs
+++ b/src/ui/Features/Assa/AssaApplyCustomOverrideTags/AssaApplyCustomOverrideTagsViewModel.cs
@@ -48,6 +48,8 @@ public partial class AssaApplyCustomOverrideTagsViewModel : ObservableObject
     private LibMpvDynamicPlayer? _mpvPlayer;
     private bool _isSubtitleLoaded;
     private string _oldSubtitleText;
+    private string? _header;
+    private string? _footer;
     private string? _videoFileName;
     private DispatcherTimer _positionTimer = new DispatcherTimer();
     private List<SubtitleLineViewModel> _subtitleLines = new List<SubtitleLineViewModel>();
@@ -81,11 +83,14 @@ public partial class AssaApplyCustomOverrideTagsViewModel : ObservableObject
     }
 
     public void Initialize(
+        Subtitle subtitle,
         List<SubtitleLineViewModel> paragraphs,
         List<SubtitleLineViewModel> selectedParagraphs,
         string? videoFileName)
     {
         Paragraphs = new ObservableCollection<SubtitleDisplayItem>(paragraphs.Select(p => new SubtitleDisplayItem(p)));
+        _header = subtitle.Header;
+        _footer = subtitle.Footer;
         _videoFileName = videoFileName;
         _subtitleLines = paragraphs;
         _selectedSubtitleLines = selectedParagraphs;
@@ -125,24 +130,7 @@ public partial class AssaApplyCustomOverrideTagsViewModel : ObservableObject
                 return;
             }
 
-            var subtitle = new Subtitle();
-            int firstSelectedIndex = Paragraphs.IndexOf(Paragraphs.First(p => p.Subtitle.Id == _selectedSubtitleLines[0].Id));
-            var idx = 0;
-            foreach (var item in Paragraphs)
-            {
-                var p = new SubtitleLineViewModel(item.Subtitle);
-
-                if (AdjustAll ||
-                    AdjustSelectedLines && _selectedSubtitleLines.Any(x => x.Id == item.Subtitle.Id) ||
-                    AdjustSelectedLinesAndForward && idx >= firstSelectedIndex)
-                {
-                    p.Text = CurrentTag + p.Text;
-                }
-
-                subtitle.Paragraphs.Add(p.ToParagraph());
-                idx++;
-            }
-
+            var subtitle = BuildTaggedSubtitle();
             var text = _assaFormat.ToText(subtitle, string.Empty);
             if (_oldSubtitleText == text)
             {
@@ -161,10 +149,60 @@ public partial class AssaApplyCustomOverrideTagsViewModel : ObservableObject
             }
 
             _oldSubtitleText = text;
-            UpdatedSubtitle = subtitle;
         };
 
         _positionTimer.Start();
+    }
+
+    private Subtitle BuildTaggedSubtitle()
+    {
+        return BuildTaggedSubtitle(_header, _footer, _subtitleLines, _selectedSubtitleLines, CurrentTag,
+            AdjustAll, AdjustSelectedLines, AdjustSelectedLinesAndForward, _assaFormat);
+    }
+
+    /// <summary>
+    /// Applies the override tag to the chosen lines and returns the result as a subtitle that
+    /// keeps the file's header, so both the mpv preview and the OK result render/save with the
+    /// real styles.
+    /// </summary>
+    internal static Subtitle BuildTaggedSubtitle(
+        string? header,
+        string? footer,
+        List<SubtitleLineViewModel> lines,
+        List<SubtitleLineViewModel> selectedLines,
+        string tag,
+        bool adjustAll,
+        bool adjustSelectedLines,
+        bool adjustSelectedLinesAndForward,
+        SubtitleFormat format)
+    {
+        var subtitle = new Subtitle { Header = header, Footer = footer };
+
+        // No selection means "selected lines"/"and forward" have nothing to apply to.
+        var firstSelectedIndex = selectedLines.Count > 0
+            ? lines.FindIndex(l => l.Id == selectedLines[0].Id)
+            : -1;
+        if (firstSelectedIndex < 0)
+        {
+            firstSelectedIndex = int.MaxValue;
+        }
+
+        var selectedIds = new HashSet<Guid>(selectedLines.Select(s => s.Id));
+        for (var idx = 0; idx < lines.Count; idx++)
+        {
+            var p = new SubtitleLineViewModel(lines[idx]);
+
+            if (adjustAll ||
+                adjustSelectedLines && selectedIds.Contains(p.Id) ||
+                adjustSelectedLinesAndForward && idx >= firstSelectedIndex)
+            {
+                p.Text = tag + p.Text;
+            }
+
+            subtitle.Paragraphs.Add(p.ToParagraph(format));
+        }
+
+        return subtitle;
     }
 
     [RelayCommand]
@@ -220,6 +258,10 @@ public partial class AssaApplyCustomOverrideTagsViewModel : ObservableObject
     [RelayCommand]
     private void Ok()
     {
+        // Build the result here rather than reusing the preview timer's snapshot: the timer only
+        // runs when a video is loaded (OK used to be a silent no-op without one), and its last
+        // tick could be up to 500 ms behind the current tag.
+        UpdatedSubtitle = BuildTaggedSubtitle();
         OkPressed = true;
         Window?.Close();
     }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -2084,7 +2084,7 @@ public partial class MainViewModel :
         {
             var paragraphs = Subtitles.Select(p => new SubtitleLineViewModel(p)).ToList();
             var selectedParagraphs = SubtitleGridSelectedItems.Cast<SubtitleLineViewModel>().ToList();
-            vm.Initialize(paragraphs, selectedParagraphs, _videoFileName);
+            vm.Initialize(GetUpdateSubtitle(), paragraphs, selectedParagraphs, _videoFileName);
         });
 
         if (result.OkPressed && result.UpdatedSubtitle.Paragraphs.Count == Subtitles.Count)

--- a/tests/UI/Features/Assa/AssaApplyCustomOverrideTagsBuildTests.cs
+++ b/tests/UI/Features/Assa/AssaApplyCustomOverrideTagsBuildTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Assa.AssaApplyCustomOverrideTags;
+using Nikse.SubtitleEdit.Features.Main;
+
+namespace UITests.Features.Assa;
+
+/// <summary>
+/// Tests for the subtitle that "Apply custom override tags" builds for both the mpv preview and
+/// the OK result. Regressions covered: the preview dropped the file's header (all lines rendered
+/// in the app default style), the Dialogue style column fell back to the first header style, and
+/// OK without a video silently discarded the tag.
+/// </summary>
+public class AssaApplyCustomOverrideTagsBuildTests
+{
+    private const string HeaderWithTwoStyles = @"[Script Info]
+; This is an Advanced Sub Station Alpha v4+ script.
+Title:
+ScriptType: v4.00+
+PlayResX: 1920
+PlayResY: 1080
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Default,Arial,20,&H00FFFFFF,&H0300FFFF,&H00000000,&H02000000,0,0,0,0,100,100,0,0,1,2,1,2,10,10,10,1
+Style: Big,Verdana,72,&H0000FFFF,&H0300FFFF,&H00000000,&H02000000,-1,0,0,0,100,100,0,0,1,3,2,8,10,10,10,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text";
+
+    private static readonly AdvancedSubStationAlpha Format = new();
+
+    private static List<SubtitleLineViewModel> MakeLines(params string[] styles)
+    {
+        var lines = new List<SubtitleLineViewModel>();
+        for (var i = 0; i < styles.Length; i++)
+        {
+            var p = new Paragraph($"Line {i + 1}", i * 2000, i * 2000 + 1000) { Extra = styles[i] };
+            lines.Add(new SubtitleLineViewModel(p, Format));
+        }
+
+        return lines;
+    }
+
+    private static Subtitle Build(
+        List<SubtitleLineViewModel> lines,
+        List<SubtitleLineViewModel> selected,
+        string tag,
+        bool all = false,
+        bool selectedOnly = false,
+        bool selectedAndForward = false)
+    {
+        return AssaApplyCustomOverrideTagsViewModel.BuildTaggedSubtitle(
+            HeaderWithTwoStyles, null, lines, selected, tag, all, selectedOnly, selectedAndForward, Format);
+    }
+
+    private static string[] GetDialogueStyles(Subtitle subtitle)
+    {
+        var text = Format.ToText(subtitle, string.Empty);
+        return text.SplitToLines()
+            .Where(l => l.StartsWith("Dialogue:", StringComparison.Ordinal))
+            .Select(l => l.Substring("Dialogue:".Length).Split(',')[3].Trim())
+            .ToArray();
+    }
+
+    [Fact]
+    public void KeepsHeaderAndPerLineStyles()
+    {
+        var lines = MakeLines("Default", "Big", "Default");
+
+        var result = Build(lines, new List<SubtitleLineViewModel>(), "{\\blur2}", all: true);
+
+        Assert.Equal(HeaderWithTwoStyles, result.Header);
+        Assert.Equal(new[] { "Default", "Big", "Default" }, GetDialogueStyles(result));
+    }
+
+    [Fact]
+    public void AdjustAll_TagsEveryLine()
+    {
+        var lines = MakeLines("Default", "Big");
+
+        var result = Build(lines, new List<SubtitleLineViewModel>(), "{\\blur2}", all: true);
+
+        Assert.All(result.Paragraphs, p => Assert.StartsWith("{\\blur2}", p.Text));
+    }
+
+    [Fact]
+    public void AdjustSelectedLines_TagsOnlySelected()
+    {
+        var lines = MakeLines("Default", "Big", "Default");
+        var selected = new List<SubtitleLineViewModel> { lines[1] };
+
+        var result = Build(lines, selected, "{\\blur2}", selectedOnly: true);
+
+        Assert.Equal("Line 1", result.Paragraphs[0].Text);
+        Assert.Equal("{\\blur2}Line 2", result.Paragraphs[1].Text);
+        Assert.Equal("Line 3", result.Paragraphs[2].Text);
+    }
+
+    [Fact]
+    public void AdjustSelectedLinesAndForward_TagsFromFirstSelected()
+    {
+        var lines = MakeLines("Default", "Big", "Default");
+        var selected = new List<SubtitleLineViewModel> { lines[1] };
+
+        var result = Build(lines, selected, "{\\blur2}", selectedAndForward: true);
+
+        Assert.Equal("Line 1", result.Paragraphs[0].Text);
+        Assert.Equal("{\\blur2}Line 2", result.Paragraphs[1].Text);
+        Assert.Equal("{\\blur2}Line 3", result.Paragraphs[2].Text);
+    }
+
+    [Fact]
+    public void EmptySelection_DoesNotThrowAndTagsNothing()
+    {
+        var lines = MakeLines("Default", "Big");
+
+        var selectedOnly = Build(lines, new List<SubtitleLineViewModel>(), "{\\blur2}", selectedOnly: true);
+        var forward = Build(lines, new List<SubtitleLineViewModel>(), "{\\blur2}", selectedAndForward: true);
+
+        Assert.All(selectedOnly.Paragraphs, p => Assert.DoesNotContain("\\blur2", p.Text));
+        Assert.All(forward.Paragraphs, p => Assert.DoesNotContain("\\blur2", p.Text));
+    }
+
+    [Fact]
+    public void SourceLinesAreNotMutated()
+    {
+        var lines = MakeLines("Default", "Big");
+
+        _ = Build(lines, new List<SubtitleLineViewModel>(), "{\\blur2}", all: true);
+
+        Assert.All(lines, l => Assert.DoesNotContain("\\blur2", l.Text));
+    }
+}


### PR DESCRIPTION
Follow-up to #13352 — same defect family found while analyzing discussion #13350, plus a silent data-loss path.

### Defects fixed

1. **Preview discarded the file's styles.** The 500 ms preview timer built `new Subtitle()` with no header, so `ToText` fell back to the generated template header and mpv rendered every line in the app default style. `Initialize` now receives the current subtitle and reuses its header/footer.
2. **Style column fell back to the first header style.** Paragraphs were built with `ToParagraph()` (no format), which leaves `Paragraph.Extra` empty — the same root cause as #13352. Now `ToParagraph(assaFormat)`.
3. **OK without a video was a silent no-op.** `UpdatedSubtitle` was only assigned inside the timer tick, which bails while `_mpvPlayer` is null — permanent when no video is loaded — so the main window's paragraph-count guard rejected the empty result and the tag was discarded. Even with a video, OK applied the last tick's snapshot, losing tag edits made within 500 ms of clicking. OK now builds the result at click time.

### Changes

- Extracted `BuildTaggedSubtitle` (shared by the preview timer and OK), keeping header/footer and per-line styles; also guards the previously-throwing empty-selection case in the forward/selected scopes.
- `MainViewModel` passes `GetUpdateSubtitle()` into `Initialize`.
- 6 tests: header + per-line style preservation, all three apply-scopes, empty selection, and source-line immutability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)