### PR TITLE
Let the "Edit rule" window show a whole rule (#13530)

### DIFF
--- a/src/ui/Features/Edit/MultipleReplace/EditRuleWindow.cs
+++ b/src/ui/Features/Edit/MultipleReplace/EditRuleWindow.cs
@@ -1,6 +1,10 @@
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
 using Avalonia.Layout;
+using Avalonia.Media;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -11,19 +15,26 @@ public class EditRuleWindow : Window
     public EditRuleWindow(EditRuleViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        SizeToContent = SizeToContent.WidthAndHeight;
-        CanResize = false;
+
+        // Rules are often long regular expressions, so the window is resizable and the
+        // find/replace boxes wrap and grow with it - a fixed-width single-line box only
+        // ever showed ~60 characters of a rule (#13530).
+        Width = 700;
+        Height = 460;
+        MinWidth = 450;
+        MinHeight = 320;
+        CanResize = true;
         vm.Window = this;
         DataContext = vm;
 
-        var labelFindWhat = UiUtil.MakeLabel(Se.Language.Edit.MultipleReplace.FindWhat);
-        var textBoxFindWhat = UiUtil.MakeTextBox(300, vm, nameof(vm.FindWhat));
+        var labelFindWhat = MakeTopLabel(Se.Language.Edit.MultipleReplace.FindWhat);
+        var textBoxFindWhat = MakeWrappingTextBox(vm, nameof(vm.FindWhat), Se.Language.Edit.MultipleReplace.FindWhat);
 
-        var labelReplaceWith = UiUtil.MakeLabel(Se.Language.General.ReplaceWith);
-        var textBoxReplaceWith = UiUtil.MakeTextBox(300, vm, nameof(vm.ReplaceWith));
+        var labelReplaceWith = MakeTopLabel(Se.Language.General.ReplaceWith);
+        var textBoxReplaceWith = MakeWrappingTextBox(vm, nameof(vm.ReplaceWith), Se.Language.General.ReplaceWith);
 
         var labelDescription = UiUtil.MakeLabel(Se.Language.Edit.MultipleReplace.DescriptionOptional);
-        var textBoxDescription = UiUtil.MakeTextBox(300, vm, nameof(vm.Description));
+        var textBoxDescription = MakeStretchingTextBox(vm, nameof(vm.Description), Se.Language.General.Description);
 
         var radioButtonRegularExpression = UiUtil.MakeRadioButton(Se.Language.General.RegularExpression, vm, nameof(vm.IsRegularExpression));
         var radioButtonCaseSensitive = UiUtil.MakeRadioButton(Se.Language.General.CaseSensitive, vm, nameof(vm.IsCaseSensitive));
@@ -43,21 +54,21 @@ public class EditRuleWindow : Window
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
         var buttonPanel = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
-        
+
         var grid = new Grid
         {
             RowDefinitions =
             {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
                 new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
-                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
             },
             Margin = UiUtil.MakeWindowMargin(),
             ColumnSpacing = 10,
@@ -86,6 +97,56 @@ public class EditRuleWindow : Window
 
         Activated += delegate { textBoxFindWhat.Focus(); }; // hack to make OnKeyDown work
         KeyDown += vm.OnKeyDown;
-        Loaded += (s, e) => { Title = vm.Title; };
+        Loaded += (s, e) =>
+        {
+            Title = vm.Title;
+            UiUtil.RestoreWindowPosition(this);
+        };
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+    }
+
+    private static Label MakeTopLabel(string text)
+    {
+        var label = UiUtil.MakeLabel(text);
+        label.VerticalAlignment = VerticalAlignment.Top;
+        return label;
+    }
+
+    /// <summary>
+    /// Find/replace box: fills the window and wraps, so a long rule can be read in full.
+    /// AcceptsReturn stays false - Enter is the dialog's OK shortcut.
+    /// </summary>
+    private static TextBox MakeWrappingTextBox(EditRuleViewModel vm, string propertyTextPath, string automationName)
+    {
+        var textBox = new TextBox
+        {
+            AcceptsReturn = false,
+            TextWrapping = TextWrapping.Wrap,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            VerticalContentAlignment = VerticalAlignment.Top,
+            DataContext = vm,
+            [!TextBox.TextProperty] = new Binding(propertyTextPath) { Mode = BindingMode.TwoWay },
+        };
+
+        ScrollViewer.SetVerticalScrollBarVisibility(textBox, ScrollBarVisibility.Auto);
+        AutomationProperties.SetName(textBox, automationName);
+
+        return textBox;
+    }
+
+    private static TextBox MakeStretchingTextBox(EditRuleViewModel vm, string propertyTextPath, string automationName)
+    {
+        var textBox = new TextBox
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Center,
+            DataContext = vm,
+            [!TextBox.TextProperty] = new Binding(propertyTextPath) { Mode = BindingMode.TwoWay },
+        };
+
+        AutomationProperties.SetName(textBox, automationName);
+
+        return textBox;
     }
 }

