### PR TITLE
Update Japanese translation for v5.2.0-beta12

### DIFF
--- a/src/ui/Assets/Languages/Japanese.json
+++ b/src/ui/Assets/Languages/Japanese.json
@@ -396,6 +396,7 @@
     "startServer": "サーバーを開始",
     "stopServer": "サーバーを停止",
     "pickOutputFolder": "出力フォルダを選択",
+    "pleaseSelectOutputFolder": "出力フォルダーを選択してください",
     "pickResolutionFromCurrentVideo": "現在のビデオの解像度を選択",
     "pickResolutionFromVideoDotDotDot": "ビデオの解像度を選択",
     "pickSubtitleFile": "字幕ファイルを選択",
@@ -629,6 +630,7 @@
     "updateAndClose": "更新して閉じる",
     "updateAvailable": "更新が利用可能です",
     "updateDetails": "更新の詳細",
+    "updateX": "{0}を更新",
     "updatedBy": "更新者",
     "upToDate": "更新日",
     "url": "URL",
@@ -1329,6 +1331,7 @@
     "saveCompareHtmlTitle": "比較結果をHTMLで保存",
     "pickMatroskaTrackX": "Matroskaトラックを選択 - {0}",
     "pickTransportStreamTrackX": "トラックを選択 - {0}",
+    "pickMp4TrackX": "MP4トラックを選択（{0}）",
     "rosettaProperties": "Timed Text Rosetta IMSCプロパティ",
     "rosettaFontSize": "フォントサイズ（行高）",
     "xProperties": "{0}のプロパティ"
@@ -1390,7 +1393,8 @@
       "deleteRuleConfirm": "ルール「{0}」を削除しますか？",
       "findWhat": "検索文字列",
       "descriptionOptional": "説明（任意）",
-      "invalidRegularExpressionX": "正規表現が無効です: {0}"
+      "invalidRegularExpressionX": "正規表現が無効です: {0}",
+      "regularExpressionTooSlowX": "正規表現が{0}秒でタイムアウトしました - このルールはスキップされます。より単純なパターンを試してください"
     },
     "find": {
       "searchTextWatermark": "検索中...",
@@ -1434,6 +1438,7 @@
     "selectedXCharactersYLines": "選択: {0}文字、{1}行",
     "replacedXOccurrences": "{0}件を置換しました",
     "invalidRegularExpression": "正規表現が無効です",
+    "regularExpressionTooSlowX": "正規表現が{0}秒でタイムアウトしました - より単純なパターンを試してください",
     "moveLineUp": "行を上へ移動",
     "moveLineDown": "行を下へ移動",
     "duplicateLine": "行を複製",
@@ -3144,6 +3149,8 @@
     "llamaCppDownloadModelPrompt": "llama.cppには、選択したOCRモデルのダウンロードが必要です。今すぐダウンロードしますか？",
     "crispEmbedNotDownloaded": "CrispEmbed エンジン/モデルがダウンロードされていません。バッチ変換の設定からダウンロードしてください",
     "crispEmbedReturnedNoText": "CrispEmbed の認識結果が空でした。モデルを確認してください",
+    "crispEmbedSettingsTitle": "CrispEmbedの設定",
+    "crispEmbedDescription": "複数のモデルに対応したローカルOCRエンジン - ここからエンジンとモデルをダウンロードできます。",
     "trainNOcrDatabase": "nOCRデータベースを学習...",
     "startTraining": "学習開始",
     "abortTraining": "学習中止",


### PR DESCRIPTION
Updated `Japanese.json` from hisui3393 in [discussion #10742](https://github.com/SubtitleEdit/subtitleedit/discussions/10742#discussioncomment-17997798).

Adds translations for eight new strings (`pleaseSelectOutputFolder`, `updateX`, `pickMp4TrackX`, the two `regularExpressionTooSlowX` messages, and the CrispEmbed settings strings). Line endings normalized to LF to match the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)