### PR TITLE
Fix #13401: target file size with VideoToolbox burn-in

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -523,7 +523,7 @@ public partial class BurnInViewModel : ObservableObject
         });
 
         bool result;
-        if (jobItem.UseTargetFileSize)
+        if (jobItem.UseTargetFileSize && !IsVideoToolboxEncoder(SelectedVideoEncoding?.Codec))
         {
             result = await RunTwoPassEncoding(jobItem);
             if (result)
@@ -533,6 +533,17 @@ public partial class BurnInViewModel : ObservableObject
         }
         else
         {
+            if (jobItem.UseTargetFileSize)
+            {
+                // VideoToolbox accepts -pass but writes an empty stats file, so pass 1 only
+                // doubles the encode time. Hit the target with single-pass average bit rate
+                // instead (#13401).
+                if (!SetTargetBitRate(jobItem))
+                {
+                    return;
+                }
+            }
+
             result = await RunOnePassEncoding(jobItem);
             if (result)
             {
@@ -541,7 +552,21 @@ public partial class BurnInViewModel : ObservableObject
         }
     }
 
-    private async Task<bool> RunTwoPassEncoding(BurnInJobItem jobItem)
+    /// <summary>
+    /// VideoToolbox has no working two-pass mode: ffmpeg accepts -pass but the encoder writes
+    /// no statistics, so the analyze pass is pure wasted time. These encodes target a file size
+    /// with a single-pass average bit rate instead (#13401).
+    /// </summary>
+    internal static bool IsVideoToolboxEncoder(string? codec)
+    {
+        return !string.IsNullOrEmpty(codec) && codec.EndsWith("_videotoolbox", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Computes the bit rate needed to hit the requested file size and stores it on the job.
+    /// Returns false (and tells the user) when the target is too small to encode.
+    /// </summary>
+    private bool SetTargetBitRate(BurnInJobItem jobItem)
     {
         var bitRate = GetVideoBitRate(jobItem);
         jobItem.VideoBitRate = bitRate.ToString(CultureInfo.InvariantCulture) + "k";
@@ -555,6 +580,16 @@ public partial class BurnInViewModel : ObservableObject
                     $"Bit rate too low: {bitRate}k",
                     MessageBoxButtons.OK);
             });
+            return false;
+        }
+
+        return true;
+    }
+
+    private async Task<bool> RunTwoPassEncoding(BurnInJobItem jobItem)
+    {
+        if (!SetTargetBitRate(jobItem))
+        {
             return false;
         }
 

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -161,7 +161,11 @@ public class FfmpegGenerator
         }
 
         var crfSettings = string.Empty;
