### PR TITLE
Add "BDN/xml 8-bit" export with palette-indexed PNGs

### DIFF
--- a/docs/features/binary-edit.md
+++ b/docs/features/binary-edit.md
@@ -45,7 +45,7 @@ The Synchronization menu offers **Adjust all times**, **Change frame rate**, and
 There is no in-place save — use File → Export:
 
 - **Blu-ray (sup)**, **VobSub (sub/idx)**
-- **BDN/xml**, **DOST/png**, **Final Cut Pro + image**
+- **BDN/xml**, **BDN/xml 8-bit**, **DOST/png**, **Final Cut Pro + image**
 - **IMSC 1.1 image profile**, **WebVTT png**
 - **Images with HTML index**, **Images with time code**
 

--- a/docs/features/file.md
+++ b/docs/features/file.md
@@ -119,6 +119,8 @@ Export subtitles in Cavena 890 format.
 
 Export subtitles as images (BDN XML, VobSub, Blu-ray SUP, Final Cut Pro + image, IMSC 1.1 image profile, etc.).
 
+**BDN/xml** writes 32-bit PNGs; **BDN/xml 8-bit** writes the same index.xml with 8-bit palette-indexed PNGs, which is what most Blu-ray authoring tools expect.
+
 The **IMSC 1.1 image profile** export writes a single self-contained TTML file with each subtitle embedded as a base64 PNG (`smpte:image` / `smpte:backgroundImage`), media timebase, and percentage-positioned regions — the standardized image-subtitle carriage for streaming and broadcast delivery.
 
 <!-- Screenshot: Export image-based window -->

--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -575,6 +575,7 @@ The CLI rule IDs match the check-box rules in the desktop app's *Fix Common Erro
 | `bluraysup`, `sup` | Blu-Ray sup — image |
 | `vobsub` | VobSub — image |
 | `bdnxml`, `bdn-xml` | BDN-XML — image (folder of PNGs + index.xml) |
+| `bdnxml8bit`, `bdn-xml8-bit` | BDN-XML with 8-bit palette-indexed PNGs — image |
 | `dost`, `dostimage` | DOST/image |
 | `fcpimage`, `fcp` | FCP/image |
 | `dcinemainterop` | D-Cinema interop/png |

