### PR TITLE
Apply all profile rules, including the two duration limits

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -843,22 +843,7 @@ public partial class MainViewModel :
 
     private static void SetLibSeSettings()
     {
-        Configuration.Settings.General.SubtitleLineMaximumLength = Se.Settings.General.SubtitleLineMaximumLength;
-        Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds = Se.Settings.General.SubtitleMaximumCharactersPerSeconds;
-        Configuration.Settings.General.SubtitleOptimalCharactersPerSeconds = Se.Settings.General.SubtitleOptimalCharactersPerSeconds;
-        Configuration.Settings.General.SubtitleMaximumWordsPerMinute = Se.Settings.General.SubtitleMaximumWordsPerMinute;
-        Configuration.Settings.General.MinimumMillisecondsBetweenLines = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
-        Configuration.Settings.General.MaxNumberOfLines = Se.Settings.General.MaxNumberOfLines;
-        Configuration.Settings.General.MergeLinesShorterThan = Se.Settings.General.UnbreakLinesShorterThan;
-
-        if (Enum.TryParse<Core.Enums.DialogType>(Se.Settings.General.DialogStyle, out var dt))
-        {
-            Configuration.Settings.General.DialogStyle = dt;
-        }
-
-        Se.ApplyContinuationStyleToLibSe();
-
-        Configuration.Settings.General.CpsLineLengthStrategy = Se.Settings.General.CpsLineLengthStrategy;
+        Se.ApplyRuleSettingsToLibSe();
 
         TimedTextImscRosetta.LineHeight = Se.Settings.Formats.RosettaLineHeight;
         TimedTextImscRosetta.FontSize = Se.Settings.Formats.RosettaFontSize;
@@ -6753,20 +6738,7 @@ public partial class MainViewModel :
         if (result is { OkPressed: true, SelectedProfile: not null })
         {
             var p = result.SelectedProfile.ToRulesProfile();
-            Se.Settings.General.CurrentProfile = p.Name;
-            Se.Settings.General.SubtitleLineMaximumLength = p.SubtitleLineMaximumLength;
-            Se.Settings.General.SubtitleMaximumCharactersPerSeconds = (double)p.SubtitleMaximumCharactersPerSeconds;
-            Se.Settings.General.SubtitleOptimalCharactersPerSeconds = (double)p.SubtitleOptimalCharactersPerSeconds;
-            Se.Settings.General.SubtitleMaximumWordsPerMinute = (double)p.SubtitleMaximumWordsPerMinute;
-            Se.Settings.General.MinimumBetweenLines.Milliseconds = p.MinimumMillisecondsBetweenLines;
-            Se.Settings.General.MinimumBetweenLines.Frames = SubtitleFormat.MillisecondsToFrames(p.MinimumMillisecondsBetweenLines);
-            Se.Settings.General.MaxNumberOfLines = p.MaxNumberOfLines;
-            Se.Settings.General.UnbreakLinesShorterThan = p.MergeLinesShorterThan;
-            Se.Settings.General.DialogStyle = p.DialogStyle.ToString();
-            Se.Settings.General.ContinuationStyle = p.ContinuationStyle.ToString();
-            Se.Settings.General.CpsLineLengthStrategy = p.CpsLineLengthStrategy;
-
-            Se.Settings.General.CustomContinuationStyle = new CustomContinuationStyle(p.CustomContinuationStyle);
+            Se.ApplyRuleProfile(p);
 
             SetLibSeSettings();
 

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -2854,6 +2854,13 @@ public partial class SettingsViewModel : ObservableObject
             MinDurationMs = profile.MinDurationMs;
             MaxDurationMs = profile.MaxDurationMs;
             MinGapMs = profile.MinGapMs;
+            // A profile stores the gap in milliseconds only, but the setting is ms-or-frames and
+            // frame mode reads the frame value, so derive it instead of leaving it on the old profile's.
+            if (profile.MinGapMs.HasValue)
+            {
+                MinGapFrames = SubtitleFormat.MillisecondsToFrames(profile.MinGapMs.Value);
+            }
+
             MaxLines = profile.MaxLines;
             UnbreakLinesShorterThan = profile.UnbreakLinesShorterThan;
             DialogStyle = profile.DialogStyle;
@@ -2888,7 +2895,10 @@ public partial class SettingsViewModel : ObservableObject
         profileItem.MaxWordsPerMin = MaxWordsPerMin;
         profileItem.MinDurationMs = MinDurationMs;
         profileItem.MaxDurationMs = MaxDurationMs;
-        profileItem.MinGapMs = MinGapMs;
+        // In frame mode the frames box is the one the user edits, so that is the value to store.
+        profileItem.MinGapMs = UseFrameMode && MinGapFrames.HasValue
+            ? SubtitleFormat.FramesToMilliseconds(MinGapFrames.Value)
+            : MinGapMs;
         profileItem.MaxLines = MaxLines;
         profileItem.UnbreakLinesShorterThan = UnbreakLinesShorterThan;
         profileItem.DialogStyle = DialogStyle;

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -1,5 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic.Config.Language;
 using System;
@@ -727,6 +728,61 @@ public class Se
         }
 
         (g.CustomContinuationStyle ?? new CustomContinuationStyle()).ApplyToGeneralSettings(Configuration.Settings.General);
+    }
+
+    /// <summary>
+    /// Copies every rule in <paramref name="profile"/> into the general settings; callers still
+    /// need to run the libse bridge afterwards. Kept in one place because the profile picker used
+    /// to apply the fields inline and quietly dropped the two duration limits.
+    /// </summary>
+    public static void ApplyRuleProfile(RulesProfile profile)
+    {
+        var g = Settings.General;
+
+        g.CurrentProfile = profile.Name;
+        g.SubtitleLineMaximumLength = profile.SubtitleLineMaximumLength;
+        g.SubtitleMaximumCharactersPerSeconds = (double)profile.SubtitleMaximumCharactersPerSeconds;
+        g.SubtitleOptimalCharactersPerSeconds = (double)profile.SubtitleOptimalCharactersPerSeconds;
+        g.SubtitleMaximumWordsPerMinute = (double)profile.SubtitleMaximumWordsPerMinute;
+        g.SubtitleMinimumDisplayMilliseconds = profile.SubtitleMinimumDisplayMilliseconds;
+        g.SubtitleMaximumDisplayMilliseconds = profile.SubtitleMaximumDisplayMilliseconds;
+        g.MinimumBetweenLines.Milliseconds = profile.MinimumMillisecondsBetweenLines;
+        g.MinimumBetweenLines.Frames = SubtitleFormat.MillisecondsToFrames(profile.MinimumMillisecondsBetweenLines);
+        g.MaxNumberOfLines = profile.MaxNumberOfLines;
+        g.UnbreakLinesShorterThan = profile.MergeLinesShorterThan;
+        g.DialogStyle = profile.DialogStyle.ToString();
+        g.ContinuationStyle = profile.ContinuationStyle.ToString();
+        g.CpsLineLengthStrategy = profile.CpsLineLengthStrategy;
+        g.CustomContinuationStyle = new CustomContinuationStyle(profile.CustomContinuationStyle);
+    }
+
+    /// <summary>
+    /// Pushes the rule settings into libse's Configuration, which is what the fix/merge engines
+    /// and the duration helpers read. Sits next to <see cref="ApplyRuleProfile"/> so the two
+    /// field lists stay in step - the duration limits were missing here for the same reason.
+    /// </summary>
+    public static void ApplyRuleSettingsToLibSe()
+    {
+        var g = Settings.General;
+        var libSe = Configuration.Settings.General;
+
+        libSe.SubtitleLineMaximumLength = g.SubtitleLineMaximumLength;
+        libSe.SubtitleMaximumCharactersPerSeconds = g.SubtitleMaximumCharactersPerSeconds;
+        libSe.SubtitleOptimalCharactersPerSeconds = g.SubtitleOptimalCharactersPerSeconds;
+        libSe.SubtitleMaximumWordsPerMinute = g.SubtitleMaximumWordsPerMinute;
+        libSe.SubtitleMinimumDisplayMilliseconds = g.SubtitleMinimumDisplayMilliseconds;
+        libSe.SubtitleMaximumDisplayMilliseconds = g.SubtitleMaximumDisplayMilliseconds;
+        libSe.MinimumMillisecondsBetweenLines = g.MinimumBetweenLines.GetMilliseconds();
+        libSe.MaxNumberOfLines = g.MaxNumberOfLines;
+        libSe.MergeLinesShorterThan = g.UnbreakLinesShorterThan;
+        libSe.CpsLineLengthStrategy = g.CpsLineLengthStrategy;
+
+        if (Enum.TryParse<Core.Enums.DialogType>(g.DialogStyle, out var dt))
+        {
+            libSe.DialogStyle = dt;
+        }
+
+        ApplyContinuationStyleToLibSe();
     }
 
     public static string GetErrorLogFilePath()

