### PR TITLE
Fix #13405: enforce modal foreground for the dialog's whole lifetime

### DIFF
--- a/src/ui/Features/Assa/AssaDraw/AssaDrawViewModel.cs
+++ b/src/ui/Features/Assa/AssaDraw/AssaDrawViewModel.cs
@@ -479,7 +479,7 @@ public partial class AssaDrawViewModel : ObservableObject
 
         var vm = new PickLayerViewModel { Layer = currentLayer };
         var pickLayerWindow = new PickLayerWindow(vm);
-        await pickLayerWindow.ShowDialog(Window);
+        await WindowService.ShowModalAsync(Window, pickLayerWindow);
 
         if (!vm.OkPressed || vm.Layer == currentLayer)
         {

--- a/src/ui/Features/Assa/AssaStylesWindow.cs
+++ b/src/ui/Features/Assa/AssaStylesWindow.cs
@@ -710,7 +710,7 @@ public class AssaStylesWindow : Window
             var pickerVm = new ColorPickerViewModel();
             pickerVm.Initialize(currentColor);
             var pickerWindow = new ColorPickerWindow(pickerVm);
-            await pickerWindow.ShowDialog(window);
+            await WindowService.ShowModalAsync(window, pickerWindow);
 
             if (pickerVm.OkPressed)
             {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -21822,6 +21822,15 @@ public partial class MainViewModel :
                 return;
             }
 
+            if (WindowService.IsModalDialogOpen)
+            {
+                // A modal dialog is open, so this window is input-disabled and must not pull
+                // keyboard focus back to itself - that is exactly the "dialog drawn on top but
+                // keys land in the main window" state of #13405. WindowService's modal
+                // foreground enforcement hands activation to the dialog instead.
+                return;
+            }
+
             if (GetRestorableFocusedControl() != null)
             {
                 return; // focus landed somewhere real (e.g. the user clicked a control) - leave it

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrInspectViewModel.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrInspectViewModel.cs
@@ -262,7 +262,7 @@ public partial class BinaryOcrInspectViewModel : ObservableObject
         addVm.Initialize(_nBmp, _ocrSubtitleItem, _letters, LetterIndex, _db, _maxWrongPixels,
             _binaryOcrAddHistoryManager, false, false);
         var addWindow = new BinaryOcrCharacterAddWindow(addVm);
-        await addWindow.ShowDialog(Window!);
+        await WindowService.ShowModalAsync(Window!, addWindow);
 
         if (addVm.OkPressed && addVm.BinaryOcrBitmap != null)
         {

--- a/src/ui/Features/Ocr/NOcr/NOcrInspectViewModel.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrInspectViewModel.cs
@@ -289,7 +289,7 @@ public partial class NOcrInspectViewModel : ObservableObject
         addVm.ShowAbort = false;
         addVm.ShowCancel = true;
         var addWindow = new NOcrCharacterAddWindow(addVm);
-        await addWindow.ShowDialog(Window!);
+        await WindowService.ShowModalAsync(Window!, addWindow);
 
         if (addVm.OkPressed)
         {
@@ -304,7 +304,7 @@ public partial class NOcrInspectViewModel : ObservableObject
             var historyVm = new NOcrCharacterHistoryViewModel();
             historyVm.Initialize(_nOcrDb, _nOcrAddHistoryManager);
             var historyWindow = new NOcrCharacterHistoryWindow(historyVm);
-            await historyWindow.ShowDialog(Window!);
+            await WindowService.ShowModalAsync(Window!, historyWindow);
         }
     }
 

--- a/src/ui/Features/Options/Settings/WaveformThemes/WaveformThemesViewModel.cs
+++ b/src/ui/Features/Options/Settings/WaveformThemes/WaveformThemesViewModel.cs
@@ -124,7 +124,7 @@ public partial class WaveformThemesViewModel : ObservableObject
         var vm = new PromptTextBoxViewModel();
         vm.Initialize("Save custom theme", $"Custom {_customThemeCount}", 200, 30, returnSubmits: true);
         var promptWindow = new PromptTextBoxWindow(vm);
-        await promptWindow.ShowDialog(Window);
+        await WindowService.ShowModalAsync(Window, promptWindow);
 
         if (!vm.OkPressed || string.IsNullOrWhiteSpace(vm.Text))
         {

--- a/src/ui/Features/Options/Settings/WaveformThemes/WaveformThemesWindow.cs
+++ b/src/ui/Features/Options/Settings/WaveformThemes/WaveformThemesWindow.cs
@@ -172,7 +172,7 @@ public class WaveformThemesWindow : Window
             var pickerVm = new ColorPickerViewModel();
             pickerVm.Initialize(currentColor);
             var pickerWindow = new ColorPickerWindow(pickerVm);
-            await pickerWindow.ShowDialog(window);
+            await WindowService.ShowModalAsync(window, pickerWindow);
 
             if (pickerVm.OkPressed)
             {

--- a/src/ui/Features/Shared/MessageBox.cs
+++ b/src/ui/Features/Shared/MessageBox.cs
@@ -376,18 +376,11 @@ public class MessageBox : Window
     {
         var msgBox = new MessageBox(title, message, buttons, icon, custom1, custom2, custom3, custom4);
 
-        // Keep the message box above undocked tool windows (audio visualizer / video player),
-        // which float on top of the main window via KeepTopmostWhileOwnerActive. Without this the
-        // message box opens behind them in undocked mode. (#12268)
-        WindowService.KeepTopmostWhileOwnerActive(msgBox, owner);
-
-        // Drop the undocked windows' topmost for the dialog's lifetime and make sure the
-        // message box really gets OS activation - without this it was drawn on top but never
-        // activated on Windows in undocked mode: gray buttons, no keyboard focus (#13325).
-        using var undockedSuspension = WindowService.SuspendUndockedTopmost();
-        WindowService.ActivateWhenOpened(msgBox);
-
-        return await msgBox.ShowDialog<MessageBoxResult>(owner);
+        // The shared modal plumbing: kept above the undocked tool windows (#12268), undocked
+        // topmost suspended, and OS activation enforced while open - without the latter the box
+        // was drawn on top but never activated on Windows in undocked mode: gray buttons, no
+        // keyboard focus (#13325/#13405).
+        return await WindowService.ShowModalAsync<MessageBoxResult>(owner, msgBox);
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Ssa/SsaStylesWindow.cs
+++ b/src/ui/Features/Ssa/SsaStylesWindow.cs
@@ -674,7 +674,7 @@ public class SsaStylesWindow : Window
             };
             pickerVm.Initialize(SsaStylesViewModel.WithoutAlpha(currentColor));
             var pickerWindow = new ColorPickerWindow(pickerVm);
-            await pickerWindow.ShowDialog(window);
+            await WindowService.ShowModalAsync(window, pickerWindow);
 
             if (pickerVm.OkPressed)
             {

--- a/src/ui/Features/WebVtt/WebVttStylesWindow.cs
+++ b/src/ui/Features/WebVtt/WebVttStylesWindow.cs
@@ -418,7 +418,7 @@ public class WebVttStylesWindow : Window
             var pickerVm = new ColorPickerViewModel();
             pickerVm.Initialize(currentColor);
             var pickerWindow = new ColorPickerWindow(pickerVm);
-            await pickerWindow.ShowDialog(window);
+            await WindowService.ShowModalAsync(window, pickerWindow);
 
             if (pickerVm.OkPressed)
             {

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -2308,7 +2308,7 @@ public static class UiUtil
             vm.Initialize(currentColor);
             vm.ShowAlpha = showAlpha;
             var pickerWindow = new ColorPickerWindow(vm);
-            await pickerWindow.ShowDialog(window);
+            await WindowService.ShowModalAsync(window, pickerWindow);
 
             if (vm.OkPressed)
             {

--- a/src/ui/Logic/WindowsService.cs
+++ b/src/ui/Logic/WindowsService.cs
@@ -167,18 +167,7 @@ namespace Nikse.SubtitleEdit.Logic
             ApplyRightToLeftSettings(window);
             UiTheme.ApplyScaleToWindow(window);
 
-            // Keep the dialog above undocked tool windows (audio visualizer / video player), which
-            // float on top of the main window via the same helper. Without this the dialog opens
-            // behind them in undocked mode. (#11971)
-            KeepTopmostWhileOwnerActive(window, owner);
-
-            // Drop the undocked windows' topmost for the dialog's lifetime and make sure the
-            // dialog really gets OS activation, not just top-of-z-order drawing (#13325).
-            using var undockedSuspension = SuspendUndockedTopmost();
-            ActivateWhenOpened(window);
-
-            await YieldForPendingFlyoutDismissAsync();
-            await window.ShowDialog(owner);
+            await ShowModalAsync(owner, window);
 
             return window;
         }
@@ -207,20 +196,56 @@ namespace Nikse.SubtitleEdit.Logic
             ApplyRightToLeftSettings(window);
             UiTheme.ApplyScaleToWindow(window);
 
+            await ShowModalAsync(owner, window);
+
+            return viewModel;
+        }
+
+        /// <summary>
+        /// Shows an already-constructed window as a modal dialog with the shared foreground
+        /// handling every modal in SE needs: kept above the undocked tool windows (#11971),
+        /// undocked topmost suspended for its lifetime (#13325), and foreground enforced while it
+        /// is open (#13405). Use this instead of calling <see cref="Window.ShowDialog(Window)"/>
+        /// directly - a bare ShowDialog is how dialogs end up drawn on top but never activated.
+        /// </summary>
+        public static Task ShowModalAsync(Window owner, Window dialog)
+        {
+            return RunModalAsync(owner, dialog, () => dialog.ShowDialog(owner));
+        }
+
+        /// <summary>
+        /// Same as <see cref="ShowModalAsync(Window, Window)"/> for dialogs closed with a result.
+        /// </summary>
+        public static async Task<TResult> ShowModalAsync<TResult>(Window owner, Window dialog)
+        {
+            TResult result = default!;
+            await RunModalAsync(owner, dialog, async () => result = await dialog.ShowDialog<TResult>(owner));
+            return result;
+        }
+
+        private static async Task RunModalAsync(Window owner, Window dialog, Func<Task> showDialog)
+        {
             // Keep the dialog above undocked tool windows (audio visualizer / video player), which
             // float on top of the main window via the same helper. Without this the dialog opens
             // behind them in undocked mode. (#11971)
-            KeepTopmostWhileOwnerActive(window, owner);
+            KeepTopmostWhileOwnerActive(dialog, owner);
 
-            // Drop the undocked windows' topmost for the dialog's lifetime and make sure the
-            // dialog really gets OS activation, not just top-of-z-order drawing (#13325).
+            // Drop the undocked windows' topmost for the dialog's lifetime and keep OS activation
+            // on the dialog, not just top-of-z-order drawing (#13325/#13405).
             using var undockedSuspension = SuspendUndockedTopmost();
-            ActivateWhenOpened(window);
+            var foregroundEnforcement = EnforceModalForegroundWhileOpen(dialog, owner);
 
-            await YieldForPendingFlyoutDismissAsync();
-            await window.ShowDialog(owner);
-
-            return viewModel;
+            _openModalCount++;
+            try
+            {
+                await YieldForPendingFlyoutDismissAsync();
+                await showDialog();
+            }
+            finally
+            {
+                _openModalCount--;
+                foregroundEnforcement.Dispose();
+            }
         }
 
         // When a dialog is launched from a context menu item, the command runs synchronously while the
@@ -326,22 +351,108 @@ namespace Nikse.SubtitleEdit.Logic
             };
         }
 
+        // Every open modal shown through this service (dialogs and message boxes) counts here.
+        // While a modal is open its owner is input-disabled, so any code path that would give the
+        // owner keyboard focus is wrong by definition - the main window consults this before
+        // pulling the caret back on re-activation (#13405).
+        private static int _openModalCount;
+
         /// <summary>
-        /// Explicitly activates <paramref name="window"/> once it has opened, in case the OS
-        /// left foreground/keyboard focus on another window during the open (seen on Windows in
-        /// undocked mode, where the dialog was drawn on top but never activated - gray buttons,
-        /// no keyboard focus - #13325). Posted at Background priority so pending activation and
-        /// topmost changes settle first; a no-op when the window is already active.
+        /// True while any modal dialog shown through <see cref="ShowModalAsync(Window, Window)"/>
+        /// (which includes every ShowDialogAsync call and <see cref="Features.Shared.MessageBox"/>)
+        /// is open.
         /// </summary>
-        public static void ActivateWhenOpened(Window window)
+        public static bool IsModalDialogOpen => _openModalCount > 0;
+
+        /// <summary>
+        /// Test hook: clears the open-modal count left behind by tests that tore a dialog down
+        /// without completing its ShowDialog task.
+        /// </summary>
+        internal static void ResetOpenModalsForTests()
         {
-            window.Opened += (_, _) => Dispatcher.UIThread.Post(() =>
+            _openModalCount = 0;
+        }
+
+        /// <summary>
+        /// Keeps OS activation on <paramref name="dialog"/> for as long as it is open.
+        ///
+        /// A modal's owner is input-disabled, yet Windows happily leaves (or puts) keyboard focus
+        /// on it: the open-time topmost churn in undocked mode (#13325), a rebuild of the undocked
+        /// windows (#13398), or a modal opening right as the previous one closes (#13405) all end
+        /// in the same state - the dialog drawn on top, gray buttons, and every key landing in the
+        /// window underneath. A one-shot activation at open time only wins when the steal has
+        /// already happened, so instead enforce the invariant for the dialog's lifetime: whenever
+        /// the owner ends up active while the dialog is open, hand activation to the dialog. The
+        /// owner.IsActive guard scopes this to the unambiguously broken state - it never yanks
+        /// foreground from other applications or from the (independent, enabled) undocked tool
+        /// windows.
+        /// </summary>
+        private static IDisposable EnforceModalForegroundWhileOpen(Window dialog, Window owner)
+        {
+            var disposed = false;
+
+            void BounceToDialog()
             {
-                if (window.IsVisible && !window.IsActive)
+                if (!disposed && owner.IsActive && !dialog.IsActive && !dialog.IsClosing())
                 {
-                    window.Activate();
+                    dialog.Activate();
                 }
-            }, DispatcherPriority.Background);
+            }
+
+            void OnActivationChanged(object? sender, EventArgs e)
+            {
+                // Deferred so IsActive has settled on both windows (Deactivated of one window can
+                // fire before Activated of the other).
+                Dispatcher.UIThread.Post(BounceToDialog, DispatcherPriority.Background);
+            }
+
+            void OnOpened(object? sender, EventArgs e)
+            {
+                // The unconditional one-shot from #13325: when no SE window kept activation (the
+                // user is in another application), Activate() still requests attention there.
+                Dispatcher.UIThread.Post(() =>
+                {
+                    if (!disposed && dialog.IsVisible && !dialog.IsActive)
+                    {
+                        dialog.Activate();
+                    }
+                }, DispatcherPriority.Background);
+
+                // The open-time churn can leave the dialog inactive without any activation event
+                // ever firing afterwards (the owner never lost activation, so nothing changes) -
+                // re-check on short timers as well. Guarded by owner.IsActive, so they are no-ops
+                // in every healthy state.
+                DispatcherTimer.RunOnce(BounceToDialog, TimeSpan.FromMilliseconds(150));
+                DispatcherTimer.RunOnce(BounceToDialog, TimeSpan.FromMilliseconds(450));
+            }
+
+            owner.Activated += OnActivationChanged;
+            dialog.Deactivated += OnActivationChanged;
+            dialog.Opened += OnOpened;
+
+            return new ActionDisposable(() =>
+            {
+                disposed = true;
+                owner.Activated -= OnActivationChanged;
+                dialog.Deactivated -= OnActivationChanged;
+                dialog.Opened -= OnOpened;
+            });
+        }
+
+        private sealed class ActionDisposable : IDisposable
+        {
+            private Action? _dispose;
+
+            public ActionDisposable(Action dispose)
+            {
+                _dispose = dispose;
+            }
+
+            public void Dispose()
+            {
+                _dispose?.Invoke();
+                _dispose = null;
+            }
         }
 
         /// <summary>

--- a/tests/UI/Logic/ModalForegroundEnforcementTests.cs
+++ b/tests/UI/Logic/ModalForegroundEnforcementTests.cs
@@ -1,0 +1,158 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+// A modal dialog's owner is input-disabled, yet keyboard focus kept ending up on it - the
+// dialog drawn on top with gray buttons while every key landed in the window underneath
+// (#13325/#13398/#13405). WindowService.ShowModalAsync enforces the invariant for the
+// dialog's whole lifetime: whenever the owner ends up active while the dialog is open,
+// activation is handed back to the dialog. These tests drive the platform activation
+// callbacks directly to simulate the OS foreground churn that steals activation.
+public class ModalForegroundEnforcementTests : IDisposable
+{
+    public ModalForegroundEnforcementTests()
+    {
+        WindowService.ResetUndockedTopmostSuspensionsForTests();
+        WindowService.ResetOpenModalsForTests();
+    }
+
+    public void Dispose()
+    {
+        WindowService.RegisterUndockedTopmostSetter(null);
+        WindowService.ResetUndockedTopmostSuspensionsForTests();
+        WindowService.ResetOpenModalsForTests();
+    }
+
+    // Raises the same platform callbacks the OS raises when it moves foreground between two
+    // windows - Deactivated of the loser can fire before Activated of the winner, which is
+    // the order the enforcement has to cope with. The callback properties' accessors are
+    // internal to Avalonia, so go through reflection.
+    private static void RaisePlatformEvent(Window window, string callbackName)
+    {
+        var impl = window.PlatformImpl;
+        var property = impl?.GetType()
+            .GetProperties(System.Reflection.BindingFlags.Instance |
+                           System.Reflection.BindingFlags.Public |
+                           System.Reflection.BindingFlags.NonPublic)
+            .FirstOrDefault(p => p.Name == callbackName || p.Name.EndsWith("." + callbackName));
+        Assert.NotNull(property);
+
+        (property.GetValue(impl) as Action)?.Invoke();
+    }
+
+    private static void SimulateOsForegroundMove(Window from, Window to)
+    {
+        RaisePlatformEvent(from, "Deactivated");
+        RaisePlatformEvent(to, "Activated");
+    }
+
+    private static (Window Owner, Window Dialog, Task DialogTask) OpenModal()
+    {
+        var owner = new Window();
+        owner.Show();
+
+        var dialog = new Window();
+        var dialogTask = WindowService.ShowModalAsync(owner, dialog);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(dialog.IsVisible);
+        return (owner, dialog, dialogTask);
+    }
+
+    [AvaloniaFact]
+    public void IsModalDialogOpen_TracksTheDialogLifetime()
+    {
+        Assert.False(WindowService.IsModalDialogOpen);
+
+        var (_, dialog, dialogTask) = OpenModal();
+        Assert.True(WindowService.IsModalDialogOpen);
+
+        dialog.Close();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(dialogTask.IsCompletedSuccessfully);
+        Assert.False(WindowService.IsModalDialogOpen);
+    }
+
+    [AvaloniaFact]
+    public void ShowModalAsyncWithResult_ReturnsTheDialogResult()
+    {
+        var owner = new Window();
+        owner.Show();
+
+        var dialog = new Window();
+        var dialogTask = WindowService.ShowModalAsync<string>(owner, dialog);
+        Dispatcher.UIThread.RunJobs();
+
+        dialog.Close("the result");
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(dialogTask.IsCompletedSuccessfully);
+        Assert.Equal("the result", dialogTask.Result);
+        Assert.False(WindowService.IsModalDialogOpen);
+    }
+
+    [AvaloniaFact]
+    public void OwnerActivatedWhileModalIsOpen_HandsActivationBackToTheDialog()
+    {
+        var (owner, dialog, _) = OpenModal();
+        Assert.True(dialog.IsActive);
+
+        // The churn: the OS puts foreground on the input-disabled owner (#13405).
+        SimulateOsForegroundMove(from: dialog, to: owner);
+        Assert.False(dialog.IsActive);
+
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(dialog.IsActive);
+    }
+
+    [AvaloniaFact]
+    public void DialogDeactivatedToAnotherApplication_IsLeftAlone()
+    {
+        var (owner, dialog, _) = OpenModal();
+        RaisePlatformEvent(owner, "Deactivated");
+
+        // Foreground went to another application: no SE window is active, so the
+        // enforcement must not fight the user over it.
+        RaisePlatformEvent(dialog, "Deactivated");
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(dialog.IsActive);
+        Assert.False(owner.IsActive);
+    }
+
+    [AvaloniaFact]
+    public void EnforcementStops_WhenTheDialogCloses()
+    {
+        var (owner, dialog, dialogTask) = OpenModal();
+
+        dialog.Close();
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(dialogTask.IsCompletedSuccessfully);
+
+        // Re-activating the owner after the close must not touch the dead dialog.
+        RaisePlatformEvent(owner, "Activated");
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(dialog.IsActive);
+    }
+
+    [AvaloniaFact]
+    public void ShowModalAsync_SuspendsUndockedTopmostForTheDialogLifetime()
+    {
+        var calls = new List<bool>();
+        WindowService.RegisterUndockedTopmostSetter(calls.Add);
+
+        var (_, dialog, _) = OpenModal();
+        Assert.Equal([false], calls);
+
+        dialog.Close();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal([false, true], calls);
+    }
+}


### PR DESCRIPTION
Fixes #13405.

## The common failure state

All three reports in #13405 (Speech to text window, "No subtitle loaded" error box, the post-transcription "Open subtitle file?" prompt) are the same broken state: **a modal dialog is open while its input-disabled owner holds OS keyboard focus**. Windows' `WS_DISABLED` blocks mouse input but *not* keyboard delivery, so the owner keeps processing Tab/keys — which is exactly what the reporter observed under the dialog.

The existing defense (`ActivateWhenOpened`, #13325) was a **one-shot** `Activate()` posted right after open. Anything that churns activation after that single instant wins:

- the undocked-topmost flips at open time (this churn can leave the owner active with **no further activation event ever firing**, so nothing event-driven can heal it),
- a modal opening right as the previous one closes (the STT batch prompt, case 3),
- an undock rebuild taking foreground (#13398),
- and the #13371 caret restore, which — new in beta 8 — actively pulled keyboard focus back into the main window on re-activation (the "focus in the Duration box" in screenshot 5).

Each earlier fix targeted one churn source; hence the whack-a-mole.

## The fix: enforce the invariant continuously, in one place

- **`WindowService.ShowModalAsync(owner, dialog)`** is now the single modal chokepoint (keep-above-undocked #11971, topmost suspension #13325, foreground enforcement, open-modal count). Both `ShowDialogAsync` overloads, `MessageBox.Show`, and every formerly-bare `window.ShowDialog(owner)` call site (color pickers, NOcr/BinaryOcr character add, PickLayer, PromptTextBox) now route through it — those bare sites had none of the machinery and were the next moles.
- **`EnforceModalForegroundWhileOpen`**: for the dialog's whole lifetime, whenever the owner ends up active while the dialog is open (`owner.Activated` / `dialog.Deactivated`), activation is handed back to the dialog; plus 150/450 ms watchdog re-checks after open for the no-event steal. Guarded by `owner.IsActive`, so it never takes foreground from other applications or from the (independent, enabled) undocked tool windows.
- **`WindowService.IsModalDialogOpen`**: the #13371 caret restore in `MainViewModel.OnWindowActivated` now bails while a modal is open — the disabled owner must never pull keyboard focus back to itself.

## Tests

`tests/UI/Logic/ModalForegroundEnforcementTests.cs` simulates the OS foreground churn by raising the platform impl's activation callbacks, and pins: the bounce back to the dialog, the leave-other-apps-alone guard, enforcement ending at close, the modal count, and the suspension lifetime through `ShowModalAsync`. Full UI suite: 1793/1793 pass.

The Windows-specific halves (SetForegroundWindow timing, undocked churn) can't be verified headlessly — worth a manual check on Windows in undocked mode: Video → Text to speech with no subtitle, Video → Speech to text via keyboard menu navigation, and an STT batch run's completion prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)