### PR TITLE
Add Apple VideoToolbox encoders to burn-in, filter encoder list by OS

### DIFF
--- a/docs/features/burn-in.md
+++ b/docs/features/burn-in.md
@@ -61,6 +61,9 @@ differ between Windows/Linux and macOS.
 NVENC takes its own preset list (`p1`–`p7`, `hq`, `ll`, …) instead of the x264 presets. AMF has
 no preset. Quality is left blank by default, which lets FFmpeg pick a bitrate.
 
+All HEVC output is tagged `hvc1` so it plays in QuickTime and other Apple players, which reject
+the `hev1` tag FFmpeg writes by default.
+
 ### macOS (Apple VideoToolbox)
 
 | Encoder | Hardware | Quality setting |
@@ -76,7 +79,6 @@ Notes:
 - The **Quality** setting requires Apple silicon. On Intel Macs FFmpeg reports
   *"qscale not available for encoder"*; leave Quality blank there and use two-pass/bitrate
   instead. Quality is blank by default, so encoding works out of the box on both.
-- `hevc_videotoolbox` output is tagged `hvc1` so QuickTime and other Apple players accept it.
 - `prores_videotoolbox` uses the same profiles as `prores_ks` (proxy, lt, standard, hq, 4444,
   4444xq) and is far faster than the CPU ProRes encoder.
 - Two-pass encoding is not supported by VideoToolbox.

--- a/docs/features/burn-in.md
+++ b/docs/features/burn-in.md
@@ -40,6 +40,51 @@ Hardcode (burn-in) subtitles permanently into a video file using FFmpeg.
 - **Preset** — Encoding speed/quality preset
 - **CRF** — Constant Rate Factor (quality level)
 
+## Hardware Acceleration
+
+Besides the CPU encoders (`libx264`, `libx265`, `libvpx-vp9`, `prores_ks`), the encoding list
+offers the GPU encoders available on your platform. GPU encoding is much faster than CPU
+encoding, at somewhat lower quality per bit — for the same visual quality a GPU encoder
+produces a larger file.
+
+Only encoders that can actually run on the current operating system are listed, so the choices
+differ between Windows/Linux and macOS.
+
+### Windows and Linux
+
+| Encoder | Hardware | Quality setting |
+|---------|----------|-----------------|
+| `h264_nvenc` / `hevc_nvenc` | NVIDIA GPU | **CQ** 0–51 (lower is better) |
+| `h264_amf` / `hevc_amf` | AMD GPU | **Quality** 0–10 (lower is better) |
+| `h264_qsv` / `hevc_qsv` | Intel Quick Sync | **CRF** (lower is better) |
+
+NVENC takes its own preset list (`p1`–`p7`, `hq`, `ll`, …) instead of the x264 presets. AMF has
+no preset. Quality is left blank by default, which lets FFmpeg pick a bitrate.
+
+### macOS (Apple VideoToolbox)
+
+| Encoder | Hardware | Quality setting |
+|---------|----------|-----------------|
+| `h264_videotoolbox` | Apple silicon / Intel Mac media engine | **Quality** 1–100 (higher is better) |
+| `hevc_videotoolbox` | Apple silicon / Intel Mac media engine | **Quality** 1–100 (higher is better) |
+| `prores_videotoolbox` | Apple silicon media engine | Profile only |
+
+Notes:
+
+- VideoToolbox has no preset — the **Preset** list is empty for these encoders.
+- Quality runs the opposite way from CRF: **higher is better**, and it replaces CRF entirely.
+- The **Quality** setting requires Apple silicon. On Intel Macs FFmpeg reports
+  *"qscale not available for encoder"*; leave Quality blank there and use two-pass/bitrate
+  instead. Quality is blank by default, so encoding works out of the box on both.
+- `hevc_videotoolbox` output is tagged `hvc1` so QuickTime and other Apple players accept it.
+- `prores_videotoolbox` uses the same profiles as `prores_ks` (proxy, lt, standard, hq, 4444,
+  4444xq) and is far faster than the CPU ProRes encoder.
+- Two-pass encoding is not supported by VideoToolbox.
+
+Hardware encoders depend on the FFmpeg build in use. If an encoder fails immediately, run
+`ffmpeg -encoders` and check that it is listed; on macOS the Homebrew and official FFmpeg
+builds all include VideoToolbox.
+
 ## Audio Settings
 
 - **Encoding** — Audio codec

