### PR TITLE
Optimize four more StringExtensions hot paths

### DIFF
--- a/src/libse/Common/StringExtensions.cs
+++ b/src/libse/Common/StringExtensions.cs
@@ -126,57 +126,39 @@ namespace Nikse.SubtitleEdit.Core.Common
         public static List<string> SplitToLines(this string s, int max)
         {
             //original non-optimized version: return source.Replace("\r\r\n", "\n").Replace("\r\n", "\n").Replace('\r', '\n').Replace('\u2028', '\n').Split('\n');
-
-            var lines = new List<string>();
-            var start = 0;
-            var i = 0;
+            // See https://github.com/SubtitleEdit/subtitleedit/issues/8854 - "\r\r\n" is
+            // deliberately two line breaks (following how VS Code opens such files).
+            // Line breaks are sparse, so hop between them with vectorized IndexOfAny
+            // instead of testing every char.
 
             if (s.Length < max)
             {
                 max = s.Length;
             }
 
-            while (i < max)
+            var lines = new List<string>();
+            var span = s.AsSpan(0, max);
+            var start = 0;
+            var pos = 0;
+            while (true)
             {
-                var ch = s[i];
-                if (ch == '\r')
+                var idx = span.Slice(pos).IndexOfAny('\r', '\n', '\u2028');
+                if (idx < 0)
                 {
-                    // See https://github.com/SubtitleEdit/subtitleedit/issues/8854
-                    // SE now tries to follow how VS code opens text file
-                    //if (i < max - 2 && s[i + 1] == '\r' && s[i + 2] == '\n') // \r\r\n
-                    //{
-                    //    lines.Add(s.Substring(start, i - start));
-                    //    i += 3;
-                    //    start = i;
-                    //    continue;
-                    //}
-
-                    if (i < max - 1 && s[i + 1] == '\n') // \r\n
-                    {
-                        lines.Add(s.Substring(start, i - start));
-                        i += 2;
-                        start = i;
-                        continue;
-                    }
-
-                    lines.Add(s.Substring(start, i - start));
-                    i++;
-                    start = i;
-                    continue;
+                    break;
                 }
 
-                if (ch == '\n' || ch == '\u2028')
+                var i = pos + idx;
+                lines.Add(s.Substring(start, i - start));
+                if (span[i] == '\r' && i + 1 < max && span[i + 1] == '\n') // \r\n
                 {
-                    lines.Add(s.Substring(start, i - start));
                     i++;
-                    start = i;
-                    continue;
                 }
 
-                i++;
+                pos = start = i + 1;
             }
 
-            lines.Add(s.Substring(start, i - start));
+            lines.Add(start == 0 && max == s.Length ? s : s.Substring(start, max - start));
             return lines;
         }
 
@@ -485,19 +467,51 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public static string RemoveControlCharacters(this string s)
         {
-            var max = s.Length;
-            var newStr = new char[max];
-            var newIdx = 0;
-            for (int index = 0; index < max; index++)
+            // char.IsControl matches exactly U+0000-U+001F and U+007F-U+009F; almost all
+            // input has none, so return the original instance without allocating.
+            var span = s.AsSpan();
+#if NET8_0_OR_GREATER
+            if (!span.ContainsAnyInRange('\u0000', '\u001F') && !span.ContainsAnyInRange('\u007F', '\u009F'))
             {
-                var ch = s[index];
-                if (!char.IsControl(ch))
+                return s;
+            }
+#else
+            var hasControl = false;
+            foreach (var c in span)
+            {
+                if (char.IsControl(c))
                 {
-                    newStr[newIdx++] = ch;
+                    hasControl = true;
+                    break;
                 }
             }
 
-            return new string(newStr, 0, newIdx);
+            if (!hasControl)
+            {
+                return s;
+            }
+#endif
+
+            var count = 0;
+            foreach (var ch in span)
+            {
+                if (char.IsControl(ch))
+                {
+                    count++;
+                }
+            }
+
+            return string.Create(s.Length - count, s, (chars, state) =>
+            {
+                var index = 0;
+                foreach (var ch in state)
+                {
+                    if (!char.IsControl(ch))
+                    {
+                        chars[index++] = ch;
+                    }
+                }
+            });
         }
 
         public static bool IsOnlyControlCharactersOrWhiteSpace(this string s)
