### PR TITLE
Add frame rate to image export (fixes missing BDN/xml fps)

### DIFF
--- a/src/libuilogic/Export/ExportHandlerBdnXml.cs
+++ b/src/libuilogic/Export/ExportHandlerBdnXml.cs
@@ -25,6 +25,10 @@ public class ExportHandlerBdnXml : IExportHandler
     {
         _width = imageParameter.ScreenWidth;
         _height = imageParameter.ScreenHeight;
+        if (imageParameter.FramesPerSecond > 0)
+        {
+            _frameRate = imageParameter.FramesPerSecond;
+        }
 
         _folderName = fileOrFolderName;
         if (!Directory.Exists(_folderName))

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
@@ -69,6 +69,8 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
     [ObservableProperty] ExportContentAlignmentDisplay _selectedContentAlignment;
     [ObservableProperty] private ObservableCollection<int> _lineSpacings;
     [ObservableProperty] int _selectedLineSpacing;
+    [ObservableProperty] private ObservableCollection<double> _frameRates;
+    [ObservableProperty] private double _selectedFrameRate;
     [ObservableProperty] private ObservableCollection<SeExportImagesProfile> _profiles;
     [ObservableProperty] private SeExportImagesProfile? _selectedProfile;
     [ObservableProperty] private string _imageInfo;
@@ -162,6 +164,8 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
         SelectedContentAlignment = ContentAlignments[0];
         LineSpacings = new ObservableCollection<int>(Enumerable.Range(-50, 501));
         SelectedLineSpacing = 0;
+        FrameRates = new ObservableCollection<double> { 23.976, 24, 25, 29.97, 30, 50, 59.94, 60 };
+        SelectedFrameRate = 25;
         SubtitleGrid = new TableView();
         Title = string.Empty;
         BitmapPreview = new SKBitmap(1, 1, false).ToAvaloniaBitmap();
@@ -548,6 +552,7 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
             BottomTopMargin = SelectedTopBottomMargin,
             LeftRightMargin = SelectedLeftRightMargin,
             IsRightToLeft = IsRightToLeft,
+            FramesPerSecond = SelectedFrameRate,
         };
 
         return imageParameter;
@@ -946,6 +951,7 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
             SelectedPaddingLeftRight = profile.PaddingLeftRight;
             SelectedPaddingTopBottom = profile.PaddingTopBottom;
             SelectedLineSpacing = profile.LineSpacingPercent;
+            SelectedFrameRate = FrameRates.Contains(profile.FramesPerSecond) ? profile.FramesPerSecond : 25;
         }
     }
 
@@ -977,6 +983,7 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
             profile.PaddingLeftRight = SelectedPaddingLeftRight;
             profile.PaddingTopBottom = SelectedPaddingTopBottom;
             profile.LineSpacingPercent = SelectedLineSpacing;
+            profile.FramesPerSecond = SelectedFrameRate;
         }
     }
 

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
@@ -382,8 +382,18 @@ public class ExportImageBasedWindow : Window
         // column 3
         var checkBoxBold = UiUtil.MakeCheckBox(Se.Language.General.Bold, vm, nameof(vm.IsBold));
         checkBoxBold.IsCheckedChanged += vm.CheckBoxChanged;
-        grid.Add(checkBoxBold, 0, 5);
-        
+        var checkBoxRightToLeft = UiUtil.MakeCheckBox(Se.Language.General.RightToLeft, vm, nameof(vm.IsRightToLeft));
+        checkBoxRightToLeft.IsCheckedChanged += vm.CheckBoxChanged;
+        var panelBoldAndRightToLeft = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children = { checkBoxBold, checkBoxRightToLeft }
+        };
+        grid.Add(panelBoldAndRightToLeft, 0, 5);
+
+
         var labelOutlineWidth = UiUtil.MakeLabel(Se.Language.General.OutlineWidth);
         var comboBoxOutlineWidth = UiUtil.MakeComboBox(vm.OutlineWidths, vm, nameof(vm.SelectedOutlineWidth));
         comboBoxOutlineWidth.SelectionChanged += vm.ComboChanged;
@@ -431,9 +441,11 @@ public class ExportImageBasedWindow : Window
         grid.Add(labelBoxType, 5, 4);
         grid.Add(comboBoxBoxType, 5, 5);
         
-        var checkBoxRightToLeft = UiUtil.MakeCheckBox(Se.Language.General.RightToLeft, vm, nameof(vm.IsRightToLeft));
-        checkBoxRightToLeft.IsCheckedChanged += vm.CheckBoxChanged;
-        grid.Add(checkBoxRightToLeft, 6, 5);
+        var labelFrameRate = UiUtil.MakeLabel(Se.Language.General.FrameRate);
+        var comboBoxFrameRate = UiUtil.MakeComboBox(vm.FrameRates, vm, nameof(vm.SelectedFrameRate));
+        comboBoxFrameRate.SelectionChanged += vm.ComboChanged;
+        grid.Add(labelFrameRate, 6, 4);
+        grid.Add(comboBoxFrameRate, 6, 5);
 
         return UiUtil.MakeBorderForControl(grid);
     }


### PR DESCRIPTION
Since 5.x the "fps" setting was missing when exporting to BDN/xml: `ExportHandlerBdnXml` hard-coded `23.976`, so both the `<Format FrameRate="...">` attribute and every HH:MM:SS:FF timecode were computed at that rate regardless of the subtitle.

- Added a **Frame rate** combo box to the export images window, in the slot where **Right to left** used to be.
- **Right to left** moved up next to **Bold**.
- Plumbed the value through `ImageParameter.FramesPerSecond` (the property already existed but was never set) and used it in `ExportHandlerBdnXml`; falls back to 23.976 when unset, so other callers (batch convert, binary edit) are unchanged.
- The frame rate is saved/loaded with the export profile (`SeExportImagesProfile.FramesPerSecond`).

Standard list: 23.976, 24, 25, 29.97, 30, 50, 59.94, 60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)