### PR TITLE
Add Shift+Backspace as a forward-delete (Delete key) text box shortcut

### DIFF
--- a/src/ui/Controls/SyntaxTextEditorControl/SyntaxTextView.cs
+++ b/src/ui/Controls/SyntaxTextEditorControl/SyntaxTextView.cs
@@ -1599,7 +1599,8 @@ public class SyntaxTextView : Control
         ApplyEdit(start, _caretOffset - start, string.Empty);
     }
 
-    private void DeleteForward()
+    /// <summary>Deletes the selection, or the character after the caret (the Delete key).</summary>
+    public void DeleteForward()
     {
         if (IsReadOnly)
         {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -15448,10 +15448,13 @@ public partial class MainViewModel :
         }
     }
 
+    // Deletes the selection, or the character after the caret - a stand-in for the Delete key,
+    // defaulting to Shift+Backspace for Apple keyboards where Delete is only a backspace.
     [RelayCommand]
-    private void TextBoxDeleteSelection()
+    private void TextBoxDeleteForward()
     {
-        EditTextBox.SelectedText = string.Empty;
+        var textBox = EditTextBoxOriginal.IsFocused ? EditTextBoxOriginal : EditTextBox;
+        textBox.DeleteForward();
     }
 
     [RelayCommand]
@@ -22417,8 +22420,7 @@ public partial class MainViewModel :
         ReferenceEquals(command, TextBoxCut2Command) ||
         ReferenceEquals(command, TextBoxCopyCommand) ||
         ReferenceEquals(command, TextBoxPasteCommand) ||
-        ReferenceEquals(command, TextBoxSelectAllCommand) ||
-        ReferenceEquals(command, TextBoxDeleteSelectionCommand);
+        ReferenceEquals(command, TextBoxSelectAllCommand);
 
     /// <summary>
     /// Tunnelling pointer handler that tells <see cref="_altMenuActivationGuard"/> when Alt was used as

--- a/src/ui/Features/Shared/TextBoxUtils/ITextBoxWrapper.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/ITextBoxWrapper.cs
@@ -24,6 +24,8 @@ public interface ITextBoxWrapper
     void Paste();
     void SelectAll();
     void ClearSelection();
+    /// <summary>Deletes the selection, or the character after the caret (the Delete key).</summary>
+    void DeleteForward();
     void SetAlignment(Avalonia.Media.TextAlignment alignment);
 
     // Live spell check - a no-op for editors without underline support (plain TextBox).

--- a/src/ui/Features/Shared/TextBoxUtils/SyntaxTextEditorWrapper.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/SyntaxTextEditorWrapper.cs
@@ -85,6 +85,8 @@ public class SyntaxTextEditorWrapper : ITextBoxWrapper
 
     public void ClearSelection() => _editor.ClearSelection();
 
+    public void DeleteForward() => _editor.View.DeleteForward();
+
     /// <summary>
     /// Source text is always left aligned - centering it would only make the time codes harder to
     /// read. The subtitle edit box is the one that follows this setting.

--- a/src/ui/Features/Shared/TextBoxUtils/TextBoxWrapper.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/TextBoxWrapper.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using Nikse.SubtitleEdit.Controls;
 using Nikse.SubtitleEdit.Features.SpellCheck;
 using Nikse.SubtitleEdit.Logic;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Nikse.SubtitleEdit.UiLogic.SpellCheck;
