### PR TITLE
Destroy the TTS preview mpv core off the UI thread

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -2097,6 +2097,11 @@ public partial class TextToSpeechViewModel : ObservableObject
         IsNotGenerating = true;
         ProgressOpacity = 0;
         OkPressed = true;
+
+        // Tear the preview player down here, before the window starts closing, so libmpv's
+        // native teardown is never concurrent with Avalonia's window teardown (#13376).
+        DisposePreviewPlayer();
+
         Close();
     }
 
@@ -2158,22 +2163,68 @@ public partial class TextToSpeechViewModel : ObservableObject
         }
     }
 
-    private async Task PlayAudio(string fileName)
+    /// <summary>
+    /// Drops the voice-preview player and destroys its mpv core on a worker thread.
+    /// <para>
+    /// <c>mpv_terminate_destroy</c> blocks until every mpv worker has exited and runs libmpv's
+    /// native win32/audio deinit, so it must not run on the UI thread while a window is closing:
+    /// doing it inline in <c>OnClosing</c> left <c>Window.CloseInternal()</c> to make its next COM
+    /// call (<c>IFrameworkInputPane.Unadvise</c>) into an apartment libmpv's teardown had already
+    /// disturbed - an access violation no catch block can intercept (#13376, same crash reported
+    /// as #12626). Same reasoning as <c>VideoPlayerControl.CloseAndDisposePlayer</c> (#11176).
+    /// </para>
+    /// Safe to call more than once - the second call finds no player and does nothing.
+    /// </summary>
+    private void DisposePreviewPlayer()
     {
+        LibMpvDynamicPlayer? player;
         lock (_playLock)
         {
-            _mpvContext?.Stop();
-            _mpvContext?.Dispose();
+            player = _mpvContext;
+            _mpvContext = null;
+        }
 
-            _mpvContext = new LibMpvDynamicPlayer();
-            _mpvContext.LoadLib(); // core not initialized"
-            var err = _mpvContext.Initialize();
+        if (player == null)
+        {
+            return;
+        }
+
+        Se.WriteToolsLog("TTS window: disposing audio preview player (mpv) on worker thread");
+        Task.Run(() =>
+        {
+            try
+            {
+                // Stop first so the core tears down from an idle state instead of mid-playback.
+                player.Stop();
+                player.Dispose();
+            }
+            catch (Exception ex)
+            {
+                SeLogger.Error(ex, "TTS window: disposing the audio preview player failed");
+            }
+        });
+    }
+
+    private async Task PlayAudio(string fileName)
+    {
+        DisposePreviewPlayer();
+
+        LibMpvDynamicPlayer player;
+        lock (_playLock)
+        {
+            player = new LibMpvDynamicPlayer();
+            player.LoadLib(); // core not initialized"
+            var err = player.Initialize();
             if (err < 0)
             {
-                throw new InvalidOperationException($"Failed to initialize mpv: {_mpvContext.GetErrorString(err)}");
+                throw new InvalidOperationException($"Failed to initialize mpv: {player.GetErrorString(err)}");
             }
+
+            _mpvContext = player;
         }
-        await _mpvContext.LoadAudio(fileName);
+
+        // Through the local: a close running now can null the field out from under us.
+        await player.LoadAudio(fileName);
     }
 
     private async Task<bool> IsEngineInstalled(ITtsEngine engine)
@@ -3610,21 +3661,12 @@ public partial class TextToSpeechViewModel : ObservableObject
             SeLogger.Error(ex, "TTS window close: stopping the playback timer failed");
         }
 
+        // Only present when Test voice played a clip, and normally already gone: OK disposes it
+        // before the close starts. This covers the paths that close without OK (Cancel, Escape,
+        // title bar). Never dispose it inline here - see DisposePreviewPlayer (#13376).
         try
         {
-            lock (_playLock)
-            {
-                if (_mpvContext != null)
-                {
-                    // Only used when Test voice played a clip. Stop before Dispose so libmpv
-                    // tears down from an idle state instead of mid-playback - this dispose is
-                    // the prime native-crash suspect in #12626.
-                    Se.WriteToolsLog("TTS window: disposing audio preview player (mpv)");
-                    _mpvContext.Stop();
-                    _mpvContext.Dispose();
-                    _mpvContext = null;
-                }
-            }
+            DisposePreviewPlayer();
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Fixes the silent crash when closing the Text to Speech window (#13376, reported earlier as #12626).

## The crash

The reporter's Event Viewer entry is an access violation (`0xc0000005`) with the managed stack ending at:

```
Avalonia.Win32.Win32Com.Impl.__MicroComIFrameworkInputPaneProxy.Unadvise(UInt32)
Avalonia.Controls.Window.CloseInternal()
TextToSpeechViewModel.CloseWindowSafely()
```

The try/catch added for #12626/#12628 cannot help here — an AV in a COM proxy is not a managed exception, which the comment on `CloseWindowSafely` already predicted.

## Root cause

`OnClosing` disposed the voice-preview player inline on the UI thread. `LibMpvDynamicPlayer.Dispose()` runs `mpv_terminate_destroy`, which blocks until every mpv worker has exited and runs libmpv's native win32/audio deinit. Control then returned to `Window.CloseInternal()`, whose next act is a COM call — `Unadvise` — into an apartment that teardown had already disturbed.

The rest of the codebase already treats UI-thread mpv termination as a hazard: `FreeRenderContextIfDisposePending` pushes `TerminateCore` onto `Task.Run` citing #11176/#13083, and `VideoPlayerControl.CloseAndDisposePlayer` does the same. The TTS window was the one place still doing it inline on a close path.

## Change

- New `DisposePreviewPlayer()` — takes the player out of `_mpvContext` under `_playLock`, nulls the field, then `Stop()` + `Dispose()` inside `Task.Run` with its own try/catch. Idempotent.
- `Ok()` calls it **before** posting the close, so libmpv teardown and Avalonia's window teardown never overlap.
- `OnClosing` calls the same helper instead of disposing inline, covering Cancel / Escape / title-bar close.
- `PlayAudio` retires the previous player the same way, and awaits `LoadAudio` through a local since a concurrent close can now null the field.

## Verification

Builds clean. The preview player only exists if the user pressed **Test voice**, so the tools log now records `disposing audio preview player (mpv) on worker thread` — a fresh log from the reporter will confirm a player was in play. If it turns out no preview was ever played, this change is still correct but the crash would be elsewhere, and the next step would be pinning the STA apartment with an extra `CoInitializeEx` at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)