### PR TITLE
Fix find window trimming edge spaces from restored search pattern

### DIFF
--- a/src/ui/Features/Edit/Find/FindViewModel.cs
+++ b/src/ui/Features/Edit/Find/FindViewModel.cs
@@ -161,7 +161,7 @@ public partial class FindViewModel : ObservableObject
         _originalSubs = originalSubs;
         if (string.IsNullOrEmpty(SearchText))
         {
-            SearchText = RegexUtils.EscapeNewLines(selectedText.Trim());
+            SearchText = RegexUtils.EscapeNewLines(selectedText);
         }
         _findResult = findResult;
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12311,7 +12311,11 @@ public partial class MainViewModel :
             if ((string.IsNullOrEmpty(selectedText) || string.Equals(selectedText, _findService.CurrentTextFound, _findService.CurrentFindMode == FindMode.CaseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
                 && !string.IsNullOrEmpty(_findService.SearchText))
             {
-                selectedText = _findService.SearchText;
+                selectedText = _findService.SearchText; // last search pattern - may have significant edge spaces
+            }
+            else
+            {
+                selectedText = selectedText.Trim();
             }
 
             vm.InitializeFindData(_findService, subs, selectedText, this, origs);

--- a/tests/UI/Features/Edit/Find/FindViewModelInitializeTests.cs
+++ b/tests/UI/Features/Edit/Find/FindViewModelInitializeTests.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Nikse.SubtitleEdit.Features.Edit.Find;
+using Nikse.SubtitleEdit.Features.Edit.Replace;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Features.Edit.Find;
+
+/// <summary>
+/// Reopening the find window restores the previous search pattern verbatim:
+/// edge spaces are significant in a search pattern and must not be trimmed
+/// away by InitializeFindData (issue #13489).
+/// </summary>
+public class FindViewModelInitializeTests
+{
+    private sealed class StubFindResult : IFindResult
+    {
+        public void RequestFindData()
+        {
+        }
+
+        public Task HandleFindResult(FindViewModel result)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task HandleReplaceResult(ReplaceViewModel result)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public void InitializeFindData_KeepsEdgeSpacesInSearchText()
+    {
+        var vm = new FindViewModel();
+
+        vm.InitializeFindData(new FindService(), new List<string> { "some text here" }, " some text ", new StubFindResult());
+
+        Assert.Equal(" some text ", vm.SearchText);
+    }
+}


### PR DESCRIPTION
Fixes #13489

Reopening the find window restored the previous search pattern with leading/trailing spaces stripped, because the pattern travels through the `selectedText` parameter of `FindViewModel.InitializeFindData`, which applied `.Trim()`.

- `FindViewModel.InitializeFindData` no longer trims the incoming text.
- The trim (meant to clean up text selected in the edit text box before opening find) now happens at the capture site in `ShowFind`, and only in the branch where the raw selection is actually used — the untrimmed selection is still compared against `CurrentTextFound` first, so a space-edged pattern keeps routing reopening to the persisted pattern.
- Regression test: `InitializeFindData` keeps `" some text "` verbatim.

The Replace dialog already passed the text through untrimmed, so this makes Find consistent with Replace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)