### PR TITLE
VobSub color isolation fixes

### DIFF
--- a/src/libse/Common/VobSubColorIsolation.cs
+++ b/src/libse/Common/VobSubColorIsolation.cs
@@ -43,7 +43,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             var height = source.Height;
             var result = new SKBitmap(new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Opaque));
 
-            // Tally every opaque colour and how many of its pixels touch the transparent
+            // Tally every opaque colour and how often totally its pixels touch the transparent
             // background (4-neighbourhood; the bitmap edge counts as background). Key on RGB
             // only (alpha already gates the background) so anti-aliasing tiers that share a
             // hue but differ in coverage still merge.
@@ -61,14 +61,14 @@ namespace Nikse.SubtitleEdit.Core.Common
                     var key = (uint)((c.Red << 16) | (c.Green << 8) | c.Blue);
                     counts[key] = counts.TryGetValue(key, out var n) ? n + 1 : 1;
 
-                    var touchesBackground =
-                        x == 0 || source.GetPixel(x - 1, y).Alpha < alphaThreshold ||
-                        x == width - 1 || source.GetPixel(x + 1, y).Alpha < alphaThreshold ||
-                        y == 0 || source.GetPixel(x, y - 1).Alpha < alphaThreshold ||
-                        y == height - 1 || source.GetPixel(x, y + 1).Alpha < alphaThreshold;
-                    if (touchesBackground)
+                    var nb = 0;
+                    if (x == 0 || source.GetPixel(x - 1, y).Alpha < alphaThreshold) { nb++; }
+                    if (x == width - 1 || source.GetPixel(x + 1, y).Alpha < alphaThreshold) { nb++; }
+                    if (y == 0 || source.GetPixel(x, y - 1).Alpha < alphaThreshold) { nb++; }
+                    if (y == height - 1 || source.GetPixel(x, y + 1).Alpha < alphaThreshold) { nb++; }
+                    if (nb > 0)
                     {
-                        borderCounts[key] = borderCounts.TryGetValue(key, out var b) ? b + 1 : 1;
+                        borderCounts[key] = borderCounts.TryGetValue(key, out var b) ? b + nb : nb;
                     }
                 }
             }
@@ -93,7 +93,8 @@ namespace Nikse.SubtitleEdit.Core.Common
             {
                 opaqueTotal += kv.Value;
             }
-            var minPlane = Math.Max(16, opaqueTotal / 20);
+            // Catch also texts like ".." in thin font
+            var minPlane = Math.Max(8, opaqueTotal / 20);
 
             var foreground = 0u;
             var bestRatio = double.MaxValue;
@@ -105,7 +106,9 @@ namespace Nikse.SubtitleEdit.Core.Common
                     continue;
                 }
                 considered++;
-                var ratio = borderCounts.TryGetValue(kv.Key, out var b) ? (double)b / kv.Value : 0.0;
+                // A fixed 0 (like from the aliasing between i & its dot) would always win.
+                // We use Laplace smoothing to avoid this & let the real text win.
+                var ratio = borderCounts.TryGetValue(kv.Key, out var b) ? (double)(b + 1) / (kv.Value + 1) : 1.0 / (kv.Value + 1);
                 if (ratio < bestRatio || (Math.Abs(ratio - bestRatio) < 0.0001 && kv.Key < foreground))
                 {
                     bestRatio = ratio;

--- a/src/libse/Common/VobSubColorIsolation.cs
+++ b/src/libse/Common/VobSubColorIsolation.cs
@@ -17,7 +17,8 @@ namespace Nikse.SubtitleEdit.Core.Common
     ///
     /// This pass rebuilds a crisp black-on-white bitmap from plane topology: transparent
     /// pixels are the background, and of the opaque colours the one that is most *interior*
-    /// — the smallest fraction of its pixels bordering the transparent background — is the
+    /// — the lowest background adjacency per pixel (background-facing pixel sides divided
+    /// by pixel count, Laplace-smoothed) — is the
     /// glyph fill (kept as black); every other opaque colour (the outline / anti-alias
     /// tiers, which by construction wrap the fill and face the background) collapses into
     /// the white background. The result is a clean binary mask that OCR engines recognise
@@ -43,10 +44,12 @@ namespace Nikse.SubtitleEdit.Core.Common
             var height = source.Height;
             var result = new SKBitmap(new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Opaque));
 
