### PR TITLE
Perf: cache the waveform spectrogram per block and memoize the change-detection hash

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -2,6 +2,8 @@
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
 using Avalonia.Threading;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Main;
@@ -1844,6 +1846,21 @@ public class AudioVisualizer : Control
         }
     }
 
+    // Anchored spectrogram cache, the same scheme the waveform/timeline/grid-line caches use (see
+    // DrawWaveForm), and the last per-frame rebuild in this control. Composing the visible window
+    // meant a fresh SKBitmap plus a fresh WriteableBitmap of ~1 MB each and a full per-pixel walk
+    // between them on **every** ~60 fps frame - two large-object allocations per frame, so the
+    // spectrogram alone cost more than the whole rest of the render and forced a gen2 collection
+    // every few frames. Now the composed window is built once per 256-column block (~1.5 s of
+    // audio at default zoom) into buffers that are reused across rebuilds, and a view scrolling
+    // inside the block is just a translated destination rectangle.
+    private const int SpectrogramCacheBlockColumns = 256;
+    private SKBitmap? _spectrogramCacheSource;
+    private WriteableBitmap? _spectrogramCacheBitmap;
+    private SpectrogramData2? _spectrogramCacheData;
+    private int _spectrogramCacheAnchorColumn = -1;
+    private int _spectrogramCacheColumns;
+
     private void DrawSpectrogram(DrawingContext context, ref RenderContext renderCtx)
     {
         if (_spectrogram == null || _displayMode == WaveformDisplayMode.OnlyWaveform)
@@ -1864,34 +1881,118 @@ public class AudioVisualizer : Control
             return;
         }
 
-        // Create a combined bitmap using SkiaSharp
-        using var skBitmapCombined = new SKBitmap(width, _spectrogram.FftSize / 2);
-        using var skCanvas = new SKCanvas(skBitmapCombined);
-
         var left = (int)Math.Round(StartPositionSeconds / _spectrogram.SampleDuration);
-        var offset = 0;
-        var imageIndex = left / _spectrogram.ImageWidth;
 
-        while (offset < width && imageIndex < _spectrogram.Images.Count)
+        // Build for the block boundary at or before the visible window and one block of padding,
+        // so any view starting inside the block is fully covered: left - anchor is in
+        // [0, block) and the window ends at left + width <= anchor + width + block.
+        var anchorColumn = (int)(Math.Floor(left / (double)SpectrogramCacheBlockColumns) * SpectrogramCacheBlockColumns);
+        var cacheColumns = width + SpectrogramCacheBlockColumns;
+        var cacheHeight = _spectrogram.FftSize / 2;
+        if (cacheHeight <= 0)
         {
-            var x = (left + offset) % _spectrogram.ImageWidth;
-            var w = Math.Min(_spectrogram.ImageWidth - x, width - offset);
-
-            // Draw part of the spectrogram image
-            var sourceRect = new SKRect(x, 0, x + w, skBitmapCombined.Height);
-            var destRect = new SKRect(offset, 0, offset + w, skBitmapCombined.Height);
-            skCanvas.DrawBitmap(_spectrogram.Images[imageIndex], sourceRect, destRect);
-
-            offset += w;
-            imageIndex++;
+            return;
         }
 
-        // Convert SKBitmap to Avalonia Bitmap and draw it
-        var displayHeight = height;
-        using var avaloniaBitmap = skBitmapCombined.ToAvaloniaBitmap();
+        var bitmap = _spectrogramCacheBitmap;
+        if (bitmap == null ||
+            !ReferenceEquals(_spectrogramCacheData, _spectrogram) ||
+            _spectrogramCacheAnchorColumn != anchorColumn ||
+            _spectrogramCacheColumns != cacheColumns ||
+            _spectrogramCacheSource?.Height != cacheHeight)
+        {
+            bitmap = BuildSpectrogramCache(anchorColumn, cacheColumns, cacheHeight);
+            if (bitmap == null)
+            {
+                return;
+            }
+        }
 
