### PR TITLE
Add select all/none/invert to the Multiple replace preview

### DIFF
--- a/docs/features/edit.md
+++ b/docs/features/edit.md
@@ -81,6 +81,20 @@ The window is split into two resizable panels:
 | **Left — Rules** | Tree of categories and their rules. Each rule shows its type icon, find pattern, replacement, and an optional description. |
 | **Right — Fixes** | Preview of all lines that will be changed. The **Before** column highlights removed characters in red and the **After** column highlights added characters in green. Selecting a row reveals an **Applied rules** detail panel at the bottom listing every rule that matched that line. |
 
+### Choosing which fixes to apply
+
+Every line in the preview starts ticked in the **Apply** column, and only ticked lines are changed by **OK** or **Apply**. Untick a line to leave it as it is.
+
+Right-click the preview to tick or untick many rows at once:
+
+- **Select all** (`Ctrl+A`) — tick every row
+- **Select none** (`Ctrl+D`) — untick every row, so single rows can be picked
+- **Invert selection** (`Ctrl+Shift+I`) — tick the unticked rows and untick the ticked ones
+
+`Space` toggles the checkbox of the rows that are highlighted, so a range selected with Shift+click can be flipped in one go. These gestures work while the preview has focus; the rules tree keeps its own shortcuts below.
+
+Editing a rule regenerates the preview, which ticks every row again.
+
 ### Rule types
 
 Each rule has one of three match types, shown as an icon in the tree:
@@ -132,6 +146,8 @@ Double-clicking a rule also opens the **Edit rule** dialog.
 | `F1` | Open help |
 
 The expand/collapse buttons (`+` / `−`) above the tree expand or collapse all categories at once (`Ctrl+Shift++` / `Ctrl+Shift+-`).