-            // Tally every opaque colour and how often totally its pixels touch the transparent
-            // background (4-neighbourhood; the bitmap edge counts as background). Key on RGB
-            // only (alpha already gates the background) so anti-aliasing tiers that share a
-            // hue but differ in coverage still merge.
+            // Tally every opaque colour: its pixel count, and its background adjacency as the
+            // number of background-facing sides (0–4) per pixel (4-neighbourhood; the bitmap
+            // edge counts as background). Counting sides rather than pixels makes one-pixel-thin
+            // outline runs — background on both flanks — score double, separating them further
+            // from the compact fill. Key on RGB only (alpha already gates the background) so
+            // anti-aliasing tiers that share a hue but differ in coverage still merge.
             var counts = new Dictionary<uint, int>();
             var borderCounts = new Dictionary<uint, int>();
             for (var y = 0; y < height; y++)
@@ -82,18 +85,23 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return result;
             }
 
-            // The glyph fill is the most interior plane: lowest share of its pixels facing
-            // the transparent background. The outline faces the background on (at least) its
-            // outer edge, and the anti-alias tier is the boundary itself, so both score
-            // higher. Planes too small to be the text body (speckle, stray anti-alias
-            // colours) are ignored unless nothing bigger exists. Ties resolve to the lowest
-            // colour key so the output is deterministic regardless of dictionary order.
+            // The glyph fill is the most interior plane: lowest background adjacency per
+            // pixel. The outline faces the background on (at least) its outer edge, and the
+            // anti-alias tier is the boundary itself, so both score higher. Planes too small
+            // to be the text body (speckle, stray anti-alias colours) are ignored unless
+            // nothing bigger exists. The floor sits at 8 pixels, not higher: very short text
+            // in a thin font (".", "..") can leave the fill plane under 16 pixels while the
+            // outline clears it, and a floor that excludes only the fill hands the frame to
+            // the outline (PR #13481). The cost is that an 8–15 px fully-enclosed speckle
+            // plane may now compete — accepted, since a colour that exists *only* inside a
+            // cavity does not occur in normally-authored 4-colour subpictures. Ties resolve
+            // to the lowest colour key so the output is deterministic regardless of
+            // dictionary order.
             var opaqueTotal = 0;
             foreach (var kv in counts)
             {
                 opaqueTotal += kv.Value;
             }
-            // Catch also texts like ".." in thin font
             var minPlane = Math.Max(8, opaqueTotal / 20);
 
             var foreground = 0u;
@@ -106,9 +114,12 @@ namespace Nikse.SubtitleEdit.Core.Common
                     continue;
                 }
                 considered++;
