### PR TITLE
Let the CrispEmbed hardware build be re-picked after the first install

### DIFF
--- a/src/ui/Features/Ocr/Download/CrispEmbedDownloadHelper.cs
+++ b/src/ui/Features/Ocr/Download/CrispEmbedDownloadHelper.cs
@@ -3,6 +3,7 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Ocr.Engines;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
@@ -30,77 +31,10 @@ public static class CrispEmbedDownloadHelper
         Action? onEngineDownloadClosed = null,
         Action? onModelDownloadClosed = null)
     {
-        if (!CrispEmbedEngine.IsEngineInstalled())
+        if (!CrispEmbedEngine.IsEngineInstalled()
+            && !await DownloadEngineAsync(owner, windowService, onEngineDownloadClosed))
         {
-            string variant;
-            if (Configuration.IsRunningOnWindows)
-            {
-                var answer = await MessageBox.Show(
-                    owner,
-                    "Download CrispEmbed?",
-                    $"{Environment.NewLine}\"CrispEmbed\" requires downloading the CrispEmbed engine.{Environment.NewLine}{Environment.NewLine}Download and use CrispEmbed?",
-                    MessageBoxButtons.Cancel,
-                    MessageBoxIcon.Question,
-                    "CPU",
-                    "Vulkan",
-                    "CUDA");
-
-                if (answer == MessageBoxResult.Cancel)
-                {
-                    return false;
-                }
-
-                variant = answer switch
-                {
-                    MessageBoxResult.Custom1 => "cpu",
-                    MessageBoxResult.Custom3 => "cuda",
-                    _ => "vulkan",
-                };
-            }
-            else if (Configuration.IsRunningOnLinux && RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
-            {
-                var answer = await MessageBox.Show(
-                    owner,
-                    "Download CrispEmbed?",
-                    $"{Environment.NewLine}\"CrispEmbed\" requires downloading the CrispEmbed engine.{Environment.NewLine}{Environment.NewLine}Download and use CrispEmbed?",
-                    MessageBoxButtons.Cancel,
-                    MessageBoxIcon.Question,
-                    "CPU (~10 MB)",
-                    "GPU CUDA (~718 MB)");
-
-                if (answer == MessageBoxResult.Cancel)
-                {
-                    return false;
-                }
-
-                variant = answer == MessageBoxResult.Custom2 ? "cuda" : string.Empty;
-            }
-            else
-            {
-                var answer = await MessageBox.Show(
-                    owner,
-                    "Download CrispEmbed?",
-                    $"{Environment.NewLine}\"CrispEmbed\" requires downloading the CrispEmbed engine ({CrispEmbedEngine.DownloadSizeText}).{Environment.NewLine}{Environment.NewLine}Download and use CrispEmbed?",
-                    MessageBoxButtons.YesNoCancel,
-                    MessageBoxIcon.Question);
-
-                if (answer != MessageBoxResult.Yes)
-                {
-                    return false;
-                }
-
-                variant = string.Empty;
-            }
-
-            var engineResult = await windowService.ShowDialogAsync<DownloadCrispEmbedWindow, DownloadCrispEmbedViewModel>(owner,
-                vm => vm.InitializeEngine(variant));
-
-            onEngineDownloadClosed?.Invoke();
-
-            if (!engineResult.OkPressed)
-            {
-                return false;
-            }
+            return false;
         }
 
         if (forceModelDownload || !backend.IsModelInstalled(model))
@@ -132,5 +66,101 @@ public static class CrispEmbedDownloadHelper
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Asks which hardware build to fetch (where the platform has a choice) and runs the engine
+    /// download. Used both for the first install and for re-downloading over an existing one -
+    /// the extract step clears only the top-level binaries, so downloaded models survive a
+    /// variant switch.
+    /// </summary>
+    /// <returns>True when the engine was downloaded; false if the user cancelled or it failed.</returns>
+    public static async Task<bool> DownloadEngineAsync(
+        Window owner,
+        IWindowService windowService,
+        Action? onEngineDownloadClosed = null)
+    {
+        var isReDownload = CrispEmbedEngine.IsEngineInstalled();
+        var title = isReDownload
+            ? string.Format(Se.Language.General.ReDownloadX, CrispEmbedEngine.StaticName)
+            : "Download CrispEmbed?";
+        var lead = isReDownload
+            ? "\"CrispEmbed\" is already installed."
+            : "\"CrispEmbed\" requires downloading the CrispEmbed engine.";
+
+        // Where there is a build to choose, ask for it either way - re-running this prompt is
+        // the only route back to Vulkan/CUDA for someone who picked CPU on first run (#13400).
+        var pickMessage = $"{Environment.NewLine}{lead}{Environment.NewLine}{Environment.NewLine}Select a version to download:";
+
+        string variant;
+        if (Configuration.IsRunningOnWindows)
+        {
+            var answer = await MessageBox.Show(
+                owner,
+                title,
+                pickMessage,
+                MessageBoxButtons.Cancel,
+                MessageBoxIcon.Question,
+                "CPU",
+                "Vulkan",
+                "CUDA");
+
+            if (answer == MessageBoxResult.Cancel || answer == MessageBoxResult.None)
+            {
+                return false;
+            }
+
+            variant = answer switch
+            {
+                MessageBoxResult.Custom1 => "cpu",
+                MessageBoxResult.Custom3 => "cuda",
+                _ => "vulkan",
+            };
+        }
+        else if (Configuration.IsRunningOnLinux && RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
+        {
+            var answer = await MessageBox.Show(
+                owner,
+                title,
+                pickMessage,
+                MessageBoxButtons.Cancel,
+                MessageBoxIcon.Question,
+                "CPU (~10 MB)",
+                "GPU CUDA (~718 MB)");
+
+            if (answer == MessageBoxResult.Cancel || answer == MessageBoxResult.None)
+            {
+                return false;
+            }
+
+            variant = answer == MessageBoxResult.Custom2 ? "cuda" : string.Empty;
+        }
+        else
+        {
+            // macOS and Linux ARM64 ship a single build, so there is nothing to choose - but a
+            // re-download is still useful to pick up a new release or repair a broken install.
+            var answer = await MessageBox.Show(
+                owner,
+                title,
+                isReDownload
+                    ? $"{Environment.NewLine}{lead}{Environment.NewLine}{Environment.NewLine}Download it again?"
+                    : $"{Environment.NewLine}\"CrispEmbed\" requires downloading the CrispEmbed engine ({CrispEmbedEngine.DownloadSizeText}).{Environment.NewLine}{Environment.NewLine}Download and use CrispEmbed?",
+                MessageBoxButtons.YesNoCancel,
+                MessageBoxIcon.Question);
+
+            if (answer != MessageBoxResult.Yes)
+            {
+                return false;
+            }
+
+            variant = string.Empty;
+        }
+
+        var engineResult = await windowService.ShowDialogAsync<DownloadCrispEmbedWindow, DownloadCrispEmbedViewModel>(owner,
+            vm => vm.InitializeEngine(variant));
+
+        onEngineDownloadClosed?.Invoke();
+
+        return engineResult.OkPressed;
     }
 }

--- a/src/ui/Features/Ocr/Download/DownloadCrispEmbedViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadCrispEmbedViewModel.cs
@@ -243,7 +243,7 @@ public partial class DownloadCrispEmbedViewModel : ObservableObject, IClosingCle
     /// the new executable would load by mistake. Only top-level executables and shared
     /// libraries are removed; the models/ subfolder and the sidecar are left in place.
     /// </summary>
-    private static void RemoveStaleBinaries(string folder)
+    internal static void RemoveStaleBinaries(string folder)
     {
         if (!Directory.Exists(folder))
         {

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -1281,6 +1281,28 @@ public partial class OcrViewModel : ObservableObject
     }
 
     /// <summary>
+    /// Re-downloads the CrispEmbed engine binaries, re-asking which hardware build to use. The
+    /// CPU/Vulkan/CUDA choice is otherwise only offered on first install, which left anyone who
+    /// picked CPU with no way back to a GPU build (issue #13400). Downloaded models are kept.
+    /// </summary>
+    [RelayCommand]
+    private async Task ReDownloadCrispEmbedEngine()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        await CrispEmbedDownloadHelper.DownloadEngineAsync(
+            Window, _windowService,
+            onEngineDownloadClosed: () =>
+            {
+                _isCtrlDown = false;
+                RefreshEngineCombo?.Invoke();
+            });
+    }
+
+    /// <summary>
     /// Makes sure the CrispEmbed engine binaries and the selected model are on disk, offering
     /// downloads for anything missing - the OCR-side analog of the CrispASR engine/model
     /// download flow in the speech-to-text window.

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -358,6 +358,14 @@ public class OcrWindow : Window
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.Model, vm => vm.IsCrispEmbedVisible),
                 comboBoxCrispEmbedModels,
                 UiUtil.MakeButton(vm.DownloadCrispEmbedCommand, IconNames.Download, Se.Language.General.Download)
+                    .WithMarginRight(5)
+                    .BindIsVisible(vm, nameof(vm.IsCrispEmbedVisible))
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                // Separate from the download button above, which fetches the selected *model*:
+                // this one re-fetches the engine binaries and re-asks CPU/Vulkan/CUDA, the only
+                // way to change hardware build after the first install (issue #13400).
+                UiUtil.MakeButton(vm.ReDownloadCrispEmbedEngineCommand, IconNames.CloudDownload,
+                        string.Format(Se.Language.General.ReDownloadX, CrispEmbedEngine.StaticName))
                     .WithMarginRight(10)
                     .BindIsVisible(vm, nameof(vm.IsCrispEmbedVisible))
                     .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),