+
+> **Note:** `Ctrl+D` duplicates the selected rule, except while the fixes preview has focus — there it unticks every row, as in the other preview lists (see [Choosing which fixes to apply](#choosing-which-fixes-to-apply)).
 
 ### Import / Export
 

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -133,7 +133,7 @@ wins over the menu activation.
 
 ## Fix Lists in Dialogs
 
-Dialogs that preview their changes in a list of checkboxes — [Remove text for hearing impaired](../features/remove-text-hi.md) — accept these in the list itself. They are fixed and not part of **Options** → **Shortcuts**.
+Dialogs that preview their changes in a list of checkboxes — [Remove text for hearing impaired](../features/remove-text-hi.md), [Multiple replace](../features/edit.md#choosing-which-fixes-to-apply) — accept these in the list itself. They are fixed and not part of **Options** → **Shortcuts**.
 
 | Shortcut | Action |
 |----------|--------|
@@ -142,4 +142,4 @@ Dialogs that preview their changes in a list of checkboxes — [Remove text for 
 | Ctrl+Shift+I | Invert selection |
 | Space | Toggle the checkbox of the highlighted rows |
 
-The same three actions sit in the list's right-click menu. Other tools with such a list (Fix common errors, Merge continuation lines, Remove unicode characters, Fix Netflix errors, AI review) put buttons below the list for the same job.
+The same three actions sit in the list's right-click menu. In Multiple replace they apply to the fixes preview on the right; the rules tree on the left keeps its own `Ctrl+D` (duplicate rule). Other tools with such a list (Fix common errors, Merge continuation lines, Remove unicode characters, Fix Netflix errors, AI review) put buttons below the list for the same job.

--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceFix.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceFix.cs
@@ -1,11 +1,14 @@
-﻿using Nikse.SubtitleEdit.Core.Common;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using Nikse.SubtitleEdit.Core.Common;
 using System.Collections.Generic;
 
 namespace Nikse.SubtitleEdit.Features.Edit.MultipleReplace;
 
-public class MultipleReplaceFix
+public partial class MultipleReplaceFix : ObservableObject
 {
-    public bool Apply { get; set; }
+    // Observable because tick all / untick all / invert set it from the view model (#13502);
+    // a plain property leaves the checkboxes showing the old state.
+    [ObservableProperty] private bool _apply;
     public int Number { get; set; }
     public string Before { get; set; }
     public string After { get; set; }

--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
@@ -323,6 +323,69 @@ public partial class MultipleReplaceViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private void SelectAllFixes()
+    {
+        foreach (var fix in Fixes)
+        {
+            fix.Apply = true;
+        }
+    }
+
+    [RelayCommand]
+    private void SelectNoFixes()
+    {
+        foreach (var fix in Fixes)
+        {
+            fix.Apply = false;
+        }
+    }
+
+    [RelayCommand]
+    private void InvertFixesSelection()
+    {
+        foreach (var fix in Fixes)
+        {
+            fix.Apply = !fix.Apply;
+        }
+    }
+
+    /// <summary>
+    /// The gestures advertised by the fixes grid context menu (#13502): tick all, untick all and
+    /// invert the "Apply" column, the same set Remove text for hearing impaired and the rule
+    /// category picker use. Called from a tunneling handler on the grid, which has to run before
+    /// the TableView turns Ctrl+A into "select all rows" - and before the window's own key
+    /// handler, where Ctrl+D means "duplicate rule".
+    /// </summary>
+    internal bool HandleFixesSelectionKey(KeyEventArgs e)
+    {
+        var isCommand = e.KeyModifiers.HasFlag(KeyModifiers.Control) || e.KeyModifiers.HasFlag(KeyModifiers.Meta);
+        if (!isCommand || e.KeyModifiers.HasFlag(KeyModifiers.Alt))
+        {
+            return false;
+        }
+
+        var isShift = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
+        if (e.Key == Key.A && !isShift)
+        {
+            SelectAllFixes();
+        }
+        else if (e.Key == Key.D && !isShift)
+        {
+            SelectNoFixes();
+        }
+        else if (e.Key == Key.I && isShift)
+        {
+            InvertFixesSelection();
+        }
+        else
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    [RelayCommand]
     private void Cancel()
     {
         Window?.Close();

--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceWindow.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceWindow.cs
@@ -409,7 +409,9 @@ public class MultipleReplaceWindow : Window
         // No header sorting (the DataGrid's CanUserSortColumns is not carried over):
         // this is a fix preview in subtitle order, and the replace rules themselves run
         // in list order - reordering the backing collection would scramble the preview.
-        var dataGrid = TableViewExtras.MakeTableView(multiSelect: false);
+        // Multi-select so a range picked with Shift+click can have its "Apply" checkbox flipped
+        // in one go with Space (#13502); the fix detail panel below still follows SelectedItem.
+        var dataGrid = TableViewExtras.MakeTableView();
         dataGrid.DataContext = vm;
         dataGrid.ItemsSource = vm.Fixes;
         dataGrid.Columns.AddRange(new TableViewColumn[]
@@ -477,6 +479,21 @@ public class MultipleReplaceWindow : Window
             },
         });
         dataGrid.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedFix)) { Source = vm });
+
+        TableViewExtras.AddSpaceToggle<MultipleReplaceFix>(dataGrid,
+            item => item.Apply, (item, v) => item.Apply = v);
+
+        dataGrid.ContextMenu = MakeFixesContextMenu(vm);
+
+        // Tunneling: the TableView (a ListBox) would otherwise take Ctrl+A as "select all rows",
+        // and the window's key handler takes Ctrl+D as "duplicate rule" (#13502).
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (vm.HandleFixesSelectionKey(e))
+            {
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
 
         var hitsItemsControl = new ItemsControl
         {
@@ -614,5 +631,40 @@ public class MultipleReplaceWindow : Window
         };
 
         return border;
+    }
+
+    // A preview with one row per changed line is far too long to untick by hand, so offer
+    // tick all / untick all / invert with the gestures the sibling lists advertise (#13502).
+    private static ContextMenu MakeFixesContextMenu(MultipleReplaceViewModel vm)
+    {
+        var commandModifier = System.OperatingSystem.IsMacOS() ? KeyModifiers.Meta : KeyModifiers.Control;
+
+        return new ContextMenu
+        {
+            Items =
+            {
+                new Avalonia.Controls.MenuItem
+                {
+                    Header = Se.Language.General.SelectAll,
+                    DataContext = vm,
+                    Command = vm.SelectAllFixesCommand,
+                    InputGesture = new KeyGesture(Key.A, commandModifier),
+                },
+                new Avalonia.Controls.MenuItem
+                {
+                    Header = Se.Language.General.SelectNone,
+                    DataContext = vm,
+                    Command = vm.SelectNoFixesCommand,
+                    InputGesture = new KeyGesture(Key.D, commandModifier),
+                },
+                new Avalonia.Controls.MenuItem
+                {
+                    Header = Se.Language.General.InvertSelection,
+                    DataContext = vm,
+                    Command = vm.InvertFixesSelectionCommand,
+                    InputGesture = new KeyGesture(Key.I, commandModifier | KeyModifiers.Shift),
+                },
+            },
+        };
     }
 }

--- a/tests/UI/Features/Edit/MultipleReplaceSelectFixesTests.cs
+++ b/tests/UI/Features/Edit/MultipleReplaceSelectFixesTests.cs
@@ -1,0 +1,210 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Edit.MultipleReplace;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Linq;
+using System.Threading;
+
+namespace UITests.Features.Edit;
+
+/// <summary>
+/// The Multiple replace preview ticks every fix it finds, so keeping a handful of lines out of a
+/// long list meant unticking the rest by hand (#13502). Tick all / untick all / invert are the
+/// same three commands the sibling lists offer.
+/// </summary>
+public class MultipleReplaceSelectFixesTests
+{
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static MultipleReplaceViewModel NewViewModel()
+    {
+        var vm = new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        vm.Nodes.Clear();
+        return vm;
+    }
+
+    // Three lines that all match one rule, so the preview holds three fixes.
+    private static MultipleReplaceViewModel WithThreeFixes()
+    {
+        var vm = NewViewModel();
+        var category = new RuleTreeNode(true) { CategoryName = "c1", IsActive = true };
+        vm.Nodes.Add(category);
+        category.SubNodes!.Add(new RuleTreeNode(false)
+        {
+            Find = "colour",
+            ReplaceWith = "color",
+            IsActive = true,
+            Parent = category,
+            Type = MultipleReplaceType.CaseInsensitive,
+        });
+
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("The colour is red.", 0, 2000));
+        subtitle.Paragraphs.Add(new Paragraph("The colour is green.", 2000, 4000));
+        subtitle.Paragraphs.Add(new Paragraph("The colour is blue.", 4000, 6000));
+        vm.Initialize(subtitle);
+
+        WaitForPreview(vm, 3);
+        Assert.Equal(3, vm.Fixes.Count);
+        return vm;
+    }
+
+    // The preview is generated on a background timer, so waiting is the only way to observe it.
+    private static void WaitForPreview(MultipleReplaceViewModel vm, int expectedFixes)
+    {
+        var end = Environment.TickCount64 + 3000;
+        while (Environment.TickCount64 < end)
+        {
+            Dispatcher.UIThread.RunJobs();
+            if (vm.Fixes.Count == expectedFixes)
+            {
+                Dispatcher.UIThread.RunJobs();
+                return;
+            }
+
+            Thread.Sleep(20);
+        }
+
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static string Ticked(MultipleReplaceViewModel vm) =>
+        string.Join(",", vm.Fixes.Where(f => f.Apply).Select(f => f.Number));
+
+    private static bool SendKey(MultipleReplaceViewModel vm, Key key, KeyModifiers modifiers)
+    {
+        var e = new KeyEventArgs { Key = key, KeyModifiers = modifiers, RoutedEvent = InputElement.KeyDownEvent };
+        return vm.HandleFixesSelectionKey(e);
+    }
+
+    [AvaloniaFact]
+    public void SelectNoFixes_UnticksEveryFix()
+    {
+        var vm = WithThreeFixes();
+
+        vm.SelectNoFixesCommand.Execute(null);
+
+        Assert.Equal(string.Empty, Ticked(vm));
+    }
+
+    [AvaloniaFact]
+    public void SelectAllFixes_TicksEveryFix()
+    {
+        var vm = WithThreeFixes();
+        vm.SelectNoFixesCommand.Execute(null);
+
+        vm.SelectAllFixesCommand.Execute(null);
+
+        Assert.Equal("1,2,3", Ticked(vm));
+    }
+
+    [AvaloniaFact]
+    public void InvertFixesSelection_FlipsEveryFix()
+    {
+        var vm = WithThreeFixes();
+        vm.Fixes[1].Apply = false;
+
+        vm.InvertFixesSelectionCommand.Execute(null);
+
+        Assert.Equal("2", Ticked(vm));
+    }
+
+    // The checkboxes are bound to Apply, so they only follow the commands if the fix raises
+    // property changed - it was a plain property until #13502.
+    [AvaloniaFact]
+    public void Fix_RaisesPropertyChangedForApply()
+    {
+        var fix = new MultipleReplaceFix();
+        var raised = 0;
+        fix.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(MultipleReplaceFix.Apply))
+            {
+                raised++;
+            }
+        };
+
+        fix.Apply = false;
+
+        Assert.Equal(1, raised);
+    }
+
+    [AvaloniaTheory]
+    [InlineData(Key.A, KeyModifiers.Control, "1,2,3")]
+    [InlineData(Key.A, KeyModifiers.Meta, "1,2,3")]
+    [InlineData(Key.D, KeyModifiers.Control, "")]
+    [InlineData(Key.D, KeyModifiers.Meta, "")]
+    [InlineData(Key.I, KeyModifiers.Control | KeyModifiers.Shift, "1,3")]
+    [InlineData(Key.I, KeyModifiers.Meta | KeyModifiers.Shift, "1,3")]
+    public void AdvertisedGestures_TickUntickAndInvert(Key key, KeyModifiers modifiers, string expected)
+    {
+        var vm = WithThreeFixes();
+        vm.Fixes[0].Apply = false;
+        vm.Fixes[2].Apply = false;
+
+        Assert.True(SendKey(vm, key, modifiers));
+
+        Assert.Equal(expected, Ticked(vm));
+    }
+
+    // Ctrl+D is "duplicate rule" in this window and Ctrl+A is "select all rows" in the grid, so
+    // everything the fixes grid does not claim has to travel on untouched.
+    [AvaloniaTheory]
+    [InlineData(Key.A, KeyModifiers.None)]
+    [InlineData(Key.A, KeyModifiers.Shift)]
+    [InlineData(Key.A, KeyModifiers.Control | KeyModifiers.Alt)]
+    [InlineData(Key.D, KeyModifiers.Control | KeyModifiers.Shift)]
+    [InlineData(Key.I, KeyModifiers.Control)]
+    [InlineData(Key.N, KeyModifiers.Control)]
+    public void OtherGestures_AreLeftAlone(Key key, KeyModifiers modifiers)
+    {
+        var vm = WithThreeFixes();
+        vm.Fixes[1].Apply = false;
+
+        Assert.False(SendKey(vm, key, modifiers));
+
+        Assert.Equal("1,3", Ticked(vm));
+    }
+
+    // "Untick everything, then OK" has to leave the subtitle alone. OK regenerates the preview
+    // before reverting the unticked lines, and only survives that because the regenerated list
+    // reaches Fixes through the dispatcher - so assert on the result, not on the commands.
+    [AvaloniaFact]
+    public void Ok_AfterSelectNone_LeavesEveryLineUnchanged()
+    {
+        var vm = WithThreeFixes();
+
+        vm.SelectNoFixesCommand.Execute(null);
+        vm.OkCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(vm.OkPressed);
+        Assert.Equal("The colour is red.", vm.FixedSubtitle.Paragraphs[0].Text);
+        Assert.Equal("The colour is green.", vm.FixedSubtitle.Paragraphs[1].Text);
+        Assert.Equal("The colour is blue.", vm.FixedSubtitle.Paragraphs[2].Text);
+    }
+
+    [AvaloniaFact]
+    public void Ok_AfterInvert_KeepsOnlyTheTickedLines()
+    {
+        var vm = WithThreeFixes();
+
+        vm.SelectNoFixesCommand.Execute(null);
+        vm.Fixes[1].Apply = true;
+        vm.InvertFixesSelectionCommand.Execute(null);
+        vm.OkCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("The color is red.", vm.FixedSubtitle.Paragraphs[0].Text);
+        Assert.Equal("The colour is green.", vm.FixedSubtitle.Paragraphs[1].Text);
+        Assert.Equal("The color is blue.", vm.FixedSubtitle.Paragraphs[2].Text);
+    }
+}

