### PR TITLE
Fix ASSA tag scan in StrippableText.FixCasing

### DIFF
--- a/src/libse/Common/StrippableText.cs
+++ b/src/libse/Common/StrippableText.cs
@@ -200,7 +200,6 @@ namespace Nikse.SubtitleEdit.Core.Common
                             lower = StrippedText.ToLowerInvariant();
                         }
                     }
-
                     if (start + 3 > lower.Length)
                     {
                         start = lower.Length + 1;
@@ -219,26 +218,31 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
         }
 
-        private void ReplaceNamesWithIds(List<string> replaceIds, List<string> replaceNames, List<string> originalNames)
+        private void ReplaceAssaTagsRemove(List<string> replaceIds, List<string> replaceNames, List<string> originalNames)
         {
             int idName = 1000;
             var openIndex = StrippedText.IndexOf('{');
             while (openIndex >= 0)
             {
+                // Pair each "{" with the first "}" after it - searching both from the same start
+                // index made a stray "}" (as in "a} b {\i1}") look like an unbalanced tag and
+                // abort the scan, leaving the real tags unprotected.
                 var closeIndex = StrippedText.IndexOf('}', openIndex + 1);
-
-                if (closeIndex < openIndex)
+                if (closeIndex < 0)
                 {
                     return;
                 }
 
-                string name = StrippedText.Substring(openIndex, closeIndex - openIndex + 1);
-                StrippedText = StrippedText.Remove(openIndex, name.Length);
-                string genId = GetAndInsertNextId(replaceIds, replaceNames, name, idName++);
-                StrippedText = StrippedText.Insert(openIndex, genId);
-                originalNames.Add(name);
+                var tag = StrippedText.Substring(openIndex, closeIndex - openIndex + 1);
+                StrippedText = StrippedText.Remove(openIndex, tag.Length);
+                var id = GetAndInsertNextId(replaceIds, replaceNames, tag, idName++);
+                StrippedText = StrippedText.Insert(openIndex, id);
+                originalNames.Add(tag);
 
-                openIndex = StrippedText.IndexOf('{', openIndex + genId.Length);
+                // Resume after the inserted id - "closeIndex + 1" was an index into the string
+                // as it looked before the replacement, so any tag longer than the id skipped
+                // the following tags.
+                openIndex = StrippedText.IndexOf('{', openIndex + id.Length);
             }
         }
 
@@ -257,7 +261,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             var replaceNames = new List<string>();
             var originalNames = new List<string>();
             ReplaceNames1Remove(nameList, replaceIds, replaceNames, originalNames);
-            ReplaceNamesWithIds(replaceIds, replaceNames, originalNames);
+            ReplaceAssaTagsRemove(replaceIds, replaceNames, originalNames);
 
             if (checkLastLine && ShouldStartWithUpperCase(lastLine, millisecondsFromLast))
             {

--- a/src/libse/Common/StrippableText.cs
+++ b/src/libse/Common/StrippableText.cs
@@ -200,6 +200,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                             lower = StrippedText.ToLowerInvariant();
                         }
                     }
+
                     if (start + 3 > lower.Length)
                     {
                         start = lower.Length + 1;
@@ -218,29 +219,26 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
         }
 
-        private void ReplacAssaTagsRemove(List<string> replaceIds, List<string> replaceNames, List<string> originalNames)
+        private void ReplaceNamesWithIds(List<string> replaceIds, List<string> replaceNames, List<string> originalNames)
         {
             int idName = 1000;
-            var idx = 0;
-            while (StrippedText.IndexOf("{", idx) >= 0 && StrippedText.IndexOf('}', idx) > 0)
+            var openIndex = StrippedText.IndexOf('{');
+            while (openIndex >= 0)
             {
-                var start = StrippedText.IndexOf("{", idx);
-                var end = StrippedText.IndexOf("}", idx);
-                if (end < start)
+                var closeIndex = StrippedText.IndexOf('}', openIndex + 1);
+
+                if (closeIndex < openIndex)
                 {
                     return;
                 }
 
-                var tag = StrippedText.Substring(start, end - start + 1);
-                StrippedText = StrippedText.Remove(start, tag.Length);
-                StrippedText = StrippedText.Insert(start, GetAndInsertNextId(replaceIds, replaceNames, tag, idName++));
-                originalNames.Add(tag);
+                string name = StrippedText.Substring(openIndex, closeIndex - openIndex + 1);
+                StrippedText = StrippedText.Remove(openIndex, name.Length);
+                string genId = GetAndInsertNextId(replaceIds, replaceNames, name, idName++);
+                StrippedText = StrippedText.Insert(openIndex, genId);
+                originalNames.Add(name);
 
-                idx = end + 1;
-                if (idx >= StrippedText.Length)
-                {
-                    return;
-                }   
+                openIndex = StrippedText.IndexOf('{', openIndex + genId.Length);
             }
         }
 
