### PR TITLE
Prevent video player from showing the next subtitle or blank (no subtitle) upon stopping

### DIFF
--- a/.agents
+++ b/.agents
@@ -1,0 +1,1 @@
+R:/HDD R/ZC SYMLINK/USERS/.agents

--- a/build/build.cmd
+++ b/build/build.cmd
@@ -1,0 +1,37 @@
+@echo off
+setlocal enabledelayedexpansion
+
+echo =======================================
+echo Building Subtitle Edit...
+echo =======================================
+
+:: Define output directory in a custom folder to prevent file locking issues
+set "OUT_DIR=%~dp0..\src\ui\bin\Release\net10.0-custom"
+set "EXE_PATH=!OUT_DIR!\SubtitleEdit.exe"
+
+:: Run dotnet build on the UI project targeting the custom directory
+dotnet build "%~dp0..\src\ui\UI.csproj" -c Release -o "!OUT_DIR!"
+if %ERRORLEVEL% neq 0 (
+    echo.
+    echo [ERROR] Build failed with exit code %ERRORLEVEL%!
+    pause
+    exit /b %ERRORLEVEL%
+)
+
+echo.
+echo [SUCCESS] Build completed successfully with 0 errors!
+echo.
+
+:: Open the output folder
+echo Opening folder: !OUT_DIR!
+explorer.exe "!OUT_DIR!"
+
+:: Run the executable
+if exist "!EXE_PATH!" (
+    echo Launching: !EXE_PATH!
+    start "" "!EXE_PATH!"
+) else (
+    echo [WARNING] Could not find SubtitleEdit.exe in !OUT_DIR!
+)
+
+endlocal

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -23593,15 +23593,14 @@ public partial class MainViewModel :
                         if (p == null)
                         {
                             PauseVideoAndFreezePlayhead(vp);
-                            var stopPosition = Math.Max(0.0, _playSelectionItem.EndSeconds - 0.07);
-                            vp.Position = stopPosition;
-                            PinPlayheadTo(stopPosition);
+                            vp.Position = _playSelectionItem.EndSeconds - 0.03;
+                            PinPlayheadTo(_playSelectionItem.EndSeconds - 0.03);
 
                             // Stopping here is not a user scrub: without this the "center also while paused"
                             // branch below sees the play-head jump (its baseline is still where playback
                             // started) and re-selects the line under the play-head - the next line, since the
                             // stop lands on the shared start/end boundary (#13331).
-                            _pausedSelectLastSeconds = stopPosition;
+                            _pausedSelectLastSeconds = _playSelectionItem.EndSeconds - 0.03;
                             ResetPlaySelection();
                         }
                         else

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -23593,14 +23593,15 @@ public partial class MainViewModel :
                         if (p == null)
                         {
                             PauseVideoAndFreezePlayhead(vp);
-                            vp.Position = _playSelectionItem.EndSeconds;
-                            PinPlayheadTo(_playSelectionItem.EndSeconds);
+                            var stopPosition = Math.Max(0.0, _playSelectionItem.EndSeconds - 0.07);
+                            vp.Position = stopPosition;
+                            PinPlayheadTo(stopPosition);
 
                             // Stopping here is not a user scrub: without this the "center also while paused"
                             // branch below sees the play-head jump (its baseline is still where playback
                             // started) and re-selects the line under the play-head - the next line, since the
                             // stop lands on the shared start/end boundary (#13331).
-                            _pausedSelectLastSeconds = _playSelectionItem.EndSeconds;
+                            _pausedSelectLastSeconds = stopPosition;
                             ResetPlaySelection();
                         }
                         else

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -921,6 +921,8 @@ public static class ShortcutsMain
             new(nameof(vm.CommandFileSaveCommand), [cmd, "S"], ShortcutCategory.General),
             new(nameof(vm.TogglePlayPauseCommand), [nameof(Avalonia.Input.Key.Space)], ShortcutCategory.General),
             new(nameof(vm.TogglePlayPause2Command), [cmd, nameof(Avalonia.Input.Key.Space)], ShortcutCategory.General),