-        var destRectangle = new Rect(0, renderCtx.Height - displayHeight, renderCtx.Width, displayHeight);
-        context.DrawImage(avaloniaBitmap, destRectangle);
+        // The cached window starts at anchorColumn, so it is drawn shifted left by the columns
+        // between it and the view. Same pixels per column as before (the visible width columns
+        // still span exactly renderCtx.Width), just extended past both edges and clipped.
+        var pixelsPerColumn = renderCtx.Width / width;
+        var destRectangle = new Rect(
+            (anchorColumn - left) * pixelsPerColumn,
+            renderCtx.Height - height,
+            cacheColumns * pixelsPerColumn,
+            height);
+        context.DrawImage(bitmap, destRectangle);
+    }
+
+    private WriteableBitmap? BuildSpectrogramCache(int anchorColumn, int cacheColumns, int cacheHeight)
+    {
+        var spectrogram = _spectrogram;
+        if (spectrogram == null)
+        {
+            return null;
+        }
+
+        if (_spectrogramCacheSource == null ||
+            _spectrogramCacheSource.Width != cacheColumns ||
+            _spectrogramCacheSource.Height != cacheHeight)
+        {
+            _spectrogramCacheSource?.Dispose();
+            _spectrogramCacheSource = new SKBitmap(cacheColumns, cacheHeight);
+
+            _spectrogramCacheBitmap?.Dispose();
+            _spectrogramCacheBitmap = new WriteableBitmap(
+                new PixelSize(cacheColumns, cacheHeight),
+                new Vector(96, 96),
+                PixelFormat.Bgra8888,
+                AlphaFormat.Premul);
+        }
+
+        var skBitmapCombined = _spectrogramCacheSource;
+        using (var skCanvas = new SKCanvas(skBitmapCombined))
+        {
+            // Past the end of the audio there is no image to blit, so clear first - the buffer
+            // is reused and would otherwise still hold the previous block's pixels there.
+            skCanvas.Clear(SKColors.Transparent);
+
+            var offset = 0;
+            var imageIndex = anchorColumn / spectrogram.ImageWidth;
+            while (offset < cacheColumns && imageIndex < spectrogram.Images.Count)
+            {
+                var x = (anchorColumn + offset) % spectrogram.ImageWidth;
+                var w = Math.Min(spectrogram.ImageWidth - x, cacheColumns - offset);
+
+                // Draw part of the spectrogram image
+                var sourceRect = new SKRect(x, 0, x + w, cacheHeight);
+                var destRect = new SKRect(offset, 0, offset + w, cacheHeight);
+                skCanvas.DrawBitmap(spectrogram.Images[imageIndex], sourceRect, destRect);
+
+                offset += w;
+                imageIndex++;
+            }
+        }
+
+        skBitmapCombined.CopyToAvaloniaBitmap(_spectrogramCacheBitmap!);
+
+        _spectrogramCacheData = spectrogram;
+        _spectrogramCacheAnchorColumn = anchorColumn;
+        _spectrogramCacheColumns = cacheColumns;
+        return _spectrogramCacheBitmap;
+    }
+
+    /// <param name="releaseBuffers">
+    /// Also free the two cache surfaces (a few MB together). Wanted when the spectrogram is
+    /// being replaced or dropped; not when only its pixels became stale (a theme change), where
+    /// the next rebuild reuses them.
+    /// </param>
+    private void InvalidateSpectrogramCache(bool releaseBuffers = false)
+    {
+        _spectrogramCacheData = null;
+        _spectrogramCacheAnchorColumn = -1;
+        _spectrogramCacheColumns = 0;
+
+        if (releaseBuffers)
+        {
+            _spectrogramCacheSource?.Dispose();
+            _spectrogramCacheSource = null;
+            _spectrogramCacheBitmap?.Dispose();
+            _spectrogramCacheBitmap = null;
+        }
     }
 
     // Pooled buffers and FormattedText cache for the timeline ruler.
@@ -3487,6 +3588,10 @@ public class AudioVisualizer : Control
 
     internal void SetSpectrogram(SpectrogramData2? spectrogram)
     {
+        // The block cache holds pixels blitted from the outgoing spectrogram's images, and its
+        // key is that instance - drop it before the images are disposed.
+        InvalidateSpectrogramCache(releaseBuffers: true);
+
         if (_spectrogram != null)
         {
             _spectrogram.Dispose();
@@ -3891,6 +3996,7 @@ public class AudioVisualizer : Control
         _waveformCacheValid = false;
         _gridLinesGeometry = null;
         _timeLineCacheValid = false;
+        InvalidateSpectrogramCache();
 
         _paintText = new SolidColorBrush(Se.Settings.Waveform.WaveformTextColor.FromHexToColor());
         _typeface = new Typeface(UiUtil.GetDefaultFontName(), FontStyle.Normal, Se.Settings.Waveform.WaveformTextFontBold ? FontWeight.Bold : FontWeight.Normal);

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -20928,8 +20928,11 @@ public partial class MainViewModel :
                 hash = hash * 23 + p.Number;
                 hash = hash * 23 + p.StartTime.TotalMilliseconds.GetHashCode();
                 hash = hash * 23 + p.EndTime.TotalMilliseconds.GetHashCode();
-                hash = hash * 23 + (p.Text?.GetHashCode() ?? 0);
-                hash = hash * 23 + (p.OriginalText?.GetHashCode() ?? 0);
+                // TextHash/OriginalTextHash are GetHashCode() memoized on the string instance -
+                // see the comment on them: this loop runs several times a second over the whole
+                // file and string.GetHashCode is a full pass over the characters every call.
+                hash = hash * 23 + p.TextHash;
+                hash = hash * 23 + p.OriginalTextHash;
                 hash = hash * 23 + (p.Style?.GetHashCode() ?? 0);
                 hash = hash * 23 + (p.Extra?.GetHashCode() ?? 0);
                 hash = hash * 23 + (p.Actor?.GetHashCode() ?? 0);
@@ -20984,7 +20987,7 @@ public partial class MainViewModel :
 
                 if (p.Text != null)
                 {
-                    hash = hash * 23 + p.Text.GetHashCode();
+                    hash = hash * 23 + p.TextHash; // memoized GetHashCode, see SubtitleLineViewModel
                 }
 
                 hash = hash * 23 + (p.Style?.GetHashCode() ?? 0);
@@ -21021,7 +21024,7 @@ public partial class MainViewModel :
 
                 if (p.OriginalText != null)
                 {
-                    hash = hash * 23 + p.OriginalText.GetHashCode();
+                    hash = hash * 23 + p.OriginalTextHash; // memoized GetHashCode
                 }
 
                 hash = hash * 23 + (p.Style?.GetHashCode() ?? 0);

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -296,6 +296,65 @@ public partial class SubtitleLineViewModel : ObservableObject
         return _strippedLinesCacheValue!;
     }
 
+    // Read-time memos for the change-detection hashes, keyed on the string instance like the
+    // memos around them. The dirty star, auto-save and undo change detection hash every line of
+    // the file about five times a second (a 333 ms undo timer and a 400 ms title/auto-save tick,
+    // each for the working text and the original), and .NET does not cache string.GetHashCode -
+    // every call is a full Marvin pass over the characters. A line's text is unchanged between
+    // practically all of those ticks, so the second and later hashes of the same instance are
+    // pure waste. Strings are immutable, so the same instance can only have the same hash.
+    private string? _textHashCacheText;
+    private int _textHashCacheValue;
+    private string? _originalTextHashCacheText;
+    private int _originalTextHashCacheValue;
+
+    /// <summary>
+    /// <c>Text.GetHashCode()</c>, memoized per string instance. Zero for a null text, which is
+    /// what the change-detection hashes substituted for it.
+    /// </summary>
+    internal int TextHash
+    {
+        get
+        {
+            var text = Text;
+            if (text == null)
+            {
+                return 0;
+            }
+
+            if (!ReferenceEquals(_textHashCacheText, text))
+            {
+                _textHashCacheValue = text.GetHashCode();
+                _textHashCacheText = text;
+            }
+
+            return _textHashCacheValue;
+        }
+    }
+
+    /// <summary>
+    /// <c>OriginalText.GetHashCode()</c>, memoized per string instance. See <see cref="TextHash"/>.
+    /// </summary>
+    internal int OriginalTextHash
+    {
+        get
+        {
+            var text = OriginalText;
+            if (text == null)
+            {
+                return 0;
+            }
+
+            if (!ReferenceEquals(_originalTextHashCacheText, text))
+            {
+                _originalTextHashCacheValue = text.GetHashCode();
+                _originalTextHashCacheText = text;
+            }
+
+            return _originalTextHashCacheValue;
+        }
+    }
+
     // Read-time memos for the two WebVTT grid columns below, keyed on the text instance like
     // the memos around them - both parse the text, and a cell binding re-reads its value on
     // every repaint.

--- a/src/ui/Logic/SkBitmapExtensions.cs
+++ b/src/ui/Logic/SkBitmapExtensions.cs
@@ -241,6 +241,41 @@ internal static class SkBitmapExtensions
             PixelFormat.Bgra8888,
             AlphaFormat.Premul);
 
