### PR TITLE
Fix #13361: Alt+letter menus no longer hide behind undocked tool windows

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -633,7 +633,9 @@ public partial class MainViewModel :
         ContentGrid = new Grid();
         MenuReopen = new MenuItem();
         MenuPlugins = new MenuItem();
-        Menu = new Menu();
+        // Custom interaction handler so Alt+letter access keys open the Menu itself (Opened
+        // fires, undocked topmost drops) and not just the item's drop-down popup (#13361).
+        Menu = new Menu(new MainMenuInteractionHandler());
         PanelSingleLineLengths = new StackPanel();
         MenuItemMergeAsDialog = new MenuItem();
         MenuItemExtendToLineBefore = new MenuItem();

--- a/src/ui/Logic/MainMenuInteractionHandler.cs
+++ b/src/ui/Logic/MainMenuInteractionHandler.cs
@@ -1,0 +1,63 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Platform;
+using Avalonia.Interactivity;
+using Avalonia.LogicalTree;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Interaction handler for the main menu bar that makes the <see cref="Menu"/> raise Opened
+/// when a top-level drop-down is opened with an access key (Alt+F etc.).
+///
+/// Avalonia's <see cref="DefaultMenuInteractionHandler.AccessKeyPressed"/> opens the item's
+/// drop-down popup directly without calling Menu.Open() - unlike both the pointer path
+/// (PointerPressed calls IMainMenu.Open() first) and the bare-Alt path (AccessKeyHandler
+/// calls MainMenu.Open()). MenuBase.OnSubmenuOpened then flips IsOpen to true as a silent
+/// side effect, so the menu ends up open with the Opened event never raised (and Closed
+/// firing unpaired later). Everything keyed to Opened silently skips; most visibly, the
+/// undocked tool windows kept their topmost and covered the drop-down and its cascaded
+/// submenus (#13361 - still unfixed in upstream Avalonia master as of 12.1.1).
+///
+/// DefaultMenuInteractionHandler is marked [Unstable]; the access-key regression test in
+/// MainMenuKeyboardActivationTests pins this behavior across Avalonia upgrades.
+/// </summary>
+public sealed class MainMenuInteractionHandler : DefaultMenuInteractionHandler
+{
+    public MainMenuInteractionHandler()
+        : base(isContextMenu: false)
+    {
+    }
+
+    protected override void AccessKeyPressed(object? sender, RoutedEventArgs e)
+    {
+        // Mirror the pointer path: open the Menu before the item's drop-down, so Opened fires
+        // and the menu's open state is consistent no matter how the user got in. For an
+        // ambiguous access key (two top-level items sharing a letter - none in SE's menu) the
+        // base handler only moves focus; opening the bar then still matches bare-Alt semantics
+        // (IsOpen with no drop-down). The ambiguity flag itself (AccessKeyEventArgs.IsMultiple)
+        // is internal to Avalonia, so it cannot be consulted here.
+        if (FindMenuItem(e.Source) is { IsTopLevel: true, HasSubMenu: true, IsEffectivelyEnabled: true } item &&
+            item.Parent is MenuBase { IsOpen: false } menu)
+        {
+            menu.Open();
+        }
+
+        base.AccessKeyPressed(sender, e);
+    }
+
+    private static MenuItem? FindMenuItem(object? source)
+    {
+        var current = source as ILogical;
+        while (current != null)
+        {
+            if (current is MenuItem item)
+            {
+                return item;
+            }
+
+            current = current.LogicalParent;
+        }
+
+        return null;
+    }
+}

--- a/tests/UI/Features/Main/MainMenuKeyboardActivationTests.cs
+++ b/tests/UI/Features/Main/MainMenuKeyboardActivationTests.cs
@@ -371,4 +371,64 @@ public class MainMenuKeyboardActivationTests : IDisposable
 
         window.Close();
     }
