### PR TITLE
Write "Set position" coordinates in PlayRes space, not video pixels

### DIFF
--- a/src/ui/Features/Assa/AssaSetPosition/AssaSetPositionViewModel.cs
+++ b/src/ui/Features/Assa/AssaSetPosition/AssaSetPositionViewModel.cs
@@ -46,6 +46,12 @@ public partial class AssaSetPositionViewModel : ObservableObject
     public decimal ResultRotation => Rotation;
 
     private Subtitle _subtitle = new();
+
+    // Size of the canvas the overlay text was rendered on. ScreenshotX/Y and the overlay bitmap
+    // live in this pixel space; \pos() is PlayRes (SourceWidth/Height) space - see ToScriptSpace.
+    private int _renderWidth = 1920;
+    private int _renderHeight = 1080;
+
     private bool _isLeftAligned = false;
     private bool _isHorizontalCentered = true;
     private bool _isRightAligned = false;
@@ -67,17 +73,17 @@ public partial class AssaSetPositionViewModel : ObservableObject
     {
         get
         {
+            var renderX = (double)ScreenshotX;
             if (_isHorizontalCentered)
             {
-                return (int)Math.Round(ScreenshotX + ScreenshotOverlayText.Size.Width / 2.0, MidpointRounding.AwayFromZero);
+                renderX += ScreenshotOverlayText.Size.Width / 2.0;
             }
-
-            if (_isRightAligned)
+            else if (_isRightAligned)
             {
-                return (int)Math.Round(ScreenshotX + ScreenshotOverlayText.Size.Width, MidpointRounding.AwayFromZero);
+                renderX += ScreenshotOverlayText.Size.Width;
             }
 
-            return ScreenshotX;
+            return ToScriptSpace(renderX, SourceWidth, _renderWidth);
         }
     }
 
@@ -86,18 +92,34 @@ public partial class AssaSetPositionViewModel : ObservableObject
     {
         get
         {
+            var renderY = (double)ScreenshotY;
             if (_isBottomAligned)
             {
-                return (int)Math.Round(ScreenshotY + ScreenshotOverlayText.Size.Height, MidpointRounding.AwayFromZero);
+                renderY += ScreenshotOverlayText.Size.Height;
             }
-
-            if (_isVerticalCentered)
+            else if (_isVerticalCentered)
             {
-                return (int)Math.Round(ScreenshotY + ScreenshotOverlayText.Size.Height / 2.0, MidpointRounding.AwayFromZero);
+                renderY += ScreenshotOverlayText.Size.Height / 2.0;
             }
 
-            return ScreenshotY;
+            return ToScriptSpace(renderY, SourceHeight, _renderHeight);
         }
+    }
+
+    /// <summary>
+    /// The overlay is measured in render (video pixel) space, but libass interprets \pos() in
+    /// PlayRes space - e.g. \pos(320,180) with PlayRes 640x360 is the center of a 1080p frame.
+    /// Convert at this boundary; writing render pixels into the tag put the text off by
+    /// renderSize/playRes whenever the script resolution differs from the video's (#13350).
+    /// </summary>
+    internal static int ToScriptSpace(double renderValue, int playRes, int renderSize)
+    {
+        if (playRes <= 0 || renderSize <= 0)
+        {
+            return (int)Math.Round(renderValue, MidpointRounding.AwayFromZero);
+        }
+
+        return (int)Math.Round(renderValue * playRes / renderSize, MidpointRounding.AwayFromZero);
     }
 
     partial void OnScreenshotXChanged(int value)
@@ -136,7 +158,20 @@ public partial class AssaSetPositionViewModel : ObservableObject
             Rotation = frz;
         }
 
-        var styles = AdvancedSubStationAlpha.GetSsaStylesFromHeader(subtitle.Header);
+        if (string.IsNullOrEmpty(_subtitle.Header))
+        {
+            _subtitle.Header = AdvancedSubStationAlpha.DefaultHeader;
+        }
+
+        // Resolve the script resolution before rendering the preview. A header without PlayRes
+        // would make libass assume 384x288 while this dialog measured in a different space, so
+        // stamp one in that case - ResultSubtitle carries it back so the saved \pos matches.
+        (_subtitle.Header, var playResX, var playResY) =
+            EnsurePlayRes(_subtitle.Header, videoWidth ?? 1920, videoHeight ?? 1080);
+        SourceWidth = playResX;
+        SourceHeight = playResY;
+
+        var styles = AdvancedSubStationAlpha.GetSsaStylesFromHeader(_subtitle.Header);
         var style = styles.FirstOrDefault(s => s.Name.Equals(line.Style, StringComparison.OrdinalIgnoreCase));
         if (style != null)
         {
@@ -149,32 +184,22 @@ public partial class AssaSetPositionViewModel : ObservableObject
             _isBottomAligned = style.Alignment == "1" || style.Alignment == "2" || style.Alignment == "3";
         }
 
