### PR TITLE
Show filtered file count in batch convert info label

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -491,22 +491,34 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
                 BatchItems.Add(item);
             }
         }
+
+        MakeBatchItemsInfo();
     }
 
     private bool PassesFilter(BatchConvertItem item)
     {
-        if (SelectedFilterItem == Se.Language.Tools.BatchConvert.FileNameContainsDotDotDot && !string.IsNullOrEmpty(FilterText))
+        if (!IsFilterActive)
+        {
+            return true;
+        }
+
+        if (SelectedFilterItem == Se.Language.Tools.BatchConvert.FileNameContainsDotDotDot)
         {
             return item.FileName.Contains(FilterText, StringComparison.InvariantCultureIgnoreCase);
         }
 
-        if (SelectedFilterItem == Se.Language.Tools.BatchConvert.TrackLanguageContainsDotDotDot && !string.IsNullOrEmpty(FilterText))
+        if (SelectedFilterItem == Se.Language.Tools.BatchConvert.TrackLanguageContainsDotDotDot)
         {
             return item.Format.Contains(FilterText, StringComparison.InvariantCultureIgnoreCase);
         }
 
         return true;
     }
+
+    private bool IsFilterActive =>
+        !string.IsNullOrEmpty(FilterText) &&
+        (SelectedFilterItem == Se.Language.Tools.BatchConvert.FileNameContainsDotDotDot ||
+         SelectedFilterItem == Se.Language.Tools.BatchConvert.TrackLanguageContainsDotDotDot);
 
     // Appends just-parsed items to the visible grid (respecting the active filter) so files show
     // up incrementally as they load. Must run on the UI thread.
@@ -1944,17 +1956,25 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
 
     private void MakeBatchItemsInfo()
     {
-        if (BatchItems.Count == 0)
+        var total = _allBatchItems.Count;
+        var shown = BatchItems.Count;
+
+        if (total == 0)
         {
             BatchItemsInfo = string.Empty;
         }
-        else if (BatchItems.Count == 1)
+        else if (IsFilterActive)
+        {
+            // With a filter on, only the visible files get converted - show that count next to the total.
+            BatchItemsInfo = string.Format(Se.Language.General.XOfYFiles, shown, total);
+        }
+        else if (total == 1)
         {
             BatchItemsInfo = Se.Language.General.OneFile;
         }
         else
         {
-            BatchItemsInfo = string.Format(Se.Language.General.XFiles, BatchItems.Count);
+            BatchItemsInfo = string.Format(Se.Language.General.XFiles, total);
         }
     }
 

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -679,6 +679,7 @@ public class LanguageGeneral
     public string PixelWidth { get; set; }
     public string Wpm { get; set; }
     public string XFiles { get; set; }
+    public string XOfYFiles { get; set; }
     public string XFilesConvertedInY { get; set; }
     public string XNoLinesUpdated { get; set; }
     public string XNotFound { get; set; }
@@ -1417,6 +1418,7 @@ public class LanguageGeneral
         PixelWidth = "Pixel width";
         Wpm = "Words/min";
         XFiles = "{0:#,###,##0} files";
+        XOfYFiles = "{0:#,###,##0} of {1:#,###,##0} files";
         XFilesConvertedInY = "{0:#,###,##0} files converted in {1}";
         XNoLinesUpdated = "{0}: no line(s) updated";
         XNotFound = "\"{0}\" not found";


### PR DESCRIPTION
In batch convert, the info label under the file grid showed a stale count once a filter was applied: it was only refreshed when files were added or removed, never when the filter changed. So it could still read "152 files" while the grid — and the conversion, which runs over the visible items — covered only a handful.

Changes:

- `UpdateFilteredFiles` now refreshes the label, so it tracks the filter.
- While a filter is active the label shows both counts: `12 of 152 files` (new `XOfYFiles` string). With no filter it is unchanged (`One file` / `152 files`).
- Small refactor: the "is a filter actually active" check is factored out of `PassesFilter` into `IsFilterActive`, reused by the label so a transient count mismatch during incremental file loading can't render as a bogus "3 of 7 files".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
