### PR TITLE
Fix six bugs found in a review of today's commits

### DIFF
--- a/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
@@ -162,10 +162,15 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
 
                 // Most headers end at "[Events]", but some (e.g. HeaderNoStyles) already carry
                 // the events format line - appending another gave a duplicate "Format:" line.
+                // Only the exact standard line may be skipped: Dialogue lines are always written
+                // in the standard field order, so a nonstandard Format line (an MKV CodecPrivate
+                // is kept verbatim in the header) must still be overridden by appending the
+                // standard one after it - the last Format line wins when parsing.
+                const string eventsFormatLine = "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text";
                 var eventsIndex = subtitle.Header.LastIndexOf("[Events]", StringComparison.Ordinal);
-                if (eventsIndex < 0 || subtitle.Header.IndexOf("Format:", eventsIndex, StringComparison.Ordinal) < 0)
+                if (eventsIndex < 0 || subtitle.Header.IndexOf(eventsFormatLine, eventsIndex, StringComparison.Ordinal) < 0)
                 {
-                    sb.AppendLine("Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text");
+                    sb.AppendLine(eventsFormatLine);
                 }
 
                 styles = GetStylesFromHeader(subtitle.Header);

--- a/src/libse/VobSub/Idx.cs
+++ b/src/libse/VobSub/Idx.cs
@@ -18,6 +18,12 @@ namespace Nikse.SubtitleEdit.Core.VobSub
         /// </summary>
         public readonly List<string> LanguageCodes = new List<string>();
 
+        /// <summary>
+        /// Frame size from the idx "size:" line (e.g. 720x576 for PAL); 0 when absent.
+        /// </summary>
+        public int ScreenWidth { get; private set; }
+        public int ScreenHeight { get; private set; }
+
         private static readonly Regex TimeCodeLinePattern = new Regex(@"^timestamp: \d+:\d+:\d+:\d+, filepos: [\dabcdefABCDEF]+$", RegexOptions.Compiled);
 
         public Idx(string fileName)
@@ -45,6 +51,18 @@ namespace Nikse.SubtitleEdit.Core.VobSub
                     foreach (string hex in colors)
                     {
                         Palette.Add(HexToColor(hex));
+                    }
+                }
+                else if (line.StartsWith("size:", StringComparison.OrdinalIgnoreCase) && line.Length > 6)
+                {
+                    // size: 720x576
+                    var parts = line.Substring("size:".Length).Split(new[] { 'x', 'X', ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length >= 2 &&
+                        int.TryParse(parts[0], out var width) && width > 0 &&
+                        int.TryParse(parts[1], out var height) && height > 0)
+                    {
+                        ScreenWidth = width;
+                        ScreenHeight = height;
                     }
                 }
                 else if (line.StartsWith("id:", StringComparison.OrdinalIgnoreCase) && line.Length > 4)

--- a/src/libuilogic/Ocr/NOcrDb.cs
+++ b/src/libuilogic/Ocr/NOcrDb.cs
@@ -750,6 +750,7 @@ public class NOcrDb
             AspectMaxDelta = 20, SizeMaxDelta = int.MaxValue, MarginTopMaxDelta = 15,
             MinLineCount = 41,
             ErrorsAllowed = ErrorsCappedAtTwenty,
+            ErrorsAllowedSensitive = ErrorsTen,
             AspectMaxDeltaSensitive = 30,
         },
         // deepSeek: very wide aspect, requires lots of lines, errors as requested

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -2613,12 +2613,18 @@ public partial class MainViewModel :
             if (vp.VideoPlayer is LibMpvDynamicPlayer mpv)
             {
                 _mpvReloader.Reset();
-                _ = _mpvReloader.RefreshMpv(mpv, GetUpdateSubtitle(), _subtitleSecondary, SelectedSubtitleFormat);
+                // Through RunPreviewRefresh so a rejected push (player just recreated, mpv not
+                // playing yet) arms the dirty-flag retry instead of being lost (#13407).
+                _ = RunPreviewRefresh(() => _mpvReloader.RefreshMpv(mpv, GetUpdateSubtitle(), _subtitleSecondary, SelectedSubtitleFormat));
             }
             else if (vp.VideoPlayer is LibVlcDynamicPlayer vlc)
             {
                 _vlcReloader.Reset();
-                _ = _vlcReloader.RefreshVlc(vlc, GetUpdateSubtitle(), _subtitleSecondary, SelectedSubtitleFormat);
+                _ = RunPreviewRefresh(async () =>
+                {
+                    await _vlcReloader.RefreshVlc(vlc, GetUpdateSubtitle(), _subtitleSecondary, SelectedSubtitleFormat);
+                    return true;
+                });
             }
         }
     }
