### PR TITLE
Update English.json and make regenerating it a test

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.2.0-beta10",
+  "version": "v5.2.0-beta11",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {
@@ -1329,6 +1329,7 @@
     "saveCompareHtmlTitle": "Save compare HTML file",
     "pickMatroskaTrackX": "Pick Matroska track - {0}",
     "pickTransportStreamTrackX": "Pick transport stream track - {0}",
+    "pickMp4TrackX": "Pick MP4 track - {0}",
     "rosettaProperties": "Timed Text Rosetta IMSC properties",
     "rosettaFontSize": "Font size (row height)",
     "xProperties": "{0} properties"

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -178,7 +178,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
@@ -2267,24 +2266,7 @@ public partial class MainViewModel :
             return;
         }
 
-        var json = JsonSerializer.Serialize(Se.Language, new JsonSerializerOptions
-        {
-            WriteIndented = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-
-            // English.json is the base every translation is generated from, so it must not depend on
-            // who saved it: WriteIndented defaults to Environment.NewLine, which gives CRLF on Windows
-            // and LF elsewhere, turning a re-save into a whole-file diff with no real change in it.
-            NewLine = "\n",
-        });
-
-        // Same reason, for the line breaks *inside* the strings: several language classes build their
-        // text with Environment.NewLine, so the same class yields "\r\n" on Windows and "\n" elsewhere
-        // and the file flip-flopped with whoever regenerated it last. Normalize to "\n" here rather
-        // than chase every class - this is the one place the file is written. Only escaped CRLF in
-        // string values matches; a literal backslash-r in the text is escaped as "\\r" and is left be.
-        json = json.Replace("\\r\\n", "\\n");
+        var json = SeLanguage.ToJson(Se.Language);
 
         var currentDirectory = Directory.GetCurrentDirectory();
         var fileName = Path.Combine(currentDirectory, "English.json");

--- a/src/ui/Logic/Config/Language/SeLanguage.cs
+++ b/src/ui/Logic/Config/Language/SeLanguage.cs
@@ -1,4 +1,6 @@
-﻿using Nikse.SubtitleEdit.Logic.Config.Language.Assa;
+﻿using System.Text.Encodings.Web;
+using System.Text.Json;
+using Nikse.SubtitleEdit.Logic.Config.Language.Assa;
 using Nikse.SubtitleEdit.Logic.Config.Language.Edit;
 using Nikse.SubtitleEdit.Logic.Config.Language.File;
 using Nikse.SubtitleEdit.Logic.Config.Language.Main;
@@ -34,4 +36,31 @@ public class SeLanguage
     public LanguageOcr Ocr { get; set; } = new();
     public LanguageAssa Assa { get; set; } = new();
     public LanguageAbout About { get; set; } = new();
+
+    /// <summary>
+    /// Serializes a language to the exact text used for <c>English.json</c> - the base file every
+    /// translation is generated from. Used both by the "Save language file" shortcut in the main
+    /// window and by the test that checks the checked-in English.json is still in sync with the code.
+    /// </summary>
+    public static string ToJson(SeLanguage language)
+    {
+        var json = JsonSerializer.Serialize(language, new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+
+            // English.json must not depend on who saved it: WriteIndented defaults to
+            // Environment.NewLine, which gives CRLF on Windows and LF elsewhere, turning a re-save
+            // into a whole-file diff with no real change in it.
+            NewLine = "\n",
+        });
+
+        // Same reason, for the line breaks *inside* the strings: several language classes build their
+        // text with Environment.NewLine, so the same class yields "\r\n" on Windows and "\n" elsewhere
+        // and the file flip-flopped with whoever regenerated it last. Normalize to "\n" here rather
+        // than chase every class - this is the one place the file is written. Only escaped CRLF in
+        // string values matches; a literal backslash-r in the text is escaped as "\\r" and is left be.
+        return json.Replace("\\r\\n", "\\n");
+    }
 }

--- a/tests/UI/Logic/EnglishLanguageFileUpToDateTests.cs
+++ b/tests/UI/Logic/EnglishLanguageFileUpToDateTests.cs
@@ -1,0 +1,73 @@
+using System.Text;
+using Nikse.SubtitleEdit.Logic.Config.Language;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// <c>src/ui/Assets/Languages/English.json</c> is generated from the <c>Language*</c> classes in
+/// code (the "Save language file" shortcut in the main window does it), and every translation is
+/// generated from it - so a new or changed string in code is invisible to translators until the
+/// file is regenerated. Running this test regenerates it, so no one has to start the app to do it:
+///
+/// <code>
+/// dotnet test tests/UI/UITests.csproj --filter EnglishLanguageFileUpToDateTests
+/// </code>
+///
+/// It deliberately does not fail on drift - a stale English.json is a chore, not a broken build,
+/// and failing would turn every new UI string into a red CI run. It rewrites the file (harmless on
+/// a CI agent, where the working copy is thrown away) and passes either way.
+/// </summary>
+public class EnglishLanguageFileUpToDateTests
+{
+    [Fact]
+    public void EnglishJson_IsRegeneratedFromLanguageClassesInCode()
+    {
+        // Serializing the whole language graph is the part actually worth asserting - it runs on
+        // every start-up for translated users, so a class that cannot be serialized must not pass.
+        var expected = SeLanguage.ToJson(new SeLanguage());
+        Assert.False(string.IsNullOrWhiteSpace(expected));
+
+        var path = FindEnglishJson();
+        if (path is null)
+        {
+            // Test binaries run from somewhere without the repository above them - nothing to update.
+            return;
+        }
+
+        // File.ReadAllText strips the UTF-8 BOM the file is saved with.
+        if (expected == File.ReadAllText(path))
+        {
+            return;
+        }
+
+        try
+        {
+            File.WriteAllText(path, expected, new UTF8Encoding(true));
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            // Read-only checkout (some CI agents): regenerating is a convenience, not a test subject.
+        }
+    }
+
+    /// <summary>
+    /// Walks up from the test output directory to the repository copy of English.json,
+    /// or null when the tests are not running from inside a checkout.
+    /// </summary>
+    private static string? FindEnglishJson()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "src", "ui", "Assets", "Languages", "English.json");
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
`English.json` is generated from the `Language*` classes in code, and every translation is generated from it - so a new string is invisible to translators until someone starts the app and hits the "Save language file" shortcut.

- Regenerated `English.json`: version bump to `v5.2.0-beta11` and the missing `pickMp4TrackX` string. Nothing else had drifted.
- Moved the serialization out of `MainViewModel.SaveLanguageFile` into `SeLanguage.ToJson`, so the shortcut and any tooling produce byte-identical output (same LF + BOM normalization as before; shortcut behaviour unchanged).
- Added `EnglishLanguageFileUpToDateTests`, which regenerates the file:

  ```
  dotnet test tests/UI/UITests.csproj --filter EnglishLanguageFileUpToDateTests
  ```

  It does **not** fail on drift - a stale `English.json` is a chore, not a broken build, and failing would turn every new UI string into a red CI run. It rewrites the file (harmless on a CI agent, where the working copy is thrown away) and passes either way. What it does assert is that the whole language graph still serializes, which is a real start-up path for translated users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
