### PR TITLE
Select all/none/invert for the remove-text-for-HI preview list

### DIFF
--- a/docs/features/remove-text-hi.md
+++ b/docs/features/remove-text-hi.md
@@ -41,6 +41,14 @@ Click **Edit** next to *Remove interjections* to modify the list of interjection
 
 All proposed removals are shown in a preview list with **Before** and **After** columns. Uncheck individual items to exclude them before clicking **OK**.
 
+Right-click the list to tick or untick many rows at once:
+
+- **Select all** (`Ctrl+A`) — tick every row
+- **Select none** (`Ctrl+D`) — untick every row, so single rows can be picked
+- **Invert selection** (`Ctrl+Shift+I`) — tick the unticked rows and untick the ticked ones
+
+`Space` toggles the checkbox of the rows that are highlighted, so a range selected with Shift+click can be flipped in one go.
+
 ## Keeping the Hearing-Impaired Text
 
 To save the hearing-impaired text instead of just discarding it, use the **Hearing impaired (SDH)** rule in [Modify selection](modify-selection.md). It selects the lines this tool would change, so they can be cut out into a subtitle of their own — useful before aligning, when the SDH should be merged back in afterwards. That rule reads its options from the settings above.

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -130,3 +130,16 @@ wins over the menu activation.
 | Ctrl+Alt+Shift+L | Save language file |
 
 > **Note:** Several actions (Bold, Underline, shot-change snapping/extending, green-zone in/out cues, etc.) ship without a default key. Open **Options** → **Shortcuts** to assign them, or use **Import from SE 4.x** to bring over a familiar set.
