### PR TITLE
Persist all split/rebalance long lines settings on OK

### DIFF
--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
@@ -589,9 +589,16 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
 
     private void LoadSettings()
     {
-        SingleLineMaxLength = Se.Settings.General.SubtitleLineMaximumLength;
-        MaxNumberOfLines = Se.Settings.General.MaxNumberOfLines;
-        UnbreakLinesShorterThan = Se.Settings.General.UnbreakLinesShorterThan;
+        // Values of 0 mean "not saved yet" - fall back to the general settings
+        SingleLineMaxLength = Se.Settings.Tools.SplitRebalanceLongLinesSingleLineMaxLength > 0
+            ? Se.Settings.Tools.SplitRebalanceLongLinesSingleLineMaxLength
+            : Se.Settings.General.SubtitleLineMaximumLength;
+        MaxNumberOfLines = Se.Settings.Tools.SplitRebalanceLongLinesMaxNumberOfLines > 0
+            ? Se.Settings.Tools.SplitRebalanceLongLinesMaxNumberOfLines
+            : Se.Settings.General.MaxNumberOfLines;
+        UnbreakLinesShorterThan = Se.Settings.Tools.SplitRebalanceLongLinesUnbreakShorterThan > 0
+            ? Se.Settings.Tools.SplitRebalanceLongLinesUnbreakShorterThan
+            : Se.Settings.General.UnbreakLinesShorterThan;
         SplitLongLines = Se.Settings.Tools.SplitRebalanceLongLinesSplit;
         RebalanceLongLines = Se.Settings.Tools.SplitRebalanceLongLinesRebalance;
     }
@@ -600,6 +607,9 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
     {
         Se.Settings.Tools.SplitRebalanceLongLinesSplit = SplitLongLines;
         Se.Settings.Tools.SplitRebalanceLongLinesRebalance = RebalanceLongLines;
+        Se.Settings.Tools.SplitRebalanceLongLinesSingleLineMaxLength = SingleLineMaxLength;
+        Se.Settings.Tools.SplitRebalanceLongLinesMaxNumberOfLines = MaxNumberOfLines;
+        Se.Settings.Tools.SplitRebalanceLongLinesUnbreakShorterThan = UnbreakLinesShorterThan;
         Se.SaveSettings();
     }
 

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -67,6 +67,9 @@ public class SeTools
     public bool GoToFirstAndLastLineAlsoSetVideoPosition { get; set; }
     public bool SplitRebalanceLongLinesSplit { get; set; }
     public bool SplitRebalanceLongLinesRebalance { get; set; }
+    public int SplitRebalanceLongLinesSingleLineMaxLength { get; set; }
+    public int SplitRebalanceLongLinesMaxNumberOfLines { get; set; }
+    public int SplitRebalanceLongLinesUnbreakShorterThan { get; set; }
     public string UnicodeSymbolsToInsert { get; set; }
     public string MusicSymbol { get; set; }
     public string MusicSymbolReplace { get; set; }

