### PR TITLE
Burn-in: default to h264_videotoolbox on macOS

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -1399,7 +1399,9 @@ public partial class BurnInViewModel : ObservableObject
         FontMarginVertical = (int)settings.NonAssaMarginVertical;
         SelectedFontBoxType = FontBoxTypes.FirstOrDefault(p => (int)p.BoxType == settings.NonAssaBoxType) ?? FontBoxTypes[0];
 
-        SelectedVideoEncoding = VideoEncodings.FirstOrDefault(p => p.Codec == settings.Encoding) ?? VideoEncodings[0];
+        SelectedVideoEncoding = VideoEncodings.FirstOrDefault(p => p.Codec == settings.Encoding)
+                                ?? VideoEncodings.FirstOrDefault(p => p.Codec == SeVideoBurnIn.DefaultEncoding)
+                                ?? VideoEncodings[0];
         SelectedVideoPixelFormat = VideoPixelFormats.FirstOrDefault(p => p.Codec == settings.PixelFormat) ?? VideoPixelFormats[0];
         FillPreset(SelectedVideoEncoding.Codec);
         FillCrf(SelectedVideoEncoding.Codec);

--- a/src/ui/Logic/Config/SeVideoBurnIn.cs
+++ b/src/ui/Logic/Config/SeVideoBurnIn.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Nikse.SubtitleEdit.Core.Common;
+using System;
 using SkiaSharp;
 
 namespace Nikse.SubtitleEdit.Logic.Config;
@@ -47,6 +48,9 @@ public class SeVideoBurnIn
     public string OutputExtension { get; set; }
     public string Effects { get; set; }
 
+    // On macOS the hardware encoder is always present, so default to it there.
+    public static string DefaultEncoding => Configuration.IsRunningOnMac ? "h264_videotoolbox" : "libx264";
+
     public SeVideoBurnIn()
     {
         FontName = "Arial";
@@ -54,7 +58,7 @@ public class SeVideoBurnIn
         EmbedOutputExt = ".mkv";
         OutputFolder = string.Empty;
         FontFactor = 0.52;
-        Encoding = "libx264";
+        Encoding = DefaultEncoding;
         Preset = "medium";
         Crf = "23";
         Tune = "film";


### PR DESCRIPTION
On macOS the Burn-in window now defaults to **H.264 (Apple VideoToolbox)** instead of libx264 for first-run users — hardware-speed encoding with universally compatible H.264 output. Other platforms keep the libx264 default.

- `SeVideoBurnIn` gets a platform-aware `DefaultEncoding` used by the constructor.
- `LoadSettings` now falls back to the platform default (then `VideoEncodings[0]`) when the saved codec isn't available on this platform, e.g. a settings file with `h264_nvenc` opened on a Mac.

The stale libx264 `Preset`/`Crf` defaults are harmless: VideoToolbox has its own preset/CRF lists and the existing `Contains` guards discard values not in them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)