### PR TITLE
Bring back the "Full frame image" export option

### DIFF
--- a/src/libuilogic/Export/ExportHandlerBluRaySup.cs
+++ b/src/libuilogic/Export/ExportHandlerBluRaySup.cs
@@ -1,5 +1,4 @@
 using Nikse.SubtitleEdit.Core.BluRaySup;
-using Nikse.SubtitleEdit.Core.Common;
 
 namespace Nikse.SubtitleEdit.UiLogic.Export;
 
@@ -49,54 +48,10 @@ public class ExportHandlerBluRaySup : IExportHandler
         };
         if (param.IsFullFrame)
         {
-            var nbmp = new NikseBitmap(param.Bitmap);
-            nbmp.ReplaceTransparentWith(param.BackgroundColor);
-            using (var bmp = nbmp.GetBitmap())
-            {
-                var top = param.ScreenHeight - (param.Bitmap.Height + param.BottomTopMargin);
-                var left = (param.ScreenWidth - param.Bitmap.Width) / 2;
-
-                var b = new NikseBitmap(param.ScreenWidth, param.ScreenHeight);
-                {
-                    b.Fill(param.BackgroundColor);
-                    using (var fullSize = b.GetBitmap())
-                    {
-                        if (param.Alignment == ExportAlignment.BottomLeft || param.Alignment == ExportAlignment.MiddleLeft || param.Alignment == ExportAlignment.TopLeft)
-                        {
-                            left = param.LeftRightMargin;
-                        }
-                        else if (param.Alignment == ExportAlignment.BottomRight || param.Alignment == ExportAlignment.MiddleRight || param.Alignment == ExportAlignment.TopRight)
-                        {
-                            left = param.ScreenWidth - param.Bitmap.Width - param.LeftRightMargin;
-                        }
-
-                        if (param.Alignment == ExportAlignment.TopLeft || param.Alignment == ExportAlignment.TopCenter || param.Alignment == ExportAlignment.TopRight)
-                        {
-                            top = param.BottomTopMargin;
-                        }
-
-                        if (param.Alignment == ExportAlignment.MiddleLeft || param.Alignment == ExportAlignment.MiddleCenter || param.Alignment == ExportAlignment.MiddleRight)
-                        {
-                            top = param.ScreenHeight - (param.Bitmap.Height / 2);
-                        }
-
-                        if (param.OverridePosition != null &&
-                            param.OverridePosition.Value.X >= 0 && param.OverridePosition.Value.X < param.ScreenWidth &&
-                            param.OverridePosition.Value.Y >= 0 && param.OverridePosition.Value.Y < param.ScreenHeight)
-                        {
-                            left = param.OverridePosition.Value.X;
-                            top = param.OverridePosition.Value.Y;
-                        }
-
-                        //using (var g = Graphics.FromImage(fullSize))
-                        //{
-                        //    g.DrawImage(bmp, left, top);
-                        //    g.Dispose();
-                        //}
-                        param.Buffer = BluRaySupPicture.CreateSupFrame(brSub, fullSize, param.FontColor, param.FramesPerSecond, 0, 0, BluRayContentAlignment.BottomCenter);
-                    }
-                }
-            }
+            // The image already covers the frame, so it goes in at 0,0 with no margins - the
+            // alignment and margins were used to place the text inside it.
+            using var fullSize = FullFrameImage.Create(param);
+            param.Buffer = BluRaySupPicture.CreateSupFrame(brSub, fullSize, param.FontColor, param.FramesPerSecond, 0, 0, BluRayContentAlignment.BottomCenter);
         }
         else
         {

--- a/src/libuilogic/Export/ExportHandlerFcp.cs
+++ b/src/libuilogic/Export/ExportHandlerFcp.cs
@@ -1,5 +1,6 @@
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using SkiaSharp;
 using System.Globalization;
 using System.Text;
 
@@ -34,6 +35,14 @@ public class ExportHandlerFcp : IExportHandler
         _imagesSavedCount = 0;
         _width = imageParameter.ScreenWidth;
         _height = imageParameter.ScreenHeight;
+
+        // Nothing sets the FrameRate property, so the chosen frame rate only ever reached this
+        // handler through the image parameters - and every time code in the xmeml was written at
+        // the 25 fps default. Take it from the parameters, like the BDN XML handler does.
+        if (imageParameter.FramesPerSecond > 0)
+        {
+            FrameRate = imageParameter.FramesPerSecond;
+        }
     }
 
     public void CreateParagraph(ImageParameter param)
@@ -68,7 +77,7 @@ public class ExportHandlerFcp : IExportHandler
             <out>[OUT]</out>
             <start>[START]</start>
             <end>[END]</end>
-            <pixelaspectratio>" + param.ScreenWidth + "x" + param.ScreenHeight + @"</pixelaspectratio>
+            <pixelaspectratio>square</pixelaspectratio>
             <stillframe>TRUE</stillframe>
             <anamorphic>FALSE</anamorphic>
             <alphatype>straight</alphatype>
@@ -100,106 +109,24 @@ public class ExportHandlerFcp : IExportHandler
             <fielddominance>none</fielddominance>
           </clipitem>";
 
-        var outBitmap = param.Bitmap;
-        //if (checkBoxFullFrameImage.Checked)
-        //{
-        //    var nbmp = new NikseBitmap(param.Bitmap);
-        //    nbmp.ReplaceTransparentWith(panelFullFrameBackground.BackColor);
-        //    using (var bmp = nbmp.GetBitmap())
-        //    {
-        //        int top = param.ScreenHeight - (param.Bitmap.Height + param.BottomMargin);
-        //        int left = (param.ScreenWidth - param.Bitmap.Width) / 2;
+        // "Full frame" writes the subtitle onto a frame-sized image, so every png can be dropped
+        // on the timeline at 0,0 and still land where Subtitle Edit placed it.
+        SKBitmap? fullFrameBitmap = null;
+        if (param.IsFullFrame)
+        {
+            fullFrameBitmap = FullFrameImage.Create(param);
+        }
 
-        //        var b = new NikseBitmap(param.ScreenWidth, param.ScreenHeight);
-        //        {
-        //            b.Fill(panelFullFrameBackground.BackColor);
-        //            outBitmap = b.GetBitmap();
-        //            {
-        //                if (param.Alignment == ContentAlignment.BottomLeft || param.Alignment == ContentAlignment.MiddleLeft || param.Alignment == ContentAlignment.TopLeft)
-        //                {
-        //                    left = param.LeftMargin;
-        //                }
-        //                else if (param.Alignment == ContentAlignment.BottomRight || param.Alignment == ContentAlignment.MiddleRight || param.Alignment == ContentAlignment.TopRight)
-        //                {
-        //                    left = param.ScreenWidth - param.Bitmap.Width - param.RightMargin;
-        //                }
+        try
+        {
+            File.WriteAllBytes(targetImageFileName, (fullFrameBitmap ?? param.Bitmap).ToPngArray());
+        }
+        finally
+        {
+            fullFrameBitmap?.Dispose();
+        }
 
