### PR TITLE
Repair Chatterbox reference voices that are not 24 kHz mono

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2108,6 +2108,7 @@
       "importVoiceDotDotDot": "Import voice...",
       "voiceImportSuccessTitle": "Voice imported",
       "voiceXImported": "Voice '{0}' imported successfully",
+      "voiceXCouldNotBeImported": "Voice '{0}' could not be imported - see the log for details",
       "importPiperVoiceTitle": "Open Piper voice model (.onnx)",
       "piperVoiceConfigMissingTitle": "Config file missing",
       "piperVoiceConfigMissingMessage": "A Piper voice needs its config file next to the model file: {0}",

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -42,6 +42,18 @@ public class ChatterboxTtsCpp : ITtsEngine
     public bool HasModel => true;
     public bool HasKeyFile => false;
 
+    /// <summary>
+    /// The only sample rate the chatterbox backend clones from without losing anything. 16 kHz
+    /// keeps a partial path upstream, but SE always targets the full one.
+    /// </summary>
+    internal const int CloneReferenceSampleRate = 24000;
+
+    /// <summary>WAVE_FORMAT_IEEE_FLOAT — the other reference format the backend accepts.</summary>
+    private const int AudioFormatIeeeFloat = 3;
+
+    /// <summary>A 44-byte canonical WAV header with no samples after it. Anything this small is not audio.</summary>
+    private const long MinimumUsableWavLength = 44;
+
     public const string ModelKeyBase = ChatterboxTtsCppDownloadService.ModelKeyBase;
     public const string ModelKeyTurbo = ChatterboxTtsCppDownloadService.ModelKeyTurbo;
     public const string DefaultModelKey = ChatterboxTtsCppDownloadService.DefaultModelKey;
@@ -325,6 +337,13 @@ public class ChatterboxTtsCpp : ITtsEngine
         var modelKey = ResolveModelKey(model);
         await EnsureServerRunningAsync(modelKey, cancellationToken);
 
+        // Off the calling thread because the repair shells out to ffmpeg. Deliberately not a hard
+        // failure either: the check is stricter than the backend's (which still has a partial
+        // 16 kHz path), so a reference that could not be re-encoded - no ffmpeg, say - is still
+        // worth sending. If the backend does reject it, the 500 handler below turns "backend
+        // returned empty audio" into an explanation.
+        await Task.Run(() => EnsureCloneReferenceIsUsable(chatterboxVoice.FilePath), cancellationToken);
+
         var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
         var inputText = text;
 
@@ -391,8 +410,19 @@ public class ChatterboxTtsCpp : ITtsEngine
                     + LaunchCmdSuffix(launchCommand);
                 Se.LogError(errMsg);
                 Se.WriteToolsLog(errMsg);
+
+                // The HTTP body only ever says "backend returned empty audio" - the reason the
+                // backend produced none is in the server log, so name it (#13508).
+                var prefix = LooksLikeCloneReferenceRejected(serverLog)
+                    ? $"Chatterbox TTS could not use the reference voice \"{Path.GetFileName(chatterboxVoice.FilePath)}\" for cloning: "
+                      + $"CrispASR needs a {CloneReferenceSampleRate / 1000} kHz mono WAV and re-encoding this one did not produce that. "
+                      + "Re-import the voice, or convert it yourself with "
+                      + $"`ffmpeg -i <input> -ar {CloneReferenceSampleRate} -ac 1 -c:a pcm_s16le <output>.wav`. "
+                    : string.Empty;
+
                 throw new InvalidOperationException(
-                    $"Chatterbox TTS synthesis failed ({(int)response.StatusCode}): {errorBody}"
+                    prefix
+                    + $"Chatterbox TTS synthesis failed ({(int)response.StatusCode}): {errorBody}"
                     + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}")
                     + LaunchCmdSuffix(launchCommand));
             }
@@ -670,6 +700,19 @@ public class ChatterboxTtsCpp : ITtsEngine
         return output.Contains("tensor read out of bounds", StringComparison.Ordinal);
     }
 
