### PR TITLE
Keep Google Lens OCR going when a single image fails

### DIFF
--- a/src/ui/Features/Ocr/Engines/GoogleLensOcrSharp.cs
+++ b/src/ui/Features/Ocr/Engines/GoogleLensOcrSharp.cs
@@ -1,7 +1,9 @@
-﻿using Nikse.SubtitleEdit.Logic.Ocr.GoogleLens;
+﻿using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Ocr.GoogleLens;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,8 +11,23 @@ namespace Nikse.SubtitleEdit.Features.Ocr.Engines;
 
 public class GoogleLensOcrSharp
 {
+    /// <summary>
+    /// Number of tries per image before giving up on it and moving on to the next one.
+    /// </summary>
+    private const int MaxAttemptsPerImage = 3;
+
     private IProgress<PaddleOcrBatchProgress>? _batchProgress;
     private ILens _lens;
+
+    /// <summary>
+    /// Images that could not be read even after retrying - they were skipped, not OCR'ed.
+    /// </summary>
+    public int SkippedImageCount { get; private set; }
+
+    /// <summary>
+    /// How long to wait before the next try. Overridable so tests do not have to sleep.
+    /// </summary>
+    internal Func<Exception, int, TimeSpan> RetryDelay { get; set; } = GetRetryDelay;
 
     public GoogleLensOcrSharp(ILens lens)
     {
@@ -22,6 +39,7 @@ public class GoogleLensOcrSharp
     public async Task OcrBatch(List<PaddleOcrBatchInput> input, string language, IProgress<PaddleOcrBatchProgress> progress, CancellationToken cancellationToken)
     {
         _batchProgress = progress;
+        SkippedImageCount = 0;
 
         foreach (var bmpInput in input)
         {
@@ -35,7 +53,14 @@ public class GoogleLensOcrSharp
                 continue;
             }
 
-            var result = await _lens.ScanByBitmap(bmpInput.Bitmap, language);
+            var result = await ScanWithRetry(bmpInput, language, cancellationToken);
+            if (result == null)
+            {
+                // Google Lens is a public endpoint that will now and then time out or rate limit us.
+                // Letting that bubble up aborted the whole run and the user had to press "Start OCR"
+                // again (losing the unknown-words list), so skip just this image and keep going (#13563).
+                continue;
+            }
 
             var lines = OcrLoneDashFixer.FixLoneDashes(result.Segments.Select(x => x.Text).ToList());
 
@@ -67,6 +92,65 @@ public class GoogleLensOcrSharp
                 _batchProgress?.Report(progressReport);
             }
         }
+    }
+
+    /// <summary>
+    /// Scans one image, retrying transient failures. Returns null when the image has to be skipped.
+    /// </summary>
+    private async Task<LensResult?> ScanWithRetry(PaddleOcrBatchInput bmpInput, string language, CancellationToken cancellationToken)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                return await _lens.ScanByBitmap(bmpInput.Bitmap!, language);
+            }
+            catch (Exception exception)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return null;
+                }
+
+                if (attempt >= MaxAttemptsPerImage || !IsTransient(exception))
+                {
+                    SkippedImageCount++;
+                    Se.LogError(exception, $"Google Lens OCR gave up on image with index {bmpInput.Index} - skipping it");
+                    return null;
+                }
+
+                try
+                {
+                    await Task.Delay(RetryDelay(exception, attempt), cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    return null;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// True for failures that tend to fix themselves - trying the same image again may well work.
+    /// </summary>
+    private static bool IsTransient(Exception exception)
+    {
+        if (exception is LensError lensError)
+        {
+            // 408 request timeout, 429 too many requests, 5xx = something broke on Google's side.
+            return lensError.Code == 408 || lensError.Code == 429 || lensError.Code >= 500;
+        }
+
+        // Connection reset/dropped, or our own 30 second HttpClient timeout.
+        return exception is HttpRequestException || exception is TaskCanceledException || exception is TimeoutException;
+    }
+
+    private static TimeSpan GetRetryDelay(Exception exception, int attempt)
+    {
+        // Back off a lot harder when Google is rate limiting us, a second is plenty for the rest.
+        var seconds = exception is LensError { Code: 429 } ? 5 * attempt : attempt;
+        return TimeSpan.FromSeconds(seconds);
     }
 
     public static List<OcrLanguage2> GetLanguages()

--- a/tests/UI/Features/Ocr/Engines/GoogleLensOcrSharpRetryTests.cs
+++ b/tests/UI/Features/Ocr/Engines/GoogleLensOcrSharpRetryTests.cs
@@ -1,0 +1,168 @@
+using Nikse.SubtitleEdit.Features.Ocr;
+using Nikse.SubtitleEdit.Features.Ocr.Engines;
+using Nikse.SubtitleEdit.Logic.Ocr.GoogleLens;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace UITests.Features.Ocr.Engines;
+
+// Google Lens is a public endpoint that will time out or rate limit now and then. A single failed
+// image used to throw out of the batch loop, so OCR stopped mid-run and the user had to press
+// "Start OCR" again - losing the unknown-words list (#13563). Failures are now retried and, when
+// they persist, that one image is skipped so the rest of the subtitle still gets OCR'ed.
+public class GoogleLensOcrSharpRetryTests
+{
+    private sealed class FakeLens : ILens
+    {
+        private readonly Queue<Func<LensResult>> _responses;
+
+        public int CallCount { get; private set; }
+
+        public FakeLens(params Func<LensResult>[] responses)
+        {
+            _responses = new Queue<Func<LensResult>>(responses);
+        }
+
+        public Task<LensResult> ScanByBitmap(SKBitmap bitmap, string twoLetterLanguageCode)
+        {
+            CallCount++;
+            return Task.FromResult(_responses.Dequeue()());
+        }
+    }
+
+    // Progress<T> hands the callback to the thread pool, which would race the batch loop.
+    private sealed class SyncProgress : IProgress<PaddleOcrBatchProgress>
+    {
+        private readonly Action<PaddleOcrBatchProgress> _onReport;
+
+        public SyncProgress(Action<PaddleOcrBatchProgress>? onReport = null)
+        {
+            _onReport = onReport ?? (_ => { });
+        }
+
+        public void Report(PaddleOcrBatchProgress value) => _onReport(value);
+    }
+
+    private static Func<LensResult> Text(string text) =>
+        () => new LensResult("en", new List<Segment>
+        {
+            new(text, new BoundingBox(new double[] { 0.5, 0.5, 1, 1 }, new[] { 100, 20 })),
+        });
+
+    private static Func<LensResult> Throws(Exception exception) =>
+        () => throw exception;
+
+    private static List<PaddleOcrBatchInput> Images(int count) =>
+        Enumerable.Range(0, count)
+            .Select(i => new PaddleOcrBatchInput { Index = i, Bitmap = new SKBitmap(10, 10) })
+            .ToList();
+
+    private static GoogleLensOcrSharp CreateEngine(FakeLens lens) =>
+        new(lens) { RetryDelay = (_, _) => TimeSpan.Zero };
+
+    [Fact]
+    public async Task TransientFailure_IsRetriedAndSucceeds()
+    {
+        var lens = new FakeLens(
+            Throws(new LensError("Lens returned status code 429", 429)),
+            Text("HELLO THERE"));
+        var images = Images(1);
+
+        var engine = CreateEngine(lens);
+        await engine.OcrBatch(images, "en", new SyncProgress(), CancellationToken.None);
+
+        Assert.Equal(2, lens.CallCount);
+        Assert.Equal("HELLO THERE", images[0].Text);
+        Assert.Equal(0, engine.SkippedImageCount);
+    }
+
+    [Fact]
+    public async Task PersistentFailure_SkipsOnlyThatImage()
+    {
+        var lens = new FakeLens(
+            Text("FIRST LINE"),
+            Throws(new HttpRequestException("connection reset")),
+            Throws(new HttpRequestException("connection reset")),
+            Throws(new HttpRequestException("connection reset")),
+            Text("THIRD LINE"));
+        var images = Images(3);
+        var reported = new List<int>();
+
+        var engine = CreateEngine(lens);
+        await engine.OcrBatch(images, "en", new SyncProgress(p => reported.Add(p.Index)), CancellationToken.None);
+
+        // Three tries were spent on the middle image, then the batch carried on to the last one.
+        Assert.Equal(5, lens.CallCount);
+        Assert.Equal("FIRST LINE", images[0].Text);
+        Assert.Equal(string.Empty, images[1].Text);
+        Assert.Equal("THIRD LINE", images[2].Text);
+        Assert.Equal(1, engine.SkippedImageCount);
+        Assert.Equal(new List<int> { 0, 2 }, reported);
+    }
+
+    [Fact]
+    public async Task NonTransientFailure_IsNotRetriedButBatchContinues()
+    {
+        var lens = new FakeLens(
+            Throws(new LensError("Lens returned status code 400", 400)),
+            Text("SECOND LINE"));
+        var images = Images(2);
+
+        var engine = CreateEngine(lens);
+        await engine.OcrBatch(images, "en", new SyncProgress(), CancellationToken.None);
+
+        // A 400 will not go away by asking again, so only one try for the first image.
+        Assert.Equal(2, lens.CallCount);
+        Assert.Equal(string.Empty, images[0].Text);
+        Assert.Equal("SECOND LINE", images[1].Text);
+        Assert.Equal(1, engine.SkippedImageCount);
+    }
+
+    [Fact]
+    public async Task Cancellation_StopsTheBatch()
+    {
+        var cancellationTokenSource = new CancellationTokenSource();
+        var lens = new FakeLens(
+            Text("FIRST LINE"),
+            Text("NEVER REACHED"));
+        var images = Images(2);
+
+        var engine = CreateEngine(lens);
+        await engine.OcrBatch(
+            images,
+            "en",
+            new SyncProgress(_ => cancellationTokenSource.Cancel()),
+            cancellationTokenSource.Token);
+
+        Assert.Equal(1, lens.CallCount);
+        Assert.Equal("FIRST LINE", images[0].Text);
+        Assert.Equal(string.Empty, images[1].Text);
+    }
+
+    [Fact]
+    public async Task CancellationDuringRetry_DoesNotCountAsSkipped()
+    {
+        var cancellationTokenSource = new CancellationTokenSource();
+        var lens = new FakeLens(
+            Throws(new LensError("Lens returned status code 503", 503)),
+            Text("NEVER REACHED"));
+        var images = Images(1);
+
+        var engine = CreateEngine(lens);
+        engine.RetryDelay = (_, _) =>
+        {
+            cancellationTokenSource.Cancel();
+            return TimeSpan.Zero;
+        };
+
+        await engine.OcrBatch(images, "en", new SyncProgress(), cancellationTokenSource.Token);
+
+        Assert.Equal(1, lens.CallCount);
+        Assert.Equal(0, engine.SkippedImageCount);
+    }
+}


### PR DESCRIPTION
Fixes #13563

### The problem

The reporter runs OCR on a SUP file with **Google Lens Sharp** and the run keeps stopping on its own part way through — pressing "Start OCR" again restarts it (and loses the unknown-words list), several times per file.

`GoogleLensOcrSharp.OcrBatch` called the Lens endpoint straight from the batch loop:

```csharp
var result = await _lens.ScanByBitmap(bmpInput.Bitmap, language);
```

Google Lens is a public endpoint, and `LensCore.SendProtoRequest` throws `LensError` on any non-success status — including the 429/5xx you get when firing hundreds of images at it back-to-back — plus `HttpRequestException` / timeouts from the 30 second `HttpClient`. Any one of those escaped the `foreach`, so a single hiccup on image 200 of 900 killed the whole run. `OcrViewModel.RunGoogleLensOcrSharp` catches it, writes it to the error log and clears `IsOcrRunning` — from the UI it just looks like OCR quietly stopped.

### The fix

Per-image error handling instead of per-batch:

- Transient failures (`408`, `429`, `5xx`, `HttpRequestException`, `TaskCanceledException`, `TimeoutException`) are retried up to 3 times, backing off 1s/2s — or 5s/10s on `429`, where hammering is exactly the wrong move.
- Anything that a retry will not fix (e.g. a `400` on one odd image) is not retried.
- When an image still can't be read it is skipped and logged, and the batch carries on with the remaining lines, so the file finishes in one pass. `SkippedImageCount` records how many were dropped.
- Cancellation is honoured while waiting to retry, and a user-cancelled run is not logged as a failure.

### Tests

`tests/UI/Features/Ocr/Engines/GoogleLensOcrSharpRetryTests.cs` drives `OcrBatch` through a fake `ILens`: a 429 that succeeds on retry, a persistently failing image that gets skipped while its neighbours are still OCR'ed, a 400 that is not retried, and the two cancellation paths. The retry delay is an internal seam so the tests don't sleep.

All 5 pass. Full `UITests` run: 2563 passed, 15 failed — the 15 are pre-existing `UITests.Features.Main.*` headless-window failures, verified failing identically on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)