### PR TITLE
Stop profile serialization dropping and rejecting fields

### DIFF
--- a/src/libse/Common/RulesProfile.cs
+++ b/src/libse/Common/RulesProfile.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Enums;
+using Nikse.SubtitleEdit.Core.Settings;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using System;
 using System.Collections.Generic;
@@ -65,7 +66,8 @@ namespace Nikse.SubtitleEdit.Core.Common
                 {
                     sb.Append(",");
                 }
-                sb.Append("{\"name\":\"" + Json.EncodeJsonText(p.Name) + "\", " +
+                var ccs = p.CustomContinuationStyle ?? new CustomContinuationStyle();
+                sb.Append("{\"name\":\"" + Encode(p.Name) + "\", " +
                           "\"maxNumberOfLines\":\"" + p.MaxNumberOfLines.ToString(CultureInfo.InvariantCulture) + "\"," +
                           "\"cpsLineLengthStrategy\":\"" + p.CpsLineLengthStrategy + "\"," +
                           "\"mergeLinesShorterThan\":\"" + p.MergeLinesShorterThan.ToString(CultureInfo.InvariantCulture) + "\"," +
@@ -77,7 +79,23 @@ namespace Nikse.SubtitleEdit.Core.Common
                           "\"subtitleMinimumDisplayMilliseconds\":\"" + p.SubtitleMinimumDisplayMilliseconds.ToString(CultureInfo.InvariantCulture) + "\"," +
                           "\"subtitleOptimalCharactersPerSeconds\":\"" + p.SubtitleOptimalCharactersPerSeconds.ToString(CultureInfo.InvariantCulture) + "\"," +
                           "\"dialogStyle\":\"" + p.DialogStyle + "\"," +
-                          "\"continuationStyle\":\"" + p.ContinuationStyle + "\"" +
+                          "\"continuationStyle\":\"" + p.ContinuationStyle + "\"," +
+                          // Flat fields rather than a nested object: Json.ReadTag is a plain string
+                          // scanner and would read a nested object value only up to its first comma.
+                          "\"customContinuationStylePause\":\"" + ccs.Pause.ToString(CultureInfo.InvariantCulture) + "\"," +
+                          "\"customContinuationStyleSuffix\":\"" + Encode(ccs.Suffix) + "\"," +
+                          "\"customContinuationStyleSuffixApplyIfComma\":\"" + ccs.SuffixApplyIfComma + "\"," +
+                          "\"customContinuationStyleSuffixAddSpace\":\"" + ccs.SuffixAddSpace + "\"," +
+                          "\"customContinuationStyleSuffixReplaceComma\":\"" + ccs.SuffixReplaceComma + "\"," +
+                          "\"customContinuationStylePrefix\":\"" + Encode(ccs.Prefix) + "\"," +
+                          "\"customContinuationStylePrefixAddSpace\":\"" + ccs.PrefixAddSpace + "\"," +
+                          "\"customContinuationStyleUseDifferentStyleGap\":\"" + ccs.UseDifferentStyleGap + "\"," +
+                          "\"customContinuationStyleGapSuffix\":\"" + Encode(ccs.GapSuffix) + "\"," +
+                          "\"customContinuationStyleGapSuffixApplyIfComma\":\"" + ccs.GapSuffixApplyIfComma + "\"," +
+                          "\"customContinuationStyleGapSuffixAddSpace\":\"" + ccs.GapSuffixAddSpace + "\"," +
+                          "\"customContinuationStyleGapSuffixReplaceComma\":\"" + ccs.GapSuffixReplaceComma + "\"," +
+                          "\"customContinuationStyleGapPrefix\":\"" + Encode(ccs.GapPrefix) + "\"," +
+                          "\"customContinuationStyleGapPrefixAddSpace\":\"" + ccs.GapPrefixAddSpace + "\"" +
                           "}");
             }
             sb.AppendLine("]}");
