### PR TITLE
Fix #13407: subtitles intermittently missing in fullscreen playback

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1094,6 +1094,11 @@ public partial class MainViewModel :
                 // (discussion #11744).
                 ReapplyPlaybackSpeed();
 
+                // The subtitle is state the fresh player starts over with too, and the refresh
+                // armed above may well have run before its mpv core was up. Arm it again now
+                // that the player is really playing (same reasoning as fullscreen, #13407).
+                RefreshSubtitlePreview();
+
                 if (savedAudioTrack != null && vp.VideoPlayer is LibMpvDynamicPlayer mpv)
                 {
                     mpv.SetAudioTrack(savedAudioTrack.Id);
@@ -13498,25 +13503,21 @@ public partial class MainViewModel :
             }
 
             Dispatcher.UIThread.Post(() => TableViewExtras.FocusRow(SubtitleGrid));
-        }, toggleKeys, showMediaInfoKeys, showMediaInformationOwnedBy, extraBindings, ReapplySelectedAudioTrack);
+        }, toggleKeys, showMediaInfoKeys, showMediaInformationOwnedBy, extraBindings, readyPlayer =>
+        {
+            // Runs once the fullscreen player has actually opened the file (see the window's
+            // Loaded handler). Both of these re-apply state a brand new mpv instance starts
+            // over with, and both have to wait for that point:
+            ReapplySelectedAudioTrack(readyPlayer); // the selected audio track (#12844)
+            RefreshSubtitlePreview();               // and the subtitle itself (#13407)
+        });
         fullScreenWindow.Show(Window!);
         _shortcutManager.ClearKeys();
 
-        var vp = GetVideoPlayerControl();
-        if (vp != null)
-        {
-            if (vp.VideoPlayer is LibMpvDynamicPlayer mpv)
-            {
-                _mpvReloader.Reset();
-                _mpvReloader.RefreshMpv(mpv, GetUpdateSubtitle(), _subtitleSecondary, SelectedSubtitleFormat);
-            }
-            else if (vp.VideoPlayer is LibVlcDynamicPlayer vlc)
-            {
-                _vlcReloader.Reset();
-                _vlcReloader.RefreshVlc(vlc, GetUpdateSubtitle(), _subtitleSecondary, SelectedSubtitleFormat);
-            }
-        }
-
+        // Only arms the preview - the push happens on the next timer tick and is retried until
+        // the new player takes it. Pushing right here (as this used to) cannot work: the
+        // fullscreen mpv core is initialized lazily by its rendering surface and has not even
+        // loaded the video yet, so mpv rejected the sub-add and nothing tried again (#13407).
         RefreshSubtitlePreview();
     }
 
@@ -23768,8 +23769,12 @@ public partial class MainViewModel :
             return;
         }
 
+        // No player, or a player with no video: there is nothing to draw a subtitle on. The dirty
+        // flag stays set (and VideoOpenFile re-arms it anyway), so opening a video pushes right
+        // away - while a rejected push is not retried against a player that has no file, which
+        // would rewrite the temp subtitle file every 400 ms for the rest of the session.
         var vp = GetVideoPlayerControl();
-        if (vp == null)
+        if (vp == null || string.IsNullOrEmpty(_videoFileName))
         {
             return;
         }
@@ -23800,27 +23805,45 @@ public partial class MainViewModel :
                 subtitle.Paragraphs.RemoveAll(p => !_visibleLayers!.Contains(p.Layer));
             }
 
-            _ = RunPreviewRefresh(() => _vlcReloader.RefreshVlc(vlc, subtitle, _subtitleSecondary, SelectedSubtitleFormat));
+            _ = RunPreviewRefresh(async () =>
+            {
+                await _vlcReloader.RefreshVlc(vlc, subtitle, _subtitleSecondary, SelectedSubtitleFormat);
+                return true;
+            });
         }
     }
 
