### PR TITLE
Perf: four micro-optimizations in the grid converters and the waveform render loop

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -1827,13 +1827,7 @@ public class AudioVisualizer : Control
 
             if (WavePeaks == null && ShowClickToGenerateHint && !string.IsNullOrEmpty(ClickToGenerateText))
             {
-                var hint = new FormattedText(
-                    ClickToGenerateText,
-                    CultureInfo.CurrentCulture,
-                    FlowDirection.LeftToRight,
-                    Typeface.Default,
-                    14,
-                    Brushes.Gainsboro);
+                var hint = GetClickToGenerateHintText();
                 context.DrawText(hint, new Point((width - hint.Width) / 2, (height - hint.Height) / 2));
             }
 
@@ -1842,6 +1836,31 @@ public class AudioVisualizer : Control
                 context.DrawRectangle(null, _paintPenSelected, boundsRect);
             }
         }
+    }
+
+    // The "click to generate" hint is drawn while a video is loaded but its waveform has not been
+    // generated yet - and CurrentVideoPositionSeconds is an AffectsRender property the ~60 fps
+    // cursor timer writes on every tick, so that state renders at full frame rate. Shaping the
+    // hint per frame was a FormattedText (and a full text layout) 60 times a second for a string
+    // that only changes with the UI language.
+    private FormattedText? _clickToGenerateHintText;
+    private string? _clickToGenerateHintSource;
+
+    private FormattedText GetClickToGenerateHintText()
+    {
+        if (_clickToGenerateHintText == null || !ReferenceEquals(_clickToGenerateHintSource, ClickToGenerateText))
+        {
+            _clickToGenerateHintSource = ClickToGenerateText;
+            _clickToGenerateHintText = new FormattedText(
+                ClickToGenerateText,
+                CultureInfo.CurrentCulture,
+                FlowDirection.LeftToRight,
+                Typeface.Default,
+                14,
+                Brushes.Gainsboro);
+        }
+
+        return _clickToGenerateHintText;
     }
 
     private void DrawSpectrogram(DrawingContext context, ref RenderContext renderCtx)

--- a/src/ui/Logic/SubtitleSyntaxTokenizer.cs
+++ b/src/ui/Logic/SubtitleSyntaxTokenizer.cs
@@ -180,9 +180,20 @@ public static class SubtitleSyntaxTokenizer
         { "yellowgreen", Color.FromRgb(154, 205, 50) }
     };
 
+    // Both colour parsers run per colour tag, per visible row, on every grid repaint - and again
+    // per keystroke for the edit box, which tokenizes its visible lines. Parsing a "#RRGGBB"
+    // used to allocate six strings on the way (the caller's substring, Trim, the part after '#'
+    // and one two-char string per channel) plus a Convert.ToByte per channel; the span overloads
+    // below allocate nothing. The string overloads are kept for callers that already hold one.
+    private static readonly Dictionary<string, Color>.AlternateLookup<ReadOnlySpan<char>> NamedColorsBySpan =
+        NamedColors.GetAlternateLookup<ReadOnlySpan<char>>();
+
     internal static Color? TryParseColor(string colorValue)
+        => colorValue == null ? null : TryParseColor(colorValue.AsSpan());
+
+    internal static Color? TryParseColor(ReadOnlySpan<char> colorValue)
     {
-        if (string.IsNullOrWhiteSpace(colorValue))
+        if (colorValue.IsWhiteSpace())
         {
             return null;
         }
@@ -190,45 +201,45 @@ public static class SubtitleSyntaxTokenizer
         colorValue = colorValue.Trim();
 
         // Check named colors
-        if (NamedColors.TryGetValue(colorValue, out var namedColor))
+        if (NamedColorsBySpan.TryGetValue(colorValue, out var namedColor))
         {
             return namedColor;
         }
 
         // Check hex colors
-        if (colorValue.StartsWith('#'))
+        if (colorValue.Length > 0 && colorValue[0] == '#')
         {
             var hex = colorValue[1..];
-            try
+            if (hex.Length == 3)
             {
-                if (hex.Length == 3)
+                // Short hex format: #RGB -> #RRGGBB
+                if (TryParseHexDigit(hex[0], out var r) &&
+                    TryParseHexDigit(hex[1], out var g) &&
+                    TryParseHexDigit(hex[2], out var b))
                 {
-                    // Short hex format: #RGB -> #RRGGBB
-                    var r = Convert.ToByte(new string(hex[0], 2), 16);
-                    var g = Convert.ToByte(new string(hex[1], 2), 16);
-                    var b = Convert.ToByte(new string(hex[2], 2), 16);
-                    return Color.FromRgb(r, g, b);
+                    // What Convert.ToByte(new string(digit, 2), 16) produced: the digit doubled.
+                    return Color.FromRgb((byte)(r * 17), (byte)(g * 17), (byte)(b * 17));
                 }
-                else if (hex.Length == 6)
+            }
+            else if (hex.Length == 6)
+            {
+                // Standard hex format: #RRGGBB
+                if (TryParseHexByte(hex[..2], out var r) &&
+                    TryParseHexByte(hex[2..4], out var g) &&
+                    TryParseHexByte(hex[4..6], out var b))
                 {
-                    // Standard hex format: #RRGGBB
-                    var r = Convert.ToByte(hex[..2], 16);
-                    var g = Convert.ToByte(hex[2..4], 16);
-                    var b = Convert.ToByte(hex[4..6], 16);
-                    return Color.FromRgb(r, g, b);
-                }
-                else if (hex.Length == 8)
-                {
-                    // Hex with alpha: #AARRGGBB or #RRGGBBAA
-                    var r = Convert.ToByte(hex[2..4], 16);
-                    var g = Convert.ToByte(hex[4..6], 16);
-                    var b = Convert.ToByte(hex[6..8], 16);
                     return Color.FromRgb(r, g, b);
                 }
             }
-            catch
+            else if (hex.Length == 8)
             {
-                return null;
+                // Hex with alpha: #AARRGGBB or #RRGGBBAA
+                if (TryParseHexByte(hex[2..4], out var r) &&
+                    TryParseHexByte(hex[4..6], out var g) &&
+                    TryParseHexByte(hex[6..8], out var b))
+                {
+                    return Color.FromRgb(r, g, b);
+                }
             }
         }
 
@@ -236,8 +247,11 @@ public static class SubtitleSyntaxTokenizer
     }
 
     internal static Color? TryParseAssColor(string colorValue)
