### PR TITLE
Fix #13333: compose dead keys via local XIM on Linux non-CJK locales

### DIFF
--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -19,6 +19,7 @@ using Optris.Icons.Avalonia.FontAwesome;
 using Optris.Icons.Avalonia.MaterialDesign;
 using System;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
@@ -38,6 +39,10 @@ namespace Nikse.SubtitleEdit
             // Must run before any SkiaSharp.HarfBuzz use so the bundled libHarfBuzzSharp
             // deep-binds its own hb_* symbols and doesn't crash the export shaper on Linux (#11864).
             Nikse.SubtitleEdit.UiLogic.HarfBuzzNativeFix.Apply();
+
+            // Must run before Avalonia initializes its X11 backend (which reads these
+            // environment variables both from managed code and through native getenv).
+            ApplyLinuxDeadKeyInputFix();
 
             try
             {
@@ -167,13 +172,12 @@ namespace Nikse.SubtitleEdit
                     {
                         RenderingMode = new[] { X11RenderingMode.Glx, X11RenderingMode.Egl },
 
-                        // Avalonia only connects to the desktop's input method for CJK locales by
-                        // default; European locales fall back to libX11's local compose path, which
-                        // does not work on ibus desktops (GNOME/Fedora/Ubuntu) - dead keys type
-                        // nothing and swallow the next keystroke (issues #13333, #12334, #10618;
-                        // upstream AvaloniaUI/Avalonia#18596). Always enabling IME makes Avalonia
-                        // talk to ibus/fcitx over D-Bus like GTK apps do, so dead-key composition
-                        // (á, ê, õ, ...) works. Users can still opt out with AVALONIA_IM_MODULE=none.
+                        // Required for dead-key composition on Linux: without it Avalonia opens
+                        // neither an input method nor XIM for European locales, so dead keys type
+                        // nothing (issues #13333, #12334, #10618). Which input path is then used is
+                        // steered by ApplyLinuxDeadKeyInputFix above: non-CJK locales get XIM with
+                        // libX11's local compose (reliable), CJK locales keep the ibus/fcitx D-Bus
+                        // route. Users can still opt out with AVALONIA_IM_MODULE=none.
                         EnableIme = true,
                     })
                     .With(new AvaloniaNativePlatformOptions
@@ -235,6 +239,49 @@ namespace Nikse.SubtitleEdit
                 Se.LogError(exception, "Critical error during application startup");
                 Environment.Exit(1);
             }