@@ -100,6 +101,28 @@ public class TextBoxWrapper : ITextBoxWrapper
     public void ClearSelection()
     {
         _textBox.ClearSelection();
+    }
+
+    public void DeleteForward()
+    {
+        if (_textBox.SelectionStart != _textBox.SelectionEnd)
+        {
+            _textBox.SelectedText = string.Empty;
+            return;
+        }
+
+        var text = _textBox.Text ?? string.Empty;
+        var caret = _textBox.CaretIndex;
+        if (caret >= text.Length)
+        {
+            return;
+        }
+
+        // Delete a whole text element so CRLF, surrogate pairs, and combining marks go together.
+        var length = System.Globalization.StringInfo.GetNextTextElementLength(text.AsSpan(caret));
+        _textBox.SelectionStart = caret;
+        _textBox.SelectionEnd = caret + length;
+        _textBox.SelectedText = string.Empty;
     }
 
     public void SetAlignment(Avalonia.Media.TextAlignment alignment)

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -94,7 +94,7 @@ public class LanguageSettingsShortcuts
     public string VideoGoToPreviousTimeCode { get; set; }
     public string VideoGoToNextTimeCode { get; set; }
     public string GoToNextLineAndSetVideoPosition { get; set; }
-    public string TextBoxDeleteSelectionNoClipboard { get; set; }
+    public string TextBoxDeleteForward { get; set; }
     public string TextBoxCut { get; set; }
     public string TextBoxCut2 { get; set; }
     public string TextBoxPaste { get; set; }
@@ -350,7 +350,7 @@ public class LanguageSettingsShortcuts
         GoToNextLineFromVideoPosition = "Go to next subtitle (from current video position)";
         VideoGoToPreviousTimeCode = "Go to previous time code";
         VideoGoToNextTimeCode = "Go to next time code";
-        TextBoxDeleteSelectionNoClipboard = "Text box: Delete selection (no clipboard)";
+        TextBoxDeleteForward = "Text box: Delete selection or next character (forward delete)";
         TextBoxCut = "Text box: Cut";
         TextBoxCut2 = "Text box: Cut (alternative)";
         TextBoxPaste = "Text box: Paste";

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -16,7 +16,7 @@ namespace Nikse.SubtitleEdit.Logic.Config;
 public class Se
 {
     internal const int CurrentMacOsFontMigrationVersion = 1;
-    internal const int CurrentShortcutsMigrationVersion = 1;
+    internal const int CurrentShortcutsMigrationVersion = 2;
 
     public static string Version { get; set; } = "v5.2.0-beta6";
 
@@ -288,23 +288,42 @@ public class Se
     /// standard F10 menu-bar activation (#13083). The default is gone now, and the stale persisted
     /// copy - indistinguishable from a user assignment - is cleared here once; users who really
     /// want F10 on the action can assign it again and it will stick.
+    ///
+    /// Version 2: "Text box: Delete selection (no clipboard)" grew into the forward-delete
+    /// (Delete key) command and was renamed; the persisted entry is renamed with it so user
+    /// assignments - including a deliberately cleared binding - survive.
     /// </summary>
     internal void MigrateShortcuts()
     {
-        if (ShortcutsMigrationVersion.GetValueOrDefault() >= CurrentShortcutsMigrationVersion)
+        var fromVersion = ShortcutsMigrationVersion.GetValueOrDefault();
+        if (fromVersion >= CurrentShortcutsMigrationVersion)
         {
             return;
         }
 
         ShortcutsMigrationVersion = CurrentShortcutsMigrationVersion;
 
-        foreach (var shortcut in Shortcuts)
+        if (fromVersion < 1)
         {
-            if (shortcut.ActionName == nameof(MainViewModel.WaveformSetEndAndGoToNextCommand) &&
-                shortcut.Keys.Count == 1 &&
-                shortcut.Keys[0].Equals(nameof(Avalonia.Input.Key.F10), StringComparison.OrdinalIgnoreCase))
+            foreach (var shortcut in Shortcuts)
             {
-                shortcut.Keys.Clear();
+                if (shortcut.ActionName == nameof(MainViewModel.WaveformSetEndAndGoToNextCommand) &&
+                    shortcut.Keys.Count == 1 &&
+                    shortcut.Keys[0].Equals(nameof(Avalonia.Input.Key.F10), StringComparison.OrdinalIgnoreCase))
+                {
+                    shortcut.Keys.Clear();
+                }
+            }
+        }
+
+        if (fromVersion < 2)
+        {
+            foreach (var shortcut in Shortcuts)
+            {
+                if (shortcut.ActionName == "TextBoxDeleteSelectionCommand")
+                {
+                    shortcut.ActionName = nameof(MainViewModel.TextBoxDeleteForwardCommand);
+                }
             }
         }
     }

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -248,7 +248,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.SplitAtVideoPositionCommand), Se.Language.General.SplitLineAtVideoPosition },
         { nameof(MainViewModel.SplitAtTextBoxCursorPositionCommand), Se.Language.General.SplitAtTextBoxCursorPosition },
         { nameof(MainViewModel.SplitAtVideoPositionAndTextBoxCursorPositionCommand), Se.Language.General.SplitLineAtVideoAndTextBoxPosition },