+
+## Fix Lists in Dialogs
+
+Dialogs that preview their changes in a list of checkboxes — [Remove text for hearing impaired](../features/remove-text-hi.md) — accept these in the list itself. They are fixed and not part of **Options** → **Shortcuts**.
+
+| Shortcut | Action |
+|----------|--------|
+| Ctrl+A | Select all (tick every row) |
+| Ctrl+D | Select none (untick every row) |
+| Ctrl+Shift+I | Invert selection |
+| Space | Toggle the checkbox of the highlighted rows |
+
+The same three actions sit in the list's right-click menu. Other tools with such a list (Fix common errors, Merge continuation lines, Remove unicode characters, Fix Netflix errors, AI review) put buttons below the list for the same job.

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModel.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModel.cs
@@ -237,6 +237,68 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private void SelectAllFixes()
+    {
+        foreach (var fix in Fixes)
+        {
+            fix.Apply = true;
+        }
+    }
+
+    [RelayCommand]
+    private void SelectNoFixes()
+    {
+        foreach (var fix in Fixes)
+        {
+            fix.Apply = false;
+        }
+    }
+
+    [RelayCommand]
+    private void InvertFixesSelection()
+    {
+        foreach (var fix in Fixes)
+        {
+            fix.Apply = !fix.Apply;
+        }
+    }
+
+    /// <summary>
+    /// The gestures advertised by the fixes grid context menu (#13496): tick all, untick all
+    /// and invert the "Apply" column. Called both from the window (focus sits on a button) and
+    /// from a tunneling handler on the grid, which would otherwise swallow Ctrl+A as
+    /// "select all rows".
+    /// </summary>
+    internal bool HandleFixesSelectionKey(KeyEventArgs e)
+    {
+        var isCommand = e.KeyModifiers.HasFlag(KeyModifiers.Control) || e.KeyModifiers.HasFlag(KeyModifiers.Meta);
+        if (!isCommand || e.KeyModifiers.HasFlag(KeyModifiers.Alt))
+        {
+            return false;
+        }
+
+        var isShift = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
+        if (e.Key == Key.A && !isShift)
+        {
+            SelectAllFixes();
+        }
+        else if (e.Key == Key.D && !isShift)
+        {
+            SelectNoFixes();
+        }
+        else if (e.Key == Key.I && isShift)
+        {
+            InvertFixesSelection();
+        }
+        else
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    [RelayCommand]
     private async Task EditInterjections()
     {
         await _windowService.ShowDialogAsync<InterjectionsWindow, InterjectionsViewModel>(Window!, vm => 
@@ -367,6 +429,10 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject
         {
             e.Handled = true;
             UiUtil.ShowHelp("features/remove-text-hi");
+        }
+        else if (HandleFixesSelectionKey(e))
+        {
+            e.Handled = true;
         }
     }
 

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
@@ -10,6 +10,7 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Threading;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 
 namespace Nikse.SubtitleEdit.Features.Tools.RemoveTextForHearingImpaired;
 
@@ -366,6 +367,18 @@ public class RemoveTextForHearingImpairedWindow : Window
         TableViewExtras.AddSpaceToggle<RemoveItem>(dataGrid,
             item => item.Apply, (item, v) => item.Apply = v);
 
+        dataGrid.ContextMenu = MakeFixesContextMenu(vm);
+
+        // The context menu gestures must mean the same with the grid focused, so take them
+        // before the TableView (a ListBox) turns Ctrl+A into "select all rows" (#13496).
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (vm.HandleFixesSelectionKey(e))
+            {
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
+
         var labelLinesFound = UiUtil.MakeLabel().WithBindText(vm, new Binding($"{nameof(vm.Fixes)}.{nameof(vm.Fixes.Count)}")
         {
             Mode = BindingMode.OneWay,
@@ -393,6 +406,41 @@ public class RemoveTextForHearingImpairedWindow : Window
         grid.Add(labelLinesFound, 1, 0);
 
         return grid;
+    }
+
+    // Mass-ticking the "Apply" column by hand is not an option on a long list (1259 fixes in
+    // the report on #13496), so offer tick all / untick all / invert with SE's usual gestures.
+    private static ContextMenu MakeFixesContextMenu(RemoveTextForHearingImpairedViewModel vm)
+    {
+        var commandModifier = OperatingSystem.IsMacOS() ? KeyModifiers.Meta : KeyModifiers.Control;
+
+        return new ContextMenu
+        {
+            Items =
+            {
+                new MenuItem
+                {
+                    Header = Se.Language.General.SelectAll,
+                    DataContext = vm,
+                    Command = vm.SelectAllFixesCommand,
+                    InputGesture = new KeyGesture(Key.A, commandModifier),
+                },
+                new MenuItem
+                {
+                    Header = Se.Language.General.SelectNone,
+                    DataContext = vm,
+                    Command = vm.SelectNoFixesCommand,
+                    InputGesture = new KeyGesture(Key.D, commandModifier),
+                },
+                new MenuItem
+                {
+                    Header = Se.Language.General.InvertSelection,
+                    DataContext = vm,
+                    Command = vm.InvertFixesSelectionCommand,
+                    InputGesture = new KeyGesture(Key.I, commandModifier | KeyModifiers.Shift),
+                },
+            },
+        };
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/tests/UI/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModelTests.cs
+++ b/tests/UI/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModelTests.cs
@@ -1,4 +1,5 @@
 using Avalonia.Headless.XUnit;
+using Avalonia.Input;
 using Microsoft.Extensions.DependencyInjection;
 using Nikse.SubtitleEdit;
 using Nikse.SubtitleEdit.Core.Common;
@@ -79,5 +80,71 @@ public class RemoveTextForHearingImpairedViewModelTests
 
         Assert.Single(vm.Fixes);
         Assert.Equal("Hello there.", vm.Fixes[0].After);
+    }
+
+    [AvaloniaFact]
+    public void SelectionCommands_TickUntickAndInvertApplyColumn()
+    {
+        var vm = Resolve();
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("[door slams]", 0, 1000));
+        sub.Paragraphs.Add(new Paragraph("(sighs)", 1000, 2000));
+        vm.Initialize(sub, _ => { });
+
+        vm.Fixes.Add(new RemoveItem(true, 0, "[door slams]", string.Empty, sub.Paragraphs[0]));
+        vm.Fixes.Add(new RemoveItem(false, 1, "(sighs)", string.Empty, sub.Paragraphs[1]));
+
+        vm.SelectNoFixesCommand.Execute(null);
+        Assert.All(vm.Fixes, f => Assert.False(f.Apply));
+
+        vm.SelectAllFixesCommand.Execute(null);
+        Assert.All(vm.Fixes, f => Assert.True(f.Apply));
+
+        vm.Fixes[0].Apply = false;
+        vm.InvertFixesSelectionCommand.Execute(null);
+        Assert.True(vm.Fixes[0].Apply);
+        Assert.False(vm.Fixes[1].Apply);
+    }
+
+    [AvaloniaTheory]
+    [InlineData(Key.A, KeyModifiers.Control, true, true)]
+    [InlineData(Key.D, KeyModifiers.Control, true, false)]
+    [InlineData(Key.A, KeyModifiers.Meta, true, true)]
+    [InlineData(Key.A, KeyModifiers.None, false, false)]
+    [InlineData(Key.A, KeyModifiers.Control | KeyModifiers.Shift, false, false)]
+    [InlineData(Key.D, KeyModifiers.None, false, false)]
+    public void SelectionShortcuts_TickOrUntickAllFixes(Key key, KeyModifiers modifiers, bool expectedHandled, bool expectedApply)
+    {
+        var vm = Resolve();
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("[door slams]", 0, 1000));
+        vm.Initialize(sub, _ => { });
+        vm.Fixes.Add(new RemoveItem(false, 0, "[door slams]", string.Empty, sub.Paragraphs[0]));
+
+        var e = new KeyEventArgs { Key = key, KeyModifiers = modifiers, RoutedEvent = InputElement.KeyDownEvent };
+        vm.OnKeyDown(e);
+
+        Assert.Equal(expectedHandled, e.Handled);
+        Assert.Equal(expectedApply, vm.Fixes[0].Apply);
+    }
+
+    [AvaloniaFact]
+    public void InvertShortcut_NeedsShift()
+    {
+        var vm = Resolve();
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("[door slams]", 0, 1000));
+        vm.Initialize(sub, _ => { });
+        vm.Fixes.Add(new RemoveItem(false, 0, "[door slams]", string.Empty, sub.Paragraphs[0]));
+
+        var withoutShift = new KeyEventArgs { Key = Key.I, KeyModifiers = KeyModifiers.Control, RoutedEvent = InputElement.KeyDownEvent };
+        vm.OnKeyDown(withoutShift);
+        Assert.False(withoutShift.Handled);
+        Assert.False(vm.Fixes[0].Apply);
+
+        var withShift = new KeyEventArgs { Key = Key.I, KeyModifiers = KeyModifiers.Control | KeyModifiers.Shift, RoutedEvent = InputElement.KeyDownEvent };
+        vm.OnKeyDown(withShift);
+        Assert.True(withShift.Handled);
+        Assert.True(vm.Fixes[0].Apply);
     }
 }

