### PR TITLE
Index-mapped scrollbar for the subtitle grid (fixes thumb jitter, #13579)

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -112,7 +112,10 @@ public static partial class InitListViewAndEditBox
         var dropHost = new Border
         {
             Background = Brushes.Transparent,
-            Child = vm.SubtitleGrid
+            // Index-mapped scrollbar (#13579): hides the grid's native pixel-mapped vertical
+            // bar and docks a row-index one beside it, so the thumb no longer jitters with
+            // the virtualization panel's extent re-estimates on variable-height rows.
+            Child = new TableViewIndexScrollBar(vm.SubtitleGrid)
         };
         vm.SubtitleGridDropHost = dropHost;
         DragDrop.SetAllowDrop(dropHost, true);

--- a/src/ui/Logic/TableViewIndexScrollBar.cs
+++ b/src/ui/Logic/TableViewIndexScrollBar.cs
@@ -1,0 +1,595 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Hosts a <see cref="TableView"/> next to a vertical scroll bar that works in row indices
+/// instead of pixels, so the thumb stays steady with variable-height rows (issue #13579).
+///
+/// TableView virtualizes with Avalonia's VirtualizingStackPanel, which estimates the total
+/// extent as "realized rows + remaining count x average realized height". With rows of one
+/// and two text lines the average changes with every wheel tick as the realized window moves,
+/// the extent is recomputed, and the native thumb jumps around (upstream: AvaloniaUI/Avalonia
+/// #17831 "More precise VirtualizingStackPanel"). The estimator is private and the native
+/// scroll bar cannot be re-united: any ScrollBar whose TemplatedParent is a ScrollViewer
+/// pushes every Value change straight into the pixel offset from its own PropertyChanged.
+///
+/// So the native vertical bar is hidden (ScrollViewer.VerticalScrollBarVisibility=Hidden on
+/// the grid, template-bound into the inner ScrollViewer) and this control docks a standalone
+/// ScrollBar - TemplatedParent null, so it never couples to any ScrollViewer - beside the
+/// grid, mapped like the SE4 list view:
+///   Value    = index of the first visible row (+ the fraction scrolled into it)
+///   Maximum  = row count - fully visible rows
+/// The scroll wheel, keyboard and ScrollIntoView still move the pixel offset; ScrollChanged
+/// re-derives Value from the realized rows. Dragging the thumb (or the trough/step buttons)
+/// changes Value; the row at floor(Value) is then placed at the viewport top via
+/// <see cref="TableViewExtras.PrePositionScroll"/>, which realizes at most a few viewports
+/// instead of walking the list.
+///
+/// The trough gets the same Windows-standard press-and-hold behavior the in-grid bars get
+/// from <see cref="TableViewScrollBarBehavior"/> (#12894: page toward the cursor, pause when
+/// the thumb reaches it; #12051/#12438: shift+click jumps to the position). That behavior
+/// only wires bars *inside* a TableView, which this bar deliberately is not, so the small
+/// press/hold state machine is replicated here in index units.
+/// </summary>
+public sealed class TableViewIndexScrollBar : Grid
+{
+    // Avalonia's RepeatButton defaults, same as TableViewScrollBarBehavior.
+    private static readonly TimeSpan RepeatDelay = TimeSpan.FromMilliseconds(300);
+    private static readonly TimeSpan RepeatInterval = TimeSpan.FromMilliseconds(100);
+
+    private readonly TableView _tableView;
+    private readonly ScrollBar _bar;
+    private ScrollViewer? _scrollViewer;
+
+    // Writing bar properties from the view state - ignore the resulting Value change.
+    private bool _syncingBar;
+    // Scrolling the view from a bar value - ignore the resulting ScrollChanged.
+    private bool _applyingValue;
+    // Latest user-driven Value not yet applied; coalesces a fast thumb drag to one
+    // scroll per dispatcher pass instead of one per pointer move.
+    private double? _pendingValue;
+    // Left button held somewhere on the bar (thumb drag or trough hold). The pointer owns
+    // Value for the duration, so the view->bar sync must not write it back mid-drag.
+    private bool _barPressed;
+
+    // Non-null only while the left button is held on the trough.
+    private TroughHold? _troughHold;
+
+    private sealed class TroughHold
+    {
+        public required DispatcherTimer Timer { get; init; }
+        public required IPointer Pointer { get; init; }
+        public required Track Track { get; init; }
+        public required bool PageDown { get; init; }
+        public Point PointerPosition { get; set; } // in bar coordinates
+    }
+
+    public TableViewIndexScrollBar(TableView tableView)
+    {
+        _tableView = tableView;
+
+        ColumnDefinitions = new ColumnDefinitions("*,Auto");
+
+        // Hide the native pixel-mapped vertical bar; the grid still scrolls, it just has
+        // no bar of its own. (The horizontal bar is untouched.)
+        ScrollViewer.SetVerticalScrollBarVisibility(tableView, ScrollBarVisibility.Hidden);
+
+        _bar = new ScrollBar
+        {
+            Orientation = Orientation.Vertical,
+            // Auto hides the bar when everything fits (Maximum stays 0), like the native one.
+            Visibility = ScrollBarVisibility.Auto,
+            Minimum = 0,
+            Maximum = 0,
+            SmallChange = 1,
+        };
+
+        SetColumn(tableView, 0);
+        SetColumn(_bar, 1);
+        Children.Add(tableView);
+        Children.Add(_bar);
+
+        tableView.Loaded += (_, _) => HookScrollViewer();
+        tableView.PropertyChanged += (_, e) =>
+        {
+            if (e.Property == ItemsControl.ItemCountProperty)
+            {
+                SyncBarFromView();
+            }
+        };
+
+        _bar.PropertyChanged += (_, e) =>
+        {
+            if (e.Property == RangeBase.ValueProperty && !_syncingBar)
+            {
+                QueueApply(_bar.Value);
+            }
+        };
+
+        // The native bar sits inside the ScrollViewer, so wheeling over it scrolls the list;
+        // keep that for this bar by forwarding the wheel as rows.
+        _bar.PointerWheelChanged += (_, e) =>
+        {
+            if (_scrollViewer is { } scrollViewer)
+            {
+                var rowHeight = AverageRealizedRowHeight();
+                if (rowHeight > 0)
+                {
+                    var newY = Math.Clamp(
+                        scrollViewer.Offset.Y - e.Delta.Y * 3 * rowHeight,
+                        0, Math.Max(0, scrollViewer.Extent.Height - scrollViewer.Viewport.Height));
+                    scrollViewer.Offset = new Vector(scrollViewer.Offset.X, newY);
+                }
+
+                e.Handled = true;
+            }
+        };
+
+        WireTroughBehavior();
+    }
+
+    private void HookScrollViewer()
+    {
+        if (_scrollViewer != null)
+        {
+            return;
+        }
+
+        _scrollViewer = _tableView.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
+        if (_scrollViewer == null)
+        {
+            // Template not applied yet - try again after the layout pass that applies it.
+            Dispatcher.UIThread.Post(HookScrollViewer, DispatcherPriority.Loaded);
+            return;
+        }
+
+        _scrollViewer.ScrollChanged += (_, _) => SyncBarFromView();
+
+        // Start the bar below the column header, like the native bar in the grid template.
+        var header = _tableView.GetVisualDescendants().OfType<TableViewColumnHeadersPresenter>().FirstOrDefault();
+        if (header != null && header.Bounds.Height > 0)
+        {
+            _bar.Margin = new Thickness(0, header.Bounds.Height, 0, 0);
+        }
+
+        SyncBarFromView();
+    }
+
+    /// <summary>
+    /// The visual whose origin is the viewport's top-left corner. The TableView template
+    /// keeps the column header *inside* the ScrollViewer (pinned above the rows), so the
+    /// ScrollViewer's own origin sits a header height above the viewport - rows must be
+    /// measured against the content presenter instead.
+    /// </summary>
+    private Visual? ViewportOrigin => (Visual?)_scrollViewer?.Presenter ?? _scrollViewer;
+
+    /// <summary>All realized rows with a height, as (index, top, height) with the top in
+    /// viewport coordinates, ordered by index.</summary>
+    private List<(int Index, double Top, double Height)> GetRealizedRows()
+    {
+        var rows = new List<(int Index, double Top, double Height)>();
+        if (ViewportOrigin is not { } viewportOrigin)
+        {
+            return rows;
+        }
+
+        foreach (var row in _tableView.GetRealizedContainers().OfType<TableViewRow>())
+        {
+            var height = row.Bounds.Height;
+            if (height <= 0)
+            {
+                continue;
+            }
+
+            var index = _tableView.IndexFromContainer(row);
+            if (index < 0)
+            {
+                continue;
+            }
+
+            var top = ((Visual)row).TranslatePoint(new Point(0, 0), viewportOrigin)?.Y;
+            if (top == null)
+            {
+                continue;
+            }
+
+            rows.Add((index, top.Value, height));
+        }
+
+        rows.Sort((a, b) => a.Index.CompareTo(b.Index));
+        return rows;
+    }
+
+    private double AverageRealizedRowHeight()
+    {
+        var rows = GetRealizedRows();
+        return rows.Count == 0 ? 0 : rows.Average(r => r.Height);
+    }
+
+    private void SyncBarFromView()
+    {
+        if (_applyingValue || _scrollViewer == null)
+        {
+            return;
+        }
+
+        var count = _tableView.ItemCount;
+        var rows = GetRealizedRows();
+        if (count == 0 || rows.Count == 0)
+        {
+            _syncingBar = true;
+            _bar.Maximum = 0;
+            _bar.Value = 0;
+            _syncingBar = false;
+            return;
+        }
+
+        var viewportHeight = _scrollViewer.Viewport.Height;
+
+        // The row under the viewport top edge carries the value; the fraction scrolled into
+        // it keeps the thumb gliding instead of stepping row by row.
+        var first = rows.FirstOrDefault(r => r.Top + r.Height > 0.5, rows[^1]);
+        var value = first.Index + Math.Clamp(-first.Top / first.Height, 0, 1);
+
+        var fullyVisible = rows.Count(r => r.Top >= -0.5 && r.Top + r.Height <= viewportHeight + 0.5);
+        var visibleRows = Math.Max(1, fullyVisible);
+        var maximum = Math.Max(0, count - visibleRows);
+
+        // Pin the ends: the pixel offset knows exactly when the list is at the top or the
+        // bottom, and the thumb must sit hard against the end there.
+        if (_scrollViewer.Offset.Y <= 0.5)
+        {
+            value = 0;
+        }
+        else if (_scrollViewer.Offset.Y >= _scrollViewer.Extent.Height - viewportHeight - 0.5)
+        {
+            value = maximum;
+        }
+
+        _syncingBar = true;
+        _bar.Maximum = maximum;
+        _bar.ViewportSize = visibleRows;
+        _bar.LargeChange = Math.Max(1, visibleRows - 1);
+
+        // While the pointer is down on the bar the drag owns Value; writing it back from
+        // layout would make the thumb fight the hand holding it.
+        if (!_barPressed && Math.Abs(_bar.Value - value) > 0.001)
+        {
+            _bar.Value = Math.Clamp(value, 0, maximum);
+        }
+
+        _syncingBar = false;
+    }
+
+    private void QueueApply(double value)
+    {
+        var schedule = _pendingValue == null;
+        _pendingValue = value;
+        if (schedule)
+        {
+            // Render priority: one scroll per frame however fast the thumb moves.
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (_pendingValue is { } pending)
+                {
+                    _pendingValue = null;
+                    ApplyBarValue(pending);
+                }
+            }, DispatcherPriority.Render);
+        }
+    }
+
+    private void ApplyBarValue(double value)
+    {
+        if (_scrollViewer == null)
+        {
+            return;
+        }
+
+        var count = _tableView.ItemCount;
+        if (count == 0)
+        {
+            return;
+        }
+
+        _applyingValue = true;
+        try
+        {
+            if (value <= 0.001)
+            {
+                _scrollViewer.Offset = new Vector(_scrollViewer.Offset.X, 0);
+                _tableView.UpdateLayout();
+                return;
+            }
+
+            if (value >= _bar.Maximum - 0.001)
+            {
+                ScrollToEnd(count);
+                return;
+            }
+
+            var index = Math.Clamp((int)value, 0, count - 1);
+            var fraction = value - index;
+
+            // Jump the offset near the target first so ScrollIntoView never row-walks.
+            TableViewExtras.PrePositionScroll(_tableView, index);
+            _tableView.ScrollIntoView(index);
+            _tableView.UpdateLayout();
+
+            // Put the row's top at the viewport top, plus the fractional part. Setting the
+            // offset makes the panel re-estimate and re-anchor, which can nudge the rows by
+            // a fraction of a row (or recycle the target's container entirely) - measure
+            // and correct again until the row stays put.
+            for (var pass = 0; pass < 3; pass++)
+            {
+                if (_tableView.ContainerFromIndex(index) is not { } row || row.Bounds.Height <= 0)
+                {
+                    // The re-anchor derealized the target; bring it back and try again.
+                    _tableView.ScrollIntoView(index);
+                    _tableView.UpdateLayout();
+                    if (_tableView.ContainerFromIndex(index) is not { } retried || retried.Bounds.Height <= 0)
+                    {
+                        break;
+                    }
+
+                    row = retried;
+                }
+
+                if (ViewportOrigin is not { } viewportOrigin ||
+                    row.TranslatePoint(new Point(0, 0), viewportOrigin)?.Y is not { } rowTop)
+                {
+                    break;
+                }
+
+                var delta = rowTop + fraction * row.Bounds.Height;
+                var newY = Math.Clamp(
+                    _scrollViewer.Offset.Y + delta,
+                    0, Math.Max(0, _scrollViewer.Extent.Height - _scrollViewer.Viewport.Height));
+                if (Math.Abs(newY - _scrollViewer.Offset.Y) < 0.5)
+                {
+                    break;
+                }
+
+                _scrollViewer.Offset = new Vector(_scrollViewer.Offset.X, newY);
+                _tableView.UpdateLayout();
+            }
+        }
+        finally
+        {
+            _applyingValue = false;
+        }
+
+        SyncBarFromView();
+    }
+
+    private void ScrollToEnd(int count)
+    {
+        if (_scrollViewer == null)
+        {
+            return;
+        }
+
+        TableViewExtras.PrePositionScroll(_tableView, count - 1);
+        _tableView.ScrollIntoView(count - 1);
+        _tableView.UpdateLayout();
+
+        // The extent is re-estimated as rows realize near the end, so clamping once is not
+        // enough - settle until the offset stops moving.
+        for (var i = 0; i < 3; i++)
+        {
+            var maxY = Math.Max(0, _scrollViewer.Extent.Height - _scrollViewer.Viewport.Height);
+            if (Math.Abs(_scrollViewer.Offset.Y - maxY) < 0.5)
+            {
+                break;
+            }
+
+            _scrollViewer.Offset = new Vector(_scrollViewer.Offset.X, maxY);
+            _tableView.UpdateLayout();
+        }
+    }
+
+    // ---- Trough press-and-hold / shift+click, in index units ----------------------------
+
+    private void WireTroughBehavior()
+    {
+        _bar.AddHandler(PointerPressedEvent, (_, e) =>
+        {
+            if (!e.GetCurrentPoint(_bar).Properties.IsLeftButtonPressed)
+            {
+                return;
+            }
+
+            _barPressed = true;
+
+            if ((e.KeyModifiers & KeyModifiers.Shift) != 0)
+            {
+                JumpToClickPosition(e);
+            }
+            else
+            {
+                StartTroughHold(e);
+            }
+        }, RoutingStrategies.Tunnel);
+
+        _bar.PointerMoved += (_, e) =>
+        {
+            if (_troughHold is { } hold)
+            {
+                hold.PointerPosition = e.GetPosition(_bar);
+            }
+        };
+
+        _bar.AddHandler(PointerReleasedEvent, (_, e) =>
+        {
+            if (e.InitialPressMouseButton == MouseButton.Left)
+            {
+                _barPressed = false;
+                if (_troughHold != null)
+                {
+                    StopTroughHold();
+                    e.Pointer.Capture(null);
+                    e.Handled = true;
+                }
+            }
+        }, RoutingStrategies.Tunnel, handledEventsToo: true);
+
+        _bar.PointerCaptureLost += (_, _) =>
+        {
+            _barPressed = false;
+            StopTroughHold();
+        };
+    }
+
+    /// <summary>The press's Y in track coordinates for a genuine trough press, or null for
+    /// presses on the thumb (a normal drag) or outside the track (the step arrows).</summary>
+    private (Track Track, double PosY, bool IsBelowThumb)? GetTroughPress(PointerEventArgs e)
+    {
+        if (_bar.Maximum <= 0)
+        {
+            return null;
+        }
+
+        var track = _bar.GetVisualDescendants().OfType<Track>().FirstOrDefault();
+        if (track == null || track.Bounds.Height <= 0)
+        {
+            return null;
+        }
+
+        var y = e.GetPosition(track).Y;
+        if (y < 0 || y > track.Bounds.Height)
+        {
+            return null;
+        }
+
+        if (track.Thumb is { } thumb && y >= thumb.Bounds.Top && y <= thumb.Bounds.Bottom)
+        {
+            return null;
+        }
+
+        return (track, y, track.Thumb == null || y > track.Thumb.Bounds.Bottom);
+    }
+
+    private void StartTroughHold(PointerPressedEventArgs e)
+    {
+        if (_troughHold != null || GetTroughPress(e) is not { } press)
+        {
+            return;
+        }
+
+        var timer = new DispatcherTimer { Interval = RepeatDelay };
+        var hold = new TroughHold
+        {
+            Timer = timer,
+            Pointer = e.Pointer,
+            Track = press.Track,
+            PageDown = press.IsBelowThumb,
+            PointerPosition = e.GetPosition(_bar),
+        };
+
+        timer.Tick += (_, _) =>
+        {
+            timer.Interval = RepeatInterval;
+            TickTroughHold(hold);
+        };
+
+        _troughHold = hold;
+        e.Pointer.Capture(_bar);
+        PageOnce(hold.PageDown);
+        timer.Start();
+
+        // Keep the theme's trough repeat button from starting its own (runaway) repeat.
+        e.Handled = true;
+    }
+
+    private void TickTroughHold(TroughHold hold)
+    {
+        if (hold.Pointer.Captured != _bar)
+        {
+            StopTroughHold();
+            return;
+        }
+
+        var thumb = hold.Track.Thumb;
+        var posY = _bar.TranslatePoint(hold.PointerPosition, hold.Track)?.Y;
+        if (thumb == null || posY == null)
+        {
+            return;
+        }
+
+        // Pause (not stop) once the thumb has reached the pointer, like the Windows bar.
+        var shouldPage = hold.PageDown ? posY.Value > thumb.Bounds.Bottom : posY.Value < thumb.Bounds.Top;
+        if (shouldPage)
+        {
+            PageOnce(hold.PageDown);
+        }
+    }
+
+    private void PageOnce(bool pageDown)
+    {
+        var delta = pageDown ? _bar.LargeChange : -_bar.LargeChange;
+        var newValue = Math.Clamp(_bar.Value + delta, _bar.Minimum, _bar.Maximum);
+        if (Math.Abs(newValue - _bar.Value) > 0.001)
+        {
+            _bar.Value = newValue;
+        }
+    }
+
+    private void StopTroughHold()
+    {
+        if (_troughHold is { } hold)
+        {
+            hold.Timer.Stop();
+            _troughHold = null;
+        }
+    }
+
+    private void JumpToClickPosition(PointerPressedEventArgs e)
+    {
+        if (GetTroughPress(e) is not { } press)
+        {
+            return;
+        }
+
+        // Center the thumb on the cursor, scaled by the travel the thumb actually has.
+        var thumbLength = press.Track.Thumb?.Bounds.Height ?? 0;
+        var travel = Math.Max(1, press.Track.Bounds.Height - thumbLength);
+        var fraction = Math.Clamp((press.PosY - thumbLength / 2.0) / travel, 0.0, 1.0);
+        _bar.Value = Math.Clamp(fraction * _bar.Maximum, _bar.Minimum, _bar.Maximum);
+        e.Handled = true;
+    }
+
+    // The headless test dispatcher never fires a DispatcherTimer; the tests step the repeat
+    // by hand, like TableViewScrollBarBehavior.TickTroughHoldPagingForTest.
+    internal void TickTroughHoldForTest()
+    {
+        if (_troughHold is { } hold)
+        {
+            TickTroughHold(hold);
+        }
+    }
+
+    // The tests drive the bar->view mapping synchronously instead of waiting for the posted
+    // dispatcher job.
+    internal void ApplyPendingForTest()
+    {
+        if (_pendingValue is { } pending)
+        {
+            _pendingValue = null;
+            ApplyBarValue(pending);
+        }
+    }
+
+    internal ScrollBar BarForTest => _bar;
+}

