### PR TITLE
Fix #13389: don't report a trailing empty line as a remove-text-for-HI change

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -22852,6 +22852,7 @@ public partial class MainViewModel :
     private void SubtitleGridSelectionChanged(List<SubtitleLineViewModel>? alreadyOrderedSelection = null)
     {
         var selectedItems = alreadyOrderedSelection ?? SubtitleGridSelectedItems;
+        var outgoing = SelectedSubtitle;
         EditTextBox.ClearSelection();
         EditTextBoxOriginal.ClearSelection();
         ResetPlaySelection();
@@ -22862,6 +22863,7 @@ public partial class MainViewModel :
             SelectedSubtitle = null;
             SelectedSubtitleIndex = null;
             _selectedSubtitles = null;
+            outgoing?.TrimTrailingTextWhitespace();
             StatusTextRight = string.Empty;
             EditTextCharactersPerSecond = string.Empty;
             EditTextCharactersPerSecondBackground = Brushes.Transparent;
@@ -22911,6 +22913,7 @@ public partial class MainViewModel :
             SelectedSubtitle = null;
             SelectedSubtitleIndex = null;
             StatusTextRight = string.Empty;
+            outgoing?.TrimTrailingTextWhitespace();
             return;
         }
 
@@ -22932,6 +22935,14 @@ public partial class MainViewModel :
         finally
         {
             _subtitleGridSelectionChangedSkip = false;
+        }
+
+        // The row that lost selection is committed: drop any trailing empty line the user
+        // typed (#13389). Runs after SelectedSubtitle is reassigned, so the edit text box is
+        // already bound to the new row and the trim cannot eat a newline mid-edit.
+        if (rowChanged)
+        {
+            outgoing?.TrimTrailingTextWhitespace();
         }
 
         // Same caret reset as SelectAndScrollToRow (#12707): Avalonia keeps the caret index when

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -188,7 +188,10 @@ public partial class SubtitleLineViewModel : ObservableObject
             Number = Number,
             StartTime = new TimeCode(StartTime),
             EndTime = new TimeCode(EndTime),
-            Text = Text,
+            // TrimEnd: the edit text box is bound raw, so a trailing Enter lives in Text
+            // until the row loses selection - it must never reach saved files or tools
+            // (SE4 kept the same invariant by trimming in the TextChanged handler) - #13389.
+            Text = Text.TrimEnd(),
             Actor = Actor,
             Style = Style,
             Language = Language,
@@ -219,7 +222,7 @@ public partial class SubtitleLineViewModel : ObservableObject
             Number = Number,
             StartTime = new TimeCode(StartTime),
             EndTime = new TimeCode(EndTime),
-            Text = OriginalText,
+            Text = OriginalText.TrimEnd(),
             Actor = Actor,
             Style = Style,
             Language = Language,
@@ -869,6 +872,29 @@ public partial class SubtitleLineViewModel : ObservableObject
     public void RefreshText()
     {
         OnPropertyChanged(nameof(Text));
+    }
+
+    /// <summary>
+    /// Removes trailing whitespace - typically an empty line left by pressing Enter at the
+    /// end of the text - from <see cref="Text"/> and <see cref="OriginalText"/>. Called when
+    /// the row loses selection, so the line count/CPS shown in the grid match what
+    /// <see cref="ToParagraph"/> commits (#13389). Not safe to run while the row is still
+    /// bound to the edit text box: the TwoWay binding would push the trimmed value back and
+    /// delete a newline the user just typed.
+    /// </summary>
+    public void TrimTrailingTextWhitespace()
+    {
+        var trimmed = Text.TrimEnd();
+        if (trimmed.Length != Text.Length)
+        {
+            Text = trimmed;
+        }
+
+        var trimmedOriginal = OriginalText.TrimEnd();
+        if (trimmedOriginal.Length != OriginalText.Length)
+        {
+            OriginalText = trimmedOriginal;
+        }
     }
 
     /// <summary>

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModel.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModel.cs
@@ -284,7 +284,10 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
             var p = _subtitle.Paragraphs[index];
             _removeTextForHiLib.WarningIndex = index - 1;
             var newText = _removeTextForHiLib.RemoveTextFromHearImpaired(p.Text, _subtitle, index, twoLetterIsoLanguageName);
