### PR TITLE
Fix five bugs found in the beta11 commits

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1390,7 +1390,8 @@
       "deleteRuleConfirm": "Delete rule '{0}'?",
       "findWhat": "Find what",
       "descriptionOptional": "Description (optional)",
-      "invalidRegularExpressionX": "Invalid regular expression: {0}"
+      "invalidRegularExpressionX": "Invalid regular expression: {0}",
+      "regularExpressionTooSlowX": "Regular expression gave up after {0} seconds - the rule is skipped, try a simpler pattern"
     },
     "find": {
       "searchTextWatermark": "Search text...",
@@ -1434,6 +1435,7 @@
     "selectedXCharactersYLines": "Selected: {0} characters in {1} line(s)",
     "replacedXOccurrences": "Replaced {0} occurrence(s)",
     "invalidRegularExpression": "Invalid regular expression",
+    "regularExpressionTooSlowX": "Regular expression gave up after {0} seconds - try a simpler pattern",
     "moveLineUp": "Move line up",
     "moveLineDown": "Move line down",
     "duplicateLine": "Duplicate line",

--- a/src/ui/Features/Edit/MultipleReplace/CategoryPickerViewModel.cs
+++ b/src/ui/Features/Edit/MultipleReplace/CategoryPickerViewModel.cs
@@ -128,23 +128,35 @@ public partial class CategoryPickerViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+            return;
         }
-        else if (e.Key == Key.A && (e.KeyModifiers & (KeyModifiers.Control | KeyModifiers.Meta)) != 0)
+
+        // Ctrl/Cmd + A / D / Shift+I, the same three gestures the other tick-a-column lists use
+        // (see RemoveTextForHearingImpairedViewModel.HandleFixesSelectionKey).
+        var isCommand = e.KeyModifiers.HasFlag(KeyModifiers.Control) || e.KeyModifiers.HasFlag(KeyModifiers.Meta);
+        if (!isCommand || e.KeyModifiers.HasFlag(KeyModifiers.Alt))
         {
-            e.Handled = true;
-            if ((e.KeyModifiers & KeyModifiers.Shift) != 0)
-            {
-                SelectNone();
-            }
-            else
-            {
-                SelectAll();
-            }
+            return;
         }
-        else if (e.Key == Key.I && (e.KeyModifiers & KeyModifiers.Shift) != 0)
+
+        var isShift = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
+        if (e.Key == Key.A && !isShift)
         {
-            e.Handled = true;
+            SelectAll();
+        }
+        else if (e.Key == Key.D && !isShift)
+        {
+            SelectNone();
+        }
+        else if (e.Key == Key.I && isShift)
+        {
             InvertSelection();
         }
+        else
+        {
+            return;
+        }
+
+        e.Handled = true;
     }
 }

--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
@@ -54,7 +54,11 @@ public partial class MultipleReplaceViewModel : ObservableObject
     private readonly IFileHelper _fileHelper;
     private Subtitle _subtitle;
     private readonly ConcurrentDictionary<string, Regex> _compiledRegExList;
-    private readonly ConcurrentDictionary<string, string> _invalidRegExList;
+
+    // Pattern -> why it cannot run, or null when it is fine. Every regular expression rule is
+    // checked so a broken one is marked even in an unticked category, so this must not be the
+    // compiled cache: see GetRegexError.
+    private readonly ConcurrentDictionary<string, string?> _regExErrors;
     private readonly Timer _timerReplace;
     private readonly object _previewLock = new();
     private volatile bool _dirty;
@@ -80,7 +84,7 @@ public partial class MultipleReplaceViewModel : ObservableObject
         IsMultipleReplaceDotDotDotButtonsVisible = Se.Settings.Tools.MultipleReplaceShowDotDotDotButtons;
 
         _compiledRegExList = new ConcurrentDictionary<string, Regex>();
-        _invalidRegExList = new ConcurrentDictionary<string, string>();
+        _regExErrors = new ConcurrentDictionary<string, string?>();
 
         _timerReplace = new Timer();
         _timerReplace.Interval = 250;
@@ -1296,6 +1300,10 @@ public partial class MultipleReplaceViewModel : ObservableObject
         FixedSubtitle = new Subtitle(_subtitle, false);
         TotalReplaced = 0;
         var fixes = new List<MultipleReplaceFix>();
+
+        // Patterns the match timeout stopped part way through this pass - see the catch below.
+        HashSet<string>? retiredThisPass = null;
+
         for (var i = 0; i < _subtitle.Paragraphs.Count; i++)
         {
             var p = _subtitle.Paragraphs[i];
@@ -1317,19 +1325,35 @@ public partial class MultipleReplaceViewModel : ObservableObject
                 }
                 else if (item.SearchType == ReplaceExpression.SearchRegEx)
                 {
-                    if (!_compiledRegExList.TryGetValue(item.FindWhat, out var r))
+                    // retiredThisPass is null until something times out, so this costs a null
+                    // check per rule per line in the normal case. It is needed because the
+                    // expression list was built before the timeout, and without it every
+                    // remaining line would pay the five seconds again.
+                    if (retiredThisPass?.Contains(item.FindWhat) == true ||
+                        !TryGetRunnableRegex(item.FindWhat, out var r))
                     {
                         continue;
                     }
 
-                    // Match against line-feed-normalized text so a pattern's \n line break matches even
-                    // when the paragraph text uses \r\n (the pattern is FixNewLine'd to \n) (#11956).
-                    if (r.IsMatch(string.Join("\n", newText.SplitToLines())))
+                    try
                     {
-                        hit = true;
-                        ruleInfo = string.IsNullOrEmpty(ruleInfo) ? item.RuleInfo : $"{ruleInfo} + {item.RuleInfo}";
-                        ruleHits.Add(item);
-                        newText = RegexUtils.ReplaceNewLineSafe(r, newText, item.ReplaceWith);
+                        // Match against line-feed-normalized text so a pattern's \n line break matches even
+                        // when the paragraph text uses \r\n (the pattern is FixNewLine'd to \n) (#11956).
+                        if (r.IsMatch(string.Join("\n", newText.SplitToLines())))
+                        {
+                            var replaced = RegexUtils.ReplaceNewLineSafe(r, newText, item.ReplaceWith);
+                            hit = true;
+                            ruleInfo = string.IsNullOrEmpty(ruleInfo) ? item.RuleInfo : $"{ruleInfo} + {item.RuleInfo}";
+                            ruleHits.Add(item);
+                            newText = replaced;
+                        }
+                    }
+                    catch (RegexMatchTimeoutException)
+                    {
+                        // Five seconds on one line for a pattern that backtracks catastrophically
+                        // is already too much, so retire the rule rather than carrying on with it.
+                        (retiredThisPass ??= new HashSet<string>(StringComparer.Ordinal)).Add(item.FindWhat);
+                        RetireTimedOutRegex(item.FindWhat);
                     }
                 }
                 else
@@ -1419,32 +1443,65 @@ public partial class MultipleReplaceViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Null when the pattern compiles. A pattern that does not is skipped rather than allowed to
-    /// take the whole preview down with it (#13534) - the rule is marked in the tree instead.
+    /// Null when the pattern is usable. A pattern that will not compile - or that has already been
+    /// stopped by the match timeout - is skipped rather than allowed to take the whole preview down
+    /// with it (#13534); the rule is marked in the tree instead.
     /// </summary>
     private string? GetRegexError(string findWhat)
     {
-        if (_compiledRegExList.ContainsKey(findWhat))
+        // Deliberately NOT RegexOptions.Compiled: every regular expression rule is validated,
+        // including the ones in unticked categories that never run, and compiling emits IL that
+        // is never reclaimed. The runnable regex is built lazily in TryGetRunnableRegex instead.
+        return _regExErrors.GetOrAdd(findWhat, static pattern =>
         {
-            return null;
-        }
+            try
+            {
+                _ = new Regex(pattern, RegexOptions.Multiline, RegexUtils.UserPatternMatchTimeout);
+                return null;
+            }
+            catch (ArgumentException exception)
+            {
+                return string.Format(Se.Language.Edit.MultipleReplace.InvalidRegularExpressionX, exception.Message);
+            }
+        });
+    }
 