--- a/tests/UI/Logic/TableViewIndexScrollBarTests.cs
+++ b/tests/UI/Logic/TableViewIndexScrollBarTests.cs
@@ -1,0 +1,303 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Styling;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// The index-mapped scrollbar for the main subtitle grid (issue #13579): the grid's rows are
+/// variable height (one or two text lines), and the virtualizing panel re-estimates the
+/// pixel extent from the average realized height on every scroll, which made the native
+/// thumb jitter. TableViewIndexScrollBar hides the native vertical bar and maps its own bar
+/// to row indices, so the thumb moves monotonically no matter how the row heights are mixed.
+/// </summary>
+public class TableViewIndexScrollBarTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private sealed record Row(int Number, string Text);
+
+    private const int RowCount = 500;
+
+    private (Window window, TableView grid, TableViewIndexScrollBar wrapper, ScrollBar bar, ScrollViewer scrollViewer) BuildShownGrid()
+    {
+        // Every third row has two text lines, so realized row heights vary the way the
+        // subtitle grid's do - the very mix that makes the native pixel extent jitter.
+        var grid = new TableView
+        {
+            ItemsSource = Enumerable.Range(1, RowCount)
+                .Select(i => new Row(i, i % 3 == 0 ? $"Line {i}\nsecond line" : $"Line {i}"))
+                .ToList(),
+            Columns =
+            {
+                new TableViewColumn { Header = "#", Binding = new Avalonia.Data.Binding(nameof(Row.Number)) },
+                new TableViewColumn { Header = "Text", Binding = new Avalonia.Data.Binding(nameof(Row.Text)) },
+            },
+        };
+
+        var wrapper = new TableViewIndexScrollBar(grid);
+        var window = new Window { Content = wrapper, Width = 400, Height = 300 };
+
+        // Like the app (UiTheme.ApplyScrollBarStyle): keep the bar expanded so its trough
+        // is hit-testable without hover expansion, which headless input never delivers.
+        window.Styles.Add(new Style(x => x.OfType<ScrollBar>())
+        {
+            Setters = { new Setter(ScrollBar.AllowAutoHideProperty, false) },
+        });
+
+        _windows.Add(window);
+        window.Show();
+        window.UpdateLayout();
+        AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        var bar = wrapper.BarForTest;
+        var scrollViewer = grid.GetVisualDescendants().OfType<ScrollViewer>().First();
+        return (window, grid, wrapper, bar, scrollViewer);
+    }
+
+    // The TableView template pins the column header inside the ScrollViewer, so the true
+    // viewport origin is the content presenter, a header height below the ScrollViewer's own.
+    private static Visual ViewportOrigin(ScrollViewer scrollViewer) => (Visual?)scrollViewer.Presenter ?? scrollViewer;
+
+    private static int FirstVisibleIndex(TableView grid, ScrollViewer scrollViewer)
+    {
+        var best = -1;
+        var bestTop = double.MaxValue;
+        foreach (var row in grid.GetRealizedContainers().OfType<TableViewRow>())
+        {
+            var top = ((Visual)row).TranslatePoint(new Point(0, 0), ViewportOrigin(scrollViewer))?.Y;
+            if (top == null || row.Bounds.Height <= 0 || top.Value + row.Bounds.Height <= 0.5)
+            {
+                continue;
+            }
+
+            if (top.Value < bestTop)
+            {
+                bestTop = top.Value;
+                best = grid.IndexFromContainer(row);
+            }
+        }
+
+        return best;
+    }
+
+    [AvaloniaFact]
+    public void RowsHaveVariableHeights()
+    {
+        // Guard for the whole file: if a template change ever made all rows the same
+        // height, these tests would no longer exercise the jitter scenario at all.
+        var (_, grid, _, _, _) = BuildShownGrid();
+
+        var heights = grid.GetRealizedContainers().OfType<TableViewRow>()
+            .Select(r => r.Bounds.Height)
+            .Where(h => h > 0)
+            .Distinct()
+            .ToList();
+
+        Assert.True(heights.Count > 1, "expected a mix of one and two line rows");
+    }
+
+    [AvaloniaFact]
+    public void NativeVerticalScrollBar_IsHidden()
+    {
+        var (_, grid, _, bar, _) = BuildShownGrid();
+
+        var nativeBar = grid.GetVisualDescendants().OfType<ScrollBar>()
+            .First(s => s.Orientation == Orientation.Vertical && !ReferenceEquals(s, bar));
+
+        Assert.False(nativeBar.IsVisible, "the native pixel-mapped vertical bar should be hidden");
+        Assert.True(bar.IsVisible, "the index-mapped bar should be visible");
+    }
+
+    [AvaloniaFact]
+    public void Maximum_IsRowBased()
+    {
+        var (_, _, _, bar, scrollViewer) = BuildShownGrid();
+
+        // Row units, not pixels: the viewport shows a handful of rows out of 500, so the
+        // maximum sits just below the row count - while the pixel extent is thousands.
+        Assert.InRange(bar.Maximum, RowCount - 30, RowCount - 1);
+        Assert.True(scrollViewer.Extent.Height - scrollViewer.Viewport.Height > bar.Maximum * 2,
+            "sanity: the pixel extent should be far larger than the row-based maximum");
+        Assert.Equal(0, bar.Value);
+    }
+
+    [AvaloniaFact]
+    public void WheelScrollingDown_MovesValueMonotonically_AndMaximumStaysRowStable()
+    {
+        var (window, grid, _, bar, scrollViewer) = BuildShownGrid();
+
+        var previousValue = bar.Value;
+        var maxSeen = bar.Maximum;
+        var minSeen = bar.Maximum;
+
+        while (scrollViewer.Offset.Y < scrollViewer.Extent.Height - scrollViewer.Viewport.Height - 0.5)
+        {
+            // A wheel notch's worth of pixels; drives the same ScrollChanged path as the wheel.
+            scrollViewer.Offset = new Vector(0, scrollViewer.Offset.Y + 120);
+            window.UpdateLayout();
+
+            Assert.True(bar.Value >= previousValue - 0.001,
+                $"thumb moved backwards while scrolling down: {previousValue} -> {bar.Value} at offset {scrollViewer.Offset.Y}");
+            previousValue = bar.Value;
+            maxSeen = Math.Max(maxSeen, bar.Maximum);
+            minSeen = Math.Min(minSeen, bar.Maximum);
+        }
+
+        // The native bar's Maximum (pixel extent) swings by whole percents as the average
+        // row height is re-estimated; the index bar's varies only with the handful of rows
+        // that fit the viewport.
+        Assert.True(maxSeen - minSeen <= 6,
+            $"row-based maximum should be stable, varied {minSeen}..{maxSeen}");
+
+        Assert.Equal(bar.Maximum, bar.Value, 3); // pinned hard to the end at the bottom
+    }
+
+    [AvaloniaFact]
+    public void ScrollingToTop_PinsValueToZero()
+    {
+        var (window, _, wrapper, bar, scrollViewer) = BuildShownGrid();
+
+        bar.Value = bar.Maximum;
+        wrapper.ApplyPendingForTest();
+        window.UpdateLayout();
+        Assert.True(scrollViewer.Offset.Y > 0);
+
+        scrollViewer.Offset = new Vector(0, 0);
+        window.UpdateLayout();
+
+        Assert.Equal(0, bar.Value, 3);
+    }
+
+    [AvaloniaFact]
+    public void SettingValue_ScrollsThatRowToViewportTop()
+    {
+        var (window, grid, wrapper, bar, scrollViewer) = BuildShownGrid();
+
+        bar.Value = 250;
+        wrapper.ApplyPendingForTest();
+        window.UpdateLayout();
+
+        Assert.Equal(250, FirstVisibleIndex(grid, scrollViewer));
+
+        var row = grid.ContainerFromIndex(250)!;
+        var top = ((Visual)row).TranslatePoint(new Point(0, 0), ViewportOrigin(scrollViewer))!.Value.Y;
+        Assert.InRange(top, -1, 1);
+    }
+
+    [AvaloniaFact]
+    public void SettingValueToMaximum_ShowsTheLastRow()
+    {
+        var (window, grid, wrapper, bar, scrollViewer) = BuildShownGrid();
+
+        bar.Value = bar.Maximum;
+        wrapper.ApplyPendingForTest();
+        window.UpdateLayout();
+
+        var lastRow = grid.ContainerFromIndex(RowCount - 1);
+        Assert.NotNull(lastRow);
+        var bottom = ((Visual)lastRow!).TranslatePoint(new Point(0, lastRow.Bounds.Height), ViewportOrigin(scrollViewer))!.Value.Y;
+        Assert.InRange(bottom, scrollViewer.Viewport.Height - 2, scrollViewer.Viewport.Height + 2);
+    }
+
+    // ---- Trough behavior in index units --------------------------------------------------
+
+    private static Track TrackOf(ScrollBar scrollBar) => scrollBar.GetVisualDescendants().OfType<Track>().First();
+
+    private static Point TroughPointBelowThumb(Window window, ScrollBar scrollBar)
+    {
+        var track = TrackOf(scrollBar);
+        var yInTrack = (track.Thumb!.Bounds.Bottom + track.Bounds.Height) / 2;
+        return track.TranslatePoint(new Point(track.Bounds.Width / 2, yInTrack), window)!.Value;
+    }
+
+    [AvaloniaFact]
+    public void TroughPress_PagesOneViewportOfRows()
+    {
+        var (window, _, wrapper, bar, _) = BuildShownGrid();
+        Assert.True(bar.LargeChange > 1, "LargeChange should be the visible row count minus one");
+
+        var point = TroughPointBelowThumb(window, bar);
+        window.MouseDown(point, MouseButton.Left);
+
+        Assert.Equal(bar.LargeChange, bar.Value, 3);
+
+        // The rows follow the value.
+        wrapper.ApplyPendingForTest();
+        window.UpdateLayout();
+        var (grid, scrollViewer) = (wrapper.Children.OfType<TableView>().First(),
+            wrapper.Children.OfType<TableView>().First().GetVisualDescendants().OfType<ScrollViewer>().First());
+        Assert.Equal((int)bar.Value, FirstVisibleIndex(grid, scrollViewer));
+
+        window.MouseUp(point, MouseButton.Left);
+    }
+
+    [AvaloniaFact]
+    public void TroughHold_PausesWhenThumbReachesPointer()
+    {
+        var (window, _, wrapper, bar, _) = BuildShownGrid();
+
+        var point = TroughPointBelowThumb(window, bar);
+        window.MouseDown(point, MouseButton.Left);
+        for (var i = 0; i < 50; i++)
+        {
+            wrapper.TickTroughHoldForTest();
+            wrapper.ApplyPendingForTest();
+            window.UpdateLayout();
+        }
+
+        Assert.True(bar.Value > 0, "the hold should have paged");
+        Assert.True(bar.Value < bar.Maximum,
+            $"paging ran past the pointer to the end ({bar.Value} of {bar.Maximum})");
+
+        window.MouseUp(point, MouseButton.Left);
+    }
+
+    [AvaloniaFact]
+    public void ShiftTroughPress_JumpsToClickPosition()
+    {
+        var (window, _, wrapper, bar, _) = BuildShownGrid();
+        Assert.Equal(0, bar.Value);
+
+        var track = TrackOf(bar);
+        var point = track.TranslatePoint(new Point(track.Bounds.Width / 2, track.Bounds.Height * 0.9), window)!.Value;
+        window.MouseDown(point, MouseButton.Left, RawInputModifiers.Shift);
+
+        Assert.True(bar.Value > bar.Maximum * 0.5,
+            $"shift+click should jump near the click position ({bar.Value} of {bar.Maximum})");
+
+        wrapper.ApplyPendingForTest();
+        window.MouseUp(point, MouseButton.Left, RawInputModifiers.Shift);
+    }
+
+    [AvaloniaFact]
+    public void ThumbPress_DoesNotPage()
+    {
+        var (window, _, _, bar, _) = BuildShownGrid();
+
+        var thumb = TrackOf(bar).Thumb!;
+        var thumbCenter = thumb.TranslatePoint(new Point(thumb.Bounds.Width / 2, thumb.Bounds.Height / 2), window)!.Value;
+
+        window.MouseDown(thumbCenter, MouseButton.Left);
+        Assert.Equal(0, bar.Value);
+        window.MouseUp(thumbCenter, MouseButton.Left);
+    }
+}


