### PR TITLE
Add rule selection to seconv --remove-formatting

### DIFF
--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -73,6 +73,7 @@ seconv list-encodings       # list text encodings
 seconv list-pac-codepages   # list PAC code pages
 seconv list-ocr-engines     # list OCR engines + installation status
 seconv list-fce-rules       # list FixCommonErrors rule IDs
+seconv list-rf-rules        # list remove-formatting rule IDs
 seconv dump-settings        # print a full --settings JSON with libse defaults
 seconv info <file>          # print format/encoding/duration/language for a file
 seconv lint <pattern>       # validate subtitle(s); exit 1 if issues found
@@ -465,7 +466,8 @@ Operations run after the structural transforms (offset, fps, renumber, adjust-du
 | `--merge-same-time-codes` | Merge entries with same time codes |
 | `--merge-short-lines` | Merge short lines |
 | `--redo-casing` | Redo text casing |
-| `--remove-formatting` | Remove formatting tags |
+| `--remove-formatting` | Remove **all** formatting tags |
+| `--remove-formatting-rules:<list>` | Remove only some kinds of formatting (CSV; supports `all,-RuleId`) |
 | `--remove-line-breaks` | Remove line breaks |
 | `--remove-text-for-hi` | Remove text for hearing impaired |
 | `--remove-unicode-control-chars` | Remove Unicode control characters |
@@ -554,6 +556,38 @@ The CLI rule IDs match the check-box rules in the desktop app's *Fix Common Erro
 | `RemoveDialogFirstLineInNonDialogs` | Remove start dash in first line for non-dialogs | — |
 | `RemoveSpaceBetweenNumbers` | Remove space between numbers | — |
 | `FixCommonOcrErrors` | Fix common OCR errors (using OCR replace list) | — |
+
+### Remove-formatting rule selection
+
+`--remove-formatting` (no value) strips **every** tag — HTML plus SSA/ASSA override blocks. Pass `--remove-formatting-rules:<list>` to remove only some kinds of formatting; supplying that option implies `--remove-formatting`.
+
+```bash
+seconv movie.ass subrip --remove-formatting                              # remove every tag
+seconv movie.ass subrip --remove-formatting-rules:RemoveItalic,RemoveBold
+seconv movie.ass subrip --remove-formatting-rules:all,-RemoveColor       # every named rule except colors
+seconv list-rf-rules                                                     # show rule IDs
+```
+
+**`all` is narrower than the bare flag.** The bare `--remove-formatting` removes tags wholesale, including ones no named rule covers — positioning (`{\pos(..)}`), fades, karaoke timing, and any other ASSA override. `--remove-formatting-rules:all` is the *union of the six named rules*, so those tags survive it:
+
+```bash
+# "{\pos(10,20)}<i>Hi</i>"
+seconv in.ass subrip --remove-formatting                     # -> "Hi"
+seconv in.ass subrip --remove-formatting-rules:all           # -> "{\pos(10,20)}Hi"
+```
+
+This mirrors the desktop app, where batch convert's *Remove formatting* function has a separate *Remove all formatting* check box above the six per-kind ones.
+
+#### Rule ID ↔ GUI equivalent
+
+| Rule ID | GUI equivalent | Removes |
+|---|---|---|
+| `RemoveItalic` | Remove italic | `<i>`, `{\i0}`, `{\i1}` |
+| `RemoveBold` | Remove bold | `<b>`, `{\b0}`, `{\b1}` |
+| `RemoveUnderline` | Remove underline | `<u>`, `{\u0}`, `{\u1}` |
+| `RemoveFontName` | Remove font name | `<font face="..">`, `{\fnArial}` |
+| `RemoveAlignment` | Remove alignment | `{\an1}`–`{\an9}`, `{\a1}`–`{\a9}` |
+| `RemoveColor` | Remove color | `<font color="..">`, `{\c&H..&}`, `{\1c&H..&}` |
 
 ## Output format aliases
 

--- a/src/libse/Common/RemoveFormattingUtil.cs
+++ b/src/libse/Common/RemoveFormattingUtil.cs
@@ -1,0 +1,92 @@
+using System;
+
+namespace Nikse.SubtitleEdit.Core.Common
+{
+    /// <summary>
+    /// Formatting categories that <see cref="RemoveFormattingUtil"/> can strip from subtitle text.
+    /// <see cref="All"/> removes every tag wholesale (HTML plus SSA/ASSA override blocks), which is
+    /// broader than the union of the named categories - e.g. positioning tags like <c>{\pos(..)}</c>
+    /// only go away with <see cref="All"/>.
+    /// </summary>
+    [Flags]
+    public enum RemoveFormattingType
+    {
+        None = 0,
+        Italic = 1 << 0,
+        Bold = 1 << 1,
+        Underline = 1 << 2,
+        FontName = 1 << 3,
+        Alignment = 1 << 4,
+        Color = 1 << 5,
+        All = 1 << 6,
+    }
+
+    /// <summary>
+    /// Removes formatting tags from subtitle text. Single source of truth for the GUI's batch
+    /// convert "Remove formatting" function and seconv's <c>--remove-formatting</c> /
+    /// <c>--remove-formatting-rules</c> options, so both strip tags identically (#13518).
+    /// </summary>
+    public static class RemoveFormattingUtil
+    {
+        public static string Remove(string text, RemoveFormattingType types)
+        {
+            if (string.IsNullOrEmpty(text) || types == RemoveFormattingType.None)
+            {
+                return text;
+            }
+
+            if ((types & RemoveFormattingType.All) != 0)
+            {
+                return HtmlUtil.RemoveHtmlTags(text, true);
+            }
+
+            if ((types & RemoveFormattingType.Italic) != 0)
+            {
+                text = HtmlUtil.RemoveOpenCloseTags(text, HtmlUtil.TagItalic);
+                text = text
+                    .Replace("{\\i}", string.Empty)
+                    .Replace("{\\i0}", string.Empty)
+                    .Replace("{\\i1}", string.Empty);
+            }
+
+            if ((types & RemoveFormattingType.Bold) != 0)
+            {
+                text = HtmlUtil.RemoveOpenCloseTags(text, HtmlUtil.TagBold);
+                text = text
+                    .Replace("{\\b}", string.Empty)
+                    .Replace("{\\b0}", string.Empty)
+                    .Replace("{\\b1}", string.Empty);
+            }
+
+            if ((types & RemoveFormattingType.Underline) != 0)
+            {
+                text = HtmlUtil.RemoveOpenCloseTags(text, HtmlUtil.TagUnderline);
+                text = text
+                    .Replace("{\\u}", string.Empty)
+                    .Replace("{\\u0}", string.Empty)
+                    .Replace("{\\u1}", string.Empty);
+            }
+
+            if ((types & RemoveFormattingType.Color) != 0)
+            {
+                text = HtmlUtil.RemoveColorTags(text);
+                if (text.Contains("\\c") || text.Contains("\\1c"))
+                {
+                    text = HtmlUtil.RemoveAssaColor(text);
+                }
+            }
+
+            if ((types & RemoveFormattingType.FontName) != 0)
+            {
+                text = HtmlUtil.RemoveFontName(text);
+            }
+
+            if ((types & RemoveFormattingType.Alignment) != 0 && text.Contains('{'))
+            {
+                text = HtmlUtil.RemoveAssAlignmentTags(text);
+            }
+
+            return text;
+        }
+    }
+}

--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -357,6 +357,10 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         [Description("Remove formatting")]
         public bool RemoveFormatting { get; init; }
 
+        [CommandOption("--remove-formatting-rules|--RemoveFormattingRules")]
+        [Description("Comma-separated formatting-removal rule IDs (or 'all,-RuleId' to subtract); implies --remove-formatting. See: seconv list-rf-rules")]
+        public string? RemoveFormattingRules { get; init; }
+
         [CommandOption("--remove-line-breaks|--RemoveLineBreaks")]
         [Description("Remove line breaks")]
         public bool RemoveLineBreaks { get; init; }
@@ -558,6 +562,25 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 }
             }
 
