### PR TITLE
Fix two focus/topmost violations against other applications

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -19969,8 +19969,13 @@ public partial class MainViewModel :
             {
                 if (Window != null)
                 {
-                    Window.Activate();
-                    TableViewExtras.FocusRow(SubtitleGrid);
+                    // Only claim focus when the main window still holds it - this runs a
+                    // second after startup, and activating here would pull SE back over
+                    // another application the user switched to while SE was loading.
+                    if (Window.IsActive)
+                    {
+                        TableViewExtras.FocusRow(SubtitleGrid);
+                    }
 
                     SurroundWith1Text = string.Format(Se.Language.Options.Shortcuts.SurroundWithXY, Se.Settings.Surround1Left, Se.Settings.Surround1Right);
                     SurroundWith2Text = string.Format(Se.Language.Options.Shortcuts.SurroundWithXY, Se.Settings.Surround2Left, Se.Settings.Surround2Right);
@@ -24776,6 +24781,9 @@ public partial class MainViewModel :
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
                 progressWindow = new TranscriptionProgressWindow(progressViewModel);
+                // Above the main window while SE is active, but never above other
+                // applications the user switches to during the transcription (#11243).
+                WindowService.KeepTopmostWhileOwnerActive(progressWindow, ownerWindow);
                 progressWindow.Show(ownerWindow);
             });
 

--- a/src/ui/Features/Video/SpeechToText/OpenAiCompatible/TranscriptionProgressWindow.axaml.cs
+++ b/src/ui/Features/Video/SpeechToText/OpenAiCompatible/TranscriptionProgressWindow.axaml.cs
@@ -30,7 +30,6 @@ public class TranscriptionProgressWindow : Window
         Width = 500;
         Height = 450;
         WindowStartupLocation = WindowStartupLocation.CenterOwner;
-        Topmost = true;
         CanResize = false;
 
         var connectionInfoText = new TextBlock


### PR DESCRIPTION
Audit of the window/sub-window focus & topmost handling found two places where SE could stay in front of (or pull itself back over) another application; everything else follows the `KeepTopmostWhileOwnerActive` / `ShowModalAsync` architecture correctly.

## 1. Transcription progress window floated above other apps

`TranscriptionProgressWindow` (the OpenAI-compatible auto-transcribe progress, shown from the waveform-selection hook) set a blanket `Topmost = true`. While a transcription ran, switching to another application left the window floating **on top of the other app** — worst on macOS, where Avalonia maps `Topmost` to `NSWindowLevel.Floating` process-independently.

Fixed by dropping the blanket flag and wiring the window through `WindowService.KeepTopmostWhileOwnerActive` at the show site, the same pattern used by Find/Replace and the undocked video/waveform windows: it stays above the main window while SE is active and drops behind the moment SE loses focus to another app.

## 2. Startup `Activate()` stole foreground back

The startup sequence posts a follow-up one second after launch that unconditionally called `Window.Activate()`. If the user switched to another application while SE was loading, SE yanked itself back to the foreground (macOS/Linux; a taskbar flash on Windows).

Fixed by only focusing the subtitle grid when the main window is still active — which also avoids stealing app-global keyboard focus from an undocked tool window or a dialog that happens to be in front at that moment. When the window is already active, the old `Activate()` was a no-op anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)