### PR TITLE
Sync Paddle OCR language list with PaddleOCR 3.4 and the bundled models

### DIFF
--- a/src/ui/Features/Ocr/Engines/PaddleOcr.cs
+++ b/src/ui/Features/Ocr/Engines/PaddleOcr.cs
@@ -60,35 +60,60 @@ public partial class PaddleOcr
 
     private const string TextlineOrientationModelName = "PP-LCNet_x1_0_textline_ori";
 
-    private readonly List<string> LatinLanguageCodes = new List<string>
+    // The script groups below mirror LATIN_LANGS/ARABIC_LANGS/ESLAV_LANGS/CYRILLIC_LANGS/
+    // DEVANAGARI_LANGS in PaddleOCR 3.4 (paddleocr/_pipelines/ocr.py) - the version the
+    // bundled standalone engine is built from. Keep them in sync with GetLanguages(); a
+    // code offered in the dropdown but missing from every group here silently falls
+    // through to the Latin recognition model and OCRs to garbage.
+    private static readonly HashSet<string> LatinLanguageCodes = new HashSet<string>
     {
-        "af", "az", "bs", "cs", "cy", "da", "de", "es", "et", "fr", "ga",
-        "hr", "hu", "id", "is", "it", "ku", "la", "lt", "lv", "mi", "ms",
-        "mt", "nl", "no", "oc", "pi", "pl", "pt", "ro", "rs_latin", "sk",
-        "sl", "sq", "sv", "sw", "tl", "tr", "uz", "vi", "french", "german"
+        "af", "az", "bs", "ca", "cs", "cy", "da", "de", "es", "et", "eu",
+        "fi", "fr", "ga", "gl", "hr", "hu", "id", "is", "it", "ku", "la",
+        "lb", "lt", "lv", "mi", "ms", "mt", "nl", "no", "oc", "pi", "pl",
+        "pt", "qu", "rm", "ro", "rs_latin", "sk", "sl", "sq", "sv", "sw",
+        "tl", "tr", "uz", "vi", "french", "german"
     };
 
-    private readonly List<string> ArabicLanguageCodes = new List<string>
+    private static readonly HashSet<string> ArabicLanguageCodes = new HashSet<string>
     {
-        "ar", "fa", "ug", "ur"
+        "ar", "bal", "fa", "ps", "sd", "ug", "ur"
     };
 
-    private readonly List<string> EslavLanguageCodes = new List<string>
+    private static readonly HashSet<string> EslavLanguageCodes = new HashSet<string>
     {
         "ru", "be", "uk"
     };
 
-    private readonly List<string> CyrillicLanguageCodes = new List<string>
+    private static readonly HashSet<string> CyrillicLanguageCodes = new HashSet<string>
     {
         "rs_cyrillic", "bg", "mn", "abq", "ady", "kbd", "ava", "dar",
-        "inh", "che", "lbe", "lez", "tab"
+        "inh", "che", "lbe", "lez", "tab", "ba", "bua", "cv", "kaa",
+        "kk", "kv", "ky", "mhr", "mk", "mo", "os", "sah", "tg", "tt",
+        "tyv", "udm", "xal"
     };
 
-    private readonly List<string> DevanagariLanguageCodes = new List<string>
+    private static readonly HashSet<string> DevanagariLanguageCodes = new HashSet<string>
     {
         "hi", "mr", "ne", "bh", "mai", "ang", "bho", "mah",
         "sck", "new", "gom", "bgc", "sa"
     };
+
+    // The languages with their own single-language PP-OCRv5 recognition model.
+    private static readonly HashSet<string> OwnModelLanguageCodes = new HashSet<string>
+    {
+        "el", "ta", "te", "th"
+    };
+
+    internal static IReadOnlyCollection<string> GetLatinLanguageCodesForTest() => LatinLanguageCodes;
+
+    internal static IEnumerable<string> GetAllScriptGroupCodesForTest() =>
+        LatinLanguageCodes
+            .Concat(ArabicLanguageCodes)
+            .Concat(EslavLanguageCodes)
+            .Concat(CyrillicLanguageCodes)
+            .Concat(DevanagariLanguageCodes)
+            .Concat(OwnModelLanguageCodes)
+            .Distinct();
 
     public PaddleOcr()
     {
@@ -101,7 +126,11 @@ public partial class PaddleOcr
         _cancellationToken = new CancellationToken();
     }
 