-        if (_invalidRegExList.TryGetValue(findWhat, out var known))
+    /// <summary>
+    /// The regex a rule actually runs with, built on first use. Carries the match timeout: without
+    /// it a pattern with catastrophic backtracking holds <see cref="_previewLock"/> forever - and
+    /// with it the UI thread, which waits on the same lock in "Ok" and "Apply".
+    /// </summary>
+    private bool TryGetRunnableRegex(string findWhat, out Regex regex)
+    {
+        if (_compiledRegExList.TryGetValue(findWhat, out regex!))
         {
-            return known;
+            return true;
         }
 
         try
         {
-            _compiledRegExList[findWhat] = new Regex(findWhat, RegexOptions.Compiled | RegexOptions.Multiline);
-            return null;
+            regex = new Regex(findWhat, RegexOptions.Compiled | RegexOptions.Multiline, RegexUtils.UserPatternMatchTimeout);
+            _compiledRegExList[findWhat] = regex;
+            return true;
         }
-        catch (ArgumentException exception)
+        catch (ArgumentException)
         {
-            var message = string.Format(Se.Language.Edit.MultipleReplace.InvalidRegularExpressionX, exception.Message);
-            _invalidRegExList[findWhat] = message;
-            return message;
+            regex = null!;
+            return false;
         }
+    }
+
+    /// <summary>
+    /// Retires a pattern the match timeout stopped. Recording it as an error means the next pass
+    /// leaves the rule out and marks it in the tree, so a rule that is too slow to run says so
+    /// rather than looking like a rule that simply matches nothing.
+    /// </summary>
+    private void RetireTimedOutRegex(string findWhat)
+    {
+        _regExErrors[findWhat] = string.Format(
+            Se.Language.Edit.MultipleReplace.RegularExpressionTooSlowX,
+            RegexUtils.UserPatternMatchTimeout.TotalSeconds);
+        _dirty = true;
     }
 
     private void ReportRuleErrors(List<(RuleTreeNode Rule, string? Message)> errors)

--- a/src/ui/Features/Shared/SourceView/SourceViewViewModel.cs
+++ b/src/ui/Features/Shared/SourceView/SourceViewViewModel.cs
@@ -376,13 +376,23 @@ public partial class SourceViewViewModel : ObservableObject, IClosingCleanup
         var options = MatchCase ? RegexOptions.None : RegexOptions.IgnoreCase;
         try
         {
-            return new Regex(pattern, options);
+            // Timeout so a pattern with catastrophic backtracking cannot hang the UI thread the
+            // search runs on; the three callers report the timeout as "no match" - see
+            // ReportRegexTooSlow.
+            return new Regex(pattern, options, RegexUtils.UserPatternMatchTimeout);
         }
         catch (ArgumentException)
         {
             FindStatus = Se.Language.SourceView.InvalidRegularExpression;
             return null;
         }
+    }
+
+    private void ReportRegexTooSlow()
+    {
+        FindStatus = string.Format(
+            Se.Language.SourceView.RegularExpressionTooSlowX,
+            RegexUtils.UserPatternMatchTimeout.TotalSeconds);
     }
 
     [RelayCommand]
@@ -426,9 +436,18 @@ public partial class SourceViewViewModel : ObservableObject, IClosingCleanup
             searchFrom++;
         }
 
-        var match = forward
-            ? FindForward(regex, text, searchFrom)
-            : FindBackward(regex, text, _editor.SelectionStart);
+        Match? match;
+        try
+        {
+            match = forward
+                ? FindForward(regex, text, searchFrom)
+                : FindBackward(regex, text, _editor.SelectionStart);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            ReportRegexTooSlow();
+            return false;
+        }
 
         if (match == null)
         {
@@ -500,15 +519,23 @@ public partial class SourceViewViewModel : ObservableObject, IClosingCleanup
         if (_editor.SelectionLength > 0)
         {
             var selected = _editor.SelectedText;
-            var match = regex.Match(selected);
-            if (match.Success && match.Index == 0 && match.Length == selected.Length)
+            try
             {
-                var replacement = UseRegularExpression
-                    ? match.Result(ReplaceText ?? string.Empty)
-                    : ReplaceText ?? string.Empty;
+                var match = regex.Match(selected);
+                if (match.Success && match.Index == 0 && match.Length == selected.Length)
+                {
+                    var replacement = UseRegularExpression
+                        ? match.Result(ReplaceText ?? string.Empty)
+                        : ReplaceText ?? string.Empty;
 
-                _editor.InsertText(replacement);
-                _editor.Select(_editor.CaretOffset, 0);
+                    _editor.InsertText(replacement);
+                    _editor.Select(_editor.CaretOffset, 0);
+                }
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                ReportRegexTooSlow();
+                return;
             }
         }
 
@@ -530,22 +557,36 @@ public partial class SourceViewViewModel : ObservableObject, IClosingCleanup
         }
 
         var text = _editor.Text ?? string.Empty;
-        var count = regex.Count(text);
-        if (count == 0)
+        int count;
+        string replacedText;
+        try
         {
-            FindStatus = string.Format(Se.Language.General.XNotFound, SearchText);
+            count = regex.Count(text);
+            if (count == 0)
+            {
+                FindStatus = string.Format(Se.Language.General.XNotFound, SearchText);
+                return;
+            }
+
+            var replacement = UseRegularExpression
+                ? ReplaceText ?? string.Empty
+                : (ReplaceText ?? string.Empty).Replace("$", "$$"); // a literal replacement stays literal
+
+            replacedText = regex.Replace(text, replacement);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            // Nothing is written: a half-applied replace-all over the whole document would be
+            // worse than none at all.
+            ReportRegexTooSlow();
             return;
         }
-
-        var replacement = UseRegularExpression
-            ? ReplaceText ?? string.Empty
-            : (ReplaceText ?? string.Empty).Replace("$", "$$"); // a literal replacement stays literal
 
         var caretBefore = _editor.CaretOffset;
 
         // One edit for the whole document: one undo step, and the text never goes around the undo
         // stack the way assigning Text would.
-        _editor.ReplaceAllText(regex.Replace(text, replacement));
+        _editor.ReplaceAllText(replacedText);
 
         _editor.Select(Math.Min(caretBefore, _editor.Document.TextLength), 0);
         _editor.BringCaretIntoView();

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -1870,7 +1870,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                     {
                         // Leave the line alone rather than the whole batch: the timeout already
                         // cost five seconds here and every remaining line would cost the same.
-                        SeLogger.Error($"Batch convert, multiple replace: rule '{item.RuleInfo}' timed out on line {i + 1} - skipping it for the rest of this file");
+                        SeLogger.Error($"Batch convert, multiple replace: {DescribeRule(item)} timed out on line {i + 1} - skipping it for the rest of this file");
                         timedOut.Add(item.FindWhat);
                     }
                 }
@@ -1937,6 +1937,21 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         }
 
         return replaceExpressions;
+    }
+
+    /// <summary>
+    /// A rule named so the log pinpoints it. RuleInfo is "category: description" and a description
+    /// is optional - and not unique when it is there - so the pattern is what actually identifies
+    /// the rule in the user's list.
+    /// </summary>
+    internal static string DescribeRule(ReplaceExpression item)
+    {
+        var info = (item.RuleInfo ?? string.Empty).TrimEnd();
+        info = info.TrimEnd(':').TrimEnd();
+
+        return string.IsNullOrEmpty(info)
+            ? $"rule '{item.FindWhat}'"
+            : $"rule '{item.FindWhat}' ({info})";
     }
 
     private Subtitle RemoveFormatting(Subtitle subtitle)

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -1826,6 +1826,11 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         }
 
         var replaceExpressions = BuildReplaceExpressions();