@@ -259,7 +257,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             var replaceNames = new List<string>();
             var originalNames = new List<string>();
             ReplaceNames1Remove(nameList, replaceIds, replaceNames, originalNames);
-            ReplacAssaTagsRemove(replaceIds, replaceNames, originalNames);
+            ReplaceNamesWithIds(replaceIds, replaceNames, originalNames);
 
             if (checkLastLine && ShouldStartWithUpperCase(lastLine, millisecondsFromLast))
             {

--- a/tests/libse/Common/StrippableTextFixCasingTest.cs
+++ b/tests/libse/Common/StrippableTextFixCasingTest.cs
@@ -83,6 +83,34 @@ public class StrippableTextFixCasingTest
     }
 
     [Fact]
+    public void FixCasing_ProtectsTagsFollowingALongerTag()
+    {
+        // A tag is swapped for a 7 char id, so a longer tag before it used to leave the scan
+        // index past the following tags. Those stayed literal, and "}" is a break character -
+        // so the words after them were uppercased in the middle of a sentence.
+        var st = new StrippableText(@"one {\an8\pos(1,2)} two {\i1} three {\b1} four");
+        st.FixCasing(new List<string>(), true, makeUppercaseAfterBreak: true, false, string.Empty);
+        Assert.Equal(@"one {\an8\pos(1,2)} two {\i1} three {\b1} four", st.MergedString);
+    }
+
+    [Fact]
+    public void FixCasing_ProtectsTagFollowingStrayClosingBrace()
+    {
+        // A "}" before the first "{" must not abort the tag scan.
+        var st = new StrippableText(@"a} b {\i1} c");
+        st.FixCasing(new List<string>(), true, makeUppercaseAfterBreak: true, false, string.Empty);
+        Assert.Equal(@"a} B {\i1} c", st.MergedString);
+    }
+
+    [Fact]
+    public void FixCasing_LeavesUnclosedTagAlone()
+    {
+        var st = new StrippableText("hello {unclosed bob");
+        st.FixCasing(new List<string> { "Bob" }, true, false, false, string.Empty);
+        Assert.Equal("hello {unclosed Bob", st.MergedString);
+    }
+
+    [Fact]
     public void FixCasing_NoNamesLeavesTextUnchanged()
     {
         Assert.Equal("nothing to do here", FixNames("nothing to do here", new List<string>()));


### PR DESCRIPTION
## Summary
Fix two index bugs in the ASSA tag scan of `StrippableText.FixCasing`:

- Pair each `{` with the first `}` **after it**, instead of searching both braces from the same start index. A stray `}` before the first `{` (e.g. `a} b {\i1}`) no longer aborts the scan.
- Resume the scan after the inserted id. The old `idx = end + 1` used an index into the string as it looked *before* `Remove`/`Insert` changed its length, so any tag longer than the 7 char id (`_@1000_`) made the loop skip every following tag.
- Fix the typo in the method name: `ReplacAssaTagsRemove` -> `ReplaceAssaTagsRemove`.

### Why it matters

A tag that the scan skips stays literal in `StrippedText` while casing is fixed, and `}` is one of the `breakAfterChars` - so the word after it was uppercased in the middle of a sentence:

| input | before | after |
|---|---|---|
| `one {\an8\pos(1,2)} two {\i1} three {\b1} four` | `... two {\i1} Three {\b1} Four` | `... two {\i1} three {\b1} four` |
| `a} b {\i1} c` | `a} B {\i1} C` | `a} B {\i1} c` |

This also removes an inconsistency: lines whose tags were all short (<= 7 chars) already behaved the way this PR now makes every line behave.

## Test plan
- [x] `dotnet test tests/libse/LibSETests.csproj` - 984 passed
- [x] Two new regression tests in `StrippableTextFixCasingTest`, both verified to fail on `main` and pass here
- [x] Differential run of `FixCasing` over tagged lines (`{\p1}` drawings, unclosed `{`, `{}`, multiple inline tags, leading `{\an8}`) - the only output changes are the spurious uppercases shown above

## Not addressed (pre-existing)
Tag ids start at `idName = 1000`, but the two id lookups in `FixCasing` rebuild them as `$"_@{i}_"` from the list index, so they never match a tag entry. When a tag id follows a sentence break, the loop uppercases the id's leading `_` and clears `lastWasBreak`, so the real word is never capitalized - `hello. {\i1}how are you?` keeps `how` lowercase both before and after this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