+            // Resolve remove-formatting rule selection. Passing --RemoveFormattingRules implicitly
+            // enables --RemoveFormatting. Null = bare flag = remove every tag wholesale
+            // (HtmlUtil.RemoveHtmlTags, pre-#13518 behaviour) - broader than 'all', which is
+            // the union of the named rules and leaves e.g. {\pos(..)} alone.
+            IReadOnlyList<string>? removeFormattingRules = null;
+            var removeFormattingRequested = settings.RemoveFormatting || !string.IsNullOrWhiteSpace(settings.RemoveFormattingRules);
+            if (!string.IsNullOrWhiteSpace(settings.RemoveFormattingRules))
+            {
+                try
+                {
+                    removeFormattingRules = RemoveFormattingRunner.ResolveRuleIds(settings.RemoveFormattingRules);
+                }
+                catch (ArgumentException ex)
+                {
+                    AnsiConsole.MarkupLineInterpolated($"[red]Error: {ex.Message}[/]");
+                    return 1;
+                }
+            }
+
             // Build operations list. Operations run in the order the user typed them and
             // repeat for each occurrence (SE4 parity) - e.g. "--fix-common-errors" twice
             // runs two FCE passes. Spectre collapses repeated flags, so the order/count is
@@ -565,7 +588,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
             List<string> operations;
             if (RawArgs.Length > 0)
             {
-                operations = OperationOrderParser.BuildOperations(RawArgs, fceRequested);
+                operations = OperationOrderParser.BuildOperations(RawArgs, fceRequested, removeFormattingRequested);
             }
             else
             {
@@ -580,7 +603,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 if (settings.MergeSameTimeCodes) operations.Add("MergeSameTimeCodes");
                 if (settings.MergeShortLines) operations.Add("MergeShortLines");
                 if (settings.RedoCasing) operations.Add("RedoCasing");
-                if (settings.RemoveFormatting) operations.Add("RemoveFormatting");
+                if (removeFormattingRequested) operations.Add("RemoveFormatting");
                 if (settings.RemoveLineBreaks) operations.Add("RemoveLineBreaks");
                 if (settings.RemoveTextForHI) operations.Add("RemoveTextForHI");
                 if (settings.RemoveUnicodeControlChars) operations.Add("RemoveUnicodeControlChars");
@@ -656,6 +679,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 Operations = operations,
                 FixCommonErrorsRules = fceRules,
                 FixCommonErrorsLanguage = settings.FixCommonErrorsLanguage,
+                RemoveFormattingRules = removeFormattingRules,
                 DeleteFirst = settings.DeleteFirst,
                 DeleteLast = settings.DeleteLast,
                 DeleteContains = settings.DeleteContains,

--- a/src/seconv/Core/FixCommonErrorsRunner.cs
+++ b/src/seconv/Core/FixCommonErrorsRunner.cs
@@ -354,72 +354,8 @@ internal static class FixCommonErrorsRunner
     /// Matching is case-insensitive. Throws <see cref="ArgumentException"/> for unknown IDs.
     /// Returned IDs are in canonical order.
     /// </summary>
-    public static IReadOnlyList<string> ResolveRuleIds(string? spec)
-    {
-        if (string.IsNullOrWhiteSpace(spec))
-        {
-            return AvailableRuleIds;
-        }
-
-        var available = new HashSet<string>(AvailableRuleIds, StringComparer.OrdinalIgnoreCase);
-        var tokens = spec.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-        var hasPositive = tokens.Any(t => !t.StartsWith('-'));
-        var selected = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        // Negation-only specs ("-FixCommas,-FixDanishLetterI") imply a leading "all".
-        if (!hasPositive)
-        {
-            foreach (var a in AvailableRuleIds)
-            {
-                selected.Add(a);
-            }
-        }
-
-        foreach (var raw in tokens)
-        {
-            var negate = raw.StartsWith('-');
-            var id = negate ? raw[1..].Trim() : raw;
-
-            if (string.IsNullOrEmpty(id))
-            {
-                continue;
-            }
-
-            if (id.Equals("all", StringComparison.OrdinalIgnoreCase))
-            {
-                if (negate)
-                {
-                    selected.Clear();
-                }
-                else
-                {
-                    foreach (var a in AvailableRuleIds)
-                    {
-                        selected.Add(a);
-                    }
-                }
-                continue;
-            }
-
-            if (!available.Contains(id))
-            {
-                throw new ArgumentException(
-                    $"Unknown FixCommonErrors rule '{id}'. Run 'seconv list-fce-rules' to see available IDs.");
-            }
-
-            if (negate)
-            {
-                selected.Remove(id);
-            }
-            else
-            {
-                selected.Add(id);
-            }
-        }
-
-        return AvailableRuleIds.Where(selected.Contains).ToArray();
-    }
+    public static IReadOnlyList<string> ResolveRuleIds(string? spec) =>
+        RuleIdSpec.Resolve(spec, AvailableRuleIds, "FixCommonErrors", "list-fce-rules");
 
     /// <summary>
     /// Canonical rule list. Order here defines execution order. <c>FixCommonOcrErrors</c>

--- a/src/seconv/Core/LibSEIntegration.cs
+++ b/src/seconv/Core/LibSEIntegration.cs
@@ -564,12 +564,15 @@ internal static class LibSEIntegration
     /// <c>null</c> or empty to run all FCE rules.
     /// <paramref name="fixCommonErrorsLanguage"/> forces the language used for FCE gating /
     /// OCR-fix (from <c>--fce-language</c>); pass <c>null</c> to auto-detect from content.
+    /// <paramref name="removeFormattingRules"/> is consulted only when <c>removeformatting</c>
+    /// is in the operation list — pass <c>null</c> to strip every tag wholesale.
     /// </summary>
     public static void ApplyOperations(
         Subtitle subtitle,
         List<string> operations,
         IReadOnlyList<string>? fixCommonErrorsRules = null,
-        string? fixCommonErrorsLanguage = null)
+        string? fixCommonErrorsLanguage = null,
+        IReadOnlyList<string>? removeFormattingRules = null)
     {
         if (subtitle == null || operations == null || operations.Count == 0)
         {
@@ -578,7 +581,7 @@ internal static class LibSEIntegration
 
         foreach (var operation in operations)
         {
-            ApplyOperation(subtitle, operation, fixCommonErrorsRules, fixCommonErrorsLanguage);
+            ApplyOperation(subtitle, operation, fixCommonErrorsRules, fixCommonErrorsLanguage, removeFormattingRules);
         }
     }
 
@@ -586,7 +589,8 @@ internal static class LibSEIntegration
         Subtitle subtitle,
         string operation,
         IReadOnlyList<string>? fixCommonErrorsRules,
-        string? fixCommonErrorsLanguage)
+        string? fixCommonErrorsLanguage,
+        IReadOnlyList<string>? removeFormattingRules)
     {
         switch (operation.ToLowerInvariant())
         {
@@ -685,7 +689,7 @@ internal static class LibSEIntegration
                 break;
 
             case "removeformatting":
-                RemoveFormatting(subtitle);
+                RemoveFormattingRunner.Run(subtitle, removeFormattingRules);
                 break;
 
             case "removelinebreaks":
@@ -749,14 +753,6 @@ internal static class LibSEIntegration
             default:
                 // Unknown operation - ignore or log warning
                 break;
-        }
-    }
-
-    private static void RemoveFormatting(Subtitle subtitle)
-    {
-        foreach (var p in subtitle.Paragraphs)
-        {
-            p.Text = HtmlUtil.RemoveHtmlTags(p.Text, true);
         }
     }
 

