### PR TITLE
Pre-size lists from computed counts, drop a header copy loop

### DIFF
--- a/src/libse/Common/PlainTextImporter.cs
+++ b/src/libse/Common/PlainTextImporter.cs
@@ -287,7 +287,7 @@
             public List<string> SplitToFour(string text)
             {
                 var lines = Utilities.AutoBreakLinePrivate(text.Trim(), _singleLineMaxLength, Configuration.Settings.General.MergeLinesShorterThan, _language, true).SplitToLines();
-                var list = new List<string>();
+                var list = new List<string>(lines.Count);
                 foreach (var line in lines)
                 {
                     list.Add(Utilities.AutoBreakLinePrivate(line, _singleLineMaxLength, Configuration.Settings.General.MergeLinesShorterThan, _language, true));

--- a/src/libse/Common/TextEffect/KaraokeEffect.cs
+++ b/src/libse/Common/TextEffect/KaraokeEffect.cs
@@ -24,7 +24,7 @@ namespace Nikse.SubtitleEdit.Core.Common.TextEffect
             // the gaps must be 0 to avoid flickering
             const double gapBetweenSentences = 0;
 
-            var animations = new List<Paragraph>();
+            var animations = new List<Paragraph>(result.Length);
             for (var i = 0; i < result.Length; i++)
             {
                 var startTime = new TimeCode(baseStartTime + i * durationPerSentence);

--- a/src/libse/Common/TextSplitResult.cs
+++ b/src/libse/Common/TextSplitResult.cs
@@ -112,7 +112,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         {
             Lines = lines;
 
-            LengthCharacters = new List<int>();
+            LengthCharacters = new List<int>(lines.Count);
             foreach (var line in lines)
             {
                 LengthCharacters.Add(line.Length);

--- a/src/libse/Common/UnknownFormatImporterCsv.cs
+++ b/src/libse/Common/UnknownFormatImporterCsv.cs
@@ -161,7 +161,12 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         private double[] GetGaps(string[] strings)
         {
-            var gaps = new List<double>();
+            if (strings == null || strings.Length < 2)
+            {
+                return Array.Empty<double>();
+            }
+
+            var gaps = new List<double>(strings.Length - 1);
             for (var i = 1; i < strings.Length; i++)
             {
                 var start = TimeCode.ParseToMilliseconds(strings[i - 1]);

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -3286,11 +3286,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 subtitle.Header = subtitle.Header.Trim() + Environment.NewLine;
             }
 
-            lines = new List<string>();
-            foreach (string l in subtitle.Header.Trim().SplitToLines())
-            {
-                lines.Add(l);
-            }
+            lines = subtitle.Header.Trim().SplitToLines();
 
             const string timeCodeFormat = "{0}:{1:00}:{2:00}.{3:00}"; // h:mm:ss.cc
             foreach (var mp in sub)

--- a/src/libse/Forms/RemoveTextForHISettings.cs
+++ b/src/libse/Forms/RemoveTextForHISettings.cs
@@ -31,8 +31,9 @@ namespace Nikse.SubtitleEdit.Core.Forms
         {
             OnlyIfInSeparateLine = Configuration.Settings.RemoveTextForHearingImpaired.RemoveTextBetweenOnlySeparateLines;
             RemoveIfAllUppercase = Configuration.Settings.RemoveTextForHearingImpaired.RemoveIfAllUppercase;
-            UppercaseWhitelist = new List<string>();
-            foreach (var item in (Configuration.Settings.RemoveTextForHearingImpaired.RemoveIfAllUppercaseWhitelist ?? string.Empty).Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries))
+            var uppercaseWhitelistItems = (Configuration.Settings.RemoveTextForHearingImpaired.RemoveIfAllUppercaseWhitelist ?? string.Empty).Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
+            UppercaseWhitelist = new List<string>(uppercaseWhitelistItems.Length);
+            foreach (var item in uppercaseWhitelistItems)
             {
                 UppercaseWhitelist.Add(item.Trim());
             }
@@ -40,8 +41,9 @@ namespace Nikse.SubtitleEdit.Core.Forms
             RemoveTextBeforeColonOnlyUppercase = Configuration.Settings.RemoveTextForHearingImpaired.RemoveTextBeforeColonOnlyIfUppercase;
             ColonSeparateLine = Configuration.Settings.RemoveTextForHearingImpaired.RemoveTextBeforeColonOnlyOnSeparateLine;
             RemoveWhereContains = Configuration.Settings.RemoveTextForHearingImpaired.RemoveIfContains;
-            RemoveIfTextContains = new List<string>();
-            foreach (var item in Configuration.Settings.RemoveTextForHearingImpaired.RemoveIfContainsText.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
+            var removeIfContainsItems = Configuration.Settings.RemoveTextForHearingImpaired.RemoveIfContainsText.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+            RemoveIfTextContains = new List<string>(removeIfContainsItems.Length);
+            foreach (var item in removeIfContainsItems)
             {
                 RemoveIfTextContains.Add(item.Trim());
             }

--- a/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
@@ -432,7 +432,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                 return DefaultHeader;
             }
 
-            var styles = new List<SsaStyle>();
+            var styles = new List<SsaStyle>(stylesContent.Count);
             foreach (var styleAsString in stylesContent)
             {
                 styles.Add(SsaStyle.FromRawSsa(header, styleAsString));
@@ -1025,8 +1025,9 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
 
         public static List<SsaStyle> GetSsaStylesFromHeader(string header)
         {
-            var styles = new List<SsaStyle>();
-            foreach (var styleName in GetStylesFromHeader(header))
+            var styleNames = GetStylesFromHeader(header);
+            var styles = new List<SsaStyle>(styleNames.Count);
+            foreach (var styleName in styleNames)
             {
                 styles.Add(GetSsaStyle(styleName, header));
             }

--- a/src/libse/SubtitleFormats/TextST.cs
+++ b/src/libse/SubtitleFormats/TextST.cs
@@ -216,7 +216,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     idx += 29;
                 }
 
-                UserStyles = new List<UserStyle>();
+                UserStyles = new List<UserStyle>(NumberOfUserStyles);
                 for (int j = 0; j < NumberOfUserStyles; j++)
                 {
                     var us = new UserStyle


### PR DESCRIPTION
## Summary

The best parts of #13375 by @ivandrofly (who is credited as co-author on the commit), extracted into their own PR:

- Pass the source `Count`/`Length` as `List<T>` capacity where it is available at construction time: `PlainTextImporter.SplitToFour`, `TextSplitResult`, `KaraokeEffect.Transform`, `TextST.DialogStyleSegment` (`NumberOfUserStyles`, matching the existing `RegionStyles` pre-size), and both style loops in `AdvancedSubStationAlpha`
- Hoist `Split(...)` in `RemoveTextForHISettings` and `GetStylesFromHeader()` in `GetSsaStylesFromHeader` into locals so they are evaluated once instead of per-check
- Replace the header copy loop in `Utilities.LoadMatroskaSSA` with direct assignment of the `SplitToLines()` result (it already returns a fresh list)
- `UnknownFormatImporterCsv.GetGaps`: return `Array.Empty<double>()` for null/short input (null previously threw) and pre-size the gaps list

Deliberately **not** carried over from #13375: the ~47 hard-coded capacity literals on static tables (`new List<string>(29) { ... }` etc.). The numbers all check out today, but they rot silently when someone edits a list, and most of those sites are one-time static initializers where the saving is a few transient arrays at startup. Several of the remaining sites (per-call constant lists like `onOffTags`, `msNames`, `rowCodes`) deserve hoisting to `static readonly` arrays instead, which is a separate change.

## Test plan
- [x] `dotnet build src/libse/LibSE.csproj` - 0 warnings, 0 errors (both target frameworks)
- [x] `dotnet test tests/libse/LibSETests.csproj` - 935/935 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)