+
+        // Patterns the match timeout stopped. Retried on the next file - a pattern can be
+        // pathological on one line and harmless on the rest of the batch.
+        var timedOut = new HashSet<string>();
+
         for (var i = 0; i < subtitle.Paragraphs.Count; i++)
         {
             var p = subtitle.Paragraphs[i];
@@ -1845,12 +1850,28 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                 }
                 else if (item.SearchType == ReplaceExpression.SearchRegEx)
                 {
-                    var r = _compiledRegExList[item.FindWhat];
-                    if (r.IsMatch(newText))
+                    if (timedOut.Contains(item.FindWhat) ||
+                        !_compiledRegExList.TryGetValue(item.FindWhat, out var r))
                     {
-                        hit = true;
-                        ruleInfo = string.IsNullOrEmpty(ruleInfo) ? item.RuleInfo : $"{ruleInfo} + {item.RuleInfo}";
-                        newText = RegexUtils.ReplaceNewLineSafe(r, newText, item.ReplaceWith);
+                        continue; // pattern did not compile, or already gave up - both logged
+                    }
+
+                    try
+                    {
+                        if (r.IsMatch(newText))
+                        {
+                            var replaced = RegexUtils.ReplaceNewLineSafe(r, newText, item.ReplaceWith);
+                            hit = true;
+                            ruleInfo = string.IsNullOrEmpty(ruleInfo) ? item.RuleInfo : $"{ruleInfo} + {item.RuleInfo}";
+                            newText = replaced;
+                        }
+                    }
+                    catch (RegexMatchTimeoutException)
+                    {
+                        // Leave the line alone rather than the whole batch: the timeout already
+                        // cost five seconds here and every remaining line would cost the same.
+                        SeLogger.Error($"Batch convert, multiple replace: rule '{item.RuleInfo}' timed out on line {i + 1} - skipping it for the rest of this file");
+                        timedOut.Add(item.FindWhat);
                     }
                 }
                 else
@@ -1891,12 +1912,27 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                 var replaceWith = isRegex ? RegexUtils.FixNewLine(rule.ReplaceWith) : rule.ReplaceWith;
 
                 var mpi = new ReplaceExpression(findWhat, replaceWith, rule.Type.ToString(), category.Name + ": " + rule.Description);
-                replaceExpressions.Add(mpi);
                 if (mpi.SearchType == ReplaceExpression.SearchRegEx && !_compiledRegExList.ContainsKey(findWhat))
                 {
-                    _compiledRegExList.Add(findWhat,
-                        new Regex(findWhat, RegexOptions.Compiled | RegexOptions.Multiline));
+                    try
+                    {
+                        // With the match timeout, so a pattern with catastrophic backtracking cannot
+                        // stall the batch - the whole point of running it unattended.
+                        _compiledRegExList.Add(findWhat,
+                            new Regex(findWhat, RegexOptions.Compiled | RegexOptions.Multiline, RegexUtils.UserPatternMatchTimeout));
+                    }
+                    catch (ArgumentException exception)
+                    {
+                        // One saved rule that will not compile used to throw out of here and fail
+                        // every file in the batch with an opaque "parsing ..." status, naming
+                        // neither the rule nor the category. Skip the rule and carry on, the way
+                        // the Multiple replace window does (#13534).
+                        SeLogger.Error(exception, $"Batch convert, multiple replace: skipping rule with invalid regular expression '{findWhat}' in category '{category.Name}'");
+                        continue;
+                    }
                 }
+
+                replaceExpressions.Add(mpi);
             }
         }
 

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -6,6 +6,7 @@ using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.UiLogic;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -901,6 +902,16 @@ public class ChatterboxTtsCpp : ITtsEngine
             return true;
         }
 
+        // This runs per line, so a repair that cannot succeed - no ffmpeg on the machine, a WAV
+        // ffmpeg will not decode - must be attempted once, not once for every line of the
+        // subtitle. Checked ahead of the header read as well: that read logs when it fails, and
+        // a tools-log entry per line is its own kind of runaway. A repair that succeeds needs no
+        // guard at all - the file then passes the header check below and never comes back here.
+        if (FailedCloneReferenceRepairs.ContainsKey(voiceFilePath))
+        {
+            return false;
+        }
+
         if (!File.Exists(voiceFilePath) || IsCloneReadyReferenceWav(voiceFilePath))
         {
             return true;
@@ -909,8 +920,23 @@ public class ChatterboxTtsCpp : ITtsEngine
         Se.WriteToolsLog($"Chatterbox TTS: reference voice \"{Path.GetFileName(voiceFilePath)}\" is not "
             + $"{CloneReferenceSampleRate / 1000} kHz mono - re-encoding it in place before synthesis");
 
-        return ConvertToCloneReferenceWav(voiceFilePath, voiceFilePath);
+        if (ConvertToCloneReferenceWav(voiceFilePath, voiceFilePath))
+        {
+            return true;
+        }
+
+        FailedCloneReferenceRepairs[voiceFilePath] = 0;
+        return false;
     }
+
+    /// <summary>
+    /// Reference WAVs whose in-place repair has already been tried and failed, so it is not
+    /// retried for every remaining line. Re-import of the voice goes through
+    /// <see cref="ImportVoice"/>, which writes a new file name, so a fixed voice is never
+    /// held back by a stale entry here.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, byte> FailedCloneReferenceRepairs =
+        new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// True when the WAV is exactly what the chatterbox backend clones from: 24 kHz mono,

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -890,9 +890,10 @@ public class ChatterboxTtsCpp : ITtsEngine
     /// the conversion only ever runs once per file.
     /// </summary>
     /// <returns>
-    /// false only when there is a reference that needs converting and the conversion failed. No
-    /// reference at all (the baked default voice) and a reference that has gone missing are both
-    /// the server's business, not a conversion failure.
+    /// false only when there is a reference that needs converting and the conversion failed -
+    /// on this call, or on an earlier one against the same file contents. No reference at all
+    /// (the baked default voice) and a reference that has gone missing are both the server's
+    /// business, not a conversion failure.
     /// </returns>
     internal static bool EnsureCloneReferenceIsUsable(string? voiceFilePath)
     {
@@ -902,17 +903,45 @@ public class ChatterboxTtsCpp : ITtsEngine
             return true;
         }
 
+        FileStamp stamp;
+        try
+        {
+            var info = new FileInfo(voiceFilePath);
+            if (!info.Exists)
+            {
+                // A reference that has gone missing is the server's business, not a conversion
+                // failure.
+                return true;
+            }
+
+            stamp = new FileStamp(info.LastWriteTimeUtc.Ticks, info.Length);
+        }
+        catch (Exception exception)
+        {
+            Se.WriteToolsLog($"Chatterbox TTS: could not stat the reference voice \"{voiceFilePath}\" ({exception.Message}) - sending it as it is");
+            return true;
+        }
+
         // This runs per line, so a repair that cannot succeed - no ffmpeg on the machine, a WAV
         // ffmpeg will not decode - must be attempted once, not once for every line of the
         // subtitle. Checked ahead of the header read as well: that read logs when it fails, and
         // a tools-log entry per line is its own kind of runaway. A repair that succeeds needs no
         // guard at all - the file then passes the header check below and never comes back here.
-        if (FailedCloneReferenceRepairs.ContainsKey(voiceFilePath))
+        //
+        // Keyed on the file's stamp, not its path alone: the voices folder is documented and the
+        // user may well fix the WAV in place while the session is running, and a path-only guard
+        // would keep refusing the repaired file until restart.
+        if (FailedCloneReferenceRepairs.TryGetValue(voiceFilePath, out var failedStamp))
         {
-            return false;
+            if (failedStamp == stamp)
+            {
+                return false;
+            }
+
+            FailedCloneReferenceRepairs.TryRemove(voiceFilePath, out _);
         }
 
-        if (!File.Exists(voiceFilePath) || IsCloneReadyReferenceWav(voiceFilePath))
+        if (IsCloneReadyReferenceWav(voiceFilePath))
         {
             return true;
         }
@@ -925,17 +954,21 @@ public class ChatterboxTtsCpp : ITtsEngine
             return true;
         }
 
-        FailedCloneReferenceRepairs[voiceFilePath] = 0;
+        // The conversion writes a temp file and only moves it on success, so a failure leaves the
+        // reference exactly as it was - the stamp read above still describes it.
+        FailedCloneReferenceRepairs[voiceFilePath] = stamp;
         return false;
     }
 
