### PR TITLE
Cut video preview settle latency to ~0.27 s and trim ASSA save allocations

### DIFF
--- a/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
@@ -156,7 +156,9 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
             var styles = new List<string>();
             if (isValidAssHeader)
             {
-                sb.AppendLine(subtitle.Header.Trim());
+                // Trim via span: Header.Trim() re-allocated the whole (possibly multi-KB)
+                // header on every save and every mpv preview refresh.
+                sb.Append(subtitle.Header.AsSpan().Trim()).AppendLine();
                 sb.AppendLine("Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text");
                 styles = GetStylesFromHeader(subtitle.Header);
             }
@@ -269,7 +271,6 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                     effect = p.Effect;
                 }
 
-                var text = p.Text.Replace(Environment.NewLine, "\\N");
                 // Layout: "(Dialogue|Comment): {layer},{start},{end},{style},{actor},{marginL},{marginR},{marginV},{effect},{text}".
                 // Appending directly skips AppendFormat's per-call format parsing, the object[10]
                 // and the boxed layer, plus the two intermediate time-code strings.
@@ -283,7 +284,21 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                 sb.Append(marginR).Append(',');
                 sb.Append(marginV).Append(',');
                 sb.Append(effect).Append(',');
-                sb.Append(FormatText(text)).AppendLine();
+                if (p.Text.Contains('<'))
+                {
+                    // Rare path (HTML-style tags present): keep the original order -
+                    // newline replace first, then tag conversion.
+                    sb.Append(FormatText(p.Text.Replace(Environment.NewLine, "\\N")));
+                }
+                else
+                {
+                    // Common path: append span chunks around the newlines instead of
+                    // allocating an intermediate Replace string per line (FormatText is
+                    // an identity function without '<').
+                    AppendTextWithAssaNewLines(sb, p.Text);
+                }
+
+                sb.AppendLine();
             }
 
             if (!string.IsNullOrEmpty(subtitle.Footer) &&
@@ -320,6 +335,24 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
             sb.Append('.');
             AppendNumber(sb, fragment, 2);
             return sb;
+        }
+
+        // Appends the text with Environment.NewLine replaced by "\N", matching
+        // string.Replace's left-to-right non-overlapping semantics without the
+        // intermediate string allocation.
+        private static void AppendTextWithAssaNewLines(StringBuilder sb, string text)
+        {
+            var span = text.AsSpan();
+            var newLine = Environment.NewLine.AsSpan();
+            var index = span.IndexOf(newLine, StringComparison.Ordinal);
+            while (index >= 0)
+            {
+                sb.Append(span[..index]).Append('\\').Append('N');
+                span = span[(index + newLine.Length)..];
+                index = span.IndexOf(newLine, StringComparison.Ordinal);
+            }
+
+            sb.Append(span);
         }
 
         // Matches "{0:00}"-style formatting: sign first, then the absolute value padded with

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -23460,6 +23460,12 @@ public partial class MainViewModel :
         _cursorTimer = new DispatcherTimer(DispatcherPriority.Normal) { Interval = TimeSpan.FromMilliseconds(16) };
         _cursorTimer.Tick += (s, e) =>
         {
+            // Fast settle for the on-video subtitle preview: waiting for the 400 ms _slowTimer
+            // added up to 400 ms of tick alignment on top of the settle window, so the preview
+            // trailed the text by up to ~0.9 s. Checking here costs one bool in the steady
+            // state (the dirty flag gates everything else).
+            TryRefreshVideoPreview();
+
             var vp = GetVideoPlayerControl();
             if (vp == null || string.IsNullOrEmpty(_videoFileName))
             {
@@ -23512,47 +23518,83 @@ public partial class MainViewModel :
             UpdateGaps();
             AutoSaveTick(mainHash, originalHash);
 
-            var vp = GetVideoPlayerControl();
-            // IsUserEditing: refreshing the preview mid-edit means paying GetUpdateSubtitle +
-            // two Subtitle copies + ToText + a temp-file write on the UI thread every 400 ms
-            // while the user types or drags in the waveform (issue #13234). The dirty flag
-            // stays set, so the settled state is pushed on the first quiet tick - and the
-            // preview reads better settling once than flickering mid-word anyway.
-            if (!_mpvPreviewDirty || vp == null || _mpvPreviewRefreshBusy || IsUserEditing())
-            {
-                return;
-            }
-
-            // Filter once instead of: Where().ToList() + Clear + AddRange (which
-            // allocates an extra List and walks the paragraphs three times).
-            // Verified with BenchmarkDotNet at ~1.7-2x faster and 0-45 % less
-            // allocation across 100/1000/5000-line subtitles.
-            var hideLayers = _visibleLayers != null && Se.Settings.Assa.HideLayersFromVideoPreview;
-
-            if (vp.VideoPlayer is LibMpvDynamicPlayer mpv)
-            {
-                var subtitle = GetUpdateSubtitle();
-                _mpvPreviewDirty = false; // clear only after subtitle snapshot is successfully obtained
-                if (hideLayers)
-                {
-                    subtitle.Paragraphs.RemoveAll(p => !_visibleLayers!.Contains(p.Layer));
-                }
-
-                _ = RunPreviewRefresh(() => _mpvReloader.RefreshMpv(mpv, subtitle, _subtitleSecondary, SelectedSubtitleFormat));
-            }
-            else if (vp.VideoPlayer is LibVlcDynamicPlayer vlc)
-            {
-                var subtitle = GetUpdateSubtitle();
-                _mpvPreviewDirty = false; // clear only after subtitle snapshot is successfully obtained
-                if (hideLayers)
-                {
-                    subtitle.Paragraphs.RemoveAll(p => !_visibleLayers!.Contains(p.Layer));
-                }
-
-                _ = RunPreviewRefresh(() => _vlcReloader.RefreshVlc(vlc, subtitle, _subtitleSecondary, SelectedSubtitleFormat));
-            }
+            TryRefreshVideoPreview();
         };
         _slowTimer.Start();
+    }
+
+    // Preview settle window after the last keystroke. Deliberately shorter than
+    // IsUserEditing()'s 500 ms undo window: the expensive serialize now runs off the UI
+    // thread in MpvReloader.RefreshMpv, so a refresh landing in a short typing pause no
+    // longer risks a felt hitch, and the on-video preview follows the text much sooner
+    // (issue #13234 follow-up). Undo change detection keeps the full 500 ms.
+    private const int PreviewSettleAfterTypingMs = 250;
+    private long _previewRetryNotBeforeMs;
+
+    private bool IsUserEditingForPreview()
+    {
+        if (_lastKeyPressedMs != 0 && Environment.TickCount64 - _lastKeyPressedMs < PreviewSettleAfterTypingMs)
+        {
+            return true;
+        }
+
+        // Dragging in the waveform is the pointer equivalent of typing - see IsUserEditing().
+        return AudioVisualizer?.IsEditingWithPointer == true;
+    }
+
+    // Called at ~60 fps from _cursorTimer (fast settle after edits) and every 400 ms from
+    // _slowTimer (safety net when the cursor timer is stopped). Refreshing the preview
+    // mid-edit means paying GetUpdateSubtitle + a Subtitle copy on the UI thread on every
+    // settle check while the user types or drags in the waveform (issue #13234). The dirty
+    // flag stays set, so the settled state is pushed on the first quiet tick - and the
+    // preview reads better settling once than flickering mid-word anyway.
+    private void TryRefreshVideoPreview()
+    {
+        if (!_mpvPreviewDirty || _mpvPreviewRefreshBusy || IsUserEditingForPreview())
+        {
+            return;
+        }
+
+        // After a failed refresh, retry at the old slow cadence instead of ~60 fps.
+        if (Environment.TickCount64 < _previewRetryNotBeforeMs)
+        {
+            return;
+        }
+
+        var vp = GetVideoPlayerControl();
+        if (vp == null)
+        {
+            return;
+        }
+
+        // Filter once instead of: Where().ToList() + Clear + AddRange (which
+        // allocates an extra List and walks the paragraphs three times).
+        // Verified with BenchmarkDotNet at ~1.7-2x faster and 0-45 % less
+        // allocation across 100/1000/5000-line subtitles.
+        var hideLayers = _visibleLayers != null && Se.Settings.Assa.HideLayersFromVideoPreview;
+
+        if (vp.VideoPlayer is LibMpvDynamicPlayer mpv)
+        {
+            var subtitle = GetUpdateSubtitle();
+            _mpvPreviewDirty = false; // clear only after subtitle snapshot is successfully obtained
+            if (hideLayers)
+            {
+                subtitle.Paragraphs.RemoveAll(p => !_visibleLayers!.Contains(p.Layer));
+            }
+
+            _ = RunPreviewRefresh(() => _mpvReloader.RefreshMpv(mpv, subtitle, _subtitleSecondary, SelectedSubtitleFormat));
+        }
+        else if (vp.VideoPlayer is LibVlcDynamicPlayer vlc)
+        {
+            var subtitle = GetUpdateSubtitle();
+            _mpvPreviewDirty = false; // clear only after subtitle snapshot is successfully obtained
+            if (hideLayers)
+            {
+                subtitle.Paragraphs.RemoveAll(p => !_visibleLayers!.Contains(p.Layer));
+            }
+
+            _ = RunPreviewRefresh(() => _vlcReloader.RefreshVlc(vlc, subtitle, _subtitleSecondary, SelectedSubtitleFormat));
+        }
     }
 
     private async Task RunPreviewRefresh(Func<Task> refresh)