--- a/tests/UI/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindowShortcutTests.cs
+++ b/tests/UI/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindowShortcutTests.cs
@@ -1,0 +1,138 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Tools.RemoveTextForHearingImpaired;
+
+namespace UITests.Features.Tools.RemoveTextForHearingImpaired;
+
+/// <summary>
+/// The fixes grid offers tick all / untick all / invert via context menu and gestures (#13496).
+/// With the grid focused those gestures have to beat the TableView's own Ctrl+A ("select all
+/// rows"), which is why the window takes them in the tunneling phase.
+/// </summary>
+public class RemoveTextForHearingImpairedWindowShortcutTests
+{
+    private static RemoveTextForHearingImpairedViewModel Resolve()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        return services.BuildServiceProvider().GetRequiredService<RemoveTextForHearingImpairedViewModel>();
+    }
+
+    private static (RemoveTextForHearingImpairedViewModel Vm, Window Window) OpenWithTwoFixes()
+    {
+        var vm = Resolve();
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("[door slams]", 0, 1000));
+        subtitle.Paragraphs.Add(new Paragraph("(sighs)", 1000, 2000));
+        vm.Initialize(subtitle, _ => { });
+        vm.Fixes.Add(new RemoveItem(true, 0, "[door slams]", string.Empty, subtitle.Paragraphs[0]));
+        vm.Fixes.Add(new RemoveItem(true, 1, "(sighs)", string.Empty, subtitle.Paragraphs[1]));
+
+        var window = new RemoveTextForHearingImpairedWindow(vm);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        return (vm, window);
+    }
+
+    private static TableView FixesGrid(Window window)
+    {
+        return window.GetVisualDescendants().OfType<TableView>().First();
+    }
+
+    // Clicking a row is the only way to get real keyboard focus into the grid - TableView.Focus()
+    // does not move it (the row containers take focus, not the control).
+    private static TableView FocusFixesGrid(Window window, RemoveTextForHearingImpairedViewModel vm)
+    {
+        var grid = FixesGrid(window);
+        var container = (Visual?)grid.ContainerFromItem(vm.Fixes[0]);
+        Assert.NotNull(container);
+
+        var bounds = container!.Bounds;
+        var point = container.TranslatePoint(new Point(bounds.Width / 2, bounds.Height / 2), window)!.Value;
+        window.MouseDown(point, MouseButton.Left, RawInputModifiers.None);
+        window.MouseUp(point, MouseButton.Left, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(grid.IsKeyboardFocusWithin, "the gestures have to work with the grid focused");
+        return grid;
+    }
+
+    [AvaloniaFact]
+    public void GridCtrlD_UntticksEveryFix()
+    {
+        var (vm, window) = OpenWithTwoFixes();
+        FocusFixesGrid(window, vm);
+
+        window.KeyPressQwerty(PhysicalKey.D, RawInputModifiers.Control);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.All(vm.Fixes, f => Assert.False(f.Apply));
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void GridCtrlA_TicksEveryFix_InsteadOfSelectingAllRows()
+    {
+        var (vm, window) = OpenWithTwoFixes();
+        foreach (var fix in vm.Fixes)
+        {
+            fix.Apply = false;
+        }
+
+        var grid = FocusFixesGrid(window, vm);
+
+        window.KeyPressQwerty(PhysicalKey.A, RawInputModifiers.Control);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.All(vm.Fixes, f => Assert.True(f.Apply));
+        // ...and the TableView did not turn it into "select all rows" on top of that.
+        Assert.Equal(1, grid.SelectedItems?.Count ?? 0);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void GridCtrlShiftI_InvertsEveryFix()
+    {
+        var (vm, window) = OpenWithTwoFixes();
+        vm.Fixes[1].Apply = false;
+
+        FocusFixesGrid(window, vm);
+
+        window.KeyPressQwerty(PhysicalKey.I, RawInputModifiers.Control | RawInputModifiers.Shift);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(vm.Fixes[0].Apply);
+        Assert.True(vm.Fixes[1].Apply);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void FixesGrid_HasSelectAllSelectNoneAndInvertInItsContextMenu()
+    {
+        var (_, window) = OpenWithTwoFixes();
+
+        var headers = FixesGrid(window).ContextMenu?.Items.OfType<MenuItem>().Select(m => m.Header as string).ToList();
+
+        Assert.NotNull(headers);
+        Assert.Equal(3, headers!.Count);
+        Assert.Contains(Nikse.SubtitleEdit.Logic.Config.Se.Language.General.SelectAll, headers);
+        Assert.Contains(Nikse.SubtitleEdit.Logic.Config.Se.Language.General.SelectNone, headers);
+        Assert.Contains(Nikse.SubtitleEdit.Logic.Config.Se.Language.General.InvertSelection, headers);
+
+        window.Close();
+    }
+}


### PR DESCRIPTION
Closes #13496.

The preview list in *Remove text for hearing impaired* opens with every fix ticked, so excluding most of them meant clicking each checkbox - 1259 rows in the report.

Right-clicking the grid now offers:

| Item | Gesture |
| --- | --- |
| Select all | `Ctrl+A` |
| Select none | `Ctrl+D` |
| Invert selection | `Ctrl+Shift+I` |

Wording reuses the existing `General.SelectAll` / `SelectNone` / `InvertSelection` strings (no new translations), and `Ctrl+Shift+I` matches the main window's inverse-selection gesture. On macOS the gestures use Cmd.

Note: with the grid focused the gestures are taken in the tunneling phase, because the TableView would otherwise consume `Ctrl+A` as "select all rows" - verified by a test that fails without it. `Space` still toggles the checkbox of the highlighted rows, so a Shift+click range can be flipped as before.

Docs: the [Preview section](docs/features/remove-text-hi.md) (the window's F1 target) documents the three items and the previously undocumented `Space` toggle, and [the shortcut reference](docs/reference/keyboard-shortcuts.md) gets a "Fix lists in dialogs" section noting these are fixed rather than customizable in Options → Shortcuts.

Tests: 3 view-model tests for the commands and the key matching (including that `Ctrl+I` without Shift and `Ctrl+Shift+A` do nothing), plus 4 headless window tests that click a row for real keyboard focus and press each gesture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)