+    /// <summary>Last write time and length, enough to tell a replaced reference WAV from the old one.</summary>
+    private readonly record struct FileStamp(long Ticks, long Length);
+
     /// <summary>
-    /// Reference WAVs whose in-place repair has already been tried and failed, so it is not
-    /// retried for every remaining line. Re-import of the voice goes through
-    /// <see cref="ImportVoice"/>, which writes a new file name, so a fixed voice is never
-    /// held back by a stale entry here.
+    /// Reference WAVs whose in-place repair has already been tried and failed, against the file
+    /// contents that failed, so it is not retried for every remaining line - but a file the user
+    /// replaces or repairs mid-session gets a fresh attempt.
     /// </summary>
-    private static readonly ConcurrentDictionary<string, byte> FailedCloneReferenceRepairs =
+    private static readonly ConcurrentDictionary<string, FileStamp> FailedCloneReferenceRepairs =
         new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>

--- a/src/ui/Logic/Config/Language/Edit/LanguageMultipleReplace.cs
+++ b/src/ui/Logic/Config/Language/Edit/LanguageMultipleReplace.cs
@@ -18,6 +18,7 @@ public class LanguageMultipleReplace
     public string FindWhat { get; set; }
     public string DescriptionOptional { get; set; }
     public string InvalidRegularExpressionX { get; set; }
+    public string RegularExpressionTooSlowX { get; set; }
 
     public LanguageMultipleReplace()
     {
@@ -37,5 +38,6 @@ public class LanguageMultipleReplace
         FindWhat = "Find what";
         DescriptionOptional = "Description (optional)";
         InvalidRegularExpressionX = "Invalid regular expression: {0}";
+        RegularExpressionTooSlowX = "Regular expression gave up after {0} seconds - the rule is skipped, try a simpler pattern";
     }
 }

--- a/src/ui/Logic/Config/Language/LanguageSourceView.cs
+++ b/src/ui/Logic/Config/Language/LanguageSourceView.cs
@@ -10,6 +10,7 @@ public class LanguageSourceView
     public string SelectedXCharactersYLines { get; set; }
     public string ReplacedXOccurrences { get; set; }
     public string InvalidRegularExpression { get; set; }
+    public string RegularExpressionTooSlowX { get; set; }
     public string MoveLineUp { get; set; }
     public string MoveLineDown { get; set; }
     public string DuplicateLine { get; set; }
@@ -26,6 +27,7 @@ public class LanguageSourceView
         SelectedXCharactersYLines = "Selected: {0} characters in {1} line(s)";
         ReplacedXOccurrences = "Replaced {0} occurrence(s)";
         InvalidRegularExpression = "Invalid regular expression";
+        RegularExpressionTooSlowX = "Regular expression gave up after {0} seconds - try a simpler pattern";
         MoveLineUp = "Move line up";
         MoveLineDown = "Move line down";
         DuplicateLine = "Duplicate line";

--- a/tests/UI/Features/Edit/CategoryPickerTests.cs
+++ b/tests/UI/Features/Edit/CategoryPickerTests.cs
@@ -79,12 +79,15 @@ public class CategoryPickerTests
         Assert.Equal("c1,c2,c4", Ticked(vm));
     }
 
+    // Ctrl/Cmd + A / D / Shift+I - the same three SE's other tick-a-column lists use, so the
+    // gestures mean the same wherever the user learned them (RemoveTextForHearingImpaired).
     [AvaloniaTheory]
     [InlineData(Key.A, KeyModifiers.Control, "c1,c2,c3")]
     [InlineData(Key.A, KeyModifiers.Meta, "c1,c2,c3")]
-    [InlineData(Key.A, KeyModifiers.Control | KeyModifiers.Shift, "")]
-    [InlineData(Key.A, KeyModifiers.Meta | KeyModifiers.Shift, "")]
-    [InlineData(Key.I, KeyModifiers.Shift, "c1,c3")]
+    [InlineData(Key.D, KeyModifiers.Control, "")]
+    [InlineData(Key.D, KeyModifiers.Meta, "")]
+    [InlineData(Key.I, KeyModifiers.Control | KeyModifiers.Shift, "c1,c3")]
+    [InlineData(Key.I, KeyModifiers.Meta | KeyModifiers.Shift, "c1,c3")]
     public void Shortcuts_ChangeTheSelection(Key key, KeyModifiers modifiers, string expected)
     {
         var vm = new CategoryPickerViewModel();
@@ -120,7 +123,7 @@ public class CategoryPickerTests
             : Se.Language.Edit.MultipleReplace.ExportReplaceRules, window.Title);
     }
 
-    // A bare "a" is a list type-ahead key, not select all.
+    // A bare "a" is a list type-ahead key, not select all - and a bare shift+I types a capital I.
     [AvaloniaFact]
     public void Shortcuts_IgnoreUnmodifiedKeys()
     {
@@ -130,6 +133,20 @@ public class CategoryPickerTests
 
         Assert.False(SendKey(vm, Key.A, KeyModifiers.None));
         Assert.False(SendKey(vm, Key.I, KeyModifiers.None));
+        Assert.False(SendKey(vm, Key.I, KeyModifiers.Shift));
+        Assert.False(SendKey(vm, Key.D, KeyModifiers.None));
+        Assert.Equal("c2", Ticked(vm));
+    }
+
+    // Alt is somebody else's shortcut (menu access keys), so it is not a near-miss of these.
+    [AvaloniaFact]
+    public void Shortcuts_IgnoreAltCombinations()
+    {
+        var vm = new CategoryPickerViewModel();
+        var categories = BuildCategories(3);
+        vm.InitializeForExport(categories, categories[1]);
+
+        Assert.False(SendKey(vm, Key.A, KeyModifiers.Control | KeyModifiers.Alt));
         Assert.Equal("c2", Ticked(vm));
     }
 }

