### PR TITLE
Chatterbox TTS: 23-language selection, and re-download of English-only GGUFs

### DIFF
--- a/docs/features/text-to-speech.md
+++ b/docs/features/text-to-speech.md
@@ -31,7 +31,7 @@ Generate speech audio from subtitle text using various TTS engines.
 - **Kokoro TTS** — Local downloadable Kokoro TTS server and models
 - **OmniVoice TTS** — Local CPU TTS with voice cloning and many languages
 - **Qwen3 TTS (CrispASR)** — Local Qwen3 TTS running through the CrispASR runtime (VoiceDesign, CustomVoice, and Voice clone 1.7B models)
-- **Chatterbox TTS (CrispASR)** — Chatterbox TTS via the CrispASR runtime, with voice cloning (Base or Turbo model)
+- **Chatterbox TTS (CrispASR)** — Chatterbox TTS via the CrispASR runtime, with voice cloning (multilingual Base or English-only Turbo model)
 
 Local downloadable engines are installed into the Subtitle Edit data folder when you accept the download prompt.
 
@@ -60,6 +60,8 @@ Qwen3 TTS runs through the CrispASR runtime and shares the `CrispASR/models` dir
 Chatterbox TTS runs through the CrispASR runtime (shared with the speech-to-text feature) and supports voice cloning.
 
 - Available model choices are **Base** and **Turbo**.
