### PR TITLE
Honor SE proxy settings in downloads, update check, and cloud OCR

### DIFF
--- a/src/libuilogic/AutoTranslate/NoLanguageLeftBehindApi.cs
+++ b/src/libuilogic/AutoTranslate/NoLanguageLeftBehindApi.cs
@@ -25,7 +25,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
         public void Initialize()
         {
             _httpClient?.Dispose();
-            _httpClient = new HttpClient();
+            _httpClient = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
             // The endpoint is a relative URI against BaseAddress, and .NET drops the base's

--- a/src/libuilogic/AutoTranslate/NoLanguageLeftBehindServe.cs
+++ b/src/libuilogic/AutoTranslate/NoLanguageLeftBehindServe.cs
@@ -1,5 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.UiLogic.Http;
 using Nikse.SubtitleEdit.UiLogic.Translate;
 using System;
 using System.Collections.Generic;
@@ -25,7 +26,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
         public void Initialize()
         {
             _httpClient?.Dispose();
-            _httpClient = new HttpClient();
+            _httpClient = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
             // The endpoint is a relative URI against BaseAddress, and .NET drops the base's

--- a/src/libuilogic/Http/DownloaderFactory.cs
+++ b/src/libuilogic/Http/DownloaderFactory.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Net;
 using System.Net.Http;
 using Nikse.SubtitleEdit.Core.Common;
-using Nikse.SubtitleEdit.Core.Settings;
-using Nikse.SubtitleEdit.UiLogic.Http;
 
 namespace Nikse.SubtitleEdit.UiLogic.Http
 {
@@ -11,7 +8,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Http
     {
         public static IDownloader MakeHttpClient()
         {
-            var httpClient = new HttpClient(CreateHandler(Configuration.Settings.Proxy))
+            var httpClient = new HttpClient(HttpClientFactoryWithProxy.CreateHandler())
             {
                 Timeout = TimeSpan.FromMinutes(30) // 30 minutes for large downloads
             };
@@ -22,52 +19,6 @@ namespace Nikse.SubtitleEdit.UiLogic.Http
             }
 
             return new HttpClientDownloader(httpClient);
-        }
-
-        private static HttpClientHandler CreateHandler(ProxySettings proxySettings)
-        {
-            var handler = new HttpClientHandler();
-
-            if (string.IsNullOrEmpty(proxySettings.ProxyAddress))
-            {
-                // No proxy configured in SE - downloads still go through the system/environment
-                // proxy, so the loopback + bypass-list behavior must apply there too, same as
-                // HttpClientFactoryWithProxy.
-                var systemProxy = HttpClient.DefaultProxy;
-                if (systemProxy != null)
-                {
-                    handler.UseProxy = true;
-                    handler.Proxy = new BypassingWebProxy(systemProxy, proxySettings.BypassList);
-                }
-
-                if (proxySettings.UseDefaultCredentials)
-                {
-                    handler.Credentials = CredentialCache.DefaultNetworkCredentials;
-                }
-
-                return handler;
-            }
-
-            var proxy = new WebProxy(proxySettings.ProxyAddress);
-
-            if (!proxySettings.UseDefaultCredentials && !string.IsNullOrEmpty(proxySettings.UserName))
-            {
-                // Credentials go on the proxy itself, like in HttpClientFactoryWithProxy - a
-                // CredentialCache would need ProxySettings.AuthType, which nothing ever sets,
-                // and CredentialCache.Add throws on a null auth type.
-                proxy.Credentials = string.IsNullOrWhiteSpace(proxySettings.Domain)
-                    ? new NetworkCredential(proxySettings.UserName, proxySettings.DecodePassword())
-                    : new NetworkCredential(proxySettings.UserName, proxySettings.DecodePassword(), proxySettings.Domain);
-            }
-            else
-            {
-                proxy.UseDefaultCredentials = true;
-            }
-
-            handler.UseProxy = true;
-            handler.Proxy = new BypassingWebProxy(proxy, proxySettings.BypassList);
-
-            return handler;
         }
     }
 }

--- a/src/libuilogic/Http/HttpClientFactoryWithProxy.cs
+++ b/src/libuilogic/Http/HttpClientFactoryWithProxy.cs
@@ -2,6 +2,7 @@ using System.Net.Http;
 using System.Net;
 
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Settings;
 
 namespace Nikse.SubtitleEdit.UiLogic.Http
 {
@@ -9,37 +10,47 @@ namespace Nikse.SubtitleEdit.UiLogic.Http
     {
         public static HttpClient CreateHttpClientWithProxy()
         {
-            var proxySettings = Configuration.Settings.Proxy;
-            var proxyAddress = proxySettings.ProxyAddress;
-            if (string.IsNullOrEmpty(proxyAddress))
+            return new HttpClient(CreateHandler());
+        }
+
+        public static HttpClientHandler CreateHandler()
+        {
+            return CreateHandler(Configuration.Settings.Proxy);
+        }
+
+        public static HttpClientHandler CreateHandler(ProxySettings proxySettings)
+        {
+            var handler = new HttpClientHandler();
+
+            if (string.IsNullOrEmpty(proxySettings.ProxyAddress))
             {
+                // No proxy configured in SE - requests still go through the system/environment
+                // proxy, so the loopback + bypass-list behavior must apply there too.
                 var systemProxy = HttpClient.DefaultProxy;
-                if (systemProxy == null)
+                if (systemProxy != null)
                 {
-                    return new HttpClient();
+                    handler.UseProxy = true;
+                    handler.Proxy = new BypassingWebProxy(systemProxy, proxySettings.BypassList);
                 }
 
-                var defaultHandler = new HttpClientHandler
+                if (proxySettings.UseDefaultCredentials)
                 {
-                    UseProxy = true,
-                    Proxy = new BypassingWebProxy(systemProxy, proxySettings.BypassList),
-                };
+                    handler.Credentials = CredentialCache.DefaultNetworkCredentials;
+                }
 
-                return new HttpClient(defaultHandler);
+                return handler;
             }
 
-            var handler = new HttpClientHandler();
-            var proxy = new WebProxy(proxyAddress);
+            var proxy = new WebProxy(proxySettings.ProxyAddress);
 
-            var userName = proxySettings.UserName;
-            var password = proxySettings.DecodePassword();
-            var domain = proxySettings.Domain;
-
-            if (!proxySettings.UseDefaultCredentials && !string.IsNullOrEmpty(userName))
+            if (!proxySettings.UseDefaultCredentials && !string.IsNullOrEmpty(proxySettings.UserName))
             {
-                proxy.Credentials = string.IsNullOrEmpty(domain)
-                    ? new NetworkCredential(userName, password)
-                    : new NetworkCredential(userName, password, domain);
+                // Credentials go on the proxy itself - a CredentialCache would need
+                // ProxySettings.AuthType, which nothing ever sets, and
+                // CredentialCache.Add throws on a null auth type.
+                proxy.Credentials = string.IsNullOrWhiteSpace(proxySettings.Domain)
+                    ? new NetworkCredential(proxySettings.UserName, proxySettings.DecodePassword())
+                    : new NetworkCredential(proxySettings.UserName, proxySettings.DecodePassword(), proxySettings.Domain);
             }
             else
             {
@@ -49,7 +60,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Http
             handler.UseProxy = true;
             handler.Proxy = new BypassingWebProxy(proxy, proxySettings.BypassList);
 
-            return new HttpClient(handler);
+            return handler;
         }
     }
 }

--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -176,6 +176,7 @@ using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.Logic.Initializers;
 using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.Logic.Plugins;
+using Nikse.SubtitleEdit.UiLogic.Http;
 using Nikse.SubtitleEdit.UiLogic.Ocr;
 using Nikse.SubtitleEdit.Logic.Ocr;
 using Nikse.SubtitleEdit.Logic.Ocr.GoogleLens;
@@ -226,7 +227,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<ICasingToggler, CasingToggler>();
         collection.AddTransient<IChatLlmDownloadService, ChatLlmDownloadService>();
         collection.AddTransient<IColorService, ColorService>();
-        collection.AddHttpClient<ICrispAsrDownloadService, CrispAsrDownloadService>();
+        collection.AddHttpClientWithProxy<ICrispAsrDownloadService, CrispAsrDownloadService>();
         collection.AddTransient<IDictionaryInitializer, DictionaryInitializer>();
         collection.AddTransient<IFindService, FindService>();
         collection.AddTransient<IFontNameService, FontNameService>();
@@ -256,32 +257,32 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<IZipUnpacker, ZipUnpacker>();
 
         // Download services
-        collection.AddHttpClient<IFfmpegDownloadService, FfmpegDownloadService>();
-        collection.AddHttpClient<ILibMpvDownloadService, LibMpvDownloadService>();
-        collection.AddHttpClient<ILibVlcDownloadService, LibVlcDownloadService>();
-        collection.AddHttpClient<IPaddleOcrDownloadService, PaddleOcrDownloadService>();
-        collection.AddHttpClient<ICrispEmbedDownloadService, CrispEmbedDownloadService>();
-        collection.AddHttpClient<ISpellCheckDictionaryDownloadService, SpellCheckDictionaryDownloadService>();
-        collection.AddHttpClient<ITesseractDownloadService, TesseractDownloadService>();
-        collection.AddHttpClient<IWhisperDownloadService, WhisperDownloadService>();
-        collection.AddHttpClient<IYtDlpDownloadService, YtDlpDownloadService>();
-        collection.AddHttpClient<IUpdateCheckService, UpdateCheckService>();
-        collection.AddHttpClient<ILlamaCppDownloadService, LlamaCppDownloadService>();
-        collection.AddHttpClient<IQwen3AsrCppDownloadService, Qwen3AsrCppDownloadService>();
-        collection.AddHttpClient<IQwen3TtsCppDownloadService, Qwen3TtsCppDownloadService>();
-        collection.AddHttpClient<IQwen3TtsCrispAsrDownloadService, Qwen3TtsCrispAsrDownloadService>();
-        collection.AddHttpClient<IVibeVoiceCrispAsrDownloadService, VibeVoiceCrispAsrDownloadService>();
-        collection.AddHttpClient<IIndexTtsCrispAsrDownloadService, IndexTtsCrispAsrDownloadService>();
-        collection.AddHttpClient<ICosyVoice3CrispAsrDownloadService, CosyVoice3CrispAsrDownloadService>();
-        collection.AddHttpClient<IF5TtsCrispAsrDownloadService, F5TtsCrispAsrDownloadService>();
-        collection.AddHttpClient<IOmniVoiceCrispAsrDownloadService, OmniVoiceCrispAsrDownloadService>();
-        collection.AddHttpClient<IVoxCPM2CrispAsrDownloadService, VoxCPM2CrispAsrDownloadService>();
-        collection.AddHttpClient<IMossTtsCrispAsrDownloadService, MossTtsCrispAsrDownloadService>();
-        collection.AddHttpClient<IZonosTtsCrispAsrDownloadService, ZonosTtsCrispAsrDownloadService>();
-        collection.AddHttpClient<IKokoroTtsCppDownloadService, KokoroTtsCppDownloadService>();
-        collection.AddHttpClient<IChatterboxTtsCppDownloadService, ChatterboxTtsCppDownloadService>();
-        collection.AddHttpClient<IOmniVoiceDownloadService, OmniVoiceDownloadService>();
-        collection.AddHttpClient<IPluginDownloadService, PluginDownloadService>();
+        collection.AddHttpClientWithProxy<IFfmpegDownloadService, FfmpegDownloadService>();
+        collection.AddHttpClientWithProxy<ILibMpvDownloadService, LibMpvDownloadService>();
+        collection.AddHttpClientWithProxy<ILibVlcDownloadService, LibVlcDownloadService>();
+        collection.AddHttpClientWithProxy<IPaddleOcrDownloadService, PaddleOcrDownloadService>();
+        collection.AddHttpClientWithProxy<ICrispEmbedDownloadService, CrispEmbedDownloadService>();
+        collection.AddHttpClientWithProxy<ISpellCheckDictionaryDownloadService, SpellCheckDictionaryDownloadService>();
+        collection.AddHttpClientWithProxy<ITesseractDownloadService, TesseractDownloadService>();
+        collection.AddHttpClientWithProxy<IWhisperDownloadService, WhisperDownloadService>();
+        collection.AddHttpClientWithProxy<IYtDlpDownloadService, YtDlpDownloadService>();
+        collection.AddHttpClientWithProxy<IUpdateCheckService, UpdateCheckService>();
+        collection.AddHttpClientWithProxy<ILlamaCppDownloadService, LlamaCppDownloadService>();
+        collection.AddHttpClientWithProxy<IQwen3AsrCppDownloadService, Qwen3AsrCppDownloadService>();
+        collection.AddHttpClientWithProxy<IQwen3TtsCppDownloadService, Qwen3TtsCppDownloadService>();
+        collection.AddHttpClientWithProxy<IQwen3TtsCrispAsrDownloadService, Qwen3TtsCrispAsrDownloadService>();
+        collection.AddHttpClientWithProxy<IVibeVoiceCrispAsrDownloadService, VibeVoiceCrispAsrDownloadService>();
+        collection.AddHttpClientWithProxy<IIndexTtsCrispAsrDownloadService, IndexTtsCrispAsrDownloadService>();
+        collection.AddHttpClientWithProxy<ICosyVoice3CrispAsrDownloadService, CosyVoice3CrispAsrDownloadService>();
+        collection.AddHttpClientWithProxy<IF5TtsCrispAsrDownloadService, F5TtsCrispAsrDownloadService>();
+        collection.AddHttpClientWithProxy<IOmniVoiceCrispAsrDownloadService, OmniVoiceCrispAsrDownloadService>();
+        collection.AddHttpClientWithProxy<IVoxCPM2CrispAsrDownloadService, VoxCPM2CrispAsrDownloadService>();
+        collection.AddHttpClientWithProxy<IMossTtsCrispAsrDownloadService, MossTtsCrispAsrDownloadService>();
+        collection.AddHttpClientWithProxy<IZonosTtsCrispAsrDownloadService, ZonosTtsCrispAsrDownloadService>();
+        collection.AddHttpClientWithProxy<IKokoroTtsCppDownloadService, KokoroTtsCppDownloadService>();
+        collection.AddHttpClientWithProxy<IChatterboxTtsCppDownloadService, ChatterboxTtsCppDownloadService>();
+        collection.AddHttpClientWithProxy<IOmniVoiceDownloadService, OmniVoiceDownloadService>();
+        collection.AddHttpClientWithProxy<IPluginDownloadService, PluginDownloadService>();
 
         // Window view models
         collection.AddTransient<AdvancedTtsSettingsViewModel>();
@@ -548,5 +549,18 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<SpeechToTextAdvancedViewModel>();
         collection.AddTransient<SpeechToTextPostProcessingViewModel>();
         collection.AddTransient<WordListsViewModel>();
+    }
+
+    /// <summary>
+    /// Like AddHttpClient, but the client honors the proxy configured in SE's settings
+    /// (plus the loopback/bypass-list rules) - the default handler only picks up the
+    /// system/environment proxy, so a proxy entered in SE's own settings was ignored.
+    /// </summary>
+    private static void AddHttpClientWithProxy<TClient, TImplementation>(this IServiceCollection collection)
+        where TClient : class
+        where TImplementation : class, TClient
+    {
+        collection.AddHttpClient<TClient, TImplementation>()
+            .ConfigurePrimaryHttpMessageHandler(() => HttpClientFactoryWithProxy.CreateHandler());
     }
 }

