### PR TITLE
Bump CrispEmbed to v0.17.7

### DIFF
--- a/src/ui/Features/Ocr/Engines/CrispEmbedOcr.cs
+++ b/src/ui/Features/Ocr/Engines/CrispEmbedOcr.cs
@@ -286,6 +286,13 @@ public class CrispEmbedOcr : IDisposable
             },
         };
 
+        // v0.17.7 made the PP-OCRv6 detector CUDA-resident, which left the scalar path everyone
+        // else runs (Metal, CPU) ~21% slower than v0.17.6 - measured over 12 interleaved A/B
+        // pairs on Apple Silicon, every pair slower. The release ships the recovery as an
+        // opt-in gate: with it on, the same corpus is back within ~4% of v0.17.6 and the text,
+        // region count and mean confidence are identical on all ten images (2026-08-09).
+        process.StartInfo.Environment["CRISPEMBED_CONV2D_MK"] = "1";
+
         process.Start();
 
         var stdOutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);

--- a/src/ui/Logic/Download/CrispEmbedDownloadService.cs
+++ b/src/ui/Logic/Download/CrispEmbedDownloadService.cs
@@ -21,18 +21,18 @@ public class CrispEmbedDownloadService : ICrispEmbedDownloadService
 {
     private readonly HttpClient _httpClient;
 
-    private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.6/crispembed-windows-x86_64-cuda.zip";
-    private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.6/crispembed-windows-x86_64-vulkan.zip";
-    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.6/crispembed-windows-x86_64.zip";
-    private const string MacUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.6/crispembed-macos-arm64.tar.gz";
-    private const string LinuxUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.6/crispembed-linux-x86_64.tar.gz";
+    private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.7/crispembed-windows-x86_64-cuda.zip";
+    private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.7/crispembed-windows-x86_64-vulkan.zip";
+    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.7/crispembed-windows-x86_64.zip";
+    private const string MacUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.7/crispembed-macos-arm64.tar.gz";
+    private const string LinuxUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.7/crispembed-linux-x86_64.tar.gz";
     // The plain "-cuda" archive expects a CUDA 12.x *toolkit* on the host (libcudart/libcublas),
     // not just a driver, and fails in the dynamic loader with exit code 127 when it is missing.
     // The "-bundled" variant ships those two libraries, so it runs with only an NVIDIA driver.
     // Note the CUDA archives keep a glibc 2.38 floor (they build outside the manylinux container
     // the CPU archives use, which lowered those to 2.27).
-    private const string LinuxCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.6/crispembed-linux-x86_64-cuda-bundled.tar.gz";
-    private const string LinuxArmUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.6/crispembed-linux-arm64.tar.gz";
+    private const string LinuxCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.7/crispembed-linux-x86_64-cuda-bundled.tar.gz";
+    private const string LinuxArmUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.7/crispembed-linux-arm64.tar.gz";
 
     public CrispEmbedDownloadService(HttpClient httpClient)
     {

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -747,7 +747,8 @@ public static class DownloadHashManager
             // otherwise users will be prompted to "update" to the same version they just got.
             [CrispEmbed.WindowsCuda] = new[]
             {
-                "b8c9355f5cdc318b84bcef50c293998d643ef0b0305215b6fc34213c43eaedb4", // v0.17.6 (current download URL)
+                "ff5d85824ecdbf2c29c4ed19f63024c94b963f3a7634e62f18140d9cb020ef8f", // v0.17.7 (current download URL)
+                "b8c9355f5cdc318b84bcef50c293998d643ef0b0305215b6fc34213c43eaedb4", // v0.17.6
                 "3cc05e2a8d166956cf56ed633b562b1df61f1c829ea3ea56468bfc287d3df18a", // v0.17.5
                 "62c67b9ee210ae39f46fc416faa7125a2db82b8766b2518924e1c1c2ee166466", // v0.17.2
                 "957cd0292caa2962927b78a64d897cf6a86404212e37e7907233f9c675a30ef1", // v0.17.0
@@ -757,7 +758,8 @@ public static class DownloadHashManager
             },
             [CrispEmbed.WindowsVulkan] = new[]
             {
-                "591edc9c91991df575f867f10b91d69166daa80eaf49f9b5a8bd80e0541c890c", // v0.17.6 (current download URL)
+                "7a9b6cc9190be3283aa7f72e8f9ab9e035530f02d766afe77ee091e027ac9970", // v0.17.7 (current download URL)
+                "591edc9c91991df575f867f10b91d69166daa80eaf49f9b5a8bd80e0541c890c", // v0.17.6
                 "8936580e143d6e0382e1ed44203800733627f1db8d9856f88df641c8319b11b1", // v0.17.5
                 "aad639f14bfb4202ade4140cd6d1505abd97b69cd0e00639158ac5ef7fe211bd", // v0.17.2
                 "4c25232b037291c8ff1ce6999de7cd669fe7a4d6ebed84735173dd458edb0250", // v0.17.0
@@ -767,7 +769,8 @@ public static class DownloadHashManager
             },
             [CrispEmbed.WindowsCpu] = new[]
             {
-                "bcb3c1b5c2b88fea34390fdcd5a0f4e9805024aa31d2a30ab2526e2d9e28b0e2", // v0.17.6 (current download URL)
+                "e7b7dbbcfe192462d7a4b1d25a903d2394eae83c1c8efb8b8270fe9b3ec90f2e", // v0.17.7 (current download URL)
+                "bcb3c1b5c2b88fea34390fdcd5a0f4e9805024aa31d2a30ab2526e2d9e28b0e2", // v0.17.6
                 "46a3c4dad9b6fe7bb96cb95d277435db8b2a5591481dd2bb99123156d0b7f5d2", // v0.17.5
                 "4e06b89a315a75f5aa495a88278039d4e89800f56b15f1ada4a99998da3020a3", // v0.17.2
                 "601f722b8fd01896ea4943f87099b5bc1f32177c6163cabfbd327e5a9866c0a0", // v0.17.0
@@ -777,7 +780,8 @@ public static class DownloadHashManager
             },
             [CrispEmbed.MacOs] = new[]
             {
-                "09291257a15ea766373ef0a96126590d5ff6d65184b8ce1e80c4172f3ad5e5bb", // v0.17.6 (current download URL)
+                "0718bfc35e44ed4acd9d2c8d4c20a4b5b4134af826178a362b08a8c9985e0d7d", // v0.17.7 (current download URL)
+                "09291257a15ea766373ef0a96126590d5ff6d65184b8ce1e80c4172f3ad5e5bb", // v0.17.6
                 "fe92b64bc4937f2fa60d3eb71c67774e47bc30678f4e6312ef82f0b1c9f1023b", // v0.17.5
                 "6b5f44da74da4a99bce41aaaa2ddb1f8905e60ec455d45780ba32d9d05f4d0f2", // v0.17.2
                 "4146cf85ab13bad1ebab0a9903022e8098dc5eafec4f844e2eeaa65a6ae069dc", // v0.17.0
@@ -787,7 +791,8 @@ public static class DownloadHashManager
             },
             [CrispEmbed.Linux] = new[]
             {
-                "df9e2308b670d92135e48629baa5eb6278db35aeab324b787ae155589d113918", // v0.17.6 (glibc 2.27 floor) (current download URL)
+                "a5bbcbeb321489cc6cec79ea81ae12a6a93a35fd097a1ef907cee0e33f8c10e0", // v0.17.7 (glibc 2.27 floor) (current download URL)
+                "df9e2308b670d92135e48629baa5eb6278db35aeab324b787ae155589d113918", // v0.17.6 (glibc 2.27 floor)
                 "43466635f2da9b5acd8d28346e1f4bb67dc1785c436211a15a67ff6b95e71796", // v0.17.5 (glibc 2.27 floor)
                 "149e3c3db4a2b5e8efad0396cf9382902f529e40be0ebca894ea1eeb92f8fb92", // v0.17.2
                 "61b4a47c471743665d6629e38babc3e7eb32ccffb79f35e99ce76da192c3d61e", // v0.17.0
@@ -797,7 +802,8 @@ public static class DownloadHashManager
             },
             [CrispEmbed.LinuxCuda] = new[]
             {
-                "337c7bf20b52eccd8d50159b8ca415224a9252aca3fbae53eb1ffea2432f5484", // v0.17.6 (bundled CUDA runtime) (current download URL)
+                "5639e562dde68730d4086c92366cdd2b95879164e5491096c1617e8ce88bd94f", // v0.17.7 (bundled CUDA runtime) (current download URL)
+                "337c7bf20b52eccd8d50159b8ca415224a9252aca3fbae53eb1ffea2432f5484", // v0.17.6 (bundled CUDA runtime)
                 "5aea8caf95ccf6b3bd6a782e5ce1a858dfd35d272d89128e66980174bf96fb0d", // v0.17.5 (bundled CUDA runtime)
                 "82be9b2546c741d236c96ee244f7264303f743dd62421f0a0391796aafd5237d", // v0.17.2 (bundled CUDA runtime)
                 "2d8b9c242c3c50fd8092ccde954d8540feefbcfc800f763b8a4a227b226c59d7", // v0.17.0
@@ -807,7 +813,8 @@ public static class DownloadHashManager
             },
             [CrispEmbed.LinuxArm] = new[]
             {
-                "90243108d6388bbb2780948a2dbe35a55b7f5670716fb5fb4f87576069f95427", // v0.17.6 (glibc 2.27 floor) (current download URL)
+                "9045e69e06fd9b456d3fbb4df37ec6cc0586e5eae74790e61b968d1befce5b07", // v0.17.7 (glibc 2.27 floor) (current download URL)
+                "90243108d6388bbb2780948a2dbe35a55b7f5670716fb5fb4f87576069f95427", // v0.17.6 (glibc 2.27 floor)
                 "5e40342a1e6017057f5012292a6ec206af56da35e47f57819ae7897379a971ef", // v0.17.5 (glibc 2.27 floor)
                 "088874ae9f79a8aec1bd1f16699bad18beb130693d69465fadccfe7751d6ca99", // v0.17.2
                 "77309c2ab93a01e255a806ba8d54be2854ee160b3e6bb0a85b11cd68e22093a9", // v0.17.0


### PR DESCRIPTION
Points the seven CrispEmbed download URLs at [v0.17.7](https://github.com/CrispStrobe/CrispEmbed/releases/tag/v0.17.7) and prepends the new archive hashes so the sidecar check does not offer an "update" to the version just installed.

### What in v0.17.7 reaches SE

- **GLM-OCR** had mRoPE applied to NEOX-style split-half pairs on weights trained with interleaved pairs; the fix is a load-time Q/K row permute. Upstream attributes both the thin-strip hallucination and the runaway repetition to it — which is exactly the shape of a subtitle bitmap. `glm_ocr` also moves off a bare argmax onto the shared no-repeat-ngram greedy guard.
- The **PP-OCRv6 detector** and three other engines silently discarded the `n_threads` they were handed and ran single-threaded.
- Large VLMs now **refuse to load rather than swap-thrash** the host, which is the failure mode behind the 4 GB-RAM reports on #13238.
- The PP-OCRv6 quantized-recognition fix does **not** apply here: SE ships the f16 rec model, not a quantized one.

### The one regression, and the extra line of code

Making the PP-OCRv6 detector CUDA-resident left the scalar path everyone else runs (Metal, plain CPU) measurably slower. Over **12 interleaved A/B pairs** on Apple Silicon, **every single pair** was slower on v0.17.7 — 57.6 s → 69.8 s in total, ~21%.

The release ships the recovery as an opt-in gate, so `CrispEmbedOcr.OcrViaCliPipeline` now sets `CRISPEMBED_CONV2D_MK=1`. With it on, the full corpus is back within ~4% of v0.17.6 (43.6 s → 45.3 s) and text, region count and mean confidence are unchanged on all ten images. It sits next to the existing `DS2_CROP_MODE=0` precedent, and PP-OCRv6 is the only backend on the CLI path so the gate is scoped to it.

### Verification

**Archives.** SHA-256 of the macOS, both Linux and both Windows non-CUDA archives matches what is committed here. The two CUDA archives (1.4 GB combined) were not downloaded — their hashes come from the same GitHub per-asset `digest` field that just reproduced all five computed locally.

**Linux loader.** `linux-x86_64` and `linux-arm64` both parse clean: no unresolved `DT_NEEDED`, no `libggml-blas`, and the glibc floor is still `GLIBC_2.27` — so the #13205 OpenBLAS fix and the manylinux floor hold.

**Output parity**, on a ten-image EN/DE/FR/ES/RU/JA/ZH corpus of subtitle-style bitmaps (thin single-line strips down to 64 px tall, plus two-liners), every shipped backend, both versions:

| backend | images | result |
|---|---|---|
| GLM-OCR q4_k | 10 | byte-identical |
| GLM-OCR q8_0 | 10 | byte-identical |
| GOT-OCR2 q4_k | 10 | byte-identical |
| PP-OCRv6 f16 | 10 | byte-identical (also `n_regions` and `mean_confidence`) |
| DeepSeek-OCR-2 q4_k-stacked | 10 | byte-identical |

50 comparisons, zero differences. DeepSeek is also slightly faster on v0.17.7 (46.1 s → 43.2 s).

Build clean, 22 CrispEmbed tests pass.

**Not verified:** the new RAM preflight. Capping the available-RAM budget did not make the server refuse to load, so the #13238 claim above rests on upstream's release notes rather than a measurement here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
