### PR TITLE
Restore trough paging for the TableView scroll bar (#12894)

### DIFF
--- a/src/ui/Logic/TableViewScrollBarBehavior.cs
+++ b/src/ui/Logic/TableViewScrollBarBehavior.cs
@@ -1,0 +1,308 @@
+using System;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Gives a <see cref="TableView"/>'s vertical scroll bar Windows-standard trough behavior:
+/// press-and-hold on the trough pages toward the cursor and pauses when the thumb reaches
+/// it (#12894), and shift + trough click jumps the thumb straight to the click position
+/// (#12051/#12438).
+///
+/// Both behaviors shipped for the old DataGrid in DataGridScrollBarBehavior, which the
+/// TableView migration retired with the grid itself (b24211a1b1) on the note that native
+/// ScrollViewer paging replaced it. It only half did: a plain ScrollViewer does page a full
+/// viewport per trough click, but the trough of Avalonia's Fluent ScrollBar is a
+/// RepeatButton that keeps firing while IsPressed, and Button only re-evaluates IsPressed
+/// on PointerMoved - so with a stationary cursor no event arrives as the thumb slides under
+/// it and the paging runs right past the cursor to the end of the list. The shift+click
+/// jump has no native counterpart at all.
+///
+/// Unlike the DataGrid version there is no reflection and no LargeChange bookkeeping here:
+/// the ScrollViewer template binds the scroll bar's Value two-way to the scroll offset and
+/// its LargeChange to the viewport, so a page is just a Value change.
+/// </summary>
+public static class TableViewScrollBarBehavior
+{
+    // Avalonia's RepeatButton defaults, so the trough repeats like every other scroll bar.
+    private static readonly TimeSpan RepeatDelay = TimeSpan.FromMilliseconds(300);
+    private static readonly TimeSpan RepeatInterval = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>
+    /// Attach the trough paging and shift+click jump to a TableView. Set once, application
+    /// wide, from a single TableView style in Styles.axaml so every grid gets the
+    /// Windows-standard scroll bar behavior without each window wiring it by hand (#12438),
+    /// including the grids built with plain new TableView() rather than
+    /// <see cref="TableViewExtras.MakeTableView"/>.
+    /// </summary>
+    public static readonly AttachedProperty<bool> EnableTroughPagingProperty =
+        AvaloniaProperty.RegisterAttached<TableView, bool>("EnableTroughPaging", typeof(TableViewScrollBarBehavior));
+
+    // Marks a grid already wired so that setting the attached property to true more than once
+    // does not stack a second set of pointer handlers.
+    private static readonly AttachedProperty<bool> WiredProperty =
+        AvaloniaProperty.RegisterAttached<TableView, bool>("TroughPagingWired", typeof(TableViewScrollBarBehavior));
+
+    // Non-null only while the left button is held on the grid's vertical trough.
+    private static readonly AttachedProperty<TroughHoldState?> HoldStateProperty =
+        AvaloniaProperty.RegisterAttached<TableView, TroughHoldState?>("TroughHoldState", typeof(TableViewScrollBarBehavior));
+
+    public static void SetEnableTroughPaging(TableView tableView, bool value) => tableView.SetValue(EnableTroughPagingProperty, value);
+
+    public static bool GetEnableTroughPaging(TableView tableView) => tableView.GetValue(EnableTroughPagingProperty);
+
+    static TableViewScrollBarBehavior()
+    {
+        EnableTroughPagingProperty.Changed.AddClassHandler<TableView>((tableView, e) =>
+        {
+            if (e.NewValue is true && !tableView.GetValue(WiredProperty))
+            {
+                tableView.SetValue(WiredProperty, true);
+                Wire(tableView);
+            }
+        });
+    }
+
+    // All handlers sit on the grid, not the scroll bar: the scroll bar lives two templates
+    // deep (grid template -> ScrollViewer template) and only exists once both have applied,
+    // while a tunneling handler on the grid sees the press first regardless - before the
+    // theme's trough repeat button can engage.
+    private static void Wire(TableView tableView)
+    {
+        tableView.AddHandler(
+            InputElement.PointerPressedEvent,
+            (sender, e) =>
+            {
+                var grid = (TableView)sender!;
+                if ((e.KeyModifiers & KeyModifiers.Shift) != 0)
+                {
+                    JumpToClickPosition(grid, e);
+                }
+                else
+                {
+                    StartTroughHoldPaging(grid, e);
+                }
+            },
+            RoutingStrategies.Tunnel);
+
+        tableView.PointerMoved += (sender, e) =>
+        {
+            var grid = (TableView)sender!;
+            if (GetHoldState(grid) is { } state)
+            {
+                state.PointerPosition = e.GetPosition(grid);
+            }
+        };
+
+        tableView.PointerReleased += (sender, e) =>
+        {
+            var grid = (TableView)sender!;
+            if (GetHoldState(grid) != null && e.InitialPressMouseButton == MouseButton.Left)
+            {
+                StopTroughHoldPaging(grid);
+                e.Pointer.Capture(null);
+                e.Handled = true;
+            }
+        };
+
+        // Covers a release outside the window and window deactivation mid-hold.
+        tableView.PointerCaptureLost += (sender, _) => StopTroughHoldPaging((TableView)sender!);
+    }
+
+    // State for a press-and-hold on the trough. The direction is latched at press time
+    // (Windows-style): re-deciding it per tick would ping-pong once a page overshoots.
+    private sealed class TroughHoldState
+    {
+        public required DispatcherTimer Timer { get; init; }
+        public required IPointer Pointer { get; init; }
+        public required ScrollBar ScrollBar { get; init; }
+        public required Track Track { get; init; }
+        public required bool PageDown { get; init; }
+        public Point PointerPosition { get; set; } // in grid coordinates
+    }
+
+    private static void StartTroughHoldPaging(TableView tableView, PointerPressedEventArgs e)
+    {
+        if (GetHoldState(tableView) != null ||
+            !e.GetCurrentPoint(tableView).Properties.IsLeftButtonPressed ||
+            !TryGetTroughPress(tableView, e, out var scrollBar, out var track, out _, out var isBelowThumb))
+        {
+            return;
+        }
+
+        var timer = new DispatcherTimer { Interval = RepeatDelay };
+        var state = new TroughHoldState
+        {
+            Timer = timer,
+            Pointer = e.Pointer,
+            ScrollBar = scrollBar,
+            Track = track,
+            PageDown = isBelowThumb,
+            PointerPosition = e.GetPosition(tableView),
+        };
+
+        timer.Tick += (_, _) =>
+        {
+            timer.Interval = RepeatInterval;
+            TickTroughHoldPaging(tableView, state);
+        };
+
+        tableView.SetValue(HoldStateProperty, state);
+        e.Pointer.Capture(tableView);
+        PageOnce(scrollBar, state.PageDown);
+        timer.Start();
+
+        // Keep the trough repeat button from setting IsPressed and starting its own repeat.
+        e.Handled = true;
+    }
+
+    private static void TickTroughHoldPaging(TableView tableView, TroughHoldState state)
+    {
+        // A missed release, or a capture taken elsewhere, must not leave the timer paging.
+        if (state.Pointer.Captured != tableView)
+        {
+            StopTroughHoldPaging(tableView);
+            return;
+        }
+
+        var thumb = state.Track.Thumb;
+        var posY = tableView.TranslatePoint(state.PointerPosition, state.Track)?.Y;
+        if (thumb == null || posY == null)
+        {
+            return;
+        }
+
+        // Pause (not stop) once the thumb has reached the pointer: paging resumes if the
+        // pointer moves further in the latched direction, like the Windows scroll bar.
+        if (ShouldPage(posY.Value, thumb.Bounds, state.PageDown))
+        {
+            PageOnce(state.ScrollBar, state.PageDown);
+        }
+    }
+
+    private static bool ShouldPage(double posY, Rect thumbBounds, bool pageDown)
+    {
+        return pageDown ? posY > thumbBounds.Bottom : posY < thumbBounds.Top;
+    }
+
+    private static void PageOnce(ScrollBar scrollBar, bool pageDown)
+    {
+        var delta = pageDown ? scrollBar.LargeChange : -scrollBar.LargeChange;
+        var newValue = Math.Clamp(scrollBar.Value + delta, scrollBar.Minimum, scrollBar.Maximum);
+        if (newValue != scrollBar.Value)
+        {
+            scrollBar.Value = newValue;
+        }
+    }
+
+    private static TroughHoldState? GetHoldState(TableView tableView) => tableView.GetValue(HoldStateProperty);
+
+    private static void StopTroughHoldPaging(TableView tableView)
+    {
+        if (GetHoldState(tableView) is { } state)
+        {
+            state.Timer.Stop();
+            tableView.SetValue(HoldStateProperty, null);
+        }
+    }
+
+    // The headless test dispatcher never fires a DispatcherTimer, so the tests step the
+    // repeat by hand (TableViewScrollBarTroughPagingTests).
+    internal static void TickTroughHoldPagingForTest(TableView tableView)
+    {
+        if (GetHoldState(tableView) is { } state)
+        {
+            TickTroughHoldPaging(tableView, state);
+        }
+    }
+
+    private static void JumpToClickPosition(TableView tableView, PointerPressedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(tableView).Properties.IsLeftButtonPressed ||
+            !TryGetTroughPress(tableView, e, out var scrollBar, out var track, out var posY, out _))
+        {
+            return;
+        }
+
+        // Center the thumb on the cursor: subtract half the thumb length and scale by the
+        // travel the thumb actually has (track height minus thumb length).
+        var range = scrollBar.Maximum - scrollBar.Minimum;
+        var thumbLength = track.Thumb?.Bounds.Height ?? 0;
+        var travel = Math.Max(1, track.Bounds.Height - thumbLength);
+        var offset = posY - (thumbLength / 2.0);
+        var fraction = Math.Clamp(offset / travel, 0.0, 1.0);
+
+        scrollBar.Value = Math.Clamp(scrollBar.Minimum + (fraction * range), scrollBar.Minimum, scrollBar.Maximum);
+        e.Handled = true;
+    }
+
+    /// <summary>
+    /// Returns the scroll bar, its track and the press's track-relative Y for a genuine
+    /// trough press, or false for presses elsewhere in the grid (rows, headers), outside the
+    /// track (the line step arrows), on the thumb itself (which begins a normal drag), on a
+    /// scroll bar that is not the grid's own vertical one (the horizontal bar, or one of a
+    /// control hosted inside a cell), or when there is nothing to scroll. Shared by the
+    /// shift+click jump and the hold paging so both agree on what counts as the trough.
+    /// </summary>
+    private static bool TryGetTroughPress(TableView tableView, PointerEventArgs e, out ScrollBar scrollBar, out Track track, out double posY, out bool isBelowThumb)
+    {
+        scrollBar = null!;
+        track = null!;
+        posY = 0;
+        isBelowThumb = false;
+
+        var foundScrollBar = (e.Source as Visual)?.FindAncestorOfType<ScrollBar>(includeSelf: true);
+        if (foundScrollBar == null ||
+            foundScrollBar.Orientation != Orientation.Vertical ||
+            foundScrollBar.FindAncestorOfType<TableView>() != tableView)
+        {
+            return false;
+        }
+
+        var range = foundScrollBar.Maximum - foundScrollBar.Minimum;
+        if (double.IsNaN(range) || range <= 0)
+        {
+            return false;
+        }
+
+        var foundTrack = foundScrollBar.GetVisualDescendants().OfType<Track>().FirstOrDefault();
+        if (foundTrack == null || foundTrack.Bounds.Height <= 0)
+        {
+            return false;
+        }
+
+        var y = e.GetPosition(foundTrack).Y;
+        if (y < 0 || y > foundTrack.Bounds.Height)
+        {
+            return false;
+        }
+
+        var thumb = foundTrack.Thumb;
+        if (thumb != null)
+        {
+            if (y >= thumb.Bounds.Top && y <= thumb.Bounds.Bottom)
+            {
+                return false;
+            }
+
+            isBelowThumb = y > thumb.Bounds.Bottom;
+        }
+        else
+        {
+            isBelowThumb = true;
+        }
+
+        scrollBar = foundScrollBar;
+        track = foundTrack;
+        posY = y;
+        return true;
+    }
+}