--- a/tests/UI/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesSettingsTests.cs
+++ b/tests/UI/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesSettingsTests.cs
@@ -1,0 +1,105 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Features.Tools.SplitBreakLongLines;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Tools.SplitBreakLongLines;
+
+public class SplitBreakLongLinesSettingsTests
+{
+    [Fact]
+    public void Constructor_NoSavedToolValues_FallsBackToGeneralSettings()
+    {
+        var savedSettings = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.General.SubtitleLineMaximumLength = 47;
+            Se.Settings.General.MaxNumberOfLines = 3;
+            Se.Settings.General.UnbreakLinesShorterThan = 29;
+
+            var vm = new SplitBreakLongLinesViewModel();
+            vm.OnClosingCleanup();
+
+            Assert.Equal(47, vm.SingleLineMaxLength);
+            Assert.Equal(3, vm.MaxNumberOfLines);
+            Assert.Equal(29, vm.UnbreakLinesShorterThan);
+        }
+        finally
+        {
+            Se.Settings = savedSettings;
+        }
+    }
+
+    [Fact]
+    public void Constructor_SavedToolValues_WinOverGeneralSettings()
+    {
+        var savedSettings = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.General.SubtitleLineMaximumLength = 47;
+            Se.Settings.General.MaxNumberOfLines = 3;
+            Se.Settings.General.UnbreakLinesShorterThan = 29;
+            Se.Settings.Tools.SplitRebalanceLongLinesSingleLineMaxLength = 38;
+            Se.Settings.Tools.SplitRebalanceLongLinesMaxNumberOfLines = 2;
+            Se.Settings.Tools.SplitRebalanceLongLinesUnbreakShorterThan = 21;
+
+            var vm = new SplitBreakLongLinesViewModel();
+            vm.OnClosingCleanup();
+
+            Assert.Equal(38, vm.SingleLineMaxLength);
+            Assert.Equal(2, vm.MaxNumberOfLines);
+            Assert.Equal(21, vm.UnbreakLinesShorterThan);
+        }
+        finally
+        {
+            Se.Settings = savedSettings;
+        }
+    }
+
+    [AvaloniaFact]
+    public void Ok_PersistsAllConfiguredValues()
+    {
+        // Regression for #13514: OK only saved the two checkboxes, so the numeric
+        // values reset to the general settings every time the dialog was opened.
+        var savedSettings = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+
+            var vm = new SplitBreakLongLinesViewModel
+            {
+                Window = new Window(),
+                SplitLongLines = false,
+                RebalanceLongLines = true,
+                SingleLineMaxLength = 38,
+                MaxNumberOfLines = 2,
+                UnbreakLinesShorterThan = 21,
+            };
+
+            vm.OkCommand.Execute(null);
+            vm.OnClosingCleanup();
+
+            Assert.True(vm.OkPressed);
+            Assert.False(Se.Settings.Tools.SplitRebalanceLongLinesSplit);
+            Assert.True(Se.Settings.Tools.SplitRebalanceLongLinesRebalance);
+            Assert.Equal(38, Se.Settings.Tools.SplitRebalanceLongLinesSingleLineMaxLength);
+            Assert.Equal(2, Se.Settings.Tools.SplitRebalanceLongLinesMaxNumberOfLines);
+            Assert.Equal(21, Se.Settings.Tools.SplitRebalanceLongLinesUnbreakShorterThan);
+
+            // A fresh dialog must come back with the values the user saved.
+            var vm2 = new SplitBreakLongLinesViewModel();
+            vm2.OnClosingCleanup();
+            Assert.Equal(38, vm2.SingleLineMaxLength);
+            Assert.Equal(2, vm2.MaxNumberOfLines);
+            Assert.Equal(21, vm2.UnbreakLinesShorterThan);
+            Assert.False(vm2.SplitLongLines);
+            Assert.True(vm2.RebalanceLongLines);
+        }
+        finally
+        {
+            Se.Settings = savedSettings;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #13514.

The Split/rebalance long lines dialog only saved its two checkboxes on OK — the numeric values (single line max length, max number of lines, unbreak lines shorter than) were loaded from the general settings and never written anywhere, so the user's configuration reset every time the dialog was opened.

### Fix
- Added three tool-scoped settings (`SplitRebalanceLongLinesSingleLineMaxLength`, `SplitRebalanceLongLinesMaxNumberOfLines`, `SplitRebalanceLongLinesUnbreakShorterThan`) to `SeTools` and persist them in the dialog's `SaveSettings`.
- On load, a value of 0 means "not saved yet" and falls back to the general settings, so existing installs keep their current behavior until the user presses OK once. 0 is unambiguous as a sentinel because the dialog's numeric inputs all have minimums ≥ 1.
- Keeping the values tool-scoped (mirroring the batch-convert `SplitBreakLongLinesSettings` pattern) also means the dialog no longer needs to write into the profile-backed general settings.

### Tests
- New `SplitBreakLongLinesSettingsTests`: fallback to general settings when unset, saved tool values win over general settings, and an OK round-trip that verifies a fresh dialog comes back with all five saved values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)