### PR TITLE
Give user-entered regular expressions a match timeout

### DIFF
--- a/docs/features/edit.md
+++ b/docs/features/edit.md
@@ -34,6 +34,10 @@ Options:
 
 > **Matching a line break with a regular expression:** use `\n` between the words on the two lines (for example `ear\ntwice`). `\r\n` and `\r` are accepted too and are treated the same as `\n`, so a rule works regardless of how it was written or which platform created it.
 
+> **`^` and `$` in Find and Replace** match the start and the end of the whole subtitle text, so in a two-line subtitle `^-` only finds the dash on the first line. Write `(?m)` in front of the pattern - `(?m)^- ` - to make them match at every line break instead. (Multiple replace is the other way around, see below.)
+
+> **Slow patterns:** a pattern that has not finished with a single subtitle after five seconds is given up on and treated as no match for that subtitle, so an expression that backtracks forever - `(a+)+b` and friends - cannot lock up the program.
+
 > **Translator mode:** with an original subtitle loaded, both the text and the original text are searched. Within a line the text is searched first, then the original text, and the match is selected in the text box of the column it was found in.
 
 <!-- Screenshot: Find window -->
@@ -53,6 +57,8 @@ With an editable original subtitle loaded, a **Replace/search in** drop-down app
 - **Original text only** - only change the original subtitle
 
 The choice is remembered between sessions. It also applies to `F3` / `Shift+F3` until the Find window is used again, which always searches both columns. The drop-down is hidden when there is no original subtitle, or when the original is opened as a read-only reference - a read-only original is never written to.
+
+> **Replacement text:** group references work - `$1`, `$&`, `${name}` - and `\n` inserts a line break. Other backslash escapes are not expanded there: `\t` and `\u00A0` are inserted as those literal characters. To insert a special character, paste the character itself into the **Replace with** box. In the search pattern all .NET escapes work as usual, `\u00A0` included.
 
 <!-- Screenshot: Replace window -->
 ![Replace](../screenshots/replace.png)
@@ -84,6 +90,8 @@ Each rule has one of three match types, shown as an icon in the tree:
 | Case insensitive | Plain text match, ignores case |
 | Case sensitive | Plain text match, exact case |
 | Regular expression | Full .NET regex syntax. Use `\n` to match a line break between two lines (`\r\n` and `\r` are accepted too and treated as `\n`). |
+
+Unlike Find and Replace, regular expression rules here are matched in multiline mode: `^` and `$` match at the start and the end of *every* line, so `^- ` strips the dash from both lines of a two-line subtitle. Put `(?-m)` in front of the pattern to anchor to the whole subtitle text instead. The replacement text follows the same rules as in Replace above - `$1` and `\n` work, other backslash escapes do not.
 
 ### Managing categories
 

--- a/docs/features/modify-selection.md
+++ b/docs/features/modify-selection.md
@@ -23,7 +23,7 @@ Text rules:
 - **Starts with** — Text starts with the entered string
 - **Ends with** — Text ends with the entered string
 - **Not contains** — Text does not contain the entered string
-- **Regular expression** — Text matches the entered regex (case-insensitive; an invalid pattern matches nothing)
+- **Regular expression** — Text matches the entered regex (case-insensitive; an invalid pattern matches nothing, and one that has not finished with a line after five seconds is given up on for that line)
 - **All uppercase** — Text has letters and none of them are lowercase
 - **Blank lines** — Text is empty or whitespace only
 

