### PR TITLE
Fix ten bugs found in a hunt over recently merged PRs

### DIFF
--- a/src/libuilogic/AutoTranslate/OllamaTranslate.cs
+++ b/src/libuilogic/AutoTranslate/OllamaTranslate.cs
@@ -1,5 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.UiLogic.Http;
 using Nikse.SubtitleEdit.UiLogic.Translate;
 using System;
 using System.Collections.Generic;
@@ -31,7 +32,9 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
         public void Initialize()
         {
             _httpClient?.Dispose();
-            _httpClient = new HttpClient();
+            // The Ollama url is user-configurable and may point at a remote host, so the SE proxy
+            // settings apply like they do for the other translate engines.
+            _httpClient = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
             _httpClient.BaseAddress = new Uri(AutoTranslateUrl.Complete(Configuration.Settings.Tools.OllamaApiUrl, DefaultUrl));

--- a/src/libuilogic/Http/HttpClientFactoryWithProxy.cs
+++ b/src/libuilogic/Http/HttpClientFactoryWithProxy.cs
@@ -35,7 +35,11 @@ namespace Nikse.SubtitleEdit.UiLogic.Http
 
                 if (proxySettings.UseDefaultCredentials)
                 {
-                    handler.Credentials = CredentialCache.DefaultNetworkCredentials;
+                    // These answer the proxy's 407 challenge. Handler.Credentials would instead
+                    // answer 401s from the target servers themselves - offering the machine's
+                    // credentials to any external host - while the authenticating proxy the user
+                    // configured this for would still be refused.
+                    handler.DefaultProxyCredentials = CredentialCache.DefaultNetworkCredentials;
                 }
 
                 return handler;

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleImageParameter.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleImageParameter.cs
@@ -58,38 +58,12 @@ public class OcrSubtitleImageParameter : IOcrSubtitle
             return new SKPointI(-1, -1);
         }
 
-        var left = 0;
-        var top = 0;
+        // Same placement math as the full-frame export. The hand-rolled version here had no
+        // branch for center or bottom alignments, so the default bottom-center came out as
+        // (0,0) - which the batch converter then promoted to an override position, pinning
+        // batch text->image subtitles to the top-left corner of the frame.
         var param = _imageParameterList[index];
-
-        if (param.Alignment == ExportAlignment.BottomLeft || param.Alignment == ExportAlignment.MiddleLeft || param.Alignment == ExportAlignment.TopLeft)
-        {
-            left = param.LeftRightMargin;
-        }
-        else if (param.Alignment == ExportAlignment.BottomRight || param.Alignment == ExportAlignment.MiddleRight || param.Alignment == ExportAlignment.TopRight)
-        {
-            left = param.ScreenWidth - param.Bitmap.Width - param.LeftRightMargin;
-        }
-
-        if (param.Alignment == ExportAlignment.TopLeft || param.Alignment == ExportAlignment.TopCenter || param.Alignment == ExportAlignment.TopRight)
-        {
-            top = param.BottomTopMargin;
-        }
-
-        if (param.Alignment == ExportAlignment.MiddleLeft || param.Alignment == ExportAlignment.MiddleCenter || param.Alignment == ExportAlignment.MiddleRight)
-        {
-            top = param.ScreenHeight - (param.Bitmap.Height / 2);
-        }
-
-        if (param.OverridePosition != null &&
-            param.OverridePosition.Value.X >= 0 && param.OverridePosition.Value.X < param.ScreenWidth &&
-            param.OverridePosition.Value.Y >= 0 && param.OverridePosition.Value.Y < param.ScreenHeight)
-        {
-            left = param.OverridePosition.Value.X;
-            top = param.OverridePosition.Value.Y;
-        }
-
-        return new SKPointI(left, top);
+        return FullFrameImage.GetPosition(param, param.Bitmap.Width, param.Bitmap.Height);
     }
 
     public SKSizeI GetScreenSize(int index)