--- a/tests/UI/Logic/Config/RuleProfileApplyTests.cs
+++ b/tests/UI/Logic/Config/RuleProfileApplyTests.cs
@@ -1,0 +1,153 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Common.TextLengthCalculator;
+using Nikse.SubtitleEdit.Core.Enums;
+using Nikse.SubtitleEdit.Core.Settings;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Logic.Config;
+
+public class RuleProfileApplyTests
+{
+    private static RulesProfile MakeProfile()
+    {
+        return new RulesProfile
+        {
+            Name = "Test profile",
+            SubtitleLineMaximumLength = 42,
+            SubtitleOptimalCharactersPerSeconds = 15,
+            SubtitleMaximumCharactersPerSeconds = 20,
+            SubtitleMaximumWordsPerMinute = 240,
+            SubtitleMinimumDisplayMilliseconds = 833,
+            SubtitleMaximumDisplayMilliseconds = 7007,
+            MinimumMillisecondsBetweenLines = 83,
+            MaxNumberOfLines = 2,
+            MergeLinesShorterThan = 43,
+            DialogStyle = DialogType.DashBothLinesWithoutSpace,
+            ContinuationStyle = ContinuationStyle.NoneLeadingTrailingEllipsis,
+            CpsLineLengthStrategy = nameof(CalcCjk),
+        };
+    }
+
+    // The profile picker used to apply these fields inline and silently dropped the two duration
+    // limits, so picking e.g. "Netflix (English)" left min/max duration untouched.
+    [Fact]
+    public void ApplyRuleProfile_CopiesEveryRuleIntoGeneralSettings()
+    {
+        var savedSettings = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.General.SubtitleMinimumDisplayMilliseconds = 1;
+            Se.Settings.General.SubtitleMaximumDisplayMilliseconds = 2;
+
+            Se.ApplyRuleProfile(MakeProfile());
+
+            var g = Se.Settings.General;
+            Assert.Equal("Test profile", g.CurrentProfile);
+            Assert.Equal(42, g.SubtitleLineMaximumLength);
+            Assert.Equal(15, g.SubtitleOptimalCharactersPerSeconds);
+            Assert.Equal(20, g.SubtitleMaximumCharactersPerSeconds);
+            Assert.Equal(240, g.SubtitleMaximumWordsPerMinute);
+            Assert.Equal(833, g.SubtitleMinimumDisplayMilliseconds);
+            Assert.Equal(7007, g.SubtitleMaximumDisplayMilliseconds);
+            Assert.Equal(83, g.MinimumBetweenLines.Milliseconds);
+            Assert.Equal(2, g.MaxNumberOfLines);
+            Assert.Equal(43, g.UnbreakLinesShorterThan);
+            Assert.Equal(nameof(DialogType.DashBothLinesWithoutSpace), g.DialogStyle);
+            Assert.Equal(nameof(ContinuationStyle.NoneLeadingTrailingEllipsis), g.ContinuationStyle);
+            Assert.Equal(nameof(CalcCjk), g.CpsLineLengthStrategy);
+        }
+        finally
+        {
+            Se.Settings = savedSettings;
+        }
+    }
+
+    // The gap setting is ms-or-frames and frame mode reads the frame value, so a profile that
+    // only carries milliseconds has to populate both.
+    [Fact]
+    public void ApplyRuleProfile_DerivesTheGapInFramesFromMilliseconds()
+    {
+        var savedSettings = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.General.MinimumBetweenLines.Frames = 99;
+
+            Se.ApplyRuleProfile(MakeProfile());
+
+            Assert.Equal(SubtitleFormat.MillisecondsToFrames(83), Se.Settings.General.MinimumBetweenLines.Frames);
+            Assert.NotEqual(99, Se.Settings.General.MinimumBetweenLines.Frames);
+        }
+        finally
+        {
+            Se.Settings = savedSettings;
+        }
+    }
+
+    // libse enforces duration limits from its own Configuration, which defaults to 1000/8000.
+    // Without this bridge the user's limits never reached RecalculateDisplayTimes and friends.
+    [Fact]
+    public void ApplyRuleSettingsToLibSe_BridgesEveryRuleIncludingTheDurationLimits()
+    {
+        var savedSettings = Se.Settings;
+        var savedLibSe = new GeneralSettings();
+        CopyRuleSettings(Configuration.Settings.General, savedLibSe);
+        try
+        {
+            Se.Settings = new Se();
+            var g = Se.Settings.General;
+            g.SubtitleLineMaximumLength = 42;
+            g.SubtitleOptimalCharactersPerSeconds = 15;
+            g.SubtitleMaximumCharactersPerSeconds = 20;
+            g.SubtitleMaximumWordsPerMinute = 240;
+            g.SubtitleMinimumDisplayMilliseconds = 833;
+            g.SubtitleMaximumDisplayMilliseconds = 7007;
+            g.MinimumBetweenLines.Milliseconds = 83;
+            g.UseFrameMode = false;
+            g.MaxNumberOfLines = 2;
+            g.UnbreakLinesShorterThan = 43;
+            g.CpsLineLengthStrategy = nameof(CalcCjk);
+            g.DialogStyle = nameof(DialogType.DashBothLinesWithoutSpace);
+
+            Se.ApplyRuleSettingsToLibSe();
+
+            var libSe = Configuration.Settings.General;
+            Assert.Equal(42, libSe.SubtitleLineMaximumLength);
+            Assert.Equal(15, libSe.SubtitleOptimalCharactersPerSeconds);
+            Assert.Equal(20, libSe.SubtitleMaximumCharactersPerSeconds);
+            Assert.Equal(240, libSe.SubtitleMaximumWordsPerMinute);
+            Assert.Equal(833, libSe.SubtitleMinimumDisplayMilliseconds);
+            Assert.Equal(7007, libSe.SubtitleMaximumDisplayMilliseconds);
+            Assert.Equal(83, libSe.MinimumMillisecondsBetweenLines);
+            Assert.Equal(2, libSe.MaxNumberOfLines);
+            Assert.Equal(43, libSe.MergeLinesShorterThan);
+            Assert.Equal(nameof(CalcCjk), libSe.CpsLineLengthStrategy);
+            Assert.Equal(DialogType.DashBothLinesWithoutSpace, libSe.DialogStyle);
+        }
+        finally
+        {
+            Se.Settings = savedSettings;
+            CopyRuleSettings(savedLibSe, Configuration.Settings.General);
+        }
+    }
+
+    /// <summary>Snapshot/restore helper - the bridge writes global libse state that later tests read.</summary>
+    private static void CopyRuleSettings(GeneralSettings from, GeneralSettings to)
+    {
+        to.SubtitleLineMaximumLength = from.SubtitleLineMaximumLength;
+        to.SubtitleOptimalCharactersPerSeconds = from.SubtitleOptimalCharactersPerSeconds;
+        to.SubtitleMaximumCharactersPerSeconds = from.SubtitleMaximumCharactersPerSeconds;
+        to.SubtitleMaximumWordsPerMinute = from.SubtitleMaximumWordsPerMinute;
+        to.SubtitleMinimumDisplayMilliseconds = from.SubtitleMinimumDisplayMilliseconds;
+        to.SubtitleMaximumDisplayMilliseconds = from.SubtitleMaximumDisplayMilliseconds;
+        to.MinimumMillisecondsBetweenLines = from.MinimumMillisecondsBetweenLines;
+        to.MaxNumberOfLines = from.MaxNumberOfLines;
+        to.MergeLinesShorterThan = from.MergeLinesShorterThan;
+        to.CpsLineLengthStrategy = from.CpsLineLengthStrategy;
+        to.DialogStyle = from.DialogStyle;
+        to.ContinuationStyle = from.ContinuationStyle;
+        CustomContinuationStyle.FromGeneralSettings(from).ApplyToGeneralSettings(to);
+    }
+}