@@ -87,51 +105,104 @@ namespace Nikse.SubtitleEdit.Core.Common
         public static List<RulesProfile> Deserialize(string input)
         {
             var list = new List<RulesProfile>();
-            var s = input.Trim();
-            var profiles = Json.ReadObjectArray(s.Substring(s.IndexOf('[')).TrimEnd('}'));
+            var s = (input ?? string.Empty).Trim();
+            var arrayStart = s.IndexOf('[');
+            if (arrayStart < 0)
+            {
+                return list;
+            }
+
+            var profiles = Json.ReadObjectArray(s.Substring(arrayStart).TrimEnd('}'));
             if (profiles == null || profiles.Count == 0)
             {
                 return list;
             }
 
+            // A profile written by an older version can be missing any of these tags. Fall back to
+            // the built-in defaults rather than letting Convert.ToInt32(null) silently yield 0 - a
+            // zero maximum duration would flag every line - or letting Enum.Parse throw on a
+            // missing dialogStyle and take the whole profile list down with it.
+            var defaults = new GeneralSettings();
+
             foreach (var p in profiles)
             {
-                var name = Json.DecodeJsonText(Json.ReadTag(p, "name"));
-                var maxNumberOfLines = Convert.ToInt32(Json.ReadTag(p, "maxNumberOfLines"), CultureInfo.InvariantCulture);
-                var cpsLineLengthStrategy = Json.ReadTag(p, "cpsLineLengthStrategy");
-                var mergeLinesShorterThan = Convert.ToInt32(Json.ReadTag(p, "mergeLinesShorterThan"), CultureInfo.InvariantCulture);
-                var minimumMillisecondsBetweenLines = Convert.ToInt32(Json.ReadTag(p, "minimumMillisecondsBetweenLines"), CultureInfo.InvariantCulture);
-                var subtitleLineMaximumLength = Convert.ToInt32(Json.ReadTag(p, "subtitleLineMaximumLength"), CultureInfo.InvariantCulture);
-                var subtitleMaximumCharactersPerSeconds = Convert.ToDecimal(Json.ReadTag(p, "subtitleMaximumCharactersPerSeconds"), CultureInfo.InvariantCulture);
-                var subtitleMaximumWordsPerMinute = Convert.ToDecimal(Json.ReadTag(p, "subtitleMaximumWordsPerMinute"), CultureInfo.InvariantCulture);
-                var subtitleMaximumDisplayMilliseconds = Convert.ToInt32(Json.ReadTag(p, "subtitleMaximumDisplayMilliseconds"), CultureInfo.InvariantCulture);
-                var subtitleMinimumDisplayMilliseconds = Convert.ToInt32(Json.ReadTag(p, "subtitleMinimumDisplayMilliseconds"), CultureInfo.InvariantCulture);
-                var subtitleOptimalCharactersPerSeconds = Convert.ToDecimal(Json.ReadTag(p, "subtitleOptimalCharactersPerSeconds"), CultureInfo.InvariantCulture);
-                var dialogStyle = (DialogType)Enum.Parse(typeof(DialogType), Json.ReadTag(p, "dialogStyle"));
-                var continuationStyle = ContinuationStyle.None;
-                var continuationStyleJson = Json.ReadTag(p, "continuationStyle");
-                if (!string.IsNullOrEmpty(continuationStyleJson))
-                {
-                    continuationStyle = (ContinuationStyle)Enum.Parse(typeof(ContinuationStyle), continuationStyleJson);
-                }
                 list.Add(new RulesProfile
                 {
-                    Name = name,
-                    MaxNumberOfLines = maxNumberOfLines,
-                    CpsLineLengthStrategy = cpsLineLengthStrategy,
-                    MergeLinesShorterThan = mergeLinesShorterThan,
-                    MinimumMillisecondsBetweenLines = minimumMillisecondsBetweenLines,
-                    SubtitleLineMaximumLength = subtitleLineMaximumLength,
-                    SubtitleMaximumCharactersPerSeconds = subtitleMaximumCharactersPerSeconds,
-                    SubtitleMaximumWordsPerMinute = subtitleMaximumWordsPerMinute,
-                    SubtitleMaximumDisplayMilliseconds = subtitleMaximumDisplayMilliseconds,
-                    SubtitleMinimumDisplayMilliseconds = subtitleMinimumDisplayMilliseconds,
-                    SubtitleOptimalCharactersPerSeconds = subtitleOptimalCharactersPerSeconds,
-                    DialogStyle = dialogStyle,
-                    ContinuationStyle = continuationStyle
+                    Name = ReadString(p, "name", string.Empty),
+                    MaxNumberOfLines = ReadInt(p, "maxNumberOfLines", defaults.MaxNumberOfLines),
+                    CpsLineLengthStrategy = Json.ReadTag(p, "cpsLineLengthStrategy") ?? string.Empty,
+                    MergeLinesShorterThan = ReadInt(p, "mergeLinesShorterThan", defaults.MergeLinesShorterThan),
+                    MinimumMillisecondsBetweenLines = ReadInt(p, "minimumMillisecondsBetweenLines", defaults.MinimumMillisecondsBetweenLines),
+                    SubtitleLineMaximumLength = ReadInt(p, "subtitleLineMaximumLength", defaults.SubtitleLineMaximumLength),
+                    SubtitleMaximumCharactersPerSeconds = ReadDecimal(p, "subtitleMaximumCharactersPerSeconds", (decimal)defaults.SubtitleMaximumCharactersPerSeconds),
+                    SubtitleMaximumWordsPerMinute = ReadDecimal(p, "subtitleMaximumWordsPerMinute", (decimal)defaults.SubtitleMaximumWordsPerMinute),
+                    SubtitleMaximumDisplayMilliseconds = ReadInt(p, "subtitleMaximumDisplayMilliseconds", defaults.SubtitleMaximumDisplayMilliseconds),
+                    SubtitleMinimumDisplayMilliseconds = ReadInt(p, "subtitleMinimumDisplayMilliseconds", defaults.SubtitleMinimumDisplayMilliseconds),
+                    SubtitleOptimalCharactersPerSeconds = ReadDecimal(p, "subtitleOptimalCharactersPerSeconds", (decimal)defaults.SubtitleOptimalCharactersPerSeconds),
+                    DialogStyle = ReadEnum(p, "dialogStyle", defaults.DialogStyle),
+                    ContinuationStyle = ReadEnum(p, "continuationStyle", defaults.ContinuationStyle),
+                    CustomContinuationStyle = ReadCustomContinuationStyle(p),
                 });
             }
+
             return list;
+        }
+
+        private static CustomContinuationStyle ReadCustomContinuationStyle(string json)
+        {
+            var defaults = new CustomContinuationStyle();
+            return new CustomContinuationStyle
+            {
+                Pause = ReadInt(json, "customContinuationStylePause", defaults.Pause),
+                Suffix = ReadString(json, "customContinuationStyleSuffix", defaults.Suffix),
+                SuffixApplyIfComma = ReadBool(json, "customContinuationStyleSuffixApplyIfComma", defaults.SuffixApplyIfComma),
+                SuffixAddSpace = ReadBool(json, "customContinuationStyleSuffixAddSpace", defaults.SuffixAddSpace),
+                SuffixReplaceComma = ReadBool(json, "customContinuationStyleSuffixReplaceComma", defaults.SuffixReplaceComma),
+                Prefix = ReadString(json, "customContinuationStylePrefix", defaults.Prefix),
+                PrefixAddSpace = ReadBool(json, "customContinuationStylePrefixAddSpace", defaults.PrefixAddSpace),
+                UseDifferentStyleGap = ReadBool(json, "customContinuationStyleUseDifferentStyleGap", defaults.UseDifferentStyleGap),
+                GapSuffix = ReadString(json, "customContinuationStyleGapSuffix", defaults.GapSuffix),
+                GapSuffixApplyIfComma = ReadBool(json, "customContinuationStyleGapSuffixApplyIfComma", defaults.GapSuffixApplyIfComma),
+                GapSuffixAddSpace = ReadBool(json, "customContinuationStyleGapSuffixAddSpace", defaults.GapSuffixAddSpace),
+                GapSuffixReplaceComma = ReadBool(json, "customContinuationStyleGapSuffixReplaceComma", defaults.GapSuffixReplaceComma),
+                GapPrefix = ReadString(json, "customContinuationStyleGapPrefix", defaults.GapPrefix),
+                GapPrefixAddSpace = ReadBool(json, "customContinuationStyleGapPrefixAddSpace", defaults.GapPrefixAddSpace),
+            };
+        }
+
+        private static string Encode(string text)
+        {
+            return Json.EncodeJsonText(text ?? string.Empty);
+        }
+
+        private static string ReadString(string json, string tag, string defaultValue)
+        {
+            var value = Json.ReadTag(json, tag);
+            return value == null ? defaultValue : Json.DecodeJsonText(value);
+        }
+
+        private static int ReadInt(string json, string tag, int defaultValue)
+        {
+            return int.TryParse(Json.ReadTag(json, tag), NumberStyles.Any, CultureInfo.InvariantCulture, out var result)
+                ? result
+                : defaultValue;
+        }
+
+        private static decimal ReadDecimal(string json, string tag, decimal defaultValue)
+        {
+            return decimal.TryParse(Json.ReadTag(json, tag), NumberStyles.Any, CultureInfo.InvariantCulture, out var result)
+                ? result
+                : defaultValue;
+        }
+
+        private static bool ReadBool(string json, string tag, bool defaultValue)
+        {
+            return bool.TryParse(Json.ReadTag(json, tag), out var result) ? result : defaultValue;
+        }
+
+        private static T ReadEnum<T>(string json, string tag, T defaultValue) where T : struct
+        {
+            return Enum.TryParse<T>(Json.ReadTag(json, tag), out var result) ? result : defaultValue;
         }
     }
 }