--- a/src/ui/Features/Tools/AiReview/AiReviewClient.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewClient.cs
@@ -89,16 +89,34 @@ public class AiReviewClient : IDisposable
     /// </summary>
     internal static bool IsUnsupportedParameter(string? body, string parameterName)
     {
-        if (string.IsNullOrEmpty(body) || body.IndexOf(parameterName, StringComparison.OrdinalIgnoreCase) < 0)
+        if (string.IsNullOrEmpty(body))
         {
             return false;
         }
 
-        return body.Contains("unsupported", StringComparison.OrdinalIgnoreCase) ||
-               body.Contains("not support", StringComparison.OrdinalIgnoreCase) ||
-               body.Contains("unrecognized", StringComparison.OrdinalIgnoreCase) ||
-               body.Contains("invalid", StringComparison.OrdinalIgnoreCase) ||
-               body.Contains("unknown", StringComparison.OrdinalIgnoreCase);
+        // The rejection keyword must sit near the parameter name: some servers echo the whole
+        // submitted request in their error body, so the name plus a stray "invalid" about
+        // something else entirely (a bad API key, say) must not downgrade every later request
+        // in the run.
+        var index = body.IndexOf(parameterName, StringComparison.OrdinalIgnoreCase);
+        while (index >= 0)
+        {
+            var start = Math.Max(0, index - 120);
+            var length = Math.Min(body.Length - start, parameterName.Length + 240);
+            var nearby = body.AsSpan(start, length);
+            if (nearby.Contains("unsupported", StringComparison.OrdinalIgnoreCase) ||
+                nearby.Contains("not support", StringComparison.OrdinalIgnoreCase) ||
+                nearby.Contains("unrecognized", StringComparison.OrdinalIgnoreCase) ||
+                nearby.Contains("invalid", StringComparison.OrdinalIgnoreCase) ||
+                nearby.Contains("unknown", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            index = body.IndexOf(parameterName, index + parameterName.Length, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
     }
 
     internal static string BuildRequestJson(string model, string systemPrompt, string userContent, bool jsonMode, bool includeTemperature)

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -1683,6 +1683,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
                     var added = AddFile(fileName);
                     Dispatcher.UIThread.Post(() =>
                     {
+                        _allBatchItems.AddRange(added);
                         AddFilteredItems(added);
                         AddingFilesProgressValue = current;
                         MakeBatchItemsInfo();
@@ -1790,9 +1791,10 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         }
     }
 
-    // Parses a file and appends the resulting item(s) to _allBatchItems only (no UI-bound
-    // collection touched), so it is safe to call from a background thread. Returns the items
-    // added for this file; callers add them to the visible BatchItems on the UI thread.
+    // Parses a file and returns the resulting item(s) without touching any shared collection,
+    // so it is safe to call from a background thread. Callers append the returned items to
+    // _allBatchItems and the visible BatchItems on the UI thread - _allBatchItems is read there
+    // (filtering, the info label), so mutating it from the parse thread would race those reads.
     private List<BatchConvertItem> AddFile(string fileName)
     {
         var added = new List<BatchConvertItem>();
@@ -1858,7 +1860,6 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
                             var matroskaBatchItem = new BatchConvertItem(fileName, fileInfo.Length, format, subtitle);
                             matroskaBatchItem.LanguageCode = track.Language;
                             matroskaBatchItem.TrackNumber = track.TrackNumber.ToString(CultureInfo.InvariantCulture);
-                            _allBatchItems.Add(matroskaBatchItem);
                             added.Add(matroskaBatchItem);
                         }
                     }
@@ -1883,7 +1884,6 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
                 mp4Files.Add(name);
                 var mp4BatchItem = new BatchConvertItem(fileName, fileInfo.Length, name, subtitle);
                 mp4BatchItem.LanguageCode = mp4Parser.VttcLanguage;
-                _allBatchItems.Add(mp4BatchItem);
                 added.Add(mp4BatchItem);
             }
 
@@ -1895,8 +1895,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
                     mp4Files.Add(name);
                     var mp4BatchItem = new BatchConvertItem(fileName, fileInfo.Length, name, subtitle);
                     mp4BatchItem.LanguageCode = track.Mdia.Mdhd.Iso639ThreeLetterCode ?? track.Mdia.Mdhd.LanguageString;
-                    _allBatchItems.Add(mp4BatchItem);
-                    added.Add(mp4BatchItem);
+                        added.Add(mp4BatchItem);
                 }
             }
 
@@ -1912,7 +1911,6 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         {
             format = "Transport Stream";
             var tsBatchItem = new BatchConvertItem(fileName, fileInfo.Length, format, subtitle);
-            _allBatchItems.Add(tsBatchItem);
             added.Add(tsBatchItem);
             return added;
         }
@@ -1951,7 +1949,6 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         }
 
         var batchItem = new BatchConvertItem(fileName, fileInfo.Length, format, subtitle);