-        if (!string.IsNullOrWhiteSpace(crf) && string.IsNullOrWhiteSpace(pass))
+        // A bit rate target and a quality target are mutually exclusive. With -pass that is
+        // implicit, but VideoToolbox targets a file size in a single pass (no -pass), and there
+        // ffmpeg takes -q:v and silently ignores -b:v - the encode would quietly come out at the
+        // quality-based size instead of the requested one (#13401).
+        if (!string.IsNullOrWhiteSpace(crf) && string.IsNullOrWhiteSpace(pass) && string.IsNullOrWhiteSpace(twoPassBitRate))
         {
             if (videoEncoding == "h264_nvenc" || videoEncoding == "hevc_nvenc")
             {
@@ -191,7 +195,18 @@ public class FfmpegGenerator
         outputVideoFileName = $"\"{outputVideoFileName}\"";
 
         var passSettings = string.Empty;
-        if (!string.IsNullOrWhiteSpace(pass) && !string.IsNullOrWhiteSpace(twoPassBitRate))
+        if (string.IsNullOrWhiteSpace(pass) && !string.IsNullOrWhiteSpace(twoPassBitRate))
+        {
+            // Single-pass average bit rate, used where two-pass is not available (VideoToolbox
+            // writes no stats file, so its "pass 1" is wasted work - see #13401).
+            passSettings = $" -b:v {twoPassBitRate}";
+
+            if (!string.IsNullOrWhiteSpace(audioBitRate))
+            {
+                passSettings += $" -b:a {audioBitRate}";
+            }
+        }
+        else if (!string.IsNullOrWhiteSpace(pass) && !string.IsNullOrWhiteSpace(twoPassBitRate))
         {
             passSettings = $" -b:v {twoPassBitRate} -pass {pass}";
 

--- a/tests/UI/Logic/FfmpegTargetFileSizeTests.cs
+++ b/tests/UI/Logic/FfmpegTargetFileSizeTests.cs
@@ -1,0 +1,94 @@
+using Nikse.SubtitleEdit.Features.Video.BurnIn;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace UITests.Logic;
+
+// Targeting a file size normally runs two passes. VideoToolbox accepts -pass but writes an empty
+// stats file, so its analyze pass is wasted time and those encodes go single-pass with an average
+// bit rate instead (#13401). The trap that makes this worth pinning: with both -q:v and -b:v on
+// the command line ffmpeg keeps the quality target and silently ignores the bit rate, so the file
+// comes out at the wrong size with no warning. Verified against ffmpeg 4.4.6 / h264_videotoolbox:
+// "-q:v 50 -b:v 800k" produced byte-for-byte the same output as "-q:v 50" alone.
+public class FfmpegTargetFileSizeTests
+{
+    private static string Generate(string videoEncoding, string crf, string pass, string bitRate)
+    {
+        return FfmpegGenerator.GenerateHardcodedVideoFile(
+            "in.mp4",
+            "sub.ass",
+            "out.mp4",
+            1920,
+            1080,
+            videoEncoding,
+            string.Empty,
+            "yuv420p",
+            crf,
+            "aac",
+            false,
+            "48000",
+            string.Empty,
+            "128k",
+            pass,
+            bitRate);
+    }
+
+    [Theory]
+    [InlineData("h264_videotoolbox")]
+    [InlineData("hevc_videotoolbox")]
+    [InlineData("prores_videotoolbox")]
+    public void IsVideoToolboxEncoder_DetectsAllThree(string codec)
+    {
+        Assert.True(BurnInViewModel.IsVideoToolboxEncoder(codec));
+    }
+
+    [Theory]
+    [InlineData("libx264")]
+    [InlineData("libx265")]
+    [InlineData("h264_nvenc")]
+    [InlineData("hevc_amf")]
+    [InlineData("h264_qsv")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void IsVideoToolboxEncoder_IgnoresEverythingElse(string? codec)
+    {
+        Assert.False(BurnInViewModel.IsVideoToolboxEncoder(codec));
+    }
+
+    [Fact]
+    public void BitRateWithoutPass_EmitsSinglePassAverageBitRate()
+    {
+        var args = Generate("h264_videotoolbox", string.Empty, string.Empty, "2500k");
+
+        Assert.Contains("-b:v 2500k", args);
+        Assert.DoesNotContain("-pass", args);
+    }
+
+    [Fact]
+    public void BitRateWithoutPass_DropsTheQualityTargetSoTheBitRateIsNotIgnored()
+    {
+        var args = Generate("h264_videotoolbox", "70", string.Empty, "2500k");
+
+        Assert.Contains("-b:v 2500k", args);
+        Assert.DoesNotContain("-q:v", args);
+    }
+
+    [Fact]
+    public void QualityWithoutBitRate_StillEmitsTheQualityTarget()
+    {
+        var args = Generate("h264_videotoolbox", "70", string.Empty, string.Empty);
+
+        Assert.Contains("-q:v 70", args);
+        Assert.DoesNotContain("-b:v", args);
+    }
+
+    [Theory]
+    [InlineData("1")]
+    [InlineData("2")]
+    public void TwoPassIsUnchangedForTheOtherEncoders(string pass)
+    {
+        var args = Generate("libx264", "23", pass, "2500k");
+
+        Assert.Contains($"-b:v 2500k -pass {pass}", args);
+        Assert.DoesNotContain("-crf", args);
+    }
+}


### PR DESCRIPTION
Fixes #13401. Thanks @luisblop — both remarks check out, and I measured them rather than taking them on trust.

## Measurements

ffmpeg 4.4.6, `h264_videotoolbox`, Apple silicon, 4 s test clip.

**1. `-q:v` silently beats `-b:v`.** This is the nastier of the two — there is no error and no warning:

| Command | Output size |
|---|---:|
| `-q:v 50 -b:v 800k` | 56,196 B |
| `-q:v 50` alone | 56,196 B ← byte-identical |
| `-b:v 800k` alone | 163,475 B |

So if a quality flag were ever emitted alongside the bit rate, a user asking for a target file size would silently get whatever size the quality setting happened to produce.

**2. Two-pass is a no-op, not an error.** `-pass 1` completes fine and leaves `ffmpeg2pass-0.log` at **0 bytes** — the encoder writes no statistics. Pass 2 then produces exactly the same output as a plain single-pass encode at the same bit rate. So it is not a hard failure; it just **doubles the encode time for nothing**.

## What was actually broken

`BurnInViewModel` routed *every* "target file size" job through `RunTwoPassEncoding`, regardless of encoder. On macOS with VideoToolbox that meant a wasted analyze pass on every burn-in.

The `-q:v`/`-b:v` conflict was not reachable before this change, because `crfSettings` was gated on `pass` being empty and target-size always set a pass. It becomes reachable the moment a bit rate can appear *without* a pass — which is exactly what the fix introduces — so it is handled here too.

## Fix

- `BurnInViewModel`: VideoToolbox target-size jobs run a **single pass with `-b:v`**, using the same `GetVideoBitRate` the two-pass path already used. The bit-rate-too-low guard moved into a shared `SetTargetBitRate` so both paths keep it.
- `FfmpegGenerator`: emits `-b:v <rate>` with no `-pass` when a bit rate is set and no pass is, and **drops the quality flag whenever a bit rate target is present**.
- Two-pass for libx264/libx265/NVENC/AMF/QSV is untouched.

I did **not** add `-maxrate`/`-bufsize`. You listed them as optional, and they change the rate-control shape (VBV constraint rather than plain ABR), so they felt like a separate, opinionated call rather than part of a bug fix. Easy to add if you want them.

## Test plan

- [x] `dotnet test tests/UI/UITests.csproj` — 1787 passed (15 new)
- [x] New `FfmpegTargetFileSizeTests` pins: `-b:v` without `-pass`, quality dropped when a bit rate is present, quality kept when it is not, two-pass unchanged for other encoders, and the encoder-detection predicate
- [x] `dotnet build src/ui/UI.csproj -c Release`
- [x] ffmpeg behaviour verified directly on Apple silicon (table above)
- [ ] **Needs a real burn-in run on a Mac**: enable "target file size", pick an Apple VideoToolbox encoder, and confirm the output lands near the requested size and only one ffmpeg pass runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