@@ -23566,6 +23608,7 @@ public partial class MainViewModel :
         {
             Se.LogError(exception, "Video preview subtitle refresh failed");
             _mpvPreviewDirty = true; // retry on a later tick
+            _previewRetryNotBeforeMs = Environment.TickCount64 + 400;
         }
         finally
         {

--- a/src/ui/Logic/Media/MpvReloader.cs
+++ b/src/ui/Logic/Media/MpvReloader.cs
@@ -26,10 +26,17 @@ public class MpvReloader : IMpvReloader
     private int _retryCount = 3;
     private string? _mpvPreviewStyleHeader;
 
+    // Bumped whenever newer state supersedes an in-flight background serialize (a newer
+    // refresh, a reset, or a subtitle removal), so the stale result is discarded instead
+    // of pushing old text over new. Only touched on the UI thread.
+    private int _refreshVersion;
+
     public async Task RefreshMpv(LibMpvDynamicPlayer mpvContext, Subtitle subtitle, Subtitle? subtitleSecondary, SubtitleFormat uiFormat)
     {
         if (subtitle.Paragraphs.Count == 0 && subtitleSecondary == null)
         {
+            _refreshVersion++; // an in-flight serialize would re-add the removed subtitle
+
             // All subtitles were deleted - remove any previously loaded subtitle from mpv,
             // otherwise the last shown lines stay visible on the video.
             if (!string.IsNullOrEmpty(_mpvTextFileName) || !string.IsNullOrEmpty(_mpvTextOld))
@@ -56,119 +63,43 @@ public class MpvReloader : IMpvReloader
         try
         {
             var uiFormatType = uiFormat.GetType();
+
+            // Deep copy on the calling (UI) thread: the caller usually passes the live
+            // GetUpdateSubtitle() instance, which other UI code clears and repopulates at
+            // will, so it must not be touched from the background serialize below.
             subtitle = new Subtitle(subtitle, false);
 
-            if (SmpteMode)
+            // Prime the lazy style-header memo while still on the UI thread, so the
+            // background thread only ever reads the field (UpdateMpvStyle writes it
+            // from the settings dialog on the UI thread).
+            _ = MpvPreviewStyleHeader;
+
+            var version = ++_refreshVersion;
+            var oldHash = _mpvSubOldHash;
+            var oldText = _mpvTextOld;
+
+            // Serialize off the UI thread: the SMPTE/RTL/header transforms + hash + ToText
+            // are the expensive part of a preview refresh, and running them on the UI thread
+            // is why the preview used to wait out a long typing pause (issue #13234).
+            // "subtitle" is a thread-confined copy from here on; the secondary subtitle is
+            // only read (its paragraphs are never mutated by the transforms).
+            var built = await Task.Run(() => BuildPreviewText(subtitle, subtitleSecondary, uiFormatType, oldHash, oldText));
+
+            if (version != _refreshVersion)
             {
-                foreach (var paragraph in subtitle.Paragraphs)
-                {
-                    paragraph.StartTime.TotalMilliseconds *= 1.001;
-                    paragraph.EndTime.TotalMilliseconds *= 1.001;
-                }
+                // Superseded while serializing (newer refresh, reset, or removal) -
+                // applying this result would push stale text over newer state.
+                return;
             }
 
-            SubtitleFormat format = _assFormat;
-            string text;
-            if (uiFormatType == typeof(WebVTT) || uiFormatType == typeof(WebVTTFileWithLineNumber))
+            subtitle = built.Subtitle;
+            var text = built.Text;
+            if (built.HashValid)
             {
-                var defaultStyle = GetMpvPreviewStyle(Se.Settings.Video);
-                defaultStyle.BorderStyle = "3";
-                // No extra copy here: "subtitle" is already this method's private copy, and
-                // Convert deep-copies its input again internally without mutating it.
-                subtitle = WebVttToAssa.Convert(subtitle, defaultStyle, VideoWidth, VideoHeight);
-                AddSecondarySubtitle(subtitle, subtitleSecondary);
-                text = subtitle.ToText(_assFormat);
-            }
-            else
-            {
-                if (subtitle.Header == null || !subtitle.Header.Contains("[V4+ Styles]") || uiFormatType != typeof(AdvancedSubStationAlpha))
-                {
-                    if (string.IsNullOrEmpty(subtitle.Header) && uiFormatType == typeof(SubStationAlpha))
-                    {
-                        subtitle.Header = SubStationAlpha.DefaultHeader;
-                    }
-
-                    if (subtitle.Header != null && subtitle.Header.Contains("[V4 Styles]", StringComparison.Ordinal))
-                    {
-                        subtitle.Header = AdvancedSubStationAlpha.GetHeaderAndStylesFromSubStationAlpha(subtitle.Header);
-                    }
-
-                    // "subtitle" is already this method's private copy (see the top of the try
-                    // block), so mutating it in place is safe - the second full deep copy that
-                    // used to live here cost one Paragraph + two TimeCode allocations per line
-                    // on the UI thread for every preview refresh. Only the pre-preview-style
-                    // header is needed for the STL checks below.
-                    var oldHeader = subtitle.Header;
-                    if (Se.Settings.Appearance.RightToLeft)
-                    {
-                        for (var index = 0; index < subtitle.Paragraphs.Count; index++)
-                        {
-                            var paragraph = subtitle.Paragraphs[index];
-                            if (LanguageAutoDetect.ContainsRightToLeftLetter(paragraph.Text))
-                            {
-                                paragraph.Text = Utilities.FixRtlViaUnicodeChars(paragraph.Text);
-                            }
-                        }
-                    }
-
-                    if (subtitle.Header == null || !(subtitle.Header.Contains("[V4+ Styles]") && uiFormatType == typeof(SubStationAlpha)))
-                    {
-                        subtitle.Header = MpvPreviewStyleHeader;
-                    }
-
-                    if (oldHeader != null && oldHeader.Length > 20 && oldHeader.AsSpan(3, 3).SequenceEqual("STL"))
-                    {
-                        var previewFontName = Configuration.IsRunningOnLinux ? Configuration.DefaultLinuxFontName : "Tahoma";
-                        var boxStyle = $"Style: Box,{previewFontName},12,&H00FFFFFF,&H0300FFFF,&H00000000,&H02000000,-1,0,0,0,100,100,0,0,3,2,0,2,10,10,10,1{Environment.NewLine}Style: Default,";
-                        subtitle.Header = subtitle.Header.Replace("Style: Default,", boxStyle, StringComparison.Ordinal);
-
-                        var useBox = false;
-                        if (Configuration.Settings.SubtitleSettings.EbuStlTeletextUseBox)
-                        {
-                            try
-                            {
-                                var encoding = Ebu.GetEncoding(oldHeader[..3]);
-                                var buffer = encoding.GetBytes(oldHeader);
-                                var header = Ebu.ReadHeader(buffer);
-                                if (header.DisplayStandardCode != "0")
-                                {
-                                    useBox = true;
-                                }
-                            }
-                            catch
-                            {
-                                // ignore
-                            }
-                        }
-
-                        for (var index = 0; index < subtitle.Paragraphs.Count; index++)
-                        {
-                            var p = subtitle.Paragraphs[index];
-
-                            p.Extra = useBox ? "Box" : "Default";
-
-                            if (p.Text.Contains("<box>", StringComparison.Ordinal))
-                            {
-                                p.Extra = "Box";
-                                p.Text = p.Text.Replace("<box>", string.Empty).Replace("</box>", string.Empty);
-                            }
-                        }
-                    }
-                }
-
-                AddSecondarySubtitle(subtitle, subtitleSecondary);
-                var hash = subtitle.GetFastHashCode(null);
-                if (hash != _mpvSubOldHash || string.IsNullOrEmpty(_mpvTextOld))
-                {
-                    text = subtitle.ToText(_assFormat);
-                    _mpvSubOldHash = hash;
-                }
-                else
-                {
-                    text = _mpvTextOld;
-                }
+                _mpvSubOldHash = built.Hash;
             }
 
+            var format = _assFormat;
             if (text != _mpvTextOld || _mpvTextFileName == null || _retryCount > 0)
             {
                 if (_retryCount >= 0 || string.IsNullOrEmpty(_mpvTextFileName) || _subtitlePrev == null || _subtitlePrev.FileName != subtitle.FileName || _mpvTextFileExtension != format.Extension)
@@ -198,6 +129,115 @@ public class MpvReloader : IMpvReloader
         {
             Se.LogError(exception);
         }
+    }
+
+    // Runs on a background thread (see RefreshMpv). Must only touch the thread-confined
+    // subtitle copy, read-only state and libse statics - never the memo fields.
+    private (Subtitle Subtitle, string Text, int Hash, bool HashValid) BuildPreviewText(Subtitle subtitle, Subtitle? subtitleSecondary, Type uiFormatType, int oldHash, string oldText)
+    {
+        if (SmpteMode)
+        {
+            foreach (var paragraph in subtitle.Paragraphs)
+            {
+                paragraph.StartTime.TotalMilliseconds *= 1.001;
+                paragraph.EndTime.TotalMilliseconds *= 1.001;
+            }
+        }
+
+        if (uiFormatType == typeof(WebVTT) || uiFormatType == typeof(WebVTTFileWithLineNumber))
+        {
+            var defaultStyle = GetMpvPreviewStyle(Se.Settings.Video);
+            defaultStyle.BorderStyle = "3";
+            // No extra copy here: "subtitle" is already RefreshMpv's private copy, and
+            // Convert deep-copies its input again internally without mutating it.
+            subtitle = WebVttToAssa.Convert(subtitle, defaultStyle, VideoWidth, VideoHeight);
+            AddSecondarySubtitle(subtitle, subtitleSecondary);
+            // The WebVTT path never used the hash memo, so keep it untouched (HashValid false).
+            return (subtitle, subtitle.ToText(_assFormat), 0, false);
+        }
+
+        if (subtitle.Header == null || !subtitle.Header.Contains("[V4+ Styles]") || uiFormatType != typeof(AdvancedSubStationAlpha))
+        {
+            if (string.IsNullOrEmpty(subtitle.Header) && uiFormatType == typeof(SubStationAlpha))
+            {
+                subtitle.Header = SubStationAlpha.DefaultHeader;
+            }
+
+            if (subtitle.Header != null && subtitle.Header.Contains("[V4 Styles]", StringComparison.Ordinal))
+            {
+                subtitle.Header = AdvancedSubStationAlpha.GetHeaderAndStylesFromSubStationAlpha(subtitle.Header);
+            }
+
+            // "subtitle" is RefreshMpv's private copy, so mutating it in place is safe -
+            // the second full deep copy that used to live here cost one Paragraph + two
+            // TimeCode allocations per line on the UI thread for every preview refresh.
+            // Only the pre-preview-style header is needed for the STL checks below.
+            var oldHeader = subtitle.Header;
+            if (Se.Settings.Appearance.RightToLeft)
+            {
+                for (var index = 0; index < subtitle.Paragraphs.Count; index++)
+                {
+                    var paragraph = subtitle.Paragraphs[index];
+                    if (LanguageAutoDetect.ContainsRightToLeftLetter(paragraph.Text))
+                    {
+                        paragraph.Text = Utilities.FixRtlViaUnicodeChars(paragraph.Text);
+                    }
+                }
+            }
+
+            if (subtitle.Header == null || !(subtitle.Header.Contains("[V4+ Styles]") && uiFormatType == typeof(SubStationAlpha)))
+            {
+                subtitle.Header = MpvPreviewStyleHeader;
+            }
+
+            if (oldHeader != null && oldHeader.Length > 20 && oldHeader.AsSpan(3, 3).SequenceEqual("STL"))
+            {
+                var previewFontName = Configuration.IsRunningOnLinux ? Configuration.DefaultLinuxFontName : "Tahoma";
+                var boxStyle = $"Style: Box,{previewFontName},12,&H00FFFFFF,&H0300FFFF,&H00000000,&H02000000,-1,0,0,0,100,100,0,0,3,2,0,2,10,10,10,1{Environment.NewLine}Style: Default,";
+                subtitle.Header = subtitle.Header.Replace("Style: Default,", boxStyle, StringComparison.Ordinal);
+
+                var useBox = false;
+                if (Configuration.Settings.SubtitleSettings.EbuStlTeletextUseBox)
+                {
+                    try
+                    {
+                        var encoding = Ebu.GetEncoding(oldHeader[..3]);
+                        var buffer = encoding.GetBytes(oldHeader);
+                        var header = Ebu.ReadHeader(buffer);
+                        if (header.DisplayStandardCode != "0")
+                        {
+                            useBox = true;
+                        }
+                    }
+                    catch
+                    {
+                        // ignore
+                    }
+                }
+
+                for (var index = 0; index < subtitle.Paragraphs.Count; index++)
+                {
+                    var p = subtitle.Paragraphs[index];
+
+                    p.Extra = useBox ? "Box" : "Default";
+
+                    if (p.Text.Contains("<box>", StringComparison.Ordinal))
+                    {
+                        p.Extra = "Box";
+                        p.Text = p.Text.Replace("<box>", string.Empty).Replace("</box>", string.Empty);
+                    }
+                }
+            }
+        }
+
+        AddSecondarySubtitle(subtitle, subtitleSecondary);
+        var hash = subtitle.GetFastHashCode(null);
+        if (hash != oldHash || string.IsNullOrEmpty(oldText))
+        {
+            return (subtitle, subtitle.ToText(_assFormat), hash, true);
+        }
+
+        return (subtitle, oldText, hash, true);
     }
 
     private static void AddSecondarySubtitle(Subtitle subtitle, Subtitle? subtitleSecondary)
@@ -276,6 +316,7 @@ public class MpvReloader : IMpvReloader
 
     public void Reset()
     {
+        _refreshVersion++; // discard any in-flight background serialize
         DeleteTempMpvFileName();
         _mpvTextFileName = null;
         _mpvTextFileExtension = null;


### PR DESCRIPTION
## Preview latency after typing stops: ~0.9 s → ~0.27 s

Follow-up to #13302 / issue #13234. The on-video subtitle preview trailed the last keystroke by up to ~0.9 s: a 500 ms `IsUserEditing()` window plus up to 400 ms of `_slowTimer` tick alignment.

- The settle check (`TryRefreshVideoPreview`, extracted from the slow-timer tick) now also runs from the 16 ms cursor timer. It is dirty-flag gated, so the steady-state cost is a single bool check per tick; the 400 ms timer keeps it as a safety net.
- The preview gets its own 250 ms settle window (`IsUserEditingForPreview`); undo change detection keeps the full 500 ms window untouched.
- What makes the shorter window safe: `MpvReloader.RefreshMpv` now runs the expensive part of a refresh (SMPTE/RTL/header transforms, hash, ASSA `ToText`) in `Task.Run` instead of on the UI thread, so a refresh landing in a brief typing pause can't cause a felt hitch.
  - The deep copy stays on the UI thread — `GetUpdateSubtitle()` returns a shared instance that other UI code clears and repopulates at will.
  - An `_refreshVersion` counter (bumped by newer refreshes, `Reset()`, and the delete-all path) discards stale background results, so old text can never be pushed over newer state.
  - Failed refreshes back off 400 ms instead of retrying at 60 fps.

Behavioral note: with the 250 ms window, slower typists may see the preview update between words — intentional, closer to SE4's live feel, and free of UI-thread cost now that the serialize is off-thread. `PreviewSettleAfterTypingMs` is the one knob to adjust.

## ASSA save hot path (`ToText`) — runs on every save and every preview refresh

Two per-call allocation sources removed, output byte-identical:

- The header is trimmed via span append instead of `Header.Trim()`, which re-allocated the whole (possibly multi-KB) header per call.
- Lines without `<` tags (the common case) append span chunks around newlines instead of allocating an intermediate `Replace` string per line; tagged lines keep the original replace-then-`FormatText` order.

## Verification

- BenchmarkDotNet (`ToTextBenchmarks.AssaToText`, default job, baseline via git stash):

| Paragraphs | Mean before | Mean after | Alloc before | Alloc after |
|---|---|---|---|---|
| 1,000 | 370.0 µs | 375.1 µs (within error bars) | 465.3 KB | 427.0 KB |
| 10,000 | 4,254.5 µs | 3,878.8 µs (−9%) | 4,053 KB | 3,860 KB |

- Byte-identity dump harness over an edge-case battery (valid/padded/many-styles/SSA-v4/WebVTT/null headers; newline positions; `<i>`/`<font>` tags; comments; non-integer margins; fragment/minute/hour time carries; negative times) — identical before/after.
- Full libse (927) and UI (1719) test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)