### PR TITLE
Let the replace window pick which columns to search (#13471)

### DIFF
--- a/docs/features/edit.md
+++ b/docs/features/edit.md
@@ -46,7 +46,13 @@ Find and replace text in the subtitle.
 - **Menu:** Edit → Replace
 - **Shortcut:** `Ctrl+H`
 
-With an original subtitle loaded, replace works on both the text and the original text (same as Find).
+With an editable original subtitle loaded, a **Replace/search in** drop-down appears with three choices:
+
+- **Text and original text** - both columns (the default, and what Find always does)
+- **Text only** - leave the original subtitle alone
+- **Original text only** - only change the original subtitle
+
+The choice is remembered between sessions. It also applies to `F3` / `Shift+F3` until the Find window is used again, which always searches both columns. The drop-down is hidden when there is no original subtitle, or when the original is opened as a read-only reference - a read-only original is never written to.
 
 <!-- Screenshot: Replace window -->
 ![Replace](../screenshots/replace.png)

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -49,6 +49,7 @@
     "backward": "Backward",
     "batchMode": "Batch mode",
     "bdnXml": "BDN/xml",
+    "bdnXml8Bit": "BDN/xml 8-bit",
     "before": "Before",
     "beginning": "Beginning",
     "bluRaySup": "Blu-ray (sup)",
@@ -679,6 +680,7 @@
     "pixelWidth": "Pixel width",
     "wpm": "Words/min",
     "xFiles": "{0:#,###,##0} files",
+    "xOfYFiles": "{0:#,###,##0} of {1:#,###,##0} files",
     "xFilesConvertedInY": "{0:#,###,##0} files converted in {1}",
     "xNoLinesUpdated": "{0}: no line(s) updated",
     "xNotFound": "\"{0}\" not found",
@@ -1131,6 +1133,7 @@
       "mergeShortLines": "Merge short lines",
       "fixed": "Fixed",
       "numberOfSubtitlesX": "Number of subtitles: {0}",
+      "numberOfSubtitlesXForcedY": "Number of subtitles: {0} ({1} forced)",
       "gapMs": "Gap (ms)",
       "useFixedDuration": "Use fixed duration",
       "fixedDurationMs": "Fixed duration (ms)",
@@ -1390,7 +1393,11 @@
       "findNext": "_Find next",
       "replaceAndFindNext": "_Replace & find next",
       "replaceAll": "Replace _all",
-      "replaceTextWatermark": "Replace with..."
+      "replaceTextWatermark": "Replace with...",
+      "replaceIn": "Replace/search in",
+      "replaceInTextAndOriginal": "Text and original text",
+      "replaceInTextOnly": "Text only",
+      "replaceInOriginalOnly": "Original text only"
     },
     "regularExpressionContextMenu": {
       "wordBoundary": "Word boundary (\\b)",

--- a/src/ui/Features/Edit/Replace/ReplaceScopeDisplay.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceScopeDisplay.cs
@@ -1,0 +1,32 @@
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections.Generic;
+using static Nikse.SubtitleEdit.Logic.FindService;
+
+namespace Nikse.SubtitleEdit.Features.Edit.Replace;
+
+public class ReplaceScopeDisplay
+{
+    public string Name { get; set; }
+    public FindScope Scope { get; set; }
+
+    public ReplaceScopeDisplay(string name, FindScope scope)
+    {
+        Name = name;
+        Scope = scope;
+    }
+
+    public override string ToString()
+    {
+        return Name;
+    }
+
+    public static List<ReplaceScopeDisplay> List()
+    {
+        return
+        [
+            new(Se.Language.Edit.Find.ReplaceInTextAndOriginal, FindScope.TextAndOriginal),
+            new(Se.Language.Edit.Find.ReplaceInTextOnly, FindScope.TextOnly),
+            new(Se.Language.Edit.Find.ReplaceInOriginalOnly, FindScope.OriginalOnly),
+        ];
+    }
+}

--- a/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
@@ -10,6 +10,7 @@ using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using static Nikse.SubtitleEdit.Logic.FindService;
 
@@ -22,12 +23,26 @@ public partial class ReplaceViewModel : ObservableObject
     [ObservableProperty] private bool _wholeWord;
     [ObservableProperty] private string _replaceText;
     [ObservableProperty] private string _countResult;
-    
+    [ObservableProperty] private ObservableCollection<ReplaceScopeDisplay> _scopes;
+    [ObservableProperty] private ReplaceScopeDisplay _selectedScope;
+
+    /// <summary>
+    /// The scope picker only makes sense with an editable original text column on screen, and is
+    /// hidden otherwise (SE 4 showed it disabled) - see <see cref="EffectiveScope"/>.
+    /// </summary>
+    [ObservableProperty] private bool _isScopeVisible;
+
     [ObservableProperty]
     public partial FindMode FindMode { get; set; }
-    
+
     public Window? Window { get; set; }
     public Action? FocusSearchBox { get; set; }
+
+    /// <summary>
+    /// The scope to apply: the picked one while the picker is shown, otherwise both columns - which
+    /// with no original loaded means the text column, the only one there is.
+    /// </summary>
+    public FindScope EffectiveScope => IsScopeVisible ? SelectedScope.Scope : FindScope.TextAndOriginal;
 
     public bool FocusReplaceOnOpen { get; set; }
     public bool FindNextPressed { get; private set; }
@@ -46,6 +61,8 @@ public partial class ReplaceViewModel : ObservableObject
         SearchText = string.Empty;
         ReplaceText = string.Empty;
         CountResult = string.Empty;
+        Scopes = new ObservableCollection<ReplaceScopeDisplay>(ReplaceScopeDisplay.List());
+        SelectedScope = Scopes[0];
 
         LoadSettings();
     }
