### PR TITLE
Fix #13405: reclaim keyboard focus stolen from an open modal dialog

### DIFF
--- a/src/ui/Logic/WindowsService.cs
+++ b/src/ui/Logic/WindowsService.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using Microsoft.Extensions.DependencyInjection;
 using Nikse.SubtitleEdit.Features.Main.MainHelpers;
 using Nikse.SubtitleEdit.Features.Options.Settings;
@@ -371,6 +376,7 @@ namespace Nikse.SubtitleEdit.Logic
         internal static void ResetOpenModalsForTests()
         {
             _openModalCount = 0;
+            _modalFrames.Clear();
         }
 
         /// <summary>
@@ -386,10 +392,23 @@ namespace Nikse.SubtitleEdit.Logic
         /// owner.IsActive guard scopes this to the unambiguously broken state - it never yanks
         /// foreground from other applications or from the (independent, enabled) undocked tool
         /// windows.
+        ///
+        /// OS activation is only half of the invariant. Avalonia routes every key press to its
+        /// single app-global focused element, no matter which window the OS delivered the key to
+        /// (KeyboardDevice.ProcessRawEvent). So a deferred Focus() call into the owner - the menu
+        /// bar's post-close focus restore, a posted grid-focus after an edit - lands after the
+        /// dialog opened and silently re-routes the keyboard into the disabled owner while the
+        /// dialog stays OS-active with an active-looking title bar: Esc is dead and Tab visibly
+        /// walks the window underneath, with no hint at all (#13405 beta-9 feedback). Activation
+        /// events never fire for this state, so it is also enforced directly: focus landing on the
+        /// owner while the dialog is open is handed straight back to the dialog, and the key that
+        /// slipped through is swallowed rather than delivered to the input-disabled owner.
         /// </summary>
         private static IDisposable EnforceModalForegroundWhileOpen(Window dialog, Window owner)
         {
             var disposed = false;
+            var frame = new ModalFrame(dialog, owner);
+            _modalFrames.Add(frame);
 
             void BounceToDialog()
             {
@@ -426,17 +445,155 @@ namespace Nikse.SubtitleEdit.Logic
                 DispatcherTimer.RunOnce(BounceToDialog, TimeSpan.FromMilliseconds(450));
             }
 
+            void OnDialogGotFocus(object? sender, FocusChangedEventArgs e)
+            {
+                // Remember where the keyboard focus lives inside the dialog, so a reclaim can
+                // put it back exactly where it was instead of on the first focusable control.
+                if (e.Source is InputElement element && element != dialog &&
+                    TopLevel.GetTopLevel(element) == dialog)
+                {
+                    frame.LastDialogFocus = element;
+                }
+            }
+
+            void OnOwnerGotFocus(object? sender, FocusChangedEventArgs e)
+            {
+                if (disposed || !dialog.IsVisible || dialog.IsClosing())
+                {
+                    return; // before open / during close, focus in the owner is legitimate
+                }
+
+                // Deferred so an immediately-following focus change (the dialog taking focus
+                // itself) wins without a fight; the reclaim re-checks the state when it runs.
+                Dispatcher.UIThread.Post(ReclaimKeyboardFocusFromDisabledOwner, DispatcherPriority.Background);
+            }
+
+            void OnOwnerKeyInput(object? sender, RoutedEventArgs e)
+            {
+                if (disposed || !dialog.IsVisible || dialog.IsClosing())
+                {
+                    return;
+                }
+
+                // A key reaching the input-disabled owner is always wrong - swallow it (better a
+                // dead keystroke than one editing the subtitle underneath the dialog) and repair.
+                e.Handled = true;
+                Dispatcher.UIThread.Post(ReclaimKeyboardFocusFromDisabledOwner, DispatcherPriority.Background);
+            }
+
             owner.Activated += OnActivationChanged;
             dialog.Deactivated += OnActivationChanged;
             dialog.Opened += OnOpened;
+            // handledEventsToo: a control marking GotFocus handled must not hide the steal.
+            dialog.AddHandler(InputElement.GotFocusEvent, OnDialogGotFocus, RoutingStrategies.Bubble, handledEventsToo: true);
+            owner.AddHandler(InputElement.GotFocusEvent, OnOwnerGotFocus, RoutingStrategies.Bubble, handledEventsToo: true);
+            // Tunnel: run before the owner's own handlers (shortcut manager, text boxes) see the key.
+            owner.AddHandler(InputElement.KeyDownEvent, OnOwnerKeyInput, RoutingStrategies.Tunnel);
+            owner.AddHandler(InputElement.TextInputEvent, OnOwnerKeyInput, RoutingStrategies.Tunnel);
 
             return new ActionDisposable(() =>
             {
                 disposed = true;
+                _modalFrames.Remove(frame);
                 owner.Activated -= OnActivationChanged;
                 dialog.Deactivated -= OnActivationChanged;
                 dialog.Opened -= OnOpened;
+                dialog.RemoveHandler(InputElement.GotFocusEvent, OnDialogGotFocus);
+                owner.RemoveHandler(InputElement.GotFocusEvent, OnOwnerGotFocus);
+                owner.RemoveHandler(InputElement.KeyDownEvent, OnOwnerKeyInput);
+                owner.RemoveHandler(InputElement.TextInputEvent, OnOwnerKeyInput);
             });
+        }
+
+        // The open modals in open order - the last entry is the top-most dialog, the only window
+        // that may hold keyboard focus. The owners in this list (which include the lower dialogs
+        // of a nested chain) are exactly the input-disabled windows; independent enabled windows
+        // (undocked video player / audio visualizer) are never in it.
+        private static readonly List<ModalFrame> _modalFrames = new();
+
+        private sealed class ModalFrame
+        {
+            public ModalFrame(Window dialog, Window owner)
+            {
+                Dialog = dialog;
+                Owner = owner;
+            }
+
+            public Window Dialog { get; }
+            public Window Owner { get; }
+            public IInputElement? LastDialogFocus { get; set; }
+        }
+
+        /// <summary>
+        /// Moves the app-global keyboard focus back into the top-most open modal when it has ended
+        /// up in one of the input-disabled windows below it (or nowhere useful at all). No-op when
+        /// focus is already in the dialog or in an independent, enabled window.
+        /// </summary>
+        private static void ReclaimKeyboardFocusFromDisabledOwner()
+        {
+            if (_modalFrames.Count == 0)
+            {
+                return;
+            }
+
+            var frame = _modalFrames[^1];
+            var dialog = frame.Dialog;
+            if (!dialog.IsVisible || dialog.IsClosing())
+            {
+                return;
+            }
+
+            var focusedTopLevel = dialog.FocusManager?.GetFocusedElement() is Visual focusedVisual
+                ? TopLevel.GetTopLevel(focusedVisual)
+                : null;
+            if (focusedTopLevel == dialog)
+            {
+                return; // healthy
+            }
+
+            if (focusedTopLevel != null && !IsDisabledByOpenModal(focusedTopLevel))
+            {
+                return; // focus is in an enabled window (e.g. the undocked video player) - legitimate
+            }
+
+            // Focus is in a disabled owner, on a detached control (a closed popup's item), or
+            // nowhere: the dialog is the only right place for it while it is open. Prefer the
+            // control that last held the caret; fall back to the first focusable control when it
+            // cannot take focus anymore (hidden page, disabled button).
+            if (frame.LastDialogFocus is InputElement last &&
+                TopLevel.GetTopLevel(last) == dialog &&
+                last.Focus())
+            {
+                return;
+            }
+
+            (FindFirstFocusable(dialog) as InputElement)?.Focus();
+        }
+
+        private static IInputElement? FindFirstFocusable(Visual root)
+        {
+            foreach (var visual in root.GetVisualDescendants())
+            {
+                if (visual is InputElement { Focusable: true, IsEffectivelyEnabled: true, IsEffectivelyVisible: true } element)
+                {
+                    return element;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool IsDisabledByOpenModal(TopLevel topLevel)
+        {
+            foreach (var frame in _modalFrames)
+            {
+                if (frame.Owner == topLevel)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private sealed class ActionDisposable : IDisposable

--- a/tests/UI/Logic/ModalForegroundEnforcementTests.cs
+++ b/tests/UI/Logic/ModalForegroundEnforcementTests.cs
@@ -1,5 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Threading;
 using Nikse.SubtitleEdit.Logic;
 
@@ -154,5 +156,151 @@ public class ModalForegroundEnforcementTests : IDisposable
         Dispatcher.UIThread.RunJobs();
 
         Assert.Equal([false, true], calls);
+    }
+
+    // OS activation is only half the invariant: Avalonia delivers key presses to the app-global
+    // focused element regardless of which window the OS sent them to, so a deferred Focus() call
+    // into the owner (the menu bar's post-close restore, a posted grid focus) re-routes the
+    // keyboard under the dialog while its title bar still looks active (#13405 beta-9 feedback).
+    // These tests cover the focus half.
+
+    private static (Window Owner, TextBox OwnerTextBox, Window Dialog, TextBox DialogTextBox, Task DialogTask) OpenModalWithFocusableContent()
+    {
+        var ownerTextBox = new TextBox();
+        var owner = new Window { Content = ownerTextBox };
+        owner.Show();
+
+        var dialogTextBox = new TextBox();
+        var dialog = new Window { Content = dialogTextBox };
+        var dialogTask = WindowService.ShowModalAsync(owner, dialog);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(dialog.IsVisible);
+
+        dialogTextBox.Focus();
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(dialogTextBox.IsFocused);
+
+        return (owner, ownerTextBox, dialog, dialogTextBox, dialogTask);
+    }
+
+    [AvaloniaFact]
+    public void FocusStolenIntoTheOwnerWhileModalIsOpen_IsHandedBackToTheDialog()
+    {
+        var (_, ownerTextBox, _, dialogTextBox, _) = OpenModalWithFocusableContent();
+
+        // The steal: a deferred focus restore lands on the owner after the dialog opened.
+        ownerTextBox.Focus();
+        Assert.True(ownerTextBox.IsFocused);
+
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(ownerTextBox.IsFocused);
+        Assert.True(dialogTextBox.IsFocused);
+    }
+
+    [AvaloniaFact]
+    public void FocusReclaim_ReturnsToTheControlTheDialogLastFocused()
+    {
+        var firstBox = new TextBox();
+        var secondBox = new TextBox();
+        var ownerTextBox = new TextBox();
+        var owner = new Window { Content = ownerTextBox };
+        owner.Show();
+
+        var dialog = new Window { Content = new StackPanel { Children = { firstBox, secondBox } } };
+        _ = WindowService.ShowModalAsync(owner, dialog);
+        Dispatcher.UIThread.RunJobs();
+
+        secondBox.Focus();
+        Dispatcher.UIThread.RunJobs();
+
+        ownerTextBox.Focus();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(secondBox.IsFocused); // not firstBox - the reclaim remembers the caret position
+    }
+
+    [AvaloniaFact]
+    public void KeyDownReachingTheDisabledOwner_IsSwallowed()
+    {
+        var (_, ownerTextBox, _, _, _) = OpenModalWithFocusableContent();
+
+        var keyDown = new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Key = Key.Tab,
+            Source = ownerTextBox,
+        };
+        ownerTextBox.RaiseEvent(keyDown);
+
+        Assert.True(keyDown.Handled);
+    }
+
+    [AvaloniaFact]
+    public void KeyDownInTheDialog_IsNotSwallowed()
+    {
+        var (_, _, _, dialogTextBox, _) = OpenModalWithFocusableContent();
+
+        var keyDown = new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Key = Key.A,
+            Source = dialogTextBox,
+        };
+        dialogTextBox.RaiseEvent(keyDown);
+
+        Assert.False(keyDown.Handled);
+    }
+
+    [AvaloniaFact]
+    public void FocusInAnIndependentEnabledWindow_IsLeftAlone()
+    {
+        var (_, _, _, dialogTextBox, _) = OpenModalWithFocusableContent();
+
+        // An undocked tool window: enabled, independent, not part of the modal owner chain.
+        var independentTextBox = new TextBox();
+        var independent = new Window { Content = independentTextBox };
+        independent.Show();
+
+        independentTextBox.Focus();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(independentTextBox.IsFocused);
+        Assert.False(dialogTextBox.IsFocused);
+    }
+
+    [AvaloniaFact]
+    public void FocusStolenIntoTheOwner_WithNestedModals_GoesToTheTopDialog()
+    {
+        var (owner, ownerTextBox, dialog, _, _) = OpenModalWithFocusableContent();
+
+        var topTextBox = new TextBox();
+        var topDialog = new Window { Content = topTextBox };
+        _ = WindowService.ShowModalAsync(dialog, topDialog);
+        Dispatcher.UIThread.RunJobs();
+        topTextBox.Focus();
+        Dispatcher.UIThread.RunJobs();
+
+        ownerTextBox.Focus();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(ownerTextBox.IsFocused);
+        Assert.True(topTextBox.IsFocused);
+        _ = owner;
+    }
+
+    [AvaloniaFact]
+    public void FocusInTheOwnerAfterTheDialogCloses_IsLeftAlone()
+    {
+        var (_, ownerTextBox, dialog, _, dialogTask) = OpenModalWithFocusableContent();
+
+        dialog.Close();
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(dialogTask.IsCompletedSuccessfully);
+
+        ownerTextBox.Focus();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(ownerTextBox.IsFocused);
     }
 }


### PR DESCRIPTION
Fixes the three remaining beta 9 repros from #13405 ([comment](https://github.com/SubtitleEdit/subtitleedit/issues/13405#issuecomment-5238749288)):

- Text to Speech with nothing loaded → warning box not in foreground
- Speech to Text with no video → dialog opens not in foreground
- Post-transcribe: "1 completed" box fine, the chained "open subtitle?" box in *fake* foreground (intermittent)

### Why #13409 didn't catch these

#13409 enforces **OS activation** on the dialog. But Avalonia routes every key press to its single **app-global focused element**, regardless of which window the OS delivered the key to (`KeyboardDevice.ProcessRawEvent`). So any deferred `Focus()` into the main window — the menu bar's post-close focus restore (`DeactivateMainMenu` posts it), a posted grid focus after an edit — lands *after* the dialog opened and silently re-routes the keyboard under the dialog, while the dialog stays genuinely OS-active with an active-looking title bar. That is exactly the reported state: no visible hint, Esc dead, Tab visibly walking the main window underneath. No activation event ever fires for it, so the #13409 enforcement is blind to it. The keyboard-first workflow (Alt-menus) makes it likely: the menu's focus restore races the dialog open, which also explains the intermittency.

### The fix

`ShowModalAsync` now enforces the focus half of the invariant for the dialog's whole lifetime, alongside the activation half:

- Focus landing on the input-disabled owner while the dialog is open is handed straight back to the dialog — to the control that last held the caret, falling back to the first focusable control.
- A key press or text input that reaches the owner is swallowed instead of delivered (better a dead keystroke than one editing the subtitle under the dialog), and triggers the same repair. This also repairs key routing even when Windows refuses the `SetForegroundWindow` call, since routing follows the global focused element, not the OS-active window.
- Nested modals reclaim to the top-most dialog; focus in the independent, enabled undocked tool windows is never touched.

Like #13409, the repair is driven by the broken state itself, not by patching each producer — so all three repros (and any future producer of the same steal) are covered by one mechanism in one place.

### Tests

7 new headless tests in `ModalForegroundEnforcementTests`: steal-and-reclaim, caret-position restore, owner key swallow (and dialog keys not swallowed), independent-window focus left alone, nested-modal reclaim to top, and no interference after close. Full UI suite green: 2269/2269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)