### PR TITLE
Fix #13493: context menu no longer hides behind the undocked audio visualizer

### DIFF
--- a/src/ui/Features/Main/Layout/InitWaveform.cs
+++ b/src/ui/Features/Main/Layout/InitWaveform.cs
@@ -826,6 +826,8 @@ public class InitWaveform
         var flyoutMore = new MenuFlyout();
         buttonMore.Flyout = flyoutMore;
         buttonMore.Click += (s, e) => flyoutMore.ShowAt(buttonMore, true);
+        // With the video player undocked (and topmost), it could cover this menu (#13493).
+        WindowService.SuspendUndockedTopmostWhileOpen(flyoutMore);
         var menuItemResetZoom = new MenuItem
         {
             Header = string.Format(languageHints.ResetZoomAndSpeed, UiUtil.MakeShortcutsString(shortcuts, nameof(vm.ResetWaveformZoomAndSpeedCommand))),

--- a/src/ui/Logic/WindowsService.cs
+++ b/src/ui/Logic/WindowsService.cs
@@ -330,11 +330,35 @@ namespace Nikse.SubtitleEdit.Logic
         /// Keeps the undocked tool windows non-topmost while <paramref name="flyout"/> is open,
         /// so its popup (a plain non-topmost native window) is not covered by them in undocked
         /// mode (#13325). Cascaded submenus are covered too: they belong to the same open flyout.
+        ///
+        /// The suspension is keyed to Opening, not Opened: Opened fires after the popup's
+        /// native window is already on screen, and on Windows demoting a topmost window
+        /// (SetWindowPos HWND_NOTOPMOST) re-inserts it at the top of the non-topmost band -
+        /// above the popup it was supposed to uncover, so the tool windows kept covering the
+        /// grid's context menu (#13493). At Opening the popup does not exist yet; it is
+        /// created right after, on top of the just-demoted tool windows. The main menu never
+        /// had this problem because Menu.Opened fires before any drop-down popup opens.
         /// </summary>
-        public static void SuspendUndockedTopmostWhileOpen(FlyoutBase flyout)
+        public static void SuspendUndockedTopmostWhileOpen(PopupFlyoutBase flyout)
         {
             IDisposable? suspension = null;
-            flyout.Opened += (_, _) => suspension ??= SuspendUndockedTopmost();
+            flyout.Opening += (_, _) =>
+            {
+                suspension ??= SuspendUndockedTopmost();
+
+                // A subclass can cancel the open in OnOpening after the event has been raised;
+                // Closed then never fires and the suspension would leak, leaving the tool
+                // windows permanently non-topmost. No SE flyout cancels today - this is a
+                // cheap backstop.
+                Dispatcher.UIThread.Post(() =>
+                {
+                    if (!flyout.IsOpen)
+                    {
+                        suspension?.Dispose();
+                        suspension = null;
+                    }
+                }, DispatcherPriority.Background);
+            };
             flyout.Closed += (_, _) =>
             {
                 suspension?.Dispose();
@@ -343,7 +367,9 @@ namespace Nikse.SubtitleEdit.Logic
         }
 
         /// <summary>
-        /// Same as <see cref="SuspendUndockedTopmostWhileOpen(FlyoutBase)"/> for the main menu bar.
+        /// Same as <see cref="SuspendUndockedTopmostWhileOpen(PopupFlyoutBase)"/> for the main
+        /// menu bar. Opened is early enough here: MenuBase raises it when the bar opens,
+        /// before any drop-down popup window is created.
         /// </summary>
         public static void SuspendUndockedTopmostWhileOpen(MenuBase menu)
         {

--- a/tests/UI/Logic/SuspendUndockedTopmostFlyoutTests.cs
+++ b/tests/UI/Logic/SuspendUndockedTopmostFlyoutTests.cs
@@ -1,0 +1,116 @@
+using System.ComponentModel;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// The flyout overload of WindowService.SuspendUndockedTopmostWhileOpen must take the
+/// suspension at Opening, before the flyout's popup window exists. Opened fires after the
+/// popup is already on screen, and on Windows demoting a topmost window re-inserts it at
+/// the top of the non-topmost band - above the popup it was supposed to uncover, so the
+/// undocked audio visualizer kept covering the subtitle grid's context menu (#13493).
+/// </summary>
+public class SuspendUndockedTopmostFlyoutTests : IDisposable
+{
+    private readonly List<bool> _calls = [];
+    private readonly List<Window> _windows = [];
+
+    public SuspendUndockedTopmostFlyoutTests()
+    {
+        WindowService.ResetUndockedTopmostSuspensionsForTests();
+        WindowService.RegisterUndockedTopmostSetter(_calls.Add);
+    }
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+        WindowService.RegisterUndockedTopmostSetter(null);
+        WindowService.ResetUndockedTopmostSuspensionsForTests();
+    }
+
+    private Button ShowWindowWithTarget()
+    {
+        var target = new Button { Content = "target" };
+        var window = new Window { Width = 400, Height = 300, Content = target };
+        _windows.Add(window);
+        window.Show();
+        return target;
+    }
+
+    [AvaloniaFact]
+    public void SuspensionEngagesAtOpening_BeforeThePopupExists_AndRestoresOnClose()
+    {
+        var target = ShowWindowWithTarget();
+        var flyout = new MenuFlyout { Items = { new MenuItem { Header = "item" } } };
+
+        WindowService.SuspendUndockedTopmostWhileOpen(flyout);
+
+        // Subscribed after the helper, so the helper's Opening handler has already run when
+        // this one observes the calls - and the popup itself has not been created yet.
+        List<bool>? callsAtOpening = null;
+        flyout.Opening += (_, _) => callsAtOpening = [.. _calls];
+
+        flyout.ShowAt(target);
+
+        Assert.True(flyout.IsOpen);
+        Assert.Equal([false], callsAtOpening);
+
+        flyout.Hide();
+        Assert.Equal([false, true], _calls);
+    }
+
+    [AvaloniaFact]
+    public void ReopeningTakesAFreshSuspension()
+    {
+        var target = ShowWindowWithTarget();
+        var flyout = new MenuFlyout { Items = { new MenuItem { Header = "item" } } };
+
+        WindowService.SuspendUndockedTopmostWhileOpen(flyout);
+
+        flyout.ShowAt(target);
+        flyout.Hide();
+        flyout.ShowAt(target);
+
+        Assert.Equal([false, true, false], _calls);
+
+        flyout.Hide();
+        Assert.Equal([false, true, false, true], _calls);
+    }
+
+    [AvaloniaFact]
+    public void CancelledOpenDoesNotLeakTheSuspension()
+    {
+        var target = ShowWindowWithTarget();
+        var flyout = new CancellingMenuFlyout { Items = { new MenuItem { Header = "item" } } };
+
+        WindowService.SuspendUndockedTopmostWhileOpen(flyout);
+
+        flyout.ShowAt(target);
+        Assert.False(flyout.IsOpen);
+
+        // Closed never fires for a cancelled open; the deferred backstop must release the
+        // suspension so the tool windows do not stay non-topmost forever.
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal([false, true], _calls);
+    }
+
+    private sealed class CancellingMenuFlyout : MenuFlyout
+    {
+        protected override void OnOpening(CancelEventArgs args)
+        {
+            // Raise Opening for subscribers first (the helper takes its suspension there),
+            // then cancel - the worst case for a leak.
+            base.OnOpening(args);
+            args.Cancel = true;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #13493 (the popup half of #13325 that survived betas 8–10).

### Root cause

The central undocked-topmost suspension (#13362) keyed the flyout overload of `SuspendUndockedTopmostWhileOpen` to `Opened` — but `PopupFlyoutBase` raises `Opened` **after** the popup's native window is already on screen (`ShowAtCore`: raise `Opening` → `Popup.IsOpen = true` → raise `Opened`).

On Windows that ordering makes the suspension self-defeating: Avalonia popups are plain non-topmost tool windows (`WS_EX_TOOLWINDOW`, shown no-activate), and demoting a topmost window (`SetWindowPos` with `HWND_NOTOPMOST`) re-inserts it *at the top of the non-topmost band* — i.e. directly above the popup it was supposed to uncover. So the undocked audio visualizer kept covering the subtitle grid's context menu, via right-click and Shift+F10 alike (both go through `ShowAtCore`).

This also explains the asymmetries in the reports:
- the **main menu bar** works because `Menu.Opened` fires before any drop-down popup opens (the ordering #13361 guarantees for Alt+letter),
- **modal dialogs** work because their suspension runs before `ShowDialog` and the dialog is made topmost + activation-enforced itself,
- **macOS** never reproduces it: popups there sit above the `Floating` window level `Topmost` maps to, regardless of timing.

### Fix

Key the flyout suspension to `Opening` instead — it runs before the popup window is created, so the popup lands above the just-demoted tool windows, the same ordering that already makes the menu bar work. A deferred backstop releases the suspension if a subclass ever cancels the open in `OnOpening` (`Closed` never fires then and the tool windows would be stuck non-topmost).

Also wires the waveform toolbar's "…" flyout, which had no suspension at all.

### Tests

New headless regression tests pin the `Opening`-time engagement (they fail against the `Opened`-keyed code), the reopen cycle, and the cancelled-open backstop. Suspension, menu-activation, and modal-foreground families all green locally (6 + 23 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)