### PR TITLE
MKV track picker: VobSub/DVB preview and VobSub export

### DIFF
--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -870,7 +870,7 @@ public partial class BinaryEditViewModel : ObservableObject
                 return pcsData.Count == 0 ? null : new OcrSubtitleMkvBluRay(selectedTrack, pcsData);
             }
 
-            if (selectedTrack.CodecId.Equals("S_VOBSUB", StringComparison.OrdinalIgnoreCase))
+            if (selectedTrack.CodecId.Equals(MatroskaTrackType.VobSub, StringComparison.OrdinalIgnoreCase))
             {
                 if (selectedTrack.ContentEncodingType == 1)
                 {
@@ -880,13 +880,13 @@ public partial class BinaryEditViewModel : ObservableObject
                     return null;
                 }
 
-                var (mergedPacks, palette) = ExtractMkvVobSub(selectedTrack, matroska);
-                return mergedPacks.Count == 0 ? null : new OcrSubtitleVobSub(mergedPacks, palette);
+                var mergedPacks = MatroskaImageSubtitleExtractor.ExtractVobSub(selectedTrack, matroska, out var idx);
+                return mergedPacks.Count == 0 ? null : new OcrSubtitleVobSub(mergedPacks, idx?.Palette);
             }
 
-            if (selectedTrack.CodecId.Equals("S_DVBSUB", StringComparison.OrdinalIgnoreCase))
+            if (selectedTrack.CodecId.Equals(MatroskaTrackType.Dvb, StringComparison.OrdinalIgnoreCase))
             {
-                var (subtitle, subtitleImages) = ExtractMkvDvb(selectedTrack, matroska);
+                var (subtitle, subtitleImages) = MatroskaImageSubtitleExtractor.ExtractDvb(selectedTrack, matroska);
                 return subtitleImages.Count == 0 ? null : new OcrSubtitleMkvDvb(selectedTrack, subtitle, subtitleImages);
             }
 