@@ -60,6 +77,14 @@ public partial class ReplaceViewModel : ObservableObject
             nameof(FindMode.CaseSensitive) => FindMode.CaseSensitive,
             _ => FindMode.RegularExpression
         };
+
+        var scope = Se.Settings.Edit.Find.ReplaceIn switch
+        {
+            nameof(FindScope.TextOnly) => FindScope.TextOnly,
+            nameof(FindScope.OriginalOnly) => FindScope.OriginalOnly,
+            _ => FindScope.TextAndOriginal
+        };
+        SelectedScope = Scopes.First(p => p.Scope == scope);
     }
 
     [RelayCommand]
@@ -112,7 +137,7 @@ public partial class ReplaceViewModel : ObservableObject
             return;
         }
 
-        var count = _findService.Count(SearchText, _subs, WholeWord, FindMode, _originalSubs);
+        var count = _findService.Count(SearchText, _subs, WholeWord, FindMode, _originalSubs, EffectiveScope);
 
         if (count <= 0)
         {
@@ -132,6 +157,13 @@ public partial class ReplaceViewModel : ObservableObject
     {
         Se.Settings.Edit.Find.FindWholeWords = WholeWord;
         Se.Settings.Edit.Find.FindSearchType = FindMode.ToString();
+
+        // Only remember a scope the user could actually see and pick (SE 4 did the same by
+        // leaving the setting alone while its combo box was disabled).
+        if (IsScopeVisible)
+        {
+            Se.Settings.Edit.Find.ReplaceIn = SelectedScope.Scope.ToString();
+        }
     }
     
     internal void OnKeyDown(object? sender, KeyEventArgs e)
@@ -158,18 +190,20 @@ public partial class ReplaceViewModel : ObservableObject
         }
     }
 
-    internal void RefreshSubtitles(List<string> subs, List<string>? originalSubs = null)
+    internal void RefreshSubtitles(List<string> subs, List<string>? originalSubs = null, bool canEditOriginal = false)
     {
         _subs = subs;
         _originalSubs = originalSubs;
+        IsScopeVisible = canEditOriginal;
     }
 
