### PR TITLE
Stop play-selection on the line's last visible frame

### DIFF
--- a/docs/features/video-player.md
+++ b/docs/features/video-player.md
@@ -19,8 +19,11 @@ Subtitle Edit includes an integrated video player for previewing subtitles with 
 | Play/Pause toggle | Toggle video playback |
 | Play | Start playback |
 | Pause | Pause playback |
-| Play next | Play the next subtitle |
+| Play next (and stop / and loop) | Play the next subtitle, then stop or loop |
+| Play previous (and stop / and loop) | Play the previous subtitle, then stop or loop |
 | Play selected lines | Play only the selected subtitle lines |
+
+> **Note:** When a "play and stop" playback stops, the video parks on the **last visible frame** of the line (one frame before its end time) rather than exactly on the end time. This keeps the line you just played visible on the video — stopping exactly on the end time would show a blank frame, or the next line when two lines share a boundary. The played line also stays selected in the subtitle grid.
 
 ## Navigation
 

--- a/src/ui/Features/Main/MainHelpers/PlaySelectionItem.cs
+++ b/src/ui/Features/Main/MainHelpers/PlaySelectionItem.cs
@@ -41,6 +41,16 @@ public class PlaySelectionItem
         return null;
     }
 
+    public double GetCurrentStartSeconds()
+    {
+        if (Index < 0 || Index >= Subtitles.Count)
+        {
+            return 0;
+        }
+
+        return Subtitles[Index].StartTime.TotalSeconds;
+    }
+
     public bool HasGapOrIsFirst()
     {
         if (Index < 1)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -23600,14 +23600,23 @@ public partial class MainViewModel :
                         if (p == null)
                         {
                             PauseVideoAndFreezePlayhead(vp);
-                            vp.Position = _playSelectionItem.EndSeconds;
-                            PinPlayheadTo(_playSelectionItem.EndSeconds);
+
+                            // Park on the line's last visible frame, not the exact end time: mpv renders
+                            // the sub track itself and hides the line at its end time, so an exact-end stop
+                            // shows a blank frame - or the *next* line on a shared boundary - instead of the
+                            // line that was just played (#13429).
+                            var fps = Se.Settings.General.CurrentFrameRate;
+                            var frameSeconds = fps >= 10 ? 1.0 / fps : 0.04;
+                            var stopSeconds = Math.Max(_playSelectionItem.GetCurrentStartSeconds(),
+                                _playSelectionItem.EndSeconds - frameSeconds);
+
+                            vp.Position = stopSeconds;
+                            PinPlayheadTo(stopSeconds);
 
                             // Stopping here is not a user scrub: without this the "center also while paused"
                             // branch below sees the play-head jump (its baseline is still where playback
-                            // started) and re-selects the line under the play-head - the next line, since the
-                            // stop lands on the shared start/end boundary (#13331).
-                            _pausedSelectLastSeconds = _playSelectionItem.EndSeconds;
+                            // started) and re-selects the line under the play-head (#13331).
+                            _pausedSelectLastSeconds = stopSeconds;
                             ResetPlaySelection();
                         }
                         else


### PR DESCRIPTION
"Play next (and stop)", "Play previous (and stop)" and "Play selected lines" stopped exactly on the played line's end time. mpv renders the subtitle track itself and hides a line at its end time, so the stop always landed on a frame where the just-played line is invisible — a blank frame, or the *next* line's text when two lines share a start/end boundary. Reviewing a line and ending on someone else's text defeats the point of the feature.

### Fix

Park the play-head on the line's **last visible frame** instead: `end time − one frame` at the video's frame rate (40 ms fallback when the frame rate is unknown), clamped to the line's start for very short lines. The play-head pin, the paused scrub baseline and the player position all use the same value, so the selection freeze from #13334 works unchanged — the stop now lands strictly inside the line, so keeping the played line selected no longer relies on the boundary tie-break at all.

Also documents the behavior in `docs/features/video-player.md`.

### Credit

Implements the idea from #13429 by @ghostminhtoan, made frame-rate based — a fixed 30 ms rewind is less than one frame at 24/25 fps, so where the stop lands would depend on the video's frame rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)