@@ -2628,6 +2634,7 @@ public partial class MainViewModel :
     {
         IsSubtitleSecondaryVisible = false;
         _subtitleSecondary = null;
+        RefreshSubtitlePreview(); // push the removal, or the cleared secondary stays on the video
     }
 
     [RelayCommand]

--- a/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackViewModel.cs
+++ b/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackViewModel.cs
@@ -9,6 +9,7 @@ using Nikse.SubtitleEdit.Core.BluRaySup;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.ContainerFormats.Matroska;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Core.VobSub;
 using Nikse.SubtitleEdit.Features.Files.ExportImageBased;
 using Nikse.SubtitleEdit.Features.Shared.PromptFileSaved;
 using Nikse.SubtitleEdit.Logic;
@@ -192,11 +193,23 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
             var screenSize = packs[0].GetScreenSize();
             var screenWidth = (int)Math.Round(screenSize.Width, MidpointRounding.AwayFromZero);
             var screenHeight = (int)Math.Round(screenSize.Height, MidpointRounding.AwayFromZero);
+            if (idx is { ScreenWidth: > 0, ScreenHeight: > 0 })
+            {
+                // The pack default is NTSC 720x480; a PAL track declares 720x576 on the idx
+                // "size:" line, and positions past y=480 would otherwise be discarded.
+                screenWidth = idx.ScreenWidth;
+                screenHeight = idx.ScreenHeight;
+            }
+
             var exportHandler = new ExportHandlerVobSub();
             exportHandler.WriteHeader(fileName, new ImageParameter
             {
                 ScreenWidth = screenWidth,
                 ScreenHeight = screenHeight,
+                // Pattern/emphasis of the written DVD palette. Left at the default (transparent
+                // black) the four-color flatten maps every visible pixel to an invisible color.
+                FontColor = SKColors.White,
+                OutlineColor = SKColors.Black,
             });
 
             for (var i = 0; i < packs.Count; i++)
@@ -208,7 +221,6 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
                 }
 
                 using var packBitmap = pack.GetBitmap();
-                var position = pack.GetPosition();
                 exportHandler.WriteParagraph(new ImageParameter
                 {
                     Bitmap = packBitmap,
@@ -217,7 +229,7 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
                     ScreenWidth = screenWidth,
                     ScreenHeight = screenHeight,
                     Index = i + 1,
-                    OverridePosition = new SKPointI(position.Left, position.Top),
+                    OverridePosition = GetCroppedPosition(pack),
                 });
             }
 
@@ -230,6 +242,22 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
         {
             await MessageBox.Show(Window, Se.Language.General.Error, "Format not supported: " + trackInfo.CodecId);
         }
+    }
+
+    /// <summary>
+    /// GetBitmap() crops the transparent borders away, so the display-area origin must be
+    /// shifted by the cropped top/left margins - otherwise the text drifts up/left (a
+    /// full-frame subpicture would jump to the top of the screen).
+    /// </summary>
+    private static SKPointI GetCroppedPosition(VobSubMergedPack pack)
+    {
+        var left = pack.SubPicture.ImageDisplayArea.Left;
+        var top = pack.SubPicture.ImageDisplayArea.Top;
+        using var uncropped = pack.SubPicture.GetBitmap(pack.Palette, SKColors.Transparent, SKColors.Black, SKColors.White, SKColors.Black, false, false);
+        var nikseBitmap = new NikseBitmap(uncropped);
+        top += nikseBitmap.CropTopTransparent(0);
+        left += nikseBitmap.CalcLeftCroppingTransparent();
+        return new SKPointI(left, top);
     }
 
     private async Task WriteTextSubtitleFile(Window window, MatroskaTrackInfo trackInfo, List<MatroskaSubtitle> subtitles, SubtitleFormat format)

