### PR TITLE
Fix #13425: secondary subtitle tiny/huge in video player + preview flicker

### DIFF
--- a/src/ui/Features/Video/OpenSecondarySubtitle/OpenSecondarySubtitleViewModel.cs
+++ b/src/ui/Features/Video/OpenSecondarySubtitle/OpenSecondarySubtitleViewModel.cs
@@ -41,6 +41,10 @@ public partial class OpenSecondarySubtitleViewModel : ObservableObject
     public VideoPlayerControl VideoPlayerControl { get; set; }
     public ComboBox ComboBoxParagraphs { get; set; }
 
+    // Stable per-dialog style name: regenerating it in every BuildAssaSubtitle call made the
+    // serialized preview text differ on every 500 ms tick, forcing a SubReload twice a second
+    // (the "flicker" in issue #13425).
+    private readonly string _styleName = "Style" + Guid.NewGuid().ToString().Replace("-", string.Empty);
     private Subtitle _secondarySubtitle = new Subtitle();
     private Subtitle _subtitle = new Subtitle();
     private SubtitleFormat _subtitleFormat = new SubRip();
@@ -280,7 +284,7 @@ public partial class OpenSecondarySubtitleViewModel : ObservableObject
     {
         var style = new SsaStyle
         {
-            Name = "Style" + Guid.NewGuid().ToString().Replace("-", string.Empty),
+            Name = _styleName,
             FontName = "Arial",
             FontSize = FontSize,
             Primary = SubtitleColor.ToSKColor(),
@@ -297,11 +301,6 @@ public partial class OpenSecondarySubtitleViewModel : ObservableObject
             ScaleX = 100,
             ScaleY = 100,
         };
-
-        if (!mergeWithSubtitle && _subtitleFormat.GetType() != typeof(AdvancedSubStationAlpha))
-        {
-            style.FontSize = Se.Settings.Video.MpvPreviewFontSize;
-        }
 
         style.Outline = new SkiaSharp.SKColor(style.Outline.Red, style.Outline.Green, style.Outline.Blue, SubtitleColor.A);
         style.Background = new SkiaSharp.SKColor(style.Background.Red, style.Background.Green, style.Background.Blue, SubtitleColor.A);

--- a/src/ui/Logic/Media/MpvReloader.cs
+++ b/src/ui/Logic/Media/MpvReloader.cs
@@ -188,7 +188,7 @@ public class MpvReloader : IMpvReloader
             // No extra copy here: "subtitle" is already RefreshMpv's private copy, and
             // Convert deep-copies its input again internally without mutating it.
             subtitle = WebVttToAssa.Convert(subtitle, defaultStyle, VideoWidth, VideoHeight);
-            AddSecondarySubtitle(subtitle, subtitleSecondary);
+            SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary);
             // The WebVTT path never used the hash memo, so keep it untouched (HashValid false).
             return (subtitle, subtitle.ToText(_assFormat), 0, false);
         }
@@ -267,7 +267,7 @@ public class MpvReloader : IMpvReloader
             }
         }
 
-        AddSecondarySubtitle(subtitle, subtitleSecondary);
+        SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary);
         var hash = subtitle.GetFastHashCode(null);
         if (hash != oldHash || string.IsNullOrEmpty(oldText))
         {
@@ -275,23 +275,6 @@ public class MpvReloader : IMpvReloader
         }
 
         return (subtitle, oldText, hash, true);
-    }
-
-    private static void AddSecondarySubtitle(Subtitle subtitle, Subtitle? subtitleSecondary)
-    {
-        if (subtitleSecondary == null)
-        {
-            return;
-        }
-
-
-        var styleName = subtitleSecondary.Paragraphs.FirstOrDefault()?.Extra ?? "Secondary";
-        var style = AdvancedSubStationAlpha.GetSsaStyle(styleName, subtitleSecondary.Header);
-        subtitle.Header = AdvancedSubStationAlpha.AddSsaStyle(style, subtitle.Header);
-        foreach (var p in subtitleSecondary.Paragraphs)
-        {
-            subtitle.Paragraphs.Add(p);
-        }
     }
 
     private string MpvPreviewStyleHeader