-        var previewSubtitle = MakePreviewSubtitle(subtitle, line);
-        var previewScreenshotFileName = FfmpegGenerator.GetScreenShotWithSubtitle(previewSubtitle, videoWidth ?? 1920, videoHeight ?? 1080);
+        // Without a video, render at the script's own resolution so PlayRes aspect is honored and
+        // render space equals script space. GetScreenShotWithSubtitle bumps odd sizes to even for
+        // the encoder - mirror that here so the stored dimensions match the actual canvas.
+        _renderWidth = videoWidth is > 0 ? videoWidth.Value : SourceWidth;
+        _renderHeight = videoHeight is > 0 ? videoHeight.Value : SourceHeight;
+        _renderWidth += _renderWidth % 2;
+        _renderHeight += _renderHeight % 2;
+
+        var previewSubtitle = MakePreviewSubtitle(_subtitle, line);
+        var previewScreenshotFileName = FfmpegGenerator.GetScreenShotWithSubtitle(previewSubtitle, _renderWidth, _renderHeight);
         var skBitmap = SKBitmap.Decode(previewScreenshotFileName);
         var trimResult = skBitmap.TrimTransparentPixels();
 
         ScreenshotOverlayText = trimResult.TrimmedBitmap.ToAvaloniaBitmap();
         ScreenshotX = trimResult.Left;
         ScreenshotY = trimResult.Top;
-
-        if (string.IsNullOrEmpty(_subtitle.Header))
-        {
-            _subtitle.Header = AdvancedSubStationAlpha.DefaultHeader;
-        }
-
-        // Get source resolution from subtitle header
-        var oldPlayResX = AdvancedSubStationAlpha.GetTagValueFromHeader("PlayResX", "[Script Info]", _subtitle.Header);
-        if (int.TryParse(oldPlayResX, out var w) && w > 0)
-        {
-            SourceWidth = w;
-        }
-
-        var oldPlayResY = AdvancedSubStationAlpha.GetTagValueFromHeader("PlayResY", "[Script Info]", _subtitle.Header);
-        if (int.TryParse(oldPlayResY, out var h) && h > 0)
-        {
-            SourceHeight = h;
-        }
 
         // Set target resolution from video if available
         if (videoWidth.HasValue && videoWidth.Value > 0)
@@ -246,16 +271,34 @@ public partial class AssaSetPositionViewModel : ObservableObject
         return previewSubtitle;
     }
 
+    /// <summary>
+    /// Returns the header with a guaranteed PlayResX/PlayResY (stamping the fallback when either
+    /// is missing or invalid) together with the effective values.
+    /// </summary>
+    internal static (string Header, int PlayResX, int PlayResY) EnsurePlayRes(string header, int fallbackWidth, int fallbackHeight)
+    {
+        var hasX = int.TryParse(AdvancedSubStationAlpha.GetTagValueFromHeader("PlayResX", "[Script Info]", header), out var w) && w > 0;
+        var hasY = int.TryParse(AdvancedSubStationAlpha.GetTagValueFromHeader("PlayResY", "[Script Info]", header), out var h) && h > 0;
+        if (hasX && hasY)
+        {
+            return (header, w, h);
+        }
+
+        return (AdvancedSubStationAlpha.SetResolution(header, fallbackWidth, fallbackHeight), fallbackWidth, fallbackHeight);
+    }
+
     [RelayCommand]
     private async Task CenterHorizontally()
     {
-        ScreenshotX = (int)Math.Round(SourceWidth / 2.0 - ScreenshotOverlayText.Size.Width / 2.0, MidpointRounding.AwayFromZero);
+        // ScreenshotX/Y are render-space, so center on the render canvas - centering on
+        // SourceWidth (PlayRes) was off whenever the two resolutions differed.
+        ScreenshotX = (int)Math.Round(_renderWidth / 2.0 - ScreenshotOverlayText.Size.Width / 2.0, MidpointRounding.AwayFromZero);
     }
 
     [RelayCommand]
     private async Task CenterVertically()
     {
-        ScreenshotY = (int)Math.Round(SourceHeight / 2.0 - ScreenshotOverlayText.Size.Height / 2.0, MidpointRounding.AwayFromZero);
+        ScreenshotY = (int)Math.Round(_renderHeight / 2.0 - ScreenshotOverlayText.Size.Height / 2.0, MidpointRounding.AwayFromZero);
     }
 
     [RelayCommand]