-    internal void InitializeFindData(IFindService findService, List<string> subs, string selectedText, MainViewModel mainViewModel, List<string>? originalSubs = null)
+    internal void InitializeFindData(IFindService findService, List<string> subs, string selectedText, MainViewModel mainViewModel, List<string>? originalSubs = null, bool canEditOriginal = false)
     {
         _findService = findService;
         _subs = subs;
         _originalSubs = originalSubs;
         _findResult = mainViewModel;
+        IsScopeVisible = canEditOriginal;
         if (!string.IsNullOrEmpty(selectedText))
         {
             SearchText = RegexUtils.EscapeNewLines(selectedText);

--- a/src/ui/Features/Edit/Replace/ReplaceWindow.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceWindow.cs
@@ -134,6 +134,26 @@ public class ReplaceWindow : Window
             }
         };
 
+        // Only relevant while an editable original text column is on screen, so the whole block
+        // stays hidden the rest of the time instead of offering choices with no effect.
+        var panelScope = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 10, 0, 0),
+            Children =
+            {
+                new TextBlock
+                {
+                    Text = Se.Language.Edit.Find.ReplaceIn,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Margin = new Thickness(0, 0, 0, 3),
+                },
+                UiUtil.MakeComboBox(vm.Scopes, vm, nameof(vm.SelectedScope)).WithMinWidth(200),
+            },
+            [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsScopeVisible)) { Source = vm },
+        };
+
         var buttonFindNext = UiUtil.MakeButton(Se.Language.Edit.Find.FindNext, vm.FindNextCommand)
             .WithLeftAlignment()
             .WithMinWidth(150)
@@ -179,6 +199,7 @@ public class ReplaceWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
@@ -194,7 +215,8 @@ public class ReplaceWindow : Window
         grid.Add(panelFind, 0, 0);
         grid.Add(panelReplace, 1, 0);
         grid.Add(panelFindTypes, 2, 0);
-        grid.Add(panelButtons, 0, 1, 3, 1);
+        grid.Add(panelScope, 3, 0);
+        grid.Add(panelButtons, 0, 1, 4, 1);
 
         Content = grid;
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12331,7 +12331,7 @@ public partial class MainViewModel :
 
         if (_replaceViewModel != null)
         {
-            _replaceViewModel.RefreshSubtitles(subs, origs);
+            _replaceViewModel.RefreshSubtitles(subs, origs, CanEditOriginal);
         }
     }
 
@@ -12350,6 +12350,12 @@ public partial class MainViewModel :
             var currentLineIndex = Subtitles.IndexOf(selectedSubtitle);
             var subs = Subtitles.Select(p => p.Text).ToList();
             var origs = GetOriginalTextsForFind();
+
+            // The find window has no scope picker and always covers both columns, so it also clears
+            // a scope the replace window left behind (SE 4's find dialog built a fresh helper with
+            // both flags set for the same reason).
+            _findService.CurrentScope = FindScope.TextAndOriginal;
+
             var startInOriginal = IsFindPositionInOriginal();
             var startTextBox = GetFindTextBox(startInOriginal);
             _findService.Initialize(subs, SelectedSubtitleIndex ?? 0, result.WholeWord, result.FindMode, origs);
@@ -12512,12 +12518,19 @@ public partial class MainViewModel :
     /// <summary>
     /// Which column a find should continue from: the focused text box if one has focus
     /// (find/replace windows do not take focus from it), otherwise the column of the last match.
+    /// A single-column scope decides it outright - continuing from the caret of a column that is
+    /// not being searched would start the excluded column's offset in the searched one.
     /// </summary>
     private bool IsFindPositionInOriginal()
     {
-        if (!ShowColumnOriginalText)
+        if (!ShowColumnOriginalText || _findService.CurrentScope == FindScope.TextOnly)
         {
             return false;
+        }
+
+        if (_findService.CurrentScope == FindScope.OriginalOnly)
+        {
+            return true;
         }
 
         if (EditTextBoxOriginal.IsFocused)
@@ -12632,7 +12645,7 @@ public partial class MainViewModel :
                 selectedText = _findService.SearchText;
             }
 
