### PR TITLE
Fix Persian text and dark theme highlighting in the compare view

### DIFF
--- a/src/ui/Features/Files/Compare/CompareColors.cs
+++ b/src/ui/Features/Files/Compare/CompareColors.cs
@@ -1,0 +1,79 @@
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+
+namespace Nikse.SubtitleEdit.Features.Files.Compare;
+
+/// <summary>
+/// The three highlight colors of the compare view - "only in one file", "text or time
+/// difference" and "number difference" - in one place, so the row backgrounds, the color
+/// legend and the exported HTML page cannot drift apart.
+///
+/// The light pastels were the only palette for a long time, which left them unreadable in
+/// the dark theme: a near-white row background under the dark theme's near-white text
+/// (issue #13435). Each color now has a dark counterpart in the same family as the run
+/// highlighting of <see cref="TextDiffHighlighter"/>.
+/// </summary>
+internal static class CompareColors
+{
+    private const byte RowAlpha = 180;
+
+    // The light palette doubles as the export palette: the generated HTML page has a white
+    // background and black text, so it must keep the pastels whatever theme is active.
+    internal static readonly Color OnlyInOneFileLight = Color.FromRgb(255, 235, 233);
+    internal static readonly Color TextOrTimeDifferenceLight = Color.FromRgb(230, 255, 237);
+    internal static readonly Color NumberDifferenceLight = Color.FromRgb(255, 248, 220);
+
+    private static readonly Color OnlyInOneFileDark = Color.FromRgb(90, 35, 35);
+    private static readonly Color TextOrTimeDifferenceDark = Color.FromRgb(35, 75, 40);
+    private static readonly Color NumberDifferenceDark = Color.FromRgb(85, 70, 25);
+
+    private static readonly IBrush OnlyInOneFileRowLight = MakeRowBrush(OnlyInOneFileLight);
+    private static readonly IBrush TextOrTimeDifferenceRowLight = MakeRowBrush(TextOrTimeDifferenceLight);
+    private static readonly IBrush NumberDifferenceRowLight = MakeRowBrush(NumberDifferenceLight);
+
+    private static readonly IBrush OnlyInOneFileRowDark = MakeRowBrush(OnlyInOneFileDark);
+    private static readonly IBrush TextOrTimeDifferenceRowDark = MakeRowBrush(TextOrTimeDifferenceDark);
+    private static readonly IBrush NumberDifferenceRowDark = MakeRowBrush(NumberDifferenceDark);
+
+    /// <summary>Opaque color for the legend swatches.</summary>
+    internal static Color OnlyInOneFile => UiTheme.IsDarkThemeEnabled() ? OnlyInOneFileDark : OnlyInOneFileLight;
+
+    internal static Color TextOrTimeDifference => UiTheme.IsDarkThemeEnabled() ? TextOrTimeDifferenceDark : TextOrTimeDifferenceLight;
+
+    internal static Color NumberDifference => UiTheme.IsDarkThemeEnabled() ? NumberDifferenceDark : NumberDifferenceLight;
+
+    /// <summary>Row background brush; the same instance per theme, so brushes stay reference comparable.</summary>
+    internal static IBrush OnlyInOneFileRow => UiTheme.IsDarkThemeEnabled() ? OnlyInOneFileRowDark : OnlyInOneFileRowLight;
+
+    internal static IBrush TextOrTimeDifferenceRow => UiTheme.IsDarkThemeEnabled() ? TextOrTimeDifferenceRowDark : TextOrTimeDifferenceRowLight;
+
+    internal static IBrush NumberDifferenceRow => UiTheme.IsDarkThemeEnabled() ? NumberDifferenceRowDark : NumberDifferenceRowLight;
+
+    /// <summary>
+    /// Light-palette color for a row brush, or null when the cell is not highlighted. The
+    /// exported page is always light, so a dark-theme brush must export as its light twin -
+    /// otherwise the export carries dark cells behind the page's black text.
+    /// </summary>
+    internal static Color? GetExportColor(IBrush? brush)
+    {
+        if (ReferenceEquals(brush, OnlyInOneFileRowLight) || ReferenceEquals(brush, OnlyInOneFileRowDark))
+        {
+            return OnlyInOneFileLight;
+        }
+
+        if (ReferenceEquals(brush, TextOrTimeDifferenceRowLight) || ReferenceEquals(brush, TextOrTimeDifferenceRowDark))
+        {
+            return TextOrTimeDifferenceLight;
+        }
+
+        if (ReferenceEquals(brush, NumberDifferenceRowLight) || ReferenceEquals(brush, NumberDifferenceRowDark))
+        {
+            return NumberDifferenceLight;
+        }
+
+        return null;
+    }
+
+    private static IBrush MakeRowBrush(Color color)
+        => new SolidColorBrush(Color.FromArgb(RowAlpha, color.R, color.G, color.B));
+}

