### PR TITLE
Rewrite CountWords: single-pass tag skipping + word-boundary fixes

### DIFF
--- a/src/libse/Common/StringExtensions.cs
+++ b/src/libse/Common/StringExtensions.cs
@@ -182,26 +182,59 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public static int CountWords(this string source)
         {
-            // Called per line on grid repaints (words-per-minute) - count boundaries directly
-            // instead of allocating a separator array plus one substring per word.
-            var text = HtmlUtil.RemoveHtmlTags(source, true);
             var count = 0;
-            var inWord = false;
-            for (var i = 0; i < text.Length; i++)
+            var l = 0;
+            var len = source.Length;
+            for (int r = 0; r < len; r++)
             {
-                var ch = text[i];
-                if (ch == ' ' || ch == '\n' || ch == '\r')
+                if (source[r] == '<' || source[r] == '{')
                 {
-                    inWord = false;
+                    if (CountWord(source, l, r))
+                    {
+                        count++;
+                    }
+
+                    l = r;
                 }
-                else if (!inWord)
+                else if ((source[r] == '>' && source[l] == '<') || (source[r] == '}' && source[l] == '{'))
                 {
-                    inWord = true;
-                    count++;
+                    l = r + 1;
+                }
+                else if (!(source[l] == '<' || source[l] == '{') &&
+                         (source[r] == ' ' || source[r] == '\n' || source[r] == '\r' || source[r] == '\t'))
+                {
+                    if (CountWord(source, l, r))
+                    {
+                        count++;
+                    }
+
+                    l = r + 1;
                 }
             }
 
+            // last word runs to the end of the string; skip if inside an unclosed tag
+            if (l < len && source[l] != '<' && source[l] != '{' && CountWord(source, l, len))
+            {
+                count++;
+            }
+
             return count;
+
+            static bool CountWord(string source, int l, int r)
+            {
+                // for things like: "Foo  bar"
+                if (r - l > 1 && !(source[l] == '\n' || source[l] == '\r' || source[l] == '\t' || source[l] == ' '))
+                {
+                    return true;
+                }
+
+                if (r - l == 1 && char.IsLetterOrDigit(source[l])) // we dont want to count symbols like dash etc
+                {
+                    return true;
+                }
+
+                return false;
+            }
         }
 
         // http://www.codeproject.com/Articles/43726/Optimizing-string-operations-in-C

--- a/tests/libse/Core/StringExtensionsTest.cs
+++ b/tests/libse/Core/StringExtensionsTest.cs
@@ -461,4 +461,25 @@ public class StringExtensionsTest
         Assert.True("foobar;".HasSentenceEnding(greekCultureTwoLetter));
     }
 
+    [Theory]
+    [InlineData("", 0)]
+    [InlineData("Hello there, how are you?", 5)]
+    [InlineData("<i>Hello there,</i> how are you?", 5)]
+    [InlineData("{\\an8}Hello there, how are you?", 5)]
+    [InlineData("Hello there,\r\nhow are you today my friend?", 8)]
+    [InlineData("Foo  bar", 2)]
+    [InlineData("foo\tbar\tbaz", 3)]
+    [InlineData("foo - bar", 2)] // a lone dash is not a word
+    [InlineData("<i></i>", 0)]
+    [InlineData("{\\i1}{\\i0}", 0)]
+    [InlineData("<font color=\"red\">Wow!</font> {\\i1}nice{\\i0} one", 3)]
+    [InlineData("Word", 1)]
+    [InlineData("I", 1)]
+    [InlineData("Chapter 5", 2)] // single-character word at end of string
+    [InlineData("foo -", 1)]
+    public void CountWordsTest(string input, int expected)
+    {
+        Assert.Equal(expected, input.CountWords());
+    }
+
 }


### PR DESCRIPTION
## Summary

- Rewrite `StringExtensions.CountWords` as a single pass over the source string that skips `<...>` and `{...}` tag blocks inline, instead of allocating an intermediate string via `HtmlUtil.RemoveHtmlTags`.
- Tabs (`\t`) now act as word separators (previously `"foo\tbar\tbaz"` counted as 1 word).
- Single-character non-alphanumeric tokens are no longer counted as words (`"foo - bar"` now counts 2 words instead of 3), which better reflects words-per-minute.
- Adds unit tests covering plain text, HTML/ASSA tags, multi-line, tabs, double spaces, lone symbols, empty/unclosed tags, and single-character words at end of string.

## Behavior differences vs. old implementation

| Input | Old | New | Note |
|---|---:|---:|---|
| `foo - bar` | 3 | 2 | lone dash no longer counted as a word |
| `foo\tbar\tbaz` | 1 | 3 | tab now treated as a word separator |

All other checked cases agree (plain text, `<i>` tags, `{\an8}` tags, multi-line `\r\n`, double spaces, empty string, tag-only strings, mixed `<font>`/`{\i1}` tags, single-character words like `"I"` and `"Chapter 5"`).

## Benchmarks

BenchmarkDotNet v0.14.0, ShortRunJob, .NET 10.0.10, i7-13700, `[MemoryDiagnoser]`. Old = previous `HtmlUtil.RemoveHtmlTags`-based implementation (baseline), New = this PR.

| Case | Old mean | New mean | Ratio | Old alloc | New alloc |
|---|---:|---:|---:|---:|---:|
| ASSA tag `{\an8}...` (5 words) | 97.2 ns | 56.4 ns | 0.58 | 72 B | 0 B |
| HTML tag `<i>...</i>` (5 words) | 114.9 ns | 52.4 ns | 0.46 | 72 B | 0 B |
| plain short (5 words) | 30.5 ns | 27.9 ns | 0.92 | 0 B | 0 B |
| two-line `\r\n` (8 words) | 53.9 ns | 73.7 ns | 1.37 | 0 B | 0 B |
| long line, no tags (26 words) | 165.8 ns | 240.8 ns | 1.45 | 0 B | 0 B |

Tagged lines are roughly twice as fast and allocation-free. Untagged multi-word lines (where `RemoveHtmlTags` already had a no-tag fast path) are somewhat slower, still in the tens-of-nanoseconds range per line.

## Test plan

- [x] `dotnet test tests/libse/LibSETests.csproj` passes (999 tests, verified locally)
- [x] `dotnet test tests/UI/UITests.csproj --filter "FullyQualifiedName~SubtitleLineViewModel"` passes (28 tests, verified locally)
- [x] Open a subtitle with italic/ASSA-tagged lines and confirm the words-per-minute column shows sane values
- [ ] Check Statistics window total word count on a file containing dashes and dialog lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