--- a/src/libse/Common/RegexUtils.cs
+++ b/src/libse/Common/RegexUtils.cs
@@ -6,6 +6,14 @@ namespace Nikse.SubtitleEdit.Core.Common
 {
     public static partial class RegexUtils
     {
+        /// <summary>
+        /// Match timeout for user-entered regular expressions. A pattern with catastrophic backtracking
+        /// (e.g. "(a+)+b" on a long line without a "b") runs for practically forever, and as find/replace
+        /// matches on the UI thread that means a frozen program with no way out. SE 4 used the same five
+        /// seconds in its find/replace helper; callers treat the timeout as "no match".
+        /// </summary>
+        public static readonly TimeSpan UserPatternMatchTimeout = TimeSpan.FromSeconds(5);
+
         // Others classes may want to use this regex.
 #if NET7_0_OR_GREATER
         [GeneratedRegex(@"\bi\b")]

--- a/src/ui/Features/Edit/ModifySelection/ModifySelectionRule.cs
+++ b/src/ui/Features/Edit/ModifySelection/ModifySelectionRule.cs
@@ -348,7 +348,7 @@ public class ModifySelectionRule
                     _cachedRegexOptions = options;
                     try
                     {
-                        _cachedRegex = new Regex(Text, options | RegexOptions.Compiled);
+                        _cachedRegex = new Regex(Text, options | RegexOptions.Compiled, RegexUtils.UserPatternMatchTimeout);
                     }
                     catch
                     {
@@ -356,7 +356,20 @@ public class ModifySelectionRule
                     }
                 }
 
-                return _cachedRegex != null && _cachedRegex.IsMatch(text);
+                if (_cachedRegex == null)
+                {
+                    return false;
+                }
+
+                try
+                {
+                    return _cachedRegex.IsMatch(text);
+                }
+                catch (RegexMatchTimeoutException)
+                {
+                    // Pattern too slow for this line - no match, rather than taking the program down.
+                    return false;
+                }
 
             case RuleType.Odd:
                 return (item.Number % 2) == 1;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12770,7 +12770,7 @@ public partial class MainViewModel :
                 // failed and a \n replacement silently did nothing (#12484).
                 var normalizedLine = line.Replace("\r\n", "\n").Replace("\r", "\n");
                 var normalizedIndex = line.Substring(0, matchIndex).Replace("\r\n", "\n").Replace("\r", "\n").Length;
-                var regex = new Regex(RegexUtils.FixNewLine(result.SearchText));
+                var regex = new Regex(RegexUtils.FixNewLine(result.SearchText), RegexOptions.None, RegexUtils.UserPatternMatchTimeout);
                 var match = regex.Match(normalizedLine, normalizedIndex);
 
                 // Bail unless the match starts exactly at the recorded index AND
@@ -12790,7 +12790,7 @@ public partial class MainViewModel :
                 newLine = normalizedLine.Substring(0, normalizedIndex) + replaced + normalizedLine.Substring(normalizedIndex + match.Length);
                 return replaced.Length;
             }
-            catch (ArgumentException)
+            catch (Exception exception) when (exception is ArgumentException or RegexMatchTimeoutException)
             {
                 newLine = line;
                 return null;

--- a/src/ui/Logic/FindService.cs
+++ b/src/ui/Logic/FindService.cs
@@ -36,7 +36,9 @@ public partial class FindService : IFindService
     {
         if (_cachedRegex == null || _cachedRegexPattern != pattern || _cachedRegexOptions != options)
         {
-            _cachedRegex = new Regex(pattern, options);
+            // Timeout so a pattern with catastrophic backtracking cannot hang the UI thread; every
+            // caller below treats RegexMatchTimeoutException like an invalid pattern - no match.
+            _cachedRegex = new Regex(pattern, options, RegexUtils.UserPatternMatchTimeout);
             _cachedRegexPattern = pattern;
             _cachedRegexOptions = options;
         }
@@ -534,7 +536,7 @@ public partial class FindService : IFindService
                 return (true, newText, totalReplacements);
             }
         }
-        catch (ArgumentException)
+        catch (Exception exception) when (exception is ArgumentException or RegexMatchTimeoutException)
         {
             return (false, line, 0);
         }
@@ -613,7 +615,7 @@ public partial class FindService : IFindService
                 return (newText != line, newText, totalReplacements);
             }
         }
-        catch (ArgumentException)
+        catch (Exception exception) when (exception is ArgumentException or RegexMatchTimeoutException)
         {
             return (false, line, 0);
         }
@@ -636,7 +638,7 @@ public partial class FindService : IFindService
                     return (true, startIndex + match.Index, match.Value);
                 }
             }
-            catch (ArgumentException)
+            catch (Exception exception) when (exception is ArgumentException or RegexMatchTimeoutException)
             {
                 return (false, -1, string.Empty);
             }
@@ -671,7 +673,7 @@ public partial class FindService : IFindService
                     return (true, lastMatch.Index, lastMatch.Value);
                 }
             }
