### PR TITLE
Fix Multiple replace preview freezing after a failed rule (#13534)

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.2.0-beta9",
+  "version": "v5.2.0-beta10",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {
@@ -1387,7 +1387,8 @@
       "deleteCategoryConfirm": "Delete category '{0}'?",
       "deleteRuleConfirm": "Delete rule '{0}'?",
       "findWhat": "Find what",
-      "descriptionOptional": "Description (optional)"
+      "descriptionOptional": "Description (optional)",
+      "invalidRegularExpressionX": "Invalid regular expression: {0}"
     },
     "find": {
       "searchTextWatermark": "Search text...",

--- a/src/ui/Features/Edit/MultipleReplace/CategoryImportExportItem.cs
+++ b/src/ui/Features/Edit/MultipleReplace/CategoryImportExportItem.cs
@@ -105,6 +105,9 @@ public class CategoryImportExportItem
                     Description = rule.Description,
                     IsActive = rule.IsActive,
                     Type = Enum.Parse<MultipleReplaceType>(rule.Type),
+                    // Without the parent link, duplicate / insert / delete / move all silently do
+                    // nothing on a freshly imported rule until the window is reopened.
+                    Parent = categoryNode,
                 };
                 categoryNode.SubNodes?.Add(ruleNode);
             }

--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
@@ -54,6 +54,7 @@ public partial class MultipleReplaceViewModel : ObservableObject
     private readonly IFileHelper _fileHelper;
     private Subtitle _subtitle;
     private readonly ConcurrentDictionary<string, Regex> _compiledRegExList;
+    private readonly ConcurrentDictionary<string, string> _invalidRegExList;
     private readonly Timer _timerReplace;
     private readonly object _previewLock = new();
     private volatile bool _dirty;
@@ -79,6 +80,7 @@ public partial class MultipleReplaceViewModel : ObservableObject
         IsMultipleReplaceDotDotDotButtonsVisible = Se.Settings.Tools.MultipleReplaceShowDotDotDotButtons;
 
         _compiledRegExList = new ConcurrentDictionary<string, Regex>();
+        _invalidRegExList = new ConcurrentDictionary<string, string>();
 
         _timerReplace = new Timer();
         _timerReplace.Interval = 250;
@@ -1351,34 +1353,32 @@ public partial class MultipleReplaceViewModel : ObservableObject
     private List<ReplaceExpression> BuildReplaceExpressions()
     {
         var replaceExpressions = new List<ReplaceExpression>();
+        var errors = new List<(RuleTreeNode Rule, string? Message)>();
+
         foreach (var group in SnapshotRules())
         {
             var rules = group.Rules;
             for (var ruleNumber = 1; ruleNumber <= rules.Count; ruleNumber++)
             {
                 var rule = rules[ruleNumber - 1];
-                if (!rule.IsActive)
-                {
-                    continue;
-                }
-
-                var findWhat = rule.Find;
-                if (string.IsNullOrEmpty(findWhat)) // allow space or spaces
-                {
-                    continue;
-                }
-
                 var isRegex = rule.SearchType == ReplaceExpression.SearchTypeRegularExpression;
-                var replaceWith = isRegex ? RegexUtils.FixNewLine(rule.ReplaceWith) : rule.ReplaceWith;
-                findWhat = isRegex ? RegexUtils.FixNewLine(findWhat) : findWhat;
-
-                if (isRegex && !TryCompileRegex(findWhat))
+                var findWhat = rule.Find;
+                if (!string.IsNullOrEmpty(findWhat) && isRegex) // allow space or spaces
                 {
-                    // Half-typed or malformed pattern - skip this one rule. Letting the exception
-                    // out killed the whole preview instead (#13534).
+                    findWhat = RegexUtils.FixNewLine(findWhat);
+                }
+
+                // Every regular expression is checked, whether or not it runs, so that a rule
+                // sitting in an unticked category is still flagged as broken in the tree.
+                var error = isRegex && !string.IsNullOrEmpty(findWhat) ? GetRegexError(findWhat) : null;
+                errors.Add((rule, error));
+
+                if (error != null || !group.IsActive || !rule.IsActive || string.IsNullOrEmpty(findWhat))
+                {
                     continue;
                 }
 
+                var replaceWith = isRegex ? RegexUtils.FixNewLine(rule.ReplaceWith) : rule.ReplaceWith;
                 var ruleInfo = string.IsNullOrEmpty(rule.Description)
                     ? $"Group name: {group.CategoryName} - Rule number: {ruleNumber}"
                     : $"Group name: {group.CategoryName} - Rule number: {ruleNumber}. {rule.Description}";
@@ -1388,37 +1388,66 @@ public partial class MultipleReplaceViewModel : ObservableObject
             }
         }
 
+        ReportRuleErrors(errors);
+
         return replaceExpressions;
     }
 