--- a/src/seconv/Core/ListHelpers.cs
+++ b/src/seconv/Core/ListHelpers.cs
@@ -108,6 +108,38 @@ internal static class ListHelpers
             "  [dim]--fix-common-errors-rules:FixSpanishInvertedQuestionAndExclamationMarks --fce-language:es[/]  [dim]# force a named gated rule[/]");
     }
 
+    public static void PrintRemoveFormattingRules()
+    {
+        AnsiConsole.MarkupLine("[bold cyan]Remove-formatting rule IDs (pass via --remove-formatting-rules)[/]");
+        AnsiConsole.WriteLine();
+        var table = new Table().Border(TableBorder.Rounded);
+        table.AddColumn("[yellow]Rule ID[/]");
+        table.AddColumn("[yellow]GUI equivalent[/]");
+
+        foreach (var id in RemoveFormattingRunner.AvailableRuleIds)
+        {
+            // GUI equivalent: the checkbox label in the desktop batch convert "Remove
+            // formatting" function, so users who prototyped in the GUI can find the
+            // matching CLI ID (#13518).
+            var gui = RemoveFormattingRunner.GuiLabels.TryGetValue(id, out var label)
+                ? $"[cyan]{label.EscapeMarkup()}[/]"
+                : "[dim]—[/]";
+            table.AddRow($"[green]{id}[/]", gui);
+        }
+
+        AnsiConsole.Write(table);
+        AnsiConsole.MarkupLine(
+            "\n[dim]The GUI equivalent is the checkbox label in the desktop batch convert 'Remove formatting' function.[/]\n" +
+            "[dim]Note: bare[/] [green]--remove-formatting[/] [dim]strips every tag wholesale (GUI: 'Remove all formatting'),[/]\n" +
+            "[dim]which is broader than[/] [green]--remove-formatting-rules:all[/] [dim]- the union of the rules above.[/]\n" +
+            "[dim]Tags no rule covers, e.g. positioning like {\\pos(..)}, only go away with the bare flag.[/]");
+        AnsiConsole.MarkupLine(
+            "\n[dim]Examples:[/]\n" +
+            "  [dim]--remove-formatting[/]                                  [dim]# remove every tag[/]\n" +
+            "  [dim]--remove-formatting-rules:RemoveItalic,RemoveBold[/]    [dim]# only these two[/]\n" +
+            "  [dim]--remove-formatting-rules:all,-RemoveColor[/]           [dim]# every named rule except colors[/]");
+    }
+
     public static void PrintOcrEngines()
     {
         AnsiConsole.MarkupLine("[bold cyan]OCR engines (pass via --ocr-engine)[/]");

--- a/src/seconv/Core/OperationOrderParser.cs
+++ b/src/seconv/Core/OperationOrderParser.cs
@@ -81,7 +81,14 @@ internal static class OperationOrderParser
     /// True when Fix Common Errors was requested (a bare flag and/or <c>--fix-common-errors-rules</c>).
     /// Guarantees at least one Fix Common Errors pass when only the rules option was supplied.
     /// </param>
-    public static List<string> BuildOperations(IReadOnlyList<string> rawArgs, bool fceRequested)
+    /// <param name="removeFormattingRequested">
+    /// Same for Remove Formatting: true when requested via a bare flag and/or
+    /// <c>--remove-formatting-rules</c>, guaranteeing at least one pass.
+    /// </param>
+    public static List<string> BuildOperations(
+        IReadOnlyList<string> rawArgs,
+        bool fceRequested,
+        bool removeFormattingRequested = false)
     {
         var operations = new List<string>();
         if (rawArgs == null)
@@ -90,10 +97,15 @@ internal static class OperationOrderParser
         }
 
         var sawBareFce = false;
-        int? rulesPosition = null;
+        var sawBareRemoveFormatting = false;
+        int? fceRulesPosition = null;
+        int? removeFormattingRulesPosition = null;
+        int? fceRulesArgIndex = null;
+        int? removeFormattingRulesArgIndex = null;
 
-        foreach (var arg in rawArgs)
+        for (var argIndex = 0; argIndex < rawArgs.Count; argIndex++)
         {
+            var arg = rawArgs[argIndex];
             if (string.IsNullOrEmpty(arg) || (arg[0] != '-' && arg[0] != '/'))
             {
                 continue; // positional (e.g. a file pattern) or a value, not a flag
@@ -101,11 +113,19 @@ internal static class OperationOrderParser
 
             var key = Normalize(arg);
 
-            // Fix Common Errors rules option configures the FCE pass(es) globally; it does
-            // not itself add a pass, but it does imply one when no bare flag is present.
+            // A rules option configures its pass(es) globally; it does not itself add a
+            // pass, but it does imply one when no bare flag is present.
             if (key == "fixcommonerrorsrules")
             {
-                rulesPosition ??= operations.Count;
+                fceRulesPosition ??= operations.Count;
+                fceRulesArgIndex ??= argIndex;
+                continue;
+            }
+
+            if (key == "removeformattingrules")
+            {
+                removeFormattingRulesPosition ??= operations.Count;
+                removeFormattingRulesArgIndex ??= argIndex;
                 continue;
             }
 
@@ -115,15 +135,34 @@ internal static class OperationOrderParser
                 {
                     sawBareFce = true;
                 }
+                else if (operation == "RemoveFormatting")
+                {
+                    sawBareRemoveFormatting = true;
+                }
 
                 operations.Add(operation);
             }
         }
 
-        // Back-compat: "--fix-common-errors-rules:..." on its own still runs one FCE pass.
+        // Back-compat: a rules option on its own still runs one pass, inserted where the
+        // rules flag appeared. Insert higher positions first (ties broken by raw-arg order)
+        // so an earlier insert cannot shift a later one.
+        var implied = new List<(int Position, int ArgIndex, string Operation)>();
         if (fceRequested && !sawBareFce)
         {
-            operations.Insert(rulesPosition ?? operations.Count, "FixCommonErrors");
+            implied.Add((fceRulesPosition ?? operations.Count, fceRulesArgIndex ?? int.MaxValue, "FixCommonErrors"));
+        }
+
+        if (removeFormattingRequested && !sawBareRemoveFormatting)
+        {
+            implied.Add((removeFormattingRulesPosition ?? operations.Count, removeFormattingRulesArgIndex ?? int.MaxValue, "RemoveFormatting"));
+        }
+
+        foreach (var (position, _, operation) in implied
+                     .OrderByDescending(i => i.Position)
+                     .ThenByDescending(i => i.ArgIndex))
+        {
+            operations.Insert(position, operation);
         }
 
         return operations;

--- a/src/seconv/Core/RemoveFormattingRunner.cs
+++ b/src/seconv/Core/RemoveFormattingRunner.cs
@@ -1,0 +1,97 @@
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace SeConv.Core;
+
+/// <summary>
+/// Applies the <c>--remove-formatting</c> pass. A null rule list (bare
+/// <c>--remove-formatting</c>) strips every tag wholesale via
+/// <see cref="RemoveFormattingType.All"/> - same as the GUI batch convert's "Remove all
+/// formatting" checkbox, and same as seconv behaved before rule selection existed. A rule
+/// list from <c>--remove-formatting-rules</c> maps each ID onto its
+/// <see cref="RemoveFormattingType"/> flag instead. Note that <c>all</c> in a rule spec
+/// means "all named rules", which is narrower than the wholesale pass: tags no rule covers
+/// (e.g. <c>{\pos(..)}</c>) survive it (#13518).
+/// </summary>
+internal static class RemoveFormattingRunner
+{
+    // Rule IDs are stable string keys users pass via --remove-formatting-rules; matching is
+    // case-insensitive. Order matches the GUI batch convert "Remove formatting" checkboxes
+    // and defines the canonical order ResolveRuleIds returns.
+    private static readonly IReadOnlyList<(string Id, RemoveFormattingType Type)> Rules =
+    [
+        ("RemoveItalic", RemoveFormattingType.Italic),
+        ("RemoveBold", RemoveFormattingType.Bold),
+        ("RemoveUnderline", RemoveFormattingType.Underline),
+        ("RemoveFontName", RemoveFormattingType.FontName),
+        ("RemoveAlignment", RemoveFormattingType.Alignment),
+        ("RemoveColor", RemoveFormattingType.Color),
+    ];
+
+    public static IReadOnlyList<string> AvailableRuleIds { get; } = Rules.Select(r => r.Id).ToArray();
+
+    /// <summary>
+    /// Maps each CLI rule ID to the checkbox label the GUI's batch convert "Remove formatting"
+    /// function shows for the same option, so users who prototyped in the desktop app can find
+    /// the matching <c>--remove-formatting-rules</c> ID. Single source of truth for the
+    /// <c>list-rf-rules</c> "GUI equivalent" column. Kept in sync with the GUI strings in
+    /// <c>LanguageGeneral</c> / <c>ViewRemoveFormatting</c>; a test asserts every
+    /// <see cref="AvailableRuleIds"/> entry has a label here.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> GuiLabels { get; } =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["RemoveItalic"] = "Remove italic",
+            ["RemoveBold"] = "Remove bold",
+            ["RemoveUnderline"] = "Remove underline",
+            ["RemoveFontName"] = "Remove font name",
+            ["RemoveAlignment"] = "Remove alignment",
+            ["RemoveColor"] = "Remove color",
+        };
+
+    /// <summary>
+    /// Resolves a comma-separated rule spec (e.g. <c>"all,-RemoveItalic"</c>) into concrete
+    /// rule IDs in canonical order. Throws <see cref="ArgumentException"/> for unknown IDs.
+    /// </summary>
+    public static IReadOnlyList<string> ResolveRuleIds(string? spec) =>
+        RuleIdSpec.Resolve(spec, AvailableRuleIds, "remove-formatting", "list-rf-rules");
+
+    public static void Run(Subtitle subtitle, IReadOnlyCollection<string>? ruleIds = null)
+    {
+        var types = ToTypes(ruleIds);
+        if (types == RemoveFormattingType.None)
+        {
+            return;
+        }
+
+        foreach (var p in subtitle.Paragraphs)
+        {
+            p.Text = RemoveFormattingUtil.Remove(p.Text, types);
+        }
+    }
+
+    /// <summary>
+    /// Null = bare <c>--remove-formatting</c> = wholesale <see cref="RemoveFormattingType.All"/>.
+    /// An empty list (the user subtracted every rule, e.g. <c>all,-…</c> naming all of them)
+    /// selects nothing and yields <see cref="RemoveFormattingType.None"/> rather than silently
+    /// falling back to the wholesale pass.
+    /// </summary>
+    internal static RemoveFormattingType ToTypes(IReadOnlyCollection<string>? ruleIds)
+    {
+        if (ruleIds == null)
+        {
+            return RemoveFormattingType.All;
+        }
+
+        var wanted = new HashSet<string>(ruleIds, StringComparer.OrdinalIgnoreCase);
+        var types = RemoveFormattingType.None;
+        foreach (var (id, type) in Rules)
+        {
+            if (wanted.Contains(id))
+            {
+                types |= type;
+            }
+        }
+
+        return types;
+    }
+}