-            catch (ArgumentException)
+            catch (Exception exception) when (exception is ArgumentException or RegexMatchTimeoutException)
             {
                 return (false, -1, string.Empty);
             }
@@ -702,7 +704,7 @@ public partial class FindService : IFindService
                 return (true, startIndex + MapNormalizedIndex(indexMap, match.Index, originalLength), match.Value);
             }
         }
-        catch (ArgumentException)
+        catch (Exception exception) when (exception is ArgumentException or RegexMatchTimeoutException)
         {
             return (false, -1, string.Empty);
         }
@@ -736,7 +738,7 @@ public partial class FindService : IFindService
                 return (true, MapNormalizedIndex(indexMap, lastMatch.Index, originalLength), lastMatch.Value);
             }
         }
-        catch (ArgumentException)
+        catch (Exception exception) when (exception is ArgumentException or RegexMatchTimeoutException)
         {
             return (false, -1, string.Empty);
         }
@@ -759,7 +761,7 @@ public partial class FindService : IFindService
                     var searchLine = NormalizeLineEndingsForRegex(line);
                     return GetCachedRegex(RegexUtils.FixNewLine(searchText)).Matches(searchLine).Count;
                 }
-                catch (ArgumentException)
+                catch (Exception exception) when (exception is ArgumentException or RegexMatchTimeoutException)
                 {
                     return 0;
                 }
@@ -791,7 +793,7 @@ public partial class FindService : IFindService
                         matches.Add(new FindMatch(MapNormalizedIndex(indexMap, match.Index, line.Length), match.Value));
                     }
                 }
-                catch (ArgumentException)
+                catch (Exception exception) when (exception is ArgumentException or RegexMatchTimeoutException)
                 {
                     // Invalid regex pattern
                 }
@@ -815,7 +817,7 @@ public partial class FindService : IFindService
                             matches.Add(new FindMatch(match.Index, match.Value));
                         }
                     }
-                    catch (ArgumentException)
+                    catch (Exception exception) when (exception is ArgumentException or RegexMatchTimeoutException)
                     {
                         // Invalid regex pattern
                     }

--- a/tests/UI/Logic/FindServiceRegexTimeoutTests.cs
+++ b/tests/UI/Logic/FindServiceRegexTimeoutTests.cs
@@ -1,0 +1,92 @@
+using Nikse.SubtitleEdit.Logic;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace UITests.Logic;
+
+// A user-entered pattern with catastrophic backtracking used to run on the UI thread with no
+// timeout at all, so find/replace hung the program until it was killed. SE 4 gave the same
+// patterns five seconds; the timeout now comes back as "no match" instead of an exception.
+public class FindServiceRegexTimeoutTests
+{
+    // 30 a's and no "b": "(a+)+b" has to try every way of splitting them before giving up.
+    private const string EvilPattern = "(a+)+b";
+    private static readonly string EvilLine = new string('a', 30) + "c";
+
+    // Well above the five second timeout, but far below "never returns" - the point is that the
+    // call comes back at all, not how quickly.
+    private const int MaxSeconds = 60;
+
+    [Fact]
+    public void FindNext_CatastrophicPattern_TimesOutAsNotFound()
+    {
+        var lines = new List<string> { EvilLine };
+        var service = new FindService();
+        service.Initialize(lines, 0, false, FindService.FindMode.RegularExpression);
+
+        var stopwatch = Stopwatch.StartNew();
+        var lineIndex = service.FindNext(EvilPattern, lines, 0, 0);
+        stopwatch.Stop();
+
+        Assert.Equal(-1, lineIndex);
+        Assert.True(stopwatch.Elapsed.TotalSeconds < MaxSeconds, $"FindNext took {stopwatch.Elapsed.TotalSeconds:0.0}s");
+    }
+
+    [Fact]
+    public void ReplaceAll_CatastrophicPattern_TimesOutAndLeavesTextUnchanged()
+    {
+        var lines = new List<string> { EvilLine };
+        var service = new FindService();
+        service.Initialize(lines, 0, false, FindService.FindMode.RegularExpression);
+
+        var stopwatch = Stopwatch.StartNew();
+        var count = service.ReplaceAll(EvilPattern, "x");
+        stopwatch.Stop();
+
+        Assert.Equal(0, count);
+        Assert.Equal(EvilLine, lines[0]);
+        Assert.True(stopwatch.Elapsed.TotalSeconds < MaxSeconds, $"ReplaceAll took {stopwatch.Elapsed.TotalSeconds:0.0}s");
+    }
+
+    [Fact]
+    public void Count_CatastrophicPattern_TimesOutAsZero()
+    {
+        var lines = new List<string> { EvilLine };
+        var service = new FindService();
+        service.Initialize(lines, 0, false, FindService.FindMode.RegularExpression);
+
+        var stopwatch = Stopwatch.StartNew();
+        var count = service.Count(EvilPattern, lines, false, FindService.FindMode.RegularExpression);
+        stopwatch.Stop();
+
+        Assert.Equal(0, count);
+        Assert.True(stopwatch.Elapsed.TotalSeconds < MaxSeconds, $"Count took {stopwatch.Elapsed.TotalSeconds:0.0}s");
+    }
+
+    [Fact]
+    public void FindAll_CatastrophicPattern_TimesOutAsNoMatches()
+    {
+        var lines = new List<string> { EvilLine };
+        var service = new FindService();
+        service.Initialize(lines, 0, false, FindService.FindMode.RegularExpression);
+
+        var stopwatch = Stopwatch.StartNew();
+        var matches = service.FindAll(EvilPattern);
+        stopwatch.Stop();
+
+        Assert.Empty(matches);
+        Assert.True(stopwatch.Elapsed.TotalSeconds < MaxSeconds, $"FindAll took {stopwatch.Elapsed.TotalSeconds:0.0}s");
+    }
+
+    // A pattern that is merely long, not pathological, must still work - the timeout is a
+    // backstop, not a length limit.
+    [Fact]
+    public void FindNext_HeavyButFinitePattern_StillMatches()
+    {
+        var lines = new List<string> { new string('a', 5000) + "b" };
+        var service = new FindService();
+        service.Initialize(lines, 0, false, FindService.FindMode.RegularExpression);
+
+        Assert.Equal(0, service.FindNext("a+b", lines, 0, 0));
+    }
+}


