### PR TITLE
Show the engine description in Video OCR

### DIFF
--- a/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
@@ -39,6 +39,7 @@ public partial class VideoOcrViewModel : ObservableObject
     [ObservableProperty] private bool _isGlmEngine;
     [ObservableProperty] private bool _isLlamaCppEngine;
     [ObservableProperty] private bool _isCrispEmbedEngine;
+    [ObservableProperty] private string _selectedEngineDescription;
     [ObservableProperty] private ObservableCollection<OcrLanguage2> _paddleLanguages;
     [ObservableProperty] private OcrLanguage2? _selectedPaddleLanguage;
     [ObservableProperty] private string _ollamaUrl;
@@ -121,6 +122,10 @@ public partial class VideoOcrViewModel : ObservableObject
         ProgressText = string.Empty;
         PreviewPositionText = string.Empty;
         ScanAreaText = string.Empty;
+
+        // LoadSettings re-selects the saved engine below, which fills this in via
+        // OnSelectedEngineChanged - this is only the non-nullable seed.
+        SelectedEngineDescription = string.Empty;
 
         // One-shot debounce for preview loading: restarted on every slider change.
         _previewTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(300) };
@@ -212,6 +217,7 @@ public partial class VideoOcrViewModel : ObservableObject
         IsGlmEngine = value.EngineType == OcrEngineType.Glm;
         IsLlamaCppEngine = value.EngineType == OcrEngineType.LlamaCpp;
         IsCrispEmbedEngine = value.EngineType == OcrEngineType.CrispEmbed;
+        SelectedEngineDescription = value.Description;
 
         if (IsLlamaCppEngine && LlamaCppModels.Count == 0)
         {

--- a/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
@@ -203,6 +203,17 @@ public class VideoOcrWindow : Window
         panel.Children.Add(MakeHeader(Se.Language.Video.VideoOcr.Engine, isFirst: true));
         panel.Children.Add(comboEngine);
 
+        // What the selected engine actually is - each engine carries a one-line description
+        // (local vs cloud, what it needs installed) that had no home in the window until now.
+        var engineDescription = new TextBlock
+        {
+            Opacity = 0.7,
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Thickness(0, 2, 0, 4),
+        };
+        engineDescription.Bind(TextBlock.TextProperty, new Binding(nameof(vm.SelectedEngineDescription)) { Source = vm });
+        panel.Children.Add(engineDescription);
+
         // Paddle OCR settings
         var paddlePanel = new StackPanel { Orientation = Orientation.Vertical, Spacing = 4 };
         paddlePanel.Children.Add(UiUtil.MakeLabel(Se.Language.General.Language));

--- a/tests/UI/Features/Video/VideoOcr/VideoOcrViewModelEngineDescriptionTests.cs
+++ b/tests/UI/Features/Video/VideoOcr/VideoOcrViewModelEngineDescriptionTests.cs
@@ -1,0 +1,51 @@
+using Avalonia.Headless.XUnit;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Features.Video.VideoOcr;
+using System.Linq;
+
+namespace UITests.Features.Video.VideoOcr;
+
+/// <summary>
+/// The engine description line under the Video OCR engine combo. Every engine carries a
+/// one-line description; these guard that it is actually populated and that it follows the
+/// selection, since the property was dead plumbing before it had a home in the window.
+/// </summary>
+public class VideoOcrViewModelEngineDescriptionTests
+{
+    [AvaloniaFact]
+    public void EveryEngine_HasADescription()
+    {
+        Assert.All(VideoOcrEngineItem.GetEngines(),
+            engine => Assert.False(string.IsNullOrWhiteSpace(engine.Description)));
+    }
+
+    [AvaloniaFact]
+    public void Description_FollowsTheSelectedEngine()
+    {
+        var viewModel = MakeViewModel();
+
+        foreach (var engine in viewModel.Engines)
+        {
+            viewModel.SelectedEngine = engine;
+            Assert.Equal(engine.Description, viewModel.SelectedEngineDescription);
+        }
+    }
+
+    [AvaloniaFact]
+    public void Description_IsSetForTheInitialSelection()
+    {
+        var viewModel = MakeViewModel();
+
+        Assert.False(string.IsNullOrWhiteSpace(viewModel.SelectedEngineDescription));
+        Assert.Equal(viewModel.SelectedEngine.Description, viewModel.SelectedEngineDescription);
+    }
+
+    private static VideoOcrViewModel MakeViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        using var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<VideoOcrViewModel>();
+    }
+}


### PR DESCRIPTION
Every Video OCR engine already carried a one-line description saying what it is — local or cloud, and what it needs installed — but `VideoOcrEngineItem.Description` was never rendered anywhere. The engine combo showed only a name, so nothing told the user that "Paddle OCR Python" wants a `pip install`, or that "GLM API" is a cloud service needing an API key.

This binds it to a wrapping line under the engine combo, in the same muted style (`Opacity = 0.7`) the window already uses for the scan-area text. No new strings — the descriptions were already written.

Lines shown:

| engine | description |
|---|---|
| Paddle OCR Standalone | Local OCR engine (downloaded automatically) - fast and accurate |
| Paddle OCR Python | Local OCR engine via Python (requires "pip install paddleocr") |
| Ollama vision | Local vision model via Ollama - e.g. glm-ocr |
| llama.cpp | Local vision model via llama.cpp (downloaded automatically) |
| CrispEmbed | Local OCR engine with multiple model backends (downloaded automatically) |
| GLM API | GLM vision model via Z.ai / bigmodel.cn API (requires API key) |

### Notes

- **Stacked on #13553** (base is `feat/video-ocr-crispembed`), because both change `VideoOcrWindow.cs` and `VideoOcrViewModel.cs` and the CrispEmbed row is one of the descriptions shown. Retarget to `main` once that merges.
- The same dead `Description` property exists on `OcrEngineItem` in the OCR window. Left alone here — that window's layout is busier and deserves its own change.
- Full UI suite green (2535), including 3 new tests: every engine has a description, the line follows the selection, and it is populated for the initial selection.
- Layout not visually confirmed — I don't launch the GUI. Worth a glance at the panel width (350) with the longest string, the Paddle Python one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