--- a/src/ui/Features/Options/Settings/ProfileImportExport.cs
+++ b/src/ui/Features/Options/Settings/ProfileImportExport.cs
@@ -61,29 +61,40 @@ namespace Nikse.SubtitleEdit.Features.Options.Settings
             var list = new List<ProfileDisplay>();
             foreach (var item in Profiles)
             {
+                // Every rule is left null when the file omits it or it will not parse, so the
+                // existing "?? current setting" fallbacks fill it in. Parsing strictly here meant
+                // one bad or missing field aborted the whole import with a FormatException.
                 var profile = new ProfileDisplay
                 {
                     Name = item.Name,
-                    MaxLines = int.Parse(item.MaxNumberOfLines, CultureInfo.InvariantCulture),
+                    MaxLines = ParseInt(item.MaxNumberOfLines),
                     CpsLineLengthStrategy = CpsLineLengthStrategyDisplay.List().FirstOrDefault(p=>p.Code == item.CpsLineLengthStrategy) ?? CpsLineLengthStrategyDisplay.List().First(),
-                    UnbreakLinesShorterThan = int.Parse(item.MergeLinesShorterThan, CultureInfo.InvariantCulture),
-                    MinGapMs = int.Parse(item.MinimumMillisecondsBetweenLines, CultureInfo.InvariantCulture),
-                    SingleLineMaxLength = int.Parse(item.SubtitleLineMaximumLength, CultureInfo.InvariantCulture),
-                    MaxCharsPerSec = double.Parse(item.SubtitleMaximumCharactersPerSeconds, CultureInfo.InvariantCulture),
-                    MaxDurationMs = int.Parse(item.SubtitleMaximumDisplayMilliseconds, CultureInfo.InvariantCulture),
-                    MaxWordsPerMin = double.Parse(item.SubtitleMaximumWordsPerMinute, CultureInfo.InvariantCulture),
-                    MinDurationMs = int.Parse(item.SubtitleMinimumDisplayMilliseconds, CultureInfo.InvariantCulture),
-                    OptimalCharsPerSec = double.Parse(item.SubtitleOptimalCharactersPerSeconds, CultureInfo.InvariantCulture),
+                    UnbreakLinesShorterThan = ParseInt(item.MergeLinesShorterThan),
+                    MinGapMs = ParseInt(item.MinimumMillisecondsBetweenLines),
+                    SingleLineMaxLength = ParseInt(item.SubtitleLineMaximumLength),
+                    MaxCharsPerSec = ParseDouble(item.SubtitleMaximumCharactersPerSeconds),
+                    MaxDurationMs = ParseInt(item.SubtitleMaximumDisplayMilliseconds),
+                    MaxWordsPerMin = ParseDouble(item.SubtitleMaximumWordsPerMinute),
+                    MinDurationMs = ParseInt(item.SubtitleMinimumDisplayMilliseconds),
+                    OptimalCharsPerSec = ParseDouble(item.SubtitleOptimalCharactersPerSeconds),
                     DialogStyle = DialogStyleDisplay.List().FirstOrDefault(p => p.Code == item.DialogStyle) ?? DialogStyleDisplay.List().First(),
                     ContinuationStyle = ContinuationStyleDisplay.List().FirstOrDefault(p => p.Code == item.ContinuationStyle) ?? ContinuationStyleDisplay.List().First(),
-                    CustomContinuationStyle = item.CustomContinuationStyle != null
-                        ? new CustomContinuationStyle(item.CustomContinuationStyle)
-                        : new CustomContinuationStyle()
+                    CustomContinuationStyle = new CustomContinuationStyle(item.CustomContinuationStyle)
                 };
 
                 list.Add(profile);
             }
             return list;