+        => colorValue == null ? null : TryParseAssColor(colorValue.AsSpan());
+
+    internal static Color? TryParseAssColor(ReadOnlySpan<char> colorValue)
     {
-        if (string.IsNullOrWhiteSpace(colorValue))
+        if (colorValue.IsWhiteSpace())
         {
             return null;
         }
@@ -245,35 +259,74 @@ public static class SubtitleSyntaxTokenizer
         colorValue = colorValue.Trim();
 
         // ASS/SSA color format: &HBBGGRR& or &HAABBGGRR&
-        if (colorValue.StartsWith("&H", StringComparison.OrdinalIgnoreCase) && colorValue.EndsWith('&'))
+        if (colorValue.StartsWith("&H", StringComparison.OrdinalIgnoreCase) && colorValue.EndsWith("&"))
         {
-            var hex = colorValue.Substring(2, colorValue.Length - 3);
-            try
+            var hex = colorValue.Slice(2, colorValue.Length - 3);
+            if (hex.Length == 6)
             {
-                if (hex.Length == 6)
+                // Format: &HBBGGRR& (BGR format)
+                if (TryParseHexByte(hex[..2], out var b) &&
+                    TryParseHexByte(hex[2..4], out var g) &&
+                    TryParseHexByte(hex[4..6], out var r))
                 {
-                    // Format: &HBBGGRR& (BGR format)
-                    var b = Convert.ToByte(hex[..2], 16);
-                    var g = Convert.ToByte(hex[2..4], 16);
-                    var r = Convert.ToByte(hex[4..6], 16);
-                    return Color.FromRgb(r, g, b);
-                }
-                else if (hex.Length == 8)
-                {
-                    // Format: &HAABBGGRR& (ABGR format)
-                    var b = Convert.ToByte(hex[2..4], 16);
-                    var g = Convert.ToByte(hex[4..6], 16);
-                    var r = Convert.ToByte(hex[6..8], 16);
                     return Color.FromRgb(r, g, b);
                 }
             }
-            catch
+            else if (hex.Length == 8)
             {
-                return null;
+                // Format: &HAABBGGRR& (ABGR format)
+                if (TryParseHexByte(hex[2..4], out var b) &&
+                    TryParseHexByte(hex[4..6], out var g) &&
+                    TryParseHexByte(hex[6..8], out var r))
+                {
+                    return Color.FromRgb(r, g, b);
+                }
             }
         }
 
         return null;
+    }
+
+    // Exact Convert.ToByte(s, 16) parity for the two-character slices above, which is what the
+    // string version called. Its accepted grammar for two characters is two hex digits, or a
+    // leading '+' and one hex digit ("+f" is 15) - and notably NOT surrounding white space, so
+    // byte.TryParse with NumberStyles.HexNumber is *not* a drop-in replacement: it would accept
+    // "#ff 800" and "&H00 F00&", which the old parser rejected (caught by the equivalence test).
+    private static bool TryParseHexByte(ReadOnlySpan<char> hex, out byte value)
+    {
+        value = 0;
+        if (hex.Length != 2)
+        {
+            return false;
+        }
+
+        if (hex[0] == '+')
+        {
+            if (!TryParseHexDigit(hex[1], out var only))
+            {
+                return false;
+            }
+
+            value = (byte)only;
+            return true;
+        }
+
+        if (!TryParseHexDigit(hex[0], out var high) || !TryParseHexDigit(hex[1], out var low))
+        {
+            return false;
+        }
+
+        value = (byte)((high << 4) | low);
+        return true;
+    }
+
+    private static bool TryParseHexDigit(char c, out int value)
+    {
+        if (c >= '0' && c <= '9') { value = c - '0'; return true; }
+        if (c >= 'a' && c <= 'f') { value = c - 'a' + 10; return true; }
+        if (c >= 'A' && c <= 'F') { value = c - 'A' + 10; return true; }
+        value = 0;
+        return false;
     }
 
     /// <summary>
@@ -297,10 +350,6 @@ public static class SubtitleSyntaxTokenizer
         return tagNameEnd;
     }
 