### PR DESCRIPTION
Three bugs in how rule profiles get applied. The profile *definitions* are fine — the values in `SeGeneral.AddExtraProfiles` match the style guides they claim to follow. It's the plumbing that drops fields.

## Picking a profile ignored both duration limits

`ShowChooseProfile` applied 11 of the 13 rules a `RulesProfile` carries. `SubtitleMinimumDisplayMilliseconds` and `SubtitleMaximumDisplayMilliseconds` were absent from the list, even though `ProfileDisplay.ToRulesProfile()` populates them on the object being read.

So choosing "Netflix (English)" applied the line length, CPS, WPM, gap, max lines and dialog style, but left min/max duration untouched — and the grid kept colouring durations against the old limits, since `SubtitleLineViewModel` reads them from `Se.Settings.General`. The settings dialog was the only writer of those two values.

## The libse bridge never sent them either

`SetLibSeSettings` was missing the same two fields, so `Configuration.Settings.General.Subtitle{Minimum,Maximum}DisplayMilliseconds` stayed at libse's defaults of **1000 / 8000** for the entire session regardless of configuration. Everything in libse that enforces duration limits was using those defaults:

- `Subtitle.RecalculateDisplayTimes(…, enforceDurationLimits: true)` — batch convert
- `Utilities.GetOptimalDisplayMilliseconds` — paste from clipboard
- `Utilities.cs:3201`

