### PR TITLE
Show subtitle file name in dialog title bars

### DIFF
--- a/src/ui/Features/Edit/ModifySelection/ModifySelectionWindow.cs
+++ b/src/ui/Features/Edit/ModifySelection/ModifySelectionWindow.cs
@@ -17,7 +17,7 @@ public class ModifySelectionWindow : Window
     public ModifySelectionWindow(ModifySelectionViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Edit.ModifySelection.Title;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Edit.ModifySelection.Title);
         CanResize = true;
         Width = 900;
         Height = 700;

--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceWindow.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceWindow.cs
@@ -20,7 +20,7 @@ public class MultipleReplaceWindow : Window
     public MultipleReplaceWindow(MultipleReplaceViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.General.MultipleReplace;
+        Title = UiUtil.MakeWindowTitle(Se.Language.General.MultipleReplace);
         Width = 1110;
         Height = 740;
         MinWidth = 850;

--- a/src/ui/Features/Edit/ShowHistory/ShowHistoryWindow.cs
+++ b/src/ui/Features/Edit/ShowHistory/ShowHistoryWindow.cs
@@ -12,7 +12,7 @@ public class ShowHistoryWindow : Window
     public ShowHistoryWindow(ShowHistoryViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Edit.ShowHistory;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Edit.ShowHistory);
         Width = 810;
         Height = 640;
         CanResize = true;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -721,6 +721,9 @@ public partial class MainViewModel :
         _ytDlpDownloadService = ytDlpDownloadService;
         _updateCheckService = updateCheckService;
 
+        // Let dialogs show the current subtitle file name in their title bar - see UiUtil.MakeWindowTitle.
+        UiUtil.CurrentSubtitleFileNameProvider = () => _subtitleFileName;
+
         _loading = true;
         EditText = string.Empty;
         EditTextCharactersPerSecond = string.Empty;

--- a/src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs
+++ b/src/ui/Features/Shared/PickMp4Track/PickMp4TrackViewModel.cs
@@ -58,7 +58,7 @@ public partial class PickMp4TrackViewModel : ObservableObject
     {
         _mp4Tracks = mp4Tracks;
         _fileName = fileName;
-        WindowTitle = $"Pick MP4 track - {fileName}";
+        WindowTitle = string.Format(Se.Language.File.PickMp4TrackX, fileName);
         foreach (var track in _mp4Tracks)
         {
             // A trak box without an mdia child carries no media information at all;
@@ -102,7 +102,7 @@ public partial class PickMp4TrackViewModel : ObservableObject
     public void Initialize(List<Mp4FragmentedSubtitleTrack> fragmentedTracks, string fileName)
     {
         _fileName = fileName;
-        WindowTitle = $"Pick MP4 track - {fileName}";
+        WindowTitle = string.Format(Se.Language.File.PickMp4TrackX, fileName);
         foreach (var track in fragmentedTracks)
         {
             Tracks.Add(new Mp4TrackInfoDisplay

--- a/src/ui/Features/SpellCheck/FindDoubleLines/FindDoubleLinesWindow.cs
+++ b/src/ui/Features/SpellCheck/FindDoubleLines/FindDoubleLinesWindow.cs
@@ -14,7 +14,7 @@ public class FindDoubleLinesWindow : Window
     public FindDoubleLinesWindow(FindDoubleLinesViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.General.DoubleLines;
+        Title = UiUtil.MakeWindowTitle(Se.Language.General.DoubleLines);
         CanResize = true;
         Width = 600;
         Height = 700;

--- a/src/ui/Features/SpellCheck/FindDoubleWords/FindDoubleWordsWindow.cs
+++ b/src/ui/Features/SpellCheck/FindDoubleWords/FindDoubleWordsWindow.cs
@@ -14,7 +14,7 @@ public class FindDoubleWordsWindow : Window
     public FindDoubleWordsWindow(FindDoubleWordsViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.General.DoubleWords;
+        Title = UiUtil.MakeWindowTitle(Se.Language.General.DoubleWords);
         CanResize = true;
         Width = 600;
         Height = 700;

--- a/src/ui/Features/SpellCheck/SpellCheckWindow.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckWindow.cs
@@ -14,7 +14,7 @@ public class SpellCheckWindow : Window
     public SpellCheckWindow(SpellCheckViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.SpellCheck.SpellCheck;
+        Title = UiUtil.MakeWindowTitle(Se.Language.SpellCheck.SpellCheck);
         SizeToContent = SizeToContent.Height;
         Width = 700;
         CanResize = false;

--- a/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesWindow.cs
+++ b/src/ui/Features/Sync/AdjustAllTimes/AdjustAllTimesWindow.cs
@@ -14,7 +14,7 @@ public class AdjustAllTimesWindow : Window
     public AdjustAllTimesWindow(AdjustAllTimesViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Sync.AdjustAllTimes;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Sync.AdjustAllTimes);
         SizeToContent = SizeToContent.WidthAndHeight;
         CanResize = false;
         vm.Window = this;

--- a/src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateWindow.cs
+++ b/src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateWindow.cs
@@ -10,7 +10,7 @@ public class ChangeFrameRateWindow : Window
     public ChangeFrameRateWindow(ChangeFrameRateViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.General.ChangeFrameRate;
+        Title = UiUtil.MakeWindowTitle(Se.Language.General.ChangeFrameRate);
         SizeToContent = SizeToContent.WidthAndHeight;
         CanResize = false;
         vm.Window = this;

--- a/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedWindow.cs
+++ b/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedWindow.cs
@@ -14,7 +14,7 @@ public class ChangeSpeedWindow : Window
     public ChangeSpeedWindow(ChangeSpeedViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.General.ChangeSpeed;
+        Title = UiUtil.MakeWindowTitle(Se.Language.General.ChangeSpeed);
         SizeToContent = SizeToContent.WidthAndHeight;
         CanResize = false;
         vm.Window = this;

--- a/src/ui/Features/Sync/PointSync/PointSyncWindow.cs
+++ b/src/ui/Features/Sync/PointSync/PointSyncWindow.cs
@@ -19,7 +19,7 @@ public class PointSyncWindow : Window
     {
         vm.Window = this;
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Sync.PointSync;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Sync.PointSync);
         Width = 800;
         Height = 600;
         MinWidth = 600;

--- a/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherWindow.cs
+++ b/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherWindow.cs
@@ -19,7 +19,7 @@ public class PointSyncViaOtherWindow : Window
     {
         vm.Window = this;
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Sync.PointSyncViaOther;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Sync.PointSyncViaOther);
         Width = 1100;
         Height = 600;
         MinWidth = 800;

--- a/src/ui/Features/Sync/VisualSync/VisualSyncWindow.cs
+++ b/src/ui/Features/Sync/VisualSync/VisualSyncWindow.cs
@@ -13,7 +13,7 @@ public class VisualSyncWindow : Window
     public VisualSyncWindow(VisualSyncViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Sync.VisualSync;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Sync.VisualSync);
         CanResize = true;
         Width = 1100;
         Height = 700;

--- a/src/ui/Features/Tools/AdjustDuration/AdjustDurationWindow.cs
+++ b/src/ui/Features/Tools/AdjustDuration/AdjustDurationWindow.cs
@@ -17,7 +17,7 @@ public class AdjustDurationWindow : Window
     public AdjustDurationWindow(AdjustDurationViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Tools.AdjustDurations.Title;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Tools.AdjustDurations.Title);
         SizeToContent = SizeToContent.WidthAndHeight;
         CanResize = false;
         vm.Window = this;

--- a/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
@@ -18,7 +18,7 @@ public class AiReviewWindow : Window
     public AiReviewWindow(AiReviewViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Tools.AiReview.Title;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Tools.AiReview.Title);
         Width = 1024;
         Height = 720;
         MinWidth = 800;

--- a/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsWindow.cs
+++ b/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsWindow.cs
@@ -23,7 +23,7 @@ public class ApplyDurationLimitsWindow : Window
     public ApplyDurationLimitsWindow(ApplyDurationLimitsViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Tools.ApplyDurationLimits.Title;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Tools.ApplyDurationLimits.Title);
         CanResize = true;
         Width = 900;
         Height = 800;

--- a/src/ui/Features/Tools/ApplyMinGap/ApplyMinGapWindow.cs
+++ b/src/ui/Features/Tools/ApplyMinGap/ApplyMinGapWindow.cs
@@ -15,7 +15,7 @@ public class ApplyMinGapWindow : Window
     public ApplyMinGapWindow(ApplyMinGapViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Tools.ApplyMinGaps.Title;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Tools.ApplyMinGaps.Title);
         CanResize = true;
         Width = 1000;
         Height = 800;

--- a/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesWindow.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesWindow.cs
@@ -14,7 +14,7 @@ public class BeautifyTimeCodesWindow : Window
     public BeautifyTimeCodesWindow(BeautifyTimeCodesViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Tools.BeautifyTimeCodes.Title;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Tools.BeautifyTimeCodes.Title);
         CanResize = true;
         Width = 1100;
         Height = 600;

--- a/src/ui/Features/Tools/BridgeGaps/BridgeGapsWindow.cs
+++ b/src/ui/Features/Tools/BridgeGaps/BridgeGapsWindow.cs
@@ -15,7 +15,7 @@ public class BridgeGapsWindow : Window
     public BridgeGapsWindow(BridgeGapsViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.General.BridgeGaps;
+        Title = UiUtil.MakeWindowTitle(Se.Language.General.BridgeGaps);
         CanResize = true;
         Width = 1000;
         Height = 800;

--- a/src/ui/Features/Tools/ChangeCasing/ChangeCasingWindow.cs
+++ b/src/ui/Features/Tools/ChangeCasing/ChangeCasingWindow.cs
@@ -12,7 +12,7 @@ public class ChangeCasingWindow : Window
     public ChangeCasingWindow(ChangeCasingViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.General.ChangeCasing;
+        Title = UiUtil.MakeWindowTitle(Se.Language.General.ChangeCasing);
         SizeToContent = SizeToContent.WidthAndHeight;
         MinWidth = 300;
         CanResize = false;

--- a/src/ui/Features/Tools/ChangeFormatting/ChangeFormattingWindow.cs
+++ b/src/ui/Features/Tools/ChangeFormatting/ChangeFormattingWindow.cs
@@ -15,7 +15,7 @@ public class ChangeFormattingWindow : Window
     public ChangeFormattingWindow(ChangeFormattingViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.General.ChangeFormatting;
+        Title = UiUtil.MakeWindowTitle(Se.Language.General.ChangeFormatting);
         CanResize = true;
         Width = 1000;
         Height = 800;

--- a/src/ui/Features/Tools/ConvertActors/ConvertActorsWindow.cs
+++ b/src/ui/Features/Tools/ConvertActors/ConvertActorsWindow.cs
@@ -18,7 +18,7 @@ public class ConvertActorsWindow : Window
     public ConvertActorsWindow(ConvertActorsViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Tools.ConvertActors.Title;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Tools.ConvertActors.Title);
         CanResize = true;
         Width = 1000;
         Height = 800;

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -26,7 +26,7 @@ public class FixCommonErrorsWindow : Window
     public FixCommonErrorsWindow(FixCommonErrorsViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.General.FixCommonErrors;
+        Title = UiUtil.MakeWindowTitle(Se.Language.General.FixCommonErrors);
         Width = 1024;
         Height = 720;
         MinWidth = 800;

--- a/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsWindow.cs
@@ -22,7 +22,7 @@ public class FixNetflixErrorsWindow : Window
     public FixNetflixErrorsWindow(FixNetflixErrorsViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Tools.NetflixCheckAndFix.Title;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Tools.NetflixCheckAndFix.Title);
         Width = 1100;
         Height = 680;
         MinWidth = 900;

--- a/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
+++ b/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
@@ -21,7 +21,7 @@ public class MergeContinuationLinesWindow : Window
     public MergeContinuationLinesWindow(MergeContinuationLinesViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Tools.MergeContinuationLines.Title;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Tools.MergeContinuationLines.Title);
         CanResize = true;
         Width = 1000;
         Height = 700;

--- a/src/ui/Features/Tools/MergeShortLines/MergeShortLinesWindow.cs
+++ b/src/ui/Features/Tools/MergeShortLines/MergeShortLinesWindow.cs
@@ -16,7 +16,7 @@ public class MergeShortLinesWindow : Window
     public MergeShortLinesWindow(MergeShortLinesViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Tools.MergeShortLines.Title;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Tools.MergeShortLines.Title);
         CanResize = true;
         Width = 900;
         Height = 800;

--- a/src/ui/Features/Tools/MergeSubtitlesWithSameText/MergeSameTextWindow.cs
+++ b/src/ui/Features/Tools/MergeSubtitlesWithSameText/MergeSameTextWindow.cs
@@ -20,7 +20,7 @@ public class MergeSameTextWindow : Window
     public MergeSameTextWindow(MergeSameTextViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.General.MergeLinesWithSameText;
+        Title = UiUtil.MakeWindowTitle(Se.Language.General.MergeLinesWithSameText);
         CanResize = true;
         Width = 900;
         Height = 800;

--- a/src/ui/Features/Tools/MergeSubtitlesWithSameTimeCodes/MergeSameTimeCodesWindow.cs
+++ b/src/ui/Features/Tools/MergeSubtitlesWithSameTimeCodes/MergeSameTimeCodesWindow.cs
@@ -23,7 +23,7 @@ public class MergeSameTimeCodesWindow : Window
     public MergeSameTimeCodesWindow(MergeSameTimeCodesViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.General.MergeLinesWithSameTimeCodes;
+        Title = UiUtil.MakeWindowTitle(Se.Language.General.MergeLinesWithSameTimeCodes);
         CanResize = true;
         Width = 800;
         Height = 750;

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
@@ -26,7 +26,7 @@ public class RemoveTextForHearingImpairedWindow : Window
     public RemoveTextForHearingImpairedWindow(RemoveTextForHearingImpairedViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.General.RemoveTextForHearingImpaired;
+        Title = UiUtil.MakeWindowTitle(Se.Language.General.RemoveTextForHearingImpaired);
         Width = 910;
         Height = 640;
         MinWidth = 800;

--- a/src/ui/Features/Tools/RemoveUnicodeCharacters/RemoveUnicodeCharactersWindow.cs
+++ b/src/ui/Features/Tools/RemoveUnicodeCharacters/RemoveUnicodeCharactersWindow.cs
@@ -16,7 +16,7 @@ public class RemoveUnicodeCharactersWindow : Window
     public RemoveUnicodeCharactersWindow(RemoveUnicodeCharactersViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Tools.RemoveUnicodeCharacters.Title;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Tools.RemoveUnicodeCharacters.Title);
         CanResize = true;
         Width = 800;
         Height = 600;

--- a/src/ui/Features/Tools/Renumber/RenumberWindow.cs
+++ b/src/ui/Features/Tools/Renumber/RenumberWindow.cs
@@ -10,7 +10,7 @@ public class RenumberWindow : Window
     public RenumberWindow(RenumberViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Tools.Renumber.Title;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Tools.Renumber.Title);
         CanResize = false;
         Width = 350;
         Height = 180;

--- a/src/ui/Features/Tools/SortBy/SortByWindow.cs
+++ b/src/ui/Features/Tools/SortBy/SortByWindow.cs
@@ -19,7 +19,7 @@ public class SortByWindow : Window
     public SortByWindow(SortByViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Tools.SortBy.Title;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Tools.SortBy.Title);
         CanResize = true;
         Width = 1200;
         Height = 800;

--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesWindow.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesWindow.cs
@@ -19,7 +19,7 @@ public class SplitBreakLongLinesWindow : Window
     public SplitBreakLongLinesWindow(SplitBreakLongLinesViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Tools.SplitBreakLongLines.Title;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Tools.SplitBreakLongLines.Title);
         CanResize = true;
         Width = 900;
         Height = 800;

--- a/src/ui/Features/Tools/SplitSubtitle/SplitSubtitleWindow.cs
+++ b/src/ui/Features/Tools/SplitSubtitle/SplitSubtitleWindow.cs
@@ -18,7 +18,7 @@ public class SplitSubtitleWindow : Window
     public SplitSubtitleWindow(SplitSubtitleViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Tools.SplitSubtitle.Title;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Tools.SplitSubtitle.Title);
         CanResize = true;
         Width = 900;
         Height = 700;

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -29,7 +29,7 @@ public class AutoTranslateWindow : Window
     public AutoTranslateWindow(AutoTranslateViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.General.AutoTranslate;
+        Title = UiUtil.MakeWindowTitle(Se.Language.General.AutoTranslate);
         Width = 1050;
         MinWidth = 800;
         Height = 780;

--- a/src/ui/Features/Translate/CopyPasteTranslateWindow.cs
+++ b/src/ui/Features/Translate/CopyPasteTranslateWindow.cs
@@ -14,7 +14,7 @@ public class CopyPasteTranslateWindow : Window
     public CopyPasteTranslateWindow(CopyPasteTranslateViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Translate.TranslateViaCopyPaste;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Translate.TranslateViaCopyPaste);
         CanResize = true;
         Width = 900;
         Height = 800;

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -27,7 +27,7 @@ public class TextToSpeechWindow : Window
     public TextToSpeechWindow(TextToSpeechViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.Video.TextToSpeech.Title;
+        Title = UiUtil.MakeWindowTitle(Se.Language.Video.TextToSpeech.Title);
         SizeToContent = SizeToContent.WidthAndHeight;
         CanResize = false;
 

--- a/src/ui/Logic/Config/Language/File/LanguageFile.cs
+++ b/src/ui/Logic/Config/Language/File/LanguageFile.cs
@@ -30,6 +30,7 @@ public class LanguageFile
     public string SaveCompareHtmlTitle { get; set; }
     public string PickMatroskaTrackX { get; set; }
     public string PickTransportStreamTrackX { get; set; }
+    public string PickMp4TrackX { get; set; }
     public string RosettaProperties { get; set; }
     public string RosettaFontSize { get; set; }
     public string XProperties { get; set; }
@@ -54,6 +55,7 @@ public class LanguageFile
         SaveCompareHtmlTitle = "Save compare HTML file";
         PickMatroskaTrackX = "Pick Matroska track - {0}";
         PickTransportStreamTrackX = "Pick transport stream track - {0}";
+        PickMp4TrackX = "Pick MP4 track - {0}";
         RosettaProperties = "Timed Text Rosetta IMSC properties";
         RosettaFontSize = "Font size (row height)";
         XProperties = "{0} properties";

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -3099,6 +3099,28 @@ public static class UiUtil
         return shortcutString;
     }
 
+    /// <summary>
+    /// Returns the file name of the subtitle currently open in the main window (empty when untitled).
+    /// Set once by the main view model so any dialog can put the file name in its title bar without
+    /// every view model having to take it as an extra Initialize parameter.
+    /// </summary>
+    internal static Func<string?>? CurrentSubtitleFileNameProvider { get; set; }
+
+    /// <summary>
+    /// Window title with the current subtitle file name appended, e.g. "Auto-translate - my movie.srt".
+    /// The plain title is returned unchanged when no subtitle file is open.
+    /// </summary>
+    internal static string MakeWindowTitle(string title)
+    {
+        var fileName = CurrentSubtitleFileNameProvider?.Invoke();
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return title;
+        }
+
+        return title + " - " + System.IO.Path.GetFileName(fileName);
+    }
+
     internal static void InitializeWindow(Window window, string name)
     {
         window.Icon = GetSeIcon();

--- a/tests/UI/Logic/MakeWindowTitleTests.cs
+++ b/tests/UI/Logic/MakeWindowTitleTests.cs
@@ -1,0 +1,56 @@
+using Nikse.SubtitleEdit.Logic;
+using System;
+using System.IO;
+
+namespace UITests.Logic;
+
+public class MakeWindowTitleTests : IDisposable
+{
+    private readonly Func<string?>? _oldProvider = UiUtil.CurrentSubtitleFileNameProvider;
+
+    public void Dispose()
+    {
+        UiUtil.CurrentSubtitleFileNameProvider = _oldProvider;
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void NoProvider_KeepsPlainTitle()
+    {
+        UiUtil.CurrentSubtitleFileNameProvider = null;
+        Assert.Equal("Auto-translate", UiUtil.MakeWindowTitle("Auto-translate"));
+    }
+
+    [Fact]
+    public void UntitledSubtitle_KeepsPlainTitle()
+    {
+        UiUtil.CurrentSubtitleFileNameProvider = () => string.Empty;
+        Assert.Equal("Auto-translate", UiUtil.MakeWindowTitle("Auto-translate"));
+    }
+
+    [Fact]
+    public void NullFileName_KeepsPlainTitle()
+    {
+        UiUtil.CurrentSubtitleFileNameProvider = () => null;
+        Assert.Equal("Auto-translate", UiUtil.MakeWindowTitle("Auto-translate"));
+    }
+
+    [Fact]
+    public void FullPath_AppendsFileNameOnly()
+    {
+        var fullPath = Path.Combine(Path.GetTempPath(), "my movie.en.srt");
+        UiUtil.CurrentSubtitleFileNameProvider = () => fullPath;
+        Assert.Equal("Auto-translate - my movie.en.srt", UiUtil.MakeWindowTitle("Auto-translate"));
+    }
+
+    [Fact]
+    public void ProviderIsReadAtCallTime()
+    {
+        var fileName = "first.srt";
+        UiUtil.CurrentSubtitleFileNameProvider = () => fileName;
+        Assert.Equal("Spell check - first.srt", UiUtil.MakeWindowTitle("Spell check"));
+
+        fileName = "second.ass";
+        Assert.Equal("Spell check - second.ass", UiUtil.MakeWindowTitle("Spell check"));
+    }
+}


### PR DESCRIPTION
Asked for in the auto-translate window: it is not obvious which file a long-running dialog is working on. Dialogs that operate on the currently loaded subtitle now end their title with the file name:

```
Auto-translate - my movie.en.srt
Fix common errors - my movie.en.srt
```

## How

`UiUtil.MakeWindowTitle(title)` appends `" - " + Path.GetFileName(...)`, and `MainViewModel` hands `UiUtil` a provider for the current file name in its constructor. No view model needs an extra `Initialize` parameter, and the name is read live when the window is built. The plain title is kept when nothing is loaded, so untitled subtitles look as before.

Opting a window in is one line:

```csharp
Title = UiUtil.MakeWindowTitle(Se.Language.General.AutoTranslate);
```

## Windows included (36)

Auto-translate, translate via copy/paste, fix common errors, Netflix quality check, remove text for hearing impaired, change casing, adjust durations, apply duration limits, apply minimum gap, bridge gaps, beautify time codes, merge short lines / same text / same time codes / continuation lines, split-break long lines, split subtitle, sort by, renumber, convert actors, change formatting, remove unicode characters, AI review, spell check, double lines, double words, multiple replace, modify selection, show history, adjust all times, change speed, change frame rate, visual sync, point sync, point sync via other, text to speech.

Left alone on purpose:

- Burn-in, transparent subtitles and batch convert have a batch mode over several files, where a single file name in the title would be wrong.
- Track pickers (Matroska/TS/MP4/VobSub), source view and statistics already put a file name in their title.
- Settings/about/shortcuts/download-progress dialogs, and the small find/replace dialogs.

## Also

The MP4 track picker built its title from a hardcoded English `$"Pick MP4 track - {fileName}"`. It now uses a language string, `File.PickMp4TrackX`, like the Matroska and transport stream pickers.

## Testing

`tests/UI/Logic/MakeWindowTitleTests.cs` covers no provider, untitled, null file name, full path shortened to the file name, and that the provider is read at call time. Full UI suite green locally (2444 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)