--- a/tests/UI/Features/Edit/EditRuleWindowLayoutTests.cs
+++ b/tests/UI/Features/Edit/EditRuleWindowLayoutTests.cs
@@ -1,0 +1,124 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Features.Edit.MultipleReplace;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UITests.Features.Edit;
+
+/// <summary>
+/// The "Edit rule" window used to be a fixed-size dialog with three 300 px single-line text
+/// boxes, so a long regular expression could only ever be read ~60 characters at a time and
+/// the window could not be resized to see more (#13530). These tests pin the layout that
+/// fixes it: a resizable window whose find/replace boxes stretch with it and wrap.
+/// </summary>
+public class EditRuleWindowLayoutTests : IDisposable
+{
+    // An unclosed window outlives the test and races with the headless session teardown -
+    // and a stranded modal steals app-wide keyboard focus from every later test.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            // InitializeWindow posts a clamp-to-screen callback from Opened; flush it while the
+            // window is still alive so it does not run against a disposed platform implementation.
+            Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private EditRuleWindow BuildWindow(string findWhat = "", string replaceWith = "")
+    {
+        var vm = new EditRuleViewModel
+        {
+            FindWhat = findWhat,
+            ReplaceWith = replaceWith,
+        };
+        var window = new EditRuleWindow(vm);
+        _windows.Add(window);
+        return window;
+    }
+
+    private static List<TextBox> TextBoxes(EditRuleWindow window)
+    {
+        return window.GetLogicalDescendants().OfType<TextBox>().ToList();
+    }
+
+    [AvaloniaFact]
+    public void Window_IsResizable_AndOpensWideEnoughForALongRule()
+    {
+        var window = BuildWindow();
+
+        Assert.True(window.CanResize, "The edit rule window must be resizable.");
+        Assert.True(window.Width >= 600, $"The edit rule window opens only {window.Width:0.#} wide.");
+    }
+
+    [AvaloniaFact]
+    public void FindAndReplaceBoxes_FillTheWindowAndWrap()
+    {
+        var window = BuildWindow();
+        window.Show();
+        window.UpdateLayout();
+
+        var textBoxes = TextBoxes(window);
+        Assert.Equal(3, textBoxes.Count); // find, replace with, description
+
+        foreach (var textBox in textBoxes.Take(2))
+        {
+            Assert.Equal(TextWrapping.Wrap, textBox.TextWrapping);
+
+            // Enter is the dialog's OK shortcut, so the boxes wrap but never take a newline.
+            Assert.False(textBox.AcceptsReturn);
+
+            Assert.True(
+                textBox.Bounds.Width > window.Width / 2,
+                $"Text box is only {textBox.Bounds.Width:0.#} wide in a {window.Width:0.#} wide window.");
+        }
+    }
+
+    // The boxes can only follow the window if nothing pins their width: the old layout had a
+    // hard Width = 300 in an Auto column, so resizing the window just added empty space.
+    [AvaloniaFact]
+    public void NothingPinsTheWidthOfTheFieldColumn()
+    {
+        var window = BuildWindow();
+        window.Show();
+        window.UpdateLayout();
+
+        var grid = Assert.IsType<Grid>(window.Content);
+        var fieldColumn = grid.ColumnDefinitions[1];
+        Assert.Equal(GridUnitType.Star, fieldColumn.Width.GridUnitType);
+
+        foreach (var textBox in TextBoxes(window))
+        {
+            Assert.True(double.IsNaN(textBox.Width), $"Text box has a fixed width of {textBox.Width:0.#}.");
+            Assert.Equal(HorizontalAlignment.Stretch, textBox.HorizontalAlignment);
+        }
+    }
+
+    [AvaloniaFact]
+    public void ALongRule_IsLaidOutOverSeveralLines()
+    {
+        // ~180 characters - the kind of rule that used to scroll past a 60 character peephole.
+        var longRule = string.Concat(Enumerable.Repeat("(?<=[a-z])(foo|bar|baz)(?=[A-Z])|", 6));
+        var window = BuildWindow(longRule);
+        window.Show();
+        window.UpdateLayout();
+
+        var presenter = TextBoxes(window)[0].GetVisualDescendants().OfType<TextPresenter>().FirstOrDefault();
+        Assert.NotNull(presenter);
+        Assert.True(
+            presenter.TextLayout.TextLines.Count > 1,
+            $"A {longRule.Length} character rule was laid out on {presenter.TextLayout.TextLines.Count} line(s).");
+    }
+}


### PR DESCRIPTION
Fixes #13530.

The Multiple replace **Edit rule** dialog was a fixed-size window with three 300 px single-line text boxes (`CanResize = false`, both grid columns `Auto`), so a long regular expression could only be read ~60 characters at a time and there was no way to widen the window to see more.

### Changes

- The window is resizable and opens at 700x460 (min 450x320) instead of sizing itself to a fixed 300 px content.
- The fields live in a star column and stretch, so they follow the window width.
- *Find what* and *Replace with* wrap over several lines. `AcceptsReturn` stays `false`, so Enter is still the OK shortcut.
- Size and position are remembered, like in the other resizable windows (guarded by *Remember position and size*).

### Tests

New `EditRuleWindowLayoutTests` (headless) pins the layout: window resizable and wide enough, boxes wrap and fill the window, nothing pins the field width, and a ~180 character rule is laid out over more than one line. Full UI suite green (2462 tests).