### PR TITLE
Restore focus after activation loss and reset caret on grid navigation (#13371)

### DIFF
--- a/src/ui/Features/Main/MainView.cs
+++ b/src/ui/Features/Main/MainView.cs
@@ -55,6 +55,7 @@ public class MainView : ViewBase
             _vm.Window = hostWindow;
             _vm.Window.Closing += _vm.OnClosing;
             _vm.Window.Deactivated += _vm.OnWindowDeactivated;
+            _vm.Window.Activated += _vm.OnWindowActivated;
             _vm.Window.Loaded += (_, _) =>
             {
                 _vm.OnLoaded();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -382,6 +382,7 @@ public partial class MainViewModel :
     FindViewModel? _findViewModel;
     Control? _findPreviousFocus;
     Control? _focusBeforeMainMenu;
+    Control? _focusBeforeWindowDeactivated;
     bool _altClosesMainMenuOnKeyUp;
     readonly AltMenuActivationGuard _altMenuActivationGuard = new();
     bool _findClosingProgrammatically;
@@ -21670,6 +21671,10 @@ public partial class MainViewModel :
     /// </summary>
     internal void OnWindowDeactivated(object? sender, EventArgs e)
     {
+        // Remember where the caret was so re-activation can put it back (see OnWindowActivated).
+        // Captured before the cleanup below, which can move focus itself.
+        _focusBeforeWindowDeactivated = GetRestorableFocusedControl();
+
         // Avalonia's AccessKeyHandler must not be left mid-Alt-gesture either: a modal opened
         // while Alt was held (Alt, O, ... reaching the Shortcuts window) eats the physical Alt
         // release, and the stranded "ignore the next Alt up" state makes the next bare Alt press
@@ -21693,6 +21698,69 @@ public partial class MainViewModel :
         {
             DeactivateMainMenu();
         }
+    }
+
+    /// <summary>
+    /// Restores keyboard focus to the control that had it before the window lost activation.
+    ///
+    /// Another application taking focus and handing it straight back - a global hotkey from a
+    /// clipboard manager, a launcher, a notification - leaves Avalonia without a focus target, and
+    /// focus then lands on the first focusable element in the window: the menu bar. The user sees
+    /// "File" highlighted, the caret gone from the subtitle text box, and every following key
+    /// swallowed by the menu (OnKeyDownHandler bails while IsMainMenuFocused). SE4 kept the caret
+    /// where it was, so do the same (#13371).
+    ///
+    /// Deferred, and only applied when focus is genuinely nowhere useful, so re-activating by
+    /// clicking a control keeps whatever the click focused.
+    /// </summary>
+    internal void OnWindowActivated(object? sender, EventArgs e)
+    {
+        var previous = _focusBeforeWindowDeactivated;
+        _focusBeforeWindowDeactivated = null;
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (Window is not { IsActive: true })
+            {
+                return;
+            }
+
+            if (GetRestorableFocusedControl() != null)
+            {
+                return; // focus landed somewhere real (e.g. the user clicked a control) - leave it
+            }
+
+            if (previous != null && TopLevel.GetTopLevel(previous) != null)
+            {
+                previous.Focus();
+                return;
+            }
+
+            SubtitleGrid?.Focus();
+        });
+    }
+
+    /// <summary>
+    /// The focused control, when it is a real, on-screen one worth returning to later. Null for the
+    /// bare window, for a control detached from the visual tree (how a closed popup's menu item
+    /// looks while it still holds focus) and for the main menu bar - focus sitting on the menu is
+    /// exactly the state <see cref="OnWindowActivated"/> exists to undo.
+    /// </summary>
+    private Control? GetRestorableFocusedControl()
+    {
+        if (Window?.FocusManager?.GetFocusedElement() is not Control focused ||
+            focused == Window ||
+            TopLevel.GetTopLevel(focused) == null)
+        {
+            return null;
+        }
+
+        if (focused is MenuItem || IsWithinMainMenu(focused))
+        {
+            return null;
+        }
+
+        return focused;
     }
 
     /// <summary>
@@ -22853,6 +22921,8 @@ public partial class MainViewModel :
             return;
         }
 
+        var rowChanged = !ReferenceEquals(item, SelectedSubtitle);
+
         try
         {
             _subtitleGridSelectionChangedSkip = true;
@@ -22862,6 +22932,19 @@ public partial class MainViewModel :
         finally
         {
             _subtitleGridSelectionChangedSkip = false;
+        }
+
+        // Same caret reset as SelectAndScrollToRow (#12707): Avalonia keeps the caret index when
+        // the bound text changes, so a new line inherited the previous line's clamped offset.
+        // SelectAndScrollToRow only covers the commanded jumps - plain grid navigation (arrow
+        // keys, mouse) comes through here instead and kept the stale caret (#13371). Must run
+        // after SelectedSubtitle is assigned, so the TwoWay Text binding has already updated.
+        // Callers that place the caret themselves set the row first, so they either see
+        // rowChanged false here, or run after this synchronous handler and win anyway.
+        if (rowChanged)
+        {
+            EditTextBox.CaretIndex = 0;
+            EditTextBoxOriginal.CaretIndex = 0;
         }
 
         MakeSubtitleTextInfo(item.Text, item);


### PR DESCRIPTION
Fixes points 1 and 2 of #13371.

## 1. Ctrl+1..9 "hijacked by the top menu"

Not a shortcut collision — SE binds nothing on Ctrl+digit except `SetupLikeSe4Command` (Ctrl+4), menu headers use no digit mnemonics, and `MenuItem.InputGesture` is display-only in Avalonia. The reporter's Ctrl+1..9 are **Ditto's global hotkeys**, so SE never sees the keys at all.

What actually happens is a focus fallback. SE handles `Window.Deactivated` but had nothing on `Activated`. Another app taking focus and handing it straight back — a global hotkey from a clipboard manager, a launcher, a notification — leaves Avalonia without a focus target, and focus falls to the first focusable element in the window: the menu bar. "File" then looks activated, the text box loses its caret, and every following key is swallowed, because `OnKeyDownHandler` returns early while `IsMainMenuFocused()`. The same failure mode is already documented for #13111 in `InitListViewAndEditBox`.

The fix remembers the focused control on deactivation and restores it on re-activation, deferred and gated on focus having genuinely landed nowhere useful — so re-activating the window with a click keeps whatever the click focused, and the grid is the fallback.

## 2. Caret position persists across subtitles

A partial regression of the #12707 fix. The reset lives in `SelectAndScrollToRow`, which covers commanded jumps, but plain grid navigation (arrow keys, mouse) goes through `SubtitleGridSelectionChanged` instead. That path only calls `EditTextBox.ClearSelection()`, which collapses the selection to the caret without moving it — and since the text box is a TwoWay binding, Avalonia keeps `CaretIndex` when the bound text changes, so the new line inherited the previous line's clamped offset. Now reset on the same "row actually changed" condition.

## Not included

Point 3 (Shift+Enter inserting a line break) is standard `AcceptsReturn` behaviour and left as-is. The related line-limit bug — the max-lines limiter requires `KeyModifiers.None`, so Shift+Enter bypasses "limit number of lines" while plain Enter respects it — and the SE4-style "Shift+Enter goes to the next subtitle" request are better handled separately.

## Testing

`dotnet build` clean; full UI suite green (1729 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)