### PR TITLE
nOCR: stop the scaled expanded match from swallowing separate letters

### DIFF
--- a/src/libuilogic/Ocr/NOcrDb.cs
+++ b/src/libuilogic/Ocr/NOcrDb.cs
@@ -270,6 +270,7 @@ public class NOcrDb
                 var heightToWidthPercent = size.Y * 100.0 / size.X;
                 if (Math.Abs(heightToWidthPercent - oc.HeightToWidthPercent) < 15 &&
                     Math.Abs(size.X - oc.Width) < 25 && Math.Abs(size.Y - oc.Height) < 20 &&
+                    IsScaleRatioSane(size.X, oc.Width) && IsScaleRatioSane(size.Y, oc.Height) &&
                     IsExpandedLineMatchScaled(oc, targetItem, nikseBitmap, size.X, size.Y))
                 {
                     return oc;
@@ -281,16 +282,38 @@ public class NOcrDb
     }
 
     /// <summary>
+    /// The scaled expanded pass may only bridge a moderate size difference between the trained
+    /// character and the target group. Without this gate the absolute size deltas (±25/±20 px)
+    /// let a tiny two-part glyph (a 10x12 double quote) be "scaled" onto a letter-pair group
+    /// three to four times its size.
+    /// </summary>
+    private static bool IsScaleRatioSane(int targetSize, int charSize)
+    {
+        if (targetSize <= 0 || charSize <= 0)
+        {
+            return false;
+        }
+
+        var big = Math.Max(targetSize, charSize);
+        var small = Math.Min(targetSize, charSize);
+        return big * 2 <= small * 5; // ratio <= 2.5
+    }
+
+    /// <summary>
     /// Scaled expanded match against the actual bounding box of the target group. The old
     /// "scaled" pass walked the character's lines at the character's own size, so an expanded
     /// glyph (e.g. a two-part quote) rendered at a different size than it was trained at could
     /// essentially never match; the single-part fallback then turned every cross-size " into '.
-    /// A small area-scaled error budget absorbs antialiasing differences.
+    /// The error budget scales with the number of line points actually walked (~5%), NOT with
+    /// the target area: measured legit scaled matches stay under ~2-3% wrong points, while a
+    /// wrong expanded character claiming a group of ordinary neighboring letters (e.g. a
+    /// trained "fi" pair swallowing "t"+"i") runs at 9%+. An area-based budget grows with the
+    /// group being claimed, so it was loosest exactly for those letter-pair steals.
     /// </summary>
     private static bool IsExpandedLineMatchScaled(NOcrChar oc, ImageSplitterItem2 targetItem, NikseBitmap2 nikseBitmap, int targetWidth, int targetHeight)
     {
-        var errorsAllowed = Math.Max(4, targetWidth * targetHeight / 16);
         var errors = 0;
+        var points = 0;
         var scaledMarginTop = (int)Math.Round(oc.MarginTop * targetHeight / (double)Math.Max(1, oc.Height), MidpointRounding.AwayFromZero);
         var originY = targetItem.Y - scaledMarginTop;
 
@@ -298,15 +321,13 @@ public class NOcrDb
         {
             foreach (var point in op.ScaledWalkPoints(oc, targetWidth, targetHeight))
             {
+                points++;
                 var p = new OcrPoint(point.X + targetItem.X, point.Y + originY);
                 // Out-of-bounds foreground points can't be on text - count them as errors.
                 if (p.X < 0 || p.Y < 0 || p.X >= nikseBitmap.Width || p.Y >= nikseBitmap.Height ||
                     nikseBitmap.GetAlpha(p.X, p.Y) <= 150)
                 {
-                    if (++errors > errorsAllowed)
-                    {
-                        return false;
-                    }
+                    errors++;
                 }
             }
         }
@@ -315,6 +336,7 @@ public class NOcrDb
         {
             foreach (var point in op.ScaledWalkPoints(oc, targetWidth, targetHeight))
             {
+                points++;
                 var p = new OcrPoint(point.X + targetItem.X, point.Y + originY);
                 // Out-of-bounds background points are definitionally "not on text" - fine.
                 if (p.X < 0 || p.Y < 0 || p.X >= nikseBitmap.Width || p.Y >= nikseBitmap.Height)
@@ -324,15 +346,12 @@ public class NOcrDb
 
                 if (nikseBitmap.GetAlpha(p.X, p.Y) > 150)
                 {
-                    if (++errors > errorsAllowed)
-                    {
-                        return false;
-                    }
+                    errors++;
                 }
             }
         }
 
-        return true;
+        return errors <= Math.Max(4, points / 20);
     }
 
     private static bool IsExpandedLineMatch(NOcrChar oc, ImageSplitterItem2 targetItem, NikseBitmap2 nikseBitmap)

