### PR TITLE
nOCR: match-result cache, exact-match index, and Train nOCR from SE4

### DIFF
--- a/src/libuilogic/Ocr/NOcrDb.cs
+++ b/src/libuilogic/Ocr/NOcrDb.cs
@@ -37,6 +37,80 @@ public class NOcrDb
 
     private readonly Lock _lock = new();
 
+    // Subtitle lines repeat the same glyph bitmaps over and over, so cache match results per
+    // exact pixel content. Unmatched glyphs benefit the most: a "no match" previously re-ran the
+    // whole pass cascade against the full database for every occurrence. The cache is cleared on
+    // any mutation (Add/Remove/Load) and on Save, because the edit dialogs mutate the character
+    // lists/lines directly and always call Save afterwards.
+    private readonly Dictionary<MatchCacheKey, MatchCacheEntry> _matchCache = new();
+    private const int MatchCacheMaxEntries = 5000;
+
+    // Exact-match candidates bucketed by (width, height) so the exact pass doesn't scan the
+    // whole single-character list per glyph. Rebuilt lazily after mutations; insertion order is
+    // preserved within a bucket so the first-match-wins semantics are unchanged.
+    private Dictionary<long, List<NOcrChar>>? _exactSizeIndex;
+
+    private sealed class MatchCacheEntry
+    {
+        public NOcrChar? ExactMatch;
+        public NOcrChar? SingleMatch;
+    }
+
+    private readonly struct MatchCacheKey : IEquatable<MatchCacheKey>
+    {
+        private readonly byte[] _pixels;
+        private readonly int _width;
+        private readonly int _topMargin;
+        private readonly int _maxWrongPixels;
+        private readonly bool _deepSeek;
+        private readonly bool _lastDitch;
+        private readonly int _hashCode;
+
+        public MatchCacheKey(NikseBitmap2 bitmap, int topMargin, bool deepSeek, int maxWrongPixels, bool lastDitch)
+        {
+            _pixels = bitmap.GetPixelData().ToArray();
+            _width = bitmap.Width;
+            _topMargin = topMargin;
+            _maxWrongPixels = maxWrongPixels;
+            _deepSeek = deepSeek;
+            _lastDitch = lastDitch;
+
+            // FNV-1a over the pixel bytes plus the match parameters.
+            var hash = unchecked((int)2166136261);
+            foreach (var b in _pixels)
+            {
+                hash = unchecked((hash ^ b) * 16777619);
+            }
+
+            hash = unchecked((hash ^ _width) * 16777619);
+            hash = unchecked((hash ^ _topMargin) * 16777619);
+            hash = unchecked((hash ^ _maxWrongPixels) * 16777619);
+            hash = unchecked((hash ^ (_deepSeek ? 1 : 0) ^ (_lastDitch ? 2 : 0)) * 16777619);
+            _hashCode = hash;
+        }
+
+        public bool Equals(MatchCacheKey other)
+        {
+            return _hashCode == other._hashCode &&
+                   _width == other._width &&
+                   _topMargin == other._topMargin &&
+                   _maxWrongPixels == other._maxWrongPixels &&
+                   _deepSeek == other._deepSeek &&
+                   _lastDitch == other._lastDitch &&
+                   _pixels.AsSpan().SequenceEqual(other._pixels);
+        }
+
+        public override bool Equals(object? obj) => obj is MatchCacheKey other && Equals(other);
+
+        public override int GetHashCode() => _hashCode;
+    }
+
+    private void InvalidateCaches()
+    {
+        _matchCache.Clear();
+        _exactSizeIndex = null;
+    }
+
     public void Save()
     {
         lock (_lock)
@@ -60,6 +134,10 @@ public class NOcrDb
             }
 
             File.Move(tempFileName, FileName, overwrite: true);
+
+            // The edit dialogs mutate OcrCharacters/character lines directly and then call
+            // Save, so treat Save as a mutation barrier for the caches.
+            InvalidateCaches();
         }
     }
 
@@ -74,6 +152,7 @@ public class NOcrDb
             {
                 OcrCharacters = list;
                 OcrCharactersExpanded = listExpanded;
+                InvalidateCaches();
                 return;
             }
 
@@ -115,6 +194,7 @@ public class NOcrDb
 
             OcrCharacters = list;
             OcrCharactersExpanded = listExpanded;
+            InvalidateCaches();
         }
     }
 
@@ -130,6 +210,8 @@ public class NOcrDb
             {
                 OcrCharacters.Insert(0, ocrChar);
             }
+
+            InvalidateCaches();
         }
     }
 
@@ -145,6 +227,8 @@ public class NOcrDb
             {
                 OcrCharacters.Remove(ocrChar);
             }
+
+            InvalidateCaches();
         }
     }
 
@@ -290,36 +374,101 @@ public class NOcrDb
             return null;
         }
 
+        var key = new MatchCacheKey(item.NikseBitmap, topMargin, deepSeek, maxWrongPixels, lastDitch);
+        MatchCacheEntry? cached;
+        lock (_lock)
+        {
+            _matchCache.TryGetValue(key, out cached);
+        }
+
+        if (cached != null)
+        {
+            if (cached.ExactMatch != null)
+            {
+                return cached.ExactMatch;
+            }
+
+            // The expanded scan depends on the neighboring splitter items and the parent
+            // bitmap, so it can't be cached per glyph bitmap - always evaluate it live.
+            return GetMatchExpanded(parentBitmap, item, list.IndexOf(item), list) ?? cached.SingleMatch;
+        }
+
         // A perfect single match (exact size, 0 errors) means the user has explicitly added an
         // entry for this bitmap, so prefer it over a possibly-greedy expanded match.
         var exactSingle = GetExactMatchSingle(item.NikseBitmap, topMargin);
         if (exactSingle != null)
         {
+            CacheMatch(key, new MatchCacheEntry { ExactMatch = exactSingle });
             return exactSingle;
         }
 
         var expandedResult = GetMatchExpanded(parentBitmap, item, list.IndexOf(item), list);
         if (expandedResult != null)
         {
+            // Nothing cached: the single-match result was never computed, and the expanded
+            // result must not be cached (see above).
             return expandedResult;
         }
 
         // skipExactCheck: the exact scan already ran (and missed) above - without the flag,
         // GetMatchSingle re-scanned the whole single-character list a second time for every
         // glyph that wasn't an exact match.