-    private string GetRecName(string language, string mode)
+    // Only the recognition models shipped in "PaddleOCR.PP-OCRv5.support.files" are on
+    // disk - nothing is fetched per language. Returning a name that is not in that bundle
+    // points at a folder that does not exist, and the run then fails when PaddleX tries to
+    // read the model's inference.yml.
+    internal static string GetRecName(string language, string mode)
     {
         string recName;
         if (language == "ch" ||
@@ -113,7 +142,7 @@ public partial class PaddleOcr
         }
         else if (ArabicLanguageCodes.Contains(language))
         {
-            recName = "arabic_PP-OCRv3_mobile_rec";
+            recName = "arabic_PP-OCRv5_mobile_rec";
         }
         else if (EslavLanguageCodes.Contains(language))
         {
@@ -121,15 +150,24 @@ public partial class PaddleOcr
         }
         else if (CyrillicLanguageCodes.Contains(language))
         {
-            recName = "cyrillic_PP-OCRv3_mobile_rec";
+            recName = "cyrillic_PP-OCRv5_mobile_rec";
         }
         else if (DevanagariLanguageCodes.Contains(language))
         {
-            recName = "devanagari_PP-OCRv3_mobile_rec";
+            recName = "devanagari_PP-OCRv5_mobile_rec";
         }
         else if (language == "korean")
         {
             recName = "korean_PP-OCRv5_mobile_rec";
+        }
+        else if (OwnModelLanguageCodes.Contains(language))
+        {
+            recName = $"{language}_PP-OCRv5_mobile_rec";
+        }
+        else if (language == "ka")
+        {
+            // Georgian has no PP-OCRv5 recognition model yet.
+            recName = "ka_PP-OCRv3_mobile_rec";
         }
         else
         {
@@ -139,22 +177,13 @@ public partial class PaddleOcr
         return recName;
     }
 
-    private string GetDetectionName(string language, string mode)
+    internal static string GetDetectionName(string language, string mode)
     {
-        if (language == "ch" ||
-            language == "chinese_cht" ||
-            language == "en" ||
-            language == "japan" ||
-            language == "korean" ||
-            LatinLanguageCodes.Contains(language) ||
-            EslavLanguageCodes.Contains(language))
-        {
-            return $"PP-OCRv5_{mode}_det";
-        }
-        else
-        {
-            return "PP-OCRv3_mobile_det";
-        }
+        // Georgian is the one remaining PP-OCRv3 language; everything else recognizes
+        // with a PP-OCRv5 model and detects with the matching PP-OCRv5 detector.
+        return language == "ka"
+            ? "PP-OCRv3_mobile_det"
+            : $"PP-OCRv5_{mode}_det";
     }
 
     private static SKBitmap MakeTransparentBlack(SKBitmap bitmap)
@@ -196,8 +225,6 @@ public partial class PaddleOcr
     public async Task OcrBatch(OcrEngineType engineType, List<PaddleOcrBatchInput> bitmaps, string language,
         string mode, IProgress<PaddleOcrBatchProgress> progress, CancellationToken cancellationToken)
     {
-        string detFilePrefix = MakeDetPrefix(language);
-        string recFilePrefix = MakeRecPrefix(language);
         var detName = GetDetectionName(language, mode);
         var recName = GetRecName(language, mode);
         _batchProgress = progress;
@@ -877,56 +904,6 @@ public partial class PaddleOcr
         return result;
     }
 
-    private string MakeRecPrefix(string language)
-    {
-        var recFilePrefix = language;
-        if (LatinLanguageCodes.Contains(language))
-        {
-            recFilePrefix = $"latin{Path.DirectorySeparatorChar}latin_PP-OCRv3_rec_infer";
-        }
-        else if (ArabicLanguageCodes.Contains(language))
-        {
-            recFilePrefix = $"arabic{Path.DirectorySeparatorChar}arabic_PP-OCRv4_rec_infer";
-        }
-        else if (CyrillicLanguageCodes.Contains(language))
-        {
-            recFilePrefix = $"cyrillic{Path.DirectorySeparatorChar}cyrillic_PP-OCRv3_rec_infer";
-        }
-        else if (DevanagariLanguageCodes.Contains(language))
-        {
-            recFilePrefix = $"devanagari{Path.DirectorySeparatorChar}devanagari_PP-OCRv4_rec_infer";
-        }
-        else if (language == "chinese_cht")
-        {
-            recFilePrefix = $"{language}{Path.DirectorySeparatorChar}{language}_PP-OCRv3_rec_infer";
-        }
-        else
-        {
-            recFilePrefix = $"{language}{Path.DirectorySeparatorChar}{language}_PP-OCRv4_rec_infer";
-        }
-
-        return recFilePrefix;
-    }
-
-    private static string MakeDetPrefix(string language)
-    {
-        var detFilePrefix = language;
-        if (language != "en" && language != "ch")
-        {
-            detFilePrefix = $"ml{Path.DirectorySeparatorChar}Multilingual_PP-OCRv3_det_infer";
-        }
-        else if (language == "ch")
-        {
-            detFilePrefix = $"{language}{Path.DirectorySeparatorChar}{language}_PP-OCRv4_det_infer";
-        }
-        else
-        {
-            detFilePrefix = $"{language}{Path.DirectorySeparatorChar}{language}_PP-OCRv3_det_infer";
-        }
-
-        return detFilePrefix;
-    }
-
     public static SKBitmap AddBorder(SKBitmap originalBitmap, int borderWidth, SKColor color)
     {
         // Calculate new dimensions
@@ -1093,11 +1070,15 @@ public partial class PaddleOcr
     }
 
 
+    // Every language PaddleOCR 3.4 supports with a recognition model that ships in the
+    // bundled support files. Adding a code here is enough to offer it - as long as the
+    // code is also listed in the matching script group above, so GetRecName picks the
+    // right model (PaddleOcrLanguageMappingTests guards that).
     public static List<OcrLanguage2> GetLanguages()
     {
         return new List<OcrLanguage2>
         {
-            new("abq", "Abkhazian"),
+            new("abq", "Abaza"),
             new("ady", "Adyghe"),
             new("af", "Afrikaans"),
             new("sq", "Albanian"),
@@ -1105,13 +1086,20 @@ public partial class PaddleOcr
             new("ar", "Arabic"),
             new("ava", "Avar"),
             new("az", "Azerbaijani"),
+            new("bal", "Balochi"),
+            new("ba", "Bashkir"),
+            new("eu", "Basque"),
             new("be", "Belarusian"),
             new("bho", "Bhojpuri"),
             new("bh", "Bihari"),
             new("bs", "Bosnian"),
             new("bg", "Bulgarian"),
+            new("bua", "Buriat"),
+            new("ca", "Catalan"),
+            new("che", "Chechen"),
             new("ch", "Chinese and English"),
             new("chinese_cht", "Chinese traditional"),
+            new("cv", "Chuvash"),
             new("hr", "Croatian"),
             new("cs", "Czech"),
             new("da", "Danish"),
@@ -1119,36 +1107,66 @@ public partial class PaddleOcr
             new("nl", "Dutch"),
             new("en", "English"),
             new("et", "Estonian"),
+            new("fi", "Finnish"),
             new("fr", "French"),
-            new("german", "German"),
+            new("gl", "Galician"),
+            new("ka", "Georgian"),
+            new("de", "German"),
+            new("el", "Greek"),
+            new("bgc", "Haryanvi"),
+            new("hi", "Hindi"),
+            new("hu", "Hungarian"),
+            new("is", "Icelandic"),
+            new("id", "Indonesian"),
+            new("inh", "Ingush"),
+            new("ga", "Irish"),
+            new("it", "Italian"),
             new("japan", "Japanese"),
             new("kbd", "Kabardian"),
+            new("xal", "Kalmyk"),
+            new("kaa", "Karakalpak"),
+            new("kk", "Kazakh"),
+            new("kv", "Komi"),
+            new("gom", "Konkani"),
             new("korean", "Korean"),
             new("ku", "Kurdish"),
+            new("ky", "Kyrgyz"),
             new("lbe", "Lak"),
+            new("la", "Latin"),
             new("lv", "Latvian"),
             new("lez", "Lezghian"),
             new("lt", "Lithuanian"),
+            new("lb", "Luxembourgish"),
+            new("mk", "Macedonian"),
             new("mah", "Magahi"),
             new("mai", "Maithili"),
             new("ms", "Malay"),
             new("mt", "Maltese"),
             new("mi", "Maori"),
+            new("mhr", "Mari"),
             new("mr", "Marathi"),
+            new("mo", "Moldovan"),
             new("mn", "Mongolian"),
             new("sck", "Nagpur"),
             new("ne", "Nepali"),
             new("new", "Newari"),
             new("no", "Norwegian"),
             new("oc", "Occitan"),
+            new("os", "Ossetian"),
+            new("pi", "Pali"),
+            new("ps", "Pashto"),
             new("fa", "Persian"),
             new("pl", "Polish"),
             new("pt", "Portuguese"),
+            new("qu", "Quechua"),
             new("ro", "Romanian"),
+            new("rm", "Romansh"),
             new("ru", "Russian"),
+            new("sah", "Sakha"),
             new("sa", "Sanskrit"),
             new("rs_cyrillic", "Serbian (cyrillic)"),
             new("rs_latin", "Serbian (latin)"),
+            new("sd", "Sindhi"),
             new("sk", "Slovak"),
             new("sl", "Slovenian"),
             new("es", "Spanish"),
@@ -1156,9 +1174,14 @@ public partial class PaddleOcr
             new("sv", "Swedish"),
             new("tab", "Tabassaran"),
             new("tl", "Tagalog"),
+            new("tg", "Tajik"),
             new("ta", "Tamil"),
+            new("tt", "Tatar"),
             new("te", "Telugu"),
+            new("th", "Thai"),
             new("tr", "Turkish"),
+            new("tyv", "Tuvinian"),
+            new("udm", "Udmurt"),
             new("uk", "Ukrainian"),
             new("ur", "Urdu"),
             new("ug", "Uyghur"),
@@ -1167,4 +1190,17 @@ public partial class PaddleOcr
             new("cy", "Welsh"),
         }.OrderBy(p => p.Name).ToList();
     }
+
+    /// <summary>
+    /// Maps the legacy language codes the dropdown used to offer onto the ISO codes it
+    /// offers now, so an already saved setting still selects the same language. PaddleOCR
+    /// accepts both spellings, so only the stored value needs translating.
+    /// </summary>
+    public static string NormalizeLanguageCode(string? code) => code switch
+    {
+        "german" => "de",
+        "french" => "fr",
+        null => string.Empty,
+        _ => code,
+    };
 }

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -304,7 +304,10 @@ public partial class OcrViewModel : ObservableObject
             GoogleVisionApiKey = ocr.GoogleVisionApiKey;
             MistralApiKey = ocr.MistralApiKey;
             SelectedGoogleVisionLanguage = GoogleVisionLanguages.FirstOrDefault(p => p.Code == ocr.GoogleVisionLanguage);
