### PR TITLE
Fix blank space above the first line after End followed by Home

### DIFF
--- a/src/ui/Logic/TableViewExtras.cs
+++ b/src/ui/Logic/TableViewExtras.cs
@@ -720,6 +720,14 @@ public static class TableViewExtras
             if (scrollViewer.Offset.Y > 0.5)
             {
                 scrollViewer.Offset = new Vector(scrollViewer.Offset.X, 0);
+
+                // Realize the top rows before the caller's ScrollIntoView runs. Without this
+                // the panel is still laid out for the old position, and ScrollIntoView has to
+                // place row 0 at an offset estimated from the average row height - with
+                // variable-height rows that estimate can land below the extent origin, which
+                // shows as blank space above the first row after End followed by Home (#13428).
+                // From a realized offset of 0 there is nothing to estimate: index 0 sits at 0.
+                tableView.UpdateLayout();
             }
 
             return;
@@ -811,13 +819,17 @@ public static class TableViewExtras
     {
         Dispatcher.UIThread.Post(() =>
         {
-            if (tableView.ContainerFromItem(item) is not { } row || row.Bounds.Height <= 0)
+            var scrollViewer = tableView.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
+            if (scrollViewer == null || scrollViewer.Viewport.Height <= 0)
             {
                 return;
             }
 
-            var scrollViewer = tableView.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
-            if (scrollViewer == null || scrollViewer.Viewport.Height <= 0)
+            // The repair can recycle and re-realize containers, so it runs before the
+            // target row's container is looked up.
+            RepairTopAnchor(tableView, scrollViewer);
+
+            if (tableView.ContainerFromItem(item) is not { } row || row.Bounds.Height <= 0)
             {
                 return;
             }
@@ -844,6 +856,46 @@ public static class TableViewExtras
 
             scrollViewer.Offset = new Vector(offset.X, newY);
         }, DispatcherPriority.Loaded);
+    }
+
+    /// <summary>
+    /// Repairs a mis-anchored virtualizing panel: after a long jump towards the top the panel
+    /// can end up with row 0 realized at a position estimated from the average row height
+    /// instead of at the extent origin, leaving blank space above the first row while the
+    /// scrollbar sits at the top (#13428). The blank space is part of the panel's own position
+    /// estimate, so no offset change can remove it; what removes it is what users found by
+    /// hand - scrolling away and back. Do exactly that, synchronously and invisibly: move the
+    /// viewport far enough down that row 0 is recycled, then return to the top, and the panel
+    /// re-anchors index 0 at position 0.
+    /// </summary>
+    private static void RepairTopAnchor(TableView tableView, ScrollViewer scrollViewer)
+    {
+        if (tableView.ContainerFromIndex(0) is not { } first || first.Bounds.Height <= 0)
+        {
+            return;
+        }
+
+        // Row 0's arranged position inside the virtualizing panel - anything above ~0 is
+        // phantom space. Bounds is relative to the panel (the scrolled content), so the
+        // column header sitting above the rows inside the ScrollViewer does not count.
+        var gap = first.Bounds.Y;
+        if (gap < 0.5)
+        {
+            return;
+        }
+
+        var away = Math.Min(scrollViewer.Extent.Height - scrollViewer.Viewport.Height,
+            gap + first.Bounds.Height + 2 * scrollViewer.Viewport.Height);
+        if (away <= 0.5)
+        {
+            return;
+        }
+
+        var offsetX = scrollViewer.Offset.X;
+        scrollViewer.Offset = new Vector(offsetX, away);
+        tableView.UpdateLayout();
+        scrollViewer.Offset = new Vector(offsetX, 0);
+        tableView.UpdateLayout();
     }
 
     /// <summary>

--- a/tests/UI/Features/Main/SubtitleGridScrollPerformanceTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridScrollPerformanceTests.cs
@@ -55,7 +55,7 @@ public class SubtitleGridScrollPerformanceTests : IDisposable
     }
 
     private (Window Window, MainViewModel Vm, TableView Grid, ScrollViewer ScrollViewer) ShowMainWindowWithLines(
-        int lineCount = LineCount)
+        int lineCount = LineCount, Func<int, string>? lineFactory = null)
     {
         var services = new ServiceCollection();
         services.AddSubtitleEditServices();
@@ -75,7 +75,8 @@ public class SubtitleGridScrollPerformanceTests : IDisposable
         {
             // Every third line is two lines tall - variable row heights are what makes the
             // panel's average-height estimate drift in the first place.
-            var text = $"Line {i} of the test subtitle" + (i % 3 == 0 ? Environment.NewLine + "second line here" : string.Empty);
+            var text = lineFactory?.Invoke(i)
+                       ?? $"Line {i} of the test subtitle" + (i % 3 == 0 ? Environment.NewLine + "second line here" : string.Empty);
             vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph(text, i * 2000, i * 2000 + 1500), null!) { Number = i + 1 });
         }
 
@@ -240,6 +241,64 @@ public class SubtitleGridScrollPerformanceTests : IDisposable
                               $"offset={scrollViewer.Offset.Y:F0} extent={scrollViewer.Extent.Height:F0}");
             Assert.Equal(0, grid.SelectedIndex);
             Assert.True(home <= MaxRealizedPerJump, $"Home realized {home} rows in round {round}");