-            vm.InitializeFindData(_findService, subs, selectedText, this, origs);
+            vm.InitializeFindData(_findService, subs, selectedText, this, origs, CanEditOriginal);
             if (!string.IsNullOrEmpty(findSearchText))
             {
                 vm.SearchText = findSearchText;
@@ -12776,6 +12789,9 @@ public partial class MainViewModel :
             var savedFoundIndex = _findService.CurrentTextIndex;
             var savedFoundText = _findService.CurrentTextFound;
             var savedFoundInOriginal = _findService.CurrentMatchInOriginal;
+
+            // Set before the position is worked out - IsFindPositionInOriginal follows the scope.
+            _findService.CurrentScope = CanEditOriginal ? result.EffectiveScope : FindScope.TextAndOriginal;
 
             var startInOriginal = IsFindPositionInOriginal();
             var startTextBox = GetFindTextBox(startInOriginal);

--- a/src/ui/Logic/Config/Language/Edit/LanguageEditFind.cs
+++ b/src/ui/Logic/Config/Language/Edit/LanguageEditFind.cs
@@ -9,6 +9,10 @@ public class LanguageEditFind
     public string ReplaceAndFindNext { get; set; }
     public string ReplaceAll { get; set; }
     public string ReplaceTextWatermark { get; set; }
+    public string ReplaceIn { get; set; }
+    public string ReplaceInTextAndOriginal { get; set; }
+    public string ReplaceInTextOnly { get; set; }
+    public string ReplaceInOriginalOnly { get; set; }
 
     public LanguageEditFind()
     {
@@ -19,5 +23,9 @@ public class LanguageEditFind
         FindNext = "_Find next";
         ReplaceAndFindNext = "_Replace & find next";
         ReplaceAll = "Replace _all";
+        ReplaceIn = "Replace/search in";
+        ReplaceInTextAndOriginal = "Text and original text";
+        ReplaceInTextOnly = "Text only";
+        ReplaceInOriginalOnly = "Original text only";
     }
 }

--- a/src/ui/Logic/Config/SeEditFind.cs
+++ b/src/ui/Logic/Config/SeEditFind.cs
@@ -1,4 +1,4 @@
-﻿using static Nikse.SubtitleEdit.Logic.FindService;
+using static Nikse.SubtitleEdit.Logic.FindService;
 
 namespace Nikse.SubtitleEdit.Logic.Config;
 
@@ -7,10 +7,16 @@ public class SeEditFind
     public bool FindWholeWords { get; set; }
     public string FindSearchType { get; set; }
 
+    /// <summary>
+    /// Which columns the replace window works on in translator mode - see <see cref="FindScope"/>.
+    /// </summary>
+    public string ReplaceIn { get; set; }
+
 
     public SeEditFind()
     {
         FindWholeWords = false;
         FindSearchType = nameof(FindMode.CaseInsensitive);
+        ReplaceIn = nameof(FindScope.TextAndOriginal);
     }
 }

--- a/src/ui/Logic/FindScope.cs
+++ b/src/ui/Logic/FindScope.cs
@@ -1,0 +1,15 @@
+namespace Nikse.SubtitleEdit.Logic;
+
+public partial class FindService
+{
+    /// <summary>
+    /// Which columns a find or replace covers while an original subtitle is loaded (translator
+    /// mode). Ignored when there is no original text - everything then targets the text column.
+    /// </summary>
+    public enum FindScope
+    {
+        TextAndOriginal,
+        TextOnly,
+        OriginalOnly,
+    }
+}

--- a/src/ui/Logic/FindService.cs
+++ b/src/ui/Logic/FindService.cs
@@ -16,6 +16,10 @@ public partial class FindService : IFindService
     public bool CurrentMatchInOriginal { get; set; }
     public bool WholeWord { get; set; }
     public FindMode CurrentFindMode { get; set; } = FindMode.CaseInsensitive;
+    public FindScope CurrentScope { get; set; } = FindScope.TextAndOriginal;
+
+    private bool IncludeText => CurrentScope != FindScope.OriginalOnly;
+    private bool IncludeOriginal => CurrentScope != FindScope.TextOnly;
 
     private List<string> _textLines = new List<string>();
     private List<string>? _originalTextLines;
@@ -133,11 +137,13 @@ public partial class FindService : IFindService
     }
 
     /// <summary>