--- a/tests/libuilogic/Ocr/NOcrDbExpandedMatchTests.cs
+++ b/tests/libuilogic/Ocr/NOcrDbExpandedMatchTests.cs
@@ -1,0 +1,134 @@
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+using SkiaSharp;
+
+namespace LibUiLogicTests.Ocr;
+
+/// <summary>
+/// Regression tests for the scaled expanded match (the pass that lets a multi-part expanded
+/// character match at a different size than it was trained at). Its error budget must scale
+/// with the number of line points walked, not with the target group's area: an area-scaled
+/// budget grows with the group being claimed, so a trained expanded letter pair (e.g. "fi")
+/// could swallow two ordinary separately-split letters ("t"+"i", "l"+"o") at ~10% wrong
+/// points and hand them back merged as one glyph image.
+/// </summary>
+public class NOcrDbExpandedMatchTests
+{
+    private static NikseBitmap2 MakeSolidBitmap(int width, int height)
+    {
+        var bmp = new SKBitmap(width, height);
+        using (var canvas = new SKCanvas(bmp))
+        {
+            canvas.Clear(SKColors.Transparent);
+            using var paint = new SKPaint { Color = SKColors.White };
+            canvas.DrawRect(0, 0, width, height, paint);
+        }
+
+        return new NikseBitmap2(bmp);
+    }
+
+    private static NOcrChar MakeTwoBarPair()
+    {
+        // An expanded two-part character trained at 28x38: two vertical bars with a verified
+        // background gap between them (think "ll" or a large quote pair).
+        var pair = new NOcrChar("fi") { Width = 28, Height = 38, MarginTop = 0, ExpandCount = 2 };
+        pair.LinesForeground.Add(new NOcrLine(new OcrPoint(3, 1), new OcrPoint(3, 36)));
+        pair.LinesForeground.Add(new NOcrLine(new OcrPoint(22, 1), new OcrPoint(22, 36)));
+        pair.LinesBackground.Add(new NOcrLine(new OcrPoint(13, 0), new OcrPoint(13, 37)));
+        return pair;
+    }
+
+    [Fact]
+    public void ScaledExpandedMatch_DoesNotClaimGroupWithWrongMiddle()
+    {
+        // Target group at 32x40 (inside the ±25/±20 size gates and within 15 aspect points of
+        // the trained pair): a narrow bar plus a wide solid blob. The blob covers the trained
+        // pair's background gap, so a full third of the walked points are wrong - yet the old
+        // area-scaled budget (32*40/16 = 80 errors) accepted it and merged the two separate
+        // letters into one glyph.
+        var parentBmp = new SKBitmap(40, 45);
+        using (var canvas = new SKCanvas(parentBmp))
+        {
+            canvas.Clear(SKColors.Transparent);
+            using var paint = new SKPaint { Color = SKColors.White };
+            canvas.DrawRect(2, 0, 6, 40, paint);   // "l"-like bar at x=2..7
+            canvas.DrawRect(14, 0, 20, 40, paint); // "o"-like blob at x=14..33
+        }
+
+        var parent = new NikseBitmap2(parentBmp);
+        var bar = new ImageSplitterItem2(2, 0, MakeSolidBitmap(6, 40)) { Top = 0 };
+        var blob = new ImageSplitterItem2(14, 0, MakeSolidBitmap(20, 40)) { Top = 0 };
+        var letters = new List<ImageSplitterItem2> { bar, blob };
+
+        var db = new NOcrDb(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".nocr"));
+        db.Add(MakeTwoBarPair());
+
+        var match = db.GetMatchExpanded(parent, bar, 0, letters);
+
+        Assert.Null(match);
+    }
+
+    [Fact]
+    public void ScaledExpandedMatch_StillMatchesSameShapeAtOtherSize()
+    {
+        // The counterpart guard: the same trained pair against a true two-bar group at 30x40
+        // (bars where the pair has bars, empty gap where it has background) must still match -
+        // that cross-size case is what the scaled pass exists for.
+        var parentBmp = new SKBitmap(40, 45);
+        using (var canvas = new SKCanvas(parentBmp))
+        {
+            canvas.Clear(SKColors.Transparent);
+            using var paint = new SKPaint { Color = SKColors.White };
+            canvas.DrawRect(2, 0, 6, 40, paint);  // bar 1 at x=2..7
+            canvas.DrawRect(26, 0, 6, 40, paint); // bar 2 at x=26..31
+        }
+
+        var parent = new NikseBitmap2(parentBmp);
+        var bar1 = new ImageSplitterItem2(2, 0, MakeSolidBitmap(6, 40)) { Top = 0 };
+        var bar2 = new ImageSplitterItem2(26, 0, MakeSolidBitmap(6, 40)) { Top = 0 };
+        var letters = new List<ImageSplitterItem2> { bar1, bar2 };
+
+        var db = new NOcrDb(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".nocr"));
+        db.Add(MakeTwoBarPair());
+
+        var match = db.GetMatchExpanded(parent, bar1, 0, letters);
+
+        Assert.NotNull(match);
+        Assert.Equal("fi", match!.Text);
+        Assert.Equal(2, match.ExpandCount);
+    }
+
+    [Fact]
+    public void ScaledExpandedMatch_RejectsExtremeScaleRatio()
+    {
+        // A small two-part glyph (10x12, like a trained double quote) must never be "scaled"
+        // onto a letter-pair group more than 2.5x its size, even if the walked lines happen to
+        // land on text: the absolute ±25/±20 size gates alone would allow it.
+        var quote = new NOcrChar("\"") { Width = 10, Height = 12, MarginTop = 0, ExpandCount = 2 };
+        quote.LinesForeground.Add(new NOcrLine(new OcrPoint(2, 1), new OcrPoint(2, 10)));
+        quote.LinesForeground.Add(new NOcrLine(new OcrPoint(7, 1), new OcrPoint(7, 10)));
+
+        var parentBmp = new SKBitmap(45, 40);
+        using (var canvas = new SKCanvas(parentBmp))
+        {
+            canvas.Clear(SKColors.Transparent);
+            using var paint = new SKPaint { Color = SKColors.White };
+            canvas.DrawRect(2, 0, 6, 31, paint);
+            canvas.DrawRect(20, 0, 8, 31, paint);
+        }
+
+        // Group bounding box: 26x31 - 2.6x the trained width, inside all absolute gates
+        // (|26-10| < 25, |31-12| < 20, aspect 119 vs 120), and the quote's two scaled bars
+        // both land fully on the parts, so only the scale-ratio gate can reject it.
+        var parent = new NikseBitmap2(parentBmp);
+        var part1 = new ImageSplitterItem2(2, 0, MakeSolidBitmap(6, 31)) { Top = 0 };
+        var part2 = new ImageSplitterItem2(20, 0, MakeSolidBitmap(8, 31)) { Top = 0 };
+        var letters = new List<ImageSplitterItem2> { part1, part2 };
+
+        var db = new NOcrDb(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".nocr"));
+        db.Add(quote);
+
+        var match = db.GetMatchExpanded(parent, part1, 0, letters);
+
+        Assert.Null(match);
+    }
+}


