### PR TITLE
Create the transcription progress window via the window service

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -166,6 +166,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VoxCPM2CrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.MossTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.EngineSettings;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.OpenAiCompatible;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.EncodingSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ReviewSpeech;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VoiceSettings;
@@ -534,6 +535,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<TimedText10PropertiesViewModel>();
         collection.AddTransient<TimedTextImsc11PropertiesViewModel>();
         collection.AddTransient<TmpegEncXmlPropertiesViewModel>();
+        collection.AddTransient<TranscriptionProgressViewModel>();
         collection.AddTransient<TranslateSettingsViewModel>();
         collection.AddTransient<TranslationErrorViewModel>();
         collection.AddTransient<TransparentSettingsViewModel>();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -24772,20 +24772,22 @@ public partial class MainViewModel :
             }
 
             var settings = OpenAiSttService.GetSettingsFromConfiguration();
-            progressViewModel = new TranscriptionProgressViewModel();
-            progressViewModel.StatusText = Se.Language.Video.AudioToText.Transcribing;
-            progressViewModel.ServerUrl = settings.EndpointUrl;
-            progressViewModel.ModelName = string.IsNullOrEmpty(settings.Model) ? Se.Language.General.TranscriptionProgressModelAuto : settings.Model;
 
             var ownerWindow = Window!;
-            await Dispatcher.UIThread.InvokeAsync(() =>
-            {
-                progressWindow = new TranscriptionProgressWindow(progressViewModel);
-                // Above the main window while SE is active, but never above other
-                // applications the user switches to during the transcription (#11243).
-                WindowService.KeepTopmostWhileOwnerActive(progressWindow, ownerWindow);
-                progressWindow.Show(ownerWindow);
-            });
+            progressViewModel = await Dispatcher.UIThread.InvokeAsync(() =>
+                _windowService.ShowWindow<TranscriptionProgressWindow, TranscriptionProgressViewModel>(ownerWindow, (window, vm) =>
+                {
+                    // The configure callback runs before Show(), so the texts are set for the
+                    // first frame and the topmost handling is wired before the window is up.
+                    vm.StatusText = Se.Language.Video.AudioToText.Transcribing;
+                    vm.ServerUrl = settings.EndpointUrl;
+                    vm.ModelName = string.IsNullOrEmpty(settings.Model) ? Se.Language.General.TranscriptionProgressModelAuto : settings.Model;
+
+                    // Above the main window while SE is active, but never above other
+                    // applications the user switches to during the transcription (#11243).
+                    WindowService.KeepTopmostWhileOwnerActive(window, ownerWindow);
+                    progressWindow = window;
+                }));
 
             var service = new OpenAiSttService(settings);
 


### PR DESCRIPTION
Follow-up to #13519. The OpenAI-compatible transcription progress window (auto-transcribe of a waveform selection) was the only window in the app constructed outside `WindowService` — a bare `new TranscriptionProgressWindow(...)` + `Show(owner)` — so it silently missed the shared setup every other window gets:

- `UiTheme.ApplyScaleToWindow`: the user's UI scale, and the Windows dark-mode title bar, which must be applied **before** `Show()` (#12665) — the window appeared unscaled with a light title bar in dark mode.
- The right-to-left setting.

It is now created through `ShowWindow<TranscriptionProgressWindow, TranscriptionProgressViewModel>`, with the view model registered in DI like every other window VM. The status/server/model text setup and the `KeepTopmostWhileOwnerActive` wiring from #13519 move into the configure callback, which runs before `Show()`, so the first visible frame is complete and the topmost rule is wired before the window is up. No behavior change to the transcription flow itself — cancel, streaming updates, and the close paths are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)