--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -1701,7 +1701,12 @@ public partial class BurnInViewModel : ObservableObject
         {
             items = new List<string> { string.Empty };
         }
-        else if (videoCodec == "prores_ks")
+        else if (videoCodec is "h264_videotoolbox" or "hevc_videotoolbox")
+        {
+            // VideoToolbox has no "preset" option at all - passing one only makes ffmpeg warn.
+            items = new List<string> { string.Empty };
+        }
+        else if (videoCodec is "prores_ks" or "prores_videotoolbox")
         {
             items = new List<string>
             {
@@ -1813,6 +1818,23 @@ public partial class BurnInViewModel : ObservableObject
             VideoCrf.AddRange(items);
             SelectedVideoCrf = null;
         }
+        else if (videoCodec is "h264_videotoolbox" or "hevc_videotoolbox")
+        {
+            // VideoToolbox knows no CRF; quality is "-q:v 1-100" and runs the other way round
+            // (higher is better). It also requires Apple silicon - on Intel Macs ffmpeg errors
+            // out with "qscale not available for encoder", so leave it unset by default and let
+            // ffmpeg pick a bitrate.
+            for (var i = 1; i <= 100; i++)
+            {
+                items.Add(i.ToString(CultureInfo.InvariantCulture));
+            }
+
+            VideoCrfText = "Quality";
+            VideoCrfHint = "1=lowest quality, 100=best quality (Apple silicon only)";
+            VideoCrf.Clear();
+            VideoCrf.AddRange(items);
+            SelectedVideoCrf = null;
+        }
         else if (videoCodec.Contains("av1"))
         {
             for (var i = 0; i <= 63; i++)
@@ -1823,7 +1845,7 @@ public partial class BurnInViewModel : ObservableObject
             VideoCrf.AddRange(items);
             SelectedVideoCrf = "30";
         }
-        else if (videoCodec == "prores_ks")
+        else if (videoCodec is "prores_ks" or "prores_videotoolbox")
         {
             items = new List<string>();
             VideoCrf.Clear();

--- a/src/ui/Features/Video/BurnIn/VideoEncodingItem.cs
+++ b/src/ui/Features/Video/BurnIn/VideoEncodingItem.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Nikse.SubtitleEdit.Core.Common;
+using System.Collections.Generic;
 
 namespace Nikse.SubtitleEdit.Features.Video.BurnIn;
 
@@ -18,22 +19,42 @@ public class VideoEncodingItem
         return $"{Codec}: {Name}";
     }
 
-    public static List<VideoEncodingItem> VideoEncodings = new()
+    public static readonly List<VideoEncodingItem> VideoEncodings = BuildVideoEncodings();
+
+    // Hardware encoders are platform-bound: NVENC/AMF/QSV need Windows or Linux drivers, and
+    // VideoToolbox only exists on macOS. Offering all of them on every platform just gives the
+    // user choices that fail at encode time (#13382), so list only what can actually run here.
+    private static List<VideoEncodingItem> BuildVideoEncodings()
     {
-        new VideoEncodingItem("libx264", "H.264/AVC (CPU)"),
-        new VideoEncodingItem("libx265", "H.265/HEVC (CPU)"),
-        new VideoEncodingItem("libvpx-vp9", "VP9 (CPU)"),
-        new VideoEncodingItem("h264_nvenc", "H.264/AVC (NVIDIA GPU)"),
-        new VideoEncodingItem("hevc_nvenc", "H.265/HEVC (NVIDIA GPU)"),
-        new VideoEncodingItem("h264_amf", "H.264/AVC (AMD GPU)"),
-        new VideoEncodingItem("hevc_amf", "H.265/HEVC (AMD GPU)"),
-        new VideoEncodingItem("prores_ks", "ProRes (CPU)"),
-        new VideoEncodingItem("h264_qsv", "H.264/AVC (Intel QSV)"),
-        new VideoEncodingItem("hevc_qsv", "H.265/HEVC (Intel QSV)"),
-        //new VideoEncodingItem("libaom-av1", "AOM AV1 Encoder"),
-        //new VideoEncodingItem("libsvtav1", "SVT-AV1 Encoder"),
-        //new VideoEncodingItem("av1_nvenc", "NVIDIA AV1 Encoder"),
-        //new VideoEncodingItem("av1_qsv", "Intel QSV AV1 Encoder"),
-        //new VideoEncodingItem("av1_amf", "AMD AV1 Encoder (AMF)"),
-    };
+        var items = new List<VideoEncodingItem>
+        {
+            new VideoEncodingItem("libx264", "H.264/AVC (CPU)"),
+            new VideoEncodingItem("libx265", "H.265/HEVC (CPU)"),
+            new VideoEncodingItem("libvpx-vp9", "VP9 (CPU)"),
+            new VideoEncodingItem("prores_ks", "ProRes (CPU)"),
+            //new VideoEncodingItem("libaom-av1", "AOM AV1 Encoder"),
+            //new VideoEncodingItem("libsvtav1", "SVT-AV1 Encoder"),
+        };
+
+        if (Configuration.IsRunningOnMac)
+        {
+            items.Add(new VideoEncodingItem("h264_videotoolbox", "H.264/AVC (Apple VideoToolbox)"));
+            items.Add(new VideoEncodingItem("hevc_videotoolbox", "H.265/HEVC (Apple VideoToolbox)"));
+            items.Add(new VideoEncodingItem("prores_videotoolbox", "ProRes (Apple VideoToolbox)"));
+        }
+        else
+        {
+            items.Add(new VideoEncodingItem("h264_nvenc", "H.264/AVC (NVIDIA GPU)"));
+            items.Add(new VideoEncodingItem("hevc_nvenc", "H.265/HEVC (NVIDIA GPU)"));
+            items.Add(new VideoEncodingItem("h264_amf", "H.264/AVC (AMD GPU)"));
+            items.Add(new VideoEncodingItem("hevc_amf", "H.265/HEVC (AMD GPU)"));
+            items.Add(new VideoEncodingItem("h264_qsv", "H.264/AVC (Intel QSV)"));
+            items.Add(new VideoEncodingItem("hevc_qsv", "H.265/HEVC (Intel QSV)"));
+            //items.Add(new VideoEncodingItem("av1_nvenc", "NVIDIA AV1 Encoder"));
+            //items.Add(new VideoEncodingItem("av1_qsv", "Intel QSV AV1 Encoder"));
+            //items.Add(new VideoEncodingItem("av1_amf", "AMD AV1 Encoder (AMF)"));
+        }
+
+        return items;
+    }
 }

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -85,8 +85,11 @@ public class FfmpegGenerator
         if (!string.IsNullOrWhiteSpace(videoEncoding))
         {
             videoEncodingSettings = $"-c:v {videoEncoding}";
-            if (videoEncoding == "libx265")
+            if (videoEncoding is "libx265" or "hevc_videotoolbox")
             {
+                // Without the hvc1 tag the mov/mp4 muxer writes hev1, which QuickTime and the
+                // rest of the Apple stack refuse to play - the very platform hevc_videotoolbox
+                // targets.
                 videoEncodingSettings += " -tag:v hvc1";
             }
         }
