### PR TITLE
Tear the TTS review player's mpv core down off the UI thread

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -1836,6 +1836,47 @@ public partial class ReviewSpeechViewModel : ObservableObject
         }
     }
 
+    /// <summary>
+    /// Drops the playback player and destroys its mpv core on a worker thread.
+    /// <para>
+    /// <c>mpv_terminate_destroy</c> runs libmpv's native win32/audio deinit, which must not happen
+    /// on the UI thread while a window is closing: it leaves <c>Window.CloseInternal()</c> to make
+    /// its next COM call (<c>IFrameworkInputPane.Unadvise</c>) into an apartment libmpv's teardown
+    /// has already disturbed - an access violation no catch block can intercept. Same reasoning,
+    /// and same off-thread cure, as <c>TextToSpeechViewModel.DisposePreviewPlayer</c> (#13376) and
+    /// <c>VideoPlayerControl.CloseAndDisposePlayer</c> (#11176).
+    /// </para>
+    /// Safe to call more than once - the second call finds no player and does nothing.
+    /// </summary>
+    private void DisposePlayerOffThread()
+    {
+        LibMpvDynamicPlayer? player;
+        lock (_playLock)
+        {
+            player = _mpvContext;
+            _mpvContext = null;
+        }
+
+        if (player == null)
+        {
+            return;
+        }
+
+        Task.Run(() =>
+        {
+            try
+            {
+                // Stop first so the core tears down from an idle state instead of mid-playback.
+                player.Stop();
+                player.Dispose();
+            }
+            catch (Exception ex)
+            {
+                SeLogger.Error(ex, "ReviewSpeech: disposing the audio player failed");
+            }
+        });
+    }
+
     internal void OnClosing(WindowClosingEventArgs e)
     {
         // Title-bar X / Alt+F4 bypass the Escape guard, so a regenerate can still be in flight
@@ -1852,11 +1893,8 @@ public partial class ReviewSpeechViewModel : ObservableObject
         {
             try { _cancellationTokenSource.Dispose(); } catch (ObjectDisposedException) { }
         }
-        lock (_playLock)
-        {
-            _mpvContext?.Dispose();
-            _mpvContext = null;
-        }
+
+        DisposePlayerOffThread();
 
         // The waveform mirrors subscribe to PropertyChanged in Initialize so drags
         // on the visualizer write back into the per-row TtsStepResult. Detach now


### PR DESCRIPTION
Re #13567 — a candidate root cause, not a verified fix. Please read the caveat at the bottom before merging.

### What the crash report says

```
at Avalonia.Win32.Win32Com.Impl.__MicroComIFrameworkInputPaneProxy.Unadvise(UInt32)
at Avalonia.Controls.Window.CloseInternal()
at Avalonia.Controls.Window.Close()
at Nikse.SubtitleEdit.Features.Video.TextToSpeech.TextToSpeechViewModel.CloseWindowSafely()
```

…with `0xc0000005` in `coreclr.dll` — an access violation, which is why nothing lands in `error-log.txt` and why the existing `try/catch` in `CloseWindowSafely` cannot help. `TextToSpeechViewModel.CloseWindowSafely`'s own doc comment already says as much.

### The inconsistency

#13376 diagnosed this exact signature and wrote the rule down in `DisposePreviewPlayer`:

> `mpv_terminate_destroy` … runs libmpv's native win32/audio deinit, so it must not run on the UI thread while a window is closing: doing it inline in `OnClosing` left `Window.CloseInternal()` to make its next COM call (`IFrameworkInputPane.Unadvise`) into an apartment libmpv's teardown had already disturbed — an access violation no catch block can intercept.

`TextToSpeechViewModel` was fixed accordingly, and `OnClosing` there even warns: *"Never dispose it inline here — see DisposePreviewPlayer (#13376)."*

But [`ReviewSpeechViewModel.OnClosing`](src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs) still did precisely the forbidden thing:

```csharp
lock (_playLock)
{
    _mpvContext?.Dispose();   // inline, UI thread, from inside the window close
    _mpvContext = null;
}
```

And the review window is the one that actually plays audio in this workflow — the reporter describes "editing and regenerating individual blocks", which is exactly where `PlayAudio` spins up an mpv core. If libmpv's deinit disturbs the UI thread's apartment, the damage surfaces at the *next* COM call on that thread — which, after the review window closes, is the TTS window's own `Unadvise`. That matches the reported stack: the review window closes cleanly, and the TTS window's close is what dies.

### The change

`ReviewSpeechViewModel` gets a `DisposePlayerOffThread` helper that mirrors `TextToSpeechViewModel.DisposePreviewPlayer` — take the player out from under `_playLock`, null the field, then `Stop()`/`Dispose()` it on the thread pool. `OnClosing` calls that instead of disposing inline.

The inline disposals in `Stop()` and `PlayAudio()` are deliberately left alone: neither runs during a window close, so `CloseInternal`'s COM calls are not in flight there, and making them async would risk a new core being created while the old one is still terminating.

### Caveat — please weigh this before merging

I could not reproduce the crash (it needs an ElevenLabs key and a full TTS run, and it is an intermittent native AV), so this is **not verified against the reporter's scenario**. What I can stand behind is narrower: the review window was violating a rule this codebase established and documented for exactly this crash signature, and it is the window holding the mpv player in the reporter's workflow. That makes it the best available candidate, not a proven fix.

There is also a second, weaker suspect I did not touch, in case this one does not settle it: `TextToSpeechViewModel.Ok` comments that it tears the preview player down *"before the window starts closing, so libmpv's native teardown is never concurrent with Avalonia's window teardown"* — but `DisposePreviewPlayer` is `Task.Run` fire-and-forget, so the teardown is in fact still concurrent with `CloseInternal()`, just off the UI thread. Making the close await that task (bounded) would close that race too. I left it out of this PR because it is speculative and would muddy an already unverifiable change.

No test: this is a threading move around a native library, with nothing meaningful to assert without a real mpv core. `src/ui` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)