### PR TITLE
Fix #13325: central undocked-topmost suspension for dialogs and popups

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1251,6 +1251,9 @@ public static partial class InitListViewAndEditBox
 
         // Set the ContextFlyout on the drop host so right-clicks on empty space also show the menu
         dropHost.ContextFlyout = flyout;
+        // In undocked mode the tool windows are topmost while SE is active (#11971), which
+        // covers this context menu and its cascaded submenus (#13325).
+        WindowService.SuspendUndockedTopmostWhileOpen(flyout);
         dropHost.AddHandler(InputElement.PointerPressedEvent, vm.SubtitleGrid_PointerPressed, RoutingStrategies.Tunnel, handledEventsToo: true);
         dropHost.AddHandler(InputElement.PointerReleasedEvent, vm.SubtitleGrid_PointerReleased, RoutingStrategies.Tunnel, handledEventsToo: true);
         dropHost.AddHandler(InputElement.PointerMovedEvent, vm.SubtitleGrid_PointerMoved, RoutingStrategies.Tunnel, handledEventsToo: true);
@@ -1567,6 +1570,8 @@ public static partial class InitListViewAndEditBox
         };
         textEditor.ContextFlyout = flyoutTextBox;
         flyoutTextBox.Opening += vm.TextBoxContextOpening;
+        // Keep the undocked tool windows from covering the text box context menu (#13325).
+        WindowService.SuspendUndockedTopmostWhileOpen(flyoutTextBox);
 
         var cutMenuItem = new MenuItem { Header = Se.Language.General.Cut };
         cutMenuItem.Command = vm.TextBoxCutCommand;

--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -40,8 +40,9 @@ public static class InitMenu
 
         // In undocked mode the tool windows are topmost while SE is active (#11971), which
         // covers the menu popups - drop their topmost while a menu is open (#13187/#12899).
-        menu.Opened += (s, e) => vm.SetUndockedWindowsTopmost(false);
-        menu.Closed += (s, e) => vm.SetUndockedWindowsTopmost(true);
+        // Ref-counted so a dialog opened from a menu item keeps the suppression alive after
+        // the menu itself closes (#13325).
+        WindowService.SuspendUndockedTopmostWhileOpen(menu);
 
         // Drop the menu's font one notch below the theme default and tighten
         // each item's vertical padding — a denser menu reads better when there

--- a/src/ui/Features/Main/Layout/InitWaveform.cs
+++ b/src/ui/Features/Main/Layout/InitWaveform.cs
@@ -314,6 +314,10 @@ public class InitWaveform
             // on the control's initial flyout, which this replaces on every layout rebuild.
             flyout.Closed += (_, _) => vm.RestoreFocusIfLost();
 
+            // With the video player undocked (and topmost), the docked waveform's context
+            // menu could still be covered by it (#13325).
+            WindowService.SuspendUndockedTopmostWhileOpen(flyout);
+
             vm.AudioVisualizer.MenuFlyout = flyout;
         }
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -665,6 +665,9 @@ public partial class MainViewModel :
         SubtitleDataGridSyntaxHighlighting = new TextWithSubtitleSyntaxHighlightingConverter();
         Toolbar = new Border();
         UiTheme.SystemThemeChangedCallback = OnSystemThemeChanged;
+        // Lets dialogs and popups drop the undocked tool windows' topmost while they are open
+        // (WindowService.SuspendUndockedTopmost, #13325).
+        WindowService.RegisterUndockedTopmostSetter(SetUndockedWindowsTopmost);
         ButtonWaveformPlay = new Button();
         _subtitle = new Subtitle();
         _subtitleOriginal = new Subtitle();
@@ -6556,15 +6559,19 @@ public partial class MainViewModel :
     /// <summary>
     /// Suppress (or restore) the undocked tool windows' topmost state. They float above the
     /// main window while SE is active (KeepTopmostWhileOwnerActive, #11971), which also puts