### PR DESCRIPTION
Follow-up to the regex questions in #13527.

### Match timeout is back

SE 4 built its find/replace regex with `TimeSpan.FromSeconds(5)` (`FindReplaceDialogHelper.cs:103, 449`). The v5 rewrite dropped it, so a user-entered pattern with catastrophic backtracking - the classic `(a+)+b` against a line of a's - ran on the UI thread with nothing to stop it, and the only way out was to kill the program.

The five seconds come back as `RegexUtils.UserPatternMatchTimeout`, used everywhere a pattern typed by the user is compiled:

- `FindService` - find, find previous, count, find all, replace, replace all
- `MainViewModel.TryBuildReplacement` - the single replace from the main window
- `ModifySelectionRule` - the *Regular expression* rule

Every one of those call sites already treated an invalid pattern as "no match", so a timeout is folded into the same handling instead of surfacing an exception. *Modify selection* also needed its `IsMatch` guarded, since a timeout there would otherwise have escaped.

Multiple replace is left alone on purpose - it is being touched in another branch right now, and it never had a timeout in SE 4 either. Worth a follow-up.

### Docs

While answering #13527 it turned out none of this was written down anywhere:

- `^` and `$` anchor to the **whole subtitle text** in Find/Replace, but to **each line** in Multiple replace (SE 4 had the same split - `MultipleReplace.cs` used `RegexOptions.Multiline`, the find/replace helper used `RegexOptions.None`). `(?m)` and `(?-m)` switch either one, so both behaviours are reachable without changing the defaults and breaking everyone's saved rules.
- The replacement text expands `$1` / `$&` / `${name}` and `\n` only. `\t` and `\uNNNN` are inserted literally - .NET does not process backslash escapes in a replacement string. That was the actual complaint in #13527.
- The new timeout, in both Find/Replace and Modify selection.

### Tests

`tests/UI/Logic/FindServiceRegexTimeoutTests.cs` - find next, replace all, count and find all with a catastrophic pattern all come back as "nothing found" instead of hanging, plus one heavy-but-finite pattern that must still match, so the timeout cannot be mistaken for a length limit.

They cost about 20 seconds of wall clock, since proving the timeout means waiting for it four times. Say the word if that is too much and I will trim it to find next + replace all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