--- a/tests/UI/Features/Edit/MultipleReplaceRegexTimeoutTests.cs
+++ b/tests/UI/Features/Edit/MultipleReplaceRegexTimeoutTests.cs
@@ -1,0 +1,237 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Edit.MultipleReplace;
+using Nikse.SubtitleEdit.Features.Options.Settings;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading;
+
+namespace UITests.Features.Edit;
+
+/// <summary>
+/// Multiple replace rules are user-entered regular expressions, so they get the same five second
+/// match timeout as find/replace: without it a pattern with catastrophic backtracking held the
+/// preview lock forever, and with it the UI thread, which waits on that same lock in "Ok" and
+/// "Apply".
+///
+/// The second half pins the other side of #13534's "validate every rule so a broken one is marked
+/// even in an unticked category": validation must not be what builds the RegexOptions.Compiled
+/// regex, or opening the dialog emits IL for every rule in the file.
+/// </summary>
+public class MultipleReplaceRegexTimeoutTests
+{
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    // 30 a's and no "b": "(a+)+b" has to try every way of splitting them before giving up.
+    private const string EvilPattern = "(a+)+b";
+    private static readonly string EvilLine = new string('a', 30) + "c";
+
+    // Well above the five second timeout, but far below "never returns" - the point is that the
+    // preview comes back at all, not how quickly.
+    private const int MaxSeconds = 60;
+
+    private static MultipleReplaceViewModel NewViewModel()
+    {
+        var vm = new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        vm.Nodes.Clear();
+        return vm;
+    }
+
+    private static RuleTreeNode AddCategory(MultipleReplaceViewModel vm, string name, bool isActive = true)
+    {
+        var category = new RuleTreeNode(true) { CategoryName = name, IsActive = isActive };
+        vm.Nodes.Add(category);
+        return category;
+    }
+
+    private static RuleTreeNode AddRule(RuleTreeNode category, string find, string replaceWith, MultipleReplaceType type)
+    {
+        var node = new RuleTreeNode(false)
+        {
+            Find = find,
+            ReplaceWith = replaceWith,
+            IsActive = true,
+            Parent = category,
+            Type = type,
+        };
+        category.SubNodes!.Add(node);
+        return node;
+    }
+
+    private static ConcurrentDictionary<string, Regex> CompiledRegexes(MultipleReplaceViewModel vm)
+    {
+        var field = typeof(MultipleReplaceViewModel).GetField("_compiledRegExList", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (ConcurrentDictionary<string, Regex>)field.GetValue(vm)!;
+    }
+
+    private static void Settle(int ms)
+    {
+        var end = Environment.TickCount64 + ms;
+        while (Environment.TickCount64 < end)
+        {
+            Dispatcher.UIThread.RunJobs();
+            Thread.Sleep(20);
+        }
+
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static void WaitUntil(Func<bool> done, int timeoutMs)
+    {
+        var end = Environment.TickCount64 + timeoutMs;
+        while (Environment.TickCount64 < end)
+        {
+            Dispatcher.UIThread.RunJobs();
+            if (done())
+            {
+                Dispatcher.UIThread.RunJobs();
+                return;
+            }
+
+            Thread.Sleep(20);
+        }
+
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static Subtitle OneLine(string text)
+    {
+        var s = new Subtitle();
+        s.Paragraphs.Add(new Paragraph(text, 0, 2000));
+        return s;
+    }
+
+    [AvaloniaFact]
+    public void CatastrophicPattern_GivesUpAndMarksTheRule()
+    {
+        var vm = NewViewModel();
+        var category = AddCategory(vm, "c1");
+        var evil = AddRule(category, EvilPattern, "x", MultipleReplaceType.RegularExpression);
+
+        var stopwatch = Stopwatch.StartNew();
+        vm.Initialize(OneLine(EvilLine));
+        WaitUntil(() => evil.HasError, MaxSeconds * 1000);
+        stopwatch.Stop();
+
+        Assert.True(evil.HasError, "the rule that timed out was not marked in the tree");
+        Assert.True(stopwatch.Elapsed.TotalSeconds < MaxSeconds, $"the preview took {stopwatch.Elapsed.TotalSeconds:0.0}s");
+        Assert.Empty(vm.Fixes);
+    }
+
+    // The rule that gives up must cost only itself, exactly like one that will not compile.
+    [AvaloniaFact]
+    public void CatastrophicPattern_LeavesTheOtherRulesWorking()
+    {
+        var vm = NewViewModel();
+        var category = AddCategory(vm, "c1");
+        AddRule(category, EvilPattern, "x", MultipleReplaceType.RegularExpression);
+        AddRule(category, "colour", "color", MultipleReplaceType.CaseInsensitive);
+
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(EvilLine + " colour", 0, 2000));
+        vm.Initialize(subtitle);
+
+        WaitUntil(() => vm.Fixes.Count == 1, MaxSeconds * 1000);
+
+        Assert.Single(vm.Fixes);
+        Assert.Equal(EvilLine + " color", vm.Fixes[0].After);
+    }
+
+    // A pattern the timeout stopped is not retried on every remaining line: five seconds each
+    // over a whole file is not a preview, it is a hang with extra steps.
+    [AvaloniaFact]
+    public void CatastrophicPattern_IsNotRetriedForEveryLine()
+    {
+        var vm = NewViewModel();
+        var category = AddCategory(vm, "c1");
+        var evil = AddRule(category, EvilPattern, "x", MultipleReplaceType.RegularExpression);
+
+        var subtitle = new Subtitle();
+        for (var i = 0; i < 20; i++)
+        {
+            subtitle.Paragraphs.Add(new Paragraph(EvilLine, 0, 2000));
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+        vm.Initialize(subtitle);
+        WaitUntil(() => evil.HasError, MaxSeconds * 1000);
+        stopwatch.Stop();
+
+        Assert.True(evil.HasError);
+
+        // Twenty lines at the five second timeout each would be 100 seconds; one is ~5.
+        Assert.True(stopwatch.Elapsed.TotalSeconds < MaxSeconds, $"the preview took {stopwatch.Elapsed.TotalSeconds:0.0}s for 20 lines");
+    }
+
+    // Validation covers every rule so the tree can mark a broken one anywhere; compiling is what
+    // must stay lazy. RegexOptions.Compiled emits IL that is never reclaimed, and a rule pack
+    // import (#13529) brings in hundreds of rules the user may never tick.
+    [AvaloniaFact]
+    public void RuleInUntickedCategory_IsValidatedButNotCompiled()
+    {
+        var vm = NewViewModel();
+        var ticked = AddCategory(vm, "ticked");
+        AddRule(ticked, "red", "blue", MultipleReplaceType.RegularExpression);
+
+        var unticked = AddCategory(vm, "unticked", isActive: false);
+        var goodButUnused = AddRule(unticked, "green", "yellow", MultipleReplaceType.RegularExpression);
+        var broken = AddRule(unticked, "(unclosed", string.Empty, MultipleReplaceType.RegularExpression);
+
+        vm.Initialize(OneLine("The colour is red."));
+        WaitUntil(() => vm.Fixes.Count == 1, 3000);
+        Settle(300);
+
+        // Validated: the broken rule in the unticked category is still marked...
+        Assert.True(broken.HasError);
+        Assert.False(goodButUnused.HasError);
+
+        // ...but only the rule that actually ran was compiled.
+        var compiled = CompiledRegexes(vm);
+        Assert.Contains("red", compiled.Keys);
+        Assert.DoesNotContain("green", compiled.Keys);
+        Assert.DoesNotContain("(unclosed", compiled.Keys);
+    }
+
+    [AvaloniaFact]
+    public void TickingTheCategory_CompilesItsRulesThen()
+    {
+        var vm = NewViewModel();
+        var category = AddCategory(vm, "later", isActive: false);
+        AddRule(category, "red", "blue", MultipleReplaceType.RegularExpression);
+
+        vm.Initialize(OneLine("The colour is red."));
+        Settle(600);
+        Assert.DoesNotContain("red", CompiledRegexes(vm).Keys);
+
+        category.IsActive = true;
+        vm.OnActiveChanged(null, new Avalonia.Interactivity.RoutedEventArgs());
+        WaitUntil(() => vm.Fixes.Count == 1, 3000);
+
+        Assert.Single(vm.Fixes);
+        Assert.Contains("red", CompiledRegexes(vm).Keys);
+    }
+
+    // Every runnable regex must carry the timeout, whatever route built it.
+    [AvaloniaFact]
+    public void CompiledRules_CarryTheMatchTimeout()
+    {
+        var vm = NewViewModel();
+        var category = AddCategory(vm, "c1");
+        AddRule(category, "red", "blue", MultipleReplaceType.RegularExpression);
+
+        vm.Initialize(OneLine("The colour is red."));
+        WaitUntil(() => vm.Fixes.Count == 1, 3000);
+
+        Assert.All(CompiledRegexes(vm).Values, r => Assert.Equal(RegexUtils.UserPatternMatchTimeout, r.MatchTimeout));
+    }
+}

--- a/tests/UI/Features/SourceViewRegexTimeoutTests.cs
+++ b/tests/UI/Features/SourceViewRegexTimeoutTests.cs
@@ -1,0 +1,130 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Controls.SyntaxTextEditorControl;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Shared.SourceView;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Diagnostics;
+
+namespace UITests.Features;
+
+/// <summary>
+/// The source view's find/replace takes a user-entered regular expression and runs it on the UI
+/// thread, so it gets the same five second match timeout as the main find/replace: without one a
+/// pattern with catastrophic backtracking hung the program with no way out. The timeout is
+/// reported like "not found" - the document is never left half-replaced.
+/// </summary>
+public class SourceViewRegexTimeoutTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private sealed class NoWindowService : IWindowService
+    {
+        public T ShowWindow<T>(Window owner, Action<T>? configure = null) where T : Window
+            => throw new NotSupportedException();
+
+        public TViewModel ShowWindow<T, TViewModel>(Window owner, Action<T, TViewModel>? configure = null)
+            where T : Window where TViewModel : class
+            => throw new NotSupportedException();
+
+        public TViewModel ShowIndependentWindow<T, TViewModel>(Action<T, TViewModel>? configure = null)
+            where T : Window where TViewModel : class
+            => throw new NotSupportedException();
+
+        public Task<T> ShowDialogAsync<T>(Window owner, Action<T>? configure = null) where T : Window
+            => throw new NotSupportedException();
+
+        public Task<TViewModel> ShowDialogAsync<TWindow, TViewModel>(
+            Window owner,
+            Action<TViewModel>? configureViewModel = null,
+            Action<TWindow>? configureWindow = null)
+            where TWindow : Window where TViewModel : class
+            => throw new NotSupportedException();
+    }
+
+    // 30 a's and no "b": "(a+)+b" has to try every way of splitting them before giving up.
+    private const string EvilPattern = "(a+)+b";
+    private static readonly string EvilLine = new string('a', 30) + "c";
+
+    // Well above the five second timeout, but far below "never returns".
+    private const int MaxSeconds = 60;
+
+    private SourceViewViewModel MakeSourceView()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(EvilLine, 1000, 3000));
+
+        var format = new SubRip();
+        var text = subtitle.ToText(format);
+
+        var vm = new SourceViewViewModel(new NoWindowService());
+        vm.Initialize("Source view", text, format, subtitle, 0);
+        vm.UseRegularExpression = true;
+        vm.SearchText = EvilPattern;
+
+        var window = new Window { Content = new Border { Child = vm.SourceViewTextBox.ContentControl } };
+        _windows.Add(window);
+        vm.Window = window;
+        window.Show();
+        window.UpdateLayout();
+
+        return vm;
+    }
+
+    private static string TooSlowMessage() => string.Format(
+        Se.Language.SourceView.RegularExpressionTooSlowX,
+        RegexUtils.UserPatternMatchTimeout.TotalSeconds);
+
+    [AvaloniaFact]
+    public void FindNext_CatastrophicPattern_GivesUpAndSaysSo()
+    {
+        var vm = MakeSourceView();
+
+        var stopwatch = Stopwatch.StartNew();
+        vm.FindNextCommand.Execute(null);
+        stopwatch.Stop();
+
+        Assert.Equal(TooSlowMessage(), vm.FindStatus);
+        Assert.True(stopwatch.Elapsed.TotalSeconds < MaxSeconds, $"FindNext took {stopwatch.Elapsed.TotalSeconds:0.0}s");
+    }
+
+    [AvaloniaFact]
+    public void ReplaceAll_CatastrophicPattern_GivesUpAndLeavesTheDocumentAlone()
+    {
+        var vm = MakeSourceView();
+        var before = ((SyntaxTextView)vm.SourceViewTextBox.TextControl).Document.Text;
+        vm.ReplaceText = "x";
+
+        var stopwatch = Stopwatch.StartNew();
+        vm.ReplaceAllCommand.Execute(null);
+        stopwatch.Stop();
+
+        Assert.Equal(TooSlowMessage(), vm.FindStatus);
+        Assert.Equal(before, ((SyntaxTextView)vm.SourceViewTextBox.TextControl).Document.Text);
+        Assert.True(stopwatch.Elapsed.TotalSeconds < MaxSeconds, $"ReplaceAll took {stopwatch.Elapsed.TotalSeconds:0.0}s");
+    }
+
+    // The timeout must not turn an ordinary search into a failure.
+    [AvaloniaFact]
+    public void OrdinaryPattern_StillFinds()
+    {
+        var vm = MakeSourceView();
+        vm.SearchText = "a{5}";
+
+        vm.FindNextCommand.Execute(null);
+
+        Assert.Equal(string.Empty, vm.FindStatus);
+    }
+}