-    private bool TryCompileRegex(string findWhat)
+    /// <summary>
+    /// Null when the pattern compiles. A pattern that does not is skipped rather than allowed to
+    /// take the whole preview down with it (#13534) - the rule is marked in the tree instead.
+    /// </summary>
+    private string? GetRegexError(string findWhat)
     {
         if (_compiledRegExList.ContainsKey(findWhat))
         {
-            return true;
+            return null;
+        }
+
+        if (_invalidRegExList.TryGetValue(findWhat, out var known))
+        {
+            return known;
         }
 
         try
         {
             _compiledRegExList[findWhat] = new Regex(findWhat, RegexOptions.Compiled | RegexOptions.Multiline);
-            return true;
+            return null;
         }
-        catch (ArgumentException)
+        catch (ArgumentException exception)
         {
-            return false;
+            var message = string.Format(Se.Language.Edit.MultipleReplace.InvalidRegularExpressionX, exception.Message);
+            _invalidRegExList[findWhat] = message;
+            return message;
         }
+    }
+
+    private void ReportRuleErrors(List<(RuleTreeNode Rule, string? Message)> errors)
+    {
+        if (errors.All(e => e.Message == e.Rule.ErrorMessage))
+        {
+            return;
+        }
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            foreach (var (rule, message) in errors)
+            {
+                rule.ErrorMessage = message;
+            }
+        });
     }
 
     /// <summary>
     /// The rule tree is owned by the UI thread but the preview runs on a timer thread, so copy the
-    /// active groups and their rules over there - iterating the live collections could throw
-    /// "collection was modified" mid-edit, which took the whole preview down with it (#13534).
+    /// groups and their rules over there - iterating the live collections could throw "collection
+    /// was modified" mid-edit, which took the whole preview down with it (#13534).
     /// </summary>
-    private List<(string CategoryName, List<RuleTreeNode> Rules)> SnapshotRules()
+    private List<(string CategoryName, bool IsActive, List<RuleTreeNode> Rules)> SnapshotRules()
     {
         return Dispatcher.UIThread.Invoke(() => Nodes
-            .Where(p => p.IsActive && p.SubNodes != null)
-            .Select(p => (p.CategoryName, Rules: p.SubNodes!.ToList()))
+            .Where(p => p.SubNodes != null)
+            .Select(p => (p.CategoryName, p.IsActive, Rules: p.SubNodes!.ToList()))
             .ToList());
     }
 

--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
@@ -14,6 +14,7 @@ using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -52,9 +53,11 @@ public partial class MultipleReplaceViewModel : ObservableObject
     private readonly IWindowService _windowService;
     private readonly IFileHelper _fileHelper;
     private Subtitle _subtitle;
-    private readonly Dictionary<string, Regex> _compiledRegExList;
+    private readonly ConcurrentDictionary<string, Regex> _compiledRegExList;
     private readonly Timer _timerReplace;
-    private bool _dirty;
+    private readonly object _previewLock = new();
+    private volatile bool _dirty;
+    private volatile bool _closed;
 
     // Subtitle Edit 4 used Ctrl+Up/Down/Home/End for the four move commands on both the rules
     // and the groups list (#13523). Ctrl+Up/Down is Mission Control on macOS, so show Cmd there.
@@ -75,7 +78,7 @@ public partial class MultipleReplaceViewModel : ObservableObject
         RulesTreeView = new TreeView();
         IsMultipleReplaceDotDotDotButtonsVisible = Se.Settings.Tools.MultipleReplaceShowDotDotDotButtons;
 
-        _compiledRegExList = new Dictionary<string, Regex>();
+        _compiledRegExList = new ConcurrentDictionary<string, Regex>();
 
         _timerReplace = new Timer();
         _timerReplace.Interval = 250;
@@ -143,15 +146,32 @@ public partial class MultipleReplaceViewModel : ObservableObject
 
     private void TimerReplaceElapsed(object? sender, ElapsedEventArgs e)
     {
-        if (!_dirty)
+        if (!_dirty || _closed)
         {
             return;
         }
 
         _timerReplace.Stop();
         _dirty = false;
-        GeneratePreview();
-        _timerReplace.Start();
+        try
+        {
+            GeneratePreview();
+        }
+        catch (Exception exception)
+        {
+            // The timer is stopped while generating, so an escaping exception used to leave it
+            // stopped for good - the preview then silently froze for the rest of the session and
+            // no rule or category tick ever changed it again (#13534). Retry on the next tick.
+            _dirty = true;
+            SeLogger.Error(exception, "Multiple replace: unable to generate preview");
+        }
+        finally
+        {
+            if (!_closed)
+            {
+                _timerReplace.Start();
+            }
+        }
     }
 
     public void Initialize(Subtitle subtitle)
@@ -167,7 +187,6 @@ public partial class MultipleReplaceViewModel : ObservableObject
                 if (item.DataContext is RuleTreeNode node && node.IsCategory)
                 {
                     item.IsExpanded = node.IsExpanded;
-                    break;
                 }
             }
         });
@@ -1233,9 +1252,22 @@ public partial class MultipleReplaceViewModel : ObservableObject
 
     private void GeneratePreview()
     {
+        // Snapshot outside the lock: it hops to the UI thread, and "Ok"/"Apply" call this from
+        // there while the timer thread may already hold the lock.
+        var replaceExpressions = BuildReplaceExpressions();
+
+        lock (_previewLock)
+        {
+            GeneratePreview(replaceExpressions);
+        }
+    }
+
+    // "Ok" and "Apply" generate on the UI thread while the preview timer generates on its own
+    // thread; both write FixedSubtitle and TotalReplaced, so only one may run at a time.
+    private void GeneratePreview(List<ReplaceExpression> replaceExpressions)
+    {
         FixedSubtitle = new Subtitle(_subtitle, false);
         TotalReplaced = 0;
-        var replaceExpressions = BuildReplaceExpressions();
         var fixes = new List<MultipleReplaceFix>();
         for (var i = 0; i < _subtitle.Paragraphs.Count; i++)
         {
@@ -1258,7 +1290,11 @@ public partial class MultipleReplaceViewModel : ObservableObject
                 }
                 else if (item.SearchType == ReplaceExpression.SearchRegEx)
                 {
-                    var r = _compiledRegExList[item.FindWhat];
+                    if (!_compiledRegExList.TryGetValue(item.FindWhat, out var r))
+                    {
+                        continue;
+                    }
+
                     // Match against line-feed-normalized text so a pattern's \n line break matches even
                     // when the paragraph text uses \r\n (the pattern is FixNewLine'd to \n) (#11956).
                     if (r.IsMatch(string.Join("\n", newText.SplitToLines())))
@@ -1312,37 +1348,78 @@ public partial class MultipleReplaceViewModel : ObservableObject
         });
     }
 
