### PR TITLE
Prepare v5.2.0-beta12

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,39 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.2.0-beta12 (13th of August 2026)
+
+* Add CrispEmbed as an engine for "OCR burned-in subtitle", with its own settings dialog - thx tal-maker
+* Add Chatterbox Base in F16 and Q4_K alongside Q8_0 - thx subof
+* Add select all/none/invert to the "Multiple replace" preview list - thx Davanix
+* Show what each engine is in the "OCR burned-in subtitle" engine list
+* Remember the numbers and formats seven more tool dialogs ask for
+* Use the usual tick-all shortcuts in the "Multiple replace" rule category picker
+* Make the AI review window a little wider
+* Keep Google Lens OCR going when a single image fails instead of stopping the run - thx fartle
+* Fix crash when closing "Text to speech" after reviewing audio - thx cvrle77
+* Fix undocked video player being in front of the main window at startup - thx GrampaWildWilly
+* Fix "Multiple replace" freezing on a slow regular expression rule
+* Fix batch convert failing every file when one replace rule does not compile
+* Fix the same original line being shown on two rows when opening a non-matching original
+* Fix transparent subtitles ignoring the output folder picked in its own settings dialog
+* Fix Perplexity API key, model and URL being forgotten on restart
+* Fix "Apply minimum gap" mixing up frames and milliseconds
+* Fix "Export plain text" saving its settings when cancelled
+* Fix "OCR burned-in subtitle" repeating a line, and saving engine settings while browsing the lists
+* Fix "OCR burned-in subtitle" running to the end without reporting a broken CrispEmbed/llama.cpp server
+* Fix batch convert dialogs showing the main window's file name in the title bar
+* Fix hardcoded English in the transparent video, burn-in and batch convert output folder pickers
+* Fix Chatterbox retrying an impossible reference voice repair once per line
+* Fix timers and preview images left running after closing several dialogs
+* Update Japanese translation - thx hisui3393
+* Update Korean translation - thx 12si27
+* Update Chinese (Traditional) translation - thx love80312
+* Update French translation - thx Need74
+* Minor performance improvements in string handling
+
+-----------------------------------------------------------------------------------------------------
+
 v5.2.0-beta11 (12th of August 2026)
 
 * Add import/export of selected rule categories to "Multiple replace" - thx KaDeeKe

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -19,7 +19,7 @@ public class Se
     internal const int CurrentMacOsFontMigrationVersion = 1;
     internal const int CurrentShortcutsMigrationVersion = 2;
 
-    public static string Version { get; set; } = "v5.2.0-beta11";
+    public static string Version { get; set; } = "v5.2.0-beta12";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Bumps `Se.Version` to `v5.2.0-beta12` and adds the change-log section for it.

The entry set was compiled by ancestor-checking every merged PR's merge commit against the `v5.2.0-beta11` tag — 22 PRs landed on `main` since it (a 23rd, #13573, targets `se4-legacy` and is not part of this release). Credits come from the linked issue authors: tal-maker (#13541), subof (#13572), Davanix (#13502), fartle (#13563), cvrle77 (#13567), GrampaWildWilly (#13569).

Rolled up rather than listed one-per-PR:

- The four bug-hunt PRs (#13545, #13547, #13550, #13557 — 27 fixes) become individual lines only where the fix is user-visible; the settings-persistence family and the timer/bitmap lifecycle leaks are one line each.
- #13561 and #13566 become the single performance line.
- #13549 (English.json regeneration test) and #13552 (revert of a change that never shipped in a tagged build) get no entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)