@@ -111,7 +114,7 @@ public class FfmpegGenerator
         var presetSettings = string.Empty;
         if (!string.IsNullOrWhiteSpace(preset))
         {
-            if (videoEncoding == "prores_ks")
+            if (videoEncoding is "prores_ks" or "prores_videotoolbox")
             {
                 if (preset == "proxy")
                 {
@@ -147,6 +150,10 @@ public class FfmpegGenerator
                     presetSettings = $" -profile:v {preset}";
                 }
             }
+            else if (videoEncoding is "h264_videotoolbox" or "hevc_videotoolbox")
+            {
+                // VideoToolbox has no preset option - emitting one only produces an ffmpeg warning.
+            }
             else
             {
                 presetSettings = $" -preset {preset}";
@@ -163,6 +170,11 @@ public class FfmpegGenerator
             else if (videoEncoding == "h264_amf" || videoEncoding == "hevc_amf")
             {
                 crfSettings = $" -quality {crf}";
+            }
+            else if (videoEncoding is "h264_videotoolbox" or "hevc_videotoolbox")
+            {
+                // Constant quality is "-q:v 1-100" (higher is better), not CRF.
+                crfSettings = $" -q:v {crf}";
             }
             else
             {

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -85,11 +85,11 @@ public class FfmpegGenerator
         if (!string.IsNullOrWhiteSpace(videoEncoding))
         {
             videoEncodingSettings = $"-c:v {videoEncoding}";
-            if (videoEncoding is "libx265" or "hevc_videotoolbox")
+            if (videoEncoding == "libx265" || videoEncoding.StartsWith("hevc_", StringComparison.Ordinal))
             {
-                // Without the hvc1 tag the mov/mp4 muxer writes hev1, which QuickTime and the
-                // rest of the Apple stack refuse to play - the very platform hevc_videotoolbox
-                // targets.
+                // Without the hvc1 tag the mov/mp4 muxer writes hev1, which QuickTime and the rest
+                // of the Apple stack refuse to play. This used to be applied to libx265 only, so
+                // the hardware HEVC encoders produced .mp4 files that would not open there.
                 videoEncodingSettings += " -tag:v hvc1";
             }
         }

--- a/tests/UI/Logic/FfmpegVideoToolboxTests.cs
+++ b/tests/UI/Logic/FfmpegVideoToolboxTests.cs
@@ -1,0 +1,83 @@
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace UITests.Logic;
+
+// VideoToolbox (issue #13382) takes a different set of flags than the x264/NVENC/AMF encoders:
+// no -preset, and constant quality is "-q:v 1-100" rather than "-crf". Emitting the wrong flag
+// is not a hard error - ffmpeg just warns and silently ignores it - so lock the mapping down.
+public class FfmpegVideoToolboxTests
+{
+    private static string Generate(string videoEncoding, string preset, string crf)
+    {
+        return FfmpegGenerator.GenerateHardcodedVideoFile(
+            "in.mp4",
+            "sub.ass",
+            "out.mp4",
+            1920,
+            1080,
+            videoEncoding,
+            preset,
+            "yuv420p",
+            crf,
+            "aac",
+            false,
+            "48000",
+            string.Empty,
+            "128k",
+            string.Empty,
+            string.Empty);
+    }
+
+    [Theory]
+    [InlineData("h264_videotoolbox")]
+    [InlineData("hevc_videotoolbox")]
+    public void VideoToolbox_UsesQualityInsteadOfCrf(string videoEncoding)
+    {
+        var args = Generate(videoEncoding, string.Empty, "70");
+
+        Assert.Contains($"-c:v {videoEncoding}", args);
+        Assert.Contains("-q:v 70", args);
+        Assert.DoesNotContain("-crf", args);
+    }
+
+    [Theory]
+    [InlineData("h264_videotoolbox")]
+    [InlineData("hevc_videotoolbox")]
+    public void VideoToolbox_NeverEmitsPreset(string videoEncoding)
+    {
+        // A preset can survive in the saved settings from a previously selected encoder.
+        var args = Generate(videoEncoding, "medium", string.Empty);
+
+        Assert.DoesNotContain("-preset", args);
+    }
+
+    // QuickTime and the rest of the Apple stack reject the hev1 tag the mov muxer writes by
+    // default - which would make the macOS encoder unusable on macOS.
+    [Fact]
+    public void HevcVideoToolbox_IsTaggedHvc1()
+    {
+        Assert.Contains("-tag:v hvc1", Generate("hevc_videotoolbox", string.Empty, string.Empty));
+    }
+
+    [Fact]
+    public void H264VideoToolbox_IsNotTaggedHvc1()
+    {
+        Assert.DoesNotContain("-tag:v hvc1", Generate("h264_videotoolbox", string.Empty, string.Empty));
+    }
+
+    // prores_videotoolbox takes the same named profiles as prores_ks, mapped to their indexes.
+    [Theory]
+    [InlineData("proxy", "0")]
+    [InlineData("lt", "1")]
+    [InlineData("standard", "2")]
+    [InlineData("hq", "3")]
+    [InlineData("4444", "4")]
+    [InlineData("4444xq", "5")]
+    public void ProResVideoToolbox_MapsProfileNameToIndex(string preset, string expectedProfile)
+    {
+        var args = Generate("prores_videotoolbox", preset, string.Empty);
+
+        Assert.Contains($"-profile:v {expectedProfile}", args);
+        Assert.DoesNotContain("-preset", args);
+    }
+}

--- a/tests/UI/Logic/FfmpegVideoToolboxTests.cs
+++ b/tests/UI/Logic/FfmpegVideoToolboxTests.cs
@@ -5,6 +5,7 @@ namespace UITests.Logic;
 // VideoToolbox (issue #13382) takes a different set of flags than the x264/NVENC/AMF encoders:
 // no -preset, and constant quality is "-q:v 1-100" rather than "-crf". Emitting the wrong flag
 // is not a hard error - ffmpeg just warns and silently ignores it - so lock the mapping down.
+// Also covers the hvc1 tag, which every HEVC encoder needs for Apple playback.
 public class FfmpegVideoToolboxTests
 {
     private static string Generate(string videoEncoding, string preset, string crf)
@@ -52,17 +53,27 @@ public class FfmpegVideoToolboxTests
     }
 
     // QuickTime and the rest of the Apple stack reject the hev1 tag the mov muxer writes by
-    // default - which would make the macOS encoder unusable on macOS.
-    [Fact]
-    public void HevcVideoToolbox_IsTaggedHvc1()
+    // default, so every HEVC encoder needs the tag - not just libx265, which was the only one
+    // getting it before.
+    [Theory]
+    [InlineData("libx265")]
+    [InlineData("hevc_videotoolbox")]
+    [InlineData("hevc_nvenc")]
+    [InlineData("hevc_amf")]
+    [InlineData("hevc_qsv")]
+    public void HevcEncoders_AreTaggedHvc1(string videoEncoding)
     {
-        Assert.Contains("-tag:v hvc1", Generate("hevc_videotoolbox", string.Empty, string.Empty));
+        Assert.Contains("-tag:v hvc1", Generate(videoEncoding, string.Empty, string.Empty));
     }
 
-    [Fact]
-    public void H264VideoToolbox_IsNotTaggedHvc1()
+    [Theory]
+    [InlineData("libx264")]
+    [InlineData("h264_videotoolbox")]
+    [InlineData("h264_nvenc")]
+    [InlineData("prores_videotoolbox")]
+    public void NonHevcEncoders_AreNotTaggedHvc1(string videoEncoding)
     {
-        Assert.DoesNotContain("-tag:v hvc1", Generate("h264_videotoolbox", string.Empty, string.Empty));
+        Assert.DoesNotContain("-tag:v hvc1", Generate(videoEncoding, string.Empty, string.Empty));
     }
 
     // prores_videotoolbox takes the same named profiles as prores_ks, mapped to their indexes.


### PR DESCRIPTION
Fixes #13382.

Burn-in only offered CPU encoders on macOS — NVENC, AMF and QSV can't run there, so Mac users had no GPU option at all.

## Changes

**Three new encoders** (the complete set FFmpeg exposes — there is no `av1_videotoolbox`, Apple silicon does AV1 decode only):

| Codec | Name in UI |
|---|---|
| `h264_videotoolbox` | H.264/AVC (Apple VideoToolbox) |
| `hevc_videotoolbox` | H.265/HEVC (Apple VideoToolbox) |
| `prores_videotoolbox` | ProRes (Apple VideoToolbox) |

**The encoder list is now filtered by OS.** macOS gets CPU + VideoToolbox; Windows/Linux get CPU + NVENC/AMF/QSV. Previously every platform saw all three GPU vendors, most of which fail at encode time.

**VideoToolbox needs different flags than the existing encoders** — and getting these wrong is not a hard error, ffmpeg just warns and silently ignores the flag, so the setting would appear to work while doing nothing:

- **No `-preset`.** VideoToolbox has no preset option at all, so the preset list is empty and no `-preset` is emitted.
- **`-q:v 1-100` instead of `-crf`**, and it runs the opposite way — higher is better. It is also Apple-silicon only (ffmpeg errors with *"qscale not available for encoder"* on Intel Macs), so quality is left unset by default and ffmpeg picks a bitrate — works out of the box on both.
- **`prores_videotoolbox`** reuses the existing `prores_ks` profile mapping (proxy/lt/standard/hq/4444/4444xq → 0–5, same values for both encoders).

**All HEVC output is now tagged `hvc1`** (second commit). The mov/mp4 muxer writes `hev1` by default, which QuickTime and other Apple players reject. Only `libx265` was tagged before, so `hevc_nvenc`, `hevc_amf` and `hevc_qsv` were producing .mp4 files that wouldn't open there — a pre-existing bug this change also fixes.

## Tests

New `tests/UI/Logic/FfmpegVideoToolboxTests.cs` locks down the argument mapping and the hvc1 tagging across every encoder (19 tests, passing).

## Docs

`docs/features/burn-in.md` gains a **Hardware Acceleration** section covering the per-platform encoders — NVIDIA/AMD/Intel on Windows and Linux, Apple VideoToolbox on macOS — with each one's quality-setting scale and direction, since they all differ.

## Not verified on hardware

I don't have a Mac to run this on, so the VideoToolbox command lines are verified by unit test and against the AVOption tables in `libavcodec/videotoolboxenc.c`, not by an actual encode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
