### PR TITLE
Correct the CRISPEMBED_CONV2D_MK figures and link the upstream issue

### DIFF
--- a/src/ui/Features/Ocr/Engines/CrispEmbedOcr.cs
+++ b/src/ui/Features/Ocr/Engines/CrispEmbedOcr.cs
@@ -287,10 +287,11 @@ public class CrispEmbedOcr : IDisposable
         };
 
         // v0.17.7 made the PP-OCRv6 detector CUDA-resident, which left the scalar path everyone
-        // else runs (Metal, CPU) ~21% slower than v0.17.6 - measured over 12 interleaved A/B
-        // pairs on Apple Silicon, every pair slower. The release ships the recovery as an
-        // opt-in gate: with it on, the same corpus is back within ~4% of v0.17.6 and the text,
-        // region count and mean confidence are identical on all ten images (2026-08-09).
+        // else runs (Metal, CPU) ~18% slower than v0.17.6 on a ten-image subtitle corpus, and
+        // slower on all 12 pairs of an interleaved A/B run. The release ships the recovery as an
+        // opt-in gate; it takes back about two thirds of that (+18.1% -> +5.6%) with the text,
+        // region count and mean confidence identical on all ten images. Reported upstream as
+        // CrispStrobe/CrispEmbed#45 - drop this if the gate ever defaults on (2026-08-09).
         process.StartInfo.Environment["CRISPEMBED_CONV2D_MK"] = "1";
 
         process.Start();


### PR DESCRIPTION
Comment-only follow-up to #13410.

The figures in that PR came from a run sharing the machine with a 2.3 GB model download, which inflated both the regression and the apparent recovery. Re-measured on an idle machine, same ten-image subtitle corpus, same three arms:

| build | total | vs v0.17.6 |
|---|---|---|
| v0.17.6 | 32086 ms | — |
| v0.17.7 | 37888 ms | +18.1% |
| v0.17.7 + `CRISPEMBED_CONV2D_MK=1` | 33890 ms | +5.6% |

So the gate takes back about two thirds of the loss rather than nearly all of it. Worth stating accurately, since that residual is exactly what upstream is being asked about.

Output is unchanged in every arm — `full_text`, `n_regions` and `mean_confidence` identical across all thirty invocations, so nothing about the decision to set the gate changes.

Also links CrispStrobe/CrispEmbed#45, so whoever next bumps the pin can check whether the gate has defaulted on and drop the line.

No behavior change: comment text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)