### PR TITLE
Fix ten bugs found in a global bug hunt

### DIFF
--- a/src/ui/Features/Assa/AssaProgressBar/AssaProgressBarViewModel.cs
+++ b/src/ui/Features/Assa/AssaProgressBar/AssaProgressBarViewModel.cs
@@ -18,7 +18,7 @@ using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 
 namespace Nikse.SubtitleEdit.Features.Assa.AssaProgressBar;
 
-public partial class AssaProgressBarViewModel : ObservableObject
+public partial class AssaProgressBarViewModel : ObservableObject, IClosingCleanup
 {
     public Window? Window { get; internal set; }
     public bool OkPressed { get; private set; }
@@ -64,6 +64,7 @@ public partial class AssaProgressBarViewModel : ObservableObject
     private LibMpvDynamicPlayer? _mpvPlayer;
     private string _oldSubtitleText = string.Empty;
     private DispatcherTimer _positionTimer = new DispatcherTimer();
+    private bool _isClosing;
     private readonly SubtitleFormat _assaFormat = new AdvancedSubStationAlpha();
     private readonly string _tempSubtitleFileName;
     private bool _isSubtitleLoaded;
@@ -131,10 +132,14 @@ public partial class AssaProgressBarViewModel : ObservableObject
     
     private void StartTitleTimer()
     {
+        // Initialize can run more than once per view model, and the previous timer would otherwise
+        // keep ticking beside the new one.
+        _positionTimer.Stop();
+
         _positionTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(500) };
         _positionTimer.Tick += (s, e) =>
         {
-            if (_mpvPlayer == null)
+            if (_mpvPlayer == null || _isClosing)
             {
                 return;
             }
@@ -561,6 +566,41 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
         {
             Window?.Close();
         });
+    }
+
+    /// <summary>
+    /// Runs on every close path (buttons, Escape, title-bar X) via the central hook in
+    /// <see cref="UiUtil.InitializeWindow"/>. Without it the 500 ms preview timer went on ticking
+    /// for the rest of the session: re-rendering the progress bar, rewriting the temp subtitle and
+    /// calling SubReload on an mpv player whose window was already gone - and a fresh timer was
+    /// added every time the dialog was opened.
+    /// </summary>
+    public void OnClosingCleanup()
+    {
+        _isClosing = true;
+        _positionTimer.Stop();
+        _mpvPlayer = null;
+
+        try
+        {
+            VideoPlayerControl?.Close();
+        }
+        catch
+        {
+            // the player may already be gone
+        }
+
+        try
+        {
+            if (!string.IsNullOrEmpty(_tempSubtitleFileName) && File.Exists(_tempSubtitleFileName))
+            {
+                File.Delete(_tempSubtitleFileName);
+            }
+        }
+        catch
+        {
+            // best effort
+        }
     }
 
     internal void KeyDown(object? sender, KeyEventArgs e)

--- a/src/ui/Features/Files/ExportPlainText/ExportPlainTextViewModel.cs
+++ b/src/ui/Features/Files/ExportPlainText/ExportPlainTextViewModel.cs
@@ -306,7 +306,8 @@ public partial class ExportPlainTextViewModel : ObservableObject, IClosingCleanu
     [RelayCommand]
     private void Cancel()
     {
-        SaveSettings();
+        // No SaveSettings: cancelling has to leave the options as they were, the way Escape
+        // already did - so the two ways out of the dialog no longer disagree.
         Window?.Close();
     }
 

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrInspectViewModel.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrInspectViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -160,8 +160,20 @@ public partial class BinaryOcrInspectViewModel : ObservableObject
         {
             BinaryOcrBitmap.Text = NewText;
         }
+
+        SaveSettings();
         OkPressed = true;
         Close();
+    }
+
+    /// <summary>
+    /// The same control in the "add character" window persists this; here it was read on open and
+    /// never written, so changing it only lasted until the window closed.
+    /// </summary>
+    private void SaveSettings()
+    {
+        Se.Settings.Ocr.NOcrNoOfLinesToAutoDraw = SelectedNoOfLinesToAutoDraw;
+        Se.SaveSettings();
     }
 
     [RelayCommand]

--- a/src/ui/Features/Ocr/Engines/LlamaCppOcr.cs
+++ b/src/ui/Features/Ocr/Engines/LlamaCppOcr.cs
@@ -1,4 +1,4 @@
-﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic;
 using SkiaSharp;
 using System;
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Ocr.Engines;
 
-public class LlamaCppOcr
+public class LlamaCppOcr : IDisposable
 {
     private readonly HttpClient _httpClient;
 
@@ -126,5 +126,15 @@ public class LlamaCppOcr
         }
 
         return squareBitmap;