-    private async Task RunPreviewRefresh(Func<Task> refresh)
+    /// <param name="refresh">
+    /// Pushes the subtitle to the player and answers whether it arrived. A false - mpv rejecting
+    /// sub-add because the freshly created player is not playing yet - is retried, not swallowed:
+    /// nothing else re-pushes during plain playback, so one lost push left fullscreen without
+    /// subtitles for the whole session (issue #13407).
+    /// </param>
+    private async Task RunPreviewRefresh(Func<Task<bool>> refresh)
     {
         _mpvPreviewRefreshBusy = true;
         try
         {
-            await refresh();
+            if (!await refresh())
+            {
+                RetryPreviewRefreshLater();
+            }
         }
         catch (Exception exception)
         {
             Se.LogError(exception, "Video preview subtitle refresh failed");
-            _mpvPreviewDirty = true; // retry on a later tick
-            _previewRetryNotBeforeMs = Environment.TickCount64 + 400;
+            RetryPreviewRefreshLater();
         }
         finally
         {
             _mpvPreviewRefreshBusy = false;
         }
+    }
+
+    private void RetryPreviewRefreshLater()
+    {
+        _mpvPreviewDirty = true; // retry on a later tick
+        _previewRetryNotBeforeMs = Environment.TickCount64 + 400;
     }
 
     // Auto-save (saves the actual open file) state. Debounced: we only write once edits have

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -13502,6 +13502,12 @@ public partial class MainViewModel :
                 dockedMpv.SetSubtitleVisibility(_mpvReloader.SubtitlesVisible);
             }
 