-        //                if (param.Alignment == ContentAlignment.TopLeft || param.Alignment == ContentAlignment.TopCenter || param.Alignment == ContentAlignment.TopRight)
-        //                {
-        //                    top = param.BottomMargin;
-        //                }
-
-        //                if (param.Alignment == ContentAlignment.MiddleLeft || param.Alignment == ContentAlignment.MiddleCenter || param.Alignment == ContentAlignment.MiddleRight)
-        //                {
-        //                    top = (param.ScreenHeight - param.Bitmap.Height) / 2;
-        //                }
-
-        //                if (param.OverridePosition.HasValue &&
-        //                    param.OverridePosition.Value.X >= 0 && param.OverridePosition.Value.X < param.Bitmap.Width &&
-        //                    param.OverridePosition.Value.Y >= 0 && param.OverridePosition.Value.Y < param.Bitmap.Height)
-        //                {
-        //                    left = param.OverridePosition.Value.X;
-        //                    top = param.OverridePosition.Value.Y;
-        //                }
-
-        //                using (var g = Graphics.FromImage(outBitmap))
-        //                {
-        //                    g.DrawImage(bmp, left, top);
-        //                    g.Dispose();
-        //                }
-        //            }
-        //        }
-        //    }
-        //}
-
-
-        File.WriteAllBytes(targetImageFileName, param.Bitmap.ToPngArray());
-
-        //if (comboBoxImageFormat.Text == "8-bit png")
-        //{
-        //    foreach (var encoder in ImageCodecInfo.GetImageEncoders())
-        //    {
-        //        if (encoder.FormatID == ImageFormat.Png.Guid)
-        //        {
-        //            var parameters = new EncoderParameters();
-        //            parameters.Param[0] = new EncoderParameter(System.Drawing.Imaging.Encoder.ColorDepth, 8);
-
-        //            var nbmp = new NikseBitmap(outBitmap);
-        //            var b = nbmp.ConvertTo8BitsPerPixel();
-        //            b.Save(targetImageFileName, encoder, parameters);
-        //            b.Dispose();
-
-        //            break;
-        //        }
-        //    }
-        //}
-        //else
-        //{
-        //    SaveImage(outBitmap, targetImageFileName, ImageFormat);
-        //}
-
-        var timeBase = 25;
-        var ntsc = "FALSE";
-        //if (comboBoxLanguage.SelectedItem.ToString().Equals("NTSC", StringComparison.Ordinal))
-        //{
-        //    ntsc = "TRUE";
-        //}
-
-        //if (Math.Abs(param.FramesPerSeconds - 29.97) < 0.01)
-        //{
-        //    timeBase = 30;
-        //    ntsc = "TRUE";
-        //}
-        //else if (Math.Abs(param.FramesPerSeconds - 23.976) < 0.01)
-        //{
-        //    timeBase = 24;
-        //    ntsc = "TRUE";
-        //}
-        //else if (Math.Abs(param.FramesPerSeconds - 59.94) < 0.01)
-        //{
-        //    timeBase = 60;
-        //    ntsc = "TRUE";
-        //}
+        var (timeBase, ntsc) = GetTimeBaseAndNtsc();
 
         var duration = SubtitleFormat.MillisecondsToFrames(param.EndTime.TotalMilliseconds - param.StartTime.TotalMilliseconds, FrameRate);
         var start = SubtitleFormat.MillisecondsToFrames(param.StartTime.TotalMilliseconds, FrameRate);
@@ -231,18 +158,18 @@ public class ExportHandlerFcp : IExportHandler
                    "    <name>" + System.Security.SecurityElement.Escape(_prefix) + @"</name>
     <duration>" + duration.ToString(CultureInfo.InvariantCulture) + @"</duration>
     <rate>
-      <ntsc>FALSE</ntsc>
-      <timebase>25</timebase>
+      <ntsc>[NTSC]</ntsc>
+      <timebase>[TIMEBASE]</timebase>
     </rate>
     <timecode>
       <rate>
-        <ntsc>FALSE</ntsc>
-        <timebase>25</timebase>
+        <ntsc>[NTSC]</ntsc>
+        <timebase>[TIMEBASE]</timebase>
       </rate>
       <string>00:00:00:00</string>
       <frame>0</frame>
       <source>source</source>
-      <displayformat>NDF</displayformat>
+      <displayformat>[DISPLAYFORMAT]</displayformat>
     </timecode>
     <in>0</in>
     <out>[OUT]</out>
@@ -251,11 +178,11 @@ public class ExportHandlerFcp : IExportHandler
         <format>
           <samplecharacteristics>
             <rate>
-              <timebase>25</timebase>
-              <ntsc>FALSE</ntsc>
+              <timebase>[TIMEBASE]</timebase>
+              <ntsc>[NTSC]</ntsc>
             </rate>
-            <width>1920</width>
-            <height>1080</height>
+            <width>[WIDTH]</width>
+            <height>[HEIGHT]</height>
             <anamorphic>FALSE</anamorphic>
             <pixelaspectratio>square</pixelaspectratio>
             <fielddominance>none</fielddominance>
@@ -297,43 +224,30 @@ public class ExportHandlerFcp : IExportHandler
     <ismasterclip>FALSE</ismasterclip>
   </sequence>
 </xmeml>";
-        if (FrameRate == 29.97)
-        {
-            s = s.Replace("<displayformat>NDF</displayformat>", "<displayformat>DF</displayformat>"); //Non Drop Frame or Drop Frame
-            s = s.Replace("<timebase>25</timebase>", "<timebase>30</timebase>");
-            s = s.Replace("<ntsc>FALSE</ntsc>", "<ntsc>TRUE</ntsc>");
-        }
-        else if (FrameRate == 23.976)
-        {
-            s = s.Replace("<displayformat>NDF</displayformat>", "<displayformat>DF</displayformat>"); //Non Drop Frame or Drop Frame
-            s = s.Replace("<timebase>25</timebase>", "<timebase>24</timebase>");
-            s = s.Replace("<ntsc>FALSE</ntsc>", "<ntsc>TRUE</ntsc>");
-        }
-        else if (FrameRate == 59.94)
-        {
-            s = s.Replace("<displayformat>NDF</displayformat>", "<displayformat>DF</displayformat>"); //Non Drop Frame or Drop Frame
-            s = s.Replace("<timebase>25</timebase>", "<timebase>60</timebase>");
-            s = s.Replace("<ntsc>FALSE</ntsc>", "<ntsc>TRUE</ntsc>");
-        }
-        else
-        {
-            s = s.Replace("<timebase>25</timebase>", "<timebase>" + FrameRate.ToString(CultureInfo.InvariantCulture) + "</timebase>");
-        }
+        // The clip items in _sb already have their own placeholders filled in, so these only
+        // reach the sequence around them - the old code replaced whole "<timebase>25</timebase>"
+        // elements, which reached into the clip items too.
+        var (timeBase, ntsc) = GetTimeBaseAndNtsc();
+        s = s.Replace("[TIMEBASE]", timeBase.ToString(CultureInfo.InvariantCulture));
+        s = s.Replace("[NTSC]", ntsc);
+        s = s.Replace("[DISPLAYFORMAT]", ntsc == "TRUE" ? "DF" : "NDF"); //Non Drop Frame or Drop Frame
 