@@ -543,12 +557,30 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public static string CapitalizeFirstLetter(this string s, CultureInfo ci = null)
         {
-            var si = new StringInfo(s);
             if (ci == null)
             {
                 ci = CultureInfo.CurrentCulture;
             }
 
+            if (s.Length > 0 && s[0] < 0x80)
+            {
+                // ASCII first char: it cannot be part of a surrogate pair or carry combining
+                // marks, so the StringInfo text-element machinery (which allocates heavily)
+                // is not needed.
+                var up = char.ToUpper(s[0], ci);
+                if (up == s[0])
+                {
+                    return s;
+                }
+
+                return string.Create(s.Length, (s, up), (chars, state) =>
+                {
+                    chars[0] = state.up;
+                    state.s.AsSpan(1).CopyTo(chars.Slice(1));
+                });
+            }
+
+            var si = new StringInfo(s);
             if (si.LengthInTextElements > 0)
             {
                 s = si.SubstringByTextElements(0, 1).ToUpper(ci);
@@ -977,15 +1009,30 @@ namespace Nikse.SubtitleEdit.Core.Common
             return value.HasSentenceEnding(string.Empty);
         }
 
-        private static readonly HashSet<char> NeutralSentenceEndingChars = new HashSet<char>
+        private static bool IsNeutralSentenceEndingChar(char c)
         {
-            '.', '!', '?', ']', ')', '…', '♪', '؟', '。', '？'
-        };
+            switch (c)
+            {
+                case '.':
+                case '!':
+                case '?':
+                case ']':
+                case ')':
+                case '…':
+                case '♪':
+                case '؟':
+                case '。':
+                case '？':
+                    return true;
+                default:
+                    return false;
+            }
+        }
 
-        private static readonly HashSet<char> GreekSentenceEndingChars = new HashSet<char>
+        private static bool IsGreekSentenceEndingChar(char c)
         {
-            '\u037E', ';'
-        };
+            return c == '\u037E' || c == ';';
+        }
 
         public static bool HasSentenceEnding(this string value, string twoLetterLanguageCode)
         {
@@ -1048,7 +1095,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
             // evaluate culture type
             var isCultureNeutral = twoLetterLanguageCode == null || twoLetterLanguageCode.Equals("el", StringComparison.OrdinalIgnoreCase) == false;
-            return NeutralSentenceEndingChars.Contains(charAtIndex) || (!isCultureNeutral && GreekSentenceEndingChars.Contains(charAtIndex));
+            return IsNeutralSentenceEndingChar(charAtIndex) || (!isCultureNeutral && IsGreekSentenceEndingChar(charAtIndex));
         }
 
         public static string NormalizeUnicode(this string input, Encoding encoding)


### PR DESCRIPTION
## Summary

Follow-up to #13561 — a systematic pass over the rest of `StringExtensions` for perf opportunities, keeping only changes that won on real subtitle data. All outputs are verified identical to the old implementations (element-wise over a 171k-line real-subtitle corpus, randomized inputs, and the full 65,536-char space for the sentence-ending classifier).

- **`SplitToLines`** (369 call sites): hop between sparse line breaks with vectorized `IndexOfAny('\r', '\n', ' ')` instead of testing every char, and return the original string as the single element when there is no line break. `\r\r\n` keeps its deliberate two-break behavior (#8854).
- **`CapitalizeFirstLetter`**: ASCII-first-char fast path — an ASCII char can't be part of a surrogate pair or carry combining marks, so the heavily allocating `StringInfo` text-element machinery is skipped; already-capitalized strings return unchanged with zero allocation. Non-ASCII first chars keep the old path.
- **`RemoveControlCharacters`**: `char.IsControl` matches exactly U+0000–001F and U+007F–009F, and only ~0.4% of real subtitle lines contain any — a vectorized `ContainsAnyInRange` check returns the original instance in the common case (netstandard2.1 uses a scalar pre-scan); the rare slow path writes through `string.Create`.
- **`HasSentenceEnding`**: switch-based char classification instead of two `HashSet<char>` lookups.

## Benchmarks

BenchmarkDotNet, .NET 10, Apple Silicon. Each benchmark is one full pass over 171,738 lines from 12 real subtitle files (English/Danish/Swedish/anime; .srt/.ass/.vtt).

| Method (full corpus pass) | Old | New | Speedup | Alloc old → new |
|---|---:|---:|---:|---|
| CapitalizeFirstLetter | 22,472 μs | 1,158 μs | **19.4×** | 36.2 MB → 1.1 MB |
| RemoveControlCharacters | 2,688 μs | 858 μs | **3.1×** | 17.5 MB → **134 KB** |
| SplitToLines (paragraphs) | 2,831 μs | 2,369 μs | 1.20× | unchanged |
| SplitToLines (single lines) | 2,989 μs | 2,518 μs | 1.19× | unchanged |
| SplitToLines (whole files) | 9,055 μs | 8,675 μs | 1.04× | unchanged |
| Sentence-ending check | 392 μs | 140 μs | **2.8×** | — |

Also evaluated and rejected: replacing `FastIndexOf`'s hand-rolled loop with the built-in ordinal span search — it measured ~5% slower on real patterns, so the existing code stays.

## Test plan
- [x] `dotnet build src/libse/LibSE.csproj` clean for netstandard2.1 and net10.0
- [x] Full LibSE test suite passes (1,024 tests)
- [x] Element-wise/byte-wise equivalence vs old implementations on the real-subtitle corpus and randomized inputs (incl. `\r\r\n`, ` `, truncating `max` values, Turkish/Danish cultures for capitalization, control-char mixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)