-    /// <summary>
-    /// True for the ASS/SSA color tags whose value is rendered in its actual color
-    /// (c, 1c, 2c, 3c, 4c).
-    /// </summary>
     internal static bool IsAssColorTag(ReadOnlySpan<char> tagName)
     {
         return tagName.Equals("c", StringComparison.OrdinalIgnoreCase) ||
@@ -384,7 +433,7 @@ public static class SubtitleSyntaxTokenizer
                             Color? assColor = null;
                             if (IsAssColorTag(tagName))
                             {
-                                assColor = TryParseAssColor(text[tagNameEnd..thisTagEnd]);
+                                assColor = TryParseAssColor(text.AsSpan(tagNameEnd, thisTagEnd - tagNameEnd));
                             }
 
                             Add(tagNameEnd, thisTagEnd, assColor ?? valuesColor);
@@ -510,7 +559,7 @@ public static class SubtitleSyntaxTokenizer
                 // Check if this is a color attribute
                 if (lastAttributeIsColor && !valueContent.IsEmpty)
                 {
-                    valueColor = TryParseColor(valueContent.ToString());
+                    valueColor = TryParseColor(valueContent);
                 }
 
                 // If not a color attribute or color parsing failed, use default logic

--- a/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
@@ -60,10 +60,30 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
 
     private static readonly TextDecorationCollection MisspelledDecorations = new() { MisspelledDecoration };
 
-    // Colors parsed out of the subtitle itself (ASSA \c tags, <font color=...>) are arbitrary, so
-    // there is nothing worth caching - but an immutable brush is a plain object where
-    // SolidColorBrush is an AvaloniaObject that drags a property store along for a fixed color.
-    private static ImmutableSolidColorBrush CreateBrush(Color color) => new(color);
+    // Colors parsed out of the subtitle itself (ASSA \c tags, <font color=...>). An immutable
+    // brush is a plain object where SolidColorBrush is an AvaloniaObject that drags a property
+    // store along for a fixed color - but a brush per colored run per repaint still adds up:
+    // a file typically uses a handful of colors across hundreds of lines, and every one of those
+    // runs is rebuilt whenever its row repaints. Unlike the theme palette above these colors are
+    // arbitrary, so the cache is capped and dropped wholesale rather than grown without bound.
+    private static readonly Dictionary<Color, ImmutableSolidColorBrush> DocumentBrushCache = new();
+    private const int DocumentBrushCacheLimit = 256;
+
+    private static ImmutableSolidColorBrush CreateBrush(Color color)
+    {
+        if (!DocumentBrushCache.TryGetValue(color, out var brush))
+        {
+            if (DocumentBrushCache.Count >= DocumentBrushCacheLimit)
+            {
+                DocumentBrushCache.Clear();
+            }
+
+            brush = new ImmutableSolidColorBrush(color);
+            DocumentBrushCache[color] = brush;
+        }
+
+        return brush;
+    }
 
     // <font face="..."> and \fnName repeat the same handful of names down a whole file, and
     // constructing a FontFamily parses the name every time.
@@ -526,7 +546,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                             if (SubtitleSyntaxTokenizer.IsAssColorTag(str.AsSpan(tagNameStart, tagNameEnd - tagNameStart)))
                             {
                                 // Only the color tags need the value as a string
-                                assColor = SubtitleSyntaxTokenizer.TryParseAssColor(str.Substring(tagNameEnd, thisTagEnd - tagNameEnd));
+                                assColor = SubtitleSyntaxTokenizer.TryParseAssColor(str.AsSpan(tagNameEnd, thisTagEnd - tagNameEnd));
                             }
 
                             builder.Append(str, tagNameEnd, thisTagEnd - tagNameEnd,
@@ -729,7 +749,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                         }
                         else if (tagName.Equals("font", StringComparison.OrdinalIgnoreCase))
                         {
-                            ParseFontTag(str.Substring(contentStart, contentEnd - contentStart), state);
+                            ParseFontTag(str.AsSpan(contentStart, contentEnd - contentStart), state);
                         }
                     }
                     i = tagEnd + 1;
@@ -854,12 +874,62 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
         return run;
     }
 