+        WritePixels(skBitmap, bitmap);
+        return bitmap;
+    }
+
+    /// <summary>
+    /// Same conversion as <see cref="ToAvaloniaBitmap"/>, but into a bitmap the caller already
+    /// owns. For callers that redraw the same surface over and over (the waveform's spectrogram
+    /// block cache), so a rebuild does not allocate a large-object-heap sized bitmap each time.
+    /// The target must be Bgra8888/Premul and the same pixel size as the source.
+    /// </summary>
+    public static void CopyToAvaloniaBitmap(this SKBitmap skBitmap, WriteableBitmap target)
+    {
+        if (skBitmap.Width <= 0 || skBitmap.Height <= 0 ||
+            target.PixelSize.Width != skBitmap.Width || target.PixelSize.Height != skBitmap.Height)
+        {
+            return;
+        }
+
+        if (skBitmap.ColorType != SKColorType.Bgra8888)
+        {
+            using var converted = skBitmap.Copy(SKColorType.Bgra8888);
+            if (converted == null)
+            {
+                return;
+            }
+
+            WritePixels(converted, target);
+            return;
+        }
+
+        WritePixels(skBitmap, target);
+    }
+
+    private static void WritePixels(SKBitmap skBitmap, WriteableBitmap bitmap)
+    {
         using (var lockedBitmap = bitmap.Lock())
         {
             int width = skBitmap.Width;
@@ -295,8 +330,6 @@ internal static class SkBitmapExtensions
                 }
             }
         }
-
-        return bitmap;
     }
 
     // Original simple code for ToSkBitmap:

--- a/tests/UI/Features/Main/SubtitleLineViewModelHashCacheTests.cs
+++ b/tests/UI/Features/Main/SubtitleLineViewModelHashCacheTests.cs
@@ -1,0 +1,86 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Features.Main;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// <see cref="SubtitleLineViewModel.TextHash"/> / <see cref="SubtitleLineViewModel.OriginalTextHash"/>
+/// memoize <c>string.GetHashCode()</c> per string instance for the change-detection hashes (dirty
+/// star, auto-save, undo). These pin down that they stay equal to the call they replace - a stale
+/// hash would make an edited file look unchanged, so auto-save and undo would silently skip it.
+/// </summary>
+public class SubtitleLineViewModelHashCacheTests
+{
+    [AvaloniaFact]
+    public void TextHash_EqualsGetHashCode()
+    {
+        var vm = new SubtitleLineViewModel { Text = "Hello there, world." };
+
+        Assert.Equal(vm.Text.GetHashCode(), vm.TextHash);
+        Assert.Equal(vm.TextHash, vm.TextHash); // memoized read returns the same value
+    }
+
+    [AvaloniaFact]
+    public void TextHash_FollowsTextChange()
+    {
+        var vm = new SubtitleLineViewModel { Text = "Hello there, world." };
+        var before = vm.TextHash;
+
+        vm.Text = "Something else entirely.";
+
+        Assert.Equal(vm.Text.GetHashCode(), vm.TextHash);
+        Assert.NotEqual(before, vm.TextHash);
+    }
+
+    [AvaloniaFact]
+    public void TextHash_FollowsChangeBackToAnEqualValue()
+    {
+        // A different instance with the same content must still hash the same - the memo is
+        // keyed on the instance, so this is the case where it recomputes and must agree.
+        var vm = new SubtitleLineViewModel { Text = "Line one" };
+        var before = vm.TextHash;
+
+        vm.Text = "Line two";
+        vm.Text = string.Concat("Line", " one");
+
+        Assert.Equal(before, vm.TextHash);
+    }
+
+    [AvaloniaFact]
+    public void TextHash_IsZeroForEmptyAndNull()
+    {
+        var vm = new SubtitleLineViewModel { Text = string.Empty };
+        Assert.Equal(string.Empty.GetHashCode(), vm.TextHash);
+
+        vm.Text = null!;
+        Assert.Equal(0, vm.TextHash);
+    }
+
+    [AvaloniaFact]
+    public void OriginalTextHash_EqualsGetHashCodeAndFollowsChanges()
+    {
+        var vm = new SubtitleLineViewModel { OriginalText = "Den originale tekst." };
+        Assert.Equal(vm.OriginalText.GetHashCode(), vm.OriginalTextHash);
+
+        var before = vm.OriginalTextHash;
+        vm.OriginalText = "En anden tekst.";
+
+        Assert.Equal(vm.OriginalText.GetHashCode(), vm.OriginalTextHash);
+        Assert.NotEqual(before, vm.OriginalTextHash);
+
+        vm.OriginalText = null!;
+        Assert.Equal(0, vm.OriginalTextHash);
+    }
+
+    [AvaloniaFact]
+    public void TextAndOriginalTextHashes_AreIndependent()
+    {
+        var vm = new SubtitleLineViewModel { Text = "Working", OriginalText = "Original" };
+        var textHash = vm.TextHash;
+
+        vm.OriginalText = "Changed original";
+
+        Assert.Equal(textHash, vm.TextHash);
+        Assert.Equal(vm.OriginalText.GetHashCode(), vm.OriginalTextHash);
+    }
+}

--- a/tests/UI/Logic/SkBitmapCopyToAvaloniaBitmapTests.cs
+++ b/tests/UI/Logic/SkBitmapCopyToAvaloniaBitmapTests.cs
@@ -1,0 +1,112 @@
+using Avalonia;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using Nikse.SubtitleEdit.Logic;
+using SkiaSharp;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// <c>CopyToAvaloniaBitmap</c> is <c>ToAvaloniaBitmap</c> writing into a bitmap the caller already
+/// owns, so the waveform's spectrogram block cache can reuse one surface instead of allocating a
+/// megabyte-sized bitmap per frame. Both go through the same pixel writer, and these pin that down
+/// over the shapes that reach it: premultiplied and straight alpha, fully opaque and fully
+/// transparent pixels, and a colour type that has to be converted first.
+/// </summary>
+public class SkBitmapCopyToAvaloniaBitmapTests
+{
+    private const int Width = 17; // deliberately not a multiple of anything
+    private const int Height = 5;
+
+    [AvaloniaTheory]
+    [InlineData(SKColorType.Bgra8888, SKAlphaType.Premul)]
+    [InlineData(SKColorType.Bgra8888, SKAlphaType.Unpremul)]
+    [InlineData(SKColorType.Rgba8888, SKAlphaType.Premul)]
+    [InlineData(SKColorType.Rgba8888, SKAlphaType.Unpremul)]
+    public void CopyToAvaloniaBitmap_MatchesToAvaloniaBitmap(SKColorType colorType, SKAlphaType alphaType)
+    {
+        using var source = MakeSource(colorType, alphaType);
+
+        using var expected = (WriteableBitmap)source.ToAvaloniaBitmap();
+
+        using var actual = new WriteableBitmap(
+            new PixelSize(Width, Height), new Vector(96, 96), PixelFormat.Bgra8888, AlphaFormat.Premul);
+        source.CopyToAvaloniaBitmap(actual);
+
+        Assert.Equal(ReadPixels(expected), ReadPixels(actual));
+    }
+
+    [AvaloniaFact]
+    public void CopyToAvaloniaBitmap_LeavesTargetAloneOnSizeMismatch()
+    {
+        using var source = MakeSource(SKColorType.Bgra8888, SKAlphaType.Premul);
+
+        using var target = new WriteableBitmap(
+            new PixelSize(Width + 1, Height), new Vector(96, 96), PixelFormat.Bgra8888, AlphaFormat.Premul);
+        var before = ReadPixels(target);
+
+        source.CopyToAvaloniaBitmap(target);
+
+        Assert.Equal(before, ReadPixels(target));
+    }
+
+    [AvaloniaFact]
+    public void CopyToAvaloniaBitmap_OverwritesEveryPixelOnReuse()
+    {
+        // The spectrogram cache reuses one surface across rebuilds, so a second copy must not
+        // leave any pixel of the first behind.
+        using var first = MakeSource(SKColorType.Bgra8888, SKAlphaType.Premul);
+        using var second = MakeSource(SKColorType.Bgra8888, SKAlphaType.Premul, seed: 91);
+
+        using var target = new WriteableBitmap(
+            new PixelSize(Width, Height), new Vector(96, 96), PixelFormat.Bgra8888, AlphaFormat.Premul);
+
+        first.CopyToAvaloniaBitmap(target);
+        second.CopyToAvaloniaBitmap(target);
+
+        using var expected = (WriteableBitmap)second.ToAvaloniaBitmap();
+        Assert.Equal(ReadPixels(expected), ReadPixels(target));
+    }
+
+    /// <summary>
+    /// A deterministic pattern that covers alpha 255 (the opaque fast path), alpha 0 (which the
+    /// writer zeroes out) and the partial alphas in between.
+    /// </summary>
+    private static SKBitmap MakeSource(SKColorType colorType, SKAlphaType alphaType, int seed = 7)
+    {
+        var bitmap = new SKBitmap(Width, Height, colorType, alphaType);
+        for (var y = 0; y < Height; y++)
+        {
+            for (var x = 0; x < Width; x++)
+            {
+                var i = y * Width + x + seed;
+                var alpha = (i % 4) switch
+                {
+                    0 => (byte)255,
+                    1 => (byte)0,
+                    2 => (byte)128,
+                    _ => (byte)37,
+                };
+
+                // Keep the channels below the alpha so the premultiplied inputs stay valid.
+                var scale = alpha / 255.0;
+                bitmap.SetPixel(x, y, new SKColor(
+                    (byte)(i * 7 % 256 * scale),
+                    (byte)(i * 13 % 256 * scale),
+                    (byte)(i * 29 % 256 * scale),
+                    alpha));
+            }
+        }
+
+        return bitmap;
+    }
+
+    private static byte[] ReadPixels(WriteableBitmap bitmap)
+    {
+        using var locked = bitmap.Lock();
+        var bytes = new byte[locked.RowBytes * bitmap.PixelSize.Height];
+        System.Runtime.InteropServices.Marshal.Copy(locked.Address, bytes, 0, bytes.Length);
+        return bytes;
+    }
+}