+        // The sequence was hardcoded to 1920x1080 no matter which resolution was exported.
+        s = s.Replace("[WIDTH]", _width.ToString(CultureInfo.InvariantCulture));
+        s = s.Replace("[HEIGHT]", _height.ToString(CultureInfo.InvariantCulture));
+
+        var sequenceEnd = 0;
         if (_imagesSavedCount > 0)
         {
-            var end = SubtitleFormat.MillisecondsToFrames(_endTime.TotalMilliseconds, FrameRate);
-            end++;
-            s = s.Replace("[OUT]", end.ToString(CultureInfo.InvariantCulture));
+            sequenceEnd = SubtitleFormat.MillisecondsToFrames(_endTime.TotalMilliseconds, FrameRate) + 1;
         }
+
+        s = s.Replace("[OUT]", sequenceEnd.ToString(CultureInfo.InvariantCulture));
 
         //if (comboBoxLanguage.Text == "NTSC")
         //{
         //    s = s.Replace("<ntsc>FALSE</ntsc>", "<ntsc>TRUE</ntsc>");
         //}
-
-        s = s.Replace("<width>1920</width>", "<width>" + _width.ToString(CultureInfo.InvariantCulture) + "</width>");
-        s = s.Replace("<height>1080</height>", "<height>" + _height.ToString(CultureInfo.InvariantCulture) + "</height>");
 
         //if (comboBoxImageFormat.Text.Contains("8-bit"))
         //{
@@ -342,5 +256,29 @@ public class ExportHandlerFcp : IExportHandler
 
         var fileName = Path.Combine(_folderName, "fcpxml_export.xml");
         File.WriteAllText(fileName, s);
+    }
+
+    /// <summary>
+    /// The xmeml time base (a whole number of frames per second) and NTSC flag for
+    /// <see cref="FrameRate"/> - 29.97 is the 30 time base with NTSC pull-down, and so on.
+    /// </summary>
+    private (int TimeBase, string Ntsc) GetTimeBaseAndNtsc()
+    {
+        if (Math.Abs(FrameRate - 29.97) < 0.01)
+        {
+            return (30, "TRUE");
+        }
+
+        if (Math.Abs(FrameRate - 23.976) < 0.01)
+        {
+            return (24, "TRUE");
+        }
+
+        if (Math.Abs(FrameRate - 59.94) < 0.01)
+        {
+            return (60, "TRUE");
+        }
+
+        return ((int)Math.Round(FrameRate, MidpointRounding.AwayFromZero), "FALSE");
     }
 }

--- a/src/libuilogic/Export/FullFrameImage.cs
+++ b/src/libuilogic/Export/FullFrameImage.cs
@@ -1,0 +1,69 @@
+using SkiaSharp;
+
+namespace Nikse.SubtitleEdit.UiLogic.Export;
+
+/// <summary>
+/// Builds "full frame" images: the rendered subtitle bitmap drawn onto a canvas the size of the
+/// video frame. Video editors (Final Cut Pro, Premiere, DaVinci Resolve) can then place every
+/// image at 0,0 and get the placement Subtitle Edit calculated, instead of having to position a
+/// tightly cropped bitmap per line.
+/// </summary>
+public static class FullFrameImage
+{
+    /// <summary>
+    /// Top left corner of a <paramref name="width"/> x <paramref name="height"/> subtitle bitmap
+    /// inside the frame, from the alignment and the margins - or from the "{\pos(x,y)}" override
+    /// when that falls inside the frame.
+    /// </summary>
+    public static SKPointI GetPosition(ImageParameter param, int width, int height)
+    {
+        if (param.OverridePosition.HasValue &&
+            param.OverridePosition.Value.X >= 0 && param.OverridePosition.Value.X < param.ScreenWidth &&
+            param.OverridePosition.Value.Y >= 0 && param.OverridePosition.Value.Y < param.ScreenHeight)
+        {
+            return param.OverridePosition.Value;
+        }
+
+        var x = param.Alignment switch
+        {
+            ExportAlignment.TopLeft or ExportAlignment.MiddleLeft or ExportAlignment.BottomLeft
+                => param.LeftRightMargin,
+            ExportAlignment.TopRight or ExportAlignment.MiddleRight or ExportAlignment.BottomRight
+                => param.ScreenWidth - width - param.LeftRightMargin,
+            _ => (param.ScreenWidth - width) / 2,
+        };
+
+        var y = param.Alignment switch
+        {
+            ExportAlignment.TopLeft or ExportAlignment.TopCenter or ExportAlignment.TopRight
+                => param.BottomTopMargin,
+            ExportAlignment.MiddleLeft or ExportAlignment.MiddleCenter or ExportAlignment.MiddleRight
+                => (param.ScreenHeight - height) / 2,
+            _ => param.ScreenHeight - height - param.BottomTopMargin,
+        };
+
+        return new SKPointI(x, y);
+    }
+
+    /// <summary>
+    /// Returns a new frame-sized bitmap holding <see cref="ImageParameter.Bitmap"/> at its
+    /// calculated position, on a <see cref="ImageParameter.FullFrameBackgroundColor"/> background.
+    /// The caller owns the returned bitmap.
+    /// </summary>
+    public static SKBitmap Create(ImageParameter param)
+    {
+        var width = Math.Max(1, param.ScreenWidth);
+        var height = Math.Max(1, param.ScreenHeight);
+
+        // Not opaque even for an opaque background colour: a transparent background is the point
+        // of the option for editing timelines, where the images go on a track above the video.
+        var bitmap = new SKBitmap(width, height, false);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(param.FullFrameBackgroundColor);
+
+        var position = GetPosition(param, param.Bitmap.Width, param.Bitmap.Height);
+        canvas.DrawBitmap(param.Bitmap, position.X, position.Y);
+
+        return bitmap;
+    }
+}

--- a/src/libuilogic/Export/ImageParameter.cs
+++ b/src/libuilogic/Export/ImageParameter.cs
@@ -34,6 +34,14 @@ public class ImageParameter
     public string Error { get; set; }
     public bool IsForced { get; set; }
     public bool IsFullFrame { get; set; }
+
+    /// <summary>
+    /// Background of the frame-sized image made when <see cref="IsFullFrame"/> is set. Separate
+    /// from <see cref="BackgroundColor"/>, which is the colour of the box behind the text.
+    /// Transparent by default, so a full frame image only pads the subtitle out to the frame.
+    /// </summary>
+    public SKColor FullFrameBackgroundColor { get; set; } = SKColors.Transparent;
+
     public double FramesPerSecond { get; set; }
     public bool IsRightToLeft { get; set; } = false;
     public ExportBoxType BoxType { get; set; } = ExportBoxType.None;

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -880,6 +880,7 @@
       "saveAsHint": "Save subtitle with a new name {0}",
       "findHint": "Find text in subtitles {0}",
       "replaceHint": "Find and replace text {0}",