--- a/tests/UI/Features/Tools/BatchConvert/BatchConverterMultipleReplaceRegexTests.cs
+++ b/tests/UI/Features/Tools/BatchConvert/BatchConverterMultipleReplaceRegexTests.cs
@@ -1,0 +1,113 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Edit.MultipleReplace;
+using Nikse.SubtitleEdit.Features.Options.Settings;
+using Nikse.SubtitleEdit.Features.Tools.BatchConvert;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.UiLogic.BatchConvert;
+using System.Diagnostics;
+
+namespace UITests.Features.Tools.BatchConvert;
+
+/// <summary>
+/// Batch convert runs the Multiple replace rules unattended, so neither a saved rule that will
+/// not compile nor one that backtracks catastrophically may take the run down with it. The
+/// window learned this in #13534; the batch path had the same two holes: it built its regexes
+/// with the indexer and no try/catch (one bad rule failed every file in the batch with an opaque
+/// "parsing ..." status naming neither rule nor category), and with no match timeout at all.
+/// </summary>
+public class BatchConverterMultipleReplaceRegexTests
+{
+    // 30 a's and no "b": "(a+)+b" has to try every way of splitting them before giving up.
+    private const string EvilPattern = "(a+)+b";
+    private static readonly string EvilLine = new string('a', 30) + "c";
+
+    private const int MaxSeconds = 60;
+
+    private static SeEditMultipleReplace.MultipleReplaceCategory Category(params MultipleReplaceRule[] rules)
+    {
+        var category = new SeEditMultipleReplace.MultipleReplaceCategory { Name = "test", IsActive = true };
+        foreach (var rule in rules)
+        {
+            category.Rules.Add(rule);
+        }
+
+        return category;
+    }
+
+    private static MultipleReplaceRule Rule(string find, string replaceWith, MultipleReplaceType type) =>
+        new() { Active = true, Find = find, ReplaceWith = replaceWith, Type = type };
+
+    private static async Task<string> ConvertAsync(string inputText, SeEditMultipleReplace.MultipleReplaceCategory category)
+    {
+        Se.Settings.Edit.MultipleReplace.Categories.Clear();
+        Se.Settings.Edit.MultipleReplace.Categories.Add(category);
+
+        var dir = Directory.CreateTempSubdirectory("se-batch-multiple-replace-test");
+        try
+        {
+            var inputFile = Path.Combine(dir.FullName, "input.srt");
+            await File.WriteAllTextAsync(
+                inputFile,
+                "1\r\n00:00:01,000 --> 00:00:03,000\r\n" + inputText + "\r\n\r\n",
+                TestContext.Current.CancellationToken);
+
+            var outputFolder = Path.Combine(dir.FullName, "out");
+            Directory.CreateDirectory(outputFolder);
+
+            var subtitle = Subtitle.Parse(inputFile);
+            var item = new BatchConvertItem(inputFile, new FileInfo(inputFile).Length, new SubRip().Name, subtitle);
+
+            var config = new BatchConvertConfig
+            {
+                SaveInSourceFolder = false,
+                OutputFolder = outputFolder,
+                Overwrite = true,
+                TargetFormatName = SubRip.NameOfFormat,
+            };
+            config.MultipleReplace.IsActive = true;
+
+            var converter = new BatchConverter(null!, null!, null!);
+            converter.Initialize(config);
+            await converter.Convert(item, TestContext.Current.CancellationToken);
+
+            var outputFile = Path.Combine(outputFolder, "input.srt");
+            Assert.True(File.Exists(outputFile), "converted file was not written - status: " + item.Status);
+
+            return Subtitle.Parse(outputFile).Paragraphs[0].Text;
+        }
+        finally
+        {
+            Se.Settings.Edit.MultipleReplace.Categories.Clear();
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task InvalidRegexRule_DoesNotFailTheFile()
+    {
+        var text = await ConvertAsync(
+            "The colour is red.",
+            Category(
+                Rule("(unclosed", string.Empty, MultipleReplaceType.RegularExpression),
+                Rule("colour", "color", MultipleReplaceType.CaseInsensitive)));
+
+        // The whole file used to come back as "Error: parsing '(unclosed' ..." with nothing applied.
+        Assert.Equal("The color is red.", text);
+    }
+
+    [Fact]
+    public async Task CatastrophicPattern_GivesUpAndLeavesTheRestOfTheRulesWorking()
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var text = await ConvertAsync(
+            EvilLine + " colour",
+            Category(
+                Rule(EvilPattern, "x", MultipleReplaceType.RegularExpression),
+                Rule("colour", "color", MultipleReplaceType.CaseInsensitive)));
+        stopwatch.Stop();
+
+        Assert.Equal(EvilLine + " color", text);
+        Assert.True(stopwatch.Elapsed.TotalSeconds < MaxSeconds, $"the conversion took {stopwatch.Elapsed.TotalSeconds:0.0}s");
+    }
+}

--- a/tests/UI/Features/Tools/BatchConvert/BatchConverterMultipleReplaceRegexTests.cs
+++ b/tests/UI/Features/Tools/BatchConvert/BatchConverterMultipleReplaceRegexTests.cs
@@ -96,6 +96,20 @@ public class BatchConverterMultipleReplaceRegexTests
         Assert.Equal("The color is red.", text);
     }
 