@@ -901,127 +901,8 @@ public partial class BinaryEditViewModel : ObservableObject
     private static bool IsImageBasedMatroskaTrack(MatroskaTrackInfo track)
     {
         return track.CodecId.Equals(MatroskaTrackType.BluRay, StringComparison.OrdinalIgnoreCase)
-            || track.CodecId.Equals("S_VOBSUB", StringComparison.OrdinalIgnoreCase)
-            || track.CodecId.Equals("S_DVBSUB", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static (List<VobSubMergedPack> mergedPacks, List<SKColor>? palette) ExtractMkvVobSub(
-        MatroskaTrackInfo track, MatroskaFile matroska)
-    {
-        var sub = matroska.GetSubtitle(track.TrackNumber, null);
-        var idx = new Idx(track.GetCodecPrivate().SplitToLines());
-        var mergedVobSubPacks = new List<VobSubMergedPack>();
-
-        foreach (var p in sub)
-        {
-            mergedVobSubPacks.Add(new VobSubMergedPack(p.GetData(track), TimeSpan.FromMilliseconds(p.Start), 32, null));
-            mergedVobSubPacks[mergedVobSubPacks.Count - 1].EndTime = TimeSpan.FromMilliseconds(p.End);
-
-            // fix overlapping (some Handbrake versions produce overlapping timecodes)
-            if (mergedVobSubPacks.Count > 1 &&
-                mergedVobSubPacks[mergedVobSubPacks.Count - 2].EndTime > mergedVobSubPacks[mergedVobSubPacks.Count - 1].StartTime)
-            {
-                mergedVobSubPacks[mergedVobSubPacks.Count - 2].EndTime =
-                    TimeSpan.FromMilliseconds(mergedVobSubPacks[mergedVobSubPacks.Count - 1].StartTime.TotalMilliseconds - 1);
-            }
-        }
-
-        for (var i = mergedVobSubPacks.Count - 1; i >= 0; i--)
-        {
-            if (mergedVobSubPacks[i].SubPicture.SubPictureDateSize <= 2)
-            {
-                mergedVobSubPacks.RemoveAt(i);
-            }
-            else if (mergedVobSubPacks[i].SubPicture.SubPictureDateSize <= 67 &&
-                     mergedVobSubPacks[i].SubPicture.Delay.TotalMilliseconds < 35)
-            {
-                mergedVobSubPacks.RemoveAt(i);
-            }
-        }
-
-        return (mergedVobSubPacks, idx.Palette);
-    }
-
-    private static (Subtitle subtitle, List<DvbSubPes> subtitleImages) ExtractMkvDvb(
-        MatroskaTrackInfo track, MatroskaFile matroska)
-    {
-        var sub = matroska.GetSubtitle(track.TrackNumber, null);
-        var subtitleImages = new List<DvbSubPes>();
-        var subtitle = new Subtitle();
-
-        for (var index = 0; index < sub.Count; index++)
-        {
-            try
-            {
-                var msub = sub[index];
-                DvbSubPes? pes = null;
-                var data = msub.GetData(track);
-                if (data != null && data.Length > 9 && data[0] == 15 &&
-                    data[1] >= SubtitleSegment.PageCompositionSegment &&
-                    data[1] <= SubtitleSegment.DisplayDefinitionSegment)
-                {
-                    var buffer = new byte[data.Length + 3];
-                    Buffer.BlockCopy(data, 0, buffer, 2, data.Length);
-                    buffer[0] = 32;
-                    buffer[1] = 0;
-                    buffer[buffer.Length - 1] = 255;
-                    pes = new DvbSubPes(0, buffer);
-                }
-                else if (VobSubParser.IsMpeg2PackHeader(data))
-                {
-                    pes = new DvbSubPes(data, Mpeg2Header.Length);
-                }
-                else if (VobSubParser.IsPrivateStream1(data, 0))
-                {
-                    pes = new DvbSubPes(data, 0);
-                }
-                else if (data!.Length > 9 && data[0] == 32 && data[1] == 0 && data[2] == 14 && data[3] == 16)
-                {
-                    pes = new DvbSubPes(0, data);
-                }
-
-                if (pes == null && subtitle.Paragraphs.Count > 0)
-                {
-                    var last = subtitle.Paragraphs[subtitle.Paragraphs.Count - 1];
-                    if (last.DurationTotalMilliseconds < 100)
-                    {
-                        last.EndTime.TotalMilliseconds = msub.Start;
-                        if (last.DurationTotalMilliseconds > Se.Settings.General.SubtitleMaximumDisplayMilliseconds)
-                        {
-                            last.EndTime.TotalMilliseconds = last.StartTime.TotalMilliseconds + 3000;
-                        }
-                    }
-                }
-
-                if (pes != null && pes.PageCompositions != null && pes.PageCompositions.Any(p => p.Regions.Count > 0))
-                {
-                    subtitleImages.Add(pes);
-                    subtitle.Paragraphs.Add(new Paragraph(string.Empty, msub.Start, msub.End));
-                }
-            }
-            catch
-            {
-                // continue
-            }
-        }
-
-        for (var index = 0; index < subtitle.Paragraphs.Count; index++)
-        {
-            var p = subtitle.Paragraphs[index];
-            if (p.DurationTotalMilliseconds < 200)
-            {
-                p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + 3000;
-            }
-
-            var next = subtitle.GetParagraphOrDefault(index + 1);
-            if (next != null && next.StartTime.TotalMilliseconds < p.EndTime.TotalMilliseconds)
-            {
-                p.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds -
-                                              Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
-            }
-        }
-
-        return (subtitle, subtitleImages);
+            || track.CodecId.Equals(MatroskaTrackType.VobSub, StringComparison.OrdinalIgnoreCase)
+            || track.CodecId.Equals(MatroskaTrackType.Dvb, StringComparison.OrdinalIgnoreCase);
     }
 
     private string? TryGetVideoFileName(string fileName)

--- a/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackViewModel.cs
+++ b/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackViewModel.cs
@@ -174,6 +174,58 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
             Utilities.ParseMatroskaTextSt(trackInfo, subtitles, subtitle);
             await WriteTextSubtitleFile(Window, trackInfo, subtitles, new SubRip());
         }
+        else if (trackInfo.CodecId.Equals(MatroskaTrackType.VobSub, StringComparison.OrdinalIgnoreCase) && subtitles != null)
+        {
+            var packs = MatroskaImageSubtitleExtractor.ExtractVobSub(trackInfo, subtitles, out var idx);
+            if (packs.Count == 0)
+            {
+                return;
+            }
+
+            var suggestedFileName = Utilities.GetPathAndFileNameWithoutExtension(_fileName);
+            var fileName = await _fileHelper.PickSaveSubtitleFile(Window, ".sub", suggestedFileName, Se.Language.General.SaveFileAsTitle);
+            if (string.IsNullOrEmpty(fileName))
+            {
+                return;
+            }
+
+            var screenSize = packs[0].GetScreenSize();
+            var screenWidth = (int)Math.Round(screenSize.Width, MidpointRounding.AwayFromZero);
+            var screenHeight = (int)Math.Round(screenSize.Height, MidpointRounding.AwayFromZero);
+            var exportHandler = new ExportHandlerVobSub();
+            exportHandler.WriteHeader(fileName, new ImageParameter
+            {
+                ScreenWidth = screenWidth,
+                ScreenHeight = screenHeight,
+            });
+
+            for (var i = 0; i < packs.Count; i++)
+            {
+                var pack = packs[i];
+                if (idx != null)
+                {
+                    pack.Palette = idx.Palette;
+                }
+
+                using var packBitmap = pack.GetBitmap();
+                var position = pack.GetPosition();
+                exportHandler.WriteParagraph(new ImageParameter
+                {
+                    Bitmap = packBitmap,
+                    StartTime = pack.StartTime,
+                    EndTime = pack.EndTime,
+                    ScreenWidth = screenWidth,
+                    ScreenHeight = screenHeight,
+                    Index = i + 1,
+                    OverridePosition = new SKPointI(position.Left, position.Top),
+                });
+            }
+
+            exportHandler.WriteFooter();
+
+            _ = await _windowService.ShowDialogAsync<PromptFileSavedWindow, PromptFileSavedViewModel>(Window,
+                vm => { vm.Initialize(Se.Language.General.SubtitleFileSaved, string.Format(Se.Language.General.SubtitleFileSavedToX, fileName), fileName, true, true); });
+        }
         else
         {
             await MessageBox.Show(Window, Se.Language.General.Error, "Format not supported: " + trackInfo.CodecId);
@@ -387,6 +439,45 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
                     Show = item.StartTime.TimeSpan,
                     Duration = TimeSpan.FromMilliseconds(item.EndTime.TotalMilliseconds - item.StartTime.TotalMilliseconds),
                     Text = item.Text,
+                });
+            }
+        }
+        else if (trackInfo.CodecId.Equals(MatroskaTrackType.VobSub, StringComparison.OrdinalIgnoreCase))
+        {
+            var packs = MatroskaImageSubtitleExtractor.ExtractVobSub(trackInfo, subtitles, out var idx);
+            count = packs.Count;
+            for (var i = 0; i < 20 && i < packs.Count; i++)
+            {
+                var pack = packs[i];
+                if (idx != null)
+                {
+                    pack.Palette = idx.Palette;
+                }
+
+                using var packBitmap = pack.GetBitmap();
+                cues.Add(new PreviewCueData
+                {
+                    Number = i + 1,
+                    Show = pack.StartTime,
+                    Duration = pack.EndTime - pack.StartTime,
+                    Image = packBitmap.ToAvaloniaBitmap(),
+                });
+            }
+        }
+        else if (trackInfo.CodecId.Equals(MatroskaTrackType.Dvb, StringComparison.OrdinalIgnoreCase))
+        {
+            var (dvbSubtitle, dvbImages) = MatroskaImageSubtitleExtractor.ExtractDvb(trackInfo, subtitles);
+            count = dvbImages.Count;
+            for (var i = 0; i < 20 && i < dvbImages.Count; i++)
+            {
+                var item = dvbSubtitle.Paragraphs[i];
+                using var pesBitmap = dvbImages[i].GetImageFull();
+                cues.Add(new PreviewCueData
+                {
+                    Number = i + 1,
+                    Show = item.StartTime.TimeSpan,
+                    Duration = TimeSpan.FromMilliseconds(item.EndTime.TotalMilliseconds - item.StartTime.TotalMilliseconds),
+                    Image = pesBitmap.ToAvaloniaBitmap(),
                 });
             }
         }

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -568,31 +568,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
 
     internal static List<VobSubMergedPack> LoadVobSubFromMatroska(MatroskaTrackInfo matroskaSubtitleInfo, MatroskaFile matroska, out Core.VobSub.Idx? idx)
     {
-        var mergedVobSubPacks = new List<VobSubMergedPack>();
-        if (matroskaSubtitleInfo.ContentEncodingType == 1)
-        {
-            idx = null;
-            return mergedVobSubPacks;
-        }
-
-        var sub = matroska.GetSubtitle(matroskaSubtitleInfo.TrackNumber, null);
-        idx = new Core.VobSub.Idx(matroskaSubtitleInfo.GetCodecPrivate().SplitToLines());
-        foreach (var p in sub)
-        {
-            mergedVobSubPacks.Add(new VobSubMergedPack(p.GetData(matroskaSubtitleInfo), TimeSpan.FromMilliseconds(p.Start), 32, null));
-            if (mergedVobSubPacks.Count > 0)
-            {
-                mergedVobSubPacks[mergedVobSubPacks.Count - 1].EndTime = TimeSpan.FromMilliseconds(p.End);
-            }
-
-            // fix overlapping (some versions of Handbrake makes overlapping time codes - thx Hawke)
-            if (mergedVobSubPacks.Count > 1 && mergedVobSubPacks[mergedVobSubPacks.Count - 2].EndTime > mergedVobSubPacks[mergedVobSubPacks.Count - 1].StartTime)
-            {
-                mergedVobSubPacks[mergedVobSubPacks.Count - 2].EndTime = TimeSpan.FromMilliseconds(mergedVobSubPacks[mergedVobSubPacks.Count - 1].StartTime.TotalMilliseconds - 1);
-            }
-        }
-
-        return mergedVobSubPacks;
+        return MatroskaImageSubtitleExtractor.ExtractVobSub(matroskaSubtitleInfo, matroska, out idx);
     }
 
 