+      "multipleReplaceHint": "Multiple replace {0}",
       "spellCheckHint": "Check subtitles for spelling errors {0}",
       "fixCommonErrorsHint": "Fix common subtitle errors {0}",
       "removeTextForHiHint": "Remove text for hearing impaired {0}",
@@ -1184,7 +1185,9 @@
       "addLineBetweenSubtitles": "Add line between subtitles",
       "titleExportDCinemaInteropPng": "D-Cinema interop/png",
       "titleExportDCinemaSmpte2014Png": "D-Cinema SMPTE 2014/png",
-      "imageBasedSubtitleSaved": "Image-based subtitle saved"
+      "imageBasedSubtitleSaved": "Image-based subtitle saved",
+      "fullFrameImage": "Full frame image",
+      "fullFrameImageHint": "Make each image the size of the video frame, with the subtitle in its place"
     },
     "statistics": {
       "title": "Statistics",
@@ -2549,6 +2552,7 @@
       "showToolbarSaveAs": "Show save as icon",
       "showToolbarFind": "Show find icon",
       "showToolbarReplace": "Show replace icon",
+      "showToolbarMultipleReplace": "Show multiple replace icon",
       "showToolbarSpellCheck": "Show spell check icon",
       "showToolbarFixCommonErrors": "Show fix common errors icon",
       "showToolbarRemoveTextForHi": "Show remove text for hearing impaired icon",

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
@@ -84,6 +84,9 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
     [ObservableProperty] private int _boxPaddingRight;
     [ObservableProperty] private int _boxPaddingTop;
     [ObservableProperty] private int _boxPaddingBottom;
+    [ObservableProperty] private bool _isFullFrame;
+    [ObservableProperty] private Color _fullFrameBackgroundColor;
+    [ObservableProperty] private bool _isFullFrameVisible;
     public ObservableCollection<int> BoxPaddingValues { get; } = new ObservableCollection<int>(Enumerable.Range(0, 100));
 
     private string _outlineColorText = string.Empty;
@@ -157,6 +160,7 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
         FontColor = Colors.White;
         ShadowColor = Colors.Black;
         BoxColor = Color.FromArgb(180, 0, 0, 0);
+        FullFrameBackgroundColor = Colors.Transparent;
         Alignments = new ObservableCollection<ExportAlignmentDisplay>(ExportAlignmentDisplay.GetAlignments());
         SelectedAlignment = Alignments[0];
         ContentAlignments =
@@ -513,7 +517,7 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
         SelectedSubtitle = item;
     }
 
-    private ImageParameter GetImageParameter(int i)
+    internal ImageParameter GetImageParameter(int i)
     {
         var subtitle = Subtitles[i];
         var imageParameter = new ImageParameter
@@ -553,6 +557,8 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
             LeftRightMargin = SelectedLeftRightMargin,
             IsRightToLeft = IsRightToLeft,
             FramesPerSecond = SelectedFrameRate,
+            IsFullFrame = IsFullFrameVisible && IsFullFrame,
+            FullFrameBackgroundColor = FullFrameBackgroundColor.ToSKColor(),
         };
 
         return imageParameter;
@@ -640,6 +646,11 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
         _subtitleFileName = subtitleFileName;
         Title = exportHandler.Title;
 
+        // Only the formats that can carry a frame-sized image: the editing timelines the images
+        // are dropped on (Final Cut Pro & co), and Blu-ray sup, which SE4 offered it for too. The
+        // other formats position the subtitle themselves from its own bitmap size.
+        IsFullFrameVisible = exportHandler.ExportImageType is ExportImageType.Fcp or ExportImageType.BluRaySup;
+
         SelectedSubtitle = Subtitles.FirstOrDefault();
 
         if (!string.IsNullOrEmpty(videoFileName))
@@ -686,60 +697,23 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
         BitmapPreview = ip.Bitmap.ToAvaloniaBitmap();
         ExportTextTags.ApplyPositionTag(ip, text);
         var position = CalculatePosition(ip, BitmapPreview.Size.Width, BitmapPreview.Size.Height);
-        ImageInfo = $"{BitmapPreview.Size.Width}x{BitmapPreview.Size.Height} @ {position.X},{position.Y}";
+
+        // With "full frame image" the exported png is the size of the video frame, not of the
+        // text bitmap shown here - report the size that actually gets written.
+        ImageInfo = ip.IsFullFrame
+            ? $"{ip.ScreenWidth}x{ip.ScreenHeight} @ {position.X},{position.Y}"
+            : $"{BitmapPreview.Size.Width}x{BitmapPreview.Size.Height} @ {position.X},{position.Y}";
     }
 
+    /// <summary>
+    /// Where the subtitle bitmap lands inside the frame. Shares
+    /// <see cref="FullFrameImage.GetPosition"/> with the export handlers - including the
+    /// "{\pos(x,y)}" override that ExportTextTags.ApplyPositionTag put on the parameter - so the
+    /// preview cannot drift from what is exported.
+    /// </summary>
     private static SKPointI CalculatePosition(ImageParameter ip, double width, double height)
     {
-        // Set from a "{\pos(x,y)}" tag by ExportTextTags.ApplyPositionTag - the handlers use it
-        // instead of the alignment, so the preview must too.
-        if (ip.OverridePosition.HasValue)
-        {
-            return ip.OverridePosition.Value;
-        }
-
-        var x = 0;
-        var y = 0;
-
-        if (ip.Alignment == ExportAlignment.TopLeft ||
-            ip.Alignment == ExportAlignment.MiddleLeft ||
-            ip.Alignment == ExportAlignment.BottomLeft)
-        {
-            x = ip.LeftRightMargin;
-        }
-        else if (ip.Alignment == ExportAlignment.TopCenter ||
-                 ip.Alignment == ExportAlignment.MiddleCenter ||
-                 ip.Alignment == ExportAlignment.BottomCenter)
-        {
-            x = (int)((ip.ScreenWidth - width) / 2);
-        }
-        else if (ip.Alignment == ExportAlignment.TopRight ||
-                 ip.Alignment == ExportAlignment.MiddleRight ||
-                 ip.Alignment == ExportAlignment.BottomRight)
-        {
-            x = (int)(ip.ScreenWidth - width - ip.LeftRightMargin);
-        }
-
-        if (ip.Alignment == ExportAlignment.TopLeft ||
-            ip.Alignment == ExportAlignment.TopCenter ||
-            ip.Alignment == ExportAlignment.TopRight)
-        {
-            y = ip.BottomTopMargin;
-        }
-        else if (ip.Alignment == ExportAlignment.MiddleLeft ||
-                 ip.Alignment == ExportAlignment.MiddleCenter ||
-                 ip.Alignment == ExportAlignment.MiddleRight)
-        {
-            y = (int)((ip.ScreenHeight - height) / 2);
-        }
-        else if (ip.Alignment == ExportAlignment.BottomLeft ||
-                 ip.Alignment == ExportAlignment.BottomCenter ||
-                 ip.Alignment == ExportAlignment.BottomRight)
-        {
-            y = (int)(ip.ScreenHeight - height - ip.BottomTopMargin);
-        }
-
-        return new SKPointI(x, y);
+        return FullFrameImage.GetPosition(ip, (int)width, (int)height);
     }
 
     public static SKBitmap GenerateBitmap(ImageParameter ip)
