### PR TITLE
Fix #13388: update-check settings and a passive startup update notification

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -265,6 +265,7 @@ public static class DependencyInjectionExtensions
         collection.AddHttpClient<ITesseractDownloadService, TesseractDownloadService>();
         collection.AddHttpClient<IWhisperDownloadService, WhisperDownloadService>();
         collection.AddHttpClient<IYtDlpDownloadService, YtDlpDownloadService>();
+        collection.AddHttpClient<IUpdateCheckService, UpdateCheckService>();
         collection.AddHttpClient<ILlamaCppDownloadService, LlamaCppDownloadService>();
         collection.AddHttpClient<IQwen3AsrCppDownloadService, Qwen3AsrCppDownloadService>();
         collection.AddHttpClient<IQwen3TtsCppDownloadService, Qwen3TtsCppDownloadService>();
@@ -353,7 +354,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<ConvertActorsViewModel>();
         collection.AddTransient<ChangeFrameRateViewModel>();
         collection.AddTransient<ChangeSpeedViewModel>();
-        collection.AddHttpClient<CheckForUpdatesViewModel>();
+        collection.AddTransient<CheckForUpdatesViewModel>();
         collection.AddTransient<ColorPickerViewModel>();
         collection.AddTransient<ColumnPasteViewModel>();
         collection.AddTransient<CompareViewModel>();