--- a/src/ui/Logic/TableViewScrollBarBehavior.cs
+++ b/src/ui/Logic/TableViewScrollBarBehavior.cs
@@ -248,9 +248,18 @@ public static class TableViewScrollBarBehavior
     /// Returns the scroll bar, its track and the press's track-relative Y for a genuine
     /// trough press, or false for presses elsewhere in the grid (rows, headers), outside the
     /// track (the line step arrows), on the thumb itself (which begins a normal drag), on a
-    /// scroll bar that is not the grid's own vertical one (the horizontal bar, or one of a
-    /// control hosted inside a cell), or when there is nothing to scroll. Shared by the
-    /// shift+click jump and the hold paging so both agree on what counts as the trough.
+    /// horizontal scroll bar, or when there is nothing to scroll. Shared by the shift+click
+    /// jump and the hold paging so both agree on what counts as the trough.
+    ///
+    /// Any vertical scroll bar inside the grid counts, not just the grid's own: a scrollable
+    /// control hosted in a cell has the same runaway trough repeat (it is Fluent's ScrollBar,
+    /// not anything the grid does), so it is paged the same way - the bar the press landed on
+    /// is the one that pages. A nested TableView keeps its own scroll bar: the outer grid's
+    /// handler sees the inner grid as the nearest TableView ancestor and bows out.
+    ///
+    /// Horizontal bars keep the native (runaway) repeat, as they did for the DataGrid. If that
+    /// is ever reported for a wide grid, the fix is this same path without the orientation
+    /// check, with the thumb comparison on X instead of Y.
     /// </summary>
     private static bool TryGetTroughPress(TableView tableView, PointerEventArgs e, out ScrollBar scrollBar, out Track track, out double posY, out bool isBelowThumb)
     {

--- a/src/ui/Styles.axaml
+++ b/src/ui/Styles.axaml
@@ -2,6 +2,11 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:logic="clr-namespace:Nikse.SubtitleEdit.Logic;assembly=SubtitleEdit"
         xmlns:seControls="clr-namespace:Nikse.SubtitleEdit.Controls;assembly=SubtitleEdit">
+    <!-- Windows-standard scroll bar for every grid: a trough hold pages toward the cursor and
+         pauses when the thumb reaches it (#12894), shift+click jumps to the position (#12438). -->
+    <Style Selector="TableView">
+        <Setter Property="logic:TableViewScrollBarBehavior.EnableTroughPaging" Value="True"/>
+    </Style>
     <Styles.Resources>
         <!-- Formerly supplied by the retired Avalonia.Controls.DataGrid theme; the
              TableView header theme still resolves this key (and SE's custom themes

--- a/tests/UI/Logic/TableViewScrollBarTroughPagingTests.cs
+++ b/tests/UI/Logic/TableViewScrollBarTroughPagingTests.cs
@@ -1,0 +1,229 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Styling;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// A press on the trough of a TableView's vertical scroll bar pages toward the cursor and
+/// pauses when the thumb reaches it, and shift+click jumps the thumb to the click position,
+/// instead of the theme's trough RepeatButton paging right past the cursor to the end of
+/// the list (#12894 - fixed for the DataGrid, regressed when that behavior was retired with
+/// the DataGrid itself). The headless dispatcher never fires a DispatcherTimer, so the
+/// repeats are stepped by hand through TickTroughHoldPagingForTest.
+/// </summary>
+public class TableViewScrollBarTroughPagingTests : IDisposable
+{
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private sealed record Row(int Number, string Text);
+
+    private (Window window, TableView grid, ScrollBar scrollBar) BuildShownGrid()
+    {
+        var grid = new TableView
+        {
+            ItemsSource = Enumerable.Range(1, 200).Select(i => new Row(i, $"Line {i}")).ToList(),
+            Columns =
+            {
+                new TableViewColumn { Header = "#", Binding = new Avalonia.Data.Binding(nameof(Row.Number)) },
+                new TableViewColumn { Header = "Text", Binding = new Avalonia.Data.Binding(nameof(Row.Text)) },
+            },
+        };
+        TableViewScrollBarBehavior.SetEnableTroughPaging(grid, true);
+
+        var window = new Window { Content = grid, Width = 400, Height = 300 };
+
+        // The app keeps scroll bars always expanded (UiTheme.ApplyScrollBarStyle, except on
+        // macOS set to auto-hide); do the same here so the trough is hit-testable without the
+        // hover-expansion that headless input never delivers.
+        window.Styles.Add(new Style(x => x.OfType<ScrollBar>())
+        {
+            Setters = { new Setter(ScrollBar.AllowAutoHideProperty, false) },
+        });
+
+        _windows.Add(window);
+        window.Show();
+        window.UpdateLayout();
+        AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        var scrollBar = grid.GetVisualDescendants().OfType<ScrollBar>()
+            .First(s => s.Orientation == Orientation.Vertical);
+        return (window, grid, scrollBar);
+    }
+
+    private static Track TrackOf(ScrollBar scrollBar) => scrollBar.GetVisualDescendants().OfType<Track>().First();
+
+    // A point centered horizontally, at the given fraction down the track, in window coordinates.
+    private static Point TrackPoint(Window window, ScrollBar scrollBar, double fraction)
+    {
+        var track = TrackOf(scrollBar);
+        return track.TranslatePoint(new Point(track.Bounds.Width / 2, track.Bounds.Height * fraction), window)!.Value;
+    }
+
+    private static Point TroughPointBelowThumb(Window window, ScrollBar scrollBar)
+    {
+        var track = TrackOf(scrollBar);
+
+        // Well below the thumb, which sits at the top while Value is 0.
+        var yInTrack = (track.Thumb!.Bounds.Bottom + track.Bounds.Height) / 2;
+        return track.TranslatePoint(new Point(track.Bounds.Width / 2, yInTrack), window)!.Value;
+    }
+
+    private static void Repeat(Window window, TableView grid, int ticks)
+    {
+        for (var i = 0; i < ticks; i++)
+        {
+            TableViewScrollBarBehavior.TickTroughHoldPagingForTest(grid);
+            window.UpdateLayout();
+        }
+    }
+
+    // True once the thumb has caught up with the pointer, so paging should have paused.
+    private static bool ThumbReached(Window window, ScrollBar scrollBar, Point windowPoint)
+    {
+        var track = TrackOf(scrollBar);
+        return track.Thumb!.Bounds.Bottom >= window.TranslatePoint(windowPoint, track)!.Value.Y;
+    }
+
+    [AvaloniaFact]
+    public void TroughPress_PagesExactlyOneViewport()
+    {
+        var (window, grid, scrollBar) = BuildShownGrid();
+        Assert.True(scrollBar.Maximum > 0, "grid should have enough rows to scroll");
+        Assert.True(scrollBar.LargeChange > 1, "LargeChange should follow the viewport via the ScrollViewer template binding");
+        Assert.Equal(0, scrollBar.Value);
+
+        var point = TroughPointBelowThumb(window, scrollBar);
+        window.MouseDown(point, MouseButton.Left);
+
+        // One immediate page of one viewport; the repeat has not been stepped yet.
+        Assert.Equal(scrollBar.LargeChange, scrollBar.Value, 3);
+
+        // The rows follow: the scroll bar's Value is bound two-way to the scroll offset
+        // (the old DataGrid needed its internal scroll processing invoked by reflection).
+        var scrollViewer = grid.GetVisualDescendants().OfType<ScrollViewer>().First();
+        Assert.Equal(scrollBar.Value, scrollViewer.Offset.Y, 3);
+
+        window.MouseUp(point, MouseButton.Left);
+    }
+
+    [AvaloniaFact]
+    public void TroughHold_PausesWhenThumbReachesPointer()
+    {
+        var (window, grid, scrollBar) = BuildShownGrid();
+
+        var point = TroughPointBelowThumb(window, scrollBar);
+        window.MouseDown(point, MouseButton.Left);
+        Repeat(window, grid, 50);
+
+        Assert.True(ThumbReached(window, scrollBar, point), "the thumb should have reached the pointer");
+        Assert.True(scrollBar.Value > 0, "the hold should have paged");
+        Assert.True(scrollBar.Value < scrollBar.Maximum, $"paging ran past the pointer to the end ({scrollBar.Value} of {scrollBar.Maximum})");
+
+        window.MouseUp(point, MouseButton.Left);
+    }
+
+    [AvaloniaFact]
+    public void TroughHold_ResumesWhenPointerMovesFurther()
+    {
+        var (window, grid, scrollBar) = BuildShownGrid();
+
+        var point = TroughPointBelowThumb(window, scrollBar);
+        window.MouseDown(point, MouseButton.Left);
+        Repeat(window, grid, 50);
+        var pausedValue = scrollBar.Value;
+
+        var lower = TrackPoint(window, scrollBar, 0.95);
+        window.MouseMove(lower);
+        Repeat(window, grid, 50);
+
+        Assert.True(scrollBar.Value > pausedValue, "paging should resume when the pointer moves further down");
+
+        window.MouseUp(lower, MouseButton.Left);
+    }
+
+    [AvaloniaFact]
+    public void TroughHold_DoesNotReverseWhenPointerMovesBack()
+    {
+        var (window, grid, scrollBar) = BuildShownGrid();
+
+        var point = TroughPointBelowThumb(window, scrollBar);
+        window.MouseDown(point, MouseButton.Left);
+        Repeat(window, grid, 50);
+        var pausedValue = scrollBar.Value;
+
+        window.MouseMove(TrackPoint(window, scrollBar, 0.0));
+        Repeat(window, grid, 10);
+
+        Assert.Equal(pausedValue, scrollBar.Value);
+
+        window.MouseUp(point, MouseButton.Left);
+    }
+
+    [AvaloniaFact]
+    public void TroughRelease_StopsPaging()
+    {
+        var (window, grid, scrollBar) = BuildShownGrid();
+
+        var point = TroughPointBelowThumb(window, scrollBar);
+        window.MouseDown(point, MouseButton.Left);
+        window.MouseUp(point, MouseButton.Left);
+
+        var valueAfterRelease = scrollBar.Value;
+        Repeat(window, grid, 10);
+
+        Assert.Equal(valueAfterRelease, scrollBar.Value);
+    }
+
+    [AvaloniaFact]
+    public void ThumbPress_DoesNotPage()
+    {
+        var (window, grid, scrollBar) = BuildShownGrid();
+
+        var thumb = TrackOf(scrollBar).Thumb!;
+        var thumbCenter = thumb.TranslatePoint(
+            new Point(thumb.Bounds.Width / 2, thumb.Bounds.Height / 2), window)!.Value;
+
+        window.MouseDown(thumbCenter, MouseButton.Left);
+        Repeat(window, grid, 10);
+
+        Assert.Equal(0, scrollBar.Value);
+
+        window.MouseUp(thumbCenter, MouseButton.Left);
+    }
+
+    [AvaloniaFact]
+    public void ShiftTroughPress_JumpsToClickPosition()
+    {
+        var (window, _, scrollBar) = BuildShownGrid();
+        Assert.Equal(0, scrollBar.Value);
+
+        var point = TrackPoint(window, scrollBar, 0.9);
+        window.MouseDown(point, MouseButton.Left, RawInputModifiers.Shift);
+
+        Assert.True(scrollBar.Value > scrollBar.Maximum * 0.5,
+            $"shift+click should jump near the click position ({scrollBar.Value} of {scrollBar.Maximum})");
+
+        window.MouseUp(point, MouseButton.Left, RawInputModifiers.Shift);
+    }
+}

--- a/tests/UI/Logic/TableViewScrollBarTroughPagingTests.cs
+++ b/tests/UI/Logic/TableViewScrollBarTroughPagingTests.cs
@@ -5,6 +5,7 @@ using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
 using Avalonia.Styling;
 using Avalonia.VisualTree;
 using Nikse.SubtitleEdit.Logic;
@@ -37,7 +38,12 @@ public class TableViewScrollBarTroughPagingTests : IDisposable
 
     private sealed record Row(int Number, string Text);
 
-    private (Window window, TableView grid, ScrollBar scrollBar) BuildShownGrid()
+    /// <param name="viaAppStyles">
+    /// Enable the behavior the way the app does - the TableView style in Styles.axaml - instead
+    /// of setting the attached property on the grid. The wiring is what the DataGrid retirement
+    /// dropped, so a selector or property rename must fail a test rather than ship silently.
+    /// </param>
+    private (Window window, TableView grid, ScrollBar scrollBar) BuildShownGrid(bool viaAppStyles = false)
     {
         var grid = new TableView
         {
@@ -48,9 +54,16 @@ public class TableViewScrollBarTroughPagingTests : IDisposable
                 new TableViewColumn { Header = "Text", Binding = new Avalonia.Data.Binding(nameof(Row.Text)) },
             },
         };
-        TableViewScrollBarBehavior.SetEnableTroughPaging(grid, true);
+        if (!viaAppStyles)
+        {
+            TableViewScrollBarBehavior.SetEnableTroughPaging(grid, true);
+        }
 
         var window = new Window { Content = grid, Width = 400, Height = 300 };
+        if (viaAppStyles)
+        {
+            window.Styles.Add((Styles)AvaloniaXamlLoader.Load(new Uri("avares://SubtitleEdit/Styles.axaml")));
+        }
 
         // The app keeps scroll bars always expanded (UiTheme.ApplyScrollBarStyle, except on
         // macOS set to auto-hide); do the same here so the trough is hit-testable without the
@@ -103,6 +116,31 @@ public class TableViewScrollBarTroughPagingTests : IDisposable
     {
         var track = TrackOf(scrollBar);
         return track.Thumb!.Bounds.Bottom >= window.TranslatePoint(windowPoint, track)!.Value.Y;
+    }
+
+    /// <summary>
+    /// The behavior only reaches users through the TableView style in Styles.axaml, and that
+    /// wiring - not the behavior - is what went missing with the DataGrid. Every other test here
+    /// sets the attached property by hand, so without this one a renamed property or a selector
+    /// that stops matching would leave the whole file green and the grids unfixed.
+    /// </summary>
+    [AvaloniaFact]
+    public void StylesAxaml_EnablesTroughPagingOnEveryGrid()
+    {
+        var (window, grid, scrollBar) = BuildShownGrid(viaAppStyles: true);
+
+        Assert.True(TableViewScrollBarBehavior.GetEnableTroughPaging(grid),
+            "the TableView style in Styles.axaml no longer sets EnableTroughPaging");
+
+        var point = TroughPointBelowThumb(window, scrollBar);
+        window.MouseDown(point, MouseButton.Left);
+        Repeat(window, grid, 50);
+
+        Assert.True(scrollBar.Value > 0, "a trough press on a style-wired grid did not page");
+        Assert.True(scrollBar.Value < scrollBar.Maximum,
+            $"paging ran past the pointer to the end ({scrollBar.Value} of {scrollBar.Maximum})");
+
+        window.MouseUp(point, MouseButton.Left);
     }
 
     [AvaloniaFact]


### PR DESCRIPTION
## Summary

Fixes the regression of #12894 reported in https://github.com/SubtitleEdit/subtitleedit/issues/12894#issuecomment-5238879921 (5.2.0-beta9): press-and-hold on the scroll bar trough pages right past the cursor to the end of the list again.

The DataGrid retirement (b24211a1b1) deleted `DataGridScrollBarBehavior` on the note that native ScrollViewer paging replaced it. It only half did: a trough click does page a full viewport now, but the trough of Avalonia's Fluent ScrollBar is a RepeatButton that keeps firing while `IsPressed`, and Button only re-evaluates `IsPressed` on PointerMoved — so with a stationary cursor the paging never stops. The shift+trough-click jump (#12051/#12438) had no native counterpart and was lost outright.

- New `TableViewScrollBarBehavior`: hold paging latches its direction, pages toward the cursor and pauses when the thumb reaches it (resuming only if the pointer moves further along, like the native Windows scroll bar); shift+click jumps the thumb to the click position.
- Enabled app-wide from a `TableView` style in Styles.axaml (same pattern as the old DataGrid style), which also covers the grids built with plain `new TableView()`.
- Unlike the DataGrid version there is no reflection and no LargeChange bookkeeping: the ScrollViewer template binds the scroll bar's `Value` two-way to the scroll offset and its `LargeChange` to the viewport. Handlers sit on the grid itself (tunneled press), so no template-applied wiring is needed.
- The old headless trough-paging tests return, ported to TableView, plus a shift+click jump test and an assertion that the scroll offset follows the bar.

Vertical scroll bar only, as before — the horizontal trough keeps the native behavior.

## Test plan

- [ ] Load a subtitle with a few hundred lines; press and hold the trough below the thumb with the mouse still: the view pages down and pauses when the thumb reaches the cursor instead of running to the end.
- [ ] Move the pointer further down during the hold: paging resumes; move it back up: it stays paused (no reverse).
- [ ] Release and short-click the trough: exactly one viewport per click.
- [ ] Shift+click the trough: the thumb jumps to the click position.
- [ ] Dragging the thumb still works normally.
- [ ] Same behavior in other grids, e.g. Options → Shortcuts.
- [ ] `dotnet test tests/UI/UITests.csproj --filter "FullyQualifiedName~TableViewScrollBarTroughPaging"` passes (7 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)