--- a/src/ui/Features/Files/Compare/CompareItem.cs
+++ b/src/ui/Features/Files/Compare/CompareItem.cs
@@ -60,9 +60,14 @@ public partial class CompareItem : ObservableObject
         StartTimeBackgroundBrush = new SolidColorBrush(Colors.Transparent);
         EndTimeBackgroundBrush = new SolidColorBrush(Colors.Transparent);
         TextBackgroundBrush = new SolidColorBrush(Colors.Transparent);
+
+        // Right to left text needs the paragraph direction of its content, or the line reads
+        // backwards - the same rule the subtitle grid applies through TextToFlowDirectionConverter (#13435).
+        var label = UiUtil.MakeLabel(line.Text);
+        label.FlowDirection = TextToFlowDirectionConverter.GetFlowDirection(line.Text);
         TextPanel = new StackPanel
         {
-            Children = { UiUtil.MakeLabel(line.Text) }
+            Children = { label }
         };
     }
 }

--- a/src/ui/Features/Files/Compare/CompareViewModel.cs
+++ b/src/ui/Features/Files/Compare/CompareViewModel.cs
@@ -52,9 +52,10 @@ public partial class CompareViewModel : ObservableObject
     private List<SubtitleLineViewModel> _rightLines = new();
     private string _language = string.Empty;
 
-    private static readonly IBrush ListViewRed = new SolidColorBrush(Color.FromArgb(180, 255, 235, 233));
-    private static readonly IBrush ListViewGreen = new SolidColorBrush(Color.FromArgb(180, 230, 255, 237));
-    private static readonly IBrush ListViewOrange = new SolidColorBrush(Color.FromArgb(180, 255, 248, 220));
+    // Theme aware - the light pastels are unreadable under the dark theme's near-white text (#13435).
+    private static IBrush ListViewRed => CompareColors.OnlyInOneFileRow;
+    private static IBrush ListViewGreen => CompareColors.TextOrTimeDifferenceRow;
+    private static IBrush ListViewOrange => CompareColors.NumberDifferenceRow;
     private static readonly IBrush TransparentBrush = new SolidColorBrush(Colors.Transparent);
 
     public CompareViewModel(IFileHelper fileHelper, IFolderHelper folderHelper)
@@ -814,24 +815,17 @@ public partial class CompareViewModel : ObservableObject
 
     private static string GetHtmlBackgroundColor(IBrush brush)
     {
-        if (brush == null)
+        // The exported page is white with black text, so a highlight always exports as its
+        // light pastel - the dark theme's row brushes would render as near-black cells.
+        var exportColor = CompareColors.GetExportColor(brush);
+        if (exportColor == null)
         {
             return string.Empty;
         }
 
-        if (brush is SolidColorBrush solidColorBrush)
-        {
-            if (solidColorBrush.Color == Colors.Transparent)
-            {
-                return string.Empty;
-            }
-
-            var c = solidColorBrush.Color;
-            var htmlColor = $"#{c.R:X2}{c.G:X2}{c.B:X2}";
-            return $" style='background-color:{htmlColor}'";
-        }
-
-        return string.Empty;
+        var c = exportColor.Value;
+        var htmlColor = $"#{c.R:X2}{c.G:X2}{c.B:X2}";
+        return $" style='background-color:{htmlColor}'";
     }
 
     private void Close()

