### PR TITLE
Fix #13398: keep foreground on the dialog that triggered an undock rebuild

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -6536,6 +6536,13 @@ public partial class MainViewModel :
 
         Dispatcher.UIThread.Post(() =>
         {
+            // Rebuilding the undocked windows below ends in ShowIndependentWindow, which does
+            // Show() + Focus() - so it takes foreground. Settings -> Apply reaches here through
+            // ApplySettings while its own dialog is still open, which left that dialog visible
+            // but deactivated and an undocked window in front of it (#13398). Remember a
+            // foreground dialog now and hand activation back once both windows exist.
+            var windowToReactivate = GetActiveWindowOtherThanMainAndUndocked();
+
             AreVideoControlsUndocked = true;
 
             var position = vp.Position;
@@ -6589,7 +6596,49 @@ public partial class MainViewModel :
             }
 
             RefreshSubtitlePreview();
+
+            if (windowToReactivate != null)
+            {
+                // Background priority so the two Show()/Focus() calls above have settled.
+                Dispatcher.UIThread.Post(() =>
+                {
+                    if (windowToReactivate.IsVisible && !windowToReactivate.IsActive)
+                    {
+                        windowToReactivate.Activate();
+                    }
+                }, DispatcherPriority.Background);
+            }
         });
+    }
+
+    /// <summary>
+    /// The active window when it is neither the main window nor one of the undocked tool
+    /// windows - i.e. a dialog sitting in front. Used to give foreground back to a dialog that
+    /// triggered a rebuild of the undocked windows (#13398). The undocked windows are excluded
+    /// because they are closed and re-created by that rebuild.
+    /// </summary>
+    private Window? GetActiveWindowOtherThanMainAndUndocked()
+    {
+        if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            return null;
+        }
+
+        var videoWindow = _videoPlayerUndockedViewModel?.Window;
+        var waveformWindow = _audioVisualizerUndockedViewModel?.Window;
+
+        foreach (var window in desktop.Windows)
+        {
+            if (window.IsActive &&
+                !ReferenceEquals(window, Window) &&
+                !ReferenceEquals(window, videoWindow) &&
+                !ReferenceEquals(window, waveformWindow))
+            {
+                return window;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #13398.

## What happens

With the video controls undocked, **Settings → Apply** leaves the Settings dialog visible but *deactivated*, with an undocked window in front. @GrampaWildWilly had to Alt+Tab back to the dialog to reach OK.

## Why

`Apply` calls `MainViewModel.ApplySettings`, which in undocked mode runs `VideoUndockControls` to rebuild the layout. That closes **both** undocked tool windows and re-creates them via `WindowService.ShowIndependentWindow` — which ends in:

```csharp
window.Show();
window.Focus();
```

So the rebuild takes foreground, even though the dialog that asked for it is still open.

This also explains the flicker in the report ("the Audio visualizer briefly flickered into view then disappeared again"): the freshly shown windows come up topmost, and `KeepTopmostWhileOwnerActive` immediately drops them again because the dialog's `SuspendUndockedTopmost` is still held.

Worth saying explicitly, since the issue asks about it: the central suspension service from #13325/#13362 was working correctly here. It governs **Z-order**, not **activation** — it has no way to stop an explicit `Focus()` call on a newly shown window. That is why this one slipped past it.

## Fix

Remember which window was in front before the rebuild, and hand activation back once both undocked windows exist — posted at `Background` priority so the two `Show()`/`Focus()` calls have settled first.

The candidate must be neither the main window nor either undocked tool window. That keeps the change tightly scoped:
- undocking from the menu (no dialog in front) behaves exactly as before;
- the two windows being destroyed and re-created can never be picked as the reactivation target.

## Test plan

- [x] `dotnet test tests/UI/UITests.csproj` — 1772 passed
- [x] `dotnet build src/ui/UI.csproj -c Release`
- [ ] **Needs manual verification** (I could not reproduce this without a GUI session): undock the video controls, open Settings, change a setting, press Apply — the Settings dialog should stay in foreground, and the undocked windows should stay behind it until the dialog closes.
- [ ] Regression check: undock/redock from the menu with no dialog open still leaves the main window in front.

I have not added an automated test. The existing `SuspendUndockedTopmostTests` cover the ref-counted service, but window *activation* is not observable headlessly — `Window.IsActive` is read-only and needs a real desktop lifetime — so a test here would have to abstract away the very thing being fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