@@ -796,6 +770,7 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
     partial void OnOutlineColorChanged(Color value) => _dirty = true;
     partial void OnShadowColorChanged(Color value) => _dirty = true;
     partial void OnBoxColorChanged(Color value) => _dirty = true;
+    partial void OnFullFrameBackgroundColorChanged(Color value) => _dirty = true;
     partial void OnBoxPaddingLeftChanged(int value) => _dirty = true;
     partial void OnBoxPaddingRightChanged(int value) => _dirty = true;
     partial void OnBoxPaddingTopChanged(int value) => _dirty = true;
@@ -952,6 +927,8 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
             SelectedPaddingTopBottom = profile.PaddingTopBottom;
             SelectedLineSpacing = profile.LineSpacingPercent;
             SelectedFrameRate = FrameRates.Contains(profile.FramesPerSecond) ? profile.FramesPerSecond : 25;
+            IsFullFrame = profile.IsFullFrame;
+            FullFrameBackgroundColor = profile.FullFrameBackgroundColor.FromHex().ToAvaloniaColor();
         }
     }
 
@@ -984,6 +961,8 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
             profile.PaddingTopBottom = SelectedPaddingTopBottom;
             profile.LineSpacingPercent = SelectedLineSpacing;
             profile.FramesPerSecond = SelectedFrameRate;
+            profile.IsFullFrame = IsFullFrame;
+            profile.FullFrameBackgroundColor = FullFrameBackgroundColor.FromColorToHex(true);
         }
     }
 

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
@@ -447,6 +447,26 @@ public class ExportImageBasedWindow : Window
         grid.Add(labelFrameRate, 6, 4);
         grid.Add(comboBoxFrameRate, 6, 5);
 
+        // Only shown for the formats that can use a frame-sized image (see IsFullFrameVisible).
+        var checkBoxFullFrame = UiUtil.MakeCheckBox(Se.Language.File.Export.FullFrameImage, vm, nameof(vm.IsFullFrame));
+        checkBoxFullFrame.IsCheckedChanged += vm.CheckBoxChanged;
+        var colorPickerFullFrame = UiUtil.MakeColorPickerButton(vm, nameof(vm.FullFrameBackgroundColor), true);
+        colorPickerFullFrame.Bind(IsVisibleProperty, new Binding(nameof(vm.IsFullFrame)) { Source = vm });
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            ToolTip.SetTip(checkBoxFullFrame, Se.Language.File.Export.FullFrameImageHint);
+            ToolTip.SetTip(colorPickerFullFrame, Se.Language.General.BackgroundColor);
+        }
+
+        var panelFullFrame = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 5,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children = { checkBoxFullFrame, colorPickerFullFrame },
+        }.WithBindIsVisible(vm, nameof(vm.IsFullFrameVisible));
+        grid.Add(panelFullFrame, 7, 0, 1, 6);
+
         return UiUtil.MakeBorderForControl(grid);
     }
 

--- a/src/ui/Logic/Config/Language/File/LanguageExport.cs
+++ b/src/ui/Logic/Config/Language/File/LanguageExport.cs
@@ -41,6 +41,8 @@ public class LanguageExport
     public string TitleExportDCinemaInteropPng { get; set; }
     public string TitleExportDCinemaSmpte2014Png { get; set; }
     public string ImageBasedSubtitleSaved { get; set; }
+    public string FullFrameImage { get; set; }
+    public string FullFrameImageHint { get; set; }
 
     public LanguageExport()
     {
@@ -83,5 +85,7 @@ public class LanguageExport
         TitleExportDCinemaInteropPng = "D-Cinema interop/png";
         TitleExportDCinemaSmpte2014Png = "D-Cinema SMPTE 2014/png";
         ImageBasedSubtitleSaved = "Image-based subtitle saved";
+        FullFrameImage = "Full frame image";
+        FullFrameImageHint = "Make each image the size of the video frame, with the subtitle in its place";
     }
 }

--- a/src/ui/Logic/Config/SeExportImagesProfile.cs
+++ b/src/ui/Logic/Config/SeExportImagesProfile.cs
@@ -33,6 +33,7 @@ public class SeExportImagesProfile
     public string Error { get; set; }
     public bool IsForced { get; set; }
     public bool IsFullFrame { get; set; }
+    public string FullFrameBackgroundColor { get; set; }
     public double FramesPerSecond { get; set; }
     public int PaddingLeftRight { get; set; }
     public int PaddingTopBottom { get; set; }
@@ -56,6 +57,9 @@ public class SeExportImagesProfile
         ShadowColor = SKColors.Black.ToHex(true);
         ShadowWidth = 2;
         BackgroundColor = new SKColor(0, 0, 0, 180).ToHex(true);
+        // Transparent: a full frame image should only pad the subtitle out to the frame size,
+        // so it can go on a track above the video.
+        FullFrameBackgroundColor = SKColors.Transparent.ToHex(true);
         BackgroundCornerRadius = 0;
         ScreenWidth = 1920;
         ScreenHeight = 1080;

