### PR TITLE
Train nOCR: fix corrupted font list on scroll

### DIFF
--- a/src/ui/Features/Ocr/NOcr/NOcrTrainWindow.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrTrainWindow.cs
@@ -1,6 +1,8 @@
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Data.Converters;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Nikse.SubtitleEdit.Logic;
@@ -41,17 +43,29 @@ public class NOcrTrainWindow : Window
             RowSpacing = 10,
         };
 
-        // Fonts (checkbox list, each rendered in its own typeface)
+        // Fonts (checkbox list, each rendered in its own typeface).
+        // The template must bind everything (no use of the build parameter): the virtualized
+        // ListBox recycles containers with a null item, and reuses them for other items where
+        // static values would go stale. Uniform row height keeps scroll extent estimation sane
+        // despite wildly varying font line heights.
+        var fontNameToFontFamily = new FuncValueConverter<string?, FontFamily>(name =>
+            string.IsNullOrWhiteSpace(name) ? FontFamily.Default : new FontFamily(name));
         var fontsListBox = new ListBox
         {
             Height = 260,
             ItemsSource = vm.Fonts,
-            ItemTemplate = new FuncDataTemplate<NOcrTrainFontItem>((item, _) => new CheckBox
+            ItemTemplate = new FuncDataTemplate<NOcrTrainFontItem>((_, _) => new CheckBox
             {
                 [!CheckBox.IsCheckedProperty] = new Binding(nameof(NOcrTrainFontItem.IsSelected)),
-                Content = item.Name,
-                FontFamily = new FontFamily(item.Name),
-            }),
+                [!ContentControl.ContentProperty] = new Binding(nameof(NOcrTrainFontItem.Name)),
+                [!TemplatedControl.FontFamilyProperty] = new Binding(nameof(NOcrTrainFontItem.Name))
+                {
+                    Converter = fontNameToFontFamily,
+                },
+                Height = 26,
+                VerticalContentAlignment = VerticalAlignment.Center,
+                ClipToBounds = true,
+            }, supportsRecycling: true),
         };
         var fontsPanel = new StackPanel { Orientation = Orientation.Vertical, Spacing = 4 };
         fontsPanel.Children.Add(UiUtil.MakeLabel(Se.Language.General.Fonts));