--- a/tests/UI/Features/Ocr/Download/CrispEmbedRemoveStaleBinariesTests.cs
+++ b/tests/UI/Features/Ocr/Download/CrispEmbedRemoveStaleBinariesTests.cs
@@ -1,0 +1,100 @@
+using Nikse.SubtitleEdit.Features.Ocr.Download;
+
+namespace UITests.Features.Ocr.Download;
+
+/// <summary>
+/// Re-downloading the CrispEmbed engine (to switch CPU/Vulkan/CUDA) extracts over the existing
+/// install, so the cleanup step must drop the old binaries without touching anything the user
+/// would hate to lose - above all the multi-GB models in models/.
+/// </summary>
+public class CrispEmbedRemoveStaleBinariesTests
+{
+    private static string NewFolder()
+    {
+        var folder = Path.Combine(Path.GetTempPath(), "se-crispembed-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(folder);
+        return folder;
+    }
+
+    [Fact]
+    public void RemoveStaleBinaries_KeepsDownloadedModels()
+    {
+        var folder = NewFolder();
+        try
+        {
+            var models = Path.Combine(folder, "models");
+            Directory.CreateDirectory(models);
+            var model = Path.Combine(models, "glm-ocr-q4_k.gguf");
+            File.WriteAllText(model, "not really a model");
+
+            // A model folder can also hold a stray .dll/.so next to the GGUFs; the sweep is
+            // top-level only, so nothing under models/ may be touched whatever its extension.
+            var strayInModels = Path.Combine(models, "libggml.so");
+            File.WriteAllText(strayInModels, "x");
+
+            DownloadCrispEmbedViewModel.RemoveStaleBinaries(folder);
+
+            Assert.True(File.Exists(model));
+            Assert.True(File.Exists(strayInModels));
+        }
+        finally
+        {
+            Directory.Delete(folder, true);
+        }
+    }
+
+    [Theory]
+    [InlineData("ggml-vulkan.dll")]
+    [InlineData("libggml.so")]
+    [InlineData("libggml.dylib")]
+    [InlineData("crispembed-server.exe")]
+    public void RemoveStaleBinaries_RemovesTopLevelBinaries(string fileName)
+    {
+        var folder = NewFolder();
+        try
+        {
+            var path = Path.Combine(folder, fileName);
+            File.WriteAllText(path, "x");
+
+            DownloadCrispEmbedViewModel.RemoveStaleBinaries(folder);
+
+            Assert.False(File.Exists(path));
+        }
+        finally
+        {
+            Directory.Delete(folder, true);
+        }
+    }
+
+    [Fact]
+    public void RemoveStaleBinaries_KeepsSidecarAndDocs()
+    {
+        var folder = NewFolder();
+        try
+        {
+            // The sidecar records which build is installed; wiping it would make the engine look
+            // up to date forever, so it has to survive the sweep.
+            var sidecar = Path.Combine(folder, ".installed.sha256");
+            var readme = Path.Combine(folder, "README.md");
+            File.WriteAllText(sidecar, "abc");
+            File.WriteAllText(readme, "docs");
+
+            DownloadCrispEmbedViewModel.RemoveStaleBinaries(folder);
+
+            Assert.True(File.Exists(sidecar));
+            Assert.True(File.Exists(readme));
+        }
+        finally
+        {
+            Directory.Delete(folder, true);
+        }
+    }
+
+    [Fact]
+    public void RemoveStaleBinaries_MissingFolderDoesNotThrow()
+    {
+        var folder = Path.Combine(Path.GetTempPath(), "se-crispembed-missing-" + Guid.NewGuid().ToString("N"));
+
+        DownloadCrispEmbedViewModel.RemoveStaleBinaries(folder);
+    }
+}


### PR DESCRIPTION
Follow-up to #13400.

## The problem

The CPU / Vulkan / CUDA choice for CrispEmbed was only ever offered when the engine folder was empty — `CrispEmbedDownloadHelper.EnsureReadyAsync` gated the entire prompt on `!IsEngineInstalled()`. Someone who picked CPU on first run had no way to move to a GPU build except quitting SE, deleting `OCR/CrispEmbed` by hand, and knowing to move `models/` aside first so their multi-GB downloads did not go with it.

That was the only answer I could give the user on #13400, who asked for Vulkan support — and who already *had* Vulkan support, just no way to reach it.

## The change

- Extracts the variant prompt and the engine download out of `EnsureReadyAsync` into a new `DownloadEngineAsync`, so first install and re-download share one implementation instead of drifting apart.
- Adds a button beside the existing CrispEmbed model-download button that re-runs it. This mirrors the **Re-download X** item the speech-to-text window already offers for CrispASR, and reuses the existing `General.ReDownloadX` string — **no new translatable text**.
- On macOS and Linux ARM64 there is a single build and nothing to choose, so the button degrades to a plain "download it again" — still useful for picking up a new release or repairing a broken install.

## Why re-downloading over an install is safe

`RemoveStaleBinaries` sweeps top-level executables and shared libraries only, leaving `models/` and the install sidecar untouched. The whole feature rests on that, so it is now covered by tests — including a stray `.so` placed *inside* `models/`, which must survive precisely because the sweep is `TopDirectoryOnly`.

## Testing

Full UI suite: 2248 tests, 1 failure — `MainMenuKeyboardActivationTests.F10_TogglesTheMenuBarOffAgain_WithEmptyGrid`, which is in the known-flaky menu-activation family and passes on rerun in isolation (10/10). Unrelated to OCR downloads. New tests: 7.

## Not done here

**llama.cpp has the same structural gap.** `LlamaCppDownloadHelper.DownloadAsync` only shows its Windows build picker when `!LlamaCppServerManager.IsEngineInstalled()`, and no caller passes `forceEngineDownload` together with a fresh variant prompt — so a llama.cpp user who picked CPU is equally stuck. Left alone because fixing it touches auto-translate, AI review and video OCR. Happy to do it as a follow-up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)