--- a/src/seconv/Core/RuleIdSpec.cs
+++ b/src/seconv/Core/RuleIdSpec.cs
@@ -1,0 +1,91 @@
+namespace SeConv.Core;
+
+/// <summary>
+/// Parses the comma-separated rule-selection spec shared by <c>--fix-common-errors-rules</c>
+/// and <c>--remove-formatting-rules</c>. Supports:
+/// <list type="bullet">
+///   <item><c>all</c> — every rule (also the default when spec is null/empty/whitespace).</item>
+///   <item><c>RuleA,RuleB</c> — explicit allow-list.</item>
+///   <item><c>all,-RuleA</c> — start from all, then subtract.</item>
+///   <item><c>-RuleA</c> (negations only) — implied <c>all</c>, then subtract.</item>
+/// </list>
+/// Matching is case-insensitive. Throws <see cref="ArgumentException"/> for unknown IDs.
+/// Returned IDs are in the canonical order of <paramref name="availableIds"/>.
+/// </summary>
+internal static class RuleIdSpec
+{
+    /// <param name="spec">The raw option value, e.g. <c>"all,-RemoveItalic"</c>.</param>
+    /// <param name="availableIds">Canonical rule IDs; defines the result order.</param>
+    /// <param name="ruleKind">Rule family name for error messages, e.g. <c>"FixCommonErrors"</c>.</param>
+    /// <param name="listCommand">Subcommand that lists the IDs, e.g. <c>"list-fce-rules"</c>.</param>
+    public static IReadOnlyList<string> Resolve(
+        string? spec,
+        IReadOnlyList<string> availableIds,
+        string ruleKind,
+        string listCommand)
+    {
+        if (string.IsNullOrWhiteSpace(spec))
+        {
+            return availableIds;
+        }
+
+        var available = new HashSet<string>(availableIds, StringComparer.OrdinalIgnoreCase);
+        var tokens = spec.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        var hasPositive = tokens.Any(t => !t.StartsWith('-'));
+        var selected = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // Negation-only specs ("-FixCommas,-FixDanishLetterI") imply a leading "all".
+        if (!hasPositive)
+        {
+            foreach (var a in availableIds)
+            {
+                selected.Add(a);
+            }
+        }
+
+        foreach (var raw in tokens)
+        {
+            var negate = raw.StartsWith('-');
+            var id = negate ? raw[1..].Trim() : raw;
+
+            if (string.IsNullOrEmpty(id))
+            {
+                continue;
+            }
+
+            if (id.Equals("all", StringComparison.OrdinalIgnoreCase))
+            {
+                if (negate)
+                {
+                    selected.Clear();
+                }
+                else
+                {
+                    foreach (var a in availableIds)
+                    {
+                        selected.Add(a);
+                    }
+                }
+                continue;
+            }
+
+            if (!available.Contains(id))
+            {
+                throw new ArgumentException(
+                    $"Unknown {ruleKind} rule '{id}'. Run 'seconv {listCommand}' to see available IDs.");
+            }
+
+            if (negate)
+            {
+                selected.Remove(id);
+            }
+            else
+            {
+                selected.Add(id);
+            }
+        }
+
+        return availableIds.Where(selected.Contains).ToArray();
+    }
+}

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -745,7 +745,8 @@ internal class SubtitleConverter
                 subtitle,
                 options.Operations,
                 options.FixCommonErrorsRules,
