### PR TITLE
Harden BeautifyTimeCodes OK: adjust times in place, keep row state

### DIFF
--- a/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
@@ -621,21 +621,39 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
         StopPositionTimer();
         _timerUpdatePreview.StopAndDispose(TimerUpdatePreviewElapsed);
 
-        // Apply final beautification to commit the result back to _allSubtitles
-        var subtitle = BuildSubtitleFromRows();
-
-        var beautifier = new Core.Forms.TimeCodesBeautifier(subtitle, _frameRate, new List<double>(), _shotChanges);
-        beautifier.Beautify();
-
-        _allSubtitles.Clear();
-        var subRipFormat = new SubRip();
-        foreach (var p in subtitle.Paragraphs)
-        {
-            _allSubtitles.Add(new SubtitleLineViewModel(p, subRipFormat));
-        }
+        CommitBeautifiedTimes(_allSubtitles, _frameRate, _shotChanges);
 
         OkPressed = true;
         Window?.Close();
+    }
+
+    /// <summary>
+    /// Runs the final beautify and writes the new times back onto the existing rows (sorted by
+    /// start time, as the beautifier expects). The rows keep all their view-model-only state -
+    /// the previous rebuild from Paragraphs silently dropped OriginalText, Id and the ASSA style.
+    /// </summary>
+    internal static void CommitBeautifiedTimes(List<SubtitleLineViewModel> rows, double frameRate, List<double> shotChanges)
+    {
+        var ordered = rows.OrderBy(p => p.StartTime.TotalMilliseconds).ToList();
+        var subtitle = new Subtitle();
+        foreach (var vm in ordered)
+        {
+            subtitle.Paragraphs.Add(vm.ToParagraph());
+        }
+
+        var beautifier = new Core.Forms.TimeCodesBeautifier(subtitle, frameRate, new List<double>(), shotChanges);
+        beautifier.Beautify();
+
+        // Beautify adjusts cue boundaries only, so the paragraphs still line up with the rows.
+        for (var i = 0; i < ordered.Count && i < subtitle.Paragraphs.Count; i++)
+        {
+            ordered[i].StartTime = TimeSpan.FromMilliseconds(subtitle.Paragraphs[i].StartTime.TotalMilliseconds);
+            ordered[i].EndTime = TimeSpan.FromMilliseconds(subtitle.Paragraphs[i].EndTime.TotalMilliseconds);
+            ordered[i].UpdateDuration();
+        }
+
+        rows.Clear();
+        rows.AddRange(ordered);
     }
 
     [RelayCommand]

--- a/tests/UI/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesCommitTests.cs
+++ b/tests/UI/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesCommitTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Tools.BeautifyTimeCodes;
+
+namespace UITests.Features.Tools.BeautifyTimeCodes;
+
+/// <summary>
+/// The beautify OK path used to rebuild its rows from Paragraphs, silently dropping
+/// view-model-only state (OriginalText, Id, ASSA style via Extra). The shipped callers only
+/// copied times back so nothing was lost in practice, but any consumer taking whole rows
+/// would get degraded data. CommitBeautifiedTimes must adjust times in place instead.
+/// </summary>
+public class BeautifyTimeCodesCommitTests
+{
+    private static SubtitleLineViewModel MakeLine(string text, string originalText, string style, int startMs, int endMs)
+    {
+        var line = new SubtitleLineViewModel(
+            new Paragraph(text, startMs, endMs) { Extra = style },
+            new AdvancedSubStationAlpha());
+        line.OriginalText = originalText;
+        return line;
+    }
+
+    [Fact]
+    public void CommitBeautifiedTimes_AdjustsTimesInPlaceAndKeepsRowState()
+    {
+        // Deliberately unsorted, with off-frame time codes.
+        var line2 = MakeLine("Second", "Orig 2", "Big", 4007, 6499);
+        var line1 = MakeLine("First", "Orig 1", "Default", 1013, 3987);
+        var rows = new List<SubtitleLineViewModel> { line2, line1 };
+        var ids = new[] { line1.Id, line2.Id };
+
+        BeautifyTimeCodesViewModel.CommitBeautifiedTimes(rows, 25.0, new List<double>());
+
+        // Same instances, sorted by start time - nothing rebuilt.
+        Assert.Equal(2, rows.Count);
+        Assert.Same(line1, rows[0]);
+        Assert.Same(line2, rows[1]);
+        Assert.Equal(ids[0], rows[0].Id);
+        Assert.Equal(ids[1], rows[1].Id);
+
+        // View-model-only state survives.
+        Assert.Equal("Orig 1", rows[0].OriginalText);
+        Assert.Equal("Orig 2", rows[1].OriginalText);
+        Assert.Equal("Default", rows[0].Style);
+        Assert.Equal("Big", rows[1].Style);
+
+        // And the beautifier actually ran: all time codes are aligned to 25 fps frames.
+        foreach (var row in rows)
+        {
+            foreach (var ms in new[] { row.StartTime.TotalMilliseconds, row.EndTime.TotalMilliseconds })
+            {
+                var frames = ms * 25.0 / 1000.0;
+                Assert.True(Math.Abs(frames - Math.Round(frames)) < 0.1,
+                    $"time code {ms} ms is not aligned to a 25 fps frame");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Follow-up from the #13355 audit, prompted by a closer look at the BeautifyTimeCodes OK path.

**Finding first:** this is *not* a user-visible bug today — both `MainViewModel` callers only copy the beautified `StartTime`/`EndTime` back onto the live grid rows, so nothing is currently lost.

**The trap:** `Ok()` rebuilt `_allSubtitles` from `Paragraph`s after beautifying, which strips view-model-only state — `OriginalText`, row `Id`, and the ASSA style for any future format-aware consumer (`Extra` is empty after a bare `ToParagraph`, same family as #13352/#13353/#13355). Any future consumer of `GetBeautifiedSubtitles()` that takes whole rows instead of just times would silently lose data.

**Change:** `CommitBeautifiedTimes` writes the beautified times back onto the original row instances (sorted by start time, as before) instead of rebuilding them. Covered by a test pinning instance identity, `OriginalText`/style survival, and 25 fps frame alignment. Existing beautify batch tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)