+    }
+
+    /// <summary>
+    /// A new engine (and so a new HttpClient, handler and connection pool) is built per OCR run
+    /// from several call sites; without disposal those pile up and eventually exhaust sockets.
+    /// </summary>
+    public void Dispose()
+    {
+        _httpClient.Dispose();
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/ui/Features/Ocr/Engines/OllamaOcr.cs
+++ b/src/ui/Features/Ocr/Engines/OllamaOcr.cs
@@ -1,6 +1,7 @@
-﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.UiLogic.Http;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
@@ -14,7 +15,7 @@ using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Ocr.Engines;
 
-public class OllamaOcr
+public class OllamaOcr : IDisposable
 {
     // glm-ocr and similar are "thinking" models that, left unchecked, emit reasoning, markdown
     // fences and the same line over and over. We disable thinking, use a strict prompt, cap the
@@ -29,7 +30,9 @@ public class OllamaOcr
     public OllamaOcr(int timeoutMinutes = 5)
     {
         Error = string.Empty;
-        _httpClient = new HttpClient();
+        // Through the proxy factory: unlike the llama.cpp / CrispEmbed servers SE spawns on
+        // loopback, the Ollama host is a user setting and may well be another machine.
+        _httpClient = new HttpClient(HttpClientFactoryWithProxy.CreateHandler());
         _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json");
         _httpClient.Timeout = TimeSpan.FromMinutes(Math.Max(1, timeoutMinutes));
     }
@@ -191,5 +194,15 @@ public class OllamaOcr
         }
 
         return squareBitmap;
+    }
+
+    /// <summary>
+    /// A new engine (and so a new HttpClient, handler and connection pool) is built per OCR run
+    /// from several call sites; without disposal those pile up and eventually exhaust sockets.
+    /// </summary>
+    public void Dispose()
+    {
+        _httpClient.Dispose();
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/ui/Features/Ocr/NOcr/NOcrInspectViewModel.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrInspectViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -160,8 +160,19 @@ public partial class NOcrInspectViewModel : ObservableObject
     private void Ok()
     {
         NOcrChar.Text = NewText;
+        SaveSettings();
         OkPressed = true;
         Close();
+    }
+
+    /// <summary>
+    /// The same control in the "add character" window persists this; here it was read on open and
+    /// never written, so changing it only lasted until the window closed.
+    /// </summary>
+    private void SaveSettings()
+    {
+        Se.Settings.Ocr.NOcrNoOfLinesToAutoDraw = SelectedNoOfLinesToAutoDraw;
+        Se.SaveSettings();
     }
 
     [RelayCommand]

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -4034,7 +4034,7 @@ public partial class OcrViewModel : ObservableObject
 
     private void RunOllamaOcr(List<int> selectedIndices, CancellationToken cancellationToken)
     {
-        var ollamaOcr = new OllamaOcr(Se.Settings.Ocr.OllamaOcrTimeoutMinutes);
+        using var ollamaOcr = new OllamaOcr(Se.Settings.Ocr.OllamaOcrTimeoutMinutes);
         var url = OllamaUrl;
         var model = OllamaModel;
 
@@ -4122,7 +4122,7 @@ public partial class OcrViewModel : ObservableObject
 
     private void RunLlamaCppOcr(List<int> selectedIndices, CancellationToken cancellationToken)
     {
-        var engine = new LlamaCppOcr(Se.Settings.Ocr.LlamaCppOcrTimeoutMinutes);
+        using var engine = new LlamaCppOcr(Se.Settings.Ocr.LlamaCppOcrTimeoutMinutes);
         var selectedModel = SelectedLlamaCppOcrModel?.Model;
         var prompt = Se.Settings.Ocr.LlamaCppOcrPrompt;
 

--- a/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsViewModel.cs
+++ b/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsViewModel.cs
@@ -236,11 +236,17 @@ public partial class ApplyDurationLimitsViewModel : ObservableObject, IClosingCl
 
     private void LoadSettings()
     {
+        // 0 means "not saved yet" - fall back to the general defaults (#13514 pattern). Saving the
+        // dialog's own copy keeps a one-off run from rewriting the app-wide duration settings.
         FixMinDurationMs = true;
-        MinDurationMs = Se.Settings.General.SubtitleMinimumDisplayMilliseconds;
+        MinDurationMs = Se.Settings.Tools.ApplyDurationLimitsMinDurationMs > 0
+            ? Se.Settings.Tools.ApplyDurationLimitsMinDurationMs
+            : Se.Settings.General.SubtitleMinimumDisplayMilliseconds;
 
         FixMaxDurationMs = true;
-        MaxDurationMs = Se.Settings.General.SubtitleMaximumDisplayMilliseconds;
+        MaxDurationMs = Se.Settings.Tools.ApplyDurationLimitsMaxDurationMs > 0
+            ? Se.Settings.Tools.ApplyDurationLimitsMaxDurationMs
+            : Se.Settings.General.SubtitleMaximumDisplayMilliseconds;
 
         DoNotGoPastShotChange = Se.Settings.Tools.ApplyDurationLimits.DoNotExtendPastShotChange;
     }
@@ -248,6 +254,8 @@ public partial class ApplyDurationLimitsViewModel : ObservableObject, IClosingCl
     private void SaveSettings()
     {
         Se.Settings.Tools.ApplyDurationLimits.DoNotExtendPastShotChange = DoNotGoPastShotChange;
+        Se.Settings.Tools.ApplyDurationLimitsMinDurationMs = MinDurationMs ?? 0;
+        Se.Settings.Tools.ApplyDurationLimitsMaxDurationMs = MaxDurationMs ?? 0;
         Se.SaveSettings();
     }
 

--- a/src/ui/Features/Tools/ApplyMinGap/ApplyMinGapViewModel.cs
+++ b/src/ui/Features/Tools/ApplyMinGap/ApplyMinGapViewModel.cs
@@ -140,13 +140,19 @@ public partial class ApplyMinGapViewModel : ObservableObject, IClosingCleanup
 
     private void LoadSettings()
     {
-        MinGapMsOrFrames = Se.Settings.General.UseFrameMode
-            ? Se.Settings.General.MinimumBetweenLines.Frames
-            : Se.Settings.General.MinimumBetweenLines.Milliseconds;
+        // 0 means "not saved yet" - fall back to the general minimum-gap setting, which is what
+        // the dialog used to open on every time because nothing here was ever written back.
+        var saved = Se.Settings.Tools.ApplyMinGapMsOrFrames;
+        MinGapMsOrFrames = saved > 0
+            ? saved
+            : Se.Settings.General.UseFrameMode
+                ? Se.Settings.General.MinimumBetweenLines.Frames
+                : Se.Settings.General.MinimumBetweenLines.Milliseconds;
     }
 
     private void SaveSettings()
     {
+        Se.Settings.Tools.ApplyMinGapMsOrFrames = MinGapMsOrFrames;
         Se.SaveSettings();
     }
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Skia;
+using Avalonia.Skia;
 using Nikse.SubtitleEdit.UiLogic.Export;
 using Nikse.SubtitleEdit.Core.BluRaySup;
 using Nikse.SubtitleEdit.Features.Assa.ResolutionResampler;
@@ -1272,7 +1272,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
     /// </returns>
     private async Task<bool> RunOllamaOcr(IOcrSubtitle imageSubtitles, BatchConvertItem item, CancellationToken cancellationToken)
     {
-        var ollamaOcr = new OllamaOcr();
+        using var ollamaOcr = new OllamaOcr();
         var url = Se.Settings.Ocr.OllamaUrl;
         var model = Se.Settings.Ocr.OllamaModel;
         var language = Se.Settings.Ocr.OllamaLanguage;
@@ -1333,7 +1333,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             return false;
         }
 
-        var engine = new LlamaCppOcr(Se.Settings.Ocr.LlamaCppOcrTimeoutMinutes);
+        using var engine = new LlamaCppOcr(Se.Settings.Ocr.LlamaCppOcrTimeoutMinutes);
         var url = LlamaCppServerManager.ApiUrl;
         var modelName = Path.GetFileNameWithoutExtension(model.FileName);
         var language = Se.Settings.Ocr.OllamaLanguage;

--- a/src/ui/Features/Tools/MergeShortLines/MergeShortLinesViewModel.cs
+++ b/src/ui/Features/Tools/MergeShortLines/MergeShortLinesViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
 using Avalonia.Input;
 using Nikse.SubtitleEdit.Logic;
 using Avalonia.Threading;
@@ -133,12 +133,19 @@ public partial class MergeShortLinesViewModel : ObservableObject, IClosingCleanu
 
     private void LoadSettings()
     {
-        SingleLineMaxLength = Se.Settings.General.SubtitleLineMaximumLength;
-        MaxNumberOfLines = Se.Settings.General.MaxNumberOfLines;
+        // 0 means "not saved yet" - fall back to the general defaults (#13514 pattern).
+        SingleLineMaxLength = Se.Settings.Tools.MergeShortLinesSingleLineMaxLength > 0
+            ? Se.Settings.Tools.MergeShortLinesSingleLineMaxLength
+            : Se.Settings.General.SubtitleLineMaximumLength;
+        MaxNumberOfLines = Se.Settings.Tools.MergeShortLinesMaxNumberOfLines > 0
+            ? Se.Settings.Tools.MergeShortLinesMaxNumberOfLines
+            : Se.Settings.General.MaxNumberOfLines;
     }
 
     private void SaveSettings()
     {
+        Se.Settings.Tools.MergeShortLinesSingleLineMaxLength = SingleLineMaxLength;
+        Se.Settings.Tools.MergeShortLinesMaxNumberOfLines = MaxNumberOfLines;
         Se.SaveSettings();
     }
 

--- a/src/ui/Features/Tools/SplitSubtitle/SplitSubtitleViewModel.cs
+++ b/src/ui/Features/Tools/SplitSubtitle/SplitSubtitleViewModel.cs
@@ -11,6 +11,7 @@ using Nikse.SubtitleEdit.Logic.Media;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -55,9 +56,14 @@ public partial class SplitSubtitleViewModel : ObservableObject, IClosingCleanup
 
         SplitItems = new ObservableCollection<SplitDisplayItem>();
         Formats = new ObservableCollection<SubtitleFormat>(SubtitleFormatHelper.GetSubtitleFormatsWithFavoritesAtTop());
-        SelectedSubtitleFormat = Formats[0];
+
+        // Both are written on OK but were never read back, so the dialog always reopened on the
+        // first entry in the list instead of what the user last split with.
+        SelectedSubtitleFormat = Formats.FirstOrDefault(p => p.Name == Se.Settings.Tools.SplitSubtitleFormat)
+                                 ?? Formats[0];
         Encodings = new ObservableCollection<TextEncoding>(EncodingHelper.GetEncodings());
-        SelectedEncoding = Encodings[0];
+        SelectedEncoding = Encodings.FirstOrDefault(p => p.DisplayName == Se.Settings.Tools.SplitSubtitleEncoding)
+                           ?? Encodings[0];
         OutputFolder = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
         SubtitleInfo = string.Empty;
         SplitByLines = true;

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -595,6 +595,14 @@ public partial class AutoTranslateViewModel : ObservableObject
         Se.Settings.AutoTranslate.PapagoApiKeyId = Configuration.Settings.Tools.AutoTranslatePapagoApiKeyId;
         Se.Settings.AutoTranslate.PapagoApiKey = Configuration.Settings.Tools.AutoTranslatePapagoApiKey;
 
+        // Perplexity was the only engine missing from this block, so its API key, model and URL
+        // were read from Se.Settings on open but only ever written to the libse-side settings -
+        // and lost on restart.
+        Se.Settings.AutoTranslate.PerplexityApiKey = Configuration.Settings.Tools.PerplexityApiKey;
+        Se.Settings.AutoTranslate.PerplexityUrl = Configuration.Settings.Tools.PerplexityUrl;
+        Se.Settings.AutoTranslate.PerplexityModel = Configuration.Settings.Tools.PerplexityModel;
+        Se.Settings.AutoTranslate.PerplexityPrompt = Configuration.Settings.Tools.PerplexityPrompt;
+
         Se.SaveSettings();
     }
 

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSettingsViewModel.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSettingsViewModel.cs
@@ -33,7 +33,9 @@ public partial class TransparentSettingsViewModel : ObservableObject
     {
         UseSourceFolder = !Se.Settings.Video.Transparent.UseOutputFolder; 
         UseOutputFolder = Se.Settings.Video.Transparent.UseOutputFolder;
-        OutputFolder = Se.Settings.Video.BurnIn.OutputFolder;
+        // This dialog's own folder - it saves to Video.Transparent.OutputFolder below, so loading
+        // burn-in's showed the wrong folder back and hid the fact that the saved one was unused.
+        OutputFolder = Se.Settings.Video.Transparent.OutputFolder;
     }
 
     private void SaveSettings()

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
@@ -711,20 +711,25 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         var nameNoExt = Path.GetFileNameWithoutExtension(videoFileName);
         var ext = SelectedVideoExtension;
         var suffix = Se.Settings.Video.BurnIn.BurnInSuffix;
+
+        // This dialog's own output folder, not burn-in's. The settings window has always written
+        // Video.Transparent.OutputFolder / UseOutputFolder, but nothing read them - so whatever
+        // folder was picked here had no effect and the files went to the burn-in folder instead.
+        var transparent = Se.Settings.Video.Transparent;
+        var useOutputFolder = transparent.UseOutputFolder && !string.IsNullOrEmpty(transparent.OutputFolder);
+
         var fileName = Path.Combine(Path.GetDirectoryName(videoFileName)!, nameNoExt + suffix + ext);
-        if (Se.Settings.Video.BurnIn.UseOutputFolder &&
-            !string.IsNullOrEmpty(Se.Settings.Video.BurnIn.OutputFolder) &&
-            Directory.Exists(Se.Settings.Video.BurnIn.OutputFolder))
+        if (useOutputFolder && Directory.Exists(transparent.OutputFolder))
         {
-            fileName = Path.Combine(Se.Settings.Video.BurnIn.OutputFolder, nameNoExt + suffix + ext);
+            fileName = Path.Combine(transparent.OutputFolder, nameNoExt + suffix + ext);
         }
 
         var i = 2;
         while (File.Exists(fileName))
         {
-            if (Se.Settings.Video.BurnIn.UseOutputFolder && !string.IsNullOrEmpty(Se.Settings.Video.BurnIn.OutputFolder))
+            if (useOutputFolder)
             {
-                fileName = Path.Combine(Se.Settings.Video.BurnIn.OutputFolder, $"{nameNoExt}{suffix}_{i}{ext}");
+                fileName = Path.Combine(transparent.OutputFolder, $"{nameNoExt}{suffix}_{i}{ext}");
             }
             else
             {
@@ -798,7 +803,7 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
     [RelayCommand]
     private async Task OpenOutputFolder()
     {
-        await _folderHelper.OpenFolder(Window!, Se.Settings.Video.BurnIn.OutputFolder);
+        await _folderHelper.OpenFolder(Window!, Se.Settings.Video.Transparent.OutputFolder);
     }
 
     [RelayCommand]

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
@@ -716,10 +716,17 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         // Video.Transparent.OutputFolder / UseOutputFolder, but nothing read them - so whatever
         // folder was picked here had no effect and the files went to the burn-in folder instead.
         var transparent = Se.Settings.Video.Transparent;
-        var useOutputFolder = transparent.UseOutputFolder && !string.IsNullOrEmpty(transparent.OutputFolder);
+
+        // Directory.Exists belongs in the condition itself, not only at the first use: the
+        // collision loop below picks the folder again, and testing it in one place but not the
+        // other builds "<missing folder>/name_2.mp4" for the second file of a run and fails at
+        // write time. Falling back to the source folder is what the first check already does.
+        var useOutputFolder = transparent.UseOutputFolder &&
+                              !string.IsNullOrEmpty(transparent.OutputFolder) &&
+                              Directory.Exists(transparent.OutputFolder);
 
         var fileName = Path.Combine(Path.GetDirectoryName(videoFileName)!, nameNoExt + suffix + ext);
-        if (useOutputFolder && Directory.Exists(transparent.OutputFolder))
+        if (useOutputFolder)
         {
             fileName = Path.Combine(transparent.OutputFolder, nameNoExt + suffix + ext);
         }

--- a/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
@@ -859,7 +859,7 @@ public partial class VideoOcrViewModel : ObservableObject
         }
         else if (engineType == OcrEngineType.Ollama)
         {
-            var ollamaOcr = new OllamaOcr(Se.Settings.Ocr.OllamaOcrTimeoutMinutes);
+            using var ollamaOcr = new OllamaOcr(Se.Settings.Ocr.OllamaOcrTimeoutMinutes);
             await RunLlmOcr(ocrGroups, group => OcrWithBitmap(group, bitmap =>
                     ollamaOcr.Ocr(bitmap, OllamaUrl, OllamaModel, OllamaLanguage, cancellationToken)),
                 () => ollamaOcr.Error, reportProgress, addPreviewLine, cancellationToken);
@@ -873,7 +873,7 @@ public partial class VideoOcrViewModel : ObservableObject
         }
         else if (engineType == OcrEngineType.LlamaCpp)
         {
-            var llamaCppOcr = new LlamaCppOcr(Se.Settings.Ocr.LlamaCppOcrTimeoutMinutes);
+            using var llamaCppOcr = new LlamaCppOcr(Se.Settings.Ocr.LlamaCppOcrTimeoutMinutes);
             var url = LlamaCppServerManager.ApiUrl;
             var modelName = SelectedLlamaCppModel?.Model.FileName is { } fileName
                 ? Path.GetFileNameWithoutExtension(fileName)

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -70,6 +70,15 @@ public class SeTools
     public int SplitRebalanceLongLinesSingleLineMaxLength { get; set; }
     public int SplitRebalanceLongLinesMaxNumberOfLines { get; set; }
     public int SplitRebalanceLongLinesUnbreakShorterThan { get; set; }
+
+    // Per-dialog copies of the general defaults, so a one-off run does not rewrite the app-wide
+    // setting - and the dialog still opens on what it was last used with. 0 means "not saved yet";
+    // every one of these is >= 1 in the UI. Same shape as the split/rebalance keys above (#13514).
+    public int MergeShortLinesSingleLineMaxLength { get; set; }
+    public int MergeShortLinesMaxNumberOfLines { get; set; }
+    public int ApplyDurationLimitsMinDurationMs { get; set; }
+    public int ApplyDurationLimitsMaxDurationMs { get; set; }
+    public int ApplyMinGapMsOrFrames { get; set; }
     public string UnicodeSymbolsToInsert { get; set; }
     public string MusicSymbol { get; set; }
     public string MusicSymbolReplace { get; set; }

--- a/tests/UI/Features/OutputTargetAndDisposalTests.cs
+++ b/tests/UI/Features/OutputTargetAndDisposalTests.cs
@@ -25,28 +25,20 @@ public class OutputTargetAndDisposalTests
     [Fact]
     public void TransparentSettings_LoadsAndSavesItsOwnOutputFolder()
     {
-        var beforeTransparent = Se.Settings.Video.Transparent.OutputFolder;
-        var beforeBurnIn = Se.Settings.Video.BurnIn.OutputFolder;
-        try
-        {
-            Se.Settings.Video.Transparent.OutputFolder = "/tmp/transparent-out";
-            Se.Settings.Video.BurnIn.OutputFolder = "/tmp/burnin-out";
+        using var _ = new SettingsScope("Video.Transparent.OutputFolder", "Video.BurnIn.OutputFolder");
 
-            var vm = new TransparentSettingsViewModel(null!);
-            Invoke(vm, "LoadSettings");
-            Assert.Equal("/tmp/transparent-out", Get(vm, "OutputFolder"));
+        Se.Settings.Video.Transparent.OutputFolder = "/tmp/transparent-out";
+        Se.Settings.Video.BurnIn.OutputFolder = "/tmp/burnin-out";
 
-            Set(vm, "OutputFolder", "/tmp/changed");
-            Invoke(vm, "SaveSettings");
+        var vm = new TransparentSettingsViewModel(null!);
+        Invoke(vm, "LoadSettings");
+        Assert.Equal("/tmp/transparent-out", Get(vm, "OutputFolder"));
 
-            Assert.Equal("/tmp/changed", Se.Settings.Video.Transparent.OutputFolder);
-            Assert.Equal("/tmp/burnin-out", Se.Settings.Video.BurnIn.OutputFolder); // untouched
-        }
-        finally
-        {
-            Se.Settings.Video.Transparent.OutputFolder = beforeTransparent;
-            Se.Settings.Video.BurnIn.OutputFolder = beforeBurnIn;
-        }
+        Set(vm, "OutputFolder", "/tmp/changed");
+        Invoke(vm, "SaveSettings");
+
+        Assert.Equal("/tmp/changed", Se.Settings.Video.Transparent.OutputFolder);
+        Assert.Equal("/tmp/burnin-out", Se.Settings.Video.BurnIn.OutputFolder); // untouched
     }
 
     /// <summary>
@@ -56,49 +48,80 @@ public class OutputTargetAndDisposalTests
     [Fact]
     public void SplitSubtitle_ReopensOnTheLastUsedFormatAndEncoding()
     {
-        var beforeFormat = Se.Settings.Tools.SplitSubtitleFormat;
-        var beforeEncoding = Se.Settings.Tools.SplitSubtitleEncoding;
-        try
-        {
-            var first = new SplitSubtitleViewModel(null!, null!);
-            var otherFormat = first.Formats.Skip(3).First();
-            var otherEncoding = first.Encodings.Skip(2).First();
+        using var _ = new SettingsScope("Tools.SplitSubtitleFormat", "Tools.SplitSubtitleEncoding");
 
-            Se.Settings.Tools.SplitSubtitleFormat = otherFormat.Name;
-            Se.Settings.Tools.SplitSubtitleEncoding = otherEncoding.DisplayName;
+        var first = new SplitSubtitleViewModel(null!, null!);
+        var otherFormat = first.Formats.Skip(3).First();
+        var otherEncoding = first.Encodings.Skip(2).First();
 
-            var reopened = new SplitSubtitleViewModel(null!, null!);
+        Se.Settings.Tools.SplitSubtitleFormat = otherFormat.Name;
+        Se.Settings.Tools.SplitSubtitleEncoding = otherEncoding.DisplayName;
 
-            Assert.Equal(otherFormat.Name, reopened.SelectedSubtitleFormat?.Name);
-            Assert.Equal(otherEncoding.DisplayName, reopened.SelectedEncoding?.DisplayName);
-        }
-        finally
-        {
-            Se.Settings.Tools.SplitSubtitleFormat = beforeFormat;
-            Se.Settings.Tools.SplitSubtitleEncoding = beforeEncoding;
-        }
+        var reopened = new SplitSubtitleViewModel(null!, null!);
+
+        Assert.Equal(otherFormat.Name, reopened.SelectedSubtitleFormat?.Name);
+        Assert.Equal(otherEncoding.DisplayName, reopened.SelectedEncoding?.DisplayName);
     }
 
     // An unknown saved name must not leave the dialog with nothing selected.
     [Fact]
     public void SplitSubtitle_FallsBackWhenTheSavedNamesAreGone()
     {
-        var beforeFormat = Se.Settings.Tools.SplitSubtitleFormat;
-        var beforeEncoding = Se.Settings.Tools.SplitSubtitleEncoding;
+        using var _ = new SettingsScope("Tools.SplitSubtitleFormat", "Tools.SplitSubtitleEncoding");
+
+        Se.Settings.Tools.SplitSubtitleFormat = "no such format";
+        Se.Settings.Tools.SplitSubtitleEncoding = "no such encoding";
+
+        var vm = new SplitSubtitleViewModel(null!, null!);
+
+        Assert.Equal(vm.Formats[0].Name, vm.SelectedSubtitleFormat?.Name);
+        Assert.Equal(vm.Encodings[0].DisplayName, vm.SelectedEncoding?.DisplayName);
+    }
+
+    /// <summary>
+    /// The output folder is only usable if it exists, and that has to hold for the collision loop
+    /// too: testing Directory.Exists at the first use but not when resolving "_2", "_3", ... builds
+    /// a path into a missing directory for the second file of a run, which then fails at write time.
+    /// </summary>
+    [Theory]
+    [InlineData(false)] // first file
+    [InlineData(true)]  // name already taken, so the collision loop picks the folder again
+    public void TransparentSubtitles_MissingOutputFolder_FallsBackToTheSourceFolder(bool nameTaken)
+    {
+        using var _ = new SettingsScope(
+            "Video.Transparent.OutputFolder",
+            "Video.Transparent.UseOutputFolder",
+            "Video.BurnIn.BurnInSuffix");
+
+        var dir = Directory.CreateTempSubdirectory("se-transparent-output");
         try
         {
-            Se.Settings.Tools.SplitSubtitleFormat = "no such format";
-            Se.Settings.Tools.SplitSubtitleEncoding = "no such encoding";
+            var missing = Path.Combine(dir.FullName, "does", "not", "exist");
+            Se.Settings.Video.Transparent.UseOutputFolder = true;
+            Se.Settings.Video.Transparent.OutputFolder = missing;
+            Se.Settings.Video.BurnIn.BurnInSuffix = "_new";
 
-            var vm = new SplitSubtitleViewModel(null!, null!);
+            var videoFileName = Path.Combine(dir.FullName, "clip.mp4");
+            File.WriteAllText(videoFileName, string.Empty);
 
-            Assert.Equal(vm.Formats[0].Name, vm.SelectedSubtitleFormat?.Name);
-            Assert.Equal(vm.Encodings[0].DisplayName, vm.SelectedEncoding?.DisplayName);
+            var vm = new TransparentSubtitlesViewModel(null!, null!, null!);
+            var ext = (string)Get(vm, "SelectedVideoExtension")!;
+            if (nameTaken)
+            {
+                File.WriteAllText(Path.Combine(dir.FullName, "clip_new" + ext), string.Empty);
+            }
+
+            var method = typeof(TransparentSubtitlesViewModel)
+                .GetMethod("MakeOutputFileName", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var result = (string)method.Invoke(vm, new object[] { videoFileName })!;
+
+            Assert.False(result.StartsWith(missing, StringComparison.Ordinal),
+                $"resolved into the missing output folder: {result}");
+            Assert.Equal(dir.FullName, Path.GetDirectoryName(result));
         }
         finally
         {
-            Se.Settings.Tools.SplitSubtitleFormat = beforeFormat;
-            Se.Settings.Tools.SplitSubtitleEncoding = beforeEncoding;
+            dir.Delete(recursive: true);
         }
     }
 

--- a/tests/UI/Features/OutputTargetAndDisposalTests.cs
+++ b/tests/UI/Features/OutputTargetAndDisposalTests.cs
@@ -1,0 +1,122 @@
+using Nikse.SubtitleEdit.Features.Ocr.Engines;
+using Nikse.SubtitleEdit.Features.Tools.SplitSubtitle;
+using Nikse.SubtitleEdit.Features.Video.TransparentSubtitles;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Reflection;
+
+namespace UITests.Features;
+
+public class OutputTargetAndDisposalTests
+{
+    private static void Invoke(object vm, string method) =>
+        vm.GetType().GetMethod(method, BindingFlags.Instance | BindingFlags.NonPublic)!.Invoke(vm, null);
+
+    private static void Set(object vm, string property, object value) =>
+        vm.GetType().GetProperty(property)!.SetValue(vm, value);
+
+    private static object? Get(object vm, string property) =>
+        vm.GetType().GetProperty(property)!.GetValue(vm);
+
+    /// <summary>
+    /// The transparent-subtitles settings dialog saved to Video.Transparent.OutputFolder but loaded
+    /// Video.BurnIn.OutputFolder - and nothing read the value it saved, so the folder picked here
+    /// had no effect at all and the generated files went to the burn-in folder instead.
+    /// </summary>
+    [Fact]
+    public void TransparentSettings_LoadsAndSavesItsOwnOutputFolder()
+    {
+        var beforeTransparent = Se.Settings.Video.Transparent.OutputFolder;
+        var beforeBurnIn = Se.Settings.Video.BurnIn.OutputFolder;
+        try
+        {
+            Se.Settings.Video.Transparent.OutputFolder = "/tmp/transparent-out";
+            Se.Settings.Video.BurnIn.OutputFolder = "/tmp/burnin-out";
+
+            var vm = new TransparentSettingsViewModel(null!);
+            Invoke(vm, "LoadSettings");
+            Assert.Equal("/tmp/transparent-out", Get(vm, "OutputFolder"));
+
+            Set(vm, "OutputFolder", "/tmp/changed");
+            Invoke(vm, "SaveSettings");
+
+            Assert.Equal("/tmp/changed", Se.Settings.Video.Transparent.OutputFolder);
+            Assert.Equal("/tmp/burnin-out", Se.Settings.Video.BurnIn.OutputFolder); // untouched
+        }
+        finally
+        {
+            Se.Settings.Video.Transparent.OutputFolder = beforeTransparent;
+            Se.Settings.Video.BurnIn.OutputFolder = beforeBurnIn;
+        }
+    }
+
+    /// <summary>
+    /// Split subtitle wrote the chosen format and encoding on OK but never read them back, so the
+    /// dialog always reopened on the first entry of each list.
+    /// </summary>
+    [Fact]
+    public void SplitSubtitle_ReopensOnTheLastUsedFormatAndEncoding()
+    {
+        var beforeFormat = Se.Settings.Tools.SplitSubtitleFormat;
+        var beforeEncoding = Se.Settings.Tools.SplitSubtitleEncoding;
+        try
+        {
+            var first = new SplitSubtitleViewModel(null!, null!);
+            var otherFormat = first.Formats.Skip(3).First();
+            var otherEncoding = first.Encodings.Skip(2).First();
+
+            Se.Settings.Tools.SplitSubtitleFormat = otherFormat.Name;
+            Se.Settings.Tools.SplitSubtitleEncoding = otherEncoding.DisplayName;
+
+            var reopened = new SplitSubtitleViewModel(null!, null!);
+
+            Assert.Equal(otherFormat.Name, reopened.SelectedSubtitleFormat?.Name);
+            Assert.Equal(otherEncoding.DisplayName, reopened.SelectedEncoding?.DisplayName);
+        }
+        finally
+        {
+            Se.Settings.Tools.SplitSubtitleFormat = beforeFormat;
+            Se.Settings.Tools.SplitSubtitleEncoding = beforeEncoding;
+        }
+    }
+
+    // An unknown saved name must not leave the dialog with nothing selected.
+    [Fact]
+    public void SplitSubtitle_FallsBackWhenTheSavedNamesAreGone()
+    {
+        var beforeFormat = Se.Settings.Tools.SplitSubtitleFormat;
+        var beforeEncoding = Se.Settings.Tools.SplitSubtitleEncoding;
+        try
+        {
+            Se.Settings.Tools.SplitSubtitleFormat = "no such format";
+            Se.Settings.Tools.SplitSubtitleEncoding = "no such encoding";
+
+            var vm = new SplitSubtitleViewModel(null!, null!);
+
+            Assert.Equal(vm.Formats[0].Name, vm.SelectedSubtitleFormat?.Name);
+            Assert.Equal(vm.Encodings[0].DisplayName, vm.SelectedEncoding?.DisplayName);
+        }
+        finally
+        {
+            Se.Settings.Tools.SplitSubtitleFormat = beforeFormat;
+            Se.Settings.Tools.SplitSubtitleEncoding = beforeEncoding;
+        }
+    }
+
+    // A new engine - and so a new HttpClient, handler and connection pool - is built per OCR run
+    // from three call sites each; without disposal those accumulate until sockets run out.
+    [Fact]
+    public void OcrEnginesOwningAnHttpClient_AreDisposable()
+    {
+        Assert.True(typeof(IDisposable).IsAssignableFrom(typeof(OllamaOcr)));
+        Assert.True(typeof(IDisposable).IsAssignableFrom(typeof(LlamaCppOcr)));
+
+        // Idempotent: the call sites use "using", and a double dispose must not throw.
+        var ollama = new OllamaOcr();
+        ollama.Dispose();
+        ollama.Dispose();
+
+        var llamaCpp = new LlamaCppOcr();
+        llamaCpp.Dispose();
+        llamaCpp.Dispose();
+    }
+}

--- a/tests/UI/Features/SettingsPersistenceTests.cs
+++ b/tests/UI/Features/SettingsPersistenceTests.cs
@@ -12,6 +12,10 @@ namespace UITests.Features;
 /// and they have to keep that in their own settings key, not by writing back over the app-wide
 /// default (#13514 established both halves for split/rebalance long lines). Three more dialogs had
 /// a <c>SaveSettings</c> that stored nothing at all, so every visit reset to the general default.
+///
+/// Every global these tests touch - the dialog's own key and the general default it falls back to -
+/// goes through <see cref="SettingsScope"/>, because Se.Settings is one instance shared by the
+/// whole run and a leaked value silently changes what later tests start from.
 /// </summary>
 public class SettingsPersistenceTests
 {
@@ -27,103 +31,92 @@ public class SettingsPersistenceTests
     [Fact]
     public void ApplyMinGap_RemembersTheGap()
     {
-        var before = Se.Settings.Tools.ApplyMinGapMsOrFrames;
-        try
-        {
-            Se.Settings.Tools.ApplyMinGapMsOrFrames = 0;
-            Se.Settings.General.MinimumBetweenLines.Milliseconds = 24;
-            Se.Settings.General.UseFrameMode = false;
+        using var _ = new SettingsScope(
+            "Tools.ApplyMinGapMsOrFrames",
+            "General.MinimumBetweenLines.Milliseconds",
+            "General.UseFrameMode");
 
-            var vm = new ApplyMinGapViewModel();
-            Invoke(vm, "LoadSettings");
-            Assert.Equal(24, Get(vm, "MinGapMsOrFrames")); // falls back to the general default
+        Se.Settings.Tools.ApplyMinGapMsOrFrames = 0;
+        Se.Settings.General.MinimumBetweenLines.Milliseconds = 24;
+        Se.Settings.General.UseFrameMode = false;
 
-            Set(vm, "MinGapMsOrFrames", 120);
-            Invoke(vm, "SaveSettings");
+        var vm = new ApplyMinGapViewModel();
+        Invoke(vm, "LoadSettings");
+        Assert.Equal(24, Get(vm, "MinGapMsOrFrames")); // falls back to the general default
 
-            var reopened = new ApplyMinGapViewModel();
-            Invoke(reopened, "LoadSettings");
-            Assert.Equal(120, Get(reopened, "MinGapMsOrFrames"));
+        Set(vm, "MinGapMsOrFrames", 120);
+        Invoke(vm, "SaveSettings");
 
-            // The dialog keeps its own copy - the app-wide default is left alone.
-            Assert.Equal(24, Se.Settings.General.MinimumBetweenLines.Milliseconds);
-        }
-        finally
-        {
-            Se.Settings.Tools.ApplyMinGapMsOrFrames = before;
-        }
+        var reopened = new ApplyMinGapViewModel();
+        Invoke(reopened, "LoadSettings");
+        Assert.Equal(120, Get(reopened, "MinGapMsOrFrames"));
+
+        // The dialog keeps its own copy - the app-wide default is left alone.
+        Assert.Equal(24, Se.Settings.General.MinimumBetweenLines.Milliseconds);
     }
 
     [Fact]
     public void MergeShortLines_RemembersMaxLengthAndMaxLines()
     {
-        var beforeLength = Se.Settings.Tools.MergeShortLinesSingleLineMaxLength;
-        var beforeLines = Se.Settings.Tools.MergeShortLinesMaxNumberOfLines;
-        try
-        {
-            Se.Settings.Tools.MergeShortLinesSingleLineMaxLength = 0;
-            Se.Settings.Tools.MergeShortLinesMaxNumberOfLines = 0;
-            Se.Settings.General.SubtitleLineMaximumLength = 43;
-            Se.Settings.General.MaxNumberOfLines = 2;
+        using var _ = new SettingsScope(
+            "Tools.MergeShortLinesSingleLineMaxLength",
+            "Tools.MergeShortLinesMaxNumberOfLines",
+            "General.SubtitleLineMaximumLength",
+            "General.MaxNumberOfLines");
 
-            var vm = new MergeShortLinesViewModel();
-            Invoke(vm, "LoadSettings");
-            Assert.Equal(43, Get(vm, "SingleLineMaxLength"));
-            Assert.Equal(2, Get(vm, "MaxNumberOfLines"));
+        Se.Settings.Tools.MergeShortLinesSingleLineMaxLength = 0;
+        Se.Settings.Tools.MergeShortLinesMaxNumberOfLines = 0;
+        Se.Settings.General.SubtitleLineMaximumLength = 43;
+        Se.Settings.General.MaxNumberOfLines = 2;
 
-            Set(vm, "SingleLineMaxLength", 37);
-            Set(vm, "MaxNumberOfLines", 3);
-            Invoke(vm, "SaveSettings");
+        var vm = new MergeShortLinesViewModel();
+        Invoke(vm, "LoadSettings");
+        Assert.Equal(43, Get(vm, "SingleLineMaxLength"));
+        Assert.Equal(2, Get(vm, "MaxNumberOfLines"));
 
-            var reopened = new MergeShortLinesViewModel();
-            Invoke(reopened, "LoadSettings");
-            Assert.Equal(37, Get(reopened, "SingleLineMaxLength"));
-            Assert.Equal(3, Get(reopened, "MaxNumberOfLines"));
+        Set(vm, "SingleLineMaxLength", 37);
+        Set(vm, "MaxNumberOfLines", 3);
+        Invoke(vm, "SaveSettings");
 
-            Assert.Equal(43, Se.Settings.General.SubtitleLineMaximumLength);
-            Assert.Equal(2, Se.Settings.General.MaxNumberOfLines);
-        }
-        finally
-        {
-            Se.Settings.Tools.MergeShortLinesSingleLineMaxLength = beforeLength;
-            Se.Settings.Tools.MergeShortLinesMaxNumberOfLines = beforeLines;
-        }
+        var reopened = new MergeShortLinesViewModel();
+        Invoke(reopened, "LoadSettings");
+        Assert.Equal(37, Get(reopened, "SingleLineMaxLength"));
+        Assert.Equal(3, Get(reopened, "MaxNumberOfLines"));
+
+        Assert.Equal(43, Se.Settings.General.SubtitleLineMaximumLength);
+        Assert.Equal(2, Se.Settings.General.MaxNumberOfLines);
     }
 
     [Fact]
     public void ApplyDurationLimits_RemembersMinAndMaxDuration()
     {
-        var beforeMin = Se.Settings.Tools.ApplyDurationLimitsMinDurationMs;
-        var beforeMax = Se.Settings.Tools.ApplyDurationLimitsMaxDurationMs;
-        try
-        {
-            Se.Settings.Tools.ApplyDurationLimitsMinDurationMs = 0;
-            Se.Settings.Tools.ApplyDurationLimitsMaxDurationMs = 0;
-            Se.Settings.General.SubtitleMinimumDisplayMilliseconds = 1000;
-            Se.Settings.General.SubtitleMaximumDisplayMilliseconds = 8000;
+        using var _ = new SettingsScope(
+            "Tools.ApplyDurationLimitsMinDurationMs",
+            "Tools.ApplyDurationLimitsMaxDurationMs",
+            "General.SubtitleMinimumDisplayMilliseconds",
+            "General.SubtitleMaximumDisplayMilliseconds");
 
-            var vm = new ApplyDurationLimitsViewModel();
-            Invoke(vm, "LoadSettings");
-            Assert.Equal(1000, Get(vm, "MinDurationMs"));
-            Assert.Equal(8000, Get(vm, "MaxDurationMs"));
+        Se.Settings.Tools.ApplyDurationLimitsMinDurationMs = 0;
+        Se.Settings.Tools.ApplyDurationLimitsMaxDurationMs = 0;
+        Se.Settings.General.SubtitleMinimumDisplayMilliseconds = 1000;
+        Se.Settings.General.SubtitleMaximumDisplayMilliseconds = 8000;
 
-            Set(vm, "MinDurationMs", 1200);
-            Set(vm, "MaxDurationMs", 6000);
-            Invoke(vm, "SaveSettings");
+        var vm = new ApplyDurationLimitsViewModel();
+        Invoke(vm, "LoadSettings");
+        Assert.Equal(1000, Get(vm, "MinDurationMs"));
+        Assert.Equal(8000, Get(vm, "MaxDurationMs"));
 
-            var reopened = new ApplyDurationLimitsViewModel();
-            Invoke(reopened, "LoadSettings");
-            Assert.Equal(1200, Get(reopened, "MinDurationMs"));
-            Assert.Equal(6000, Get(reopened, "MaxDurationMs"));
+        Set(vm, "MinDurationMs", 1200);
+        Set(vm, "MaxDurationMs", 6000);
+        Invoke(vm, "SaveSettings");
 
-            Assert.Equal(1000, Se.Settings.General.SubtitleMinimumDisplayMilliseconds);
-            Assert.Equal(8000, Se.Settings.General.SubtitleMaximumDisplayMilliseconds);
-        }
-        finally
-        {
-            Se.Settings.Tools.ApplyDurationLimitsMinDurationMs = beforeMin;
-            Se.Settings.Tools.ApplyDurationLimitsMaxDurationMs = beforeMax;
-        }
+        var reopened = new ApplyDurationLimitsViewModel();
+        Invoke(reopened, "LoadSettings");
+        Assert.Equal(1200, Get(reopened, "MinDurationMs"));
+        Assert.Equal(6000, Get(reopened, "MaxDurationMs"));
+
+        Assert.Equal(1000, Se.Settings.General.SubtitleMinimumDisplayMilliseconds);
+        Assert.Equal(8000, Se.Settings.General.SubtitleMaximumDisplayMilliseconds);
     }
 
     // Cancel has to leave the options alone - Escape in the same dialog already did, so the two
@@ -131,20 +124,14 @@ public class SettingsPersistenceTests
     [Fact]
     public void ExportPlainText_CancelDoesNotSaveSettings()
     {
-        var before = Se.Settings.File.ExportPlainText.ShowLineNumbers;
-        try
-        {
-            Se.Settings.File.ExportPlainText.ShowLineNumbers = false;
+        using var _ = new SettingsScope("File.ExportPlainText.ShowLineNumbers");
 
-            var vm = new ExportPlainTextViewModel(null!, null!);
-            Set(vm, "ShowLineNumbers", true);
-            vm.CancelCommand.Execute(null);
+        Se.Settings.File.ExportPlainText.ShowLineNumbers = false;
 
-            Assert.False(Se.Settings.File.ExportPlainText.ShowLineNumbers);
-        }
-        finally
-        {
-            Se.Settings.File.ExportPlainText.ShowLineNumbers = before;
-        }
+        var vm = new ExportPlainTextViewModel(null!, null!);
+        Set(vm, "ShowLineNumbers", true);
+        vm.CancelCommand.Execute(null);
+
+        Assert.False(Se.Settings.File.ExportPlainText.ShowLineNumbers);
     }
 }

--- a/tests/UI/Features/SettingsPersistenceTests.cs
+++ b/tests/UI/Features/SettingsPersistenceTests.cs
@@ -1,0 +1,150 @@
+using Nikse.SubtitleEdit.Features.Files.ExportPlainText;
+using Nikse.SubtitleEdit.Features.Tools.ApplyDurationLimits;
+using Nikse.SubtitleEdit.Features.Tools.ApplyMinGap;
+using Nikse.SubtitleEdit.Features.Tools.MergeShortLines;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Reflection;
+
+namespace UITests.Features;
+
+/// <summary>
+/// Dialogs that offer a number the user can change have to reopen on the number they last used -
+/// and they have to keep that in their own settings key, not by writing back over the app-wide
+/// default (#13514 established both halves for split/rebalance long lines). Three more dialogs had
+/// a <c>SaveSettings</c> that stored nothing at all, so every visit reset to the general default.
+/// </summary>
+public class SettingsPersistenceTests
+{
+    private static void Invoke(object vm, string method) =>
+        vm.GetType().GetMethod(method, BindingFlags.Instance | BindingFlags.NonPublic)!.Invoke(vm, null);
+
+    private static void Set(object vm, string property, object value) =>
+        vm.GetType().GetProperty(property)!.SetValue(vm, value);
+
+    private static object? Get(object vm, string property) =>
+        vm.GetType().GetProperty(property)!.GetValue(vm);
+
+    [Fact]
+    public void ApplyMinGap_RemembersTheGap()
+    {
+        var before = Se.Settings.Tools.ApplyMinGapMsOrFrames;
+        try
+        {
+            Se.Settings.Tools.ApplyMinGapMsOrFrames = 0;
+            Se.Settings.General.MinimumBetweenLines.Milliseconds = 24;
+            Se.Settings.General.UseFrameMode = false;
+
+            var vm = new ApplyMinGapViewModel();
+            Invoke(vm, "LoadSettings");
+            Assert.Equal(24, Get(vm, "MinGapMsOrFrames")); // falls back to the general default
+
+            Set(vm, "MinGapMsOrFrames", 120);
+            Invoke(vm, "SaveSettings");
+
+            var reopened = new ApplyMinGapViewModel();
+            Invoke(reopened, "LoadSettings");
+            Assert.Equal(120, Get(reopened, "MinGapMsOrFrames"));
+
+            // The dialog keeps its own copy - the app-wide default is left alone.
+            Assert.Equal(24, Se.Settings.General.MinimumBetweenLines.Milliseconds);
+        }
+        finally
+        {
+            Se.Settings.Tools.ApplyMinGapMsOrFrames = before;
+        }
+    }
+
+    [Fact]
+    public void MergeShortLines_RemembersMaxLengthAndMaxLines()
+    {
+        var beforeLength = Se.Settings.Tools.MergeShortLinesSingleLineMaxLength;
+        var beforeLines = Se.Settings.Tools.MergeShortLinesMaxNumberOfLines;
+        try
+        {
+            Se.Settings.Tools.MergeShortLinesSingleLineMaxLength = 0;
+            Se.Settings.Tools.MergeShortLinesMaxNumberOfLines = 0;
+            Se.Settings.General.SubtitleLineMaximumLength = 43;
+            Se.Settings.General.MaxNumberOfLines = 2;
+
+            var vm = new MergeShortLinesViewModel();
+            Invoke(vm, "LoadSettings");
+            Assert.Equal(43, Get(vm, "SingleLineMaxLength"));
+            Assert.Equal(2, Get(vm, "MaxNumberOfLines"));
+
+            Set(vm, "SingleLineMaxLength", 37);
+            Set(vm, "MaxNumberOfLines", 3);
+            Invoke(vm, "SaveSettings");
+
+            var reopened = new MergeShortLinesViewModel();
+            Invoke(reopened, "LoadSettings");
+            Assert.Equal(37, Get(reopened, "SingleLineMaxLength"));
+            Assert.Equal(3, Get(reopened, "MaxNumberOfLines"));
+
+            Assert.Equal(43, Se.Settings.General.SubtitleLineMaximumLength);
+            Assert.Equal(2, Se.Settings.General.MaxNumberOfLines);
+        }
+        finally
+        {
+            Se.Settings.Tools.MergeShortLinesSingleLineMaxLength = beforeLength;
+            Se.Settings.Tools.MergeShortLinesMaxNumberOfLines = beforeLines;
+        }
+    }
+
+    [Fact]
+    public void ApplyDurationLimits_RemembersMinAndMaxDuration()
+    {
+        var beforeMin = Se.Settings.Tools.ApplyDurationLimitsMinDurationMs;
+        var beforeMax = Se.Settings.Tools.ApplyDurationLimitsMaxDurationMs;
+        try
+        {
+            Se.Settings.Tools.ApplyDurationLimitsMinDurationMs = 0;
+            Se.Settings.Tools.ApplyDurationLimitsMaxDurationMs = 0;
+            Se.Settings.General.SubtitleMinimumDisplayMilliseconds = 1000;
+            Se.Settings.General.SubtitleMaximumDisplayMilliseconds = 8000;
+
+            var vm = new ApplyDurationLimitsViewModel();
+            Invoke(vm, "LoadSettings");
+            Assert.Equal(1000, Get(vm, "MinDurationMs"));
+            Assert.Equal(8000, Get(vm, "MaxDurationMs"));
+
+            Set(vm, "MinDurationMs", 1200);
+            Set(vm, "MaxDurationMs", 6000);
+            Invoke(vm, "SaveSettings");
+
+            var reopened = new ApplyDurationLimitsViewModel();
+            Invoke(reopened, "LoadSettings");
+            Assert.Equal(1200, Get(reopened, "MinDurationMs"));
+            Assert.Equal(6000, Get(reopened, "MaxDurationMs"));
+
+            Assert.Equal(1000, Se.Settings.General.SubtitleMinimumDisplayMilliseconds);
+            Assert.Equal(8000, Se.Settings.General.SubtitleMaximumDisplayMilliseconds);
+        }
+        finally
+        {
+            Se.Settings.Tools.ApplyDurationLimitsMinDurationMs = beforeMin;
+            Se.Settings.Tools.ApplyDurationLimitsMaxDurationMs = beforeMax;
+        }
+    }
+
+    // Cancel has to leave the options alone - Escape in the same dialog already did, so the two
+    // ways out disagreed and the button was the wrong one.
+    [Fact]
+    public void ExportPlainText_CancelDoesNotSaveSettings()
+    {
+        var before = Se.Settings.File.ExportPlainText.ShowLineNumbers;
+        try
+        {
+            Se.Settings.File.ExportPlainText.ShowLineNumbers = false;
+
+            var vm = new ExportPlainTextViewModel(null!, null!);
+            Set(vm, "ShowLineNumbers", true);
+            vm.CancelCommand.Execute(null);
+
+            Assert.False(Se.Settings.File.ExportPlainText.ShowLineNumbers);
+        }
+        finally
+        {
+            Se.Settings.File.ExportPlainText.ShowLineNumbers = before;
+        }
+    }
+}

--- a/tests/UI/SettingsScope.cs
+++ b/tests/UI/SettingsScope.cs
@@ -1,0 +1,59 @@
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Reflection;
+
+namespace UITests;
+
+/// <summary>
+/// Snapshots the settings a test is about to change and puts them back on dispose.
+///
+/// <see cref="Se.Settings"/> is one static instance shared by the whole headless run, so a test
+/// that leaves <c>General.SubtitleLineMaximumLength</c> (or any other global default) rewritten
+/// changes the starting conditions of every test that runs after it - which shows up as a suite
+/// that passes alone and fails in a different order. Restoring by hand is easy to get half right:
+/// the usual failure is remembering the setting under test and forgetting the defaults it falls
+/// back to.
+///
+/// Paths are the dotted names below <c>Se.Settings</c>, e.g. "General.MaxNumberOfLines" or
+/// "Tools.ApplyMinGapMsOrFrames".
+/// </summary>
+internal sealed class SettingsScope : IDisposable
+{
+    private readonly List<(PropertyInfo Property, object Owner, object? Value)> _saved = new();
+
+    internal SettingsScope(params string[] paths)
+    {
+        foreach (var path in paths)
+        {
+            var (owner, property) = Resolve(path);
+            _saved.Add((property, owner, property.GetValue(owner)));
+        }
+    }
+
+    public void Dispose()
+    {
+        // Reverse order so a nested scope over the same path restores in the order it saved.
+        for (var i = _saved.Count - 1; i >= 0; i--)
+        {
+            var (property, owner, value) = _saved[i];
+            property.SetValue(owner, value);
+        }
+    }
+
+    private static (object Owner, PropertyInfo Property) Resolve(string path)
+    {
+        object owner = Se.Settings;
+        var parts = path.Split('.');
+        for (var i = 0; i < parts.Length - 1; i++)
+        {
+            var step = owner.GetType().GetProperty(parts[i])
+                       ?? throw new ArgumentException($"No settings property '{parts[i]}' in '{path}'");
+            owner = step.GetValue(owner)
+                    ?? throw new ArgumentException($"Settings property '{parts[i]}' is null in '{path}'");
+        }
+
+        var last = owner.GetType().GetProperty(parts[^1])
+                   ?? throw new ArgumentException($"No settings property '{parts[^1]}' in '{path}'");
+
+        return (owner, last);
+    }
+}


### PR DESCRIPTION
A hunt across the whole codebase rather than a commit range. Ten bugs, each verified by following the code path end to end — no speculative entries.

| # | Bug | Severity |
|---|-----|----------|
| 1 | Transparent-subtitles output folder setting had no effect; files went to the **burn-in** folder | High |
| 2 | ASSA progress bar leaked a 500 ms timer and an mpv player for the rest of the session | High |
| 3 | Perplexity translate API key / model / URL lost on every restart | High |
| 4 | Ollama and llama.cpp OCR engines leaked an `HttpClient` per run | Med-High |
| 5 | Apply minimum gap: chosen gap never saved | Medium |
| 6 | Merge short lines: max length / max lines never saved | Medium |
| 7 | Apply duration limits: min/max duration never saved | Medium |
| 8 | Export plain text: **Cancel** saved the settings | Medium |
| 9 | Split subtitle: output format/encoding never restored | Low-Med |
| 10 | nOCR / binary-OCR inspect: "lines to auto draw" not saved | Low |

### The three that matter most

**#1** is a read/write mismatch that hid itself. The settings dialog wrote `Video.Transparent.OutputFolder` / `UseOutputFolder`, which **nothing** read — generation and "Open output folder" both used `Video.BurnIn.*`. So the folder you picked never applied, and ticking "use output folder" did nothing. The dialog then loaded burn-in's folder back into its own box, so the setting looked like it was simply being discarded.

*Behaviour change worth flagging:* anyone with a burn-in output folder configured will now get transparent output beside the source video (or in this dialog's own folder) rather than in the burn-in folder — which is what the dialog has claimed all along.

**#2** `AssaProgressBarWindow` wired no closing cleanup at all. The `DispatcherTimer` kept ticking after close: re-rendering, rewriting the temp `.ass` on every change, and calling `SubAdd`/`SubReload` on a player whose window was gone — the kind of call into a disposed player #13083 was about. Each reopen added another timer. Fixed via `IClosingCleanup`, which `UiUtil.InitializeWindow` already invokes on every close path.

**#3** Auto-translate copies `Configuration.Settings.Tools.X → Se.Settings.AutoTranslate.X` for ~30 engines before `Se.SaveSettings()`. Perplexity was the only one missing, so its credentials never reached the settings file.

### #5–#7 share a root with #13514

Same shape as the already-fixed split/rebalance dialog: two of the three had a `SaveSettings` whose entire body was `Se.SaveSettings()`. Same remedy — per-dialog `Tools.*` keys with `0` meaning "not saved yet" so the first run still falls back to the general default. A one-off run in a tool dialog shouldn't silently redefine the app-wide setting, which is why these get their own keys rather than writing back to `General.*`.

---

**Tests:** 4054 pass (15 new). Two new files cover the settings-persistence family (including that `General.*` is left untouched), the Transparent/BurnIn folder separation, split-subtitle restore plus its fallback when a saved name is gone, and that both OCR engines are disposable and idempotently so.

### What the sweeps cleared

Worth recording, since absence of findings is a result too: 408 subtitle formats round-tripped and survived 11 hostile inputs with **zero** exceptions; `AutoBreakLine`, `RemoveHtmlTags` idempotence and frame-code round-trips hold across a mixed Latin/Hebrew/Japanese corpus; all **1053** settings survive a JSON save/load cycle; the suite passes under Danish and Turkish locales (comma-decimal and dotted-I); only 4 non-invariant `ToLower`/`ToUpper` calls exist in libse and none in a comparison; all 12 TTS engines guard their `ProcessExit` hook.

What actually paid off was scripted read-vs-write comparison of settings paths followed by hand-verification — I discarded roughly two thirds of the script's hits as false positives (colour settings, profile names, legitimately read-only global defaults), and dropped one candidate entirely (`VobSubColorIsolation`'s fallback tie-break) once a test showed it already behaves correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