-        _allBatchItems.Add(batchItem);
         added.Add(batchItem);
         return added;
     }

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -1511,6 +1511,8 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             return;
         }
 
+        var profile = GetExportImagesProfile();
+
         var imageParameters = new List<ImageParameter>();
         for (var i = 0; i < imageSubtitle.Count; i++)
         {
@@ -1539,6 +1541,12 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                 BottomTopMargin = 0,
                 LeftRightMargin = 0,
                 Bitmap = ApplyImageAdjustments(imageSubtitle.GetBitmap(i)),
+                // The export handlers read these off the parameters: FCP/BDN take their
+                // timecode frame rate from here (falling back to a 25/23.976 default), and
+                // FCP/Blu-ray render onto a frame-sized canvas when full frame is on.
+                FramesPerSecond = profile.FramesPerSecond,
+                IsFullFrame = profile.IsFullFrame,
+                FullFrameBackgroundColor = profile.FullFrameBackgroundColor.FromHexToColor().ToSKColor(),
             };
             var position = imageSubtitle.GetPosition(i);
             if (position.X >= 0 && position.Y >= 0)
@@ -1691,18 +1699,17 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         }
     }
 
+    /// <summary>The export-images profile the target-format settings dialog edits and saves.</summary>
+    private static SeExportImagesProfile GetExportImagesProfile()
+    {
+        return Se.Settings.File.ExportImages.Profiles.FirstOrDefault(p => p.ProfileName == Se.Settings.File.ExportImages.LastProfileName)
+               ?? Se.Settings.File.ExportImages.Profiles.FirstOrDefault()
+               ?? new SeExportImagesProfile();
+    }
+
     private IOcrSubtitle? CreateImageSubtitles(BatchConvertItem item)
     {
-        var profile = Se.Settings.File.ExportImages.Profiles.FirstOrDefault(p => p.ProfileName == Se.Settings.File.ExportImages.LastProfileName);
-        if (profile == null)
-        {
-            profile = Se.Settings.File.ExportImages.Profiles.FirstOrDefault();
-        }
-
-        if (profile == null)
-        {
-            profile = new SeExportImagesProfile();
-        }
+        var profile = GetExportImagesProfile();
 
         if (item.Subtitle == null)
         {
@@ -1742,6 +1749,12 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                 ScreenHeight = profile.ScreenHeight,
                 BottomTopMargin = profile.BottomTopMargin,
                 LeftRightMargin = profile.LeftRightMargin,
+                // The export handlers read these off the parameters: FCP/BDN take their
+                // timecode frame rate from here (falling back to a 25/23.976 default), and
+                // FCP/Blu-ray render onto a frame-sized canvas when full frame is on.
+                FramesPerSecond = profile.FramesPerSecond,
+                IsFullFrame = profile.IsFullFrame,
+                FullFrameBackgroundColor = profile.FullFrameBackgroundColor.FromHexToColor().ToSKColor(),
             };
 
             imageParameter.Bitmap = ExportImageBasedViewModel.GenerateBitmap(imageParameter);

--- a/src/ui/Features/Video/BurnIn/BurnInResolutionPickerWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInResolutionPickerWindow.cs
@@ -2,6 +2,7 @@
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Data.Converters;
 using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Styling;
@@ -32,41 +33,47 @@ public class BurnInResolutionPickerWindow : Window
             SelectedItem = vm.SelectedResolution,
             VerticalAlignment = VerticalAlignment.Center,
             [!ListBox.SelectedItemProperty] = new Binding(nameof(vm.SelectedResolution)) { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged },
-            ItemTemplate = new FuncDataTemplate<ResolutionItem>((item, namescope) =>
+            // Recycling-safe template: everything binds and nothing dereferences the build
+            // parameter - a recycled container gets a different item as its DataContext, so a
+            // structural branch on the first item (separator vs row) and a captured `item` in
+            // the click handler would both act on the wrong resolution after scrolling.
+            ItemTemplate = new FuncDataTemplate<ResolutionItem>((_, _) =>
             {
-                if (item.IsSeparator)
+                var separator = new Separator
                 {
-                    return new Separator
-                    {
-                        Margin = new Thickness(0, 2, 0, 2),
-                        IsHitTestVisible = false, 
-                    };
-                }
-                else
+                    Margin = new Thickness(0, 2, 0, 2),
+                    IsHitTestVisible = false,
+                };
+                separator.Bind(Visual.IsVisibleProperty, new Binding(nameof(ResolutionItem.IsSeparator)));
+
+                var border = new Border();
+                border.Bind(Border.BackgroundProperty, new Binding(nameof(ResolutionItem.BackgroundColor)));
+                border.Bind(Visual.IsVisibleProperty, new Binding(nameof(ResolutionItem.IsSeparator))
                 {
-                    // Selectable item
-                    var border = new Border();
-                    border.Bind(Border.BackgroundProperty, new Binding(nameof(ResolutionItem.BackgroundColor)));
+                    Converter = BoolConverters.Not,
+                });
 
-                    var textBlock = new TextBlock
+                var textBlock = new TextBlock
+                {
+                    // Use the theme-appropriate text color (white in dark mode, black in
+                    // light mode). Previously the foreground was bound to
+                    // ResolutionItem.TextColor, which was never assigned, so it fell back to
+                    // a black/transparent color that was unreadable in dark mode.
+                    Foreground = UiUtil.GetTextColor(),
+                };
+                textBlock.Bind(TextBlock.TextProperty, new Binding(nameof(ResolutionItem.DisplayName)));
+
+                border.Child = textBlock;
+
+                border.PointerPressed += (s, e) =>
+                {
+                    if ((s as Border)?.DataContext is ResolutionItem current)
                     {
-                        // Use the theme-appropriate text color (white in dark mode, black in
-                        // light mode). Previously the foreground was bound to
-                        // ResolutionItem.TextColor, which was never assigned, so it fell back to
-                        // a black/transparent color that was unreadable in dark mode.
-                        Foreground = UiUtil.GetTextColor(),
-                    };
-                    textBlock.Bind(TextBlock.TextProperty, new Binding(nameof(ResolutionItem.DisplayName)));
+                        vm.ResolutionItemClicked(current);
+                    }
+                };
 
-                    border.Child = textBlock;
-
-                    border.PointerPressed += (s, e) =>
-                    {
-                        vm.ResolutionItemClicked(item); 
-                    };
-
-                    return border;
-                }
+                return new Panel { Children = { separator, border } };
             }, true),
         };
 

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -436,7 +436,13 @@ public partial class TextToSpeechViewModel : ObservableObject
         else if (SelectedEngine is ChatterboxTtsCpp)
         {
             Se.Settings.Video.TextToSpeech.ChatterboxModel = SelectedModel ?? ChatterboxTtsCpp.DefaultModelKey;
-            Se.Settings.Video.TextToSpeech.ChatterboxCrispAsrLanguage = SelectedLanguage?.Name ?? string.Empty;
+
+            // Turbo is English-only and offers just "Auto" - saving that would discard the
+            // language the user picked for the multilingual Base model.
+            if (ChatterboxTtsCpp.ResolveModelKey(SelectedModel) != ChatterboxTtsCpp.ModelKeyTurbo)
+            {
+                Se.Settings.Video.TextToSpeech.ChatterboxCrispAsrLanguage = SelectedLanguage?.Name ?? string.Empty;
+            }
         }
         else if (SelectedEngine is KokoroTtsCpp)
         {
@@ -3759,7 +3765,9 @@ public partial class TextToSpeechViewModel : ObservableObject
                                    ?? Languages.FirstOrDefault(p => p.Name == Se.Settings.Video.TextToSpeech.ElevenLabsLanguage);
                 if (SelectedLanguage == null)
                 {
-                    SelectedLanguage = Languages.FirstOrDefault(p => p.Code == "en");
+                    // Fall back to the list's first entry so the combo is never left empty -
+                    // Chatterbox Turbo, for example, offers only "Auto", whose code is not "en".
+                    SelectedLanguage = Languages.FirstOrDefault(p => p.Code == "en") ?? Languages.FirstOrDefault();
                 }
             }
         });