--- a/src/libuilogic/Export/ExportHandlerBdnXml.cs
+++ b/src/libuilogic/Export/ExportHandlerBdnXml.cs
@@ -7,11 +7,12 @@ namespace Nikse.SubtitleEdit.UiLogic.Export;
 
 public class ExportHandlerBdnXml : IExportHandler
 {
-    public ExportImageType ExportImageType => ExportImageType.BdnXml;
+    public ExportImageType ExportImageType => _use8BitPng ? ExportImageType.BdnXml8Bit : ExportImageType.BdnXml;
     public string Extension => "";
     public bool UseFileName => false;
-    public string Title => string.Format("Export to {0}", "BDN XML");
+    public string Title => string.Format("Export to {0}", _use8BitPng ? "BDN XML 8-bit" : "BDN XML");
 
+    private readonly bool _use8BitPng;
     private int _width;
     private int _height;
     private StringBuilder _sb = new StringBuilder();
@@ -20,6 +21,15 @@ public class ExportHandlerBdnXml : IExportHandler
     private string _folderName = string.Empty;
     private int _imagesSavedCount = 0;
     private double _frameRate = 23.976;
+
+    /// <param name="use8BitPng">
+    /// Write the images as 8-bit palette-indexed PNGs instead of 32-bit RGBA ones. Blu-ray
+    /// authoring tools generally want indexed color for BDN XML image sets (issue #13452).
+    /// </param>
+    public ExportHandlerBdnXml(bool use8BitPng = false)
+    {
+        _use8BitPng = use8BitPng;
+    }
 
     public void WriteHeader(string fileOrFolderName, ImageParameter imageParameter)
     {
@@ -57,7 +67,7 @@ public class ExportHandlerBdnXml : IExportHandler
         var numberString = $"{_imagesSavedCount:0000}";
         var fileName = Path.Combine(_folderName, numberString + ".png");
 
-        File.WriteAllBytes(fileName, param.Bitmap.ToPngArray());
+        File.WriteAllBytes(fileName, _use8BitPng ? param.Bitmap.ToPng8BitArray() : param.Bitmap.ToPngArray());
 
         _sb.AppendLine("<Event InTC=\"" + ToHHMMSSFF(new TimeCode(param.StartTime)) + "\" OutTC=\"" +
                                 ToHHMMSSFF(new TimeCode(param.EndTime)) + "\" Forced=\"" + param.IsForced.ToString().ToLowerInvariant() + "\">");

--- a/src/libuilogic/Export/ExportImageType.cs
+++ b/src/libuilogic/Export/ExportImageType.cs
@@ -3,6 +3,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Export;
 public enum ExportImageType
 {
     BdnXml,
+    BdnXml8Bit,
     BluRaySup,
     DCinemaPng,
     Dost,

--- a/src/libuilogic/Export/Png8BitEncoder.cs
+++ b/src/libuilogic/Export/Png8BitEncoder.cs
@@ -1,0 +1,262 @@
+using SkiaSharp;
+using System.IO.Compression;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.UiLogic.Export;
+
+/// <summary>
+/// Encodes a bitmap as an 8-bit palette-indexed PNG (PNG color type 3) with a tRNS chunk
+/// holding the per-palette-entry alpha. Blu-ray authoring tools (Scenarist, DoStudio, ...)
+/// expect BDN XML image sets in indexed color, which is what "BDN/xml 8-bit" writes.
+/// Skia can only encode 32-bit RGBA PNGs (Skia dropped its indexed color type), so the
+/// chunks are written by hand here.
+/// The quantizer is the one SE4 used (NikseBitmap.ConvertTo8BitsPerPixel): a greedy
+/// nearest-color palette, index 0 reserved for transparent.
+/// </summary>
+public static class Png8BitEncoder
+{
+    /// <summary>Palette entries, index 0 included - one less than the 256 PNG allows, as SE4 did.</summary>
+    private const int MaxPaletteColors = 255;
+
+    private static readonly byte[] PngSignature = { 137, 80, 78, 71, 13, 10, 26, 10 };
+    private static readonly uint[] CrcTable = CreateCrcTable();
+
+    public static byte[] Encode(SKBitmap bitmap)
+    {
+        ArgumentNullException.ThrowIfNull(bitmap);
+
+        if (bitmap.Width <= 0 || bitmap.Height <= 0)
+        {
+            // PNG has no zero-sized images; hand back a single transparent pixel instead.
+            return Write(1, 1, new byte[1], new List<SKColor> { SKColors.Transparent });
+        }
+
+        var width = bitmap.Width;
+        var height = bitmap.Height;
+        var palette = new List<SKColor> { SKColors.Transparent };
+        var indexes = new byte[width * height];
+
+        using (var straight = ToStraightBgra8888(bitmap))
+        {
+            var pixels = straight.GetPixelSpan();
+            var rowBytes = straight.RowBytes;
+
+            // Anti-aliased text repeats the same few hundred colors over and over, and the
+            // nearest-color search below is a linear scan of the palette - without this the
+            // per-image cost is width * height * palette-size.
+            var seen = new Dictionary<uint, byte>();
+
+            for (var y = 0; y < height; y++)
+            {
+                var row = y * rowBytes;
+                for (var x = 0; x < width; x++)
+                {
+                    var offset = row + (x * 4);
+                    var b = pixels[offset];
+                    var g = pixels[offset + 1];
+                    var r = pixels[offset + 2];
+                    var a = pixels[offset + 3];
+
+                    if (a < 5)
+                    {
+                        continue; // index 0 - the array is already zeroed
+                    }
+
+                    var key = ((uint)a << 24) | ((uint)r << 16) | ((uint)g << 8) | b;
+                    if (seen.TryGetValue(key, out var cached))
+                    {
+                        indexes[(y * width) + x] = cached;
+                        continue;
+                    }
+
+                    var color = new SKColor(r, g, b, a);
+                    var index = FindBestMatch(color, palette, out var maxDiff);
+
+                    if ((index < 0 && palette.Count < MaxPaletteColors) ||
+                        (palette.Count < 200 && maxDiff > 5) ||
+                        (palette.Count < MaxPaletteColors && maxDiff > 15))
+                    {
+                        index = palette.Count;
+                        palette.Add(color);
+                    }
+
+                    // index can still be -1 when the palette is full and nothing came close;
+                    // fall back to transparent, like SE4 did.
+                    var paletteIndex = (byte)(index >= 0 ? index : 0);
+                    indexes[(y * width) + x] = paletteIndex;
+                    seen[key] = paletteIndex;
+                }
+            }
+        }
+
+        return Write(width, height, indexes, palette);
+    }
+
+    /// <summary>
+    /// Straight (non-premultiplied) BGRA copy - the palette must hold the real colors, not
+    /// colors already scaled by their alpha.
+    /// </summary>
+    private static SKBitmap ToStraightBgra8888(SKBitmap bitmap)
+    {
+        var info = new SKImageInfo(bitmap.Width, bitmap.Height, SKColorType.Bgra8888, SKAlphaType.Unpremul);
+        var copy = new SKBitmap(info);
+        using (var image = SKImage.FromBitmap(bitmap))
+        {
+            if (image != null && image.ReadPixels(info, copy.GetPixels(), copy.RowBytes, 0, 0))
+            {
+                return copy;
+            }
+        }
+
+        copy.Dispose();
+
+        // Unconvertible color type - a plain copy still gives four bytes per pixel to walk.
+        return bitmap.Copy(SKColorType.Bgra8888) ?? new SKBitmap(info);
+    }
+
+    private static int FindBestMatch(SKColor color, List<SKColor> palette, out int maxDiff)
+    {
+        var smallestDiff = 1000;
+        var smallestDiffIndex = -1;
+        for (var i = 0; i < palette.Count; i++)
+        {
+            var pc = palette[i];
+            var diff = Math.Abs(pc.Alpha - color.Alpha) +
+                       Math.Abs(pc.Red - color.Red) +
+                       Math.Abs(pc.Green - color.Green) +
+                       Math.Abs(pc.Blue - color.Blue);
+            if (diff < smallestDiff)
+            {
+                smallestDiff = diff;
+                smallestDiffIndex = i;
+                if (smallestDiff < 4)
+                {
+                    maxDiff = smallestDiff;
+                    return smallestDiffIndex;
+                }
+            }
+        }
+
+        maxDiff = smallestDiff;
+        return smallestDiffIndex;
+    }
+
+    private static byte[] Write(int width, int height, byte[] indexes, List<SKColor> palette)
+    {
+        using var stream = new MemoryStream();
+        stream.Write(PngSignature, 0, PngSignature.Length);
+
+        var header = new byte[13];
+        WriteUInt32BigEndian(header, 0, (uint)width);
+        WriteUInt32BigEndian(header, 4, (uint)height);
+        header[8] = 8; // bit depth
+        header[9] = 3; // color type: palette
+        header[10] = 0; // compression: deflate
+        header[11] = 0; // filter: adaptive
+        header[12] = 0; // interlace: none
+        WriteChunk(stream, "IHDR", header);
+
+        var plte = new byte[palette.Count * 3];
+        for (var i = 0; i < palette.Count; i++)
+        {
+            plte[i * 3] = palette[i].Red;
+            plte[(i * 3) + 1] = palette[i].Green;
+            plte[(i * 3) + 2] = palette[i].Blue;
+        }
+
+        WriteChunk(stream, "PLTE", plte);
+
+        // tRNS may stop at the last non-opaque entry; everything after it is opaque by default.
+        var alphaCount = palette.Count;
+        while (alphaCount > 0 && palette[alphaCount - 1].Alpha == 255)
+        {
+            alphaCount--;
+        }
+
+        if (alphaCount > 0)
+        {
+            var trns = new byte[alphaCount];
+            for (var i = 0; i < alphaCount; i++)
+            {
+                trns[i] = palette[i].Alpha;
+            }
+
+            WriteChunk(stream, "tRNS", trns);
+        }
+
+        WriteChunk(stream, "IDAT", Deflate(width, height, indexes));
+        WriteChunk(stream, "IEND", Array.Empty<byte>());
+
+        return stream.ToArray();
+    }
+
+    private static byte[] Deflate(int width, int height, byte[] indexes)
+    {
+        // One filter byte per scan line. The PNG spec recommends leaving palette images
+        // unfiltered (filter type 0) - the bytes are indexes, so deltas mean nothing.
+        var raw = new byte[(width + 1) * height];
+        for (var y = 0; y < height; y++)
+        {
+            Buffer.BlockCopy(indexes, y * width, raw, (y * (width + 1)) + 1, width);
+        }
+
+        using var compressed = new MemoryStream();
+        using (var zlib = new ZLibStream(compressed, CompressionLevel.SmallestSize, true))
+        {
+            zlib.Write(raw, 0, raw.Length);
+        }
+
+        return compressed.ToArray();
+    }
+
+    private static void WriteChunk(Stream stream, string type, byte[] data)
+    {
+        var length = new byte[4];
+        WriteUInt32BigEndian(length, 0, (uint)data.Length);
+        stream.Write(length, 0, length.Length);
+
+        var typeBytes = Encoding.ASCII.GetBytes(type);
+        stream.Write(typeBytes, 0, typeBytes.Length);
+        stream.Write(data, 0, data.Length);
+
+        var crc = Crc32(Crc32(0xffffffff, typeBytes), data) ^ 0xffffffff;
+        var crcBytes = new byte[4];
+        WriteUInt32BigEndian(crcBytes, 0, crc);
+        stream.Write(crcBytes, 0, crcBytes.Length);
+    }
+
+    private static void WriteUInt32BigEndian(byte[] buffer, int offset, uint value)
+    {
+        buffer[offset] = (byte)(value >> 24);
+        buffer[offset + 1] = (byte)(value >> 16);
+        buffer[offset + 2] = (byte)(value >> 8);
+        buffer[offset + 3] = (byte)value;
+    }
+
+    private static uint Crc32(uint crc, byte[] data)
+    {
+        foreach (var b in data)
+        {
+            crc = CrcTable[(crc ^ b) & 0xff] ^ (crc >> 8);
+        }
+
+        return crc;
+    }
+
+    private static uint[] CreateCrcTable()
+    {
+        var table = new uint[256];
+        for (var n = 0; n < 256; n++)
+        {
+            var c = (uint)n;
+            for (var k = 0; k < 8; k++)
+            {
+                c = (c & 1) != 0 ? 0xedb88320 ^ (c >> 1) : c >> 1;
+            }
+
+            table[n] = c;
+        }
+
+        return table;
+    }
+}

--- a/src/libuilogic/Export/SkBitmapExportExtensions.cs
+++ b/src/libuilogic/Export/SkBitmapExportExtensions.cs
@@ -10,4 +10,9 @@ internal static class SkBitmapExportExtensions
         using var data = image.Encode(SKEncodedImageFormat.Png, 100);
         return data.ToArray();
     }
+
+    public static byte[] ToPng8BitArray(this SKBitmap bitmap)
+    {
+        return Png8BitEncoder.Encode(bitmap);
+    }
 }

--- a/src/seconv/Core/ImageOutputWriter.cs
+++ b/src/seconv/Core/ImageOutputWriter.cs
@@ -24,6 +24,10 @@ internal static class ImageOutputWriter
                 => new ExportHandlerVobSub(),
             var x when x.Equals("BDN-XML", StringComparison.OrdinalIgnoreCase) || x.Equals("BdnXml", StringComparison.OrdinalIgnoreCase)
                 => new ExportHandlerBdnXml(),
+            // Same output, but with 8-bit palette-indexed PNGs - what Blu-ray authoring
+            // tools expect (issue #13452).
+            var x when x.Equals("BDN-XML 8-bit", StringComparison.OrdinalIgnoreCase) || x.Equals("BdnXml8Bit", StringComparison.OrdinalIgnoreCase)
+                => new ExportHandlerBdnXml(true),
             var x when x.Equals("DOST/image", StringComparison.OrdinalIgnoreCase) || x.Equals("Dost", StringComparison.OrdinalIgnoreCase)
                 => new ExportHandlerDost(),
             var x when x.Equals("FCP/image", StringComparison.OrdinalIgnoreCase) || x.Equals("FcpImage", StringComparison.OrdinalIgnoreCase)

--- a/src/seconv/Core/LibSEIntegration.cs
+++ b/src/seconv/Core/LibSEIntegration.cs
@@ -1159,6 +1159,7 @@ internal static class LibSEIntegration
             "bluraysup" or "blurayup" or "sup" => "Blu-ray sup",
             "vobsub" => "VobSub",
             "bdnxml" or "bdn-xml" => "BDN-XML",
+            "bdnxml8bit" or "bdn-xml8bit" or "bdnxml8-bit" or "bdn-xml8-bit" => "BDN-XML 8-bit",
             "dost" or "dostimage" => "DOST/image",
             "fcp" or "fcpimage" => "FCP/image",
             "dcinemainterop" or "dcinema-interop" => "D-Cinema interop/png",

--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -217,6 +217,11 @@ public static class InitMenu
                         },
                         new MenuItem
                         {
+                            Header = Se.Language.General.BdnXml8Bit,
+                            Command = vm.ExportBdnXml8BitCommand,
+                        },
+                        new MenuItem
+                        {
                             Header = Se.Language.File.Export.TitleExportImscImage,
                             Command = vm.ExportImscImageCommand,
                         },

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -231,6 +231,7 @@ public static class InitNativeMacMenu
         var exportItems = new NativeMenu();
         exportItems.Items.Add(Item(Se.Language.General.BluRaySup, v => v.ExportBluRaySupCommand));
         exportItems.Items.Add(Item(Se.Language.General.BdnXml, v => v.ExportBdnXmlCommand));
