### PR TITLE
Fix names: collapse bulk toggles into a single immediate preview request

### DIFF
--- a/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
+++ b/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
@@ -144,11 +144,12 @@ public partial class FixNamesViewModel : ObservableObject, IClosingCleanup
     private CancellationTokenSource? _cancellationTokenSource;
     private bool _isClosing;
     private bool _previewPending;
+    private bool _suppressPreviewRequests;
     private Task _previewTask = Task.CompletedTask;
 
     private void RequestPreview(int delayMilliseconds = 500)
     {
-        if (_isClosing)
+        if (_isClosing || _suppressPreviewRequests)
         {
             return;
         }
@@ -249,19 +250,34 @@ public partial class FixNamesViewModel : ObservableObject, IClosingCleanup
     [RelayCommand]
     public void NamesSelectAll()
     {
-        foreach (var name in Names)
-        {
-            name.IsChecked = true; // PropertyChanged requests the preview
-        }
+        SetAllNames(_ => true);
     }
 
     [RelayCommand]
     public void NamesInvertSelection()
     {
-        foreach (var name in Names)
+        SetAllNames(name => !name.IsChecked);
+    }
+
+    private void SetAllNames(Func<FixNameItem, bool> getValue)
+    {
+        // Each IsChecked change fires the PropertyChanged handler; suppress those
+        // per-item requests during the bulk update and issue one immediate one,
+        // so a whole-list toggle doesn't sit through the 500 ms debounce.
+        _suppressPreviewRequests = true;
+        try
         {
-            name.IsChecked = !name.IsChecked; // PropertyChanged requests the preview
+            foreach (var name in Names)
+            {
+                name.IsChecked = getValue(name);
+            }
         }
+        finally
+        {
+            _suppressPreviewRequests = false;
+        }
+
+        RequestPreview(0);
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Summary
Follow-up to #13206, addressing @ivandrofly's [review comment](https://github.com/SubtitleEdit/subtitleedit/pull/13206#pullrequestreview-4892703474): Select all / Invert selection set `IsChecked` on every item, and each change fired the `PropertyChanged` handler — N `RequestPreview` calls (each cancelling and reallocating a `CancellationTokenSource`) for one gesture. The debounce already collapsed those into a single preview *generation*, but the churn was pointless, and the bulk commands also sat through the 500 ms debounce meant for individual checkbox clicks while other explicit call sites refresh immediately.

- `NamesSelectAll` / `NamesInvertSelection` now share a `SetAllNames` helper that suppresses the per-item preview requests during the bulk update (`_suppressPreviewRequests`, reset in `finally`) and issues one zero-delay request afterwards.
- The per-item `PropertyChanged` subscription stays as the safety net for individual clicks and the space-bar multi-toggle, where the 500 ms coalescing is the desired behavior.

## Test plan
- [x] Build passes with no warnings
- [ ] Open Tools → Change casing → Fix names; Select all from the context menu updates the hits preview immediately (no 500 ms wait)
- [ ] Invert selection likewise refreshes immediately
- [ ] Individual checkbox toggles still debounce at 500 ms

(Manual steps not yet run — verified by code inspection only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)