@@ -313,9 +356,11 @@ public partial class AssaSetPositionViewModel : ObservableObject
             return;
         }
 
-        // Calculate scale factor based on screenshot image size
-        var scaleX = screenshotImageWidth / TargetWidth;
-        var scaleY = screenshotImageHeight / TargetHeight;
+        // Overlay coordinates are render-canvas pixels; the background screenshot always shows the
+        // same full frame, so map render space to the displayed image size. (TargetWidth is the
+        // PlayRes fallback when no video is loaded, which is the wrong space for the overlay.)
+        var scaleX = screenshotImageWidth / _renderWidth;
+        var scaleY = screenshotImageHeight / _renderHeight;
 
         // Position and size the overlay
         var overlayWidth = overlayBitmap.Size.Width * scaleX;
@@ -341,8 +386,9 @@ public partial class AssaSetPositionViewModel : ObservableObject
         ScreenshotOverlayImage.RenderTransformOrigin = RelativePoint.Center;
         ScreenshotOverlayImage.RenderTransform = new RotateTransform(-(double)Rotation);
 
+        // Show the script-space anchor that OK writes into \pos, not the render-space top-left.
         ScreenshotOverlayPosiion = Rotation == 0
-            ? $"X: {ScreenshotX}, Y: {ScreenshotY}"
-            : $"X: {ScreenshotX}, Y: {ScreenshotY}, {Rotation}°";
+            ? $"X: {ResultX}, Y: {ResultY}"
+            : $"X: {ResultX}, Y: {ResultY}, {Rotation}°";
     }
 }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -2042,6 +2042,10 @@ public partial class MainViewModel :
             return;
         }
 
+        // The dialog stamps PlayResX/Y into the header when missing; adopt it so the saved file
+        // interprets the \pos below in the same space the dialog measured in.
+        _subtitle.Header = result.ResultSubtitle.Header;
+
         var x = result.ResultX;
         var y = result.ResultY;
         var tags = $"\\pos({x},{y})";