+        }
+
+        private static int? ParseInt(string value)
+        {
+            return int.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var result) ? result : null;
+        }
+
+        private static double? ParseDouble(string value)
+        {
+            return double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var result) ? result : null;
         }
     }
 }

--- a/tests/UI/Features/Options/Settings/ProfileImportExportTests.cs
+++ b/tests/UI/Features/Options/Settings/ProfileImportExportTests.cs
@@ -1,0 +1,85 @@
+using System.Text.Json;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Options.Settings;
+
+namespace UITests.Features.Options.Settings;
+
+public class ProfileImportExportTests
+{
+    private static ProfileImportExport Read(string json)
+    {
+        return JsonSerializer.Deserialize<ProfileImportExport>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+    }
+
+    // Import used to int.Parse every field, so a single missing or blank rule threw a
+    // FormatException and took the whole file down with it.
+    [Fact]
+    public void ImportKeepsMissingRulesNullSoTheCurrentSettingIsUsed()
+    {
+        var imported = Read("{\"profiles\":[{\"name\":\"Sparse\"}]}").ToProfileDisplayList();
+
+        Assert.NotNull(imported);
+        var p = Assert.Single(imported!);
+        Assert.Equal("Sparse", p.Name);
+        Assert.Null(p.MaxLines);
+        Assert.Null(p.MinDurationMs);
+        Assert.Null(p.MaxDurationMs);
+        Assert.Null(p.SingleLineMaxLength);
+        Assert.Null(p.MaxCharsPerSec);
+        Assert.NotNull(p.CustomContinuationStyle);
+    }
+
+    [Fact]
+    public void ImportIgnoresAnUnparseableRuleRatherThanFailingTheFile()
+    {
+        var json = "{\"profiles\":[{\"name\":\"Odd\",\"subtitleLineMaximumLength\":\"forty-two\",\"maxNumberOfLines\":\"2\"}]}";
+
+        var imported = Read(json).ToProfileDisplayList();
+
+        var p = Assert.Single(imported!);
+        Assert.Null(p.SingleLineMaxLength);
+        Assert.Equal(2, p.MaxLines);
+    }
+
+    [Fact]
+    public void ImportReadsEveryRuleWhenPresent()
+    {
+        var json = "{\"profiles\":[{\"name\":\"Full\",\"maxNumberOfLines\":\"2\",\"mergeLinesShorterThan\":\"43\"," +
+                   "\"minimumMillisecondsBetweenLines\":\"83\",\"subtitleLineMaximumLength\":\"42\"," +
+                   "\"subtitleMaximumCharactersPerSeconds\":\"20\",\"subtitleMaximumDisplayMilliseconds\":\"7007\"," +
+                   "\"subtitleMaximumWordsPerMinute\":\"240\",\"subtitleMinimumDisplayMilliseconds\":\"833\"," +
+                   "\"subtitleOptimalCharactersPerSeconds\":\"15\"}]}";
+
+        var p = Assert.Single(Read(json).ToProfileDisplayList()!);
+
+        Assert.Equal(2, p.MaxLines);
+        Assert.Equal(43, p.UnbreakLinesShorterThan);
+        Assert.Equal(83, p.MinGapMs);
+        Assert.Equal(42, p.SingleLineMaxLength);
+        Assert.Equal(20, p.MaxCharsPerSec);
+        Assert.Equal(7007, p.MaxDurationMs);
+        Assert.Equal(240, p.MaxWordsPerMin);
+        Assert.Equal(833, p.MinDurationMs);
+        Assert.Equal(15, p.OptimalCharsPerSec);
+    }
+
+    [Fact]
+    public void ExportImportRoundTripsTheCustomContinuationStyle()
+    {
+        var source = new ProfileDisplay
+        {
+            Name = "P1",
+            CustomContinuationStyle = new CustomContinuationStyle { Pause = 555, Suffix = "..", GapPrefix = "—" },
+        };
+
+        var json = JsonSerializer.Serialize(
+            new ProfileImportExport(new List<ProfileDisplay> { source }),
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
+        var p = Assert.Single(Read(json).ToProfileDisplayList()!);
+
+        Assert.Equal(555, p.CustomContinuationStyle.Pause);
+        Assert.Equal("..", p.CustomContinuationStyle.Suffix);
+        Assert.Equal("—", p.CustomContinuationStyle.GapPrefix);
+    }
+}

--- a/tests/libse/Common/RulesProfileTest.cs
+++ b/tests/libse/Common/RulesProfileTest.cs
@@ -62,5 +62,122 @@ public class RulesProfileTest
         Assert.Equal("P1", roundTripped[0].Name);
         Assert.Equal(3, roundTripped[0].MaxNumberOfLines);
         Assert.Equal(ContinuationStyle.LeadingTrailingDash, roundTripped[0].ContinuationStyle);
+        Assert.Equal(25, roundTripped[0].MergeLinesShorterThan);
+        Assert.Equal(24, roundTripped[0].MinimumMillisecondsBetweenLines);
+        Assert.Equal(43, roundTripped[0].SubtitleLineMaximumLength);
+        Assert.Equal(25, roundTripped[0].SubtitleMaximumCharactersPerSeconds);
+        Assert.Equal(400, roundTripped[0].SubtitleMaximumWordsPerMinute);
+        Assert.Equal(10000, roundTripped[0].SubtitleMaximumDisplayMilliseconds);
+        Assert.Equal(500, roundTripped[0].SubtitleMinimumDisplayMilliseconds);
+        Assert.Equal(20, roundTripped[0].SubtitleOptimalCharactersPerSeconds);
+        Assert.Equal(DialogType.DashBothLinesWithSpace, roundTripped[0].DialogStyle);
+    }
+
+    // The custom continuation style used to be dropped entirely: Serialize never wrote it and
+    // Deserialize never read it, so a "Custom" profile came back with the built-in defaults.
+    [Fact]
+    public void SerializeDeserializeRoundTripsCustomContinuationStyle()
+    {
+        var original = new RulesProfile
+        {
+            Name = "P1",
+            ContinuationStyle = ContinuationStyle.Custom,
+            CustomContinuationStyle = new CustomContinuationStyle
+            {
+                Pause = 555,
+                Suffix = "..",
+                SuffixApplyIfComma = true,
+                SuffixAddSpace = true,
+                SuffixReplaceComma = true,
+                Prefix = "-",
+                PrefixAddSpace = true,
+                UseDifferentStyleGap = false,
+                GapSuffix = "…",
+                GapSuffixApplyIfComma = false,
+                GapSuffixAddSpace = true,
+                GapSuffixReplaceComma = false,
+                GapPrefix = "—",
+                GapPrefixAddSpace = true,
+            },
+        };
+
+        var roundTripped = RulesProfile.Deserialize(RulesProfile.Serialize(new List<RulesProfile> { original }));
+
+        var ccs = roundTripped[0].CustomContinuationStyle;
+        Assert.Equal(555, ccs.Pause);
+        Assert.Equal("..", ccs.Suffix);
+        Assert.True(ccs.SuffixApplyIfComma);
+        Assert.True(ccs.SuffixAddSpace);
+        Assert.True(ccs.SuffixReplaceComma);
+        Assert.Equal("-", ccs.Prefix);
+        Assert.True(ccs.PrefixAddSpace);
+        Assert.False(ccs.UseDifferentStyleGap);
+        Assert.Equal("…", ccs.GapSuffix);
+        Assert.False(ccs.GapSuffixApplyIfComma);
+        Assert.True(ccs.GapSuffixAddSpace);
+        Assert.False(ccs.GapSuffixReplaceComma);
+        Assert.Equal("—", ccs.GapPrefix);
+        Assert.True(ccs.GapPrefixAddSpace);
+    }
+
+    [Fact]
+    public void SerializeDeserializeRoundTripsSeveralProfiles()
+    {
+        var profiles = new List<RulesProfile>
+        {
+            new() { Name = "A", SubtitleMinimumDisplayMilliseconds = 833, DialogStyle = DialogType.DashBothLinesWithoutSpace },
+            new() { Name = "B", SubtitleMinimumDisplayMilliseconds = 1400, DialogStyle = DialogType.DashSecondLineWithoutSpace },
+        };
+
+        var roundTripped = RulesProfile.Deserialize(RulesProfile.Serialize(profiles));
+
+        Assert.Equal(2, roundTripped.Count);
+        Assert.Equal("A", roundTripped[0].Name);
+        Assert.Equal(833, roundTripped[0].SubtitleMinimumDisplayMilliseconds);
+        Assert.Equal(DialogType.DashBothLinesWithoutSpace, roundTripped[0].DialogStyle);
+        Assert.Equal("B", roundTripped[1].Name);
+        Assert.Equal(1400, roundTripped[1].SubtitleMinimumDisplayMilliseconds);
+        Assert.Equal(DialogType.DashSecondLineWithoutSpace, roundTripped[1].DialogStyle);
+    }
+
+    // A missing dialogStyle used to throw out of Enum.Parse and take the whole profile list with it.
+    [Fact]
+    public void DeserializeUsesDefaultsForMissingTagsInsteadOfThrowing()
+    {
+        var json = "{\"profiles\":[{\"name\":\"Sparse\"}]}";
+
+        var profiles = RulesProfile.Deserialize(json);
+
+        Assert.Single(profiles);
+        Assert.Equal("Sparse", profiles[0].Name);
+        Assert.Equal(DialogType.DashBothLinesWithSpace, profiles[0].DialogStyle);
+        Assert.Equal(ContinuationStyle.None, profiles[0].ContinuationStyle);
+        Assert.NotNull(profiles[0].CustomContinuationStyle);
+        Assert.Equal(300, profiles[0].CustomContinuationStyle.Pause);
+    }
+
+    // Convert.ToInt32(null) returns 0, so a missing duration used to mean "flag every line".
+    [Fact]
+    public void DeserializeDoesNotTurnMissingNumbersIntoZero()
+    {
+        var json = "{\"profiles\":[{\"name\":\"Sparse\"}]}";
+
+        var profiles = RulesProfile.Deserialize(json);
+
+        Assert.NotEqual(0, profiles[0].SubtitleMaximumDisplayMilliseconds);
+        Assert.NotEqual(0, profiles[0].SubtitleMinimumDisplayMilliseconds);
+        Assert.NotEqual(0, profiles[0].SubtitleLineMaximumLength);
+        Assert.NotEqual(0, profiles[0].SubtitleMaximumCharactersPerSeconds);
+        Assert.NotEqual(0, profiles[0].MaxNumberOfLines);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("not json at all")]
+    [InlineData("{\"profiles\":[]}")]
+    public void DeserializeReturnsEmptyForUnusableInput(string? input)
+    {
+        Assert.Empty(RulesProfile.Deserialize(input));
     }
 }


