### PR TITLE
Fix six bugs in the original-as-reference feature (#13449 follow-up)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1510,6 +1510,17 @@ public partial class MainViewModel :
         }
     }
 
+    // AreTimeCodesLocked follows this mode, and the waveform enforces the lock through its own
+    // IsReadOnly - it must follow too, or dragging a paragraph edge would retime lines the lock
+    // exists to protect.
+    partial void OnIsShowingOriginalNonMatchingLinesChanged(bool value)
+    {
+        if (AudioVisualizer != null)
+        {
+            AudioVisualizer.IsReadOnly = AreTimeCodesLocked;
+        }
+    }
+
     [RelayCommand]
     private async Task ShowHelp()
     {
@@ -2405,6 +2416,10 @@ public partial class MainViewModel :
         _changeSubtitleHashOriginal = GetFastHashOriginal();
         _saveAsFileNameSuggestion = null;
 
+        // A remembered original-only scope would make every find come up empty now that there is
+        // no original column to search.
+        _findService.CurrentScope = FindScope.TextAndOriginal;
+
         _visibleLayers = null;
         ShowLayerFilterIcon = false;
 
@@ -2667,6 +2682,13 @@ public partial class MainViewModel :
             return;
         }
 
+        // The baseline hash covers the rows, so the remap below shifts it even when the original's
+        // content is untouched. Rebaseline afterwards only when the original was clean going in -
+        // an already-dirty original must stay dirty, or its unsaved edits would no longer count as
+        // changes and the app would close without offering to save them. A read-only original has
+        // nothing to save, so it always rebaselines.
+        var wasDirty = !IsOriginalReadOnly && _changeSubtitleHashOriginal != GetFastHashOriginal();
+
         if (capture)
         {
             CaptureOriginalFromRows();
@@ -2690,7 +2712,11 @@ public partial class MainViewModel :
             _reapplyingReadOnlyReference = false;
         }
 
-        _changeSubtitleHashOriginal = GetFastHashOriginal();
+        if (!wasDirty)
+        {
+            _changeSubtitleHashOriginal = GetFastHashOriginal();
+        }
+
         _referenceMappingDirty = false;
     }
 
@@ -2814,6 +2840,10 @@ public partial class MainViewModel :
             _changeSubtitleHashOriginal = GetFastHashOriginal();
         }
 
+        // A remembered original-only scope would make every find come up empty now that the
+        // original is gone.
+        _findService.CurrentScope = FindScope.TextAndOriginal;
+
         ShowColumnOriginalText = false;
         AutoFitColumns();
         _shortcutManager.ClearKeys();
@@ -2880,6 +2910,21 @@ public partial class MainViewModel :
         {
             subtitle.Text = subtitle.OriginalText;
             subtitle.OriginalText = string.Empty;
+
+            // A display-only reference row carries a line of the original, so the promotion turns
+            // it into an ordinary line - left flagged, it would be dropped from every save by
+            // GetUpdateSubtitle and keep its dimmed, read-only appearance.
+            subtitle.IsReferenceOnly = false;
+        }
+
+        if (IsShowingOriginalNonMatchingLines)
+        {
+            // The mode (and its time-code lock) is over: the original is now the working subtitle.
+            // Rebuild the rows so the promoted reference rows lose their dimmed look and take a
+            // number - IsReferenceOnly is not observable, so in-place edits would not re-render.
+            IsShowingOriginalNonMatchingLines = false;
+            _subtitle = GetUpdateSubtitle();
+            SetSubtitles(_subtitle, null);
         }
 
         _subtitleFileName = _subtitleFileNameOriginal;
@@ -2887,6 +2932,11 @@ public partial class MainViewModel :
         _subtitleOriginal = new Subtitle();
         _changeSubtitleHash = GetFastHash();
         _changeSubtitleHashOriginal = GetFastHashOriginal();
+
+        // A remembered original-only scope would make every find come up empty now that the
+        // original is gone.
+        _findService.CurrentScope = FindScope.TextAndOriginal;
+
         ShowColumnOriginalText = false;
         AutoFitColumns();
         _shortcutManager.ClearKeys();
@@ -12331,7 +12381,10 @@ public partial class MainViewModel :
 
         if (_replaceViewModel != null)
         {
-            _replaceViewModel.RefreshSubtitles(subs, origs, CanEditOriginal);
+            // The replace window's Count must agree with its Find next/Replace all, which go
+            // through HandleReplaceResult and never touch a read-only original - handing it the
+            // for-find texts would count matches that replace then cannot find.
+            _replaceViewModel.RefreshSubtitles(subs, GetOriginalTextsForReplace(), CanEditOriginal);
         }
     }
 