--- a/src/ui/Features/Ocr/Download/DownloadPaddleOcrViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadPaddleOcrViewModel.cs
@@ -7,6 +7,7 @@ using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.Logic.SevenZipExtractor;
+using Nikse.SubtitleEdit.UiLogic.Http;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -97,7 +98,7 @@ public partial class DownloadPaddleOcrViewModel : ObservableObject, IClosingClea
                         ProgressText = $"Starting download {_downloadTaskIndex + 1} of {_downloadTaskUrls.Count}...";
                         var url = _downloadTaskUrls[_downloadTaskIndex];
                         var fileName = Path.Combine(_tempFolder, Path.GetFileName(url));
-                        _downloadTask = DownloadHelper.DownloadFileAsync(new HttpClient(), url, fileName, new Progress<float>(number =>
+                        _downloadTask = DownloadHelper.DownloadFileAsync(HttpClientFactoryWithProxy.CreateHttpClientWithProxy(), url, fileName, new Progress<float>(number =>
                         {
                             var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
                             var pctString = percentage.ToString(CultureInfo.InvariantCulture);
@@ -280,28 +281,28 @@ public partial class DownloadPaddleOcrViewModel : ObservableObject, IClosingClea
             _downloadTaskUrls.AddRange(PaddleOcr.UrlsSupportFiles);
             var url = _downloadTaskUrls[_downloadTaskIndex];
             var fileName = Path.Combine(_tempFolder, Path.GetFileName(url));
-            _downloadTask = DownloadHelper.DownloadFileAsync(new HttpClient(), url, fileName, downloadProgress, _cancellationTokenSource.Token);
+            _downloadTask = DownloadHelper.DownloadFileAsync(HttpClientFactoryWithProxy.CreateHttpClientWithProxy(), url, fileName, downloadProgress, _cancellationTokenSource.Token);
         }
         else if (_downloadType == PaddleOcrDownloadType.EngineGpu11)
         {
             _downloadTaskUrls.AddRange(PaddleOcr.UrlsWindowsGpuCuda11);
             var url = _downloadTaskUrls[_downloadTaskIndex];
             var fileName = Path.Combine(_tempFolder, Path.GetFileName(url));
-            _downloadTask = DownloadHelper.DownloadFileAsync(new HttpClient(), url, fileName, downloadProgress, _cancellationTokenSource.Token);
+            _downloadTask = DownloadHelper.DownloadFileAsync(HttpClientFactoryWithProxy.CreateHttpClientWithProxy(), url, fileName, downloadProgress, _cancellationTokenSource.Token);
         }
         else if (_downloadType == PaddleOcrDownloadType.EngineGpu12)
         {
             _downloadTaskUrls.AddRange(PaddleOcr.UrlsWindowsGpuCuda12);
             var url = _downloadTaskUrls[_downloadTaskIndex];
             var fileName = Path.Combine(_tempFolder, Path.GetFileName(url));
-            _downloadTask = DownloadHelper.DownloadFileAsync(new HttpClient(), url, fileName, downloadProgress, _cancellationTokenSource.Token);
+            _downloadTask = DownloadHelper.DownloadFileAsync(HttpClientFactoryWithProxy.CreateHttpClientWithProxy(), url, fileName, downloadProgress, _cancellationTokenSource.Token);
         }
         else if (_downloadType == PaddleOcrDownloadType.EngineCpu)
         {
             _downloadTaskUrls.AddRange(PaddleOcr.UrlsWindowsCpu);
             var url = _downloadTaskUrls[_downloadTaskIndex];
             var fileName = Path.Combine(_tempFolder, Path.GetFileName(url));
-            _downloadTask = DownloadHelper.DownloadFileAsync(new HttpClient(), url, fileName, downloadProgress,
+            _downloadTask = DownloadHelper.DownloadFileAsync(HttpClientFactoryWithProxy.CreateHttpClientWithProxy(), url, fileName, downloadProgress,
                 _cancellationTokenSource.Token);
         }
         else if (_downloadType == PaddleOcrDownloadType.EngineGpuLinux)
@@ -309,14 +310,14 @@ public partial class DownloadPaddleOcrViewModel : ObservableObject, IClosingClea
             _downloadTaskUrls.AddRange(PaddleOcr.UrlsLinuxGpu);
             var url = _downloadTaskUrls[_downloadTaskIndex];
             var fileName = Path.Combine(_tempFolder, Path.GetFileName(url));
-            _downloadTask = DownloadHelper.DownloadFileAsync(new HttpClient(), url, fileName, downloadProgress, _cancellationTokenSource.Token);
+            _downloadTask = DownloadHelper.DownloadFileAsync(HttpClientFactoryWithProxy.CreateHttpClientWithProxy(), url, fileName, downloadProgress, _cancellationTokenSource.Token);
         }            
         else if (_downloadType == PaddleOcrDownloadType.EngineCpuLinux)
         {
             _downloadTaskUrls.AddRange(PaddleOcr.UrlsLinuxCpu);
             var url = _downloadTaskUrls[_downloadTaskIndex];
             var fileName = Path.Combine(_tempFolder, Path.GetFileName(url));
-            _downloadTask = DownloadHelper.DownloadFileAsync(new HttpClient(), url, fileName, downloadProgress, _cancellationTokenSource.Token);
+            _downloadTask = DownloadHelper.DownloadFileAsync(HttpClientFactoryWithProxy.CreateHttpClientWithProxy(), url, fileName, downloadProgress, _cancellationTokenSource.Token);
         }         
         else
         {

--- a/src/ui/Features/Ocr/Engines/GlmOcr.cs
+++ b/src/ui/Features/Ocr/Engines/GlmOcr.cs
@@ -1,6 +1,7 @@
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.UiLogic.Http;
 using SkiaSharp;
 using System;
 using System.IO;
@@ -28,7 +29,7 @@ public class GlmOcr
     public GlmOcr(string apiKey, int timeoutMinutes = 5)
     {
         Error = string.Empty;
-        _httpClient = new HttpClient();
+        _httpClient = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
         _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
         if (!string.IsNullOrWhiteSpace(apiKey))
         {

--- a/src/ui/Features/Ocr/Engines/GoogleVisionOcr.cs
+++ b/src/ui/Features/Ocr/Engines/GoogleVisionOcr.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.UiLogic.Http;
 using Nikse.SubtitleEdit.UiLogic.Ocr;
 using Nikse.SubtitleEdit.UiLogic.Ocr.Service;
 using Nikse.SubtitleEdit.Logic;
@@ -26,7 +27,7 @@ public class GoogleVisionOcr
 
     public GoogleVisionOcr()
     {
-        _httpClient = new HttpClient();
+        _httpClient = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
         _httpClient.BaseAddress = new Uri("https://vision.googleapis.com/v1/images:annotate");
         _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
     }

--- a/src/ui/Features/Ocr/Engines/MistralOcr.cs
+++ b/src/ui/Features/Ocr/Engines/MistralOcr.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Nikse.SubtitleEdit.UiLogic.Http;
+using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -21,7 +22,7 @@ public class MistralOcr
     {
         Error = string.Empty;
         _apiKey = apiKey ?? throw new ArgumentNullException(nameof(apiKey));
-        _httpClient = new HttpClient();
+        _httpClient = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
         _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
         _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
         _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);

--- a/src/ui/Logic/Ocr/GoogleLens/Core.cs
+++ b/src/ui/Logic/Ocr/GoogleLens/Core.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json.Linq;
+using Nikse.SubtitleEdit.UiLogic.Http;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
@@ -391,7 +392,7 @@ public class Core
 
     private async Task<HttpResponseMessage> DefaultFetchAsync(HttpRequestMessage request)
     {
-        using var client = new HttpClient();
+        using var client = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
         return await client.SendAsync(request);
     }
     

--- a/src/ui/Logic/Ocr/GoogleLens/LensCore.cs
+++ b/src/ui/Logic/Ocr/GoogleLens/LensCore.cs
@@ -1,4 +1,5 @@
 using Nikse.SubtitleEdit.Logic.Ocr.GoogleLens.Proto;
+using Nikse.SubtitleEdit.UiLogic.Http;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,10 +21,8 @@ public class LensCore
 
     static LensCore()
     {
-        var handler = new HttpClientHandler
-        {
-            AutomaticDecompression = System.Net.DecompressionMethods.All
-        };
+        var handler = HttpClientFactoryWithProxy.CreateHandler();
+        handler.AutomaticDecompression = System.Net.DecompressionMethods.All;
 
         _sharedHttpClient = new HttpClient(handler)
         {

--- a/tests/libuilogic/Http/HttpClientFactoryWithProxyTests.cs
+++ b/tests/libuilogic/Http/HttpClientFactoryWithProxyTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Net;
+using Nikse.SubtitleEdit.Core.Settings;
+using Nikse.SubtitleEdit.UiLogic.Http;
+
+namespace LibUiLogicTests.Http;
+
+public class HttpClientFactoryWithProxyTests
+{
+    [Fact]
+    public void CreateHandler_WithProxyAddress_RoutesRemoteHostsThroughProxy()
+    {
+        var handler = HttpClientFactoryWithProxy.CreateHandler(new ProxySettings
+        {
+            ProxyAddress = "192.168.123.99:3128",
+        });
+
+        Assert.True(handler.UseProxy);
+        Assert.NotNull(handler.Proxy);
+        var proxyUri = handler.Proxy!.GetProxy(new Uri("https://github.com/"));
+        Assert.Equal(new Uri("http://192.168.123.99:3128"), proxyUri);
+    }
+
+    [Fact]
+    public void CreateHandler_WithProxyAddress_BypassesLoopback()
+    {
+        var handler = HttpClientFactoryWithProxy.CreateHandler(new ProxySettings
+        {
+            ProxyAddress = "http://192.168.123.99:3128",
+        });
+
+        Assert.True(handler.Proxy!.IsBypassed(new Uri("http://localhost:11434/")));
+        Assert.True(handler.Proxy!.IsBypassed(new Uri("http://127.0.0.1:8080/")));
+        Assert.False(handler.Proxy!.IsBypassed(new Uri("https://github.com/")));
+    }
+
+    [Fact]
+    public void CreateHandler_WithBypassList_BypassesListedHostsAndSubdomains()
+    {
+        var handler = HttpClientFactoryWithProxy.CreateHandler(new ProxySettings
+        {
+            ProxyAddress = "http://192.168.123.99:3128",
+            BypassList = "*.example.com; internal.local",
+        });
+
+        Assert.True(handler.Proxy!.IsBypassed(new Uri("https://example.com/")));
+        Assert.True(handler.Proxy!.IsBypassed(new Uri("https://sub.example.com/")));
+        Assert.True(handler.Proxy!.IsBypassed(new Uri("https://internal.local/")));
+        Assert.False(handler.Proxy!.IsBypassed(new Uri("https://github.com/")));
+    }
+
+    [Fact]
+    public void CreateHandler_WithUserNameAndPassword_SetsProxyCredentials()
+    {
+        var settings = new ProxySettings
+        {
+            ProxyAddress = "http://192.168.123.99:3128",
+            UserName = "user",
+            UseDefaultCredentials = false,
+        };
+        settings.EncodePassword("secret");
+
+        var handler = HttpClientFactoryWithProxy.CreateHandler(settings);
+
+        var credentials = handler.Proxy!.Credentials as NetworkCredential;
+        Assert.NotNull(credentials);
+        Assert.Equal("user", credentials!.UserName);
+        Assert.Equal("secret", credentials.Password);
+    }
+
+    [Fact]
+    public void CreateHandler_NoProxyAddress_StillAppliesBypassListToSystemProxy()
+    {
+        var handler = HttpClientFactoryWithProxy.CreateHandler(new ProxySettings
+        {
+            ProxyAddress = string.Empty,
+            BypassList = "example.com",
+        });
+
+        // System proxy present or not, the wrapping proxy must bypass loopback and listed hosts.
+        Assert.True(handler.UseProxy);
+        Assert.NotNull(handler.Proxy);
+        Assert.True(handler.Proxy!.IsBypassed(new Uri("http://localhost:9000/")));
+        Assert.True(handler.Proxy!.IsBypassed(new Uri("https://example.com/")));
+    }
+}


### PR DESCRIPTION
## Problem

A proxy configured in SE's own settings (Options → Settings → Proxy) was only honored by the auto-translate engines and the `DownloaderFactory` path. Everything else created default `HttpClient`s that only pick up the system/environment proxy:

- the ~27 typed `AddHttpClient` download services (ffmpeg, libmpv, Whisper, Tesseract, all TTS/ASR model downloads, spell-check dictionaries, plugins, yt-dlp) — **including the update check**
- the PaddleOCR model download view model (7 bare clients)
- the cloud OCR engines: Google Vision, Mistral, GLM, Google Lens
- the NLLB API/serve translate engines

On a network where traffic must go through the configured proxy (reported by a user running the Synology DSM proxy, which works fine in SE 4.0.16), these requests just time out.

## Fix

- Extract handler construction into `HttpClientFactoryWithProxy.CreateHandler()` — unified with the `DownloaderFactory` variant, which was a superset (it also applied default credentials in the no-address case) — and reuse it from `DownloaderFactory`.
- Register all typed HttpClients via a new `AddHttpClientWithProxy` helper that plugs the handler in with `ConfigurePrimaryHttpMessageHandler`.
- Switch the bare `new HttpClient()` call sites for non-local services to the factory. Local engines (Ollama, llama.cpp, CrispEmbed) are untouched, and loopback plus bypass-list hosts still connect directly via `BypassingWebProxy` in any case.

## Tests

New `HttpClientFactoryWithProxyTests` covering: scheme-less `host:port` proxy address resolves to `http://host:port`, loopback always bypassed, bypass list incl. subdomains, proxy credentials, and bypass rules applying when only a system proxy is in play. Full LibUiLogicTests suite passes (178/178); UI and seconv build clean.

Note: `IHttpClientFactory` caches primary handlers for ~2 minutes, so a proxy change in settings takes effect on the next handler rotation (or restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)