### PR TITLE
Fix the headless UI test flake: never strand the "Save changes?" prompt

### DIFF
--- a/tests/UI/Features/Main/FileNewMenuFocusTests.cs
+++ b/tests/UI/Features/Main/FileNewMenuFocusTests.cs
@@ -51,6 +51,7 @@ public class FileNewMenuFocusTests : IDisposable
         window.UpdateLayout();
 
         var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
         vm.Menu.IsVisible = true;
 
         for (var i = 0; i < lineCount; i++)

--- a/tests/UI/Features/Main/MainMenuKeyboardActivationTests.cs
+++ b/tests/UI/Features/Main/MainMenuKeyboardActivationTests.cs
@@ -56,6 +56,7 @@ public class MainMenuKeyboardActivationTests : IDisposable
         window.UpdateLayout();
 
         var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
 
         // On macOS the in-window menu is hidden in favor of the native menu bar; these tests
         // exercise the in-window menu (the Windows/Linux path), so show it regardless of the

--- a/tests/UI/Features/Main/PlayheadSyncFocusTests.cs
+++ b/tests/UI/Features/Main/PlayheadSyncFocusTests.cs
@@ -50,6 +50,7 @@ public class PlayheadSyncFocusTests : IDisposable
         window.UpdateLayout();
 
         var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
         vm.Menu.IsVisible = true;
 
         for (var i = 0; i < lineCount; i++)

--- a/tests/UI/Features/Main/RestoredVideoStartPositionTests.cs
+++ b/tests/UI/Features/Main/RestoredVideoStartPositionTests.cs
@@ -58,6 +58,7 @@ public class RestoredVideoStartPositionTests : IDisposable
         window.UpdateLayout();
 
         var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
         return (window, vm);
     }
 

--- a/tests/UI/Features/Main/SubtitleGridEnterShortcutTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridEnterShortcutTests.cs
@@ -36,6 +36,7 @@ public class SubtitleGridEnterShortcutTests
         window.UpdateLayout();
 
         var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
         for (var i = 0; i < lineCount; i++)
         {
             vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph($"Line {i + 1}", i * 2000, i * 2000 + 1500), null!)

--- a/tests/UI/Features/Main/SubtitleGridScrollPerformanceTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridScrollPerformanceTests.cs
@@ -71,6 +71,7 @@ public class SubtitleGridScrollPerformanceTests : IDisposable
         window.UpdateLayout();
 
         var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
         for (var i = 0; i < lineCount; i++)
         {
             // Every third line is two lines tall - variable row heights are what makes the

--- a/tests/UI/Features/Main/SubtitleGridSelectionOrderTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridSelectionOrderTests.cs
@@ -55,6 +55,7 @@ public class SubtitleGridSelectionOrderTests : IDisposable
         window.UpdateLayout();
 
         var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
         for (var i = 0; i < LineCount; i++)
         {
             vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph($"Line {i + 1}", i * 2000, i * 2000 + 1500), null!)

--- a/tests/UI/Features/Main/SubtitleGridWebVttColumnTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridWebVttColumnTests.cs
@@ -46,6 +46,7 @@ public class SubtitleGridWebVttColumnTests : IDisposable
         window.Show();
 
         var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
         vm.ShowColumnStyle = true;
         vm.ShowColumnActor = true;
         vm.Subtitles.Add(new SubtitleLineViewModel(

--- a/tests/UI/Features/Main/SubtitleOpenFirstRowDeleteTests.cs
+++ b/tests/UI/Features/Main/SubtitleOpenFirstRowDeleteTests.cs
@@ -62,6 +62,7 @@ public class SubtitleOpenFirstRowDeleteTests : IDisposable
         window.UpdateLayout();
 
         var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
         return (window, vm);
     }
 

--- a/tests/UI/MainWindowTestHost.cs
+++ b/tests/UI/MainWindowTestHost.cs
@@ -1,0 +1,32 @@
+using Avalonia.Controls;
+using Nikse.SubtitleEdit.Features.Main;
+
+namespace UITests;
+
+/// <summary>
+/// Shared setup for tests that host <see cref="MainView"/> in a window.
+/// </summary>
+internal static class MainWindowTestHost
+{
+    /// <summary>
+    /// Takes <see cref="MainViewModel.OnClosing"/> off the window so closing it cannot strand a
+    /// modal message box.
+    ///
+    /// OnClosing cancels the close and opens the "Save changes?" box whenever the subtitle differs
+    /// from the last saved state - which is every test that puts lines in the grid. Nothing answers
+    /// that box, so it and the window it belongs to stay open for the rest of the run, and
+    /// WindowService.ShowModalAsync goes on enforcing the stranded box's foreground: each time a
+    /// later test focuses a control of its own, the enforcement pulls keyboard focus back to the
+    /// box's default button. Avalonia raises key events on a single app-wide focused element
+    /// (KeyboardDevice.FocusedElement) and the whole headless run shares one application, so one
+    /// unanswered prompt makes key presses land nowhere in an arbitrary later test - the CI flake
+    /// that picked a different victim on every run.
+    ///
+    /// A test that wants the prompt (see MainWindowClosingTranslationTests) keeps the handler and
+    /// closes the message box itself instead.
+    /// </summary>
+    internal static void SuppressSaveChangesPromptOnClose(this Window window, MainViewModel vm)
+    {
+        window.Closing -= vm.OnClosing;
+    }
+}


### PR DESCRIPTION
The `test` job has been failing intermittently on unrelated PRs (e.g. #13497, a Russian translation update), with a different victim test every run — `SyntaxTextEditorTests`, `MainMenuKeyboardActivationTests`, `SubtitleGridScrollPerformanceTests`, `PlayheadSyncFocusTests`. The symptom was always the same: a key press produced nothing, or focus was not where the test had just put it.

## Root cause

Closing a test window that hosts `MainView` runs `MainViewModel.OnClosing`, which cancels the close and opens the modal "Save changes?" message box whenever the subtitle differs from the last saved state — which is every test that puts lines in the grid. Nothing answers that box, so it and the window it belongs to stayed open for the rest of the run, and `WindowService.ShowModalAsync` went on enforcing the stranded box's foreground: every time a later test focused a control of its own, the enforcement pulled keyboard focus back to the box's default button.

Avalonia raises key events on a single app-wide focused element (`KeyboardDevice.FocusedElement`) and the whole headless run shares one application, so that one unanswered prompt made key presses land nowhere in an arbitrary later test.

A probe logging the app-wide focused element after every test showed it plainly — the box owned the focus for 39 consecutive tests:

```
...JumpToRow_FromTheBottom_RealizesOnlyAFewViewports(target: 700)
    -> Button window=MessageBox windowTitle=Save changes? windowVisible=True
```

## Fix

Take `OnClosing` off the window in the test hosts that do not test closing, so the window really closes and no prompt is created. `MainWindowClosingTranslationTests` and `MainReadOnlyOriginalTests` want the prompt and already close the box themselves — they keep the handler.

## Verification

Locally the full `UITests` suite failed roughly one run in three before this change (2 of 6, then 2 of 6 again, always a different test) and passed **20 of 20** after it. Same probe after the fix: no `MessageBox` entry left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)