-            SelectedPaddleOcrLanguage = PaddleOcrLanguages.FirstOrDefault(p => p.Code == Se.Settings.Ocr.PaddleOcrLastLanguage) ?? PaddleOcrLanguages.First();
+            var paddleOcrLastLanguage = PaddleOcr.NormalizeLanguageCode(Se.Settings.Ocr.PaddleOcrLastLanguage);
+            SelectedPaddleOcrLanguage = PaddleOcrLanguages.FirstOrDefault(p => p.Code == paddleOcrLastLanguage) ??
+                                        PaddleOcrLanguages.FirstOrDefault(p => p.Code == "en") ??
+                                        PaddleOcrLanguages.First();
             SelectedGoogleLensLanguage = GoogleLensLanguages.FirstOrDefault(p => p.Code == Se.Settings.Ocr.GoogleLensOcrLastLanguage) ?? GoogleLensLanguages.First();
             if (!string.IsNullOrEmpty(ocr.TextBoxFontName))
             {
@@ -4785,7 +4788,8 @@ public partial class OcrViewModel : ObservableObject
         {
             if (SelectedPaddleOcrLanguage == null)
             {
-                SelectedPaddleOcrLanguage = PaddleOcrLanguages.FirstOrDefault(p => p.Code == "eng") ??
+                SelectedPaddleOcrLanguage = PaddleOcrLanguages.FirstOrDefault(p => _sourceLanguageIso != null && p.Code == _sourceLanguageIso.TwoLetterCode) ??
+                                            PaddleOcrLanguages.FirstOrDefault(p => p.Code == "en") ??
                                             PaddleOcrLanguages.FirstOrDefault();
             }
         }

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
@@ -428,8 +428,10 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
 
         if (ocrEngine == "PaddleOCR")
         {
-            SelectedPaddleOcrLanguage = PaddleOcrLanguages
-                .FirstOrDefault(p => p.Code == Se.Settings.Tools.BatchConvert.PaddleLanguage) ?? PaddleOcrLanguages.FirstOrDefault();
+            var paddleLanguage = PaddleOcr.NormalizeLanguageCode(Se.Settings.Tools.BatchConvert.PaddleLanguage);
+            SelectedPaddleOcrLanguage = PaddleOcrLanguages.FirstOrDefault(p => p.Code == paddleLanguage) ??
+                                        PaddleOcrLanguages.FirstOrDefault(p => p.Code == "en") ??
+                                        PaddleOcrLanguages.FirstOrDefault();
         }
 
         if (ocrEngine == "BinaryOcr")

--- a/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
@@ -971,7 +971,8 @@ public partial class VideoOcrViewModel : ObservableObject
         var settings = Se.Settings.Video.VideoOcr;
         SelectedEngine = Engines.FirstOrDefault(p => p.EngineType.ToString() == settings.Engine) ?? Engines[0];
         OnSelectedEngineChanged(SelectedEngine);
-        SelectedPaddleLanguage = PaddleLanguages.FirstOrDefault(p => p.Code == settings.PaddleLanguage) ??
+        var paddleLanguage = PaddleOcr.NormalizeLanguageCode(settings.PaddleLanguage);
+        SelectedPaddleLanguage = PaddleLanguages.FirstOrDefault(p => p.Code == paddleLanguage) ??
                                  PaddleLanguages.FirstOrDefault(p => p.Code == "en");
         OllamaUrl = settings.OllamaUrl;
         OllamaModel = settings.OllamaModel;

--- a/tests/UI/Features/Ocr/Engines/PaddleOcrLanguageMappingTests.cs
+++ b/tests/UI/Features/Ocr/Engines/PaddleOcrLanguageMappingTests.cs
@@ -1,0 +1,119 @@
+using System.Collections.Generic;
+using System.Linq;
+using Nikse.SubtitleEdit.Features.Ocr;
+
+namespace UITests.Features.Ocr.Engines;
+
+/// <summary>
+/// Guards the Paddle OCR language dropdown against the two ways it can go wrong:
+/// offering a language whose recognition/detection model is not on disk, and offering a
+/// language that no script group claims - which silently OCRs it with the Latin model.
+/// </summary>
+public class PaddleOcrLanguageMappingTests
+{
+    // Model folders shipped in "PaddleOCR.PP-OCRv5.support.files" (standalone v1.4.0),
+    // which is the only model source - nothing is downloaded per language.
+    private static readonly HashSet<string> BundledRecModels = new()
+    {
+        "PP-OCRv5_mobile_rec",
+        "PP-OCRv5_server_rec",
+        "arabic_PP-OCRv5_mobile_rec",
+        "cyrillic_PP-OCRv5_mobile_rec",
+        "devanagari_PP-OCRv5_mobile_rec",
+        "el_PP-OCRv5_mobile_rec",
+        "en_PP-OCRv5_mobile_rec",
+        "eslav_PP-OCRv5_mobile_rec",
+        "ka_PP-OCRv3_mobile_rec",
+        "korean_PP-OCRv5_mobile_rec",
+        "latin_PP-OCRv5_mobile_rec",
+        "ta_PP-OCRv5_mobile_rec",
+        "te_PP-OCRv5_mobile_rec",
+        "th_PP-OCRv5_mobile_rec",
+    };
+
+    private static readonly HashSet<string> BundledDetModels = new()
+    {
+        "PP-OCRv3_mobile_det",
+        "PP-OCRv5_mobile_det",
+        "PP-OCRv5_server_det",
+    };
+
+    public static TheoryData<string, string> LanguageAndMode()
+    {
+        var data = new TheoryData<string, string>();
+        foreach (var language in PaddleOcr.GetLanguages())
+        {
+            data.Add(language.Code, "mobile");
+            data.Add(language.Code, "server");
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(LanguageAndMode))]
+    public void EveryOfferedLanguage_MapsToBundledModels(string code, string mode)
+    {
+        Assert.Contains(PaddleOcr.GetRecName(code, mode), BundledRecModels);
+        Assert.Contains(PaddleOcr.GetDetectionName(code, mode), BundledDetModels);
+    }
+
+    [Theory]
+    [MemberData(nameof(LanguageAndMode))]
+    public void OnlyLatinLanguages_UseTheLatinModel(string code, string mode)
+    {
+        var isLatinCode = PaddleOcr.GetLatinLanguageCodesForTest().Contains(code);
+
+        // A code missing from every script group falls through to the Latin model, so
+        // "uses latin" and "is a Latin language" must be the same set.
+        Assert.Equal(isLatinCode, PaddleOcr.GetRecName(code, mode) == "latin_PP-OCRv5_mobile_rec");
+    }
+
+    [Fact]
+    public void OfferedLanguages_HaveNoDuplicateCodesOrNames()
+    {
+        var languages = PaddleOcr.GetLanguages();
+
+        Assert.Empty(languages.GroupBy(p => p.Code).Where(g => g.Count() > 1).Select(g => g.Key));
+        Assert.Empty(languages.GroupBy(p => p.Name).Where(g => g.Count() > 1).Select(g => g.Key));
+    }
+
+    [Fact]
+    public void OfferedLanguages_CoverEveryLanguageInTheScriptGroups()
+    {
+        var offered = PaddleOcr.GetLanguages().Select(p => p.Code).ToHashSet();
+
+        // PaddleOCR accepts both "fr"/"french" and "de"/"german" for French and German. The
+        // dropdown offers the ISO code, so the two legacy aliases are expected to be absent
+        // from it - NormalizeLanguageCode maps them onto the offered codes.
+        var aliases = new[] { "french", "german" };
+        var missing = PaddleOcr.GetAllScriptGroupCodesForTest()
+            .Where(p => !aliases.Contains(p))
+            .Where(p => !offered.Contains(p))
+            .OrderBy(p => p)
+            .ToList();
+
+        Assert.Empty(missing);
+    }
+
+    [Theory]
+    [InlineData("german", "de")]
+    [InlineData("french", "fr")]
+    public void LegacySavedCode_SelectsTheSameLanguage(string savedCode, string expectedCode)
+    {
+        var normalized = PaddleOcr.NormalizeLanguageCode(savedCode);
+
+        Assert.Equal(expectedCode, normalized);
+        Assert.Contains(normalized, PaddleOcr.GetLanguages().Select(p => p.Code));
+    }
+
+    [Theory]
+    [InlineData("it")]
+    [InlineData("en")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void NormalizeLanguageCode_LeavesEverythingElseAlone(string? code)
+    {
+        Assert.Equal(code ?? string.Empty, PaddleOcr.NormalizeLanguageCode(code));
+    }
+}


### PR DESCRIPTION
Fixes #13406 — Italian was missing from the Paddle OCR language dropdown.

## Why Italian was missing

The dropdown is built from `PaddleOcr.GetLanguages()`, a hand-maintained PaddleOCR 2.x-era subset. `"it"` was never added to it, even though it was already in `LatinLanguageCodes` and resolves to `latin_PP-OCRv5_mobile_rec` — the same model French, Spanish and Portuguese already use, and one that already ships in the support files. So it needed no download; it was purely a list omission.

Eleven more languages were in the same position: **Hindi**, Hungarian, Indonesian, Icelandic, Irish, Latin, Pali, Konkani, Haryanvi, Chechen and Ingush.

## What this changes

**The list goes 68 → 110 languages**, covering every language PaddleOCR 3.4 supports with a recognition model that is actually on disk:

- the twelve above, including Italian
- **Thai, Greek and Georgian** — their models shipped in the bundle but were unreachable
- the languages PP-OCRv5 added to the script groups: `fi eu gl lb rm ca qu` (Latin), `ps sd bal` (Arabic), and 17 Cyrillic (`kk ky tg mk tt cv ba mhr mo udm kv os bua xal tyv sah kaa`)
- `abq` relabelled **Abaza** (Abkhaz is `ab`; the 2.x docs confirm `abq` = Abaza)

The codes come from `LATIN_LANGS`/`ARABIC_LANGS`/`ESLAV_LANGS`/`CYRILLIC_LANGS`/`DEVANAGARI_LANGS` in PaddleOCR 3.4.0's `paddleocr/_pipelines/ocr.py` — the version standalone v1.4.0 is built from — not the docs table, which spells several codes differently (`ab`/`av`/`lki` vs the code's `abq`/`ava`/`lbe`).

## Two model-mapping bugs found on the way

I listed the shipped bundle (`PaddleOCR.PP-OCRv5.support.files.VideOCR.tar.xz`, v1.4.0) to check what is actually available. It carries exactly 14 recognition models — `PP-OCRv5_mobile_rec`, `PP-OCRv5_server_rec`, `arabic`/`cyrillic`/`devanagari`/`el`/`en`/`eslav`/`korean`/`latin`/`ta`/`te`/`th_PP-OCRv5_mobile_rec` and `ka_PP-OCRv3_mobile_rec` — and 3 detection models. That surfaced:

1. **Arabic, Cyrillic and Devanagari pointed at models that do not exist.** `GetRecName` returned `arabic_PP-OCRv3_mobile_rec`, `cyrillic_PP-OCRv3_mobile_rec` and `devanagari_PP-OCRv3_mobile_rec`, but the bundle only carries the PP-OCRv5 variants of those three. Since we pass `--text_recognition_model_dir` explicitly, PaddleX reads `<dir>/inference.yml` and the run fails rather than falling back — so Arabic, Persian, Urdu, Uyghur, Serbian (cyrillic), Bulgarian, Mongolian, Marathi, Nepali, Sanskrit and friends could not OCR at all. (Russian/Belarusian/Ukrainian escaped it — they route to `eslav_PP-OCRv5`, which is bundled.)
2. **Tamil and Telugu were offered but belonged to no script group**, so they fell through to the Latin model and OCR'd to garbage — while `ta_PP-OCRv5_mobile_rec` and `te_PP-OCRv5_mobile_rec` sat unused on disk.

Detection now follows recognition: PP-OCRv5 for everything, except Georgian which has no PP-OCRv5 recognition model yet and keeps `PP-OCRv3_mobile_det`.

## Two smaller fixes that fell out

- **German's code becomes `de`.** Source-language autodetect matches the ISO two-letter code, so the old `german` could never be auto-selected. `PaddleOcr.NormalizeLanguageCode` maps the legacy `german`/`french` values in existing settings onto the offered codes, so nobody's saved selection changes (PaddleOCR accepts both spellings anyway).
- **The no-selection fallback looked up `"eng"`**, which matches no Paddle code, so it silently landed on whatever sorted first alphabetically. It now prefers the detected source language, then English.

Also drops `MakeRecPrefix`/`MakeDetPrefix`, whose results have been assigned and ignored since the move to explicit model dirs.

## Testing

New `PaddleOcrLanguageMappingTests` asserts, for all 110 languages × both mobile/server modes, that the resolved recognition **and** detection model names are in the bundled sets, and that "uses the Latin model" and "is a Latin language" are the same set — that second assertion is what catches the Tamil/Telugu class of bug. Plus coverage for the legacy-code normalization and for duplicate codes/names.

Full UI suite: **2235 passed, 0 failed**.

Not touched here: `en` still uses `PP-OCRv5_{mode}_rec` rather than upstream's `en_PP-OCRv5_mobile_rec` (both ship; no reason to change English behavior in this PR), and the DI-registered-but-never-resolved `PaddleOcrDownloadService` with its stale v1.3.x URLs is dead code for a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