+        }
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int setenv(string name, string value, int overwrite);
+
+        /// <summary>
+        /// Makes dead-key accents (á, ê, õ, ...) work on Linux. Avalonia's ibus D-Bus client
+        /// (enabled via EnableIme below) races key events against ibus and loses: the dead key
+        /// and the following letter are both swallowed before they reach the app, so no app-level
+        /// fallback can recover them (issues #13333, #12334, #10618; verified against a
+        /// Xvfb + ibus test rig - see PR). Instead, for non-CJK locales, steer Avalonia to XIM
+        /// with libX11's built-in "local" input method, which composes dead keys client-side and
+        /// needs no input-method daemon at all. CJK locales are left untouched so Chinese/
+        /// Japanese/Korean input keeps the ibus/fcitx D-Bus route, and setting AVALONIA_IM_MODULE
+        /// to anything skips this entirely.
+        /// </summary>
+        private static void ApplyLinuxDeadKeyInputFix()
+        {
+            if (!OperatingSystem.IsLinux())
+            {
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AVALONIA_IM_MODULE")))
+            {
+                return; // explicit user choice wins
+            }
+
+            var lang = Environment.GetEnvironmentVariable("LANG") ?? string.Empty;
+            if (lang.Contains("zh") || lang.Contains("ja") || lang.Contains("ko"))
+            {
+                return; // keep the real input method for CJK text entry
+            }
+
+            // Avalonia picks its input path from the managed environment: clearing the IM-module
+            // variables makes its D-Bus IME detection fall through, and "@im=local" makes its
+            // ShouldUseXim check pass. libX11 reads XMODIFIERS through native getenv when XOpenIM
+            // runs, and managed SetEnvironmentVariable never reaches the native environment, so
+            // the value must also be set via libc setenv - before Avalonia loads libX11.
+            Environment.SetEnvironmentVariable("GTK_IM_MODULE", null);
+            Environment.SetEnvironmentVariable("QT_IM_MODULE", null);
+            Environment.SetEnvironmentVariable("XMODIFIERS", "@im=local");
+            setenv("XMODIFIERS", "@im=local", 1);
         }
 
         private static void ConfigureApplication(AppBuilder b, ClassicDesktopStyleApplicationLifetime lifetime)


### PR DESCRIPTION
Fixes #13333 (follow-up to #13351; same root cause family as #12334 and #10618).

### Why #13351 wasn't enough

The reporter of #13333 confirmed accents still fail on beta7, even though `EnableIme = true` shipped — and their diagnostics showed a healthy ibus setup (`ibus-portal` running, `QT_IM_MODULE=ibus`, GNOME Wayland). To find out why, this PR was developed against a **ground-truth rig**: a Docker container with Xvfb (`-noreset`), a session D-Bus, a full ibus stack (daemon + portal + simple engine), real dead keys in the X keymap, and xdotool driving key events — first into a minimal Avalonia probe app that logs every KeyDown/TextInput, then into Subtitle Edit itself, with `dbus-monitor` capturing the app↔ibus conversation.

The rig reproduces the bug deterministically, and the D-Bus capture shows what goes wrong with Avalonia's ibus client:

- The **key-down events never reach ibus with their keysyms** — the dead key's down is dropped, the following letter's down goes out as `ProcessKeyEvent(0, 0, 0)`, which ibus answers `handled=true`, swallowing the letter. Only key-releases carry correct keysyms. No `CommitText` ever comes back.
- Under an X protocol proxy (xtrace) that slightly shifts event timing, **the exact same setup composes `á` correctly** — proving this is a race in Avalonia's async IME pipeline, not a protocol mismatch. That also explains why some machines appear fine while others (like the reporter's) always fail.
- Because the letter is swallowed *before* it reaches the app, no app-level compose fallback can recover it.

### The fix

For **non-CJK locales** on Linux, steer Avalonia away from the racy ibus route and onto XIM with libX11's built-in *local* input method, which composes dead keys client-side with no input-method daemon involved:

- clear `GTK_IM_MODULE` / `QT_IM_MODULE` (managed env — Avalonia's D-Bus IME detection reads these),
- set `XMODIFIERS=@im=local` both managed (for Avalonia's `ShouldUseXim` check) and via libc `setenv` (XOpenIM reads it through native `getenv`; managed writes never reach the native environment),
- keep `EnableIme = true` (required for Avalonia to open XIM at all).

**CJK locales are untouched** — Chinese/Japanese/Korean users keep the ibus/fcitx D-Bus route for real IME input. Setting `AVALONIA_IM_MODULE` to anything skips the override entirely (escape hatch).

This also restores the behavior of the old `GTK_IM_MODULE="" QT_IM_MODULE="" XMODIFIERS=""` workaround, which silently stopped working when Avalonia began opening XIM only when `XMODIFIERS` contains `@im=` — with the variables cleared there was no XIM and therefore no compose at all.

### Verification (same SE build, A/B in the rig)

| Run | Typed `´a ~o ^e sim` | Result |
|---|---|---|
| Fix active (default) | subtitle text editor | **`áõêsim`** ✅ |
| `AVALONIA_IM_MODULE=ibus` (old route) | subtitle text editor | `sim` — all accents swallowed ❌ |

Plain typing, and the probe app's full event log, show no regressions for non-dead keys.

Would be good to have the reporter of #13333 confirm on the next beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