--- a/src/ui/Features/Help/CheckForUpdates/CheckForUpdatesViewModel.cs
+++ b/src/ui/Features/Help/CheckForUpdates/CheckForUpdatesViewModel.cs
@@ -4,27 +4,19 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
-using System;
-using System.Net.Http;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Help.CheckForUpdates;
 
 public partial class CheckForUpdatesViewModel : ObservableObject
 {
-    private const string ChangeLogUrl1 = "https://raw.githubusercontent.com/SubtitleEdit/subtitleedit/refs/heads/main/change-log.txt";
-    private const string ChangeLogUrl2 = "https://raw.githubusercontent.com/SubtitleEdit/subtitleedit/refs/heads/main/Changelog.txt";
-    private const string ChangeLogUrl3 = "https://raw.githubusercontent.com/SubtitleEdit/subtitleedit/refs/heads/main/ChangeLog.txt";
     private const string ReleasesUrl = "https://github.com/SubtitleEdit/subtitleedit/releases";
-    private static readonly Regex UnreleasedChangeLogRegex = new(@"(x(th|st) \w+ \d+|TBD)", RegexOptions.Compiled);
 
-    private readonly HttpClient _httpClient;
+    private readonly IUpdateCheckService _updateCheckService;
 
-    public CheckForUpdatesViewModel(HttpClient httpClient)
+    public CheckForUpdatesViewModel(IUpdateCheckService updateCheckService)
     {
-        _httpClient = httpClient;
-        _httpClient.Timeout = TimeSpan.FromSeconds(15);
+        _updateCheckService = updateCheckService;
     }
 
     public Window? Window { get; set; }
@@ -42,35 +34,18 @@ public partial class CheckForUpdatesViewModel : ObservableObject
 
         try
         {
-            string content;
-            try
-            {
-                content = await _httpClient.GetStringAsync(ChangeLogUrl1);
-            }
-            catch
-            {
-                try
-                {
-                    content = await _httpClient.GetStringAsync(ChangeLogUrl2);
-                }
-                catch
-                {
-                    content = await _httpClient.GetStringAsync(ChangeLogUrl3);
-                }
-            }
+            var result = await _updateCheckService.CheckForUpdates();
+            ChangeLogText = result.ChangeLogText;
 
-            ChangeLogText = ParseLatestChangeLog(content);
-            var latestVersion = ParseLatestVersion(ChangeLogText);
-
-            if (string.IsNullOrEmpty(latestVersion))
+            if (string.IsNullOrEmpty(result.LatestVersion))
             {
                 StatusText = Se.Language.Help.CheckForUpdatesUnableToCheck;
                 return;
             }
 
-            if (IsNewerThanCurrent(latestVersion))
+            if (result.IsNewVersionAvailable)
             {
-                StatusText = string.Format(Se.Language.Help.CheckForUpdatesNewVersionAvailable, latestVersion);
+                StatusText = string.Format(Se.Language.Help.CheckForUpdatesNewVersionAvailable, result.LatestVersion);
                 IsDownloadLinkVisible = true;
             }
             else
@@ -82,44 +57,6 @@ public partial class CheckForUpdatesViewModel : ObservableObject
         {
             StatusText = Se.Language.Help.CheckForUpdatesUnableToCheck;
         }
-    }
-
-    internal static bool IsNewerThanCurrent(string latestVersion)
-    {
-        try
-        {
-            return new SemanticVersion(latestVersion).IsGreaterThan(new SemanticVersion(Se.Version));
-        }
-        catch (ArgumentException)
-        {
-            // unparsable version - only offer the download when it differs from what we run
-            return !string.Equals(latestVersion, Se.Version, StringComparison.OrdinalIgnoreCase);
-        }
-    }
-
-    private static string ParseLatestVersion(string changeLogContent)
-    {
-        var match = Regex.Match(changeLogContent, @"^(v[\d.]+(?:-\w+)?)\s*\(", RegexOptions.Multiline);
-        return match.Success ? match.Groups[1].Value : string.Empty;
-    }
-
-    private static string ParseLatestChangeLog(string changeLogContent)
-    {
-        const string releaseSeparator = "-----------------------------------------------------------------------------------------------------";
-        foreach (var block in changeLogContent.Split(releaseSeparator))
-        {
-            var changeLog = block.Trim();
-            if (changeLog.Length == 0 ||
-                string.IsNullOrEmpty(ParseLatestVersion(changeLog)) || // file title or other block without a version header
-                UnreleasedChangeLogRegex.IsMatch(changeLog)) // unreleased draft entry
-            {
-                continue;
-            }
-
-            return changeLog;
-        }
-
-        return changeLogContent.Trim();
     }
 
     [RelayCommand]

--- a/src/ui/Features/Help/CheckForUpdates/UpdateCheckService.cs
+++ b/src/ui/Features/Help/CheckForUpdates/UpdateCheckService.cs
@@ -1,0 +1,166 @@
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Help.CheckForUpdates;
+
+public interface IUpdateCheckService
+{
+    Task<UpdateCheckResult> CheckForUpdates();
+}
+
+public class UpdateCheckResult
+{
+    public string ChangeLogText { get; set; } = string.Empty;
+    public string LatestVersion { get; set; } = string.Empty;
+    public bool IsNewVersionAvailable { get; set; }
+}
+
+public class UpdateCheckService : IUpdateCheckService
+{
+    public const string ChannelStable = "Stable";
+    public const string ChannelBeta = "Beta";
+
+    private const string ChangeLogUrl1 = "https://raw.githubusercontent.com/SubtitleEdit/subtitleedit/refs/heads/main/change-log.txt";
+    private const string ChangeLogUrl2 = "https://raw.githubusercontent.com/SubtitleEdit/subtitleedit/refs/heads/main/Changelog.txt";
+    private const string ChangeLogUrl3 = "https://raw.githubusercontent.com/SubtitleEdit/subtitleedit/refs/heads/main/ChangeLog.txt";
+    private static readonly Regex UnreleasedChangeLogRegex = new(@"(x(th|st) \w+ \d+|TBD)", RegexOptions.Compiled);
+
+    private readonly HttpClient _httpClient;
+
+    public UpdateCheckService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+        _httpClient.Timeout = TimeSpan.FromSeconds(15);
+    }
+
+    /// <summary>
+    /// Flatpak (and other store-managed) installs get their updates through the store,
+    /// so the startup check and its setting are suppressed there.
+    /// </summary>
+    public static bool IsStoreManagedInstall =>
+        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("FLATPAK_ID"));
+
+    public static bool IncludePrereleases()
+    {
+        return ResolveIncludePrereleases(Se.Settings.General.CheckForUpdatesChannel, Se.Version);
+    }
+
+    public static bool ResolveIncludePrereleases(string channel, string currentVersion)
+    {
+        if (channel == ChannelStable)
+        {
+            return false;
+        }
+
+        if (channel == ChannelBeta)
+        {
+            return true;
+        }
+
+        // Empty = the user never picked a channel: people already running a
+        // beta/rc build get pre-release updates, stable users stable only.
+        return IsPrerelease(currentVersion);
+    }
+
+    public static bool IsPrerelease(string version)
+    {
+        try
+        {
+            return !string.IsNullOrEmpty(new SemanticVersion(version).PreRelease);
+        }
+        catch (ArgumentException)
+        {
+            return version.Contains('-');
+        }
+    }
+
+    public async Task<UpdateCheckResult> CheckForUpdates()
+    {
+        string content;
+        try
+        {
+            content = await _httpClient.GetStringAsync(ChangeLogUrl1);
+        }
+        catch
+        {
+            try
+            {
+                content = await _httpClient.GetStringAsync(ChangeLogUrl2);
+            }
+            catch
+            {
+                content = await _httpClient.GetStringAsync(ChangeLogUrl3);
+            }
+        }
+
+        var includePrereleases = IncludePrereleases();
+        var changeLogText = ParseLatestChangeLog(content, includePrereleases);
+        var latestVersion = ParseLatestVersion(changeLogText);
+
+        return new UpdateCheckResult
+        {
+            ChangeLogText = changeLogText,
+            LatestVersion = latestVersion,
+            IsNewVersionAvailable = !string.IsNullOrEmpty(latestVersion) &&
+                                    IsNewerThanCurrent(latestVersion) &&
+                                    (includePrereleases || !IsPrerelease(latestVersion)),
+        };
+    }
+
+    public static bool IsNewerThanCurrent(string latestVersion)
+    {
+        return IsNewerThan(latestVersion, Se.Version);
+    }
+
+    public static bool IsNewerThan(string latestVersion, string currentVersion)
+    {
+        try
+        {
+            return new SemanticVersion(latestVersion).IsGreaterThan(new SemanticVersion(currentVersion));
+        }
+        catch (ArgumentException)
+        {
+            // unparsable version - only offer the download when it differs from what we run
+            return !string.Equals(latestVersion, currentVersion, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    public static string ParseLatestVersion(string changeLogContent)
+    {
+        var match = Regex.Match(changeLogContent, @"^(v[\d.]+(?:-\w+)?)\s*\(", RegexOptions.Multiline);
+        return match.Success ? match.Groups[1].Value : string.Empty;
+    }
+
+    public static string ParseLatestChangeLog(string changeLogContent, bool includePrereleases)
+    {
+        const string releaseSeparator = "-----------------------------------------------------------------------------------------------------";
+        foreach (var block in changeLogContent.Split(releaseSeparator))
+        {
+            var changeLog = block.Trim();
+            if (changeLog.Length == 0)
+            {
+                continue;
+            }
+
+            var version = ParseLatestVersion(changeLog);
+            if (string.IsNullOrEmpty(version) || // file title or other block without a version header
+                UnreleasedChangeLogRegex.IsMatch(changeLog)) // unreleased draft entry
+            {
+                continue;
+            }
+
+            if (!includePrereleases && IsPrerelease(version))
+            {
+                continue;
+            }
+
+            return changeLog;
+        }
+
+        return changeLogContent.Trim();
+    }
+}

--- a/src/ui/Features/Main/Layout/InitFooter.cs
+++ b/src/ui/Features/Main/Layout/InitFooter.cs
@@ -106,6 +106,37 @@ public static class InitFooter
             VerticalAlignment = VerticalAlignment.Center,
             Children =
             {
+                new Button
+                {
+                    Content = new StackPanel
+                    {
+                        Orientation = Orientation.Horizontal,
+                        Spacing = 4,
+                        VerticalAlignment = VerticalAlignment.Center,
+                        Children =
+                        {
+                            new Icon
+                            {
+                                Value = IconNames.CloudDownload,
+                                FontSize = 18,
+                                VerticalAlignment = VerticalAlignment.Center,
+                            },
+                            UiUtil.MakeLabel().WithBindText(vm, vm => vm.UpdateAvailableText),
+                        },
+                    },
+                    [AutomationProperties.NameProperty] = Se.Language.Help.CheckForUpdates,
+                    [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsUpdateAvailable)),
+                    [!Button.CommandProperty] = new Binding(nameof(vm.ShowCheckForUpdatesCommand)),
+
+                    // Transparent, not null, so the whole button (not just the glyph strokes)
+                    // is hit-testable.
+                    Background = Brushes.Transparent,
+                    BorderBrush = null,
+                    Padding = new Thickness(4, 2, 4, 2),
+                    Margin = new Thickness(0, 0, 15, 0),
+                    VerticalAlignment = VerticalAlignment.Center,
+                },
+
                 new Icon
                 {
                     Value = IconNames.LockClock,

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1,6 +1,7 @@
 using Nikse.SubtitleEdit.UiLogic.Export;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Input;
@@ -227,6 +228,9 @@ public partial class MainViewModel :
 
     [ObservableProperty] private string _statusTextLeft;
     [ObservableProperty] private string _statusTextRight;
+
+    [ObservableProperty] private bool _isUpdateAvailable;
+    [ObservableProperty] private string _updateAvailableText = string.Empty;
 
     [ObservableProperty] private bool _isWaveformToolbarVisible;
     [ObservableProperty] private bool _isSubtitleGridFlyoutHeaderVisible;
@@ -515,6 +519,7 @@ public partial class MainViewModel :
     private readonly IPluginCatalog _pluginCatalog;
     private readonly IPluginRunner _pluginRunner;
     private readonly IYtDlpDownloadService _ytDlpDownloadService;
+    private readonly IUpdateCheckService _updateCheckService;
 
     private bool IsEmpty => Subtitles.Count == 0 || (Subtitles.Count == 1 && string.IsNullOrEmpty(Subtitles[0].Text));
 
@@ -597,7 +602,8 @@ public partial class MainViewModel :
         IPasteFromClipboardHelper pasteFromClipboardHelper,
         IPluginCatalog pluginCatalog,
         IPluginRunner pluginRunner,
-        IYtDlpDownloadService ytDlpDownloadService)
+        IYtDlpDownloadService ytDlpDownloadService,
+        IUpdateCheckService updateCheckService)
     {
         _fileHelper = fileHelper;
         _folderHelper = folderHelper;
@@ -621,6 +627,7 @@ public partial class MainViewModel :
         _pluginCatalog = pluginCatalog;
         _pluginRunner = pluginRunner;
         _ytDlpDownloadService = ytDlpDownloadService;
+        _updateCheckService = updateCheckService;
 
         _loading = true;
         EditText = string.Empty;
@@ -809,6 +816,47 @@ public partial class MainViewModel :
             _dropDownFormatsSearchText = string.Empty;
             _dropDownFormatsSearchTimer.Stop();
         };
+
+        StartCheckForUpdates();
+    }
+
+    private void StartCheckForUpdates()
+    {
+        if (!Se.Settings.General.CheckForUpdatesOnStartup || UpdateCheckService.IsStoreManagedInstall)
+        {
+            return;
+        }
+
+        // Only in the real desktop app - headless unit tests also build this
+        // view model and must not hit the network.
+        if (Application.Current?.ApplicationLifetime is not ClassicDesktopStyleApplicationLifetime)
+        {
+            return;
+        }
+
+        _ = Task.Run(async () =>
+        {
+            // Delayed well past startup so the check never competes with the UI
+            // coming up; a newer version just lights up the status bar indicator.
+            await Task.Delay(TimeSpan.FromSeconds(15));
+
+            try
+            {
+                var result = await _updateCheckService.CheckForUpdates();
+                if (result.IsNewVersionAvailable)
+                {
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        UpdateAvailableText = string.Format(Se.Language.Help.CheckForUpdatesNewVersionAvailable, result.LatestVersion);
+                        IsUpdateAvailable = true;
+                    });
+                }
+            }
+            catch
+            {
+                // Offline or GitHub unreachable - stay silent and try again next start.
+            }
+        });
     }
 
     private void FirstLoad()

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -11,6 +11,7 @@ using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Help.CheckForUpdates;
 using Nikse.SubtitleEdit.Features.Shared.PickLanguage;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -836,6 +837,26 @@ public class SettingsPage : UserControl
                 return textBox;
             }),
         ]));
