### PR TITLE
Fix two more ASSA style losses from bare ToParagraph() calls

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4218,7 +4218,9 @@ public partial class MainViewModel :
         {
             var subsToKeep = Subtitles.Where(p => p.StartTime.TotalSeconds >= vp.Position).ToList();
             _subtitle.Paragraphs.Clear();
-            _subtitle.Paragraphs.AddRange(subsToKeep.Select(p => p.ToParagraph()));
+            // Pass the format so Paragraph.Extra keeps the ASSA style - SetSubtitles below
+            // rebuilds the rows from these paragraphs and reads the style back from Extra.
+            _subtitle.Paragraphs.AddRange(subsToKeep.Select(p => p.ToParagraph(SelectedSubtitleFormat)));
         }
 
         AudioVisualizer.GenerateTimeCodes(_subtitle, startFromSeconds, result.ScanBlockSize.Value, result.ScanBlockAverageMin.Value, result.ScanBlockAverageMax.Value,

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -2128,7 +2128,10 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         subtitle.Paragraphs.Clear();
         foreach (var sv in subtitlesFixed)
         {
-            subtitle.Paragraphs.Add(sv.ToParagraph());
+            // Pass the format: a bare ToParagraph leaves Paragraph.Extra empty, and the ASSA
+            // writer reads the Dialogue style column from Extra - every line in a styled file
+            // would fall back to the first style in the header.
+            subtitle.Paragraphs.Add(sv.ToParagraph(subtitle.OriginalFormat));
         }
 
         return subtitle;

--- a/tests/UI/Features/Main/SubtitleLineViewModelStyleRoundTripTests.cs
+++ b/tests/UI/Features/Main/SubtitleLineViewModelStyleRoundTripTests.cs
@@ -1,0 +1,46 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Main;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// Documents the ToParagraph/ctor round-trip invariant behind the ASSA style-loss family
+/// (PRs #13352/#13353 and the waveform guess-time-codes fix): ToParagraph only fills
+/// Paragraph.Extra when it knows the format, the ASSA writer reads the style column from
+/// Extra, and the format-aware ctor reads the style back from Extra. Any round trip through
+/// a bare ToParagraph() therefore wipes the style as soon as an ASSA format re-enters.
+/// </summary>
+public class SubtitleLineViewModelStyleRoundTripTests
+{
+    private static readonly AdvancedSubStationAlpha Assa = new();
+
+    private static SubtitleLineViewModel MakeStyledLine()
+    {
+        return new SubtitleLineViewModel(new Paragraph("Hello", 0, 1000) { Extra = "Big" }, Assa);
+    }
+
+    [Fact]
+    public void FormatAwareRoundTrip_KeepsStyle()
+    {
+        var line = MakeStyledLine();
+        Assert.Equal("Big", line.Style);
+
+        var roundTripped = new SubtitleLineViewModel(line.ToParagraph(Assa), Assa);
+
+        Assert.Equal("Big", roundTripped.Style);
+    }
+
+    [Fact]
+    public void BareToParagraph_LeavesExtraEmpty()
+    {
+        var line = MakeStyledLine();
+
+        var p = line.ToParagraph();
+
+        // This is the trap: the ASSA writer and the format-aware ctor both read Extra, so a
+        // bare ToParagraph drops the style even though Paragraph.Style still carries it.
+        Assert.True(string.IsNullOrEmpty(p.Extra));
+        Assert.Equal("Big", p.Style);
+    }
+}

--- a/tests/UI/Features/Tools/BatchConvert/BatchConverterAssaStyleTests.cs
+++ b/tests/UI/Features/Tools/BatchConvert/BatchConverterAssaStyleTests.cs
@@ -1,0 +1,78 @@
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Tools.BatchConvert;
+using Nikse.SubtitleEdit.UiLogic.BatchConvert;
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace UITests.Features.Tools.BatchConvert;
+
+/// <summary>
+/// Regression test for the ASSA style-loss family (see PRs #13352/#13353): the
+/// split/break-long-lines step rebuilt the subtitle with a bare ToParagraph(), leaving
+/// Paragraph.Extra empty - and the ASSA writer takes the Dialogue style column from Extra,
+/// so a styled file came out with every line on the first style in the header.
+/// </summary>
+public class BatchConverterAssaStyleTests
+{
+    private const string InputAss = @"[Script Info]
+ScriptType: v4.00+
+PlayResX: 1920
+PlayResY: 1080
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Default,Arial,20,&H00FFFFFF,&H0300FFFF,&H00000000,&H02000000,0,0,0,0,100,100,0,0,1,2,1,2,10,10,10,1
+Style: Big,Verdana,72,&H0000FFFF,&H0300FFFF,&H00000000,&H02000000,-1,0,0,0,100,100,0,0,1,3,2,8,10,10,10,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,Hello there.
+Dialogue: 0,0:00:04.00,0:00:06.00,Big,,0,0,0,,Second line.
+";
+
+    [Fact]
+    public async Task Convert_SplitBreakLongLinesActive_KeepsAssaStyles()
+    {
+        var dir = Directory.CreateTempSubdirectory("se-assa-style-test");
+        try
+        {
+            var inputFile = Path.Combine(dir.FullName, "input.ass");
+            await File.WriteAllTextAsync(inputFile, InputAss);
+
+            var outputFolder = Path.Combine(dir.FullName, "out");
+            Directory.CreateDirectory(outputFolder);
+
+            var subtitle = Subtitle.Parse(inputFile);
+            var item = new BatchConvertItem(inputFile, new FileInfo(inputFile).Length, new AdvancedSubStationAlpha().Name, subtitle);
+
+            var config = new BatchConvertConfig
+            {
+                SaveInSourceFolder = false,
+                OutputFolder = outputFolder,
+                Overwrite = true,
+                TargetFormatName = AdvancedSubStationAlpha.NameOfFormat,
+            };
+
+            // Route the subtitle through the rebuild in SplitBreakLongLines without
+            // changing any line - the pure pass-through used to drop the styles.
+            config.SplitBreakLongLines.IsActive = true;
+            config.SplitBreakLongLines.SplitLongLines = false;
+            config.SplitBreakLongLines.RebalanceLongLines = false;
+
+            var converter = new BatchConverter(null!, null!, null!);
+            converter.Initialize(config);
+            await converter.Convert(item, CancellationToken.None);
+
+            var outputFile = Path.Combine(outputFolder, "input.ass");
+            Assert.True(File.Exists(outputFile), "converted file was not written");
+
+            var result = Subtitle.Parse(outputFile);
+            Assert.Equal(2, result.Paragraphs.Count);
+            Assert.Equal("Default", result.Paragraphs[0].Extra);
+            Assert.Equal("Big", result.Paragraphs[1].Extra);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Audit of the remaining format-less `ToParagraph()` call sites after #13352/#13353. A bare call leaves `Paragraph.Extra` empty; both the ASSA writer (Dialogue style column) and the format-aware `SubtitleLineViewModel` ctor read the style from `Extra`, so the style is lost as soon as an ASSA format re-enters the pipeline.

### Fixed (2)

- **Batch convert, split/break long lines** ([BatchConverter.cs](src/ui/Features/Tools/BatchConvert/BatchConverter.cs)): the step rebuilds the subtitle via bare `ToParagraph()`, so batch-converting a styled ASSA file with this function active reset every line to the first style in the header — even in pure pass-through (no line changed).
- **Waveform guess time codes, "delete lines from video position"** ([MainViewModel.cs](src/ui/Features/Main/MainViewModel.cs)): the kept lines were flattened with bare `ToParagraph()`, and `SetSubtitles` then rebuilds the rows with the ASSA-aware ctor, which overwrites `Style` with the empty `Extra` — wiping the style of every kept line.

### Audited, safe (3)

- `ConvertActorsViewModel` — paragraphs feed language autodetect and text transforms only; results flow back through VM copies that keep `Style`.
- `BeautifyTimeCodesViewModel` — paragraphs round-trip back into VMs via `Paragraph.Style`, which a bare call does preserve.
- `MergeContinuationLinesHelper` — paragraphs feed `QualifiesForMerge` and are discarded.

### Tests

End-to-end batch convert of a two-style .ass through the split-long-lines path (fails with `Expected: "Big", Actual: "Default"` without the fix — verified), plus a round-trip test documenting the `Extra`/`Style` invariant. Full BatchConvert suite (22) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)