--- a/src/ui/Logic/Config/SeVideoBurnIn.cs
+++ b/src/ui/Logic/Config/SeVideoBurnIn.cs
@@ -60,7 +60,10 @@ public class SeVideoBurnIn
         FontFactor = 0.52;
         Encoding = DefaultEncoding;
         Preset = "medium";
-        Crf = "23";
+        // 23 is the right default for libx264 CRF (0-51, lower is better), but the macOS default
+        // encoder is VideoToolbox, whose quality scale is 1-100 with higher being better - and on
+        // Intel Macs "-q:v" fails outright. Its quality stays unset so ffmpeg picks a bitrate.
+        Crf = DefaultEncoding == "libx264" ? "23" : string.Empty;
         Tune = "film";
         AudioEncoding = "copy";
         AudioForceStereo = true;

--- a/src/ui/Logic/WindowsService.cs
+++ b/src/ui/Logic/WindowsService.cs
@@ -488,7 +488,10 @@ namespace Nikse.SubtitleEdit.Logic
             dialog.AddHandler(InputElement.GotFocusEvent, OnDialogGotFocus, RoutingStrategies.Bubble, handledEventsToo: true);
             owner.AddHandler(InputElement.GotFocusEvent, OnOwnerGotFocus, RoutingStrategies.Bubble, handledEventsToo: true);
             // Tunnel: run before the owner's own handlers (shortcut manager, text boxes) see the key.