--- a/tests/UI/Features/Files/ExportImageBasedFullFrameTests.cs
+++ b/tests/UI/Features/Files/ExportImageBasedFullFrameTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Files.ExportImageBased;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.UiLogic.Export;
+
+namespace UITests.Features.Files;
+
+/// <summary>
+/// The "full frame image" option: a frame-sized png with the subtitle in its place, which SE4
+/// offered for Final Cut Pro and Blu-ray sup. The other image formats place the subtitle from the
+/// bitmap size themselves, so the option stays hidden for them.
+/// </summary>
+public class ExportImageBasedFullFrameTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private ExportImageBasedViewModel BuildViewModel(IExportHandler handler)
+    {
+        var vm = new ExportImageBasedViewModel(
+            new FileHelper(),
+            new FolderHelper(),
+            new WindowService(new NullServiceProvider()));
+
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new SubtitleLineViewModel
+            {
+                Number = 1,
+                Text = "Hello world",
+                StartTime = TimeSpan.FromSeconds(1),
+                EndTime = TimeSpan.FromSeconds(3),
+            },
+        };
+
+        vm.Initialize(handler, subtitles, null, null);
+        return vm;
+    }
+
+    private ExportImageBasedWindow BuildWindow(IExportHandler handler)
+    {
+        var window = new ExportImageBasedWindow(BuildViewModel(handler));
+        _windows.Add(window);
+        return window;
+    }
+
+    private static CheckBox FindFullFrameCheckBox(ExportImageBasedWindow window)
+    {
+        var checkBox = window.GetLogicalDescendants()
+            .OfType<CheckBox>()
+            .FirstOrDefault(c => Equals(c.Content, Se.Language.File.Export.FullFrameImage));
+        Assert.NotNull(checkBox);
+        return checkBox;
+    }
+
+    [AvaloniaFact]
+    public void FullFrameOption_IsShownForFinalCutPro()
+    {
+        var window = BuildWindow(new ExportHandlerFcp());
+        window.Show();
+
+        var checkBox = FindFullFrameCheckBox(window);
+        Assert.True(checkBox.IsEffectivelyVisible);
+    }
+
+    [AvaloniaFact]
+    public void FullFrameOption_IsShownForBluRaySup()
+    {
+        var window = BuildWindow(new ExportHandlerBluRaySup());
+        window.Show();
+
+        var checkBox = FindFullFrameCheckBox(window);
+        Assert.True(checkBox.IsEffectivelyVisible);
+    }
+
+    [AvaloniaFact]
+    public void FullFrameOption_IsHiddenForTheOtherFormats()
+    {
+        var window = BuildWindow(new ExportHandlerVobSub());
+        window.Show();
+
+        var checkBox = FindFullFrameCheckBox(window);
+        Assert.False(checkBox.IsEffectivelyVisible);
+    }
+
+    /// <summary>
+    /// A profile is shared by every image export, so a checked box saved from a Final Cut Pro
+    /// export must not turn frame-sized images on for a format that never offered the option.
+    /// </summary>
+    [AvaloniaFact]
+    public void FullFrame_IsNotAppliedWhenTheOptionIsHidden()
+    {
+        var vm = BuildViewModel(new ExportHandlerVobSub());
+        vm.IsFullFrame = true;
+
+        Assert.False(vm.GetImageParameter(0).IsFullFrame);
+    }
+
+    [AvaloniaFact]
+    public void FullFrame_IsAppliedWithItsOwnBackgroundColor()
+    {
+        var vm = BuildViewModel(new ExportHandlerFcp());
+        vm.IsFullFrame = true;
+        vm.FullFrameBackgroundColor = Colors.Blue;
+        vm.BoxColor = Colors.Red;
+
+        var parameter = vm.GetImageParameter(0);
+
+        Assert.True(parameter.IsFullFrame);
+        Assert.Equal(SkiaSharp.SKColors.Blue, parameter.FullFrameBackgroundColor);
+
+        // The box behind the text keeps its own colour.
+        Assert.Equal(SkiaSharp.SKColors.Red, parameter.BackgroundColor);
+    }
+}

--- a/tests/libuilogic/Export/ExportHandlerBluRaySupFullFrameTests.cs
+++ b/tests/libuilogic/Export/ExportHandlerBluRaySupFullFrameTests.cs
@@ -1,0 +1,87 @@
+using Nikse.SubtitleEdit.Core.BluRaySup;
+using Nikse.SubtitleEdit.UiLogic.Export;
+using SkiaSharp;
+using System.Text;
+
+namespace LibUiLogicTests.Export;
+
+/// <summary>
+/// The "full frame" branch of the Blu-ray sup handler never drew the subtitle onto the frame it
+/// built (the draw call was commented out during the port), so it wrote blank frames.
+/// </summary>
+public class ExportHandlerBluRaySupFullFrameTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "bluraysup_" + Guid.NewGuid().ToString("N"));
+
+    public ExportHandlerBluRaySupFullFrameTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, true); } catch { /* best effort */ }
+    }
+
+    private static ImageParameter Cue(bool fullFrame)
+    {
+        var bitmap = new SKBitmap(300, 80);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            using var paint = new SKPaint { Color = SKColors.White };
+            canvas.DrawRect(0, 0, 300, 80, paint);
+        }
+
+        return new ImageParameter
+        {
+            Text = "Hello",
+            Bitmap = bitmap,
+            StartTime = TimeSpan.FromSeconds(1),
+            EndTime = TimeSpan.FromSeconds(3),
+            Index = 0,
+            ScreenWidth = 1280,
+            ScreenHeight = 720,
+            Alignment = ExportAlignment.BottomCenter,
+            BottomTopMargin = 50,
+            LeftRightMargin = 40,
+            FramesPerSecond = 25,
+            FontColor = SKColors.White,
+            IsFullFrame = fullFrame,
+        };
+    }
+
+    private SKBitmap ExportAndReadBack(bool fullFrame)
+    {
+        var fileName = Path.Combine(_dir, fullFrame + ".sup");
+        var handler = new ExportHandlerBluRaySup();
+        var cue = Cue(fullFrame);
+
+        handler.WriteHeader(fileName, cue);
+        handler.CreateParagraph(cue);
+        handler.WriteParagraph(cue);
+        handler.WriteFooter();
+
+        var subtitles = BluRaySupParser.ParseBluRaySup(fileName, new StringBuilder());
+        return Assert.Single(subtitles).GetBitmap();
+    }
+
+    [Fact]
+    public void FullFrame_WritesAFrameSizedImageWithTheSubtitleInIt()
+    {
+        using var bitmap = ExportAndReadBack(fullFrame: true);
+
+        Assert.Equal(1280, bitmap.Width);
+        Assert.Equal(720, bitmap.Height);
+
+        // Bottom centered with a 50 px bottom margin, as the alignment and margins ask for.
+        Assert.True(bitmap.GetPixel(1280 / 2, 720 - 50 - 1).Alpha > 0, "the subtitle is missing from the full frame image");
+        Assert.Equal(0, bitmap.GetPixel(0, 0).Alpha);
+    }
+
+    [Fact]
+    public void WithoutFullFrame_TheImageIsStillCroppedToTheSubtitle()
+    {
+        using var bitmap = ExportAndReadBack(fullFrame: false);
+
+        Assert.True(bitmap.Width < 1280, "the cropped export should not cover the frame");
+        Assert.True(bitmap.Height < 720, "the cropped export should not cover the frame");
+    }
+}