+        exportItems.Items.Add(Item(Se.Language.General.BdnXml8Bit, v => v.ExportBdnXml8BitCommand));
         exportItems.Items.Add(Item(new CapMakerPlus().Name, v => v.ExportCapMakerPlusCommand));
         exportItems.Items.Add(Item(CheetahCaption.NameOfFormat, v => v.ExportCheetahCaptionCommand));
         exportItems.Items.Add(Item(CheetahCaptionOld.NameOfFormat, v => v.ExportCheetahCaptionOldCommand));

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -3047,6 +3047,36 @@ public partial class MainViewModel :
         }
     }
 
+    /// <summary>
+    /// Same as <see cref="ExportBdnXml"/>, but the images are 8-bit palette-indexed PNGs -
+    /// what Blu-ray authoring tools want (issue #13452).
+    /// </summary>
+    [RelayCommand]
+    private async Task ExportBdnXml8Bit()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        if (IsEmpty)
+        {
+            ShowSubtitleNotLoadedMessage();
+            return;
+        }
+
+        IExportHandler exportHandler = new ExportHandlerBdnXml(true);
+        var result = await ShowDialogAsync<ExportImageBasedWindow, ExportImageBasedViewModel>(vm =>
+        {
+            vm.Initialize(exportHandler, Subtitles, _subtitleFileName, _videoFileName);
+        });
+
+        if (!result.OkPressed)
+        {
+            return;
+        }
+    }
+
     [RelayCommand]
     private async Task ExportImscImage()
     {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -940,6 +940,12 @@ public partial class BinaryEditViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private async Task ExportBdnXml8Bit()
+    {
+        await DoExport(new ExportHandlerBdnXml(true), string.Empty, false);
+    }
+
+    [RelayCommand]
     private async Task ExportVobSub()
     {
         await DoExport(new ExportHandlerVobSub(), ".sub");

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -208,6 +208,11 @@ public class BinaryEditWindow : Window
                         },
                         new MenuItem
                         {
+                            Header = Se.Language.General.BdnXml8Bit,
+                            Command = vm.ExportBdnXml8BitCommand,
+                        },
+                        new MenuItem
+                        {
                             Header = Se.Language.File.Export.TitleExportImscImage,
                             Command = vm.ExportImscImageCommand,
                         },

--- a/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
+++ b/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
@@ -18,6 +18,7 @@ public static class InitNativeMacMenuBinaryEdit
         var exportMenu = new NativeMenu();
         Add(exportMenu, Se.Language.General.BluRaySup, vm.ExportBluRaySupCommand);
         Add(exportMenu, Se.Language.General.BdnXml, vm.ExportBdnXmlCommand);
+        Add(exportMenu, Se.Language.General.BdnXml8Bit, vm.ExportBdnXml8BitCommand);
         Add(exportMenu, Se.Language.File.Export.TitleExportImscImage, vm.ExportImscImageCommand);
         Add(exportMenu, Se.Language.File.Export.TitleExportDostPng, vm.ExportDostPngCommand);
         Add(exportMenu, Se.Language.File.Export.TitleExportFcpImage, vm.ExportFcpPngCommand);

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertConfig.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertConfig.cs
@@ -95,6 +95,7 @@ public class BatchConvertConfig
         TargetFormatName == BatchConverter.FormatVobSub ||
         TargetFormatName == BatchConverter.FormatDostImage ||
         TargetFormatName == BatchConverter.FormatBdnXml ||
+        TargetFormatName == BatchConverter.FormatBdnXml8Bit ||
         TargetFormatName == BatchConverter.FormatFcpImage ||
         TargetFormatName == BatchConverter.FormatImagesWithTimeCodesInFileName;
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -290,6 +290,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         {
             BatchConverter.FormatAyato,
             BatchConverter.FormatBdnXml,
+            BatchConverter.FormatBdnXml8Bit,
             BatchConverter.FormatBluRaySup,
             BatchConverter.FormatCavena890,
             BatchConverter.FormatCustomTextFormat,
@@ -426,6 +427,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         _targetFormatsWithSettings = new List<string>
         {
             BatchConverter.FormatBdnXml,
+            BatchConverter.FormatBdnXml8Bit,
             BatchConverter.FormatBluRaySup,
             BatchConverter.FormatCustomTextFormat,
             BatchConverter.FormatDostImage,
@@ -1584,6 +1586,10 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         {
             exportHandler = new ExportHandlerBdnXml();
         }
+        else if (targetFormat == BatchConverter.FormatBdnXml8Bit)
+        {
+            exportHandler = new ExportHandlerBdnXml(true);
+        }
         else if (targetFormat == BatchConverter.FormatBluRaySup)
         {
             exportHandler = new ExportHandlerBluRaySup();
@@ -1734,6 +1740,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             new(BatchConverter.FormatBluRaySup, null),
             new(BatchConverter.FormatVobSub, null),
             new(BatchConverter.FormatBdnXml, null),
+            new(BatchConverter.FormatBdnXml8Bit, null),
             new(BatchConverter.FormatDostImage, null),
             new(BatchConverter.FormatFcpImage, null),
             new(BatchConverter.FormatDCinemaInterop, null),

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -48,6 +48,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
 {
     public static readonly string FormatAyato = new Ayato().Name;
     public const string FormatBdnXml = "BDN-XML";
+    public const string FormatBdnXml8Bit = "BDN-XML 8-bit";
     public const string FormatBluRaySup = "Blu-ray sup";
     public static readonly string FormatCavena890 = new Cavena890().Name;
     public const string FormatDCinemaInterop = "D-Cinema interop/png";
@@ -1565,6 +1566,12 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         if (_config.TargetFormatName == FormatBdnXml)
         {
             exportHandler = new ExportHandlerBdnXml();
+            extension = string.Empty; // folder
+        }
+
+        if (_config.TargetFormatName == FormatBdnXml8Bit)
+        {
+            exportHandler = new ExportHandlerBdnXml(true);
             extension = string.Empty; // folder
         }
 

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -49,6 +49,7 @@ public class LanguageGeneral
     public string Backward { get; set; }
     public string BatchMode { get; set; }
     public string BdnXml { get; set; }
+    public string BdnXml8Bit { get; set; }
     public string Before { get; set; }
     public string Beginning { get; set; }
     public string BluRaySup { get; set; }
@@ -787,6 +788,7 @@ public class LanguageGeneral
         Backward = "Backward";
         BatchMode = "Batch mode";
         BdnXml = "BDN/xml";
+        BdnXml8Bit = "BDN/xml 8-bit";
         Before = "Before";
         Beginning = "Beginning";
         BluRaySup = "Blu-ray (sup)";

--- a/tests/libuilogic/Export/ExportHandlerBdnXmlTests.cs
+++ b/tests/libuilogic/Export/ExportHandlerBdnXmlTests.cs
@@ -1,0 +1,96 @@
+using Nikse.SubtitleEdit.UiLogic.Export;
+using SkiaSharp;
+
+namespace LibUiLogicTests.Export;
+
+public class ExportHandlerBdnXmlTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "bdnxml_" + Guid.NewGuid().ToString("N"));
+
+    public ExportHandlerBdnXmlTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, true); } catch { /* best effort */ }
+    }
+
+    private static ImageParameter Cue(int index, string text, int startMs, int endMs)
+    {
+        var bitmap = new SKBitmap(300, 80);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            using var paint = new SKPaint { Color = SKColors.White, IsAntialias = true };
+            using var font = new SKFont(SKTypeface.Default, 24);
+            canvas.DrawText(text, 4, 40, font, paint);
+        }
+
+        return new ImageParameter
+        {
+            Text = text,
+            Bitmap = bitmap,
+            StartTime = TimeSpan.FromMilliseconds(startMs),
+            EndTime = TimeSpan.FromMilliseconds(endMs),
+            Index = index,
+            ScreenWidth = 1920,
+            ScreenHeight = 1080,
+            Alignment = ExportAlignment.BottomCenter,
+            BottomTopMargin = 50,
+            FramesPerSecond = 25,
+        };
+    }
+
+    private string Export(bool use8BitPng)
+    {
+        var folder = Path.Combine(_dir, use8BitPng ? "8bit" : "32bit");
+        var handler = new ExportHandlerBdnXml(use8BitPng);
+        var cues = new[] { Cue(0, "Hello", 1000, 3000), Cue(1, "World", 4000, 6000) };
+        handler.WriteHeader(folder, cues[0]);
+        foreach (var cue in cues)
+        {
+            handler.WriteParagraph(cue);
+        }
+
+        handler.WriteFooter();
+        return folder;
+    }
+
+    private static int ColorType(string pngFileName)
+    {
+        var bytes = File.ReadAllBytes(pngFileName);
+        return bytes[25]; // signature (8) + length/type (8) + width/height (8) + bit depth (1)
+    }
+
+    [Fact]
+    public void EightBitExportWritesPaletteIndexedPngs()
+    {
+        var folder = Export(true);
+
+        Assert.True(File.Exists(Path.Combine(folder, "index.xml")));
+        foreach (var image in new[] { "0001.png", "0002.png" })
+        {
+            var fileName = Path.Combine(folder, image);
+            Assert.True(File.Exists(fileName), image + " missing");
+            Assert.Equal(3, ColorType(fileName)); // 3 = palette
+        }
+    }
+
+    [Fact]
+    public void DefaultExportKeepsThirtyTwoBitPngs()
+    {
+        var folder = Export(false);
+
+        Assert.Equal(6, ColorType(Path.Combine(folder, "0001.png"))); // 6 = truecolor with alpha
+    }
+
+    [Fact]
+    public void BothVariantsWriteTheSameIndexXml()
+    {
+        var eightBit = File.ReadAllText(Path.Combine(Export(true), "index.xml"));
+        var thirtyTwoBit = File.ReadAllText(Path.Combine(Export(false), "index.xml"));
+
+        Assert.Equal(thirtyTwoBit, eightBit);
+        Assert.Contains("<Graphic Width=\"300\" Height=\"80\"", eightBit);
+        Assert.Contains("NumberofEvents=\"2\"", eightBit);
+    }
+}