--- a/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
+++ b/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
@@ -143,6 +143,8 @@ public partial class FixNamesViewModel : ObservableObject, IClosingCleanup
 
     private CancellationTokenSource? _cancellationTokenSource;
     private bool _isClosing;
+    private bool _previewPending;
+    private Task _previewTask = Task.CompletedTask;
 
     private void RequestPreview(int delayMilliseconds = 500)
     {
@@ -154,7 +156,8 @@ public partial class FixNamesViewModel : ObservableObject, IClosingCleanup
         _cancellationTokenSource?.Cancel();
         _cancellationTokenSource?.Dispose();
         _cancellationTokenSource = new CancellationTokenSource();
-        _ = DebouncedPreviewAsync(delayMilliseconds, _cancellationTokenSource.Token);
+        _previewPending = true;
+        _previewTask = DebouncedPreviewAsync(delayMilliseconds, _cancellationTokenSource.Token);
     }
 
     private async Task DebouncedPreviewAsync(int delayMilliseconds, CancellationToken token)
@@ -169,7 +172,7 @@ public partial class FixNamesViewModel : ObservableObject, IClosingCleanup
                 Names.Where(n => n.IsChecked).Select(n => n.Name).ToArray());
             token.ThrowIfCancellationRequested();
 
-            GeneratePreview(activeNames);
+            GeneratePreview(activeNames, token);
         }
         catch (OperationCanceledException)
         {
@@ -191,7 +194,7 @@ public partial class FixNamesViewModel : ObservableObject, IClosingCleanup
         _cancellationTokenSource = null;
     }
 
-    private void GeneratePreview(string[] activeNames)
+    private void GeneratePreview(string[] activeNames, CancellationToken token)
     {
         var hits = new List<FixNameHitItem>();
 
@@ -229,8 +232,17 @@ public partial class FixNamesViewModel : ObservableObject, IClosingCleanup
 
         Dispatcher.UIThread.Invoke(() =>
         {
+            // Cancellation happens on the UI thread, so checking here (not before the Invoke)
+            // guarantees a superseded computation - one that was already past the earlier token
+            // check when a newer request cancelled it - can never overwrite the newer result.
+            if (token.IsCancellationRequested)
+            {
+                return;
+            }
+
             Hits.Clear();
             Hits.AddRange(hits);
+            _previewPending = false;
         });
     }
 
@@ -271,8 +283,17 @@ public partial class FixNamesViewModel : ObservableObject, IClosingCleanup
     }
 
     [RelayCommand]
-    private void Ok()
+    private async Task Ok()
     {
+        // A preview may still be pending (the 500 ms debounce, or a computation in flight), so
+        // Hits can lag behind the checkboxes - applying it would use fixes for names the user
+        // just deselected. Flush with a zero-delay preview and wait for it before committing.
+        if (_previewPending)
+        {
+            RequestPreview(0);
+            await _previewTask;
+        }
+
         Subtitle = new Subtitle(_subtitle, false);
 
         foreach (var hit in Hits)

--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -497,6 +497,10 @@ public partial class BurnInViewModel : ObservableObject
                 jobItem.TotalFrames = (long)Math.Round(jobItem.TotalSeconds * 25.0);
             }
         }
+        // Batch job items survive between Generate clicks, and SetTargetBitRate stores its
+        // computed rate here - stale, it would turn a later quality-based run into a silent
+        // "-b:v <old rate>" encode with the quality flag dropped.
+        jobItem.VideoBitRate = string.Empty;
         jobItem.UseTargetFileSize = UseTargetFileSize;
         // Resolve the per-file target (MB): "match source" derives it from each input file's own
         // size (so a batch of differently-sized videos keeps each output near its source), otherwise