--- a/tests/libuilogic/Export/ExportHandlerFcpTests.cs
+++ b/tests/libuilogic/Export/ExportHandlerFcpTests.cs
@@ -1,0 +1,150 @@
+using Nikse.SubtitleEdit.UiLogic.Export;
+using SkiaSharp;
+
+namespace LibUiLogicTests.Export;
+
+public class ExportHandlerFcpTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "fcp_" + Guid.NewGuid().ToString("N"));
+
+    public ExportHandlerFcpTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, true); } catch { /* best effort */ }
+    }
+
+    private static ImageParameter Cue(int index, int startMs, int endMs, double fps, bool fullFrame = false)
+    {
+        var bitmap = new SKBitmap(300, 80);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            using var paint = new SKPaint { Color = SKColors.White };
+            canvas.DrawRect(0, 0, 300, 80, paint);
+        }
+
+        return new ImageParameter
+        {
+            Text = "Hello",
+            Bitmap = bitmap,
+            StartTime = TimeSpan.FromMilliseconds(startMs),
+            EndTime = TimeSpan.FromMilliseconds(endMs),
+            Index = index,
+            ScreenWidth = 1280,
+            ScreenHeight = 720,
+            Alignment = ExportAlignment.BottomCenter,
+            BottomTopMargin = 50,
+            LeftRightMargin = 40,
+            FramesPerSecond = fps,
+            IsFullFrame = fullFrame,
+        };
+    }
+
+    private string Export(double fps, bool fullFrame = false)
+    {
+        var folder = Path.Combine(_dir, $"{fps}_{fullFrame}");
+        var handler = new ExportHandlerFcp();
+        var cues = new[] { Cue(0, 1000, 3000, fps, fullFrame), Cue(1, 4000, 6000, fps, fullFrame) };
+        handler.WriteHeader(folder, cues[0]);
+        foreach (var cue in cues)
+        {
+            handler.WriteParagraph(cue);
+        }
+
+        handler.WriteFooter();
+        return folder;
+    }
+
+    /// <summary>
+    /// Nothing assigned the handler's FrameRate property, so every time code was written at the
+    /// 25 fps default no matter which frame rate was picked in the export window.
+    /// </summary>
+    [Fact]
+    public void FrameRate_ComesFromTheImageParameters()
+    {
+        var xml = File.ReadAllText(Path.Combine(Export(30), "fcpxml_export.xml"));
+
+        // 1000 ms in at 30 fps is frame 30, not frame 25.
+        Assert.Contains("<in>30</in>", xml);
+        Assert.Contains("<start>30</start>", xml);
+        Assert.Contains("<end>180</end>", xml);
+    }
+
+    [Fact]
+    public void FrameRate_25_KeepsTheNonNtscTimeBase()
+    {
+        var xml = File.ReadAllText(Path.Combine(Export(25), "fcpxml_export.xml"));
+
+        Assert.Contains("<timebase>25</timebase>", xml);
+        Assert.DoesNotContain("<ntsc>TRUE</ntsc>", xml);
+        Assert.Contains("<displayformat>NDF</displayformat>", xml);
+    }
+
+    [Fact]
+    public void FrameRate_2997_UsesThe30TimeBaseWithNtscEverywhere()
+    {
+        var xml = File.ReadAllText(Path.Combine(Export(29.97), "fcpxml_export.xml"));
+
+        Assert.Contains("<timebase>30</timebase>", xml);
+        Assert.DoesNotContain("<timebase>25</timebase>", xml);
+        Assert.DoesNotContain("<ntsc>FALSE</ntsc>", xml);
+        Assert.Contains("<displayformat>DF</displayformat>", xml);
+    }
+
+    [Fact]
+    public void FrameRate_23976_UsesThe24TimeBaseWithNtsc()
+    {
+        var xml = File.ReadAllText(Path.Combine(Export(23.976), "fcpxml_export.xml"));
+
+        Assert.Contains("<timebase>24</timebase>", xml);
+        Assert.DoesNotContain("<ntsc>FALSE</ntsc>", xml);
+    }
+
+    [Fact]
+    public void Sequence_UsesTheExportedResolution()
+    {
+        var xml = File.ReadAllText(Path.Combine(Export(25), "fcpxml_export.xml"));
+
+        Assert.Contains("<width>1280</width>", xml);
+        Assert.Contains("<height>720</height>", xml);
+        Assert.DoesNotContain("1920", xml);
+        Assert.DoesNotContain("1080", xml);
+    }
+
+    [Fact]
+    public void Xml_HasNoUnreplacedPlaceholders()
+    {
+        var xml = File.ReadAllText(Path.Combine(Export(25), "fcpxml_export.xml"));
+
+        // "<!DOCTYPE xmeml[]>" has the only other square brackets in the file.
+        foreach (var placeholder in new[] { "[TIMEBASE]", "[NTSC]", "[DISPLAYFORMAT]", "[WIDTH]", "[HEIGHT]", "[OUT]", "[IN]", "[START]", "[END]", "[DURATION]" })
+        {
+            Assert.DoesNotContain(placeholder, xml);
+        }
+    }
+
+    [Fact]
+    public void Images_AreCroppedToTheSubtitleByDefault()
+    {
+        var pngFileName = Directory.GetFiles(Export(25), "*.png").First();
+
+        using var bitmap = SKBitmap.Decode(pngFileName);
+        Assert.Equal(300, bitmap.Width);
+        Assert.Equal(80, bitmap.Height);
+    }
+
+    [Fact]
+    public void Images_AreFrameSizedWhenFullFrameIsOn()
+    {
+        var pngFileName = Directory.GetFiles(Export(25, fullFrame: true), "*.png").First();
+
+        using var bitmap = SKBitmap.Decode(pngFileName);
+        Assert.Equal(1280, bitmap.Width);
+        Assert.Equal(720, bitmap.Height);
+
+        // Bottom centered, 50 px up from the bottom edge - and transparent everywhere else.
+        Assert.Equal(SKColors.White, bitmap.GetPixel(1280 / 2, 720 - 50 - 1));
+        Assert.Equal(0, bitmap.GetPixel(0, 0).Alpha);
+    }
+}