+
+        var updateItems = new List<SettingsItem>();
+        if (!UpdateCheckService.IsStoreManagedInstall)
+        {
+            // Store-managed installs (Flatpak) update through the store, so the startup check is hidden there.
+            updateItems.Add(MakeCheckboxSetting(Se.Language.Options.Settings.CheckForUpdatesOnStartup, nameof(_vm.CheckForUpdatesOnStartup)));
+        }
+
+        updateItems.Add(new SettingsItem(Se.Language.Options.Settings.CheckForUpdatesChannel, () => new ComboBox
+        {
+            MinWidth = 200,
+            DataContext = _vm,
+            [!ItemsControl.ItemsSourceProperty] = new Binding(nameof(_vm.UpdateChannels)),
+            [!SelectingItemsControl.SelectedItemProperty] = new Binding(nameof(_vm.SelectedUpdateChannel))
+            {
+                Mode = BindingMode.TwoWay,
+            }
+        }));
+
+        sections.Add(new SettingsSection(Se.Language.Options.Settings.Updates, IconNames.CloudDownload, "#d0a24e", updateItems));
 
         if (OperatingSystem.IsWindows())
         {

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -14,6 +14,7 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Assa;
+using Nikse.SubtitleEdit.Features.Help.CheckForUpdates;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Options.DoNotBreakAfterList;
 using Nikse.SubtitleEdit.Features.Options.Settings.SyntaxColorTooWideSettings;
@@ -284,6 +285,10 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private string _proxyDomain = string.Empty;
     [ObservableProperty] private bool _proxyUseDefaultCredentials;
     [ObservableProperty] private string _proxyBypassList = string.Empty;
+    [ObservableProperty] private bool _checkForUpdatesOnStartup;
+    [ObservableProperty] private ObservableCollection<string> _updateChannels;
+    [ObservableProperty] private string _selectedUpdateChannel;
+    private string _loadedUpdateChannel = string.Empty;
     [ObservableProperty] private int _waveformTextFontSize;
     [ObservableProperty] private bool _waveformTextFontBold;
     [ObservableProperty] private Color _waveformTextColor;
@@ -445,6 +450,13 @@ public partial class SettingsViewModel : ObservableObject
         MpvPreviewFontAlignments = new ObservableCollection<AlignmentItem>(AlignmentItem.Alignments);
         MpvPreviewSelectedFontAlignment = MpvPreviewFontAlignments[7];
         LibVlcStatus = string.Empty;
+
+        UpdateChannels =
+        [
+            Se.Language.Options.Settings.CheckForUpdatesChannelStable,
+            Se.Language.Options.Settings.CheckForUpdatesChannelStableAndBeta,
+        ];
+        SelectedUpdateChannel = UpdateChannels[0];
 
         Themes = [Se.Language.General.System, Se.Language.General.Light, Se.Language.General.Dark, Se.Language.General.Classic, "Pastel"];
         SelectedTheme = Themes[0];
@@ -1031,6 +1043,11 @@ public partial class SettingsViewModel : ObservableObject
         ProxyDomain = Se.Settings.General.ProxyDomain ?? string.Empty;
         ProxyUseDefaultCredentials = Se.Settings.General.ProxyUseDefaultCredentials;
         ProxyBypassList = Se.Settings.General.ProxyBypassList ?? string.Empty;
+        CheckForUpdatesOnStartup = Se.Settings.General.CheckForUpdatesOnStartup;
+        SelectedUpdateChannel = UpdateCheckService.IncludePrereleases()
+            ? Se.Language.Options.Settings.CheckForUpdatesChannelStableAndBeta
+            : Se.Language.Options.Settings.CheckForUpdatesChannelStable;
+        _loadedUpdateChannel = SelectedUpdateChannel;
         SetFfmpegStatus();
         SetLibMpvStatus();
         SetLibVlcStatus();
@@ -1837,6 +1854,15 @@ public partial class SettingsViewModel : ObservableObject
         general.ProxyDomain = ProxyDomain;
         general.ProxyUseDefaultCredentials = ProxyUseDefaultCredentials;
         general.ProxyBypassList = ProxyBypassList;
+        general.CheckForUpdatesOnStartup = CheckForUpdatesOnStartup;
+        if (SelectedUpdateChannel != _loadedUpdateChannel)
+        {
+            // Only an actual change is stored, so an untouched dropdown keeps the
+            // "auto" default (beta users follow betas, stable users stable only).
+            general.CheckForUpdatesChannel = SelectedUpdateChannel == Se.Language.Options.Settings.CheckForUpdatesChannelStableAndBeta
+                ? UpdateCheckService.ChannelBeta
+                : UpdateCheckService.ChannelStable;
+        }
 
         general.CurrentProfile = SelectedProfile;
         general.Profiles.Clear();

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -169,6 +169,13 @@ public class LanguageSettings
     public string ProxyBypassList { get; set; }
     public string ProxyBypassListHint { get; set; }
 
+    // Updates
+    public string Updates { get; set; }
+    public string CheckForUpdatesOnStartup { get; set; }
+    public string CheckForUpdatesChannel { get; set; }
+    public string CheckForUpdatesChannelStable { get; set; }
+    public string CheckForUpdatesChannelStableAndBeta { get; set; }
+
     public string DefaultFormat { get; set; }
     public string DefaultSaveAsFormat { get; set; }
     public string FavoriteSubtitleFormats { get; set; }
@@ -478,6 +485,13 @@ public class LanguageSettings
         ProxyUseSystemCredentials = "Use system credentials";
         ProxyBypassList = "Bypass proxy for";
         ProxyBypassListHint = "Semicolon separated host names that connect directly, e.g. \"internal.company.com;example.org\"";
+
+        // Updates
+        Updates = "Updates";
+        CheckForUpdatesOnStartup = "Check for updates when the app starts";
+        CheckForUpdatesChannel = "Notify about";
+        CheckForUpdatesChannelStable = "Stable versions only";
+        CheckForUpdatesChannelStableAndBeta = "Stable and beta versions";
 
         ShowStopButton = "Show stop button";
         ShowFullscreenButton = "Show full-screen button";

--- a/src/ui/Logic/Config/SeGeneral.cs
+++ b/src/ui/Logic/Config/SeGeneral.cs
@@ -99,6 +99,11 @@ public class SeGeneral
     public bool ProxyUseDefaultCredentials { get; set; }
     public string ProxyBypassList { get; set; }
 
+    public bool CheckForUpdatesOnStartup { get; set; } = true;
+
+    // "Stable", "Beta" or empty = auto (users on a beta build get beta updates, stable users stable only)
+    public string CheckForUpdatesChannel { get; set; } = string.Empty;
+
     public bool ShowColumnStartTime { get; set; }
     public bool ShowColumnEndTime { get; set; }
     public bool ShowColumnGap { get; set; }

--- a/tests/UI/Features/Help/UpdateCheckServiceTests.cs
+++ b/tests/UI/Features/Help/UpdateCheckServiceTests.cs
@@ -1,0 +1,83 @@
+using Nikse.SubtitleEdit.Features.Help.CheckForUpdates;
+
+namespace Tests.Features.Help;
+
+public class UpdateCheckServiceTests
+{
+    private const string Separator = "-----------------------------------------------------------------------------------------------------";
+
+    private static string MakeChangeLog(params string[] blocks)
+    {
+        return "Subtitle Edit Changelog\r\n\r\n" + Separator + "\r\n\r\n" +
+               string.Join("\r\n\r\n" + Separator + "\r\n\r\n", blocks);
+    }
+
+    [Fact]
+    public void ParseLatestChangeLog_StableOnly_SkipsBetaBlocks()
+    {
+        var changeLog = MakeChangeLog(
+            "v5.2.0-beta7 (8th of August 2026)\r\n\r\n* Beta stuff",
+            "v5.2.0-beta6 (7th of August 2026)\r\n\r\n* More beta stuff",
+            "v5.1.0 (13th of July 2026)\r\n\r\n* Stable stuff");
+
+        var result = UpdateCheckService.ParseLatestChangeLog(changeLog, includePrereleases: false);
+
+        Assert.StartsWith("v5.1.0", result);
+        Assert.Equal("v5.1.0", UpdateCheckService.ParseLatestVersion(result));
+    }
+
+    [Fact]
+    public void ParseLatestChangeLog_WithPrereleases_ReturnsNewestBlock()
+    {
+        var changeLog = MakeChangeLog(
+            "v5.2.0-beta7 (8th of August 2026)\r\n\r\n* Beta stuff",
+            "v5.1.0 (13th of July 2026)\r\n\r\n* Stable stuff");
+
+        var result = UpdateCheckService.ParseLatestChangeLog(changeLog, includePrereleases: true);
+
+        Assert.Equal("v5.2.0-beta7", UpdateCheckService.ParseLatestVersion(result));
+    }
+
+    [Fact]
+    public void ParseLatestChangeLog_SkipsUnreleasedDraftEntry()
+    {
+        var changeLog = MakeChangeLog(
+            "v5.2.0 (xth August 2026)\r\n\r\n* Not released yet",
+            "v5.1.0 (13th of July 2026)\r\n\r\n* Stable stuff");
+
+        var result = UpdateCheckService.ParseLatestChangeLog(changeLog, includePrereleases: true);
+
+        Assert.Equal("v5.1.0", UpdateCheckService.ParseLatestVersion(result));
+    }
+
+    [Theory]
+    [InlineData("v5.2.0-beta7", true)]
+    [InlineData("v5.2.0-rc1", true)]
+    [InlineData("v5.2.0", false)]
+    [InlineData("v5.1.0", false)]
+    public void IsPrerelease(string version, bool expected)
+    {
+        Assert.Equal(expected, UpdateCheckService.IsPrerelease(version));
+    }
+
+    [Theory]
+    [InlineData(UpdateCheckService.ChannelStable, "v5.2.0-beta7", false)]
+    [InlineData(UpdateCheckService.ChannelBeta, "v5.1.0", true)]
+    [InlineData("", "v5.2.0-beta7", true)] // auto: beta build follows betas
+    [InlineData("", "v5.1.0", false)] // auto: stable build follows stable only
+    public void ResolveIncludePrereleases(string channel, string currentVersion, bool expected)
+    {
+        Assert.Equal(expected, UpdateCheckService.ResolveIncludePrereleases(channel, currentVersion));
+    }
+
+    [Theory]
+    [InlineData("v5.2.0", "v5.1.0", true)]
+    [InlineData("v5.1.0", "v5.2.0-beta7", false)] // stable-only beta user stays put until the next final
+    [InlineData("v5.2.0", "v5.2.0-beta7", true)] // the final release outranks its own betas
+    [InlineData("v5.2.0-beta8", "v5.2.0-beta7", true)]
+    [InlineData("v5.1.0", "v5.1.0", false)]
+    public void IsNewerThan(string latest, string current, bool expected)
+    {
+        Assert.Equal(expected, UpdateCheckService.IsNewerThan(latest, current));
+    }
+}


### PR DESCRIPTION
Fixes #13388.

SE 5 had no update settings at all - the only mechanism was the manual Help → Check for updates dialog, which always showed the topmost changelog entry, currently a beta. This PR adds the setting requested in #13388 plus the startup check that makes it meaningful.

### New "Updates" section in Options → Settings

- **Check for updates when the app starts** - on by default. Hidden on Flatpak (detected via `FLATPAK_ID`), where updates come through the store.
- **Notify about** - "Stable versions only" / "Stable and beta versions". Until the user explicitly picks, the channel resolves automatically: users already running a beta/rc build follow betas, stable users get stable only (the widely used prerelease-channel convention). Only an actual dropdown change is persisted, so the auto behavior survives settings round-trips.

### Startup check

- Runs on a background task **15 seconds after launch**, so it adds nothing to startup time; failures (offline etc.) are silent.
- When a matching newer version exists, a clickable "New version available: vX.Y.Z" indicator appears in the status bar and opens the existing Check for updates dialog. No dialogs pop up on their own.
- Guarded to the real desktop app (`ClassicDesktopStyleApplicationLifetime`), so headless unit tests that build `MainViewModel` never hit the network.

### Shared logic

Changelog fetching/parsing moved from `CheckForUpdatesViewModel` into a new `UpdateCheckService` used by both the dialog and the startup check. The parser now skips prerelease blocks when the channel is stable-only, so the manual dialog also stops offering betas to stable users; a stable-only user on a beta build correctly reports "up to date" until the next final release ships.

### Tests

16 new unit tests cover channel resolution, prerelease detection, changelog block filtering (including unreleased-draft skipping), and version comparison. Full UI suite passes (one known-flaky focus test failed once and passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)