@@ -533,22 +537,28 @@ public partial class BurnInViewModel : ObservableObject
         }
         else
         {
-            if (jobItem.UseTargetFileSize)
-            {
-                // VideoToolbox accepts -pass but writes an empty stats file, so pass 1 only
-                // doubles the encode time. Hit the target with single-pass average bit rate
-                // instead (#13401).
-                if (!SetTargetBitRate(jobItem))
-                {
-                    return;
-                }
-            }
+            // VideoToolbox accepts -pass but writes an empty stats file, so pass 1 only
+            // doubles the encode time. Hit the target with single-pass average bit rate
+            // instead (#13401).
+            result = !jobItem.UseTargetFileSize || SetTargetBitRate(jobItem);
 
-            result = await RunOnePassEncoding(jobItem);
             if (result)
             {
-                _timerGenerate.Start();
+                result = await RunOnePassEncoding(jobItem);
+                if (result)
+                {
+                    _timerGenerate.Start();
+                }
             }
+        }
+
+        if (!result)
+        {
+            // No process and no timer running: nothing would ever consume _doAbort or reset the
+            // generating state, leaving the dialog stuck with a dead Cancel button.
+            jobItem.Status = Se.Language.General.Error;
+            IsGenerating = false;
+            ProgressValue = 0;
         }
     }
 

--- a/tests/libse/SubtitleFormats/AdvancedSubStationAlphaTest.cs
+++ b/tests/libse/SubtitleFormats/AdvancedSubStationAlphaTest.cs
@@ -1,0 +1,64 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace LibSETests.SubtitleFormats;
+
+public class AdvancedSubStationAlphaTest
+{
+    private const string StandardEventsFormatLine = "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text";
+
+    private static Subtitle MakeSubtitle(string header)
+    {
+        var subtitle = new Subtitle { Header = header };
+        subtitle.Paragraphs.Add(new Paragraph("Hello", 1000, 2000));
+        return subtitle;
+    }
+
+    private static string HeaderWithEventsFormat(string formatLine)
+    {
+        return @"[Script Info]
+ScriptType: v4.00+
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Default,Arial,20,&H00FFFFFF,&H0300FFFF,&H00000000,&H02000000,0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1
+
+[Events]
+" + formatLine;
+    }
+
+    [Fact]
+    public void ToText_HeaderWithStandardEventsFormatLine_DoesNotDuplicateIt()
+    {
+        var subtitle = MakeSubtitle(HeaderWithEventsFormat(StandardEventsFormatLine));
+
+        var text = new AdvancedSubStationAlpha().ToText(subtitle, string.Empty);
+
+        var formatCount = text.SplitToLines().Count(l => l.StartsWith("Format: Layer", System.StringComparison.Ordinal));
+        Assert.Equal(1, formatCount);
+    }
+
+    [Fact]
+    public void ToText_HeaderWithNonStandardEventsFormatLine_AppendsStandardLineAfterIt()
+    {
+        // An MKV CodecPrivate header is kept verbatim, so its events Format line can use a
+        // nonstandard field order. Dialogue lines are always written in the standard order, so
+        // the standard Format line must still be appended (last Format line wins when parsing) -
+        // otherwise every parser maps the fields to the wrong comma slots.
+        var subtitle = MakeSubtitle(HeaderWithEventsFormat("Format: Start, End, Style, Text"));
+
+        var text = new AdvancedSubStationAlpha().ToText(subtitle, string.Empty);
+
+        var lines = text.SplitToLines();
+        var nonStandardIndex = lines.IndexOf("Format: Start, End, Style, Text");
+        var standardIndex = lines.IndexOf(StandardEventsFormatLine);
+        Assert.True(nonStandardIndex >= 0);
+        Assert.True(standardIndex > nonStandardIndex);
+
+        // And the output must round-trip: SE's own parser reads the text back correctly.
+        var reloaded = new Subtitle();
+        new AdvancedSubStationAlpha().LoadSubtitle(reloaded, lines, "test.ass");
+        Assert.Single(reloaded.Paragraphs);
+        Assert.Equal("Hello", reloaded.Paragraphs[0].Text);
+    }
+}

