### PR TITLE
Skip duplicate events Format line in ASSA ToText

### DIFF
--- a/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
@@ -159,7 +159,15 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                 // Trim via span: Header.Trim() re-allocated the whole (possibly multi-KB)
                 // header on every save and every mpv preview refresh.
                 sb.Append(subtitle.Header.AsSpan().Trim()).AppendLine();
-                sb.AppendLine("Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text");
+
+                // Most headers end at "[Events]", but some (e.g. HeaderNoStyles) already carry
+                // the events format line - appending another gave a duplicate "Format:" line.
+                var eventsIndex = subtitle.Header.LastIndexOf("[Events]", StringComparison.Ordinal);
+                if (eventsIndex < 0 || subtitle.Header.IndexOf("Format:", eventsIndex, StringComparison.Ordinal) < 0)
+                {
+                    sb.AppendLine("Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text");
+                }
+
                 styles = GetStylesFromHeader(subtitle.Header);
             }
             else if (!string.IsNullOrEmpty(subtitle.Header) && subtitle.Header.Contains("[V4 Styles]"))


### PR DESCRIPTION
Follow-up to #13430 / #13425.

`AdvancedSubStationAlpha.ToText` appended the events `Format:` line unconditionally after any valid ASSA header, so headers that already end with it (e.g. `HeaderNoStyles`, used for mpv/VLC preview files) produced a duplicate `Format:` line in `[Events]`. Now the line is only appended when the header's `[Events]` section doesn't already carry one; headers ending at bare `[Events]` (the common case) still get it.

Verified with a libse harness: `HeaderNoStyles`, `DefaultHeader`-derived headers, and a load/save round-trip all emit exactly one `Format:` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)