+
+    /// <summary>
+    /// Alt+letter (e.g. Alt+F for "_File") must open the Menu control itself, not just the
+    /// item's drop-down popup. Avalonia's DefaultMenuInteractionHandler.AccessKeyPressed skips
+    /// IMainMenu.Open() - unlike the pointer and bare-Alt paths - so Menu.Opened never fired
+    /// and everything keyed to it silently skipped; most visibly the undocked tool windows
+    /// kept their topmost and covered the drop-down (#13361). MainMenuInteractionHandler
+    /// closes that gap; this test pins it across Avalonia upgrades (the handler subclasses an
+    /// [Unstable] Avalonia class).
+    /// </summary>
+    [AvaloniaFact]
+    public async Task AltLetter_OpensTheMenuBarItself_AndSuspendsUndockedTopmost()
+    {
+        var (window, vm) = ShowMainWindowWithEmptyGrid();
+        TableViewExtras.FocusRow(vm.SubtitleGrid);
+        Settle(window);
+        await WaitForGridFocus(window, vm);
+
+        // Observe the undocked-topmost suspension the way MainViewModel's setter would be
+        // driven (the suspension is keyed to Menu.Opened/Closed, WindowService ref-counted).
+        var topmostCalls = new List<bool>();
+        WindowService.ResetUndockedTopmostSuspensionsForTests();
+        WindowService.RegisterUndockedTopmostSetter(topmostCalls.Add);
+
+        try
+        {
+            // Alt held, F pressed: the access key opens the File drop-down. The assertions run
+            // before the Alt release on purpose - on a desktop the drop-down popup is a separate
+            // top-level that swallows the release, so the release must not be what opens the bar.
+            window.KeyPressQwerty(PhysicalKey.AltLeft, RawInputModifiers.Alt);
+            Dispatcher.UIThread.RunJobs();
+            window.KeyPressQwerty(PhysicalKey.F, RawInputModifiers.Alt);
+            Dispatcher.UIThread.RunJobs();
+            window.KeyReleaseQwerty(PhysicalKey.F, RawInputModifiers.Alt);
+            Settle(window);
+
+            await WaitUntil(() => vm.Menu.Items.OfType<MenuItem>().Any(mi => mi.IsSubMenuOpen), "Alt+F should open the File drop-down");
+            Assert.True(vm.Menu.IsOpen, "Alt+F must open the menu bar itself, not just the drop-down (#13361)");
+            Assert.Equal([false], topmostCalls);
+
+            window.KeyReleaseQwerty(PhysicalKey.AltLeft, RawInputModifiers.None);
+            Settle(window);
+
+            // First Escape closes the drop-down (bar stays armed), second deactivates the bar -
+            // the suspension must be released exactly once, when the bar actually closes.
+            PressAndRelease(window, PhysicalKey.Escape, RawInputModifiers.None);
+            Assert.Equal([false], topmostCalls);
+            PressAndRelease(window, PhysicalKey.Escape, RawInputModifiers.None);
+
+            await WaitUntil(() => !vm.Menu.IsOpen, "the second Escape should close the menu bar");
+            await WaitUntil(() => topmostCalls.Count == 2 && topmostCalls[1], "closing the bar should restore the undocked windows' topmost");
+        }
+        finally
+        {
+            WindowService.RegisterUndockedTopmostSetter(null);
+            WindowService.ResetUndockedTopmostSuspensionsForTests();
+        }
+
+        window.Close();
+    }
 }


### PR DESCRIPTION
Fixes #13361.

### Root cause

Opening a top-level drop-down with an access key (Alt+F, Alt+E, …) never raised `Menu.Opened`. Avalonia's `DefaultMenuInteractionHandler.AccessKeyPressed` opens the item's popup directly without calling `Menu.Open()` — unlike both the pointer path (`PointerPressed` calls `IMainMenu.Open()` first) and the bare-Alt path (`AccessKeyHandler` calls `MainMenu.Open()`). `MenuBase.OnSubmenuOpened` then flips `IsOpen` to true as a silent side effect, so the menu ended up open with `Opened` never raised (and `Closed` firing unpaired later). Still unfixed in upstream Avalonia master as of 12.1.1.

Everything keyed to `Opened` silently skipped — most visibly the central undocked-topmost suspension from #13362 never engaged, so the undocked audio visualizer / video player kept their topmost and covered the drop-down and its cascaded submenus. Bare Alt + arrow navigation went through `MainMenu.Open()` and worked, which is exactly the half-regression described in the issue. The shortcut-hint refresh on menu open skipped on this path too.

### Fix

`MainMenuInteractionHandler` subclasses `DefaultMenuInteractionHandler` and, in `AccessKeyPressed`, opens the `Menu` before the item's drop-down for top-level items — mirroring what the pointer path already does. With `Opened`/`Closed` now firing in pairs on every input path, the #13362 suspension, shortcut hints, and focus bookkeeping all behave identically regardless of how the menu was opened.

The base class is marked `[Unstable]`, so a regression test pins the behavior across Avalonia upgrades: Alt+F must raise `Opened` and suspend the undocked windows' topmost *before* the Alt release (on desktop the drop-down popup is a separate top-level that swallows the release), and the suspension must be released exactly once when the bar closes.

### Testing

- New `AltLetter_OpensTheMenuBarItself_AndSuspendsUndockedTopmost` fails on stock `new Menu()` at the suspension assert and passes with the handler.
- Full UI suite: 1721/1723 green; the 2 `SyntaxTextEditorTests` failures are the known flaky family and pass on rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)