-    /// them above the main menu's popups - so the menu drops their topmost while it is open
-    /// (#13187/#12899). Restoring re-applies the helper's rule instead of a blanket true.
+    /// them above the main window's popups and above modal dialogs. Registered with
+    /// WindowService.RegisterUndockedTopmostSetter, and driven through the ref-counted
+    /// WindowService.SuspendUndockedTopmost while a menu, context menu, or dialog is open
+    /// (#13187/#12899/#13325). Restoring re-applies the helper's rule instead of a blanket true.
     /// </summary>
     internal void SetUndockedWindowsTopmost(bool topmost)
     {
         // Remembered (and consulted by the KeepTopmostWhileOwnerActive registrations) so the
-        // helper's activation handler cannot re-assert Topmost while a menu is still open:
-        // opening a cascaded submenu churns window activation, and the re-asserted Topmost put
-        // the tool windows back over the submenu popup (#13187 follow-up).
+        // helper's activation handler cannot re-assert Topmost while a menu or dialog is still
+        // open: opening a cascaded submenu (or a modal dialog) churns window activation, and the
+        // re-asserted Topmost put the tool windows back over the popup (#13187 follow-up) - and
+        // on Windows the SetWindowPos churn could steal OS activation from a just-opened modal
+        // dialog, leaving it drawn on top but inactive (#13325).
         _suppressUndockedTopmost = !topmost;
 
         foreach (var undockedWindow in new[] { _videoPlayerUndockedViewModel?.Window, _audioVisualizerUndockedViewModel?.Window })

--- a/src/ui/Features/Shared/MessageBox.cs
+++ b/src/ui/Features/Shared/MessageBox.cs
@@ -381,6 +381,12 @@ public class MessageBox : Window
         // message box opens behind them in undocked mode. (#12268)
         WindowService.KeepTopmostWhileOwnerActive(msgBox, owner);
 
+        // Drop the undocked windows' topmost for the dialog's lifetime and make sure the
+        // message box really gets OS activation - without this it was drawn on top but never
+        // activated on Windows in undocked mode: gray buttons, no keyboard focus (#13325).
+        using var undockedSuspension = WindowService.SuspendUndockedTopmost();
+        WindowService.ActivateWhenOpened(msgBox);
+
         return await msgBox.ShowDialog<MessageBoxResult>(owner);
     }
 

--- a/src/ui/Logic/WindowsService.cs
+++ b/src/ui/Logic/WindowsService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Nikse.SubtitleEdit.Features.Main.MainHelpers;
@@ -171,6 +172,11 @@ namespace Nikse.SubtitleEdit.Logic
             // behind them in undocked mode. (#11971)
             KeepTopmostWhileOwnerActive(window, owner);
 
+            // Drop the undocked windows' topmost for the dialog's lifetime and make sure the
+            // dialog really gets OS activation, not just top-of-z-order drawing (#13325).
+            using var undockedSuspension = SuspendUndockedTopmost();
+            ActivateWhenOpened(window);
+
             await YieldForPendingFlyoutDismissAsync();
             await window.ShowDialog(owner);
 
@@ -206,6 +212,11 @@ namespace Nikse.SubtitleEdit.Logic
             // behind them in undocked mode. (#11971)
             KeepTopmostWhileOwnerActive(window, owner);
 
+            // Drop the undocked windows' topmost for the dialog's lifetime and make sure the
+            // dialog really gets OS activation, not just top-of-z-order drawing (#13325).
+            using var undockedSuspension = SuspendUndockedTopmost();
+            ActivateWhenOpened(window);
+
             await YieldForPendingFlyoutDismissAsync();
             await window.ShowDialog(owner);
 
