### PR TITLE
Add move to top/bottom and move shortcuts to Multiple replace

### DIFF
--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
@@ -56,6 +56,14 @@ public partial class MultipleReplaceViewModel : ObservableObject
     private readonly Timer _timerReplace;
     private bool _dirty;
 
+    // Subtitle Edit 4 used Ctrl+Up/Down/Home/End for the four move commands on both the rules
+    // and the groups list (#13523). Ctrl+Up/Down is Mission Control on macOS, so show Cmd there.
+    private static readonly KeyModifiers MoveModifier = OperatingSystem.IsMacOS() ? KeyModifiers.Meta : KeyModifiers.Control;
+    private static readonly KeyGesture MoveUpGesture = new(Key.Up, MoveModifier);
+    private static readonly KeyGesture MoveDownGesture = new(Key.Down, MoveModifier);
+    private static readonly KeyGesture MoveToTopGesture = new(Key.Home, MoveModifier);
+    private static readonly KeyGesture MoveToBottomGesture = new(Key.End, MoveModifier);
+
     public MultipleReplaceViewModel(IWindowService windowService, IFileHelper fileHelper)
     {
         _windowService = windowService;
@@ -331,13 +339,29 @@ public partial class MultipleReplaceViewModel : ObservableObject
                 {
                     Header = Se.Language.General.MoveUp,
                     Command = CategoryMoveUpCommand,
-                    CommandParameter = node
+                    CommandParameter = node,
+                    InputGesture = MoveUpGesture,
                 },
                 new MenuItem
                 {
                     Header = Se.Language.General.MoveDown,
                     Command = CategoryMoveDownCommand,
-                    CommandParameter = node
+                    CommandParameter = node,
+                    InputGesture = MoveDownGesture,
+                },
+                new MenuItem
+                {
+                    Header = Se.Language.General.MoveToTop,
+                    Command = CategoryMoveToTopCommand,
+                    CommandParameter = node,
+                    InputGesture = MoveToTopGesture,
+                },
+                new MenuItem
+                {
+                    Header = Se.Language.General.MoveToBottom,
+                    Command = CategoryMoveToBottomCommand,
+                    CommandParameter = node,
+                    InputGesture = MoveToBottomGesture,
                 },
                 new Separator(),
                 new MenuItem
@@ -651,36 +675,25 @@ public partial class MultipleReplaceViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void CategoryMoveUp(RuleTreeNode? node)
-    {
-        if (node == null)
-        {
-            return;
-        }
-
-        var index = Nodes.IndexOf(node);
-        if (index > 0)
-        {
-            Nodes.Move(index, index - 1);
-            _dirty = true;
-        }
-    }
+    private void CategoryMoveUp(RuleTreeNode? node) => MoveCategory(node, ListMoveDirection.Up);
 
     [RelayCommand]
-    private void CategoryMoveDown(RuleTreeNode? node)
+    private void CategoryMoveDown(RuleTreeNode? node) => MoveCategory(node, ListMoveDirection.Down);
+
+    [RelayCommand]
+    private void CategoryMoveToTop(RuleTreeNode? node) => MoveCategory(node, ListMoveDirection.Top);
+
+    [RelayCommand]
+    private void CategoryMoveToBottom(RuleTreeNode? node) => MoveCategory(node, ListMoveDirection.Bottom);
+
+    private void MoveCategory(RuleTreeNode? node, ListMoveDirection direction)
     {
-        if (node == null)
+        if (node == null || !node.IsCategory)
         {
             return;
         }
 
-        var index = Nodes.IndexOf(node);
-        if (index < Nodes.Count - 1)
-        {
-            Nodes.Move(index, index + 1);
-        }
-
-        _dirty = true;
+        MoveNodeIn(Nodes, node, direction);
     }
 
     [RelayCommand]
@@ -725,13 +738,29 @@ public partial class MultipleReplaceViewModel : ObservableObject
                 {
                     Header = Se.Language.General.MoveUp,
                     Command = NodeMoveUpCommand,
-                    CommandParameter = node
+                    CommandParameter = node,
+                    InputGesture = MoveUpGesture,
                 },
                 new MenuItem
                 {
                     Header = Se.Language.General.MoveDown,
                     Command = NodeMoveDownCommand,
-                    CommandParameter = node
+                    CommandParameter = node,
+                    InputGesture = MoveDownGesture,
+                },
+                new MenuItem
+                {
+                    Header = Se.Language.General.MoveToTop,
+                    Command = NodeMoveToTopCommand,
+                    CommandParameter = node,
+                    InputGesture = MoveToTopGesture,
+                },
+                new MenuItem
+                {
+                    Header = Se.Language.General.MoveToBottom,
+                    Command = NodeMoveToBottomCommand,
+                    CommandParameter = node,
+                    InputGesture = MoveToBottomGesture,
                 },
                 new Separator(),
                 new MenuItem
@@ -883,37 +912,58 @@ public partial class MultipleReplaceViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void NodeMoveUp(RuleTreeNode? node)
-    {
-        if (node == null || node.Parent == null || node.Parent.SubNodes == null)
-        {
-            return;
-        }
-
-        var nodes = node.Parent.SubNodes;
-        var index = nodes.IndexOf(node);
-        if (index > 0)
-        {
-            nodes.Move(index, index - 1);
-            _dirty = true;
-        }
-    }
+    private void NodeMoveUp(RuleTreeNode? node) => MoveRule(node, ListMoveDirection.Up);
 
     [RelayCommand]
-    private void NodeMoveDown(RuleTreeNode? node)
+    private void NodeMoveDown(RuleTreeNode? node) => MoveRule(node, ListMoveDirection.Down);
+
+    [RelayCommand]
+    private void NodeMoveToTop(RuleTreeNode? node) => MoveRule(node, ListMoveDirection.Top);
+
+    [RelayCommand]
+    private void NodeMoveToBottom(RuleTreeNode? node) => MoveRule(node, ListMoveDirection.Bottom);
+
+    private void MoveRule(RuleTreeNode? node, ListMoveDirection direction)
     {
-        if (node == null || node.Parent == null || node.Parent.SubNodes == null)
+        if (node == null || node.IsCategory || node.Parent?.SubNodes == null)
         {
             return;
         }
 
-        var nodes = node.Parent.SubNodes;
+        MoveNodeIn(node.Parent.SubNodes, node, direction);
+    }
+
+    /// <summary>
+    /// Reorders a single node inside the collection it lives in and keeps it selected and
+    /// focused afterwards - <see cref="ObservableCollection{T}.Move"/> rebuilds the tree
+    /// container, which otherwise drops both.
+    /// </summary>
+    private void MoveNodeIn(ObservableCollection<RuleTreeNode> nodes, RuleTreeNode node, ListMoveDirection direction)
+    {
         var index = nodes.IndexOf(node);
-        if (index < nodes.Count - 1)
+        if (index < 0)
         {
-            nodes.Move(index, index + 1);
-            _dirty = true;
+            return;
         }
+
+        ListReorder.Move(nodes, new[] { index }, direction);
+
+        if (nodes.IndexOf(node) == index)
+        {
+            return; // already at the edge - nothing moved, so the rules are unchanged
+        }
+
+        _dirty = true;
+        SelectedNode = node;
+        Dispatcher.UIThread.Post(() =>
+        {
+            SelectedNode = node;
+            if (RulesTreeView.ContainerFromItem(node) is TreeViewItem container)
+            {
+                container.BringIntoView();
+                container.Focus(NavigationMethod.Directional);
+            }
+        }, DispatcherPriority.Input);
     }
 
     internal void OnKeyDown(object? sender, KeyEventArgs e)
@@ -1020,6 +1070,49 @@ public partial class MultipleReplaceViewModel : ObservableObject
                 }
             }, DispatcherPriority.Input);
         }, DispatcherPriority.Background);
