### PR TITLE
Avoid exact floating-point equality in hide-max value converters

### DIFF
--- a/src/ui/Logic/ValueConverters/DoubleToDisplayShortConverter.cs
+++ b/src/ui/Logic/ValueConverters/DoubleToDisplayShortConverter.cs
@@ -20,7 +20,7 @@ public class DoubleToDisplayShortConverter : IValueConverter
         var useFrameMode = Se.Settings.General.UseFrameMode;
         if (value is double ms)
         {
-            if (ms == double.MaxValue || double.IsNaN(ms))
+            if (Math.Abs(ms - double.MaxValue) < 0.01 || double.IsNaN(ms))
             {
                 // Sentinel for "no value" (e.g. the gap after the last line) - show nothing
                 // instead of a clamped "0,000".

--- a/src/ui/Logic/ValueConverters/DoubleToNoDecimalHideMaxConverter.cs
+++ b/src/ui/Logic/ValueConverters/DoubleToNoDecimalHideMaxConverter.cs
@@ -13,7 +13,7 @@ public class DoubleToNoDecimalHideMaxConverter : IValueConverter
         if (value is double d)
         {
             // NaN never equals anything, itself included - "d == double.NaN" was always false.
-            if (d == double.MaxValue || double.IsNaN(d))
+            if (Math.Abs(d - double.MaxValue) < 0.01 || double.IsNaN(d))
             {
                 return string.Empty;
             }

--- a/src/ui/Logic/ValueConverters/DoubleToOneDecimalHideMaxConverter.cs
+++ b/src/ui/Logic/ValueConverters/DoubleToOneDecimalHideMaxConverter.cs
@@ -12,7 +12,7 @@ public class DoubleToOneDecimalHideMaxConverter : IValueConverter
     {
         if (value is double d)
         {
-            if (d == double.MaxValue || double.IsNaN(d))
+            if (Math.Abs(d - double.MaxValue) < 0.01 || double.IsNaN(d))
             {
                 return string.Empty;
             }


### PR DESCRIPTION
## Summary
- Replace `d == double.MaxValue` with `Math.Abs(d - double.MaxValue) < 0.01` in `DoubleToDisplayShortConverter`, `DoubleToNoDecimalHideMaxConverter` and `DoubleToOneDecimalHideMaxConverter`
- The `double.MaxValue` sentinel ("no value") is still detected; the tolerance form avoids floating-point equality comparison warnings

## Test plan
- [ ] `dotnet build src/ui/UI.csproj` succeeds
- [ ] Open a subtitle and check the gap column: the row after the last line (sentinel value) shows an empty cell, not a clamped number
- [ ] Regular gap/duration values still display as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)