--- a/tests/libuilogic/Export/Png8BitEncoderTests.cs
+++ b/tests/libuilogic/Export/Png8BitEncoderTests.cs
@@ -1,0 +1,143 @@
+using Nikse.SubtitleEdit.UiLogic.Export;
+using SkiaSharp;
+using System.Text;
+
+namespace LibUiLogicTests.Export;
+
+public class Png8BitEncoderTests
+{
+    private static SKBitmap MakeBitmap(int width, int height, Func<int, int, SKColor> pixel)
+    {
+        var bitmap = new SKBitmap(new SKImageInfo(width, height, SKColorType.Bgra8888, SKAlphaType.Unpremul));
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                bitmap.SetPixel(x, y, pixel(x, y));
+            }
+        }
+
+        return bitmap;
+    }
+
+    private static List<(string Type, byte[] Data)> ReadChunks(byte[] png)
+    {
+        var chunks = new List<(string, byte[])>();
+        var offset = 8; // signature
+        while (offset + 8 <= png.Length)
+        {
+            var length = (png[offset] << 24) | (png[offset + 1] << 16) | (png[offset + 2] << 8) | png[offset + 3];
+            var type = Encoding.ASCII.GetString(png, offset + 4, 4);
+            var data = new byte[length];
+            Array.Copy(png, offset + 8, data, 0, length);
+            chunks.Add((type, data));
+            offset += 12 + length; // length + type + data + crc
+        }
+
+        return chunks;
+    }
+
+    [Fact]
+    public void WritesIndexedColorPngWithPaletteAndTransparency()
+    {
+        using var bitmap = MakeBitmap(8, 4, (x, _) => x < 4 ? SKColors.Transparent : SKColors.White);
+
+        var png = Png8BitEncoder.Encode(bitmap);
+
+        Assert.Equal(new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 }, png.Take(8).ToArray());
+
+        var chunks = ReadChunks(png);
+        Assert.Equal(new[] { "IHDR", "PLTE", "tRNS", "IDAT", "IEND" }, chunks.Select(c => c.Type).ToArray());
+
+        var header = chunks[0].Data;
+        Assert.Equal(8, (header[0] << 24) | (header[1] << 16) | (header[2] << 8) | header[3]); // width
+        Assert.Equal(4, (header[4] << 24) | (header[5] << 16) | (header[6] << 8) | header[7]); // height
+        Assert.Equal(8, header[8]); // bit depth
+        Assert.Equal(3, header[9]); // color type: palette
+
+        // Index 0 is the fully transparent entry, white was added as index 1.
+        Assert.Equal(2 * 3, chunks[1].Data.Length);
+        Assert.Equal(0, chunks[2].Data[0]);
+    }
+
+    [Fact]
+    public void DecodesBackToTheOriginalColors()
+    {
+        var colors = new[] { SKColors.Transparent, SKColors.White, SKColors.Black, new SKColor(255, 0, 0, 128) };
+        using var bitmap = MakeBitmap(4, 3, (x, _) => colors[x]);
+
+        var png = Png8BitEncoder.Encode(bitmap);
+
+        using var decoded = SKBitmap.Decode(png);
+        Assert.NotNull(decoded);
+        Assert.Equal(4, decoded.Width);
+        Assert.Equal(3, decoded.Height);
+        for (var y = 0; y < 3; y++)
+        {
+            for (var x = 0; x < 4; x++)
+            {
+                var actual = decoded.GetPixel(x, y);
+                if (colors[x].Alpha == 0)
+                {
+                    Assert.Equal(0, actual.Alpha);
+                    continue;
+                }
+
+                Assert.Equal(colors[x].Alpha, actual.Alpha);
+                Assert.Equal(colors[x].Red, actual.Red);
+                Assert.Equal(colors[x].Green, actual.Green);
+                Assert.Equal(colors[x].Blue, actual.Blue);
+            }
+        }
+    }
+
+    [Fact]
+    public void PremultipliedInputKeepsItsStraightColors()
+    {
+        // A half transparent white pixel is stored as (128,128,128,128) when premultiplied -
+        // the palette must hold the straight color, or semi-transparent anti-aliased edges
+        // come out too dark.
+        using var bitmap = new SKBitmap(new SKImageInfo(1, 1, SKColorType.Bgra8888, SKAlphaType.Premul));
+        bitmap.SetPixel(0, 0, new SKColor(255, 255, 255, 128));
+
+        var png = Png8BitEncoder.Encode(bitmap);
+
+        using var decoded = SKBitmap.Decode(png);
+        var pixel = decoded.GetPixel(0, 0);
+        Assert.Equal(128, pixel.Alpha);
+        Assert.True(pixel.Red >= 254, $"Expected white, got {pixel}");
+        Assert.True(pixel.Green >= 254, $"Expected white, got {pixel}");
+        Assert.True(pixel.Blue >= 254, $"Expected white, got {pixel}");
+    }
+
+    [Fact]
+    public void ManyColorsStayWithinAnEightBitPalette()
+    {
+        // A gradient has far more than 255 distinct colors; the quantizer must still fit.
+        using var bitmap = MakeBitmap(64, 64, (x, y) => new SKColor((byte)(x * 4), (byte)(y * 4), (byte)((x + y) * 2)));
+
+        var png = Png8BitEncoder.Encode(bitmap);
+
+        var chunks = ReadChunks(png);
+        var plte = chunks.First(c => c.Type == "PLTE").Data;
+        Assert.True(plte.Length % 3 == 0);
+        Assert.InRange(plte.Length / 3, 1, 256);
+
+        using var decoded = SKBitmap.Decode(png);
+        Assert.Equal(64, decoded.Width);
+        Assert.Equal(64, decoded.Height);
+    }
+
+    [Fact]
+    public void EmptyBitmapGivesASinglePixelPng()
+    {
+        using var bitmap = new SKBitmap(0, 0);
+
+        var png = Png8BitEncoder.Encode(bitmap);
+
+        using var decoded = SKBitmap.Decode(png);
+        Assert.NotNull(decoded);
+        Assert.Equal(1, decoded.Width);
+        Assert.Equal(1, decoded.Height);
+    }
+}


