### PR TITLE
Make AI review window a little wider

### DIFF
--- a/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
@@ -19,9 +19,9 @@ public class AiReviewWindow : Window
     {
         UiUtil.InitializeWindow(this, GetType().Name);
         Title = UiUtil.MakeWindowTitle(Se.Language.Tools.AiReview.Title);
-        Width = 1024;
+        Width = 1200;
         Height = 720;
-        MinWidth = 800;
+        MinWidth = 900;
         MinHeight = 500;
         CanResize = true;
         vm.Window = this;


### PR DESCRIPTION
The AI review window opened at 1024 px wide, which felt cramped for the suggestion grid.

- Default width 1024 → 1200
- Minimum width 800 → 900

Note: `UiUtil.InitializeWindow` restores a previously saved size, so the new default only applies to a fresh window state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)