+- The **Base** model is multilingual: pick one of its 23 languages (Arabic, Chinese, Danish, Dutch, English, Finnish, French, German, Greek, Hebrew, Hindi, Italian, Japanese, Korean, Malay, Norwegian, Polish, Portuguese, Russian, Spanish, Swahili, Swedish, Turkish) in the language dropdown. **Auto** sends no language and lets the model guess — non-English text usually comes out with an English accent that way, so picking the language explicitly is recommended. **Turbo** is an English-only distillation and has no language choice.
+- If the models were downloaded before the multilingual release, Subtitle Edit will prompt to download them again — the older files are English-only and ignore the language selection.
 - Imported reference WAV voices are sent as the per-request voice for runtime cloning.
 
 ### Kokoro TTS

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxLanguages.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxLanguages.cs
@@ -1,0 +1,126 @@
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// The 23 languages of the multilingual Chatterbox model, plus an "Auto" entry that sends no
+/// language and keeps the pre-selection behaviour (the model guesses, usually with an English
+/// accent on non-English text).
+///
+/// The codes are ISO 639-1 two-letter IDs. CrispASR's chatterbox backend turns the request's
+/// <c>language</c> field into the <c>[xx]</c> language token it prepends to the T3 prompt —
+/// the same mechanism as its CLI <c>-l</c> flag. This only has an effect on the multilingual
+/// Base GGUFs (2454-token text vocab); see
+/// <see cref="Logic.Download.ChatterboxTtsCppDownloadService.IsLegacyEnglishOnlyModel"/> for how
+/// pre-multilingual files are detected and re-downloaded. Chatterbox Turbo is an English-only
+/// distillation, so <see cref="ChatterboxTtsCpp.GetLanguages"/> offers it "Auto" alone.
+///
+/// The multilingual tokenizer actually carries a few more tags (bg, cs, hu, ro, sk, ta, vi and
+/// special tags like [ipa]); only the 23 languages ResembleAI ships and documents are listed
+/// here — the extra tags exist in the vocab but are not advertised as trained.
+/// </summary>
+internal static class ChatterboxLanguages
+{
+    private static readonly TtsLanguage[] Catalog = new TtsLanguage[]
+    {
+        new("Arabic", "ar"),
+        new("Chinese", "zh"),
+        new("Danish", "da"),
+        new("Dutch", "nl"),
+        new("English", "en"),
+        new("Finnish", "fi"),
+        new("French", "fr"),
+        new("German", "de"),
+        new("Greek", "el"),
+        new("Hebrew", "he"),
+        new("Hindi", "hi"),
+        new("Italian", "it"),
+        new("Japanese", "ja"),
+        new("Korean", "ko"),
+        new("Malay", "ms"),
+        new("Norwegian", "no"),
+        new("Polish", "pl"),
+        new("Portuguese", "pt"),
+        new("Russian", "ru"),
+        new("Spanish", "es"),
+        new("Swahili", "sw"),
+        new("Swedish", "sv"),
+        new("Turkish", "tr"),
+    };
+
+    /// <summary>
+    /// Code for the "Auto" entry — an empty code means no language field is sent.
+    /// </summary>
+    public const string AutoCode = "";
+
+    public static readonly TtsLanguage Auto = new("Auto", AutoCode);
+
+    /// <summary>
+    /// "Auto" first, then the 23 languages alphabetically. Auto leads so a combo that falls
+    /// back to its first entry preserves the old no-language behaviour.
+    ///
+    /// Declared after <see cref="Catalog"/> on purpose: static field initializers run in textual
+    /// order, so moving this above the catalog would copy a null array.
+    /// </summary>
+    public static readonly TtsLanguage[] All = BuildAll();
+
+    private static TtsLanguage[] BuildAll()
+    {
+        var result = new TtsLanguage[Catalog.Length + 1];
+        result[0] = Auto;
+        Array.Copy(Catalog, 0, result, 1, Catalog.Length);
+        return result;
+    }
+
+    /// <summary>
+    /// The value to send as the request's <c>language</c> field for <paramref name="language"/>,
+    /// or an empty string when no field should be sent (Auto, an unknown entry, or nothing
+    /// selected).
+    /// </summary>
+    public static string ResolveLanguageArg(TtsLanguage? language)
+    {
+        // A null language means the CALLER had none to hand over, which is not the same as the
+        // user picking "Auto". The cast dialog's voice-test button and every cross-engine cast
+        // row pass null on purpose ("engines fall back to their own saved defaults"), so without
+        // this fallback those paths would silently ignore the language the user did pick — the
+        // same hole CosyVoice3 had in #13272.
+        if (language == null)
+        {
+            return ResolveSavedLanguageArg();
+        }
+
+        var code = language.Code;
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            return string.Empty;
+        }
+
+        // Guard against a language object left over from another engine (the view model can hold
+        // one while switching engines): only codes this engine actually advertises are passed on.
+        return IsSupported(code) ? code : string.Empty;
+    }
+
+    /// <summary>
+    /// The language code behind the pick saved by the main TTS window for this engine, or an
+    /// empty string when nothing is saved / the saved entry is "Auto". The setting stores the
+    /// DISPLAY NAME, which is how <c>TextToSpeechViewModel</c> writes and restores it.
+    /// </summary>
+    public static string ResolveSavedLanguageArg()
+    {
+        var savedName = Se.Settings.Video.TextToSpeech.ChatterboxCrispAsrLanguage;
+        if (string.IsNullOrWhiteSpace(savedName))
+        {
+            return string.Empty;
+        }
+
+        return All.FirstOrDefault(l => string.Equals(l.Name, savedName, StringComparison.OrdinalIgnoreCase))?.Code
+               ?? string.Empty;
+    }
+
+    /// <summary>True when <paramref name="code"/> is one of the 23 supported language codes.</summary>
+    public static bool IsSupported(string? code) =>
+        !string.IsNullOrWhiteSpace(code)
+        && Catalog.Any(l => string.Equals(l.Code, code, StringComparison.OrdinalIgnoreCase));
+}

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -29,12 +29,14 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 /// Chatterbox has one baked default voice; "voices" listed beyond Default come from
 /// WAVs imported via <see cref="ImportVoice"/>. The full reference-WAV path is sent per-request
 /// as the `voice` field — runtime WAV cloning is wired upstream in CrispASR's chatterbox backend.