--- a/src/ui/Logic/Media/SecondarySubtitleMerger.cs
+++ b/src/ui/Logic/Media/SecondarySubtitleMerger.cs
@@ -1,0 +1,71 @@
+﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System.Globalization;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Logic.Media;
+
+public static class SecondarySubtitleMerger
+{
+    /// <summary>
+    /// Adds the secondary subtitle's paragraphs and style to a preview subtitle about
+    /// to be pushed to the video player.
+    /// The secondary style is sized against its own header's PlayRes (the real video
+    /// dimensions), while the target header may use a different - or no - PlayRes
+    /// (libass defaults to 384x288 when absent). Grafting the style line verbatim made
+    /// the secondary subtitle tiny for WebVTT mains (PlayResY = video height) and huge
+    /// for ASSA mains with a small PlayResY (issue #13425), so resample it to the
+    /// target's scale first.
+    /// </summary>
+    public static void AddSecondarySubtitle(Subtitle subtitle, Subtitle? subtitleSecondary)
+    {
+        if (subtitleSecondary == null)
+        {
+            return;
+        }
+
+        var styleName = subtitleSecondary.Paragraphs.FirstOrDefault()?.Extra ?? "Secondary";
+        var style = AdvancedSubStationAlpha.GetSsaStyle(styleName, subtitleSecondary.Header);
+
+        var sourceWidth = GetPlayRes(subtitleSecondary.Header, "PlayResX", 384);
+        var sourceHeight = GetPlayRes(subtitleSecondary.Header, "PlayResY", 288);
+        var targetWidth = GetPlayRes(subtitle.Header, "PlayResX", 384);
+        var targetHeight = GetPlayRes(subtitle.Header, "PlayResY", 288);
+
+        if (sourceHeight != targetHeight)
+        {
+            style.FontSize = AssaResampler.Resample(sourceHeight, targetHeight, style.FontSize);
+            style.OutlineWidth = AssaResampler.Resample(sourceHeight, targetHeight, style.OutlineWidth);
+            style.ShadowWidth = AssaResampler.Resample(sourceHeight, targetHeight, style.ShadowWidth);
+            style.MarginVertical = AssaResampler.Resample(sourceHeight, targetHeight, style.MarginVertical);
+        }
+
+        if (sourceWidth != targetWidth)
+        {
+            style.MarginLeft = AssaResampler.Resample(sourceWidth, targetWidth, style.MarginLeft);
+            style.MarginRight = AssaResampler.Resample(sourceWidth, targetWidth, style.MarginRight);
+        }
+
+        subtitle.Header = AdvancedSubStationAlpha.AddSsaStyle(style, subtitle.Header);
+        foreach (var p in subtitleSecondary.Paragraphs)
+        {
+            subtitle.Paragraphs.Add(p);
+        }
+    }
+
+    private static decimal GetPlayRes(string? header, string tagName, int defaultValue)
+    {
+        if (string.IsNullOrEmpty(header))
+        {
+            return defaultValue;
+        }
+
+        var value = AdvancedSubStationAlpha.GetTagValueFromHeader(tagName, "[Script Info]", header);
+        if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var number) && number > 0)
+        {
+            return number;
+        }
+
+        return defaultValue;
+    }
+}

--- a/src/ui/Logic/Media/VlcReloader.cs
+++ b/src/ui/Logic/Media/VlcReloader.cs
@@ -54,7 +54,7 @@ public class VlcReloader : IVlcReloader
                 defaultStyle.BorderStyle = "3";
                 subtitle = new Subtitle(subtitle);
                 subtitle = WebVttToAssa.Convert(subtitle, defaultStyle, VideoWidth, VideoHeight);
-                AddSecondarySubtitle(subtitle, subtitleSecondary);
+                SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary);
                 text = subtitle.ToText(_assFormat);
             }
             else
@@ -130,7 +130,7 @@ public class VlcReloader : IVlcReloader
                     }
                 }
 
-                AddSecondarySubtitle(subtitle, subtitleSecondary);
+                SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary);
                 var hash = subtitle.GetFastHashCode(null);
                 if (hash != _mpvSubOldHash || string.IsNullOrEmpty(_mpvTextOld))
                 {
@@ -169,23 +169,6 @@ public class VlcReloader : IVlcReloader
         catch (Exception exception)
         {
             Se.LogError(exception);
-        }
-    }
-
-    private static void AddSecondarySubtitle(Subtitle subtitle, Subtitle? subtitleSecondary)
-    {
-        if (subtitleSecondary == null)
-        {
-            return;
-        }
-
-
-        var styleName = subtitleSecondary.Paragraphs.FirstOrDefault()?.Extra ?? "Secondary";
-        var style = AdvancedSubStationAlpha.GetSsaStyle(styleName, subtitleSecondary.Header);
-        subtitle.Header = AdvancedSubStationAlpha.AddSsaStyle(style, subtitle.Header);
-        foreach (var p in subtitleSecondary.Paragraphs)
-        {
-            subtitle.Paragraphs.Add(p);
         }
     }
 


### PR DESCRIPTION
Fixes #13425.

**Root cause:** the secondary subtitle style is sized against the real video dimensions (PlayResX/Y in its own header), but `AddSecondarySubtitle` grafted the style line verbatim into the mpv/VLC preview header, which may use a different — or no — PlayRes (libass defaults to 384x288). For WebVTT main subtitles (preview header PlayResY = video height) the secondary text rendered tiny; for ASSA mains with a small PlayResY it rendered huge.

**Changes:**
- New shared `SecondarySubtitleMerger` (replaces the duplicated private helpers in `MpvReloader`/`VlcReloader`) resamples font size, outline, shadow and margins from the secondary header's PlayRes to the target header's PlayRes.
- The OK path no longer overrides the user's chosen font size with `MpvPreviewFontSize` for non-ASSA formats — the merger handles the scale conversion, so the dialog's font size setting now carries into the main/fullscreen player.
- Stable per-dialog style name: regenerating the Guid-based name in every `BuildAssaSubtitle` call changed the serialized preview text on every 500 ms timer tick, forcing `SubReload` twice a second — the reported preview flicker.

**Verified** with a libse harness simulating the three main-format paths: WebVTT keeps the 1080-scaled size (matches primary), SRT and 288-res ASSA resample down to the 288 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)