-        return GetMatchSingle(item.NikseBitmap, topMargin, deepSeek, maxWrongPixels, lastDitch, skipExactCheck: true);
+        var single = GetMatchSingle(item.NikseBitmap, topMargin, deepSeek, maxWrongPixels, lastDitch, skipExactCheck: true);
+        CacheMatch(key, new MatchCacheEntry { SingleMatch = single });
+        return single;
+    }
+
+    private void CacheMatch(MatchCacheKey key, MatchCacheEntry entry)
+    {
+        lock (_lock)
+        {
+            if (_matchCache.Count >= MatchCacheMaxEntries)
+            {
+                _matchCache.Clear();
+            }
+
+            _matchCache[key] = entry;
+        }
     }
 
     private NOcrChar? GetExactMatchSingle(NikseBitmap2 bitmap, int topMargin)
     {
-        foreach (var oc in OcrCharacters)
+        var index = _exactSizeIndex;
+        if (index == null)
         {
-            if (bitmap.Width == oc.Width && bitmap.Height == oc.Height && Math.Abs(oc.MarginTop - topMargin) < 5)
+            lock (_lock)
             {
-                if (IsMatch(bitmap, oc, 0))
+                index = _exactSizeIndex;
+                if (index == null)
                 {
-                    return oc;
+                    index = new Dictionary<long, List<NOcrChar>>();
+                    foreach (var oc in OcrCharacters)
+                    {
+                        var k = ((long)oc.Width << 32) | (uint)oc.Height;
+                        if (!index.TryGetValue(k, out var bucket))
+                        {
+                            bucket = new List<NOcrChar>();
+                            index[k] = bucket;
+                        }
+
+                        bucket.Add(oc);
+                    }
+
+                    _exactSizeIndex = index;
                 }
+            }
+        }
+
+        if (!index.TryGetValue(((long)bitmap.Width << 32) | (uint)bitmap.Height, out var candidates))
+        {
+            return null;
+        }
+
+        foreach (var oc in candidates)
+        {
+            if (Math.Abs(oc.MarginTop - topMargin) < 5 && IsMatch(bitmap, oc, 0))
+            {
+                return oc;
             }
         }
 

--- a/src/libuilogic/Ocr/NOcrDb.cs
+++ b/src/libuilogic/Ocr/NOcrDb.cs
@@ -507,6 +507,14 @@ public class NOcrDb
 
             var errorsAllowed = pass.ErrorsAllowed(maxWrongPixels);
 
+            // Best-match within the pass: the first candidate that fits the error budget used to
+            // win outright, so with generous budgets a mediocre early entry beat a near-perfect
+            // later one. Now the candidate with the fewest wrong pixels wins; ties keep list
+            // order (newest first), so a user's just-added character still takes precedence over
+            // an equally-good older one. The counting loop shrinks its budget to "current best
+            // minus one", so each candidate aborts as soon as it can no longer win.
+            NOcrChar? best = null;
+            var bestErrors = int.MaxValue;
             foreach (var oc in OcrCharacters)
             {
                 if (!PassFilter(bitmap, heightToWidthPercent, oc, topMargin, pass))
@@ -514,10 +522,21 @@ public class NOcrDb
                     continue;
                 }
 
-                if (IsMatch(bitmap, oc, errorsAllowed))
+                var budget = Math.Min(errorsAllowed, bestErrors - 1);
+                if (TryCountErrors(bitmap, oc, budget, out var errors))
                 {
-                    return oc;
+                    best = oc;
+                    bestErrors = errors;
+                    if (errors == 0)
+                    {
+                        break;
+                    }
                 }
+            }
+
+            if (best != null)
+            {
+                return best;
             }
         }
 
@@ -655,6 +674,69 @@ public class NOcrDb
             ErrorsAllowed = ErrorsAsRequestedDoubled,
         },
     };