-                options.FixCommonErrorsLanguage);
+                options.FixCommonErrorsLanguage,
+                options.RemoveFormattingRules);
         }
 
         if (options.BridgeGapsMaxMs.HasValue && options.BridgeGapsMaxMs.Value > 0)
@@ -878,6 +879,13 @@ internal record class ConversionOptions
     /// code, or English name (see <see cref="FixCommonErrorsRunner.NormalizeLanguageOverride"/>).
     /// </summary>
     public string? FixCommonErrorsLanguage { get; init; }
+
+    /// <summary>
+    /// Optional formatting-removal rule selection (from <c>--remove-formatting-rules</c>).
+    /// Null = bare <c>--remove-formatting</c> = strip every tag wholesale. Resolve via
+    /// <see cref="RemoveFormattingRunner.ResolveRuleIds"/>.
+    /// </summary>
+    public IReadOnlyList<string>? RemoveFormattingRules { get; init; }
     public int? DeleteFirst { get; init; }
     public int? DeleteLast { get; init; }
     public string? DeleteContains { get; init; }

--- a/src/seconv/Helpers/HelpDisplay.cs
+++ b/src/seconv/Helpers/HelpDisplay.cs
@@ -84,7 +84,8 @@ internal static class HelpDisplay
         ShowParameter("--merge-same-time-codes", "Merge entries with same time codes");
         ShowParameter("--merge-short-lines", "Merge short lines");
         ShowParameter("--redo-casing", "Redo text casing");
-        ShowParameter("--remove-formatting", "Remove formatting tags");
+        ShowParameter("--remove-formatting", "Remove all formatting tags");
+        ShowParameter("--remove-formatting-rules:<list>", "Formatting-removal rule IDs (csv); supports 'all,-RuleId'. List: seconv list-rf-rules");
         ShowParameter("--remove-line-breaks", "Remove line breaks");
         ShowParameter("--remove-text-for-hi", "Remove text for hearing impaired");
         ShowParameter("--remove-unicode-control-chars", "Remove Unicode control characters");
@@ -99,6 +100,7 @@ internal static class HelpDisplay
         ShowParameter("list-pac-codepages", "List PAC code pages (--pac-codepage values)");
         ShowParameter("list-ocr-engines", "List OCR engines + installation status");
         ShowParameter("list-fce-rules", "List FixCommonErrors rule IDs");
+        ShowParameter("list-rf-rules", "List remove-formatting rule IDs");
         ShowParameter("dump-settings", "Print a full --settings JSON with libse defaults (redirect to a file)");
         ShowParameter("info <file>", "Print format / encoding / duration / language info");
         ShowParameter("lint <pattern>", "Validate subtitle(s); exit 1 if any issues found");

--- a/src/seconv/Program.cs
+++ b/src/seconv/Program.cs
@@ -77,6 +77,12 @@ internal class Program
                 ListHelpers.PrintFixCommonErrorsRules();
                 return 0;
             }