+    // A skipped rule is only useful in the log if the log says which rule. RuleInfo is
+    // "category: description", and the description is optional and not unique, so the pattern -
+    // the one thing that identifies the rule in the user's list - has to be in there.
+    [Theory]
+    [InlineData("cat: strip dashes", "rule '(a+)+b' (cat: strip dashes)")]
+    [InlineData("cat: ", "rule '(a+)+b' (cat)")]
+    [InlineData("", "rule '(a+)+b'")]
+    public void DescribeRule_AlwaysNamesThePattern(string ruleInfo, string expected)
+    {
+        var expression = new ReplaceExpression("(a+)+b", "x", ReplaceExpression.SearchTypeRegularExpression, ruleInfo);
+
+        Assert.Equal(expected, BatchConverter.DescribeRule(expression));
+    }
+
     [Fact]
     public async Task CatastrophicPattern_GivesUpAndLeavesTheRestOfTheRulesWorking()
     {

--- a/tests/UI/Features/Video/TextToSpeech/Engines/ChatterboxCloneReferenceRepairTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/ChatterboxCloneReferenceRepairTests.cs
@@ -1,0 +1,148 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text;
+
+namespace UITests.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// A reference voice that is not 24 kHz mono is re-encoded in place before synthesis, because the
+/// voices folder is documented and users copy WAVs into it by hand (#13508). That check runs per
+/// line, so a repair that cannot succeed - no ffmpeg on the machine, a WAV ffmpeg will not decode -
+/// has to be attempted once, not once for every line of the subtitle.
+/// </summary>
+public class ChatterboxCloneReferenceRepairTests
+{
+    /// <summary>A canonical 44-byte PCM WAV header followed by <paramref name="sampleBytes"/> of silence.</summary>
+    private static byte[] Wav(int sampleRate, short channels, short bitsPerSample, int sampleBytes)
+    {
+        var blockAlign = (short)(channels * bitsPerSample / 8);
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream, Encoding.ASCII);
+
+        writer.Write("RIFF"u8.ToArray());
+        writer.Write(36 + sampleBytes);
+        writer.Write("WAVE"u8.ToArray());
+        writer.Write("fmt "u8.ToArray());
+        writer.Write(16);                                   // PCM fmt chunk size
+        writer.Write((short)1);                             // WAVE_FORMAT_PCM
+        writer.Write(channels);
+        writer.Write(sampleRate);
+        writer.Write(sampleRate * blockAlign);              // byte rate
+        writer.Write(blockAlign);
+        writer.Write(bitsPerSample);
+        writer.Write("data"u8.ToArray());
+        writer.Write(sampleBytes);
+        writer.Write(new byte[sampleBytes]);
+        writer.Flush();
+
+        return stream.ToArray();
+    }
+
+    private static string WriteTempFile(byte[] content, string extension = ".wav")
+    {
+        var fileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + extension);
+        File.WriteAllBytes(fileName, content);
+        return fileName;
+    }
+
+    [Fact]
+    public void CloneReadyWav_IsAccepted()
+    {
+        var fileName = WriteTempFile(Wav(24000, channels: 1, bitsPerSample: 16, sampleBytes: 480));
+        try
+        {
+            Assert.True(ChatterboxTtsCpp.IsCloneReadyReferenceWav(fileName));
+            Assert.True(ChatterboxTtsCpp.EnsureCloneReferenceIsUsable(fileName));
+        }
+        finally
+        {
+            File.Delete(fileName);
+        }
+    }
+
+    [Theory]
+    [InlineData(48000, 1, 16)] // wrong sample rate
+    [InlineData(24000, 2, 16)] // stereo
+    [InlineData(24000, 1, 8)]  // 8 bit
+    public void WavTheBackendCannotCloneFrom_IsRejected(int sampleRate, short channels, short bitsPerSample)
+    {
+        var fileName = WriteTempFile(Wav(sampleRate, channels, bitsPerSample, sampleBytes: 480));
+        try
+        {
+            Assert.False(ChatterboxTtsCpp.IsCloneReadyReferenceWav(fileName));
+        }
+        finally
+        {
+            File.Delete(fileName);
+        }
+    }
+
+    [Fact]
+    public void NoReferenceAtAll_NeedsNothing()
+    {
+        // The baked default voice is not cloning.
+        Assert.True(ChatterboxTtsCpp.EnsureCloneReferenceIsUsable(null));
+        Assert.True(ChatterboxTtsCpp.EnsureCloneReferenceIsUsable(string.Empty));
+
+        // A reference that has gone missing is the server's business, not a conversion failure.
+        Assert.True(ChatterboxTtsCpp.EnsureCloneReferenceIsUsable(Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".wav")));
+    }
+
+    // The set of paths whose repair already failed. Read directly: whether a second call really
+    // skipped the ffmpeg run cannot be timed reliably on a machine that has no ffmpeg to spawn.
+    private static ICollection<string> FailedRepairs()
+    {
+        var field = typeof(ChatterboxTtsCpp).GetField(
+            "FailedCloneReferenceRepairs",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+        return ((ConcurrentDictionary<string, byte>)field.GetValue(null)!).Keys;
+    }
+
+    [Fact]
+    public void ARepairThatCannotSucceed_IsOnlyAttemptedOnce()
+    {
+        // Not decodable by ffmpeg either, so the repair fails however the machine is set up.
+        var fileName = WriteTempFile(Encoding.ASCII.GetBytes("this is not a wav file at all, not even close"));
+        try
+        {
+            Assert.DoesNotContain(fileName, FailedRepairs());
+
+            Assert.False(ChatterboxTtsCpp.EnsureCloneReferenceIsUsable(fileName));
+            Assert.Contains(fileName, FailedRepairs()); // remembered, so line two does not try again
+
+            // Every following line of the subtitle comes back here. Without the guard each one
+            // spawns another doomed ffmpeg run; with it the answer is a dictionary lookup.
+            var stopwatch = Stopwatch.StartNew();
+            for (var i = 0; i < 20; i++)
+            {
+                Assert.False(ChatterboxTtsCpp.EnsureCloneReferenceIsUsable(fileName));
+            }
+
+            stopwatch.Stop();
+            Assert.True(stopwatch.ElapsedMilliseconds < 500, $"20 repeat checks took {stopwatch.ElapsedMilliseconds} ms - the repair is being retried");
+        }
+        finally
+        {
+            File.Delete(fileName);
+        }
+    }
+
+    // A voice that never needed repairing must not end up on the "already failed" list, or a
+    // later genuine repair of the same path would be skipped.
+    [Fact]
+    public void AWorkingReference_IsNeverRecordedAsFailed()
+    {
+        var fileName = WriteTempFile(Wav(24000, channels: 1, bitsPerSample: 16, sampleBytes: 480));
+        try
+        {
+            Assert.True(ChatterboxTtsCpp.EnsureCloneReferenceIsUsable(fileName));
+            Assert.DoesNotContain(fileName, FailedRepairs());
+        }
+        finally
+        {
+            File.Delete(fileName);
+        }
+    }
+}

--- a/tests/UI/Features/Video/TextToSpeech/Engines/ChatterboxCloneReferenceRepairTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/ChatterboxCloneReferenceRepairTests.cs
@@ -1,5 +1,5 @@
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
-using System.Collections.Concurrent;
+using System.Collections;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text;
@@ -90,14 +90,23 @@ public class ChatterboxCloneReferenceRepairTests
         Assert.True(ChatterboxTtsCpp.EnsureCloneReferenceIsUsable(Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".wav")));
     }
 