@@ -12940,25 +12993,34 @@ public partial class MainViewModel :
             return;
         }
 
+        // The dialog talks in the displayed line numbers, which skip the display-only reference
+        // rows - so they are not grid indexes when such rows are interleaved, and the entered
+        // number must be looked up by row number, not used as an index.
+        var lineCount = Subtitles.Count(p => !p.IsReferenceOnly);
+
         var viewModel = await ShowDialogAsync<GoToLineNumberWindow, GoToLineNumberViewModel>(vm =>
         {
             var idx = 1;
             if (SelectedSubtitle != null)
             {
-                idx = Subtitles.IndexOf(SelectedSubtitle) + 1;
+                idx = SelectedSubtitle.Number > 0
+                    ? SelectedSubtitle.Number
+                    : Subtitles.IndexOf(SelectedSubtitle) + 1;
             }
 
-            vm.Initialize(idx, Subtitles.Count);
+            vm.Initialize(idx, lineCount);
         });
 
-        if (viewModel is { OkPressed: true, LineNumber: >= 0 } && viewModel.LineNumber <= Subtitles.Count)
+        if (viewModel is { OkPressed: true, LineNumber: >= 0 } && viewModel.LineNumber <= lineCount)
         {
             var no = (int)viewModel.LineNumber;
-            SelectAndScrollToRow(no - 1);
+            var row = Subtitles.FirstOrDefault(p => !p.IsReferenceOnly && p.Number == no);
+            var index = row != null ? Subtitles.IndexOf(row) : no - 1;
+            SelectAndScrollToRow(index);
             var vp = GetVideoPlayerControl();
             if (Se.Settings.Tools.GoToLineNumberAlsoSetVideoPosition && !string.IsNullOrEmpty(_videoFileName) && vp != null)
             {
-                var s = Subtitles.GetOrNull(no - 1);
+                var s = Subtitles.GetOrNull(index);
                 if (s != null)
                 {
                     vp.Position = s.StartTime.TotalSeconds;
@@ -19366,8 +19428,17 @@ public partial class MainViewModel :
             }
 
             previousFormat.RemoveNativeFormatting(_subtitle, saveAsResult.SubtitleFormat);
+
+            // Same as the format-change handler: fold an editable original back from the rows
+            // before the rebuild blanks them, or the capture inside the re-apply would rebuild
+            // the original from empty rows.
+            if (IsShowingOriginalNonMatchingLines)
+            {
+                CaptureOriginalFromRows();
+            }
+
             SetSubtitles(_subtitle, IsOriginalReadOnly || IsShowingOriginalNonMatchingLines ? null : _subtitleOriginal);
-            ReapplyOriginalReference();
+            ReapplyOriginalReference(capture: false);
         }
 
         SetSubtitleFormat(saveAsResult.SubtitleFormat);
@@ -20953,7 +21024,10 @@ public partial class MainViewModel :
 
     private async Task DeleteSelectedItems()
     {
-        var selectedItems = _selectedSubtitles?.ToList() ?? [];
+        // The selection may span display-only reference rows (they are selectable so their text
+        // can be read), but they belong to the original, not the working subtitle - deleting one
+        // would permanently drop that line from an editable original on the next capture.
+        var selectedItems = _selectedSubtitles?.Where(p => !p.IsReferenceOnly).ToList() ?? [];
         if (selectedItems.Count == 0)
         {
             return;
@@ -25585,8 +25659,16 @@ public partial class MainViewModel :
                     SetAssaResolution(true);
                 }
 
+                // The rebuild below blanks the original column and drops the reference rows, so an
+                // editable original must be folded back from the rows while they still hold it -
+                // capturing after the rebuild would rebuild the original from empty rows.
+                if (IsShowingOriginalNonMatchingLines)
+                {
+                    CaptureOriginalFromRows();
+                }
+
                 SetSubtitles(_subtitle, IsOriginalReadOnly || IsShowingOriginalNonMatchingLines ? null : _subtitleOriginal);
-                ReapplyOriginalReference();
+                ReapplyOriginalReference(capture: false);
             }
         }
 

--- a/tests/UI/Features/Main/MainReadOnlyOriginalTests.cs
+++ b/tests/UI/Features/Main/MainReadOnlyOriginalTests.cs
@@ -8,6 +8,7 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Main.MainHelpers;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
 
 namespace UITests.Features.Main;
 
@@ -447,6 +448,186 @@ public class MainReadOnlyOriginalTests
     }
 
     /// <summary>