### PR DESCRIPTION
## Problem

Reported today: nOCR stopped splitting some bitmaps — e.g. the "lo" in "looks" came back as one image.

The splitter itself is fine (verified against the reported bitmap: every letter splits cleanly). The merge happens at match time. The scaled expanded pass added earlier today (#13420) used an error budget scaled by the **target group's area** (`width*height/16`). That budget grows with the group being claimed, so it was loosest exactly where it must be strictest: a trained expanded letter pair (e.g. a user-trained "fi") could claim two ordinary, separately-split neighboring letters ("t"+"i", "l"+"o") at 9–14% wrong points (~55 errors under a ~68 budget) and hand them back merged as one glyph image.

Reproduced end-to-end on the reported bitmap: with expanded "fi" pairs in the db, "time" became "fime" and "putting" became "pu**fing**", each merging two split items. Pre-#13420 code shows no merges (its scaled pass effectively never matched, and the unscaled pass allows zero errors).

## Fix

- **Error budget proportional to points walked** (5%, floor 4) instead of target area. Measured: legitimate scaled matches (cross-size two-part quotes — the case the pass exists for) stay under ~2–3% wrong points; steals never got below ~9%. On the measurement scenario the new budget rejects every steal and keeps every legitimate quote match the old budget accepted, plus one quote size the old budget wrongly rejected.
- **Scale-ratio sanity gate (2.5× per axis)**: the absolute ±25/±20 px size gates alone let a 10x12 two-part quote be "scaled" onto a 26x31 letter-pair group without any line evidence disagreeing.

## Tests

Three deterministic tests (no font rendering): a wrong-middle group must not match, the same shape at another size must still match, and an extreme scale ratio must not match even with perfect line hits. Both negative tests fail on current main; the positive test passes on both. Full libuilogic suite: 165/165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)