-                // A fixed 0 (like from the aliasing between i & its dot) would always win.
-                // We use Laplace smoothing to avoid this & let the real text win.
-                var ratio = borderCounts.TryGetValue(kv.Key, out var b) ? (double)(b + 1) / (kv.Value + 1) : 1.0 / (kv.Value + 1);
+                // A plane that never touches the background (the anti-alias tier trapped
+                // between fill and outline, e.g. bridging an i-dot gap) would score a flat
+                // 0.0 and tie with a fully-outlined fill, letting the colour-key tie-break
+                // pick the wrong plane. Laplace smoothing (+1) turns that tie into a size
+                // contest the larger text body wins.
+                var ratio = (borderCounts.TryGetValue(kv.Key, out var b) ? b + 1.0 : 1.0) / (kv.Value + 1);
                 if (ratio < bestRatio || (Math.Abs(ratio - bestRatio) < 0.0001 && kv.Key < foreground))
                 {
                     bestRatio = ratio;

--- a/tests/libse/Common/VobSubColorIsolationTest.cs
+++ b/tests/libse/Common/VobSubColorIsolationTest.cs
@@ -1,0 +1,136 @@
+using Nikse.SubtitleEdit.Core.Common;
+using SkiaSharp;
+
+namespace LibSETests.Common;
+
+// VobSubColorIsolation.Isolate rebuilds a black-on-white OCR bitmap by keeping only the
+// glyph-fill colour plane — the most interior one (lowest background adjacency). These
+// tests build tiny synthetic indexed bitmaps and assert which plane survives.
+public class VobSubColorIsolationTest
+{
+    private static readonly SKColor Fill = new SKColor(255, 255, 255);
+    private static readonly SKColor Outline = new SKColor(0, 0, 1);
+    private static readonly SKColor AntiAlias = new SKColor(128, 128, 128);
+
+    [Fact]
+    public void Isolate_BlankFrame_ReturnsAllWhite()
+    {
+        using var source = MakeTransparent(8, 8);
+        using var result = VobSubColorIsolation.Isolate(source);
+        AssertPlaneKept(result, source, null);
+    }
+
+    // The classic #12772 case: the outline holds more pixels than the fill, so frequency
+    // alone picks the wrong plane; interiority must win.
+    [Fact]
+    public void Isolate_OutlineLargerThanFill_KeepsFill()
+    {
+        using var source = MakeTransparent(24, 24);
+        FillRect(source, 2, 2, 20, 20, Outline);   // 4-px thick ring after fill overwrite
+        FillRect(source, 6, 6, 12, 12, Fill);
+        using var result = VobSubColorIsolation.Isolate(source);
+        AssertPlaneKept(result, source, Fill);
+    }
+
+    // PR #13481 regression: an anti-alias tier fully trapped between fill and outline
+    // (e.g. bridging the gap between an i-dot and its stem) never touches the background.
+    // Unsmoothed it ties with the fully-outlined fill at ratio 0.0 and the colour-key
+    // tie-break picks the (lower-keyed) grey tier, wiping the text. Laplace smoothing
+    // must let the larger fill win.
+    [Fact]
+    public void Isolate_TrappedAntiAliasTier_KeepsFill()
+    {
+        using var source = MakeTransparent(12, 30);
+        // Outline envelope around dot and stem, bridging the gap between them.
+        FillRect(source, 2, 2, 8, 26, Outline);
+        // Anti-alias tier strictly inside the outline (fully trapped, borderCount = 0).
+        FillRect(source, 3, 3, 6, 5, AntiAlias);   // around the dot
+        FillRect(source, 3, 12, 6, 15, AntiAlias); // around the stem
+        // Fill strictly inside the anti-alias tier (also borderCount = 0, but larger).
+        FillRect(source, 4, 4, 4, 3, Fill);        // dot
+        FillRect(source, 4, 13, 4, 13, Fill);      // stem
+        using var result = VobSubColorIsolation.Isolate(source);
+        AssertPlaneKept(result, source, Fill);
+    }
+
+    // PR #13481: very short text in a thin font (".") can leave the fill plane under the
+    // old 16-pixel floor while the outline clears it, so only the outline was considered
+    // and the text was wiped. The floor must relax so the fill can compete.
+    [Fact]
+    public void Isolate_ThinFontShortText_KeepsSmallFill()
+    {
+        using var source = MakeTransparent(10, 10);
+        FillRect(source, 2, 2, 6, 6, Outline); // 36 px ring after fill overwrite
+        FillRect(source, 4, 4, 3, 3, Fill);    // 9 px fill: >= 8, < 16
+        using var result = VobSubColorIsolation.Isolate(source);
+        AssertPlaneKept(result, source, Fill);
+    }
+
+    // Guard for the 8-pixel floor: a plane below it that is trapped inside the fill
+    // (borderCount 0) would beat any background-touching fill under smoothing, so the
+    // floor must keep excluding it.
+    [Fact]
+    public void Isolate_SpeckBelowFloorInsideFill_DoesNotStealForeground()
+    {
+        using var source = MakeTransparent(20, 12);
+        FillRect(source, 3, 3, 14, 6, Fill);       // 84 px, touches background
+        FillRect(source, 8, 5, 3, 2, AntiAlias);   // 6 px speck, fully enclosed, below floor
+        using var result = VobSubColorIsolation.Isolate(source);
+        AssertPlaneKept(result, source, Fill);
+    }
+
+    // When every plane is speckle-sized the frequency fallback keeps the biggest one
+    // instead of blanking the frame.
+    [Fact]
+    public void Isolate_OnlySpeckles_FallsBackToMostFrequent()
+    {
+        using var source = MakeTransparent(12, 6);
+        FillRect(source, 1, 1, 3, 2, Fill);      // 6 px
+        FillRect(source, 7, 1, 2, 2, AntiAlias); // 4 px
+        using var result = VobSubColorIsolation.Isolate(source);
+        AssertPlaneKept(result, source, Fill);
+    }
+
+    private static SKBitmap MakeTransparent(int width, int height)
+    {
+        var bmp = new SKBitmap(new SKImageInfo(width, height, SKColorType.Bgra8888, SKAlphaType.Unpremul));
+        bmp.Erase(SKColors.Transparent);
+        return bmp;
+    }
+
+    private static void FillRect(SKBitmap bmp, int x, int y, int width, int height, SKColor color)
+    {
+        for (var yy = y; yy < y + height; yy++)
+        {
+            for (var xx = x; xx < x + width; xx++)
+            {
+                bmp.SetPixel(xx, yy, color);
+            }
+        }
+    }
+
+    // Every source pixel of `kept` must come out black; every other pixel white.
+    private static void AssertPlaneKept(SKBitmap result, SKBitmap source, SKColor? kept)
+    {
+        for (var y = 0; y < source.Height; y++)
+        {
+            for (var x = 0; x < source.Width; x++)
+            {
+                var s = source.GetPixel(x, y);
+                var expectBlack = kept.HasValue && s.Alpha >= 128 &&
+                                  s.Red == kept.Value.Red && s.Green == kept.Value.Green && s.Blue == kept.Value.Blue;
+                var r = result.GetPixel(x, y);
+                if (expectBlack)
+                {
+                    Assert.True(r.Red < 64 && r.Green < 64 && r.Blue < 64,
+                        $"pixel ({x},{y}) should be kept as black ink, was {r}");
+                }
+                else
+                {
+                    Assert.True(r.Red > 192 && r.Green > 192 && r.Blue > 192,
+                        $"pixel ({x},{y}) should be white background, was {r}");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi Nikse,

First, I want to apologize for my poorly thought-out histogram proposal back in issue #12293. While the intention was right, the implementation had logical flaws. Thank you for following up on that and introducing the inner-pixel logic in v5.1.0-rc15!

However, the inner-search heuristic introduced a new edge case with letters like "i", "j", or umlauts ("ä", "ö", "ü"). The shadow/outline pixels completely bridge the narrow gap between the dot and the main glyph body. Since the true background color never penetrates this tiny cavity, the code flags those trapped pixels as `touchesBackground = false`, assigning them a `ratio = 0.0`. Because the code looks for the *lowest* ratio, the outline wins and the actual text body is wiped out. 

This PR brings three topological changes to resolve this:

1. **Laplace Smoothing:** We now calculate the ratio via `(b + 1) / (total + 1)`. If both the text body and a trapped cavity shadow hit $b = 0$, the larger mass in the denominator ensures that the larger text body pushes the ratio closer to 0, preventing the cavity shadow from winning.
2. **4-Directional Edge Intensity:** Instead of a binary boolean check, we sum up the actual background borders (0 to 4) per pixel to better differentiate between outlines and compact interior text shapes.
3. **`minPlane` Recalibration:** We lowered the noise floor from `16` to `8` pixels to ensure short words or isolated punctuation marks don't bypass the main loop, while safely preserving your original frequency fallback for absolute pixel-starved extreme cases.

***

**Feature Request for `seconv` / CLI:**
On a side note, since `seconv` is widely used for unattended batch conversion, would it be possible to bring the **line break separation** logic from the GUI to the CLI? Additionally, adding the **italics recognition feature** from Subtitle Edit 4 to `seconv` would greatly improve automated VobSub/PGS OCR. 

Thanks for your work on Subtitle Edit!