+/// The Base model is the multilingual build (23 languages via <see cref="ChatterboxLanguages"/>,
+/// sent as the per-request `language` field); Turbo is English-only.
 /// </summary>
 public class ChatterboxTtsCpp : ITtsEngine
 {
     public string Name => "Chatterbox TTS (CrispASR)";
     public string Description => "via CrispASR (Base or Turbo model + voice cloning)";
-    public bool HasLanguageParameter => false;
+    public bool HasLanguageParameter => true;
     public bool HasApiKey => false;
     public bool HasRegion => false;
     public bool HasModel => true;
@@ -255,8 +257,18 @@ public class ChatterboxTtsCpp : ITtsEngine
     public static string GetS3GenModelPath(string? modelKey = null) =>
         Path.Combine(GetSetModelsFolder(), ChatterboxTtsCppDownloadService.GetS3GenFileName(ResolveModelKey(modelKey)));
 
-    public static bool AreModelsInstalled(string? modelKey = null) =>
-        File.Exists(GetT3ModelPath(modelKey)) && File.Exists(GetS3GenModelPath(modelKey));
+    // Legacy pre-multilingual Base GGUFs (English-only T3, downloaded before upstream's
+    // 2026-06-18 in-place rebuild of cstr/chatterbox-GGUF) count as NOT installed so the
+    // normal "Download models?" prompt re-fetches the multilingual files — without this,
+    // picking a language changes nothing for those users and there is no visible reason why.
+    public static bool AreModelsInstalled(string? modelKey = null)
+    {
+        var t3Path = GetT3ModelPath(modelKey);
+        var s3genPath = GetS3GenModelPath(modelKey);
+        return File.Exists(t3Path) && File.Exists(s3genPath)
+            && !ChatterboxTtsCppDownloadService.IsLegacyEnglishOnlyModel(t3Path)
+            && !ChatterboxTtsCppDownloadService.IsLegacyEnglishOnlyModel(s3genPath);
+    }
 
     public Task<Voice[]> GetVoices(string language)
     {
@@ -281,7 +293,15 @@ public class ChatterboxTtsCpp : ITtsEngine
 
     public Task<string[]> GetModels() => Task.FromResult(new[] { ModelKeyBase, ModelKeyTurbo });
 
-    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(Array.Empty<TtsLanguage>());
+    /// <summary>
+    /// The multilingual Base model takes a per-request language (23 languages, "[xx]" prompt
+    /// token server-side); Turbo is an English-only distillation, so it gets "Auto" alone
+    /// rather than an empty combo.
+    /// </summary>
+    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) =>
+        Task.FromResult(ResolveModelKey(model) == ModelKeyTurbo
+            ? new[] { ChatterboxLanguages.Auto }
+            : ChatterboxLanguages.All);
 
     public Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken)
     {
@@ -302,16 +322,24 @@ public class ChatterboxTtsCpp : ITtsEngine
             throw new ArgumentException("Voice is not a ChatterboxVoice");
         }
 
-        await EnsureServerRunningAsync(ResolveModelKey(model), cancellationToken);
+        var modelKey = ResolveModelKey(model);
+        await EnsureServerRunningAsync(modelKey, cancellationToken);
 
         var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
         var inputText = text;
 