-    /// Original text of a line, or null when no original subtitle is loaded.
+    /// Original text of a line, or null when no original subtitle is loaded or the current scope
+    /// leaves the original column out. Returning null here is what makes every column-advance
+    /// step treat the original as absent, so the scope needs no further handling in them.
     /// </summary>
     private string? GetOriginalLine(int lineIndex)
     {
-        if (_originalTextLines == null || lineIndex < 0 || lineIndex >= _originalTextLines.Count)
+        if (_originalTextLines == null || !IncludeOriginal || lineIndex < 0 || lineIndex >= _originalTextLines.Count)
         {
             return null;
         }
@@ -212,7 +218,7 @@ public partial class FindService : IFindService
         return CurrentLineNumber;
     }
 
-    public int Count(string searchText, IReadOnlyList<string> textLines, bool wholeWord, FindMode findMode, IReadOnlyList<string>? originalTextLines = null)
+    public int Count(string searchText, IReadOnlyList<string> textLines, bool wholeWord, FindMode findMode, IReadOnlyList<string>? originalTextLines = null, FindScope scope = FindScope.TextAndOriginal)
     {
         if (string.IsNullOrEmpty(searchText) || textLines == null || textLines.Count == 0)
         {
@@ -220,12 +226,15 @@ public partial class FindService : IFindService
         }
 
         var total = 0;
-        foreach (var line in textLines)
+        if (scope != FindScope.OriginalOnly)
         {
-            total += CountMatchesInLine(line, searchText, wholeWord, findMode);
+            foreach (var line in textLines)
+            {
+                total += CountMatchesInLine(line, searchText, wholeWord, findMode);
+            }
         }
 
-        if (originalTextLines != null)
+        if (originalTextLines != null && scope != FindScope.TextOnly)
         {
             foreach (var line in originalTextLines)
             {
@@ -266,17 +275,20 @@ public partial class FindService : IFindService
 
         int totalReplacements = 0;
 
-        for (int lineIndex = 0; lineIndex < _textLines.Count; lineIndex++)
+        if (IncludeText)
         {
-            var replacedText = ReplaceInLine(_textLines[lineIndex], searchText, replaceText);
-            if (replacedText.replaced)
+            for (int lineIndex = 0; lineIndex < _textLines.Count; lineIndex++)
             {
-                _textLines[lineIndex] = replacedText.newText;
-                totalReplacements += replacedText.replacementCount;
+                var replacedText = ReplaceInLine(_textLines[lineIndex], searchText, replaceText);
+                if (replacedText.replaced)
+                {
+                    _textLines[lineIndex] = replacedText.newText;
+                    totalReplacements += replacedText.replacementCount;
+                }
             }
         }
 
-        if (_originalTextLines != null)
+        if (_originalTextLines != null && IncludeOriginal)
         {
             for (int lineIndex = 0; lineIndex < _originalTextLines.Count; lineIndex++)
             {
@@ -350,7 +362,7 @@ public partial class FindService : IFindService
             var first = i == startLineIndex;
             var textIndex = first ? startTextIndex : 0;
 
-            if (!(first && startInOriginal))
+            if (IncludeText && !(first && startInOriginal))
             {
                 var match = FindInLine(_textLines[i], searchText, textIndex);
                 if (match.found)
@@ -398,11 +410,14 @@ public partial class FindService : IFindService
                 }
             }
 
-            var mainTextIndex = first && !startInOriginal ? startTextIndex : _textLines[i].Length - 1;
-            var mainMatch = FindInLineReverse(_textLines[i], searchText, mainTextIndex);
-            if (mainMatch.found)
+            if (IncludeText)
             {
-                return (i, mainMatch.index, mainMatch.foundText, false);
+                var mainTextIndex = first && !startInOriginal ? startTextIndex : _textLines[i].Length - 1;
+                var mainMatch = FindInLineReverse(_textLines[i], searchText, mainTextIndex);
+                if (mainMatch.found)
+                {
+                    return (i, mainMatch.index, mainMatch.foundText, false);
+                }
             }
         }
 

--- a/src/ui/Logic/IFindService.cs
+++ b/src/ui/Logic/IFindService.cs
@@ -17,13 +17,20 @@ public interface IFindService
 
     bool WholeWord { get; set; }
     FindMode CurrentFindMode { get; set; }
+
+    /// <summary>
+    /// Which columns the next find/replace covers. Sticky, so a find-next after the replace window
+    /// set it keeps the same scope; the find window resets it to <see cref="FindScope.TextAndOriginal"/>.
+    /// </summary>
+    FindScope CurrentScope { get; set; }
+
     IReadOnlyList<string> SearchHistory { get; }
 
     void Initialize(List<string> textLines, int currentLineIndex, bool wholeWord, FindMode findMode, List<string>? originalTextLines = null);
     int FindNext(string searchText, List<string> textLines, int currentLineIndex, int startTextIndex, List<string>? originalTextLines = null, bool startInOriginal = false);
     int FindPrevious(string searchText, List<string> textLines, int currentLineIndex, int startTextIndex, List<string>? originalTextLines = null, bool startInOriginal = false);
     int ReplaceAll(string searchText, string replaceText);
-    int Count(string searchText, IReadOnlyList<string> textLines, bool wholeWord, FindMode findMode, IReadOnlyList<string>? originalTextLines = null);
+    int Count(string searchText, IReadOnlyList<string> textLines, bool wholeWord, FindMode findMode, IReadOnlyList<string>? originalTextLines = null, FindScope scope = FindScope.TextAndOriginal);
     List<(int LineIndex, int TextIndex, string FoundText)> FindAll(string searchText);
     void Reset();
     void RemoveFromSearchHistory(string searchText);

--- a/tests/UI/Features/Edit/ReplaceWindowScopeTests.cs
+++ b/tests/UI/Features/Edit/ReplaceWindowScopeTests.cs
@@ -1,0 +1,81 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Features.Edit.Replace;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Linq;
+
+namespace UITests.Features.Edit;
+
+/// <summary>
+/// The "Replace/search in" picker (#13471). It is only meaningful with an editable original text
+/// column on screen, so it must stay out of the window entirely the rest of the time.
+/// </summary>
+public class ReplaceWindowScopeTests
+{
+    // Shown and closed inside the test, with the dispatcher flushed while the window is still
+    // alive: InitializeWindow posts a clamp-to-working-area job from Opened, which throws against
+    // the disposed platform implementation if it is left to run during session teardown.
+    private static bool IsScopePickerVisible(bool canEditOriginal)
+    {
+        var vm = new ReplaceViewModel();
+        vm.RefreshSubtitles(["Hello world"], ["Hallo Welt"], canEditOriginal);
+        var window = new ReplaceWindow(vm);
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var comboBox = window.GetLogicalDescendants()
+                .OfType<ComboBox>()
+                .FirstOrDefault(c => c.ItemsSource is IEnumerable<ReplaceScopeDisplay>);
+
+            Assert.NotNull(comboBox);
+            return comboBox!.IsEffectivelyVisible;
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void ScopePicker_IsShown_WhenOriginalIsEditable()
+    {
+        Assert.True(IsScopePickerVisible(canEditOriginal: true));
+    }
+
+    [AvaloniaFact]
+    public void ScopePicker_IsHidden_WhenThereIsNoEditableOriginal()
+    {
+        Assert.False(IsScopePickerVisible(canEditOriginal: false));
+    }
+
+    // A scope the user could not see must not be saved over their remembered choice, and must not
+    // reach the find service either - both columns is the only meaningful scope without an original.
+    [AvaloniaFact]
+    public void EffectiveScope_IsBothColumns_WhenPickerIsHidden()
+    {
+        var vm = new ReplaceViewModel();
+        vm.RefreshSubtitles(["Hello world"], null, canEditOriginal: false);
+        vm.SelectedScope = vm.Scopes.First(p => p.Scope == FindService.FindScope.OriginalOnly);
+
+        Assert.Equal(FindService.FindScope.TextAndOriginal, vm.EffectiveScope);
+
+        var before = Se.Settings.Edit.Find.ReplaceIn;
+        vm.SaveSettings();
+        Assert.Equal(before, Se.Settings.Edit.Find.ReplaceIn);
+    }
+
+    [AvaloniaFact]
+    public void EffectiveScope_FollowsSelection_WhenPickerIsShown()
+    {
+        var vm = new ReplaceViewModel();
+        vm.RefreshSubtitles(["Hello world"], ["Hallo Welt"], canEditOriginal: true);
+        vm.SelectedScope = vm.Scopes.First(p => p.Scope == FindService.FindScope.TextOnly);
+
+        Assert.Equal(FindService.FindScope.TextOnly, vm.EffectiveScope);
+    }
+}

--- a/tests/UI/Logic/FindServiceTests.cs
+++ b/tests/UI/Logic/FindServiceTests.cs
@@ -271,4 +271,122 @@ public class FindServiceTests
         Assert.Equal(0, idx);
         Assert.False(service.CurrentMatchInOriginal);
     }
+
+    // #13471: searching both columns is not always wanted - the replace window can narrow the
+    // scope to one column, as SE 4's "Replace/search in" combo box did.
+    [Fact]
+    public void FindNext_TextOnly_IgnoresOriginalText()
+    {
+        var lines = new List<string> { "nothing here", "hello world" };
+        var originals = new List<string> { "hello again", "nothing either" };
+        var service = new FindService { CurrentScope = FindService.FindScope.TextOnly };
+        service.Initialize(lines, 0, false, FindService.FindMode.CaseInsensitive, originals);
+
+        var idx = service.FindNext("hello", lines, 0, 0, originals);
+
+        Assert.Equal(1, idx);
+        Assert.False(service.CurrentMatchInOriginal);
+    }
+
+    [Fact]
+    public void FindNext_OriginalOnly_IgnoresText()
+    {
+        var lines = new List<string> { "hello world", "nothing here" };
+        var originals = new List<string> { "nothing either", "hello again" };
+        var service = new FindService { CurrentScope = FindService.FindScope.OriginalOnly };
+        service.Initialize(lines, 0, false, FindService.FindMode.CaseInsensitive, originals);
+
+        var idx = service.FindNext("hello", lines, 0, 0, originals, true);
+
+        Assert.Equal(1, idx);
+        Assert.True(service.CurrentMatchInOriginal);
+    }
+
+    [Fact]
+    public void FindPrevious_TextOnly_IgnoresOriginalText()
+    {
+        var lines = new List<string> { "hello world", "nothing here" };
+        var originals = new List<string> { "nothing either", "hello again" };
+        var service = new FindService { CurrentScope = FindService.FindScope.TextOnly };
+        service.Initialize(lines, 0, false, FindService.FindMode.CaseInsensitive, originals);
+
+        var idx = service.FindPrevious("hello", lines, 1, lines[1].Length - 1, originals);
+
+        Assert.Equal(0, idx);
+        Assert.False(service.CurrentMatchInOriginal);
+    }
+
+    [Fact]
+    public void FindPrevious_OriginalOnly_IgnoresText()
+    {
+        var lines = new List<string> { "hello world", "nothing here" };
+        var originals = new List<string> { "hello again", "nothing either" };
+        var service = new FindService { CurrentScope = FindService.FindScope.OriginalOnly };
+        service.Initialize(lines, 0, false, FindService.FindMode.CaseInsensitive, originals);
+
+        var idx = service.FindPrevious("hello", lines, 1, originals[1].Length - 1, originals, true);
+
+        Assert.Equal(0, idx);
+        Assert.True(service.CurrentMatchInOriginal);
+    }
+
+    [Theory]
+    [InlineData(FindService.FindScope.TextAndOriginal, 3)]
+    [InlineData(FindService.FindScope.TextOnly, 1)]
+    [InlineData(FindService.FindScope.OriginalOnly, 2)]
+    public void Count_HonoursScope(FindService.FindScope scope, int expected)
+    {
+        var lines = new List<string> { "hello world", "nothing" };
+        var originals = new List<string> { "hello again", "hello once more" };
+        var service = new FindService();
+
+        var count = service.Count("hello", lines, false, FindService.FindMode.CaseInsensitive, originals, scope);
+
+        Assert.Equal(expected, count);
+    }
+
+    [Fact]
+    public void ReplaceAll_TextOnly_LeavesOriginalUntouched()
+    {
+        var lines = new List<string> { "hello world" };
+        var originals = new List<string> { "hello again" };
+        var service = new FindService { CurrentScope = FindService.FindScope.TextOnly };
+        service.Initialize(lines, 0, false, FindService.FindMode.CaseInsensitive, originals);
+
+        var count = service.ReplaceAll("hello", "hi");
+
+        Assert.Equal(1, count);
+        Assert.Equal("hi world", lines[0]);
+        Assert.Equal("hello again", originals[0]);
+    }
+
+    [Fact]
+    public void ReplaceAll_OriginalOnly_LeavesTextUntouched()
+    {
+        var lines = new List<string> { "hello world" };
+        var originals = new List<string> { "hello again" };
+        var service = new FindService { CurrentScope = FindService.FindScope.OriginalOnly };
+        service.Initialize(lines, 0, false, FindService.FindMode.CaseInsensitive, originals);
+
+        var count = service.ReplaceAll("hello", "hi");
+
+        Assert.Equal(1, count);
+        Assert.Equal("hello world", lines[0]);
+        Assert.Equal("hi again", originals[0]);
+    }
+
+    // The scope is about which columns exist to search - with no original loaded, "original only"
+    // must not silently swallow the text column.
+    [Fact]
+    public void ReplaceAll_OriginalOnly_WithoutOriginals_ReplacesNothing()
+    {
+        var lines = new List<string> { "hello world" };
+        var service = new FindService { CurrentScope = FindService.FindScope.OriginalOnly };
+        service.Initialize(lines, 0, false, FindService.FindMode.CaseInsensitive);
+
+        var count = service.ReplaceAll("hello", "hi");
+
+        Assert.Equal(0, count);
+        Assert.Equal("hello world", lines[0]);
+    }
 }


### PR DESCRIPTION
Fixes #13471.

Since #13053 find and replace cover both the text and the original text in translator mode, so `Ctrl+H` changes the original subtitle as well — which is not always wanted.

## How SE 4 handled it

The reporter is right that SE 4 had an option, and it lived in the replace dialog rather than in the settings:

- **Replace (`Ctrl+H`)**: a *"Replace/search in:"* combo box — *Translation and original* / *Translation only* / *Original only* — persisted in `Configuration.Settings.Tools.ReplaceIn`, enabled only while an editable original text column was on screen.
- **Find (`Ctrl+F`)**: no scope picker at all; it always set `SearchOriginal = true; SearchTranslation = true`.
- In both, the original was searched only when `Configuration.Settings.General.AllowEditOfOriginalSubtitle` was on.

## This PR

The same picker, worded for SE 5's own column names:

- The replace window gets a **Replace/search in** drop-down: *Text and original text* (default) / *Text only* / *Original text only*, remembered in `Edit.Find.ReplaceIn`.
- It is **hidden** — rather than disabled, as in SE 4 — when there is no original text column, or when the original was opened as a read-only reference that must not be written to. A scope the user could not see is neither applied nor saved.
- `FindService` grows a sticky `CurrentScope` honoured by the column walk, `Count` and `ReplaceAll`. `F3` / `Shift+F3` inherit it, so a scoped replace stays scoped; opening the find window resets it to both columns, the way SE 4's find dialog built a fresh helper with both flags set.

Two SE 4 bugs deliberately not carried over: its `FindPrevious` has the two scope flags swapped relative to `FindNext`, and additionally requires an original subtitle before it will search the translation at all.

`English.json` also picks up `bdnXml8Bit`, `xOfYFiles` and `numberOfSubtitlesXForcedY`, which were already in the language classes but had not been regenerated. The four new strings have no SE 4 keys in the shipped language files to inherit from, so they ship English-only until translated.

## Testing

- 9 new `FindServiceTests` covering find/find-previous/count/replace-all under each scope, including *Original text only* with no original loaded.
- 4 new headless `ReplaceWindowScopeTests` covering the picker's visibility and the effective/saved scope.
- Full UI suite green (2334 tests; the one `MainMenuKeyboardActivationTests` failure is the known flaky family and passes on rerun).

🤖 Generated with [Claude Code](https://claude.com/claude-code)