-            if (p.Text.RemoveChar(' ') != newText.RemoveChar(' '))
+            // Trim before comparing: RemoveTextFromHearImpaired rebuilds the text and drops
+            // e.g. a trailing empty line, which would otherwise list a "fix" whose before and
+            // after render identically (#13389).
+            if (p.Text.Trim().RemoveChar(' ') != newText.Trim().RemoveChar(' '))
             {
                 var apply = true;
                 var oldItem = Fixes.FirstOrDefault(f => f.Index == index);

--- a/tests/UI/Features/Main/SubtitleLineViewModelTrailingWhitespaceTests.cs
+++ b/tests/UI/Features/Main/SubtitleLineViewModelTrailingWhitespaceTests.cs
@@ -1,0 +1,74 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Main;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// The edit text box is bound raw to <see cref="SubtitleLineViewModel.Text"/>, so pressing
+/// Enter at the end of a subtitle leaves a trailing empty line in the row (#13389). SE4
+/// trimmed in the TextChanged handler; SE5 restores the invariant at the commit points
+/// instead: ToParagraph/ToParagraphOriginal (saving, every tool dialog) and
+/// TrimTrailingTextWhitespace (row losing selection).
+/// </summary>
+public class SubtitleLineViewModelTrailingWhitespaceTests
+{
+    private static SubtitleLineViewModel MakeLine(string text)
+    {
+        return new SubtitleLineViewModel(new Paragraph(text, 0, 1000), new SubRip());
+    }
+
+    [Fact]
+    public void ToParagraph_TrimsTrailingWhitespace()
+    {
+        var line = MakeLine("Hello there." + Environment.NewLine);
+
+        var p = line.ToParagraph();
+
+        Assert.Equal("Hello there.", p.Text);
+        // The row itself is untouched - the text box may still be editing it.
+        Assert.Equal("Hello there." + Environment.NewLine, line.Text);
+    }
+
+    [Fact]
+    public void ToParagraph_KeepsInteriorEmptyLine()
+    {
+        var text = "One." + Environment.NewLine + Environment.NewLine + "Two.";
+        var line = MakeLine(text);
+
+        Assert.Equal(text, line.ToParagraph().Text);
+    }
+
+    [Fact]
+    public void ToParagraphOriginal_TrimsTrailingWhitespace()
+    {
+        var line = MakeLine("Hello there.");
+        line.OriginalText = "Original text." + Environment.NewLine;
+
+        Assert.Equal("Original text.", line.ToParagraphOriginal().Text);
+    }
+
+    [Fact]
+    public void TrimTrailingTextWhitespace_TrimsBothTextFields()
+    {
+        var line = MakeLine("Hello there." + Environment.NewLine);
+        line.OriginalText = "Original text. ";
+
+        line.TrimTrailingTextWhitespace();
+
+        Assert.Equal("Hello there.", line.Text);
+        Assert.Equal("Original text.", line.OriginalText);
+    }
+
+    [Fact]
+    public void TrimTrailingTextWhitespace_LeavesCleanTextAlone()
+    {
+        var line = MakeLine("Hello there.");
+        line.OriginalText = "Original text.";
+
+        line.TrimTrailingTextWhitespace();
+
+        Assert.Equal("Hello there.", line.Text);
+        Assert.Equal("Original text.", line.OriginalText);
+    }
+}

--- a/tests/UI/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModelTests.cs
+++ b/tests/UI/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModelTests.cs
@@ -46,4 +46,38 @@ public class RemoveTextForHearingImpairedViewModelTests
         Assert.Single(applied!.Paragraphs); // the emptied line was dropped
         Assert.Equal("Hello there", applied.Paragraphs[0].Text);
     }
+
+    [AvaloniaFact]
+    public void Preview_IgnoresTrailingEmptyLine_WhenNoHiRuleApplies()
+    {
+        var vm = Resolve();
+        var sub = new Subtitle();
+        // A trailing Enter in the edit text box leaves a trailing empty line; the lib rebuilds
+        // the text without it, which must not be reported as a change (#13389).
+        sub.Paragraphs.Add(new Paragraph("Hello there." + Environment.NewLine, 0, 1000));
+
+        vm.Initialize(sub, _ => { });
+        vm.IsRemoveBracketsOn = true;
+
+        // Apply regenerates the preview synchronously (same path the timer takes).
+        vm.ApplyCommand.Execute(null);
+
+        Assert.Empty(vm.Fixes);
+    }
+
+    [AvaloniaFact]
+    public void Preview_StillReportsRealFix_WhenTextHasTrailingEmptyLine()
+    {
+        var vm = Resolve();
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("[door slams]" + Environment.NewLine + "Hello there." + Environment.NewLine, 0, 1000));
+
+        vm.Initialize(sub, _ => { });
+        vm.IsRemoveBracketsOn = true;
+
+        vm.ApplyCommand.Execute(null);
+
+        Assert.Single(vm.Fixes);
+        Assert.Equal("Hello there.", vm.Fixes[0].After);
+    }
 }


### PR DESCRIPTION
Fixes #13389.

## Root cause

Two SE4→SE5 behavior differences stacked:

1. **SE5 keeps a trailing empty line in the model.** The edit text box is a raw TwoWay binding to `SubtitleLineViewModel.Text`, so pressing Enter at the end of a subtitle stores the trailing newline. SE4 never let it reach the model — its TextChanged handler committed `p.Text = textBox.Text.TrimEnd()` (Main.cs:11466 at 4.0.16). In SE5 the newline also reached saved files (an extra blank line inside an SRT cue, which silently disappears on reload).
2. **The HI "changed" check ignores spaces but not newlines.** `RemoveTextFromHearImpaired` rebuilds the text and drops the trailing empty line, so the comparison flagged a "fix" whose Before/After render identically. (The comparison itself is identical to SE4's — SE4 reported 0 purely because of point 1.)

## Fix

Restore the SE4 invariant at the commit points instead of fighting the TwoWay binding (trimming in the property setter would push the trimmed value back into the text box and delete a newline the user just typed mid-edit):

- `ToParagraph`/`ToParagraphOriginal` now `TrimEnd()` the text, so saving and every dialog that goes through `GetUpdateSubtitle` see the committed text.
- When a row loses selection in the grid, its `Text`/`OriginalText` are trimmed, so the grid line count/CPS match what gets committed (mirrors SE4, where re-selecting a row showed the trimmed text). This runs after `SelectedSubtitle` is reassigned, so the trim can't touch the text box mid-edit; the undo change-detection timer coalesces it like any edit.
- Defense in depth: the HI preview comparison now ignores whitespace-only differences, covering subtitles whose source (e.g. pretty-printed XML formats) carries trailing whitespace SE never edited.

Interior empty lines are untouched — only trailing whitespace is trimmed.

## Tests

- New `SubtitleLineViewModelTrailingWhitespaceTests` (ToParagraph/ToParagraphOriginal trim, interior empty line kept, row-commit helper).
- Two new `RemoveTextForHearingImpairedViewModelTests`: a trailing empty line with no HI content reports no fixes; a real HI fix is still reported when the text has a trailing empty line.
- Full UI suite: 1756 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)