+            // And the subtitle itself: entering fullscreen reset the reloader, which deleted
+            // the temp file behind the docked player's still-loaded subtitle - so it can only
+            // show the pre-fullscreen text and cannot even be sub-reloaded. Re-arm the preview
+            // so the docked player gets a fresh push (#13407).
+            RefreshSubtitlePreview();
+
             Dispatcher.UIThread.Post(() => TableViewExtras.FocusRow(SubtitleGrid));
         }, toggleKeys, showMediaInfoKeys, showMediaInformationOwnedBy, extraBindings, readyPlayer =>
         {

--- a/src/ui/Logic/Media/IMpvReloader.cs
+++ b/src/ui/Logic/Media/IMpvReloader.cs
@@ -7,7 +7,9 @@ namespace Nikse.SubtitleEdit.Logic.Media;
 
 public interface IMpvReloader
 {
-    Task RefreshMpv(LibMpvDynamicPlayer mpv, Subtitle subtitle, Subtitle? subtitleSecondary, SubtitleFormat uiFormat);
+    /// <returns>False when mpv did not take the subtitle and the caller should retry - see
+    /// <see cref="MpvReloader.RefreshMpv"/>.</returns>
+    Task<bool> RefreshMpv(LibMpvDynamicPlayer mpv, Subtitle subtitle, Subtitle? subtitleSecondary, SubtitleFormat uiFormat);
     void Reset();
     bool SmpteMode { get; set; }
     bool SubtitlesVisible { get; set; }

--- a/src/ui/Logic/Media/MpvReloader.cs
+++ b/src/ui/Logic/Media/MpvReloader.cs
@@ -134,6 +134,16 @@ public class MpvReloader : IMpvReloader
                     // fields alone - remembering this text as the one mpv is showing is what used
                     // to make the miss permanent - and let the caller retry. The retry budget is
                     // not spent either: nothing was loaded to retry against yet.
+                    if (!reAdd)
+                    {
+                        // A failed sub-reload cannot fix itself: it means the player has no
+                        // loadable file behind its subtitle track (leaving fullscreen goes back
+                        // to a player whose temp file was deleted when fullscreen opened).
+                        // Forget the file so the retry takes the sub-remove + sub-add path
+                        // instead of reloading into the void every 400 ms.
+                        _mpvTextFileName = null;
+                    }
+
                     return false;
                 }
 

--- a/src/ui/Logic/Media/MpvReloader.cs
+++ b/src/ui/Logic/Media/MpvReloader.cs
@@ -31,7 +31,14 @@ public class MpvReloader : IMpvReloader
     // of pushing old text over new. Only touched on the UI thread.
     private int _refreshVersion;
 
-    public async Task RefreshMpv(LibMpvDynamicPlayer mpvContext, Subtitle subtitle, Subtitle? subtitleSecondary, SubtitleFormat uiFormat)
+    /// <returns>
+    /// False when the subtitle could not be handed to mpv and the caller should try again - the
+    /// core of a freshly created player (fullscreen, undock, layout rebuild) is initialized
+    /// lazily and rejects sub-add until the file is actually playing. The push used to be
+    /// counted as done either way, so a single mistimed refresh left the video without
+    /// subtitles until the next edit (issue #13407).
+    /// </returns>
+    public async Task<bool> RefreshMpv(LibMpvDynamicPlayer mpvContext, Subtitle subtitle, Subtitle? subtitleSecondary, SubtitleFormat uiFormat)
     {
         if (subtitle.Paragraphs.Count == 0 && subtitleSecondary == null)
         {
@@ -57,7 +64,7 @@ public class MpvReloader : IMpvReloader
                 _subtitlePrev = null;
             }
 
-            return;
+            return true;
         }
 
         try
@@ -88,8 +95,9 @@ public class MpvReloader : IMpvReloader
             if (version != _refreshVersion)
             {
                 // Superseded while serializing (newer refresh, reset, or removal) -
-                // applying this result would push stale text over newer state.
-                return;
+                // applying this result would push stale text over newer state. Not a
+                // failure: whatever superseded this refresh does the pushing now.
+                return true;
             }
 
             subtitle = built.Subtitle;
@@ -102,21 +110,38 @@ public class MpvReloader : IMpvReloader
             var format = _assFormat;
             if (text != _mpvTextOld || _mpvTextFileName == null || _retryCount > 0)
             {
-                if (_retryCount >= 0 || string.IsNullOrEmpty(_mpvTextFileName) || _subtitlePrev == null || _subtitlePrev.FileName != subtitle.FileName || _mpvTextFileExtension != format.Extension)
+                var reAdd = _retryCount >= 0 || string.IsNullOrEmpty(_mpvTextFileName) || _subtitlePrev == null || _subtitlePrev.FileName != subtitle.FileName || _mpvTextFileExtension != format.Extension;
+                int mpvResult;
+                if (reAdd)
                 {
                     DeleteTempMpvFileName();
                     _mpvTextFileName = FileUtil.GetTempFileName(format.Extension);
                     _mpvTextFileExtension = format.Extension;
                     await File.WriteAllTextAsync(_mpvTextFileName, text);
-                    mpvContext.SubRemove();
-                    mpvContext.SubAdd(_mpvTextFileName);
-                    _retryCount--;
+                    mpvContext.SubRemove(); // nothing to remove yet on a new player - its result says nothing
+                    mpvResult = mpvContext.SubAdd(_mpvTextFileName);
                 }
                 else
                 {
-                    await File.WriteAllTextAsync(_mpvTextFileName, text);
-                    mpvContext.SubReload();
+                    // Not re-adding means the checks above found an existing temp file to rewrite.
+                    await File.WriteAllTextAsync(_mpvTextFileName!, text);
+                    mpvResult = mpvContext.SubReload();
                 }
+
+                if (mpvResult < 0)
+                {
+                    // mpv did not take it (core not up yet, or no file playing). Leave the memo
+                    // fields alone - remembering this text as the one mpv is showing is what used
+                    // to make the miss permanent - and let the caller retry. The retry budget is
+                    // not spent either: nothing was loaded to retry against yet.
+                    return false;
+                }
+
+                if (reAdd)
+                {
+                    _retryCount--;
+                }
+
                 _mpvTextOld = text;
             }
 
@@ -124,10 +149,12 @@ public class MpvReloader : IMpvReloader
             // created player (fullscreen/undock create a new mpv instance).
             mpvContext.SetSubtitleVisibility(SubtitlesVisible);
             _subtitlePrev = subtitle;
+            return true;
         }
         catch (Exception exception)
         {
             Se.LogError(exception);
+            return false;
         }
     }
 

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -1054,6 +1054,13 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         DoMpvCommand("set", "pause", "yes");
         _pausedValue = null;
 
+        // Before loadfile, not after: mpv applies "sid" when the file loads, and setting it
+        // afterwards left a window in which an external subtitle pushed by MpvReloader was added
+        // and selected, only to be deselected again a moment later - added but never drawn
+        // (issue #13407). Set here it does the same job (no embedded subtitle track is picked)
+        // without ever undoing a sub-add that got in first.
+        SetOptionString("sid", "no");
+
         var err = await Task.Run(() => DoMpvCommand("loadfile", path));
         if (_disposed)
         {
@@ -1070,7 +1077,6 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         // hook it was meant to help. The path is handed to ytdl_hook before mpv_initialize now.
 
         SetOptionString("keep-open", "always");
-        SetOptionString("sid", "no");
 
         SetOptionString("hr-seek", "yes");
         SetOptionString("rebase-start-time", "no");
@@ -1916,9 +1922,18 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         }
     }
 