### PR DESCRIPTION
Fixes #13452.

SE4 offered a "Png 8-bit" choice in the BDN XML export dialog; SE5 only wrote 32-bit RGBA PNGs. Blu-ray authoring tools generally want the image set in 8-bit indexed color, so this adds **BDN/xml 8-bit** next to the existing **BDN/xml** entry. The `index.xml` is identical either way — only the PNGs differ.

### The encoder

Skia dropped its indexed color type and can only encode 32-bit RGBA PNGs, so `Png8BitEncoder` writes the chunks by hand: IHDR (bit depth 8, color type 3), PLTE, tRNS for per-palette-entry alpha, a deflated IDAT (unfiltered — the PNG spec recommends leaving palette images unfiltered), and CRC32 per chunk.

The quantizer is a port of SE4's `NikseBitmap.ConvertTo8BitsPerPixel`: a greedy nearest-color palette with index 0 reserved for transparent, and the same distance tolerances. Two things on top of the port:

- a color → index cache, since the palette search is a linear scan and anti-aliased text repeats the same few hundred colors;
- pixels are read as straight (non-premultiplied) BGRA, otherwise semi-transparent anti-aliased edges land in the palette too dark.

### Where it shows up

- File → Export → **BDN/xml 8-bit** (menu bar and macOS native menu)
- Binary edit window → File → Export
- Batch convert target format **BDN-XML 8-bit**
- `seconv subs.srt bdnxml8bit`

### Verification

A 500-line subtitle exported through `seconv` both ways:

- all 500 images report `PNG image data, 8-bit colormap, non-interlaced` (`file`), and Pillow reads them as mode `P` with ~110 palette entries;
- against the 32-bit output, the maximum per-pixel channel-sum difference on visible pixels is 3 — inside the quantizer's own `< 4` match tolerance — so the result is visually identical;
- output shrank from 18 MB to 7.9 MB, and the run was slightly faster (6.5 s vs 7.8 s) since the smaller PNG writes more than pay for the quantization.

New tests: `Png8BitEncoderTests` (chunk layout, decode round-trip, premultiplied input, >255 colors, empty bitmap) and `ExportHandlerBdnXmlTests` (color type of the written PNGs, index.xml equality between the two variants).

Note: `English.json` is not touched — it is generated from the language classes, and until it is regenerated the `LanguageGeneral` default supplies the menu label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)