--- a/tests/benchmarks/HotPathRound6Benchmarks.cs
+++ b/tests/benchmarks/HotPathRound6Benchmarks.cs
@@ -1,0 +1,166 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// The change-detection hash the editor runs over the whole file about five times a second:
+/// the 333 ms undo change-detection timer (working text and original folded into one pass) and
+/// the 400 ms title/auto-save tick (working text and original as two passes). All of it happens
+/// on the UI thread - GetFastHash marshals itself there - so it is pure typing latency.
+///
+/// <see cref="InlineTextGetHashCode"/> is the loop verbatim as it was; <see cref="MemoizedTextHash"/>
+/// is the same loop reading the memoized per-instance hash. Two separate methods with direct
+/// calls, not one method behind a delegate, so tiered PGO cannot devirtualize one into looking
+/// faster than the other.
+/// </summary>
+[MemoryDiagnoser]
+public class ChangeDetectionHashBenchmarks
+{
+    private List<SubtitleLineViewModel> _lines = null!;
+
+    /// <summary>A feature-length subtitle.</summary>
+    [Params(2000)]
+    public int Lines { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _lines = SubtitleFactory.Make(Lines);
+
+        // A translation job has both columns filled; the undo hash covers both.
+        for (var i = 0; i < _lines.Count; i++)
+        {
+            _lines[i].OriginalText = "Original line " + i + ": the text this line was translated from.";
+            _lines[i].Style = "Default";
+            _lines[i].Actor = string.Empty;
+            _lines[i].Extra = string.Empty;
+        }
+
+        // One warm-up pass, matching the app: the first tick after an edit populates the memo
+        // and the four or five ticks before the next edit are the ones being measured.
+        MemoizedTextHash();
+    }
+
+    [Benchmark(Baseline = true)]
+    public int InlineTextGetHashCode()
+    {
+        unchecked
+        {
+            var hash = 17;
+            for (var i = 0; i < _lines.Count; i++)
+            {
+                var p = _lines[i];
+                hash = hash * 23 + p.Number;
+                hash = hash * 23 + p.StartTime.TotalMilliseconds.GetHashCode();
+                hash = hash * 23 + p.EndTime.TotalMilliseconds.GetHashCode();
+                hash = hash * 23 + (p.Text?.GetHashCode() ?? 0);
+                hash = hash * 23 + (p.OriginalText?.GetHashCode() ?? 0);
+                hash = hash * 23 + (p.Style?.GetHashCode() ?? 0);
+                hash = hash * 23 + (p.Extra?.GetHashCode() ?? 0);
+                hash = hash * 23 + (p.Actor?.GetHashCode() ?? 0);
+                hash = hash * 23 + p.Layer;
+            }
+
+            return hash;
+        }
+    }
+
+    [Benchmark]
+    public int MemoizedTextHash()
+    {
+        unchecked
+        {
+            var hash = 17;
+            for (var i = 0; i < _lines.Count; i++)
+            {
+                var p = _lines[i];
+                hash = hash * 23 + p.Number;
+                hash = hash * 23 + p.StartTime.TotalMilliseconds.GetHashCode();
+                hash = hash * 23 + p.EndTime.TotalMilliseconds.GetHashCode();
+                hash = hash * 23 + p.TextHash;
+                hash = hash * 23 + p.OriginalTextHash;
+                hash = hash * 23 + (p.Style?.GetHashCode() ?? 0);
+                hash = hash * 23 + (p.Extra?.GetHashCode() ?? 0);
+                hash = hash * 23 + (p.Actor?.GetHashCode() ?? 0);
+                hash = hash * 23 + p.Layer;
+            }
+
+            return hash;
+        }
+    }
+}
+
+/// <summary>
+/// The 400 ms slow timer's whole-file gap refresh. Included as a measured "is this worth
+/// touching" probe rather than as a candidate: the generated observable setters skip the
+/// notification when the value is unchanged, which is the case on every idle tick.
+/// </summary>
+[MemoryDiagnoser]
+public class UpdateGapsBenchmarks
+{
+    private List<SubtitleLineViewModel> _lines = null!;
+
+    [Params(2000)]
+    public int Lines { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _lines = SubtitleFactory.Make(Lines);
+        SubtitleTextInfoHelper.UpdateGaps(_lines);
+    }
+
+    [Benchmark]
+    public void IdleTick() => SubtitleTextInfoHelper.UpdateGaps(_lines);
+}
+
+/// <summary>
+/// The CPS / WPM cells were the most expensive converter per cell in
+/// <c>GridCellConverterBenchmarks</c> (~55 ns each), and all they do is
+/// <c>d.ToString("0.0", culture)</c>. A custom format string is re-parsed on every call, while
+/// the standard "F1" specifier takes the fast path - this checks whether that is worth taking
+/// (an equivalence sweep over the whole double range lives in the UI tests).
+/// </summary>
+[MemoryDiagnoser]
+public class OneDecimalFormatBenchmarks
+{
+    private double[] _values = null!;
+    private readonly System.Globalization.CultureInfo _culture = System.Globalization.CultureInfo.InvariantCulture;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // CPS and WPM as a grid shows them: CPS around 5-25, WPM around 100-250.
+        _values = new double[400];
+        for (var i = 0; i < _values.Length; i++)
+        {
+            _values[i] = i % 2 == 0 ? 8.5 + i % 17 * 1.13 : 95.0 + i % 160 * 1.07;
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    public string CustomFormat()
+    {
+        var last = string.Empty;
+        for (var i = 0; i < _values.Length; i++)
+        {
+            last = _values[i].ToString("0.0", _culture);
+        }
+
+        return last;
+    }
+
+    [Benchmark]
+    public string StandardFormat()
+    {
+        var last = string.Empty;
+        for (var i = 0; i < _values.Length; i++)
+        {
+            last = _values[i].ToString("F1", _culture);
+        }
+
+        return last;
+    }
+}

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -37,6 +37,10 @@ Reports land in `tests/benchmarks/BenchmarkDotNet.Artifacts/results/` (gitignore
 | `SyntaxHighlightingConverterBenchmarks` | The same repaint through the syntax highlighting converter - the most expensive per-row work in the grid - in all three formatting modes. |
 | `SmallConverterBenchmarks` | The handful of small converters a row goes through (boolean/null bindings, color swatches, ellipsis, batch convert status). |
 | `BrushCreationBenchmarks` | Why the converters hand out `ImmutableSolidColorBrush`: a `SolidColorBrush` is an AvaloniaObject with a property store, for a color that never changes. |
+| `SpectrogramRenderBenchmarks` | One playback frame of `AudioVisualizer.Render` with the spectrogram shown, static view vs center mode, against a waveform-only frame as the control. |
+| `ChangeDetectionHashBenchmarks` | The whole-file hash the dirty star, auto-save and undo change detection run about five times a second, on the UI thread. |
+| `UpdateGapsBenchmarks` | The 400 ms slow timer's whole-file gap refresh. |
+| `OneDecimalFormatBenchmarks` | The CPS/WPM cells' `ToString("0.0")` against the standard `"F1"` specifier. |
 
 Benchmarks that model a collection the app gets from Avalonia (e.g. `DataGrid.SelectedItems`)
 reproduce its interface surface rather than substituting a `List<T>` - `SelectedItems` only

--- a/tests/benchmarks/SpectrogramRenderBenchmarks.cs
+++ b/tests/benchmarks/SpectrogramRenderBenchmarks.cs
@@ -1,0 +1,212 @@
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic.Media;
+using SkiaSharp;
+using System.Runtime.InteropServices;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// One real playback frame of <see cref="AudioVisualizer.Render"/> with the spectrogram shown -
+/// the sibling scenario of <see cref="AudioVisualizerRenderBenchmarks"/>, which only ever runs
+/// the waveform. Every other draw method in the control has an anchored per-block cache;
+/// DrawSpectrogram was the one that rebuilt its whole bitmap on every frame (a new SKBitmap, N
+/// blits into it and a full per-pixel premultiply walk into a fresh WriteableBitmap), so this
+/// stands in for what the ~60 fps cursor timer pays while the spectrogram is visible.
+///
+/// Rasterized rather than recorded (see RenderFrame): the DrawingGroup recorder that
+/// AudioVisualizerRenderBenchmarks uses does not implement DrawBitmap, the one call
+/// DrawSpectrogram makes. The raster cost is the same in all three scenarios below.
+///
+/// Scenarios:
+///  - StaticViewPlaybackFrame (baseline): the view stands still (plain playback, waveform not
+///    centered) and only the cursor moves.
+///  - CenterModePlaybackFrame: "center video position" is on, so the view scrolls a few
+///    spectrogram columns every frame - the pathological path for an exact-position cache key.
+///  - WaveformOnlyPlaybackFrame: the same static frame with the spectrogram hidden, as the floor.
+/// </summary>
+[MemoryDiagnoser]
+public class SpectrogramRenderBenchmarks
+{
+    private const double WidthPx = 1600;
+    private const double HeightPx = 220;
+    private const double FrameSeconds = 1 / 60.0;
+    private const int PeaksPerSecond = 126; // Se.Settings.Waveform.WaveformMinimumSampleRate default
+    private const int PeaksLengthSeconds = 600;
+
+    // What WavePeakGenerator2 uses: fft size 256 (image height 128), 1024 columns per image,
+    // one column per 256 samples at 44.1 kHz.
+    private const int FftSize = 256;
+    private const int SpectrogramImageWidth = 1024;
+    private const double SampleDuration = FftSize / 44100.0;
+
+    private static bool _avaloniaInitialized;
+
+    private AudioVisualizer _withSpectrogram = null!;
+    private AudioVisualizer _waveformOnly = null!;
+    private List<SubtitleLineViewModel> _subtitles = null!;
+    private readonly List<SubtitleLineViewModel> _noSelection = new();
+    private double _centerPositionSeconds;
+    private double _staticPositionSeconds;
+    private double _viewSeconds;
+    private int _frameIndex;
+
+    private const double StaticViewStart = 10;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        if (!_avaloniaInitialized)
+        {
+            _avaloniaInitialized = true;
+            AppBuilder.Configure<Application>()
+                .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false })
+                .UseSkia()
+                .WithInterFont()
+                .SetupWithoutStarting();
+        }
+
+        _renderTarget = new RenderTargetBitmap(new PixelSize((int)WidthPx, (int)HeightPx), new Vector(96, 96));
+        _withSpectrogram = MakeVisualizer(withSpectrogram: true);
+        _waveformOnly = MakeVisualizer(withSpectrogram: false);
+
+        _subtitles = SubtitleFactory.Make(2000);
+        _viewSeconds = WidthPx / (double)PeaksPerSecond; // ZoomFactor is 1.0
+        _centerPositionSeconds = 10;
+        _staticPositionSeconds = StaticViewStart + 1;
+        _frameIndex = 0;
+    }
+
+    private static AudioVisualizer MakeVisualizer(bool withSpectrogram)
+    {
+        var av = new AudioVisualizer
+        {
+            WaveformDrawStyle = WaveformDrawStyle.Classic,
+            WavePeaks = MakeSpeechLikePeaks(),
+        };
+
+        if (withSpectrogram)
+        {
+            av.SetSpectrogram(MakeSpectrogram());
+            av.SetDisplayMode(WaveformDisplayMode.WaveformAndSpectrogram);
+        }
+
+        av.Measure(new Size(WidthPx, HeightPx));
+        av.Arrange(new Rect(0, 0, WidthPx, HeightPx));
+        return av;
+    }
+
+    [Benchmark]
+    public void CenterModePlaybackFrame()
+    {
+        _centerPositionSeconds += FrameSeconds;
+        if (_centerPositionSeconds > PeaksLengthSeconds - _viewSeconds - 5)
+        {
+            _centerPositionSeconds = 10;
+        }
+
+        Drive(_withSpectrogram, Math.Max(0, _centerPositionSeconds - _viewSeconds / 2.0), _centerPositionSeconds);
+        RenderFrame(_withSpectrogram);
+    }
+
+    [Benchmark(Baseline = true)]
+    public void StaticViewPlaybackFrame()
+    {
+        AdvanceStatic();
+        Drive(_withSpectrogram, StaticViewStart, _staticPositionSeconds);
+        RenderFrame(_withSpectrogram);
+    }
+
+    [Benchmark]
+    public void WaveformOnlyPlaybackFrame()
+    {
+        AdvanceStatic();
+        Drive(_waveformOnly, StaticViewStart, _staticPositionSeconds);
+        RenderFrame(_waveformOnly);
+    }
+
+    private void AdvanceStatic()
+    {
+        _staticPositionSeconds += FrameSeconds;
+        if (_staticPositionSeconds > StaticViewStart + _viewSeconds - 1)
+        {
+            _staticPositionSeconds = StaticViewStart + 1;
+        }
+    }
+
+    private void Drive(AudioVisualizer av, double startSeconds, double positionSeconds)
+    {
+        // Every third frame is the 50 ms position timer refreshing the paragraph window; the
+        // other two are the ~60 fps cursor timer gliding the cursor and the centered scroll.
+        if (++_frameIndex % 3 == 0)
+        {
+            av.SetPosition(startSeconds, _subtitles, positionSeconds, -1, _noSelection);
+        }
+        else
+        {
+            av.StartPositionSeconds = startSeconds;
+            av.CurrentVideoPositionSeconds = positionSeconds;
+        }
+    }
+
+    private RenderTargetBitmap _renderTarget = null!;
+
+    private void RenderFrame(AudioVisualizer av)
+    {
+        // Rasterizing rather than recording into a DrawingGroup (which AudioVisualizerRenderBenchmarks
+        // can do): the DrawingGroup recorder does not implement DrawBitmap, which is exactly the call
+        // DrawSpectrogram makes. The raster cost is identical across all three scenarios here, so the
+        // differences between them are still purely the per-frame spectrogram work.
+        using var context = _renderTarget.CreateDrawingContext();
+        av.Render(context);
+    }
+
+    /// <summary>
+    /// Spectrogram images shaped exactly like the generator's: Rgba8888/Premul, 1024 columns
+    /// wide and fft/2 tall, with a deterministic pattern so nothing is a uniform block.
+    /// </summary>
+    private static SpectrogramData2 MakeSpectrogram()
+    {
+        const int height = FftSize / 2;
+        var imageCount = (int)(PeaksLengthSeconds / (SampleDuration * SpectrogramImageWidth)) + 2;
+        var images = new List<SKBitmap>(imageCount);
+        var buffer = new byte[SpectrogramImageWidth * height * 4];
+        for (var i = 0; i < imageCount; i++)
+        {
+            for (var p = 0; p < buffer.Length; p += 4)
+            {
+                var v = (byte)((p / 4 + i * 37) % 251);
+                buffer[p] = v;
+                buffer[p + 1] = (byte)(255 - v);
+                buffer[p + 2] = (byte)(v / 2);
+                buffer[p + 3] = 255;
+            }
+
+            var bmp = new SKBitmap(SpectrogramImageWidth, height, SKColorType.Rgba8888, SKAlphaType.Premul);
+            Marshal.Copy(buffer, 0, bmp.GetPixels(), buffer.Length);
+            images.Add(bmp);
+        }
+
+        return new SpectrogramData2(FftSize, SpectrogramImageWidth, SampleDuration, images);
+    }
+
+    private static WavePeakData2 MakeSpeechLikePeaks()
+    {
+        var random = new Random(42);
+        var peaks = new WavePeak2[PeaksPerSecond * PeaksLengthSeconds];
+        for (var i = 0; i < peaks.Length; i++)
+        {
+            var seconds = i / (double)PeaksPerSecond;
+            var inBurst = seconds % 0.5 < 0.3;
+            var amplitude = inBurst ? random.Next(4000, 28000) : random.Next(0, 900);
+            peaks[i] = new WavePeak2((short)amplitude, (short)-random.Next(amplitude / 2, amplitude + 1));
+        }
+
+        return new WavePeakData2(PeaksPerSecond, peaks);
+    }
+}