+        }
+
+        window.Close();
+    }
+
+    /// <summary>
+    /// End followed by Home must land with row 0 at the very top - no blank space above it.
+    /// When ScrollIntoView has to place an unrealized row 0 it estimates its offset from the
+    /// average row height, and with irregular row heights the estimate lands below the extent
+    /// origin: the scrollbar sits at the top while the first rows are drawn at the bottom of
+    /// the viewport with a blank area above them (#13428). The row heights here are aperiodic
+    /// on purpose - a regular pattern averages out and rarely drifts far enough to reproduce.
+    /// </summary>
+    [AvaloniaFact]
+    public void Home_AfterEnd_LeavesNoBlankSpaceAboveTheFirstRow()
+    {
+        var (window, _, grid, scrollViewer) = ShowMainWindowWithLines(lineFactory: i =>
+        {
+            // 1-3 text lines per row, mixed aperiodically (Knuth multiplicative hash).
+            var lines = 1 + (int)(unchecked((uint)i * 2654435761u) % 3);
+            return string.Join(Environment.NewLine,
+                Enumerable.Range(0, lines).Select(l => $"Line {i}.{l} of the test subtitle"));
+        });
+
+        grid.SelectedIndex = 0;
+        Dispatcher.UIThread.RunJobs();
+
+        void Press(PhysicalKey key)
+        {
+            // Same focus pinning as HomeAndEnd_RealizeOnlyAViewportOfRows: what this test
+            // measures is where the rows land, not how Avalonia routes keys.
+            TableViewExtras.FocusRow(grid);
+            Dispatcher.UIThread.RunJobs();
+            window.KeyPressQwerty(key, RawInputModifiers.None);
+            Settle(window);
+        }
+
+        for (var round = 0; round < 10; round++)
+        {
+            Press(PhysicalKey.End);
+            Assert.Equal(LineCount - 1, grid.SelectedIndex);
+
+            Press(PhysicalKey.Home);
+            Assert.Equal(0, grid.SelectedIndex);
+
+            var first = grid.ContainerFromIndex(0);
+            Assert.NotNull(first);
+
+            // Bounds is relative to the virtualizing panel (the scrolled content): row 0
+            // arranged at anything above 0 is phantom blank space. The ScrollViewer is not
+            // a usable reference point - the column header scrolls inside it, sitting
+            // between the viewport top and row 0 even in the healthy state.
+            var gap = first!.Bounds.Y;
+            _output.WriteLine($"round {round}: offset={scrollViewer.Offset.Y:F1} row0PanelY={gap:F1}");
+            Assert.True(scrollViewer.Offset.Y < 0.5,
+                $"round {round}: scroll offset {scrollViewer.Offset.Y:F1} did not land at the top");
+            Assert.True(gap < 0.5,
+                $"round {round}: {gap:F1}px of blank space above row 0");
         }
 
         window.Close();


### PR DESCRIPTION
Fixes #13428.

## Symptom

After **End** (jump to last line) followed by **Home** (jump to first line), the grid sometimes showed the first rows at the bottom of the viewport with a large blank area above them, while the scrollbar sat at the top. Scrolling away and back healed it. Intermittent - the reporter saw the same steps work one time and fail the next.

## Cause

TableView's virtualizing panel places an unrealized row at an offset estimated from the average height of the rows it has realized. With variable-height rows that estimate drifts, and on a long jump to the top the estimate for row 0 can land *below* the extent origin: the panel then anchors row 0 with phantom blank space above it. No offset change can remove that space - it is part of the panel's own position bookkeeping - which is why only scrolling away and back fixed it.

The trigger was in `PrePositionScroll`: for a jump to index 0 it reset the scroll offset but - unlike the general path - skipped the layout pass, so the following `ScrollIntoView` ran against the stale layout and had to estimate row 0's position. The intermittency is the estimate: whether it drifts depends on which rows happened to be realized at the moment of the jump.

## Fix (two parts, both in `TableViewExtras`)

1. **Prevent** - `PrePositionScroll` now runs `UpdateLayout()` after resetting the offset to 0. From a realized offset of 0 there is nothing to estimate: index 0 sits at position 0. This alone fixes the End→Home repro (verified by toggling each part against the regression test).
2. **Repair** - `EnsureRowFullyVisible`/`CenterRow` now detect a mis-anchored panel (row 0 realized at a position > 0 inside the panel) and do what users did by hand: scroll far enough away that row 0 is recycled, then back - synchronously within one layout pass, so nothing flickers. This covers every other `ScrollIntoView` path that can hit the same estimate (Find, go to line number, bookmarks, playhead sync).

## Test

New headless regression test `Home_AfterEnd_LeavesNoBlankSpaceAboveTheFirstRow` doing 10 End/Home round trips and asserting row 0 lands at position 0 inside the panel with the offset at the top. Row heights are mixed aperiodically (1-3 text lines via a multiplicative hash) - a regular pattern averages out and rarely drifts far enough to reproduce. Red on unfixed code (11px phantom gap in round 1), green with the fix; the whole `SubtitleGridScrollPerformanceTests` class stays green, so the realization-count limits from the earlier slow-jump fix still hold.

Note: the assertion deliberately measures `Bounds.Y` relative to the virtualizing panel, not the ScrollViewer - the column header scrolls inside the ScrollViewer and sits between the viewport top and row 0 even in the healthy state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)