--- a/src/ui/Logic/Media/MatroskaImageSubtitleExtractor.cs
+++ b/src/ui/Logic/Media/MatroskaImageSubtitleExtractor.cs
@@ -1,0 +1,159 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.ContainerFormats.Matroska;
+using Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream;
+using Nikse.SubtitleEdit.Core.VobSub;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Logic.Media;
+
+/// <summary>
+/// Builds image based subtitle data (VobSub/DVB) from a Matroska track. Shared by the
+/// track picker preview, the binary edit import, and batch convert, which used to carry
+/// their own copies of this parsing.
+/// </summary>
+public static class MatroskaImageSubtitleExtractor
+{
+    public static List<VobSubMergedPack> ExtractVobSub(MatroskaTrackInfo track, MatroskaFile matroska, out Idx? idx,
+        MatroskaFile.LoadMatroskaCallback? progressCallback = null)
+    {
+        if (track.ContentEncodingType == 1) // encrypted
+        {
+            idx = null;
+            return new List<VobSubMergedPack>();
+        }
+
+        var sub = matroska.GetSubtitle(track.TrackNumber, progressCallback);
+        return ExtractVobSub(track, sub, out idx);
+    }
+
+    public static List<VobSubMergedPack> ExtractVobSub(MatroskaTrackInfo track, List<MatroskaSubtitle> sub, out Idx? idx)
+    {
+        var mergedVobSubPacks = new List<VobSubMergedPack>();
+        if (track.ContentEncodingType == 1) // encrypted
+        {
+            idx = null;
+            return mergedVobSubPacks;
+        }
+
+        idx = new Idx(track.GetCodecPrivate().SplitToLines());
+        foreach (var p in sub)
+        {
+            mergedVobSubPacks.Add(new VobSubMergedPack(p.GetData(track), TimeSpan.FromMilliseconds(p.Start), 32, null));
+            mergedVobSubPacks[mergedVobSubPacks.Count - 1].EndTime = TimeSpan.FromMilliseconds(p.End);
+
+            // fix overlapping (some versions of Handbrake make overlapping time codes - thx Hawke)
+            if (mergedVobSubPacks.Count > 1 &&
+                mergedVobSubPacks[mergedVobSubPacks.Count - 2].EndTime > mergedVobSubPacks[mergedVobSubPacks.Count - 1].StartTime)
+            {
+                mergedVobSubPacks[mergedVobSubPacks.Count - 2].EndTime =
+                    TimeSpan.FromMilliseconds(mergedVobSubPacks[mergedVobSubPacks.Count - 1].StartTime.TotalMilliseconds - 1);
+            }
+        }
+
+        // remove bad packs
+        for (var i = mergedVobSubPacks.Count - 1; i >= 0; i--)
+        {
+            if (mergedVobSubPacks[i].SubPicture.SubPictureDateSize <= 2)
+            {
+                mergedVobSubPacks.RemoveAt(i);
+            }
+            else if (mergedVobSubPacks[i].SubPicture.SubPictureDateSize <= 67 &&
+                     mergedVobSubPacks[i].SubPicture.Delay.TotalMilliseconds < 35)
+            {
+                mergedVobSubPacks.RemoveAt(i);
+            }
+        }
+
+        return mergedVobSubPacks;
+    }
+
+    public static (Subtitle subtitle, List<DvbSubPes> subtitleImages) ExtractDvb(MatroskaTrackInfo track, MatroskaFile matroska,
+        MatroskaFile.LoadMatroskaCallback? progressCallback = null)
+    {
+        var sub = matroska.GetSubtitle(track.TrackNumber, progressCallback);
+        return ExtractDvb(track, sub);
+    }
+
+    public static (Subtitle subtitle, List<DvbSubPes> subtitleImages) ExtractDvb(MatroskaTrackInfo track, List<MatroskaSubtitle> sub)
+    {
+        var subtitleImages = new List<DvbSubPes>();
+        var subtitle = new Subtitle();
+
+        for (var index = 0; index < sub.Count; index++)
+        {
+            try
+            {
+                var msub = sub[index];
+                DvbSubPes? pes = null;
+                var data = msub.GetData(track);
+                if (data != null && data.Length > 9 && data[0] == 15 &&
+                    data[1] >= SubtitleSegment.PageCompositionSegment &&
+                    data[1] <= SubtitleSegment.DisplayDefinitionSegment) // sync byte + segment id
+                {
+                    var buffer = new byte[data.Length + 3];
+                    Buffer.BlockCopy(data, 0, buffer, 2, data.Length);
+                    buffer[0] = 32;
+                    buffer[1] = 0;
+                    buffer[buffer.Length - 1] = 255;
+                    pes = new DvbSubPes(0, buffer);
+                }
+                else if (VobSubParser.IsMpeg2PackHeader(data))
+                {
+                    pes = new DvbSubPes(data, Mpeg2Header.Length);
+                }
+                else if (VobSubParser.IsPrivateStream1(data, 0))
+                {
+                    pes = new DvbSubPes(data, 0);
+                }
+                else if (data!.Length > 9 && data[0] == 32 && data[1] == 0 && data[2] == 14 && data[3] == 16)
+                {
+                    pes = new DvbSubPes(0, data);
+                }
+
+                if (pes == null && subtitle.Paragraphs.Count > 0)
+                {
+                    var last = subtitle.Paragraphs[subtitle.Paragraphs.Count - 1];
+                    if (last.DurationTotalMilliseconds < 100)
+                    {
+                        last.EndTime.TotalMilliseconds = msub.Start;
+                        if (last.DurationTotalMilliseconds > Se.Settings.General.SubtitleMaximumDisplayMilliseconds)
+                        {
+                            last.EndTime.TotalMilliseconds = last.StartTime.TotalMilliseconds + 3000;
+                        }
+                    }
+                }
+
+                if (pes != null && pes.PageCompositions != null && pes.PageCompositions.Any(p => p.Regions.Count > 0))
+                {
+                    subtitleImages.Add(pes);
+                    subtitle.Paragraphs.Add(new Paragraph(string.Empty, msub.Start, msub.End));
+                }
+            }
+            catch
+            {
+                // continue
+            }
+        }
+
+        for (var index = 0; index < subtitle.Paragraphs.Count; index++)
+        {
+            var p = subtitle.Paragraphs[index];
+            if (p.DurationTotalMilliseconds < 200)
+            {
+                p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + 3000;
+            }
+
+            var next = subtitle.GetParagraphOrDefault(index + 1);
+            if (next != null && next.StartTime.TotalMilliseconds < p.EndTime.TotalMilliseconds)
+            {
+                p.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds -
+                                              Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
+            }
+        }
+
+        return (subtitle, subtitleImages);
+    }
+}