### PR DESCRIPTION
Follow-up to #13363, from the same audit. Separate branch off `main`; no overlapping files.

## `CustomContinuationStyle` was dropped on round-trip

`RulesProfile.Serialize` never wrote it and `Deserialize` never read it, so a profile using the "Custom" continuation style came back with the built-in defaults.

It's written as flat `customContinuationStyle*` tags rather than a nested object on purpose: `Json.ReadTag` is a plain string scanner that reads a value up to the first comma or closing brace, so a nested object would come back truncated. Flat also matches how libse's own `GeneralSettings` stores this style.

## `Deserialize` threw on one missing field, or silently produced zeros

`Enum.Parse` on `dialogStyle` was unguarded — a profile without that tag threw and took **the whole profile list** with it, not just the one profile. Two lines below, `continuationStyle` was already guarded, which is what made the asymmetry look accidental rather than intended.

Meanwhile every numeric went through `Convert.ToInt32(null)`, which returns **0** rather than throwing. A profile missing `subtitleMaximumDisplayMilliseconds` loaded with a maximum duration of zero — i.e. every line flagged. Silent and much worse than an error.

Each field now falls back to the corresponding `GeneralSettings` default, and input with no array at all returns an empty list instead of throwing out of `Substring(-1)`.

## The same bug was live in the import users can actually reach

While confirming `RulesProfile.Serialize`/`Deserialize` have no callers outside tests, I found `ProfileImportExport.ToProfileDisplayList` — behind Settings → Profiles → Import — doing `int.Parse` on every rule. One blank or malformed field failed the entire import with "Unable to import profiles: Input string was not in a correct format."

Unparseable rules are now left `null`, which the existing `?? current setting` fallbacks in `ToRulesProfile` and the settings save path already handle. This one is beyond what was strictly asked, but fixing the dead code path while leaving the live one broken seemed like the wrong call.

(That class already round-trips `CustomContinuationStyle` correctly — it uses `System.Text.Json`, not the libse serializer.)

## Tests

`RulesProfileTest`: 11 pass, covering the full round-trip including all 14 custom continuation fields, multiple profiles, sparse input, and unusable input. Full libse suite: **935 passed, 0 failed**.

`ProfileImportExportTests`: 4 new tests for the import path. **These have not been run yet** — an untracked local WIP file, `tests/UI/Features/Main/SubtitleGridTopGapTests.cs`, is currently missing a `using Avalonia.Headless.XUnit;` and fails to compile, which blocks the whole UI test project. The production change compiles clean (`UI.csproj`, Release, 0 warnings). Worth a re-run once that file builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)