### PR TITLE
Show number of forced cues in the Matroska track picker

### DIFF
--- a/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackViewModel.cs
+++ b/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackViewModel.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -381,7 +382,7 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
                     });
                 }
 
-                SubtitleCountText = string.Format(Se.Language.File.Import.NumberOfSubtitlesX, preview.Count);
+                SubtitleCountText = FormatSubtitleCount(preview.Count, preview.ForcedCount);
             }
             catch (Exception exception)
             {
@@ -408,13 +409,14 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
     {
         var cues = new List<PreviewCueData>();
         var count = 0;
+        int? forcedCount = null;
 
         MatroskaFile.LoadMatroskaCallback? callback =
             pleaseWaitVm != null ? (position, total) => pleaseWaitVm.ReportProgress(position, total) : null;
         var subtitles = matroskaFile.GetSubtitle(trackInfo.TrackNumber, callback);
         if (subtitles == null)
         {
-            return new PreviewResult(0, cues);
+            return new PreviewResult(0, null, cues);
         }
 
         if (trackInfo.CodecId is MatroskaTrackType.SubRip
@@ -440,6 +442,7 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
         {
             var pcsData = BluRaySupParser.ParseBluRaySupFromMatroska(trackInfo, matroskaFile);
             count = pcsData.Count;
+            forcedCount = pcsData.Count(p => p.IsForced);
             for (var i = 0; i < 20 && i < pcsData.Count; i++)
             {
                 var item = pcsData[i];
@@ -474,6 +477,7 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
         {
             var packs = MatroskaImageSubtitleExtractor.ExtractVobSub(trackInfo, subtitles, out var idx);
             count = packs.Count;
+            forcedCount = packs.Count(p => p.IsForced);
             for (var i = 0; i < 20 && i < packs.Count; i++)
             {
                 var pack = packs[i];
@@ -510,10 +514,24 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
             }
         }
 
-        return new PreviewResult(count, cues);
+        return new PreviewResult(count, forcedCount, cues);
     }
 
-    private sealed record PreviewResult(int Count, List<PreviewCueData> Cues);
+    /// <summary>
+    /// The count line below the preview. Image-based tracks carry a per-cue forced flag, so the
+    /// number of forced cues is shown too - a movie can hold several tracks in the same language
+    /// where only one is the forced/signs track, and until now the only way to tell them apart was
+    /// to open each one (#13453). Text tracks have no such flag, so they get the plain count.
+    /// </summary>
+    internal static string FormatSubtitleCount(int count, int? forcedCount)
+    {
+        return forcedCount.HasValue
+            ? string.Format(Se.Language.File.Import.NumberOfSubtitlesXForcedY, count, forcedCount.Value)
+            : string.Format(Se.Language.File.Import.NumberOfSubtitlesX, count);
+    }
+
+    /// <summary><see cref="ForcedCount"/> is null for formats without a forced flag.</summary>
+    private sealed record PreviewResult(int Count, int? ForcedCount, List<PreviewCueData> Cues);
 
     private sealed class PreviewCueData
     {

--- a/src/ui/Logic/Config/Language/File/LanguageImport.cs
+++ b/src/ui/Logic/Config/Language/File/LanguageImport.cs
@@ -30,6 +30,7 @@ public class LanguageImport
     public string MergeShortLines { get; set; }
     public string Fixed { get; set; }
     public string NumberOfSubtitlesX { get; set; }
+    public string NumberOfSubtitlesXForcedY { get; set; }
     public string GapMs { get; set; }
     public string UseFixedDuration { get; set; }
     public string FixedDurationMs { get; set; }
@@ -75,6 +76,7 @@ Rules:
         MergeShortLines = "Merge short lines";
         Fixed = "Fixed";
         NumberOfSubtitlesX = "Number of subtitles: {0}";
+        NumberOfSubtitlesXForcedY = "Number of subtitles: {0} ({1} forced)";
         GapMs = "Gap (ms)";
         UseFixedDuration = "Use fixed duration";
         FixedDurationMs = "Fixed duration (ms)";

--- a/tests/UI/Features/Shared/PickMatroskaTrackCountTextTests.cs
+++ b/tests/UI/Features/Shared/PickMatroskaTrackCountTextTests.cs
@@ -1,0 +1,34 @@
+using Nikse.SubtitleEdit.Features.Shared.PickMatroskaTrack;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Shared;
+
+/// <summary>
+/// A movie can hold several image-based subtitle tracks in the same language where only one is the
+/// forced/signs track. The count line under the preview reports how many cues carry the forced
+/// flag, so the tracks can be told apart without opening each one (#13453).
+/// </summary>
+public class PickMatroskaTrackCountTextTests
+{
+    [Fact]
+    public void FormatSubtitleCount_WithoutForcedFlag_ShowsPlainCount()
+    {
+        var text = PickMatroskaTrackViewModel.FormatSubtitleCount(42, null);
+
+        Assert.Equal(string.Format(Se.Language.File.Import.NumberOfSubtitlesX, 42), text);
+        Assert.DoesNotContain("forced", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(842, 19)]
+    [InlineData(19, 19)]
+    [InlineData(842, 0)] // shown even at zero: "no forced cues" is the answer the user is after
+    public void FormatSubtitleCount_WithForcedFlag_ShowsBothCounts(int count, int forcedCount)
+    {
+        var text = PickMatroskaTrackViewModel.FormatSubtitleCount(count, forcedCount);
+
+        Assert.Equal(string.Format(Se.Language.File.Import.NumberOfSubtitlesXForcedY, count, forcedCount), text);
+        Assert.Contains(count.ToString(), text);
+        Assert.Contains($"({forcedCount} forced)", text);
+    }
+}


### PR DESCRIPTION
Fixes #13453

A movie can hold several image-based subtitle tracks in the same language where only one is the forced/signs track. The picker's track list only shows the Matroska header's forced flag (a track-level flag that says nothing about the cues inside), so the tracks could only be told apart by opening each one.

The count line under the preview now reads `Number of subtitles: 842 (19 forced)` for formats that carry a per-cue forced flag:

- PGS/Blu-ray — `PcsData.IsForced`
- VobSub — `VobSubMergedPack.IsForced`

The whole track is already parsed to build the preview, so counting is free — no extra reading, no change to the progress-window path.

Text tracks (SRT/ASS/WebVTT/TextST) and DVB have no per-cue forced flag, so they keep the plain `Number of subtitles: {0}` line rather than a misleading `(0 forced)`. For formats that do have the flag, `(0 forced)` *is* shown — "this track has no forced cues" is exactly the answer being looked for when comparing two same-language tracks.

New language string: `NumberOfSubtitlesXForcedY = "Number of subtitles: {0} ({1} forced)"`.

Tests: 4 new tests in `tests/UI/Features/Shared/PickMatroskaTrackCountTextTests.cs`, passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)