### PR TITLE
Vectorize StringExtensions.RemoveChar

### DIFF
--- a/src/libse/Common/StringExtensions.cs
+++ b/src/libse/Common/StringExtensions.cs
@@ -783,53 +783,180 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public static string RemoveChar(this string value, char charToRemove)
         {
-            char[] array = new char[value.Length];
-            int arrayIndex = 0;
-            for (int i = 0; i < value.Length; i++)
+#if NET10_0_OR_GREATER
+            var count = value.AsSpan().Count(charToRemove);
+#else
+            var count = 0;
+            for (var i = 0; i < value.Length; i++)
             {
-                char ch = value[i];
-                if (ch != charToRemove)
+                if (value[i] == charToRemove)
                 {
-                    array[arrayIndex++] = ch;
+                    count++;
                 }
             }
+#endif
+            if (count == 0)
+            {
+                return value;
+            }
 
-            return new string(array, 0, arrayIndex);
+            return string.Create(value.Length - count, (value, charToRemove), (chars, state) =>
+            {
+                var index = 0;
+                foreach (var ch in state.value)
+                {
+                    if (ch != state.charToRemove)
+                    {
+                        chars[index++] = ch;
+                    }
+                }
+            });
         }
 
         public static string RemoveChar(this string value, char charToRemove, char charToRemove2)
         {
-            char[] array = new char[value.Length];
-            int arrayIndex = 0;
-            for (int i = 0; i < value.Length; i++)
+            if (charToRemove == charToRemove2)
             {
-                char ch = value[i];
-                if (ch != charToRemove && ch != charToRemove2)
-                {
-                    array[arrayIndex++] = ch;
-                }
+                return value.RemoveChar(charToRemove);
             }
 
-            return new string(array, 0, arrayIndex);
+#if NET10_0_OR_GREATER
+            var span = value.AsSpan();
+            var count = span.Count(charToRemove) + span.Count(charToRemove2);
+#else
+            var count = 0;
+            for (var i = 0; i < value.Length; i++)
+            {
+                var ch = value[i];
+                if (ch == charToRemove || ch == charToRemove2)
+                {
+                    count++;
+                }
+            }
+#endif
+            if (count == 0)
+            {
+                return value;
+            }
+
+            return string.Create(value.Length - count, (value, charToRemove, charToRemove2), (chars, state) =>
+            {
+                var index = 0;
+                foreach (var ch in state.value)
+                {
+                    if (ch != state.charToRemove && ch != state.charToRemove2)
+                    {
+                        chars[index++] = ch;
+                    }
+                }
+            });
         }
 
+#if NET10_0_OR_GREATER
+        private ref struct RemoveCharContext
+        {
+            public string Value;
+            public ReadOnlySpan<char> CharsToRemove;
+            public int First;
+        }
+
+        public static string RemoveChar(this string value, params ReadOnlySpan<char> charsToRemove)
+        {
+            // Callers pass a handful of literal chars (3-13). Matches are sparse in subtitle
+            // text, so hopping between them with vectorized IndexOfAny and block-copying the
+            // clean stretches beats testing every char against the removal set.
+            var span = value.AsSpan();
+            var first = span.IndexOfAny(charsToRemove);
+            if (first < 0)
+            {
+                return value;
+            }
+
+            var count = 1;
+            var rest = span.Slice(first + 1);
+            while (true)
+            {
+                var i = rest.IndexOfAny(charsToRemove);
+                if (i < 0)
+                {
+                    break;
+                }
+
+                count++;
+                rest = rest.Slice(i + 1);
+            }
+
+            var context = new RemoveCharContext { Value = value, CharsToRemove = charsToRemove, First = first };
+            return string.Create(value.Length - count, context, (chars, state) =>
+            {
+                var src = state.Value.AsSpan();
+                src.Slice(0, state.First).CopyTo(chars);
+                var written = state.First;
+                src = src.Slice(state.First + 1);
+                while (true)
+                {
+                    var i = src.IndexOfAny(state.CharsToRemove);
+                    if (i < 0)
+                    {
+                        src.CopyTo(chars.Slice(written));
+                        return;
+                    }
+
+                    src.Slice(0, i).CopyTo(chars.Slice(written));
+                    written += i;
+                    src = src.Slice(i + 1);
+                }
+            });
+        }
+#else
         public static string RemoveChar(this string value, params char[] charsToRemove)
         {
-            // Callers pass a handful of literal chars (3-13), so a vectorized linear probe
-            // beats allocating and hashing a HashSet per call.
-            char[] array = new char[value.Length];
-            int arrayIndex = 0;
-            for (int i = 0; i < value.Length; i++)
+            // Callers pass a handful of literal chars (3-13). Matches are sparse in subtitle
+            // text, so hopping between them with IndexOfAny and block-copying the clean
+            // stretches beats testing every char against the removal set.
+            var span = value.AsSpan();
+            var first = span.IndexOfAny(charsToRemove);
+            if (first < 0)
             {
-                char ch = value[i];
-                if (Array.IndexOf(charsToRemove, ch) < 0)
-                {
-                    array[arrayIndex++] = ch;
-                }
+                return value;
             }
 
-            return new string(array, 0, arrayIndex);
+            var count = 1;
+            var rest = span.Slice(first + 1);
+            while (true)
+            {
+                var i = rest.IndexOfAny(charsToRemove);
+                if (i < 0)
+                {
+                    break;
+                }
+
+                count++;
+                rest = rest.Slice(i + 1);
+            }
+
+            return string.Create(value.Length - count, (value, charsToRemove, first), (chars, state) =>
+            {
+                var src = state.value.AsSpan();
+                src.Slice(0, state.first).CopyTo(chars);
+                var written = state.first;
+                src = src.Slice(state.first + 1);
+                while (true)
+                {
+                    var i = src.IndexOfAny<char>(state.charsToRemove);
+                    if (i < 0)
+                    {
+                        src.CopyTo(chars.Slice(written));
+                        return;
+                    }
+
+                    src.Slice(0, i).CopyTo(chars.Slice(written));
+                    written += i;
+                    src = src.Slice(i + 1);
+                }
+            });
         }