--- a/src/ui/Features/Files/Compare/CompareWindow.cs
+++ b/src/ui/Features/Files/Compare/CompareWindow.cs
@@ -101,9 +101,9 @@ public class CompareWindow : Window
         };
 
         // color legend for the difference highlighting
-        panelDisplayType.Children.Add(MakeLegendSwatch(Color.FromArgb(255, 255, 235, 233), Se.Language.File.CompareOnlyInOneFile));
-        panelDisplayType.Children.Add(MakeLegendSwatch(Color.FromArgb(255, 230, 255, 237), Se.Language.File.CompareTextOrTimeDifference));
-        panelDisplayType.Children.Add(MakeLegendSwatch(Color.FromArgb(255, 255, 248, 220), Se.Language.File.CompareNumberDifference));
+        panelDisplayType.Children.Add(MakeLegendSwatch(CompareColors.OnlyInOneFile, Se.Language.File.CompareOnlyInOneFile));
+        panelDisplayType.Children.Add(MakeLegendSwatch(CompareColors.TextOrTimeDifference, Se.Language.File.CompareTextOrTimeDifference));
+        panelDisplayType.Children.Add(MakeLegendSwatch(CompareColors.NumberDifference, Se.Language.File.CompareNumberDifference));
         grid.Add(panelDisplayType, 3, 0, 1, 2);
 
         // buttons
@@ -151,11 +151,6 @@ public class CompareWindow : Window
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };
         Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
-    }
-
-    private Control MakeSubtitlesView(ObservableCollection<CompareItem> leftSubtitles, string v, object fileGridOnDragOverLeft, object fileGridOnDropLeft)
-    {
-        throw new NotImplementedException();
     }
 
     private static Control MakeLegendSwatch(Color color, string label)

--- a/src/ui/Features/Files/Compare/TextDiffHighlighter.cs
+++ b/src/ui/Features/Files/Compare/TextDiffHighlighter.cs
@@ -4,8 +4,10 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.ValueConverters;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Features.Files.Compare;
 
@@ -78,13 +80,27 @@ public static class TextDiffHighlighter
         return string.Join("\n", text.SplitToLines());
     }
 