+    /// The re-match that follows a row change may only rebaseline a clean original - an original
+    /// with unsaved edits must still count as changed afterwards, or the edits would be lost on
+    /// exit without a save prompt.
+    /// </summary>
+    [AvaloniaFact]
+    public void EditableOriginal_ReapplyAfterRowChange_KeepsUnsavedEditsCountingAsChanges()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Translated one", string.Empty, 0, 2000);
+            AddLine(vm, "Translated two", string.Empty, 4000, 6000);
+
+            var reference = BuildSampleReference();
+            var match = ImportOriginalHelper.MatchOriginalLines(vm.Subtitles, reference);
+            InvokeImportOriginalSubtitle(vm, "reference.srt", reference, match, isReadOnly: false);
+            SetPrivateField(vm, "_changeSubtitleHash", vm.GetFastHash());
+            Assert.False(vm.HasChanges());
+
+            vm.Subtitles[0].OriginalText = "Edited original line";
+            Assert.True(vm.HasChanges());
+
+            InvokeReapplyReadOnlyReference(vm);
+
+            Assert.True(vm.HasChanges());
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>...while a clean original stays clean across the re-match's row shuffling.</summary>
+    [AvaloniaFact]
+    public void EditableOriginal_ReapplyAfterRowChange_KeepsACleanOriginalClean()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Translated one", string.Empty, 0, 2000);
+            AddLine(vm, "Translated two", string.Empty, 4000, 6000);
+
+            var reference = BuildSampleReference();
+            var match = ImportOriginalHelper.MatchOriginalLines(vm.Subtitles, reference);
+            InvokeImportOriginalSubtitle(vm, "reference.srt", reference, match, isReadOnly: false);
+            SetPrivateField(vm, "_changeSubtitleHash", vm.GetFastHash());
+
+            InvokeReapplyReadOnlyReference(vm);
+
+            Assert.False(vm.HasChanges());
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// "Remove translation" promotes the original to the working subtitle. With the non-matching
+    /// lines on screen, the display-only rows carry original lines too - so they must become
+    /// ordinary, numbered, saveable lines, and the mode (with its time-code lock) must end.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task EditableOriginal_RemoveTranslation_PromotesTheReferenceOnlyRows()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Translated one", string.Empty, 0, 2000);
+            AddLine(vm, "Translated two", string.Empty, 4000, 6000);
+
+            var reference = BuildSampleReference();
+            var match = ImportOriginalHelper.MatchOriginalLines(vm.Subtitles, reference);
+            InvokeImportOriginalSubtitle(vm, "reference.srt", reference, match, isReadOnly: false);
+            SetPrivateField(vm, "_changeSubtitleHash", vm.GetFastHash());
+
+            await InvokeFileCloseTranslation(vm);
+
+            Assert.False(vm.IsShowingOriginalNonMatchingLines);
+            Assert.False(vm.AreTimeCodesLocked);
+            Assert.DoesNotContain(vm.Subtitles, p => p.IsReferenceOnly);
+
+            var saved = vm.GetUpdateSubtitle();
+            Assert.Equal(3, saved.Paragraphs.Count);
+            Assert.Equal("Reference one", saved.Paragraphs[0].Text);
+            Assert.Equal("Reference only - no translation", saved.Paragraphs[1].Text);
+            Assert.Equal("Reference two", saved.Paragraphs[2].Text);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// The Delete command must skip reference-only rows in the selection: they belong to the
+    /// original, and deleting one from an editable original would drop the line for good on the
+    /// next capture.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task DeleteSelectedItems_SkipsReferenceOnlyRows()
+    {
+        var (window, vm) = CreateMainViewModel();
+        var promptBeforeDelete = Se.Settings.General.PromptBeforeDelete;
+        Se.Settings.General.PromptBeforeDelete = false;
+        try
+        {
+            ImportSampleReference(vm);
+            var referenceRow = Assert.Single(vm.Subtitles, p => p.IsReferenceOnly);
+
+            SetPrivateField(vm, "_selectedSubtitles",
+                new List<SubtitleLineViewModel> { referenceRow, vm.Subtitles[0] });
+
+            await InvokeDeleteSelectedItems(vm);
+
+            Assert.Contains(referenceRow, vm.Subtitles);
+            Assert.DoesNotContain(vm.Subtitles, p => p.Text == "Translated one");
+        }
+        finally
+        {
+            Se.Settings.General.PromptBeforeDelete = promptBeforeDelete;
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// The waveform enforces the time-code lock through its own IsReadOnly, so it must follow the
+    /// lock that showing/closing the non-matching lines toggles.
+    /// </summary>
+    [AvaloniaFact]
+    public void ShowingNonMatchingOriginalLines_MakesTheWaveformReadOnly()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            if (vm.AudioVisualizer == null)
+            {
+                return; // no waveform in this headless setup - nothing to verify
+            }
+
+            Assert.False(vm.AudioVisualizer.IsReadOnly);
+
+            ImportSampleReference(vm);
+            Assert.True(vm.AudioVisualizer.IsReadOnly);
+
+            InvokeFileCloseOriginal(vm);
+            Assert.False(vm.AudioVisualizer.IsReadOnly);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// A remembered "original text only" find scope must not survive the original going away, or
+    /// every find afterwards searches nothing and comes up empty.
+    /// </summary>
+    [AvaloniaFact]
+    public void CloseOriginal_ResetsAnOriginalOnlyFindScope()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            ImportSampleReference(vm);
+
+            var findService = (IFindService)GetField("_findService").GetValue(vm)!;
+            findService.CurrentScope = FindService.FindScope.OriginalOnly;
+
+            InvokeFileCloseOriginal(vm);
+
+            Assert.Equal(FindService.FindScope.TextAndOriginal, findService.CurrentScope);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
     /// Working subtitle: two translated lines with a gap. Reference: the same two plus a line in the
     /// gap that the translation never got - the case from issue #13449.
     /// </summary>
@@ -554,6 +735,24 @@ public class MainReadOnlyOriginalTests
                      ?? throw new InvalidOperationException("FileCloseOriginal not found");
 
         method.Invoke(vm, null);
+    }
+
+    private static async Task InvokeFileCloseTranslation(MainViewModel vm)
+    {
+        var method = typeof(MainViewModel).GetMethod(
+                         "FileCloseTranslation", BindingFlags.Instance | BindingFlags.NonPublic)
+                     ?? throw new InvalidOperationException("FileCloseTranslation not found");
+
+        await (Task)method.Invoke(vm, null)!;
+    }
+
+    private static async Task InvokeDeleteSelectedItems(MainViewModel vm)
+    {
+        var method = typeof(MainViewModel).GetMethod(
+                         "DeleteSelectedItems", BindingFlags.Instance | BindingFlags.NonPublic)
+                     ?? throw new InvalidOperationException("DeleteSelectedItems not found");
+
+        await (Task)method.Invoke(vm, null)!;
     }
 
     private static void SetPrivateField(MainViewModel vm, string name, object value)


### PR DESCRIPTION
Follow-ups from a bug hunt over the recently merged #13468/#13474. All found by review + verified in code; each fix has a regression test where the harness allows.

## Data-loss fixes (editable original with non-matching lines shown)

- **Format change erased the original.** The format combo (and "Save as" with a format change) rebuilt the rows with a blank original column first and captured the original from them afterwards — rebuilding `_subtitleOriginal` from empty rows into an empty subtitle and marking it clean. Capture now happens before the rebuild.
- **Unsaved original edits stopped counting as changes.** The re-match that follows any structural row edit reset `_changeSubtitleHashOriginal`, so the exit prompt / auto-save saw a dirty original as clean and the edits were silently lost. The re-match now only rebaselines an original that was clean going in.
- **The Delete key could remove a reference row.** `DeleteSelectedItems` read the with-reference selection; the next capture then permanently dropped that line from the original. Reference rows are now filtered out of the delete.

## Behavior fixes

- **Waveform ignored the time-code lock.** `AudioVisualizer.IsReadOnly` now follows `AreTimeCodesLocked` when the mode toggles, so paragraph edges can no longer be dragged while locked.
- **"Remove translation" left zombie rows.** Promoted reference rows kept `IsReferenceOnly` (excluded from every save, still dimmed/read-only) and the mode never ended. They are now promoted to ordinary numbered lines and the grid is rebuilt.
- **"Go to line number" mis-landed.** It treated the displayed number as a grid index; displayed numbers skip reference rows. It now looks the row up by number.
- **Replace window's Count disagreed with Replace.** Count searched the read-only original that Find next/Replace all (correctly) never touch — "Found 1 match" that "not found" then contradicted. Count now uses the same texts as replace.
- **Stale "original text only" scope.** The scope survived closing the original / opening a new file, making every F3 find come up empty. It resets when the original goes away.

## Tests

Six new tests in `MainReadOnlyOriginalTests` (dirty-baseline preserved, clean stays clean, remove-translation promotion, delete skips reference rows, waveform lock sync, scope reset). All 23 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)