-    private static void ParseFontTag(string tagContent, FormattingState state)
+    /// <summary>
+    /// What a <c>&lt;font ...&gt;</c> tag sets, memoized by the tag's text.
+    /// </summary>
+    private readonly record struct FontTagValues(Color? Color, string? FontName, double? FontSize);
+
+    // A subtitle repeats the same few <font> tags down the whole file, and every visible row
+    // re-parses its own on every repaint: a substring of the tag, up to three regex matches and
+    // a group value per attribute, plus a color parse. Memoize by the tag text and probe with a
+    // span, so a hit costs one dictionary lookup and allocates nothing at all. Capped and
+    // dropped wholesale like the brush cache above - the contents are arbitrary user data.
+    private static readonly Dictionary<string, FontTagValues> FontTagCache = new(StringComparer.Ordinal);
+    private static readonly Dictionary<string, FontTagValues>.AlternateLookup<ReadOnlySpan<char>> FontTagCacheBySpan =
+        FontTagCache.GetAlternateLookup<ReadOnlySpan<char>>();
+    private const int FontTagCacheLimit = 128;
+
+    private static void ParseFontTag(ReadOnlySpan<char> tagContent, FormattingState state)
     {
-        if (string.IsNullOrEmpty(tagContent) || tagContent.Length > 500)
+        if (tagContent.IsEmpty || tagContent.Length > 500)
         {
             return; // Skip empty or excessively long tag content
         }
+
+        if (!FontTagCacheBySpan.TryGetValue(tagContent, out var values))
+        {
+            values = ParseFontTagUncached(tagContent.ToString());
+            if (FontTagCache.Count >= FontTagCacheLimit)
+            {
+                FontTagCache.Clear();
+            }
+
+            FontTagCacheBySpan[tagContent] = values;
+        }
+
+        // Only attributes the tag actually carried are applied, exactly as before: the parse
+        // wrote to the state only inside each attribute's success branch.
+        if (values.Color.HasValue)
+        {
+            state.Color = values.Color;
+        }
+
+        if (values.FontName != null)
+        {
+            state.FontName = values.FontName;
+        }
+
+        if (values.FontSize.HasValue)
+        {
+            state.FontSize = values.FontSize;
+        }
+    }
+
+    private static FontTagValues ParseFontTagUncached(string tagContent)
+    {
+        Color? color = null;
+        string? fontName = null;
+        double? fontSize = null;
 
         try
         {
@@ -877,7 +947,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                     try
                     {
                         var skColor = HtmlUtil.GetColorFromString(colorValue);
-                        state.Color = Color.FromArgb(skColor.Alpha, skColor.Red, skColor.Green, skColor.Blue);
+                        color = Color.FromArgb(skColor.Alpha, skColor.Red, skColor.Green, skColor.Blue);
                     }
                     catch
                     {
@@ -892,10 +962,10 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                 : Match.Empty;
             if (faceMatch.Success)
             {
-                var fontName = faceMatch.Groups[1].Value.Trim();
-                if (fontName.Length > 0 && fontName.Length <= 100)
+                var face = faceMatch.Groups[1].Value.Trim();
+                if (face.Length > 0 && face.Length <= 100)
                 {
-                    state.FontName = fontName;
+                    fontName = face;
                 }
             }
 
@@ -905,7 +975,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                 : Match.Empty;
             if (sizeMatch.Success && double.TryParse(sizeMatch.Groups[1].Value, out var size))
             {
-                state.FontSize = size;
+                fontSize = size;
             }
         }
         catch (RegexMatchTimeoutException)
@@ -916,6 +986,8 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
         {
             // Ignore any other parsing errors
         }
+
+        return new FontTagValues(color, fontName, fontSize);
     }
 
     /// <summary>
@@ -1407,7 +1479,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                 IBrush valueBrush;
                 if (source.AsSpan(attrStart, attributeNameLength).Equals("color", StringComparison.OrdinalIgnoreCase))
                 {
-                    var parsedColor = SubtitleSyntaxTokenizer.TryParseColor(source.Substring(valueStart, i - valueStart));
+                    var parsedColor = SubtitleSyntaxTokenizer.TryParseColor(source.AsSpan(valueStart, i - valueStart));
                     valueBrush = parsedColor.HasValue
                         ? CreateBrush(parsedColor.Value)
                         : ValuesBrush;

--- a/src/ui/Logic/ValueConverters/TimeCodeDisplayCache.cs
+++ b/src/ui/Logic/ValueConverters/TimeCodeDisplayCache.cs
@@ -1,0 +1,63 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections.Generic;
+
+namespace Nikse.SubtitleEdit.Logic.ValueConverters;
+
+/// <summary>
+/// Memoizes formatted time codes for the grid's time converters.
+/// </summary>
+/// <remarks>
+/// Every visible row formats its start and end time twice and its duration twice: once for the
+/// cell, and once more for the row's accessible name, which is a MultiBinding over the same
+/// values through the same converter instances (see InitListViewAndEditBox). So half of the
+/// time-code formatting a repaint does - and half of the strings it allocates - is a value that
+/// was just produced. Scrolling back over rows that were already shown hits too.
+///
+/// UI thread only, like the <c>TimeCode</c> instance the converters reuse for formatting.
+/// </remarks>
+internal sealed class TimeCodeDisplayCache
+{
+    // A viewport is a few dozen rows; the cap only exists so a long session of dragging time
+    // codes cannot grow this without bound. Dropped wholesale, like the waveform's text caches.
+    private const int Limit = 4096;
+
+    private readonly Dictionary<long, string> _byTicks = new(256);
+
+    // Everything outside the time value itself that the formatters consult. Held as a snapshot
+    // rather than folded into the key so a hit stays a single lookup; a change drops the cache,
+    // which is what happens when the user flips the time format or sets a video offset.
+    private bool _frameMode;
+    private double _frameRate;
+    private double _videoOffsetMs;
+
+    public bool TryGet(long ticks, out string value)
+    {
+        var general = Se.Settings.General;
+        var frameMode = general.UseFrameMode;
+        var frameRate = Configuration.Settings.General.CurrentFrameRate;
+        var videoOffsetMs = general.CurrentVideoOffsetInMs;
+
+        if (_frameMode != frameMode || _frameRate != frameRate || _videoOffsetMs != videoOffsetMs)
+        {
+            _frameMode = frameMode;
+            _frameRate = frameRate;
+            _videoOffsetMs = videoOffsetMs;
+            _byTicks.Clear();
+            value = string.Empty;
+            return false;
+        }
+
+        return _byTicks.TryGetValue(ticks, out value!);
+    }
+
+    public void Set(long ticks, string value)
+    {
+        if (_byTicks.Count >= Limit)
+        {
+            _byTicks.Clear();
+        }
+
+        _byTicks[ticks] = value;
+    }
+}

--- a/src/ui/Logic/ValueConverters/TimeSpanToDisplayFullConverter.cs
+++ b/src/ui/Logic/ValueConverters/TimeSpanToDisplayFullConverter.cs
@@ -17,10 +17,20 @@ public class TimeSpanToDisplayFullConverter : IValueConverter
     private const string ZeroTime = "00:00:00,000";
     private static readonly char[] SplitChars = ['.', ':', ';', ','];
 
+    // The start and end time of every visible row go through here twice per repaint - see
+    // TimeCodeDisplayCache.
+    private readonly TimeCodeDisplayCache _cache = new();
+
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is TimeSpan ts)
         {
+            if (_cache.TryGet(ts.Ticks, out var cached))
+            {
+                return cached;
+            }
+
+            var key = ts.Ticks;
             if (Se.Settings.General.CurrentVideoOffsetInMs != 0)
             {
                 ts = ts.Add(TimeSpan.FromMilliseconds(Se.Settings.General.CurrentVideoOffsetInMs));
@@ -28,12 +38,12 @@ public class TimeSpanToDisplayFullConverter : IValueConverter
 
             _formattingTimeCode.TimeSpan = ts;
 
-            if (Se.Settings.General.UseFrameMode)
-            {
-                return _formattingTimeCode.ToHHMMSSFF();
-            }
+            var formatted = Se.Settings.General.UseFrameMode
+                ? _formattingTimeCode.ToHHMMSSFF()
+                : _formattingTimeCode.ToString();
 
-            return _formattingTimeCode.ToString();
+            _cache.Set(key, formatted);
+            return formatted;
         }
 
         return Se.Settings.General.UseFrameMode ? ZeroFrameMode : ZeroTime;

--- a/src/ui/Logic/ValueConverters/TimeSpanToDisplayShortConverter.cs
+++ b/src/ui/Logic/ValueConverters/TimeSpanToDisplayShortConverter.cs
@@ -16,15 +16,27 @@ public class TimeSpanToDisplayShortConverter : IValueConverter
     private const string ZeroFrameMode = "00.00";
     private const string ZeroTime = "00,000";
 
+    // The duration of every visible row goes through here twice per repaint - see
+    // TimeCodeDisplayCache.
+    private readonly TimeCodeDisplayCache _cache = new();
+
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         var useFrameMode = Se.Settings.General.UseFrameMode;
         if (value is TimeSpan ts)
         {
+            if (_cache.TryGet(ts.Ticks, out var cached))
+            {
+                return cached;
+            }
+
             _formattingTimeCode.TimeSpan = ts;
-            return useFrameMode
+            var formatted = useFrameMode
                 ? _formattingTimeCode.ToShortStringHHMMSSFF()
                 : _formattingTimeCode.ToShortString();
+
+            _cache.Set(ts.Ticks, formatted);
+            return formatted;
         }
 
         return useFrameMode ? ZeroFrameMode : ZeroTime;

--- a/tests/UI/Logic/SubtitleSyntaxTokenizerColorEquivalenceTests.cs
+++ b/tests/UI/Logic/SubtitleSyntaxTokenizerColorEquivalenceTests.cs
@@ -1,0 +1,198 @@
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using System;
+using System.Collections.Generic;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// The colour parsers were rewritten to work on spans (they run per colour tag, per visible row,
+/// on every grid repaint, and again per keystroke for the edit box). These pin the rewrite against
+/// verbatim copies of the implementations it replaced, over a battery that covers every branch and
+/// the odd inputs a subtitle file can carry: wrong lengths, non-hex digits, surrounding and
+/// embedded whitespace, empty and whitespace-only values, and casing.
+/// </summary>
+public class SubtitleSyntaxTokenizerColorEquivalenceTests
+{
+    [Fact]
+    public void TryParseColor_MatchesTheImplementationItReplaced()
+    {
+        var diffs = new List<string>();
+        foreach (var input in Battery())
+        {
+            var expected = ReferenceTryParseColor(input);
+            var actual = SubtitleSyntaxTokenizer.TryParseColor(input);
+            if (expected != actual)
+            {
+                diffs.Add($"[{input}] expected={expected?.ToString() ?? "null"} actual={actual?.ToString() ?? "null"}");
+            }
+        }
+
+        Assert.True(diffs.Count == 0, string.Join("\n", diffs));
+    }
+
+    [Fact]
+    public void TryParseAssColor_MatchesTheImplementationItReplaced()
+    {
+        var diffs = new List<string>();
+        foreach (var input in Battery())
+        {
+            var expected = ReferenceTryParseAssColor(input);
+            var actual = SubtitleSyntaxTokenizer.TryParseAssColor(input);
+            if (expected != actual)
+            {
+                diffs.Add($"[{input}] expected={expected?.ToString() ?? "null"} actual={actual?.ToString() ?? "null"}");
+            }
+        }
+
+        Assert.True(diffs.Count == 0, string.Join("\n", diffs));
+    }
+
+    [Fact]
+    public void TryParseColor_ParsesTheCommonForms()
+    {
+        Assert.Equal(Color.FromRgb(0xFF, 0x88, 0x00), SubtitleSyntaxTokenizer.TryParseColor("#ff8800"));
+        Assert.Equal(Color.FromRgb(0xAA, 0xBB, 0xCC), SubtitleSyntaxTokenizer.TryParseColor("#abc"));
+        Assert.Equal(Color.FromRgb(255, 0, 0), SubtitleSyntaxTokenizer.TryParseColor("Red"));
+        Assert.Null(SubtitleSyntaxTokenizer.TryParseColor("#gg8800"));
+    }
+
+    [Fact]
+    public void TryParseAssColor_ParsesTheCommonForms()
+    {
+        // &HBBGGRR&
+        Assert.Equal(Color.FromRgb(0x00, 0xFF, 0x00), SubtitleSyntaxTokenizer.TryParseAssColor("&H00FF00&"));
+        Assert.Equal(Color.FromRgb(0x33, 0x22, 0x11), SubtitleSyntaxTokenizer.TryParseAssColor("&H112233&"));
+        Assert.Null(SubtitleSyntaxTokenizer.TryParseAssColor("&H00FF00"));
+    }
+
+    private static IEnumerable<string> Battery()
+    {
+        string[] cores =
+        {
+            "", " ", "\t", "#", "#a", "#ab", "#abc", "#ABC", "#f0f", "#ff8800", "#FF8800",
+            "#ff88", "#ff880", "#ff8800ff", "#ffff8800", "#gg8800", "#ff88zz", "#-f8800",
+            "#+f8800", "#ff 800", "# ff8800", "#0x8800", "red", "Red", "RED", "notacolor",
+            "&H00FF00&", "&h00ff00&", "&H112233&", "&HFF112233&", "&H00FF00", "H00FF00&",
+            "&H&", "&H1&", "&H12345&", "&H1234567&", "&HGGFF00&", "&H00 F00&", "&H-0FF00&",
+            "&H00FF00&&", "&&H00FF00&",
+        };
+
+        foreach (var core in cores)
+        {
+            yield return core;
+            yield return " " + core;
+            yield return core + " ";
+            yield return "  " + core + "  ";
+            yield return "\t" + core + "\n";
+        }
+    }
+
+    // ---- verbatim copies of the string implementations that were replaced ----
+
+    private static Color? ReferenceTryParseColor(string colorValue)
+    {
+        if (string.IsNullOrWhiteSpace(colorValue))
+        {
+            return null;
+        }
+
+        colorValue = colorValue.Trim();
+
+        if (NamedColors.TryGetValue(colorValue, out var namedColor))
+        {
+            return namedColor;
+        }
+
+        if (colorValue.StartsWith('#'))
+        {
+            var hex = colorValue[1..];
+            try
+            {
+                if (hex.Length == 3)
+                {
+                    var r = Convert.ToByte(new string(hex[0], 2), 16);
+                    var g = Convert.ToByte(new string(hex[1], 2), 16);
+                    var b = Convert.ToByte(new string(hex[2], 2), 16);
+                    return Color.FromRgb(r, g, b);
+                }
+
+                if (hex.Length == 6)
+                {
+                    var r = Convert.ToByte(hex[..2], 16);
+                    var g = Convert.ToByte(hex[2..4], 16);
+                    var b = Convert.ToByte(hex[4..6], 16);
+                    return Color.FromRgb(r, g, b);
+                }
+
+                if (hex.Length == 8)
+                {
+                    var r = Convert.ToByte(hex[2..4], 16);
+                    var g = Convert.ToByte(hex[4..6], 16);
+                    var b = Convert.ToByte(hex[6..8], 16);
+                    return Color.FromRgb(r, g, b);
+                }
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    private static Color? ReferenceTryParseAssColor(string colorValue)
+    {
+        if (string.IsNullOrWhiteSpace(colorValue))
+        {
+            return null;
+        }
+
+        colorValue = colorValue.Trim();
+
+        if (colorValue.StartsWith("&H", StringComparison.OrdinalIgnoreCase) && colorValue.EndsWith('&'))
+        {
+            var hex = colorValue.Substring(2, colorValue.Length - 3);
+            try
+            {
+                if (hex.Length == 6)
+                {
+                    var b = Convert.ToByte(hex[..2], 16);
+                    var g = Convert.ToByte(hex[2..4], 16);
+                    var r = Convert.ToByte(hex[4..6], 16);
+                    return Color.FromRgb(r, g, b);
+                }
+
+                if (hex.Length == 8)
+                {
+                    var b = Convert.ToByte(hex[2..4], 16);
+                    var g = Convert.ToByte(hex[4..6], 16);
+                    var r = Convert.ToByte(hex[6..8], 16);
+                    return Color.FromRgb(r, g, b);
+                }
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The production named-colour table, read by reflection so the reference above can only
+    /// differ from it in loop shape, never in data.
+    /// </summary>
+    private static readonly Dictionary<string, Color> NamedColors = ReadNamedColors();
+
+    private static Dictionary<string, Color> ReadNamedColors()
+    {
+        var field = typeof(SubtitleSyntaxTokenizer).GetField(
+            "NamedColors",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(field);
+        return (Dictionary<string, Color>)field!.GetValue(null)!;
+    }
+}

--- a/tests/benchmarks/MicroPathRound6Benchmarks.cs
+++ b/tests/benchmarks/MicroPathRound6Benchmarks.cs
@@ -1,0 +1,268 @@
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.Logic.ValueConverters;
+using System.Globalization;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// The grid's time-code cells as the app actually drives them: every visible row formats its
+/// start and end time and its duration once for the cell binding and a second time for the row's
+/// accessible name, which is a MultiBinding over the same values through the same converter
+/// instances (InitListViewAndEditBox). <see cref="GridCellConverterBenchmarks"/> converts each
+/// value once and so cannot see that.
+/// </summary>
+[MemoryDiagnoser]
+public class TimeCodeCellRepaintBenchmarks
+{
+    private const int Rows = 40; // a viewport, not the whole file - the grid virtualizes
+
+    private readonly CultureInfo _culture = CultureInfo.InvariantCulture;
+
+    private TimeSpanToDisplayFullConverter _fullTime = null!;
+    private TimeSpanToDisplayShortConverter _shortTime = null!;
+    private TimeSpan[] _startTimes = null!;
+    private TimeSpan[] _endTimes = null!;
+    private TimeSpan[] _durations = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        GridCellConverterBenchmarks.EnsureAvalonia();
+
+        _fullTime = new TimeSpanToDisplayFullConverter();
+        _shortTime = new TimeSpanToDisplayShortConverter();
+
+        _startTimes = new TimeSpan[Rows];
+        _endTimes = new TimeSpan[Rows];
+        _durations = new TimeSpan[Rows];
+        for (var i = 0; i < Rows; i++)
+        {
+            _startTimes[i] = TimeSpan.FromMilliseconds(i * 2400 + 137);
+            _durations[i] = TimeSpan.FromMilliseconds(1500 + i % 900);
+            _endTimes[i] = _startTimes[i] + _durations[i];
+        }
+    }
+
+    /// <summary>One repaint: three cell bindings plus the accessible-name MultiBinding per row.</summary>
+    [Benchmark]
+    public object ViewportRepaint()
+    {
+        object last = null!;
+        for (var i = 0; i < Rows; i++)
+        {
+            // Cells
+            last = _fullTime.Convert(_startTimes[i], typeof(string), null, _culture);
+            last = _fullTime.Convert(_endTimes[i], typeof(string), null, _culture);
+            last = _shortTime.Convert(_durations[i], typeof(string), null, _culture);
+
+            // AutomationProperties.Name MultiBinding over the same three values
+            last = _fullTime.Convert(_startTimes[i], typeof(string), null, _culture);
+            last = _fullTime.Convert(_endTimes[i], typeof(string), null, _culture);
+            last = _shortTime.Convert(_durations[i], typeof(string), null, _culture);
+        }
+
+        return last;
+    }
+}
+
+/// <summary>
+/// One playback frame of the waveform in two states the other render benchmarks do not cover:
+/// zoomed far out, where a screenful holds many paragraph rectangles and their footers, and with a
+/// video loaded whose waveform has not been generated yet (the "click to generate" hint). Both
+/// render at the full ~60 fps rate because CurrentVideoPositionSeconds is an AffectsRender
+/// property the cursor timer writes on every tick.
+/// </summary>
+[MemoryDiagnoser]
+public class WaveformPerFrameTextBenchmarks
+{
+    private const double WidthPx = 1600;
+    private const double HeightPx = 220;
+    private const double FrameSeconds = 1 / 60.0;
+    private const int PeaksPerSecond = 126;
+    private const int PeaksLengthSeconds = 600;
+
+    private static bool _avaloniaInitialized;
+
+    private AudioVisualizer _zoomedOut = null!;
+    private AudioVisualizer _noPeaks = null!;
+    private List<SubtitleLineViewModel> _subtitles = null!;
+    private readonly List<SubtitleLineViewModel> _noSelection = new();
+    private RenderTargetBitmap _renderTarget = null!;
+    private double _positionSeconds;
+    private int _frameIndex;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        if (!_avaloniaInitialized)
+        {
+            _avaloniaInitialized = true;
+            AppBuilder.Configure<Application>()
+                .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false })
+                .UseSkia()
+                .WithInterFont()
+                .SetupWithoutStarting();
+        }
+
+        Se.Settings.Waveform.WaveformShowNumberAndDuration = true;
+        Se.Settings.Waveform.WaveformShowCps = true;
+
+        _renderTarget = new RenderTargetBitmap(new PixelSize((int)WidthPx, (int)HeightPx), new Vector(96, 96));
+
+        _zoomedOut = new AudioVisualizer
+        {
+            WaveformDrawStyle = WaveformDrawStyle.Classic,
+            WavePeaks = MakeSpeechLikePeaks(),
+            // n = ZoomFactor * SampleRate lands between 15 and 51: the band where each footer is
+            // just "#N", and where a screenful holds a lot of paragraphs.
+            ZoomFactor = 0.25,
+        };
+        Arrange(_zoomedOut);
+
+        _noPeaks = new AudioVisualizer
+        {
+            ShowClickToGenerateHint = true,
+            ClickToGenerateText = "Click here to generate the waveform",
+        };
+        Arrange(_noPeaks);
+
+        _subtitles = SubtitleFactory.Make(2000);
+        _positionSeconds = 10;
+        _frameIndex = 0;
+    }
+
+    private static void Arrange(AudioVisualizer av)
+    {
+        av.Measure(new Size(WidthPx, HeightPx));
+        av.Arrange(new Rect(0, 0, WidthPx, HeightPx));
+    }
+
+    [Benchmark]
+    public void ZoomedOutParagraphFooters()
+    {
+        _positionSeconds += FrameSeconds;
+        if (_positionSeconds > PeaksLengthSeconds - 60)
+        {
+            _positionSeconds = 10;
+        }
+
+        if (++_frameIndex % 3 == 0)
+        {
+            _zoomedOut.SetPosition(10, _subtitles, _positionSeconds, -1, _noSelection);
+        }
+        else
+        {
+            _zoomedOut.CurrentVideoPositionSeconds = _positionSeconds;
+        }
+
+        RenderFrame(_zoomedOut);
+    }
+
+    [Benchmark]
+    public void ClickToGenerateHintFrame()
+    {
+        _positionSeconds += FrameSeconds;
+        _noPeaks.CurrentVideoPositionSeconds = _positionSeconds;
+        RenderFrame(_noPeaks);
+    }
+
+    private void RenderFrame(AudioVisualizer av)
+    {
+        using var context = _renderTarget.CreateDrawingContext();
+        av.Render(context);
+    }
+
+    private static WavePeakData2 MakeSpeechLikePeaks()
+    {
+        var random = new Random(42);
+        var peaks = new WavePeak2[PeaksPerSecond * PeaksLengthSeconds];
+        for (var i = 0; i < peaks.Length; i++)
+        {
+            var seconds = i / (double)PeaksPerSecond;
+            var inBurst = seconds % 0.5 < 0.3;
+            var amplitude = inBurst ? random.Next(4000, 28000) : random.Next(0, 900);
+            peaks[i] = new WavePeak2((short)amplitude, (short)-random.Next(amplitude / 2, amplitude + 1));
+        }
+
+        return new WavePeakData2(PeaksPerSecond, peaks);
+    }
+}
+
+/// <summary>
+/// The syntax highlighting converter over rows that carry colours - an HTML font tag and an ASSA
+/// colour override. Those are the rows that re-parsed the tag and built a brush on every repaint;
+/// <see cref="SyntaxHighlightingConverterBenchmarks"/> mixes them into a realistic file where they
+/// are one row in ten, which hides the per-row cost.
+/// </summary>
+[MemoryDiagnoser]
+public class ColoredSyntaxHighlightingBenchmarks
+{
+    private const int Rows = 200;
+
+    private readonly CultureInfo _culture = CultureInfo.InvariantCulture;
+
+    private TextWithSubtitleSyntaxHighlightingConverter _converter = null!;
+    private string[] _texts = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        GridCellConverterBenchmarks.EnsureAvalonia();
+        Se.Settings.Appearance.SubtitleGridFormattingType = (int)SubtitleGridFormattingTypes.ShowFormatting;
+        _converter = new TextWithSubtitleSyntaxHighlightingConverter();
+
+        // A colour-graded file: the same handful of font tags repeated down the whole subtitle,
+        // which is what colour tagging looks like in practice.
+        string[] sentences =
+        {
+            "<font color=\"#ff8800\" face=\"Arial\" size=\"20\">Somewhere in Denmark</font>",
+            "<font color=\"#00ccff\">- Are you coming with us?</font>\r\n<font color=\"#00ccff\">- No.</font>",
+            "{\\i1\\c&H00FF00&\\fnArial\\fs28}Do you have any idea{\\i0}\r\nwhat you have done?",
+            "<font color=\"#ff8800\" face=\"Arial\" size=\"20\">He said: \"Never again.\"</font>",
+        };
+
+        _texts = new string[Rows];
+        for (var i = 0; i < Rows; i++)
+        {
+            _texts[i] = sentences[i % sentences.Length];
+        }
+    }
+
+    /// <summary>The default grid mode: the tags are applied and hidden.</summary>
+    [Benchmark]
+    public object ColoredRowsRepaint()
+    {
+        Se.Settings.Appearance.SubtitleGridFormattingType = (int)SubtitleGridFormattingTypes.ShowFormatting;
+        return RunAll();
+    }
+
+    /// <summary>
+    /// "Show tags" mode, where the tag text itself is coloured - the mode that runs the
+    /// tokenizer's colour-value parsers (the edit box runs them per keystroke too).
+    /// </summary>
+    [Benchmark]
+    public object ColoredRowsRepaintShowTags()
+    {
+        Se.Settings.Appearance.SubtitleGridFormattingType = (int)SubtitleGridFormattingTypes.ShowTags;
+        return RunAll();
+    }
+
+    private object RunAll()
+    {
+        object last = null!;
+        for (var i = 0; i < Rows; i++)
+        {
+            last = _converter.Convert(_texts[i], typeof(object), null, _culture);
+        }
+
+        return last;
+    }
+}

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -37,6 +37,9 @@ Reports land in `tests/benchmarks/BenchmarkDotNet.Artifacts/results/` (gitignore
 | `SyntaxHighlightingConverterBenchmarks` | The same repaint through the syntax highlighting converter - the most expensive per-row work in the grid - in all three formatting modes. |
 | `SmallConverterBenchmarks` | The handful of small converters a row goes through (boolean/null bindings, color swatches, ellipsis, batch convert status). |
 | `BrushCreationBenchmarks` | Why the converters hand out `ImmutableSolidColorBrush`: a `SolidColorBrush` is an AvaloniaObject with a property store, for a color that never changes. |
+| `TimeCodeCellRepaintBenchmarks` | The grid's time-code cells as the app drives them: three cell bindings plus the accessible-name MultiBinding over the same three values. |
+| `WaveformPerFrameTextBenchmarks` | A playback frame zoomed far out, and one with a video loaded whose waveform has not been generated yet. |
+| `ColoredSyntaxHighlightingBenchmarks` | The syntax highlighting converter over rows carrying colours (font tags, ASSA colour overrides), in both formatting modes. |
 
 Benchmarks that model a collection the app gets from Avalonia (e.g. `DataGrid.SelectedItems`)
 reproduce its interface surface rather than substituting a `List<T>` - `SelectedItems` only


### PR DESCRIPTION
Four small wins found by reading the paths that run per row per repaint or per frame. Each is verified with BenchmarkDotNet, and the benchmarks are included — as is the one for the candidate that measured as a dud, so the next pass does not retry it.

Split out of #13537, which keeps the two larger items (the spectrogram block cache and the change-detection hash). Independent of that PR; either can go first.

---

## 1. Time-code cells were formatted twice per row

Every visible row formats its start and end time and its duration once for the cell binding, and again for the row's `AutomationProperties.Name` — a MultiBinding over the same three values through the same converter instances (see `InitListViewAndEditBox`). So half of the time-code formatting a repaint does, and half of the strings it allocates, reproduce a value that was just produced. Scrolling back over rows that were already shown hits too.

New `TimeCodeDisplayCache` memoizes the formatted string by tick value, and drops the cache when the time format, frame rate or video offset changes (held as a snapshot rather than folded into the key, so a hit stays a single lookup).

| 40-row viewport repaint | Before | After |
|---|---:|---:|
| Mean | 5.86 µs | **1.17 µs** |
| Allocated | 15.6 KB | **5.6 KB** |

## 2. `<font>` tags re-parsed on every repaint

A `<font>` tag was re-parsed for every visible row carrying one, on every repaint: a substring of the tag, up to three regex matches, a group value per attribute and a colour parse — for a tag a subtitle repeats down hundreds of lines. It is now memoized by the tag text and probed with a span (`Dictionary.GetAlternateLookup<ReadOnlySpan<char>>`), so a hit costs one dictionary lookup and allocates nothing at all.

`CreateBrush` also built a new `ImmutableSolidColorBrush` per coloured run per repaint. A file uses a handful of colours across hundreds of lines, so they are cached — capped and dropped wholesale, since unlike the theme palette these are arbitrary user data.

| 200 colour-graded rows, default formatting mode | Before | After |
|---|---:|---:|
| Mean | 146.1 µs | **101.0 µs** |
| Allocated | 750 KB | **550 KB** |

## 3. Colour value parsing without allocations

`SubtitleSyntaxTokenizer.TryParseColor` / `TryParseAssColor` allocated about six strings per call: the caller's substring, `Trim`, the part after `#`, and one two-character string per channel. They now have span overloads that allocate nothing, and the callers hand over spans. This runs per colour tag per repaint in "show tags" mode, and per keystroke for the edit box, which tokenizes its visible lines.

| 200 colour-graded rows, show-tags mode | Before | After |
|---|---:|---:|
| Mean | 678.1 µs | **658.8 µs** |
| Allocated | 3986 KB | **3927 KB** |

Modest, because show-tags mode is dominated by the Avalonia `Run` objects the colouring needs — but the parsers themselves are now free, and the edit box gets the same saving per keystroke.

**Worth a look during review:** the hex parsing is written to reproduce `Convert.ToByte(s, 16)` exactly rather than using `NumberStyles.HexNumber`, which is *not* a drop-in replacement — it accepts surrounding white space that `Convert` rejects (`"#ff 800"`, `"&H00 F00&"`) and rejects the leading `+` that `Convert` accepts (`"+f"` is 15). The first version of this change had all three differences; the new equivalence test caught them. It pins both parsers against verbatim copies of the implementations they replace over a 205-input battery (wrong lengths, non-hex digits, embedded and surrounding whitespace, casing, empty and whitespace-only values), reading the production named-colour table by reflection so the reference can only differ in loop shape, never in data.

## 4. The "click to generate" waveform hint

Shaped a `FormattedText` on every frame while a video is loaded but its waveform has not been generated yet. That state renders at the full ~60 fps rate, because `CurrentVideoPositionSeconds` is an `AffectsRender` property the cursor timer writes on every tick. Now cached per hint string, so it is rebuilt only when the UI language changes.

| One frame in that state | Before | After |
|---|---:|---:|
| Mean | 66.9 µs | **57.9 µs** |
| Allocated | 9.43 KB | **4.85 KB** |

---

## Measured and rejected

Caching the `"#N"` paragraph footer label. It *is* allocated per visible paragraph per frame, but the 250-paragraph cap plus the 5 px minimum rectangle width keep the count near 25, so a zoomed-out frame did not move: 662.5 → 656.7 µs, identical allocation. Reverted — and that scenario is kept as `WaveformPerFrameTextBenchmarks.ZoomedOutParagraphFooters`, where it doubles as the unchanged in-run control for the numbers above.

## Testing

Full UI suite on the branch: **2462 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