--- a/tests/UI/Features/Edit/MultipleReplaceWindowShortcutTests.cs
+++ b/tests/UI/Features/Edit/MultipleReplaceWindowShortcutTests.cs
@@ -1,0 +1,205 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Edit.MultipleReplace;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Linq;
+using System.Threading;
+
+namespace UITests.Features.Edit;
+
+/// <summary>
+/// The fixes grid offers tick all / untick all / invert via context menu and gestures (#13502).
+/// With the grid focused those have to beat the TableView's own Ctrl+A ("select all rows") and
+/// the window's Ctrl+D ("duplicate rule"), which is why the grid takes them while tunneling.
+/// </summary>
+public class MultipleReplaceWindowShortcutTests
+{
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static (MultipleReplaceViewModel Vm, Window Window, RuleTreeNode Category) OpenWithThreeFixes()
+    {
+        var vm = new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        vm.Nodes.Clear();
+
+        var category = new RuleTreeNode(true) { CategoryName = "c1", IsActive = true };
+        vm.Nodes.Add(category);
+        category.SubNodes!.Add(new RuleTreeNode(false)
+        {
+            Find = "colour",
+            ReplaceWith = "color",
+            IsActive = true,
+            Parent = category,
+            Type = MultipleReplaceType.CaseInsensitive,
+        });
+
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("The colour is red.", 0, 2000));
+        subtitle.Paragraphs.Add(new Paragraph("The colour is green.", 2000, 4000));
+        subtitle.Paragraphs.Add(new Paragraph("The colour is blue.", 4000, 6000));
+        vm.Initialize(subtitle);
+
+        var window = new MultipleReplaceWindow(vm);
+        window.Show();
+        WaitForPreview(vm, 3);
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(3, vm.Fixes.Count);
+        return (vm, window, category);
+    }
+
+    private static void WaitForPreview(MultipleReplaceViewModel vm, int expectedFixes)
+    {
+        var end = Environment.TickCount64 + 3000;
+        while (Environment.TickCount64 < end)
+        {
+            Dispatcher.UIThread.RunJobs();
+            if (vm.Fixes.Count == expectedFixes)
+            {
+                Dispatcher.UIThread.RunJobs();
+                return;
+            }
+
+            Thread.Sleep(20);
+        }
+
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    // The rules panel is a TreeView, so the fixes grid is the only TableView in the window.
+    private static TableView FixesGrid(Window window)
+    {
+        return window.GetVisualDescendants().OfType<TableView>().First();
+    }
+
+    private static Point CenterOf(Visual container, Window window)
+    {
+        var bounds = container.Bounds;
+        return container.TranslatePoint(new Point(bounds.Width / 2, bounds.Height / 2), window)!.Value;
+    }
+
+    // Clicking a row is the only way to get real keyboard focus into the grid - TableView.Focus()
+    // does not move it (the row containers take focus, not the control).
+    private static TableView ClickRow(Window window, MultipleReplaceViewModel vm, int index, RawInputModifiers modifiers = RawInputModifiers.None)
+    {
+        var grid = FixesGrid(window);
+        var container = (Visual?)grid.ContainerFromItem(vm.Fixes[index]);
+        Assert.NotNull(container);
+
+        var point = CenterOf(container!, window);
+        window.MouseDown(point, MouseButton.Left, modifiers);
+        window.MouseUp(point, MouseButton.Left, modifiers);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(grid.IsKeyboardFocusWithin, "the gestures have to work with the grid focused");
+        return grid;
+    }
+
+    private static string Ticked(MultipleReplaceViewModel vm) =>
+        string.Join(",", vm.Fixes.Where(f => f.Apply).Select(f => f.Number));
+
+    [AvaloniaFact]
+    public void GridCtrlD_UnticksEveryFix_InsteadOfDuplicatingTheRule()
+    {
+        var (vm, window, category) = OpenWithThreeFixes();
+        ClickRow(window, vm, 0);
+
+        window.KeyPressQwerty(PhysicalKey.D, RawInputModifiers.Control);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(string.Empty, Ticked(vm));
+        // ...and the window's own Ctrl+D never saw it.
+        Assert.Single(category.SubNodes!);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void GridCtrlA_TicksEveryFix_InsteadOfSelectingAllRows()
+    {
+        var (vm, window, _) = OpenWithThreeFixes();
+        foreach (var fix in vm.Fixes)
+        {
+            fix.Apply = false;
+        }
+
+        var grid = ClickRow(window, vm, 0);
+
+        window.KeyPressQwerty(PhysicalKey.A, RawInputModifiers.Control);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("1,2,3", Ticked(vm));
+        // ...and the TableView did not turn it into "select all rows" on top of that.
+        Assert.Equal(1, grid.SelectedItems?.Count ?? 0);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void GridCtrlShiftI_InvertsEveryFix()
+    {
+        var (vm, window, _) = OpenWithThreeFixes();
+        vm.Fixes[1].Apply = false;
+
+        ClickRow(window, vm, 0);
+
+        window.KeyPressQwerty(PhysicalKey.I, RawInputModifiers.Control | RawInputModifiers.Shift);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("2", Ticked(vm));
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void FixesGrid_HasSelectAllSelectNoneAndInvertInItsContextMenu()
+    {
+        var (_, window, _) = OpenWithThreeFixes();
+
+        var headers = FixesGrid(window).ContextMenu?.Items.OfType<MenuItem>().Select(m => m.Header as string).ToList();
+
+        Assert.NotNull(headers);
+        Assert.Equal(3, headers!.Count);
+        Assert.Contains(Se.Language.General.SelectAll, headers);
+        Assert.Contains(Se.Language.General.SelectNone, headers);
+        Assert.Contains(Se.Language.General.InvertSelection, headers);
+
+        window.Close();
+    }
+
+    // A range picked with Shift+click is flipped in one go - the reason the grid went
+    // multi-select in #13502.
+    [AvaloniaFact]
+    public void Space_TogglesTheHighlightedRange()
+    {
+        var (vm, window, _) = OpenWithThreeFixes();
+
+        ClickRow(window, vm, 0);
+        var grid = ClickRow(window, vm, 1, RawInputModifiers.Shift);
+        Assert.Equal(2, grid.SelectedItems?.Count ?? 0);
+
+        window.KeyPressQwerty(PhysicalKey.Space, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("3", Ticked(vm));
+
+        window.KeyPressQwerty(PhysicalKey.Space, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("1,2,3", Ticked(vm));
+
+        window.Close();
+    }
+}


### PR DESCRIPTION
Fixes #13502 - follow-up to #13496/#13499, which added the same three actions to the *Remove text for hearing impaired* preview.

The Multiple replace fixes preview ticks every line it finds, and the only way to keep a few lines out was to untick the rest one checkbox at a time.

## What changed

Right-clicking the fixes grid now offers the set the sibling lists advertise:

| Gesture | Action |
|---|---|
| `Ctrl/Cmd+A` | Select all - tick every row |
| `Ctrl/Cmd+D` | Select none - untick every row |
| `Ctrl/Cmd+Shift+I` | Invert selection |
| `Space` | Toggle the checkbox of the highlighted rows |

The grid also went multi-select, so a range picked with Shift+click can be flipped in one go with `Space`. The **Applied rules** detail panel still follows the focused row.

## Notes

- The gestures are taken in the grid's **tunneling** phase for two reasons: the `TableView` would otherwise consume `Ctrl+A` as "select all rows", and this window's own key handler takes `Ctrl+D` as "duplicate rule". With the preview focused the grid claims those two and marks them handled, so no rule gets duplicated; everything else (`Ctrl+N`, `Ctrl+F`, plain `Ctrl+I`, ...) travels on untouched, and `Ctrl+A` in the Find / Replace-with boxes still selects text.
- `MultipleReplaceFix.Apply` had to become an `[ObservableProperty]`: the checkboxes bind to it, so setting it from a command left them showing the old state.

## Tests

Two new files, 23 tests:

- `MultipleReplaceSelectFixesTests` - the three commands, the full gesture matrix (including that nothing else is claimed), that `Apply` now raises property changed, and that "select none, then OK" leaves every line unchanged while "invert" keeps exactly the ticked ones.
- `MultipleReplaceWindowShortcutTests` - the same gestures with the grid really focused (click a row, then key press): `Ctrl+D` unticks instead of duplicating the rule, `Ctrl+A` ticks instead of selecting all rows, `Ctrl+Shift+I` inverts, the context menu holds the three items, and `Space` flips a Shift+click range.

Full headless UI suite passes (2558 tests).

Docs: a new *Choosing which fixes to apply* section in `docs/features/edit.md`, plus Multiple replace added to the "Fix Lists in Dialogs" table in `docs/reference/keyboard-shortcuts.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)