+    }
+
+    /// <summary>
+    /// Ctrl/Cmd + Up/Down/Home/End reorders the selected rule or category. This has to tunnel:
+    /// the list box inside the tree view handles Ctrl+Arrow itself (move focus, keep selection),
+    /// so a bubbling handler never sees it.
+    /// </summary>
+    internal void RulesTreeView_PreviewKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.KeyModifiers is not (KeyModifiers.Control or KeyModifiers.Meta))
+        {
+            return;
+        }
+
+        var direction = e.Key switch
+        {
+            Key.Up => (ListMoveDirection?)ListMoveDirection.Up,
+            Key.Down => ListMoveDirection.Down,
+            Key.Home => ListMoveDirection.Top,
+            Key.End => ListMoveDirection.Bottom,
+            _ => null,
+        };
+
+        if (direction == null)
+        {
+            return;
+        }
+
+        var node = SelectedNode;
+        if (node == null)
+        {
+            return;
+        }
+
+        e.Handled = true;
+        if (node.IsCategory)
+        {
+            MoveCategory(node, direction.Value);
+        }
+        else
+        {
+            MoveRule(node, direction.Value);
+        }
     }
 
     internal async void RulesTreeView_KeyDown(object? sender, KeyEventArgs e)

--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceWindow.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceWindow.cs
@@ -279,6 +279,7 @@ public class MultipleReplaceWindow : Window
         vm.RulesTreeView = treeView;
         treeView.SelectionChanged += vm.RulesTreeView_SelectionChanged;
         treeView.KeyDown += vm.RulesTreeView_KeyDown;