+            // Key-up included: the AccessKeyHandler arms on Alt key-down but opens the menu bar on
+            // the key-up, so letting the release through would pop the disabled owner's menu.
             owner.AddHandler(InputElement.KeyDownEvent, OnOwnerKeyInput, RoutingStrategies.Tunnel);
+            owner.AddHandler(InputElement.KeyUpEvent, OnOwnerKeyInput, RoutingStrategies.Tunnel);
             owner.AddHandler(InputElement.TextInputEvent, OnOwnerKeyInput, RoutingStrategies.Tunnel);
 
             return new ActionDisposable(() =>
@@ -501,6 +504,7 @@ namespace Nikse.SubtitleEdit.Logic
                 dialog.RemoveHandler(InputElement.GotFocusEvent, OnDialogGotFocus);
                 owner.RemoveHandler(InputElement.GotFocusEvent, OnOwnerGotFocus);
                 owner.RemoveHandler(InputElement.KeyDownEvent, OnOwnerKeyInput);
+                owner.RemoveHandler(InputElement.KeyUpEvent, OnOwnerKeyInput);
                 owner.RemoveHandler(InputElement.TextInputEvent, OnOwnerKeyInput);
             });
         }

--- a/tests/UI/Features/Tools/AiReview/AiReviewClientTests.cs
+++ b/tests/UI/Features/Tools/AiReview/AiReviewClientTests.cs
@@ -24,6 +24,17 @@ public class AiReviewClientTests
         "{ \"error\": { \"message\": \"Rate limit reached for gpt-5.6-luna, please try again later.\", " +
         "\"type\": \"requests\", \"code\": \"rate_limit_exceeded\" } }";
 
+    // An error body that echoes the submitted request: it contains both parameter names and the
+    // word "invalid" - but about the API key, far away from either parameter, so it must not be
+    // read as a parameter rejection.
+    private const string EchoedRequestError =
+        "{ \"request\": { \"model\": \"gpt-5.6-luna\", \"temperature\": 0, \"stream\": false, " +
+        "\"response_format\": { \"type\": \"json_object\" }, \"messages\": [ { \"role\": \"system\", " +
+        "\"content\": \"You review subtitles for grammar, casing and punctuation problems and reply " +
+        "with a json object listing each line number and the corrected text, leaving correct lines " +
+        "out of the reply entirely so the caller can apply the fixes one by one.\" } ] }, " +
+        "\"error\": { \"message\": \"invalid api key\", \"code\": 401 } }";
+
     private const string Reply = "{ \"choices\": [ { \"message\": { \"content\": \"all good\" } } ] }";
 
     [Fact]
@@ -52,6 +63,8 @@ public class AiReviewClientTests
     [InlineData(ResponseFormatError, "temperature", false)]
     [InlineData(RateLimitError, "temperature", false)]
     [InlineData(RateLimitError, "response_format", false)]
+    [InlineData(EchoedRequestError, "temperature", false)]
+    [InlineData(EchoedRequestError, "response_format", false)]
     [InlineData("", "temperature", false)]
     public void IsUnsupportedParameter_OnlyMatchesParameterRejections(string body, string parameterName, bool expected)
     {

--- a/tests/libuilogic/Http/HttpClientFactoryWithProxyTests.cs
+++ b/tests/libuilogic/Http/HttpClientFactoryWithProxyTests.cs
@@ -69,6 +69,22 @@ public class HttpClientFactoryWithProxyTests
     }
 
     [Fact]