+    // A text block laid out left to right places its runs left to right, so the chunks of a
+    // right to left line come out in reverse reading order - the line reads backwards even
+    // though each chunk on its own is fine. Each side follows its own content, so an Arabic
+    // line still compares against a Latin one (#13435).
+    private static TextBlock MakeTextBlock(string text)
+    {
+        return new TextBlock
+        {
+            TextWrapping = TextWrapping.Wrap,
+            VerticalAlignment = VerticalAlignment.Center,
+            FlowDirection = TextToFlowDirectionConverter.GetFlowDirection(text),
+        };
+    }
+
     public static (TextBlock left, TextBlock right) Compare(string text1, string text2)
     {
         text1 = NormalizeNewLines(text1);
         text2 = NormalizeNewLines(text2);
 
-        var left = new TextBlock { TextWrapping = TextWrapping.Wrap, VerticalAlignment = VerticalAlignment.Center };
-        var right = new TextBlock { TextWrapping = TextWrapping.Wrap, VerticalAlignment = VerticalAlignment.Center };
+        var left = MakeTextBlock(text1);
+        var right = MakeTextBlock(text2);
 
         if (left.Inlines == null || right.Inlines == null)
         {
@@ -143,8 +159,8 @@ public static class TextDiffHighlighter
         text1 = NormalizeNewLines(text1);
         text2 = NormalizeNewLines(text2);
 
-        var before = new TextBlock { TextWrapping = TextWrapping.Wrap, VerticalAlignment = VerticalAlignment.Center };
-        var after = new TextBlock { TextWrapping = TextWrapping.Wrap, VerticalAlignment = VerticalAlignment.Center };
+        var before = MakeTextBlock(text1);
+        var after = MakeTextBlock(text2);
 
         if (before.Inlines == null || after.Inlines == null)
         {
@@ -187,63 +203,117 @@ public static class TextDiffHighlighter
     private static void BuildDiffRuns(TextBlock textBlock, string text, int commonStart, int commonEnd,
         List<(int start, int length)> middleCommon, bool hasDifferences, IBrush diffForeground, IBrush diffBackground)
     {
-        int currentPos = 0;
+        // Mark which characters differ first, then emit one run per stretch. Going through a
+        // mask instead of straight to runs is what lets the boundaries be moved (see
+        // SnapToWordBoundaries) before anything is rendered.
+        var isDiff = BuildDiffMask(text, commonStart, commonEnd, middleCommon);
 
-        // Add prefix if common
-        if (commonStart > 0)
+        if (LanguageAutoDetect.ContainsRightToLeftLetter(text))
         {
-            textBlock.Inlines!.Add(new Run(text.Substring(0, commonStart))
-            {
-                Background = hasDifferences ? GetDiffBackgroundColor() : null
-            });
-            currentPos = commonStart;
+            SnapToWordBoundaries(text, isDiff);
         }
 
-        // Add middle parts (mix of common and different)
-        int middleEnd = text.Length - commonEnd;
-        if (middleCommon.Count > 0)
+        var commonBackground = hasDifferences ? GetDiffBackgroundColor() : null;
+
+        var pos = 0;
+        while (pos < text.Length)
         {
-            foreach (var (start, length) in middleCommon)
+            var diff = isDiff[pos];
+            var end = pos + 1;
+            while (end < text.Length && isDiff[end] == diff)
             {
-                // Add different part before this common part
-                if (start > currentPos)
+                end++;
+            }
+
+            textBlock.Inlines!.Add(new Run(text.Substring(pos, end - pos))
+            {
+                Foreground = diff ? diffForeground : null,
+                Background = diff ? diffBackground : commonBackground,
+            });
+
+            pos = end;
+        }
+    }
+
+    private static bool[] BuildDiffMask(string text, int commonStart, int commonEnd, List<(int start, int length)> middleCommon)
+    {
+        var isDiff = new bool[text.Length];
+        var currentPos = Math.Clamp(commonStart, 0, text.Length);
+        var middleEnd = Math.Clamp(text.Length - commonEnd, 0, text.Length);
+
+        foreach (var (start, length) in middleCommon)
+        {
+            var commonPartStart = Math.Clamp(start, 0, text.Length);
+            for (var i = currentPos; i < commonPartStart; i++)
+            {
+                isDiff[i] = true;
+            }
+
+            currentPos = Math.Clamp(commonPartStart + length, 0, text.Length);
+        }
+
+        for (var i = currentPos; i < middleEnd; i++)
+        {
+            isDiff[i] = true;
+        }
+
+        return isDiff;
+    }
+
+    /// <summary>
+    /// Grows every difference to cover whole words. Arabic script letters join up and Avalonia
+    /// shapes each run on its own, so a boundary inside a word forces the two halves into
+    /// isolated letter forms - a Persian word comes out as loose, unconnected letters (#13435).
+    /// Only applied to text holding right to left letters, so left to right diffs keep their
+    /// finer character level granularity.
+    /// </summary>
+    private static void SnapToWordBoundaries(string text, bool[] isDiff)
+    {
+        var i = 0;
+        while (i < text.Length)
+        {
+            if (!IsWordChar(text[i]))
+            {
+                i++;
+                continue;
+            }
+
+            var wordStart = i;
+            while (i < text.Length && IsWordChar(text[i]))
+            {
+                i++;
+            }
+
+            var wordHasDifference = false;
+            for (var j = wordStart; j < i; j++)
+            {
+                if (isDiff[j])
                 {
-                    textBlock.Inlines!.Add(new Run(text.Substring(currentPos, start - currentPos))
-                    {
-                        Foreground = diffForeground,
-                        Background = diffBackground
-                    });
+                    wordHasDifference = true;
+                    break;
                 }
+            }
 
-                // Add common part
-                textBlock.Inlines!.Add(new Run(text.Substring(start, length))
-                {
-                    Background = GetDiffBackgroundColor()
-                });
+            if (!wordHasDifference)
+            {
+                continue;
+            }
 
-                currentPos = start + length;
+            for (var j = wordStart; j < i; j++)
+            {
+                isDiff[j] = true;
             }
         }
+    }
 
-        // Add remaining different part in the middle
-        if (currentPos < middleEnd)
-        {
-            textBlock.Inlines!.Add(new Run(text.Substring(currentPos, middleEnd - currentPos))
-            {
-                Foreground = diffForeground,
-                Background = diffBackground
-            });
-            currentPos = middleEnd;
-        }
-
-        // Add suffix if common
-        if (commonEnd > 0)
-        {
-            textBlock.Inlines!.Add(new Run(text.Substring(text.Length - commonEnd))
-            {
-                Background = hasDifferences ? GetDiffBackgroundColor() : null
-            });
-        }
+    private static bool IsWordChar(char c)
+    {
+        // Zero width non-joiner and joiner sit inside Persian words (می‌رود), and Arabic
+        // diacritics are non spacing marks - both belong to the word they are written in.
+        return char.IsLetterOrDigit(c)
+               || c == '\u200c'
+               || c == '\u200d'
+               || CharUnicodeInfo.GetUnicodeCategory(c) == UnicodeCategory.NonSpacingMark;
     }
 
     private static (int commonStart, int commonEnd, List<(int start, int length)> middleCommon1, List<(int start, int length)> middleCommon2) FindCommonParts(string text1, string text2)

--- a/src/ui/Logic/ValueConverters/TextToFlowDirectionConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextToFlowDirectionConverter.cs
@@ -1,4 +1,5 @@
 using Avalonia.Data.Converters;
+using Avalonia.Media;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
@@ -15,13 +16,18 @@ namespace Nikse.SubtitleEdit.Logic.ValueConverters;
 /// </summary>
 public class TextToFlowDirectionConverter : IValueConverter
 {
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    /// <summary>
+    /// The flow direction some text should be laid out with. Also for controls built in
+    /// code rather than bound (the compare view's diff runs, for instance), so that every
+    /// text surface follows the same rule.
+    /// </summary>
+    public static FlowDirection GetFlowDirection(string? text)
     {
-        if (value is string text && !string.IsNullOrWhiteSpace(text))
+        if (!string.IsNullOrWhiteSpace(text))
         {
             return LanguageAutoDetect.ContainsRightToLeftLetter(text)
-                ? ConverterBoxes.FlowDirectionRightToLeft
-                : ConverterBoxes.FlowDirectionLeftToRight;
+                ? FlowDirection.RightToLeft
+                : FlowDirection.LeftToRight;
         }
 
         // Always produce an explicit direction: a binding that yields UnsetValue
@@ -29,6 +35,13 @@ public class TextToFlowDirectionConverter : IValueConverter
         // default (left to right), which left right to left cells misaligned in
         // right to left mode.
         return Se.Settings.Appearance.RightToLeft
+            ? FlowDirection.RightToLeft
+            : FlowDirection.LeftToRight;
+    }
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return GetFlowDirection(value as string) == FlowDirection.RightToLeft
             ? ConverterBoxes.FlowDirectionRightToLeft
             : ConverterBoxes.FlowDirectionLeftToRight;
     }

--- a/tests/UI/Features/Files/Compare/CompareColorsTests.cs
+++ b/tests/UI/Features/Files/Compare/CompareColorsTests.cs
@@ -1,0 +1,61 @@
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Files.Compare;
+using System.Reflection;
+
+namespace UITests.Features.Files.Compare;
+
+public class CompareColorsTests
+{
+    private static T GetPrivateStatic<T>(string name)
+        => (T)typeof(CompareColors).GetField(name, BindingFlags.NonPublic | BindingFlags.Static)!.GetValue(null)!;
+
+    [Theory]
+    [InlineData("OnlyInOneFileRowLight", 255, 235, 233)]
+    [InlineData("OnlyInOneFileRowDark", 255, 235, 233)]
+    [InlineData("TextOrTimeDifferenceRowLight", 230, 255, 237)]
+    [InlineData("TextOrTimeDifferenceRowDark", 230, 255, 237)]
+    [InlineData("NumberDifferenceRowLight", 255, 248, 220)]
+    [InlineData("NumberDifferenceRowDark", 255, 248, 220)]
+    public void GetExportColor_MapsEveryThemeBrushToTheLightPastel(string brushField, byte r, byte g, byte b)
+    {
+        // The exported HTML page is white with black text, so a dark-theme row must still
+        // export as its light twin.
+        var color = CompareColors.GetExportColor(GetPrivateStatic<IBrush>(brushField));
+
+        Assert.NotNull(color);
+        Assert.Equal(Color.FromRgb(r, g, b), color!.Value);
+    }
+
+    [Fact]
+    public void GetExportColor_ForAnUnhighlightedCell_IsNull()
+    {
+        Assert.Null(CompareColors.GetExportColor(new SolidColorBrush(Colors.Transparent)));
+        Assert.Null(CompareColors.GetExportColor(null));
+    }
+
+    [Theory]
+    [InlineData("OnlyInOneFileDark")]
+    [InlineData("TextOrTimeDifferenceDark")]
+    [InlineData("NumberDifferenceDark")]
+    public void DarkHighlights_AreDarkEnoughToReadLightTextOn(string colorField)
+    {
+        // The light pastels were used in both themes, which left near-white rows under the
+        // dark theme's near-white text (#13435).
+        var color = GetPrivateStatic<Color>(colorField);
+        var luminance = (0.2126 * color.R + 0.7152 * color.G + 0.0722 * color.B) / 255.0;
+
+        Assert.True(luminance < 0.3, $"{colorField} luminance {luminance:0.00} is too light for the dark theme");
+    }
+
+    [Theory]
+    [InlineData("OnlyInOneFileLight")]
+    [InlineData("TextOrTimeDifferenceLight")]
+    [InlineData("NumberDifferenceLight")]
+    public void LightHighlights_AreLightEnoughToReadDarkTextOn(string colorField)
+    {
+        var color = GetPrivateStatic<Color>(colorField);
+        var luminance = (0.2126 * color.R + 0.7152 * color.G + 0.0722 * color.B) / 255.0;
+
+        Assert.True(luminance > 0.7, $"{colorField} luminance {luminance:0.00} is too dark for the light theme");
+    }
+}

--- a/tests/UI/Features/Files/Compare/TextDiffHighlighterTests.cs
+++ b/tests/UI/Features/Files/Compare/TextDiffHighlighterTests.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls.Documents;
+using Avalonia.Media;
 using Nikse.SubtitleEdit.Features.Files.Compare;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,8 +9,21 @@ namespace UITests.Features.Files.Compare;
 
 public class TextDiffHighlighterTests
 {
+    // "He goes home" and "He went home". The verb differs only in its last two letters, and
+    // Persian writes it with a zero width non-joiner inside the word, so a character level
+    // diff cuts the word in two - which breaks the cursive joining when each half is shaped
+    // as its own run (#13435).
+    private const string PersianGoesHome = "او به خانه می‌رود";
+    private const string PersianWentHome = "او به خانه می‌رفت";
+    private const string PersianCommonPart = "او به خانه ";
+    private const string PersianGoesVerb = "می‌رود";
+    private const string PersianWentVerb = "می‌رفت";
+
     private static string JoinRuns(InlineCollection? inlines)
         => string.Concat(inlines!.Cast<Run>().Select(r => r.Text));
+
+    private static string[] RunTexts(InlineCollection? inlines)
+        => inlines!.Cast<Run>().Select(r => r.Text!).ToArray();
 
     [Fact]
     public void CompareReplacement_CrLfBeforeVsLfAfter_NormalizesInsteadOfDiffingTheCr()
@@ -76,6 +90,108 @@ public class TextDiffHighlighterTests
             Assert.True(middleCommon2[i - 1].start <= middleCommon2[i].start,
                 $"middleCommon2[{i - 1}].start ({middleCommon2[i - 1].start}) " +
                 $"must be <= middleCommon2[{i}].start ({middleCommon2[i].start})");
+        }
+    }
+
+    [Fact]
+    public void Compare_RightToLeftText_BothSidesFlowRightToLeft()
+    {
+        // A left to right text block lays its runs out left to right, so the chunks of a Persian
+        // line come out in reverse reading order - the line reads backwards (#13435).
+        var (left, right) = TextDiffHighlighter.Compare(PersianGoesHome, PersianWentHome);
+
+        Assert.Equal(FlowDirection.RightToLeft, left.FlowDirection);
+        Assert.Equal(FlowDirection.RightToLeft, right.FlowDirection);
+    }
+
+    [Fact]
+    public void Compare_LeftToRightText_BothSidesFlowLeftToRight()
+    {
+        var (left, right) = TextDiffHighlighter.Compare("Hello there", "Hello world");
+
+        Assert.Equal(FlowDirection.LeftToRight, left.FlowDirection);
+        Assert.Equal(FlowDirection.LeftToRight, right.FlowDirection);
+    }
+
+    [Fact]
+    public void Compare_RightToLeftAgainstLeftToRight_EachSideFollowsItsOwnContent()
+    {
+        // An untranslated original next to a Persian translation: the two columns do not have
+        // to agree on a direction.
+        var (left, right) = TextDiffHighlighter.Compare("He goes home", PersianGoesHome);
+
+        Assert.Equal(FlowDirection.LeftToRight, left.FlowDirection);
+        Assert.Equal(FlowDirection.RightToLeft, right.FlowDirection);
+    }
+
+    [Fact]
+    public void CompareReplacement_RightToLeftText_BothSidesFlowRightToLeft()
+    {
+        var (before, after) = TextDiffHighlighter.CompareReplacement(PersianGoesHome, PersianWentHome);
+
+        Assert.Equal(FlowDirection.RightToLeft, before.FlowDirection);
+        Assert.Equal(FlowDirection.RightToLeft, after.FlowDirection);
+    }
+
+    [Fact]
+    public void Compare_RightToLeftText_DifferenceCoversTheWholeWord()
+    {
+        // The verbs share everything up to and including the "ر", so a character level diff
+        // splits the word: Avalonia shapes each run on its own and the halves fall back to
+        // isolated letter forms. The difference has to grow out to the word boundaries.
+        var (left, right) = TextDiffHighlighter.Compare(PersianGoesHome, PersianWentHome);
+
+        Assert.Equal(new[] { PersianCommonPart, PersianGoesVerb }, RunTexts(left.Inlines));
+        Assert.Equal(new[] { PersianCommonPart, PersianWentVerb }, RunTexts(right.Inlines));
+    }
+
+    [Fact]
+    public void Compare_RightToLeftText_NoRunEndsInsideAWord()
+    {
+        var (left, right) = TextDiffHighlighter.Compare(
+            "سلام دنیا، حال شما چطور است؟",
+            "سلام دنیای زیبا، حال شما چطور بود؟");
+
+        AssertNoRunSplitsAWord(left.Inlines);
+        AssertNoRunSplitsAWord(right.Inlines);
+    }
+
+    [Fact]
+    public void Compare_RightToLeftText_RunsStillCoverTheWholeText()
+    {
+        var (left, right) = TextDiffHighlighter.Compare(
+            "سلام دنیا، حال شما چطور است؟",
+            "سلام دنیای زیبا، حال شما چطور بود؟");
+
+        Assert.Equal("سلام دنیا، حال شما چطور است؟", JoinRuns(left.Inlines));
+        Assert.Equal("سلام دنیای زیبا، حال شما چطور بود؟", JoinRuns(right.Inlines));
+    }
+
+    [Fact]
+    public void Compare_LeftToRightText_KeepsCharacterLevelGranularity()
+    {
+        // Word snapping is only for cursive right to left scripts; Latin text keeps the finer
+        // "colo[u]r" style highlighting it has always had.
+        var (left, _) = TextDiffHighlighter.Compare("colour", "color");
+
+        Assert.Equal(new[] { "colo", "u", "r" }, RunTexts(left.Inlines));
+    }
+
+    private static void AssertNoRunSplitsAWord(InlineCollection? inlines)
+    {
+        var isWordChar = typeof(TextDiffHighlighter).GetMethod(
+            "IsWordChar", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        var runs = inlines!.Cast<Run>().Select(r => r.Text!).ToArray();
+        for (var i = 1; i < runs.Length; i++)
+        {
+            var lastOfPrevious = runs[i - 1][^1];
+            var firstOfCurrent = runs[i][0];
+            var splitsWord = (bool)isWordChar.Invoke(null, [lastOfPrevious])!
+                             && (bool)isWordChar.Invoke(null, [firstOfCurrent])!;
+
+            Assert.False(splitsWord,
+                $"Run boundary {i} splits a word: '{runs[i - 1]}' | '{runs[i]}'");
         }
     }
 }


### PR DESCRIPTION
Fixes #13435.

File → Compare had three separate defects, all still present in 5.2.0-beta9.

### 1. Right to left text read backwards

The compare view builds its text cells by hand and was the one text surface in the app that never set `FlowDirection` — the subtitle grid, Fix common errors and the image export all go through `TextToFlowDirectionConverter`.

With a left to right paragraph direction the diff chunks of a Persian line come out in scrambled visual order. Laying out `Run("او به خانه ") + Run("می‌رود")` and reading the shaped runs back in visual order:

| flow direction | visual order of shaped runs |
| --- | --- |
| `LeftToRight` | `[می][او به خانه ][ZWNJ][رود]` ❌ |
| `RightToLeft` | `[رود][ZWNJ][می][او به خانه ]` ✅ |

Same total width in both cases, so it is purely a reordering. Each side follows its own content, so a Persian translation still compares against a Latin original.

### 2. Words were cut in half

The diff works per character and Avalonia shapes every run on its own, so a difference boundary inside a word breaks the cursive joining and the two halves fall back to isolated letter forms. Measured: `سلام` shapes to **3 glyphs / 20.76 px** as one run, but **4 glyphs / 22.96 px** when split into `سل` + `ام`.

Differences now grow out to whole word boundaries before any run is emitted. Only for text holding right to left letters — Latin text keeps the finer `colo[u]r` granularity it has always had. Zero width non-joiners and Arabic diacritics count as part of the word they sit in.

### 3. Dark theme highlighting was unreadable

The three row colors were hardcoded light pastels used in both themes, leaving near-white rows under the dark theme's near-white text (the screenshot in the issue). They now have dark counterparts in the same family as `TextDiffHighlighter`'s run highlighting, and the color legend reads from the same source instead of repeating the literals.

The HTML export keeps the light palette whatever theme is active — the exported page is white with black text, so a dark row brush would export as a near-black cell. Export output in the light theme is unchanged.

### Also

Drops a dead `MakeSubtitlesView` overload in `CompareWindow` that only threw `NotImplementedException` while shadowing the real one.

### Testing

`dotnet test tests/UI/UITests.csproj` → 2279 passed, 0 failed. 12 new tests cover the flow direction of both sides (right to left, left to right, and mixed), that a difference covers the whole word, that no run boundary lands inside a word, that the runs still reproduce the input text, that Latin diffs keep character granularity, and that every theme's row brush exports as its light pastel.

The two shaping/ordering measurements above were taken with a throwaway headless probe reading `TextLayout.TextLines[0].TextRuns` back; not kept as a test since glyph counts and widths depend on the installed fonts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)