+    internal static bool LooksLikeCloneReferenceRejected(string output)
+    {
+        // The chatterbox backend clones from the reference WAV natively and only accepts
+        // 24 kHz (full path) or 16 kHz (partial M2+M3 path) mono. Anything else used to
+        // degrade to the baked default voice; since v0.8.x it produces no audio at all and
+        // the server answers HTTP 500 "synthesis failed (backend returned empty audio)":
+        //   chatterbox: native WAV cloning failed.
+        //     Tried 24 kHz: sample rate 48000 not supported (need 24000); pre-convert ...
+        //     Tried 16 kHz: sample rate 48000 not supported (need 16000); pre-convert ...
+        return output.Contains("native WAV cloning failed", StringComparison.Ordinal)
+            || output.Contains("not supported (need 24000)", StringComparison.Ordinal);
+    }
+
     private static bool LooksLikeStaleModelCache(string output)
     {
         // A truncated/format-mismatched GGUF surfaces as either a clean "tensor not
@@ -829,25 +872,124 @@ public class ChatterboxTtsCpp : ITtsEngine
         var destinationFileName = GetUniqueDestinationFileName(voicesFolder, baseName);
 
         // CrispASR's chatterbox backend only does "atomic" voice cloning when the
-        // reference WAV is 24 kHz mono PCM16/F32 — anything else silently falls back
-        // to the default voice. Always resample on import via ffmpeg so the saved
-        // WAV is in the right shape regardless of what the user picked.
+        // reference WAV is 24 kHz mono PCM16/F32 — anything else used to silently fall
+        // back to the default voice and now fails synthesis outright. Always resample on
+        // import via ffmpeg so the saved WAV is in the right shape regardless of what the
+        // user picked.
+        return ConvertToCloneReferenceWav(fileName, destinationFileName);
+    }
+
+    /// <summary>
+    /// Re-encodes the reference WAV in place when it is not in the shape the chatterbox backend
+    /// can clone from. <see cref="ImportVoice"/> already converts on the way in, but that is not
+    /// the only way a WAV reaches the voices folder: the folder is documented and users copy
+    /// files into it directly, and voices imported by older versions predate the conversion.
+    /// Such a file fails every synthesis with an opaque HTTP 500 (#13508), so the shape is
+    /// re-checked before each request — a header read, so the cost is one open of ~44 bytes and
+    /// the conversion only ever runs once per file.
+    /// </summary>
+    /// <returns>
+    /// false only when there is a reference that needs converting and the conversion failed. No
+    /// reference at all (the baked default voice) and a reference that has gone missing are both
+    /// the server's business, not a conversion failure.
+    /// </returns>
+    internal static bool EnsureCloneReferenceIsUsable(string? voiceFilePath)
+    {
+        // No reference means the baked default voice, which is not cloning and needs no WAV.
+        if (string.IsNullOrEmpty(voiceFilePath))
+        {
+            return true;
+        }
+
+        if (!File.Exists(voiceFilePath) || IsCloneReadyReferenceWav(voiceFilePath))
+        {
+            return true;
+        }
+
+        Se.WriteToolsLog($"Chatterbox TTS: reference voice \"{Path.GetFileName(voiceFilePath)}\" is not "
+            + $"{CloneReferenceSampleRate / 1000} kHz mono - re-encoding it in place before synthesis");
+
+        return ConvertToCloneReferenceWav(voiceFilePath, voiceFilePath);
+    }
+
+    /// <summary>
+    /// True when the WAV is exactly what the chatterbox backend clones from: 24 kHz mono,
+    /// PCM16 or 32-bit float. Everything else — including a file that is not a RIFF/WAVE at
+    /// all, or one whose header cannot be parsed — counts as needing a conversion, which is
+    /// the safe direction: converting an acceptable file again costs one ffmpeg run, while
+    /// letting an unacceptable one through fails the synthesis.
+    /// </summary>
+    internal static bool IsCloneReadyReferenceWav(string fileName)
+    {
         try
         {
-            var process = FfmpegGenerator.ConvertToMono24kHzWav(fileName, destinationFileName);
-            if (!process.Start())
+            using var stream = File.OpenRead(fileName);
+            var header = new WaveHeader2(stream);
+            if (header.ChunkId != "RIFF" || header.Format != "WAVE")
             {
                 return false;
             }
 
-            process.WaitForExit();
+            if (header.SampleRate != CloneReferenceSampleRate || header.NumberOfChannels != 1)
+            {
+                return false;
+            }
+
+            return (header.AudioFormat == WaveHeader2.AudioFormatPcm && header.BitsPerSample == 16)
+                   || (header.AudioFormat == AudioFormatIeeeFloat && header.BitsPerSample == 32);
         }
         catch (Exception ex)
         {
-            Se.LogError(ex, "Chatterbox TTS voice import failed (ffmpeg conversion).");
+            Se.WriteToolsLog($"Chatterbox TTS: could not read the WAV header of \"{fileName}\" ({ex.Message}) - treating it as needing a conversion");
             return false;
         }
+    }
 
