### PR TITLE
Fix two bugs found in a hunt over the beta10 commits

### DIFF
--- a/src/ui/Features/Main/MainHelpers/ImportOriginalHelper.cs
+++ b/src/ui/Features/Main/MainHelpers/ImportOriginalHelper.cs
@@ -30,12 +30,20 @@ public static class ImportOriginalHelper
         var newOriginal = new Subtitle();
 
         // Tracked by index, not by paragraph identity: two original lines can carry the same text and
-        // timings, and each must be accounted for separately.
+        // timings, and each must be accounted for separately. Also fed back into the search so no
+        // original line is handed to a second row: the last of the three passes matches on nothing
+        // more than overlapping middles, so one original line spanning two working rows - which is
+        // exactly what a line-count mismatch usually is - used to be projected onto both of them,
+        // showing the same source text twice while the line that really had no row became a
+        // reference-only row.
         var used = new bool[original.Paragraphs.Count];
 
+        // Rows claim lines in order, so an earlier row can still take a line by loose middle
+        // overlap that a later row would have matched exactly. Matching every row at once would
+        // need a global assignment; this only has to stop the same line being used twice.
         foreach (var line in current)
         {
-            var index = FindOriginalLineIndex(line, original);
+            var index = FindOriginalLineIndex(line, original, used);
             if (index >= 0)
             {
                 newOriginal.Paragraphs.Add(original.Paragraphs[index]);
@@ -65,10 +73,20 @@ public static class ImportOriginalHelper
         return new OriginalMatch(newOriginal, unmatched);
     }
 
-    private static int FindOriginalLineIndex(SubtitleLineViewModel line, Subtitle original)
+    /// <param name="used">
+    /// Lines already given to an earlier working row; they are skipped so no original line lands in
+    /// two rows. A row that finds only used lines gets an empty original, which is the truthful
+    /// answer - it has no source line of its own.
+    /// </param>
+    private static int FindOriginalLineIndex(SubtitleLineViewModel line, Subtitle original, bool[] used)
     {
         for (var i = 0; i < original.Paragraphs.Count; i++)
         {
+            if (used[i])
+            {
+                continue;
+            }
+
             var originalLine = original.Paragraphs[i];
             if (line.StartTime.TotalMilliseconds == originalLine.StartTime.TotalMilliseconds &&
                 line.EndTime.TotalMilliseconds == originalLine.EndTime.TotalMilliseconds)
@@ -80,6 +98,11 @@ public static class ImportOriginalHelper
         // try with some tolerance
         for (var i = 0; i < original.Paragraphs.Count; i++)
         {
+            if (used[i])
+            {
+                continue;
+            }
+
             var originalLine = original.Paragraphs[i];
             if (Math.Abs(line.StartTime.TotalMilliseconds - originalLine.StartTime.TotalMilliseconds) < 250 &&
                 Math.Abs(line.EndTime.TotalMilliseconds - originalLine.EndTime.TotalMilliseconds) < 500)
@@ -92,6 +115,11 @@ public static class ImportOriginalHelper
         var lineMiddle = (line.StartTime.TotalMilliseconds + line.EndTime.TotalMilliseconds) / 2.0;
         for (var i = 0; i < original.Paragraphs.Count; i++)
         {
+            if (used[i])
+            {
+                continue;
+            }
+
             var originalLine = original.Paragraphs[i];
             if (originalLine.StartTime.TotalMilliseconds <= lineMiddle && originalLine.EndTime.TotalMilliseconds >= lineMiddle)
             {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12411,10 +12411,7 @@ public partial class MainViewModel :
             var subs = Subtitles.Select(p => p.Text).ToList();
             var origs = GetOriginalTextsForFind();
 
-            // The find window has no scope picker and always covers both columns, so it also clears
-            // a scope the replace window left behind (SE 4's find dialog built a fresh helper with
-            // both flags set for the same reason).
-            _findService.CurrentScope = FindScope.TextAndOriginal;
+            ResetFindScopeToBothColumns();
 
             var startInOriginal = IsFindPositionInOriginal();
             var startTextBox = GetFindTextBox(startInOriginal);
@@ -12478,6 +12475,10 @@ public partial class MainViewModel :
 
         var subs = Subtitles.Select(p => p.Text).ToList();
         var origs = GetOriginalTextsForFind();
+
+        // Before IsFindPositionInOriginal, which follows the scope - see HandleFindResult.
+        ResetFindScopeToBothColumns();
+
         var startInOriginal = IsFindPositionInOriginal();
         var currentLineIndex = Subtitles.IndexOf(selectedSubtitle);
         var currentCharIndex = GetFindTextBox(startInOriginal).SelectionEnd;
@@ -12525,6 +12526,10 @@ public partial class MainViewModel :
 
         var subs = Subtitles.Select(p => p.Text).ToList();
         var origs = GetOriginalTextsForFind();
+
+        // Before IsFindPositionInOriginal, which follows the scope - see HandleFindResult.
+        ResetFindScopeToBothColumns();
+
         var startInOriginal = IsFindPositionInOriginal();
         var currentLineIndex = Subtitles.IndexOf(selectedSubtitle);
         var idx = _findService.FindPrevious(_findService.SearchText, subs, currentLineIndex, GetFindTextBox(startInOriginal).SelectionStart - 1, origs, startInOriginal);
@@ -12573,6 +12578,21 @@ public partial class MainViewModel :
     private List<string>? GetOriginalTextsForReplace()
     {
         return CanEditOriginal ? GetOriginalTextsForFind() : null;
+    }
+
+    /// <summary>
+    /// Puts the find service back to searching both columns. Finding always covers both - only the
+    /// replace window can narrow it, and it does that by leaving the scope on the shared service
+    /// (SE 4's find dialog built a fresh helper with both flags set for the same reason). So every
+    /// way into a find has to clear what a replace left behind: the find window, and the find
+    /// next / find previous shortcuts, which reach the service without opening any window.
+    ///
+    /// Call before <see cref="IsFindPositionInOriginal"/>, which follows the scope - a stale one
+    /// would also start the search from the wrong column's caret.
+    /// </summary>
+    private void ResetFindScopeToBothColumns()
+    {
+        _findService.CurrentScope = FindScope.TextAndOriginal;
     }
 
     /// <summary>

--- a/src/ui/Logic/IFindService.cs
+++ b/src/ui/Logic/IFindService.cs
@@ -19,8 +19,11 @@ public interface IFindService
     FindMode CurrentFindMode { get; set; }
 
     /// <summary>
-    /// Which columns the next find/replace covers. Sticky, so a find-next after the replace window
-    /// set it keeps the same scope; the find window resets it to <see cref="FindScope.TextAndOriginal"/>.
+    /// Which columns the next find/replace covers. Only the replace window narrows it, and it sets
+    /// it again on every action, so the scope lives for one replace window session: finding always
+    /// covers both columns and resets this on the way in - the find window, and the find next /
+    /// find previous shortcuts, which reach the service without opening a window. A find that
+    /// silently skipped a column would have nothing on screen to say so.
     /// </summary>
     FindScope CurrentScope { get; set; }
 

--- a/tests/UI/Features/Main/ImportOriginalMatchTests.cs
+++ b/tests/UI/Features/Main/ImportOriginalMatchTests.cs
@@ -1,0 +1,119 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Main.MainHelpers;
+using System.Collections.ObjectModel;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// Aligning an original subtitle that does not line up 1:1 with the working rows (#13449). The
+/// three matching passes get progressively looser, the last one settling for nothing more than
+/// overlapping middles - so without the used-line check one original line spanning two working
+/// rows was projected onto both, showing the same source text twice while the line that really
+/// had no row of its own turned into a reference-only row.
+/// </summary>
+public class ImportOriginalMatchTests
+{
+    private static ObservableCollection<SubtitleLineViewModel> Working(params (int Start, int End)[] times)
+    {
+        var list = new ObservableCollection<SubtitleLineViewModel>();
+        var number = 1;
+        foreach (var (start, end) in times)
+        {
+            list.Add(new SubtitleLineViewModel(new Paragraph("working " + number++, start, end), new SubRip()));
+        }
+
+        return list;
+    }
+
+    private static Subtitle Original(params (int Start, int End, string Text)[] paragraphs)
+    {
+        var subtitle = new Subtitle();
+        foreach (var (start, end, text) in paragraphs)
+        {
+            subtitle.Paragraphs.Add(new Paragraph(text, start, end));
+        }
+
+        return subtitle;
+    }
+
+    private static string Projected(ImportOriginalHelper.OriginalMatch match) =>
+        string.Join("|", match.Projection.Paragraphs.Select(p => p.Text));
+
+    private static string Unmatched(ImportOriginalHelper.OriginalMatch match) =>
+        string.Join("|", match.Unmatched.Select(p => p.Text));
+
+    [Fact]
+    public void OneOriginalLineSpanningTwoRows_GoesToOneRowOnly()
+    {
+        // The translator split one original line in two - the usual reason for a count mismatch.
+        var match = ImportOriginalHelper.MatchOriginalLines(
+            Working((1000, 2000), (2000, 3000)),
+            Original((1000, 3000, "long"), (4000, 5000, "second")));
+
+        Assert.Equal("long|", Projected(match));
+        Assert.Equal("second", Unmatched(match));
+    }
+
+    [Fact]
+    public void IdenticalOriginalLines_AreHandedOutOnePerRow()
+    {
+        // Two original lines with the same text and timings are still two lines.
+        var match = ImportOriginalHelper.MatchOriginalLines(
+            Working((1000, 2000), (1000, 2000)),
+            Original((1000, 2000, "same"), (1000, 2000, "same")));
+
+        Assert.Equal("same|same", Projected(match));
+        Assert.Equal(string.Empty, Unmatched(match));
+        Assert.NotSame(match.Projection.Paragraphs[0], match.Projection.Paragraphs[1]);
+    }
+
+    [Fact]
+    public void FewerOriginalLinesThanRows_LeavesTheExtraRowsEmpty()
+    {
+        var match = ImportOriginalHelper.MatchOriginalLines(
+            Working((1000, 2000), (3000, 4000), (5000, 6000)),
+            Original((1000, 2000, "first")));
+
+        Assert.Equal("first||", Projected(match));
+        Assert.Equal(string.Empty, Unmatched(match));
+    }
+
+    [Fact]
+    public void EveryRowMatching_StillProjectsOneForOne()
+    {
+        var match = ImportOriginalHelper.MatchOriginalLines(
+            Working((1000, 2000), (3000, 4000)),
+            Original((1000, 2000, "a"), (3000, 4000, "b")));
+
+        Assert.Equal("a|b", Projected(match));
+        Assert.Equal(string.Empty, Unmatched(match));
+    }
+
+    // Every original line lands in exactly one place: a working row, or the unmatched list.
+    [Fact]
+    public void NoOriginalLineIsUsedTwiceOrLost()
+    {
+        var original = Original(
+            (1000, 5000, "wide"),
+            (1200, 1800, "inside a"),
+            (2000, 2500, "inside b"),
+            (9000, 9500, "far away"));
+
+        var match = ImportOriginalHelper.MatchOriginalLines(
+            Working((1000, 2000), (2000, 3000), (3000, 4000)),
+            original);
+
+        var placed = match.Projection.Paragraphs
+            .Where(p => !string.IsNullOrEmpty(p.Text))
+            .Concat(match.Unmatched)
+            .ToList();
+
+        Assert.Equal(original.Paragraphs.Count, placed.Count);
+        foreach (var paragraph in original.Paragraphs)
+        {
+            Assert.Single(placed, p => ReferenceEquals(p, paragraph));
+        }
+    }
+}

--- a/tests/UI/Features/Main/MainReadOnlyOriginalTests.cs
+++ b/tests/UI/Features/Main/MainReadOnlyOriginalTests.cs
@@ -628,6 +628,50 @@ public class MainReadOnlyOriginalTests
     }
 
     /// <summary>
+    /// The replace window can narrow the scope to one column, and it leaves that on the shared find
+    /// service. The find window clears it on the way in, but the find next / find previous shortcuts
+    /// reach the service without opening a window - so they used to inherit it, and after a
+    /// "replace in original only" every F3 quietly stopped searching the translation column, with
+    /// nothing on screen to say why.
+    /// </summary>
+    [AvaloniaTheory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void FindNextAndPrevious_ClearAScopeTheReplaceWindowLeftBehind(bool forward)
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "alpha one", "reference one", 0, 2000);
+            AddLine(vm, "alpha two", "reference two", 2000, 4000);
+            vm.ShowColumnOriginalText = true;
+            vm.SelectedSubtitle = vm.Subtitles[forward ? 0 : 1];
+            Dispatcher.UIThread.RunJobs();
+
+            var findService = (IFindService)GetField("_findService").GetValue(vm)!;
+            findService.SearchText = "alpha";
+            findService.CurrentScope = FindService.FindScope.OriginalOnly;
+
+            if (forward)
+            {
+                vm.FindNextCommand.Execute(null);
+            }
+            else
+            {
+                vm.FindPreviousCommand.Execute(null);
+            }
+
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(FindService.FindScope.TextAndOriginal, findService.CurrentScope);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
     /// Working subtitle: two translated lines with a gap. Reference: the same two plus a line in the
     /// gap that the translation never got - the case from issue #13449.
     /// </summary>


### PR DESCRIPTION
A second bug hunt, this time over `v5.2.0-beta9..v5.2.0-beta10` (66 commits) — territory the beta11 hunt never covered.

### 1. One original line could be projected onto several working rows

`ImportOriginalHelper` aligns a mismatching original against the working rows in three passes, each looser than the last; the third settles for nothing more than overlapping middles. None of them consulted the `used[]` array the caller fills in, so nothing stopped one original line being handed to more than one row.

Confirmed against the real code rather than by reading — working rows `1000-2000` and `2000-3000`, original `1000-3000` + `4000-5000`:

```
projection = [one long original | one long original]   unmatched = [second original]
```

Both rows show the same source text, and the line that genuinely had no row becomes a reference-only ghost row. This is the normal case, not a corner one: one original line spanning two working rows is what a split-during-translation file looks like, and a line-count mismatch is the only situation this code runs in at all. In "matching lines only" mode the duplicated paragraph also ends up in `_subtitleOriginal`, so saving the original writes it twice.

`used[]` was already being filled correctly — it was just only read afterwards, to build the unmatched list. It now feeds the search too. A row that finds nothing left gets an empty original, which is the truthful answer.

Rows still claim lines in order, so an earlier row can take a line by loose middle overlap that a later row would have matched exactly. That needs a global assignment rather than a per-row search; out of scope here, and noted in the code.

### 2. F3 / Shift+F3 inherited the replace window's column scope

The replace-in-column feature (#13471) stores the picked scope as state on the shared `IFindService`. Every other way into a find clears it first, each with a comment saying why — closing the original, loading a new file, and the find window (*"no scope picker and always covers both columns"*). The find next / find previous **shortcuts** reach the service without opening a window, and were missed.

After a "replace in original only", F3 quietly stopped searching the translation column. `IsFindPositionInOriginal()` follows the same scope, so the search also resumed from the wrong column's caret. Nothing on screen indicates a narrowed scope once the replace window is closed, and the only way back is to open the find window again.

**One judgment call worth your eyes:** this contradicts what `IFindService.CurrentScope` documented — *"sticky, so a find-next after the replace window set it keeps the same scope"*. Read against the replace window's own **Find next button** that is still true (it re-sets the scope from the picker on every action). Read against the **shortcut** it describes an invisible mode. I took the second reading and updated the doc to match the three existing reset sites — say the word and I'll flip it back to sticky instead.

---

**Tests:** 4021 pass. New `ImportOriginalMatchTests` covers the projection (including that every original line lands in exactly one place — a row or the unmatched list); `MainReadOnlyOriginalTests` gains a theory for both shortcut directions.

### One finding I reported and then withdrew

I also flagged `VobSubColorIsolation`'s speckle fallback as having a dead tie-break (`kv.Key < foreground` against the `0u` initializer). Writing the regression test disproved it: it passes without any change, because `foreground` is only the sentinel on the *first* iteration, where `kv.Value > best` (`best = -1`) fires regardless. From the second on it holds a real colour key and the tie-break works. Nothing changed there.

### Checked and clean

`Png8BitEncoder` — round-tripped through Skia's decoder, 0 pixel mismatches; palette, tRNS, CRC and zlib framing all correct. The proxy-handler consolidation is a genuine improvement (`DefaultProxyCredentials` rather than `Credentials`, which had been offering machine credentials to target hosts). CrispASR hash index 0 matches the pinned v0.8.28 on every key. The mismatch dialog warns explicitly before the lossy mode. `StrippableText`'s ASSA tag scan, `FullFrameImage`, `CompareColors` and the AI-review retry loop (terminates in ≤3 requests) all look right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