+        treeView.AddHandler(InputElement.KeyDownEvent, vm.RulesTreeView_PreviewKeyDown, RoutingStrategies.Tunnel);
         treeView.DoubleTapped += (_, e) => vm.TreeViewDoubleTapped(e);
         treeView.AddHandler(InputElement.PointerReleasedEvent, (_, e) =>
         {

--- a/tests/UI/Features/Edit/MultipleReplaceMoveTests.cs
+++ b/tests/UI/Features/Edit/MultipleReplaceMoveTests.cs
@@ -1,0 +1,283 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Features.Edit.MultipleReplace;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Linq;
+
+namespace UITests.Features.Edit;
+
+/// <summary>
+/// Reordering on the Multiple replace rule tree. Subtitle Edit 4 had move up / down / to top /
+/// to bottom on both the rules and the groups context menu, all four bound to Ctrl+Up / Down /
+/// Home / End; SE 5 shipped with only up and down and no shortcuts at all (#13523).
+/// The order is data - it decides which rule gets to a line first - so this is real reordering.
+/// </summary>
+public class MultipleReplaceMoveTests
+{
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    // Three categories of three rules each, named "c1"/"c1r1" and so on, so a wrong move shows up
+    // as a readable sequence rather than an index.
+    private static MultipleReplaceViewModel BuildViewModel()
+    {
+        var vm = new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        vm.Nodes.Clear();
+
+        for (var c = 1; c <= 3; c++)
+        {
+            var category = new RuleTreeNode(true) { CategoryName = $"c{c}" };
+            for (var r = 1; r <= 3; r++)
+            {
+                category.SubNodes!.Add(new RuleTreeNode(false) { Find = $"c{c}r{r}", Parent = category });
+            }
+
+            vm.Nodes.Add(category);
+        }
+
+        return vm;
+    }
+
+    private static string Categories(MultipleReplaceViewModel vm) =>
+        string.Join(",", vm.Nodes.Select(n => n.CategoryName));
+
+    private static string Rules(RuleTreeNode category) =>
+        string.Join(",", category.SubNodes!.Select(n => n.Find));
+
+    private static bool SendKey(MultipleReplaceViewModel vm, Key key, KeyModifiers modifiers)
+    {
+        var e = new KeyEventArgs { Key = key, KeyModifiers = modifiers, RoutedEvent = InputElement.KeyDownEvent };
+        vm.RulesTreeView_PreviewKeyDown(null, e);
+        return e.Handled;
+    }
+
+    [AvaloniaTheory]
+    [InlineData(0, "MoveDown", "c2,c1,c3")]
+    [InlineData(2, "MoveUp", "c1,c3,c2")]
+    [InlineData(2, "MoveToTop", "c3,c1,c2")]
+    [InlineData(0, "MoveToBottom", "c2,c3,c1")]
+    public void CategoryMove_ReordersCategories(int index, string command, string expected)
+    {
+        var vm = BuildViewModel();
+        var category = vm.Nodes[index];
+
+        switch (command)
+        {
+            case "MoveUp": vm.CategoryMoveUpCommand.Execute(category); break;
+            case "MoveDown": vm.CategoryMoveDownCommand.Execute(category); break;
+            case "MoveToTop": vm.CategoryMoveToTopCommand.Execute(category); break;
+            case "MoveToBottom": vm.CategoryMoveToBottomCommand.Execute(category); break;
+        }
+
+        Assert.Equal(expected, Categories(vm));
+    }
+
+    [AvaloniaTheory]
+    [InlineData(0, "MoveDown", "c2r2,c2r1,c2r3")]
+    [InlineData(2, "MoveUp", "c2r1,c2r3,c2r2")]
+    [InlineData(2, "MoveToTop", "c2r3,c2r1,c2r2")]
+    [InlineData(0, "MoveToBottom", "c2r2,c2r3,c2r1")]
+    public void RuleMove_ReordersRulesInsideTheirCategory(int index, string command, string expected)
+    {
+        var vm = BuildViewModel();
+        var category = vm.Nodes[1];
+        var rule = category.SubNodes![index];
+
+        switch (command)
+        {
+            case "MoveUp": vm.NodeMoveUpCommand.Execute(rule); break;
+            case "MoveDown": vm.NodeMoveDownCommand.Execute(rule); break;
+            case "MoveToTop": vm.NodeMoveToTopCommand.Execute(rule); break;
+            case "MoveToBottom": vm.NodeMoveToBottomCommand.Execute(rule); break;
+        }
+
+        Assert.Equal(expected, Rules(category));
+        Assert.Equal("c1r1,c1r2,c1r3", Rules(vm.Nodes[0]));
+        Assert.Equal("c3r1,c3r2,c3r3", Rules(vm.Nodes[2]));
+    }
+
+    // A rule at the top of its category has nowhere to go - it must not fall into the category
+    // above it, which is what a naive "move within the flattened tree" would do.
+    [AvaloniaFact]
+    public void RuleMoveUp_AtTopOfCategory_StaysPut()
+    {
+        var vm = BuildViewModel();
+        var category = vm.Nodes[1];
+
+        vm.NodeMoveUpCommand.Execute(category.SubNodes![0]);
+        vm.NodeMoveToTopCommand.Execute(category.SubNodes[0]);
+
+        Assert.Equal("c2r1,c2r2,c2r3", Rules(category));
+        Assert.Equal("c1r1,c1r2,c1r3", Rules(vm.Nodes[0]));
+        Assert.Equal(3, category.SubNodes.Count);
+    }
+
+    [AvaloniaFact]
+    public void CategoryMoveDown_AtBottom_StaysPut()
+    {
+        var vm = BuildViewModel();
+
+        vm.CategoryMoveDownCommand.Execute(vm.Nodes[2]);
+        vm.CategoryMoveToBottomCommand.Execute(vm.Nodes[2]);
+
+        Assert.Equal("c1,c2,c3", Categories(vm));
+    }
+
+    // A category node handed to a rule command (and the other way round) must be ignored rather
+    // than reordered against the wrong collection.
+    [AvaloniaFact]
+    public void MoveCommands_IgnoreNodesOfTheWrongKind()
+    {
+        var vm = BuildViewModel();
+
+        vm.NodeMoveToBottomCommand.Execute(vm.Nodes[0]);
+        vm.CategoryMoveToBottomCommand.Execute(vm.Nodes[0].SubNodes![0]);
+
+        Assert.Equal("c1,c2,c3", Categories(vm));
+        Assert.Equal("c1r1,c1r2,c1r3", Rules(vm.Nodes[0]));
+    }
+
+    [AvaloniaTheory]
+    [InlineData(Key.Down, "c2r2,c2r1,c2r3")]
+    [InlineData(Key.Home, "c2r1,c2r2,c2r3")]
+    [InlineData(Key.End, "c2r2,c2r3,c2r1")]
+    public void CtrlKey_MovesSelectedRule(Key key, string expected)
+    {
+        var vm = BuildViewModel();
+        var category = vm.Nodes[1];
+        vm.SelectedNode = category.SubNodes![0];
+
+        Assert.True(SendKey(vm, key, KeyModifiers.Control));
+        Assert.Equal(expected, Rules(category));
+    }
+
+    // Ctrl+Up/Down is Mission Control on macOS, so the menus show Cmd there - both have to work.
+    [AvaloniaFact]
+    public void CmdKey_MovesSelectedRule()
+    {
+        var vm = BuildViewModel();
+        var category = vm.Nodes[1];
+        vm.SelectedNode = category.SubNodes![2];
+
+        Assert.True(SendKey(vm, Key.Home, KeyModifiers.Meta));
+        Assert.Equal("c2r3,c2r1,c2r2", Rules(category));
+    }
+
+    [AvaloniaFact]
+    public void CtrlKey_MovesSelectedCategory()
+    {
+        var vm = BuildViewModel();
+        vm.SelectedNode = vm.Nodes[0];
+
+        Assert.True(SendKey(vm, Key.End, KeyModifiers.Control));
+        Assert.Equal("c2,c3,c1", Categories(vm));
+    }
+
+    // Plain arrows are the tree's own navigation, and Ctrl+Shift+Arrow is not a move either -
+    // the handler tunnels, so anything it wrongly claims is lost to the tree view.
+    [AvaloniaTheory]
+    [InlineData(Key.Down, KeyModifiers.None)]
+    [InlineData(Key.Home, KeyModifiers.None)]
+    [InlineData(Key.End, KeyModifiers.Control | KeyModifiers.Shift)]
+    [InlineData(Key.PageDown, KeyModifiers.Control)]
+    public void OtherKeys_AreLeftToTheTreeView(Key key, KeyModifiers modifiers)
+    {
+        var vm = BuildViewModel();
+        var category = vm.Nodes[1];
+        vm.SelectedNode = category.SubNodes![0];
+
+        Assert.False(SendKey(vm, key, modifiers));
+        Assert.Equal("c2r1,c2r2,c2r3", Rules(category));
+        Assert.Equal("c1,c2,c3", Categories(vm));
+    }
+
+    [AvaloniaFact]
+    public void CtrlKey_WithNothingSelected_IsIgnored()
+    {
+        var vm = BuildViewModel();
+        vm.SelectedNode = null;
+
+        Assert.False(SendKey(vm, Key.End, KeyModifiers.Control));
+        Assert.Equal("c1,c2,c3", Categories(vm));
+    }
+
+    // The handler is only reached because the window registers it as a tunnel handler - the list
+    // box inside the tree view handles Ctrl+Arrow itself, so a bubbling registration silently
+    // does nothing. Raise the event on the real tree to pin the registration, not just the method.
+    [AvaloniaFact]
+    public void CtrlHome_IsHandledThroughTheTreeViewsTunnelRoute()
+    {
+        var vm = BuildViewModel();
+        var window = new MultipleReplaceWindow(vm);
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var category = vm.Nodes[1];
+            vm.SelectedNode = category.SubNodes![2];
+
+            var e = new KeyEventArgs
+            {
+                Key = Key.Home,
+                KeyModifiers = KeyModifiers.Control,
+                RoutedEvent = InputElement.KeyDownEvent,
+            };
+            vm.RulesTreeView.RaiseEvent(e);
+
+            Assert.True(e.Handled);
+            Assert.Equal("c2r3,c2r1,c2r2", Rules(category));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    // The commands existing is not enough - what regressed in SE 5 was the menu wiring, so pin
+    // that both context menus offer all four moves.
+    [AvaloniaTheory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ContextMenu_OffersAllFourMoves(bool category)
+    {
+        var vm = BuildViewModel();
+        var window = new MultipleReplaceWindow(vm);
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var node = category ? vm.Nodes[1] : vm.Nodes[1].SubNodes![0];
+            if (category)
+            {
+                vm.NodeCategoryOpenContextMenuCommand.Execute(node);
+            }
+            else
+            {
+                vm.NodeOpenContextMenuCommand.Execute(node);
+            }
+
+            var headers = vm.RulesTreeView.ContextMenu!.Items
+                .OfType<MenuItem>()
+                .Select(m => m.Header as string)
+                .ToList();
+
+            Assert.Contains(Se.Language.General.MoveUp, headers);
+            Assert.Contains(Se.Language.General.MoveDown, headers);
+            Assert.Contains(Se.Language.General.MoveToTop, headers);
+            Assert.Contains(Se.Language.General.MoveToBottom, headers);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #13523

Subtitle Edit 4's Multiple replace had **move up / move down / move to top / move to bottom** on both the rules and the groups context menu, each bound to <kbd>Ctrl</kbd>+<kbd>Up</kbd> / <kbd>Down</kbd> / <kbd>Home</kbd> / <kbd>End</kbd>. SE 5 shipped with only move up and move down, and with no keyboard shortcuts at all.

## Changes

- **Move to top / Move to bottom** added to both the rule and the category context menu (and the "⋮" button menus), in the SE 4 order.
- **Keyboard shortcuts** for all four, shown in the menus: <kbd>Ctrl</kbd>+<kbd>Up</kbd>/<kbd>Down</kbd>/<kbd>Home</kbd>/<kbd>End</kbd> — <kbd>Cmd</kbd> on macOS, where <kbd>Ctrl</kbd>+arrow is Mission Control. Both modifiers are accepted at runtime.
  The handler has to tunnel: the list box inside the tree view handles <kbd>Ctrl</kbd>+arrow itself (move focus, keep selection), so a bubbling handler never sees it.
- Reordering now goes through the shared, unit-tested `ListReorder` helper instead of hand-rolled index math, and re-selects + re-focuses the moved node — `ObservableCollection.Move` rebuilds the tree container and drops both.
- Drive-by: "move down" on the last category no longer marks the rules dirty; it did so unconditionally, even when nothing moved.

No language strings were added — `General.MoveToTop` / `MoveToBottom` already exist and are translated (they are used by the ASSA/SSA styles, WebVTT styles and join-subtitles windows).

## Tests

25 new tests in `tests/UI/Features/Edit/MultipleReplaceMoveTests.cs`: reordering of categories and of rules for all four directions, edge no-ops, rules not escaping their category, the four shortcuts (Ctrl and Cmd), keys that must be left to the tree view, plus two wiring canaries — that both context menus really offer all four entries, and that <kbd>Ctrl</kbd>+<kbd>Home</kbd> is handled through the tree view's tunnel route. Both canaries were verified to fail without the corresponding wiring.

Full UI suite green: 2439 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)