Fix Common Errors was unaffected because it patches both values into libse itself before running. That local patch is what kept this hidden, and it's why the bug never showed up in the tool most likely to expose it. I left it in place as a defensive re-sync rather than widening this PR.

These two compound: fixing the picker alone still wouldn't have got the value to libse.

## Minimum gap was broken in frame mode

A profile stores the gap in milliseconds only, but the setting is an `MsOrFramesValue` whose `GetMilliseconds()` returns the **frame**-derived value when frame mode is on. The settings dialog only ever read and wrote `MinGapMs` — `ProfileChanged()` never touched `MinGapFrames`, and `RuleValueChanged()` never read it. So in frame mode, switching profiles produced no effective gap change, and a gap edited in frames never made it into the profile.

The profile picker already got this right (it derives and sets both components); the settings dialog now does too.

## Structure

Both field lists now sit next to each other in `Se` as `ApplyRuleProfile` and `ApplyRuleSettingsToLibSe`, replacing two inline blocks in `MainViewModel`. A rule added to `RulesProfile` now has one obvious place to be wired up instead of two places to be forgotten in — which is exactly how the duration limits went missing from both.

## Tests

Three new tests in `RuleProfileApplyTests`, covering every field of both copies plus the frames derivation. Full UI suite: 1721 passed, 0 failed (two consecutive runs).

Worth knowing for review: my first attempt had the libse test call `SetLibSeSettings` directly, which writes ~30 globals and leaked state into later tests. That's part of why the bridge is now a narrowly-scoped method the test can snapshot and restore precisely.

## Not fixed here

`general.MinimumBetweenLines` keeps its ms and frames components independent on save, so the two can still disagree if the user edits one and switches mode. Pre-existing, affects users who never touch profiles, and syncing them would silently rewrite the hidden box — so it seemed worth raising rather than deciding unilaterally.

Also still open from the same audit: `RulesProfile.Serialize`/`Deserialize` drop `CustomContinuationStyle` entirely, `Deserialize` throws on a missing `dialogStyle` (unguarded `Enum.Parse`) and silently turns missing numeric fields into 0. Latent today since SE5 persists profiles via `Se.Settings` JSON and only a libse test exercises those methods — but a trap if profile import/export gets wired up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)