+#endif
 
         /// <summary>
         /// Count characters excl. white spaces, ssa-tags, html-tags, control-characters, normal spaces and


### PR DESCRIPTION
## Summary

Builds on the direction of #13558 (thanks @ivandrofly for the `string.Create` + return-original-on-no-match idea) but replaces the scalar scanning with vectorized span operations, so match-present calls get faster too instead of slower:

- **1-char / 2-char overloads**: the counting pass uses vectorized `span.Count(char)` instead of a scalar loop; the write pass goes through `string.Create` directly into the final string's buffer. The 2-char overload delegates to the 1-char overload when both chars are equal (keeps the two `Count` calls from double-counting).
- **params overload**: matches for sets like `'.', '?', '!', '-', '—'` are sparse in subtitle text, so it hops match-to-match with vectorized `IndexOfAny` and block-copies the clean stretches — never testing characters one at a time. On net10 it takes `params ReadOnlySpan<char>` (literal args no longer allocate an array); netstandard2.1 keeps `params char[]` with the same segment-copy shape.
- All overloads return the original string when nothing matches (zero allocation).

## Microbenchmarks

BenchmarkDotNet, .NET 10, Apple Silicon. Same cases as #13558: "short" = 38-char subtitle line, "long" ≈ 200 chars, "no match" = removed chars do not occur.

| Overload | Case | main (char[]) | #13558 | This PR |
|---|---|---:|---:|---:|
| 1 char | short | 21.7 ns | 26.0 ns | **18.4 ns** |
| 1 char | long | 98.5 ns | 136.3 ns | **94.1 ns** |
| 1 char | no match | 23.1 ns | 10.0 ns | **1.8 ns** |
| 2 chars | short | 23.2 ns | 30.1 ns | **22.5 ns** |
| 2 chars | long | 102.6 ns | 198.8 ns | 110.8 ns |
| 2 chars | no match | 23.4 ns | 13.2 ns | **5.1 ns** |
| 4 chars | short | 50.8 ns | 82.5 ns | **14.5 ns** |
| 4 chars | long | 241.9 ns | 405.9 ns | **59.8 ns** |
| 4 chars | no match | 51.8 ns | 38.3 ns | **2.2 ns** |

Allocations match #13558: roughly halved when matches exist, zero when nothing matches.

## Real-subtitle replay

171,738 lines from 12 real subtitle files (English/Danish/Swedish/anime; .srt/.ass/.vtt), replaying the six RemoveChar call-site patterns actually used in the codebase (timecode `' '` stripping, the `'\r'`/`'\n'`/`' '` chain, `(' ', '\t')`, the mostly-no-match `('♪', '♫')` check, the 5-char interjection set, the 7-char Unicode-control set), 40 reps:

| Implementation | Time | Allocated |
|---|---:|---:|
| main | 1,146 ms | 5,292 MB |
| #13558 | 994 ms | 887 MB |
| This PR | **571 ms** | **887 MB** |

2.0× faster than main and 1.74× faster than #13558 on real data, with the same 6× allocation reduction.

## Correctness

- Byte-identical to the current implementation over 2M randomized inputs per overload, plus edge cases (empty string, everything removed, duplicate chars, zero args) and the full 171k-line real-subtitle corpus
- `dotnet build src/libse/LibSE.csproj` clean for netstandard2.1 and net10.0
- All 52 `StringExtensionsTest` tests pass (RemoveChar1–4 cover all three overloads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)