### PR TITLE
Pass known capacity when creating lists in libse

### DIFF
--- a/src/libse/Common/ContinuationUtilities.cs
+++ b/src/libse/Common/ContinuationUtilities.cs
@@ -58,7 +58,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         private const string MusicSymbols = "♪♫#*¶";
         private static readonly string ExplanationQuotes = "'\"“”‘’«»‹›";
 
-        private static readonly List<string> LanguagesWithoutCaseDistinction = new List<string>
+        private static readonly List<string> LanguagesWithoutCaseDistinction = new List<string>(33)
         {
             "am", "ar", "as", "az", "bn", "my", "zh", "ka", "gu", "he", "hi", "ja", "kn", "ks", "km", "ko", "ku", "lo",
             "ml", "ps", "fa", "pa", "sd", "si", "su", "ta", "te", "th", "bo", "ti", "ur", "ug", "yi"
@@ -78,9 +78,9 @@ namespace Nikse.SubtitleEdit.Core.Common
             {'›', '‹'}
         };
 
-        public static readonly List<string> Prefixes = new List<string> { "...", "..", "-", "‐", "–", "—", "…" };
+        public static readonly List<string> Prefixes = new List<string>(7) { "...", "..", "-", "‐", "–", "—", "…" };
         public static readonly List<string> DashPrefixes = new List<string> { "-", "‐", "–", "—" };
-        public static readonly List<string> Suffixes = new List<string> { "...", "..", "-", "‐", "–", "—", "…" };
+        public static readonly List<string> Suffixes = new List<string>(7) { "...", "..", "-", "‐", "–", "—", "…" };
 
         public static readonly List<ContinuationStyle> ContinuationStyles = Enum.GetValues(typeof(ContinuationStyle)).Cast<ContinuationStyle>().ToList();
 