--- a/tests/UI/Features/Assa/AssaSetPositionCoordinateSpaceTests.cs
+++ b/tests/UI/Features/Assa/AssaSetPositionCoordinateSpaceTests.cs
@@ -1,0 +1,109 @@
+using System.Threading.Tasks;
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Assa.AssaSetPosition;
+
+namespace UITests.Features.Assa;
+
+/// <summary>
+/// Regression tests for the "Set position" coordinate spaces: the overlay pipeline measures in
+/// render (video pixel) space, but libass interprets \pos() in PlayRes space — e.g.
+/// \pos(320,180) with PlayRes 640x360 is the center of a 1080p frame. The dialog used to write
+/// render pixels into the tag (off by renderSize/playRes), and the Center buttons made the
+/// opposite mistake, centering the render-space overlay on the PlayRes width.
+/// </summary>
+public class AssaSetPositionCoordinateSpaceTests
+{
+    [Theory]
+    [InlineData(960.0, 640, 1920, 320)] // 3x downscale
+    [InlineData(960.0, 1920, 1920, 960)] // identity when PlayRes == render size
+    [InlineData(100.4, 1920, 1920, 100)] // rounds
+    [InlineData(100.5, 1920, 1920, 101)] // ... away from zero
+    [InlineData(960.0, 3840, 1920, 1920)] // upscale
+    [InlineData(960.0, 0, 1920, 960)] // degenerate PlayRes: pass through
+    [InlineData(960.0, 640, 0, 960)] // degenerate render size: pass through
+    public void ToScriptSpace_ScalesByPlayResOverRenderSize(double renderValue, int playRes, int renderSize, int expected)
+    {
+        Assert.Equal(expected, AssaSetPositionViewModel.ToScriptSpace(renderValue, playRes, renderSize));
+    }
+
+    [AvaloniaFact]
+    public void ResultXy_ConvertRenderSpaceToPlayResSpace()
+    {
+        // Fresh VM: 1x1 overlay bitmap, centered/bottom alignment, render canvas 1920x1080.
+        var vm = new AssaSetPositionViewModel
+        {
+            SourceWidth = 640,
+            SourceHeight = 360,
+            ScreenshotX = 300,
+            ScreenshotY = 600,
+        };
+
+        // X: (300 + 0.5) * 640 / 1920 = 100.17 -> 100; Y: (600 + 1) * 360 / 1080 = 200.33 -> 200.
+        Assert.Equal(100, vm.ResultX);
+        Assert.Equal(200, vm.ResultY);
+    }
+
+    [AvaloniaFact]
+    public void ResultXy_AreUnchangedWhenPlayResMatchesRenderSize()
+    {
+        var vm = new AssaSetPositionViewModel
+        {
+            SourceWidth = 1920,
+            SourceHeight = 1080,
+            ScreenshotX = 300,
+            ScreenshotY = 600,
+        };
+
+        // Same values the pre-conversion code produced for the 1x1 overlay: 300.5 -> 301, 601.
+        Assert.Equal(301, vm.ResultX);
+        Assert.Equal(601, vm.ResultY);
+    }
+
+    [AvaloniaFact]
+    public async Task CenterButtons_CenterOnTheRenderCanvasNotPlayRes()
+    {
+        var vm = new AssaSetPositionViewModel
+        {
+            SourceWidth = 640, // must not influence centering
+            SourceHeight = 360,
+        };
+
+        await vm.CenterHorizontallyCommand.ExecuteAsync(null);
+        await vm.CenterVerticallyCommand.ExecuteAsync(null);
+
+        // Render canvas defaults to 1920x1080; overlay is 1x1: 960 - 0.5 -> 960, 540 - 0.5 -> 540.
+        Assert.Equal(960, vm.ScreenshotX);
+        Assert.Equal(540, vm.ScreenshotY);
+
+        // And the resulting \pos anchor is the script-space center.
+        Assert.Equal(320, vm.ResultX);
+        Assert.Equal(180, vm.ResultY);
+    }
+
+    [Fact]
+    public void EnsurePlayRes_ReadsExistingResolution()
+    {
+        var header = AdvancedSubStationAlpha.SetResolution(AdvancedSubStationAlpha.DefaultHeader, 640, 360);
+
+        var (result, w, h) = AssaSetPositionViewModel.EnsurePlayRes(header, 1920, 1080);
+
+        Assert.Equal(header, result);
+        Assert.Equal(640, w);
+        Assert.Equal(360, h);
+    }
+
+    [Fact]
+    public void EnsurePlayRes_StampsFallbackWhenMissing()
+    {
+        // The default header carries no PlayRes lines - libass would assume 384x288.
+        var header = AdvancedSubStationAlpha.DefaultHeader;
+
+        var (result, w, h) = AssaSetPositionViewModel.EnsurePlayRes(header, 1920, 1080);
+
+        Assert.Equal(1920, w);
+        Assert.Equal(1080, h);
+        Assert.Equal("1920", AdvancedSubStationAlpha.GetTagValueFromHeader("PlayResX", "[Script Info]", result));
+        Assert.Equal("1080", AdvancedSubStationAlpha.GetTagValueFromHeader("PlayResY", "[Script Info]", result));
+    }
+}


### PR DESCRIPTION
Second follow-up from the discussion #13350 analysis (builds on #13352).

### Bug

The Set position dialog measures everything in video pixels (overlay rendered at video resolution, `ScreenshotX/Y` from trimming that bitmap), but libass interprets `\pos()` in **PlayRes space** — verified with ffmpeg: a `\pos(320,180)` cue with PlayRes 640×360 renders dead-center on a 1920×1080 canvas. So whenever the script resolution differs from the video's, the saved position is off by that ratio: drag the text to the visual center of 1080p video over a 640×360 script and it plays back off-screen. The Center buttons had the inverse mix (PlayRes width vs video-pixel overlay). Usually masked because auto-set-resolution makes the two spaces coincide; live for imported scripts with their own PlayRes and whenever no video is open.

### Fix

- `ResultX/Y` convert to script space at the boundary (`ToScriptSpace`); the preview pipeline stays in render space, where it is correct for display.
- Center buttons center on the render canvas.
- Script resolution is resolved before the preview render: a header without PlayRes (libass assumes 384×288) gets an explicit resolution stamped (`EnsurePlayRes`), and `MainViewModel` adopts the header on OK so the saved file interprets the tag in the same space the dialog measured in.
- With no video, the preview renders at the script's own resolution — the overlay previously mapped onto the checkered background with mismatched spaces here too.
- The X/Y readout now shows the script-space `\pos` anchor, i.e. exactly what OK writes.

### Tests

7 conversion cases (downscale/identity/upscale/rounding/degenerate), VM-level `ResultX/Y` in both matching and differing resolutions, Center-button space check, and `EnsurePlayRes` stamp/preserve — 16 total in the file including the #13352 tests; full `Features.Assa` suite (67) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)