+            if (first.Equals("list-rf-rules", StringComparison.OrdinalIgnoreCase) ||
+                first.Equals("list-remove-formatting-rules", StringComparison.OrdinalIgnoreCase))
+            {
+                ListHelpers.PrintRemoveFormattingRules();
+                return 0;
+            }
             if (first.Equals("dump-settings", StringComparison.OrdinalIgnoreCase) ||
                 first.Equals("default-settings", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -1910,63 +1910,19 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             return subtitle;
         }
 
+        var s = _config.RemoveFormatting;
+        var types = RemoveFormattingType.None;
+        if (s.RemoveAll) { types |= RemoveFormattingType.All; }
+        if (s.RemoveItalic) { types |= RemoveFormattingType.Italic; }
+        if (s.RemoveBold) { types |= RemoveFormattingType.Bold; }
+        if (s.RemoveUnderline) { types |= RemoveFormattingType.Underline; }
+        if (s.RemoveColor) { types |= RemoveFormattingType.Color; }
+        if (s.RemoveFontName) { types |= RemoveFormattingType.FontName; }
+        if (s.RemoveAlignment) { types |= RemoveFormattingType.Alignment; }
+
         foreach (var p in subtitle.Paragraphs)
         {
-            if (_config.RemoveFormatting.RemoveAll)
-            {
-                p.Text = HtmlUtil.RemoveHtmlTags(p.Text, true);
-            }
-            else
-            {
-                if (_config.RemoveFormatting.RemoveItalic)
-                {
-                    p.Text = HtmlUtil.RemoveOpenCloseTags(p.Text, HtmlUtil.TagItalic);
-                    p.Text = p.Text
-                        .Replace("{\\i}", string.Empty)
-                        .Replace("{\\i0}", string.Empty)
-                        .Replace("{\\i1}", string.Empty);
-                }
-
-                if (_config.RemoveFormatting.RemoveBold)
-                {
-                    p.Text = HtmlUtil.RemoveOpenCloseTags(p.Text, HtmlUtil.TagBold);
-                    p.Text = p.Text
-                        .Replace("{\\b}", string.Empty)
-                        .Replace("{\\b0}", string.Empty)
-                        .Replace("{\\b1}", string.Empty);
-                }
-
-                if (_config.RemoveFormatting.RemoveUnderline)
-                {
-                    p.Text = HtmlUtil.RemoveOpenCloseTags(p.Text, HtmlUtil.TagUnderline);
-                    p.Text = p.Text
-                        .Replace("{\\u}", string.Empty)
-                        .Replace("{\\u0}", string.Empty)
-                        .Replace("{\\u1}", string.Empty);
-                }
-
-                if (_config.RemoveFormatting.RemoveColor)
-                {
-                    p.Text = HtmlUtil.RemoveColorTags(p.Text);
-                    if (p.Text.Contains("\\c") || p.Text.Contains("\\1c"))
-                    {
-                        p.Text = HtmlUtil.RemoveAssaColor(p.Text);
-                    }
-                }
-
-                if (_config.RemoveFormatting.RemoveFontName)
-                {
-                    p.Text = HtmlUtil.RemoveFontName(p.Text);
-                }
-
-                if (_config.RemoveFormatting.RemoveAlignment)
-                {
-                    if (p.Text.Contains('{'))
-                    {
-                        p.Text = HtmlUtil.RemoveAssAlignmentTags(p.Text);
-                    }
-                }
-            }
+            p.Text = RemoveFormattingUtil.Remove(p.Text, types);
         }
 
         return subtitle;

--- a/tests/UI/Features/Tools/BatchConvert/BatchConverterRemoveFormattingTests.cs
+++ b/tests/UI/Features/Tools/BatchConvert/BatchConverterRemoveFormattingTests.cs
@@ -1,0 +1,101 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Tools.BatchConvert;
+using Nikse.SubtitleEdit.UiLogic.BatchConvert;
+
+namespace UITests.Features.Tools.BatchConvert;
+
+/// <summary>
+/// Pins the wiring from <see cref="BatchConvertConfig.RemoveFormattingSettings"/> onto the
+/// shared <see cref="RemoveFormattingUtil"/> flags. The removal logic itself moved into libse
+/// so seconv's --remove-formatting-rules and this function strip tags identically (#13518);
+/// what can still regress on this side is the config-to-flags mapping.
+/// </summary>
+public class BatchConverterRemoveFormattingTests
+{
+    private const string InputAss = @"[Script Info]
+ScriptType: v4.00+
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Default,Arial,20,&H00FFFFFF,&H0300FFFF,&H00000000,&H02000000,0,0,0,0,100,100,0,0,1,2,1,2,10,10,10,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,{\pos(10,20)}{\i1}Hi{\i0} {\b1}bold{\b0}
+";
+
+    private static async Task<string> ConvertAsync(Action<BatchConvertConfig.RemoveFormattingSettings> configure)
+    {
+        var dir = Directory.CreateTempSubdirectory("se-remove-formatting-test");
+        try
+        {
+            var inputFile = Path.Combine(dir.FullName, "input.ass");
+            await File.WriteAllTextAsync(inputFile, InputAss, TestContext.Current.CancellationToken);
+
+            var outputFolder = Path.Combine(dir.FullName, "out");
+            Directory.CreateDirectory(outputFolder);
+
+            var subtitle = Subtitle.Parse(inputFile);
+            var item = new BatchConvertItem(inputFile, new FileInfo(inputFile).Length, new AdvancedSubStationAlpha().Name, subtitle);
+
+            var config = new BatchConvertConfig
+            {
+                SaveInSourceFolder = false,
+                OutputFolder = outputFolder,
+                Overwrite = true,
+                TargetFormatName = AdvancedSubStationAlpha.NameOfFormat,
+            };
+            config.RemoveFormatting.IsActive = true;
+            configure(config.RemoveFormatting);
+
+            var converter = new BatchConverter(null!, null!, null!);
+            converter.Initialize(config);
+            await converter.Convert(item, TestContext.Current.CancellationToken);
+
+            var outputFile = Path.Combine(outputFolder, "input.ass");
+            Assert.True(File.Exists(outputFile), "converted file was not written");
+
+            return Subtitle.Parse(outputFile).Paragraphs[0].Text;
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RemoveAll_StripsEveryTagIncludingPosition()
+    {
+        Assert.Equal("Hi bold", await ConvertAsync(s => s.RemoveAll = true));
+    }
+
+    [Fact]
+    public async Task RemoveItalicOnly_KeepsBoldAndPosition()
+    {
+        Assert.Equal("{\\pos(10,20)}Hi {\\b1}bold{\\b0}", await ConvertAsync(s => s.RemoveItalic = true));
+    }
+
+    [Fact]
+    public async Task EveryPerKindOption_LeavesPositionTagAlone()
+    {
+        // The per-kind options together are narrower than RemoveAll: positioning survives.
+        var text = await ConvertAsync(s =>
+        {
+            s.RemoveItalic = true;
+            s.RemoveBold = true;
+            s.RemoveUnderline = true;
+            s.RemoveColor = true;
+            s.RemoveFontName = true;
+            s.RemoveAlignment = true;
+        });
+
+        Assert.Equal("{\\pos(10,20)}Hi bold", text);
+    }
+
+    [Fact]
+    public async Task NoOptionSelected_LeavesTextUntouched()
+    {
+        Assert.Equal("{\\pos(10,20)}{\\i1}Hi{\\i0} {\\b1}bold{\\b0}", await ConvertAsync(_ => { }));
+    }
+}

--- a/tests/libse/Common/RemoveFormattingUtilTest.cs
+++ b/tests/libse/Common/RemoveFormattingUtilTest.cs
@@ -1,0 +1,104 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Xunit;
+
+namespace LibSETests.Common;
+
+/// <summary>
+/// RemoveFormattingUtil is the single source of truth for both the GUI batch convert
+/// "Remove formatting" function and seconv's --remove-formatting / --remove-formatting-rules
+/// (#13518). These tests pin down each category's behaviour and the key design distinction:
+/// <see cref="RemoveFormattingType.All"/> is wholesale (strips tags no named category
+/// covers, e.g. {\pos(..)}), while the union of the named categories leaves those alone.
+/// </summary>
+public class RemoveFormattingUtilTest
+{
+    private const RemoveFormattingType AllNamed =
+        RemoveFormattingType.Italic |
+        RemoveFormattingType.Bold |
+        RemoveFormattingType.Underline |
+        RemoveFormattingType.FontName |
+        RemoveFormattingType.Alignment |
+        RemoveFormattingType.Color;
+
+    [Fact]
+    public void None_LeavesTextUnchanged()
+    {
+        Assert.Equal("<i>Hi</i>", RemoveFormattingUtil.Remove("<i>Hi</i>", RemoveFormattingType.None));
+    }
+
+    [Fact]
+    public void Italic_RemovesHtmlAndAssaItalic_KeepsBold()
+    {
+        Assert.Equal("Hi <b>there</b>", RemoveFormattingUtil.Remove("<i>Hi</i> <b>there</b>", RemoveFormattingType.Italic));
+        Assert.Equal("Hi", RemoveFormattingUtil.Remove("{\\i1}Hi{\\i0}", RemoveFormattingType.Italic));
+    }
+
+    [Fact]
+    public void Bold_RemovesHtmlAndAssaBold_KeepsItalic()
+    {
+        Assert.Equal("<i>Hi</i> there", RemoveFormattingUtil.Remove("<i>Hi</i> <b>there</b>", RemoveFormattingType.Bold));
+        Assert.Equal("Hi", RemoveFormattingUtil.Remove("{\\b1}Hi{\\b0}", RemoveFormattingType.Bold));
+    }
+
+    [Fact]
+    public void Underline_RemovesHtmlAndAssaUnderline()
+    {
+        Assert.Equal("Hi", RemoveFormattingUtil.Remove("<u>Hi</u>", RemoveFormattingType.Underline));
+        Assert.Equal("Hi", RemoveFormattingUtil.Remove("{\\u1}Hi{\\u0}", RemoveFormattingType.Underline));
+    }
+
+    [Fact]
+    public void Color_RemovesFontColorAndAssaColor()
+    {
+        Assert.Equal("Hi", RemoveFormattingUtil.Remove("<font color=\"red\">Hi</font>", RemoveFormattingType.Color));
+        Assert.Equal("{\\an8}Hi", RemoveFormattingUtil.Remove("{\\an8}{\\c&H0000FF&}Hi", RemoveFormattingType.Color));
+    }
+
+    [Fact]
+    public void FontName_RemovesFaceAttributeAndAssaFn()
+    {
+        Assert.Equal("Hi", RemoveFormattingUtil.Remove("<font face=\"Arial\">Hi</font>", RemoveFormattingType.FontName));
+        Assert.Equal("Hi", RemoveFormattingUtil.Remove("{\\fnArial}Hi", RemoveFormattingType.FontName));
+    }
+
+    [Fact]
+    public void Alignment_RemovesAssAlignmentTag_KeepsItalic()
+    {
+        Assert.Equal("<i>Hi</i>", RemoveFormattingUtil.Remove("{\\an8}<i>Hi</i>", RemoveFormattingType.Alignment));
+    }
+
+    [Fact]
+    public void All_IsWholesale_AlsoRemovesPositionTags()
+    {
+        Assert.Equal("Hi", RemoveFormattingUtil.Remove("{\\pos(10,20)}<i>Hi</i>", RemoveFormattingType.All));
+    }
+
+    [Fact]
+    public void AllNamedCategories_LeavePositionTagsAlone()
+    {
+        // The union of every named category is narrower than All: tags no category
+        // covers (like positioning) must survive.
+        Assert.Equal("{\\pos(10,20)}Hi", RemoveFormattingUtil.Remove("{\\pos(10,20)}<i>Hi</i>", AllNamed));
+    }
+
+    [Fact]
+    public void All_WinsOverNamedCategories()
+    {
+        var both = RemoveFormattingType.All | RemoveFormattingType.Italic;
+        Assert.Equal("Hi", RemoveFormattingUtil.Remove("{\\pos(10,20)}<i>Hi</i>", both));
+    }
+
+    [Fact]
+    public void CombinedCategories_ApplyTogether()
+    {
+        Assert.Equal(
+            "Hi there",
+            RemoveFormattingUtil.Remove("<i>Hi</i> <b>there</b>", RemoveFormattingType.Italic | RemoveFormattingType.Bold));
+    }
+
+    [Fact]
+    public void EmptyText_ReturnsUnchanged()
+    {
+        Assert.Equal(string.Empty, RemoveFormattingUtil.Remove(string.Empty, RemoveFormattingType.All));
+    }
+}

--- a/tests/seconv/Core/OperationOrderParserTest.cs
+++ b/tests/seconv/Core/OperationOrderParserTest.cs
@@ -75,4 +75,44 @@ public class OperationOrderParserTest
 
         Assert.Empty(ops);
     }
+
+    [Fact]
+    public void RemoveFormattingRulesAloneImpliesOnePass_AtFlagPosition()
+    {
+        var args = new[] { "in.srt", "subrip", "--balance-lines", "--remove-formatting-rules:RemoveItalic", "--redo-casing" };
+
+        var ops = OperationOrderParser.BuildOperations(args, fceRequested: false, removeFormattingRequested: true);
+
+        Assert.Equal(new[] { "BalanceLines", "RemoveFormatting", "RedoCasing" }, ops.ToArray());
+    }
+
+    [Fact]
+    public void RemoveFormattingRulesDoesNotAddExtraPassWhenBareFlagPresent()
+    {
+        var args = new[] { "--remove-formatting", "--remove-formatting-rules:RemoveItalic" };
+
+        var ops = OperationOrderParser.BuildOperations(args, fceRequested: false, removeFormattingRequested: true);
+
+        Assert.Equal(new[] { "RemoveFormatting" }, ops.ToArray());
+    }
+
+    [Fact]
+    public void BothRulesOptionsAlone_ImplyPassesInCommandLineOrder()
+    {
+        var args = new[] { "in.srt", "subrip", "--remove-formatting-rules:RemoveItalic", "--fix-common-errors-rules:FixCommas" };
+
+        var ops = OperationOrderParser.BuildOperations(args, fceRequested: true, removeFormattingRequested: true);
+
+        Assert.Equal(new[] { "RemoveFormatting", "FixCommonErrors" }, ops.ToArray());
+    }
+
+    [Fact]
+    public void BothRulesOptionsAroundBareOperation_KeepTheirPositions()
+    {
+        var args = new[] { "--fix-common-errors-rules:FixCommas", "--balance-lines", "--remove-formatting-rules:RemoveItalic" };
+
+        var ops = OperationOrderParser.BuildOperations(args, fceRequested: true, removeFormattingRequested: true);
+
+        Assert.Equal(new[] { "FixCommonErrors", "BalanceLines", "RemoveFormatting" }, ops.ToArray());
+    }
 }

--- a/tests/seconv/Core/RemoveFormattingRunnerTest.cs
+++ b/tests/seconv/Core/RemoveFormattingRunnerTest.cs
@@ -1,0 +1,149 @@
+using Nikse.SubtitleEdit.Core.Common;
+using SeConv.Core;
+using Xunit;
+
+namespace SeConvTests.Core;
+
+public class RemoveFormattingRunnerTest
+{
+    [Fact]
+    public void ResolveRuleIds_NullOrWhitespaceOrAll_ReturnsAllRules()
+    {
+        var all = RemoveFormattingRunner.AvailableRuleIds;
+
+        Assert.Equal(all, RemoveFormattingRunner.ResolveRuleIds(null));
+        Assert.Equal(all, RemoveFormattingRunner.ResolveRuleIds(""));
+        Assert.Equal(all, RemoveFormattingRunner.ResolveRuleIds("   "));
+        Assert.Equal(all, RemoveFormattingRunner.ResolveRuleIds("all"));
+    }
+
+    [Fact]
+    public void ResolveRuleIds_ExplicitList_ReturnsSubsetInCanonicalOrder()
+    {
+        // Canonical order is the GUI checkbox order, not the order the user typed.
+        var resolved = RemoveFormattingRunner.ResolveRuleIds("RemoveColor,RemoveItalic");
+
+        Assert.Equal(new[] { "RemoveItalic", "RemoveColor" }, resolved);
+    }
+
+    [Fact]
+    public void ResolveRuleIds_AllMinusOne_DropsThatRule()
+    {
+        var resolved = RemoveFormattingRunner.ResolveRuleIds("all,-RemoveItalic");
+
+        Assert.DoesNotContain("RemoveItalic", resolved);
+        Assert.Equal(RemoveFormattingRunner.AvailableRuleIds.Count - 1, resolved.Count);
+    }
+
+    [Fact]
+    public void ResolveRuleIds_NegationsOnly_ImpliesAll()
+    {
+        var resolved = RemoveFormattingRunner.ResolveRuleIds("-RemoveColor");
+
+        Assert.DoesNotContain("RemoveColor", resolved);
+        Assert.Equal(RemoveFormattingRunner.AvailableRuleIds.Count - 1, resolved.Count);
+    }
+
+    [Fact]
+    public void ResolveRuleIds_CaseInsensitive()
+    {
+        var resolved = RemoveFormattingRunner.ResolveRuleIds("removeitalic,REMOVEBOLD");
+
+        Assert.Equal(new[] { "RemoveItalic", "RemoveBold" }, resolved);
+    }
+
+    [Fact]
+    public void ResolveRuleIds_UnknownRule_ThrowsWithListCommandHint()
+    {
+        var ex = Assert.Throws<ArgumentException>(
+            () => RemoveFormattingRunner.ResolveRuleIds("RemoveItalic,NotARealRule"));
+
+        Assert.Contains("NotARealRule", ex.Message);
+        Assert.Contains("list-rf-rules", ex.Message);
+    }
+
+    [Fact]
+    public void ToTypes_Null_MeansWholesaleAll()
+    {
+        // Bare --remove-formatting keeps the pre-#13518 behaviour: strip everything.
+        Assert.Equal(RemoveFormattingType.All, RemoveFormattingRunner.ToTypes(null));
+    }
+
+    [Fact]
+    public void ToTypes_EmptyList_MeansNone()
+    {
+        // The user subtracted every rule; a silent fallback to wholesale would be worse.
+        Assert.Equal(RemoveFormattingType.None, RemoveFormattingRunner.ToTypes([]));
+    }
+
+    [Fact]
+    public void ToTypes_MapsEachRuleToItsFlag()
+    {
+        Assert.Equal(RemoveFormattingType.Italic, RemoveFormattingRunner.ToTypes(["RemoveItalic"]));
+        Assert.Equal(RemoveFormattingType.Bold, RemoveFormattingRunner.ToTypes(["RemoveBold"]));
+        Assert.Equal(RemoveFormattingType.Underline, RemoveFormattingRunner.ToTypes(["RemoveUnderline"]));
+        Assert.Equal(RemoveFormattingType.FontName, RemoveFormattingRunner.ToTypes(["RemoveFontName"]));
+        Assert.Equal(RemoveFormattingType.Alignment, RemoveFormattingRunner.ToTypes(["RemoveAlignment"]));
+        Assert.Equal(RemoveFormattingType.Color, RemoveFormattingRunner.ToTypes(["RemoveColor"]));
+        Assert.Equal(
+            RemoveFormattingType.Italic | RemoveFormattingType.Color,
+            RemoveFormattingRunner.ToTypes(["RemoveItalic", "RemoveColor"]));
+    }
+
+    [Fact]
+    public void Run_NullRules_StripsEverythingIncludingPositionTags()
+    {
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("{\\pos(10,20)}<i>Hi</i>", 0, 1000));
+
+        RemoveFormattingRunner.Run(sub);
+
+        Assert.Equal("Hi", sub.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void Run_ItalicOnly_KeepsOtherFormatting()
+    {
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("<i>Hi</i> <b>there</b>", 0, 1000));
+
+        RemoveFormattingRunner.Run(sub, ["RemoveItalic"]);
+
+        Assert.Equal("Hi <b>there</b>", sub.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void Run_AllNamedRules_LeavesPositionTagsAlone()
+    {
+        // 'all' in a rule spec is the union of the named rules - narrower than the
+        // wholesale pass a bare --remove-formatting performs.
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("{\\pos(10,20)}<i>Hi</i>", 0, 1000));
+
+        RemoveFormattingRunner.Run(sub, RemoveFormattingRunner.ResolveRuleIds("all"));
+
+        Assert.Equal("{\\pos(10,20)}Hi", sub.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void GuiLabels_CoversEveryAvailableRule_WithNonEmptyText()
+    {
+        foreach (var id in RemoveFormattingRunner.AvailableRuleIds)
+        {
+            Assert.True(
+                RemoveFormattingRunner.GuiLabels.TryGetValue(id, out var label),
+                $"Rule '{id}' has no GUI-equivalent label in RemoveFormattingRunner.GuiLabels.");
+            Assert.False(string.IsNullOrWhiteSpace(label));
+        }
+    }
+
+    [Fact]
+    public void GuiLabels_HasNoLabelForUnknownRule()
+    {
+        var available = new HashSet<string>(RemoveFormattingRunner.AvailableRuleIds, StringComparer.OrdinalIgnoreCase);
+        foreach (var id in RemoveFormattingRunner.GuiLabels.Keys)
+        {
+            Assert.Contains(id, available);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #13518.

`seconv --remove-formatting` was all-or-nothing, while the desktop batch converter has had six per-kind check boxes for a while. This adds `--remove-formatting-rules:<list>` following the `--fix-common-errors-rules` design.

## What's new

- **`--remove-formatting-rules:<list>`** — `RemoveItalic`, `RemoveBold`, `RemoveUnderline`, `RemoveFontName`, `RemoveAlignment`, `RemoveColor`. Case-insensitive, supports the `all,-RuleId` subtraction pattern, and implies `--remove-formatting` so you don't have to pass both. Unknown IDs are a hard error pointing at the list subcommand.
- **`seconv list-rf-rules`** — prints each ID next to the GUI check box label it corresponds to (also aliased `list-remove-formatting-rules`).

```bash
seconv movie.ass subrip --remove-formatting-rules:RemoveItalic,RemoveBold
seconv movie.ass subrip --remove-formatting-rules:all,-RemoveColor
```

## `all` is deliberately narrower than the bare flag

Bare `--remove-formatting` keeps its current meaning: strip everything via `HtmlUtil.RemoveHtmlTags(text, true)`, which also takes out tags no named rule covers — `{\pos(..)}`, fades, karaoke timing. That isn't decomposable into the six rules, so `--remove-formatting-rules:all` means *the union of the six rules* and leaves those alone:

| Input | Command | Output |
|---|---|---|
| `{\pos(10,20)}<i>Hi</i>` | `--remove-formatting` | `Hi` |
| `{\pos(10,20)}<i>Hi</i>` | `--remove-formatting-rules:all` | `{\pos(10,20)}Hi` |

This is the same distinction the GUI already draws between its *Remove all formatting* check box and the six per-kind ones. `list-rf-rules`, `--help`, and the docs all call it out so nobody is surprised. Bare `--remove-formatting` is unchanged, so existing scripts keep their behaviour.

## Single source of truth

The per-kind removal logic moved out of `BatchConverter` into `libse`'s new `RemoveFormattingUtil`, so the GUI function and the CLI strip tags through the same code instead of drifting apart. The rule-spec parser (`all`, `all,-X`, negations-only, unknown-ID errors) moved out of `FixCommonErrorsRunner` into a shared `RuleIdSpec` used by both rule families.

`OperationOrderParser` now treats `--remove-formatting-rules` the way it treats `--fix-common-errors-rules`: the option itself adds no pass but implies one at the position the flag appeared, so operation ordering still follows the command line when both rules options are used alone.

## Tests

25 new tests: per-category behaviour and the All-vs-named-union distinction (libse), spec resolution / flag mapping / runner behaviour (seconv), operation ordering with one or both rules options, and the GUI config→flags wiring through the real `BatchConverter` (UI).

Full suites green locally: libse 1024, seconv 309, libuilogic 199, UI 2411.

Also verified end-to-end against a real ASSA file with every variant (`--remove-formatting`, `:all`, single rules, `all,-RemoveColor`, unknown-rule error path, `list-rf-rules`) — the doc table above is copied from that output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)