--- a/tests/libuilogic/Export/FullFrameImageTests.cs
+++ b/tests/libuilogic/Export/FullFrameImageTests.cs
@@ -1,0 +1,153 @@
+using Nikse.SubtitleEdit.UiLogic.Export;
+using SkiaSharp;
+
+namespace LibUiLogicTests.Export;
+
+public class FullFrameImageTests
+{
+    private static ImageParameter Param(ExportAlignment alignment, int bitmapWidth = 300, int bitmapHeight = 80)
+    {
+        var bitmap = new SKBitmap(bitmapWidth, bitmapHeight);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            using var paint = new SKPaint { Color = SKColors.Red };
+            canvas.DrawRect(0, 0, bitmapWidth, bitmapHeight, paint);
+        }
+
+        return new ImageParameter
+        {
+            Bitmap = bitmap,
+            ScreenWidth = 1920,
+            ScreenHeight = 1080,
+            Alignment = alignment,
+            BottomTopMargin = 50,
+            LeftRightMargin = 40,
+            IsFullFrame = true,
+        };
+    }
+
+    [Fact]
+    public void GetPosition_BottomCenter_CentersAndUsesBottomMargin()
+    {
+        var param = Param(ExportAlignment.BottomCenter);
+
+        var position = FullFrameImage.GetPosition(param, param.Bitmap.Width, param.Bitmap.Height);
+
+        Assert.Equal((1920 - 300) / 2, position.X);
+        Assert.Equal(1080 - 80 - 50, position.Y);
+    }
+
+    [Fact]
+    public void GetPosition_TopLeft_UsesBothMargins()
+    {
+        var param = Param(ExportAlignment.TopLeft);
+
+        var position = FullFrameImage.GetPosition(param, param.Bitmap.Width, param.Bitmap.Height);
+
+        Assert.Equal(40, position.X);
+        Assert.Equal(50, position.Y);
+    }
+
+    [Fact]
+    public void GetPosition_BottomRight_MeasuresFromTheRightEdge()
+    {
+        var param = Param(ExportAlignment.BottomRight);
+
+        var position = FullFrameImage.GetPosition(param, param.Bitmap.Width, param.Bitmap.Height);
+
+        Assert.Equal(1920 - 300 - 40, position.X);
+        Assert.Equal(1080 - 80 - 50, position.Y);
+    }
+
+    /// <summary>
+    /// Middle alignment centers the bitmap vertically. The Blu-ray sup handler used to compute
+    /// "ScreenHeight - Height / 2", which put the subtitle below the bottom edge.
+    /// </summary>
+    [Fact]
+    public void GetPosition_MiddleCenter_CentersVertically()
+    {
+        var param = Param(ExportAlignment.MiddleCenter);
+
+        var position = FullFrameImage.GetPosition(param, param.Bitmap.Width, param.Bitmap.Height);
+
+        Assert.Equal((1920 - 300) / 2, position.X);
+        Assert.Equal((1080 - 80) / 2, position.Y);
+    }
+
+    [Fact]
+    public void GetPosition_OverridePositionInsideFrame_Wins()
+    {
+        var param = Param(ExportAlignment.BottomCenter);
+        param.OverridePosition = new SKPointI(111, 222);
+
+        var position = FullFrameImage.GetPosition(param, param.Bitmap.Width, param.Bitmap.Height);
+
+        Assert.Equal(111, position.X);
+        Assert.Equal(222, position.Y);
+    }
+
+    [Fact]
+    public void GetPosition_OverridePositionOutsideFrame_FallsBackToAlignment()
+    {
+        var param = Param(ExportAlignment.BottomCenter);
+        param.OverridePosition = new SKPointI(5000, -10);
+
+        var position = FullFrameImage.GetPosition(param, param.Bitmap.Width, param.Bitmap.Height);
+
+        Assert.Equal((1920 - 300) / 2, position.X);
+        Assert.Equal(1080 - 80 - 50, position.Y);
+    }
+
+    [Fact]
+    public void Create_ReturnsFrameSizedBitmapWithTheSubtitleDrawnIn()
+    {
+        var param = Param(ExportAlignment.BottomCenter);
+
+        using var fullFrame = FullFrameImage.Create(param);
+
+        Assert.Equal(1920, fullFrame.Width);
+        Assert.Equal(1080, fullFrame.Height);
+
+        var position = FullFrameImage.GetPosition(param, param.Bitmap.Width, param.Bitmap.Height);
+        Assert.Equal(SKColors.Red, fullFrame.GetPixel(position.X + 1, position.Y + 1));
+        Assert.Equal(SKColors.Red, fullFrame.GetPixel(position.X + 299, position.Y + 79));
+    }
+
+    [Fact]
+    public void Create_DefaultBackgroundIsTransparent()
+    {
+        var param = Param(ExportAlignment.BottomCenter);
+
+        using var fullFrame = FullFrameImage.Create(param);
+
+        Assert.Equal(0, fullFrame.GetPixel(0, 0).Alpha);
+    }
+
+    [Fact]
+    public void Create_FillsWithTheFullFrameBackgroundColor()
+    {
+        var param = Param(ExportAlignment.BottomCenter);
+        param.FullFrameBackgroundColor = SKColors.Blue;
+
+        using var fullFrame = FullFrameImage.Create(param);
+
+        Assert.Equal(SKColors.Blue, fullFrame.GetPixel(0, 0));
+        Assert.Equal(SKColors.Blue, fullFrame.GetPixel(1919, 1079));
+    }
+
+    /// <summary>
+    /// The box colour behind the text and the full frame background are separate settings - a
+    /// black box behind the subtitle must not paint the whole frame black.
+    /// </summary>
+    [Fact]
+    public void Create_IgnoresTheTextBoxBackgroundColor()
+    {
+        var param = Param(ExportAlignment.BottomCenter);
+        param.BackgroundColor = SKColors.Black;
+
+        using var fullFrame = FullFrameImage.Create(param);
+
+        Assert.Equal(0, fullFrame.GetPixel(0, 0).Alpha);
+    }
+}


### PR DESCRIPTION
Fixes #13479.

SE4 could write each exported image at the size of the video frame, with the subtitle in its calculated place, so every image can be dropped on a Final Cut Pro / Premiere / DaVinci timeline at 0,0 and land where Subtitle Edit put it. The option went missing in SE5.

Part of the plumbing survived the port — `ImageParameter.IsFullFrame` and `SeExportImagesProfile.IsFullFrame` — but nothing ever set it, so it was dead code in the whole product: no UI, the Final Cut Pro handler had the compositing commented out, and the Blu-ray sup branch built the frame-sized canvas and never drew the subtitle onto it (`g.DrawImage` was among the commented-out lines), so it would have written blank frames.

### What this adds

- **"Full frame image" checkbox + its own background colour** in the image export window, shown for **Final Cut Pro** and **Blu-ray sup** (the formats SE4 offered it for; FAB has no SE5 equivalent). Transparent by default, so a full frame image only pads the subtitle out to the frame. Saved with the export profile.
- **`FullFrameImage`** in libuilogic holds the compositing and the position calculation, shared by both handlers and by the preview, so they cannot drift apart. The export window's own `CalculatePosition` now calls it — which also makes the preview honour the same out-of-frame `{\pos(x,y)}` fallback the handlers use.
- The full frame background is **separate from the box colour** behind the text (`ImageParameter.FullFrameBackgroundColor`): the old Blu-ray branch reused `BackgroundColor`, so a black subtitle box would have painted the whole frame black.
- The size shown under the preview reports the exported size (the frame) when the option is on.

### Two Final Cut Pro fixes found along the way

- **The frame rate combo had no effect.** Nothing ever assigned `ExportHandlerFcp.FrameRate`, so all `<duration>/<in>/<out>/<start>/<end>` frame numbers were written at the 25 fps default and the per-clip `<timebase>`/`<ntsc>` were hardcoded to 25/FALSE — a 23.976 or 29.97 export had wrong timings throughout. The frame rate now comes from the image parameters, the way the BDN XML handler takes it, and the timebase/NTSC/drop-frame flags follow it. This fixes `seconv`'s FCP output too.
- **`<pixelaspectratio>` held the resolution** (`1920x1080`), an element that takes values like `square`.

The sequence footer built its rate elements by replacing whole `<timebase>25</timebase>` strings, which also reached into the clip items embedded in it; that is now placeholder-based, so the two cannot interfere.

### Tests

`FullFrameImageTests`, `ExportHandlerFcpTests` and `ExportHandlerBluRaySupFullFrameTests` (the Blu-ray one exports and parses the .sup back, asserting the subtitle really is in the frame), plus headless window tests for the option's visibility per format and for a profile with the box checked not leaking into a format that never offered it. Full suites are green: libuilogic 198, UI 2351, libse 984, seconv 291.

`English.json` is regenerated; it also picks up the two `multipleReplace` strings that #13477 added to the language classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)