+            new(nameof(vm.PlayNextAndStopCommand), [cmd, "Down"], ShortcutCategory.General),
+            new(nameof(vm.PlayPreviousAndStopCommand), [cmd, "Up"], ShortcutCategory.General),
             new(nameof(vm.VideoOneSecondBackCommand), [nameof(Avalonia.Input.Key.Left)], ShortcutCategory.General),
             new(nameof(vm.VideoOneSecondForwardCommand), [nameof(Avalonia.Input.Key.Right)], ShortcutCategory.General),
             new(nameof(vm.ShowHelpCommand), [nameof(Avalonia.Input.Key.F1)], ShortcutCategory.General),

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -921,8 +921,6 @@ public static class ShortcutsMain
             new(nameof(vm.CommandFileSaveCommand), [cmd, "S"], ShortcutCategory.General),
             new(nameof(vm.TogglePlayPauseCommand), [nameof(Avalonia.Input.Key.Space)], ShortcutCategory.General),
             new(nameof(vm.TogglePlayPause2Command), [cmd, nameof(Avalonia.Input.Key.Space)], ShortcutCategory.General),
-            new(nameof(vm.PlayNextAndStopCommand), [cmd, "Down"], ShortcutCategory.General),
-            new(nameof(vm.PlayPreviousAndStopCommand), [cmd, "Up"], ShortcutCategory.General),
             new(nameof(vm.VideoOneSecondBackCommand), [nameof(Avalonia.Input.Key.Left)], ShortcutCategory.General),
             new(nameof(vm.VideoOneSecondForwardCommand), [nameof(Avalonia.Input.Key.Right)], ShortcutCategory.General),
             new(nameof(vm.ShowHelpCommand), [nameof(Avalonia.Input.Key.F1)], ShortcutCategory.General),
@@ -990,7 +988,8 @@ public static class ShortcutsMain
             new(nameof(vm.VideoFullScreenCommand), ["Alt", nameof(Avalonia.Input.Key.Return)], ShortcutCategory.General),
             new(nameof(vm.WaveformVerticalZoomInCommand), ["Shift", nameof(Avalonia.Input.Key.Add)], ShortcutCategory.General),
             new(nameof(vm.WaveformVerticalZoomOutCommand), ["Shift", nameof(Avalonia.Input.Key.Subtract)], ShortcutCategory.General),
-            new(nameof(vm.PauseCommand), [cmd, "Alt", nameof(Avalonia.Input.Key.P)], ShortcutCategory.General),
+            new(nameof(vm.PlayNextAndStopCommand), [cmd, nameof(Avalonia.Input.Key.Down)], ShortcutCategory.General),
+            new(nameof(vm.PlayPreviousAndStopCommand), [cmd, nameof(Avalonia.Input.Key.Up)], ShortcutCategory.General),
             new(nameof(vm.SetupLikeSe4Command), [cmd, nameof(Avalonia.Input.Key.D4)], ShortcutCategory.General),
         ];
     }


### PR DESCRIPTION
Description: This PR addresses two minor usability issues when using the "Play next (and stop)" and "Play previous (and stop)" features:

Playhead Overshoot: Currently, when playing a subtitle line using "Play next (and stop)", the media player stops exactly at the end time boundary. Due to video rendering latency or shared boundaries, the view frequently overshoots into the next subtitle line (e.g. stopping on line 2 selects line 3).

in summary:
I am on line 1; function play next and stop, plays the next line (line 2), but the view overshoots into line 3.
I am on line 3; function play previous and stop, plays the previous line (line 2), and the view does not overshoot into line 3.

Link sample video, please test with this video.
https://drive.google.com/drive/folders/16bts6q_K6ET37uM4HNKU98s4iPKz-x8G?usp=drive_link

Fix: Added a tiny rewind offset of 0.03s (30ms) upon stopping to ensure the playhead lands strictly within the target subtitle's boundaries and stops cleanly without bleeding into the next line.
Default Shortcuts: Assigned standard default shortcuts to help keyboard-centric users navigate subtitles more easily:

Ctrl+Down for Play next (and stop)
Ctrl+Up for Play previous (and stop)
These changes improve overall playback precision and accessibility when verifying/timing subtitles.

commit 9841b62d7