### PR TITLE
Spell check: crop transparent area from source-image preview

### DIFF
--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -3607,7 +3607,7 @@ public partial class OcrViewModel : ObservableObject
 
                     var suggestions = _ocrFixEngine.GetSpellCheckSuggestions(unknownWord.Word.FixedWord);
                     var result = await _windowService.ShowDialogAsync<PromptUnknownWordWindow, PromptUnknownWordViewModel>(Window!,
-                        vm => { vm.Initialize(item.GetBitmap(), item.Text, unknownWord, suggestions); });
+                        vm => { vm.Initialize(item.GetBitmapCropped(), item.Text, unknownWord, suggestions); });
 
                     if (result.ChangeWholeTextPressed)
                     {

--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -416,8 +416,12 @@ public partial class SpellCheckViewModel : ObservableObject, IClosingCleanup
         var previous = SourceImage;
         try
         {
+            // Trim the transparent screen area around the text so formats with full-screen
+            // bitmaps (e.g. VobSub) show the text zoomed to the preview instead of a tiny
+            // strip at the bottom (#13418).
             using var sourceBitmap = _ocrSourceImages.GetBitmap(bestIndex);
-            SourceImage = sourceBitmap.ToAvaloniaBitmap();
+            using var cropped = sourceBitmap.CropTransparentColors();
+            SourceImage = cropped.ToAvaloniaBitmap();
         }
         catch
         {


### PR DESCRIPTION
Fixes #13418

The spell check window's source-image preview showed the raw subtitle bitmap. For formats that store full-screen bitmaps (e.g. VobSub idx/sub), the actual text is a tiny strip at the bottom of a mostly transparent 719×571 frame, so the preview was unreadable.

## Changes

- `SpellCheckViewModel.UpdateSourceImage`: run the bitmap through the existing `CropTransparentColors()` extension before converting to an Avalonia bitmap. With the transparent border gone, the preview's `Stretch.Uniform` scales the text strip to fill the panel — effectively zoomed in. Both temporaries are disposed, preserving the per-line leak fix from #11719.
- OCR unknown-word prompt (`OcrViewModel.PromptForUnknownWordsAsync`): use the existing `item.GetBitmapCropped()` instead of `item.GetBitmap()` — same problem, same fix.

## Verification

Ran the real pipeline (`VobSubParser` → `OcrSubtitleVobSub.GetBitmap` → `CropTransparentColors`) headlessly on the issue's attached eng.idx/eng.sub: 1642 packs parsed (matching "line 1495 of 1642" in the issue's screenshot); line 1495 crops from 719×571 to 471×26 and reads clearly ("You cannot hide here for ever, meu amor."). `CropTransparentColors` already handles fully transparent frames (returns 1×1) and empty bitmaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)