-        return File.Exists(destinationFileName);
+    /// <summary>
+    /// Resamples to 24 kHz mono PCM16 via <see cref="VoiceSeedHelper"/> (which owns the ffmpeg
+    /// traps: a run that never exits, and an exit code nobody checked). Always converts into a
+    /// temp file first — ffmpeg cannot read and write the same path, which is exactly what the
+    /// in-place repair asks for, and a half-written file must never end up in the voices folder
+    /// where it would be listed as a voice.
+    /// </summary>
+    /// <returns>false when nothing usable was produced; the destination is then left untouched.</returns>
+    private static bool ConvertToCloneReferenceWav(string sourceFileName, string destinationFileName)
+    {
+        var tempFileName = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.wav");
+        try
+        {
+            // copyOnFailure: false — the whole point here is that a verbatim copy seeds a voice
+            // the backend refuses to clone from. Better no voice than a broken one.
+            VoiceSeedHelper.CopyOrResample(sourceFileName, tempFileName, CloneReferenceSampleRate, "Chatterbox TTS", copyOnFailure: false);
+
+            // A header with no samples after it is not audio, however cleanly ffmpeg exited.
+            if (!File.Exists(tempFileName) || new FileInfo(tempFileName).Length <= MinimumUsableWavLength)
+            {
+                Se.LogError($"Chatterbox TTS: no usable {CloneReferenceSampleRate / 1000} kHz mono audio came out of converting \"{sourceFileName}\".");
+                return false;
+            }
+
+            File.Move(tempFileName, destinationFileName, overwrite: true);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "Chatterbox TTS voice conversion failed (ffmpeg).");
+            return false;
+        }
+        finally
+        {
+            try
+            {
+                if (File.Exists(tempFileName))
+                {
+                    File.Delete(tempFileName);
+                }
+            }
+            catch
+            {
+                // best effort
+            }
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
@@ -286,12 +286,21 @@ public partial class VoiceSettingsViewModel : ObservableObject
             ok = _engine.ImportVoice(fileName);
         }
 
-        if (ok)
+        var importedFileName = Path.GetFileName(fileName);
+        if (!ok)
         {
-            var fileNameOnly = Path.GetFileName(fileName);
-            await MessageBox.Show(Window, Se.Language.Video.TextToSpeech.VoiceImportSuccessTitle, string.Format(Se.Language.Video.TextToSpeech.VoiceXImported, fileNameOnly));
-            RefreshVoices = true;
+            // Without this the dialog just closed with nothing to show for it, which reads as
+            // "imported" - and users then copy the file into the voices folder by hand instead,
+            // bypassing the conversion every cloning engine does on import (#13508).
+            await MessageBox.Show(
+                Window,
+                Se.Language.General.Error,
+                string.Format(Se.Language.Video.TextToSpeech.VoiceXCouldNotBeImported, importedFileName));
+            return;
         }
+
+        await MessageBox.Show(Window, Se.Language.Video.TextToSpeech.VoiceImportSuccessTitle, string.Format(Se.Language.Video.TextToSpeech.VoiceXImported, importedFileName));
+        RefreshVoices = true;
     }
 
     internal void OnDragOver(object? sender, DragEventArgs e)

--- a/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
@@ -35,6 +35,7 @@ public class LanguageTextToSpeech
     public string ImportVoiceDotDotDot { get; set; }
     public string VoiceImportSuccessTitle { get; set; }
     public string VoiceXImported { get; set; }
+    public string VoiceXCouldNotBeImported { get; set; }
     public string ImportPiperVoiceTitle { get; set; }
     public string PiperVoiceConfigMissingTitle { get; set; }
     public string PiperVoiceConfigMissingMessage { get; set; }
@@ -140,6 +141,7 @@ public class LanguageTextToSpeech
         ImportVoiceDotDotDot = "Import voice...";
         VoiceImportSuccessTitle = "Voice imported";
         VoiceXImported = "Voice '{0}' imported successfully";
+        VoiceXCouldNotBeImported = "Voice '{0}' could not be imported - see the log for details";
         ImportPiperVoiceTitle = "Open Piper voice model (.onnx)";
         PiperVoiceConfigMissingTitle = "Config file missing";
         PiperVoiceConfigMissingMessage = "A Piper voice needs its config file next to the model file: {0}";

--- a/tests/UI/Features/Video/TextToSpeech/Engines/ChatterboxTtsCppTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/ChatterboxTtsCppTests.cs
@@ -126,6 +126,128 @@ public class ChatterboxTtsCppTests
         Assert.Equal(string.Empty, ChatterboxLanguages.ResolveLanguageArg(foreign));
     }
 