+
+    /// <summary>
+    /// Like <see cref="IsMatch"/> but reports how many pixels disagreed, so callers can rank
+    /// candidates that all fit the budget. Returns false (and an unspecified count) as soon as
+    /// the budget is exceeded.
+    /// </summary>
+    private static bool TryCountErrors(NikseBitmap2 bitmap, NOcrChar oc, int errorsAllowed, out int errors)
+    {
+        errors = 0;
+        if (errorsAllowed < 0)
+        {
+            return false;
+        }
+
+        // Same zero-line guard as IsMatch: an entry with no lines would "match" anything.
+        if (oc.LinesForeground.Count + oc.LinesBackground.Count < MinLinesForSingleMatch)
+        {
+            return false;
+        }
+
+        var width = bitmap.Width;
+        var height = bitmap.Height;
+        var pixelData = bitmap.GetPixelData();
+        var widthX4 = width * 4;
+
+        foreach (var op in oc.LinesForeground)
+        {
+            foreach (var point in op.ScaledWalkPoints(oc, width, height))
+            {
+                if ((uint)point.X < (uint)width && (uint)point.Y < (uint)height)
+                {
+                    var a = pixelData[point.X * 4 + point.Y * widthX4 + 3];
+                    if (a <= 150)
+                    {
+                        if (++errors > errorsAllowed)
+                        {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+
+        foreach (var op in oc.LinesBackground)
+        {
+            foreach (var point in op.ScaledWalkPoints(oc, width, height))
+            {
+                if ((uint)point.X < (uint)width && (uint)point.Y < (uint)height)
+                {
+                    var a = pixelData[point.X * 4 + point.Y * widthX4 + 3];
+                    if (a > 150)
+                    {
+                        if (++errors > errorsAllowed)
+                        {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
 
     public static bool IsMatch(NikseBitmap2 bitmap, NOcrChar oc, int errorsAllowed)
     {

--- a/src/libuilogic/Ocr/NOcrTrainer.cs
+++ b/src/libuilogic/Ocr/NOcrTrainer.cs
@@ -1,0 +1,257 @@
+using SkiaSharp;
+
+namespace Nikse.SubtitleEdit.UiLogic.Ocr;
+
+/// <summary>
+/// Trains an nOCR database by rendering characters with real fonts (white fill, black outline,
+/// like typical image subtitles) and generating line segments for each glyph the database does
+/// not already recognize. Port of SE4's "Train nOCR" (VobSubNOcrTrain).
+/// </summary>
+public sealed class NOcrTrainerSettings
+{
+    public List<string> FontNames { get; set; } = new();
+    public float FontSize { get; set; } = 30;
+    public bool IncludeBold { get; set; }
+    public bool IncludeItalic { get; set; }
+    public int NumberOfLineSegments { get; set; } = 60;
+
+    /// <summary>All characters to train, as a plain string (whitespace is ignored).</summary>
+    public string CharactersToTrain { get; set; } = NOcrTrainer.DefaultTrainingCharacters;
+
+    /// <summary>Space separated multi-character combinations (2-3 chars, e.g. ligature-prone pairs like "fi ff rn").</summary>
+    public string MergedLetterCombinations { get; set; } = string.Empty;
+
+    public NOcrLineAlgorithm LineSegmentAlgorithm { get; set; } = NOcrLineAlgorithm.Random;
+}
+
+public sealed class NOcrTrainerProgress
+{
+    public int CharactersLearned { get; init; }
+    public int CharactersSkipped { get; init; }
+    public string CurrentFontName { get; init; } = string.Empty;
+    public string CurrentText { get; init; } = string.Empty;
+}
+
+public sealed class NOcrTrainer
+{
+    public const string DefaultTrainingCharacters =
+        "abcdefghijklmnopqrstuvwxyz" +
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+        "0123456789" +
+        ".,!?\"'()[]:;-+/%&$#@*=" +
+        "æøåäöüßéèêëáàâíìîóòôúùûñç" +
+        "ÆØÅÄÖÜÉÈÊËÁÀÂÍÌÎÓÒÔÚÙÛÑÇ";
+
+    // Matches the runtime OCR pipeline (OcrViewModel/seconv): two-color threshold and the
+    // wrong-pixel budget used when checking whether a glyph is already recognized.
+    private const int TwoColorThreshold = 200;
+    private const int MaxWrongPixels = 25;
+    private const int PixelsAreSpace = 10;
+    private const int MinLineHeight = 25;
+    private const float OutlineWidth = 2.0f;
+
+    /// <summary>
+    /// Trains <paramref name="db"/> in place. Call from a background thread; use
+    /// <paramref name="abortRequested"/> to cancel between characters.
+    /// </summary>
+    /// <returns>The number of characters learned (added to the database).</returns>
+    public int Train(NOcrTrainerSettings settings, NOcrDb db, Func<bool>? abortRequested = null, Action<NOcrTrainerProgress>? progress = null)
+    {
+        var learned = 0;
+        var skipped = 0;
+
+        var singleCharacters = new List<string>();
+        foreach (var ch in settings.CharactersToTrain)
+        {
+            var s = ch.ToString();
+            if (!char.IsWhiteSpace(ch) && !singleCharacters.Contains(s))
+            {
+                singleCharacters.Add(s);
+            }
+        }
+
+        var mergedCombinations = settings.MergedLetterCombinations
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(s => s.Length > 1 && s.Length <= 3)
+            .Distinct()
+            .ToList();
+
+        foreach (var fontName in settings.FontNames)
+        {
+            foreach (var text in singleCharacters.Concat(mergedCombinations))
+            {
+                if (abortRequested?.Invoke() == true)
+                {
+                    return learned;
+                }
+
+                var isMerged = text.Length > 1;
+                foreach (var (bold, italic) in GetStyles(settings))
+                {
+                    if (TrainCharacter(settings, db, text, fontName, bold, italic, isMerged))
+                    {
+                        learned++;
+                    }
+                    else
+                    {
+                        skipped++;
+                    }
+                }
+
+                progress?.Invoke(new NOcrTrainerProgress
+                {
+                    CharactersLearned = learned,
+                    CharactersSkipped = skipped,
+                    CurrentFontName = fontName,
+                    CurrentText = text,
+                });
+            }
+        }
+
+        return learned;
+    }
+
+    private static IEnumerable<(bool Bold, bool Italic)> GetStyles(NOcrTrainerSettings settings)
+    {
+        yield return (false, false);
+
+        if (settings.IncludeBold)
+        {
+            yield return (true, false);
+        }
+
+        if (settings.IncludeItalic)
+        {
+            yield return (false, true);
+        }
+    }
+
+    private static bool TrainCharacter(NOcrTrainerSettings settings, NOcrDb db, string text, string fontName, bool bold, bool italic, bool isMerged)
+    {
+        // "H" establishes the line's cap height so the target glyph gets a realistic top
+        // margin; the wide gap makes the splitter separate it from the target.
+        using var bitmap = RenderCharacterImage("H   " + text, fontName, settings.FontSize, bold, italic);
+        if (bitmap == null)
+        {
+            return false;
+        }
+
+        var nikseBitmap = new NikseBitmap2(bitmap);
+        nikseBitmap.MakeTwoColor(TwoColorThreshold);
+        nikseBitmap.CropTop(0, new SKColor(0, 0, 0, 0));
+        var list = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(nikseBitmap, PixelsAreSpace, false, false, MinLineHeight, false);
+
+        // Expected: [H][space][target...]
+        if (list.Count == 3 && list[2].NikseBitmap != null)
+        {
+            var item = list[2];
+            var match = db.GetMatchSingle(item.NikseBitmap!, item.Top, false, MaxWrongPixels);
+            if (match != null && match.Text == text)
+            {
+                return false; // already recognized
+            }
+
+            var nOcrChar = new NOcrChar(text)
+            {
+                Width = item.NikseBitmap!.Width,
+                Height = item.NikseBitmap.Height,
+                MarginTop = item.Top,
+                Italic = italic,
+            };
+            var segments = settings.NumberOfLineSegments + (isMerged ? 20 : 0);
+            NOcrChar.GenerateLineSegments(segments, false, nOcrChar, item.NikseBitmap, settings.LineSegmentAlgorithm);
+            db.Add(nOcrChar);
+            return true;
+        }
+
+        // Multi-part glyphs (e.g. ", %, ?) - train as an expanded character spanning all parts.
+        // Merged letter combinations are only trained when they render as one connected glyph
+        // (same as SE4); separate glyphs are already covered by the single characters.
+        if (!isMerged && list.Count is 4 or 5)
+        {
+            var group = ExpandedOcrGroup.Create(nikseBitmap, list, 2, list.Count - 2);
+            if (group == null)
+            {
+                return false;
+            }
+
+            var existing = db.GetMatchExpanded(nikseBitmap, list[2], 2, list);
+            if (existing != null && existing.Text == text)
+            {
+                return false;
+            }
+
+            var nOcrChar = group.CreateNOcrChar();
+            nOcrChar.Text = text;
+            nOcrChar.Italic = italic;
+            var segments = settings.NumberOfLineSegments + (list.Count == 5 ? 10 : 5);
+            NOcrChar.GenerateLineSegments(segments, false, nOcrChar, group.PreviewBitmap, settings.LineSegmentAlgorithm);
+            db.Add(nOcrChar);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Renders text like a typical image subtitle: white fill with a black outline on a
+    /// transparent background.
+    /// </summary>
+    public static SKBitmap? RenderCharacterImage(string text, string fontName, float fontSize, bool bold, bool italic)
+    {
+        using var typeface = SKTypeface.FromFamilyName(
+            fontName,
+            bold ? SKFontStyleWeight.Bold : SKFontStyleWeight.Normal,
+            SKFontStyleWidth.Normal,
+            italic ? SKFontStyleSlant.Italic : SKFontStyleSlant.Upright);
+        if (typeface == null)
+        {
+            return null;
+        }
+
+        using var font = new SKFont(typeface, fontSize);
+        if (italic && !typeface.IsItalic)
+        {
+            font.SkewX = -0.25f; // synthetic slant when the font has no italic face
+        }
+
+        using var paint = new SKPaint { IsAntialias = true };
+        font.MeasureText(text, out var textBounds, paint);
+        font.GetFontMetrics(out var metrics);
+
+        const int padding = 10;
+        var width = (int)Math.Ceiling(textBounds.Width + padding * 2 + OutlineWidth * 2);
+        var height = (int)Math.Ceiling(-metrics.Ascent + metrics.Descent + padding * 2 + OutlineWidth * 2);
+        if (width < 1 || height < 1)
+        {
+            return null;
+        }
+
+        var bitmap = new SKBitmap(width, height);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(SKColors.Transparent);
+
+        var x = padding + OutlineWidth;
+        var baseline = padding + OutlineWidth - metrics.Ascent;
+        using var textPath = font.GetTextPath(text, new SKPoint(x, baseline));
+
+        using var outlinePaint = new SKPaint
+        {
+            IsAntialias = true,
+            Style = SKPaintStyle.Stroke,
+            StrokeWidth = OutlineWidth,
+            Color = SKColors.Black,
+        };
+        canvas.DrawPath(textPath, outlinePaint);
+
+        using var fillPaint = new SKPaint
+        {
+            IsAntialias = true,
+            Style = SKPaintStyle.Fill,
+            Color = SKColors.White,
+        };
+        canvas.DrawPath(textPath, fillPaint);
+
+        return bitmap;
+    }
+}

--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -442,6 +442,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<NOcrDbNewViewModel>();
         collection.AddTransient<NOcrInspectViewModel>();
         collection.AddTransient<NOcrSettingsViewModel>();
+        collection.AddTransient<NOcrTrainViewModel>();
         collection.AddTransient<LlamaCppOcrSettingsViewModel>();
         collection.AddTransient<LlamaCppEngineSettingsViewModel>();
         collection.AddTransient<Features.Translate.LlamaCppAdvanced.LlamaCppAdvancedSettingsViewModel>();

--- a/src/ui/Features/Ocr/NOcr/NOcrSettingsViewModel.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrSettingsViewModel.cs
@@ -21,6 +21,7 @@ public partial class NOcrSettingsViewModel : ObservableObject
     public bool DeletePressed { get; set; }
     public bool NewPressed { get; set; }
     public bool RenamePressed { get; set; }
+    public bool TrainPressed { get; set; }
     private NOcrDb _nOcrDb;
 
     private readonly IWindowService _windowService;
@@ -79,6 +80,13 @@ public partial class NOcrSettingsViewModel : ObservableObject
     private void Rename()
     {
         RenamePressed = true;
+        Close();
+    }
+
+    [RelayCommand]
+    private void Train()
+    {
+        TrainPressed = true;
         Close();
     }
 

--- a/src/ui/Features/Ocr/NOcr/NOcrSettingsWindow.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrSettingsWindow.cs
@@ -48,6 +48,17 @@ public class NOcrSettingsWindow : Window
 
         Content = grid;
 
+        // Semi-hidden power-user feature: right-click anywhere in the dialog to train a new
+        // nOCR database from installed fonts (port of SE4's "Train nOCR").
+        var menuFlyout = new MenuFlyout();
+        menuFlyout.Items.Add(new MenuItem
+        {
+            Header = Se.Language.Ocr.TrainNOcrDatabase,
+            Command = vm.TrainCommand,
+        });
+        grid.ContextFlyout = menuFlyout;
+        UiUtil.AttachMacContextFlyoutHandler(this, grid);
+
         Activated += delegate
         {
             buttonEdit.Focus(); // hack to make OnKeyDown work

--- a/src/ui/Features/Ocr/NOcr/NOcrTrainViewModel.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrTrainViewModel.cs
@@ -1,0 +1,246 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Ocr.NOcr;
+
+public partial class NOcrTrainFontItem : ObservableObject
+{
+    public string Name { get; }
+    [ObservableProperty] private bool _isSelected;
+
+    public NOcrTrainFontItem(string name, bool isSelected)
+    {
+        Name = name;
+        IsSelected = isSelected;
+    }
+}
+
+public partial class NOcrTrainViewModel : ObservableObject
+{
+    public Window? Window { get; set; }
+
+    public ObservableCollection<NOcrTrainFontItem> Fonts { get; }
+
+    [ObservableProperty] private string _databaseName;
+    [ObservableProperty] private string _charactersToTrain;
+    [ObservableProperty] private string _mergedLetters;
+    [ObservableProperty] private bool _trainBold;
+    [ObservableProperty] private bool _trainItalic;
+    [ObservableProperty] private int _fontSize;
+    [ObservableProperty] private int _numberOfSegments;
+    [ObservableProperty] private string _statusText;
+    [ObservableProperty] private bool _isTraining;
+    [ObservableProperty] private string _trainButtonText;
+
+    /// <summary>Set when a database was trained and saved; the caller should refresh its database list.</summary>
+    public string? TrainedDatabaseName { get; private set; }
+
+    private bool _abort;
+    private readonly IFileHelper _fileHelper;
+
+    public NOcrTrainViewModel(IFileHelper fileHelper)
+    {
+        _fileHelper = fileHelper;
+
+        var ocr = Se.Settings.Ocr;
+        var selectedFonts = (ocr.NOcrTrainFonts ?? string.Empty).Split(';', StringSplitOptions.RemoveEmptyEntries);
+        Fonts = new ObservableCollection<NOcrTrainFontItem>(
+            FontHelper.GetSystemFonts().Select(name => new NOcrTrainFontItem(name, selectedFonts.Contains(name))));
+
+        DatabaseName = string.Empty;
+        CharactersToTrain = NOcrTrainer.DefaultTrainingCharacters;
+        MergedLetters = ocr.NOcrTrainMergedLetters;
+        TrainBold = ocr.NOcrTrainBold;
+        TrainItalic = ocr.NOcrTrainItalic;
+        FontSize = Math.Clamp(ocr.NOcrTrainFontSize, 20, 100);
+        NumberOfSegments = Math.Clamp(ocr.NOcrTrainSegmentCount, 10, 500);
+        StatusText = string.Empty;
+        TrainButtonText = Se.Language.Ocr.StartTraining;
+    }
+
+    [RelayCommand]
+    private async Task StartOrAbortTraining()
+    {
+        if (IsTraining)
+        {
+            _abort = true;
+            return;
+        }
+
+        var fontNames = Fonts.Where(f => f.IsSelected).Select(f => f.Name).ToList();
+        if (fontNames.Count == 0)
+        {
+            await MessageBox.Show(Window!, Se.Language.Ocr.TrainNOcrDatabase, Se.Language.Ocr.SelectAtLeastOneFont,
+                MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        var databaseName = DatabaseName.Trim();
+        if (string.IsNullOrEmpty(databaseName) || databaseName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            return;
+        }
+
+        if (!Directory.Exists(Se.OcrFolder))
+        {
+            Directory.CreateDirectory(Se.OcrFolder);
+        }
+
+        var fileName = Path.Combine(Se.OcrFolder, databaseName + ".nocr");
+        if (File.Exists(fileName) && TrainedDatabaseName != databaseName)
+        {
+            var answer = await MessageBox.Show(Window!, Se.Language.General.FileAlreadyExists,
+                string.Format(Se.Language.General.FileXAlreadyExists, fileName),
+                MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
+            if (answer != MessageBoxResult.Yes)
+            {
+                return;
+            }
+        }
+
+        SaveSettings(fontNames);
+
+        var settings = new NOcrTrainerSettings
+        {
+            FontNames = fontNames,
+            FontSize = FontSize,
+            IncludeBold = TrainBold,
+            IncludeItalic = TrainItalic,
+            NumberOfLineSegments = NumberOfSegments,
+            CharactersToTrain = CharactersToTrain,
+            MergedLetterCombinations = MergedLetters,
+        };
+
+        _abort = false;
+        IsTraining = true;
+        TrainButtonText = Se.Language.Ocr.AbortTraining;
+
+        await Task.Run(() =>
+        {
+            try
+            {
+                var db = new NOcrDb(fileName)
+                {
+                    OcrCharacters = new(),
+                    OcrCharactersExpanded = new(),
+                };
+                var trainer = new NOcrTrainer();
+                var learned = trainer.Train(settings, db, () => _abort, p =>
+                {
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        StatusText = string.Format(Se.Language.Ocr.TrainingXLearnedYSkipped,
+                            p.CurrentFontName, p.CharactersLearned, p.CharactersSkipped);
+                    });
+                });
+
+                db.Save();
+
+                Dispatcher.UIThread.Post(() =>
+                {
+                    TrainedDatabaseName = databaseName;
+                    StatusText = string.Format(Se.Language.Ocr.TrainingDoneXLearned, learned);
+                });
+            }
+            catch (Exception exception)
+            {
+                Se.LogError(exception, "nOCR training failed");
+                Dispatcher.UIThread.Post(() => { StatusText = exception.Message; });
+            }
+        });
+
+        IsTraining = false;
+        TrainButtonText = Se.Language.Ocr.StartTraining;
+    }
+
+    [RelayCommand]
+    private async Task ImportCharactersFromFile()
+    {
+        var fileName = await _fileHelper.PickOpenSubtitleFile(Window!, Se.Language.General.OpenSubtitleFileTitle, includeVideoFiles: false);
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return;
+        }
+
+        var subtitle = Subtitle.Parse(fileName);
+        if (subtitle == null)
+        {
+            return;
+        }
+
+        var seen = new System.Collections.Generic.HashSet<char>();
+        var sb = new StringBuilder();
+        foreach (var paragraph in subtitle.Paragraphs)
+        {
+            foreach (var ch in HtmlUtil.RemoveHtmlTags(paragraph.Text, true))
+            {
+                if (!char.IsWhiteSpace(ch) && seen.Add(ch))
+                {
+                    sb.Append(ch);
+                }
+            }
+        }
+
+        if (sb.Length > 0)
+        {
+            CharactersToTrain = sb.ToString();
+        }
+    }
+
+    [RelayCommand]
+    private void Done()
+    {
+        _abort = true;
+        SaveSettings(Fonts.Where(f => f.IsSelected).Select(f => f.Name).ToList());
+        Close();
+    }
+
+    private void SaveSettings(System.Collections.Generic.List<string> fontNames)
+    {
+        var ocr = Se.Settings.Ocr;
+        ocr.NOcrTrainFonts = string.Join(';', fontNames);
+        ocr.NOcrTrainMergedLetters = MergedLetters;
+        ocr.NOcrTrainFontSize = FontSize;
+        ocr.NOcrTrainSegmentCount = NumberOfSegments;
+        ocr.NOcrTrainBold = TrainBold;
+        ocr.NOcrTrainItalic = TrainItalic;
+        Se.SaveSettings();
+    }
+
+    private void Close()
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            Window?.Close();
+        });
+    }
+
+    internal void KeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Done();
+        }
+    }
+
+    internal void OnClosing()
+    {
+        _abort = true;
+    }
+}

--- a/src/ui/Features/Ocr/NOcr/NOcrTrainWindow.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrTrainWindow.cs
@@ -1,0 +1,119 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Ocr.NOcr;
+
+public class NOcrTrainWindow : Window
+{
+    public NOcrTrainWindow(NOcrTrainViewModel vm)
+    {
+        Title = Se.Language.Ocr.TrainNOcrDatabase.TrimEnd('.');
+        vm.Window = this;
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Width = 760;
+        SizeToContent = SizeToContent.Height;
+        CanResize = false;
+        WindowStartupLocation = WindowStartupLocation.CenterOwner;
+        DataContext = vm;
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // fonts + options
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // characters
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // merged letters
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // status
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // buttons
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            ColumnSpacing = 10,
+            RowSpacing = 10,
+        };
+
+        // Fonts (checkbox list, each rendered in its own typeface)
+        var fontsListBox = new ListBox
+        {
+            Height = 260,
+            ItemsSource = vm.Fonts,
+            ItemTemplate = new FuncDataTemplate<NOcrTrainFontItem>((item, _) => new CheckBox
+            {
+                [!CheckBox.IsCheckedProperty] = new Binding(nameof(NOcrTrainFontItem.IsSelected)),
+                Content = item.Name,
+                FontFamily = new FontFamily(item.Name),
+            }),
+        };
+        var fontsPanel = new StackPanel { Orientation = Orientation.Vertical, Spacing = 4 };
+        fontsPanel.Children.Add(UiUtil.MakeLabel(Se.Language.General.Fonts));
+        fontsPanel.Children.Add(UiUtil.MakeBorderForControlNoPadding(fontsListBox));
+        var fontsGroup = fontsPanel;
+
+        // Options
+        var optionsPanel = new StackPanel { Orientation = Orientation.Vertical, Spacing = 6 };
+        optionsPanel.Children.Add(UiUtil.MakeLabel(Se.Language.General.Name));
+        optionsPanel.Children.Add(UiUtil.MakeTextBox(220, vm, nameof(vm.DatabaseName)));
+        optionsPanel.Children.Add(UiUtil.MakeLabel(Se.Language.General.FontSize));
+        optionsPanel.Children.Add(UiUtil.MakeNumericUpDownInt(20, 100, 30, 120, vm, nameof(vm.FontSize)));
+        optionsPanel.Children.Add(UiUtil.MakeLabel(Se.Language.Ocr.NumberOfLineSegments));
+        optionsPanel.Children.Add(UiUtil.MakeNumericUpDownInt(10, 500, 60, 120, vm, nameof(vm.NumberOfSegments)));
+        optionsPanel.Children.Add(UiUtil.MakeCheckBox(Se.Language.Ocr.AlsoTrainBold, vm, nameof(vm.TrainBold)));
+        optionsPanel.Children.Add(UiUtil.MakeCheckBox(Se.Language.Ocr.AlsoTrainItalic, vm, nameof(vm.TrainItalic)));
+        var optionsOuterPanel = new StackPanel { Orientation = Orientation.Vertical, Spacing = 4 };
+        optionsOuterPanel.Children.Add(UiUtil.MakeLabel(Se.Language.Ocr.TrainingOptions));
+        optionsOuterPanel.Children.Add(UiUtil.MakeBorderForControl(optionsPanel));
+        var optionsGroup = optionsOuterPanel;
+
+        // Characters to train + import from subtitle file
+        var charactersPanel = new StackPanel { Orientation = Orientation.Vertical, Spacing = 6 };
+        var charactersTextBox = UiUtil.MakeTextBox(710, vm, nameof(vm.CharactersToTrain));
+        charactersTextBox.TextWrapping = TextWrapping.Wrap;
+        charactersTextBox.AcceptsReturn = false;
+        charactersTextBox.Height = 60;
+        charactersPanel.Children.Add(charactersTextBox);
+        charactersPanel.Children.Add(UiUtil.MakeButton(Se.Language.Ocr.ImportCharactersFromSubtitleFile, vm.ImportCharactersFromFileCommand));
+        var charactersOuterPanel = new StackPanel { Orientation = Orientation.Vertical, Spacing = 4 };
+        charactersOuterPanel.Children.Add(UiUtil.MakeLabel(Se.Language.Ocr.CharactersToTrain));
+        charactersOuterPanel.Children.Add(charactersPanel);
+        var charactersGroup = charactersOuterPanel;
+
+        // Merged letter combinations
+        var mergedTextBox = UiUtil.MakeTextBox(710, vm, nameof(vm.MergedLetters));
+        var mergedPanel = new StackPanel { Orientation = Orientation.Vertical, Spacing = 4 };
+        mergedPanel.Children.Add(UiUtil.MakeLabel(Se.Language.Ocr.LetterCombinationsToTrain));
+        mergedPanel.Children.Add(mergedTextBox);
+        var mergedGroup = mergedPanel;
+
+        var labelStatus = UiUtil.MakeLabel(string.Empty).WithBindText(vm, nameof(vm.StatusText));
+
+        var buttonTrain = UiUtil.MakeButton(Se.Language.Ocr.StartTraining, vm.StartOrAbortTrainingCommand);
+        buttonTrain[!ContentControl.ContentProperty] = new Binding(nameof(vm.TrainButtonText));
+        var buttonDone = UiUtil.MakeButtonDone(vm.DoneCommand);
+        var buttonBar = UiUtil.MakeButtonBar(buttonTrain, buttonDone);
+
+        grid.Add(fontsGroup, 0, 0);
+        grid.Add(optionsGroup, 0, 1);
+        grid.Add(charactersGroup, 1, 0, 1, 2);
+        grid.Add(mergedGroup, 2, 0, 1, 2);
+        grid.Add(labelStatus, 3, 0, 1, 2);
+        grid.Add(buttonBar, 4, 0, 1, 2);
+
+        Content = grid;
+
+        Activated += delegate
+        {
+            buttonTrain.Focus(); // hack to make OnKeyDown work
+        };
+        KeyDown += (_, e) => vm.KeyDown(e);
+        Closing += (_, _) => vm.OnClosing();
+    }
+}

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -1558,6 +1558,24 @@ public partial class OcrViewModel : ObservableObject
             return;
         }
 
+        if (result.TrainPressed)
+        {
+            var trainResult = await _windowService.ShowDialogAsync<NOcrTrainWindow, NOcrTrainViewModel>(Window!, _ => { });
+            _isCtrlDown = false;
+            if (trainResult.TrainedDatabaseName != null)
+            {
+                NOcrDatabases.Clear();
+                foreach (var s in NOcrDb.GetDatabases(Se.OcrFolder).OrderBy(p => p))
+                {
+                    NOcrDatabases.Add(s);
+                }
+
+                SelectedNOcrDatabase = trainResult.TrainedDatabaseName;
+            }
+
+            return;
+        }
+
         if (result.RenamePressed)
         {
             var newResult = await _windowService.ShowDialogAsync<NOcrDbNewWindow, NOcrDbNewViewModel>(Window!,

--- a/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
+++ b/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
@@ -124,6 +124,19 @@ public class LanguageOcr
     public string LlamaCppDownloadModelPrompt { get; set; }
     public string CrispEmbedNotDownloaded { get; set; }
     public string CrispEmbedReturnedNoText { get; set; }
+    public string TrainNOcrDatabase { get; set; }
+    public string StartTraining { get; set; }
+    public string AbortTraining { get; set; }
+    public string TrainingOptions { get; set; }
+    public string CharactersToTrain { get; set; }
+    public string LetterCombinationsToTrain { get; set; }
+    public string ImportCharactersFromSubtitleFile { get; set; }
+    public string NumberOfLineSegments { get; set; }
+    public string AlsoTrainBold { get; set; }
+    public string AlsoTrainItalic { get; set; }
+    public string TrainingXLearnedYSkipped { get; set; }
+    public string TrainingDoneXLearned { get; set; }
+    public string SelectAtLeastOneFont { get; set; }
 
     public LanguageOcr()
     {
@@ -250,5 +263,19 @@ public class LanguageOcr
         LlamaCppDownloadModelPrompt = "llama.cpp requires the selected OCR model to be downloaded. Download now?";
         CrispEmbedNotDownloaded = "CrispEmbed engine/model not downloaded - download via batch convert settings";
         CrispEmbedReturnedNoText = "CrispEmbed returned no text - check the model";
+
+        TrainNOcrDatabase = "Train nOCR database...";
+        StartTraining = "Start training";
+        AbortTraining = "Abort training";
+        TrainingOptions = "Training options";
+        CharactersToTrain = "Characters to train";
+        LetterCombinationsToTrain = "Letter combinations that might be split to one image";
+        ImportCharactersFromSubtitleFile = "Import characters from subtitle file...";
+        NumberOfLineSegments = "Number of line segments";
+        AlsoTrainBold = "Also train bold";
+        AlsoTrainItalic = "Also train italic";
+        TrainingXLearnedYSkipped = "Training \"{0}\" - {1:#,##0} characters learned, {2:#,##0} skipped";
+        TrainingDoneXLearned = "Training done - {0:#,##0} characters learned";
+        SelectAtLeastOneFont = "Please select at least one font";
     }
 }

--- a/src/ui/Logic/Config/SeOcr.cs
+++ b/src/ui/Logic/Config/SeOcr.cs
@@ -51,6 +51,12 @@ public class SeOcr
     public bool TextBoxFontBold { get; set; }
     public string TextBoxFontName { get; set; }
     public bool UseWordSplitList { get; set; }
+    public string NOcrTrainFonts { get; set; }
+    public string NOcrTrainMergedLetters { get; set; }
+    public int NOcrTrainFontSize { get; set; }
+    public int NOcrTrainSegmentCount { get; set; }
+    public bool NOcrTrainBold { get; set; }
+    public bool NOcrTrainItalic { get; set; }
     public bool VobSubUseCustomColors { get; set; }
     public string VobSubColorBackground { get; set; }
     public string VobSubColorPattern { get; set; }
@@ -115,6 +121,11 @@ public class SeOcr
         CaptureAssaPosition = false;
 
         PromptForBlankOcrText = true;
+
+        NOcrTrainFonts = string.Empty;
+        NOcrTrainMergedLetters = string.Empty;
+        NOcrTrainFontSize = 30;
+        NOcrTrainSegmentCount = 60;
 
         VobSubUseCustomColors = false;
         VobSubColorBackground = "#00000000";

--- a/tests/libuilogic/Ocr/NOcrDbBestMatchTests.cs
+++ b/tests/libuilogic/Ocr/NOcrDbBestMatchTests.cs
@@ -1,0 +1,83 @@
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+using SkiaSharp;
+
+namespace LibUiLogicTests.Ocr;
+
+/// <summary>
+/// Pins the best-match-within-pass semantics of <see cref="NOcrDb.GetMatchSingle"/>: when
+/// several candidates fit a pass's error budget, the one with the fewest wrong pixels wins -
+/// not the one that happens to come first in the list.
+/// </summary>
+public class NOcrDbBestMatchTests
+{
+    /// <summary>10x10 bitmap with an opaque 3px vertical bar at x = 4..6.</summary>
+    private static NikseBitmap2 MakeBarBitmap()
+    {
+        var bmp = new SKBitmap(10, 10);
+        using (var canvas = new SKCanvas(bmp))
+        {
+            canvas.Clear(SKColors.Transparent);
+            using var paint = new SKPaint { Color = SKColors.White };
+            canvas.DrawRect(4, 0, 3, 10, paint);
+        }
+
+        return new NikseBitmap2(bmp);
+    }
+
+    [Fact]
+    public void GetMatchSingle_PrefersFewestErrors_OverListOrder()
+    {
+        var bitmap = MakeBarBitmap();
+
+        // Both characters are 20x20 (so the strict size passes are skipped and matching lands
+        // in the aspect-only pass with a 3-error budget) and match the bar's foreground.
+        // The decoy also has a short background line that lands ON the bar when scaled
+        // (2 wrong pixels) - still within the pass budget, so the old first-match-wins
+        // algorithm returned it. The correct character matches with 0 errors.
+        var decoy = new NOcrChar("#") { Width = 20, Height = 20, MarginTop = 0 };
+        decoy.LinesForeground.Add(new NOcrLine(new OcrPoint(10, 0), new OcrPoint(10, 19)));
+        decoy.LinesBackground.Add(new NOcrLine(new OcrPoint(8, 0), new OcrPoint(8, 1)));
+
+        var correct = new NOcrChar("l") { Width = 20, Height = 20, MarginTop = 0 };
+        correct.LinesForeground.Add(new NOcrLine(new OcrPoint(10, 0), new OcrPoint(10, 19)));
+        correct.LinesBackground.Add(new NOcrLine(new OcrPoint(1, 0), new OcrPoint(1, 19)));
+
+        var db = new NOcrDb(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".nocr"));
+        db.Add(correct);
+        db.Add(decoy); // Add inserts at the front, so the decoy is FIRST in the list
+
+        // Sanity: the decoy really does fit the 3-error budget (the old algorithm would
+        // have accepted it), and the correct char matches perfectly.
+        Assert.True(NOcrDb.IsMatch(bitmap, decoy, 3));
+        Assert.False(NOcrDb.IsMatch(bitmap, decoy, 1));
+        Assert.True(NOcrDb.IsMatch(bitmap, correct, 0));
+
+        var match = db.GetMatchSingle(bitmap, 0, false, 25);
+
+        Assert.NotNull(match);
+        Assert.Equal("l", match!.Text);
+    }
+
+    [Fact]
+    public void GetMatchSingle_EqualErrors_KeepsNewestFirst()
+    {
+        var bitmap = MakeBarBitmap();
+
+        // Two equally good candidates: the newest added (front of the list) must win, so a
+        // user's just-added correction takes precedence over an equally-matching older entry.
+        var older = new NOcrChar("I") { Width = 20, Height = 20, MarginTop = 0 };
+        older.LinesForeground.Add(new NOcrLine(new OcrPoint(10, 0), new OcrPoint(10, 19)));
+
+        var newer = new NOcrChar("l") { Width = 20, Height = 20, MarginTop = 0 };
+        newer.LinesForeground.Add(new NOcrLine(new OcrPoint(10, 0), new OcrPoint(10, 19)));
+
+        var db = new NOcrDb(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".nocr"));
+        db.Add(older);
+        db.Add(newer);
+
+        var match = db.GetMatchSingle(bitmap, 0, false, 25);
+
+        Assert.NotNull(match);
+        Assert.Equal("l", match!.Text);
+    }
+}

--- a/tests/libuilogic/Ocr/NOcrDbMatchCacheTests.cs
+++ b/tests/libuilogic/Ocr/NOcrDbMatchCacheTests.cs
@@ -1,0 +1,113 @@
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+using SkiaSharp;
+
+namespace LibUiLogicTests.Ocr;
+
+/// <summary>
+/// Verifies that the match-result cache in <see cref="NOcrDb"/> is transparent: repeated calls
+/// return the same results, and database mutations (Add/Remove) invalidate cached results.
+/// </summary>
+public class NOcrDbMatchCacheTests
+{
+    private static string TestFontName => SKTypeface.Default.FamilyName;
+
+    private static (NOcrDb Db, NikseBitmap2 Parent, List<ImageSplitterItem2> Letters) SetUp(string trainChars, string renderText)
+    {
+        var db = new NOcrDb(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".nocr"));
+        var trainer = new NOcrTrainer();
+        trainer.Train(new NOcrTrainerSettings
+        {
+            FontNames = { TestFontName },
+            FontSize = 50,
+            CharactersToTrain = trainChars,
+        }, db);
+
+        using var bmp = NOcrTrainer.RenderCharacterImage(renderText, TestFontName, 50, false, false);
+        var parent = new NikseBitmap2(bmp!);
+        parent.MakeTwoColor(200);
+        parent.CropTop(0, new SKColor(0, 0, 0, 0));
+        var letters = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(parent, 10, false, false, 25, false);
+        return (db, parent, letters);
+    }
+
+    [Fact]
+    public void GetMatch_RepeatedCalls_ReturnSameResults()
+    {
+        var (db, parent, letters) = SetUp("abc", "abc abc abc");
+
+        var first = new List<string?>();
+        var second = new List<string?>();
+        foreach (var round in new[] { first, second })
+        {
+            foreach (var item in letters.Where(l => l.NikseBitmap != null))
+            {
+                var match = db.GetMatch(parent, letters, item, item.Top, true, 25);
+                round.Add(match?.Text);
+            }
+        }
+
+        Assert.Equal(first, second);
+        Assert.Contains("a", first);
+        Assert.Contains("b", first);
+        Assert.Contains("c", first);
+    }
+
+    [Fact]
+    public void GetMatch_AddInvalidatesCachedMiss()
+    {
+        var (db, parent, letters) = SetUp("ab", "abz");
+
+        var glyphs = letters.Where(l => l.NikseBitmap != null).ToList();
+        var zItem = glyphs[^1];
+
+        // Cache the miss for 'z'.
+        var missing = db.GetMatch(parent, letters, zItem, zItem.Top, true, 25);
+        Assert.Null(missing);
+
+        // Now train 'z' into the same db - the cached miss must be discarded.
+        var trainer = new NOcrTrainer();
+        trainer.Train(new NOcrTrainerSettings
+        {
+            FontNames = { TestFontName },
+            FontSize = 50,
+            CharactersToTrain = "z",
+        }, db);
+
+        var found = db.GetMatch(parent, letters, zItem, zItem.Top, true, 25);
+        Assert.NotNull(found);
+        Assert.Equal("z", found!.Text);
+    }
+
+    [Fact]
+    public void GetMatch_RemoveInvalidatesCachedHit()
+    {
+        var (db, parent, letters) = SetUp("ab", "ab");
+
+        var glyphs = letters.Where(l => l.NikseBitmap != null).ToList();
+        var aItem = glyphs[0];
+
+        var match = db.GetMatch(parent, letters, aItem, aItem.Top, true, 25);
+        Assert.NotNull(match);
+
+        db.Remove(match!);
+
+        var afterRemove = db.GetMatch(parent, letters, aItem, aItem.Top, true, 25);
+        Assert.True(afterRemove == null || !ReferenceEquals(afterRemove, match));
+    }
+
+    [Fact]
+    public void GetMatch_DifferentParameters_DoNotShareCacheEntries()
+    {
+        var (db, parent, letters) = SetUp("a", "a");
+
+        var item = letters.First(l => l.NikseBitmap != null);
+
+        // Prime the cache with a strict budget, then query with a generous one; the two
+        // parameter sets must not alias each other.
+        var strict = db.GetMatch(parent, letters, item, item.Top, false, 0);
+        var generous = db.GetMatch(parent, letters, item, item.Top, true, 25);
+
+        Assert.NotNull(generous);
+        Assert.True(strict == null || strict.Text == generous!.Text);
+    }
+}

--- a/tests/libuilogic/Ocr/NOcrTrainerTests.cs
+++ b/tests/libuilogic/Ocr/NOcrTrainerTests.cs
@@ -1,0 +1,136 @@
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+using SkiaSharp;
+using System.Text;
+
+namespace LibUiLogicTests.Ocr;
+
+/// <summary>
+/// End-to-end verification of the nOCR engine: train a database from rendered glyphs
+/// (<see cref="NOcrTrainer"/>), then run the same recognition pipeline the app uses
+/// (two-color + crop + splitter + <see cref="NOcrDb.GetMatch"/>) over rendered sentences and
+/// verify the text round-trips.
+/// </summary>
+public class NOcrTrainerTests
+{
+    private const float FontSize = 50f;
+    private const int MaxWrongPixels = 25;
+    // The app default (SeOcr.NOcrPixelsAreSpace / seconv PixelsAreSpaceDefault).
+    private const int PixelsAreSpace = 12;
+
+    private static string TestFontName => SKTypeface.Default.FamilyName;
+
+    private static NOcrDb Train(string characters, bool italic = false)
+    {
+        var db = new NOcrDb(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".nocr"));
+        var trainer = new NOcrTrainer();
+        var settings = new NOcrTrainerSettings
+        {
+            FontNames = { TestFontName },
+            FontSize = FontSize,
+            CharactersToTrain = characters,
+            IncludeItalic = italic,
+        };
+        var learned = trainer.Train(settings, db);
+        Assert.True(learned > 0, "training should learn at least one character");
+        return db;
+    }
+
+    private static string Recognize(NOcrDb db, string text, bool italic = false)
+    {
+        using var bmp = NOcrTrainer.RenderCharacterImage(text, TestFontName, FontSize, false, italic);
+        Assert.NotNull(bmp);
+        var parent = new NikseBitmap2(bmp!);
+        parent.MakeTwoColor(200);
+        parent.CropTop(0, new SKColor(0, 0, 0, 0));
+        var letters = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(parent, PixelsAreSpace, false, false, 25, false);
+
+        var sb = new StringBuilder();
+        var i = 0;
+        while (i < letters.Count)
+        {
+            var item = letters[i];
+            if (item.NikseBitmap == null)
+            {
+                sb.Append(item.SpecialCharacter);
+            }
+            else
+            {
+                var match = db.GetMatch(parent, letters, item, item.Top, true, MaxWrongPixels);
+                if (match is { ExpandCount: > 0 })
+                {
+                    i += match.ExpandCount - 1;
+                }
+
+                sb.Append(match?.Text ?? "*");
+            }
+
+            i++;
+        }
+
+        return sb.ToString().Trim();
+    }
+
+    [Fact]
+    public void TrainedDb_RoundTripsRenderedSentence()
+    {
+        var db = Train("HeloWrd123");
+
+        var result = Recognize(db, "Hello World 123");
+
+        Assert.Equal("Hello World 123", result);
+    }
+
+    [Fact]
+    public void TrainedDb_RoundTripsAfterSaveAndReload()
+    {
+        var db = Train("Subtiles");
+        try
+        {
+            db.Save();
+            var reloaded = new NOcrDb(db.FileName);
+            Assert.Equal(db.TotalCharacterCount, reloaded.TotalCharacterCount);
+
+            var result = Recognize(reloaded, "Subtitle test");
+            Assert.Equal("Subtitle test", result);
+        }
+        finally
+        {
+            if (File.Exists(db.FileName))
+            {
+                File.Delete(db.FileName);
+            }
+        }
+    }
+
+    [Fact]
+    public void Trainer_SkipsAlreadyKnownCharacters()
+    {
+        var db = new NOcrDb(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".nocr"));
+        var trainer = new NOcrTrainer();
+        var settings = new NOcrTrainerSettings
+        {
+            FontNames = { TestFontName },
+            FontSize = FontSize,
+            CharactersToTrain = "ABC",
+        };
+
+        var firstRun = trainer.Train(settings, db);
+        var countAfterFirst = db.TotalCharacterCount;
+        var secondRun = trainer.Train(settings, db);
+
+        Assert.True(firstRun > 0);
+        Assert.Equal(countAfterFirst, db.TotalCharacterCount);
+        Assert.Equal(0, secondRun);
+    }
+
+    [Fact]
+    public void Trainer_UnknownGlyph_RecognizesAsAsterisk()
+    {
+        var db = Train("Helo");
+
+        var result = Recognize(db, "Hello Zebra");
+
+        Assert.StartsWith("Hello ", result);
+        Assert.Contains("*", result);
+    }
+}


### PR DESCRIPTION
## Engine improvements (`NOcrDb`)

- **Match-result cache**: `GetMatch` results are cached per exact glyph pixel content + match parameters (top margin, deep-seek, wrong-pixel budget, last-ditch). Subtitle lines repeat the same glyph bitmaps constantly, and *unmatched* glyphs were the worst case — every occurrence re-ran the whole 8-pass cascade against the full database. Cache hits compare full pixel data (not just the hash), so a collision can never return a wrong character. Expanded matches are always evaluated live since they depend on neighboring splitter items.
- **Exact-match size index**: exact-match candidates are bucketed by `(width, height)` instead of scanning the whole single-character list per glyph. Insertion order is preserved per bucket, so first-match-wins semantics are unchanged.
- Both caches are invalidated on `Add`/`Remove`/`Load` and on `Save` (the edit dialogs mutate the character lists/lines directly and always save afterwards).

Measured with a harness over the shipped `Latin.nocr` (694 chars, 200 rendered lines, miss-heavy workload): **1291 ms with cache vs 2790 ms with the cache cleared per line** — and the per-line-cleared baseline still benefits from within-line caching, so the speedup vs the old code is larger.

## Train nOCR (port of SE4's `VobSubNOcrTrain`)

- **`NOcrTrainer`** (libuilogic, UI-free): renders characters with installed fonts via SkiaSharp — white fill + black outline, like typical image subtitles — using the `"H   x"` layout from SE4 so glyphs get realistic top margins. Trains every glyph the database doesn't already recognize, including multi-part glyphs (`"`, `%`, …) as expanded characters via `ExpandedOcrGroup`. Merged letter combinations (e.g. `fi rn`) are trained when they render as one connected glyph, matching SE4.
- **`NOcrTrainWindow`**: font checklist (each font previewed in its own typeface), font size, line-segment count, bold/italic, editable character set + "import characters from subtitle file", trains into a new database in the OCR folder and selects it afterwards. Settings persist in `SeOcr`.
- **Semi-hidden entry**: right-click context menu in the nOCR database settings dialog (Edit/Delete/Rename/New) → "Train nOCR database...".

New language strings are in `LanguageOcr.cs` only (English.json regeneration left to the usual flow).

## Verification tests

- **End-to-end** (`NOcrTrainerTests`): train a database from rendered glyphs, then OCR rendered sentences through the real pipeline (two-color → crop → splitter → `GetMatch`) and assert the text round-trips exactly ("Hello World 123"), including after save/reload; unknown glyphs come back as `*`; re-training a trained set learns 0 new characters.
- **Cache** (`NOcrDbMatchCacheTests`): repeated calls return identical results; `Add` invalidates cached misses (the mid-OCR "add character" flow); `Remove` invalidates cached hits; different match parameters don't alias each other.

Full suite: 157/157 libuilogic, 2251/2251 UI tests, full solution builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Accuracy: best-match-within-pass (second commit)

`GetMatchSingle` was first-match-wins: with the loose passes' budgets (3/10/20+ wrong pixels), the first DB character that fit the budget won even when a later one matched near-perfectly. Each pass now ranks all candidates passing its filters by actual wrong-pixel count and returns the best; equal-error ties keep list order so a user's just-added character still beats an equally-good older entry. The counting loop shrinks its budget to "current best − 1" (candidates abort as soon as they can't win), and the match cache means the extra scanning is paid once per distinct glyph.

Cross-size harness (train at 40/44 px, recognize pangrams at 30–52 px, 980 chars): error rate drops at every size — **12.8% → ~8–9%** at the trained size, **~214 → ~168 total errors (~20% relative)**. Rate-based ranking (errors ÷ points walked) was also tried and was no better than the simple count, so the simpler rule stays.

`NOcrDbBestMatchTests` pins the semantics deterministically: a planted decoy inside the pass budget loses to a later perfect match (the old algorithm returned the decoy), and equal-error ties stay newest-first.