-    // The set of paths whose repair already failed. Read directly: whether a second call really
-    // skipped the ffmpeg run cannot be timed reliably on a machine that has no ffmpeg to spawn.
+    // The paths whose repair already failed. Read directly: whether a second call really skipped
+    // the ffmpeg run cannot be timed reliably on a machine that has no ffmpeg to spawn. The value
+    // type is the private FileStamp record, so only the keys are read here.
     private static ICollection<string> FailedRepairs()
     {
         var field = typeof(ChatterboxTtsCpp).GetField(
             "FailedCloneReferenceRepairs",
             BindingFlags.Static | BindingFlags.NonPublic)!;
-        return ((ConcurrentDictionary<string, byte>)field.GetValue(null)!).Keys;
+        var dictionary = (IEnumerable)field.GetValue(null)!;
+
+        var keys = new List<string>();
+        foreach (var entry in dictionary)
+        {
+            keys.Add((string)entry.GetType().GetProperty("Key")!.GetValue(entry)!);
+        }
+
+        return keys;
     }
 
     [Fact]
@@ -144,5 +153,84 @@ public class ChatterboxCloneReferenceRepairTests
         {
             File.Delete(fileName);
         }
+    }
+
+    // The voices folder is documented and users copy WAVs into it by hand, so the obvious answer
+    // to a rejected voice is to fix the file in place. A guard keyed on the path alone would go
+    // on refusing the repaired file until SE restarts, so it is keyed on the contents that failed.
+    [Fact]
+    public void AReferenceRepairedInPlace_IsAcceptedWithoutARestart()
+    {
+        var fileName = WriteTempFile(Encoding.ASCII.GetBytes("this is not a wav file at all, not even close"));
+        try
+        {
+            Assert.False(ChatterboxTtsCpp.EnsureCloneReferenceIsUsable(fileName));
+            Assert.Contains(fileName, FailedRepairs());
+
+            // The user drops a proper 24 kHz mono WAV in over the broken one.
+            File.WriteAllBytes(fileName, Wav(24000, channels: 1, bitsPerSample: 16, sampleBytes: 480));
+            File.SetLastWriteTimeUtc(fileName, DateTime.UtcNow.AddSeconds(1));
+
+            Assert.True(ChatterboxTtsCpp.EnsureCloneReferenceIsUsable(fileName));
+            Assert.DoesNotContain(fileName, FailedRepairs());
+        }
+        finally
+        {
+            File.Delete(fileName);
+        }
+    }
+
+    // ...and one that is replaced by a different but still unusable file is retried once more,
+    // rather than being answered from the stale entry.
+    [Fact]
+    public void AReferenceReplacedByAnotherBrokenOne_IsJudgedOnItsOwnContents()
+    {
+        var fileName = WriteTempFile(Encoding.ASCII.GetBytes("not a wav"));
+        try
+        {
+            Assert.False(ChatterboxTtsCpp.EnsureCloneReferenceIsUsable(fileName));
+
+            File.WriteAllBytes(fileName, Wav(48000, channels: 2, bitsPerSample: 16, sampleBytes: 960));
+            File.SetLastWriteTimeUtc(fileName, DateTime.UtcNow.AddSeconds(1));
+
+            // Still not clone-ready, and with no ffmpeg the repair fails again - but it was the new
+            // file that was judged, not the old entry.
+            ChatterboxTtsCpp.EnsureCloneReferenceIsUsable(fileName);
+
+            var stamp = FailedRepairsStamp(fileName);
+            if (stamp != null)
+            {
+                Assert.Equal(new FileInfo(fileName).Length, stamp.Value.Length);
+            }
+        }
+        finally
+        {
+            File.Delete(fileName);
+        }
+    }
+
+    /// <summary>The recorded (ticks, length) for a path, or null when it is not recorded as failed.</summary>
+    private static (long Ticks, long Length)? FailedRepairsStamp(string path)
+    {
+        var field = typeof(ChatterboxTtsCpp).GetField(
+            "FailedCloneReferenceRepairs",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        foreach (var entry in (IEnumerable)field.GetValue(null)!)
+        {
+            var type = entry.GetType();
+            var key = (string)type.GetProperty("Key")!.GetValue(entry)!;
+            if (!string.Equals(key, path, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var value = type.GetProperty("Value")!.GetValue(entry)!;
+            var valueType = value.GetType();
+            return ((long)valueType.GetProperty("Ticks")!.GetValue(value)!,
+                    (long)valueType.GetProperty("Length")!.GetValue(value)!);
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
A bug hunt over `v5.2.0-beta10..ad1ba9f96`. Five findings, all fixed here with tests.

### 1. Multiple replace ran user regexes with no match timeout — and froze the UI doing it

#13542 gave find/replace and Modify selection a five second match timeout. Multiple replace was missed, and it is the worst place to miss: #13534's fix serialized preview generation behind `_previewLock`, and `Ok`/`Apply` take that same lock from the UI thread. A rule like `(a+)+b` against a line with no `b` therefore froze the whole program, not just the preview.

A pattern the timeout stops is now retired and marked in the tree — the same treatment as one that will not compile — so it says why it did nothing instead of looking like a rule that matches nothing. Retiring takes effect **within** the pass that hit it: the expression list was built before the timeout, so otherwise every remaining line paid the five seconds again. (A test caught exactly that in the first cut of this fix; the test file went 72 s → 18 s once it was right.)

### 2. Every regex rule was compiled, including the ones in unticked categories

#13534 validates every regular expression rule so a broken one is flagged even inside an unticked category — deliberate and good. But validation was what built the regex, with `RegexOptions.Compiled`. That emits IL, which is never reclaimed, for every rule in the file; a rule pack import (#13529) can make that hundreds of rules the user never ticks.

Validation now parses without `Compiled`; the runnable regex is built on first use by the rule that actually runs.

### 3. Batch convert failed every file in the batch on one bad rule

`BatchConverter.BuildReplaceExpressions` built its regexes with the dictionary indexer and no `try`/`catch`. One saved rule that will not compile threw out of it for every file, so the whole batch came back `Error: parsing "..." — ...`, naming neither the rule nor the category. It now skips the rule and logs which rule in which category, the way the window does — plus the timeout from #1.

### 4. Chatterbox retried an impossible voice repair once per subtitle line

#13510 re-checks the reference WAV before every synthesis request so a hand-copied voice is repaired in place (#13508). That runs per line, and a repair that cannot succeed — no ffmpeg, a WAV ffmpeg will not decode — failed again for each one: a thousand-line job spawned a thousand doomed ffmpeg runs. Failed paths are now remembered.

The guard sits ahead of the WAV header read as well, because that read writes a tools log entry when it fails — one per line is its own kind of runaway. (Found because the test's timing assertion was measuring the log I/O, not the ffmpeg runs.)

### 5. The rule category picker used its own tick-all shortcuts

The picker (#13529) and the fixes grid in Remove text for hearing impaired (#13496) landed days apart and gave the same three commands different gestures. The latter advertises <kbd>Ctrl/Cmd</kbd>+<kbd>A</kbd>/<kbd>D</kbd>/<kbd>Shift</kbd>+<kbd>I</kbd> in a context menu; the picker used <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>A</kbd> to untick and a bare <kbd>Shift</kbd>+<kbd>I</kbd> to invert. Now the same set.

---

**Tests:** 4034 pass (20 new). New files cover the timeout and lazy-compile behaviour in Multiple replace, batch convert and source view, and the Chatterbox repair guard; `CategoryPickerTests` was updated for the new gestures.

**Strings:** two new keys, `RegularExpressionTooSlowX`, in `LanguageMultipleReplace` and `LanguageSourceView` (mirrored into `English.json`).

Also checked and found clean while hunting: the round-6 perf rewrites (`RichTextToPlainText`, `SubtitleSyntaxTokenizer` colour parsing, the name-list reverse indexes, `TimeCodeDisplayCache` invalidation, the gutter and waveform caches) are all behaviour-preserving, and the updated translations pass a placeholder-consistency sweep against English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