+    [Theory]
+    [InlineData(24000, 1, 16, true)]   // exactly what the backend clones from
+    [InlineData(48000, 1, 16, false)]  // #13508: the reported reference - right shape, wrong rate
+    [InlineData(16000, 1, 16, false)]  // only the partial M2+M3 path upstream, so still converted
+    [InlineData(24000, 2, 16, false)]  // stereo
+    [InlineData(24000, 1, 8, false)]   // PCM8
+    [InlineData(24000, 1, 24, false)]  // PCM24
+    public void IsCloneReadyReferenceWav_AcceptsOnly24kHzMono(int sampleRate, int channels, int bitsPerSample, bool expected)
+    {
+        var path = WriteTempWav(MakeWav(sampleRate, channels, bitsPerSample));
+        try
+        {
+            Assert.Equal(expected, ChatterboxTtsCpp.IsCloneReadyReferenceWav(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void IsCloneReadyReferenceWav_Accepts24kHzMonoFloat32()
+    {
+        // WAVE_FORMAT_IEEE_FLOAT is the backend's other accepted reference format, so a file
+        // already in it must not be re-encoded on every synthesis.
+        var path = WriteTempWav(MakeWav(24000, 1, 32, audioFormat: 3));
+        try
+        {
+            Assert.True(ChatterboxTtsCpp.IsCloneReadyReferenceWav(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void IsCloneReadyReferenceWav_TreatsUnreadableFileAsNeedingConversion()
+    {
+        // A non-RIFF file (an MP3 renamed .wav, a truncated download) must fall to the ffmpeg
+        // path rather than be sent to a backend that cannot open it.
+        var path = WriteTempWav("this is not a wav file"u8.ToArray());
+        try
+        {
+            Assert.False(ChatterboxTtsCpp.IsCloneReadyReferenceWav(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void EnsureCloneReferenceIsUsable_LeavesAGoodReferenceByteIdentical()
+    {
+        // The repair rewrites the file in place, so a reference that is already right must not
+        // be touched at all - re-encoding on every synthesis would degrade it a generation at a time.
+        var bytes = MakeWav(24000, 1, 16);
+        var path = WriteTempWav(bytes);
+        try
+        {
+            Assert.True(ChatterboxTtsCpp.EnsureCloneReferenceIsUsable(path));
+            Assert.Equal(bytes, File.ReadAllBytes(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void EnsureCloneReferenceIsUsable_RepairsAWrongRateReferenceInPlace()
+    {
+        // The #13508 case: a 48 kHz WAV that reached the voices folder without passing through
+        // ImportVoice. It has to come back out as something the backend can clone from, under
+        // the same file name - the `voice` field is that name.
+        var path = WriteTempWav(MakeWav(48000, 2, 16));
+        try
+        {
+            var repaired = ChatterboxTtsCpp.EnsureCloneReferenceIsUsable(path);
+
+            // ffmpeg is not on every box (CI images, a fresh dev machine). The repair then fails,
+            // and the one thing that must still hold is that the original was left alone rather
+            // than replaced by a half-written file.
+            Assert.True(File.Exists(path));
+            Assert.True(new FileInfo(path).Length > 44);
+            if (repaired)
+            {
+                Assert.True(ChatterboxTtsCpp.IsCloneReadyReferenceWav(path));
+            }
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void EnsureCloneReferenceIsUsable_WithNoReference_IsNotAFailure()
+    {
+        // The baked default voice sends no `voice` field, so there is nothing to check.
+        Assert.True(ChatterboxTtsCpp.EnsureCloneReferenceIsUsable(string.Empty));
+        Assert.True(ChatterboxTtsCpp.EnsureCloneReferenceIsUsable(null));
+    }
+
+    [Fact]
+    public void EnsureCloneReferenceIsUsable_WithMissingFile_IsNotAFailure()
+    {
+        // A voice deleted behind SE's back is the server's error to report, not a conversion failure.
+        Assert.True(ChatterboxTtsCpp.EnsureCloneReferenceIsUsable(Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.wav")));
+    }
+
+    [Theory]
+    [InlineData("chatterbox: native WAV cloning failed.\n  Tried 24 kHz: sample rate 48000 not supported (need 24000); pre-convert or use the python baker", true)]
+    [InlineData("crispasr-server: listening on 127.0.0.1:8836", false)]
+    public void LooksLikeCloneReferenceRejected_MatchesTheBackendsRefusal(string serverLog, bool expected)
+    {
+        // The HTTP body only says "backend returned empty audio" - the reason is log-only, and
+        // this is what turns it into something the user can act on.
+        Assert.Equal(expected, ChatterboxTtsCpp.LooksLikeCloneReferenceRejected(serverLog));
+    }
+
     [Fact]
     public void LegacyEnglishOnlyGguf_IsDetectedBySize()
     {
@@ -153,5 +275,39 @@ public class ChatterboxTtsCppTests
         {
             File.Delete(path);
         }
+    }
+
+    private static string WriteTempWav(byte[] bytes)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"chatterbox-ref-test-{Guid.NewGuid():N}.wav");
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    private static byte[] MakeWav(int sampleRate, int channels, int bitsPerSample, int audioFormat = 1)
+    {
+        const int samples = 100;
+        var blockAlign = channels * ((bitsPerSample + 7) / 8);
+        var dataBytes = samples * blockAlign;
+
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream);
+        writer.Write("RIFF"u8.ToArray());
+        writer.Write(36 + dataBytes);
+        writer.Write("WAVE"u8.ToArray());
+        writer.Write("fmt "u8.ToArray());
+        writer.Write(16);
+        writer.Write((short)audioFormat);
+        writer.Write((short)channels);
+        writer.Write(sampleRate);
+        writer.Write(sampleRate * blockAlign);
+        writer.Write((short)blockAlign);
+        writer.Write((short)bitsPerSample);
+        writer.Write("data"u8.ToArray());
+        writer.Write(dataBytes);
+        writer.Write(new byte[dataBytes]);
+        writer.Flush();
+
+        return stream.ToArray();
     }
 }


### PR DESCRIPTION
Fixes #13508.

### What happened

The reporter's Chatterbox synthesis failed with an HTTP 500 whose body says only `synthesis failed (backend returned empty audio)`. The real reason is log-only:

```
chatterbox: native WAV cloning failed.
  Tried 24 kHz: sample rate 48000 not supported (need 24000); pre-convert or use the python baker
  Tried 16 kHz: sample rate 48000 not supported (need 16000); pre-convert or use the python baker
```

The reference voice in the voices folder is 48 kHz. CrispASR's chatterbox backend clones natively from the reference WAV and takes 24 kHz mono only (16 kHz keeps a partial path). This used to degrade to the baked default voice; at the pinned v0.8.x it produces no audio at all, so *every* synthesis with that voice fails. Nothing was wrong with the models, the launch command, or the consent/marking plumbing.

`ImportVoice` has resampled on the way in since v5.0.0-beta28 — but that is not the only way a WAV reaches the voices folder. The folder is documented in `docs/third-party-components.md`, users copy files into it directly, and voices imported by older versions predate the conversion. `GetVoices` lists any `*.wav` there unconditionally, so such a voice is broken forever with nothing pointing at why.

### Changes

- **Re-check the reference before each synthesis and repair it in place.** `EnsureCloneReferenceIsUsable` reads the WAV header (24 kHz, mono, PCM16 or float32) and re-encodes via ffmpeg when it is wrong, keeping the same file name — the `voice` field *is* that name. It is a header read, so the check costs one small file open and the conversion only ever runs once per file. Deliberately **not** a hard failure: the check is stricter than the backend's, so a reference that could not be re-encoded (no ffmpeg, say) is still sent.
- **Name the reason when the backend does refuse a reference**, the way the existing ggml-crash signature is handled, instead of passing "backend returned empty audio" through to the user.
- **Route both import and repair through `VoiceSeedHelper`**, which already handles the ffmpeg traps this code had: a run that never exits, and an exit code nobody checked — `ImportVoice` took `File.Exists` as success, so a truncated ffmpeg output was imported as a working voice. Conversion goes via a temp file (ffmpeg cannot read and write one path, which is exactly what the in-place repair asks for) and never falls back to copying the file verbatim, which would just re-seed the rate the backend rejects.
- **Report a failed voice import at all.** `ImportVoiceFromFileAsync` was `if (ok) { show success }` with no `else` — a failed import closed the dialog with nothing to show for it, which reads as success and pushes users toward copying files into the folder by hand. Adds one language string, `voiceXCouldNotBeImported`.

### Testing

- 12 new tests in `ChatterboxTtsCppTests`: the accepted/rejected reference shapes (including the reported 48 kHz case and float32), unparseable files treated as needing conversion, an already-good reference left byte-identical, the missing/empty reference cases, and the server-log signature.
- The in-place repair test asserts unconditionally that the original is left intact and checks the repaired shape only when ffmpeg is present, so it is meaningful on boxes with ffmpeg and safe on those without. Verified locally with a temporary hard assertion that the real ffmpeg path runs and yields a 24 kHz mono file.
- Full UI suite green (2389 passed).

### Notes for the reporter

Existing broken voices repair themselves on the next synthesis attempt (given ffmpeg). No settings change, no re-download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)