-    public void SubRemove()
+    /// <summary>
+    /// mpv's result for the sub-* commands: 0 or higher when the command was applied, negative
+    /// when it was not. Callers that push a subtitle into a player they just created (fullscreen,
+    /// undock, layout rebuild) must check this and retry: the core is initialized lazily by the
+    /// rendering surface, and "sub-add" is one of mpv's playback-only commands, so a push that
+    /// arrives before the core is up - or before "loadfile" has actually started playback - is
+    /// rejected. Ignoring that left the video with no subtitles for the rest of the session,
+    /// because nothing pushes again until an edit dirties the preview (issue #13407).
+    /// </summary>
+    public int SubRemove()
     {
-        DoMpvCommand("sub-remove");
+        return DoSubtitleCommand("sub-remove");
     }
 
     public void SetSubtitleVisibility(bool visible)
@@ -1926,15 +1941,32 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         DoMpvCommand("set", "sub-visibility", visible ? "yes" : "no");
     }
 
-    public void SubReload()
+    /// <inheritdoc cref="SubRemove"/>
+    public int SubReload()
     {
-        DoMpvCommand("sub-reload");
+        return DoSubtitleCommand("sub-reload");
     }
 
-    public void SubAdd(string fileName)
+    /// <inheritdoc cref="SubRemove"/>
+    public int SubAdd(string fileName)
     {
-        DoMpvCommand("sub-add", fileName, "select");
+        return DoSubtitleCommand("sub-add", fileName, "select");
     }
+
+    private int DoSubtitleCommand(params string[] args)
+    {
+        // DoMpvCommand answers 0 - mpv's "success" - when there is no core to talk to at all,
+        // which would read as an applied subtitle. Report the same "not initialized" mpv itself
+        // uses so the caller retries instead.
+        if (_mpv == IntPtr.Zero || !_coreInitialized)
+        {
+            return MpvErrorUninitialized;
+        }
+
+        return DoMpvCommand(args);
+    }
+
+    private const int MpvErrorUninitialized = -3; // MPV_ERROR_UNINITIALIZED in mpv's client.h
 
     public string VersionNumber
     {

--- a/tests/UI/Logic/Media/MpvReloaderRetryTests.cs
+++ b/tests/UI/Logic/Media/MpvReloaderRetryTests.cs
@@ -1,0 +1,92 @@
+using System.Reflection;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
+
+namespace UITests.Logic.Media;
+
+/// <summary>
+/// Going fullscreen, undocking and every layout rebuild create a brand new mpv player, and the
+/// subtitle has to be pushed into it as an external file. That push used to be counted as done
+/// even when mpv refused it - which it does until its core is initialized (lazily, by the
+/// rendering surface) and the video is actually playing. Nothing pushes again during plain
+/// playback, so one mistimed push left the video without subtitles for the rest of the
+/// fullscreen session (issue #13407).
+///
+/// A default-constructed player has no core, which is exactly the state a just-created player
+/// is in, so it stands in for "mpv is not ready yet" here.
+/// </summary>
+public class MpvReloaderRetryTests
+{
+    private static Subtitle MakeSubtitle()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello world", 1000, 3000));
+        return subtitle;
+    }
+
+    private static T GetPrivateField<T>(MpvReloader reloader, string name)
+    {
+        var field = typeof(MpvReloader).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return (T)field!.GetValue(reloader)!;
+    }
+
+    [Fact]
+    public async Task RefreshMpv_ReportsFailure_WhenTheCoreIsNotUpYet()
+    {
+        var reloader = new MpvReloader();
+        using var player = new LibMpvDynamicPlayer();
+
+        var applied = await reloader.RefreshMpv(player, MakeSubtitle(), null, new SubRip());
+
+        Assert.False(applied);
+
+        reloader.Reset(); // drops the temp file the attempt created
+    }
+
+    [Fact]
+    public async Task RefreshMpv_DoesNotRememberSubtitleTextMpvRejected()
+    {
+        var reloader = new MpvReloader();
+        using var player = new LibMpvDynamicPlayer();
+
+        await reloader.RefreshMpv(player, MakeSubtitle(), null, new SubRip());
+
+        // Remembering the text as "what mpv is showing" is what made the miss permanent: the
+        // next push would compare equal and skip the sub-add that never happened.
+        Assert.Empty(GetPrivateField<string>(reloader, "_mpvTextOld"));
+
+        reloader.Reset();
+    }
+
+    [Fact]
+    public async Task RefreshMpv_DoesNotSpendARetry_WhenMpvRejectedThePush()
+    {
+        var reloader = new MpvReloader();
+        using var player = new LibMpvDynamicPlayer();
+        var before = GetPrivateField<int>(reloader, "_retryCount");
+
+        await reloader.RefreshMpv(player, MakeSubtitle(), null, new SubRip());
+        await reloader.RefreshMpv(player, MakeSubtitle(), null, new SubRip());
+
+        // The retry budget covers pushes mpv accepted; burning it on pushes that never reached
+        // a live core would leave nothing for the ones that can actually land.
+        Assert.Equal(before, GetPrivateField<int>(reloader, "_retryCount"));
+
+        reloader.Reset();
+    }
+
+    [Fact]
+    public void SubtitleCommands_ReportNotInitialized_WhenThereIsNoCore()
+    {
+        using var player = new LibMpvDynamicPlayer();
+
+        // Without this the commands answered mpv's success code (0) for a core that does not
+        // exist, so callers could not tell an applied subtitle from a dropped one.
+        Assert.True(player.SubAdd("some.ass") < 0);
+        Assert.True(player.SubReload() < 0);
+        Assert.True(player.SubRemove() < 0);
+    }
+}