@@ -220,6 +231,117 @@ namespace Nikse.SubtitleEdit.Logic
         private static Task YieldForPendingFlyoutDismissAsync()
         {
             return Dispatcher.UIThread.InvokeAsync(static () => { }, DispatcherPriority.Background).GetTask();
+        }
+
+        // The undocked tool windows (audio visualizer / video player) float above the main
+        // window via KeepTopmostWhileOwnerActive - which also puts them above every popup and
+        // dialog the main window opens. Rather than making each popup/dialog fight back with
+        // its own Topmost (#11971/#12268/#12899/#13187 - and the OS foreground churn between
+        // two competing topmost windows left dialogs drawn on top but never activated,
+        // #13325), the undocked windows drop their topmost for the lifetime of whatever
+        // would be covered. MainViewModel registers the setter; the count makes nested
+        // suspensions safe (menu -> dialog -> message box).
+        private static Action<bool>? _setUndockedWindowsTopmost;
+        private static int _undockedTopmostSuspendCount;
+
+        /// <summary>
+        /// Registers the callback that applies (true) or suppresses (false) the undocked tool
+        /// windows' topmost state. Registered by MainViewModel; consulted by
+        /// <see cref="SuspendUndockedTopmost"/>.
+        /// </summary>
+        public static void RegisterUndockedTopmostSetter(Action<bool>? setTopmost)
+        {
+            _setUndockedWindowsTopmost = setTopmost;
+        }
+
+        /// <summary>
+        /// Test hook: clears leftover suspensions from tests that opened a menu or dialog and
+        /// tore the window down without the matching Closed event ever firing.
+        /// </summary>
+        internal static void ResetUndockedTopmostSuspensionsForTests()
+        {
+            _undockedTopmostSuspendCount = 0;
+        }
+
+        /// <summary>
+        /// Drops the undocked tool windows' topmost state until the returned token is disposed.
+        /// Re-entrant: the state is restored when the last outstanding token is disposed.
+        /// </summary>
+        public static IDisposable SuspendUndockedTopmost()
+        {
+            if (++_undockedTopmostSuspendCount == 1)
+            {
+                _setUndockedWindowsTopmost?.Invoke(false);
+            }
+
+            return new UndockedTopmostSuspension();
+        }
+
+        private sealed class UndockedTopmostSuspension : IDisposable
+        {
+            private bool _disposed;
+
+            public void Dispose()
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                if (--_undockedTopmostSuspendCount == 0)
+                {
+                    _setUndockedWindowsTopmost?.Invoke(true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Keeps the undocked tool windows non-topmost while <paramref name="flyout"/> is open,
+        /// so its popup (a plain non-topmost native window) is not covered by them in undocked
+        /// mode (#13325). Cascaded submenus are covered too: they belong to the same open flyout.
+        /// </summary>
+        public static void SuspendUndockedTopmostWhileOpen(FlyoutBase flyout)
+        {
+            IDisposable? suspension = null;
+            flyout.Opened += (_, _) => suspension ??= SuspendUndockedTopmost();
+            flyout.Closed += (_, _) =>
+            {
+                suspension?.Dispose();
+                suspension = null;
+            };
+        }
+
+        /// <summary>
+        /// Same as <see cref="SuspendUndockedTopmostWhileOpen(FlyoutBase)"/> for the main menu bar.
+        /// </summary>
+        public static void SuspendUndockedTopmostWhileOpen(MenuBase menu)
+        {
+            IDisposable? suspension = null;
+            menu.Opened += (_, _) => suspension ??= SuspendUndockedTopmost();
+            menu.Closed += (_, _) =>
+            {
+                suspension?.Dispose();
+                suspension = null;
+            };
+        }
+
+        /// <summary>
+        /// Explicitly activates <paramref name="window"/> once it has opened, in case the OS
+        /// left foreground/keyboard focus on another window during the open (seen on Windows in
+        /// undocked mode, where the dialog was drawn on top but never activated - gray buttons,
+        /// no keyboard focus - #13325). Posted at Background priority so pending activation and
+        /// topmost changes settle first; a no-op when the window is already active.
+        /// </summary>
+        public static void ActivateWhenOpened(Window window)
+        {
+            window.Opened += (_, _) => Dispatcher.UIThread.Post(() =>
+            {
+                if (window.IsVisible && !window.IsActive)
+                {
+                    window.Activate();
+                }
+            }, DispatcherPriority.Background);
         }
 
         /// <summary>

--- a/tests/UI/Logic/SuspendUndockedTopmostTests.cs
+++ b/tests/UI/Logic/SuspendUndockedTopmostTests.cs
@@ -1,0 +1,68 @@
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+// The undocked tool windows (audio visualizer / video player) are topmost while SE is
+// active, which covered the main window's popups and stole OS activation from modal
+// dialogs (#13325). WindowService.SuspendUndockedTopmost drops their topmost for the
+// lifetime of whatever would be covered; the suspension is ref-counted so nested users
+// (menu -> dialog -> message box) restore only when the last one closes.
+public class SuspendUndockedTopmostTests : IDisposable
+{
+    private readonly List<bool> _calls = [];
+
+    public SuspendUndockedTopmostTests()
+    {
+        // Earlier tests may have opened a menu or dialog and torn the window down without the
+        // matching Closed event, leaving the static suspend count non-zero.
+        WindowService.ResetUndockedTopmostSuspensionsForTests();
+        WindowService.RegisterUndockedTopmostSetter(_calls.Add);
+    }
+
+    public void Dispose()
+    {
+        WindowService.RegisterUndockedTopmostSetter(null);
+        WindowService.ResetUndockedTopmostSuspensionsForTests();
+    }
+
+    [Fact]
+    public void SingleSuspension_SuppressesAndRestores()
+    {
+        var suspension = WindowService.SuspendUndockedTopmost();
+        Assert.Equal([false], _calls);
+
+        suspension.Dispose();
+        Assert.Equal([false, true], _calls);
+    }
+
+    [Fact]
+    public void NestedSuspensions_RestoreOnlyWhenLastOneIsDisposed()
+    {
+        // Menu opens, a dialog is launched from a menu item, then the menu closes while
+        // the dialog is still up - the topmost state must stay suppressed until the
+        // dialog closes too.
+        var menu = WindowService.SuspendUndockedTopmost();
+        var dialog = WindowService.SuspendUndockedTopmost();
+        Assert.Equal([false], _calls);
+
+        menu.Dispose();
+        Assert.Equal([false], _calls);
+
+        dialog.Dispose();
+        Assert.Equal([false, true], _calls);
+    }
+
+    [Fact]
+    public void DisposingTwice_DoesNotUnbalanceTheCount()
+    {
+        var outer = WindowService.SuspendUndockedTopmost();
+        var inner = WindowService.SuspendUndockedTopmost();
+
+        inner.Dispose();
+        inner.Dispose();
+        Assert.Equal([false], _calls);
+
+        outer.Dispose();
+        Assert.Equal([false, true], _calls);
+    }
+}


### PR DESCRIPTION
Fixes #13325.

### Symptoms (undocked mode, any row - reported in #13306 comments and retested in beta 7)
1. The delete confirmation dialog (and other modals) came up drawn on top but **not actually activated**: all buttons gray, no keyboard focus, Alt+Tab required to really bring it forward.
2. The subtitle grid's context menu - including cascaded submenus - opened **underneath** the undocked audio visualizer.

### Root cause
The undocked tool windows are topmost while SE is active (#11971), and each thing they covered has so far fought back individually: dialogs got their own `KeepTopmostWhileOwnerActive` (#11971/#12268), the main menu got a suppress toggle (#12899/#13187) - but the grid/text box/waveform context menus never did, and for dialogs the topmost-vs-topmost arrangement had a worse failure mode on Windows: the undocked window's deferred `Topmost` churn right after `ShowDialog` stole OS activation from the just-opened dialog, leaving it visible but inert.

### Fix - one central mechanism instead of per-window fixes
`WindowService` now owns a **ref-counted suspension**: `SuspendUndockedTopmost()` drops the undocked windows' topmost until the last outstanding token is disposed. `MainViewModel` registers its existing `SetUndockedWindowsTopmost` as the setter.

- **Dialog chokepoints** - both `ShowDialogAsync` overloads and `MessageBox.Show` - suspend *before* showing (so the topmost drop settles before activation instead of churning right after it), and `ActivateWhenOpened` explicitly activates the dialog if the OS still left it inactive.
- **Popup sites** - main menu (converted from the old boolean toggle; ref-counting makes it nesting-safe when a dialog opens from a menu item), subtitle grid context menu, text box context menu, and waveform context menu suspend while open. Cascaded submenus ride along with the root flyout.

Any future dialog automatically inherits the behavior via the chokepoints; a new main-window flyout needs one `SuspendUndockedTopmostWhileOpen(flyout)` call.

### Tests
New unit tests for the ref-count semantics (suppress once, restore only on last dispose, double-dispose safe). Full UI suite: 1722/1722 green.

Note: the failing behavior is Windows-native z-order/activation, which headless tests can't reproduce - needs a manual check on Windows with the audio visualizer undocked (right-click a row; press Delete with the confirmation prompt enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)