+    public void CreateHandler_NoProxyAddress_DefaultCredentialsAnswerProxyAuthOnly()
+    {
+        var handler = HttpClientFactoryWithProxy.CreateHandler(new ProxySettings
+        {
+            ProxyAddress = string.Empty,
+            UseDefaultCredentials = true,
+        });
+
+        // The machine's credentials answer the proxy's 407 challenge. They must not land on
+        // Credentials, which answers 401s from the target servers themselves - that would offer
+        // the user's domain credentials to any external host.
+        Assert.Same(CredentialCache.DefaultNetworkCredentials, handler.DefaultProxyCredentials);
+        Assert.Null(handler.Credentials);
+    }
+
+    [Fact]
     public void CreateHandler_NoProxyAddress_StillAppliesBypassListToSystemProxy()
     {
         var handler = HttpClientFactoryWithProxy.CreateHandler(new ProxySettings


### PR DESCRIPTION
Second half of the 2026-08-11 bug hunt (first half: #13485). Independent fixes across recently merged PRs, each verified in code before fixing; regression tests added where the code is testable headlessly.

## From #13446 (VideoToolbox default)
- **Fresh macOS installs got `h264_videotoolbox -q:v 23`.** The persisted default `Crf = "23"` was chosen for libx264; on VideoToolbox's 1–100 higher-is-better scale that means quality 23/100 on Apple silicon, and on Intel Macs ffmpeg fails with "qscale not available" — burn-in broken out of the box. `FillCrf` already documented that VideoToolbox quality should stay unset; the default now respects that.

## From #13463 (proxy plumbing)
- **"Use default credentials" without a proxy address set server-auth credentials, not proxy-auth.** `handler.Credentials` answers 401s from target servers — offering the machine's domain credentials to any external host — while the authenticating system proxy's 407 stayed unanswered. Now on `DefaultProxyCredentials`. (+ regression test)
- **`OllamaTranslate` still built a bare `HttpClient`**, bypassing the proxy its sibling engines honor; the Ollama URL is user-configurable to a remote host.

## From #13470 (Chatterbox multilingual)
- **Switching to Turbo blanked the language combo and clobbered the saved language.** Turbo offers only "Auto" (code `""`), which no restore rule matched; closing the dialog then saved an empty `ChatterboxCrispAsrLanguage`, discarding e.g. "French" picked for Base. The restore chain now falls back to the list's first entry, and Turbo no longer overwrites the saved multilingual language.

## From #13483 (full-frame export) — batch convert
- **The batch target-format settings dialog showed and saved "Full frame image" and the frame rate, but the batch converter never read either.** Both ImageParameter builders now carry `IsFullFrame`, `FullFrameBackgroundColor`, and `FramesPerSecond` from the profile, so FCP/BDN timecodes use the chosen frame rate and FCP/Blu-ray render full-frame when asked.
- **Batch text→image conversions rendered subtitles at the frame's top-left.** `OcrSubtitleImageParameter.GetPosition` had no branch for center or bottom alignments, so the default bottom-center returned (0,0) — which the converter then promoted to an override position. It now delegates to `FullFrameImage.GetPosition`.

## From #13472 (batch file count)
- **Add-files parsed on a background thread while mutating `_allBatchItems`, which the UI thread filters and counts.** Typing in the filter box during a large scan could throw "collection was modified". `AddFile` is now pure; items are appended on the UI thread.

## From #13444's pattern (template recycling)
- **The burn-in resolution picker's list template branched on the build parameter and captured it in the click closure.** With `supportsRecycling: true`, a scrolled list would render separators/rows for the wrong items and click the wrong resolution. Rebuilt in the bind-everything style with visibility-bound separator/row.

## From #13476 (AI review retry)
- **`IsUnsupportedParameter` matched "invalid" anywhere in the body.** A server echoing the submitted request (which contains `temperature`/`response_format`) plus an unrelated "invalid api key" would permanently downgrade JSON mode for the run. The keyword must now appear near the parameter name. (+ regression test)

## From #13465 (modal focus)
- **The owner-key swallow covered KeyDown/TextInput but not KeyUp.** Avalonia's AccessKeyHandler opens the menu bar on the Alt *release*, so a bare Alt during a focus-steal window could pop the disabled owner's menu under the modal. KeyUp is now swallowed too.

## Tests
New: proxy-credentials scope test, echoed-request-body AI-review cases. All affected suites green: proxy (6), AI review (14), batch/burn-in/full-frame (32), TTS (135), libuilogic export (26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)