### PR TITLE
Fix bold "Line length" label after layout switch

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1763,14 +1763,8 @@ public static partial class InitListViewAndEditBox
             Mode = BindingMode.OneWay,
             Source = vm
         });
-        // add label to panelSingleLineLengthsOriginal
-        var singleLineLengthLabel = new TextBlock
-        {
-            Text = Se.Language.Main.SingleLineLength,
-            FontWeight = FontWeight.Bold,
-            Margin = new Thickness(0, 0, 5, 0)
-        };
-        panelSingleLineLengthsOriginal.Children.Add(singleLineLengthLabel);
+        // no seed label here - SubtitleTextInfoHelper.FillLineLengthPanel writes the
+        // "Single line length" label into index 0 itself (and reuses the text blocks)
 
         var buttonPanel = new StackPanel
         {

--- a/src/ui/Logic/SubtitleTextInfoHelper.cs
+++ b/src/ui/Logic/SubtitleTextInfoHelper.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Media;
@@ -121,6 +122,9 @@ internal static class SubtitleTextInfoHelper
         }
     }
 
+    private const double LabelFontSize = 12;
+    private static readonly Thickness LabelPadding = new Thickness(2);
+
     private static void SetLabel(Avalonia.Controls.Controls children, ref int index, string text, IBrush? background)
     {
         if (index < children.Count && children[index] is TextBlock existing)
@@ -134,10 +138,32 @@ internal static class SubtitleTextInfoHelper
             {
                 existing.Background = background;
             }
+
+            // The panel may have been built with differently styled text blocks (e.g. a bold
+            // header seeded by the layout code); reused blocks must still look like our own.
+            if (existing.FontWeight != FontWeight.Normal)
+            {
+                existing.FontWeight = FontWeight.Normal;
+            }
+
+            if (Math.Abs(existing.FontSize - LabelFontSize) > 0.001)
+            {
+                existing.FontSize = LabelFontSize;
+            }
+
+            if (existing.Padding != LabelPadding)
+            {
+                existing.Padding = LabelPadding;
+            }
+
+            if (existing.Margin != default)
+            {
+                existing.Margin = default;
+            }
         }
         else
         {
-            var tb = UiUtil.MakeTextBlock(text).WithFontSize(12).WithPadding(2);
+            var tb = UiUtil.MakeTextBlock(text).WithFontSize(LabelFontSize).WithPadding(2);
             tb.Background = background;
             if (index < children.Count)
             {


### PR DESCRIPTION
Fixes #13384

### Problem

After switching layouts (and back) with an original subtitle open, the "Line length:" label under **Original text** turns bold and stays bold. The label under **Text** is unaffected.

### Root cause

`panelSingleLineLengthsOriginal` was seeded with a bold `TextBlock` at construction time in `InitListViewAndEditBox` — the non-original panel has no such seed, which is why only the original label misbehaved.

`SubtitleTextInfoHelper.FillLineLengthPanel` reuses the text blocks already in the panel (a typing-perf optimization) and `SetLabel` rewrote only `Text` and `Background`, never `FontWeight`/`FontSize`/`Padding`. So index 0 kept the seed's bold, larger font.

It only showed up after a layout switch because at startup nothing is selected, so `PanelSingleLineLengthsOriginal.Children.Clear()` threw the seed away and every later fill created fresh normal-weight labels. Switching layout re-runs `InitListViewAndEditBox` and builds a new panel with the seed — but now a line is already selected, so the clear path never runs.

### Fix

- Remove the seed label; `FillLineLengthPanel` writes the "Single line length" text into index 0 itself.
- Harden `SetLabel` to normalize `FontWeight`/`FontSize`/`Padding`/`Margin` on reused blocks, each behind an equality guard so the keystroke path still writes nothing when the block is already ours.

The first change fixes the bug; the second means any future foreign or differently-styled control dropped into either panel gets restyled instead of leaking its look.

### Testing

Builds clean. This is UI-tree behavior with no unit-test seam in the current test project, so it needs the manual repro from the issue: open a subtitle + original subtitle, switch layout, switch back, confirm both "Line length:" labels keep regular weight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