### PR DESCRIPTION
Two hot paths found by a perf pass over the waveform render loop and the subtitle grid's change detection, both verified with BenchmarkDotNet.

The four smaller items from the same pass are in #13538 — split out so they can be reviewed and merged separately. Independent of this PR; either can go first.

---

## 1. Waveform spectrogram: build once per block instead of once per frame

`AudioVisualizer.DrawSpectrogram` was the last draw method in the control without an anchored cache. It composed the visible window into a fresh `SKBitmap` and converted it into a fresh `WriteableBitmap` — about a megabyte each — on **every ~60 fps frame**. It now builds once per 256-column block (with one block of padding) into buffers that are reused across rebuilds, and a view scrolling inside the block is drawn as a translated destination rectangle. Same scheme `DrawWaveForm`, `DrawTimeLine` and `DrawAllGridLines` already use.

One center-mode playback frame with the spectrogram shown, against a waveform-only frame as the in-run control:

| | Before | After |
|---|---:|---:|
| Center-mode frame | 2,639.8 µs | **1,687.1 µs** |
| Gen0 / Gen2 collections per 1000 frames | 125 / **117** | 7.8 / **0** |
| Control (spectrogram hidden, untouched) | 911.3 µs | 912.7 µs |

The gen2 column is the point: two large-object allocations per frame forced a full GC every few frames, which is what the play-head stutter looks like. The measured means include Skia rasterization, which the app does on the render thread, so the UI-thread saving is larger than the table shows.

