### PR TITLE
Retry AI review requests without the parameters the engine rejects (#13473)

### DIFF
--- a/src/ui/Features/Tools/AiReview/AiReviewClient.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewClient.cs
@@ -18,6 +18,11 @@ public class AiReviewClient : IDisposable
 {
     private readonly HttpClient _httpClient;
 
+    // A server accepts or rejects an optional parameter for every request alike, so remember what it
+    // turned down instead of paying a failed request per chunk for the rest of the run.
+    private bool _temperatureUnsupported;
+    private bool _jsonObjectUnsupported;
+
     public string Error { get; private set; } = string.Empty;
 
     public AiReviewClient()
@@ -32,13 +37,40 @@ public class AiReviewClient : IDisposable
 
         // AI review wants a JSON object back; the text box assistant wants the plain
         // reply, so it passes preferJsonObject: false to avoid a JSON-wrapped answer.
-        // Some servers reject response_format, so a JSON request also retries plain.
-        var response = await PostAsync(url,
-            BuildRequestJson(model, systemPrompt, userContent, jsonMode: preferJsonObject),
-            apiKey, cancellationToken);
-        if (!response.ok && preferJsonObject && !cancellationToken.IsCancellationRequested)
+        var jsonMode = preferJsonObject && !_jsonObjectUnsupported;
+        var includeTemperature = !_temperatureUnsupported;
+
+        (bool ok, string body) response;
+        while (true)
         {
-            response = await PostAsync(url, BuildRequestJson(model, systemPrompt, userContent, jsonMode: false), apiKey, cancellationToken);
+            response = await PostAsync(url,
+                BuildRequestJson(model, systemPrompt, userContent, jsonMode, includeTemperature),
+                apiKey, cancellationToken);
+            if (response.ok || cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            // OpenAI's reasoning models (gpt-5*, o*) only accept the default temperature and answer
+            // "Unsupported value: 'temperature' does not support 0 with this model" - see issue #13473.
+            if (includeTemperature && IsUnsupportedParameter(response.body, "temperature"))
+            {
+                _temperatureUnsupported = true;
+                includeTemperature = false;
+                continue;
+            }
+
+            // Some servers reject response_format, so a JSON request also retries plain. Only remember
+            // it when the server actually named the parameter - a rate limit or a network blip must not
+            // downgrade every later request in the run.
+            if (jsonMode)
+            {
+                _jsonObjectUnsupported = IsUnsupportedParameter(response.body, "response_format");
+                jsonMode = false;
+                continue;
+            }
+
+            break;
         }
 
         if (!response.ok)
@@ -51,7 +83,25 @@ public class AiReviewClient : IDisposable
         return ExtractContent(response.body);
     }
 
-    private static string BuildRequestJson(string model, string systemPrompt, string userContent, bool jsonMode)
+    /// <summary>
+    /// True when an error body blames a request parameter by name, like OpenAI's
+    /// "Unsupported value: 'temperature' does not support 0 with this model." (issue #13473).
+    /// </summary>
+    internal static bool IsUnsupportedParameter(string? body, string parameterName)
+    {
+        if (string.IsNullOrEmpty(body) || body.IndexOf(parameterName, StringComparison.OrdinalIgnoreCase) < 0)
+        {
+            return false;
+        }
+
+        return body.Contains("unsupported", StringComparison.OrdinalIgnoreCase) ||
+               body.Contains("not support", StringComparison.OrdinalIgnoreCase) ||
+               body.Contains("unrecognized", StringComparison.OrdinalIgnoreCase) ||
+               body.Contains("invalid", StringComparison.OrdinalIgnoreCase) ||
+               body.Contains("unknown", StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static string BuildRequestJson(string model, string systemPrompt, string userContent, bool jsonMode, bool includeTemperature)
     {
         using var stream = new System.IO.MemoryStream();
         using (var writer = new Utf8JsonWriter(stream))
@@ -62,7 +112,11 @@ public class AiReviewClient : IDisposable
                 writer.WriteString("model", model);
             }
 
-            writer.WriteNumber("temperature", 0);
+            if (includeTemperature)
+            {
+                writer.WriteNumber("temperature", 0);
+            }
+
             writer.WriteBoolean("stream", false);
             if (jsonMode)
             {

--- a/tests/UI/Features/Tools/AiReview/AiReviewClientTests.cs
+++ b/tests/UI/Features/Tools/AiReview/AiReviewClientTests.cs
@@ -1,0 +1,254 @@
+using System.Net.Sockets;
+using System.Text;
+using Nikse.SubtitleEdit.Features.Tools.AiReview;
+
+namespace UITests.Features.Tools.AiReview;
+
+/// <summary>
+/// Regression tests for issue #13473: AI review always sent "temperature": 0, which OpenAI's
+/// reasoning models (gpt-5*, o*) reject with "Only the default (1) value is supported", and the
+/// single retry only dropped response_format - so every request failed.
+/// </summary>
+public class AiReviewClientTests
+{
+    private const string TemperatureError =
+        "{ \"error\": { \"message\": \"Unsupported value: 'temperature' does not support 0 with this model. " +
+        "Only the default (1) value is supported.\", \"type\": \"invalid_request_error\", " +
+        "\"param\": \"temperature\", \"code\": \"unsupported_value\" } }";
+
+    private const string ResponseFormatError =
+        "{ \"error\": { \"message\": \"Unrecognized request argument supplied: response_format\", " +
+        "\"type\": \"invalid_request_error\" } }";
+
+    private const string RateLimitError =
+        "{ \"error\": { \"message\": \"Rate limit reached for gpt-5.6-luna, please try again later.\", " +
+        "\"type\": \"requests\", \"code\": \"rate_limit_exceeded\" } }";
+
+    private const string Reply = "{ \"choices\": [ { \"message\": { \"content\": \"all good\" } } ] }";
+
+    [Fact]
+    public void BuildRequestJson_IncludesTemperatureAndJsonMode()
+    {
+        var json = AiReviewClient.BuildRequestJson("gpt-5.6-luna", "system", "user", jsonMode: true, includeTemperature: true);
+
+        Assert.Contains("\"temperature\":0", json);
+        Assert.Contains("\"response_format\":{\"type\":\"json_object\"}", json);
+    }
+
+    [Fact]
+    public void BuildRequestJson_CanOmitTemperature()
+    {
+        var json = AiReviewClient.BuildRequestJson("gpt-5.6-luna", "system", "user", jsonMode: false, includeTemperature: false);
+
+        Assert.DoesNotContain("temperature", json);
+        Assert.DoesNotContain("response_format", json);
+        Assert.Contains("\"model\":\"gpt-5.6-luna\"", json);
+    }
+
+    [Theory]
+    [InlineData(TemperatureError, "temperature", true)]
+    [InlineData(TemperatureError, "response_format", false)]
+    [InlineData(ResponseFormatError, "response_format", true)]
+    [InlineData(ResponseFormatError, "temperature", false)]
+    [InlineData(RateLimitError, "temperature", false)]
+    [InlineData(RateLimitError, "response_format", false)]
+    [InlineData("", "temperature", false)]
+    public void IsUnsupportedParameter_OnlyMatchesParameterRejections(string body, string parameterName, bool expected)
+    {
+        Assert.Equal(expected, AiReviewClient.IsUnsupportedParameter(body, parameterName));
+    }
+
+    [Fact]
+    public async Task ChatAsync_RetriesWithoutTemperature_WhenTheModelRejectsIt()
+    {
+        using var server = new StubServer(body => body.Contains("\"temperature\"")
+            ? (400, TemperatureError)
+            : (200, Reply));
+        using var client = new AiReviewClient();
+
+        var reply = await client.ChatAsync(server.Url, "gpt-5.6-luna", "system", "user", CancellationToken.None);
+
+        Assert.Equal("all good", reply);
+        Assert.Equal(2, server.Requests.Count);
+        Assert.Contains("\"temperature\"", server.Requests[0]);
+        Assert.DoesNotContain("\"temperature\"", server.Requests[1]);
+
+        // The rejection sticks, so later chunks go straight out without temperature.
+        await client.ChatAsync(server.Url, "gpt-5.6-luna", "system", "user two", CancellationToken.None);
+        Assert.Equal(3, server.Requests.Count);
+        Assert.DoesNotContain("\"temperature\"", server.Requests[2]);
+    }
+
+    [Fact]
+    public async Task ChatAsync_DropsTemperatureAndJsonMode_WhenTheServerRejectsBoth()
+    {
+        using var server = new StubServer(body =>
+        {
+            if (body.Contains("\"response_format\""))
+            {
+                return (400, ResponseFormatError);
+            }
+
+            return body.Contains("\"temperature\"") ? (400, TemperatureError) : (200, Reply);
+        });
+        using var client = new AiReviewClient();
+
+        var reply = await client.ChatAsync(server.Url, "some-model", "system", "user", CancellationToken.None);
+
+        Assert.Equal("all good", reply);
+        Assert.Equal(3, server.Requests.Count);
+        Assert.DoesNotContain("\"response_format\"", server.Requests[2]);
+        Assert.DoesNotContain("\"temperature\"", server.Requests[2]);
+    }
+
+    [Fact]
+    public async Task ChatAsync_KeepsJsonMode_WhenTheFailureIsNotAboutParameters()
+    {
+        using var server = new StubServer(_ => (429, RateLimitError));
+        using var client = new AiReviewClient();
+
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            client.ChatAsync(server.Url, "gpt-5.6-luna", "system", "user", CancellationToken.None));
+
+        // Today's behavior: a JSON request still retries plain once, but a rate limit must not
+        // downgrade the rest of the run.
+        Assert.Equal(2, server.Requests.Count);
+        Assert.Contains("\"response_format\"", server.Requests[0]);
+        Assert.Contains(RateLimitError, client.Error);
+
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            client.ChatAsync(server.Url, "gpt-5.6-luna", "system", "user two", CancellationToken.None));
+        Assert.Contains("\"response_format\"", server.Requests[2]);
+    }
+
+    /// <summary>
+    /// Minimal HTTP/1.1 server on loopback - HttpListener needs a URL ACL on Windows, and the
+    /// requests here are simple enough to answer from a raw socket.
+    /// </summary>
+    private sealed class StubServer : IDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly CancellationTokenSource _cancellationTokenSource = new();
+        private readonly List<string> _requests = new();
+        private readonly object _lock = new();
+
+        public StubServer(Func<string, (int status, string body)> respond)
+        {
+            _listener = new TcpListener(System.Net.IPAddress.Loopback, 0);
+            _listener.Start();
+            Url = "http://127.0.0.1:" + ((System.Net.IPEndPoint)_listener.LocalEndpoint).Port + "/v1/chat/completions";
+            _ = Task.Run(() => AcceptLoopAsync(respond));
+        }
+
+        public string Url { get; }
+
+        public List<string> Requests
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return new List<string>(_requests);
+                }
+            }
+        }
+
+        private async Task AcceptLoopAsync(Func<string, (int status, string body)> respond)
+        {
+            while (!_cancellationTokenSource.IsCancellationRequested)
+            {
+                TcpClient client;
+                try
+                {
+                    client = await _listener.AcceptTcpClientAsync(_cancellationTokenSource.Token);
+                }
+                catch (Exception)
+                {
+                    return; // the test disposed the server
+                }
+
+                using (client)
+                {
+                    try
+                    {
+                        var requestBody = await ReadRequestBodyAsync(client.GetStream());
+                        lock (_lock)
+                        {
+                            _requests.Add(requestBody);
+                        }
+
+                        var (status, body) = respond(requestBody);
+                        var payload = Encoding.UTF8.GetBytes(body);
+                        var header = Encoding.ASCII.GetBytes(
+                            "HTTP/1.1 " + status + " \r\n" +
+                            "Content-Type: application/json\r\n" +
+                            "Content-Length: " + payload.Length + "\r\n" +
+                            "Connection: close\r\n\r\n");
+                        await client.GetStream().WriteAsync(header);
+                        await client.GetStream().WriteAsync(payload);
+                        await client.GetStream().FlushAsync();
+                    }
+                    catch (Exception)
+                    {
+                        // a half-open connection is not worth failing the test over
+                    }
+                }
+            }
+        }
+
+        private static async Task<string> ReadRequestBodyAsync(NetworkStream stream)
+        {
+            var buffer = new byte[8192];
+            var received = new MemoryStream();
+            var headerEnd = -1;
+            var contentLength = 0;
+
+            while (true)
+            {
+                if (headerEnd < 0)
+                {
+                    var text = Encoding.UTF8.GetString(received.GetBuffer(), 0, (int)received.Length);
+                    headerEnd = text.IndexOf("\r\n\r\n", StringComparison.Ordinal);
+                    if (headerEnd >= 0)
+                    {
+                        contentLength = ReadContentLength(text.Substring(0, headerEnd));
+                    }
+                }
+
+                if (headerEnd >= 0 && received.Length - (headerEnd + 4) >= contentLength)
+                {
+                    return Encoding.UTF8.GetString(received.GetBuffer(), headerEnd + 4, contentLength);
+                }
+
+                var read = await stream.ReadAsync(buffer);
+                if (read == 0)
+                {
+                    return string.Empty;
+                }
+
+                received.Write(buffer, 0, read);
+            }
+        }
+
+        private static int ReadContentLength(string header)
+        {
+            foreach (var line in header.Split("\r\n"))
+            {
+                if (line.StartsWith("Content-Length:", StringComparison.OrdinalIgnoreCase) &&
+                    int.TryParse(line.Substring("Content-Length:".Length).Trim(), out var length))
+                {
+                    return length;
+                }
+            }
+
+            return 0;
+        }
+
+        public void Dispose()
+        {
+            _cancellationTokenSource.Cancel();
+            _listener.Stop();
+            _cancellationTokenSource.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #13473.

AI review always sent `"temperature": 0`, and the single retry only dropped `response_format` — so against OpenAI's reasoning models (`gpt-5*`, `o*`) both attempts failed and the feature was unusable:

> Unsupported value: 'temperature' does not support 0 with this model. Only the default (1) value is supported.

There is no temperature UI, so users had no workaround (the `0` spinner in the report is the request delay). The text box AI assistant shares the client and had the same problem.

## Change

`AiReviewClient` now retries adaptively: when an error body names a parameter, that parameter is dropped and the request goes out again — at most three posts.

- `temperature` named → retry without it.
- Otherwise, a JSON request still retries plain once (today's behaviour).
- Rejections are remembered per client instance, so a long review doesn't pay a failed request per chunk.
- Stickiness only applies when the server actually named the parameter, so a 429 or a network blip no longer costs the JSON response format for the rest of the run.

Local llama.cpp/Ollama keep `temperature: 0`, so deterministic proofreading is unchanged; only engines that refuse it fall back to their default.

## Tests

New `AiReviewClientTests` (12 cases): request-body shape, the `IsUnsupportedParameter` truth table (including the exact OpenAI body from the issue and a rate-limit body that must not match), and three end-to-end retry sequences against a small loopback `TcpListener` stub — temperature rejected, both parameters rejected, and rate-limited-so-nothing-sticks. A raw socket rather than `HttpListener`, which would need a URL ACL on Windows CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)