@@ -1203,7 +1203,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
             if (language == "nl")
             {
-                conjunctions = new List<string>
+                conjunctions = new List<string>(22)
                 {
                     "maar", "dus", "omdat", "aangezien", "want", "vermits", "zodat", "opdat", "zoals", "bijvoorbeeld",
                     "net", "behalve", "al", "alhoewel", "hoewel", "ofschoon", "tenzij", "waardoor", "waarna", "misschien", "waarschijnlijk", "vast"
@@ -1211,21 +1211,21 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
             else if (language == "en")
             {
-                conjunctions = new List<string>
+                conjunctions = new List<string>(8)
                 {
                     "and", "but", "for", "nor", "yet", "or", "so", "such as"
                 };
             }
             else if (language == "fr")
             {
-                conjunctions = new List<string>
+                conjunctions = new List<string>(5)
                 {
                     "mais", "car", "donc", "parce que", "par exemple"
                 };
             }
             else if (language == "pt")
             {
-                conjunctions = new List<string>
+                conjunctions = new List<string>(14)
                 {
                     "mas", "nem", "por exemplo", "e", "bem com", "todavia", "no entanto", "mas também", "como também",
                     "bem como", "porém", "por isso", "porque", "portanto"

--- a/src/libse/Common/HtmlUtil.cs
+++ b/src/libse/Common/HtmlUtil.cs
@@ -1274,7 +1274,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
             if (assa)
             {
-                var onOffTags = new List<string> { "i", "b", "u", "s", "be" };
+                var onOffTags = new List<string>(5) { "i", "b", "u", "s", "be" };
                 if (onOffTags.Contains(tag))
                 {
                     if (text.Contains($"\\{tag}1"))
@@ -1342,7 +1342,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
             if (assa)
             {
-                var onOffTags = new List<string> { "i", "b", "u", "s", "be" };
+                var onOffTags = new List<string>(5) { "i", "b", "u", "s", "be" };
                 if (onOffTags.Contains(tag))
                 {
                     return text.Contains($"\\{tag}1");
@@ -1369,7 +1369,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
             if (assa)
             {
-                var onOffTags = new List<string> { "i", "b", "u", "s", "be" };
+                var onOffTags = new List<string>(5) { "i", "b", "u", "s", "be" };
                 if (onOffTags.Contains(tag))
                 {
                     text = text.Replace($"{{\\{tag}1}}", string.Empty);
@@ -1423,7 +1423,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
             if (assa)
             {
-                var onOffTags = new List<string> { "i", "b", "u", "s", "be" };
+                var onOffTags = new List<string>(5) { "i", "b", "u", "s", "be" };
                 if (onOffTags.Contains(tag))
                 {
                     if (text.Contains($"\\{tag}1"))

--- a/src/libse/Common/Iso639Dash2LanguageCode.cs
+++ b/src/libse/Common/Iso639Dash2LanguageCode.cs
@@ -29,7 +29,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             BibliographicCode = string.IsNullOrEmpty(bibliographicCode) ? threeLetterCode : bibliographicCode;
         }
 
-        public static readonly List<Iso639Dash2LanguageCode> List = new List<Iso639Dash2LanguageCode>
+        public static readonly List<Iso639Dash2LanguageCode> List = new List<Iso639Dash2LanguageCode>(184)
         {
             new Iso639Dash2LanguageCode("aar", "aa", "Afar", "aar"),
             new Iso639Dash2LanguageCode("abk", "ab", "Abkhazian", "abk"),

--- a/src/libse/Common/PlainTextImporter.cs
+++ b/src/libse/Common/PlainTextImporter.cs
@@ -287,7 +287,7 @@
             public List<string> SplitToFour(string text)
             {
                 var lines = Utilities.AutoBreakLinePrivate(text.Trim(), _singleLineMaxLength, Configuration.Settings.General.MergeLinesShorterThan, _language, true).SplitToLines();
-                var list = new List<string>();
+                var list = new List<string>(lines.Count);
                 foreach (var line in lines)
                 {
                     list.Add(Utilities.AutoBreakLinePrivate(line, _singleLineMaxLength, Configuration.Settings.General.MergeLinesShorterThan, _language, true));

--- a/src/libse/Common/RichTextToPlainText.cs
+++ b/src/libse/Common/RichTextToPlainText.cs
@@ -33,7 +33,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         private static readonly Regex RtfRegex = new Regex(@"\\([a-z]{1,32})(-?\d{1,10})?[ ]?|\\'([0-9a-f]{2})|\\([^a-z])|([{}])|[\r\n]+|(.)", RegexOptions.Singleline | RegexOptions.IgnoreCase);
 
-        private static readonly List<string> Destinations = new List<string>
+        private static readonly List<string> Destinations = new List<string>(294)
         {
             "aftncn","aftnsep","aftnsepc","annotation","atnauthor","atndate","atnicn","atnid",
             "atnparent","atnref","atntime","atrfend","atrfstart","author","background",

--- a/src/libse/Common/SccPositionAndStyleTable.cs
+++ b/src/libse/Common/SccPositionAndStyleTable.cs
@@ -7,7 +7,7 @@ namespace Nikse.SubtitleEdit.Core.Common
     public static class SccPositionAndStyleTable
     {
         public static readonly ReadOnlyCollection<SccPositionAndStyle> SccPositionAndStyles =
-            new ReadOnlyCollection<SccPositionAndStyle>(new List<SccPositionAndStyle>
+            new ReadOnlyCollection<SccPositionAndStyle>(new List<SccPositionAndStyle>(634)
         {
             //NO x-coordinate?
             new SccPositionAndStyle(SKColors.White, SccFontStyle.Regular, 01, 0, "1140"),

--- a/src/libse/Common/TextEffect/KaraokeEffect.cs
+++ b/src/libse/Common/TextEffect/KaraokeEffect.cs
@@ -24,7 +24,7 @@ namespace Nikse.SubtitleEdit.Core.Common.TextEffect
             // the gaps must be 0 to avoid flickering
             const double gapBetweenSentences = 0;
 
-            var animations = new List<Paragraph>();
+            var animations = new List<Paragraph>(result.Length);
             for (var i = 0; i < result.Length; i++)
             {
                 var startTime = new TimeCode(baseStartTime + i * durationPerSentence);

--- a/src/libse/Common/TextLengthCalculator/CalcFactory.cs
+++ b/src/libse/Common/TextLengthCalculator/CalcFactory.cs
@@ -5,7 +5,7 @@ namespace Nikse.SubtitleEdit.Core.Common.TextLengthCalculator
 {
     public static class CalcFactory
     {
-        public static List<ICalcLength> Calculators = new List<ICalcLength>
+        public static List<ICalcLength> Calculators = new List<ICalcLength>(11)
         {
             new CalcAll(),
             new CalcNoSpaceCpsOnly(),

--- a/src/libse/Common/TextSplitResult.cs
+++ b/src/libse/Common/TextSplitResult.cs
@@ -112,7 +112,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         {
             Lines = lines;
 
-            LengthCharacters = new List<int>();
+            LengthCharacters = new List<int>(lines.Count);
             foreach (var line in lines)
             {
                 LengthCharacters.Add(line.Length);

--- a/src/libse/Common/UnknownFormatImporterCsv.cs
+++ b/src/libse/Common/UnknownFormatImporterCsv.cs
@@ -16,11 +16,11 @@ namespace Nikse.SubtitleEdit.Core.Common
             public bool Play { get; set; }
         }
 
-        private readonly List<string> _startNames = new List<string> { "start", "start time", "in", "begin", "starttime", "start_time", "starttime", "startmillis", "start_millis", "startms", "start_ms", "startms", "startmilliseconds", "start_millisesonds", "startmilliseconds", "from", "fromtime", "from_ms", "fromms", "frommilliseconds", "from_milliseconds", "tc-in", "tc in", "show", "timecode", "start tc", "start-tc", "tc start", "tc-start" };
-        private readonly List<string> _endNames = new List<string> { "end", "end time", "out", "stop", "endtime", "end_time", "endtime", "endmillis", "end_millis", "endms", "end_ms", "endmilliseconds", "end_millisesonds", "endmilliseconds", "to", "totime", "to_ms", "toms", "tomilliseconds", "to_milliseconds", "tc-out", "tc out", "hide", "end tc", "end-tc", "tc end", "tc-end" };
+        private readonly List<string> _startNames = new List<string>(29) { "start", "start time", "in", "begin", "starttime", "start_time", "starttime", "startmillis", "start_millis", "startms", "start_ms", "startms", "startmilliseconds", "start_millisesonds", "startmilliseconds", "from", "fromtime", "from_ms", "fromms", "frommilliseconds", "from_milliseconds", "tc-in", "tc in", "show", "timecode", "start tc", "start-tc", "tc start", "tc-start" };
+        private readonly List<string> _endNames = new List<string>(27) { "end", "end time", "out", "stop", "endtime", "end_time", "endtime", "endmillis", "end_millis", "endms", "end_ms", "endmilliseconds", "end_millisesonds", "endmilliseconds", "to", "totime", "to_ms", "toms", "tomilliseconds", "to_milliseconds", "tc-out", "tc out", "hide", "end tc", "end-tc", "tc end", "tc-end" };
         private readonly List<string> _durationNames = new List<string> { "duration", "durationms", "dur" };
-        private readonly List<string> _textNames = new List<string> { "text", "content", "value", "caption", "sentence", "dialog", "dialogue" };
-        private readonly List<string> _characterNames = new List<string> { "speaker", "voice", "character", "role", "name", "actor", "rolle", "character name", "sprecher" };
+        private readonly List<string> _textNames = new List<string>(7) { "text", "content", "value", "caption", "sentence", "dialog", "dialogue" };
+        private readonly List<string> _characterNames = new List<string>(9) { "speaker", "voice", "character", "role", "name", "actor", "rolle", "character name", "sprecher" };
 
         public Subtitle AutoGuessImport(List<string> lines)
         {
@@ -161,7 +161,12 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         private double[] GetGaps(string[] strings)
         {
-            var gaps = new List<double>();
+            if (strings == null || strings.Length < 2)
+            {
+                return Array.Empty<double>();
+            }
+
+            var gaps = new List<double>(strings.Length - 1);
             for (var i = 1; i < strings.Length; i++)
             {
                 var start = TimeCode.ParseToMilliseconds(strings[i - 1]);
@@ -221,7 +226,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         !csvLine.Start.Contains(';') &&
                         double.TryParse(csvLine.Start, out var n))
                     {
-                        var msNames = new List<string> { "startmillis", "start_millis", "startms", "start_ms", "startms", "startmilliseconds", "start_millisesonds", "startmilliseconds", "from_ms", "fromms", "frommilliseconds", "from_milliseconds" };
+                        var msNames = new List<string>(12) { "startmillis", "start_millis", "startms", "start_ms", "startms", "startmilliseconds", "start_millisesonds", "startmilliseconds", "from_ms", "fromms", "frommilliseconds", "from_milliseconds" };
                         if (msNames.Contains(headers[startIndex].ToLowerInvariant()))
                         {
                             csvLine.Start = new TimeCode(n).ToString(false);
@@ -239,7 +244,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         !csvLine.End.Contains(';') &&
                         double.TryParse(csvLine.End, out var n))
                     {
-                        var msNames = new List<string> { "endmillis", "end_millis", "endms", "end_ms", "endmilliseconds", "end_millisesonds", "endmilliseconds", "to_ms", "toms", "tomilliseconds", "to_milliseconds" };
+                        var msNames = new List<string>(11) { "endmillis", "end_millis", "endms", "end_ms", "endmilliseconds", "end_millisesonds", "endmilliseconds", "to_ms", "toms", "tomilliseconds", "to_milliseconds" };
                         if (msNames.Contains(headers[endIndex].ToLowerInvariant()))
                         {
                             csvLine.End = new TimeCode(n).ToString(false);

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -1882,7 +1882,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         public static string ToSuperscript(string text)
         {
             var sb = new StringBuilder();
-            var superscript = new List<char>{
+            var superscript = new List<char>(58){
                                               '⁰',
                                               '¹',
                                               '²',
@@ -1942,7 +1942,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                                               'ᵁ',
                                               'ᵂ'
                                             };
-            var normal = new List<char>{
+            var normal = new List<char>(58){
                                          '0', // "⁰"
                                          '1', // "¹"
                                          '2', // "²"
@@ -2021,7 +2021,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         public static string ToSubscript(string text)
         {
             var sb = new StringBuilder();
-            var subcript = new List<char>{
+            var subcript = new List<char>(23){
                                            '₀',
                                            '₁',
                                            '₂',
@@ -2046,7 +2046,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                                            'ᵥ',
                                            'ₓ',
                                             };
-            var normal = new List<char>
+            var normal = new List<char>(23)
                              {
                                '0',  // "₀"
                                '1',  // "₁"
@@ -3286,11 +3286,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 subtitle.Header = subtitle.Header.Trim() + Environment.NewLine;
             }
 
-            lines = new List<string>();
-            foreach (string l in subtitle.Header.Trim().SplitToLines())
-            {
-                lines.Add(l);
-            }
+            lines = subtitle.Header.Trim().SplitToLines();
 
             const string timeCodeFormat = "{0}:{1:00}:{2:00}.{3:00}"; // h:mm:ss.cc
             foreach (var mp in sub)

--- a/src/libse/ContainerFormats/TransportStream/ObjectDataSegment.cs
+++ b/src/libse/ContainerFormats/TransportStream/ObjectDataSegment.cs
@@ -53,7 +53,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
             {
                 var twoToFourBitColorLookup = new List<int> { 0, 1, 2, 3 };
                 var twoToEightBitColorLookup = new List<int> { 0, 1, 2, 3 };
-                var fourToEightBitColorLookup = new List<int> { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+                var fourToEightBitColorLookup = new List<int>(16) { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
 
                 int pixelCode = 0;
                 int runLength = 0;
@@ -136,7 +136,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
             {
                 var twoToFourBitColorLookup = new List<int> { 0, 1, 2, 3 };
                 var twoToEightBitColorLookup = new List<int> { 0, 1, 2, 3 };
-                var fourToEightBitColorLookup = new List<int> { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+                var fourToEightBitColorLookup = new List<int>(16) { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
 
                 var pixelCode = 0;
                 var runLength = 0;

--- a/src/libse/Dictionaries/StringWithoutSpaceSplitToWords.cs
+++ b/src/libse/Dictionaries/StringWithoutSpaceSplitToWords.cs
@@ -121,7 +121,7 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
 
             if (threeLetterIsoLanguageName == "eng")
             {
-                wordList.AddRange(new List<string>
+                wordList.AddRange(new List<string>(23)
                 {
                     // Ignore list
                     "Andor", "honour", "honours", "putain", "whoah", "eastside", "Starpath", "comlink", "Taamet",

--- a/src/libse/Forms/RemoveTextForHISettings.cs
+++ b/src/libse/Forms/RemoveTextForHISettings.cs
@@ -31,8 +31,9 @@ namespace Nikse.SubtitleEdit.Core.Forms
         {
             OnlyIfInSeparateLine = Configuration.Settings.RemoveTextForHearingImpaired.RemoveTextBetweenOnlySeparateLines;
             RemoveIfAllUppercase = Configuration.Settings.RemoveTextForHearingImpaired.RemoveIfAllUppercase;
-            UppercaseWhitelist = new List<string>();
-            foreach (var item in (Configuration.Settings.RemoveTextForHearingImpaired.RemoveIfAllUppercaseWhitelist ?? string.Empty).Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries))
+            var uppercaseWhitelistItems = (Configuration.Settings.RemoveTextForHearingImpaired.RemoveIfAllUppercaseWhitelist ?? string.Empty).Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
+            UppercaseWhitelist = new List<string>(uppercaseWhitelistItems.Length);
+            foreach (var item in uppercaseWhitelistItems)
             {
                 UppercaseWhitelist.Add(item.Trim());
             }
@@ -40,8 +41,9 @@ namespace Nikse.SubtitleEdit.Core.Forms
             RemoveTextBeforeColonOnlyUppercase = Configuration.Settings.RemoveTextForHearingImpaired.RemoveTextBeforeColonOnlyIfUppercase;
             ColonSeparateLine = Configuration.Settings.RemoveTextForHearingImpaired.RemoveTextBeforeColonOnlyOnSeparateLine;
             RemoveWhereContains = Configuration.Settings.RemoveTextForHearingImpaired.RemoveIfContains;
-            RemoveIfTextContains = new List<string>();
-            foreach (var item in Configuration.Settings.RemoveTextForHearingImpaired.RemoveIfContainsText.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
+            var removeIfContainsItems = Configuration.Settings.RemoveTextForHearingImpaired.RemoveIfContainsText.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+            RemoveIfTextContains = new List<string>(removeIfContainsItems.Length);
+            foreach (var item in removeIfContainsItems)
             {
                 RemoveIfTextContains.Add(item.Trim());
             }

--- a/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
@@ -432,7 +432,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                 return DefaultHeader;
             }
 
-            var styles = new List<SsaStyle>();
+            var styles = new List<SsaStyle>(stylesContent.Count);
             foreach (var styleAsString in stylesContent)
             {
                 styles.Add(SsaStyle.FromRawSsa(header, styleAsString));
@@ -1025,8 +1025,9 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
 
         public static List<SsaStyle> GetSsaStylesFromHeader(string header)
         {
-            var styles = new List<SsaStyle>();
-            foreach (var styleName in GetStylesFromHeader(header))
+            var styleNames = GetStylesFromHeader(header);
+            var styles = new List<SsaStyle>(styleNames.Count);
+            foreach (var styleName in styleNames)
             {
                 styles.Add(GetSsaStyle(styleName, header));
             }
@@ -1488,7 +1489,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                 return false;
             }
 
-            var unsupportedTags = new List<string>
+            var unsupportedTags = new List<string>(28)
             {
                 "\\alpha",
                 "\\be0",

--- a/src/libse/SubtitleFormats/Cavena890.cs
+++ b/src/libse/SubtitleFormats/Cavena890.cs
@@ -71,7 +71,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             { 0x6c, "ـ" },
         };
 
-        private static readonly List<int> HebrewCodes = new List<int>
+        private static readonly List<int> HebrewCodes = new List<int>(79)
         {
             0x40, // א
             0x41, // ב
@@ -156,7 +156,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             0xAA, // "Z" - weird
         };
 
-        private static readonly List<string> HebrewLetters = new List<string>
+        private static readonly List<string> HebrewLetters = new List<string>(79)
         {
             "א",
             "ב",
@@ -241,7 +241,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             "Z", // 0xAA,
         };
 
-        private static readonly List<int> RussianCodes = new List<int>
+        private static readonly List<int> RussianCodes = new List<int>(44)
         {
             0x42, // Б
             0x45, // Е
@@ -289,7 +289,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             0x68, // П
         };
 
-        private static readonly List<string> RussianLetters = new List<string>
+        private static readonly List<string> RussianLetters = new List<string>(44)
         {
             "Б",
             "Е",
@@ -337,7 +337,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             "х",
         };
 
-        private static readonly List<Tuple<int, string>> Greek = new List<Tuple<int, string>>
+        private static readonly List<Tuple<int, string>> Greek = new List<Tuple<int, string>>(145)
         {
             new Tuple<int, string>(0x20, " "),
             new Tuple<int, string>(0x21, "!"),

--- a/src/libse/SubtitleFormats/Chk.cs
+++ b/src/libse/SubtitleFormats/Chk.cs
@@ -140,7 +140,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
             else // time codes
             {
-                var newTimeCodes = new List<Paragraph>();
+                var newTimeCodes = new List<Paragraph>(15);
                 for (int i = 0; i < 15; i++)
                 {
                     int start = index + 2 + (i * 8);

--- a/src/libse/SubtitleFormats/ItunesTimedText.cs
+++ b/src/libse/SubtitleFormats/ItunesTimedText.cs
@@ -149,7 +149,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
                     if (divNode != null)
                     {
-                        var lst = new List<XmlNode>();
+                        var lst = new List<XmlNode>(divNode.ChildNodes.Count);
                         foreach (XmlNode child in divNode.ChildNodes)
                         {
                             lst.Add(child);

--- a/src/libse/SubtitleFormats/ScenaristClosedCaptions.cs
+++ b/src/libse/SubtitleFormats/ScenaristClosedCaptions.cs
@@ -22,7 +22,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         protected virtual Regex RegexTimeCodes => Regex;
         protected bool DropFrame;
 
-        private static readonly List<KeyValuePair<string, string>> LetterDictionary = new List<KeyValuePair<string, string>>
+        private static readonly List<KeyValuePair<string, string>> LetterDictionary = new List<KeyValuePair<string, string>>(339)
         {
             new KeyValuePair<string, string>("20",                  " " ),
             new KeyValuePair<string, string>("a1",                  "!" ),
@@ -732,7 +732,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 row = 6 - totalLines / 2 + lineNumber;
             }
-            var rowCodes = new List<string> { "91", "91", "92", "92", "15", "15", "16", "16", "97", "97", "10", "13", "13", "94", "94" };
+            var rowCodes = new List<string>(15) { "91", "91", "92", "92", "15", "15", "16", "16", "97", "97", "10", "13", "13", "94", "94" };
             var rowCode = rowCodes[row];
 
             var left = (32 - text.Length) / 2;
@@ -751,28 +751,28 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             switch (column)
             {
                 case 0:
-                    columnCodes = new List<string> { "d0", "70", "d0", "70", "d0", "70", "d0", "70", "d0", "70", "d0", "d0", "70", "d0", "70" };
+                    columnCodes = new List<string>(15) { "d0", "70", "d0", "70", "d0", "70", "d0", "70", "d0", "70", "d0", "d0", "70", "d0", "70" };
                     break;
                 case 4:
-                    columnCodes = new List<string> { "52", "f2", "52", "f2", "52", "f2", "52", "f2", "52", "f2", "52", "52", "f2", "52", "f2" };
+                    columnCodes = new List<string>(15) { "52", "f2", "52", "f2", "52", "f2", "52", "f2", "52", "f2", "52", "52", "f2", "52", "f2" };
                     break;
                 case 8:
-                    columnCodes = new List<string> { "54", "f4", "54", "f4", "54", "f4", "54", "f4", "54", "f4", "54", "54", "f4", "54", "f4" };
+                    columnCodes = new List<string>(15) { "54", "f4", "54", "f4", "54", "f4", "54", "f4", "54", "f4", "54", "54", "f4", "54", "f4" };
                     break;
                 case 12:
-                    columnCodes = new List<string> { "d6", "76", "d6", "76", "d6", "76", "d6", "76", "d6", "76", "d6", "d6", "76", "d6", "76" };
+                    columnCodes = new List<string>(15) { "d6", "76", "d6", "76", "d6", "76", "d6", "76", "d6", "76", "d6", "d6", "76", "d6", "76" };
                     break;
                 case 16:
-                    columnCodes = new List<string> { "58", "f8", "58", "f8", "58", "f8", "58", "f8", "58", "f8", "58", "58", "f8", "58", "f8" };
+                    columnCodes = new List<string>(15) { "58", "f8", "58", "f8", "58", "f8", "58", "f8", "58", "f8", "58", "58", "f8", "58", "f8" };
                     break;
                 case 20:
-                    columnCodes = new List<string> { "da", "7a", "da", "7a", "da", "7a", "da", "7a", "da", "7a", "da", "da", "7a", "da", "7a" };
+                    columnCodes = new List<string>(15) { "da", "7a", "da", "7a", "da", "7a", "da", "7a", "da", "7a", "da", "da", "7a", "da", "7a" };
                     break;
                 case 24:
-                    columnCodes = new List<string> { "dc", "7c", "dc", "7c", "dc", "7c", "dc", "7c", "dc", "7c", "dc", "dc", "7c", "dc", "7c" };
+                    columnCodes = new List<string>(15) { "dc", "7c", "dc", "7c", "dc", "7c", "dc", "7c", "dc", "7c", "dc", "dc", "7c", "dc", "7c" };
                     break;
                 default: // 28
-                    columnCodes = new List<string> { "5e", "fe", "5e", "fe", "5e", "fe", "5e", "fe", "5e", "fe", "5e", "5e", "fe", "5e", "fe" };
+                    columnCodes = new List<string>(15) { "5e", "fe", "5e", "fe", "5e", "fe", "5e", "fe", "5e", "fe", "5e", "5e", "fe", "5e", "fe" };
                     break;
             }
             var code = rowCode + columnCodes[row];

--- a/src/libse/SubtitleFormats/SubtitleFormat.cs
+++ b/src/libse/SubtitleFormats/SubtitleFormat.cs
@@ -82,7 +82,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     return _allSubtitleFormats;
                 }
 
-                _allSubtitleFormats = new List<SubtitleFormat>
+                _allSubtitleFormats = new List<SubtitleFormat>(333)
                 {
                     new SubRip(),
                     new AbcIViewer(),

--- a/src/libse/SubtitleFormats/TextST.cs
+++ b/src/libse/SubtitleFormats/TextST.cs
@@ -216,7 +216,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     idx += 29;
                 }
 
-                UserStyles = new List<UserStyle>();
+                UserStyles = new List<UserStyle>(NumberOfUserStyles);
                 for (int j = 0; j < NumberOfUserStyles; j++)
                 {
                     var us = new UserStyle

--- a/src/libse/SubtitleFormats/TimedText10.cs
+++ b/src/libse/SubtitleFormats/TimedText10.cs
@@ -268,7 +268,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         bodyNode.RemoveChild(child);
                     }
 
-                    var lst = new List<XmlNode>();
+                    var lst = new List<XmlNode>(divNode.ChildNodes.Count);
                     foreach (XmlNode child in divNode.ChildNodes)
                     {
                         lst.Add(child);
@@ -881,7 +881,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     }
 
                     // Saving attributes
-                    var effectsToSave = new List<string>
+                    var effectsToSave = new List<string>(8)
                     {
                         "xml:space",
                         "tts:fontSize",
@@ -907,7 +907,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     if (!string.IsNullOrEmpty(region))
                     {
                         var regionCorrespondToTag = false;
-                        var regionTags = new List<KeyValuePair<string, string>>
+                        var regionTags = new List<KeyValuePair<string, string>>(9)
                         {
                             new KeyValuePair<string, string>("bottomLeft", "{\\an1}"),
                             new KeyValuePair<string, string>("bottomCenter", "{\\an2}"),

--- a/src/libse/SubtitleFormats/TimedTextNoNs.cs
+++ b/src/libse/SubtitleFormats/TimedTextNoNs.cs
@@ -139,7 +139,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         bodyNode.RemoveChild(child);
                     }
 
-                    var lst = new List<XmlNode>();
+                    var lst = new List<XmlNode>(divNode.ChildNodes.Count);
                     foreach (XmlNode child in divNode.ChildNodes)
                     {
                         lst.Add(child);


### PR DESCRIPTION
## Summary
- Pre-size `List<T>` allocations in libse where the exact element count is provably known at construction, avoiding internal array growth (4 → 8 → 16 → …)
- Collection initializers with 5+ items now pass the item count as capacity (47 sites, e.g. the SCC letter table, Cavena890 character tables, ISO 639 language list); initializers with ≤4 items are left untouched since the first `Add` allocates a 4-slot array anyway
- Lists filled by one-`Add`-per-item loops now pass the source `Count`/`Length` (13 sites); inline calls (`GetStylesFromHeader`, `Split`) are hoisted to locals first so they are not evaluated twice
- A pure copy loop in `Utilities` is replaced with direct assignment of the `SplitToLines()` result

## Test plan
- [ ] `dotnet build src/libse/LibSE.csproj` succeeds on both target frameworks (netstandard2.1 and net10.0)
- [ ] `dotnet test tests/libse/LibSETests.csproj` passes (935/935 locally)
- [ ] Load an ASSA subtitle with styles and verify styles are parsed and applied as before
- [ ] Save a subtitle as Scenarist Closed Captions and compare output to a pre-change export
- [ ] Run Remove Text for Hearing Impaired with a comma-separated whitelist/contains list configured and verify behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)