The cache is dropped when the spectrogram is replaced (its pixels come from that instance's images) and on a theme change; the buffers themselves are only released in the former case, so a theme change reuses them.

## 2. Change-detection hash: memoize the per-line text hash

The dirty star, auto-save and undo change detection hash every line of the file about five times a second — a 333 ms undo timer and a 400 ms title/auto-save tick, each covering the working text and the original — and all of it runs on the UI thread (`GetFastHash` marshals itself there deliberately, so a tick cannot enumerate `Subtitles` mid-edit and lose an undo entry). `string.GetHashCode` is a full pass over the characters on every call; .NET does not cache it. A line's text is unchanged between practically all of those ticks, so it is now memoized per string instance, like the other read-time memos on the row view model. Strings are immutable, so the same instance can only ever have the same hash.

| Whole-file pass, 2000-line translation job | Before | After |
|---|---:|---:|
| Mean | 112.63 µs | **18.43 µs** |

## Supporting change

`ToAvaloniaBitmap`'s pixel walk moved into a shared writer plus a new `CopyToAvaloniaBitmap(SKBitmap, WriteableBitmap)` so the block cache can target a bitmap it already owns. The conversion logic itself is unchanged, and a test pins the new entry point against it over premultiplied and straight alpha, opaque and transparent pixels, converted colour types, and buffer reuse.

---

## Measured and rejected

Kept as benchmarks rather than as code, so the next pass does not retry them:

- **`ToString("F1")` instead of `"0.0"`** for the CPS/WPM cells (the most expensive grid converter per cell): 35.7 vs 36.4 µs — identical. .NET already fast-paths that custom format.
- **`UpdateGaps`** on the 400 ms timer: 4.33 µs for 2000 lines, zero allocation. Nothing to gain.

## Testing

Full UI suite on the branch: **2460 passed, 0 failed**. New tests cover the memoized hashes against the `GetHashCode` call they replace, and the new bitmap writer against the conversion it shares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