--- a/tests/libse/VobSub/IdxTest.cs
+++ b/tests/libse/VobSub/IdxTest.cs
@@ -1,0 +1,31 @@
+using Nikse.SubtitleEdit.Core.VobSub;
+using System.Collections.Generic;
+
+namespace LibSETests.VobSub;
+
+public class IdxTest
+{
+    [Fact]
+    public void SizeLineIsParsed()
+    {
+        var idx = new Idx(new List<string>
+        {
+            "# VobSub index file, v7 (do not modify this line!)",
+            "size: 720x576",
+            "palette: 000000, f0f0f0, cccccc, 999999, 3333fa, 1111bb, fa3333, bb1111, 33fa33, 11bb11, fafa33, bbbb11, fa33fa, bb11bb, 33fafa, 11bbbb",
+            "id: en, index: 0",
+        });
+
+        Assert.Equal(720, idx.ScreenWidth);
+        Assert.Equal(576, idx.ScreenHeight);
+    }
+
+    [Fact]
+    public void MissingSizeLineLeavesSizeAtZero()
+    {
+        var idx = new Idx(new List<string> { "id: en, index: 0" });
+
+        Assert.Equal(0, idx.ScreenWidth);
+        Assert.Equal(0, idx.ScreenHeight);
+    }
+}


### PR DESCRIPTION
A bug hunt over today's 19 code commits (translation updates excluded) turned up six confirmed defects; each fix is a separate commit.

## Fixes

**MKV VobSub export wrote unusable files** (from e4001a36e / #13432)
- `ImageParameter.FontColor`/`OutlineColor` were left at `default` (transparent black), so `ConvertToFourColors` flattened every pack to an invisible palette — the exported `.sub/.idx` showed nothing, or black boxes. Now uses the same White/Black pattern/emphasis colors as the batch convert export.
- The `.idx` frame size was the pack's hardcoded NTSC 720x480; PAL tracks (720x576) had their bottom-subtitle positions past y=480 discarded by `VobSubWriter`. The idx `size:` line is now parsed and used.
- `GetBitmap()` crops transparent borders, but positions used the uncropped display-area origin, drifting text up/left. Positions are now crop-adjusted like `OcrSubtitleVobSub`.

**Fix-names preview races** (from 0e4ab9d10)
- An older, slower preview already past the token check could overwrite a newer result after being cancelled — OK then applied fixes for names the user had deselected. The token is now re-checked inside the final UI-thread write.
- Select-all/invert go through the 500 ms debounce, so OK inside that window committed pre-toggle hits. OK now flushes a pending preview before applying.

**ASSA ToText could emit a mismatched events Format line** (from 3263663f4)
The duplicate-Format skip fired on *any* `Format:` after `[Events]`. An MKV CodecPrivate header kept verbatim can carry a nonstandard field order, and Dialogue lines are always written in standard order — the file then parsed garbage everywhere. Only the exact standard line is skipped now; regression tests added.

**Burn-in target-size regressions** (from 0fbe7ff97 / #13401)
- `jobItem.VideoBitRate` was never cleared and batch job items survive between Generate clicks — a later quality-based run silently encoded at the previous run's `-b:v` with the quality flag suppressed. Reset when (re)starting a job.
- A "bit rate too low" failure returned with `IsGenerating` stuck true and no timer running to consume `_doAbort` — the dialog was wedged with a dead Cancel. Failure now marks the job and resets the generating state.

**nOCR sensitive-character budget never wired up** (from 3e2eecb7e)
The merged sensitive pass documents a tighter budget (10), but `ErrorsAllowedSensitive` was never assigned and `ErrorsTen` was dead code — O/o/0/quotes/dashes could claim glyphs at up to 20 wrong pixels. One-line wire-up.

**Secondary-subtitle push bypassed the #13407 retry contract** (from 050627bf7)
The dialog's OK handler discarded `RefreshMpv`'s result — a push rejected by a freshly created mpv player was lost with no retry, the exact failure mode 050627bf7 fixed elsewhere. Now routed through `RunPreviewRefresh`; `ClearSecondarySubtitle` also pushes the removal (the cleared secondary previously stayed on the video until the next edit).

## Verification
- Full solution builds; full test suite passes (2,255 UI + libse/libuilogic/seconv; one known-flaky `MainMenuKeyboardActivation` test passed on isolated rerun).
- New regression tests: ASSA standard/nonstandard events Format line (incl. round-trip), idx `size:` parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)