### PR DESCRIPTION
## What

Prototype for the scrollbar-thumb jitter reported in #13579: with variable-height rows (one vs two text lines), TableView's `VirtualizingStackPanel` re-estimates the pixel extent from the average realized row height on every scroll, so the native thumb's position and size jumped around during wheel scrolling. That estimator is upstream and private (AvaloniaUI/Avalonia#17831), and a ScrollBar templated into a ScrollViewer pushes every `Value` change straight into the pixel offset, so the native bar cannot be re-united to rows.

`TableViewIndexScrollBar` hides the grid's native vertical bar and docks a standalone one beside it that works in **row indices**, like the SE4 list view:

- `Value` = first visible row + the fraction scrolled into it, `Maximum` = row count − visible rows → the thumb moves monotonically and steadily no matter how row heights are mixed.
- Wheel/keyboard/`ScrollIntoView` still move the pixel offset; `ScrollChanged` re-derives the value from the realized rows, with the ends pinned hard to 0 / Maximum.
- Dragging the thumb (coalesced to one scroll per frame) places the target row at the viewport top through `PrePositionScroll`, so long jumps never row-walk.
- The trough keeps the Windows-standard hold-to-page-with-pause (#12894) and shift+click jump (#12051/#12438), replicated in index units because `TableViewScrollBarBehavior` only wires bars inside a grid.

A subtlety worth knowing: the TableView template pins the column header *inside* the ScrollViewer, so rows must be measured against the ScrollViewer's content presenter — measuring against the ScrollViewer itself lands one row off.

Scope: main subtitle grid only for now; other grids keep the native bar.

## Tests

11 new headless tests (`TableViewIndexScrollBarTests`): variable-height guard, native bar hidden, row-based maximum, monotonic value during a full scroll-through, end pinning, drag-to-row placement, trough page/pause, shift+click jump, thumb-press no-op. Full UI suite: 2606 passed.

Closes #13579 (the scrollbar part; the Ctrl+R auto-break jump in that issue is a separate fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)