### PR TITLE
Revert: keep the find scope sticky across find next / previous

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12393,7 +12393,10 @@ public partial class MainViewModel :
             var subs = Subtitles.Select(p => p.Text).ToList();
             var origs = GetOriginalTextsForFind();
 
-            ResetFindScopeToBothColumns();
+            // The find window has no scope picker and always covers both columns, so it also clears
+            // a scope the replace window left behind (SE 4's find dialog built a fresh helper with
+            // both flags set for the same reason).
+            _findService.CurrentScope = FindScope.TextAndOriginal;
 
             var startInOriginal = IsFindPositionInOriginal();
             var startTextBox = GetFindTextBox(startInOriginal);
@@ -12457,10 +12460,6 @@ public partial class MainViewModel :
 
         var subs = Subtitles.Select(p => p.Text).ToList();
         var origs = GetOriginalTextsForFind();
-
-        // Before IsFindPositionInOriginal, which follows the scope - see HandleFindResult.
-        ResetFindScopeToBothColumns();
-
         var startInOriginal = IsFindPositionInOriginal();
         var currentLineIndex = Subtitles.IndexOf(selectedSubtitle);
         var currentCharIndex = GetFindTextBox(startInOriginal).SelectionEnd;
@@ -12508,10 +12507,6 @@ public partial class MainViewModel :
 
         var subs = Subtitles.Select(p => p.Text).ToList();
         var origs = GetOriginalTextsForFind();
-
-        // Before IsFindPositionInOriginal, which follows the scope - see HandleFindResult.
-        ResetFindScopeToBothColumns();
-
         var startInOriginal = IsFindPositionInOriginal();
         var currentLineIndex = Subtitles.IndexOf(selectedSubtitle);
         var idx = _findService.FindPrevious(_findService.SearchText, subs, currentLineIndex, GetFindTextBox(startInOriginal).SelectionStart - 1, origs, startInOriginal);
@@ -12560,21 +12555,6 @@ public partial class MainViewModel :
     private List<string>? GetOriginalTextsForReplace()
     {
         return CanEditOriginal ? GetOriginalTextsForFind() : null;
-    }
-
-    /// <summary>
-    /// Puts the find service back to searching both columns. Finding always covers both - only the
-    /// replace window can narrow it, and it does that by leaving the scope on the shared service
-    /// (SE 4's find dialog built a fresh helper with both flags set for the same reason). So every
-    /// way into a find has to clear what a replace left behind: the find window, and the find
-    /// next / find previous shortcuts, which reach the service without opening any window.
-    ///
-    /// Call before <see cref="IsFindPositionInOriginal"/>, which follows the scope - a stale one
-    /// would also start the search from the wrong column's caret.
-    /// </summary>
-    private void ResetFindScopeToBothColumns()
-    {
-        _findService.CurrentScope = FindScope.TextAndOriginal;
     }
 
     /// <summary>

--- a/src/ui/Logic/IFindService.cs
+++ b/src/ui/Logic/IFindService.cs
@@ -19,11 +19,8 @@ public interface IFindService
     FindMode CurrentFindMode { get; set; }
 
     /// <summary>
-    /// Which columns the next find/replace covers. Only the replace window narrows it, and it sets
-    /// it again on every action, so the scope lives for one replace window session: finding always
-    /// covers both columns and resets this on the way in - the find window, and the find next /
-    /// find previous shortcuts, which reach the service without opening a window. A find that
-    /// silently skipped a column would have nothing on screen to say so.
+    /// Which columns the next find/replace covers. Sticky, so a find-next after the replace window
+    /// set it keeps the same scope; the find window resets it to <see cref="FindScope.TextAndOriginal"/>.
     /// </summary>
     FindScope CurrentScope { get; set; }
 

--- a/tests/UI/Features/Main/MainReadOnlyOriginalTests.cs
+++ b/tests/UI/Features/Main/MainReadOnlyOriginalTests.cs
@@ -628,50 +628,6 @@ public class MainReadOnlyOriginalTests
     }
 
     /// <summary>
-    /// The replace window can narrow the scope to one column, and it leaves that on the shared find
-    /// service. The find window clears it on the way in, but the find next / find previous shortcuts
-    /// reach the service without opening a window - so they used to inherit it, and after a
-    /// "replace in original only" every F3 quietly stopped searching the translation column, with
-    /// nothing on screen to say why.
-    /// </summary>
-    [AvaloniaTheory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void FindNextAndPrevious_ClearAScopeTheReplaceWindowLeftBehind(bool forward)
-    {
-        var (window, vm) = CreateMainViewModel();
-        try
-        {
-            AddLine(vm, "alpha one", "reference one", 0, 2000);
-            AddLine(vm, "alpha two", "reference two", 2000, 4000);
-            vm.ShowColumnOriginalText = true;
-            vm.SelectedSubtitle = vm.Subtitles[forward ? 0 : 1];
-            Dispatcher.UIThread.RunJobs();
-
-            var findService = (IFindService)GetField("_findService").GetValue(vm)!;
-            findService.SearchText = "alpha";
-            findService.CurrentScope = FindService.FindScope.OriginalOnly;
-
-            if (forward)
-            {
-                vm.FindNextCommand.Execute(null);
-            }
-            else
-            {
-                vm.FindPreviousCommand.Execute(null);
-            }
-
-            Dispatcher.UIThread.RunJobs();
-
-            Assert.Equal(FindService.FindScope.TextAndOriginal, findService.CurrentScope);
-        }
-        finally
-        {
-            CloseWindow(window, vm);
-        }
-    }
-
-    /// <summary>
     /// Working subtitle: two translated lines with a gap. Reference: the same two plus a line in the
     /// gap that the translation never got - the case from issue #13449.
     /// </summary>


### PR DESCRIPTION
Reverts the second commit of #13547 at the maintainer's request.

That commit made the find next / find previous **shortcuts** reset `IFindService.CurrentScope` to `TextAndOriginal`, on the reasoning that a bare F3 with no on-screen indication of a narrowed scope is a trap. The documented contract says the opposite — *"sticky, so a find-next after the replace window set it keeps the same scope"* — and stickiness is the intended behaviour, so the doc stands and the change goes.

After this, `CurrentScope` is cleared only where it was before: the find window, closing the original, and loading a new file. A scope picked in the replace window carries into a subsequent F3, which is the point.

The other commit in #13547 — `ImportOriginalHelper` no longer handing the same original line to two working rows — is untouched and stays on main.

**Tests:** 4045 pass. The theory this commit added (`FindNextAndPrevious_ClearAScopeTheReplaceWindowLeftBehind`) is removed along with it; the rest of `MainReadOnlyOriginalTests`, including `CloseOriginal_ResetsAnOriginalOnlyFindScope`, is unchanged and still passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
