### PR TITLE
OCR: keep selected line visible when OCR stops

### DIFF
--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -4624,6 +4624,35 @@ public partial class OcrViewModel : ObservableObject
         }, DispatcherPriority.Background);
     }
 
+    partial void OnIsOcrRunningChanged(bool value)
+    {
+        if (value)
+        {
+            return;
+        }
+
+        // When OCR stops, the last per-line scroll may have run before that row's
+        // text/image finished layout, leaving the selected row just outside the
+        // viewport. ContextIdle runs below Background, i.e. after any pending
+        // SelectAndScrollToRow work and the layout passes it triggers; the second
+        // pass corrects drift from rows realized at estimated heights.
+        Dispatcher.UIThread.Post(() =>
+        {
+            ScrollSelectedRowIntoView();
+            Dispatcher.UIThread.Post(ScrollSelectedRowIntoView, DispatcherPriority.ContextIdle);
+        }, DispatcherPriority.ContextIdle);
+    }
+
+    private void ScrollSelectedRowIntoView()
+    {
+        var selected = SelectedOcrSubtitleItem;
+        var index = selected != null ? OcrSubtitleItems.IndexOf(selected) : -1;
+        if (index >= 0)
+        {
+            SubtitleGrid.ScrollIntoView(index);
+        }
+    }
+
     private void SetOcrSubtitleItems()
     {
         _allOcrSubtitleItems = _ocrSubtitle!.MakeOcrSubtitleItems();


### PR DESCRIPTION
## Problem
In the main OCR window, stopping/cancelling the OCR process sometimes leaves the selected line just outside the viewport — the user has to scroll down a little to see it.

## Cause
The OCR grid is a TableView with variable-height rows (per-row bitmap thumbnails, text cells that grow as OCR fills them in). While OCR runs, each processed line calls `SelectAndScrollToRow`, but that scroll can execute before the row's text update and image layout have settled, landing the row slightly below the visible area. During a run the next line's scroll masks this; on pause/cancel there is no next scroll, so the drift sticks.

## Fix
Add an `OnIsOcrRunningChanged` handler that re-scrolls the selected row into view whenever `IsOcrRunning` flips to false — covering pause, cancel from any dialog, nOCR abort, and normal completion via a single hook. The scroll is posted at `ContextIdle` priority so it runs after all pending per-line scroll work and the layout passes it triggers, with a second pass to correct drift from rows realized at estimated heights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)