-    private HashSet<ReplaceExpression> BuildReplaceExpressions()
+    private List<ReplaceExpression> BuildReplaceExpressions()
     {
-        var replaceExpressions = new HashSet<ReplaceExpression>();
-        foreach (var group in Nodes.Where(p => p.IsActive && p.SubNodes != null))
+        var replaceExpressions = new List<ReplaceExpression>();
+        foreach (var group in SnapshotRules())
         {
-            foreach (var rule in group.SubNodes!.Where(p => p.IsActive))
+            var rules = group.Rules;
+            for (var ruleNumber = 1; ruleNumber <= rules.Count; ruleNumber++)
             {
-                var findWhat = rule.Find;
-                if (!string.IsNullOrEmpty(findWhat)) // allow space or spaces
+                var rule = rules[ruleNumber - 1];
+                if (!rule.IsActive)
                 {
-                    var isRegex = rule.SearchType == ReplaceExpression.SearchTypeRegularExpression;
-                    var replaceWith = isRegex ? RegexUtils.FixNewLine(rule.ReplaceWith) : rule.ReplaceWith;
-                    findWhat = isRegex ? RegexUtils.FixNewLine(findWhat) : findWhat;
-                    if (group.SubNodes != null)
-                    {
-                        var ruleInfo = string.IsNullOrEmpty(rule.Description)
-                            ? $"Group name: {group.CategoryName} - Rule number: {group.SubNodes.IndexOf(rule) + 1}"
-                            : $"Group name: {group.CategoryName} - Rule number: {group.SubNodes.IndexOf(rule) + 1}. {rule.Description}";
-                        var mpi = new ReplaceExpression(findWhat, replaceWith, rule.SearchType, ruleInfo);
-                        mpi.RuleTreeNode = rule;
-                        replaceExpressions.Add(mpi);
-                        if (mpi.SearchType == ReplaceExpression.SearchRegEx && !_compiledRegExList.ContainsKey(findWhat))
-                        {
-                            _compiledRegExList.Add(findWhat, new Regex(findWhat, RegexOptions.Compiled | RegexOptions.Multiline));
-                        }
-                    }
+                    continue;
                 }
+
+                var findWhat = rule.Find;
+                if (string.IsNullOrEmpty(findWhat)) // allow space or spaces
+                {
+                    continue;
+                }
+
+                var isRegex = rule.SearchType == ReplaceExpression.SearchTypeRegularExpression;
+                var replaceWith = isRegex ? RegexUtils.FixNewLine(rule.ReplaceWith) : rule.ReplaceWith;
+                findWhat = isRegex ? RegexUtils.FixNewLine(findWhat) : findWhat;
+
+                if (isRegex && !TryCompileRegex(findWhat))
+                {
+                    // Half-typed or malformed pattern - skip this one rule. Letting the exception
+                    // out killed the whole preview instead (#13534).
+                    continue;
+                }
+
+                var ruleInfo = string.IsNullOrEmpty(rule.Description)
+                    ? $"Group name: {group.CategoryName} - Rule number: {ruleNumber}"
+                    : $"Group name: {group.CategoryName} - Rule number: {ruleNumber}. {rule.Description}";
+                var mpi = new ReplaceExpression(findWhat, replaceWith, rule.SearchType, ruleInfo);
+                mpi.RuleTreeNode = rule;
+                replaceExpressions.Add(mpi);
             }
         }
 
         return replaceExpressions;
+    }
+
+    private bool TryCompileRegex(string findWhat)
+    {
+        if (_compiledRegExList.ContainsKey(findWhat))
+        {
+            return true;
+        }
+
+        try
+        {
+            _compiledRegExList[findWhat] = new Regex(findWhat, RegexOptions.Compiled | RegexOptions.Multiline);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// The rule tree is owned by the UI thread but the preview runs on a timer thread, so copy the
+    /// active groups and their rules over there - iterating the live collections could throw
+    /// "collection was modified" mid-edit, which took the whole preview down with it (#13534).
+    /// </summary>
+    private List<(string CategoryName, List<RuleTreeNode> Rules)> SnapshotRules()
+    {
+        return Dispatcher.UIThread.Invoke(() => Nodes
+            .Where(p => p.IsActive && p.SubNodes != null)
+            .Select(p => (p.CategoryName, Rules: p.SubNodes!.ToList()))
+            .ToList());
     }
 
     public void RulesTreeView_SelectionChanged(object? sender, SelectionChangedEventArgs e)
@@ -1381,6 +1458,13 @@ public partial class MultipleReplaceViewModel : ObservableObject
 
     internal void OnClosing()
     {
+        // The view model is transient, so without this every visit to the dialog leaves another
+        // preview timer ticking for the rest of the process lifetime.
+        _closed = true;
+        _timerReplace.Stop();
+        _timerReplace.Elapsed -= TimerReplaceElapsed;
+        _timerReplace.Dispose();
+
         SaveSettings();
         UiUtil.SaveWindowPosition(Window);
     }

--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceWindow.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceWindow.cs
@@ -231,7 +231,10 @@ public class MultipleReplaceWindow : Window
             };
             Attached.SetIcon(labelError, IconNames.Alert);
             labelError.Bind(Visual.IsVisibleProperty, new Binding(nameof(RuleTreeNode.HasError)) { Source = node });
-            labelError.Bind(ToolTip.TipProperty, new Binding(nameof(RuleTreeNode.ErrorMessage)) { Source = node });
+            if (Se.Settings.Appearance.ShowHints)
+            {
+                labelError.Bind(ToolTip.TipProperty, new Binding(nameof(RuleTreeNode.ErrorMessage)) { Source = node });
+            }
 
             var buttonActions = new Button
             {

--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceWindow.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceWindow.cs
@@ -216,6 +216,23 @@ public class MultipleReplaceWindow : Window
             labelIcon.Margin = new Thickness(5, 0, 2, 0);
             labelIcon.Padding = new Thickness(0);
 
+            // A rule the preview cannot run - today only a regular expression that will not
+            // compile. It is skipped silently otherwise, which reads as a rule that just does
+            // nothing (#13534).
+            var labelError = new Label
+            {
+                Foreground = new SolidColorBrush(UiTheme.IsDarkThemeEnabled()
+                    ? Color.FromRgb(255, 100, 100)
+                    : Color.FromRgb(183, 28, 28)),
+                VerticalAlignment = VerticalAlignment.Center,
+                VerticalContentAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 0, 4, 0),
+                Padding = new Thickness(0),
+            };
+            Attached.SetIcon(labelError, IconNames.Alert);
+            labelError.Bind(Visual.IsVisibleProperty, new Binding(nameof(RuleTreeNode.HasError)) { Source = node });
+            labelError.Bind(ToolTip.TipProperty, new Binding(nameof(RuleTreeNode.ErrorMessage)) { Source = node });
+
             var buttonActions = new Button
             {
                 HorizontalAlignment = HorizontalAlignment.Left,
@@ -246,6 +263,7 @@ public class MultipleReplaceWindow : Window
                 Margin = new Thickness(0, 0, 0, 0),
                 Children =
                 {
+                    labelError,
                     labelIcon,
                     labelFind,
                     labelSeparator,

--- a/src/ui/Features/Edit/MultipleReplace/RuleTreeNode.cs
+++ b/src/ui/Features/Edit/MultipleReplace/RuleTreeNode.cs
@@ -17,6 +17,16 @@ public partial class RuleTreeNode : ObservableObject
     [ObservableProperty] private bool _isSelected;
     [ObservableProperty] private bool _isExpanded;
 
+    /// <summary>
+    /// Why this rule cannot run - currently only a regular expression that will not compile.
+    /// Set by the preview, shown as a warning marker on the row.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasError))]
+    private string? _errorMessage;
+
+    public bool HasError => !string.IsNullOrEmpty(ErrorMessage);
+
     private MultipleReplaceType _type;
     public MultipleReplaceType Type
     {

--- a/src/ui/Logic/Config/Language/Edit/LanguageMultipleReplace.cs
+++ b/src/ui/Logic/Config/Language/Edit/LanguageMultipleReplace.cs
@@ -15,6 +15,7 @@ public class LanguageMultipleReplace
     public string DeleteRuleConfirm { get; set; }
     public string FindWhat { get; set; }
     public string DescriptionOptional { get; set; }
+    public string InvalidRegularExpressionX { get; set; }
 
     public LanguageMultipleReplace()
     {
@@ -31,5 +32,6 @@ public class LanguageMultipleReplace
         DeleteRuleConfirm = "Delete rule '{0}'?";
         FindWhat = "Find what";
         DescriptionOptional = "Description (optional)";
+        InvalidRegularExpressionX = "Invalid regular expression: {0}";
     }
 }

--- a/tests/UI/Features/Edit/MultipleReplacePreviewTests.cs
+++ b/tests/UI/Features/Edit/MultipleReplacePreviewTests.cs
@@ -12,6 +12,7 @@ using Nikse.SubtitleEdit.Features.Options.Settings;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
+using Optris.Icons.Avalonia;
 using System;
 using System.Linq;
 using System.Reflection;
@@ -272,10 +273,16 @@ public class MultipleReplacePreviewTests
         Assert.True(inactive.HasError);
     }
 
-    // The marker is a control in the tree, not just a view model flag.
-    [AvaloniaFact]
-    public void BrokenRegexRule_ShowsAWarningInTheTree()
+    // The marker is a control in the tree, not just a view model flag. The message rides on a
+    // tooltip, so it follows the "show hints" setting like every other tip in the app - but the
+    // icon itself has to be there either way, otherwise a broken rule looks like a working one.
+    [AvaloniaTheory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void BrokenRegexRule_ShowsAWarningInTheTree(bool showHints)
     {
+        var oldShowHints = Se.Settings.Appearance.ShowHints;
+        Se.Settings.Appearance.ShowHints = showHints;
         var vm = NewViewModel();
         var category = AddCategory(vm, "c1");
         var regexRule = AddRule(category, "(", string.Empty, MultipleReplaceType.RegularExpression);
@@ -290,14 +297,16 @@ public class MultipleReplacePreviewTests
             Assert.True(regexRule.HasError);
             var marker = vm.RulesTreeView.GetVisualDescendants()
                 .OfType<Label>()
-                .FirstOrDefault(l => Equals(ToolTip.GetTip(l), regexRule.ErrorMessage));
+                .FirstOrDefault(l => Attached.GetIcon(l) == IconNames.Alert);
 
             Assert.NotNull(marker);
             Assert.True(marker!.IsVisible);
+            Assert.Equal(showHints ? regexRule.ErrorMessage : null, ToolTip.GetTip(marker));
         }
         finally
         {
             window.Close();
+            Se.Settings.Appearance.ShowHints = oldShowHints;
         }
     }
 

--- a/tests/UI/Features/Edit/MultipleReplacePreviewTests.cs
+++ b/tests/UI/Features/Edit/MultipleReplacePreviewTests.cs
@@ -1,0 +1,443 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Edit.MultipleReplace;
+using Nikse.SubtitleEdit.Features.Options.Settings;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+
+namespace UITests.Features.Edit;
+
+/// <summary>
+/// The Multiple replace preview runs on a 250 ms timer that stops itself while generating and
+/// only restarts afterwards, so anything that threw took the preview down for the rest of the
+/// session - after that no rule tick, no category tick and no edit ever changed it again.
+/// A half-typed regular expression in the live edit panel was enough to trigger it (#13534).
+/// </summary>
+public class MultipleReplacePreviewTests
+{
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static MultipleReplaceViewModel NewViewModel()
+    {
+        var vm = new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        vm.Nodes.Clear();
+        return vm;
+    }
+
+    private static RuleTreeNode AddCategory(MultipleReplaceViewModel vm, string name)
+    {
+        var category = new RuleTreeNode(true) { CategoryName = name, IsActive = true };
+        vm.Nodes.Add(category);
+        return category;
+    }
+
+    private static RuleTreeNode AddRule(RuleTreeNode category, string find, string replaceWith, MultipleReplaceType type)
+    {
+        var node = new RuleTreeNode(false)
+        {
+            Find = find,
+            ReplaceWith = replaceWith,
+            IsActive = true,
+            Parent = category,
+            Type = type,
+        };
+        category.SubNodes!.Add(node);
+        return node;
+    }
+
+    private static bool TimerEnabled(MultipleReplaceViewModel vm)
+    {
+        var field = typeof(MultipleReplaceViewModel).GetField("_timerReplace", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return ((System.Timers.Timer)field.GetValue(vm)!).Enabled;
+    }
+
+    // The preview is generated on a background timer, so waiting is the only way to observe it.
+    private static void WaitForPreview(MultipleReplaceViewModel vm, int expectedFixes)
+    {
+        var end = Environment.TickCount64 + 3000;
+        while (Environment.TickCount64 < end)
+        {
+            Dispatcher.UIThread.RunJobs();
+            if (vm.Fixes.Count == expectedFixes)
+            {
+                Dispatcher.UIThread.RunJobs();
+                return;
+            }
+
+            Thread.Sleep(20);
+        }
+
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    // Unconditional wait - used where the preview must be given the chance to pick up a state it
+    // is expected to reject, so waiting for a fix count would return before the timer ever ticked.
+    private static void Settle(int ms = 800)
+    {
+        var end = Environment.TickCount64 + ms;
+        while (Environment.TickCount64 < end)
+        {
+            Dispatcher.UIThread.RunJobs();
+            Thread.Sleep(20);
+        }
+
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static Subtitle OneLine(string text)
+    {
+        var s = new Subtitle();
+        s.Paragraphs.Add(new Paragraph(text, 0, 2000));
+        return s;
+    }
+
+    // Typing "(red|green)" passes through "(", which Regex cannot compile.
+    [AvaloniaFact]
+    public void IncompleteRegexKeystroke_DoesNotStopThePreviewTimer()
+    {
+        var vm = NewViewModel();
+        var category = AddCategory(vm, "c1");
+        var rule = AddRule(category, "red", "blue", MultipleReplaceType.RegularExpression);
+        vm.Initialize(OneLine("The colour is red."));
+
+        WaitForPreview(vm, 1);
+        Assert.Single(vm.Fixes);
+
+        rule.Find = "(";
+        vm.RuleTextChanged(null, null!);
+        Settle();
+
+        Assert.True(TimerEnabled(vm));
+    }
+
+    // The whole reported symptom: after a bad keystroke the preview kept showing stale fixes,
+    // including hits from a category the user had just unticked.
+    [AvaloniaFact]
+    public void AfterAnIncompleteRegex_PreviewStillFollowsTheRules()
+    {
+        var vm = NewViewModel();
+        var category = AddCategory(vm, "c1");
+        AddRule(category, "colour", "color", MultipleReplaceType.CaseInsensitive);
+        var regexRule = AddRule(category, "red", "blue", MultipleReplaceType.RegularExpression);
+        vm.Initialize(OneLine("The colour is red."));
+
+        WaitForPreview(vm, 1);
+        Assert.Single(vm.Fixes);
+
+        // the timer must actually tick on the broken pattern - that is what used to kill it
+        regexRule.Find = "(";
+        vm.RuleTextChanged(null, null!);
+        Settle();
+
+        regexRule.Find = "(red|green)";
+        vm.RuleTextChanged(null, null!);
+        Settle();
+        Assert.Single(vm.Fixes);
+        Assert.Equal("The color is blue.", vm.Fixes[0].After);
+
+        category.IsActive = false;
+        vm.OnActiveChanged(null, new RoutedEventArgs());
+        WaitForPreview(vm, 0);
+        Assert.Empty(vm.Fixes);
+    }
+
+    // A rule that can never compile must cost only itself, not every other rule in the tree.
+    [AvaloniaFact]
+    public void InvalidRegexRule_OnlySkipsThatRule()
+    {
+        var vm = NewViewModel();
+        var good = AddCategory(vm, "good");
+        AddRule(good, "colour", "color", MultipleReplaceType.CaseInsensitive);
+        var bad = AddCategory(vm, "bad");
+        AddRule(bad, "(unclosed", string.Empty, MultipleReplaceType.RegularExpression);
+        vm.Initialize(OneLine("The colour is red."));
+
+        WaitForPreview(vm, 1);
+
+        Assert.Single(vm.Fixes);
+        Assert.Equal("The color is red.", vm.Fixes[0].After);
+    }
+
+    // The preview thread used to iterate the live rule tree while the user edited it on the UI
+    // thread, which can throw "collection was modified" - and again kill the timer.
+    [AvaloniaFact]
+    public void EditingRulesWhileThePreviewRuns_KeepsThePreviewLive()
+    {
+        var vm = NewViewModel();
+        var category = AddCategory(vm, "c1");
+        for (var i = 0; i < 300; i++)
+        {
+            AddRule(category, "w" + i, "x" + i, MultipleReplaceType.CaseInsensitive);
+        }
+
+        var subtitle = new Subtitle();
+        for (var i = 0; i < 300; i++)
+        {
+            subtitle.Paragraphs.Add(new Paragraph($"the w{i} thing", 0, 2000));
+        }
+
+        vm.Initialize(subtitle);
+
+        for (var i = 0; i < 150; i++)
+        {
+            AddRule(category, "z" + i, "y" + i, MultipleReplaceType.CaseInsensitive);
+            category.SubNodes!.RemoveAt(category.SubNodes.Count - 1);
+            Dispatcher.UIThread.RunJobs();
+            Thread.Sleep(2);
+        }
+
+        WaitForPreview(vm, 300);
+        Assert.Equal(300, vm.Fixes.Count);
+        Assert.True(TimerEnabled(vm));
+
+        category.IsActive = false;
+        vm.OnActiveChanged(null, new RoutedEventArgs());
+        WaitForPreview(vm, 0);
+        Assert.Empty(vm.Fixes);
+    }
+
+    // Rules run in tree order - the first rule to match a line wins, so the order the preview
+    // applies them in has to be the order they are listed in.
+    [AvaloniaFact]
+    public void RulesAreAppliedInTreeOrder()
+    {
+        var vm = NewViewModel();
+        var category = AddCategory(vm, "c1");
+        AddRule(category, "aa", "bb", MultipleReplaceType.CaseInsensitive);
+        AddRule(category, "bb", "cc", MultipleReplaceType.CaseInsensitive);
+        vm.Initialize(OneLine("aa"));
+
+        WaitForPreview(vm, 1);
+
+        Assert.Single(vm.Fixes);
+        Assert.Equal("cc", vm.Fixes[0].After);
+    }
+
+    // "Ok" and "Apply" generate the preview synchronously on the UI thread, which is also the
+    // thread the rule snapshot is taken on - that has to run inline instead of waiting on itself.
+    [AvaloniaFact]
+    public void OkAndApply_GenerateOnTheUiThreadWithoutDeadlocking()
+    {
+        var vm = NewViewModel();
+        var category = AddCategory(vm, "c1");
+        AddRule(category, "colour", "color", MultipleReplaceType.CaseInsensitive);
+        var window = new MultipleReplaceWindow(vm);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        vm.Initialize(OneLine("The colour is red."));
+        WaitForPreview(vm, 1);
+
+        var applied = 0;
+        vm.OnApply = (_, count) => applied = count;
+
+        vm.ApplyCommand.Execute(null);
+        Assert.Equal(1, applied);
+
+        vm.OkCommand.Execute(null);
+        Assert.True(vm.OkPressed);
+        Assert.Equal("The color is red.", vm.FixedSubtitle.Paragraphs[0].Text);
+    }
+
+    // Closing the window has to stop the timer - the view model is transient, so otherwise every
+    // visit leaves another one ticking for the life of the process.
+    [AvaloniaFact]
+    public void ClosingTheWindow_StopsThePreviewTimer()
+    {
+        var vm = NewViewModel();
+        AddRule(AddCategory(vm, "c1"), "colour", "color", MultipleReplaceType.CaseInsensitive);
+        var window = new MultipleReplaceWindow(vm);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        vm.Initialize(OneLine("The colour is red."));
+        WaitForPreview(vm, 1);
+        Assert.True(TimerEnabled(vm));
+
+        window.Close();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(TimerEnabled(vm));
+    }
+}
+
+/// <summary>
+/// Unticking a category has to drop its rules from the preview - #13534 was reported this way,
+/// so pin the path end to end with a real click on the real window.
+/// </summary>
+public class MultipleReplaceCategoryActiveTests
+{
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static void SeedSettings()
+    {
+        Se.Settings.Edit.MultipleReplace.Categories.Clear();
+        foreach (var name in new[] { "Dutch", "English" })
+        {
+            var c = new SeEditMultipleReplace.MultipleReplaceCategory { Name = name, IsActive = true, IsExpanded = true };
+            for (var r = 1; r <= 2; r++)
+            {
+                c.Rules.Add(new MultipleReplaceRule
+                {
+                    Active = true,
+                    Find = $"{name}{r}",
+                    ReplaceWith = $"repl{name}{r}",
+                    Type = MultipleReplaceType.CaseInsensitive,
+                });
+            }
+
+            Se.Settings.Edit.MultipleReplace.Categories.Add(c);
+        }
+    }
+
+    private static Subtitle MakeSubtitle()
+    {
+        var s = new Subtitle();
+        foreach (var name in new[] { "Dutch", "English" })
+        {
+            for (var r = 1; r <= 2; r++)
+            {
+                s.Paragraphs.Add(new Paragraph($"line with {name}{r} in it", 0, 2000));
+            }
+        }
+
+        return s;
+    }
+
+    private static void WaitForPreview(MultipleReplaceViewModel vm, int expectedFixes)
+    {
+        var end = Environment.TickCount64 + 3000;
+        while (Environment.TickCount64 < end)
+        {
+            Dispatcher.UIThread.RunJobs();
+            if (vm.Fixes.Count == expectedFixes)
+            {
+                Dispatcher.UIThread.RunJobs();
+                return;
+            }
+
+            Thread.Sleep(20);
+        }
+
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    [AvaloniaFact]
+    public void ClickingACategoryCheckBox_DropsThatCategorysRulesFromThePreview()
+    {
+        SeedSettings();
+        var vm = new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        vm.Initialize(MakeSubtitle());
+        var window = new MultipleReplaceWindow(vm);
+        try
+        {
+            window.Show();
+            vm.ExpandAllCommand.Execute(null);
+            for (var i = 0; i < 20; i++)
+            {
+                Dispatcher.UIThread.RunJobs();
+                Thread.Sleep(10);
+            }
+
+            WaitForPreview(vm, 4);
+            Assert.Equal(4, vm.Fixes.Count);
+
+            var english = vm.Nodes.First(n => n.CategoryName == "English");
+            var container = (TreeViewItem)vm.RulesTreeView.ContainerFromItem(english)!;
+            var checkBox = container.GetVisualDescendants().OfType<CheckBox>().First();
+            var point = checkBox.TranslatePoint(new Point(checkBox.Bounds.Width / 2, checkBox.Bounds.Height / 2), window);
+            Assert.NotNull(point);
+
+            window.MouseDown(point!.Value, MouseButton.Left);
+            window.MouseUp(point.Value, MouseButton.Left);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.False(english.IsActive);
+            WaitForPreview(vm, 2);
+            Assert.Equal(2, vm.Fixes.Count);
+            Assert.All(vm.Fixes, f => Assert.Contains("Dutch", f.Before));
+        }
+        finally
+        {
+            window.Close();
+            Se.Settings.Edit.MultipleReplace.Categories.Clear();
+        }
+    }
+
+    [AvaloniaFact]
+    public void UntickedCategory_SurvivesCloseAndReopen()
+    {
+        SeedSettings();
+        try
+        {
+            var vm = new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+            var window = new MultipleReplaceWindow(vm);
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            vm.Nodes.First(n => n.CategoryName == "English").IsActive = false;
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.False(Se.Settings.Edit.MultipleReplace.Categories.First(c => c.Name == "English").IsActive);
+
+            var reopened = new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+            Assert.False(reopened.Nodes.First(n => n.CategoryName == "English").IsActive);
+            Assert.True(reopened.Nodes.First(n => n.CategoryName == "Dutch").IsActive);
+        }
+        finally
+        {
+            Se.Settings.Edit.MultipleReplace.Categories.Clear();
+        }
+    }
+
+    // Imported rules used to come back without a parent link, which silently disabled duplicate,
+    // insert before / after, delete and the four move commands until the window was reopened.
+    [AvaloniaFact]
+    public void ImportedRules_KnowTheirCategory()
+    {
+        var item = new CategoryImportExportItem
+        {
+            Categories = new()
+            {
+                new CategoryImportExportItem.RuleImportExportCategory
+                {
+                    Name = "imported",
+                    Rules = new()
+                    {
+                        new CategoryImportExportItem.RuleImportExportItem
+                        {
+                            Find = "colour",
+                            ReplaceWith = "color",
+                            IsActive = true,
+                            Type = nameof(MultipleReplaceType.CaseInsensitive),
+                        },
+                    },
+                },
+            },
+        };
+
+        var method = typeof(CategoryImportExportItem).GetMethod("RuleTreeNodeList", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var nodes = (System.Collections.Generic.List<RuleTreeNode>)method.Invoke(item, null)!;
+
+        var category = Assert.Single(nodes);
+        var rule = Assert.Single(category.SubNodes!);
+        Assert.Same(category, rule.Parent);
+    }
+}

--- a/tests/UI/Features/Edit/MultipleReplacePreviewTests.cs
+++ b/tests/UI/Features/Edit/MultipleReplacePreviewTests.cs
@@ -228,6 +228,79 @@ public class MultipleReplacePreviewTests
         Assert.Equal("cc", vm.Fixes[0].After);
     }
 
+    // A rule that is skipped silently reads as a rule that simply does nothing, so the tree marks
+    // it - and clears the mark once the pattern compiles again.
+    [AvaloniaFact]
+    public void BrokenRegexRule_IsMarkedInTheTreeUntilItCompiles()
+    {
+        var vm = NewViewModel();
+        var category = AddCategory(vm, "c1");
+        var good = AddRule(category, "colour", "color", MultipleReplaceType.CaseInsensitive);
+        var regexRule = AddRule(category, "(", string.Empty, MultipleReplaceType.RegularExpression);
+        vm.Initialize(OneLine("The colour is red."));
+
+        Settle();
+
+        Assert.True(regexRule.HasError);
+        Assert.Contains("Invalid regular expression", regexRule.ErrorMessage);
+        Assert.False(good.HasError);
+
+        regexRule.Find = "(red|green)";
+        vm.RuleTextChanged(null, null!);
+        Settle();
+
+        Assert.False(regexRule.HasError);
+        Assert.Null(regexRule.ErrorMessage);
+    }
+
+    // Rules in an unticked category never run, but the user still wants to see that one of them
+    // is broken.
+    [AvaloniaFact]
+    public void BrokenRegexRule_IsMarkedEvenInAnUntickedCategory()
+    {
+        var vm = NewViewModel();
+        var off = AddCategory(vm, "off");
+        off.IsActive = false;
+        var broken = AddRule(off, "(", string.Empty, MultipleReplaceType.RegularExpression);
+        var inactive = AddRule(off, "[", string.Empty, MultipleReplaceType.RegularExpression);
+        inactive.IsActive = false;
+        vm.Initialize(OneLine("The colour is red."));
+
+        Settle();
+
+        Assert.True(broken.HasError);
+        Assert.True(inactive.HasError);
+    }
+
+    // The marker is a control in the tree, not just a view model flag.
+    [AvaloniaFact]
+    public void BrokenRegexRule_ShowsAWarningInTheTree()
+    {
+        var vm = NewViewModel();
+        var category = AddCategory(vm, "c1");
+        var regexRule = AddRule(category, "(", string.Empty, MultipleReplaceType.RegularExpression);
+        vm.Initialize(OneLine("The colour is red."));
+        var window = new MultipleReplaceWindow(vm);
+        try
+        {
+            window.Show();
+            vm.ExpandAllCommand.Execute(null);
+            Settle();
+
+            Assert.True(regexRule.HasError);
+            var marker = vm.RulesTreeView.GetVisualDescendants()
+                .OfType<Label>()
+                .FirstOrDefault(l => Equals(ToolTip.GetTip(l), regexRule.ErrorMessage));
+
+            Assert.NotNull(marker);
+            Assert.True(marker!.IsVisible);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
     // "Ok" and "Apply" generate the preview synchronously on the UI thread, which is also the
     // thread the rule snapshot is taken on - that has to run inline instead of waiting on itself.
     [AvaloniaFact]


### PR DESCRIPTION
Fixes #13534.

## What was reported

Unticking a rule category in Multiple replace appeared to have no effect on the preview — the rules of the unticked category seemed to stay in effect.

## What is actually wrong

The category filter itself is fine. The preview had already stopped updating.

The preview runs on a 250 ms timer that stops itself before generating and only restarts afterwards:

```csharp
_timerReplace.Stop();
_dirty = false;
GeneratePreview();      // throws
_timerReplace.Start();  // never reached
```

`System.Timers.Timer` swallows exceptions from `Elapsed`, so this failed silently and left the timer stopped for the rest of the dialog session. After that, nothing refreshed the preview — not a rule tick, not a category tick, not an edit. The stale fixes stayed on screen, still listing "Applied rules" chips naming the category the user had just unticked.

The everyday trigger is the live edit panel: every keystroke in **Find** marks the preview dirty, and each pattern was compiled with an unguarded `new Regex(...)`. Typing `(red|green)` dies on the leading `(`. One keystroke, preview dead. An invalid regex already saved in an active category has the same effect from the first tick.

## Changes

- Generate inside `try/catch/finally` — always restart the timer, log the failure, and mark dirty so the next tick retries.
- Skip only the offending rule when its pattern will not compile, instead of losing every rule in the tree.
- **Mark the broken rule in the tree**: a red warning icon on the row with the compiler's own message as its tooltip, cleared as soon as the pattern compiles again. Every regular expression is checked whether or not it runs, so a rule in an unticked category is still flagged. Without this, a permanently broken rule would just quietly do nothing.
- Snapshot the rule tree on the UI thread. The preview thread iterated the live `ObservableCollection`s while the user edited them, which throws `collection was modified` and killed the timer the same way.
- Serialize preview generation. `Ok` and `Apply` generate on the UI thread while the timer generates on its own, and both write `FixedSubtitle` and `TotalReplaced`; the shared regex cache is now a `ConcurrentDictionary`.

### Also fixed while in here

- The preview timer is disposed when the window closes. The view model is transient, so every visit to the dialog left another timer ticking for the life of the process.
- Imported rules get their parent link. Without it, duplicate / insert before / insert after / delete and the four move commands silently did nothing on freshly imported rules until the window was reopened.
- The expanded state is restored for every category, not just the first (a stray `break`).
- The rule list is built in tree order rather than relying on `HashSet` enumeration order — rules run first-match-wins, so the order is data.

One new language string, `invalidRegularExpressionX`; `English.json` regenerated from the language classes (which also picks up the beta9 → beta10 version line).

## Tests

`tests/UI/Features/Edit/MultipleReplacePreviewTests.cs`, 13 tests. Five fail on `main` and pass here; the rest pin the new marker and behaviour that was already correct (real mouse click on a category checkbox in the real window, settings round-trip, Ok/Apply on the UI thread).

Full UI suite: 2452 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)