--- a/src/ui/Logic/Media/MatroskaTrackType.cs
+++ b/src/ui/Logic/Media/MatroskaTrackType.cs
@@ -17,5 +17,7 @@ public class MatroskaTrackType
     public const string WebVTT = "S_TEXT/WEBVTT";
     public const string WebVTT2 = "D_WEBVTT/SUBTITLES";
 
+    public const string VobSub = "S_VOBSUB";
 
+    public const string Dvb = "S_DVBSUB";
 }


### PR DESCRIPTION
Fixes #13432.

The "Pick Matroska track" dialog's preview builder only had branches for text formats, `S_HDMV/PGS` and `S_HDMV/TEXTST`. An `S_VOBSUB` (or `S_DVBSUB`) track fell through all of them, so the right column stayed empty and showed "Number of subtitles: 0" — even though pressing OK imports the track fine. The dialog's Export button also rejected VobSub with "Format not supported".

### Changes
- **VobSub preview**: decodes the track's packs (palette from the `CodecPrivate` idx block) and shows the first 20 subpicture bitmaps plus the real count.
- **DVB preview**: same for `S_DVBSUB` tracks via `DvbSubPes.GetImageFull()`.
- **VobSub export**: the Export button now writes a .sub/.idx pair via `ExportHandlerVobSub`, keeping each pack's original palette and screen position.
- The pack/PES building was previously duplicated in `MainViewModel`, `BinaryEditViewModel` and `BatchConverter`; the latter two now share a new `MatroskaImageSubtitleExtractor` (the batch convert path thereby also gains the "remove bad packs" filtering the main import flow does). `MainViewModel` is left untouched for now to keep this diff conflict-free with in-flight work there.
- New `MatroskaTrackType.VobSub`/`Dvb` constants replace scattered `"S_VOBSUB"`/`"S_DVBSUB"` literals in the touched files.

### Testing
- Authored a VobSub .sub/.idx with SE's own `VobSubWriter`, muxed it into Matroska with ffmpeg (`S_VOBSUB`, and transcoded to `S_DVBSUB` for the DVB case), then ran the new extractor headlessly: correct pack counts, readable subpicture bitmaps at the right DVD positions for both codecs.
- Round-tripped the new Export path: exported .sub/.idx re-parses with `VobSubParser` to the same pack count.
- `UI` and `UITests` projects build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)