### PR DESCRIPTION
Fixes #13407.

### Root cause

Going fullscreen creates a brand-new `VideoPlayerControl` with its own mpv core, and the subtitle has to be pushed into it as an external ASS file (`sub-add`) by `MpvReloader`. That push raced the new player's startup:

- the mpv core is initialized lazily by the rendering surface, and `loadfile` runs after that - while the subtitle push fires on the next 16 ms preview tick;
- `SubAdd`/`SubReload` discarded mpv's return code, so a rejected push (core not up, or no file playing - `sub-add` is a playback-only command) was recorded as delivered: `MpvReloader` memoized the text as "what mpv is showing" and the dirty flag was cleared;
- nothing re-pushes during plain playback (only edits dirty the preview), so one mistimed push meant **no subtitles for the entire fullscreen session**, while the docked player still had them.

The intermittency comes from the 250 ms typing-settle window: entering fullscreen by shortcut delays the push long enough for the core to come up more often than entering by mouse; GPU/decoder warm-up variance does the rest. (The B7→B8 diff doesn't touch any of this code - B8 just shifted the timing. The race is latent in B7 too.)

There was also a second, narrower window: `sid=no` was set *after* `loadfile`, so a `sub-add ... select` landing in between was added and then immediately deselected - present but never drawn.

### Fix

- **`LibMpvDynamicPlayer`**: `SubAdd`/`SubReload`/`SubRemove` now return mpv's result, and answer `MPV_ERROR_UNINITIALIZED` instead of a silent success when there is no core; `sid=no` moved before `loadfile` so it can never undo a `sub-add` that got in first.
- **`MpvReloader.RefreshMpv`** returns whether mpv took the push; on a rejected push it leaves the memo fields (and retry budget) untouched so the next attempt actually retries.
- **`MainViewModel`**:
  - `RunPreviewRefresh` re-arms the dirty flag (400 ms backoff, same as the existing exception path) when the push was rejected, so it retries until the new player takes it;
  - the fullscreen path now arms the preview from the window's `onPlayerReady` callback (after `Open` + ready-wait) instead of pushing synchronously at window-open time, which could never work; same re-arm added after the layout-rebuild ready-wait;
  - `TryRefreshVideoPreview` skips pushes while no video is loaded, so the retry loop can't spin against an empty player.

### Tests

Four new tests in `MpvReloaderRetryTests` (a default-constructed player has no core - exactly the state a just-created player is in): push reports failure, rejected text is not memoized, retry budget is not spent, and the sub-commands report "not initialized" instead of success. All four fail against the old behavior; full UI suite (2255) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)