-        { nameof(MainViewModel.TextBoxDeleteSelectionCommand), Se.Language.Options.Shortcuts.TextBoxDeleteSelectionNoClipboard },
+        { nameof(MainViewModel.TextBoxDeleteForwardCommand), Se.Language.Options.Shortcuts.TextBoxDeleteForward },
         { nameof(MainViewModel.TextBoxCutCommand), Se.Language.Options.Shortcuts.TextBoxCut },
         { nameof(MainViewModel.TextBoxCut2Command), Se.Language.Options.Shortcuts.TextBoxCut2 },
         { nameof(MainViewModel.TextBoxPasteCommand), Se.Language.Options.Shortcuts.TextBoxPaste },
@@ -600,7 +600,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.SplitAtVideoPositionCommand, nameof(vm.SplitAtVideoPositionCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SplitAtTextBoxCursorPositionCommand, nameof(vm.SplitAtTextBoxCursorPositionCommand), ShortcutCategory.TextBox);
         AddShortcut(shortcuts, vm.SplitAtVideoPositionAndTextBoxCursorPositionCommand, nameof(vm.SplitAtVideoPositionAndTextBoxCursorPositionCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.TextBoxDeleteSelectionCommand, nameof(vm.TextBoxDeleteSelectionCommand), ShortcutCategory.TextBox);
+        AddShortcut(shortcuts, vm.TextBoxDeleteForwardCommand, nameof(vm.TextBoxDeleteForwardCommand), ShortcutCategory.TextBox);
         AddShortcut(shortcuts, vm.TextBoxCutCommand, nameof(vm.TextBoxCutCommand), ShortcutCategory.TextBox);
         AddShortcut(shortcuts, vm.TextBoxCut2Command, nameof(vm.TextBoxCut2Command), ShortcutCategory.TextBox);
         AddShortcut(shortcuts, vm.TextBoxPasteCommand, nameof(vm.TextBoxPasteCommand), ShortcutCategory.TextBox);
@@ -923,7 +923,8 @@ public static class ShortcutsMain
             new(nameof(vm.VideoOneSecondForwardCommand), [nameof(Avalonia.Input.Key.Right)], ShortcutCategory.General),
             new(nameof(vm.ShowHelpCommand), [nameof(Avalonia.Input.Key.F1)], ShortcutCategory.General),
             new(nameof(vm.ShowSourceViewCommand), [nameof(Avalonia.Input.Key.F2)], ShortcutCategory.General),
-            new(nameof(vm.TextBoxDeleteSelectionCommand), ["Shift", nameof(Avalonia.Input.Key.Back)], ShortcutCategory.TextBox),
+            // Forward delete for Apple keyboards, where the Delete key is only a backspace.
+            new(nameof(vm.TextBoxDeleteForwardCommand), ["Shift", nameof(Avalonia.Input.Key.Back)], ShortcutCategory.TextBox),
             new(nameof(vm.TextBoxCut2Command), ["Shift", nameof(Avalonia.Input.Key.Delete) ], ShortcutCategory.TextBox),
             new(nameof(vm.TextBoxCutCommand), [cmd, nameof(Avalonia.Input.Key.X)], ShortcutCategory.TextBox),
             new(nameof(vm.TextBoxPasteCommand), [cmd, nameof(Avalonia.Input.Key.V)], ShortcutCategory.TextBox),

--- a/tests/UI/Features/TextBoxWrapperDeleteForwardTests.cs
+++ b/tests/UI/Features/TextBoxWrapperDeleteForwardTests.cs
@@ -1,0 +1,73 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Features.Shared.TextBoxUtils;
+
+namespace UITests.Features;
+
+/// <summary>
+/// DeleteForward emulates the Delete key on the plain TextBox wrapper (the syntax editor has its
+/// own native implementation): delete the selection, or the whole text element after the caret -
+/// CRLF and surrogate pairs must never be split in half.
+/// </summary>
+public class TextBoxWrapperDeleteForwardTests
+{
+    private static TextBoxWrapper MakeWrapper(string text, int caretIndex, out TextBox textBox)
+    {
+        textBox = new TextBox { Text = text, CaretIndex = caretIndex };
+        return new TextBoxWrapper(textBox);
+    }
+
+    [AvaloniaFact]
+    public void DeletesCharacterAfterCaret()
+    {
+        var wrapper = MakeWrapper("abc", 1, out var textBox);
+
+        wrapper.DeleteForward();
+
+        Assert.Equal("ac", textBox.Text);
+        Assert.Equal(1, textBox.CaretIndex);
+    }
+
+    [AvaloniaFact]
+    public void AtEndOfTextDoesNothing()
+    {
+        var wrapper = MakeWrapper("abc", 3, out var textBox);
+
+        wrapper.DeleteForward();
+
+        Assert.Equal("abc", textBox.Text);
+        Assert.Equal(3, textBox.CaretIndex);
+    }
+
+    [AvaloniaFact]
+    public void DeletesSelectionInsteadOfCharacter()
+    {
+        var wrapper = MakeWrapper("abcdef", 0, out var textBox);
+        textBox.SelectionStart = 1;
+        textBox.SelectionEnd = 4;
+
+        wrapper.DeleteForward();
+
+        Assert.Equal("aef", textBox.Text);
+    }
+
+    [AvaloniaFact]
+    public void DeletesCrLfAsOneStep()
+    {
+        var wrapper = MakeWrapper("a\r\nb", 1, out var textBox);
+
+        wrapper.DeleteForward();
+
+        Assert.Equal("ab", textBox.Text);
+    }
+
+    [AvaloniaFact]
+    public void DeletesSurrogatePairAsOneStep()
+    {
+        var wrapper = MakeWrapper("a\U0001F600b", 1, out var textBox);
+
+        wrapper.DeleteForward();
+
+        Assert.Equal("ab", textBox.Text);
+    }
+}

--- a/tests/UI/Logic/ShortcutsForwardDeleteMigrationTests.cs
+++ b/tests/UI/Logic/ShortcutsForwardDeleteMigrationTests.cs
@@ -1,0 +1,69 @@
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// "Text box: Delete selection (no clipboard)" grew into the forward-delete (Delete key) command
+/// - defaulting to Shift+Backspace so Apple keyboards, whose Delete key is only a backspace, get
+/// a real Delete key. The rename is carried into persisted settings by shortcut migration v2 so
+/// user assignments (including a deliberately cleared binding) survive the upgrade.
+/// </summary>
+public class ShortcutsForwardDeleteMigrationTests
+{
+    private const string OldName = "TextBoxDeleteSelectionCommand";
+    private const string NewName = nameof(MainViewModel.TextBoxDeleteForwardCommand);
+
+    [Fact]
+    public void DefaultBindsShiftBackspaceToForwardDelete()
+    {
+        // GetDefaultShortcuts only uses the vm parameter for nameof() - never dereferenced.
+        var defaults = ShortcutsMain.GetDefaultShortcuts(null!);
+
+        var forwardDelete = defaults.Single(s => s.ActionName == NewName);
+        Assert.Equal(new[] { "Shift", "Back" }, forwardDelete.Keys);
+        Assert.DoesNotContain(defaults, s => s.ActionName == OldName);
+    }
+
+    [Fact]
+    public void MigrationRenamesPersistedEntryAndKeepsCustomKeys()
+    {
+        var settings = new Se();
+        settings.Shortcuts.Add(new SeShortCut(OldName, ["Control", "D"]));
+
+        settings.MigrateShortcuts();
+
+        Assert.Equal(new[] { "Control", "D" }, settings.Shortcuts.Single(s => s.ActionName == NewName).Keys);
+        Assert.DoesNotContain(settings.Shortcuts, s => s.ActionName == OldName);
+        Assert.Equal(Se.CurrentShortcutsMigrationVersion, settings.ShortcutsMigrationVersion);
+    }
+
+    [Fact]
+    public void MigratedClearedBindingIsNotRevivedByDefaultsMerge()
+    {
+        // The user unbound the old command on purpose; after rename the defaults merge must not
+        // hand the renamed command its Shift+Backspace default back.
+        var settings = new Se();
+        settings.Shortcuts.Add(new SeShortCut(OldName, []));
+
+        settings.InitializeMainShortcuts(null!);
+
+        Assert.Empty(settings.Shortcuts.Single(s => s.ActionName == NewName).Keys);
+    }
+
+    [Fact]
+    public void MigrationFromVersion1OnlyRunsVersion2Step()
+    {
+        // A user already at migration v1 re-assigned F10 afterwards; jumping to v2 must apply
+        // only the rename and leave the v1-covered F10 binding alone.
+        var settings = new Se { ShortcutsMigrationVersion = 1 };
+        settings.Shortcuts.Add(new SeShortCut(nameof(MainViewModel.WaveformSetEndAndGoToNextCommand), ["F10"]));
+        settings.Shortcuts.Add(new SeShortCut(OldName, ["Shift", "Back"]));
+
+        settings.MigrateShortcuts();
+
+        Assert.Equal(new[] { "F10" }, settings.Shortcuts[0].Keys);
+        Assert.Equal(NewName, settings.Shortcuts[1].ActionName);
+    }
+}


### PR DESCRIPTION
### What

A user emailed: with an Apple Bluetooth keyboard on Windows, the key labeled "delete" is a backspace, and there is no forward-delete key at all (Mac laptops have the same layout; there Fn+Delete helps, but on Windows there is no Fn-layer fallback). Shift+Backspace now acts as a real Delete key in the subtitle text boxes: it deletes the selection, or the character after the caret.

### How

- The existing **"Text box: Delete selection (no clipboard)"** command already held the Shift+Backspace default, but it sat on the native-clipboard skip list, so it never fired from the keyboard. It grows into the new customizable **"Text box: Delete selection or next character (forward delete)"** command and comes off the skip list.
- The command targets whichever edit box is focused (main or original) via a new `ITextBoxWrapper.DeleteForward()`:
  - the syntax editor reuses its native `DeleteForward()` (now public),
  - the plain TextBox wrapper deletes one whole text element per step, so CRLF and surrogate pairs are never split.
- **Shortcut migration v2** renames the persisted `TextBoxDeleteSelectionCommand` entry to `TextBoxDeleteForwardCommand`, so existing user assignments — including a deliberately cleared binding — survive; `MigrateShortcuts` is now gated per version.
- Language string renamed to `TextBoxDeleteForward` (translations of the old key will fall back to English until updated, since the meaning changed).

### Tests

- Migration: default gesture present, rename keeps custom keys, cleared binding not revived by the defaults merge, v1→v2 upgrade only runs the v2 step. Existing F10 migration tests still pass.
- Wrapper: deletes char after caret, no-op at end, deletes selection, CRLF and surrogate pair deleted as one step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)