-        var payload = BuildSpeakPayload(inputText, chatterboxVoice.FilePath);
+        // Multilingual language selection (#13273-adjacent): a per-request field the server
+        // turns into the [xx] prompt token. Only the Base model is multilingual — Turbo is an
+        // English-only distillation, so no field is sent for it regardless of the pick.
+        var languageArg = modelKey == ModelKeyTurbo
+            ? string.Empty
+            : ChatterboxLanguages.ResolveLanguageArg(language);
+
+        var payload = BuildSpeakPayload(inputText, chatterboxVoice.FilePath, languageArg);
 
         var body = JsonSerializer.Serialize(payload);
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
-        Se.WriteToolsLog($"Chatterbox TTS: POST {ServerBaseUrl}/v1/audio/speech (voice={chatterboxVoice}, model={ResolveModelKey(model)}, textLen={text.Length})");
+        Se.WriteToolsLog($"Chatterbox TTS: POST {ServerBaseUrl}/v1/audio/speech (voice={chatterboxVoice}, model={modelKey}, textLen={text.Length}, language={(string.IsNullOrEmpty(languageArg) ? "(auto)" : languageArg)})");
         HttpResponseMessage response;
         try
         {
@@ -392,13 +420,18 @@ public class ChatterboxTtsCpp : ITtsEngine
     /// the one SE engine that hard-requires the attestations. An empty path falls back to the
     /// model's baked default voice, which is not cloning and needs no attestation.
     /// </remarks>
-    internal static Dictionary<string, object> BuildSpeakPayload(string inputText, string? voiceFilePath)
+    internal static Dictionary<string, object> BuildSpeakPayload(string inputText, string? voiceFilePath, string? languageCode = null)
     {
         var payload = new Dictionary<string, object>
         {
             ["input"] = inputText,
             ["response_format"] = "wav",
         };
+
+        if (!string.IsNullOrEmpty(languageCode))
+        {
+            payload["language"] = languageCode;
+        }
 
         if (!string.IsNullOrEmpty(voiceFilePath))
         {

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -436,6 +436,7 @@ public partial class TextToSpeechViewModel : ObservableObject
         else if (SelectedEngine is ChatterboxTtsCpp)
         {
             Se.Settings.Video.TextToSpeech.ChatterboxModel = SelectedModel ?? ChatterboxTtsCpp.DefaultModelKey;
+            Se.Settings.Video.TextToSpeech.ChatterboxCrispAsrLanguage = SelectedLanguage?.Name ?? string.Empty;
         }
         else if (SelectedEngine is KokoroTtsCpp)
         {
@@ -3401,6 +3402,8 @@ public partial class TextToSpeechViewModel : ObservableObject
                     CosyVoice3CrispAsr => Languages.FirstOrDefault(l => l.Name == Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrLanguage)
                                           ?? Languages.FirstOrDefault(),
                     Qwen3TtsCrispAsr => Languages.FirstOrDefault(l => l.Name == Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrLanguage)
+                                        ?? Languages.FirstOrDefault(),
+                    ChatterboxTtsCpp => Languages.FirstOrDefault(l => l.Name == Se.Settings.Video.TextToSpeech.ChatterboxCrispAsrLanguage)
                                         ?? Languages.FirstOrDefault(),
                     _ => Languages.FirstOrDefault(),
                 };

--- a/src/ui/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/ui/Logic/Config/SeVideoTextToSpeech.cs
@@ -60,6 +60,7 @@ public class SeVideoTextToSpeech
     public string OmniVoiceTtsCppVulkanPath { get; set; }
     public string OmniVoiceTtsCppInstruction { get; set; }
     public string ChatterboxModel { get; set; }
+    public string ChatterboxCrispAsrLanguage { get; set; }
     public string KokoroVoice { get; set; }
     public string GoogleApiKey { get; set; }
     public string GoogleKeyFile { get; set; }
@@ -156,6 +157,7 @@ public class SeVideoTextToSpeech
         OmniVoiceTtsCppVulkanPath = string.Empty;
         OmniVoiceTtsCppInstruction = string.Empty;
         ChatterboxModel = "Base";
+        ChatterboxCrispAsrLanguage = string.Empty;
         KokoroVoice = "af_maple";
         GoogleApiKey = string.Empty;
         GoogleKeyFile = string.Empty;

--- a/src/ui/Logic/Download/ChatterboxTtsCppDownloadService.cs
+++ b/src/ui/Logic/Download/ChatterboxTtsCppDownloadService.cs
@@ -54,6 +54,39 @@ public class ChatterboxTtsCppDownloadService : IChatterboxTtsCppDownloadService
     public static string GetBackendName(string? modelKey) =>
         ResolveModelKey(modelKey) == ModelKeyTurbo ? "chatterbox-turbo" : "chatterbox";
 
+    // cstr/chatterbox-GGUF was rebuilt IN PLACE around 2026-06-18: the same file names went
+    // from the English-only v1 weights (T3 text vocab 704) to the multilingual weights
+    // (text vocab 2454, with the [de]/[fr]/... language tokens the `language` request field
+    // needs). Anyone who downloaded before the rebuild still has the English-only files and a
+    // bare File.Exists check would keep them forever — language selection then changes nothing
+    // and non-English text comes out as accented gibberish. These are the exact byte sizes of
+    // the legacy files, used to force a re-download; the Turbo repo was not part of the rebuild.
+    private const long LegacyBaseT3Size = 630_177_120;
+    private const long LegacyBaseS3GenSize = 358_278_528;
+
+    /// <summary>
+    /// True when <paramref name="path"/> is one of the pre-multilingual (English-only) Base
+    /// GGUFs, identified by exact byte size. Such a file works for English synthesis but lacks
+    /// the language tokens, so it is treated as not installed to trigger a re-download.
+    /// </summary>
+    public static bool IsLegacyEnglishOnlyModel(string path)
+    {
+        try
+        {
+            if (!File.Exists(path))
+            {
+                return false;
+            }
+
+            var length = new FileInfo(path).Length;
+            return length == LegacyBaseT3Size || length == LegacyBaseS3GenSize;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     public ChatterboxTtsCppDownloadService(HttpClient httpClient)
     {
         _httpClient = httpClient;
@@ -69,8 +102,8 @@ public class ChatterboxTtsCppDownloadService : IChatterboxTtsCppDownloadService
 
         var t3Path = Path.Combine(modelsFolder, t3FileName);
         var s3genPath = Path.Combine(modelsFolder, s3genFileName);
-        var needT3 = !File.Exists(t3Path);
-        var needS3Gen = !File.Exists(s3genPath);
+        var needT3 = !File.Exists(t3Path) || IsLegacyEnglishOnlyModel(t3Path);
+        var needS3Gen = !File.Exists(s3genPath) || IsLegacyEnglishOnlyModel(s3genPath);
         var total = (needT3 ? 1 : 0) + (needS3Gen ? 1 : 0);
         var step = 0;
 

--- a/tests/UI/Features/Video/TextToSpeech/Engines/ChatterboxTtsCppTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/ChatterboxTtsCppTests.cs
@@ -1,3 +1,4 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 
 namespace UITests.Features.Video.TextToSpeech.Engines;
@@ -66,5 +67,91 @@ public class ChatterboxTtsCppTests
         Assert.False(payload.ContainsKey("consent_attestation"));
         Assert.False(payload.ContainsKey("marking_attestation"));
         Assert.Equal("hello", payload["input"]);
+    }
+
+    [Fact]
+    public void BuildSpeakPayload_WithLanguage_SendsLanguageField()
+    {
+        var payload = ChatterboxTtsCpp.BuildSpeakPayload("bonjour", string.Empty, "fr");
+
+        Assert.Equal("fr", payload["language"]);
+    }
+
+    [Fact]
+    public void BuildSpeakPayload_WithoutLanguage_SendsNoLanguageField()
+    {
+        // No language (Auto, or the Turbo model) must keep the payload identical to the
+        // pre-multilingual behaviour — the server treats a missing field as language-agnostic.
+        var payload = ChatterboxTtsCpp.BuildSpeakPayload("hello", string.Empty);
+
+        Assert.False(payload.ContainsKey("language"));
+    }
+
+    [Fact]
+    public void Languages_LeadWithAutoThenTheTwentyThreeSupportedLanguages()
+    {
+        // "Auto" first so a combo falling back to its first entry reproduces the
+        // pre-language-selection behaviour (no field sent).
+        var all = ChatterboxLanguages.All;
+
+        Assert.Equal(24, all.Length);
+        Assert.Equal("Auto", all[0].Name);
+        Assert.Equal(string.Empty, all[0].Code);
+    }
+
+    [Theory]
+    [InlineData("French", "fr")]
+    [InlineData("German", "de")]
+    [InlineData("Chinese", "zh")]
+    public void Languages_ResolveToIsoCode(string displayName, string expectedArg)
+    {
+        var language = ChatterboxLanguages.All.Single(l => l.Name == displayName);
+
+        Assert.Equal(expectedArg, ChatterboxLanguages.ResolveLanguageArg(language));
+    }
+
+    [Fact]
+    public void Languages_AutoResolvesToEmpty()
+    {
+        Assert.Equal(string.Empty, ChatterboxLanguages.ResolveLanguageArg(ChatterboxLanguages.Auto));
+    }
+
+    [Fact]
+    public void Languages_ForeignEngineCodeIsDropped()
+    {
+        // A language object left over from another engine (e.g. OmniVoice's ISO 639-3 ids)
+        // must not leak onto the wire.
+        var foreign = new TtsLanguage("Standard Arabic", "arb");
+
+        Assert.Equal(string.Empty, ChatterboxLanguages.ResolveLanguageArg(foreign));
+    }
+
+    [Fact]
+    public void LegacyEnglishOnlyGguf_IsDetectedBySize()
+    {
+        // cstr/chatterbox-GGUF was rebuilt in place with multilingual weights; the legacy
+        // English-only files are recognised by exact byte size so they get re-downloaded.
+        // SetLength is metadata-only, so no 630 MB is actually written.
+        var path = Path.Combine(Path.GetTempPath(), $"chatterbox-legacy-test-{Guid.NewGuid():N}.gguf");
+        try
+        {
+            using (var fs = new FileStream(path, FileMode.CreateNew, FileAccess.Write))
+            {
+                fs.SetLength(630_177_120);
+            }
+
+            Assert.True(Nikse.SubtitleEdit.Logic.Download.ChatterboxTtsCppDownloadService.IsLegacyEnglishOnlyModel(path));
+
+            using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
+            {
+                fs.SetLength(639_285_952); // the current multilingual T3 — must NOT be flagged
+            }
+
+            Assert.False(Nikse.SubtitleEdit.Logic.Download.ChatterboxTtsCppDownloadService.IsLegacyEnglishOnlyModel(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 }


### PR DESCRIPTION
Follow-up to subof's report on #13273: *"Chatterbox (23lang) isn't working yet."* It couldn't — two independent gaps, both fixed here.

## 1. SE never sent a language

CrispASR's `chatterbox` backend runs ResembleAI's 23-language multilingual model, selected per request via the `language` field of `/v1/audio/speech` (the server turns it into the `[xx]` prompt token — same mechanism as its CLI `-l`). SE had `HasLanguageParameter => false` and never sent the field.

The engine now offers the 23 documented languages behind an **Auto** entry (Auto sends no field, i.e. exactly the old behaviour). The pick persists as `ChatterboxCrispAsrLanguage`, and a null language from cast-dialog/voice-test paths falls back to the saved pick — the same hole CosyVoice3 had in #13272. **Turbo** is an English-only distillation: it shows "Auto" alone and never sends a language.

## 2. Many installs physically can't speak anything but English

`cstr/chatterbox-GGUF` was rebuilt **in place** around 2026-06-18 — same filenames, new multilingual weights (T3 text vocab 704 → 2454). Anyone who downloaded before that has the English-only files, and the `File.Exists` install check kept them forever, with no visible reason why a language pick changed nothing. The legacy files are now recognised by exact byte size and treated as not installed, so the normal "Download models?" prompt re-fetches the rebuilt pair. The Turbo repo wasn't part of the rebuild and is untouched.

## Verification (headless, v0.8.27 macOS binary)

- Wiring proof: a bogus `"language":"xx"` draws the backend's `language token '[xx]' not in vocab` warning — the field demonstrably reaches `chatterbox_set_language` on every request.
- End-to-end with SE's exact server invocation and payload: `"language":"de"` → Parakeet-v3 roundtrips **"Guten Abend meine Damen und Herren, willkommen zur Sendung."** verbatim. Without the field, the French equivalent came back as "Bonjour toolamon, comment tell Avery Swar".
- Deterministic CLI A/B (fixed seed): `-l fr` vs no flag produce different generations; `-l fr` roundtrips verbatim on both Q8_0 and Q4_K.
- 14 unit tests pass (payload shape incl. attestation interplay, language resolution, Auto/foreign-code guards, legacy-size detection via sparse file).

Note for reviewers: sensevoice-small is not a usable judge for this — it transcribes correct French output as gibberish; parakeet-tdt-0.6b-v3 agrees with upstream's own smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)