--- a/tests/UI/Features/Ocr/NOcrTrainFontListTests.cs
+++ b/tests/UI/Features/Ocr/NOcrTrainFontListTests.cs
@@ -1,0 +1,117 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Features.Ocr.NOcr;
+
+namespace UITests.Features.Ocr;
+
+/// <summary>
+/// The Train nOCR font list is a virtualized ListBox whose item template originally read the
+/// FuncDataTemplate build parameter instead of binding. Scrolling recycled containers with a
+/// null item, throwing a NullReferenceException mid-layout; the global dispatcher handler
+/// swallowed it, leaving the panel visually corrupted (duplicate/missing rows, broken scroll).
+/// These tests scroll the list through recycling and assert every realized row still shows
+/// its own item's name, typeface, and checked state.
+/// </summary>
+public class NOcrTrainFontListTests
+{
+    private static NOcrTrainViewModel MakeViewModel(int fontCount)
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        var provider = services.BuildServiceProvider();
+        var vm = provider.GetRequiredService<NOcrTrainViewModel>();
+
+        vm.Fonts.Clear();
+        for (var i = 0; i < fontCount; i++)
+        {
+            vm.Fonts.Add(new NOcrTrainFontItem($"Font {i:000}", i % 3 == 0));
+        }
+
+        return vm;
+    }
+
+    private static void PumpLayout(Window window)
+    {
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+    }
+
+    private static void AssertRealizedRowsMatchTheirItems(ListBox listBox)
+    {
+        var containers = listBox.GetRealizedContainers().OfType<ListBoxItem>().ToList();
+        Assert.NotEmpty(containers);
+        foreach (var container in containers)
+        {
+            var item = Assert.IsType<NOcrTrainFontItem>(container.DataContext);
+            var checkBox = container.GetVisualDescendants().OfType<CheckBox>().First();
+            Assert.Equal(item.Name, checkBox.Content);
+            Assert.Equal(item.Name, checkBox.FontFamily.Name);
+            Assert.Equal(item.IsSelected, checkBox.IsChecked);
+        }
+    }
+
+    [AvaloniaFact]
+    public void ScrollFontList_RecyclesContainers_WithoutCrashOrStaleRows()
+    {
+        var vm = MakeViewModel(200);
+        var window = new NOcrTrainWindow(vm);
+        window.Show();
+        PumpLayout(window);
+
+        var listBox = window.GetVisualDescendants().OfType<ListBox>().First();
+        var scrollViewer = listBox.GetVisualDescendants().OfType<ScrollViewer>().First();
+
+        AssertRealizedRowsMatchTheirItems(listBox);
+
+        // page down through the list to force container recycling
+        for (var i = 0; i < 5; i++)
+        {
+            scrollViewer.Offset = new Vector(0, scrollViewer.Offset.Y + scrollViewer.Viewport.Height);
+            PumpLayout(window);
+            AssertRealizedRowsMatchTheirItems(listBox);
+        }
+
+        // jump to the end, then back to the top
+        scrollViewer.Offset = new Vector(0, scrollViewer.Extent.Height);
+        PumpLayout(window);
+        AssertRealizedRowsMatchTheirItems(listBox);
+
+        Assert.True(scrollViewer.Offset.Y > 0, "scrolling to the end should move the offset");
+
+        scrollViewer.Offset = new Vector(0, 0);
+        PumpLayout(window);
+        AssertRealizedRowsMatchTheirItems(listBox);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void ToggleCheckBox_AfterScrolling_TogglesTheRowsOwnItem()
+    {
+        var vm = MakeViewModel(200);
+        var window = new NOcrTrainWindow(vm);
+        window.Show();
+        PumpLayout(window);
+
+        var listBox = window.GetVisualDescendants().OfType<ListBox>().First();
+        var scrollViewer = listBox.GetVisualDescendants().OfType<ScrollViewer>().First();
+
+        scrollViewer.Offset = new Vector(0, scrollViewer.Extent.Height / 2);
+        PumpLayout(window);
+
+        var container = listBox.GetRealizedContainers().OfType<ListBoxItem>().Last();
+        var item = Assert.IsType<NOcrTrainFontItem>(container.DataContext);
+        var checkBox = container.GetVisualDescendants().OfType<CheckBox>().First();
+
+        var before = item.IsSelected;
+        checkBox.IsChecked = !before;
+        Assert.Equal(!before, item.IsSelected);
+
+        window.Close();
+    }
+}


### PR DESCRIPTION
## Problem

In the Train nOCR database window, the font list broke down as soon as it was scrolled: duplicated/overlapping text, missing rows, and scrolling that would not work.

## Root cause

The item template read the `FuncDataTemplate` build parameter statically (`Content = item.Name`, `FontFamily = new FontFamily(item.Name)`) instead of binding. The virtualized `ListBox` recycles containers by clearing their content to **null**, which re-ran the template with a null item and threw a `NullReferenceException` in the middle of the layout pass. The global `Dispatcher.UIThread.UnhandledException` handler swallowed the exception, so instead of crashing, the `VirtualizingStackPanel` was left half-recycled — exactly the double text / missing text / broken scroll symptoms. Reproduced headlessly: one page-down over 200 items throws the NRE from `VirtualizingStackPanel.MeasureOverride`.

## Fix

- Bind `Content` and `FontFamily` (via a `FuncValueConverter`) instead of capturing the build parameter, and pass `supportsRecycling: true`. Note that only adding `supportsRecycling: true` without the bindings would trade the crash for stale rows: a recycled row would show the previous font's name/typeface while its checkbox toggled a different font.
- Give rows a uniform clipped height (26px, centered) so fonts with huge line heights can't overlap neighboring rows or destabilize the virtualization's scroll extent estimation.

## Tests

Two headless regression tests: one scrolls the list page-by-page through container recycling and asserts every realized row still shows its own item's name, typeface, and checked state (crashes with the NRE before this fix); one toggles a checkbox after scrolling and asserts it toggles that row's own item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)